### PR TITLE
fix(brokers/longbridge): live mark price + options/warrants multiplier

### DIFF
--- a/src/domain/trading/brokers/ibkr/request-bridge.ts
+++ b/src/domain/trading/brokers/ibkr/request-bridge.ts
@@ -463,9 +463,12 @@ export class RequestBridge extends DefaultEWrapper {
       quantity: position.abs(),
       avgCost: averageCost,
       marketPrice,
+      // TWS already bakes contract.multiplier into marketValue — we
+      // surface the multiplier as metadata only, no math here.
       marketValue: new Decimal(marketValue).abs().toString(),
       unrealizedPnL: unrealizedPNL,
       realizedPnL: realizedPNL,
+      multiplier: contract.multiplier || '1',
     })
   }
 

--- a/src/domain/trading/brokers/longbridge/LongbridgeBroker.spec.ts
+++ b/src/domain/trading/brokers/longbridge/LongbridgeBroker.spec.ts
@@ -63,6 +63,8 @@ function attachMockContexts(broker: LongbridgeBroker): {
     depth: vi.fn(),
     staticInfo: vi.fn(),
     tradingSession: vi.fn(),
+    optionQuote: vi.fn(),
+    warrantQuote: vi.fn(),
   }
   ;(broker as unknown as { tradeCtx: typeof trade; quoteCtx: typeof quote }).tradeCtx = trade
   ;(broker as unknown as { tradeCtx: typeof trade; quoteCtx: typeof quote }).quoteCtx = quote
