### PR TITLE
Market workbench tradeable bridge + broker search retrieval + PR convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,3 +162,61 @@ Centralized registry. `tool/` files register tools via `ToolCenter.register()`, 
 - `archive/dev-pre-beta6` is a historical snapshot — do not modify or delete
 - **After merging a PR**, always `git pull origin master` to sync local master. Stale local master causes confusion about what's merged and what's not.
 - **Before creating a PR**, always `git fetch origin master` to check what's already merged. Use `git log --oneline origin/master..HEAD` to verify only the intended commits are ahead. Stale local refs cause PRs with wrong diff.
+
+### Rolling dev → master PR convention
+
+Multiple Claude sessions hit `dev` in parallel; GitHub allows only **one
+open PR per (head, base) pair** anyway. So we keep a single rolling PR
+from `dev → master` and **append** to its body each session instead of
+opening fresh — otherwise each new PR loses the context of what other
+sessions did.
+
+**Before opening a new PR, always check first:**
+
+```bash
+gh pr list --base master --head dev --state open --json number,title,body
+```
+
+- **If a PR exists** → append your section to its body with
+  `gh pr edit <num> --body-file <(...)`. Don't open a new one.
+- **If none exists** → open with `gh pr create` using the template below.
+
+**PR body template:**
+
+```markdown
+## Summary
+<rolling thematic summary — latest session may rewrite this when new
+work meaningfully shifts the PR's framing>
+
+## Per-session contributions
+### YYYY-MM-DD — <session theme, e.g. "Market workbench tradeable card">
+- What changed (1–3 bullets)
+- Why
+- Key commits: `<sha-short>`, `<sha-short>`
+
+### YYYY-MM-DD — <prior session theme>
+…(append on top, keep prior sessions verbatim — never edit other sessions' entries)…
+
+## Full commit log
+<output of: git log --oneline origin/master..HEAD>
+(regenerate from scratch on each body update)
+
+## Test plan
+- [ ] tsc --noEmit clean
+- [ ] pnpm test passes
+- [ ] (session-specific manual verifications)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+**When you append:**
+
+1. Refresh the "Full commit log" section from `git log --oneline origin/master..HEAD`.
+2. Add your "Per-session contributions" entry on top of the list, with today's date.
+3. Don't edit other sessions' entries — that's their record.
+4. Update "Summary" only if your work actually changes the PR's framing
+   (e.g., what was a "frontend tweak" PR becomes a "frontend + new domain
+   service" PR after your work).
+
+This keeps the PR description as a faithful audit trail across sessions,
+and lets reviewers see who-did-what without trawling the commit log alone.

--- a/TODO.md
+++ b/TODO.md
@@ -68,4 +68,165 @@ the item when done — git log is the history.
       final displayed value — the TODO can't be narrowed without a
       concrete data point.
 
+- [ ] Heartbeat dedup window lost on restart. `HeartbeatDedup.lastText`
+      / `lastSentAt` (`src/task/heartbeat/heartbeat.ts:392-410`) live
+      only in memory. Restart inside the 24h dedup window → identical
+      heartbeat re-pushes. Fix: persist last-sent text + ts to a small
+      JSON file (or derive from past `heartbeat.done` events in the
+      EventLog — stronger but needs a load-on-init scan). Surfaced
+      during the autonomous-loop discussion (see Architecture section)
+      but stands on its own as a correctness bug.
+
+- [ ] Cooldown guard state lost on restart. `CooldownGuard.lastTradeTime`
+      (Map<symbol, ts>) at `src/domain/trading/guards/cooldown.ts:9,30`
+      is in-memory only. If a trade fires at T-1s before restart, the
+      next trade at T+30s post-restart bypasses the cooldown entirely.
+      This is a real risk-control violation, not just a UX wrinkle.
+      Fix: persist per-symbol last-trade-ts to disk on each set, reload
+      on init. Or derive from past order-fill events.
+
+- [ ] Trading git staging area lost on restart. `TradingGit.stagingArea`,
+      `pendingMessage`, `pendingHash`, `currentRound` at
+      `src/domain/trading/git/TradingGit.ts:41-46` are RAM-only. Stage
+      orders, restart before push → user has to redo. Worse if a push
+      was in flight: commit metadata is gone, can't tell what failed.
+      Fix: write staging area to disk on each mutation.
+
+- [ ] OKX UTA spot-holding fix needs live confirmation. The CcxtBroker
+      now synthesizes spot balances into Position records (see
+      `fetchSpotHoldings` in `src/domain/trading/brokers/ccxt/CcxtBroker.ts`)
+      so OKX UTA users should now see BTC/ETH/etc. holdings instead of
+      a USD-only view. Spec covers the path but no live OKX account was
+      available — confirm on a real OKX UTA that snapshot.positions
+      includes spot, totalCashValue sums all stablecoins, and
+      netLiquidation matches the exchange's own equity figure.
+
+## Architecture
+
+- [ ] Autonomous-loop substrate (news watcher + sandbox + time machine).
+      Long discussion documented below — this is a major architectural
+      pillar, not a feature. Park until there's a dedicated multi-week
+      block.
+
+      **Origin.** `NewsCollectorStore.ingest()` writes to JSONL but emits
+      no event. The natural next step is a Listener that subscribes to
+      a new `news.ingested` event, judges relevance against the user's
+      holdings, and pushes an alert. Mechanically straightforward
+      (heartbeat is the closest existing pattern, modulo heartbeat being
+      OpenClaw-era legacy that should not be used as a template — see
+      memory `project_heartbeat_legacy.md`).
+
+      **Why this can't ship as just a Listener.** Two compounding
+      problems:
+
+      1. **Sub-agent escalation.** A useful watcher doesn't only push
+         text. When it judges "this might matter," it should be able
+         to spawn a sub-agent task (check kline, scan recent events,
+         re-grep news). Sub-agents read large slices of system state,
+         so any replay/eval must freeze the entire observable
+         environment, not just the watcher's immediate inputs.
+
+      2. **Statefulness kills evaluation.** The watcher's decisions
+         depend on prior state (which alerts already pushed, what's
+         in brain, what the session looks like). Changing the prompt
+         changes the decisions, which changes downstream state, which
+         changes future decisions — classic off-policy evaluation. You
+         can't measure prompt improvements without a way to replay
+         decisions against frozen historical state.
+
+      Both problems point at the same answer: **a TimeView abstraction
+      + a powerless sandbox execution context**.
+
+      **TimeView.** Interface like `getPositionsAt(t)`,
+      `getNewsAt(t, lookback)`, `getBrainAt(t)`,
+      `getRecentAlertsAt(t)`. Two implementations: `LiveTimeView`
+      ("now" — current behavior) and `ReplayTimeView(t, eventLog)`
+      (reconstruct from disk). All autonomous components consume
+      TimeView, never call live services directly. Inventoried disk
+      assets are mostly already replayable:
+        - EventLog (`data/event-log/events.jsonl`)
+        - Sessions (`data/sessions/*.jsonl`)
+        - Tool call log (`data/tool-calls/tool-calls.jsonl`)
+        - News (`data/news-collector/news.jsonl`)
+        - Trading snapshots (`data/trading/{acct}/snapshots/`)
+        - Brain commits (`data/brain/commit.json`)
+      Gaps:
+        - **Market data not persisted at all.** Kline / quotes are
+          live API calls. Blocks any "did this alert correlate with a
+          real move" evaluation; blocks quant-iterator entirely;
+          blocks backtester resurrection. Needs a periodic kline
+          snapshotter at minimum.
+        - **Five JSONLs are independent timelines** — no cross-source
+          index, no event → underlying-record pointer. Tolerable for
+          window queries (watcher's use case); painful for "what was
+          Alice thinking at 14:35".
+        - **In-memory authoritative state** (heartbeat dedup, cooldown
+          guard, trading staging) — see Bugs section, fix as standalone
+          correctness issues regardless.
+        - **Config files overwrite-only** — "what feeds were enabled
+          at T?" not answerable without git history backup.
+        - **Brain commits are a single JSON file with array append**,
+          not true JSONL — fragile under concurrency at scale.
+
+      **Powerless sandbox.** Capability-based execution context where
+      writes are virtualized:
+        - All reads through TimeView, pinned to T (including
+          `Date.now()` inside tools — the tool layer's "now" must
+          obey the pin).
+        - All writes (ConnectorCenter, Brain commits, order
+          submission, sub-agent spawn) go through capability
+          handles. Live mode = real execution. Sandbox mode =
+          captured as proposed actions, not executed.
+        - Sub-agent spawning is recursive: parent in sandbox →
+          child in sandbox. Otherwise the child calls a live broker
+          and the bubble pops.
+        - Third-party API calls (FMP, OpenBB, broker) need
+          historical snapshots OR fail-fast in sandbox. Every live
+          call site needs a capability gate.
+
+      Mental model parallels: capability security, effect systems,
+      React concurrent mode's speculative renders.
+
+      **Why this is big.** The largest hidden cost is that **every
+      tool in the tool layer has to become execution-context-aware**.
+      OpenAlice's tool count is non-trivial; each one needs auditing
+      for live-vs-sandbox behavior. This is not "add a listener."
+      It's "virtualize the AI runtime." Probably multi-week
+      dedicated work.
+
+      **Two staging paths considered, both rejected as today-work:**
+        - *v0-shadow watcher*: emit `news.alert.proposed` events with
+          no push and no sub-agent spawn. Trivially replay-friendly
+          (only state is event log). But Ame ruled this out as too
+          weak to justify — without sub-agent escalation it's just
+          "curated news in the UI."
+        - *Foundation-only*: draft the TimeView interface, enumerate
+          the capability surface, fix the in-memory bugs (already
+          tracked above). Doesn't ship watcher value but de-risks the
+          eventual build by ~1 week.
+
+      **Open design questions** (from the discussion, none resolved):
+        - Should TimeView v1 be narrow (only what news watcher needs)
+          or pre-cover the quant-iterator surface? Leaning narrow.
+        - LLM non-determinism in replay: re-call model vs use
+          archived response — both modes are useful, suggests
+          archiving raw model responses into the EventLog from day 1.
+        - Cold start: when Alice restarts, should the watcher replay
+          missed `news.ingested` events from before the restart, or
+          only see new ones? Leaning skip + tell the LLM "you just
+          woke up."
+        - Asymmetric output protocol: brake bias (warn but never
+          recommend trades from news alone). Different from
+          heartbeat's STATUS:HEARTBEAT_OK/CHAT_YES which is
+          symmetric/general.
+        - Holdings + brain composition: holdings from
+          `accountManager` (world-state, can't live in brain per the
+          de-se principle), watchlist focus from brain frontal-lobe
+          note. Watcher consumes both as TimeView inputs.
+
+      **Standalone unblockers** (not strictly autonomous-loop but
+      adjacent): see the three in-memory bugs in the Bugs section.
+      Those should be fixed independently regardless of whether the
+      watcher project ever lands.
+
 ## (seed more areas as they come up)

--- a/packages/opentypebb/src/providers/fmp/models/equity-profile.ts
+++ b/packages/opentypebb/src/providers/fmp/models/equity-profile.ts
@@ -79,10 +79,13 @@ export class FMPEquityProfileFetcher extends Fetcher {
         if (result && result.length > 0) {
           results.push(result[0])
         } else {
-          console.warn(`Symbol Error: No data found for ${symbol}`)
+          // FMP returned an empty array — usually means delisted, never
+          // listed, or simply outside FMP's coverage (some international
+          // tickers, very obscure assets).
+          console.info(`fmp/profile: no profile for ${symbol} (delisted, unsupported region, or outside FMP coverage)`)
         }
-      } catch {
-        console.warn(`Symbol Error: No data found for ${symbol}`)
+      } catch (err) {
+        console.warn(`fmp/profile: request failed for ${symbol}:`, err instanceof Error ? err.message : err)
       }
     }
 

--- a/packages/opentypebb/src/providers/fmp/models/equity-quote.ts
+++ b/packages/opentypebb/src/providers/fmp/models/equity-quote.ts
@@ -64,10 +64,14 @@ export class FMPEquityQuoteFetcher extends Fetcher {
         if (result && result.length > 0) {
           results.push(...result)
         } else {
-          console.warn(`Symbol Error: No data found for ${symbol}`)
+          // No quote means delisted, halted, or outside FMP coverage. Not
+          // an error — quote is the most basic endpoint, so empty here is
+          // a strong "we don't carry this asset" signal worth logging at
+          // info level.
+          console.info(`fmp/quote: no quote for ${symbol} (likely delisted or outside FMP coverage)`)
         }
-      } catch {
-        console.warn(`Symbol Error: No data found for ${symbol}`)
+      } catch (err) {
+        console.warn(`fmp/quote: request failed for ${symbol}:`, err instanceof Error ? err.message : err)
       }
     }
 

--- a/packages/opentypebb/src/providers/fmp/models/financial-ratios.ts
+++ b/packages/opentypebb/src/providers/fmp/models/financial-ratios.ts
@@ -126,10 +126,12 @@ export class FMPFinancialRatiosFetcher extends Fetcher {
         if (result.length > 0) {
           results.push(...result)
         } else {
-          console.warn(`Symbol Error: No data found for ${symbol}.`)
+          // Asset has no traditional financial ratios on FMP — typical for
+          // ETFs, commodity pools, and other non-operating-company structures.
+          console.info(`fmp/ratios: no rows for ${symbol} (typical for ETFs / partnerships without conventional fundamentals)`)
         }
-      } catch {
-        console.warn(`Symbol Error: No data found for ${symbol}.`)
+      } catch (err) {
+        console.warn(`fmp/ratios: request failed for ${symbol}:`, err instanceof Error ? err.message : err)
       }
     }
 

--- a/packages/opentypebb/src/providers/fmp/models/key-metrics.ts
+++ b/packages/opentypebb/src/providers/fmp/models/key-metrics.ts
@@ -102,10 +102,15 @@ export class FMPKeyMetricsFetcher extends Fetcher {
         if (result.length > 0) {
           results.push(...result)
         } else {
-          console.warn(`Symbol Error: No data found for ${symbol}.`)
+          // Empty-but-successful: the asset legitimately has no key-metrics
+          // data on FMP. Common for ETFs / partnerships / commodity pools
+          // (Teucrium CORN, GLD, etc.) — they don't report standard company
+          // metrics. info, not warn — this is degradation, not an error.
+          console.info(`fmp/key-metrics: no rows for ${symbol} (typical for ETFs / partnerships without conventional fundamentals)`)
         }
-      } catch {
-        console.warn(`Symbol Error: No data found for ${symbol}.`)
+      } catch (err) {
+        // Real failure path — preserve the cause so it's debuggable.
+        console.warn(`fmp/key-metrics: request failed for ${symbol}:`, err instanceof Error ? err.message : err)
       }
     }
 

--- a/packages/opentypebb/src/providers/fmp/models/price-target-consensus.ts
+++ b/packages/opentypebb/src/providers/fmp/models/price-target-consensus.ts
@@ -47,10 +47,12 @@ export class FMPPriceTargetConsensusFetcher extends Fetcher {
         if (result && result.length > 0) {
           results.push(...result)
         } else {
-          console.warn(`Symbol Error: No data found for ${symbol}`)
+          // No analyst price targets — common for ETFs, small-caps without
+          // sell-side coverage, or recently IPO'd tickers. Not an error.
+          console.info(`fmp/price-target-consensus: no analyst targets for ${symbol}`)
         }
-      } catch {
-        console.warn(`Symbol Error: No data found for ${symbol}`)
+      } catch (err) {
+        console.warn(`fmp/price-target-consensus: request failed for ${symbol}:`, err instanceof Error ? err.message : err)
       }
     }
 

--- a/src/connectors/web/routes/trading.ts
+++ b/src/connectors/web/routes/trading.ts
@@ -4,6 +4,11 @@ import type { EngineContext } from '../../../core/types.js'
 import { BrokerError } from '../../../domain/trading/brokers/types.js'
 import type { UnifiedTradingAccount } from '../../../domain/trading/UnifiedTradingAccount.js'
 import { searchTradeableContracts } from '../../../domain/trading/contract-search.js'
+import type { AssetClassHint } from '../../../domain/trading/contract-search-rules.js'
+
+const ALLOWED_ASSET_CLASSES: ReadonlySet<AssetClassHint> = new Set([
+  'equity', 'crypto', 'currency', 'commodity', 'unknown',
+])
 
 /** Resolve account by :id param, return 404 if not found. */
 function resolveAccount(ctx: EngineContext, c: Context): UnifiedTradingAccount | null {
@@ -71,7 +76,13 @@ export function createTradingRoutes(ctx: EngineContext) {
     if (accounts.length === 0) {
       return c.json({ results: [], count: 0, accountsConfigured: 0 })
     }
-    const hits = await searchTradeableContracts(ctx.accountManager, pattern)
+    // Caller may hint the data-vendor asset class so the rule set in
+    // contract-search-rules.ts can pick the right normalization
+    // (e.g. crypto/currency strip the quote suffix). Defaults to
+    // 'unknown' — identity passthrough — when omitted or invalid.
+    const rawAc = c.req.query('assetClass') as AssetClassHint | undefined
+    const assetClass: AssetClassHint = rawAc && ALLOWED_ASSET_CLASSES.has(rawAc) ? rawAc : 'unknown'
+    const hits = await searchTradeableContracts(ctx.accountManager, pattern, assetClass)
     return c.json({ results: hits, count: hits.length, accountsConfigured: accounts.length })
   })
 

