### PR TITLE
UTA detail page + UTA-naming pass

### DIFF
--- a/src/connectors/telegram/telegram-plugin.ts
+++ b/src/connectors/telegram/telegram-plugin.ts
@@ -13,7 +13,7 @@ import { forceCompact } from '../../core/compaction'
 import { readAIProviderConfig, setActiveProfile, readConnectorsConfig } from '../../core/config'
 import type { ConnectorCenter } from '../../core/connector-center.js'
 import { TelegramConnector, splitMessage, MAX_MESSAGE_LENGTH } from './telegram-connector.js'
-import type { AccountManager } from '../../domain/trading/index.js'
+import type { UTAManager } from '../../domain/trading/index.js'
 import type { Operation } from '../../domain/trading/git/types.js'
 import { getOperationSymbol } from '../../domain/trading/git/types.js'
 import { UNSET_DECIMAL } from '@traderalice/ibkr'
@@ -109,7 +109,7 @@ export class TelegramPlugin implements Plugin {
     })
 
     bot.command('trading', async (ctx) => {
-      await this.handleTradingCommand(ctx.chat.id, engineCtx.accountManager)
+      await this.handleTradingCommand(ctx.chat.id, engineCtx.utaManager)
     })
 
     // ── Callback queries (inline keyboard presses) ──
@@ -141,21 +141,21 @@ export class TelegramPlugin implements Plugin {
 
           if (action === 'back') {
             // Return to overview
-            const { text, keyboard } = await this.buildTradingOverview(engineCtx.accountManager)
+            const { text, keyboard } = await this.buildTradingOverview(engineCtx.utaManager)
             await ctx.answerCallbackQuery()
             await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() => {})
           } else if (action === 'view') {
-            const { text, keyboard } = await this.buildAccountPanel(engineCtx.accountManager, accountId)
+            const { text, keyboard } = await this.buildAccountPanel(engineCtx.utaManager, accountId)
             await ctx.answerCallbackQuery()
             await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() => {})
           } else if (action === 'push' || action === 'reject') {
-            const uta = engineCtx.accountManager.get(accountId)
+            const uta = engineCtx.utaManager.get(accountId)
             if (!uta) { await ctx.answerCallbackQuery({ text: 'Account not found' }); return }
             const status = uta.status()
             if (!status.pendingMessage) {
               await ctx.answerCallbackQuery({ text: 'No pending commit' })
               // Refresh panel
-              const { text, keyboard } = await this.buildAccountPanel(engineCtx.accountManager, accountId)
+              const { text, keyboard } = await this.buildAccountPanel(engineCtx.utaManager, accountId)
               await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() => {})
               return
             }
@@ -167,7 +167,7 @@ export class TelegramPlugin implements Plugin {
               await ctx.answerCallbackQuery({ text: 'Rejected' })
             }
             // Refresh panel after action
-            const { text, keyboard } = await this.buildAccountPanel(engineCtx.accountManager, accountId)
+            const { text, keyboard } = await this.buildAccountPanel(engineCtx.utaManager, accountId)
             await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() => {})
           }
         } else if (data.startsWith('heartbeat:')) {
@@ -447,8 +447,8 @@ export class TelegramPlugin implements Plugin {
 
   // ── Trading command ──
 
-  private async handleTradingCommand(chatId: number, accountManager: AccountManager) {
-    const accounts = accountManager.resolve()
+  private async handleTradingCommand(chatId: number, utaManager: UTAManager) {
+    const accounts = utaManager.resolve()
     if (accounts.length === 0) {
       await this.sendReply(chatId, 'No trading accounts configured.')
       return
@@ -456,18 +456,18 @@ export class TelegramPlugin implements Plugin {
 
     // Single account — skip overview, show panel directly
     if (accounts.length === 1) {
-      const { text, keyboard } = await this.buildAccountPanel(accountManager, accounts[0].id)
+      const { text, keyboard } = await this.buildAccountPanel(utaManager, accounts[0].id)
       await this.bot!.api.sendMessage(chatId, text, { reply_markup: keyboard })
       return
     }
 
     // Multiple accounts — show overview with account selector
-    const { text, keyboard } = await this.buildTradingOverview(accountManager)
+    const { text, keyboard } = await this.buildTradingOverview(utaManager)
     await this.bot!.api.sendMessage(chatId, text, { reply_markup: keyboard })
   }
 
-  private async buildTradingOverview(accountManager: AccountManager): Promise<{ text: string; keyboard: InlineKeyboard }> {
-    const accounts = accountManager.resolve()
+  private async buildTradingOverview(utaManager: UTAManager): Promise<{ text: string; keyboard: InlineKeyboard }> {
+    const accounts = utaManager.resolve()
     const lines: string[] = ['Trading Panel', '']
     const keyboard = new InlineKeyboard()
 
@@ -487,8 +487,8 @@ export class TelegramPlugin implements Plugin {
     return { text: lines.join('\n'), keyboard }
   }
 
-  private async buildAccountPanel(accountManager: AccountManager, accountId: string): Promise<{ text: string; keyboard: InlineKeyboard }> {
-    const uta = accountManager.get(accountId)
+  private async buildAccountPanel(utaManager: UTAManager, accountId: string): Promise<{ text: string; keyboard: InlineKeyboard }> {
+    const uta = utaManager.get(accountId)
     if (!uta) return { text: 'Account not found.', keyboard: new InlineKeyboard() }
 
     const healthIcon = uta.health === 'healthy' ? '🟢' : uta.health === 'degraded' ? '🟡' : '🔴'
@@ -537,7 +537,7 @@ export class TelegramPlugin implements Plugin {
     }
 
     // Back button only if multiple accounts
-    if (accountManager.size > 1) {
+    if (utaManager.size > 1) {
       keyboard.text('← Back', 'trading:back:')
     }
 

--- a/src/connectors/web/routes/trading-config.ts
+++ b/src/connectors/web/routes/trading-config.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono'
 import type { EngineContext } from '../../../core/types.js'
 import {
-  readAccountsConfig, writeAccountsConfig,
-  accountConfigSchema,
+  readUTAsConfig, writeUTAsConfig,
+  utaConfigSchema,
 } from '../../../core/config.js'
 import { createBroker } from '../../../domain/trading/brokers/factory.js'
 import { BUILTIN_BROKER_PRESETS } from '../../../domain/trading/brokers/presets.js'
@@ -61,17 +61,17 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
 
   app.get('/', async (c) => {
     try {
-      const accounts = await readAccountsConfig()
-      const maskedAccounts = accounts.map((a) => maskSecrets({ ...a }))
-      return c.json({ accounts: maskedAccounts })
+      const utas = await readUTAsConfig()
+      const maskedUTAs = utas.map((a) => maskSecrets({ ...a }))
+      return c.json({ utas: maskedUTAs })
     } catch (err) {
       return c.json({ error: String(err) }, 500)
     }
   })
 
-  // ==================== Accounts CRUD ====================
+  // ==================== UTA CRUD ====================
 
-  app.put('/accounts/:id', async (c) => {
+  app.put('/uta/:id', async (c) => {
     try {
       const id = c.req.param('id')
       const body = await c.req.json()
@@ -80,13 +80,13 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
       }
 
       // Restore masked credentials from existing config
-      const accounts = await readAccountsConfig()
+      const accounts = await readUTAsConfig()
       const existing = accounts.find((a) => a.id === id)
       if (existing) {
         unmaskSecrets(body, existing as unknown as Record<string, unknown>)
       }
 
-      const validated = accountConfigSchema.parse(body)
+      const validated = utaConfigSchema.parse(body)
 
       const idx = accounts.findIndex((a) => a.id === id)
       if (idx >= 0) {
@@ -94,17 +94,17 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
       } else {
         accounts.push(validated)
       }
-      await writeAccountsConfig(accounts)
+      await writeUTAsConfig(accounts)
 
       // Handle enabled state changes at runtime
       const wasEnabled = existing?.enabled !== false
       const nowEnabled = validated.enabled !== false
       if (wasEnabled && !nowEnabled) {
         // Disabled — close running account
-        await ctx.accountManager.removeAccount(id)
+        await ctx.utaManager.removeUTA(id)
       } else if (!wasEnabled && nowEnabled) {
         // Enabled — start account
-        ctx.accountManager.reconnectAccount(id).catch(() => {})
+        ctx.utaManager.reconnectUTA(id).catch(() => {})
       }
 
       return c.json(validated)
@@ -116,17 +116,17 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
     }
   })
 
-  app.delete('/accounts/:id', async (c) => {
+  app.delete('/uta/:id', async (c) => {
     try {
       const id = c.req.param('id')
-      const accounts = await readAccountsConfig()
+      const accounts = await readUTAsConfig()
       const filtered = accounts.filter((a) => a.id !== id)
       if (filtered.length === accounts.length) {
         return c.json({ error: `Account "${id}" not found` }, 404)
       }
-      await writeAccountsConfig(filtered)
+      await writeUTAsConfig(filtered)
       // Close and deregister running account instance if any
-      await ctx.accountManager.removeAccount(id)
+      await ctx.utaManager.removeUTA(id)
       return c.json({ success: true })
     } catch (err) {
       return c.json({ error: String(err) }, 500)
@@ -144,9 +144,9 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
     } | null = null
     try {
       const body = await c.req.json()
-      const accountConfig = accountConfigSchema.parse({ ...body, id: body.id ?? '__test__' })
+      const utaConfig = utaConfigSchema.parse({ ...body, id: body.id ?? '__test__' })
 
-      broker = createBroker(accountConfig)
+      broker = createBroker(utaConfig)
       await broker.init()
       // Run both calls in parallel — getAccount proves auth, getPositions
       // exercises the data path the user actually cares about (e.g. for OKX

--- a/src/connectors/web/routes/trading-order-entry.spec.ts
+++ b/src/connectors/web/routes/trading-order-entry.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * Tests for the one-shot order entry routes:
+ *   POST /api/trading/uta/:id/wallet/place-order
+ *   POST /api/trading/uta/:id/wallet/close-position
+ *   POST /api/trading/uta/:id/wallet/cancel-order
+ *
+ * These wrap stage → commit → push into a single HTTP roundtrip. We
+ * test:
+ *   - Happy path returns 200 + push result
+ *   - Bad aliceId throws at stage → 400 phase=stage
+ *   - Missing message → Zod 400
+ *   - Numeric strings preserved through to UTA staging (no float
+ *     roundtrip; Decimal precision intact)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createTradingRoutes } from './trading.js'
+import type { EngineContext } from '../../../core/types.js'
+
+// Stub the UTA + manager just enough that the handler can call through.
+// We capture every call to verify what landed at the staging layer.
+
+interface CapturedCall { method: string; args: unknown[] }
+
+function makeMockUTA(opts: { stageThrows?: 'stage' | 'commit' | 'push' | null; pushResult?: unknown } = {}) {
+  const calls: CapturedCall[] = []
+  let pendingMessage: string | null = null
+  return {
+    calls,
+    uta: {
+      id: 'mock-uta',
+      label: 'Mock UTA',
+      stagePlaceOrder: vi.fn((p: unknown) => {
+        calls.push({ method: 'stagePlaceOrder', args: [p] })
+        if (opts.stageThrows === 'stage') throw new Error('Invalid aliceId')
+      }),
+      stageClosePosition: vi.fn((p: unknown) => {
+        calls.push({ method: 'stageClosePosition', args: [p] })
+        if (opts.stageThrows === 'stage') throw new Error('No such position')
+      }),
+      stageCancelOrder: vi.fn((p: unknown) => {
+        calls.push({ method: 'stageCancelOrder', args: [p] })
+        if (opts.stageThrows === 'stage') throw new Error('No such order')
+      }),
+      commit: vi.fn((msg: string) => {
+        calls.push({ method: 'commit', args: [msg] })
+        if (opts.stageThrows === 'commit') throw new Error('Guard rejected')
+        pendingMessage = msg
+      }),
+      push: vi.fn(async () => {
+        calls.push({ method: 'push', args: [] })
+        if (opts.stageThrows === 'push') throw new Error('Broker offline')
+        return opts.pushResult ?? {
+          hash: 'abc123',
+          message: pendingMessage,
+          operationCount: 1,
+          submitted: [{ action: 'placeOrder', success: true, orderId: 'ord-1', status: 'Submitted' }],
+          rejected: [],
+        }
+      }),
+      reject: vi.fn(async () => {
+        calls.push({ method: 'reject', args: [] })
+        return { hash: 'rej', message: 'rolled back', operationCount: 0 }
+      }),
+      status: vi.fn(() => ({ pendingMessage, staged: [], head: null, commitCount: 0 })),
+    },
+  }
+}
+
+function makeRoutes(uta: unknown) {
+  // Minimal EngineContext — only `utaManager.get` is exercised.
+  const ctx = {
+    utaManager: {
+      get: (id: string) => (id === 'mock-uta' ? uta : undefined),
+      resolve: () => [],
+      listUTAs: () => [],
+      getAggregatedEquity: vi.fn(),
+    },
+    snapshotService: undefined,
+  } as unknown as EngineContext
+  return createTradingRoutes(ctx)
+}
+
+async function post(routes: ReturnType<typeof createTradingRoutes>, path: string, body: unknown) {
+  const res = await routes.request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const json = res.status === 204 ? null : await res.json().catch(() => null)
+  return { status: res.status, body: json }
+}
+
+// ==================== place-order ====================
+
+describe('POST /uta/:id/wallet/place-order', () => {
+  let mock: ReturnType<typeof makeMockUTA>
+  beforeEach(() => { mock = makeMockUTA() })
+
+  it('happy path: stages + commits + pushes, returns push result', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status, body } = await post(routes, '/uta/mock-uta/wallet/place-order', {
+      aliceId: 'mock-uta|BTC/USDT',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '0.001',
+      message: 'manual test',
+    })
+
+    expect(status).toBe(200)
+    expect((body as { hash: string }).hash).toBe('abc123')
+    expect(mock.calls.map(c => c.method)).toEqual(['stagePlaceOrder', 'commit', 'push'])
+  })
+
+  it('rejects body without commit message (Zod 400)', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status, body } = await post(routes, '/uta/mock-uta/wallet/place-order', {
+      aliceId: 'mock-uta|BTC/USDT',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '0.001',
+      // message missing
+    })
+
+    expect(status).toBe(400)
+    // No staging/commit/push happened
+    expect(mock.calls).toHaveLength(0)
+  })
+
+  it('rejects body without quantity OR cashQty', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status } = await post(routes, '/uta/mock-uta/wallet/place-order', {
+      aliceId: 'mock-uta|BTC/USDT',
+      action: 'BUY',
+      orderType: 'MKT',
+      message: 'manual test',
+    })
+
+    expect(status).toBe(400)
+    expect(mock.calls).toHaveLength(0)
+  })
+
+  it('returns phase=stage when staging throws', async () => {
+    const failing = makeMockUTA({ stageThrows: 'stage' })
+    const routes = makeRoutes(failing.uta)
+    const { status, body } = await post(routes, '/uta/mock-uta/wallet/place-order', {
+      aliceId: 'mock-uta|BTC/USDT',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '0.001',
+      message: 'manual test',
+    })
+
+    expect(status).toBe(400)
+    expect((body as { phase: string }).phase).toBe('stage')
+    // commit + push should NOT have been called
+    expect(failing.calls.map(c => c.method)).toEqual(['stagePlaceOrder'])
+  })
+
+  it('returns phase=commit when commit throws (and rolls back staging)', async () => {
+    const failing = makeMockUTA({ stageThrows: 'commit' })
+    const routes = makeRoutes(failing.uta)
+    const { status, body } = await post(routes, '/uta/mock-uta/wallet/place-order', {
+      aliceId: 'mock-uta|BTC/USDT',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '0.001',
+      message: 'manual test',
+    })
+
+    expect(status).toBe(400)
+    expect((body as { phase: string }).phase).toBe('commit')
+    expect(failing.calls.map(c => c.method)).toContain('reject') // auto-rollback
+    expect(failing.uta.push).not.toHaveBeenCalled()
+  })
+
+  it('returns phase=push when push throws', async () => {
+    const failing = makeMockUTA({ stageThrows: 'push' })
+    const routes = makeRoutes(failing.uta)
+    const { status, body } = await post(routes, '/uta/mock-uta/wallet/place-order', {
+      aliceId: 'mock-uta|BTC/USDT',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '0.001',
+      message: 'manual test',
+    })
+
+    expect(status).toBe(500)
+    expect((body as { phase: string }).phase).toBe('push')
+  })
+
+  it('returns 404 when UTA does not exist', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status } = await post(routes, '/uta/does-not-exist/wallet/place-order', {
+      aliceId: 'x|y',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '0.001',
+      message: 'manual test',
+    })
+    expect(status).toBe(404)
+  })
+
+  it('preserves quantity precision through to staging (string, not float)', async () => {
+    // High-precision quantity that would lose bits as a float.
+    const routes = makeRoutes(mock.uta)
+    const tinyQty = '0.123456789012345'
+    await post(routes, '/uta/mock-uta/wallet/place-order', {
+      aliceId: 'mock-uta|BTC/USDT',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: tinyQty,
+      message: 'precision regression',
+    })
+
+    const stagedArg = mock.calls.find(c => c.method === 'stagePlaceOrder')!.args[0] as { totalQuantity: string }
+    expect(stagedArg.totalQuantity).toBe(tinyQty)
+    expect(typeof stagedArg.totalQuantity).toBe('string')
+  })
+
+  it('passes the user message into commit', async () => {
+    const routes = makeRoutes(mock.uta)
+    await post(routes, '/uta/mock-uta/wallet/place-order', {
+      aliceId: 'mock-uta|BTC/USDT',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '1',
+      message: 'this exact message',
+    })
+
+    expect(mock.uta.commit).toHaveBeenCalledWith('this exact message')
+  })
+})
+
+// ==================== close-position ====================
+
+describe('POST /uta/:id/wallet/close-position', () => {
+  let mock: ReturnType<typeof makeMockUTA>
+  beforeEach(() => { mock = makeMockUTA() })
+
+  it('happy path with explicit qty', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status } = await post(routes, '/uta/mock-uta/wallet/close-position', {
+      aliceId: 'mock-uta|BTC/USDT',
+      qty: '0.001',
+      message: 'closing test position',
+    })
+
+    expect(status).toBe(200)
+    const stagedArg = mock.calls.find(c => c.method === 'stageClosePosition')!.args[0] as { qty: string }
+    // qty stays a string — preserves precision
+    expect(stagedArg.qty).toBe('0.001')
+    expect(typeof stagedArg.qty).toBe('string')
+  })
+
+  it('happy path without qty (close full position)', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status } = await post(routes, '/uta/mock-uta/wallet/close-position', {
+      aliceId: 'mock-uta|BTC/USDT',
+      message: 'close all',
+    })
+
+    expect(status).toBe(200)
+    const stagedArg = mock.calls.find(c => c.method === 'stageClosePosition')!.args[0] as { qty?: unknown }
+    expect(stagedArg.qty).toBeUndefined()
+  })
+
+  it('rejects body without commit message', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status } = await post(routes, '/uta/mock-uta/wallet/close-position', {
+      aliceId: 'mock-uta|BTC/USDT',
+      qty: '0.001',
+    })
+    expect(status).toBe(400)
+    expect(mock.calls).toHaveLength(0)
+  })
+})
+
+// ==================== cancel-order ====================
+
+describe('POST /uta/:id/wallet/cancel-order', () => {
+  let mock: ReturnType<typeof makeMockUTA>
+  beforeEach(() => { mock = makeMockUTA() })
+
+  it('happy path', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status } = await post(routes, '/uta/mock-uta/wallet/cancel-order', {
+      orderId: 'ord-42',
+      message: 'cancelling stale order',
+    })
+
+    expect(status).toBe(200)
+    const stagedArg = mock.calls.find(c => c.method === 'stageCancelOrder')!.args[0] as { orderId: string }
+    expect(stagedArg.orderId).toBe('ord-42')
+  })
+
+  it('rejects empty orderId', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status } = await post(routes, '/uta/mock-uta/wallet/cancel-order', {
+      orderId: '',
+      message: 'foo',
+    })
+    expect(status).toBe(400)
+  })
+
+  it('rejects empty message', async () => {
+    const routes = makeRoutes(mock.uta)
+    const { status } = await post(routes, '/uta/mock-uta/wallet/cancel-order', {
+      orderId: 'ord-42',
+      message: '',
+    })
+    expect(status).toBe(400)
+  })
+})

--- a/src/connectors/web/routes/trading.ts
+++ b/src/connectors/web/routes/trading.ts
@@ -1,10 +1,97 @@
 import { Hono } from 'hono'
 import type { Context } from 'hono'
+import { z } from 'zod'
 import type { EngineContext } from '../../../core/types.js'
 import { BrokerError } from '../../../domain/trading/brokers/types.js'
 import type { UnifiedTradingAccount } from '../../../domain/trading/UnifiedTradingAccount.js'
 import { searchTradeableContracts } from '../../../domain/trading/contract-search.js'
 import type { AssetClassHint } from '../../../domain/trading/contract-search-rules.js'
