### PR TITLE
docs(readme): community + nav badge rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/TraderAlice/OpenAlice/actions/workflows/ci.yml"><img src="https://github.com/TraderAlice/OpenAlice/actions/workflows/ci.yml/badge.svg" alt="CI"></a> · <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a> · <a href="https://openalice.ai"><img src="https://img.shields.io/badge/Website-openalice.ai-blue" alt="openalice.ai"></a> · <a href="https://openalice.ai/docs"><img src="https://img.shields.io/badge/Docs-Read-green" alt="Docs"></a> · <a href="https://deepwiki.com/TraderAlice/OpenAlice"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+  <a href="https://openalice.ai"><img src="https://img.shields.io/badge/Website-blue" alt="Website"></a> · <a href="https://openalice.ai/docs"><img src="https://img.shields.io/badge/Docs-green" alt="Docs"></a> · <a href="https://x.com/OpenAliceAI"><img src="https://img.shields.io/badge/X-000000?logo=x&logoColor=white" alt="X (Twitter)"></a> · <a href="https://discord.gg/zf4STmrQd8"><img src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white" alt="Discord"></a> · <a href="https://qm.qq.com/q/iSg6O4FmrC"><img src="https://img.shields.io/badge/QQ-12B7F5" alt="QQ"></a>
 </p>
 
 <p align="center">
@@ -189,6 +189,18 @@ OpenAlice is in pre-release. All planned v1 milestones are now complete — rema
 - [x] **IBKR broker** — Interactive Brokers integration via TWS/Gateway. `IbkrBroker` bridges the callback-based `@traderalice/ibkr` SDK to the Promise-based `IBroker` interface via `RequestBridge`. Supports all IBroker methods including conId-based contract resolution
 - [x] **Account snapshot & analytics** — periodic and event-driven snapshots with equity curve visualization, configurable intervals, and carry-forward for data gaps
 
+## Getting Help
+
+Stuck? Here's the recommended path, roughly in order:
+
+1. **Let an AI agent fix it** — Claude Code, Cursor, or any other coding agent can read the codebase and patch most issues directly. Fastest path for bugs and "how do I do X" questions
+2. **[Ask DeepWiki](https://deepwiki.com/TraderAlice/OpenAlice)** — natural-language Q&A over the entire codebase, good for architectural questions and figuring out where to look
+3. **Community** — [Discord](https://discord.gg/zf4STmrQd8) for English speakers, [QQ 群](https://qm.qq.com/q/iSg6O4FmrC) for 中文开发者. For things AI can't answer — design discussions, edge cases, or just hanging out
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=TraderAlice/OpenAlice&type=Date)](https://star-history.com/#TraderAlice/OpenAlice&Date)
+
+## License
+
+[AGPL-3.0](LICENSE)


### PR DESCRIPTION
## Summary

Header rework on README: replace status/license/wiki badges with a clean nav row of label-only chips (Website, Docs, X, Discord, QQ). Adds a "Getting Help" section pointing users at AI agents → DeepWiki → community channels, and moves License to a small footer.

## Per-session contributions

### 2026-04-30 — README community + nav badge rework
- Replace top badge row with five label-only nav chips (Website, Docs, X, Discord, QQ); drop CI/License/DeepWiki from the header
- Add Getting Help section pointing to AI agents → DeepWiki → community
- Move License to a small footer section after Star History
- Set TraderAlice org twitter_username=OpenAliceAI and blog=https://openalice.ai on GitHub
- Key commit: 4838713

## Full commit log

\`\`\`
4838713 docs(readme): rework header badges, add community + getting help
\`\`\`

## Test plan

- [x] tsc --noEmit clean (docs-only change, no code touched)
- [x] pnpm test passes (docs-only change)
- [ ] Verify all 5 badges render with correct colors/icons on GitHub
- [ ] Verify links (Website, Docs, X, Discord, QQ) all resolve
- [ ] Verify Discord merge webhook fires on this PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)