### PR TITLE
fix(build): fix opentypebb exports for production + add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "dev": "tsx src/main.ts",
     "dev:ui": "pnpm --filter open-alice-ui dev",
-    "build": "pnpm build:ui && pnpm build:backend",
+    "predev": "pnpm --filter opentypebb build",
+    "build": "pnpm --filter opentypebb build && pnpm build:ui && pnpm build:backend",
     "build:ui": "pnpm --filter open-alice-ui build",
     "build:backend": "tsup src/main.ts --format esm --dts",
+    "start": "node dist/main.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/opentypebb/package.json
+++ b/packages/opentypebb/package.json
@@ -5,12 +5,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./server": {
-      "import": "./src/server.ts",
-      "types": "./src/server.ts"
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Fixes #53

## Changes
- `packages/opentypebb/package.json`: exports 从 `src/*.ts` 改为 `dist/*.js`，production build 下 Node 能正确解析
- `package.json`: 加 `start` script、`predev` 先 build opentypebb、`build` 也先 build opentypebb

## Test
- `pnpm build` 全程无报错
- `pnpm start` 正常启动，所有插件就绪

🤖 Generated with [Claude Code](https://claude.com/claude-code)