### PR TITLE
Simulator console + derived UTA id + multi-asset MockBroker fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,6 +45,18 @@ the item when done — git log is the history.
 
 ## Architecture
 
+- [ ] Extract `derivePositionMath(raw): { marketValue, unrealizedPnL }`
+      shared util. Today's IBroker contract requires every broker's
+      `getPositions` to multiply by `multiplier` when computing
+      marketValue / unrealizedPnL — but it's documentation-only, no
+      enforcement. Production brokers happen to dodge it because their
+      primary markets all have multiplier=1 (CCXT spot/perp) or the
+      upstream API hands back pre-multiplied values (Alpaca, IBKR).
+      First broker to grow custom OPT/FUT math will repeat Mock's
+      bug shape (cash-flow / marketValue / PnL all need multiplier).
+      Replace per-broker computation with one shared derive call;
+      brokers emit raw fields (qty, markPrice, multiplier, side,
+      avgCost) and downstream math is contract-uniform.
 - [ ] Unified config hot-reload. Right now every consumer of a config
       section has to solve "did the user edit this?" on its own —
       Telegram/MCP-Ask via `reconnectConnectors`, opentypebb via lazy

--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,15 @@ the item when done — git log is the history.
       entirely on localhost binding. Needs a proper auth story (shared
       admin token? session cookies? per-route scopes?) before any of it
       is exposed beyond a single-user local machine.
+- [ ] Retire `PUT /api/trading/config/uta/:id` once all on-disk UTAs
+      have derived ids. The route still accepts a full `UTAConfig` body
+      including credentials (we unmask masked values from the existing
+      record before re-saving) — that's a credential-handling surface
+      we'd rather not keep around long-term. Replacement: a narrower
+      `PATCH /uta/:id` that only allows label / guards / enabled
+      changes; credential rotation goes via DELETE + new POST. Wait
+      until the user-typed-id legacy UTAs have all migrated naturally
+      so we don't break edits on existing accounts.
 - [ ] Webhook tokens: add admin UI for listing / adding / rotating
       tokens inside the Webhook tab instead of requiring hand-editing
       `data/config/webhook.json`. Config surface exists; just missing

--- a/src/domain/trading/UnifiedTradingAccount.ts
+++ b/src/domain/trading/UnifiedTradingAccount.ts
@@ -558,7 +558,11 @@ export class UnifiedTradingAccount {
       if (!final) continue  // Should be unreachable — reconcile would seed it.
 
       p.avgCost = final.avgCost.toString()
-      const pnl = p.quantity.mul(new Decimal(p.marketPrice).minus(final.avgCost))
+      // Per IBroker.Position contract, unrealizedPnL is multiplier-applied;
+      // cost-basis WAC operates on per-unit prices, so the multiplier has
+      // to be reapplied here. Defaults to 1 for stocks / crypto.
+      const multiplier = p.multiplier && p.multiplier !== '' ? new Decimal(p.multiplier) : new Decimal(1)
+      const pnl = p.quantity.mul(new Decimal(p.marketPrice).minus(final.avgCost)).mul(multiplier)
       p.unrealizedPnL = pnl.toString()
     }
   }

--- a/src/domain/trading/brokers/mock/MockBroker.spec.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.spec.ts
@@ -518,3 +518,111 @@ describe('position keying — placeOrder and externalDeposit converge', () => {
     expect(positions[0].quantity.toString()).toBe('1.5')
   })
 })
+
+// ==================== Multi-asset / multiplier discipline ====================
+//
+// IBroker.Position contract requires `marketValue` and `unrealizedPnL` to
+// be multiplier-applied at the broker layer; cash flow on BUY/SELL must
+// likewise debit/credit `qty × price × multiplier`. A live QA run on
+// 2026-05-07 found three bug shapes from violating this:
+//   1. cash flow missed multiplier (BUY 3 OPT @50 dropped $150 not $15,000)
+//   2. resolveNativeKey returned a STK stub, losing secType/multiplier
+//      when re-ordering an aliceId after a position was sold flat
+//   3. oversell silently filled (SELL 999 BTC against 0.01 BTC) and
+//      phantom-credited cash
+// These tests pin those down.
+
+describe('multiplier discipline (regression)', () => {
+  it('BUY of OPT contracts debits cash by qty × price × multiplier (×100)', async () => {
+    const Decimal = (await import('decimal.js')).default
+    const { Order, Contract } = await import('@traderalice/ibkr')
+
+    const acc = new MockBroker({ id: 'mock-paper', cash: 100_000 })
+    acc.setMarkPrice('AAPL-20260720-C150', 50)
+    // Seed position via deposit so OPT contract is in the registry
+    acc.externalDeposit({
+      nativeKey: 'AAPL-20260720-C150',
+      quantity: 1,
+      contract: {
+        symbol: 'AAPL', secType: 'OPT', localSymbol: 'AAPL-20260720-C150',
+        lastTradeDateOrContractMonth: '20260720', strike: 150, right: 'C', multiplier: '100',
+      },
+    })
+
+    // BUY 3 more contracts at premium 50 — should drop cash by 3 × 50 × 100 = 15,000
+    const cashBefore = (await acc.getAccount()).totalCashValue
+    const contract = acc.resolveNativeKey('AAPL-20260720-C150')
+    contract.aliceId = 'mock-paper|AAPL-20260720-C150'
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'MKT'
+    order.totalQuantity = new Decimal(3)
+    await acc.placeOrder(contract, order)
+
+    const cashAfter = (await acc.getAccount()).totalCashValue
+    const dropped = new Decimal(cashBefore).minus(cashAfter)
+    expect(dropped.toNumber()).toBe(15_000)
+  })
+
+  it('resolveNativeKey returns the original Contract (preserves OPT metadata) after sell-down', async () => {
+    const Decimal = (await import('decimal.js')).default
+    const { Order } = await import('@traderalice/ibkr')
+
+    const acc = new MockBroker({ id: 'mock-paper', cash: 200_000 })
+    acc.setMarkPrice('AAPL-20260720-C150', 50)
+    acc.externalDeposit({
+      nativeKey: 'AAPL-20260720-C150',
+      quantity: 5,
+      contract: {
+        symbol: 'AAPL', secType: 'OPT', localSymbol: 'AAPL-20260720-C150',
+        lastTradeDateOrContractMonth: '20260720', strike: 150, right: 'C', multiplier: '100',
+      },
+    })
+
+    // Sell all 5 to clear the position from _positions
+    const sellContract = acc.resolveNativeKey('AAPL-20260720-C150')
+    sellContract.aliceId = 'mock-paper|AAPL-20260720-C150'
+    const sellOrder = new Order()
+    sellOrder.action = 'SELL'
+    sellOrder.orderType = 'MKT'
+    sellOrder.totalQuantity = new Decimal(5)
+    await acc.placeOrder(sellContract, sellOrder)
+    expect(await acc.getPositions()).toHaveLength(0)
+
+    // Re-resolve: registry must remember the OPT metadata.
+    const reresolved = acc.resolveNativeKey('AAPL-20260720-C150')
+    expect(reresolved.secType).toBe('OPT')
+    expect(reresolved.multiplier).toBe('100')
+    expect(reresolved.strike).toBe(150)
+    expect(reresolved.right).toBe('C')
+    expect(reresolved.lastTradeDateOrContractMonth).toBe('20260720')
+  })
+
+  it('SELL beyond held quantity rejects without phantom-crediting cash', async () => {
+    const Decimal = (await import('decimal.js')).default
+    const { Order } = await import('@traderalice/ibkr')
+
+    const acc = new MockBroker({ id: 'mock-paper', cash: 100_000 })
+    acc.setMarkPrice('BTC', 80_000)
+    acc.externalDeposit({ nativeKey: 'BTC', quantity: 0.01 })
+
+    const cashBefore = (await acc.getAccount()).totalCashValue
+
+    const contract = acc.resolveNativeKey('BTC')
+    contract.aliceId = 'mock-paper|BTC'
+    const order = new Order()
+    order.action = 'SELL'
+    order.orderType = 'MKT'
+    order.totalQuantity = new Decimal(999)
+
+    const result = await acc.placeOrder(contract, order)
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/cannot SELL/i)
+
+    const cashAfter = (await acc.getAccount()).totalCashValue
+    expect(cashAfter).toBe(cashBefore)
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].quantity.toNumber()).toBeCloseTo(0.01)
+  })
+})

--- a/src/domain/trading/brokers/mock/MockBroker.spec.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.spec.ts
@@ -425,3 +425,96 @@ describe('factory helpers', () => {
     expect(r.orderId).toBe('order-1')
   })
 })
+
+// ==================== Position-key consistency ====================
+//
+// Regression: positions placed via the IBroker pipeline (where UTA stamps
+// `aliceId` like "simulator|BTC") and positions injected via the simulator
+// surface (`externalDeposit`, keyed by user-supplied nativeKey "BTC")
+// must land in the same map slot. Previously _applyFill used
+// `aliceId ?? symbol` while externalDeposit used the bare nativeKey, so
+// the same logical asset showed up as TWO positions in the simulator UI.
+
+describe('position keying — placeOrder and externalDeposit converge', () => {
+  it('externalDeposit + market BUY on same symbol merge into one position', async () => {
+    const Decimal = (await import('decimal.js')).default
+    const { Order, Contract } = await import('@traderalice/ibkr')
+
+    const acc = new MockBroker({ id: 'mock-paper', cash: 100_000 })
+    acc.setMarkPrice('BTC', 80_000)
+
+    // Step 1: external deposit (transfer-in / 空投) of 1 BTC.
+    acc.externalDeposit({ nativeKey: 'BTC', quantity: 1 })
+
+    // Step 2: market BUY 0.5 BTC via the IBroker pipeline. Mimic UTA by
+    // stamping aliceId on the contract before placing.
+    const contract = new Contract()
+    contract.symbol = 'BTC'
+    contract.secType = 'CRYPTO'
+    contract.exchange = 'MOCK'
+    contract.currency = 'USD'
+    contract.aliceId = 'mock-paper|BTC'   // what UTA.stampAliceId would write
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'MKT'
+    order.totalQuantity = new Decimal('0.5')
+    await acc.placeOrder(contract, order)
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].quantity.toString()).toBe('1.5')
+  })
+
+  it('closePosition resolves a position originally created by externalDeposit', async () => {
+    const Decimal = (await import('decimal.js')).default
+    const { Contract } = await import('@traderalice/ibkr')
+
+    const acc = new MockBroker({ id: 'mock-paper', cash: 100_000 })
+    acc.setMarkPrice('BTC', 80_000)
+    acc.externalDeposit({ nativeKey: 'BTC', quantity: 2 })
+
+    const contract = new Contract()
+    contract.symbol = 'BTC'
+    contract.secType = 'CRYPTO'
+    contract.exchange = 'MOCK'
+    contract.currency = 'USD'
+    contract.aliceId = 'mock-paper|BTC'
+    const result = await acc.closePosition(contract, new Decimal(1))
+    expect(result.success).toBe(true)
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].quantity.toString()).toBe('1')
+  })
+
+  it('pending limit order matches against externalDeposit position on the same nativeKey', async () => {
+    const Decimal = (await import('decimal.js')).default
+    const { Order, Contract } = await import('@traderalice/ibkr')
+
+    const acc = new MockBroker({ id: 'mock-paper', cash: 100_000 })
+    acc.setMarkPrice('BTC', 80_000)
+    acc.externalDeposit({ nativeKey: 'BTC', quantity: 1 })
+
+    const contract = new Contract()
+    contract.symbol = 'BTC'
+    contract.secType = 'CRYPTO'
+    contract.exchange = 'MOCK'
+    contract.currency = 'USD'
+    contract.aliceId = 'mock-paper|BTC'
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal('0.5')
+    order.lmtPrice = new Decimal(75_000)
+    await acc.placeOrder(contract, order)
+
+    expect(acc.getSimulatorState().pendingOrders).toHaveLength(1)
+
+    const filled = acc.setMarkPrice('BTC', 75_000)
+    expect(filled).toHaveLength(1)
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].quantity.toString()).toBe('1.5')
+  })
+})

--- a/src/domain/trading/brokers/mock/MockBroker.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.ts
@@ -4,8 +4,16 @@
  * Same level as CcxtBroker/AlpacaBroker — a full behavioral implementation,
  * not just vi.fn() stubs. Internally all-Decimal for precision guarantees.
  *
- * Market orders fill immediately. Limit orders go to pending (use
- * fillPendingOrder() to trigger fills in tests).
+ * Market orders fill immediately at current markPrice. Limit/stop orders
+ * sit Submitted until either (a) `setMarkPrice()` 触达 the trigger price
+ * (auto-match), or (b) the simulator manually calls `fillOrder(orderId)`.
+ *
+ * Beyond IBroker, MockBroker exposes a "simulator control panel" — methods
+ * not on the IBroker interface that let test/dev surfaces inject god-view
+ * events: change markPrice, fill or partially fill pending orders, simulate
+ * external deposits/withdrawals (空投, transfer-in) and external trades
+ * (user manually trading on the exchange app outside Alice). Routes/UI
+ * call these to drive scenarios without going through `placeOrder`.
  */
 
 import { z } from 'zod'
