### PR TITLE
docs: rewrite README positioning and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,60 @@ An append-only event log sits at the center of Alice. All system activity — tr
 - **Evolution mode** — permission escalation that gives Alice full project access including Bash, enabling self-modification
 
 
+## Architecture
+
+Alice has four layers. Each layer only talks to the one directly above or below it.
+
+```mermaid
+graph TB
+  subgraph Interface["Interface — where users interact"]
+    WEB[Web UI]
+    TG[Telegram]
+    MCP[MCP Server]
+  end
+
+  subgraph Core["Core — orchestration & routing"]
+    AC[AgentCenter]
+    PR[ProviderRouter]
+    TC[ToolCenter]
+    EL[Event Log]
+    CCR[ConnectorCenter]
+  end
+
+  subgraph Domain["Domain — business logic"]
+    subgraph UTA["UTA (Trading)"]
+      TG2[Trading Git]
+      GD[Guards]
+      BK[Brokers]
+    end
+    MD[Market Data]
+    AN[Analysis]
+    NC[News]
+    BR[Brain]
+  end
+
+  subgraph Automation["Automation — scheduled & event-driven"]
+    CRON[Cron Engine]
+    HB[Heartbeat]
+  end
+
+  WEB & TG & MCP --> AC
+  AC --> PR
+  PR -->|Claude| AS[Agent SDK]
+  PR -->|Vercel| VS[Vercel AI SDK]
+  TC --> Domain
+  EL --> Automation
+  CCR --> Interface
+```
+
+**Interface** — external surfaces (Web UI, Telegram, MCP). Users and external agents connect here. ConnectorCenter tracks last-used channel for delivery routing.
+
+**Core** — AgentCenter routes all AI calls through ProviderRouter. ToolCenter is a shared registry — domain modules register tools there, and it exports them to whichever AI provider is active. EventLog is the central event bus.
+
+**Domain** — business logic. UTA is the trading workspace (see Key Concepts below). Market Data, Analysis, News, and Brain are independent modules, each exposed to AI through tool registrations.
+
+**Automation** — listeners on the EventLog bus. Cron fires scheduled jobs, Heartbeat is a special cron job for periodic market review.
+
 ## Key Concepts
 
 **UTA (Unified Trading Account)** — The core abstraction. Each UTA wraps a broker connection, operation history, guard pipeline, and snapshot scheduler into a single self-contained workspace. AI and the frontend interact with UTAs exclusively — brokers are internal implementation details. Multiple UTAs work like independent repositories: one for Alpaca US equities, one for Bybit crypto, each with its own history and guards.
@@ -72,85 +126,6 @@ An append-only event log sits at the center of Alice. All system activity — tr
 **Connector** — An external interface through which users interact with Alice. Built-in: Web UI, Telegram, MCP Ask. Delivery always goes to the channel you last spoke through.
 
 **AI Provider** — The AI backend that powers Alice. Claude (via Agent SDK, supports OAuth login or API key) or Vercel AI SDK (Anthropic, OpenAI, Google). Switchable at runtime — no restart needed.
-
-## Architecture
-
-```mermaid
-graph LR
-  subgraph Providers
-    AS[Claude / Agent SDK]
-    VS[Vercel AI SDK]
-  end
-
-  subgraph Core
-    PR[ProviderRouter]
-    AC[AgentCenter]
-    TC[ToolCenter]
-    S[Session Store]
-    EL[Event Log]
-    CCR[ConnectorCenter]
-  end
-
-  subgraph Domain
-    MD[Market Data]
-    AN[Analysis]
-    subgraph UTA[Unified Trading Account]
-      TR[Trading Git]
-      GD[Guards]
-      BK[Brokers]
-      SN[Snapshots]
-    end
-    NC[News Collector]
-    BR[Brain]
-    BW[Browser]
-  end
-
-  subgraph Tasks
-    CRON[Cron Engine]
-    HB[Heartbeat]
-  end
-
-  subgraph Interfaces
-    WEB[Web UI]
-    TG[Telegram]
-    MCP[MCP Server]
-  end
-
-  AS --> PR
-  VS --> PR
-  PR --> AC
-  AC --> S
-  TC -->|Vercel tools| VS
-  TC -->|in-process MCP| AS
-  TC -->|MCP tools| MCP
-  MD --> AN
-  MD --> NC
-  AN --> TC
-  GD --> TR
-  TR --> BK
-  UTA --> TC
-  NC --> TC
-  BR --> TC
-  BW --> TC
-  CRON --> EL
-  HB --> CRON
-  EL --> CRON
-  CCR --> WEB
-  CCR --> TG
-  WEB --> AC
-  TG --> AC
-  MCP --> AC
-```
-
-**Providers** — interchangeable AI backends. Claude (Agent SDK) uses `@anthropic-ai/claude-agent-sdk` with tools delivered via in-process MCP — supports Claude Pro/Max OAuth login or API key. Vercel AI SDK runs a `ToolLoopAgent` in-process with direct API calls. `ProviderRouter` reads `ai-provider.json` on each call to select the active backend at runtime.
-
-**Core** — `AgentCenter` is the top-level orchestration center that routes all calls (both stateless and session-aware) through `ProviderRouter`. `ToolCenter` is a centralized tool registry — `tool/` files register domain capabilities there, and it exports them in Vercel AI SDK and MCP formats. `EventLog` provides persistent append-only event storage (JSONL) with real-time subscriptions and crash recovery. `ConnectorCenter` tracks which channel the user last spoke through.
-
-**Domain** — business logic modules registered as AI tools via the `tool/` bridge layer. The trading domain centers on `UnifiedTradingAccount` (UTA) — each UTA bundles a broker connection, git-like operation history, guard pipeline, and snapshot scheduler into a single entity. Guards enforce pre-execution safety checks (position size limits, trade cooldowns, symbol whitelist) inside each UTA before orders reach the broker. Snapshots capture periodic account state for equity curve tracking. `NewsCollector` runs background RSS fetches into a persistent archive searchable by the agent.
-
-**Tasks** — scheduled background work. `CronEngine` manages jobs and fires `cron.fire` events into the EventLog on schedule; a listener picks them up, runs them through `AgentCenter`, and delivers replies via `ConnectorCenter`. `Heartbeat` is a periodic health-check that uses a structured response protocol (HEARTBEAT_OK / CHAT_NO / CHAT_YES).
-
-**Interfaces** — external surfaces. Web UI for local chat (with SSE streaming and sub-channels), Telegram bot for mobile, MCP server for tool exposure. External agents can also [converse with Alice via a separate MCP endpoint](docs/mcp-ask-connector.md).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 
 # Open Alice
 
