### PR TITLE
refactor(trading): IBKR-as-truth — canonical Contract taxonomy

### DIFF
--- a/packages/ibkr/src/contract.ts
+++ b/packages/ibkr/src/contract.ts
@@ -53,10 +53,78 @@ export class DeltaNeutralContract {
   }
 }
 
+/**
+ * Canonical security types — mirrors IBKR TWS API's full secType taxonomy.
+ *
+ * **NO new secTypes may be added without explicit project-lead sign-off.**
+ * IBKR's catalog is the source of truth; if IBKR can't represent an asset,
+ * OpenAlice doesn't represent it either. Brokers that work in non-IBKR
+ * universes are expected to map their native instruments INTO this set
+ * (e.g. Longbridge HK warrants → 'WAR'; LeverUp synthetic-perps → 'CRYPTO_PERP').
+ *
+ * The single intentional deviation from IBKR's exact list is the pair
+ * `'CRYPTO' | 'CRYPTO_PERP'`. IBKR has weak crypto-perp coverage (they
+ * shoehorn perps into futures/swaps), and crypto's wire format is simple
+ * enough that splitting spot vs. perp at the type level pays off
+ * immediately downstream (PnL formulas, contract identity, fingerprint
+ * fields). No other "subtype" extensions of this kind are allowed —
+ * if you find yourself wanting `STK_PRE`, `OPT_LEAP`, etc., the answer
+ * is "no, encode it via existing fields (lastTradeDateOrContractMonth,
+ * tradingClass, etc.)".
+ */
+const SEC_TYPE_VALUES = new Set<string>([
+  'STK', 'OPT', 'FUT', 'FOP', 'IND', 'CASH', 'BOND', 'CMDTY',
+  'WAR', 'IOPT', 'FUND', 'BAG', 'NEWS', 'CFD', 'CRYPTO',
+  'CRYPTO_PERP',
+])
+
+/**
+ * Wire-side coercion: turns whatever raw secType string TWS sent into
+ * either a typed `SecType` or `''`. Use at the bytes-to-objects boundary
+ * (decoders) so downstream code can trust `Contract.secType: SecType | ''`
+ * without runtime guards. If TWS adds a new secType we don't model yet,
+ * decoder logs a warning and stamps `''` rather than corrupt the type.
+ */
+export function coerceSecType(raw: string | undefined | null): SecType | '' {
+  if (!raw) return ''
+  if (SEC_TYPE_VALUES.has(raw)) return raw as SecType
+  // Unknown — TWS sent something not in our SecType union. Don't propagate
+  // an arbitrary string into the type system; downstream validation will
+  // surface the missing instrument as "no secType set".
+  console.warn(`@traderalice/ibkr: unknown secType "${raw}" — dropped (extend SecType in contract.ts if you need to model it).`)
+  return ''
+}
+
+export type SecType =
+  // ─── IBKR canonical (mirrors TWS API's documented values) ───
+  | 'STK'      // Stock / ETF
+  | 'OPT'      // Equity option
+  | 'FUT'      // Future
+  | 'FOP'      // Future option
+  | 'IND'      // Index
+  | 'CASH'     // Forex pair
+  | 'BOND'     // Bond
+  | 'CMDTY'    // Commodity
+  | 'WAR'      // Warrant
+  | 'IOPT'     // Dutch warrant / structured product
+  | 'FUND'     // Mutual fund
+  | 'BAG'      // Combo (multi-leg)
+  | 'NEWS'     // News
+  | 'CFD'      // Contract for difference
+  | 'CRYPTO'   // Crypto spot
+  // ─── OpenAlice extension — the ONLY allowed deviation from IBKR ───
+  | 'CRYPTO_PERP'
+
 export class Contract {
   conId: number = 0
   symbol: string = ''
-  secType: string = ''
+  /**
+   * Strict union — see `SecType` above for the no-extensions policy.
+   * Empty `''` is the un-set state on a freshly-constructed Contract;
+   * assertContract (in domain/trading/contract-discipline.ts) rejects
+   * `''` at broker output boundaries.
+   */
+  secType: SecType | '' = ''
   lastTradeDateOrContractMonth: string = ''
   lastTradeDate: string = ''
   strike: number = UNSET_DOUBLE

--- a/packages/ibkr/src/decoder/account.ts
+++ b/packages/ibkr/src/decoder/account.ts
@@ -18,7 +18,7 @@ import {
   MIN_SERVER_VER_UNREALIZED_PNL,
   MIN_SERVER_VER_REALIZED_PNL,
 } from '../server-versions.js'
-import { Contract } from '../contract.js'
+import { Contract, coerceSecType } from '../contract.js'
 import Decimal from 'decimal.js'
 
 // Protobuf message types
@@ -47,7 +47,7 @@ function decodeContractProto(cp: ContractProto): Contract {
   const c = new Contract()
   if (cp.conId !== undefined) c.conId = cp.conId
   if (cp.symbol !== undefined) c.symbol = cp.symbol
-  if (cp.secType !== undefined) c.secType = cp.secType
+  if (cp.secType !== undefined) 
   if (cp.lastTradeDateOrContractMonth !== undefined) c.lastTradeDateOrContractMonth = cp.lastTradeDateOrContractMonth
   if (cp.strike !== undefined) c.strike = cp.strike
   if (cp.right !== undefined) c.right = cp.right
@@ -103,7 +103,7 @@ export function applyAccountHandlers(decoder: Decoder): void {
     const contract = new Contract()
     contract.conId = decodeInt(fields) // ver 6
     contract.symbol = decodeStr(fields)
-    contract.secType = decodeStr(fields)
+    contract.secType = coerceSecType(decodeStr(fields))
     contract.lastTradeDateOrContractMonth = decodeStr(fields)
     contract.strike = decodeFloat(fields)
     contract.right = decodeStr(fields)
@@ -220,7 +220,7 @@ export function applyAccountHandlers(decoder: Decoder): void {
     const contract = new Contract()
     contract.conId = decodeInt(fields)
     contract.symbol = decodeStr(fields)
-    contract.secType = decodeStr(fields)
+    contract.secType = coerceSecType(decodeStr(fields))
     contract.lastTradeDateOrContractMonth = decodeStr(fields)
     contract.strike = decodeFloat(fields)
     contract.right = decodeStr(fields)
@@ -325,7 +325,7 @@ export function applyAccountHandlers(decoder: Decoder): void {
     const contract = new Contract()
     contract.conId = decodeInt(fields)
     contract.symbol = decodeStr(fields)
-    contract.secType = decodeStr(fields)
+    contract.secType = coerceSecType(decodeStr(fields))
     contract.lastTradeDateOrContractMonth = decodeStr(fields)
     contract.strike = decodeFloat(fields)
     contract.right = decodeStr(fields)

--- a/packages/ibkr/src/decoder/contract.ts
+++ b/packages/ibkr/src/decoder/contract.ts
@@ -24,6 +24,7 @@ import {
   ComboLeg,
   FundDistributionPolicyIndicator,
   FundAssetType,
+  coerceSecType,
 } from '../contract.js'
 import { TagValue } from '../tag-value.js'
 import { PriceIncrement } from '../common.js'
@@ -116,7 +117,7 @@ function decodeContractFromProto(proto: ContractProto): Contract {
   const c = new Contract()
   if (proto.conId !== undefined) c.conId = proto.conId
   if (proto.symbol !== undefined) c.symbol = proto.symbol
-  if (proto.secType !== undefined) c.secType = proto.secType
+  if (proto.secType !== undefined) c.secType = coerceSecType(proto.secType)
   if (proto.lastTradeDateOrContractMonth !== undefined) c.lastTradeDateOrContractMonth = proto.lastTradeDateOrContractMonth
   if (proto.strike !== undefined) c.strike = proto.strike
   if (proto.right !== undefined) c.right = proto.right
@@ -293,7 +294,7 @@ function processContractDataMsg(d: Decoder, fields: Iterator<string>): void {
 
   const contract = new ContractDetails()
   contract.contract.symbol = decodeStr(fields)
-  contract.contract.secType = decodeStr(fields)
+  contract.contract.secType = coerceSecType(decodeStr(fields))
   readLastTradeDate(fields, contract, false)
   if (d.serverVersion >= MIN_SERVER_VER_LAST_TRADE_DATE) {
     contract.contract.lastTradeDate = decodeStr(fields)
@@ -444,7 +445,7 @@ function processBondContractDataMsg(d: Decoder, fields: Iterator<string>): void 
 
   const contract = new ContractDetails()
   contract.contract.symbol = decodeStr(fields)
-  contract.contract.secType = decodeStr(fields)
+  contract.contract.secType = coerceSecType(decodeStr(fields))
   contract.cusip = decodeStr(fields)
   contract.coupon = decodeFloat(fields)
   readLastTradeDate(fields, contract, true)
@@ -532,7 +533,7 @@ function processSymbolSamplesMsg(d: Decoder, fields: Iterator<string>): void {
     const conDesc = new ContractDescription()
     conDesc.contract.conId = decodeInt(fields)
     conDesc.contract.symbol = decodeStr(fields)
-    conDesc.contract.secType = decodeStr(fields)
+    conDesc.contract.secType = coerceSecType(decodeStr(fields))
     conDesc.contract.primaryExchange = decodeStr(fields)
     conDesc.contract.currency = decodeStr(fields)
 

--- a/packages/ibkr/src/decoder/execution.ts
+++ b/packages/ibkr/src/decoder/execution.ts
@@ -24,7 +24,7 @@ import {
   MIN_SERVER_VER_SUBMITTER,
 } from '../server-versions.js'
 import { NO_VALID_ID } from '../const.js'
-import { Contract, ComboLeg, DeltaNeutralContract } from '../contract.js'
+import { Contract, ComboLeg, DeltaNeutralContract, coerceSecType } from '../contract.js'
 import { Execution, OptionExerciseType } from '../execution.js'
 import { CommissionAndFeesReport } from '../commission-and-fees-report.js'
 
@@ -43,7 +43,7 @@ function decodeContractFromProto(cp: ContractProtoType): Contract {
   const contract = new Contract()
   if (cp.conId !== undefined) contract.conId = cp.conId
   if (cp.symbol !== undefined) contract.symbol = cp.symbol
-  if (cp.secType !== undefined) contract.secType = cp.secType
+  if (cp.secType !== undefined) 
   if (cp.lastTradeDateOrContractMonth !== undefined) contract.lastTradeDateOrContractMonth = cp.lastTradeDateOrContractMonth
   if (cp.strike !== undefined) contract.strike = cp.strike
   if (cp.right !== undefined) contract.right = cp.right
@@ -140,7 +140,7 @@ export function applyExecutionHandlers(decoder: Decoder): void {
     const contract = new Contract()
     contract.conId = decodeInt(fields) // ver 5
     contract.symbol = decodeStr(fields)
-    contract.secType = decodeStr(fields)
+    contract.secType = coerceSecType(decodeStr(fields))
     contract.lastTradeDateOrContractMonth = decodeStr(fields)
     contract.strike = decodeFloat(fields)
     contract.right = decodeStr(fields)

--- a/packages/ibkr/src/decoder/misc.ts
+++ b/packages/ibkr/src/decoder/misc.ts
@@ -57,7 +57,7 @@ import {
   NewsProvider,
 } from '../common.js'
 import { ScanData } from '../scanner.js'
-import { ContractDetails, Contract } from '../contract.js'
+import { ContractDetails, Contract, coerceSecType } from '../contract.js'
 
 // Protobuf message types
 import { CurrentTime as CurrentTimeProto } from '../protobuf/CurrentTime.js'
@@ -103,7 +103,7 @@ function decodeContractFromProto(cp: ContractProto): Contract {
   const contract = new Contract()
   if (cp.conId !== undefined) contract.conId = cp.conId
   if (cp.symbol !== undefined) contract.symbol = cp.symbol
-  if (cp.secType !== undefined) contract.secType = cp.secType
+  if (cp.secType !== undefined) 
   if (cp.lastTradeDateOrContractMonth !== undefined) contract.lastTradeDateOrContractMonth = cp.lastTradeDateOrContractMonth
   if (cp.strike !== undefined) contract.strike = cp.strike
   if (cp.right !== undefined) contract.right = cp.right
@@ -237,7 +237,7 @@ export function applyMiscHandlers(decoder: Decoder): void {
       data.rank = decodeInt(fields)
       contractDetails.contract.conId = decodeInt(fields) // ver 3
       contractDetails.contract.symbol = decodeStr(fields)
-      contractDetails.contract.secType = decodeStr(fields)
+      contractDetails.contract.secType = coerceSecType(decodeStr(fields))
       contractDetails.contract.lastTradeDateOrContractMonth = decodeStr(fields)
       contractDetails.contract.strike = decodeFloat(fields)
       contractDetails.contract.right = decodeStr(fields)
@@ -418,7 +418,7 @@ export function applyMiscHandlers(decoder: Decoder): void {
       for (let i = 0; i < nDepthMktDataDescriptions; i++) {
         const desc = new DepthMktDataDescription()
         desc.exchange = decodeStr(fields)
-        desc.secType = decodeStr(fields)
+        desc.secType = coerceSecType(decodeStr(fields))
         if (d.serverVersion >= MIN_SERVER_VER_SERVICE_DATA_TYPE) {
           desc.listingExch = decodeStr(fields)
           desc.serviceDataType = decodeStr(fields)

--- a/packages/ibkr/src/decoder/orders.ts
+++ b/packages/ibkr/src/decoder/orders.ts
@@ -69,7 +69,7 @@ function decodeContractFromProto(cp: ContractProto): Contract {
   const contract = new Contract()
   if (cp.conId !== undefined) contract.conId = cp.conId
   if (cp.symbol !== undefined) contract.symbol = cp.symbol
-  if (cp.secType !== undefined) contract.secType = cp.secType
+  if (cp.secType !== undefined) 
   if (cp.lastTradeDateOrContractMonth !== undefined) contract.lastTradeDateOrContractMonth = cp.lastTradeDateOrContractMonth
   if (cp.strike !== undefined) contract.strike = cp.strike
   if (cp.right !== undefined) contract.right = cp.right

--- a/packages/ibkr/src/index.ts
+++ b/packages/ibkr/src/index.ts
@@ -17,7 +17,8 @@ export { AccountSummaryTags, AllTags } from './account-summary-tags.js'
 export { IneligibilityReason } from './ineligibility-reason.js'
 
 // Data models
-export { Contract, ContractDetails, ComboLeg, DeltaNeutralContract, ContractDescription } from './contract.js'
+export { Contract, ContractDetails, ComboLeg, DeltaNeutralContract, ContractDescription, coerceSecType } from './contract.js'
+export type { SecType } from './contract.js'
 export { Order, OrderComboLeg } from './order.js'
 export { OrderState, OrderAllocation } from './order-state.js'
 export { OrderCancel } from './order-cancel.js'

--- a/packages/ibkr/src/order-decoder.ts
+++ b/packages/ibkr/src/order-decoder.ts
@@ -4,7 +4,7 @@
 
 import Decimal from 'decimal.js'
 import { UNSET_DOUBLE, UNSET_INTEGER, UNSET_DECIMAL } from './const.js'
-import { Contract, ComboLeg, DeltaNeutralContract } from './contract.js'
+import { Contract, ComboLeg, DeltaNeutralContract, coerceSecType } from './contract.js'
 import { Order, OrderComboLeg } from './order.js'
 import { OrderState, OrderAllocation } from './order-state.js'
 import { OrderCondition, Create as createOrderCondition } from './order-condition.js'
@@ -73,7 +73,7 @@ export class OrderDecoder {
   decodeContractFields(fields: Iterator<string>): void {
     this.contract.conId = decodeInt(fields)
     this.contract.symbol = decodeStr(fields)
-    this.contract.secType = decodeStr(fields)
+    this.contract.secType = coerceSecType(decodeStr(fields))
     this.contract.lastTradeDateOrContractMonth = decodeStr(fields)
     this.contract.strike = decodeFloat(fields)
     this.contract.right = decodeStr(fields)

--- a/src/domain/trading/UnifiedTradingAccount.ts
+++ b/src/domain/trading/UnifiedTradingAccount.ts
@@ -12,6 +12,7 @@ import { Contract, Order, ContractDescription, ContractDetails, UNSET_DECIMAL } 
 import { BrokerError, type IBroker, type AccountInfo, type Position, type OpenOrder, type PlaceOrderResult, type Quote, type MarketClock, type AccountCapabilities, type BrokerHealth, type BrokerHealthInfo, type TpSlParams } from './brokers/types.js'
 import { TradingGit } from './git/TradingGit.js'
 import { recomputeCostBasisFromCommits } from './cost-basis.js'
+import { pnlOf } from './position-math.js'
 import type {
   Operation,
   AddResult,
@@ -558,12 +559,16 @@ export class UnifiedTradingAccount {
       if (!final) continue  // Should be unreachable — reconcile would seed it.
 
       p.avgCost = final.avgCost.toString()
-      // Per IBroker.Position contract, unrealizedPnL is multiplier-applied;
-      // cost-basis WAC operates on per-unit prices, so the multiplier has
-      // to be reapplied here. Defaults to 1 for stocks / crypto.
-      const multiplier = p.multiplier && p.multiplier !== '' ? new Decimal(p.multiplier) : new Decimal(1)
-      const pnl = p.quantity.mul(new Decimal(p.marketPrice).minus(final.avgCost)).mul(multiplier)
-      p.unrealizedPnL = pnl.toString()
+      // Cost-basis WAC operates on per-unit prices; the IBroker.Position
+      // contract requires unrealizedPnL to be multiplier-applied.
+      // `pnlOf` enforces the rule (defaults multiplier to '1' if absent).
+      p.unrealizedPnL = pnlOf({
+        quantity: p.quantity,
+        marketPrice: p.marketPrice,
+        avgCost: final.avgCost,
+        multiplier: p.multiplier || '1',
+        side: p.side,
+      })
     }
   }
 

--- a/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -407,6 +407,8 @@ export class AlpacaBroker implements IBroker {
         marketValue: new Decimal(p.market_value).abs().toString(),
         unrealizedPnL: new Decimal(p.unrealized_pl).toString(),
         realizedPnL: '0',
+        // Alpaca is STK-only — canonical multiplier is always '1'.
+        multiplier: '1',
       }))
     } catch (err) {
       throw BrokerError.from(err)

--- a/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -35,6 +35,7 @@ import type {
   AlpacaClockRaw,
 } from './alpaca-types.js'
 import { makeContract, resolveSymbol, mapAlpacaOrderStatus, makeOrderState } from './alpaca-contracts.js'
+import { buildPosition } from '../contract-builder.js'
 import { fuzzyRankContracts, type FuzzyRankInput } from '../fuzzy-rank.js'
 
 /** Subset of Alpaca's `/v2/assets` row we actually use for catalog matching. */
@@ -397,13 +398,16 @@ export class AlpacaBroker implements IBroker {
     try {
       const raw = await this.client.getPositions() as AlpacaPositionRaw[]
 
-      return raw.map(p => ({
+      return raw.map(p => buildPosition({
         contract: makeContract(p.symbol),
         currency: 'USD',
         side: p.side === 'long' ? 'long' as const : 'short' as const,
         quantity: new Decimal(p.qty),
         avgCost: new Decimal(p.avg_entry_price).toString(),
         marketPrice: new Decimal(p.current_price).toString(),
+        // Pass-through: Alpaca's API already provides multiplier-applied
+        // numbers. Don't re-derive (would re-do the math from scratch and
+        // could disagree with their server in edge cases).
         marketValue: new Decimal(p.market_value).abs().toString(),
         unrealizedPnL: new Decimal(p.unrealized_pl).toString(),
         realizedPnL: '0',

--- a/src/domain/trading/brokers/alpaca/alpaca-contracts.ts
+++ b/src/domain/trading/brokers/alpaca/alpaca-contracts.ts
@@ -7,15 +7,16 @@
 
 import { Contract, OrderState } from '@traderalice/ibkr'
 import '../../contract-ext.js'
+import { buildContract } from '../contract-builder.js'
 
 /** Build a fully qualified IBKR Contract for an Alpaca ticker. */
 export function makeContract(ticker: string): Contract {
-  const c = new Contract()
-  c.symbol = ticker
-  c.secType = 'STK'
-  c.exchange = 'SMART'
-  c.currency = 'USD'
-  return c
+  return buildContract({
+    symbol: ticker,
+    secType: 'STK',
+    exchange: 'SMART',
+    currency: 'USD',
+  })
 }
 
 /** Extract native symbol from aliceId, or null if not ours. */

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
@@ -1011,7 +1011,7 @@ describe('CcxtBroker — getPositions', () => {
     expect(btc.avgCost).toBe('60000')        // markPrice placeholder; UTA replaces via wallet ledger
     expect(btc.marketValue).toBe('30000')
     expect(btc.unrealizedPnL).toBe('0')
-    expect(btc.contract.localSymbol).toBe('BTC/USDT')  // spot, no settle suffix
+    expect(btc.contract.localSymbol).toBe('BTC')       // canonical (no broker-flavored encoding)
     expect(btc.avgCostSource).toBe('wallet')           // signals UTA to reconstruct cost
   })
 
@@ -1111,9 +1111,10 @@ describe('CcxtBroker — getPositions', () => {
     const positions = await acc.getPositions()
     expect(positions).toHaveLength(2)
     // Distinct contract identities — same underlying, different products.
+    // Canonical localSymbols disambiguate without leaking CCXT wire format.
     const localSymbols = positions.map(p => p.contract.localSymbol)
-    expect(localSymbols).toContain('BTC/USDT')        // spot
-    expect(localSymbols).toContain('BTC/USDT:USDT')   // perp
+    expect(localSymbols).toContain('BTC')        // spot
+    expect(localSymbols).toContain('BTC-PERP')   // perp
   })
 
   it('falls back to per-symbol fetchTicker when fetchTickers throws', async () => {

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -34,6 +34,7 @@ import {
   makeOrderState,
   marketToContract,
   contractToCcxt,
+  canonicalLocalSymbol,
 } from './ccxt-contracts.js'
 import { fuzzyRankContracts } from '../fuzzy-rank.js'
 import {
@@ -335,16 +336,16 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       pattern,
     )
 
-    // Index original markets by symbol so we can look up derivative-type
-    // metadata from each ranked hit.
-    const marketBySymbol = new Map<string, CcxtMarket>()
-    for (const m of candidates) marketBySymbol.set(m.symbol, m)
+    // Index by canonical localSymbol — that's what `marketToContract`
+    // emits onto each ranked hit's Contract, so this is the join key.
+    // (The CCXT wire `m.symbol` no longer appears on Contract.localSymbol
+    // post-Phase-3.)
+    const marketByCanonical = new Map<string, CcxtMarket>()
+    for (const m of candidates) marketByCanonical.set(canonicalLocalSymbol(m), m)
 
-    // derivativeSecTypes — surface what derivative product types appear in
-    // the result set, same shape as before.
     const derivativeTypes = new Set<string>()
     for (const desc of ranked) {
-      const m = marketBySymbol.get(desc.contract.localSymbol ?? '')
+      const m = marketByCanonical.get(desc.contract.localSymbol ?? '')
       if (!m) continue
       if (m.type === 'future') derivativeTypes.add('FUT')
       if (m.type === 'option') derivativeTypes.add('OPT')
@@ -512,13 +513,20 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
 
 
     const positions = await this.getPositions()
-    const ccxtSymbol = contractToCcxt(contract, this.exchange.markets as Record<string, CcxtMarket>, this.exchangeName)
-    const symbol = contract.symbol?.toUpperCase()
+    const markets = this.exchange.markets as Record<string, CcxtMarket>
+    const ccxtSymbol = contractToCcxt(contract, markets, this.exchangeName)
 
-    const pos = positions.find(p =>
-      (ccxtSymbol && p.contract.localSymbol === ccxtSymbol) ||
-      (symbol && p.contract.symbol === symbol),
-    )
+    // Resolve both input + each position's contract to CCXT wire format.
+    // That's the unambiguous identity per exchange — works whether the input
+    // contract carries canonical localSymbol (post-Phase-3 internal flow) or
+    // wire-format localSymbol (legacy callers, user-constructed contracts).
+    const symbol = contract.symbol?.toUpperCase()
+    const pos = positions.find(p => {
+      const posWire = contractToCcxt(p.contract, markets, this.exchangeName)
+      if (ccxtSymbol && posWire === ccxtSymbol) return true
+      // Fallback for inputs we couldn't wire-resolve — match on symbol+secType.
+      return symbol && p.contract.symbol === symbol && p.contract.secType === contract.secType
+    })
 
     if (!pos) {
       return { success: false, error: `No open position for ${ccxtSymbol ?? symbol ?? 'unknown'}` }

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -624,6 +624,8 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         marketValue: marketValue.toString(),
         unrealizedPnL: '0',
         realizedPnL: '0',
+        // CCXT spot has no IBKR-style multiplier; canonical default is '1'.
+        multiplier: '1',
         avgCostSource: 'wallet',
       })
     }
@@ -735,6 +737,11 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
           marketValue: marketValue.toString(),
           unrealizedPnL: unrealizedPnL.toString(),
           realizedPnL: new Decimal(String((p as unknown as Record<string, unknown>).realizedPnl ?? 0)).toString(),
+          // CCXT contract size is folded into `quantity = contracts × contractSize`
+          // upstream, so `multiplier` here is canonical 1 (matches IBKR's view of
+          // the position). If a future CCXT exchange exposes a separate IBKR-style
+          // multiplier, plumb it via marketToContract.
+          multiplier: '1',
           avgCostSource: 'broker',
         })
       }

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -25,6 +25,7 @@ import {
   type TpSlParams,
 } from '../types.js'
 import '../../contract-ext.js'
+import { buildPosition } from '../contract-builder.js'
 import { CCXT_CREDENTIAL_FIELDS, type CcxtBrokerConfig, type CcxtMarket, type FundingRate, type OrderBook, type OrderBookLevel } from './ccxt-types.js'
 import { MAX_INIT_RETRIES, INIT_RETRY_BASE_MS } from './ccxt-types.js'
 import {
@@ -613,7 +614,7 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       const markPrice = new Decimal(String(last))
       const marketValue = h.quantity.mul(markPrice)
 
-      result.push({
+      result.push(buildPosition({
         contract: marketToContract(h.market, this.exchangeName),
         currency: normalizeQuoteCurrency(h.market.quote ?? 'USDT'),
         side: 'long',
@@ -621,13 +622,17 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         // Placeholder — UTA will replace via wallet-ledger reconstruction.
         avgCost: markPrice.toString(),
         marketPrice: markPrice.toString(),
+        // CCXT pre-computes marketValue per the spot-synthesis path; the
+        // upstream API doesn't give us PnL since we have no historical cost,
+        // so we explicitly pin both pre-computed values to avoid `buildPosition`
+        // re-deriving with avgCost=markPrice (which would yield 0 anyway).
         marketValue: marketValue.toString(),
         unrealizedPnL: '0',
         realizedPnL: '0',
-        // CCXT spot has no IBKR-style multiplier; canonical default is '1'.
+        // CCXT spot has no IBKR-style multiplier — canonical default '1'.
         multiplier: '1',
         avgCostSource: 'wallet',
-      })
+      }))
     }
 
     return result
@@ -727,23 +732,22 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         const marketValue = quantity.mul(markPrice)
         const unrealizedPnL = new Decimal(String(p.unrealizedPnl ?? 0))
 
-        result.push({
+        result.push(buildPosition({
           contract: marketToContract(market, this.exchangeName),
           currency: normalizeQuoteCurrency(market.quote ?? 'USDT'),
           side: p.side === 'long' ? 'long' : 'short',
           quantity,
           avgCost: entryPrice.toString(),
           marketPrice: markPrice.toString(),
+          // CCXT exchange already returns notional and PnL — pass through.
           marketValue: marketValue.toString(),
           unrealizedPnL: unrealizedPnL.toString(),
           realizedPnL: new Decimal(String((p as unknown as Record<string, unknown>).realizedPnl ?? 0)).toString(),
-          // CCXT contract size is folded into `quantity = contracts × contractSize`
-          // upstream, so `multiplier` here is canonical 1 (matches IBKR's view of
-          // the position). If a future CCXT exchange exposes a separate IBKR-style
-          // multiplier, plumb it via marketToContract.
+          // contracts × contractSize is folded into `quantity` upstream, so
+          // multiplier is canonical 1 here.
           multiplier: '1',
           avgCostSource: 'broker',
-        })
+        }))
       }
 
       // Spot holdings carry distinct contract identity (no settle suffix

--- a/src/domain/trading/brokers/ccxt/ccxt-contracts.spec.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-contracts.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the CCXT-side contract translators.
+ *
+ * Phase 3 of the IBKR-as-truth refactor moved canonical localSymbol
+ * generation here — these tests pin the per-secType formats so we don't
+ * regress to dumping CCXT's wire format ("BTC/USDT:USDT") onto Contract.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  canonicalLocalSymbol,
+  marketToContract,
+  contractToCcxt,
+  ccxtTypeToSecType,
+} from './ccxt-contracts.js'
+import type { CcxtMarket } from './ccxt-types.js'
+
+function makeMarket(overrides: Partial<CcxtMarket> & { type: CcxtMarket['type']; base: string; quote: string; symbol: string }): CcxtMarket {
+  return {
+    id: overrides.symbol,
+    symbol: overrides.symbol,
+    base: overrides.base,
+    quote: overrides.quote,
+    type: overrides.type,
+    active: true,
+    settle: overrides.settle,
+    ...overrides,
+  } as CcxtMarket
+}
+
+describe('canonicalLocalSymbol', () => {
+  it('spot → base only', () => {
+    expect(canonicalLocalSymbol(makeMarket({
+      type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT',
+    }))).toBe('BTC')
+  })
+
+  it('swap → base-PERP (no settle suffix, no quote)', () => {
+    expect(canonicalLocalSymbol(makeMarket({
+      type: 'swap', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT', settle: 'USDT',
+    }))).toBe('BTC-PERP')
+  })
+
+  it('dated future → base-FUT-YYYYMM from market.expiry epoch', () => {
+    expect(canonicalLocalSymbol(makeMarket({
+      type: 'future', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT-220929',
+      // 2022-09-29 UTC = 1664409600000
+      expiry: 1664409600000,
+    } as Partial<CcxtMarket> & { type: 'future'; base: string; quote: string; symbol: string }))).toBe('BTC-FUT-202209')
+  })
+
+  it('dated future without epoch — falls back to symbol tail', () => {
+    expect(canonicalLocalSymbol(makeMarket({
+      type: 'future', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT-220929',
+    }))).toBe('BTC-FUT-220929')
+  })
+
+  it('option preserves wire format (out of scope for Phase 3)', () => {
+    expect(canonicalLocalSymbol(makeMarket({
+      type: 'option', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT-240920-50000-C',
+    }))).toBe('BTC/USDT:USDT-240920-50000-C')
+  })
+})
+
+describe('marketToContract — emits canonical Contract', () => {
+  it('spot Contract has canonical localSymbol', () => {
+    const c = marketToContract(makeMarket({
+      type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT',
+    }), 'bybit')
+    expect(c.symbol).toBe('BTC')
+    expect(c.localSymbol).toBe('BTC')
+    expect(c.secType).toBe('CRYPTO')
+    expect(c.exchange).toBe('bybit')
+    expect(c.currency).toBe('USDT')
+  })
+
+  it('perp Contract gets canonical -PERP suffix', () => {
+    const c = marketToContract(makeMarket({
+      type: 'swap', base: 'ETH', quote: 'USDT', symbol: 'ETH/USDT:USDT', settle: 'USDT',
+    }), 'bybit')
+    expect(c.localSymbol).toBe('ETH-PERP')
+    expect(c.secType).toBe('CRYPTO_PERP')
+  })
+
+  it('contracts pass assertContract — no missing universal fields', () => {
+    expect(() => marketToContract(makeMarket({
+      type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT',
+    }), 'bybit')).not.toThrow()
+  })
+})
+
+describe('contractToCcxt — canonical → wire format derivation', () => {
+  const markets: Record<string, CcxtMarket> = {
+    'BTC/USDT': makeMarket({ type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT' }),
+    'BTC/USDT:USDT': makeMarket({ type: 'swap', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT', settle: 'USDT' }),
+    'ETH/USDT': makeMarket({ type: 'spot', base: 'ETH', quote: 'USDT', symbol: 'ETH/USDT' }),
+  }
+
+  it('canonical spot Contract resolves to spot wire symbol via base+secType+currency search', () => {
+    const c = marketToContract(markets['BTC/USDT'], 'bybit')
+    // c.localSymbol = 'BTC', not 'BTC/USDT' — direct lookup misses, falls
+    // back to resolveContractSync which finds the spot market.
+    expect(contractToCcxt(c, markets, 'bybit')).toBe('BTC/USDT')
+  })
+
+  it('canonical perp Contract resolves to perp wire symbol', () => {
+    const c = marketToContract(markets['BTC/USDT:USDT'], 'bybit')
+    expect(contractToCcxt(c, markets, 'bybit')).toBe('BTC/USDT:USDT')
+  })
+
+  it('legacy wire-format localSymbol still resolves (back-compat for user-supplied contracts)', () => {
+    // User constructs Contract with wire-format localSymbol — direct hit.
+    const c = makeMarket({ type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT' })
+    const wireContract = marketToContract(c, 'bybit')
+    wireContract.localSymbol = 'BTC/USDT'  // simulate legacy
+    expect(contractToCcxt(wireContract, markets, 'bybit')).toBe('BTC/USDT')
+  })
+})
+
+describe('ccxtTypeToSecType (already covered, sanity)', () => {
+  it('spot/swap/future/option', () => {
+    expect(ccxtTypeToSecType('spot')).toBe('CRYPTO')
+    expect(ccxtTypeToSecType('swap')).toBe('CRYPTO_PERP')
+    expect(ccxtTypeToSecType('future')).toBe('FUT')
+    expect(ccxtTypeToSecType('option')).toBe('OPT')
+  })
+})

--- a/src/domain/trading/brokers/ccxt/ccxt-contracts.spec.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-contracts.spec.ts
@@ -18,12 +18,7 @@ import type { CcxtMarket } from './ccxt-types.js'
 function makeMarket(overrides: Partial<CcxtMarket> & { type: CcxtMarket['type']; base: string; quote: string; symbol: string }): CcxtMarket {
   return {
     id: overrides.symbol,
-    symbol: overrides.symbol,
-    base: overrides.base,
-    quote: overrides.quote,
-    type: overrides.type,
     active: true,
-    settle: overrides.settle,
     ...overrides,
   } as CcxtMarket
 }

--- a/src/domain/trading/brokers/ccxt/ccxt-contracts.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-contracts.ts
@@ -27,6 +27,55 @@ export function decodeSymbol(encoded: string): string {
   return encoded.replace(/_/g, '/').replace(/\./g, ':')
 }
 
+// ---- Canonical localSymbol (Phase 3 of IBKR-as-truth refactor) ----
+
+/**
+ * Build the canonical Contract.localSymbol for a CCXT market — IBKR-shaped
+ * (broker-agnostic) instead of CCXT's wire format (`BTC/USDT:USDT`).
+ *
+ * The canonical form lets aliceIds and downstream consumers stop
+ * special-casing CCXT's wire encoding. CCXT's wire format itself stays
+ * a CcxtBroker-internal concern: `contractToCcxt` now derives wire from
+ * the canonical Contract via `resolveContractSync`'s base+secType+currency
+ * search, which already existed as a fallback.
+ *
+ * Format per market.type:
+ *   - spot:   `${base}`                      (e.g. `BTC`)
+ *   - swap:   `${base}-PERP`                 (e.g. `BTC-PERP`)
+ *   - future: `${base}-FUT-${expiryYYYYMM}`  (e.g. `BTC-FUT-202609`)
+ *   - option: `${base}-OPT-...`              (skipped — CCXT options are niche)
+ *
+ * Multi-quote disambiguation (BTC/USDT vs BTC/USDC spot held simultaneously)
+ * is left for a follow-up — most users hold one quote per underlying, and
+ * `Contract.currency` differentiates them within the same UTA.
+ */
+export function canonicalLocalSymbol(market: CcxtMarket): string {
+  const base = market.base
+  switch (market.type) {
+    case 'spot':   return base
+    case 'swap':   return `${base}-PERP`
+    case 'future': return `${base}-FUT-${ccxtExpiryToCanonical(market)}`
+    case 'option': return market.symbol  // out of scope; preserve wire format
+    default:       return market.symbol
+  }
+}
+
+/** Best-effort YYYYMM extraction from a CCXT future market's expiry. */
+function ccxtExpiryToCanonical(market: CcxtMarket): string {
+  // CCXT exposes `expiry` (ms epoch) on dated futures. Fall back to whatever
+  // is encoded in the symbol if not present.
+  const ms = (market as unknown as { expiry?: number }).expiry
+  if (typeof ms === 'number') {
+    const d = new Date(ms)
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0')
+    return `${d.getUTCFullYear()}${m}`
+  }
+  // Fallback: tail of `BTC/USDT:USDT-220929` after the trailing dash.
+  const dash = market.symbol.lastIndexOf('-')
+  if (dash >= 0) return market.symbol.slice(dash + 1)
+  return 'unknown'
+}
+
 // ---- Type mapping ----
 
 export function ccxtTypeToSecType(type: string): string {
@@ -61,13 +110,10 @@ export function makeOrderState(ccxtStatus: string | undefined): OrderState {
 // ---- Contract ↔ CCXT symbol conversion ----
 
 /**
- * Convert a CcxtMarket to an IBKR Contract.
- *
- * NOTE: `localSymbol` here still carries CCXT's unified-symbol wire format
- * ("BTC/USDT:USDT"). Phase 3 of the IBKR-as-truth refactor moves that to
- * a broker-internal cache and emits a canonical localSymbol instead. For
- * now we keep the wire format on the Contract because `contractToCcxt`
- * (below) and order placement still read it.
+ * Convert a CcxtMarket to an IBKR Contract with a canonical localSymbol.
+ * CCXT's wire format ("BTC/USDT:USDT") is no longer on the Contract —
+ * `contractToCcxt` derives it from `(base, secType, currency)` via the
+ * markets table when CCXT-side talk is needed.
  */
 export function marketToContract(market: CcxtMarket, exchangeName: string): Contract {
   return buildContract({
@@ -75,7 +121,7 @@ export function marketToContract(market: CcxtMarket, exchangeName: string): Cont
     secType: ccxtTypeToSecType(market.type) as SecType,
     exchange: exchangeName,
     currency: market.quote,
-    localSymbol: market.symbol,       // CCXT unified symbol, e.g. "BTC/USDT:USDT"
+    localSymbol: canonicalLocalSymbol(market),
     description: `${market.base}/${market.quote} ${market.type}${market.settle ? ` (${market.settle} settled)` : ''}`,
   })
 }

--- a/src/domain/trading/brokers/ccxt/ccxt-contracts.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-contracts.ts
@@ -12,6 +12,8 @@
 import { Contract, OrderState } from '@traderalice/ibkr'
 import '../../contract-ext.js'
 import type { CcxtMarket } from './ccxt-types.js'
+import { buildContract } from '../contract-builder.js'
+import type { SecType } from '../../contract-discipline.js'
 
 // ---- Symbol encoding for aliceId ----
 
@@ -60,17 +62,22 @@ export function makeOrderState(ccxtStatus: string | undefined): OrderState {
 
 /**
  * Convert a CcxtMarket to an IBKR Contract.
- * aliceId = "{exchangeName}-{encodeSymbol(market.symbol)}"
+ *
+ * NOTE: `localSymbol` here still carries CCXT's unified-symbol wire format
+ * ("BTC/USDT:USDT"). Phase 3 of the IBKR-as-truth refactor moves that to
+ * a broker-internal cache and emits a canonical localSymbol instead. For
+ * now we keep the wire format on the Contract because `contractToCcxt`
+ * (below) and order placement still read it.
  */
 export function marketToContract(market: CcxtMarket, exchangeName: string): Contract {
-  const c = new Contract()
-  c.symbol = market.base
-  c.secType = ccxtTypeToSecType(market.type)
-  c.exchange = exchangeName
-  c.currency = market.quote
-  c.localSymbol = market.symbol       // CCXT unified symbol, e.g. "BTC/USDT:USDT"
-  c.description = `${market.base}/${market.quote} ${market.type}${market.settle ? ` (${market.settle} settled)` : ''}`
-  return c
+  return buildContract({
+    symbol: market.base,
+    secType: ccxtTypeToSecType(market.type) as SecType,
+    exchange: exchangeName,
+    currency: market.quote,
+    localSymbol: market.symbol,       // CCXT unified symbol, e.g. "BTC/USDT:USDT"
+    description: `${market.base}/${market.quote} ${market.type}${market.settle ? ` (${market.settle} settled)` : ''}`,
+  })
 }
 
 /** Parse aliceId → CCXT unified symbol. */

--- a/src/domain/trading/brokers/contract-builder.spec.ts
+++ b/src/domain/trading/brokers/contract-builder.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
+import { buildContract, buildPosition } from './contract-builder.js'
+
+describe('buildContract — defaults & validation', () => {
+  it('STK with universal fields → valid contract, localSymbol defaults to symbol', () => {
+    const c = buildContract({ symbol: 'AAPL', secType: 'STK', exchange: 'SMART', currency: 'USD' })
+    expect(c.symbol).toBe('AAPL')
+    expect(c.secType).toBe('STK')
+    expect(c.localSymbol).toBe('AAPL')  // default
+    expect(c.multiplier).toBe('')
+  })
+
+  it('OPT requires expiry/strike/right/multiplier — throws via assertContract', () => {
+    expect(() => buildContract({
+      symbol: 'AAPL', secType: 'OPT', exchange: 'CBOE', currency: 'USD',
+    })).toThrow(/lastTradeDateOrContractMonth.*strike.*right.*multiplier/s)
+  })
+
+  it('OPT with all fields → valid', () => {
+    const c = buildContract({
+      symbol: 'AAPL', secType: 'OPT', exchange: 'CBOE', currency: 'USD',
+      lastTradeDateOrContractMonth: '20260720',
+      strike: 150,
+      right: 'C',
+      multiplier: '100',
+    })
+    expect(c.right).toBe('C')
+    expect(c.strike).toBe(150)
+    expect(c.multiplier).toBe('100')
+  })
+
+  it('FUT requires expiry/multiplier (not strike/right)', () => {
+    expect(() => buildContract({
+      symbol: 'ES', secType: 'FUT', exchange: 'CME', currency: 'USD',
+    })).toThrow(/lastTradeDateOrContractMonth.*multiplier/s)
+    const c = buildContract({
+      symbol: 'ES', secType: 'FUT', exchange: 'CME', currency: 'USD',
+      lastTradeDateOrContractMonth: '202606', multiplier: '50',
+    })
+    expect(c.multiplier).toBe('50')
+  })
+
+  it('rejects unknown secType at buildContract output', () => {
+    expect(() => buildContract({
+      symbol: 'AAPL',
+      // @ts-expect-error — intentionally wrong to verify runtime catch
+      secType: 'BANANA',
+      exchange: 'SMART',
+      currency: 'USD',
+    })).toThrow(/secType "BANANA"/)
+  })
+
+  it('CRYPTO / CRYPTO_PERP need only universal fields', () => {
+    expect(buildContract({ symbol: 'BTC', secType: 'CRYPTO', exchange: 'BYBIT', currency: 'USD' })).toBeDefined()
+    expect(buildContract({ symbol: 'BTC', secType: 'CRYPTO_PERP', exchange: 'BYBIT', currency: 'USDT' })).toBeDefined()
+  })
+})
+
+describe('buildPosition — pass-through vs derive', () => {
+  const baseContract = buildContract({
+    symbol: 'AAPL', secType: 'STK', exchange: 'SMART', currency: 'USD',
+  })
+
+  it('derives marketValue and PnL when both are absent', () => {
+    const p = buildPosition({
+      contract: baseContract,
+      currency: 'USD',
+      side: 'long',
+      quantity: new Decimal(100),
+      avgCost: '200',
+      marketPrice: '210',
+      realizedPnL: '0',
+    })
+    expect(p.marketValue).toBe('21000')   // 100 × 210 × 1
+    expect(p.unrealizedPnL).toBe('1000')  // 100 × 10 × 1
+    expect(p.multiplier).toBe('1')        // default
+  })
+
+  it('passes through marketValue + unrealizedPnL when both supplied (Alpaca/IBKR path)', () => {
+    const p = buildPosition({
+      contract: baseContract,
+      currency: 'USD',
+      side: 'long',
+      quantity: new Decimal(100),
+      avgCost: '200',
+      marketPrice: '210',
+      realizedPnL: '0',
+      marketValue: '99999',  // arbitrary upstream value
+      unrealizedPnL: '12345',
+    })
+    expect(p.marketValue).toBe('99999')
+    expect(p.unrealizedPnL).toBe('12345')
+  })
+
+  it('inherits multiplier from contract when not overridden', () => {
+    const optContract = buildContract({
+      symbol: 'AAPL', secType: 'OPT', exchange: 'CBOE', currency: 'USD',
+      lastTradeDateOrContractMonth: '20260720', strike: 150, right: 'C', multiplier: '100',
+    })
+    const p = buildPosition({
+      contract: optContract,
+      currency: 'USD',
+      side: 'long',
+      quantity: new Decimal(5),
+      avgCost: '58',
+      marketPrice: '70',
+      realizedPnL: '0',
+    })
+    expect(p.multiplier).toBe('100')
+    expect(p.marketValue).toBe('35000')   // 5 × 70 × 100
+    expect(p.unrealizedPnL).toBe('6000')  // 5 × 12 × 100
+  })
+
+  it('explicit multiplier override wins over contract.multiplier', () => {
+    const optContract = buildContract({
+      symbol: 'AAPL', secType: 'OPT', exchange: 'CBOE', currency: 'USD',
+      lastTradeDateOrContractMonth: '20260720', strike: 150, right: 'C', multiplier: '100',
+    })
+    const p = buildPosition({
+      contract: optContract,
+      currency: 'USD',
+      side: 'long',
+      quantity: new Decimal(1),
+      avgCost: '50',
+      marketPrice: '50',
+      realizedPnL: '0',
+      multiplier: '50',  // override
+    })
+    expect(p.multiplier).toBe('50')
+  })
+
+  it('avgCostSource is preserved when set', () => {
+    const p = buildPosition({
+      contract: baseContract,
+      currency: 'USD',
+      side: 'long',
+      quantity: new Decimal(1),
+      avgCost: '100',
+      marketPrice: '100',
+      realizedPnL: '0',
+      avgCostSource: 'wallet',
+    })
+    expect(p.avgCostSource).toBe('wallet')
+  })
+})

--- a/src/domain/trading/brokers/contract-builder.ts
+++ b/src/domain/trading/brokers/contract-builder.ts
@@ -1,0 +1,141 @@
+/**
+ * Contract / Position output funnel.
+ *
+ * Phase 2 of the IBKR-as-truth refactor: every broker's `getPositions` and
+ * contract-construction call goes through `buildContract` and `buildPosition`.
+ * The functions enforce discipline at the broker output boundary:
+ *
+ *   - `buildContract` runs `assertContract` so any invalid output throws
+ *     immediately. The error names the missing/wrong field — the alternative
+ *     was bugs that surface days later as "why is OPT PnL wrong?"
+ *   - `buildPosition` is the single multiplier-aware position constructor.
+ *     If the broker has a pre-computed marketValue / unrealizedPnL from an
+ *     upstream API (Alpaca, IBKR/TWS), we trust those. Otherwise we derive
+ *     via `derivePositionMath`. Either way, `Position.multiplier` is always
+ *     populated (defaults to `contract.multiplier || '1'`), so consumers
+ *     can stop defending against optionality.
+ */
+
+import { Contract } from '@traderalice/ibkr'
+import Decimal from 'decimal.js'
+import type { Position } from './types.js'
+import { assertContract, type SecType } from '../contract-discipline.js'
+import { derivePositionMath } from '../position-math.js'
+
+// ==================== buildContract ====================
+
+export interface BuildContractInput {
+  symbol: string
+  secType: SecType
+  exchange: string
+  currency: string
+  /** Defaults to `symbol` when absent. */
+  localSymbol?: string
+  /** OPT/FOP: YYYYMMDD. FUT: YYYYMM. */
+  lastTradeDateOrContractMonth?: string
+  /** OPT/FOP only. */
+  strike?: number
+  /** OPT/FOP only — `'C'`/`'P'`/`'CALL'`/`'PUT'`. */
+  right?: 'C' | 'P' | 'CALL' | 'PUT'
+  /** OPT/FOP/FUT need this; non-derivative may leave it empty (consumers default to '1'). */
+  multiplier?: string
+  primaryExchange?: string
+  conId?: number
+  tradingClass?: string
+  /** Free-form description; some brokers use this for long names. */
+  description?: string
+}
+
+/**
+ * Construct a fully-validated IBKR Contract from broker-supplied fields.
+ * Throws via `assertContract` if the result violates the SecType taxonomy
+ * (e.g. an OPT without strike). All brokers' contract creation funnels
+ * here — adding a new broker means matching this input shape, not
+ * spelunking through the IBKR Contract class to remember which fields
+ * matter.
+ */
+export function buildContract(input: BuildContractInput): Contract {
+  const c = new Contract()
+  c.symbol = input.symbol
+  c.secType = input.secType
+  c.exchange = input.exchange
+  c.currency = input.currency
+  c.localSymbol = input.localSymbol ?? input.symbol
+  if (input.lastTradeDateOrContractMonth) c.lastTradeDateOrContractMonth = input.lastTradeDateOrContractMonth
+  if (input.strike !== undefined) c.strike = input.strike
+  if (input.right) c.right = input.right
+  if (input.multiplier) c.multiplier = input.multiplier
+  if (input.primaryExchange) c.primaryExchange = input.primaryExchange
+  if (input.conId !== undefined) c.conId = input.conId
+  if (input.tradingClass) c.tradingClass = input.tradingClass
+  if (input.description) c.description = input.description
+  assertContract(c)
+  return c
+}
+
+// ==================== buildPosition ====================
+
+export interface BuildPositionInput {
+  contract: Contract
+  currency: string
+  side: 'long' | 'short'
+  quantity: Decimal
+  avgCost: string
+  marketPrice: string
+  realizedPnL: string
+  /** Override `contract.multiplier` (defaults to that, then '1'). */
+  multiplier?: string
+  /**
+   * Pre-computed marketValue (multiplier-applied) from an upstream API.
+   * When set, used as-is. When absent, derived from quantity × marketPrice
+   * × multiplier × side via `derivePositionMath`.
+   */
+  marketValue?: string
+  /** Pre-computed unrealizedPnL — see marketValue. */
+  unrealizedPnL?: string
+  avgCostSource?: 'broker' | 'wallet'
+}
+
+/**
+ * Construct a canonical Position. Brokers either pass through pre-computed
+ * marketValue/unrealizedPnL from upstream APIs (Alpaca / IBKR — already
+ * multiplier-applied server-side) or omit them and let the builder derive
+ * the math. Multiplier is always non-empty on output (the IBroker contract
+ * promised this; previously brokers had to opt in, now the builder enforces).
+ */
+export function buildPosition(input: BuildPositionInput): Position {
+  const multiplier = input.multiplier
+    ?? (input.contract.multiplier ? input.contract.multiplier : '1')
+
+  // Either pass-through or derive — never both.
+  let marketValue: string
+  let unrealizedPnL: string
+  if (input.marketValue !== undefined && input.unrealizedPnL !== undefined) {
+    marketValue = input.marketValue
+    unrealizedPnL = input.unrealizedPnL
+  } else {
+    const derived = derivePositionMath({
+      quantity: input.quantity,
+      marketPrice: input.marketPrice,
+      avgCost: input.avgCost,
+      multiplier,
+      side: input.side,
+    })
+    marketValue = input.marketValue ?? derived.marketValue
+    unrealizedPnL = input.unrealizedPnL ?? derived.unrealizedPnL
+  }
+
+  return {
+    contract: input.contract,
+    currency: input.currency,
+    side: input.side,
+    quantity: input.quantity,
+    avgCost: input.avgCost,
+    marketPrice: input.marketPrice,
+    marketValue,
+    unrealizedPnL,
+    realizedPnL: input.realizedPnL,
+    multiplier,
+    ...(input.avgCostSource && { avgCostSource: input.avgCostSource }),
+  }
+}

--- a/src/domain/trading/brokers/fuzzy-rank.spec.ts
+++ b/src/domain/trading/brokers/fuzzy-rank.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { Contract } from '@traderalice/ibkr'
+import { Contract, type SecType } from '@traderalice/ibkr'
 import { fuzzyRankContracts, type FuzzyRankInput } from './fuzzy-rank.js'
 
 function entry(
   symbol: string,
-  opts: { base?: string; quote?: string; name?: string; localSymbol?: string; secType?: string } = {},
+  opts: { base?: string; quote?: string; name?: string; localSymbol?: string; secType?: SecType } = {},
 ): FuzzyRankInput {
   const c = new Contract()
   c.symbol = symbol

--- a/src/domain/trading/brokers/ibkr/ibkr-contracts.ts
+++ b/src/domain/trading/brokers/ibkr/ibkr-contracts.ts
@@ -8,20 +8,17 @@
 import { Contract } from '@traderalice/ibkr'
 import { BrokerError, type BrokerErrorCode } from '../types.js'
 import '../../contract-ext.js'
+import { buildContract } from '../contract-builder.js'
+import type { SecType } from '../../contract-discipline.js'
 
 /** Build a standard IBKR Contract (defaults: STK + SMART + USD). */
 export function makeContract(
   symbol: string,
-  secType = 'STK',
+  secType: SecType = 'STK',
   exchange = 'SMART',
   currency = 'USD',
 ): Contract {
-  const c = new Contract()
-  c.symbol = symbol
-  c.secType = secType
-  c.exchange = exchange
-  c.currency = currency
-  return c
+  return buildContract({ symbol, secType, exchange, currency })
 }
 
 /**

--- a/src/domain/trading/brokers/ibkr/request-bridge.ts
+++ b/src/domain/trading/brokers/ibkr/request-bridge.ts
@@ -28,6 +28,7 @@ import {
 } from '@traderalice/ibkr'
 import { BrokerError } from '../types.js'
 import { classifyIbkrError } from './ibkr-contracts.js'
+import { buildPosition } from '../contract-builder.js'
 import type {
   PendingRequest,
   TickSnapshot,
@@ -456,20 +457,21 @@ export class RequestBridge extends DefaultEWrapper {
     if (!this.accountCachePending_) return
     if (position.isZero()) return
 
-    this.accountCachePending_.positions.push({
+    this.accountCachePending_.positions.push(buildPosition({
       contract,
       currency: contract.currency || 'USD',
       side: position.greaterThan(0) ? 'long' : 'short',
       quantity: position.abs(),
       avgCost: averageCost,
       marketPrice,
-      // TWS already bakes contract.multiplier into marketValue — we
-      // surface the multiplier as metadata only, no math here.
+      // TWS already bakes contract.multiplier into the values it reports
+      // here — pass through as-is (don't re-derive). multiplier is surfaced
+      // as metadata for downstream consumers.
       marketValue: new Decimal(marketValue).abs().toString(),
       unrealizedPnL: unrealizedPNL,
       realizedPnL: realizedPNL,
       multiplier: contract.multiplier || '1',
-    })
+    }))
   }
 
   override updateAccountValue(key: string, val: string, _currency: string, _accountName: string): void {

--- a/src/domain/trading/brokers/longbridge/LongbridgeBroker.ts
+++ b/src/domain/trading/brokers/longbridge/LongbridgeBroker.ts
@@ -41,6 +41,7 @@ import {
   type TpSlParams,
 } from '../types.js'
 import '../../contract-ext.js'
+import { buildPosition } from '../contract-builder.js'
 import type { FxService } from '../../fx-service.js'
 import {
   echoContractDescription,
@@ -522,18 +523,20 @@ export class LongbridgeBroker implements IBroker {
     const absQty = qty.abs()
     const marketValue = marketPrice.times(absQty).times(multiplier)
     const unrealizedPnL = marketPrice.minus(cost).times(absQty).times(multiplier)
-    return {
+    return buildPosition({
       contract,
       currency: p.currency.toUpperCase(),
       side: qty.gte(0) ? 'long' : 'short',
       quantity: absQty,
       avgCost: cost.toString(),
       marketPrice: marketPrice.toString(),
+      // Longbridge derives marketValue and unrealizedPnL from its own
+      // market data + cost — pass through as already-correct.
       marketValue: marketValue.toString(),
       unrealizedPnL: unrealizedPnL.toString(),
       realizedPnL: '0',
       multiplier: multiplier.toString(),
-    }
+    })
   }
 
   /** Batch-fetch live `lastDone` for a symbol set. Returns empty map on failure. */

--- a/src/domain/trading/brokers/longbridge/longbridge-contracts.ts
+++ b/src/domain/trading/brokers/longbridge/longbridge-contracts.ts
@@ -8,6 +8,7 @@
 
 import { Contract, ContractDescription, OrderState } from '@traderalice/ibkr'
 import '../../contract-ext.js'
+import { buildContract } from '../contract-builder.js'
 
 /** Per-suffix metadata: which exchange / currency the SDK considers it. */
 interface SuffixInfo {
@@ -30,16 +31,15 @@ const SUFFIX_TABLE: Record<string, SuffixInfo> = {
  *                   tickers are accepted as a fallback (treated as US).
  */
 export function makeContract(lbSymbol: string): Contract {
-  const c = new Contract()
   const { ticker, suffix } = parseLbSymbol(lbSymbol)
   const info = SUFFIX_TABLE[suffix] ?? SUFFIX_TABLE['US']
-
-  c.symbol = ticker
-  c.localSymbol = lbSymbol  // preserve native key for round-trip resolution
-  c.secType = 'STK'
-  c.exchange = info.exchange
-  c.currency = info.currency
-  return c
+  return buildContract({
+    symbol: ticker,
+    localSymbol: lbSymbol,  // preserve native key for round-trip resolution
+    secType: 'STK',
+    exchange: info.exchange,
+    currency: info.currency,
+  })
 }
 
 /**

--- a/src/domain/trading/brokers/mock/MockBroker.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.ts
@@ -31,6 +31,7 @@ import type {
   TpSlParams,
 } from '../types.js'
 import '../../contract-ext.js'
+import { derivePositionMath } from '../../position-math.js'
 
 // ==================== Helpers ====================
 
@@ -120,6 +121,7 @@ export function makePosition(overrides: Partial<Position> = {}): Position {
     marketValue: '1600',
     unrealizedPnL: '100',
     realizedPnL: '0',
+    multiplier: '1',
     ...overrides,
   }
 }
@@ -375,10 +377,15 @@ export class MockBroker implements IBroker {
     let marketValueAcc = new Decimal(0)
     for (const pos of this._positions.values()) {
       const price = pos.marketPriceOverride ?? this._markPriceFor(pos.contract) ?? pos.avgCost
-      const mult = multiplierOf(pos.contract)
-      const posValue = pos.quantity.mul(price).mul(mult)
-      marketValueAcc = marketValueAcc.plus(posValue)
-      unrealizedPnL = unrealizedPnL.plus(pos.quantity.mul(price.minus(pos.avgCost)).mul(mult))
+      const { marketValue, unrealizedPnL: pnl } = derivePositionMath({
+        quantity: pos.quantity,
+        marketPrice: price,
+        avgCost: pos.avgCost,
+        multiplier: pos.contract.multiplier || '1',
+        side: pos.side,
+      })
+      marketValueAcc = marketValueAcc.plus(marketValue)
+      unrealizedPnL = unrealizedPnL.plus(pnl)
     }
 
     return {
@@ -396,11 +403,14 @@ export class MockBroker implements IBroker {
     const result: Position[] = []
     for (const pos of this._positions.values()) {
       const price = pos.marketPriceOverride ?? this._markPriceFor(pos.contract) ?? pos.avgCost
-      // Per IBroker.Position contract: marketValue / unrealizedPnL must be
-      // multiplier-applied at the broker layer. For OPT (×100) and futures
-      // (per-contract size), the simulator has to fold multiplier in here
-      // or downstream cost-basis ends up reporting per-unit numbers.
-      const mult = multiplierOf(pos.contract)
+      const multiplier = pos.contract.multiplier || '1'
+      const { marketValue, unrealizedPnL } = derivePositionMath({
+        quantity: pos.quantity,
+        marketPrice: price,
+        avgCost: pos.avgCost,
+        multiplier,
+        side: pos.side,
+      })
       result.push({
         contract: pos.contract,
         currency: pos.contract.currency || 'USD',
@@ -408,10 +418,10 @@ export class MockBroker implements IBroker {
         quantity: pos.quantity,
         avgCost: pos.avgCost.toString(),
         marketPrice: price.toString(),
-        marketValue: pos.quantity.mul(price).mul(mult).toString(),
-        unrealizedPnL: pos.quantity.mul(price.minus(pos.avgCost)).mul(mult).toString(),
+        marketValue,
+        unrealizedPnL,
         realizedPnL: '0',
-        ...(pos.contract.multiplier && { multiplier: pos.contract.multiplier }),
+        multiplier,
         ...(pos.avgCostSource && { avgCostSource: pos.avgCostSource }),
       })
     }

--- a/src/domain/trading/brokers/mock/MockBroker.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.ts
@@ -32,6 +32,8 @@ import type {
 } from '../types.js'
 import '../../contract-ext.js'
 import { derivePositionMath } from '../../position-math.js'
+import { buildContract, buildPosition } from '../contract-builder.js'
+import type { SecType } from '../../contract-discipline.js'
 
 // ==================== Helpers ====================
 
@@ -403,27 +405,16 @@ export class MockBroker implements IBroker {
     const result: Position[] = []
     for (const pos of this._positions.values()) {
       const price = pos.marketPriceOverride ?? this._markPriceFor(pos.contract) ?? pos.avgCost
-      const multiplier = pos.contract.multiplier || '1'
-      const { marketValue, unrealizedPnL } = derivePositionMath({
-        quantity: pos.quantity,
-        marketPrice: price,
-        avgCost: pos.avgCost,
-        multiplier,
-        side: pos.side,
-      })
-      result.push({
+      result.push(buildPosition({
         contract: pos.contract,
         currency: pos.contract.currency || 'USD',
         side: pos.side,
         quantity: pos.quantity,
         avgCost: pos.avgCost.toString(),
         marketPrice: price.toString(),
-        marketValue,
-        unrealizedPnL,
         realizedPnL: '0',
-        multiplier,
         ...(pos.avgCostSource && { avgCostSource: pos.avgCostSource }),
-      })
+      }))
     }
     return result
   }
@@ -576,16 +567,18 @@ export class MockBroker implements IBroker {
    * options + futures + FOP positions render correctly downstream.
    */
   private _buildContract(nativeKey: string, partial: Partial<Contract> | undefined): Contract {
-    const c = new Contract()
-    c.symbol = partial?.symbol ?? nativeKey
-    c.localSymbol = partial?.localSymbol ?? nativeKey
-    c.secType = partial?.secType ?? 'CRYPTO'
-    c.exchange = partial?.exchange ?? 'MOCK'
-    c.currency = partial?.currency ?? 'USD'
-    if (partial?.lastTradeDateOrContractMonth) c.lastTradeDateOrContractMonth = partial.lastTradeDateOrContractMonth
-    if (partial?.strike != null && partial.strike !== UNSET_DOUBLE) c.strike = partial.strike
-    if (partial?.right) c.right = partial.right
-    if (partial?.multiplier) c.multiplier = partial.multiplier
+    const right = partial?.right
+    const c = buildContract({
+      symbol: partial?.symbol || nativeKey,
+      secType: (partial?.secType as SecType) || 'CRYPTO',
+      exchange: partial?.exchange || 'MOCK',
+      currency: partial?.currency || 'USD',
+      localSymbol: partial?.localSymbol || nativeKey,
+      ...(partial?.lastTradeDateOrContractMonth && { lastTradeDateOrContractMonth: partial.lastTradeDateOrContractMonth }),
+      ...(partial?.strike != null && partial.strike !== UNSET_DOUBLE && { strike: partial.strike }),
+      ...(right === 'C' || right === 'P' || right === 'CALL' || right === 'PUT' ? { right } : {}),
+      ...(partial?.multiplier && { multiplier: partial.multiplier }),
+    })
     this._rememberContract(c)
     return c
   }

--- a/src/domain/trading/brokers/others/leverup/LeverupBroker.ts
+++ b/src/domain/trading/brokers/others/leverup/LeverupBroker.ts
@@ -430,6 +430,8 @@ export class LeverupBroker implements IBroker {
           marketValue: margin.toString(),
           unrealizedPnL: '0',  // not directly given by REST; future: compute mark - entry
           realizedPnL: '0',
+          // LeverUp perps don't expose a contract multiplier; canonical default is '1'.
+          multiplier: '1',
         })
       }
       return out

--- a/src/domain/trading/brokers/others/leverup/LeverupBroker.ts
+++ b/src/domain/trading/brokers/others/leverup/LeverupBroker.ts
@@ -31,6 +31,7 @@ import {
   type TpSlParams,
 } from '../../types.js'
 import '../../../contract-ext.js'
+import { buildContract, buildPosition } from '../../contract-builder.js'
 
 import {
   type LeverupBrokerConfig,
@@ -188,14 +189,16 @@ export class LeverupBroker implements IBroker {
   }
 
   private pairToContract(pair: LeverupPair): Contract {
-    const c = new Contract()
-    c.symbol = pair.base
-    c.secType = 'CRYPTO_PERP'  // LeverUp synthesizes everything (forex, stocks) as crypto-perps
-    c.exchange = 'LEVERUP'
-    c.currency = pair.quote
-    c.localSymbol = pair.symbol
-    c.description = `${pair.symbol} (LeverUp ${pair.category}${pair.highLeverage ? ', 500x' : ''})`
-    return c
+    return buildContract({
+      symbol: pair.base,
+      // LeverUp synthesizes forex / stocks as crypto-perps; the canonical
+      // taxonomy doesn't have a "synthetic perp" — closest fit is CRYPTO_PERP.
+      secType: 'CRYPTO_PERP',
+      exchange: 'LEVERUP',
+      currency: pair.quote,
+      localSymbol: pair.symbol,
+      description: `${pair.symbol} (LeverUp ${pair.category}${pair.highLeverage ? ', 500x' : ''})`,
+    })
   }
 
   private resolvePair(contract: Contract): LeverupPair | undefined {
@@ -420,19 +423,22 @@ export class LeverupBroker implements IBroker {
         const qty = weiToQty(BigInt(r.qty || '0'))
         const entryPrice = weiToPrice(BigInt(r.entryPrice || '0'))
         const margin = weiToAmountIn(BigInt(r.margin || '0'), USDC_DECIMALS)
-        out.push({
+        out.push(buildPosition({
           contract: this.pairToContract(pair),
           currency: 'USD',
           side: r.isLong ? 'long' : 'short',
           quantity: qty,
           avgCost: entryPrice.toString(),
           marketPrice: entryPrice.toString(),  // refined by getQuote callers if needed
+          // LeverUp uses margin (not full notional) for marketValue — preserved
+          // pre-buildPosition. Same for unrealizedPnL = '0' (REST doesn't expose
+          // it). Both are pass-through; the broker's known limitation, filed in
+          // the original LeverupBroker.ts comment.
           marketValue: margin.toString(),
-          unrealizedPnL: '0',  // not directly given by REST; future: compute mark - entry
+          unrealizedPnL: '0',
           realizedPnL: '0',
-          // LeverUp perps don't expose a contract multiplier; canonical default is '1'.
           multiplier: '1',
-        })
+        }))
       }
       return out
     } catch (err) {

--- a/src/domain/trading/brokers/types.ts
+++ b/src/domain/trading/brokers/types.ts
@@ -78,16 +78,19 @@ export interface Position {
   unrealizedPnL: string
   realizedPnL: string
   /**
-   * Shares-per-contract metadata: how many underlying shares one
-   * unit of `quantity` represents. `'1'` for plain stocks; `'100'`
-   * for US equity options; HK warrants/CBBCs use the issuer-specific
-   * conversion ratio (often a non-integer like '0.1' or '10').
+   * Shares-per-contract: how many underlying units one `quantity` unit
+   * represents. `'1'` for plain stocks/crypto/forex; `'100'` for US
+   * equity options; broker-specific for futures (e.g. ES = '50');
+   * issuer-specific for HK warrants/CBBCs (often a non-integer).
    *
-   * `marketValue` is already multiplier-applied at the broker layer —
-   * this field is metadata for UI / analytics ("1 contract = 100
-   * shares"), not a math input. Consumers must NOT re-apply.
+   * `marketValue` and `unrealizedPnL` are derived via `derivePositionMath`
+   * with this field folded in, so consumers must NOT re-apply. This was
+   * optional before the IBKR-as-truth refactor; it's required now to
+   * force every broker to declare a value rather than rely on an implicit
+   * 1-default. Read-time normalization in TradingGit.rehydrateGitState
+   * fills missing values from older commit.json files.
    */
-  multiplier?: string
+  multiplier: string
   /**
    * Provenance of `avgCost`:
    * - `'broker'`: broker reported it directly (Alpaca avg_entry_price,

--- a/src/domain/trading/contract-discipline.spec.ts
+++ b/src/domain/trading/contract-discipline.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import { Contract } from '@traderalice/ibkr'
+import {
+  isSecType,
+  validateContract,
+  assertContract,
+  SEC_TYPES,
+} from './contract-discipline.js'
+
+function makeContract(overrides: Partial<Contract> = {}): Contract {
+  const c = new Contract()
+  c.symbol = overrides.symbol ?? 'AAPL'
+  c.secType = overrides.secType ?? 'STK'
+  c.exchange = overrides.exchange ?? 'NASDAQ'
+  c.currency = overrides.currency ?? 'USD'
+  if (overrides.lastTradeDateOrContractMonth) c.lastTradeDateOrContractMonth = overrides.lastTradeDateOrContractMonth
+  if (overrides.strike != null) c.strike = overrides.strike
+  if (overrides.right) c.right = overrides.right
+  if (overrides.multiplier) c.multiplier = overrides.multiplier
+  if (overrides.localSymbol) c.localSymbol = overrides.localSymbol
+  return c
+}
+
+describe('SecType taxonomy', () => {
+  it('SEC_TYPES covers the documented set', () => {
+    expect(SEC_TYPES).toEqual(['STK', 'OPT', 'FUT', 'FOP', 'CASH', 'BOND', 'WAR', 'CRYPTO', 'CRYPTO_PERP'])
+  })
+
+  it('isSecType narrows correctly', () => {
+    expect(isSecType('STK')).toBe(true)
+    expect(isSecType('OPT')).toBe(true)
+    expect(isSecType('CRYPTO_PERP')).toBe(true)
+    expect(isSecType('crypto')).toBe(false)  // case-sensitive
+    expect(isSecType('FUTURES')).toBe(false)
+    expect(isSecType('')).toBe(false)
+    expect(isSecType(null)).toBe(false)
+  })
+})
+
+describe('validateContract — universal fields', () => {
+  it('ok for a complete STK contract', () => {
+    const r = validateContract(makeContract())
+    expect(r.ok).toBe(true)
+  })
+
+  it('rejects empty symbol', () => {
+    const c = makeContract({ symbol: '' })
+    const r = validateContract(c)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.errors.some(e => /symbol/.test(e))).toBe(true)
+  })
+
+  it('rejects unknown secType', () => {
+    const c = makeContract()
+    c.secType = 'BANANA'
+    const r = validateContract(c)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.errors.some(e => /secType .* not a known SecType/.test(e))).toBe(true)
+  })
+
+  it('rejects empty exchange / currency', () => {
+    const c = makeContract({ exchange: '' })
+    const r = validateContract(c)
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('validateContract — OPT/FOP requirements', () => {
+  it('OPT needs expiry + strike + right + multiplier', () => {
+    const c = makeContract({ secType: 'OPT' })
+    const r = validateContract(c)
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.errors.some(e => /lastTradeDateOrContractMonth/.test(e))).toBe(true)
+      expect(r.errors.some(e => /strike/.test(e))).toBe(true)
+      expect(r.errors.some(e => /right/.test(e))).toBe(true)
+      expect(r.errors.some(e => /multiplier/.test(e))).toBe(true)
+    }
+  })
+
+  it('OPT with all four fields is valid', () => {
+    const c = makeContract({
+      secType: 'OPT', symbol: 'AAPL', exchange: 'CBOE',
+      lastTradeDateOrContractMonth: '20260720', strike: 150, right: 'C', multiplier: '100',
+    })
+    expect(validateContract(c).ok).toBe(true)
+  })
+
+  it('OPT with bad right value fails', () => {
+    const c = makeContract({
+      secType: 'OPT', symbol: 'AAPL', exchange: 'CBOE',
+      lastTradeDateOrContractMonth: '20260720', strike: 150, right: 'X', multiplier: '100',
+    })
+    const r = validateContract(c)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.errors.some(e => /right must be C\/P/.test(e))).toBe(true)
+  })
+})
+
+describe('validateContract — FUT requirements', () => {
+  it('FUT needs expiry + multiplier; not strike/right', () => {
+    const incomplete = makeContract({ secType: 'FUT', symbol: 'ES', exchange: 'CME' })
+    expect(validateContract(incomplete).ok).toBe(false)
+    const ok = makeContract({
+      secType: 'FUT', symbol: 'ES', exchange: 'CME',
+      lastTradeDateOrContractMonth: '202606', multiplier: '50',
+    })
+    expect(validateContract(ok).ok).toBe(true)
+  })
+})
+
+describe('validateContract — STK / CRYPTO need only universal', () => {
+  it('STK passes without expiry/strike/right/multiplier', () => {
+    expect(validateContract(makeContract({ secType: 'STK' })).ok).toBe(true)
+  })
+
+  it('CRYPTO passes without derivative fields', () => {
+    const c = makeContract({ secType: 'CRYPTO', symbol: 'BTC', exchange: 'BYBIT', currency: 'USD' })
+    expect(validateContract(c).ok).toBe(true)
+  })
+
+  it('CRYPTO_PERP passes', () => {
+    const c = makeContract({ secType: 'CRYPTO_PERP', symbol: 'BTC', exchange: 'BYBIT', currency: 'USDT' })
+    expect(validateContract(c).ok).toBe(true)
+  })
+})
+
+describe('assertContract', () => {
+  it('throws with all errors joined', () => {
+    const c = makeContract({ secType: 'OPT', symbol: '' })
+    expect(() => assertContract(c)).toThrow(/Invalid contract:.*symbol.*OPT requires/s)
+  })
+
+  it('returns silently on valid contract', () => {
+    expect(() => assertContract(makeContract())).not.toThrow()
+  })
+})

--- a/src/domain/trading/contract-discipline.spec.ts
+++ b/src/domain/trading/contract-discipline.spec.ts
@@ -23,7 +23,13 @@ function makeContract(overrides: Partial<Contract> = {}): Contract {
 
 describe('SecType taxonomy', () => {
   it('SEC_TYPES covers the documented set', () => {
-    expect(SEC_TYPES).toEqual(['STK', 'OPT', 'FUT', 'FOP', 'CASH', 'BOND', 'WAR', 'CRYPTO', 'CRYPTO_PERP'])
+    expect(SEC_TYPES).toEqual([
+      // IBKR canonical taxonomy (mirrors TWS API)
+      'STK', 'OPT', 'FUT', 'FOP', 'IND', 'CASH', 'BOND', 'CMDTY',
+      'WAR', 'IOPT', 'FUND', 'BAG', 'NEWS', 'CFD', 'CRYPTO',
+      // OpenAlice extension (only allowed deviation from IBKR)
+      'CRYPTO_PERP',
+    ])
   })
 
   it('isSecType narrows correctly', () => {
@@ -52,7 +58,11 @@ describe('validateContract — universal fields', () => {
 
   it('rejects unknown secType', () => {
     const c = makeContract()
-    c.secType = 'BANANA'
+    // Forced cast — TS would reject the literal at compile time (which is the
+    // whole point of the SecType union). The test is verifying the runtime
+    // validator catches the same shape if it were to slip through e.g. a JSON
+    // load from an old commit.json.
+    c.secType = 'BANANA' as unknown as typeof c.secType
     const r = validateContract(c)
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.errors.some(e => /secType .* not a known SecType/.test(e))).toBe(true)

--- a/src/domain/trading/contract-discipline.ts
+++ b/src/domain/trading/contract-discipline.ts
@@ -1,0 +1,132 @@
+/**
+ * Contract discipline — strict SecType taxonomy + per-secType validation.
+ *
+ * The `@traderalice/ibkr` Contract class is intentionally permissive (mirrors
+ * the IBKR ibapi shape; every field has a default). That permissiveness
+ * meant secType drifted to freeform `string` and downstream consumers had
+ * no way to know which fields were required for a given instrument.
+ *
+ * This module promotes IBKR's contract taxonomy to canonical:
+ *   - `SecType` is a strict union — adding a new type touches one place.
+ *   - `validateContract(c)` enforces per-secType structural requirements
+ *     (OPT/FOP need expiry+strike+right+multiplier; FUT needs expiry+
+ *     multiplier; STK/CRYPTO/etc. need symbol+exchange+currency).
+ *
+ * Brokers funnel their Contract construction through `buildContract` (added
+ * in Phase 2 of the IBKR-as-truth refactor) which calls `validateContract`
+ * at output and throws in dev. Phase 1 (this commit) just makes the
+ * machinery available; later phases enforce it.
+ */
+
+import { Contract, UNSET_DOUBLE } from '@traderalice/ibkr'
+
+// ==================== SecType union ====================
+
+/**
+ * Canonical security types. Adding a new type:
+ *   1. Add to this union.
+ *   2. Add a row to `SECTYPE_REQUIREMENTS` describing the required fields.
+ *   3. Update consumers' exhaustive switches (TS will surface them).
+ */
+export type SecType =
+  | 'STK'
+  | 'OPT'
+  | 'FUT'
+  | 'FOP'    // futures option
+  | 'CASH'   // forex
+  | 'BOND'
+  | 'WAR'    // warrant
+  | 'CRYPTO'
+  | 'CRYPTO_PERP'
+
+export const SEC_TYPES: readonly SecType[] = [
+  'STK', 'OPT', 'FUT', 'FOP', 'CASH', 'BOND', 'WAR', 'CRYPTO', 'CRYPTO_PERP',
+] as const
+
+const SEC_TYPE_SET = new Set<string>(SEC_TYPES)
+
+export function isSecType(v: unknown): v is SecType {
+  return typeof v === 'string' && SEC_TYPE_SET.has(v)
+}
+
+// ==================== Per-secType requirements ====================
+
+export interface ContractRequirements {
+  /** Universal: every contract regardless of secType. */
+  universal: ['symbol', 'secType', 'exchange', 'currency']
+  /** Required only when secType matches (in addition to universal). */
+  bySecType: Partial<Record<SecType, Array<keyof Contract>>>
+}
+
+export const SECTYPE_REQUIREMENTS: ContractRequirements = {
+  universal: ['symbol', 'secType', 'exchange', 'currency'],
+  bySecType: {
+    OPT: ['lastTradeDateOrContractMonth', 'strike', 'right', 'multiplier'],
+    FOP: ['lastTradeDateOrContractMonth', 'strike', 'right', 'multiplier'],
+    FUT: ['lastTradeDateOrContractMonth', 'multiplier'],
+    // STK / CASH / BOND / WAR / CRYPTO / CRYPTO_PERP need only the universal
+    // fields. Multiplier defaults to '1' downstream when absent.
+  },
+}
+
+// ==================== Validator ====================
+
+export type ValidationResult = { ok: true } | { ok: false; errors: string[] }
+
+/**
+ * Validate a Contract against the canonical taxonomy. Returns a list of
+ * issues so callers can decide whether to throw or warn.
+ */
+export function validateContract(c: Contract): ValidationResult {
+  const errors: string[] = []
+
+  // Universal: non-empty
+  if (!c.symbol) errors.push('symbol is required')
+  if (!c.secType) errors.push('secType is required')
+  else if (!isSecType(c.secType)) errors.push(`secType "${c.secType}" is not a known SecType (allowed: ${SEC_TYPES.join(', ')})`)
+  if (!c.exchange) errors.push('exchange is required')
+  if (!c.currency) errors.push('currency is required')
+
+  // Per-secType (only if secType is itself valid)
+  if (isSecType(c.secType)) {
+    const required = SECTYPE_REQUIREMENTS.bySecType[c.secType] ?? []
+    for (const field of required) {
+      if (!hasContractField(c, field)) {
+        errors.push(`${c.secType} requires ${field}`)
+      }
+    }
+    // Right must be C/P/CALL/PUT for OPT/FOP
+    if ((c.secType === 'OPT' || c.secType === 'FOP') && c.right) {
+      const r = c.right.toUpperCase()
+      if (r !== 'C' && r !== 'P' && r !== 'CALL' && r !== 'PUT') {
+        errors.push(`${c.secType} right must be C/P/CALL/PUT (got "${c.right}")`)
+      }
+    }
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors }
+}
+
+/**
+ * Throwing variant for places that want hard enforcement (broker output
+ * boundary). Phase 2 wires this into `buildContract`; Phase 1 leaves it
+ * available without enforcing.
+ */
+export function assertContract(c: Contract): void {
+  const r = validateContract(c)
+  if (!r.ok) {
+    throw new Error(`Invalid contract: ${r.errors.join('; ')}`)
+  }
+}
+
+/**
+ * Check whether a Contract field has a non-default value. The IBKR class
+ * uses sentinels (UNSET_DOUBLE for strike, '' for strings) — so "missing"
+ * means "still at sentinel".
+ */
+function hasContractField(c: Contract, field: keyof Contract): boolean {
+  const v = c[field]
+  if (typeof v === 'string') return v !== ''
+  if (typeof v === 'number') return v !== UNSET_DOUBLE
+  return v != null
+}

--- a/src/domain/trading/contract-discipline.ts
+++ b/src/domain/trading/contract-discipline.ts
@@ -18,29 +18,21 @@
  * machinery available; later phases enforce it.
  */
 
-import { Contract, UNSET_DOUBLE } from '@traderalice/ibkr'
+import { Contract, UNSET_DOUBLE, type SecType } from '@traderalice/ibkr'
 
-// ==================== SecType union ====================
-
-/**
- * Canonical security types. Adding a new type:
- *   1. Add to this union.
- *   2. Add a row to `SECTYPE_REQUIREMENTS` describing the required fields.
- *   3. Update consumers' exhaustive switches (TS will surface them).
- */
-export type SecType =
-  | 'STK'
-  | 'OPT'
-  | 'FUT'
-  | 'FOP'    // futures option
-  | 'CASH'   // forex
-  | 'BOND'
-  | 'WAR'    // warrant
-  | 'CRYPTO'
-  | 'CRYPTO_PERP'
+// Re-export so callers under `domain/trading/*` can keep importing SecType
+// from this module — the canonical definition lives in @traderalice/ibkr
+// alongside the Contract class. See the policy doc on `SecType` there:
+// no new secTypes without explicit sign-off; CRYPTO/CRYPTO_PERP are the
+// only intentional deviations from IBKR's documented taxonomy.
+export type { SecType }
 
 export const SEC_TYPES: readonly SecType[] = [
-  'STK', 'OPT', 'FUT', 'FOP', 'CASH', 'BOND', 'WAR', 'CRYPTO', 'CRYPTO_PERP',
+  // IBKR canonical
+  'STK', 'OPT', 'FUT', 'FOP', 'IND', 'CASH', 'BOND', 'CMDTY',
+  'WAR', 'IOPT', 'FUND', 'BAG', 'NEWS', 'CFD', 'CRYPTO',
+  // OpenAlice-only extension
+  'CRYPTO_PERP',
 ] as const
 
 const SEC_TYPE_SET = new Set<string>(SEC_TYPES)

--- a/src/domain/trading/contract-ext.ts
+++ b/src/domain/trading/contract-ext.ts
@@ -2,15 +2,18 @@
  * Declaration merge: adds `aliceId` to IBKR Contract class.
  *
  * aliceId is Alice's unique asset identifier: "{utaId}|{nativeKey}"
- * e.g. "alpaca-paper|META", "bybit-main|ETH/USDT:USDT"
+ * e.g. "alpaca-paper|META", "bybit-main|ETH-PERP"
  *
  * Constructed by UTA layer (not broker). Broker uses symbol/localSymbol for resolution.
  * The @traderalice/ibkr package stays a pure IBKR replica.
  *
- * localSymbol semantics by broker:
+ * localSymbol semantics — canonical (broker-agnostic) post-Phase-3 of the
+ * IBKR-as-truth refactor:
  * - IBKR: exchange-native symbol (e.g., "AAPL", "ESZ4")
  * - Alpaca: ticker symbol (e.g., "AAPL")
- * - CCXT: unified market symbol (e.g., "ETH/USDT:USDT")
+ * - CCXT: canonical (e.g., "ETH" spot, "ETH-PERP" perp, "BTC-FUT-202609" dated future).
+ *         CCXT's wire format ("ETH/USDT:USDT") stays a CcxtBroker-internal concern,
+ *         derived on demand via `contractToCcxt`.
  * UTA uses localSymbol as nativeKey in aliceId: "{utaId}|{nativeKey}"
  */
 

--- a/src/domain/trading/git/TradingGit.spec.ts
+++ b/src/domain/trading/git/TradingGit.spec.ts
@@ -675,7 +675,7 @@ describe('TradingGit', () => {
             marketValue: '1600',
             unrealizedPnL: '100',
             realizedPnL: '0',
-
+            multiplier: '1',
           },
         ],
       })
@@ -706,7 +706,7 @@ describe('TradingGit', () => {
             marketValue: '1600',
             unrealizedPnL: '100',
             realizedPnL: '0',
-
+            multiplier: '1',
           },
         ],
       })
@@ -728,12 +728,12 @@ describe('TradingGit', () => {
           {
             contract: makeContract({ symbol: 'AAPL' }),
             currency: 'USD', side: 'long', quantity: new Decimal(10), avgCost: '100', marketPrice: '100',
-            marketValue: '1000', unrealizedPnL: '0', realizedPnL: '0',
+            marketValue: '1000', unrealizedPnL: '0', realizedPnL: '0', multiplier: '1',
           },
           {
             contract: makeContract({ symbol: 'GOOG' }),
             currency: 'USD', side: 'long', quantity: new Decimal(5), avgCost: '200', marketPrice: '200',
-            marketValue: '1000', unrealizedPnL: '0', realizedPnL: '0',
+            marketValue: '1000', unrealizedPnL: '0', realizedPnL: '0', multiplier: '1',
           },
         ],
       })
@@ -753,7 +753,7 @@ describe('TradingGit', () => {
           {
             contract: makeContract({ symbol: 'AAPL' }),
             currency: 'USD', side: 'long', quantity: new Decimal(10), avgCost: '100', marketPrice: '100',
-            marketValue: '1000', unrealizedPnL: '0', realizedPnL: '0',
+            marketValue: '1000', unrealizedPnL: '0', realizedPnL: '0', multiplier: '1',
           },
         ],
       })

--- a/src/domain/trading/git/TradingGit.ts
+++ b/src/domain/trading/git/TradingGit.ts
@@ -442,6 +442,12 @@ export class TradingGit implements ITradingGit {
       positions: state.positions.map((pos) => ({
         ...pos,
         quantity: new Decimal(String(pos.quantity)),
+        // Position.multiplier became required in the IBKR-as-truth refactor
+        // (Phase 1). Older commit.json files written under the optional
+        // contract have positions with no multiplier set — fill the
+        // canonical default so they don't fail downstream consumers that
+        // expect every Position to declare one.
+        multiplier: pos.multiplier ?? '1',
       })),
     }
   }

--- a/src/domain/trading/position-math.spec.ts
+++ b/src/domain/trading/position-math.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
+import { derivePositionMath, pnlOf, multiplierToDecimal } from './position-math.js'
+
+describe('derivePositionMath', () => {
+  it('STK long — multiplier=1: marketValue and PnL are simple products', () => {
+    const r = derivePositionMath({
+      quantity: 100, marketPrice: 210, avgCost: 200, multiplier: '1', side: 'long',
+    })
+    expect(r.marketValue).toBe('21000')
+    expect(r.unrealizedPnL).toBe('1000')
+  })
+
+  it('OPT long — multiplier=100 folds into both fields', () => {
+    const r = derivePositionMath({
+      quantity: 5, marketPrice: 70, avgCost: 58, multiplier: '100', side: 'long',
+    })
+    expect(r.marketValue).toBe('35000')   // 5 × 70 × 100
+    expect(r.unrealizedPnL).toBe('6000')  // 5 × (70-58) × 100
+  })
+
+  it('FUT long — multiplier=50 (ES-style)', () => {
+    const r = derivePositionMath({
+      quantity: 2, marketPrice: 5850, avgCost: 5800, multiplier: '50', side: 'long',
+    })
+    expect(r.marketValue).toBe('585000')   // 2 × 5850 × 50
+    expect(r.unrealizedPnL).toBe('5000')   // 2 × 50 × 50 = 5000
+  })
+
+  it('short side flips the sign of unrealizedPnL', () => {
+    const long = derivePositionMath({
+      quantity: 1, marketPrice: 110, avgCost: 100, multiplier: '1', side: 'long',
+    })
+    const short = derivePositionMath({
+      quantity: 1, marketPrice: 110, avgCost: 100, multiplier: '1', side: 'short',
+    })
+    expect(long.unrealizedPnL).toBe('10')
+    expect(short.unrealizedPnL).toBe('-10')
+    // marketValue is sign-agnostic — quantity is already absolute
+    expect(long.marketValue).toBe(short.marketValue)
+  })
+
+  it('handles Decimal inputs equivalently to string/number', () => {
+    const a = derivePositionMath({
+      quantity: new Decimal('1.0093'), marketPrice: new Decimal('80000'),
+      avgCost: new Decimal('80000'), multiplier: '1', side: 'long',
+    })
+    const b = derivePositionMath({
+      quantity: '1.0093', marketPrice: 80000, avgCost: '80000', multiplier: '1', side: 'long',
+    })
+    expect(a).toEqual(b)
+  })
+
+  it('zero or empty multiplier defaults to 1 (defensive)', () => {
+    const r = derivePositionMath({
+      quantity: 10, marketPrice: 100, avgCost: 95, multiplier: '0', side: 'long',
+    })
+    expect(r.unrealizedPnL).toBe('50')  // 10 × 5 × 1, not 0
+  })
+})
+
+describe('pnlOf', () => {
+  it('matches the unrealizedPnL produced by derivePositionMath', () => {
+    const inputs = {
+      quantity: '5', marketPrice: '70', avgCost: '58', multiplier: '100', side: 'long' as const,
+    }
+    expect(pnlOf(inputs)).toBe(derivePositionMath(inputs).unrealizedPnL)
+  })
+
+  it('zero PnL when mark equals avgCost', () => {
+    expect(pnlOf({
+      quantity: 100, marketPrice: 200, avgCost: 200, multiplier: '1', side: 'long',
+    })).toBe('0')
+  })
+})
+
+describe('multiplierToDecimal', () => {
+  it('empty/missing → 1', () => {
+    expect(multiplierToDecimal(undefined).toNumber()).toBe(1)
+    expect(multiplierToDecimal('').toNumber()).toBe(1)
+  })
+  it('numeric strings parse', () => {
+    expect(multiplierToDecimal('100').toNumber()).toBe(100)
+    expect(multiplierToDecimal('0.5').toNumber()).toBe(0.5)
+  })
+  it('zero → 1 (zero is a "broker forgot to set" signal)', () => {
+    expect(multiplierToDecimal('0').toNumber()).toBe(1)
+  })
+})

--- a/src/domain/trading/position-math.ts
+++ b/src/domain/trading/position-math.ts
@@ -1,0 +1,79 @@
+/**
+ * Position math — single source for `marketValue` and `unrealizedPnL`.
+ *
+ * The IBroker.Position contract requires marketValue and unrealizedPnL
+ * to be multiplier-applied. Historically every broker implemented the
+ * math itself, leading to drift (Mock had three multiplier-related bugs
+ * surfaced in 2026-05-07 QA). This module is the only place that math
+ * lives — brokers, UTA reconcile, and UI consumers all funnel here so
+ * the multiplier rule is enforced in exactly one implementation.
+ *
+ * Convention recap (matches the docstring on `Position.multiplier`):
+ *   - `quantity`, `avgCost`, `marketPrice` are per-unit values.
+ *   - `multiplier` is shares-per-contract: 1 for stocks/crypto, typically
+ *     100 for US equity options, broker-specific for futures.
+ *   - `marketValue   = quantity × marketPrice × multiplier`
+ *   - `unrealizedPnL = quantity × (marketPrice − avgCost) × multiplier × side`
+ *     where `side = +1` for long, `−1` for short.
+ */
+
+import Decimal from 'decimal.js'
+
+export interface PositionMathInput {
+  quantity: Decimal | string | number
+  marketPrice: Decimal | string | number
+  avgCost: Decimal | string | number
+  multiplier: string
+  side: 'long' | 'short'
+}
+
+export interface PositionMathOutput {
+  marketValue: string
+  unrealizedPnL: string
+}
+
+/** Coerce a numeric-ish input to Decimal; defaults to 0 on falsy/empty. */
+function toDecimal(v: Decimal | string | number | undefined | null): Decimal {
+  if (v == null || v === '') return new Decimal(0)
+  return v instanceof Decimal ? v : new Decimal(v)
+}
+
+/** Coerce multiplier string to Decimal; empty → 1 (the canonical default). */
+export function multiplierToDecimal(m: string | undefined): Decimal {
+  if (!m) return new Decimal(1)
+  const d = new Decimal(m)
+  return d.isZero() ? new Decimal(1) : d
+}
+
+/**
+ * Compute marketValue and unrealizedPnL from raw position inputs. Brokers
+ * call this in their `getPositions` instead of computing the values inline.
+ */
+export function derivePositionMath(input: PositionMathInput): PositionMathOutput {
+  const qty = toDecimal(input.quantity)
+  const mark = toDecimal(input.marketPrice)
+  const avg = toDecimal(input.avgCost)
+  const mult = multiplierToDecimal(input.multiplier)
+  const sideSign = input.side === 'long' ? 1 : -1
+
+  const marketValue = qty.mul(mark).mul(mult)
+  const unrealizedPnL = qty.mul(mark.minus(avg)).mul(mult).mul(sideSign)
+  return {
+    marketValue: marketValue.toString(),
+    unrealizedPnL: unrealizedPnL.toString(),
+  }
+}
+
+/**
+ * PnL-only convenience for consumers that already have marketValue but
+ * need to recompute PnL after avgCost changes (UTA reconcile pipeline,
+ * simulator UI on price tick). Same multiplier discipline as derive.
+ */
+export function pnlOf(input: PositionMathInput): string {
+  const qty = toDecimal(input.quantity)
+  const mark = toDecimal(input.marketPrice)
+  const avg = toDecimal(input.avgCost)
+  const mult = multiplierToDecimal(input.multiplier)
+  const sideSign = input.side === 'long' ? 1 : -1
+  return qty.mul(mark.minus(avg)).mul(mult).mul(sideSign).toString()
+}

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -9,7 +9,7 @@
 import { tool, type Tool } from 'ai'
 import { z } from 'zod'
 import Decimal from 'decimal.js'
-import { Contract, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { Contract, UNSET_DECIMAL, coerceSecType } from '@traderalice/ibkr'
 import type { UTAManager } from '@/domain/trading/uta-manager.js'
 import { BrokerError, type OpenOrder } from '@/domain/trading/brokers/types.js'
 import type { FxService } from '@/domain/trading/fx-service.js'
@@ -147,7 +147,7 @@ hitting the broker, which otherwise expects the bare base ticker.`,
         const query = new Contract()
         if (symbol) query.symbol = symbol
         if (aliceId) query.aliceId = aliceId
-        if (secType) query.secType = secType
+        if (secType) query.secType = coerceSecType(secType)
         if (currency) query.currency = currency
         const details = await uta.getContractDetails(query)
         if (!details) return { error: 'No contract details found.' }

--- a/src/webui/routes/simulator.ts
+++ b/src/webui/routes/simulator.ts
@@ -19,6 +19,7 @@ import type { Context } from 'hono'
 import { z } from 'zod'
 import type { EngineContext } from '../../core/types.js'
 import { MockBroker } from '../../domain/trading/brokers/mock/MockBroker.js'
+import { SEC_TYPES, type SecType } from '../../domain/trading/contract-discipline.js'
 
 // ==================== Schemas ====================
 
@@ -40,11 +41,13 @@ const fillOrderSchema = z.object({
 })
 
 // IBKR contract surface: includes derivative-distinguishing fields so the
-// simulator can model OPT/FOP/FUT/CASH/BOND alongside CRYPTO.
+// simulator can model OPT/FOP/FUT/CASH/BOND alongside CRYPTO. `secType` is
+// validated against `SEC_TYPES` at the network boundary so unknown values
+// are rejected with a 400 — the in-memory `Contract` type stays strict.
 const contractSchema = z.object({
   symbol: z.string().optional(),
   localSymbol: z.string().optional(),
-  secType: z.string().optional(),
+  secType: z.enum([...SEC_TYPES] as [SecType, ...SecType[]]).optional(),
   exchange: z.string().optional(),
   currency: z.string().optional(),
   // Derivative metadata

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -346,37 +346,34 @@ interface PositionWithAccount extends Position {
   accountProvider: string
 }
 
-/** True when the position carries derivative-specific context worth showing. */
-function isDerivative(p: Position): boolean {
-  const t = p.contract.secType
-  if (t === 'FUT' || t === 'OPT' || t === 'FOP' || t === 'CRYPTO_PERP') return true
-  return p.side === 'short'
-}
-
-/** Build display fragments for a contract based on its secType. */
-function contractDisplay(p: Position): { name: string; tag?: string } {
+/**
+ * Build display fragments for a contract.
+ *
+ * The `tag` is the canonical SecType string (STK / CRYPTO / CRYPTO_PERP /
+ * OPT / FUT / ...) — no vernacular translation. UI mirrors the taxonomy
+ * directly so a `[CRYPTO_PERP]` pill is unambiguously the same thing as
+ * `Position.contract.secType === 'CRYPTO_PERP'` everywhere else in the
+ * stack.
+ *
+ * `name` defaults to the symbol; for OPT/FOP we build a longer descriptor
+ * (expiry/right/strike) so two option positions on the same underlying
+ * are distinguishable in the table.
+ */
+function contractDisplay(p: Position): { name: string; tag: string } {
   const c = p.contract
   const sym = c.symbol ?? '???'
-  const t = c.secType
+  const t = c.secType || 'UNK'
 
   if (t === 'OPT' || t === 'FOP') {
-    // Options: show localSymbol if available, else construct from parts
     const optDesc = c.localSymbol
       ?? [sym, c.lastTradeDateOrContractMonth, c.right, c.strike && fmt(c.strike)].filter(Boolean).join(' ')
-    return { name: optDesc, tag: 'opt' }
+    return { name: optDesc, tag: t }
   }
   if (t === 'FUT') {
     const expiry = c.lastTradeDateOrContractMonth
-    return { name: expiry ? `${sym} ${expiry}` : sym, tag: 'fut' }
+    return { name: expiry ? `${sym} ${expiry}` : sym, tag: t }
   }
-  if (t === 'CRYPTO_PERP') {
-    return { name: sym, tag: 'perp' }
-  }
-  if (t === 'CRYPTO') {
-    return { name: sym, tag: 'spot' }
-  }
-  // STK, CASH, BOND, CMDTY, etc. — just the symbol, no tag
-  return { name: sym }
+  return { name: sym, tag: t }
 }
 
 function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount[]; fxRates: FxRateInfo[] }) {
@@ -406,25 +403,21 @@ function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount
           <tbody>
             {positions.map((p, i) => {
               const display = contractDisplay(p)
-              const deriv = isDerivative(p)
               const ccy = p.currency ?? 'USD'
               const fxRate = ccy === 'USD' ? 1 : (rateMap[ccy] ?? 1)
               const usdValue = Number(p.marketValue) * fxRate
+              const isShort = p.side === 'short'
 
               return (
                 <tr key={i} className="border-t border-border hover:bg-bg-tertiary/30 transition-colors">
                   <td className="px-3 py-2">
                     <div className="flex items-center gap-1.5 flex-wrap">
                       <span className="font-medium text-text">{display.name}</span>
-                      {display.tag && (
-                        <span className="text-[10px] px-1 py-0.5 rounded bg-bg-tertiary text-text-muted">{display.tag}</span>
+                      <span className="text-[10px] px-1 py-0.5 rounded bg-bg-tertiary text-text-muted font-mono tracking-tight">{display.tag}</span>
+                      {isShort && (
+                        <span className="text-[10px] px-1 py-0.5 rounded font-medium bg-red/15 text-red">SHORT</span>
                       )}
-                      {deriv && (
-                        <span className={`text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
-                          {p.side}
-                        </span>
-                      )}
-                      <span className="text-[10px] text-text-muted/50">{p.accountLabel}</span>
+                      <span className="text-[10px] text-text-muted/70">{p.accountLabel}</span>
                     </div>
                   </td>
                   <td className="px-3 py-2 text-center text-text-muted text-[11px]">{ccy}</td>


### PR DESCRIPTION
## Summary

Make IBKR's contract taxonomy the canonical model for the entire trading
subsystem. Other brokers (Alpaca, CCXT, LeverUp, Mock, Longbridge) emit
contracts shaped like IBKR contracts, validated at the broker output
boundary; secType is a strict union; the UI mirrors the taxonomy
directly without trader-vernacular translation.

## Phase decomposition

### Phase 1 — type discipline + shared position math (`2d152ff`)
- `Position.multiplier` becomes required (was optional)
- New `derivePositionMath()` / `pnlOf()` — single source for marketValue
  and unrealizedPnL math, multiplier-aware
- `multiplierToDecimal('0' | '' | undefined)` → `1` (consistent default)

### Phase 2 — broker output funnels (`2cbf033`)
- `buildContract(input)` — runs `assertContract` and throws on any
  contract that doesn't satisfy IBKR's per-secType field requirements
  (OPT/FOP need expiry+strike+right+multiplier, FUT needs
  expiry+multiplier, etc.)
- `buildPosition(input)` — either pass-through broker-supplied PnL or
  derive via `derivePositionMath`
- All brokers (Alpaca, CCXT, IBKR, LeverUp, Mock, Longbridge) routed
  through the funnels — broken contract shapes can no longer escape

### Phase 3 — drain CCXT wire format (`4bcf2f4`)
- `canonicalLocalSymbol(market)` — emits canonical `BTC` (spot),
  `BTC-PERP` (swap), `BTC-FUT-202209` (dated) instead of CCXT's
  `BTC/USDT`, `BTC/USDT:USDT`, `BTC/USDT:USDT-220929`
- `searchContracts` indexes by canonical localSymbol
- `closePosition` matches via `contractToCcxt` on both sides — wire
  format only at the CCXT boundary
- aliceId pollution audit confirmed broker-scoped only; no
  cross-broker leakage

### Phase 4 — strict SecType union (`72519b9`)
- `SecType = 'STK' | 'OPT' | 'FUT' | 'FOP' | 'IND' | 'CASH' | 'BOND' | 'CMDTY' | 'WAR' | 'IOPT' | 'FUND' | 'BAG' | 'NEWS' | 'CFD' | 'CRYPTO' | 'CRYPTO_PERP'`
- Full IBKR TWS API taxonomy + CRYPTO/CRYPTO_PERP as the only allowed
  OpenAlice extension; no new secTypes without sign-off
- `Contract.secType: string` → `SecType | ''`
- `coerceSecType()` helper at wire decode boundary (TWS protocol +
  AI tool input) — unknown values warn and drop to `''` rather than
  silently passing through

### Phase 5 — UI mirrors canonical taxonomy (`d6e4a92`)
- `PortfolioPage.contractDisplay` no longer translates
  CRYPTO → "spot" / CRYPTO_PERP → "perp" / OPT → "opt" — pill renders
  the SecType string verbatim. Removes the "spot is a peer of STK"
  visual confusion.
- side pill renders only when SHORT (long is the implicit default)
- accountLabel bumped to /70 visibility for multi-broker disambiguation

## Bug fixes shipped along the way

- Mock cash flow ignored multiplier on OPT/FUT
- Mock contract registry lost OPT metadata (resolveNativeKey was a
  STK stub)
- Oversell silently filled with phantom cash → now throws + returns
  `success: false`
- Position decimal serialization issues in reconcileBalance op

## Full commit log

```
d6e4a92 fix(ui): Portfolio position pill mirrors canonical SecType
72519b9 refactor(trading): Phase 4 — strict SecType union + full IBKR taxonomy
4bcf2f4 refactor(trading): Phase 3 — drain CCXT wire format from canonical Contract
2cbf033 refactor(trading): Phase 2 — broker output funnels through buildContract / buildPosition
2d152ff refactor(trading): Phase 1 — type discipline + shared position math
```

## Test plan

- [x] `npx tsc --noEmit` clean (root + ui workspace)
- [x] `pnpm vitest run` — 73 files / 1429 tests passing
- [x] Dev server: Portfolio page renders canonical pills (`[CRYPTO]`,
      `[CRYPTO_PERP]`, `[STK]`); SHORT pill only when actually short;
      multi-broker rows distinguishable by accountLabel
- [ ] Smoke test against live brokers (Bybit / Alpaca paper / IBKR)
      after merge — taxonomy changes are at the boundary so wire
      decode regressions would surface immediately

## Out of scope (filed as TODO)

- PnL% formula for perp positions (currently uses spot formula
  `unrealizedPnL / (avgCost*qty)`, should use ROI for derivatives —
  needs broker-supplied margin/leverage)
- BrokerLens test infrastructure (Phase 5 of the original plan,
  deferred — current per-broker spec coverage is sufficient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)