### PR TITLE
feat: Telegram connector overhaul — auth, trading panel, hot-reload

### DIFF
--- a/src/connectors/telegram/telegram-plugin.ts
+++ b/src/connectors/telegram/telegram-plugin.ts
@@ -13,6 +13,9 @@ import { forceCompact } from '../../core/compaction'
 import { readAIBackend, writeAIBackend, readConnectorsConfig, type AIBackend } from '../../core/config'
 import type { ConnectorCenter } from '../../core/connector-center.js'
 import { TelegramConnector, splitMessage, MAX_MESSAGE_LENGTH } from './telegram-connector.js'
+import type { AccountManager } from '../../domain/trading/index.js'
+import type { Operation } from '../../domain/trading/git/types.js'
+import { getOperationSymbol } from '../../domain/trading/git/types.js'
 
 const BACKEND_LABELS: Record<AIBackend, string> = {
   'claude-code': 'Claude Code',
@@ -103,6 +106,10 @@ export class TelegramPlugin implements Plugin {
       await this.handleCompactCommand(ctx.chat.id, userId)
     })
 
+    bot.command('trading', async (ctx) => {
+      await this.handleTradingCommand(ctx.chat.id, engineCtx.accountManager)
+    })
+
     // ── Callback queries (inline keyboard presses) ──
     bot.on('callback_query:data', async (ctx) => {
       const data = ctx.callbackQuery.data
@@ -124,6 +131,42 @@ export class TelegramPlugin implements Plugin {
             `Current provider: ${BACKEND_LABELS[backend]}\n\nChoose default AI provider:`,
             { reply_markup: keyboard },
           )
+        } else if (data.startsWith('trading:')) {
+          const parts = data.split(':')
+          const action = parts[1]
+          const accountId = parts.slice(2).join(':')
+
+          if (action === 'back') {
+            // Return to overview
+            const { text, keyboard } = await this.buildTradingOverview(engineCtx.accountManager)
+            await ctx.answerCallbackQuery()
+            await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() => {})
+          } else if (action === 'view') {
+            const { text, keyboard } = await this.buildAccountPanel(engineCtx.accountManager, accountId)
+            await ctx.answerCallbackQuery()
+            await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() => {})
+          } else if (action === 'push' || action === 'reject') {
+            const uta = engineCtx.accountManager.get(accountId)
+            if (!uta) { await ctx.answerCallbackQuery({ text: 'Account not found' }); return }
+            const status = uta.status()
+            if (!status.pendingMessage) {
+              await ctx.answerCallbackQuery({ text: 'No pending commit' })
+              // Refresh panel
+              const { text, keyboard } = await this.buildAccountPanel(engineCtx.accountManager, accountId)
+              await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() => {})
+              return
+            }
+            if (action === 'push') {
+              const result = await uta.push()
+              await ctx.answerCallbackQuery({ text: `${result.submitted.length} submitted, ${result.rejected.length} rejected` })
+            } else {
+              await uta.reject()
+              await ctx.answerCallbackQuery({ text: 'Rejected' })
+            }
+            // Refresh panel after action
+            const { text, keyboard } = await this.buildAccountPanel(engineCtx.accountManager, accountId)
+            await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() => {})
+          }
         } else if (data.startsWith('heartbeat:')) {
           const newEnabled = data === 'heartbeat:on'
           await engineCtx.heartbeat.setEnabled(newEnabled)
@@ -169,6 +212,7 @@ export class TelegramPlugin implements Plugin {
       { command: 'settings', description: 'Choose default AI provider' },
       { command: 'heartbeat', description: 'Toggle heartbeat self-check' },
       { command: 'compact', description: 'Force compact session context' },
+      { command: 'trading', description: 'Trading status and pending commits' },
     ])
 
     // ── Initialize and get bot info ──
