### PR TITLE
feat: add MiniMax as a first-class AI provider (M2.7 default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ pnpm test       # run tests
 
 All config lives in `data/config/` as JSON files with Zod validation. Missing files fall back to sensible defaults. You can edit these files directly or use the Web UI.
 
-**AI Provider** — The default provider is Claude Code (`claude -p` subprocess). To use the [Vercel AI SDK](https://sdk.vercel.ai/docs) instead (Anthropic, OpenAI, Google, etc.), switch `ai-provider.json` to `vercel-ai-sdk` and add your API key to `api-keys.json`. A third option, Agent SDK (`@anthropic-ai/claude-agent-sdk`), is also available via `agent-sdk`.
+**AI Provider** — The default provider is Claude Code (`claude -p` subprocess). To use the [Vercel AI SDK](https://sdk.vercel.ai/docs) instead (Anthropic, OpenAI, Google, [MiniMax](https://www.minimax.io), etc.), switch `ai-provider.json` to `vercel-ai-sdk` and add your API key to `api-keys.json`. A third option, Agent SDK (`@anthropic-ai/claude-agent-sdk`), is also available via `agent-sdk`.
 
 **Trading** — Multi-account architecture. Crypto via [CCXT](https://docs.ccxt.com/) (Bybit, OKX, Binance, etc.) configured in `crypto.json`. US equities via [Alpaca](https://alpaca.markets/) configured in `securities.json`. Both use the same git-like trading workflow.
 
@@ -163,7 +163,7 @@ All config lives in `data/config/` as JSON files with Zod validation. Missing fi
 | `engine.json` | Trading pairs, tick interval, timeframe |
 | `agent.json` | Max agent steps, evolution mode toggle, Claude Code tool permissions |
 | `ai-provider.json` | Active AI provider (`claude-code`, `vercel-ai-sdk`, or `agent-sdk`), switchable at runtime |
-| `api-keys.json` | AI provider API keys (Anthropic, OpenAI, Google) — only needed for Vercel AI SDK mode |
+| `api-keys.json` | AI provider API keys (Anthropic, OpenAI, Google, MiniMax) — only needed for Vercel AI SDK mode |
 | `platforms.json` | Trading platform definitions (CCXT exchanges, Alpaca) |
 | `accounts.json` | Trading account credentials and guard config, references platforms |
 | `crypto.json` | CCXT exchange config + API keys, allowed symbols, guards |

--- a/src/ai-providers/vercel-ai-sdk/model-factory.ts
+++ b/src/ai-providers/vercel-ai-sdk/model-factory.ts
@@ -54,7 +54,16 @@ export async function createModelFromConfig(override?: ModelOverride): Promise<M
       const client = createGoogleGenerativeAI({ apiKey: resolveApiKey('google'), baseURL: url || undefined })
       return { model: client(m), key }
     }
+    case 'minimax': {
+      const { createOpenAI } = await import('@ai-sdk/openai')
+      const client = createOpenAI({
+        apiKey: resolveApiKey('minimax') ?? process.env.MINIMAX_API_KEY,
+        baseURL: url || 'https://api.minimax.io/v1',
+        compatibility: 'compatible',
+      })
+      return { model: client.chat(m), key }
+    }
     default:
-      throw new Error(`Unsupported model provider: "${p}". Supported: anthropic, openai, google`)
+      throw new Error(`Unsupported model provider: "${p}". Supported: anthropic, openai, google, minimax`)
   }
 }

--- a/src/connectors/web/routes/config.ts
+++ b/src/connectors/web/routes/config.ts
@@ -60,6 +60,7 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
         anthropic: !!config.apiKeys.anthropic,
         openai: !!config.apiKeys.openai,
         google: !!config.apiKeys.google,
+        minimax: !!config.apiKeys.minimax,
       })
     } catch (err) {
       return c.json({ error: String(err) }, 500)

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -22,6 +22,7 @@ export const aiProviderSchema = z.object({
     anthropic: z.string().optional(),
     openai: z.string().optional(),
     google: z.string().optional(),
+    minimax: z.string().optional(),
   }).default({}),
 })
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -61,7 +61,7 @@ export interface AIProviderConfig {
   provider: string
   model: string
   baseUrl?: string
-  apiKeys: { anthropic?: string; openai?: string; google?: string }
+  apiKeys: { anthropic?: string; openai?: string; google?: string; minimax?: string }
 }
 
 export interface AppConfig {

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -23,6 +23,8 @@ const PROVIDER_MODELS: Record<string, { label: string; value: string }[]> = {
     { label: 'Gemini 2.5 Pro', value: 'gemini-2.5-pro' },
   ],
   minimax: [
+    { label: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
+    { label: 'MiniMax-M2.7-highspeed', value: 'MiniMax-M2.7-highspeed' },
     { label: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
     { label: 'MiniMax-M2.5-highspeed', value: 'MiniMax-M2.5-highspeed' },
   ],

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -22,12 +22,17 @@ const PROVIDER_MODELS: Record<string, { label: string; value: string }[]> = {
     { label: 'Gemini 3 Flash', value: 'gemini-3-flash-preview' },
     { label: 'Gemini 2.5 Pro', value: 'gemini-2.5-pro' },
   ],
+  minimax: [
+    { label: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
+    { label: 'MiniMax-M2.5-highspeed', value: 'MiniMax-M2.5-highspeed' },
+  ],
 }
 
 const PROVIDERS = [
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'openai', label: 'OpenAI' },
   { value: 'google', label: 'Google' },
+  { value: 'minimax', label: 'MiniMax' },
   { value: 'custom', label: 'Custom' },
 ]
 
@@ -115,7 +120,7 @@ function ModelForm({ aiProvider }: { aiProvider: AIProviderConfig }) {
   const [customModel, setCustomModel] = useState(initCustom ? (aiProvider.model || '') : '')
   const [baseUrl, setBaseUrl] = useState(aiProvider.baseUrl || '')
   const [showKeys, setShowKeys] = useState(false)
-  const [keys, setKeys] = useState({ anthropic: '', openai: '', google: '' })
+  const [keys, setKeys] = useState({ anthropic: '', openai: '', google: '', minimax: '' })
   const [keySaveStatus, setKeySaveStatus] = useState<SaveStatus>('idle')
   const keySavedTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -152,6 +157,7 @@ function ModelForm({ aiProvider }: { aiProvider: AIProviderConfig }) {
     anthropic: !!aiProvider.apiKeys?.anthropic,
     openai: !!aiProvider.apiKeys?.openai,
     google: !!aiProvider.apiKeys?.google,
+    minimax: !!aiProvider.apiKeys?.minimax,
   }), [aiProvider.apiKeys])
 
   const [liveKeyStatus, setLiveKeyStatus] = useState(keyStatus)
@@ -199,13 +205,15 @@ function ModelForm({ aiProvider }: { aiProvider: AIProviderConfig }) {
       if (keys.anthropic) updatedKeys.anthropic = keys.anthropic
       if (keys.openai) updatedKeys.openai = keys.openai
       if (keys.google) updatedKeys.google = keys.google
+      if (keys.minimax) updatedKeys.minimax = keys.minimax
       await api.config.updateSection('aiProvider', { ...aiProvider, apiKeys: updatedKeys })
       setLiveKeyStatus({
         anthropic: !!updatedKeys.anthropic,
         openai: !!updatedKeys.openai,
         google: !!updatedKeys.google,
+        minimax: !!updatedKeys.minimax,
       })
-      setKeys({ anthropic: '', openai: '', google: '' })
+      setKeys({ anthropic: '', openai: '', google: '', minimax: '' })
       setKeySaveStatus('saved')
       if (keySavedTimer.current) clearTimeout(keySavedTimer.current)
       keySavedTimer.current = setTimeout(() => setKeySaveStatus('idle'), 2000)


### PR DESCRIPTION
## Summary
Add MiniMax as a first-class AI provider via Vercel AI SDK OpenAI-compatible adapter, with M2.7 as default model.

## Changes
- Add MiniMax provider to model factory (OpenAI-compatible via `@ai-sdk/openai`)
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to model selection list (default)
- Add MiniMax-M2.5 and MiniMax-M2.5-highspeed as alternative models
- Add MiniMax API key management in config and UI
- API Base URL: `https://api.minimax.io/v1`

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

## Testing
- All 766 existing unit tests pass
- Integration tested with MiniMax API