### PR TITLE
feat: event-driven architecture + external triggers + Flow visualization

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
 
   ui:
     dependencies:
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       dompurify:
         specifier: ^3.3.1
         version: 3.3.3
@@ -1359,6 +1362,9 @@ packages:
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
 
@@ -1371,6 +1377,9 @@ packages:
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
 
@@ -1379,6 +1388,12 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1506,6 +1521,15 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -1647,6 +1671,9 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1712,6 +1739,14 @@ packages:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
@@ -1732,6 +1767,10 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
@@ -1746,6 +1785,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   data-urls@7.0.0:
@@ -3187,6 +3236,21 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
 snapshots:
 
   '@ai-sdk/anthropic@3.0.44(zod@4.3.6)':
@@ -4025,6 +4089,10 @@ snapshots:
 
   '@types/d3-color@3.1.3': {}
 
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
   '@types/d3-ease@3.0.2': {}
 
   '@types/d3-interpolate@3.0.4':
@@ -4037,6 +4105,8 @@ snapshots:
     dependencies:
       '@types/d3-time': 3.0.4
 
+  '@types/d3-selection@3.0.11': {}
+
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
@@ -4044,6 +4114,15 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
 
   '@types/deep-eql@4.0.2': {}
 
@@ -4211,6 +4290,29 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -4360,6 +4462,8 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  classcat@5.0.5: {}
+
   clsx@2.1.1: {}
 
   combined-stream@1.0.8:
@@ -4408,6 +4512,13 @@ snapshots:
 
   d3-color@3.1.0: {}
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
 
   d3-format@3.1.2: {}
@@ -4426,6 +4537,8 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
+  d3-selection@3.0.0: {}
+
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
@@ -4439,6 +4552,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@7.0.0:
     dependencies:
@@ -5897,3 +6027,11 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.4
+      react: 19.2.4

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -12,7 +12,7 @@ export interface SendPayload {
   /** Media attachments (e.g. screenshots from tools). */
   media?: MediaAttachment[]
   /** Where this payload originated from. */
-  source?: 'heartbeat' | 'cron' | 'manual'
+  source?: 'heartbeat' | 'cron' | 'trigger' | 'manual'
 }
 
 /** Result of a send() call. */

--- a/src/connectors/web/routes/events.ts
+++ b/src/connectors/web/routes/events.ts
@@ -1,10 +1,34 @@
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import type { EngineContext } from '../../../core/types.js'
+import type { TriggerPayload } from '../../../core/agent-event.js'
+import { validateEventPayload } from '../../../core/agent-event.js'
 
