### PR TITLE
dev → master: ephemeral UTAs + IBKR-as-truth scope correction + FRED tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,3 +220,62 @@ work meaningfully shifts the PR's framing>
 
 This keeps the PR description as a faithful audit trail across sessions,
 and lets reviewers see who-did-what without trawling the commit log alone.
+
+### Default vs. isolated branch — when to deviate from `dev`
+
+The default for any session is **work on `dev`** and let the rolling
+PR carry it to master. The exception is **invasive, long-running work
+that shouldn't share a branch with parallel sessions** — typically a
+refactor of shared types / cross-cutting infrastructure that, while
+in-flight, would force every other session to rebase against churn
+they don't have context for.
+
+Examples worth isolating: changing a base interface every broker
+implements; renaming or restructuring a module everyone imports from;
+multi-day schema migrations.
+Examples that stay on `dev`: any feature, any local fix, anything
+scoped to one subsystem.
+
+When isolation is the right call:
+
+```bash
+# Branch from master (clean baseline, dev's churn won't bleed in)
+git fetch origin
+git checkout master
+git pull origin master
+git checkout -b refactor/<short-name>
+
+# During the refactor, periodically rebase against master so the
+# eventual merge stays small. Skip dev — its session-by-session
+# churn is intentionally not part of the baseline you're testing
+# against.
+git fetch origin
+git rebase origin/master
+
+# When done, PR straight to master (NOT dev). The refactor is its own
+# coherent unit, reviewed end-to-end.
+git push -u origin refactor/<short-name>
+gh pr create --base master --head refactor/<short-name> ...
+```
+
+**After the refactor merges**, dev needs to absorb the new master so
+in-flight sessions land on the new baseline:
+
+```bash
+git checkout dev
+git pull origin dev
+git fetch origin
+git merge origin/master
+git push origin dev
+```
+
+In-flight rolling-PR work then sees the refactor in their next pull
+and rebases naturally. Their diffs against the refreshed `dev` may
+need real fix-ups (that's the cost of an invasive refactor — and
+the reason you isolated it in the first place).
+
+**Decision rule for the next session that starts work:** if `master`
+is currently ahead of `dev` (because a refactor branch just landed
+there), do `git checkout dev && git merge origin/master` *before*
+starting any new feature work. Otherwise your new commits will land
+on a stale baseline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,3 +279,10 @@ is currently ahead of `dev` (because a refactor branch just landed
 there), do `git checkout dev && git merge origin/master` *before*
 starting any new feature work. Otherwise your new commits will land
 on a stale baseline.
+
+**Parallel work happens in the cloud, not in local worktrees.** For a
+project this size, spinning up multiple local worktrees costs more
+in `pnpm install` / `data/` copying / port juggling than it saves.
+Hand parallel tracks off to cloud Claude sessions instead — each
+gets its own sandbox, returns a PR, and doesn't touch the local
+working tree.

--- a/TODO.md
+++ b/TODO.md
@@ -78,6 +78,22 @@ the item when done — git log is the history.
 
 ## Bugs
 
