### PR TITLE
feat: MCP Ask connector for external agent conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ graph LR
 
 **Tasks** — scheduled background work. `CronEngine` manages jobs and fires `cron.fire` events into the EventLog on schedule; a listener picks them up, runs them through the AI engine, and delivers replies via the ConnectorRegistry. `Heartbeat` is a periodic health-check that uses a structured response protocol (HEARTBEAT_OK / CHAT_NO / CHAT_YES).
 
-**Interfaces** — external surfaces. Web UI for local chat, Telegram bot for mobile, HTTP for webhooks, MCP server for tool exposure.
+**Interfaces** — external surfaces. Web UI for local chat, Telegram bot for mobile, HTTP for webhooks, MCP server for tool exposure. External agents can also [converse with Alice via a separate MCP endpoint](docs/mcp-ask-connector.md).
 
 ## Quick Start
 
@@ -192,6 +192,7 @@ src/
   connectors/
     web/                     # Web UI chat (Hono, SSE push)
     telegram/                # Telegram bot (grammY, polling, commands)
+    mcp-ask/                 # MCP Ask connector (external agent conversation)
   task/
     cron/                    # Cron scheduling (engine, listener, AI tools)
     heartbeat/               # Periodic heartbeat with structured response protocol

--- a/docs/mcp-ask-connector.md
+++ b/docs/mcp-ask-connector.md
@@ -1,0 +1,165 @@
+# MCP Ask Connector
+
+External agents can converse with Alice via a dedicated MCP server, without reducing Alice to a passive tool provider.
+
+## Design Philosophy
+
+1. **Alice stays autonomous** — External agents talk *to* Alice, not *through* her. Alice retains her own reasoning, memory, and decision-making. The caller is another conversation partner, not a puppet master.
+2. **Isolated from tool MCP** — The Ask connector runs on a separate port from the main MCP server (which exposes internal tools). This prevents circular calls: Alice's own AI provider never discovers these tools because they are not registered in ToolCenter.
+3. **Caller owns session identity, Alice owns storage** — The caller decides which session to use and when to start a new one. Alice persists conversation history, handles compaction, and maintains context across turns.
+4. **Connector pattern** — The Ask connector is a first-class connector, identical in architecture to Telegram and Web. It registers with the ConnectorRegistry, records interactions via `touchInteraction()`, and participates in delivery routing.
+
+## Architecture
+
+```
+External Agent (OpenClaw, etc.)
+    │
+    │  MCP protocol (Streamable HTTP)
+    │  Port: askMcpPort (e.g. 3003)
+    ▼
+┌──────────────────────┐
+│  MCP Ask Connector   │  ← Separate from main MCP server
+│                      │
+│  Tools:              │
+│  - askWithSession    │  → engine.askWithSession()
+│  - listSessions      │  → glob session files
+│  - getSessionHistory │  → session.readActive()
+└──────────┬───────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  Engine / AgentCenter │  ← Same AI pipeline as Telegram/Web
+│  ProviderRouter       │
+│  Session Store        │
+└──────────────────────┘
+```
+
+**Separation from main MCP:**
+
+| Server | Port | Purpose | Registered in ToolCenter? |
+|--------|------|---------|---------------------------|
+| Main MCP (`McpPlugin`) | `mcpPort` | Expose internal tools (trading, analysis, brain) | Yes |
+| Ask MCP (`McpAskPlugin`) | `askMcpPort` | Expose conversation ability | No |
+
+Because Ask tools are not in ToolCenter, Alice's AI provider (Vercel AI SDK or Claude Code) cannot see them. This structurally prevents circular invocation.
+
+## Tools
+
+### `askWithSession`
+
+Send a message to Alice and receive a response within a persistent session.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `message` | string | yes | The message to send to Alice |
+| `sessionId` | string | yes | Session identifier, managed by the caller |
+
+**Returns:**
+
+```json
+{
+  "text": "Alice's response...",
+  "sessionId": "the-session-id"
+}
+```
+
+**Behavior:**
+- Creates a new session on first use of a `sessionId`, resumes on subsequent calls
+- Routes through `engine.askWithSession()` — the same pipeline used by Telegram and Web
+- Session history is persisted as JSONL in `data/sessions/mcp-ask__{sessionId}.jsonl`
+- Automatic compaction applies when context grows large
+
+### `listSessions`
+
+List all sessions created through the Ask connector.
+
+**Parameters:** none
+
+**Returns:**
+
+```json
+{
+  "sessions": [
+    { "sessionId": "trading-analysis" },
+    { "sessionId": "portfolio-review" }
+  ]
+}
+```
+
+### `getSessionHistory`
+
+Read conversation history for a specific session.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sessionId` | string | yes | Session identifier |
+| `limit` | number | no | Max messages to return (default: 50) |
+
+**Returns:**
+
+```json
+{
+  "messages": [
+    { "role": "user", "text": "What's the current BTC outlook?" },
+    { "role": "assistant", "text": "Based on recent analysis..." }
+  ]
+}
+```
+
+## Configuration
+
+Add `askMcpPort` to `data/config/engine.json`:
+
+```json
+{
+  "pairs": ["BTC/USD", "ETH/USD"],
+  "askMcpPort": 3003
+}
+```
+
+The port is optional. When omitted, the Ask connector is not started.
+
+You can also configure the port via the Web UI under **Settings > Connectivity > Ask MCP Port**.
+
+## Session Management
+
+Sessions are caller-managed (identity) and Alice-managed (storage):
+
+- **Caller provides `sessionId`** — Can be any string. Use meaningful names (e.g. `"daily-review"`, `"risk-check"`) or generated UUIDs.
+- **Alice persists on disk** — Each session is a JSONL file at `data/sessions/mcp-ask__{sessionId}.jsonl`, following the same format as Telegram and Web sessions.
+- **Compaction applies** — Long sessions are automatically compacted (summarized) to stay within context limits.
+- **No expiration** — Sessions persist indefinitely. The caller decides when to start fresh by using a new `sessionId`.
+
+## File Inventory
+
+```
+src/
+  connectors/
+    mcp-ask/
+      mcp-ask-plugin.ts    # MCP server, tool registration, session management
+      index.ts              # Public export
+data/
+  sessions/
+    mcp-ask__*.jsonl        # Per-session conversation history
+```
+
+## Example: OpenClaw Integration
+
+An orchestration agent like OpenClaw can use the Ask connector to delegate trading decisions to Alice:
+
+```
+User → OpenClaw: "Should I buy more ETH?"
+         │
+         │  askWithSession({ message: "The user is asking about ETH. Current price is $3,200. What's your view?", sessionId: "user-123" })
+         ▼
+       Alice: "Based on the 4h RSI at 42 and declining volume, I'd wait for a pullback to $3,050 support..."
+         │
+         ▼
+OpenClaw → User: "Alice suggests waiting for $3,050 support before adding. RSI is at 42 with declining volume."
+```
+
+Alice processes the question using her full toolkit (market data, indicators, position context, memory) and responds as an autonomous agent — not as a function returning a value.

--- a/src/connectors/mcp-ask/index.ts
+++ b/src/connectors/mcp-ask/index.ts
@@ -1,0 +1,2 @@
+export { McpAskPlugin } from './mcp-ask-plugin.js'
+export type { McpAskConfig } from './mcp-ask-plugin.js'

--- a/src/connectors/mcp-ask/mcp-ask-plugin.ts
+++ b/src/connectors/mcp-ask/mcp-ask-plugin.ts
@@ -1,0 +1,149 @@
+/**
+ * MCP Ask Connector
+ *
+ * Exposes Alice's conversation ability via a standalone MCP server on a
+ * dedicated port. External agents (e.g. OpenClaw) call `askWithSession`
+ * to talk to Alice as an agent — not to use her tools directly.
+ *
+ * Deliberately separated from the main MCP server (which exposes internal
+ * tools) to prevent circular calls: Alice's own AI provider never sees
+ * these tools because they are not registered in ToolCenter.
+ */
+
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { serve } from '@hono/node-server'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import { z } from 'zod'
+import { glob } from 'node:fs/promises'
+import { join, basename } from 'node:path'
+import type { Plugin, EngineContext } from '../../core/types.js'
+import { SessionStore, toTextHistory } from '../../core/session.js'
+import { registerConnector, touchInteraction } from '../../core/connector-registry.js'
+
+export interface McpAskConfig {
+  port: number
+}
+
+const SESSION_PREFIX = 'mcp-ask'
+
+export class McpAskPlugin implements Plugin {
+  name = 'mcp-ask'
+  private server: ReturnType<typeof serve> | null = null
+  private sessions = new Map<string, SessionStore>()
+  private unregisterConnector?: () => void
+
+  constructor(private config: McpAskConfig) {}
+
+  private async getSession(sessionId: string): Promise<SessionStore> {
+    let session = this.sessions.get(sessionId)
+    if (!session) {
+      session = new SessionStore(`${SESSION_PREFIX}__${sessionId}`)
+      await session.restore()
+      this.sessions.set(sessionId, session)
+    }
+    return session
+  }
+
+  async start(ctx: EngineContext) {
+    const plugin = this
+
+    const createMcpServer = () => {
+      const mcp = new McpServer({ name: 'open-alice-ask', version: '1.0.0' })
+
+      // ── askWithSession ──
+      mcp.tool(
+        'askWithSession',
+        'Send a message to Alice and get a response within a persistent session.',
+        { message: z.string().describe('The message to send to Alice'), sessionId: z.string().describe('Session identifier (caller-managed)') },
+        async ({ message, sessionId }) => {
+          const session = await plugin.getSession(sessionId)
+          touchInteraction('mcp-ask', sessionId)
+
+          const result = await ctx.engine.askWithSession(message, session, {
+            historyPreamble: 'The following is the conversation from an external MCP client. Use it as context if the caller references earlier messages.',
+          })
+
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ text: result.text, sessionId }) }],
+          }
+        },
+      )
+
+      // ── listSessions ──
+      mcp.tool(
+        'listSessions',
+        'List all mcp-ask sessions.',
+        {},
+        async () => {
+          const sessionsDir = join(process.cwd(), 'data', 'sessions')
+          const sessions: Array<{ sessionId: string }> = []
+          try {
+            for await (const entry of glob(`${SESSION_PREFIX}__*.jsonl`, { cwd: sessionsDir })) {
+              const name = basename(entry, '.jsonl')
+              const sessionId = name.slice(`${SESSION_PREFIX}__`.length)
+              if (sessionId) sessions.push({ sessionId })
+            }
+          } catch { /* no sessions dir yet */ }
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ sessions }) }],
+          }
+        },
+      )
+
+      // ── getSessionHistory ──
+      mcp.tool(
+        'getSessionHistory',
+        'Read conversation history for a session.',
+        { sessionId: z.string().describe('Session identifier'), limit: z.number().int().positive().default(50).describe('Max messages to return').optional() },
+        async ({ sessionId, limit }) => {
+          const session = await plugin.getSession(sessionId)
+          const entries = await session.readActive()
+          const history = toTextHistory(entries)
+          const trimmed = history.slice(-(limit ?? 50))
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ messages: trimmed }) }],
+          }
+        },
+      )
+
+      return mcp
+    }
+
+    const app = new Hono()
+
+    app.use('*', cors({
+      origin: '*',
+      allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+      allowHeaders: ['Content-Type', 'mcp-session-id', 'Last-Event-ID', 'mcp-protocol-version'],
+      exposeHeaders: ['mcp-session-id', 'mcp-protocol-version'],
+    }))
+
+    app.all('/mcp', async (c) => {
+      const transport = new WebStandardStreamableHTTPServerTransport()
+      const mcp = createMcpServer()
+      await mcp.connect(transport)
+      return transport.handleRequest(c.req.raw)
+    })
+
+    // Register as connector for outbound delivery (heartbeat/cron)
+    this.unregisterConnector = registerConnector({
+      channel: 'mcp-ask',
+      to: 'default',
+      deliver: async (_text: string) => {
+        // MCP is pull-based; outbound delivery is a no-op.
+        // Callers retrieve responses by calling askWithSession.
+      },
+    })
+
+    this.server = serve({ fetch: app.fetch, port: this.config.port }, (info) => {
+      console.log(`mcp-ask connector listening on http://localhost:${info.port}/mcp`)
+    })
+  }
+
+  async stop() {
+    this.unregisterConnector?.()
+    this.server?.close()
+  }
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -11,6 +11,7 @@ const engineSchema = z.object({
   interval: z.number().int().positive().default(5000),
   port: z.number().int().positive().default(3000),
   mcpPort: z.number().int().positive().optional(),
+  askMcpPort: z.number().int().positive().optional(),
   webPort: z.number().int().positive().default(3002),
   timeframe: z.string().default('1h'),
   dataRefreshInterval: z.number().int().positive().default(600_000),

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { HttpPlugin } from './plugins/http.js'
 import { McpPlugin } from './plugins/mcp.js'
 import { TelegramPlugin } from './connectors/telegram/index.js'
 import { WebPlugin } from './connectors/web/index.js'
+import { McpAskPlugin } from './connectors/mcp-ask/index.js'
 import { Sandbox, RealMarketDataProvider, RealNewsProvider, fetchRealtimeData } from './extension/analysis-kit/index.js'
 import type { MarketData, NewsItem } from './extension/analysis-kit/index.js'
 import { createAnalysisTools } from './extension/analysis-kit/index.js'
@@ -283,6 +284,10 @@ async function main() {
 
   if (config.engine.mcpPort) {
     plugins.push(new McpPlugin(toolCenter.getMcpTools(), config.engine.mcpPort))
+  }
+
+  if (config.engine.askMcpPort) {
+    plugins.push(new McpAskPlugin({ port: config.engine.askMcpPort }))
   }
 
   if (config.engine.webPort) {

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -101,6 +101,11 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
                 </Section>
               )}
 
+              {/* Connectivity */}
+              <Section title="Connectivity">
+                <ConnectivityForm config={config} onSave={saveSection} />
+              </Section>
+
               {/* Compaction */}
               <Section title="Compaction">
                 <CompactionForm config={config} onSave={saveSection} />
@@ -206,6 +211,38 @@ function CompactionForm({
         onClick={() =>
           onSave('compaction', { maxContextTokens: Number(ctx), maxOutputTokens: Number(out) }, 'Compaction')
         }
+      />
+    </>
+  )
+}
+
+function ConnectivityForm({
+  config,
+  onSave,
+}: {
+  config: AppConfig
+  onSave: (section: string, data: unknown, label: string) => void
+}) {
+  const eng = config.engine as Record<string, unknown>
+  const [mcpPort, setMcpPort] = useState(String(eng.mcpPort ?? ''))
+  const [askMcpPort, setAskMcpPort] = useState(String(eng.askMcpPort ?? ''))
+
+  return (
+    <>
+      <Field label="MCP Port (tools)">
+        <input className={inputClass} type="number" value={mcpPort} onChange={(e) => setMcpPort(e.target.value)} placeholder="Disabled" />
+      </Field>
+      <Field label="Ask MCP Port (connector)">
+        <input className={inputClass} type="number" value={askMcpPort} onChange={(e) => setAskMcpPort(e.target.value)} placeholder="Disabled" />
+      </Field>
+      <p className="text-[11px] text-text-muted mb-2">Leave empty to disable. Restart required after change.</p>
+      <SaveButton
+        onClick={() => {
+          const patch = { ...eng }
+          if (mcpPort) patch.mcpPort = Number(mcpPort); else delete patch.mcpPort
+          if (askMcpPort) patch.askMcpPort = Number(askMcpPort); else delete patch.askMcpPort
+          onSave('engine', patch, 'Connectivity')
+        }}
       />
     </>
   )


### PR DESCRIPTION
## Summary
- New MCP Ask connector on a dedicated port (`askMcpPort`), exposing `askWithSession`, `listSessions`, and `getSessionHistory`
- Isolated from main MCP server to prevent circular calls
- Connectivity settings added to Web UI
- Documentation at `docs/mcp-ask-connector.md`

## Test plan
- [ ] Set `askMcpPort: 3003` in engine config, verify connector starts
- [ ] Connect MCP client, confirm only 3 tools visible (not internal tools)
- [ ] Multi-turn conversation via `askWithSession` with persistent session
- [ ] Verify main MCP server unchanged

Closes #3