### PR TITLE
fix(ci): remove pnpm cache from release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,6 @@ jobs:
         with:
           node-version: 22
           registry-url: https://npm.pkg.github.com
-          cache: pnpm
 
       - name: Check published versions
         id: check


### PR DESCRIPTION
## Summary
- Remove `cache: pnpm` from `publish-opentypebb` job in release workflow
- When the package version is already published, the Build step is skipped, `pnpm install` never runs, and the pnpm store path doesn't exist — causing `setup-node` post-cleanup to fail

## Test plan
- [x] CI passes on dev
- [ ] Next master merge should show Release workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)