### PR TITLE
Add doc links to README, misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="alice-full.png" alt="Open Alice" width="128">
 </p>
 
+<p align="center">
+  <a href="https://deepwiki.com/TraderAlice/OpenAlice">📖 Documentation</a> · <a href="https://traderalice.com/live">🔴 Live Demo</a> · <a href="https://github.com/TraderAlice/OpenAlice/blob/master/LICENSE">MIT License</a>
+</p>
+
 # Open Alice
 
 A personal AI trading agent. She automatically fetches news, computes quantitative factors, logs trade rationale, builds strategies across different timeframes, and monitors and adjusts your portfolio 24/7.

--- a/docs/scheduling_zh.md
+++ b/docs/scheduling_zh.md
@@ -415,7 +415,7 @@ npx vitest run src/core/*.spec.ts
 ## 设计决策记录
 
 ### 为什么不用 BullMQ？
-Little Pony 是单进程应用，不需要 Redis 支持的分布式任务队列。Agent Events（84 行的 EventEmitter）+ 文件持久化已经满足需求。
+OpenAlice 是单进程应用，不需要 Redis 支持的分布式任务队列。Agent Events（84 行的 EventEmitter）+ 文件持久化已经满足需求。
 
 ### 为什么心跳和 cron 共用 scheduler？
 OpenClaw 的设计：两条独立的触发线（cron timer + heartbeat interval）最终汇聚到同一个执行入口。共用 scheduler 天然支持唤醒合并 — cron 和心跳在同一个 250ms 窗口内只执行一次。

--- a/src/extension/securities-trading/providers/alpaca/AlpacaTradingEngine.ts
+++ b/src/extension/securities-trading/providers/alpaca/AlpacaTradingEngine.ts
@@ -197,7 +197,7 @@ export class AlpacaTradingEngine implements ISecuritiesTradingEngine {
       equity: parseFloat(account.equity),
       buyingPower: parseFloat(account.buying_power),
       unrealizedPnL,
-      realizedPnL: parseFloat(account.equity) - parseFloat(account.cash) - unrealizedPnL,
+      realizedPnL: 0, // Alpaca account API 不提供此字段，由 wallet commit history 追踪
       dayTradeCount: account.daytrade_count,
       dayTradingBuyingPower: parseFloat(account.daytrading_buying_power),
     };


### PR DESCRIPTION
## Summary
- Add Documentation, Live Demo, and License links below header image in README
- Fix remaining "Little Pony" reference in scheduling_zh.md
- Fix Alpaca realizedPnL calculation (tracked by wallet instead)

## Test plan
- [x] Verify README links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)