--- a/src/connectors/web/routes/trading.ts
+++ b/src/connectors/web/routes/trading.ts
@@ -3,6 +3,7 @@ import type { Context } from 'hono'
 import type { EngineContext } from '../../../core/types.js'
 import { BrokerError } from '../../../domain/trading/brokers/types.js'
 import type { UnifiedTradingAccount } from '../../../domain/trading/UnifiedTradingAccount.js'
+import { searchTradeableContracts } from '../../../domain/trading/contract-search.js'
 
 /** Resolve account by :id param, return 404 if not found. */
 function resolveAccount(ctx: EngineContext, c: Context): UnifiedTradingAccount | null {
@@ -56,6 +57,22 @@ export function createTradingRoutes(ctx: EngineContext) {
   app.get('/equity', async (c) => {
     const equity = await ctx.accountManager.getAggregatedEquity()
     return c.json(equity)
+  })
+
+  // ==================== Tradeable contract search ====================
+  // Heuristic broker-side search across every configured account. Powers
+  // the Market workbench's "tradeable contracts" hint card and any other
+  // surface that wants to bridge a data-vendor symbol to actionable
+  // alias_ids without making the bridge structural.
+  app.get('/contracts/search', async (c) => {
+    const pattern = (c.req.query('pattern') ?? c.req.query('query') ?? '').trim()
+    if (!pattern) return c.json({ results: [], count: 0 })
+    const accounts = ctx.accountManager.listAccounts()
+    if (accounts.length === 0) {
+      return c.json({ results: [], count: 0, accountsConfigured: 0 })
+    }
+    const hits = await searchTradeableContracts(ctx.accountManager, pattern)
+    return c.json({ results: hits, count: hits.length, accountsConfigured: accounts.length })
   })
 
   // ==================== FX rates ====================

--- a/src/domain/news/collector/rss.ts
+++ b/src/domain/news/collector/rss.ts
@@ -20,6 +20,12 @@ export class NewsCollector {
   private store: NewsCollectorStore
   private feeds: RSSFeedConfig[]
   private intervalMs: number
+  /**
+   * In-flight guard: if a fetchAll is already running when the next interval
+   * tick fires, share the existing promise instead of starting a second pass.
+   * Prevents duplicate HTTP work when network latency exceeds intervalMs.
+   */
+  private fetchInFlight: Promise<{ total: number; new: number }> | null = null
 
   constructor(opts: CollectorOpts) {
     this.store = opts.store
@@ -48,8 +54,22 @@ export class NewsCollector {
     }
   }
 
-  /** Fetch all active feeds once. Disabled feeds are skipped. Returns counts. */
+  /**
+   * Fetch all active feeds once. Disabled feeds are skipped. Returns counts.
+   *
+   * Concurrent calls share the in-flight promise (no overlapping fetch passes).
+   */
   async fetchAll(): Promise<{ total: number; new: number }> {
+    if (this.fetchInFlight) return this.fetchInFlight
+    this.fetchInFlight = this._fetchAllImpl()
+    try {
+      return await this.fetchInFlight
+    } finally {
+      this.fetchInFlight = null
+    }
+  }
+
+  private async _fetchAllImpl(): Promise<{ total: number; new: number }> {
     let totalItems = 0
     let totalNew = 0
 

--- a/src/domain/news/query/archive.ts
+++ b/src/domain/news/query/archive.ts
@@ -146,13 +146,15 @@ export function createNewsArchiveTools(provider: INewsProvider) {
 Returns matching headlines with index, title, content length, and metadata preview.
 Use this to quickly scan what's been happening in the market.
 
-Time range control:
-- lookback: "1h", "2h", "12h", "1d", "7d" (default: all available news)
+Search pool: the most recent ${NEWS_LIMIT} items within \`lookback\` (or the
+most recent ${NEWS_LIMIT} overall when \`lookback\` is omitted). Older items
+within the lookback window are NOT searched. Your \`limit\` then bounds the
+match count returned from that pool.
 
 Example: globNews({ pattern: "BTC|Bitcoin", lookback: "1d" })`,
       inputSchema: z.object({
         pattern: z.string().describe('Regex to match against news titles'),
-        lookback: z.string().optional().describe('Time range: "1h", "12h", "1d", "7d"'),
+        lookback: z.string().optional().describe(`Time range: "1h", "12h", "1d", "7d" (searches up to ${NEWS_LIMIT} most recent items in the window)`),
         metadataFilter: z.record(z.string(), z.string()).optional().describe('Filter by metadata key-value'),
         limit: z.number().int().positive().optional().describe('Max results'),
       }),
@@ -170,10 +172,14 @@ Example: globNews({ pattern: "BTC|Bitcoin", lookback: "1d" })`,
 Returns matched text with surrounding context.
 Use this to find specific mentions in news articles.
 
+Search pool: the most recent ${NEWS_LIMIT} items within \`lookback\` (or the
+most recent ${NEWS_LIMIT} overall when \`lookback\` is omitted). Older items
+within the lookback window are NOT searched.
+
 Example: grepNews({ pattern: "interest rate", lookback: "2d" })`,
       inputSchema: z.object({
         pattern: z.string().describe('Regex to search in title and content'),
-        lookback: z.string().optional().describe('Time range: "1h", "12h", "1d", "7d"'),
+        lookback: z.string().optional().describe(`Time range: "1h", "12h", "1d", "7d" (searches up to ${NEWS_LIMIT} most recent items in the window)`),
         contextChars: z.number().int().positive().optional().describe('Context chars around match (default: 50)'),
         metadataFilter: z.record(z.string(), z.string()).optional().describe('Filter by metadata key-value'),
         limit: z.number().int().positive().optional().describe('Max results'),
@@ -189,11 +195,12 @@ Example: grepNews({ pattern: "interest rate", lookback: "2d" })`,
     readNews: tool({
       description: `Read full content of a collected news item by index (like "cat").
 
-Use after globNews/grepNews to read a specific article.
-Use the same lookback as your previous query for consistent indices.`,
+Use after globNews/grepNews to read a specific article. The index addresses the
+same ${NEWS_LIMIT}-item search pool used by globNews/grepNews — pass the SAME
+\`lookback\` you used in the prior call, otherwise the indices will not align.`,
       inputSchema: z.object({
         index: z.number().int().nonnegative().describe('News index from globNews/grepNews results'),
-        lookback: z.string().optional().describe('Match the lookback from your prior globNews/grepNews call'),
+        lookback: z.string().optional().describe(`Match the lookback from your prior globNews/grepNews call (addresses the same ${NEWS_LIMIT}-item pool)`),
       }),
       execute: async ({ index, lookback }) => {
         const result = await readNews(

--- a/src/domain/news/store.spec.ts
+++ b/src/domain/news/store.spec.ts
@@ -132,6 +132,29 @@ describe('NewsCollectorStore', () => {
     expect(store.count).toBe(2)
   })
 
+  it('serializes concurrent ingest of the same dedupKey (no duplicate writes)', async () => {
+    const item = {
+      title: 'Race',
+      content: 'Concurrent ingest',
+      pubTime: new Date('2026-02-27T10:00:00Z'),
+      dedupKey: 'guid:race',
+      metadata: { source: 'test' },
+    }
+
+    const results = await Promise.all(Array.from({ length: 50 }, () => store.ingest(item)))
+
+    // Exactly one ingest reports "new", all others see the dedup
+    expect(results.filter((r) => r === true)).toHaveLength(1)
+    expect(results.filter((r) => r === false)).toHaveLength(49)
+    expect(store.count).toBe(1)
+    expect(store.dedupCount).toBe(1)
+
+    // Disk has exactly one record
+    const raw = await readFile(TEST_LOG_PATH, 'utf-8')
+    const lines = raw.split('\n').filter((l) => l.trim())
+    expect(lines).toHaveLength(1)
+  })
+
   it('respects maxInMemory', async () => {
     const smallStore = new NewsCollectorStore({ logPath: TEST_LOG_PATH, maxInMemory: 3, retentionDays: 7 })
     await smallStore.init()
@@ -166,12 +189,12 @@ describe('NewsCollectorStore', () => {
       }
     })
 
-    it('getNews filters by time range', async () => {
+    it('getNewsV2 with explicit start/end filters by time range', async () => {
       const base = new Date('2026-02-27T00:00:00Z').getTime()
-      const items = await store.getNews(
-        new Date(base + 2 * 3600_000), // after news 2
-        new Date(base + 5 * 3600_000), // up to news 5
-      )
+      const items = await store.getNewsV2({
+        startTime: new Date(base + 2 * 3600_000), // after news 2
+        endTime: new Date(base + 5 * 3600_000),   // up to news 5
+      })
       expect(items).toHaveLength(3) // news 3, 4, 5
       expect(items[0].title).toBe('News 3')
       expect(items[2].title).toBe('News 5')

--- a/src/domain/news/store.ts
+++ b/src/domain/news/store.ts
@@ -50,6 +50,13 @@ export class NewsCollectorStore implements INewsProvider {
   private dedupSet: Set<string> = new Set()
   /** Monotonic sequence counter */
   private seq: number = 0
+  /**
+   * Promise-chain mutex: serialize ingest() so the dedup-check / appendFile /
+   * dedup-add sequence is atomic across concurrent callers. Without this, two
+   * ingests of the same key both pass has(), both appendFile, and the JSONL
+   * gets duplicate lines (recovery dedups them, but the file is dirty).
+   */
+  private writeChain: Promise<unknown> = Promise.resolve()
 
   constructor(opts?: NewsCollectorStoreOpts) {
     this.logPath = opts?.logPath ?? DEFAULT_LOG_PATH
@@ -112,8 +119,23 @@ export class NewsCollectorStore implements INewsProvider {
 
   /**
    * Ingest a single news item. Returns true if new (not a duplicate).
+   *
+   * Serialized via writeChain so that concurrent callers cannot both pass the
+   * dedup check before either writes to disk.
    */
   async ingest(item: {
+    title: string
+    content: string
+    pubTime: Date
+    dedupKey: string
+    metadata: Record<string, string | null>
+  }): Promise<boolean> {
+    const next = this.writeChain.then(() => this._ingestImpl(item))
+    this.writeChain = next.catch(() => {})
+    return next
+  }
+
+  private async _ingestImpl(item: {
     title: string
     content: string
     pubTime: Date
@@ -185,18 +207,6 @@ export class NewsCollectorStore implements INewsProvider {
   }
 
   // ==================== INewsProvider ====================
-
-  async getNews(startTime: Date, endTime: Date): Promise<NewsItem[]> {
-    const startMs = startTime.getTime()
-    const endMs = endTime.getTime()
-
-    const filtered = this.buffer.filter(
-      (r) => r.pubTs > startMs && r.pubTs <= endMs,
-    )
-
-    filtered.sort((a, b) => a.pubTs - b.pubTs)
-    return filtered.map(recordToNewsItem)
-  }
 
   async getNewsV2(options: GetNewsV2Options): Promise<NewsItem[]> {
     const { endTime, startTime, lookback, limit } = options

--- a/src/domain/news/types.ts
+++ b/src/domain/news/types.ts
@@ -72,16 +72,7 @@ export interface GetNewsV2Options {
 /** News data provider interface */
 export interface INewsProvider {
   /**
-   * Get news within a time range
-   *
-   * @param startTime - Start time (exclusive)
-   * @param endTime - End time (inclusive)
-   * @returns News within the time range (ascending by time)
-   */
-  getNews(startTime: Date, endTime: Date): Promise<NewsItem[]>
-
-  /**
-   * Get news (V2, supports semantic time and count limit)
+   * Get news (supports semantic time and count limit)
    *
    * @param options - Query options
    * @returns News list (ascending by time, newest last)

--- a/src/domain/trading/UnifiedTradingAccount.ts
+++ b/src/domain/trading/UnifiedTradingAccount.ts
@@ -530,6 +530,18 @@ export class UnifiedTradingAccount {
     return results
   }
 
+  /**
+   * Optional broker-side catalog refresh (Alpaca, CCXT, Mock — those that
+   * cache an enumerable list locally). No-op for brokers that source search
+   * server-side (IBKR). Caller — typically a cron job — gets a resolved
+   * promise either way and a thrown exception if the broker tried and
+   * failed to refresh.
+   */
+  async refreshCatalog(): Promise<void> {
+    if (typeof this.broker.refreshCatalog !== 'function') return
+    await this._callBroker(() => this.broker.refreshCatalog!())
+  }
+
   async getContractDetails(query: Contract): Promise<ContractDetails | null> {
     const details = await this._callBroker(() => this.broker.getContractDetails(query))
     if (details) this.stampAliceId(details.contract)

--- a/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -35,6 +35,17 @@ import type {
   AlpacaClockRaw,
 } from './alpaca-types.js'
 import { makeContract, resolveSymbol, mapAlpacaOrderStatus, makeOrderState } from './alpaca-contracts.js'
+import { fuzzyRankContracts, type FuzzyRankInput } from '../fuzzy-rank.js'
+
+/** Subset of Alpaca's `/v2/assets` row we actually use for catalog matching. */
+interface AlpacaAssetRaw {
+  symbol: string
+  name?: string
+  class?: string         // 'us_equity' | 'crypto'
+  exchange?: string
+  tradable?: boolean
+  status?: string        // 'active' | 'inactive'
+}
 
 /** Map IBKR orderType codes to Alpaca API order type strings. */
 function ibkrOrderTypeToAlpaca(orderType: string): string {
@@ -93,6 +104,12 @@ export class AlpacaBroker implements IBroker {
 
   private client!: InstanceType<typeof Alpaca>
   private readonly config: AlpacaBrokerConfig
+  /**
+   * Local cache of Alpaca's tradeable asset list. Pulled at connect-time and
+   * (eventually) refreshed by a 6h cron in main.ts. Empty array (rather than
+   * null) means "we tried and got nothing" — null means "haven't tried yet".
+   */
+  private catalog: AlpacaAssetRaw[] | null = null
 
   constructor(config: AlpacaBrokerConfig) {
     this.config = config
@@ -127,6 +144,12 @@ export class AlpacaBroker implements IBroker {
         console.log(
           `AlpacaBroker[${this.id}]: connected (paper=${this.config.paper}, equity=$${parseFloat(account.equity).toFixed(2)})`,
         )
+        // Pull the asset catalog opportunistically — failure here is
+        // non-fatal because searchContracts can fall back to echoing the
+        // ticker, and the 6h cron will retry. Still log so the user knows.
+        this.refreshCatalog().catch((err) => {
+          console.warn(`AlpacaBroker[${this.id}]: initial catalog load failed:`, err instanceof Error ? err.message : err)
+        })
         return
       } catch (err) {
         lastErr = err
@@ -152,16 +175,53 @@ export class AlpacaBroker implements IBroker {
     // Alpaca SDK has no explicit close
   }
 
-  // ---- Contract search ----
+  // ---- Contract search (EnumeratingCatalog model) ----
+
+  /**
+   * Pull Alpaca's full active asset list and atomically replace the local
+   * cache. Failure preserves the previous cache (better stale than empty).
+   *
+   * Called once at init() and periodically by main.ts's 6h cron.
+   */
+  async refreshCatalog(): Promise<void> {
+    try {
+      const raw = await (this.client as unknown as {
+        getAssets: (opts?: { status?: string }) => Promise<AlpacaAssetRaw[]>
+      }).getAssets({ status: 'active' })
+      // Filter to tradable assets only — there's no point surfacing a
+      // contract the broker won't accept orders for.
+      const next = (raw ?? []).filter((a) => a.tradable !== false)
+      this.catalog = next
+      console.log(`AlpacaBroker[${this.id}]: catalog loaded (${next.length} active tradable assets)`)
+    } catch (err) {
+      // Re-throw so the caller (init / cron) can decide whether to log or
+      // swallow. We don't clobber `this.catalog` on failure.
+      throw err
+    }
+  }
 
   async searchContracts(pattern: string): Promise<ContractDescription[]> {
     if (!pattern) return []
 
-    // Alpaca tickers are unique for stocks — pattern is treated as exact ticker match
-    const ticker = pattern.toUpperCase()
-    const desc = new ContractDescription()
-    desc.contract = makeContract(ticker)
-    return [desc]
+    // Catalog hasn't loaded yet (init still running, or first load failed).
+    // Fall back to a single echo so the broker isn't dead in the water —
+    // this is the pre-catalog behaviour, kept as a safety net.
+    if (this.catalog == null) {
+      const desc = new ContractDescription()
+      desc.contract = makeContract(pattern.toUpperCase())
+      return [desc]
+    }
+
+    const entries: FuzzyRankInput[] = this.catalog.map((a) => {
+      const c = makeContract(a.symbol)
+      // Stash the asset name in `description` so panels that render it
+      // (e.g. TradeableContractsPanel) can show "Teucrium Commodity Trust"
+      // alongside the ticker.
+      if (a.name) c.description = a.name
+      if (a.exchange) c.primaryExchange = a.exchange
+      return { contract: c, name: a.name }
+    })
+    return fuzzyRankContracts(entries, pattern)
   }
 
   async getContractDetails(query: Contract): Promise<ContractDetails | null> {

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
@@ -19,8 +19,9 @@ vi.mock('ccxt', () => {
     this.loadMarkets = vi.fn().mockResolvedValue({})
     this.fetchMarkets = vi.fn().mockResolvedValue([])
     this.fetchTicker = vi.fn()
-    this.fetchBalance = vi.fn()
-    this.fetchPositions = vi.fn()
+    this.fetchTickers = vi.fn().mockResolvedValue({})
+    this.fetchBalance = vi.fn().mockResolvedValue({ free: {}, used: {}, total: {} })
+    this.fetchPositions = vi.fn().mockResolvedValue([])
     this.fetchOpenOrders = vi.fn()
     this.fetchClosedOrders = vi.fn()
     this.createOrder = vi.fn()
@@ -832,9 +833,10 @@ describe('CcxtBroker — getAccount', () => {
     setInitialized(acc, {})
 
     ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
-      total: { USDT: 10000 },
-      free: { USDT: 8000 },
-      used: { USDT: 2000 },
+      // Real CCXT shape: per-coin entries at top level. The aggregate
+      // free/used/total dicts also exist on real responses but our parser
+      // reads the per-coin form.
+      USDT: { free: 8000, used: 2000, total: 10000 },
     })
     // Positions must include contracts/contractSize/markPrice so the broker
     // can reconstruct netLiquidation from fresh position market values.
@@ -856,6 +858,46 @@ describe('CcxtBroker — getAccount', () => {
     const acc = new CcxtBroker({ exchange: 'bybit', apiKey: '', secret: '', sandbox: false })
 
     await expect(acc.init()).rejects.toThrow(/requires credentials/)
+  })
+
+  it('sums all stablecoins (USDT + USDC + FDUSD) into totalCashValue', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, {})
+
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      USDT: { free: 1000, used: 200, total: 1200 },
+      USDC: { free: 500, used: 0, total: 500 },
+      FDUSD: { free: 300, used: 100, total: 400 },
+      free: {},  // reserved aggregate, must be ignored
+      used: {},
+    })
+    ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([])
+
+    const info = await acc.getAccount()
+    expect(info.totalCashValue).toBe('1800')   // 1000 + 500 + 300
+    expect(info.initMarginReq).toBe('300')     // 200 + 0 + 100
+    expect(info.netLiquidation).toBe('1800')   // no positions, equity = cash
+  })
+
+  it('includes spot holdings value in netLiquidation', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, {
+      'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT'),
+    })
+
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      USDT: { free: 1000, used: 0, total: 1000 },
+      BTC: { free: 0.5, used: 0, total: 0.5 },
+    })
+    ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([])
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockResolvedValue({
+      'BTC/USDT': { last: 60000 },
+    })
+
+    const info = await acc.getAccount()
+    // netLiq = cash (1000) + spot value (0.5 * 60000 = 30000) = 31000
+    expect(info.totalCashValue).toBe('1000')
+    expect(info.netLiquidation).toBe('31000')
   })
 })
 
@@ -936,6 +978,155 @@ describe('CcxtBroker — getPositions', () => {
 
     const positions = await acc.getPositions()
     expect(positions).toHaveLength(0)
+  })
+
+  // ---- Spot holding synthesis ----
+
+  it('synthesizes spot positions from non-stable balance entries', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, {
+      'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT'),
+      'ETH/USDT': makeSpotMarket('ETH', 'USDT', 'ETH/USDT'),
+    })
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      // CCXT shape: per-coin entries + aggregate keys mixed at top level.
+      USDT: { free: 1000, used: 0, total: 1000 },
+      BTC: { free: 0.5, used: 0, total: 0.5 },
+      ETH: { free: 2, used: 0, total: 2 },
+      free: {},  // reserved aggregate — must not be treated as a coin
+      used: {},
+      total: {},
+    })
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockResolvedValue({
+      'BTC/USDT': { last: 60000 },
+      'ETH/USDT': { last: 2000 },
+    })
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(2)
+    const btc = positions.find(p => p.contract.symbol === 'BTC')!
+    expect(btc.side).toBe('long')
+    expect(btc.quantity.toString()).toBe('0.5')
+    expect(btc.avgCost).toBe('60000')        // markPrice as cost basis
+    expect(btc.marketValue).toBe('30000')
+    expect(btc.unrealizedPnL).toBe('0')
+    expect(btc.contract.localSymbol).toBe('BTC/USDT')  // spot, no settle suffix
+  })
+
+  it('combines free + used into spot quantity', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT') })
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      BTC: { free: 0.3, used: 0.2, total: 0.5 },  // 0.2 locked as collateral
+    })
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockResolvedValue({
+      'BTC/USDT': { last: 60000 },
+    })
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].quantity.toString()).toBe('0.5')
+  })
+
+  it('skips spot holdings with no <COIN>/USDT|USDC|USD market', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT') })
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      BTC: { free: 0.5, used: 0, total: 0.5 },
+      OBSCURE: { free: 100, used: 0, total: 100 },  // no market → skip
+    })
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockResolvedValue({
+      'BTC/USDT': { last: 60000 },
+    })
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].contract.symbol).toBe('BTC')
+  })
+
+  it('skips zero spot balances', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, {
+      'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT'),
+      'ETH/USDT': makeSpotMarket('ETH', 'USDT', 'ETH/USDT'),
+    })
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      BTC: { free: 0.5, used: 0, total: 0.5 },
+      ETH: { free: 0, used: 0, total: 0 },  // dust/empty
+    })
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockResolvedValue({
+      'BTC/USDT': { last: 60000 },
+      'ETH/USDT': { last: 2000 },
+    })
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].contract.symbol).toBe('BTC')
+  })
+
+  it('does not treat stablecoins as spot positions', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, {
+      'USDT/USD': makeSpotMarket('USDT', 'USD', 'USDT/USD'),  // exists but USDT is stable
+      'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT'),
+    })
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      USDT: { free: 1000, used: 0, total: 1000 },
+      USDC: { free: 500, used: 0, total: 500 },
+      FDUSD: { free: 200, used: 0, total: 200 },  // post-BUSD stable on Binance
+      BTC: { free: 0.1, used: 0, total: 0.1 },
+    })
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockResolvedValue({
+      'BTC/USDT': { last: 60000 },
+    })
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].contract.symbol).toBe('BTC')
+  })
+
+  it('returns spot and perp on the same underlying as separate Positions', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, {
+      'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT'),
+      'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT'),
+    })
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      BTC: { free: 0.5, used: 0, total: 0.5 },
+    })
+    ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([
+      {
+        symbol: 'BTC/USDT:USDT',
+        contracts: 1, contractSize: 1, markPrice: 60000, entryPrice: 58000,
+        unrealizedPnl: 2000, side: 'long', leverage: 5, initialMargin: 11600,
+        liquidationPrice: 50000,
+      },
+    ])
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockResolvedValue({
+      'BTC/USDT': { last: 60000 },
+    })
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(2)
+    // Distinct contract identities — same underlying, different products.
+    const localSymbols = positions.map(p => p.contract.localSymbol)
+    expect(localSymbols).toContain('BTC/USDT')        // spot
+    expect(localSymbols).toContain('BTC/USDT:USDT')   // perp
+  })
+
+  it('falls back to per-symbol fetchTicker when fetchTickers throws', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT') })
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
+      BTC: { free: 0.5, used: 0, total: 0.5 },
+    })
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockRejectedValue(new Error('not supported'))
+    ;(acc as any).exchange.fetchTicker = vi.fn().mockResolvedValue({ last: 60000 })
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].marketPrice).toBe('60000')
+    expect((acc as any).exchange.fetchTicker).toHaveBeenCalledWith('BTC/USDT')
   })
 })
 

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -44,7 +44,26 @@ import {
   defaultFetchPositions,
 } from './overrides.js'
 