+- [ ] IBKR `getNativeKey` may use the wrong field for nativeKey. Surfaced
+      2026-05-07 during the Phase-3 revert (`afddd41`) when articulating
+      the per-broker uniqueness scheme. IBKR's `Contract.symbol` and
+      `Contract.localSymbol` aren't reliably unique — one symbol "AAPL"
+      matches the underlying stock + every option chain expiry + every
+      weekly + every LEAP. The actual primary key is `conId` (numeric).
+      If `IbkrBroker.getNativeKey` currently returns `localSymbol ||
+      symbol`, it works only by accident — the moment users hold the
+      same underlying across multiple expiries, aliceId starts colliding.
+      Audit `src/domain/trading/brokers/ibkr/IbkrBroker.ts` (look for
+      `getNativeKey`); change to `String(contract.conId)` if not already.
+      Also extend the same audit to Alpaca / LeverUp / Bybit-direct
+      brokers — each should have an explicit getNativeKey returning the
+      broker's documented primary key, not a lazy `localSymbol ||
+      symbol` fallback.
+
 - [ ] Snapshot / FX: after currency conversion, snapshot values
       occasionally come out as wildly wrong numbers (reported, cause
       unknown). Likely a direction mistake (multiply vs divide) or

--- a/TODO.md
+++ b/TODO.md
@@ -78,25 +78,6 @@ the item when done — git log is the history.
 
 ## Bugs
 
-- [ ] UTA cost-basis bootstrap overwrites broker's real avgCost with
-      markPrice on first sight. Surfaced 2026-05-07 via the simulator
-      covered-call test: MockBroker reports AAPL stock avgCost=$148.50
-      and short AAPL 150C avgCost=$3.20; UTA `getPositions()` returns
-      both with avgCost == current markPrice and unrealizedPnL=0.
-      Root: the `recomputeCostBasisFromGit` + `reconcileBalance`
-      bootstrap pipeline was designed to handle CCXT spot (where
-      broker's avgCost is itself faked from markPrice), but it
-      generalized to ALL `avgCostSource: 'wallet'` positions and now
-      destroys correct data on Mock / Alpaca / IBKR / etc.
-      Fix direction: distinguish "broker is honest about avgCost" from
-      "broker is bullshitting" — likely a finer-grained source label
-      (e.g. `'wallet-mark-bootstrap'` vs `'broker'`) or a per-broker
-      capability flag. CCXT spot keeps mark-bootstrap; everyone else
-      bootstraps at broker-reported avgCost.
-      Files: `src/domain/trading/UnifiedTradingAccount.ts` (the
-      reconcile loop), `src/domain/trading/cost-basis.ts`,
-      `src/domain/trading/brokers/types.ts` (Position.avgCostSource).
-
 - [ ] Snapshot / FX: after currency conversion, snapshot values
       occasionally come out as wildly wrong numbers (reported, cause
       unknown). Likely a direction mistake (multiply vs divide) or

--- a/TODO.md
+++ b/TODO.md
@@ -78,6 +78,25 @@ the item when done — git log is the history.
 
 ## Bugs
 
+- [ ] UTA cost-basis bootstrap overwrites broker's real avgCost with
+      markPrice on first sight. Surfaced 2026-05-07 via the simulator
+      covered-call test: MockBroker reports AAPL stock avgCost=$148.50
+      and short AAPL 150C avgCost=$3.20; UTA `getPositions()` returns
+      both with avgCost == current markPrice and unrealizedPnL=0.
+      Root: the `recomputeCostBasisFromGit` + `reconcileBalance`
+      bootstrap pipeline was designed to handle CCXT spot (where
+      broker's avgCost is itself faked from markPrice), but it
+      generalized to ALL `avgCostSource: 'wallet'` positions and now
+      destroys correct data on Mock / Alpaca / IBKR / etc.
+      Fix direction: distinguish "broker is honest about avgCost" from
+      "broker is bullshitting" — likely a finer-grained source label
+      (e.g. `'wallet-mark-bootstrap'` vs `'broker'`) or a per-broker
+      capability flag. CCXT spot keeps mark-bootstrap; everyone else
+      bootstraps at broker-reported avgCost.
+      Files: `src/domain/trading/UnifiedTradingAccount.ts` (the
+      reconcile loop), `src/domain/trading/cost-basis.ts`,
+      `src/domain/trading/brokers/types.ts` (Position.avgCostSource).
+
 - [ ] Snapshot / FX: after currency conversion, snapshot values
       occasionally come out as wildly wrong numbers (reported, cause
       unknown). Likely a direction mistake (multiply vs divide) or

--- a/packages/opentypebb/src/providers/eia/index.ts
+++ b/packages/opentypebb/src/providers/eia/index.ts
@@ -14,7 +14,11 @@ export const eiaProvider = new Provider({
   description:
     'The U.S. Energy Information Administration (EIA) collects, analyzes, and ' +
     'disseminates independent and impartial energy information.',
-  credentials: ['eia_api_key'],
+  // Plain `api_key` — Provider constructor auto-prefixes with provider name,
+  // so the runtime credential field becomes `eia_api_key`. Declaring the
+  // already-prefixed form here would double-prefix to `eia_eia_api_key`
+  // and silently break credential propagation.
+  credentials: ['api_key'],
   fetcherDict: {
     PetroleumStatusReport: EIAPetroleumStatusReportFetcher,
     ShortTermEnergyOutlook: EIAShortTermEnergyOutlookFetcher,

--- a/packages/opentypebb/src/providers/eia/models/petroleum-status-report.ts
+++ b/packages/opentypebb/src/providers/eia/models/petroleum-status-report.ts
@@ -28,7 +28,10 @@ interface EiaResponse {
   response?: {
     data?: Array<{
       period: string
-      value: number | null
+      // EIA API serialises numeric observations as strings ("75.10"), with
+      // null only for missing periods. Coerce in extractData; the schema
+      // expects number.
+      value: string | number | null
       'series-description'?: string
     }>
   }
@@ -47,12 +50,16 @@ export class EIAPetroleumStatusReportFetcher extends Fetcher {
     const catInfo = CATEGORY_SERIES[query.category]
     if (!catInfo) throw new EmptyDataError(`Unknown category: ${query.category}`)
 
+    // EIA API v2 takes PHP-style bracket params, not JSON-encoded sort —
+    // see https://www.eia.gov/opendata/documentation.php. The JSON form
+    // is silently rejected with HTTP 403 on most endpoints.
     const params = new URLSearchParams({
       api_key: apiKey,
       frequency: 'weekly',
       'data[0]': 'value',
       'facets[series][]': catInfo.series,
-      sort: JSON.stringify([{ column: 'period', direction: 'desc' }]),
+      'sort[0][column]': 'period',
+      'sort[0][direction]': 'desc',
       length: '260', // ~5 years of weekly data
     })
 
@@ -65,9 +72,11 @@ export class EIAPetroleumStatusReportFetcher extends Fetcher {
     const results: Record<string, unknown>[] = []
     for (const obs of data.response?.data ?? []) {
       if (obs.value == null) continue
+      const value = typeof obs.value === 'string' ? parseFloat(obs.value) : obs.value
+      if (Number.isNaN(value)) continue
       results.push({
         date: obs.period,
-        value: obs.value,
+        value,
         category: query.category,
         unit: catInfo.unit,
       })

--- a/packages/opentypebb/src/providers/eia/models/short-term-energy-outlook.ts
+++ b/packages/opentypebb/src/providers/eia/models/short-term-energy-outlook.ts
@@ -27,7 +27,10 @@ interface EiaSteoResponse {
   response?: {
     data?: Array<{
       period: string
-      value: number | null
+      // EIA API serialises numeric observations as strings ("75.10"), with
+      // null only for missing periods. Coerce in extractData; the schema
+      // expects number.
+      value: string | number | null
       seriesDescription?: string
     }>
   }
@@ -46,12 +49,16 @@ export class EIAShortTermEnergyOutlookFetcher extends Fetcher {
     const catInfo = CATEGORY_SERIES[query.category]
     if (!catInfo) throw new EmptyDataError(`Unknown STEO category: ${query.category}`)
 
+    // EIA API v2 takes PHP-style bracket params, not JSON-encoded sort —
+    // see https://www.eia.gov/opendata/documentation.php. The JSON form
+    // is silently rejected with HTTP 403 on most endpoints.
     const params = new URLSearchParams({
       api_key: apiKey,
       frequency: 'monthly',
       'data[0]': 'value',
       'facets[seriesId][]': catInfo.series,
-      sort: JSON.stringify([{ column: 'period', direction: 'desc' }]),
+      'sort[0][column]': 'period',
+      'sort[0][direction]': 'desc',
       length: '120', // ~10 years of monthly data
     })
 
@@ -68,9 +75,11 @@ export class EIAShortTermEnergyOutlookFetcher extends Fetcher {
     const results: Record<string, unknown>[] = []
     for (const obs of data.response?.data ?? []) {
       if (obs.value == null) continue
+      const value = typeof obs.value === 'string' ? parseFloat(obs.value) : obs.value
+      if (Number.isNaN(value)) continue
       results.push({
         date: `${obs.period}-01`,
-        value: obs.value,
+        value,
         category: query.category,
         unit: catInfo.unit,
         forecast: obs.period > currentPeriod,

--- a/packages/opentypebb/src/providers/federal_reserve/utils/fred-helpers.ts
+++ b/packages/opentypebb/src/providers/federal_reserve/utils/fred-helpers.ts
@@ -9,6 +9,7 @@ import { amakeRequest } from '../../../core/provider/utils/helpers.js'
 import { EmptyDataError } from '../../../core/provider/utils/errors.js'
 
 const FRED_BASE = 'https://api.stlouisfed.org/fred'
+const GEOFRED_BASE = 'https://api.stlouisfed.org/geofred'
 
 export interface FredObservation {
   date: string
@@ -27,13 +28,17 @@ export interface FredSeriesInfo {
 
 /**
  * Build a FRED API URL with common parameters.
+ *
+ * Pass `base` to target a sibling API tree on api.stlouisfed.org —
+ * GeoFRED is at /geofred/... (no /fred/ prefix), not under /fred/geofred/.
  */
 function buildFredUrl(
   endpoint: string,
   params: Record<string, string | number | undefined>,
   apiKey: string,
+  base: string = FRED_BASE,
 ): string {
-  const url = new URL(`${FRED_BASE}/${endpoint}`)
+  const url = new URL(`${base}/${endpoint}`)
   url.searchParams.set('file_type', 'json')
   if (apiKey) url.searchParams.set('api_key', apiKey)
   for (const [k, v] of Object.entries(params)) {
@@ -46,6 +51,13 @@ function buildFredUrl(
 
 /**
  * Fetch observations for a single FRED series.
+ *
+ * When the caller supplies `limit` without an explicit start date,
+ * "limit N" means "the latest N observations" — fetch desc and reverse
+ * to ascending so downstream date-based merges keep working. Asking
+ * upstream desc + reversing is what aligns with the OpenBB Python
+ * upstream and with user intuition; the prior asc default returned
+ * 1946-era observations for any limited query without an anchor date.
  */
 export async function fetchFredSeries(
   seriesId: string,
@@ -59,18 +71,23 @@ export async function fetchFredSeries(
     units?: string
   } = {},
 ): Promise<FredObservation[]> {
+  const sortOrder = opts.sortOrder ?? 'desc'
   const url = buildFredUrl('series/observations', {
     series_id: seriesId,
     observation_start: opts.startDate ?? undefined,
     observation_end: opts.endDate ?? undefined,
     limit: opts.limit,
-    sort_order: opts.sortOrder ?? 'asc',
+    sort_order: sortOrder,
     frequency: opts.frequency,
     units: opts.units,
   }, apiKey)
 
   const data = await amakeRequest<{ observations?: FredObservation[] }>(url)
-  return (data.observations ?? []).filter(o => o.value !== '.')
+  const observations = (data.observations ?? []).filter(o => o.value !== '.')
+  // Caller-facing contract is ascending. If the upstream call ran desc,
+  // reverse before returning so multiSeriesToRecords' localeCompare and
+  // any date-ordered consumer keeps the same shape as before.
+  return sortOrder === 'desc' ? observations.reverse() : observations
 }
 
 /**
@@ -151,9 +168,14 @@ export async function fredReleaseTableApi(
 
 /**
  * Fetch FRED regional/GeoFRED data.
+ *
+ * GeoFRED lives at api.stlouisfed.org/geofred/... — a sibling tree of
+ * /fred/, not a child. The endpoint takes `series_id` (e.g. WIPCPI for
+ * per-capita income), and returns data nested under `meta.data`, keyed
+ * by observation date.
  */
 export async function fredRegionalApi(
-  seriesGroup: string,
+  seriesId: string,
   apiKey: string,
   opts: {
     regionType?: string
@@ -165,8 +187,8 @@ export async function fredRegionalApi(
     transformationCode?: string
   } = {},
 ): Promise<Record<string, unknown>[]> {
-  const url = buildFredUrl('geofred/series/data', {
-    series_group: seriesGroup,
+  const url = buildFredUrl('series/data', {
+    series_id: seriesId,
     region_type: opts.regionType ?? 'state',
     date: opts.date,
     start_date: opts.startDate,
@@ -174,14 +196,15 @@ export async function fredRegionalApi(
     units: opts.units,
     frequency: opts.frequency,
     transformation: opts.transformationCode,
-  }, apiKey)
+  }, apiKey, GEOFRED_BASE)
 
-  const data = await amakeRequest<{ meta?: Record<string, unknown>; data?: Record<string, unknown> }>(url)
-  if (!data.data) return []
+  const data = await amakeRequest<{ meta?: { data?: Record<string, unknown> } }>(url)
+  const dataMap = data.meta?.data
+  if (!dataMap) return []
 
-  // GeoFRED returns { data: { "2024-01-01": [{ region: ..., value: ... }, ...] } }
+  // GeoFRED returns { meta: { data: { "2024-01-01": [{ region, code, value, series_id }, ...] } } }
   const results: Record<string, unknown>[] = []
-  for (const [date, regions] of Object.entries(data.data)) {
+  for (const [date, regions] of Object.entries(dataMap)) {
     if (Array.isArray(regions)) {
       for (const region of regions) {
         results.push({ date, ...(region as Record<string, unknown>) })
@@ -214,8 +237,17 @@ export function multiSeriesToRecords(
 }
 
 /**
- * Get credentials helper — extracts FRED API key.
+ * Get credentials helper — extracts the FRED API key.
+ *
+ * The SDK path delivers the key as `federal_reserve_api_key` (the
+ * provider-prefixed form, see Provider constructor). Older callers
+ * and direct helper invocations may still pass `fred_api_key` or
+ * `api_key`; keep them as fallback so this helper stays compatible
+ * with both call sites.
  */
 export function getFredApiKey(credentials: Record<string, string> | null): string {
-  return credentials?.fred_api_key ?? credentials?.api_key ?? ''
+  return credentials?.federal_reserve_api_key
+      ?? credentials?.fred_api_key
+      ?? credentials?.api_key
+      ?? ''
 }

--- a/packages/opentypebb/src/standard-models/fred-regional.ts
+++ b/packages/opentypebb/src/standard-models/fred-regional.ts
@@ -6,7 +6,7 @@
 import { z } from 'zod'
 
 export const FredRegionalQueryParamsSchema = z.object({
-  symbol: z.string().describe('FRED series group ID for GeoFRED data.'),
+  symbol: z.string().describe('FRED regional series ID (e.g. WIPCPI for per-capita personal income).'),
   region_type: z.string().default('state').describe('Region type: state, msa, county, etc.'),
   date: z.string().nullable().default(null).describe('Observation date in YYYY-MM-DD.'),
   start_date: z.string().nullable().default(null).describe('Start date for data range.'),

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { readFile, writeFile, mkdir, unlink } from 'fs/promises'
+import { readFile, writeFile, mkdir, unlink, rm } from 'fs/promises'
 import { resolve } from 'path'
 import { newsCollectorSchema } from '../domain/news/config.js'
 
@@ -287,6 +287,18 @@ export const utaConfigSchema = z.object({
   guards: z.array(guardConfigSchema).default([]),
   /** User-filled form values, validated against the preset's own zodSchema. */
   presetConfig: z.record(z.string(), z.unknown()).default({}),
+  /**
+   * Test/throwaway UTA — purged at every server startup (config entry
+   * removed + `data/trading/<id>/` wiped) and dropped immediately when
+   * deleted via the UTA-config DELETE endpoint. For fixture-based testing:
+   * each session starts from a clean slate, no cross-session cost-basis
+   * pollution. Only allowed on `mock-simulator` preset; setting it on a
+   * real broker would silently destroy account history on next boot.
+   */
+  ephemeral: z.boolean().optional(),
+}).refine((u) => u.ephemeral !== true || u.presetId === 'mock-simulator', {
+  message: 'ephemeral: true is only allowed on mock-simulator UTAs (would destroy real broker history at next boot)',
+  path: ['ephemeral'],
 })
 
 export const utasFileSchema = z.array(utaConfigSchema)
@@ -675,6 +687,40 @@ export async function writeUTAsConfig(utas: UTAConfig[]): Promise<void> {
   const validated = utasFileSchema.parse(utas)
   await mkdir(CONFIG_DIR, { recursive: true })
   await writeFile(resolve(CONFIG_DIR, 'accounts.json'), JSON.stringify(validated, null, 2) + '\n')
+}
+
+/**
+ * Wipe a UTA's persistent trading state (`data/trading/<id>/`). Used when
+ * destroying ephemeral UTAs — boot-time purge AND mid-session DELETE both
+ * funnel here so commit history / snapshots don't outlive the UTA.
+ *
+ * No-op if the directory doesn't exist; never touches `data/config/`.
+ */
+export async function wipeUTATradingData(id: string): Promise<void> {
+  const dir = resolve('data', 'trading', id)
+  await rm(dir, { recursive: true, force: true })
+}
+
+/**
+ * Purge ephemeral UTAs at server startup: remove their entries from
+ * `accounts.json` AND wipe their `data/trading/<id>/` dirs. Called once
+ * from the boot path before UTAManager starts initializing UTAs, so
+ * ephemeral residue from the previous session never reaches the manager.
+ *
+ * Returns the surviving non-ephemeral UTAs (caller iterates these for
+ * normal init).
+ */
+export async function purgeEphemeralUTAs(utas: UTAConfig[]): Promise<UTAConfig[]> {
+  const ephemeral = utas.filter((u) => u.ephemeral === true)
+  if (ephemeral.length === 0) return utas
+
+  for (const u of ephemeral) {
+    console.log(`startup: purging ephemeral UTA ${u.id}${u.label ? ` (${u.label})` : ''}`)
+    await wipeUTATradingData(u.id)
+  }
+  const survivors = utas.filter((u) => u.ephemeral !== true)
+  await writeUTAsConfig(survivors)
+  return survivors
 }
 
 // ==================== Hot-read helpers ====================

--- a/src/domain/market-data/__test__/e2e/market-data.e2e.spec.ts
+++ b/src/domain/market-data/__test__/e2e/market-data.e2e.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Market-data e2e — FRED end-to-end via webui routes.
+ *
+ * Reproduces the actual path users hit: webui route → bbEngine → fetcher
+ * → live FRED API. bbProvider specs only cover the inner fetcher slice
+ * and miss the credential-mapping / route-wiring layer where the
+ * community-reported "fred 配不下来" failure modes live.
+ *
+ * Run: pnpm test:e2e
+ * Skips if OpenAlice config has no `fred` key configured.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { getTestApp, hasProviderKey, getJson, postJson, type TestApp } from './setup.js'
+
+let t: TestApp
+beforeAll(async () => { t = await getTestApp() })
+
+describe('market-data e2e — FRED via webui routes', () => {
+  beforeEach(({ skip }) => { if (!hasProviderKey(t.config, 'fred')) skip('no fred key in config') })
+
+  it('test-provider endpoint reports ok for valid fred key', async () => {
+    // Reproduces "前端 Test Connection" button. Catches the provider
+    // name mismatch (config.ts:157 used 'fred', registry has 'federal_reserve')
+    // and the credential field-name mismatch in one shot.
+    const key = t.config.marketData.providerKeys!.fred!
+    const r = await postJson(t.app, '/api/market-data/test-provider', { provider: 'fred', key })
+    expect(r.status).toBe(200)
+    if (!r.data.ok) console.log('  test-provider error:', r.data.error)
+    expect(r.data.ok).toBe(true)
+  })
+
+  it('fred_search via opentypebb route returns matching series', async () => {
+    // Reproduces AI tool call path. Catches credential-not-flowing-through.
+    const rows = await getJson(t.app, '/api/market-data-v1/economy/fred_search?provider=federal_reserve&query=GDP&limit=3')
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows[0]).toHaveProperty('series_id')
+    console.log(`  fred_search top hit: ${rows[0].series_id} — ${rows[0].title}`)
+  })
+
+  it('fred_series limit=5 returns latest data, not 1946', async () => {
+    // Catches the asc-by-default + limit regression (returned 1946-1950 era data
+    // because FRED API defaults to ascending sort).
+    const rows = await getJson(t.app, '/api/market-data-v1/economy/fred_series?provider=federal_reserve&symbol=GDP&limit=5')
+    expect(rows.length).toBe(5)
+    const lastDate = new Date(rows[rows.length - 1].date)
+    expect(lastDate.getFullYear()).toBeGreaterThanOrEqual(2025)
+    console.log(`  GDP latest: ${rows[rows.length - 1].date} = ${rows[rows.length - 1].GDP}`)
+  })
+
+  it('fred_series multi-symbol returns rows with both columns populated', async () => {
+    // Catches the same asc bug indirectly — with old asc default, GDP (from 1947)
+    // and UNRATE (from 1948) latest-N timestamps had near-zero overlap, so
+    // merged rows were almost always single-column. With desc default,
+    // both series share the same recent dates.
+    const rows = await getJson(t.app, '/api/market-data-v1/economy/fred_series?provider=federal_reserve&symbol=GDP,UNRATE&limit=5')
+    expect(rows.length).toBeGreaterThan(0)
+    const hasBoth = rows.some(r => r.GDP != null && r.UNRATE != null)
+    expect(hasBoth).toBe(true)
+  })
+
+  it('fred_regional returns state-level rows', async () => {
+    // Catches all three GeoFRED bugs: wrong base URL prefix, wrong param
+    // name (series_group → series_id), wrong response parse path
+    // (data.data → data.meta.data). Any one wrong → 0 rows or 404.
+    const rows = await getJson(t.app, '/api/market-data-v1/economy/fred_regional?provider=federal_reserve&symbol=WIPCPI&date=2024-01-01')
+    expect(rows.length).toBeGreaterThanOrEqual(50)  // 50 states + DC + territories
+    expect(rows[0]).toHaveProperty('region')
+    expect(rows[0]).toHaveProperty('value')
+    const ca = rows.find(r => r.region === 'California')
+    if (ca) console.log(`  California 2024 per-capita personal income: $${ca.value}`)
+  })
+})

--- a/src/domain/market-data/__test__/e2e/market-data.e2e.spec.ts
+++ b/src/domain/market-data/__test__/e2e/market-data.e2e.spec.ts
@@ -71,3 +71,50 @@ describe('market-data e2e — FRED via webui routes', () => {
     if (ca) console.log(`  California 2024 per-capita personal income: $${ca.value}`)
   })
 })
+
+// EIA endpoints sit under /commodity/* (OpenBB upstream classification),
+// not /economy/*. Provider must be explicit because the commodity asset
+// class default provider is yfinance, which has no EIA fetchers.
+describe('market-data e2e — EIA via webui routes', () => {
+  beforeEach(({ skip }) => { if (!hasProviderKey(t.config, 'eia')) skip('no eia key in config') })
+
+  it('test-provider endpoint reports ok for valid eia key', async () => {
+    // Catches the same class of bugs FRED had: provider name + cred field
+    // alignment. EIA had its own twist — declared `credentials: ['eia_api_key']`
+    // (already prefixed) so the constructor double-prefixed to `eia_eia_api_key`.
+    const key = t.config.marketData.providerKeys!.eia!
+    const r = await postJson(t.app, '/api/market-data/test-provider', { provider: 'eia', key })
+    expect(r.status).toBe(200)
+    if (!r.data.ok) console.log('  test-provider error:', r.data.error)
+    expect(r.data.ok).toBe(true)
+  })
+
+  it('short_term_energy_outlook returns recent + forecast rows', async () => {
+    // STEO returns ~10 years of monthly data, mixing observed and forecast.
+    // Catches: PHP-bracket sort param (was JSON.stringify, EIA returned 403);
+    // string→number coercion of `value` (EIA wire format is string).
+    const rows = await getJson(
+      t.app,
+      '/api/market-data-v1/commodity/short_term_energy_outlook?provider=eia&category=crude_oil_price',
+    )
+    expect(rows.length).toBeGreaterThan(60)
+    expect(typeof rows[0].value).toBe('number')
+    const hasForecast = rows.some(r => r.forecast === true)
+    expect(hasForecast).toBe(true)
+    const last = rows[rows.length - 1]
+    console.log(`  STEO crude oil price latest: ${last.date} = $${last.value} (forecast=${last.forecast})`)
+  })
+
+  it('petroleum_status_report returns weekly inventory rows', async () => {
+    const rows = await getJson(
+      t.app,
+      '/api/market-data-v1/commodity/petroleum_status_report?provider=eia&category=crude_oil_stocks',
+    )
+    expect(rows.length).toBeGreaterThan(50)  // ~5 years of weekly data
+    expect(typeof rows[0].value).toBe('number')
+    const last = rows[rows.length - 1]
+    const lastDate = new Date(last.date)
+    expect(lastDate.getFullYear()).toBeGreaterThanOrEqual(2025)
+    console.log(`  Crude oil stocks latest: ${last.date} = ${last.value} ${last.unit}`)
+  })
+})

--- a/src/domain/market-data/__test__/e2e/setup.ts
+++ b/src/domain/market-data/__test__/e2e/setup.ts
@@ -1,0 +1,99 @@
+/**
+ * Market-data e2e setup — shared, lazily-initialized Hono app + executor.
+ *
+ * Mirrors src/domain/trading/__test__/e2e/setup.ts:62-71's lazy-singleton
+ * pattern but for the read-only market-data surface. Builds a minimal
+ * Hono app that mounts the same routes the real webui plugin mounts, so
+ * specs can hit them via app.request() — reproducing the path that
+ * "前端点 Test Connection" / "AI 调 fred_search 工具" actually walks
+ * (webui route → bbEngine → fetcher → live API), not just the inner
+ * fetcher slice that bbProvider specs cover.
+ *
+ * Read-only by construction; no isPaper() guard is needed (unlike trading
+ * e2e where MockBroker / paper account safety is critical).
+ */
+
+import { Hono } from 'hono'
+import { loadConfig, type Config } from '@/core/config.js'
+import { buildSDKCredentials } from '@/domain/market-data/credential-map.js'
+import { createExecutor, type QueryExecutor } from '@traderalice/opentypebb'
+import { mountOpenTypeBB } from '@/server/opentypebb.js'
+import { createMarketDataRoutes } from '@/webui/routes/config.js'
+import type { EngineContext } from '@/core/types.js'
+
+export interface TestApp {
+  app: Hono
+  config: Config
+  executor: QueryExecutor
+  /** SDK-shaped credentials (after buildSDKCredentials transform). */
+  credentials: Record<string, string>
+}
+
+let cached: Promise<TestApp> | null = null
+
+/** Get the shared TestApp. First call loads config + mounts routes. */
+export function getTestApp(): Promise<TestApp> {
+  if (!cached) cached = init()
+  return cached
+}
+
+async function init(): Promise<TestApp> {
+  const config = await loadConfig()
+  const executor = createExecutor()
+  const credentials = buildSDKCredentials(config.marketData.providerKeys)
+
+  // createMarketDataRoutes only reads ctx.bbEngine — pass a partial ctx
+  // shape with only the fields it needs.
+  const ctx = { bbEngine: executor, config } as unknown as EngineContext
+
+  const app = new Hono()
+  app.route('/api/market-data', createMarketDataRoutes(ctx))
+  mountOpenTypeBB(app, executor, {
+    basePath: '/api/market-data-v1',
+    defaultCredentials: () => credentials,
+    defaultProviders: () => config.marketData.providers,
+  })
+
+  return { app, config, executor, credentials }
+}
+
+/**
+ * Check whether OpenAlice config has a key configured for a given user-key
+ * provider name (`fred`, `fmp`, …) — i.e. the field as the user types it
+ * in the Settings UI, not the SDK-prefixed form.
+ */
+export function hasProviderKey(config: Config, userKey: string): boolean {
+  const keys = config.marketData.providerKeys as Record<string, string | undefined> | undefined
+  return !!keys?.[userKey]
+}
+
+// ==================== Hono app.request helpers ====================
+
+/**
+ * GET an opentypebb-mounted route and unwrap the OpenBB-style envelope.
+ * opentypebb returns `{ results, provider, warnings, chart, extra, error? }`.
+ */
+export async function getJson(app: Hono, path: string): Promise<any[]> {
+  const res = await app.request(path)
+  if (res.status !== 200) {
+    const body = await res.text()
+    throw new Error(`GET ${path} → ${res.status}: ${body}`)
+  }
+  const body = await res.json() as { results?: unknown[]; error?: string }
+  if (body.error) throw new Error(`GET ${path} → 200 with error: ${body.error}`)
+  return (body.results ?? []) as any[]
+}
+
+/** POST a JSON body, return { status, data }. */
+export async function postJson(
+  app: Hono,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; data: any }> {
+  const res = await app.request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return { status: res.status, data: await res.json() }
+}

--- a/src/domain/market-data/__tests__/credential-map.spec.ts
+++ b/src/domain/market-data/__tests__/credential-map.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * credential-map — pinning the two-table contract.
+ *
+ * The HTTP path (legacy Python OpenBB sidecar) and the SDK path
+ * (in-process opentypebb) want different field names for the same
+ * underlying user key. `fred` is the canonical example: HTTP wants
+ * `fred_api_key`, SDK wants `federal_reserve_api_key` (provider
+ * auto-prefix, see Provider constructor in the opentypebb package).
+ *
+ * If a future change merges these mappings back into one table, this
+ * test fails — and that's the point. The two-table split is intentional.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildSDKCredentials, buildCredentialsHeader } from '../credential-map.js'
+
+describe('buildSDKCredentials — in-process opentypebb path', () => {
+  it('maps fred → federal_reserve_api_key (provider name auto-prefix)', () => {
+    expect(buildSDKCredentials({ fred: 'k1' })).toEqual({ federal_reserve_api_key: 'k1' })
+  })
+
+  it('maps fmp → fmp_api_key (user key matches provider name)', () => {
+    expect(buildSDKCredentials({ fmp: 'k2' })).toEqual({ fmp_api_key: 'k2' })
+  })
+
+  it('maps multiple providers in one call', () => {
+    expect(buildSDKCredentials({ fred: 'k1', fmp: 'k2', bls: 'k3' })).toEqual({
+      federal_reserve_api_key: 'k1',
+      fmp_api_key: 'k2',
+      bls_api_key: 'k3',
+    })
+  })
+
+  it('returns {} for undefined input', () => {
+    expect(buildSDKCredentials(undefined)).toEqual({})
+  })
+
+  it('skips entries with empty/undefined values', () => {
+    expect(buildSDKCredentials({ fred: undefined, fmp: '' })).toEqual({})
+  })
+
+  it('skips unknown provider keys', () => {
+    expect(buildSDKCredentials({ fred: 'k1', unknown_provider: 'k2' })).toEqual({
+      federal_reserve_api_key: 'k1',
+    })
+  })
+})
+
+describe('buildCredentialsHeader — legacy Python sidecar HTTP path', () => {
+  it('still maps fred → fred_api_key (Python OpenBB contract, intentional divergence from SDK path)', () => {
+    expect(buildCredentialsHeader({ fred: 'k1' })).toBe(JSON.stringify({ fred_api_key: 'k1' }))
+  })
+
+  it('returns undefined when no keys are configured', () => {
+    expect(buildCredentialsHeader(undefined)).toBeUndefined()
+    expect(buildCredentialsHeader({})).toBeUndefined()
+    expect(buildCredentialsHeader({ fred: undefined })).toBeUndefined()
+  })
+
+  it('maps multiple providers into one JSON object', () => {
+    const header = buildCredentialsHeader({ fred: 'k1', fmp: 'k2' })
+    expect(JSON.parse(header!)).toEqual({ fred_api_key: 'k1', fmp_api_key: 'k2' })
+  })
+})
+
+describe('two-table contract — divergence is intentional', () => {
+  it('fred maps to different field names on each path', () => {
+    // HTTP: legacy Python OpenBB sidecar expects `fred_api_key`
+    expect(JSON.parse(buildCredentialsHeader({ fred: 'k' })!)).toEqual({ fred_api_key: 'k' })
+    // SDK: in-process opentypebb expects provider-prefixed `federal_reserve_api_key`
+    expect(buildSDKCredentials({ fred: 'k' })).toEqual({ federal_reserve_api_key: 'k' })
+  })
+})

--- a/src/domain/market-data/client/types.ts
+++ b/src/domain/market-data/client/types.ts
@@ -26,7 +26,7 @@ import type {
   FuturesHistoricalData, FuturesCurveData, FuturesInfoData, FuturesInstrumentsData,
   OptionsChainsData, OptionsSnapshotsData, OptionsUnusualData,
   // Commodity
-  CommoditySpotPriceData,
+  CommoditySpotPriceData, PetroleumStatusReportData, ShortTermEnergyOutlookData,
   // Economy (FRED)
   FredSearchData, FredSeriesData, FredRegionalData,
 } from '@traderalice/opentypebb'
@@ -82,6 +82,12 @@ export interface IndexClientLike {
 
 export interface CommodityClientLike {
   getSpotPrices(params: Record<string, unknown>): Promise<CommoditySpotPriceData[]>
+  // EIA endpoints — semantically macro/economy data, but OpenBB upstream
+  // routes them under /commodity/* (output is oil/gas prices + inventories).
+  // The SDK clients carry them; the tool layer surfaces them under
+  // tool/economy.ts so AI agents see one coherent macro namespace.
+  getPetroleumStatus(params: Record<string, unknown>): Promise<PetroleumStatusReportData[]>
+  getEnergyOutlook(params: Record<string, unknown>): Promise<ShortTermEnergyOutlookData[]>
 }
 
 export interface EconomyClientLike {

--- a/src/domain/market-data/client/types.ts
+++ b/src/domain/market-data/client/types.ts
@@ -27,6 +27,8 @@ import type {
   OptionsChainsData, OptionsSnapshotsData, OptionsUnusualData,
   // Commodity
   CommoditySpotPriceData,
+  // Economy (FRED)
+  FredSearchData, FredSeriesData, FredRegionalData,
 } from '@traderalice/opentypebb'
 
 export interface EquityClientLike {
@@ -80,6 +82,12 @@ export interface IndexClientLike {
 
 export interface CommodityClientLike {
   getSpotPrices(params: Record<string, unknown>): Promise<CommoditySpotPriceData[]>
+}
+
+export interface EconomyClientLike {
+  fredSearch(params: Record<string, unknown>): Promise<FredSearchData[]>
+  fredSeries(params: Record<string, unknown>): Promise<FredSeriesData[]>
+  fredRegional(params: Record<string, unknown>): Promise<FredRegionalData[]>
 }
 
 export interface DerivativesClientLike {

--- a/src/domain/market-data/credential-map.ts
+++ b/src/domain/market-data/credential-map.ts
@@ -1,11 +1,25 @@
 /**
- * Maps OpenAlice provider key names to OpenBB credential field names.
+ * Maps OpenAlice provider key names to credential field names.
  *
- * OpenAlice config (openbb.json):   { "fred": "abc123" }
- * OpenBB expects:                   { "fred_api_key": "abc123" }
+ * Two paths, two tables — they look similar but the contracts diverge:
+ *
+ *   1. HTTP path (legacy Python OpenBB sidecar via X-OpenBB-Credentials header)
+ *      → field name follows OpenBB Python convention: `<user_key>_api_key`.
+ *   2. SDK path (in-process @traderalice/opentypebb)
+ *      → field name follows the provider's auto-prefixed credential
+ *      (`Provider` constructor at packages/opentypebb/src/core/provider/abstract/provider.ts:54-59
+ *      prepends the provider name to declared credentials, so e.g.
+ *      `federal_reserve` provider with `credentials: ['api_key']` ends up
+ *      requiring `federal_reserve_api_key`).
+ *
+ * For most providers the user-facing key matches the SDK provider name
+ * (fmp/bls/eia/...), so both tables agree. Only `fred` (user-key) ↔
+ * `federal_reserve` (provider-name) diverges — that's the row that has
+ * to differ. Keep the tables independent so future divergences (or
+ * provider-name renames) don't silently couple the two paths.
  */
 
-const keyMapping: Record<string, string> = {
+const httpKeyMapping: Record<string, string> = {
   fred: 'fred_api_key',
   fmp: 'fmp_api_key',
   eia: 'eia_api_key',
@@ -19,37 +33,52 @@ const keyMapping: Record<string, string> = {
   biztoc: 'biztoc_api_key',
 }
 
+const sdkKeyMapping: Record<string, string> = {
+  fred: 'federal_reserve_api_key',  // user-key ≠ provider-name; SDK path needs provider-prefixed name
+  fmp: 'fmp_api_key',
+  eia: 'eia_api_key',
+  bls: 'bls_api_key',
+  nasdaq: 'nasdaq_api_key',
+  tradingeconomics: 'tradingeconomics_api_key',
+  econdb: 'econdb_api_key',
+  intrinio: 'intrinio_api_key',
+  benzinga: 'benzinga_api_key',
+  tiingo: 'tiingo_token',
+  biztoc: 'biztoc_api_key',
+}
+
+function applyMapping(
+  providerKeys: Record<string, string | undefined> | undefined,
+  table: Record<string, string>,
+): Record<string, string> {
+  if (!providerKeys) return {}
+  const mapped: Record<string, string> = {}
+  for (const [k, v] of Object.entries(providerKeys)) {
+    if (v && table[k]) mapped[table[k]] = v
+  }
+  return mapped
+}
+
 /**
- * Build the JSON string for the X-OpenBB-Credentials header.
+ * Build the JSON string for the X-OpenBB-Credentials header (legacy
+ * Python OpenBB sidecar HTTP path).
  * Returns undefined if no keys are configured.
  */
 export function buildCredentialsHeader(
   providerKeys: Record<string, string | undefined> | undefined,
 ): string | undefined {
-  if (!providerKeys) return undefined
-
-  const mapped: Record<string, string> = {}
-  for (const [k, v] of Object.entries(providerKeys)) {
-    if (v && keyMapping[k]) mapped[keyMapping[k]] = v
-  }
-
+  const mapped = applyMapping(providerKeys, httpKeyMapping)
   return Object.keys(mapped).length > 0 ? JSON.stringify(mapped) : undefined
 }
 
 /**
- * Build credentials object for OpenTypeBB SDK executor.
- * Same mapping as buildCredentialsHeader, but returns a plain object
- * instead of a JSON string (executor.execute() accepts Record<string, string>).
+ * Build credentials object for the in-process OpenTypeBB SDK executor.
+ * Field names follow the SDK's auto-prefixed credential convention
+ * (provider name + cred name) — see file header for why this differs
+ * from the HTTP header path.
  */
 export function buildSDKCredentials(
   providerKeys: Record<string, string | undefined> | undefined,
 ): Record<string, string> {
-  if (!providerKeys) return {}
-
-  const mapped: Record<string, string> = {}
-  for (const [k, v] of Object.entries(providerKeys)) {
-    if (v && keyMapping[k]) mapped[keyMapping[k]] = v
-  }
-
-  return mapped
+  return applyMapping(providerKeys, sdkKeyMapping)
 }

--- a/src/domain/trading/UnifiedTradingAccount.spec.ts
+++ b/src/domain/trading/UnifiedTradingAccount.spec.ts
@@ -797,6 +797,36 @@ describe('UTA — getPositions wallet reconciliation', () => {
     expect(positions[0].unrealizedPnL).toBe('100')
   })
 
+  it('bootstraps at broker-reported avgCost when it differs from markPrice', async () => {
+    // Mock externalTrade scenario: broker observed a real fill at $148.50,
+    // current mark is $152. Bootstrap should use the trade price, not mark
+    // — otherwise we destroy the broker's correct cost basis on first sight
+    // (covered call test surfaced this 2026-05-07: AAPL bought at $148.50,
+    // mark at $152, UI showed avgCost=$152 / PnL=0 instead of avgCost=$148.50
+    // / PnL=+$350).
+    const broker = new MockBroker()
+    broker.setPositions([makePosition({
+      contract: makeContract({ symbol: 'AAPL', secType: 'STK' }),
+      quantity: new Decimal('100'),
+      avgCost: '148.50',           // broker has the real trade price
+      marketPrice: '152',          // mark moved up
+      unrealizedPnL: '0',
+      avgCostSource: 'wallet',
+    })])
+    const { uta } = createUTA(broker)
+
+    const positions = await uta.getPositions()
+    expect(new Decimal(positions[0].avgCost).toNumber()).toBeCloseTo(148.50, 4)
+    expect(new Decimal(positions[0].unrealizedPnL).toNumber()).toBeCloseTo(350, 4)
+
+    // Reconcile commit recorded the drift at the trade price, not markPrice.
+    const commits = uta.git.exportState().commits
+    const reconciles = commits.filter(c => c.operations.some(op => op.action === 'reconcileBalance'))
+    expect(reconciles).toHaveLength(1)
+    const op = reconciles[0].operations[0] as Extract<Operation, { action: 'reconcileBalance' }>
+    expect(new Decimal(op.markPrice).toNumber()).toBeCloseTo(148.50, 4)
+  })
+
   it('bootstraps a wallet position with no history → reconcile at markPrice, PnL=0', async () => {
     const broker = new MockBroker()
     broker.setPositions([makePosition({

--- a/src/domain/trading/UnifiedTradingAccount.ts
+++ b/src/domain/trading/UnifiedTradingAccount.ts
@@ -545,10 +545,18 @@ export class UnifiedTradingAccount {
       // Tolerance: dust-level differences (sub-1e-8) come from precision
       // round-trips, not from real balance changes.
       if (drift.abs().gt(new Decimal('1e-8'))) {
+        // Bootstrap price: prefer broker-reported avgCost when non-zero
+        // (Mock externalTrade, future CCXT-with-fetchMyTrades, anything
+        // that observed a real fill price). Fall back to markPrice only
+        // when the broker has nothing — current CCXT spot synthesis sets
+        // avgCost equal to markPrice anyway, so the fallback case
+        // produces identical behavior there.
+        const brokerAvgCost = p.avgCost ? new Decimal(p.avgCost) : new Decimal(0)
+        const bootstrapPrice = brokerAvgCost.gt(0) ? brokerAvgCost : new Decimal(p.marketPrice)
         await this.git.recordReconcile({
           aliceId,
           quantityDelta: drift,
-          markPrice: new Decimal(p.marketPrice),
+          markPrice: bootstrapPrice,
           stateAfter: this._buildReconcileStateAfter(positions),
         })
       }

--- a/src/domain/trading/__test__/e2e/ccxt-bybit.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/ccxt-bybit.e2e.spec.ts
@@ -50,14 +50,14 @@ describe('CcxtBroker — Bybit e2e', () => {
 
     const results = await b().searchContracts('ETH')
     expect(results.length).toBeGreaterThan(0)
-    const perp = results.find(r => r.contract.localSymbol?.includes('USDT:USDT'))
+    const perp = results.find(r => r.contract.secType === 'CRYPTO_PERP')
     expect(perp).toBeDefined()
     console.log(`  found ${results.length} ETH contracts, perp: ${perp!.contract.localSymbol}`)
   })
 
   it('places market buy 0.01 ETH → execution returned', async ({ skip }) => {
     const matches = await b().searchContracts('ETH')
-    const ethPerp = matches.find(m => m.contract.localSymbol?.includes('USDT:USDT'))
+    const ethPerp = matches.find(m => m.contract.secType === 'CRYPTO_PERP')
     if (!ethPerp) return skip('ETH/USDT perp not found')
 
     // Diagnostic: see raw CCXT createOrder response
@@ -100,7 +100,7 @@ describe('CcxtBroker — Bybit e2e', () => {
 
   it('closes ETH position with reduceOnly', async ({ skip }) => {
     const matches = await b().searchContracts('ETH')
-    const ethPerp = matches.find(m => m.contract.localSymbol?.includes('USDT:USDT'))
+    const ethPerp = matches.find(m => m.contract.secType === 'CRYPTO_PERP')
     if (!ethPerp) return skip('ETH/USDT perp not found')
 
     const result = await b().closePosition(ethPerp.contract, new Decimal('0.01'))
@@ -111,7 +111,7 @@ describe('CcxtBroker — Bybit e2e', () => {
   it('queries order by ID', async ({ skip }) => {
     // Place a small order to get an orderId
     const matches = await b().searchContracts('ETH')
-    const ethPerp = matches.find(m => m.contract.localSymbol?.includes('USDT:USDT'))
+    const ethPerp = matches.find(m => m.contract.secType === 'CRYPTO_PERP')
     if (!ethPerp) return skip('ETH/USDT perp not found')
 
     const order = new Order()
@@ -139,7 +139,7 @@ describe('CcxtBroker — Bybit e2e', () => {
 
   it('places order with TPSL and reads back tpsl from getOrder', async ({ skip }) => {
     const matches = await b().searchContracts('ETH')
-    const ethPerp = matches.find(m => m.contract.localSymbol?.includes('USDT:USDT'))
+    const ethPerp = matches.find(m => m.contract.secType === 'CRYPTO_PERP')
     if (!ethPerp) return skip('ETH/USDT perp not found')
 
     const order = new Order()
@@ -187,7 +187,7 @@ describe('CcxtBroker — Bybit e2e', () => {
     // Place a stop-loss trigger order far from market price, then verify getOrder can see it.
     // This is the core scenario from issue #90.
     const matches = await b().searchContracts('ETH')
-    const ethPerp = matches.find(m => m.contract.localSymbol?.includes('USDT:USDT'))
+    const ethPerp = matches.find(m => m.contract.secType === 'CRYPTO_PERP')
     if (!ethPerp) return skip('ETH/USDT perp not found')
 
     // Open a small position first — stop-loss with reduceOnly needs an existing position

--- a/src/domain/trading/__test__/e2e/ccxt-hyperliquid.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/ccxt-hyperliquid.e2e.spec.ts
@@ -79,7 +79,7 @@ describe('CcxtBroker — Hyperliquid e2e', () => {
     const results = await b().searchContracts('BTC')
     expect(results.length).toBeGreaterThan(0)
     // Hyperliquid uses USDC as the perpetual settle currency
-    const perp = results.find(r => r.contract.localSymbol?.includes('USDC:USDC'))
+    const perp = results.find(r => r.contract.secType === 'CRYPTO_PERP')
     expect(perp, `BTC perp not found. Results: ${results.slice(0, 5).map(r => r.contract.localSymbol).join(', ')}`).toBeDefined()
     console.log(`  found ${results.length} BTC contracts, perp: ${perp!.contract.localSymbol}`)
   })
@@ -87,7 +87,7 @@ describe('CcxtBroker — Hyperliquid e2e', () => {
   it('searches ETH contracts and finds a perpetual', async () => {
     const results = await b().searchContracts('ETH')
     expect(results.length).toBeGreaterThan(0)
-    const perp = results.find(r => r.contract.localSymbol?.includes('USDC:USDC'))
+    const perp = results.find(r => r.contract.secType === 'CRYPTO_PERP')
     expect(perp).toBeDefined()
     console.log(`  found ${results.length} ETH contracts, perp: ${perp!.contract.localSymbol}`)
   })
@@ -96,7 +96,7 @@ describe('CcxtBroker — Hyperliquid e2e', () => {
 
   it('places market buy 0.001 BTC perp → execution returned', async ({ skip }) => {
     const matches = await b().searchContracts('BTC')
-    const btcPerp = matches.find(m => m.contract.localSymbol?.includes('USDC:USDC'))
+    const btcPerp = matches.find(m => m.contract.secType === 'CRYPTO_PERP')
     if (!btcPerp) return skip('BTC perp not found')
 
     // Hyperliquid minimum order value: $10. At ~$60k BTC, 0.001 = $60 (well above min).
@@ -130,7 +130,7 @@ describe('CcxtBroker — Hyperliquid e2e', () => {
 
   it('closes BTC position with reduceOnly', async ({ skip }) => {
     const matches = await b().searchContracts('BTC')
-    const btcPerp = matches.find(m => m.contract.localSymbol?.includes('USDC:USDC'))
+    const btcPerp = matches.find(m => m.contract.secType === 'CRYPTO_PERP')
     if (!btcPerp) return skip('BTC perp not found')
 
     const result = await b().closePosition(btcPerp.contract, new Decimal('0.001'))
@@ -140,7 +140,7 @@ describe('CcxtBroker — Hyperliquid e2e', () => {
 
   it('queries order by ID after place', async ({ skip }) => {
     const matches = await b().searchContracts('BTC')
-    const btcPerp = matches.find(m => m.contract.localSymbol?.includes('USDC:USDC'))
+    const btcPerp = matches.find(m => m.contract.secType === 'CRYPTO_PERP')
     if (!btcPerp) return skip('BTC perp not found')
 
     const order = new Order()

--- a/src/domain/trading/__test__/e2e/ccxt-okx.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/ccxt-okx.e2e.spec.ts
@@ -96,7 +96,7 @@ describe('CcxtBroker — OKX e2e', () => {
   it('searches ETH contracts and finds a perpetual', async () => {
     const results = await b().searchContracts('ETH')
     expect(results.length).toBeGreaterThan(0)
-    const perp = results.find(r => r.contract.localSymbol?.includes('USDT:USDT'))
+    const perp = results.find(r => r.contract.localSymbol === 'ETH/USDT:USDT')
     expect(perp).toBeDefined()
     console.log(`  found ${results.length} ETH contracts, perp: ${perp!.contract.localSymbol}`)
   })

--- a/src/domain/trading/__test__/e2e/uta-bybit.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/uta-bybit.e2e.spec.ts
@@ -28,7 +28,7 @@ describe('UTA — Bybit lifecycle (ETH perp)', () => {
     broker = bybit.broker
 
     const results = await broker.searchContracts('ETH')
-    const perp = results.find(r => r.contract.localSymbol?.includes('USDT:USDT'))
+    const perp = results.find(r => r.contract.secType === 'CRYPTO_PERP')
     if (!perp) {
       console.log('e2e: No ETH/USDT perp found, skipping')
       broker = null
@@ -46,7 +46,7 @@ describe('UTA — Bybit lifecycle (ETH perp)', () => {
   it('buy → sync → verify → close → sync → verify', async () => {
     // Record initial state
     const initialPositions = await broker!.getPositions()
-    const initialEthQty = initialPositions.find(p => p.contract.localSymbol?.includes('USDT:USDT'))?.quantity.toNumber() ?? 0
+    const initialEthQty = initialPositions.find(p => p.contract.secType === 'CRYPTO_PERP')?.quantity.toNumber() ?? 0
     console.log(`  initial ETH qty=${initialEthQty}`)
 
     // === Stage + Commit + Push: buy 0.01 ETH ===
@@ -108,7 +108,7 @@ describe('UTA — Bybit lifecycle (ETH perp)', () => {
 
     // === Verify: net change should be ~0 ===
     const finalPositions = await broker!.getPositions()
-    const finalEthQty = finalPositions.find(p => p.contract.localSymbol?.includes('USDT:USDT'))?.quantity.toNumber() ?? 0
+    const finalEthQty = finalPositions.find(p => p.contract.secType === 'CRYPTO_PERP')?.quantity.toNumber() ?? 0
     console.log(`  final ETH qty=${finalEthQty} (initial was ${initialEthQty})`)
     expect(Math.abs(finalEthQty - initialEthQty)).toBeLessThan(0.02)
 

--- a/src/domain/trading/__test__/e2e/uta-ccxt-bybit.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/uta-ccxt-bybit.e2e.spec.ts
@@ -28,7 +28,7 @@ describe('UTA — Bybit demo (ETH perp)', () => {
     broker = bybit.broker
 
     const results = await broker.searchContracts('ETH')
-    const perp = results.find(r => r.contract.localSymbol?.includes('USDT:USDT'))
+    const perp = results.find(r => r.contract.secType === 'CRYPTO_PERP')
     if (!perp) {
       console.log('e2e: No ETH/USDT perp found, skipping')
       broker = null
@@ -44,7 +44,7 @@ describe('UTA — Bybit demo (ETH perp)', () => {
 
   it('buy → sync → close → sync (full lifecycle)', async () => {
     const initialPositions = await broker!.getPositions()
-    const initialQty = initialPositions.find(p => p.contract.localSymbol?.includes('USDT:USDT'))?.quantity.toNumber() ?? 0
+    const initialQty = initialPositions.find(p => p.contract.secType === 'CRYPTO_PERP')?.quantity.toNumber() ?? 0
     console.log(`  initial ETH qty=${initialQty}`)
 
     // Stage + Commit + Push: buy 0.01 ETH
@@ -88,7 +88,7 @@ describe('UTA — Bybit demo (ETH perp)', () => {
 
     // Verify final qty
     const finalPositions = await broker!.getPositions()
-    const finalQty = finalPositions.find(p => p.contract.localSymbol?.includes('USDT:USDT'))?.quantity.toNumber() ?? 0
+    const finalQty = finalPositions.find(p => p.contract.secType === 'CRYPTO_PERP')?.quantity.toNumber() ?? 0
     expect(Math.abs(finalQty - initialQty)).toBeLessThan(0.02)
     console.log(`  final ETH qty=${finalQty} (initial=${initialQty})`)
 

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
@@ -1011,7 +1011,7 @@ describe('CcxtBroker — getPositions', () => {
     expect(btc.avgCost).toBe('60000')        // markPrice placeholder; UTA replaces via wallet ledger
     expect(btc.marketValue).toBe('30000')
     expect(btc.unrealizedPnL).toBe('0')
-    expect(btc.contract.localSymbol).toBe('BTC')       // canonical (no broker-flavored encoding)
+    expect(btc.contract.localSymbol).toBe('BTC/USDT')   // CCXT wire format (broker-native uniqueness)
     expect(btc.avgCostSource).toBe('wallet')           // signals UTA to reconstruct cost
   })
 
@@ -1111,10 +1111,11 @@ describe('CcxtBroker — getPositions', () => {
     const positions = await acc.getPositions()
     expect(positions).toHaveLength(2)
     // Distinct contract identities — same underlying, different products.
-    // Canonical localSymbols disambiguate without leaking CCXT wire format.
+    // CCXT wire format encodes the distinction directly (`:settle` suffix
+    // separates spot from perp, also USDC-margined from USDT-margined).
     const localSymbols = positions.map(p => p.contract.localSymbol)
-    expect(localSymbols).toContain('BTC')        // spot
-    expect(localSymbols).toContain('BTC-PERP')   // perp
+    expect(localSymbols).toContain('BTC/USDT')        // spot
+    expect(localSymbols).toContain('BTC/USDT:USDT')   // perp
   })
 
   it('falls back to per-symbol fetchTicker when fetchTickers throws', async () => {

--- a/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -34,7 +34,6 @@ import {
   makeOrderState,
   marketToContract,
   contractToCcxt,
-  canonicalLocalSymbol,
 } from './ccxt-contracts.js'
 import { fuzzyRankContracts } from '../fuzzy-rank.js'
 import {
@@ -328,24 +327,30 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
     // type "BTC" and expect every BTC market); substring / name hits show up
     // afterward so partial keywords (e.g. "tesl", "popcorn") still surface
     // something useful.
+    // Skip CCXT markets that fail strict contract validation (typically
+    // dated FUT/OPT entries with missing expiry or multiplier in the
+    // exchange's market metadata). One bad market shouldn't drop the
+    // entire search; surface a one-line warning so the gap is visible
+    // without being noisy.
     const ranked = fuzzyRankContracts(
-      candidates.map((m) => {
-        const c = marketToContract(m, this.exchangeName)
-        return { contract: c, base: m.base, quote: m.quote, name: m.id ?? m.symbol }
+      candidates.flatMap((m) => {
+        try {
+          const c = marketToContract(m, this.exchangeName)
+          return [{ contract: c, base: m.base, quote: m.quote, name: m.id ?? m.symbol }]
+        } catch (err) {
+          console.warn(`ccxt[${this.exchangeName}]: skipping market ${m.symbol}: ${err instanceof Error ? err.message : String(err)}`)
+          return []
+        }
       }),
       pattern,
     )
 
-    // Index by canonical localSymbol — that's what `marketToContract`
-    // emits onto each ranked hit's Contract, so this is the join key.
-    // (The CCXT wire `m.symbol` no longer appears on Contract.localSymbol
-    // post-Phase-3.)
-    const marketByCanonical = new Map<string, CcxtMarket>()
-    for (const m of candidates) marketByCanonical.set(canonicalLocalSymbol(m), m)
-
+    // Each ranked hit's Contract carries `localSymbol = market.symbol`
+    // (CCXT's wire format), so direct `markets[localSymbol]` lookup is
+    // the join key — matches the broker's own primary index.
     const derivativeTypes = new Set<string>()
     for (const desc of ranked) {
-      const m = marketByCanonical.get(desc.contract.localSymbol ?? '')
+      const m = desc.contract.localSymbol ? this.markets[desc.contract.localSymbol] : undefined
       if (!m) continue
       if (m.type === 'future') derivativeTypes.add('FUT')
       if (m.type === 'option') derivativeTypes.add('OPT')
@@ -880,9 +885,16 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
   }
 
   resolveNativeKey(nativeKey: string): Contract {
+    // CCXT's nativeKey IS the unified wire symbol (e.g. "BTC/USDT:USDT"),
+    // which is also the markets-table key. Direct lookup is the only
+    // path needed — no normalization, no reverse-mapping.
     const market = this.markets[nativeKey]
     if (market) return marketToContract(market, this.exchange.id)
-    // Fallback: construct minimal contract from symbol string
+
+    // Last-resort skeletal contract for an unknown nativeKey. Operations
+    // that need market metadata (placeOrder / getQuote / closePosition)
+    // will fail downstream — that's the loud failure we want rather than
+    // a silent half-broken contract.
     const c = new Contract()
     c.localSymbol = nativeKey
     c.symbol = nativeKey.split('/')[0] ?? nativeKey

--- a/src/domain/trading/brokers/ccxt/ccxt-contracts.spec.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-contracts.spec.ts
@@ -1,14 +1,14 @@
 /**
  * Tests for the CCXT-side contract translators.
  *
- * Phase 3 of the IBKR-as-truth refactor moved canonical localSymbol
- * generation here — these tests pin the per-secType formats so we don't
- * regress to dumping CCXT's wire format ("BTC/USDT:USDT") onto Contract.
+ * `marketToContract` writes CCXT's wire symbol (`market.symbol`) into
+ * `Contract.localSymbol` directly — that string is CCXT's own uniqueness
+ * primitive (encodes base/quote/settle) and feeds straight into
+ * `getNativeKey` → aliceId. No normalization across brokers.
  */
 
 import { describe, it, expect } from 'vitest'
 import {
-  canonicalLocalSymbol,
   marketToContract,
   contractToCcxt,
   ccxtTypeToSecType,
@@ -23,58 +23,50 @@ function makeMarket(overrides: Partial<CcxtMarket> & { type: CcxtMarket['type'];
   } as CcxtMarket
 }
 
-describe('canonicalLocalSymbol', () => {
-  it('spot → base only', () => {
-    expect(canonicalLocalSymbol(makeMarket({
-      type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT',
-    }))).toBe('BTC')
-  })
-
-  it('swap → base-PERP (no settle suffix, no quote)', () => {
-    expect(canonicalLocalSymbol(makeMarket({
-      type: 'swap', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT', settle: 'USDT',
-    }))).toBe('BTC-PERP')
-  })
-
-  it('dated future → base-FUT-YYYYMM from market.expiry epoch', () => {
-    expect(canonicalLocalSymbol(makeMarket({
-      type: 'future', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT-220929',
-      // 2022-09-29 UTC = 1664409600000
-      expiry: 1664409600000,
-    } as Partial<CcxtMarket> & { type: 'future'; base: string; quote: string; symbol: string }))).toBe('BTC-FUT-202209')
-  })
-
-  it('dated future without epoch — falls back to symbol tail', () => {
-    expect(canonicalLocalSymbol(makeMarket({
-      type: 'future', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT-220929',
-    }))).toBe('BTC-FUT-220929')
-  })
-
-  it('option preserves wire format (out of scope for Phase 3)', () => {
-    expect(canonicalLocalSymbol(makeMarket({
-      type: 'option', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT-240920-50000-C',
-    }))).toBe('BTC/USDT:USDT-240920-50000-C')
-  })
-})
-
-describe('marketToContract — emits canonical Contract', () => {
-  it('spot Contract has canonical localSymbol', () => {
+describe('marketToContract — preserves CCXT wire format', () => {
+  it('spot Contract.localSymbol matches market.symbol', () => {
     const c = marketToContract(makeMarket({
       type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT',
     }), 'bybit')
     expect(c.symbol).toBe('BTC')
-    expect(c.localSymbol).toBe('BTC')
+    expect(c.localSymbol).toBe('BTC/USDT')
     expect(c.secType).toBe('CRYPTO')
     expect(c.exchange).toBe('bybit')
     expect(c.currency).toBe('USDT')
   })
 
-  it('perp Contract gets canonical -PERP suffix', () => {
+  it('perp Contract.localSymbol carries :settle suffix (USDT-margined)', () => {
     const c = marketToContract(makeMarket({
       type: 'swap', base: 'ETH', quote: 'USDT', symbol: 'ETH/USDT:USDT', settle: 'USDT',
     }), 'bybit')
-    expect(c.localSymbol).toBe('ETH-PERP')
+    expect(c.localSymbol).toBe('ETH/USDT:USDT')
     expect(c.secType).toBe('CRYPTO_PERP')
+  })
+
+  it('USDC-margined perp stays distinct from USDT-margined perp', () => {
+    // Same underlying (ETH), different settle currency = different products
+    // — wire format encodes this distinction; canonicalization would erase it.
+    const usdt = marketToContract(makeMarket({
+      type: 'swap', base: 'ETH', quote: 'USDT', symbol: 'ETH/USDT:USDT', settle: 'USDT',
+    }), 'bybit')
+    const usdc = marketToContract(makeMarket({
+      type: 'swap', base: 'ETH', quote: 'USDC', symbol: 'ETH/USDC:USDC', settle: 'USDC',
+    }), 'bybit')
+    expect(usdt.localSymbol).not.toBe(usdc.localSymbol)
+    expect(usdt.localSymbol).toBe('ETH/USDT:USDT')
+    expect(usdc.localSymbol).toBe('ETH/USDC:USDC')
+  })
+
+  it('FUT carries expiry derived from market.expiry (ms epoch)', () => {
+    const c = marketToContract(makeMarket({
+      type: 'future', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT-220929',
+      // 2022-09-29 UTC = 1664409600000
+      expiry: 1664409600000,
+      contractSize: 1,
+    } as Partial<CcxtMarket> & { type: 'future'; base: string; quote: string; symbol: string }), 'bybit')
+    expect(c.localSymbol).toBe('BTC/USDT:USDT-220929')
+    expect(c.lastTradeDateOrContractMonth).toBe('20220929')
+    expect(c.multiplier).toBe('1')
   })
 
   it('contracts pass assertContract — no missing universal fields', () => {
@@ -84,35 +76,33 @@ describe('marketToContract — emits canonical Contract', () => {
   })
 })
 
-describe('contractToCcxt — canonical → wire format derivation', () => {
+describe('contractToCcxt — wire-format Contract resolves directly via markets table', () => {
   const markets: Record<string, CcxtMarket> = {
     'BTC/USDT': makeMarket({ type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT' }),
     'BTC/USDT:USDT': makeMarket({ type: 'swap', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT:USDT', settle: 'USDT' }),
     'ETH/USDT': makeMarket({ type: 'spot', base: 'ETH', quote: 'USDT', symbol: 'ETH/USDT' }),
   }
 
-  it('canonical spot Contract resolves to spot wire symbol via base+secType+currency search', () => {
+  it('spot Contract.localSymbol === market.symbol → direct hit', () => {
     const c = marketToContract(markets['BTC/USDT'], 'bybit')
-    // c.localSymbol = 'BTC', not 'BTC/USDT' — direct lookup misses, falls
-    // back to resolveContractSync which finds the spot market.
     expect(contractToCcxt(c, markets, 'bybit')).toBe('BTC/USDT')
   })
 
-  it('canonical perp Contract resolves to perp wire symbol', () => {
+  it('perp Contract.localSymbol === wire format → direct hit', () => {
     const c = marketToContract(markets['BTC/USDT:USDT'], 'bybit')
     expect(contractToCcxt(c, markets, 'bybit')).toBe('BTC/USDT:USDT')
   })
 
-  it('legacy wire-format localSymbol still resolves (back-compat for user-supplied contracts)', () => {
-    // User constructs Contract with wire-format localSymbol — direct hit.
-    const c = makeMarket({ type: 'spot', base: 'BTC', quote: 'USDT', symbol: 'BTC/USDT' })
-    const wireContract = marketToContract(c, 'bybit')
-    wireContract.localSymbol = 'BTC/USDT'  // simulate legacy
-    expect(contractToCcxt(wireContract, markets, 'bybit')).toBe('BTC/USDT')
+  it('user-supplied Contract with no localSymbol falls back to base+secType+currency search', () => {
+    // Some callers construct Contract from scratch (symbol only). The
+    // resolveContractSync fallback handles this path.
+    const c = marketToContract(markets['BTC/USDT'], 'bybit')
+    c.localSymbol = ''  // simulate user-constructed contract
+    expect(contractToCcxt(c, markets, 'bybit')).toBe('BTC/USDT')
   })
 })
 
-describe('ccxtTypeToSecType (already covered, sanity)', () => {
+describe('ccxtTypeToSecType (sanity)', () => {
   it('spot/swap/future/option', () => {
     expect(ccxtTypeToSecType('spot')).toBe('CRYPTO')
     expect(ccxtTypeToSecType('swap')).toBe('CRYPTO_PERP')

--- a/src/domain/trading/brokers/ccxt/ccxt-contracts.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-contracts.ts
@@ -27,55 +27,6 @@ export function decodeSymbol(encoded: string): string {
   return encoded.replace(/_/g, '/').replace(/\./g, ':')
 }
 
-// ---- Canonical localSymbol (Phase 3 of IBKR-as-truth refactor) ----
-
-/**
- * Build the canonical Contract.localSymbol for a CCXT market — IBKR-shaped
- * (broker-agnostic) instead of CCXT's wire format (`BTC/USDT:USDT`).
- *
- * The canonical form lets aliceIds and downstream consumers stop
- * special-casing CCXT's wire encoding. CCXT's wire format itself stays
- * a CcxtBroker-internal concern: `contractToCcxt` now derives wire from
- * the canonical Contract via `resolveContractSync`'s base+secType+currency
- * search, which already existed as a fallback.
- *
- * Format per market.type:
- *   - spot:   `${base}`                      (e.g. `BTC`)
- *   - swap:   `${base}-PERP`                 (e.g. `BTC-PERP`)
- *   - future: `${base}-FUT-${expiryYYYYMM}`  (e.g. `BTC-FUT-202609`)
- *   - option: `${base}-OPT-...`              (skipped — CCXT options are niche)
- *
- * Multi-quote disambiguation (BTC/USDT vs BTC/USDC spot held simultaneously)
- * is left for a follow-up — most users hold one quote per underlying, and
- * `Contract.currency` differentiates them within the same UTA.
- */
-export function canonicalLocalSymbol(market: CcxtMarket): string {
-  const base = market.base
-  switch (market.type) {
-    case 'spot':   return base
-    case 'swap':   return `${base}-PERP`
-    case 'future': return `${base}-FUT-${ccxtExpiryToCanonical(market)}`
-    case 'option': return market.symbol  // out of scope; preserve wire format
-    default:       return market.symbol
-  }
-}
-
-/** Best-effort YYYYMM extraction from a CCXT future market's expiry. */
-function ccxtExpiryToCanonical(market: CcxtMarket): string {
-  // CCXT exposes `expiry` (ms epoch) on dated futures. Fall back to whatever
-  // is encoded in the symbol if not present.
-  const ms = (market as unknown as { expiry?: number }).expiry
-  if (typeof ms === 'number') {
-    const d = new Date(ms)
-    const m = String(d.getUTCMonth() + 1).padStart(2, '0')
-    return `${d.getUTCFullYear()}${m}`
-  }
-  // Fallback: tail of `BTC/USDT:USDT-220929` after the trailing dash.
-  const dash = market.symbol.lastIndexOf('-')
-  if (dash >= 0) return market.symbol.slice(dash + 1)
-  return 'unknown'
-}
-
 // ---- Type mapping ----
 
 export function ccxtTypeToSecType(type: string): string {
@@ -110,20 +61,59 @@ export function makeOrderState(ccxtStatus: string | undefined): OrderState {
 // ---- Contract ↔ CCXT symbol conversion ----
 
 /**
- * Convert a CcxtMarket to an IBKR Contract with a canonical localSymbol.
- * CCXT's wire format ("BTC/USDT:USDT") is no longer on the Contract —
- * `contractToCcxt` derives it from `(base, secType, currency)` via the
- * markets table when CCXT-side talk is needed.
+ * Convert a CcxtMarket to an IBKR Contract.
+ *
+ * `Contract.localSymbol` is set to `market.symbol` — CCXT's unified wire
+ * format (`BTC/USDT:USDT`, `BTC/USDT`, `BTC/USDT:USDT-220929`). That's
+ * CCXT's own uniqueness primitive: it encodes base + quote + (optional)
+ * settle + (optional) expiry in one string, distinguishing every product
+ * the exchange offers. We do not normalize this across brokers —
+ * `aliceId`'s `{utaId}|` prefix already scopes per-broker, and each
+ * broker's `getNativeKey` reads its own native key out of Contract.
+ *
+ * For FUT/OPT/FOP markets, derives `lastTradeDateOrContractMonth` from
+ * `market.expiry` (CCXT exposes it as ms epoch on dated derivatives) and
+ * `multiplier` from `market.contractSize`. CCXT-typed `optionType` and
+ * `strike` populate the OPT-specific fields. `assertContract` (called
+ * inside `buildContract`) verifies all required taxonomy fields are
+ * present — malformed market data throws here so callers can decide
+ * whether to skip or surface the error.
  */
 export function marketToContract(market: CcxtMarket, exchangeName: string): Contract {
-  return buildContract({
+  const secType = ccxtTypeToSecType(market.type) as SecType
+  // CcxtMarket only types the universal subset; CCXT actually exposes
+  // expiry / contractSize / strike / optionType on derivative markets.
+  const m = market as unknown as {
+    expiry?: number
+    contractSize?: number
+    strike?: number
+    optionType?: 'call' | 'put'
+  }
+
+  const params: Parameters<typeof buildContract>[0] = {
     symbol: market.base,
-    secType: ccxtTypeToSecType(market.type) as SecType,
+    secType,
     exchange: exchangeName,
     currency: market.quote,
-    localSymbol: canonicalLocalSymbol(market),
+    localSymbol: market.symbol,
     description: `${market.base}/${market.quote} ${market.type}${market.settle ? ` (${market.settle} settled)` : ''}`,
-  })
+  }
+
+  if (secType === 'FUT' || secType === 'OPT' || secType === 'FOP') {
+    if (m.expiry) {
+      const d = new Date(m.expiry)
+      params.lastTradeDateOrContractMonth =
+        `${d.getUTCFullYear()}${String(d.getUTCMonth() + 1).padStart(2, '0')}${String(d.getUTCDate()).padStart(2, '0')}`
+    }
+    params.multiplier = m.contractSize != null ? String(m.contractSize) : '1'
+  }
+  if (secType === 'OPT' || secType === 'FOP') {
+    if (m.strike != null) params.strike = m.strike
+    if (m.optionType === 'call') params.right = 'C'
+    else if (m.optionType === 'put') params.right = 'P'
+  }
+
+  return buildContract(params)
 }
 
 /** Parse aliceId → CCXT unified symbol. */
@@ -178,6 +168,10 @@ export function resolveContractSync(
 
   for (const market of Object.values(markets)) {
     if (market.active === false) continue
+    // Some exchange-supplied market entries are skeletal (delisted /
+    // synthetic / index-only) and lack base or quote — skip those rather
+    // than crash on .toUpperCase().
+    if (!market.base || !market.quote) continue
     if (market.base.toUpperCase() !== searchBase) continue
 
     if (query.secType) {

--- a/src/domain/trading/brokers/mock/MockBroker.ts
+++ b/src/domain/trading/brokers/mock/MockBroker.ts
@@ -659,14 +659,17 @@ export class MockBroker implements IBroker {
     if (qty.lte(0)) throw new Error('externalTrade: quantity must be positive')
 
     const existing = this._positions.get(params.nativeKey)
-    if (!existing && params.side === 'SELL') {
-      throw new Error(`MockBroker[${this.id}]: cannot externalTrade SELL — no position at ${params.nativeKey}`)
-    }
 
     if (!existing) {
+      // No existing position → opening. BUY opens long, SELL opens short.
+      // externalTrade models the user manually trading on the exchange app,
+      // where opening a short (covered call's call leg, naked put, perp
+      // short, etc.) is a legitimate action — distinct from placeOrder /
+      // _applyFill, which still rejects SELL-without-position because Alice
+      // shouldn't silently flip a SELL intent into a short open.
       this._positions.set(params.nativeKey, {
         contract: this._buildContract(params.nativeKey, params.contract),
-        side: 'long',
+        side: params.side === 'BUY' ? 'long' : 'short',
         quantity: qty,
         avgCost: price,
         avgCostSource: 'wallet',

--- a/src/domain/trading/contract-ext.ts
+++ b/src/domain/trading/contract-ext.ts
@@ -1,20 +1,25 @@
 /**
  * Declaration merge: adds `aliceId` to IBKR Contract class.
  *
- * aliceId is Alice's unique asset identifier: "{utaId}|{nativeKey}"
- * e.g. "alpaca-paper|META", "bybit-main|ETH-PERP"
+ * aliceId is Alice's system-level unique asset identifier:
+ *   "{utaId}|{nativeKey}"
+ * e.g. "alpaca-paper|META", "bybit-main|ETH/USDT:USDT", "ibkr|265598" (conId)
  *
- * Constructed by UTA layer (not broker). Broker uses symbol/localSymbol for resolution.
- * The @traderalice/ibkr package stays a pure IBKR replica.
+ * Constructed by the UTA layer via `stampAliceId`. The `nativeKey` half
+ * comes from `broker.getNativeKey(contract)` — each broker chooses its
+ * own uniqueness primitive there:
  *
- * localSymbol semantics — canonical (broker-agnostic) post-Phase-3 of the
- * IBKR-as-truth refactor:
- * - IBKR: exchange-native symbol (e.g., "AAPL", "ESZ4")
- * - Alpaca: ticker symbol (e.g., "AAPL")
- * - CCXT: canonical (e.g., "ETH" spot, "ETH-PERP" perp, "BTC-FUT-202609" dated future).
- *         CCXT's wire format ("ETH/USDT:USDT") stays a CcxtBroker-internal concern,
- *         derived on demand via `contractToCcxt`.
- * UTA uses localSymbol as nativeKey in aliceId: "{utaId}|{nativeKey}"
+ *   - IBKR:   `conId` (numeric — the only reliably unique key, since
+ *             symbol/localSymbol collide across the option-chain fanout)
+ *   - CCXT:   the unified wire symbol (`BTC/USDT:USDT`) — encodes
+ *             base+quote+settle, which CCXT considers structural
+ *   - Alpaca: ticker symbol (flat US-equities universe)
+ *   - Mock:   per-config nativeKey (tester-defined)
+ *
+ * `Contract.localSymbol` is **not** the system uniqueness primitive —
+ * each broker writes whatever its native data model dictates, no
+ * normalization across brokers. What matters is that getNativeKey
+ * returns the broker's actual primary key.
  */
 
 import '@traderalice/ibkr'

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,7 +193,7 @@ async function main() {
     equityClient = new OpenBBEquityClient(url, providers.equity, keys)
     cryptoClient = new OpenBBCryptoClient(url, providers.crypto, keys)
     currencyClient = new OpenBBCurrencyClient(url, providers.currency, keys)
-    commodityClient = new OpenBBCommodityClient(url, providers.commodity, keys)
+    commodityClient = new OpenBBCommodityClient(url, providers.commodity, keys) as unknown as CommodityClientLike
     economyClient = new OpenBBEconomyClient(url, 'federal_reserve', keys) as unknown as EconomyClientLike
   } else {
     const executor = getSDKExecutor()
@@ -243,7 +243,7 @@ async function main() {
     toolCenter.register(createNewsArchiveTools(newsStore), 'news')
   }
   toolCenter.register(createAnalysisTools(equityClient, cryptoClient, currencyClient, commodityClient), 'analysis')
-  toolCenter.register(createEconomyTools(economyClient), 'economy')
+  toolCenter.register(createEconomyTools(economyClient, commodityClient), 'economy')
 
   console.log(`tool-center: ${toolCenter.list().length} tools registered`)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,15 +18,17 @@ import { createBrowserTools } from './tool/browser.js'
 import { SymbolIndex } from './domain/market-data/equity/index.js'
 import { CommodityCatalog } from './domain/market-data/commodity/index.js'
 import { createEquityTools } from './tool/equity.js'
-import { getSDKExecutor, buildRouteMap, SDKEquityClient, SDKCryptoClient, SDKCurrencyClient, SDKEtfClient, SDKIndexClient, SDKDerivativesClient, SDKCommodityClient } from './domain/market-data/client/typebb/index.js'
-import type { EquityClientLike, CryptoClientLike, CurrencyClientLike, EtfClientLike, IndexClientLike, DerivativesClientLike, CommodityClientLike } from './domain/market-data/client/types.js'
+import { getSDKExecutor, buildRouteMap, SDKEquityClient, SDKCryptoClient, SDKCurrencyClient, SDKEtfClient, SDKIndexClient, SDKDerivativesClient, SDKCommodityClient, SDKEconomyClient } from './domain/market-data/client/typebb/index.js'
+import type { EquityClientLike, CryptoClientLike, CurrencyClientLike, EtfClientLike, IndexClientLike, DerivativesClientLike, CommodityClientLike, EconomyClientLike } from './domain/market-data/client/types.js'
 import { buildSDKCredentials } from './domain/market-data/credential-map.js'
 import { OpenBBEquityClient } from './domain/market-data/client/openbb-api/equity-client.js'
 import { OpenBBCryptoClient } from './domain/market-data/client/openbb-api/crypto-client.js'
 import { OpenBBCurrencyClient } from './domain/market-data/client/openbb-api/currency-client.js'
 import { OpenBBCommodityClient } from './domain/market-data/client/openbb-api/commodity-client.js'
+import { OpenBBEconomyClient } from './domain/market-data/client/openbb-api/economy-client.js'
 import { createMarketSearchTools } from './tool/market.js'
 import { createAnalysisTools } from './tool/analysis.js'
+import { createEconomyTools } from './tool/economy.js'
 import { createSessionTools } from './tool/session.js'
 import { SessionStore } from './core/session.js'
 import { ConnectorCenter } from './core/connector-center.js'
@@ -183,6 +185,7 @@ async function main() {
   let etfClient: EtfClientLike | undefined
   let indexClient: IndexClientLike | undefined
   let derivativesClient: DerivativesClientLike | undefined
+  let economyClient: EconomyClientLike
 
   if (config.marketData.backend === 'openbb-api') {
     const url = config.marketData.apiUrl
@@ -191,6 +194,7 @@ async function main() {
     cryptoClient = new OpenBBCryptoClient(url, providers.crypto, keys)
     currencyClient = new OpenBBCurrencyClient(url, providers.currency, keys)
     commodityClient = new OpenBBCommodityClient(url, providers.commodity, keys)
+    economyClient = new OpenBBEconomyClient(url, 'federal_reserve', keys) as unknown as EconomyClientLike
   } else {
     const executor = getSDKExecutor()
     const routeMap = buildRouteMap()
@@ -202,6 +206,7 @@ async function main() {
     etfClient = new SDKEtfClient(executor, 'etf', providers.equity, credentials, routeMap)
     indexClient = new SDKIndexClient(executor, 'index', providers.equity, credentials, routeMap)
     derivativesClient = new SDKDerivativesClient(executor, 'derivatives', providers.equity, credentials, routeMap)
+    economyClient = new SDKEconomyClient(executor, 'economy', 'federal_reserve', credentials, routeMap)
   }
 
   // ==================== FX Service ====================
@@ -238,6 +243,7 @@ async function main() {
     toolCenter.register(createNewsArchiveTools(newsStore), 'news')
   }
   toolCenter.register(createAnalysisTools(equityClient, cryptoClient, currencyClient, commodityClient), 'analysis')
+  toolCenter.register(createEconomyTools(economyClient), 'economy')
 
   console.log(`tool-center: ${toolCenter.list().length} tools registered`)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile, mkdir } from 'fs/promises'
 import { resolve, dirname } from 'path'
 // Engine removed — AgentCenter is the top-level AI entry point
-import { loadConfig, readUTAsConfig } from './core/config.js'
+import { loadConfig, readUTAsConfig, purgeEphemeralUTAs } from './core/config.js'
 import type { Plugin, EngineContext, ReconnectResult } from './core/types.js'
 import { McpPlugin } from './server/mcp.js'
 import { TelegramPlugin } from './connectors/telegram/index.js'
@@ -104,8 +104,11 @@ async function main() {
 
   const utaManager = new UTAManager({ eventLog, toolCenter })
 
-  const utaConfigs = await readUTAsConfig()
-  for (const accCfg of utaConfigs) {
+  // Ephemeral test UTAs from a previous session are purged before init —
+  // their config rows are removed and `data/trading/<id>/` is wiped, so
+  // fixture-driven tests start each session from a clean slate.
+  const survivors = await purgeEphemeralUTAs(await readUTAsConfig())
+  for (const accCfg of survivors) {
     if (accCfg.enabled === false) continue
     await utaManager.initUTA(accCfg)
   }

--- a/src/tool/economy.spec.ts
+++ b/src/tool/economy.spec.ts
@@ -10,14 +10,22 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import type { EconomyClientLike } from '@/domain/market-data/client/types'
+import type { EconomyClientLike, CommodityClientLike } from '@/domain/market-data/client/types'
 import { createEconomyTools } from './economy.js'
 
-function makeMockClient(): EconomyClientLike {
+function makeMockEconomyClient(): EconomyClientLike {
   return {
     fredSearch: vi.fn(async () => []),
     fredSeries: vi.fn(async () => []),
     fredRegional: vi.fn(async () => []),
+  }
+}
+
+function makeMockCommodityClient(): CommodityClientLike {
+  return {
+    getSpotPrices: vi.fn(async () => []),
+    getPetroleumStatus: vi.fn(async () => []),
+    getEnergyOutlook: vi.fn(async () => []),
   }
 }
 
@@ -26,11 +34,13 @@ const exec = (t: any, args: unknown) => (t.execute as Function)(args)
 
 describe('createEconomyTools — economyFredSearch', () => {
   let client: EconomyClientLike
+  let commodity: CommodityClientLike
   let tools: ReturnType<typeof createEconomyTools>
 
   beforeEach(() => {
-    client = makeMockClient()
-    tools = createEconomyTools(client)
+    client = makeMockEconomyClient()
+    commodity = makeMockCommodityClient()
+    tools = createEconomyTools(client, commodity)
   })
 
   it('passes query through and pins provider to federal_reserve', async () => {
@@ -76,11 +86,13 @@ describe('createEconomyTools — economyFredSearch', () => {
 
 describe('createEconomyTools — economyFredSeries', () => {
   let client: EconomyClientLike
+  let commodity: CommodityClientLike
   let tools: ReturnType<typeof createEconomyTools>
 
   beforeEach(() => {
-    client = makeMockClient()
-    tools = createEconomyTools(client)
+    client = makeMockEconomyClient()
+    commodity = makeMockCommodityClient()
+    tools = createEconomyTools(client, commodity)
   })
 
   it('passes single symbol + provider', async () => {
@@ -118,11 +130,13 @@ describe('createEconomyTools — economyFredSeries', () => {
 
 describe('createEconomyTools — economyFredRegional', () => {
   let client: EconomyClientLike
+  let commodity: CommodityClientLike
   let tools: ReturnType<typeof createEconomyTools>
 
   beforeEach(() => {
-    client = makeMockClient()
-    tools = createEconomyTools(client)
+    client = makeMockEconomyClient()
+    commodity = makeMockCommodityClient()
+    tools = createEconomyTools(client, commodity)
   })
 
   it('passes symbol + provider with no extras', async () => {
@@ -146,18 +160,96 @@ describe('createEconomyTools — economyFredRegional', () => {
   })
 })
 
+describe('createEconomyTools — economyEnergyOutlook', () => {
+  let economy: EconomyClientLike
+  let commodity: CommodityClientLike
+  let tools: ReturnType<typeof createEconomyTools>
+
+  beforeEach(() => {
+    economy = makeMockEconomyClient()
+    commodity = makeMockCommodityClient()
+    tools = createEconomyTools(economy, commodity)
+  })
+
+  it('passes category through and pins provider to eia', async () => {
+    await exec(tools.economyEnergyOutlook, { category: 'crude_oil_price' })
+    expect(commodity.getEnergyOutlook).toHaveBeenCalledWith({ category: 'crude_oil_price', provider: 'eia' })
+  })
+
+  it('forwards date range when provided', async () => {
+    await exec(tools.economyEnergyOutlook, {
+      category: 'natural_gas_price', start_date: '2024-01-01', end_date: '2024-12-31',
+    })
+    expect(commodity.getEnergyOutlook).toHaveBeenCalledWith({
+      category: 'natural_gas_price', provider: 'eia',
+      start_date: '2024-01-01', end_date: '2024-12-31',
+    })
+  })
+
+  it('schema rejects unknown category (zod enum)', () => {
+    const schema = (tools.economyEnergyOutlook as any).inputSchema
+    expect(schema.safeParse({ category: 'bitcoin_price' }).success).toBe(false)
+  })
+
+  it('schema rejects missing category', () => {
+    const schema = (tools.economyEnergyOutlook as any).inputSchema
+    expect(schema.safeParse({}).success).toBe(false)
+  })
+
+  it('does NOT touch economyClient', async () => {
+    await exec(tools.economyEnergyOutlook, { category: 'crude_oil_price' })
+    expect(economy.fredSearch).not.toHaveBeenCalled()
+    expect(economy.fredSeries).not.toHaveBeenCalled()
+    expect(economy.fredRegional).not.toHaveBeenCalled()
+  })
+
+  it('propagates client errors instead of swallowing', async () => {
+    ;(commodity.getEnergyOutlook as any).mockRejectedValueOnce(new Error('eia 403'))
+    await expect(exec(tools.economyEnergyOutlook, { category: 'crude_oil_price' })).rejects.toThrow('eia 403')
+  })
+})
+
+describe('createEconomyTools — economyPetroleumStatus', () => {
+  let economy: EconomyClientLike
+  let commodity: CommodityClientLike
+  let tools: ReturnType<typeof createEconomyTools>
+
+  beforeEach(() => {
+    economy = makeMockEconomyClient()
+    commodity = makeMockCommodityClient()
+    tools = createEconomyTools(economy, commodity)
+  })
+
+  it('passes category through and pins provider to eia', async () => {
+    await exec(tools.economyPetroleumStatus, { category: 'crude_oil_stocks' })
+    expect(commodity.getPetroleumStatus).toHaveBeenCalledWith({ category: 'crude_oil_stocks', provider: 'eia' })
+  })
+
+  it('schema rejects unknown category', () => {
+    const schema = (tools.economyPetroleumStatus as any).inputSchema
+    expect(schema.safeParse({ category: 'gold_inventory' }).success).toBe(false)
+  })
+
+  it('does NOT touch economyClient', async () => {
+    await exec(tools.economyPetroleumStatus, { category: 'crude_oil_stocks' })
+    expect(economy.fredSearch).not.toHaveBeenCalled()
+  })
+})
+
 describe('createEconomyTools — toolset surface', () => {
-  it('exposes exactly the three FRED tools', () => {
-    const tools = createEconomyTools(makeMockClient())
+  it('exposes the FRED + EIA tools', () => {
+    const tools = createEconomyTools(makeMockEconomyClient(), makeMockCommodityClient())
     expect(Object.keys(tools).sort()).toEqual([
+      'economyEnergyOutlook',
       'economyFredRegional',
       'economyFredSearch',
       'economyFredSeries',
+      'economyPetroleumStatus',
     ])
   })
 
   it('every tool has a description and inputSchema', () => {
-    const tools = createEconomyTools(makeMockClient()) as Record<string, any>
+    const tools = createEconomyTools(makeMockEconomyClient(), makeMockCommodityClient()) as Record<string, any>
     for (const [name, t] of Object.entries(tools)) {
       expect(t.description, `${name} description`).toBeTruthy()
       expect(t.inputSchema, `${name} inputSchema`).toBeDefined()

--- a/src/tool/economy.spec.ts
+++ b/src/tool/economy.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Economy tool unit tests — schema / passthrough / error.
+ *
+ * Mirrors the trading.spec.ts pattern: don't hit the network, mock the
+ * EconomyClientLike surface, and verify the three things that can break
+ * silently when you turn a domain function into an AI tool:
+ *   1. Input schema accepts valid args + rejects invalid ones (zod check)
+ *   2. Args land at the client unchanged + provider is pinned to federal_reserve
+ *   3. Errors from the client propagate (no swallowing)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { EconomyClientLike } from '@/domain/market-data/client/types'
+import { createEconomyTools } from './economy.js'
+
+function makeMockClient(): EconomyClientLike {
+  return {
+    fredSearch: vi.fn(async () => []),
+    fredSeries: vi.fn(async () => []),
+    fredRegional: vi.fn(async () => []),
+  }
+}
+
+// Helper to bypass Vercel AI's tool execute typing — same pattern as trading.spec.ts
+const exec = (t: any, args: unknown) => (t.execute as Function)(args)
+
+describe('createEconomyTools — economyFredSearch', () => {
+  let client: EconomyClientLike
+  let tools: ReturnType<typeof createEconomyTools>
+
+  beforeEach(() => {
+    client = makeMockClient()
+    tools = createEconomyTools(client)
+  })
+
+  it('passes query through and pins provider to federal_reserve', async () => {
+    await exec(tools.economyFredSearch, { query: 'GDP' })
+    expect(client.fredSearch).toHaveBeenCalledWith({ query: 'GDP', provider: 'federal_reserve' })
+  })
+
+  it('forwards optional limit when present', async () => {
+    await exec(tools.economyFredSearch, { query: 'GDP', limit: 5 })
+    expect(client.fredSearch).toHaveBeenCalledWith({ query: 'GDP', provider: 'federal_reserve', limit: 5 })
+  })
+
+  it('omits limit from params when not provided (does not send undefined)', async () => {
+    await exec(tools.economyFredSearch, { query: 'GDP' })
+    const callArg = (client.fredSearch as any).mock.calls[0][0]
+    expect('limit' in callArg).toBe(false)
+  })
+
+  it('returns the client result unchanged', async () => {
+    const fixture = [{ series_id: 'GDP', title: 'Gross Domestic Product' }] as any
+    ;(client.fredSearch as any).mockResolvedValueOnce(fixture)
+    const result = await exec(tools.economyFredSearch, { query: 'GDP' })
+    expect(result).toBe(fixture)
+  })
+
+  it('propagates client errors instead of swallowing', async () => {
+    ;(client.fredSearch as any).mockRejectedValueOnce(new Error('upstream 500'))
+    await expect(exec(tools.economyFredSearch, { query: 'GDP' })).rejects.toThrow('upstream 500')
+  })
+
+  it('schema rejects missing query', () => {
+    const schema = (tools.economyFredSearch as any).inputSchema
+    expect(schema.safeParse({}).success).toBe(false)
+  })
+
+  it('schema rejects non-positive limit', () => {
+    const schema = (tools.economyFredSearch as any).inputSchema
+    expect(schema.safeParse({ query: 'GDP', limit: 0 }).success).toBe(false)
+    expect(schema.safeParse({ query: 'GDP', limit: -1 }).success).toBe(false)
+    expect(schema.safeParse({ query: 'GDP', limit: 1.5 }).success).toBe(false)
+  })
+})
+
+describe('createEconomyTools — economyFredSeries', () => {
+  let client: EconomyClientLike
+  let tools: ReturnType<typeof createEconomyTools>
+
+  beforeEach(() => {
+    client = makeMockClient()
+    tools = createEconomyTools(client)
+  })
+
+  it('passes single symbol + provider', async () => {
+    await exec(tools.economyFredSeries, { symbol: 'GDP' })
+    expect(client.fredSeries).toHaveBeenCalledWith({ symbol: 'GDP', provider: 'federal_reserve' })
+  })
+
+  it('passes comma-separated symbols verbatim (multi-series merge)', async () => {
+    await exec(tools.economyFredSeries, { symbol: 'GDP,UNRATE' })
+    expect(client.fredSeries).toHaveBeenCalledWith({ symbol: 'GDP,UNRATE', provider: 'federal_reserve' })
+  })
+
+  it('forwards date range and limit', async () => {
+    await exec(tools.economyFredSeries, {
+      symbol: 'GDP', start_date: '2020-01-01', end_date: '2024-12-31', limit: 12,
+    })
+    expect(client.fredSeries).toHaveBeenCalledWith({
+      symbol: 'GDP', provider: 'federal_reserve',
+      start_date: '2020-01-01', end_date: '2024-12-31', limit: 12,
+    })
+  })
+
+  it('forwards frequency when provided', async () => {
+    await exec(tools.economyFredSeries, { symbol: 'GDP', frequency: 'm' })
+    expect(client.fredSeries).toHaveBeenCalledWith({
+      symbol: 'GDP', provider: 'federal_reserve', frequency: 'm',
+    })
+  })
+
+  it('schema rejects missing symbol', () => {
+    const schema = (tools.economyFredSeries as any).inputSchema
+    expect(schema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe('createEconomyTools — economyFredRegional', () => {
+  let client: EconomyClientLike
+  let tools: ReturnType<typeof createEconomyTools>
+
+  beforeEach(() => {
+    client = makeMockClient()
+    tools = createEconomyTools(client)
+  })
+
+  it('passes symbol + provider with no extras', async () => {
+    await exec(tools.economyFredRegional, { symbol: 'WIPCPI' })
+    expect(client.fredRegional).toHaveBeenCalledWith({ symbol: 'WIPCPI', provider: 'federal_reserve' })
+  })
+
+  it('forwards date and region_type when present', async () => {
+    await exec(tools.economyFredRegional, {
+      symbol: 'WIPCPI', date: '2024-01-01', region_type: 'state',
+    })
+    expect(client.fredRegional).toHaveBeenCalledWith({
+      symbol: 'WIPCPI', provider: 'federal_reserve',
+      date: '2024-01-01', region_type: 'state',
+    })
+  })
+
+  it('schema rejects missing symbol', () => {
+    const schema = (tools.economyFredRegional as any).inputSchema
+    expect(schema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe('createEconomyTools — toolset surface', () => {
+  it('exposes exactly the three FRED tools', () => {
+    const tools = createEconomyTools(makeMockClient())
+    expect(Object.keys(tools).sort()).toEqual([
+      'economyFredRegional',
+      'economyFredSearch',
+      'economyFredSeries',
+    ])
+  })
+
+  it('every tool has a description and inputSchema', () => {
+    const tools = createEconomyTools(makeMockClient()) as Record<string, any>
+    for (const [name, t] of Object.entries(tools)) {
+      expect(t.description, `${name} description`).toBeTruthy()
+      expect(t.inputSchema, `${name} inputSchema`).toBeDefined()
+    }
+  })
+})

--- a/src/tool/economy.ts
+++ b/src/tool/economy.ts
@@ -1,24 +1,33 @@
 /**
  * Economy AI Tools
  *
- * Currently exposes the FRED (Federal Reserve Economic Data) surface:
- *   economyFredSearch    — find a series by keyword
- *   economyFredSeries    — fetch observations for one or more series
- *   economyFredRegional  — fetch state-level cross-section for a regional series
+ * Macro / economic data surface exposed to the AI agent. Backed by
+ * multiple providers under the hood — semantics drives the namespace
+ * (the AI sees one cohesive "look up macro indicators" toolset), even
+ * though the underlying SDK clients route them differently:
  *
- * All three pin `provider: 'federal_reserve'` because that is the only
- * registered FRED data source on the SDK side. If/when other macro
- * providers (BLS series, OECD CLI) get tool-wrapped, they belong in
- * sibling tools in this same file rather than overloaded here.
+ *   FRED (federal_reserve) — economyFredSearch / FredSeries / FredRegional
+ *     (routed via /economy/* on the HTTP layer; uses EconomyClientLike)
+ *   EIA — economyEnergyOutlook / economyPetroleumStatus
+ *     (routed via /commodity/* upstream — OpenBB classifies oil/gas as
+ *     commodity data; uses CommodityClientLike. Conceptually macro for
+ *     the AI, structurally commodity for the wire.)
+ *
+ * Provider names are pinned at the tool boundary so the LLM never has
+ * to know about the federal_reserve / eia provider strings.
  */
 
 import { tool } from 'ai'
 import { z } from 'zod'
-import type { EconomyClientLike } from '@/domain/market-data/client/types'
+import type { EconomyClientLike, CommodityClientLike } from '@/domain/market-data/client/types'
 
-const PROVIDER = 'federal_reserve'
+const FRED_PROVIDER = 'federal_reserve'
+const EIA_PROVIDER = 'eia'
 
-export function createEconomyTools(economyClient: EconomyClientLike) {
+export function createEconomyTools(
+  economyClient: EconomyClientLike,
+  commodityClient: CommodityClientLike,
+) {
   return {
     economyFredSearch: tool({
       description: `Search the FRED database for economic time series by keyword.
