### PR TITLE
feat: cron channel targeting + cron management UI page

### DIFF
--- a/openspec/specs/cron-channel-targeting/spec.md
+++ b/openspec/specs/cron-channel-targeting/spec.md
@@ -1,0 +1,29 @@
+## Purpose
+
+Allow cron jobs to deliver their output to a specific connector channel (e.g. "telegram", "web") instead of always using the last-interacted channel. This enables scenarios where scheduled market analysis goes to Telegram while interactive chat stays on the web UI.
+
+## Requirements
+
+### Requirement: Channel field on CronJob
+The `CronJob` interface in `src/task/cron/engine.ts` SHALL include an optional `channel?: string` field. When set, the cron job's output SHALL be delivered to that specific connector channel.
+
+### Requirement: Channel propagation through CronFirePayload
+The `CronFirePayload` interface SHALL include the `channel?: string` field, propagated from the originating `CronJob`. The cron engine SHALL pass `job.channel` into the fire event payload.
+
+### Requirement: Channel in CRUD operations
+- `CronJobCreate` SHALL accept an optional `channel` field.
+- `CronJobPatch` SHALL accept an optional `channel` field.
+- The cron engine `add()` SHALL persist the channel value.
+- The cron engine `update()` SHALL update the channel value when provided.
+
+### Requirement: AI tool support
+The `cronAdd` and `cronUpdate` AI tools SHALL expose a `channel` parameter described as "Deliver results to a specific connector channel (e.g. 'telegram', 'web'). Defaults to last-interacted." The tools SHALL pass the channel value through to the engine.
+
+### Requirement: ConnectorCenter targeted delivery
+`ConnectorCenter.notify()` and `ConnectorCenter.notifyStream()` SHALL accept a `channel` option in `NotifyOpts`. When `channel` is provided, the method SHALL look up the connector by name via `this.get(opts.channel)` instead of using the last-interacted fallback via `this.resolveTarget()`.
+
+### Requirement: CronListener delivery
+The `CronListener` SHALL pass `payload.channel` into the `connectorCenter.notify()` call's options, enabling the fired job's output to reach the intended channel.
+
+### Requirement: API route support
+The `POST /api/cron/jobs` route SHALL accept an optional `channel` field in the request body and pass it to `cronEngine.add()`.