-const STABLECOIN_TO_USD = new Set(['USDT', 'USDC', 'BUSD', 'DAI', 'TUSD'])
+// Treated as cash (1:1 to USD) when computing balances and as ineligible
+// for spot-position synthesis. Compared against `coin.toUpperCase()` so
+// CCXT's mixed-case codes like 'USDe' normalize correctly.
+const STABLECOIN_TO_USD = new Set([
+  'USDT', 'USDC', 'BUSD', 'DAI', 'TUSD',
+  'FDUSD',  // First Digital USD — Binance's primary post-BUSD stablecoin
+  'PYUSD',  // PayPal USD
+  'USDE',   // Ethena synthetic USD
+  'USDP',   // Paxos USD
+])
+
+// Top-level keys CCXT returns alongside per-currency entries in fetchBalance.
+// Skipping these prevents us from treating 'free'/'used'/'total' aggregates
+// as if they were a coin called "free".
+const BALANCE_RESERVED_KEYS = new Set(['free', 'used', 'total', 'info', 'timestamp', 'datetime'])
+
+// Quote currencies tried, in order, when looking for a market to price a
+// spot holding. USDT first because it has the densest coverage across
+// CCXT exchanges; USDC/USD as fallbacks.
+const SPOT_QUOTE_PREFERENCE = ['USDT', 'USDC', 'USD'] as const
 
 /** Normalize stablecoin quote currencies to 'USD' so they don't trigger FX conversion. */
 function normalizeQuoteCurrency(quote: string): string {
@@ -514,6 +533,102 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
 
   // ---- Queries ----
 
+  /**
+   * Synthesize spot holdings (BTC/ETH/etc balances) into Position records.
+   *
+   * CCXT's fetchPositions() only returns derivative positions
+   * (SWAP/FUTURES/MARGIN/OPTION); spot assets sit in fetchBalance() as
+   * per-currency entries. Without this synthesis, a UTA user holding only
+   * spot would see an empty positions list and a netLiquidation that
+   * reflects only their stablecoin balance.
+   *
+   * Treated as long positions priced at the current ticker — consistent
+   * with how IBKR exposes equity holdings. avgCost is set to markPrice
+   * because reconstructing historic fill cost would require fetchMyTrades,
+   * which is too expensive for a snapshot path.
+   */
+  private async fetchSpotHoldings(prefetched?: Awaited<ReturnType<Exchange['fetchBalance']>>): Promise<Position[]> {
+    const balance = prefetched ?? await this.exchange.fetchBalance()
+    const bal = balance as unknown as Record<string, unknown>
+
+    type Holding = { coin: string; quantity: Decimal; ccxtSymbol: string; market: CcxtMarket }
+    const holdings: Holding[] = []
+
+    for (const [coin, entry] of Object.entries(bal)) {
+      if (BALANCE_RESERVED_KEYS.has(coin)) continue
+      if (STABLECOIN_TO_USD.has(coin.toUpperCase())) continue
+      if (typeof entry !== 'object' || entry === null) continue
+
+      const e = entry as Record<string, unknown>
+      const free = new Decimal(String(e['free'] ?? 0))
+      const used = new Decimal(String(e['used'] ?? 0))
+      const quantity = free.plus(used)
+      if (quantity.lte(0)) continue
+
+      // Find the most preferred quote market for pricing this holding.
+      let resolved: { ccxtSymbol: string; market: CcxtMarket } | null = null
+      for (const quote of SPOT_QUOTE_PREFERENCE) {
+        const candidate = `${coin}/${quote}`
+        const m = this.markets[candidate]
+        if (m && m.active !== false && m.type === 'spot') {
+          resolved = { ccxtSymbol: candidate, market: m }
+          break
+        }
+      }
+      if (!resolved) {
+        console.warn(`CcxtBroker[${this.id}]: spot holding ${coin} (${quantity.toString()}) — no <COIN>/USDT|USDC|USD spot market, skipping`)
+        continue
+      }
+
+      holdings.push({ coin, quantity, ...resolved })
+    }
+
+    if (holdings.length === 0) return []
+
+    // Bulk fetch tickers — one HTTP call instead of N. Some exchanges
+    // don't support multi-symbol fetchTickers; fall back to per-symbol on
+    // failure so we don't lose the entire spot view over an API quirk.
+    const symbols = holdings.map(h => h.ccxtSymbol)
+    let tickers: Record<string, { last?: number | null }> = {}
+    try {
+      tickers = await this.exchange.fetchTickers(symbols) as unknown as Record<string, { last?: number | null }>
+    } catch {
+      for (const s of symbols) {
+        try {
+          tickers[s] = await this.exchange.fetchTicker(s) as unknown as { last?: number | null }
+        } catch {
+          // skip — warned per-holding below
+        }
+      }
+    }
+
+    const result: Position[] = []
+    for (const h of holdings) {
+      const last = tickers[h.ccxtSymbol]?.last
+      if (last == null) {
+        console.warn(`CcxtBroker[${this.id}]: spot holding ${h.coin} — no ticker for ${h.ccxtSymbol}, skipping`)
+        continue
+      }
+      const markPrice = new Decimal(String(last))
+      const marketValue = h.quantity.mul(markPrice)
+
+      result.push({
+        contract: marketToContract(h.market, this.exchangeName),
+        currency: normalizeQuoteCurrency(h.market.quote ?? 'USDT'),
+        side: 'long',
+        quantity: h.quantity,
+        // markPrice as cost basis — historic cost would need fetchMyTrades
+        avgCost: markPrice.toString(),
+        marketPrice: markPrice.toString(),
+        marketValue: marketValue.toString(),
+        unrealizedPnL: '0',
+        realizedPnL: '0',
+      })
+    }
+
+    return result
+  }
+
   async getAccount(): Promise<AccountInfo> {
     this.ensureInit()
 
@@ -523,11 +638,23 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         this.exchange.fetchPositions(),
       ])
 
