### PR TITLE
feat(market): workbench page + market-data HTTP consolidation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,22 +36,15 @@ the item when done — git log is the history.
 
 ## Bugs
 
-- [ ] Chat page: can't scroll up past a certain point — suspect a state
-      lock (e.g. a `loading` / `hasMore` guard that never releases, or
-      the auto-scroll-to-bottom effect fighting the user scroll).
-      Start: `ui/src/pages/ChatPage.tsx` around the scroll handler
-      (`onScroll` + `scrollToBottom` `useEffect`).
 - [ ] Snapshot / FX: after currency conversion, snapshot values
       occasionally come out as wildly wrong numbers (reported, cause
       unknown). Likely a direction mistake (multiply vs divide) or
       precision loss going through `number` instead of `Decimal`.
       Start: `src/domain/trading/snapshot/service.ts` (only file in
       snapshot/ that touches fx) + `src/domain/trading/fx-service.ts`.
-- [ ] Trading / Git Push UI: values shown on the Push approval panel
-      have visible precision issues (display clearly wrong). Likely a
-      `toFixed` / `Number(...)` step on the frontend rendering an
-      Operation's quantity or price. Start:
-      `ui/src/components/PushApprovalPanel.tsx` and any number-
-      formatting helpers it pulls in.
+      When next triggered, capture: (a) the raw `netLiquidation` /
+      currency on the account, (b) the rate FxService returned, (c) the
+      final displayed value — the TODO can't be narrowed without a
+      concrete data point.
 
 ## (seed more areas as they come up)

--- a/default/heartbeat.default.md
+++ b/default/heartbeat.default.md
@@ -2,6 +2,10 @@
 
 Read this file at the start of every heartbeat to recall what you should be paying attention to. Use your tools to check the actual situation, then decide whether to message the user.
 
+## Before You Check
+
+Take a beat to sense the market's mood this round — frothy, fearful, rangebound, directional? Name it briefly so your read has a frame. This is a fresh reflection each round, not something to persist.
+
 ## Watch List
 
 - Scan for significant price movements across tracked pairs (>3% in the last few hours)

--- a/packages/ibkr/src/client/orders.ts
+++ b/packages/ibkr/src/client/orders.ts
@@ -7,7 +7,7 @@ import { EClient } from './base.js'
 import { makeField, makeFieldHandleEmpty } from '../comm.js'
 import { OUT } from '../message.js'
 import * as SV from '../server-versions.js'
-import { NO_VALID_ID, UNSET_DOUBLE, UNSET_INTEGER } from '../const.js'
+import { NO_VALID_ID, UNSET_DOUBLE, UNSET_INTEGER, UNSET_DECIMAL } from '../const.js'
 import * as errors from '../errors.js'
 import { currentTimeMillis, isPegBenchOrder, isPegBestOrder, isPegMidOrder } from '../utils.js'
 import { COMPETE_AGAINST_BEST_OFFSET_UP_TO_MID } from '../order.js'
