### PR TITLE
fix(ui/tabs): crypto.randomUUID fallback for non-secure contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage/
 
 # Claude Code
 .claude/
+.playwright-mcp/
 packages/ibkr/ref/source/JavaClient/
 packages/ibkr/ref/source/cppclient/
 packages/ibkr/ref/samples/Java/

--- a/ui/src/tabs/store.ts
+++ b/ui/src/tabs/store.ts
@@ -51,7 +51,21 @@ export type WorkspaceStore = WorkspaceState & WorkspaceActions
 const DEFAULT_GROUP_ID = 'g1'
 
 function newId(): string {
-  return crypto.randomUUID()
+  // Browser crypto.randomUUID() is only defined in secure contexts (HTTPS /
+  // localhost). LAN-IP HTTP access gets undefined, so build a v4 id ourselves.
+  // crypto.getRandomValues IS available over HTTP.
+  const c = typeof crypto !== 'undefined' ? crypto : undefined
+  if (c?.randomUUID) return c.randomUUID()
+  const bytes = new Uint8Array(16)
+  if (c?.getRandomValues) {
+    c.getRandomValues(bytes)
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256)
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
 }
 
 function buildInitialState(): WorkspaceState {


### PR DESCRIPTION
## Summary
Browser tab id generation crashed for testers accessing OpenAlice over a
plain-HTTP LAN-IP URL — `crypto.randomUUID` is only defined in secure
contexts. Fix is a self-contained UUIDv4 fallback in `ui/src/tabs/store.ts`
that uses `crypto.getRandomValues` (which IS available over HTTP) and
falls back to `Math.random` if even that is missing. Also adds a
`.playwright-mcp/` entry to `.gitignore` for the session-scoped browser
debug artifacts that the Playwright MCP server drops when an agent runs
end-to-end verification.

## Per-session contributions
### 2026-05-12 — Crypto.randomUUID secure-context fix
- `newId()` in `ui/src/tabs/store.ts` now feature-tests `crypto.randomUUID`
  and synthesizes a v4 id from `crypto.getRandomValues` (or `Math.random`)
  when it is undefined.
- Why: a tester reported `TypeError: crypto.randomUUID is not a function`
  on first page load. The regression landed with the workspace store
  in `b1f1ec8` / `82aecd9` — local dev (`http://localhost:3002`) is a
  secure context so it went unnoticed; LAN-IP HTTP access is not.
- Add `.playwright-mcp/` to `.gitignore` so Playwright MCP's per-session
  console logs / accessibility snapshots stop polluting untracked status.
- Key commits: `0814b1d`, `42c4e7b`

## Full commit log
```
42c4e7b chore: gitignore .playwright-mcp/
0814b1d fix(ui/tabs): crypto.randomUUID fallback for non-secure contexts
```

## Test plan
- [x] `npx tsc --noEmit` clean (root + `ui/` package)
- [x] `pnpm test` — 86 files / 1675 tests pass from repo root
- [x] Bundle confirms fallback shipped (`grep getRandomValues dist/ui/assets/index-*.js`)
- [x] Live verification via Playwright MCP — with `crypto.randomUUID` deleted at runtime, clicking `Market → Browse Markets` creates a tab with a valid v4 id and zero console errors. Same gesture before the fix throws `TypeError: crypto.randomUUID is not a function` at `openOrFocus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)