@@ -386,6 +388,144 @@ describe('LongbridgeBroker — getPositions()', () => {
     const [p] = await b.getPositions()
     expect(p.side).toBe('short')
     expect(p.quantity.toString()).toBe('100')
+  })
+
+  it('uses live lastDone from quote() as marketPrice (not costPrice)', async () => {
+    const b = makeBroker()
+    const { trade, quote } = attachMockContexts(b)
+    trade.stockPositions.mockResolvedValue({
+      channels: [{ accountChannel: 'HK', positions: [
+        { symbol: '700.HK', symbolName: 'Tencent', quantity: dec('200'), costPrice: dec('300'), currency: 'HKD', market: 2 },
+      ] }],
+    })
+    quote.quote.mockResolvedValue([{ symbol: '700.HK', lastDone: dec('350') }])
+    quote.staticInfo.mockResolvedValue([{ symbol: '700.HK', stockDerivatives: [], lotSize: 100 }])
+
+    const [p] = await b.getPositions()
+    expect(p.avgCost).toBe('300')
+    expect(p.marketPrice).toBe('350')                  // live, not costPrice
+    expect(p.marketPrice).not.toBe(p.avgCost)          // bug 1 regression guard
+    expect(p.marketValue).toBe('70000')                // 200 * 350 * 1
+    expect(p.unrealizedPnL).toBe('10000')              // (350-300) * 200 * 1
+    expect(p.multiplier).toBe('1')
+  })
+
+  it('falls back to costPrice when quote() fails for the symbol', async () => {
+    const b = makeBroker()
+    const { trade, quote } = attachMockContexts(b)
+    trade.stockPositions.mockResolvedValue({
+      channels: [{ accountChannel: 'HK', positions: [
+        { symbol: '700.HK', symbolName: '', quantity: dec('100'), costPrice: dec('300'), currency: 'HKD', market: 2 },
+      ] }],
+    })
+    quote.quote.mockRejectedValue(new Error('rate limited'))
+
+    const [p] = await b.getPositions()
+    expect(p.marketPrice).toBe('300')                  // fallback to cost
+    expect(p.marketValue).toBe('30000')                // 100 * 300 * 1
+    expect(p.unrealizedPnL).toBe('0')                  // mark==cost → 0 PnL
+  })
+
+  it('applies 100x multiplier to US options (contractMultiplier from optionQuote)', async () => {
+    const b = makeBroker()
+    const { trade, quote } = attachMockContexts(b)
+    trade.stockPositions.mockResolvedValue({
+      channels: [{ accountChannel: 'US', positions: [
+        // 1 contract of an AAPL call, $5.50 cost basis, current $7.00
+        { symbol: 'AAPL241220C00200000.US', symbolName: 'AAPL Call', quantity: dec('1'), costPrice: dec('5.5'), currency: 'USD', market: 1 },
+      ] }],
+    })
+    quote.quote.mockResolvedValue([{ symbol: 'AAPL241220C00200000.US', lastDone: dec('7') }])
+    quote.staticInfo.mockResolvedValue([
+      { symbol: 'AAPL241220C00200000.US', stockDerivatives: [0 /* Option */], lotSize: 100 },
+    ])
+    quote.optionQuote.mockResolvedValue([
+      { symbol: 'AAPL241220C00200000.US', contractMultiplier: dec('100') },
+    ])
+
+    const [p] = await b.getPositions()
+    expect(p.multiplier).toBe('100')
+    expect(p.marketPrice).toBe('7')
+    expect(p.marketValue).toBe('700')                  // 1 * 7 * 100 — was 7 before fix
+    expect(p.unrealizedPnL).toBe('150')                // (7-5.5) * 1 * 100
+  })
+
+  it('applies conversionRatio multiplier to HK warrants', async () => {
+    const b = makeBroker()
+    const { trade, quote } = attachMockContexts(b)
+    trade.stockPositions.mockResolvedValue({
+      channels: [{ accountChannel: 'HK', positions: [
+        { symbol: '21125.HK', symbolName: 'HSI Warrant', quantity: dec('10000'), costPrice: dec('0.20'), currency: 'HKD', market: 2 },
+      ] }],
+    })
+    quote.quote.mockResolvedValue([{ symbol: '21125.HK', lastDone: dec('0.25') }])
+    quote.staticInfo.mockResolvedValue([
+      { symbol: '21125.HK', stockDerivatives: [1 /* Warrant */], lotSize: 1000 },
+    ])
+    quote.warrantQuote.mockResolvedValue([
+      { symbol: '21125.HK', conversionRatio: dec('0.1') },  // 1 warrant ↔ 0.1 share
+    ])
+
+    const [p] = await b.getPositions()
+    expect(p.multiplier).toBe('0.1')
+    expect(p.marketPrice).toBe('0.25')
+    expect(p.marketValue).toBe('250')                  // 10000 * 0.25 * 0.1
+    // (0.25 - 0.2) * 10000 * 0.1 = 50
+    expect(new Decimal(p.unrealizedPnL).toFixed(0)).toBe('50')
+  })
+
+  it('mixes plain stock + option in one batch correctly', async () => {
+    const b = makeBroker()
+    const { trade, quote } = attachMockContexts(b)
+    trade.stockPositions.mockResolvedValue({
+      channels: [{ accountChannel: 'US', positions: [
+        { symbol: 'TSLA.US', symbolName: 'Tesla', quantity: dec('10'), costPrice: dec('200'), currency: 'USD', market: 1 },
+        { symbol: 'TSLA241220C00250000.US', symbolName: 'TSLA Call', quantity: dec('2'), costPrice: dec('3'), currency: 'USD', market: 1 },
+      ] }],
+    })
+    quote.quote.mockResolvedValue([
+      { symbol: 'TSLA.US', lastDone: dec('210') },
+      { symbol: 'TSLA241220C00250000.US', lastDone: dec('4') },
+    ])
+    quote.staticInfo.mockResolvedValue([
+      { symbol: 'TSLA.US', stockDerivatives: [], lotSize: 1 },
+      { symbol: 'TSLA241220C00250000.US', stockDerivatives: [0], lotSize: 100 },
+    ])
+    quote.optionQuote.mockResolvedValue([
+      { symbol: 'TSLA241220C00250000.US', contractMultiplier: dec('100') },
+    ])
+
+    const positions = await b.getPositions()
+    const stock = positions.find(p => p.contract.localSymbol === 'TSLA.US')!
+    const opt = positions.find(p => p.contract.localSymbol === 'TSLA241220C00250000.US')!
+    expect(stock.multiplier).toBe('1')
+    expect(stock.marketValue).toBe('2100')             // 10 * 210 * 1
+    expect(opt.multiplier).toBe('100')
+    expect(opt.marketValue).toBe('800')                // 2 * 4 * 100
+  })
+
+  it('staticInfo failure → all positions degrade to multiplier=1 (does not throw)', async () => {
+    const b = makeBroker()
+    const { trade, quote } = attachMockContexts(b)
+    trade.stockPositions.mockResolvedValue({
+      channels: [{ accountChannel: 'US', positions: [
+        { symbol: 'AAPL241220C00200000.US', symbolName: '', quantity: dec('1'), costPrice: dec('5.5'), currency: 'USD', market: 1 },
+      ] }],
+    })
+    quote.quote.mockResolvedValue([{ symbol: 'AAPL241220C00200000.US', lastDone: dec('7') }])
+    quote.staticInfo.mockRejectedValue(new Error('boom'))
+
+    const [p] = await b.getPositions()
+    expect(p.multiplier).toBe('1')                     // graceful degrade
+    expect(p.marketPrice).toBe('7')                    // live quote still works
+    expect(p.marketValue).toBe('7')                    // 1 * 7 * 1 (under-counts but doesn't throw)
+  })
+
+  it('still throws BrokerError when stockPositions itself fails', async () => {
+    const b = makeBroker()
+    const { trade } = attachMockContexts(b)
+    trade.stockPositions.mockRejectedValue(new Error('500 Internal Server Error'))
+    await expect(b.getPositions()).rejects.toThrow(/Internal Server Error/)
   })
 })
 