-Your one-person Wall Street. Alice is an AI trading agent that gives you your own research desk, quant team, trading floor, and risk management — all running on your laptop 24/7.
+Your one-person Wall Street. Alice is an AI trading agent that covers equities, crypto, commodities, forex, and macro — from research and analysis through position entry, ongoing management, to exit. 
 
-- **File-driven** — Markdown defines persona and tasks, JSON defines config, JSONL stores conversations. Both humans and AI control Alice by reading and modifying files. The same read/write primitives that power vibe coding transfer directly to vibe trading. No database, no containers, just files.
-- **Reasoning-driven** — every trading decision is based on continuous reasoning and signal mixing.
-- **OS-native** — Alice can interact with your operating system. Search the web through your browser, send messages via Telegram, and connect to local devices.
+- **Full-spectrum** — analyze and trade across asset classes. Multiple brokers combine into one unified workspace so you're never stuck with "I can see it but can't trade it."
+- **Full-lifecycle** — not just entry signals. Research, position sizing, ongoing monitoring, risk management, and exit decisions — Alice covers the entire trading lifecycle, 24/7.
+- **Full-control** — every trade goes through version history and safety checks, and requires your explicit approval before execution. You see every step, you can stop every step.
+
+Alice runs on your own machine, because trading involves private keys and real money — that trust can't be outsourced.
 
 <p align="center">
   <img src="docs/images/preview.png" alt="Open Alice Preview" width="720">
@@ -23,42 +25,53 @@ Your one-person Wall Street. Alice is an AI trading agent that gives you your ow
 
 ## Features
 
-- **Multi-provider AI** — switch between Claude (via Agent SDK with OAuth or API key) and Vercel AI SDK at runtime, no restart needed
-- **Unified Trading Account (UTA)** — each trading account is a self-contained entity that owns its broker connection, git-like operation history, and guard pipeline. AI interacts with UTAs, never with brokers directly. All order types use IBKR's type system (`@traderalice/ibkr`) as the single source of truth. Supported brokers: CCXT (100+ crypto exchanges), Alpaca (US equities), Interactive Brokers (stocks, options, futures, bonds via TWS/Gateway). Each broker self-registers its config schema and UI field descriptors — adding a new broker requires zero changes to the framework
-- **Trading-as-Git** — stage orders, commit with a message, push to execute. Every commit gets an 8-char hash. Full history reviewable via `tradingLog` / `tradingShow`
-- **Guard pipeline** — pre-execution safety checks (max position size, cooldown, symbol whitelist) that run inside each UTA before orders reach the broker
-- **Market data** — TypeScript-native OpenBB engine (`opentypebb`) with no external sidecar required. Covers equity, crypto, commodity, currency, and macro data with unified symbol search (`marketSearchForResearch`) and technical indicator calculator. Can also expose an embedded OpenBB-compatible HTTP API for external tools
-- **Equity research** — company profiles, financial statements, ratios, analyst estimates, earnings calendar, insider trading, and market movers (top gainers, losers, most active)
-- **News** — background RSS collection from configurable feeds with archive search tools (`globNews`/`grepNews`/`readNews`)
-- **Cognitive state** — persistent "brain" with frontal lobe memory, emotion tracking, and commit history
-- **Event log** — persistent append-only JSONL event log with real-time subscriptions and crash recovery
-- **Cron scheduling** — event-driven cron system with AI-powered job execution and automatic delivery to the last-interacted channel
-- **Evolution mode** — two-tier permission system. Normal mode sandboxes the AI to `data/brain/`; evolution mode gives full project access including Bash, enabling the agent to modify its own source code
-- **Account snapshots** — periodic and event-driven account state capture with equity curve visualization. Configurable snapshot intervals and carry-forward for gaps
-- **Hot-reload** — enable/disable trading accounts and connectors (Telegram, MCP Ask) at runtime without restart
-- **Web UI** — local chat interface with real-time SSE streaming, sub-channels with per-channel AI config, portfolio dashboard with equity curve, and full config management. Dynamic broker config forms rendered from broker-declared schemas
+### Trading
+
+- **Unified Trading Account (UTA)** — multiple brokers (CCXT, Alpaca, Interactive Brokers) combine into unified workspaces. AI interacts with UTAs, never with brokers directly
+- **Trading-as-Git** — stage orders, commit with a message, push to execute. Full history reviewable with commit hashes
+- **Guard pipeline** — pre-execution safety checks (max position size, cooldown, symbol whitelist) per account
+- **Account snapshots** — periodic and event-driven state capture with equity curve visualization
+
+### Research & Analysis
+
+- **Market data** — equity, crypto, commodity, currency, and macro data via TypeScript-native OpenBB engine. Unified cross-asset symbol search and technical indicator calculator
+- **Fundamental research** — company profiles, financial statements, ratios, analyst estimates, earnings calendar, insider trading, and market movers. Currently deepest for equities, expanding to other asset classes
+- **News** — background RSS collection with archive search
+
+### Automation
+
+An append-only event log sits at the center of Alice. All system activity — trades, messages, scheduled fires, heartbeat results — flows through as typed events with real-time subscriptions. Automation features are listeners on this bus:
+
+- **Cron scheduling** — cron expressions, intervals, or one-shot timestamps. On fire, emits an event → listener routes through AI → delivers reply to your last-used channel
+- **Heartbeat** — a special cron job that periodically reviews market conditions, filters by active hours, and only reaches out when something matters
+- **Webhooks** — inbound event triggers from external systems (planned)
+
+### Interface
+
+- **Web UI** — chat with SSE streaming, sub-channels, portfolio dashboard with equity curve, and full config management
+- **Telegram** — mobile access with trading panel
+- **MCP server** — tool exposure for external agents
+
+### And More!
+
+- **Multi-provider AI** — Claude (Agent SDK with OAuth or API key) or Vercel AI SDK (Anthropic, OpenAI, Google), switchable at runtime
+- **Brain** — persistent memory and emotion tracking across conversations
+- **Evolution mode** — permission escalation that gives Alice full project access including Bash, enabling self-modification
+
 
 ## Key Concepts
 