-/** Event log routes: GET /, GET /recent, GET /stream (SSE) */
+/** Event log routes: GET /, GET /recent, GET /stream (SSE), POST /ingest */
 export function createEventsRoutes(ctx: EngineContext) {
   const app = new Hono()
+
+  // Ingest external events — webhook / API producer surface.
+  // Note: no auth. Currently localhost-only; gate behind a reverse proxy or add
+  // a token check before exposing publicly.
+  app.post('/ingest', async (c) => {
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+
+    try {
+      validateEventPayload('trigger', body)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return c.json({ error: msg }, 400)
+    }
+
+    const entry = await ctx.eventLog.append('trigger', body as TriggerPayload)
+    return c.json(entry, 201)
+  })
 
   // Paginated query from disk (full history)
   app.get('/', async (c) => {

--- a/src/connectors/web/routes/topology.ts
+++ b/src/connectors/web/routes/topology.ts
@@ -1,0 +1,27 @@
+import { Hono } from 'hono'
+import type { EngineContext } from '../../../core/types.js'
+import { AgentEventSchemas } from '../../../core/agent-event.js'
+
+/**
+ * Topology routes: GET /
+ *
+ * Returns the static shape of the agent's event-driven nervous system:
+ * every known event type + every registered listener (with its subscribed
+ * event type and declared emits). The frontend uses this to render a DAG
+ * of Alice's async lifecycle.
+ */
+export function createTopologyRoutes(ctx: EngineContext) {
+  const app = new Hono()
+
+  app.get('/', (c) => {
+    const eventTypes = Object.keys(AgentEventSchemas)
+    const listeners = ctx.listenerRegistry.list().map((l) => ({
+      name: l.name,
+      eventType: l.eventType,
+      emits: [...l.emits],
+    }))
+    return c.json({ eventTypes, listeners })
+  })
+
+  return app
+}

--- a/src/connectors/web/web-plugin.ts
+++ b/src/connectors/web/web-plugin.ts
@@ -11,6 +11,7 @@ import { createChatRoutes, createMediaRoutes, type SSEClient } from './routes/ch
 import { createChannelsRoutes } from './routes/channels.js'
 import { createConfigRoutes, createMarketDataRoutes } from './routes/config.js'
 import { createEventsRoutes } from './routes/events.js'
+import { createTopologyRoutes } from './routes/topology.js'
 import { createCronRoutes } from './routes/cron.js'
 import { createHeartbeatRoutes } from './routes/heartbeat.js'
 import { createDiaryRoutes } from './routes/diary.js'
@@ -80,6 +81,7 @@ export class WebPlugin implements Plugin {
     }))
     app.route('/api/market-data', createMarketDataRoutes(ctx))
     app.route('/api/events', createEventsRoutes(ctx))
+    app.route('/api/topology', createTopologyRoutes(ctx))
     app.route('/api/cron', createCronRoutes(ctx))
     app.route('/api/heartbeat', createHeartbeatRoutes(ctx))
     app.route('/api/diary', createDiaryRoutes(ctx))

--- a/src/core/agent-event.spec.ts
+++ b/src/core/agent-event.spec.ts
@@ -9,7 +9,7 @@ describe('AgentEventSchemas', () => {
     'cron.fire', 'cron.done', 'cron.error',
     'heartbeat.done', 'heartbeat.skip', 'heartbeat.error',
     'message.received', 'message.sent',
-    'trigger',
+    'trigger', 'trigger.done', 'trigger.error',
   ]
 
   it('should have a schema for every key in AgentEventMap', () => {
@@ -130,6 +130,26 @@ describe('validateEventPayload', () => {
     expect(() => validateEventPayload('trigger', {
       name: 'test', data: {},
     })).toThrow(/Invalid payload.*trigger/)
+  })
+
+  // -- trigger.done --
+  it('should accept valid trigger.done payload', () => {
+    expect(() => validateEventPayload('trigger.done', {
+      source: 'webhook', name: 'ping', reply: 'ok', durationMs: 300,
+    })).not.toThrow()
+  })
+
+  it('should reject trigger.done with missing reply', () => {
+    expect(() => validateEventPayload('trigger.done', {
+      source: 'webhook', name: 'ping', durationMs: 300,
+    })).toThrow(/Invalid payload.*trigger\.done/)
+  })
+
+  // -- trigger.error --
+  it('should accept valid trigger.error payload', () => {
+    expect(() => validateEventPayload('trigger.error', {
+      source: 'webhook', name: 'ping', error: 'boom', durationMs: 50,
+    })).not.toThrow()
   })
 
   // -- unregistered types --

--- a/src/core/agent-event.ts
+++ b/src/core/agent-event.ts
@@ -71,6 +71,20 @@ export interface TriggerPayload {
   data: Record<string, unknown>
 }
 
+export interface TriggerDonePayload {
+  source: string
+  name: string
+  reply: string
+  durationMs: number
+}
+
+export interface TriggerErrorPayload {
+  source: string
+  name: string
+  error: string
+  durationMs: number
+}
+
 // ==================== Event Map ====================
 
 // Import the actual CronFirePayload type for use in the map
@@ -86,6 +100,8 @@ export interface AgentEventMap {
   'message.received': MessageReceivedPayload
   'message.sent': MessageSentPayload
   'trigger': TriggerPayload
+  'trigger.done': TriggerDonePayload
+  'trigger.error': TriggerErrorPayload
 }
 
 // ==================== TypeBox Schemas ====================
@@ -147,6 +163,20 @@ const TriggerSchema = Type.Object({
   data: Type.Record(Type.String(), Type.Unknown()),
 })
 
+const TriggerDoneSchema = Type.Object({
+  source: Type.String(),
+  name: Type.String(),
+  reply: Type.String(),
+  durationMs: Type.Number(),
+})
+
+const TriggerErrorSchema = Type.Object({
+  source: Type.String(),
+  name: Type.String(),
+  error: Type.String(),
+  durationMs: Type.Number(),
+})
+
 /** Schema registry — same keys as AgentEventMap. */
 export const AgentEventSchemas: { [K in keyof AgentEventMap]: TSchema } = {
   'cron.fire': CronFireSchema,
@@ -158,6 +188,8 @@ export const AgentEventSchemas: { [K in keyof AgentEventMap]: TSchema } = {
   'message.received': MessageReceivedSchema,
   'message.sent': MessageSentSchema,
   'trigger': TriggerSchema,
+  'trigger.done': TriggerDoneSchema,
+  'trigger.error': TriggerErrorSchema,
 }
 
 // ==================== Runtime Validation ====================

--- a/src/core/connector-center.ts
+++ b/src/core/connector-center.ts
@@ -25,7 +25,7 @@ export type { Connector, SendPayload, SendResult, ConnectorCapabilities } from '
 export interface NotifyOpts {
   kind?: 'message' | 'notification'
   media?: MediaAttachment[]
-  source?: 'heartbeat' | 'cron' | 'manual'
+  source?: 'heartbeat' | 'cron' | 'trigger' | 'manual'
 }
 
 /** Result of a notify() call. */

--- a/src/core/event-log.spec.ts
+++ b/src/core/event-log.spec.ts
@@ -436,6 +436,38 @@ describe('event-log', () => {
     })
   })
 
+  // ==================== causedBy ====================
+
+  describe('causedBy', () => {
+    it('should persist causedBy when provided via opts', async () => {
+      const entry = await log.append('a', { x: 1 }, { causedBy: 42 })
+      expect(entry.causedBy).toBe(42)
+    })
+
+    it('should omit causedBy when not provided', async () => {
+      const entry = await log.append('a', { x: 1 })
+      expect(entry.causedBy).toBeUndefined()
+      // Should not serialize as 'causedBy: undefined' either
+      expect('causedBy' in entry).toBe(false)
+    })
+
+    it('should survive disk round-trip', async () => {
+      const logPath = tempLogPath()
+      const log1 = await createEventLog({ logPath })
+      await log1.append('parent', {})
+      await log1.append('child', { note: 'caused by 1' }, { causedBy: 1 })
+      await log1.close()
+
+      const log2 = await createEventLog({ logPath })
+      const all = await log2.read()
+      expect(all).toHaveLength(2)
+      expect(all[0].causedBy).toBeUndefined()
+      expect(all[1].causedBy).toBe(1)
+
+      await log2._resetForTest()
+    })
+  })
+
   // ==================== _resetForTest ====================
 
   describe('_resetForTest', () => {

--- a/src/core/event-log.ts
+++ b/src/core/event-log.ts
@@ -26,6 +26,14 @@ export interface EventLogEntry<T = unknown> {
   type: string
   /** Arbitrary JSON-serializable payload. */
   payload: T
+  /** Parent event's seq — present if this event was emitted in response to another. */
+  causedBy?: number
+}
+
+/** Options accepted by EventLog.append(). */
+export interface AppendOpts {
+  /** Parent event's seq. Set by listeners to link a child event back to what triggered it. */
+  causedBy?: number
 }
 
 export type EventLogListener = (entry: EventLogEntry) => void
@@ -40,9 +48,9 @@ export interface EventLogQueryResult {
 
 export interface EventLog {
   /** Append a typed event (registered in AgentEventMap). Validates payload at runtime. */
-  append<K extends keyof AgentEventMap>(type: K, payload: AgentEventMap[K]): Promise<EventLogEntry<AgentEventMap[K]>>
+  append<K extends keyof AgentEventMap>(type: K, payload: AgentEventMap[K], opts?: AppendOpts): Promise<EventLogEntry<AgentEventMap[K]>>
   /** Append an unregistered event (no runtime validation). */
-  append<T>(type: string, payload: T): Promise<EventLogEntry<T>>
+  append<T>(type: string, payload: T, opts?: AppendOpts): Promise<EventLogEntry<T>>
 
   /**
    * Read events from the DISK log file.
@@ -123,7 +131,7 @@ export async function createEventLog(opts?: {
 
   // ---------- append ----------
 
-  async function append<T>(type: string, payload: T): Promise<EventLogEntry<T>> {
+  async function append<T>(type: string, payload: T, opts?: AppendOpts): Promise<EventLogEntry<T>> {
     validateEventPayload(type, payload)
     seq += 1
     const entry: EventLogEntry<T> = {
@@ -131,6 +139,9 @@ export async function createEventLog(opts?: {
       ts: Date.now(),
       type,
       payload,
+    }
+    if (opts?.causedBy !== undefined) {
+      entry.causedBy = opts.causedBy
     }
 
     // Dual write: disk first, then memory

--- a/src/core/listener-registry.spec.ts
+++ b/src/core/listener-registry.spec.ts
@@ -43,7 +43,7 @@ describe('ListenerRegistry', () => {
 
       const infos = registry.list()
       expect(infos).toHaveLength(1)
-      expect(infos[0]).toEqual({ name: 'test', eventType: 'cron.fire' })
+      expect(infos[0]).toEqual({ name: 'test', eventType: 'cron.fire', emits: [] })
     })
 
     it('should throw on duplicate name', () => {
@@ -192,6 +192,141 @@ describe('ListenerRegistry', () => {
       await flush()
 
       expect(received).toEqual(['j2'])
+    })
+  })
+
+  // ==================== ctx.emit ====================
+
+  describe('ctx.emit', () => {
+    it('should allow emitting declared types and auto-set causedBy', async () => {
+      registry.register({
+        name: 'cron-echo',
+        eventType: 'cron.fire',
+        emits: ['cron.done'] as const,
+        async handle(entry, ctx) {
+          await ctx.emit('cron.done', {
+            jobId: entry.payload.jobId,
+            jobName: entry.payload.jobName,
+            reply: 'ok',
+            durationMs: 10,
+          })
+        },
+      })
+      await registry.start()
+
+      const parent = await eventLog.append('cron.fire', {
+        jobId: 'j1', jobName: 'x', payload: 'p',
+      })
+      await flush()
+
+      const done = eventLog.recent({ type: 'cron.done' })
+      expect(done).toHaveLength(1)
+      expect(done[0].causedBy).toBe(parent.seq)
+      expect(done[0].payload).toMatchObject({ jobId: 'j1', reply: 'ok' })
+    })
+
+    it('should reject emit of un-declared event type at runtime', async () => {
+      const errors: unknown[] = []
+      const origErr = console.error
+      console.error = (...a: unknown[]) => { errors.push(a) }
+      try {
+        registry.register({
+          name: 'naughty',
+          eventType: 'cron.fire',
+          emits: ['cron.done'] as const,
+          async handle(_entry, ctx) {
+            // Cast past the type system to simulate a misuse
+            await (ctx.emit as unknown as (t: string, p: unknown) => Promise<unknown>)(
+              'heartbeat.done',
+              { reply: 'x', reason: '', durationMs: 0, delivered: false },
+            )
+          },
+        })
+        await registry.start()
+
+        await eventLog.append('cron.fire', { jobId: 'j1', jobName: 'x', payload: 'p' })
+        await flush()
+
+        // Error was caught by registry's error isolation and logged
+        expect(errors.length).toBeGreaterThan(0)
+        const msg = String((errors[0] as unknown[])[1])
+        expect(msg).toMatch(/naughty.*heartbeat\.done.*declared emits.*cron\.done/)
+      } finally {
+        console.error = origErr
+      }
+    })
+
+    it('should reject all emit calls when listener has no emits declared', async () => {
+      const errors: unknown[] = []
+      const origErr = console.error
+      console.error = (...a: unknown[]) => { errors.push(a) }
+      try {
+        registry.register({
+          name: 'silent',
+          eventType: 'cron.fire',
+          async handle(_entry, ctx) {
+            await (ctx.emit as unknown as (t: string, p: unknown) => Promise<unknown>)(
+              'cron.done',
+              { jobId: '', jobName: '', reply: '', durationMs: 0 },
+            )
+          },
+        })
+        await registry.start()
+
+        await eventLog.append('cron.fire', { jobId: 'j1', jobName: 'x', payload: 'p' })
+        await flush()
+
+        expect(errors.length).toBeGreaterThan(0)
+        const msg = String((errors[0] as unknown[])[1])
+        expect(msg).toMatch(/silent.*declared emits: \(none\)/)
+      } finally {
+        console.error = origErr
+      }
+    })
+
+    it('should allow overriding causedBy explicitly via opts', async () => {
+      registry.register({
+        name: 'cron-override',
+        eventType: 'cron.fire',
+        emits: ['cron.done'] as const,
+        async handle(_entry, ctx) {
+          await ctx.emit(
+            'cron.done',
+            { jobId: 'j1', jobName: 'x', reply: 'ok', durationMs: 0 },
+            { causedBy: 999 },
+          )
+        },
+      })
+      await registry.start()
+
+      await eventLog.append('cron.fire', { jobId: 'j1', jobName: 'x', payload: 'p' })
+      await flush()
+
+      const [done] = eventLog.recent({ type: 'cron.done' })
+      expect(done.causedBy).toBe(999)
+    })
+  })
+
+  // ==================== ctx.events ====================
+
+  describe('ctx.events', () => {
+    it('should expose read-only event log access', async () => {
+      await eventLog.append('cron.fire', { jobId: 'older', jobName: 'x', payload: 'p' })
+
+      let recentSeen: number | undefined
+      registry.register({
+        name: 'snoop',
+        eventType: 'cron.fire',
+        async handle(_entry, ctx) {
+          recentSeen = ctx.events.recent({ type: 'cron.fire' }).length
+        },
+      })
+      await registry.start()
+
+      await eventLog.append('cron.fire', { jobId: 'newer', jobName: 'x', payload: 'p' })
+      await flush()
+
+      expect(recentSeen).toBe(2)
     })
   })
 })

--- a/src/core/listener-registry.ts
+++ b/src/core/listener-registry.ts
@@ -6,56 +6,97 @@
  * all registered listeners together via `start()` and tears them down
  * via `stop()`.
  *
+ * On subscription, the registry wraps the EventLog into a `ListenerContext`
+ * whose `emit()` is constrained to the listener's declared `emits`. This
+ * both enforces the declaration at runtime and auto-populates `causedBy`
+ * with the currently-handled event's seq.
+ *
  * Errors thrown inside a listener's `handle()` are caught and logged —
  * they do not affect other listeners.
  */
 
 import type { AgentEventMap } from './agent-event.js'
-import type { EventLog } from './event-log.js'
-import type { Listener } from './listener.js'
+import type { AppendOpts, EventLog, EventLogEntry } from './event-log.js'
+import type { Listener, ListenerContext } from './listener.js'
 
 export interface ListenerInfo {
   name: string
   eventType: string
+  emits: ReadonlyArray<string>
 }
 
 export interface ListenerRegistry {
   /** Register a listener. Throws if the name is already taken. */
-  register<K extends keyof AgentEventMap>(listener: Listener<K>): void
+  register<K extends keyof AgentEventMap, E extends readonly (keyof AgentEventMap)[]>(
+    listener: Listener<K, E>,
+  ): void
   /** Unregister a listener by name. Unsubscribes it if the registry is started. No-op if not found. */
   unregister(name: string): void
   /** Activate all registered listeners (subscribe to EventLog). */
   start(): Promise<void>
   /** Deactivate all listeners (unsubscribe). */
   stop(): Promise<void>
-  /** Introspection — registered listener names and their event types. */
+  /** Introspection — registered listener names, event types, emits. */
   list(): ReadonlyArray<ListenerInfo>
 }
 
 export function createListenerRegistry(eventLog: EventLog): ListenerRegistry {
   // Storage is necessarily wide-typed (union across all event types).
-  // Per-call type precision is preserved via the generic `register<K>` signature.
-  type AnyListener = Listener<keyof AgentEventMap>
+  // Per-call type precision is preserved via the generic `register<K, E>` signature.
+  type AnyListener = Listener<keyof AgentEventMap, readonly (keyof AgentEventMap)[]>
   const listeners = new Map<string, AnyListener>()
   const unsubscribes = new Map<string, () => void>()
   let started = false
 
-  function register<K extends keyof AgentEventMap>(listener: Listener<K>): void {
+  function register<K extends keyof AgentEventMap, E extends readonly (keyof AgentEventMap)[]>(
+    listener: Listener<K, E>,
+  ): void {
     if (listeners.has(listener.name)) {
       throw new Error(`ListenerRegistry: listener "${listener.name}" already registered`)
     }
-    listeners.set(listener.name, listener as AnyListener)
+    listeners.set(listener.name, listener as unknown as AnyListener)
     // If registry is already running, subscribe immediately
     if (started) {
-      subscribeOne(listener as AnyListener)
+      subscribeOne(listener as unknown as AnyListener)
+    }
+  }
+
+  function buildContext(
+    listener: AnyListener,
+    parentEntry: EventLogEntry,
+  ): ListenerContext<readonly (keyof AgentEventMap)[]> {
+    const declared = new Set<string>(listener.emits ?? [])
+
+    return {
+      async emit(type, payload, opts?: AppendOpts) {
+        if (!declared.has(type as string)) {
+          const declaredList = [...declared].join(', ') || '(none)'
+          throw new Error(
+            `Listener '${listener.name}' tried to emit '${type as string}' but declared emits: ${declaredList}`,
+          )
+        }
+        // Auto-set causedBy unless caller explicitly provided one
+        const mergedOpts: AppendOpts = {
+          ...opts,
+          causedBy: opts?.causedBy ?? parentEntry.seq,
+        }
+        return eventLog.append(type as keyof AgentEventMap, payload as never, mergedOpts) as never
+      },
+      events: {
+        read: eventLog.read,
+        recent: eventLog.recent,
+        query: eventLog.query,
+        lastSeq: eventLog.lastSeq,
+      },
     }
   }
 
   function subscribeOne(listener: AnyListener): void {
     const unsub = eventLog.subscribeType(listener.eventType, (entry) => {
+      const ctx = buildContext(listener, entry)
       // Fire-and-forget with error isolation
       Promise.resolve()
-        .then(() => listener.handle(entry, eventLog))
+        .then(() => listener.handle(entry, ctx))
         .catch((err) => {
           console.error(`listener[${listener.name}]: unhandled error:`, err)
         })
@@ -95,6 +136,7 @@ export function createListenerRegistry(eventLog: EventLog): ListenerRegistry {
     return Array.from(listeners.values()).map((l) => ({
       name: l.name,
       eventType: l.eventType,
+      emits: [...(l.emits ?? [])],
     }))
   }
 

--- a/src/core/listener.ts
+++ b/src/core/listener.ts
@@ -4,16 +4,54 @@
  * A Listener represents a single handler for one event type. Filtering,
  * serial locks, and internal state are the listener's own responsibility —
  * the registry only manages subscription lifecycle and error isolation.
+ *
+ * Listeners declare what event types they emit via the `emits` field. The
+ * Registry passes a `ListenerContext` into `handle()` whose `emit()` method
+ * is constrained (compile + runtime) to the declared set. This keeps emit
+ * declarations load-bearing — if a listener tries to emit an undeclared
+ * type, it fails.
  */
 
 import type { AgentEventMap } from './agent-event.js'
-import type { EventLog, EventLogEntry } from './event-log.js'
+import type { AppendOpts, EventLog, EventLogEntry } from './event-log.js'
 
-export interface Listener<K extends keyof AgentEventMap = keyof AgentEventMap> {
+/** Handle-time context passed to a listener. Wraps the EventLog with
+ *  a constrained emitter and read-only history access. */
+export interface ListenerContext<
+  Emits extends readonly (keyof AgentEventMap)[] = readonly (keyof AgentEventMap)[],
+> {
+  /**
+   * Emit a child event. The `type` must be in this listener's declared `emits`.
+   * `causedBy` defaults to the currently-handled event's seq (override via opts).
+   */
+  emit<E extends Emits[number]>(
+    type: E,
+    payload: AgentEventMap[E],
+    opts?: AppendOpts,
+  ): Promise<EventLogEntry<AgentEventMap[E]>>
+
+  /** Read-only access to the event log (history queries). */
+  readonly events: {
+    read: EventLog['read']
+    recent: EventLog['recent']
+    query: EventLog['query']
+    lastSeq: EventLog['lastSeq']
+  }
+}
+
+export interface Listener<
+  K extends keyof AgentEventMap = keyof AgentEventMap,
+  Emits extends readonly (keyof AgentEventMap)[] = readonly (keyof AgentEventMap)[],
+> {
   /** Unique name for identification (registry key, future UI display). */
   name: string
   /** Event type this listener subscribes to. */
   eventType: K
-  /** Called when a matching event is appended. Receives the entry + full EventLog for history queries. */
-  handle(entry: EventLogEntry<AgentEventMap[K]>, eventLog: EventLog): Promise<void>
+  /** Event types this listener may emit. Omitted = emits nothing. */
+  emits?: Emits
+  /** Called when a matching event is appended. */
+  handle(
+    entry: EventLogEntry<AgentEventMap[K]>,
+    ctx: ListenerContext<Emits>,
+  ): Promise<void>
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,6 +11,7 @@ import type { AgentCenter } from './agent-center.js'
 import type { EventLog } from './event-log.js'
 import type { ToolCallLog } from './tool-call-log.js'
 import type { ToolCenter } from './tool-center.js'
+import type { ListenerRegistry } from './listener-registry.js'
 
 export type { Config, WebChannel }
 
@@ -35,6 +36,7 @@ export interface EngineContext {
   heartbeat: Heartbeat
   cronEngine: CronEngine
   toolCenter: ToolCenter
+  listenerRegistry: ListenerRegistry
 
   // Market data
   bbEngine: QueryExecutor

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,7 @@ import { createToolCallLog } from './core/tool-call-log.js'
 import { createListenerRegistry } from './core/listener-registry.js'
 import { createCronEngine, createCronListener, createCronTools } from './task/cron/index.js'
 import { createHeartbeat } from './task/heartbeat/index.js'
+import { createTriggerListener } from './task/trigger/index.js'
 import { NewsCollectorStore, NewsCollector } from './domain/news/index.js'
 import { createNewsArchiveTools } from './tool/news.js'
 
@@ -284,6 +285,15 @@ async function main() {
     console.log(`heartbeat: enabled (every ${config.heartbeat.every})`)
   }
 
+  // ==================== Trigger Listener (external event router) ====================
+
+  const triggerSession = new SessionStore('trigger/default')
+  await triggerSession.restore()
+  const triggerListener = createTriggerListener({
+    connectorCenter, agentCenter, registry: listenerRegistry, session: triggerSession,
+  })
+  await triggerListener.start()
+
   // ==================== Activate Listeners + Start Cron Engine ====================
 
   await listenerRegistry.start()
@@ -440,6 +450,7 @@ async function main() {
     newsCollector?.stop()
     snapshotScheduler.stop()
     heartbeat.stop()
+    triggerListener.stop()
     cronListener.stop()
     cronEngine.stop()
     await listenerRegistry.stop()

--- a/src/main.ts
+++ b/src/main.ts
@@ -429,6 +429,7 @@ async function main() {
 
   const ctx: EngineContext = {
     config, connectorCenter, agentCenter, eventLog, toolCallLog, heartbeat, cronEngine, toolCenter,
+    listenerRegistry,
     bbEngine: getSDKExecutor(),
     accountManager, fxService, snapshotService,
     newsProvider: newsStore,

--- a/src/task/cron/engine.ts
+++ b/src/task/cron/engine.ts
@@ -112,7 +112,9 @@ export function createCronEngine(opts: CronEngineOpts): CronEngine {
 
   async function save(): Promise<void> {
     await mkdir(dirname(storePath), { recursive: true })
-    const tmp = `${storePath}.${process.pid}.tmp`
+    // Unique tmp filename per call — prevents rename races when save() is
+    // called concurrently (e.g. onTick save vs UI-triggered add/update).
+    const tmp = `${storePath}.${process.pid}.${randomUUID().slice(0, 8)}.tmp`
     await writeFile(tmp, JSON.stringify({ jobs }, null, 2), 'utf-8')
     await rename(tmp, storePath)
   }

--- a/src/task/cron/listener.spec.ts
+++ b/src/task/cron/listener.spec.ts
@@ -89,7 +89,7 @@ describe('cron listener', () => {
     })
 
     it('should write cron.done event on success', async () => {
-      await eventLog.append('cron.fire', {
+      const fireEntry = await eventLog.append('cron.fire', {
         jobId: 'abc12345',
         jobName: 'test-job',
         payload: 'Do something',
@@ -107,6 +107,7 @@ describe('cron listener', () => {
         reply: 'AI reply',
       })
       expect((done[0].payload as any).durationMs).toBeGreaterThanOrEqual(0)
+      expect(done[0].causedBy).toBe(fireEntry.seq)
     })
 
     it('should not react to other event types', async () => {
@@ -187,7 +188,7 @@ describe('cron listener', () => {
     it('should write cron.error on engine failure', async () => {
       mockEngine.setShouldFail(true)
 
-      await eventLog.append('cron.fire', {
+      const fireEntry = await eventLog.append('cron.fire', {
         jobId: 'abc12345',
         jobName: 'test-job',
         payload: 'Will fail',
@@ -205,6 +206,7 @@ describe('cron listener', () => {
         error: 'engine error',
       })
       expect((errors[0].payload as any).durationMs).toBeGreaterThanOrEqual(0)
+      expect(errors[0].causedBy).toBe(fireEntry.seq)
     })
   })
 

--- a/src/task/cron/listener.ts
+++ b/src/task/cron/listener.ts
@@ -93,7 +93,7 @@ export function createCronListener(opts: CronListenerOpts): CronListener {
           jobName: payload.jobName,
           reply: result.text,
           durationMs: Date.now() - startMs,
-        })
+        }, { causedBy: entry.seq })
       } catch (err) {
         console.error(`cron-listener: error processing job ${payload.jobId}:`, err)
 
@@ -103,7 +103,7 @@ export function createCronListener(opts: CronListenerOpts): CronListener {
           jobName: payload.jobName,
           error: err instanceof Error ? err.message : String(err),
           durationMs: Date.now() - startMs,
-        })
+        }, { causedBy: entry.seq })
       } finally {
         processing = false
       }

--- a/src/task/cron/listener.ts
+++ b/src/task/cron/listener.ts
@@ -5,18 +5,18 @@
  * Flow:
  *   eventLog 'cron.fire' → agentCenter.askWithSession(payload, session)
  *                         → connectorCenter.notify(reply)
- *                         → eventLog 'cron.done' / 'cron.error'
+ *                         → ctx.emit 'cron.done' / 'cron.error'
  *
  * The listener owns a dedicated SessionStore for cron conversations,
  * independent of user chat sessions (Telegram, Web, etc.).
  */
 
-import type { EventLog, EventLogEntry } from '../../core/event-log.js'
+import type { EventLogEntry } from '../../core/event-log.js'
 import type { CronFirePayload } from '../../core/agent-event.js'
 import type { AgentCenter } from '../../core/agent-center.js'
 import { SessionStore } from '../../core/session.js'
 import type { ConnectorCenter } from '../../core/connector-center.js'
-import type { Listener } from '../../core/listener.js'
+import type { Listener, ListenerContext } from '../../core/listener.js'
 import type { ListenerRegistry } from '../../core/listener-registry.js'
 
 /** Internal jobs (prefixed with __) have dedicated handlers and should not be routed to the AI. */
@@ -25,6 +25,9 @@ function isInternalJob(name: string): boolean {
 }
 
 // ==================== Types ====================
+
+const CRON_EMITS = ['cron.done', 'cron.error'] as const
+type CronEmits = typeof CRON_EMITS
 
 export interface CronListenerOpts {
   connectorCenter: ConnectorCenter
@@ -41,7 +44,7 @@ export interface CronListener {
   /** Unregister the listener from the registry. */
   stop(): void
   /** Expose the raw Listener object (for testing `handle()` directly). */
-  readonly listener: Listener<'cron.fire'>
+  readonly listener: Listener<'cron.fire', CronEmits>
 }
 
 // ==================== Factory ====================
@@ -53,10 +56,14 @@ export function createCronListener(opts: CronListenerOpts): CronListener {
   let processing = false
   let registered = false
 
-  const listener: Listener<'cron.fire'> = {
+  const listener: Listener<'cron.fire', CronEmits> = {
     name: 'cron-router',
     eventType: 'cron.fire',
-    async handle(entry: EventLogEntry<CronFirePayload>, eventLog: EventLog): Promise<void> {
+    emits: CRON_EMITS,
+    async handle(
+      entry: EventLogEntry<CronFirePayload>,
+      ctx: ListenerContext<CronEmits>,
+    ): Promise<void> {
       const payload = entry.payload
 
       // Guard: internal jobs (__heartbeat__, __snapshot__, etc.) have dedicated handlers
@@ -88,22 +95,21 @@ export function createCronListener(opts: CronListenerOpts): CronListener {
         }
 
         // Log success
-        await eventLog.append('cron.done', {
+        await ctx.emit('cron.done', {
           jobId: payload.jobId,
           jobName: payload.jobName,
           reply: result.text,
           durationMs: Date.now() - startMs,
-        }, { causedBy: entry.seq })
+        })
       } catch (err) {
         console.error(`cron-listener: error processing job ${payload.jobId}:`, err)
 
-        // Log error
-        await eventLog.append('cron.error', {
+        await ctx.emit('cron.error', {
           jobId: payload.jobId,
           jobName: payload.jobName,
           error: err instanceof Error ? err.message : String(err),
           durationMs: Date.now() - startMs,
-        }, { causedBy: entry.seq })
+        })
       } finally {
         processing = false
       }

--- a/src/task/heartbeat/heartbeat.ts
+++ b/src/task/heartbeat/heartbeat.ts
@@ -131,7 +131,7 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
       // 1. Active hours guard
       if (!isWithinActiveHours(config.activeHours, now())) {
         console.log('heartbeat: skipped (outside active hours)')
-        await eventLog.append('heartbeat.skip', { reason: 'outside-active-hours' })
+        await eventLog.append('heartbeat.skip', { reason: 'outside-active-hours' }, { causedBy: entry.seq })
         return
       }
 
@@ -149,7 +149,7 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
         await eventLog.append('heartbeat.skip', {
           reason: 'ack',
           parsedReason: parsed.reason,
-        })
+        }, { causedBy: entry.seq })
         return
       }
 
@@ -157,14 +157,14 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
       const text = parsed.content || result.text
       if (!text.trim()) {
         console.log(`heartbeat: skipped (empty content) (${durationMs}ms)`)
-        await eventLog.append('heartbeat.skip', { reason: 'empty' })
+        await eventLog.append('heartbeat.skip', { reason: 'empty' }, { causedBy: entry.seq })
         return
       }
 
       // 4. Dedup
       if (dedup.isDuplicate(text, now())) {
         console.log(`heartbeat: skipped (duplicate) (${durationMs}ms)`)
-        await eventLog.append('heartbeat.skip', { reason: 'duplicate' })
+        await eventLog.append('heartbeat.skip', { reason: 'duplicate' }, { causedBy: entry.seq })
         return
       }
 
@@ -189,13 +189,13 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
         reason: parsed.reason,
         durationMs,
         delivered,
-      })
+      }, { causedBy: entry.seq })
     } catch (err) {
       console.error('heartbeat: error:', err)
       await eventLog.append('heartbeat.error', {
         error: err instanceof Error ? err.message : String(err),
         durationMs: now() - startMs,
-      })
+      }, { causedBy: entry.seq })
     } finally {
       processing = false
     }

--- a/src/task/heartbeat/heartbeat.ts
+++ b/src/task/heartbeat/heartbeat.ts
@@ -15,15 +15,18 @@
  *   - heartbeat.error { error, durationMs }
  */
 
-import type { EventLog, EventLogEntry } from '../../core/event-log.js'
+import type { EventLogEntry } from '../../core/event-log.js'
 import type { CronFirePayload } from '../../core/agent-event.js'
 import type { AgentCenter } from '../../core/agent-center.js'
 import { SessionStore } from '../../core/session.js'
 import type { ConnectorCenter } from '../../core/connector-center.js'
 import { writeConfigSection } from '../../core/config.js'
 import type { CronEngine } from '../cron/engine.js'
-import type { Listener } from '../../core/listener.js'
+import type { Listener, ListenerContext } from '../../core/listener.js'
 import type { ListenerRegistry } from '../../core/listener-registry.js'
+
+const HEARTBEAT_EMITS = ['heartbeat.done', 'heartbeat.skip', 'heartbeat.error'] as const
+type HeartbeatEmits = typeof HEARTBEAT_EMITS
 
 // ==================== Constants ====================
 
@@ -97,7 +100,7 @@ export interface Heartbeat {
   /** Current enabled state. */
   isEnabled(): boolean
   /** Expose the raw listener for direct testing. */
-  readonly listener: Listener<'cron.fire'>
+  readonly listener: Listener<'cron.fire', HeartbeatEmits>
 }
 
 // ==================== Factory ====================
@@ -114,7 +117,10 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
 
   const dedup = new HeartbeatDedup()
 
-  async function handleFire(entry: EventLogEntry<CronFirePayload>, eventLog: EventLog): Promise<void> {
+  async function handleFire(
+    entry: EventLogEntry<CronFirePayload>,
+    ctx: ListenerContext<HeartbeatEmits>,
+  ): Promise<void> {
     const payload = entry.payload
 
     // Only handle our own job
@@ -131,7 +137,7 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
       // 1. Active hours guard
       if (!isWithinActiveHours(config.activeHours, now())) {
         console.log('heartbeat: skipped (outside active hours)')
-        await eventLog.append('heartbeat.skip', { reason: 'outside-active-hours' }, { causedBy: entry.seq })
+        await ctx.emit('heartbeat.skip', { reason: 'outside-active-hours' })
         return
       }
 
@@ -146,10 +152,10 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
 
       if (parsed.status === 'HEARTBEAT_OK') {
         console.log(`heartbeat: HEARTBEAT_OK — ${parsed.reason || 'no reason'} (${durationMs}ms)`)
-        await eventLog.append('heartbeat.skip', {
+        await ctx.emit('heartbeat.skip', {
           reason: 'ack',
           parsedReason: parsed.reason,
-        }, { causedBy: entry.seq })
+        })
         return
       }
 
@@ -157,14 +163,14 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
       const text = parsed.content || result.text
       if (!text.trim()) {
         console.log(`heartbeat: skipped (empty content) (${durationMs}ms)`)
-        await eventLog.append('heartbeat.skip', { reason: 'empty' }, { causedBy: entry.seq })
+        await ctx.emit('heartbeat.skip', { reason: 'empty' })
         return
       }
 
       // 4. Dedup
       if (dedup.isDuplicate(text, now())) {
         console.log(`heartbeat: skipped (duplicate) (${durationMs}ms)`)
-        await eventLog.append('heartbeat.skip', { reason: 'duplicate' }, { causedBy: entry.seq })
+        await ctx.emit('heartbeat.skip', { reason: 'duplicate' })
         return
       }
 
@@ -184,26 +190,27 @@ export function createHeartbeat(opts: HeartbeatOpts): Heartbeat {
       console.log(`heartbeat: CHAT_YES — delivered=${delivered} (${durationMs}ms)`)
 
       // 6. Done event
-      await eventLog.append('heartbeat.done', {
+      await ctx.emit('heartbeat.done', {
         reply: text,
         reason: parsed.reason,
         durationMs,
         delivered,
-      }, { causedBy: entry.seq })
+      })
     } catch (err) {
       console.error('heartbeat: error:', err)
-      await eventLog.append('heartbeat.error', {
+      await ctx.emit('heartbeat.error', {
         error: err instanceof Error ? err.message : String(err),
         durationMs: now() - startMs,
-      }, { causedBy: entry.seq })
+      })
     } finally {
       processing = false
     }
   }
 
-  const listener: Listener<'cron.fire'> = {
+  const listener: Listener<'cron.fire', HeartbeatEmits> = {
     name: 'heartbeat',
     eventType: 'cron.fire',
+    emits: HEARTBEAT_EMITS,
     handle: handleFire,
   }
 

--- a/src/task/trigger/index.ts
+++ b/src/task/trigger/index.ts
@@ -1,0 +1,1 @@
+export { createTriggerListener, type TriggerListener, type TriggerListenerOpts } from './listener.js'

--- a/src/task/trigger/listener.spec.ts
+++ b/src/task/trigger/listener.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+import { createEventLog, type EventLog } from '../../core/event-log.js'
+import { createListenerRegistry, type ListenerRegistry } from '../../core/listener-registry.js'
+import { createTriggerListener, type TriggerListener } from './listener.js'
+import { SessionStore } from '../../core/session.js'
+import type { TriggerPayload } from '../../core/agent-event.js'
+import { ConnectorCenter } from '../../core/connector-center.js'
+
+function tempPath(ext: string): string {
+  return join(tmpdir(), `trigger-listener-test-${randomUUID()}.${ext}`)
+}
+
+// ==================== Mock Engine ====================
+
+function createMockEngine(response = 'AI reply') {
+  const calls: Array<{ prompt: string; session: SessionStore }> = []
+  let shouldFail = false
+
+  return {
+    calls,
+    setResponse(text: string) { response = text },
+    setShouldFail(val: boolean) { shouldFail = val },
+    askWithSession: vi.fn(async (prompt: string, session: SessionStore) => {
+      calls.push({ prompt, session })
+      if (shouldFail) throw new Error('engine error')
+      return { text: response, media: [] }
+    }),
+    ask: vi.fn(),
+  }
+}
+
+describe('trigger listener', () => {
+  let eventLog: EventLog
+  let registry: ListenerRegistry
+  let triggerListener: TriggerListener
+  let mockEngine: ReturnType<typeof createMockEngine>
+  let session: SessionStore
+  let connectorCenter: ConnectorCenter
+
+  beforeEach(async () => {
+    const logPath = tempPath('jsonl')
+    eventLog = await createEventLog({ logPath })
+    registry = createListenerRegistry(eventLog)
+    mockEngine = createMockEngine()
+    session = new SessionStore(`test/trigger-${randomUUID()}`)
+    connectorCenter = new ConnectorCenter()
+
+    triggerListener = createTriggerListener({
+      connectorCenter,
+      agentCenter: mockEngine as any,
+      registry,
+      session,
+    })
+    await triggerListener.start()
+    await registry.start()
+  })
+
+  afterEach(async () => {
+    await registry.stop()
+    await eventLog._resetForTest()
+  })
+
+  // ==================== Basic handling ====================
+
+  describe('event handling', () => {
+    it('should call agentCenter.askWithSession on trigger', async () => {
+      await eventLog.append('trigger', {
+        source: 'tradingview',
+        name: 'btc-breakout',
+        data: { symbol: 'BTC', price: 105000 },
+      } satisfies TriggerPayload)
+
+      await vi.waitFor(() => {
+        expect(mockEngine.askWithSession).toHaveBeenCalledTimes(1)
+      })
+
+      const [prompt] = mockEngine.askWithSession.mock.calls[0]
+      expect(prompt).toContain('Source: tradingview')
+      expect(prompt).toContain('Name:   btc-breakout')
+      expect(prompt).toContain('"symbol": "BTC"')
+      expect(prompt).toContain('"price": 105000')
+    })
+
+    it('should write trigger.done on success with causedBy', async () => {
+      const triggerEntry = await eventLog.append('trigger', {
+        source: 'webhook', name: 'test', data: {},
+      } satisfies TriggerPayload)
+
+      await vi.waitFor(() => {
+        const done = eventLog.recent({ type: 'trigger.done' })
+        expect(done).toHaveLength(1)
+      })
+
+      const [done] = eventLog.recent({ type: 'trigger.done' })
+      expect(done.payload).toMatchObject({
+        source: 'webhook',
+        name: 'test',
+        reply: 'AI reply',
+      })
+      expect(done.causedBy).toBe(triggerEntry.seq)
+    })
+
+    it('should not react to other event types', async () => {
+      await eventLog.append('some.other.event', { data: 'hello' })
+
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(mockEngine.askWithSession).not.toHaveBeenCalled()
+    })
+  })
+
+  // ==================== Delivery ====================
+
+  describe('delivery', () => {
+    it('should deliver reply through ConnectorCenter', async () => {
+      const delivered: string[] = []
+      connectorCenter.register({
+        channel: 'test', to: 'u1',
+        capabilities: { push: true, media: false },
+        send: async (p) => { delivered.push(p.text); return { delivered: true } },
+      })
+
+      await eventLog.append('trigger', {
+        source: 'test', name: 'ping', data: {},
+      } satisfies TriggerPayload)
+
+      await vi.waitFor(() => {
+        expect(delivered).toHaveLength(1)
+      })
+
+      expect(delivered[0]).toBe('AI reply')
+    })
+
+    it('should still log trigger.done when delivery fails', async () => {
+      connectorCenter.register({
+        channel: 'test', to: 'u1',
+        capabilities: { push: true, media: false },
+        send: async () => { throw new Error('send failed') },
+      })
+
+      await eventLog.append('trigger', {
+        source: 'test', name: 'ping', data: {},
+      } satisfies TriggerPayload)
+
+      await vi.waitFor(() => {
+        const done = eventLog.recent({ type: 'trigger.done' })
+        expect(done).toHaveLength(1)
+      })
+    })
+  })
+
+  // ==================== Error handling ====================
+
+  describe('error handling', () => {
+    it('should write trigger.error on engine failure with causedBy', async () => {
+      mockEngine.setShouldFail(true)
+
+      const triggerEntry = await eventLog.append('trigger', {
+        source: 'test', name: 'will-fail', data: {},
+      } satisfies TriggerPayload)
+
+      await vi.waitFor(() => {
+        const errors = eventLog.recent({ type: 'trigger.error' })
+        expect(errors).toHaveLength(1)
+      })
+
+      const [err] = eventLog.recent({ type: 'trigger.error' })
+      expect(err.payload).toMatchObject({
+        source: 'test',
+        name: 'will-fail',
+        error: 'engine error',
+      })
+      expect(err.causedBy).toBe(triggerEntry.seq)
+    })
+  })
+
+  // ==================== Lifecycle ====================
+
+  describe('lifecycle', () => {
+    it('should stop receiving events after stop()', async () => {
+      triggerListener.stop()
+
+      await eventLog.append('trigger', {
+        source: 'test', name: 'ignored', data: {},
+      } satisfies TriggerPayload)
+
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(mockEngine.askWithSession).not.toHaveBeenCalled()
+    })
+
+    it('should be idempotent on repeated start()', async () => {
+      await triggerListener.start()  // second call should be no-op
+      // No error
+    })
+  })
+})

--- a/src/task/trigger/listener.ts
+++ b/src/task/trigger/listener.ts
@@ -1,0 +1,127 @@
+/**
+ * Trigger Listener — subscribes to `trigger` events from the EventLog
+ * and routes them through the AgentCenter for processing.
+ *
+ * Triggers come from external sources (webhook, HTTP ingest, any producer
+ * calling eventLog.append('trigger', ...)). This is the default routing
+ * listener — it builds a prompt from the payload, asks the AI, notifies
+ * via the connector center, and emits trigger.done / trigger.error events
+ * linked back to the source via `causedBy`.
+ */
+
+import type { EventLog, EventLogEntry } from '../../core/event-log.js'
+import type { TriggerPayload } from '../../core/agent-event.js'
+import type { AgentCenter } from '../../core/agent-center.js'
+import { SessionStore } from '../../core/session.js'
+import type { ConnectorCenter } from '../../core/connector-center.js'
+import type { Listener } from '../../core/listener.js'
+import type { ListenerRegistry } from '../../core/listener-registry.js'
+
+// ==================== Types ====================
+
+export interface TriggerListenerOpts {
+  connectorCenter: ConnectorCenter
+  agentCenter: AgentCenter
+  /** Registry to auto-register this listener with. */
+  registry: ListenerRegistry
+  /** Optional: inject a session for testing. Otherwise creates a dedicated trigger session. */
+  session?: SessionStore
+}
+
+export interface TriggerListener {
+  /** Register the listener with the registry (idempotent). */
+  start(): Promise<void>
+  /** Unregister the listener from the registry. */
+  stop(): void
+  /** Expose the raw Listener object (for testing `handle()` directly). */
+  readonly listener: Listener<'trigger'>
+}
+
+// ==================== Prompt ====================
+
+function buildPrompt(payload: TriggerPayload): string {
+  return [
+    'External event received.',
+    '',
+    `Source: ${payload.source}`,
+    `Name:   ${payload.name}`,
+    '',
+    'Data:',
+    JSON.stringify(payload.data, null, 2),
+  ].join('\n')
+}
+
+// ==================== Factory ====================
+
+export function createTriggerListener(opts: TriggerListenerOpts): TriggerListener {
+  const { connectorCenter, agentCenter, registry } = opts
+  const session = opts.session ?? new SessionStore('trigger/default')
+
+  let processing = false
+  let registered = false
+
+  const listener: Listener<'trigger'> = {
+    name: 'trigger-router',
+    eventType: 'trigger',
+    async handle(entry: EventLogEntry<TriggerPayload>, eventLog: EventLog): Promise<void> {
+      const payload = entry.payload
+
+      // Guard: skip if already processing (serial execution)
+      if (processing) {
+        console.warn(`trigger-listener: skipping ${payload.source}/${payload.name} (already processing)`)
+        return
+      }
+
+      processing = true
+      const startMs = Date.now()
+
+      try {
+        const prompt = buildPrompt(payload)
+        const result = await agentCenter.askWithSession(prompt, session, {
+          historyPreamble: `You are operating in the trigger-routing context (session: trigger/default, source: ${payload.source}). An external event was just received.`,
+        })
+
+        try {
+          await connectorCenter.notify(result.text, {
+            media: result.media,
+            source: 'trigger',
+          })
+        } catch (sendErr) {
+          console.warn(`trigger-listener: send failed for ${payload.source}/${payload.name}:`, sendErr)
+        }
+
+        await eventLog.append('trigger.done', {
+          source: payload.source,
+          name: payload.name,
+          reply: result.text,
+          durationMs: Date.now() - startMs,
+        }, { causedBy: entry.seq })
+      } catch (err) {
+        console.error(`trigger-listener: error processing ${payload.source}/${payload.name}:`, err)
+        await eventLog.append('trigger.error', {
+          source: payload.source,
+          name: payload.name,
+          error: err instanceof Error ? err.message : String(err),
+          durationMs: Date.now() - startMs,
+        }, { causedBy: entry.seq })
+      } finally {
+        processing = false
+      }
+    },
+  }
+
+  return {
+    listener,
+    async start() {
+      if (registered) return
+      registry.register(listener)
+      registered = true
+    },
+    stop() {
+      if (registered) {
+        registry.unregister(listener.name)
+        registered = false
+      }
+    },
+  }
+}

--- a/src/task/trigger/listener.ts
+++ b/src/task/trigger/listener.ts
@@ -5,19 +5,21 @@
  * Triggers come from external sources (webhook, HTTP ingest, any producer
  * calling eventLog.append('trigger', ...)). This is the default routing
  * listener — it builds a prompt from the payload, asks the AI, notifies
- * via the connector center, and emits trigger.done / trigger.error events
- * linked back to the source via `causedBy`.
+ * via the connector center, and emits trigger.done / trigger.error events.
  */
 
-import type { EventLog, EventLogEntry } from '../../core/event-log.js'
+import type { EventLogEntry } from '../../core/event-log.js'
 import type { TriggerPayload } from '../../core/agent-event.js'
 import type { AgentCenter } from '../../core/agent-center.js'
 import { SessionStore } from '../../core/session.js'
 import type { ConnectorCenter } from '../../core/connector-center.js'
-import type { Listener } from '../../core/listener.js'
+import type { Listener, ListenerContext } from '../../core/listener.js'
 import type { ListenerRegistry } from '../../core/listener-registry.js'
 
 // ==================== Types ====================
+
+const TRIGGER_EMITS = ['trigger.done', 'trigger.error'] as const
+type TriggerEmits = typeof TRIGGER_EMITS
 
 export interface TriggerListenerOpts {
   connectorCenter: ConnectorCenter
@@ -34,7 +36,7 @@ export interface TriggerListener {
   /** Unregister the listener from the registry. */
   stop(): void
   /** Expose the raw Listener object (for testing `handle()` directly). */
-  readonly listener: Listener<'trigger'>
+  readonly listener: Listener<'trigger', TriggerEmits>
 }
 
 // ==================== Prompt ====================
@@ -60,10 +62,14 @@ export function createTriggerListener(opts: TriggerListenerOpts): TriggerListene
   let processing = false
   let registered = false
 
-  const listener: Listener<'trigger'> = {
+  const listener: Listener<'trigger', TriggerEmits> = {
     name: 'trigger-router',
     eventType: 'trigger',
-    async handle(entry: EventLogEntry<TriggerPayload>, eventLog: EventLog): Promise<void> {
+    emits: TRIGGER_EMITS,
+    async handle(
+      entry: EventLogEntry<TriggerPayload>,
+      ctx: ListenerContext<TriggerEmits>,
+    ): Promise<void> {
       const payload = entry.payload
 
       // Guard: skip if already processing (serial execution)
@@ -90,20 +96,20 @@ export function createTriggerListener(opts: TriggerListenerOpts): TriggerListene
           console.warn(`trigger-listener: send failed for ${payload.source}/${payload.name}:`, sendErr)
         }
 
-        await eventLog.append('trigger.done', {
+        await ctx.emit('trigger.done', {
           source: payload.source,
           name: payload.name,
           reply: result.text,
           durationMs: Date.now() - startMs,
-        }, { causedBy: entry.seq })
+        })
       } catch (err) {
         console.error(`trigger-listener: error processing ${payload.source}/${payload.name}:`, err)
-        await eventLog.append('trigger.error', {
+        await ctx.emit('trigger.error', {
           source: payload.source,
           name: payload.name,
           error: err instanceof Error ? err.message : String(err),
           durationMs: Date.now() - startMs,
-        }, { causedBy: entry.seq })
+        })
       } finally {
         processing = false
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@xyflow/react": "^12.10.2",
     "dompurify": "^3.3.1",
     "highlight.js": "^11.11.1",
     "marked": "^15.0.12",

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -16,6 +16,7 @@ import { agentStatusApi } from './agentStatus'
 import { personaApi } from './persona'
 import { newsApi } from './news'
 import { diaryApi } from './diary'
+import { topologyApi } from './topology'
 export const api = {
   chat: chatApi,
   config: configApi,
@@ -31,6 +32,7 @@ export const api = {
   persona: personaApi,
   news: newsApi,
   diary: diaryApi,
+  topology: topologyApi,
 }
 
 // Re-export all types for convenience
@@ -65,6 +67,8 @@ export type {
   EquityCurvePoint,
   NewsArticle,
   NewsListResponse,
+  TopologyResponse,
+  TopologyListener,
 } from './types'
 export type { EventQueryResult } from './events'
 export type { ToolCallQueryResult } from './agentStatus'

--- a/ui/src/api/topology.ts
+++ b/ui/src/api/topology.ts
@@ -1,0 +1,8 @@
+import { fetchJson } from './client'
+import type { TopologyResponse } from './types'
+
+export const topologyApi = {
+  async get(): Promise<TopologyResponse> {
+    return fetchJson('/api/topology')
+  },
+}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -124,6 +124,19 @@ export interface ConnectorsConfig {
   }
 }
 
+// ==================== Topology ====================
+
+export interface TopologyListener {
+  name: string
+  eventType: string
+  emits: string[]
+}
+
+export interface TopologyResponse {
+  eventTypes: string[]
+  listeners: TopologyListener[]
+}
+
 // ==================== News Collector ====================
 
 export interface NewsCollectorFeed {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -265,3 +265,69 @@ body,
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
 }
+
+/* ==================== Automation Flow (React Flow) ==================== */
+
+/* Event-type nodes (inputs + outputs) */
+.react-flow__node.flow-event-node {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 8px 14px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  min-width: 140px;
+  text-align: center;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+/* Listener nodes (middle column) */
+.react-flow__node.flow-listener-node {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+  border: 1px solid var(--color-accent);
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  min-width: 200px;
+  text-align: center;
+  box-shadow: 0 0 0 1px rgba(88, 166, 255, 0.1);
+}
+
+/* Pulse animation when an event of this type fires */
+.react-flow__node.flow-pulse {
+  animation: flow-pulse 800ms ease-out;
+  border-color: var(--color-accent);
+}
+@keyframes flow-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(88, 166, 255, 0.6);
+    border-color: var(--color-accent);
+  }
+  100% {
+    box-shadow: 0 0 0 14px rgba(88, 166, 255, 0);
+    border-color: var(--color-border);
+  }
+}
+
+/* React Flow background + controls theming */
+.react-flow__controls {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.react-flow__controls-button {
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+}
+.react-flow__controls-button:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+}
+.react-flow__controls-button svg {
+  fill: currentColor;
+}

--- a/ui/src/pages/AutomationFlowSection.tsx
+++ b/ui/src/pages/AutomationFlowSection.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MarkerType,
+  type Node,
+  type Edge,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import { api, type TopologyResponse, type EventLogEntry } from '../api'
+import { useSSE } from '../hooks/useSSE'
+import { PageLoading, EmptyState } from '../components/StateViews'
+
+// ==================== Layout ====================
+
+const COL_X = {
+  inputs: 40,
+  listeners: 360,
+  outputs: 680,
+}
+const ROW_HEIGHT = 80
+const PULSE_MS = 800
+
+function buildGraph(topology: TopologyResponse): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = []
+  const edges: Edge[] = []
+
+  // Partition event types into "inputs" (subscribed by some listener) and
+  // "outputs" (emitted by some listener). A type can be both — in that
+  // case we render it in inputs only (it's a producer-facing node).
+  const subscribedTo = new Set(topology.listeners.map((l) => l.eventType))
+  const emitted = new Set<string>()
+  for (const l of topology.listeners) for (const e of l.emits) emitted.add(e)
+
+  const inputs = topology.eventTypes.filter((t) => subscribedTo.has(t))
+  const outputs = topology.eventTypes.filter((t) => emitted.has(t) && !subscribedTo.has(t))
+
+  // Input event nodes (left column)
+  inputs.forEach((type, i) => {
+    nodes.push({
+      id: `event:${type}`,
+      type: 'default',
+      data: { label: type },
+      position: { x: COL_X.inputs, y: 20 + i * ROW_HEIGHT },
+      className: 'flow-event-node',
+      sourcePosition: 'right' as any,
+      targetPosition: 'left' as any,
+    })
+  })
+
+  // Listener nodes (middle column)
+  topology.listeners.forEach((l, i) => {
+    nodes.push({
+      id: `listener:${l.name}`,
+      type: 'default',
+      data: { label: l.name },
+      position: { x: COL_X.listeners, y: 20 + i * ROW_HEIGHT },
+      className: 'flow-listener-node',
+      sourcePosition: 'right' as any,
+      targetPosition: 'left' as any,
+    })
+  })
+
+  // Output event nodes (right column)
+  outputs.forEach((type, i) => {
+    nodes.push({
+      id: `event:${type}`,
+      type: 'default',
+      data: { label: type },
+      position: { x: COL_X.outputs, y: 20 + i * ROW_HEIGHT },
+      className: 'flow-event-node',
+      sourcePosition: 'right' as any,
+      targetPosition: 'left' as any,
+    })
+  })
+
+  // Subscribe edges: eventType → listener
+  for (const l of topology.listeners) {
+    edges.push({
+      id: `sub:${l.eventType}->${l.name}`,
+      source: `event:${l.eventType}`,
+      target: `listener:${l.name}`,
+      markerEnd: { type: MarkerType.ArrowClosed },
+      style: { stroke: '#58a6ff', strokeWidth: 1.5 },
+    })
+  }
+
+  // Emit edges: listener → eventType
+  for (const l of topology.listeners) {
+    for (const e of l.emits) {
+      edges.push({
+        id: `emit:${l.name}->${e}`,
+        source: `listener:${l.name}`,
+        target: `event:${e}`,
+        markerEnd: { type: MarkerType.ArrowClosed },
+        style: { stroke: '#3fb950', strokeWidth: 1.5, strokeDasharray: '4 3' },
+      })
+    }
+  }
+
+  return { nodes, edges }
+}
+
+// ==================== Component ====================
+
+export function AutomationFlowSection() {
+  const [topology, setTopology] = useState<TopologyResponse | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  // Track which nodes are currently pulsing (key: node id)
+  const [pulsing, setPulsing] = useState<Set<string>>(new Set())
+  const pulseTimers = useRef<Map<string, number>>(new Map())
+
+  // Fetch topology
+  useEffect(() => {
+    api.topology.get()
+      .then(setTopology)
+      .catch((err) => setLoadError(err instanceof Error ? err.message : String(err)))
+  }, [])
+
+  // Pulse the event-type node when an event of that type arrives
+  const handleSSE = useCallback((entry: EventLogEntry) => {
+    const nodeId = `event:${entry.type}`
+    setPulsing((prev) => {
+      if (prev.has(nodeId)) return prev
+      const next = new Set(prev)
+      next.add(nodeId)
+      return next
+    })
+    // Clear after PULSE_MS
+    const existing = pulseTimers.current.get(nodeId)
+    if (existing) window.clearTimeout(existing)
+    const t = window.setTimeout(() => {
+      setPulsing((prev) => {
+        if (!prev.has(nodeId)) return prev
+        const next = new Set(prev)
+        next.delete(nodeId)
+        return next
+      })
+      pulseTimers.current.delete(nodeId)
+    }, PULSE_MS)
+    pulseTimers.current.set(nodeId, t as unknown as number)
+  }, [])
+
+  useSSE({
+    url: '/api/events/stream',
+    onMessage: handleSSE,
+  })
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    return () => {
+      pulseTimers.current.forEach((t) => window.clearTimeout(t))
+      pulseTimers.current.clear()
+    }
+  }, [])
+
+  // Build graph + overlay pulse class
+  const { nodes, edges } = useMemo(() => {
+    if (!topology) return { nodes: [] as Node[], edges: [] as Edge[] }
+    const g = buildGraph(topology)
+    g.nodes = g.nodes.map((n) => {
+      if (pulsing.has(n.id)) {
+        return { ...n, className: `${n.className ?? ''} flow-pulse` }
+      }
+      return n
+    })
+    return g
+  }, [topology, pulsing])
+
+  if (loadError) {
+    return <EmptyState title="Failed to load topology" description={loadError} />
+  }
+  if (!topology) return <PageLoading />
+
+  return (
+    <div className="flex flex-col gap-3 h-full">
+      <div className="rounded-lg border border-border/50 bg-bg-secondary/50 px-4 py-3">
+        <p className="text-[13px] text-text-muted leading-relaxed">
+          Alice's async lifecycle as a graph. Left column: event types Alice listens to. Middle: registered
+          listeners. Right: event types they emit. Solid blue arrows are subscriptions, dashed green arrows are
+          emissions. Nodes pulse in real time when events flow through the system.
+        </p>
+      </div>
+
+      <div className="flex-1 min-h-0 rounded-lg border border-border bg-bg overflow-hidden">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          fitView
+          fitViewOptions={{ padding: 0.15 }}
+          proOptions={{ hideAttribution: true }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+        >
+          <Background color="#30363d" gap={16} />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -5,6 +5,7 @@ import { SaveIndicator } from '../components/SaveIndicator'
 import { ConfigSection, Field, inputClass } from '../components/form'
 import { useAutoSave } from '../hooks/useAutoSave'
 import { PageHeader } from '../components/PageHeader'
+import { AutomationFlowSection } from './AutomationFlowSection'
 
 // ==================== Helpers ====================
 
@@ -596,15 +597,16 @@ function AddCronJobForm({ onClose, onCreated }: { onClose: () => void; onCreated
 
 // ==================== Page ====================
 
-type Tab = 'heartbeat' | 'cron'
+type Tab = 'flow' | 'heartbeat' | 'cron'
 
 const TABS: { key: Tab; label: string }[] = [
+  { key: 'flow', label: 'Flow' },
   { key: 'heartbeat', label: 'Heartbeat' },
   { key: 'cron', label: 'Cron Jobs' },
 ]
 
 export function AutomationPage() {
-  const [tab, setTab] = useState<Tab>('heartbeat')
+  const [tab, setTab] = useState<Tab>('flow')
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -634,7 +636,13 @@ export function AutomationPage() {
 
       <div className="flex-1 flex flex-col min-h-0 px-4 md:px-6 py-5">
         <div className="flex-1 min-h-0">
-          {tab === 'heartbeat' ? <HeartbeatSection /> : <CronSection />}
+          {tab === 'flow' ? (
+            <AutomationFlowSection />
+          ) : tab === 'heartbeat' ? (
+            <HeartbeatSection />
+          ) : (
+            <CronSection />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Three commits that progressively open up Alice's event-driven lifecycle, culminating in a visual representation.

- **fix**: cron engine save() race that caused intermittent ENOENT when the periodic onTick save() collided with a UI-triggered save()
- **feat**: webhook ingest at `POST /api/events/ingest` + `TriggerListener` that routes external events through the AI pipeline, plus a `causedBy` field on EventLogEntry for causal tracing
- **feat**: constrained emitter — listeners declare `emits` tuples, Registry wraps `handle()` with a typed `ListenerContext` whose `emit()` is restricted (compile + runtime) to the declared set and auto-populates `causedBy`. `GET /api/topology` exposes the resulting graph. New Flow tab on `/automation` renders it with `@xyflow/react` and pulses nodes in real time via SSE.

## Test plan
- [x] `npx tsc --noEmit` — backend + UI clean
- [x] `pnpm test` — 1043/1043 pass (+14 new registry tests, +schema coverage for trigger.done / trigger.error)
- [x] Manual: `curl -X POST /api/events/ingest -d '{...}'` → 201, downstream trigger.done with causedBy
- [x] Manual: `/automation` → Flow tab renders full topology, nodes pulse when events flow
- [x] Manual: `curl /api/topology` → expected shape (11 event types, 5 listeners with emits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)