@@ -34,7 +43,7 @@ common term. Increase limit only if you need to scan beyond the most popular res
         limit: z.number().int().positive().optional().describe('Max results to return (default: 100)'),
       }),
       execute: async ({ query, limit }) => {
-        const params: Record<string, unknown> = { query, provider: PROVIDER }
+        const params: Record<string, unknown> = { query, provider: FRED_PROVIDER }
         if (limit !== undefined) params.limit = limit
         return await economyClient.fredSearch(params)
       },
@@ -59,7 +68,7 @@ If you don't know the series_id, call economyFredSearch first.`,
         frequency: z.string().optional().describe('Aggregation frequency override (e.g. "m", "q", "a")'),
       }),
       execute: async ({ symbol, start_date, end_date, limit, frequency }) => {
-        const params: Record<string, unknown> = { symbol, provider: PROVIDER }
+        const params: Record<string, unknown> = { symbol, provider: FRED_PROVIDER }
         if (start_date !== undefined) params.start_date = start_date
         if (end_date !== undefined) params.end_date = end_date
         if (limit !== undefined) params.limit = limit
@@ -85,11 +94,71 @@ per-capita income).`,
         start_date: z.string().optional().describe('Start date for ranged queries (optional)'),
       }),
       execute: async ({ symbol, date, region_type, start_date }) => {
-        const params: Record<string, unknown> = { symbol, provider: PROVIDER }
+        const params: Record<string, unknown> = { symbol, provider: FRED_PROVIDER }
         if (date !== undefined) params.date = date
         if (region_type !== undefined) params.region_type = region_type
         if (start_date !== undefined) params.start_date = start_date
         return await economyClient.fredRegional(params)
+      },
+    }),
+
+    economyEnergyOutlook: tool({
+      description: `Fetch the EIA Short-Term Energy Outlook (STEO) for a given category.
+
+Returns ~10 years of monthly observations (mix of historical + forecast). The
+\`forecast\` field on each row is true when the observation is a projection,
+false when it is a realised value — useful for distinguishing "what happened"
+from "what EIA expects".
+
+Use for energy-market context (oil price trajectory, refinery throughput,
+gasoline price, gas/petroleum production trends). For macro indicators like
+GDP / unemployment / CPI, use economyFredSeries instead.`,
+      inputSchema: z.object({
+        category: z.enum([
+          'crude_oil_price',
+          'gasoline_price',
+          'natural_gas_price',
+          'crude_oil_production',
+          'petroleum_consumption',
+        ]).describe('STEO category'),
+        start_date: z.string().optional().describe('Start date YYYY-MM-DD (optional)'),
+        end_date: z.string().optional().describe('End date YYYY-MM-DD (optional)'),
+      }),
+      execute: async ({ category, start_date, end_date }) => {
+        const params: Record<string, unknown> = { category, provider: EIA_PROVIDER }
+        if (start_date !== undefined) params.start_date = start_date
+        if (end_date !== undefined) params.end_date = end_date
+        return await commodityClient.getEnergyOutlook(params)
+      },
+    }),
+
+    economyPetroleumStatus: tool({
+      description: `Fetch the EIA Weekly Petroleum Status Report for a given category.
+
+Returns ~5 years of weekly observations (no forecast — this is the EIA's
+realised inventory + production data, released every Wednesday). Use for
+short-horizon energy-market signals: crude/gasoline/distillate stock draws,
+refinery utilisation, US crude production.
+
+Categories cover commercial inventories ("..._stocks"), production, and
+refinery utilisation. For longer-horizon outlook + forecasts use
+economyEnergyOutlook.`,
+      inputSchema: z.object({
+        category: z.enum([
+          'crude_oil_production',
+          'crude_oil_stocks',
+          'gasoline_stocks',
+          'distillate_stocks',
+          'refinery_utilization',
+        ]).describe('Petroleum data category'),
+        start_date: z.string().optional().describe('Start date YYYY-MM-DD (optional)'),
+        end_date: z.string().optional().describe('End date YYYY-MM-DD (optional)'),
+      }),
+      execute: async ({ category, start_date, end_date }) => {
+        const params: Record<string, unknown> = { category, provider: EIA_PROVIDER }
+        if (start_date !== undefined) params.start_date = start_date
+        if (end_date !== undefined) params.end_date = end_date
+        return await commodityClient.getPetroleumStatus(params)
       },
     }),
   }

