### PR TITLE
Broker preset refactor — UTA config rebuild (BREAKING)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.9.0-beta.13",
+  "version": "0.10.0-beta.0",
   "description": "File-based trading agent engine",
   "type": "module",
   "scripts": {

--- a/src/connectors/web/routes/trading-config.ts
+++ b/src/connectors/web/routes/trading-config.ts
@@ -1,29 +1,11 @@
 import { Hono } from 'hono'
-import ccxt from 'ccxt'
 import type { EngineContext } from '../../../core/types.js'
 import {
   readAccountsConfig, writeAccountsConfig,
   accountConfigSchema,
 } from '../../../core/config.js'
 import { createBroker } from '../../../domain/trading/brokers/factory.js'
-import { BROKER_REGISTRY } from '../../../domain/trading/brokers/registry.js'
-import type { BrokerConfigField } from '../../../domain/trading/brokers/types.js'
-
-// ==================== CCXT credential field metadata ====================
-
-/** Map of CCXT standard credential field name → UI display metadata. */
-const CCXT_CREDENTIAL_LABELS: Record<string, { label: string; type: BrokerConfigField['type']; sensitive: boolean; placeholder?: string }> = {
-  apiKey:        { label: 'API Key',        type: 'password', sensitive: true },
-  secret:        { label: 'API Secret',     type: 'password', sensitive: true },
-  uid:           { label: 'User ID',        type: 'text',     sensitive: false },
-  accountId:     { label: 'Account ID',     type: 'text',     sensitive: false },
-  login:         { label: 'Login',          type: 'text',     sensitive: false },
-  password:      { label: 'Passphrase',     type: 'password', sensitive: true, placeholder: 'Required by some exchanges (e.g. OKX)' },
-  twofa:         { label: '2FA Secret',     type: 'password', sensitive: true },
-  privateKey:    { label: 'Private Key',    type: 'password', sensitive: true, placeholder: 'Wallet private key (for Hyperliquid, dYdX, etc.)' },
-  walletAddress: { label: 'Wallet Address', type: 'text',     sensitive: false, placeholder: '0x...' },
-  token:         { label: 'Token',          type: 'password', sensitive: true },
-}
+import { BUILTIN_BROKER_PRESETS } from '../../../domain/trading/brokers/presets.js'
 
 // ==================== Credential helpers ====================
 
@@ -69,59 +51,10 @@ function unmaskSecrets(
 export function createTradingConfigRoutes(ctx: EngineContext) {
   const app = new Hono()
 
-  // ==================== Broker types (for dynamic UI rendering) ====================
+  // ==================== Broker presets (for the wizard) ====================
 
-  app.get('/broker-types', (c) => {
-    const brokerTypes = Object.entries(BROKER_REGISTRY).map(([type, entry]) => ({
-      type,
-      name: entry.name,
-      description: entry.description,
-      setupGuide: entry.setupGuide,
-      badge: entry.badge,
-      badgeColor: entry.badgeColor,
-      fields: entry.configFields,
-      subtitleFields: entry.subtitleFields,
-      guardCategory: entry.guardCategory,
-    }))
-    return c.json({ brokerTypes })
-  })
-
-  // ==================== CCXT dynamic exchange + credential metadata ====================
-
-  /** List all CCXT-supported exchanges (dynamically from the ccxt package). */
-  app.get('/ccxt/exchanges', (c) => {
-    const exchanges = (ccxt as unknown as { exchanges: string[] }).exchanges ?? []
-    return c.json({ exchanges })
-  })
-
-  /** Return the credential fields a given CCXT exchange requires (read from its requiredCredentials map). */
-  app.get('/ccxt/exchanges/:name/credentials', (c) => {
-    const name = c.req.param('name')
-    const exchanges = ccxt as unknown as Record<string, new (opts?: Record<string, unknown>) => { requiredCredentials?: Record<string, boolean> }>
-    const ExchangeClass = exchanges[name]
-    if (!ExchangeClass) return c.json({ error: `Unknown exchange: ${name}` }, 404)
-
-    try {
-      const inst = new ExchangeClass()
-      const required = inst.requiredCredentials ?? {}
-      const fields: BrokerConfigField[] = []
-      for (const [key, needed] of Object.entries(required)) {
-        if (!needed) continue
-        const meta = CCXT_CREDENTIAL_LABELS[key]
-        if (!meta) continue // skip unknown credential names (CCXT may add new ones)
-        fields.push({
-          name: key,
-          type: meta.type,
-          label: meta.label,
-          required: true,
-          sensitive: meta.sensitive,
-          placeholder: meta.placeholder,
-        })
-      }
-      return c.json({ fields })
-    } catch (err) {
-      return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
-    }
+  app.get('/broker-presets', (c) => {
+    return c.json({ presets: BUILTIN_BROKER_PRESETS })
   })
 
   // ==================== Read all ====================

--- a/src/connectors/web/routes/trading-config.ts
+++ b/src/connectors/web/routes/trading-config.ts
@@ -136,15 +136,26 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
   // ==================== Test Connection ====================
 
   app.post('/test-connection', async (c) => {
-    let broker: { init: () => Promise<void>; getAccount: () => Promise<unknown>; close: () => Promise<void> } | null = null
+    let broker: {
+      init: () => Promise<void>
+      getAccount: () => Promise<unknown>
+      getPositions: () => Promise<unknown>
+      close: () => Promise<void>
+    } | null = null
     try {
       const body = await c.req.json()
       const accountConfig = accountConfigSchema.parse({ ...body, id: body.id ?? '__test__' })
 
       broker = createBroker(accountConfig)
       await broker.init()
-      const account = await broker.getAccount()
-      return c.json({ success: true, account })
+      // Run both calls in parallel — getAccount proves auth, getPositions
+      // exercises the data path the user actually cares about (e.g. for OKX
+      // UTA, this is what surfaces spot holdings via fetchSpotHoldings).
+      const [account, positions] = await Promise.all([
+        broker.getAccount(),
+        broker.getPositions(),
+      ])
+      return c.json({ success: true, account, positions })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       return c.json({ success: false, error: msg }, 400)

--- a/src/core/config.spec.ts
+++ b/src/core/config.spec.ts
@@ -218,32 +218,40 @@ describe('readAccountsConfig', () => {
     expect(mockWriteFile).toHaveBeenCalledTimes(1)
   })
 
-  it('parses ccxt account from file', async () => {
-    fileReturns([{ id: 'bybit-main', type: 'ccxt', exchange: 'bybit', apiKey: 'key1', apiSecret: 'sec1' }])
+  it('parses preset-shaped accounts from file', async () => {
+    fileReturns([
+      { id: 'okx-main', presetId: 'okx', enabled: true, guards: [], presetConfig: { mode: 'live', apiKey: 'k', secret: 's', password: 'p' } },
+      { id: 'alpaca-paper', presetId: 'alpaca', enabled: true, guards: [], presetConfig: { mode: 'paper', apiKey: 'k', apiSecret: 's' } },
+    ])
     const accounts = await readAccountsConfig()
-    expect(accounts).toHaveLength(1)
-    expect(accounts[0].id).toBe('bybit-main')
-    expect(accounts[0].type).toBe('ccxt')
+    expect(accounts).toHaveLength(2)
+    expect(accounts[0].presetId).toBe('okx')
+    expect(accounts[1].presetId).toBe('alpaca')
   })
 
-  it('parses alpaca account from file', async () => {
-    fileReturns([{ id: 'alpaca-paper', type: 'alpaca', paper: true, apiKey: 'k', apiSecret: 's' }])
-    const accounts = await readAccountsConfig()
-    expect(accounts).toHaveLength(1)
-    expect(accounts[0].type).toBe('alpaca')
+  it('refuses pre-preset (legacy) shape with a clear error and backs up the file', async () => {
+    fileReturns([{ id: 'bybit-main', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'bybit', apiKey: 'k', apiSecret: 's' } }])
+    await expect(readAccountsConfig()).rejects.toThrow(/pre-preset format/)
+    // Should write both the backup file and the empty replacement
+    const writePaths = mockWriteFile.mock.calls.map((c) => c[0] as string)
+    expect(writePaths.some((p) => p.endsWith('accounts.json.backup-pre-preset'))).toBe(true)
+    expect(writePaths.some((p) => p.endsWith('accounts.json'))).toBe(true)
   })
 })
 
 describe('writeAccountsConfig', () => {
   it('writes validated accounts to accounts.json', async () => {
-    await writeAccountsConfig([{ id: 'acc-1', type: 'alpaca', enabled: true, guards: [], brokerConfig: { paper: true } }])
+    await writeAccountsConfig([{
+      id: 'acc-1', presetId: 'alpaca', enabled: true, guards: [],
+      presetConfig: { mode: 'paper', apiKey: 'k', apiSecret: 's' },
+    }])
     const filePath = mockWriteFile.mock.calls[0][0] as string
     expect(filePath).toMatch(/accounts\.json$/)
   })
 
   it('throws ZodError for missing required fields', async () => {
     await expect(
-      writeAccountsConfig([{ type: 'alpaca' } as any])
+      writeAccountsConfig([{ presetId: 'alpaca' } as any])
     ).rejects.toThrow()
     expect(mockWriteFile).not.toHaveBeenCalled()
   })

--- a/src/core/config.spec.ts
+++ b/src/core/config.spec.ts
@@ -229,13 +229,41 @@ describe('readAccountsConfig', () => {
     expect(accounts[1].presetId).toBe('alpaca')
   })
 
-  it('refuses pre-preset (legacy) shape with a clear error and backs up the file', async () => {
-    fileReturns([{ id: 'bybit-main', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'bybit', apiKey: 'k', apiSecret: 's' } }])
-    await expect(readAccountsConfig()).rejects.toThrow(/pre-preset format/)
-    // Should write both the backup file and the empty replacement
+  it('auto-migrates pre-preset (legacy) ccxt shape and backs up the original', async () => {
+    fileReturns([
+      { id: 'okx-live', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'okx', sandbox: false, apiKey: 'k', apiSecret: 's', password: 'p' } },
+      { id: 'okx-demo', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'okx', sandbox: true, apiKey: 'k', apiSecret: 's', password: 'p' } },
+      { id: 'bybit-test', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'bybit', sandbox: true, apiKey: 'k', apiSecret: 's' } },
+    ])
+    const accounts = await readAccountsConfig()
+    expect(accounts).toHaveLength(3)
+    expect(accounts[0]).toMatchObject({ id: 'okx-live', presetId: 'okx', presetConfig: { mode: 'live' } })
+    expect(accounts[1]).toMatchObject({ id: 'okx-demo', presetId: 'okx', presetConfig: { mode: 'demo' } })
+    expect(accounts[2]).toMatchObject({ id: 'bybit-test', presetId: 'bybit', presetConfig: { mode: 'testnet' } })
+    // CCXT secret alias (apiSecret → secret)
+    expect(accounts[0].presetConfig.secret).toBe('s')
+    // Backup + rewritten accounts.json both written
     const writePaths = mockWriteFile.mock.calls.map((c) => c[0] as string)
     expect(writePaths.some((p) => p.endsWith('accounts.json.backup-pre-preset'))).toBe(true)
     expect(writePaths.some((p) => p.endsWith('accounts.json'))).toBe(true)
+  })
+
+  it('migrates legacy alpaca + ibkr accounts', async () => {
+    fileReturns([
+      { id: 'alp', type: 'alpaca', enabled: true, guards: [], brokerConfig: { paper: true, apiKey: 'k', apiSecret: 's' } },
+      { id: 'ibk', type: 'ibkr', enabled: true, guards: [], brokerConfig: { host: '127.0.0.1', port: 7497, clientId: 0 } },
+    ])
+    const accounts = await readAccountsConfig()
+    expect(accounts[0]).toMatchObject({ presetId: 'alpaca', presetConfig: { mode: 'paper' } })
+    expect(accounts[1]).toMatchObject({ presetId: 'ibkr-tws', presetConfig: { host: '127.0.0.1', port: 7497 } })
+  })
+
+  it('falls back to ccxt-custom for unknown ccxt exchanges', async () => {
+    fileReturns([
+      { id: 'kc', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'kucoin', apiKey: 'k', apiSecret: 's', password: 'p' } },
+    ])
+    const accounts = await readAccountsConfig()
+    expect(accounts[0]).toMatchObject({ presetId: 'ccxt-custom', presetConfig: { exchange: 'kucoin', secret: 's' } })
   })
 })
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -274,10 +274,12 @@ const guardConfigSchema = z.object({
 export const accountConfigSchema = z.object({
   id: z.string(),
   label: z.string().optional(),
-  type: z.string(),
+  /** Broker preset id — resolves to engine + form schema via BROKER_PRESET_CATALOG. */
+  presetId: z.string(),
   enabled: z.boolean().default(true),
   guards: z.array(guardConfigSchema).default([]),
-  brokerConfig: z.record(z.string(), z.unknown()).default({}),
+  /** User-filled form values, validated against the preset's own zodSchema. */
+  presetConfig: z.record(z.string(), z.unknown()).default({}),
 })
 
 export const accountsFileSchema = z.array(accountConfigSchema)
@@ -504,26 +506,16 @@ export async function loadConfig(): Promise<Config> {
 
 // ==================== Account Config Loader ====================
 
-/** Common fields that live at the top level, not inside brokerConfig. */
-const BASE_FIELDS = new Set(['id', 'label', 'type', 'guards', 'brokerConfig'])
-
 /**
- * Migrate flat account config (legacy) to nested brokerConfig format.
- * Any field not in BASE_FIELDS gets moved into brokerConfig.
+ * Detect the pre-preset (legacy) account shape: presence of `type` field
+ * (now removed) without the new `presetId` field. Returns true if any
+ * record matches.
  */
-function migrateAccountConfig(raw: Record<string, unknown>): Record<string, unknown> {
-  if (raw.brokerConfig) return raw  // already migrated
-  const migrated: Record<string, unknown> = {}
-  const brokerConfig: Record<string, unknown> = {}
-  for (const [k, v] of Object.entries(raw)) {
-    if (BASE_FIELDS.has(k)) {
-      migrated[k] = v
-    } else {
-      brokerConfig[k] = v
-    }
-  }
-  migrated.brokerConfig = brokerConfig
-  return migrated
+function isLegacyAccountShape(raw: unknown[]): boolean {
+  return raw.some((r) => {
+    const o = r as Record<string, unknown>
+    return typeof o['type'] === 'string' && typeof o['presetId'] !== 'string'
+  })
 }
 
 export async function readAccountsConfig(): Promise<AccountConfig[]> {
@@ -534,9 +526,28 @@ export async function readAccountsConfig(): Promise<AccountConfig[]> {
     await writeFile(resolve(CONFIG_DIR, 'accounts.json'), '[]\n')
     return []
   }
-  // Migrate legacy flat format → nested brokerConfig
-  const migrated = (raw as unknown[]).map((item) => migrateAccountConfig(item as Record<string, unknown>))
-  return accountsFileSchema.parse(migrated)
+
+  // Pre-preset shape used `type` + `brokerConfig`; current shape uses
+  // `presetId` + `presetConfig`. We don't auto-migrate (per design — the
+  // mapping from old { type:'ccxt', brokerConfig:{exchange:'okx', ...} }
+  // to new { presetId:'okx', presetConfig:{mode:..., ...} } would have
+  // to invent values like `mode` from sandbox/demoTrading flags, and
+  // we'd rather have the user re-create accounts in the new wizard than
+  // silently mis-translate credentials.
+  if (Array.isArray(raw) && isLegacyAccountShape(raw as unknown[])) {
+    const backupPath = resolve(CONFIG_DIR, 'accounts.json.backup-pre-preset')
+    await writeFile(backupPath, JSON.stringify(raw, null, 2) + '\n')
+    await writeFile(resolve(CONFIG_DIR, 'accounts.json'), '[]\n')
+    throw new Error(
+      `accounts.json is in the pre-preset format (records with "type" + "brokerConfig"). ` +
+      `The trading account schema changed in v0.10 to a preset-based system — see ` +
+      `src/domain/trading/brokers/preset-catalog.ts for the new shape. ` +
+      `Your previous config has been backed up to ${backupPath} and accounts.json has been ` +
+      `reset to empty. Restart and re-create your accounts via the new wizard at /trading.`,
+    )
+  }
+
+  return accountsFileSchema.parse(raw)
 }
 
 export async function writeAccountsConfig(accounts: AccountConfig[]): Promise<void> {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -506,16 +506,115 @@ export async function loadConfig(): Promise<Config> {
 
 // ==================== Account Config Loader ====================
 
+/** Single legacy record carries `type` (removed) without `presetId` (new). */
+function isLegacyRecord(o: Record<string, unknown>): boolean {
+  return typeof o['type'] === 'string' && typeof o['presetId'] !== 'string'
+}
+
 /**
- * Detect the pre-preset (legacy) account shape: presence of `type` field
- * (now removed) without the new `presetId` field. Returns true if any
- * record matches.
+ * Best-effort migration from the pre-preset shape ({type, brokerConfig})
+ * to the preset shape ({presetId, presetConfig}).
+ *
+ * Returns null when the legacy record can't be mapped (unknown engine /
+ * missing exchange) — caller logs and skips.
+ *
+ * TODO(v0.10 → v1.0): remove this migration once nobody is upgrading
+ * from the pre-preset schema. Tracked alongside the AI-side migration
+ * cleanup at the top of this file.
  */
-function isLegacyAccountShape(raw: unknown[]): boolean {
-  return raw.some((r) => {
-    const o = r as Record<string, unknown>
-    return typeof o['type'] === 'string' && typeof o['presetId'] !== 'string'
+function migrateLegacyAccount(raw: Record<string, unknown>): Record<string, unknown> | null {
+  const id = String(raw['id'] ?? '')
+  const label = raw['label'] as string | undefined
+  const enabled = raw['enabled'] as boolean | undefined
+  const guards = raw['guards'] as unknown[] | undefined
+  const type = String(raw['type'] ?? '')
+  const bc = (raw['brokerConfig'] ?? {}) as Record<string, unknown>
+
+  const base = (presetId: string, presetConfig: Record<string, unknown>) => ({
+    id,
+    ...(label !== undefined && { label }),
+    presetId,
+    enabled: enabled ?? true,
+    guards: guards ?? [],
+    presetConfig,
   })
+
+  // CCXT — derive preset from exchange + flags
+  if (type === 'ccxt') {
+    const exchange = String(bc['exchange'] ?? '').toLowerCase()
+    const apiKey = bc['apiKey'] as string | undefined
+    // Legacy used both `secret` and `apiSecret` (alias); new presets use `secret`.
+    const secret = (bc['secret'] ?? bc['apiSecret']) as string | undefined
+    const password = bc['password'] as string | undefined
+    const sandbox = Boolean(bc['sandbox'])
+    const demoTrading = Boolean(bc['demoTrading'])
+    const walletAddress = bc['walletAddress'] as string | undefined
+    const privateKey = bc['privateKey'] as string | undefined
+
+    switch (exchange) {
+      case 'okx':
+        // OKX old configs that set demoTrading: true were broken (the engine
+        // would set urls['api'] = undefined). We treat any non-live flag as
+        // mode=demo so the migrated account actually works.
+        return base('okx', {
+          mode: (sandbox || demoTrading) ? 'demo' : 'live',
+          ...(apiKey && { apiKey }),
+          ...(secret && { secret }),
+          ...(password && { password }),
+        })
+      case 'bybit':
+        return base('bybit', {
+          mode: sandbox ? 'testnet' : (demoTrading ? 'demo' : 'live'),
+          ...(apiKey && { apiKey }),
+          ...(secret && { secret }),
+        })
+      case 'hyperliquid':
+        return base('hyperliquid', {
+          mode: sandbox ? 'testnet' : 'live',
+          ...(walletAddress && { walletAddress }),
+          ...(privateKey && { privateKey }),
+        })
+      case 'bitget':
+        return base('bitget', {
+          mode: demoTrading ? 'demo' : 'live',
+          ...(apiKey && { apiKey }),
+          ...(secret && { secret }),
+          ...(password && { password }),
+        })
+      default:
+        // Unknown / untested exchange — keep functional via the escape hatch.
+        if (!exchange) return null
+        return base('ccxt-custom', {
+          exchange,
+          sandbox,
+          demoTrading,
+          ...(apiKey && { apiKey }),
+          ...(secret && { secret }),
+          ...(password && { password }),
+          ...(walletAddress && { walletAddress }),
+          ...(privateKey && { privateKey }),
+        })
+    }
+  }
+
+  if (type === 'alpaca') {
+    return base('alpaca', {
+      mode: bc['paper'] === false ? 'live' : 'paper',
+      ...(bc['apiKey'] !== undefined && { apiKey: bc['apiKey'] }),
+      ...(bc['apiSecret'] !== undefined && { apiSecret: bc['apiSecret'] }),
+    })
+  }
+
+  if (type === 'ibkr') {
+    return base('ibkr-tws', {
+      ...(bc['host'] !== undefined && { host: bc['host'] }),
+      ...(bc['port'] !== undefined && { port: bc['port'] }),
+      ...(bc['clientId'] !== undefined && { clientId: bc['clientId'] }),
+      ...(bc['accountId'] !== undefined && { accountId: bc['accountId'] }),
+    })
+  }
+
+  return null
 }
 
 export async function readAccountsConfig(): Promise<AccountConfig[]> {
@@ -527,24 +626,36 @@ export async function readAccountsConfig(): Promise<AccountConfig[]> {
     return []
   }
 
-  // Pre-preset shape used `type` + `brokerConfig`; current shape uses
-  // `presetId` + `presetConfig`. We don't auto-migrate (per design — the
-  // mapping from old { type:'ccxt', brokerConfig:{exchange:'okx', ...} }
-  // to new { presetId:'okx', presetConfig:{mode:..., ...} } would have
-  // to invent values like `mode` from sandbox/demoTrading flags, and
-  // we'd rather have the user re-create accounts in the new wizard than
-  // silently mis-translate credentials.
-  if (Array.isArray(raw) && isLegacyAccountShape(raw as unknown[])) {
+  // Auto-migrate the pre-preset shape ({type, brokerConfig}) into the
+  // current shape ({presetId, presetConfig}). We back the original up
+  // first (so a bad migration is never destructive) and write the
+  // translated records to disk so subsequent reads skip this branch.
+  if (Array.isArray(raw) && (raw as unknown[]).some((r) => isLegacyRecord(r as Record<string, unknown>))) {
     const backupPath = resolve(CONFIG_DIR, 'accounts.json.backup-pre-preset')
     await writeFile(backupPath, JSON.stringify(raw, null, 2) + '\n')
-    await writeFile(resolve(CONFIG_DIR, 'accounts.json'), '[]\n')
-    throw new Error(
-      `accounts.json is in the pre-preset format (records with "type" + "brokerConfig"). ` +
-      `The trading account schema changed in v0.10 to a preset-based system — see ` +
-      `src/domain/trading/brokers/preset-catalog.ts for the new shape. ` +
-      `Your previous config has been backed up to ${backupPath} and accounts.json has been ` +
-      `reset to empty. Restart and re-create your accounts via the new wizard at /trading.`,
+
+    const migrated: Record<string, unknown>[] = []
+    const skipped: string[] = []
+    for (const item of raw as Record<string, unknown>[]) {
+      // Already in new shape — keep verbatim.
+      if (!isLegacyRecord(item)) { migrated.push(item); continue }
+      const next = migrateLegacyAccount(item)
+      if (next) {
+        migrated.push(next)
+      } else {
+        skipped.push(String(item['id'] ?? '<unknown>'))
+      }
+    }
+
+    console.warn(
+      `accounts.json: migrated ${migrated.length - skipped.length} legacy record(s) to preset shape ` +
+      `(backup: ${backupPath}).` +
+      (skipped.length ? ` Skipped (unknown engine, recreate manually): ${skipped.join(', ')}.` : ''),
     )
+
+    const validated = accountsFileSchema.parse(migrated)
+    await writeFile(resolve(CONFIG_DIR, 'accounts.json'), JSON.stringify(validated, null, 2) + '\n')
+    return validated
   }
 
   return accountsFileSchema.parse(raw)

--- a/src/domain/trading/__test__/e2e/ccxt-okx.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/ccxt-okx.e2e.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * CcxtBroker e2e — real calls against OKX demo trading.
+ *
+ * Reads Alice's config, picks the first OKX account whose preset
+ * resolves to a paper/demo mode (isPaperPreset === true). If none
+ * configured, the entire suite skips.
+ *
+ * OKX is the spot-synthesis canary. fetchPositions() on OKX returns
+ * derivative positions only (SWAP/FUTURES/MARGIN/OPTION); spot
+ * holdings live in fetchBalance(). CcxtBroker.fetchSpotHoldings
+ * synthesizes them into Position records — these tests exercise
+ * that path with a real account.
+ *
+ * Required configuration in data/config/accounts.json:
+ *   {
+ *     "id": "okx-test",
+ *     "presetId": "okx",
+ *     "enabled": true,
+ *     "guards": [],
+ *     "presetConfig": {
+ *       "mode": "demo",
+ *       "apiKey": "...",
+ *       "secret": "...",
+ *       "password": "..."
+ *     }
+ *   }
+ *
+ * OKX demo seeds the account with ~100k USDT — plenty of headroom for
+ * the small test trades below.
+ *
+ * Run: pnpm test:e2e
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import Decimal from 'decimal.js'
+import { Order } from '@traderalice/ibkr'
+import { getTestAccounts, filterByProvider } from './setup.js'
+import type { IBroker } from '../../brokers/types.js'
+import '../../contract-ext.js'
+
+let broker: IBroker | null = null
+
+beforeAll(async () => {
+  const all = await getTestAccounts()
+  const okx = filterByProvider(all, 'ccxt').find(a => a.id.includes('okx'))
+  if (!okx) {
+    console.log('e2e: No OKX demo account configured, skipping')
+    return
+  }
+  broker = okx.broker
+  console.log(`e2e: ${okx.label} connected`)
+}, 60_000)
+
+describe('CcxtBroker — OKX e2e', () => {
+  beforeEach(({ skip }) => { if (!broker) skip('no OKX account') })
+
+  /** Narrow broker type — beforeEach guarantees non-null via skip(). */
+  function b(): IBroker { return broker! }
+
+  // ==================== Connectivity ====================
+
+  it('fetches account info with positive equity (demo seeds ~100k USDT)', async () => {
+    const account = await b().getAccount()
+    expect(account.baseCurrency).toBe('USD')
+    expect(Number(account.netLiquidation)).toBeGreaterThan(0)
+    console.log(`  equity: $${Number(account.netLiquidation).toFixed(2)}, cash: $${Number(account.totalCashValue).toFixed(2)}`)
+  })
+
+  it('fetches positions (derivative + spot synthesized)', async () => {
+    const positions = await b().getPositions()
+    expect(Array.isArray(positions)).toBe(true)
+    console.log(`  ${positions.length} open positions`)
+    for (const p of positions) {
+      expect(p.currency).toBeDefined()
+      expect(Number(p.marketPrice), `marketPrice missing for ${p.contract.symbol}`).toBeGreaterThan(0)
+      // marketValue = qty × markPrice (within Decimal rounding)
+      expect(Number(p.marketValue)).toBeCloseTo(p.quantity.toNumber() * Number(p.marketPrice), 2)
+      // Spot positions carry no settle suffix in localSymbol (e.g. "BTC/USDT");
+      // perps carry it (e.g. "BTC/USDT:USDT"). Either is acceptable here.
+      console.log(`    ${p.contract.localSymbol}: ${p.side} ${p.quantity} @ ${p.marketPrice} ${p.currency}`)
+    }
+  })
+
+  // ==================== Markets / search ====================
+
+  it('searches BTC contracts and finds spot + perp', async () => {
+    const results = await b().searchContracts('BTC')
+    expect(results.length).toBeGreaterThan(0)
+    const spot = results.find(r => r.contract.localSymbol === 'BTC/USDT')
+    const perp = results.find(r => r.contract.localSymbol === 'BTC/USDT:USDT')
+    expect(spot, 'BTC/USDT spot not found').toBeDefined()
+    expect(perp, 'BTC/USDT:USDT perp not found').toBeDefined()
+    console.log(`  found ${results.length} BTC contracts (spot + perp present)`)
+  })
+
+  it('searches ETH contracts and finds a perpetual', async () => {
+    const results = await b().searchContracts('ETH')
+    expect(results.length).toBeGreaterThan(0)
+    const perp = results.find(r => r.contract.localSymbol?.includes('USDT:USDT'))
+    expect(perp).toBeDefined()
+    console.log(`  found ${results.length} ETH contracts, perp: ${perp!.contract.localSymbol}`)
+  })
+
+  // ==================== Spot synthesis (OKX-unique) ====================
+
+  it('places small spot BTC buy (~$50) → BTC appears as a long Position via fetchSpotHoldings', async ({ skip }) => {
+    const matches = await b().searchContracts('BTC')
+    const btcSpot = matches.find(m => m.contract.localSymbol === 'BTC/USDT')
+    if (!btcSpot) return skip('BTC/USDT spot not found')
+
+    // OKX spot minimums for BTC/USDT are ~5 USDT — $50 notional is comfortably above.
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'MKT'
+    order.cashQty = new Decimal('50')
+
+    const placeResult = await b().placeOrder(btcSpot.contract, order)
+    expect(placeResult.success, `placeOrder failed: ${placeResult.error}`).toBe(true)
+    console.log(`  spot buy: orderId=${placeResult.orderId}, status=${placeResult.orderState?.status}`)
+
+    // Give OKX a moment to update balance — fetchBalance is what feeds spot synthesis
+    await new Promise(r => setTimeout(r, 3000))
+
+    const positions = await b().getPositions()
+    const btcSpotPos = positions.find(p => p.contract.localSymbol === 'BTC/USDT')
+    expect(btcSpotPos, `BTC spot position not synthesized. Positions: ${positions.map(p => p.contract.localSymbol).join(', ')}`).toBeDefined()
+    if (btcSpotPos) {
+      expect(btcSpotPos.side).toBe('long')
+      expect(Number(btcSpotPos.quantity)).toBeGreaterThan(0)
+      expect(Number(btcSpotPos.marketValue)).toBeGreaterThan(0)
+      // Spot synthesis sets avgCost = markPrice (we can't reconstruct historic cost)
+      expect(btcSpotPos.unrealizedPnL).toBe('0')
+      console.log(`  BTC spot synthesized: ${btcSpotPos.quantity} @ $${btcSpotPos.marketPrice}, value=$${btcSpotPos.marketValue}`)
+    }
+  }, 30_000)
+
+  it('sells back the spot BTC → position drops out', async ({ skip }) => {
+    const positions = await b().getPositions()
+    const btcSpot = positions.find(p => p.contract.localSymbol === 'BTC/USDT')
+    if (!btcSpot) return skip('no BTC spot position to sell')
+
+    const order = new Order()
+    order.action = 'SELL'
+    order.orderType = 'MKT'
+    order.totalQuantity = btcSpot.quantity
+
+    const result = await b().placeOrder(btcSpot.contract, order)
+    expect(result.success, `sell failed: ${result.error}`).toBe(true)
+    console.log(`  spot sell: orderId=${result.orderId}, qty=${btcSpot.quantity}`)
+
+    await new Promise(r => setTimeout(r, 3000))
+
+    const after = await b().getPositions()
+    const btcAfter = after.find(p => p.contract.localSymbol === 'BTC/USDT')
+    // Allow for dust remainders below the dust threshold; the position
+    // should at minimum have shrunk dramatically.
+    if (btcAfter) {
+      expect(Number(btcAfter.quantity)).toBeLessThan(Number(btcSpot.quantity) * 0.1)
+    }
+    console.log(`  after sell: ${btcAfter ? `${btcAfter.quantity} (dust)` : 'gone'}`)
+  }, 30_000)
+
+  // ==================== Derivative trading ====================
+  //
+  // OKX accounts default to "Cash" mode which forbids derivatives. Perp
+  // trading requires switching the account to Single-currency Margin /
+  // Multi-currency Margin / Portfolio Margin in the OKX UI. When the
+  // account is in Cash mode, OKX rejects perp orders with code 51010
+  // ("You can't complete this request under your current account mode").
+  // We detect that error and skip — cash-mode demo accounts still cover
+  // every spot path above; margin-mode accounts get full coverage.
+
+  /** True if a CCXT/OKX error string is the cash-mode rejection. */
+  function isCashModeError(err: string | undefined): boolean {
+    return !!err && (err.includes('"sCode":"51010"') || err.includes('current account mode'))
+  }
+
+  /** Place an ETH perp buy and return the result, or null if cash-mode skip. */
+  async function tryPerpBuy(): Promise<{ orderId: string | undefined; cashMode: boolean }> {
+    const matches = await b().searchContracts('ETH')
+    const ethPerp = matches.find(m => m.contract.localSymbol === 'ETH/USDT:USDT')
+    if (!ethPerp) throw new Error('ETH/USDT perp not found')
+
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'MKT'
+    order.totalQuantity = new Decimal('0.01')
+
+    const result = await b().placeOrder(ethPerp.contract, order)
+    if (!result.success && isCashModeError(result.error)) {
+      return { orderId: undefined, cashMode: true }
+    }
+    if (!result.success) throw new Error(`placeOrder failed: ${result.error}`)
+    return { orderId: result.orderId, cashMode: false }
+  }
+
+  it('places market buy 0.01 ETH perp → execution returned', async ({ skip }) => {
+    const { orderId, cashMode } = await tryPerpBuy()
+    if (cashMode) return skip('OKX account in Cash mode — switch to a margin mode for perp coverage')
+    expect(orderId).toBeDefined()
+    console.log(`  perp buy: orderId=${orderId}`)
+  }, 30_000)
+
+  it('verifies ETH perp position exists separately from any ETH spot', async ({ skip }) => {
+    const positions = await b().getPositions()
+    const ethPerp = positions.find(p => p.contract.localSymbol === 'ETH/USDT:USDT')
+    if (!ethPerp) return skip('no ETH perp position (preceding buy was skipped or perp closed)')
+    // Distinct contract identity: spot is "ETH/USDT", perp is "ETH/USDT:USDT".
+    // Same underlying, different products — must not be merged.
+    expect(ethPerp.contract.localSymbol).toBe('ETH/USDT:USDT')
+    console.log(`  ETH perp: ${ethPerp.quantity} ${ethPerp.side} @ ${ethPerp.marketPrice} ${ethPerp.currency}`)
+  })
+
+  it('closes ETH perp position with reduceOnly', async ({ skip }) => {
+    const matches = await b().searchContracts('ETH')
+    const ethPerp = matches.find(m => m.contract.localSymbol === 'ETH/USDT:USDT')
+    if (!ethPerp) return skip('ETH/USDT perp not found')
+
+    const result = await b().closePosition(ethPerp.contract, new Decimal('0.01'))
+    if (!result.success && isCashModeError(result.error)) {
+      return skip('OKX account in Cash mode — no perp position to close')
+    }
+    // OKX 51205 is "Reduce Only is not available" — happens when there's no
+    // open perp position to reduce. Treat as skip here for the same reason.
+    if (!result.success && /51205|Reduce Only is not available/i.test(result.error ?? '')) {
+      return skip('no open perp position to close (preceding buy was skipped)')
+    }
+    expect(result.success, `closePosition failed: ${result.error}`).toBe(true)
+    console.log(`  close perp orderId=${result.orderId}`)
+  }, 30_000)
+
+  // ==================== Order query ====================
+
+  it('queries order by ID after place', async ({ skip }) => {
+    const { orderId, cashMode } = await tryPerpBuy()
+    if (cashMode) return skip('OKX account in Cash mode — perp path skipped')
+    if (!orderId) return skip('no orderId returned')
+
+    // OKX needs a moment for the order to settle into queryable state
+    await new Promise(r => setTimeout(r, 3000))
+
+    const detail = await b().getOrder(orderId)
+    console.log(`  getOrder(${orderId}): ${detail ? `status=${detail.orderState.status}` : 'null'}`)
+    expect(detail).not.toBeNull()
+    if (detail) {
+      expect(detail.orderState.status).toBe('Filled')
+    }
+
+    // Clean up — find the perp again so we have its contract
+    const matches = await b().searchContracts('ETH')
+    const ethPerp = matches.find(m => m.contract.localSymbol === 'ETH/USDT:USDT')
+    if (ethPerp) await b().closePosition(ethPerp.contract, new Decimal('0.01'))
+  }, 30_000)
+})

--- a/src/domain/trading/__test__/e2e/setup.ts
+++ b/src/domain/trading/__test__/e2e/setup.ts
@@ -12,38 +12,34 @@ import net from 'node:net'
 import { readAccountsConfig, type AccountConfig } from '@/core/config.js'
 import type { IBroker } from '../../brokers/types.js'
 import { createBroker } from '../../brokers/factory.js'
+import { getBrokerPreset, isPaperPreset, type BrokerEngine } from '../../brokers/preset-catalog.js'
 import { CCXT_CREDENTIAL_FIELDS } from '../../brokers/ccxt/ccxt-types.js'
 
 export interface TestAccount {
   id: string
   label: string
-  provider: AccountConfig['type']
+  provider: BrokerEngine
   broker: IBroker
 }
 
 // ==================== Safety ====================
 
-/** Unified paper/sandbox check — E2E only runs non-live accounts. */
+/** Unified paper/sandbox check — E2E only runs non-live accounts. Routed through preset.isPaper. */
 function isPaper(acct: AccountConfig): boolean {
-  const bc = acct.brokerConfig
-  switch (acct.type) {
-    case 'alpaca': return !!bc.paper
-    case 'ccxt':   return !!(bc.sandbox || bc.demoTrading)
-    case 'ibkr':   return !!bc.paper
-    default:       return false
-  }
+  return isPaperPreset(acct.presetId, acct.presetConfig)
 }
 
 /** Check whether API credentials are configured (not applicable for all broker types). */
 function hasCredentials(acct: AccountConfig): boolean {
-  const bc = acct.brokerConfig
-  switch (acct.type) {
+  const engine = getBrokerPreset(acct.presetId).engine
+  const pc = acct.presetConfig as Record<string, unknown>
+  switch (engine) {
     case 'alpaca':
-      return !!bc.apiKey
+      return !!pc.apiKey
     case 'ccxt':
-      // CCXT exchanges use different credential schemes — apiKey/secret for most,
-      // walletAddress/privateKey for Hyperliquid, etc. Match any standard CCXT field.
-      return CCXT_CREDENTIAL_FIELDS.some(k => !!(bc as Record<string, unknown>)[k])
+      // Different exchanges use different credential schemes — apiKey/secret for
+      // most, walletAddress/privateKey for Hyperliquid. Either side counts.
+      return CCXT_CREDENTIAL_FIELDS.some(k => !!pc[k]) || !!pc.walletAddress
     case 'ibkr':
       return true  // no API key — auth via TWS/Gateway login
     default:
@@ -85,12 +81,15 @@ async function initAll(): Promise<TestAccount[]> {
     // Skip disabled accounts
     if (acct.enabled === false) continue
 
+    const engine = getBrokerPreset(acct.presetId).engine
     // IBKR: check TWS/Gateway reachability before attempting connect
-    if (acct.type === 'ibkr') {
-      const bc = acct.brokerConfig
-      const reachable = await isTcpReachable(String(bc.host ?? '127.0.0.1'), Number(bc.port ?? 7497))
+    if (engine === 'ibkr') {
+      const pc = acct.presetConfig as Record<string, unknown>
+      const host = String(pc.host ?? '127.0.0.1')
+      const port = Number(pc.port ?? 7497)
+      const reachable = await isTcpReachable(host, port)
       if (!reachable) {
-        console.warn(`e2e setup: ${acct.id} — TWS not reachable at ${bc.host ?? '127.0.0.1'}:${bc.port ?? 7497}, skipping`)
+        console.warn(`e2e setup: ${acct.id} — TWS not reachable at ${host}:${port}, skipping`)
         continue
       }
     }
@@ -107,7 +106,7 @@ async function initAll(): Promise<TestAccount[]> {
     result.push({
       id: acct.id,
       label: acct.label ?? acct.id,
-      provider: acct.type,
+      provider: engine,
       broker,
     })
   }
@@ -115,7 +114,7 @@ async function initAll(): Promise<TestAccount[]> {
   return result
 }
 
-/** Filter test accounts by provider type. */
-export function filterByProvider(accounts: TestAccount[], provider: AccountConfig['type']): TestAccount[] {
+/** Filter test accounts by provider engine. */
+export function filterByProvider(accounts: TestAccount[], provider: BrokerEngine): TestAccount[] {
   return accounts.filter(a => a.provider === provider)
 }

--- a/src/domain/trading/account-manager.ts
+++ b/src/domain/trading/account-manager.ts
@@ -11,6 +11,7 @@ import type { AccountCapabilities, BrokerHealth, BrokerHealthInfo } from './brok
 import { CcxtBroker } from './brokers/ccxt/CcxtBroker.js'
 import { createCcxtProviderTools } from './brokers/ccxt/ccxt-tools.js'
 import { createBroker } from './brokers/factory.js'
+import { getBrokerPreset } from './brokers/preset-catalog.js'
 import { UnifiedTradingAccount } from './UnifiedTradingAccount.js'
 import { loadGitState, createGitPersister } from './git-persistence.js'
 import { readAccountsConfig, type AccountConfig } from '../../core/config.js'
@@ -129,8 +130,8 @@ export class AccountManager {
       // Wait for broker.init() + broker.getAccount() to verify the connection
       await uta.waitForConnect()
 
-      // Re-register CCXT-specific tools if this is a CCXT account
-      if (accCfg.type === 'ccxt') {
+      // Re-register CCXT-specific tools if this account routes to the CCXT engine.
+      if (getBrokerPreset(accCfg.presetId).engine === 'ccxt') {
         this.toolCenter?.register(
           createCcxtProviderTools(this),
           'trading-ccxt',

--- a/src/domain/trading/brokers/factory.ts
+++ b/src/domain/trading/brokers/factory.ts
@@ -1,19 +1,35 @@
 /**
- * Broker Factory — creates broker instances from account config.
+ * Broker Factory — preset → engine resolver.
  *
- * Delegates to the broker registry. Each broker class owns its own
- * configSchema + fromConfig — no manual field mapping here.
+ * Looks up the AccountConfig's preset, validates the user-facing form
+ * data against the preset's own Zod schema, calls preset.toEngineConfig
+ * to translate it into the engine-shaped dict, then delegates to the
+ * target engine's fromConfig.
+ *
+ * AccountConfig.presetId is the only thing tying account records to
+ * engine implementations — the engine identity is never serialized
+ * directly. Swapping CCXT for a native client later means changing the
+ * preset's `engine` field; on-disk account records stay valid.
  */
 
 import type { IBroker } from './types.js'
-import { BROKER_REGISTRY } from './registry.js'
+import { BROKER_ENGINE_REGISTRY } from './registry.js'
+import { getBrokerPreset } from './preset-catalog.js'
 import type { AccountConfig } from '../../../core/config.js'
 
-/** Create an IBroker from account config. */
+/** Create an IBroker from account config via preset resolution. */
 export function createBroker(config: AccountConfig): IBroker {
-  const entry = BROKER_REGISTRY[config.type]
+  const preset = getBrokerPreset(config.presetId)
+  const presetData = preset.zodSchema.parse(config.presetConfig) as Record<string, unknown>
+  const engineConfig = preset.toEngineConfig(presetData)
+
+  const entry = BROKER_ENGINE_REGISTRY[preset.engine]
   if (!entry) {
-    throw new Error(`Unknown broker type: "${config.type}". Registered types: ${Object.keys(BROKER_REGISTRY).join(', ')}`)
+    throw new Error(`Unknown broker engine "${preset.engine}" referenced by preset "${preset.id}"`)
   }
-  return entry.fromConfig(config)
+  return entry.fromConfig({
+    id: config.id,
+    label: config.label,
+    brokerConfig: engineConfig,
+  })
 }

--- a/src/domain/trading/brokers/index.ts
+++ b/src/domain/trading/brokers/index.ts
@@ -12,10 +12,14 @@ export type {
   TpSlParams,
 } from './types.js'
 
-// Factory + Registry
+// Factory
 export { createBroker } from './factory.js'
-export { BROKER_REGISTRY } from './registry.js'
-export type { BrokerRegistryEntry } from './registry.js'
+
+// Presets (the user-facing surface — many presets, few engines)
+export { BROKER_PRESET_CATALOG, getBrokerPreset, isPaperPreset } from './preset-catalog.js'
+export type { BrokerPresetDef, BrokerEngine, ModeOption, SubtitleSegment } from './preset-catalog.js'
+export { BUILTIN_BROKER_PRESETS } from './presets.js'
+export type { SerializedBrokerPreset } from './presets.js'
 
 // Alpaca
 export { AlpacaBroker } from './alpaca/index.js'

--- a/src/domain/trading/brokers/preset-catalog.ts
+++ b/src/domain/trading/brokers/preset-catalog.ts
@@ -1,0 +1,354 @@
+/**
+ * Broker Preset Catalog — Zod-defined preset declarations.
+ *
+ * Single source of truth for every broker preset the wizard offers.
+ * Each preset is one user-facing "account type" (e.g., OKX, Bybit, Alpaca).
+ * Multiple presets map to a small set of engine implementations
+ * (CcxtBroker, AlpacaBroker, IbkrBroker) — same many-to-few pattern as
+ * the AI provider preset system in src/ai-providers/preset-catalog.ts.
+ *
+ * To add a new preset: add an entry below + register in BROKER_PRESET_CATALOG.
+ */
+
+import { z } from 'zod'
+
+// ==================== Types ====================
+
+export type BrokerEngine = 'ccxt' | 'alpaca' | 'ibkr'
+
+export interface ModeOption {
+  id: string
+  label: string
+}
+
+/** Field shown on an account card under the account name (e.g., "OKX · Demo Trading"). */
+export interface SubtitleSegment {
+  /** Field path inside presetConfig (e.g., "mode"). */
+  field: string
+  /** Static text rendered when the field is truthy. */
+  label?: string
+  /** Static text rendered when the field is falsy (boolean fields only). */
+  falseLabel?: string
+  /** Prefix prepended to the value (text fields). */
+  prefix?: string
+}
+
+export interface BrokerPresetDef {
+  /** Stable id stored on disk in AccountConfig.presetId. */
+  id: string
+  /** User-facing label in the wizard. */
+  label: string
+  /** Short description shown under the label. */
+  description: string
+  /** Group in the picker UI. */
+  category: 'crypto' | 'securities' | 'custom'
+  /** Optional explanatory text rendered with the form (mode-specific gotchas, etc.). */
+  hint?: string
+  /** Default account id suggested in the wizard (e.g., "okx-main"). */
+  defaultName: string
+  /** 2–3-char badge text for the account card. */
+  badge: string
+  /** Tailwind text color for the badge. */
+  badgeColor: string
+  /** Engine class invoked after preset resolution. */
+  engine: BrokerEngine
+  /** Guard category for the guards UI. */
+  guardCategory: 'crypto' | 'securities'
+  /** Zod schema for presetConfig — validates only the fields this preset uses. */
+  zodSchema: z.ZodType
+  /** Optional "Mode" dropdown (Live/Demo/Testnet/Paper/etc.). */
+  modes?: ModeOption[]
+  /** Account-card subtitle layout. */
+  subtitleFields: SubtitleSegment[]
+  /** Field names that should render as password inputs. */
+  writeOnlyFields?: string[]
+  /**
+   * Translate validated preset form data into the engine's internal
+   * config dict. This is where preset-specific knowledge (e.g., "OKX
+   * demo mode = sandbox=true") lives.
+   */
+  toEngineConfig: (presetData: Record<string, unknown>) => Record<string, unknown>
+  /**
+   * Whether a given preset config represents a paper/demo/testnet
+   * account. Used by E2E test setup to filter out live accounts.
+   * Default: true if presetData.mode is one of demo/testnet/paper.
+   */
+  isPaper?: (presetData: Record<string, unknown>) => boolean
+}
+
+// ==================== Helpers ====================
+
+/** Default isPaper: any non-live mode counts as paper. */
+function defaultIsPaper(data: Record<string, unknown>): boolean {
+  const mode = String(data['mode'] ?? '').toLowerCase()
+  return mode === 'demo' || mode === 'testnet' || mode === 'paper'
+}
+
+// ==================== CCXT-engine presets ====================
+
+export const OKX_PRESET: BrokerPresetDef = {
+  id: 'okx',
+  label: 'OKX',
+  description: 'OKX Unified Trading Account — spot, perps, futures, options.',
+  category: 'crypto',
+  hint: 'Demo Trading uses the same domain as live but routes orders to a simulated matching engine. **You must generate a separate set of API keys from OKX\'s demo trading mode** — your live API keys will be rejected in demo. Live keys give the bot real money access; double-check trade-only permissions and never enable withdrawals.',
+  defaultName: 'okx-main',
+  badge: 'OKX',
+  badgeColor: 'text-accent',
+  engine: 'ccxt',
+  guardCategory: 'crypto',
+  modes: [
+    { id: 'live', label: 'Live' },
+    { id: 'demo', label: 'Demo Trading' },
+  ],
+  zodSchema: z.object({
+    mode: z.enum(['live', 'demo']).default('live').describe('Mode'),
+    apiKey: z.string().min(1).describe('API Key'),
+    secret: z.string().min(1).describe('API Secret'),
+    password: z.string().min(1).describe('Passphrase'),
+  }),
+  subtitleFields: [
+    { field: 'mode', prefix: 'OKX · ' },
+  ],
+  writeOnlyFields: ['apiKey', 'secret', 'password'],
+  toEngineConfig: (d) => ({
+    exchange: 'okx',
+    sandbox: d.mode === 'demo',
+    apiKey: d.apiKey,
+    secret: d.secret,
+    password: d.password,
+  }),
+}
+
+export const BYBIT_PRESET: BrokerPresetDef = {
+  id: 'bybit',
+  label: 'Bybit',
+  description: 'Bybit Unified Trading — spot, perps, USDC options.',
+  category: 'crypto',
+  hint: 'Bybit ships **two** non-live environments: Testnet (separate domain api-testnet.bybit.com, fake market data, fake matching) and Demo Trading (production domain, **real** market data, simulated matching). Each requires its own API keys generated in the matching environment.',
+  defaultName: 'bybit-main',
+  badge: 'BY',
+  badgeColor: 'text-accent',
+  engine: 'ccxt',
+  guardCategory: 'crypto',
+  modes: [
+    { id: 'live', label: 'Live' },
+    { id: 'testnet', label: 'Testnet (api-testnet.bybit.com)' },
+    { id: 'demo', label: 'Demo Trading (real market data, fake fills)' },
+  ],
+  zodSchema: z.object({
+    mode: z.enum(['live', 'testnet', 'demo']).default('live').describe('Mode'),
+    apiKey: z.string().min(1).describe('API Key'),
+    secret: z.string().min(1).describe('API Secret'),
+  }),
+  subtitleFields: [
+    { field: 'mode', prefix: 'Bybit · ' },
+  ],
+  writeOnlyFields: ['apiKey', 'secret'],
+  toEngineConfig: (d) => ({
+    exchange: 'bybit',
+    sandbox: d.mode === 'testnet',
+    demoTrading: d.mode === 'demo',
+    apiKey: d.apiKey,
+    secret: d.secret,
+  }),
+}
+
+export const HYPERLIQUID_PRESET: BrokerPresetDef = {
+  id: 'hyperliquid',
+  label: 'Hyperliquid',
+  description: 'Hyperliquid perp DEX. Uses wallet auth, not API keys.',
+  category: 'crypto',
+  hint: 'Hyperliquid authenticates via wallet signatures. Generate a **dedicated API wallet** at app.hyperliquid.xyz/API and use its private key here — never paste your main wallet\'s key. The wallet address can be either the main wallet (vault owner) or the API wallet itself.',
+  defaultName: 'hyperliquid-main',
+  badge: 'HL',
+  badgeColor: 'text-accent',
+  engine: 'ccxt',
+  guardCategory: 'crypto',
+  modes: [
+    { id: 'live', label: 'Mainnet' },
+    { id: 'testnet', label: 'Testnet' },
+  ],
+  zodSchema: z.object({
+    mode: z.enum(['live', 'testnet']).default('live').describe('Network'),
+    walletAddress: z.string().min(1).describe('Wallet Address (0x...)'),
+    privateKey: z.string().min(1).describe('API Wallet Private Key'),
+  }),
+  subtitleFields: [
+    { field: 'mode', prefix: 'Hyperliquid · ' },
+  ],
+  writeOnlyFields: ['privateKey'],
+  toEngineConfig: (d) => ({
+    exchange: 'hyperliquid',
+    sandbox: d.mode === 'testnet',
+    walletAddress: d.walletAddress,
+    privateKey: d.privateKey,
+  }),
+}
+
+export const BITGET_PRESET: BrokerPresetDef = {
+  id: 'bitget',
+  label: 'Bitget',
+  description: 'Bitget — spot and USDT-M perpetuals.',
+  category: 'crypto',
+  hint: 'Bitget requires API key + secret + passphrase (set when creating the key). Demo Trading routes orders to a simulated environment using the production domain.',
+  defaultName: 'bitget-main',
+  badge: 'BG',
+  badgeColor: 'text-accent',
+  engine: 'ccxt',
+  guardCategory: 'crypto',
+  modes: [
+    { id: 'live', label: 'Live' },
+    { id: 'demo', label: 'Demo Trading' },
+  ],
+  zodSchema: z.object({
+    mode: z.enum(['live', 'demo']).default('live').describe('Mode'),
+    apiKey: z.string().min(1).describe('API Key'),
+    secret: z.string().min(1).describe('API Secret'),
+    password: z.string().min(1).describe('Passphrase'),
+  }),
+  subtitleFields: [
+    { field: 'mode', prefix: 'Bitget · ' },
+  ],
+  writeOnlyFields: ['apiKey', 'secret', 'password'],
+  toEngineConfig: (d) => ({
+    exchange: 'bitget',
+    demoTrading: d.mode === 'demo',
+    apiKey: d.apiKey,
+    secret: d.secret,
+    password: d.password,
+  }),
+}
+
+export const CCXT_CUSTOM_PRESET: BrokerPresetDef = {
+  id: 'ccxt-custom',
+  label: 'CCXT Custom (any exchange)',
+  description: 'Power-user escape hatch — connect to any of CCXT\'s 100+ exchanges with the raw credential field set. Untested; expect rough edges.',
+  category: 'custom',
+  hint: 'This preset exposes every CCXT credential field. Use it only for exchanges without a dedicated preset. Read the exchange\'s CCXT page (docs.ccxt.com) to know which fields it actually requires — sandbox/demoTrading semantics vary per exchange.',
+  defaultName: 'ccxt-custom',
+  badge: 'CC',
+  badgeColor: 'text-text-muted',
+  engine: 'ccxt',
+  guardCategory: 'crypto',
+  zodSchema: z.object({
+    exchange: z.string().min(1).describe('Exchange ID (e.g., kucoin, gate, mexc)'),
+    sandbox: z.boolean().default(false).describe('Sandbox / Testnet'),
+    demoTrading: z.boolean().default(false).describe('Demo Trading (per-exchange semantics; usually opens fake matching on prod URL)'),
+    apiKey: z.string().optional().describe('API Key'),
+    secret: z.string().optional().describe('API Secret'),
+    password: z.string().optional().describe('Passphrase'),
+    uid: z.string().optional().describe('User ID'),
+    walletAddress: z.string().optional().describe('Wallet Address (DEX exchanges)'),
+    privateKey: z.string().optional().describe('Private Key (DEX exchanges)'),
+  }),
+  subtitleFields: [
+    { field: 'exchange', prefix: 'CCXT · ' },
+    { field: 'sandbox', label: 'Sandbox' },
+    { field: 'demoTrading', label: 'Demo' },
+  ],
+  writeOnlyFields: ['apiKey', 'secret', 'password', 'privateKey'],
+  toEngineConfig: (d) => {
+    // Pass through every defined field — engine's CcxtBroker.configSchema
+    // will accept whatever subset the user supplies.
+    const out: Record<string, unknown> = { exchange: d.exchange }
+    for (const k of ['sandbox', 'demoTrading', 'apiKey', 'secret', 'password', 'uid', 'walletAddress', 'privateKey']) {
+      if (d[k] !== undefined && d[k] !== '') out[k] = d[k]
+    }
+    return out
+  },
+  isPaper: (d) => Boolean(d.sandbox || d.demoTrading),
+}
+
+// ==================== Native-engine presets ====================
+
+export const ALPACA_PRESET: BrokerPresetDef = {
+  id: 'alpaca',
+  label: 'Alpaca (US Equities)',
+  description: 'Commission-free US stocks and ETFs with fractional shares.',
+  category: 'securities',
+  hint: 'Paper and Live use **separate** API keys — generate from the matching dashboard at alpaca.markets. Paper is free and unlimited; Live places real orders on real money.',
+  defaultName: 'alpaca-paper',
+  badge: 'AL',
+  badgeColor: 'text-green',
+  engine: 'alpaca',
+  guardCategory: 'securities',
+  modes: [
+    { id: 'paper', label: 'Paper Trading' },
+    { id: 'live', label: 'Live Trading' },
+  ],
+  zodSchema: z.object({
+    mode: z.enum(['paper', 'live']).default('paper').describe('Mode'),
+    apiKey: z.string().min(1).describe('API Key'),
+    apiSecret: z.string().min(1).describe('Secret Key'),
+  }),
+  subtitleFields: [
+    { field: 'mode', prefix: 'Alpaca · ' },
+  ],
+  writeOnlyFields: ['apiKey', 'apiSecret'],
+  toEngineConfig: (d) => ({
+    paper: d.mode === 'paper',
+    apiKey: d.apiKey,
+    apiSecret: d.apiSecret,
+  }),
+}
+
+export const IBKR_PRESET: BrokerPresetDef = {
+  id: 'ibkr-tws',
+  label: 'IBKR (TWS / IB Gateway)',
+  description: 'Interactive Brokers via local TWS or IB Gateway socket — stocks, options, futures, FX, bonds.',
+  category: 'securities',
+  hint: 'IBKR auth happens via your TWS/Gateway login — no API keys here. Make sure TWS is running and "Enable ActiveX and Socket Clients" is on (File → Global Configuration → API → Settings). Default ports: 7496 (live) / 7497 (paper). For IB Gateway: 4001 (live) / 4002 (paper).',
+  defaultName: 'ibkr',
+  badge: 'IB',
+  badgeColor: 'text-orange-400',
+  engine: 'ibkr',
+  guardCategory: 'securities',
+  zodSchema: z.object({
+    host: z.string().default('127.0.0.1').describe('Host'),
+    port: z.coerce.number().int().default(7497).describe('Port'),
+    clientId: z.coerce.number().int().default(0).describe('Client ID'),
+    accountId: z.string().optional().describe('Account ID (auto-detected from TWS if blank)'),
+  }),
+  subtitleFields: [
+    { field: 'host', prefix: 'TWS ' },
+    { field: 'port' },
+  ],
+  toEngineConfig: (d) => ({
+    host: d.host,
+    port: d.port,
+    clientId: d.clientId,
+    accountId: d.accountId,
+  }),
+  isPaper: (d) => Number(d.port) === 7497 || Number(d.port) === 4002,
+}
+
+// ==================== Catalog ====================
+
+export const BROKER_PRESET_CATALOG: BrokerPresetDef[] = [
+  // Crypto (tested with real API keys)
+  OKX_PRESET,
+  BYBIT_PRESET,
+  HYPERLIQUID_PRESET,
+  BITGET_PRESET,
+  // Securities
+  ALPACA_PRESET,
+  IBKR_PRESET,
+  // Escape hatch (untested exchanges)
+  CCXT_CUSTOM_PRESET,
+]
+
+/** Lookup by id. Throws if unknown. */
+export function getBrokerPreset(presetId: string): BrokerPresetDef {
+  const preset = BROKER_PRESET_CATALOG.find(p => p.id === presetId)
+  if (!preset) {
+    throw new Error(`Unknown broker preset: "${presetId}". Known presets: ${BROKER_PRESET_CATALOG.map(p => p.id).join(', ')}`)
+  }
+  return preset
+}
+
+/** Returns true if presetId resolves to a paper/demo/testnet account. */
+export function isPaperPreset(presetId: string, presetConfig: Record<string, unknown>): boolean {
+  const preset = getBrokerPreset(presetId)
+  return preset.isPaper ? preset.isPaper(presetConfig) : defaultIsPaper(presetConfig)
+}

--- a/src/domain/trading/brokers/presets.spec.ts
+++ b/src/domain/trading/brokers/presets.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * BROKER_PRESET_CATALOG round-trip tests.
+ *
+ * For every preset, ensure:
+ *   1. A reasonable presetConfig sample passes the preset's zodSchema
+ *   2. toEngineConfig(parsed) produces a dict accepted by the target
+ *      engine's configSchema
+ *   3. isPaper / default isPaper resolves predictably
+ *
+ * This catches drift between preset declarations and engine schemas
+ * (e.g. a preset adding a field the engine doesn't know about).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  BROKER_PRESET_CATALOG,
+  getBrokerPreset,
+  isPaperPreset,
+  OKX_PRESET,
+  BYBIT_PRESET,
+  HYPERLIQUID_PRESET,
+  BITGET_PRESET,
+  ALPACA_PRESET,
+  IBKR_PRESET,
+  CCXT_CUSTOM_PRESET,
+} from './preset-catalog.js'
+import { BROKER_ENGINE_REGISTRY } from './registry.js'
+import { BUILTIN_BROKER_PRESETS } from './presets.js'
+
+// ==================== Sample data per preset ====================
+
+/** Minimal valid presetConfig for each preset id. Use to round-trip through schema + engine. */
+const SAMPLE_CONFIGS: Record<string, Record<string, unknown>> = {
+  okx:           { mode: 'live', apiKey: 'k', secret: 's', password: 'p' },
+  bybit:         { mode: 'live', apiKey: 'k', secret: 's' },
+  hyperliquid:   { mode: 'live', walletAddress: '0xabc', privateKey: 'pk' },
+  bitget:        { mode: 'live', apiKey: 'k', secret: 's', password: 'p' },
+  alpaca:        { mode: 'paper', apiKey: 'k', apiSecret: 's' },
+  'ibkr-tws':    { host: '127.0.0.1', port: 7497, clientId: 0 },
+  'ccxt-custom': { exchange: 'kucoin', apiKey: 'k', secret: 's' },
+}
+
+// ==================== Catalog integrity ====================
+
+describe('BROKER_PRESET_CATALOG', () => {
+  it('declares unique preset ids', () => {
+    const ids = BROKER_PRESET_CATALOG.map(p => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every preset id has a sample config in the test fixture', () => {
+    for (const preset of BROKER_PRESET_CATALOG) {
+      expect(SAMPLE_CONFIGS[preset.id], `missing SAMPLE_CONFIGS["${preset.id}"]`).toBeDefined()
+    }
+  })
+
+  it('getBrokerPreset throws on unknown id', () => {
+    expect(() => getBrokerPreset('does-not-exist')).toThrow(/Unknown broker preset/)
+  })
+})
+
+// ==================== Per-preset round-trip ====================
+
+describe.each(BROKER_PRESET_CATALOG)('preset $id', (preset) => {
+  const sample = SAMPLE_CONFIGS[preset.id]
+
+  it('zodSchema accepts the sample presetConfig', () => {
+    expect(() => preset.zodSchema.parse(sample)).not.toThrow()
+  })
+
+  it('toEngineConfig output is accepted by the target engine schema', () => {
+    const parsed = preset.zodSchema.parse(sample) as Record<string, unknown>
+    const engineConfig = preset.toEngineConfig(parsed)
+    const engineEntry = BROKER_ENGINE_REGISTRY[preset.engine]
+    expect(() => engineEntry.configSchema.parse(engineConfig)).not.toThrow()
+  })
+})
+
+// ==================== Mode → engine flag translation (the OKX-bug guard) ====================
+
+describe('preset → engine config translation', () => {
+  it('OKX mode=demo sets sandbox=true (avoids the demoTrading footgun)', () => {
+    const cfg = OKX_PRESET.toEngineConfig({ mode: 'demo', apiKey: 'k', secret: 's', password: 'p' })
+    expect(cfg.sandbox).toBe(true)
+    expect(cfg.demoTrading).toBeUndefined()  // never use the broken switch on OKX
+  })
+
+  it('OKX mode=live sets sandbox=false', () => {
+    const cfg = OKX_PRESET.toEngineConfig({ mode: 'live', apiKey: 'k', secret: 's', password: 'p' })
+    expect(cfg.sandbox).toBe(false)
+  })
+
+  it('Bybit mode=testnet sets sandbox=true (separate testnet domain)', () => {
+    const cfg = BYBIT_PRESET.toEngineConfig({ mode: 'testnet', apiKey: 'k', secret: 's' })
+    expect(cfg.sandbox).toBe(true)
+    expect(cfg.demoTrading).toBe(false)
+  })
+
+  it('Bybit mode=demo sets demoTrading=true (production URL with simulated header)', () => {
+    const cfg = BYBIT_PRESET.toEngineConfig({ mode: 'demo', apiKey: 'k', secret: 's' })
+    expect(cfg.sandbox).toBe(false)
+    expect(cfg.demoTrading).toBe(true)
+  })
+
+  it('Hyperliquid mode=testnet sets sandbox=true', () => {
+    const cfg = HYPERLIQUID_PRESET.toEngineConfig({ mode: 'testnet', walletAddress: '0x', privateKey: 'pk' })
+    expect(cfg.sandbox).toBe(true)
+  })
+
+  it('Bitget mode=demo sets demoTrading=true', () => {
+    const cfg = BITGET_PRESET.toEngineConfig({ mode: 'demo', apiKey: 'k', secret: 's', password: 'p' })
+    expect(cfg.demoTrading).toBe(true)
+  })
+
+  it('Alpaca mode=paper sets paper=true', () => {
+    const cfg = ALPACA_PRESET.toEngineConfig({ mode: 'paper', apiKey: 'k', apiSecret: 's' })
+    expect(cfg.paper).toBe(true)
+  })
+
+  it('Alpaca mode=live sets paper=false', () => {
+    const cfg = ALPACA_PRESET.toEngineConfig({ mode: 'live', apiKey: 'k', apiSecret: 's' })
+    expect(cfg.paper).toBe(false)
+  })
+
+  it('IBKR passes host/port/clientId straight through', () => {
+    const cfg = IBKR_PRESET.toEngineConfig({ host: '10.0.0.5', port: 7496, clientId: 7 })
+    expect(cfg).toMatchObject({ host: '10.0.0.5', port: 7496, clientId: 7 })
+  })
+
+  it('CCXT Custom drops empty/undefined optional fields', () => {
+    const cfg = CCXT_CUSTOM_PRESET.toEngineConfig({ exchange: 'kucoin', apiKey: 'k', secret: '', uid: undefined })
+    expect(cfg).toEqual({ exchange: 'kucoin', apiKey: 'k' })
+  })
+})
+
+// ==================== isPaper helper ====================
+
+describe('isPaperPreset', () => {
+  it('true for OKX demo, false for OKX live', () => {
+    expect(isPaperPreset('okx', { mode: 'demo' })).toBe(true)
+    expect(isPaperPreset('okx', { mode: 'live' })).toBe(false)
+  })
+
+  it('true for Bybit testnet AND demo, false for live', () => {
+    expect(isPaperPreset('bybit', { mode: 'testnet' })).toBe(true)
+    expect(isPaperPreset('bybit', { mode: 'demo' })).toBe(true)
+    expect(isPaperPreset('bybit', { mode: 'live' })).toBe(false)
+  })
+
+  it('true for Alpaca paper, false for Alpaca live', () => {
+    expect(isPaperPreset('alpaca', { mode: 'paper' })).toBe(true)
+    expect(isPaperPreset('alpaca', { mode: 'live' })).toBe(false)
+  })
+
+  it('IBKR uses port-based detection (7497 / 4002 → paper)', () => {
+    expect(isPaperPreset('ibkr-tws', { port: 7497 })).toBe(true)
+    expect(isPaperPreset('ibkr-tws', { port: 4002 })).toBe(true)
+    expect(isPaperPreset('ibkr-tws', { port: 7496 })).toBe(false)
+    expect(isPaperPreset('ibkr-tws', { port: 4001 })).toBe(false)
+  })
+
+  it('CCXT Custom checks sandbox/demoTrading flags', () => {
+    expect(isPaperPreset('ccxt-custom', { sandbox: true })).toBe(true)
+    expect(isPaperPreset('ccxt-custom', { demoTrading: true })).toBe(true)
+    expect(isPaperPreset('ccxt-custom', {})).toBe(false)
+  })
+})
+
+// ==================== Serialization ====================
+
+describe('BUILTIN_BROKER_PRESETS', () => {
+  it('serializes every catalog preset', () => {
+    expect(BUILTIN_BROKER_PRESETS.map(p => p.id).sort()).toEqual(BROKER_PRESET_CATALOG.map(p => p.id).sort())
+  })
+
+  it('Mode field becomes oneOf with title labels (so the wizard renders human-readable options)', () => {
+    const okx = BUILTIN_BROKER_PRESETS.find(p => p.id === 'okx')!
+    const props = (okx.schema as { properties: Record<string, { oneOf?: Array<{ const: string; title: string }> }> }).properties
+    expect(props.mode.oneOf).toEqual([
+      { const: 'live', title: 'Live' },
+      { const: 'demo', title: 'Demo Trading' },
+    ])
+  })
+
+  it('writeOnly markers applied to credential fields', () => {
+    const okx = BUILTIN_BROKER_PRESETS.find(p => p.id === 'okx')!
+    const props = (okx.schema as { properties: Record<string, { writeOnly?: boolean }> }).properties
+    expect(props.apiKey.writeOnly).toBe(true)
+    expect(props.secret.writeOnly).toBe(true)
+    expect(props.password.writeOnly).toBe(true)
+  })
+})

--- a/src/domain/trading/brokers/presets.ts
+++ b/src/domain/trading/brokers/presets.ts
@@ -1,0 +1,72 @@
+/**
+ * Broker Preset serialization layer.
+ *
+ * Reads BrokerPresetDef from preset-catalog.ts and converts each Zod
+ * schema to a JSON Schema that the frontend can render via the
+ * shared `useSchemaForm` hook (ui/src/hooks/useSchemaForm.ts).
+ *
+ * Mirrors src/ai-providers/presets.ts — same buildJsonSchema pipeline,
+ * same writeOnly + oneOf-with-titles conventions for password inputs and
+ * labeled dropdowns.
+ */
+
+import { z } from 'zod'
+import { BROKER_PRESET_CATALOG, type BrokerPresetDef, type ModeOption, type SubtitleSegment } from './preset-catalog.js'
+
+// ==================== Serialized shape (sent to frontend) ====================
+
+export interface SerializedBrokerPreset {
+  id: string
+  label: string
+  description: string
+  category: 'crypto' | 'securities' | 'custom'
+  hint?: string
+  defaultName: string
+  badge: string
+  badgeColor: string
+  engine: 'ccxt' | 'alpaca' | 'ibkr'
+  guardCategory: 'crypto' | 'securities'
+  modes?: ModeOption[]
+  subtitleFields: SubtitleSegment[]
+  schema: Record<string, unknown>
+}
+
+// ==================== Schema post-processing ====================
+
+function buildJsonSchema(def: BrokerPresetDef): Record<string, unknown> {
+  const raw = z.toJSONSchema(def.zodSchema) as Record<string, unknown>
+  const props = (raw.properties ?? {}) as Record<string, Record<string, unknown>>
+
+  // Mode field: render as labeled dropdown using preset.modes (label > id).
+  if (def.modes?.length && props['mode']) {
+    const oneOf = def.modes.map(m => ({ const: m.id, title: m.label }))
+    const { enum: _e, ...rest } = props['mode']
+    props['mode'] = { ...rest, oneOf }
+  }
+
+  // writeOnly markers for password fields.
+  for (const field of def.writeOnlyFields ?? []) {
+    if (props[field]) props[field].writeOnly = true
+  }
+
+  raw.properties = props
+  return raw
+}
+
+// ==================== Exported ====================
+
+export const BUILTIN_BROKER_PRESETS: SerializedBrokerPreset[] = BROKER_PRESET_CATALOG.map(def => ({
+  id: def.id,
+  label: def.label,
+  description: def.description,
+  category: def.category,
+  hint: def.hint,
+  defaultName: def.defaultName,
+  badge: def.badge,
+  badgeColor: def.badgeColor,
+  engine: def.engine,
+  guardCategory: def.guardCategory,
+  modes: def.modes,
+  subtitleFields: def.subtitleFields,
+  schema: buildJsonSchema(def),
+}))

--- a/src/domain/trading/brokers/registry.ts
+++ b/src/domain/trading/brokers/registry.ts
@@ -1,116 +1,40 @@
 /**
- * Broker Registry — maps type strings to broker classes.
+ * Internal Broker Engine Registry — maps engine names to implementation classes.
  *
- * Each broker self-registers via static configSchema + configFields + fromConfig.
- * Adding a new broker: import it here and add one entry to the registry.
+ * NOT exposed to the frontend. The user-facing surface is BROKER_PRESET_CATALOG
+ * (preset-catalog.ts), which decides *which* engine to use and translates
+ * preset form data into the engine's internal config dict.
+ *
+ * This keeps the option open to swap CcxtBroker for native exchange clients
+ * later without touching the preset surface or any UI.
  */
 
 import type { z } from 'zod'
-import type { IBroker, BrokerConfigField } from './types.js'
-import type { AccountConfig } from '../../../core/config.js'
+import type { IBroker } from './types.js'
 import { CcxtBroker } from './ccxt/CcxtBroker.js'
 import { AlpacaBroker } from './alpaca/AlpacaBroker.js'
 import { IbkrBroker } from './ibkr/IbkrBroker.js'
+import type { BrokerEngine } from './preset-catalog.js'
 
-// ==================== Subtitle field descriptor ====================
-
-export interface SubtitleField {
-  field: string
-  /** Text to show when boolean field is true */
-  label?: string
-  /** Text to show when boolean field is false (omitted = don't show) */
-  falseLabel?: string
-  /** Prefix before the value (e.g. "TWS ") */
-  prefix?: string
-}
-
-// ==================== Registry entry ====================
-
-export interface BrokerRegistryEntry {
-  /** Zod schema for validating brokerConfig fields */
+/** Minimal engine entry: just enough to validate + instantiate. */
+export interface BrokerEngineEntry {
+  /** Zod schema for the engine-shaped config dict (post preset translation). */
   configSchema: z.ZodType
-  /** UI field descriptors for dynamic form rendering */
-  configFields: BrokerConfigField[]
-  /** Construct a broker instance from AccountConfig */
-  fromConfig: (config: AccountConfig) => IBroker
-  /** Display name */
-  name: string
-  /** Short description */
-  description: string
-  /** Badge text (2-3 chars) */
-  badge: string
-  /** Tailwind badge color class */
-  badgeColor: string
-  /** Fields to show in account card subtitle */
-  subtitleFields: SubtitleField[]
-  /** Guard category — determines which guard types are available */
-  guardCategory: 'crypto' | 'securities'
-  /** Multi-line setup guide shown in the New Account wizard. Paragraphs separated by `\n\n`. */
-  setupGuide?: string
+  /** Construct a broker instance from { id, label, brokerConfig }. */
+  fromConfig: (config: { id: string; label?: string; brokerConfig: Record<string, unknown> }) => IBroker
 }
 
-// ==================== Registry ====================
-
-export const BROKER_REGISTRY: Record<string, BrokerRegistryEntry> = {
+export const BROKER_ENGINE_REGISTRY: Record<BrokerEngine, BrokerEngineEntry> = {
   ccxt: {
     configSchema: CcxtBroker.configSchema,
-    configFields: CcxtBroker.configFields,
     fromConfig: CcxtBroker.fromConfig,
-    name: 'CCXT (Crypto)',
-    description: 'Unified API for 100+ crypto exchanges. Supports Binance, Bybit, OKX, Coinbase, and more.',
-    badge: 'CC',
-    badgeColor: 'text-accent',
-    subtitleFields: [
-      { field: 'exchange' },
-      { field: 'demoTrading', label: 'Demo' },
-      { field: 'sandbox', label: 'Sandbox' },
-    ],
-    guardCategory: 'crypto',
-    setupGuide: `CCXT is a unified library that connects to 100+ cryptocurrency exchanges through a single API. After picking a specific exchange below, the form will auto-load the credential fields that exchange requires.
-
-Most exchanges (Binance, Bybit, OKX, etc.) use API key + secret — you can create them in your exchange account's API settings. OKX additionally requires a passphrase you set when creating the key.
-
-Wallet-based exchanges like Hyperliquid use a wallet address + private key instead. For Hyperliquid, you can generate a dedicated API wallet at app.hyperliquid.xyz/API to avoid exposing your main wallet's private key.
-
-Make sure to grant only the permissions you need (read + trade), and never enable withdrawal permissions on automated trading keys.`,
   },
   alpaca: {
     configSchema: AlpacaBroker.configSchema,
-    configFields: AlpacaBroker.configFields,
     fromConfig: AlpacaBroker.fromConfig,
-    name: 'Alpaca (Securities)',
-    description: 'Commission-free US equities and ETFs with fractional share support.',
-    badge: 'AL',
-    badgeColor: 'text-green',
-    subtitleFields: [
-      { field: 'paper', label: 'Paper Trading', falseLabel: 'Live Trading' },
-    ],
-    guardCategory: 'securities',
-    setupGuide: `Alpaca is a commission-free US equities broker with a clean REST API. It supports paper trading (free, simulated) and live trading.
-
-Sign up at alpaca.markets, then create API keys from the dashboard. Toggle "Paper" on this form to use the paper trading endpoint with your paper keys, or off for live trading with your live keys (different key sets).`,
   },
   ibkr: {
     configSchema: IbkrBroker.configSchema,
-    configFields: IbkrBroker.configFields,
     fromConfig: IbkrBroker.fromConfig,
-    name: 'IBKR (Interactive Brokers)',
-    description: 'Professional-grade trading via TWS or IB Gateway. Stocks, options, futures, bonds.',
-    badge: 'IB',
-    badgeColor: 'text-orange-400',
-    subtitleFields: [
-      { field: 'host', prefix: 'TWS ' },
-      { field: 'port' },
-    ],
-    guardCategory: 'securities',
-    setupGuide: `Interactive Brokers requires a local TWS (Trader Workstation) or IB Gateway process running on your machine. OpenAlice connects to it over a TCP socket — no API key needed, authentication happens via TWS login.
-
-Before connecting:
-1. Open TWS / IB Gateway and log in to your paper or live account
-2. Enable API access: File → Global Configuration → API → Settings → "Enable ActiveX and Socket Clients"
-3. Note the socket port (paper: 7497, live: 7496)
-4. Add 127.0.0.1 to "Trusted IPs" if running locally
-
-Paper trading requires a separate paper account login in TWS.`,
   },
 }

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -1,5 +1,5 @@
 import { fetchJson } from './client'
-import type { TradingAccount, AccountSummary, AccountInfo, Position, WalletCommitLog, ReconnectResult, AccountConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerTypeInfo, BrokerConfigField, UTASnapshotSummary, EquityCurvePoint } from './types'
+import type { TradingAccount, AccountSummary, AccountInfo, Position, WalletCommitLog, ReconnectResult, AccountConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, UTASnapshotSummary, EquityCurvePoint } from './types'
 
 /** One contract returned by the broker-side fuzzy search. Shape mirrors what
  *  the AI tool emits — same canonical aliceId for downstream order routing. */
@@ -110,18 +110,10 @@ export const tradingApi = {
     return res.json()
   },
 
-  // ==================== Broker Types ====================
+  // ==================== Broker Presets ====================
 
-  async getBrokerTypes(): Promise<{ brokerTypes: BrokerTypeInfo[] }> {
-    return fetchJson('/api/trading/config/broker-types')
-  },
-
-  async getCcxtExchanges(): Promise<{ exchanges: string[] }> {
-    return fetchJson('/api/trading/config/ccxt/exchanges')
-  },
-
-  async getCcxtCredentialFields(exchange: string): Promise<{ fields: BrokerConfigField[] }> {
-    return fetchJson(`/api/trading/config/ccxt/exchanges/${encodeURIComponent(exchange)}/credentials`)
+  async getBrokerPresets(): Promise<{ presets: BrokerPreset[] }> {
+    return fetchJson('/api/trading/config/broker-presets')
   },
 
   // ==================== Trading Config CRUD ====================

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -351,24 +351,19 @@ export interface ToolCallRecord {
 export interface AccountConfig {
   id: string
   label?: string
-  type: string
+  /** Broker preset id — resolves to engine + form schema on the backend. */
+  presetId: string
   enabled: boolean
   guards: GuardEntry[]
-  brokerConfig: Record<string, unknown>
+  /** User-filled form values for the preset's schema. */
+  presetConfig: Record<string, unknown>
 }
 
-// ==================== Broker Type Metadata (from /broker-types endpoint) ====================
+// ==================== Broker Preset Metadata (from /broker-presets endpoint) ====================
 
-export interface BrokerConfigField {
-  name: string
-  type: 'text' | 'password' | 'number' | 'boolean' | 'select'
+export interface ModeOption {
+  id: string
   label: string
-  placeholder?: string
-  default?: unknown
-  required?: boolean
-  options?: Array<{ value: string; label: string }>
-  description?: string
-  sensitive?: boolean
 }
 
 export interface SubtitleField {
@@ -378,17 +373,20 @@ export interface SubtitleField {
   prefix?: string
 }
 
-export interface BrokerTypeInfo {
-  type: string
-  name: string
+export interface BrokerPreset {
+  id: string
+  label: string
   description: string
-  /** Multi-line setup guide shown in the New Account wizard. Paragraphs separated by `\n\n`. */
-  setupGuide?: string
+  category: 'crypto' | 'securities' | 'custom'
+  hint?: string
+  defaultName: string
   badge: string
   badgeColor: string
-  fields: BrokerConfigField[]
-  subtitleFields: SubtitleField[]
+  engine: 'ccxt' | 'alpaca' | 'ibkr'
   guardCategory: 'crypto' | 'securities'
+  modes?: ModeOption[]
+  subtitleFields: SubtitleField[]
+  schema: JsonSchema
 }
 
 export interface GuardEntry {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -397,7 +397,8 @@ export interface GuardEntry {
 export interface TestConnectionResult {
   success: boolean
   error?: string
-  account?: unknown
+  account?: AccountInfo
+  positions?: Position[]
 }
 
 // ==================== Snapshots ====================

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -7,9 +7,10 @@ import type { SDKOption } from '../components/SDKSelector'
 import { ReconnectButton } from '../components/ReconnectButton'
 import { useTradingConfig } from '../hooks/useTradingConfig'
 import { useAccountHealth } from '../hooks/useAccountHealth'
+import { useSchemaForm, type SchemaField } from '../hooks/useSchemaForm'
 import { PageHeader } from '../components/PageHeader'
 import { api } from '../api'
-import type { AccountConfig, BrokerTypeInfo, BrokerConfigField, BrokerHealthInfo } from '../api/types'
+import type { AccountConfig, BrokerPreset, BrokerHealthInfo, SubtitleField } from '../api/types'
 
 // ==================== Dialog state ====================
 
@@ -24,11 +25,11 @@ export function TradingPage() {
   const tc = useTradingConfig()
   const healthMap = useAccountHealth()
   const [dialog, setDialog] = useState<DialogState>(null)
-  const [brokerTypes, setBrokerTypes] = useState<BrokerTypeInfo[]>([])
+  const [presets, setPresets] = useState<BrokerPreset[]>([])
 
-  // Fetch broker type metadata on mount
+  // Fetch broker preset metadata on mount
   useEffect(() => {
-    api.trading.getBrokerTypes().then(r => setBrokerTypes(r.brokerTypes)).catch(() => {})
+    api.trading.getBrokerPresets().then(r => setPresets(r.presets)).catch(() => {})
   }, [])
 
   useEffect(() => {
@@ -66,7 +67,7 @@ export function TradingPage() {
                 <AccountCard
                   key={account.id}
                   account={account}
-                  brokerType={brokerTypes.find(bt => bt.type === account.type)}
+                  preset={presets.find(p => p.id === account.presetId)}
                   health={healthMap[account.id]}
                   onClick={() => setDialog({ kind: 'edit', accountId: account.id })}
                 />
@@ -85,7 +86,7 @@ export function TradingPage() {
       {/* Create Wizard */}
       {dialog?.kind === 'add' && (
         <CreateWizard
-          brokerTypes={brokerTypes}
+          presets={presets}
           existingAccountIds={tc.accounts.map((a) => a.id)}
           onSave={async (account) => {
             await tc.saveAccount(account)
@@ -106,7 +107,7 @@ export function TradingPage() {
         return (
           <EditDialog
             account={account}
-            brokerType={brokerTypes.find(bt => bt.type === account.type)}
+            preset={presets.find(p => p.id === account.presetId)}
             health={healthMap[account.id]}
             onSaveAccount={tc.saveAccount}
             onDelete={() => deleteAccount(account.id)}
@@ -215,34 +216,40 @@ function HealthBadge({ health, size = 'sm' }: { health?: BrokerHealthInfo; size?
 
 // ==================== Subtitle builder ====================
 
-function buildSubtitle(account: AccountConfig, brokerType?: BrokerTypeInfo): string {
-  if (!brokerType) return account.type
-  const bc = account.brokerConfig
+function buildSubtitle(account: AccountConfig, preset?: BrokerPreset): string {
+  if (!preset) return account.presetId
+  const pc = account.presetConfig
   const parts: string[] = []
-  for (const sf of brokerType.subtitleFields) {
-    const val = bc[sf.field]
+  for (const sf of preset.subtitleFields) {
+    const val = pc[sf.field]
     if (typeof val === 'boolean') {
       if (val && sf.label) parts.push(sf.label)
       else if (!val && sf.falseLabel) parts.push(sf.falseLabel)
     } else if (val != null && val !== '') {
-      parts.push(`${sf.prefix ?? ''}${val}`)
+      // For mode field, prefer the human-readable label from preset.modes
+      let display = String(val)
+      if (sf.field === 'mode' && preset.modes) {
+        const mode = preset.modes.find(m => m.id === val)
+        if (mode) display = mode.label
+      }
+      parts.push(`${sf.prefix ?? ''}${display}`)
     }
   }
-  return parts.join(' · ') || brokerType.name
+  return parts.join(' · ') || preset.label
 }
 
 // ==================== Account Card ====================
 
-function AccountCard({ account, brokerType, health, onClick }: {
+function AccountCard({ account, preset, health, onClick }: {
   account: AccountConfig
-  brokerType?: BrokerTypeInfo
+  preset?: BrokerPreset
   health?: BrokerHealthInfo
   onClick: () => void
 }) {
   const isDisabled = health?.disabled || account.enabled === false
-  const badge = brokerType
-    ? { text: brokerType.badge, color: `${brokerType.badgeColor} ${brokerType.badgeColor.replace('text-', 'bg-')}/10` }
-    : { text: account.type.slice(0, 2).toUpperCase(), color: 'text-text-muted bg-text-muted/10' }
+  const badge = preset
+    ? { text: preset.badge, color: `${preset.badgeColor} ${preset.badgeColor.replace('text-', 'bg-')}/10` }
+    : { text: account.presetId.slice(0, 2).toUpperCase(), color: 'text-text-muted bg-text-muted/10' }
 
   return (
     <button
@@ -256,7 +263,7 @@ function AccountCard({ account, brokerType, health, onClick }: {
         <div className="flex-1 min-w-0">
           <div className="text-[13px] font-medium text-text truncate">{account.id}</div>
           <div className="text-[11px] text-text-muted truncate mt-0.5">
-            {buildSubtitle(account, brokerType)}
+            {buildSubtitle(account, preset)}
             {account.guards.length > 0 && <span className="ml-2 text-text-muted/50">{account.guards.length} guard{account.guards.length > 1 ? 's' : ''}</span>}
           </div>
         </div>
@@ -271,54 +278,53 @@ function AccountCard({ account, brokerType, health, onClick }: {
   )
 }
 
-// ==================== Dynamic Broker Fields ====================
+// ==================== Schema-driven form fields ====================
 
-function DynamicBrokerFields({ fields, values, showSecrets, onChange }: {
-  fields: BrokerConfigField[]
-  values: Record<string, unknown>
+function SchemaFormFields({ fields, formData, setField, showSecrets }: {
+  fields: SchemaField[]
+  formData: Record<string, string>
+  setField: (key: string, value: string) => void
   showSecrets: boolean
-  onChange: (field: string, value: unknown) => void
 }) {
   return (
     <div className="space-y-3">
-      {fields.map((f) => {
+      {fields.map(f => {
+        const value = formData[f.key] ?? f.defaultValue ?? ''
         switch (f.type) {
-          case 'boolean':
-            return (
-              <div key={f.name}>
-                <label className="flex items-center gap-2.5 cursor-pointer">
-                  <Toggle checked={Boolean(values[f.name] ?? f.default)} onChange={(v) => onChange(f.name, v)} />
-                  <span className="text-[13px] text-text">{f.label}</span>
-                </label>
-                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
-              </div>
-            )
           case 'select':
             return (
-              <Field key={f.name} label={f.label}>
-                <select className={inputClass} value={String(values[f.name] ?? f.default ?? '')} onChange={(e) => onChange(f.name, e.target.value)}>
+              <Field key={f.key} label={f.title}>
+                <select className={inputClass} value={value} onChange={(e) => setField(f.key, e.target.value)}>
                   {f.options?.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
                 </select>
+                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
               </Field>
             )
-          case 'number':
+          case 'password':
             return (
-              <Field key={f.name} label={f.label}>
-                <input className={inputClass} type="number" value={Number(values[f.name] ?? f.default ?? 0)} onChange={(e) => onChange(f.name, parseInt(e.target.value) || 0)} placeholder={f.placeholder} />
+              <Field key={f.key} label={f.title}>
+                <input
+                  className={inputClass}
+                  type={showSecrets ? 'text' : 'password'}
+                  value={value}
+                  onChange={(e) => setField(f.key, e.target.value)}
+                  placeholder={f.required ? 'Required' : ''}
+                />
+                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
               </Field>
             )
           case 'text':
-          case 'password':
           default:
             return (
-              <Field key={f.name} label={f.label}>
+              <Field key={f.key} label={f.title}>
                 <input
                   className={inputClass}
-                  type={f.sensitive && !showSecrets ? 'password' : 'text'}
-                  value={String(values[f.name] ?? f.default ?? '')}
-                  onChange={(e) => onChange(f.name, e.target.value)}
-                  placeholder={f.placeholder || (f.required ? 'Required' : '')}
+                  type="text"
+                  value={value}
+                  onChange={(e) => setField(f.key, e.target.value)}
+                  placeholder={f.required ? 'Required' : ''}
                 />
+                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
               </Field>
             )
         }
@@ -327,95 +333,75 @@ function DynamicBrokerFields({ fields, values, showSecrets, onChange }: {
   )
 }
 
+// ==================== Hint renderer (markdown-lite) ====================
+
+function HintBlock({ text }: { text: string }) {
+  // Very simple **bold** + paragraph rendering. Splits paragraphs on \n\n.
+  return (
+    <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-2">
+      {text.trim().split('\n\n').map((para, i) => (
+        <p key={i} className="text-[12px] text-text-muted leading-relaxed">
+          {para.split(/(\*\*[^*]+\*\*)/).map((seg, j) =>
+            seg.startsWith('**') && seg.endsWith('**')
+              ? <strong key={j} className="text-text">{seg.slice(2, -2)}</strong>
+              : <span key={j}>{seg}</span>
+          )}
+        </p>
+      ))}
+    </div>
+  )
+}
+
 // ==================== Create Wizard ====================
 
-function CreateWizard({ brokerTypes, existingAccountIds, onSave, onClose }: {
-  brokerTypes: BrokerTypeInfo[]
+function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
+  presets: BrokerPreset[]
   existingAccountIds: string[]
   onSave: (account: AccountConfig) => Promise<void>
   onClose: () => void
 }) {
-  const [type, setType] = useState<string | null>(null)
+  const [presetId, setPresetId] = useState<string | null>(null)
   const [id, setId] = useState('')
-  const [brokerConfig, setBrokerConfig] = useState<Record<string, unknown>>({})
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [showSecrets, setShowSecrets] = useState(false)
-  // CCXT-only: dynamic exchange list and credential fields
-  const [ccxtExchanges, setCcxtExchanges] = useState<string[]>([])
-  const [ccxtCredFields, setCcxtCredFields] = useState<BrokerConfigField[]>([])
 
-  const bt = brokerTypes.find(b => b.type === type)
+  const preset = presets.find(p => p.id === presetId)
+  const hasSensitive = preset?.schema && Object.values((preset.schema as { properties?: Record<string, { writeOnly?: boolean }> }).properties ?? {}).some(p => p.writeOnly)
 
-  // Merge dynamic CCXT data into broker fields
-  const mergedFields: BrokerConfigField[] = useMemo(() => {
-    if (!bt) return []
-    if (type !== 'ccxt') return bt.fields
-    return bt.fields.map(f => {
-      if (f.name === 'exchange') {
-        return { ...f, options: ccxtExchanges.map(e => ({ value: e, label: e.charAt(0).toUpperCase() + e.slice(1) })) }
-      }
-      return f
-    }).concat(ccxtCredFields)
-  }, [bt, type, ccxtExchanges, ccxtCredFields])
+  const { fields, formData, setField, getSubmitData, validate } = useSchemaForm(preset?.schema)
 
-  const hasSensitive = mergedFields.some(f => f.sensitive)
-
-  // Fetch CCXT exchange list when CCXT is selected
-  useEffect(() => {
-    if (type !== 'ccxt') return
-    api.trading.getCcxtExchanges().then(r => setCcxtExchanges(r.exchanges)).catch(() => setCcxtExchanges([]))
-  }, [type])
-
-  // Fetch CCXT credential fields when exchange changes
-  useEffect(() => {
-    if (type !== 'ccxt') { setCcxtCredFields([]); return }
-    const exchange = brokerConfig.exchange as string | undefined
-    if (!exchange) { setCcxtCredFields([]); return }
-    api.trading.getCcxtCredentialFields(exchange)
-      .then(r => setCcxtCredFields(r.fields))
-      .catch(() => setCcxtCredFields([]))
-  }, [type, brokerConfig.exchange])
-
-  // Initialize defaults when type changes
-  useEffect(() => {
-    if (!bt) return
-    const defaults: Record<string, unknown> = {}
-    for (const f of bt.fields) {
-      if (f.default !== undefined) defaults[f.name] = f.default
-      else if (f.type === 'select' && f.options?.length) defaults[f.name] = f.options[0].value
-    }
-    setBrokerConfig(defaults)
-  }, [type])
-
-  // For CCXT: pre-select first exchange once the list arrives
-  useEffect(() => {
-    if (type !== 'ccxt' || ccxtExchanges.length === 0) return
-    if (!brokerConfig.exchange) {
-      setBrokerConfig(prev => ({ ...prev, exchange: ccxtExchanges[0] }))
-    }
-  }, [type, ccxtExchanges])
-
-  const defaultId = type ? `${type}-main` : ''
+  const defaultId = preset?.defaultName ?? ''
   const finalId = id.trim() || defaultId
 
-  const platformOptions: SDKOption[] = brokerTypes.map(b => ({
-    id: b.type,
-    name: b.name,
-    description: b.description,
-    badge: b.badge,
-    badgeColor: b.badgeColor,
-  }))
+  const platformOptions: SDKOption[] = useMemo(() => presets.map(p => ({
+    id: p.id,
+    name: p.label,
+    description: p.description,
+    badge: p.badge,
+    badgeColor: p.badgeColor,
+  })), [presets])
 
   const handleCreate = async () => {
-    if (!type) return
+    if (!preset) return
     if (existingAccountIds.includes(finalId)) {
       setError(`Account "${finalId}" already exists`)
       return
     }
+    const validationError = validate()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
     setSaving(true); setError('')
     try {
-      const account: AccountConfig = { id: finalId, type, enabled: true, guards: [], brokerConfig }
+      const account: AccountConfig = {
+        id: finalId,
+        presetId: preset.id,
+        enabled: true,
+        guards: [],
+        presetConfig: getSubmitData(),
+      }
 
       const testResult = await api.trading.testConnection(account)
       if (!testResult.success) {
@@ -430,9 +416,6 @@ function CreateWizard({ brokerTypes, existingAccountIds, onSave, onClose }: {
       setSaving(false)
     }
   }
-
-  const canCreate = !!type
-    && mergedFields.filter(f => f.required).every(f => String(brokerConfig[f.name] ?? '').trim())
 
   return (
     <Dialog onClose={onClose}>
@@ -451,31 +434,23 @@ function CreateWizard({ brokerTypes, existingAccountIds, onSave, onClose }: {
         <div className="space-y-5">
           <div>
             <p className="text-[12px] font-medium text-text-muted uppercase tracking-wide mb-3">Platform</p>
-            <SDKSelector options={platformOptions} selected={type ?? ''} onSelect={(t) => setType(t)} />
+            <SDKSelector options={platformOptions} selected={presetId ?? ''} onSelect={(p) => setPresetId(p)} />
           </div>
 
-          {type && bt && (
+          {preset && (
             <>
-              {bt.setupGuide && (
-                <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-2">
-                  {bt.setupGuide.trim().split('\n\n').map((para, i) => (
-                    <p key={i} className="text-[12px] text-text-muted leading-relaxed whitespace-pre-line">
-                      {para}
-                    </p>
-                  ))}
-                </div>
-              )}
+              {preset.hint && <HintBlock text={preset.hint} />}
 
               <div className="space-y-3 pt-2 border-t border-border">
                 <p className="text-[12px] font-medium text-text-muted uppercase tracking-wide mb-1">Configuration</p>
                 <Field label="Account ID">
                   <input className={inputClass} value={id} onChange={(e) => setId(e.target.value.trim())} placeholder={defaultId} />
                 </Field>
-                <DynamicBrokerFields
-                  fields={mergedFields}
-                  values={brokerConfig}
+                <SchemaFormFields
+                  fields={fields}
+                  formData={formData}
+                  setField={setField}
                   showSecrets={showSecrets}
-                  onChange={(f, v) => setBrokerConfig(prev => ({ ...prev, [f]: v }))}
                 />
                 {hasSensitive && (
                   <button
@@ -496,7 +471,7 @@ function CreateWizard({ brokerTypes, existingAccountIds, onSave, onClose }: {
       {/* Footer */}
       <div className="shrink-0 flex items-center justify-between px-6 py-4 border-t border-border">
         <button onClick={onClose} className="btn-secondary">Cancel</button>
-        <button onClick={handleCreate} disabled={saving || !canCreate} className="btn-primary">
+        <button onClick={handleCreate} disabled={saving || !preset} className="btn-primary">
           {saving ? 'Connecting...' : 'Create Account'}
         </button>
       </div>
@@ -506,9 +481,9 @@ function CreateWizard({ brokerTypes, existingAccountIds, onSave, onClose }: {
 
 // ==================== Edit Dialog ====================
 
-function EditDialog({ account, brokerType, health, onSaveAccount, onDelete, onClose }: {
+function EditDialog({ account, preset, health, onSaveAccount, onDelete, onClose }: {
   account: AccountConfig
-  brokerType?: BrokerTypeInfo
+  preset?: BrokerPreset
   health?: BrokerHealthInfo
   onSaveAccount: (a: AccountConfig) => Promise<void>
   onDelete: () => Promise<void>
@@ -519,33 +494,27 @@ function EditDialog({ account, brokerType, health, onSaveAccount, onDelete, onCl
   const [msg, setMsg] = useState('')
   const [guardsOpen, setGuardsOpen] = useState(false)
   const [showKeys, setShowKeys] = useState(false)
-  // CCXT-only: dynamic exchange list and credential fields
-  const [ccxtExchanges, setCcxtExchanges] = useState<string[]>([])
-  const [ccxtCredFields, setCcxtCredFields] = useState<BrokerConfigField[]>([])
+
+  // Schema-driven form pre-populated from account.presetConfig.
+  const initialValues = useMemo(() => {
+    const out: Record<string, string> = {}
+    for (const [k, v] of Object.entries(account.presetConfig)) {
+      if (v != null) out[k] = String(v)
+    }
+    return out
+  }, [account])
+  const { fields, formData, setField, getSubmitData } = useSchemaForm(preset?.schema, initialValues)
+  const hasSensitive = fields.some(f => f.type === 'password')
+
+  // Sync draft.presetConfig from form state on every form change
+  useEffect(() => {
+    const submitData = getSubmitData()
+    setDraft(d => ({ ...d, presetConfig: submitData }))
+  }, [formData, getSubmitData])
 
   useEffect(() => { setDraft(account) }, [account])
 
-  // Fetch CCXT exchange list when editing a CCXT account
-  useEffect(() => {
-    if (account.type !== 'ccxt') return
-    api.trading.getCcxtExchanges().then(r => setCcxtExchanges(r.exchanges)).catch(() => setCcxtExchanges([]))
-  }, [account.type])
-
-  // Fetch CCXT credential fields whenever exchange changes
-  useEffect(() => {
-    if (account.type !== 'ccxt') { setCcxtCredFields([]); return }
-    const exchange = draft.brokerConfig.exchange as string | undefined
-    if (!exchange) { setCcxtCredFields([]); return }
-    api.trading.getCcxtCredentialFields(exchange)
-      .then(r => setCcxtCredFields(r.fields))
-      .catch(() => setCcxtCredFields([]))
-  }, [account.type, draft.brokerConfig.exchange])
-
   const dirty = JSON.stringify(draft) !== JSON.stringify(account)
-
-  const patchBrokerConfig = (field: string, value: unknown) => {
-    setDraft(d => ({ ...d, brokerConfig: { ...d.brokerConfig, [field]: value } }))
-  }
 
   const patchGuards = (guards: AccountConfig['guards']) => {
     setDraft(d => ({ ...d, guards }))
@@ -564,20 +533,7 @@ function EditDialog({ account, brokerType, health, onSaveAccount, onDelete, onCl
     }
   }
 
-  // Merge dynamic CCXT data into broker fields
-  const fields: BrokerConfigField[] = useMemo(() => {
-    const base = brokerType?.fields ?? []
-    if (account.type !== 'ccxt') return base
-    return base.map(f => {
-      if (f.name === 'exchange') {
-        return { ...f, options: ccxtExchanges.map(e => ({ value: e, label: e.charAt(0).toUpperCase() + e.slice(1) })) }
-      }
-      return f
-    }).concat(ccxtCredFields)
-  }, [brokerType, account.type, ccxtExchanges, ccxtCredFields])
-
-  const hasSensitive = fields.some(f => f.sensitive)
-  const guardTypes = (brokerType?.guardCategory === 'crypto') ? CRYPTO_GUARD_TYPES : SECURITIES_GUARD_TYPES
+  const guardTypes = (preset?.guardCategory === 'crypto') ? CRYPTO_GUARD_TYPES : SECURITIES_GUARD_TYPES
 
   return (
     <Dialog onClose={onClose} width="w-[560px]">
@@ -599,13 +555,13 @@ function EditDialog({ account, brokerType, health, onSaveAccount, onDelete, onCl
         <Section title="Configuration">
           <div className="mb-3">
             <span className="text-[12px] text-text-muted">Type</span>
-            <span className="ml-2 text-[12px] font-medium text-text">{brokerType?.name ?? account.type}</span>
+            <span className="ml-2 text-[12px] font-medium text-text">{preset?.label ?? account.presetId}</span>
           </div>
-          <DynamicBrokerFields
+          <SchemaFormFields
             fields={fields}
-            values={draft.brokerConfig}
+            formData={formData}
+            setField={setField}
             showSecrets={showKeys}
-            onChange={patchBrokerConfig}
           />
           {hasSensitive && (
             <button
@@ -696,3 +652,6 @@ function DeleteButton({ label, onConfirm }: { label: string; onConfirm: () => vo
     </button>
   )
 }
+
+// SubtitleField is referenced via preset.subtitleFields elements, kept here for type consumers.
+export type { SubtitleField as _SubtitleField }

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -10,7 +10,7 @@ import { useAccountHealth } from '../hooks/useAccountHealth'
 import { useSchemaForm, type SchemaField } from '../hooks/useSchemaForm'
 import { PageHeader } from '../components/PageHeader'
 import { api } from '../api'
-import type { AccountConfig, BrokerPreset, BrokerHealthInfo, SubtitleField } from '../api/types'
+import type { AccountConfig, BrokerPreset, BrokerHealthInfo, SubtitleField, TestConnectionResult } from '../api/types'
 
 // ==================== Dialog state ====================
 
@@ -352,7 +352,9 @@ function HintBlock({ text }: { text: string }) {
   )
 }
 
-// ==================== Create Wizard ====================
+// ==================== Create Wizard (multi-step) ====================
+
+type WizardStep = 'pick' | 'config' | 'test'
 
 function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
   presets: BrokerPreset[]
@@ -360,15 +362,17 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
   onSave: (account: AccountConfig) => Promise<void>
   onClose: () => void
 }) {
+  const [step, setStep] = useState<WizardStep>('pick')
   const [presetId, setPresetId] = useState<string | null>(null)
   const [id, setId] = useState('')
+  const [showSecrets, setShowSecrets] = useState(false)
+  const [testing, setTesting] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
-  const [showSecrets, setShowSecrets] = useState(false)
+  const [testResult, setTestResult] = useState<TestConnectionResult | null>(null)
 
   const preset = presets.find(p => p.id === presetId)
   const hasSensitive = preset?.schema && Object.values((preset.schema as { properties?: Record<string, { writeOnly?: boolean }> }).properties ?? {}).some(p => p.writeOnly)
-
   const { fields, formData, setField, getSubmitData, validate } = useSchemaForm(preset?.schema)
 
   const defaultId = preset?.defaultName ?? ''
@@ -382,8 +386,26 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
     badgeColor: p.badgeColor,
   })), [presets])
 
-  const handleCreate = async () => {
+  const buildAccount = (): AccountConfig | null => {
+    if (!preset) return null
+    return {
+      id: finalId,
+      presetId: preset.id,
+      enabled: true,
+      guards: [],
+      presetConfig: getSubmitData(),
+    }
+  }
+
+  const handlePick = (id: string) => {
+    setPresetId(id)
+    setError('')
+    setStep('config')
+  }
+
+  const handleTest = async () => {
     if (!preset) return
+    setError('')
     if (existingAccountIds.includes(finalId)) {
       setError(`Account "${finalId}" already exists`)
       return
@@ -393,35 +415,47 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
       setError(validationError)
       return
     }
+    const account = buildAccount()
+    if (!account) return
+    setTesting(true)
+    try {
+      const result = await api.trading.testConnection(account)
+      setTestResult(result)
+      setStep('test')
+    } catch (err) {
+      setTestResult({ success: false, error: err instanceof Error ? err.message : String(err) })
+      setStep('test')
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const handleSave = async () => {
+    const account = buildAccount()
+    if (!account) return
     setSaving(true); setError('')
     try {
-      const account: AccountConfig = {
-        id: finalId,
-        presetId: preset.id,
-        enabled: true,
-        guards: [],
-        presetConfig: getSubmitData(),
-      }
-
-      const testResult = await api.trading.testConnection(account)
-      if (!testResult.success) {
-        setError(testResult.error || 'Connection failed')
-        setSaving(false)
-        return
-      }
-
       await onSave(account)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create account')
+      setError(err instanceof Error ? err.message : 'Failed to save account')
       setSaving(false)
     }
   }
+
+  // Header text mirrors current step so the user always knows where they are.
+  const headerLabel =
+    step === 'pick'   ? 'New Account · Pick Platform' :
+    step === 'config' ? `New Account · Configure ${preset?.label ?? ''}` :
+                        `New Account · Test ${preset?.label ?? ''}`
 
   return (
     <Dialog onClose={onClose}>
       {/* Header */}
       <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
-        <h3 className="text-[14px] font-semibold text-text">New Account</h3>
+        <div className="flex items-center gap-3 min-w-0">
+          <h3 className="text-[14px] font-semibold text-text truncate">{headerLabel}</h3>
+          <StepDots current={step} />
+        </div>
         <button onClick={onClose} className="text-text-muted hover:text-text p-1 transition-colors">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
             <path d="M18 6L6 18M6 6l12 12" />
@@ -431,51 +465,178 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
 
       {/* Body */}
       <div className="flex-1 overflow-y-auto px-6 py-6">
-        <div className="space-y-5">
-          <div>
-            <p className="text-[12px] font-medium text-text-muted uppercase tracking-wide mb-3">Platform</p>
-            <SDKSelector options={platformOptions} selected={presetId ?? ''} onSelect={(p) => setPresetId(p)} />
+        {step === 'pick' && (
+          <SDKSelector options={platformOptions} selected={presetId ?? ''} onSelect={handlePick} />
+        )}
+
+        {step === 'config' && preset && (
+          <div className="space-y-5">
+            {preset.hint && <HintBlock text={preset.hint} />}
+            <div className="space-y-3">
+              <Field label="Account ID">
+                <input className={inputClass} value={id} onChange={(e) => setId(e.target.value.trim())} placeholder={defaultId} />
+              </Field>
+              <SchemaFormFields
+                fields={fields}
+                formData={formData}
+                setField={setField}
+                showSecrets={showSecrets}
+              />
+              {hasSensitive && (
+                <button
+                  onClick={() => setShowSecrets(!showSecrets)}
+                  className="text-[11px] text-text-muted hover:text-text transition-colors"
+                >
+                  {showSecrets ? 'Hide secrets' : 'Show secrets'}
+                </button>
+              )}
+              {error && <p className="text-[12px] text-red">{error}</p>}
+            </div>
           </div>
+        )}
 
-          {preset && (
-            <>
-              {preset.hint && <HintBlock text={preset.hint} />}
-
-              <div className="space-y-3 pt-2 border-t border-border">
-                <p className="text-[12px] font-medium text-text-muted uppercase tracking-wide mb-1">Configuration</p>
-                <Field label="Account ID">
-                  <input className={inputClass} value={id} onChange={(e) => setId(e.target.value.trim())} placeholder={defaultId} />
-                </Field>
-                <SchemaFormFields
-                  fields={fields}
-                  formData={formData}
-                  setField={setField}
-                  showSecrets={showSecrets}
-                />
-                {hasSensitive && (
-                  <button
-                    onClick={() => setShowSecrets(!showSecrets)}
-                    className="text-[11px] text-text-muted hover:text-text transition-colors"
-                  >
-                    {showSecrets ? 'Hide secrets' : 'Show secrets'}
-                  </button>
-                )}
-              </div>
-            </>
-          )}
-
-          {error && <p className="text-[12px] text-red">{error}</p>}
-        </div>
+        {step === 'test' && testResult && (
+          <TestResultPanel result={testResult} accountId={finalId} />
+        )}
       </div>
 
       {/* Footer */}
       <div className="shrink-0 flex items-center justify-between px-6 py-4 border-t border-border">
-        <button onClick={onClose} className="btn-secondary">Cancel</button>
-        <button onClick={handleCreate} disabled={saving || !preset} className="btn-primary">
-          {saving ? 'Connecting...' : 'Create Account'}
-        </button>
+        {step === 'pick' && (
+          <>
+            <button onClick={onClose} className="btn-secondary">Cancel</button>
+            <span className="text-[11px] text-text-muted">Pick a platform to continue</span>
+          </>
+        )}
+        {step === 'config' && (
+          <>
+            <button onClick={() => setStep('pick')} className="btn-secondary">← Back</button>
+            <button onClick={handleTest} disabled={testing} className="btn-primary">
+              {testing ? 'Testing...' : 'Test Connection →'}
+            </button>
+          </>
+        )}
+        {step === 'test' && (
+          <>
+            <button onClick={() => setStep('config')} className="btn-secondary">← Back</button>
+            {testResult?.success ? (
+              <button onClick={handleSave} disabled={saving} className="btn-primary">
+                {saving ? 'Saving...' : 'Save Account'}
+              </button>
+            ) : (
+              <span className="text-[11px] text-text-muted">Fix the config and try again</span>
+            )}
+          </>
+        )}
       </div>
     </Dialog>
+  )
+}
+
+// ==================== Wizard substeps ====================
+
+function StepDots({ current }: { current: WizardStep }) {
+  const order: WizardStep[] = ['pick', 'config', 'test']
+  return (
+    <div className="flex items-center gap-1.5">
+      {order.map((s) => (
+        <span
+          key={s}
+          className={`w-1.5 h-1.5 rounded-full transition-colors ${
+            s === current ? 'bg-accent' : 'bg-border'
+          }`}
+        />
+      ))}
+    </div>
+  )
+}
+
+function TestResultPanel({ result, accountId }: { result: TestConnectionResult; accountId: string }) {
+  if (!result.success) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <span className="w-2 h-2 rounded-full bg-red shrink-0" />
+          <span className="text-[13px] font-medium text-red">Connection failed</span>
+        </div>
+        <div className="rounded-md border border-red/30 bg-red/5 px-3 py-2.5">
+          <p className="text-[12px] text-text leading-relaxed whitespace-pre-wrap">{result.error ?? 'Unknown error'}</p>
+        </div>
+        <p className="text-[11px] text-text-muted">
+          Click <strong className="text-text">← Back</strong> to fix the configuration and try again.
+        </p>
+      </div>
+    )
+  }
+
+  const acct = result.account
+  const positions = result.positions ?? []
+  const visiblePositions = positions.slice(0, 8)
+  const moreCount = positions.length - visiblePositions.length
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <span className="w-2 h-2 rounded-full bg-green shrink-0" />
+        <span className="text-[13px] font-medium text-green">Connected as {accountId}</span>
+      </div>
+
+      {acct && (
+        <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-1">
+          <div className="flex justify-between text-[12px]">
+            <span className="text-text-muted">Net Liquidation</span>
+            <span className="text-text font-medium">{acct.baseCurrency} {acct.netLiquidation}</span>
+          </div>
+          <div className="flex justify-between text-[12px]">
+            <span className="text-text-muted">Cash</span>
+            <span className="text-text">{acct.baseCurrency} {acct.totalCashValue}</span>
+          </div>
+          {acct.unrealizedPnL !== '0' && (
+            <div className="flex justify-between text-[12px]">
+              <span className="text-text-muted">Unrealized P&L</span>
+              <span className="text-text">{acct.baseCurrency} {acct.unrealizedPnL}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div>
+        <p className="text-[12px] font-medium text-text-muted uppercase tracking-wide mb-2">
+          Positions ({positions.length})
+        </p>
+        {positions.length === 0 ? (
+          <p className="text-[12px] text-text-muted">No open positions — connection works, account is empty.</p>
+        ) : (
+          <div className="rounded-md border border-border overflow-hidden">
+            <table className="w-full text-[11px]">
+              <thead>
+                <tr className="bg-bg-tertiary/30 text-text-muted">
+                  <th className="text-left px-2.5 py-1.5 font-medium">Contract</th>
+                  <th className="text-left px-2.5 py-1.5 font-medium">Side</th>
+                  <th className="text-right px-2.5 py-1.5 font-medium">Qty</th>
+                  <th className="text-right px-2.5 py-1.5 font-medium">Mkt Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visiblePositions.map((p, i) => (
+                  <tr key={i} className="border-t border-border">
+                    <td className="px-2.5 py-1.5 text-text font-mono">{p.contract.aliceId ?? p.contract.localSymbol ?? p.contract.symbol ?? '?'}</td>
+                    <td className="px-2.5 py-1.5 text-text-muted">{p.side}</td>
+                    <td className="px-2.5 py-1.5 text-right text-text">{p.quantity}</td>
+                    <td className="px-2.5 py-1.5 text-right text-text">{p.currency} {p.marketValue}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {moreCount > 0 && (
+              <div className="px-2.5 py-1.5 border-t border-border text-[11px] text-text-muted bg-bg-tertiary/20">
+                +{moreCount} more
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

Broker config rebuild on the AI-provider preset model. The OKX
`sandbox`/`demoTrading` chaos diagnosed in the last PR was a symptom
of the underlying "one engine, one universal form" pattern — this PR
refactors that pattern out, replacing it with per-preset Zod schemas,
hint copy, mode dropdowns, and a `toEngineConfig` translation layer.

User picks "OKX (Live)" or "OKX (Demo Trading)" from a preset list and
sees only the fields that matter; the form has no demoTrading toggle
on OKX because it doesn't apply on OKX. Same many-to-few pattern the
AI side already uses (claude-oauth / GLM China / etc. all map to
agent-sdk).

This is a **breaking schema change**. accounts.json shape changed
from `{type, brokerConfig}` to `{presetId, presetConfig}`. No
auto-migration — translating sandbox/demoTrading flags into the new
mode dropdown semantics has too many ways to silently mis-translate
credentials. Old config gets backed up to
`accounts.json.backup-pre-preset` and the user is told (via thrown
error) to recreate accounts in the new wizard.

## Per-session contributions

### 2026-04-29 — Broker preset refactor (UTA config rebuild)

- New `BROKER_PRESET_CATALOG` (`src/domain/trading/brokers/preset-catalog.ts`)
  with seven initial presets: OKX, Bybit, Hyperliquid, Bitget, Alpaca,
  IBKR, plus a CCXT Custom escape hatch. Coverage scope chosen by user
  (the four crypto presets are the ones with tested API keys).
- Each preset declares: per-preset Zod schema, hint copy, mode dropdown
  (Live/Demo/Testnet/Paper as appropriate), engine target,
  `toEngineConfig` translation function, `subtitleFields`, badge,
  `guardCategory`, `isPaper` predicate.
- New serialization layer (`presets.ts`) mirrors the AI side's
  `buildJsonSchema` — Zod → JSON Schema with oneOf-with-titles for
  labeled dropdowns and writeOnly markers for password inputs. The
  frontend uses the existing `useSchemaForm` hook (originally built
  for AI provider profiles) — reused cross-domain, no new form
  rendering code.
- `BROKER_REGISTRY` slimmed to `BROKER_ENGINE_REGISTRY` (configSchema
  + fromConfig only) and marked internal — only preset metadata is
  exposed externally. Future swap of CcxtBroker for native exchange
  clients touches no on-disk records.
- `factory.ts` rewritten to resolve preset → validate presetConfig →
  call `preset.toEngineConfig` → dispatch to engine. The OKX
  demoTrading footgun is gone at the source: OKX preset's
  `toEngineConfig` only ever sets `sandbox`, never `demoTrading`.
- Routes: dropped `/broker-types`, `/ccxt/exchanges`, and
  `/ccxt/exchanges/:name/credentials` (per-exchange field discovery is
  now baked into preset schemas). Single replacement:
  `GET /api/trading/config/broker-presets` returns serialized presets.
- Frontend wizard rewritten end-to-end. `CreateWizard` and
  `EditDialog` are now schema-driven via `useSchemaForm`. Mode
  dropdowns get human-readable labels from `preset.modes`. Hints
  rendered with light markdown (**bold** + paragraph splits).
- Migration: `readAccountsConfig` detects the legacy shape (records
  with `type` field), backs the file up to
  `accounts.json.backup-pre-preset`, then **best-effort auto-migrates**
  every record into the new shape and writes the result back to
  `accounts.json`. Mapping table covers all 4 tested crypto presets
  (OKX/Bybit/Hyperliquid/Bitget) + Alpaca + IBKR + ccxt-custom for
  unknown exchanges. CCXT secret aliasing (`apiSecret` ↔ `secret`)
  handled. Records with no recognizable engine are skipped with a
  warn log naming the id. (Initial commit threw on legacy shape and
  prevented dev server startup; follow-up commit `64ecac7` switched
  to auto-migration.)
- Tests: new `presets.spec.ts` covers per-preset schema parse +
  `toEngineConfig` round-trip against the engine schema, mode →
  engine flag translation (with explicit OKX/Bybit/Hyperliquid/Bitget
  guards against the demoTrading footgun), and the `isPaper` helper.
  `config.spec.ts` updated for the new account shape, plus migration
  cases (OKX live/demo, Bybit testnet, Alpaca, IBKR, ccxt-custom
  fallback). **1172 tests pass** (was 1135, +37).
- `e2e/setup.ts` updated to route paper/credential checks through the
  preset (no more hard-coded `acct.type === 'ccxt'` branches).
- The OKX live-confirmation TODO from the previous PR is now bundled
  with this work — user has OKX demo keys ready; verification will
  happen via the new wizard. Once confirmed working, that TODO entry
  can be dropped from `TODO.md`.
- Wizard UX rebuild (`3bebb21`) after first-pass review feedback:
  the single-page form (preset picker + form scrolling under a fold)
  was hard to scan. New flow is three discrete steps — `pick`
  (platform grid) → `config` (form for the chosen preset, with
  back + Test Connection) → `test` (live results from getAccount +
  getPositions, back + Save Account). Mirrors the AI provider profile
  flow. The test result panel shows net liquidation + cash + first 8
  positions with quantity and market value; for OKX UTA in particular
  this is what proves the spot-holding synthesis is wired through
  end-to-end (empty panel = working but empty book; populated panel
  = full success). `test-connection` route extended to also call
  `getPositions()` in parallel with `getAccount()`.
- New OKX e2e spec (`c2e5621`,
  `src/domain/trading/__test__/e2e/ccxt-okx.e2e.spec.ts`) mirroring
  the bybit + hyperliquid layout. Covers the OKX-unique paths the
  others can't reach: spot synthesis via `fetchSpotHoldings` (spot
  buy → position surfaces with `side='long'`, `avgCost=markPrice`,
  `unrealizedPnL='0'`), spot+perp coexistence on the same underlying
  (ETH/USDT vs ETH/USDT:USDT preserved as separate Position records),
  and graceful skip on OKX cash-mode accounts (error code 51010 →
  spec passes with hint pointing to the margin-mode switch). Verified
  against author's OKX demo account in Multi-currency Margin mode:
  **10/10 tests pass** end-to-end (account · spot synthesis · spot
  trade · perp trade · close · order query). The OKX
  live-confirmation TODO from PR #151 can be dropped — the path is
  proven on a real account.
- Key commits: `f7fa8f5`, `64ecac7`, `3bebb21`, `c2e5621`

## Full commit log

```
c2e5621 test(e2e): OKX broker — covers spot synthesis end-to-end
3bebb21 feat(trading/wizard): multi-step new-account flow with explicit test
64ecac7 fix(config): auto-migrate legacy accounts.json instead of crashing
f7fa8f5 refactor(trading): preset-based UTA config (BREAKING)
```

## Test plan

- [x] `npx tsc --noEmit` clean (root + ui/)
- [x] `pnpm test` — 1172 tests / 59 files pass
- [x] `presets.spec.ts`: every preset's `toEngineConfig` output is
      accepted by the target engine's `configSchema`
- [x] `presets.spec.ts`: explicit guard that OKX `mode='demo'`
      produces `sandbox=true` and never sets `demoTrading`
- [x] `config.spec.ts`: legacy-shape `accounts.json` auto-migrates
      to the new shape with original backed up
- [x] **Live OKX Demo end-to-end**: 10/10 tests pass against author's
      real OKX demo account (Multi-currency Margin mode). Confirms
      spot synthesis via `fetchSpotHoldings` works on a real account
      (OKB/ETH/BTC spot holdings surfaced with correct quantities and
      market values). Closes the OKX TODO from PR #151.
- [x] Migration on real config: author's `accounts.json` (4 legacy
      records: bybit-demo, alpaca-paper, ibkr-paper, hyperliquid-test)
      auto-migrated cleanly. Backup at
      `accounts.json.backup-pre-preset` preserved. dev server starts.
- [ ] Wizard UX in browser: pick each preset (OKX, Bybit, Hyperliquid,
      Bitget, Alpaca, IBKR, CCXT Custom), confirm the 3-step flow
      (pick → config → test) renders correctly and the test panel
      shows positions for accounts with holdings

🤖 Generated with [Claude Code](https://claude.com/claude-code)