+
+// ==================== Order entry schemas ====================
+//
+// All numeric fields use string on the wire (matching the
+// new Decimal(String(x)) pattern in UnifiedTradingAccount.ts) — keeps
+// frontend/backend aligned on Decimal precision and avoids IEEE-754
+// rounding artifacts in JSON serialization.
+
+const numericString = z.string().min(1)
+const message = z.string().min(1, { message: 'Commit message is required' })
+
+const placeOrderSchema = z.object({
+  aliceId: z.string().min(1),
+  symbol: z.string().optional(),
+  action: z.enum(['BUY', 'SELL']),
+  orderType: z.string().min(1),
+  totalQuantity: numericString.optional(),
+  cashQty: numericString.optional(),
+  lmtPrice: numericString.optional(),
+  auxPrice: numericString.optional(),
+  trailStopPrice: numericString.optional(),
+  trailingPercent: numericString.optional(),
+  tif: z.string().optional(),
+  goodTillDate: z.string().optional(),
+  outsideRth: z.boolean().optional(),
+  parentId: z.string().optional(),
+  ocaGroup: z.string().optional(),
+  takeProfit: z.object({ price: numericString }).optional(),
+  stopLoss: z.object({ price: numericString, limitPrice: numericString.optional() }).optional(),
+  message,
+}).refine(
+  (d) => d.totalQuantity != null || d.cashQty != null,
+  { message: 'Either totalQuantity or cashQty is required' },
+)
+
+const closePositionSchema = z.object({
+  aliceId: z.string().min(1),
+  symbol: z.string().optional(),
+  qty: numericString.optional(),
+  message,
+})
+
+const cancelOrderSchema = z.object({
+  orderId: z.string().min(1),
+  message,
+})
+
+/**
+ * Combine stage → commit → push into one HTTP roundtrip. The
+ * underlying TradingGit phases stay separate; this is a route-layer
+ * convenience for the frontend's manual order entry surface. Returns
+ * the full PushResult (including per-op submitted/rejected breakdown
+ * with fills + errors) so the user can see async behavior end-to-end.
+ *
+ * On error, the response carries `phase` so the frontend can label
+ * which step failed (stage → guards bounced; commit → invalid state;
+ * push → broker exception before any per-op result).
+ */
+async function executeOneShot<T>(
+  c: Context,
+  uta: UnifiedTradingAccount,
+  message: string,
+  stage: () => T,
+): Promise<Response> {
+  // Stage
+  try {
+    stage()
+  } catch (err) {
+    return c.json({ error: err instanceof Error ? err.message : String(err), phase: 'stage' }, 400)
+  }
+  // Commit
+  try {
+    uta.commit(message)
+  } catch (err) {
+    // Roll back the staging area so the next attempt starts clean.
+    try { await uta.reject('auto-rollback after commit error') } catch { /* best effort */ }
+    return c.json({ error: err instanceof Error ? err.message : String(err), phase: 'commit' }, 400)
+  }
+  // Push
+  try {
+    const result = await uta.push()
+    return c.json(result)
+  } catch (err) {
+    return c.json({ error: err instanceof Error ? err.message : String(err), phase: 'push' }, 500)
+  }
+}
 
 const ALLOWED_ASSET_CLASSES: ReadonlySet<AssetClassHint> = new Set([
   'equity', 'crypto', 'currency', 'commodity', 'unknown',
@@ -215,6 +302,57 @@ export function createTradingRoutes(ctx: EngineContext) {
     } catch (err) {
       return c.json({ error: String(err) }, 500)
     }
+  })
+
+  // ==================== One-shot order entry ====================
+  //
+  // Combine stage → commit → push for the frontend's manual order
+  // surface. The TradingGit primitives stay separate underneath; this
+  // is a route-layer convenience.
+
+  app.post('/uta/:id/wallet/place-order', async (c) => {
+    const uta = ctx.utaManager.get(c.req.param('id'))
+    if (!uta) return c.json({ error: 'UTA not found' }, 404)
+    let body: z.infer<typeof placeOrderSchema>
+    try {
+      body = placeOrderSchema.parse(await c.req.json())
+    } catch (err) {
+      return c.json({ error: err instanceof z.ZodError ? err.message : String(err), phase: 'validate' }, 400)
+    }
+    return executeOneShot(c, uta, body.message, () => {
+      const { message: _msg, ...stageParams } = body
+      uta.stagePlaceOrder(stageParams)
+    })
+  })
+
+  app.post('/uta/:id/wallet/close-position', async (c) => {
+    const uta = ctx.utaManager.get(c.req.param('id'))
+    if (!uta) return c.json({ error: 'UTA not found' }, 404)
+    let body: z.infer<typeof closePositionSchema>
+    try {
+      body = closePositionSchema.parse(await c.req.json())
+    } catch (err) {
+      return c.json({ error: err instanceof z.ZodError ? err.message : String(err), phase: 'validate' }, 400)
+    }
+    return executeOneShot(c, uta, body.message, () => {
+      const { message: _msg, ...stageParams } = body
+      // qty stays a string all the way to Decimal — no float roundtrip.
+      uta.stageClosePosition(stageParams)
+    })
+  })
+
+  app.post('/uta/:id/wallet/cancel-order', async (c) => {
+    const uta = ctx.utaManager.get(c.req.param('id'))
+    if (!uta) return c.json({ error: 'UTA not found' }, 404)
+    let body: z.infer<typeof cancelOrderSchema>
+    try {
+      body = cancelOrderSchema.parse(await c.req.json())
+    } catch (err) {
+      return c.json({ error: err instanceof z.ZodError ? err.message : String(err), phase: 'validate' }, 400)
+    }
+    return executeOneShot(c, uta, body.message, () => {
+      uta.stageCancelOrder({ orderId: body.orderId })
+    })
   })
 
   // ==================== Snapshot routes ====================

