### PR TITLE
Release v0.10.0-beta.2: placeOrder schema empty-string tolerance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.10.0-beta.1",
+  "version": "0.10.0-beta.2",
   "description": "File-based trading agent engine",
   "type": "module",
   "scripts": {

--- a/src/tool/trading.spec.ts
+++ b/src/tool/trading.spec.ts
@@ -251,3 +251,50 @@ describe('createTradingTools — getOrders summarization', () => {
     expect(result['mock-paper|ETH'].orders).toHaveLength(1)
   })
 })
+
+// ==================== placeOrder schema (AI ergonomics) ====================
+
+describe('placeOrder inputSchema', () => {
+  // LLMs frequently emit "" for fields they don't intend to set rather than
+  // omitting the key. Without empty-string tolerance, every optional numeric
+  // field rejects with "must be a positive numeric string" and the whole MKT
+  // call fails at the schema gate (the cashQty/lmtPrice/auxPrice cluster bug
+  // reported 2026-05-12).
+  it('treats empty-string optional numeric fields as omitted', () => {
+    const broker = new MockBroker({ id: 'mock-paper' })
+    const tools = createTradingTools(makeManager(broker))
+
+    const result = (tools.placeOrder.inputSchema as any).safeParse({
+      source: 'mock-paper',
+      aliceId: 'mock-paper|AAPL',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '0.01',
+      cashQty: '',
+      lmtPrice: '',
+      auxPrice: '',
+      trailStopPrice: '',
+      trailingPercent: '',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data.cashQty).toBeUndefined()
+    expect(result.data.lmtPrice).toBeUndefined()
+    expect(result.data.totalQuantity).toBe('0.01')
+  })
+
+  it('still rejects non-empty invalid numerics', () => {
+    const broker = new MockBroker({ id: 'mock-paper' })
+    const tools = createTradingTools(makeManager(broker))
+
+    const result = (tools.placeOrder.inputSchema as any).safeParse({
+      source: 'mock-paper',
+      aliceId: 'mock-paper|AAPL',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '0',
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -75,11 +75,20 @@ const sourceDesc = (required: boolean, extra?: string) => {
  * when the schema demands them; permissive `union([number, string])`
  * is unnecessary and re-opens the precision-loss path that this
  * whole sweep was meant to close.
+ *
+ * Empty string `""` is normalized to `undefined` before validation.
+ * Why: when this validator is used with `.optional()`, LLMs often
+ * emit `""` for fields they don't intend to set (instead of omitting
+ * the key), and a bare `z.string().refine(...).optional()` would
+ * then reject the empty string against the positive-number rule.
+ * Treating `""` as "not provided" matches the AI-ergonomics the
+ * `.optional()` site actually wants.
  */
 const positiveNumeric = z
   .string()
   .refine(
     (v) => {
+      if (v === '') return true
       try {
         return new Decimal(v).gt(0) && new Decimal(v).isFinite()
       } catch {
@@ -88,6 +97,7 @@ const positiveNumeric = z
     },
     { message: 'must be a positive numeric string (e.g. "0.001", "150")' },
   )
+  .transform((v) => (v === '' ? undefined : v))
 
 export function createTradingTools(manager: UTAManager, fxService?: FxService): Record<string, Tool> {
   return {


### PR DESCRIPTION
## Summary

Patch release fixing an order-staging bug that affected production use:
LLMs frequently emit `""` for optional numeric fields they don't intend
to set rather than omitting the key. The `placeOrder` schema's
`positiveNumeric.optional()` validator then rejected the empty string
against the positive-number refine, surfacing as
"cashQty / lmtPrice / auxPrice / trailStopPrice / trailingPercent
要求正数字" on otherwise-valid MKT orders. Fix is at the validator
level — empty string is now treated as "not provided" and transformed
to `undefined` before downstream code sees it.

This is a beta increment (0.10.0-beta.1 → 0.10.0-beta.2). One
user-facing bug fix plus two earlier housekeeping commits that hadn't
shipped yet.

## Per-session contributions

### 2026-05-12 — placeOrder empty-string tolerance + release

- `fix(tool/trading)`: `positiveNumeric` accepts `""` and transforms
  to `undefined`. Single change covers all 13 `.optional()` call
  sites in `placeOrder`, `modifyOrder`, and `closePosition`. Zero
  and non-numeric still rejected.
- Regression test in `src/tool/trading.spec.ts` exercises the exact
  shape the AI was emitting (MKT with five empty-string optionals).
- `chore(release)`: bump root `package.json` to `0.10.0-beta.2`.
- Key commits: `1bac549`, `93ef259`

## Full commit log

```
93ef259 chore(release): 0.10.0-beta.2
1bac549 fix(tool/trading): tolerate empty string in positiveNumeric
42c4e7b chore: gitignore .playwright-mcp/
0814b1d fix(ui/tabs): crypto.randomUUID fallback for non-secure contexts
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm test src/tool/trading.spec.ts` — 15/15 (2 new regression cases)
- [ ] Manual: place a MKT order from the AI on OKX testnet (or any CCXT
      broker) and confirm it stages without "要求正数字" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)