### PR TITLE
fix(market-data): hot-reload provider + credentials when config changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,27 @@ the item when done — git log is the history.
       event type. When more external types exist, let tokens declare
       which event types they're allowed to inject.
 
+## Architecture
+
+- [ ] Unified config hot-reload. Right now every consumer of a config
+      section has to solve "did the user edit this?" on its own —
+      Telegram/MCP-Ask via `reconnectConnectors`, opentypebb via lazy
+      getters closing over `ctx.config` plus an `Object.assign` patch
+      in the config PUT route, and anything holding a sub-reference
+      (`const providers = ctx.config.marketData.providers` style) just
+      goes stale. That's three different strategies living in one
+      codebase, and the last patch (opentypebb lazy getters + ctx.config
+      assign) is a band-aid that only works because `ctx.config`'s
+      top-level object identity is preserved. What's missing: a single
+      subscribe/publish surface over config sections (`configBus.on(
+      'marketData', handler)` / `get('marketData')`) that writers hit
+      once and consumers subscribe to, plus a file-watcher for the
+      direct-edit case (people editing `data/config/*.json` in their
+      editor bypass the PUT route entirely and still see stale behavior).
+      Two-month-old config layer has been getting patched incrementally;
+      worth doing one focused pass instead of another band-aid next time
+      something goes stale.
+
 ## Bugs
 
 - [ ] Snapshot / FX: after currency conversion, snapshot values