-**Provider** — The AI backend that powers Alice. Claude (via `@anthropic-ai/claude-agent-sdk`, supports OAuth login or API key) or Vercel AI SDK (direct API calls to Anthropic, OpenAI, Google). Switchable at runtime via `ai-provider.json`.
+**UTA (Unified Trading Account)** — The core abstraction. Each UTA wraps a broker connection, operation history, guard pipeline, and snapshot scheduler into a single self-contained workspace. AI and the frontend interact with UTAs exclusively — brokers are internal implementation details. Multiple UTAs work like independent repositories: one for Alpaca US equities, one for Bybit crypto, each with its own history and guards.
 
-**Domain** — Business logic layer (`src/domain/`). Each domain module (trading, market-data, analysis, news, brain, thinking) owns its state and persistence. **Tool** (`src/tool/`) is a thin bridge layer that registers domain capabilities as AI tools in ToolCenter.
+**Trading-as-Git** — The workflow inside each UTA. Stage orders, commit with a message, then push to execute. Push runs guards, dispatches to the broker, snapshots account state, and records a commit with an 8-char hash. Full history is reviewable like `git log` / `git show`.
 
-**UTA (Unified Trading Account)** — The core business entity for trading. Each UTA owns a broker connection (`IBroker`), a git-like operation history (`TradingGit`), a guard pipeline, and a snapshot scheduler. Think of it as a git repository for trades — multiple UTAs are like a monorepo with independent histories. AI and the frontend interact with UTAs exclusively; brokers are internal implementation details. All types (Contract, Order, Execution, OrderState) come from IBKR's type system via `@traderalice/ibkr`. `AccountManager` owns the full UTA lifecycle (create, reconnect, enable/disable, remove).
+**Guard** — A pre-execution safety check that runs inside a UTA before orders reach the broker. Guards enforce limits (max position size, cooldown between trades, symbol whitelist) and are configured per-account. Think of it as ESLint for trading — automated rules that catch problems before they go live.
 
-**Trading-as-Git** — The workflow inside each UTA. Stage operations (`stagePlaceOrder`, `stageClosePosition`, etc.), commit with a message, then push to execute. Push runs guards, dispatches to the broker, snapshots account state, and records a commit with an 8-char hash. Full history is reviewable via `tradingLog` / `tradingShow`.
+**Heartbeat** — A periodic check-in where Alice reviews market conditions and decides whether to send you a message. Useful for monitoring positions overnight or tracking macro events — Alice reaches out when something matters, stays quiet when it doesn't.
 
-**Guard** — A pre-execution check that runs inside a UTA before operations reach the broker. Guards enforce limits (max position size, cooldown between trades, symbol whitelist) and are configured per-account.
+**Connector** — An external interface through which users interact with Alice. Built-in: Web UI, Telegram, MCP Ask. Delivery always goes to the channel you last spoke through.
 
