### PR TITLE
Add web UI connector for local browser chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A personal AI trading agent. She automatically fetches news, computes quantitati
 - **Market analysis** — technical indicators, news search, and price simulation via sandboxed tools
 - **Cognitive state** — persistent "brain" with frontal lobe memory, emotion tracking, and commit history
 - **Scheduling** — heartbeat loop + cron jobs with auto-compaction, dedup, and delivery queue
+- **Web UI** — built-in local chat interface on port 3002, no Telegram account needed
 
 ## Architecture
 
@@ -48,6 +49,7 @@ graph LR
   end
 
   subgraph Connectors
+    WEB[Web UI]
     TG[Telegram]
     HTTP[HTTP API]
     MCP[MCP Server]
@@ -63,6 +65,7 @@ graph LR
   BR --> E
   BW --> E
   CR --> E
+  WEB --> E
   TG --> E
   HTTP --> E
   MCP --> E
@@ -74,7 +77,7 @@ graph LR
 
 **Extensions** — domain-specific tool sets injected into the engine. Each extension owns its tools, state, and persistence.
 
-**Connectors** — external interfaces. Telegram bot for chat, HTTP for webhooks, MCP server for tool exposure.
+**Connectors** — external interfaces. Web UI for local chat, Telegram bot for mobile, HTTP for webhooks, MCP server for tool exposure.
 
 ## Quick Start
 
@@ -159,6 +162,7 @@ src/
     browser/                 # Browser automation bridge
     cron/                    # Cron job management tools
   connectors/
+    web/                     # Web UI chat (local browser, SSE push)
     telegram/                # Telegram bot (polling, commands, settings)
   plugins/
     http.ts                  # HTTP webhook endpoint

--- a/src/connectors/web/index.ts
+++ b/src/connectors/web/index.ts
@@ -1,0 +1,2 @@
+export { WebPlugin } from './web-plugin.js'
+export type { WebConfig } from './web-plugin.js'