--- a/openspec/specs/cron-ui-page/spec.md
+++ b/openspec/specs/cron-ui-page/spec.md
@@ -1,0 +1,128 @@
+## Purpose
+
+Provide a web UI page for managing cron jobs — listing, creating, editing, enabling/disabling, triggering, and deleting scheduled jobs. Complements the existing backend cron API routes (`/api/cron/jobs`) and the AI-facing cron tools, giving the user a visual dashboard for all scheduled tasks including heartbeat, market briefings, and trading signal monitors.
+
+## Requirements
+
+### Requirement: CronPage route and sidebar entry
+The Cron Jobs page SHALL be registered as a new route in `ui/src/App.tsx`:
+- Page type: `'cron'`
+- Route path: `/cron`
+- Component: `CronPage` from `ui/src/pages/CronPage.tsx`
+
+The sidebar (`ui/src/components/Sidebar.tsx`) SHALL include a "Cron Jobs" navigation item with a clock icon, positioned after the Heartbeat entry.
+
+#### Scenario: Navigation to Cron page
+- **WHEN** the user clicks "Cron Jobs" in the sidebar
+- **THEN** the app SHALL navigate to `/cron` and render `CronPage`
+
+#### Scenario: Active state in sidebar
+- **WHEN** the current path is `/cron`
+- **THEN** the "Cron Jobs" nav item SHALL display with the active indicator (accent bar + highlighted text)
+
+### Requirement: Job list display
+`CronPage` SHALL fetch all cron jobs from `api.cron.list()` on mount and display them as cards. Each job card SHALL show:
+- Job name (with "Heartbeat" display for `__heartbeat__` jobs)
+- Status badge: green "OK" for last successful run, red "Error (Nx)" for consecutive errors, gray "Never run" for new jobs
+- Schedule label: human-readable format (e.g. `every 4h`, `0 9 * * 1-5`, `once @ 2026-04-01T09:00:00Z`)
+- Job ID
+- Next run time (relative + absolute)
+- Last run time (absolute)
+- Collapsible payload preview showing the full prompt text
+
+#### Scenario: Jobs loaded and displayed
+- **WHEN** the CronPage mounts
+- **THEN** all jobs from `/api/cron/jobs` SHALL be displayed as cards
+
+#### Scenario: Heartbeat job shown separately
+- **WHEN** a job with `name: '__heartbeat__'` exists
+- **THEN** it SHALL be displayed first, with a "system" badge and "Heartbeat" as the display name
+
+#### Scenario: Disabled jobs visually distinct
+- **WHEN** a job has `enabled: false`
+- **THEN** the card SHALL render with reduced opacity (60%)
+
+### Requirement: Toggle enable/disable
+Each job card SHALL include a `Toggle` component that enables or disables the job via `api.cron.update(id, { enabled })`. The job list SHALL refresh after toggling.
+
+#### Scenario: Disable a job
+- **WHEN** the user toggles a job from enabled to disabled
+- **THEN** `PUT /api/cron/jobs/:id` SHALL be called with `{ enabled: false }` and the list SHALL reload
+
+### Requirement: Run Now button
+Each job card SHALL include a "Run" button that triggers immediate execution via `api.cron.runNow(id)`. The button SHALL show a loading state while the request is in flight and display a "Job triggered!" feedback message on success.
+
+#### Scenario: Manual trigger
+- **WHEN** the user clicks "Run" on a job
+- **THEN** `POST /api/cron/jobs/:id/run` SHALL be called, triggering the job immediately
+
+### Requirement: Delete with confirmation
+Non-heartbeat job cards SHALL include a delete button (trash icon). Clicking it SHALL show inline "Yes" / "No" confirmation buttons. Confirming SHALL call `api.cron.remove(id)` and refresh the list. The heartbeat job SHALL NOT have a delete button.
+
+#### Scenario: Delete confirmed
+- **WHEN** the user clicks delete then confirms
+- **THEN** `DELETE /api/cron/jobs/:id` SHALL be called and the job SHALL disappear from the list
+
+#### Scenario: Delete cancelled
+- **WHEN** the user clicks delete then clicks "No"
+- **THEN** the confirmation UI SHALL dismiss without any API call
+
+### Requirement: Create/Edit modal
+The page SHALL include a "New Job" button (in the page header) and "Edit" buttons on each non-heartbeat card. Both SHALL open a modal form with the following fields:
+- **Name** (text input, required)
+- **Schedule Type** (select: Cron 5-field / Interval / One-shot)
+- **Schedule Value** (text input with placeholder matching the selected type)
+- **Channel** (select: Default / Telegram / Web)
+- **Payload** (textarea, monospace, min 200px height, required)
+- **Enabled** (toggle)
+
+The modal SHALL close on backdrop click, the X button, or the Cancel button. On submit, it SHALL call `api.cron.add()` for new jobs or `api.cron.update()` for edits, then refresh the list.
+
+#### Scenario: Create new job
+- **WHEN** the user fills the form and clicks "Create"
+- **THEN** `POST /api/cron/jobs` SHALL be called with the form data and the new job SHALL appear in the list
+
+#### Scenario: Edit existing job
+- **WHEN** the user edits a job and clicks "Update"
+- **THEN** `PUT /api/cron/jobs/:id` SHALL be called with the changed fields
+
+#### Scenario: Validation
+- **WHEN** the user submits with empty name, schedule, or payload
+- **THEN** the form SHALL display an error message and NOT call the API
+
+### Requirement: Recent cron events
+The page SHALL include a "Recent Cron Events" section that fetches the last 500 event log entries, filters to `cron.*` types, and displays the most recent 30 in a table with columns:
+- Time (formatted date + time)
+- Type (fire / done / error, color-coded: green for done, red for error, purple for fire)
+- Job name
+- Details (duration for done events, error message for error events)
+
+#### Scenario: Events displayed
+- **WHEN** the CronPage loads and cron events exist in the event log
+- **THEN** the events table SHALL show the most recent 30 cron-related events
+
+#### Scenario: No events
+- **WHEN** no cron events exist
+- **THEN** the table SHALL show "No cron events yet"
+
+### Requirement: API client
+The UI SHALL use the existing `ui/src/api/cron.ts` module which provides:
+- `cronApi.list()` → `GET /api/cron/jobs` → `{ jobs: CronJob[] }`
+- `cronApi.add(params)` → `POST /api/cron/jobs` → `{ id: string }`
+- `cronApi.update(id, patch)` → `PUT /api/cron/jobs/:id`
+- `cronApi.remove(id)` → `DELETE /api/cron/jobs/:id`
+- `cronApi.runNow(id)` → `POST /api/cron/jobs/:id/run`
+
+The `CronJob` type is already defined in `ui/src/api/types.ts` with fields: `id`, `name`, `enabled`, `schedule` (CronSchedule), `payload`, `state` (CronJobState), `createdAt`.
+
+### Requirement: Consistent design system
+The CronPage SHALL use the same UI components as other pages:
+- `PageHeader` for title bar with job count and action buttons
+- `Section` / `Card` containers from `ui/src/components/form.tsx`
+- `Toggle` from `ui/src/components/Toggle.tsx`
+- `inputClass` for form inputs
+- Standard color tokens (`text`, `text-muted`, `bg`, `bg-secondary`, `bg-tertiary`, `border`, `accent`, `green`, `red`, `purple`)
+
+#### Scenario: Visual consistency
+- **WHEN** the CronPage is rendered alongside other pages (Heartbeat, Settings, etc.)
+- **THEN** the styling SHALL be visually consistent with the rest of the application

