### PR TITLE
fix(trading): seal UNSET_DECIMAL sentinel at wire boundary

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,6 +54,35 @@ the item when done — git log is the history.
 
 ## Architecture
 
+- [ ] `OrderRequest` discriminated union — long-term followup to the
+      2026-05-14 OrderHelper boundary fix. Idea: introduce a domain-level
+      intent type (`{ orderType: 'MKT'; ... } | { orderType: 'LMT';
+      lmtPrice: Decimal; ... } | ...`) that the web/tool entry points
+      parse into, so "MKT can't carry lmtPrice" / "LMT requires lmtPrice"
+      becomes a compile-time invariant instead of a runtime sentinel
+      check. `Order` (IBKR's 200-field flat struct) stays as the broker
+      interface contract — UTA would translate OrderRequest → Order at
+      the broker call site. Helper structure already accommodates: just
+      add `fromRequest(req): Order` alongside the existing `read` / `toWire`.
+      Decision deferred: discussed at length on 2026-05-13/14, deliberately
+      postponed because the helper-only fix closes the live incident and
+      narrowing field surface risks losing the IBKR-as-superset scaffold
+      that forces brokers to make explicit "support / loud reject"
+      decisions on each IBKR field. Revisit when adding a broker that
+      stresses orderType variants (e.g. TRAIL LIMIT / MOC / LOC).
+
+- [ ] Phase-1 broker internal cleanup with `OrderHelper.read()`. The
+      sentinel boundary at TradingGit (2026-05-14) plugged the wire leak,
+      but `CcxtBroker`, `AlpacaBroker`, `MockBroker`, `LongbridgeBroker`,
+      `IbkrBroker` all still carry the `if (!order.lmtPrice.equals(
+      UNSET_DECIMAL))` template at every consumption site. Migrate each
+      broker's `placeOrder` / `modifyOrder` / `convertCcxtOrder` /
+      equivalents to consume `OrderHelper.read(order)` and read
+      `view.lmtPrice` / `view.auxPrice` etc. — same semantics, no sentinel
+      knowledge inside broker code. Independent PRs per broker; not
+      blocking. Broker interface signature `placeOrder(order: Order)`
+      stays as-is — Order remains the contract.
+
 - [ ] Broker raw-upstream recorder + no-connect replay harness (Layer 2
       bug debug surface). When a community user reports a broker-specific
       normalize bug — IBKR's `request-bridge.ts:470 .abs()`, the proto
@@ -160,6 +189,30 @@ the item when done — git log is the history.
       something goes stale.
 
 ## Bugs
+
+- [ ] `Execution.price` / `OperationResult.execution.price` sentinel leak.
+      Same bug shape as the OrderHelper boundary fix (2026-05-14) but for
+      IBKR's number-typed `UNSET_DOUBLE = Number.MAX_VALUE = 1.7e308`.
+      `TradingGit.formatOperationChange:321,330,347` reads
+      `result.execution?.price` and renders ` @${price}`; if a broker hands
+      back an unfilled Execution with the default sentinel (or any other
+      surface reaches Execution before it's populated), the commit log
+      shows `@1.7e308`. OrderHelper only covers Decimal-typed Order
+      fields. Either extend the helper with an Execution variant, or strip
+      Execution sentinels at the same wire boundary (`projectOperation`
+      handles `result.execution.price` too). Not reproduced in the wild
+      yet — flagged structurally during the 2026-05-13 incident review.
+
+- [ ] CCXT `convertCcxtOrder` may not extract `o.average` into
+      `avgFillPrice`. Surfaced 2026-05-13 during the precision-explosion
+      investigation. After a Bybit MKT fill, the staged Operation's
+      filledPrice was empty even though CCXT's returned order had a
+      populated `average`. `src/domain/trading/brokers/ccxt/CcxtBroker.ts`
+      `convertCcxtOrder()` ~line 823-854 returns `{ contract, order,
+      orderState, ...tpsl }` with no `avgFillPrice`; the field needs to
+      be sourced from `o.average` (when present). Confirm against a real
+      Bybit fill before patching — also audit whether `o.filled` /
+      `o.amount` should populate `filledQty` symmetrically.
 
 - [ ] IBKR `getNativeKey` may use the wrong field for nativeKey. Surfaced
       2026-05-07 during the Phase-3 revert (`afddd41`) when articulating

--- a/src/domain/trading/OrderHelper.ts
+++ b/src/domain/trading/OrderHelper.ts
@@ -1,0 +1,104 @@
+/**
+ * OrderHelper — single authority for the IBKR Order sentinel boundary.
+ *
+ * The `Order` class in @traderalice/ibkr mirrors IBKR's binary wire
+ * protocol: every optional Decimal field defaults to UNSET_DECIMAL = 2^127-1
+ * rather than `undefined`, because the protocol can't express "field absent."
+ * That convention is legitimate inside broker implementations where both
+ * sides recognise the sentinel.
+ *
+ * It is catastrophic the moment it crosses a JSON boundary into UI / MCP /
+ * Telegram — without the sender/receiver agreement, 1.7e38 looks like a real
+ * price. The 2026-05-13 incident ("BUY 0.0005 BTC/USDT MKT @ 1.7e38" in
+ * PushApprovalPanel) is exactly that.
+ *
+ * This module is where "which Order fields use a sentinel" lives, and the
+ * only authority for Order ↔ wire-clean shape conversion. It sits at UTA
+ * level (not in `git/` or `brokers/`) so anyone editing trading code sees
+ * it. Enforcement: `TradingGit.stagingArea` is private — every public
+ * observer (status / log / show / exportState) routes through `toWire`
+ * here, so external consumers cannot accidentally receive a sentinel-
+ * tainted shape.
+ *
+ * Two APIs:
+ *   - read(order)   → typed OrderView, sentinel → undefined.
+ *                     For broker-internal consumption (replaces the
+ *                     `if (!x.equals(UNSET_DECIMAL))` template).
+ *   - toWire(order) → plain object, sentinel fields removed.
+ *                     For anything crossing a JSON boundary.
+ */
+
+import Decimal from 'decimal.js'
+import type { Order } from '@traderalice/ibkr'
+import { UNSET_DECIMAL } from '@traderalice/ibkr'
+
+// Add new Decimal-valued optional Order fields here too.
+const SENTINEL_DECIMAL_FIELDS = [
+  'totalQuantity',
+  'cashQty',
+  'lmtPrice',
+  'auxPrice',
+  'trailStopPrice',
+  'trailingPercent',
+  'filledQuantity',
+] as const
+
+/**
+ * Narrow nullable view for broker-internal consumption. Only the fields
+ * OpenAlice actually uses across brokers — the full 200-field Order remains
+ * the broker interface contract (IBKR-as-superset principle).
+ */
+export interface OrderView {
+  action: string
+  orderType: string
+  tif?: string
+  totalQuantity?: Decimal
+  cashQty?: Decimal
+  lmtPrice?: Decimal
+  auxPrice?: Decimal
+  trailStopPrice?: Decimal
+  trailingPercent?: Decimal
+  filledQuantity?: Decimal
+  outsideRth?: boolean
+  parentId?: number
+  ocaGroup?: string
+  goodTillDate?: string
+}
+
+function unsetToUndef(d: Decimal): Decimal | undefined {
+  return d.equals(UNSET_DECIMAL) ? undefined : d
+}
+
+export const OrderHelper = {
+  /** Typed nullable view; sentinel → undefined. */
+  read(order: Order): OrderView {
+    return {
+      action: order.action,
+      orderType: order.orderType,
+      tif: order.tif || undefined,
+      totalQuantity: unsetToUndef(order.totalQuantity),
+      cashQty: unsetToUndef(order.cashQty),
+      lmtPrice: unsetToUndef(order.lmtPrice),
+      auxPrice: unsetToUndef(order.auxPrice),
+      trailStopPrice: unsetToUndef(order.trailStopPrice),
+      trailingPercent: unsetToUndef(order.trailingPercent),
+      filledQuantity: unsetToUndef(order.filledQuantity),
+      outsideRth: order.outsideRth || undefined,
+      parentId: order.parentId || undefined,
+      ocaGroup: order.ocaGroup || undefined,
+      goodTillDate: order.goodTillDate || undefined,
+    }
+  },
+
+  // Accepts Order or Partial<Order> (modifyOrder.changes is the latter).
+  toWire(order: Order | Partial<Order>): Record<string, unknown> {
+    const out: Record<string, unknown> = { ...order }
+    for (const field of SENTINEL_DECIMAL_FIELDS) {
+      const v = out[field]
+      if (v instanceof Decimal && v.equals(UNSET_DECIMAL)) {
+        delete out[field]
+      }
+    }
+    return out
+  },
+}

--- a/src/domain/trading/__test__/e2e/uta-ccxt-bybit.e2e.spec.ts
+++ b/src/domain/trading/__test__/e2e/uta-ccxt-bybit.e2e.spec.ts
@@ -178,4 +178,40 @@ describe('UTA — Bybit demo (ETH perp)', () => {
     const fullCommit = uta!.show(result.hash)
     expect(fullCommit!.results[0].error).toBe('Rejected by user')
   }, 15_000)
+
+  // Regression: 2026-05-13 — UNSET_DECIMAL (2^127-1) leaked from Order's
+  // class defaults through TradingGit's wire path into PushApprovalPanel
+  // as "BUY 0.0005 BTC/USDT MKT @ 1.7e38". The unit-level fix lives in
+  // OrderHelper.toWire; this e2e ensures the projection survives a real
+  // broker round-trip (stage → push → sync → show).
+  it('sentinel never crosses status/show/exportState boundary on MKT order', async () => {
+    const SENTINEL_LITERAL = '170141183460469231731687303715884105727'
+
+    uta!.stagePlaceOrder({ aliceId: ethAliceId, action: 'BUY', orderType: 'MKT', totalQuantity: '0.01' })
+
+    // Pre-commit staging: sentinel must already be gone.
+    const status = uta!.status()
+    expect(JSON.stringify(status)).not.toContain(SENTINEL_LITERAL)
+
+    uta!.commit('e2e: sentinel boundary')
+    const pushResult = await uta!.push()
+    expect(pushResult.submitted).toHaveLength(1)
+
+    // Post-push: show + exportState + log must all be sentinel-free.
+    const head = uta!.status().head!
+    const shown = uta!.show(head)
+    const exported = uta!.exportGitState()
+    const logged = uta!.log({ limit: 5 })
+    for (const blob of [shown, exported, logged]) {
+      expect(JSON.stringify(blob)).not.toContain(SENTINEL_LITERAL)
+    }
+
+    // Clean up: close the position so the test is idempotent.
+    if (pushResult.submitted[0].status === 'submitted') {
+      await uta!.sync({ delayMs: 3000 })
+    }
+    uta!.stageClosePosition({ aliceId: ethAliceId, qty: '0.01' })
+    uta!.commit('e2e: close sentinel-boundary position')
+    await uta!.push()
+  }, 30_000)
 })

