### PR TITLE
fix(trading): aliceId resolution for read-side tools + e2e init bounds

### DIFF
--- a/src/domain/trading/UnifiedTradingAccount.spec.ts
+++ b/src/domain/trading/UnifiedTradingAccount.spec.ts
@@ -447,6 +447,34 @@ describe('UTA — stageClosePosition', () => {
   })
 })
 
+// ==================== contractFromAliceId ====================
+
+describe('UTA — contractFromAliceId', () => {
+  let uta: UnifiedTradingAccount
+
+  beforeEach(() => {
+    ({ uta } = createUTA())
+  })
+
+  it('resolves a valid aliceId to a Contract with native fields filled', () => {
+    const contract = uta.contractFromAliceId('mock-paper|AAPL')
+    expect(contract.aliceId).toBe('mock-paper|AAPL')
+    // MockBroker.resolveNativeKey produces a stamped Contract with the
+    // ticker on `symbol` — anything more concrete is broker-specific, but
+    // we at minimum want a non-empty handle that downstream broker APIs
+    // can resolve back to the same market.
+    expect(contract.symbol || contract.localSymbol).toBeTruthy()
+  })
+
+  it('throws on malformed aliceId (no separator)', () => {
+    expect(() => uta.contractFromAliceId('mock-paper-AAPL')).toThrow(/Invalid aliceId/)
+  })
+
+  it('throws when aliceId belongs to a different UTA', () => {
+    expect(() => uta.contractFromAliceId('alpaca-paper|AAPL')).toThrow(/belongs to UTA "alpaca-paper"/)
+  })
+})
+
 // ==================== stageCancelOrder ====================
 
 describe('UTA — stageCancelOrder', () => {

--- a/src/domain/trading/UnifiedTradingAccount.ts
+++ b/src/domain/trading/UnifiedTradingAccount.ts
@@ -344,16 +344,36 @@ export class UnifiedTradingAccount {
     return { utaId: aliceId.slice(0, sep), nativeKey: aliceId.slice(sep + 1) }
   }
 
+  /**
+   * Reverse of `stampAliceId`: parse an aliceId, verify it belongs to this
+   * UTA, and rebuild the full Contract via the broker's native-key resolver.
+   * Throws on malformed input or cross-UTA mismatch — those are caller bugs
+   * (AI passing an aliceId from a different account, or stale state) and
+   * should surface loudly rather than silently no-op.
+   *
+   * Use this whenever an AI tool or HTTP route receives an aliceId from the
+   * outside and needs to call a broker read API (getQuote, getOrderBook,
+   * getFundingRate, getContractDetails). The staging methods below also
+   * funnel through here for consistency.
+   */
+  contractFromAliceId(aliceId: string): Contract {
+    const parsed = UnifiedTradingAccount.parseAliceId(aliceId)
+    if (!parsed) {
+      throw new Error(`Invalid aliceId "${aliceId}". Use searchContracts to get a valid contract identifier (expected format: "accountId|nativeKey").`)
+    }
+    if (parsed.utaId !== this.id) {
+      throw new Error(`aliceId "${aliceId}" belongs to UTA "${parsed.utaId}", not "${this.id}".`)
+    }
+    const contract = this.broker.resolveNativeKey(parsed.nativeKey)
+    contract.aliceId = aliceId
+    return contract
+  }
+
   // ==================== Stage operations ====================
 
   stagePlaceOrder(params: StagePlaceOrderParams): AddResult {
     // Resolve aliceId → full contract via broker (fills secType, exchange, currency, conId, etc.)
-    const parsed = UnifiedTradingAccount.parseAliceId(params.aliceId)
-    if (!parsed) {
-      throw new Error(`Invalid aliceId "${params.aliceId}". Use searchContracts to get a valid contract identifier (expected format: "accountId|nativeKey").`)
-    }
-    const contract = this.broker.resolveNativeKey(parsed.nativeKey)
-    contract.aliceId = params.aliceId
+    const contract = this.contractFromAliceId(params.aliceId)
     if (params.symbol) contract.symbol = params.symbol
 
     const order = new Order()
@@ -395,12 +415,7 @@ export class UnifiedTradingAccount {
   }
 
   stageClosePosition(params: StageClosePositionParams): AddResult {
-    const parsed = UnifiedTradingAccount.parseAliceId(params.aliceId)
-    if (!parsed) {
-      throw new Error(`Invalid aliceId "${params.aliceId}". Use searchContracts to get a valid contract identifier (expected format: "accountId|nativeKey").`)
-    }
-    const contract = this.broker.resolveNativeKey(parsed.nativeKey)
-    contract.aliceId = params.aliceId
+    const contract = this.contractFromAliceId(params.aliceId)
     if (params.symbol) contract.symbol = params.symbol
 
     return this.git.add({

--- a/src/domain/trading/__test__/e2e/setup.ts
+++ b/src/domain/trading/__test__/e2e/setup.ts
@@ -59,6 +59,30 @@ function isTcpReachable(host: string, port: number, timeoutMs = 2000): Promise<b
 
 // ==================== Lazy singleton ====================
 
+/**
+ * Per-broker init budget. Prevents one stuck testnet from blocking the
+ * whole serial setup (Hyperliquid testnet outages have burned ~5min on
+ * the CCXT retry/backoff ladder in the past). Tests with longer-than-30s
+ * legitimate init should expose their own setup hook rather than raising
+ * this ceiling.
+ */
+const BROKER_INIT_TIMEOUT_MS = 30_000
+
+function initWithTimeout(broker: IBroker, ms: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      reject(new Error(`broker.init timed out after ${ms}ms`))
+    }, ms)
+    broker.init().then(
+      () => { if (!settled) { settled = true; clearTimeout(timer); resolve() } },
+      (err) => { if (!settled) { settled = true; clearTimeout(timer); reject(err) } },
+    )
+  })
+}
+
 let cached: Promise<TestAccount[]> | null = null
 
 /**
@@ -97,7 +121,7 @@ async function initAll(): Promise<TestAccount[]> {
     const broker = createBroker(acct)
 
     try {
-      await broker.init()
+      await initWithTimeout(broker, BROKER_INIT_TIMEOUT_MS)
     } catch (err) {
       console.warn(`e2e setup: ${acct.id} init failed, skipping:`, err)
       continue

--- a/src/domain/trading/__test__/e2e/uta-alpaca.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/uta-alpaca.e2e.spec.ts
@@ -11,6 +11,8 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
 import { getTestAccounts, filterByProvider } from './setup.js'
 import { UnifiedTradingAccount } from '../../UnifiedTradingAccount.js'
+import { UTAManager } from '../../uta-manager.js'
+import { createTradingTools } from '../../../../tool/trading.js'
 import type { IBroker } from '../../brokers/types.js'
 import '../../contract-ext.js'
 
@@ -72,6 +74,57 @@ describe('UTA — Alpaca order lifecycle', () => {
 
     // Verify log has 2 commits
     expect(uta!.log().length).toBeGreaterThanOrEqual(2)
+  }, 30_000)
+})
+
+// ==================== AI read tools — aliceId resolution ====================
+
+// Regression guard for the 2026-05 bug: `getQuote` / `getContractDetails`
+// stamped raw aliceId onto a fresh Contract; Alpaca's `resolveSymbol`
+// only reads `contract.symbol`, so the broker silently failed to find
+// anything. This block exercises the AI tool path end-to-end.
+
+describe('UTA — Alpaca AI tool aliceId resolution', () => {
+  beforeEach(({ skip }) => { if (!uta) skip('no Alpaca paper account') })
+
+  it('searchContracts → getQuote round-trips with a real aliceId', async () => {
+    const mgr = new UTAManager()
+    mgr.add(uta!)
+    const tools = createTradingTools(mgr)
+
+    const searchResult = await (tools.searchContracts.execute as Function)({
+      pattern: 'AAPL',
+      source: uta!.id,
+    })
+    expect(Array.isArray(searchResult)).toBe(true)
+    const aapl = (searchResult as Array<Record<string, unknown>>)[0]
+    expect(aapl).toBeDefined()
+    const realAliceId = (aapl as any).contract.aliceId
+    expect(realAliceId).toMatch(/^.+\|.+/)
+    console.log(`  AI tools: Alpaca aliceId=${realAliceId}`)
+
+    const quote = await (tools.getQuote.execute as Function)({ aliceId: realAliceId })
+    expect(quote.error).toBeUndefined()
+    expect(quote.source).toBe(uta!.id)
+    expect(quote.last).toBeDefined()
+    console.log(`  AI tools: AAPL quote last=${quote.last}, bid=${quote.bid}, ask=${quote.ask}`)
+  }, 30_000)
+
+  it('getContractDetails with aliceId returns spec', async () => {
+    const mgr = new UTAManager()
+    mgr.add(uta!)
+    const tools = createTradingTools(mgr)
+    const nativeKey = broker!.getNativeKey({ symbol: 'AAPL' } as any)
+    const aliceId = `${uta!.id}|${nativeKey}`
+
+    const result = await (tools.getContractDetails.execute as Function)({
+      source: uta!.id,
+      aliceId,
+    })
+    expect(result.error).toBeUndefined()
+    expect(result.contract).toBeDefined()
+    expect(result.contract.symbol).toBe('AAPL')
+    console.log(`  AI tools: AAPL contractDetails secType=${result.contract.secType}`)
   }, 30_000)
 })
 

--- a/src/domain/trading/__test__/e2e/uta-bybit.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/uta-bybit.e2e.spec.ts
@@ -10,6 +10,9 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
 import { getTestAccounts, filterByProvider } from './setup.js'
 import { UnifiedTradingAccount } from '../../UnifiedTradingAccount.js'
+import { UTAManager } from '../../uta-manager.js'
+import { createTradingTools } from '../../../../tool/trading.js'
+import { createCcxtProviderTools } from '../../brokers/ccxt/ccxt-tools.js'
 import type { IBroker } from '../../brokers/types.js'
 import '../../contract-ext.js'
 
@@ -117,6 +120,85 @@ describe('UTA — Bybit lifecycle (ETH perp)', () => {
     console.log(`  log: ${history.length} commits — [${history.map(h => h.message).join(', ')}]`)
     expect(history.length).toBeGreaterThanOrEqual(2)
   }, 60_000)
+
+  // ==================== AI read tools — aliceId resolution ====================
+
+  // Regression guard for the 2026-05 bug: ccxt-tools `getOrderBook` /
+  // `getFundingRate` and the generic `getQuote` / `getContractDetails`
+  // were stamping the raw aliceId onto a fresh Contract without resolving
+  // it through `broker.resolveNativeKey`. The broker's `contractToCcxt`
+  // only reads `localSymbol`/`symbol`, so every read returned an error.
+  // These tests exercise the same path AI tool calls take end-to-end.
+
+  it('AI tools: searchContracts → getQuote round-trips with a real aliceId', async () => {
+    const mgr = new UTAManager()
+    mgr.add(uta!)
+    const tools = createTradingTools(mgr)
+
+    // Step 1: search → get the canonical aliceId the AI would receive.
+    const searchResult = await (tools.searchContracts.execute as Function)({
+      pattern: 'ETH',
+      assetClass: 'crypto',
+      source: uta!.id,
+    })
+    expect(Array.isArray(searchResult)).toBe(true)
+    const perp = (searchResult as Array<Record<string, unknown>>).find(
+      (r) => (r as any).contract?.secType === 'CRYPTO_PERP',
+    )
+    expect(perp).toBeDefined()
+    const realAliceId = (perp as any).contract.aliceId
+    expect(realAliceId).toMatch(/^.+\|.+/)
+    console.log(`  AI tools: aliceId=${realAliceId}`)
+
+    // Step 2: getQuote — would have errored on the legacy code path.
+    const quote = await (tools.getQuote.execute as Function)({ aliceId: realAliceId })
+    expect(quote.error).toBeUndefined()
+    expect(quote.source).toBe(uta!.id)
+    expect(quote.last).toBeDefined()
+    expect(parseFloat(quote.last)).toBeGreaterThan(0)
+    console.log(`  AI tools: quote last=${quote.last}, bid=${quote.bid}, ask=${quote.ask}`)
+  }, 30_000)
+
+  it('AI tools: getOrderBook + getFundingRate via createCcxtProviderTools', async () => {
+    const mgr = new UTAManager()
+    mgr.add(uta!)
+    const ccxtTools = createCcxtProviderTools(mgr)
+
+    const ob = await (ccxtTools.getOrderBook.execute as Function)({
+      aliceId: ethAliceId,
+      limit: 5,
+    })
+    expect(ob.error).toBeUndefined()
+    expect(Array.isArray(ob.bids)).toBe(true)
+    expect(Array.isArray(ob.asks)).toBe(true)
+    expect(ob.bids.length).toBeGreaterThan(0)
+    expect(ob.asks.length).toBeGreaterThan(0)
+    console.log(`  AI tools: orderbook bids=${ob.bids.length}, asks=${ob.asks.length}`)
+
+    const fr = await (ccxtTools.getFundingRate.execute as Function)({
+      aliceId: ethAliceId,
+    })
+    expect(fr.error).toBeUndefined()
+    expect(typeof fr.fundingRate).toBe('number')
+    console.log(`  AI tools: fundingRate=${fr.fundingRate}`)
+  }, 30_000)
+
+  it('AI tools: getContractDetails with aliceId returns spec', async () => {
+    const mgr = new UTAManager()
+    mgr.add(uta!)
+    const tools = createTradingTools(mgr)
+
+    const result = await (tools.getContractDetails.execute as Function)({
+      source: uta!.id,
+      aliceId: ethAliceId,
+    })
+    expect(result.error).toBeUndefined()
+    expect(result.contract).toBeDefined()
+    expect(result.contract.aliceId).toBe(ethAliceId)
+    console.log(`  AI tools: contractDetails secType=${result.contract.secType}`)
+  }, 30_000)
+
+  // ============================================================================
 
   it('buy with TPSL → tpsl visible on fetched order', async () => {
     const quote = await broker!.getQuote(broker!.resolveNativeKey(ethAliceId.split('|')[1]))

--- a/src/domain/trading/brokers/alpaca/alpaca-contracts.ts
+++ b/src/domain/trading/brokers/alpaca/alpaca-contracts.ts
@@ -19,13 +19,6 @@ export function makeContract(ticker: string): Contract {
   })
 }
 
-/** Extract native symbol from aliceId, or null if not ours. */
-export function parseAliceId(aliceId: string, provider: string): string | null {
-  const prefix = `${provider}-`
-  if (!aliceId.startsWith(prefix)) return null
-  return aliceId.slice(prefix.length)
-}
-
 /**
  * Resolve a Contract to an Alpaca ticker symbol.
  * Uses symbol directly. aliceId is managed by UTA layer, not broker.

--- a/src/domain/trading/brokers/ccxt/ccxt-contracts.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-contracts.ts
@@ -2,11 +2,8 @@
  * Contract resolution helpers for CCXT exchanges.
  *
  * Pure functions parameterized by (markets, exchangeName) —
- * no dependency on the CcxtBroker instance.
- *
- * aliceId format: "{exchange}-{encodedSymbol}"
- * where encodedSymbol = market.symbol with / → _ and : → .
- * e.g. "bybit-ETH_USDT.USDT" for "ETH/USDT:USDT"
+ * no dependency on the CcxtBroker instance. aliceId is owned by
+ * UnifiedTradingAccount, not this layer — see `UTA.stampAliceId`.
  */
 
 import { Contract, OrderState } from '@traderalice/ibkr'
@@ -14,18 +11,6 @@ import '../../contract-ext.js'
 import type { CcxtMarket } from './ccxt-types.js'
 import { buildContract } from '../contract-builder.js'
 import type { SecType } from '../../contract-discipline.js'
-
-// ---- Symbol encoding for aliceId ----
-
-/** CCXT symbol → aliceId suffix (escape / and :) */
-export function encodeSymbol(symbol: string): string {
-  return symbol.replace(/\//g, '_').replace(/:/g, '.')
-}
-
-/** aliceId suffix → CCXT symbol (unescape) */
-export function decodeSymbol(encoded: string): string {
-  return encoded.replace(/_/g, '/').replace(/\./g, ':')
-}
 
 // ---- Type mapping ----
 
@@ -114,13 +99,6 @@ export function marketToContract(market: CcxtMarket, exchangeName: string): Cont
   }
 
   return buildContract(params)
-}
-
-/** Parse aliceId → CCXT unified symbol. */
-export function aliceIdToCcxt(aliceId: string, exchangeName: string): string | null {
-  const prefix = `${exchangeName}-`
-  if (!aliceId.startsWith(prefix)) return null
-  return decodeSymbol(aliceId.slice(prefix.length))
 }
 
 /**

--- a/src/domain/trading/brokers/ccxt/ccxt-tools.spec.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-tools.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * createCcxtProviderTools — unit tests.
+ *
+ * Verifies the AI-tool layer correctly resolves aliceId via
+ * `uta.contractFromAliceId` before forwarding to the broker. Bug history:
+ * the prior implementation stamped the raw input on `Contract.aliceId` and
+ * passed it through, leaving `contractToCcxt` unable to resolve.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock ccxt BEFORE importing CcxtBroker (mirrors CcxtBroker.spec.ts).
+vi.mock('ccxt', () => {
+  const MockExchange = vi.fn(function (this: any) {
+    // `id` is what CcxtBroker.resolveNativeKey forwards to marketToContract
+    // as the exchange tag. Empty id → buildContract rejects.
+    this.id = 'bybit'
+    this.markets = {}
+    this.options = { fetchMarkets: { types: ['spot', 'linear'] } }
+    this.setSandboxMode = vi.fn()
+    this.loadMarkets = vi.fn().mockResolvedValue({})
+    this.fetchMarkets = vi.fn().mockResolvedValue([])
+    this.fetchOrderBook = vi.fn()
+    this.fetchFundingRate = vi.fn()
+  })
+  return { default: { bybit: MockExchange, binance: MockExchange } }
+})
+
+import { CcxtBroker } from './CcxtBroker.js'
+import { createCcxtProviderTools } from './ccxt-tools.js'
+import { MockBroker } from '../mock/MockBroker.js'
+import { UTAManager } from '../../uta-manager.js'
+import { UnifiedTradingAccount } from '../../UnifiedTradingAccount.js'
+import '../../contract-ext.js'
+
+function makeSwapMarket(base: string, quote: string): any {
+  return {
+    id: `${base}${quote}`,
+    symbol: `${base}/${quote}:${quote}`,
+    base, quote,
+    type: 'swap',
+    active: true,
+    precision: { price: 0.01 },
+    limits: {},
+    settle: quote,
+  }
+}
+
+function makeCcxtUta(): { uta: UnifiedTradingAccount; broker: CcxtBroker; mgr: UTAManager } {
+  const broker = new CcxtBroker({ exchange: 'bybit', apiKey: 'k', secret: 's', sandbox: false })
+  ;(broker as any).initialized = true
+  // CcxtBroker.markets is a getter that reads from exchange.markets — set there.
+  ;(broker as any).exchange.markets = {
+    'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT'),
+  }
+  // UTA._connect runs broker.init + broker.getAccount in the constructor; the
+  // ccxt mock has no real init wiring, so stub both to no-op so the UTA stays
+  // enabled. We're not exercising the connection path here — only resolution.
+  vi.spyOn(broker, 'init').mockResolvedValue(undefined)
+  vi.spyOn(broker, 'getAccount').mockResolvedValue({
+    netLiquidation: '0', totalCashValue: '0', buyingPower: '0',
+    unrealizedPnL: '0', realizedPnL: '0', currency: 'USD',
+  } as any)
+  vi.spyOn(broker, 'getPositions').mockResolvedValue([])
+  vi.spyOn(broker, 'getOrders').mockResolvedValue([])
+  const uta = new UnifiedTradingAccount(broker)
+  const mgr = new UTAManager()
+  mgr.add(uta)
+  return { uta, broker, mgr }
+}
+
+describe('createCcxtProviderTools — getOrderBook', () => {
+  let broker: CcxtBroker
+  let mgr: UTAManager
+
+  beforeEach(() => {
+    ({ broker, mgr } = makeCcxtUta())
+    ;(broker as any).exchange.fetchOrderBook = vi.fn().mockResolvedValue({
+      bids: [[100, 1], [99, 2]],
+      asks: [[101, 1], [102, 2]],
+      timestamp: Date.now(),
+    })
+  })
+
+  it('resolves aliceId via UTA and forwards a Contract with localSymbol', async () => {
+    const tools = createCcxtProviderTools(mgr)
+    const brokerSpy = vi.spyOn(broker, 'getOrderBook')
+
+    const result = await (tools.getOrderBook.execute as Function)({
+      aliceId: 'bybit-main|BTC/USDT:USDT',
+    })
+
+    expect(brokerSpy).toHaveBeenCalledTimes(1)
+    const [passedContract] = brokerSpy.mock.calls[0]
+    // Without contractFromAliceId, localSymbol would be empty and
+    // contractToCcxt would fail.
+    expect(passedContract.localSymbol).toBe('BTC/USDT:USDT')
+    expect(passedContract.aliceId).toBe('bybit-main|BTC/USDT:USDT')
+    expect(result.source).toBe('bybit-main')
+    expect(result.bids).toHaveLength(2)
+  })
+
+  it('returns error on malformed aliceId', async () => {
+    const tools = createCcxtProviderTools(mgr)
+    const result = await (tools.getOrderBook.execute as Function)({
+      aliceId: 'no-separator-here',
+    })
+    expect(result.error).toMatch(/Invalid aliceId/)
+  })
+
+  it('returns error when aliceId points to a different UTA', async () => {
+    const tools = createCcxtProviderTools(mgr)
+    const result = await (tools.getOrderBook.execute as Function)({
+      aliceId: 'other-account|BTC/USDT:USDT',
+    })
+    expect(result.error).toMatch(/belongs to UTA "other-account"/)
+  })
+
+  it('returns error when no CCXT account is registered', async () => {
+    const mgrOnlyMock = new UTAManager()
+    mgrOnlyMock.add(new UnifiedTradingAccount(new MockBroker({ id: 'mock-paper' })))
+    const tools = createCcxtProviderTools(mgrOnlyMock)
+    const result = await (tools.getOrderBook.execute as Function)({
+      aliceId: 'mock-paper|BTC',
+    })
+    expect(result.error).toMatch(/No CCXT account available/)
+  })
+})
+
+describe('createCcxtProviderTools — getFundingRate', () => {
+  it('resolves aliceId via UTA and forwards Contract to broker.getFundingRate', async () => {
+    const { broker, mgr } = makeCcxtUta()
+    ;(broker as any).exchange.fetchFundingRate = vi.fn().mockResolvedValue({
+      fundingRate: 0.0001,
+      fundingDatetime: new Date().toISOString(),
+      timestamp: Date.now(),
+    })
+    const brokerSpy = vi.spyOn(broker, 'getFundingRate')
+    const tools = createCcxtProviderTools(mgr)
+
+    const result = await (tools.getFundingRate.execute as Function)({
+      aliceId: 'bybit-main|BTC/USDT:USDT',
+    })
+
+    expect(brokerSpy).toHaveBeenCalledTimes(1)
+    const [passedContract] = brokerSpy.mock.calls[0]
+    expect(passedContract.localSymbol).toBe('BTC/USDT:USDT')
+    expect(result.source).toBe('bybit-main')
+    expect(result.fundingRate).toBe(0.0001)
+  })
+})

--- a/src/domain/trading/brokers/ccxt/ccxt-tools.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-tools.ts
@@ -6,21 +6,23 @@
 
 import { tool } from 'ai'
 import { z } from 'zod'
-import { Contract } from '@traderalice/ibkr'
+import type { UnifiedTradingAccount } from '../../UnifiedTradingAccount.js'
 import type { UTAManager } from '../../uta-manager.js'
 import { CcxtBroker } from './CcxtBroker.js'
 import '../../contract-ext.js'
 
 export function createCcxtProviderTools(manager: UTAManager) {
-  /** Resolve to exactly one CcxtBroker. Returns error object if unable. */
-  const resolveCcxtOne = (source?: string): { broker: CcxtBroker; id: string } | { error: string } => {
+  /** Resolve to exactly one CCXT UTA. Returns error object if unable. */
+  const resolveCcxtOne = (
+    source?: string,
+  ): { uta: UnifiedTradingAccount; broker: CcxtBroker; id: string } | { error: string } => {
     const targets = manager.resolve(source)
       .filter((uta): uta is typeof uta & { broker: CcxtBroker } => uta.broker instanceof CcxtBroker)
     if (targets.length === 0) return { error: 'No CCXT account available.' }
     if (targets.length > 1) {
       return { error: `Multiple CCXT accounts: ${targets.map(t => t.id).join(', ')}. Specify source.` }
     }
-    return { broker: targets[0].broker, id: targets[0].id }
+    return { uta: targets[0], broker: targets[0].broker, id: targets[0].id }
   }
 
   const sourceDesc =
@@ -38,15 +40,16 @@ Returns:
 Positive rate = longs pay shorts. Negative rate = shorts pay longs.
 Use searchContracts first to get the aliceId.`,
       inputSchema: z.object({
-        aliceId: z.string().describe('Contract identifier from searchContracts (e.g. "bybit-BTC_USDT.USDT")'),
+        aliceId: z.string().describe('Contract identifier from searchContracts (format: accountId|nativeKey, e.g. "bybit-main|BTC/USDT:USDT")'),
         source: z.string().optional().describe(sourceDesc),
       }),
       execute: async ({ aliceId, source }) => {
         const resolved = resolveCcxtOne(source)
         if ('error' in resolved) return resolved
-        const { broker, id } = resolved
-        const contract = new Contract()
-        contract.aliceId = aliceId
+        const { uta, broker, id } = resolved
+        let contract
+        try { contract = uta.contractFromAliceId(aliceId) }
+        catch (err) { return { error: (err as Error).message } }
         const result = await broker.getFundingRate(contract)
         return { source: id, ...result }
       },
@@ -59,7 +62,7 @@ Returns bids and asks sorted by price. Each level is [price, amount].
 Use this to evaluate liquidity and potential slippage before placing large orders.
 Use searchContracts first to get the aliceId.`,
       inputSchema: z.object({
-        aliceId: z.string().describe('Contract identifier from searchContracts (e.g. "bybit-BTC_USDT.USDT")'),
+        aliceId: z.string().describe('Contract identifier from searchContracts (format: accountId|nativeKey, e.g. "bybit-main|BTC/USDT:USDT")'),
         limit: z
           .number()
           .int()
@@ -72,9 +75,10 @@ Use searchContracts first to get the aliceId.`,
       execute: async ({ aliceId, limit, source }) => {
         const resolved = resolveCcxtOne(source)
         if ('error' in resolved) return resolved
-        const { broker, id } = resolved
-        const contract = new Contract()
-        contract.aliceId = aliceId
+        const { uta, broker, id } = resolved
+        let contract
+        try { contract = uta.contractFromAliceId(aliceId) }
+        catch (err) { return { error: (err as Error).message } }
         const result = await broker.getOrderBook(contract, limit ?? 20)
         return { source: id, ...result }
       },

--- a/src/domain/trading/brokers/ccxt/ccxt-types.ts
+++ b/src/domain/trading/brokers/ccxt/ccxt-types.ts
@@ -37,8 +37,18 @@ export interface CcxtMarket {
   precision?: { price?: number; amount?: number }
 }
 
-export const MAX_INIT_RETRIES = 8
-export const INIT_RETRY_BASE_MS = 500
+// Init-retry budget. Defaults are tuned for production where transient
+// network blips warrant aggressive retries. E2E (and any harness that can't
+// tolerate a single broker burning ~140s per type) overrides via env:
+//   CCXT_INIT_RETRIES=2 CCXT_INIT_RETRY_BASE_MS=250
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback
+}
+export const MAX_INIT_RETRIES = envInt('CCXT_INIT_RETRIES', 8)
+export const INIT_RETRY_BASE_MS = envInt('CCXT_INIT_RETRY_BASE_MS', 500)
 
 // ==================== CCXT-specific types (not part of IBroker) ====================
 

--- a/src/tool/trading.spec.ts
+++ b/src/tool/trading.spec.ts
@@ -252,6 +252,76 @@ describe('createTradingTools — getOrders summarization', () => {
   })
 })
 
+// ==================== getQuote (aliceId resolution) ====================
+
+describe('createTradingTools — getQuote', () => {
+  it('resolves aliceId via UTA so broker sees a contract with native fields', async () => {
+    const broker = new MockBroker({ id: 'mock-paper' })
+    const spy = vi.spyOn(broker, 'getQuote')
+    const tools = createTradingTools(makeManager(broker))
+
+    const result = await (tools.getQuote.execute as Function)({ aliceId: 'mock-paper|AAPL' })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    const [passedContract] = spy.mock.calls[0]
+    // Without contractFromAliceId, this would be empty and broker resolution
+    // would fail. With the fix, MockBroker.resolveNativeKey populates symbol.
+    expect(passedContract.symbol || passedContract.localSymbol).toBeTruthy()
+    expect(passedContract.aliceId).toBe('mock-paper|AAPL')
+    expect(result.source).toBe('mock-paper')
+  })
+
+  it('returns error on malformed aliceId', async () => {
+    const broker = new MockBroker({ id: 'mock-paper' })
+    const tools = createTradingTools(makeManager(broker))
+    const result = await (tools.getQuote.execute as Function)({ aliceId: 'no-separator-here' })
+    expect(result.error).toMatch(/Invalid aliceId/)
+  })
+
+  it('routes to the UTA encoded in the aliceId without an explicit source', async () => {
+    const a1 = new MockBroker({ id: 'alpaca-paper' })
+    const a2 = new MockBroker({ id: 'bybit-main' })
+    const spy1 = vi.spyOn(a1, 'getQuote')
+    const spy2 = vi.spyOn(a2, 'getQuote')
+    const tools = createTradingTools(makeManager(a1, a2))
+
+    await (tools.getQuote.execute as Function)({ aliceId: 'bybit-main|BTC' })
+
+    expect(spy2).toHaveBeenCalledTimes(1)
+    expect(spy1).not.toHaveBeenCalled()
+  })
+})
+
+// ==================== getContractDetails (aliceId resolution) ====================
+
+describe('createTradingTools — getContractDetails', () => {
+  it('expands aliceId via UTA before calling broker.getContractDetails', async () => {
+    const broker = new MockBroker({ id: 'mock-paper' })
+    const spy = vi.spyOn(broker, 'getContractDetails')
+    const tools = createTradingTools(makeManager(broker))
+
+    await (tools.getContractDetails.execute as Function)({
+      source: 'mock-paper',
+      aliceId: 'mock-paper|AAPL',
+    })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    const [passedQuery] = spy.mock.calls[0]
+    expect(passedQuery.symbol || passedQuery.localSymbol).toBeTruthy()
+    expect(passedQuery.aliceId).toBe('mock-paper|AAPL')
+  })
+
+  it('returns error on cross-UTA aliceId mismatch', async () => {
+    const broker = new MockBroker({ id: 'mock-paper' })
+    const tools = createTradingTools(makeManager(broker))
+    const result = await (tools.getContractDetails.execute as Function)({
+      source: 'mock-paper',
+      aliceId: 'other-account|AAPL',
+    })
+    expect(result.error).toMatch(/belongs to UTA "other-account"/)
+  })
+})
+
 // ==================== placeOrder schema (AI ergonomics) ====================
 
 describe('placeOrder inputSchema', () => {

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import Decimal from 'decimal.js'
 import { Contract, UNSET_DECIMAL, coerceSecType } from '@traderalice/ibkr'
 import type { UTAManager } from '@/domain/trading/uta-manager.js'
+import { UnifiedTradingAccount } from '@/domain/trading/UnifiedTradingAccount.js'
 import { BrokerError, type OpenOrder } from '@/domain/trading/brokers/types.js'
 import type { FxService } from '@/domain/trading/fx-service.js'
 import { normalizeBrokerSearchPattern } from '@/domain/trading/contract-search-rules.js'
@@ -154,9 +155,16 @@ hitting the broker, which otherwise expects the bare base ticker.`,
       }),
       execute: async ({ source, symbol, aliceId, secType, currency }) => {
         const uta = manager.resolveOne(source)
-        const query = new Contract()
+        // When aliceId is provided, expand it via the broker's native-key
+        // resolver so the broker actually sees `localSymbol`/`symbol` —
+        // bare `query.aliceId = aliceId` is invisible to broker resolution.
+        let query: Contract
+        try {
+          query = aliceId ? uta.contractFromAliceId(aliceId) : new Contract()
+        } catch (err) {
+          return handleBrokerError(err)
+        }
         if (symbol) query.symbol = symbol
-        if (aliceId) query.aliceId = aliceId
         if (secType) query.secType = coerceSecType(secType)
         if (currency) query.currency = currency
         const details = await uta.getContractDetails(query)
@@ -289,16 +297,20 @@ If this tool returns an error with transient=true, wait a few seconds and retry 
         source: z.string().optional().describe(sourceDesc(false)),
       }),
       execute: async ({ aliceId, source }) => {
-        const targets = manager.resolve(source)
-        if (targets.length === 0) return { error: 'No accounts available.' }
-        const query = new Contract()
-        query.aliceId = aliceId
-        const results: Array<Record<string, unknown>> = []
-        for (const uta of targets) {
-          try { results.push({ source: uta.id, ...await uta.getQuote(query) }) } catch { /* skip */ }
+        // aliceId is UTA-scoped (`{utaId}|{nativeKey}`); route directly to the
+        // owning UTA. Fall back to caller-supplied `source` if given (allows
+        // overrides / sanity-check). `contractFromAliceId` cross-validates.
+        const parsed = UnifiedTradingAccount.parseAliceId(aliceId)
+        if (!parsed) {
+          return { error: `Invalid aliceId "${aliceId}". Expected format: "accountId|nativeKey".` }
         }
-        if (results.length === 0) return { error: `No account could quote aliceId "${aliceId}".` }
-        return results.length === 1 ? results[0] : results
+        try {
+          const uta = manager.resolveOne(source ?? parsed.utaId)
+          const contract = uta.contractFromAliceId(aliceId)
+          return { source: uta.id, ...await uta.getQuote(contract) }
+        } catch (err) {
+          return handleBrokerError(err)
+        }
       },
     }),
 

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -18,5 +18,15 @@ export default {
     fileParallelism: false,
     pool: 'forks',
     poolOptions: { forks: { singleFork: true } },
+    // Cap CCXT init retries during e2e — production defaults (8 retries with
+    // exponential backoff) burn ~140s per market type when a testnet is
+    // unreachable, blocking the entire serial setup. 2 retries × 250ms base
+    // bounds a failing init's backoff to under a second (the bulk of the time
+    // is still the underlying CCXT HTTP timeouts, which setup.ts caps with
+    // its own 30s per-broker race).
+    env: {
+      CCXT_INIT_RETRIES: '2',
+      CCXT_INIT_RETRY_BASE_MS: '250',
+    },
   },
 }