--- a/src/connectors/web/routes/cron.ts
+++ b/src/connectors/web/routes/cron.ts
@@ -17,6 +17,7 @@ export function createCronRoutes(ctx: EngineContext) {
         payload: string
         schedule: { kind: string; at?: string; every?: string; cron?: string }
         enabled?: boolean
+        channel?: string
       }>()
       if (!body.name || !body.payload || !body.schedule?.kind) {
         return c.json({ error: 'name, payload, and schedule are required' }, 400)
@@ -26,6 +27,7 @@ export function createCronRoutes(ctx: EngineContext) {
         payload: body.payload,
         schedule: body.schedule as CronSchedule,
         enabled: body.enabled,
+        channel: body.channel,
       })
       return c.json({ id })
     } catch (err) {

--- a/src/core/connector-center.ts
+++ b/src/core/connector-center.ts
@@ -24,6 +24,8 @@ export interface NotifyOpts {
   kind?: 'message' | 'notification'
   media?: MediaAttachment[]
   source?: 'heartbeat' | 'cron' | 'manual'
+  /** Override: deliver to this specific channel instead of last-interacted. */
+  channel?: string
 }
 
 /** Result of a notify() call. */
@@ -89,7 +91,7 @@ export class ConnectorCenter {
    * Falls back to the first registered connector if no interaction yet.
    */
   async notify(text: string, opts?: NotifyOpts): Promise<NotifyResult> {
-    const target = this.resolveTarget()
+    const target = opts?.channel ? this.get(opts.channel) : this.resolveTarget()
     if (!target) return { delivered: false }
 
     const payload = this.buildPayload(text, opts)
@@ -103,7 +105,7 @@ export class ConnectorCenter {
    * Otherwise drains the stream and falls back to send() with the completed result.
    */
   async notifyStream(stream: StreamableResult, opts?: NotifyOpts): Promise<NotifyResult> {
-    const target = this.resolveTarget()
+    const target = opts?.channel ? this.get(opts.channel) : this.resolveTarget()
     if (!target) {
       await stream // drain to prevent hanging generator
       return { delivered: false }

--- a/src/task/cron/engine.ts
+++ b/src/task/cron/engine.ts
@@ -37,6 +37,8 @@ export interface CronJob {
   enabled: boolean
   schedule: CronSchedule
   payload: string
+  /** Deliver results to this specific connector channel (e.g. "telegram", "web"). */
+  channel?: string
   state: CronJobState
   createdAt: number
 }
@@ -45,6 +47,8 @@ export interface CronFirePayload {
   jobId: string
   jobName: string
   payload: string
+  /** Target connector channel for delivery. */
+  channel?: string
 }
 
 // ==================== CRUD Types ====================
@@ -54,6 +58,7 @@ export interface CronJobCreate {
   schedule: CronSchedule
   payload: string
   enabled?: boolean
+  channel?: string
 }
 
 export interface CronJobPatch {
@@ -61,6 +66,7 @@ export interface CronJobPatch {
   schedule?: CronSchedule
   payload?: string
   enabled?: boolean
+  channel?: string
 }
 
 // ==================== Engine Interface ====================
@@ -163,6 +169,7 @@ export function createCronEngine(opts: CronEngineOpts): CronEngine {
         jobId: job.id,
         jobName: job.name,
         payload: job.payload,
+        channel: job.channel,
       } satisfies CronFirePayload)
 
       job.state.lastStatus = 'ok'
@@ -220,6 +227,7 @@ export function createCronEngine(opts: CronEngineOpts): CronEngine {
         enabled: params.enabled ?? true,
         schedule: params.schedule,
         payload: params.payload,
+        channel: params.channel,
         state: {
           nextRunAtMs: computeNextRun(params.schedule, currentMs),
           lastRunAtMs: null,
@@ -246,6 +254,7 @@ export function createCronEngine(opts: CronEngineOpts): CronEngine {
       if (patch.name !== undefined) job.name = patch.name
       if (patch.payload !== undefined) job.payload = patch.payload
       if (patch.enabled !== undefined) job.enabled = patch.enabled
+      if (patch.channel !== undefined) job.channel = patch.channel
 
       if (patch.schedule !== undefined) {
         job.schedule = patch.schedule

--- a/src/task/cron/listener.ts
+++ b/src/task/cron/listener.ts
@@ -63,11 +63,12 @@ export function createCronListener(opts: CronListenerOpts): CronListener {
         historyPreamble: 'The following is the recent cron session conversation. This is an automated cron job execution.',
       })
 
-      // Send notification through the last-interacted connector
+      // Send notification through the targeted connector (or last-interacted fallback)
       try {
         await connectorCenter.notify(result.text, {
           media: result.media,
           source: 'cron',
+          channel: payload.channel,
         })
       } catch (sendErr) {
         console.warn(`cron-listener: send failed for job ${payload.jobId}:`, sendErr)

--- a/src/task/cron/tools.ts
+++ b/src/task/cron/tools.ts
@@ -61,12 +61,13 @@ export function createCronTools(cronEngine: CronEngine) {
         payload: z.string().describe('The reminder/instruction text delivered to you when the job fires'),
         schedule: scheduleSchema.optional().describe('When the job should run'),
         enabled: z.boolean().optional().describe('Whether the job starts enabled (default: true)'),
+        channel: z.string().optional().describe('Deliver results to a specific connector channel (e.g. "telegram", "web"). Defaults to last-interacted.'),
         sessionTarget: z
           .enum(['main', 'isolated'])
           .optional()
           .describe('Where to run: "main" injects into heartbeat session (default), "isolated" runs in a fresh session'),
       }),
-      execute: async ({ name, payload, schedule, enabled }) => {
+      execute: async ({ name, payload, schedule, enabled, channel }) => {
         if (!schedule) {
           return { error: 'schedule is required' }
         }
@@ -75,6 +76,7 @@ export function createCronTools(cronEngine: CronEngine) {
           payload,
           schedule,
           enabled,
+          channel,
         })
         return { id }
       },
@@ -91,14 +93,15 @@ export function createCronTools(cronEngine: CronEngine) {
         payload: z.string().optional().describe('New payload text'),
         schedule: scheduleSchema.optional().describe('New schedule'),
         enabled: z.boolean().optional().describe('Enable or disable the job'),
+        channel: z.string().optional().describe('Deliver results to a specific connector channel (e.g. "telegram", "web").'),
         sessionTarget: z
           .enum(['main', 'isolated'])
           .optional()
           .describe('New session target'),
       }),
-      execute: async ({ id, name, payload, schedule, enabled }) => {
+      execute: async ({ id, name, payload, schedule, enabled, channel }) => {
         try {
-          await cronEngine.update(id, { name, payload, schedule, enabled })
+          await cronEngine.update(id, { name, payload, schedule, enabled, channel })
           return { ok: true }
         } catch (err) {
           return { error: err instanceof Error ? err.message : String(err) }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -12,11 +12,12 @@ import { TradingPage } from './pages/TradingPage'
 import { ConnectorsPage } from './pages/ConnectorsPage'
 import { DevPage } from './pages/DevPage'
 import { HeartbeatPage } from './pages/HeartbeatPage'
+import { CronPage } from './pages/CronPage'
 import { ToolsPage } from './pages/ToolsPage'
 import { AgentStatusPage } from './pages/AgentStatusPage'
 
 export type Page =
-  | 'chat' | 'portfolio' | 'events' | 'agent-status' | 'heartbeat' | 'market-data' | 'news' | 'connectors'
+  | 'chat' | 'portfolio' | 'events' | 'agent-status' | 'heartbeat' | 'cron' | 'market-data' | 'news' | 'connectors'
   | 'trading'
   | 'ai-provider' | 'settings' | 'tools' | 'dev'
 
@@ -27,6 +28,7 @@ export const ROUTES: Record<Page, string> = {
   'events': '/events',
   'agent-status': '/agent-status',
   'heartbeat': '/heartbeat',
+  'cron': '/cron',
   'market-data': '/market-data',
   'news': '/news',
   'connectors': '/connectors',
@@ -70,6 +72,7 @@ export function App() {
             <Route path="/events" element={<EventsPage />} />
             <Route path="/agent-status" element={<AgentStatusPage />} />
             <Route path="/heartbeat" element={<HeartbeatPage />} />
+            <Route path="/cron" element={<CronPage />} />
             <Route path="/market-data" element={<MarketDataPage />} />
             <Route path="/news" element={<NewsPage />} />
             <Route path="/data-sources" element={<Navigate to="/market-data" replace />} />

--- a/ui/src/api/cron.ts
+++ b/ui/src/api/cron.ts
@@ -8,7 +8,7 @@ export const cronApi = {
     return res.json()
   },
 
-  async add(params: { name: string; payload: string; schedule: CronSchedule; enabled?: boolean }): Promise<{ id: string }> {
+  async add(params: { name: string; payload: string; schedule: CronSchedule; enabled?: boolean; channel?: string }): Promise<{ id: string }> {
     const res = await fetch('/api/cron/jobs', {
       method: 'POST',
       headers,
@@ -21,7 +21,7 @@ export const cronApi = {
     return res.json()
   },
 
-  async update(id: string, patch: Partial<{ name: string; payload: string; schedule: CronSchedule; enabled: boolean }>): Promise<void> {
+  async update(id: string, patch: Partial<{ name: string; payload: string; schedule: CronSchedule; enabled: boolean; channel: string }>): Promise<void> {
     const res = await fetch(`/api/cron/jobs/${id}`, {
       method: 'PUT',
       headers,

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -141,6 +141,7 @@ export interface CronJob {
   enabled: boolean
   schedule: CronSchedule
   payload: string
+  channel?: string
   state: CronJobState
   createdAt: number
 }

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -88,6 +88,16 @@ const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    page: 'cron' as const,
+    label: 'Cron Jobs',
+    icon: (active: boolean) => (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill={active ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+    ),
+  },
+  {
     page: 'market-data',
     label: 'Market Data',
     icon: (active) => (

--- a/ui/src/pages/CronPage.tsx
+++ b/ui/src/pages/CronPage.tsx
@@ -1,0 +1,524 @@
+import { useState, useEffect, useCallback } from 'react'
+import { api, type CronJob, type CronSchedule, type EventLogEntry } from '../api'
+import { Toggle } from '../components/Toggle'
+import { PageHeader } from '../components/PageHeader'
+import { Section, inputClass } from '../components/form'
+
+function formatDateTime(ts: number): string {
+  const d = new Date(ts)
+  const date = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  const time = d.toLocaleTimeString('en-US', { hour12: false })
+  return `${date} ${time}`
+}
+
+function formatRelative(ms: number): string {
+  const now = Date.now()
+  const diff = ms - now
+  if (diff < 0) return 'overdue'
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 60) return `in ${mins}m`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `in ${hrs}h ${mins % 60}m`
+  return `in ${Math.floor(hrs / 24)}d`
+}
+
+function scheduleLabel(s: CronSchedule): string {
+  switch (s.kind) {
+    case 'at': return `once @ ${s.at}`
+    case 'every': return `every ${s.every}`
+    case 'cron': return s.cron
+  }
+}
+
+function statusBadge(state: CronJob['state']): { color: string; label: string } {
+  if (state.lastStatus === 'ok') return { color: 'bg-green', label: 'OK' }
+  if (state.lastStatus === 'error') return { color: 'bg-red', label: `Error (${state.consecutiveErrors}x)` }
+  return { color: 'bg-text-muted', label: 'Never run' }
+}
+
+// ==================== Job Card ====================
+
+interface JobCardProps {
+  job: CronJob
+  onToggle: (id: string, enabled: boolean) => void
+  onRunNow: (id: string) => void
+  onDelete: (id: string) => void
+  onEdit: (job: CronJob) => void
+}
+
+function JobCard({ job, onToggle, onRunNow, onDelete, onEdit }: JobCardProps) {
+  const [running, setRunning] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const badge = statusBadge(job.state)
+  const isHeartbeat = job.name === '__heartbeat__'
+
+  const handleRunNow = async () => {
+    setRunning(true)
+    try { await onRunNow(job.id) } finally { setRunning(false) }
+  }
+
+  return (
+    <div className={`bg-bg rounded-lg border border-border p-4 transition-colors ${!job.enabled ? 'opacity-60' : ''}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h4 className="text-sm font-medium text-text truncate">
+              {isHeartbeat ? 'Heartbeat' : job.name}
+            </h4>
+            <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-white ${badge.color}`}>
+              {badge.label}
+            </span>
+            {isHeartbeat && (
+              <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-dim text-purple border border-purple/30">
+                system
+              </span>
+            )}
+          </div>
+          <div className="text-xs text-text-muted space-y-0.5">
+            <div className="flex items-center gap-2">
+              <span className="font-mono">{scheduleLabel(job.schedule)}</span>
+              <span className="text-text-muted/50">|</span>
+              <span className="text-[11px]">ID: {job.id}</span>
+            </div>
+            {job.state.nextRunAtMs && (
+              <div>Next: {formatRelative(job.state.nextRunAtMs)} ({formatDateTime(job.state.nextRunAtMs)})</div>
+            )}
+            {job.state.lastRunAtMs && (
+              <div>Last: {formatDateTime(job.state.lastRunAtMs)}</div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            onClick={handleRunNow}
+            disabled={running}
+            className="px-2.5 py-1 text-[11px] rounded-md bg-purple-dim text-purple border border-purple/30 hover:bg-purple/30 transition-colors disabled:opacity-50"
+            title="Run now"
+          >
+            {running ? '...' : 'Run'}
+          </button>
+          {!isHeartbeat && (
+            <button
+              onClick={() => onEdit(job)}
+              className="px-2.5 py-1 text-[11px] rounded-md bg-bg-tertiary text-text-muted border border-border hover:text-text hover:bg-bg-tertiary/80 transition-colors"
+            >
+              Edit
+            </button>
+          )}
+          <Toggle checked={job.enabled} onChange={(v) => onToggle(job.id, v)} size="sm" />
+          {!isHeartbeat && (
+            confirmDelete ? (
+              <div className="flex items-center gap-1">
+                <button onClick={() => onDelete(job.id)} className="px-2 py-1 text-[11px] rounded-md bg-red/20 text-red border border-red/30 hover:bg-red/30">Yes</button>
+                <button onClick={() => setConfirmDelete(false)} className="px-2 py-1 text-[11px] rounded-md bg-bg-tertiary text-text-muted border border-border">No</button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setConfirmDelete(true)}
+                className="px-2 py-1 text-[11px] rounded-md text-red/60 hover:text-red hover:bg-red/10 transition-colors"
+                title="Delete"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="3 6 5 6 21 6" /><path d="M19 6l-2 14H7L5 6" /><path d="M10 11v6" /><path d="M14 11v6" /><path d="M9 6V4h6v2" />
+                </svg>
+              </button>
+            )
+          )}
+        </div>
+      </div>
+
+      {/* Payload preview */}
+      <details className="mt-3 group">
+        <summary className="text-[11px] text-text-muted cursor-pointer hover:text-text transition-colors select-none">
+          Show payload
+        </summary>
+        <pre className="mt-2 p-3 bg-bg-secondary rounded-md text-[11px] text-text-muted font-mono whitespace-pre-wrap break-words max-h-[300px] overflow-y-auto leading-relaxed">
+          {job.payload}
+        </pre>
+      </details>
+    </div>
+  )
+}
+
+// ==================== Add/Edit Modal ====================
+
+interface JobFormData {
+  name: string
+  scheduleKind: 'at' | 'every' | 'cron'
+  scheduleValue: string
+  payload: string
+  channel: string
+  enabled: boolean
+}
+
+const defaultForm: JobFormData = {
+  name: '',
+  scheduleKind: 'cron',
+  scheduleValue: '',
+  payload: '',
+  channel: 'telegram',
+  enabled: true,
+}
+
+function jobToForm(job: CronJob): JobFormData {
+  const s = job.schedule
+  return {
+    name: job.name,
+    scheduleKind: s.kind,
+    scheduleValue: s.kind === 'at' ? s.at : s.kind === 'every' ? s.every : s.cron,
+    payload: job.payload,
+    channel: job.channel || '',
+    enabled: job.enabled,
+  }
+}
+
+function formToSchedule(form: JobFormData): CronSchedule {
+  switch (form.scheduleKind) {
+    case 'at': return { kind: 'at', at: form.scheduleValue }
+    case 'every': return { kind: 'every', every: form.scheduleValue }
+    case 'cron': return { kind: 'cron', cron: form.scheduleValue }
+  }
+}
+
+interface JobModalProps {
+  editing: CronJob | null
+  onClose: () => void
+  onSave: (form: JobFormData, editingId: string | null) => Promise<void>
+}
+
+function JobModal({ editing, onClose, onSave }: JobModalProps) {
+  const [form, setForm] = useState<JobFormData>(editing ? jobToForm(editing) : defaultForm)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!form.name.trim() || !form.scheduleValue.trim() || !form.payload.trim()) {
+      setError('Name, schedule, and payload are required')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave(form, editing?.id ?? null)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const update = (patch: Partial<JobFormData>) => setForm((f) => ({ ...f, ...patch }))
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+        className="bg-bg-secondary border border-border rounded-xl w-full max-w-[640px] max-h-[90vh] flex flex-col shadow-2xl mx-4"
+      >
+        <div className="px-5 py-4 border-b border-border flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-text">{editing ? 'Edit Job' : 'New Cron Job'}</h3>
+          <button type="button" onClick={onClose} className="text-text-muted hover:text-text transition-colors">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          <div>
+            <label className="block text-[13px] text-text mb-1.5 font-medium">Name</label>
+            <input className={inputClass} value={form.name} onChange={(e) => update({ name: e.target.value })} placeholder="My signal check" />
+          </div>
+
+          <div className="grid grid-cols-[140px_1fr] gap-3">
+            <div>
+              <label className="block text-[13px] text-text mb-1.5 font-medium">Schedule Type</label>
+              <select className={inputClass} value={form.scheduleKind} onChange={(e) => update({ scheduleKind: e.target.value as any })}>
+                <option value="cron">Cron (5-field)</option>
+                <option value="every">Interval</option>
+                <option value="at">One-shot</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-[13px] text-text mb-1.5 font-medium">
+                {form.scheduleKind === 'cron' ? 'Expression' : form.scheduleKind === 'every' ? 'Interval' : 'ISO Timestamp'}
+              </label>
+              <input
+                className={`${inputClass} font-mono`}
+                value={form.scheduleValue}
+                onChange={(e) => update({ scheduleValue: e.target.value })}
+                placeholder={form.scheduleKind === 'cron' ? '0 9 * * 1-5' : form.scheduleKind === 'every' ? '4h' : '2026-04-01T09:00:00Z'}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-[13px] text-text mb-1.5 font-medium">Channel</label>
+            <select className={inputClass} value={form.channel} onChange={(e) => update({ channel: e.target.value })}>
+              <option value="">Default (last interacted)</option>
+              <option value="telegram">Telegram</option>
+              <option value="web">Web</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-[13px] text-text mb-1.5 font-medium">Payload (prompt)</label>
+            <textarea
+              className={`${inputClass} min-h-[200px] max-h-[400px] resize-y font-mono text-xs leading-relaxed`}
+              value={form.payload}
+              onChange={(e) => update({ payload: e.target.value })}
+              placeholder="Instructions for Alice when this job fires..."
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Toggle checked={form.enabled} onChange={(v) => update({ enabled: v })} size="sm" />
+            <span className="text-[13px] text-text-muted">{form.enabled ? 'Enabled' : 'Disabled'}</span>
+          </div>
+        </div>
+
+        <div className="px-5 py-3 border-t border-border flex items-center justify-between">
+          <div>
+            {error && <span className="text-xs text-red">{error}</span>}
+          </div>
+          <div className="flex gap-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 text-xs rounded-md text-text-muted hover:text-text transition-colors">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 text-xs rounded-md bg-accent text-bg font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : editing ? 'Update' : 'Create'}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+// ==================== Recent Cron Events ====================
+
+function CronEvents() {
+  const [entries, setEntries] = useState<EventLogEntry[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.events.recent({ limit: 500 })
+      .then(({ entries }) => {
+        const cronEntries = entries
+          .filter((e) => e.type.startsWith('cron.'))
+          .slice(-30)
+          .reverse()
+        setEntries(cronEntries)
+      })
+      .catch(console.warn)
+      .finally(() => setLoading(false))
+  }, [])
+
+  const typeColor = (t: string) => {
+    if (t === 'cron.done') return 'text-green'
+    if (t === 'cron.error') return 'text-red'
+    return 'text-purple'
+  }
+
+  return (
+    <Section title="Recent Cron Events">
+      <div className="bg-bg rounded-lg border border-border overflow-x-auto font-mono text-xs">
+        {loading ? (
+          <div className="px-4 py-6 text-center text-text-muted">Loading...</div>
+        ) : entries.length === 0 ? (
+          <div className="px-4 py-6 text-center text-text-muted">No cron events yet</div>
+        ) : (
+          <table className="w-full">
+            <thead className="bg-bg-secondary">
+              <tr className="text-text-muted text-left">
+                <th className="px-3 py-2 w-36">Time</th>
+                <th className="px-3 py-2 w-24">Type</th>
+                <th className="px-3 py-2 w-40">Job</th>
+                <th className="px-3 py-2">Details</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => {
+                const p = entry.payload as Record<string, unknown>
+                const detail = p.error ? String(p.error) :
+                  p.durationMs ? `${p.durationMs}ms` :
+                  ''
+                return (
+                  <tr key={entry.seq} className="border-t border-border/50 hover:bg-bg-tertiary/30 transition-colors">
+                    <td className="px-3 py-1.5 text-text-muted whitespace-nowrap">{formatDateTime(entry.ts)}</td>
+                    <td className={`px-3 py-1.5 ${typeColor(entry.type)}`}>{entry.type.replace('cron.', '')}</td>
+                    <td className="px-3 py-1.5 text-text-muted truncate max-w-0">{String(p.jobName || p.jobId || '')}</td>
+                    <td className="px-3 py-1.5 text-text-muted truncate max-w-0">{detail}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </Section>
+  )
+}
+
+// ==================== Main Page ====================
+
+export function CronPage() {
+  const [jobs, setJobs] = useState<CronJob[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showModal, setShowModal] = useState(false)
+  const [editingJob, setEditingJob] = useState<CronJob | null>(null)
+  const [feedback, setFeedback] = useState<string | null>(null)
+
+  const loadJobs = useCallback(async () => {
+    try {
+      const { jobs } = await api.cron.list()
+      setJobs(jobs)
+    } catch (err) {
+      console.warn('Failed to load cron jobs:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { loadJobs() }, [loadJobs])
+
+  const showFeedback = (msg: string) => {
+    setFeedback(msg)
+    setTimeout(() => setFeedback(null), 3000)
+  }
+
+  const handleToggle = async (id: string, enabled: boolean) => {
+    try {
+      await api.cron.update(id, { enabled })
+      await loadJobs()
+    } catch { showFeedback('Toggle failed') }
+  }
+
+  const handleRunNow = async (id: string) => {
+    try {
+      await api.cron.runNow(id)
+      showFeedback('Job triggered!')
+      setTimeout(loadJobs, 2000)
+    } catch { showFeedback('Trigger failed') }
+  }
+
+  const handleDelete = async (id: string) => {
+    try {
+      await api.cron.remove(id)
+      showFeedback('Job deleted')
+      await loadJobs()
+    } catch { showFeedback('Delete failed') }
+  }
+
+  const handleEdit = (job: CronJob) => {
+    setEditingJob(job)
+    setShowModal(true)
+  }
+
+  const handleSave = async (form: JobFormData, editingId: string | null) => {
+    const schedule = formToSchedule(form)
+    if (editingId) {
+      await api.cron.update(editingId, {
+        name: form.name,
+        payload: form.payload,
+        schedule,
+        enabled: form.enabled,
+      })
+    } else {
+      await api.cron.add({
+        name: form.name,
+        payload: form.payload,
+        schedule,
+        enabled: form.enabled,
+      })
+    }
+    showFeedback(editingId ? 'Job updated' : 'Job created')
+    await loadJobs()
+  }
+
+  const userJobs = jobs.filter((j) => j.name !== '__heartbeat__')
+  const heartbeatJob = jobs.find((j) => j.name === '__heartbeat__')
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <PageHeader
+        title="Cron Jobs"
+        description={`${userJobs.filter((j) => j.enabled).length} active jobs`}
+        right={
+          <div className="flex items-center gap-3">
+            {feedback && (
+              <span className={`text-xs ${feedback.includes('failed') ? 'text-red' : 'text-green'}`}>
+                {feedback}
+              </span>
+            )}
+            <button
+              onClick={() => { setEditingJob(null); setShowModal(true) }}
+              className="px-3 py-1.5 text-xs rounded-md bg-accent text-bg font-medium hover:opacity-90 transition-opacity"
+            >
+              + New Job
+            </button>
+          </div>
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">
+        <div className="max-w-[800px] space-y-4">
+          {loading ? (
+            <div className="text-sm text-text-muted text-center py-12">Loading cron jobs...</div>
+          ) : (
+            <>
+              {heartbeatJob && (
+                <JobCard
+                  job={heartbeatJob}
+                  onToggle={handleToggle}
+                  onRunNow={handleRunNow}
+                  onDelete={handleDelete}
+                  onEdit={handleEdit}
+                />
+              )}
+              {userJobs.map((job) => (
+                <JobCard
+                  key={job.id}
+                  job={job}
+                  onToggle={handleToggle}
+                  onRunNow={handleRunNow}
+                  onDelete={handleDelete}
+                  onEdit={handleEdit}
+                />
+              ))}
+              {userJobs.length === 0 && !heartbeatJob && (
+                <div className="text-center py-12">
+                  <div className="text-text-muted text-sm mb-2">No cron jobs configured</div>
+                  <button
+                    onClick={() => { setEditingJob(null); setShowModal(true) }}
+                    className="text-accent text-sm hover:underline"
+                  >
+                    Create your first job
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+
+          <CronEvents />
+        </div>
+      </div>
+
+      {showModal && (
+        <JobModal
+          editing={editingJob}
+          onClose={() => { setShowModal(false); setEditingJob(null) }}
+          onSave={handleSave}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add optional `channel` field to cron jobs, allowing each job to deliver results to a specific connector (e.g. "telegram", "web") instead of always using last-interacted channel. Propagated through `CronJob` → `CronFirePayload` → `CronListener` → `ConnectorCenter`.
- Add full **Cron Jobs UI page** (`/cron`): job listing with status badges, create/edit modal, enable/disable toggle, run-now trigger, delete with confirmation, and recent cron events table.
- Add `channel` support to cron AI tools (`cronAdd`, `cronUpdate`) and API routes.

## Changes

### Backend
- `src/task/cron/engine.ts`: `channel` field on `CronJob`, `CronJobCreate`, `CronJobPatch`, `CronFirePayload`
- `src/task/cron/listener.ts`: Pass `channel` to `connectorCenter.notify()`
- `src/task/cron/tools.ts`: `channel` param on `cronAdd` and `cronUpdate` tools
- `src/connectors/web/routes/cron.ts`: Accept `channel` in POST body
- `src/core/connector-center.ts`: `channel` option in `NotifyOpts`, targeted delivery in `notify()` and `notifyStream()`

### Frontend
- `ui/src/pages/CronPage.tsx`: New page with full CRUD, run-now, events table
- `ui/src/App.tsx`: Route registration for `/cron`
- `ui/src/components/Sidebar.tsx`: Navigation entry with clock icon
- `ui/src/api/cron.ts`: `channel` param support in `add()` and `update()`
- `ui/src/api/types.ts`: `channel` field on `CronJob` interface

### OpenSpec
- `openspec/specs/cron-channel-targeting/spec.md`
- `openspec/specs/cron-ui-page/spec.md`

## Test plan

- [ ] Verify cron jobs page loads at `/cron` and lists existing jobs
- [ ] Create a new cron job with channel targeting (e.g. "telegram")
- [ ] Edit an existing job, toggle enable/disable
- [ ] Run a job manually and verify output reaches the targeted channel
- [ ] Delete a non-heartbeat job
- [ ] Verify heartbeat job cannot be deleted
- [ ] Verify recent cron events display correctly

Made with [Cursor](https://cursor.com)