--- a/src/connectors/web/ui.ts
+++ b/src/connectors/web/ui.ts
@@ -1,0 +1,524 @@
+/**
+ * Web UI HTML template — single-file chat interface.
+ *
+ * Inlined as a template literal so it works with both tsx (dev) and tsup (prod)
+ * without needing to resolve static file paths.
+ */
+
+export const WEB_UI_HTML = /* html */ `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Alice</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.0/marked.min.js"><\/script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"><\/script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0d1117;
+      --bg-secondary: #161b22;
+      --bg-tertiary: #21262d;
+      --border: #30363d;
+      --text: #e6edf3;
+      --text-muted: #8b949e;
+      --accent: #58a6ff;
+      --accent-dim: #1f6feb33;
+      --user-bubble: #1f6feb;
+      --assistant-bubble: #161b22;
+      --notification-bg: #2d1f00;
+      --notification-border: #d29922;
+      --green: #3fb950;
+      --red: #f85149;
+    }
+
+    html, body {
+      height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", "Hiragino Sans GB", "Noto Sans CJK SC", sans-serif;
+      font-size: 15px;
+      line-height: 1.6;
+    }
+
+    #app {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+
+    /* Header */
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-secondary);
+      flex-shrink: 0;
+    }
+    header h1 {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--text);
+    }
+    header .status {
+      font-size: 12px;
+      color: var(--text-muted);
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    header .status .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--green);
+    }
+    header .status .dot.disconnected {
+      background: var(--red);
+    }
+
+    /* Messages container */
+    #messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    #messages::-webkit-scrollbar { width: 6px; }
+    #messages::-webkit-scrollbar-track { background: transparent; }
+    #messages::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+    /* Message bubbles */
+    .msg {
+      max-width: 85%;
+      padding: 10px 16px;
+      border-radius: 12px;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+    }
+    .msg.user {
+      align-self: flex-end;
+      background: var(--user-bubble);
+      border-bottom-right-radius: 4px;
+    }
+    .msg.assistant {
+      align-self: flex-start;
+      background: var(--assistant-bubble);
+      border: 1px solid var(--border);
+      border-bottom-left-radius: 4px;
+    }
+    .msg.notification {
+      align-self: center;
+      background: var(--notification-bg);
+      border: 1px solid var(--notification-border);
+      border-radius: 8px;
+      font-size: 13px;
+      max-width: 90%;
+    }
+    .msg.notification::before {
+      content: "\\1F514 ";
+    }
+
+    /* Thinking indicator */
+    .msg.thinking {
+      align-self: flex-start;
+      background: var(--assistant-bubble);
+      border: 1px solid var(--border);
+      border-bottom-left-radius: 4px;
+      color: var(--text-muted);
+    }
+    .thinking-dots span {
+      animation: blink 1.4s infinite;
+      font-size: 20px;
+      line-height: 1;
+    }
+    .thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+    .thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+    @keyframes blink {
+      0%, 20% { opacity: 0.2; }
+      50% { opacity: 1; }
+      80%, 100% { opacity: 0.2; }
+    }
+
+    /* Markdown content styling */
+    .msg.assistant .content p { margin: 0.5em 0; }
+    .msg.assistant .content p:first-child { margin-top: 0; }
+    .msg.assistant .content p:last-child { margin-bottom: 0; }
+    .msg.assistant .content pre {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 12px;
+      overflow-x: auto;
+      margin: 8px 0;
+      font-size: 13px;
+    }
+    .msg.assistant .content code {
+      font-family: "SF Mono", "Fira Code", "Cascadia Code", Menlo, Consolas, monospace;
+      font-size: 13px;
+    }
+    .msg.assistant .content :not(pre) > code {
+      background: var(--bg-tertiary);
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .msg.assistant .content ul, .msg.assistant .content ol {
+      padding-left: 1.5em;
+      margin: 0.5em 0;
+    }
+    .msg.assistant .content blockquote {
+      border-left: 3px solid var(--accent);
+      padding-left: 12px;
+      color: var(--text-muted);
+      margin: 0.5em 0;
+    }
+    .msg.assistant .content table {
+      border-collapse: collapse;
+      margin: 8px 0;
+      width: 100%;
+    }
+    .msg.assistant .content th, .msg.assistant .content td {
+      border: 1px solid var(--border);
+      padding: 6px 12px;
+      text-align: left;
+    }
+    .msg.assistant .content th {
+      background: var(--bg-tertiary);
+    }
+    .msg.assistant .content img {
+      max-width: 100%;
+      border-radius: 8px;
+      margin: 8px 0;
+    }
+    .msg.assistant .content a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+    .msg.assistant .content a:hover {
+      text-decoration: underline;
+    }
+
+    /* Timestamp */
+    .msg-time {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-top: 4px;
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+    .msg-wrapper:hover .msg-time { opacity: 1; }
+
+    .msg-wrapper {
+      display: flex;
+      flex-direction: column;
+    }
+    .msg-wrapper.user { align-items: flex-end; }
+    .msg-wrapper.assistant { align-items: flex-start; }
+    .msg-wrapper.notification { align-items: center; }
+
+    /* Input area */
+    #input-area {
+      display: flex;
+      gap: 10px;
+      padding: 16px 20px;
+      border-top: 1px solid var(--border);
+      background: var(--bg-secondary);
+      flex-shrink: 0;
+    }
+    #input {
+      flex: 1;
+      background: var(--bg);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 14px;
+      font-family: inherit;
+      font-size: 15px;
+      line-height: 1.5;
+      resize: none;
+      outline: none;
+      max-height: 200px;
+      transition: border-color 0.2s;
+    }
+    #input:focus { border-color: var(--accent); }
+    #input::placeholder { color: var(--text-muted); }
+    #send {
+      align-self: flex-end;
+      background: var(--user-bubble);
+      color: white;
+      border: none;
+      border-radius: 10px;
+      padding: 10px 20px;
+      font-size: 15px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: opacity 0.2s;
+      flex-shrink: 0;
+    }
+    #send:hover { opacity: 0.85; }
+    #send:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* Empty state */
+    #empty-state {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--text-muted);
+      font-size: 16px;
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      #app { max-width: 100%; }
+      .msg { max-width: 92%; }
+      #messages { padding: 12px; }
+      #input-area { padding: 12px; }
+    }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <header>
+      <h1>Open Alice</h1>
+      <div class="status">
+        <div class="dot" id="sse-dot"></div>
+        <span id="sse-status">connected</span>
+      </div>
+    </header>
+    <div id="messages"></div>
+    <div id="input-area">
+      <textarea id="input" placeholder="Send a message..." rows="1"><\/textarea>
+      <button id="send">Send<\/button>
+    </div>
+  </div>
+
+  <script>
+    // ==================== Config ====================
+    const API_BASE = window.location.origin;
+
+    // ==================== Marked setup ====================
+    marked.setOptions({
+      highlight: (code, lang) => {
+        if (lang && hljs.getLanguage(lang)) {
+          return hljs.highlight(code, { language: lang }).value;
+        }
+        return hljs.highlightAuto(code).value;
+      },
+      breaks: true,
+    });
+
+    // ==================== DOM refs ====================
+    const messagesEl = document.getElementById('messages');
+    const inputEl = document.getElementById('input');
+    const sendBtn = document.getElementById('send');
+    const sseDot = document.getElementById('sse-dot');
+    const sseStatus = document.getElementById('sse-status');
+
+    let isWaiting = false;
+    let userScrolledUp = false;
+
+    // ==================== Auto-scroll ====================
+    messagesEl.addEventListener('scroll', () => {
+      const { scrollTop, scrollHeight, clientHeight } = messagesEl;
+      userScrolledUp = scrollHeight - scrollTop - clientHeight > 80;
+    });
+
+    function scrollToBottom() {
+      if (!userScrolledUp) {
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+      }
+    }
+
+    // ==================== Render helpers ====================
+    function renderMessage(role, text, timestamp) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'msg-wrapper ' + role;
+
+      const bubble = document.createElement('div');
+      bubble.className = 'msg ' + role;
+
+      if (role === 'user') {
+        bubble.textContent = text;
+      } else if (role === 'notification') {
+        bubble.innerHTML = '<div class="content">' + marked.parse(text) + '</div>';
+      } else {
+        bubble.innerHTML = '<div class="content">' + marked.parse(text) + '</div>';
+      }
+
+      wrapper.appendChild(bubble);
+
+      if (timestamp) {
+        const timeEl = document.createElement('div');
+        timeEl.className = 'msg-time';
+        timeEl.textContent = new Date(timestamp).toLocaleString();
+        wrapper.appendChild(timeEl);
+      }
+
+      messagesEl.appendChild(wrapper);
+      scrollToBottom();
+
+      // Highlight code blocks
+      wrapper.querySelectorAll('pre code').forEach((block) => {
+        hljs.highlightElement(block);
+      });
+
+      return wrapper;
+    }
+
+    function showThinking() {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'msg-wrapper assistant';
+      wrapper.id = 'thinking';
+
+      const bubble = document.createElement('div');
+      bubble.className = 'msg thinking';
+      bubble.innerHTML = '<div class="thinking-dots"><span>.</span><span>.</span><span>.</span></div>';
+
+      wrapper.appendChild(bubble);
+      messagesEl.appendChild(wrapper);
+      scrollToBottom();
+    }
+
+    function removeThinking() {
+      const el = document.getElementById('thinking');
+      if (el) el.remove();
+    }
+
+    // ==================== Media rendering ====================
+    function renderMedia(media) {
+      if (!media || media.length === 0) return;
+      for (const m of media) {
+        if (m.type === 'image') {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'msg-wrapper assistant';
+          const bubble = document.createElement('div');
+          bubble.className = 'msg assistant';
+          bubble.innerHTML = '<div class="content"><img src="' + m.url + '" alt="image"></div>';
+          wrapper.appendChild(bubble);
+          messagesEl.appendChild(wrapper);
+        }
+      }
+      scrollToBottom();
+    }
+
+    // ==================== Chat ====================
+    async function sendMessage() {
+      const text = inputEl.value.trim();
+      if (!text || isWaiting) return;
+
+      inputEl.value = '';
+      inputEl.style.height = 'auto';
+      isWaiting = true;
+      sendBtn.disabled = true;
+
+      renderMessage('user', text);
+      showThinking();
+
+      try {
+        const res = await fetch(API_BASE + '/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: text }),
+        });
+
+        removeThinking();
+
+        if (res.status === 409) {
+          renderMessage('notification', 'Engine is busy, please try again in a moment.');
+        } else if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: 'Unknown error' }));
+          renderMessage('notification', 'Error: ' + (err.error || res.statusText));
+        } else {
+          const data = await res.json();
+          renderMedia(data.media);
+          if (data.text) {
+            renderMessage('assistant', data.text);
+          }
+        }
+      } catch (err) {
+        removeThinking();
+        renderMessage('notification', 'Network error: ' + err.message);
+      } finally {
+        isWaiting = false;
+        sendBtn.disabled = false;
+        inputEl.focus();
+      }
+    }
+
+    // ==================== Input handling ====================
+    inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    });
+
+    // Auto-resize textarea
+    inputEl.addEventListener('input', () => {
+      inputEl.style.height = 'auto';
+      inputEl.style.height = Math.min(inputEl.scrollHeight, 200) + 'px';
+    });
+
+    sendBtn.addEventListener('click', sendMessage);
+
+    // ==================== Load history ====================
+    async function loadHistory() {
+      try {
+        const res = await fetch(API_BASE + '/api/chat/history?limit=100');
+        if (!res.ok) return;
+        const data = await res.json();
+
+        if (data.messages.length === 0) return;
+
+        for (const msg of data.messages) {
+          renderMessage(msg.role, msg.text, msg.timestamp);
+        }
+      } catch (err) {
+        console.warn('Failed to load history:', err);
+      }
+    }
+
+    // ==================== SSE ====================
+    function connectSSE() {
+      const es = new EventSource(API_BASE + '/api/chat/events');
+
+      es.onopen = () => {
+        sseDot.classList.remove('disconnected');
+        sseStatus.textContent = 'connected';
+      };
+
+      es.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === 'message' && data.text) {
+            renderMessage('notification', data.text);
+          }
+        } catch {}
+      };
+
+      es.onerror = () => {
+        sseDot.classList.add('disconnected');
+        sseStatus.textContent = 'reconnecting...';
+        // EventSource auto-reconnects
+      };
+    }
+
+    // ==================== Init ====================
+    loadHistory().then(() => {
+      connectSSE();
+      inputEl.focus();
+    });
+  <\/script>
+</body>
+</html>
+`