-      const bal = balance as unknown as Record<string, Record<string, unknown>>
-      const free = new Decimal(String(bal['free']?.['USDT'] ?? bal['free']?.['USD'] ?? 0))
-      const used = new Decimal(String(bal['used']?.['USDT'] ?? bal['used']?.['USD'] ?? 0))
+      const bal = balance as unknown as Record<string, unknown>
 
-      // Aggregate P&L and market value from positions.
+      // Sum every stablecoin entry — not just USDT — into cash. OKX UTA
+      // and Binance both quote against multiple stablecoins (USDT, USDC,
+      // FDUSD, …) and a user can hold any of them.
+      let free = new Decimal(0)
+      let used = new Decimal(0)
+      for (const [coin, entry] of Object.entries(bal)) {
+        if (BALANCE_RESERVED_KEYS.has(coin)) continue
+        if (!STABLECOIN_TO_USD.has(coin.toUpperCase())) continue
+        if (typeof entry !== 'object' || entry === null) continue
+        const e = entry as Record<string, unknown>
+        free = free.plus(new Decimal(String(e['free'] ?? 0)))
+        used = used.plus(new Decimal(String(e['used'] ?? 0)))
+      }
+
+      // Aggregate P&L and market value from derivative positions.
       // We use position-level markPrice (which is fresh from the exchange's
       // websocket feed) rather than balance.total (which is a cached wallet
       // snapshot that may not update between funding/settlement cycles).
@@ -538,7 +665,6 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         unrealizedPnL = unrealizedPnL.plus(new Decimal(String(p.unrealizedPnl ?? 0)))
         realizedPnL = realizedPnL.plus(new Decimal(String((p as unknown as Record<string, unknown>).realizedPnl ?? 0)))
 
-        // Compute position market value from fresh markPrice
         const contracts = new Decimal(String(p.contracts ?? 0)).abs()
         const contractSize = new Decimal(String(p.contractSize ?? 1))
         const quantity = contracts.mul(contractSize)
@@ -546,10 +672,14 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         totalPositionValue = totalPositionValue.plus(quantity.mul(markPrice))
       }
 
-      // Reconstruct netLiquidation from fresh components:
-      //   netLiq = available cash + total position market value
-      // This gives a real-time equity figure that tracks markPrice movements,
-      // unlike balance.total which only updates on exchange settlement.
+      // Fold spot holdings (BTC/ETH/etc balances) into position value.
+      // They behave like long positions — capital converted from cash into
+      // an asset — so they count toward netLiquidation, not totalCashValue.
+      const spotHoldings = await this.fetchSpotHoldings(balance)
+      for (const sp of spotHoldings) {
+        totalPositionValue = totalPositionValue.plus(new Decimal(sp.marketValue))
+      }
+
       const netLiquidation = free.plus(totalPositionValue)
 
       return {
@@ -570,9 +700,12 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
 
     try {
       const fetchOverride = this.overrides.fetchPositions
-      const raw = fetchOverride
-        ? await fetchOverride(this.exchange, defaultFetchPositions)
-        : await defaultFetchPositions(this.exchange)
+      const [raw, spotHoldings] = await Promise.all([
+        fetchOverride
+          ? fetchOverride(this.exchange, defaultFetchPositions)
+          : defaultFetchPositions(this.exchange),
+        this.fetchSpotHoldings(),
+      ])
       const result: Position[] = []
 
       for (const p of raw) {
@@ -603,7 +736,10 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         })
       }
 
-      return result
+      // Spot holdings carry distinct contract identity (no settle suffix
+      // in aliceId), so they coexist with derivative positions on the
+      // same underlying — same model as ETF vs futures in IBKR.
+      return [...result, ...spotHoldings]
     } catch (err) {
       throw BrokerError.from(err)
     }

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -34,6 +34,7 @@ import {
   marketToContract,
   contractToCcxt,
 } from './ccxt-contracts.js'
+import { fuzzyRankContracts } from '../fuzzy-rank.js'
 import {
   type CcxtExchangeOverrides,
   exchangeOverrides,
@@ -253,32 +254,46 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
     // CCXT exchanges typically don't need explicit closing
   }
 