--- a/src/domain/trading/git/TradingGit.spec.ts
+++ b/src/domain/trading/git/TradingGit.spec.ts
@@ -427,6 +427,94 @@ describe('TradingGit', () => {
     })
   })
 
+  // ==================== sentinel boundary ====================
+
+  describe('sentinel boundary (OrderHelper.toWire)', () => {
+    // Regression: 2026-05-13 — MKT order on Bybit rendered as
+    // "BUY 0.0005 BTC/USDT MKT @ 1.70141183460469231731687303715884105727e+38"
+    // in PushApprovalPanel. UNSET_DECIMAL (2^127-1) leaked from Order's
+    // class defaults through c.json into the UI. Every public observer of
+    // staged/committed Operations must strip Order-class sentinels.
+    const UNSET_DECIMAL_STR = '1.70141183460469231731687303715884105727e+38'
+
+    it('status().staged strips sentinel fields from a MKT placeOrder', () => {
+      // MKT order — totalQuantity is the only price-shaped field user set.
+      // lmtPrice / auxPrice / trailStopPrice / trailingPercent / cashQty
+      // all hold the UNSET_DECIMAL class default and must NOT appear.
+      git.add(buyOp())
+      const s = git.status()
+      const op = s.staged[0] as Extract<Operation, { action: 'placeOrder' }>
+      expect(op.order).not.toHaveProperty('lmtPrice')
+      expect(op.order).not.toHaveProperty('auxPrice')
+      expect(op.order).not.toHaveProperty('trailStopPrice')
+      expect(op.order).not.toHaveProperty('trailingPercent')
+      expect(op.order).not.toHaveProperty('cashQty')
+      expect(op.order).not.toHaveProperty('filledQuantity')
+      // Real value passes through.
+      expect(op.order.totalQuantity).toBeInstanceOf(Decimal)
+      expect(op.order.totalQuantity.toFixed()).toBe('10')
+    })
+
+    it('show()/exportState()/status() JSON output contains no sentinel literal', async () => {
+      git.add(buyOp())
+      git.commit('mkt buy')
+      await git.push()
+
+      const head = git.status().head!
+      for (const blob of [git.status(), git.show(head), git.exportState()]) {
+        const serialised = JSON.stringify(blob)
+        expect(serialised).not.toContain(UNSET_DECIMAL_STR)
+        expect(serialised).not.toContain('170141183460469231731687303715884105727')
+      }
+    })
+
+    it('modifyOrder.changes also strips sentinels', () => {
+      const partialChanges = new Order()
+      partialChanges.lmtPrice = new Decimal('150')
+      // All other fields remain at UNSET_DECIMAL class defaults.
+      git.add({ action: 'modifyOrder', orderId: 'o-1', changes: partialChanges })
+      const s = git.status()
+      const op = s.staged[0] as Extract<Operation, { action: 'modifyOrder' }>
+      expect(op.changes.lmtPrice).toBeInstanceOf(Decimal)
+      expect((op.changes.lmtPrice as Decimal).toFixed()).toBe('150')
+      expect(op.changes).not.toHaveProperty('auxPrice')
+      expect(op.changes).not.toHaveProperty('trailStopPrice')
+      expect(op.changes).not.toHaveProperty('totalQuantity')
+    })
+
+    it('non-sentinel Decimal fields survive (round-trip safety)', async () => {
+      const contract = makeContract({ symbol: 'ETH' })
+      const order = new Order()
+      order.action = 'BUY'
+      order.orderType = 'LMT'
+      order.totalQuantity = new Decimal('0.5')
+      order.lmtPrice = new Decimal('3500.25')
+      git.add({ action: 'placeOrder', contract, order })
+      git.commit('lmt buy')
+      await git.push()
+
+      const exported = git.exportState()
+      const op = exported.commits[0].operations[0] as Extract<Operation, { action: 'placeOrder' }>
+      expect(op.order.lmtPrice).toBeInstanceOf(Decimal)
+      expect((op.order.lmtPrice as Decimal).toFixed()).toBe('3500.25')
+      expect(op.order.totalQuantity.toFixed()).toBe('0.5')
+      // But unset auxPrice still gone.
+      expect(op.order).not.toHaveProperty('auxPrice')
+    })
+
+    it('staging mutation after status() does not affect prior projection', () => {
+      // Defensive: projectOperation must spread, not return raw ref.
+      git.add(buyOp())
+      const s1 = git.status()
+      const op1 = s1.staged[0] as Extract<Operation, { action: 'placeOrder' }>
+      // Mutate the projection — should not bleed back into staging.
+      ;(op1.order as unknown as Record<string, unknown>).lmtPrice = 'tampered'
+      const s2 = git.status()
+      const op2 = s2.staged[0] as Extract<Operation, { action: 'placeOrder' }>
+      expect(op2.order).not.toHaveProperty('lmtPrice')
+    })
+  })
+
   // ==================== exportState / restore ====================
 
   describe('exportState / restore', () => {

--- a/src/domain/trading/git/TradingGit.ts
+++ b/src/domain/trading/git/TradingGit.ts
@@ -7,6 +7,7 @@
 import { createHash } from 'crypto'
 import Decimal from 'decimal.js'
 import { Order, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { OrderHelper } from '../OrderHelper.js'
 import type { ITradingGit, TradingGitConfig } from './interfaces.js'
 import type {
   CommitHash,
@@ -358,12 +359,13 @@ export class TradingGit implements ITradingGit {
   }
 
   show(hash: CommitHash): GitCommit | null {
-    return this.commits.find((c) => c.hash === hash) ?? null
+    const commit = this.commits.find((c) => c.hash === hash)
+    return commit ? this.projectCommit(commit) : null
   }
 
   status(): GitStatus {
     return {
-      staged: [...this.stagingArea],
+      staged: this.stagingArea.map((op) => this.projectOperation(op)),
       pendingMessage: this.pendingMessage,
       pendingHash: this.pendingHash,
       head: this.head,
@@ -371,10 +373,30 @@ export class TradingGit implements ITradingGit {
     }
   }
 
+  // Strip IBKR sentinel defaults before any Operation leaves this class —
+  // raw Order instances stay private to staging / push internals, never
+  // observed by external callers (UI, MCP, c.json, on-disk commit.json).
+  private projectOperation(op: Operation): Operation {
+    if (op.action === 'placeOrder') {
+      return { ...op, order: OrderHelper.toWire(op.order) as unknown as Order }
+    }
+    if (op.action === 'modifyOrder') {
+      return { ...op, changes: OrderHelper.toWire(op.changes) as unknown as Partial<Order> }
+    }
+    return op
+  }
+
+  private projectCommit(commit: GitCommit): GitCommit {
+    return { ...commit, operations: commit.operations.map((op) => this.projectOperation(op)) }
+  }
+
   // ==================== Serialization ====================
 
   exportState(): GitExportState {
-    return { commits: [...this.commits], head: this.head }
+    return {
+      commits: this.commits.map((c) => this.projectCommit(c)),
+      head: this.head,
+    }
   }
 
   static restore(state: GitExportState, config: TradingGitConfig): TradingGit {

--- a/ui/src/components/PushApprovalPanel.tsx
+++ b/ui/src/components/PushApprovalPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../api'
+import { isUnsetDecimal } from '../lib/format'
 import type { TradingAccount, WalletStatus, WalletPushResult, WalletCommitLog } from '../api/types'
 
 // ==================== Types ====================
@@ -30,15 +31,9 @@ function opSymbol(op: WalletStatus['staged'][number]): string {
   return sep !== -1 ? raw.slice(sep + 1) : raw
 }
 
-/**
- * Format quantity/price for display.
- * Strings pass through (backend already Decimal-serialized).
- * Numbers go through toFixed(8) + trim to avoid IEEE 754 artifacts and
- * the default toLocaleString behavior that truncates decimals to 3 (which
- * turns crypto-scale quantities like 0.00012345 into "0").
- */
 function fmtNum(n: number | string | undefined | null): string {
   if (n == null || n === '') return ''
+  if (isUnsetDecimal(n)) return ''
   if (typeof n === 'string') return n
   if (!Number.isFinite(n)) return String(n)
   const rounded = n.toFixed(8).replace(/\.?0+$/, '')

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -22,6 +22,15 @@ export function currencySymbol(currency?: string): string {
   return CURRENCY_SYMBOLS[currency.toUpperCase()] ?? `${currency} `
 }
 
+// Defense layer: if the backend's OrderHelper.toWire ever forgets to strip
+// IBKR's UNSET_DECIMAL = 2^127-1, callers can detect the sentinel string
+// shape and treat it as "no value" instead of rendering "$1.7e38".
+export const UNSET_DECIMAL_STR = '1.70141183460469231731687303715884105727e+38'
+
+export function isUnsetDecimal(v: number | string | undefined | null): boolean {
+  return v === UNSET_DECIMAL_STR || v === Number(UNSET_DECIMAL_STR)
+}
+
 function toFiniteNumber(input: number | string | undefined | null): number | null {
   if (input == null) return null
   const n = typeof input === 'number' ? input : Number(input)

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -15,7 +15,7 @@ import { OrderEntryDialog, type OrderEntryMode } from '../components/uta/OrderEn
 import { SnapshotDetail } from '../components/SnapshotDetail'
 import { EquityCurve } from '../components/EquityCurve'
 import { Metric, signFromDelta } from '../components/Metric'
-import { fmt, fmtPnl, fmtNum, fmtPctSigned } from '../lib/format'
+import { fmt, fmtPnl, fmtNum, fmtPctSigned, isUnsetDecimal } from '../lib/format'
 import { secTypeToClass, assetClassLabel, ASSET_CLASS_ORDER, type AssetClass } from '../lib/asset-class'
 
 // ==================== Page ====================
@@ -505,7 +505,7 @@ function OrdersSection({ orders }: { orders: unknown[] }) {
                 <td className={`px-3 py-2 font-medium ${o.order?.action === 'BUY' ? 'text-green' : o.order?.action === 'SELL' ? 'text-red' : 'text-text'}`}>{o.order?.action ?? '—'}</td>
                 <td className="px-3 py-2 text-text-muted">{o.order?.orderType ?? '—'}</td>
                 <td className="px-3 py-2 text-right text-text tabular-nums">{String(o.order?.totalQuantity ?? '')}</td>
-                <td className="px-3 py-2 text-right text-text-muted tabular-nums">{o.order?.lmtPrice != null ? String(o.order.lmtPrice) : '—'}</td>
+                <td className="px-3 py-2 text-right text-text-muted tabular-nums">{o.order?.lmtPrice != null && !isUnsetDecimal(o.order.lmtPrice) ? String(o.order.lmtPrice) : '—'}</td>
                 <td className="px-3 py-2">
                   <span className="text-[11px] text-text-muted">{o.orderState?.status ?? 'Unknown'}</span>
                 </td>


### PR DESCRIPTION
## Summary

Plug the IBKR `UNSET_DECIMAL = 2^127-1` sentinel from leaking through
Trading-as-Git's staging area into UI / MCP / commit.json. Surfaced when
a Bybit MKT order rendered as
\`BUY 0.0005 BTC/USDT MKT @ 1.70141183460469231731687303715884105727e+38\`
in PushApprovalPanel.

Introduces \`OrderHelper\` at UTA level as the single authority for the
Order ↔ wire-clean shape boundary. \`TradingGit\`'s \`stagingArea\` stays
private; \`status()/show()/exportState()\` route every Operation through
\`OrderHelper.toWire\` so external consumers cannot observe sentinel-tainted
shapes. \`Order\`'s 200-field IBKR-mirroring struct and broker interface
signature are unchanged — the IBKR-as-superset scaffold remains intact.

## Per-session contributions

### 2026-05-14 — OrderHelper sentinel boundary

- New \`src/domain/trading/OrderHelper.ts\` (sits at UTA level, not buried
  in \`git/\` or \`brokers/\`) with two APIs: \`read()\` (typed nullable view
  for broker-internal consumption) and \`toWire()\` (plain object with
  sentinel fields removed for JSON crossings). Shared
  \`SENTINEL_DECIMAL_FIELDS\` list — add new Decimal Order fields in one
  place.
- \`TradingGit\` adds \`projectOperation\` / \`projectCommit\` private helpers;
  \`status() / show() / exportState()\` all run through them. Enforcement is
  structural: \`stagingArea\` is private and there is no raw observer.
- UI defense layer: \`isUnsetDecimal()\` in \`ui/src/lib/format.ts\`; wired
  into \`PushApprovalPanel.fmtNum\` and \`UTADetailPage\`'s Open Orders
  table.
- 5 new \`TradingGit.spec.ts\` regression tests covering staging /
  show / exportState / modifyOrder changes / mutation-isolation.
- TODO.md records three followups (deferred deliberately):
  \`OrderRequest\` discriminated union, same-shape \`Execution.price\`
  sentinel (number-typed, separate wire leak), Phase-1 broker internals
  migration to \`OrderHelper.read()\`.
- Key commit: \`f205f3b\`

## Full commit log

\`\`\`
f205f3b fix(trading): seal UNSET_DECIMAL sentinel at TradingGit wire boundary
\`\`\`

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`pnpm test\` — 1694/1694 pass (89 files)
- [x] New sentinel-boundary describe block — 5 tests, all pass
- [ ] Manual: place a real Bybit MKT order via Web UI, confirm
      PushApprovalPanel renders \`BUY <qty> BTC/USDT MKT\` with no
      \`@ 1.7e38\` trailing
- [ ] Manual: UTA detail page's Open Orders table shows \`—\` for the
      Limit column on MKT orders (not \`1.7e38\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)