### PR TITLE
Default Claude to Opus 4.7 + ListenerRegistry refactor

### DIFF
--- a/src/ai-providers/agent-sdk/query.ts
+++ b/src/ai-providers/agent-sdk/query.ts
@@ -151,7 +151,7 @@ export async function askAgentSdk(
       options: {
         cwd,
         env,
-        model: override?.model ?? 'claude-sonnet-4-6',
+        model: override?.model ?? 'claude-opus-4-7',
         maxTurns,
         allowedTools: finalAllowed,
         disallowedTools: finalDisallowed,

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -40,13 +40,14 @@ export const CLAUDE_OAUTH: PresetDef = {
   description: 'Use your Claude Pro/Max subscription',
   category: 'official',
   defaultName: 'Claude (Pro/Max)',
-  hint: 'Requires Claude Code CLI login. Run `claude login` in your terminal first.',
+  hint: 'Requires Claude Code CLI login — run `claude login` in your terminal first. Model is switchable here or from the profile list anytime; Opus is most capable but burns subscription quota faster, so consider Sonnet for routine work.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('claudeai'),
-    model: z.string().default('claude-sonnet-4-6').describe('Model'),
+    model: z.string().default('claude-opus-4-7').describe('Model'),
   }),
   models: [
+    { id: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
     { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
     { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   ],
@@ -58,13 +59,15 @@ export const CLAUDE_API: PresetDef = {
   description: 'Pay per token via Anthropic API',
   category: 'official',
   defaultName: 'Claude (API Key)',
+  hint: 'Model is switchable here or from the profile list anytime. Opus is ~5× the cost of Sonnet; Haiku is cheapest for high-volume work.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
-    model: z.string().default('claude-sonnet-4-6').describe('Model'),
+    model: z.string().default('claude-opus-4-7').describe('Model'),
     apiKey: z.string().min(1).describe('Anthropic API key'),
   }),
   models: [
+    { id: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
     { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
     { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
     { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },

--- a/src/core/__tests__/pipeline/delivery.spec.ts
+++ b/src/core/__tests__/pipeline/delivery.spec.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { StreamableResult, type ProviderEvent } from '../../ai-provider-manager.js'
 import { ConnectorCenter } from '../../connector-center.js'
 import { createEventLog } from '../../event-log.js'
+import { createListenerRegistry } from '../../listener-registry.js'
 import type { MediaAttachment } from '../../types.js'
 import {
   MockConnector,
@@ -170,8 +171,10 @@ describe('ConnectorCenter — delivery', () => {
 
   it('C9: resolveTarget follows lastInteraction via EventLog', async () => {
     const eventLog = await createEventLog({ logPath: `/tmp/test-pipeline-c9-${Date.now()}.jsonl` })
+    const listenerRegistry = createListenerRegistry(eventLog)
+    await listenerRegistry.start()
     try {
-      const cc = new ConnectorCenter(eventLog)
+      const cc = new ConnectorCenter({ eventLog, listenerRegistry })
 
       const web = new MockConnector({ channel: 'web' })
       const telegram = new MockConnector({ channel: 'telegram' })

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -21,7 +21,7 @@ const legacyLoginMethodSchema = z.enum(['api-key', 'claudeai', 'codex-oauth'])
 export const aiProviderLegacySchema = z.object({
   backend: z.enum(['claude-code', 'vercel-ai-sdk', 'agent-sdk', 'codex']).default('claude-code'),
   provider: z.string().default('anthropic'),
-  model: z.string().default('claude-sonnet-4-6'),
+  model: z.string().default('claude-opus-4-7'),
   baseUrl: z.string().min(1).optional(),
   loginMethod: legacyLoginMethodSchema.default('api-key'),
   apiKeys: z.object({
@@ -51,7 +51,7 @@ const baseProfileFields = {
 export const agentSdkProfileSchema = z.object({
   ...baseProfileFields,
   backend: z.literal('agent-sdk'),
-  model: z.string().default('claude-sonnet-4-6'),
+  model: z.string().default('claude-opus-4-7'),
   loginMethod: z.enum(['api-key', 'claudeai']).default('api-key'),
 })
 
@@ -66,7 +66,7 @@ export const vercelProfileSchema = z.object({
   ...baseProfileFields,
   backend: z.literal('vercel-ai-sdk'),
   provider: z.string().default('anthropic'),
-  model: z.string().default('claude-sonnet-4-6'),
+  model: z.string().default('claude-opus-4-7'),
 })
 
 export const profileSchema = z.discriminatedUnion('backend', [
@@ -81,7 +81,7 @@ export const aiProviderSchema = z.object({
     z.string(),
     profileSchema,
   ).default({
-    default: { backend: 'agent-sdk', model: 'claude-sonnet-4-6', loginMethod: 'claudeai' },
+    default: { backend: 'agent-sdk', model: 'claude-opus-4-7', loginMethod: 'claudeai' },
   }),
   activeProfile: z.string().default('default'),
 })
@@ -409,7 +409,7 @@ export async function loadConfig(): Promise<Config> {
         default: {
           backend: 'agent-sdk',
           label: 'Default',
-          model: (oldModel?.model as string) ?? 'claude-sonnet-4-6',
+          model: (oldModel?.model as string) ?? 'claude-opus-4-7',
           loginMethod: 'claudeai',
           provider: (oldModel?.provider as string) ?? 'anthropic',
         },

--- a/src/core/connector-center.spec.ts
+++ b/src/core/connector-center.spec.ts
@@ -8,6 +8,7 @@ import {
   type SendPayload,
 } from './connector-center.js'
 import { createEventLog, type EventLog } from './event-log.js'
+import { createListenerRegistry } from './listener-registry.js'
 
 function makeConnector(overrides: Partial<Connector> = {}): Connector {
   return {
@@ -235,14 +236,18 @@ describe('ConnectorCenter', () => {
   describe('with EventLog', () => {
     let cc: ConnectorCenter
     let eventLog: EventLog
+    let listenerRegistry: ReturnType<typeof createListenerRegistry>
 
     beforeEach(async () => {
       const logPath = join(tmpdir(), `cc-test-${randomUUID()}.jsonl`)
       eventLog = await createEventLog({ logPath })
-      cc = new ConnectorCenter(eventLog)
+      listenerRegistry = createListenerRegistry(eventLog)
+      await listenerRegistry.start()
+      cc = new ConnectorCenter({ eventLog, listenerRegistry })
     })
 
     afterEach(async () => {
+      await listenerRegistry.stop()
       await eventLog._resetForTest()
     })
 

--- a/src/core/connector-center.ts
+++ b/src/core/connector-center.ts
@@ -14,6 +14,8 @@ import type { EventLog } from './event-log.js'
 import type { MediaAttachment } from './types.js'
 import type { StreamableResult } from './ai-provider-manager.js'
 import type { Connector, SendPayload, SendResult } from '../connectors/types.js'
+import type { Listener } from './listener.js'
+import type { ListenerRegistry } from './listener-registry.js'
 
 export type { Connector, SendPayload, SendResult, ConnectorCapabilities } from '../connectors/types.js'
 
@@ -42,11 +44,24 @@ export interface LastInteraction {
 
 // ==================== ConnectorCenter ====================
 
+export interface ConnectorCenterOpts {
+  eventLog?: EventLog
+  listenerRegistry?: ListenerRegistry
+}
+
 export class ConnectorCenter {
   private connectors = new Map<string, Connector>()
   private lastInteraction: LastInteraction | null = null
 
-  constructor(eventLog?: EventLog) {
+  constructor(opts?: ConnectorCenterOpts | EventLog) {
+    // Backward-compat: accept bare EventLog for tests that pre-date the options shape
+    const resolved: ConnectorCenterOpts =
+      opts && typeof (opts as EventLog).subscribeType === 'function'
+        ? { eventLog: opts as EventLog }
+        : (opts as ConnectorCenterOpts | undefined) ?? {}
+
+    const { eventLog, listenerRegistry } = resolved
+
     // Restore last interaction from event log buffer (survives restart)
     if (eventLog) {
       const recent = eventLog.recent({ type: 'message.received' })
@@ -57,11 +72,17 @@ export class ConnectorCenter {
       }
     }
 
-    // Subscribe to future interactions
-    eventLog?.subscribeType('message.received', (entry) => {
-      const { channel, to } = entry.payload
-      this.touch(channel, to)
-    })
+    // Register interaction-tracking listener with the registry
+    if (listenerRegistry) {
+      const listener: Listener<'message.received'> = {
+        name: 'connector-interaction-tracker',
+        eventType: 'message.received',
+        handle: async (entry) => {
+          this.touch(entry.payload.channel, entry.payload.to)
+        },
+      }
+      listenerRegistry.register(listener)
+    }
   }
 
   /** Register a Connector instance. Replaces any existing registration for this channel. */

--- a/src/core/listener-registry.spec.ts
+++ b/src/core/listener-registry.spec.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createEventLog, type EventLog } from './event-log.js'
+import { createListenerRegistry, type ListenerRegistry } from './listener-registry.js'
+import type { Listener } from './listener.js'
+
+function tempLogPath(): string {
+  return join(tmpdir(), `listener-registry-${randomUUID()}.jsonl`)
+}
+
+// Wait one microtask + a small macrotask to let the registry's fire-and-forget
+// Promise chain settle.
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 5))
+}
+
+describe('ListenerRegistry', () => {
+  let eventLog: EventLog
+  let registry: ListenerRegistry
+
+  beforeEach(async () => {
+    eventLog = await createEventLog({ logPath: tempLogPath() })
+    registry = createListenerRegistry(eventLog)
+  })
+
+  afterEach(async () => {
+    await registry.stop()
+    await eventLog._resetForTest()
+  })
+
+  // ==================== register ====================
+
+  describe('register', () => {
+    it('should register a listener and show it in list()', () => {
+      const listener: Listener<'cron.fire'> = {
+        name: 'test',
+        eventType: 'cron.fire',
+        async handle() { /* no-op */ },
+      }
+      registry.register(listener)
+
+      const infos = registry.list()
+      expect(infos).toHaveLength(1)
+      expect(infos[0]).toEqual({ name: 'test', eventType: 'cron.fire' })
+    })
+
+    it('should throw on duplicate name', () => {
+      const listener: Listener<'cron.fire'> = {
+        name: 'dup',
+        eventType: 'cron.fire',
+        async handle() { /* no-op */ },
+      }
+      registry.register(listener)
+
+      expect(() => registry.register(listener)).toThrow(/already registered/)
+    })
+  })
+
+  // ==================== start / stop ====================
+
+  describe('start/stop', () => {
+    it('should deliver matching events after start()', async () => {
+      const received: string[] = []
+      registry.register({
+        name: 'l1',
+        eventType: 'cron.fire',
+        async handle(entry) { received.push(entry.payload.jobId) },
+      })
+      await registry.start()
+
+      await eventLog.append('cron.fire', { jobId: 'j1', jobName: 'x', payload: 'p' })
+      await flush()
+
+      expect(received).toEqual(['j1'])
+    })
+
+    it('should not deliver non-matching event types', async () => {
+      const received: unknown[] = []
+      registry.register({
+        name: 'l1',
+        eventType: 'cron.fire',
+        async handle(entry) { received.push(entry) },
+      })
+      await registry.start()
+
+      await eventLog.append('heartbeat.skip', { reason: 'test' })
+      await flush()
+
+      expect(received).toHaveLength(0)
+    })
+
+    it('should stop delivering after stop()', async () => {
+      const received: string[] = []
+      registry.register({
+        name: 'l1',
+        eventType: 'cron.fire',
+        async handle(entry) { received.push(entry.payload.jobId) },
+      })
+      await registry.start()
+
+      await eventLog.append('cron.fire', { jobId: 'before', jobName: 'x', payload: 'p' })
+      await flush()
+
+      await registry.stop()
+
+      await eventLog.append('cron.fire', { jobId: 'after', jobName: 'x', payload: 'p' })
+      await flush()
+
+      expect(received).toEqual(['before'])
+    })
+
+    it('should deliver to multiple listeners on same event type', async () => {
+      const a: string[] = []
+      const b: string[] = []
+      registry.register({
+        name: 'a',
+        eventType: 'cron.fire',
+        async handle(entry) { a.push(entry.payload.jobId) },
+      })
+      registry.register({
+        name: 'b',
+        eventType: 'cron.fire',
+        async handle(entry) { b.push(entry.payload.jobId) },
+      })
+      await registry.start()
+
+      await eventLog.append('cron.fire', { jobId: 'j1', jobName: 'x', payload: 'p' })
+      await flush()
+
+      expect(a).toEqual(['j1'])
+      expect(b).toEqual(['j1'])
+    })
+
+    it('should subscribe listener registered after start()', async () => {
+      await registry.start()
+
+      const received: string[] = []
+      registry.register({
+        name: 'late',
+        eventType: 'cron.fire',
+        async handle(entry) { received.push(entry.payload.jobId) },
+      })
+
+      await eventLog.append('cron.fire', { jobId: 'j1', jobName: 'x', payload: 'p' })
+      await flush()
+
+      expect(received).toEqual(['j1'])
+    })
+  })
+
+  // ==================== error isolation ====================
+
+  describe('error isolation', () => {
+    it('should not affect other listeners when one throws', async () => {
+      const received: string[] = []
+      registry.register({
+        name: 'boom',
+        eventType: 'cron.fire',
+        async handle() { throw new Error('boom') },
+      })
+      registry.register({
+        name: 'ok',
+        eventType: 'cron.fire',
+        async handle(entry) { received.push(entry.payload.jobId) },
+      })
+      await registry.start()
+
+      await eventLog.append('cron.fire', { jobId: 'j1', jobName: 'x', payload: 'p' })
+      await flush()
+
+      expect(received).toEqual(['j1'])
+    })
+
+    it('should continue accepting events after a handle() error', async () => {
+      const received: string[] = []
+      let first = true
+      registry.register({
+        name: 'flaky',
+        eventType: 'cron.fire',
+        async handle(entry) {
+          if (first) { first = false; throw new Error('first one fails') }
+          received.push(entry.payload.jobId)
+        },
+      })
+      await registry.start()
+
+      await eventLog.append('cron.fire', { jobId: 'j1', jobName: 'x', payload: 'p' })
+      await flush()
+      await eventLog.append('cron.fire', { jobId: 'j2', jobName: 'x', payload: 'p' })
+      await flush()
+
+      expect(received).toEqual(['j2'])
+    })
+  })
+})

--- a/src/core/listener-registry.ts
+++ b/src/core/listener-registry.ts
@@ -1,0 +1,102 @@
+/**
+ * ListenerRegistry — centralized lifecycle management for Listeners.
+ *
+ * Each module that needs to listen owns its Listener and calls
+ * `registry.register(...)` during its own setup. The registry activates
+ * all registered listeners together via `start()` and tears them down
+ * via `stop()`.
+ *
+ * Errors thrown inside a listener's `handle()` are caught and logged —
+ * they do not affect other listeners.
+ */
+
+import type { AgentEventMap } from './agent-event.js'
+import type { EventLog } from './event-log.js'
+import type { Listener } from './listener.js'
+
+export interface ListenerInfo {
+  name: string
+  eventType: string
+}
+
+export interface ListenerRegistry {
+  /** Register a listener. Throws if the name is already taken. */
+  register<K extends keyof AgentEventMap>(listener: Listener<K>): void
+  /** Unregister a listener by name. Unsubscribes it if the registry is started. No-op if not found. */
+  unregister(name: string): void
+  /** Activate all registered listeners (subscribe to EventLog). */
+  start(): Promise<void>
+  /** Deactivate all listeners (unsubscribe). */
+  stop(): Promise<void>
+  /** Introspection — registered listener names and their event types. */
+  list(): ReadonlyArray<ListenerInfo>
+}
+
+export function createListenerRegistry(eventLog: EventLog): ListenerRegistry {
+  // Storage is necessarily wide-typed (union across all event types).
+  // Per-call type precision is preserved via the generic `register<K>` signature.
+  type AnyListener = Listener<keyof AgentEventMap>
+  const listeners = new Map<string, AnyListener>()
+  const unsubscribes = new Map<string, () => void>()
+  let started = false
+
+  function register<K extends keyof AgentEventMap>(listener: Listener<K>): void {
+    if (listeners.has(listener.name)) {
+      throw new Error(`ListenerRegistry: listener "${listener.name}" already registered`)
+    }
+    listeners.set(listener.name, listener as AnyListener)
+    // If registry is already running, subscribe immediately
+    if (started) {
+      subscribeOne(listener as AnyListener)
+    }
+  }
+
+  function subscribeOne(listener: AnyListener): void {
+    const unsub = eventLog.subscribeType(listener.eventType, (entry) => {
+      // Fire-and-forget with error isolation
+      Promise.resolve()
+        .then(() => listener.handle(entry, eventLog))
+        .catch((err) => {
+          console.error(`listener[${listener.name}]: unhandled error:`, err)
+        })
+    })
+    unsubscribes.set(listener.name, unsub)
+  }
+
+  function unregister(name: string): void {
+    const existing = listeners.get(name)
+    if (!existing) return
+    listeners.delete(name)
+    const unsub = unsubscribes.get(name)
+    if (unsub) {
+      try { unsub() } catch { /* swallow */ }
+      unsubscribes.delete(name)
+    }
+  }
+
+  async function start(): Promise<void> {
+    if (started) return
+    started = true
+    for (const listener of listeners.values()) {
+      subscribeOne(listener)
+    }
+  }
+
+  async function stop(): Promise<void> {
+    if (!started) return
+    started = false
+    for (const unsub of unsubscribes.values()) {
+      try { unsub() } catch { /* swallow */ }
+    }
+    unsubscribes.clear()
+  }
+
+  function list(): ReadonlyArray<ListenerInfo> {
+    return Array.from(listeners.values()).map((l) => ({
+      name: l.name,
+      eventType: l.eventType,
+    }))
+  }
+
+  return { register, unregister, start, stop, list }
+}

--- a/src/core/listener.ts
+++ b/src/core/listener.ts
@@ -1,0 +1,19 @@
+/**
+ * Listener — standard interface for subscribing to AgentEvent types.
+ *
+ * A Listener represents a single handler for one event type. Filtering,
+ * serial locks, and internal state are the listener's own responsibility —
+ * the registry only manages subscription lifecycle and error isolation.
+ */
+
+import type { AgentEventMap } from './agent-event.js'
+import type { EventLog, EventLogEntry } from './event-log.js'
+
+export interface Listener<K extends keyof AgentEventMap = keyof AgentEventMap> {
+  /** Unique name for identification (registry key, future UI display). */
+  name: string
+  /** Event type this listener subscribes to. */
+  eventType: K
+  /** Called when a matching event is appended. Receives the entry + full EventLog for history queries. */
+  handle(entry: EventLogEntry<AgentEventMap[K]>, eventLog: EventLog): Promise<void>
+}

--- a/src/domain/trading/snapshot/scheduler.ts
+++ b/src/domain/trading/snapshot/scheduler.ts
@@ -1,16 +1,18 @@
 /**
  * Snapshot scheduler — periodic snapshots via cron engine.
  *
- * Registers a cron job (`__snapshot__`) and subscribes to `cron.fire` events.
- * When fired, captures snapshots for all accounts.
+ * Registers a cron job (`__snapshot__`) and registers a `cron.fire` listener
+ * with the ListenerRegistry. When fired, captures snapshots for all accounts.
  *
  * Follows the same pattern as the heartbeat system.
  */
 
-import type { EventLog, EventLogEntry } from '../../../core/event-log.js'
+import type { EventLogEntry } from '../../../core/event-log.js'
 import type { CronFirePayload } from '../../../core/agent-event.js'
 import type { CronEngine } from '../../../task/cron/engine.js'
 import type { SnapshotService } from './service.js'
+import type { Listener } from '../../../core/listener.js'
+import type { ListenerRegistry } from '../../../core/listener-registry.js'
 
 const SNAPSHOT_JOB_NAME = '__snapshot__'
 
@@ -22,18 +24,19 @@ export interface SnapshotConfig {
 export interface SnapshotScheduler {
   start(): Promise<void>
   stop(): void
+  readonly listener: Listener<'cron.fire'>
 }
 
 export function createSnapshotScheduler(deps: {
   snapshotService: SnapshotService
   cronEngine: CronEngine
-  eventLog: EventLog
+  registry: ListenerRegistry
   config: SnapshotConfig
 }): SnapshotScheduler {
-  const { snapshotService, cronEngine, eventLog, config } = deps
+  const { snapshotService, cronEngine, registry, config } = deps
 
-  let unsubscribe: (() => void) | null = null
   let processing = false
+  let registered = false
 
   async function handleFire(entry: EventLogEntry<CronFirePayload>): Promise<void> {
     const payload = entry.payload
@@ -50,7 +53,14 @@ export function createSnapshotScheduler(deps: {
     }
   }
 
+  const listener: Listener<'cron.fire'> = {
+    name: 'snapshot',
+    eventType: 'cron.fire',
+    handle: handleFire,
+  }
+
   return {
+    listener,
     async start() {
       // Find or create the cron job
       const existing = cronEngine.list().find(j => j.name === SNAPSHOT_JOB_NAME)
@@ -68,19 +78,18 @@ export function createSnapshotScheduler(deps: {
         })
       }
 
-      // Subscribe to cron.fire events
-      if (!unsubscribe) {
-        unsubscribe = eventLog.subscribeType('cron.fire', (entry) => {
-          handleFire(entry).catch(err => {
-            console.error('snapshot-scheduler: unhandled error:', err)
-          })
-        })
+      // Register listener exactly once
+      if (!registered) {
+        registry.register(listener)
+        registered = true
       }
     },
 
     stop() {
-      unsubscribe?.()
-      unsubscribe = null
+      if (registered) {
+        registry.unregister(listener.name)
+        registered = false
+      }
     },
   }
 }

--- a/src/domain/trading/snapshot/snapshot.spec.ts
+++ b/src/domain/trading/snapshot/snapshot.spec.ts
@@ -10,6 +10,7 @@ import type { UnifiedTradingAccountOptions } from '../UnifiedTradingAccount.js'
 import { MockBroker, makeContract, makePosition, makeOpenOrder } from '../brokers/mock/index.js'
 import { AccountManager } from '../account-manager.js'
 import { createEventLog, type EventLog } from '../../../core/event-log.js'
+import { createListenerRegistry, type ListenerRegistry } from '../../../core/listener-registry.js'
 import { createCronEngine, type CronEngine } from '../../../task/cron/engine.js'
 import { buildSnapshot } from './builder.js'
 import { createSnapshotStore, type SnapshotStore } from './store.js'
@@ -448,6 +449,7 @@ describe('Snapshot Service', () => {
 
 describe('Snapshot Scheduler', () => {
   let eventLog: EventLog
+  let listenerRegistry: ListenerRegistry
   let cronEngine: CronEngine
   let scheduler: SnapshotScheduler
   let mockService: SnapshotService
@@ -456,6 +458,8 @@ describe('Snapshot Scheduler', () => {
     const logPath = tempPath('jsonl')
     const storePath = tempPath('json')
     eventLog = await createEventLog({ logPath })
+    listenerRegistry = createListenerRegistry(eventLog)
+    await listenerRegistry.start()
     cronEngine = createCronEngine({ eventLog, storePath })
     await cronEngine.start()
 
@@ -469,7 +473,7 @@ describe('Snapshot Scheduler', () => {
     scheduler = createSnapshotScheduler({
       snapshotService: mockService,
       cronEngine,
-      eventLog,
+      registry: listenerRegistry,
       config: { enabled: true, every: '15m' },
     })
   })
@@ -477,6 +481,7 @@ describe('Snapshot Scheduler', () => {
   afterEach(async () => {
     scheduler?.stop()
     cronEngine.stop()
+    await listenerRegistry.stop()
     await eventLog._resetForTest()
   })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import { AgentSdkProvider } from './ai-providers/agent-sdk/agent-sdk-provider.js
 import { CodexProvider } from './ai-providers/codex/index.js'
 import { createEventLog } from './core/event-log.js'
 import { createToolCallLog } from './core/tool-call-log.js'
+import { createListenerRegistry } from './core/listener-registry.js'
 import { createCronEngine, createCronListener, createCronTools } from './task/cron/index.js'
 import { createHeartbeat } from './task/heartbeat/index.js'
 import { NewsCollectorStore, NewsCollector } from './domain/news/index.js'
@@ -246,25 +247,27 @@ async function main() {
     toolCallLog,
   })
 
+  // ==================== Listener Registry ====================
+
+  const listenerRegistry = createListenerRegistry(eventLog)
+
   // ==================== Connector Center ====================
 
-  const connectorCenter = new ConnectorCenter(eventLog)
+  const connectorCenter = new ConnectorCenter({ eventLog, listenerRegistry })
 
   // Session awareness tools (registered here because they need connectorCenter)
   toolCenter.register(createSessionTools(connectorCenter), 'session')
 
-  // ==================== Cron Lifecycle ====================
+  // ==================== Cron Listener ====================
 
-  await cronEngine.start()
   const cronSession = new SessionStore('cron/default')
   await cronSession.restore()
-  const cronListener = createCronListener({ connectorCenter, eventLog, agentCenter, session: cronSession })
-  cronListener.start()
-  console.log('cron: engine + listener started')
+  const cronListener = createCronListener({ connectorCenter, agentCenter, registry: listenerRegistry, session: cronSession })
+  await cronListener.start()
 
   // ==================== Snapshot Scheduler ====================
 
-  const snapshotScheduler = createSnapshotScheduler({ snapshotService, cronEngine, eventLog, config: config.snapshot })
+  const snapshotScheduler = createSnapshotScheduler({ snapshotService, cronEngine, registry: listenerRegistry, config: config.snapshot })
   await snapshotScheduler.start()
   if (config.snapshot.enabled) {
     console.log(`snapshot: scheduler started (every ${config.snapshot.every})`)
@@ -274,12 +277,19 @@ async function main() {
 
   const heartbeat = createHeartbeat({
     config: config.heartbeat,
-    connectorCenter, cronEngine, eventLog, agentCenter,
+    connectorCenter, cronEngine, agentCenter, registry: listenerRegistry,
   })
   await heartbeat.start()
   if (config.heartbeat.enabled) {
     console.log(`heartbeat: enabled (every ${config.heartbeat.every})`)
   }
+
+  // ==================== Activate Listeners + Start Cron Engine ====================
+
+  await listenerRegistry.start()
+  await cronEngine.start()
+  console.log(`listener-registry: started (${listenerRegistry.list().length} listeners)`)
+  console.log('cron: engine started')
 
   // ==================== News Collector ====================
 
@@ -432,6 +442,7 @@ async function main() {
     heartbeat.stop()
     cronListener.stop()
     cronEngine.stop()
+    await listenerRegistry.stop()
     for (const plugin of [...corePlugins, ...optionalPlugins.values()]) {
       await plugin.stop()
     }

--- a/src/task/cron/listener.spec.ts
+++ b/src/task/cron/listener.spec.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
-import { createEventLog, type EventLog, type EventLogEntry } from '../../core/event-log.js'
+import { createEventLog, type EventLog } from '../../core/event-log.js'
+import { createListenerRegistry, type ListenerRegistry } from '../../core/listener-registry.js'
 import { createCronListener, type CronListener } from './listener.js'
 import { SessionStore } from '../../core/session.js'
 import type { CronFirePayload } from './engine.js'
@@ -35,7 +36,8 @@ function createMockEngine(response = 'AI reply') {
 
 describe('cron listener', () => {
   let eventLog: EventLog
-  let listener: CronListener
+  let registry: ListenerRegistry
+  let cronListener: CronListener
   let mockEngine: ReturnType<typeof createMockEngine>
   let session: SessionStore
   let logPath: string
@@ -44,20 +46,23 @@ describe('cron listener', () => {
   beforeEach(async () => {
     logPath = tempPath('jsonl')
     eventLog = await createEventLog({ logPath })
+    registry = createListenerRegistry(eventLog)
     mockEngine = createMockEngine()
     session = new SessionStore(`test/cron-${randomUUID()}`)
     connectorCenter = new ConnectorCenter()
 
-    listener = createCronListener({
+    cronListener = createCronListener({
       connectorCenter,
-      eventLog,
       agentCenter: mockEngine as any,
+      registry,
       session,
     })
+    await cronListener.start()
+    await registry.start()
   })
 
   afterEach(async () => {
-    listener.stop()
+    await registry.stop()
     await eventLog._resetForTest()
   })
 
@@ -65,8 +70,6 @@ describe('cron listener', () => {
 
   describe('event handling', () => {
     it('should call engine.askWithSession on cron.fire', async () => {
-      listener.start()
-
       await eventLog.append('cron.fire', {
         jobId: 'abc12345',
         jobName: 'test-job',
@@ -86,8 +89,6 @@ describe('cron listener', () => {
     })
 
     it('should write cron.done event on success', async () => {
-      listener.start()
-
       await eventLog.append('cron.fire', {
         jobId: 'abc12345',
         jobName: 'test-job',
@@ -109,8 +110,6 @@ describe('cron listener', () => {
     })
 
     it('should not react to other event types', async () => {
-      listener.start()
-
       await eventLog.append('some.other.event', { data: 'hello' })
 
       // Give it a moment
@@ -131,8 +130,6 @@ describe('cron listener', () => {
         capabilities: { push: true, media: false },
         send: async (payload) => { delivered.push(payload.text); return { delivered: true } },
       })
-
-      listener.start()
 
       await eventLog.append('cron.fire', {
         jobId: 'abc12345',
@@ -155,8 +152,6 @@ describe('cron listener', () => {
         send: async () => { throw new Error('send failed') },
       })
 
-      listener.start()
-
       await eventLog.append('cron.fire', {
         jobId: 'abc12345',
         jobName: 'test-job',
@@ -172,8 +167,6 @@ describe('cron listener', () => {
 
     it('should handle no connectors gracefully', async () => {
       // No connectors registered
-      listener.start()
-
       await eventLog.append('cron.fire', {
         jobId: 'abc12345',
         jobName: 'test-job',
@@ -193,7 +186,6 @@ describe('cron listener', () => {
   describe('error handling', () => {
     it('should write cron.error on engine failure', async () => {
       mockEngine.setShouldFail(true)
-      listener.start()
 
       await eventLog.append('cron.fire', {
         jobId: 'abc12345',
@@ -219,9 +211,8 @@ describe('cron listener', () => {
   // ==================== Lifecycle ====================
 
   describe('lifecycle', () => {
-    it('should stop receiving events after stop()', async () => {
-      listener.start()
-      listener.stop()
+    it('should stop receiving events after registry.stop()', async () => {
+      await registry.stop()
 
       await eventLog.append('cron.fire', {
         jobId: 'abc12345',
@@ -235,11 +226,8 @@ describe('cron listener', () => {
       expect(mockEngine.askWithSession).not.toHaveBeenCalled()
     })
 
-    it('should be idempotent (start twice, stop twice)', () => {
-      listener.start()
-      listener.start()
-      listener.stop()
-      listener.stop()
+    it('should be idempotent on repeated start()', async () => {
+      await cronListener.start()  // second call — should be a no-op
       // No error
     })
   })

--- a/src/task/cron/listener.ts
+++ b/src/task/cron/listener.ts
@@ -16,6 +16,9 @@ import type { CronFirePayload } from '../../core/agent-event.js'
 import type { AgentCenter } from '../../core/agent-center.js'
 import { SessionStore } from '../../core/session.js'
 import type { ConnectorCenter } from '../../core/connector-center.js'
+import type { Listener } from '../../core/listener.js'
+import type { ListenerRegistry } from '../../core/listener-registry.js'
+
 /** Internal jobs (prefixed with __) have dedicated handlers and should not be routed to the AI. */
 function isInternalJob(name: string): boolean {
   return name.startsWith('__') && name.endsWith('__')
@@ -25,93 +28,100 @@ function isInternalJob(name: string): boolean {
 
 export interface CronListenerOpts {
   connectorCenter: ConnectorCenter
-  eventLog: EventLog
   agentCenter: AgentCenter
+  /** Registry to auto-register this listener with. */
+  registry: ListenerRegistry
   /** Optional: inject a session for testing. Otherwise creates a dedicated cron session. */
   session?: SessionStore
 }
 
 export interface CronListener {
-  start(): void
+  /** Register the listener with the registry (idempotent). */
+  start(): Promise<void>
+  /** Unregister the listener from the registry. */
   stop(): void
+  /** Expose the raw Listener object (for testing `handle()` directly). */
+  readonly listener: Listener<'cron.fire'>
 }
 
 // ==================== Factory ====================
 
 export function createCronListener(opts: CronListenerOpts): CronListener {
-  const { connectorCenter, eventLog, agentCenter } = opts
+  const { connectorCenter, agentCenter, registry } = opts
   const session = opts.session ?? new SessionStore('cron/default')
 
-  let unsubscribe: (() => void) | null = null
   let processing = false
+  let registered = false
 
-  async function handleFire(entry: EventLogEntry<CronFirePayload>): Promise<void> {
-    const payload = entry.payload
+  const listener: Listener<'cron.fire'> = {
+    name: 'cron-router',
+    eventType: 'cron.fire',
+    async handle(entry: EventLogEntry<CronFirePayload>, eventLog: EventLog): Promise<void> {
+      const payload = entry.payload
 
-    // Guard: internal jobs (__heartbeat__, __snapshot__, etc.) have dedicated handlers
-    if (isInternalJob(payload.jobName)) return
+      // Guard: internal jobs (__heartbeat__, __snapshot__, etc.) have dedicated handlers
+      if (isInternalJob(payload.jobName)) return
 
-    // Guard: skip if already processing (serial execution)
-    if (processing) {
-      console.warn(`cron-listener: skipping job ${payload.jobId} (already processing)`)
-      return
-    }
-
-    processing = true
-    const startMs = Date.now()
-
-    try {
-      // Ask the AI engine with the cron payload
-      const result = await agentCenter.askWithSession(payload.payload, session, {
-        historyPreamble: `You are operating in the cron job context (session: cron/default, job: ${payload.jobName}). This is an automated cron job execution.`,
-      })
-
-      // Send notification through the last-interacted connector
-      try {
-        await connectorCenter.notify(result.text, {
-          media: result.media,
-          source: 'cron',
-        })
-      } catch (sendErr) {
-        console.warn(`cron-listener: send failed for job ${payload.jobId}:`, sendErr)
+      // Guard: skip if already processing (serial execution)
+      if (processing) {
+        console.warn(`cron-listener: skipping job ${payload.jobId} (already processing)`)
+        return
       }
 
-      // Log success
-      await eventLog.append('cron.done', {
-        jobId: payload.jobId,
-        jobName: payload.jobName,
-        reply: result.text,
-        durationMs: Date.now() - startMs,
-      })
-    } catch (err) {
-      console.error(`cron-listener: error processing job ${payload.jobId}:`, err)
+      processing = true
+      const startMs = Date.now()
 
-      // Log error
-      await eventLog.append('cron.error', {
-        jobId: payload.jobId,
-        jobName: payload.jobName,
-        error: err instanceof Error ? err.message : String(err),
-        durationMs: Date.now() - startMs,
-      })
-    } finally {
-      processing = false
-    }
+      try {
+        // Ask the AI engine with the cron payload
+        const result = await agentCenter.askWithSession(payload.payload, session, {
+          historyPreamble: `You are operating in the cron job context (session: cron/default, job: ${payload.jobName}). This is an automated cron job execution.`,
+        })
+
+        // Send notification through the last-interacted connector
+        try {
+          await connectorCenter.notify(result.text, {
+            media: result.media,
+            source: 'cron',
+          })
+        } catch (sendErr) {
+          console.warn(`cron-listener: send failed for job ${payload.jobId}:`, sendErr)
+        }
+
+        // Log success
+        await eventLog.append('cron.done', {
+          jobId: payload.jobId,
+          jobName: payload.jobName,
+          reply: result.text,
+          durationMs: Date.now() - startMs,
+        })
+      } catch (err) {
+        console.error(`cron-listener: error processing job ${payload.jobId}:`, err)
+
+        // Log error
+        await eventLog.append('cron.error', {
+          jobId: payload.jobId,
+          jobName: payload.jobName,
+          error: err instanceof Error ? err.message : String(err),
+          durationMs: Date.now() - startMs,
+        })
+      } finally {
+        processing = false
+      }
+    },
   }
 
   return {
-    start() {
-      if (unsubscribe) return // already started
-      unsubscribe = eventLog.subscribeType('cron.fire', (entry) => {
-        // Fire-and-forget — errors are caught inside handleFire
-        handleFire(entry).catch((err) => {
-          console.error('cron-listener: unhandled error in handleFire:', err)
-        })
-      })
+    listener,
+    async start() {
+      if (registered) return
+      registry.register(listener)
+      registered = true
     },
-
     stop() {
-      unsubscribe?.()
-      unsubscribe = null
+      if (registered) {
+        registry.unregister(listener.name)
+        registered = false
+      }
     },
   }
 }

--- a/src/task/heartbeat/heartbeat.spec.ts
+++ b/src/task/heartbeat/heartbeat.spec.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import { createEventLog, type EventLog } from '../../core/event-log.js'
+import { createListenerRegistry, type ListenerRegistry } from '../../core/listener-registry.js'
 import { createCronEngine, type CronEngine } from '../cron/engine.js'
 import {
   createHeartbeat,
@@ -54,6 +55,7 @@ function createMockEngine(response = CHAT_YES_RESPONSE) {
 
 describe('heartbeat', () => {
   let eventLog: EventLog
+  let listenerRegistry: ListenerRegistry
   let cronEngine: CronEngine
   let heartbeat: Heartbeat
   let mockEngine: ReturnType<typeof createMockEngine>
@@ -64,6 +66,8 @@ describe('heartbeat', () => {
     const logPath = tempPath('jsonl')
     const storePath = tempPath('json')
     eventLog = await createEventLog({ logPath })
+    listenerRegistry = createListenerRegistry(eventLog)
+    await listenerRegistry.start()  // Start registry so late registrations subscribe immediately
     cronEngine = createCronEngine({ eventLog, storePath })
     await cronEngine.start()
 
@@ -75,6 +79,7 @@ describe('heartbeat', () => {
   afterEach(async () => {
     heartbeat?.stop()
     cronEngine.stop()
+    await listenerRegistry.stop()
     await eventLog._resetForTest()
   })
 
@@ -84,7 +89,7 @@ describe('heartbeat', () => {
     it('should register a cron job on start', async () => {
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -100,7 +105,7 @@ describe('heartbeat', () => {
     it('should be idempotent (update existing job, not create duplicate)', async () => {
       heartbeat = createHeartbeat({
         config: makeConfig({ every: '30m' }),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -111,7 +116,7 @@ describe('heartbeat', () => {
       // Start again with different interval
       heartbeat = createHeartbeat({
         config: makeConfig({ every: '1h' }),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -126,7 +131,7 @@ describe('heartbeat', () => {
     it('should register disabled job when config.enabled is false', async () => {
       heartbeat = createHeartbeat({
         config: makeConfig({ enabled: false }),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -153,7 +158,7 @@ describe('heartbeat', () => {
 
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -182,7 +187,7 @@ describe('heartbeat', () => {
 
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -215,7 +220,7 @@ describe('heartbeat', () => {
 
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -235,7 +240,7 @@ describe('heartbeat', () => {
     it('should ignore non-heartbeat cron.fire events', async () => {
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -265,7 +270,7 @@ describe('heartbeat', () => {
         config: makeConfig({
           activeHours: { start: '09:00', end: '22:00', timezone: 'local' },
         }),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
         now: () => fakeNow,
@@ -298,7 +303,7 @@ describe('heartbeat', () => {
 
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -333,7 +338,7 @@ describe('heartbeat', () => {
 
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -359,7 +364,7 @@ describe('heartbeat', () => {
 
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -383,7 +388,7 @@ describe('heartbeat', () => {
     it('should stop listening after stop()', async () => {
       heartbeat = createHeartbeat({
         config: makeConfig(),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -403,7 +408,7 @@ describe('heartbeat', () => {
     it('should enable a previously disabled heartbeat', async () => {
       heartbeat = createHeartbeat({
         config: makeConfig({ enabled: false }),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -421,7 +426,7 @@ describe('heartbeat', () => {
     it('should disable an enabled heartbeat', async () => {
       heartbeat = createHeartbeat({
         config: makeConfig({ enabled: true }),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -440,7 +445,7 @@ describe('heartbeat', () => {
 
       heartbeat = createHeartbeat({
         config: makeConfig({ enabled: false }),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })
@@ -460,7 +465,7 @@ describe('heartbeat', () => {
 
       heartbeat = createHeartbeat({
         config: makeConfig({ enabled: false }),
-        connectorCenter, cronEngine, eventLog,
+        connectorCenter, cronEngine, registry: listenerRegistry,
         agentCenter: mockEngine as any,
         session,
       })

--- a/src/task/heartbeat/heartbeat.ts
+++ b/src/task/heartbeat/heartbeat.ts
@@ -22,6 +22,8 @@ import { SessionStore } from '../../core/session.js'
 import type { ConnectorCenter } from '../../core/connector-center.js'
 import { writeConfigSection } from '../../core/config.js'
 import type { CronEngine } from '../cron/engine.js'
+import type { Listener } from '../../core/listener.js'
+import type { ListenerRegistry } from '../../core/listener-registry.js'
 
 // ==================== Constants ====================
 
@@ -78,8 +80,9 @@ export interface HeartbeatOpts {
   config: HeartbeatConfig
   connectorCenter: ConnectorCenter
   cronEngine: CronEngine
-  eventLog: EventLog
   agentCenter: AgentCenter
+  /** Registry to auto-register the heartbeat listener with. */
+  registry: ListenerRegistry
   /** Optional: inject a session for testing. */
   session?: SessionStore
   /** Inject clock for testing. */
@@ -93,23 +96,25 @@ export interface Heartbeat {
   setEnabled(enabled: boolean): Promise<void>
   /** Current enabled state. */
   isEnabled(): boolean
+  /** Expose the raw listener for direct testing. */
+  readonly listener: Listener<'cron.fire'>
 }
 
 // ==================== Factory ====================
 
 export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
-  const { config, connectorCenter, cronEngine, eventLog, agentCenter } = opts
+  const { config, connectorCenter, cronEngine, agentCenter, registry } = opts
   const session = opts.session ?? new SessionStore('heartbeat')
   const now = opts.now ?? Date.now
 
-  let unsubscribe: (() => void) | null = null
   let jobId: string | null = null
   let processing = false
   let enabled = config.enabled
+  let registered = false
 
   const dedup = new HeartbeatDedup()
 
-  async function handleFire(entry: EventLogEntry<CronFirePayload>): Promise<void> {
+  async function handleFire(entry: EventLogEntry<CronFirePayload>, eventLog: EventLog): Promise<void> {
     const payload = entry.payload
 
     // Only handle our own job
@@ -196,7 +201,13 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
     }
   }
 
-  /** Ensure the cron job and event listener exist (idempotent). */
+  const listener: Listener<'cron.fire'> = {
+    name: 'heartbeat',
+    eventType: 'cron.fire',
+    handle: handleFire,
+  }
+
+  /** Ensure the cron job exists and listener is registered (idempotent). */
   async function ensureJobAndListener(): Promise<void> {
     // Idempotent: find existing heartbeat job or create one
     const existing = cronEngine.list().find((j) => j.name === HEARTBEAT_JOB_NAME)
@@ -216,26 +227,27 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
       })
     }
 
-    // Subscribe to cron.fire events if not already subscribed
-    if (!unsubscribe) {
-      unsubscribe = eventLog.subscribeType('cron.fire', (entry) => {
-        handleFire(entry).catch((err) => {
-          console.error('heartbeat: unhandled error:', err)
-        })
-      })
+    // Register listener exactly once
+    if (!registered) {
+      registry.register(listener)
+      registered = true
     }
   }
 
   return {
+    listener,
     async start() {
       // Always register job + listener (even if disabled) so setEnabled can toggle later
       await ensureJobAndListener()
     },
 
     stop() {
-      unsubscribe?.()
-      unsubscribe = null
-      // Don't delete the cron job — it persists for restart recovery
+      // Unregister the listener so a subsequent start() re-registers cleanly.
+      // Don't delete the cron job — it persists for restart recovery.
+      if (registered) {
+        registry.unregister(listener.name)
+        registered = false
+      }
     },
 
     async setEnabled(newEnabled: boolean) {

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -20,6 +20,15 @@ function getSchemaConst(schema: Preset['schema'], field: string): unknown {
   return props?.[field]?.const
 }
 
+function getModelOptions(profile: Profile, presets: Preset[]): Array<{ id: string; label: string }> {
+  const preset = presets.find(p => p.id === profile.preset)
+  if (!preset) return []
+  const props = preset.schema?.properties as Record<string, { oneOf?: Array<{ const: string; title: string }> }> | undefined
+  const oneOf = props?.model?.oneOf
+  if (!oneOf) return []
+  return oneOf.map(o => ({ id: o.const, label: o.title }))
+}
+
 // ==================== Main Page ====================
 
 export function AIProviderPage() {
@@ -60,6 +69,16 @@ export function AIProviderPage() {
     setProfiles((p) => p ? { ...p, [slug]: profile } : p)
   }
 
+  const handleInlineModelChange = async (slug: string, profile: Profile, newModel: string) => {
+    const updated = { ...profile, model: newModel }
+    setProfiles((p) => p ? { ...p, [slug]: updated } : p)
+    try {
+      await api.config.updateProfile(slug, updated)
+    } catch {
+      setProfiles((p) => p ? { ...p, [slug]: profile } : p)
+    }
+  }
+
   if (!profiles) return <div className="flex flex-col flex-1 min-h-0"><PageHeader title="AI Provider" description="Manage AI provider profiles." /><PageLoading /></div>
 
   return (
@@ -69,6 +88,8 @@ export function AIProviderPage() {
         <div className="max-w-[640px] mx-auto space-y-3">
           {Object.entries(profiles).map(([slug, profile]) => {
             const isActive = slug === activeProfile
+            const modelOptions = getModelOptions(profile, presets)
+            const canSwitchModel = modelOptions.length > 1 && modelOptions.some(o => o.id === profile.model)
             return (
               <div key={slug} className={`flex items-center gap-3 p-4 rounded-xl border transition-all ${isActive ? 'border-accent bg-accent-dim/20' : 'border-border bg-bg'}`}>
                 <div className="text-text-muted">{BACKEND_ICONS[profile.backend]}</div>
@@ -77,7 +98,21 @@ export function AIProviderPage() {
                     <span className="text-[13px] font-semibold text-text truncate">{slug}</span>
                     {isActive && <span className="text-[10px] px-1.5 py-0.5 rounded bg-accent/20 text-accent font-medium shrink-0">Active</span>}
                   </div>
-                  <p className="text-[11px] text-text-muted truncate">{profile.model || 'Auto (subscription plan)'}</p>
+                  {canSwitchModel ? (
+                    <div className="relative inline-flex items-center group -ml-1">
+                      <select
+                        value={profile.model}
+                        onChange={(e) => handleInlineModelChange(slug, profile, e.target.value)}
+                        className="appearance-none text-[11px] text-text-muted bg-transparent border-0 cursor-pointer hover:text-accent focus:text-accent focus:outline-none pl-1 pr-4 py-0.5 rounded hover:bg-bg-tertiary transition-colors"
+                        title="Change model"
+                      >
+                        {modelOptions.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+                      </select>
+                      <svg className="pointer-events-none absolute right-1 w-3 h-3 text-text-muted group-hover:text-accent transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9" /></svg>
+                    </div>
+                  ) : (
+                    <p className="text-[11px] text-text-muted truncate">{profile.model || 'Auto (subscription plan)'}</p>
+                  )}
                 </div>
                 <div className="flex items-center gap-1.5 shrink-0">
                   {!isActive && <button onClick={() => handleSetActive(slug)} className="text-[11px] px-2 py-1 rounded-md border border-border text-text-muted hover:text-accent hover:border-accent transition-colors">Set Default</button>}


### PR DESCRIPTION
Two commits ahead of master, pushed together.

## Claude default → Opus 4.7 + inline model switcher (`f64ca4e`)

- Default model across presets, profile schemas (agent-sdk, vercel-ai-sdk), legacy migration fallbacks, and the agent-sdk query fallback all move to `claude-opus-4-7`
- Added Opus 4.7 to Claude OAuth / Claude API model option lists (placed first)
- Expanded `claude-oauth` hint and added `claude-api` hint — both surface that the model is switchable in-UI and note the cost/quota trade-off, so users aren't surprised by Opus being the default
- Profile list card: replaced the static model text with a clickable `<select>` chip (chevron affordance) so users can switch models inline without entering the Edit modal. Display also now uses labels (`Claude Opus 4.7`) instead of raw ids (`claude-opus-4-7`)

## ListenerRegistry refactor (`65b9349`)

- New `Listener<K>` interface + `ListenerRegistry` centralizing subscription lifecycle
- Migrated `CronListener`, `Heartbeat`, `SnapshotScheduler`, and `ConnectorCenter` to the new pattern
- `main.ts` no longer calls `subscribeType` directly — each module registers its own listener via the registry

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`pnpm test\` — 1024 tests pass
- [ ] Manual: AI Provider page — model chip dropdown switches models on Claude Subscription without opening Edit modal
- [ ] Manual: creating a new Claude Subscription profile shows the updated hint with model-switching guidance
- [ ] Manual: heartbeat / cron / snapshot listeners still fire after ListenerRegistry migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)