### PR TITLE
feat(ai-providers): GLM + Kimi presets, region-aware endpoints, quieter auth errors

### DIFF
--- a/src/ai-providers/agent-sdk/query.ts
+++ b/src/ai-providers/agent-sdk/query.ts
@@ -85,6 +85,26 @@ function stripImageData(raw: string): string {
   } catch { return raw }
 }
 
+// ==================== Error classification ====================
+
+type ErrorClass = 'auth' | 'unknown'
+
+const AUTH_PATTERNS = [
+  /\b401\b/,
+  /\binvalid[_\s-]?api[_\s-]?key\b/i,
+  /\bauthentication\b/i,
+  /\bunauthor(?:ized|ised)\b/i,
+  /\bpermission[_\s-]denied\b/i,
+  /\bx-api-key\b/i,
+]
+
+function classifyError(details: Record<string, unknown>): ErrorClass {
+  const haystack = [details.message, details.stderr, details.stdout]
+    .filter((x): x is string => typeof x === 'string')
+    .join('\n')
+  return AUTH_PATTERNS.some(p => p.test(haystack)) ? 'auth' : 'unknown'
+}
+
 // ==================== Public ====================
 
 /**
@@ -217,8 +237,16 @@ export async function askAgentSdk(
           resultText = result.errors?.join('\n') ?? `Agent SDK error: ${result.subtype}`
           // Log failed results with all available detail
           const resultDetail = { subtype: result.subtype, errors: result.errors, result: result.result }
-          logger.error({ ...resultDetail, turns: result.num_turns, durationMs: result.duration_ms }, 'result_error')
-          console.error('[agent-sdk] Non-success result:', resultDetail)
+          const classification = classifyError({
+            message: resultText,
+            stderr: Array.isArray(result.errors) ? result.errors.join('\n') : undefined,
+          })
+          logger.error({ ...resultDetail, classification, turns: result.num_turns, durationMs: result.duration_ms }, 'result_error')
+          if (classification === 'auth') {
+            console.warn('[agent-sdk] Auth failed — check your API key / baseUrl in the active profile')
+          } else {
+            console.error('[agent-sdk] Non-success result:', resultDetail)
+          }
         }
         logger.info({ subtype: result.subtype, turns: result.num_turns, durationMs: result.duration_ms }, 'result')
       }
@@ -238,9 +266,14 @@ export async function askAgentSdk(
     const extraKeys = Object.keys(errObj).filter(k => !(k in details))
     for (const k of extraKeys) details[k] = (errObj as any)[k]
 
-    logger.error(details, 'query_error')
-    // Also log to console so the developer can see it in the terminal
-    console.error('[agent-sdk] Claude Code process error:', details)
+    const classification = classifyError(details)
+    logger.error({ ...details, classification }, 'query_error')
+    if (classification === 'auth') {
+      // User-fixable: don't scream, just hint. Full detail already in logs/agent-sdk.log.
+      console.warn('[agent-sdk] Auth failed — check your API key / baseUrl in the active profile')
+    } else {
+      console.error('[agent-sdk] Claude Code process error:', details)
+    }
     ok = false
     const stderrHint = details.stderr ? `\nstderr: ${details.stderr}` : ''
     resultText = `Agent SDK error: ${errObj.message}${stderrHint}`

--- a/src/ai-providers/agent-sdk/query.ts
+++ b/src/ai-providers/agent-sdk/query.ts
@@ -87,7 +87,7 @@ function stripImageData(raw: string): string {
 
 // ==================== Error classification ====================
 
-type ErrorClass = 'auth' | 'unknown'
+type ErrorClass = 'auth' | 'model' | 'unknown'
 
 const AUTH_PATTERNS = [
   /\b401\b/,
@@ -98,11 +98,20 @@ const AUTH_PATTERNS = [
   /\bx-api-key\b/i,
 ]
 
+const MODEL_PATTERNS = [
+  /\bmodel[_\s-]not[_\s-]found\b/i,
+  /\binvalid[_\s-]?model\b/i,
+  /\bunknown[_\s-]?model\b/i,
+  /\bmodel\s+.+?\s+(?:does\s+not\s+exist|is\s+not\s+(?:a\s+)?valid)\b/i,
+]
+
 function classifyError(details: Record<string, unknown>): ErrorClass {
   const haystack = [details.message, details.stderr, details.stdout]
     .filter((x): x is string => typeof x === 'string')
     .join('\n')
-  return AUTH_PATTERNS.some(p => p.test(haystack)) ? 'auth' : 'unknown'
+  if (AUTH_PATTERNS.some(p => p.test(haystack))) return 'auth'
+  if (MODEL_PATTERNS.some(p => p.test(haystack))) return 'model'
+  return 'unknown'
 }
 
 // ==================== Public ====================
@@ -244,6 +253,8 @@ export async function askAgentSdk(
           logger.error({ ...resultDetail, classification, turns: result.num_turns, durationMs: result.duration_ms }, 'result_error')
           if (classification === 'auth') {
             console.warn('[agent-sdk] Auth failed — check your API key / baseUrl in the active profile')
+          } else if (classification === 'model') {
+            console.warn('[agent-sdk] Model not available on this endpoint — check the region / model combo')
           } else {
             console.error('[agent-sdk] Non-success result:', resultDetail)
           }
@@ -271,6 +282,8 @@ export async function askAgentSdk(
     if (classification === 'auth') {
       // User-fixable: don't scream, just hint. Full detail already in logs/agent-sdk.log.
       console.warn('[agent-sdk] Auth failed — check your API key / baseUrl in the active profile')
+    } else if (classification === 'model') {
+      console.warn('[agent-sdk] Model not available on this endpoint — check the region / model combo')
     } else {
       console.error('[agent-sdk] Claude Code process error:', details)
     }

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -198,6 +198,11 @@ export const GLM: PresetDef = {
 
 // ==================== Third-party: Kimi (Moonshot) ====================
 
+// Moonshot officially pushes OpenAI Chat Completions as the primary integration
+// path; we route via their secondary Anthropic-compat endpoint
+// (api.moonshot.*/anthropic) to stay on agent-sdk. Our codex backend speaks
+// the OpenAI Responses API, which Moonshot's direct endpoints do not
+// implement, so codex isn't a viable alternative here.
 export const KIMI: PresetDef = {
   id: 'kimi',
   label: 'Kimi (Moonshot)',

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -20,6 +20,11 @@ export interface ModelOption {
   label: string
 }
 
+export interface EndpointOption {
+  id: string
+  label: string
+}
+
 export interface PresetDef {
   id: string
   label: string
@@ -29,6 +34,7 @@ export interface PresetDef {
   defaultName: string
   zodSchema: z.ZodType
   models?: ModelOption[]
+  endpoints?: EndpointOption[]
   writeOnlyFields?: string[]
 }
 
@@ -143,14 +149,18 @@ export const MINIMAX: PresetDef = {
   description: 'MiniMax models via Claude Agent SDK (Anthropic-compatible)',
   category: 'third-party',
   defaultName: 'MiniMax',
-  hint: 'Get your API key at minimaxi.com',
+  hint: 'China console: minimaxi.com — International console: minimax.io. API keys are region-locked.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
-    baseUrl: z.literal('https://api.minimaxi.com/anthropic').describe('MiniMax API endpoint'),
+    baseUrl: z.string().default('https://api.minimaxi.com/anthropic').describe('API endpoint'),
     model: z.string().default('MiniMax-M2.7').describe('Model'),
     apiKey: z.string().min(1).describe('MiniMax API key'),
   }),
+  endpoints: [
+    { id: 'https://api.minimaxi.com/anthropic', label: 'China (minimaxi.com)' },
+    { id: 'https://api.minimax.io/anthropic', label: 'International (minimax.io)' },
+  ],
   models: [
     { id: 'MiniMax-M2.7', label: 'MiniMax M2.7' },
   ],
@@ -165,19 +175,49 @@ export const GLM: PresetDef = {
   description: 'Zhipu GLM models via Claude Agent SDK (Anthropic-compatible)',
   category: 'third-party',
   defaultName: 'GLM',
-  hint: 'Get your API key at bigmodel.cn',
+  hint: 'China console: bigmodel.cn — International console: z.ai. API keys are region-locked. Latest GLM 5.1 is China-only for now.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
-    baseUrl: z.literal('https://open.bigmodel.cn/api/anthropic').describe('GLM API endpoint'),
-    model: z.string().default('glm-5.1').describe('Model'),
+    baseUrl: z.string().default('https://open.bigmodel.cn/api/anthropic').describe('API endpoint'),
+    model: z.string().default('glm-4.7').describe('Model'),
     apiKey: z.string().min(1).describe('GLM API key'),
   }),