### PR DESCRIPTION
## Summary
Reverse-resolve aliceId through the broker's native-key lookup whenever a
read-side AI tool needs to talk to a broker. Same pattern the staging path
already uses; collapses the two routes into one helper on UTA. Plus an
e2e-side cap so a single stuck testnet can't hold the suite hostage.

## Per-session contributions
### 2026-05-14 — aliceId read-side fix + e2e init bounds
- `fix(trading)` — Hoist `parseAliceId + broker.resolveNativeKey` into
  `UnifiedTradingAccount.contractFromAliceId`; route `getQuote`,
  `getContractDetails`, `getOrderBook`, `getFundingRate` through it.
  Previously each stamped the raw input on `Contract.aliceId` and the
  broker (which resolves via `localSymbol`/`symbol`) returned the
  `No account could quote aliceId ...` / `Cannot resolve contract to
  CCXT symbol` error visible from AI. Deletes stale aliceId helpers in
  `ccxt-contracts.ts` and `alpaca-contracts.ts` from the pre-refactor
  format.
- `chore(e2e)` — Wrap `broker.init()` in a 30s per-broker race in
  `setup.ts`; expose `CCXT_INIT_RETRIES` / `CCXT_INIT_RETRY_BASE_MS` as
  env overrides and set them to `2 / 250ms` in `vitest.e2e.config.ts`.
  Production retry budget unchanged.
- Tests: 3-branch unit coverage for `contractFromAliceId`; unit
  coverage for the 4 fixed tools; e2e coverage on Bybit demo + Alpaca
  paper that walks `searchContracts → getQuote / getOrderBook /
  getFundingRate / getContractDetails` with a real round-tripped aliceId.
- Key commits: `3d35404`, `8d02777`

## Full commit log
```
8d02777 chore(e2e): cap per-broker init + make CCXT retries env-configurable
3d35404 fix(trading): route aliceId through resolveNativeKey for read-side tools
```

## Test plan
- [x] tsc --noEmit clean
- [x] pnpm test passes (89 files, 1689 tests)
- [x] pnpm test:e2e against Bybit demo + Alpaca paper: 8 of the
      relevant AI-tool tests pass with real ticker / order-book /
      funding-rate / contract-details data returned through the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)