-**Connector** — An external interface through which users interact with Alice. Built-in: Web UI, Telegram, MCP Ask. Connectors register with ConnectorCenter; delivery always goes to the channel of last interaction.
-
-**Brain** — Alice's persistent cognitive state. The frontal lobe stores working memory across rounds; emotion tracking logs sentiment shifts with rationale. Both are versioned as commits.
-
-**Heartbeat** — A periodic check-in where Alice reviews market conditions and decides whether to send you a message. Uses a structured protocol: `HEARTBEAT_OK` (nothing to report), `CHAT_YES` (has something to say), `CHAT_NO` (quiet).
-
-**EventLog** — A persistent append-only JSONL event bus. Cron fires, heartbeat results, and errors all flow through here. Supports real-time subscriptions and crash recovery.
-
-**Evolution Mode** — A permission escalation toggle. Off: Alice can only read/write `data/brain/`. On: full project access including Bash — Alice can modify her own source code.
+**AI Provider** — The AI backend that powers Alice. Claude (via Agent SDK, supports OAuth login or API key) or Vercel AI SDK (Anthropic, OpenAI, Google). Switchable at runtime — no restart needed.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -140,15 +140,6 @@ pnpm dev
 
 Open [localhost:3002](http://localhost:3002) and start chatting. No API keys or config needed — the default setup uses your local Claude Code login (Claude Pro/Max subscription).
 
-```bash
-pnpm dev        # start backend (port 3002) with watch mode
-pnpm dev:ui     # start frontend dev server (port 5173) with hot reload
-pnpm build      # production build (backend + UI)
-pnpm test       # run tests
-```
-
-> **Note:** Port 3002 serves the UI only after `pnpm build`. For frontend development, use `pnpm dev:ui` (port 5173) which proxies to the backend and provides hot reload.
-
 ## Configuration
 
 All config lives in `data/config/` as JSON files with Zod validation. Missing files fall back to sensible defaults. You can edit these files directly or use the Web UI.
@@ -184,94 +175,7 @@ On first run, defaults are auto-copied to the user override path. Edit the user 
 
 ## Project Structure
 
-Open Alice is a pnpm monorepo with Turborepo build orchestration.
-
-```
-packages/
-├── ibkr/                      # @traderalice/ibkr — IBKR TWS API TypeScript port
-└── opentypebb/                # @traderalice/opentypebb — OpenBB platform TS port
-ui/                            # React frontend (Vite, 13 pages)
-src/
-├── main.ts                    # Composition root — wires everything together
-├── core/
-│   ├── agent-center.ts        # Top-level AI orchestration, owns ProviderRouter
-│   ├── ai-provider-manager.ts # GenerateRouter + StreamableResult + AskOptions
-│   ├── tool-center.ts         # Centralized tool registry (Vercel + MCP export)
-│   ├── mcp-export.ts          # Shared MCP export layer with type coercion
-│   ├── session.ts             # JSONL session store + format converters
-│   ├── compaction.ts          # Auto-summarize long context windows
-│   ├── config.ts              # Zod-validated config loader
-│   ├── event-log.ts           # Append-only JSONL event log
-│   ├── connector-center.ts    # ConnectorCenter — push delivery + last-interacted tracking
-│   ├── async-channel.ts       # AsyncChannel for streaming provider events to SSE
-│   ├── tool-call-log.ts       # Tool invocation logging
-│   ├── media.ts               # MediaAttachment extraction
-│   ├── media-store.ts         # Media file persistence
-│   └── types.ts               # Plugin, EngineContext interfaces
-├── ai-providers/
-│   ├── vercel-ai-sdk/         # Vercel AI SDK ToolLoopAgent wrapper
-│   ├── agent-sdk/             # Claude backend (@anthropic-ai/claude-agent-sdk, OAuth + API key)
-│   └── mock/                  # Mock provider (testing)
-├── domain/
-│   ├── trading/               # Unified multi-account trading, guard pipeline, git-like commits
-│   │   ├── account-manager.ts # UTA lifecycle (init, reconnect, enable/disable) + registry
-│   │   ├── git-persistence.ts # Git state load/save
-│   │   ├── brokers/
-│   │   │   ├── registry.ts    # Broker self-registration (configSchema + configFields + fromConfig)
-│   │   │   ├── alpaca/        # Alpaca (US equities)
-│   │   │   ├── ccxt/          # CCXT (100+ crypto exchanges)
-│   │   │   ├── ibkr/          # Interactive Brokers (TWS/Gateway)
-│   │   │   └── mock/          # In-memory test broker
-│   │   ├── git/               # Trading-as-Git engine (stage → commit → push)
-│   │   ├── guards/            # Pre-execution safety checks (position size, cooldown, whitelist)
-│   │   └── snapshot/          # Periodic + event-driven account state capture, equity curve
-│   ├── market-data/           # Structured data layer (opentypebb in-process + OpenBB API remote)
-│   │   ├── equity/            # Equity data + SymbolIndex (SEC/TMX local cache)
-│   │   ├── crypto/            # Crypto data layer
-│   │   ├── currency/          # Currency/forex data layer
-│   │   ├── commodity/         # Commodity data layer (EIA, spot prices)
-│   │   ├── economy/           # Macro economy data layer
-│   │   └── client/            # Data backend clients (opentypebb SDK, openbb-api)
-│   ├── analysis/              # Indicators, technical analysis
-│   ├── news/                  # RSS collector + archive search
-│   ├── brain/                 # Cognitive state (memory, emotion)
-│   └── thinking/              # Safe expression evaluator
-├── tool/                      # AI tool definitions — thin bridge from domain to ToolCenter
-│   ├── trading.ts             # Trading tools (delegates to domain/trading)
-│   ├── equity.ts              # Equity fundamental tools
-│   ├── market.ts              # Symbol search tools
-│   ├── analysis.ts            # Indicator calculation tools
-│   ├── news.ts                # News archive tools
-│   ├── brain.ts               # Cognition tools
-│   ├── thinking.ts            # Reasoning tools
-│   ├── browser.ts             # Browser automation tools (wraps openclaw)
-│   └── session.ts             # Session awareness tools
-├── server/
-│   ├── mcp.ts                 # MCP protocol server
-│   └── opentypebb.ts          # Embedded OpenBB-compatible HTTP API (optional)
-├── connectors/
-│   ├── web/                   # Web UI (Hono, SSE streaming, sub-channels)
-│   ├── telegram/              # Telegram bot (grammY, magic link auth, /trading panel)
-│   ├── mcp-ask/               # MCP Ask connector (external agent conversation)
-│   └── mock/                  # Mock connector (testing)
-├── task/
-│   ├── cron/                  # Cron scheduling (engine, listener, AI tools)
-│   └── heartbeat/             # Periodic heartbeat with structured response protocol
-└── openclaw/                  # ⚠️ Frozen — DO NOT MODIFY
-data/
-├── config/                    # JSON configuration files
-├── sessions/                  # JSONL conversation histories (web/, telegram/, cron/)
-├── brain/                     # Agent memory and emotion logs
-├── cache/                     # API response caches
-├── trading/                   # Trading commit history + snapshots (per-account)
-├── news-collector/            # Persistent news archive (JSONL)
-├── cron/                      # Cron job definitions (jobs.json)
-├── event-log/                 # Persistent event log (events.jsonl)
-├── tool-calls/                # Tool invocation logs
-└── media/                     # Uploaded attachments
-default/                       # Factory defaults (persona, heartbeat, skills)
-docs/                          # Documentation
-```
+Open Alice is a pnpm monorepo with Turborepo build orchestration. See [docs/project-structure.md](docs/project-structure.md) for the full file tree.
 
 ## Roadmap to v1
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,90 @@
+# Project Structure
+
+Open Alice is a pnpm monorepo with Turborepo build orchestration.
+
+```
+packages/
+├── ibkr/                      # @traderalice/ibkr — IBKR TWS API TypeScript port
+└── opentypebb/                # @traderalice/opentypebb — OpenBB platform TS port
+ui/                            # React frontend (Vite, 13 pages)
+src/
+├── main.ts                    # Composition root — wires everything together
+├── core/
+│   ├── agent-center.ts        # Top-level AI orchestration, owns ProviderRouter
+│   ├── ai-provider-manager.ts # GenerateRouter + StreamableResult + AskOptions
+│   ├── tool-center.ts         # Centralized tool registry (Vercel + MCP export)
+│   ├── mcp-export.ts          # Shared MCP export layer with type coercion
+│   ├── session.ts             # JSONL session store + format converters
+│   ├── compaction.ts          # Auto-summarize long context windows
+│   ├── config.ts              # Zod-validated config loader
+│   ├── event-log.ts           # Append-only JSONL event log
+│   ├── connector-center.ts    # ConnectorCenter — push delivery + last-interacted tracking
+│   ├── async-channel.ts       # AsyncChannel for streaming provider events to SSE
+│   ├── tool-call-log.ts       # Tool invocation logging
+│   ├── media.ts               # MediaAttachment extraction
+│   ├── media-store.ts         # Media file persistence
+│   └── types.ts               # Plugin, EngineContext interfaces
+├── ai-providers/
+│   ├── vercel-ai-sdk/         # Vercel AI SDK ToolLoopAgent wrapper
+│   ├── agent-sdk/             # Claude backend (@anthropic-ai/claude-agent-sdk, OAuth + API key)
+│   └── mock/                  # Mock provider (testing)
+├── domain/
+│   ├── trading/               # Unified multi-account trading, guard pipeline, git-like commits
+│   │   ├── account-manager.ts # UTA lifecycle (init, reconnect, enable/disable) + registry
+│   │   ├── git-persistence.ts # Git state load/save
+│   │   ├── brokers/
+│   │   │   ├── registry.ts    # Broker self-registration (configSchema + configFields + fromConfig)
+│   │   │   ├── alpaca/        # Alpaca (US equities)
+│   │   │   ├── ccxt/          # CCXT (100+ crypto exchanges)
+│   │   │   ├── ibkr/          # Interactive Brokers (TWS/Gateway)
+│   │   │   └── mock/          # In-memory test broker
+│   │   ├── git/               # Trading-as-Git engine (stage → commit → push)
+│   │   ├── guards/            # Pre-execution safety checks (position size, cooldown, whitelist)
+│   │   └── snapshot/          # Periodic + event-driven account state capture, equity curve
+│   ├── market-data/           # Structured data layer (opentypebb in-process + OpenBB API remote)
+│   │   ├── equity/            # Equity data + SymbolIndex (SEC/TMX local cache)
+│   │   ├── crypto/            # Crypto data layer
+│   │   ├── currency/          # Currency/forex data layer
+│   │   ├── commodity/         # Commodity data layer (EIA, spot prices)
+│   │   ├── economy/           # Macro economy data layer
+│   │   └── client/            # Data backend clients (opentypebb SDK, openbb-api)
+│   ├── analysis/              # Indicators, technical analysis
+│   ├── news/                  # RSS collector + archive search
+│   ├── brain/                 # Cognitive state (memory, emotion)
+│   └── thinking/              # Safe expression evaluator
+├── tool/                      # AI tool definitions — thin bridge from domain to ToolCenter
+│   ├── trading.ts             # Trading tools (delegates to domain/trading)
+│   ├── equity.ts              # Equity fundamental tools
+│   ├── market.ts              # Symbol search tools
+│   ├── analysis.ts            # Indicator calculation tools
+│   ├── news.ts                # News archive tools
+│   ├── brain.ts               # Cognition tools
+│   ├── thinking.ts            # Reasoning tools
+│   ├── browser.ts             # Browser automation tools (wraps openclaw)
+│   └── session.ts             # Session awareness tools
+├── server/
+│   ├── mcp.ts                 # MCP protocol server
+│   └── opentypebb.ts          # Embedded OpenBB-compatible HTTP API (optional)
+├── connectors/
+│   ├── web/                   # Web UI (Hono, SSE streaming, sub-channels)
+│   ├── telegram/              # Telegram bot (grammY, magic link auth, /trading panel)
+│   ├── mcp-ask/               # MCP Ask connector (external agent conversation)
+│   └── mock/                  # Mock connector (testing)
+├── task/
+│   ├── cron/                  # Cron scheduling (engine, listener, AI tools)
+│   └── heartbeat/             # Periodic heartbeat with structured response protocol
+└── openclaw/                  # ⚠️ Frozen — DO NOT MODIFY
+data/
+├── config/                    # JSON configuration files
+├── sessions/                  # JSONL conversation histories (web/, telegram/, cron/)
+├── brain/                     # Agent memory and emotion logs
+├── cache/                     # API response caches
+├── trading/                   # Trading commit history + snapshots (per-account)
+├── news-collector/            # Persistent news archive (JSONL)
+├── cron/                      # Cron job definitions (jobs.json)
+├── event-log/                 # Persistent event log (events.jsonl)
+├── tool-calls/                # Tool invocation logs
+└── media/                     # Uploaded attachments
+default/                       # Factory defaults (persona, heartbeat, skills)
+docs/                          # Documentation
+```

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,12 +9,13 @@ import { SettingsPage } from './pages/SettingsPage'
 import { AIProviderPage } from './pages/AIProviderPage'
 import { MarketDataPage } from './pages/MarketDataPage'
 import { NewsPage } from './pages/NewsPage'
+import { NewsCollectorPage } from './pages/NewsCollectorPage'
 import { TradingPage } from './pages/TradingPage'
 import { ConnectorsPage } from './pages/ConnectorsPage'
 import { DevPage } from './pages/DevPage'
 
 export type Page =
-  | 'chat' | 'portfolio' | 'automation' | 'logs' | 'market-data' | 'news' | 'connectors'
+  | 'chat' | 'portfolio' | 'news' | 'automation' | 'logs' | 'market-data' | 'news-collector' | 'connectors'
   | 'trading'
   | 'ai-provider' | 'settings' | 'dev'
 
@@ -25,6 +26,7 @@ export const ROUTES: Record<Page, string> = {
   'automation': '/automation',
   'logs': '/logs',
   'market-data': '/market-data',
+  'news-collector': '/news-collector',
   'news': '/news',
   'connectors': '/connectors',
   'trading': '/trading',
@@ -66,6 +68,7 @@ export function App() {
             <Route path="/automation" element={<AutomationPage />} />
             <Route path="/logs" element={<LogsPage />} />
             <Route path="/market-data" element={<MarketDataPage />} />
+            <Route path="/news-collector" element={<NewsCollectorPage />} />
             <Route path="/news" element={<NewsPage />} />
             {/* Redirects for old URLs */}
             <Route path="/events" element={<Navigate to="/logs" replace />} />

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -46,6 +46,18 @@ const NAV_SECTIONS: NavSection[] = [
           </svg>
         ),
       },
+      {
+        page: 'news',
+        label: 'News',
+        icon: (active) => (
+          <svg width="18" height="18" viewBox="0 0 24 24" fill={active ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-2 2zm0 0a2 2 0 0 1-2-2v-9h4" />
+            <path d="M10 7h8" />
+            <path d="M10 11h8" />
+            <path d="M10 15h4" />
+          </svg>
+        ),
+      },
     ],
   },
   {
@@ -77,14 +89,13 @@ const NAV_SECTIONS: NavSection[] = [
         ),
       },
       {
-        page: 'news',
-        label: 'News',
+        page: 'news-collector',
+        label: 'News Collector',
         icon: (active) => (
           <svg width="18" height="18" viewBox="0 0 24 24" fill={active ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-2 2zm0 0a2 2 0 0 1-2-2v-9h4" />
-            <path d="M10 7h8" />
-            <path d="M10 11h8" />
-            <path d="M10 15h4" />
+            <path d="M4 11a9 9 0 0 1 9 9" />
+            <path d="M4 4a16 16 0 0 1 16 16" />
+            <circle cx="5" cy="19" r="1" />
           </svg>
         ),
       },

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react'
+import { type AppConfig, type NewsCollectorConfig, type NewsCollectorFeed } from '../api'
+import { SaveIndicator } from '../components/SaveIndicator'
+import { ConfigSection, Field, inputClass } from '../components/form'
+import { Toggle } from '../components/Toggle'
+import { useConfigPage } from '../hooks/useConfigPage'
+import { PageHeader } from '../components/PageHeader'
+
+// ==================== Config Section ====================
+
+const DEFAULT_NEWS_CONFIG: NewsCollectorConfig = {
+  enabled: true,
+  intervalMinutes: 10,
+  maxInMemory: 2000,
+  retentionDays: 7,
+  feeds: [],
+}
+
+function CollectorSettings() {
+  const { config, status, loadError, updateConfig, updateConfigImmediate, retry } = useConfigPage<NewsCollectorConfig>({
+    section: 'news',
+    extract: (full: AppConfig) => (full as Record<string, unknown>).news as NewsCollectorConfig,
+  })
+
+  const cfg = config ?? DEFAULT_NEWS_CONFIG
+  const enabled = cfg.enabled !== false
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-[880px] mx-auto">
+        <div className="flex items-center justify-end gap-3 mb-4">
+          <SaveIndicator status={status} onRetry={retry} />
+          <Toggle size="sm" checked={enabled} onChange={(v) => updateConfigImmediate({ enabled: v })} />
+        </div>
+
+        <div className={`${!enabled ? 'opacity-40 pointer-events-none' : ''}`}>
+          {/* Collection Settings */}
+          <ConfigSection
+            title="Collection Settings"
+            description="Control how often articles are fetched and how long they are retained in the archive."
+          >
+            <div className="grid grid-cols-2 gap-4">
+              <Field label="Fetch interval (min)">
+                <input
+                  className={inputClass}
+                  type="number"
+                  min={1}
+                  value={cfg.intervalMinutes}
+                  onChange={(e) => updateConfig({ intervalMinutes: Number(e.target.value) || 10 })}
+                />
+              </Field>
+              <Field label="Retention (days)">
+                <input
+                  className={inputClass}
+                  type="number"
+                  min={1}
+                  value={cfg.retentionDays}
+                  onChange={(e) => updateConfig({ retentionDays: Number(e.target.value) || 7 })}
+                />
+              </Field>
+            </div>
+          </ConfigSection>
+
+          {/* RSS Feeds */}
+          <FeedsSection
+            feeds={cfg.feeds}
+            onChange={(feeds) => updateConfigImmediate({ feeds })}
+          />
+        </div>
+        {loadError && <p className="text-[13px] text-red mt-4">Failed to load configuration.</p>}
+      </div>
+    </div>
+  )
+}
+
+// ==================== Feeds Section ====================
+
+function FeedsSection({
+  feeds,
+  onChange,
+}: {
+  feeds: NewsCollectorFeed[]
+  onChange: (feeds: NewsCollectorFeed[]) => void
+}) {
+  const [newName, setNewName] = useState('')
+  const [newUrl, setNewUrl] = useState('')
+  const [newSource, setNewSource] = useState('')
+
+  const removeFeed = (index: number) => onChange(feeds.filter((_, i) => i !== index))
+
+  const addFeed = () => {
+    if (!newName.trim() || !newUrl.trim() || !newSource.trim()) return
+    onChange([...feeds, { name: newName.trim(), url: newUrl.trim(), source: newSource.trim() }])
+    setNewName('')
+    setNewUrl('')
+    setNewSource('')
+  }
+
+  return (
+    <ConfigSection
+      title="RSS Feeds"
+      description={
+        feeds.length > 0
+          ? `${feeds.length} feed${feeds.length > 1 ? 's' : ''} configured. Articles are searchable via globNews, grepNews, and readNews tools.`
+          : 'No feeds configured yet. Add feeds to start collecting articles.'
+      }
+    >
+      {/* Existing feeds */}
+      {feeds.length > 0 && (
+        <div className="space-y-2 mb-4">
+          {feeds.map((feed, i) => (
+            <div
+              key={`${feed.source}-${i}`}
+              className="flex items-center gap-3 border border-border/60 rounded-lg px-3 py-2.5"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-[13px] font-medium text-text truncate">{feed.name}</p>
+                <p className="text-[12px] text-text-muted truncate">{feed.url}</p>
+                <p className="text-[11px] text-text-muted/50 mt-0.5">source: {feed.source}</p>
+              </div>
+              <button
+                onClick={() => removeFeed(i)}
+                className="shrink-0 text-text-muted hover:text-red transition-colors p-1"
+                title="Remove feed"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add feed form */}
+      <div className="border border-border/40 rounded-lg p-4 space-y-3">
+        <p className="text-[13px] font-medium text-text-muted">Add Feed</p>
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Name">
+            <input className={inputClass} value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="e.g. CoinDesk" />
+          </Field>
+          <Field label="Source Tag">
+            <input className={inputClass} value={newSource} onChange={(e) => setNewSource(e.target.value)} placeholder="e.g. coindesk" />
+          </Field>
+        </div>
+        <Field label="Feed URL">
+          <input className={inputClass} value={newUrl} onChange={(e) => setNewUrl(e.target.value)} placeholder="https://example.com/rss.xml" />
+        </Field>
+        <button
+          onClick={addFeed}
+          disabled={!newName.trim() || !newUrl.trim() || !newSource.trim()}
+          className="btn-secondary"
+        >
+          Add Feed
+        </button>
+      </div>
+    </ConfigSection>
+  )
+}
+
+// ==================== Page ====================
+
+export function NewsCollectorPage() {
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <PageHeader
+        title="News Collector"
+        description="Configure RSS feeds and collection settings."
+      />
+
+      <div className="flex-1 flex flex-col min-h-0 px-4 md:px-8 py-5">
+        <CollectorSettings />
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/NewsPage.tsx
+++ b/ui/src/pages/NewsPage.tsx
@@ -1,9 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { api, type AppConfig, type NewsCollectorConfig, type NewsCollectorFeed, type NewsArticle } from '../api'
-import { SaveIndicator } from '../components/SaveIndicator'
-import { ConfigSection, Field, inputClass } from '../components/form'
-import { Toggle } from '../components/Toggle'
-import { useConfigPage } from '../hooks/useConfigPage'
+import { api, type NewsArticle } from '../api'
 import { PageHeader } from '../components/PageHeader'
 import { EmptyState } from '../components/StateViews'
 
@@ -24,99 +20,7 @@ const LOOKBACK_OPTIONS = [
   { value: '7d', label: '7 days' },
 ]
 
-// ==================== Feed Section ====================
-
-function NewsFeedSection() {
-  const [articles, setArticles] = useState<NewsArticle[]>([])
-  const [lookback, setLookback] = useState('24h')
-  const [sourceFilter, setSourceFilter] = useState('')
-  const [loading, setLoading] = useState(true)
-  const [sources, setSources] = useState<string[]>([])
-
-  const fetchArticles = useCallback(async (lb: string, src: string) => {
-    try {
-      const res = await api.news.list({
-        lookback: lb,
-        limit: 200,
-        source: src || undefined,
-      })
-      setArticles(res.items)
-      // Collect unique sources for filter dropdown
-      const seen = new Set<string>()
-      for (const item of res.items) {
-        if (item.source) seen.add(item.source)
-      }
-      setSources((prev) => {
-        const merged = new Set([...prev, ...seen])
-        return [...merged].sort()
-      })
-    } catch (err) {
-      console.warn('Failed to load news:', err)
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  // Fetch on mount and when filters change
-  useEffect(() => {
-    setLoading(true)
-    fetchArticles(lookback, sourceFilter)
-  }, [lookback, sourceFilter, fetchArticles])
-
-  // Poll every 60s
-  useEffect(() => {
-    const id = setInterval(() => fetchArticles(lookback, sourceFilter), 60_000)
-    return () => clearInterval(id)
-  }, [lookback, sourceFilter, fetchArticles])
-
-  return (
-    <div className="flex flex-col gap-3 h-full">
-      {/* Controls */}
-      <div className="flex items-center gap-3 shrink-0 flex-wrap">
-        <select
-          value={lookback}
-          onChange={(e) => setLookback(e.target.value)}
-          className="bg-bg-tertiary text-text text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-accent"
-        >
-          {LOOKBACK_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
-
-        <select
-          value={sourceFilter}
-          onChange={(e) => setSourceFilter(e.target.value)}
-          className="bg-bg-tertiary text-text text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-accent"
-        >
-          <option value="">All sources</option>
-          {sources.map((s) => (
-            <option key={s} value={s}>{s}</option>
-          ))}
-        </select>
-
-        <span className="text-xs text-text-muted ml-auto">
-          {articles.length} article{articles.length !== 1 ? 's' : ''}
-        </span>
-      </div>
-
-      {/* Article list */}
-      <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border border-border bg-bg">
-        {loading && articles.length === 0 ? (
-          <div className="px-4 py-8 text-center text-text-muted">Loading...</div>
-        ) : articles.length === 0 ? (
-          <EmptyState title="No articles" description="No news articles found for this time range." />
-        ) : (
-          <div className="divide-y divide-border/50">
-            {/* Reverse to show newest first */}
-            {[...articles].reverse().map((article, i) => (
-              <ArticleRow key={`${article.time}-${i}`} article={article} />
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
+// ==================== Article Row ====================
 
 function ArticleRow({ article }: { article: NewsArticle }) {
   const [expanded, setExpanded] = useState(false)
@@ -178,198 +82,96 @@ function ArticleRow({ article }: { article: NewsArticle }) {
   )
 }
 
-// ==================== Settings Section ====================
-
-const DEFAULT_NEWS_CONFIG: NewsCollectorConfig = {
-  enabled: true,
-  intervalMinutes: 10,
-  maxInMemory: 2000,
-  retentionDays: 7,
-  feeds: [],
-}
-
-function NewsSettingsSection() {
-  const { config, status, loadError, updateConfig, updateConfigImmediate, retry } = useConfigPage<NewsCollectorConfig>({
-    section: 'news',
-    extract: (full: AppConfig) => (full as Record<string, unknown>).news as NewsCollectorConfig,
-  })
-
-  const cfg = config ?? DEFAULT_NEWS_CONFIG
-  const enabled = cfg.enabled !== false
-
-  return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="flex items-center justify-end gap-3 mb-4">
-        <SaveIndicator status={status} onRetry={retry} />
-        <Toggle size="sm" checked={enabled} onChange={(v) => updateConfigImmediate({ enabled: v })} />
-      </div>
-
-      <div className={`max-w-[880px] mx-auto ${!enabled ? 'opacity-40 pointer-events-none' : ''}`}>
-        {/* Collection Settings */}
-        <ConfigSection
-          title="Collection Settings"
-          description="Control how often articles are fetched and how long they are retained in the archive."
-        >
-          <div className="grid grid-cols-2 gap-4">
-            <Field label="Fetch interval (min)">
-              <input
-                className={inputClass}
-                type="number"
-                min={1}
-                value={cfg.intervalMinutes}
-                onChange={(e) => updateConfig({ intervalMinutes: Number(e.target.value) || 10 })}
-              />
-            </Field>
-            <Field label="Retention (days)">
-              <input
-                className={inputClass}
-                type="number"
-                min={1}
-                value={cfg.retentionDays}
-                onChange={(e) => updateConfig({ retentionDays: Number(e.target.value) || 7 })}
-              />
-            </Field>
-          </div>
-        </ConfigSection>
-
-        {/* RSS Feeds */}
-        <FeedsSection
-          feeds={cfg.feeds}
-          onChange={(feeds) => updateConfigImmediate({ feeds })}
-        />
-      </div>
-      {loadError && <p className="text-[13px] text-red mt-4 max-w-[880px] mx-auto">Failed to load configuration.</p>}
-    </div>
-  )
-}
-
-// ==================== Feeds Section ====================
-
-function FeedsSection({
-  feeds,
-  onChange,
-}: {
-  feeds: NewsCollectorFeed[]
-  onChange: (feeds: NewsCollectorFeed[]) => void
-}) {
-  const [newName, setNewName] = useState('')
-  const [newUrl, setNewUrl] = useState('')
-  const [newSource, setNewSource] = useState('')
-
-  const removeFeed = (index: number) => onChange(feeds.filter((_, i) => i !== index))
-
-  const addFeed = () => {
-    if (!newName.trim() || !newUrl.trim() || !newSource.trim()) return
-    onChange([...feeds, { name: newName.trim(), url: newUrl.trim(), source: newSource.trim() }])
-    setNewName('')
-    setNewUrl('')
-    setNewSource('')
-  }
-
-  return (
-    <ConfigSection
-      title="RSS Feeds"
-      description={
-        feeds.length > 0
-          ? `${feeds.length} feed${feeds.length > 1 ? 's' : ''} configured. Articles are searchable via globNews, grepNews, and readNews tools.`
-          : 'No feeds configured yet. Add feeds to start collecting articles.'
-      }
-    >
-      {/* Existing feeds */}
-      {feeds.length > 0 && (
-        <div className="space-y-2 mb-4">
-          {feeds.map((feed, i) => (
-            <div
-              key={`${feed.source}-${i}`}
-              className="flex items-center gap-3 border border-border/60 rounded-lg px-3 py-2.5"
-            >
-              <div className="flex-1 min-w-0">
-                <p className="text-[13px] font-medium text-text truncate">{feed.name}</p>
-                <p className="text-[12px] text-text-muted truncate">{feed.url}</p>
-                <p className="text-[11px] text-text-muted/50 mt-0.5">source: {feed.source}</p>
-              </div>
-              <button
-                onClick={() => removeFeed(i)}
-                className="shrink-0 text-text-muted hover:text-red transition-colors p-1"
-                title="Remove feed"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18" />
-                  <line x1="6" y1="6" x2="18" y2="18" />
-                </svg>
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Add feed form */}
-      <div className="border border-border/40 rounded-lg p-4 space-y-3">
-        <p className="text-[13px] font-medium text-text-muted">Add Feed</p>
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="Name">
-            <input className={inputClass} value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="e.g. CoinDesk" />
-          </Field>
-          <Field label="Source Tag">
-            <input className={inputClass} value={newSource} onChange={(e) => setNewSource(e.target.value)} placeholder="e.g. coindesk" />
-          </Field>
-        </div>
-        <Field label="Feed URL">
-          <input className={inputClass} value={newUrl} onChange={(e) => setNewUrl(e.target.value)} placeholder="https://example.com/rss.xml" />
-        </Field>
-        <button
-          onClick={addFeed}
-          disabled={!newName.trim() || !newUrl.trim() || !newSource.trim()}
-          className="btn-secondary"
-        >
-          Add Feed
-        </button>
-      </div>
-    </ConfigSection>
-  )
-}
-
 // ==================== Page ====================
 
-type Tab = 'feed' | 'settings'
-
-const TABS: { key: Tab; label: string }[] = [
-  { key: 'feed', label: 'Feed' },
-  { key: 'settings', label: 'Settings' },
-]
-
 export function NewsPage() {
-  const [tab, setTab] = useState<Tab>('feed')
+  const [articles, setArticles] = useState<NewsArticle[]>([])
+  const [lookback, setLookback] = useState('24h')
+  const [sourceFilter, setSourceFilter] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [sources, setSources] = useState<string[]>([])
+
+  const fetchArticles = useCallback(async (lb: string, src: string) => {
+    try {
+      const res = await api.news.list({
+        lookback: lb,
+        limit: 200,
+        source: src || undefined,
+      })
+      setArticles(res.items)
+      const seen = new Set<string>()
+      for (const item of res.items) {
+        if (item.source) seen.add(item.source)
+      }
+      setSources((prev) => {
+        const merged = new Set([...prev, ...seen])
+        return [...merged].sort()
+      })
+    } catch (err) {
+      console.warn('Failed to load news:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
+    fetchArticles(lookback, sourceFilter)
+  }, [lookback, sourceFilter, fetchArticles])
+
+  useEffect(() => {
+    const id = setInterval(() => fetchArticles(lookback, sourceFilter), 60_000)
+    return () => clearInterval(id)
+  }, [lookback, sourceFilter, fetchArticles])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <PageHeader
-        title="News"
-        description="RSS feed collection and article archive."
-      />
-
-      <div className="px-4 md:px-6 border-b border-border/60">
-        <div className="flex gap-1">
-          {TABS.map((t) => (
-            <button
-              key={t.key}
-              onClick={() => setTab(t.key)}
-              className={`px-3 py-2 text-sm font-medium transition-colors relative ${
-                tab === t.key ? 'text-accent' : 'text-text-muted hover:text-text'
-              }`}
-            >
-              {t.label}
-              {tab === t.key && (
-                <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-accent rounded-t" />
-              )}
-            </button>
-          ))}
-        </div>
-      </div>
+      <PageHeader title="News" />
 
       <div className="flex-1 flex flex-col min-h-0 px-4 md:px-6 py-5">
-        <div className="flex-1 min-h-0">
-          {tab === 'feed' ? <NewsFeedSection /> : <NewsSettingsSection />}
+        <div className="flex flex-col gap-3 h-full">
+          {/* Controls */}
+          <div className="flex items-center gap-3 shrink-0 flex-wrap">
+            <select
+              value={lookback}
+              onChange={(e) => setLookback(e.target.value)}
+              className="bg-bg-tertiary text-text text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-accent"
+            >
+              {LOOKBACK_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+
+            <select
+              value={sourceFilter}
+              onChange={(e) => setSourceFilter(e.target.value)}
+              className="bg-bg-tertiary text-text text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-accent"
+            >
+              <option value="">All sources</option>
+              {sources.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+
+            <span className="text-xs text-text-muted ml-auto">
+              {articles.length} article{articles.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+
+          {/* Article list */}
+          <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border border-border bg-bg">
+            {loading && articles.length === 0 ? (
+              <div className="px-4 py-8 text-center text-text-muted">Loading...</div>
+            ) : articles.length === 0 ? (
+              <EmptyState title="No articles" description="No news articles found for this time range." />
+            ) : (
+              <div className="divide-y divide-border/50">
+                {[...articles].reverse().map((article, i) => (
+                  <ArticleRow key={`${article.time}-${i}`} article={article} />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Rewrite README intro: replace implementation-focused bullets (file-driven, OS-native, reasoning-driven) with user-value framing (full-spectrum, full-lifecycle, full-control)
- Reorganize flat feature list into grouped sections: Trading, Research & Analysis, Automation, Interface, And More
- Restructure Architecture section with layered TB diagram (Interface → Core → Domain → Automation) instead of implementation-focused LR graph
- Rewrite Key Concepts with correct priority ordering (UTA first, AI Provider last), remove non-terms (Brain, Evolution Mode, Domain, EventLog)
- Clean up Quick Start to focus on getting users running — remove dev commands
- Move 80-line project structure file tree to `docs/project-structure.md`

Also includes: refactor News page into feed terminal + collector config (UI)

## Test plan

- [ ] Verify mermaid diagram renders correctly on GitHub
- [ ] Check all internal links (`docs/project-structure.md`, `docs/mcp-ask-connector.md`)
- [ ] Read through for consistency between Features, Key Concepts, and Architecture sections


🤖 Generated with [Claude Code](https://claude.com/claude-code)