--- a/src/connectors/web/web-plugin.ts
+++ b/src/connectors/web/web-plugin.ts
@@ -1,0 +1,192 @@
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { streamSSE } from 'hono/streaming'
+import { serve } from '@hono/node-server'
+import { readFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import type { Plugin, EngineContext } from '../../core/types.js'
+import { SessionStore, toTextHistory } from '../../core/session.js'
+import { registerConnector, touchInteraction } from '../../core/connector-registry.js'
+import { readAIConfig } from '../../core/ai-config.js'
+import { askClaudeCodeWithSession } from '../../providers/claude-code/index.js'
+import { WEB_UI_HTML } from './ui.js'
+
+export interface WebConfig {
+  port: number
+}
+
+interface SSEClient {
+  id: string
+  send: (data: string) => void
+}
+
+export class WebPlugin implements Plugin {
+  name = 'web'
+  private server: ReturnType<typeof serve> | null = null
+  private session!: SessionStore
+  private ctx!: EngineContext
+  private sseClients = new Map<string, SSEClient>()
+  private unregisterConnector?: () => void
+  /** Media path lookup: id → absolute file path. */
+  private mediaMap = new Map<string, string>()
+
+  constructor(private config: WebConfig) {}
+
+  async start(ctx: EngineContext) {
+    this.ctx = ctx
+
+    // Initialize session (mirrors Telegram's per-user pattern, single user for web)
+    this.session = new SessionStore('web/default')
+    await this.session.restore()
+
+    const app = new Hono()
+    app.use('/api/*', cors())
+
+    // ==================== Serve UI ====================
+    app.get('/', (c) => c.html(WEB_UI_HTML))
+
+    // ==================== Chat endpoint ====================
+    app.post('/api/chat', async (c) => {
+      const body = await c.req.json<{ message?: string }>()
+      const message = body.message?.trim()
+      if (!message) {
+        return c.json({ error: 'message is required' }, 400)
+      }
+
+      // Guard: engine already processing
+      if (ctx.engine.isGenerating) {
+        return c.json({ error: 'Engine is busy, please try again in a moment.' }, 409)
+      }
+
+      touchInteraction('web', 'default')
+
+      // Route based on configured AI provider (same as Telegram connector)
+      const aiConfig = await readAIConfig()
+      let result: { text: string; media?: Array<{ type: 'image'; path: string }> }
+
+      if (aiConfig.provider === 'claude-code') {
+        result = await askClaudeCodeWithSession(message, this.session, {
+          claudeCode: {
+            allowedTools: ctx.config.agent.claudeCode.allowedTools,
+            disallowedTools: ctx.config.agent.claudeCode.disallowedTools,
+            maxTurns: ctx.config.agent.claudeCode.maxTurns,
+          },
+          compaction: ctx.config.compaction,
+          historyPreamble: 'The following is the recent conversation from the Web UI. Use it as context if the user references earlier messages.',
+        })
+      } else {
+        result = await ctx.engine.askWithSession(message, this.session)
+      }
+
+      // Map media files to serveable URLs
+      const media = (result.media ?? []).map((m) => {
+        const id = randomUUID()
+        this.mediaMap.set(id, m.path)
+        return { type: 'image' as const, url: `/api/media/${id}` }
+      })
+
+      // Evict old media entries (keep last 200)
+      if (this.mediaMap.size > 200) {
+        const keys = [...this.mediaMap.keys()]
+        for (let i = 0; i < keys.length - 200; i++) {
+          this.mediaMap.delete(keys[i])
+        }
+      }
+
+      return c.json({ text: result.text, media })
+    })
+
+    // ==================== History endpoint ====================
+    app.get('/api/chat/history', async (c) => {
+      const limit = Number(c.req.query('limit')) || 100
+
+      const entries = await this.session.readActive()
+      const history = toTextHistory(entries)
+      const trimmed = history.slice(-limit)
+
+      // Attach timestamps from the original entries (best-effort match)
+      const entryTimestamps = entries
+        .filter((e) => e.type === 'user' || e.type === 'assistant')
+        .map((e) => e.timestamp)
+
+      const messages = trimmed.map((h, i) => ({
+        role: h.role,
+        text: h.text,
+        timestamp: entryTimestamps[entryTimestamps.length - trimmed.length + i] ?? null,
+      }))
+
+      return c.json({ messages })
+    })
+
+    // ==================== SSE endpoint ====================
+    app.get('/api/chat/events', (c) => {
+      return streamSSE(c, async (stream) => {
+        const clientId = randomUUID()
+
+        this.sseClients.set(clientId, {
+          id: clientId,
+          send: (data) => {
+            stream.writeSSE({ data }).catch(() => {})
+          },
+        })
+
+        // Keep alive with periodic pings
+        const pingInterval = setInterval(() => {
+          stream.writeSSE({ event: 'ping', data: '' }).catch(() => {})
+        }, 30_000)
+
+        stream.onAbort(() => {
+          clearInterval(pingInterval)
+          this.sseClients.delete(clientId)
+        })
+
+        // Keep stream open indefinitely
+        await new Promise<void>(() => {})
+      })
+    })
+
+    // ==================== Media endpoint ====================
+    app.get('/api/media/:id', async (c) => {
+      const id = c.req.param('id')
+      const filePath = this.mediaMap.get(id)
+      if (!filePath) return c.notFound()
+
+      try {
+        const buf = await readFile(filePath)
+        const ext = filePath.split('.').pop()?.toLowerCase()
+        const mime =
+          ext === 'png' ? 'image/png'
+            : ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg'
+              : ext === 'webp' ? 'image/webp'
+                : ext === 'gif' ? 'image/gif'
+                  : 'application/octet-stream'
+        return c.body(buf, { headers: { 'Content-Type': mime } })
+      } catch {
+        return c.notFound()
+      }
+    })
+
+    // ==================== Connector registration ====================
+    this.unregisterConnector = registerConnector({
+      channel: 'web',
+      to: 'default',
+      deliver: async (text: string) => {
+        const data = JSON.stringify({ type: 'message', text })
+        for (const client of this.sseClients.values()) {
+          try { client.send(data) } catch { /* client disconnected */ }
+        }
+      },
+    })
+
+    // ==================== Start server ====================
+    this.server = serve({ fetch: app.fetch, port: this.config.port }, (info) => {
+      console.log(`web plugin listening on http://localhost:${info.port}`)
+    })
+  }
+
+  async stop() {
+    this.sseClients.clear()
+    this.unregisterConnector?.()
+    this.server?.close()
+  }
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -11,6 +11,7 @@ const engineSchema = z.object({
   interval: z.number().int().positive().default(5000),
   port: z.number().int().positive().default(3000),
   mcpPort: z.number().int().positive().optional(),
+  webPort: z.number().int().positive().default(3002),
   timeframe: z.string().default('1h'),
   dataRefreshInterval: z.number().int().positive().default(300_000),
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import type { Plugin, EngineContext, MediaAttachment } from './core/types.js'
 import { HttpPlugin } from './plugins/http.js'
 import { McpPlugin } from './plugins/mcp.js'
 import { TelegramPlugin } from './connectors/telegram/index.js'
+import { WebPlugin } from './connectors/web/index.js'
 import { Sandbox, RealMarketDataProvider, RealNewsProvider, fetchRealtimeData } from './extension/analysis-kit/index.js'
 import { createAnalysisTools } from './extension/analysis-kit/index.js'
 import type { ICryptoTradingEngine, Operation, WalletExportState } from './extension/crypto-trading/index.js'
@@ -254,6 +255,10 @@ async function main() {
 
   if (config.engine.mcpPort) {
     plugins.push(new McpPlugin(engine.tools, config.engine.mcpPort))
+  }
+
+  if (config.engine.webPort) {
+    plugins.push(new WebPlugin({ port: config.engine.webPort }))
   }
 
   if (process.env.TELEGRAM_BOT_TOKEN) {


### PR DESCRIPTION
## Summary
- New `web` connector (`src/connectors/web/`) with a built-in dark-themed chat UI at `localhost:3002`
- No Telegram account required — just open a browser to chat with Alice
- Supports markdown rendering, code highlighting, image display, SSE push notifications (heartbeat/cron), session history restore, and AI provider routing (Vercel AI SDK / Claude Code)
- Default-on via `webPort: 3002` in engine config schema

## Test plan
- [ ] `pnpm dev` starts with `web plugin listening on http://localhost:3002` in logs
- [ ] Open `http://localhost:3002`, send a message, verify AI response renders with markdown
- [ ] Refresh page, verify chat history loads correctly
- [ ] If heartbeat enabled, verify SSE push notifications appear as notification bubbles
- [ ] Verify image media (e.g. browser screenshots) display inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)