### PR TITLE
workspaces + chat: codex inheritance fix, Overview dashboard, two-kinds-of-chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,41 @@ graph TB
 
 **AI Provider** — The AI backend that powers Alice. Claude (via Agent SDK, supports OAuth login or API key) or Vercel AI SDK (Anthropic, OpenAI, Google). Switchable at runtime — no restart needed.
 
+## Two kinds of chat
+
+OpenAlice ships two paths for chatting with Alice. They have very different performance characteristics, and picking the right one matters more than it looks.
+
+### Workspace chat (recommended when available)
+
+A chat-type **workspace** is a directory + git repo + a persistent terminal session running the native CLI of your chosen agent (`claude`, `codex`, or `shell`). The CLI process handles all model interaction, prompt caching, and rendering — OpenAlice's job is to plumb its MCP server into the workspace and surface the terminal in the UI.
+
+- **Native prompt cache.** Claude Code, Codex, and the other agent CLIs implement vendor-specific cache control we can't replicate. On a long conversation this is often a 10× cost reduction.
+- **Native frontend.** TUI rendering, syntax highlighting, diff display — the CLI vendor has already tuned these for their model.
+- **Full tool surface.** The CLI sees the workspace's local files plus OpenAlice's MCP tools. No "greatest-common-denominator" trimming.
+- **Stable.** No `ChatHook` protocol layer between you and the model.
+
+The only requirement: the CLI binary has to be installed on the host running OpenAlice.
+
+### Traditional chat
+
+The original `/chat` page. OpenAlice's `ChatHook` calls the agent SDK (Vercel AI SDK or Anthropic Agent SDK) directly, normalizes events through its own layer, and renders them.
+
+- **No shell required.** Works in any environment OpenAlice runs in.
+- **Reachable by connectors.** Telegram, MCP Ask, and webhook-pushed messages all land here because those surfaces have no terminal to host a CLI in.
+
+The cost: token usage is high (cache control is OpenAlice's responsibility and still incomplete), capability is constrained (each new CLI feature has to be re-implemented at the `ChatHook` layer), and `ChatHook` itself is still maturing.
+
+### Which one should I use?
+
+| Scenario | Use |
+| --- | --- |
+| Interactive UI chats with Alice on this machine | **Workspace chat** |
+| Connector-pushed messages (Telegram bot, webhook callbacks) | Traditional chat |
+| Long sessions where token cost matters | **Workspace chat** |
+| Environment with no shell / no CLI installed | Traditional chat |
+
+Today the connectors are wired to traditional chat. If shell-bridged connectors arrive later, they can opt into workspace chat too — the two paths are designed to coexist, not replace each other.
+
 ## Quick Start
 
 Prerequisites: Node.js 22+, pnpm 10+, [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated.

--- a/TODO.md
+++ b/TODO.md
@@ -107,6 +107,39 @@ the item when done — git log is the history.
       third parties (Together, Groq, vLLM, LM Studio, Ollama) a
       proper light chat path. Same structural shape as the Anthropic
       one. ~3-4h.
+- [ ] **Profile + AI Provider model needs structural rethink.**
+      Surfaced 2026-05-13 during workspaces' per-workspace codex
+      override testing (commit `6b52853`). `ai-provider-manager.json`
+      profiles (Kimi/MiniMax/DeepSeek/Claude Pro) are **claude-shaped**
+      — each profile's `baseUrl` is the vendor's Anthropic-compat
+      endpoint (e.g. `https://api.moonshot.ai/anthropic`) and `model`
+      is the Anthropic-side model name. Applying the same profile to
+      codex via `WorkspaceAIConfigModal`'s shared Apply-from-profile
+      quick-pick silently produces invalid configs: codex speaks
+      OpenAI Responses shape, POSTs against an Anthropic endpoint →
+      `POST /anthropic/responses` → 404.
+
+      The shape mismatch isn't a quick-fix item — disabling
+      Apply-in-codex-tab or adding "no `/anthropic` in baseUrl"
+      sanity checks just covers one foot-gun each. "AI Provider"
+      today conflates four concepts that have started to diverge:
+      Anthropic-API endpoints, OpenAI-API endpoints, **vendor
+      identity** (Moonshot/DeepSeek/etc., one credential, multiple
+      endpoint shapes), and the `(baseUrl, model)` triple stored
+      per-profile. Each consumer (chat path / workspace claude /
+      workspace codex / future Anthropic-native / future
+      OpenAI-native) needs a different slice. Bolting more
+      `(baseUrl, apiKey, model)` triples onto the profile struct
+      keeps stacking the conflation.
+
+      Adjacent work that should design together (don't ship in
+      isolation): the **Native Anthropic / Native OpenAI provider**
+      TODOs above — their concrete client-side input shapes
+      clarify what profile dimensions actually need to exist. The
+      per-workspace override modal (just shipped) hits the same
+      foot-gun and would benefit from the redesigned profile model
+      directly. Land all three in one focused pass.
+
 - [ ] Unified config hot-reload. Right now every consumer of a config
       section has to solve "did the user edit this?" on its own —
       Telegram/MCP-Ask via `reconnectConnectors`, opentypebb via lazy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.10.0-beta.4",
+  "version": "0.10.0-beta.5",
   "description": "File-based trading agent engine",
   "type": "module",
   "scripts": {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -8,8 +8,8 @@
 
 import { Hono } from 'hono';
 import { randomUUID } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
-import { resolve as resolvePath } from 'node:path';
+import { readFile, rm } from 'node:fs/promises';
+import { join, resolve as resolvePath } from 'node:path';
 
 import { listDir, PathTraversal, readWorkspaceFile, writeWorkspaceFile } from '../../workspaces/file-service.js';
 import { gitLog, gitStatus } from '../../workspaces/git-service.js';
@@ -546,8 +546,11 @@ async function readClaudeConfig(workspaceDir: string): Promise<ClaudeConfigShape
 async function writeClaudeConfig(workspaceDir: string, cfg: AgentConfigInput): Promise<void> {
   const hasAny = cfg.baseUrl || cfg.apiKey || cfg.model;
   if (!hasAny) {
-    // Reset: empty settings.local.json so claude falls back to global.
-    await writeWorkspaceFile(workspaceDir, CLAUDE_SETTINGS_PATH, '{}\n');
+    // Reset: delete the settings file so claude falls back to its global
+    // OAuth / settings. We don't leave an empty `{}` behind — workspace
+    // files exist only when there's an actual override.
+    const filePath = join(workspaceDir, CLAUDE_SETTINGS_PATH);
+    await rm(filePath, { force: true });
     return;
   }
   const out: Record<string, unknown> = {};
@@ -598,37 +601,44 @@ async function readCodexConfig(workspaceDir: string): Promise<CodexConfigShape |
 }
 
 async function writeCodexConfig(workspaceDir: string, cfg: AgentConfigInput): Promise<void> {
-  // Always preserve the MCP block (constant content, OpenAlice infrastructure).
-  // Provider block + top-level `model` / `model_provider` only when configured.
-  const mcpBlock =
-    '[mcp_servers.openalice]\n' +
-    'url = "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"\n';
-
   const hasProvider = !!(cfg.baseUrl || cfg.model);
-  let toml = mcpBlock;
-  if (hasProvider) {
+
+  if (!hasProvider) {
+    // Reset: tear down the workspace's entire `.codex/` directory. The
+    // adapter's `composeEnv` won't set `CODEX_HOME` when the directory is
+    // absent, so codex falls back to the user's global `~/.codex/`. We
+    // don't leave empty stubs behind — workspace files exist only when
+    // there's an actual override. Note: `CODEX_HOME` is exclusive (not a
+    // merge layer), so a half-empty `.codex/` would *shadow* the user's
+    // global login and break auth. Full teardown is the only safe reset.
+    const codexDir = join(workspaceDir, '.codex');
+    await rm(codexDir, { recursive: true, force: true });
+    return;
+  }
+
+  // Provider override. config.toml carries only model / model_provider /
+  // [model_providers.*] — the OpenAlice MCP server entry is wired per-spawn
+  // via the codex adapter's `-c mcp_servers.openalice.url=...` flag, so we
+  // don't repeat it here.
+  let toml = '';
+  if (cfg.model) toml += `model = ${tomlString(cfg.model)}\n`;
+  if (cfg.baseUrl) toml += `model_provider = "${CODEX_PROVIDER_NAME}"\n`;
+  if (cfg.baseUrl) {
     toml += '\n';
-    if (cfg.model) toml += `model = ${tomlString(cfg.model)}\n`;
-    if (cfg.baseUrl) toml += `model_provider = "${CODEX_PROVIDER_NAME}"\n`;
-    if (cfg.baseUrl) {
-      toml += '\n';
-      toml += `[model_providers.${CODEX_PROVIDER_NAME}]\n`;
-      toml += `name = "OpenAlice workspace provider"\n`;
-      toml += `base_url = ${tomlString(cfg.baseUrl)}\n`;
-      toml += `env_key = "${CODEX_KEY_ENV_NAME}"\n`;
-      toml += `wire_api = "${cfg.wireApi ?? 'chat'}"\n`;
-    }
+    toml += `[model_providers.${CODEX_PROVIDER_NAME}]\n`;
+    toml += `name = "OpenAlice workspace provider"\n`;
+    toml += `base_url = ${tomlString(cfg.baseUrl)}\n`;
+    toml += `env_key = "${CODEX_KEY_ENV_NAME}"\n`;
+    toml += `wire_api = "${cfg.wireApi ?? 'chat'}"\n`;
   }
   await writeWorkspaceFile(workspaceDir, CODEX_CONFIG_PATH, toml);
 
   // env.json: holds the per-workspace API key codex picks up via env_key.
-  // Adapter's composeEnv reads this and exports at spawn. Empty / missing
-  // file = no workspace key (codex falls back to ~/.codex/auth.json OAuth).
+  // Adapter's composeEnv reads this and exports at spawn.
   if (cfg.apiKey) {
     const envObj: Record<string, string> = { [CODEX_KEY_ENV_NAME]: cfg.apiKey };
     await writeWorkspaceFile(workspaceDir, CODEX_ENV_PATH, JSON.stringify(envObj, null, 2) + '\n');
   } else {
-    // Reset key: write empty object so the adapter sees nothing to inject.
     await writeWorkspaceFile(workspaceDir, CODEX_ENV_PATH, '{}\n');
   }
 }

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -29,6 +29,8 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
       templates: svc.templates.list().map((t) => ({
         name: t.name,
         ...(t.description !== undefined ? { description: t.description } : {}),
+        ...(t.displayName !== undefined ? { displayName: t.displayName } : {}),
+        ...(t.groupOrder !== undefined ? { groupOrder: t.groupOrder } : {}),
         defaultAgents: t.defaultAgents,
       })),
     });

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -24,16 +24,28 @@ import type { BootstrapContext, CliAdapter, SpawnContext } from '../cli-adapter.
  *   pre-writes that entry so the launcher's spawn doesn't stall on the
  *   prompt.
  *
- * AI provider config: each workspace owns its own `.codex/` (we set
- * `CODEX_HOME=<cwd>/.codex` via `composeEnv` below). The workspace's
- * `config.toml` carries the OpenAlice MCP server entry + any
- * UI-configured `[model_providers.*]` blocks; `auth.json` starts as a
- * symlink to `~/.codex/auth.json` (graceful fallback to global login)
- * and gets replaced by the UI with a real file when the user picks a
- * workspace-specific provider. The MCP-flag translation that the
- * launcher originally did via `mcpJsonToCodexFlags` is gone — codex
- * reads MCP entries directly from the workspace's `config.toml` now.
+ * AI provider model — two modes, mutually exclusive:
+ *
+ *   1. **Default (no override).** Workspace has no `.codex/` directory.
+ *      Adapter doesn't set `CODEX_HOME`. Codex reads the user's global
+ *      `~/.codex/auth.json` + `~/.codex/config.toml` — exactly what a
+ *      vanilla `codex` invocation in any project does. The OpenAlice MCP
+ *      server is wired via the per-invocation `-c mcp_servers.openalice.url=...`
+ *      flag in `composeCommand` below, so MCP is visible without
+ *      polluting the user's global config.
+ *
+ *   2. **Override (user-configured via OpenAlice UI).** Workspace has its
+ *      own `.codex/{config.toml, env.json[, auth.json]}`. Adapter sets
+ *      `CODEX_HOME=<cwd>/.codex`. Codex reads workspace files only,
+ *      isolated from global state.
+ *
+ * No symlinks, no global-fallback inheritance. The `-c` flag is OpenAlice's
+ * "local MCP registration" — analogous to claude's `.mcp.json` cwd
+ * discovery, but driven via codex's CLI override flag since codex has no
+ * cwd-MCP convention of its own.
  */
+const OPENALICE_MCP_URL_DEFAULT = 'http://127.0.0.1:3001/mcp';
+
 export const codexAdapter: CliAdapter = {
   id: 'codex',
   displayName: 'Codex',
@@ -45,41 +57,40 @@ export const codexAdapter: CliAdapter = {
     transcriptDiscovery: 'none',
   },
 
+  /**
+   * Always prepends `-c mcp_servers.openalice.url="..."` so OpenAlice MCP
+   * is visible per-spawn without writing to `~/.codex/config.toml`. The
+   * flag overrides any same-key entry in the read config.toml (verified
+   * empirically), and adds a new key when none exists — safe in both
+   * default and override modes.
+   */
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
-    const head = ['codex'];
+    const mcpUrl = process.env['OPENALICE_MCP_URL'] ?? OPENALICE_MCP_URL_DEFAULT;
+    const head = ['codex', '-c', `mcp_servers.openalice.url="${mcpUrl}"`];
     if (ctx.resume === undefined) return head;
     if (ctx.resume === 'last') return [...head, 'resume', '--last'];
     return [...head, 'resume', ctx.resume.sessionId];
   },
 
   /**
-   * Point codex at the workspace's own `.codex/` and inject any
-   * UI-configured env vars (api keys named by `[model_providers.X].env_key`
-   * in the workspace's `config.toml`).
+   * Set `CODEX_HOME` only when workspace has its own `.codex/` directory
+   * (override mode). Otherwise codex falls back to its own `~/.codex/`,
+   * which is its normal behavior in any uninvolved project. The "reset
+   * to default" UI action deletes the entire `.codex/` directory so the
+   * adapter naturally falls back here.
    *
-   * Defensive: only set `CODEX_HOME` when `<cwd>/.codex/auth.json` exists.
-   * Codex *crashes* ("Codex requires a login") if `CODEX_HOME` points at a
-   * dir without `auth.json`. Workspaces created by the current bootstrap
-   * always have it (real file or symlink to `~/.codex/auth.json`); legacy
-   * workspaces from before this change don't — those silently fall back
-   * to the global `~/.codex/` and lose workspace-MCP wiring until
-   * recreated. That's the migration story.
-   *
-   * `.codex/env.json` is the workspace's per-CLI env contribution. Codex
-   * has no notion of "literal api key in config" — its `env_key` field
-   * indirects through an env var. The OpenAlice UI writes the user's
-   * chosen key into `env.json` (e.g. `{"OPENALICE_WORKSPACE_KEY":"sk-..."}`)
-   * and the adapter exports those at spawn so codex's `env_key` lookup
-   * resolves. This is the one place we DO bridge a file → env (because
-   * codex requires env), but the source of truth is still the workspace
-   * file, not OpenAlice's internal state.
+   * `.codex/env.json` is OpenAlice's per-workspace key bridge. Codex's
+   * `[model_providers.X].env_key` field indirects through an env var; the
+   * UI writes the chosen key into `env.json` and the adapter exports it
+   * at spawn so codex's `env_key` lookup resolves. This is the only place
+   * we bridge file → env, and the source of truth is still the workspace
+   * file (not OpenAlice's internal state).
    */
   composeEnv(ctx: SpawnContext): Record<string, string> {
     const result: Record<string, string> = {};
     const workspaceCodex = join(ctx.cwd, '.codex');
-    if (existsSync(join(workspaceCodex, 'auth.json'))) {
-      result['CODEX_HOME'] = workspaceCodex;
-    }
+    if (!existsSync(workspaceCodex)) return result;
+    result['CODEX_HOME'] = workspaceCodex;
     const envFile = join(workspaceCodex, 'env.json');
     if (existsSync(envFile)) {
       try {

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -8,6 +8,7 @@
  * Lifecycle: `createWorkspaceService()` at plugin start; `dispose()` at stop.
  */
 
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { claudeAdapter } from './adapters/claude.js';
@@ -172,7 +173,14 @@ export async function createWorkspaceService(): Promise<WorkspaceService> {
         startedAt: liveEntry?.startedAt ?? null,
       };
     });
-    return { ...w, sessions };
+    // Workspace AI provider override signals — read by the Overview
+    // dashboard for the "⚙ Workspace override" footer per card. Cheap
+    // (single statSync each) so it's safe on the regular list poll.
+    const agentOverride = {
+      claude: existsSync(join(w.dir, '.claude', 'settings.local.json')),
+      codex: existsSync(join(w.dir, '.codex')),
+    };
+    return { ...w, sessions, agentOverride };
   };
 
   const dispose = async (reason: string): Promise<void> => {

--- a/src/workspaces/template-registry.ts
+++ b/src/workspaces/template-registry.ts
@@ -7,6 +7,20 @@ import type { Logger } from './logger.js';
 export interface TemplateMeta {
   readonly name: string;
   readonly description?: string;
+  /**
+   * Human-readable name surfaced in the UI (dashboard section headers,
+   * etc.). Sourced from `template.json`'s `displayName` key. Falls back
+   * to a humanized form of `name` on the client when missing.
+   */
+  readonly displayName?: string;
+  /**
+   * Sort key for grouping workspaces by template type in the dashboard.
+   * Lower = earlier. Sourced from `template.json`'s `groupOrder` key.
+   * Templates without a declared `groupOrder` sort after declared ones,
+   * by name. New template types just need to add this field to their
+   * `template.json` — no frontend code change required.
+   */
+  readonly groupOrder?: number;
   /** Absolute path to the template's `bootstrap.sh`. */
   readonly bootstrapScript: string;
   /** Absolute path to the template's `files/` directory (may not exist). */
@@ -55,6 +69,8 @@ export class TemplateRegistry {
       const meta: TemplateMeta = {
         name,
         ...(tplMeta.description !== undefined ? { description: tplMeta.description } : {}),
+        ...(tplMeta.displayName !== undefined ? { displayName: tplMeta.displayName } : {}),
+        ...(tplMeta.groupOrder !== undefined ? { groupOrder: tplMeta.groupOrder } : {}),
         bootstrapScript,
         filesDir,
         defaultAgents: tplMeta.defaultAgents,
@@ -96,6 +112,8 @@ export class TemplateRegistry {
 
 interface ParsedTemplateMeta {
   readonly description?: string;
+  readonly displayName?: string;
+  readonly groupOrder?: number;
   readonly defaultAgents: readonly string[];
 }
 
@@ -112,11 +130,18 @@ async function readTemplateMeta(path: string): Promise<ParsedTemplateMeta> {
     if (typeof parsed !== 'object' || parsed === null) return fallback;
     const obj = parsed as Record<string, unknown>;
     const description = typeof obj['description'] === 'string' ? obj['description'] : undefined;
+    const displayName = typeof obj['displayName'] === 'string' ? obj['displayName'] : undefined;
+    const groupOrder =
+      typeof obj['groupOrder'] === 'number' && Number.isFinite(obj['groupOrder'])
+        ? obj['groupOrder']
+        : undefined;
     const defaultAgents = Array.isArray(obj['defaultAgents'])
       ? obj['defaultAgents'].filter((a): a is string => typeof a === 'string')
       : null;
     return {
       ...(description !== undefined ? { description } : {}),
+      ...(displayName !== undefined ? { displayName } : {}),
+      ...(groupOrder !== undefined ? { groupOrder } : {}),
       defaultAgents: defaultAgents && defaultAgents.length > 0 ? defaultAgents : ['claude'],
     };
   } catch {

--- a/src/workspaces/templates/auto-quant/bootstrap.sh
+++ b/src/workspaces/templates/auto-quant/bootstrap.sh
@@ -73,16 +73,12 @@ cd "$OUT_DIR"
 # 2. autoresearch branch from whatever master/main the source points at.
 git checkout -b "autoresearch/$TAG" >/dev/null
 
-# ── Codex workspace skeleton + agent-config excludes ─────────────────────
-# Mirror the chat template's setup so codex's CODEX_HOME=$cwd/.codex works
-# and the UI-saved secrets never leak to upstream Auto-Quant pushes. See
-# chat/bootstrap.sh for the full rationale.
-mkdir -p .codex
-ln -sf "$HOME/.codex/auth.json" .codex/auth.json
-cat > .codex/config.toml <<'TOML'
-[mcp_servers.openalice]
-url = "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"
-TOML
+# ── Agent-config excludes ────────────────────────────────────────────────
+# Preemptive defense: if the user later configures workspace-specific AI
+# provider via the OpenAlice UI (writing `.claude/settings.local.json` /
+# `.codex/auth.json`), the per-clone exclude keeps those secrets out of any
+# push to upstream Auto-Quant. Claude itself auto-ignores its file; this
+# entry is defense-in-depth.
 {
   echo '.claude/settings.local.json'
   echo '.codex/auth.json'

--- a/src/workspaces/templates/auto-quant/template.json
+++ b/src/workspaces/templates/auto-quant/template.json
@@ -1,4 +1,6 @@
 {
+  "displayName": "Auto-Quant",
+  "groupOrder": 20,
   "description": "Auto-Quant autoresearch workspace — clones the public Auto-Quant repo on first use (~/.openalice/workspaces/auto-quant-mirror), then makes per-workspace local clones with an autoresearch/<tag> branch and symlinked .feather data. Set AQ_TEMPLATE_DIR to override the source location.",
   "defaultAgents": ["claude"]
 }

--- a/src/workspaces/templates/chat/bootstrap.sh
+++ b/src/workspaces/templates/chat/bootstrap.sh
@@ -56,35 +56,18 @@ fi
 # drift; this is a literal copy, not a separate compose pass.
 cp CLAUDE.md AGENTS.md
 
-# ── Codex workspace skeleton ────────────────────────────────────────────────
-# Each workspace is its own VS-Code-style "open folder" — claude reads
-# `.claude/settings*.json` from cwd, codex reads `$CODEX_HOME` (which the
-# codex adapter points at this `.codex/` dir at spawn). We seed:
-#   - `.codex/config.toml` with the OpenAlice MCP block so codex sees the
-#     OpenAlice tool surface from day 1. The OpenAlice UI later patches
-#     `[model_providers.*]` + `model` / `model_provider` keys when the user
-#     picks a provider; we deliberately do not write provider config at
-#     create time (workspaces inherit the user's global CLI auth until
-#     explicitly configured).
-#   - `.codex/auth.json` symlinked to the user's global codex login so a
-#     fresh-config workspace still has a valid auth. The UI replaces this
-#     symlink with a real file when the user assigns a workspace-specific
-#     key (so global rotation doesn't leak into configured workspaces).
-mkdir -p .codex
-ln -sf "$HOME/.codex/auth.json" .codex/auth.json
-cat > .codex/config.toml <<'TOML'
-[mcp_servers.openalice]
-url = "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"
-TOML
-
 git init -q
 
-# `.git/info/exclude` is per-clone, untracked. Belt-and-suspenders against
-# UI-saved secrets ever entering a push:
+# `.git/info/exclude` is per-clone, untracked. Preemptive defense for
+# files the OpenAlice UI may later write when the user configures
+# workspace-specific AI provider overrides:
 #   - .claude/settings.local.json — claude itself auto-ignores this, but
 #     the entry here defends against any future tooling reading from
 #     `.gitignore` instead of trusting claude's runtime behaviour.
-#   - .codex/auth.json — codex's auth (symlink or real file). Never push.
+#   - .codex/auth.json — workspace-local codex auth (real file written
+#     by the UI when user configures a workspace-specific provider).
+#     Bootstrap doesn't create this; it's listed here so a configured
+#     workspace's secret never enters a push.
 {
   echo '.claude/settings.local.json'
   echo '.codex/auth.json'

--- a/src/workspaces/templates/chat/template.json
+++ b/src/workspaces/templates/chat/template.json
@@ -1,4 +1,6 @@
 {
+  "displayName": "Chat",
+  "groupOrder": 10,
   "description": "Chat workspace wired to OpenAlice's MCP server — full trading/market/brain tool surface available to the agent.",
   "defaultAgents": ["claude", "codex"]
 }

--- a/ui/src/components/ChatChannelListContainer.tsx
+++ b/ui/src/components/ChatChannelListContainer.tsx
@@ -1,25 +1,26 @@
-import { Bell, Notebook } from 'lucide-react'
+import { Bell, HelpCircle, Notebook } from 'lucide-react'
 import { useChannels } from '../contexts/ChannelsContext'
 import { useWorkspace } from '../tabs/store'
 import { getFocusedTab } from '../tabs/types'
 import { useUnreadNotificationsCount } from '../live/notifications-read'
 import { ChatChannelList } from './ChatChannelList'
+import { ChatWorkspaceSection } from './workspace/ChatWorkspaceSection'
 import { SidebarRow } from './SidebarRow'
 
 /**
- * Connects ChatChannelList to ChannelsContext + the workspace store.
+ * Chat activity sidebar. Two conceptual sections:
  *
- * Layout reflects the framing of "Chat" as the catch-all activity for
- * interactions with Alice — not strictly chat:
+ *   - **Workspace chat** (recommended) — chat-template workspaces, each
+ *     wrapping a native CLI session (claude / codex / shell). Native
+ *     prompt cache + native frontend; the path most users should default
+ *     to. See README "Two kinds of chat".
+ *   - **Traditional chat** — the original /chat channels backed by
+ *     OpenAlice's ChatHook. Required for connectors (Telegram / MCP Ask
+ *     / webhook) which have no PTY to host a CLI in.
  *
- *   - Notifications  (inbound system pushes; unread badge)
- *   - Diary          (Alice's first-person output stream — read-only)
- *   ─────
- *   - Channels       (the chat conversations the user opens)
- *
- * The two upper rows are "Alice surfaces"; the channel list is "user
- * actions". They share this sidebar because the unifying mental model
- * is "everything Alice-shaped" rather than "places to type messages".
+ * Above both: Notifications + Diary — system-push surfaces that share
+ * this sidebar because the unifying mental model is "everything
+ * Alice-shaped".
  *
  * Active row tracking is derived from the focused tab — switching tabs
  * naturally shifts the highlight without bespoke wiring.
@@ -69,17 +70,40 @@ export function ChatChannelListContainer() {
         />
       </div>
 
-      <div className="mt-2 px-3 text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
-        Channels
-      </div>
-      <div className="flex-1 overflow-y-auto min-h-0 mt-0.5">
-        <ChatChannelList
-          channels={channels}
-          activeChannel={focusedChannelId}
-          onSelect={(id) => openOrFocus({ kind: 'chat', params: { channelId: id } })}
-          onEdit={openEditDialog}
-          onDelete={deleteChannel}
-        />
+      <div className="flex-1 overflow-y-auto min-h-0 mt-2">
+        <div className="px-3 flex items-baseline gap-2">
+          <h3 className="text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
+            Workspace chat
+          </h3>
+          <span className="text-[10px] text-text-muted/50">recommended</span>
+        </div>
+        <div className="mt-0.5 mb-3">
+          <ChatWorkspaceSection />
+        </div>
+
+        <div className="px-3 mt-1 text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
+          Traditional
+        </div>
+        <div className="mt-0.5">
+          <ChatChannelList
+            channels={channels}
+            activeChannel={focusedChannelId}
+            onSelect={(id) => openOrFocus({ kind: 'chat', params: { channelId: id } })}
+            onEdit={openEditDialog}
+            onDelete={deleteChannel}
+          />
+        </div>
+
+        <a
+          href="https://github.com/TraderAlice/OpenAlice#two-kinds-of-chat"
+          target="_blank"
+          rel="noreferrer"
+          className="mx-3 my-3 flex items-center gap-1.5 text-[11px] text-text-muted/70 hover:text-text transition-colors"
+          title="Open README — Two kinds of chat"
+        >
+          <HelpCircle size={11} strokeWidth={2} aria-hidden="true" />
+          <span>Why two kinds of chat?</span>
+        </a>
       </div>
     </div>
   )

--- a/ui/src/components/ChatChannelListContainer.tsx
+++ b/ui/src/components/ChatChannelListContainer.tsx
@@ -70,18 +70,10 @@ export function ChatChannelListContainer() {
         />
       </div>
 
-      <div className="flex-1 overflow-y-auto min-h-0 mt-2">
-        <div className="px-3 flex items-baseline gap-2">
-          <h3 className="text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
-            Workspace chat
-          </h3>
-          <span className="text-[10px] text-text-muted/50">recommended</span>
-        </div>
-        <div className="mt-0.5 mb-3">
-          <ChatWorkspaceSection />
-        </div>
+      <div className="flex-1 overflow-y-auto min-h-0">
+        <ChatWorkspaceSection />
 
-        <div className="px-3 mt-1 text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
+        <div className="px-3 mt-3 text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
           Traditional
         </div>
         <div className="mt-0.5">

--- a/ui/src/components/TabStrip.tsx
+++ b/ui/src/components/TabStrip.tsx
@@ -1,6 +1,7 @@
 import { useState, type MouseEvent, type WheelEvent } from 'react'
 import { X } from 'lucide-react'
 import { useChannels } from '../contexts/ChannelsContext'
+import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { useWorkspace } from '../tabs/store'
 import { getView } from '../tabs/registry'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu'
@@ -22,6 +23,7 @@ import { ContextMenu, type ContextMenuItem } from './ContextMenu'
  */
 export function TabStrip() {
   const { channels } = useChannels()
+  const { workspaces } = useWorkspaces()
   const tabIds = useWorkspace((state) =>
     state.tree.kind === 'leaf' ? state.tree.group.tabIds : [],
   )
@@ -101,7 +103,7 @@ export function TabStrip() {
           const tab = tabsMap[id]
           if (!tab) return null
           const view = getView(tab.spec.kind)
-          const title = view.title(tab.spec as never, { channels })
+          const title = view.title(tab.spec as never, { channels, workspaces })
           const isActive = id === activeTabId
           return (
             <TabButton

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -1,0 +1,185 @@
+/**
+ * "Workspace chat" section embedded inside the Chat activity sidebar.
+ *
+ * A curated view of chat-template workspaces — the recommended path for
+ * interactive chats because the underlying CLI (claude / codex / ...)
+ * brings its own prompt cache + native frontend. See README "Two kinds
+ * of chat".
+ *
+ * Wraps the same `WorkspaceRow` component used in the Workspaces
+ * activity, so behavior (spawn / pause / resume / config / delete /
+ * navigation) stays identical. The difference is just the lens: this
+ * section filters to template === 'chat' and provides its own create
+ * form with template locked to chat.
+ */
+
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
+
+import { useWorkspaces, type SpawnOpts } from '../../contexts/WorkspacesContext'
+import { useWorkspace } from '../../tabs/store'
+import { getFocusedTab } from '../../tabs/types'
+import { createWorkspace, deleteWorkspace } from './api'
+import { WorkspaceRow } from './Sidebar'
+
+const CHAT_TEMPLATE = 'chat'
+const TAG_HINT = 'a-z, 0-9, "-", "_", up to 33 chars'
+const TAG_RE = /^[a-z0-9][a-z0-9_-]{0,32}$/
+
+export function ChatWorkspaceSection() {
+  const ctx = useWorkspaces()
+  const focused = useWorkspace((s) => getFocusedTab(s)?.spec)
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+
+  // Filter workspaces to chat template only (this section is the chat
+  // lens; non-chat workspaces stay visible in the Workspaces activity).
+  const chatWorkspaces = useMemo(
+    () => ctx.workspaces.filter((w) => w.template === CHAT_TEMPLATE),
+    [ctx.workspaces],
+  )
+
+  // Selection state mirrors the workspaces sidebar — driven entirely by
+  // which tab is focused, so switching tabs naturally moves the highlight.
+  const isWsFocus = focused?.kind === 'workspace'
+  const selection = isWsFocus
+    ? {
+        wsId: focused.params.wsId,
+        sessionId: focused.params.sessionId ?? null,
+      }
+    : null
+
+  const chatTemplate = ctx.templates.find((t) => t.name === CHAT_TEMPLATE)
+
+  // Create-form state. Template is locked to chat — we only collect tag
+  // + agent picks. Agent defaults come from the chat template's
+  // `defaultAgents`; user can toggle individual agents off/on.
+  const [creating, setCreating] = useState(false)
+  const [tag, setTag] = useState('')
+  const [pickedAgents, setPickedAgents] = useState<Set<string> | null>(null)
+  const [createError, setCreateError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  const checkedAgents: ReadonlySet<string> = useMemo(() => {
+    if (pickedAgents) return pickedAgents
+    return new Set(chatTemplate?.defaultAgents ?? ['claude'])
+  }, [pickedAgents, chatTemplate])
+
+  const toggleAgent = (id: string): void => {
+    setPickedAgents((prev) => {
+      const base = prev ?? new Set(chatTemplate?.defaultAgents ?? ['claude'])
+      const next = new Set(base)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const submit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault()
+    const t = tag.trim()
+    if (!TAG_RE.test(t)) {
+      setCreateError(`invalid tag (${TAG_HINT})`)
+      return
+    }
+    if (checkedAgents.size === 0) {
+      setCreateError('pick at least one agent')
+      return
+    }
+    setCreating(true)
+    setCreateError(null)
+    const result = await createWorkspace(t, CHAT_TEMPLATE, Array.from(checkedAgents))
+    setCreating(false)
+    if (result.ok) {
+      setTag('')
+      setPickedAgents(null)
+      ctx.refresh()
+      openOrFocus({ kind: 'workspace', params: { wsId: result.workspace.id } })
+    } else {
+      const msg = result.error.message ?? result.error.error ?? `HTTP ${result.status}`
+      setCreateError(msg)
+    }
+  }
+
+  // Auto-focus tag input when template becomes available (e.g. first
+  // render after templates fetch). Avoids the user having to click the
+  // input on a fresh activity switch.
+  useEffect(() => {
+    // no-op effect placeholder — kept so future "focus on activity switch"
+    // logic has a hook to attach to. We intentionally don't auto-focus on
+    // every mount because that would steal focus from the channels list.
+  }, [chatTemplate])
+
+  const onDelete = async (id: string): Promise<void> => {
+    if (!window.confirm('Delete workspace? (registry only — files on disk are kept.)')) return
+    const ok = await deleteWorkspace(id)
+    if (ok) ctx.refresh()
+  }
+
+  // No chat template registered? Render nothing — the section is dead
+  // anyway, and the user can still use the Channels list below.
+  if (!chatTemplate) return null
+
+  return (
+    <aside className="sidebar workspaces-root">
+      <form className="sidebar-create" onSubmit={submit}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="tag (e.g. may1)"
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          disabled={creating}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+        />
+        <button type="submit" disabled={creating || tag.length === 0}>
+          {creating ? '…' : 'create'}
+        </button>
+        {ctx.agents.length > 0 && (
+          <div className="sidebar-create-agents">
+            {ctx.agents.map((a) => (
+              <label key={a.id} className="sidebar-agent-toggle" title={a.displayName}>
+                <input
+                  type="checkbox"
+                  checked={checkedAgents.has(a.id)}
+                  onChange={() => toggleAgent(a.id)}
+                  disabled={creating}
+                />
+                <span>{a.id}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </form>
+      {createError && <div className="sidebar-error">{createError}</div>}
+
+      <ul className="sidebar-list">
+        {chatWorkspaces.length === 0 && !ctx.listError && (
+          <li className="sidebar-empty">no chat workspaces yet</li>
+        )}
+        {ctx.listError && <li className="sidebar-error">{ctx.listError}</li>}
+        {chatWorkspaces.map((w) => (
+          <WorkspaceRow
+            key={w.id}
+            workspace={w}
+            agents={ctx.agents}
+            selection={selection}
+            onSelectWorkspace={(wsId) => {
+              if (wsId.length === 0) return
+              openOrFocus({ kind: 'workspace', params: { wsId } })
+            }}
+            onSelectSession={(wsId, sessionId) =>
+              openOrFocus({ kind: 'workspace', params: { wsId, sessionId } })
+            }
+            onSpawn={(wsId, opts?: SpawnOpts) => void ctx.spawn(wsId, opts)}
+            onPauseSession={(wsId, id) => void ctx.pauseSession(wsId, id)}
+            onResumeSession={(wsId, id) => void ctx.resumeSession(wsId, id)}
+            onDeleteSession={(wsId, id) => void ctx.deleteSession(wsId, id)}
+            onDelete={onDelete}
+            onConfigureWorkspace={(wsId) => ctx.openAgentConfig(wsId)}
+          />
+        ))}
+      </ul>
+    </aside>
+  )
+}

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -1,62 +1,74 @@
 /**
  * "Workspace chat" section embedded inside the Chat activity sidebar.
  *
- * A curated view of chat-template workspaces — the recommended path for
- * interactive chats because the underlying CLI (claude / codex / ...)
- * brings its own prompt cache + native frontend. See README "Two kinds
- * of chat".
+ * Visual rhythm matches the Traditional channels list below — single
+ * row per workspace, with a collapsible session sub-tree. Status dot
+ * prefix conveys running/idle without needing a "4h" trailing meta.
  *
- * Wraps the same `WorkspaceRow` component used in the Workspaces
- * activity, so behavior (spawn / pause / resume / config / delete /
- * navigation) stays identical. The difference is just the lens: this
- * section filters to template === 'chat' and provides its own create
- * form with template locked to chat.
+ * The create form is hidden behind a `+` toggle in the section header;
+ * when opened, the tag input pre-fills with a date-based default
+ * (`chat-may13`, `chat-may13-2`, …) so users can hit enter without
+ * typing. Power-user spawn-by-agent stays in the Workspaces activity
+ * — this sidebar is for "pick a conversation and continue".
  */
 
-import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactElement,
+} from 'react'
+import { ChevronDown, ChevronRight, Plus, Settings as SettingsIcon, X } from 'lucide-react'
 
-import { useWorkspaces, type SpawnOpts } from '../../contexts/WorkspacesContext'
+import { useWorkspaces } from '../../contexts/WorkspacesContext'
 import { useWorkspace } from '../../tabs/store'
 import { getFocusedTab } from '../../tabs/types'
-import { createWorkspace, deleteWorkspace } from './api'
-import { WorkspaceRow } from './Sidebar'
+import { ConfirmDialog } from '../ConfirmDialog'
+import { createWorkspace, deleteWorkspace, type SessionRecord, type Workspace } from './api'
+import { SessionRow } from './Sidebar'
 
 const CHAT_TEMPLATE = 'chat'
 const TAG_HINT = 'a-z, 0-9, "-", "_", up to 33 chars'
 const TAG_RE = /^[a-z0-9][a-z0-9_-]{0,32}$/
 
-export function ChatWorkspaceSection() {
+function defaultTagFor(workspaces: readonly Workspace[]): string {
+  const now = new Date()
+  const month = now.toLocaleString('en-US', { month: 'short' }).toLowerCase()
+  const day = now.getDate()
+  const base = `chat-${month}${day}`
+  const taken = new Set(workspaces.map((w) => w.tag))
+  if (!taken.has(base)) return base
+  let i = 2
+  while (taken.has(`${base}-${i}`)) i++
+  return `${base}-${i}`
+}
+
+export function ChatWorkspaceSection(): ReactElement | null {
   const ctx = useWorkspaces()
   const focused = useWorkspace((s) => getFocusedTab(s)?.spec)
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
 
-  // Filter workspaces to chat template only (this section is the chat
-  // lens; non-chat workspaces stay visible in the Workspaces activity).
   const chatWorkspaces = useMemo(
     () => ctx.workspaces.filter((w) => w.template === CHAT_TEMPLATE),
     [ctx.workspaces],
   )
 
-  // Selection state mirrors the workspaces sidebar — driven entirely by
-  // which tab is focused, so switching tabs naturally moves the highlight.
   const isWsFocus = focused?.kind === 'workspace'
   const selection = isWsFocus
-    ? {
-        wsId: focused.params.wsId,
-        sessionId: focused.params.sessionId ?? null,
-      }
+    ? { wsId: focused.params.wsId, sessionId: focused.params.sessionId ?? null }
     : null
 
   const chatTemplate = ctx.templates.find((t) => t.name === CHAT_TEMPLATE)
 
-  // Create-form state. Template is locked to chat — we only collect tag
-  // + agent picks. Agent defaults come from the chat template's
-  // `defaultAgents`; user can toggle individual agents off/on.
-  const [creating, setCreating] = useState(false)
+  const [showCreate, setShowCreate] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
   const [tag, setTag] = useState('')
   const [pickedAgents, setPickedAgents] = useState<Set<string> | null>(null)
   const [createError, setCreateError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<Workspace | null>(null)
 
   const checkedAgents: ReadonlySet<string> = useMemo(() => {
     if (pickedAgents) return pickedAgents
@@ -73,6 +85,25 @@ export function ChatWorkspaceSection() {
     })
   }
 
+  const openCreate = (): void => {
+    setShowCreate(true)
+    setTag(defaultTagFor(ctx.workspaces))
+    setCreateError(null)
+    // Focus + select on next paint so users can type to replace the
+    // default in one keystroke.
+    setTimeout(() => {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }, 0)
+  }
+
+  const closeCreate = (): void => {
+    setShowCreate(false)
+    setTag('')
+    setPickedAgents(null)
+    setCreateError(null)
+  }
+
   const submit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault()
     const t = tag.trim()
@@ -84,13 +115,12 @@ export function ChatWorkspaceSection() {
       setCreateError('pick at least one agent')
       return
     }
-    setCreating(true)
+    setSubmitting(true)
     setCreateError(null)
     const result = await createWorkspace(t, CHAT_TEMPLATE, Array.from(checkedAgents))
-    setCreating(false)
+    setSubmitting(false)
     if (result.ok) {
-      setTag('')
-      setPickedAgents(null)
+      closeCreate()
       ctx.refresh()
       openOrFocus({ kind: 'workspace', params: { wsId: result.workspace.id } })
     } else {
@@ -99,87 +129,267 @@ export function ChatWorkspaceSection() {
     }
   }
 
-  // Auto-focus tag input when template becomes available (e.g. first
-  // render after templates fetch). Avoids the user having to click the
-  // input on a fresh activity switch.
-  useEffect(() => {
-    // no-op effect placeholder — kept so future "focus on activity switch"
-    // logic has a hook to attach to. We intentionally don't auto-focus on
-    // every mount because that would steal focus from the channels list.
-  }, [chatTemplate])
-
-  const onDelete = async (id: string): Promise<void> => {
-    if (!window.confirm('Delete workspace? (registry only — files on disk are kept.)')) return
-    const ok = await deleteWorkspace(id)
-    if (ok) ctx.refresh()
+  const handleConfirmDelete = async (): Promise<void> => {
+    if (!pendingDelete) return
+    try {
+      const ok = await deleteWorkspace(pendingDelete.id)
+      if (ok) ctx.refresh()
+    } finally {
+      setPendingDelete(null)
+    }
   }
 
-  // No chat template registered? Render nothing — the section is dead
-  // anyway, and the user can still use the Channels list below.
+  useEffect(() => {
+    if (showCreate && tag === '' && chatTemplate) {
+      setTag(defaultTagFor(ctx.workspaces))
+    }
+  }, [showCreate, tag, chatTemplate, ctx.workspaces])
+
   if (!chatTemplate) return null
 
   return (
-    <aside className="sidebar workspaces-root">
-      <form className="sidebar-create" onSubmit={submit}>
-        <input
-          ref={inputRef}
-          type="text"
-          placeholder="tag (e.g. may1)"
-          value={tag}
-          onChange={(e) => setTag(e.target.value)}
-          disabled={creating}
-          spellCheck={false}
-          autoCorrect="off"
-          autoCapitalize="off"
-        />
-        <button type="submit" disabled={creating || tag.length === 0}>
-          {creating ? '…' : 'create'}
+    <>
+      <div className="px-3 mt-2 flex items-baseline gap-2">
+        <h3 className="text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
+          Workspace chat
+        </h3>
+        <span className="text-[10px] text-text-muted/50">recommended</span>
+        <button
+          type="button"
+          onClick={() => (showCreate ? closeCreate() : openCreate())}
+          className="ml-auto w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-secondary"
+          title={showCreate ? 'Cancel' : 'New chat workspace'}
+          aria-label={showCreate ? 'Cancel new chat workspace' : 'New chat workspace'}
+        >
+          {showCreate ? <X size={12} strokeWidth={2.5} /> : <Plus size={13} strokeWidth={2.25} />}
         </button>
-        {ctx.agents.length > 0 && (
-          <div className="sidebar-create-agents">
-            {ctx.agents.map((a) => (
-              <label key={a.id} className="sidebar-agent-toggle" title={a.displayName}>
-                <input
-                  type="checkbox"
-                  checked={checkedAgents.has(a.id)}
-                  onChange={() => toggleAgent(a.id)}
-                  disabled={creating}
-                />
-                <span>{a.id}</span>
-              </label>
-            ))}
-          </div>
-        )}
-      </form>
-      {createError && <div className="sidebar-error">{createError}</div>}
+      </div>
 
-      <ul className="sidebar-list">
-        {chatWorkspaces.length === 0 && !ctx.listError && (
-          <li className="sidebar-empty">no chat workspaces yet</li>
+      {showCreate && (
+        <form
+          onSubmit={submit}
+          className="mt-1.5 mx-3 mb-2 p-2 rounded-md border border-border bg-bg-secondary/40 flex flex-col gap-1.5"
+        >
+          <div className="flex gap-1.5">
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder="tag (e.g. may1)"
+              value={tag}
+              onChange={(e) => setTag(e.target.value)}
+              disabled={submitting}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+              className="flex-1 min-w-0 px-2 py-1 text-[12px] rounded border border-border bg-bg text-text placeholder:text-text-muted/60 focus:outline-none focus:border-accent"
+            />
+            <button
+              type="submit"
+              disabled={submitting || tag.length === 0}
+              className="px-2.5 py-1 text-[12px] rounded bg-accent text-white disabled:opacity-40 hover:bg-accent/90"
+            >
+              {submitting ? '…' : 'create'}
+            </button>
+          </div>
+          {ctx.agents.length > 0 && (
+            <div className="flex flex-wrap gap-2 text-[11px] text-text-muted">
+              {ctx.agents.map((a) => (
+                <label
+                  key={a.id}
+                  className="flex items-center gap-1 cursor-pointer"
+                  title={a.displayName}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checkedAgents.has(a.id)}
+                    onChange={() => toggleAgent(a.id)}
+                    disabled={submitting}
+                    className="w-3 h-3"
+                  />
+                  <span>{a.id}</span>
+                </label>
+              ))}
+            </div>
+          )}
+          {createError && (
+            <div className="text-[11px] text-red">{createError}</div>
+          )}
+        </form>
+      )}
+
+      <ul className="py-0.5">
+        {chatWorkspaces.length === 0 && !ctx.listError && !showCreate && (
+          <li className="px-3 py-2 text-[12px] text-text-muted/60">no chat workspaces yet</li>
         )}
-        {ctx.listError && <li className="sidebar-error">{ctx.listError}</li>}
+        {ctx.listError && (
+          <li className="px-3 py-1 text-[11px] text-red">{ctx.listError}</li>
+        )}
         {chatWorkspaces.map((w) => (
-          <WorkspaceRow
+          <ChatWorkspaceRow
             key={w.id}
             workspace={w}
-            agents={ctx.agents}
             selection={selection}
-            onSelectWorkspace={(wsId) => {
-              if (wsId.length === 0) return
-              openOrFocus({ kind: 'workspace', params: { wsId } })
+            onOpen={() => {
+              const recent = mostRecentSession(w.sessions)
+              if (recent) {
+                openOrFocus({
+                  kind: 'workspace',
+                  params: { wsId: w.id, sessionId: recent.id },
+                })
+              } else {
+                openOrFocus({ kind: 'workspace', params: { wsId: w.id } })
+              }
             }}
-            onSelectSession={(wsId, sessionId) =>
-              openOrFocus({ kind: 'workspace', params: { wsId, sessionId } })
+            onOpenSession={(sid) =>
+              openOrFocus({ kind: 'workspace', params: { wsId: w.id, sessionId: sid } })
             }
-            onSpawn={(wsId, opts?: SpawnOpts) => void ctx.spawn(wsId, opts)}
-            onPauseSession={(wsId, id) => void ctx.pauseSession(wsId, id)}
-            onResumeSession={(wsId, id) => void ctx.resumeSession(wsId, id)}
-            onDeleteSession={(wsId, id) => void ctx.deleteSession(wsId, id)}
-            onDelete={onDelete}
-            onConfigureWorkspace={(wsId) => ctx.openAgentConfig(wsId)}
+            onPauseSession={(sid) => void ctx.pauseSession(w.id, sid)}
+            onResumeSession={(sid) => void ctx.resumeSession(w.id, sid)}
+            onDeleteSession={(sid) => void ctx.deleteSession(w.id, sid)}
+            onConfigure={() => ctx.openAgentConfig(w.id)}
+            onDelete={() => setPendingDelete(w)}
           />
         ))}
       </ul>
-    </aside>
+
+      {pendingDelete && (
+        <ConfirmDialog
+          title="Delete chat workspace"
+          message={
+            <>
+              Delete chat workspace{' '}
+              <span className="font-mono text-text">{pendingDelete.tag}</span>? The
+              files on disk are kept; only the launcher's registry entry is removed.
+              Any open tab for it will close.
+            </>
+          }
+          confirmLabel="Delete"
+          onConfirm={handleConfirmDelete}
+          onClose={() => setPendingDelete(null)}
+        />
+      )}
+    </>
+  )
+}
+
+function mostRecentSession(
+  sessions: readonly SessionRecord[],
+): SessionRecord | undefined {
+  if (sessions.length === 0) return undefined
+  return [...sessions].sort(
+    (a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime(),
+  )[0]
+}
+
+interface ChatWorkspaceRowProps {
+  workspace: Workspace
+  selection: { wsId: string; sessionId: string | null } | null
+  onOpen: () => void
+  onOpenSession: (sid: string) => void
+  onPauseSession: (sid: string) => void
+  onResumeSession: (sid: string) => void
+  onDeleteSession: (sid: string) => void
+  onConfigure: () => void
+  onDelete: () => void
+}
+
+function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
+  const w = props.workspace
+  const hasRunning = w.sessions.some((s) => s.state === 'running')
+  const [expanded, setExpanded] = useState(true)
+  const isSelected =
+    props.selection?.wsId === w.id && props.selection.sessionId === null
+
+  const statusClass = hasRunning
+    ? 'bg-green'
+    : w.sessions.length > 0
+      ? 'bg-text-muted/40'
+      : 'border border-border'
+
+  return (
+    <li className="group relative">
+      <div
+        className={`flex items-center gap-1 px-3 py-1 text-[13px] cursor-pointer transition-colors ${
+          isSelected ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
+        }`}
+      >
+        {isSelected && (
+          <span
+            aria-hidden="true"
+            className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent"
+          />
+        )}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            setExpanded((v) => !v)
+          }}
+          className="w-3 h-4 flex items-center justify-center text-text-muted/60 hover:text-text"
+          aria-label={expanded ? 'Collapse sessions' : 'Expand sessions'}
+          title={expanded ? 'Collapse sessions' : 'Expand sessions'}
+        >
+          {expanded ? (
+            <ChevronDown size={11} strokeWidth={2.25} />
+          ) : (
+            <ChevronRight size={11} strokeWidth={2.25} />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={props.onOpen}
+          className="flex-1 min-w-0 flex items-center gap-1.5 text-left"
+        >
+          <span
+            className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusClass}`}
+            aria-hidden="true"
+          />
+          <span className="truncate" title={w.tag}>
+            {w.tag}
+          </span>
+        </button>
+        <span className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              props.onConfigure()
+            }}
+            className="w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-secondary"
+            title="AI Provider"
+            aria-label="AI Provider"
+          >
+            <SettingsIcon size={12} strokeWidth={2} />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              props.onDelete()
+            }}
+            className="w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-red hover:bg-red/10"
+            title="Delete workspace"
+            aria-label="Delete workspace"
+          >
+            <X size={12} strokeWidth={2.5} />
+          </button>
+        </span>
+      </div>
+      {expanded && w.sessions.length > 0 && (
+        <ul className="sidebar-children chat-ws-children-list">
+          {w.sessions.map((s) => (
+            <SessionRow
+              key={s.id}
+              session={s}
+              isActive={props.selection?.sessionId === s.id}
+              onSelect={() => props.onOpenSession(s.id)}
+              onPause={() => props.onPauseSession(s.id)}
+              onResume={() => props.onResumeSession(s.id)}
+              onDelete={() => props.onDeleteSession(s.id)}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
   )
 }

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -1,0 +1,179 @@
+import { useMemo } from 'react'
+import { ChevronRight, Cpu, ScrollText, Settings, Sparkles, Terminal, type LucideIcon } from 'lucide-react'
+import type { GitLogEntry, Workspace } from './api'
+
+/**
+ * Single-workspace card for the Workspaces Overview dashboard. Variant B
+ * from the design discussion — header (status dot + tag), template +
+ * relative-activity subtitle, sessions list (each clickable), provider
+ * override + latest commit footer (rendered only when present).
+ *
+ * The card body is clickable (opens the workspace tab). Inner regions —
+ * session rows, the ⚙ override row — stopPropagation and route to their
+ * own handler so the user can drill in without going through the main
+ * workspace landing.
+ */
+
+const AGENT_ICONS: Record<string, LucideIcon> = {
+  claude: Sparkles,
+  codex: Cpu,
+  shell: Terminal,
+}
+
+function AgentGlyph({ agent }: { agent: string }) {
+  const Icon = AGENT_ICONS[agent]
+  if (Icon) return <Icon size={12} strokeWidth={2.25} aria-hidden="true" />
+  return <span aria-hidden="true" className="text-[11px] font-mono">·</span>
+}
+
+function relativeTime(ms: number): string {
+  const diff = Math.max(0, Date.now() - ms)
+  const m = Math.floor(diff / 60_000)
+  if (m < 1) return 'just now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  return `${d}d ago`
+}
+
+const TEMPLATE_LABEL: Record<string, string> = {
+  chat: 'Chat workspace',
+  'auto-quant': 'Auto-Quant workspace',
+}
+
+interface Props {
+  workspace: Workspace
+  lastCommit: GitLogEntry | null
+  onOpen: () => void
+  onOpenSession: (sessionId: string) => void
+  onConfigure?: () => void
+}
+
+export function OverviewCard({
+  workspace,
+  lastCommit,
+  onOpen,
+  onOpenSession,
+  onConfigure,
+}: Props) {
+  const w = workspace
+  const hasRunning = w.sessions.some((s) => s.state === 'running')
+
+  const lastActivityMs = useMemo(() => {
+    const sessionTs = w.sessions
+      .map((s) => new Date(s.lastActiveAt).getTime())
+      .filter((n) => Number.isFinite(n))
+    if (sessionTs.length === 0) return new Date(w.createdAt).getTime()
+    return Math.max(...sessionTs)
+  }, [w.sessions, w.createdAt])
+
+  const templateLabel = w.template
+    ? (TEMPLATE_LABEL[w.template] ?? `${w.template} workspace`)
+    : 'Workspace'
+
+  const dotClass = hasRunning
+    ? 'bg-green'
+    : w.sessions.length > 0
+      ? 'bg-text-muted/40'
+      : 'border border-border'
+
+  const overrideAgents: string[] = []
+  if (w.agentOverride?.claude) overrideAgents.push('claude')
+  if (w.agentOverride?.codex) overrideAgents.push('codex')
+
+  return (
+    <div
+      onClick={onOpen}
+      className="group rounded-lg border border-border bg-bg-secondary hover:bg-bg-tertiary/40 hover:border-border/80 transition-colors cursor-pointer p-4 flex flex-col gap-3"
+    >
+      {/* Header */}
+      <div className="flex items-start gap-2.5">
+        <span
+          className={`w-2 h-2 rounded-full mt-1.5 shrink-0 ${dotClass}`}
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <h3 className="text-[14px] font-semibold text-text truncate" title={w.tag}>
+            {w.tag}
+          </h3>
+          <p className="text-[11px] text-text-muted">
+            {templateLabel} · {relativeTime(lastActivityMs)}
+          </p>
+        </div>
+      </div>
+
+      {/* Sessions */}
+      <div className="border-t border-border pt-3">
+        <div className="text-[10px] uppercase tracking-wider text-text-muted/70 mb-1.5">
+          Sessions
+        </div>
+        {w.sessions.length === 0 ? (
+          <p className="text-[12px] text-text-muted/80 italic">no sessions yet</p>
+        ) : (
+          <ul className="space-y-0.5 -mx-2">
+            {w.sessions.map((s) => (
+              <li
+                key={s.id}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onOpenSession(s.id)
+                }}
+                className="flex items-center gap-2 text-[12px] text-text hover:bg-bg-tertiary/40 px-2 py-1 rounded transition-colors cursor-pointer"
+              >
+                <span className="w-3 flex justify-center text-text-muted">
+                  <AgentGlyph agent={s.agent} />
+                </span>
+                <span className="font-mono text-[11px] tabular-nums">{s.name}</span>
+                <span
+                  className={`text-[11px] ${
+                    s.state === 'running' ? 'text-green' : 'text-text-muted'
+                  }`}
+                >
+                  {s.state}
+                </span>
+                <ChevronRight
+                  size={10}
+                  className="ml-auto text-text-muted opacity-0 group-hover:opacity-60 transition-opacity"
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Footer — only rendered when there's something to show */}
+      {(overrideAgents.length > 0 || lastCommit) && (
+        <div className="border-t border-border pt-3 space-y-1.5">
+          {overrideAgents.length > 0 && onConfigure && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onConfigure()
+              }}
+              className="flex items-center gap-2 text-[11px] text-text-muted hover:text-text transition-colors w-full text-left"
+            >
+              <Settings size={11} strokeWidth={2.25} className="shrink-0" />
+              <span>Workspace override · {overrideAgents.join(', ')}</span>
+            </button>
+          )}
+          {overrideAgents.length > 0 && !onConfigure && (
+            <div className="flex items-center gap-2 text-[11px] text-text-muted">
+              <Settings size={11} strokeWidth={2.25} className="shrink-0" />
+              <span>Workspace override · {overrideAgents.join(', ')}</span>
+            </div>
+          )}
+          {lastCommit && (
+            <div className="flex items-center gap-2 text-[11px] text-text-muted">
+              <ScrollText size={11} strokeWidth={2.25} className="shrink-0" />
+              <span className="truncate" title={lastCommit.subject}>
+                {lastCommit.subject}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -37,11 +37,6 @@ function relativeTime(ms: number): string {
   return `${d}d ago`
 }
 
-const TEMPLATE_LABEL: Record<string, string> = {
-  chat: 'Chat workspace',
-  'auto-quant': 'Auto-Quant workspace',
-}
-
 interface Props {
   workspace: Workspace
   lastCommit: GitLogEntry | null
@@ -67,10 +62,6 @@ export function OverviewCard({
     if (sessionTs.length === 0) return new Date(w.createdAt).getTime()
     return Math.max(...sessionTs)
   }, [w.sessions, w.createdAt])
-
-  const templateLabel = w.template
-    ? (TEMPLATE_LABEL[w.template] ?? `${w.template} workspace`)
-    : 'Workspace'
 
   const dotClass = hasRunning
     ? 'bg-green'
@@ -98,7 +89,7 @@ export function OverviewCard({
             {w.tag}
           </h3>
           <p className="text-[11px] text-text-muted">
-            {templateLabel} · {relativeTime(lastActivityMs)}
+            Active {relativeTime(lastActivityMs)}
           </p>
         </div>
       </div>

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { FormEvent, ReactElement } from 'react';
-import { Cpu, Sparkles, Terminal, type LucideIcon } from 'lucide-react';
+import { Cpu, LayoutGrid, Sparkles, Terminal, type LucideIcon } from 'lucide-react';
 
 import {
   createWorkspace,
@@ -39,6 +39,10 @@ export interface SidebarProps {
   readonly onChanged: () => void;
   /** Optional: open the per-workspace AI-provider config modal. */
   readonly onConfigureWorkspace?: (wsId: string) => void;
+  /** Open the Workspaces Overview dashboard tab (card view of all workspaces). */
+  readonly onOpenOverview?: () => void;
+  /** True when the Workspaces Overview tab is currently focused — highlights the pinned row. */
+  readonly overviewActive?: boolean;
 }
 
 export function Sidebar(props: SidebarProps): ReactElement {
@@ -177,6 +181,19 @@ export function Sidebar(props: SidebarProps): ReactElement {
       {createError && <div className="sidebar-error">{createError}</div>}
 
       <ul className="sidebar-list">
+        {props.onOpenOverview && (
+          <li className="sidebar-overview-row">
+            <button
+              type="button"
+              className={`sidebar-overview-btn${props.overviewActive ? ' is-active' : ''}`}
+              onClick={props.onOpenOverview}
+              title="Card-based dashboard of all workspaces"
+            >
+              <LayoutGrid size={13} strokeWidth={2.25} aria-hidden="true" />
+              <span>Overview</span>
+            </button>
+          </li>
+        )}
         {props.workspaces.length === 0 && !props.listError && (
           <li className="sidebar-empty">no workspaces yet</li>
         )}

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -400,14 +400,16 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   );
 }
 
-function SessionRow(props: {
+export interface SessionRowProps {
   session: SessionRecord;
   isActive: boolean;
   onSelect: () => void;
   onPause: () => void;
   onResume: () => void;
   onDelete: () => void;
-}): ReactElement {
+}
+
+export function SessionRow(props: SessionRowProps): ReactElement {
   const s = props.session;
   const isPaused = s.state === 'paused';
   const tidShort = s.agentSessionId ? s.agentSessionId.slice(0, 8) : null;

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -14,7 +14,7 @@ import {
 const TAG_HINT = 'a-z, 0-9, "-", "_", up to 33 chars';
 const TAG_RE = /^[a-z0-9][a-z0-9_-]{0,32}$/;
 
-interface Selection {
+export interface Selection {
   readonly wsId: string;
   readonly sessionId: string | null;
 }
@@ -219,7 +219,7 @@ export function Sidebar(props: SidebarProps): ReactElement {
   );
 }
 
-interface WorkspaceRowProps {
+export interface WorkspaceRowProps {
   readonly workspace: Workspace;
   readonly agents: readonly AgentInfo[];
   readonly selection: Selection | null;
@@ -264,7 +264,7 @@ function AgentBadgeGlyph({ agentId }: { agentId: string }): ReactElement {
   return <span aria-hidden="true">{agentPrefix(agentId)}</span>;
 }
 
-function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
+export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   const w = props.workspace;
   const isSelected = props.selection?.wsId === w.id && props.selection.sessionId === null;
   const hasRunning = w.sessions.some((s) => s.state === 'running');

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { FormEvent, ReactElement } from 'react';
+import { Cpu, Sparkles, Terminal, type LucideIcon } from 'lucide-react';
 
 import {
   createWorkspace,
@@ -227,6 +228,25 @@ function agentPrefix(id: string): string {
   return id[0] ?? '?';
 }
 
+/**
+ * Glyph for a given agent SDK. Icon-first so users don't have to learn the
+ * `c1` / `x1` / `sh1` naming convention — at-a-glance they see which CLI
+ * the session is running. Unknown adapter id falls back to its first
+ * letter (text), keeping the badge non-empty even for future adapters
+ * before they get an icon.
+ */
+const AGENT_ICONS: Record<string, LucideIcon> = {
+  claude: Sparkles,
+  codex: Cpu,
+  shell: Terminal,
+};
+
+function AgentBadgeGlyph({ agentId }: { agentId: string }): ReactElement {
+  const Icon = AGENT_ICONS[agentId];
+  if (Icon) return <Icon size={11} strokeWidth={2.25} aria-hidden="true" />;
+  return <span aria-hidden="true">{agentPrefix(agentId)}</span>;
+}
+
 function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   const w = props.workspace;
   const isSelected = props.selection?.wsId === w.id && props.selection.sessionId === null;
@@ -281,6 +301,7 @@ function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
           type="button"
           className="sidebar-row-main"
           onClick={() => props.onSelectWorkspace(w.id)}
+          title={w.tag}
         >
           <span
             className="sidebar-status-dot"
@@ -385,7 +406,7 @@ function SessionRow(props: {
     >
       <button type="button" className="sidebar-session-main" onClick={props.onSelect} title={title}>
         <span className={`sidebar-agent-badge is-${s.agent} ${isPaused ? 'is-paused' : ''}`}>
-          {agentPrefix(s.agent)}
+          <AgentBadgeGlyph agentId={s.agent} />
         </span>
         <span className="sidebar-session-name">{s.name}</span>
         {tidShort && <span className="sidebar-session-tid">{tidShort}</span>}

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -36,7 +36,11 @@ interface FormState {
   wireApi: 'chat' | 'responses'
 }
 
-const EMPTY_FORM: FormState = { baseUrl: '', apiKey: '', model: '', wireApi: 'chat' }
+// codex-cli ≥ 0.130 dropped the legacy `wire_api = "chat"` shape; "responses"
+// is now the only supported value (see github.com/openai/codex/discussions/7782).
+// We still surface "chat" as a labelled-deprecated option so users on older
+// codex builds aren't surprised, but the default is "responses".
+const EMPTY_FORM: FormState = { baseUrl: '', apiKey: '', model: '', wireApi: 'responses' }
 
 function configToForm(cfg: AgentConfig | null): FormState {
   if (!cfg) return EMPTY_FORM
@@ -44,7 +48,7 @@ function configToForm(cfg: AgentConfig | null): FormState {
     baseUrl: cfg.baseUrl ?? '',
     apiKey: cfg.apiKey ?? '',
     model: cfg.model ?? '',
-    wireApi: (cfg.wireApi as 'chat' | 'responses') ?? 'chat',
+    wireApi: (cfg.wireApi as 'chat' | 'responses') ?? 'responses',
   }
 }
 
@@ -268,8 +272,8 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
                 onChange={(e) => setForm({ ...form, wireApi: e.target.value as 'chat' | 'responses' })}
                 className={inputClass}
               >
-                <option value="chat">chat (OpenAI Chat Completions — most common)</option>
-                <option value="responses">responses (OpenAI Responses API)</option>
+                <option value="responses">responses (OpenAI Responses API — required by codex ≥ 0.130)</option>
+                <option value="chat">chat (legacy, OpenAI Chat Completions — removed in codex 0.130+)</option>
               </select>
             </div>
           )}

--- a/ui/src/components/workspace/WorkspacesSidebar.tsx
+++ b/ui/src/components/workspace/WorkspacesSidebar.tsx
@@ -22,6 +22,7 @@ export function WorkspacesSidebar() {
         sessionId: focused.params.sessionId ?? null,
       }
     : null
+  const overviewActive = focused?.kind === 'workspace-list'
 
   return (
     <div className="workspaces-root workspaces-sidebar-frame">
@@ -44,6 +45,8 @@ export function WorkspacesSidebar() {
         onDeleteSession={(wsId, id) => void ctx.deleteSession(wsId, id)}
         onChanged={() => void ctx.refresh()}
         onConfigureWorkspace={(wsId) => ctx.openAgentConfig(wsId)}
+        onOpenOverview={() => openOrFocus({ kind: 'workspace-list', params: {} })}
+        overviewActive={overviewActive}
       />
     </div>
   )

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -18,6 +18,15 @@ export interface Workspace {
    * pane state.
    */
   readonly sessions: readonly SessionRecord[];
+  /**
+   * Whether the workspace has UI-saved AI provider overrides for each
+   * agent. claude = `.claude/settings.local.json` exists; codex =
+   * `.codex/` directory exists. Surfaced in the Overview dashboard.
+   */
+  readonly agentOverride?: {
+    readonly claude: boolean;
+    readonly codex: boolean;
+  };
 }
 
 export interface CreateError {

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -79,6 +79,11 @@ export async function createWorkspace(
 export interface TemplateInfo {
   readonly name: string;
   readonly description?: string;
+  /** Human-readable name for UI surfaces (dashboard section headers, etc.). */
+  readonly displayName?: string;
+  /** Sort key for dashboard grouping. Lower = earlier. Templates without
+   *  a declared `groupOrder` sort after declared ones, by name. */
+  readonly groupOrder?: number;
   readonly defaultAgents: readonly string[];
 }
 

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -222,6 +222,44 @@
   color: var(--fg-dim);
 }
 
+/* Pinned "Overview" row at the top of the workspaces list. Opens the
+ * dashboard view rather than a session — visually distinct (icon-led,
+ * slightly muted, no agent badges or session children) so users don't
+ * confuse it with a workspace. */
+.sidebar-overview-row {
+  list-style: none;
+  margin: 0 0 4px 0;
+  padding: 0;
+}
+.sidebar-overview-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: 0;
+  border-left: 2px solid transparent;
+  padding: 6px 14px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--fg-dim);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.sidebar-overview-btn:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--fg);
+}
+.sidebar-overview-btn.is-active {
+  background: rgba(121, 192, 255, 0.08);
+  border-left-color: var(--accent);
+  color: var(--fg);
+}
+.sidebar-overview-btn > svg {
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
 .sidebar-row {
   display: flex;
   align-items: stretch;

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -243,6 +243,10 @@
   gap: 8px;
   padding: 6px 14px;
   flex: 1 1 auto;
+  /* min-width: 0 lets the .sidebar-tag child shrink below its intrinsic
+   * width so the text-overflow ellipsis kicks in. Without this, long tags
+   * push the row wider than the sidebar column and wrap or overflow. */
+  min-width: 0;
   cursor: pointer;
   text-align: left;
   font: inherit;
@@ -260,8 +264,14 @@
 
 .sidebar-tag {
   flex: 1 1 auto;
+  /* Required for ellipsis to work inside a flex parent (matches the
+   * min-width: 0 on .sidebar-row-main above). */
+  min-width: 0;
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar-meta {

--- a/ui/src/pages/WorkspaceListPage.tsx
+++ b/ui/src/pages/WorkspaceListPage.tsx
@@ -1,14 +1,15 @@
 /**
  * Workspaces Overview dashboard.
  *
- * Card-based at-a-glance view of every workspace. Each card shows the
- * workspace's running/paused sessions, its AI-provider override status,
- * and its latest commit. Card body opens the workspace's main tab;
- * session rows drill straight into that session; the override row opens
- * the AI-provider modal.
+ * Card-based at-a-glance view of every workspace, grouped by template
+ * type into sections. Section order is driven by each template's
+ * `groupOrder` declared in its `template.json` — adding a new template
+ * type just needs the JSON entry, no frontend code change. Workspaces
+ * with an unknown / missing template land in a trailing "Other" bucket.
  *
- * Future-friendly for "publish workspace state externally" (status-page
- * feel) — no secrets surface, no internal paths.
+ * Within each section, cards sort by most-recent-activity. Card body
+ * opens the workspace tab; session rows drill into that session; the
+ * ⚙ override row opens the AI-provider modal.
  */
 
 import { useEffect, useMemo, useState } from 'react'
@@ -16,7 +17,12 @@ import { useEffect, useMemo, useState } from 'react'
 import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { useWorkspace } from '../tabs/store'
 import { OverviewCard } from '../components/workspace/OverviewCard'
-import { getGitLog, type GitLogEntry, type Workspace } from '../components/workspace/api'
+import {
+  getGitLog,
+  type GitLogEntry,
+  type TemplateInfo,
+  type Workspace,
+} from '../components/workspace/api'
 
 function lastActivityMs(w: Workspace): number {
   const sessionTs = w.sessions
@@ -26,8 +32,70 @@ function lastActivityMs(w: Workspace): number {
   return Math.max(...sessionTs)
 }
 
+/** Best-effort humanization for templates that don't declare a `displayName`. */
+function humanize(name: string): string {
+  return (
+    name
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(' ') || name
+  )
+}
+
+interface Section {
+  readonly key: string
+  readonly title: string
+  readonly workspaces: readonly Workspace[]
+}
+
+const UNKNOWN_KEY = '__unknown__'
+
+function buildSections(
+  workspaces: readonly Workspace[],
+  templates: readonly TemplateInfo[],
+): Section[] {
+  // Bucket workspaces by template name; unknown / missing → "Other".
+  const knownTemplateNames = new Set(templates.map((t) => t.name))
+  const buckets = new Map<string, Workspace[]>()
+  for (const w of workspaces) {
+    const key = w.template && knownTemplateNames.has(w.template) ? w.template : UNKNOWN_KEY
+    const bucket = buckets.get(key)
+    if (bucket) bucket.push(w)
+    else buckets.set(key, [w])
+  }
+
+  // Section order = templates sorted by groupOrder (declared in each
+  // template.json), then alphabetical for ties / undeclared. Templates
+  // without a workspace in them are skipped.
+  const orderedTemplates = [...templates].sort((a, b) => {
+    const ao = a.groupOrder ?? Number.POSITIVE_INFINITY
+    const bo = b.groupOrder ?? Number.POSITIVE_INFINITY
+    if (ao !== bo) return ao - bo
+    return a.name.localeCompare(b.name)
+  })
+
+  const sections: Section[] = []
+  for (const t of orderedTemplates) {
+    const ws = buckets.get(t.name)
+    if (!ws || ws.length === 0) continue
+    const sorted = [...ws].sort((a, b) => lastActivityMs(b) - lastActivityMs(a))
+    sections.push({
+      key: t.name,
+      title: t.displayName ?? humanize(t.name),
+      workspaces: sorted,
+    })
+  }
+  const others = buckets.get(UNKNOWN_KEY)
+  if (others && others.length > 0) {
+    const sorted = [...others].sort((a, b) => lastActivityMs(b) - lastActivityMs(a))
+    sections.push({ key: UNKNOWN_KEY, title: 'Other', workspaces: sorted })
+  }
+  return sections
+}
+
 export function WorkspaceListPage() {
-  const { workspaces, openAgentConfig } = useWorkspaces()
+  const { workspaces, templates, openAgentConfig } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
 
   // Latest commit per workspace. Fetched in parallel on mount + whenever
@@ -57,9 +125,10 @@ export function WorkspaceListPage() {
     }
   }, [idsKey, workspaces])
 
-  const sorted = useMemo(() => {
-    return [...workspaces].sort((a, b) => lastActivityMs(b) - lastActivityMs(a))
-  }, [workspaces])
+  const sections = useMemo(
+    () => buildSections(workspaces, templates),
+    [workspaces, templates],
+  )
 
   if (workspaces.length === 0) {
     return (
@@ -77,30 +146,42 @@ export function WorkspaceListPage() {
   return (
     <div className="h-full overflow-y-auto">
       <div className="max-w-5xl mx-auto px-6 py-6">
-        <div className="mb-5 flex items-baseline justify-between gap-4">
+        <div className="mb-6 flex items-baseline justify-between gap-4">
           <h2 className="text-[18px] font-semibold text-text">Workspaces Overview</h2>
           <span className="text-[12px] text-text-muted">
             {workspaces.length} workspace{workspaces.length === 1 ? '' : 's'}
           </span>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          {sorted.map((w) => (
-            <OverviewCard
-              key={w.id}
-              workspace={w}
-              lastCommit={commits[w.id] ?? null}
-              onOpen={() =>
-                openOrFocus({ kind: 'workspace', params: { wsId: w.id } })
-              }
-              onOpenSession={(sid) =>
-                openOrFocus({
-                  kind: 'workspace',
-                  params: { wsId: w.id, sessionId: sid },
-                })
-              }
-              onConfigure={() => openAgentConfig(w.id)}
-            />
+        <div className="space-y-7">
+          {sections.map((sec) => (
+            <section key={sec.key}>
+              <div className="mb-3 flex items-baseline gap-2">
+                <h3 className="text-[12px] font-semibold text-text/85 uppercase tracking-wider">
+                  {sec.title}
+                </h3>
+                <span className="text-[11px] text-text-muted">· {sec.workspaces.length}</span>
+              </div>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                {sec.workspaces.map((w) => (
+                  <OverviewCard
+                    key={w.id}
+                    workspace={w}
+                    lastCommit={commits[w.id] ?? null}
+                    onOpen={() =>
+                      openOrFocus({ kind: 'workspace', params: { wsId: w.id } })
+                    }
+                    onOpenSession={(sid) =>
+                      openOrFocus({
+                        kind: 'workspace',
+                        params: { wsId: w.id, sessionId: sid },
+                      })
+                    }
+                    onConfigure={() => openAgentConfig(w.id)}
+                  />
+                ))}
+              </div>
+            </section>
           ))}
         </div>
       </div>

--- a/ui/src/pages/WorkspaceListPage.tsx
+++ b/ui/src/pages/WorkspaceListPage.tsx
@@ -1,17 +1,109 @@
 /**
- * Landing page for the Workspaces activity. Sidebar carries the actual
- * list + create form; this is just the "no workspace pinned" prompt.
+ * Workspaces Overview dashboard.
+ *
+ * Card-based at-a-glance view of every workspace. Each card shows the
+ * workspace's running/paused sessions, its AI-provider override status,
+ * and its latest commit. Card body opens the workspace's main tab;
+ * session rows drill straight into that session; the override row opens
+ * the AI-provider modal.
+ *
+ * Future-friendly for "publish workspace state externally" (status-page
+ * feel) — no secrets surface, no internal paths.
  */
 
+import { useEffect, useMemo, useState } from 'react'
+
+import { useWorkspaces } from '../contexts/WorkspacesContext'
+import { useWorkspace } from '../tabs/store'
+import { OverviewCard } from '../components/workspace/OverviewCard'
+import { getGitLog, type GitLogEntry, type Workspace } from '../components/workspace/api'
+
+function lastActivityMs(w: Workspace): number {
+  const sessionTs = w.sessions
+    .map((s) => new Date(s.lastActiveAt).getTime())
+    .filter((n) => Number.isFinite(n))
+  if (sessionTs.length === 0) return new Date(w.createdAt).getTime()
+  return Math.max(...sessionTs)
+}
+
 export function WorkspaceListPage() {
+  const { workspaces, openAgentConfig } = useWorkspaces()
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+
+  // Latest commit per workspace. Fetched in parallel on mount + whenever
+  // the set of workspace IDs changes. Polled separately from the regular
+  // workspaces refresh because git log is expensive — we don't want it
+  // running every 3s on the list poll.
+  const [commits, setCommits] = useState<Record<string, GitLogEntry | null>>({})
+  const idsKey = useMemo(() => workspaces.map((w) => w.id).join(','), [workspaces])
+  useEffect(() => {
+    if (workspaces.length === 0) return
+    let cancelled = false
+    void Promise.all(
+      workspaces.map(async (w) => {
+        try {
+          const entries = await getGitLog(w.id, 1)
+          return [w.id, entries[0] ?? null] as const
+        } catch {
+          return [w.id, null] as const
+        }
+      }),
+    ).then((pairs) => {
+      if (cancelled) return
+      setCommits(Object.fromEntries(pairs))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [idsKey, workspaces])
+
+  const sorted = useMemo(() => {
+    return [...workspaces].sort((a, b) => lastActivityMs(b) - lastActivityMs(a))
+  }, [workspaces])
+
+  if (workspaces.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-text-muted px-6">
+        <h2 className="text-lg font-medium text-text mb-2">Workspaces</h2>
+        <p className="text-sm max-w-md text-center">
+          No workspaces yet. Create one from the sidebar — each is an isolated git
+          directory with a persistent terminal session attached, wired to OpenAlice
+          over MCP.
+        </p>
+      </div>
+    )
+  }
+
   return (
-    <div className="flex flex-col items-center justify-center h-full text-text-muted">
-      <h2 className="text-lg font-medium text-text mb-2">Workspaces</h2>
-      <p className="text-sm max-w-md text-center">
-        Pick a workspace from the sidebar, or create one with the form above. Each
-        workspace is an isolated git directory with a persistent terminal session
-        attached — Claude Code, Codex, or a plain shell, all wired to OpenAlice over MCP.
-      </p>
+    <div className="h-full overflow-y-auto">
+      <div className="max-w-5xl mx-auto px-6 py-6">
+        <div className="mb-5 flex items-baseline justify-between gap-4">
+          <h2 className="text-[18px] font-semibold text-text">Workspaces Overview</h2>
+          <span className="text-[12px] text-text-muted">
+            {workspaces.length} workspace{workspaces.length === 1 ? '' : 's'}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {sorted.map((w) => (
+            <OverviewCard
+              key={w.id}
+              workspace={w}
+              lastCommit={commits[w.id] ?? null}
+              onOpen={() =>
+                openOrFocus({ kind: 'workspace', params: { wsId: w.id } })
+              }
+              onOpenSession={(sid) =>
+                openOrFocus({
+                  kind: 'workspace',
+                  params: { wsId: w.id, sessionId: sid },
+                })
+              }
+              onConfigure={() => openAgentConfig(w.id)}
+            />
+          ))}
+        </div>
+      </div>
     </div>
   )
 }

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react'
 import type { ChannelListItem } from '../api/channels'
+import type { Workspace } from '../components/workspace/api'
 import type { ViewKind, ViewSpec } from './types'
 
 import { ChatPage } from '../pages/ChatPage'
@@ -33,6 +34,9 @@ import { WorkspacePage } from '../pages/WorkspacePage'
 
 export interface TitleCtx {
   channels: ChannelListItem[]
+  /** Workspaces list, threaded from WorkspacesContext. Used by workspaceModule
+   *  to render tab titles as `<tag> · <sessionName>` instead of opaque UUIDs. */
+  workspaces?: readonly Workspace[]
 }
 
 interface ViewProps<K extends ViewKind> {
@@ -193,10 +197,14 @@ const workspaceListModule: ViewModule<'workspace-list'> = {
 
 const workspaceModule: ViewModule<'workspace'> = {
   kind: 'workspace',
-  title: (spec) => {
-    const ws = spec.params.wsId.slice(0, 8)
+  title: (spec, ctx) => {
+    const ws = ctx.workspaces?.find((w) => w.id === spec.params.wsId)
+    const tag = ws?.tag ?? spec.params.wsId.slice(0, 8)
     const sid = spec.params.sessionId
-    return sid ? `${ws} · ${sid.slice(0, 6)}` : ws
+    if (!sid) return tag
+    const session = ws?.sessions.find((s) => s.id === sid)
+    const name = session?.name ?? sid.slice(0, 6)
+    return `${tag} · ${name}`
   },
   toUrl: (spec) => {
     const base = `/workspaces/${encodeURIComponent(spec.params.wsId)}`


### PR DESCRIPTION
## Summary
- Workspace AI provider config is now strictly workspace-owned — no
  symlink inheritance from `~/.codex/`, no `~/.codex/config.toml`
  pollution.
- New Workspaces Overview dashboard, with template-grouped sections
  driven by each `template.json` (extensible to many template types
  via JSON declarations, no frontend code change).
- Chat activity sidebar restructured into two clearly labeled
  sections — Workspace chat (recommended) and Traditional — surfacing
  the cost / capability split between native-CLI chats and the
  ChatHook-driven path used by connectors.
- README documents the "Two kinds of chat" split.

## Per-session contributions
### 2026-05-13 — Codex inheritance, Overview dashboard, two-kinds-of-chat split
- **Tier-1 UX polish** (`c575415`): readable tab titles, sidebar tag
  truncate, session SDK icons.
- **Codex global-config inheritance removed** (`6b52853`): drop the
  symlink + workspace config.toml MCP block; wire MCP per-spawn via
  `-c mcp_servers.openalice.url=...`; reset deletes the workspace's
  `.codex/` directory entirely; `wire_api` default flipped to
  `responses` (codex-cli ≥ 0.130 dropped `chat`).
- **TODO** (`907fcda`): profile + AI Provider model needs structural
  rethink — flagged alongside the native-Anthropic / native-OpenAI
  TODOs.
- **Workspaces Overview dashboard** (`bb7b991`): pinned Overview row,
  card-based view per workspace, sorted by recent activity, with
  override badge + latest commit footer.
- **Template-grouped sections** (`5164253`): dashboard cards group by
  template; section order driven by each `template.json`'s
  `displayName` + `groupOrder` — new template types just need a JSON
  entry.
- **Two kinds of chat** (`24b424f`): Chat sidebar split into Workspace
  chat (recommended) + Traditional, with footer link to the README
  anchor. README adds a top-level "Two kinds of chat" section with
  the Workspace vs Traditional matrix.

## Full commit log
```
24b424f feat(chat): two-section sidebar — workspace chat (recommended) + traditional
5164253 feat(workspaces): group Overview dashboard by template type
bb7b991 feat(workspaces): Overview dashboard with card-based status view
907fcda docs(TODO): flag profile + AI Provider model needs structural rethink
6b52853 refactor(workspaces): drop global-config inheritance, wire MCP per-spawn
c575415 feat(workspaces/ui): readable tab titles + sidebar truncate + SDK icons
```

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm test` passes (1687 tests)
- [x] Fresh chat workspace creates no `.codex/` skeleton; codex spawn uses global ChatGPT auth + sees OpenAlice MCP via `-c` flag.
- [x] UI Save writes `.codex/{config.toml, env.json}` only (no MCP block, no auth.json); UI Reset deletes the entire `.codex/` directory.
- [x] `~/.codex/config.toml` unmodified after all operations.
- [x] Overview dashboard renders cards with correct status / sessions / override / commit; sections respect `groupOrder` from `template.json` (CHAT before AUTO-QUANT); card / session / override clicks route correctly.
- [x] Chat sidebar: Workspace chat section shows only template==chat workspaces; create form locked to chat template; clicking workspace opens `/workspaces/<id>` tab; Traditional section unchanged; "Why two kinds of chat?" link goes to README anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)