--- a/src/connectors/web/routes/trading.ts
+++ b/src/connectors/web/routes/trading.ts
@@ -14,7 +14,7 @@ const ALLOWED_ASSET_CLASSES: ReadonlySet<AssetClassHint> = new Set([
 function resolveAccount(ctx: EngineContext, c: Context): UnifiedTradingAccount | null {
   const id = c.req.param('id')
   if (!id) return null
-  return ctx.accountManager.get(id) ?? null
+  return ctx.utaManager.get(id) ?? null
 }
 
 /**
@@ -51,16 +51,16 @@ async function queryAccount<T>(
 export function createTradingRoutes(ctx: EngineContext) {
   const app = new Hono()
 
-  // ==================== Accounts listing ====================
+  // ==================== UTA listing ====================
 
-  app.get('/accounts', (c) => {
-    return c.json({ accounts: ctx.accountManager.listAccounts() })
+  app.get('/uta', (c) => {
+    return c.json({ utas: ctx.utaManager.listUTAs() })
   })
 
   // ==================== Aggregated equity ====================
 
   app.get('/equity', async (c) => {
-    const equity = await ctx.accountManager.getAggregatedEquity()
+    const equity = await ctx.utaManager.getAggregatedEquity()
     return c.json(equity)
   })
 
@@ -72,9 +72,9 @@ export function createTradingRoutes(ctx: EngineContext) {
   app.get('/contracts/search', async (c) => {
     const pattern = (c.req.query('pattern') ?? c.req.query('query') ?? '').trim()
     if (!pattern) return c.json({ results: [], count: 0 })
-    const accounts = ctx.accountManager.listAccounts()
-    if (accounts.length === 0) {
-      return c.json({ results: [], count: 0, accountsConfigured: 0 })
+    const utas = ctx.utaManager.listUTAs()
+    if (utas.length === 0) {
+      return c.json({ results: [], count: 0, utasConfigured: 0 })
     }
     // Caller may hint the data-vendor asset class so the rule set in
     // contract-search-rules.ts can pick the right normalization
@@ -82,8 +82,8 @@ export function createTradingRoutes(ctx: EngineContext) {
     // 'unknown' — identity passthrough — when omitted or invalid.
     const rawAc = c.req.query('assetClass') as AssetClassHint | undefined
     const assetClass: AssetClassHint = rawAc && ALLOWED_ASSET_CLASSES.has(rawAc) ? rawAc : 'unknown'
-    const hits = await searchTradeableContracts(ctx.accountManager, pattern, assetClass)
-    return c.json({ results: hits, count: hits.length, accountsConfigured: accounts.length })
+    const hits = await searchTradeableContracts(ctx.utaManager, pattern, assetClass)
+    return c.json({ results: hits, count: hits.length, utasConfigured: utas.length })
   })
 
   // ==================== FX rates ====================
@@ -91,7 +91,7 @@ export function createTradingRoutes(ctx: EngineContext) {
   app.get('/fx-rates', async (c) => {
     // Collect all unique currencies from positions across all accounts
     const currencies = new Set<string>()
-    for (const uta of ctx.accountManager.resolve()) {
+    for (const uta of ctx.utaManager.resolve()) {
       if (uta.health === 'offline') continue
       try {
         const positions = await uta.getPositions()
@@ -114,28 +114,28 @@ export function createTradingRoutes(ctx: EngineContext) {
   // ==================== Per-account routes ====================
 
   // Reconnect
-  app.post('/accounts/:id/reconnect', async (c) => {
+  app.post('/uta/:id/reconnect', async (c) => {
     const id = c.req.param('id')
-    const result = await ctx.accountManager.reconnectAccount(id)
+    const result = await ctx.utaManager.reconnectUTA(id)
     return c.json(result, result.success ? 200 : 500)
   })
 
   // Account info
-  app.get('/accounts/:id/account', async (c) => {
+  app.get('/uta/:id/account', async (c) => {
     const account = resolveAccount(ctx, c)
     if (!account) return c.json({ error: 'Account not found' }, 404)
     return queryAccount(c, account, () => account.getAccount())
   })
 
   // Positions
-  app.get('/accounts/:id/positions', async (c) => {
+  app.get('/uta/:id/positions', async (c) => {
     const account = resolveAccount(ctx, c)
     if (!account) return c.json({ error: 'Account not found' }, 404)
     return queryAccount(c, account, async () => ({ positions: await account.getPositions() }))
   })
 
   // Orders
-  app.get('/accounts/:id/orders', async (c) => {
+  app.get('/uta/:id/orders', async (c) => {
     const account = resolveAccount(ctx, c)
     if (!account) return c.json({ error: 'Account not found' }, 404)
     return queryAccount(c, account, async () => {
@@ -147,14 +147,14 @@ export function createTradingRoutes(ctx: EngineContext) {
   })
 
   // Market clock
-  app.get('/accounts/:id/market-clock', async (c) => {
+  app.get('/uta/:id/market-clock', async (c) => {
     const account = resolveAccount(ctx, c)
     if (!account) return c.json({ error: 'Account not found' }, 404)
     return queryAccount(c, account, () => account.getMarketClock())
   })
 
   // Quote
-  app.get('/accounts/:id/quote/:symbol', async (c) => {
+  app.get('/uta/:id/quote/:symbol', async (c) => {
     const account = resolveAccount(ctx, c)
     if (!account) return c.json({ error: 'Account not found' }, 404)
     return queryAccount(c, account, async () => {
@@ -167,31 +167,31 @@ export function createTradingRoutes(ctx: EngineContext) {
 
   // ==================== Per-account wallet/git routes ====================
 
-  app.get('/accounts/:id/wallet/log', (c) => {
-    const uta = ctx.accountManager.get(c.req.param('id'))
+  app.get('/uta/:id/wallet/log', (c) => {
+    const uta = ctx.utaManager.get(c.req.param('id'))
     if (!uta) return c.json({ error: 'Account not found' }, 404)
     const limit = Number(c.req.query('limit')) || 20
     const symbol = c.req.query('symbol') || undefined
     return c.json({ commits: uta.log({ limit, symbol }) })
   })
 
-  app.get('/accounts/:id/wallet/show/:hash', (c) => {
-    const uta = ctx.accountManager.get(c.req.param('id'))
+  app.get('/uta/:id/wallet/show/:hash', (c) => {
+    const uta = ctx.utaManager.get(c.req.param('id'))
     if (!uta) return c.json({ error: 'Account not found' }, 404)
     const commit = uta.show(c.req.param('hash'))
     if (!commit) return c.json({ error: 'Commit not found' }, 404)
     return c.json(commit)
   })
 
-  app.get('/accounts/:id/wallet/status', (c) => {
-    const uta = ctx.accountManager.get(c.req.param('id'))
+  app.get('/uta/:id/wallet/status', (c) => {
+    const uta = ctx.utaManager.get(c.req.param('id'))
     if (!uta) return c.json({ error: 'Account not found' }, 404)
     return c.json(uta.status())
   })
 
   // Reject (records a user-rejected commit, clears staging)
-  app.post('/accounts/:id/wallet/reject', async (c) => {
-    const uta = ctx.accountManager.get(c.req.param('id'))
+  app.post('/uta/:id/wallet/reject', async (c) => {
+    const uta = ctx.utaManager.get(c.req.param('id'))
     if (!uta) return c.json({ error: 'Account not found' }, 404)
     if (!uta.status().pendingMessage) return c.json({ error: 'Nothing to reject' }, 400)
     try {
@@ -205,8 +205,8 @@ export function createTradingRoutes(ctx: EngineContext) {
   })
 
   // Push (manual approval — the AI tool is hollowed out, only humans can push)
-  app.post('/accounts/:id/wallet/push', async (c) => {
-    const uta = ctx.accountManager.get(c.req.param('id'))
+  app.post('/uta/:id/wallet/push', async (c) => {
+    const uta = ctx.utaManager.get(c.req.param('id'))
     if (!uta) return c.json({ error: 'Account not found' }, 404)
     if (!uta.status().pendingMessage) return c.json({ error: 'Nothing to push' }, 400)
     try {
@@ -220,7 +220,7 @@ export function createTradingRoutes(ctx: EngineContext) {
   // ==================== Snapshot routes ====================
 
   // Per-account snapshots
-  app.get('/accounts/:id/snapshots', async (c) => {
+  app.get('/uta/:id/snapshots', async (c) => {
     if (!ctx.snapshotService) return c.json({ snapshots: [] })
     const id = c.req.param('id')
     const limit = Number(c.req.query('limit')) || 100
@@ -232,7 +232,7 @@ export function createTradingRoutes(ctx: EngineContext) {
     }
   })
 
-  app.delete('/accounts/:id/snapshots/:timestamp', async (c) => {
+  app.delete('/uta/:id/snapshots/:timestamp', async (c) => {
     if (!ctx.snapshotService) return c.json({ error: 'Snapshot service not available' }, 503)
     const id = c.req.param('id')
     const timestamp = decodeURIComponent(c.req.param('timestamp'))
@@ -247,7 +247,7 @@ export function createTradingRoutes(ctx: EngineContext) {
     const limit = Number(c.req.query('limit')) || 200
 
     try {
-      const accounts = ctx.accountManager.resolve()
+      const accounts = ctx.utaManager.resolve()
       // Gather snapshots per account
       const perAccount = await Promise.all(
         accounts.map(async (uta) => {

--- a/src/core/config.spec.ts
+++ b/src/core/config.spec.ts
@@ -23,8 +23,8 @@ import {
   readAgentConfig,
   readMarketDataConfig,
   writeConfigSection,
-  readAccountsConfig,
-  writeAccountsConfig,
+  readUTAsConfig,
+  writeUTAsConfig,
   aiProviderSchema,
   profileSchema,
 } from './config.js'
@@ -205,14 +205,14 @@ describe('writeConfigSection', () => {
   })
 })
 
-// ==================== readAccountsConfig / writeAccountsConfig ====================
+// ==================== readUTAsConfig / writeUTAsConfig ====================
 
-describe('readAccountsConfig', () => {
+describe('readUTAsConfig', () => {
   it('returns empty array and seeds file when missing', async () => {
     const enoent = new Error('ENOENT') as NodeJS.ErrnoException
     enoent.code = 'ENOENT'
     mockReadFile.mockRejectedValueOnce(enoent)
-    const accounts = await readAccountsConfig()
+    const accounts = await readUTAsConfig()
     expect(accounts).toEqual([])
     // Should seed empty accounts.json
     expect(mockWriteFile).toHaveBeenCalledTimes(1)
@@ -223,7 +223,7 @@ describe('readAccountsConfig', () => {
       { id: 'okx-main', presetId: 'okx', enabled: true, guards: [], presetConfig: { mode: 'live', apiKey: 'k', secret: 's', password: 'p' } },
       { id: 'alpaca-paper', presetId: 'alpaca', enabled: true, guards: [], presetConfig: { mode: 'paper', apiKey: 'k', apiSecret: 's' } },
     ])
-    const accounts = await readAccountsConfig()
+    const accounts = await readUTAsConfig()
     expect(accounts).toHaveLength(2)
     expect(accounts[0].presetId).toBe('okx')
     expect(accounts[1].presetId).toBe('alpaca')
@@ -235,7 +235,7 @@ describe('readAccountsConfig', () => {
       { id: 'okx-demo', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'okx', sandbox: true, apiKey: 'k', apiSecret: 's', password: 'p' } },
       { id: 'bybit-test', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'bybit', sandbox: true, apiKey: 'k', apiSecret: 's' } },
     ])
-    const accounts = await readAccountsConfig()
+    const accounts = await readUTAsConfig()
     expect(accounts).toHaveLength(3)
     expect(accounts[0]).toMatchObject({ id: 'okx-live', presetId: 'okx', presetConfig: { mode: 'live' } })
     expect(accounts[1]).toMatchObject({ id: 'okx-demo', presetId: 'okx', presetConfig: { mode: 'demo' } })
@@ -253,7 +253,7 @@ describe('readAccountsConfig', () => {
       { id: 'alp', type: 'alpaca', enabled: true, guards: [], brokerConfig: { paper: true, apiKey: 'k', apiSecret: 's' } },
       { id: 'ibk', type: 'ibkr', enabled: true, guards: [], brokerConfig: { host: '127.0.0.1', port: 7497, clientId: 0 } },
     ])
-    const accounts = await readAccountsConfig()
+    const accounts = await readUTAsConfig()
     expect(accounts[0]).toMatchObject({ presetId: 'alpaca', presetConfig: { mode: 'paper' } })
     expect(accounts[1]).toMatchObject({ presetId: 'ibkr-tws', presetConfig: { host: '127.0.0.1', port: 7497 } })
   })
@@ -262,14 +262,14 @@ describe('readAccountsConfig', () => {
     fileReturns([
       { id: 'kc', type: 'ccxt', enabled: true, guards: [], brokerConfig: { exchange: 'kucoin', apiKey: 'k', apiSecret: 's', password: 'p' } },
     ])
-    const accounts = await readAccountsConfig()
+    const accounts = await readUTAsConfig()
     expect(accounts[0]).toMatchObject({ presetId: 'ccxt-custom', presetConfig: { exchange: 'kucoin', secret: 's' } })
   })
 })
 
-describe('writeAccountsConfig', () => {
+describe('writeUTAsConfig', () => {
   it('writes validated accounts to accounts.json', async () => {
-    await writeAccountsConfig([{
+    await writeUTAsConfig([{
       id: 'acc-1', presetId: 'alpaca', enabled: true, guards: [],
       presetConfig: { mode: 'paper', apiKey: 'k', apiSecret: 's' },
     }])
@@ -279,7 +279,7 @@ describe('writeAccountsConfig', () => {
 
   it('throws ZodError for missing required fields', async () => {
     await expect(
-      writeAccountsConfig([{ presetId: 'alpaca' } as any])
+      writeUTAsConfig([{ presetId: 'alpaca' } as any])
     ).rejects.toThrow()
     expect(mockWriteFile).not.toHaveBeenCalled()
   })

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -264,14 +264,21 @@ export const webSubchannelsSchema = z.array(webSubchannelSchema)
 
 export type WebChannel = z.infer<typeof webSubchannelSchema>
 
-// ==================== Account Config ====================
+// ==================== UTA Config ====================
 
 const guardConfigSchema = z.object({
   type: z.string(),
   options: z.record(z.string(), z.unknown()).default({}),
 })
 
-export const accountConfigSchema = z.object({
+/**
+ * One Unified Trading Account. The user-facing concept — one preset
+ * (OKX, Bybit, IBKR, …) plus credentials, guards, and an enabled flag.
+ *
+ * Distinct from `AccountInfo` (which is broker-side: cash, equity,
+ * margin returned by `IBroker.getAccount()`). Two different "account"s.
+ */
+export const utaConfigSchema = z.object({
   id: z.string(),
   label: z.string().optional(),
   /** Broker preset id — resolves to engine + form schema via BROKER_PRESET_CATALOG. */
@@ -282,9 +289,9 @@ export const accountConfigSchema = z.object({
   presetConfig: z.record(z.string(), z.unknown()).default({}),
 })
 
-export const accountsFileSchema = z.array(accountConfigSchema)
+export const utasFileSchema = z.array(utaConfigSchema)
 
-export type AccountConfig = z.infer<typeof accountConfigSchema>
+export type UTAConfig = z.infer<typeof utaConfigSchema>
 
 // ==================== Unified Config Type ====================
 
@@ -504,7 +511,7 @@ export async function loadConfig(): Promise<Config> {
   }
 }
 
-// ==================== Account Config Loader ====================
+// ==================== UTA Config Loader ====================
 
 /** Single legacy record carries `type` (removed) without `presetId` (new). */
 function isLegacyRecord(o: Record<string, unknown>): boolean {
@@ -522,7 +529,7 @@ function isLegacyRecord(o: Record<string, unknown>): boolean {
  * from the pre-preset schema. Tracked alongside the AI-side migration
  * cleanup at the top of this file.
  */
-function migrateLegacyAccount(raw: Record<string, unknown>): Record<string, unknown> | null {
+function migrateLegacyUTA(raw: Record<string, unknown>): Record<string, unknown> | null {
   const id = String(raw['id'] ?? '')
   const label = raw['label'] as string | undefined
   const enabled = raw['enabled'] as boolean | undefined
@@ -617,7 +624,10 @@ function migrateLegacyAccount(raw: Record<string, unknown>): Record<string, unkn
   return null
 }
 
-export async function readAccountsConfig(): Promise<AccountConfig[]> {
+// File name on disk stays `accounts.json` — internal-only, never
+// user-visible. Renaming would require another migration block; cost
+// outweighs benefit. The on-disk schema is the new UTA shape.
+export async function readUTAsConfig(): Promise<UTAConfig[]> {
   const raw = await loadJsonFile('accounts.json')
   if (raw === undefined) {
     // Seed empty file on first run
@@ -639,7 +649,7 @@ export async function readAccountsConfig(): Promise<AccountConfig[]> {
     for (const item of raw as Record<string, unknown>[]) {
       // Already in new shape — keep verbatim.
       if (!isLegacyRecord(item)) { migrated.push(item); continue }
-      const next = migrateLegacyAccount(item)
+      const next = migrateLegacyUTA(item)
       if (next) {
         migrated.push(next)
       } else {
@@ -653,16 +663,16 @@ export async function readAccountsConfig(): Promise<AccountConfig[]> {
       (skipped.length ? ` Skipped (unknown engine, recreate manually): ${skipped.join(', ')}.` : ''),
     )
 
-    const validated = accountsFileSchema.parse(migrated)
+    const validated = utasFileSchema.parse(migrated)
     await writeFile(resolve(CONFIG_DIR, 'accounts.json'), JSON.stringify(validated, null, 2) + '\n')
     return validated
   }
 
-  return accountsFileSchema.parse(raw)
+  return utasFileSchema.parse(raw)
 }
 
-export async function writeAccountsConfig(accounts: AccountConfig[]): Promise<void> {
-  const validated = accountsFileSchema.parse(accounts)
+export async function writeUTAsConfig(utas: UTAConfig[]): Promise<void> {
+  const validated = utasFileSchema.parse(utas)
   await mkdir(CONFIG_DIR, { recursive: true })
   await writeFile(resolve(CONFIG_DIR, 'accounts.json'), JSON.stringify(validated, null, 2) + '\n')
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,5 @@
 import type { QueryExecutor } from '@traderalice/opentypebb'
-import type { AccountManager } from '../domain/trading/index.js'
+import type { UTAManager } from '../domain/trading/index.js'
 import type { FxService } from '../domain/trading/fx-service.js'
 import type { SnapshotService } from '../domain/trading/snapshot/index.js'
 import type { INewsProvider } from '../domain/news/types.js'
@@ -50,7 +50,7 @@ export interface EngineContext {
   marketSearch: MarketSearchDeps
 
   // Trading (unified account model)
-  accountManager: AccountManager
+  utaManager: UTAManager
   fxService: FxService
   snapshotService?: SnapshotService
   newsProvider?: INewsProvider

--- a/src/domain/trading/UnifiedTradingAccount.ts
+++ b/src/domain/trading/UnifiedTradingAccount.ts
@@ -78,7 +78,8 @@ export interface StageModifyOrderParams {
 export interface StageClosePositionParams {
   aliceId: string
   symbol?: string
-  qty?: number
+  /** Accepts string (preferred — preserves Decimal precision) or number. Empty / undefined closes the full position. */
+  qty?: number | string
 }
 
 // ==================== UnifiedTradingAccount ====================

--- a/src/domain/trading/__test__/e2e/setup.ts
+++ b/src/domain/trading/__test__/e2e/setup.ts
@@ -1,7 +1,7 @@
 /**
  * E2E test setup — shared, lazily-initialized broker instances.
  *
- * Uses the same code path as main.ts: readAccountsConfig → createBroker.
+ * Uses the same code path as main.ts: readUTAsConfig → createBroker.
  * Only selects accounts in paper/sandbox/demo environments (isPaper check).
  *
  * Singleton: first call loads config + inits all brokers. Subsequent calls
@@ -9,7 +9,7 @@
  */
 
 import net from 'node:net'
-import { readAccountsConfig, type AccountConfig } from '@/core/config.js'
+import { readUTAsConfig, type UTAConfig } from '@/core/config.js'
 import type { IBroker } from '../../brokers/types.js'
 import { createBroker } from '../../brokers/factory.js'
 import { getBrokerPreset, isPaperPreset, type BrokerEngine } from '../../brokers/preset-catalog.js'
@@ -25,12 +25,12 @@ export interface TestAccount {
 // ==================== Safety ====================
 
 /** Unified paper/sandbox check — E2E only runs non-live accounts. Routed through preset.isPaper. */
-function isPaper(acct: AccountConfig): boolean {
+function isPaper(acct: UTAConfig): boolean {
   return isPaperPreset(acct.presetId, acct.presetConfig)
 }
 
 /** Check whether API credentials are configured (not applicable for all broker types). */
-function hasCredentials(acct: AccountConfig): boolean {
+function hasCredentials(acct: UTAConfig): boolean {
   const engine = getBrokerPreset(acct.presetId).engine
   const pc = acct.presetConfig as Record<string, unknown>
   switch (engine) {
@@ -71,7 +71,7 @@ export function getTestAccounts(): Promise<TestAccount[]> {
 }
 
 async function initAll(): Promise<TestAccount[]> {
-  const accounts = await readAccountsConfig()
+  const accounts = await readUTAsConfig()
   const result: TestAccount[] = []
 
   for (const acct of accounts) {

--- a/src/domain/trading/__test__/e2e/uta-lifecycle.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/uta-lifecycle.e2e.spec.ts
@@ -45,9 +45,9 @@ describe('UTA — full trading lifecycle', () => {
     expect(positions[0].contract.symbol).toBe('AAPL')
     expect(positions[0].quantity.toNumber()).toBe(10)
 
-    // Cash decreased
+    // Cash decreased — monetary fields are strings (post Decimal migration).
     const account = await broker.getAccount()
-    expect(account.totalCashValue).toBe(100_000 - 10 * 150)
+    expect(account.totalCashValue).toBe(String(100_000 - 10 * 150))
   })
 
   it('market buy fills at push time — no sync needed', async () => {
@@ -77,7 +77,7 @@ describe('UTA — full trading lifecycle', () => {
     const state = await uta.getState()
     expect(state.positions).toHaveLength(1)
     expect(state.pendingOrders).toHaveLength(1)
-    expect(state.totalCashValue).toBe(100_000 - 10 * 150)
+    expect(state.totalCashValue).toBe(String(100_000 - 10 * 150))
   })
 
   it('limit order → submitted → fill → sync detects filled', async () => {
@@ -104,7 +104,7 @@ describe('UTA — full trading lifecycle', () => {
     const positions = await broker.getPositions()
     expect(positions).toHaveLength(1)
     expect(positions[0].quantity.toNumber()).toBe(5)
-    expect(positions[0].avgCost).toBe(144)
+    expect(positions[0].avgCost).toBe('144')
   })
 
   it('partial close reduces position', async () => {
@@ -133,7 +133,7 @@ describe('UTA — full trading lifecycle', () => {
 
     expect(await broker.getPositions()).toHaveLength(0)
     const account = await broker.getAccount()
-    expect(account.totalCashValue).toBe(100_000)
+    expect(account.totalCashValue).toBe('100000')
   })
 
   it('cancel pending order', async () => {

--- a/src/domain/trading/brokers/ccxt/ccxt-tools.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-tools.ts
@@ -7,11 +7,11 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import { Contract } from '@traderalice/ibkr'
-import type { AccountManager } from '../../account-manager.js'
+import type { UTAManager } from '../../uta-manager.js'
 import { CcxtBroker } from './CcxtBroker.js'
 import '../../contract-ext.js'
 
-export function createCcxtProviderTools(manager: AccountManager) {
+export function createCcxtProviderTools(manager: UTAManager) {
   /** Resolve to exactly one CcxtBroker. Returns error object if unable. */
   const resolveCcxtOne = (source?: string): { broker: CcxtBroker; id: string } | { error: string } => {
     const targets = manager.resolve(source)

--- a/src/domain/trading/brokers/factory.ts
+++ b/src/domain/trading/brokers/factory.ts
@@ -1,12 +1,12 @@
 /**
  * Broker Factory — preset → engine resolver.
  *
- * Looks up the AccountConfig's preset, validates the user-facing form
+ * Looks up the UTAConfig's preset, validates the user-facing form
  * data against the preset's own Zod schema, calls preset.toEngineConfig
  * to translate it into the engine-shaped dict, then delegates to the
  * target engine's fromConfig.
  *
- * AccountConfig.presetId is the only thing tying account records to
+ * UTAConfig.presetId is the only thing tying account records to
  * engine implementations — the engine identity is never serialized
  * directly. Swapping CCXT for a native client later means changing the
  * preset's `engine` field; on-disk account records stay valid.
@@ -15,10 +15,10 @@
 import type { IBroker } from './types.js'
 import { BROKER_ENGINE_REGISTRY } from './registry.js'
 import { getBrokerPreset } from './preset-catalog.js'
-import type { AccountConfig } from '../../../core/config.js'
+import type { UTAConfig } from '../../../core/config.js'
 
 /** Create an IBroker from account config via preset resolution. */
-export function createBroker(config: AccountConfig): IBroker {
+export function createBroker(config: UTAConfig): IBroker {
   const preset = getBrokerPreset(config.presetId)
   const presetData = preset.zodSchema.parse(config.presetConfig) as Record<string, unknown>
   const engineConfig = preset.toEngineConfig(presetData)

--- a/src/domain/trading/brokers/preset-catalog.ts
+++ b/src/domain/trading/brokers/preset-catalog.ts
@@ -34,7 +34,7 @@ export interface SubtitleSegment {
 }
 
 export interface BrokerPresetDef {
-  /** Stable id stored on disk in AccountConfig.presetId. */
+  /** Stable id stored on disk in UTAConfig.presetId. */
   id: string
   /** User-facing label in the wizard. */
   label: string

--- a/src/domain/trading/contract-search.ts
+++ b/src/domain/trading/contract-search.ts
@@ -14,7 +14,7 @@
  */
 
 import type { ContractDescription } from '@traderalice/ibkr'
-import type { AccountManager } from './account-manager.js'
+import type { UTAManager } from './uta-manager.js'
 import {
   normalizeBrokerSearchPattern,
   type AssetClassHint,
@@ -28,7 +28,7 @@ export interface ContractSearchHit {
 }
 
 export async function searchTradeableContracts(
-  manager: AccountManager,
+  manager: UTAManager,
   pattern: string,
   assetClass: AssetClassHint = 'unknown',
 ): Promise<ContractSearchHit[]> {

--- a/src/domain/trading/index.ts
+++ b/src/domain/trading/index.ts
@@ -5,14 +5,14 @@ import './contract-ext.js'
 export { UnifiedTradingAccount } from './UnifiedTradingAccount.js'
 export type { UnifiedTradingAccountOptions, StagePlaceOrderParams, StageModifyOrderParams, StageClosePositionParams } from './UnifiedTradingAccount.js'
 
-// AccountManager
-export { AccountManager } from './account-manager.js'
+// UTAManager
+export { UTAManager } from './uta-manager.js'
 export type {
-  AccountSummary,
+  UTASummary,
   AggregatedEquity,
   ContractSearchResult,
   SnapshotHooks,
-} from './account-manager.js'
+} from './uta-manager.js'
 
 // Brokers (types + implementations + factory)
 export type {

--- a/src/domain/trading/snapshot/service.ts
+++ b/src/domain/trading/snapshot/service.ts
@@ -8,7 +8,7 @@
  * Store instances are cached per account to ensure writes are serialized.
  */
 
-import type { AccountManager } from '../account-manager.js'
+import type { UTAManager } from '../uta-manager.js'
 import type { EventLog } from '../../../core/event-log.js'
 import type { SnapshotStore } from './store.js'
 import type { UTASnapshot, SnapshotTrigger } from './types.js'
@@ -25,12 +25,12 @@ export interface SnapshotService {
 }
 
 export function createSnapshotService(deps: {
-  accountManager: AccountManager
+  utaManager: UTAManager
   eventLog?: EventLog
   /** Override storage base directory (tests use tmpdir). */
   baseDir?: string
 }): SnapshotService {
-  const { accountManager, eventLog, baseDir } = deps
+  const { utaManager, eventLog, baseDir } = deps
   const stores = new Map<string, SnapshotStore>()
 
   function getStore(accountId: string): SnapshotStore {
@@ -44,7 +44,7 @@ export function createSnapshotService(deps: {
 
   return {
     async takeSnapshot(accountId, trigger) {
-      const uta = accountManager.get(accountId)
+      const uta = utaManager.get(accountId)
       if (!uta) return null
 
       try {
@@ -76,7 +76,7 @@ export function createSnapshotService(deps: {
     },
 
     async takeAllSnapshots(trigger) {
-      const accounts = accountManager.resolve()
+      const accounts = utaManager.resolve()
 
       // First round — try all accounts
       const results = await Promise.allSettled(

--- a/src/domain/trading/snapshot/snapshot.spec.ts
+++ b/src/domain/trading/snapshot/snapshot.spec.ts
@@ -8,7 +8,7 @@ import { Order, OrderState } from '@traderalice/ibkr'
 import { UnifiedTradingAccount } from '../UnifiedTradingAccount.js'
 import type { UnifiedTradingAccountOptions } from '../UnifiedTradingAccount.js'
 import { MockBroker, makeContract, makePosition, makeOpenOrder } from '../brokers/mock/index.js'
-import { AccountManager } from '../account-manager.js'
+import { UTAManager } from '../uta-manager.js'
 import { createEventLog, type EventLog } from '../../../core/event-log.js'
 import { createListenerRegistry, type ListenerRegistry } from '../../../core/listener-registry.js'
 import { createCronEngine, type CronEngine } from '../../../task/cron/engine.js'
@@ -340,13 +340,13 @@ describe('Snapshot Store', () => {
 // ==================== Service Tests ====================
 
 describe('Snapshot Service', () => {
-  let manager: AccountManager
+  let manager: UTAManager
   let eventLog: EventLog
   let service: SnapshotService
   let serviceDir: string
 
   beforeEach(async () => {
-    manager = new AccountManager()
+    manager = new UTAManager()
     const logPath = tempPath('jsonl')
     eventLog = await createEventLog({ logPath })
     serviceDir = tempDir()
@@ -355,7 +355,7 @@ describe('Snapshot Service', () => {
     const uta = new UnifiedTradingAccount(broker)
     manager.add(uta)
 
-    service = createSnapshotService({ accountManager: manager, eventLog, baseDir: serviceDir })
+    service = createSnapshotService({ utaManager: manager, eventLog, baseDir: serviceDir })
   })
 
   afterEach(async () => {

--- a/src/domain/trading/uta-manager.spec.ts
+++ b/src/domain/trading/uta-manager.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ContractDescription } from '@traderalice/ibkr'
-import { AccountManager } from './account-manager.js'
+import { UTAManager } from './uta-manager.js'
 import { UnifiedTradingAccount } from './UnifiedTradingAccount.js'
 import {
   MockBroker,
@@ -12,11 +12,11 @@ function makeUta(broker: MockBroker): UnifiedTradingAccount {
   return new UnifiedTradingAccount(broker)
 }
 
-describe('AccountManager', () => {
-  let manager: AccountManager
+describe('UTAManager', () => {
+  let manager: UTAManager
 
   beforeEach(() => {
-    manager = new AccountManager()
+    manager = new UTAManager()
   })
 
   // ==================== Registration ====================
@@ -50,14 +50,14 @@ describe('AccountManager', () => {
     })
   })
 
-  // ==================== listAccounts ====================
+  // ==================== listUTAs ====================
 
-  describe('listAccounts', () => {
+  describe('listUTAs', () => {
     it('returns summaries of all accounts', () => {
       manager.add(makeUta(new MockBroker({ id: 'a1', label: 'Paper' })))
       manager.add(makeUta(new MockBroker({ id: 'a2', label: 'Bybit' })))
 
-      const list = manager.listAccounts()
+      const list = manager.listUTAs()
       expect(list).toHaveLength(2)
       expect(list[0].id).toBe('a1')
       expect(list[1].id).toBe('a2')
@@ -87,7 +87,7 @@ describe('AccountManager', () => {
     })
 
     it('resolveOne throws on zero matches', () => {
-      expect(() => manager.resolveOne('nope')).toThrow('No account found')
+      expect(() => manager.resolveOne('nope')).toThrow('No UTA found')
     })
 
     it('resolveOne throws on multiple matches via resolve override', () => {

--- a/src/domain/trading/uta-manager.ts
+++ b/src/domain/trading/uta-manager.ts
@@ -1,8 +1,8 @@
 /**
- * AccountManager — UTA lifecycle management, registry, and aggregation.
+ * UTAManager — UTA lifecycle management, registry, and aggregation.
  *
- * Owns the full account lifecycle: create → register → reconnect → remove → close.
- * Also provides cross-account operations (aggregated equity, contract search).
+ * Owns the full UTA lifecycle: create → register → reconnect → remove → close.
+ * Also provides cross-UTA operations (aggregated equity, contract search).
  */
 
 import Decimal from 'decimal.js'
@@ -14,16 +14,16 @@ import { createBroker } from './brokers/factory.js'
 import { getBrokerPreset } from './brokers/preset-catalog.js'
 import { UnifiedTradingAccount } from './UnifiedTradingAccount.js'
 import { loadGitState, createGitPersister } from './git-persistence.js'
-import { readAccountsConfig, type AccountConfig } from '../../core/config.js'
+import { readUTAsConfig, type UTAConfig } from '../../core/config.js'
 import type { EventLog } from '../../core/event-log.js'
 import type { ToolCenter } from '../../core/tool-center.js'
 import type { ReconnectResult } from '../../core/types.js'
 import type { FxService } from './fx-service.js'
 import './contract-ext.js'
 
-// ==================== Account summary ====================
+// ==================== UTA summary ====================
 
-export interface AccountSummary {
+export interface UTASummary {
   id: string
   label: string
   capabilities: AccountCapabilities
@@ -57,14 +57,14 @@ export interface ContractSearchResult {
   results: ContractDescription[]
 }
 
-// ==================== AccountManager ====================
+// ==================== UTAManager ====================
 
 export interface SnapshotHooks {
-  onPostPush?: (accountId: string) => void | Promise<void>
-  onPostReject?: (accountId: string) => void | Promise<void>
+  onPostPush?: (utaId: string) => void | Promise<void>
+  onPostReject?: (utaId: string) => void | Promise<void>
 }
 
-export class AccountManager {
+export class UTAManager {
   private entries = new Map<string, UnifiedTradingAccount>()
   private reconnecting = new Set<string>()
 
@@ -89,16 +89,16 @@ export class AccountManager {
 
   // ==================== Lifecycle ====================
 
-  /** Create a UTA from account config, register it, and start async broker connection. */
-  async initAccount(accCfg: AccountConfig): Promise<UnifiedTradingAccount> {
-    const broker = createBroker(accCfg)
-    const savedState = await loadGitState(accCfg.id)
+  /** Create a UTA from config, register it, and start async broker connection. */
+  async initUTA(cfg: UTAConfig): Promise<UnifiedTradingAccount> {
+    const broker = createBroker(cfg)
+    const savedState = await loadGitState(cfg.id)
     const uta = new UnifiedTradingAccount(broker, {
-      guards: accCfg.guards,
+      guards: cfg.guards,
       savedState,
-      onCommit: createGitPersister(accCfg.id),
-      onHealthChange: (accountId, health) => {
-        this.eventLog?.append('account.health', { accountId, ...health })
+      onCommit: createGitPersister(cfg.id),
+      onHealthChange: (utaId, health) => {
+        this.eventLog?.append('account.health', { accountId: utaId, ...health })
       },
       onPostPush: this._snapshotHooks?.onPostPush,
       onPostReject: this._snapshotHooks?.onPostReject,
@@ -107,54 +107,54 @@ export class AccountManager {
     return uta
   }
 
-  /** Reconnect an account: close old → re-read config → create new → verify connection. */
-  async reconnectAccount(accountId: string): Promise<ReconnectResult> {
-    if (this.reconnecting.has(accountId)) {
+  /** Reconnect a UTA: close old → re-read config → create new → verify connection. */
+  async reconnectUTA(utaId: string): Promise<ReconnectResult> {
+    if (this.reconnecting.has(utaId)) {
       return { success: false, error: 'Reconnect already in progress' }
     }
-    this.reconnecting.add(accountId)
+    this.reconnecting.add(utaId)
     try {
       // Re-read config to pick up credential/guard changes
-      const freshAccounts = await readAccountsConfig()
+      const freshUTAs = await readUTAsConfig()
 
-      // Close old account
-      await this.removeAccount(accountId)
+      // Close old UTA
+      await this.removeUTA(utaId)
 
-      const accCfg = freshAccounts.find((a) => a.id === accountId)
-      if (!accCfg) {
-        return { success: true, message: `Account "${accountId}" not found in config (removed or disabled)` }
+      const cfg = freshUTAs.find((a) => a.id === utaId)
+      if (!cfg) {
+        return { success: true, message: `UTA "${utaId}" not found in config (removed or disabled)` }
       }
 
-      const uta = await this.initAccount(accCfg)
+      const uta = await this.initUTA(cfg)
 
       // Wait for broker.init() + broker.getAccount() to verify the connection
       await uta.waitForConnect()
 
-      // Re-register CCXT-specific tools if this account routes to the CCXT engine.
-      if (getBrokerPreset(accCfg.presetId).engine === 'ccxt') {
+      // Re-register CCXT-specific tools if this UTA routes to the CCXT engine.
+      if (getBrokerPreset(cfg.presetId).engine === 'ccxt') {
         this.toolCenter?.register(
           createCcxtProviderTools(this),
           'trading-ccxt',
         )
       }
 
-      const label = uta.label ?? accountId
+      const label = uta.label ?? utaId
       console.log(`reconnect: ${label} online`)
       return { success: true, message: `${label} reconnected` }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      console.error(`reconnect: ${accountId} failed:`, msg)
+      console.error(`reconnect: ${utaId} failed:`, msg)
       return { success: false, error: msg }
     } finally {
-      this.reconnecting.delete(accountId)
+      this.reconnecting.delete(utaId)
     }
   }
 
-  /** Close and deregister an account. No-op if account doesn't exist. */
-  async removeAccount(accountId: string): Promise<void> {
-    const uta = this.entries.get(accountId)
+  /** Close and deregister a UTA. No-op if UTA doesn't exist. */
+  async removeUTA(utaId: string): Promise<void> {
+    const uta = this.entries.get(utaId)
     if (!uta) return
-    this.entries.delete(accountId)
+    this.entries.delete(utaId)
     try { await uta.close() } catch { /* best effort */ }
   }
 
@@ -171,7 +171,7 @@ export class AccountManager {
 
   add(uta: UnifiedTradingAccount): void {
     if (this.entries.has(uta.id)) {
-      throw new Error(`Account "${uta.id}" already registered`)
+      throw new Error(`UTA "${uta.id}" already registered`)
     }
     this.entries.set(uta.id, uta)
   }
@@ -186,7 +186,7 @@ export class AccountManager {
     return this.entries.get(id)
   }
 
-  listAccounts(): AccountSummary[] {
+  listUTAs(): UTASummary[] {
     return Array.from(this.entries.values()).map((uta) => ({
       id: uta.id,
       label: uta.label,
@@ -217,11 +217,11 @@ export class AccountManager {
   resolveOne(source: string): UnifiedTradingAccount {
     const results = this.resolve(source)
     if (results.length === 0) {
-      throw new Error(`No account found matching source "${source}". Use listAccounts to see available accounts.`)
+      throw new Error(`No UTA found matching source "${source}". Use listUTAs to see available UTAs.`)
     }
     if (results.length > 1) {
       throw new Error(
-        `Multiple accounts match source "${source}": ${results.map((r) => r.id).join(', ')}. Use account id for exact match.`,
+        `Multiple UTAs match source "${source}": ${results.map((r) => r.id).join(', ')}. Use UTA id for exact match.`,
       )
     }
     return results[0]

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,14 @@
 import { readFile, writeFile, mkdir } from 'fs/promises'
 import { resolve, dirname } from 'path'
 // Engine removed — AgentCenter is the top-level AI entry point
-import { loadConfig, readAccountsConfig } from './core/config.js'
+import { loadConfig, readUTAsConfig } from './core/config.js'
 import type { Plugin, EngineContext, ReconnectResult } from './core/types.js'
 import { McpPlugin } from './server/mcp.js'
 import { TelegramPlugin } from './connectors/telegram/index.js'
 import { WebPlugin } from './connectors/web/index.js'
 import { McpAskPlugin } from './connectors/mcp-ask/index.js'
 import { createThinkingTools } from './tool/thinking.js'
-import { AccountManager, createSnapshotService, createSnapshotScheduler } from './domain/trading/index.js'
+import { UTAManager, createSnapshotService, createSnapshotScheduler } from './domain/trading/index.js'
 import { FxService } from './domain/trading/fx-service.js'
 import { createTradingTools } from './tool/trading.js'
 import { Brain } from './domain/brain/index.js'
@@ -95,25 +95,25 @@ async function main() {
 
   const listenerRegistry = createListenerRegistry(eventLog)
 
-  // ==================== Tool Center (created early — AccountManager needs it) ====================
+  // ==================== Tool Center (created early — UTAManager needs it) ====================
 
   const toolCenter = new ToolCenter()
 
   // ==================== Trading Account Manager ====================
 
-  const accountManager = new AccountManager({ eventLog, toolCenter })
+  const utaManager = new UTAManager({ eventLog, toolCenter })
 
-  const accountConfigs = await readAccountsConfig()
-  for (const accCfg of accountConfigs) {
+  const utaConfigs = await readUTAsConfig()
+  for (const accCfg of utaConfigs) {
     if (accCfg.enabled === false) continue
-    await accountManager.initAccount(accCfg)
+    await utaManager.initUTA(accCfg)
   }
-  accountManager.registerCcxtToolsIfNeeded()
+  utaManager.registerCcxtToolsIfNeeded()
 
   // ==================== Snapshot ====================
 
-  const snapshotService = createSnapshotService({ accountManager, eventLog })
-  accountManager.setSnapshotHooks({
+  const snapshotService = createSnapshotService({ utaManager, eventLog })
+  utaManager.setSnapshotHooks({
     onPostPush: (id) => { snapshotService.takeSnapshot(id, 'post-push') },
     onPostReject: (id) => { snapshotService.takeSnapshot(id, 'post-reject') },
   })
@@ -203,7 +203,7 @@ async function main() {
   // ==================== FX Service ====================
 
   const fxService = new FxService(currencyClient)
-  accountManager.setFxService(fxService)
+  utaManager.setFxService(fxService)
 
   // ==================== Equity Symbol Index ====================
 
@@ -221,7 +221,7 @@ async function main() {
 
   // One unified set of trading tools — routes via `source` parameter at runtime
   toolCenter.register(
-    createTradingTools(accountManager, fxService),
+    createTradingTools(utaManager, fxService),
     'trading',
   )
 
@@ -415,7 +415,7 @@ async function main() {
     fire: createEventBus(eventLog),
     bbEngine: getSDKExecutor(),
     marketSearch,
-    accountManager, fxService, snapshotService,
+    utaManager, fxService, snapshotService,
     newsProvider: newsStore,
     reconnectConnectors,
   }
@@ -434,7 +434,7 @@ async function main() {
   // brokers that don't cache (IBKR — server-side reqMatchingSymbols).
   const CATALOG_REFRESH_MS = 6 * 60 * 60 * 1000  // 6h
   const catalogRefreshTimer = setInterval(() => {
-    for (const uta of accountManager.resolve()) {
+    for (const uta of utaManager.resolve()) {
       uta.refreshCatalog().catch((err) => {
         console.warn(`[catalog-refresh] ${uta.id} failed:`, err instanceof Error ? err.message : err)
       })
@@ -464,7 +464,7 @@ async function main() {
     await newsStore.close()
     await toolCallLog.close()
     await eventLog.close()
-    await accountManager.closeAll()
+    await utaManager.closeAll()
     process.exit(0)
   }
   process.on('SIGINT', shutdown)

--- a/src/tool/trading.spec.ts
+++ b/src/tool/trading.spec.ts
@@ -3,7 +3,7 @@ import Decimal from 'decimal.js'
 import { ContractDescription, Order, OrderState, UNSET_DOUBLE, UNSET_DECIMAL } from '@traderalice/ibkr'
 import type { OpenOrder } from '../domain/trading/brokers/types.js'
 import { MockBroker, makeContract } from '../domain/trading/brokers/mock/index.js'
-import { AccountManager } from '../domain/trading/account-manager.js'
+import { UTAManager } from '../domain/trading/uta-manager.js'
 import { UnifiedTradingAccount } from '../domain/trading/UnifiedTradingAccount.js'
 import { createTradingTools } from './trading.js'
 import '../domain/trading/contract-ext.js'
@@ -12,16 +12,16 @@ function makeUta(broker: MockBroker): UnifiedTradingAccount {
   return new UnifiedTradingAccount(broker)
 }
 
-function makeManager(...brokers: MockBroker[]): AccountManager {
-  const mgr = new AccountManager()
+function makeManager(...brokers: MockBroker[]): UTAManager {
+  const mgr = new UTAManager()
   for (const b of brokers) mgr.add(makeUta(b))
   return mgr
 }
 
-// ==================== AccountManager.resolve ====================
+// ==================== UTAManager.resolve ====================
 
-describe('AccountManager.resolve', () => {
-  let mgr: AccountManager
+describe('UTAManager.resolve', () => {
+  let mgr: UTAManager
 
   beforeEach(() => {
     mgr = makeManager(
@@ -49,8 +49,8 @@ describe('AccountManager.resolve', () => {
 
 // ==================== resolveOne ====================
 
-describe('AccountManager.resolveOne', () => {
-  let mgr: AccountManager
+describe('UTAManager.resolveOne', () => {
+  let mgr: UTAManager
 
   beforeEach(() => {
     mgr = makeManager(
@@ -65,17 +65,17 @@ describe('AccountManager.resolveOne', () => {
   })
 
   it('throws when no UTA matches', () => {
-    expect(() => mgr.resolveOne('unknown-id')).toThrow('No account found matching source "unknown-id"')
+    expect(() => mgr.resolveOne('unknown-id')).toThrow('No UTA found matching source "unknown-id"')
   })
 })
 
-// ==================== createTradingTools: listAccounts ====================
+// ==================== createTradingTools: listUTAs ====================
 
-describe('createTradingTools — listAccounts', () => {
+describe('createTradingTools — listUTAs', () => {
   it('returns summaries for all registered UTAs', async () => {
     const mgr = makeManager(new MockBroker({ id: 'acc1', label: 'Test' }))
     const tools = createTradingTools(mgr)
-    const result = await (tools.listAccounts.execute as Function)({})
+    const result = await (tools.listUTAs.execute as Function)({})
     expect(Array.isArray(result)).toBe(true)
     expect(result[0].id).toBe('acc1')
   })

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -10,7 +10,7 @@ import { tool, type Tool } from 'ai'
 import { z } from 'zod'
 import Decimal from 'decimal.js'
 import { Contract, UNSET_DECIMAL } from '@traderalice/ibkr'
-import type { AccountManager } from '@/domain/trading/account-manager.js'
+import type { UTAManager } from '@/domain/trading/uta-manager.js'
 import { BrokerError, type OpenOrder } from '@/domain/trading/brokers/types.js'
 import type { FxService } from '@/domain/trading/fx-service.js'
 import { normalizeBrokerSearchPattern } from '@/domain/trading/contract-search-rules.js'
@@ -80,12 +80,12 @@ const positiveNumeric = z
     { message: 'must be a positive number or positive numeric string' },
   )
 
-export function createTradingTools(manager: AccountManager, fxService?: FxService): Record<string, Tool> {
+export function createTradingTools(manager: UTAManager, fxService?: FxService): Record<string, Tool> {
   return {
-    listAccounts: tool({
+    listUTAs: tool({
       description: 'List all registered trading accounts with their id, provider, label, and capabilities.',
       inputSchema: z.object({}),
-      execute: () => manager.listAccounts(),
+      execute: () => manager.listUTAs(),
     }),
 
     searchContracts: tool({

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,6 +14,7 @@ import { MarketDetailPage } from './pages/MarketDetailPage'
 import { NewsPage } from './pages/NewsPage'
 import { NewsCollectorPage } from './pages/NewsCollectorPage'
 import { TradingPage } from './pages/TradingPage'
+import { UTADetailPage } from './pages/UTADetailPage'
 import { ConnectorsPage } from './pages/ConnectorsPage'
 import { DevPage } from './pages/DevPage'
 
@@ -87,6 +88,7 @@ export function App() {
             <Route path="/connectors" element={<ConnectorsPage />} />
             <Route path="/tools" element={<Navigate to="/settings" replace />} />
             <Route path="/trading" element={<TradingPage />} />
+            <Route path="/uta/:id" element={<UTADetailPage />} />
             <Route path="/ai-provider" element={<AIProviderPage />} />
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/dev" element={<DevPage />} />

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -1,5 +1,12 @@
 import { fetchJson } from './client'
-import type { TradingAccount, UTASummary, AccountInfo, Position, WalletCommitLog, ReconnectResult, UTAConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, UTASnapshotSummary, EquityCurvePoint } from './types'
+import type { TradingAccount, UTASummary, AccountInfo, Position, WalletCommitLog, ReconnectResult, UTAConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, UTASnapshotSummary, EquityCurvePoint, PlaceOrderRequest, ClosePositionRequest, CancelOrderRequest, OrderErrorResponse } from './types'
+
+/** Thrown by the one-shot order endpoints when the server returns non-2xx. Carries the phase. */
+export class OrderEntryError extends Error {
+  constructor(public readonly status: number, public readonly response: OrderErrorResponse) {
+    super(response.error)
+  }
+}
 
 /** One contract returned by the broker-side fuzzy search. Shape mirrors what
  *  the AI tool emits — same canonical aliceId for downstream order routing. */
@@ -112,6 +119,24 @@ export const tradingApi = {
     return res.json()
   },
 
+  // ==================== One-shot order entry (manual frontend surface) ====================
+  //
+  // Each call combines stage → commit → push on the backend. Returns
+  // the full WalletPushResult; on failure throws OrderEntryError with
+  // a `phase` indicating which step blew up.
+
+  async placeOrder(utaId: string, body: PlaceOrderRequest): Promise<WalletPushResult> {
+    return postOrder(`/api/trading/uta/${utaId}/wallet/place-order`, body)
+  },
+
+  async closePosition(utaId: string, body: ClosePositionRequest): Promise<WalletPushResult> {
+    return postOrder(`/api/trading/uta/${utaId}/wallet/close-position`, body)
+  },
+
+  async cancelOrder(utaId: string, body: CancelOrderRequest): Promise<WalletPushResult> {
+    return postOrder(`/api/trading/uta/${utaId}/wallet/cancel-order`, body)
+  },
+
   // ==================== Broker Presets ====================
 
   async getBrokerPresets(): Promise<{ presets: BrokerPreset[] }> {
@@ -194,4 +219,19 @@ export const tradingApi = {
     })
     return res.json()
   },
+}
+
+// ==================== Internal helpers ====================
+
+async function postOrder(url: string, body: unknown): Promise<WalletPushResult> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const json = (await res.json().catch(() => ({}))) as OrderErrorResponse
+    throw new OrderEntryError(res.status, { error: json.error ?? `Request failed (${res.status})`, phase: json.phase })
+  }
+  return res.json()
 }

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -1,5 +1,5 @@
 import { fetchJson } from './client'
-import type { TradingAccount, AccountSummary, AccountInfo, Position, WalletCommitLog, ReconnectResult, AccountConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, UTASnapshotSummary, EquityCurvePoint } from './types'
+import type { TradingAccount, UTASummary, AccountInfo, Position, WalletCommitLog, ReconnectResult, UTAConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, UTASnapshotSummary, EquityCurvePoint } from './types'
 
 /** One contract returned by the broker-side fuzzy search. Shape mirrors what
  *  the AI tool emits — same canonical aliceId for downstream order routing. */
@@ -22,21 +22,21 @@ export interface ContractSearchHit {
 export interface ContractSearchResponse {
   results: ContractSearchHit[]
   count: number
-  /** 0 when no UTAs are configured; lets the UI nudge towards /trading/config. */
-  accountsConfigured?: number
+  /** 0 when no UTAs are configured; lets the UI nudge towards /trading. */
+  utasConfigured?: number
 }
 
 // ==================== Unified Trading API ====================
 
 export const tradingApi = {
-  // ==================== Accounts ====================
+  // ==================== UTAs (listing + per-UTA reads) ====================
 
-  async listAccounts(): Promise<{ accounts: TradingAccount[] }> {
-    return fetchJson('/api/trading/accounts')
+  async listUTAs(): Promise<{ utas: TradingAccount[] }> {
+    return fetchJson('/api/trading/uta')
   },
 
-  async listAccountSummaries(): Promise<{ accounts: AccountSummary[] }> {
-    return fetchJson('/api/trading/accounts')
+  async listUTASummaries(): Promise<{ utas: UTASummary[] }> {
+    return fetchJson('/api/trading/uta')
   },
 
   async equity(): Promise<{ totalEquity: string; totalCash: string; totalUnrealizedPnL: string; totalRealizedPnL: string; accounts: Array<{ id: string; label: string; equity: string; cash: string }> }> {
@@ -49,47 +49,49 @@ export const tradingApi = {
     return fetchJson('/api/trading/fx-rates')
   },
 
-  // ==================== Per-account ====================
+  // ==================== Per-UTA ====================
 
-  async reconnectAccount(accountId: string): Promise<ReconnectResult> {
-    const res = await fetch(`/api/trading/accounts/${accountId}/reconnect`, { method: 'POST' })
+  async reconnectUTA(utaId: string): Promise<ReconnectResult> {
+    const res = await fetch(`/api/trading/uta/${utaId}/reconnect`, { method: 'POST' })
     return res.json()
   },
 
-  async accountInfo(accountId: string): Promise<AccountInfo> {
-    return fetchJson(`/api/trading/accounts/${accountId}/account`)
+  /** Broker-side account info (cash, equity, margin) for a given UTA.
+   *  Note `account` here is the *broker* account, distinct from the UTA. */
+  async utaAccount(utaId: string): Promise<AccountInfo> {
+    return fetchJson(`/api/trading/uta/${utaId}/account`)
   },
 
-  async positions(accountId: string): Promise<{ positions: Position[] }> {
-    return fetchJson(`/api/trading/accounts/${accountId}/positions`)
+  async utaPositions(utaId: string): Promise<{ positions: Position[] }> {
+    return fetchJson(`/api/trading/uta/${utaId}/positions`)
   },
 
-  async orders(accountId: string): Promise<{ orders: unknown[] }> {
-    return fetchJson(`/api/trading/accounts/${accountId}/orders`)
+  async utaOrders(utaId: string): Promise<{ orders: unknown[] }> {
+    return fetchJson(`/api/trading/uta/${utaId}/orders`)
   },
 
-  async marketClock(accountId: string): Promise<{ isOpen: boolean; nextOpen: string; nextClose: string }> {
-    return fetchJson(`/api/trading/accounts/${accountId}/market-clock`)
+  async marketClock(utaId: string): Promise<{ isOpen: boolean; nextOpen: string; nextClose: string }> {
+    return fetchJson(`/api/trading/uta/${utaId}/market-clock`)
   },
 
-  async walletLog(accountId: string, limit = 20, symbol?: string): Promise<{ commits: WalletCommitLog[] }> {
+  async walletLog(utaId: string, limit = 20, symbol?: string): Promise<{ commits: WalletCommitLog[] }> {
     const params = new URLSearchParams({ limit: String(limit) })
     if (symbol) params.set('symbol', symbol)
-    return fetchJson(`/api/trading/accounts/${accountId}/wallet/log?${params}`)
+    return fetchJson(`/api/trading/uta/${utaId}/wallet/log?${params}`)
   },
 
-  async walletShow(accountId: string, hash: string): Promise<unknown> {
-    return fetchJson(`/api/trading/accounts/${accountId}/wallet/show/${hash}`)
+  async walletShow(utaId: string, hash: string): Promise<unknown> {
+    return fetchJson(`/api/trading/uta/${utaId}/wallet/show/${hash}`)
   },
 
   // ==================== Wallet operations ====================
 
-  async walletStatus(accountId: string): Promise<WalletStatus> {
-    return fetchJson(`/api/trading/accounts/${accountId}/wallet/status`)
+  async walletStatus(utaId: string): Promise<WalletStatus> {
+    return fetchJson(`/api/trading/uta/${utaId}/wallet/status`)
   },
 
-  async walletReject(accountId: string, reason?: string): Promise<WalletRejectResult> {
-    const res = await fetch(`/api/trading/accounts/${accountId}/wallet/reject`, {
+  async walletReject(utaId: string, reason?: string): Promise<WalletRejectResult> {
+    const res = await fetch(`/api/trading/uta/${utaId}/wallet/reject`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(reason ? { reason } : {}),
@@ -101,8 +103,8 @@ export const tradingApi = {
     return res.json()
   },
 
-  async walletPush(accountId: string): Promise<WalletPushResult> {
-    const res = await fetch(`/api/trading/accounts/${accountId}/wallet/push`, { method: 'POST' })
+  async walletPush(utaId: string): Promise<WalletPushResult> {
+    const res = await fetch(`/api/trading/uta/${utaId}/wallet/push`, { method: 'POST' })
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
       throw new Error(body.error || `Push failed (${res.status})`)
@@ -118,43 +120,43 @@ export const tradingApi = {
 
   // ==================== Trading Config CRUD ====================
 
-  async loadTradingConfig(): Promise<{ accounts: AccountConfig[] }> {
+  async loadTradingConfig(): Promise<{ utas: UTAConfig[] }> {
     return fetchJson('/api/trading/config')
   },
 
-  async upsertAccount(account: AccountConfig): Promise<AccountConfig> {
-    const res = await fetch(`/api/trading/config/accounts/${account.id}`, {
+  async upsertUTA(uta: UTAConfig): Promise<UTAConfig> {
+    const res = await fetch(`/api/trading/config/uta/${uta.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(account),
+      body: JSON.stringify(uta),
     })
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
-      throw new Error(body.error || `Failed to save account (${res.status})`)
+      throw new Error(body.error || `Failed to save UTA (${res.status})`)
     }
     return res.json()
   },
 
-  async deleteAccount(id: string): Promise<void> {
-    const res = await fetch(`/api/trading/config/accounts/${id}`, { method: 'DELETE' })
+  async deleteUTA(id: string): Promise<void> {
+    const res = await fetch(`/api/trading/config/uta/${id}`, { method: 'DELETE' })
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
-      throw new Error(body.error || `Failed to delete account (${res.status})`)
+      throw new Error(body.error || `Failed to delete UTA (${res.status})`)
     }
   },
 
   // ==================== Snapshots ====================
 
-  async snapshots(accountId: string, opts?: { limit?: number; startTime?: string; endTime?: string }): Promise<{ snapshots: UTASnapshotSummary[] }> {
+  async snapshots(utaId: string, opts?: { limit?: number; startTime?: string; endTime?: string }): Promise<{ snapshots: UTASnapshotSummary[] }> {
     const params = new URLSearchParams()
     if (opts?.limit) params.set('limit', String(opts.limit))
     if (opts?.startTime) params.set('startTime', opts.startTime)
     if (opts?.endTime) params.set('endTime', opts.endTime)
-    return fetchJson(`/api/trading/accounts/${accountId}/snapshots?${params}`)
+    return fetchJson(`/api/trading/uta/${utaId}/snapshots?${params}`)
   },
 
-  async deleteSnapshot(accountId: string, timestamp: string): Promise<{ success: boolean }> {
-    const res = await fetch(`/api/trading/accounts/${accountId}/snapshots/${encodeURIComponent(timestamp)}`, { method: 'DELETE' })
+  async deleteSnapshot(utaId: string, timestamp: string): Promise<{ success: boolean }> {
+    const res = await fetch(`/api/trading/uta/${utaId}/snapshots/${encodeURIComponent(timestamp)}`, { method: 'DELETE' })
     return res.json()
   },
 
@@ -169,13 +171,9 @@ export const tradingApi = {
   // ==================== Contract search ====================
 
   /**
-   * Heuristic broker-side search across all configured accounts. Used by the
+   * Heuristic broker-side search across all configured UTAs. Used by the
    * Market workbench to surface tradeable contracts matching a data-vendor
    * symbol — the bridge is intentionally fuzzy / display-only.
-   *
-   * `assetClass` lets the backend pick the right normalization rule (e.g.
-   * crypto/currency strip the quote-currency suffix). See
-   * `src/domain/trading/contract-search-rules.md` for the rule set.
    */
   async searchContracts(
     pattern: string,
@@ -188,11 +186,11 @@ export const tradingApi = {
 
   // ==================== Connection Testing ====================
 
-  async testConnection(account: AccountConfig): Promise<TestConnectionResult> {
+  async testConnection(uta: UTAConfig): Promise<TestConnectionResult> {
     const res = await fetch('/api/trading/config/test-connection', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(account),
+      body: JSON.stringify(uta),
     })
     return res.json()
   },

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -406,6 +406,52 @@ export interface TestConnectionResult {
   positions?: Position[]
 }
 
+// ==================== Order entry (frontend manual surface) ====================
+//
+// Numeric fields are strings on the wire — the backend uses
+// new Decimal(String(x)) to preserve precision; mirroring the type
+// here keeps frontend → backend aligned and avoids float roundtrip.
+
+export interface PlaceOrderRequest {
+  aliceId: string
+  symbol?: string
+  action: 'BUY' | 'SELL'
+  orderType: string
+  totalQuantity?: string
+  cashQty?: string
+  lmtPrice?: string
+  auxPrice?: string
+  trailStopPrice?: string
+  trailingPercent?: string
+  tif?: string
+  goodTillDate?: string
+  outsideRth?: boolean
+  parentId?: string
+  ocaGroup?: string
+  takeProfit?: { price: string }
+  stopLoss?: { price: string; limitPrice?: string }
+  message: string
+}
+
+export interface ClosePositionRequest {
+  aliceId: string
+  symbol?: string
+  qty?: string
+  message: string
+}
+
+export interface CancelOrderRequest {
+  orderId: string
+  message: string
+}
+
+/** Error response shape from one-shot order endpoints (when status !== 200). */
+export interface OrderErrorResponse {
+  error: string
+  /** Which step blew up — useful for surfacing where the failure happened. */
+  phase?: 'validate' | 'stage' | 'commit' | 'push'
+}
+
 // ==================== Snapshots ====================
 
 export interface UTASnapshotSummary {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -237,7 +237,7 @@ export interface BrokerHealthInfo {
   disabled: boolean
 }
 
-export interface AccountSummary {
+export interface UTASummary {
   id: string
   label: string
   capabilities: { supportedSecTypes: string[]; supportedOrderTypes: string[] }
@@ -348,7 +348,12 @@ export interface ToolCallRecord {
 
 // ==================== Trading Config ====================
 
-export interface AccountConfig {
+/**
+ * One Unified Trading Account configuration record. The user-facing
+ * concept that wraps a broker connection — distinct from `AccountInfo`,
+ * which is broker-side (cash, equity, margin returned by the broker).
+ */
+export interface UTAConfig {
   id: string
   label?: string
   /** Broker preset id — resolves to engine + form schema on the backend. */

--- a/ui/src/components/PushApprovalPanel.tsx
+++ b/ui/src/components/PushApprovalPanel.tsx
@@ -117,7 +117,7 @@ export function PushApprovalPanel() {
 
   const poll = useCallback(async () => {
     try {
-      const { accounts: accts } = await api.trading.listAccounts()
+      const { utas: accts } = await api.trading.listUTAs()
       setAccounts(accts)
 
       const stagedResults: StagedAccount[] = []

--- a/ui/src/components/ReconnectButton.tsx
+++ b/ui/src/components/ReconnectButton.tsx
@@ -12,7 +12,7 @@ export function ReconnectButton({ accountId }: { accountId: string }) {
     setStatus('loading')
     setMessage('')
     try {
-      const result = await api.trading.reconnectAccount(accountId)
+      const result = await api.trading.reconnectUTA(accountId)
       if (result.success) {
         setStatus('success')
         setMessage(result.message || 'Connected')

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -133,6 +133,12 @@ function byInstrumentFamiliarity(a: ContractSearchHit, b: ContractSearchHit): nu
 function ContractRow({ hit }: { hit: ContractSearchHit }) {
   const c = hit.contract
   const aliceId = c.aliceId as string | undefined
+  // Bridge to the UTA detail page's order entry — clicking jumps the
+  // user from "I see this contract on this UTA" to "place an order
+  // against it" with the alice id pre-filled.
+  const orderHref = aliceId
+    ? `/uta/${encodeURIComponent(hit.source)}?aliceId=${encodeURIComponent(aliceId)}`
+    : null
   return (
     <li className="px-3 py-2 flex items-baseline gap-3 text-[12px] hover:bg-bg-tertiary/40 transition-colors">
       <span className="font-mono font-semibold text-text">{c.symbol ?? '—'}</span>
@@ -154,6 +160,15 @@ function ContractRow({ hit }: { hit: ContractSearchHit }) {
         >
           {aliceId}
         </code>
+      )}
+      {orderHref && (
+        <Link
+          to={orderHref}
+          className="text-[11px] text-accent hover:underline shrink-0"
+          title="Open order entry on the UTA"
+        >
+          Order →
+        </Link>
       )}
     </li>
   )

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -23,7 +23,7 @@ const COLLAPSED_LIMIT = 3
 
 export function TradeableContractsPanel({ symbol, assetClass }: Props) {
   const [hits, setHits] = useState<ContractSearchHit[] | null>(null)
-  const [accountsConfigured, setAccountsConfigured] = useState<number | null>(null)
+  const [utasConfigured, setAccountsConfigured] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)
@@ -37,7 +37,7 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
       .then((res) => {
         if (cancelled) return
         setHits(res.results)
-        setAccountsConfigured(res.accountsConfigured ?? null)
+        setAccountsConfigured(res.utasConfigured ?? null)
       })
       .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)) })
       .finally(() => { if (!cancelled) setLoading(false) })
@@ -55,7 +55,7 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
       {loading && <div className="text-[12px] text-text-muted">Searching brokers…</div>}
       {error && !loading && <div className="text-[12px] text-red-400">{error}</div>}
 
-      {!loading && !error && accountsConfigured === 0 && (
+      {!loading && !error && utasConfigured === 0 && (
         <div className="text-[12px] text-text-muted">
           No trading accounts configured.{' '}
           <Link to="/trading" className="text-accent hover:underline">
@@ -65,7 +65,7 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
         </div>
       )}
 
-      {!loading && !error && accountsConfigured !== 0 && hits && hits.length === 0 && (
+      {!loading && !error && utasConfigured !== 0 && hits && hits.length === 0 && (
         <div className="text-[12px] text-text-muted">
           No tradeable contracts matching <span className="font-mono">{symbol}</span> on your configured brokers.
         </div>

--- a/ui/src/components/uta/Dialog.tsx
+++ b/ui/src/components/uta/Dialog.tsx
@@ -1,0 +1,26 @@
+import { useCallback, useEffect } from 'react'
+
+/** Generic modal dialog used by the UTA wizard + edit flows. */
+export function Dialog({ onClose, width, children }: {
+  onClose: () => void
+  width?: string
+  children: React.ReactNode
+}) {
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') onClose()
+  }, [onClose])
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className={`relative ${width || 'w-[560px]'} max-w-[95vw] max-h-[85vh] bg-bg rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden`}>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/uta/EditUTADialog.tsx
+++ b/ui/src/components/uta/EditUTADialog.tsx
@@ -1,0 +1,183 @@
+import { useState, useEffect, useMemo } from 'react'
+import { Section } from '../form'
+import { Toggle } from '../Toggle'
+import { GuardsSection, CRYPTO_GUARD_TYPES, SECURITIES_GUARD_TYPES } from '../guards'
+import { ReconnectButton } from '../ReconnectButton'
+import { useSchemaForm } from '../../hooks/useSchemaForm'
+import type { UTAConfig, BrokerPreset, BrokerHealthInfo } from '../../api/types'
+import { Dialog } from './Dialog'
+import { HealthBadge } from './HealthBadge'
+import { SchemaFormFields } from './SchemaFormFields'
+
+/**
+ * UTA configuration dialog — edits credentials, guards, enabled state.
+ * Mounted from both the trading page (legacy entry) and the UTA detail
+ * page (new entry, accessed via the Edit button in the page header).
+ */
+export function EditUTADialog({ uta, preset, health, onSave, onDelete, onClose }: {
+  uta: UTAConfig
+  preset?: BrokerPreset
+  health?: BrokerHealthInfo
+  onSave: (a: UTAConfig) => Promise<void>
+  onDelete: () => Promise<void>
+  onClose: () => void
+}) {
+  const [draft, setDraft] = useState(uta)
+  const [saving, setSaving] = useState(false)
+  const [msg, setMsg] = useState('')
+  const [guardsOpen, setGuardsOpen] = useState(false)
+  const [showKeys, setShowKeys] = useState(false)
+
+  const initialValues = useMemo(() => {
+    const out: Record<string, string> = {}
+    for (const [k, v] of Object.entries(uta.presetConfig)) {
+      if (v != null) out[k] = String(v)
+    }
+    return out
+  }, [uta])
+  const { fields, formData, setField, getSubmitData } = useSchemaForm(preset?.schema, initialValues)
+  const hasSensitive = fields.some(f => f.type === 'password')
+
+  useEffect(() => {
+    const submitData = getSubmitData()
+    setDraft(d => ({ ...d, presetConfig: submitData }))
+  }, [formData, getSubmitData])
+
+  useEffect(() => { setDraft(uta) }, [uta])
+
+  const dirty = JSON.stringify(draft) !== JSON.stringify(uta)
+
+  const patchGuards = (guards: UTAConfig['guards']) => {
+    setDraft(d => ({ ...d, guards }))
+  }
+
+  const handleSave = async () => {
+    setSaving(true); setMsg('')
+    try {
+      await onSave(draft)
+      setMsg('Saved')
+      setTimeout(() => setMsg(''), 2000)
+    } catch (err) {
+      setMsg(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const guardTypes = (preset?.guardCategory === 'crypto') ? CRYPTO_GUARD_TYPES : SECURITIES_GUARD_TYPES
+
+  return (
+    <Dialog onClose={onClose} width="w-[560px]">
+      {/* Header */}
+      <div className="shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
+        <div className="flex items-center gap-3 min-w-0">
+          <h3 className="text-[14px] font-semibold text-text truncate">{uta.id}</h3>
+          <HealthBadge health={health} size="md" />
+        </div>
+        <button onClick={onClose} className="text-text-muted hover:text-text p-1 transition-colors shrink-0">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-6 py-6 space-y-5">
+        <Section title="Configuration">
+          <div className="mb-3">
+            <span className="text-[12px] text-text-muted">Type</span>
+            <span className="ml-2 text-[12px] font-medium text-text">{preset?.label ?? uta.presetId}</span>
+          </div>
+          <SchemaFormFields
+            fields={fields}
+            formData={formData}
+            setField={setField}
+            showSecrets={showKeys}
+          />
+          {hasSensitive && (
+            <button
+              onClick={() => setShowKeys(!showKeys)}
+              className="text-[11px] text-text-muted hover:text-text transition-colors mt-2"
+            >
+              {showKeys ? 'Hide secrets' : 'Show secrets'}
+            </button>
+          )}
+        </Section>
+
+        {/* Guards */}
+        <div>
+          <button
+            onClick={() => setGuardsOpen(!guardsOpen)}
+            className="flex items-center gap-1.5 text-[13px] font-semibold text-text-muted uppercase tracking-wide"
+          >
+            <svg
+              width="12" height="12" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              className={`transition-transform duration-150 ${guardsOpen ? 'rotate-90' : ''}`}
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+            Guards ({draft.guards.length})
+          </button>
+          {guardsOpen && (
+            <div className="mt-3">
+              <GuardsSection
+                guards={draft.guards}
+                guardTypes={guardTypes}
+                description="Guards validate operations before execution. Order matters."
+                onChange={patchGuards}
+                onChangeImmediate={patchGuards}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 flex items-center px-6 py-4 border-t border-border">
+        <div className="flex items-center gap-3">
+          {dirty && (
+            <button onClick={handleSave} disabled={saving} className="btn-primary">
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          )}
+          {draft.enabled !== false && <ReconnectButton accountId={uta.id} />}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Toggle checked={draft.enabled !== false} onChange={async (v) => {
+              const updated = { ...draft, enabled: v }
+              setDraft(updated)
+              await onSave(updated)
+            }} />
+            <span className="text-[12px] text-text-muted">{draft.enabled !== false ? 'Enabled' : 'Disabled'}</span>
+          </label>
+          {msg && <span className="text-[12px] text-text-muted">{msg}</span>}
+        </div>
+        <div className="flex-1" />
+        <DeleteButton label="Delete UTA" onConfirm={onDelete} />
+      </div>
+    </Dialog>
+  )
+}
+
+function DeleteButton({ label, onConfirm }: { label: string; onConfirm: () => void }) {
+  const [confirming, setConfirming] = useState(false)
+
+  if (confirming) {
+    return (
+      <div className="flex items-center gap-2">
+        <button onClick={() => { onConfirm(); setConfirming(false) }} className="btn-danger">
+          Confirm
+        </button>
+        <button onClick={() => setConfirming(false)} className="btn-secondary">
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <button onClick={() => setConfirming(true)} className="btn-danger">
+      {label}
+    </button>
+  )
+}

--- a/ui/src/components/uta/HealthBadge.tsx
+++ b/ui/src/components/uta/HealthBadge.tsx
@@ -1,0 +1,42 @@
+import type { BrokerHealthInfo } from '../../api/types'
+
+/** Connection-status pill for a UTA. Two sizes: 'sm' (cards) / 'md' (dialog headers). */
+export function HealthBadge({ health, size = 'sm' }: { health?: BrokerHealthInfo; size?: 'sm' | 'md' }) {
+  const textSize = size === 'md' ? 'text-[12px]' : 'text-[11px]'
+  const dotSize = size === 'md' ? 'w-2 h-2' : 'w-1.5 h-1.5'
+
+  if (!health) return <span className="text-text-muted/40">—</span>
+
+  if (health.disabled) {
+    return (
+      <span className={`inline-flex items-center gap-1.5 ${textSize} text-text-muted`} title={health.lastError}>
+        <span className={`${dotSize} rounded-full bg-text-muted/40 shrink-0`} />
+        Disabled
+      </span>
+    )
+  }
+
+  switch (health.status) {
+    case 'healthy':
+      return (
+        <span className={`inline-flex items-center gap-1.5 ${textSize} text-green`}>
+          <span className={`${dotSize} rounded-full bg-green shrink-0`} />
+          Connected
+        </span>
+      )
+    case 'degraded':
+      return (
+        <span className={`inline-flex items-center gap-1.5 ${textSize} text-yellow-400`}>
+          <span className={`${dotSize} rounded-full bg-yellow-400 shrink-0`} />
+          Unstable
+        </span>
+      )
+    case 'offline':
+      return (
+        <span className={`inline-flex items-center gap-1.5 ${textSize} text-red`} title={health.lastError}>
+          <span className={`${dotSize} rounded-full bg-red shrink-0 animate-pulse`} />
+          {health.recovering ? 'Reconnecting...' : 'Offline'}
+        </span>
+      )
+  }
+}

--- a/ui/src/components/uta/OrderEntryDialog.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.tsx
@@ -1,0 +1,440 @@
+import { useState } from 'react'
+import { Field, inputClass } from '../form'
+import { Dialog } from './Dialog'
+import { tradingApi, OrderEntryError } from '../../api/trading'
+import type { WalletPushResult, PlaceOrderRequest, ClosePositionRequest } from '../../api/types'
+
+// ==================== Modes ====================
+
+export type OrderEntryMode =
+  | { kind: 'place'; aliceId?: string }
+  | { kind: 'close'; aliceId: string; quantity: string; symbol?: string }
+
+interface Props {
+  utaId: string
+  mode: OrderEntryMode
+  onClose: () => void
+  /** Called once after a *successful* push so the parent can refresh positions/orders without waiting for the polling tick. */
+  onPushComplete?: (result: WalletPushResult) => void
+}
+
+// ==================== Component ====================
+
+/**
+ * Manual order entry — single dialog driving the one-shot
+ * stage→commit→push backend endpoints. Displays the full
+ * `WalletPushResult` after submit so the user can see per-op
+ * submitted/rejected outcomes (and in particular, watch the async
+ * "Submitted → Filled" transition in real-time).
+ *
+ * Two modes share the form-then-result flow:
+ *   - `place`: full order entry form (aliceId, side, type, qty, limit)
+ *   - `close`: tiny confirm form with overridable qty for an existing
+ *     position
+ */
+export function OrderEntryDialog({ utaId, mode, onClose, onPushComplete }: Props) {
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<{ message: string; phase?: string } | null>(null)
+  const [result, setResult] = useState<WalletPushResult | null>(null)
+
+  // Whether the result panel has shown — once it has, parent should
+  // refresh on close. We notify via onPushComplete after a successful
+  // push so parent can refresh immediately AND on close.
+  const handleClose = () => {
+    if (result && onPushComplete) onPushComplete(result)
+    onClose()
+  }
+
+  return (
+    <Dialog onClose={handleClose} width="w-[560px]">
+      <Header mode={mode} onClose={handleClose} />
+
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        {result
+          ? <PushResultPanel result={result} />
+          : mode.kind === 'place'
+            ? <PlaceForm utaId={utaId} initialAliceId={mode.aliceId} submitting={submitting} error={error} setError={setError} setSubmitting={setSubmitting} setResult={setResult} onPushComplete={onPushComplete} />
+            : <CloseForm utaId={utaId} aliceId={mode.aliceId} initialQty={mode.quantity} symbol={mode.symbol} submitting={submitting} error={error} setError={setError} setSubmitting={setSubmitting} setResult={setResult} onPushComplete={onPushComplete} />
+        }
+      </div>
+
+      <div className="shrink-0 flex items-center justify-end px-6 py-4 border-t border-border">
+        <button onClick={handleClose} className="btn-secondary">
+          {result ? 'Done' : 'Cancel'}
+        </button>
+      </div>
+    </Dialog>
+  )
+}
+
+// ==================== Header ====================
+
+function Header({ mode, onClose }: { mode: OrderEntryMode; onClose: () => void }) {
+  const title = mode.kind === 'place' ? 'Place Order' : 'Close Position'
+  return (
+    <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
+      <h3 className="text-[14px] font-semibold text-text">{title}</h3>
+      <button onClick={onClose} className="text-text-muted hover:text-text p-1 transition-colors">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
+// ==================== Place form ====================
+
+interface SharedFormProps {
+  utaId: string
+  submitting: boolean
+  error: { message: string; phase?: string } | null
+  setError: (e: { message: string; phase?: string } | null) => void
+  setSubmitting: (b: boolean) => void
+  setResult: (r: WalletPushResult) => void
+  onPushComplete?: (result: WalletPushResult) => void
+}
+
+function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?: string }) {
+  const [aliceId, setAliceId] = useState(initialAliceId ?? '')
+  const [action, setAction] = useState<'BUY' | 'SELL'>('BUY')
+  const [orderType, setOrderType] = useState<'MKT' | 'LMT'>('MKT')
+  const [quantity, setQuantity] = useState('')
+  const [cashQty, setCashQty] = useState('')
+  const [lmtPrice, setLmtPrice] = useState('')
+  const [tif, setTif] = useState('DAY')
+  const [message, setMessage] = useState('')
+  const [showAdvanced, setShowAdvanced] = useState(false)
+
+  const canSubmit =
+    !!aliceId.trim() &&
+    !!message.trim() &&
+    (!!quantity.trim() || !!cashQty.trim()) &&
+    (orderType !== 'LMT' || !!lmtPrice.trim()) &&
+    !p.submitting
+
+  const handleSubmit = async () => {
+    p.setError(null)
+    p.setSubmitting(true)
+    try {
+      const body: PlaceOrderRequest = {
+        aliceId: aliceId.trim(),
+        action,
+        orderType,
+        tif,
+        message: message.trim(),
+        ...(quantity.trim() && { totalQuantity: quantity.trim() }),
+        ...(cashQty.trim() && { cashQty: cashQty.trim() }),
+        ...(orderType === 'LMT' && lmtPrice.trim() && { lmtPrice: lmtPrice.trim() }),
+      }
+      const result = await tradingApi.placeOrder(p.utaId, body)
+      p.setResult(result)
+      p.onPushComplete?.(result)
+    } catch (err) {
+      if (err instanceof OrderEntryError) {
+        p.setError({ message: err.response.error, phase: err.response.phase })
+      } else {
+        p.setError({ message: err instanceof Error ? err.message : String(err) })
+      }
+    } finally {
+      p.setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Field label="aliceId">
+        <input
+          className={`${inputClass} font-mono text-[12px]`}
+          value={aliceId}
+          onChange={(e) => setAliceId(e.target.value)}
+          placeholder="okx-test|BTC/USDT"
+        />
+      </Field>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Action">
+          <Segmented value={action} options={[{ id: 'BUY' }, { id: 'SELL' }]} onChange={(v) => setAction(v as 'BUY' | 'SELL')} />
+        </Field>
+        <Field label="Order Type">
+          <Segmented value={orderType} options={[{ id: 'MKT', label: 'Market' }, { id: 'LMT', label: 'Limit' }]} onChange={(v) => setOrderType(v as 'MKT' | 'LMT')} />
+        </Field>
+      </div>
+
+      <Field label={`Quantity${cashQty ? ' (or use Cash Qty below)' : ''}`}>
+        <input
+          className={`${inputClass} font-mono`}
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          placeholder="0.001"
+          inputMode="decimal"
+        />
+        <p className="text-[11px] text-text-muted/60 mt-1">Numeric string — preserved at full precision through to the broker (no float roundtrip).</p>
+      </Field>
+
+      {orderType === 'LMT' && (
+        <Field label="Limit Price">
+          <input
+            className={`${inputClass} font-mono`}
+            value={lmtPrice}
+            onChange={(e) => setLmtPrice(e.target.value)}
+            placeholder="60000"
+            inputMode="decimal"
+          />
+        </Field>
+      )}
+
+      <button
+        onClick={() => setShowAdvanced(!showAdvanced)}
+        className="text-[11px] text-text-muted hover:text-text transition-colors"
+      >
+        {showAdvanced ? '▾ Hide advanced' : '▸ Show advanced (cash qty, TIF)'}
+      </button>
+      {showAdvanced && (
+        <div className="space-y-3 border-l border-border pl-3">
+          <Field label="Cash Qty (notional)">
+            <input
+              className={`${inputClass} font-mono`}
+              value={cashQty}
+              onChange={(e) => setCashQty(e.target.value)}
+              placeholder="50"
+              inputMode="decimal"
+            />
+            <p className="text-[11px] text-text-muted/60 mt-1">USDT-equivalent notional. Overrides Quantity if both are set.</p>
+          </Field>
+          <Field label="Time in Force">
+            <select className={inputClass} value={tif} onChange={(e) => setTif(e.target.value)}>
+              <option value="DAY">DAY</option>
+              <option value="GTC">GTC (Good Till Cancelled)</option>
+            </select>
+          </Field>
+        </div>
+      )}
+
+      <div className="border-t border-border pt-4">
+        <Field label="Commit Message — required">
+          <input
+            className={inputClass}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Why are you placing this order?"
+            autoFocus
+          />
+          <p className="text-[11px] text-text-muted/60 mt-1">Goes into the trading-as-git commit log alongside the order. Required, even for manual entries.</p>
+        </Field>
+      </div>
+
+      {p.error && <ErrorPanel message={p.error.message} phase={p.error.phase} />}
+
+      <div className="pt-2">
+        <button
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="btn-primary w-full"
+        >
+          {p.submitting ? 'Submitting…' : 'Place Order'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ==================== Close form ====================
+
+function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { aliceId: string; initialQty: string; symbol?: string }) {
+  const [qty, setQty] = useState(initialQty)
+  const [message, setMessage] = useState('')
+
+  const canSubmit = !!message.trim() && !p.submitting
+
+  const handleSubmit = async () => {
+    p.setError(null)
+    p.setSubmitting(true)
+    try {
+      const body: ClosePositionRequest = {
+        aliceId,
+        ...(symbol && { symbol }),
+        ...(qty.trim() && { qty: qty.trim() }),
+        message: message.trim(),
+      }
+      const result = await tradingApi.closePosition(p.utaId, body)
+      p.setResult(result)
+      p.onPushComplete?.(result)
+    } catch (err) {
+      if (err instanceof OrderEntryError) {
+        p.setError({ message: err.response.error, phase: err.response.phase })
+      } else {
+        p.setError({ message: err instanceof Error ? err.message : String(err) })
+      }
+    } finally {
+      p.setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-1">
+        <div className="text-[11px] text-text-muted uppercase tracking-wide">Closing</div>
+        <div className="font-mono text-[13px] text-text">{aliceId}</div>
+      </div>
+
+      <Field label="Quantity to close">
+        <input
+          className={`${inputClass} font-mono`}
+          value={qty}
+          onChange={(e) => setQty(e.target.value)}
+          placeholder="(empty = full position)"
+          inputMode="decimal"
+        />
+        <p className="text-[11px] text-text-muted/60 mt-1">Defaults to current position size. Override for partial close. Empty = close entire position.</p>
+      </Field>
+
+      <Field label="Commit Message — required">
+        <input
+          className={inputClass}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Why are you closing?"
+          autoFocus
+        />
+      </Field>
+
+      {p.error && <ErrorPanel message={p.error.message} phase={p.error.phase} />}
+
+      <div className="pt-2">
+        <button
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="btn-danger w-full"
+        >
+          {p.submitting ? 'Closing…' : 'Close Position'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ==================== Push result panel ====================
+
+function PushResultPanel({ result }: { result: WalletPushResult }) {
+  const totalRejected = result.rejected.length
+  const totalSubmitted = result.submitted.length
+  const fullySubmitted = totalRejected === 0 && totalSubmitted > 0
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <span className={`w-2 h-2 rounded-full shrink-0 ${fullySubmitted ? 'bg-green' : 'bg-yellow-400'}`} />
+        <span className={`text-[13px] font-medium ${fullySubmitted ? 'text-green' : 'text-yellow-400'}`}>
+          {fullySubmitted
+            ? `${totalSubmitted} operation${totalSubmitted > 1 ? 's' : ''} submitted to broker`
+            : `${totalSubmitted} submitted, ${totalRejected} rejected`}
+        </span>
+      </div>
+
+      <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-1.5">
+        <div className="flex justify-between text-[12px]">
+          <span className="text-text-muted">Commit hash</span>
+          <span className="font-mono text-text">{result.hash}</span>
+        </div>
+        <div className="text-[12px]">
+          <span className="text-text-muted">Message:</span>
+          <span className="ml-2 text-text">{result.message}</span>
+        </div>
+      </div>
+
+      {result.submitted.length > 0 && (
+        <OpTable title="Submitted" rows={result.submitted} kind="submitted" />
+      )}
+      {result.rejected.length > 0 && (
+        <OpTable title="Rejected" rows={result.rejected} kind="rejected" />
+      )}
+
+      <p className="text-[11px] text-text-muted leading-relaxed">
+        Status <strong className="text-text">Submitted</strong> means the broker accepted the order — fills happen async.
+        Refresh the positions / orders panels in a moment to see the order transition to <strong className="text-text">Filled</strong>.
+      </p>
+    </div>
+  )
+}
+
+interface OpRow {
+  action: string
+  success: boolean
+  status: string
+  orderId?: string
+  error?: string
+}
+
+function OpTable({ title, rows, kind }: { title: string; rows: OpRow[]; kind: 'submitted' | 'rejected' }) {
+  return (
+    <div>
+      <p className="text-[11px] font-medium text-text-muted uppercase tracking-wide mb-1.5">{title} ({rows.length})</p>
+      <div className="rounded-md border border-border overflow-hidden">
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="bg-bg-tertiary/30 text-text-muted">
+              <th className="text-left px-2.5 py-1.5 font-medium">Action</th>
+              <th className="text-left px-2.5 py-1.5 font-medium">Order ID</th>
+              <th className="text-left px-2.5 py-1.5 font-medium">Status / Error</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={i} className="border-t border-border">
+                <td className="px-2.5 py-1.5 text-text">{r.action}</td>
+                <td className="px-2.5 py-1.5 font-mono text-text-muted text-[11px]">{r.orderId ?? '—'}</td>
+                <td className={`px-2.5 py-1.5 ${kind === 'rejected' ? 'text-red' : 'text-text'}`}>
+                  {kind === 'rejected' ? (r.error ?? r.status) : r.status}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+// ==================== Error display ====================
+
+function ErrorPanel({ message, phase }: { message: string; phase?: string }) {
+  return (
+    <div className="rounded-md border border-red/30 bg-red/5 px-3 py-2.5">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="w-2 h-2 rounded-full bg-red shrink-0" />
+        <span className="text-[12px] font-medium text-red">
+          {phase ? `Failed at ${phase} step` : 'Failed'}
+        </span>
+      </div>
+      <p className="text-[12px] text-text whitespace-pre-wrap">{message}</p>
+    </div>
+  )
+}
+
+// ==================== Segmented control ====================
+
+function Segmented({ value, options, onChange }: {
+  value: string
+  options: Array<{ id: string; label?: string }>
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="inline-flex rounded-md border border-border overflow-hidden">
+      {options.map((o) => (
+        <button
+          key={o.id}
+          onClick={() => onChange(o.id)}
+          className={`px-3 py-1.5 text-[12px] font-medium transition-colors ${
+            value === o.id
+              ? 'bg-accent/15 text-accent'
+              : 'text-text-muted hover:text-text hover:bg-bg-tertiary/30'
+          }`}
+        >
+          {o.label ?? o.id}
+        </button>
+      ))}
+    </div>
+  )
+}
+

--- a/ui/src/components/uta/SchemaFormFields.tsx
+++ b/ui/src/components/uta/SchemaFormFields.tsx
@@ -1,0 +1,59 @@
+import { Field, inputClass } from '../form'
+import type { SchemaField } from '../../hooks/useSchemaForm'
+
+/**
+ * Render a list of useSchemaForm fields as form widgets.
+ * Used by both the create wizard and the edit dialog.
+ */
+export function SchemaFormFields({ fields, formData, setField, showSecrets }: {
+  fields: SchemaField[]
+  formData: Record<string, string>
+  setField: (key: string, value: string) => void
+  showSecrets: boolean
+}) {
+  return (
+    <div className="space-y-3">
+      {fields.map(f => {
+        const value = formData[f.key] ?? f.defaultValue ?? ''
+        switch (f.type) {
+          case 'select':
+            return (
+              <Field key={f.key} label={f.title}>
+                <select className={inputClass} value={value} onChange={(e) => setField(f.key, e.target.value)}>
+                  {f.options?.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
+              </Field>
+            )
+          case 'password':
+            return (
+              <Field key={f.key} label={f.title}>
+                <input
+                  className={inputClass}
+                  type={showSecrets ? 'text' : 'password'}
+                  value={value}
+                  onChange={(e) => setField(f.key, e.target.value)}
+                  placeholder={f.required ? 'Required' : ''}
+                />
+                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
+              </Field>
+            )
+          case 'text':
+          default:
+            return (
+              <Field key={f.key} label={f.title}>
+                <input
+                  className={inputClass}
+                  type="text"
+                  value={value}
+                  onChange={(e) => setField(f.key, e.target.value)}
+                  placeholder={f.required ? 'Required' : ''}
+                />
+                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
+              </Field>
+            )
+        }
+      })}
+    </div>
+  )
+}

--- a/ui/src/hooks/useAccountHealth.ts
+++ b/ui/src/hooks/useAccountHealth.ts
@@ -11,9 +11,9 @@ export function useAccountHealth() {
   const [healthMap, setHealthMap] = useState<Record<string, BrokerHealthInfo>>({})
 
   useEffect(() => {
-    api.trading.listAccountSummaries().then(({ accounts }) => {
+    api.trading.listUTASummaries().then(({ utas }) => {
       const map: Record<string, BrokerHealthInfo> = {}
-      for (const a of accounts) map[a.id] = a.health
+      for (const a of utas) map[a.id] = a.health
       setHealthMap(map)
     }).catch(() => {})
   }, [])

--- a/ui/src/hooks/useTradingConfig.ts
+++ b/ui/src/hooks/useTradingConfig.ts
@@ -1,20 +1,20 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../api'
-import type { AccountConfig, ReconnectResult } from '../api/types'
+import type { UTAConfig, ReconnectResult } from '../api/types'
 
 export interface UseTradingConfigResult {
-  accounts: AccountConfig[]
+  utas: UTAConfig[]
   loading: boolean
   error: string | null
 
-  saveAccount: (a: AccountConfig) => Promise<void>
-  deleteAccount: (id: string) => Promise<void>
-  reconnectAccount: (id: string) => Promise<ReconnectResult>
+  saveUTA: (a: UTAConfig) => Promise<void>
+  deleteUTA: (id: string) => Promise<void>
+  reconnectUTA: (id: string) => Promise<ReconnectResult>
   refresh: () => Promise<void>
 }
 
 export function useTradingConfig(): UseTradingConfigResult {
-  const [accounts, setAccounts] = useState<AccountConfig[]>([])
+  const [utas, setUTAs] = useState<UTAConfig[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -23,7 +23,7 @@ export function useTradingConfig(): UseTradingConfigResult {
       setLoading(true)
       setError(null)
       const data = await api.trading.loadTradingConfig()
-      setAccounts(data.accounts)
+      setUTAs(data.utas)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -33,9 +33,9 @@ export function useTradingConfig(): UseTradingConfigResult {
 
   useEffect(() => { load() }, [load])
 
-  const saveAccount = useCallback(async (a: AccountConfig) => {
-    await api.trading.upsertAccount(a)
-    setAccounts((prev) => {
+  const saveUTA = useCallback(async (a: UTAConfig) => {
+    await api.trading.upsertUTA(a)
+    setUTAs((prev) => {
       const idx = prev.findIndex((x) => x.id === a.id)
       if (idx >= 0) {
         const next = [...prev]
@@ -46,18 +46,18 @@ export function useTradingConfig(): UseTradingConfigResult {
     })
   }, [])
 
-  const deleteAccount = useCallback(async (id: string) => {
-    await api.trading.deleteAccount(id)
-    setAccounts((prev) => prev.filter((a) => a.id !== id))
+  const deleteUTA = useCallback(async (id: string) => {
+    await api.trading.deleteUTA(id)
+    setUTAs((prev) => prev.filter((a) => a.id !== id))
   }, [])
 
-  const reconnectAccount = useCallback(async (id: string): Promise<ReconnectResult> => {
-    return api.trading.reconnectAccount(id)
+  const reconnectUTA = useCallback(async (id: string): Promise<ReconnectResult> => {
+    return api.trading.reconnectUTA(id)
   }, [])
 
   return {
-    accounts, loading, error,
-    saveAccount, deleteAccount,
-    reconnectAccount, refresh: load,
+    utas, loading, error,
+    saveUTA, deleteUTA,
+    reconnectUTA, refresh: load,
   }
 }

--- a/ui/src/pages/DevPage.tsx
+++ b/ui/src/pages/DevPage.tsx
@@ -312,8 +312,8 @@ function SnapshotsTab() {
 
   // Load accounts list
   useEffect(() => {
-    api.trading.listAccounts().then(r => {
-      const list = r.accounts.map(a => ({ id: a.id, label: a.label }))
+    api.trading.listUTAs().then(r => {
+      const list = r.utas.map(a => ({ id: a.id, label: a.label }))
       setAccounts(list)
       if (list.length > 0 && !selectedAccount) setSelectedAccount(list[0].id)
     }).catch(() => {})

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -234,21 +234,21 @@ export function PortfolioPage() {
 
 async function fetchPortfolioData(): Promise<PortfolioData> {
   try {
-    const [equityResult, accountsResult, fxResult] = await Promise.allSettled([
+    const [equityResult, utasResult, fxResult] = await Promise.allSettled([
       api.trading.equity(),
-      api.trading.listAccounts(),
+      api.trading.listUTAs(),
       api.trading.fxRates(),
     ])
 
     const equity = equityResult.status === 'fulfilled' ? equityResult.value : null
-    const accountsList = accountsResult.status === 'fulfilled' ? accountsResult.value.accounts : []
+    const utasList = utasResult.status === 'fulfilled' ? utasResult.value.utas : []
     const fxRates = fxResult.status === 'fulfilled' ? fxResult.value.rates : []
 
     const accounts = await Promise.all(
-      accountsList.map(async (acct): Promise<AccountData> => {
+      utasList.map(async (acct): Promise<AccountData> => {
         try {
           const [posResp, logResp] = await Promise.all([
-            api.trading.positions(acct.id),
+            api.trading.utaPositions(acct.id),
             api.trading.walletLog(acct.id, 10),
           ])
           return { ...acct, positions: posResp.positions, walletLog: logResp.commits }

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -1,42 +1,30 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
-import { Section, Field, inputClass } from '../components/form'
-import { Toggle } from '../components/Toggle'
-import { GuardsSection, CRYPTO_GUARD_TYPES, SECURITIES_GUARD_TYPES } from '../components/guards'
+import { useState, useEffect, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Field, inputClass } from '../components/form'
 import { SDKSelector } from '../components/SDKSelector'
 import type { SDKOption } from '../components/SDKSelector'
-import { ReconnectButton } from '../components/ReconnectButton'
 import { useTradingConfig } from '../hooks/useTradingConfig'
 import { useAccountHealth } from '../hooks/useAccountHealth'
-import { useSchemaForm, type SchemaField } from '../hooks/useSchemaForm'
+import { useSchemaForm } from '../hooks/useSchemaForm'
 import { PageHeader } from '../components/PageHeader'
+import { Dialog } from '../components/uta/Dialog'
+import { HealthBadge } from '../components/uta/HealthBadge'
+import { SchemaFormFields } from '../components/uta/SchemaFormFields'
 import { api } from '../api'
-import type { AccountConfig, BrokerPreset, BrokerHealthInfo, SubtitleField, TestConnectionResult } from '../api/types'
-
-// ==================== Dialog state ====================
-
-type DialogState =
-  | { kind: 'edit'; accountId: string }
-  | { kind: 'add' }
-  | null
+import type { UTAConfig, BrokerPreset, BrokerHealthInfo, TestConnectionResult, Position, AccountInfo } from '../api/types'
 
 // ==================== Page ====================
 
 export function TradingPage() {
   const tc = useTradingConfig()
   const healthMap = useAccountHealth()
-  const [dialog, setDialog] = useState<DialogState>(null)
+  const navigate = useNavigate()
+  const [showAdd, setShowAdd] = useState(false)
   const [presets, setPresets] = useState<BrokerPreset[]>([])
 
-  // Fetch broker preset metadata on mount
   useEffect(() => {
     api.trading.getBrokerPresets().then(r => setPresets(r.presets)).catch(() => {})
   }, [])
-
-  useEffect(() => {
-    if (dialog?.kind === 'edit') {
-      if (!tc.accounts.some((a) => a.id === dialog.accountId)) setDialog(null)
-    }
-  }, [tc.accounts, dialog])
 
   if (tc.loading) return <PageShell subtitle="Loading..." />
   if (tc.error) {
@@ -48,73 +36,51 @@ export function TradingPage() {
     )
   }
 
-  const deleteAccount = async (accountId: string) => {
-    await tc.deleteAccount(accountId)
-    setDialog(null)
-  }
-
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <PageHeader title="Trading" description="Configure your trading accounts." />
+      <PageHeader title="Trading" description="Configure your UTAs (Unified Trading Accounts)." />
 
       <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">
         <div className="max-w-[720px] space-y-3">
-          {tc.accounts.length === 0 ? (
-            <EmptyState onAdd={() => setDialog({ kind: 'add' })} />
+          {tc.utas.length === 0 ? (
+            <EmptyState onAdd={() => setShowAdd(true)} />
           ) : (
             <>
-              {tc.accounts.map((account) => (
-                <AccountCard
-                  key={account.id}
-                  account={account}
-                  preset={presets.find(p => p.id === account.presetId)}
-                  health={healthMap[account.id]}
-                  onClick={() => setDialog({ kind: 'edit', accountId: account.id })}
+              {tc.utas.map((uta) => (
+                <UTACard
+                  key={uta.id}
+                  uta={uta}
+                  preset={presets.find(p => p.id === uta.presetId)}
+                  health={healthMap[uta.id]}
+                  onClick={() => navigate(`/uta/${uta.id}`)}
                 />
               ))}
               <button
-                onClick={() => setDialog({ kind: 'add' })}
+                onClick={() => setShowAdd(true)}
                 className="w-full py-2.5 text-[12px] text-text-muted hover:text-text border border-dashed border-border hover:border-text-muted/40 rounded-lg transition-colors"
               >
-                + Add Account
+                + Add UTA
               </button>
             </>
           )}
         </div>
       </div>
 
-      {/* Create Wizard */}
-      {dialog?.kind === 'add' && (
+      {showAdd && (
         <CreateWizard
           presets={presets}
-          existingAccountIds={tc.accounts.map((a) => a.id)}
-          onSave={async (account) => {
-            await tc.saveAccount(account)
-            const result = await tc.reconnectAccount(account.id)
+          existingUTAIds={tc.utas.map((a) => a.id)}
+          onSave={async (uta) => {
+            await tc.saveUTA(uta)
+            const result = await tc.reconnectUTA(uta.id)
             if (!result.success) {
               throw new Error(result.error || 'Connection failed')
             }
-            setDialog(null)
+            setShowAdd(false)
           }}
-          onClose={() => setDialog(null)}
+          onClose={() => setShowAdd(false)}
         />
       )}
-
-      {/* Edit Dialog */}
-      {dialog?.kind === 'edit' && (() => {
-        const account = tc.accounts.find((a) => a.id === dialog.accountId)
-        if (!account) return null
-        return (
-          <EditDialog
-            account={account}
-            preset={presets.find(p => p.id === account.presetId)}
-            health={healthMap[account.id]}
-            onSaveAccount={tc.saveAccount}
-            onDelete={() => deleteAccount(account.id)}
-            onClose={() => setDialog(null)}
-          />
-        )
-      })()}
     </div>
   )
 }
@@ -135,90 +101,22 @@ function PageShell({ subtitle, children }: { subtitle: string; children?: React.
 function EmptyState({ onAdd }: { onAdd: () => void }) {
   return (
     <div className="rounded-xl border border-dashed border-border p-12 text-center">
-      <h3 className="text-[16px] font-semibold text-text mb-2">No trading accounts</h3>
+      <h3 className="text-[16px] font-semibold text-text mb-2">No UTAs configured</h3>
       <p className="text-[13px] text-text-muted mb-6 max-w-[320px] mx-auto leading-relaxed">
-        Connect a crypto exchange or brokerage account to start automated trading.
+        Connect a crypto exchange or brokerage to start automated trading.
       </p>
       <button onClick={onAdd} className="btn-primary">
-        + Add Account
+        + Add UTA
       </button>
     </div>
   )
 }
 
-// ==================== Dialog ====================
-
-function Dialog({ onClose, width, children }: {
-  onClose: () => void
-  width?: string
-  children: React.ReactNode
-}) {
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Escape') onClose()
-  }, [onClose])
-
-  useEffect(() => {
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [handleKeyDown])
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className={`relative ${width || 'w-[560px]'} max-w-[95vw] max-h-[85vh] bg-bg rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden`}>
-        {children}
-      </div>
-    </div>
-  )
-}
-
-// ==================== Health Badge ====================
-
-function HealthBadge({ health, size = 'sm' }: { health?: BrokerHealthInfo; size?: 'sm' | 'md' }) {
-  const textSize = size === 'md' ? 'text-[12px]' : 'text-[11px]'
-  const dotSize = size === 'md' ? 'w-2 h-2' : 'w-1.5 h-1.5'
-
-  if (!health) return <span className="text-text-muted/40">—</span>
-
-  if (health.disabled) {
-    return (
-      <span className={`inline-flex items-center gap-1.5 ${textSize} text-text-muted`} title={health.lastError}>
-        <span className={`${dotSize} rounded-full bg-text-muted/40 shrink-0`} />
-        Disabled
-      </span>
-    )
-  }
-
-  switch (health.status) {
-    case 'healthy':
-      return (
-        <span className={`inline-flex items-center gap-1.5 ${textSize} text-green`}>
-          <span className={`${dotSize} rounded-full bg-green shrink-0`} />
-          Connected
-        </span>
-      )
-    case 'degraded':
-      return (
-        <span className={`inline-flex items-center gap-1.5 ${textSize} text-yellow-400`}>
-          <span className={`${dotSize} rounded-full bg-yellow-400 shrink-0`} />
-          Unstable
-        </span>
-      )
-    case 'offline':
-      return (
-        <span className={`inline-flex items-center gap-1.5 ${textSize} text-red`} title={health.lastError}>
-          <span className={`${dotSize} rounded-full bg-red shrink-0 animate-pulse`} />
-          {health.recovering ? 'Reconnecting...' : 'Offline'}
-        </span>
-      )
-  }
-}
-
 // ==================== Subtitle builder ====================
 
-function buildSubtitle(account: AccountConfig, preset?: BrokerPreset): string {
-  if (!preset) return account.presetId
-  const pc = account.presetConfig
+function buildSubtitle(uta: UTAConfig, preset?: BrokerPreset): string {
+  if (!preset) return uta.presetId
+  const pc = uta.presetConfig
   const parts: string[] = []
   for (const sf of preset.subtitleFields) {
     const val = pc[sf.field]
@@ -226,7 +124,6 @@ function buildSubtitle(account: AccountConfig, preset?: BrokerPreset): string {
       if (val && sf.label) parts.push(sf.label)
       else if (!val && sf.falseLabel) parts.push(sf.falseLabel)
     } else if (val != null && val !== '') {
-      // For mode field, prefer the human-readable label from preset.modes
       let display = String(val)
       if (sf.field === 'mode' && preset.modes) {
         const mode = preset.modes.find(m => m.id === val)
@@ -238,18 +135,18 @@ function buildSubtitle(account: AccountConfig, preset?: BrokerPreset): string {
   return parts.join(' · ') || preset.label
 }
 
-// ==================== Account Card ====================
+// ==================== UTA Card ====================
 
-function AccountCard({ account, preset, health, onClick }: {
-  account: AccountConfig
+function UTACard({ uta, preset, health, onClick }: {
+  uta: UTAConfig
   preset?: BrokerPreset
   health?: BrokerHealthInfo
   onClick: () => void
 }) {
-  const isDisabled = health?.disabled || account.enabled === false
+  const isDisabled = health?.disabled || uta.enabled === false
   const badge = preset
     ? { text: preset.badge, color: `${preset.badgeColor} ${preset.badgeColor.replace('text-', 'bg-')}/10` }
-    : { text: account.presetId.slice(0, 2).toUpperCase(), color: 'text-text-muted bg-text-muted/10' }
+    : { text: uta.presetId.slice(0, 2).toUpperCase(), color: 'text-text-muted bg-text-muted/10' }
 
   return (
     <button
@@ -261,14 +158,14 @@ function AccountCard({ account, preset, health, onClick }: {
           {badge.text}
         </span>
         <div className="flex-1 min-w-0">
-          <div className="text-[13px] font-medium text-text truncate">{account.id}</div>
+          <div className="text-[13px] font-medium text-text truncate">{uta.id}</div>
           <div className="text-[11px] text-text-muted truncate mt-0.5">
-            {buildSubtitle(account, preset)}
-            {account.guards.length > 0 && <span className="ml-2 text-text-muted/50">{account.guards.length} guard{account.guards.length > 1 ? 's' : ''}</span>}
+            {buildSubtitle(uta, preset)}
+            {uta.guards.length > 0 && <span className="ml-2 text-text-muted/50">{uta.guards.length} guard{uta.guards.length > 1 ? 's' : ''}</span>}
           </div>
         </div>
         <div className="shrink-0">
-          {account.enabled === false
+          {uta.enabled === false
             ? <span className="text-[11px] text-text-muted">Disabled</span>
             : <HealthBadge health={health} />
           }
@@ -278,65 +175,9 @@ function AccountCard({ account, preset, health, onClick }: {
   )
 }
 
-// ==================== Schema-driven form fields ====================
-
-function SchemaFormFields({ fields, formData, setField, showSecrets }: {
-  fields: SchemaField[]
-  formData: Record<string, string>
-  setField: (key: string, value: string) => void
-  showSecrets: boolean
-}) {
-  return (
-    <div className="space-y-3">
-      {fields.map(f => {
-        const value = formData[f.key] ?? f.defaultValue ?? ''
-        switch (f.type) {
-          case 'select':
-            return (
-              <Field key={f.key} label={f.title}>
-                <select className={inputClass} value={value} onChange={(e) => setField(f.key, e.target.value)}>
-                  {f.options?.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
-              </Field>
-            )
-          case 'password':
-            return (
-              <Field key={f.key} label={f.title}>
-                <input
-                  className={inputClass}
-                  type={showSecrets ? 'text' : 'password'}
-                  value={value}
-                  onChange={(e) => setField(f.key, e.target.value)}
-                  placeholder={f.required ? 'Required' : ''}
-                />
-                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
-              </Field>
-            )
-          case 'text':
-          default:
-            return (
-              <Field key={f.key} label={f.title}>
-                <input
-                  className={inputClass}
-                  type="text"
-                  value={value}
-                  onChange={(e) => setField(f.key, e.target.value)}
-                  placeholder={f.required ? 'Required' : ''}
-                />
-                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
-              </Field>
-            )
-        }
-      })}
-    </div>
-  )
-}
-
 // ==================== Hint renderer (markdown-lite) ====================
 
 function HintBlock({ text }: { text: string }) {
-  // Very simple **bold** + paragraph rendering. Splits paragraphs on \n\n.
   return (
     <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-2">
       {text.trim().split('\n\n').map((para, i) => (
@@ -356,10 +197,10 @@ function HintBlock({ text }: { text: string }) {
 
 type WizardStep = 'pick' | 'config' | 'test'
 
-function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
+function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
   presets: BrokerPreset[]
-  existingAccountIds: string[]
-  onSave: (account: AccountConfig) => Promise<void>
+  existingUTAIds: string[]
+  onSave: (uta: UTAConfig) => Promise<void>
   onClose: () => void
 }) {
   const [step, setStep] = useState<WizardStep>('pick')
@@ -386,7 +227,7 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
     badgeColor: p.badgeColor,
   })), [presets])
 
-  const buildAccount = (): AccountConfig | null => {
+  const buildUTA = (): UTAConfig | null => {
     if (!preset) return null
     return {
       id: finalId,
@@ -406,8 +247,8 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
   const handleTest = async () => {
     if (!preset) return
     setError('')
-    if (existingAccountIds.includes(finalId)) {
-      setError(`Account "${finalId}" already exists`)
+    if (existingUTAIds.includes(finalId)) {
+      setError(`UTA "${finalId}" already exists`)
       return
     }
     const validationError = validate()
@@ -415,11 +256,11 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
       setError(validationError)
       return
     }
-    const account = buildAccount()
-    if (!account) return
+    const uta = buildUTA()
+    if (!uta) return
     setTesting(true)
     try {
-      const result = await api.trading.testConnection(account)
+      const result = await api.trading.testConnection(uta)
       setTestResult(result)
       setStep('test')
     } catch (err) {
@@ -431,26 +272,24 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
   }
 
   const handleSave = async () => {
-    const account = buildAccount()
-    if (!account) return
+    const uta = buildUTA()
+    if (!uta) return
     setSaving(true); setError('')
     try {
-      await onSave(account)
+      await onSave(uta)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save account')
+      setError(err instanceof Error ? err.message : 'Failed to save UTA')
       setSaving(false)
     }
   }
 
-  // Header text mirrors current step so the user always knows where they are.
   const headerLabel =
-    step === 'pick'   ? 'New Account · Pick Platform' :
-    step === 'config' ? `New Account · Configure ${preset?.label ?? ''}` :
-                        `New Account · Test ${preset?.label ?? ''}`
+    step === 'pick'   ? 'New UTA · Pick Platform' :
+    step === 'config' ? `New UTA · Configure ${preset?.label ?? ''}` :
+                        `New UTA · Test ${preset?.label ?? ''}`
 
   return (
     <Dialog onClose={onClose}>
-      {/* Header */}
       <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <h3 className="text-[14px] font-semibold text-text truncate">{headerLabel}</h3>
@@ -463,7 +302,6 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
         </button>
       </div>
 
-      {/* Body */}
       <div className="flex-1 overflow-y-auto px-6 py-6">
         {step === 'pick' && (
           <SDKSelector options={platformOptions} selected={presetId ?? ''} onSelect={handlePick} />
@@ -473,7 +311,7 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
           <div className="space-y-5">
             {preset.hint && <HintBlock text={preset.hint} />}
             <div className="space-y-3">
-              <Field label="Account ID">
+              <Field label="UTA ID">
                 <input className={inputClass} value={id} onChange={(e) => setId(e.target.value.trim())} placeholder={defaultId} />
               </Field>
               <SchemaFormFields
@@ -496,11 +334,10 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
         )}
 
         {step === 'test' && testResult && (
-          <TestResultPanel result={testResult} accountId={finalId} />
+          <TestResultPanel result={testResult} utaId={finalId} />
         )}
       </div>
 
-      {/* Footer */}
       <div className="shrink-0 flex items-center justify-between px-6 py-4 border-t border-border">
         {step === 'pick' && (
           <>
@@ -521,7 +358,7 @@ function CreateWizard({ presets, existingAccountIds, onSave, onClose }: {
             <button onClick={() => setStep('config')} className="btn-secondary">← Back</button>
             {testResult?.success ? (
               <button onClick={handleSave} disabled={saving} className="btn-primary">
-                {saving ? 'Saving...' : 'Save Account'}
+                {saving ? 'Saving...' : 'Save UTA'}
               </button>
             ) : (
               <span className="text-[11px] text-text-muted">Fix the config and try again</span>
@@ -551,7 +388,7 @@ function StepDots({ current }: { current: WizardStep }) {
   )
 }
 
-function TestResultPanel({ result, accountId }: { result: TestConnectionResult; accountId: string }) {
+function TestResultPanel({ result, utaId }: { result: TestConnectionResult; utaId: string }) {
   if (!result.success) {
     return (
       <div className="space-y-3">
@@ -569,8 +406,8 @@ function TestResultPanel({ result, accountId }: { result: TestConnectionResult; 
     )
   }
 
-  const acct = result.account
-  const positions = result.positions ?? []
+  const acct: AccountInfo | undefined = result.account
+  const positions: Position[] = result.positions ?? []
   const visiblePositions = positions.slice(0, 8)
   const moreCount = positions.length - visiblePositions.length
 
@@ -578,7 +415,7 @@ function TestResultPanel({ result, accountId }: { result: TestConnectionResult; 
     <div className="space-y-4">
       <div className="flex items-center gap-2">
         <span className="w-2 h-2 rounded-full bg-green shrink-0" />
-        <span className="text-[13px] font-medium text-green">Connected as {accountId}</span>
+        <span className="text-[13px] font-medium text-green">Connected as {utaId}</span>
       </div>
 
       {acct && (
@@ -639,180 +476,3 @@ function TestResultPanel({ result, accountId }: { result: TestConnectionResult; 
     </div>
   )
 }
-
-// ==================== Edit Dialog ====================
-
-function EditDialog({ account, preset, health, onSaveAccount, onDelete, onClose }: {
-  account: AccountConfig
-  preset?: BrokerPreset
-  health?: BrokerHealthInfo
-  onSaveAccount: (a: AccountConfig) => Promise<void>
-  onDelete: () => Promise<void>
-  onClose: () => void
-}) {
-  const [draft, setDraft] = useState(account)
-  const [saving, setSaving] = useState(false)
-  const [msg, setMsg] = useState('')
-  const [guardsOpen, setGuardsOpen] = useState(false)
-  const [showKeys, setShowKeys] = useState(false)
-
-  // Schema-driven form pre-populated from account.presetConfig.
-  const initialValues = useMemo(() => {
-    const out: Record<string, string> = {}
-    for (const [k, v] of Object.entries(account.presetConfig)) {
-      if (v != null) out[k] = String(v)
-    }
-    return out
-  }, [account])
-  const { fields, formData, setField, getSubmitData } = useSchemaForm(preset?.schema, initialValues)
-  const hasSensitive = fields.some(f => f.type === 'password')
-
-  // Sync draft.presetConfig from form state on every form change
-  useEffect(() => {
-    const submitData = getSubmitData()
-    setDraft(d => ({ ...d, presetConfig: submitData }))
-  }, [formData, getSubmitData])
-
-  useEffect(() => { setDraft(account) }, [account])
-
-  const dirty = JSON.stringify(draft) !== JSON.stringify(account)
-
-  const patchGuards = (guards: AccountConfig['guards']) => {
-    setDraft(d => ({ ...d, guards }))
-  }
-
-  const handleSave = async () => {
-    setSaving(true); setMsg('')
-    try {
-      await onSaveAccount(draft)
-      setMsg('Saved')
-      setTimeout(() => setMsg(''), 2000)
-    } catch (err) {
-      setMsg(err instanceof Error ? err.message : 'Save failed')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const guardTypes = (preset?.guardCategory === 'crypto') ? CRYPTO_GUARD_TYPES : SECURITIES_GUARD_TYPES
-
-  return (
-    <Dialog onClose={onClose} width="w-[560px]">
-      {/* Header */}
-      <div className="shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
-        <div className="flex items-center gap-3 min-w-0">
-          <h3 className="text-[14px] font-semibold text-text truncate">{account.id}</h3>
-          <HealthBadge health={health} size="md" />
-        </div>
-        <button onClick={onClose} className="text-text-muted hover:text-text p-1 transition-colors shrink-0">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-            <path d="M18 6L6 18M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
-
-      {/* Body */}
-      <div className="flex-1 overflow-y-auto px-6 py-6 space-y-5">
-        <Section title="Configuration">
-          <div className="mb-3">
-            <span className="text-[12px] text-text-muted">Type</span>
-            <span className="ml-2 text-[12px] font-medium text-text">{preset?.label ?? account.presetId}</span>
-          </div>
-          <SchemaFormFields
-            fields={fields}
-            formData={formData}
-            setField={setField}
-            showSecrets={showKeys}
-          />
-          {hasSensitive && (
-            <button
-              onClick={() => setShowKeys(!showKeys)}
-              className="text-[11px] text-text-muted hover:text-text transition-colors mt-2"
-            >
-              {showKeys ? 'Hide secrets' : 'Show secrets'}
-            </button>
-          )}
-        </Section>
-
-        {/* Guards */}
-        <div>
-          <button
-            onClick={() => setGuardsOpen(!guardsOpen)}
-            className="flex items-center gap-1.5 text-[13px] font-semibold text-text-muted uppercase tracking-wide"
-          >
-            <svg
-              width="12" height="12" viewBox="0 0 24 24"
-              fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-              className={`transition-transform duration-150 ${guardsOpen ? 'rotate-90' : ''}`}
-            >
-              <polyline points="9 18 15 12 9 6" />
-            </svg>
-            Guards ({draft.guards.length})
-          </button>
-          {guardsOpen && (
-            <div className="mt-3">
-              <GuardsSection
-                guards={draft.guards}
-                guardTypes={guardTypes}
-                description="Guards validate operations before execution. Order matters."
-                onChange={patchGuards}
-                onChangeImmediate={patchGuards}
-              />
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Footer */}
-      <div className="shrink-0 flex items-center px-6 py-4 border-t border-border">
-        <div className="flex items-center gap-3">
-          {dirty && (
-            <button onClick={handleSave} disabled={saving} className="btn-primary">
-              {saving ? 'Saving...' : 'Save'}
-            </button>
-          )}
-          {draft.enabled !== false && <ReconnectButton accountId={account.id} />}
-          <label className="flex items-center gap-2 cursor-pointer">
-            <Toggle checked={draft.enabled !== false} onChange={async (v) => {
-              const updated = { ...draft, enabled: v }
-              setDraft(updated)
-              await onSaveAccount(updated)
-            }} />
-            <span className="text-[12px] text-text-muted">{draft.enabled !== false ? 'Enabled' : 'Disabled'}</span>
-          </label>
-          {msg && <span className="text-[12px] text-text-muted">{msg}</span>}
-        </div>
-        <div className="flex-1" />
-        <DeleteButton label="Delete Account" onConfirm={onDelete} />
-      </div>
-    </Dialog>
-  )
-}
-
-// ==================== Delete Button ====================
-
-function DeleteButton({ label, onConfirm }: { label: string; onConfirm: () => void }) {
-  const [confirming, setConfirming] = useState(false)
-
-  if (confirming) {
-    return (
-      <div className="flex items-center gap-2">
-        <button onClick={() => { onConfirm(); setConfirming(false) }} className="btn-danger">
-          Confirm
-        </button>
-        <button onClick={() => setConfirming(false)} className="btn-secondary">
-          Cancel
-        </button>
-      </div>
-    )
-  }
-
-  return (
-    <button onClick={() => setConfirming(true)} className="btn-danger">
-      {label}
-    </button>
-  )
-}
-
-// SubtitleField is referenced via preset.subtitleFields elements, kept here for type consumers.
-export type { SubtitleField as _SubtitleField }

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { api } from '../api'
 import type { UTAConfig, BrokerPreset, AccountInfo, Position, BrokerHealthInfo, UTASnapshotSummary } from '../api/types'
 import { useTradingConfig } from '../hooks/useTradingConfig'
@@ -10,12 +10,14 @@ import { ReconnectButton } from '../components/ReconnectButton'
 import { Toggle } from '../components/Toggle'
 import { HealthBadge } from '../components/uta/HealthBadge'
 import { EditUTADialog } from '../components/uta/EditUTADialog'
+import { OrderEntryDialog, type OrderEntryMode } from '../components/uta/OrderEntryDialog'
 import { SnapshotDetail } from '../components/SnapshotDetail'
 
 // ==================== Page ====================
 
 export function UTADetailPage() {
   const { id } = useParams<{ id: string }>()
+  const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
   const tc = useTradingConfig()
   const healthMap = useAccountHealth()
@@ -26,6 +28,7 @@ export function UTADetailPage() {
   const [snapshots, setSnapshots] = useState<UTASnapshotSummary[]>([])
   const [selectedSnapshot, setSelectedSnapshot] = useState<UTASnapshotSummary | null>(null)
   const [editing, setEditing] = useState(false)
+  const [orderMode, setOrderMode] = useState<OrderEntryMode | null>(null)
   const [dataError, setDataError] = useState<string | null>(null)
 
   // Preset metadata (stable across renders)
@@ -74,6 +77,19 @@ export function UTADetailPage() {
     return () => { clearInterval(liveInterval); clearInterval(snapshotInterval) }
   }, [refreshLive, refreshSnapshots])
 
+  // URL query param `?aliceId=...` (e.g. clicked from
+  // TradeableContractsPanel) auto-opens the place-order form prefilled.
+  useEffect(() => {
+    const queryAlice = searchParams.get('aliceId')
+    if (queryAlice && !orderMode) {
+      setOrderMode({ kind: 'place', aliceId: queryAlice })
+      // Clear the param so back/forward + reopen behave sensibly.
+      const next = new URLSearchParams(searchParams)
+      next.delete('aliceId')
+      setSearchParams(next, { replace: true })
+    }
+  }, [searchParams, setSearchParams, orderMode])
+
   if (tc.loading) return <Shell title="Loading…" />
 
   if (!id) return <Shell title="UTA not specified" />
@@ -114,6 +130,13 @@ export function UTADetailPage() {
               onChange={async (v) => { await tc.saveUTA({ ...uta, enabled: v }) }}
             />
             <ReconnectButton accountId={uta.id} />
+            <button
+              onClick={() => setOrderMode({ kind: 'place' })}
+              disabled={isDisabled}
+              className="px-3 py-1.5 text-[13px] font-medium rounded-md bg-accent text-bg hover:bg-accent/90 disabled:opacity-40 transition-colors"
+            >
+              + Place Order
+            </button>
             <button onClick={() => setEditing(true)} className="px-3 py-1.5 text-[13px] font-medium rounded-md border border-border hover:bg-bg-tertiary transition-colors">
               Edit
             </button>
@@ -132,7 +155,15 @@ export function UTADetailPage() {
           <HeroMetrics account={account} />
 
           {positions.length > 0 ? (
-            <PositionsTable positions={positions} />
+            <PositionsTable
+              positions={positions}
+              onCloseClick={(p) => setOrderMode({
+                kind: 'close',
+                aliceId: p.contract.aliceId ?? p.contract.localSymbol ?? p.contract.symbol ?? '',
+                quantity: p.quantity,
+                symbol: p.contract.symbol,
+              })}
+            />
           ) : (
             <EmptyState title="No open positions." />
           )}
@@ -159,6 +190,17 @@ export function UTADetailPage() {
             navigate('/trading')
           }}
           onClose={() => setEditing(false)}
+        />
+      )}
+
+      {orderMode && (
+        <OrderEntryDialog
+          utaId={uta.id}
+          mode={orderMode}
+          onClose={() => setOrderMode(null)}
+          // Trigger an immediate refresh so the new order/position
+          // shows up without waiting for the 15s polling tick.
+          onPushComplete={() => { void refreshLive() }}
         />
       )}
     </div>
@@ -213,7 +255,10 @@ function Metric({ label, value, pnl }: { label: string; value: string; pnl?: num
 
 // ==================== Positions Table ====================
 
-function PositionsTable({ positions }: { positions: Position[] }) {
+function PositionsTable({ positions, onCloseClick }: {
+  positions: Position[]
+  onCloseClick: (p: Position) => void
+}) {
   return (
     <div>
       <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wide mb-3">
@@ -232,6 +277,7 @@ function PositionsTable({ positions }: { positions: Position[] }) {
               <th className="px-3 py-2 font-medium text-right">Mkt Value</th>
               <th className="px-3 py-2 font-medium text-right">PnL</th>
               <th className="px-3 py-2 font-medium text-right">PnL %</th>
+              <th className="px-3 py-2 font-medium text-right" />
             </tr>
           </thead>
           <tbody>
@@ -261,6 +307,14 @@ function PositionsTable({ positions }: { positions: Position[] }) {
                   </td>
                   <td className={`px-3 py-2 text-right ${pnl >= 0 ? 'text-green' : 'text-red'}`}>
                     {`${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <button
+                      onClick={() => onCloseClick(p)}
+                      className="text-[11px] text-text-muted hover:text-red transition-colors"
+                    >
+                      Close
+                    </button>
                   </td>
                 </tr>
               )

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -1,0 +1,409 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useParams, Link, useNavigate } from 'react-router-dom'
+import { api } from '../api'
+import type { UTAConfig, BrokerPreset, AccountInfo, Position, BrokerHealthInfo, UTASnapshotSummary } from '../api/types'
+import { useTradingConfig } from '../hooks/useTradingConfig'
+import { useAccountHealth } from '../hooks/useAccountHealth'
+import { PageHeader } from '../components/PageHeader'
+import { EmptyState } from '../components/StateViews'
+import { ReconnectButton } from '../components/ReconnectButton'
+import { Toggle } from '../components/Toggle'
+import { HealthBadge } from '../components/uta/HealthBadge'
+import { EditUTADialog } from '../components/uta/EditUTADialog'
+import { SnapshotDetail } from '../components/SnapshotDetail'
+
+// ==================== Page ====================
+
+export function UTADetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const tc = useTradingConfig()
+  const healthMap = useAccountHealth()
+  const [presets, setPresets] = useState<BrokerPreset[]>([])
+  const [account, setAccount] = useState<AccountInfo | null>(null)
+  const [positions, setPositions] = useState<Position[]>([])
+  const [orders, setOrders] = useState<unknown[]>([])
+  const [snapshots, setSnapshots] = useState<UTASnapshotSummary[]>([])
+  const [selectedSnapshot, setSelectedSnapshot] = useState<UTASnapshotSummary | null>(null)
+  const [editing, setEditing] = useState(false)
+  const [dataError, setDataError] = useState<string | null>(null)
+
+  // Preset metadata (stable across renders)
+  useEffect(() => {
+    api.trading.getBrokerPresets().then(r => setPresets(r.presets)).catch(() => {})
+  }, [])
+
+  const uta = useMemo<UTAConfig | undefined>(() => tc.utas.find(u => u.id === id), [tc.utas, id])
+  const preset = useMemo<BrokerPreset | undefined>(() => presets.find(p => p.id === uta?.presetId), [presets, uta])
+  const health: BrokerHealthInfo | undefined = id ? healthMap[id] : undefined
+
+  // Active polling — account/positions/orders refresh every 15s
+  const refreshLive = useCallback(async () => {
+    if (!id) return
+    setDataError(null)
+    try {
+      const [acct, pos, ord] = await Promise.all([
+        api.trading.utaAccount(id).catch(() => null),
+        api.trading.utaPositions(id).catch(() => ({ positions: [] as Position[] })),
+        api.trading.utaOrders(id).catch(() => ({ orders: [] as unknown[] })),
+      ])
+      setAccount(acct)
+      setPositions(pos.positions)
+      setOrders(ord.orders)
+    } catch (err) {
+      setDataError(err instanceof Error ? err.message : String(err))
+    }
+  }, [id])
+
+  // Snapshots refresh more slowly (60s)
+  const refreshSnapshots = useCallback(async () => {
+    if (!id) return
+    try {
+      const r = await api.trading.snapshots(id, { limit: 20 })
+      setSnapshots(r.snapshots)
+    } catch {
+      // non-fatal — snapshots are secondary content
+    }
+  }, [id])
+
+  useEffect(() => {
+    refreshLive()
+    refreshSnapshots()
+    const liveInterval = setInterval(refreshLive, 15_000)
+    const snapshotInterval = setInterval(refreshSnapshots, 60_000)
+    return () => { clearInterval(liveInterval); clearInterval(snapshotInterval) }
+  }, [refreshLive, refreshSnapshots])
+
+  if (tc.loading) return <Shell title="Loading…" />
+
+  if (!id) return <Shell title="UTA not specified" />
+  if (!uta) {
+    return (
+      <Shell title={`UTA ${id} not found`}>
+        <EmptyState
+          title={`No UTA "${id}"`}
+          description="It may have been deleted or never configured. Head back to Trading to create one or pick a different UTA."
+        />
+        <div className="mt-4">
+          <Link to="/trading" className="btn-secondary">← Back to Trading</Link>
+        </div>
+      </Shell>
+    )
+  }
+
+  const isDisabled = uta.enabled === false
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      {/* Header */}
+      <PageHeader
+        title={preset?.label ?? uta.id}
+        description={
+          <>
+            <Link to="/trading" className="text-text-muted hover:text-text">← Trading</Link>
+            <span className="mx-2 text-text-muted/40">·</span>
+            <span className="font-mono text-text-muted">{uta.id}</span>
+            <span className="mx-2 text-text-muted/40">·</span>
+            <HealthBadge health={health} size="sm" />
+          </>
+        }
+        right={
+          <div className="flex items-center gap-2">
+            <Toggle
+              checked={!isDisabled}
+              onChange={async (v) => { await tc.saveUTA({ ...uta, enabled: v }) }}
+            />
+            <ReconnectButton accountId={uta.id} />
+            <button onClick={() => setEditing(true)} className="px-3 py-1.5 text-[13px] font-medium rounded-md border border-border hover:bg-bg-tertiary transition-colors">
+              Edit
+            </button>
+          </div>
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">
+        <div className="max-w-[960px] mx-auto space-y-5">
+          {dataError && (
+            <div className="rounded-md border border-red/30 bg-red/5 px-3 py-2 text-[12px] text-red">
+              Failed to load live data: {dataError}
+            </div>
+          )}
+
+          <HeroMetrics account={account} />
+
+          {positions.length > 0 ? (
+            <PositionsTable positions={positions} />
+          ) : (
+            <EmptyState title="No open positions." />
+          )}
+
+          <OrdersSection orders={orders} />
+
+          <SnapshotsSection
+            snapshots={snapshots}
+            selected={selectedSnapshot}
+            onSelect={setSelectedSnapshot}
+          />
+        </div>
+      </div>
+
+      {editing && (
+        <EditUTADialog
+          uta={uta}
+          preset={preset}
+          health={health}
+          onSave={async (next) => { await tc.saveUTA(next) }}
+          onDelete={async () => {
+            await tc.deleteUTA(uta.id)
+            setEditing(false)
+            navigate('/trading')
+          }}
+          onClose={() => setEditing(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+// ==================== Shell (loading / error states) ====================
+
+function Shell({ title, children }: { title: string; children?: React.ReactNode }) {
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <PageHeader title={title} description={<Link to="/trading" className="text-text-muted hover:text-text">← Trading</Link>} />
+      <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">
+        <div className="max-w-[720px] mx-auto">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+// ==================== Hero Metrics ====================
+
+function HeroMetrics({ account }: { account: AccountInfo | null }) {
+  if (!account) {
+    return (
+      <div className="border border-border rounded-lg bg-bg-secondary p-5 text-center">
+        <p className="text-[13px] text-text-muted">Loading account info…</p>
+      </div>
+    )
+  }
+  const ccy = account.baseCurrency || 'USD'
+  return (
+    <div className="border border-border rounded-lg bg-bg-secondary p-5">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Metric label="Net Liquidation" value={fmt(Number(account.netLiquidation), ccy)} />
+        <Metric label="Cash" value={fmt(Number(account.totalCashValue), ccy)} />
+        <Metric label="Unrealized P&L" value={fmtPnl(Number(account.unrealizedPnL), ccy)} pnl={Number(account.unrealizedPnL)} />
+        <Metric label="Realized P&L" value={fmtPnl(Number(account.realizedPnL ?? '0'), ccy)} pnl={Number(account.realizedPnL ?? '0')} />
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, pnl }: { label: string; value: string; pnl?: number }) {
+  const color = pnl == null ? 'text-text' : pnl >= 0 ? 'text-green' : 'text-red'
+  return (
+    <div>
+      <p className="text-[11px] text-text-muted uppercase tracking-wide">{label}</p>
+      <p className={`text-[22px] md:text-[28px] font-bold tabular-nums ${color}`}>{value}</p>
+    </div>
+  )
+}
+
+// ==================== Positions Table ====================
+
+function PositionsTable({ positions }: { positions: Position[] }) {
+  return (
+    <div>
+      <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wide mb-3">
+        Positions ({positions.length})
+      </h3>
+      <div className="border border-border rounded-lg overflow-x-auto">
+        <table className="w-full text-[13px]">
+          <thead>
+            <tr className="bg-bg-secondary text-text-muted text-left">
+              <th className="px-3 py-2 font-medium">Contract</th>
+              <th className="px-3 py-2 font-medium text-center">Ccy</th>
+              <th className="px-3 py-2 font-medium">Side</th>
+              <th className="px-3 py-2 font-medium text-right">Qty</th>
+              <th className="px-3 py-2 font-medium text-right">Avg Cost</th>
+              <th className="px-3 py-2 font-medium text-right">Mark</th>
+              <th className="px-3 py-2 font-medium text-right">Mkt Value</th>
+              <th className="px-3 py-2 font-medium text-right">PnL</th>
+              <th className="px-3 py-2 font-medium text-right">PnL %</th>
+            </tr>
+          </thead>
+          <tbody>
+            {positions.map((p, i) => {
+              const ccy = p.currency ?? 'USD'
+              const cost = Number(p.avgCost) * Number(p.quantity)
+              const pnl = Number(p.unrealizedPnL)
+              const pct = cost > 0 ? (pnl / cost) * 100 : 0
+              const display = p.contract.aliceId ?? p.contract.localSymbol ?? p.contract.symbol ?? '?'
+              return (
+                <tr key={i} className="border-t border-border hover:bg-bg-tertiary/30 transition-colors">
+                  <td className="px-3 py-2">
+                    <span className="font-mono text-text">{display}</span>
+                  </td>
+                  <td className="px-3 py-2 text-center text-text-muted text-[11px]">{ccy}</td>
+                  <td className="px-3 py-2">
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
+                      {p.side}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-right text-text">{fmtNum(Number(p.quantity))}</td>
+                  <td className="px-3 py-2 text-right text-text-muted">{fmt(Number(p.avgCost), ccy)}</td>
+                  <td className="px-3 py-2 text-right text-text">{fmt(Number(p.marketPrice), ccy)}</td>
+                  <td className="px-3 py-2 text-right text-text">{fmt(Number(p.marketValue), ccy)}</td>
+                  <td className={`px-3 py-2 text-right font-medium ${pnl >= 0 ? 'text-green' : 'text-red'}`}>
+                    {fmtPnl(pnl, ccy)}
+                  </td>
+                  <td className={`px-3 py-2 text-right ${pnl >= 0 ? 'text-green' : 'text-red'}`}>
+                    {`${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+// ==================== Open Orders ====================
+
+interface OpenOrderRow {
+  orderId?: number | string
+  contract?: { aliceId?: string; symbol?: string; localSymbol?: string }
+  order?: { action?: string; orderType?: string; totalQuantity?: string | number; lmtPrice?: string | number }
+  orderState?: { status?: string }
+}
+
+function OrdersSection({ orders }: { orders: unknown[] }) {
+  const rows = orders as OpenOrderRow[]
+  return (
+    <div>
+      <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wide mb-3">
+        Open Orders ({rows.length})
+      </h3>
+      {rows.length === 0 ? (
+        <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-text-muted">
+          No open orders.
+        </div>
+      ) : (
+        <div className="border border-border rounded-lg overflow-x-auto">
+          <table className="w-full text-[13px]">
+            <thead>
+              <tr className="bg-bg-secondary text-text-muted text-left">
+                <th className="px-3 py-2 font-medium">Order ID</th>
+                <th className="px-3 py-2 font-medium">Contract</th>
+                <th className="px-3 py-2 font-medium">Action</th>
+                <th className="px-3 py-2 font-medium">Type</th>
+                <th className="px-3 py-2 font-medium text-right">Qty</th>
+                <th className="px-3 py-2 font-medium text-right">Limit</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((o, i) => (
+                <tr key={i} className="border-t border-border">
+                  <td className="px-3 py-2 font-mono text-text-muted text-[11px]">{String(o.orderId ?? '—')}</td>
+                  <td className="px-3 py-2 font-mono text-text">
+                    {o.contract?.aliceId ?? o.contract?.localSymbol ?? o.contract?.symbol ?? '?'}
+                  </td>
+                  <td className="px-3 py-2 text-text">{o.order?.action ?? '—'}</td>
+                  <td className="px-3 py-2 text-text-muted">{o.order?.orderType ?? '—'}</td>
+                  <td className="px-3 py-2 text-right text-text">{String(o.order?.totalQuantity ?? '')}</td>
+                  <td className="px-3 py-2 text-right text-text-muted">{o.order?.lmtPrice != null ? String(o.order.lmtPrice) : '—'}</td>
+                  <td className="px-3 py-2">
+                    <span className="text-[11px] text-text-muted">{o.orderState?.status ?? 'Unknown'}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ==================== Snapshots ====================
+
+function SnapshotsSection({ snapshots, selected, onSelect }: {
+  snapshots: UTASnapshotSummary[]
+  selected: UTASnapshotSummary | null
+  onSelect: (s: UTASnapshotSummary | null) => void
+}) {
+  return (
+    <div>
+      <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wide mb-3">
+        Recent Snapshots ({snapshots.length})
+      </h3>
+
+      {selected && (
+        <div className="mb-3">
+          <SnapshotDetail snapshot={selected} onClose={() => onSelect(null)} />
+        </div>
+      )}
+
+      {snapshots.length === 0 ? (
+        <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-text-muted">
+          No snapshots yet. Snapshots are captured periodically (see Portfolio settings) or after each push.
+        </div>
+      ) : (
+        <div className="border border-border rounded-lg divide-y divide-border">
+          {snapshots.map(s => (
+            <button
+              key={s.timestamp}
+              onClick={() => onSelect(selected?.timestamp === s.timestamp ? null : s)}
+              className={`w-full text-left px-3 py-2 hover:bg-bg-tertiary/30 transition-colors flex items-center justify-between ${selected?.timestamp === s.timestamp ? 'bg-bg-tertiary/40' : ''}`}
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="text-[12px] text-text-muted">{new Date(s.timestamp).toLocaleString()}</span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted">{s.trigger}</span>
+                <span className="text-[11px] text-text-muted/60">{s.positions.length} pos</span>
+              </div>
+              <span className="text-[12px] tabular-nums text-text">
+                {s.account.baseCurrency} {fmtNum(Number(s.account.netLiquidation))}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ==================== Formatting ====================
+
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: '$', HKD: 'HK$', EUR: '€', GBP: '£', JPY: '¥',
+  CNY: '¥', CNH: '¥', CAD: 'C$', AUD: 'A$', CHF: 'CHF ',
+  SGD: 'S$', KRW: '₩', INR: '₹', TWD: 'NT$', BRL: 'R$',
+}
+
+function currencySymbol(currency?: string): string {
+  if (!currency) return '$'
+  return CURRENCY_SYMBOLS[currency.toUpperCase()] ?? `${currency} `
+}
+
+function fmt(n: number, currency?: string): string {
+  const sym = currencySymbol(currency)
+  return n >= 1000
+    ? `${sym}${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : `${sym}${n.toFixed(2)}`
+}
+
+function fmtPnl(n: number, currency?: string): string {
+  const sign = n >= 0 ? '+' : ''
+  return `${sign}${fmt(n, currency)}`
+}
+
+function fmtNum(n: number): string {
+  return n >= 1
+    ? n.toLocaleString('en-US', { maximumFractionDigits: 4 })
+    : n.toPrecision(4)
+}


### PR DESCRIPTION
## Summary

The trading config got a per-UTA detail page (`/uta/:id`) — the
missing visualization surface that's the first concrete step toward
treating UTA as a product, per the project memory captured in last
session. While at it, pulled "UTA" naming through consistently top to
bottom: HTTP routes, types, manager class, frontend hooks, AI tool
names. The two different "account"s in the codebase are now clearly
separated — `UTAConfig` / `UTAManager` for the user-facing wrapper,
and `AccountInfo` / `IBroker.getAccount()` for the broker-internal
cash/equity/margin info.

## Per-session contributions

### 2026-04-29 — UTA detail page + UTA naming pass

- New page `ui/src/pages/UTADetailPage.tsx` at route `/uta/:id`:
  - Header with label, health badge, reconnect, edit, enabled toggle,
    back link to Trading.
  - HeroMetrics card (netLiq / cash / unrealized / realized PnL).
  - Positions table — full per-position detail (qty, avgCost, mark,
    market value, PnL, PnL%). For OKX UTAs, the spot synthesis added
    in PR #151 finally has a place to surface end-to-end.
  - Open orders table.
  - Recent snapshots list with click-to-expand `SnapshotDetail`.
  - Polling: 15s for live data, 60s for snapshots.
- Navigation: clicking an account card on `/trading` now navigates to
  `/uta/:id` (was: open EditDialog). Edit moved to a header button on
  the detail page that opens the same dialog. Reflects the
  configure-once / view-continuously usage pattern.
- Component extraction into `ui/src/components/uta/`: `HealthBadge`,
  `Dialog`, `SchemaFormFields`, `EditUTADialog` — all reusable across
  the trading list page and the UTA detail page.
- Backend rename (mechanical, no behavior change): `AccountConfig` →
  `UTAConfig`, `AccountManager` → `UTAManager` (file renamed to
  `uta-manager.ts`), `initAccount`/`reconnectAccount`/`removeAccount`/
  `listAccounts` → `initUTA`/`reconnectUTA`/`removeUTA`/`listUTAs`,
  `AccountSummary` → `UTASummary`. 16 HTTP endpoints under
  `/api/trading/accounts/:id/...` moved to `/api/trading/uta/:id/...`.
  Listing/config endpoint response fields `{ accounts }` → `{ utas }`.
- AI tool `listAccounts` → `listUTAs` so the LLM-facing surface uses
  the same vocabulary as the rest of the system.
- Frontend rename pass: `ui/src/api/types.ts`, `ui/src/api/trading.ts`,
  `useTradingConfig`, all call sites (TradingPage, PortfolioPage,
  DevPage, PushApprovalPanel, ReconnectButton,
  TradeableContractsPanel). Internal aggregate field names
  (`AggregatedEquity.accounts`, `EquityCurvePoint.accounts`) left
  alone — descriptive within their structures.
- Deliberately NOT renamed: `IBroker.getAccount()` and
  `AccountInfo` — these are the broker-internal account info, a
  different concept. Keeping that name was the whole point of the
  disambiguation. `data/config/accounts.json` filename also kept
  (internal, not user-visible; renaming would need another migration).
- Key commits: `4bfe0e9`

### 2026-04-29 — Manual order entry from frontend

- 3 new combined wallet endpoints fusing stage → commit → push into
  one HTTP roundtrip: `POST /uta/:id/wallet/place-order`,
  `.../close-position`, `.../cancel-order`. Each requires a commit
  message (规矩); body validated via Zod; numeric fields are strings
  on the wire (preserves Decimal precision through the existing
  `new Decimal(String(x))` pattern). TradingGit primitives stay
  separate — combination is purely route-layer convenience.
- Errors carry `phase` ('validate' | 'stage' | 'commit' | 'push')
  so the frontend can label which step failed; commit failures
  auto-rollback the staging area via `reject()`.
- Widened `StageClosePositionParams.qty` from `number` to
  `number | string` to match what `stagePlaceOrder` already accepts;
  runtime impl was already calling `new Decimal(String(qty))`.
- New `OrderEntryDialog` (two modes: `place` / `close`) with
  string-typed numeric inputs, advanced toggle for cash qty + TIF,
  required commit message, and a `PushResultPanel` showing the full
  `WalletPushResult` (per-op submitted/rejected with status, fill
  price, error). The async-status note explains "Submitted" vs
  "Filled" so the user knows what to watch for.
- Three entry points wired up:
  1. UTA detail page header — new `+ Place Order` button.
  2. Position row `Close` button — opens dialog in close mode
     pre-filled with that position's aliceId + qty.
  3. Portfolio/Market workbench `TradeableContractsPanel` — each row
     gets `Order →` link → `/uta/{source}?aliceId=...`. UTA detail
     page reads the query param via `useSearchParams` and auto-opens
     the dialog with the prefill.
- After successful push the dialog's `onPushComplete` triggers an
  immediate `refreshLive()` on the UTA detail page, bypassing the
  15s polling tick so the new position/order appears right away.
- 15 new route tests covering happy paths, missing message,
  missing qty, phase=stage/commit/push errors, 404 unknown UTA, and
  a string-precision regression sending `qty="0.123456789012345"`
  through and asserting it reaches the staging layer as that exact
  string (no float roundtrip).
- Drive-by fix (`003d7bb`): `uta-lifecycle.e2e.spec.ts` had 4
  assertions comparing `account.totalCashValue` / `position.avgCost`
  (now strings post the Decimal migration in `3fe9464`) against
  number literals. Pre-existing breakage caught while running the
  broader e2e suite to verify this PR didn't regress.
- Key commits: `715ec7e`, `003d7bb`

## Full commit log

```
003d7bb fix(test): uta-lifecycle e2e — string vs number assertions
715ec7e feat(uta): manual order entry from frontend
4bfe0e9 feat(uta): detail page at /uta/:id + UTA-naming pass top-to-bottom
```

## Test plan

- [x] `npx tsc --noEmit` clean (root + ui/)
- [x] `pnpm test` — 1187 / 60 files pass (1172 + 15 new route tests)
- [x] `pnpm test:e2e` broker level: ccxt-bybit, ccxt-hyperliquid,
      alpaca-paper, ccxt-okx all pass (22 + 10 = 32 / 32)
- [x] `pnpm test:e2e` UTA level: uta-bybit, uta-alpaca,
      uta-ccxt-bybit, uta-lifecycle all pass after the lifecycle fix
- [x] `pnpm test:e2e ccxt-okx` — still 10/10 (rename + order-entry
      didn't touch broker resolution)
- [ ] Manual UI smoke: navigate `/uta/<id>`, click `+ Place Order`,
      submit a small market buy with a commit message, confirm push
      result panel shows submitted op with status + orderId, then
      positions table auto-refreshes within ~1s.
- [ ] Manual UI smoke: position row `Close` button, confirm pre-fill
      + qty override, submit, position drops out of the list.
- [ ] Manual UI smoke: from `/market/equity/<symbol>` find
      TradeableContractsPanel `Order →` link, click, confirm dialog
      opens pre-filled with the aliceId.
- [ ] Async-exposure check: market buy on a low-liquidity contract,
      observe `submitted[].status === 'Submitted'` initially, then
      transition to `Filled` after a short wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