@@ -160,7 +160,7 @@ export function applyOrders(Client: typeof EClient): void {
     }
 
     if (this.serverVersion() < SV.MIN_SERVER_VER_TRAILING_PERCENT) {
-      if (order.trailingPercent !== UNSET_DOUBLE) {
+      if (!order.trailingPercent.equals(UNSET_DECIMAL)) {
         this.wrapper.error(orderId, currentTimeMillis(), errors.UPDATE_TWS.code(), errors.UPDATE_TWS.msg() + '  It does not support trailing percent parameter')
         return
       }
@@ -216,7 +216,7 @@ export function applyOrders(Client: typeof EClient): void {
     }
 
     if (this.serverVersion() < SV.MIN_SERVER_VER_CASH_QTY) {
-      if (order.cashQty) {
+      if (!order.cashQty.equals(UNSET_DECIMAL)) {
         this.wrapper.error(orderId, currentTimeMillis(), errors.UPDATE_TWS.code(), errors.UPDATE_TWS.msg() + ' It does not support cash quantity parameter')
         return
       }
@@ -356,12 +356,12 @@ export function applyOrders(Client: typeof EClient): void {
 
       flds.push(makeField(order.orderType))
       if (this.serverVersion() < SV.MIN_SERVER_VER_ORDER_COMBO_LEGS_PRICE) {
-        flds.push(makeField(order.lmtPrice !== UNSET_DOUBLE ? order.lmtPrice : 0))
+        flds.push(makeField(!order.lmtPrice.equals(UNSET_DECIMAL) ? order.lmtPrice : 0))
       } else {
         flds.push(makeFieldHandleEmpty(order.lmtPrice))
       }
       if (this.serverVersion() < SV.MIN_SERVER_VER_TRAILING_PERCENT) {
-        flds.push(makeField(order.auxPrice !== UNSET_DOUBLE ? order.auxPrice : 0))
+        flds.push(makeField(!order.auxPrice.equals(UNSET_DECIMAL) ? order.auxPrice : 0))
       } else {
         flds.push(makeFieldHandleEmpty(order.auxPrice))
       }
@@ -671,7 +671,9 @@ export function applyOrders(Client: typeof EClient): void {
       }
 
       if (this.serverVersion() >= SV.MIN_SERVER_VER_CASH_QTY) {
-        flds.push(makeField(order.cashQty))
+        // Must handle UNSET: sending a raw UNSET_DECIMAL string
+        // (~1.7e38) would make TWS think cashQty is actually set.
+        flds.push(makeFieldHandleEmpty(order.cashQty))
       }
 
       if (this.serverVersion() >= SV.MIN_SERVER_VER_DECISION_MAKER) {

--- a/packages/ibkr/src/comm.ts
+++ b/packages/ibkr/src/comm.ts
@@ -3,7 +3,8 @@
  * Mirrors: ibapi/comm.py
  */
 
-import { UNSET_INTEGER, UNSET_DOUBLE, DOUBLE_INFINITY, INFINITY_STR } from './const.js'
+import Decimal from 'decimal.js'
+import { UNSET_INTEGER, UNSET_DOUBLE, UNSET_DECIMAL, DOUBLE_INFINITY, INFINITY_STR } from './const.js'
 import { ClientException, isAsciiPrintable } from './utils.js'
 import { INVALID_SYMBOL } from './errors.js'
 
@@ -57,6 +58,12 @@ export function makeField(val: unknown): string {
     throw new Error('Cannot send None to TWS')
   }
 
+  // Decimal: use toFixed() to avoid scientific notation on small values
+  // (Decimal.toString() uses '1e-8' by default; TWS wire expects '0.00000001').
+  if (val instanceof Decimal) {
+    return val.toFixed() + '\0'
+  }
+
   // Validate printable ASCII for strings
   if (typeof val === 'string' && val.length > 0 && !isAsciiPrintable(val)) {
     throw new ClientException(
@@ -80,6 +87,11 @@ export function makeField(val: unknown): string {
 export function makeFieldHandleEmpty(val: unknown): string {
   if (val === null || val === undefined) {
     throw new Error('Cannot send None to TWS')
+  }
+
+  if (val instanceof Decimal) {
+    if (val.equals(UNSET_DECIMAL)) return makeField('')
+    return makeField(val)
   }
 
   if (val === UNSET_INTEGER || val === UNSET_DOUBLE) {

--- a/packages/ibkr/src/decoder/orders.ts
+++ b/packages/ibkr/src/decoder/orders.ts
@@ -216,8 +216,8 @@ function decodeOrderFromProto(orderId: number, cp: ContractProto, op: OrderProto
   if (op.action !== undefined) order.action = op.action
   if (op.totalQuantity !== undefined) order.totalQuantity = new Decimal(op.totalQuantity)
   if (op.orderType !== undefined) order.orderType = op.orderType
-  if (op.lmtPrice !== undefined) order.lmtPrice = op.lmtPrice
-  if (op.auxPrice !== undefined) order.auxPrice = op.auxPrice
+  if (op.lmtPrice !== undefined) order.lmtPrice = new Decimal(op.lmtPrice)
+  if (op.auxPrice !== undefined) order.auxPrice = new Decimal(op.auxPrice)
   if (op.tif !== undefined) order.tif = op.tif
   if (op.ocaGroup !== undefined) order.ocaGroup = op.ocaGroup
   if (op.account !== undefined) order.account = op.account
@@ -268,8 +268,8 @@ function decodeOrderFromProto(orderId: number, cp: ContractProto, op: OrderProto
   if (op.deltaNeutralDesignatedLocation !== undefined) order.deltaNeutralDesignatedLocation = op.deltaNeutralDesignatedLocation
   if (op.continuousUpdate !== undefined) order.continuousUpdate = op.continuousUpdate
   if (op.referencePriceType !== undefined) order.referencePriceType = op.referencePriceType
-  if (op.trailStopPrice !== undefined) order.trailStopPrice = op.trailStopPrice
-  if (op.trailingPercent !== undefined) order.trailingPercent = op.trailingPercent
+  if (op.trailStopPrice !== undefined) order.trailStopPrice = new Decimal(op.trailStopPrice)
+  if (op.trailingPercent !== undefined) order.trailingPercent = new Decimal(op.trailingPercent)
 
   // order combo legs
   const orderComboLegs = decodeOrderComboLegsFromProto(cp)
@@ -328,7 +328,7 @@ function decodeOrderFromProto(orderId: number, cp: ContractProto, op: OrderProto
   const sdt = decodeSoftDollarTierFromProto(op)
   if (sdt) order.softDollarTier = sdt
 
-  if (op.cashQty !== undefined) order.cashQty = op.cashQty
+  if (op.cashQty !== undefined) order.cashQty = new Decimal(op.cashQty)
   if (op.dontUseAutoPriceForHedge !== undefined) order.dontUseAutoPriceForHedge = op.dontUseAutoPriceForHedge
   if (op.isOmsContainer !== undefined) order.isOmsContainer = op.isOmsContainer
   if (op.discretionaryUpToLimitPrice !== undefined) order.discretionaryUpToLimitPrice = op.discretionaryUpToLimitPrice

--- a/packages/ibkr/src/order-decoder.ts
+++ b/packages/ibkr/src/order-decoder.ts
@@ -102,17 +102,20 @@ export class OrderDecoder {
 
   decodeLmtPrice(fields: Iterator<string>): void {
     if (this.version < 29) {
-      this.order.lmtPrice = decodeFloat(fields)
+      // Pre-v29: empty wire field meant 0 (not unset). Preserve that.
+      const raw = decodeDecimal(fields)
+      this.order.lmtPrice = raw.equals(UNSET_DECIMAL) ? new Decimal(0) : raw
     } else {
-      this.order.lmtPrice = decodeFloat(fields, SHOW_UNSET)
+      this.order.lmtPrice = decodeDecimal(fields)
     }
   }
 
   decodeAuxPrice(fields: Iterator<string>): void {
     if (this.version < 30) {
-      this.order.auxPrice = decodeFloat(fields)
+      const raw = decodeDecimal(fields)
+      this.order.auxPrice = raw.equals(UNSET_DECIMAL) ? new Decimal(0) : raw
     } else {
-      this.order.auxPrice = decodeFloat(fields, SHOW_UNSET)
+      this.order.auxPrice = decodeDecimal(fields)
     }
   }
 
@@ -297,9 +300,9 @@ export class OrderDecoder {
   }
 
   decodeTrailParams(fields: Iterator<string>): void {
-    this.order.trailStopPrice = decodeFloat(fields, SHOW_UNSET)
+    this.order.trailStopPrice = decodeDecimal(fields)
     if (this.version >= 30) {
-      this.order.trailingPercent = decodeFloat(fields, SHOW_UNSET)
+      this.order.trailingPercent = decodeDecimal(fields)
     }
   }
 
@@ -555,7 +558,8 @@ export class OrderDecoder {
   }
 
   decodeStopPriceAndLmtPriceOffset(fields: Iterator<string>): void {
-    this.order.trailStopPrice = decodeFloat(fields)
+    const raw = decodeDecimal(fields)
+    this.order.trailStopPrice = raw.equals(UNSET_DECIMAL) ? new Decimal(0) : raw
     this.order.lmtPriceOffset = decodeFloat(fields)
   }
 
@@ -570,7 +574,7 @@ export class OrderDecoder {
 
   decodeCashQty(fields: Iterator<string>): void {
     if (this.serverVersion >= MIN_SERVER_VER_CASH_QTY) {
-      this.order.cashQty = decodeFloat(fields)
+      this.order.cashQty = decodeDecimal(fields)
     }
   }
 

--- a/packages/ibkr/src/order.ts
+++ b/packages/ibkr/src/order.ts
@@ -46,8 +46,8 @@ export class Order {
   action: string = ''
   totalQuantity: Decimal = UNSET_DECIMAL
   orderType: string = ''
-  lmtPrice: number = UNSET_DOUBLE
-  auxPrice: number = UNSET_DOUBLE
+  lmtPrice: Decimal = UNSET_DECIMAL
+  auxPrice: Decimal = UNSET_DECIMAL
 
   // extended order fields
   tif: string = '' // "Time in Force" - DAY, GTC, etc.
@@ -71,8 +71,8 @@ export class Order {
   minQty: number = UNSET_INTEGER
   percentOffset: number = UNSET_DOUBLE // REL orders only
   overridePercentageConstraints: boolean = false
-  trailStopPrice: number = UNSET_DOUBLE
-  trailingPercent: number = UNSET_DOUBLE // TRAILLIMIT orders only
+  trailStopPrice: Decimal = UNSET_DECIMAL
+  trailingPercent: Decimal = UNSET_DECIMAL // TRAILLIMIT orders only
 
   // financial advisors only
   faGroup: string = ''
@@ -192,7 +192,7 @@ export class Order {
   extOperator: string = ''
 
   // native cash quantity
-  cashQty: number = UNSET_DOUBLE
+  cashQty: Decimal = UNSET_DECIMAL
 
   mifid2DecisionMaker: string = ''
   mifid2DecisionAlgo: string = ''
@@ -246,7 +246,7 @@ export class Order {
   toString(): string {
     let s = `${intMaxString(this.orderId)},${intMaxString(this.clientId)},${longMaxString(this.permId)}:`
 
-    s += ` ${this.orderType} ${this.action} ${decimalMaxString(this.totalQuantity)}@${floatMaxString(this.lmtPrice)}`
+    s += ` ${this.orderType} ${this.action} ${decimalMaxString(this.totalQuantity)}@${decimalMaxString(this.lmtPrice)}`
 
     s += ` ${this.tif}`
 

--- a/packages/ibkr/tests/e2e/order-precision.e2e.spec.ts
+++ b/packages/ibkr/tests/e2e/order-precision.e2e.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * E2E: place a LMT order with a Decimal lmtPrice against paper TWS,
+ * read it back via reqAllOpenOrders, assert the round-trip preserves
+ * the exact decimal value (no IEEE 754 artifacts).
+ *
+ * Why this exists: the lmtPrice field is now `Decimal` (was `number`).
+ * Unit tests cover encode/decode of synthetic wire bytes in isolation —
+ * but only a real TWS tells us whether the IB server accepts the wire
+ * text we produce and echoes back a value we can reconstruct exactly.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Decimal from 'decimal.js'
+import { Contract, Order, OrderCancel } from '../../src/index.js'
+import { client, available, results, waitFor, sleep } from './setup.js'
+
+// AAPL — penny-tick symbol, liquid, paper-safe. Use a far-off limit
+// price so the order never fills (we cancel it before the test ends).
+const AAPL_CONID = 265598
+
+function makeAaplContract(): Contract {
+  const c = new Contract()
+  c.conId = AAPL_CONID
+  c.symbol = 'AAPL'
+  c.secType = 'STK'
+  c.exchange = 'SMART'
+  c.primaryExchange = 'NASDAQ'
+  c.currency = 'USD'
+  return c
+}
+
+describe.runIf(available)('TWS Order precision — lmtPrice Decimal round-trip', () => {
+  const cleanupOrderIds: number[] = []
+  let baseOrderId: number
+
+  beforeAll(async () => {
+    // Refresh nextValidId — across runs on the same TWS session, the
+    // server-side counter advances; using a stale value silently rejects.
+    results.nextValidId = undefined
+    client.reqIds(1)
+    const got = await waitFor(() => results.nextValidId != null, 5000)
+    if (!got || results.nextValidId == null) {
+      throw new Error('nextValidId not received — TWS handshake incomplete')
+    }
+    // Leave a comfortable gap — this suite and other tests share the
+    // same TWS account + clientId.
+    baseOrderId = results.nextValidId + 100
+    // eslint-disable-next-line no-console
+    console.log(`  [precision e2e] baseOrderId=${baseOrderId}`)
+  })
+
+  afterAll(async () => {
+    // Best-effort cancel every order we placed, regardless of current state.
+    const oc = new OrderCancel()
+    for (const id of cleanupOrderIds) {
+      try { client.cancelOrder(id, oc) } catch { /* ignore */ }
+    }
+    // Give TWS a beat to process the cancels.
+    await sleep(500)
+  })
+
+  it('places LMT with penny-tick price and reads it back exact', async () => {
+    const orderId = baseOrderId + 1
+    cleanupOrderIds.push(orderId)
+
+    // SELL LMT far above market — sits on book, won't fill, doesn't trip
+    // TWS's "price too far from market" precaution dialog that a BUY at a
+    // deep discount would. (BUY at 1.25 vs market ~$200 silently blocks on
+    // a precaution popup in the TWS UI, never reaching the API.)
+    const order = new Order()
+    order.action = 'SELL'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal('1')
+    order.lmtPrice = new Decimal('999.25')  // way above market — won't fill
+    order.tif = 'DAY'
+    order.transmit = true
+    order.outsideRth = false
+
+    results.openOrders.delete(orderId)
+    results.orderStatus.delete(orderId)
+    const errorsBefore = results.errors.length
+    client.placeOrder(orderId, makeAaplContract(), order)
+
+    // Wait for openOrder echo. TWS auto-pushes this for client-placed
+    // orders. If it doesn't arrive on its own, fall back to reqOpenOrders.
+    let got = await waitFor(() => results.openOrders.has(orderId), 3000)
+    if (!got) {
+      client.reqOpenOrders()
+      got = await waitFor(() => results.openOrders.has(orderId), 3000)
+    }
+
+    // Only hard rejections should fail the test. Informational codes
+    // (399 "order queued until market open", 2100+ farm/data warnings)
+    // are benign.
+    const REJECTION_CODES = new Set([110, 200, 201, 202, 203])
+    const rejections = results.errors
+      .slice(errorsBefore)
+      .filter(e => e.reqId === orderId && REJECTION_CODES.has(e.code))
+    if (rejections.length > 0) {
+      throw new Error(`TWS rejected order: ${rejections.map(e => `${e.code}: ${e.msg}`).join(' | ')}`)
+    }
+
+    expect(got, 'openOrder echo did not arrive — order may not have been accepted').toBe(true)
+
+    const echo = results.openOrders.get(orderId)!
+    expect(echo.order.lmtPrice).toBeInstanceOf(Decimal)
+    expect(echo.order.lmtPrice.equals(new Decimal('999.25'))).toBe(true)
+    // Also check the string representation has no IEEE 754 noise.
+    expect(echo.order.lmtPrice.toFixed()).toBe('999.25')
+  })
+
+  it('IEEE 754 trap value (0.1 + 0.2) stays clean when sent as Decimal', async () => {
+    const orderId = baseOrderId + 2
+    cleanupOrderIds.push(orderId)
+
+    // Placing at $0.30 is below the minimum penny-tick for a $200-ish
+    // stock — TWS may reject. We want to observe the wire behaviour,
+    // not the business outcome, so any rejection still validates that
+    // *our* encoded price was clean. We read the callback either way.
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal('1')
+    // Decimal math: 0.1 + 0.2 exactly 0.3 (no noise).
+    order.lmtPrice = new Decimal('0.1').plus('0.2')
+    order.tif = 'DAY'
+    order.transmit = true
+
+    expect(order.lmtPrice.toFixed()).toBe('0.3')
+
+    results.openOrders.delete(orderId)
+    const errorCountBefore = results.errors.length
+    client.placeOrder(orderId, makeAaplContract(), order)
+
+    // Either openOrder echo or a rejection — either is diagnostic.
+    await waitFor(
+      () => results.openOrders.has(orderId) || results.errors.length > errorCountBefore,
+      5000,
+    )
+
+    if (results.openOrders.has(orderId)) {
+      const echo = results.openOrders.get(orderId)!
+      expect(echo.order.lmtPrice.toFixed()).toBe('0.3')
+    } else {
+      // TWS rejected — still fine, the wire we sent was '0.3', not
+      // '0.30000000000000004'. Record the rejection reason for the log.
+      const recent = results.errors.slice(errorCountBefore)
+      console.log('  [note] TWS rejected lmtPrice=0.3 (expected for AAPL):',
+        recent.map(e => `${e.code}: ${e.msg}`).join(' | '))
+    }
+  })
+
+  it('sub-tick precision: TWS rejects or rounds, but our wire stays exact', async () => {
+    const orderId = baseOrderId + 3
+    cleanupOrderIds.push(orderId)
+
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal('1')
+    // AAPL ticks at $0.01 above $1 — 6 decimals will either be rejected
+    // (error 110) or silently rounded. Either outcome is acceptable; we
+    // only care that the value we *sent* matches the Decimal we intended.
+    order.lmtPrice = new Decimal('1.234567')
+    order.tif = 'DAY'
+    order.transmit = true
+
+    results.openOrders.delete(orderId)
+    const errorCountBefore = results.errors.length
+    client.placeOrder(orderId, makeAaplContract(), order)
+
+    await waitFor(
+      () => results.openOrders.has(orderId) || results.errors.length > errorCountBefore,
+      5000,
+    )
+
+    if (results.openOrders.has(orderId)) {
+      const echo = results.openOrders.get(orderId)!
+      // TWS might round to tick. The echoed value should still be a clean
+      // decimal (no IEEE noise), even if different from what we sent.
+      const echoed = echo.order.lmtPrice.toFixed()
+      console.log(`  [note] sub-tick placement: sent 1.234567, TWS echoed ${echoed}`)
+      // Whatever TWS returns, it should be a clean decimal string that
+      // reconstructs without loss.
+      const reconstructed = new Decimal(echoed)
+      expect(reconstructed.toFixed()).toBe(echoed)
+    } else {
+      const recent = results.errors.slice(errorCountBefore)
+      console.log('  [note] sub-tick rejected (expected behaviour):',
+        recent.map(e => `${e.code}: ${e.msg}`).join(' | '))
+      // Rejection is fine — the test's purpose is to verify our encoder
+      // didn't corrupt the price, and that it reached TWS (which judged it).
+      expect(recent.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/ibkr/tests/e2e/setup.ts
+++ b/packages/ibkr/tests/e2e/setup.ts
@@ -8,7 +8,8 @@
  * If TWS is not running, `available` is false and tests should skip.
  */
 
-import { EClient, DefaultEWrapper, type ContractDetails } from '../../src/index.js'
+import Decimal from 'decimal.js'
+import { EClient, DefaultEWrapper, type ContractDetails, type Contract, type Order, type OrderState } from '../../src/index.js'
 import { isTwsAvailable, TWS_HOST, TWS_PORT } from '../helpers/tws.js'
 
 // --- Collected results from TWS callbacks ---
@@ -21,6 +22,10 @@ export const results = {
   errors: [] as Array<{ reqId: number; code: number; msg: string }>,
   contractDetails: new Map<number, ContractDetails[]>(),
   contractDetailsEnded: new Set<number>(),
+  // openOrder callback payloads keyed by orderId (last-write wins)
+  openOrders: new Map<number, { contract: Contract; order: Order; orderState: OrderState }>(),
+  openOrderEnded: false,
+  orderStatus: new Map<number, { status: string; filled: Decimal; remaining: Decimal }>(),
 }
 
 // --- Wrapper that collects everything ---
@@ -54,10 +59,27 @@ class E2EWrapper extends DefaultEWrapper {
   }
 
   error(reqId: number, _t: number, code: number, msg: string) {
-    // 2000+ are informational (farm connections, etc.)
-    if (code < 2000) {
-      results.errors.push({ reqId, code, msg })
-    }
+    // Capture everything during order-flow debugging. Informational (2000+)
+    // is useful too: 2109 ("order located behind market"), 2110 ("order
+    // rejected—no trading permissions"), etc.
+    results.errors.push({ reqId, code, msg })
+  }
+
+  openOrder(orderId: number, contract: Contract, order: Order, orderState: OrderState) {
+    results.openOrders.set(orderId, { contract, order, orderState })
+  }
+
+  openOrderEnd() {
+    results.openOrderEnded = true
+  }
+
+  orderStatus(
+    orderId: number,
+    status: string,
+    filled: Decimal,
+    remaining: Decimal,
+  ) {
+    results.orderStatus.set(orderId, { status, filled, remaining })
   }
 }
 

--- a/packages/ibkr/tests/models.spec.ts
+++ b/packages/ibkr/tests/models.spec.ts
@@ -9,7 +9,7 @@ import { OrderState } from '../src/order-state.js'
 import { Execution, ExecutionFilter } from '../src/execution.js'
 import { TagValue } from '../src/tag-value.js'
 import { SoftDollarTier } from '../src/softdollartier.js'
-import { UNSET_DOUBLE, UNSET_INTEGER } from '../src/const.js'
+import { UNSET_DOUBLE, UNSET_INTEGER, UNSET_DECIMAL } from '../src/const.js'
 
 describe('Contract', () => {
   it('has sensible defaults', () => {
@@ -36,8 +36,8 @@ describe('Order', () => {
     expect(o.orderId).toBe(0)
     expect(o.action).toBe('')
     expect(o.orderType).toBe('')
-    expect(o.lmtPrice).toBe(UNSET_DOUBLE)
-    expect(o.auxPrice).toBe(UNSET_DOUBLE)
+    expect(o.lmtPrice.equals(UNSET_DECIMAL)).toBe(true)
+    expect(o.auxPrice.equals(UNSET_DECIMAL)).toBe(true)
     expect(o.transmit).toBe(true)
   })
 })

--- a/packages/ibkr/tests/order-precision.spec.ts
+++ b/packages/ibkr/tests/order-precision.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for Decimal precision on Order's price fields.
+ *
+ * Locks the wire-layer contract: the 5 price fields (lmtPrice, auxPrice,
+ * trailStopPrice, trailingPercent, cashQty) are `Decimal`, survive
+ * encode/decode round-trip without IEEE 754 artifacts, and respect the
+ * UNSET_DECIMAL sentinel via makeFieldHandleEmpty.
+ */
+
+import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
+import { Order } from '../src/order.js'
+import { UNSET_DECIMAL } from '../src/const.js'
+import { makeField, makeFieldHandleEmpty } from '../src/comm.js'
+import { decodeDecimal } from '../src/utils.js'
+
+function iterOf(strs: string[]): Iterator<string> {
+  return strs[Symbol.iterator]()
+}
+
+describe('Order — price fields are Decimal', () => {
+  it('defaults to UNSET_DECIMAL', () => {
+    const o = new Order()
+    expect(o.lmtPrice.equals(UNSET_DECIMAL)).toBe(true)
+    expect(o.auxPrice.equals(UNSET_DECIMAL)).toBe(true)
+    expect(o.trailStopPrice.equals(UNSET_DECIMAL)).toBe(true)
+    expect(o.trailingPercent.equals(UNSET_DECIMAL)).toBe(true)
+    expect(o.cashQty.equals(UNSET_DECIMAL)).toBe(true)
+  })
+
+  it('accepts precise Decimal assignments without loss', () => {
+    const o = new Order()
+    o.lmtPrice = new Decimal('0.12345678')
+    o.auxPrice = new Decimal('0.00000001')
+    // Internal representation is exact; toString() may choose scientific
+    // notation for small values, but the underlying value is preserved.
+    expect(o.lmtPrice.equals(new Decimal('0.12345678'))).toBe(true)
+    expect(o.auxPrice.equals(new Decimal('0.00000001'))).toBe(true)
+    // The wire formatter (toFixed) must produce plain decimal notation.
+    expect(o.auxPrice.toFixed()).toBe('0.00000001')
+  })
+})
+
+describe('makeFieldHandleEmpty — Decimal branch', () => {
+  it('encodes UNSET_DECIMAL as empty wire field', () => {
+    expect(makeFieldHandleEmpty(UNSET_DECIMAL)).toBe('\0')
+  })
+
+  it('encodes a precise Decimal as exact decimal string', () => {
+    expect(makeFieldHandleEmpty(new Decimal('0.12345678'))).toBe('0.12345678\0')
+  })
+
+  it('encodes a Decimal with no fractional part as integer string', () => {
+    expect(makeFieldHandleEmpty(new Decimal('145'))).toBe('145\0')
+  })
+
+  it('preserves precision that JS number cannot represent', () => {
+    // 0.1 + 0.2 rendered via JS number is '0.30000000000000004'.
+    // Via Decimal it stays '0.3'.
+    const d = new Decimal('0.1').plus('0.2')
+    expect(makeFieldHandleEmpty(d)).toBe('0.3\0')
+  })
+
+  it('retains existing number UNSET sentinel semantics', () => {
+    // Non-Decimal call sites in the lib still pass number sentinels;
+    // make sure the widened helper didn't regress them.
+    expect(makeFieldHandleEmpty(Number.MAX_VALUE)).toBe('\0') // UNSET_DOUBLE
+    expect(makeFieldHandleEmpty(2 ** 31 - 1)).toBe('\0')      // UNSET_INTEGER
+  })
+})
+
+describe('decodeDecimal round-trip with encoder', () => {
+  function roundTrip(d: Decimal): Decimal {
+    // Encode → strip trailing NULL → wrap as single wire field.
+    const wire = makeFieldHandleEmpty(d).replace(/\0$/, '')
+    return decodeDecimal(iterOf([wire]))
+  }
+
+  it('round-trips satoshi-scale price', () => {
+    const original = new Decimal('0.00001234')
+    const got = roundTrip(original)
+    expect(got.equals(original)).toBe(true)
+    expect(got.toString()).toBe('0.00001234')
+  })
+
+  it('round-trips IEEE 754 trap value safely', () => {
+    const original = new Decimal('0.1').plus('0.2')
+    const got = roundTrip(original)
+    expect(got.toString()).toBe('0.3')
+  })
+
+  it('round-trips UNSET sentinel to UNSET', () => {
+    const got = roundTrip(UNSET_DECIMAL)
+    expect(got.equals(UNSET_DECIMAL)).toBe(true)
+  })
+
+  it('round-trips a typical stock price', () => {
+    const got = roundTrip(new Decimal('145.25'))
+    expect(got.toString()).toBe('145.25')
+  })
+})
+
+describe('Order.toString — uses Decimal-aware formatter', () => {
+  it('renders lmtPrice as decimal (no IEEE noise)', () => {
+    const o = new Order()
+    o.totalQuantity = new Decimal('10')
+    o.lmtPrice = new Decimal('0.1').plus('0.2')
+    o.action = 'BUY'
+    o.orderType = 'LMT'
+    // Match the toString body: ... `${decimalMaxString(quantity)}@${decimalMaxString(lmtPrice)}`
+    expect(o.toString()).toContain('10@0.3')
+    expect(o.toString()).not.toContain('0.30000000000000004')
+  })
+})
+
+describe('makeField — encodes Decimal natively', () => {
+  it('uses Decimal.toString() under the hood', () => {
+    expect(makeField(new Decimal('1.5'))).toBe('1.5\0')
+    expect(makeField(new Decimal('0.00000001'))).toBe('0.00000001\0')
+  })
+})

--- a/packages/opentypebb/src/core/app/router.ts
+++ b/packages/opentypebb/src/core/app/router.ts
@@ -157,12 +157,14 @@ export class Router {
    *
    * Each command becomes: GET /api/v1/{extension}/{path}?params...
    *   - Provider is taken from ?provider= query param
-   *   - Credentials from X-OpenBB-Credentials header
+   *   - Credentials from X-OpenBB-Credentials header, falling back to
+   *     `defaultCredentials` when the header is absent or malformed.
    */
   mountToHono(
     app: Hono,
     executor: QueryExecutor,
     basePath = '/api/v1',
+    defaultCredentials: Record<string, string> | null = null,
   ): void {
     const commands = this.getCommandMap(basePath)
 
@@ -180,14 +182,14 @@ export class Router {
         const provider = (params.provider as string) ?? ''
         delete params.provider
 
-        // Parse credentials from header
+        // Parse credentials from header; fall back to defaults when missing.
         const credHeader = c.req.header('X-OpenBB-Credentials')
-        let credentials: Record<string, string> | null = null
+        let credentials: Record<string, string> | null = defaultCredentials
         if (credHeader) {
           try {
             credentials = JSON.parse(credHeader)
           } catch {
-            // Ignore malformed credential header
+            // Malformed header — keep defaults rather than dropping creds.
           }
         }
 

--- a/packages/opentypebb/src/core/app/router.ts
+++ b/packages/opentypebb/src/core/app/router.ts
@@ -156,7 +156,8 @@ export class Router {
    * Maps to: AppLoader.add_routers() / RouterLoader in rest_api.py
    *
    * Each command becomes: GET /api/v1/{extension}/{path}?params...
-   *   - Provider is taken from ?provider= query param
+   *   - Provider: explicit `?provider=` query wins; else `resolveProvider(path, basePath)`
+   *     if supplied; else empty string (executor will surface a "provider required" error).
    *   - Credentials from X-OpenBB-Credentials header, falling back to
    *     `defaultCredentials` when the header is absent or malformed.
    */
@@ -165,6 +166,7 @@ export class Router {
     executor: QueryExecutor,
     basePath = '/api/v1',
     defaultCredentials: Record<string, string> | null = null,
+    resolveProvider?: (path: string, basePath: string) => string | undefined,
   ): void {
     const commands = this.getCommandMap(basePath)
 
@@ -178,8 +180,9 @@ export class Router {
           params[key] = coerceQueryValue(value)
         }
 
-        // Extract provider from query params (matches OpenBB behavior)
-        const provider = (params.provider as string) ?? ''
+        // Provider precedence: explicit query > resolver callback > empty string.
+        const queryProvider = (params.provider as string | undefined) ?? ''
+        const provider = queryProvider || resolveProvider?.(path, basePath) || ''
         delete params.provider
 
         // Parse credentials from header; fall back to defaults when missing.

--- a/packages/opentypebb/src/core/provider/utils/helpers.ts
+++ b/packages/opentypebb/src/core/provider/utils/helpers.ts
@@ -5,6 +5,42 @@
 
 import { OpenBBError } from './errors.js'
 
+/** Query-param names that carry secrets and must not appear in error logs. */
+const SECRET_QUERY_KEYS = new Set([
+  'apikey', 'api_key', 'api-key',
+  'token', 'access_token', 'accesstoken',
+  'key', 'secret', 'password',
+])
+
+/**
+ * Return `url` with any secret-bearing query-string values replaced by `***`.
+ * Used before embedding URLs into error messages / logs so credentials never leak.
+ * Falls back to the original string if parsing fails.
+ */
+function redactUrl(url: string): string {
+  try {
+    const u = new URL(url)
+    for (const [k] of u.searchParams) {
+      if (SECRET_QUERY_KEYS.has(k.toLowerCase())) {
+        u.searchParams.set(k, '***')
+      }
+    }
+    return u.toString()
+  } catch {
+    return url
+  }
+}
+
+/** Extract a short description from a caught value, for chaining into error text. */
+function describeCause(err: unknown): string {
+  if (err instanceof Error) {
+    const parts = [err.name !== 'Error' ? err.name : '', err.message].filter(Boolean)
+    return parts.join(': ')
+  }
+  if (typeof err === 'string') return err
+  try { return JSON.stringify(err) } catch { return String(err) }
+}
+
 /**
  * Make an async HTTP request and return the parsed JSON response.
  * Maps to: amake_request() in helpers.py
@@ -26,6 +62,7 @@ export async function amakeRequest<T = unknown>(
   } = {},
 ): Promise<T> {
   const { method = 'GET', headers, body, timeoutMs = 30_000, responseCallback } = options
+  const safeUrl = redactUrl(url)
 
   let response: Response
   try {
@@ -37,9 +74,9 @@ export async function amakeRequest<T = unknown>(
     })
   } catch (error) {
     if (error instanceof DOMException && error.name === 'TimeoutError') {
-      throw new OpenBBError(`Request timed out after ${timeoutMs}ms: ${url}`)
+      throw new OpenBBError(`Request timed out after ${timeoutMs}ms: ${safeUrl}`)
     }
-    throw new OpenBBError(`Request failed: ${url}`, error)
+    throw new OpenBBError(`Request failed (${describeCause(error)}): ${safeUrl}`, error)
   }
 
   if (responseCallback) {
@@ -49,14 +86,14 @@ export async function amakeRequest<T = unknown>(
   if (!response.ok) {
     const text = await response.text().catch(() => '')
     throw new OpenBBError(
-      `HTTP ${response.status} ${response.statusText}: ${url}${text ? ` - ${text}` : ''}`,
+      `HTTP ${response.status} ${response.statusText}: ${safeUrl}${text ? ` - ${text}` : ''}`,
     )
   }
 
   try {
     return (await response.json()) as T
   } catch (error) {
-    throw new OpenBBError(`Failed to parse JSON response from: ${url}`, error)
+    throw new OpenBBError(`Failed to parse JSON response (${describeCause(error)}): ${safeUrl}`, error)
   }
 }
 

--- a/packages/opentypebb/src/providers/fmp/utils/helpers.ts
+++ b/packages/opentypebb/src/providers/fmp/utils/helpers.ts
@@ -228,7 +228,18 @@ export async function getHistoricalOhlc(
     baseUrl += 'historical-chart/1hour?'
   }
 
-  const queryParams = { ...query }
+  // FMP's historical endpoints want `from` / `to`, not the canonical
+  // `start_date` / `end_date`. Rename before serializing — otherwise FMP
+  // silently ignores the range and returns its default 5-year window.
+  const queryParams: Record<string, unknown> = { ...query }
+  if (queryParams.start_date != null) {
+    queryParams.from = queryParams.start_date
+    delete queryParams.start_date
+  }
+  if (queryParams.end_date != null) {
+    queryParams.to = queryParams.end_date
+    delete queryParams.end_date
+  }
   const excludeKeys = ['symbol', 'adjustment', 'interval']
   const queryStr = getQueryString(queryParams, excludeKeys)
   const symbols = query.symbol.split(',')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      lightweight-charts:
+        specifier: ^5.1.0
+        version: 5.1.0
       marked:
         specifier: ^15.0.12
         version: 15.0.12
@@ -1962,6 +1965,9 @@ packages:
   extend@2.0.2:
     resolution: {integrity: sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ==}
 
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2274,6 +2280,9 @@ packages:
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
+
+  lightweight-charts@5.1.0:
+    resolution: {integrity: sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -4771,6 +4780,8 @@ snapshots:
 
   extend@2.0.2: {}
 
+  fancy-canvas@2.1.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.0: {}
@@ -5055,6 +5066,10 @@ snapshots:
       lightningcss-linux-x64-musl: 1.31.1
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
+
+  lightweight-charts@5.1.0:
+    dependencies:
+      fancy-canvas: 2.1.0
 
   lilconfig@3.1.3: {}
 

--- a/scripts/migrate-order-sentinels.ts
+++ b/scripts/migrate-order-sentinels.ts
@@ -1,0 +1,126 @@
+/**
+ * One-time migration: strip legacy UNSET_DOUBLE sentinels from persisted
+ * trading commits.
+ *
+ * Context: before the Decimal migration, Order's price-class fields
+ * (lmtPrice, auxPrice, trailStopPrice, trailingPercent, cashQty)
+ * defaulted to UNSET_DOUBLE = Number.MAX_VALUE. JSON.stringify serialised
+ * this as 1.7976931348623157e+308 into data/trading/<account>/commit.json.
+ *
+ * Post-migration the fields are Decimal with a different UNSET_DECIMAL
+ * sentinel (~1.7e38). TradingGit.rehydrateOrder wraps any non-null value
+ * via `new Decimal(String(x))`, so the old legacy sentinel rehydrates
+ * into a perfectly valid but absurd Decimal (~1.7e308) that slips past
+ * every UNSET check. Surfaces as "$179769313486231570000..." in the
+ * Recent Trades panel; would also blow up max-position-size guard if
+ * run against historical staging.
+ *
+ * Fix: delete those sentinel fields at rest. After this script, every
+ * price field is either a real numeric string / number or absent —
+ * Order's class defaults (UNSET_DECIMAL) take over on rehydrate.
+ *
+ * Idempotent — rerun is a no-op.
+ *
+ * Run:
+ *   pnpm tsx scripts/migrate-order-sentinels.ts
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync, renameSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const LEGACY_UNSET_DOUBLE = Number.MAX_VALUE  // = 1.7976931348623157e+308
+const PRICE_FIELDS = ['lmtPrice', 'auxPrice', 'trailStopPrice', 'trailingPercent', 'cashQty'] as const
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
+const TRADING_DIR = join(REPO_ROOT, 'data', 'trading')
+
+interface Commit {
+  hash?: string
+  operations?: Array<{
+    action?: string
+    order?: Record<string, unknown>
+    changes?: Record<string, unknown>
+  }>
+}
+
+interface CommitFile {
+  commits?: Commit[]
+  head?: string
+}
+
+function isLegacySentinel(v: unknown): boolean {
+  return typeof v === 'number' && v === LEGACY_UNSET_DOUBLE
+}
+
+function cleanOrderObject(obj: Record<string, unknown> | undefined, counter: Map<string, number>): boolean {
+  if (!obj) return false
+  let dirty = false
+  for (const field of PRICE_FIELDS) {
+    if (field in obj && isLegacySentinel(obj[field])) {
+      delete obj[field]
+      counter.set(field, (counter.get(field) ?? 0) + 1)
+      dirty = true
+    }
+  }
+  return dirty
+}
+
+function cleanFile(path: string): { dirty: boolean; counts: Map<string, number> } {
+  const counts = new Map<string, number>()
+  const raw = readFileSync(path, 'utf8')
+  const data: CommitFile = JSON.parse(raw)
+  let dirty = false
+
+  for (const commit of data.commits ?? []) {
+    for (const op of commit.operations ?? []) {
+      if (cleanOrderObject(op.order, counts)) dirty = true
+      if (cleanOrderObject(op.changes, counts)) dirty = true
+    }
+  }
+
+  if (dirty) {
+    const serialised = JSON.stringify(data, null, 2) + '\n'
+    const tmp = path + '.tmp'
+    writeFileSync(tmp, serialised, 'utf8')
+    renameSync(tmp, path)
+  }
+  return { dirty, counts }
+}
+
+function main() {
+  let totalFiles = 0
+  let changedFiles = 0
+  const grandTotal = new Map<string, number>()
+
+  let entries: string[]
+  try {
+    entries = readdirSync(TRADING_DIR)
+  } catch (err) {
+    console.error(`No ${TRADING_DIR} directory found. Nothing to do.`)
+    return
+  }
+
+  for (const entry of entries) {
+    const commitPath = join(TRADING_DIR, entry, 'commit.json')
+    let st
+    try { st = statSync(commitPath) } catch { continue }
+    if (!st.isFile()) continue
+    totalFiles++
+
+    const { dirty, counts } = cleanFile(commitPath)
+    const summary = [...counts.entries()].map(([k, v]) => `${k}:${v}`).join(' ')
+    if (dirty) {
+      changedFiles++
+      console.log(`✓ ${entry} — stripped ${summary}`)
+      for (const [k, v] of counts) grandTotal.set(k, (grandTotal.get(k) ?? 0) + v)
+    } else {
+      console.log(`· ${entry} — clean`)
+    }
+  }
+
+  console.log(`\n${changedFiles}/${totalFiles} files changed. Total stripped:`,
+    [...grandTotal.entries()].map(([k, v]) => `${k}=${v}`).join(', ') || '(none)')
+}
+
+main()

--- a/src/connectors/telegram/telegram-plugin.ts
+++ b/src/connectors/telegram/telegram-plugin.ts
@@ -17,6 +17,7 @@ import { TelegramConnector, splitMessage, MAX_MESSAGE_LENGTH } from './telegram-
 import type { AccountManager } from '../../domain/trading/index.js'
 import type { Operation } from '../../domain/trading/git/types.js'
 import { getOperationSymbol } from '../../domain/trading/git/types.js'
+import { UNSET_DECIMAL } from '@traderalice/ibkr'
 
 /** Build a display label for a profile. */
 function profileLabel(name: string, profile: { model: string }): string {
@@ -558,7 +559,9 @@ export class TelegramPlugin implements Plugin {
         const side = op.order?.action || '?'
         const qty = op.order?.totalQuantity
         const cashQty = op.order?.cashQty
-        const size = (cashQty && cashQty > 0) ? `$${cashQty}` : qty ? `${qty}` : '?'
+        const hasCash = cashQty && !cashQty.equals(UNSET_DECIMAL) && cashQty.gt(0)
+        const hasQty = qty && !qty.equals(UNSET_DECIMAL)
+        const size = hasCash ? `$${cashQty.toFixed()}` : hasQty ? qty.toFixed() : '?'
         return `${side} ${symbol} ${size}`
       }
       case 'closePosition':

--- a/src/connectors/web/routes/brain.ts
+++ b/src/connectors/web/routes/brain.ts
@@ -1,0 +1,44 @@
+/**
+ * Brain route — exposes Alice's global cognitive state (frontal lobe + emotion + commit history).
+ *
+ * Read-only dashboard feed. Reads `data/brain/commit.json` (written by `brainOnCommit` in main.ts)
+ * so the data is session-agnostic — brain changes from chat sessions show up alongside heartbeat ones.
+ */
+
+import { Hono } from 'hono'
+import { readFile } from 'node:fs/promises'
+import type { BrainExportState, BrainCommit } from '../../../domain/brain/index.js'
+
+const BRAIN_FILE = 'data/brain/commit.json'
+
+export interface BrainStateResponse {
+  frontalLobe: string
+  emotion: string
+  commits: BrainCommit[]
+}
+
+const EMPTY: BrainStateResponse = { frontalLobe: '', emotion: 'neutral', commits: [] }
+
+export function createBrainRoutes() {
+  const app = new Hono()
+
+  app.get('/state', async (c) => {
+    try {
+      const raw = await readFile(BRAIN_FILE, 'utf-8')
+      const parsed = JSON.parse(raw) as BrainExportState
+      const res: BrainStateResponse = {
+        frontalLobe: parsed.state?.frontalLobe ?? '',
+        emotion: parsed.state?.emotion ?? 'neutral',
+        commits: parsed.commits ?? [],
+      }
+      return c.json(res)
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return c.json(EMPTY)
+      }
+      return c.json({ error: String(err) }, 500)
+    }
+  })
+
+  return app
+}

--- a/src/connectors/web/routes/brain.ts
+++ b/src/connectors/web/routes/brain.ts
@@ -1,8 +1,9 @@
 /**
- * Brain route — exposes Alice's global cognitive state (frontal lobe + emotion + commit history).
+ * Brain route — exposes Alice's frontal-lobe state + commit history.
  *
- * Read-only dashboard feed. Reads `data/brain/commit.json` (written by `brainOnCommit` in main.ts)
- * so the data is session-agnostic — brain changes from chat sessions show up alongside heartbeat ones.
+ * Read-only dashboard feed. Reads `data/brain/commit.json` (written by
+ * `brainOnCommit` in main.ts) so the data is session-agnostic — brain changes
+ * from chat sessions show up alongside heartbeat ones.
  */
 
 import { Hono } from 'hono'
@@ -13,11 +14,10 @@ const BRAIN_FILE = 'data/brain/commit.json'
 
 export interface BrainStateResponse {
   frontalLobe: string
-  emotion: string
   commits: BrainCommit[]
 }
 
-const EMPTY: BrainStateResponse = { frontalLobe: '', emotion: 'neutral', commits: [] }
+const EMPTY: BrainStateResponse = { frontalLobe: '', commits: [] }
 
 export function createBrainRoutes() {
   const app = new Hono()
@@ -26,10 +26,12 @@ export function createBrainRoutes() {
     try {
       const raw = await readFile(BRAIN_FILE, 'utf-8')
       const parsed = JSON.parse(raw) as BrainExportState
+      // Legacy data may include emotion-type commits — strip them so the UI
+      // doesn't have to know about the retired dimension.
+      const commits = (parsed.commits ?? []).filter((c) => c.type === 'frontal_lobe')
       const res: BrainStateResponse = {
         frontalLobe: parsed.state?.frontalLobe ?? '',
-        emotion: parsed.state?.emotion ?? 'neutral',
-        commits: parsed.commits ?? [],
+        commits,
       }
       return c.json(res)
     } catch (err: unknown) {

--- a/src/connectors/web/routes/market.ts
+++ b/src/connectors/web/routes/market.ts
@@ -1,0 +1,26 @@
+/**
+ * Market data aggregation routes.
+ *
+ * `/api/market/*` is Alice's own namespace for cross-asset-class behaviour
+ * that doesn't map 1:1 to an opentypebb fetcher — currently just the
+ * heuristic symbol search. Quote / historical / fundamentals remain on the
+ * raw opentypebb passthrough at `/api/market-data-v1/*`.
+ */
+
+import { Hono } from 'hono'
+import type { EngineContext } from '../../../core/types.js'
+import { aggregateSymbolSearch } from '../../../domain/market-data/aggregate-search.js'
+
+export function createMarketRoutes(ctx: EngineContext): Hono {
+  const app = new Hono()
+
+  app.get('/search', async (c) => {
+    const query = c.req.query('query') ?? ''
+    const limitRaw = c.req.query('limit')
+    const limit = limitRaw ? Math.max(1, Math.min(100, Number(limitRaw) || 20)) : 20
+    const results = await aggregateSymbolSearch(ctx.marketSearch, query, limit)
+    return c.json({ results, count: results.length })
+  })
+
+  return app
+}

--- a/src/connectors/web/web-plugin.ts
+++ b/src/connectors/web/web-plugin.ts
@@ -16,6 +16,7 @@ import { createTopologyRoutes } from './routes/topology.js'
 import { createCronRoutes } from './routes/cron.js'
 import { createHeartbeatRoutes } from './routes/heartbeat.js'
 import { createDiaryRoutes } from './routes/diary.js'
+import { createBrainRoutes } from './routes/brain.js'
 import { createTradingRoutes } from './routes/trading.js'
 import { createTradingConfigRoutes } from './routes/trading-config.js'
 import { createDevRoutes } from './routes/dev.js'
@@ -102,6 +103,7 @@ export class WebPlugin implements Plugin {
     app.route('/api/cron', createCronRoutes(ctx))
     app.route('/api/heartbeat', createHeartbeatRoutes(ctx))
     app.route('/api/diary', createDiaryRoutes(ctx))
+    app.route('/api/brain', createBrainRoutes())
     app.route('/api/trading/config', createTradingConfigRoutes(ctx))
     app.route('/api/trading', createTradingRoutes(ctx))
     app.route('/api/dev', createDevRoutes(ctx.connectorCenter))

--- a/src/connectors/web/web-plugin.ts
+++ b/src/connectors/web/web-plugin.ts
@@ -24,6 +24,8 @@ import { createToolsRoutes } from './routes/tools.js'
 import { createAgentStatusRoutes } from './routes/agent-status.js'
 import { createPersonaRoutes } from './routes/persona.js'
 import { createNewsRoutes } from './routes/news.js'
+import { mountOpenTypeBB } from '../../server/opentypebb.js'
+import { buildSDKCredentials } from '../../domain/market-data/credential-map.js'
 
 export interface WebConfig {
   port: number
@@ -111,6 +113,14 @@ export class WebPlugin implements Plugin {
     app.route('/api/agent-status', createAgentStatusRoutes(ctx))
     app.route('/api/news', createNewsRoutes(ctx))
     app.route('/api/persona', createPersonaRoutes())
+
+    // ==================== Mount opentypebb (market data HTTP) ====================
+    // opentypebb is Alice's first-class market-data package; its router is
+    // merged into this app so UI and external consumers hit a single port.
+    mountOpenTypeBB(app, ctx.bbEngine, {
+      basePath: '/api/market-data-v1',
+      defaultCredentials: buildSDKCredentials(ctx.config.marketData.providerKeys),
+    })
 
     // ==================== Serve UI (Vite build output) ====================
     const uiRoot = resolve('dist/ui')

--- a/src/connectors/web/web-plugin.ts
+++ b/src/connectors/web/web-plugin.ts
@@ -24,6 +24,7 @@ import { createToolsRoutes } from './routes/tools.js'
 import { createAgentStatusRoutes } from './routes/agent-status.js'
 import { createPersonaRoutes } from './routes/persona.js'
 import { createNewsRoutes } from './routes/news.js'
+import { createMarketRoutes } from './routes/market.js'
 import { mountOpenTypeBB } from '../../server/opentypebb.js'
 import { buildSDKCredentials } from '../../domain/market-data/credential-map.js'
 
@@ -112,6 +113,7 @@ export class WebPlugin implements Plugin {
     app.route('/api/tools', createToolsRoutes(ctx.toolCenter))
     app.route('/api/agent-status', createAgentStatusRoutes(ctx))
     app.route('/api/news', createNewsRoutes(ctx))
+    app.route('/api/market', createMarketRoutes(ctx))
     app.route('/api/persona', createPersonaRoutes())
 
     // ==================== Mount opentypebb (market data HTTP) ====================
@@ -120,6 +122,7 @@ export class WebPlugin implements Plugin {
     mountOpenTypeBB(app, ctx.bbEngine, {
       basePath: '/api/market-data-v1',
       defaultCredentials: buildSDKCredentials(ctx.config.marketData.providerKeys),
+      defaultProviders: ctx.config.marketData.providers,
     })
 
     // ==================== Serve UI (Vite build output) ====================

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -181,10 +181,6 @@ const marketDataSchema = z.object({
     biztoc: z.string().optional(),
   }).default({}),
   backend: z.enum(['typebb-sdk', 'openbb-api']).default('typebb-sdk'),
-  apiServer: z.object({
-    enabled: z.boolean().default(true),
-    port: z.number().int().min(1024).max(65535).default(6901),
-  }).default({ enabled: true, port: 6901 }),
 })
 
 const compactionSchema = z.object({

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,6 +3,7 @@ import type { AccountManager } from '../domain/trading/index.js'
 import type { FxService } from '../domain/trading/fx-service.js'
 import type { SnapshotService } from '../domain/trading/snapshot/index.js'
 import type { INewsProvider } from '../domain/news/types.js'
+import type { MarketSearchDeps } from '../domain/market-data/aggregate-search.js'
 import type { CronEngine } from '../task/cron/engine.js'
 import type { Heartbeat } from '../task/heartbeat/index.js'
 import type { Config, WebChannel } from './config.js'
@@ -44,6 +45,9 @@ export interface EngineContext {
 
   // Market data
   bbEngine: QueryExecutor
+  /** Deps for cross-asset-class heuristic symbol search. Shared between the
+   *  AI tool (marketSearchForResearch) and the /api/market/search HTTP route. */
+  marketSearch: MarketSearchDeps
 
   // Trading (unified account model)
   accountManager: AccountManager

--- a/src/domain/brain/Brain.ts
+++ b/src/domain/brain/Brain.ts
@@ -1,8 +1,9 @@
 /**
- * Brain - Git-like cognitive state management
+ * Brain - Git-like log of frontal-lobe updates
  *
- * Tracks frontal lobe (working memory) and emotion state changes,
- * creating a commit for each change to form a complete cognitive change chain.
+ * Single-purpose now (emotion dimension was removed — see types.ts). Each
+ * `updateFrontalLobe` creates a commit so we can surface "when was this
+ * written" context when injecting the note back into the system prompt.
  */
 
 import { createHash } from 'crypto';
@@ -37,7 +38,6 @@ export class Brain {
   ) {
     this.state = {
       frontalLobe: initialState?.frontalLobe ?? '',
-      emotion: initialState?.emotion ?? 'neutral',
     };
   }
 
@@ -47,12 +47,14 @@ export class Brain {
     return this.state.frontalLobe;
   }
 
-  getEmotion(): { current: string; recentChanges: BrainCommit[] } {
-    const emotionCommits = this.commits
-      .filter((c) => c.type === 'emotion')
-      .slice(-10)
-      .reverse();
-    return { current: this.state.emotion, recentChanges: emotionCommits };
+  /** Current content + timestamp of the most recent write.
+   *  Used by the system-prompt injector to render "written Nh ago". */
+  getFrontalLobeMeta(): { content: string; updatedAt: string | null } {
+    const last = this.commits.at(-1);
+    return {
+      content: this.state.frontalLobe,
+      updatedAt: last?.timestamp ?? null,
+    };
   }
 
   log(limit = 10): BrainCommit[] {
@@ -67,16 +69,6 @@ export class Brain {
     return { success: true, message: 'Frontal lobe updated successfully' };
   }
 
-  updateEmotion(
-    emotion: string,
-    reason: string,
-  ): { success: boolean; message: string } {
-    const from = this.state.emotion;
-    this.state.emotion = emotion;
-    this.createCommit('emotion', reason);
-    return { success: true, message: `Emotion: ${from} → ${emotion}` };
-  }
-
   // ==================== Serialization ====================
 
   exportState(): BrainExportState {
@@ -88,9 +80,14 @@ export class Brain {
   }
 
   static restore(state: BrainExportState, config: BrainConfig): Brain {
-    const brain = new Brain(config, state.state);
-    brain.commits = [...state.commits];
-    brain.head = state.head;
+    const brain = new Brain(config, {
+      frontalLobe: state.state?.frontalLobe ?? '',
+    });
+    // Legacy data may contain emotion-type commits — strip them so downstream
+    // code (log viewer, timestamp queries) sees a uniform shape.
+    brain.commits = (state.commits ?? []).filter((c) => c.type === 'frontal_lobe');
+    const lastSurviving = brain.commits.at(-1);
+    brain.head = lastSurviving?.hash ?? null;
     return brain;
   }
 

--- a/src/domain/brain/types.ts
+++ b/src/domain/brain/types.ts
@@ -1,7 +1,10 @@
 /**
  * Brain type definitions
  *
- * Git-like cognitive state tracking for frontal lobe and emotion changes
+ * Git-like log of frontal-lobe updates. The "emotion" dimension was removed —
+ * it was write-only (nothing downstream read it) and its tool was buried under
+ * tool-search so the AI never reached for it. Any emotional framing now belongs
+ * inside the frontal-lobe string itself.
  */
 
 // ==================== Commit Hash ====================
@@ -10,23 +13,24 @@ export type CommitHash = string;
 
 // ==================== Brain State ====================
 
-export type BrainCommitType = 'frontal_lobe' | 'emotion';
+/** Retained as a single-value union so the persistence format can grow new
+ *  commit kinds later without schema churn. */
+export type BrainCommitType = 'frontal_lobe';
 
 /** Brain state snapshot */
 export interface BrainState {
   frontalLobe: string;
-  emotion: string;
 }
 
 // ==================== Brain Commit ====================
 
-/** Brain Commit - complete record of a cognitive state change */
+/** Brain Commit — one recorded frontal-lobe update */
 export interface BrainCommit {
   hash: CommitHash;
   parentHash: CommitHash | null;
   timestamp: string;
   type: BrainCommitType;
-  /** Change description (frontal lobe content / emotion change reason) */
+  /** Change description (first ~100 chars of the new frontal-lobe content) */
   message: string;
   stateAfter: BrainState;
 }

--- a/src/domain/market-data/aggregate-search.ts
+++ b/src/domain/market-data/aggregate-search.ts
@@ -1,0 +1,68 @@
+/**
+ * Aggregate Symbol Search
+ *
+ * Cross-asset-class heuristic search that respects Alice's per-asset-class
+ * provider config. Used both by the AI tool (marketSearchForResearch) and the
+ * HTTP route (/api/market/search) — both surfaces must return the same thing.
+ *
+ * equity    — SymbolIndex (SEC/TMX local cache, regex, zero-latency)
+ * commodity — CommodityCatalog (canonical catalog, ~25 items)
+ * crypto    — cryptoClient.search on yfinance (online fuzzy)
+ * currency  — currencyClient.search on yfinance (online fuzzy, XXXUSD filter)
+ */
+import type { SymbolIndex } from './equity/symbol-index.js'
+import type { CommodityCatalog } from './commodity/commodity-catalog.js'
+import type { CryptoClientLike, CurrencyClientLike } from './client/types.js'
+
+export type AssetClass = 'equity' | 'crypto' | 'currency' | 'commodity'
+
+export interface MarketSearchDeps {
+  symbolIndex: SymbolIndex
+  cryptoClient: CryptoClientLike
+  currencyClient: CurrencyClientLike
+  commodityCatalog: CommodityCatalog
+}
+
+export interface MarketSearchResult {
+  /** Equity / crypto / currency have a symbol; commodity uses `id` instead (canonical). */
+  symbol?: string
+  id?: string
+  name?: string | null
+  assetClass: AssetClass
+  [key: string]: unknown
+}
+
+export async function aggregateSymbolSearch(
+  deps: MarketSearchDeps,
+  query: string,
+  limit = 20,
+): Promise<MarketSearchResult[]> {
+  const q = query.trim()
+  if (!q) return []
+
+  const equityResults = deps.symbolIndex
+    .search(q, limit)
+    .map((r) => ({ ...r, assetClass: 'equity' as const }))
+
+  const commodityResults = deps.commodityCatalog
+    .search(q, limit)
+    .map((r) => ({ ...r, assetClass: 'commodity' as const }))
+
+  const [cryptoSettled, currencySettled] = await Promise.allSettled([
+    deps.cryptoClient.search({ query: q, provider: 'yfinance' }),
+    deps.currencyClient.search({ query: q, provider: 'yfinance' }),
+  ])
+
+  const cryptoResults = (cryptoSettled.status === 'fulfilled' ? cryptoSettled.value : []).map(
+    (r) => ({ ...r, assetClass: 'crypto' as const }),
+  )
+
+  const currencyResults = (currencySettled.status === 'fulfilled' ? currencySettled.value : [])
+    .filter((r) => {
+      const sym = (r as Record<string, unknown>).symbol as string | undefined
+      return sym?.endsWith('USD')
+    })
+    .map((r) => ({ ...r, assetClass: 'currency' as const }))
+
+  return [...equityResults, ...cryptoResults, ...currencyResults, ...commodityResults]
+}

--- a/src/domain/market-data/aggregate-search.ts
+++ b/src/domain/market-data/aggregate-search.ts
@@ -32,6 +32,35 @@ export interface MarketSearchResult {
   [key: string]: unknown
 }
 
+/**
+ * Score a result against the query. Higher is better.
+ * Tiers:
+ *   100  exact match on symbol, id, or name (case-insensitive)
+ *    90  exact match on a commodity alias (e.g. "xau" → gold)
+ *    80  symbol/id starts with the query
+ *    70  name starts with the query (at a word boundary)
+ *    50  name contains the query as a whole word
+ *    30  name contains the query as a substring
+ *    10  fallback — matched upstream but nothing we can explain
+ */
+function matchScore(query: string, r: MarketSearchResult): number {
+  const q = query.toLowerCase()
+  const sym = String(r.symbol ?? r.id ?? '').toLowerCase()
+  const name = String(r.name ?? '').toLowerCase()
+  const aliases = Array.isArray(r.aliases) ? (r.aliases as string[]).map((a) => a.toLowerCase()) : []
+
+  if (sym === q || name === q) return 100
+  if (aliases.includes(q)) return 90
+  if (sym && sym.startsWith(q)) return 80
+  // Name starts with query only counts as a strong match when the match
+  // ends at a word boundary — otherwise "gold" would rank "goldman" above
+  // "SPDR gold trust".
+  if (name.startsWith(q) && (name.length === q.length || !/[a-z0-9]/i.test(name[q.length]))) return 70
+  if (new RegExp(`\\b${q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(name)) return 50
+  if (name.includes(q)) return 30
+  return 10
+}
+
 export async function aggregateSymbolSearch(
   deps: MarketSearchDeps,
   query: string,
@@ -64,5 +93,16 @@ export async function aggregateSymbolSearch(
     })
     .map((r) => ({ ...r, assetClass: 'currency' as const }))
 
-  return [...equityResults, ...cryptoResults, ...currencyResults, ...commodityResults]
+  const all: MarketSearchResult[] = [
+    ...equityResults,
+    ...cryptoResults,
+    ...currencyResults,
+    ...commodityResults,
+  ]
+
+  // Stable sort by match quality descending; ties keep upstream order.
+  return all
+    .map((r, i) => ({ r, i, s: matchScore(q, r) }))
+    .sort((a, b) => b.s - a.s || a.i - b.i)
+    .map((x) => x.r)
 }

--- a/src/domain/trading/UnifiedTradingAccount.spec.ts
+++ b/src/domain/trading/UnifiedTradingAccount.spec.ts
@@ -67,7 +67,7 @@ describe('UTA — operation dispatch', () => {
       order.action = 'BUY'
       order.orderType = 'LMT'
       order.totalQuantity = new Decimal(5)
-      order.lmtPrice = 150
+      order.lmtPrice = new Decimal(150)
 
       uta.git.add({ action: 'placeOrder', contract, order })
       uta.git.commit('limit buy AAPL')
@@ -78,7 +78,7 @@ describe('UTA — operation dispatch', () => {
       expect(passedContract.secType).toBe('STK')
       expect(passedContract.currency).toBe('USD')
       expect(passedContract.exchange).toBe('NASDAQ')
-      expect(passedOrder.lmtPrice).toBe(150)
+      expect(passedOrder.lmtPrice.toNumber()).toBe(150)
     })
 
     it('returns submitted result in push (fill confirmed via sync)', async () => {
@@ -274,34 +274,56 @@ describe('UTA — stagePlaceOrder', () => {
   it('sets cashQty', () => {
     uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', action: 'BUY', orderType: 'MKT', cashQty: 5000 })
     const { order } = getStagedPlaceOrder(uta)
-    expect(order.cashQty).toBe(5000)
+    expect(order.cashQty.toNumber()).toBe(5000)
   })
 
   it('sets lmtPrice and auxPrice', () => {
     uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', action: 'BUY', orderType: 'STP LMT', totalQuantity: 10, lmtPrice: 150, auxPrice: 145 })
     const { order } = getStagedPlaceOrder(uta)
-    expect(order.lmtPrice).toBe(150)
-    expect(order.auxPrice).toBe(145)
+    expect(order.lmtPrice.toNumber()).toBe(150)
+    expect(order.auxPrice.toNumber()).toBe(145)
   })
 
   it('auxPrice sets trailing offset for TRAIL orders', () => {
     uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', action: 'SELL', orderType: 'TRAIL', totalQuantity: 10, auxPrice: 5 })
     const { order } = getStagedPlaceOrder(uta)
-    expect(order.auxPrice).toBe(5)
+    expect(order.auxPrice.toNumber()).toBe(5)
     expect(order.orderType).toBe('TRAIL')
   })
 
   it('TRAIL order with trailStopPrice and auxPrice', () => {
     uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', action: 'SELL', orderType: 'TRAIL', totalQuantity: 10, trailStopPrice: 145, auxPrice: 5 })
     const { order } = getStagedPlaceOrder(uta)
-    expect(order.trailStopPrice).toBe(145)
-    expect(order.auxPrice).toBe(5)
+    expect(order.trailStopPrice.toNumber()).toBe(145)
+    expect(order.auxPrice.toNumber()).toBe(5)
   })
 
   it('sets trailingPercent', () => {
     uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', action: 'SELL', orderType: 'TRAIL', totalQuantity: 10, trailingPercent: 2.5 })
     const { order } = getStagedPlaceOrder(uta)
-    expect(order.trailingPercent).toBe(2.5)
+    expect(order.trailingPercent.toNumber()).toBe(2.5)
+  })
+
+  it('preserves string-input precision for price fields (crypto-scale)', () => {
+    uta.stagePlaceOrder({
+      aliceId: 'mock-paper|ETH', action: 'BUY', orderType: 'LMT',
+      totalQuantity: '0.12345678', lmtPrice: '0.00001234',
+    })
+    const { order } = getStagedPlaceOrder(uta)
+    expect(order.totalQuantity.toFixed()).toBe('0.12345678')
+    expect(order.lmtPrice.toFixed()).toBe('0.00001234')
+  })
+
+  it('JSON round-trips staged price as string (not number)', () => {
+    uta.stagePlaceOrder({
+      aliceId: 'mock-paper|AAPL', action: 'BUY', orderType: 'LMT',
+      totalQuantity: 10, lmtPrice: 145.25,
+    })
+    const wire = JSON.parse(JSON.stringify(uta.status()))
+    const staged = wire.staged[0]
+    expect(typeof staged.order.lmtPrice).toBe('string')
+    expect(staged.order.lmtPrice).toBe('145.25')
+    expect(typeof staged.order.totalQuantity).toBe('string')
   })
 
   it('defaults tif to DAY', () => {
@@ -382,7 +404,7 @@ describe('UTA — stageModifyOrder', () => {
     expect(op.orderId).toBe('ord-1')
     expect(op.changes.totalQuantity).toBeInstanceOf(Decimal)
     expect(op.changes.totalQuantity!.toNumber()).toBe(20)
-    expect(op.changes.lmtPrice).toBe(155)
+    expect(op.changes.lmtPrice!.toNumber()).toBe(155)
     expect(op.changes.orderType).toBe('LMT')
     expect(op.changes.tif).toBe('GTC')
   })
@@ -391,7 +413,7 @@ describe('UTA — stageModifyOrder', () => {
     uta.stageModifyOrder({ orderId: 'ord-1', lmtPrice: 160 })
     const staged = uta.status().staged
     const op = staged[0] as Extract<Operation, { action: 'modifyOrder' }>
-    expect(op.changes.lmtPrice).toBe(160)
+    expect(op.changes.lmtPrice!.toNumber()).toBe(160)
     expect(op.changes.totalQuantity).toBeUndefined()
     expect(op.changes.orderType).toBeUndefined()
     expect(op.changes.tif).toBeUndefined()

--- a/src/domain/trading/UnifiedTradingAccount.ts
+++ b/src/domain/trading/UnifiedTradingAccount.ts
@@ -48,12 +48,12 @@ export interface StagePlaceOrderParams {
   symbol?: string
   action: 'BUY' | 'SELL'
   orderType: string
-  totalQuantity?: number
-  cashQty?: number
-  lmtPrice?: number
-  auxPrice?: number
-  trailStopPrice?: number
-  trailingPercent?: number
+  totalQuantity?: number | string
+  cashQty?: number | string
+  lmtPrice?: number | string
+  auxPrice?: number | string
+  trailStopPrice?: number | string
+  trailingPercent?: number | string
   tif?: string
   goodTillDate?: string
   outsideRth?: boolean
@@ -65,11 +65,11 @@ export interface StagePlaceOrderParams {
 
 export interface StageModifyOrderParams {
   orderId: string
-  totalQuantity?: number
-  lmtPrice?: number
-  auxPrice?: number
-  trailStopPrice?: number
-  trailingPercent?: number
+  totalQuantity?: number | string
+  lmtPrice?: number | string
+  auxPrice?: number | string
+  trailStopPrice?: number | string
+  trailingPercent?: number | string
   orderType?: string
   tif?: string
   goodTillDate?: string
@@ -352,11 +352,11 @@ export class UnifiedTradingAccount {
     order.tif = params.tif ?? 'DAY'
 
     if (params.totalQuantity != null) order.totalQuantity = new Decimal(String(params.totalQuantity))
-    if (params.cashQty != null) order.cashQty = params.cashQty
-    if (params.lmtPrice != null) order.lmtPrice = params.lmtPrice
-    if (params.auxPrice != null) order.auxPrice = params.auxPrice
-    if (params.trailStopPrice != null) order.trailStopPrice = params.trailStopPrice
-    if (params.trailingPercent != null) order.trailingPercent = params.trailingPercent
+    if (params.cashQty != null) order.cashQty = new Decimal(String(params.cashQty))
+    if (params.lmtPrice != null) order.lmtPrice = new Decimal(String(params.lmtPrice))
+    if (params.auxPrice != null) order.auxPrice = new Decimal(String(params.auxPrice))
+    if (params.trailStopPrice != null) order.trailStopPrice = new Decimal(String(params.trailStopPrice))
+    if (params.trailingPercent != null) order.trailingPercent = new Decimal(String(params.trailingPercent))
     if (params.goodTillDate != null) order.goodTillDate = params.goodTillDate
     if (params.outsideRth) order.outsideRth = true
     if (params.parentId != null) order.parentId = parseInt(params.parentId, 10) || 0
@@ -373,10 +373,10 @@ export class UnifiedTradingAccount {
   stageModifyOrder(params: StageModifyOrderParams): AddResult {
     const changes: Partial<Order> = {}
     if (params.totalQuantity != null) changes.totalQuantity = new Decimal(String(params.totalQuantity))
-    if (params.lmtPrice != null) changes.lmtPrice = params.lmtPrice
-    if (params.auxPrice != null) changes.auxPrice = params.auxPrice
-    if (params.trailStopPrice != null) changes.trailStopPrice = params.trailStopPrice
-    if (params.trailingPercent != null) changes.trailingPercent = params.trailingPercent
+    if (params.lmtPrice != null) changes.lmtPrice = new Decimal(String(params.lmtPrice))
+    if (params.auxPrice != null) changes.auxPrice = new Decimal(String(params.auxPrice))
+    if (params.trailStopPrice != null) changes.trailStopPrice = new Decimal(String(params.trailStopPrice))
+    if (params.trailingPercent != null) changes.trailingPercent = new Decimal(String(params.trailingPercent))
     if (params.orderType != null) changes.orderType = params.orderType
     if (params.tif != null) changes.tif = params.tif
     if (params.goodTillDate != null) changes.goodTillDate = params.goodTillDate

--- a/src/domain/trading/__test__/e2e/alpaca-paper.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/alpaca-paper.e2e.spec.ts
@@ -81,7 +81,7 @@ describe('AlpacaBroker — order lifecycle', () => {
     const order = new Order()
     order.action = 'BUY'
     order.orderType = 'LMT'
-    order.lmtPrice = 1.00
+    order.lmtPrice = new Decimal('1.00')
     order.totalQuantity = new Decimal('1')
     order.tif = 'GTC'
 

--- a/src/domain/trading/__test__/e2e/ibkr-paper.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/ibkr-paper.e2e.spec.ts
@@ -131,7 +131,7 @@ describe('IbkrBroker — order lifecycle', () => {
     const order = new Order()
     order.action = 'BUY'
     order.orderType = 'LMT'
-    order.lmtPrice = 1.00
+    order.lmtPrice = new Decimal('1.00')
     order.totalQuantity = new Decimal('1')
     order.tif = 'GTC'
 

--- a/src/domain/trading/__test__/e2e/uta-lifecycle.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/uta-lifecycle.e2e.spec.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import Decimal from 'decimal.js'
 import { UnifiedTradingAccount } from '../../UnifiedTradingAccount.js'
 import { MockBroker } from '../../brokers/mock/index.js'
 import '../../contract-ext.js'
@@ -228,5 +229,54 @@ describe('UTA — precision end-to-end', () => {
 
     const positions = await broker.getPositions()
     expect(positions[0].quantity.toString()).toBe('0.7')
+  })
+
+  it('lmtPrice preserves string-input precision stage → push', async () => {
+    broker.setQuote('ETH', 1920)
+    uta.stagePlaceOrder({
+      aliceId: 'mock-paper|ETH', symbol: 'ETH', action: 'BUY', orderType: 'LMT',
+      totalQuantity: '0.12345678', lmtPrice: '0.00001234',
+    })
+    uta.commit('buy ETH limit precise')
+    const result = await uta.push()
+
+    expect(result.submitted).toHaveLength(1)
+    const orderId = result.submitted[0].orderId!
+    const orders = await broker.getOrders([orderId])
+    expect(orders).toHaveLength(1)
+    expect(orders[0].order.lmtPrice.toFixed()).toBe('0.00001234')
+    expect(orders[0].order.totalQuantity.toFixed()).toBe('0.12345678')
+  })
+
+  it('wallet status JSON emits price as string (no IEEE noise)', async () => {
+    broker.setQuote('AAPL', 150)
+    uta.stagePlaceOrder({
+      aliceId: 'mock-paper|AAPL', symbol: 'AAPL', action: 'BUY', orderType: 'LMT',
+      totalQuantity: 10, lmtPrice: 145.25,
+    })
+    // Status before commit — staged ops only
+    const wire = JSON.parse(JSON.stringify(uta.status()))
+    const staged = wire.staged[0]
+    expect(typeof staged.order.lmtPrice).toBe('string')
+    expect(staged.order.lmtPrice).toBe('145.25')
+    expect(typeof staged.order.totalQuantity).toBe('string')
+    expect(staged.order.totalQuantity).toBe('10')
+  })
+
+  it('clean string input stays clean through the full pipeline', async () => {
+    // String input '0.3' bypasses the IEEE 754 trap that `0.1 + 0.2`
+    // introduces at the JS-number layer. Decimal preserves the clean value
+    // all the way to the broker.
+    broker.setQuote('AAPL', 150)
+    uta.stagePlaceOrder({
+      aliceId: 'mock-paper|AAPL', symbol: 'AAPL', action: 'BUY', orderType: 'LMT',
+      totalQuantity: 100, lmtPrice: '0.3',
+    })
+    uta.commit('clean price')
+    const result = await uta.push()
+    const orderId = result.submitted[0].orderId!
+    const orders = await broker.getOrders([orderId])
+    expect(orders[0].order.lmtPrice.equals(new Decimal('0.3'))).toBe(true)
+    expect(orders[0].order.lmtPrice.toFixed()).toBe('0.3')
   })
 })

--- a/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
+++ b/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Decimal from 'decimal.js'
-import { Contract, Order, UNSET_DOUBLE } from '@traderalice/ibkr'
+import { Contract, Order } from '@traderalice/ibkr'
 import { AlpacaBroker } from './AlpacaBroker.js'
 import '../../contract-ext.js'
 
@@ -159,7 +159,31 @@ describe('AlpacaBroker — precision', () => {
 
     await acc.placeOrder(contract, order)
     const passedQty = (acc as any).client.createOrder.mock.calls[0][0].qty
-    expect(passedQty).toBe(10.5)
+    // Alpaca REST receives qty as a decimal string — preserves precision
+    // across the wire and avoids IEEE 754 noise.
+    expect(passedQty).toBe('10.5')
+  })
+
+  it('placeOrder preserves precision across IEEE trap values', async () => {
+    const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
+    ;(acc as any).client = {
+      createOrder: vi.fn().mockResolvedValue({ id: 'ord-p', status: 'new' }),
+    }
+    const contract = new Contract()
+    contract.aliceId = 'alpaca-paper|AAPL'
+    contract.symbol = 'AAPL'
+    contract.secType = 'STK'
+    contract.exchange = 'NASDAQ'
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal('0.00001234')
+    order.lmtPrice = new Decimal('0.1').plus('0.2')
+
+    await acc.placeOrder(contract, order)
+    const payload = (acc as any).client.createOrder.mock.calls[0][0]
+    expect(payload.qty).toBe('0.00001234')
+    expect(payload.limit_price).toBe('0.3')
   })
 })
 
@@ -235,17 +259,16 @@ describe('AlpacaBroker — modifyOrder()', () => {
 
     const changes = new Order()
     changes.totalQuantity = new Decimal(20)
-    changes.lmtPrice = 155.50
-    changes.auxPrice = UNSET_DOUBLE
-    changes.trailingPercent = UNSET_DOUBLE
+    changes.lmtPrice = new Decimal('155.50')
+    // auxPrice and trailingPercent left at their defaults (UNSET_DECIMAL)
     changes.tif = 'GTC'
 
     const result = await acc.modifyOrder('ord-1', changes)
     expect(result.success).toBe(true)
     expect(result.orderId).toBe('ord-modified')
     expect(replaceOrder).toHaveBeenCalledWith('ord-1', {
-      qty: 20,
-      limit_price: 155.50,
+      qty: '20',
+      limit_price: '155.5',
       time_in_force: 'gtc',
     })
   })
@@ -258,9 +281,7 @@ describe('AlpacaBroker — modifyOrder()', () => {
 
     const changes = new Order()
     changes.totalQuantity = new Decimal(5)
-    changes.lmtPrice = UNSET_DOUBLE
-    changes.auxPrice = UNSET_DOUBLE
-    changes.trailingPercent = UNSET_DOUBLE
+    // lmtPrice/auxPrice/trailingPercent left at UNSET_DECIMAL defaults
     changes.tif = ''
 
     const result = await acc.modifyOrder('ord-999', changes)
@@ -285,8 +306,8 @@ describe('AlpacaBroker — modifyOrder null-check', () => {
     await acc.modifyOrder('ord-1', changes)
     const patch = replaceOrder.mock.calls[0][1]
 
-    expect(patch.qty).toBe(20)
-    // These should NOT be in the patch — they were undefined, not UNSET_DOUBLE
+    expect(patch.qty).toBe('20')
+    // These should NOT be in the patch — they were undefined in changes
     expect(patch).not.toHaveProperty('limit_price')
     expect(patch).not.toHaveProperty('stop_price')
     expect(patch).not.toHaveProperty('trail')
@@ -297,12 +318,12 @@ describe('AlpacaBroker — modifyOrder null-check', () => {
     const replaceOrder = vi.fn().mockResolvedValue({ id: 'ord-mod', status: 'accepted' })
     ;(acc as any).client = { replaceOrder }
 
-    const changes: Partial<Order> = { lmtPrice: 155.50 }
+    const changes: Partial<Order> = { lmtPrice: new Decimal('155.50') }
 
     await acc.modifyOrder('ord-1', changes)
     const patch = replaceOrder.mock.calls[0][1]
 
-    expect(patch.limit_price).toBe(155.50)
+    expect(patch.limit_price).toBe('155.5')
     expect(patch).not.toHaveProperty('stop_price')
     expect(patch).not.toHaveProperty('trail')
   })
@@ -312,12 +333,12 @@ describe('AlpacaBroker — modifyOrder null-check', () => {
     const replaceOrder = vi.fn().mockResolvedValue({ id: 'ord-mod', status: 'accepted' })
     ;(acc as any).client = { replaceOrder }
 
-    const changes: Partial<Order> = { auxPrice: 140 }
+    const changes: Partial<Order> = { auxPrice: new Decimal(140) }
 
     await acc.modifyOrder('ord-1', changes)
     const patch = replaceOrder.mock.calls[0][1]
 
-    expect(patch.stop_price).toBe(140)
+    expect(patch.stop_price).toBe('140')
     expect(patch).not.toHaveProperty('limit_price')
   })
 })
@@ -406,7 +427,7 @@ describe('AlpacaBroker — closePosition()', () => {
         symbol: 'AAPL',
         side: 'sell',
         type: 'market',
-        qty: 3,
+        qty: '3',
       }),
     )
   })

--- a/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -11,7 +11,7 @@
 import { z } from 'zod'
 import Alpaca from '@alpacahq/alpaca-trade-api'
 import Decimal from 'decimal.js'
-import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DOUBLE, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL } from '@traderalice/ibkr'
 import {
   BrokerError,
   type IBroker,
@@ -193,23 +193,25 @@ export class AlpacaBroker implements IBroker {
       }
 
       // Quantity: totalQuantity or cashQty (notional)
+      // Alpaca REST accepts numeric strings — preferred over .toNumber()
+      // to avoid IEEE 754 noise for satoshi-scale values.
       if (!order.totalQuantity.equals(UNSET_DECIMAL)) {
-        alpacaOrder.qty = parseFloat(order.totalQuantity.toString())
-      } else if (order.cashQty !== UNSET_DOUBLE) {
-        alpacaOrder.notional = order.cashQty
+        alpacaOrder.qty = order.totalQuantity.toFixed()
+      } else if (!order.cashQty.equals(UNSET_DECIMAL)) {
+        alpacaOrder.notional = order.cashQty.toFixed()
       }
 
       // Prices
-      if (order.lmtPrice !== UNSET_DOUBLE) alpacaOrder.limit_price = order.lmtPrice
-      if (order.auxPrice !== UNSET_DOUBLE) {
+      if (!order.lmtPrice.equals(UNSET_DECIMAL)) alpacaOrder.limit_price = order.lmtPrice.toFixed()
+      if (!order.auxPrice.equals(UNSET_DECIMAL)) {
         // auxPrice is stop price for STP, trailing offset for TRAIL
         if (order.orderType === 'TRAIL') {
-          alpacaOrder.trail_price = order.auxPrice
+          alpacaOrder.trail_price = order.auxPrice.toFixed()
         } else {
-          alpacaOrder.stop_price = order.auxPrice
+          alpacaOrder.stop_price = order.auxPrice.toFixed()
         }
       }
-      if (order.trailingPercent !== UNSET_DOUBLE) alpacaOrder.trail_percent = order.trailingPercent
+      if (!order.trailingPercent.equals(UNSET_DECIMAL)) alpacaOrder.trail_percent = order.trailingPercent.toFixed()
       if (order.outsideRth) alpacaOrder.extended_hours = true
 
       // Bracket order (TPSL)
@@ -240,10 +242,10 @@ export class AlpacaBroker implements IBroker {
   async modifyOrder(orderId: string, changes: Partial<Order>): Promise<PlaceOrderResult> {
     try {
       const patch: Record<string, unknown> = {}
-      if (changes.totalQuantity != null && !changes.totalQuantity.equals(UNSET_DECIMAL)) patch.qty = parseFloat(changes.totalQuantity.toString())
-      if (changes.lmtPrice != null && changes.lmtPrice !== UNSET_DOUBLE) patch.limit_price = changes.lmtPrice
-      if (changes.auxPrice != null && changes.auxPrice !== UNSET_DOUBLE) patch.stop_price = changes.auxPrice
-      if (changes.trailingPercent != null && changes.trailingPercent !== UNSET_DOUBLE) patch.trail = changes.trailingPercent
+      if (changes.totalQuantity != null && !changes.totalQuantity.equals(UNSET_DECIMAL)) patch.qty = changes.totalQuantity.toFixed()
+      if (changes.lmtPrice != null && !changes.lmtPrice.equals(UNSET_DECIMAL)) patch.limit_price = changes.lmtPrice.toFixed()
+      if (changes.auxPrice != null && !changes.auxPrice.equals(UNSET_DECIMAL)) patch.stop_price = changes.auxPrice.toFixed()
+      if (changes.trailingPercent != null && !changes.trailingPercent.equals(UNSET_DECIMAL)) patch.trail = changes.trailingPercent.toFixed()
       if (changes.tif) patch.time_in_force = ibkrTifToAlpaca(changes.tif)
 
       const result = await this.client.replaceOrder(orderId, patch) as AlpacaOrderRaw
@@ -432,8 +434,8 @@ export class AlpacaBroker implements IBroker {
     order.action = o.side.toUpperCase() // buy → BUY
     order.totalQuantity = new Decimal(o.qty ?? o.notional ?? '0')
     order.orderType = (o.type ?? 'market').toUpperCase()
-    if (o.limit_price) order.lmtPrice = parseFloat(o.limit_price)
-    if (o.stop_price) order.auxPrice = parseFloat(o.stop_price)
+    if (o.limit_price) order.lmtPrice = new Decimal(o.limit_price)
+    if (o.stop_price) order.auxPrice = new Decimal(o.stop_price)
     if (o.time_in_force) order.tif = o.time_in_force.toUpperCase()
     if (o.extended_hours) order.outsideRth = true
     // Alpaca order IDs are UUIDs — IBKR's orderId field is number, so leave at default 0.

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
@@ -211,7 +211,7 @@ describe('CcxtBroker — placeOrder notional', () => {
     const order = new Order()
     order.action = 'BUY'
     order.orderType = 'MKT'
-    order.cashQty = 500 // $500 worth of BTC
+    order.cashQty = new Decimal(500) // $500 worth of BTC
 
     const result = await acc.placeOrder(contract, order)
 
@@ -542,7 +542,7 @@ describe('CcxtBroker — placeOrder qty-based', () => {
     order.action = 'SELL'
     order.orderType = 'LMT'
     order.totalQuantity = new Decimal(1.0)
-    order.lmtPrice = 65000
+    order.lmtPrice = new Decimal(65000)
 
     const result = await acc.placeOrder(makeContract(), order)
     expect(result.success).toBe(true)
@@ -588,7 +588,7 @@ describe('CcxtBroker — modifyOrder', () => {
 
     const changes = new Order()
     changes.totalQuantity = new Decimal(0.75)
-    changes.lmtPrice = 62000
+    changes.lmtPrice = new Decimal(62000)
     changes.orderType = 'LMT'
 
     const result = await acc.modifyOrder('ord-100', changes)
@@ -649,7 +649,7 @@ describe('CcxtBroker — modifyOrder field forwarding', () => {
     })
     ;(acc as any).exchange.editOrder = vi.fn().mockResolvedValue({ id: 'ord-300-edited', status: 'open' })
 
-    const changes: Partial<Order> = { auxPrice: 1850 }
+    const changes: Partial<Order> = { auxPrice: new Decimal(1850) }
 
     await acc.modifyOrder('ord-300', changes)
     const call = (acc as any).exchange.editOrder.mock.calls[0]

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -10,7 +10,7 @@ import { z } from 'zod'
 import ccxt from 'ccxt'
 import Decimal from 'decimal.js'
 import type { Exchange, Order as CcxtOrder } from 'ccxt'
-import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DOUBLE, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL } from '@traderalice/ibkr'
 import {
   BrokerError,
   type IBroker,
@@ -332,19 +332,22 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       return { success: false, error: 'Cannot resolve contract to CCXT symbol' }
     }
 
-    // Use toString() to preserve Decimal precision — never go through IEEE 754 float
+    // Use toFixed() to preserve Decimal precision across any scale.
+    // toString() would emit scientific notation for small values.
     let size: string | undefined = !order.totalQuantity.equals(UNSET_DECIMAL)
-      ? order.totalQuantity.toString()
+      ? order.totalQuantity.toFixed()
       : undefined
 
     // cashQty (notional) → size conversion
-    if (!size && order.cashQty !== UNSET_DOUBLE && order.cashQty > 0) {
+    if (!size && !order.cashQty.equals(UNSET_DECIMAL) && order.cashQty.gt(0)) {
       const ticker = await this.exchange.fetchTicker(ccxtSymbol)
-      const price = order.lmtPrice !== UNSET_DOUBLE ? order.lmtPrice : ticker.last
-      if (!price) {
+      const price = !order.lmtPrice.equals(UNSET_DECIMAL)
+        ? order.lmtPrice
+        : ticker.last != null ? new Decimal(ticker.last) : null
+      if (!price || price.isZero()) {
         return { success: false, error: 'Cannot determine price for notional conversion' }
       }
-      size = String(order.cashQty / price)
+      size = order.cashQty.div(price).toFixed()
     }
 
     if (!size) {
@@ -366,8 +369,9 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
 
       const ccxtOrderType = ibkrOrderTypeToCcxt(order.orderType)
       const side = order.action.toLowerCase() as 'buy' | 'sell'
-      const refPrice = ccxtOrderType === 'limit' && order.lmtPrice !== UNSET_DOUBLE
-        ? order.lmtPrice
+      // CCXT SDK expects number for price — convert at the wire boundary.
+      const refPrice = ccxtOrderType === 'limit' && !order.lmtPrice.equals(UNSET_DECIMAL)
+        ? order.lmtPrice.toNumber()
         : undefined
 
       const placeOverride = this.overrides.placeOrder
@@ -423,14 +427,14 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       const original = fetchOverride
         ? await fetchOverride(this.exchange, orderId, ccxtSymbol, defaultFetchOrderById)
         : await defaultFetchOrderById(this.exchange, orderId, ccxtSymbol)
-      const qty = changes.totalQuantity != null && !changes.totalQuantity.equals(UNSET_DECIMAL) ? parseFloat(changes.totalQuantity.toString()) : original.amount
-      const price = changes.lmtPrice != null && changes.lmtPrice !== UNSET_DOUBLE ? changes.lmtPrice : original.price
+      const qty = changes.totalQuantity != null && !changes.totalQuantity.equals(UNSET_DECIMAL) ? changes.totalQuantity.toNumber() : original.amount
+      const price = changes.lmtPrice != null && !changes.lmtPrice.equals(UNSET_DECIMAL) ? changes.lmtPrice.toNumber() : original.price
 
       // Extra params for fields that don't fit editOrder's positional arguments
       const params: Record<string, unknown> = {}
-      if (changes.auxPrice != null && changes.auxPrice !== UNSET_DOUBLE) params.stopPrice = changes.auxPrice
-      if (changes.trailStopPrice != null && changes.trailStopPrice !== UNSET_DOUBLE) params.trailStopPrice = changes.trailStopPrice
-      if (changes.trailingPercent != null && changes.trailingPercent !== UNSET_DOUBLE) params.trailingPercent = changes.trailingPercent
+      if (changes.auxPrice != null && !changes.auxPrice.equals(UNSET_DECIMAL)) params.stopPrice = changes.auxPrice.toNumber()
+      if (changes.trailStopPrice != null && !changes.trailStopPrice.equals(UNSET_DECIMAL)) params.trailStopPrice = changes.trailStopPrice.toNumber()
+      if (changes.trailingPercent != null && !changes.trailingPercent.equals(UNSET_DECIMAL)) params.trailingPercent = changes.trailingPercent.toNumber()
       if (changes.tif) params.timeInForce = changes.tif.toLowerCase()
 
       const result = await this.exchange.editOrder(
@@ -618,7 +622,7 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
     order.action = (o.side ?? 'buy').toUpperCase()
     order.totalQuantity = new Decimal(o.amount ?? 0)
     order.orderType = (o.type ?? 'market').toUpperCase()
-    if (o.price != null) order.lmtPrice = o.price
+    if (o.price != null) order.lmtPrice = new Decimal(o.price)
     order.orderId = parseInt(o.id, 10) || 0
 
     const tp = o.takeProfitPrice

--- a/src/domain/trading/brokers/mock/MockBroker.spec.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.spec.ts
@@ -107,7 +107,7 @@ describe('placeOrder', () => {
     order.action = 'BUY'
     order.orderType = 'LMT'
     order.totalQuantity = new Decimal(10)
-    order.lmtPrice = 140
+    order.lmtPrice = new Decimal(140)
 
     const result = await broker.placeOrder(contract, order)
     expect(result.success).toBe(true)
@@ -209,7 +209,7 @@ describe('cancelOrder', () => {
     order.action = 'BUY'
     order.orderType = 'LMT'
     order.totalQuantity = new Decimal(10)
-    order.lmtPrice = 140
+    order.lmtPrice = new Decimal(140)
 
     const placed = await broker.placeOrder(contract, order)
     const cancelled = await broker.cancelOrder(placed.orderId!)
@@ -237,19 +237,19 @@ describe('modifyOrder', () => {
     order.action = 'BUY'
     order.orderType = 'LMT'
     order.totalQuantity = new Decimal(10)
-    order.lmtPrice = 140
+    order.lmtPrice = new Decimal(140)
 
     const placed = await broker.placeOrder(contract, order)
 
     const changes = new Order()
     changes.totalQuantity = new Decimal(20)
-    changes.lmtPrice = 145
+    changes.lmtPrice = new Decimal(145)
     const modified = await broker.modifyOrder(placed.orderId!, changes)
     expect(modified.success).toBe(true)
 
     const brokerOrder = await broker.getOrder(placed.orderId!)
     expect(brokerOrder!.order.totalQuantity.toNumber()).toBe(20)
-    expect(brokerOrder!.order.lmtPrice).toBe(145)
+    expect(brokerOrder!.order.lmtPrice.toNumber()).toBe(145)
   })
 
   it('returns error for unknown order', async () => {
@@ -269,7 +269,7 @@ describe('getOrder', () => {
     order.action = 'BUY'
     order.orderType = 'LMT'
     order.totalQuantity = new Decimal(10)
-    order.lmtPrice = 140
+    order.lmtPrice = new Decimal(140)
 
     const placed = await broker.placeOrder(contract, order)
     const found = await broker.getOrder(placed.orderId!)
@@ -292,7 +292,7 @@ describe('fillPendingOrder', () => {
     order.action = 'BUY'
     order.orderType = 'LMT'
     order.totalQuantity = new Decimal(10)
-    order.lmtPrice = 140
+    order.lmtPrice = new Decimal(140)
 
     const placed = await broker.placeOrder(contract, order)
     broker.fillPendingOrder(placed.orderId!, 139.50)

--- a/src/domain/trading/brokers/mock/MockBroker.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.ts
@@ -10,7 +10,7 @@
 
 import { z } from 'zod'
 import Decimal from 'decimal.js'
-import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL, UNSET_DOUBLE } from '@traderalice/ibkr'
+import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL } from '@traderalice/ibkr'
 import type {
   IBroker,
   AccountCapabilities,
@@ -275,16 +275,16 @@ export class MockBroker implements IBroker {
     if (changes.totalQuantity != null && !changes.totalQuantity.equals(UNSET_DECIMAL)) {
       internal.order.totalQuantity = changes.totalQuantity
     }
-    if (changes.lmtPrice != null && changes.lmtPrice !== UNSET_DOUBLE) {
+    if (changes.lmtPrice != null && !changes.lmtPrice.equals(UNSET_DECIMAL)) {
       internal.order.lmtPrice = changes.lmtPrice
     }
-    if (changes.auxPrice != null && changes.auxPrice !== UNSET_DOUBLE) {
+    if (changes.auxPrice != null && !changes.auxPrice.equals(UNSET_DECIMAL)) {
       internal.order.auxPrice = changes.auxPrice
     }
-    if (changes.trailStopPrice != null && changes.trailStopPrice !== UNSET_DOUBLE) {
+    if (changes.trailStopPrice != null && !changes.trailStopPrice.equals(UNSET_DECIMAL)) {
       internal.order.trailStopPrice = changes.trailStopPrice
     }
-    if (changes.trailingPercent != null && changes.trailingPercent !== UNSET_DOUBLE) {
+    if (changes.trailingPercent != null && !changes.trailingPercent.equals(UNSET_DECIMAL)) {
       internal.order.trailingPercent = changes.trailingPercent
     }
     if (changes.orderType) internal.order.orderType = changes.orderType
@@ -540,8 +540,8 @@ export class MockBroker implements IBroker {
     o.orderType = order.orderType
     o.totalQuantity = order.totalQuantity
     o.tif = order.tif
-    if (order.lmtPrice !== UNSET_DOUBLE) o.lmtPrice = order.lmtPrice
-    if (order.auxPrice !== UNSET_DOUBLE) o.auxPrice = order.auxPrice
+    if (!order.lmtPrice.equals(UNSET_DECIMAL)) o.lmtPrice = order.lmtPrice
+    if (!order.auxPrice.equals(UNSET_DECIMAL)) o.auxPrice = order.auxPrice
     o.orderId = parseInt(orderId.replace('mock-ord-', ''), 10) || 0
     return o
   }

--- a/src/domain/trading/git/TradingGit.spec.ts
+++ b/src/domain/trading/git/TradingGit.spec.ts
@@ -447,6 +447,60 @@ describe('TradingGit', () => {
       expect(log).toHaveLength(1)
       expect(log[0].message).toBe('Buy AAPL')
     })
+
+    it('rehydrates Decimal price fields through JSON round-trip', async () => {
+      const contract = makeContract({ symbol: 'ETH' })
+      const order = new Order()
+      order.action = 'BUY'
+      order.orderType = 'LMT'
+      order.totalQuantity = new Decimal('0.12345678')
+      order.lmtPrice = new Decimal('0.00001234')
+      order.auxPrice = new Decimal('0.3')
+      order.trailStopPrice = new Decimal('145.5')
+      order.trailingPercent = new Decimal('2.5')
+      order.cashQty = new Decimal('1000')
+      git.add({ action: 'placeOrder', contract, order })
+      git.commit('precise eth order')
+      await git.push()
+
+      // Simulate persist → reload by going through JSON.
+      const exported = JSON.parse(JSON.stringify(git.exportState()))
+      const restored = TradingGit.restore(exported, config)
+      const commit = restored.show(restored.status().head!)
+      const op = commit!.operations[0] as Extract<Operation, { action: 'placeOrder' }>
+      expect(op.order.totalQuantity).toBeInstanceOf(Decimal)
+      expect(op.order.totalQuantity.toFixed()).toBe('0.12345678')
+      expect(op.order.lmtPrice).toBeInstanceOf(Decimal)
+      expect(op.order.lmtPrice.toFixed()).toBe('0.00001234')
+      expect(op.order.auxPrice.toFixed()).toBe('0.3')
+      expect(op.order.trailStopPrice.toFixed()).toBe('145.5')
+      expect(op.order.trailingPercent.toFixed()).toBe('2.5')
+      expect(op.order.cashQty.toFixed()).toBe('1000')
+    })
+
+    it('rehydrates legacy number-typed price fields to Decimal', async () => {
+      // Simulate an older persisted file where price fields were JSON numbers.
+      const contract = makeContract({ symbol: 'AAPL' })
+      const order = new Order()
+      order.action = 'BUY'
+      order.orderType = 'LMT'
+      order.totalQuantity = new Decimal(10)
+      order.lmtPrice = new Decimal(145.25)
+      git.add({ action: 'placeOrder', contract, order })
+      git.commit('legacy order')
+      await git.push()
+
+      const exported = git.exportState()
+      // Tamper: rewrite lmtPrice as a bare number in the serialised form.
+      const raw = JSON.parse(JSON.stringify(exported)) as typeof exported
+      const committedOp = raw.commits[0].operations[0] as Extract<Operation, { action: 'placeOrder' }>
+      ;(committedOp.order as unknown as { lmtPrice: number }).lmtPrice = 145.25
+      const restored = TradingGit.restore(raw, config)
+      const commit = restored.show(restored.status().head!)
+      const op = commit!.operations[0] as Extract<Operation, { action: 'placeOrder' }>
+      expect(op.order.lmtPrice).toBeInstanceOf(Decimal)
+      expect(op.order.lmtPrice.toNumber()).toBe(145.25)
+    })
   })
 
   // ==================== setCurrentRound ====================

--- a/src/domain/trading/git/TradingGit.ts
+++ b/src/domain/trading/git/TradingGit.ts
@@ -6,7 +6,7 @@
 
 import { createHash } from 'crypto'
 import Decimal from 'decimal.js'
-import { Order, UNSET_DOUBLE, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { Order, UNSET_DECIMAL } from '@traderalice/ibkr'
 import type { ITradingGit, TradingGitConfig } from './interfaces.js'
 import type {
   CommitHash,
@@ -241,8 +241,8 @@ export class TradingGit implements ITradingGit {
         const qty = op.order?.totalQuantity
         const cashQty = op.order?.cashQty
         const hasQty = qty && !qty.equals(UNSET_DECIMAL)
-        const hasCash = cashQty !== UNSET_DOUBLE && cashQty > 0
-        const sizeStr = hasCash ? `$${cashQty}` : hasQty ? `${qty}` : '?'
+        const hasCash = cashQty && !cashQty.equals(UNSET_DECIMAL) && cashQty.gt(0)
+        const sizeStr = hasCash ? `$${cashQty.toFixed()}` : hasQty ? `${qty.toFixed()}` : '?'
 
         if (result?.status === 'user-rejected') {
           return `${side} ${sizeStr} (user-rejected)`
@@ -336,9 +336,26 @@ export class TradingGit implements ITradingGit {
 
   private static rehydrateOrder(order: Order): Order {
     const rehydrated = Object.assign(new Order(), order)
-    // totalQuantity is the critical Decimal field on Order
+    // Decimal fields need re-wrapping after JSON.parse — strings or numbers
+    // become plain JS values, not Decimal instances. `new Decimal(String(x))`
+    // accepts both legacy (number) and current (string) persisted forms.
     if (order.totalQuantity != null) {
       rehydrated.totalQuantity = new Decimal(String(order.totalQuantity))
+    }
+    if (order.lmtPrice != null) {
+      rehydrated.lmtPrice = new Decimal(String(order.lmtPrice))
+    }
+    if (order.auxPrice != null) {
+      rehydrated.auxPrice = new Decimal(String(order.auxPrice))
+    }
+    if (order.trailStopPrice != null) {
+      rehydrated.trailStopPrice = new Decimal(String(order.trailStopPrice))
+    }
+    if (order.trailingPercent != null) {
+      rehydrated.trailingPercent = new Decimal(String(order.trailingPercent))
+    }
+    if (order.cashQty != null) {
+      rehydrated.cashQty = new Decimal(String(order.cashQty))
     }
     return rehydrated
   }

--- a/src/domain/trading/guards/guards.spec.ts
+++ b/src/domain/trading/guards/guards.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Decimal from 'decimal.js'
-import { Contract, Order, UNSET_DOUBLE, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { Contract, Order, UNSET_DECIMAL } from '@traderalice/ibkr'
 import { MaxPositionSizeGuard } from './max-position-size.js'
 import { CooldownGuard } from './cooldown.js'
 import { SymbolWhitelistGuard } from './symbol-whitelist.js'
@@ -27,7 +27,7 @@ function makePlaceOrderOp(overrides: {
   order.orderType = overrides.orderType ?? 'MKT'
   order.totalQuantity = overrides.totalQuantity ?? new Decimal(10)
   if (overrides.cashQty != null) {
-    order.cashQty = overrides.cashQty
+    order.cashQty = new Decimal(overrides.cashQty)
   }
   return { action: 'placeOrder', contract, order }
 }

--- a/src/domain/trading/guards/max-position-size.ts
+++ b/src/domain/trading/guards/max-position-size.ts
@@ -1,5 +1,5 @@
 import Decimal from 'decimal.js'
-import { UNSET_DOUBLE, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { UNSET_DECIMAL } from '@traderalice/ibkr'
 import type { OperationGuard, GuardContext } from './types.js'
 
 const DEFAULT_MAX_PERCENT = 25
@@ -23,12 +23,12 @@ export class MaxPositionSizeGuard implements OperationGuard {
 
     // Estimate added value from IBKR Order fields
     const { order } = operation
-    const cashQty = order.cashQty !== UNSET_DOUBLE ? order.cashQty : undefined
+    const cashQty = !order.cashQty.equals(UNSET_DECIMAL) ? order.cashQty : undefined
     const qty = !order.totalQuantity.equals(UNSET_DECIMAL) ? order.totalQuantity : undefined
 
     let addedValue = new Decimal(0)
-    if (cashQty && cashQty > 0) {
-      addedValue = new Decimal(cashQty)
+    if (cashQty && cashQty.gt(0)) {
+      addedValue = cashQty
     } else if (qty && existing) {
       addedValue = qty.mul(existing.marketPrice)
     }

--- a/src/domain/trading/snapshot/snapshot.spec.ts
+++ b/src/domain/trading/snapshot/snapshot.spec.ts
@@ -42,7 +42,7 @@ function makeSubmittedOrder(symbol = 'AAPL'): ReturnType<typeof makeOpenOrder> {
   order.action = 'BUY'
   order.orderType = 'LMT'
   order.totalQuantity = new Decimal(5)
-  order.lmtPrice = 150
+  order.lmtPrice = new Decimal(150)
   const orderState = new OrderState()
   orderState.status = 'Submitted'
   return { contract, order, orderState }
@@ -114,7 +114,7 @@ describe('Snapshot Builder', () => {
     order.action = 'BUY'
     order.orderType = 'LMT'
     order.totalQuantity = new Decimal(5)
-    order.lmtPrice = 140
+    order.lmtPrice = new Decimal(140)
     order.tif = 'DAY'
 
     uta.git.add({ action: 'placeOrder', contract, order })

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,6 @@ import { OpenBBEquityClient } from './domain/market-data/client/openbb-api/equit
 import { OpenBBCryptoClient } from './domain/market-data/client/openbb-api/crypto-client.js'
 import { OpenBBCurrencyClient } from './domain/market-data/client/openbb-api/currency-client.js'
 import { OpenBBCommodityClient } from './domain/market-data/client/openbb-api/commodity-client.js'
-import { OpenBBServerPlugin } from './server/opentypebb.js'
 import { createMarketSearchTools } from './tool/market.js'
 import { createAnalysisTools } from './tool/analysis.js'
 import { createSessionTools } from './tool/session.js'
@@ -201,8 +200,6 @@ async function main() {
     derivativesClient = new SDKDerivativesClient(executor, 'derivatives', providers.equity, credentials, routeMap)
   }
 
-  // OpenBB API server is started later via optionalPlugins
-
   // ==================== FX Service ====================
 
   const fxService = new FxService(currencyClient)
@@ -354,10 +351,6 @@ async function main() {
     }))
   }
 
-  if (config.marketData.apiServer.enabled) {
-    optionalPlugins.set('openbb-server', new OpenBBServerPlugin({ port: config.marketData.apiServer.port }))
-  }
-
   // ==================== Connector Reconnect ====================
 
   let connectorsReconnecting = false
@@ -397,30 +390,6 @@ async function main() {
         await p.start(ctx)
         optionalPlugins.set('telegram', p)
         changes.push('telegram started')
-      }
-
-      // --- OpenBB API Server ---
-      const openbbWanted = fresh.marketData.apiServer.enabled
-      const openbbRunning = optionalPlugins.has('openbb-server')
-      if (openbbRunning && !openbbWanted) {
-        await optionalPlugins.get('openbb-server')!.stop()
-        optionalPlugins.delete('openbb-server')
-        changes.push('openbb-server stopped')
-      } else if (!openbbRunning && openbbWanted) {
-        const p = new OpenBBServerPlugin({ port: fresh.marketData.apiServer.port })
-        await p.start(ctx)
-        optionalPlugins.set('openbb-server', p)
-        changes.push('openbb-server started')
-      } else if (openbbRunning && openbbWanted) {
-        const current = optionalPlugins.get('openbb-server') as OpenBBServerPlugin
-        if (current.port !== fresh.marketData.apiServer.port) {
-          await current.stop()
-          optionalPlugins.delete('openbb-server')
-          const p = new OpenBBServerPlugin({ port: fresh.marketData.apiServer.port })
-          await p.start(ctx)
-          optionalPlugins.set('openbb-server', p)
-          changes.push(`openbb-server restarted on port ${fresh.marketData.apiServer.port}`)
-        }
       }
 
       if (changes.length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -213,6 +213,8 @@ async function main() {
   const commodityCatalog = new CommodityCatalog()
   commodityCatalog.load()
 
+  const marketSearch = { symbolIndex, cryptoClient, currencyClient, commodityCatalog }
+
   // ==================== Tool Registration ====================
 
   toolCenter.register(createThinkingTools(), 'thinking')
@@ -226,7 +228,7 @@ async function main() {
   toolCenter.register(createBrainTools(brain), 'brain')
   toolCenter.register(createBrowserTools(), 'browser')
   toolCenter.register(createCronTools(cronEngine), 'cron')
-  toolCenter.register(createMarketSearchTools(symbolIndex, cryptoClient, currencyClient, commodityCatalog), 'market-search')
+  toolCenter.register(createMarketSearchTools(marketSearch), 'market-search')
   toolCenter.register(createEquityTools(equityClient), 'equity')
   if (config.news.enabled) {
     toolCenter.register(createNewsArchiveTools(newsStore), 'news')
@@ -412,6 +414,7 @@ async function main() {
     listenerRegistry,
     fire: createEventBus(eventLog),
     bbEngine: getSDKExecutor(),
+    marketSearch,
     accountManager, fxService, snapshotService,
     newsProvider: newsStore,
     reconnectConnectors,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, appendFile, mkdir } from 'fs/promises'
+import { readFile, writeFile, mkdir } from 'fs/promises'
 import { resolve, dirname } from 'path'
 // Engine removed — AgentCenter is the top-level AI entry point
 import { loadConfig, readAccountsConfig } from './core/config.js'
@@ -53,13 +53,24 @@ import { createNewsArchiveTools } from './tool/news.js'
 const BRAIN_FILE = resolve('data/brain/commit.json')
 
 const FRONTAL_LOBE_FILE = resolve('data/brain/frontal-lobe.md')
-const EMOTION_LOG_FILE = resolve('data/brain/emotion-log.md')
 const PERSONA_FILE = resolve('data/brain/persona.md')
 const PERSONA_DEFAULT = resolve('default/persona.default.md')
 const HEARTBEAT_FILE = resolve('data/brain/heartbeat.md')
 const HEARTBEAT_DEFAULT = resolve('default/heartbeat.default.md')
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+/** Render a timestamp as "Nm ago" / "Nh ago" / "Nd ago" for prompt injection. */
+function formatRelativeAge(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  if (diffMs < 60_000) return 'just now'
+  const mins = Math.floor(diffMs / 60_000)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
 
 /** Read a file, copying from default if it doesn't exist yet. */
 async function readWithDefault(target: string, defaultFile: string): Promise<string> {
@@ -121,33 +132,28 @@ async function main() {
     await mkdir(brainDir, { recursive: true })
     await writeFile(BRAIN_FILE, JSON.stringify(state, null, 2))
     await writeFile(FRONTAL_LOBE_FILE, state.state.frontalLobe)
-    const latest = state.commits[state.commits.length - 1]
-    if (latest?.type === 'emotion') {
-      const prev = state.commits.length > 1
-        ? state.commits[state.commits.length - 2]?.stateAfter.emotion ?? 'unknown'
-        : 'unknown'
-      await appendFile(EMOTION_LOG_FILE,
-        `## ${latest.timestamp}\n**${prev} → ${latest.stateAfter.emotion}**\n${latest.message}\n\n`)
-    }
   }
 
   const brain = brainExport
     ? Brain.restore(brainExport, { onCommit: brainOnCommit })
     : new Brain({ onCommit: brainOnCommit })
 
-  /** Re-read persona from disk + live brain state on each request. */
+  /** Re-read persona from disk + live frontal-lobe note on each request.
+   *  Frames the note as "you wrote this Nh ago" rather than "current state"
+   *  — the time-distance cue stops her from treating a stale note as
+   *  ground truth. */
   const getInstructions = async () => {
     const persona = await readFile(PERSONA_FILE, 'utf-8').catch(() => '')
-    const frontalLobe = brain.getFrontalLobe()
-    const emotion = brain.getEmotion().current
+    const { content, updatedAt } = brain.getFrontalLobeMeta()
+    if (!content) return persona
+    const age = updatedAt ? formatRelativeAge(updatedAt) : 'at some point'
     return [
       persona,
       '---',
-      '## Current Brain State',
+      '## Notes you wrote to yourself',
+      `_(written ${age})_`,
       '',
-      `**Frontal Lobe:** ${frontalLobe || '(empty)'}`,
-      '',
-      `**Emotion:** ${emotion}`,
+      content,
     ].join('\n')
   }
 

--- a/src/server/opentypebb.ts
+++ b/src/server/opentypebb.ts
@@ -1,70 +1,45 @@
 /**
- * Embedded OpenBB API Server
+ * OpenTypeBB Mount Helper
  *
- * Starts an OpenBB-compatible HTTP server using opentypebb in-process.
- * Exposes the same REST endpoints as the Python OpenBB sidecar, allowing
- * external tools to connect to Alice's built-in data engine.
+ * Merges opentypebb's REST router into an existing Hono app so market-data
+ * endpoints live on the same port as the rest of the Alice web API.
+ *
+ * No standalone server: opentypebb is first-class inside Alice. Anyone who
+ * wants it as a detached process can run `packages/opentypebb` directly.
  */
 
-import { Hono } from 'hono'
-import { cors } from 'hono/cors'
-import { serve } from '@hono/node-server'
-import { createExecutor, createRegistry, loadAllRouters, buildWidgetsJson, mountWidgetsEndpoint } from '@traderalice/opentypebb'
-import type { Plugin, EngineContext } from '../core/types.js'
+import type { Hono } from 'hono'
+import {
+  loadAllRouters,
+  buildWidgetsJson,
+  createRegistry,
+  type QueryExecutor,
+} from '@traderalice/opentypebb'
 
-export class OpenBBServerPlugin implements Plugin {
-  readonly name = 'openbb-server'
-  readonly port: number
-  private server: ReturnType<typeof serve> | null = null
-
-  constructor(opts: { port: number }) {
-    this.port = opts.port
-  }
-
-  async start(_ctx: EngineContext): Promise<void> {
-    const registry = createRegistry()
-    const executor = createExecutor()
-
-    const app = new Hono()
-    app.use(cors())
-    app.get('/api/v1/health', (c) => c.json({ status: 'ok' }))
-
-    const rootRouter = loadAllRouters()
-
-    const widgetsJson = buildWidgetsJson(rootRouter, registry)
-    mountWidgetsEndpoint(app, widgetsJson)
-    console.log(`[openbb] Built widgets.json with ${Object.keys(widgetsJson).length} widgets`)
-
-    rootRouter.mountToHono(app, executor)
-
-    this.server = serve({ fetch: app.fetch, port: this.port })
-    console.log(`[openbb] Embedded API server listening on http://localhost:${this.port}`)
-  }
-
-  async stop(): Promise<void> {
-    this.server?.close()
-    this.server = null
-    console.log('[openbb] Embedded API server stopped')
-  }
+export interface MountOpenTypeBBOptions {
+  /** URL prefix to mount routes under (e.g. `/api/market-data-v1`). */
+  basePath: string
+  /**
+   * Credentials injected into every request that does not supply its own
+   * `X-OpenBB-Credentials` header — typically the server-side provider keys.
+   */
+  defaultCredentials: Record<string, string>
 }
 
-export function startEmbeddedOpenBBServer(port: number): void {
-  const registry = createRegistry()
-  const executor = createExecutor()
-
-  const app = new Hono()
-  app.use(cors())
-  app.get('/api/v1/health', (c) => c.json({ status: 'ok' }))
-
+export function mountOpenTypeBB(
+  app: Hono,
+  executor: QueryExecutor,
+  opts: MountOpenTypeBBOptions,
+): void {
   const rootRouter = loadAllRouters()
+  const registry = createRegistry()
 
-  // Build and mount widgets.json for OpenBB Workspace frontend
+  rootRouter.mountToHono(app, executor, opts.basePath, opts.defaultCredentials)
+
   const widgetsJson = buildWidgetsJson(rootRouter, registry)
-  mountWidgetsEndpoint(app, widgetsJson)
-  console.log(`[openbb] Built widgets.json with ${Object.keys(widgetsJson).length} widgets`)
+  app.get(`${opts.basePath}/widgets.json`, (c) => c.json(widgetsJson))
 
-  rootRouter.mountToHono(app, executor)
-
-  serve({ fetch: app.fetch, port })
-  console.log(`[openbb] Embedded API server listening on http://localhost:${port}`)
+  console.log(
+    `[opentypebb] mounted on ${opts.basePath} (${Object.keys(widgetsJson).length} widgets)`,
+  )
 }

--- a/src/server/opentypebb.ts
+++ b/src/server/opentypebb.ts
@@ -16,6 +16,14 @@ import {
   type QueryExecutor,
 } from '@traderalice/opentypebb'
 
+export interface DefaultProviders {
+  /** Also used for etf/index/derivatives, matching main.ts client construction. */
+  equity: string
+  crypto: string
+  currency: string
+  commodity: string
+}
+
 export interface MountOpenTypeBBOptions {
   /** URL prefix to mount routes under (e.g. `/api/market-data-v1`). */
   basePath: string
@@ -24,6 +32,35 @@ export interface MountOpenTypeBBOptions {
    * `X-OpenBB-Credentials` header — typically the server-side provider keys.
    */
   defaultCredentials: Record<string, string>
+  /**
+   * Per-asset-class default provider, used when the request omits `?provider=`.
+   * The asset class is the first path segment after `basePath`.
+   */
+  defaultProviders: DefaultProviders
+}
+
+function makeProviderResolver(
+  basePath: string,
+  providers: DefaultProviders,
+): (path: string) => string | undefined {
+  return (path: string) => {
+    const sub = path.slice(basePath.length).replace(/^\/+/, '').split('/')[0]
+    switch (sub) {
+      case 'equity':
+      case 'etf':
+      case 'index':
+      case 'derivatives':
+        return providers.equity
+      case 'crypto':
+        return providers.crypto
+      case 'currency':
+        return providers.currency
+      case 'commodity':
+        return providers.commodity
+      default:
+        return undefined
+    }
+  }
 }
 
 export function mountOpenTypeBB(
@@ -34,7 +71,8 @@ export function mountOpenTypeBB(
   const rootRouter = loadAllRouters()
   const registry = createRegistry()
 
-  rootRouter.mountToHono(app, executor, opts.basePath, opts.defaultCredentials)
+  const resolveProvider = makeProviderResolver(opts.basePath, opts.defaultProviders)
+  rootRouter.mountToHono(app, executor, opts.basePath, opts.defaultCredentials, resolveProvider)
 
   const widgetsJson = buildWidgetsJson(rootRouter, registry)
   app.get(`${opts.basePath}/widgets.json`, (c) => c.json(widgetsJson))

--- a/src/tool/brain.ts
+++ b/src/tool/brain.ts
@@ -3,34 +3,31 @@ import { z } from 'zod';
 import type { Brain } from '@/domain/brain/Brain';
 
 /**
- * Create brain AI tools (cognition + emotion)
+ * Frontal-lobe tools — read/write Alice's personal notes that persist across
+ * rounds (surviving session compaction).
  *
- * Tools:
- * - getFrontalLobe: Read working memory
- * - updateFrontalLobe: Update working memory (creates brain commit)
- * - getEmotion: Read emotional state + recent changes
- * - updateEmotion: Change emotional state with reason (creates brain commit)
- * - getBrainLog: View brain commit history
+ * The strict rule enforced in these descriptions: these notes must be about
+ * HER (commitments, attention targets, self-constraints, operating stances),
+ * never about the WORLD (facts, predictions, market state). World-referring
+ * content goes stale and pollutes later reasoning; self-referring content
+ * stays valid until she chooses to change it.
  */
 export function createBrainTools(brain: Brain) {
   return {
     getFrontalLobe: tool({
       description: `
-Read your own "memory space" from the last round - your self-assessment and notes that YOU wrote.
+Read your previous personal notes — things YOU committed to in earlier rounds.
 
-This is YOUR frontal lobe, where you previously saved:
-- Your market trend assessment (bullish/bearish/uncertain)
-- Current portfolio health evaluation
-- Key predictions or expectations for upcoming rounds
-- Important reminders to yourself (e.g., "Watch BTC support at $95k")
+These are *your* rules, attention targets, self-constraints, and operating
+stances, not facts about the market. They persist across rounds so you can
+maintain continuity in what you've decided to do, what you're watching for,
+and the frame you've been working under.
 
-Use this FIRST in every round to maintain continuity in your thinking.
-This helps you remember:
-- What was your market view last round?
-- What were you planning or expecting?
-- Any important levels or conditions you were watching?
+Use this at the start of a round to recover the context of your own prior
+decisions — what rules are still armed, what events you were waiting for,
+what constraints you put on yourself.
 
-Returns: Your previous self-assessment as a string (empty if this is the first round).
+Returns: your notes as a string (empty if nothing is set yet).
       `.trim(),
       inputSchema: z.object({}),
       execute: () => {
@@ -40,24 +37,37 @@ Returns: Your previous self-assessment as a string (empty if this is the first r
 
     updateFrontalLobe: tool({
       description: `
-Update your "frontal lobe" memory space with your current self-assessment.
+Update your personal notes — things that belong to YOU, not to the world.
 
-Use this at the END of each round (after executing actions and writing summary) to save:
-- Your current view on market trend (bullish/bearish/uncertain)
-- Your assessment of portfolio health
-- Key predictions or expectations for next rounds
-- Important reminders to yourself (e.g., "Watch BTC support at $95k", "Plan to take profit at $100k")
+These notes persist across rounds, so the rule is strict: write only content
+that the world cannot falsify. World-referring content goes stale between
+rounds and will pollute your future reasoning.
 
-This is YOUR personal memory that persists across rounds. Write it clearly and concisely (2-5 sentences) so your future self can quickly understand the current situation.
+✅ Write:
+- Conditional rules you've committed to: "If ETH reclaims 3800, add 10%"
+- Events you're waiting on: "FOMC Thursday 14:00 — check policy signal"
+- Self-constraints: "No new entries until macro clarity"
+- Operating stances: "Running under consolidation assumption for BTC range"
 
-Example:
-"Market is in strong uptrend, BTC holding above $97k support. Current long position is healthy with +15% PnL. Expecting continuation to $100k, will take partial profit there. Watch for reversal if we break below $95k."
+❌ Do NOT write:
+- Market state: "Market is in strong uptrend" — will be false by next round
+- Derivable facts: "Position is +15% PnL" — query the tool instead
+- Predictions: "BTC should reach 100k" — pollutes next round's reasoning
+- Emotion/confidence: "Feeling confident about this" — not decision-relevant
+
+Your notes replace the previous ones entirely each time — drop rules that
+fired or expired, carry forward ones still active, add new ones.
+
+Example (all self-referring, no world claims):
+"If ETH reclaims 3800, add 10% to the long. Waiting on FOMC Thursday 14:00.
+Holding off new entries until macro clarity. Running under consolidation
+assumption for BTC range — flip if we break 98k or lose 94k."
       `.trim(),
       inputSchema: z.object({
         content: z
           .string()
           .describe(
-            'Your self-assessment and notes (2-5 sentences, concise but informative)',
+            'Your personal notes (rules, attention targets, self-constraints, stances — not facts or predictions)',
           ),
       }),
       execute: ({ content }) => {
@@ -65,42 +75,9 @@ Example:
       },
     }),
 
-    getEmotion: tool({
-      description:
-        'Get your current emotional state and recent emotion changes. Use this to understand your own sentiment trajectory.',
-      inputSchema: z.object({}),
-      execute: () => {
-        return brain.getEmotion();
-      },
-    }),
-
-    updateEmotion: tool({
-      description: `
-Update your emotional state when you sense a shift in market sentiment or confidence level.
-Record WHY the emotion changed — this creates a permanent commit in your brain log.
-
-Common states: fearful, cautious, neutral, confident, euphoric
-
-Example: updateEmotion("cautious", "BTC rejected at $100k resistance with declining volume")
-      `.trim(),
-      inputSchema: z.object({
-        emotion: z
-          .string()
-          .describe(
-            'New emotional state (e.g., "fearful", "cautious", "neutral", "confident", "euphoric")',
-          ),
-        reason: z
-          .string()
-          .describe('Why this emotional shift occurred'),
-      }),
-      execute: ({ emotion, reason }) => {
-        return brain.updateEmotion(emotion, reason);
-      },
-    }),
-
     getBrainLog: tool({
       description:
-        'View your brain commit history — a timeline of all cognitive state changes (frontal lobe updates and emotion shifts).',
+        'View the history of your frontal-lobe updates — a timeline of how your committed rules, attention, and stances have evolved.',
       inputSchema: z.object({
         limit: z
           .number()

--- a/src/tool/market.ts
+++ b/src/tool/market.ts
@@ -2,25 +2,19 @@
  * Market Search AI Tool
  *
  * marketSearchForResearch:
- *   统一的市场数据 symbol 搜索入口，跨 equity / crypto / currency 三个资产类别。
- *   - equity: 本地 SEC/TMX 缓存，正则匹配，零延迟
- *   - crypto: yfinance 在线模糊搜索
- *   - currency: yfinance 在线模糊搜索，只返回 XXXUSD 对
- *   返回值带 assetClass 字段归属。
+ *   统一的市场数据 symbol 搜索入口，跨 equity / crypto / currency / commodity 四个资产类别。
+ *   实际聚合逻辑位于 domain/market-data/aggregate-search，HTTP 层（/api/market/search）
+ *   也复用同一个函数——AI 与 UI 看到的是同一份结果。
  */
 
 import { tool } from 'ai'
 import { z } from 'zod'
-import type { SymbolIndex } from '@/domain/market-data/equity/symbol-index'
-import type { CryptoClientLike, CurrencyClientLike } from '@/domain/market-data/client/types'
-import type { CommodityCatalog } from '@/domain/market-data/commodity/commodity-catalog'
+import {
+  aggregateSymbolSearch,
+  type MarketSearchDeps,
+} from '@/domain/market-data/aggregate-search.js'
 
-export function createMarketSearchTools(
-  symbolIndex: SymbolIndex,
-  cryptoClient: CryptoClientLike,
-  currencyClient: CurrencyClientLike,
-  commodityCatalog: CommodityCatalog,
-) {
+export function createMarketSearchTools(deps: MarketSearchDeps) {
   return {
     marketSearchForResearch: tool({
       description: `Search for symbols across all asset classes (equities, crypto, currencies, commodities) for market data research.
@@ -41,31 +35,7 @@ This is NOT for trading — use searchContracts to find broker-tradeable contrac
         limit: z.number().int().positive().optional().describe('Max results per asset class (default: 20)'),
       }),
       execute: async ({ query, limit }) => {
-        const cap = limit ?? 20
-
-        // equity + commodity: 本��同步搜索
-        const equityResults = symbolIndex.search(query, cap).map((r) => ({ ...r, assetClass: 'equity' as const }))
-        const commodityResults = commodityCatalog.search(query, cap).map((r) => ({ ...r, assetClass: 'commodity' as const }))
-
-        // crypto + currency: yfinance 在线搜索，并行，容错
-        const [cryptoSettled, currencySettled] = await Promise.allSettled([
-          cryptoClient.search({ query, provider: 'yfinance' }),
-          currencyClient.search({ query, provider: 'yfinance' }),
-        ])
-
-        const cryptoResults = (cryptoSettled.status === 'fulfilled' ? cryptoSettled.value : []).map((r) => ({
-          ...r,
-          assetClass: 'crypto' as const,
-        }))
-
-        const currencyResults = (currencySettled.status === 'fulfilled' ? currencySettled.value : [])
-          .filter((r) => {
-            const sym = (r as Record<string, unknown>).symbol as string | undefined
-            return sym?.endsWith('USD')
-          })
-          .map((r) => ({ ...r, assetClass: 'currency' as const }))
-
-        const results = [...equityResults, ...cryptoResults, ...currencyResults, ...commodityResults]
+        const results = await aggregateSymbolSearch(deps, query, limit ?? 20)
         if (results.length === 0) {
           return { results: [], message: `No symbols matching "${query}". Try a different keyword.` }
         }

--- a/src/tool/trading.spec.ts
+++ b/src/tool/trading.spec.ts
@@ -111,7 +111,7 @@ describe('createTradingTools — getOrders summarization', () => {
     order.action = overrides?.action ?? 'BUY'
     order.orderType = overrides?.orderType ?? 'MKT'
     order.totalQuantity = new Decimal(overrides?.qty ?? 10)
-    if (overrides?.lmtPrice != null) order.lmtPrice = overrides.lmtPrice
+    if (overrides?.lmtPrice != null) order.lmtPrice = new Decimal(overrides.lmtPrice)
     const orderState = new OrderState()
     orderState.status = overrides?.status ?? 'Submitted'
     return { contract, order, orderState }
@@ -189,8 +189,25 @@ describe('createTradingTools — getOrders summarization', () => {
     const result = await (tools.getOrders.execute as Function)({ source: 'mock-paper' })
     const order = result[0]
 
-    expect(order.lmtPrice).toBe(150)
+    expect(order.lmtPrice).toBe('150')
     expect(order.tpsl).toEqual({ takeProfit: { price: '160' }, stopLoss: { price: '140' } })
+  })
+
+  it('emits price fields as decimal strings (not numbers)', async () => {
+    const broker = new MockBroker({ id: 'mock-paper' })
+    const mgr = makeManager(broker)
+    const tools = createTradingTools(mgr)
+
+    const uta = mgr.resolve('mock-paper')[0]
+    vi.spyOn(uta, 'getPendingOrderIds').mockReturnValue([{ orderId: 'ord-1', symbol: 'ETH' }])
+    const openOrder = makeOpenOrder({ symbol: 'ETH', orderType: 'LMT' })
+    openOrder.order.lmtPrice = new Decimal('0.00001234')
+    vi.spyOn(uta, 'getOrders').mockResolvedValue([openOrder])
+
+    const result = await (tools.getOrders.execute as Function)({ source: 'mock-paper' })
+    const order = result[0]
+    expect(typeof order.lmtPrice).toBe('string')
+    expect(order.lmtPrice).toBe('0.00001234')
   })
 
   it('preserves string orderId from getPendingOrderIds', async () => {

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -9,7 +9,7 @@
 import { tool, type Tool } from 'ai'
 import { z } from 'zod'
 import Decimal from 'decimal.js'
-import { Contract, UNSET_DOUBLE, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { Contract, UNSET_DECIMAL } from '@traderalice/ibkr'
 import type { AccountManager } from '@/domain/trading/account-manager.js'
 import { BrokerError, type OpenOrder } from '@/domain/trading/brokers/types.js'
 import type { FxService } from '@/domain/trading/fx-service.js'
@@ -38,12 +38,12 @@ function summarizeOrder(o: OpenOrder, source: string, stringOrderId?: string) {
     symbol: o.contract.symbol || o.contract.localSymbol || '',
     action: order.action,
     orderType: order.orderType,
-    totalQuantity: order.totalQuantity.equals(UNSET_DECIMAL) ? '0' : order.totalQuantity.toString(),
+    totalQuantity: order.totalQuantity.equals(UNSET_DECIMAL) ? '0' : order.totalQuantity.toFixed(),
     status: o.orderState.status,
-    ...(order.lmtPrice !== UNSET_DOUBLE && { lmtPrice: order.lmtPrice }),
-    ...(order.auxPrice !== UNSET_DOUBLE && { auxPrice: order.auxPrice }),
-    ...(order.trailStopPrice !== UNSET_DOUBLE && { trailStopPrice: order.trailStopPrice }),
-    ...(order.trailingPercent !== UNSET_DOUBLE && { trailingPercent: order.trailingPercent }),
+    ...(!order.lmtPrice.equals(UNSET_DECIMAL) && { lmtPrice: order.lmtPrice.toFixed() }),
+    ...(!order.auxPrice.equals(UNSET_DECIMAL) && { auxPrice: order.auxPrice.toFixed() }),
+    ...(!order.trailStopPrice.equals(UNSET_DECIMAL) && { trailStopPrice: order.trailStopPrice.toFixed() }),
+    ...(!order.trailingPercent.equals(UNSET_DECIMAL) && { trailingPercent: order.trailingPercent.toFixed() }),
     ...(order.tif && { tif: order.tif }),
     ...(!order.filledQuantity.equals(UNSET_DECIMAL) && { filledQuantity: order.filledQuantity.toString() }),
     ...(o.avgFillPrice != null && { avgFillPrice: o.avgFillPrice }),
@@ -60,6 +60,24 @@ const sourceDesc = (required: boolean, extra?: string) => {
     : ' Optional — omit to query all accounts.'
   return base + req + (extra ? ` ${extra}` : '')
 }
+
+/**
+ * Numeric field that accepts either a JS number or a decimal string.
+ * String form preserves precision beyond JS double (crypto satoshi-scale).
+ * Internal pipeline wraps to Decimal regardless.
+ */
+const positiveNumeric = z
+  .union([z.number(), z.string()])
+  .refine(
+    (v) => {
+      try {
+        return new Decimal(String(v)).gt(0) && new Decimal(String(v)).isFinite()
+      } catch {
+        return false
+      }
+    },
+    { message: 'must be a positive number or positive numeric string' },
+  )
 
 export function createTradingTools(manager: AccountManager, fxService?: FxService): Record<string, Tool> {
   return {
@@ -346,12 +364,12 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
         symbol: z.string().optional().describe('Human-readable symbol (optional, for display only)'),
         action: z.enum(['BUY', 'SELL']).describe('Order direction'),
         orderType: z.enum(['MKT', 'LMT', 'STP', 'STP LMT', 'TRAIL', 'TRAIL LIMIT', 'MOC']).describe('Order type'),
-        totalQuantity: z.number().positive().optional().describe('Number of shares/contracts (mutually exclusive with cashQty)'),
-        cashQty: z.number().positive().optional().describe('Notional dollar amount (mutually exclusive with totalQuantity)'),
-        lmtPrice: z.number().positive().optional().describe('Limit price (required for LMT, STP LMT, TRAIL LIMIT)'),
-        auxPrice: z.number().positive().optional().describe('Stop trigger price for STP/STP LMT; trailing offset amount for TRAIL/TRAIL LIMIT'),
-        trailStopPrice: z.number().positive().optional().describe('Initial trailing stop price (TRAIL/TRAIL LIMIT only)'),
-        trailingPercent: z.number().positive().optional().describe('Trailing stop percentage offset (alternative to auxPrice for TRAIL)'),
+        totalQuantity: positiveNumeric.optional().describe('Number of shares/contracts (mutually exclusive with cashQty). Accepts number or decimal string.'),
+        cashQty: positiveNumeric.optional().describe('Notional dollar amount (mutually exclusive with totalQuantity).'),
+        lmtPrice: positiveNumeric.optional().describe('Limit price (required for LMT, STP LMT, TRAIL LIMIT). Accepts number or decimal string for satoshi-scale prices.'),
+        auxPrice: positiveNumeric.optional().describe('Stop trigger price for STP/STP LMT; trailing offset amount for TRAIL/TRAIL LIMIT.'),
+        trailStopPrice: positiveNumeric.optional().describe('Initial trailing stop price (TRAIL/TRAIL LIMIT only).'),
+        trailingPercent: positiveNumeric.optional().describe('Trailing stop percentage offset (alternative to auxPrice for TRAIL).'),
         tif: z.enum(['DAY', 'GTC', 'IOC', 'FOK', 'OPG', 'GTD']).default('DAY').describe('Time in force'),
         goodTillDate: z.string().optional().describe('Expiration datetime for GTD orders'),
         outsideRth: z.boolean().optional().describe('Allow execution outside regular trading hours'),
@@ -373,11 +391,11 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
       inputSchema: z.object({
         source: z.string().describe(sourceDesc(true)),
         orderId: z.string().describe('Order ID to modify'),
-        totalQuantity: z.number().positive().optional().describe('New quantity'),
-        lmtPrice: z.number().positive().optional().describe('New limit price'),
-        auxPrice: z.number().positive().optional().describe('New stop trigger price or trailing offset (depends on order type)'),
-        trailStopPrice: z.number().positive().optional().describe('New initial trailing stop price'),
-        trailingPercent: z.number().positive().optional().describe('New trailing stop percentage'),
+        totalQuantity: positiveNumeric.optional().describe('New quantity. Accepts number or decimal string.'),
+        lmtPrice: positiveNumeric.optional().describe('New limit price. Accepts number or decimal string.'),
+        auxPrice: positiveNumeric.optional().describe('New stop trigger price or trailing offset (depends on order type).'),
+        trailStopPrice: positiveNumeric.optional().describe('New initial trailing stop price.'),
+        trailingPercent: positiveNumeric.optional().describe('New trailing stop percentage.'),
         orderType: z.enum(['MKT', 'LMT', 'STP', 'STP LMT', 'TRAIL', 'TRAIL LIMIT', 'MOC']).optional().describe('New order type'),
         tif: z.enum(['DAY', 'GTC', 'IOC', 'FOK', 'OPG', 'GTD']).optional().describe('New time in force'),
         goodTillDate: z.string().optional().describe('New expiration date'),

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
     "@xyflow/react": "^12.10.2",
     "dompurify": "^3.3.1",
     "highlight.js": "^11.11.1",
+    "lightweight-charts": "^5.1.0",
     "marked": "^15.0.12",
     "marked-highlight": "^2.2.1",
     "react": "^19.1.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,6 +9,7 @@ import { LogsPage } from './pages/LogsPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { AIProviderPage } from './pages/AIProviderPage'
 import { MarketDataPage } from './pages/MarketDataPage'
+import { MarketPage } from './pages/MarketPage'
 import { NewsPage } from './pages/NewsPage'
 import { NewsCollectorPage } from './pages/NewsCollectorPage'
 import { TradingPage } from './pages/TradingPage'
@@ -16,7 +17,7 @@ import { ConnectorsPage } from './pages/ConnectorsPage'
 import { DevPage } from './pages/DevPage'
 
 export type Page =
-  | 'chat' | 'diary' | 'portfolio' | 'news' | 'automation' | 'logs' | 'market-data' | 'news-collector' | 'connectors'
+  | 'chat' | 'diary' | 'portfolio' | 'news' | 'automation' | 'logs' | 'market' | 'market-data' | 'news-collector' | 'connectors'
   | 'trading'
   | 'ai-provider' | 'settings' | 'dev'
 
@@ -27,6 +28,7 @@ export const ROUTES: Record<Page, string> = {
   'portfolio': '/portfolio',
   'automation': '/automation',
   'logs': '/logs',
+  'market': '/market',
   'market-data': '/market-data',
   'news-collector': '/news-collector',
   'news': '/news',
@@ -70,6 +72,7 @@ export function App() {
             <Route path="/portfolio" element={<PortfolioPage />} />
             <Route path="/automation" element={<AutomationPage />} />
             <Route path="/logs" element={<LogsPage />} />
+            <Route path="/market" element={<MarketPage />} />
             <Route path="/market-data" element={<MarketDataPage />} />
             <Route path="/news-collector" element={<NewsCollectorPage />} />
             <Route path="/news" element={<NewsPage />} />

--- a/ui/src/api/brain.ts
+++ b/ui/src/api/brain.ts
@@ -1,0 +1,24 @@
+export type BrainCommitType = 'frontal_lobe' | 'emotion'
+
+export interface BrainCommit {
+  hash: string
+  parentHash: string | null
+  timestamp: string
+  type: BrainCommitType
+  message: string
+  stateAfter: { frontalLobe: string; emotion: string }
+}
+
+export interface BrainState {
+  frontalLobe: string
+  emotion: string
+  commits: BrainCommit[]
+}
+
+export const brainApi = {
+  async state(): Promise<BrainState> {
+    const res = await fetch('/api/brain/state')
+    if (!res.ok) throw new Error('Failed to load brain state')
+    return res.json()
+  },
+}

--- a/ui/src/api/brain.ts
+++ b/ui/src/api/brain.ts
@@ -1,4 +1,4 @@
-export type BrainCommitType = 'frontal_lobe' | 'emotion'
+export type BrainCommitType = 'frontal_lobe'
 
 export interface BrainCommit {
   hash: string
@@ -6,12 +6,11 @@ export interface BrainCommit {
   timestamp: string
   type: BrainCommitType
   message: string
-  stateAfter: { frontalLobe: string; emotion: string }
+  stateAfter: { frontalLobe: string }
 }
 
 export interface BrainState {
   frontalLobe: string
-  emotion: string
   commits: BrainCommit[]
 }
 

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -16,6 +16,7 @@ import { agentStatusApi } from './agentStatus'
 import { personaApi } from './persona'
 import { newsApi } from './news'
 import { diaryApi } from './diary'
+import { brainApi } from './brain'
 import { topologyApi } from './topology'
 export const api = {
   chat: chatApi,
@@ -32,6 +33,7 @@ export const api = {
   persona: personaApi,
   news: newsApi,
   diary: diaryApi,
+  brain: brainApi,
   topology: topologyApi,
 }
 

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -18,6 +18,7 @@ import { newsApi } from './news'
 import { diaryApi } from './diary'
 import { brainApi } from './brain'
 import { topologyApi } from './topology'
+import { marketApi } from './market'
 export const api = {
   chat: chatApi,
   config: configApi,
@@ -35,6 +36,7 @@ export const api = {
   diary: diaryApi,
   brain: brainApi,
   topology: topologyApi,
+  market: marketApi,
 }
 
 // Re-export all types for convenience

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -43,22 +43,19 @@ export const marketApi = {
    * Historical OHLCV candles. Provider comes from the server-side default
    * (config.marketData.providers[assetClass]) — UI doesn't pick provider.
    * `assetClass` only decides the URL prefix; `interval` defaults to `1d`.
-   *
-   * Note: we deliberately don't pass start_date/end_date. Upstream providers
-   * (notably FMP's /stable/historical-price-eod/full) ignore those params
-   * and return a fixed window, which made server-side range filtering
-   * unreliable. Timeframe switching is done client-side via setVisibleRange.
    */
   async historical(
     assetClass: AssetClass,
     symbol: string,
-    opts: { interval?: string } = {},
+    opts: { interval?: string; startDate?: string; endDate?: string } = {},
   ): Promise<HistoricalResponse> {
     if (assetClass === 'commodity') {
       throw new Error('commodity historical not supported yet')
     }
     const qs = new URLSearchParams({ symbol })
     qs.set('interval', opts.interval ?? '1d')
+    if (opts.startDate) qs.set('start_date', opts.startDate)
+    if (opts.endDate) qs.set('end_date', opts.endDate)
     return fetchJson(`/api/market-data-v1/${assetClass}/price/historical?${qs}`)
   },
 }

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -1,0 +1,61 @@
+import { fetchJson } from './client'
+
+export type AssetClass = 'equity' | 'crypto' | 'currency' | 'commodity'
+
+export interface SearchResult {
+  /** Equity / crypto / currency have `symbol`. Commodity uses `id` (canonical). */
+  symbol?: string
+  id?: string
+  name?: string | null
+  assetClass: AssetClass
+  // upstream fields pass through (cik, source, currency, exchange, exchange_name, category, …)
+  [key: string]: unknown
+}
+
+export interface SearchResponse {
+  results: SearchResult[]
+  count: number
+}
+
+export interface HistoricalBar {
+  date: string
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number | null
+}
+
+export interface HistoricalResponse {
+  results: HistoricalBar[] | null
+  provider: string
+  error?: string
+}
+
+export const marketApi = {
+  /** Alice's aggregated heuristic search across all asset classes. */
+  async search(query: string, limit = 20): Promise<SearchResponse> {
+    const qs = new URLSearchParams({ query, limit: String(limit) })
+    return fetchJson(`/api/market/search?${qs}`)
+  },
+
+  /**
+   * Historical OHLCV candles. Provider comes from the server-side default
+   * (config.marketData.providers[assetClass]) — UI doesn't pick provider.
+   * `assetClass` only decides the URL prefix; `interval` defaults to `1d`.
+   */
+  async historical(
+    assetClass: AssetClass,
+    symbol: string,
+    opts: { interval?: string; startDate?: string; endDate?: string } = {},
+  ): Promise<HistoricalResponse> {
+    if (assetClass === 'commodity') {
+      throw new Error('commodity historical not supported yet')
+    }
+    const qs = new URLSearchParams({ symbol })
+    qs.set('interval', opts.interval ?? '1d')
+    if (opts.startDate) qs.set('start_date', opts.startDate)
+    if (opts.endDate) qs.set('end_date', opts.endDate)
+    return fetchJson(`/api/market-data-v1/${assetClass}/price/historical?${qs}`)
+  },
+}

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -43,19 +43,22 @@ export const marketApi = {
    * Historical OHLCV candles. Provider comes from the server-side default
    * (config.marketData.providers[assetClass]) — UI doesn't pick provider.
    * `assetClass` only decides the URL prefix; `interval` defaults to `1d`.
+   *
+   * Note: we deliberately don't pass start_date/end_date. Upstream providers
+   * (notably FMP's /stable/historical-price-eod/full) ignore those params
+   * and return a fixed window, which made server-side range filtering
+   * unreliable. Timeframe switching is done client-side via setVisibleRange.
    */
   async historical(
     assetClass: AssetClass,
     symbol: string,
-    opts: { interval?: string; startDate?: string; endDate?: string } = {},
+    opts: { interval?: string } = {},
   ): Promise<HistoricalResponse> {
     if (assetClass === 'commodity') {
       throw new Error('commodity historical not supported yet')
     }
     const qs = new URLSearchParams({ symbol })
     qs.set('interval', opts.interval ?? '1d')
-    if (opts.startDate) qs.set('start_date', opts.startDate)
-    if (opts.endDate) qs.set('end_date', opts.endDate)
     return fetchJson(`/api/market-data-v1/${assetClass}/price/historical?${qs}`)
   },
 }

--- a/ui/src/components/BrainSidebar.tsx
+++ b/ui/src/components/BrainSidebar.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { api } from '../api'
+import type { BrainCommit, BrainState } from '../api/brain'
+import { MarkdownContent } from './MarkdownContent'
+
+// Match DiaryPage cadence — brain changes are lower-frequency than heartbeat cycles.
+const POLL_INTERVAL_MS = 60_000
+
+type Variant = 'sidebar' | 'flat'
+
+// ==================== Public wrapper ====================
+
+/**
+ * Brain state panel — read-only dashboard showing current frontal lobe + emotion
+ * with a click-to-expand history dialog for each dimension.
+ *
+ * Two variants:
+ *   - sidebar: always-expanded, rendered as a right-side column on wide screens
+ *   - flat: default-collapsed panels, rendered above the feed on narrow screens
+ */
+export function BrainSidebar({ variant }: { variant: Variant }) {
+  const [state, setState] = useState<BrainState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchState = useCallback(async () => {
+    try {
+      const s = await api.brain.state()
+      setState(s)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }, [])
+
+  useEffect(() => { fetchState() }, [fetchState])
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (document.visibilityState === 'visible') fetchState()
+    }, POLL_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [fetchState])
+
+  useEffect(() => {
+    const onFocus = () => { fetchState() }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [fetchState])
+
+  const frontalCommits = useMemo(
+    () => (state?.commits ?? []).filter((c) => c.type === 'frontal_lobe'),
+    [state],
+  )
+  const emotionCommits = useMemo(
+    () => (state?.commits ?? []).filter((c) => c.type === 'emotion'),
+    [state],
+  )
+
+  if (error) {
+    return (
+      <div className="text-[11px] text-red/80 px-3 py-2">
+        Brain: {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className={variant === 'sidebar' ? 'flex flex-col gap-4' : 'flex flex-col gap-2'}>
+      <FrontalLobePanel
+        variant={variant}
+        current={state?.frontalLobe ?? ''}
+        commits={frontalCommits}
+      />
+      <EmotionPanel
+        variant={variant}
+        current={state?.emotion ?? 'neutral'}
+        commits={emotionCommits}
+      />
+    </div>
+  )
+}
+
+// ==================== Frontal Lobe panel ====================
+
+function FrontalLobePanel({
+  variant,
+  current,
+  commits,
+}: {
+  variant: Variant
+  current: string
+  commits: BrainCommit[]
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const body = current
+    ? <MarkdownContent text={current} />
+    : <span className="text-[12px] text-text-muted/50 italic">(empty)</span>
+
+  return (
+    <>
+      <CollapsiblePanel
+        variant={variant}
+        title="Frontal Lobe"
+        subtitle={commits.length > 0 ? `${commits.length} version${commits.length === 1 ? '' : 's'}` : undefined}
+        onExpand={commits.length > 0 ? () => setDialogOpen(true) : undefined}
+      >
+        <div className="text-[13px] leading-relaxed text-text/90">
+          {body}
+        </div>
+      </CollapsiblePanel>
+      {dialogOpen && (
+        <HistoryDialog
+          title="Frontal Lobe — history"
+          onClose={() => setDialogOpen(false)}
+        >
+          {commits.slice().reverse().map((c) => (
+            <article
+              key={c.hash}
+              className="rounded-lg border border-border/40 bg-bg-secondary/30 p-3"
+            >
+              <header className="text-[11px] text-text-muted/70 tabular-nums mb-2">
+                {formatTimestamp(c.timestamp)}
+              </header>
+              <div className="text-[13px] leading-relaxed text-text/90">
+                {c.stateAfter.frontalLobe
+                  ? <MarkdownContent text={c.stateAfter.frontalLobe} />
+                  : <span className="text-text-muted/50 italic">(empty)</span>}
+              </div>
+            </article>
+          ))}
+        </HistoryDialog>
+      )}
+    </>
+  )
+}
+
+// ==================== Emotion panel ====================
+
+function EmotionPanel({
+  variant,
+  current,
+  commits,
+}: {
+  variant: Variant
+  current: string
+  commits: BrainCommit[]
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  return (
+    <>
+      <CollapsiblePanel
+        variant={variant}
+        title="Emotion"
+        subtitle={commits.length > 0 ? `${commits.length} change${commits.length === 1 ? '' : 's'}` : undefined}
+        onExpand={commits.length > 0 ? () => setDialogOpen(true) : undefined}
+      >
+        <div className="flex items-center">
+          <EmotionChip emotion={current} />
+        </div>
+      </CollapsiblePanel>
+      {dialogOpen && (
+        <HistoryDialog
+          title="Emotion — history"
+          onClose={() => setDialogOpen(false)}
+        >
+          {commits.slice().reverse().map((c, i, arr) => {
+            // Walk the reversed list: the "from" is the stateAfter of the next (older) commit.
+            const prev = arr[i + 1]?.stateAfter.emotion ?? 'unknown'
+            return (
+              <article
+                key={c.hash}
+                className="rounded-lg border border-border/40 bg-bg-secondary/30 p-3"
+              >
+                <header className="flex items-center gap-2 text-[11px] text-text-muted/70 mb-2">
+                  <span className="tabular-nums">{formatTimestamp(c.timestamp)}</span>
+                </header>
+                <div className="flex items-center gap-2 mb-2 text-[12px]">
+                  <EmotionChip emotion={prev} muted />
+                  <span className="text-text-muted/60">→</span>
+                  <EmotionChip emotion={c.stateAfter.emotion} />
+                </div>
+                {c.message && (
+                  <div className="text-[12.5px] leading-relaxed text-text/80">
+                    {c.message}
+                  </div>
+                )}
+              </article>
+            )
+          })}
+        </HistoryDialog>
+      )}
+    </>
+  )
+}
+
+// ==================== CollapsiblePanel ====================
+
+function CollapsiblePanel({
+  variant,
+  title,
+  subtitle,
+  onExpand,
+  children,
+}: {
+  variant: Variant
+  title: string
+  subtitle?: string
+  onExpand?: () => void
+  children: ReactNode
+}) {
+  // On narrow screens, panels fold by default so they don't steal scroll space above the feed.
+  // On wide screens, the sidebar panels stay open.
+  const [open, setOpen] = useState(variant === 'sidebar')
+
+  return (
+    <section className="rounded-xl border border-border/40 bg-bg-secondary/20 overflow-hidden">
+      <header className="flex items-center gap-2 px-3 py-2 border-b border-border/30">
+        {variant === 'flat' ? (
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            className="flex items-center gap-1.5 text-[12px] font-medium text-text hover:text-accent transition-colors"
+            aria-expanded={open}
+          >
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={`transition-transform ${open ? 'rotate-90' : ''}`}
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+            {title}
+          </button>
+        ) : (
+          <span className="text-[12px] font-medium text-text tracking-wide">{title}</span>
+        )}
+        {subtitle && (
+          <span className="text-[10.5px] text-text-muted/60 tabular-nums">{subtitle}</span>
+        )}
+        {onExpand && (
+          <button
+            type="button"
+            onClick={onExpand}
+            className="ml-auto text-text-muted/70 hover:text-accent p-1 -m-1 rounded transition-colors"
+            title="View history"
+            aria-label="View history"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 3 21 3 21 9" />
+              <polyline points="9 21 3 21 3 15" />
+              <line x1="21" y1="3" x2="14" y2="10" />
+              <line x1="3" y1="21" x2="10" y2="14" />
+            </svg>
+          </button>
+        )}
+      </header>
+      {open && <div className="px-3 py-3">{children}</div>}
+    </section>
+  )
+}
+
+// ==================== HistoryDialog ====================
+
+function HistoryDialog({
+  title,
+  onClose,
+  children,
+}: {
+  title: string
+  onClose: () => void
+  children: ReactNode
+}) {
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="bg-bg border border-border rounded-xl shadow-2xl w-full max-w-xl max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h2 className="text-[14px] font-semibold text-text tracking-tight">{title}</h2>
+          <button
+            onClick={onClose}
+            className="text-text-muted hover:text-text transition-colors"
+            aria-label="Close"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ==================== EmotionChip ====================
+
+function EmotionChip({ emotion, muted = false }: { emotion: string; muted?: boolean }) {
+  const tone = emotionTone(emotion)
+  const base = 'inline-flex items-center px-2 py-0.5 rounded-full text-[11.5px] font-medium border tabular-nums'
+  const mutedCls = 'border-border/40 text-text-muted/70'
+  const cls = muted ? `${base} ${mutedCls}` : `${base} ${tone}`
+  return <span className={cls}>{emotion}</span>
+}
+
+// Loose keyword-based tone mapping — keeps visual variety without a hardcoded enum.
+// Alice writes free-form emotion strings (fearful, cautious, neutral, confident, euphoric, ...),
+// so we pattern-match rather than switch on exact values.
+function emotionTone(emotion: string): string {
+  const e = emotion.toLowerCase()
+  if (/(euphor|elat|excit|bullish)/.test(e)) return 'border-accent/50 text-accent bg-accent/10'
+  if (/(confident|optim|steady|calm)/.test(e)) return 'border-accent/40 text-accent bg-accent/5'
+  if (/(caut|worr|uncert|anxi)/.test(e)) return 'border-amber-500/40 text-amber-500 bg-amber-500/5'
+  if (/(fear|panic|bear|scared)/.test(e)) return 'border-red/40 text-red bg-red/5'
+  return 'border-border/40 text-text-muted'
+}
+
+// ==================== Helpers ====================
+
+function formatTimestamp(iso: string): string {
+  try {
+    const d = new Date(iso)
+    return d.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+  } catch {
+    return iso
+  }
+}

--- a/ui/src/components/BrainSidebar.tsx
+++ b/ui/src/components/BrainSidebar.tsx
@@ -11,12 +11,12 @@ type Variant = 'sidebar' | 'flat'
 // ==================== Public wrapper ====================
 
 /**
- * Brain state panel — read-only dashboard showing current frontal lobe + emotion
- * with a click-to-expand history dialog for each dimension.
+ * Brain state panel — read-only dashboard showing the current frontal-lobe
+ * note with a click-to-expand history dialog for previous versions.
  *
  * Two variants:
  *   - sidebar: always-expanded, rendered as a right-side column on wide screens
- *   - flat: default-collapsed panels, rendered above the feed on narrow screens
+ *   - flat: default-collapsed panel, rendered above the feed on narrow screens
  */
 export function BrainSidebar({ variant }: { variant: Variant }) {
   const [state, setState] = useState<BrainState | null>(null)
@@ -47,14 +47,7 @@ export function BrainSidebar({ variant }: { variant: Variant }) {
     return () => window.removeEventListener('focus', onFocus)
   }, [fetchState])
 
-  const frontalCommits = useMemo(
-    () => (state?.commits ?? []).filter((c) => c.type === 'frontal_lobe'),
-    [state],
-  )
-  const emotionCommits = useMemo(
-    () => (state?.commits ?? []).filter((c) => c.type === 'emotion'),
-    [state],
-  )
+  const commits = useMemo(() => state?.commits ?? [], [state])
 
   if (error) {
     return (
@@ -69,12 +62,8 @@ export function BrainSidebar({ variant }: { variant: Variant }) {
       <FrontalLobePanel
         variant={variant}
         current={state?.frontalLobe ?? ''}
-        commits={frontalCommits}
-      />
-      <EmotionPanel
-        variant={variant}
-        current={state?.emotion ?? 'neutral'}
-        commits={emotionCommits}
+        updatedAt={commits.at(-1)?.timestamp ?? null}
+        commits={commits}
       />
     </div>
   )
@@ -85,10 +74,12 @@ export function BrainSidebar({ variant }: { variant: Variant }) {
 function FrontalLobePanel({
   variant,
   current,
+  updatedAt,
   commits,
 }: {
   variant: Variant
   current: string
+  updatedAt: string | null
   commits: BrainCommit[]
 }) {
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -97,12 +88,21 @@ function FrontalLobePanel({
     ? <MarkdownContent text={current} />
     : <span className="text-[12px] text-text-muted/50 italic">(empty)</span>
 
+  // The "written Nh ago" cue lines up with what Alice sees in her own system
+  // prompt, so the user can reason about the same staleness she does.
+  const ageLabel = updatedAt ? formatRelativeAge(updatedAt) : null
+  const subtitle = ageLabel
+    ? `${commits.length} version${commits.length === 1 ? '' : 's'} · written ${ageLabel}`
+    : commits.length > 0
+      ? `${commits.length} version${commits.length === 1 ? '' : 's'}`
+      : undefined
+
   return (
     <>
       <CollapsiblePanel
         variant={variant}
         title="Frontal Lobe"
-        subtitle={commits.length > 0 ? `${commits.length} version${commits.length === 1 ? '' : 's'}` : undefined}
+        subtitle={subtitle}
         onExpand={commits.length > 0 ? () => setDialogOpen(true) : undefined}
       >
         <div className="text-[13px] leading-relaxed text-text/90">
@@ -135,66 +135,6 @@ function FrontalLobePanel({
   )
 }
 
-// ==================== Emotion panel ====================
-
-function EmotionPanel({
-  variant,
-  current,
-  commits,
-}: {
-  variant: Variant
-  current: string
-  commits: BrainCommit[]
-}) {
-  const [dialogOpen, setDialogOpen] = useState(false)
-
-  return (
-    <>
-      <CollapsiblePanel
-        variant={variant}
-        title="Emotion"
-        subtitle={commits.length > 0 ? `${commits.length} change${commits.length === 1 ? '' : 's'}` : undefined}
-        onExpand={commits.length > 0 ? () => setDialogOpen(true) : undefined}
-      >
-        <div className="flex items-center">
-          <EmotionChip emotion={current} />
-        </div>
-      </CollapsiblePanel>
-      {dialogOpen && (
-        <HistoryDialog
-          title="Emotion — history"
-          onClose={() => setDialogOpen(false)}
-        >
-          {commits.slice().reverse().map((c, i, arr) => {
-            // Walk the reversed list: the "from" is the stateAfter of the next (older) commit.
-            const prev = arr[i + 1]?.stateAfter.emotion ?? 'unknown'
-            return (
-              <article
-                key={c.hash}
-                className="rounded-lg border border-border/40 bg-bg-secondary/30 p-3"
-              >
-                <header className="flex items-center gap-2 text-[11px] text-text-muted/70 mb-2">
-                  <span className="tabular-nums">{formatTimestamp(c.timestamp)}</span>
-                </header>
-                <div className="flex items-center gap-2 mb-2 text-[12px]">
-                  <EmotionChip emotion={prev} muted />
-                  <span className="text-text-muted/60">→</span>
-                  <EmotionChip emotion={c.stateAfter.emotion} />
-                </div>
-                {c.message && (
-                  <div className="text-[12.5px] leading-relaxed text-text/80">
-                    {c.message}
-                  </div>
-                )}
-              </article>
-            )
-          })}
-        </HistoryDialog>
-      )}
-    </>
-  )
-}
-
 // ==================== CollapsiblePanel ====================
 
 function CollapsiblePanel({
@@ -210,8 +150,8 @@ function CollapsiblePanel({
   onExpand?: () => void
   children: ReactNode
 }) {
-  // On narrow screens, panels fold by default so they don't steal scroll space above the feed.
-  // On wide screens, the sidebar panels stay open.
+  // On narrow screens, the panel folds by default so it doesn't steal scroll
+  // space above the feed. On wide screens, the sidebar stays open.
   const [open, setOpen] = useState(variant === 'sidebar')
 
   return (
@@ -319,28 +259,6 @@ function HistoryDialog({
   )
 }
 
-// ==================== EmotionChip ====================
-
-function EmotionChip({ emotion, muted = false }: { emotion: string; muted?: boolean }) {
-  const tone = emotionTone(emotion)
-  const base = 'inline-flex items-center px-2 py-0.5 rounded-full text-[11.5px] font-medium border tabular-nums'
-  const mutedCls = 'border-border/40 text-text-muted/70'
-  const cls = muted ? `${base} ${mutedCls}` : `${base} ${tone}`
-  return <span className={cls}>{emotion}</span>
-}
-
-// Loose keyword-based tone mapping — keeps visual variety without a hardcoded enum.
-// Alice writes free-form emotion strings (fearful, cautious, neutral, confident, euphoric, ...),
-// so we pattern-match rather than switch on exact values.
-function emotionTone(emotion: string): string {
-  const e = emotion.toLowerCase()
-  if (/(euphor|elat|excit|bullish)/.test(e)) return 'border-accent/50 text-accent bg-accent/10'
-  if (/(confident|optim|steady|calm)/.test(e)) return 'border-accent/40 text-accent bg-accent/5'
-  if (/(caut|worr|uncert|anxi)/.test(e)) return 'border-amber-500/40 text-amber-500 bg-amber-500/5'
-  if (/(fear|panic|bear|scared)/.test(e)) return 'border-red/40 text-red bg-red/5'
-  return 'border-border/40 text-text-muted'
-}
-
 // ==================== Helpers ====================
 
 function formatTimestamp(iso: string): string {
@@ -357,4 +275,16 @@ function formatTimestamp(iso: string): string {
   } catch {
     return iso
   }
+}
+
+/** Mirror of server-side formatter in main.ts so UI and prompt agree on staleness cue. */
+function formatRelativeAge(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  if (diffMs < 60_000) return 'just now'
+  const mins = Math.floor(diffMs / 60_000)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
 }

--- a/ui/src/components/PushApprovalPanel.tsx
+++ b/ui/src/components/PushApprovalPanel.tsx
@@ -30,6 +30,23 @@ function opSymbol(op: WalletStatus['staged'][number]): string {
   return sep !== -1 ? raw.slice(sep + 1) : raw
 }
 
+/**
+ * Format quantity/price for display.
+ * Strings pass through (backend already Decimal-serialized).
+ * Numbers go through toFixed(8) + trim to avoid IEEE 754 artifacts and
+ * the default toLocaleString behavior that truncates decimals to 3 (which
+ * turns crypto-scale quantities like 0.00012345 into "0").
+ */
+function fmtNum(n: number | string | undefined | null): string {
+  if (n == null || n === '') return ''
+  if (typeof n === 'string') return n
+  if (!Number.isFinite(n)) return String(n)
+  const rounded = n.toFixed(8).replace(/\.?0+$/, '')
+  const [intPart, decPart] = rounded.split('.')
+  const withCommas = Number(intPart).toLocaleString('en-US')
+  return decPart ? `${withCommas}.${decPart}` : withCommas
+}
+
 /** Format operation for display — returns { text, isBuy } */
 function formatOp(op: WalletStatus['staged'][number]): { text: string; side?: 'buy' | 'sell' } {
   const symbol = opSymbol(op)
@@ -39,16 +56,18 @@ function formatOp(op: WalletStatus['staged'][number]): { text: string; side?: 'b
       const isBuy = sideRaw === 'BUY'
       const type = (op.order?.orderType || '').toUpperCase()
       const typeBadge = type === 'MKT' || type === 'MARKET' ? 'MKT' : type === 'LMT' || type === 'LIMIT' ? 'LMT' : type
-      const qty = op.order?.totalQuantity ?? op.order?.cashQty ?? ''
-      const qtyStr = typeof qty === 'number' ? qty.toLocaleString() : String(qty)
-      const price = op.order?.lmtPrice ? ` @ ${op.order.lmtPrice}` : ''
+      const qtyStr = fmtNum(op.order?.totalQuantity ?? op.order?.cashQty)
+      const priceStr = fmtNum(op.order?.lmtPrice)
+      const price = priceStr ? ` @ ${priceStr}` : ''
       return {
         text: `${sideRaw} ${qtyStr} ${symbol} ${typeBadge}${price}`.trim(),
         side: isBuy ? 'buy' : 'sell',
       }
     }
-    case 'closePosition':
-      return { text: `CLOSE ${symbol}${op.quantity ? ` (${op.quantity})` : ''}`, side: 'sell' }
+    case 'closePosition': {
+      const qtyStr = fmtNum(op.quantity)
+      return { text: `CLOSE ${symbol}${qtyStr ? ` (${qtyStr})` : ''}`, side: 'sell' }
+    }
     case 'modifyOrder':
       return { text: `MODIFY ${op.orderId || '?'}` }
     case 'cancelOrder':

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -47,6 +47,18 @@ const NAV_SECTIONS: NavSection[] = [
         ),
       },
       {
+        page: 'market',
+        label: 'Market',
+        icon: (active) => (
+          <svg width="18" height="18" viewBox="0 0 24 24" fill={active ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M7 4v16" />
+            <rect x="5" y="8" width="4" height="8" rx="1" />
+            <path d="M17 4v16" />
+            <rect x="15" y="6" width="4" height="10" rx="1" />
+          </svg>
+        ),
+      },
+      {
         page: 'news',
         label: 'News',
         icon: (active) => (

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -11,12 +11,18 @@ import {
 } from 'lightweight-charts'
 import { marketApi, type AssetClass, type HistoricalBar } from '../../api/market'
 
-type Timeframe = '1M' | '3M' | '1Y' | '5Y' | 'All'
+type Interval = '1m' | '5m' | '1h' | '1d'
+type Timeframe = '1D' | '5D' | '1M' | '3M' | '1Y' | '5Y' | 'All'
 
-const TIMEFRAMES: Timeframe[] = ['1M', '3M', '1Y', '5Y', 'All']
+const INTERVALS: Interval[] = ['1m', '5m', '1h', '1d']
+const TIMEFRAMES: Timeframe[] = ['1D', '5D', '1M', '3M', '1Y', '5Y', 'All']
+
+const INTRADAY: ReadonlySet<Interval> = new Set(['1m', '5m', '1h'])
 
 function daysForTimeframe(tf: Timeframe): number | null {
   switch (tf) {
+    case '1D': return 1
+    case '5D': return 5
     case '1M': return 30
     case '3M': return 90
     case '1Y': return 365
@@ -25,16 +31,24 @@ function daysForTimeframe(tf: Timeframe): number | null {
   }
 }
 
-function toUTCTimestamp(dateStr: string): UTCTimestamp {
-  return Math.floor(new Date(`${dateStr}T00:00:00Z`).getTime() / 1000) as UTCTimestamp
+function startDateFromToday(days: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - days)
+  return d.toISOString().slice(0, 10)
+}
+
+function toUTCTimestamp(s: string): UTCTimestamp {
+  // Daily bars use `YYYY-MM-DD`; intraday uses `YYYY-MM-DD HH:MM:SS`.
+  const iso = s.includes(' ') ? s.replace(' ', 'T') + 'Z' : `${s}T00:00:00Z`
+  return Math.floor(new Date(iso).getTime() / 1000) as UTCTimestamp
 }
 
 interface Props {
-  /** null = nothing selected yet; show empty state. */
   selection: { symbol: string; assetClass: AssetClass } | null
 }
 
 export function KlinePanel({ selection }: Props) {
+  const [interval, setInterval] = useState<Interval>('1d')
   const [tf, setTf] = useState<Timeframe>('1Y')
   const [bars, setBars] = useState<HistoricalBar[] | null>(null)
   const [provider, setProvider] = useState<string | null>(null)
@@ -45,32 +59,6 @@ export function KlinePanel({ selection }: Props) {
   const chartRef = useRef<IChartApi | null>(null)
   const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
   const volumeRef = useRef<ISeriesApi<'Histogram'> | null>(null)
-
-  // Fetch bars once per symbol (NOT per timeframe — timeframe is client-side zoom).
-  useEffect(() => {
-    if (!selection) { setBars(null); setProvider(null); setError(null); return }
-    if (selection.assetClass === 'commodity') {
-      setBars(null)
-      setProvider(null)
-      setError('Commodity K-line support is coming in the next step.')
-      return
-    }
-    setLoading(true)
-    setError(null)
-    marketApi.historical(selection.assetClass, selection.symbol, { interval: '1d' })
-      .then((res) => {
-        if (res.error || !res.results) {
-          setError(res.error ?? 'No data returned.')
-          setBars(null)
-          setProvider(null)
-        } else {
-          setBars(res.results)
-          setProvider(res.provider || null)
-        }
-      })
-      .catch((e) => { setError(e instanceof Error ? e.message : String(e)); setBars(null); setProvider(null) })
-      .finally(() => setLoading(false))
-  }, [selection])
 
   // Build chart once.
   useEffect(() => {
@@ -117,9 +105,48 @@ export function KlinePanel({ selection }: Props) {
     }
   }, [])
 
-  // Push bars into chart.
+  // Toggle time-axis detail when interval flips between intraday and daily.
   useEffect(() => {
-    if (!candleRef.current || !volumeRef.current) return
+    chartRef.current?.timeScale().applyOptions({ timeVisible: INTRADAY.has(interval) })
+  }, [interval])
+
+  // Fetch bars on any of: symbol, interval, timeframe.
+  useEffect(() => {
+    if (!selection) { setBars(null); setProvider(null); setError(null); return }
+    if (selection.assetClass === 'commodity') {
+      setBars(null)
+      setProvider(null)
+      setError('Commodity K-line support is coming in the next step.')
+      return
+    }
+    setLoading(true)
+    setError(null)
+    const days = daysForTimeframe(tf)
+    const opts: { interval: string; startDate?: string } = { interval }
+    if (days != null) opts.startDate = startDateFromToday(days)
+
+    marketApi.historical(selection.assetClass, selection.symbol, opts)
+      .then((res) => {
+        if (res.error || !res.results) {
+          setError(res.error ?? 'No data returned.')
+          setBars(null)
+          setProvider(null)
+        } else if (res.results.length === 0) {
+          setError('No bars in this range.')
+          setBars([])
+          setProvider(res.provider || null)
+        } else {
+          setBars(res.results)
+          setProvider(res.provider || null)
+        }
+      })
+      .catch((e) => { setError(e instanceof Error ? e.message : String(e)); setBars(null); setProvider(null) })
+      .finally(() => setLoading(false))
+  }, [selection, interval, tf])
+
+  // Push bars into chart and fit.
+  useEffect(() => {
+    if (!candleRef.current || !volumeRef.current || !chartRef.current) return
     if (!bars || bars.length === 0) {
       candleRef.current.setData([])
       volumeRef.current.setData([])
@@ -141,23 +168,8 @@ export function KlinePanel({ selection }: Props) {
 
     candleRef.current.setData(candleData)
     volumeRef.current.setData(volumeData)
+    chartRef.current.timeScale().fitContent()
   }, [bars])
-
-  // Apply visible range whenever timeframe or bars change.
-  useEffect(() => {
-    const chart = chartRef.current
-    if (!chart || !bars || bars.length === 0) return
-
-    const days = daysForTimeframe(tf)
-    if (!days) {
-      chart.timeScale().fitContent()
-      return
-    }
-    const lastTime = toUTCTimestamp(bars[bars.length - 1].date)
-    const firstAvailable = toUTCTimestamp(bars[0].date)
-    const from = Math.max(lastTime - days * 86400, firstAvailable) as UTCTimestamp
-    chart.timeScale().setVisibleRange({ from, to: lastTime })
-  }, [tf, bars])
 
   const title = useMemo(() => {
     if (!selection) return 'Select a symbol'
@@ -166,32 +178,53 @@ export function KlinePanel({ selection }: Props) {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between py-2 px-1">
-        <div className="flex items-center gap-2">
-          <span className="text-[13px] font-medium text-text">{title}</span>
+      <div className="flex items-center justify-between py-2 px-1 gap-3 flex-wrap">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-[13px] font-medium text-text truncate">{title}</span>
           {provider && (
             <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
               {provider}
             </span>
           )}
           {bars && bars.length > 0 && (
-            <span className="text-[11px] text-text-muted/60">
+            <span className="text-[11px] text-text-muted/60 truncate">
               {bars.length} bars · {bars[0].date} → {bars[bars.length - 1].date}
             </span>
           )}
         </div>
-        <div className="flex border border-border rounded overflow-hidden">
-          {TIMEFRAMES.map((t, i) => (
-            <button
-              key={t}
-              onClick={() => setTf(t)}
-              className={`px-2.5 py-1 text-[12px] transition-colors cursor-pointer ${
-                i > 0 ? 'border-l border-border' : ''
-              } ${tf === t ? 'bg-bg-tertiary text-text' : 'text-text-muted hover:text-text'}`}
-            >
-              {t}
-            </button>
-          ))}
+        <div className="flex items-center gap-5 flex-wrap">
+          <label className="flex items-center gap-2">
+            <span className="text-[11px] uppercase tracking-wide text-text-muted/70">Interval</span>
+            <div className="flex border border-border rounded overflow-hidden" title="Candle width (how much time each bar covers)">
+              {INTERVALS.map((iv, i) => (
+                <button
+                  key={iv}
+                  onClick={() => setInterval(iv)}
+                  className={`px-2 py-1 text-[12px] transition-colors cursor-pointer ${
+                    i > 0 ? 'border-l border-border' : ''
+                  } ${interval === iv ? 'bg-bg-tertiary text-text' : 'text-text-muted hover:text-text'}`}
+                >
+                  {iv}
+                </button>
+              ))}
+            </div>
+          </label>
+          <label className="flex items-center gap-2">
+            <span className="text-[11px] uppercase tracking-wide text-text-muted/70">Range</span>
+            <div className="flex border border-border rounded overflow-hidden" title="How far back to load history">
+              {TIMEFRAMES.map((t, i) => (
+                <button
+                  key={t}
+                  onClick={() => setTf(t)}
+                  className={`px-2 py-1 text-[12px] transition-colors cursor-pointer ${
+                    i > 0 ? 'border-l border-border' : ''
+                  } ${tf === t ? 'bg-bg-tertiary text-text' : 'text-text-muted hover:text-text'}`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </label>
         </div>
       </div>
 

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  createChart,
+  CandlestickSeries,
+  HistogramSeries,
+  type IChartApi,
+  type ISeriesApi,
+  type UTCTimestamp,
+  type CandlestickData,
+  type HistogramData,
+} from 'lightweight-charts'
+import { marketApi, type AssetClass, type HistoricalBar } from '../../api/market'
+
+type Timeframe = '1M' | '3M' | '1Y' | '5Y' | 'All'
+
+const TIMEFRAMES: Timeframe[] = ['1M', '3M', '1Y', '5Y', 'All']
+
+function daysForTimeframe(tf: Timeframe): number | null {
+  switch (tf) {
+    case '1M': return 30
+    case '3M': return 90
+    case '1Y': return 365
+    case '5Y': return 365 * 5
+    case 'All': return null
+  }
+}
+
+function toUTCTimestamp(dateStr: string): UTCTimestamp {
+  // Historical rows use `YYYY-MM-DD`; treat as UTC midnight.
+  return Math.floor(new Date(`${dateStr}T00:00:00Z`).getTime() / 1000) as UTCTimestamp
+}
+
+interface Props {
+  /** null = nothing selected yet; show empty state. */
+  selection: { symbol: string; assetClass: AssetClass } | null
+}
+
+export function KlinePanel({ selection }: Props) {
+  const [tf, setTf] = useState<Timeframe>('1Y')
+  const [bars, setBars] = useState<HistoricalBar[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
+  const volumeRef = useRef<ISeriesApi<'Histogram'> | null>(null)
+
+  // Fetch bars when selection/timeframe changes.
+  useEffect(() => {
+    if (!selection) { setBars(null); setError(null); return }
+    if (selection.assetClass === 'commodity') {
+      setBars(null)
+      setError('Commodity K-line support is coming in the next step.')
+      return
+    }
+    setLoading(true)
+    setError(null)
+    const days = daysForTimeframe(tf)
+    const opts: { interval: string; startDate?: string } = { interval: '1d' }
+    if (days) {
+      const start = new Date()
+      start.setDate(start.getDate() - days)
+      opts.startDate = start.toISOString().slice(0, 10)
+    }
+    marketApi.historical(selection.assetClass, selection.symbol, opts)
+      .then((res) => {
+        if (res.error || !res.results) {
+          setError(res.error ?? 'No data returned.')
+          setBars(null)
+        } else {
+          setBars(res.results)
+        }
+      })
+      .catch((e) => { setError(e instanceof Error ? e.message : String(e)); setBars(null) })
+      .finally(() => setLoading(false))
+  }, [selection, tf])
+
+  // Build chart once container is mounted.
+  useEffect(() => {
+    if (!containerRef.current) return
+    const chart = createChart(containerRef.current, {
+      layout: {
+        background: { color: 'transparent' },
+        textColor: '#c9d1d9',
+        panes: { separatorColor: '#30363d', separatorHoverColor: '#58a6ff33' },
+      },
+      grid: {
+        vertLines: { color: '#21262d' },
+        horzLines: { color: '#21262d' },
+      },
+      rightPriceScale: { borderColor: '#30363d' },
+      timeScale: { borderColor: '#30363d', timeVisible: false, secondsVisible: false },
+      autoSize: true,
+    })
+
+    const candle = chart.addSeries(CandlestickSeries, {
+      upColor: '#3fb950',
+      downColor: '#f85149',
+      borderUpColor: '#3fb950',
+      borderDownColor: '#f85149',
+      wickUpColor: '#3fb950',
+      wickDownColor: '#f85149',
+    })
+
+    const volume = chart.addSeries(HistogramSeries, {
+      priceFormat: { type: 'volume' },
+      priceScaleId: '',
+    }, 1)
+    volume.priceScale().applyOptions({ scaleMargins: { top: 0.1, bottom: 0 } })
+
+    chartRef.current = chart
+    candleRef.current = candle
+    volumeRef.current = volume
+
+    return () => {
+      chart.remove()
+      chartRef.current = null
+      candleRef.current = null
+      volumeRef.current = null
+    }
+  }, [])
+
+  // Push bars into chart.
+  useEffect(() => {
+    if (!candleRef.current || !volumeRef.current) return
+    if (!bars || bars.length === 0) {
+      candleRef.current.setData([])
+      volumeRef.current.setData([])
+      return
+    }
+
+    const candleData: CandlestickData[] = bars.map((b) => ({
+      time: toUTCTimestamp(b.date),
+      open: b.open,
+      high: b.high,
+      low: b.low,
+      close: b.close,
+    }))
+    const volumeData: HistogramData[] = bars.map((b) => ({
+      time: toUTCTimestamp(b.date),
+      value: b.volume ?? 0,
+      color: b.close >= b.open ? '#3fb95055' : '#f8514955',
+    }))
+
+    candleRef.current.setData(candleData)
+    volumeRef.current.setData(volumeData)
+    chartRef.current?.timeScale().fitContent()
+  }, [bars])
+
+  const title = useMemo(() => {
+    if (!selection) return 'Select a symbol'
+    return `${selection.symbol} · ${selection.assetClass}`
+  }, [selection])
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between py-2 px-1">
+        <div className="text-[13px] font-medium text-text">{title}</div>
+        <div className="flex border border-border rounded overflow-hidden">
+          {TIMEFRAMES.map((t, i) => (
+            <button
+              key={t}
+              onClick={() => setTf(t)}
+              className={`px-2.5 py-1 text-[12px] transition-colors cursor-pointer ${
+                i > 0 ? 'border-l border-border' : ''
+              } ${tf === t ? 'bg-bg-tertiary text-text' : 'text-text-muted hover:text-text'}`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="relative flex-1 min-h-0 border border-border rounded bg-bg-secondary/30">
+        <div ref={containerRef} className="absolute inset-0" />
+        {!selection && (
+          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-text-muted">
+            Pick an asset to see the K-line.
+          </div>
+        )}
+        {selection && loading && (
+          <div className="absolute top-2 right-2 text-[11px] text-text-muted">Loading…</div>
+        )}
+        {selection && error && !loading && (
+          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-text-muted px-8 text-center">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -26,7 +26,6 @@ function daysForTimeframe(tf: Timeframe): number | null {
 }
 
 function toUTCTimestamp(dateStr: string): UTCTimestamp {
-  // Historical rows use `YYYY-MM-DD`; treat as UTC midnight.
   return Math.floor(new Date(`${dateStr}T00:00:00Z`).getTime() / 1000) as UTCTimestamp
 }
 
@@ -38,6 +37,7 @@ interface Props {
 export function KlinePanel({ selection }: Props) {
   const [tf, setTf] = useState<Timeframe>('1Y')
   const [bars, setBars] = useState<HistoricalBar[] | null>(null)
+  const [provider, setProvider] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -46,37 +46,33 @@ export function KlinePanel({ selection }: Props) {
   const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
   const volumeRef = useRef<ISeriesApi<'Histogram'> | null>(null)
 
-  // Fetch bars when selection/timeframe changes.
+  // Fetch bars once per symbol (NOT per timeframe — timeframe is client-side zoom).
   useEffect(() => {
-    if (!selection) { setBars(null); setError(null); return }
+    if (!selection) { setBars(null); setProvider(null); setError(null); return }
     if (selection.assetClass === 'commodity') {
       setBars(null)
+      setProvider(null)
       setError('Commodity K-line support is coming in the next step.')
       return
     }
     setLoading(true)
     setError(null)
-    const days = daysForTimeframe(tf)
-    const opts: { interval: string; startDate?: string } = { interval: '1d' }
-    if (days) {
-      const start = new Date()
-      start.setDate(start.getDate() - days)
-      opts.startDate = start.toISOString().slice(0, 10)
-    }
-    marketApi.historical(selection.assetClass, selection.symbol, opts)
+    marketApi.historical(selection.assetClass, selection.symbol, { interval: '1d' })
       .then((res) => {
         if (res.error || !res.results) {
           setError(res.error ?? 'No data returned.')
           setBars(null)
+          setProvider(null)
         } else {
           setBars(res.results)
+          setProvider(res.provider || null)
         }
       })
-      .catch((e) => { setError(e instanceof Error ? e.message : String(e)); setBars(null) })
+      .catch((e) => { setError(e instanceof Error ? e.message : String(e)); setBars(null); setProvider(null) })
       .finally(() => setLoading(false))
-  }, [selection, tf])
+  }, [selection])
 
-  // Build chart once container is mounted.
+  // Build chart once.
   useEffect(() => {
     if (!containerRef.current) return
     const chart = createChart(containerRef.current, {
@@ -145,8 +141,23 @@ export function KlinePanel({ selection }: Props) {
 
     candleRef.current.setData(candleData)
     volumeRef.current.setData(volumeData)
-    chartRef.current?.timeScale().fitContent()
   }, [bars])
+
+  // Apply visible range whenever timeframe or bars change.
+  useEffect(() => {
+    const chart = chartRef.current
+    if (!chart || !bars || bars.length === 0) return
+
+    const days = daysForTimeframe(tf)
+    if (!days) {
+      chart.timeScale().fitContent()
+      return
+    }
+    const lastTime = toUTCTimestamp(bars[bars.length - 1].date)
+    const firstAvailable = toUTCTimestamp(bars[0].date)
+    const from = Math.max(lastTime - days * 86400, firstAvailable) as UTCTimestamp
+    chart.timeScale().setVisibleRange({ from, to: lastTime })
+  }, [tf, bars])
 
   const title = useMemo(() => {
     if (!selection) return 'Select a symbol'
@@ -156,7 +167,19 @@ export function KlinePanel({ selection }: Props) {
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between py-2 px-1">
-        <div className="text-[13px] font-medium text-text">{title}</div>
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] font-medium text-text">{title}</span>
+          {provider && (
+            <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
+              {provider}
+            </span>
+          )}
+          {bars && bars.length > 0 && (
+            <span className="text-[11px] text-text-muted/60">
+              {bars.length} bars · {bars[0].date} → {bars[bars.length - 1].date}
+            </span>
+          )}
+        </div>
         <div className="flex border border-border rounded overflow-hidden">
           {TIMEFRAMES.map((t, i) => (
             <button

--- a/ui/src/components/market/SearchBox.tsx
+++ b/ui/src/components/market/SearchBox.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react'
+import { marketApi, type SearchResult, type AssetClass } from '../../api/market'
+
+interface Props {
+  onSelect: (result: SearchResult) => void
+}
+
+const ASSET_CLASS_COLORS: Record<AssetClass, string> = {
+  equity: 'bg-accent/15 text-accent',
+  crypto: 'bg-amber-500/15 text-amber-400',
+  currency: 'bg-emerald-500/15 text-emerald-400',
+  commodity: 'bg-purple-500/15 text-purple-400',
+}
+
+function resultKey(r: SearchResult): string {
+  return `${r.assetClass}:${r.symbol ?? r.id ?? Math.random()}`
+}
+
+function resultSymbol(r: SearchResult): string {
+  return r.symbol ?? r.id ?? ''
+}
+
+export function SearchBox({ onSelect }: Props) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [highlight, setHighlight] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const q = query.trim()
+    if (!q) {
+      setResults([])
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    const timer = setTimeout(async () => {
+      try {
+        const res = await marketApi.search(q, 20)
+        setResults(res.results)
+        setHighlight(0)
+      } catch (e) {
+        console.error('search failed', e)
+        setResults([])
+      } finally {
+        setLoading(false)
+      }
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [query])
+
+  useEffect(() => {
+    const onClickAway = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickAway)
+    return () => document.removeEventListener('mousedown', onClickAway)
+  }, [])
+
+  const handleSelect = (r: SearchResult) => {
+    onSelect(r)
+    setOpen(false)
+    setQuery(resultSymbol(r))
+  }
+
+  const onKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open || results.length === 0) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setHighlight((h) => Math.min(h + 1, results.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlight((h) => Math.max(h - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      handleSelect(results[highlight])
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        className="w-full px-3 py-2 text-[14px] bg-bg-secondary border border-border rounded-md focus:outline-none focus:border-accent placeholder:text-text-muted/50"
+        placeholder="Search assets — AAPL, bitcoin, EUR, gold…"
+        value={query}
+        onChange={(e) => { setQuery(e.target.value); setOpen(true) }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKey}
+      />
+      {open && query.trim() && (
+        <div className="absolute z-20 mt-1 w-full bg-bg-secondary border border-border rounded-md shadow-lg max-h-[360px] overflow-y-auto">
+          {loading && results.length === 0 && (
+            <div className="px-3 py-2 text-[13px] text-text-muted">Searching…</div>
+          )}
+          {!loading && results.length === 0 && (
+            <div className="px-3 py-2 text-[13px] text-text-muted">No matches</div>
+          )}
+          {results.map((r, i) => (
+            <button
+              key={resultKey(r)}
+              onClick={() => handleSelect(r)}
+              onMouseEnter={() => setHighlight(i)}
+              className={`w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] cursor-pointer transition-colors ${
+                i === highlight ? 'bg-bg-tertiary' : ''
+              }`}
+            >
+              <span className="font-mono font-semibold text-text">{resultSymbol(r)}</span>
+              {r.name && (
+                <span className="text-text-muted truncate flex-1">— {r.name}</span>
+              )}
+              <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded font-medium ${ASSET_CLASS_COLORS[r.assetClass]}`}>
+                {r.assetClass}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/pages/ChatPage.tsx
+++ b/ui/src/pages/ChatPage.tsx
@@ -62,19 +62,39 @@ export function ChatPage({ onSSEStatus }: ChatPageProps) {
 
   useEffect(scrollToBottom, [messages, isWaiting, streamSegments, scrollToBottom])
 
-  // Detect user scroll
+  // Detect user scroll.
+  // Why wheel/touchmove: during streaming, scrollIntoView fires every render
+  // and races the async `scroll` event — user's scroll intent is overwritten
+  // before userScrolledUp can flip. Wheel/touchmove fire synchronously, so we
+  // set the flag before the next auto-scroll can run.
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
     const onScroll = () => {
       const { scrollTop, scrollHeight, clientHeight } = el
-      const isUp = scrollHeight - scrollTop - clientHeight > 80
+      const isUp = scrollHeight - scrollTop - clientHeight > 20
       userScrolledUp.current = isUp
       setShowScrollBtn(isUp)
       if (!isUp) setNewMsgCount(0)
     }
-    el.addEventListener('scroll', onScroll)
-    return () => el.removeEventListener('scroll', onScroll)
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaY < 0) {
+        userScrolledUp.current = true
+        setShowScrollBtn(true)
+      }
+    }
+    const onTouchMove = () => {
+      userScrolledUp.current = true
+      setShowScrollBtn(true)
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    el.addEventListener('wheel', onWheel, { passive: true })
+    el.addEventListener('touchmove', onTouchMove, { passive: true })
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      el.removeEventListener('wheel', onWheel)
+      el.removeEventListener('touchmove', onTouchMove)
+    }
   }, [])
 
   // Load channels list on mount

--- a/ui/src/pages/DiaryPage.tsx
+++ b/ui/src/pages/DiaryPage.tsx
@@ -3,6 +3,7 @@ import { api, type ChatHistoryItem } from '../api'
 import type { DiaryCycle, DiaryOutcome } from '../api/diary'
 import { ToolCallGroup } from '../components/ChatMessage'
 import { MarkdownContent } from '../components/MarkdownContent'
+import { BrainSidebar } from '../components/BrainSidebar'
 
 // ==================== Constants ====================
 
@@ -266,7 +267,8 @@ export function DiaryPage() {
 
   return (
     <div className="flex flex-1 min-h-0">
-      <div className="flex flex-col flex-1 min-h-0 max-w-[760px] mx-auto w-full">
+      {/* Main feed column — left-aligned, not centered, so the right-side Brain sidebar has room on wide screens. */}
+      <div className="flex flex-col flex-1 min-h-0 max-w-[760px]">
         {/* Slim header */}
         <div className="flex items-baseline gap-3 px-5 pt-6 pb-4 shrink-0">
           <h1 className="text-xl font-semibold text-text tracking-tight">Diary</h1>
@@ -283,6 +285,11 @@ export function DiaryPage() {
               <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
             </svg>
           </button>
+        </div>
+
+        {/* Narrow-screen Brain panels — flat layout above the feed, default collapsed. */}
+        <div className="lg:hidden px-5 pb-3 shrink-0">
+          <BrainSidebar variant="flat" />
         </div>
 
         {/* Feed */}
@@ -330,6 +337,17 @@ export function DiaryPage() {
           )}
         </div>
       </div>
+
+      {/* Wide-screen Brain sidebar — always-expanded panels on the right. */}
+      <aside className="hidden lg:flex flex-col shrink-0 w-72 xl:w-80 border-l border-border/30 bg-bg-secondary/10">
+        <div className="flex items-center gap-2 px-4 pt-6 pb-4 shrink-0">
+          <h2 className="text-[13px] font-semibold text-text tracking-tight">Brain</h2>
+          <span className="text-[11px] text-text-muted/60">Alice's inner state</span>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-6">
+          <BrainSidebar variant="sidebar" />
+        </div>
+      </aside>
     </div>
   )
 }

--- a/ui/src/pages/DiaryPage.tsx
+++ b/ui/src/pages/DiaryPage.tsx
@@ -340,11 +340,7 @@ export function DiaryPage() {
 
       {/* Wide-screen Brain sidebar — always-expanded panels on the right. */}
       <aside className="hidden lg:flex flex-col shrink-0 w-72 xl:w-80 border-l border-border/30 bg-bg-secondary/10">
-        <div className="flex items-center gap-2 px-4 pt-6 pb-4 shrink-0">
-          <h2 className="text-[13px] font-semibold text-text tracking-tight">Brain</h2>
-          <span className="text-[11px] text-text-muted/60">Alice's inner state</span>
-        </div>
-        <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-6">
+        <div className="flex-1 min-h-0 overflow-y-auto px-4 pt-6 pb-6">
           <BrainSidebar variant="sidebar" />
         </div>
       </aside>

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -86,7 +86,6 @@ export function MarketDataPage() {
 
   const dataBackend = (config.backend as string) || 'typebb-sdk'
   const apiUrl = (config.apiUrl as string) || 'http://localhost:6900'
-  const apiServer = (config.apiServer as { enabled: boolean; port: number } | undefined) ?? { enabled: false, port: 6901 }
   const providers = (config.providers ?? { equity: 'yfinance', crypto: 'yfinance', currency: 'yfinance', commodity: 'yfinance' }) as Record<string, string>
   const providerKeys = (config.providerKeys ?? {}) as Record<string, string>
 
@@ -131,14 +130,12 @@ export function MarketDataPage() {
             onKeyChange={handleKeyChange}
           />
 
-          {/* Advanced — backend switch + embedded server */}
+          {/* Advanced — backend switch */}
           <AdvancedSection
             backend={dataBackend}
             apiUrl={apiUrl}
-            apiServer={apiServer}
             onBackendChange={(backend) => updateConfigImmediate({ backend })}
             onApiUrlChange={(url) => updateConfig({ apiUrl: url })}
-            onApiServerChange={(server) => updateConfigImmediate({ apiServer: server })}
           />
         </div>
         {loadError && <p className="text-[13px] text-red mt-4 max-w-[880px] mx-auto">Failed to load configuration.</p>}
@@ -257,17 +254,13 @@ function ApiKeysSection({
 function AdvancedSection({
   backend,
   apiUrl,
-  apiServer,
   onBackendChange,
   onApiUrlChange,
-  onApiServerChange,
 }: {
   backend: string
   apiUrl: string
-  apiServer: { enabled: boolean; port: number }
   onBackendChange: (backend: string) => void
   onApiUrlChange: (url: string) => void
-  onApiServerChange: (server: { enabled: boolean; port: number }) => void
 }) {
   const [expanded, setExpanded] = useState(false)
 
@@ -281,7 +274,7 @@ function AdvancedSection({
         <span className="text-[11px] text-text-muted/50">{expanded ? '\u25BC' : '\u25B6'}</span>
       </button>
       {!expanded && (
-        <p className="text-[13px] text-text-muted/70">Data backend, embedded API server.</p>
+        <p className="text-[13px] text-text-muted/70">Data backend selection.</p>
       )}
       {expanded && (
         <div className="space-y-6 mt-4">
@@ -321,39 +314,6 @@ function AdvancedSection({
                   />
                 </Field>
               </div>
-            )}
-          </div>
-
-          {/* Embedded API Server */}
-          <div>
-            <p className="text-[13px] font-medium text-text mb-2">Embedded API Server</p>
-            <p className="text-[12px] text-text-muted/70 mb-3">
-              Expose an OpenBB-compatible HTTP API from Alice. Other services can connect to query market data.
-            </p>
-            <div className="flex items-center justify-between mb-3">
-              <div>
-                <p className="text-[13px] text-text">Enable HTTP server</p>
-                <p className="text-[12px] text-text-muted/60 mt-0.5">
-                  Serves at <span className="font-mono text-[11px]">http://localhost:{apiServer.port}</span>
-                </p>
-              </div>
-              <Toggle
-                size="sm"
-                checked={apiServer.enabled}
-                onChange={(v) => onApiServerChange({ ...apiServer, enabled: v })}
-              />
-            </div>
-            {apiServer.enabled && (
-              <Field label="Port">
-                <input
-                  className={`${inputClass} w-28`}
-                  type="number"
-                  min={1024}
-                  max={65535}
-                  value={apiServer.port}
-                  onChange={(e) => onApiServerChange({ ...apiServer, port: Number(e.target.value) || 6901 })}
-                />
-              </Field>
             )}
           </div>
         </div>

--- a/ui/src/pages/MarketPage.tsx
+++ b/ui/src/pages/MarketPage.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { PageHeader } from '../components/PageHeader'
+import { SearchBox } from '../components/market/SearchBox'
+import { KlinePanel } from '../components/market/KlinePanel'
+import type { AssetClass, SearchResult } from '../api/market'
+
+export function MarketPage() {
+  const [selection, setSelection] = useState<{ symbol: string; assetClass: AssetClass } | null>(null)
+
+  const handleSelect = (r: SearchResult) => {
+    const sym = r.symbol ?? r.id
+    if (!sym) return
+    setSelection({ symbol: sym, assetClass: r.assetClass })
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <PageHeader title="Market" description="Search assets and view price history." />
+      <div className="flex-1 flex flex-col gap-3 px-4 md:px-8 py-4 min-h-0">
+        <SearchBox onSelect={handleSelect} />
+        <div className="flex-1 min-h-0">
+          <KlinePanel selection={selection} />
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

This PR batches several related improvements on the dev branch:

### Market workbench (primary — new user-facing surface)
- New `/market` page with an aggregated symbol search and TradingView lightweight-charts K-line.
- Search backs onto Alice's cross-asset-class heuristic search (equity SEC/TMX cache, crypto/currency via yfinance, commodity canonical catalog). Results are globally ranked by match quality — queries like `gold` now put commodity `gold` at the top instead of being drowned by 20 equity hits. Asset-class badge on each result; 300ms debounce; arrow-key navigation.
- K-line with interval (`1m / 5m / 1h / 1d`) × range (`1D / 5D / 1M / 3M / 1Y / 5Y / All`). Intraday flips the time axis to hours/minutes. Provider badge + bar count + date span shown in the header. Commodity candles TBD.

### Market-data HTTP consolidation
- Collapse the three parallel market-data entry points (in-process executor, the standalone 6901 server, and a would-be third in web-plugin routes) into a single HTTP surface mounted on Alice's main port at `/api/market-data-v1/*`. One executor, one CORS policy, one place for defaults.
- opentypebb's `mountToHono` gains `defaultCredentials` and a `resolveProvider` callback; Alice wires `config.marketData.providers` in, so the UI never has to pass `?provider=` — server-side config is authoritative.

### opentypebb bug fixes (surfaced while wiring the UI)
- FMP historical endpoints wanted `from`/`to` and were silently ignoring `start_date`/`end_date`, returning a fixed 5-year window regardless of query. Fetcher now renames the keys before serialising, which restores date-range filtering across equity/crypto/currency/index historical + commodity spot.
- `amakeRequest` redacts secret query params (apikey/token/etc.) before embedding URLs in error messages, and includes the caught cause's description so logs distinguish DNS / TLS / socket failures.

### Also riding along (previously committed to dev)
- `refactor(trading)`: Order price fields migrated to Decimal end-to-end, with a legacy UNSET_DOUBLE sentinel stripper for persisted orders.
- `fix(ui)`: chat scroll no longer sticks during streaming; Push panel shows correct precision.
- `refactor(brain)` + `feat(diary)`: frontal lobe constrained to self-referring notes (emotion dimension removed); Diary gets a Brain sidebar showing frontal lobe + emotion state.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 1088 tests / 56 files pass
- [x] `curl /api/market/search?query=gold` → commodity `gold` at position 0
- [x] `curl /api/market/search?query=xau` → commodity gold via alias match
- [x] `curl /api/market-data-v1/equity/price/historical?symbol=AAPL` (no `?provider=`) → returns data using configured FMP default
- [x] `curl /api/market-data-v1/equity/price/historical?symbol=AAPL&interval=1d&start_date=2025-03-21&end_date=2025-04-21` → 21 bars (previously returned 1254 due to FMP param bug)
- [x] Browser `/market`: search apple → click AAPL → K-line renders; switching interval + range refetches
- [x] Error paths (FMP 1m on starter tier → 402, unknown symbol → empty) surface as UI messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)