--- a/packages/opentypebb/src/core/app/router.ts
+++ b/packages/opentypebb/src/core/app/router.ts
@@ -160,15 +160,24 @@ export class Router {
    *     if supplied; else empty string (executor will surface a "provider required" error).
    *   - Credentials from X-OpenBB-Credentials header, falling back to
    *     `defaultCredentials` when the header is absent or malformed.
+   *     Pass a function to have it evaluated per-request (picks up config
+   *     changes without remounting).
    */
   mountToHono(
     app: Hono,
     executor: QueryExecutor,
     basePath = '/api/v1',
-    defaultCredentials: Record<string, string> | null = null,
+    defaultCredentials:
+      | Record<string, string>
+      | null
+      | (() => Record<string, string> | null) = null,
     resolveProvider?: (path: string, basePath: string) => string | undefined,
   ): void {
     const commands = this.getCommandMap(basePath)
+    const getDefaultCredentials =
+      typeof defaultCredentials === 'function'
+        ? defaultCredentials
+        : () => defaultCredentials
 
     for (const [path, cmd] of commands) {
       app.get(path, async (c) => {
@@ -185,9 +194,10 @@ export class Router {
         const provider = queryProvider || resolveProvider?.(path, basePath) || ''
         delete params.provider
 
-        // Parse credentials from header; fall back to defaults when missing.
+        // Parse credentials from header; fall back to defaults (re-evaluated
+        // per request so config edits take effect without a restart).
         const credHeader = c.req.header('X-OpenBB-Credentials')
-        let credentials: Record<string, string> | null = defaultCredentials
+        let credentials: Record<string, string> | null = getDefaultCredentials()
         if (credHeader) {
           try {
             credentials = JSON.parse(credHeader)

--- a/src/connectors/web/routes/config.ts
+++ b/src/connectors/web/routes/config.ts
@@ -127,6 +127,14 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
       }
       const body = await c.req.json()
       const validated = await writeConfigSection(section, body)
+      // Keep the in-memory ctx.config in sync with disk so any code path
+      // reading it (opentypebb resolver, market-data helpers, …) picks up
+      // edits without a restart. Object.assign preserves ctx.config's
+      // object identity — we just swap its contents.
+      if (opts?.ctx) {
+        const fresh = await loadConfig()
+        Object.assign(opts.ctx.config, fresh)
+      }
       // Hot-reload connectors / OpenBB server when their config changes
       if (section === 'connectors' || section === 'marketData') {
         await opts?.onConnectorsChange?.()

--- a/src/connectors/web/web-plugin.ts
+++ b/src/connectors/web/web-plugin.ts
@@ -121,8 +121,11 @@ export class WebPlugin implements Plugin {
     // merged into this app so UI and external consumers hit a single port.
     mountOpenTypeBB(app, ctx.bbEngine, {
       basePath: '/api/market-data-v1',
-      defaultCredentials: buildSDKCredentials(ctx.config.marketData.providerKeys),
-      defaultProviders: ctx.config.marketData.providers,
+      // Read config lazily so UI edits to marketData.providerKeys /
+      // marketData.providers take effect on the next request — no remount
+      // needed. Requires the config-write route to refresh ctx.config.
+      defaultCredentials: () => buildSDKCredentials(ctx.config.marketData.providerKeys),
+      defaultProviders: () => ctx.config.marketData.providers,
     })
 
     // ==================== Serve UI (Vite build output) ====================

--- a/src/server/opentypebb.ts
+++ b/src/server/opentypebb.ts
@@ -30,20 +30,24 @@ export interface MountOpenTypeBBOptions {
   /**
    * Credentials injected into every request that does not supply its own
    * `X-OpenBB-Credentials` header — typically the server-side provider keys.
+   * Pass a getter to have it evaluated per-request (config changes take
+   * effect without remounting / restarting).
    */
-  defaultCredentials: Record<string, string>
+  defaultCredentials: Record<string, string> | (() => Record<string, string>)
   /**
    * Per-asset-class default provider, used when the request omits `?provider=`.
    * The asset class is the first path segment after `basePath`.
+   * Pass a getter for live config updates.
    */
-  defaultProviders: DefaultProviders
+  defaultProviders: DefaultProviders | (() => DefaultProviders)
 }
 
 function makeProviderResolver(
   basePath: string,
-  providers: DefaultProviders,
+  getProviders: () => DefaultProviders,
 ): (path: string) => string | undefined {
   return (path: string) => {
+    const providers = getProviders()
     const sub = path.slice(basePath.length).replace(/^\/+/, '').split('/')[0]
     switch (sub) {
       case 'equity':
@@ -71,8 +75,17 @@ export function mountOpenTypeBB(
   const rootRouter = loadAllRouters()
   const registry = createRegistry()
 
-  const resolveProvider = makeProviderResolver(opts.basePath, opts.defaultProviders)
-  rootRouter.mountToHono(app, executor, opts.basePath, opts.defaultCredentials, resolveProvider)
+  const getProviders =
+    typeof opts.defaultProviders === 'function'
+      ? opts.defaultProviders
+      : () => opts.defaultProviders as DefaultProviders
+  const getCredentials =
+    typeof opts.defaultCredentials === 'function'
+      ? opts.defaultCredentials
+      : () => opts.defaultCredentials as Record<string, string>
+
+  const resolveProvider = makeProviderResolver(opts.basePath, getProviders)
+  rootRouter.mountToHono(app, executor, opts.basePath, getCredentials, resolveProvider)
 
   const widgetsJson = buildWidgetsJson(rootRouter, registry)
   app.get(`${opts.basePath}/widgets.json`, (c) => c.json(widgetsJson))


### PR DESCRIPTION
## Summary

Changing \`marketData.providers\` via the UI had no effect — every \`/api/market-data-v1/*\` request kept resolving to the provider that was live at server boot, because the resolver closure and the \`defaultCredentials\` value were both snapshotted at \`mountOpenTypeBB\` time, and \`ctx.config\` itself is never reassigned when the config-write route persists edits to disk (only the Telegram / MCP-Ask reconnect path was wired to the PUT handler, and it doesn't touch opentypebb).

Three mechanical changes close the loop:

- **opentypebb** \`mountToHono\`'s \`defaultCredentials\` widens to \`value | null | (() => value | null)\` and re-evaluates the getter on each request, mirroring the \`resolveProvider\` callback that was already lazy.
- **Alice's mount helper** (\`src/server/opentypebb.ts\`) accepts static values or getters for both \`defaultProviders\` and \`defaultCredentials\`; the resolver reads via getter per request.
- **web-plugin** passes closures that read \`ctx.config.marketData.{providers,providerKeys}\` per invocation.
- **config PUT route** (\`routes/config.ts\`): after \`writeConfigSection\`, reload the full config and \`Object.assign\` onto \`ctx.config\` so in-memory state stays in sync with disk. Preserves \`ctx.config\`'s object identity.

**TODO.md** gets an Architecture entry flagging this as a band-aid — three different config-sync strategies now coexist (connector reconnect, opentypebb lazy getter + Object.assign, sub-reference capture that just goes stale), and the right fix is a unified pub/sub config bus plus a file watcher for out-of-band edits. Worth one focused pass next time something goes stale.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`pnpm test\` — 1088 tests / 56 files pass
- [x] Live flip without restart: \`PUT /api/config/marketData\` with \`providers.equity = 'fmp'\` → next \`/api/market-data-v1/equity/price/quote\` returns \`provider: fmp\`; flip back to \`yfinance\` → returns \`yfinance\`. Both directions, zero restart.
- [x] Credentials path: adding an FMP API key via UI takes effect on the next request to an FMP-gated endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)