### PR TITLE
feat(workspaces): per-workspace AI provider config

### DIFF
--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -8,8 +8,10 @@
 
 import { Hono } from 'hono';
 import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
 
-import { listDir, PathTraversal } from '../../workspaces/file-service.js';
+import { listDir, PathTraversal, readWorkspaceFile, writeWorkspaceFile } from '../../workspaces/file-service.js';
 import { gitLog, gitStatus } from '../../workspaces/git-service.js';
 import { logger as launcherLogger } from '../../workspaces/logger.js';
 import type { SessionRecord } from '../../workspaces/session-registry.js';
@@ -417,7 +419,222 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     return c.json({ ok: true, wasRunning });
   });
 
+  // ── agent provider config ────────────────────────────────────────────────
+  // Per-workspace AI provider config lives in CLI-native files inside the
+  // workspace (`.claude/settings.local.json`, `.codex/config.toml`,
+  // `.codex/env.json`). The CLIs read them directly via cwd-discovery /
+  // CODEX_HOME. These routes are pure file IO over the launcher's
+  // path-traversal guard.
+
+  app.get('/agent-profiles', async (c) => {
+    try {
+      const raw = await readFile(resolvePath('data/config/ai-provider-manager.json'), 'utf8');
+      const parsed = JSON.parse(raw) as { profiles?: Record<string, ProfileShape> };
+      const profiles = parsed.profiles ?? {};
+      const list = Object.entries(profiles).map(([name, p]) => ({
+        name,
+        baseUrl: typeof p.baseUrl === 'string' ? p.baseUrl : null,
+        apiKey: typeof p.apiKey === 'string' ? p.apiKey : null,
+        model: typeof p.model === 'string' ? p.model : null,
+      }));
+      return c.json({ profiles: list });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return c.json({ profiles: [] });
+      launcherLogger.warn('agent_profiles.read_failed', { err });
+      return c.json({ error: 'profiles_read_failed', message: (err as Error).message }, 500);
+    }
+  });
+
+  app.get('/:id/agent-config', async (c) => {
+    const id = c.req.param('id');
+    if (!validId(id)) return c.json({ error: 'not_found' }, 404);
+    const meta = svc.registry.get(id);
+    if (!meta) return c.json({ error: 'not_found' }, 404);
+    try {
+      const [claude, codex] = await Promise.all([
+        readClaudeConfig(meta.dir),
+        readCodexConfig(meta.dir),
+      ]);
+      return c.json({ claude, codex });
+    } catch (err) {
+      if (err instanceof PathTraversal) return c.json({ error: 'invalid_path' }, 400);
+      launcherLogger.warn('agent_config.read_failed', { id, err });
+      return c.json({ error: 'read_failed', message: (err as Error).message }, 500);
+    }
+  });
+
+  app.put('/:id/agent-config/:agent', async (c) => {
+    const id = c.req.param('id');
+    const agent = c.req.param('agent');
+    if (!validId(id)) return c.json({ error: 'not_found' }, 404);
+    if (agent !== 'claude' && agent !== 'codex') return c.json({ error: 'unknown_agent' }, 400);
+    const meta = svc.registry.get(id);
+    if (!meta) return c.json({ error: 'not_found' }, 404);
+
+    const body = (await safeJson(c)) as AgentConfigInput | null;
+    const cfg = body && typeof body === 'object' ? body : {};
+    try {
+      if (agent === 'claude') {
+        await writeClaudeConfig(meta.dir, cfg);
+      } else {
+        await writeCodexConfig(meta.dir, cfg);
+      }
+      launcherLogger.info('agent_config.saved', { id, agent });
+      return c.json({ ok: true });
+    } catch (err) {
+      if (err instanceof PathTraversal) return c.json({ error: 'invalid_path' }, 400);
+      launcherLogger.warn('agent_config.write_failed', { id, agent, err });
+      return c.json({ error: 'write_failed', message: (err as Error).message }, 500);
+    }
+  });
+
   return app;
