### PR TITLE
fix: Market Data provider test (FRED/FMP/EIA)

### DIFF
--- a/packages/opentypebb/src/providers/eia/models/petroleum-status-report.ts
+++ b/packages/opentypebb/src/providers/eia/models/petroleum-status-report.ts
@@ -52,7 +52,9 @@ export class EIAPetroleumStatusReportFetcher extends Fetcher {
       frequency: 'weekly',
       'data[0]': 'value',
       'facets[series][]': catInfo.series,
-      sort: JSON.stringify([{ column: 'period', direction: 'desc' }]),
+      sort: 'period',
+      'sort[0][column]': 'period',
+      'sort[0][direction]': 'desc',
       length: '260', // ~5 years of weekly data
     })
 
@@ -67,7 +69,7 @@ export class EIAPetroleumStatusReportFetcher extends Fetcher {
       if (obs.value == null) continue
       results.push({
         date: obs.period,
-        value: obs.value,
+        value: typeof obs.value === 'number' ? obs.value : parseFloat(String(obs.value)),
         category: query.category,
         unit: catInfo.unit,
       })

--- a/packages/opentypebb/src/providers/eia/models/short-term-energy-outlook.ts
+++ b/packages/opentypebb/src/providers/eia/models/short-term-energy-outlook.ts
@@ -51,7 +51,9 @@ export class EIAShortTermEnergyOutlookFetcher extends Fetcher {
       frequency: 'monthly',
       'data[0]': 'value',
       'facets[seriesId][]': catInfo.series,
-      sort: JSON.stringify([{ column: 'period', direction: 'desc' }]),
+      sort: 'period',
+      'sort[0][column]': 'period',
+      'sort[0][direction]': 'desc',
       length: '120', // ~10 years of monthly data
     })
 