@@ -130,11 +138,16 @@ export function makePlaceOrderResult(overrides: Partial<PlaceOrderResult> = {}):
 export class MockBroker implements IBroker {
   // ---- Self-registration ----
 
-  static configSchema = z.object({})
-  static configFields: import('../types.js').BrokerConfigField[] = []
+  static configSchema = z.object({
+    cash: z.coerce.number().default(100_000),
+  })
+  static configFields: import('../types.js').BrokerConfigField[] = [
+    { name: 'cash', type: 'number', label: 'Starting cash (USD)', default: 100_000 },
+  ]
 
   static fromConfig(config: { id: string; label?: string; brokerConfig: Record<string, unknown> }): MockBroker {
-    return new MockBroker({ id: config.id, label: config.label })
+    const bc = MockBroker.configSchema.parse(config.brokerConfig)
+    return new MockBroker({ id: config.id, label: config.label, cash: bc.cash })
   }
 
   // ---- Instance ----
@@ -144,7 +157,8 @@ export class MockBroker implements IBroker {
 
   private _positions = new Map<string, InternalPosition>()
   private _orders = new Map<string, InternalOrder>()
-  private _quotes = new Map<string, number>()
+  /** Per-nativeKey markPrice. Replaces the legacy `_quotes` map. */
+  private _markPrices = new Map<string, Decimal>()
   private _cash: Decimal
   private _realizedPnL = new Decimal(0)
   private _nextOrderId = 1
@@ -231,10 +245,10 @@ export class MockBroker implements IBroker {
     const symbol = contract.aliceId ?? contract.symbol ?? 'unknown'
 
     if (isMarket) {
-      const price = this._quotes.get(contract.symbol ?? '') ?? 100
+      const price = this._markPriceFor(contract) ?? new Decimal(100)
 
       // Update position
-      this._applyFill(contract, side, qty, new Decimal(price))
+      this._applyFill(contract, side, qty, price)
 
       // Update cash
       const cost = qty.mul(price)
@@ -244,7 +258,7 @@ export class MockBroker implements IBroker {
       const filledOrder = this._cloneOrder(order, orderId)
       this._orders.set(orderId, {
         id: orderId, contract, order: filledOrder,
-        status: 'Filled', fillPrice: price,
+        status: 'Filled', fillPrice: price.toNumber(),
       })
 
       // Return submitted — actual fill status discovered via getOrder/sync
@@ -335,9 +349,7 @@ export class MockBroker implements IBroker {
     let unrealizedPnL = new Decimal(0)
     let marketValueAcc = new Decimal(0)
     for (const pos of this._positions.values()) {
-      const price = this._quotes.has(pos.contract.symbol ?? '')
-        ? new Decimal(this._quotes.get(pos.contract.symbol ?? '')!)
-        : pos.avgCost
+      const price = pos.marketPriceOverride ?? this._markPriceFor(pos.contract) ?? pos.avgCost
       const posValue = pos.quantity.mul(price)
       marketValueAcc = marketValueAcc.plus(posValue)
       unrealizedPnL = unrealizedPnL.plus(pos.quantity.mul(price.minus(pos.avgCost)))
@@ -357,10 +369,7 @@ export class MockBroker implements IBroker {
     this._checkFail('getPositions')
     const result: Position[] = []
     for (const pos of this._positions.values()) {
-      const price = pos.marketPriceOverride
-        ?? (this._quotes.has(pos.contract.symbol ?? '')
-          ? new Decimal(this._quotes.get(pos.contract.symbol ?? '')!)
-          : pos.avgCost)
+      const price = pos.marketPriceOverride ?? this._markPriceFor(pos.contract) ?? pos.avgCost
       result.push({
         contract: pos.contract,
         currency: pos.contract.currency || 'USD',
@@ -398,12 +407,12 @@ export class MockBroker implements IBroker {
 
   async getQuote(contract: Contract): Promise<Quote> {
     this._record('getQuote', [contract])
-    const price = this._quotes.get(contract.symbol ?? '') ?? 100
+    const price = this._markPriceFor(contract) ?? new Decimal(100)
     return {
       contract,
-      last: String(price),
-      bid: String(price - 0.01),
-      ask: String(price + 0.01),
+      last: price.toString(),
+      bid: price.minus('0.01').toString(),
+      ask: price.plus('0.01').toString(),
       volume: '1000000',
       timestamp: new Date(),
     }
@@ -421,7 +430,11 @@ export class MockBroker implements IBroker {
   // ==================== Contract identity ====================
 
   getNativeKey(contract: Contract): string {
-    return contract.symbol
+    // Prefer localSymbol so multi-family scenarios (BTC spot vs BTC perp)
+    // can coexist without colliding in the position/markPrice maps. Falls
+    // back to plain symbol for the common single-family case — preserves
+    // back-compat with existing tests that key off bare symbols.
+    return contract.localSymbol || contract.symbol
   }
 
   resolveNativeKey(nativeKey: string): Contract {
@@ -431,33 +444,283 @@ export class MockBroker implements IBroker {
     return c
   }
 
-  // ==================== Test helpers ====================
+  // ==================== Simulator control panel ====================
+  // Methods below are NOT part of IBroker. They expose a "god view" so test
+  // specs, the webui simulator route, and other dev surfaces can drive
+  // scenarios that real exchanges produce on their own (price moves,
+  // external transfers, manual fills). Keeping them on MockBroker (not on
+  // a separate interface) means anything holding `IBroker` ignores them
+  // entirely; the simulator route narrows via `instanceof MockBroker`.
 
-  /** Inject a quote for a symbol. Used to control fill prices for market orders. */
-  setQuote(symbol: string, price: number): void {
-    this._quotes.set(symbol, price)
+  /**
+   * Set the markPrice for a native key (= localSymbol or symbol). Auto-matches
+   * any pending limit/stop orders触达 the new price; fills happen at the
+   * markPrice (better-than-limit semantics). Returns the orderIds filled.
+   */
+  setMarkPrice(nativeKey: string, price: Decimal | string | number): string[] {
+    const decimalPrice = price instanceof Decimal ? price : new Decimal(price)
+    this._markPrices.set(nativeKey, decimalPrice)
+    return this._matchPendingOrders(nativeKey, decimalPrice)
   }
 
-  /** Manually fill a pending limit order at the given price. */
-  fillPendingOrder(orderId: string, price: number): void {
+  /** Move a markPrice by a relative percent (e.g. +5 = up 5%). */
+  tickPrice(nativeKey: string, deltaPercent: number): string[] {
+    const current = this._markPrices.get(nativeKey)
+    if (!current) {
+      throw new Error(`MockBroker[${this.id}]: tickPrice — no markPrice for ${nativeKey}; call setMarkPrice first`)
+    }
+    const next = current.mul(new Decimal(100).plus(deltaPercent)).div(100)
+    return this.setMarkPrice(nativeKey, next)
+  }
+
+  /** Read the current markPrice for a native key (returns null if unset). */
+  getMarkPrice(nativeKey: string): Decimal | null {
+    return this._markPrices.get(nativeKey) ?? null
+  }
+
+  /** Manually fill a pending order. Optional price (defaults to markPrice or limit price); optional qty for partial. */
+  fillOrder(orderId: string, opts: { price?: Decimal | string | number; qty?: Decimal | string | number } = {}): void {
     const internal = this._orders.get(orderId)
-    if (!internal || internal.status !== 'Submitted') return
-    internal.status = 'Filled'
-    internal.fillPrice = price
+    if (!internal || internal.status !== 'Submitted') {
+      throw new Error(`MockBroker[${this.id}]: fillOrder — ${orderId} not pending`)
+    }
 
-    const qty = internal.order.totalQuantity
+    const fillQty = opts.qty != null
+      ? (opts.qty instanceof Decimal ? opts.qty : new Decimal(opts.qty))
+      : internal.order.totalQuantity
+    if (fillQty.lte(0)) throw new Error('fillOrder: qty must be positive')
+    if (fillQty.gt(internal.order.totalQuantity)) {
+      throw new Error('fillOrder: qty exceeds order totalQuantity')
+    }
+
+    const price = opts.price != null
+      ? (opts.price instanceof Decimal ? opts.price : new Decimal(opts.price))
+      : (this._markPriceFor(internal.contract)
+        ?? (!internal.order.lmtPrice.equals(UNSET_DECIMAL) ? internal.order.lmtPrice : new Decimal(100)))
+
     const side = internal.order.action.toUpperCase()
-    this._applyFill(internal.contract, side, qty, new Decimal(price))
-
-    const cost = qty.mul(price)
+    this._applyFill(internal.contract, side, fillQty, price)
+    const cost = fillQty.mul(price)
     this._cash = side === 'BUY' ? this._cash.minus(cost) : this._cash.plus(cost)
+
+    const isPartial = fillQty.lt(internal.order.totalQuantity)
+    if (isPartial) {
+      // Reduce remaining qty; order stays Submitted for follow-up fills
+      internal.order.totalQuantity = internal.order.totalQuantity.minus(fillQty)
+    } else {
+      internal.status = 'Filled'
+      internal.fillPrice = price.toNumber()
+    }
+  }
+
+  /** Force-cancel a pending order (simulator surface; bypasses IBroker idempotency). */
+  cancelPendingOrder(orderId: string): void {
+    const internal = this._orders.get(orderId)
+    if (!internal) throw new Error(`MockBroker[${this.id}]: order ${orderId} not found`)
+    internal.status = 'Cancelled'
+  }
+
+  /**
+   * Simulate an external balance change Alice didn't initiate (空投, transfer-in,
+   * staking reward). Adds a position without going through the order pipeline
+   * and tags `avgCostSource: 'wallet'` so UTA's reconcile pipeline kicks in
+   * and synthesizes a `reconcileBalance` commit at observed markPrice — matching
+   * how CCXT spot synthesis behaves in real life.
+   *
+   * Cash is unchanged (deposit, not purchase).
+   */
+  externalDeposit(params: {
+    nativeKey: string
+    quantity: Decimal | string | number
+    contract?: Partial<Contract>
+  }): void {
+    const qty = params.quantity instanceof Decimal ? params.quantity : new Decimal(params.quantity)
+    if (qty.lte(0)) throw new Error('externalDeposit: quantity must be positive')
+
+    const existing = this._positions.get(params.nativeKey)
+    if (existing) {
+      existing.quantity = existing.quantity.plus(qty)
+      existing.avgCostSource = 'wallet'
+      return
+    }
+
+    const contract = new Contract()
+    contract.symbol = params.contract?.symbol ?? params.nativeKey
+    contract.localSymbol = params.contract?.localSymbol ?? params.nativeKey
+    contract.secType = params.contract?.secType ?? 'CRYPTO'
+    contract.exchange = params.contract?.exchange ?? 'MOCK'
+    contract.currency = params.contract?.currency ?? 'USD'
+    const markPrice = this._markPrices.get(params.nativeKey) ?? new Decimal(0)
+
+    this._positions.set(params.nativeKey, {
+      contract,
+      side: 'long',
+      quantity: qty,
+      avgCost: markPrice,
+      avgCostSource: 'wallet',
+    })
+  }
+
+  /** Simulate an external withdrawal (transfer-out, burn). Cash unchanged. */
+  externalWithdraw(nativeKey: string, quantity: Decimal | string | number): void {
+    const qty = quantity instanceof Decimal ? quantity : new Decimal(quantity)
+    const existing = this._positions.get(nativeKey)
+    if (!existing) throw new Error(`MockBroker[${this.id}]: no position at ${nativeKey}`)
+    existing.quantity = existing.quantity.minus(qty)
+    if (existing.quantity.lte(0)) {
+      this._positions.delete(nativeKey)
+    } else {
+      existing.avgCostSource = 'wallet'
+    }
+  }
+
+  /**
+   * Simulate the user manually trading on the exchange app (outside Alice's
+   * order log). Updates position + cash like a real fill, but tags the
+   * position as wallet-sourced so UTA reconciles via observed price.
+   */
+  externalTrade(params: {
+    nativeKey: string
+    side: 'BUY' | 'SELL'
+    quantity: Decimal | string | number
+    price: Decimal | string | number
+    contract?: Partial<Contract>
+  }): void {
+    const qty = params.quantity instanceof Decimal ? params.quantity : new Decimal(params.quantity)
+    const price = params.price instanceof Decimal ? params.price : new Decimal(params.price)
+    if (qty.lte(0)) throw new Error('externalTrade: quantity must be positive')
+
+    const existing = this._positions.get(params.nativeKey)
+    if (!existing && params.side === 'SELL') {
+      throw new Error(`MockBroker[${this.id}]: cannot externalTrade SELL — no position at ${params.nativeKey}`)
+    }
+
+    if (!existing) {
+      const contract = new Contract()
+      contract.symbol = params.contract?.symbol ?? params.nativeKey
+      contract.localSymbol = params.contract?.localSymbol ?? params.nativeKey
+      contract.secType = params.contract?.secType ?? 'CRYPTO'
+      contract.exchange = params.contract?.exchange ?? 'MOCK'
+      contract.currency = params.contract?.currency ?? 'USD'
+      this._positions.set(params.nativeKey, {
+        contract,
+        side: 'long',
+        quantity: qty,
+        avgCost: price,
+        avgCostSource: 'wallet',
+      })
+    } else {
+      this._applyFill(existing.contract, params.side, qty, price)
+      const after = this._positions.get(params.nativeKey)
+      if (after) after.avgCostSource = 'wallet'
+    }
+
+    const cashDelta = qty.mul(price)
+    this._cash = params.side === 'BUY' ? this._cash.minus(cashDelta) : this._cash.plus(cashDelta)
+  }
+
+  /**
+   * Snapshot of all simulator-relevant state. Used by the webui simulator tab
+   * to render the control console without piecing together separate calls.
+   */
+  getSimulatorState(): {
+    cash: string
+    markPrices: Array<{ nativeKey: string; price: string }>
+    positions: Array<{ nativeKey: string; symbol: string; localSymbol?: string; secType?: string; side: 'long' | 'short'; quantity: string; avgCost: string; avgCostSource?: 'broker' | 'wallet' }>
+    pendingOrders: Array<{ orderId: string; nativeKey: string; symbol: string; action: string; orderType: string; totalQuantity: string; lmtPrice?: string; auxPrice?: string }>
+  } {
+    return {
+      cash: this._cash.toString(),
+      markPrices: [...this._markPrices.entries()].map(([k, v]) => ({ nativeKey: k, price: v.toString() })),
+      positions: [...this._positions.entries()].map(([k, p]) => ({
+        nativeKey: k,
+        symbol: p.contract.symbol,
+        localSymbol: p.contract.localSymbol || undefined,
+        secType: p.contract.secType || undefined,
+        side: p.side,
+        quantity: p.quantity.toString(),
+        avgCost: p.avgCost.toString(),
+        avgCostSource: p.avgCostSource,
+      })),
+      pendingOrders: [...this._orders.values()]
+        .filter(o => o.status === 'Submitted')
+        .map(o => ({
+          orderId: o.id,
+          nativeKey: this.getNativeKey(o.contract),
+          symbol: o.contract.symbol,
+          action: o.order.action,
+          orderType: o.order.orderType,
+          totalQuantity: o.order.totalQuantity.toString(),
+          lmtPrice: !o.order.lmtPrice.equals(UNSET_DECIMAL) ? o.order.lmtPrice.toString() : undefined,
+          auxPrice: !o.order.auxPrice.equals(UNSET_DECIMAL) ? o.order.auxPrice.toString() : undefined,
+        })),
+    }
+  }
+
+  /**
+   * Walk pending orders for `nativeKey`, fill any whose trigger has been
+   * crossed by `price`. Called from setMarkPrice. Returns filled orderIds.
+   *
+   * Trigger semantics:
+   *  - LMT BUY: fills when markPrice <= lmtPrice (price came down to/below us)
+   *  - LMT SELL: fills when markPrice >= lmtPrice
+   *  - STP BUY: triggers when markPrice >= auxPrice (breakout up)
+   *  - STP SELL: triggers when markPrice <= auxPrice (breakdown)
+   * Fill price = markPrice (better-than-limit, like a real exchange).
+   */
+  private _matchPendingOrders(nativeKey: string, price: Decimal): string[] {
+    const filled: string[] = []
+    for (const internal of this._orders.values()) {
+      if (internal.status !== 'Submitted') continue
+      if (this.getNativeKey(internal.contract) !== nativeKey) continue
+
+      const order = internal.order
+      const side = order.action.toUpperCase()
+      const type = order.orderType
+      const lmt = !order.lmtPrice.equals(UNSET_DECIMAL) ? order.lmtPrice : null
+      const aux = !order.auxPrice.equals(UNSET_DECIMAL) ? order.auxPrice : null
+
+      let triggered = false
+      if (type === 'LMT' && lmt) {
+        triggered = side === 'BUY' ? price.lte(lmt) : price.gte(lmt)
+      } else if (type === 'STP' && aux) {
+        triggered = side === 'BUY' ? price.gte(aux) : price.lte(aux)
+      } else if (type === 'STP LMT' && aux) {
+        // Stop-limit: aux triggers, then becomes a limit at lmt. For mock we
+        // collapse: trigger fills at lmt (or aux if no lmt) — sufficient for
+        // simulation; precise stop-limit behaviour is out of scope.
+        triggered = side === 'BUY' ? price.gte(aux) : price.lte(aux)
+      }
+      if (!triggered) continue
+
+      this.fillOrder(internal.id, { price })
+      filled.push(internal.id)
+    }
+    return filled
+  }
+
+  /** Resolve markPrice for a contract via its nativeKey. */
+  private _markPriceFor(contract: Contract): Decimal | null {
+    return this._markPrices.get(this.getNativeKey(contract)) ?? null
+  }
+
+  // ==================== Legacy test helpers ====================
+
+  /** Legacy alias for setMarkPrice — number-typed price, no auto-match return. */
+  setQuote(symbol: string, price: number): void {
+    this.setMarkPrice(symbol, price)
+  }
+
+  /** Legacy alias for fillOrder. */
+  fillPendingOrder(orderId: string, price: number): void {
+    this.fillOrder(orderId, { price })
   }
 
   /** Override positions directly (for legacy test compatibility). */
   setPositions(positions: Position[]): void {
     this._positions.clear()
     for (const p of positions) {
-      const key = p.contract.aliceId ?? p.contract.symbol ?? 'unknown'
+      const key = this.getNativeKey(p.contract) || p.contract.aliceId || 'unknown'
       this._positions.set(key, {
         contract: p.contract,
         side: p.side,

--- a/src/domain/trading/brokers/mock/MockBroker.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.ts
@@ -173,6 +173,14 @@ export class MockBroker implements IBroker {
   private _orders = new Map<string, InternalOrder>()
   /** Per-nativeKey markPrice. Replaces the legacy `_quotes` map. */
   private _markPrices = new Map<string, Decimal>()
+  /**
+   * Contracts seen via deposit / placeOrder / externalTrade, keyed by
+   * `getNativeKey(contract)`. `resolveNativeKey` looks up here first so
+   * orders against an aliceId for a previously-known instrument keep their
+   * full secType / strike / multiplier metadata even if the position was
+   * fully sold out of (i.e. removed from `_positions`).
+   */
+  private _contractRegistry = new Map<string, Contract>()
   private _cash: Decimal
   private _realizedPnL = new Decimal(0)
   private _nextOrderId = 1
@@ -259,27 +267,31 @@ export class MockBroker implements IBroker {
 
     if (isMarket) {
       const price = this._markPriceFor(contract) ?? new Decimal(100)
+      const mult = multiplierOf(contract)
 
-      // Update position
-      this._applyFill(contract, side, qty, price)
+      // Update position; on oversell `_applyFill` throws — match real broker
+      // convention by returning PlaceOrderResult.success=false rather than
+      // letting the exception escape to the caller.
+      try {
+        this._applyFill(contract, side, qty, price)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
 
-      // Update cash
-      const cost = qty.mul(price)
+      // Cash flow honours multiplier: 1 OPT contract @ $58 with multiplier=100
+      // costs $5,800, not $58. IBroker contract requires this even though
+      // position.avgCost is per-unit.
+      const cost = qty.mul(price).mul(mult)
       this._cash = side === 'BUY' ? this._cash.minus(cost) : this._cash.plus(cost)
 
-      // Record order as filled
       const filledOrder = this._cloneOrder(order, orderId)
       this._orders.set(orderId, {
         id: orderId, contract, order: filledOrder,
         status: 'Filled', fillPrice: price.toNumber(),
       })
 
-      // Return submitted — actual fill status discovered via getOrder/sync
-      // (MockBroker executes internally but doesn't expose execution in response,
-      // matching real exchange async behavior)
       const orderState = new OrderState()
       orderState.status = 'Filled'
-
       return { success: true, orderId, orderState }
     }
 
@@ -458,8 +470,14 @@ export class MockBroker implements IBroker {
   }
 
   resolveNativeKey(nativeKey: string): Contract {
+    // Prefer the registry — preserves secType / strike / right / multiplier
+    // for contracts we've already observed, so re-ordering an OPT/FUT
+    // aliceId after a full sell-down still keeps the right metadata.
+    const remembered = this._contractRegistry.get(nativeKey)
+    if (remembered) return remembered
     const c = new Contract()
     c.symbol = nativeKey
+    c.localSymbol = nativeKey
     c.secType = 'STK'
     return c
   }
@@ -520,7 +538,7 @@ export class MockBroker implements IBroker {
 
     const side = internal.order.action.toUpperCase()
     this._applyFill(internal.contract, side, fillQty, price)
-    const cost = fillQty.mul(price)
+    const cost = fillQty.mul(price).mul(multiplierOf(internal.contract))
     this._cash = side === 'BUY' ? this._cash.minus(cost) : this._cash.plus(cost)
 
     const isPartial = fillQty.lt(internal.order.totalQuantity)
@@ -558,7 +576,19 @@ export class MockBroker implements IBroker {
     if (partial?.strike != null && partial.strike !== UNSET_DOUBLE) c.strike = partial.strike
     if (partial?.right) c.right = partial.right
     if (partial?.multiplier) c.multiplier = partial.multiplier
+    this._rememberContract(c)
     return c
+  }
+
+  /** Cache the contract under its native key so `resolveNativeKey` can
+   *  recover the full IBKR Contract metadata even after the position is
+   *  fully sold out of and removed from `_positions`. */
+  private _rememberContract(c: Contract): void {
+    const key = this.getNativeKey(c)
+    if (!key) return
+    if (!this._contractRegistry.has(key)) {
+      this._contractRegistry.set(key, c)
+    }
   }
 
   /**
@@ -644,7 +674,9 @@ export class MockBroker implements IBroker {
       if (after) after.avgCostSource = 'wallet'
     }
 
-    const cashDelta = qty.mul(price)
+    const positionForMult = this._positions.get(params.nativeKey)
+    const mult = positionForMult ? multiplierOf(positionForMult.contract) : new Decimal(1)
+    const cashDelta = qty.mul(price).mul(mult)
     this._cash = params.side === 'BUY' ? this._cash.minus(cashDelta) : this._cash.plus(cashDelta)
   }
 
@@ -805,13 +837,20 @@ export class MockBroker implements IBroker {
     // simulator-direct calls (externalDeposit/externalTrade — keyed by
     // user-supplied nativeKey, e.g. "BTC") land in the same map slot.
     const key = this.getNativeKey(contract)
+    this._rememberContract(contract)
     const existing = this._positions.get(key)
 
     if (!existing) {
-      // New position
+      if (side === 'SELL') {
+        // No position to sell. Real brokers reject oversell. Mock follows
+        // suit — flipping into a short here would silently fabricate cash
+        // and a wrong-direction position. Caller (placeOrder / externalTrade)
+        // catches and surfaces the rejection.
+        throw new Error(`MockBroker[${this.id}]: cannot SELL ${qty.toFixed()} ${key} — no existing position`)
+      }
       this._positions.set(key, {
         contract,
-        side: side === 'BUY' ? 'long' : 'short',
+        side: 'long',
         quantity: qty,
         avgCost: price,
       })
@@ -828,14 +867,17 @@ export class MockBroker implements IBroker {
       existing.quantity = existing.quantity.plus(qty)
       existing.avgCost = totalCost.div(existing.quantity)
     } else {
-      // Reduce/close position
+      // Reduce / close. Reject oversell — partial close OK, full flat OK,
+      // beyond-flat is the bug shape (cash phantom-credited via the caller).
       const remaining = existing.quantity.minus(qty)
-      if (remaining.lte(0)) {
-        // Fully closed (or flipped — for simplicity we just delete)
+      if (remaining.lt(0)) {
+        throw new Error(`MockBroker[${this.id}]: cannot ${side} ${qty.toFixed()} ${key} — only ${existing.quantity.toFixed()} held`)
+      }
+      if (remaining.isZero()) {
         this._positions.delete(key)
       } else {
         existing.quantity = remaining
-        // avgCost stays the same on partial close
+        // avgCost stays the same on partial close (WAC sell-down semantics).
       }
     }
   }

--- a/src/domain/trading/brokers/mock/MockBroker.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.ts
@@ -18,7 +18,7 @@
 
 import { z } from 'zod'
 import Decimal from 'decimal.js'
-import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL, UNSET_DOUBLE } from '@traderalice/ibkr'
 import type {
   IBroker,
   AccountCapabilities,
@@ -31,6 +31,20 @@ import type {
   TpSlParams,
 } from '../types.js'
 import '../../contract-ext.js'
+
+// ==================== Helpers ====================
+
+/**
+ * Per-contract multiplier as a Decimal. Defaults to 1 when the contract
+ * doesn't declare one (stocks, crypto). Options need ×100; futures use
+ * the contract-spec value (50 for ES, 5 for MES, etc.).
+ */
+function multiplierOf(c: Contract): Decimal {
+  const m = c.multiplier
+  if (!m) return new Decimal(1)
+  const d = new Decimal(m)
+  return d.isZero() ? new Decimal(1) : d
+}
 
 // ==================== Internal types ====================
 
@@ -349,9 +363,10 @@ export class MockBroker implements IBroker {
     let marketValueAcc = new Decimal(0)
     for (const pos of this._positions.values()) {
       const price = pos.marketPriceOverride ?? this._markPriceFor(pos.contract) ?? pos.avgCost
-      const posValue = pos.quantity.mul(price)
+      const mult = multiplierOf(pos.contract)
+      const posValue = pos.quantity.mul(price).mul(mult)
       marketValueAcc = marketValueAcc.plus(posValue)
-      unrealizedPnL = unrealizedPnL.plus(pos.quantity.mul(price.minus(pos.avgCost)))
+      unrealizedPnL = unrealizedPnL.plus(pos.quantity.mul(price.minus(pos.avgCost)).mul(mult))
     }
 
     return {
@@ -369,6 +384,11 @@ export class MockBroker implements IBroker {
     const result: Position[] = []
     for (const pos of this._positions.values()) {
       const price = pos.marketPriceOverride ?? this._markPriceFor(pos.contract) ?? pos.avgCost
+      // Per IBroker.Position contract: marketValue / unrealizedPnL must be
+      // multiplier-applied at the broker layer. For OPT (×100) and futures
+      // (per-contract size), the simulator has to fold multiplier in here
+      // or downstream cost-basis ends up reporting per-unit numbers.
+      const mult = multiplierOf(pos.contract)
       result.push({
         contract: pos.contract,
         currency: pos.contract.currency || 'USD',
@@ -376,9 +396,10 @@ export class MockBroker implements IBroker {
         quantity: pos.quantity,
         avgCost: pos.avgCost.toString(),
         marketPrice: price.toString(),
-        marketValue: pos.quantity.mul(price).toString(),
-        unrealizedPnL: pos.quantity.mul(price.minus(pos.avgCost)).toString(),
+        marketValue: pos.quantity.mul(price).mul(mult).toString(),
+        unrealizedPnL: pos.quantity.mul(price.minus(pos.avgCost)).mul(mult).toString(),
         realizedPnL: '0',
+        ...(pos.contract.multiplier && { multiplier: pos.contract.multiplier }),
         ...(pos.avgCostSource && { avgCostSource: pos.avgCostSource }),
       })
     }
@@ -520,11 +541,33 @@ export class MockBroker implements IBroker {
   }
 
   /**
-   * Simulate an external balance change Alice didn't initiate (空投, transfer-in,
-   * staking reward). Adds a position without going through the order pipeline
-   * and tags `avgCostSource: 'wallet'` so UTA's reconcile pipeline kicks in
-   * and synthesizes a `reconcileBalance` commit at observed markPrice — matching
-   * how CCXT spot synthesis behaves in real life.
+   * Build a Contract from caller-supplied partial fields, defaulting only
+   * the housekeeping bits (exchange / currency). Carries through every
+   * IBKR contract field that distinguishes derivative instruments
+   * (lastTradeDateOrContractMonth / strike / right / multiplier) so
+   * options + futures + FOP positions render correctly downstream.
+   */
+  private _buildContract(nativeKey: string, partial: Partial<Contract> | undefined): Contract {
+    const c = new Contract()
+    c.symbol = partial?.symbol ?? nativeKey
+    c.localSymbol = partial?.localSymbol ?? nativeKey
+    c.secType = partial?.secType ?? 'CRYPTO'
+    c.exchange = partial?.exchange ?? 'MOCK'
+    c.currency = partial?.currency ?? 'USD'
+    if (partial?.lastTradeDateOrContractMonth) c.lastTradeDateOrContractMonth = partial.lastTradeDateOrContractMonth
+    if (partial?.strike != null && partial.strike !== UNSET_DOUBLE) c.strike = partial.strike
+    if (partial?.right) c.right = partial.right
+    if (partial?.multiplier) c.multiplier = partial.multiplier
+    return c
+  }
+
+  /**
+   * Simulate an external balance change Alice didn't initiate (airdrop,
+   * transfer-in, staking reward, off-exchange option assignment). Adds a
+   * position without going through the order pipeline and tags
+   * `avgCostSource: 'wallet'` so UTA's reconcile pipeline kicks in and
+   * synthesizes a `reconcileBalance` commit at observed markPrice —
+   * matching how CCXT spot synthesis behaves in real life.
    *
    * Cash is unchanged (deposit, not purchase).
    */
@@ -543,16 +586,9 @@ export class MockBroker implements IBroker {
       return
     }
 
-    const contract = new Contract()
-    contract.symbol = params.contract?.symbol ?? params.nativeKey
-    contract.localSymbol = params.contract?.localSymbol ?? params.nativeKey
-    contract.secType = params.contract?.secType ?? 'CRYPTO'
-    contract.exchange = params.contract?.exchange ?? 'MOCK'
-    contract.currency = params.contract?.currency ?? 'USD'
     const markPrice = this._markPrices.get(params.nativeKey) ?? new Decimal(0)
-
     this._positions.set(params.nativeKey, {
-      contract,
+      contract: this._buildContract(params.nativeKey, params.contract),
       side: 'long',
       quantity: qty,
       avgCost: markPrice,
@@ -595,14 +631,8 @@ export class MockBroker implements IBroker {
     }
 
     if (!existing) {
-      const contract = new Contract()
-      contract.symbol = params.contract?.symbol ?? params.nativeKey
-      contract.localSymbol = params.contract?.localSymbol ?? params.nativeKey
-      contract.secType = params.contract?.secType ?? 'CRYPTO'
-      contract.exchange = params.contract?.exchange ?? 'MOCK'
-      contract.currency = params.contract?.currency ?? 'USD'
       this._positions.set(params.nativeKey, {
-        contract,
+        contract: this._buildContract(params.nativeKey, params.contract),
         side: 'long',
         quantity: qty,
         avgCost: price,
@@ -625,7 +655,7 @@ export class MockBroker implements IBroker {
   getSimulatorState(): {
     cash: string
     markPrices: Array<{ nativeKey: string; price: string }>
-    positions: Array<{ nativeKey: string; symbol: string; localSymbol?: string; secType?: string; side: 'long' | 'short'; quantity: string; avgCost: string; avgCostSource?: 'broker' | 'wallet' }>
+    positions: Array<{ nativeKey: string; symbol: string; localSymbol?: string; secType?: string; side: 'long' | 'short'; quantity: string; avgCost: string; avgCostSource?: 'broker' | 'wallet'; expiry?: string; strike?: number; right?: string; multiplier?: string }>
     pendingOrders: Array<{ orderId: string; nativeKey: string; symbol: string; action: string; orderType: string; totalQuantity: string; lmtPrice?: string; auxPrice?: string }>
   } {
     return {
@@ -640,6 +670,10 @@ export class MockBroker implements IBroker {
         quantity: p.quantity.toString(),
         avgCost: p.avgCost.toString(),
         avgCostSource: p.avgCostSource,
+        expiry: p.contract.lastTradeDateOrContractMonth || undefined,
+        strike: p.contract.strike !== UNSET_DOUBLE ? p.contract.strike : undefined,
+        right: p.contract.right || undefined,
+        multiplier: p.contract.multiplier || undefined,
       })),
       pendingOrders: [...this._orders.values()]
         .filter(o => o.status === 'Submitted')

--- a/src/domain/trading/brokers/mock/MockBroker.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.ts
@@ -242,7 +242,6 @@ export class MockBroker implements IBroker {
     const isMarket = order.orderType === 'MKT'
     const side = order.action.toUpperCase()
     const qty = !order.totalQuantity.equals(UNSET_DECIMAL) ? order.totalQuantity : new Decimal(0)
-    const symbol = contract.aliceId ?? contract.symbol ?? 'unknown'
 
     if (isMarket) {
       const price = this._markPriceFor(contract) ?? new Decimal(100)
@@ -325,10 +324,10 @@ export class MockBroker implements IBroker {
 
   async closePosition(contract: Contract, quantity?: Decimal): Promise<PlaceOrderResult> {
     this._record('closePosition', [contract, quantity])
-    const symbol = contract.aliceId ?? contract.symbol ?? 'unknown'
-    const pos = this._positions.get(symbol)
+    const key = this.getNativeKey(contract)
+    const pos = this._positions.get(key)
     if (!pos) {
-      return { success: false, error: `No open position for ${symbol}` }
+      return { success: false, error: `No open position for ${key}` }
     }
 
     const order = new Order()
@@ -767,7 +766,11 @@ export class MockBroker implements IBroker {
   // ==================== Internal ====================
 
   private _applyFill(contract: Contract, side: string, qty: Decimal, price: Decimal): void {
-    const key = contract.aliceId ?? contract.symbol ?? 'unknown'
+    // All position map operations key by `getNativeKey(contract)` so that
+    // orders placed via the IBroker pipeline (with UTA-stamped aliceId) and
+    // simulator-direct calls (externalDeposit/externalTrade — keyed by
+    // user-supplied nativeKey, e.g. "BTC") land in the same map slot.
+    const key = this.getNativeKey(contract)
     const existing = this._positions.get(key)
 
     if (!existing) {

--- a/src/domain/trading/brokers/preset-catalog.ts
+++ b/src/domain/trading/brokers/preset-catalog.ts
@@ -14,7 +14,7 @@ import { z } from 'zod'
 
 // ==================== Types ====================
 
-export type BrokerEngine = 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge'
+export type BrokerEngine = 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'mock'
 
 export interface ModeOption {
   id: string
@@ -42,12 +42,13 @@ export interface BrokerPresetDef {
   description: string
   /**
    * Group in the picker UI. Wizard renders 'recommended' first, then
-   * 'crypto'. Securities + Longbridge HK + Hyperliquid sit in
-   * 'recommended' (Hyperliquid grandfathered for product-history reasons,
+   * 'crypto', then 'testing'. Securities + Longbridge HK + Hyperliquid sit
+   * in 'recommended' (Hyperliquid grandfathered for product-history reasons,
    * not because it's not crypto). Everything else crypto-native — incl.
-   * CCXT Custom — lands in 'crypto'.
+   * CCXT Custom — lands in 'crypto'. The Simulator preset (mock engine)
+   * lives alone in 'testing' so users can't conflate it with real-money brokers.
    */
-  category: 'recommended' | 'crypto'
+  category: 'recommended' | 'crypto' | 'testing'
   /** Optional explanatory text rendered with the form (mode-specific gotchas, etc.). */
   hint?: string
   /** Default account id suggested in the wizard (e.g., "okx-main"). */
@@ -397,6 +398,29 @@ Paste the **private key of the authorized wallet** below. LeverUp's team confirm
   }),
 }
 
+// ==================== Testing presets ====================
+
+export const SIMULATOR_PRESET: BrokerPresetDef = {
+  id: 'mock-simulator',
+  label: 'Simulator (testing only)',
+  description: 'In-memory mock broker with manual撮合. No real money, no exchange — use the Dev → Simulator panel to drive prices, fills, and external balance events.',
+  category: 'testing',
+  hint: 'For UI/AI repro testing only. Positions and orders live in process memory; **everything is wiped on dev server restart**. Connect via the Dev → Simulator panel to inject prices, manually撮合 limit orders, and simulate external transfers / off-platform trades.',
+  defaultName: 'simulator',
+  badge: 'SM',
+  badgeColor: 'text-text-muted',
+  engine: 'mock',
+  guardCategory: 'crypto',
+  zodSchema: z.object({
+    cash: z.coerce.number().default(100_000).describe('Starting cash (USD)'),
+  }),
+  subtitleFields: [
+    { field: 'cash', prefix: '$' },
+  ],
+  toEngineConfig: (d) => ({ cash: d.cash }),
+  isPaper: () => true,
+}
+
 // ==================== Catalog ====================
 
 // Order matters — the wizard renders presets top-down within each
@@ -419,6 +443,8 @@ export const BROKER_PRESET_CATALOG: BrokerPresetDef[] = [
   LEVERUP_PRESET,
   // Escape hatch — untested CCXT exchanges; lives at the end of Crypto.
   CCXT_CUSTOM_PRESET,
+  // ---- Testing ----
+  SIMULATOR_PRESET,
 ]
 
 /** Lookup by id. Throws if unknown. */

--- a/src/domain/trading/brokers/preset-catalog.ts
+++ b/src/domain/trading/brokers/preset-catalog.ts
@@ -11,6 +11,7 @@
  */
 
 import { z } from 'zod'
+import { createHash, randomBytes } from 'node:crypto'
 
 // ==================== Types ====================
 
@@ -34,7 +35,9 @@ export interface SubtitleSegment {
 }
 
 export interface BrokerPresetDef {
-  /** Stable id stored on disk in UTAConfig.presetId. */
+  /** Stable id stored on disk in UTAConfig.presetId. Used as the prefix
+   * of derived UTA ids — e.g. an OKX preset → `okx-a3f2b1c4`. Renaming
+   * this is a breaking change for existing UTA ids on disk. */
   id: string
   /** User-facing label in the wizard. */
   label: string
@@ -69,6 +72,17 @@ export interface BrokerPresetDef {
   subtitleFields: SubtitleSegment[]
   /** Field names that should render as password inputs. */
   writeOnlyFields?: string[]
+  /**
+   * presetConfig field names that determine broker physical identity.
+   * `deriveUtaId` reads these (and only these) from validated presetConfig
+   * to compute a deterministic UTA id. Two configs with the same values
+   * across these fields → same id → same on-disk commit log inheritance.
+   *
+   * Pick fields that uniquely identify a broker account: API key for
+   * centralized exchanges, wallet address for DEX, mode for paper/live
+   * separation, etc. Don't include cosmetic fields (label, etc.).
+   */
+  fingerprintFields: string[]
   /**
    * Translate validated preset form data into the engine's internal
    * config dict. This is where preset-specific knowledge (e.g., "OKX
@@ -118,6 +132,7 @@ export const OKX_PRESET: BrokerPresetDef = {
     { field: 'mode', prefix: 'OKX · ' },
   ],
   writeOnlyFields: ['apiKey', 'secret', 'password'],
+  fingerprintFields: ['mode', 'apiKey'],
   toEngineConfig: (d) => ({
     exchange: 'okx',
     sandbox: d.mode === 'demo',
@@ -152,6 +167,7 @@ export const BYBIT_PRESET: BrokerPresetDef = {
     { field: 'mode', prefix: 'Bybit · ' },
   ],
   writeOnlyFields: ['apiKey', 'secret'],
+  fingerprintFields: ['mode', 'apiKey'],
   toEngineConfig: (d) => ({
     exchange: 'bybit',
     sandbox: d.mode === 'testnet',
@@ -185,6 +201,7 @@ export const HYPERLIQUID_PRESET: BrokerPresetDef = {
     { field: 'mode', prefix: 'Hyperliquid · ' },
   ],
   writeOnlyFields: ['privateKey'],
+  fingerprintFields: ['mode', 'walletAddress'],
   toEngineConfig: (d) => ({
     exchange: 'hyperliquid',
     sandbox: d.mode === 'testnet',
@@ -218,6 +235,7 @@ export const BITGET_PRESET: BrokerPresetDef = {
     { field: 'mode', prefix: 'Bitget · ' },
   ],
   writeOnlyFields: ['apiKey', 'secret', 'password'],
+  fingerprintFields: ['mode', 'apiKey'],
   toEngineConfig: (d) => ({
     exchange: 'bitget',
     demoTrading: d.mode === 'demo',
@@ -255,6 +273,7 @@ export const CCXT_CUSTOM_PRESET: BrokerPresetDef = {
     { field: 'demoTrading', label: 'Demo' },
   ],
   writeOnlyFields: ['apiKey', 'secret', 'password', 'privateKey'],
+  fingerprintFields: ['exchange', 'sandbox', 'demoTrading', 'apiKey', 'walletAddress'],
   toEngineConfig: (d) => {
     // Pass through every defined field — engine's CcxtBroker.configSchema
     // will accept whatever subset the user supplies.
@@ -293,6 +312,7 @@ export const ALPACA_PRESET: BrokerPresetDef = {
     { field: 'mode', prefix: 'Alpaca · ' },
   ],
   writeOnlyFields: ['apiKey', 'apiSecret'],
+  fingerprintFields: ['mode', 'apiKey'],
   toEngineConfig: (d) => ({
     paper: d.mode === 'paper',
     apiKey: d.apiKey,
@@ -321,6 +341,7 @@ export const IBKR_PRESET: BrokerPresetDef = {
     { field: 'host', prefix: 'TWS ' },
     { field: 'port' },
   ],
+  fingerprintFields: ['host', 'port', 'clientId'],
   toEngineConfig: (d) => ({
     host: d.host,
     port: d.port,
@@ -355,6 +376,7 @@ export const LONGBRIDGE_PRESET: BrokerPresetDef = {
     { field: 'mode', prefix: 'Longbridge · ' },
   ],
   writeOnlyFields: ['appKey', 'appSecret', 'accessToken'],
+  fingerprintFields: ['mode', 'appKey'],
   toEngineConfig: (d) => ({
     appKey: d.appKey,
     appSecret: d.appSecret,
@@ -392,6 +414,7 @@ Paste the **private key of the authorized wallet** below. LeverUp's team confirm
   }),
   subtitleFields: [{ field: 'mode', prefix: 'LeverUp · ' }],
   writeOnlyFields: ['privateKey'],
+  fingerprintFields: ['mode', 'privateKey'],
   toEngineConfig: (d) => ({
     network: d.mode,
     privateKey: d.privateKey,
@@ -417,6 +440,10 @@ export const SIMULATOR_PRESET: BrokerPresetDef = {
   subtitleFields: [
     { field: 'cash', prefix: '$' },
   ],
+  // Mock has no real broker identity. The route layer mints a random
+  // _instanceId into presetConfig on POST when it's missing; the
+  // fingerprint then derives off that, giving each sim a unique id.
+  fingerprintFields: ['_instanceId'],
   toEngineConfig: (d) => ({ cash: d.cash }),
   isPaper: () => true,
 }
@@ -460,4 +487,55 @@ export function getBrokerPreset(presetId: string): BrokerPresetDef {
 export function isPaperPreset(presetId: string, presetConfig: Record<string, unknown>): boolean {
   const preset = getBrokerPreset(presetId)
   return preset.isPaper ? preset.isPaper(presetConfig) : defaultIsPaper(presetConfig)
+}
+
+// ==================== Derived UTA id ====================
+
+/**
+ * Recursively sort object keys so JSON.stringify is deterministic across
+ * field-order variations from the wizard / API. Arrays preserve order.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {}
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = canonicalize((value as Record<string, unknown>)[key])
+    }
+    return sorted
+  }
+  return value
+}
+
+/**
+ * Derive a stable, broker-identity-anchored UTA id from a preset and its
+ * presetConfig. Reads only the fields listed in `preset.fingerprintFields`
+ * — missing keys fill as null so identity is stable across optional-field
+ * presence variations.
+ *
+ * Format: `${preset.id}-${8 hex}` (8 hex = 32 bits, ~4 billion buckets;
+ * collision risk is negligible for typical user UTA counts).
+ *
+ * Stability guarantees:
+ *   - Same preset + same fingerprint-field values → byte-identical id.
+ *   - Object key order doesn't matter (canonical JSON sorts).
+ *   - Renaming preset.id breaks all derived ids for that preset (treat
+ *     preset id as a stable on-disk identifier; same as we already do).
+ */
+export function deriveUtaId(preset: BrokerPresetDef, presetConfig: Record<string, unknown>): string {
+  const filtered: Record<string, unknown> = {}
+  for (const field of preset.fingerprintFields) {
+    filtered[field] = presetConfig[field] ?? null
+  }
+  const payload = `${preset.id}:${JSON.stringify(canonicalize(filtered))}`
+  const hash = createHash('sha256').update(payload).digest('hex').slice(0, 8)
+  return `${preset.id}-${hash}`
+}
+
+/**
+ * Mint a random short hex token. Used by the create route to seed
+ * `_instanceId` on Mock presets so each sim UTA gets a unique fingerprint.
+ */
+export function mintInstanceId(): string {
+  return randomBytes(4).toString('hex')
 }

--- a/src/domain/trading/brokers/presets.spec.ts
+++ b/src/domain/trading/brokers/presets.spec.ts
@@ -44,6 +44,7 @@ const SAMPLE_CONFIGS: Record<string, Record<string, unknown>> = {
     mode: 'testnet',
     privateKey: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
   },
+  'mock-simulator': { cash: 50000 },
 }
 
 // ==================== Catalog integrity ====================

--- a/src/domain/trading/brokers/presets.spec.ts
+++ b/src/domain/trading/brokers/presets.spec.ts
@@ -16,6 +16,7 @@ import {
   BROKER_PRESET_CATALOG,
   getBrokerPreset,
   isPaperPreset,
+  deriveUtaId,
   OKX_PRESET,
   BYBIT_PRESET,
   HYPERLIQUID_PRESET,
@@ -24,6 +25,7 @@ import {
   IBKR_PRESET,
   LONGBRIDGE_PRESET,
   CCXT_CUSTOM_PRESET,
+  SIMULATOR_PRESET,
 } from './preset-catalog.js'
 import { BROKER_ENGINE_REGISTRY } from './registry.js'
 import { BUILTIN_BROKER_PRESETS } from './presets.js'
@@ -210,5 +212,64 @@ describe('BUILTIN_BROKER_PRESETS', () => {
     expect(props.apiKey.writeOnly).toBe(true)
     expect(props.secret.writeOnly).toBe(true)
     expect(props.password.writeOnly).toBe(true)
+  })
+})
+
+// ==================== Derived UTA id ====================
+
+describe('deriveUtaId', () => {
+  it('is deterministic — same inputs produce byte-identical id', () => {
+    const a = deriveUtaId(OKX_PRESET, { mode: 'live', apiKey: 'k1', secret: 's1', password: 'p1' })
+    const b = deriveUtaId(OKX_PRESET, { mode: 'live', apiKey: 'k1', secret: 's1', password: 'p1' })
+    expect(a).toBe(b)
+  })
+
+  it('matches the documented `${preset.id}-${8hex}` shape', () => {
+    const id = deriveUtaId(OKX_PRESET, { mode: 'live', apiKey: 'k1' })
+    expect(id).toMatch(/^okx-[0-9a-f]{8}$/)
+  })
+
+  it('object-key order does not change the id', () => {
+    const a = deriveUtaId(OKX_PRESET, { mode: 'live', apiKey: 'k1', secret: 's1' })
+    const b = deriveUtaId(OKX_PRESET, { secret: 's1', apiKey: 'k1', mode: 'live' })
+    expect(a).toBe(b)
+  })
+
+  it('only fingerprintFields contribute — non-fingerprint fields ignored', () => {
+    // OKX fingerprintFields = ['mode', 'apiKey']. password / secret should not affect id.
+    const a = deriveUtaId(OKX_PRESET, { mode: 'live', apiKey: 'k', secret: 's1', password: 'p1' })
+    const b = deriveUtaId(OKX_PRESET, { mode: 'live', apiKey: 'k', secret: 's2', password: 'p2' })
+    expect(a).toBe(b)
+  })
+
+  it('different fingerprint values produce different ids', () => {
+    const live = deriveUtaId(OKX_PRESET, { mode: 'live', apiKey: 'k1' })
+    const demo = deriveUtaId(OKX_PRESET, { mode: 'demo', apiKey: 'k1' })
+    expect(live).not.toBe(demo)
+  })
+
+  it('different presets with identical fingerprint values still differ (preset id prefixes the hash input)', () => {
+    const okx = deriveUtaId(OKX_PRESET, { mode: 'live', apiKey: 'k1' })
+    const bybit = deriveUtaId(BYBIT_PRESET, { mode: 'live', apiKey: 'k1' })
+    expect(okx).not.toBe(bybit)
+    expect(okx.startsWith('okx-')).toBe(true)
+    expect(bybit.startsWith('bybit-')).toBe(true)
+  })
+
+  it('missing optional fields normalize to null (stable across presence variations)', () => {
+    // CCXT Custom fingerprintFields = ['exchange','sandbox','demoTrading','apiKey','walletAddress'].
+    // Two configs that differ only on undefined-vs-null for an absent field should match.
+    const a = deriveUtaId(CCXT_CUSTOM_PRESET, { exchange: 'kucoin', apiKey: 'k' })
+    const b = deriveUtaId(CCXT_CUSTOM_PRESET, { exchange: 'kucoin', apiKey: 'k', walletAddress: undefined })
+    expect(a).toBe(b)
+  })
+
+  it('Mock derives off _instanceId — random id every freshly-minted sim', () => {
+    const a = deriveUtaId(SIMULATOR_PRESET, { _instanceId: 'aaaaaaaa', cash: 100 })
+    const b = deriveUtaId(SIMULATOR_PRESET, { _instanceId: 'bbbbbbbb', cash: 100 })
+    const same = deriveUtaId(SIMULATOR_PRESET, { _instanceId: 'aaaaaaaa', cash: 999 })
+    expect(a).not.toBe(b)
+    // Cash isn't a fingerprint field for Mock — same _instanceId gives same id.
+    expect(a).toBe(same)
   })
 })

--- a/src/domain/trading/brokers/presets.ts
+++ b/src/domain/trading/brokers/presets.ts
@@ -19,12 +19,12 @@ export interface SerializedBrokerPreset {
   id: string
   label: string
   description: string
-  category: 'recommended' | 'crypto'
+  category: 'recommended' | 'crypto' | 'testing'
   hint?: string
   defaultName: string
   badge: string
   badgeColor: string
-  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge'
+  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'mock'
   guardCategory: 'crypto' | 'securities'
   modes?: ModeOption[]
   subtitleFields: SubtitleSegment[]

--- a/src/domain/trading/brokers/registry.ts
+++ b/src/domain/trading/brokers/registry.ts
@@ -16,6 +16,7 @@ import { AlpacaBroker } from './alpaca/AlpacaBroker.js'
 import { IbkrBroker } from './ibkr/IbkrBroker.js'
 import { LeverupBroker } from './others/leverup/index.js'
 import { LongbridgeBroker } from './longbridge/index.js'
+import { MockBroker } from './mock/MockBroker.js'
 import type { BrokerEngine } from './preset-catalog.js'
 
 /** Minimal engine entry: just enough to validate + instantiate. */
@@ -46,5 +47,9 @@ export const BROKER_ENGINE_REGISTRY: Record<BrokerEngine, BrokerEngineEntry> = {
   longbridge: {
     configSchema: LongbridgeBroker.configSchema,
     fromConfig: LongbridgeBroker.fromConfig,
+  },
+  mock: {
+    configSchema: MockBroker.configSchema,
+    fromConfig: MockBroker.fromConfig,
   },
 }

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -20,6 +20,7 @@ import { createBrainRoutes } from './routes/brain.js'
 import { createTradingRoutes } from './routes/trading.js'
 import { createTradingConfigRoutes } from './routes/trading-config.js'
 import { createDevRoutes } from './routes/dev.js'
+import { createSimulatorRoutes } from './routes/simulator.js'
 import { createToolsRoutes } from './routes/tools.js'
 import { createAgentStatusRoutes } from './routes/agent-status.js'
 import { createPersonaRoutes } from './routes/persona.js'
@@ -108,6 +109,7 @@ export class WebPlugin implements Plugin {
     app.route('/api/trading/config', createTradingConfigRoutes(ctx))
     app.route('/api/trading', createTradingRoutes(ctx))
     app.route('/api/dev', createDevRoutes(ctx.connectorCenter))
+    app.route('/api/simulator', createSimulatorRoutes(ctx))
     app.route('/api/tools', createToolsRoutes(ctx.toolCenter))
     app.route('/api/agent-status', createAgentStatusRoutes(ctx))
     app.route('/api/news', createNewsRoutes(ctx))

--- a/src/webui/routes/simulator.spec.ts
+++ b/src/webui/routes/simulator.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Simulator routes spec — exercises the HTTP adapter end-to-end against a
+ * real MockBroker, NOT vi.fn() stubs. Catches both the route-layer wiring
+ * (params parsing, status codes) AND the underlying broker behaviour (a
+ * markPrice flow through to a position update).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createSimulatorRoutes } from './simulator.js'
+import { MockBroker } from '../../domain/trading/brokers/mock/MockBroker.js'
+import type { EngineContext } from '../../core/types.js'
+
+interface FakeUTA {
+  id: string
+  label: string
+  broker: MockBroker
+}
+
+function makeCtx(brokers: Record<string, MockBroker | object>): EngineContext {
+  const utas = new Map<string, FakeUTA>()
+  for (const [id, b] of Object.entries(brokers)) {
+    utas.set(id, { id, label: id, broker: b as MockBroker })
+  }
+  return {
+    utaManager: {
+      get: (id: string) => utas.get(id),
+      resolve: () => [...utas.values()],
+      listUTAs: () => [...utas.values()].map(u => ({ id: u.id, label: u.label })),
+    },
+  } as unknown as EngineContext
+}
+
+async function req(routes: ReturnType<typeof createSimulatorRoutes>, method: 'GET' | 'POST', path: string, body?: unknown) {
+  const init: RequestInit = { method }
+  if (body !== undefined) {
+    init.headers = { 'Content-Type': 'application/json' }
+    init.body = JSON.stringify(body)
+  }
+  const res = await routes.request(path, init)
+  const json = res.status === 204 ? null : await res.json().catch(() => null)
+  return { status: res.status, body: json }
+}
+
+// ==================== Tests ====================
+
+describe('GET /utas', () => {
+  it('lists only UTAs whose broker is a MockBroker', async () => {
+    const mock = new MockBroker({ id: 'sim' })
+    const fake = { /* not a MockBroker */ } as object
+    const routes = createSimulatorRoutes(makeCtx({ sim: mock, real: fake }))
+    const { status, body } = await req(routes, 'GET', '/utas')
+    expect(status).toBe(200)
+    const utas = (body as { utas: Array<{ id: string }> }).utas
+    expect(utas.map(u => u.id)).toEqual(['sim'])
+  })
+})
+
+describe('GET /uta/:id/state', () => {
+  let mock: MockBroker
+  let routes: ReturnType<typeof createSimulatorRoutes>
+  beforeEach(() => {
+    mock = new MockBroker({ id: 'sim', cash: 50_000 })
+    routes = createSimulatorRoutes(makeCtx({ sim: mock }))
+  })
+
+  it('returns full snapshot', async () => {
+    mock.setMarkPrice('BTC', 80000)
+    const { status, body } = await req(routes, 'GET', '/uta/sim/state')
+    expect(status).toBe(200)
+    expect((body as { cash: string }).cash).toBe('50000')
+    expect((body as { markPrices: Array<{ nativeKey: string; price: string }> }).markPrices)
+      .toEqual([{ nativeKey: 'BTC', price: '80000' }])
+  })
+
+  it('404 for unknown UTA', async () => {
+    const { status } = await req(routes, 'GET', '/uta/missing/state')
+    expect(status).toBe(404)
+  })
+
+  it('400 when broker is not a simulator', async () => {
+    const fake = { /* not Mock */ } as object
+    const r = createSimulatorRoutes(makeCtx({ real: fake }))
+    const { status } = await req(r, 'GET', '/uta/real/state')
+    expect(status).toBe(400)
+  })
+})
+
+describe('POST /uta/:id/mark-price', () => {
+  it('sets markPrice + auto-fills触达 limit orders', async () => {
+    const mock = new MockBroker({ id: 'sim', cash: 100_000 })
+    const routes = createSimulatorRoutes(makeCtx({ sim: mock }))
+
+    // Place a BUY LMT @ 79000 — sits pending until price drops
+    const { Contract, Order } = await import('@traderalice/ibkr')
+    const Decimal = (await import('decimal.js')).default
+    const contract = new Contract()
+    contract.symbol = 'BTC'
+    contract.localSymbol = 'BTC'
+    contract.secType = 'CRYPTO'
+    contract.exchange = 'MOCK'
+    contract.currency = 'USD'
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal(1)
+    order.lmtPrice = new Decimal(79000)
+    const placed = await mock.placeOrder(contract, order)
+    expect(placed.success).toBe(true)
+
+    // Initial price 80k → order stays pending
+    await req(routes, 'POST', '/uta/sim/mark-price', { nativeKey: 'BTC', price: '80000' })
+    expect(mock.getSimulatorState().pendingOrders).toHaveLength(1)
+
+    // Price drops to 79000 → fills
+    const { status, body } = await req(routes, 'POST', '/uta/sim/mark-price', { nativeKey: 'BTC', price: '79000' })
+    expect(status).toBe(200)
+    expect((body as { filled: string[] }).filled).toEqual([placed.orderId!])
+    expect(mock.getSimulatorState().pendingOrders).toHaveLength(0)
+    expect(mock.getSimulatorState().positions).toHaveLength(1)
+  })
+
+  it('rejects malformed body with 400', async () => {
+    const mock = new MockBroker({ id: 'sim' })
+    const routes = createSimulatorRoutes(makeCtx({ sim: mock }))
+    const { status } = await req(routes, 'POST', '/uta/sim/mark-price', { wrongField: 'x' })
+    expect(status).toBe(400)
+  })
+})
+
+describe('POST /uta/:id/external-deposit', () => {
+  it('adds a wallet-source position bypassing the order pipeline', async () => {
+    const mock = new MockBroker({ id: 'sim' })
+    const routes = createSimulatorRoutes(makeCtx({ sim: mock }))
+    mock.setMarkPrice('BTC', 80000)
+
+    const { status } = await req(routes, 'POST', '/uta/sim/external-deposit', {
+      nativeKey: 'BTC',
+      quantity: '1.0093',
+      contract: { symbol: 'BTC', secType: 'CRYPTO' },
+    })
+    expect(status).toBe(200)
+
+    const positions = await mock.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].quantity.toString()).toBe('1.0093')
+    expect(positions[0].avgCostSource).toBe('wallet')
+    // avgCost = markPrice (placeholder); UTA reconcile will replace.
+    expect(positions[0].avgCost).toBe('80000')
+  })
+})
+
+describe('POST /uta/:id/external-trade', () => {
+  it('updates position + cash; tags wallet-source', async () => {
+    const mock = new MockBroker({ id: 'sim', cash: 100_000 })
+    const routes = createSimulatorRoutes(makeCtx({ sim: mock }))
+
+    const { status } = await req(routes, 'POST', '/uta/sim/external-trade', {
+      nativeKey: 'BTC',
+      side: 'BUY',
+      quantity: '0.5',
+      price: '60000',
+      contract: { symbol: 'BTC', secType: 'CRYPTO' },
+    })
+    expect(status).toBe(200)
+
+    const positions = await mock.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].avgCost).toBe('60000')
+    expect(positions[0].avgCostSource).toBe('wallet')
+
+    const account = await mock.getAccount()
+    expect(account.totalCashValue).toBe('70000')  // 100k - 30k
+  })
+})
+
+describe('POST /uta/:id/orders/:orderId/fill', () => {
+  it('manually fills a pending order at default markPrice', async () => {
+    const mock = new MockBroker({ id: 'sim', cash: 100_000 })
+    const routes = createSimulatorRoutes(makeCtx({ sim: mock }))
+    mock.setMarkPrice('BTC', 80000)
+
+    const { Contract, Order } = await import('@traderalice/ibkr')
+    const Decimal = (await import('decimal.js')).default
+    const contract = new Contract()
+    contract.symbol = 'BTC'
+    contract.localSymbol = 'BTC'
+    contract.secType = 'CRYPTO'
+    contract.exchange = 'MOCK'
+    contract.currency = 'USD'
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal(0.5)
+    order.lmtPrice = new Decimal(70000)  // would not auto-fill at 80k
+    const placed = await mock.placeOrder(contract, order)
+
+    const { status } = await req(routes, 'POST', `/uta/sim/orders/${placed.orderId}/fill`, {})
+    expect(status).toBe(200)
+    expect(mock.getSimulatorState().pendingOrders).toHaveLength(0)
+  })
+
+  it('400 for unknown orderId', async () => {
+    const mock = new MockBroker({ id: 'sim' })
+    const routes = createSimulatorRoutes(makeCtx({ sim: mock }))
+    const { status } = await req(routes, 'POST', '/uta/sim/orders/missing/fill', {})
+    expect(status).toBe(400)
+  })
+})

--- a/src/webui/routes/simulator.ts
+++ b/src/webui/routes/simulator.ts
@@ -1,0 +1,212 @@
+/**
+ * Simulator routes — HTTP control panel for MockBroker UTAs.
+ *
+ * Thin adapter over the simulator surface MockBroker exposes (setMarkPrice,
+ * fillOrder, externalDeposit, etc.). The webui dev `/dev/simulator` tab
+ * speaks this API; spec/curl use the same endpoints.
+ *
+ * Only operates on UTAs whose broker is a MockBroker — for any other broker
+ * the routes return 400 "not a simulator". Real brokers shouldn't accept
+ * god-view commands.
+ *
+ * Per the route-layer thinness convention: all撮合 / cost-basis / position
+ * mutation logic stays in MockBroker; this file only translates HTTP →
+ * broker method calls.
+ */
+
+import { Hono } from 'hono'
+import type { Context } from 'hono'
+import { z } from 'zod'
+import type { EngineContext } from '../../core/types.js'
+import { MockBroker } from '../../domain/trading/brokers/mock/MockBroker.js'
+
+// ==================== Schemas ====================
+
+const numericString = z.union([z.string().min(1), z.number()]).transform((v) => String(v))
+
+const setMarkPriceSchema = z.object({
+  nativeKey: z.string().min(1),
+  price: numericString,
+})
+
+const tickPriceSchema = z.object({
+  nativeKey: z.string().min(1),
+  deltaPercent: z.number(),
+})
+
+const fillOrderSchema = z.object({
+  price: numericString.optional(),
+  qty: numericString.optional(),
+})
+
+const externalDepositSchema = z.object({
+  nativeKey: z.string().min(1),
+  quantity: numericString,
+  contract: z.object({
+    symbol: z.string().optional(),
+    localSymbol: z.string().optional(),
+    secType: z.string().optional(),
+    exchange: z.string().optional(),
+    currency: z.string().optional(),
+  }).optional(),
+})
+
+const externalWithdrawSchema = z.object({
+  nativeKey: z.string().min(1),
+  quantity: numericString,
+})
+
+const externalTradeSchema = z.object({
+  nativeKey: z.string().min(1),
+  side: z.enum(['BUY', 'SELL']),
+  quantity: numericString,
+  price: numericString,
+  contract: externalDepositSchema.shape.contract,
+})
+
+// ==================== Helpers ====================
+
+/** Resolve :id → UTA whose broker is a MockBroker. Returns error response on miss. */
+function resolveMock(ctx: EngineContext, c: Context): { broker: MockBroker } | { error: Response } {
+  const id = c.req.param('id')
+  if (!id) return { error: c.json({ error: 'Missing UTA id' }, 400) }
+  const uta = ctx.utaManager.get(id)
+  if (!uta) return { error: c.json({ error: `UTA ${id} not found` }, 404) }
+  if (!(uta.broker instanceof MockBroker)) {
+    return { error: c.json({ error: `UTA ${id} is not a simulator (broker=${uta.broker.constructor.name})` }, 400) }
+  }
+  return { broker: uta.broker }
+}
+
+async function parseBody<T extends z.ZodTypeAny>(c: Context, schema: T): Promise<{ ok: true; data: z.infer<T> } | { ok: false; error: Response }> {
+  let raw: unknown
+  try { raw = await c.req.json() } catch { return { ok: false, error: c.json({ error: 'Invalid JSON' }, 400) } }
+  const parsed = schema.safeParse(raw)
+  if (!parsed.success) {
+    return { ok: false, error: c.json({ error: 'Validation failed', issues: parsed.error.issues }, 400) }
+  }
+  return { ok: true, data: parsed.data }
+}
+
+// ==================== Routes ====================
+
+export function createSimulatorRoutes(ctx: EngineContext) {
+  const app = new Hono()
+
+  /** List all simulator-capable UTAs. */
+  app.get('/utas', (c) => {
+    const utas = ctx.utaManager.resolve()
+      .filter(u => u.broker instanceof MockBroker)
+      .map(u => ({ id: u.id, label: u.label }))
+    return c.json({ utas })
+  })
+
+  /** Full state snapshot for one simulator UTA. */
+  app.get('/uta/:id/state', (c) => {
+    const r = resolveMock(ctx, c)
+    if ('error' in r) return r.error
+    return c.json(r.broker.getSimulatorState())
+  })
+
+  /** Set markPrice. Auto-matches触达 pending orders. */
+  app.post('/uta/:id/mark-price', async (c) => {
+    const r = resolveMock(ctx, c)
+    if ('error' in r) return r.error
+    const body = await parseBody(c, setMarkPriceSchema)
+    if (!body.ok) return body.error
+    try {
+      const filled = r.broker.setMarkPrice(body.data.nativeKey, body.data.price)
+      return c.json({ filled })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
+    }
+  })
+
+  /** Move markPrice by relative percent. */
+  app.post('/uta/:id/tick-price', async (c) => {
+    const r = resolveMock(ctx, c)
+    if ('error' in r) return r.error
+    const body = await parseBody(c, tickPriceSchema)
+    if (!body.ok) return body.error
+    try {
+      const filled = r.broker.tickPrice(body.data.nativeKey, body.data.deltaPercent)
+      return c.json({ filled })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
+    }
+  })
+
+  /** Manually fill a pending order (full or partial). */
+  app.post('/uta/:id/orders/:orderId/fill', async (c) => {
+    const r = resolveMock(ctx, c)
+    if ('error' in r) return r.error
+    const orderId = c.req.param('orderId')
+    if (!orderId) return c.json({ error: 'Missing orderId' }, 400)
+    const body = await parseBody(c, fillOrderSchema)
+    if (!body.ok) return body.error
+    try {
+      r.broker.fillOrder(orderId, body.data)
+      return c.json({ ok: true })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
+    }
+  })
+
+  /** Force-cancel a pending order. */
+  app.post('/uta/:id/orders/:orderId/cancel', (c) => {
+    const r = resolveMock(ctx, c)
+    if ('error' in r) return r.error
+    const orderId = c.req.param('orderId')
+    if (!orderId) return c.json({ error: 'Missing orderId' }, 400)
+    try {
+      r.broker.cancelPendingOrder(orderId)
+      return c.json({ ok: true })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
+    }
+  })
+
+  /** Simulate external balance change (空投, transfer-in, staking reward). */
+  app.post('/uta/:id/external-deposit', async (c) => {
+    const r = resolveMock(ctx, c)
+    if ('error' in r) return r.error
+    const body = await parseBody(c, externalDepositSchema)
+    if (!body.ok) return body.error
+    try {
+      r.broker.externalDeposit(body.data)
+      return c.json({ ok: true })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
+    }
+  })
+
+  /** Simulate external withdrawal. */
+  app.post('/uta/:id/external-withdraw', async (c) => {
+    const r = resolveMock(ctx, c)
+    if ('error' in r) return r.error
+    const body = await parseBody(c, externalWithdrawSchema)
+    if (!body.ok) return body.error
+    try {
+      r.broker.externalWithdraw(body.data.nativeKey, body.data.quantity)
+      return c.json({ ok: true })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
+    }
+  })
+
+  /** Simulate user manually trading on the exchange app. */
+  app.post('/uta/:id/external-trade', async (c) => {
+    const r = resolveMock(ctx, c)
+    if ('error' in r) return r.error
+    const body = await parseBody(c, externalTradeSchema)
+    if (!body.ok) return body.error
+    try {
+      r.broker.externalTrade(body.data)
+      return c.json({ ok: true })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
+    }
+  })
+
+  return app
+}

--- a/src/webui/routes/simulator.ts
+++ b/src/webui/routes/simulator.ts
@@ -39,16 +39,25 @@ const fillOrderSchema = z.object({
   qty: numericString.optional(),
 })
 
+// IBKR contract surface: includes derivative-distinguishing fields so the
+// simulator can model OPT/FOP/FUT/CASH/BOND alongside CRYPTO.
+const contractSchema = z.object({
+  symbol: z.string().optional(),
+  localSymbol: z.string().optional(),
+  secType: z.string().optional(),
+  exchange: z.string().optional(),
+  currency: z.string().optional(),
+  // Derivative metadata
+  lastTradeDateOrContractMonth: z.string().optional(),  // e.g. "20260720" or "202606"
+  strike: z.number().optional(),                         // option strike, e.g. 150
+  right: z.enum(['C', 'P', 'CALL', 'PUT']).optional(),    // option right
+  multiplier: z.string().optional(),                     // shares-per-contract, e.g. "100"
+})
+
 const externalDepositSchema = z.object({
   nativeKey: z.string().min(1),
   quantity: numericString,
-  contract: z.object({
-    symbol: z.string().optional(),
-    localSymbol: z.string().optional(),
-    secType: z.string().optional(),
-    exchange: z.string().optional(),
-    currency: z.string().optional(),
-  }).optional(),
+  contract: contractSchema.optional(),
 })
 
 const externalWithdrawSchema = z.object({
@@ -61,7 +70,7 @@ const externalTradeSchema = z.object({
   side: z.enum(['BUY', 'SELL']),
   quantity: numericString,
   price: numericString,
-  contract: externalDepositSchema.shape.contract,
+  contract: contractSchema.optional(),
 })
 
 // ==================== Helpers ====================

--- a/src/webui/routes/trading-config.spec.ts
+++ b/src/webui/routes/trading-config.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * trading-config routes — covers the derived-id create flow and edit-only PUT.
+ *
+ * Mocks `core/config.js` read/write with in-memory state so we don't touch
+ * the real `data/` directory; the rest (preset catalog, deriveUtaId, route
+ * wiring) is exercised for real.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mock readUTAsConfig / writeUTAsConfig with in-memory store BEFORE importing the route.
+let utaStore: unknown[] = []
+vi.mock('../../core/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../core/config.js')>('../../core/config.js')
+  return {
+    ...actual,
+    readUTAsConfig: vi.fn(async () => utaStore),
+    writeUTAsConfig: vi.fn(async (next: unknown[]) => { utaStore = [...next] }),
+  }
+})
+
+import { createTradingConfigRoutes } from './trading-config.js'
+import type { EngineContext } from '../../core/types.js'
+import { deriveUtaId, OKX_PRESET, SIMULATOR_PRESET } from '../../domain/trading/brokers/preset-catalog.js'
+
+// ==================== Test fixtures ====================
+
+function makeRoutes() {
+  const ctx = {
+    utaManager: {
+      get: vi.fn(),
+      resolve: () => [],
+      listUTAs: () => [],
+      reconnectUTA: vi.fn(async () => ({ success: true })),
+      removeUTA: vi.fn(async () => {}),
+    },
+  } as unknown as EngineContext
+  return createTradingConfigRoutes(ctx)
+}
+
+async function req(routes: ReturnType<typeof createTradingConfigRoutes>, method: 'GET' | 'POST' | 'PUT' | 'DELETE', path: string, body?: unknown) {
+  const init: RequestInit = { method }
+  if (body !== undefined) {
+    init.headers = { 'Content-Type': 'application/json' }
+    init.body = JSON.stringify(body)
+  }
+  const res = await routes.request(path, init)
+  const json = res.status === 204 ? null : await res.json().catch(() => null)
+  return { status: res.status, body: json }
+}
+
+beforeEach(() => { utaStore = [] })
+
+// ==================== POST /uta ====================
+
+describe('POST /uta — derived id creation', () => {
+  it('201 + derived id matching deriveUtaId(preset, presetConfig)', async () => {
+    const routes = makeRoutes()
+    const presetConfig = { mode: 'live', apiKey: 'k1', secret: 's1', password: 'p1' }
+    const expectedId = deriveUtaId(OKX_PRESET, presetConfig)
+
+    const { status, body } = await req(routes, 'POST', '/uta', {
+      presetId: 'okx',
+      label: 'My OKX',
+      presetConfig,
+    })
+    expect(status).toBe(201)
+    expect((body as { id: string }).id).toBe(expectedId)
+    expect((body as { label: string }).label).toBe('My OKX')
+    expect(utaStore).toHaveLength(1)
+  })
+
+  it('400 when presetId is missing', async () => {
+    const routes = makeRoutes()
+    const { status } = await req(routes, 'POST', '/uta', { presetConfig: {} })
+    expect(status).toBe(400)
+  })
+
+  it('400 for unknown presetId', async () => {
+    const routes = makeRoutes()
+    const { status } = await req(routes, 'POST', '/uta', { presetId: 'never-existed', presetConfig: {} })
+    expect(status).toBe(400)
+  })
+
+  it('409 + existing-UTA info when fingerprint collides', async () => {
+    const routes = makeRoutes()
+    const presetConfig = { mode: 'live', apiKey: 'shared-key', secret: 's', password: 'p' }
+    const first = await req(routes, 'POST', '/uta', { presetId: 'okx', label: 'Original', presetConfig })
+    expect(first.status).toBe(201)
+
+    const second = await req(routes, 'POST', '/uta', { presetId: 'okx', label: 'Duplicate', presetConfig })
+    expect(second.status).toBe(409)
+    expect((second.body as { existing: { id: string; label: string } }).existing.label).toBe('Original')
+  })
+
+  it('409 also fires when only non-fingerprint fields differ (different secret, same apiKey)', async () => {
+    const routes = makeRoutes()
+    await req(routes, 'POST', '/uta', {
+      presetId: 'okx',
+      presetConfig: { mode: 'live', apiKey: 'k', secret: 'rotated-1', password: 'p' },
+    })
+    const second = await req(routes, 'POST', '/uta', {
+      presetId: 'okx',
+      presetConfig: { mode: 'live', apiKey: 'k', secret: 'rotated-2', password: 'p' },
+    })
+    expect(second.status).toBe(409)
+  })
+
+  it('Mock preset: mints _instanceId when missing, persists it', async () => {
+    const routes = makeRoutes()
+    const { status, body } = await req(routes, 'POST', '/uta', {
+      presetId: 'mock-simulator',
+      label: 'sim',
+      presetConfig: { cash: 50000 },
+    })
+    expect(status).toBe(201)
+    const created = body as { id: string; presetConfig: Record<string, unknown> }
+    expect(created.id).toMatch(/^mock-simulator-[0-9a-f]{8}$/)
+    expect(created.presetConfig._instanceId).toBeTruthy()
+    expect(typeof created.presetConfig._instanceId).toBe('string')
+  })
+
+  it('Mock preset: two creates without _instanceId yield different ids', async () => {
+    const routes = makeRoutes()
+    const a = await req(routes, 'POST', '/uta', { presetId: 'mock-simulator', presetConfig: { cash: 100 } })
+    const b = await req(routes, 'POST', '/uta', { presetId: 'mock-simulator', presetConfig: { cash: 100 } })
+    expect(a.status).toBe(201)
+    expect(b.status).toBe(201)
+    expect((a.body as { id: string }).id).not.toBe((b.body as { id: string }).id)
+  })
+
+  it('Mock preset: explicit _instanceId reused → 409 (deterministic)', async () => {
+    const routes = makeRoutes()
+    const presetConfig = { _instanceId: 'cafebabe', cash: 100 }
+    const first = await req(routes, 'POST', '/uta', { presetId: 'mock-simulator', presetConfig })
+    expect(first.status).toBe(201)
+    const second = await req(routes, 'POST', '/uta', { presetId: 'mock-simulator', presetConfig })
+    expect(second.status).toBe(409)
+  })
+})
+
+// ==================== PUT /uta/:id ====================
+
+describe('PUT /uta/:id — edit-only', () => {
+  it('422 when no UTA exists at the given id', async () => {
+    const routes = makeRoutes()
+    const { status, body } = await req(routes, 'PUT', '/uta/okx-deadbeef', {
+      id: 'okx-deadbeef',
+      presetId: 'okx',
+      enabled: true,
+      guards: [],
+      presetConfig: { mode: 'live', apiKey: 'k', secret: 's', password: 'p' },
+    })
+    expect(status).toBe(422)
+    expect((body as { error: string }).error).toMatch(/use POST/i)
+  })
+
+  it('200 + label updated when UTA exists', async () => {
+    const routes = makeRoutes()
+    // Seed via POST.
+    const created = await req(routes, 'POST', '/uta', {
+      presetId: 'okx',
+      label: 'before',
+      presetConfig: { mode: 'live', apiKey: 'k', secret: 's', password: 'p' },
+    })
+    const id = (created.body as { id: string }).id
+
+    const edited = await req(routes, 'PUT', `/uta/${id}`, {
+      id,
+      presetId: 'okx',
+      label: 'after',
+      enabled: true,
+      guards: [],
+      presetConfig: { mode: 'live', apiKey: 'k', secret: 's', password: 'p' },
+    })
+    expect(edited.status).toBe(200)
+    expect((edited.body as { label: string }).label).toBe('after')
+  })
+
+  it('400 when body.id !== url id', async () => {
+    const routes = makeRoutes()
+    const created = await req(routes, 'POST', '/uta', {
+      presetId: 'okx',
+      presetConfig: { mode: 'live', apiKey: 'k', secret: 's', password: 'p' },
+    })
+    const id = (created.body as { id: string }).id
+
+    const { status } = await req(routes, 'PUT', `/uta/${id}`, {
+      id: 'something-else',
+      presetId: 'okx',
+      enabled: true,
+      guards: [],
+      presetConfig: { mode: 'live', apiKey: 'k', secret: 's', password: 'p' },
+    })
+    expect(status).toBe(400)
+  })
+})
+
+// ==================== Mock preset_instanceId: deriveUtaId stable on Mock minted ID ====================
+
+describe('Mock _instanceId stability', () => {
+  it('same _instanceId across POSTs yields same derived id (idempotent for explicit instanceId)', () => {
+    const a = deriveUtaId(SIMULATOR_PRESET, { _instanceId: 'aabbccdd', cash: 1 })
+    const b = deriveUtaId(SIMULATOR_PRESET, { _instanceId: 'aabbccdd', cash: 999 })
+    expect(a).toBe(b)
+  })
+})

--- a/src/webui/routes/trading-config.ts
+++ b/src/webui/routes/trading-config.ts
@@ -6,6 +6,7 @@ import {
 } from '../../core/config.js'
 import { createBroker } from '../../domain/trading/brokers/factory.js'
 import { BUILTIN_BROKER_PRESETS } from '../../domain/trading/brokers/presets.js'
+import { deriveUtaId, getBrokerPreset, mintInstanceId } from '../../domain/trading/brokers/preset-catalog.js'
 
 // ==================== Credential helpers ====================
 
@@ -71,6 +72,76 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
 
   // ==================== UTA CRUD ====================
 
+  /**
+   * POST /uta — create a new UTA. Client supplies presetId + presetConfig
+   * (+ optional label/guards). The id is derived from the preset's
+   * fingerprintFields (deterministic broker identity) and assigned by
+   * the server. Mock presets get a freshly-minted `_instanceId` if the
+   * client didn't include one. 409 if an existing UTA already derives
+   * to the same id (so re-adding the same broker doesn't silently fork).
+   */
+  app.post('/uta', async (c) => {
+    try {
+      const body = await c.req.json() as Record<string, unknown>
+      if (!body.presetId || typeof body.presetId !== 'string') {
+        return c.json({ error: 'presetId is required' }, 400)
+      }
+
+      let preset
+      try {
+        preset = getBrokerPreset(body.presetId)
+      } catch (err) {
+        return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
+      }
+
+      // Mint _instanceId for Mock presets so each sim has a unique fingerprint.
+      const presetConfig = { ...(body.presetConfig as Record<string, unknown> | undefined ?? {}) }
+      if (preset.engine === 'mock' && !presetConfig._instanceId) {
+        presetConfig._instanceId = mintInstanceId()
+      }
+
+      const id = deriveUtaId(preset, presetConfig)
+      const accounts = await readUTAsConfig()
+      const existing = accounts.find((a) => a.id === id)
+      if (existing) {
+        return c.json({
+          error: 'A UTA already exists for this broker identity',
+          existing: {
+            id: existing.id,
+            label: existing.label ?? existing.id,
+            presetId: existing.presetId,
+          },
+        }, 409)
+      }
+
+      const candidate = {
+        id,
+        label: typeof body.label === 'string' && body.label ? body.label : id,
+        presetId: preset.id,
+        enabled: body.enabled !== false,
+        guards: Array.isArray(body.guards) ? body.guards : [],
+        presetConfig,
+      }
+      const validated = utaConfigSchema.parse(candidate)
+      accounts.push(validated)
+      await writeUTAsConfig(accounts)
+
+      ctx.utaManager.reconnectUTA(id).catch(() => {})
+      return c.json(validated, 201)
+    } catch (err) {
+      if (err instanceof Error && err.name === 'ZodError') {
+        return c.json({ error: 'Validation failed', details: JSON.parse(err.message) }, 400)
+      }
+      return c.json({ error: String(err) }, 500)
+    }
+  })
+
+  /**
+   * PUT /uta/:id — edit an existing UTA. Will NOT create a new one; new
+   * UTAs go through POST /uta which derives the id from credentials.
+   * Edits keep the original id even when credentials change (rotation
+   * is a normal user action; id is set at origin and immutable).
+   */
   app.put('/uta/:id', async (c) => {
     try {
       const id = c.req.param('id')
@@ -79,31 +150,32 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
         return c.json({ error: 'Body id must match URL id' }, 400)
       }
 
-      // Restore masked credentials from existing config
       const accounts = await readUTAsConfig()
       const existing = accounts.find((a) => a.id === id)
-      if (existing) {
-        unmaskSecrets(body, existing as unknown as Record<string, unknown>)
+      if (!existing) {
+        return c.json({
+          error: `UTA "${id}" not found. Use POST /uta to create a new account.`,
+        }, 422)
       }
+
+      // Restore masked credentials from existing config
+      unmaskSecrets(body, existing as unknown as Record<string, unknown>)
 
       const validated = utaConfigSchema.parse(body)
-
       const idx = accounts.findIndex((a) => a.id === id)
-      if (idx >= 0) {
-        accounts[idx] = validated
-      } else {
-        accounts.push(validated)
-      }
+      accounts[idx] = validated
       await writeUTAsConfig(accounts)
 
       // Handle enabled state changes at runtime
-      const wasEnabled = existing?.enabled !== false
+      const wasEnabled = existing.enabled !== false
       const nowEnabled = validated.enabled !== false
       if (wasEnabled && !nowEnabled) {
-        // Disabled — close running account
         await ctx.utaManager.removeUTA(id)
       } else if (!wasEnabled && nowEnabled) {
-        // Enabled — start account
+        ctx.utaManager.reconnectUTA(id).catch(() => {})
+      } else if (wasEnabled && nowEnabled) {
+        // Same enabled state but credentials may have changed (rotation) —
+        // bounce the account so the new credentials take effect.
         ctx.utaManager.reconnectUTA(id).catch(() => {})
       }
 

--- a/ui/src/api/simulator.ts
+++ b/ui/src/api/simulator.ts
@@ -1,0 +1,90 @@
+/**
+ * API client for the MockBroker simulator control panel.
+ * Mirrors the routes mounted at /api/simulator (see src/webui/routes/simulator.ts).
+ */
+
+export interface SimulatorUTAEntry {
+  id: string
+  label: string
+}
+
+export interface SimulatorMarkPrice {
+  nativeKey: string
+  price: string
+}
+
+export interface SimulatorPosition {
+  nativeKey: string
+  symbol: string
+  localSymbol?: string
+  secType?: string
+  side: 'long' | 'short'
+  quantity: string
+  avgCost: string
+  avgCostSource?: 'broker' | 'wallet'
+}
+
+export interface SimulatorPendingOrder {
+  orderId: string
+  nativeKey: string
+  symbol: string
+  action: string
+  orderType: string
+  totalQuantity: string
+  lmtPrice?: string
+  auxPrice?: string
+}
+
+export interface SimulatorState {
+  cash: string
+  markPrices: SimulatorMarkPrice[]
+  positions: SimulatorPosition[]
+  pendingOrders: SimulatorPendingOrder[]
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    const msg = (data as { error?: string }).error ?? `HTTP ${res.status}`
+    throw new Error(msg)
+  }
+  return data as T
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+export const simulatorApi = {
+  listUtas: () => getJson<{ utas: SimulatorUTAEntry[] }>('/api/simulator/utas'),
+
+  state: (utaId: string) => getJson<SimulatorState>(`/api/simulator/uta/${encodeURIComponent(utaId)}/state`),
+
+  setMarkPrice: (utaId: string, nativeKey: string, price: string | number) =>
+    postJson<{ filled: string[] }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/mark-price`, { nativeKey, price }),
+
+  tickPrice: (utaId: string, nativeKey: string, deltaPercent: number) =>
+    postJson<{ filled: string[] }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/tick-price`, { nativeKey, deltaPercent }),
+
+  fillOrder: (utaId: string, orderId: string, opts: { price?: string; qty?: string } = {}) =>
+    postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/orders/${encodeURIComponent(orderId)}/fill`, opts),
+
+  cancelOrder: (utaId: string, orderId: string) =>
+    postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/orders/${encodeURIComponent(orderId)}/cancel`, {}),
+
+  externalDeposit: (utaId: string, params: { nativeKey: string; quantity: string; contract?: { symbol?: string; localSymbol?: string; secType?: string; exchange?: string; currency?: string } }) =>
+    postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/external-deposit`, params),
+
+  externalWithdraw: (utaId: string, nativeKey: string, quantity: string) =>
+    postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/external-withdraw`, { nativeKey, quantity }),
+
+  externalTrade: (utaId: string, params: { nativeKey: string; side: 'BUY' | 'SELL'; quantity: string; price: string; contract?: { symbol?: string; localSymbol?: string; secType?: string; exchange?: string; currency?: string } }) =>
+    postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/external-trade`, params),
+}

--- a/ui/src/api/simulator.ts
+++ b/ui/src/api/simulator.ts
@@ -22,6 +22,11 @@ export interface SimulatorPosition {
   quantity: string
   avgCost: string
   avgCostSource?: 'broker' | 'wallet'
+  /** YYYYMMDD (OPT/FOP) or YYYYMM (FUT). */
+  expiry?: string
+  strike?: number
+  right?: string
+  multiplier?: string
 }
 
 export interface SimulatorPendingOrder {
@@ -79,12 +84,49 @@ export const simulatorApi = {
   cancelOrder: (utaId: string, orderId: string) =>
     postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/orders/${encodeURIComponent(orderId)}/cancel`, {}),
 
-  externalDeposit: (utaId: string, params: { nativeKey: string; quantity: string; contract?: { symbol?: string; localSymbol?: string; secType?: string; exchange?: string; currency?: string } }) =>
+  externalDeposit: (utaId: string, params: SimulatorExternalDepositParams) =>
     postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/external-deposit`, params),
 
   externalWithdraw: (utaId: string, nativeKey: string, quantity: string) =>
     postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/external-withdraw`, { nativeKey, quantity }),
 
-  externalTrade: (utaId: string, params: { nativeKey: string; side: 'BUY' | 'SELL'; quantity: string; price: string; contract?: { symbol?: string; localSymbol?: string; secType?: string; exchange?: string; currency?: string } }) =>
+  externalTrade: (utaId: string, params: SimulatorExternalTradeParams) =>
     postJson<{ ok: true }>(`/api/simulator/uta/${encodeURIComponent(utaId)}/external-trade`, params),
+}
+
+// ==================== Contract shapes ====================
+
+/**
+ * Subset of IBKR Contract fields the simulator accepts. `lastTradeDateOrContractMonth`,
+ * `strike`, `right`, `multiplier` enable OPT/FOP/FUT positions; bare CRYPTO/STK
+ * just need `symbol` + `secType`.
+ */
+export interface SimulatorContractInput {
+  symbol?: string
+  localSymbol?: string
+  secType?: string
+  exchange?: string
+  currency?: string
+  /** YYYYMMDD for OPT/FOP, YYYYMM for FUT. */
+  lastTradeDateOrContractMonth?: string
+  /** Option strike (number). */
+  strike?: number
+  /** Option right: C / P (or CALL / PUT). */
+  right?: 'C' | 'P' | 'CALL' | 'PUT'
+  /** Shares per contract: typically "100" for OPT, "1" for stocks/crypto. */
+  multiplier?: string
+}
+
+export interface SimulatorExternalDepositParams {
+  nativeKey: string
+  quantity: string
+  contract?: SimulatorContractInput
+}
+
+export interface SimulatorExternalTradeParams {
+  nativeKey: string
+  side: 'BUY' | 'SELL'
+  quantity: string
+  price: string
+  contract?: SimulatorContractInput
 }

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -149,6 +149,35 @@ export const tradingApi = {
     return fetchJson('/api/trading/config')
   },
 
+  /**
+   * Create a new UTA. The server derives the id from the preset's
+   * fingerprintFields applied to presetConfig — the client doesn't pick
+   * one. Returns 409 (BrokerAlreadyExistsError) if another UTA already
+   * derives to the same id.
+   */
+  async createUTA(uta: Omit<UTAConfig, 'id'>): Promise<UTAConfig> {
+    const res = await fetch('/api/trading/config/uta', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(uta),
+    })
+    const body = await res.json().catch(() => ({}))
+    if (res.status === 409) {
+      const err = new Error(body.error ?? 'A UTA already exists for this broker identity') as Error & { existing?: { id: string; label: string; presetId: string } }
+      err.name = 'BrokerAlreadyExistsError'
+      err.existing = body.existing
+      throw err
+    }
+    if (!res.ok) {
+      throw new Error(body.error || `Failed to create UTA (${res.status})`)
+    }
+    return body
+  },
+
+  /**
+   * Edit an existing UTA. Cannot create — the id must already be on disk
+   * (PUT returns 422 for unknown ids; use `createUTA` for new accounts).
+   */
   async upsertUTA(uta: UTAConfig): Promise<UTAConfig> {
     const res = await fetch(`/api/trading/config/uta/${uta.id}`, {
       method: 'PUT',
@@ -211,7 +240,12 @@ export const tradingApi = {
 
   // ==================== Connection Testing ====================
 
-  async testConnection(uta: UTAConfig): Promise<TestConnectionResult> {
+  /**
+   * Test broker credentials before committing them. Accepts either a full
+   * UTAConfig (during edit) or a draft without an id (during create) — the
+   * server stamps `__test__` if id is absent.
+   */
+  async testConnection(uta: UTAConfig | Omit<UTAConfig, 'id'>): Promise<TestConnectionResult> {
     const res = await fetch('/api/trading/config/test-connection', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -382,12 +382,12 @@ export interface BrokerPreset {
   id: string
   label: string
   description: string
-  category: 'recommended' | 'crypto'
+  category: 'recommended' | 'crypto' | 'testing'
   hint?: string
   defaultName: string
   badge: string
   badgeColor: string
-  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge'
+  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'mock'
   guardCategory: 'crypto' | 'securities'
   modes?: ModeOption[]
   subtitleFields: SubtitleField[]

--- a/ui/src/components/ContextMenu.tsx
+++ b/ui/src/components/ContextMenu.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+export type ContextMenuItem =
+  | {
+      kind: 'item'
+      label: string
+      onClick: () => void
+      disabled?: boolean
+      /** Render the item in red — for destructive actions like Close. */
+      danger?: boolean
+    }
+  | { kind: 'separator' }
+
+interface ContextMenuProps {
+  /** Viewport coordinates (e.g. mouse event clientX/clientY). */
+  anchor: { x: number; y: number }
+  items: ContextMenuItem[]
+  /** Fired on item click, ESC, or click-outside. Caller clears anchor state. */
+  onClose: () => void
+}
+
+/**
+ * Generic right-click / context menu. Anchored to a viewport coord;
+ * flips back inside the viewport if it would overflow the right or
+ * bottom edge. Closes on ESC, click outside, or any item activation.
+ *
+ * Built to be called from TabStrip's onContextMenu handler today, but
+ * the API is generic — any caller that has mouse coords and a list of
+ * actions can mount it.
+ */
+export function ContextMenu({ anchor, items, onClose }: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState(anchor)
+
+  // Adjust position so the menu stays inside the viewport. Runs after
+  // mount when we can measure the rendered menu.
+  useLayoutEffect(() => {
+    const el = menuRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const margin = 4
+    let x = anchor.x
+    let y = anchor.y
+    if (x + rect.width + margin > window.innerWidth) {
+      x = Math.max(margin, window.innerWidth - rect.width - margin)
+    }
+    if (y + rect.height + margin > window.innerHeight) {
+      y = Math.max(margin, window.innerHeight - rect.height - margin)
+    }
+    setPos({ x, y })
+  }, [anchor])
+
+  // Outside-click + ESC dismiss
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      style={{
+        position: 'fixed',
+        left: pos.x,
+        top: pos.y,
+        zIndex: 60,
+      }}
+      className="min-w-[180px] py-1 bg-bg-secondary border border-border rounded-md shadow-xl"
+    >
+      {items.map((item, i) => {
+        if (item.kind === 'separator') {
+          return <div key={`sep-${i}`} className="my-1 border-t border-border/60" />
+        }
+        const disabled = item.disabled === true
+        const colorClass = item.danger
+          ? 'text-red-400 hover:bg-red-400/10'
+          : 'text-text hover:bg-bg-tertiary'
+        return (
+          <button
+            key={`item-${i}`}
+            type="button"
+            role="menuitem"
+            disabled={disabled}
+            onClick={() => {
+              if (disabled) return
+              item.onClick()
+              onClose()
+            }}
+            className={`w-full text-left px-3 py-1.5 text-[13px] transition-colors ${
+              disabled ? 'opacity-40 cursor-not-allowed' : colorClass
+            }`}
+          >
+            {item.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/src/components/DevCategoryList.tsx
+++ b/ui/src/components/DevCategoryList.tsx
@@ -15,6 +15,7 @@ const CATEGORIES: CategoryItem[] = [
   { label: 'Sessions', tab: 'sessions' },
   { label: 'Snapshots', tab: 'snapshots' },
   { label: 'Logs', tab: 'logs' },
+  { label: 'Simulator', tab: 'simulator' },
 ]
 
 /**

--- a/ui/src/components/TabStrip.tsx
+++ b/ui/src/components/TabStrip.tsx
@@ -1,11 +1,13 @@
-import type { WheelEvent } from 'react'
+import { useState, type MouseEvent, type WheelEvent } from 'react'
 import { useChannels } from '../contexts/ChannelsContext'
 import { useWorkspace } from '../tabs/store'
 import { getView } from '../tabs/registry'
+import { ContextMenu, type ContextMenuItem } from './ContextMenu'
 
 /**
  * The strip of tab buttons above the main content area. Click to focus,
- * × or middle-click to close. No drag, no context menu yet.
+ * × or middle-click to close, right-click for context menu (close /
+ * close others / close to the right / close all / copy URL).
  *
  * The strip scrolls horizontally when the row of tabs overflows, but the
  * scrollbar itself is hidden — a thick scrollbar across the full width
@@ -28,6 +30,12 @@ export function TabStrip() {
   const tabsMap = useWorkspace((state) => state.tabs)
   const focusTab = useWorkspace((state) => state.focusTab)
   const closeTab = useWorkspace((state) => state.closeTab)
+  const closeOthers = useWorkspace((state) => state.closeOthers)
+  const closeToRight = useWorkspace((state) => state.closeToRight)
+  const closeToLeft = useWorkspace((state) => state.closeToLeft)
+  const closeAll = useWorkspace((state) => state.closeAll)
+
+  const [menu, setMenu] = useState<{ tabId: string; x: number; y: number } | null>(null)
 
   if (tabIds.length === 0) return null
 
@@ -40,28 +48,84 @@ export function TabStrip() {
     }
   }
 
+  const buildMenuItems = (tabId: string): ContextMenuItem[] => {
+    const tab = tabsMap[tabId]
+    if (!tab) return []
+    const idx = tabIds.indexOf(tabId)
+    const onlyOne = tabIds.length === 1
+    const view = getView(tab.spec.kind)
+    const url = view.toUrl(tab.spec as never)
+    return [
+      { kind: 'item', label: 'Close', danger: true, onClick: () => closeTab(tabId) },
+      {
+        kind: 'item',
+        label: 'Close Others',
+        disabled: onlyOne,
+        onClick: () => closeOthers(tabId),
+      },
+      {
+        kind: 'item',
+        label: 'Close to the Right',
+        disabled: idx === tabIds.length - 1,
+        onClick: () => closeToRight(tabId),
+      },
+      {
+        kind: 'item',
+        label: 'Close to the Left',
+        disabled: idx <= 0,
+        onClick: () => closeToLeft(tabId),
+      },
+      { kind: 'item', label: 'Close All', onClick: () => closeAll() },
+      { kind: 'separator' },
+      {
+        kind: 'item',
+        label: 'Copy URL',
+        onClick: () => {
+          const fullUrl = window.location.origin + url
+          navigator.clipboard.writeText(fullUrl).catch(() => {
+            /* clipboard refusal is fine; nothing to surface here */
+          })
+        },
+      },
+    ]
+  }
+
   return (
-    <div
-      onWheel={handleWheel}
-      className="scrollbar-hide hidden md:flex shrink-0 h-9 bg-bg-secondary border-b border-border overflow-x-auto"
-    >
-      {tabIds.map((id) => {
-        const tab = tabsMap[id]
-        if (!tab) return null
-        const view = getView(tab.spec.kind)
-        const title = view.title(tab.spec as never, { channels })
-        const isActive = id === activeTabId
-        return (
-          <TabButton
-            key={id}
-            title={title}
-            active={isActive}
-            onSelect={() => focusTab(id)}
-            onClose={() => closeTab(id)}
-          />
-        )
-      })}
-    </div>
+    <>
+      <div
+        onWheel={handleWheel}
+        className="scrollbar-hide hidden md:flex shrink-0 h-9 bg-bg-secondary border-b border-border overflow-x-auto"
+      >
+        {tabIds.map((id) => {
+          const tab = tabsMap[id]
+          if (!tab) return null
+          const view = getView(tab.spec.kind)
+          const title = view.title(tab.spec as never, { channels })
+          const isActive = id === activeTabId
+          return (
+            <TabButton
+              key={id}
+              title={title}
+              active={isActive}
+              onSelect={() => focusTab(id)}
+              onClose={() => closeTab(id)}
+              onContextMenu={(e) => {
+                e.preventDefault()
+                setMenu({ tabId: id, x: e.clientX, y: e.clientY })
+              }}
+            />
+          )
+        })}
+      </div>
+
+      {menu && (
+        <ContextMenu
+          anchor={{ x: menu.x, y: menu.y }}
+          items={buildMenuItems(menu.tabId)}
+          onClose={() => setMenu(null)}
+        />
+      )}
+    </>
   )
 }
 
@@ -70,9 +134,10 @@ interface TabButtonProps {
   active: boolean
   onSelect: () => void
   onClose: () => void
+  onContextMenu: (e: MouseEvent<HTMLDivElement>) => void
 }
 
-function TabButton({ title, active, onSelect, onClose }: TabButtonProps) {
+function TabButton({ title, active, onSelect, onClose, onContextMenu }: TabButtonProps) {
   return (
     <div
       onClick={onSelect}
@@ -83,6 +148,7 @@ function TabButton({ title, active, onSelect, onClose }: TabButtonProps) {
           onClose()
         }
       }}
+      onContextMenu={onContextMenu}
       className={`group flex items-center gap-2 pl-3 pr-2 h-full text-[13px] cursor-pointer border-r border-border transition-colors ${
         active
           ? 'bg-bg text-text'

--- a/ui/src/hooks/useTradingConfig.ts
+++ b/ui/src/hooks/useTradingConfig.ts
@@ -7,6 +7,9 @@ export interface UseTradingConfigResult {
   loading: boolean
   error: string | null
 
+  /** Create a new UTA — server derives id from preset + presetConfig. */
+  createUTA: (a: Omit<UTAConfig, 'id'>) => Promise<UTAConfig>
+  /** Edit an existing UTA. Will fail with 422 if the id doesn't exist. */
   saveUTA: (a: UTAConfig) => Promise<void>
   deleteUTA: (id: string) => Promise<void>
   reconnectUTA: (id: string) => Promise<ReconnectResult>
@@ -33,6 +36,12 @@ export function useTradingConfig(): UseTradingConfigResult {
 
   useEffect(() => { load() }, [load])
 
+  const createUTA = useCallback(async (a: Omit<UTAConfig, 'id'>): Promise<UTAConfig> => {
+    const created = await api.trading.createUTA(a)
+    setUTAs((prev) => [...prev, created])
+    return created
+  }, [])
+
   const saveUTA = useCallback(async (a: UTAConfig) => {
     await api.trading.upsertUTA(a)
     setUTAs((prev) => {
@@ -57,7 +66,7 @@ export function useTradingConfig(): UseTradingConfigResult {
 
   return {
     utas, loading, error,
-    saveUTA, deleteUTA,
+    createUTA, saveUTA, deleteUTA,
     reconnectUTA, refresh: load,
   }
 }

--- a/ui/src/pages/DevPage.tsx
+++ b/ui/src/pages/DevPage.tsx
@@ -4,6 +4,7 @@ import { PageHeader } from '../components/PageHeader'
 import { Spinner, EmptyState } from '../components/StateViews'
 import { useToast } from '../components/Toast'
 import { LogsPage } from './LogsPage'
+import { SimulatorPage } from './SimulatorPage'
 import {
   devApi,
   type RegistryResponse,
@@ -28,6 +29,7 @@ const TAB_TITLES: Record<Tab, string> = {
   sessions: 'Sessions',
   snapshots: 'Snapshots',
   logs: 'Logs',
+  simulator: 'Simulator',
 }
 
 /** Tabs that render content with internal scroll containers — the outer wrapper must NOT add overflow. */
@@ -51,6 +53,7 @@ export function DevPage({ spec }: DevPageProps) {
         {tab === 'sessions' && <SessionsTab />}
         {tab === 'snapshots' && <SnapshotsTab />}
         {tab === 'logs' && <LogsPage />}
+        {tab === 'simulator' && <SimulatorPage />}
       </div>
     </div>
   )

--- a/ui/src/pages/SimulatorPage.tsx
+++ b/ui/src/pages/SimulatorPage.tsx
@@ -270,13 +270,26 @@ function MarkPricesSection({ utaId, state, run, loading }: {
   const [newPrice, setNewPrice] = useState('')
 
   // Sync drafts with incoming state, preserving any in-flight user edits.
+  // A "no draft for key" → input shows current state.price; once the user
+  // types, the draft for that key holds their typed value until they
+  // commit (Set/Tick) or some other code path explicitly clears it.
   useEffect(() => {
     setDrafts((prev) => {
       const next: Record<string, string> = {}
-      for (const m of state.markPrices) next[m.nativeKey] = prev[m.nativeKey] ?? m.price
+      for (const m of state.markPrices) {
+        if (prev[m.nativeKey] !== undefined) next[m.nativeKey] = prev[m.nativeKey]
+      }
       return next
     })
   }, [state.markPrices])
+
+  // After a successful action on `key`, drop its draft so the input
+  // re-syncs to the freshly-fetched state.price on the next render.
+  const dropDraft = (key: string) => setDrafts((d) => {
+    const next = { ...d }
+    delete next[key]
+    return next
+  })
 
   return (
     <Section
@@ -310,24 +323,36 @@ function MarkPricesSection({ utaId, state, run, loading }: {
                     <button
                       disabled={loading}
                       onClick={() => run(
-                        `Set ${m.nativeKey} = ${drafts[m.nativeKey]}`,
-                        () => simulatorApi.setMarkPrice(utaId, m.nativeKey, drafts[m.nativeKey] ?? m.price),
+                        `Set ${m.nativeKey} = ${drafts[m.nativeKey] ?? m.price}`,
+                        async () => {
+                          await simulatorApi.setMarkPrice(utaId, m.nativeKey, drafts[m.nativeKey] ?? m.price)
+                          dropDraft(m.nativeKey)
+                        },
                       )}
                       className="btn-secondary-xs"
                     >Set</button>
                     <button
                       disabled={loading}
-                      onClick={() => run(`${m.nativeKey} −1%`, () => simulatorApi.tickPrice(utaId, m.nativeKey, -1))}
+                      onClick={() => run(`${m.nativeKey} −1%`, async () => {
+                        await simulatorApi.tickPrice(utaId, m.nativeKey, -1)
+                        dropDraft(m.nativeKey)
+                      })}
                       className="btn-secondary-xs"
                     >−1%</button>
                     <button
                       disabled={loading}
-                      onClick={() => run(`${m.nativeKey} +1%`, () => simulatorApi.tickPrice(utaId, m.nativeKey, 1))}
+                      onClick={() => run(`${m.nativeKey} +1%`, async () => {
+                        await simulatorApi.tickPrice(utaId, m.nativeKey, 1)
+                        dropDraft(m.nativeKey)
+                      })}
                       className="btn-secondary-xs"
                     >+1%</button>
                     <button
                       disabled={loading}
-                      onClick={() => run(`${m.nativeKey} +5%`, () => simulatorApi.tickPrice(utaId, m.nativeKey, 5))}
+                      onClick={() => run(`${m.nativeKey} +5%`, async () => {
+                        await simulatorApi.tickPrice(utaId, m.nativeKey, 5)
+                        dropDraft(m.nativeKey)
+                      })}
                       className="btn-secondary-xs"
                     >+5%</button>
                   </td>

--- a/ui/src/pages/SimulatorPage.tsx
+++ b/ui/src/pages/SimulatorPage.tsx
@@ -1,0 +1,519 @@
+/**
+ * Simulator dev tab — manual control panel for MockBroker UTAs.
+ *
+ * Lets you drive scenarios that real exchanges produce on their own:
+ *  - Move markPrice (auto-fills any触达 limit/stop orders)
+ *  - Manually fill or cancel a pending order
+ *  - Inject "external" events (deposit, withdraw, off-platform trade) so
+ *    the UTA reconcile pipeline kicks in just like it would on a real
+ *    spot exchange where balance changes outside Alice's order log.
+ *
+ * After any action, the state panel auto-refreshes; you can also flip to
+ * the Portfolio tab to see how the changes propagate through UTA
+ * reconcile + cost-basis projection.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Section } from '../components/form'
+import { EmptyState, Spinner } from '../components/StateViews'
+import { useToast } from '../components/Toast'
+import {
+  simulatorApi,
+  type SimulatorState,
+  type SimulatorUTAEntry,
+} from '../api/simulator'
+
+const POLL_INTERVAL_MS = 3000
+
+const inputClass =
+  'w-full px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+
+export function SimulatorPage() {
+  const [utas, setUtas] = useState<SimulatorUTAEntry[]>([])
+  const [selected, setSelected] = useState<string>('')
+  const [state, setState] = useState<SimulatorState | null>(null)
+  const [loading, setLoading] = useState(false)
+  const toast = useToast()
+
+  // Load UTA list once
+  useEffect(() => {
+    simulatorApi.listUtas().then((r) => {
+      setUtas(r.utas)
+      if (r.utas.length > 0) setSelected(r.utas[0].id)
+    }).catch((err) => {
+      toast.error(`Failed to list simulators: ${err instanceof Error ? err.message : err}`)
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const refresh = useCallback(async () => {
+    if (!selected) return
+    try {
+      const s = await simulatorApi.state(selected)
+      setState(s)
+    } catch (err) {
+      toast.error(`State fetch failed: ${err instanceof Error ? err.message : err}`)
+      setState(null)
+    }
+  }, [selected, toast])
+
+  // Refresh on selection change + poll
+  useEffect(() => {
+    refresh()
+    const t = setInterval(refresh, POLL_INTERVAL_MS)
+    return () => clearInterval(t)
+  }, [refresh])
+
+  // Wrapper that runs an action and refreshes state on success.
+  const run = useCallback(async (label: string, fn: () => Promise<unknown>) => {
+    if (!selected) return
+    setLoading(true)
+    try {
+      await fn()
+      toast.success(label)
+      await refresh()
+    } catch (err) {
+      toast.error(`${label} failed: ${err instanceof Error ? err.message : err}`)
+    } finally {
+      setLoading(false)
+    }
+  }, [selected, toast, refresh])
+
+  if (utas.length === 0) {
+    return (
+      <div className="px-4 md:px-6 py-5 max-w-[860px]">
+        <EmptyState
+          title="No simulator UTAs."
+          description="Create one from Settings → Trading → 'Simulator (testing only)'."
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="px-4 md:px-6 py-5 max-w-[960px] space-y-5">
+      <div className="flex items-center gap-3">
+        <label className="text-[13px] text-text-muted">Account</label>
+        <select
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          className="px-2.5 py-1 bg-bg text-text border border-border rounded text-sm outline-none focus:border-accent"
+        >
+          {utas.map(u => <option key={u.id} value={u.id}>{u.label} ({u.id})</option>)}
+        </select>
+        <button
+          onClick={refresh}
+          className="px-2.5 py-1 text-xs bg-bg-tertiary text-text-muted rounded hover:text-text transition-colors"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {state ? (
+        <>
+          <Section title="Cash" description="Available USD balance.">
+            <p className="font-mono text-lg text-text">${Number(state.cash).toLocaleString('en-US', { minimumFractionDigits: 2 })}</p>
+          </Section>
+
+          <MarkPricesSection
+            utaId={selected}
+            state={state}
+            run={run}
+            loading={loading}
+          />
+
+          <PendingOrdersSection
+            utaId={selected}
+            state={state}
+            run={run}
+            loading={loading}
+          />
+
+          <PositionsSection state={state} />
+
+          <ExternalEventsSection
+            utaId={selected}
+            state={state}
+            run={run}
+            loading={loading}
+          />
+        </>
+      ) : (
+        <div className="flex justify-center py-12"><Spinner /></div>
+      )}
+    </div>
+  )
+}
+
+// ==================== Mark Prices ====================
+
+function MarkPricesSection({ utaId, state, run, loading }: {
+  utaId: string
+  state: SimulatorState
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  const [newKey, setNewKey] = useState('')
+  const [newPrice, setNewPrice] = useState('')
+
+  // Sync drafts with incoming state, preserving any in-flight user edits.
+  useEffect(() => {
+    setDrafts((prev) => {
+      const next: Record<string, string> = {}
+      for (const m of state.markPrices) next[m.nativeKey] = prev[m.nativeKey] ?? m.price
+      return next
+    })
+  }, [state.markPrices])
+
+  return (
+    <Section
+      title="Mark Prices"
+      description="Per-symbol mark price. Editing or ticking auto-matches any触达 pending limit/stop orders."
+    >
+      <div className="space-y-1">
+        {state.markPrices.length === 0 ? (
+          <p className="text-xs text-text-muted">No prices set yet — add one below.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-text-muted text-xs">
+                <th className="pb-1 pr-3">Native Key</th>
+                <th className="pb-1 pr-3 w-40">Price</th>
+                <th className="pb-1 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.markPrices.map((m) => (
+                <tr key={m.nativeKey} className="text-text">
+                  <td className="py-1 pr-3 font-mono text-xs">{m.nativeKey}</td>
+                  <td className="py-1 pr-3">
+                    <input
+                      className={inputClass}
+                      value={drafts[m.nativeKey] ?? m.price}
+                      onChange={(e) => setDrafts({ ...drafts, [m.nativeKey]: e.target.value })}
+                    />
+                  </td>
+                  <td className="py-1 text-right space-x-1">
+                    <button
+                      disabled={loading}
+                      onClick={() => run(
+                        `Set ${m.nativeKey} = ${drafts[m.nativeKey]}`,
+                        () => simulatorApi.setMarkPrice(utaId, m.nativeKey, drafts[m.nativeKey] ?? m.price),
+                      )}
+                      className="btn-secondary-xs"
+                    >Set</button>
+                    <button
+                      disabled={loading}
+                      onClick={() => run(`${m.nativeKey} −1%`, () => simulatorApi.tickPrice(utaId, m.nativeKey, -1))}
+                      className="btn-secondary-xs"
+                    >−1%</button>
+                    <button
+                      disabled={loading}
+                      onClick={() => run(`${m.nativeKey} +1%`, () => simulatorApi.tickPrice(utaId, m.nativeKey, 1))}
+                      className="btn-secondary-xs"
+                    >+1%</button>
+                    <button
+                      disabled={loading}
+                      onClick={() => run(`${m.nativeKey} +5%`, () => simulatorApi.tickPrice(utaId, m.nativeKey, 5))}
+                      className="btn-secondary-xs"
+                    >+5%</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        <div className="flex items-center gap-2 pt-3 border-t border-border">
+          <input
+            className={`${inputClass} w-44`}
+            placeholder="native key (e.g. BTC)"
+            value={newKey}
+            onChange={(e) => setNewKey(e.target.value.trim())}
+          />
+          <input
+            className={`${inputClass} w-32`}
+            placeholder="price"
+            value={newPrice}
+            onChange={(e) => setNewPrice(e.target.value)}
+          />
+          <button
+            disabled={loading || !newKey || !newPrice}
+            onClick={() => run(
+              `Add ${newKey} = ${newPrice}`,
+              async () => {
+                await simulatorApi.setMarkPrice(utaId, newKey, newPrice)
+                setNewKey('')
+                setNewPrice('')
+              },
+            )}
+            className="btn-primary-sm"
+          >Add</button>
+        </div>
+      </div>
+    </Section>
+  )
+}
+
+// ==================== Pending Orders ====================
+
+function PendingOrdersSection({ utaId, state, run, loading }: {
+  utaId: string
+  state: SimulatorState
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [fillForms, setFillForms] = useState<Record<string, { price: string; qty: string }>>({})
+  const updateForm = (id: string, field: 'price' | 'qty', value: string) => {
+    setFillForms({ ...fillForms, [id]: { ...(fillForms[id] ?? { price: '', qty: '' }), [field]: value } })
+  }
+
+  return (
+    <Section
+      title="Pending Orders"
+      description="Submitted limit/stop orders waiting for触达 or manual fill."
+    >
+      {state.pendingOrders.length === 0 ? (
+        <p className="text-xs text-text-muted">No pending orders.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-text-muted text-xs">
+              <th className="pb-1 pr-3">Order</th>
+              <th className="pb-1 pr-3">Symbol</th>
+              <th className="pb-1 pr-3">Side</th>
+              <th className="pb-1 pr-3">Type</th>
+              <th className="pb-1 pr-3">Qty</th>
+              <th className="pb-1 pr-3">Trigger</th>
+              <th className="pb-1 pr-3 w-40">Fill price (opt)</th>
+              <th className="pb-1 pr-3 w-32">Fill qty (opt)</th>
+              <th className="pb-1 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state.pendingOrders.map((o) => {
+              const form = fillForms[o.orderId] ?? { price: '', qty: '' }
+              const trigger = o.lmtPrice ?? o.auxPrice ?? '—'
+              return (
+                <tr key={o.orderId} className="text-text">
+                  <td className="py-1 pr-3 font-mono text-[11px]">{o.orderId}</td>
+                  <td className="py-1 pr-3">{o.symbol}</td>
+                  <td className="py-1 pr-3">{o.action}</td>
+                  <td className="py-1 pr-3">{o.orderType}</td>
+                  <td className="py-1 pr-3 font-mono text-xs">{o.totalQuantity}</td>
+                  <td className="py-1 pr-3 font-mono text-xs">{trigger}</td>
+                  <td className="py-1 pr-3">
+                    <input
+                      className={inputClass}
+                      placeholder="markPrice"
+                      value={form.price}
+                      onChange={(e) => updateForm(o.orderId, 'price', e.target.value)}
+                    />
+                  </td>
+                  <td className="py-1 pr-3">
+                    <input
+                      className={inputClass}
+                      placeholder="full"
+                      value={form.qty}
+                      onChange={(e) => updateForm(o.orderId, 'qty', e.target.value)}
+                    />
+                  </td>
+                  <td className="py-1 text-right space-x-1">
+                    <button
+                      disabled={loading}
+                      onClick={() => run(
+                        `Fill ${o.orderId}`,
+                        () => simulatorApi.fillOrder(utaId, o.orderId, {
+                          ...(form.price && { price: form.price }),
+                          ...(form.qty && { qty: form.qty }),
+                        }),
+                      )}
+                      className="btn-secondary-xs"
+                    >Fill</button>
+                    <button
+                      disabled={loading}
+                      onClick={() => run(`Cancel ${o.orderId}`, () => simulatorApi.cancelOrder(utaId, o.orderId))}
+                      className="btn-secondary-xs"
+                    >Cancel</button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </Section>
+  )
+}
+
+// ==================== Positions ====================
+
+function PositionsSection({ state }: { state: SimulatorState }) {
+  return (
+    <Section
+      title="Positions"
+      description="Read-only — mutate via mark price moves, order fills, or external events."
+    >
+      {state.positions.length === 0 ? (
+        <p className="text-xs text-text-muted">No positions.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-text-muted text-xs">
+              <th className="pb-1 pr-3">Native Key</th>
+              <th className="pb-1 pr-3">Symbol</th>
+              <th className="pb-1 pr-3">SecType</th>
+              <th className="pb-1 pr-3">Side</th>
+              <th className="pb-1 pr-3 text-right">Qty</th>
+              <th className="pb-1 pr-3 text-right">Avg Cost</th>
+              <th className="pb-1 text-right">Source</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state.positions.map((p) => (
+              <tr key={p.nativeKey} className="text-text">
+                <td className="py-1 pr-3 font-mono text-xs">{p.nativeKey}</td>
+                <td className="py-1 pr-3">{p.symbol}</td>
+                <td className="py-1 pr-3 text-text-muted text-xs">{p.secType ?? '—'}</td>
+                <td className="py-1 pr-3">{p.side}</td>
+                <td className="py-1 pr-3 font-mono text-xs text-right">{p.quantity}</td>
+                <td className="py-1 pr-3 font-mono text-xs text-right">{p.avgCost}</td>
+                <td className="py-1 text-right text-text-muted text-xs">{p.avgCostSource ?? 'broker'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Section>
+  )
+}
+
+// ==================== External Events ====================
+
+function ExternalEventsSection({ utaId, state, run, loading }: {
+  utaId: string
+  state: SimulatorState
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [mode, setMode] = useState<'deposit' | 'withdraw' | 'trade'>('deposit')
+  const [nativeKey, setNativeKey] = useState('')
+  const [quantity, setQuantity] = useState('')
+  const [price, setPrice] = useState('')
+  const [side, setSide] = useState<'BUY' | 'SELL'>('BUY')
+  const [secType, setSecType] = useState<'CRYPTO' | 'CRYPTO_PERP' | 'STK'>('CRYPTO')
+
+  const knownKeys = useMemo(() => {
+    const set = new Set<string>()
+    for (const m of state.markPrices) set.add(m.nativeKey)
+    for (const p of state.positions) set.add(p.nativeKey)
+    return [...set].sort()
+  }, [state])
+
+  const submit = () => {
+    if (!nativeKey || !quantity) return
+    if (mode === 'deposit') {
+      run(
+        `Deposit ${quantity} ${nativeKey}`,
+        () => simulatorApi.externalDeposit(utaId, {
+          nativeKey,
+          quantity,
+          contract: { symbol: nativeKey, secType },
+        }),
+      )
+    } else if (mode === 'withdraw') {
+      run(`Withdraw ${quantity} ${nativeKey}`, () => simulatorApi.externalWithdraw(utaId, nativeKey, quantity))
+    } else {
+      if (!price) return
+      run(
+        `External ${side} ${quantity} ${nativeKey} @ ${price}`,
+        () => simulatorApi.externalTrade(utaId, {
+          nativeKey,
+          side,
+          quantity,
+          price,
+          contract: { symbol: nativeKey, secType },
+        }),
+      )
+    }
+  }
+
+  return (
+    <Section
+      title="External Events"
+      description="Simulate balance changes Alice didn't initiate (空投, transfer, off-platform trade) — exercises the UTA reconcile pipeline."
+    >
+      <div className="flex items-center gap-2 mb-3">
+        {(['deposit', 'withdraw', 'trade'] as const).map((m) => (
+          <button
+            key={m}
+            onClick={() => setMode(m)}
+            className={`px-2.5 py-1 text-xs rounded transition-colors ${mode === m ? 'bg-accent/20 text-accent font-medium' : 'bg-bg-tertiary text-text-muted hover:text-text'}`}
+          >{m}</button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2 flex-wrap">
+        <input
+          className={`${inputClass} w-44`}
+          placeholder="native key"
+          value={nativeKey}
+          onChange={(e) => setNativeKey(e.target.value.trim())}
+          list="sim-known-keys"
+        />
+        <datalist id="sim-known-keys">
+          {knownKeys.map(k => <option key={k} value={k} />)}
+        </datalist>
+
+        <input
+          className={`${inputClass} w-28`}
+          placeholder="quantity"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+        />
+
+        {mode === 'trade' && (
+          <>
+            <input
+              className={`${inputClass} w-28`}
+              placeholder="price"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+            />
+            <select
+              value={side}
+              onChange={(e) => setSide(e.target.value as 'BUY' | 'SELL')}
+              className={`${inputClass} w-20`}
+            >
+              <option value="BUY">BUY</option>
+              <option value="SELL">SELL</option>
+            </select>
+          </>
+        )}
+
+        {(mode === 'deposit' || mode === 'trade') && (
+          <select
+            value={secType}
+            onChange={(e) => setSecType(e.target.value as 'CRYPTO' | 'CRYPTO_PERP' | 'STK')}
+            className={`${inputClass} w-32`}
+          >
+            <option value="CRYPTO">CRYPTO</option>
+            <option value="CRYPTO_PERP">CRYPTO_PERP</option>
+            <option value="STK">STK</option>
+          </select>
+        )}
+
+        <button
+          disabled={loading || !nativeKey || !quantity || (mode === 'trade' && !price)}
+          onClick={submit}
+          className="btn-primary-sm"
+        >Submit</button>
+      </div>
+
+      <p className="text-[11px] text-text-muted mt-2">
+        Deposit / withdraw don't change cash. External trade decreases cash on BUY, increases on SELL — like the user manually executed on the exchange app.
+      </p>
+    </Section>
+  )
+}

--- a/ui/src/pages/SimulatorPage.tsx
+++ b/ui/src/pages/SimulatorPage.tsx
@@ -2,7 +2,8 @@
  * Simulator dev tab — manual control panel for MockBroker UTAs.
  *
  * Lets you drive scenarios that real exchanges produce on their own:
- *  - Move markPrice (auto-fills any触达 limit/stop orders)
+ *  - Move markPrice (auto-fills any limit/stop orders that the new price
+ *    crosses)
  *  - Manually fill or cancel a pending order
  *  - Inject "external" events (deposit, withdraw, off-platform trade) so
  *    the UTA reconcile pipeline kicks in just like it would on a real
@@ -90,7 +91,38 @@ export function SimulatorPage() {
   }, [selected, toast, refresh])
 
   return (
-    <div className="px-4 md:px-6 py-5 max-w-[960px] space-y-5">
+    <div className="px-4 md:px-6 py-5 max-w-[1200px] space-y-5">
+      {/* Top bar: account picker + cash + create button */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {utas.length === 0 ? (
+          <span className="text-sm text-text-muted">No simulator account yet.</span>
+        ) : (
+          <>
+            <label className="text-[12px] text-text-muted uppercase tracking-wide">Account</label>
+            <select
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+              className="px-2.5 py-1 bg-bg text-text border border-border rounded text-sm outline-none focus:border-accent min-w-[260px]"
+            >
+              {utas.map(u => <option key={u.id} value={u.id}>{u.label} ({u.id})</option>)}
+            </select>
+            <button
+              onClick={refresh}
+              className="px-2.5 py-1 text-xs bg-bg-tertiary text-text-muted rounded hover:text-text transition-colors"
+            >
+              Refresh
+            </button>
+            {state && (
+              <span className="ml-auto text-[12px] text-text-muted uppercase tracking-wide">
+                Cash <span className="font-mono text-text text-sm normal-case ml-1.5">
+                  ${Number(state.cash).toLocaleString('en-US', { minimumFractionDigits: 2 })}
+                </span>
+              </span>
+            )}
+          </>
+        )}
+      </div>
+
       <CreateSimulatorSection
         onCreated={async (newId) => {
           const list = await refreshUtaList()
@@ -98,39 +130,18 @@ export function SimulatorPage() {
         }}
       />
 
-      {utas.length === 0 ? (
-        <p className="text-sm text-text-muted">No simulator account yet — create one above.</p>
-      ) : (
-        <div className="flex items-center gap-3">
-          <label className="text-[13px] text-text-muted">Account</label>
-          <select
-            value={selected}
-            onChange={(e) => setSelected(e.target.value)}
-            className="px-2.5 py-1 bg-bg text-text border border-border rounded text-sm outline-none focus:border-accent"
-          >
-            {utas.map(u => <option key={u.id} value={u.id}>{u.label} ({u.id})</option>)}
-          </select>
-          <button
-            onClick={refresh}
-            className="px-2.5 py-1 text-xs bg-bg-tertiary text-text-muted rounded hover:text-text transition-colors"
-          >
-            Refresh
-          </button>
-        </div>
-      )}
-
       {selected && (state ? (
         <>
-          <Section title="Cash" description="Available USD balance.">
-            <p className="font-mono text-lg text-text">${Number(state.cash).toLocaleString('en-US', { minimumFractionDigits: 2 })}</p>
-          </Section>
-
-          <MarkPricesSection
-            utaId={selected}
-            state={state}
-            run={run}
-            loading={loading}
-          />
+          {/* Two-column row: prices on left (drives the simulation), positions on right (where you watch the result). Action and observation paired side by side. */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 items-start">
+            <MarkPricesSection
+              utaId={selected}
+              state={state}
+              run={run}
+              loading={loading}
+            />
+            <PositionsSection state={state} />
+          </div>
 
           <PendingOrdersSection
             utaId={selected}
@@ -138,8 +149,6 @@ export function SimulatorPage() {
             run={run}
             loading={loading}
           />
-
-          <PositionsSection state={state} />
 
           <ExternalEventsSection
             utaId={selected}
@@ -279,7 +288,7 @@ function MarkPricesSection({ utaId, state, run, loading }: {
   return (
     <Section
       title="Mark Prices"
-      description="Per-symbol mark price. Editing or ticking auto-matches any触达 pending limit/stop orders."
+      description="Per-symbol mark price. Editing or ticking auto-matches any pending limit/stop order whose trigger the new price crosses."
     >
       <div className="space-y-1">
         {state.markPrices.length === 0 ? (
@@ -394,7 +403,7 @@ function PendingOrdersSection({ utaId, state, run, loading }: {
   return (
     <Section
       title="Pending Orders"
-      description="Submitted limit/stop orders waiting for触达 or manual fill."
+      description="Submitted limit/stop orders waiting on a price trigger or manual fill."
     >
       {state.pendingOrders.length === 0 ? (
         <p className="text-xs text-text-muted">No pending orders.</p>
@@ -472,6 +481,13 @@ function PendingOrdersSection({ utaId, state, run, loading }: {
 // ==================== Positions ====================
 
 function PositionsSection({ state }: { state: SimulatorState }) {
+  // Pre-index markPrices so the PnL column reads in O(1) per row.
+  const markByKey = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const mp of state.markPrices) m.set(mp.nativeKey, mp.price)
+    return m
+  }, [state.markPrices])
+
   return (
     <Section
       title="Positions"
@@ -483,27 +499,47 @@ function PositionsSection({ state }: { state: SimulatorState }) {
         <table className="w-full text-sm">
           <thead>
             <tr className="text-left text-text-muted text-xs">
-              <th className="pb-1 pr-3">Native Key</th>
-              <th className="pb-1 pr-3">Symbol</th>
-              <th className="pb-1 pr-3">SecType</th>
-              <th className="pb-1 pr-3">Side</th>
+              <th className="pb-1 pr-3">Position</th>
               <th className="pb-1 pr-3 text-right">Qty</th>
               <th className="pb-1 pr-3 text-right">Avg Cost</th>
-              <th className="pb-1 text-right">Source</th>
+              <th className="pb-1 pr-3 text-right">Mark</th>
+              <th className="pb-1 text-right">PnL</th>
             </tr>
           </thead>
           <tbody>
-            {state.positions.map((p) => (
-              <tr key={p.nativeKey} className="text-text">
-                <td className="py-1 pr-3 font-mono text-xs">{p.nativeKey}</td>
-                <td className="py-1 pr-3">{p.symbol}</td>
-                <td className="py-1 pr-3 text-text-muted text-xs">{p.secType ?? '—'}</td>
-                <td className="py-1 pr-3">{p.side}</td>
-                <td className="py-1 pr-3 font-mono text-xs text-right">{p.quantity}</td>
-                <td className="py-1 pr-3 font-mono text-xs text-right">{p.avgCost}</td>
-                <td className="py-1 text-right text-text-muted text-xs">{p.avgCostSource ?? 'broker'}</td>
-              </tr>
-            ))}
+            {state.positions.map((p) => {
+              const mark = markByKey.get(p.nativeKey)
+              const qty = Number(p.quantity)
+              const avg = Number(p.avgCost)
+              const pnl = mark && Number.isFinite(qty) && Number.isFinite(avg)
+                ? (Number(mark) - avg) * qty * (p.side === 'long' ? 1 : -1)
+                : null
+              const pnlClass = pnl == null ? 'text-text-muted' : pnl > 0 ? 'text-green' : pnl < 0 ? 'text-red' : 'text-text'
+              return (
+                <tr key={p.nativeKey} className="text-text">
+                  <td className="py-1 pr-3">
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      <span className="font-mono text-xs">{p.nativeKey}</span>
+                      {p.secType && (
+                        <span className="text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-bg-tertiary text-text-muted/80">{p.secType}</span>
+                      )}
+                      <span className={`text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
+                        {p.side}
+                      </span>
+                      {p.avgCostSource === 'wallet' && (
+                        <span className="text-[9px] text-text-muted/60" title="Cost basis derived from UTA reconcile pipeline (wallet-source position)">wallet</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right">{p.quantity}</td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right">{p.avgCost}</td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right text-text-muted">{mark ?? '—'}</td>
+                  <td className={`py-1 font-mono text-xs text-right ${pnlClass}`}>
+                    {pnl == null ? '—' : `${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}`}
+                  </td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       )}
@@ -564,7 +600,7 @@ function ExternalEventsSection({ utaId, state, run, loading }: {
   return (
     <Section
       title="External Events"
-      description="Simulate balance changes Alice didn't initiate (空投, transfer, off-platform trade) — exercises the UTA reconcile pipeline."
+      description="Simulate balance changes Alice didn't initiate (airdrop, transfer-in, off-platform trade) — exercises the UTA reconcile pipeline."
     >
       <div className="flex items-center gap-2 mb-3">
         {(['deposit', 'withdraw', 'trade'] as const).map((m) => (

--- a/ui/src/pages/SimulatorPage.tsx
+++ b/ui/src/pages/SimulatorPage.tsx
@@ -92,7 +92,6 @@ export function SimulatorPage() {
   return (
     <div className="px-4 md:px-6 py-5 max-w-[960px] space-y-5">
       <CreateSimulatorSection
-        existingIds={utas.map(u => u.id)}
         onCreated={async (newId) => {
           const list = await refreshUtaList()
           if (list.some(u => u.id === newId)) setSelected(newId)
@@ -158,31 +157,16 @@ export function SimulatorPage() {
 
 // ==================== Create Simulator UTA ====================
 
-function CreateSimulatorSection({ existingIds, onCreated }: {
-  existingIds: string[]
+function CreateSimulatorSection({ onCreated }: {
   onCreated: (id: string) => Promise<void>
 }) {
   const [open, setOpen] = useState(false)
-  const [id, setId] = useState('')
+  const [name, setName] = useState('')
   const [cash, setCash] = useState('100000')
   const [busy, setBusy] = useState(false)
   const toast = useToast()
 
-  // Default id: simulator, simulator-2, simulator-3, …
-  const defaultId = useMemo(() => {
-    if (!existingIds.includes('simulator')) return 'simulator'
-    let i = 2
-    while (existingIds.includes(`simulator-${i}`)) i++
-    return `simulator-${i}`
-  }, [existingIds])
-
   const submit = async () => {
-    const finalId = (id || defaultId).trim()
-    if (!finalId) return
-    if (existingIds.includes(finalId)) {
-      toast.error(`Account "${finalId}" already exists`)
-      return
-    }
     const cashNum = Number(cash)
     if (!Number.isFinite(cashNum) || cashNum < 0) {
       toast.error('Cash must be a non-negative number')
@@ -190,22 +174,23 @@ function CreateSimulatorSection({ existingIds, onCreated }: {
     }
     setBusy(true)
     try {
-      await api.trading.upsertUTA({
-        id: finalId,
-        label: finalId,
+      const finalLabel = name.trim() || 'simulator'
+      // Server derives id from preset.fingerprintFields (= ['_instanceId']
+      // for Mock); a fresh _instanceId is minted server-side when missing,
+      // so each create lands on a distinct id.
+      const created = await api.trading.createUTA({
+        label: finalLabel,
         presetId: 'mock-simulator',
         enabled: true,
         guards: [],
         presetConfig: { cash: cashNum },
       })
-      // Engine load: PUT skips reconnect for brand-new accounts (no
-      // wasEnabled→nowEnabled transition), so kick it ourselves.
-      await api.trading.reconnectUTA(finalId).catch(() => {})
-      toast.success(`Created ${finalId}`)
+      await api.trading.reconnectUTA(created.id).catch(() => {})
+      toast.success(`Created ${created.label} (${created.id})`)
       setOpen(false)
-      setId('')
+      setName('')
       setCash('100000')
-      await onCreated(finalId)
+      await onCreated(created.id)
     } catch (err) {
       toast.error(`Create failed: ${err instanceof Error ? err.message : err}`)
     } finally {
@@ -231,10 +216,10 @@ function CreateSimulatorSection({ existingIds, onCreated }: {
     >
       <div className="flex items-center gap-2 flex-wrap">
         <input
-          className="px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent w-44"
-          placeholder={defaultId}
-          value={id}
-          onChange={(e) => setId(e.target.value.trim())}
+          className="px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent w-48"
+          placeholder="name (e.g. simulator)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
         />
         <input
           className="px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent w-32"
@@ -247,7 +232,7 @@ function CreateSimulatorSection({ existingIds, onCreated }: {
         </button>
         <button
           disabled={busy}
-          onClick={() => { setOpen(false); setId(''); setCash('100000') }}
+          onClick={() => { setOpen(false); setName(''); setCash('100000') }}
           className="btn-secondary-sm"
         >
           Cancel

--- a/ui/src/pages/SimulatorPage.tsx
+++ b/ui/src/pages/SimulatorPage.tsx
@@ -1,677 +1,130 @@
 /**
  * Simulator dev tab — manual control panel for MockBroker UTAs.
  *
- * Lets you drive scenarios that real exchanges produce on their own:
- *  - Move markPrice (auto-fills any limit/stop orders that the new price
- *    crosses)
- *  - Manually fill or cancel a pending order
- *  - Inject "external" events (deposit, withdraw, off-platform trade) so
- *    the UTA reconcile pipeline kicks in just like it would on a real
- *    spot exchange where balance changes outside Alice's order log.
+ * Layout:
+ *   ┌─ Top bar ───────────────────────────────────────────────┐
+ *   │ [Sim 1][Sim 2][+ New]              Cash: $X    Refresh  │
+ *   ├─────────────────────────────────────────────────────────┤
+ *   │ [ Mark Prices ]   [ Positions ]                         │  observation
+ *   │ [ Pending Orders ]                                      │  (read-only)
+ *   ├─────────────────────────────────────────────────────────┤
+ *   │ [ ActionPanel — sticky bottom dock with tabbed actions ]│  control
+ *   ├─────────────────────────────────────────────────────────┤
+ *   │ [ Event Log ]                                           │  history
+ *   └─────────────────────────────────────────────────────────┘
  *
- * After any action, the state panel auto-refreshes; you can also flip to
- * the Portfolio tab to see how the changes propagate through UTA
- * reconcile + cost-basis projection.
+ * Observation lives above; controls dock at the bottom (sticky); event
+ * log at the very bottom for audit. Mark Prices ↔ Positions are
+ * deliberately side-by-side so price→PnL feedback is one glance.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Section } from '../components/form'
-import { Spinner } from '../components/StateViews'
-import { useToast } from '../components/Toast'
-import {
-  simulatorApi,
-  type SimulatorState,
-  type SimulatorUTAEntry,
-} from '../api/simulator'
-import { api } from '../api'
-
-const POLL_INTERVAL_MS = 3000
-
-const inputClass =
-  'w-full px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+import { useCallback } from 'react'
+import { Spinner, EmptyState } from '../components/StateViews'
+import { useSimulatorState } from './simulator/useSimulatorState'
+import { CreateSimulatorSection } from './simulator/CreateSimulatorSection'
+import { MarkPrices } from './simulator/MarkPrices'
+import { Positions } from './simulator/Positions'
+import { PendingOrders } from './simulator/PendingOrders'
+import { ActionPanel } from './simulator/ActionPanel'
+import { EventLog } from './simulator/EventLog'
 
 export function SimulatorPage() {
-  const [utas, setUtas] = useState<SimulatorUTAEntry[]>([])
-  const [selected, setSelected] = useState<string>('')
-  const [state, setState] = useState<SimulatorState | null>(null)
-  const [loading, setLoading] = useState(false)
-  const toast = useToast()
+  const sim = useSimulatorState()
 
-  const refreshUtaList = useCallback(async () => {
-    try {
-      const r = await simulatorApi.listUtas()
-      setUtas(r.utas)
-      // If currently selected vanished, fall back to first
-      if (r.utas.length > 0 && !r.utas.some(u => u.id === selected)) setSelected(r.utas[0].id)
-      else if (r.utas.length === 0) setSelected('')
-      return r.utas
-    } catch (err) {
-      toast.error(`Failed to list simulators: ${err instanceof Error ? err.message : err}`)
-      return []
-    }
-  }, [selected, toast])
-
-  // Load UTA list once on mount
-  useEffect(() => {
-    refreshUtaList()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const refresh = useCallback(async () => {
-    if (!selected) return
-    try {
-      const s = await simulatorApi.state(selected)
-      setState(s)
-    } catch (err) {
-      toast.error(`State fetch failed: ${err instanceof Error ? err.message : err}`)
-      setState(null)
-    }
-  }, [selected, toast])
-
-  // Refresh on selection change + poll
-  useEffect(() => {
-    refresh()
-    const t = setInterval(refresh, POLL_INTERVAL_MS)
-    return () => clearInterval(t)
-  }, [refresh])
-
-  // Wrapper that runs an action and refreshes state on success.
-  const run = useCallback(async (label: string, fn: () => Promise<unknown>) => {
-    if (!selected) return
-    setLoading(true)
-    try {
-      await fn()
-      toast.success(label)
-      await refresh()
-    } catch (err) {
-      toast.error(`${label} failed: ${err instanceof Error ? err.message : err}`)
-    } finally {
-      setLoading(false)
-    }
-  }, [selected, toast, refresh])
+  const onCreated = useCallback(async (newId: string) => {
+    const list = await sim.refreshUtaList()
+    if (list.some(u => u.id === newId)) sim.setSelectedId(newId)
+  }, [sim])
 
   return (
     <div className="px-4 md:px-6 py-5 max-w-[1200px] space-y-5">
-      {/* Top bar: account picker + cash + create button */}
-      <div className="flex items-center gap-3 flex-wrap">
-        {utas.length === 0 ? (
-          <span className="text-sm text-text-muted">No simulator account yet.</span>
-        ) : (
-          <>
-            <label className="text-[12px] text-text-muted uppercase tracking-wide">Account</label>
-            <select
-              value={selected}
-              onChange={(e) => setSelected(e.target.value)}
-              className="px-2.5 py-1 bg-bg text-text border border-border rounded text-sm outline-none focus:border-accent min-w-[260px]"
-            >
-              {utas.map(u => <option key={u.id} value={u.id}>{u.label} ({u.id})</option>)}
-            </select>
-            <button
-              onClick={refresh}
-              className="px-2.5 py-1 text-xs bg-bg-tertiary text-text-muted rounded hover:text-text transition-colors"
-            >
-              Refresh
-            </button>
-            {state && (
-              <span className="ml-auto text-[12px] text-text-muted uppercase tracking-wide">
-                Cash <span className="font-mono text-text text-sm normal-case ml-1.5">
-                  ${Number(state.cash).toLocaleString('en-US', { minimumFractionDigits: 2 })}
-                </span>
-              </span>
-            )}
-          </>
-        )}
-      </div>
-
-      <CreateSimulatorSection
-        onCreated={async (newId) => {
-          const list = await refreshUtaList()
-          if (list.some(u => u.id === newId)) setSelected(newId)
-        }}
+      <TopBar
+        utas={sim.utas}
+        selectedId={sim.selectedId}
+        onSelect={sim.setSelectedId}
+        cash={sim.state?.cash}
+        onRefresh={sim.refresh}
       />
 
-      {selected && (state ? (
+      <CreateSimulatorSection onCreated={onCreated} />
+
+      {sim.utas.length === 0 ? (
+        <EmptyState
+          title="No simulator account yet."
+          description='Click "+ New simulator account" to create one. Each sim is a fresh in-memory MockBroker UTA — wiped on dev server restart.'
+        />
+      ) : !sim.selectedId ? null : !sim.state ? (
+        <div className="flex justify-center py-12"><Spinner /></div>
+      ) : (
         <>
-          {/* Two-column row: prices on left (drives the simulation), positions on right (where you watch the result). Action and observation paired side by side. */}
+          {/* Observation row: prices + positions side-by-side. */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 items-start">
-            <MarkPricesSection
-              utaId={selected}
-              state={state}
-              run={run}
-              loading={loading}
-            />
-            <PositionsSection state={state} />
+            <MarkPrices utaId={sim.selectedId} state={sim.state} run={sim.run} loading={sim.loading} />
+            <Positions state={sim.state} />
           </div>
 
-          <PendingOrdersSection
-            utaId={selected}
-            state={state}
-            run={run}
-            loading={loading}
-          />
+          <PendingOrders utaId={sim.selectedId} state={sim.state} run={sim.run} loading={sim.loading} />
 
-          <ExternalEventsSection
-            utaId={selected}
-            state={state}
-            run={run}
-            loading={loading}
-          />
+          <ActionPanel utaId={sim.selectedId} state={sim.state} run={sim.run} loading={sim.loading} />
+
+          <EventLog events={sim.events} />
         </>
-      ) : (
-        <div className="flex justify-center py-12"><Spinner /></div>
-      ))}
+      )}
     </div>
   )
 }
 
-// ==================== Create Simulator UTA ====================
+// ==================== Top Bar ====================
 
-function CreateSimulatorSection({ onCreated }: {
-  onCreated: (id: string) => Promise<void>
+function TopBar({ utas, selectedId, onSelect, cash, onRefresh }: {
+  utas: ReturnType<typeof useSimulatorState>['utas']
+  selectedId: string
+  onSelect: (id: string) => void
+  cash: string | undefined
+  onRefresh: () => void
 }) {
-  const [open, setOpen] = useState(false)
-  const [name, setName] = useState('')
-  const [cash, setCash] = useState('100000')
-  const [busy, setBusy] = useState(false)
-  const toast = useToast()
-
-  const submit = async () => {
-    const cashNum = Number(cash)
-    if (!Number.isFinite(cashNum) || cashNum < 0) {
-      toast.error('Cash must be a non-negative number')
-      return
-    }
-    setBusy(true)
-    try {
-      const finalLabel = name.trim() || 'simulator'
-      // Server derives id from preset.fingerprintFields (= ['_instanceId']
-      // for Mock); a fresh _instanceId is minted server-side when missing,
-      // so each create lands on a distinct id.
-      const created = await api.trading.createUTA({
-        label: finalLabel,
-        presetId: 'mock-simulator',
-        enabled: true,
-        guards: [],
-        presetConfig: { cash: cashNum },
-      })
-      await api.trading.reconnectUTA(created.id).catch(() => {})
-      toast.success(`Created ${created.label} (${created.id})`)
-      setOpen(false)
-      setName('')
-      setCash('100000')
-      await onCreated(created.id)
-    } catch (err) {
-      toast.error(`Create failed: ${err instanceof Error ? err.message : err}`)
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  if (!open) {
-    return (
-      <button
-        onClick={() => setOpen(true)}
-        className="btn-secondary-sm"
-      >
-        + New simulator account
-      </button>
-    )
+  if (utas.length === 0) {
+    return null
   }
 
   return (
-    <Section
-      title="Create simulator account"
-      description="In-memory only — wiped on dev server restart. For repro & regression testing."
-    >
-      <div className="flex items-center gap-2 flex-wrap">
-        <input
-          className="px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent w-48"
-          placeholder="name (e.g. simulator)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <input
-          className="px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent w-32"
-          placeholder="cash (USD)"
-          value={cash}
-          onChange={(e) => setCash(e.target.value)}
-        />
-        <button disabled={busy} onClick={submit} className="btn-primary-sm">
-          {busy ? 'Creating…' : 'Create'}
-        </button>
-        <button
-          disabled={busy}
-          onClick={() => { setOpen(false); setName(''); setCash('100000') }}
-          className="btn-secondary-sm"
-        >
-          Cancel
-        </button>
-      </div>
-    </Section>
-  )
-}
-
-// ==================== Mark Prices ====================
-
-function MarkPricesSection({ utaId, state, run, loading }: {
-  utaId: string
-  state: SimulatorState
-  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
-  loading: boolean
-}) {
-  const [drafts, setDrafts] = useState<Record<string, string>>({})
-  const [newKey, setNewKey] = useState('')
-  const [newPrice, setNewPrice] = useState('')
-
-  // Sync drafts with incoming state, preserving any in-flight user edits.
-  // A "no draft for key" → input shows current state.price; once the user
-  // types, the draft for that key holds their typed value until they
-  // commit (Set/Tick) or some other code path explicitly clears it.
-  useEffect(() => {
-    setDrafts((prev) => {
-      const next: Record<string, string> = {}
-      for (const m of state.markPrices) {
-        if (prev[m.nativeKey] !== undefined) next[m.nativeKey] = prev[m.nativeKey]
-      }
-      return next
-    })
-  }, [state.markPrices])
-
-  // After a successful action on `key`, drop its draft so the input
-  // re-syncs to the freshly-fetched state.price on the next render.
-  const dropDraft = (key: string) => setDrafts((d) => {
-    const next = { ...d }
-    delete next[key]
-    return next
-  })
-
-  return (
-    <Section
-      title="Mark Prices"
-      description="Per-symbol mark price. Editing or ticking auto-matches any pending limit/stop order whose trigger the new price crosses."
-    >
-      <div className="space-y-1">
-        {state.markPrices.length === 0 ? (
-          <p className="text-xs text-text-muted">No prices set yet — add one below.</p>
-        ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-text-muted text-xs">
-                <th className="pb-1 pr-3">Native Key</th>
-                <th className="pb-1 pr-3 w-40">Price</th>
-                <th className="pb-1 text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {state.markPrices.map((m) => (
-                <tr key={m.nativeKey} className="text-text">
-                  <td className="py-1 pr-3 font-mono text-xs">{m.nativeKey}</td>
-                  <td className="py-1 pr-3">
-                    <input
-                      className={inputClass}
-                      value={drafts[m.nativeKey] ?? m.price}
-                      onChange={(e) => setDrafts({ ...drafts, [m.nativeKey]: e.target.value })}
-                    />
-                  </td>
-                  <td className="py-1 text-right space-x-1">
-                    <button
-                      disabled={loading}
-                      onClick={() => run(
-                        `Set ${m.nativeKey} = ${drafts[m.nativeKey] ?? m.price}`,
-                        async () => {
-                          await simulatorApi.setMarkPrice(utaId, m.nativeKey, drafts[m.nativeKey] ?? m.price)
-                          dropDraft(m.nativeKey)
-                        },
-                      )}
-                      className="btn-secondary-xs"
-                    >Set</button>
-                    <button
-                      disabled={loading}
-                      onClick={() => run(`${m.nativeKey} −1%`, async () => {
-                        await simulatorApi.tickPrice(utaId, m.nativeKey, -1)
-                        dropDraft(m.nativeKey)
-                      })}
-                      className="btn-secondary-xs"
-                    >−1%</button>
-                    <button
-                      disabled={loading}
-                      onClick={() => run(`${m.nativeKey} +1%`, async () => {
-                        await simulatorApi.tickPrice(utaId, m.nativeKey, 1)
-                        dropDraft(m.nativeKey)
-                      })}
-                      className="btn-secondary-xs"
-                    >+1%</button>
-                    <button
-                      disabled={loading}
-                      onClick={() => run(`${m.nativeKey} +5%`, async () => {
-                        await simulatorApi.tickPrice(utaId, m.nativeKey, 5)
-                        dropDraft(m.nativeKey)
-                      })}
-                      className="btn-secondary-xs"
-                    >+5%</button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-
-        <div className="flex items-center gap-2 pt-3 border-t border-border">
-          <input
-            className={`${inputClass} w-44`}
-            placeholder="native key (e.g. BTC)"
-            value={newKey}
-            onChange={(e) => setNewKey(e.target.value.trim())}
-          />
-          <input
-            className={`${inputClass} w-32`}
-            placeholder="price"
-            value={newPrice}
-            onChange={(e) => setNewPrice(e.target.value)}
-          />
-          <button
-            disabled={loading || !newKey || !newPrice}
-            onClick={() => run(
-              `Add ${newKey} = ${newPrice}`,
-              async () => {
-                await simulatorApi.setMarkPrice(utaId, newKey, newPrice)
-                setNewKey('')
-                setNewPrice('')
-              },
-            )}
-            className="btn-primary-sm"
-          >Add</button>
-        </div>
-      </div>
-    </Section>
-  )
-}
-
-// ==================== Pending Orders ====================
-
-function PendingOrdersSection({ utaId, state, run, loading }: {
-  utaId: string
-  state: SimulatorState
-  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
-  loading: boolean
-}) {
-  const [fillForms, setFillForms] = useState<Record<string, { price: string; qty: string }>>({})
-  const updateForm = (id: string, field: 'price' | 'qty', value: string) => {
-    setFillForms({ ...fillForms, [id]: { ...(fillForms[id] ?? { price: '', qty: '' }), [field]: value } })
-  }
-
-  return (
-    <Section
-      title="Pending Orders"
-      description="Submitted limit/stop orders waiting on a price trigger or manual fill."
-    >
-      {state.pendingOrders.length === 0 ? (
-        <p className="text-xs text-text-muted">No pending orders.</p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left text-text-muted text-xs">
-              <th className="pb-1 pr-3">Order</th>
-              <th className="pb-1 pr-3">Symbol</th>
-              <th className="pb-1 pr-3">Side</th>
-              <th className="pb-1 pr-3">Type</th>
-              <th className="pb-1 pr-3">Qty</th>
-              <th className="pb-1 pr-3">Trigger</th>
-              <th className="pb-1 pr-3 w-40">Fill price (opt)</th>
-              <th className="pb-1 pr-3 w-32">Fill qty (opt)</th>
-              <th className="pb-1 text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {state.pendingOrders.map((o) => {
-              const form = fillForms[o.orderId] ?? { price: '', qty: '' }
-              const trigger = o.lmtPrice ?? o.auxPrice ?? '—'
-              return (
-                <tr key={o.orderId} className="text-text">
-                  <td className="py-1 pr-3 font-mono text-[11px]">{o.orderId}</td>
-                  <td className="py-1 pr-3">{o.symbol}</td>
-                  <td className="py-1 pr-3">{o.action}</td>
-                  <td className="py-1 pr-3">{o.orderType}</td>
-                  <td className="py-1 pr-3 font-mono text-xs">{o.totalQuantity}</td>
-                  <td className="py-1 pr-3 font-mono text-xs">{trigger}</td>
-                  <td className="py-1 pr-3">
-                    <input
-                      className={inputClass}
-                      placeholder="markPrice"
-                      value={form.price}
-                      onChange={(e) => updateForm(o.orderId, 'price', e.target.value)}
-                    />
-                  </td>
-                  <td className="py-1 pr-3">
-                    <input
-                      className={inputClass}
-                      placeholder="full"
-                      value={form.qty}
-                      onChange={(e) => updateForm(o.orderId, 'qty', e.target.value)}
-                    />
-                  </td>
-                  <td className="py-1 text-right space-x-1">
-                    <button
-                      disabled={loading}
-                      onClick={() => run(
-                        `Fill ${o.orderId}`,
-                        () => simulatorApi.fillOrder(utaId, o.orderId, {
-                          ...(form.price && { price: form.price }),
-                          ...(form.qty && { qty: form.qty }),
-                        }),
-                      )}
-                      className="btn-secondary-xs"
-                    >Fill</button>
-                    <button
-                      disabled={loading}
-                      onClick={() => run(`Cancel ${o.orderId}`, () => simulatorApi.cancelOrder(utaId, o.orderId))}
-                      className="btn-secondary-xs"
-                    >Cancel</button>
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
-      )}
-    </Section>
-  )
-}
-
-// ==================== Positions ====================
-
-function PositionsSection({ state }: { state: SimulatorState }) {
-  // Pre-index markPrices so the PnL column reads in O(1) per row.
-  const markByKey = useMemo(() => {
-    const m = new Map<string, string>()
-    for (const mp of state.markPrices) m.set(mp.nativeKey, mp.price)
-    return m
-  }, [state.markPrices])
-
-  return (
-    <Section
-      title="Positions"
-      description="Read-only — mutate via mark price moves, order fills, or external events."
-    >
-      {state.positions.length === 0 ? (
-        <p className="text-xs text-text-muted">No positions.</p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left text-text-muted text-xs">
-              <th className="pb-1 pr-3">Position</th>
-              <th className="pb-1 pr-3 text-right">Qty</th>
-              <th className="pb-1 pr-3 text-right">Avg Cost</th>
-              <th className="pb-1 pr-3 text-right">Mark</th>
-              <th className="pb-1 text-right">PnL</th>
-            </tr>
-          </thead>
-          <tbody>
-            {state.positions.map((p) => {
-              const mark = markByKey.get(p.nativeKey)
-              const qty = Number(p.quantity)
-              const avg = Number(p.avgCost)
-              const pnl = mark && Number.isFinite(qty) && Number.isFinite(avg)
-                ? (Number(mark) - avg) * qty * (p.side === 'long' ? 1 : -1)
-                : null
-              const pnlClass = pnl == null ? 'text-text-muted' : pnl > 0 ? 'text-green' : pnl < 0 ? 'text-red' : 'text-text'
-              return (
-                <tr key={p.nativeKey} className="text-text">
-                  <td className="py-1 pr-3">
-                    <div className="flex items-center gap-1.5 flex-wrap">
-                      <span className="font-mono text-xs">{p.nativeKey}</span>
-                      {p.secType && (
-                        <span className="text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-bg-tertiary text-text-muted/80">{p.secType}</span>
-                      )}
-                      <span className={`text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
-                        {p.side}
-                      </span>
-                      {p.avgCostSource === 'wallet' && (
-                        <span className="text-[9px] text-text-muted/60" title="Cost basis derived from UTA reconcile pipeline (wallet-source position)">wallet</span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="py-1 pr-3 font-mono text-xs text-right">{p.quantity}</td>
-                  <td className="py-1 pr-3 font-mono text-xs text-right">{p.avgCost}</td>
-                  <td className="py-1 pr-3 font-mono text-xs text-right text-text-muted">{mark ?? '—'}</td>
-                  <td className={`py-1 font-mono text-xs text-right ${pnlClass}`}>
-                    {pnl == null ? '—' : `${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}`}
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
-      )}
-    </Section>
-  )
-}
-
-// ==================== External Events ====================
-
-function ExternalEventsSection({ utaId, state, run, loading }: {
-  utaId: string
-  state: SimulatorState
-  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
-  loading: boolean
-}) {
-  const [mode, setMode] = useState<'deposit' | 'withdraw' | 'trade'>('deposit')
-  const [nativeKey, setNativeKey] = useState('')
-  const [quantity, setQuantity] = useState('')
-  const [price, setPrice] = useState('')
-  const [side, setSide] = useState<'BUY' | 'SELL'>('BUY')
-  const [secType, setSecType] = useState<'CRYPTO' | 'CRYPTO_PERP' | 'STK'>('CRYPTO')
-
-  const knownKeys = useMemo(() => {
-    const set = new Set<string>()
-    for (const m of state.markPrices) set.add(m.nativeKey)
-    for (const p of state.positions) set.add(p.nativeKey)
-    return [...set].sort()
-  }, [state])
-
-  const submit = () => {
-    if (!nativeKey || !quantity) return
-    if (mode === 'deposit') {
-      run(
-        `Deposit ${quantity} ${nativeKey}`,
-        () => simulatorApi.externalDeposit(utaId, {
-          nativeKey,
-          quantity,
-          contract: { symbol: nativeKey, secType },
-        }),
-      )
-    } else if (mode === 'withdraw') {
-      run(`Withdraw ${quantity} ${nativeKey}`, () => simulatorApi.externalWithdraw(utaId, nativeKey, quantity))
-    } else {
-      if (!price) return
-      run(
-        `External ${side} ${quantity} ${nativeKey} @ ${price}`,
-        () => simulatorApi.externalTrade(utaId, {
-          nativeKey,
-          side,
-          quantity,
-          price,
-          contract: { symbol: nativeKey, secType },
-        }),
-      )
-    }
-  }
-
-  return (
-    <Section
-      title="External Events"
-      description="Simulate balance changes Alice didn't initiate (airdrop, transfer-in, off-platform trade) — exercises the UTA reconcile pipeline."
-    >
-      <div className="flex items-center gap-2 mb-3">
-        {(['deposit', 'withdraw', 'trade'] as const).map((m) => (
-          <button
-            key={m}
-            onClick={() => setMode(m)}
-            className={`px-2.5 py-1 text-xs rounded transition-colors ${mode === m ? 'bg-accent/20 text-accent font-medium' : 'bg-bg-tertiary text-text-muted hover:text-text'}`}
-          >{m}</button>
-        ))}
-      </div>
-
-      <div className="flex items-center gap-2 flex-wrap">
-        <input
-          className={`${inputClass} w-44`}
-          placeholder="native key"
-          value={nativeKey}
-          onChange={(e) => setNativeKey(e.target.value.trim())}
-          list="sim-known-keys"
-        />
-        <datalist id="sim-known-keys">
-          {knownKeys.map(k => <option key={k} value={k} />)}
-        </datalist>
-
-        <input
-          className={`${inputClass} w-28`}
-          placeholder="quantity"
-          value={quantity}
-          onChange={(e) => setQuantity(e.target.value)}
-        />
-
-        {mode === 'trade' && (
-          <>
-            <input
-              className={`${inputClass} w-28`}
-              placeholder="price"
-              value={price}
-              onChange={(e) => setPrice(e.target.value)}
-            />
-            <select
-              value={side}
-              onChange={(e) => setSide(e.target.value as 'BUY' | 'SELL')}
-              className={`${inputClass} w-20`}
+    <div className="flex items-center gap-3 flex-wrap">
+      <div className="flex items-center gap-1 flex-wrap" role="tablist" aria-label="Simulator accounts">
+        {utas.map((u) => {
+          const active = u.id === selectedId
+          return (
+            <button
+              key={u.id}
+              role="tab"
+              aria-selected={active}
+              onClick={() => onSelect(u.id)}
+              title={u.id}
+              className={`px-2.5 py-1 text-sm rounded transition-colors ${
+                active
+                  ? 'bg-accent/15 text-accent font-medium border border-accent/30'
+                  : 'text-text-muted hover:text-text border border-transparent hover:bg-bg-tertiary/50'
+              }`}
             >
-              <option value="BUY">BUY</option>
-              <option value="SELL">SELL</option>
-            </select>
-          </>
-        )}
-
-        {(mode === 'deposit' || mode === 'trade') && (
-          <select
-            value={secType}
-            onChange={(e) => setSecType(e.target.value as 'CRYPTO' | 'CRYPTO_PERP' | 'STK')}
-            className={`${inputClass} w-32`}
-          >
-            <option value="CRYPTO">CRYPTO</option>
-            <option value="CRYPTO_PERP">CRYPTO_PERP</option>
-            <option value="STK">STK</option>
-          </select>
-        )}
-
-        <button
-          disabled={loading || !nativeKey || !quantity || (mode === 'trade' && !price)}
-          onClick={submit}
-          className="btn-primary-sm"
-        >Submit</button>
+              {u.label}
+            </button>
+          )
+        })}
       </div>
 
-      <p className="text-[11px] text-text-muted mt-2">
-        Deposit / withdraw don't change cash. External trade decreases cash on BUY, increases on SELL — like the user manually executed on the exchange app.
-      </p>
-    </Section>
+      <button
+        onClick={onRefresh}
+        className="px-2.5 py-1 text-xs bg-bg-tertiary text-text-muted rounded hover:text-text transition-colors"
+      >
+        Refresh
+      </button>
+
+      {cash !== undefined && (
+        <span className="ml-auto text-[12px] text-text-muted uppercase tracking-wide">
+          Cash <span className="font-mono text-text text-sm normal-case ml-1.5">
+            ${Number(cash).toLocaleString('en-US', { minimumFractionDigits: 2 })}
+          </span>
+        </span>
+      )}
+    </div>
   )
 }

--- a/ui/src/pages/SimulatorPage.tsx
+++ b/ui/src/pages/SimulatorPage.tsx
@@ -15,13 +15,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Section } from '../components/form'
-import { EmptyState, Spinner } from '../components/StateViews'
+import { Spinner } from '../components/StateViews'
 import { useToast } from '../components/Toast'
 import {
   simulatorApi,
   type SimulatorState,
   type SimulatorUTAEntry,
 } from '../api/simulator'
+import { api } from '../api'
 
 const POLL_INTERVAL_MS = 3000
 
@@ -35,14 +36,23 @@ export function SimulatorPage() {
   const [loading, setLoading] = useState(false)
   const toast = useToast()
 
-  // Load UTA list once
-  useEffect(() => {
-    simulatorApi.listUtas().then((r) => {
+  const refreshUtaList = useCallback(async () => {
+    try {
+      const r = await simulatorApi.listUtas()
       setUtas(r.utas)
-      if (r.utas.length > 0) setSelected(r.utas[0].id)
-    }).catch((err) => {
+      // If currently selected vanished, fall back to first
+      if (r.utas.length > 0 && !r.utas.some(u => u.id === selected)) setSelected(r.utas[0].id)
+      else if (r.utas.length === 0) setSelected('')
+      return r.utas
+    } catch (err) {
       toast.error(`Failed to list simulators: ${err instanceof Error ? err.message : err}`)
-    })
+      return []
+    }
+  }, [selected, toast])
+
+  // Load UTA list once on mount
+  useEffect(() => {
+    refreshUtaList()
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -79,37 +89,38 @@ export function SimulatorPage() {
     }
   }, [selected, toast, refresh])
 
-  if (utas.length === 0) {
-    return (
-      <div className="px-4 md:px-6 py-5 max-w-[860px]">
-        <EmptyState
-          title="No simulator UTAs."
-          description="Create one from Settings → Trading → 'Simulator (testing only)'."
-        />
-      </div>
-    )
-  }
-
   return (
     <div className="px-4 md:px-6 py-5 max-w-[960px] space-y-5">
-      <div className="flex items-center gap-3">
-        <label className="text-[13px] text-text-muted">Account</label>
-        <select
-          value={selected}
-          onChange={(e) => setSelected(e.target.value)}
-          className="px-2.5 py-1 bg-bg text-text border border-border rounded text-sm outline-none focus:border-accent"
-        >
-          {utas.map(u => <option key={u.id} value={u.id}>{u.label} ({u.id})</option>)}
-        </select>
-        <button
-          onClick={refresh}
-          className="px-2.5 py-1 text-xs bg-bg-tertiary text-text-muted rounded hover:text-text transition-colors"
-        >
-          Refresh
-        </button>
-      </div>
+      <CreateSimulatorSection
+        existingIds={utas.map(u => u.id)}
+        onCreated={async (newId) => {
+          const list = await refreshUtaList()
+          if (list.some(u => u.id === newId)) setSelected(newId)
+        }}
+      />
 
-      {state ? (
+      {utas.length === 0 ? (
+        <p className="text-sm text-text-muted">No simulator account yet — create one above.</p>
+      ) : (
+        <div className="flex items-center gap-3">
+          <label className="text-[13px] text-text-muted">Account</label>
+          <select
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+            className="px-2.5 py-1 bg-bg text-text border border-border rounded text-sm outline-none focus:border-accent"
+          >
+            {utas.map(u => <option key={u.id} value={u.id}>{u.label} ({u.id})</option>)}
+          </select>
+          <button
+            onClick={refresh}
+            className="px-2.5 py-1 text-xs bg-bg-tertiary text-text-muted rounded hover:text-text transition-colors"
+          >
+            Refresh
+          </button>
+        </div>
+      )}
+
+      {selected && (state ? (
         <>
           <Section title="Cash" description="Available USD balance.">
             <p className="font-mono text-lg text-text">${Number(state.cash).toLocaleString('en-US', { minimumFractionDigits: 2 })}</p>
@@ -140,8 +151,109 @@ export function SimulatorPage() {
         </>
       ) : (
         <div className="flex justify-center py-12"><Spinner /></div>
-      )}
+      ))}
     </div>
+  )
+}
+
+// ==================== Create Simulator UTA ====================
+
+function CreateSimulatorSection({ existingIds, onCreated }: {
+  existingIds: string[]
+  onCreated: (id: string) => Promise<void>
+}) {
+  const [open, setOpen] = useState(false)
+  const [id, setId] = useState('')
+  const [cash, setCash] = useState('100000')
+  const [busy, setBusy] = useState(false)
+  const toast = useToast()
+
+  // Default id: simulator, simulator-2, simulator-3, …
+  const defaultId = useMemo(() => {
+    if (!existingIds.includes('simulator')) return 'simulator'
+    let i = 2
+    while (existingIds.includes(`simulator-${i}`)) i++
+    return `simulator-${i}`
+  }, [existingIds])
+
+  const submit = async () => {
+    const finalId = (id || defaultId).trim()
+    if (!finalId) return
+    if (existingIds.includes(finalId)) {
+      toast.error(`Account "${finalId}" already exists`)
+      return
+    }
+    const cashNum = Number(cash)
+    if (!Number.isFinite(cashNum) || cashNum < 0) {
+      toast.error('Cash must be a non-negative number')
+      return
+    }
+    setBusy(true)
+    try {
+      await api.trading.upsertUTA({
+        id: finalId,
+        label: finalId,
+        presetId: 'mock-simulator',
+        enabled: true,
+        guards: [],
+        presetConfig: { cash: cashNum },
+      })
+      // Engine load: PUT skips reconnect for brand-new accounts (no
+      // wasEnabled→nowEnabled transition), so kick it ourselves.
+      await api.trading.reconnectUTA(finalId).catch(() => {})
+      toast.success(`Created ${finalId}`)
+      setOpen(false)
+      setId('')
+      setCash('100000')
+      await onCreated(finalId)
+    } catch (err) {
+      toast.error(`Create failed: ${err instanceof Error ? err.message : err}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="btn-secondary-sm"
+      >
+        + New simulator account
+      </button>
+    )
+  }
+
+  return (
+    <Section
+      title="Create simulator account"
+      description="In-memory only — wiped on dev server restart. For repro & regression testing."
+    >
+      <div className="flex items-center gap-2 flex-wrap">
+        <input
+          className="px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent w-44"
+          placeholder={defaultId}
+          value={id}
+          onChange={(e) => setId(e.target.value.trim())}
+        />
+        <input
+          className="px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent w-32"
+          placeholder="cash (USD)"
+          value={cash}
+          onChange={(e) => setCash(e.target.value)}
+        />
+        <button disabled={busy} onClick={submit} className="btn-primary-sm">
+          {busy ? 'Creating…' : 'Create'}
+        </button>
+        <button
+          disabled={busy}
+          onClick={() => { setOpen(false); setId(''); setCash('100000') }}
+          className="btn-secondary-sm"
+        >
+          Cancel
+        </button>
+      </div>
+    </Section>
   )
 }
 

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -243,6 +243,10 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
     () => presets.filter(p => p.category === 'crypto').map(toOption),
     [presets],
   )
+  const testingOptions: SDKOption[] = useMemo(
+    () => presets.filter(p => p.category === 'testing').map(toOption),
+    [presets],
+  )
 
   const buildUTA = (): UTAConfig | null => {
     if (!preset) return null
@@ -332,6 +336,12 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
               <section className="space-y-3">
                 <PickerSectionHeader title="Crypto" />
                 <SDKSelector options={cryptoOptions} selected={presetId ?? ''} onSelect={handlePick} />
+              </section>
+            )}
+            {testingOptions.length > 0 && (
+              <section className="space-y-3">
+                <PickerSectionHeader title="Testing" />
+                <SDKSelector options={testingOptions} selected={presetId ?? ''} onSelect={handlePick} />
               </section>
             )}
           </div>

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -69,14 +69,18 @@ export function TradingPage() {
       {showAdd && (
         <CreateWizard
           presets={presets}
-          existingUTAIds={tc.utas.map((a) => a.id)}
           onSave={async (uta) => {
-            await tc.saveUTA(uta)
-            const result = await tc.reconnectUTA(uta.id)
+            const created = await tc.createUTA(uta)
+            const result = await tc.reconnectUTA(created.id)
             if (!result.success) {
               throw new Error(result.error || 'Connection failed')
             }
             setShowAdd(false)
+            return created
+          }}
+          onOpenExisting={(id) => {
+            setShowAdd(false)
+            navigate(`/uta/${id}`)
           }}
           onClose={() => setShowAdd(false)}
         />
@@ -205,27 +209,32 @@ function PickerSectionHeader({ title }: { title: string }) {
 
 type WizardStep = 'pick' | 'config' | 'test'
 
-function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
+interface BrokerConflict {
+  existing: { id: string; label: string; presetId: string }
+}
+
+function CreateWizard({ presets, onSave, onOpenExisting, onClose }: {
   presets: BrokerPreset[]
-  existingUTAIds: string[]
-  onSave: (uta: UTAConfig) => Promise<void>
+  onSave: (uta: Omit<UTAConfig, 'id'>) => Promise<UTAConfig>
+  onOpenExisting: (id: string) => void
   onClose: () => void
 }) {
   const [step, setStep] = useState<WizardStep>('pick')
   const [presetId, setPresetId] = useState<string | null>(null)
-  const [id, setId] = useState('')
+  const [name, setName] = useState('')
   const [showSecrets, setShowSecrets] = useState(false)
   const [testing, setTesting] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+  const [conflict, setConflict] = useState<BrokerConflict | null>(null)
   const [testResult, setTestResult] = useState<TestConnectionResult | null>(null)
 
   const preset = presets.find(p => p.id === presetId)
   const hasSensitive = preset?.schema && Object.values((preset.schema as { properties?: Record<string, { writeOnly?: boolean }> }).properties ?? {}).some(p => p.writeOnly)
   const { fields, formData, setField, getSubmitData, validate } = useSchemaForm(preset?.schema)
 
-  const defaultId = preset?.defaultName ?? ''
-  const finalId = id.trim() || defaultId
+  const defaultName = preset?.defaultName ?? ''
+  const finalName = name.trim() || defaultName
 
   const toOption = (p: BrokerPreset): SDKOption => ({
     id: p.id,
@@ -247,10 +256,10 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
     [presets],
   )
 
-  const buildUTA = (): UTAConfig | null => {
+  const buildUTA = (): Omit<UTAConfig, 'id'> | null => {
     if (!preset) return null
     return {
-      id: finalId,
+      label: finalName,
       presetId: preset.id,
       enabled: true,
       guards: [],
@@ -267,10 +276,7 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
   const handleTest = async () => {
     if (!preset) return
     setError('')
-    if (existingUTAIds.includes(finalId)) {
-      setError(`UTA "${finalId}" already exists`)
-      return
-    }
+    setConflict(null)
     const validationError = validate()
     if (validationError) {
       setError(validationError)
@@ -294,10 +300,20 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
   const handleSave = async () => {
     const uta = buildUTA()
     if (!uta) return
-    setSaving(true); setError('')
+    setSaving(true); setError(''); setConflict(null)
     try {
       await onSave(uta)
     } catch (err) {
+      // Surface 409 collision info (typed as BrokerAlreadyExistsError) so
+      // the user can jump to the existing UTA instead of forking.
+      if (err instanceof Error && err.name === 'BrokerAlreadyExistsError') {
+        const existing = (err as Error & { existing?: BrokerConflict['existing'] }).existing
+        if (existing) {
+          setConflict({ existing })
+          setSaving(false)
+          return
+        }
+      }
       setError(err instanceof Error ? err.message : 'Failed to save UTA')
       setSaving(false)
     }
@@ -344,8 +360,8 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
           <div className="space-y-5">
             {preset.hint && <HintBlock text={preset.hint} />}
             <div className="space-y-3">
-              <Field label="UTA ID">
-                <input className={inputClass} value={id} onChange={(e) => setId(e.target.value.trim())} placeholder={defaultId} />
+              <Field label="Name" description="Display label for this account. The unique id is derived automatically from the credentials below.">
+                <input className={inputClass} value={name} onChange={(e) => setName(e.target.value)} placeholder={defaultName} />
               </Field>
               <SchemaFormFields
                 fields={fields}
@@ -366,8 +382,12 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
           </div>
         )}
 
-        {step === 'test' && testResult && (
-          <TestResultPanel result={testResult} utaId={finalId} />
+        {step === 'test' && testResult && !conflict && (
+          <TestResultPanel result={testResult} utaId={finalName} />
+        )}
+
+        {step === 'test' && conflict && (
+          <BrokerConflictPanel existing={conflict.existing} onOpenExisting={() => onOpenExisting(conflict.existing.id)} />
         )}
       </div>
 
@@ -389,7 +409,11 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
         {step === 'test' && (
           <>
             <button onClick={() => setStep('config')} className="btn-secondary">← Back</button>
-            {testResult?.success ? (
+            {conflict ? (
+              <button onClick={() => onOpenExisting(conflict.existing.id)} className="btn-primary">
+                Open existing
+              </button>
+            ) : testResult?.success ? (
               <button onClick={handleSave} disabled={saving} className="btn-primary">
                 {saving ? 'Saving...' : 'Save UTA'}
               </button>
@@ -417,6 +441,34 @@ function StepDots({ current }: { current: WizardStep }) {
           }`}
         />
       ))}
+    </div>
+  )
+}
+
+function BrokerConflictPanel({ existing, onOpenExisting }: {
+  existing: { id: string; label: string; presetId: string }
+  onOpenExisting: () => void
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="w-2 h-2 rounded-full bg-yellow-400 shrink-0" />
+        <span className="text-[13px] font-medium text-text">Broker already configured</span>
+      </div>
+      <div className="rounded-md border border-yellow-400/30 bg-yellow-400/5 px-3 py-2.5">
+        <p className="text-[12px] text-text leading-relaxed">
+          Another UTA already exists for this broker (same identity-defining credentials).
+          Re-using the same key from a separate account would double-count its positions in
+          aggregate views.
+        </p>
+        <p className="text-[12px] text-text-muted leading-relaxed mt-2">
+          Existing: <strong className="text-text">{existing.label}</strong> <span className="font-mono text-text-muted/70">({existing.id})</span>
+        </p>
+      </div>
+      <p className="text-[11px] text-text-muted">
+        Click <strong className="text-text">Open existing</strong> to use it, or <strong className="text-text">← Back</strong> to point this UTA at a different account.
+      </p>
+      <button onClick={onOpenExisting} className="btn-secondary w-full">Open existing UTA</button>
     </div>
   )
 }

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -235,16 +235,15 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
     badgeColor: p.badgeColor,
   })
 
+  // 'testing' category presets (Simulator) are intentionally excluded — their
+  // creation entry lives in Dev → Simulator so users picking a real broker
+  // here don't see "Simulator" alongside Bybit / Alpaca / IBKR.
   const recommendedOptions: SDKOption[] = useMemo(
     () => presets.filter(p => p.category === 'recommended').map(toOption),
     [presets],
   )
   const cryptoOptions: SDKOption[] = useMemo(
     () => presets.filter(p => p.category === 'crypto').map(toOption),
-    [presets],
-  )
-  const testingOptions: SDKOption[] = useMemo(
-    () => presets.filter(p => p.category === 'testing').map(toOption),
     [presets],
   )
 
@@ -336,12 +335,6 @@ function CreateWizard({ presets, existingUTAIds, onSave, onClose }: {
               <section className="space-y-3">
                 <PickerSectionHeader title="Crypto" />
                 <SDKSelector options={cryptoOptions} selected={presetId ?? ''} onSelect={handlePick} />
-              </section>
-            )}
-            {testingOptions.length > 0 && (
-              <section className="space-y-3">
-                <PickerSectionHeader title="Testing" />
-                <SDKSelector options={testingOptions} selected={presetId ?? ''} onSelect={handlePick} />
               </section>
             )}
           </div>

--- a/ui/src/pages/simulator/ActionPanel.tsx
+++ b/ui/src/pages/simulator/ActionPanel.tsx
@@ -15,6 +15,8 @@
 import { useMemo, useState } from 'react'
 import { api } from '../../api'
 import { simulatorApi, type SimulatorState } from '../../api/simulator'
+import { InstrumentInput } from './InstrumentInput'
+import { buildInstrument, type InstrumentDraft } from './instruments'
 
 const inputClass =
   'px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent'
@@ -135,96 +137,126 @@ function DepositTab({ utaId, knownKeys, run, loading }: {
   run: (label: string, fn: () => Promise<unknown>) => Promise<void>
   loading: boolean
 }) {
-  const [key, setKey] = useState('')
+  const [draft, setDraft] = useState<InstrumentDraft>({ symbol: '', secType: 'CRYPTO' })
   const [qty, setQty] = useState('')
-  const [secType, setSecType] = useState<'CRYPTO' | 'CRYPTO_PERP' | 'STK'>('CRYPTO')
+  const [withdrawKey, setWithdrawKey] = useState('')
+  const [withdrawQty, setWithdrawQty] = useState('')
   const [mode, setMode] = useState<'in' | 'out'>('in')
 
-  const submit = () => {
-    if (!key || !qty) return
-    if (mode === 'in') {
-      run(
-        `Deposit ${qty} ${key}`,
-        async () => {
-          await simulatorApi.externalDeposit(utaId, {
-            nativeKey: key,
-            quantity: qty,
-            contract: { symbol: key, secType },
-          })
-          setQty('')
-        },
-      )
-    } else {
-      run(
-        `Withdraw ${qty} ${key}`,
-        async () => {
-          await simulatorApi.externalWithdraw(utaId, key, qty)
-          setQty('')
-        },
-      )
-    }
+  const built = mode === 'in' ? buildInstrument(draft) : null
+  const draftError = built && 'error' in built ? built.error : null
+  const draftOk = built && 'nativeKey' in built ? built : null
+
+  const submitDeposit = () => {
+    if (!draftOk || !qty) return
+    run(
+      `Deposit ${qty} ${draftOk.nativeKey}`,
+      async () => {
+        await simulatorApi.externalDeposit(utaId, {
+          nativeKey: draftOk.nativeKey,
+          quantity: qty,
+          contract: draftOk.contract,
+        })
+        setQty('')
+      },
+    )
+  }
+
+  const submitWithdraw = () => {
+    if (!withdrawKey || !withdrawQty) return
+    run(
+      `Withdraw ${withdrawQty} ${withdrawKey}`,
+      async () => {
+        await simulatorApi.externalWithdraw(utaId, withdrawKey, withdrawQty)
+        setWithdrawQty('')
+      },
+    )
   }
 
   return (
-    <div className="flex items-center gap-2 flex-wrap">
-      <div className="flex rounded overflow-hidden border border-border">
-        <button
-          onClick={() => setMode('in')}
-          className={`px-2 py-1 text-xs ${mode === 'in' ? 'bg-green/20 text-green' : 'text-text-muted hover:text-text'}`}
-        >Deposit</button>
-        <button
-          onClick={() => setMode('out')}
-          className={`px-2 py-1 text-xs ${mode === 'out' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}
-        >Withdraw</button>
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex rounded overflow-hidden border border-border">
+          <button
+            onClick={() => setMode('in')}
+            className={`px-2 py-1 text-xs ${mode === 'in' ? 'bg-green/20 text-green' : 'text-text-muted hover:text-text'}`}
+          >Deposit</button>
+          <button
+            onClick={() => setMode('out')}
+            className={`px-2 py-1 text-xs ${mode === 'out' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}
+          >Withdraw</button>
+        </div>
+
+        {mode === 'in' ? (
+          <>
+            <InstrumentInput draft={draft} onChange={setDraft} />
+            <input
+              className={`${inputClassMono} w-24`}
+              placeholder="quantity"
+              value={qty}
+              onChange={(e) => setQty(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') submitDeposit() }}
+            />
+            <button
+              disabled={loading || !draftOk || !qty}
+              onClick={submitDeposit}
+              className="btn-primary-sm"
+            >Deposit</button>
+            {draftOk && <span className="text-[11px] text-text-muted/70 font-mono">→ {draftOk.nativeKey}</span>}
+            {draftError && draft.symbol && <span className="text-[11px] text-yellow-400">{draftError}</span>}
+          </>
+        ) : (
+          <>
+            <KeySelect value={withdrawKey} onChange={setWithdrawKey} options={knownKeys} placeholder="native key" />
+            <input
+              className={`${inputClassMono} w-32`}
+              placeholder="quantity"
+              value={withdrawQty}
+              onChange={(e) => setWithdrawQty(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') submitWithdraw() }}
+            />
+            <button
+              disabled={loading || !withdrawKey || !withdrawQty}
+              onClick={submitWithdraw}
+              className="btn-primary-sm"
+            >Withdraw</button>
+          </>
+        )}
+
+        <span className="text-[11px] text-text-muted ml-auto">Cash unchanged. Triggers UTA reconcile pipeline.</span>
       </div>
-      <KeySelect value={key} onChange={setKey} options={knownKeys} placeholder="symbol" />
-      <input
-        className={`${inputClassMono} w-32`}
-        placeholder="quantity"
-        value={qty}
-        onChange={(e) => setQty(e.target.value)}
-        onKeyDown={(e) => { if (e.key === 'Enter') submit() }}
-      />
-      {mode === 'in' && (
-        <select value={secType} onChange={(e) => setSecType(e.target.value as 'CRYPTO' | 'CRYPTO_PERP' | 'STK')} className={`${inputClass} w-32`}>
-          <option value="CRYPTO">CRYPTO</option>
-          <option value="CRYPTO_PERP">CRYPTO_PERP</option>
-          <option value="STK">STK</option>
-        </select>
-      )}
-      <button disabled={loading || !key || !qty} onClick={submit} className="btn-primary-sm">
-        {mode === 'in' ? 'Deposit' : 'Withdraw'}
-      </button>
-      <span className="text-[11px] text-text-muted">Cash unchanged. Triggers UTA reconcile pipeline.</span>
     </div>
   )
 }
 
 // ==================== External Trade ====================
 
-function TradeTab({ utaId, knownKeys, run, loading }: {
+function TradeTab({ utaId, run, loading }: {
   utaId: string
   knownKeys: string[]
   run: (label: string, fn: () => Promise<unknown>) => Promise<void>
   loading: boolean
 }) {
-  const [key, setKey] = useState('')
+  const [draft, setDraft] = useState<InstrumentDraft>({ symbol: '', secType: 'CRYPTO' })
   const [side, setSide] = useState<'BUY' | 'SELL'>('BUY')
   const [qty, setQty] = useState('')
   const [price, setPrice] = useState('')
-  const [secType, setSecType] = useState<'CRYPTO' | 'CRYPTO_PERP' | 'STK'>('CRYPTO')
+
+  const built = buildInstrument(draft)
+  const draftError = 'error' in built ? built.error : null
+  const draftOk = 'nativeKey' in built ? built : null
 
   const submit = () => {
-    if (!key || !qty || !price) return
+    if (!draftOk || !qty || !price) return
     run(
-      `External ${side} ${qty} ${key} @ ${price}`,
+      `External ${side} ${qty} ${draftOk.nativeKey} @ ${price}`,
       async () => {
         await simulatorApi.externalTrade(utaId, {
-          nativeKey: key,
+          nativeKey: draftOk.nativeKey,
           side,
           quantity: qty,
           price,
-          contract: { symbol: key, secType },
+          contract: draftOk.contract,
         })
         setQty('')
       },
@@ -243,16 +275,13 @@ function TradeTab({ utaId, knownKeys, run, loading }: {
           className={`px-2 py-1 text-xs ${side === 'SELL' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}
         >SELL</button>
       </div>
-      <KeySelect value={key} onChange={setKey} options={knownKeys} placeholder="symbol" />
-      <input className={`${inputClassMono} w-28`} placeholder="qty" value={qty} onChange={(e) => setQty(e.target.value)} />
-      <input className={`${inputClassMono} w-28`} placeholder="price" value={price} onChange={(e) => setPrice(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') submit() }} />
-      <select value={secType} onChange={(e) => setSecType(e.target.value as 'CRYPTO' | 'CRYPTO_PERP' | 'STK')} className={`${inputClass} w-32`}>
-        <option value="CRYPTO">CRYPTO</option>
-        <option value="CRYPTO_PERP">CRYPTO_PERP</option>
-        <option value="STK">STK</option>
-      </select>
-      <button disabled={loading || !key || !qty || !price} onClick={submit} className="btn-primary-sm">Submit</button>
-      <span className="text-[11px] text-text-muted">Cash {side === 'BUY' ? '−' : '+'} qty × price.</span>
+      <InstrumentInput draft={draft} onChange={setDraft} />
+      <input className={`${inputClassMono} w-24`} placeholder="qty" value={qty} onChange={(e) => setQty(e.target.value)} />
+      <input className={`${inputClassMono} w-24`} placeholder="price" value={price} onChange={(e) => setPrice(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') submit() }} />
+      <button disabled={loading || !draftOk || !qty || !price} onClick={submit} className="btn-primary-sm">Submit</button>
+      {draftOk && <span className="text-[11px] text-text-muted/70 font-mono">→ {draftOk.nativeKey}</span>}
+      {draftError && draft.symbol && <span className="text-[11px] text-yellow-400">{draftError}</span>}
+      <span className="text-[11px] text-text-muted ml-auto">Cash {side === 'BUY' ? '−' : '+'} qty × price.</span>
     </div>
   )
 }

--- a/ui/src/pages/simulator/ActionPanel.tsx
+++ b/ui/src/pages/simulator/ActionPanel.tsx
@@ -1,0 +1,341 @@
+/**
+ * ActionPanel — sticky bottom dock with tabbed action surfaces.
+ *
+ * Tabs:
+ *   1. Quick Tick      — symbol picker + tick buttons + set price input
+ *   2. External Deposit — fund a position out of nowhere (bypasses orders)
+ *   3. External Trade  — simulate user trading on the exchange app outside Alice
+ *   4. Place Order     — go through the real Alice order pipeline (stage→commit→push)
+ *
+ * Every action funnels through `run(label, fn)` so the EventLog gets
+ * uniform entries and state refresh is automatic. Tab content keeps its
+ * own form state across tab switches so partial inputs aren't lost.
+ */
+
+import { useMemo, useState } from 'react'
+import { api } from '../../api'
+import { simulatorApi, type SimulatorState } from '../../api/simulator'
+
+const inputClass =
+  'px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent'
+const inputClassMono =
+  'px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+
+type TabId = 'tick' | 'deposit' | 'trade' | 'order'
+
+const TABS: Array<{ id: TabId; label: string; hint: string }> = [
+  { id: 'tick',    label: 'Quick Tick',       hint: 'Move a mark price' },
+  { id: 'deposit', label: 'External Deposit', hint: 'Funds appear outside Alice (airdrop / transfer-in)' },
+  { id: 'trade',   label: 'External Trade',   hint: 'User manually traded on the exchange app' },
+  { id: 'order',   label: 'Place Order',      hint: 'Stage → commit → push through Alice' },
+]
+
+export function ActionPanel({ utaId, state, run, loading }: {
+  utaId: string
+  state: SimulatorState
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [tab, setTab] = useState<TabId>('tick')
+  const knownKeys = useMemo(() => {
+    const set = new Set<string>()
+    for (const m of state.markPrices) set.add(m.nativeKey)
+    for (const p of state.positions) set.add(p.nativeKey)
+    return [...set].sort()
+  }, [state])
+
+  return (
+    <div className="sticky bottom-0 -mx-4 md:-mx-6 px-4 md:px-6 py-3 bg-bg-secondary/95 backdrop-blur border-t border-border z-10">
+      {/* Tab strip */}
+      <div className="flex items-center gap-1 mb-3" role="tablist">
+        {TABS.map((t, i) => (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={tab === t.id}
+            title={`${t.hint} (${i + 1})`}
+            onClick={() => setTab(t.id)}
+            className={`px-2.5 py-1 text-xs rounded transition-colors ${
+              tab === t.id
+                ? 'bg-accent/20 text-accent font-medium'
+                : 'text-text-muted hover:text-text hover:bg-bg-tertiary/50'
+            }`}
+          >
+            <span className="text-[10px] text-text-muted/60 mr-1.5">{i + 1}</span>
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {tab === 'tick' && <QuickTickTab utaId={utaId} knownKeys={knownKeys} run={run} loading={loading} />}
+      {tab === 'deposit' && <DepositTab utaId={utaId} knownKeys={knownKeys} run={run} loading={loading} />}
+      {tab === 'trade' && <TradeTab utaId={utaId} knownKeys={knownKeys} run={run} loading={loading} />}
+      {tab === 'order' && <OrderTab utaId={utaId} knownKeys={knownKeys} run={run} loading={loading} />}
+    </div>
+  )
+}
+
+// ==================== Quick Tick ====================
+
+function QuickTickTab({ utaId, knownKeys, run, loading }: {
+  utaId: string
+  knownKeys: string[]
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [key, setKey] = useState(knownKeys[0] ?? '')
+  const [setPriceInput, setSetPriceInput] = useState('')
+
+  const tick = (deltaPercent: number) => {
+    if (!key) return
+    run(
+      `${key} ${deltaPercent > 0 ? '+' : ''}${deltaPercent}%`,
+      () => simulatorApi.tickPrice(utaId, key, deltaPercent),
+    )
+  }
+
+  const setExact = () => {
+    if (!key || !setPriceInput) return
+    run(
+      `Set ${key} = ${setPriceInput}`,
+      async () => {
+        await simulatorApi.setMarkPrice(utaId, key, setPriceInput)
+        setSetPriceInput('')
+      },
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <KeySelect value={key} onChange={setKey} options={knownKeys} placeholder="symbol" />
+      <span className="text-text-muted text-xs">Δ</span>
+      <button disabled={loading || !key} onClick={() => tick(-5)} className="btn-secondary-sm">−5%</button>
+      <button disabled={loading || !key} onClick={() => tick(-1)} className="btn-secondary-sm">−1%</button>
+      <button disabled={loading || !key} onClick={() => tick(1)} className="btn-secondary-sm">+1%</button>
+      <button disabled={loading || !key} onClick={() => tick(5)} className="btn-secondary-sm">+5%</button>
+      <span className="text-text-muted/60 text-xs px-1">|</span>
+      <input
+        className={`${inputClassMono} w-32`}
+        placeholder="set exact"
+        value={setPriceInput}
+        onChange={(e) => setSetPriceInput(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') setExact() }}
+      />
+      <button disabled={loading || !key || !setPriceInput} onClick={setExact} className="btn-primary-sm">Set</button>
+    </div>
+  )
+}
+
+// ==================== External Deposit ====================
+
+function DepositTab({ utaId, knownKeys, run, loading }: {
+  utaId: string
+  knownKeys: string[]
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [key, setKey] = useState('')
+  const [qty, setQty] = useState('')
+  const [secType, setSecType] = useState<'CRYPTO' | 'CRYPTO_PERP' | 'STK'>('CRYPTO')
+  const [mode, setMode] = useState<'in' | 'out'>('in')
+
+  const submit = () => {
+    if (!key || !qty) return
+    if (mode === 'in') {
+      run(
+        `Deposit ${qty} ${key}`,
+        async () => {
+          await simulatorApi.externalDeposit(utaId, {
+            nativeKey: key,
+            quantity: qty,
+            contract: { symbol: key, secType },
+          })
+          setQty('')
+        },
+      )
+    } else {
+      run(
+        `Withdraw ${qty} ${key}`,
+        async () => {
+          await simulatorApi.externalWithdraw(utaId, key, qty)
+          setQty('')
+        },
+      )
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <div className="flex rounded overflow-hidden border border-border">
+        <button
+          onClick={() => setMode('in')}
+          className={`px-2 py-1 text-xs ${mode === 'in' ? 'bg-green/20 text-green' : 'text-text-muted hover:text-text'}`}
+        >Deposit</button>
+        <button
+          onClick={() => setMode('out')}
+          className={`px-2 py-1 text-xs ${mode === 'out' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}
+        >Withdraw</button>
+      </div>
+      <KeySelect value={key} onChange={setKey} options={knownKeys} placeholder="symbol" />
+      <input
+        className={`${inputClassMono} w-32`}
+        placeholder="quantity"
+        value={qty}
+        onChange={(e) => setQty(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') submit() }}
+      />
+      {mode === 'in' && (
+        <select value={secType} onChange={(e) => setSecType(e.target.value as 'CRYPTO' | 'CRYPTO_PERP' | 'STK')} className={`${inputClass} w-32`}>
+          <option value="CRYPTO">CRYPTO</option>
+          <option value="CRYPTO_PERP">CRYPTO_PERP</option>
+          <option value="STK">STK</option>
+        </select>
+      )}
+      <button disabled={loading || !key || !qty} onClick={submit} className="btn-primary-sm">
+        {mode === 'in' ? 'Deposit' : 'Withdraw'}
+      </button>
+      <span className="text-[11px] text-text-muted">Cash unchanged. Triggers UTA reconcile pipeline.</span>
+    </div>
+  )
+}
+
+// ==================== External Trade ====================
+
+function TradeTab({ utaId, knownKeys, run, loading }: {
+  utaId: string
+  knownKeys: string[]
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [key, setKey] = useState('')
+  const [side, setSide] = useState<'BUY' | 'SELL'>('BUY')
+  const [qty, setQty] = useState('')
+  const [price, setPrice] = useState('')
+  const [secType, setSecType] = useState<'CRYPTO' | 'CRYPTO_PERP' | 'STK'>('CRYPTO')
+
+  const submit = () => {
+    if (!key || !qty || !price) return
+    run(
+      `External ${side} ${qty} ${key} @ ${price}`,
+      async () => {
+        await simulatorApi.externalTrade(utaId, {
+          nativeKey: key,
+          side,
+          quantity: qty,
+          price,
+          contract: { symbol: key, secType },
+        })
+        setQty('')
+      },
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <div className="flex rounded overflow-hidden border border-border">
+        <button
+          onClick={() => setSide('BUY')}
+          className={`px-2 py-1 text-xs ${side === 'BUY' ? 'bg-green/20 text-green' : 'text-text-muted hover:text-text'}`}
+        >BUY</button>
+        <button
+          onClick={() => setSide('SELL')}
+          className={`px-2 py-1 text-xs ${side === 'SELL' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}
+        >SELL</button>
+      </div>
+      <KeySelect value={key} onChange={setKey} options={knownKeys} placeholder="symbol" />
+      <input className={`${inputClassMono} w-28`} placeholder="qty" value={qty} onChange={(e) => setQty(e.target.value)} />
+      <input className={`${inputClassMono} w-28`} placeholder="price" value={price} onChange={(e) => setPrice(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') submit() }} />
+      <select value={secType} onChange={(e) => setSecType(e.target.value as 'CRYPTO' | 'CRYPTO_PERP' | 'STK')} className={`${inputClass} w-32`}>
+        <option value="CRYPTO">CRYPTO</option>
+        <option value="CRYPTO_PERP">CRYPTO_PERP</option>
+        <option value="STK">STK</option>
+      </select>
+      <button disabled={loading || !key || !qty || !price} onClick={submit} className="btn-primary-sm">Submit</button>
+      <span className="text-[11px] text-text-muted">Cash {side === 'BUY' ? '−' : '+'} qty × price.</span>
+    </div>
+  )
+}
+
+// ==================== Place Order (through Alice trading API) ====================
+
+function OrderTab({ utaId, knownKeys, run, loading }: {
+  utaId: string
+  knownKeys: string[]
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [key, setKey] = useState('')
+  const [side, setSide] = useState<'BUY' | 'SELL'>('BUY')
+  const [orderType, setOrderType] = useState<'MKT' | 'LMT'>('MKT')
+  const [qty, setQty] = useState('')
+  const [lmtPrice, setLmtPrice] = useState('')
+
+  const submit = () => {
+    if (!key || !qty) return
+    if (orderType === 'LMT' && !lmtPrice) return
+    const aliceId = `${utaId}|${key}`
+    const labelBits = [side, orderType, qty, key]
+    if (orderType === 'LMT') labelBits.push(`@${lmtPrice}`)
+    run(
+      labelBits.join(' '),
+      async () => {
+        await api.trading.placeOrder(utaId, {
+          aliceId,
+          symbol: key,
+          action: side,
+          orderType,
+          totalQuantity: qty,
+          ...(orderType === 'LMT' && { lmtPrice }),
+          message: `Simulator: ${labelBits.join(' ')}`,
+        })
+        setQty('')
+        if (orderType === 'LMT') setLmtPrice('')
+      },
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <div className="flex rounded overflow-hidden border border-border">
+        <button onClick={() => setSide('BUY')} className={`px-2 py-1 text-xs ${side === 'BUY' ? 'bg-green/20 text-green' : 'text-text-muted hover:text-text'}`}>BUY</button>
+        <button onClick={() => setSide('SELL')} className={`px-2 py-1 text-xs ${side === 'SELL' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}>SELL</button>
+      </div>
+      <select value={orderType} onChange={(e) => setOrderType(e.target.value as 'MKT' | 'LMT')} className={`${inputClass} w-20`}>
+        <option value="MKT">MKT</option>
+        <option value="LMT">LMT</option>
+      </select>
+      <KeySelect value={key} onChange={setKey} options={knownKeys} placeholder="symbol" />
+      <input className={`${inputClassMono} w-28`} placeholder="qty" value={qty} onChange={(e) => setQty(e.target.value)} />
+      {orderType === 'LMT' && (
+        <input className={`${inputClassMono} w-28`} placeholder="limit price" value={lmtPrice} onChange={(e) => setLmtPrice(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') submit() }} />
+      )}
+      <button disabled={loading || !key || !qty || (orderType === 'LMT' && !lmtPrice)} onClick={submit} className="btn-primary-sm">Place</button>
+      <span className="text-[11px] text-text-muted">Stage → commit → push via Alice's trading pipeline.</span>
+    </div>
+  )
+}
+
+// ==================== Shared helper ====================
+
+function KeySelect({ value, onChange, options, placeholder }: {
+  value: string
+  onChange: (v: string) => void
+  options: string[]
+  placeholder: string
+}) {
+  return (
+    <>
+      <input
+        className={`${inputClassMono} w-36`}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value.trim())}
+        list="sim-action-known-keys"
+      />
+      <datalist id="sim-action-known-keys">
+        {options.map(k => <option key={k} value={k} />)}
+      </datalist>
+    </>
+  )
+}

--- a/ui/src/pages/simulator/CreateSimulatorSection.tsx
+++ b/ui/src/pages/simulator/CreateSimulatorSection.tsx
@@ -1,0 +1,92 @@
+/**
+ * CreateSimulatorSection — collapsible button → inline form for creating
+ * a new Mock UTA. Server derives the id from the minted `_instanceId`,
+ * so each create lands on a distinct id without the user picking one.
+ */
+
+import { useState } from 'react'
+import { Section } from '../../components/form'
+import { useToast } from '../../components/Toast'
+import { api } from '../../api'
+
+export function CreateSimulatorSection({ onCreated }: {
+  onCreated: (id: string) => Promise<void>
+}) {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [cash, setCash] = useState('100000')
+  const [busy, setBusy] = useState(false)
+  const toast = useToast()
+
+  const submit = async () => {
+    const cashNum = Number(cash)
+    if (!Number.isFinite(cashNum) || cashNum < 0) {
+      toast.error('Cash must be a non-negative number')
+      return
+    }
+    setBusy(true)
+    try {
+      const finalLabel = name.trim() || 'simulator'
+      const created = await api.trading.createUTA({
+        label: finalLabel,
+        presetId: 'mock-simulator',
+        enabled: true,
+        guards: [],
+        presetConfig: { cash: cashNum },
+      })
+      await api.trading.reconnectUTA(created.id).catch(() => {})
+      toast.success(`Created ${created.label} (${created.id})`)
+      setOpen(false)
+      setName('')
+      setCash('100000')
+      await onCreated(created.id)
+    } catch (err) {
+      toast.error(`Create failed: ${err instanceof Error ? err.message : err}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="btn-secondary-sm"
+      >
+        + New simulator account
+      </button>
+    )
+  }
+
+  return (
+    <Section
+      title="Create simulator account"
+      description="In-memory only — wiped on dev server restart. For repro & regression testing."
+    >
+      <div className="flex items-center gap-2 flex-wrap">
+        <input
+          className="px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent w-48"
+          placeholder="name (e.g. simulator)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent w-32"
+          placeholder="cash (USD)"
+          value={cash}
+          onChange={(e) => setCash(e.target.value)}
+        />
+        <button disabled={busy} onClick={submit} className="btn-primary-sm">
+          {busy ? 'Creating…' : 'Create'}
+        </button>
+        <button
+          disabled={busy}
+          onClick={() => { setOpen(false); setName(''); setCash('100000') }}
+          className="btn-secondary-sm"
+        >
+          Cancel
+        </button>
+      </div>
+    </Section>
+  )
+}

--- a/ui/src/pages/simulator/EventLog.tsx
+++ b/ui/src/pages/simulator/EventLog.tsx
@@ -1,0 +1,72 @@
+/**
+ * EventLog — chronological list of every action driven through `run()`.
+ *
+ * Client-side ring buffer (capped in the hook). Newest first. Default
+ * collapsed-to-5; toggle to expand. ok/err coloring; error detail
+ * expands inline on hover so the row stays terse.
+ */
+
+import { useState } from 'react'
+import { Section } from '../../components/form'
+import type { SimulatorEvent } from './useSimulatorState'
+
+const COLLAPSED_COUNT = 5
+
+function formatTime(ts: number): string {
+  const d = new Date(ts)
+  return d.toTimeString().slice(0, 8)
+}
+
+function relativeTime(ts: number, now: number): string {
+  const sec = Math.max(0, Math.round((now - ts) / 1000))
+  if (sec < 60) return `${sec}s ago`
+  if (sec < 3600) return `${Math.round(sec / 60)}m ago`
+  return `${Math.round(sec / 3600)}h ago`
+}
+
+export function EventLog({ events }: { events: SimulatorEvent[] }) {
+  const [expanded, setExpanded] = useState(false)
+  const visible = expanded ? events : events.slice(0, COLLAPSED_COUNT)
+  const now = Date.now()
+
+  return (
+    <Section
+      title="Event Log"
+      description="Every simulator action issued through this panel, newest first. Useful for retracing steps after a surprising state change."
+    >
+      {events.length === 0 ? (
+        <p className="text-xs text-text-muted">No actions yet.</p>
+      ) : (
+        <>
+          <table className="w-full text-sm">
+            <tbody>
+              {visible.map((ev) => (
+                <tr key={ev.id} className="text-text">
+                  <td className="py-0.5 pr-3 font-mono text-[11px] text-text-muted/80 w-20">{formatTime(ev.ts)}</td>
+                  <td className="py-0.5 pr-3 text-text-muted/60 text-[11px] w-20">{relativeTime(ev.ts, now)}</td>
+                  <td className="py-0.5 pr-3">
+                    <span className={ev.status === 'err' ? 'text-red' : 'text-text'}>{ev.label}</span>
+                    {ev.detail && (
+                      <span className="ml-2 text-[11px] text-red/80" title={ev.detail}>
+                        {ev.detail.slice(0, 60)}{ev.detail.length > 60 ? '…' : ''}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {events.length > COLLAPSED_COUNT && (
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="mt-2 text-[11px] text-text-muted hover:text-text transition-colors"
+            >
+              {expanded ? `Collapse (${COLLAPSED_COUNT})` : `Show all (${events.length})`}
+            </button>
+          )}
+        </>
+      )}
+    </Section>
+  )
+}

--- a/ui/src/pages/simulator/InstrumentInput.tsx
+++ b/ui/src/pages/simulator/InstrumentInput.tsx
@@ -1,0 +1,93 @@
+/**
+ * InstrumentInput — secType picker + conditional fields (expiry / strike /
+ * right / multiplier) for OPT/FOP/FUT. Plain symbol-only flow for the
+ * other secTypes. Shared between External Deposit and External Trade tabs.
+ *
+ * Emits `InstrumentDraft` upward; the parent calls `buildInstrument()`
+ * at submit time to derive nativeKey + contract.
+ */
+
+import type { InstrumentDraft, SecType } from './instruments'
+import { SEC_TYPES } from './instruments'
+
+const inputClass =
+  'px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent'
+const inputClassMono =
+  'px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+
+export function InstrumentInput({ draft, onChange, knownSymbols }: {
+  draft: InstrumentDraft
+  onChange: (next: InstrumentDraft) => void
+  knownSymbols?: string[]
+}) {
+  const set = <K extends keyof InstrumentDraft>(field: K, value: InstrumentDraft[K]) =>
+    onChange({ ...draft, [field]: value })
+
+  const isOption = draft.secType === 'OPT' || draft.secType === 'FOP'
+  const isFuture = draft.secType === 'FUT'
+
+  return (
+    <>
+      <select
+        value={draft.secType}
+        onChange={(e) => set('secType', e.target.value as SecType)}
+        className={`${inputClass} w-32`}
+        title="Security type"
+      >
+        {SEC_TYPES.map((s) => <option key={s} value={s}>{s}</option>)}
+      </select>
+
+      <input
+        className={`${inputClassMono} w-28`}
+        placeholder="symbol"
+        value={draft.symbol}
+        onChange={(e) => set('symbol', e.target.value.trim())}
+        list={knownSymbols ? 'sim-instrument-known' : undefined}
+      />
+      {knownSymbols && (
+        <datalist id="sim-instrument-known">
+          {knownSymbols.map((k) => <option key={k} value={k} />)}
+        </datalist>
+      )}
+
+      {(isOption || isFuture) && (
+        <input
+          className={`${inputClassMono} w-28`}
+          placeholder={isOption ? 'expiry YYYYMMDD' : 'expiry YYYYMM'}
+          value={draft.expiry ?? ''}
+          onChange={(e) => set('expiry', e.target.value.trim())}
+        />
+      )}
+
+      {isOption && (
+        <>
+          <input
+            className={`${inputClassMono} w-20`}
+            placeholder="strike"
+            value={draft.strike ?? ''}
+            onChange={(e) => set('strike', e.target.value)}
+          />
+          <select
+            value={draft.right ?? ''}
+            onChange={(e) => set('right', (e.target.value || undefined) as 'C' | 'P' | undefined)}
+            className={`${inputClass} w-16`}
+            title="Right"
+          >
+            <option value="">right</option>
+            <option value="C">Call</option>
+            <option value="P">Put</option>
+          </select>
+        </>
+      )}
+
+      {(isOption || isFuture) && (
+        <input
+          className={`${inputClassMono} w-20`}
+          placeholder={isOption ? 'mult (100)' : 'mult (1)'}
+          value={draft.multiplier ?? ''}
+          onChange={(e) => set('multiplier', e.target.value)}
+        />
+      )}
+    </>
+  )
+}

--- a/ui/src/pages/simulator/MarkPrices.tsx
+++ b/ui/src/pages/simulator/MarkPrices.tsx
@@ -1,0 +1,182 @@
+/**
+ * MarkPrices panel — observation + inline action surface for per-symbol
+ * mark prices. Per-row keyboard shortcuts (↑/↓ for ±1%, Shift+↑/↓ for ±5%)
+ * make rapid PnL-walking ergonomic without leaving the keyboard.
+ *
+ * Visual feedback: when a price changes (whether via local action or via
+ * a polled state update), the row briefly tints to give "yes, the value
+ * moved" affirmation.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { Section } from '../../components/form'
+import { simulatorApi, type SimulatorState } from '../../api/simulator'
+
+const inputClass =
+  'w-full px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+
+const FLASH_MS = 500
+
+export function MarkPrices({ utaId, state, run, loading }: {
+  utaId: string
+  state: SimulatorState
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  const [newKey, setNewKey] = useState('')
+  const [newPrice, setNewPrice] = useState('')
+
+  // Track per-key "last seen price" so we can detect changes between renders
+  // and flash the row when it moves.
+  const lastSeenRef = useRef<Map<string, string>>(new Map())
+  const [flashes, setFlashes] = useState<Record<string, 'up' | 'down'>>({})
+
+  useEffect(() => {
+    const next: Record<string, 'up' | 'down'> = {}
+    let dirty = false
+    for (const m of state.markPrices) {
+      const prev = lastSeenRef.current.get(m.nativeKey)
+      if (prev !== undefined && prev !== m.price) {
+        next[m.nativeKey] = Number(m.price) >= Number(prev) ? 'up' : 'down'
+        dirty = true
+      }
+      lastSeenRef.current.set(m.nativeKey, m.price)
+    }
+    if (!dirty) return
+    setFlashes((cur) => ({ ...cur, ...next }))
+    const timer = setTimeout(() => {
+      setFlashes((cur) => {
+        const after = { ...cur }
+        for (const k of Object.keys(next)) delete after[k]
+        return after
+      })
+    }, FLASH_MS)
+    return () => clearTimeout(timer)
+  }, [state.markPrices])
+
+  // Sync drafts: only retain in-flight user edits.
+  useEffect(() => {
+    setDrafts((prev) => {
+      const next: Record<string, string> = {}
+      for (const m of state.markPrices) {
+        if (prev[m.nativeKey] !== undefined) next[m.nativeKey] = prev[m.nativeKey]
+      }
+      return next
+    })
+  }, [state.markPrices])
+
+  const dropDraft = (key: string) => setDrafts((d) => {
+    const next = { ...d }
+    delete next[key]
+    return next
+  })
+
+  const tick = (key: string, deltaPercent: number) => run(
+    `${key} ${deltaPercent > 0 ? '+' : ''}${deltaPercent}%`,
+    async () => {
+      await simulatorApi.tickPrice(utaId, key, deltaPercent)
+      dropDraft(key)
+    },
+  )
+
+  const setPrice = (key: string, value: string) => run(
+    `Set ${key} = ${value}`,
+    async () => {
+      await simulatorApi.setMarkPrice(utaId, key, value)
+      dropDraft(key)
+    },
+  )
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, key: string) => {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      e.preventDefault()
+      const sign = e.key === 'ArrowUp' ? 1 : -1
+      const magnitude = e.shiftKey ? 5 : 1
+      tick(key, sign * magnitude)
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      setPrice(key, drafts[key] ?? state.markPrices.find(m => m.nativeKey === key)?.price ?? '')
+    }
+  }
+
+  const flashClass = (key: string): string => {
+    const f = flashes[key]
+    if (!f) return ''
+    return f === 'up' ? 'bg-green/10' : 'bg-red/10'
+  }
+
+  return (
+    <Section
+      title="Mark Prices"
+      description="Per-symbol mark price. Editing or ticking auto-matches any pending limit/stop order whose trigger the new price crosses. Focus a price input and press ↑/↓ for ±1%, Shift+↑/↓ for ±5%."
+    >
+      <div className="space-y-1">
+        {state.markPrices.length === 0 ? (
+          <p className="text-xs text-text-muted">No prices set yet — add one below.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-text-muted text-xs">
+                <th className="pb-1 pr-3">Symbol</th>
+                <th className="pb-1 pr-3 w-40">Price</th>
+                <th className="pb-1 text-right">Quick</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.markPrices.map((m) => (
+                <tr
+                  key={m.nativeKey}
+                  className={`text-text transition-colors duration-500 ${flashClass(m.nativeKey)}`}
+                >
+                  <td className="py-1 pr-3 font-mono text-xs">{m.nativeKey}</td>
+                  <td className="py-1 pr-3">
+                    <input
+                      className={inputClass}
+                      value={drafts[m.nativeKey] ?? m.price}
+                      onChange={(e) => setDrafts({ ...drafts, [m.nativeKey]: e.target.value })}
+                      onKeyDown={(e) => handleKeyDown(e, m.nativeKey)}
+                    />
+                  </td>
+                  <td className="py-1 text-right space-x-1">
+                    <button disabled={loading} onClick={() => tick(m.nativeKey, -5)} className="btn-secondary-xs">−5%</button>
+                    <button disabled={loading} onClick={() => tick(m.nativeKey, -1)} className="btn-secondary-xs">−1%</button>
+                    <button disabled={loading} onClick={() => tick(m.nativeKey, 1)} className="btn-secondary-xs">+1%</button>
+                    <button disabled={loading} onClick={() => tick(m.nativeKey, 5)} className="btn-secondary-xs">+5%</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        <div className="flex items-center gap-2 pt-3 border-t border-border">
+          <input
+            className={`${inputClass} w-44`}
+            placeholder="symbol (e.g. BTC)"
+            value={newKey}
+            onChange={(e) => setNewKey(e.target.value.trim())}
+          />
+          <input
+            className={`${inputClass} w-32`}
+            placeholder="price"
+            value={newPrice}
+            onChange={(e) => setNewPrice(e.target.value)}
+          />
+          <button
+            disabled={loading || !newKey || !newPrice}
+            onClick={() => run(
+              `Add ${newKey} = ${newPrice}`,
+              async () => {
+                await simulatorApi.setMarkPrice(utaId, newKey, newPrice)
+                setNewKey('')
+                setNewPrice('')
+              },
+            )}
+            className="btn-primary-sm"
+          >Add</button>
+        </div>
+      </div>
+    </Section>
+  )
+}

--- a/ui/src/pages/simulator/PendingOrders.tsx
+++ b/ui/src/pages/simulator/PendingOrders.tsx
@@ -1,0 +1,116 @@
+/**
+ * PendingOrders panel — limit/stop orders waiting on a price trigger or
+ * manual fill. Adds a "distance" column = `current mark − trigger price`,
+ * giving a one-glance read on how close each order is to firing.
+ */
+
+import { useMemo, useState } from 'react'
+import { Section } from '../../components/form'
+import { simulatorApi, type SimulatorState } from '../../api/simulator'
+
+const inputClass =
+  'w-full px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+
+export function PendingOrders({ utaId, state, run, loading }: {
+  utaId: string
+  state: SimulatorState
+  run: (label: string, fn: () => Promise<unknown>) => Promise<void>
+  loading: boolean
+}) {
+  const [fillForms, setFillForms] = useState<Record<string, { price: string; qty: string }>>({})
+  const updateForm = (id: string, field: 'price' | 'qty', value: string) => {
+    setFillForms({ ...fillForms, [id]: { ...(fillForms[id] ?? { price: '', qty: '' }), [field]: value } })
+  }
+
+  const markByKey = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const mp of state.markPrices) m.set(mp.nativeKey, mp.price)
+    return m
+  }, [state.markPrices])
+
+  return (
+    <Section
+      title="Pending Orders"
+      description="Submitted limit/stop orders waiting on a price trigger or manual fill."
+    >
+      {state.pendingOrders.length === 0 ? (
+        <p className="text-xs text-text-muted">No pending orders.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-text-muted text-xs">
+              <th className="pb-1 pr-3">Order</th>
+              <th className="pb-1 pr-3">Symbol</th>
+              <th className="pb-1 pr-3">Side</th>
+              <th className="pb-1 pr-3">Type</th>
+              <th className="pb-1 pr-3 text-right">Qty</th>
+              <th className="pb-1 pr-3 text-right">Trigger</th>
+              <th className="pb-1 pr-3 text-right">Distance</th>
+              <th className="pb-1 pr-3 w-32">Fill price (opt)</th>
+              <th className="pb-1 pr-3 w-24">Fill qty (opt)</th>
+              <th className="pb-1 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state.pendingOrders.map((o) => {
+              const form = fillForms[o.orderId] ?? { price: '', qty: '' }
+              const trigger = o.lmtPrice ?? o.auxPrice
+              const mark = markByKey.get(o.nativeKey)
+              const distance = trigger && mark ? Number(mark) - Number(trigger) : null
+              // Pct vs trigger — < 1% lights yellow as "about to fire".
+              const distancePct = distance != null && trigger ? Math.abs(distance) / Number(trigger) : null
+              const closeToFire = distancePct != null && distancePct < 0.01
+              return (
+                <tr key={o.orderId} className="text-text">
+                  <td className="py-1 pr-3 font-mono text-[11px]">{o.orderId}</td>
+                  <td className="py-1 pr-3">{o.symbol}</td>
+                  <td className="py-1 pr-3">{o.action}</td>
+                  <td className="py-1 pr-3">{o.orderType}</td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right">{o.totalQuantity}</td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right">{trigger ?? '—'}</td>
+                  <td className={`py-1 pr-3 font-mono text-xs text-right ${closeToFire ? 'text-yellow-400' : 'text-text-muted'}`}>
+                    {distance == null ? '—' : `${distance >= 0 ? '+' : ''}${distance.toFixed(2)}`}
+                  </td>
+                  <td className="py-1 pr-3">
+                    <input
+                      className={inputClass}
+                      placeholder="markPrice"
+                      value={form.price}
+                      onChange={(e) => updateForm(o.orderId, 'price', e.target.value)}
+                    />
+                  </td>
+                  <td className="py-1 pr-3">
+                    <input
+                      className={inputClass}
+                      placeholder="full"
+                      value={form.qty}
+                      onChange={(e) => updateForm(o.orderId, 'qty', e.target.value)}
+                    />
+                  </td>
+                  <td className="py-1 text-right space-x-1">
+                    <button
+                      disabled={loading}
+                      onClick={() => run(
+                        `Fill ${o.orderId}`,
+                        () => simulatorApi.fillOrder(utaId, o.orderId, {
+                          ...(form.price && { price: form.price }),
+                          ...(form.qty && { qty: form.qty }),
+                        }),
+                      )}
+                      className="btn-secondary-xs"
+                    >Fill</button>
+                    <button
+                      disabled={loading}
+                      onClick={() => run(`Cancel ${o.orderId}`, () => simulatorApi.cancelOrder(utaId, o.orderId))}
+                      className="btn-secondary-xs"
+                    >×</button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </Section>
+  )
+}

--- a/ui/src/pages/simulator/Positions.tsx
+++ b/ui/src/pages/simulator/Positions.tsx
@@ -6,7 +6,20 @@
 
 import { useMemo } from 'react'
 import { Section } from '../../components/form'
-import type { SimulatorState } from '../../api/simulator'
+import type { SimulatorState, SimulatorPosition } from '../../api/simulator'
+import { describeInstrument } from './instruments'
+
+/** Compose the display name from contract metadata; falls back to nativeKey. */
+function describePosition(p: SimulatorPosition): string {
+  return describeInstrument({
+    symbol: p.symbol,
+    secType: p.secType,
+    lastTradeDateOrContractMonth: p.expiry,
+    strike: p.strike,
+    right: p.right as 'C' | 'P' | 'CALL' | 'PUT' | undefined,
+    multiplier: p.multiplier,
+  })
+}
 
 export function Positions({ state }: { state: SimulatorState }) {
   const markByKey = useMemo(() => {
@@ -38,21 +51,27 @@ export function Positions({ state }: { state: SimulatorState }) {
               const mark = markByKey.get(p.nativeKey)
               const qty = Number(p.quantity)
               const avg = Number(p.avgCost)
+              // Match IBroker.Position contract: PnL is multiplier-applied.
+              // Defaults to 1 for stocks / crypto; OPT typically ×100; futures vary.
+              const mult = p.multiplier ? Number(p.multiplier) || 1 : 1
               const pnl = mark && Number.isFinite(qty) && Number.isFinite(avg)
-                ? (Number(mark) - avg) * qty * (p.side === 'long' ? 1 : -1)
+                ? (Number(mark) - avg) * qty * mult * (p.side === 'long' ? 1 : -1)
                 : null
               const pnlClass = pnl == null ? 'text-text-muted' : pnl > 0 ? 'text-green' : pnl < 0 ? 'text-red' : 'text-text'
               return (
                 <tr key={p.nativeKey} className="text-text">
                   <td className="py-1 pr-3">
                     <div className="flex items-center gap-1.5 flex-wrap">
-                      <span className="font-mono text-xs">{p.nativeKey}</span>
+                      <span className="font-medium text-text">{describePosition(p)}</span>
                       {p.secType && (
                         <span className="text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-bg-tertiary text-text-muted/80">{p.secType}</span>
                       )}
                       <span className={`text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
                         {p.side}
                       </span>
+                      {p.multiplier && p.multiplier !== '1' && (
+                        <span className="text-[9px] text-text-muted/60" title={`Each contract = ${p.multiplier} units`}>×{p.multiplier}</span>
+                      )}
                       {p.avgCostSource === 'wallet' && (
                         <span className="text-[9px] text-text-muted/60" title="Cost basis derived from UTA reconcile pipeline (wallet-source position)">wallet</span>
                       )}

--- a/ui/src/pages/simulator/Positions.tsx
+++ b/ui/src/pages/simulator/Positions.tsx
@@ -1,0 +1,75 @@
+/**
+ * Positions panel — read-only view of current holdings, joined with
+ * mark prices to render live PnL. Mutates only via mark price moves,
+ * order fills, or external events from the action panel.
+ */
+
+import { useMemo } from 'react'
+import { Section } from '../../components/form'
+import type { SimulatorState } from '../../api/simulator'
+
+export function Positions({ state }: { state: SimulatorState }) {
+  const markByKey = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const mp of state.markPrices) m.set(mp.nativeKey, mp.price)
+    return m
+  }, [state.markPrices])
+
+  return (
+    <Section
+      title="Positions"
+      description="Read-only — mutate via mark price moves, order fills, or external events."
+    >
+      {state.positions.length === 0 ? (
+        <p className="text-xs text-text-muted">No positions.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-text-muted text-xs">
+              <th className="pb-1 pr-3">Position</th>
+              <th className="pb-1 pr-3 text-right">Qty</th>
+              <th className="pb-1 pr-3 text-right">Avg Cost</th>
+              <th className="pb-1 pr-3 text-right">Mark</th>
+              <th className="pb-1 text-right">PnL</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state.positions.map((p) => {
+              const mark = markByKey.get(p.nativeKey)
+              const qty = Number(p.quantity)
+              const avg = Number(p.avgCost)
+              const pnl = mark && Number.isFinite(qty) && Number.isFinite(avg)
+                ? (Number(mark) - avg) * qty * (p.side === 'long' ? 1 : -1)
+                : null
+              const pnlClass = pnl == null ? 'text-text-muted' : pnl > 0 ? 'text-green' : pnl < 0 ? 'text-red' : 'text-text'
+              return (
+                <tr key={p.nativeKey} className="text-text">
+                  <td className="py-1 pr-3">
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      <span className="font-mono text-xs">{p.nativeKey}</span>
+                      {p.secType && (
+                        <span className="text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-bg-tertiary text-text-muted/80">{p.secType}</span>
+                      )}
+                      <span className={`text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
+                        {p.side}
+                      </span>
+                      {p.avgCostSource === 'wallet' && (
+                        <span className="text-[9px] text-text-muted/60" title="Cost basis derived from UTA reconcile pipeline (wallet-source position)">wallet</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right">{p.quantity}</td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right">{p.avgCost}</td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right text-text-muted">{mark ?? '—'}</td>
+                  <td className={`py-1 font-mono text-xs text-right transition-colors duration-300 ${pnlClass}`}>
+                    {pnl == null ? '—' : `${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}`}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </Section>
+  )
+}

--- a/ui/src/pages/simulator/instruments.ts
+++ b/ui/src/pages/simulator/instruments.ts
@@ -1,0 +1,113 @@
+/**
+ * Instrument helpers — shared between Deposit / Trade tabs.
+ *
+ * The simulator's nativeKey is whatever `MockBroker.getNativeKey` returns
+ * for a contract: `localSymbol || symbol`. To make multi-family scenarios
+ * coexist (BTC spot vs BTC perp; AAPL stock vs AAPL Jul20 150C), we
+ * derive a unique `localSymbol` per instrument shape and use it as the
+ * nativeKey too — so positions land in distinct map slots and the user
+ * gets a readable identifier without manually composing IBKR-format
+ * localSymbols (e.g. `AAPL  240720C00150000`).
+ */
+
+import type { SimulatorContractInput } from '../../api/simulator'
+
+export type SecType = 'CRYPTO' | 'CRYPTO_PERP' | 'STK' | 'FUT' | 'OPT' | 'FOP' | 'CASH' | 'BOND'
+
+export const SEC_TYPES: SecType[] = ['CRYPTO', 'CRYPTO_PERP', 'STK', 'FUT', 'OPT', 'FOP', 'CASH', 'BOND']
+
+export interface InstrumentDraft {
+  symbol: string
+  secType: SecType
+  /** YYYYMMDD for OPT/FOP; YYYYMM for FUT. */
+  expiry?: string
+  strike?: string
+  right?: 'C' | 'P'
+  multiplier?: string
+}
+
+export interface BuiltInstrument {
+  nativeKey: string
+  contract: SimulatorContractInput
+}
+
+/** Default multiplier per secType when user hasn't set one. */
+function defaultMultiplier(secType: SecType): string | undefined {
+  if (secType === 'OPT' || secType === 'FOP') return '100'
+  if (secType === 'FUT') return '1'
+  return undefined
+}
+
+/**
+ * Translate user form state into nativeKey + contract payload. Returns
+ * null + a reason string when the draft isn't complete enough yet (e.g.
+ * OPT without expiry); the UI shows the reason inline.
+ */
+export function buildInstrument(input: InstrumentDraft): BuiltInstrument | { error: string } {
+  const symbol = input.symbol.trim().toUpperCase()
+  if (!symbol) return { error: 'symbol required' }
+  const sec = input.secType
+
+  const contract: SimulatorContractInput = { symbol, secType: sec }
+
+  if (sec === 'OPT' || sec === 'FOP') {
+    if (!input.expiry) return { error: `${sec} needs expiry (YYYYMMDD)` }
+    if (!input.strike) return { error: `${sec} needs strike` }
+    if (!input.right) return { error: `${sec} needs right (C/P)` }
+    const strikeNum = Number(input.strike)
+    if (!Number.isFinite(strikeNum)) return { error: 'strike must be a number' }
+    const nativeKey = `${symbol}-${input.expiry}-${input.right}${input.strike}`
+    contract.lastTradeDateOrContractMonth = input.expiry
+    contract.strike = strikeNum
+    contract.right = input.right
+    contract.multiplier = input.multiplier?.trim() || defaultMultiplier(sec)
+    contract.localSymbol = nativeKey
+    return { nativeKey, contract }
+  }
+
+  if (sec === 'FUT') {
+    if (!input.expiry) return { error: 'FUT needs expiry (YYYYMM)' }
+    const nativeKey = `${symbol}-${input.expiry}`
+    contract.lastTradeDateOrContractMonth = input.expiry
+    contract.multiplier = input.multiplier?.trim() || defaultMultiplier(sec)
+    contract.localSymbol = nativeKey
+    return { nativeKey, contract }
+  }
+
+  // Plain symbol-only types: STK, CRYPTO, CRYPTO_PERP, CASH, BOND
+  contract.localSymbol = symbol
+  return { nativeKey: symbol, contract }
+}
+
+/** Format a built instrument for display, e.g. "AAPL Jul20 150C" or "ES Mar26". */
+export function describeInstrument(contract: SimulatorContractInput): string {
+  const sym = contract.symbol ?? '?'
+  const sec = contract.secType
+  if ((sec === 'OPT' || sec === 'FOP') && contract.lastTradeDateOrContractMonth && contract.strike != null && contract.right) {
+    const expiry = formatExpiry(contract.lastTradeDateOrContractMonth)
+    const right = contract.right === 'C' || contract.right === 'CALL' ? 'C' : 'P'
+    return `${sym} ${expiry} ${contract.strike}${right}`
+  }
+  if (sec === 'FUT' && contract.lastTradeDateOrContractMonth) {
+    return `${sym} ${formatExpiry(contract.lastTradeDateOrContractMonth)}`
+  }
+  return sym
+}
+
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+
+function formatExpiry(raw: string): string {
+  // YYYYMMDD → "Jul20" (month + day-of-month)
+  // YYYYMM   → "Mar26" (month + year-yy)
+  if (/^\d{8}$/.test(raw)) {
+    const month = Number(raw.slice(4, 6))
+    const day = raw.slice(6, 8)
+    return MONTHS[month - 1] ? `${MONTHS[month - 1]}${day}` : raw
+  }
+  if (/^\d{6}$/.test(raw)) {
+    const month = Number(raw.slice(4, 6))
+    const yy = raw.slice(2, 4)
+    return MONTHS[month - 1] ? `${MONTHS[month - 1]}${yy}` : raw
+  }
+  return raw
+}

--- a/ui/src/pages/simulator/useSimulatorState.ts
+++ b/ui/src/pages/simulator/useSimulatorState.ts
@@ -1,0 +1,135 @@
+/**
+ * useSimulatorState — owns the polled simulator state + event log + the
+ * `run(label, fn)` wrapper that every action button funnels through.
+ *
+ * Centralizing here keeps the page-level component declarative (just
+ * layout + composition) and means every action automatically lands in
+ * the event log and the state refresh path. Adding a new control surface
+ * (Place Order, Set Stop Loss, …) only needs to call `run`; logging and
+ * refresh are free.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useToast } from '../../components/Toast'
+import {
+  simulatorApi,
+  type SimulatorState,
+  type SimulatorUTAEntry,
+} from '../../api/simulator'
+
+const POLL_INTERVAL_MS = 3000
+const MAX_EVENTS = 50
+
+export interface SimulatorEvent {
+  id: number
+  ts: number
+  label: string
+  status: 'ok' | 'err'
+  detail?: string
+}
+
+export interface UseSimulatorStateResult {
+  utas: SimulatorUTAEntry[]
+  selectedId: string
+  setSelectedId: (id: string) => void
+  state: SimulatorState | null
+  loading: boolean
+  events: SimulatorEvent[]
+
+  /** Reload UTA list. Returns the new list. */
+  refreshUtaList: () => Promise<SimulatorUTAEntry[]>
+  /** Force-refresh selected UTA's state. */
+  refresh: () => Promise<void>
+  /**
+   * Run an action with toast + log + state refresh. Use as the single
+   * entry point for every mutating UI button so auditability is uniform.
+   */
+  run: (label: string, fn: () => Promise<unknown>, opts?: { skipRefresh?: boolean }) => Promise<void>
+}
+
+export function useSimulatorState(): UseSimulatorStateResult {
+  const [utas, setUtas] = useState<SimulatorUTAEntry[]>([])
+  const [selectedId, setSelectedId] = useState<string>('')
+  const [state, setState] = useState<SimulatorState | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [events, setEvents] = useState<SimulatorEvent[]>([])
+  const toast = useToast()
+  const eventCounter = useRef(0)
+
+  const appendEvent = useCallback((ev: Omit<SimulatorEvent, 'id'>) => {
+    setEvents((prev) => {
+      const id = ++eventCounter.current
+      const next = [{ ...ev, id }, ...prev]
+      return next.length > MAX_EVENTS ? next.slice(0, MAX_EVENTS) : next
+    })
+  }, [])
+
+  const refreshUtaList = useCallback(async () => {
+    try {
+      const r = await simulatorApi.listUtas()
+      setUtas(r.utas)
+      setSelectedId((cur) => {
+        if (cur && r.utas.some((u) => u.id === cur)) return cur
+        return r.utas[0]?.id ?? ''
+      })
+      return r.utas
+    } catch (err) {
+      toast.error(`Failed to list simulators: ${err instanceof Error ? err.message : err}`)
+      return []
+    }
+  }, [toast])
+
+  const refresh = useCallback(async () => {
+    if (!selectedId) {
+      setState(null)
+      return
+    }
+    try {
+      const s = await simulatorApi.state(selectedId)
+      setState(s)
+    } catch (err) {
+      toast.error(`State fetch failed: ${err instanceof Error ? err.message : err}`)
+      setState(null)
+    }
+  }, [selectedId, toast])
+
+  // Bootstrap UTA list once.
+  useEffect(() => {
+    refreshUtaList()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Refresh on selection change + poll.
+  useEffect(() => {
+    refresh()
+    const t = setInterval(refresh, POLL_INTERVAL_MS)
+    return () => clearInterval(t)
+  }, [refresh])
+
+  const run = useCallback(async (
+    label: string,
+    fn: () => Promise<unknown>,
+    opts: { skipRefresh?: boolean } = {},
+  ) => {
+    if (!selectedId) return
+    setLoading(true)
+    try {
+      await fn()
+      appendEvent({ ts: Date.now(), label, status: 'ok' })
+      toast.success(label)
+      if (!opts.skipRefresh) await refresh()
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      appendEvent({ ts: Date.now(), label, status: 'err', detail })
+      toast.error(`${label} failed: ${detail}`)
+    } finally {
+      setLoading(false)
+    }
+  }, [selectedId, appendEvent, refresh, toast])
+
+  return {
+    utas, selectedId, setSelectedId,
+    state, loading, events,
+    refreshUtaList, refresh, run,
+  }
+}

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -124,7 +124,7 @@ function AdoptUtaDetail() {
 
 function AdoptDev() {
   const { tab } = useParams<{ tab: string }>()
-  const valid: ReadonlyArray<string> = ['connectors', 'tools', 'sessions', 'snapshots', 'logs']
+  const valid: ReadonlyArray<string> = ['connectors', 'tools', 'sessions', 'snapshots', 'logs', 'simulator']
   if (!tab || !valid.includes(tab)) return <Navigate to="/dev/connectors" replace />
   return (
     <AdoptStatic

--- a/ui/src/tabs/__tests__/store.spec.ts
+++ b/ui/src/tabs/__tests__/store.spec.ts
@@ -191,6 +191,61 @@ describe('closeMatching', () => {
   })
 })
 
+// ==================== bulk closers ====================
+
+describe('closeOthers / closeToRight / closeToLeft / closeAll', () => {
+  function setupFour() {
+    const s = useWorkspace.getState()
+    s.openOrFocus({ kind: 'chat', params: { channelId: 'default' } })  // [0]
+    s.openOrFocus({ kind: 'chat', params: { channelId: 'a' } })        // [1]
+    s.openOrFocus({ kind: 'chat', params: { channelId: 'b' } })        // [2]
+    s.openOrFocus({ kind: 'chat', params: { channelId: 'c' } })        // [3], focus
+    return getFocusedGroup(useWorkspace.getState())!.tabIds
+  }
+
+  it('closeOthers keeps only the named tab and focuses it', () => {
+    const ids = setupFour()
+    useWorkspace.getState().closeOthers(ids[1]) // keep 'a'
+    const group = getFocusedGroup(useWorkspace.getState())!
+    expect(group.tabIds).toEqual([ids[1]])
+    expect(group.activeTabId).toBe(ids[1])
+  })
+
+  it('closeToRight drops every tab to the right of the named one', () => {
+    const ids = setupFour()
+    useWorkspace.getState().closeToRight(ids[1]) // close c, b
+    const group = getFocusedGroup(useWorkspace.getState())!
+    expect(group.tabIds).toEqual([ids[0], ids[1]])
+    // c was focused → focus shifts; falls back to 'a' (the named tab) since
+    // it's the rightmost remaining after the slice closes.
+    expect(group.activeTabId).toBe(ids[1])
+  })
+
+  it('closeToLeft drops every tab to the left of the named one', () => {
+    const ids = setupFour()
+    useWorkspace.getState().closeToLeft(ids[2]) // close default, a
+    const group = getFocusedGroup(useWorkspace.getState())!
+    expect(group.tabIds).toEqual([ids[2], ids[3]])
+  })
+
+  it('closeAll empties the focused group entirely', () => {
+    setupFour()
+    useWorkspace.getState().closeAll()
+    const group = getFocusedGroup(useWorkspace.getState())!
+    expect(group.tabIds).toHaveLength(0)
+    expect(group.activeTabId).toBeNull()
+  })
+
+  it('closeOthers / closeToRight / closeToLeft are no-ops for unknown ids', () => {
+    setupFour()
+    const before = getFocusedGroup(useWorkspace.getState())!.tabIds
+    useWorkspace.getState().closeToRight('nonexistent')
+    useWorkspace.getState().closeToLeft('nonexistent')
+    const after = getFocusedGroup(useWorkspace.getState())!.tabIds
+    expect(after).toEqual(before)
+  })
+})
+
 // ==================== sidebar selection ====================
 
 describe('setSidebar / toggleSidebar', () => {

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -162,6 +162,7 @@ const devTabTitle: Record<Extract<ViewSpec, { kind: 'dev' }>['params']['tab'], s
   sessions: 'Sessions',
   snapshots: 'Snapshots',
   logs: 'Logs',
+  simulator: 'Simulator',
 }
 
 const devModule: ViewModule<'dev'> = {

--- a/ui/src/tabs/store.ts
+++ b/ui/src/tabs/store.ts
@@ -37,6 +37,11 @@ interface WorkspaceActions {
   closeTab: (id: string) => void
   focusTab: (id: string) => void
   closeMatching: (predicate: (spec: ViewSpec) => boolean) => void
+  /** Bulk closers used by the tab context menu. All operate on the focused group. */
+  closeOthers: (id: string) => void
+  closeToRight: (id: string) => void
+  closeToLeft: (id: string) => void
+  closeAll: () => void
   setSidebar: (section: ActivitySection | null) => void
   toggleSidebar: (section: ActivitySection) => void
 }
@@ -159,6 +164,43 @@ export const useWorkspace = create<WorkspaceStore>()(
         for (const id of toClose) {
           get().closeTab(id)
         }
+      },
+
+      // ============= Bulk closers (for the tab context menu) =============
+      // All four delegate to closeTab so the neighbour-focus / no-fallback
+      // semantics are consistent. Snapshot ids before iterating since
+      // closeTab mutates the underlying array.
+
+      closeOthers(id) {
+        const group = getFocusedGroup(get())
+        if (!group) return
+        const toClose = group.tabIds.filter((x) => x !== id)
+        for (const tid of toClose) get().closeTab(tid)
+      },
+
+      closeToRight(id) {
+        const group = getFocusedGroup(get())
+        if (!group) return
+        const idx = group.tabIds.indexOf(id)
+        if (idx < 0) return
+        const toClose = group.tabIds.slice(idx + 1)
+        for (const tid of toClose) get().closeTab(tid)
+      },
+
+      closeToLeft(id) {
+        const group = getFocusedGroup(get())
+        if (!group) return
+        const idx = group.tabIds.indexOf(id)
+        if (idx < 0) return
+        const toClose = group.tabIds.slice(0, idx)
+        for (const tid of toClose) get().closeTab(tid)
+      },
+
+      closeAll() {
+        const group = getFocusedGroup(get())
+        if (!group) return
+        const toClose = [...group.tabIds]
+        for (const tid of toClose) get().closeTab(tid)
       },
 
       setSidebar(section) {

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -23,7 +23,7 @@ export type ViewSpec =
   | { kind: 'market-detail';  params: { assetClass: 'equity' | 'crypto' | 'currency' | 'commodity'; symbol: string } }
   | { kind: 'settings';       params: { category: 'general' | 'ai-provider' | 'trading' | 'connectors' | 'market-data' | 'news-collector' } }
   | { kind: 'uta-detail';     params: { id: string } }
-  | { kind: 'dev';            params: { tab: 'connectors' | 'tools' | 'sessions' | 'snapshots' | 'logs' } }
+  | { kind: 'dev';            params: { tab: 'connectors' | 'tools' | 'sessions' | 'snapshots' | 'logs' | 'simulator' } }
   | { kind: 'notifications-inbox'; params: Record<string, never> }
 
 export type ViewKind = ViewSpec['kind']


### PR DESCRIPTION
## Summary

Three threads landed this session, all aimed at making UTA bugs faster
to reproduce and harder to ship.

- **Simulator console** at `/dev/simulator` — manual matching engine
  inside MockBroker plus a tabbed control panel (Quick Tick / External
  Deposit / External Trade / Place Order via Alice), tab-strip account
  switcher, sticky action dock, event log, keyboard shortcuts (↑/↓ for
  ±1%, Shift+↑/↓ for ±5%). UI verification (human eyeball) and API
  verification (curl/spec) hit the same observation surface.
- **Derived UTA id** — `${preset.id}-${8hex}` derived from a preset's
  `fingerprintFields` against `presetConfig`. Two creates with the same
  broker identity collide deterministically (409 → "open existing");
  Mock mints a random `_instanceId` so each sim is unique. Closes the
  silent-inheriting / silent-forking gap from user-typed ids.
- **Multi-asset MockBroker** — secType expanded to STK / OPT / FOP / FUT
  / CASH / BOND / CRYPTO / CRYPTO_PERP, with derivative metadata
  (expiry, strike, right, multiplier) carried end-to-end. The matching
  engine + cost-basis pipeline + Portfolio render now handle option /
  futures positions with multiplier-applied PnL.

## Per-session contributions

### 2026-05-07 — Simulator console + asset expansion + UTA id refactor

**Simulator MVP (commits ef4248c → 936566e → eef96ad → e58a31e → dd2fde0)**

- `MockBroker` gained a god-view control surface: setMarkPrice (auto-matches触达 limit/stop), tickPrice, fillOrder (full + partial), externalDeposit, externalWithdraw, externalTrade, getSimulatorState. Per-nativeKey markPrice map; pending order book; getNativeKey prefers `localSymbol` so multi-family coexists without collision
- `mock` engine in `BROKER_ENGINE_REGISTRY` + 'Simulator (testing only)' preset under new `'testing'` category. UI Trading wizard renders Recommended → Crypto → Testing
- `webui/routes/simulator.ts` — thin HTTP adapters; narrow via `uta.broker instanceof MockBroker`. 10 specs covering happy + 4xx paths
- `/dev/simulator` tab — markPrice editor with ±1/±5% tick buttons, pending-order Fill / Cancel, read-only positions, external-event submitter. Tab-strip account picker (replaces dropdown), sticky bottom action panel with 4 tabs, client-side event log capped at 50, mark-price flash + PnL transition on state change
- Layout split: pages/simulator/* (useSimulatorState, MarkPrices, Positions, PendingOrders, ActionPanel, EventLog, CreateSimulatorSection)
- Bug fixes en route: position-map key unified to `getNativeKey` (was inconsistent between externalDeposit and `_applyFill`); mark-price input refreshes after Set/Tick actions; reconcileBalance fields stored as string (Decimal didn't survive JSON round-trip)

**UTA id derivation (commit 435e129)**

- `BrokerPresetDef.fingerprintFields: string[]` declares per-preset which `presetConfig` keys define broker identity. SHA-256 over canonical-JSON of the filtered subset, truncated to 8 hex chars, prefixed with preset.id
- POST `/api/trading/config/uta` — derives id, 409 + existing UTA metadata on collision, Mock auto-mints `_instanceId`. PUT becomes edit-only (422 for unknown ids)
- Trading wizard: drop "UTA ID" input → "Name" (label only); 409 surfaces a `BrokerConflictPanel` with "Open existing"
- Simulator create form: drop id field + auto-avoid logic, server picks
- Existing user-typed-id UTAs retained (no auto-migration); `PUT` retire planned in TODO.md once they age out

**Multi-asset support (commits 86c7b81 → 274dfc4)**

- secType expanded: CRYPTO / CRYPTO_PERP / STK / FUT / OPT / FOP / CASH / BOND
- Derivative metadata fields (lastTradeDateOrContractMonth, strike, right, multiplier) flow through MockBroker._buildContract; route schema accepts them; getSimulatorState exposes them
- `pages/simulator/instruments.ts` — InstrumentDraft → buildInstrument(): { nativeKey, contract } translator + describeInstrument() for "AAPL Jul20 150C" / "ES Jun26" labels. Auto-derives unique nativeKey from (symbol, expiry, strike, right) so multiple options on the same underlying coexist
- `InstrumentInput` component — secType select + conditional fields shown only when relevant (OPT/FOP get strike+right, FUT only expiry+multiplier, plain types just symbol)
- Positions table renders derivative names + ×multiplier badge; PnL applies multiplier
- Three regression bugs found and fixed via QA driving: (1) cash flow ignored multiplier on OPT/FUT BUY/SELL — placeOrder/fillOrder/externalTrade all corrected; (2) `Mock.resolveNativeKey` was a STK stub that lost OPT metadata after a sell-flat → re-buy cycle — added a `_contractRegistry` keyed by nativeKey; (3) oversell silently filled and phantom-credited cash — `_applyFill` now throws, `placeOrder` catches and returns `success: false`

**Architecture notes (TODO.md updates)**

- IBroker contract requires `marketValue`/`unrealizedPnL` to be multiplier-applied; today every broker reimplements the math, currently dodging the bug because primary markets all have multiplier=1 (CCXT spot/perp) or upstream APIs hand back pre-multiplied values (Alpaca/IBKR). Filed `derivePositionMath` shared util as the structural fix
- PUT `/uta/:id` route still accepts a full UTAConfig with credentials (we unmask masked values from existing record before re-saving). Filed retirement plan once user-typed-id UTAs naturally migrate

Key commits: `ef4248c` `0fe5946` `936566e` `eef96ad` `e58a31e` `dd2fde0` `9043674` `435e129` `86c7b81` `274dfc4`

## Full commit log

\`\`\`
274dfc4 fix(mock): 3 multi-asset bugs surfaced via simulator QA pass
86c7b81 feat(simulator): support OPT / FOP / FUT / STK / CASH / BOND alongside CRYPTO
9043674 feat(ui/tabs): right-click context menu — close others / right / left / all + copy URL
dd2fde0 feat(ui/simulator): tab strip + sticky action panel + event log + keyboard
e58a31e refactor(ui/simulator): two-column layout + PnL column, drop Chinese strings
435e129 feat(trading): derive UTA id from broker identity, drop user-typed ids
eef96ad fix(mock): unify position-map key — getNativeKey everywhere
936566e fix(ui/simulator): mark-price input refreshes after Set/Tick actions
0fe5946 refactor(ui): move simulator account creation into Dev → Simulator tab
ef4248c feat(trading): MockBroker simulator console — manual撮合 + DevPage tab
17cba2e feat(ui/chat): confirm dialog before deleting a channel
\`\`\`

## Test plan

- [x] tsc --noEmit clean (backend + ui)
- [x] pnpm test passes — 1380 specs across 69 files
- [x] Simulator end-to-end via curl (STK / OPT / FUT / mixed): cash accounting, multiplier-applied PnL, sell-down reset, oversell rejection, contract registry preservation across sell-flat → re-buy
- [x] Manual sanity through `/dev/simulator` UI (account tab strip, sticky action panel, event log, keyboard ↑/↓)
- [ ] Extended manual: portfolio page consistency across mixed-asset simulator state

🤖 Generated with [Claude Code](https://claude.com/claude-code)