+  endpoints: [
+    { id: 'https://open.bigmodel.cn/api/anthropic', label: 'China (bigmodel.cn)' },
+    { id: 'https://api.z.ai/api/anthropic', label: 'International (z.ai)' },
+  ],
   models: [
-    { id: 'glm-5.1', label: 'GLM 5.1' },
+    { id: 'glm-5.1', label: 'GLM 5.1 (China only)' },
     { id: 'glm-4.7', label: 'GLM 4.7' },
-    { id: 'glm-4.6', label: 'GLM 4.6 (200K context)' },
+    { id: 'glm-4.6', label: 'GLM 4.6 — 200K (China only)' },
     { id: 'glm-4.5-air', label: 'GLM 4.5 Air' },
+  ],
+  writeOnlyFields: ['apiKey'],
+}
+
+// ==================== Third-party: Kimi (Moonshot) ====================
+
+export const KIMI: PresetDef = {
+  id: 'kimi',
+  label: 'Kimi (Moonshot)',
+  description: 'Moonshot Kimi models via Claude Agent SDK (Anthropic-compatible)',
+  category: 'third-party',
+  defaultName: 'Kimi',
+  hint: 'China console: platform.moonshot.cn — International console: platform.moonshot.ai. API keys are region-locked.',
+  zodSchema: z.object({
+    backend: z.literal('agent-sdk'),
+    loginMethod: z.literal('api-key'),
+    baseUrl: z.string().default('https://api.moonshot.cn/anthropic').describe('API endpoint'),
+    model: z.string().default('kimi-k2.5').describe('Model'),
+    apiKey: z.string().min(1).describe('Moonshot API key'),
+  }),
+  endpoints: [
+    { id: 'https://api.moonshot.cn/anthropic', label: 'China (moonshot.cn)' },
+    { id: 'https://api.moonshot.ai/anthropic', label: 'International (moonshot.ai)' },
+  ],
+  models: [
+    { id: 'kimi-k2.5', label: 'Kimi K2.5' },
   ],
   writeOnlyFields: ['apiKey'],
 }