--- a/src/domain/trading/brokers/longbridge/LongbridgeBroker.ts
+++ b/src/domain/trading/brokers/longbridge/LongbridgeBroker.ts
@@ -53,11 +53,19 @@ import type {
   LongbridgeBrokerConfig,
   LongbridgeAccountBalanceLike,
   LongbridgeStockPositionsResponseLike,
+  LongbridgeStockPositionLike,
   LongbridgeSecurityQuoteLike,
   LongbridgeSecurityDepthLike,
   LongbridgeOrderLike,
   LongbridgeMarketSessionLike,
+  LongbridgeStaticInfoLike,
+  LongbridgeOptionQuoteLike,
+  LongbridgeWarrantQuoteLike,
 } from './longbridge-types.js'
+
+// Longbridge SDK DerivativeType enum (mirrors `const enum DerivativeType`).
+const DERIVATIVE_OPTION = 0
+const DERIVATIVE_WARRANT = 1
 
 // ==================== Order-type translation ====================
 
@@ -436,37 +444,166 @@ export class LongbridgeBroker implements IBroker {
     return new Decimal(fxFrom.usd).div(new Decimal(fxTo.usd))
   }
 
+  /**
+   * Multi-stage position fetch:
+   *   1. stockPositions()       → cost / qty / currency / symbol
+   *   2. quote()  + staticInfo() → live mark price + derivative-type detection (parallel)
+   *   3. optionQuote() + warrantQuote() → multiplier metadata (parallel)
+   *
+   * stockPositions returns options and warrants under the same channels
+   * as plain stocks but does NOT identify the type or carry a multiplier
+   * — staticInfo's `stockDerivatives` field is the discriminator, and
+   * optionQuote/warrantQuote carry the actual multiplier values.
+   *
+   * Each enrichment call is independently fault-tolerant: a failure
+   * downgrades that field to a safe default (marketPrice → cost,
+   * multiplier → '1') rather than aborting the whole fetch. UI degrades
+   * gracefully instead of blanking the positions panel.
+   */
   async getPositions(): Promise<Position[]> {
+    let resp: LongbridgeStockPositionsResponseLike
     try {
-      const resp = (await this.tradeCtx.stockPositions()) as unknown as LongbridgeStockPositionsResponseLike
-      const out: Position[] = []
-      for (const channel of resp.channels) {
-        for (const p of channel.positions) {
-          const qty = new Decimal(p.quantity.toString())
-          if (qty.isZero()) continue
-          const contract = makeContract(p.symbol)
-          if (p.symbolName) contract.description = p.symbolName
-          const cost = new Decimal(p.costPrice.toString())
-          out.push({
-            contract,
-            currency: p.currency.toUpperCase(),
-            side: qty.gte(0) ? 'long' : 'short',
-            quantity: qty.abs(),
-            avgCost: cost.toString(),
-            // LB does not return live mark price on stockPositions —
-            // leave at cost so marketValue is conservative; UTA snapshot
-            // can refresh via getQuote() if needed.
-            marketPrice: cost.toString(),
-            marketValue: cost.times(qty.abs()).toString(),
-            unrealizedPnL: '0',
-            realizedPnL: '0',
-          })
-        }
-      }
-      return out
+      resp = (await this.tradeCtx.stockPositions()) as unknown as LongbridgeStockPositionsResponseLike
     } catch (err) {
       throw BrokerError.from(err)
     }
+
+    const rawPositions: LongbridgeStockPositionLike[] = []
+    for (const channel of resp.channels) {
+      for (const p of channel.positions) {
+        const qty = new Decimal(p.quantity.toString())
+        if (qty.isZero()) continue
+        rawPositions.push(p)
+      }
+    }
+    if (rawPositions.length === 0) return []
+
+    const symbols = Array.from(new Set(rawPositions.map(p => p.symbol)))
+
+    // ---- Stage 2: live quotes + static-info in parallel ----
+    const [quoteMap, staticMap] = await Promise.all([
+      this.fetchQuoteMap(symbols),
+      this.fetchStaticInfoMap(symbols),
+    ])
+
+    // Bucket symbols by derivative type from staticInfo. Symbols not
+    // present in the staticInfo map are treated as plain equity.
+    const optionSymbols: string[] = []
+    const warrantSymbols: string[] = []
+    for (const s of symbols) {
+      const derivs = staticMap.get(s)
+      if (!derivs) continue
+      if (derivs.includes(DERIVATIVE_OPTION)) optionSymbols.push(s)
+      else if (derivs.includes(DERIVATIVE_WARRANT)) warrantSymbols.push(s)
+    }
+
+    // ---- Stage 3: per-derivative multiplier in parallel ----
+    const [optMulMap, warMulMap] = await Promise.all([
+      this.fetchOptionMultiplierMap(optionSymbols),
+      this.fetchWarrantMultiplierMap(warrantSymbols),
+    ])
+
+    return rawPositions.map(p => this.buildPosition(p, quoteMap, optMulMap, warMulMap))
+  }
+
+  private buildPosition(
+    p: LongbridgeStockPositionLike,
+    quoteMap: Map<string, Decimal>,
+    optMulMap: Map<string, Decimal>,
+    warMulMap: Map<string, Decimal>,
+  ): Position {
+    const qty = new Decimal(p.quantity.toString())
+    const contract = makeContract(p.symbol)
+    if (p.symbolName) contract.description = p.symbolName
+    const cost = new Decimal(p.costPrice.toString())
+    const live = quoteMap.get(p.symbol)
+    const marketPrice = live ?? cost
+    const multiplier = optMulMap.get(p.symbol) ?? warMulMap.get(p.symbol) ?? new Decimal(1)
+    const absQty = qty.abs()
+    const marketValue = marketPrice.times(absQty).times(multiplier)
+    const unrealizedPnL = marketPrice.minus(cost).times(absQty).times(multiplier)
+    return {
+      contract,
+      currency: p.currency.toUpperCase(),
+      side: qty.gte(0) ? 'long' : 'short',
+      quantity: absQty,
+      avgCost: cost.toString(),
+      marketPrice: marketPrice.toString(),
+      marketValue: marketValue.toString(),
+      unrealizedPnL: unrealizedPnL.toString(),
+      realizedPnL: '0',
+      multiplier: multiplier.toString(),
+    }
+  }
+
+  /** Batch-fetch live `lastDone` for a symbol set. Returns empty map on failure. */
+  private async fetchQuoteMap(symbols: string[]): Promise<Map<string, Decimal>> {
+    const map = new Map<string, Decimal>()
+    if (symbols.length === 0) return map
+    try {
+      const quotes = (await this.quoteCtx.quote(symbols)) as unknown as LongbridgeSecurityQuoteLike[]
+      for (const q of quotes) {
+        map.set(q.symbol, new Decimal(q.lastDone.toString()))
+      }
+    } catch (err) {
+      console.warn(`LongbridgeBroker[${this.id}]: live-quote enrichment failed, falling back to costPrice:`,
+        err instanceof Error ? err.message : err)
+    }
+    return map
+  }
+
+  /** Batch-fetch staticInfo for derivative-type detection. Returns empty map on failure. */
+  private async fetchStaticInfoMap(symbols: string[]): Promise<Map<string, number[]>> {
+    const map = new Map<string, number[]>()
+    if (symbols.length === 0) return map
+    try {
+      const infos = await (this.quoteCtx as unknown as {
+        staticInfo: (s: string[]) => Promise<LongbridgeStaticInfoLike[]>
+      }).staticInfo(symbols)
+      for (const info of infos) {
+        map.set(info.symbol, info.stockDerivatives ?? [])
+      }
+    } catch (err) {
+      console.warn(`LongbridgeBroker[${this.id}]: staticInfo lookup failed, treating all positions as plain equity:`,
+        err instanceof Error ? err.message : err)
+    }
+    return map
+  }
+
+  /** Batch-fetch option contract multipliers. Returns empty map on failure. */
+  private async fetchOptionMultiplierMap(symbols: string[]): Promise<Map<string, Decimal>> {
+    const map = new Map<string, Decimal>()
+    if (symbols.length === 0) return map
+    try {
+      const quotes = await (this.quoteCtx as unknown as {
+        optionQuote: (s: string[]) => Promise<LongbridgeOptionQuoteLike[]>
+      }).optionQuote(symbols)
+      for (const q of quotes) {
+        map.set(q.symbol, new Decimal(q.contractMultiplier.toString()))
+      }
+    } catch (err) {
+      console.warn(`LongbridgeBroker[${this.id}]: optionQuote failed for ${symbols.length} symbols, multiplier defaults to 1:`,
+        err instanceof Error ? err.message : err)
+    }
+    return map
+  }
+
+  /** Batch-fetch warrant conversion ratios. Returns empty map on failure. */
+  private async fetchWarrantMultiplierMap(symbols: string[]): Promise<Map<string, Decimal>> {
+    const map = new Map<string, Decimal>()
+    if (symbols.length === 0) return map
+    try {
+      const quotes = await (this.quoteCtx as unknown as {
+        warrantQuote: (s: string[]) => Promise<LongbridgeWarrantQuoteLike[]>
+      }).warrantQuote(symbols)
+      for (const q of quotes) {
+        map.set(q.symbol, new Decimal(q.conversionRatio.toString()))
+      }
+    } catch (err) {
+      console.warn(`LongbridgeBroker[${this.id}]: warrantQuote failed for ${symbols.length} symbols, multiplier defaults to 1:`,
+        err instanceof Error ? err.message : err)
+    }
+    return map
   }
 
   async getOrders(orderIds: string[]): Promise<OpenOrder[]> {

--- a/src/domain/trading/brokers/longbridge/longbridge-types.ts
+++ b/src/domain/trading/brokers/longbridge/longbridge-types.ts
@@ -89,6 +89,31 @@ export interface LongbridgeOrderLike {
   msg: string
 }
 
+/** Subset of {@link SecurityStaticInfo} we read for derivative-type detection. */
+export interface LongbridgeStaticInfoLike {
+  symbol: string
+  /**
+   * Numeric DerivativeType enum values from the SDK (Option=0, Warrant=1).
+   * Empty array → plain equity / fund.
+   */
+  stockDerivatives: number[]
+  lotSize: number
+}
+
+/** Subset of {@link OptionQuote} we read. */
+export interface LongbridgeOptionQuoteLike {
+  symbol: string
+  /** Shares per contract (US equity options usually 100). */
+  contractMultiplier: { toString(): string }
+}
+
+/** Subset of {@link WarrantQuote} we read. */
+export interface LongbridgeWarrantQuoteLike {
+  symbol: string
+  /** Shares delivered per warrant on conversion (issuer-specific). */
+  conversionRatio: { toString(): string }
+}
+
 /** Subset of {@link MarketTradingSession} we read. */
 export interface LongbridgeMarketSessionLike {
   market: number

--- a/src/domain/trading/brokers/types.ts
+++ b/src/domain/trading/brokers/types.ts
@@ -77,6 +77,17 @@ export interface Position {
   marketValue: string
   unrealizedPnL: string
   realizedPnL: string
+  /**
+   * Shares-per-contract metadata: how many underlying shares one
+   * unit of `quantity` represents. `'1'` for plain stocks; `'100'`
+   * for US equity options; HK warrants/CBBCs use the issuer-specific
+   * conversion ratio (often a non-integer like '0.1' or '10').
+   *
+   * `marketValue` is already multiplier-applied at the broker layer —
+   * this field is metadata for UI / analytics ("1 contract = 100
+   * shares"), not a math input. Consumers must NOT re-apply.
+   */
+  multiplier?: string
 }
 
 // ==================== Order result ====================


### PR DESCRIPTION
## Summary

Bug fixes for LongbridgeBroker.getPositions() — two community-reported
issues with the same underlying root cause: the broker layer wasn't
fetching enough information per position to populate Position fields
correctly.

## Per-session contributions

### 2026-05-03 — Longbridge position-fetch correctness

**Bug 1 — avgCost == marketPrice**: The original implementation copied
`costPrice` into `marketPrice` as a fallback because LB's
`stockPositions()` doesn't return live mark. Now batch-fetch live
quotes via `quote([symbols])` and use real `lastDone`; fall back to
costPrice only when the quote call itself fails.

**Bug 2 — options/warrants under-counted by 100x**: LB returns
derivatives through the same `stockPositions()` channels as plain
stocks but doesn't identify them or expose a multiplier. Now detect
via `staticInfo()` → `stockDerivatives`, then resolve the multiplier
via `optionQuote()` (US: `contractMultiplier`, typically 100) or
`warrantQuote()` (HK: `conversionRatio`, issuer-specific).
`marketValue` and `unrealizedPnL` correctly include the multiplier.

**Adjacent structural fix**: `Position` interface gains optional
`multiplier?: string` metadata field. `Contract.multiplier` was on the
type but had zero downstream readers across the codebase — Alpaca only
does stocks, IBKR's TWS bakes multiplier into marketValue server-side
so the field never bubbled up. Now both LongbridgeBroker (computed)
and IbkrBroker (passed through from `contract.multiplier`) surface it
for UI / analytics. No math change in IBKR — TWS still authoritative.

**Fault tolerance**: Each enrichment call is independently wrapped —
quote / staticInfo / optionQuote / warrantQuote failures degrade the
relevant field (marketPrice → cost; multiplier → 1) instead of taking
down the whole positions fetch. Only `stockPositions()` itself failing
still propagates as `BrokerError`.

7 new unit tests (live mark path, quote fallback, US opts 100x, HK
warrants ratio, mixed batch, staticInfo failure resilience, stockPositions
propagation). 1297 tests green; tsc clean. Live verification gated on
user-supplied LB paper credentials.

Key commit: \`08573a7\`

## Full commit log

\`\`\`
08573a7 fix(brokers/longbridge): live mark price + options/warrants multiplier
\`\`\`

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`pnpm test\` passes (1297 tests, 62 files)
- [ ] LB paper account: hold 1 US option + 1 HK warrant + 1 plain HK stock; verify all three show distinct \`marketPrice\` (≠ avgCost) and correct \`marketValue\` (multiplier applied)
- [ ] IBKR paper account: confirm \`Position.multiplier\` is '100' for option positions and '1' / undefined for stocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)