@@ -395,6 +439,125 @@ export class TelegramPlugin implements Plugin {
     // No text or edit failed — clean up the placeholder
     if (placeholderMsgId) {
       await this.bot!.api.deleteMessage(chatId, placeholderMsgId).catch(() => {})
+    }
+  }
+
+  // ── Trading command ──
+
+  private async handleTradingCommand(chatId: number, accountManager: AccountManager) {
+    const accounts = accountManager.resolve()
+    if (accounts.length === 0) {
+      await this.sendReply(chatId, 'No trading accounts configured.')
+      return
+    }
+
+    // Single account — skip overview, show panel directly
+    if (accounts.length === 1) {
+      const { text, keyboard } = await this.buildAccountPanel(accountManager, accounts[0].id)
+      await this.bot!.api.sendMessage(chatId, text, { reply_markup: keyboard })
+      return
+    }
+
+    // Multiple accounts — show overview with account selector
+    const { text, keyboard } = await this.buildTradingOverview(accountManager)
+    await this.bot!.api.sendMessage(chatId, text, { reply_markup: keyboard })
+  }
+
+  private async buildTradingOverview(accountManager: AccountManager): Promise<{ text: string; keyboard: InlineKeyboard }> {
+    const accounts = accountManager.resolve()
+    const lines: string[] = ['Trading Panel', '']
+    const keyboard = new InlineKeyboard()
+
+    for (const uta of accounts) {
+      const healthIcon = uta.health === 'healthy' ? '🟢' : uta.health === 'degraded' ? '🟡' : '🔴'
+      const gitStatus = uta.status()
+      const pendingTag = gitStatus.pendingMessage ? '  ⏳ pending' : ''
+      let equityStr = ''
+      try {
+        const acc = await uta.getAccount()
+        equityStr = `  $${acc.netLiquidation.toFixed(0)}`
+      } catch { /* skip */ }
+      lines.push(`${healthIcon} ${uta.label}${equityStr}${pendingTag}`)
+      keyboard.text(uta.label, `trading:view:${uta.id}`)
+    }
+
+    return { text: lines.join('\n'), keyboard }
+  }
+
+  private async buildAccountPanel(accountManager: AccountManager, accountId: string): Promise<{ text: string; keyboard: InlineKeyboard }> {
+    const uta = accountManager.get(accountId)
+    if (!uta) return { text: 'Account not found.', keyboard: new InlineKeyboard() }
+
+    const healthIcon = uta.health === 'healthy' ? '🟢' : uta.health === 'degraded' ? '🟡' : '🔴'
+    const gitStatus = uta.status()
+    const lines: string[] = [`Trading · ${uta.label} ${healthIcon}`]
+
+    // Account info
+    try {
+      const acc = await uta.getAccount()
+      const pnl = acc.unrealizedPnL >= 0 ? `+$${acc.unrealizedPnL.toFixed(0)}` : `-$${Math.abs(acc.unrealizedPnL).toFixed(0)}`
+      lines.push(`Equity $${acc.netLiquidation.toFixed(0)}  Cash $${acc.totalCashValue.toFixed(0)}  PnL ${pnl}`)
+    } catch {
+      lines.push('(account data unavailable)')
+    }
+
+    // Pending commit
+    const keyboard = new InlineKeyboard()
+    if (gitStatus.pendingMessage) {
+      lines.push('')
+      lines.push(`Pending: ${gitStatus.pendingMessage}`)
+      for (const op of gitStatus.staged) {
+        lines.push(`  ${this.formatOperation(op)}`)
+      }
+      keyboard
+        .text('Approve', `trading:push:${uta.id}`)
+        .text('Reject', `trading:reject:${uta.id}`)
+        .row()
+    } else if (gitStatus.staged.length > 0) {
+      lines.push('')
+      lines.push('Staged (not committed):')
+      for (const op of gitStatus.staged) {
+        lines.push(`  ${this.formatOperation(op)}`)
+      }
+    }
+
+    // Recent history
+    const commits = uta.log({ limit: 3 })
+    if (commits.length > 0) {
+      lines.push('')
+      lines.push('History:')
+      for (const c of commits) {
+        const ops = c.operations.map((o) => `${o.symbol} ${o.action}`).join(', ')
+        lines.push(`  ${c.hash.slice(0, 7)} ${c.message}${ops ? ` (${ops})` : ''}`)
+      }
+    }
+
+    // Back button only if multiple accounts
+    if (accountManager.size > 1) {
+      keyboard.text('← Back', 'trading:back:')
+    }
+
+    return { text: lines.join('\n'), keyboard }
+  }
+
+  private formatOperation(op: Operation): string {
+    const symbol = getOperationSymbol(op)
+    switch (op.action) {
+      case 'placeOrder': {
+        const side = op.order?.action || '?'
+        const qty = op.order?.totalQuantity
+        const cashQty = op.order?.cashQty
+        const size = (cashQty && cashQty > 0) ? `$${cashQty}` : qty ? `${qty}` : '?'
+        return `${side} ${symbol} ${size}`
+      }
+      case 'closePosition':
+        return `CLOSE ${symbol}${op.quantity ? ` (${op.quantity})` : ''}`
+      case 'modifyOrder':
+        return `MODIFY order ${op.orderId}`
+      case 'cancelOrder':
+        return `CANCEL order ${op.orderId}`
+      case 'syncOrders':
+        return 'SYNC orders'
     }
   }
 

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -396,7 +396,7 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
     }),
 
     tradingPush: tool({
-      description: 'Trading push requires manual approval — call tradingStatus to show the user what is pending, then tell them to approve in the UI.',
+      description: 'Trading push requires manual approval — call tradingStatus to show the user what is pending, then tell them to approve (via Web UI, Telegram /trading, or other connected channels).',
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false, 'If omitted, checks all accounts.')),
       }),
@@ -414,7 +414,7 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
           return { message: 'No committed operations to push.' }
         }
         return {
-          message: 'Push requires manual approval. The user can approve pending operations in the UI.',
+          message: 'Push requires manual approval. The user can approve pending operations from any connected channel (Web UI, Telegram /trading, etc).',
           pending: pending.map(uta => ({
             source: uta.id,
             ...uta.status(),


### PR DESCRIPTION
## Summary

- **Auth hot-reload**: chatIds now hot-read from `connectors.json` per request — no restart needed to add/remove users
- **Magic link onboarding**: unauthorized users receive a clickable link to Web UI with `?addChatId=` pre-filled, one-click authorization
- **`/trading` panel**: single command with multi-account overview, per-account detail panel (equity, pending commits, history), inline keyboard Approve/Reject/Back navigation
- **Connector-neutral tool descriptions**: `tradingPush` no longer hardcodes "approve in the UI"
- Fix misleading "Empty = allow all" comment on `chatIds` (actual behavior: reject all)

## Commits

- `4e1fab1` fix: telegram auth guard hot-reload chatIds + fix misleading comment
- `89fec76` feat: telegram magic link onboarding for chat authorization
- `6799ddf` feat: Telegram /trading panel with multi-account support

## Test plan

- [ ] Send message to bot from unauthorized chat → receive magic link
- [ ] Click link → Web UI shows authorization banner → click Authorize → chatId saved
- [ ] Send message again → bot responds normally (hot-reload, no restart)
- [ ] `/trading` with single account → shows full panel
- [ ] `/trading` with multiple accounts → shows overview + account selector buttons
- [ ] Approve/Reject buttons on pending commit → executes and refreshes panel
- [ ] Back button → returns to overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)