+  /**
+   * Re-pull the exchange market list. CCXT's `loadMarkets(true)` (the
+   * `reload=true` overload) bypasses the cached snapshot it built during
+   * init. Call from a cron periodically — newly listed pairs and
+   * delistings come along for the ride.
+   */
+  async refreshCatalog(): Promise<void> {
+    this.ensureInit()
+    await this.exchange.loadMarkets(true)
+    const marketCount = Object.keys(this.exchange.markets).length
+    console.log(`CcxtBroker[${this.id}]: catalog refreshed (${marketCount} markets)`)
+  }
+
   // ---- Contract search ----
 
   async searchContracts(pattern: string): Promise<ContractDescription[]> {
     this.ensureInit()
     if (!pattern) return []
 
-    const searchBase = pattern.toUpperCase()
-    const matchedMarkets: CcxtMarket[] = []
-
+    // Eligible candidate set: active markets with both legs of the pair, and
+    // quoted in a stablecoin / USD. This is the same filter the strict
+    // implementation used; we keep it so a "tesla" fuzzy hit doesn't drag in
+    // exotic-quote pairs the user almost certainly doesn't want.
+    const candidates: CcxtMarket[] = []
     for (const market of Object.values(this.markets)) {
       if (market.active === false) continue
-      // Some exchanges (e.g. hyperliquid spot) have markets without base/quote populated
       if (!market.base || !market.quote) continue
-      if (market.base.toUpperCase() !== searchBase) continue
-
       const quote = market.quote.toUpperCase()
       if (quote !== 'USDT' && quote !== 'USD' && quote !== 'USDC') continue
-
-      matchedMarkets.push(market)
+      candidates.push(market)
     }
 
-    // Sort: derivatives first (more common for trading), then stablecoin preference
+    // Pre-sort candidates by the broker's own preference (swap > future >
+    // spot > option, USDT > USD > USDC). fuzzyRankContracts is a stable sort
+    // and uses the input order as a tiebreaker, so this carries through —
+    // exact base matches keep showing up in the familiar derivative-first
+    // order, fuzzy hits inherit the same preference.
     const typeOrder: Record<string, number> = { swap: 0, future: 1, spot: 2, option: 3 }
     const quoteOrder: Record<string, number> = { USDT: 0, USD: 1, USDC: 2 }
-
-    matchedMarkets.sort((a, b) => {
+    candidates.sort((a, b) => {
       const aType = typeOrder[a.type as keyof typeof typeOrder] ?? 99
       const bType = typeOrder[b.type as keyof typeof typeOrder] ?? 99
       if (aType !== bType) return aType - bType
@@ -287,22 +302,37 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       return aQuote - bQuote
     })
 
-    // Collect derivative types available for this base asset
+    // Run candidates through the shared fuzzy ranker. Exact-base hits land in
+    // tier 100 (preserves the strict-matcher's behaviour for power users who
+    // type "BTC" and expect every BTC market); substring / name hits show up
+    // afterward so partial keywords (e.g. "tesl", "popcorn") still surface
+    // something useful.
+    const ranked = fuzzyRankContracts(
+      candidates.map((m) => {
+        const c = marketToContract(m, this.exchangeName)
+        return { contract: c, base: m.base, quote: m.quote, name: m.id ?? m.symbol }
+      }),
+      pattern,
+    )
+
+    // Index original markets by symbol so we can look up derivative-type
+    // metadata from each ranked hit.
+    const marketBySymbol = new Map<string, CcxtMarket>()
+    for (const m of candidates) marketBySymbol.set(m.symbol, m)
+
+    // derivativeSecTypes — surface what derivative product types appear in
+    // the result set, same shape as before.
     const derivativeTypes = new Set<string>()
-    for (const m of matchedMarkets) {
+    for (const desc of ranked) {
+      const m = marketBySymbol.get(desc.contract.localSymbol ?? '')
+      if (!m) continue
       if (m.type === 'future') derivativeTypes.add('FUT')
       if (m.type === 'option') derivativeTypes.add('OPT')
     }
-    const derivativeSecTypes: string[] | undefined = derivativeTypes.size > 0
-      ? Array.from(derivativeTypes)
-      : undefined
+    const derivativeSecTypes: string[] = derivativeTypes.size > 0 ? Array.from(derivativeTypes) : []
+    for (const desc of ranked) desc.derivativeSecTypes = derivativeSecTypes
 
-    return matchedMarkets.map(market => {
-      const desc = new ContractDescription()
-      desc.contract = marketToContract(market, this.exchangeName)
-      desc.derivativeSecTypes = derivativeSecTypes ?? []
-      return desc
-    })
+    return ranked
   }
 
   async getContractDetails(query: Contract): Promise<ContractDetails | null> {

--- a/src/domain/trading/brokers/fuzzy-rank.spec.ts
+++ b/src/domain/trading/brokers/fuzzy-rank.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { Contract } from '@traderalice/ibkr'
+import { fuzzyRankContracts, type FuzzyRankInput } from './fuzzy-rank.js'
+
+function entry(
+  symbol: string,
+  opts: { base?: string; quote?: string; name?: string; localSymbol?: string; secType?: string } = {},
+): FuzzyRankInput {
+  const c = new Contract()
+  c.symbol = symbol
+  c.localSymbol = opts.localSymbol ?? ''
+  c.description = ''
+  c.secType = opts.secType ?? 'STK'
+  return { contract: c, base: opts.base, quote: opts.quote, name: opts.name }
+}
+
+const symbolsOf = (xs: ReturnType<typeof fuzzyRankContracts>): string[] => xs.map((x) => x.contract.symbol)
+
+describe('fuzzyRankContracts', () => {
+  it('returns nothing for empty query', () => {
+    expect(fuzzyRankContracts([entry('AAPL')], '')).toEqual([])
+  })
+
+  it('drops entries with zero score', () => {
+    const cat = [entry('AAPL', { name: 'Apple Inc.' }), entry('XYZ', { name: 'Nothing' })]
+    expect(symbolsOf(fuzzyRankContracts(cat, 'apple'))).toEqual(['AAPL'])
+  })
+
+  it('exact symbol match outranks substring', () => {
+    const cat = [
+      entry('CORNING', { name: 'Corning Inc' }),
+      entry('CORN', { name: 'Teucrium Commodity Trust' }),
+    ]
+    expect(symbolsOf(fuzzyRankContracts(cat, 'CORN'))).toEqual(['CORN', 'CORNING'])
+  })
+
+  it('exact base match outranks substring (CCXT-style)', () => {
+    const cat = [
+      entry('CORN', { base: 'CORN', quote: 'USDT', localSymbol: 'CORN/USDT' }),
+      entry('POPCORN', { base: 'POPCORN', quote: 'USDT', localSymbol: 'POPCORN/USDT' }),
+    ]
+    expect(symbolsOf(fuzzyRankContracts(cat, 'corn'))).toEqual(['CORN', 'POPCORN'])
+  })
+
+  it('exact name match also lands at the top', () => {
+    const cat = [entry('TLT', { name: 'iShares 20+ Year Treasury Bond ETF' }), entry('GLD', { name: 'Gold' })]
+    expect(symbolsOf(fuzzyRankContracts(cat, 'gold'))).toEqual(['GLD'])
+  })
+
+  it('symbol prefix beats arbitrary substring', () => {
+    const cat = [entry('AAPLW', { name: 'Apple Warrant' }), entry('SAAPL', { name: 'Some Apple Index' })]
+    expect(symbolsOf(fuzzyRankContracts(cat, 'AAPL'))).toEqual(['AAPLW', 'SAAPL'])
+  })
+
+  it('name word-boundary match beats name substring', () => {
+    const cat = [
+      entry('GS', { name: 'Goldman Sachs Group' }),       // 'gold' substring inside 'Goldman' — no word boundary
+      entry('GFI', { name: 'Gold Fields Ltd' }),          // word-boundary "Gold "
+    ]
+    expect(symbolsOf(fuzzyRankContracts(cat, 'gold'))).toEqual(['GFI', 'GS'])
+  })
+
+  it('escapes regex metacharacters in the query', () => {
+    // BRK.B contains a dot; "B.B" should not be treated as a wildcard.
+    const cat = [entry('BRK.B', { name: 'Berkshire Hathaway B' })]
+    expect(symbolsOf(fuzzyRankContracts(cat, 'BRK.B'))).toEqual(['BRK.B'])
+    // "B.B" pattern shouldn't match BBB-like rows via regex wildcard.
+    expect(symbolsOf(fuzzyRankContracts([entry('BBB')], 'B.B'))).toEqual([])
+  })
+
+  it('respects limit', () => {
+    const cat = Array.from({ length: 80 }, (_, i) => entry(`SYM${i}`, { name: `Test ${i}` }))
+    expect(fuzzyRankContracts(cat, 'sym', { limit: 5 })).toHaveLength(5)
+  })
+
+  it('default limit is 50', () => {
+    const cat = Array.from({ length: 80 }, (_, i) => entry(`SYM${i}`))
+    expect(fuzzyRankContracts(cat, 'sym')).toHaveLength(50)
+  })
+
+  it('preserves upstream order on ties', () => {
+    const cat = [entry('A1', { name: 'apple one' }), entry('A2', { name: 'apple two' }), entry('A3', { name: 'apple three' })]
+    // All three score equally on "apple" name-startsWith — original order should win.
+    expect(symbolsOf(fuzzyRankContracts(cat, 'apple'))).toEqual(['A1', 'A2', 'A3'])
+  })
+
+  it('quote-currency match is a low-priority fallback', () => {
+    // "USDT" should rank pairs by other signals first; pure quote-only matches end up last.
+    const cat = [
+      entry('USDT-Reserve', { name: 'Tether reserve token', base: 'USDT', quote: 'USD' }), // exact base USDT
+      entry('BTC', { base: 'BTC', quote: 'USDT', localSymbol: 'BTC/USDT' }),                // quote-only USDT
+    ]
+    expect(symbolsOf(fuzzyRankContracts(cat, 'USDT'))).toEqual(['USDT-Reserve', 'BTC'])
+  })
+
+  it('handles missing fields gracefully', () => {
+    const c = new Contract()
+    c.symbol = 'X'
+    expect(fuzzyRankContracts([{ contract: c }], 'x')).toHaveLength(1)
+    expect(fuzzyRankContracts([{ contract: c }], 'y')).toHaveLength(0)
+  })
+})

--- a/src/domain/trading/brokers/fuzzy-rank.ts
+++ b/src/domain/trading/brokers/fuzzy-rank.ts
@@ -1,0 +1,99 @@
+/**
+ * Fuzzy ranking for broker catalog entries.
+ *
+ * Brokers that expose their full catalog (Alpaca via /v2/assets, every CCXT
+ * exchange via loadMarkets, Mock via a hardcoded list) implement
+ * `searchContracts` as "score each cached entry against the query, sort by
+ * score, return the top N". This is the scoring function they share.
+ *
+ * Brokers that ship with a server-side fuzzy endpoint (IBKR's
+ * reqMatchingSymbols) bypass this entirely — they're SearchingCatalogs
+ * and trust the broker's own ranking.
+ *
+ * Scoring is intentionally a small bag of tiers rather than something
+ * subtler — predictable beats clever for a function that has to debug-by-
+ * eyeball when a broker's data changes shape.
+ */
+
+import { ContractDescription, Contract } from '@traderalice/ibkr'
+
+export interface FuzzyRankInput {
+  /** Catalog entries to rank. Anything with at least a symbol works. */
+  contract: Pick<Contract, 'symbol' | 'localSymbol' | 'description' | 'currency' | 'secType'>
+  /** Optional broker-derived hints. CCXT splits its symbol into base/quote;
+   *  Alpaca stores the long company name on the asset. Both contribute to
+   *  ranking but neither is required. */
+  base?: string
+  quote?: string
+  name?: string
+}
+
+export interface FuzzyRankOptions {
+  /** Cap the result count. Default 50; broker UIs can't usefully render more. */
+  limit?: number
+}
+
+/**
+ * Score a catalog entry against the query. Higher is better.
+ *
+ *   100 — exact match on symbol, base, or name
+ *    80 — symbol/base startsWith query
+ *    70 — name starts at a word boundary with the query
+ *    50 — name has the query as a whole word
+ *    30 — symbol/name contains the query as a substring
+ *     0 — no signal; entry is dropped
+ *
+ * Mirrors the scoring used by aggregateSymbolSearch on the data side, so
+ * "type partial keyword" feels the same in both halves of the workbench.
+ */
+function score(query: string, entry: FuzzyRankInput): number {
+  const q = query.toLowerCase()
+  if (!q) return 0
+
+  const sym = (entry.contract.symbol ?? '').toLowerCase()
+  const local = (entry.contract.localSymbol ?? '').toLowerCase()
+  const base = (entry.base ?? '').toLowerCase()
+  const quote = (entry.quote ?? '').toLowerCase()
+  const name = (entry.name ?? entry.contract.description ?? '').toLowerCase()
+
+  if (sym === q || base === q || name === q) return 100
+  if ((sym && sym.startsWith(q)) || (base && base.startsWith(q))) return 80
+  if (name.startsWith(q) && (name.length === q.length || !/[a-z0-9]/i.test(name[q.length]))) return 70
+
+  // Build a regex once per call — escape user input so symbols like `BRK.B`
+  // don't accidentally turn into regex metacharacters.
+  const wbRe = new RegExp(`\\b${q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+  if (name && wbRe.test(name)) return 50
+
+  if (sym.includes(q) || local.includes(q) || name.includes(q)) return 30
+  // Quote currency match is the weakest signal — only triggers if nothing
+  // else fits, so "USDT" doesn't dominate the result list.
+  if (quote === q) return 20
+  return 0
+}
+
+export function fuzzyRankContracts(
+  entries: FuzzyRankInput[],
+  query: string,
+  options: FuzzyRankOptions = {},
+): ContractDescription[] {
+  const q = query.trim()
+  if (!q) return []
+
+  // Precompute scores once; stable-sort by (-score, original index) so
+  // upstream broker order acts as a tiebreaker — useful for CCXT where the
+  // exchange returns markets in a roughly liquidity-ordered way.
+  const scored = entries
+    .map((e, i) => ({ e, i, s: score(q, e) }))
+    .filter((x) => x.s > 0)
+    .sort((a, b) => (b.s - a.s) || (a.i - b.i))
+
+  const limit = options.limit ?? 50
+  const top = scored.slice(0, limit)
+
+  return top.map((x) => {
+    const desc = new ContractDescription()
+    desc.contract = Object.assign(new Contract(), x.e.contract)
+    return desc
+  })
+}

--- a/src/domain/trading/brokers/types.ts
+++ b/src/domain/trading/brokers/types.ts
@@ -204,6 +204,17 @@ export interface IBroker<TMeta = unknown> {
   searchContracts(pattern: string): Promise<ContractDescription[]>
   getContractDetails(query: Contract): Promise<ContractDetails | null>
 
+  /**
+   * Refresh the broker's local catalog cache from upstream.
+   * Optional — only EnumeratingCatalog brokers (Alpaca / CCXT / Mock)
+   * implement this. SearchingCatalog brokers (IBKR via reqMatchingSymbols)
+   * leave it undefined; the cron loop in main.ts skips them via `?.`.
+   *
+   * Implementations should keep the prior cache on failure and let the
+   * exception propagate so the caller can log.
+   */
+  refreshCatalog?(): Promise<void>
+
   // ---- Trading operations (IBKR Order as source of truth) ----
 
   placeOrder(contract: Contract, order: Order, tpsl?: TpSlParams): Promise<PlaceOrderResult>

--- a/src/domain/trading/contract-search-rules.md
+++ b/src/domain/trading/contract-search-rules.md
@@ -1,0 +1,99 @@
+# Contract search normalization rules
+
+## What this is
+
+A small set of pure functions that translate a **data-vendor symbol**
+(what yfinance / FMP / similar return — e.g. `BTCUSD`, `EURUSD`,
+`AAPL`) into a **broker search pattern** (what each `Broker.searchContracts`
+implementation actually expects — e.g. `BTC`, `EUR`, `AAPL`).
+
+Lives in `contract-search-rules.ts`, alongside the rest of the
+contract-search domain layer.
+
+## Why it lives in its own file
+
+Three places call broker-side contract search, all of them needing the
+same normalization:
+
+- AI tool `searchContracts` (`src/tool/trading.ts`) — invoked by an LLM
+  that may have just been looking at market-data symbols.
+- HTTP route `/api/trading/contracts/search` (`src/connectors/web/routes/trading.ts`)
+  — invoked by the UI from a `/market/:assetClass/:symbol` page.
+- UI panel `TradeableContractsPanel` (the route's only current consumer).
+
+If the rules lived inside any one of them, the others would silently
+drift. Pulling them out gives one place to fix conventions when a new
+broker shows up or when a vendor changes how it spells crypto pairs.
+
+## The non-negotiable rule
+
+**Data-vendor symbol identity is NOT trading symbol identity.**
+
+This module's job is *not* to make them equal. It does the smallest
+possible normalization that lets a broker's deliberately-strict
+matcher return something useful for the user. After that, the
+canonical identity downstream is the broker's `aliceId`
+(`alias:broker:exchange-id`) — that's what `placeOrder` and friends
+key off, never the raw symbol the data vendor reported.
+
+The bridge is heuristic on purpose. If we get hits, great. If we
+don't, the user-facing card says "no matches" and the user moves on.
+We don't try to be clever in either direction.
+
+## Current rules
+
+| Asset class            | Rule                                                                                                | Why                                                                                                                                                                |
+|------------------------|-----------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `equity` / `commodity` | identity (no change)                                                                                | Data vendor and broker conventions match — `AAPL` is `AAPL` everywhere we currently care about.                                                                    |
+| `crypto` / `currency`  | strip a known quote-currency suffix (USDT/USDC/BUSD/USD/EUR/JPY/GBP/CNY); base must be ≥ 2 chars     | Vendors concatenate (`BTCUSD`, `EURUSD`); CCXT's `searchContracts` does base-only equality. Stripping the quote currency recovers the broker's expected pattern. The ≥ 2 floor avoids murdering tickers like `LUSD` (the Liquity stablecoin) into `L`. |
+| `unknown` / not given  | identity                                                                                            | Don't speculate. Caller knows the asset class or they don't — guessing produces worse failures than passing through.                                              |
+
+## When to add a rule
+
+Only when an actual provider/broker case has been observed failing in
+production or QA. Examples we expect to bump into eventually:
+
+- IBKR option chains return symbols with embedded expiry/strike that
+  brokers don't accept verbatim.
+- Some brokers want `BRK.B`, others want `BRK-B`.
+- yfinance currency pairs come as `EUR=X` (note the `=X` suffix).
+
+When that happens: add a branch in `normalizeBrokerSearchPattern`,
+add a test to `contract-search-rules.spec.ts`, add a row to the
+table above. Each rule should be the smallest change that fixes the
+observed case.
+
+## When NOT to add a rule
+
+- **Don't loosen the broker's strict matching to compensate.** Strict
+  matching is a feature — `CcxtBroker.searchContracts` uses base-only
+  equality on purpose so a search for `BTC` doesn't pollute the result
+  list with every meme token whose symbol happens to contain those
+  three letters.
+- **Don't try to bridge identities.** If a normalization rule starts
+  reaching for the broker's `aliceId` or the contract's `conId`, stop.
+  That belongs at a different layer (and probably means we're using
+  this function for the wrong purpose).
+- **Don't add speculative rules.** "What if some broker someday wants
+  X" is not a reason. Wait for the actual case; the rule will be
+  cleaner when you can see it.
+
+## How a future change should look
+
+```ts
+// inside normalizeBrokerSearchPattern
+case 'crypto':
+case 'currency':
+  return stripQuoteCurrency(symbol)
+case 'option':                                    // <- new
+  return parseOccSymbol(symbol)?.underlying ?? symbol
+```
+
+Plus:
+
+- A new test in `contract-search-rules.spec.ts` covering one happy
+  case and at least one shape that *shouldn't* match the new rule
+  (so future edits know the rule's boundary).
+- A new row in the table above.
+- A line in the relevant `Broker.searchContracts` docstring if the
+  broker side has matching expectations.

--- a/src/domain/trading/contract-search-rules.spec.ts
+++ b/src/domain/trading/contract-search-rules.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeBrokerSearchPattern } from './contract-search-rules.js'
+
+describe('normalizeBrokerSearchPattern', () => {
+  describe('crypto / currency: strip known quote currency suffix', () => {
+    it('strips USD from crypto pair', () => {
+      expect(normalizeBrokerSearchPattern('BTCUSD', 'crypto')).toBe('BTC')
+    })
+
+    it('strips USDT (longer match wins over USD)', () => {
+      expect(normalizeBrokerSearchPattern('SOLUSDT', 'crypto')).toBe('SOL')
+    })
+
+    it('strips USDC', () => {
+      expect(normalizeBrokerSearchPattern('ETHUSDC', 'crypto')).toBe('ETH')
+    })
+
+    it('strips USD from currency pair', () => {
+      expect(normalizeBrokerSearchPattern('EURUSD', 'currency')).toBe('EUR')
+    })
+
+    it('lowercases input still produces uppercase base', () => {
+      expect(normalizeBrokerSearchPattern('btcusd', 'crypto')).toBe('BTC')
+    })
+
+    it('leaves a symbol unchanged when no known quote suffix matches', () => {
+      // BTC is not in the strip list, so ETHBTC must NOT lose its tail.
+      expect(normalizeBrokerSearchPattern('ETHBTC', 'crypto')).toBe('ETHBTC')
+    })
+
+    it('leaves a too-short base alone (LUSD is the Liquity stablecoin)', () => {
+      // Stripping USD would leave just "L" — clearly worse than passing through.
+      expect(normalizeBrokerSearchPattern('LUSD', 'crypto')).toBe('LUSD')
+    })
+
+    it('leaves bare base symbols alone', () => {
+      expect(normalizeBrokerSearchPattern('BTC', 'crypto')).toBe('BTC')
+    })
+  })
+
+  describe('equity / commodity: identity', () => {
+    it('passes equity ticker through unchanged', () => {
+      expect(normalizeBrokerSearchPattern('AAPL', 'equity')).toBe('AAPL')
+    })
+
+    it('does not strip from equity even when it looks like a pair', () => {
+      // Some real tickers happen to look like FX pairs (rare, but defend).
+      expect(normalizeBrokerSearchPattern('EURUSD', 'equity')).toBe('EURUSD')
+    })
+
+    it('passes commodity id unchanged', () => {
+      expect(normalizeBrokerSearchPattern('gold', 'commodity')).toBe('gold')
+    })
+  })
+
+  describe('unknown / default', () => {
+    it('passes through when asset class is omitted', () => {
+      expect(normalizeBrokerSearchPattern('BTCUSD')).toBe('BTCUSD')
+    })
+
+    it('passes through when asset class is unknown', () => {
+      expect(normalizeBrokerSearchPattern('BTCUSD', 'unknown')).toBe('BTCUSD')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns empty string unchanged', () => {
+      expect(normalizeBrokerSearchPattern('', 'crypto')).toBe('')
+    })
+
+    it('trims surrounding whitespace', () => {
+      expect(normalizeBrokerSearchPattern('  BTCUSD  ', 'crypto')).toBe('BTC')
+    })
+  })
+})

--- a/src/domain/trading/contract-search-rules.ts
+++ b/src/domain/trading/contract-search-rules.ts
@@ -1,0 +1,55 @@
+/**
+ * Contract search normalization rules.
+ *
+ * If anything below looks arbitrary, read `./contract-search-rules.md`
+ * before changing it. The doc has design rationale, the list of cases
+ * we deliberately don't handle, and a "when NOT to add a rule" section.
+ *
+ * The bridge between data-vendor symbols (yfinance / FMP / …) and
+ * broker tickers (CcxtBroker / AlpacaBroker / IBKR / …) is heuristic
+ * by design; this file is the only place that heuristic lives so AI
+ * tool, HTTP route, and UI panel all share one set of rules.
+ */
+
+export type AssetClassHint = 'equity' | 'crypto' | 'currency' | 'commodity' | 'unknown'
+
+/** Quote currencies we strip from concatenated crypto/FX symbols.
+ *  Order is significant: longer prefixes first so `USDT` matches before `USD`. */
+const QUOTE_CURRENCIES = ['USDT', 'USDC', 'BUSD', 'USD', 'EUR', 'JPY', 'GBP', 'CNY'] as const
+
+const QUOTE_SUFFIX_RE = new RegExp(
+  `^([A-Z0-9]{2,})(?:${QUOTE_CURRENCIES.join('|')})$`,
+  'i',
+)
+
+/**
+ * Translate a data-vendor symbol into the pattern the broker layer
+ * actually understands.
+ *
+ * - equity / commodity / unknown → identity (vendor and broker agree)
+ * - crypto / currency → strip a known quote-currency suffix when the
+ *   remaining base is at least two characters; otherwise identity.
+ *
+ * This function is intentionally minimal. See `contract-search-rules.md`
+ * for what to add and what to leave alone.
+ */
+export function normalizeBrokerSearchPattern(
+  symbol: string,
+  assetClass: AssetClassHint = 'unknown',
+): string {
+  const trimmed = symbol.trim()
+  if (!trimmed) return trimmed
+
+  switch (assetClass) {
+    case 'crypto':
+    case 'currency': {
+      const m = trimmed.match(QUOTE_SUFFIX_RE)
+      return m ? m[1].toUpperCase() : trimmed
+    }
+    case 'equity':
+    case 'commodity':
+    case 'unknown':
+    default:
+      return trimmed
+  }
+}

--- a/src/domain/trading/contract-search.ts
+++ b/src/domain/trading/contract-search.ts
@@ -15,6 +15,10 @@
 
 import type { ContractDescription } from '@traderalice/ibkr'
 import type { AccountManager } from './account-manager.js'
+import {
+  normalizeBrokerSearchPattern,
+  type AssetClassHint,
+} from './contract-search-rules.js'
 
 export interface ContractSearchHit {
   /** UTA account id that the contract lives on (e.g. "alpaca-paper"). */
@@ -26,7 +30,14 @@ export interface ContractSearchHit {
 export async function searchTradeableContracts(
   manager: AccountManager,
   pattern: string,
+  assetClass: AssetClassHint = 'unknown',
 ): Promise<ContractSearchHit[]> {
+  // Translate data-vendor symbol to a broker-friendly pattern. The rule set
+  // and its rationale live in `./contract-search-rules.md` — read that
+  // before changing what gets normalized.
+  const brokerPattern = normalizeBrokerSearchPattern(pattern, assetClass)
+  if (!brokerPattern) return []
+
   const targets = manager.resolve()
   if (targets.length === 0) return []
 
@@ -35,7 +46,7 @@ export async function searchTradeableContracts(
   // whole sweep — the original AI tool used try/catch in a for-loop for the
   // same reason. Promise.allSettled lets it run concurrently.
   const settled = await Promise.allSettled(
-    targets.map(async (uta) => ({ id: uta.id, results: await uta.searchContracts(pattern) })),
+    targets.map(async (uta) => ({ id: uta.id, results: await uta.searchContracts(brokerPattern) })),
   )
   for (const r of settled) {
     if (r.status !== 'fulfilled') continue

--- a/src/domain/trading/contract-search.ts
+++ b/src/domain/trading/contract-search.ts
@@ -1,0 +1,51 @@
+/**
+ * Aggregate broker-side contract search across all configured UTAs.
+ *
+ * Shared by the AI tool (`searchContracts`) and the HTTP route
+ * (`GET /api/trading/contracts/search`) — both surfaces must return the
+ * same shape so a Market workbench card and an LLM see exactly what the
+ * other one would.
+ *
+ * Important — this is the **trading**-side identity layer. The pattern
+ * is matched fuzzy / heuristically against each broker's catalogue and
+ * the returned `aliceId` is the canonical identifier downstream order
+ * APIs expect. Don't try to bridge the resulting symbol back to a
+ * data-vendor identity (that's structurally a different namespace).
+ */
+
+import type { ContractDescription } from '@traderalice/ibkr'
+import type { AccountManager } from './account-manager.js'
+
+export interface ContractSearchHit {
+  /** UTA account id that the contract lives on (e.g. "alpaca-paper"). */
+  source: string
+  contract: ContractDescription['contract']
+  derivativeSecTypes: string[]
+}
+
+export async function searchTradeableContracts(
+  manager: AccountManager,
+  pattern: string,
+): Promise<ContractSearchHit[]> {
+  const targets = manager.resolve()
+  if (targets.length === 0) return []
+
+  const hits: ContractSearchHit[] = []
+  // Settle individually so a single broker's failure doesn't take down the
+  // whole sweep — the original AI tool used try/catch in a for-loop for the
+  // same reason. Promise.allSettled lets it run concurrently.
+  const settled = await Promise.allSettled(
+    targets.map(async (uta) => ({ id: uta.id, results: await uta.searchContracts(pattern) })),
+  )
+  for (const r of settled) {
+    if (r.status !== 'fulfilled') continue
+    for (const desc of r.value.results) {
+      hits.push({
+        source: r.value.id,
+        contract: desc.contract,
+        derivativeSecTypes: desc.derivativeSecTypes,
+      })
+    }
+  }
+  return hits
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -427,11 +427,29 @@ async function main() {
 
   console.log('engine: started')
 
+  // ==================== Broker catalog refresh ====================
+  // Brokers that cache their catalog locally (Alpaca, CCXT, Mock) need
+  // periodic refreshes so newly listed assets surface in search and
+  // delisted ones drop. The optional `refreshCatalog` is a no-op for
+  // brokers that don't cache (IBKR — server-side reqMatchingSymbols).
+  const CATALOG_REFRESH_MS = 6 * 60 * 60 * 1000  // 6h
+  const catalogRefreshTimer = setInterval(() => {
+    for (const uta of accountManager.resolve()) {
+      uta.refreshCatalog().catch((err) => {
+        console.warn(`[catalog-refresh] ${uta.id} failed:`, err instanceof Error ? err.message : err)
+      })
+    }
+  }, CATALOG_REFRESH_MS)
+  // Don't keep the process alive just for the refresh loop — shutdown logic
+  // below clears it anyway, this is belt-and-braces for clean Node exit.
+  catalogRefreshTimer.unref?.()
+
   // ==================== Shutdown ====================
 
   let stopped = false
   const shutdown = async () => {
     stopped = true
+    clearInterval(catalogRefreshTimer)
     newsCollector?.stop()
     snapshotScheduler.stop()
     heartbeat.stop()

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -13,6 +13,7 @@ import { Contract, UNSET_DECIMAL } from '@traderalice/ibkr'
 import type { AccountManager } from '@/domain/trading/account-manager.js'
 import { BrokerError, type OpenOrder } from '@/domain/trading/brokers/types.js'
 import type { FxService } from '@/domain/trading/fx-service.js'
+import { normalizeBrokerSearchPattern } from '@/domain/trading/contract-search-rules.js'
 import '@/domain/trading/contract-ext.js'
 
 /** Classify a broker error into a structured response for AI consumption. */
@@ -89,26 +90,36 @@ export function createTradingTools(manager: AccountManager, fxService?: FxServic
 
     searchContracts: tool({
       description: `Search broker accounts for tradeable contracts matching a pattern.
-This is a BROKER-LEVEL search — it queries your connected trading accounts.`,
+This is a BROKER-LEVEL search — it queries your connected trading accounts.
+
+Pass \`assetClass\` when known (especially "crypto" or "currency") so the
+data-vendor symbol is normalized into a broker-friendly pattern — e.g. a
+search for "BTCUSD" with assetClass="crypto" is rewritten to "BTC" before
+hitting the broker, which otherwise expects the bare base ticker.`,
       inputSchema: z.object({
         pattern: z.string().describe('Symbol or keyword to search'),
+        assetClass: z.enum(['equity', 'crypto', 'currency', 'commodity', 'unknown']).optional()
+          .describe('Asset class hint. Improves matching for crypto/currency where data symbols concatenate quote currency.'),
         source: z.string().optional().describe(sourceDesc(false)),
       }),
-      execute: async ({ pattern, source }) => {
-        // Source-scoped search reuses the same domain helper logic via a
-        // thin wrapper: when the caller pinned an account, only that one
-        // is hit; otherwise we fan out to all of them.
+      execute: async ({ pattern, assetClass, source }) => {
+        // Symbol → broker pattern: see src/domain/trading/contract-search-rules.md
+        // for what the normalization does and why.
+        const brokerPattern = normalizeBrokerSearchPattern(pattern, assetClass ?? 'unknown')
+        if (!brokerPattern) return { results: [], message: 'Empty pattern.' }
+        // Source-scoped: when the caller pinned an account, only that one is
+        // hit; otherwise fan out to all configured accounts.
         const targets = manager.resolve(source)
         if (targets.length === 0) return { error: 'No accounts available.' }
         const all: Array<Record<string, unknown>> = []
         const settled = await Promise.allSettled(
-          targets.map(async (uta) => ({ id: uta.id, results: await uta.searchContracts(pattern) })),
+          targets.map(async (uta) => ({ id: uta.id, results: await uta.searchContracts(brokerPattern) })),
         )
         for (const r of settled) {
           if (r.status !== 'fulfilled') continue
           for (const desc of r.value.results) all.push({ source: r.value.id, ...desc })
         }
-        if (all.length === 0) return { results: [], message: `No contracts found matching "${pattern}".` }
+        if (all.length === 0) return { results: [], message: `No contracts found matching "${brokerPattern}" (input: "${pattern}").` }
         return all
       },
     }),

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -95,17 +95,21 @@ This is a BROKER-LEVEL search — it queries your connected trading accounts.`,
         source: z.string().optional().describe(sourceDesc(false)),
       }),
       execute: async ({ pattern, source }) => {
+        // Source-scoped search reuses the same domain helper logic via a
+        // thin wrapper: when the caller pinned an account, only that one
+        // is hit; otherwise we fan out to all of them.
         const targets = manager.resolve(source)
         if (targets.length === 0) return { error: 'No accounts available.' }
-        const allResults: Array<Record<string, unknown>> = []
-        for (const uta of targets) {
-          try {
-            const descriptions = await uta.searchContracts(pattern)
-            for (const desc of descriptions) allResults.push({ source: uta.id, ...desc })
-          } catch { /* skip */ }
+        const all: Array<Record<string, unknown>> = []
+        const settled = await Promise.allSettled(
+          targets.map(async (uta) => ({ id: uta.id, results: await uta.searchContracts(pattern) })),
+        )
+        for (const r of settled) {
+          if (r.status !== 'fulfilled') continue
+          for (const desc of r.value.results) all.push({ source: r.value.id, ...desc })
         }
-        if (allResults.length === 0) return { results: [], message: `No contracts found matching "${pattern}".` }
-        return allResults
+        if (all.length === 0) return { results: [], message: `No contracts found matching "${pattern}".` }
+        return all
       },
     }),
 

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -180,9 +180,17 @@ export const tradingApi = {
    * Heuristic broker-side search across all configured accounts. Used by the
    * Market workbench to surface tradeable contracts matching a data-vendor
    * symbol — the bridge is intentionally fuzzy / display-only.
+   *
+   * `assetClass` lets the backend pick the right normalization rule (e.g.
+   * crypto/currency strip the quote-currency suffix). See
+   * `src/domain/trading/contract-search-rules.md` for the rule set.
    */
-  async searchContracts(pattern: string): Promise<ContractSearchResponse> {
+  async searchContracts(
+    pattern: string,
+    assetClass?: 'equity' | 'crypto' | 'currency' | 'commodity',
+  ): Promise<ContractSearchResponse> {
     const qs = new URLSearchParams({ pattern })
+    if (assetClass) qs.set('assetClass', assetClass)
     return fetchJson(`/api/trading/contracts/search?${qs}`)
   },
 

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -1,6 +1,31 @@
 import { fetchJson } from './client'
 import type { TradingAccount, AccountSummary, AccountInfo, Position, WalletCommitLog, ReconnectResult, AccountConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerTypeInfo, BrokerConfigField, UTASnapshotSummary, EquityCurvePoint } from './types'
 
+/** One contract returned by the broker-side fuzzy search. Shape mirrors what
+ *  the AI tool emits — same canonical aliceId for downstream order routing. */
+export interface ContractSearchHit {
+  source: string
+  contract: {
+    aliceId?: string
+    symbol?: string
+    secType?: string
+    exchange?: string
+    primaryExchange?: string
+    currency?: string
+    localSymbol?: string
+    description?: string
+    [key: string]: unknown
+  }
+  derivativeSecTypes: string[]
+}
+
+export interface ContractSearchResponse {
+  results: ContractSearchHit[]
+  count: number
+  /** 0 when no UTAs are configured; lets the UI nudge towards /trading/config. */
+  accountsConfigured?: number
+}
+
 // ==================== Unified Trading API ====================
 
 export const tradingApi = {
@@ -147,6 +172,18 @@ export const tradingApi = {
     if (opts?.startTime) params.set('startTime', opts.startTime)
     if (opts?.endTime) params.set('endTime', opts.endTime)
     return fetchJson(`/api/trading/snapshots/equity-curve?${params}`)
+  },
+
+  // ==================== Contract search ====================
+
+  /**
+   * Heuristic broker-side search across all configured accounts. Used by the
+   * Market workbench to surface tradeable contracts matching a data-vendor
+   * symbol — the bridge is intentionally fuzzy / display-only.
+   */
+  async searchContracts(pattern: string): Promise<ContractSearchResponse> {
+    const qs = new URLSearchParams({ pattern })
+    return fetchJson(`/api/trading/contracts/search?${qs}`)
   },
 
   // ==================== Connection Testing ====================

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { tradingApi, type ContractSearchHit } from '../../api/trading'
+import type { AssetClass } from '../../api/market'
 import { Card } from './Card'
 
 interface Props {
   /** The data-vendor symbol the user is currently viewing. */
   symbol: string
+  /** Asset class hint forwarded to the broker-side search rule set. */
+  assetClass: AssetClass
 }
 
 /**
@@ -16,7 +19,7 @@ interface Props {
  * on this, where would I do it?" — and so we get a non-AI inspection
  * window into UTA contract state for debugging.
  */
-export function TradeableContractsPanel({ symbol }: Props) {
+export function TradeableContractsPanel({ symbol, assetClass }: Props) {
   const [hits, setHits] = useState<ContractSearchHit[] | null>(null)
   const [accountsConfigured, setAccountsConfigured] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
@@ -26,7 +29,7 @@ export function TradeableContractsPanel({ symbol }: Props) {
     let cancelled = false
     setLoading(true)
     setError(null)
-    tradingApi.searchContracts(symbol)
+    tradingApi.searchContracts(symbol, assetClass)
       .then((res) => {
         if (cancelled) return
         setHits(res.results)
@@ -35,7 +38,7 @@ export function TradeableContractsPanel({ symbol }: Props) {
       .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
-  }, [symbol])
+  }, [symbol, assetClass])
 
   const info = [
     'Endpoint: /api/trading/contracts/search',

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { tradingApi, type ContractSearchHit } from '../../api/trading'
+import { Card } from './Card'
+
+interface Props {
+  /** The data-vendor symbol the user is currently viewing. */
+  symbol: string
+}
+
+/**
+ * Bridges the analysis surface to the trading surface without merging
+ * their identities. Searches every configured UTA's broker for contracts
+ * matching the data-side symbol heuristically and lists them with their
+ * canonical alice ids so a curious user can answer "if I wanted to act
+ * on this, where would I do it?" — and so we get a non-AI inspection
+ * window into UTA contract state for debugging.
+ */
+export function TradeableContractsPanel({ symbol }: Props) {
+  const [hits, setHits] = useState<ContractSearchHit[] | null>(null)
+  const [accountsConfigured, setAccountsConfigured] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    tradingApi.searchContracts(symbol)
+      .then((res) => {
+        if (cancelled) return
+        setHits(res.results)
+        setAccountsConfigured(res.accountsConfigured ?? null)
+      })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [symbol])
+
+  const info = [
+    'Endpoint: /api/trading/contracts/search',
+    'Heuristic broker-side fuzzy match — symbol on the analysis side is just a query string here, not the canonical id.',
+    'Tradeable identity is the broker\u2019s aliceId (alias:broker:exchange-id). Use it to actually place orders.',
+  ].join('\n')
+
+  return (
+    <Card title="Tradeable on configured brokers" info={info}>
+      {loading && <div className="text-[12px] text-text-muted">Searching brokers…</div>}
+      {error && !loading && <div className="text-[12px] text-red-400">{error}</div>}
+
+      {!loading && !error && accountsConfigured === 0 && (
+        <div className="text-[12px] text-text-muted">
+          No trading accounts configured.{' '}
+          <Link to="/trading" className="text-accent hover:underline">
+            Add one in Trading
+          </Link>
+          {' '}to see matching contracts here.
+        </div>
+      )}
+
+      {!loading && !error && accountsConfigured !== 0 && hits && hits.length === 0 && (
+        <div className="text-[12px] text-text-muted">
+          No tradeable contracts matching <span className="font-mono">{symbol}</span> on your configured brokers.
+        </div>
+      )}
+
+      {!loading && !error && hits && hits.length > 0 && (
+        <ul className="flex flex-col divide-y divide-border/40 -mx-3">
+          {hits.map((h, i) => (
+            <ContractRow key={`${h.source}:${h.contract.aliceId ?? i}`} hit={h} />
+          ))}
+        </ul>
+      )}
+    </Card>
+  )
+}
+
+function ContractRow({ hit }: { hit: ContractSearchHit }) {
+  const c = hit.contract
+  const aliceId = c.aliceId as string | undefined
+  return (
+    <li className="px-3 py-2 flex items-baseline gap-3 text-[12px] hover:bg-bg-tertiary/40 transition-colors">
+      <span className="font-mono font-semibold text-text">{c.symbol ?? '—'}</span>
+      {c.secType && (
+        <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
+          {c.secType}
+        </span>
+      )}
+      <span className="text-text-muted/70 truncate flex-1">
+        {[c.description || c.localSymbol, c.primaryExchange ?? c.exchange, c.currency]
+          .filter(Boolean)
+          .join(' · ')}
+      </span>
+      <span className="text-[10px] text-text-muted/60 shrink-0">{hit.source}</span>
+      {aliceId && (
+        <code
+          className="text-[10px] font-mono text-text-muted truncate max-w-[260px]"
+          title={aliceId}
+        >
+          {aliceId}
+        </code>
+      )}
+    </li>
+  )
+}

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -19,16 +19,20 @@ interface Props {
  * on this, where would I do it?" — and so we get a non-AI inspection
  * window into UTA contract state for debugging.
  */
+const COLLAPSED_LIMIT = 3
+
 export function TradeableContractsPanel({ symbol, assetClass }: Props) {
   const [hits, setHits] = useState<ContractSearchHit[] | null>(null)
   const [accountsConfigured, setAccountsConfigured] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
     setError(null)
+    setExpanded(false)  // collapse on symbol/asset change
     tradingApi.searchContracts(symbol, assetClass)
       .then((res) => {
         if (cancelled) return
@@ -67,13 +71,29 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
         </div>
       )}
 
-      {!loading && !error && hits && hits.length > 0 && (
-        <ul className="flex flex-col divide-y divide-border/40 -mx-3">
-          {[...hits].sort(byInstrumentFamiliarity).map((h, i) => (
-            <ContractRow key={`${h.source}:${h.contract.aliceId ?? i}`} hit={h} />
-          ))}
-        </ul>
-      )}
+      {!loading && !error && hits && hits.length > 0 && (() => {
+        const sorted = [...hits].sort(byInstrumentFamiliarity)
+        const overflow = sorted.length > COLLAPSED_LIMIT
+        const visible = expanded || !overflow ? sorted : sorted.slice(0, COLLAPSED_LIMIT)
+        const hidden = sorted.length - visible.length
+        return (
+          <>
+            <ul className="flex flex-col divide-y divide-border/40 -mx-3">
+              {visible.map((h, i) => (
+                <ContractRow key={`${h.source}:${h.contract.aliceId ?? i}`} hit={h} />
+              ))}
+            </ul>
+            {overflow && (
+              <button
+                onClick={() => setExpanded((v) => !v)}
+                className="mt-2 text-[11px] text-text-muted/70 hover:text-accent transition-colors cursor-pointer"
+              >
+                {expanded ? `Show fewer` : `Show ${hidden} more (${sorted.length} total)`}
+              </button>
+            )}
+          </>
+        )
+      })()}
     </Card>
   )
 }

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -69,13 +69,45 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
 
       {!loading && !error && hits && hits.length > 0 && (
         <ul className="flex flex-col divide-y divide-border/40 -mx-3">
-          {hits.map((h, i) => (
+          {[...hits].sort(byInstrumentFamiliarity).map((h, i) => (
             <ContractRow key={`${h.source}:${h.contract.aliceId ?? i}`} hit={h} />
           ))}
         </ul>
       )}
     </Card>
   )
+}
+
+/**
+ * Order rows by how directly they relate to the asset the analysis page is
+ * about — stocks first (a user looking at AAPL almost always wants the stock,
+ * not a derivative), then spot, then perpetuals, then dated futures, then
+ * options. Brokers report their own preferred order (CCXT prioritizes swaps
+ * because they're the most-traded products); we override that for the UI.
+ */
+function instrumentTier(hit: ContractSearchHit): number {
+  const c = hit.contract
+  const sec = (c.secType ?? '').toUpperCase()
+  const local = (c.localSymbol ?? c.aliceId ?? '') as string
+  if (sec === 'STK') return 0
+  if (sec === 'CRYPTO') {
+    // CCXT marks both spot and perpetual swaps as CRYPTO. Spot has no `:`
+    // settlement-currency suffix; perpetuals have `:` but no trailing
+    // `-YYMMDD` expiry.
+    if (!local.includes(':')) return 1
+    return 2
+  }
+  if (sec === 'FUT') return 3
+  if (sec === 'OPT') return 4
+  return 5
+}
+
+function byInstrumentFamiliarity(a: ContractSearchHit, b: ContractSearchHit): number {
+  const t = instrumentTier(a) - instrumentTier(b)
+  if (t !== 0) return t
+  // Within the same tier, keep upstream broker order — that already encodes
+  // each broker's "preferred quote currency" / liquidity heuristic.
+  return 0
 }
 
 function ContractRow({ hit }: { hit: ContractSearchHit }) {

--- a/ui/src/pages/market/EquityDetail.tsx
+++ b/ui/src/pages/market/EquityDetail.tsx
@@ -23,7 +23,7 @@ export function EquityDetail({ symbol }: Props) {
         <KeyMetricsPanel symbol={symbol} />
       </div>
 
-      <TradeableContractsPanel symbol={symbol} />
+      <TradeableContractsPanel symbol={symbol} assetClass="equity" />
 
       <FinancialStatementsPanel symbol={symbol} />
     </div>

--- a/ui/src/pages/market/EquityDetail.tsx
+++ b/ui/src/pages/market/EquityDetail.tsx
@@ -3,6 +3,7 @@ import { ProfilePanel } from '../../components/market/ProfilePanel'
 import { KeyMetricsPanel } from '../../components/market/KeyMetricsPanel'
 import { FinancialStatementsPanel } from '../../components/market/FinancialStatementsPanel'
 import { KlinePanel } from '../../components/market/KlinePanel'
+import { TradeableContractsPanel } from '../../components/market/TradeableContractsPanel'
 
 interface Props {
   symbol: string
@@ -21,6 +22,8 @@ export function EquityDetail({ symbol }: Props) {
         <ProfilePanel symbol={symbol} />
         <KeyMetricsPanel symbol={symbol} />
       </div>
+
+      <TradeableContractsPanel symbol={symbol} />
 
       <FinancialStatementsPanel symbol={symbol} />
     </div>

--- a/ui/src/pages/market/GenericDetail.tsx
+++ b/ui/src/pages/market/GenericDetail.tsx
@@ -28,7 +28,7 @@ export function GenericDetail({ symbol, assetClass }: Props) {
         <KlinePanel selection={{ symbol, assetClass }} />
       </div>
 
-      <TradeableContractsPanel symbol={symbol} />
+      <TradeableContractsPanel symbol={symbol} assetClass={assetClass} />
     </div>
   )
 }

--- a/ui/src/pages/market/GenericDetail.tsx
+++ b/ui/src/pages/market/GenericDetail.tsx
@@ -1,4 +1,5 @@
 import { KlinePanel } from '../../components/market/KlinePanel'
+import { TradeableContractsPanel } from '../../components/market/TradeableContractsPanel'
 import type { AssetClass } from '../../api/market'
 
 interface Props {
@@ -26,6 +27,8 @@ export function GenericDetail({ symbol, assetClass }: Props) {
       <div className="flex-1 min-h-[420px]">
         <KlinePanel selection={{ symbol, assetClass }} />
       </div>
+
+      <TradeableContractsPanel symbol={symbol} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Three main strands plus a couple of foundational refactors.

**Market workbench: tradeable-contracts bridge.** A new card on `/market/equity/:symbol` (and the GenericDetail fallback) calls every configured UTA's broker-side search and lists matching contracts with their canonical `aliceId`. Fuzzy heuristic match between the data-vendor symbol and broker tickers — `BTCUSD` (data side) → `BTC` (broker side) — centralized in a single rule set with its own design doc. Sorts STK and spot first, dated futures last; collapses past the first 3 hits to avoid wall-of-FUT scrolling. Read-only by design — the bridge to actual order placement remains the trading page.

**Broker contract search: from echo to retrieval.** `AlpacaBroker.searchContracts` was echoing the input as a fake contract (no API call, no validation, no `name`). `CcxtBroker` was strict base-equality (works for typing exact tickers, fails for partial keywords). Both now run through a shared `fuzzyRankContracts` over a locally-cached catalog refreshed every 6h; `tesla` finds TSLA + Tesla ETFs by name; `corn` returns 9 hits including Teucrium Corn Fund and Corning; `ZZZNONSENSE` correctly returns 0. IBKR is unchanged — its native `reqMatchingSymbols` is the SearchingCatalog reference.

**CCXT spot holdings as Positions.** `CcxtBroker.getPositions()` previously only surfaced derivative positions because that's all `fetchPositions()` returns; spot balances (BTC, ETH, …) sat invisibly in `fetchBalance`. OKX UTA users with spot-only books therefore saw an empty positions list and a `netLiquidation` reflecting only their stablecoin balance. CcxtBroker now synthesizes spot Positions from non-stable, non-zero balance entries, prices them via `fetchTickers` against `<COIN>/USDT|USDC|USD`, and folds the value into `netLiquidation`. Spot and perp on the same underlying remain separate Position records by design (different aliceIds, different contracts — same model as ETF vs futures in IBKR).

**FMP fetcher logging hygiene.** Five fetchers conflated "asset has no data" (legitimate, e.g. ETFs without quarterly fundamentals) with "request threw" (real failure). Split them: `console.info` for the empty case with model/symbol/why-this-might-be-normal context; `console.warn` with the caught error message for actual failures.

**Cross-session PR convention** (this PR's own commit).  CLAUDE.md now documents the rolling-PR pattern and body template so future sessions append rather than open fresh.

## Per-session contributions

### 2026-04-29 — CCXT spot-holding synthesis (OKX UTA fix)

- Diagnosed user-reported OKX UTA bug: snapshot showed only USD, no coin holdings. Root cause: `CcxtBroker.getPositions()` only called `fetchPositions()` (derivative-only on OKX) and `getAccount()` only read USDT/USD entries from balance.
- Added private `fetchSpotHoldings()` helper: walks `fetchBalance` non-stable, non-zero entries; finds `<COIN>/USDT|USDC|USD` spot market; bulk-prices via `fetchTickers` with per-symbol `fetchTicker` fallback; emits `Position{side:'long', avgCost=markPrice, unrealizedPnL='0'}`.
- `getPositions()` appends spot to derivative — separate Position records by design (spot/perp on same underlying are distinct contracts).
- `getAccount()` sums *all* stablecoin entries (USDT+USDC+FDUSD+…) into `totalCashValue`; folds spot value into `netLiquidation`.
- Stablecoin set extended: FDUSD (Binance's primary post-BUSD pair quote), PYUSD, USDE, USDP.
- Bug isn't OKX-specific — same hole existed for any CCXT exchange — but OKX exposed it because UTA users frequently hold spot as their main book. No OKX-specific override file added; the fix is general.
- 9 new spec cases in `CcxtBroker.spec.ts` covering spot synthesis, no-market skip, multi-stablecoin cash sum, spot+perp coexistence, ticker fallback, and netLiq inclusion. Existing `getAccount` test fixture updated from aggregate-form balance shape to canonical per-coin form.
- Memory captured: `feedback_crypto_spot_symmetry.md` — crypto spot ≡ traditional security; AccountInfo stays binary (cash + positions), no third "balances" field.
- TODO.md gained an OKX live-confirmation entry (no real OKX account available for end-to-end test) plus three pre-existing in-memory state bugs (heartbeat dedup / cooldown guard / trading-git staging) and the autonomous-loop substrate design discussion that were sitting in working tree.
- Key commits: `aa6a7e8`

### 2026-04-29 — Market workbench / TradeableContracts / Broker search retrieval / CLAUDE.md PR convention

- `/market/equity/:symbol` and `GenericDetail` got a `TradeableContractsPanel` card that searches every configured UTA broker for contracts matching the current symbol. Sort STK/spot first, futures/options last. Collapse past 3 hits.
- Search bridge centralized in `src/domain/trading/contract-search-rules.ts` + `.md` design doc. `assetClass` hint flows from URL → API → backend; crypto/currency strip the quote-currency suffix before hitting brokers.
- AlpacaBroker became EnumeratingCatalog: pulls `getAssets({status:'active'})` at connect, fuzzy-ranks searches against the local cache, falls back to a single echo if the catalog hasn't loaded yet. Refresh every 6h.
- CcxtBroker preserves the strict-base-equality semantics as tier 0 of the new fuzzy ranker; partial keywords now hit. `loadMarkets(true)` reload on the same 6h cron.
- `IBroker.refreshCatalog?()` optional method threaded through UTA. IBKR doesn't implement (server-side `reqMatchingSymbols` is the reference SearchingCatalog).
- 5 FMP fetchers (key-metrics, financial-ratios, equity-profile, equity-quote, price-target-consensus) split degradation logs from real errors.
- CLAUDE.md gained a rolling-PR convention so this multi-session pattern is documented.
- Key commits: `4ffe374`, `3b703b2`, `574b0e0`, `f426445`, `6535257`, `706527c`, `8ddb157`, `c072580`, `f40bd13`, `6ed2f68`

## Full commit log

```
aa6a7e8 feat(brokers/ccxt): synthesize spot holdings into Position records
4ffe374 docs(claude.md): rolling dev→master PR convention for multi-session work
3b703b2 refactor(opentypebb/fmp): split degradation logs from real errors
574b0e0 feat(brokers): EnumeratingCatalog for Alpaca + CCXT, 6h refresh cron
f426445 feat(brokers): shared fuzzy ranker + optional catalog refresh
baba4b5 refactor(news): harden write path + retire v1 getNews
6535257 refactor(market): collapse tradeable contracts beyond the first 3
706527c refactor(market): sort tradeable contracts by familiarity, not broker order
8ddb157 feat(market): pass assetClass through TradeableContractsPanel
c072580 feat(trading): centralized broker-search normalization rules
f40bd13 feat(market): TradeableContractsPanel — bridge analysis to UTA
6ed2f68 feat(trading): broker-side contract search domain helper + HTTP route
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 1135 tests / 58 files (was 1126, +9 spot-holding cases)
- [x] `tesla` / `corn` / `BTC` / `ZZZNONSENSE` queries through `/api/trading/contracts/search` produce expected (and previously-broken) results
- [x] FMP fetcher empty-data path logs at info level with model/symbol/cause hint instead of "Symbol Error: No data found"
- [x] `/market/equity/CORN` renders Teucrium financials where they exist; empty key-metrics/ratios surface as panel "no data" (not error) since `KeyMetricsPanel` already tolerates partial misses
- [ ] Live OKX UTA: confirm `snapshot.positions` includes spot BTC/ETH/etc., `totalCashValue` sums all stablecoins, `netLiquidation` matches OKX's own equity figure (no test account available — tracked in TODO.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
