### PR TITLE
fix: unset CLAUDECODE env var to allow Agent SDK inside Claude Code s…

### DIFF
--- a/src/ai-providers/agent-sdk/query.ts
+++ b/src/ai-providers/agent-sdk/query.ts
@@ -122,6 +122,8 @@ export async function askAgentSdk(
   const isOAuthMode = loginMethod === 'claudeai'
 
   const env: Record<string, string | undefined> = { ...process.env }
+  // Allow spawning inside an existing Claude Code session
+  delete env.CLAUDECODE
   if (isOAuthMode) {
     // Force OAuth by removing any inherited API key
     delete env.ANTHROPIC_API_KEY


### PR DESCRIPTION
…essions

When OpenAlice is launched from within a Claude Code terminal session, the CLAUDECODE environment variable is inherited by the process. When the Agent SDK then spawns a Claude Code subprocess, it detects this variable and refuses to start with "Claude Code cannot be launched inside another Claude Code session" (exit code 1).

Fix: delete CLAUDECODE from the spawned process environment so the subprocess starts cleanly. This is safe because each Agent SDK query is an independent, non-interactive session.