--- a/src/tool/economy.ts
+++ b/src/tool/economy.ts
@@ -1,0 +1,96 @@
+/**
+ * Economy AI Tools
+ *
+ * Currently exposes the FRED (Federal Reserve Economic Data) surface:
+ *   economyFredSearch    — find a series by keyword
+ *   economyFredSeries    — fetch observations for one or more series
+ *   economyFredRegional  — fetch state-level cross-section for a regional series
+ *
+ * All three pin `provider: 'federal_reserve'` because that is the only
+ * registered FRED data source on the SDK side. If/when other macro
+ * providers (BLS series, OECD CLI) get tool-wrapped, they belong in
+ * sibling tools in this same file rather than overloaded here.
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { EconomyClientLike } from '@/domain/market-data/client/types'
+
+const PROVIDER = 'federal_reserve'
+
+export function createEconomyTools(economyClient: EconomyClientLike) {
+  return {
+    economyFredSearch: tool({
+      description: `Search the FRED database for economic time series by keyword.
+
+Returns a list of matching series with id, title, frequency, units, and seasonal adjustment.
+Use this to discover the FRED series_id for a metric (e.g. "unemployment" → UNRATE,
+"GDP" → GDP, "CPI" → CPIAUCSL), then pass the id to economyFredSeries to get observations.
+
+The query is keyword-based and matches series titles + tags; expect dozens of hits per
+common term. Increase limit only if you need to scan beyond the most popular results.`,
+      inputSchema: z.object({
+        query: z.string().describe('Keyword(s) to search FRED, e.g. "unemployment", "GDP", "CPI"'),
+        limit: z.number().int().positive().optional().describe('Max results to return (default: 100)'),
+      }),
+      execute: async ({ query, limit }) => {
+        const params: Record<string, unknown> = { query, provider: PROVIDER }
+        if (limit !== undefined) params.limit = limit
+        return await economyClient.fredSearch(params)
+      },
+    }),
+
+    economyFredSeries: tool({
+      description: `Fetch observation values for one or more FRED series.
+
+Pass a single series_id (e.g. "GDP") or comma-separated ids (e.g. "GDP,UNRATE,CPIAUCSL")
+to retrieve and merge multiple series into one date-indexed result.
+
+When limit is set without a date range, returns the LATEST N observations (e.g. limit=12
+on a monthly series gives the most recent year). To pull a specific window, pass
+start_date and/or end_date in YYYY-MM-DD form.
+
+If you don't know the series_id, call economyFredSearch first.`,
+      inputSchema: z.object({
+        symbol: z.string().describe('FRED series id, or comma-separated ids for multi-series merge'),
+        start_date: z.string().optional().describe('Start date YYYY-MM-DD (optional)'),
+        end_date: z.string().optional().describe('End date YYYY-MM-DD (optional)'),
+        limit: z.number().int().positive().optional().describe('Max observations per series (returns latest N when no date range given)'),
+        frequency: z.string().optional().describe('Aggregation frequency override (e.g. "m", "q", "a")'),
+      }),
+      execute: async ({ symbol, start_date, end_date, limit, frequency }) => {
+        const params: Record<string, unknown> = { symbol, provider: PROVIDER }
+        if (start_date !== undefined) params.start_date = start_date
+        if (end_date !== undefined) params.end_date = end_date
+        if (limit !== undefined) params.limit = limit
+        if (frequency !== undefined) params.frequency = frequency
+        return await economyClient.fredSeries(params)
+      },
+    }),
+
+    economyFredRegional: tool({
+      description: `Fetch a US state-level cross-section for a FRED regional series.
+
+The symbol is the regional series id (e.g. "WIPCPI" for per-capita personal income,
+"UNRATE" for unemployment rate). Returns one row per region (~50 states + DC + territories)
+with region name, code, and value for the given date.
+
+Use this for state-by-state comparisons; for time-series of a single region,
+use economyFredSeries with the region-specific id (e.g. "CAPCPI" for California
+per-capita income).`,
+      inputSchema: z.object({
+        symbol: z.string().describe('FRED regional series id (e.g. "WIPCPI" for per-capita income)'),
+        date: z.string().optional().describe('Observation date YYYY-MM-DD (defaults to latest available)'),
+        region_type: z.string().optional().describe('Region granularity: "state" (default), "msa", "county"'),
+        start_date: z.string().optional().describe('Start date for ranged queries (optional)'),
+      }),
+      execute: async ({ symbol, date, region_type, start_date }) => {
+        const params: Record<string, unknown> = { symbol, provider: PROVIDER }
+        if (date !== undefined) params.date = date
+        if (region_type !== undefined) params.region_type = region_type
+        if (start_date !== undefined) params.start_date = start_date
+        return await economyClient.fredRegional(params)
+      },
+    }),
+  }
+}

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -154,7 +154,7 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
 /** Market data routes: POST /test-provider */
 export function createMarketDataRoutes(ctx: EngineContext) {
   const TEST_ENDPOINTS: Record<string, { credField: string; provider: string; model: string; params: Record<string, unknown> }> = {
-    fred:             { credField: 'fred_api_key',             provider: 'fred',             model: 'FredSearch',              params: { query: 'GDP' } },
+    fred:             { credField: 'federal_reserve_api_key',  provider: 'federal_reserve', model: 'FredSearch',              params: { query: 'GDP' } },
     bls:              { credField: 'bls_api_key',              provider: 'bls',              model: 'BlsSearch',               params: { query: 'unemployment' } },
     eia:              { credField: 'eia_api_key',              provider: 'eia',              model: 'ShortTermEnergyOutlook',  params: {} },
     econdb:           { credField: 'econdb_api_key',           provider: 'econdb',           model: 'AvailableIndicators',     params: {} },

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -159,9 +159,7 @@ export function createMarketDataRoutes(ctx: EngineContext) {
     eia:              { credField: 'eia_api_key',              provider: 'eia',              model: 'ShortTermEnergyOutlook',  params: {} },
     econdb:           { credField: 'econdb_api_key',           provider: 'econdb',           model: 'AvailableIndicators',     params: {} },
     fmp:              { credField: 'fmp_api_key',              provider: 'fmp',              model: 'EquityScreener',          params: { limit: 1 } },
-    nasdaq:           { credField: 'nasdaq_api_key',           provider: 'nasdaq',           model: 'EquitySearch',            params: { query: 'AAPL', is_symbol: true } },
     intrinio:         { credField: 'intrinio_api_key',         provider: 'intrinio',         model: 'EquitySearch',            params: { query: 'AAPL', limit: 1 } },
-    tradingeconomics: { credField: 'tradingeconomics_api_key', provider: 'tradingeconomics', model: 'EconomicCalendar',        params: {} },
   }
 
   const app = new Hono()

--- a/src/webui/routes/trading-config.ts
+++ b/src/webui/routes/trading-config.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import type { EngineContext } from '../../core/types.js'
 import {
   readUTAsConfig, writeUTAsConfig,
-  utaConfigSchema,
+  utaConfigSchema, wipeUTATradingData,
 } from '../../core/config.js'
 import { createBroker } from '../../domain/trading/brokers/factory.js'
 import { BUILTIN_BROKER_PRESETS } from '../../domain/trading/brokers/presets.js'
@@ -121,6 +121,7 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
         enabled: body.enabled !== false,
         guards: Array.isArray(body.guards) ? body.guards : [],
         presetConfig,
+        ...(body.ephemeral === true ? { ephemeral: true as const } : {}),
       }
       const validated = utaConfigSchema.parse(candidate)
       accounts.push(validated)
@@ -192,14 +193,23 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
     try {
       const id = c.req.param('id')
       const accounts = await readUTAsConfig()
-      const filtered = accounts.filter((a) => a.id !== id)
-      if (filtered.length === accounts.length) {
+      const target = accounts.find((a) => a.id === id)
+      if (!target) {
         return c.json({ error: `Account "${id}" not found` }, 404)
       }
+      const filtered = accounts.filter((a) => a.id !== id)
       await writeUTAsConfig(filtered)
       // Close and deregister running account instance if any
       await ctx.utaManager.removeUTA(id)
-      return c.json({ success: true })
+      // Ephemeral UTAs also have their persistent trading state wiped — the
+      // whole point of `ephemeral: true` is that nothing about the test
+      // account survives its destruction. Real broker UTAs keep their
+      // commit history (delete-from-config means "stop trading from here",
+      // not "erase what already happened").
+      if (target.ephemeral) {
+        await wipeUTATradingData(id)
+      }
+      return c.json({ success: true, ephemeral: target.ephemeral === true })
     } catch (err) {
       return c.json({ error: String(err) }, 500)
     }

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -25,14 +25,12 @@ const ASSET_LABELS: Record<string, string> = {
 }
 
 const ALL_PROVIDERS = [
-  { key: 'fmp', name: 'FMP', desc: 'Equity, crypto, currency, ETF, index — fundamentals, calendars, discovery.', hint: 'financialmodelingprep.com' },
-  { key: 'fred', name: 'FRED', desc: 'Federal Reserve Economic Data — CPI, GDP, interest rates, macro indicators.', hint: 'Free — fredaccount.stlouisfed.org/apikeys' },
-  { key: 'bls', name: 'BLS', desc: 'Bureau of Labor Statistics — employment, payrolls, wages, CPI.', hint: 'Free — registrationapps.bls.gov/bls_registration' },
-  { key: 'eia', name: 'EIA', desc: 'Energy Information Administration — petroleum status, energy reports.', hint: 'Free — eia.gov/opendata' },
-  { key: 'econdb', name: 'EconDB', desc: 'Global macro indicators, country profiles, shipping data.', hint: 'Optional — econdb.com' },
-  { key: 'intrinio', name: 'Intrinio', desc: 'Options snapshots, equity data.', hint: 'intrinio.com' },
-  { key: 'nasdaq', name: 'Nasdaq', desc: 'Nasdaq Data Link — dividend/earnings calendars, short interest.', hint: 'data.nasdaq.com' },
-  { key: 'tradingeconomics', name: 'Trading Economics', desc: '20M+ indicators across 196 countries, economic calendar.', hint: 'tradingeconomics.com' },
+  { key: 'fmp', name: 'FMP', desc: 'Equity, crypto, currency, commodity, ETF, index — fundamentals, calendars, discovery.', hint: 'financialmodelingprep.com' },
+  { key: 'fred', name: 'FRED', desc: 'Federal Reserve Economic Data — CPI, GDP, interest rates, macro indicators.', hint: 'Free — fred.stlouisfed.org → My Account → API Keys' },
+  { key: 'bls', name: 'BLS', desc: 'Bureau of Labor Statistics — employment, payrolls, wages, CPI.', hint: 'Free — data.bls.gov/registrationEngine/' },
+  { key: 'eia', name: 'EIA', desc: 'Energy Information Administration — petroleum status, energy reports.', hint: 'Free — eia.gov/opendata/register.php' },
+  { key: 'econdb', name: 'EconDB', desc: 'Global macro indicators, country profiles, shipping data.', hint: 'Required (free signup) — econdb.com' },
+  { key: 'intrinio', name: 'Intrinio', desc: 'Equities, ETFs, fundamentals, news, options snapshots.', hint: 'intrinio.com' },
 ] as const
 
 // ==================== Test Button ====================


### PR DESCRIPTION
## Summary

Two distinct streams landed on dev since the last cut to master:

1. **Trading subsystem maturation** — ephemeral mock-UTA lifecycle for fixture testing, three real bug fixes surfaced via a hand-driven covered-call simulator session, and an architectural correction to the IBKR-as-truth refactor (Phase 3's canonical localSymbol erased CCXT's USDC-vs-USDT margin distinction; reverted in favor of broker-native uniqueness).
2. **Macro / economic data layer end-to-end** — three independent failures along the FRED credential / executor / tool path, plus four more on the EIA path, all repaired and pushed through to the AI tool layer. AI agents can now read FRED + EIA macro data through one cohesive `economy*` toolset. UI provider-key form audited and pruned of dead links / unimplemented providers.

## Per-session contributions

### 2026-05-08 — Macro data layer (FRED + EIA) end-to-end + UI cleanup
- `fix(market-data): repair FRED end-to-end + add market-data e2e harness` (`a86612c`)
  - Three credential-chain misalignments fixed at once: webui/routes/config.ts referenced nonexistent `fred` provider (registry has `federal_reserve`); credential-map sent `fred_api_key` to both paths but in-process opentypebb auto-prefixes; etc. Adds a market-data e2e harness for future regressions.
- `feat(tool): expose FRED via three economy tools (search/series/regional)` (`0c7865e`)
  - Wraps `SDKEconomyClient` (which had been exported but never instantiated by a factory). Three Vercel AI tools route through `EconomyClientLike` with `provider: 'federal_reserve'` pinned at the tool boundary. Schema-validation tests (`economy.spec.ts`) catch zod / passthrough / error-propagation regressions in CI.
- `fix(ui): MarketDataPage hints — drop unimplemented providers, refresh dead URLs` (`86233d6`)
  - Audited the 8 entries in the API Keys form. Dropped `nasdaq` + `tradingeconomics` (no SDK provider registered — Test button always 500'd). Refreshed `bls` (registrationapps.bls.gov was retired; now points at data.bls.gov/registrationEngine/), `econdb` ("Optional" → "Required (free signup)" — anonymous API now 401), `eia` (direct register.php link), `fred` (the /apikeys deep link bounces unauthenticated users; standard fred.stlouisfed.org → My Account flow now). Widened `intrinio` and `fmp` descriptions to match what the providers actually return.
- `fix(eia): repair credential prefix + sort syntax + value coercion` (`1182dd9`)
  - Same /test-provider button caught the next provider's failure layer. EIA had three independent bugs: (1) `credentials: ['eia_api_key']` was already-prefixed and got double-prefixed by the Provider constructor to `eia_eia_api_key`, blocking credential propagation (mirror of the FRED bug, opposite direction); (2) both EIA fetchers built the `sort` query parameter as `JSON.stringify(...)`, but EIA Open Data API v2 takes PHP-style brackets and silently 403s on JSON; (3) EIA serialises numeric observations as strings and the fetchers passed the string straight through to the Zod schema. All three fixed.
- `feat(tool): expose EIA energy outlook + petroleum status as economy tools` (`b50f054`)
  - Two new AI tools — `economyEnergyOutlook` (STEO, with observed + forecast rows) and `economyPetroleumStatus` (weekly Petroleum Status Report). EIA endpoints route under `/commodity/*` upstream (OpenBB classifies oil/gas as commodity data) but conceptually they're macro, so the tool layer surfaces them in the `economy` namespace alongside FRED. `createEconomyTools` now takes both `economyClient` (FRED) and `commodityClient` (EIA); the AI / wire asymmetry is documented in the file header.

### 2026-05-07 — Trading: ephemeral UTAs, three bug fixes, Phase 3 revert
- `fix(mock): allow externalTrade SELL to open short positions` (`0e09127`)
  - The over-strict guard rejected covered-call's short-call leg. `externalTrade` (user-on-exchange semantics) now allows SELL-to-open; `placeOrder` / `_applyFill` retain the strict guard for Alice-initiated orders.
- `feat(uta): ephemeral test UTA lifecycle (boot purge + manual destroy)` (`ea8e1d2`)
  - New `ephemeral?: boolean` flag on `utaConfigSchema`, gated to the `mock-simulator` preset. Boot path purges all ephemeral entries (config row + `data/trading/<id>/`) before UTAManager init. `DELETE /api/trading/config/uta/:id` also wipes data dir for ephemeral UTAs. Closes the structural gap that let test residue pollute cost-basis across sessions.
- `fix(uta): wallet bootstrap respects broker-reported avgCost` (`ab51371`)
  - `_reconcileWalletPositions` was hardcoding the synthesized `reconcileBalance` op's price to `position.marketPrice`, destroying broker-reported avgCost on first sight (Mock externalTrade, Alpaca, IBKR). Now prefers `position.avgCost` when non-zero, falls back to `marketPrice` only when the broker has nothing — CCXT spot path unchanged (broker fakes avgCost = mark anyway), Mock/Alpaca/IBKR newly respected.
- `revert(ccxt): drop canonical localSymbol; wire format is broker-native identity` (`afddd41`)
  - Phase 3 of IBKR-as-truth (commit `4bcf2f4`) inserted a normalization step that rewrote CCXT's wire symbol `BTC/USDT:USDT` → `BTC-PERP` before storing it as `Contract.localSymbol`. That collapsed the `:settle` suffix and broke aliceId uniqueness within a single Bybit UTA (USDC-margined vs USDT-margined ETH perp became indistinguishable).
  - Architectural correction: **IBKR-as-truth = taxonomy, not identity.** IBKR's `Contract` *type* (secType union + per-secType fields) is canonical. `Contract.localSymbol` is broker-defined per broker — IBKR uses `conId`, CCXT uses unified wire symbol, Alpaca uses ticker. The system uniqueness primitive is `aliceId = "{utaId}|{nativeKey}"` where `nativeKey` comes from each broker's `getNativeKey`. We never normalize across brokers.
  - Phase 1 / 2 / 4 (position math, `buildContract` validation funnel, strict SecType union) are *taxonomy* work — kept. Phase 3 was *identity* work — reverted.

### 2026-05-07 — Workflow / CLAUDE.md
- `docs(claude): drop worktree convention; point parallel work at cloud` (`b6f7acc`)
  - Local worktrees are heavyweight for OpenAlice (per-worktree `pnpm install`, `data/` copying, port juggling); cloud Claude sessions are the right concurrency primitive for projects with stateful working trees.

### TODO bookkeeping
- `docs(todo): cost-basis bootstrap overwrites broker avgCost` (`f294217`)
- `docs(todo): drop cost-basis bootstrap entry — fixed in ab51371` (`0239694`)
- `docs(todo): IBKR getNativeKey may collide on option-chain fanout` (`15fdba8`)
  - IBKR's symbol/localSymbol aren't reliably unique — `conId` is the actual primary key. Audit needed for IBKR + Alpaca + LeverUp + Bybit-direct getNativeKey implementations.

## Full commit log

```
b50f054 feat(tool): expose EIA energy outlook + petroleum status as economy tools
1182dd9 fix(eia): repair credential prefix + sort syntax + value coercion
86233d6 fix(ui): MarketDataPage hints — drop unimplemented providers, refresh dead URLs
0c7865e feat(tool): expose FRED via three economy tools (search/series/regional)
15fdba8 docs(todo): IBKR getNativeKey may collide on option-chain fanout
afddd41 revert(ccxt): drop canonical localSymbol; wire format is broker-native identity
a86612c fix(market-data): repair FRED end-to-end + add market-data e2e harness
0239694 docs(todo): drop cost-basis bootstrap entry — fixed in ab51371
ab51371 fix(uta): wallet bootstrap respects broker-reported avgCost
f294217 docs(todo): cost-basis bootstrap overwrites broker avgCost
ea8e1d2 feat(uta): ephemeral test UTA lifecycle (boot purge + manual destroy)
0e09127 fix(mock): allow externalTrade SELL to open short positions
001c16f Merge remote-tracking branch 'origin/master' into dev
b6f7acc docs(claude): drop worktree convention; point parallel work at cloud
1df7060 docs(claude): branch convention for invasive refactors
```

## Test plan

- [x] `npx tsc --noEmit` clean (root + ui workspaces)
- [x] `pnpm vitest run` — 75 files / 1463 tests passing (was 1454; +9 EIA tool spec cases)
- [x] `pnpm vitest run --config vitest.e2e.config.ts src/domain/trading/__test__/e2e/` — 12 files / 64 trading-e2e tests passing, 23 skipped (live-broker preconditions)
- [x] `pnpm vitest run --config vitest.e2e.config.ts src/domain/market-data/__test__/e2e/` — FRED + EIA both green against live APIs (5 FRED + 3 EIA cases)
- [ ] After merge: smoke-test bybit-main / okx-test cost basis renders correctly. **Heads-up**: 16 commit.json aliceId entries on these UTAs from yesterday's Phase-3 window become orphan and re-bootstrap via reconcileBalance at current markPrice on next `getPositions`. Today's window was exploratory testing, no real cost-basis history lost.
- [ ] After merge: hit FRED + EIA tools from an Agent SDK session — `economyFredSearch` / `economyFredSeries` / `economyFredRegional` / `economyEnergyOutlook` / `economyPetroleumStatus` should return real data without credential errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