+}
+
+// ── Agent config helpers ────────────────────────────────────────────────────
+
+interface ProfileShape {
+  baseUrl?: unknown;
+  apiKey?: unknown;
+  model?: unknown;
+}
+
+interface AgentConfigInput {
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+  wireApi?: 'chat' | 'responses';
+}
+
+interface ClaudeConfigShape {
+  baseUrl: string | null;
+  apiKey: string | null;
+  model: string | null;
+}
+
+interface CodexConfigShape {
+  baseUrl: string | null;
+  apiKey: string | null;
+  model: string | null;
+  wireApi: 'chat' | 'responses' | null;
+}
+
+const CLAUDE_SETTINGS_PATH = '.claude/settings.local.json';
+const CODEX_CONFIG_PATH = '.codex/config.toml';
+const CODEX_ENV_PATH = '.codex/env.json';
+const CODEX_KEY_ENV_NAME = 'OPENALICE_WORKSPACE_KEY';
+const CODEX_PROVIDER_NAME = 'workspace';
+
+async function readClaudeConfig(workspaceDir: string): Promise<ClaudeConfigShape | null> {
+  const raw = await readWorkspaceFile(workspaceDir, CLAUDE_SETTINGS_PATH);
+  if (raw === null) return null;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const env = (parsed['env'] ?? {}) as Record<string, unknown>;
+  const baseUrl = typeof env['ANTHROPIC_BASE_URL'] === 'string' ? (env['ANTHROPIC_BASE_URL'] as string) : null;
+  const apiKey = typeof env['ANTHROPIC_API_KEY'] === 'string' ? (env['ANTHROPIC_API_KEY'] as string) : null;
+  const model = typeof parsed['model'] === 'string' ? (parsed['model'] as string) : null;
+  if (baseUrl === null && apiKey === null && model === null) return null;
+  return { baseUrl, apiKey, model };
+}
+
+async function writeClaudeConfig(workspaceDir: string, cfg: AgentConfigInput): Promise<void> {
+  const hasAny = cfg.baseUrl || cfg.apiKey || cfg.model;
+  if (!hasAny) {
+    // Reset: empty settings.local.json so claude falls back to global.
+    await writeWorkspaceFile(workspaceDir, CLAUDE_SETTINGS_PATH, '{}\n');
+    return;
+  }
+  const out: Record<string, unknown> = {};
+  const env: Record<string, string> = {};
+  if (cfg.baseUrl) env['ANTHROPIC_BASE_URL'] = cfg.baseUrl;
+  if (cfg.apiKey) env['ANTHROPIC_API_KEY'] = cfg.apiKey;
+  if (Object.keys(env).length > 0) out['env'] = env;
+  if (cfg.model) out['model'] = cfg.model;
+  await writeWorkspaceFile(workspaceDir, CLAUDE_SETTINGS_PATH, JSON.stringify(out, null, 2) + '\n');
+}
+
+async function readCodexConfig(workspaceDir: string): Promise<CodexConfigShape | null> {
+  const tomlRaw = await readWorkspaceFile(workspaceDir, CODEX_CONFIG_PATH);
+  const envRaw = await readWorkspaceFile(workspaceDir, CODEX_ENV_PATH);
+  if (tomlRaw === null && envRaw === null) return null;
+
+  let baseUrl: string | null = null;
+  let wireApi: 'chat' | 'responses' | null = null;
+  let model: string | null = null;
+  if (tomlRaw) {
+    // Shape-specific extraction: we always write the provider section as
+    // `[model_providers.workspace]` with `base_url`, `wire_api`, plus
+    // top-level `model`. Regex is brittle in general but our shape is
+    // controlled (writer below produces deterministic output).
+    const providerBlock = tomlRaw.match(/\[model_providers\.workspace\][^\[]*/);
+    if (providerBlock) {
+      const block = providerBlock[0];
+      const base = block.match(/base_url\s*=\s*"([^"]*)"/);
+      if (base) baseUrl = base[1] ?? null;
+      const wire = block.match(/wire_api\s*=\s*"(chat|responses)"/);
+      if (wire) wireApi = wire[1] as 'chat' | 'responses';
+    }
+    const modelMatch = tomlRaw.match(/^model\s*=\s*"([^"]*)"\s*$/m);
+    if (modelMatch) model = modelMatch[1] ?? null;
+  }
+
+  let apiKey: string | null = null;
+  if (envRaw) {
+    try {
+      const env = JSON.parse(envRaw) as Record<string, unknown>;
+      const k = env[CODEX_KEY_ENV_NAME];
+      if (typeof k === 'string') apiKey = k;
+    } catch { /* ignore parse error, leave apiKey null */ }
+  }
+
+  if (baseUrl === null && apiKey === null && model === null && wireApi === null) return null;
+  return { baseUrl, apiKey, model, wireApi };
+}
+
+async function writeCodexConfig(workspaceDir: string, cfg: AgentConfigInput): Promise<void> {
+  // Always preserve the MCP block (constant content, OpenAlice infrastructure).
+  // Provider block + top-level `model` / `model_provider` only when configured.
+  const mcpBlock =
+    '[mcp_servers.openalice]\n' +
+    'url = "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"\n';
+
+  const hasProvider = !!(cfg.baseUrl || cfg.model);
+  let toml = mcpBlock;
+  if (hasProvider) {
+    toml += '\n';
+    if (cfg.model) toml += `model = ${tomlString(cfg.model)}\n`;
+    if (cfg.baseUrl) toml += `model_provider = "${CODEX_PROVIDER_NAME}"\n`;
+    if (cfg.baseUrl) {
+      toml += '\n';
+      toml += `[model_providers.${CODEX_PROVIDER_NAME}]\n`;
+      toml += `name = "OpenAlice workspace provider"\n`;
+      toml += `base_url = ${tomlString(cfg.baseUrl)}\n`;
+      toml += `env_key = "${CODEX_KEY_ENV_NAME}"\n`;
+      toml += `wire_api = "${cfg.wireApi ?? 'chat'}"\n`;
+    }
+  }
+  await writeWorkspaceFile(workspaceDir, CODEX_CONFIG_PATH, toml);
+
+  // env.json: holds the per-workspace API key codex picks up via env_key.
+  // Adapter's composeEnv reads this and exports at spawn. Empty / missing
+  // file = no workspace key (codex falls back to ~/.codex/auth.json OAuth).
+  if (cfg.apiKey) {
+    const envObj: Record<string, string> = { [CODEX_KEY_ENV_NAME]: cfg.apiKey };
+    await writeWorkspaceFile(workspaceDir, CODEX_ENV_PATH, JSON.stringify(envObj, null, 2) + '\n');
+  } else {
+    // Reset key: write empty object so the adapter sees nothing to inject.
+    await writeWorkspaceFile(workspaceDir, CODEX_ENV_PATH, '{}\n');
+  }
+}
+
+function tomlString(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
 function validId(id: string | undefined): id is string {

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -23,6 +23,16 @@ import type { BootstrapContext, CliAdapter, SpawnContext } from '../cli-adapter.
  *   `~/.codex/config.toml` `[projects."<abs>"] trust_level`. `bootstrap()`
  *   pre-writes that entry so the launcher's spawn doesn't stall on the
  *   prompt.
+ *
+ * AI provider config: each workspace owns its own `.codex/` (we set
+ * `CODEX_HOME=<cwd>/.codex` via `composeEnv` below). The workspace's
+ * `config.toml` carries the OpenAlice MCP server entry + any
+ * UI-configured `[model_providers.*]` blocks; `auth.json` starts as a
+ * symlink to `~/.codex/auth.json` (graceful fallback to global login)
+ * and gets replaced by the UI with a real file when the user picks a
+ * workspace-specific provider. The MCP-flag translation that the
+ * launcher originally did via `mcpJsonToCodexFlags` is gone — codex
+ * reads MCP entries directly from the workspace's `config.toml` now.
  */
 export const codexAdapter: CliAdapter = {
   id: 'codex',
@@ -35,24 +45,57 @@ export const codexAdapter: CliAdapter = {
     transcriptDiscovery: 'none',
   },
 
-  /**
-   * Note we ignore the `base` arg (which carries the env override
-   * `WEB_TERMINAL_COMMAND`, claude-shaped). Codex has a distinct binary; if a
-   * user wants to override the path, they can wrap `codex` on $PATH.
-   *
-   * We translate the workspace's agent-agnostic `<cwd>/.mcp.json` (the same
-   * file claude reads) into codex `-c mcp_servers.*` flags so the launcher's
-   * MCP servers are visible to codex out-of-the-box, without polluting the
-   * user's global `~/.codex/config.toml`. `${VAR}` placeholders in .mcp.json
-   * are expanded against the spawn env right here (codex itself doesn't
-   * substitute env vars in `-c` values).
-   */
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
-    const mcpFlags = mcpJsonToCodexFlags(ctx.cwd, ctx.env);
-    const head = ['codex', ...mcpFlags];
+    const head = ['codex'];
     if (ctx.resume === undefined) return head;
     if (ctx.resume === 'last') return [...head, 'resume', '--last'];
     return [...head, 'resume', ctx.resume.sessionId];
+  },
+
+  /**
+   * Point codex at the workspace's own `.codex/` and inject any
+   * UI-configured env vars (api keys named by `[model_providers.X].env_key`
+   * in the workspace's `config.toml`).
+   *
+   * Defensive: only set `CODEX_HOME` when `<cwd>/.codex/auth.json` exists.
+   * Codex *crashes* ("Codex requires a login") if `CODEX_HOME` points at a
+   * dir without `auth.json`. Workspaces created by the current bootstrap
+   * always have it (real file or symlink to `~/.codex/auth.json`); legacy
+   * workspaces from before this change don't — those silently fall back
+   * to the global `~/.codex/` and lose workspace-MCP wiring until
+   * recreated. That's the migration story.
+   *
+   * `.codex/env.json` is the workspace's per-CLI env contribution. Codex
+   * has no notion of "literal api key in config" — its `env_key` field
+   * indirects through an env var. The OpenAlice UI writes the user's
+   * chosen key into `env.json` (e.g. `{"OPENALICE_WORKSPACE_KEY":"sk-..."}`)
+   * and the adapter exports those at spawn so codex's `env_key` lookup
+   * resolves. This is the one place we DO bridge a file → env (because
+   * codex requires env), but the source of truth is still the workspace
+   * file, not OpenAlice's internal state.
+   */
+  composeEnv(ctx: SpawnContext): Record<string, string> {
+    const result: Record<string, string> = {};
+    const workspaceCodex = join(ctx.cwd, '.codex');
+    if (existsSync(join(workspaceCodex, 'auth.json'))) {
+      result['CODEX_HOME'] = workspaceCodex;
+    }
+    const envFile = join(workspaceCodex, 'env.json');
+    if (existsSync(envFile)) {
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(envFile, 'utf8'));
+        if (parsed && typeof parsed === 'object') {
+          for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+            if (typeof v === 'string' && /^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) {
+              result[k] = v;
+            }
+          }
+        }
+      } catch {
+        // ignore parse errors; file is user-editable and v1 doesn't surface
+      }
+    }
+    return result;
   },
 
   async bootstrap(ctx: BootstrapContext): Promise<void> {
@@ -96,77 +139,4 @@ async function ensureTrustedProject(cwd: string): Promise<void> {
 
 function isENOENT(err: unknown): boolean {
   return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
-}
-
-// ── .mcp.json → codex `-c` flags ────────────────────────────────────────────
-
-interface McpServerSpec {
-  readonly command?: unknown;
-  readonly args?: unknown;
-  readonly env?: unknown;
-  readonly url?: unknown;
-}
-
-function mcpJsonToCodexFlags(cwd: string, env: Readonly<Record<string, string>>): readonly string[] {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(readFileSync(join(cwd, '.mcp.json'), 'utf8'));
-  } catch {
-    return [];
-  }
-  if (typeof parsed !== 'object' || parsed === null) return [];
-  const servers = (parsed as { mcpServers?: unknown }).mcpServers;
-  if (typeof servers !== 'object' || servers === null) return [];
-
-  const flags: string[] = [];
-  for (const [name, raw] of Object.entries(servers as Record<string, unknown>)) {
-    if (typeof raw !== 'object' || raw === null) continue;
-    if (!/^[A-Za-z0-9_-]+$/.test(name)) continue; // skip invalid keys to keep TOML path safe
-    const spec = raw as McpServerSpec;
-
-    // Streamable-HTTP MCP server. Codex's TOML key is just `url`; the
-    // `command`/`args`/`env` branch is mutually exclusive on codex's side
-    // (per `codex mcp add` usage), so we early-continue once we've emitted
-    // a url flag for this server name.
-    if (typeof spec.url === 'string') {
-      flags.push('-c', `mcp_servers.${name}.url=${tomlString(expand(spec.url, env))}`);
-      continue;
-    }
-
-    if (typeof spec.command === 'string') {
-      flags.push('-c', `mcp_servers.${name}.command=${tomlString(expand(spec.command, env))}`);
-    }
-    if (Array.isArray(spec.args)) {
-      const items = spec.args
-        .filter((a): a is string => typeof a === 'string')
-        .map((a) => tomlString(expand(a, env)))
-        .join(', ');
-      flags.push('-c', `mcp_servers.${name}.args=[${items}]`);
-    }
-    if (spec.env && typeof spec.env === 'object') {
-      for (const [k, v] of Object.entries(spec.env as Record<string, unknown>)) {
-        if (typeof v !== 'string') continue;
-        if (!/^[A-Za-z0-9_]+$/.test(k)) continue;
-        flags.push('-c', `mcp_servers.${name}.env.${k}=${tomlString(expand(v, env))}`);
-      }
-    }
-  }
-  return flags;
-}
-
-/** Expand `${VAR}` and `${VAR:-default}` against the spawn env. Missing vars become ''. */
-function expand(s: string, env: Readonly<Record<string, string>>): string {
-  return s.replace(/\$\{([^}]+)\}/g, (_match, expr: string) => {
-    const sep = expr.indexOf(':-');
-    if (sep >= 0) {
-      const name = expr.slice(0, sep);
-      const fallback = expr.slice(sep + 2);
-      return env[name] ?? fallback;
-    }
-    return env[expr] ?? '';
-  });
-}
-
-function tomlString(s: string): string {
-  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -80,6 +80,20 @@ export interface CliAdapter {
   envOverrides?(parent: NodeJS.ProcessEnv): EnvOverrides;
 
   /**
+   * Optional per-spawn env contribution. Unlike `envOverrides` (static, no
+   * spawn context), this receives the full `SpawnContext` so adapters can
+   * compute env values that depend on the workspace cwd — e.g. `CODEX_HOME`
+   * pointing at `<cwd>/.codex`. Merged into the spawn env AFTER
+   * `envOverrides` so this takes precedence for overlapping keys.
+   *
+   * Intentionally narrow: this is *launcher plumbing* (where to find files),
+   * NOT a back-door for injecting provider config (keys/URLs) — those live
+   * in the workspace's own files (`.claude/settings*.json`,
+   * `.codex/config.toml`) and are read by the CLI directly.
+   */
+  composeEnv?(ctx: SpawnContext): Record<string, string>;
+
+  /**
    * Workspace-creation hook. The launcher calls this once for every adapter
    * enabled on a workspace. Responsible for technical wiring (writing
    * `.mcp.json`, adding trust entries to global config, etc.) — NOT for

--- a/src/workspaces/file-service.ts
+++ b/src/workspaces/file-service.ts
@@ -1,5 +1,5 @@
-import { readdir, stat, lstat } from 'node:fs/promises';
-import { isAbsolute, normalize, resolve, sep } from 'node:path';
+import { readdir, readFile as nodeReadFile, writeFile as nodeWriteFile, mkdir, lstat as nodeLstat, stat, lstat, unlink } from 'node:fs/promises';
+import { dirname, isAbsolute, normalize, resolve, sep } from 'node:path';
 
 export interface FileEntry {
   readonly name: string;
@@ -75,4 +75,72 @@ export async function listDir(workspaceDir: string, relPath: string): Promise<Di
   });
 
   return { path: cleanRel === '.' ? '' : cleanRel, entries };
+}
+
+/**
+ * Resolve `relPath` against `workspaceDir`, enforcing the same traversal
+ * guard `listDir` uses. Returned path is absolute. Throws `PathTraversal`
+ * if the request escapes.
+ */
+function resolveInside(workspaceDir: string, relPath: string): string {
+  const cleanRel = normalize(relPath);
+  if (isAbsolute(cleanRel) || cleanRel === '..' || cleanRel.startsWith(`..${sep}`)) {
+    throw new PathTraversal(relPath);
+  }
+  const abs = resolve(workspaceDir, cleanRel);
+  const workspaceAbs = resolve(workspaceDir);
+  if (abs !== workspaceAbs && !abs.startsWith(workspaceAbs + sep)) {
+    throw new PathTraversal(relPath);
+  }
+  return abs;
+}
+
+/**
+ * Read a UTF-8 text file at `<workspaceDir>/<relPath>`. Returns `null`
+ * if the file doesn't exist (lets callers distinguish "missing" from
+ * "empty"). Symlinks are followed (we want to read what they point at,
+ * within the same traversal guard).
+ */
+export async function readWorkspaceFile(
+  workspaceDir: string,
+  relPath: string,
+): Promise<string | null> {
+  const abs = resolveInside(workspaceDir, relPath);
+  try {
+    return await nodeReadFile(abs, 'utf8');
+  } catch (err) {
+    if (isENOENT(err)) return null;
+    throw err;
+  }
+}
+
+/**
+ * Atomically write a UTF-8 text file at `<workspaceDir>/<relPath>`.
+ * Creates parent directories if missing. If a symlink exists at the
+ * target path, it's replaced with a regular file (used by the AI-config
+ * UI to upgrade `.codex/auth.json` from the bootstrap-time symlink to a
+ * workspace-local real file).
+ */
+export async function writeWorkspaceFile(
+  workspaceDir: string,
+  relPath: string,
+  content: string,
+): Promise<void> {
+  const abs = resolveInside(workspaceDir, relPath);
+  await mkdir(dirname(abs), { recursive: true });
+
+  // If the existing entry is a symlink, unlink before write so we don't
+  // mutate the link target.
+  try {
+    const ls = await nodeLstat(abs);
+    if (ls.isSymbolicLink()) await unlink(abs);
+  } catch (err) {
+    if (!isENOENT(err)) throw err;
+  }
+
+  await nodeWriteFile(abs, content, 'utf8');
+}
+
+function isENOENT(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
 }

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -117,15 +117,20 @@ export async function createWorkspaceService(): Promise<WorkspaceService> {
       const ws = registry.get(wsId);
       if (!ws) throw new Error(`workspace not found: ${wsId}`);
       const adapter = resolveAdapter(ws, ctx.agentId);
-      const env = buildSpawnEnv(process.env, {
+      const baseEnv = buildSpawnEnv(process.env, {
         AQ_WS_ID: wsId,
         AQ_LAUNCHER_REPO_ROOT: config.launcherRepoRoot,
       });
       const spawnCtx = {
         ...(ctx.resume !== undefined ? { resume: ctx.resume } : {}),
         cwd: ws.dir,
-        env,
+        env: baseEnv,
       };
+      // Adapter-contributed env (e.g. codex sets CODEX_HOME=<cwd>/.codex so
+      // the CLI reads workspace-local config). Merged AFTER baseEnv so the
+      // adapter wins on key collisions.
+      const adapterEnv = adapter.composeEnv?.(spawnCtx) ?? {};
+      const env = { ...baseEnv, ...adapterEnv };
       return {
         opts: {
           command: adapter.composeCommand(config.command, spawnCtx),

--- a/src/workspaces/templates/auto-quant/bootstrap.sh
+++ b/src/workspaces/templates/auto-quant/bootstrap.sh
@@ -73,6 +73,21 @@ cd "$OUT_DIR"
 # 2. autoresearch branch from whatever master/main the source points at.
 git checkout -b "autoresearch/$TAG" >/dev/null
 
+# ── Codex workspace skeleton + agent-config excludes ─────────────────────
+# Mirror the chat template's setup so codex's CODEX_HOME=$cwd/.codex works
+# and the UI-saved secrets never leak to upstream Auto-Quant pushes. See
+# chat/bootstrap.sh for the full rationale.
+mkdir -p .codex
+ln -sf "$HOME/.codex/auth.json" .codex/auth.json
+cat > .codex/config.toml <<'TOML'
+[mcp_servers.openalice]
+url = "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"
+TOML
+{
+  echo '.claude/settings.local.json'
+  echo '.codex/auth.json'
+} >> .git/info/exclude
+
 # 3. user_data/data is a real per-workspace directory. Auto-Quant's
 #    `.gitignore` already excludes `user_data/data/`, so prepare.py's output
 #    is untracked. If the SOURCE happens to ship pre-fetched data

--- a/src/workspaces/templates/chat/bootstrap.sh
+++ b/src/workspaces/templates/chat/bootstrap.sh
@@ -56,7 +56,40 @@ fi
 # drift; this is a literal copy, not a separate compose pass.
 cp CLAUDE.md AGENTS.md
 
+# ── Codex workspace skeleton ────────────────────────────────────────────────
+# Each workspace is its own VS-Code-style "open folder" — claude reads
+# `.claude/settings*.json` from cwd, codex reads `$CODEX_HOME` (which the
+# codex adapter points at this `.codex/` dir at spawn). We seed:
+#   - `.codex/config.toml` with the OpenAlice MCP block so codex sees the
+#     OpenAlice tool surface from day 1. The OpenAlice UI later patches
+#     `[model_providers.*]` + `model` / `model_provider` keys when the user
+#     picks a provider; we deliberately do not write provider config at
+#     create time (workspaces inherit the user's global CLI auth until
+#     explicitly configured).
+#   - `.codex/auth.json` symlinked to the user's global codex login so a
+#     fresh-config workspace still has a valid auth. The UI replaces this
+#     symlink with a real file when the user assigns a workspace-specific
+#     key (so global rotation doesn't leak into configured workspaces).
+mkdir -p .codex
+ln -sf "$HOME/.codex/auth.json" .codex/auth.json
+cat > .codex/config.toml <<'TOML'
+[mcp_servers.openalice]
+url = "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"
+TOML
+
 git init -q
+
+# `.git/info/exclude` is per-clone, untracked. Belt-and-suspenders against
+# UI-saved secrets ever entering a push:
+#   - .claude/settings.local.json — claude itself auto-ignores this, but
+#     the entry here defends against any future tooling reading from
+#     `.gitignore` instead of trusting claude's runtime behaviour.
+#   - .codex/auth.json — codex's auth (symlink or real file). Never push.
+{
+  echo '.claude/settings.local.json'
+  echo '.codex/auth.json'
+} >> .git/info/exclude
+
 git add .
 git -c user.email=launcher@local -c user.name=launcher commit -q -m "chat: $TAG"
 

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -36,6 +36,8 @@ export interface SidebarProps {
   readonly onResumeSession: (wsId: string, sessionId: string) => void;
   readonly onDeleteSession: (wsId: string, sessionId: string) => void;
   readonly onChanged: () => void;
+  /** Optional: open the per-workspace AI-provider config modal. */
+  readonly onConfigureWorkspace?: (wsId: string) => void;
 }
 
 export function Sidebar(props: SidebarProps): ReactElement {
@@ -191,6 +193,7 @@ export function Sidebar(props: SidebarProps): ReactElement {
             onResumeSession={props.onResumeSession}
             onDeleteSession={props.onDeleteSession}
             onDelete={onDelete}
+            onConfigureWorkspace={props.onConfigureWorkspace}
           />
         ))}
       </ul>
@@ -209,6 +212,7 @@ interface WorkspaceRowProps {
   readonly onResumeSession: (wsId: string, sessionId: string) => void;
   readonly onDeleteSession: (wsId: string, sessionId: string) => void;
   readonly onDelete: (id: string) => Promise<void>;
+  readonly onConfigureWorkspace?: (wsId: string) => void;
 }
 
 function agentLabel(id: string, agents: readonly AgentInfo[]): string {
@@ -318,6 +322,16 @@ function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
               </ul>
             )}
           </div>
+        )}
+        {props.onConfigureWorkspace && (
+          <button
+            type="button"
+            className="sidebar-action sidebar-action-config"
+            title="configure AI provider for this workspace"
+            onClick={() => props.onConfigureWorkspace?.(w.id)}
+          >
+            ⚙
+          </button>
         )}
         <button
           type="button"

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -1,0 +1,326 @@
+/**
+ * Per-workspace AI provider config modal.
+ *
+ * Workspaces are VS-Code-style "open folders" — each owns its CLI config
+ * files (.claude/settings.local.json, .codex/config.toml + env.json). This
+ * modal is the visual editor for those files. Files are the source of
+ * truth; the modal reads + writes via the workspace API. Restart any open
+ * sessions for changes to take effect (env is read at CLI startup).
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  getAgentConfig,
+  listAgentProfiles,
+  saveAgentConfig,
+  type AgentConfig,
+  type AgentConfigBundle,
+  type AgentId,
+  type AgentProfile,
+} from './api'
+
+interface Props {
+  wsId: string
+  onClose: () => void
+}
+
+const inputClass =
+  'w-full bg-bg-secondary border border-border rounded-md px-3 py-2 text-[13px] text-text placeholder:text-text-muted/60 focus:outline-none focus:border-accent'
+
+type Tab = 'claude' | 'codex'
+
+interface FormState {
+  baseUrl: string
+  apiKey: string
+  model: string
+  wireApi: 'chat' | 'responses'
+}
+
+const EMPTY_FORM: FormState = { baseUrl: '', apiKey: '', model: '', wireApi: 'chat' }
+
+function configToForm(cfg: AgentConfig | null): FormState {
+  if (!cfg) return EMPTY_FORM
+  return {
+    baseUrl: cfg.baseUrl ?? '',
+    apiKey: cfg.apiKey ?? '',
+    model: cfg.model ?? '',
+    wireApi: (cfg.wireApi as 'chat' | 'responses') ?? 'chat',
+  }
+}
+
+function formToConfig(form: FormState, agent: AgentId): AgentConfig {
+  const cfg: AgentConfig = {
+    baseUrl: form.baseUrl.trim() || null,
+    apiKey: form.apiKey.trim() || null,
+    model: form.model.trim() || null,
+  }
+  if (agent === 'codex') {
+    return { ...cfg, wireApi: form.wireApi }
+  }
+  return cfg
+}
+
+export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('claude')
+  const [profiles, setProfiles] = useState<AgentProfile[]>([])
+  const [bundle, setBundle] = useState<AgentConfigBundle | null>(null)
+  const [claudeForm, setClaudeForm] = useState<FormState>(EMPTY_FORM)
+  const [codexForm, setCodexForm] = useState<FormState>(EMPTY_FORM)
+  const [pickedProfile, setPickedProfile] = useState<string>('')
+  const [showKey, setShowKey] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [savedFlash, setSavedFlash] = useState(false)
+
+  useEffect(() => {
+    void Promise.all([listAgentProfiles(), getAgentConfig(wsId)])
+      .then(([ps, b]) => {
+        setProfiles(ps)
+        setBundle(b)
+        setClaudeForm(configToForm(b.claude))
+        setCodexForm(configToForm(b.codex))
+      })
+      .catch((err: Error) => setError(err.message))
+  }, [wsId])
+
+  const form = tab === 'claude' ? claudeForm : codexForm
+  const setForm = tab === 'claude' ? setClaudeForm : setCodexForm
+  const dirty = useMemo(() => {
+    if (!bundle) return false
+    const saved = tab === 'claude' ? bundle.claude : bundle.codex
+    const savedForm = configToForm(saved)
+    return (
+      savedForm.baseUrl !== form.baseUrl ||
+      savedForm.apiKey !== form.apiKey ||
+      savedForm.model !== form.model ||
+      (tab === 'codex' && savedForm.wireApi !== form.wireApi)
+    )
+  }, [bundle, form, tab])
+
+  const applyProfile = () => {
+    const p = profiles.find((x) => x.name === pickedProfile)
+    if (!p) return
+    setForm({
+      ...form,
+      baseUrl: p.baseUrl ?? '',
+      apiKey: p.apiKey ?? '',
+      model: p.model ?? '',
+    })
+  }
+
+  const handleSave = async () => {
+    setError(null)
+    setSaving(true)
+    try {
+      await saveAgentConfig(wsId, tab, formToConfig(form, tab))
+      const fresh = await getAgentConfig(wsId)
+      setBundle(fresh)
+      setSavedFlash(true)
+      setTimeout(() => setSavedFlash(false), 1800)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleReset = async () => {
+    setError(null)
+    setSaving(true)
+    try {
+      await saveAgentConfig(wsId, tab, { baseUrl: null, apiKey: null, model: null })
+      const fresh = await getAgentConfig(wsId)
+      setBundle(fresh)
+      if (tab === 'claude') setClaudeForm(EMPTY_FORM)
+      else setCodexForm(EMPTY_FORM)
+      setSavedFlash(true)
+      setTimeout(() => setSavedFlash(false), 1800)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg border border-border rounded-xl shadow-2xl w-full max-w-xl max-h-[85vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h2 className="text-[15px] font-semibold text-text">Workspace AI Provider</h2>
+          <button onClick={onClose} className="text-text-muted hover:text-text transition-colors">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-border bg-bg-secondary/50">
+          {(['claude', 'codex'] as const).map((id) => (
+            <button
+              key={id}
+              onClick={() => setTab(id)}
+              className={`flex-1 px-4 py-2.5 text-[13px] font-medium transition-colors ${
+                tab === id
+                  ? 'text-accent border-b-2 border-accent -mb-px'
+                  : 'text-text-muted hover:text-text'
+              }`}
+            >
+              {id === 'claude' ? 'Claude Code' : 'Codex'}
+            </button>
+          ))}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {/* Quick pick */}
+          <div className="rounded-lg border border-border bg-bg-secondary/30 p-3">
+            <label className="block text-xs font-medium text-text-muted mb-2">
+              Apply from OpenAlice profile
+            </label>
+            <div className="flex gap-2">
+              <select
+                value={pickedProfile}
+                onChange={(e) => setPickedProfile(e.target.value)}
+                className={inputClass + ' flex-1'}
+              >
+                <option value="">— select a profile —</option>
+                {profiles.map((p) => (
+                  <option key={p.name} value={p.name}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={applyProfile}
+                disabled={!pickedProfile}
+                className="px-3 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+
+          {/* Manual fields */}
+          <div>
+            <label className="block text-xs font-medium text-text-muted mb-1">Base URL</label>
+            <input
+              value={form.baseUrl}
+              onChange={(e) => setForm({ ...form, baseUrl: e.target.value })}
+              placeholder={tab === 'claude' ? 'https://api.anthropic.com (default)' : 'https://api.openai.com/v1 (default)'}
+              className={inputClass}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-text-muted mb-1">API Key</label>
+            <div className="flex gap-2">
+              <input
+                type={showKey ? 'text' : 'password'}
+                value={form.apiKey}
+                onChange={(e) => setForm({ ...form, apiKey: e.target.value })}
+                placeholder="sk-..."
+                className={inputClass + ' flex-1'}
+                spellCheck={false}
+                autoCapitalize="off"
+                autoCorrect="off"
+              />
+              <button
+                onClick={() => setShowKey(!showKey)}
+                className="px-3 rounded-md border border-border text-text-muted hover:text-text text-[12px]"
+                type="button"
+              >
+                {showKey ? 'Hide' : 'Show'}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-text-muted mb-1">Model</label>
+            <input
+              value={form.model}
+              onChange={(e) => setForm({ ...form, model: e.target.value })}
+              placeholder={tab === 'claude' ? 'claude-sonnet-4-6' : 'gpt-4o'}
+              className={inputClass}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+            />
+          </div>
+
+          {tab === 'codex' && (
+            <div>
+              <label className="block text-xs font-medium text-text-muted mb-1">
+                Wire Format
+              </label>
+              <select
+                value={form.wireApi}
+                onChange={(e) => setForm({ ...form, wireApi: e.target.value as 'chat' | 'responses' })}
+                className={inputClass}
+              >
+                <option value="chat">chat (OpenAI Chat Completions — most common)</option>
+                <option value="responses">responses (OpenAI Responses API)</option>
+              </select>
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-md border border-red/40 bg-red/10 text-red text-[12px] px-3 py-2">
+              {error}
+            </div>
+          )}
+          {savedFlash && (
+            <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
+              Saved. Pause + resume any open session to reload.
+            </div>
+          )}
+
+          <p className="text-[11px] text-text-muted/80 leading-snug pt-1">
+            Empty fields fall back to the CLI's global default. Changes apply to
+            <strong className="text-text"> new sessions</strong>; pause and resume
+            any open session to re-load.
+            {tab === 'claude' && ' Claude reads `.claude/settings.local.json` from the workspace cwd.'}
+            {tab === 'codex' && ' Codex reads `.codex/config.toml` + `.codex/env.json` (via CODEX_HOME).'}
+          </p>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between gap-2 p-3 border-t border-border bg-bg-secondary/30">
+          <button
+            onClick={handleReset}
+            disabled={saving}
+            className="px-3 py-2 rounded-md border border-border text-text-muted hover:text-text text-[12px] disabled:opacity-40"
+          >
+            Reset to global default
+          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              disabled={saving}
+              className="px-3 py-2 rounded-md text-text-muted hover:text-text text-[13px]"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving || !dirty}
+              className="px-4 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/workspace/WorkspacesSidebar.tsx
+++ b/ui/src/components/workspace/WorkspacesSidebar.tsx
@@ -43,6 +43,7 @@ export function WorkspacesSidebar() {
         onResumeSession={(wsId, id) => void ctx.resumeSession(wsId, id)}
         onDeleteSession={(wsId, id) => void ctx.deleteSession(wsId, id)}
         onChanged={() => void ctx.refresh()}
+        onConfigureWorkspace={(wsId) => ctx.openAgentConfig(wsId)}
       />
     </div>
   )

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -265,3 +265,59 @@ export async function listFiles(id: string, relPath: string): Promise<DirListing
   if (!res.ok) throw new Error(`list files failed: ${res.status}`);
   return (await res.json()) as DirListing;
 }
+
+// ── Agent provider config ───────────────────────────────────────────────────
+
+export interface AgentProfile {
+  readonly name: string;
+  readonly baseUrl: string | null;
+  readonly apiKey: string | null;
+  readonly model: string | null;
+}
+
+export interface AgentConfig {
+  readonly baseUrl: string | null;
+  readonly apiKey: string | null;
+  readonly model: string | null;
+  /** Codex only — wire format for the upstream API. */
+  readonly wireApi?: 'chat' | 'responses' | null;
+}
+
+export interface AgentConfigBundle {
+  readonly claude: AgentConfig | null;
+  readonly codex: AgentConfig | null;
+}
+
+export type AgentId = 'claude' | 'codex';
+
+export async function listAgentProfiles(): Promise<AgentProfile[]> {
+  const res = await fetch('/api/workspaces/agent-profiles');
+  if (!res.ok) throw new Error(`list agent profiles failed: ${res.status}`);
+  const body = (await res.json()) as { profiles: AgentProfile[] };
+  return body.profiles;
+}
+
+export async function getAgentConfig(wsId: string): Promise<AgentConfigBundle> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(wsId)}/agent-config`);
+  if (!res.ok) throw new Error(`get agent config failed: ${res.status}`);
+  return (await res.json()) as AgentConfigBundle;
+}
+
+export async function saveAgentConfig(
+  wsId: string,
+  agent: AgentId,
+  cfg: AgentConfig,
+): Promise<void> {
+  const res = await fetch(
+    `/api/workspaces/${encodeURIComponent(wsId)}/agent-config/${agent}`,
+    {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+    },
+  );
+  if (!res.ok) {
+    const msg = await res.text().catch(() => '');
+    throw new Error(`save agent config failed: ${res.status} ${msg}`);
+  }
+}

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -27,6 +27,7 @@ import {
 
 import '../components/workspace/workspaces.css'
 
+import { WorkspaceAIConfigModal } from '../components/workspace/WorkspaceAIConfigModal'
 import {
   deleteSession as apiDeleteSession,
   listAgents,
@@ -59,6 +60,8 @@ interface WorkspacesContextValue {
   pauseSession(wsId: string, sessionId: string): Promise<void>
   resumeSession(wsId: string, sessionId: string): Promise<void>
   deleteSession(wsId: string, sessionId: string): Promise<void>
+  /** Open the per-workspace AI-provider config modal for `wsId`. */
+  openAgentConfig(wsId: string): void
 }
 
 const WorkspacesContext = createContext<WorkspacesContextValue | null>(null)
@@ -73,6 +76,11 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   // "every workspace was just deleted" and a deep-linked workspace URL
   // gets its freshly-opened tab closed before the first poll lands.
   const [hasLoaded, setHasLoaded] = useState(false)
+  // AI-provider config modal target. Lifted to context so the sidebar
+  // gear button (no workspace tab needed) and the WorkspacePage header
+  // button share one modal instance — and the modal survives activity
+  // switches (rendered here, not inside an activity-scoped component).
+  const [configuringWsId, setConfiguringWsId] = useState<string | null>(null)
 
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const closeTab = useWorkspace((s) => s.closeTab)
@@ -227,9 +235,16 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         pauseSession,
         resumeSession,
         deleteSession,
+        openAgentConfig: (wsId: string) => setConfiguringWsId(wsId),
       }}
     >
       {children}
+      {configuringWsId !== null && (
+        <WorkspaceAIConfigModal
+          wsId={configuringWsId}
+          onClose={() => setConfiguringWsId(null)}
+        />
+      )}
     </WorkspacesContext.Provider>
   )
 }

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -16,11 +16,12 @@
  * keeps running on the server. Use the sidebar's × to actually delete.
  */
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import '@xterm/xterm/css/xterm.css'
 
 import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { WorkspaceView } from '../components/workspace/WorkspaceView'
+import { WorkspaceAIConfigModal } from '../components/workspace/WorkspaceAIConfigModal'
 import type { KeyMap } from '../components/workspace/Terminal'
 import type { ViewSpec } from '../tabs/types'
 
@@ -37,6 +38,7 @@ export function WorkspacePage({ spec, visible }: Props) {
   const ctx = useWorkspaces()
   const wsId = spec.params.wsId
   const sessionId = spec.params.sessionId ?? null
+  const [aiConfigOpen, setAiConfigOpen] = useState(false)
 
   const workspace = ctx.workspaces.find((w) => w.id === wsId)
   const sessions = workspace?.sessions ?? []
@@ -74,22 +76,47 @@ export function WorkspacePage({ spec, visible }: Props) {
   // xterm + WS alive, so tab switching doesn't re-mount or re-stream — the
   // launcher's old multi-slot-in-one-pane trick is moot at this layer.
   return (
-    <div className="workspaces-root flex-1 min-h-0 flex flex-col p-3">
-      <WorkspaceView
-        wsId={wsId}
-        sessionId={sessionId}
-        activeRecord={activeRecord}
-        sessions={activeRecord ? [activeRecord] : []}
-        label={workspace.tag}
-        keyMap={APP_KEY_MAP}
-        onSpawnFresh={() => void ctx.spawn(wsId, {})}
-        onResume={(id) => void ctx.resumeSession(wsId, id)}
-        onSessionLost={() => {
-          // 4404 from the WS upgrade — the session is gone server-side.
-          // Refresh the list; the reconcile effect will close this tab.
-          void ctx.refresh()
-        }}
-      />
+    <div className="workspaces-root flex-1 min-h-0 flex flex-col">
+      {/* OpenAlice-side header bar above the launcher's WorkspaceView. The
+       *  launcher component itself is byte-faithful; we add the AI-provider
+       *  affordance here. */}
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-bg-secondary/30 shrink-0">
+        <span className="text-[12px] text-text-muted font-medium">{workspace.tag}</span>
+        <button
+          type="button"
+          onClick={() => setAiConfigOpen(true)}
+          className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
+          title="Configure this workspace's AI provider (claude / codex)"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+          AI Provider
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 flex flex-col p-3">
+        <WorkspaceView
+          wsId={wsId}
+          sessionId={sessionId}
+          activeRecord={activeRecord}
+          sessions={activeRecord ? [activeRecord] : []}
+          label={workspace.tag}
+          keyMap={APP_KEY_MAP}
+          onSpawnFresh={() => void ctx.spawn(wsId, {})}
+          onResume={(id) => void ctx.resumeSession(wsId, id)}
+          onSessionLost={() => {
+            // 4404 from the WS upgrade — the session is gone server-side.
+            // Refresh the list; the reconcile effect will close this tab.
+            void ctx.refresh()
+          }}
+        />
+      </div>
+
+      {aiConfigOpen && (
+        <WorkspaceAIConfigModal wsId={wsId} onClose={() => setAiConfigOpen(false)} />
+      )}
     </div>
   )
 }

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -16,12 +16,11 @@
  * keeps running on the server. Use the sidebar's × to actually delete.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import '@xterm/xterm/css/xterm.css'
 
 import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { WorkspaceView } from '../components/workspace/WorkspaceView'
-import { WorkspaceAIConfigModal } from '../components/workspace/WorkspaceAIConfigModal'
 import type { KeyMap } from '../components/workspace/Terminal'
 import type { ViewSpec } from '../tabs/types'
 
@@ -38,7 +37,6 @@ export function WorkspacePage({ spec, visible }: Props) {
   const ctx = useWorkspaces()
   const wsId = spec.params.wsId
   const sessionId = spec.params.sessionId ?? null
-  const [aiConfigOpen, setAiConfigOpen] = useState(false)
 
   const workspace = ctx.workspaces.find((w) => w.id === wsId)
   const sessions = workspace?.sessions ?? []
@@ -84,7 +82,7 @@ export function WorkspacePage({ spec, visible }: Props) {
         <span className="text-[12px] text-text-muted font-medium">{workspace.tag}</span>
         <button
           type="button"
-          onClick={() => setAiConfigOpen(true)}
+          onClick={() => ctx.openAgentConfig(wsId)}
           className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
           title="Configure this workspace's AI provider (claude / codex)"
         >
@@ -113,10 +111,6 @@ export function WorkspacePage({ spec, visible }: Props) {
           }}
         />
       </div>
-
-      {aiConfigOpen && (
-        <WorkspaceAIConfigModal wsId={wsId} onClose={() => setAiConfigOpen(false)} />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Workspaces can now hold their own AI provider settings — each workspace is a VS-Code-style self-contained unit. Open one in MiniMax, another in DeepSeek, another in Kimi, another on Claude Pro/Max OAuth. The CLI tools read their own config from the workspace cwd by convention; OpenAlice's role is the scaffold + visual editor. No spawn-time provider injection — files on disk are the source of truth. Manual `claude` / `codex` inside the workspace terminal pick up the same provider as OpenAlice-spawned sessions.

## Per-session contributions

### 2026-05-13 — Workspace-level AI provider
- **CLI-native file layout** — claude reads `<workspace>/.claude/settings.local.json` from cwd; codex reads `<workspace>/.codex/config.toml` + `.codex/env.json` via `CODEX_HOME` (set by the codex adapter). No `.openalice/` shadow files — the workspace IS the config.
- **Bootstrap skeleton** — both chat and auto-quant templates now drop a `.codex/` skeleton (`config.toml` with the OpenAlice MCP block, `auth.json` symlinked to `~/.codex/auth.json` so codex doesn't crash before user configures). `.git/info/exclude` pre-emptively ignores secret files (`.claude/settings.local.json`, `.codex/auth.json`).
- **`composeEnv` adapter hook** — new optional `composeEnv?(ctx)` on `CliAdapter`. Codex uses it for `CODEX_HOME` (plumbing — where files live, not what to auth as) and to shuttle `.codex/env.json` values into the spawn env (codex's `env_key` indirection has no file-based alternative). Claude adapter unchanged — claude reads `env.ANTHROPIC_BASE_URL` from `.claude/settings.local.json` natively (verified via `claude --debug api` against a bogus host).
- **Backend routes** — 3 new endpoints under `/api/workspaces`: `agent-profiles` (lists OpenAlice's existing AI profiles for the UI's quick-pick), `:id/agent-config` (read), `:id/agent-config/:agent` (write). File IO uses the existing `PathTraversal` guard extended with `readWorkspaceFile` / `writeWorkspaceFile` helpers.
- **UI** — new `WorkspaceAIConfigModal` (tabs per agent, profile quick-pick + manual fields + reset). Two entry points share one modal instance (state lifted to `WorkspacesContext`, modal rendered at provider level so it survives activity switches):
  - `⚙` button on each workspace row in the sidebar — configure without opening a tab
  - `AI Provider` button in the WorkspacePage header — configure while inside a workspace
- **Codex MCP simplification** — old `mcpJsonToCodexFlags` translator removed. Workspace's own `.codex/config.toml` carries the MCP block directly now; codex reads it via CODEX_HOME.

Key commits: `7e56d1d` (feature), `eff21b7` (sidebar entry point)

## Full commit log

```
eff21b7 feat(workspaces/ui): add ⚙ AI Provider button to sidebar workspace row
7e56d1d feat(workspaces): per-workspace AI provider config via CLI-native files
```

## Migration note

Legacy workspaces created before this change don't have a `.codex/` skeleton. The codex adapter defensively skips setting `CODEX_HOME` when `<workspace>/.codex/auth.json` is missing, so those workspaces silently fall back to the user's global codex setup. They also lose workspace-MCP wiring for codex until recreated. Workspaces created after this commit are fully covered.

## Test plan

- [x] `npx tsc --noEmit` clean (root + ui)
- [x] `pnpm test` — 88 files, 1687 tests passing
- [x] `vite build` clean
- [x] Manual smoke (curl):
  - [x] Fresh chat workspace: bootstrap creates `.codex/{config.toml, auth.json symlink}`, `.git/info/exclude` has both safety lines
  - [x] `GET /api/workspaces/agent-profiles` returns Claude/MiniMax/DeepSeek
  - [x] `PUT .../agent-config/claude` writes `.claude/settings.local.json` with `env.ANTHROPIC_BASE_URL` + `env.ANTHROPIC_API_KEY` + `model`
  - [x] `PUT .../agent-config/codex` writes `.codex/config.toml` (preserving MCP block, adding `[model_providers.workspace]`) + `.codex/env.json` (containing `OPENALICE_WORKSPACE_KEY`)
  - [x] GET round-trip parses each correctly
  - [x] PUT empty body resets the file to `{}` (claude) or back to just MCP + empty env.json (codex)
- [x] Browser interactive (user-verified): created a workspace, picked Kimi via the sidebar ⚙ button, claude session in the workspace now uses Kimi endpoint without any OpenAlice profile switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)