@@ -211,5 +251,6 @@ export const PRESET_CATALOG: PresetDef[] = [
   GEMINI,
   MINIMAX,
   GLM,
+  KIMI,
   CUSTOM,
 ]

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -157,6 +157,31 @@ export const MINIMAX: PresetDef = {
   writeOnlyFields: ['apiKey'],
 }
 
+// ==================== Third-party: GLM (Zhipu) ====================
+
+export const GLM: PresetDef = {
+  id: 'glm',
+  label: 'GLM (Zhipu)',
+  description: 'Zhipu GLM models via Claude Agent SDK (Anthropic-compatible)',
+  category: 'third-party',
+  defaultName: 'GLM',
+  hint: 'Get your API key at bigmodel.cn',
+  zodSchema: z.object({
+    backend: z.literal('agent-sdk'),
+    loginMethod: z.literal('api-key'),
+    baseUrl: z.literal('https://open.bigmodel.cn/api/anthropic').describe('GLM API endpoint'),
+    model: z.string().default('glm-5.1').describe('Model'),
+    apiKey: z.string().min(1).describe('GLM API key'),
+  }),
+  models: [
+    { id: 'glm-5.1', label: 'GLM 5.1' },
+    { id: 'glm-4.7', label: 'GLM 4.7' },
+    { id: 'glm-4.6', label: 'GLM 4.6 (200K context)' },
+    { id: 'glm-4.5-air', label: 'GLM 4.5 Air' },
+  ],
+  writeOnlyFields: ['apiKey'],
+}
+
 // ==================== Custom ====================
 
 export const CUSTOM: PresetDef = {
@@ -185,5 +210,6 @@ export const PRESET_CATALOG: PresetDef[] = [
   CODEX_API,
   GEMINI,
   MINIMAX,
+  GLM,
   CUSTOM,
 ]

--- a/src/ai-providers/presets.ts
+++ b/src/ai-providers/presets.ts
@@ -30,12 +30,17 @@ function buildJsonSchema(def: PresetDef): Record<string, unknown> {
   const raw = z.toJSONSchema(def.zodSchema) as Record<string, unknown>
   const props = (raw.properties ?? {}) as Record<string, Record<string, unknown>>
 
-  // Replace model enum with oneOf (labeled options)
-  const mf = 'model'
-  if (def.models?.length && props[mf]) {
-    const oneOf = def.models.map(m => ({ const: m.id, title: m.label }))
-    const { enum: _e, ...rest } = props[mf]
-    props[mf] = { ...rest, oneOf }
+  // Replace scalar string fields with labeled oneOf when a catalog is provided
+  const labeledFields: Array<[string, Array<{ id: string; label: string }> | undefined]> = [
+    ['model', def.models],
+    ['baseUrl', def.endpoints],
+  ]
+  for (const [field, options] of labeledFields) {
+    if (options?.length && props[field]) {
+      const oneOf = options.map(o => ({ const: o.id, title: o.label }))
+      const { enum: _e, ...rest } = props[field]
+      props[field] = { ...rest, oneOf }
+    }
   }
 
   // Mark writeOnly fields


### PR DESCRIPTION
## Summary

- Add **GLM (Zhipu)** and **Kimi (Moonshot)** as third-party presets alongside MiniMax, all going through the Claude Agent SDK via each vendor's Anthropic-compatible endpoint.
- Teach presets about **regional splits**: Chinese LLM vendors all ship two hard-separated platforms (China + International) with independent accounts/keys/billing, so `baseUrl` is now a labeled dropdown — parallel to how `model` already works. MiniMax and GLM gain region pickers; Kimi ships with both regions from day one.
- **Quieter auth / model errors**: the agent-sdk wrapper now classifies process errors; mistyped API keys or wrong region/model combos get a single `console.warn` line instead of a full stack trace masquerading as a system crash. Pino still captures full detail for debugging.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 1069 tests pass
- [ ] Manually select GLM / Kimi / MiniMax from the preset picker, verify both region endpoints render as labeled dropdown options
- [ ] Point a preset at the wrong region and confirm the auth/model classifier suppresses the stack trace
- [ ] Existing user profiles still load (baseUrl schema relaxed from `z.literal` to `z.string`, so stored values continue to validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)