### PR TITLE
Fix Agent SDK nested session crash when launched from Claude Code

### DIFF
--- a/src/ai-providers/agent-sdk/query.ts
+++ b/src/ai-providers/agent-sdk/query.ts
@@ -122,6 +122,8 @@ export async function askAgentSdk(
   const isOAuthMode = loginMethod === 'claudeai'
 
   const env: Record<string, string | undefined> = { ...process.env }
+  // Prevent "nested session" detection when launched from within Claude Code
+  delete env.CLAUDECODE
   if (isOAuthMode) {
     // Force OAuth by removing any inherited API key
     delete env.ANTHROPIC_API_KEY


### PR DESCRIPTION
## Summary

Fixes #107

When OpenAlice is launched from a Claude Code terminal, the inherited `CLAUDECODE` environment variable causes the Agent SDK subprocess to detect a "nested session" and exit with code 1, resulting in silent failures for all user messages.

## Changes

- Remove the inherited `CLAUDECODE` env var before spawning the Agent SDK subprocess (`src/ai-providers/agent-sdk/query.ts`)

## How it works

Claude Code sets `CLAUDECODE` in its shell environment. When `askAgentSdk()` copies `process.env` to build the subprocess environment, this variable carries over and triggers Claude Code's nested-session guard. Deleting it from the env copy allows the subprocess to start normally.

## Test plan

- [x] Verified `claude auth status` — logged in with claudeai (Max subscription)
- [x] Reproduced the bug: Agent SDK `query()` returns `exit code 1` with `CLAUDECODE` set
- [x] Confirmed fix: after `delete env.CLAUDECODE`, Agent SDK returns `"Hello!"` successfully