### PR TITLE
feat(ai-providers): add DeepSeek preset (V4 Pro default)

### DIFF
--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -228,6 +228,32 @@ export const KIMI: PresetDef = {
   writeOnlyFields: ['apiKey'],
 }
 
+// ==================== Third-party: DeepSeek ====================
+
+export const DEEPSEEK: PresetDef = {
+  id: 'deepseek',
+  label: 'DeepSeek',
+  description: 'DeepSeek models via Claude Agent SDK (Anthropic-compatible)',
+  category: 'third-party',
+  defaultName: 'DeepSeek',
+  hint: 'Get your API key at platform.deepseek.com. Single platform — no regional split. Cached prompt input is heavily discounted ($0.03/M).',
+  zodSchema: z.object({
+    backend: z.literal('agent-sdk'),
+    loginMethod: z.literal('api-key'),
+    baseUrl: z.string().default('https://api.deepseek.com/anthropic').describe('API endpoint'),
+    model: z.string().default('deepseek-v4-pro').describe('Model'),
+    apiKey: z.string().min(1).describe('DeepSeek API key'),
+  }),
+  endpoints: [
+    { id: 'https://api.deepseek.com/anthropic', label: 'DeepSeek (api.deepseek.com)' },
+  ],
+  models: [
+    { id: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro (flagship)' },
+    { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash (cheap/fast)' },
+  ],
+  writeOnlyFields: ['apiKey'],
+}
+
 // ==================== Custom ====================
 
 export const CUSTOM: PresetDef = {
@@ -258,5 +284,6 @@ export const PRESET_CATALOG: PresetDef[] = [
   MINIMAX,
   GLM,
   KIMI,
+  DEEPSEEK,
   CUSTOM,
 ]


### PR DESCRIPTION
## Summary

- Adds a **DeepSeek** preset to the AI provider catalog, routed via DeepSeek's first-class Anthropic-compat endpoint (`https://api.deepseek.com/anthropic`) — matches the GLM / Kimi / MiniMax shape.
- Ships with `deepseek-v4-pro` as the default, `deepseek-v4-flash` as the cheaper alternative. Deprecated aliases (`deepseek-chat` / `deepseek-reasoner`) omitted; users who still need them can reach them via the Custom preset.
- Unlike Kimi, DeepSeek publishes both OpenAI-compat and Anthropic-compat endpoints as first-class, so `agent-sdk` is a blessed integration route here — no cosplay-caveat comment needed on this preset.

DeepSeek V4 context: 81% SWE-bench Verified, 1M context, hybrid reasoning, and `cache_read` priced at $0.03/M (90% off fresh input) — useful when the system prompt is large and repeated.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Manual: create a DeepSeek profile via the UI, hit Test Connection, confirm a valid 1-token response comes back
- [ ] Manual: set as active profile, send one chat message, verify routing via `ALICE_SDK_DEBUG=1` → `logs/agent-sdk-debug.log` (only `api.deepseek.com` + hardcoded Anthropic management paths should appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)