@@ -70,7 +72,7 @@ export class EIAShortTermEnergyOutlookFetcher extends Fetcher {
       if (obs.value == null) continue
       results.push({
         date: `${obs.period}-01`,
-        value: obs.value,
+        value: typeof obs.value === 'number' ? obs.value : parseFloat(String(obs.value)),
         category: query.category,
         unit: catInfo.unit,
         forecast: obs.period > currentPeriod,

--- a/packages/opentypebb/src/providers/federal_reserve/utils/fred-helpers.ts
+++ b/packages/opentypebb/src/providers/federal_reserve/utils/fred-helpers.ts
@@ -217,5 +217,5 @@ export function multiSeriesToRecords(
  * Get credentials helper — extracts FRED API key.
  */
 export function getFredApiKey(credentials: Record<string, string> | null): string {
-  return credentials?.fred_api_key ?? credentials?.api_key ?? ''
+  return credentials?.fred_api_key ?? credentials?.api_key ?? credentials?.federal_reserve_api_key ?? ''
 }

--- a/src/connectors/web/routes/config.ts
+++ b/src/connectors/web/routes/config.ts
@@ -154,11 +154,11 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
 /** Market data routes: POST /test-provider */
 export function createMarketDataRoutes(ctx: EngineContext) {
   const TEST_ENDPOINTS: Record<string, { credField: string; provider: string; model: string; params: Record<string, unknown> }> = {
-    fred:             { credField: 'fred_api_key',             provider: 'fred',             model: 'FredSearch',              params: { query: 'GDP' } },
+    fred:             { credField: 'federal_reserve_api_key', provider: 'federal_reserve',  model: 'FredSearch',              params: { query: 'GDP' } },
     bls:              { credField: 'bls_api_key',              provider: 'bls',              model: 'BlsSearch',               params: { query: 'unemployment' } },
     eia:              { credField: 'eia_api_key',              provider: 'eia',              model: 'ShortTermEnergyOutlook',  params: {} },
     econdb:           { credField: 'econdb_api_key',           provider: 'econdb',           model: 'AvailableIndicators',     params: {} },
-    fmp:              { credField: 'fmp_api_key',              provider: 'fmp',              model: 'EquityScreener',          params: { limit: 1 } },
+    fmp:              { credField: 'fmp_api_key',              provider: 'fmp',              model: 'EquitySearch',           params: { query: 'AAPL', is_symbol: true, limit: 1 } },
     nasdaq:           { credField: 'nasdaq_api_key',           provider: 'nasdaq',           model: 'EquitySearch',            params: { query: 'AAPL', is_symbol: true } },
     intrinio:         { credField: 'intrinio_api_key',         provider: 'intrinio',         model: 'EquitySearch',            params: { query: 'AAPL', limit: 1 } },
     tradingeconomics: { credField: 'tradingeconomics_api_key', provider: 'tradingeconomics', model: 'EconomicCalendar',        params: {} },


### PR DESCRIPTION
# Market Data Provider Test 接口 Bug 报告

## 环境

- OpenAlice 版本：0.9.0-beta.13
- OpenTypeBB 内置 providers 测试异常

## 问题一：TEST_ENDPOINTS 配置错误

**文件：** `src/connectors/web/routes/config.ts`

FRED provider name 错误，EIA/FMP credential field name 错误，FMP 测试端点用了付费专属接口：

```diff
const TEST_ENDPOINTS = {
-  fred:  { provider: 'fred',  model: 'FredSearch',       credField: 'fred_api_key', ... },
+  fred:  { provider: 'federal_reserve', model: 'FredSearch', credField: 'federal_reserve_api_key', ... },

-  fmp:   { provider: 'fmp',  model: 'EquityScreener',  credField: 'fmp_api_key', ... },
+  fmp:   { provider: 'fmp',  model: 'EquitySearch',   credField: 'fmp_api_key', ... },

-  eia:   { provider: 'eia',  model: 'ShortTermEnergyOutlook', credField: 'eia_api_key', ... },
+  eia:   { provider: 'eia',  model: 'ShortTermEnergyOutlook', credField: 'eia_eia_api_key', ... },
}
```

**原因：**
- OpenTypeBB Provider 有 auto-prefix 机制：`credentials: ['api_key']` + `name: 'federal_reserve'` → `federal_reserve_api_key`
- `EquityScreener` 是 FMP 付费订阅专属接口，免费账号全部返回 `Restricted Endpoint`

---

## 问题二：FRED fetcher credential fallback 缺失

**文件：** `packages/opentypebb/src/providers/federal_reserve/utils/fred-helpers.ts`

```diff
export function getFredApiKey(credentials): string {
-  return credentials?.fred_api_key ?? credentials?.api_key ?? ''
+  return credentials?.fred_api_key ?? credentials?.api_key ?? credentials?.federal_reserve_api_key ?? ''
}
```

**原因：** `getFredApiKey` 只认 `fred_api_key`，但 executor 经 auto-prefix 后传入的 key 名为 `federal_reserve_api_key`，永远匹配不上。

---

## 问题三：EIA sort 参数格式错误

**文件：** `packages/opentypebb/src/providers/eia/models/short-term-energy-outlook.ts`  
**同类型文件：** `petroleum-status-report.ts`

```diff
const params = new URLSearchParams({
  ...
-  sort: JSON.stringify([{ column: 'period', direction: 'desc' }]),
+  'sort[0][column]': 'period',
+  'sort[0][direction]': 'desc',
  ...
})
```

**原因：** EIA Open Data API v2 要求 sort 参数拆成多个 URL 参数，不接受 JSON 字符串。

---

## 问题四：EIA value 类型未转换

**文件：** `packages/opentypebb/src/providers/eia/models/short-term-energy-outlook.ts`  
**同类型文件：** `petroleum-status-report.ts`

```diff
results.push({
  date: obs.period,
-  value: obs.value,  // string from API, schema expects number
+  value: typeof obs.value === 'number' ? obs.value : parseFloat(String(obs.value)),
  ...
})
```

**原因：** EIA API v2 返回的 `value` 是字符串（如 `"123.45"`），Zod schema 期望 `number`，导致验证失败。

---

## 影响范围

以上问题导致 Market Data 设置页的 Test Provider 按钮对 FRED / FMP / EIA 三个数据源全部返回 Fail，但实际上 API key 本身是有效的。

## 修复建议

1. `src/connectors/web/routes/config.ts` — 修正 TEST_ENDPOINTS 的 provider name、model name、credField
2. `packages/opentypebb/src/providers/federal_reserve/utils/fred-helpers.ts` — 补充 `federal_reserve_api_key` fallback
3. EIA fetcher — sort 参数格式改为数组形式；value 做类型转换