### PR TITLE
feat(inbox): workspace-anchored Inbox v0 (Linear-style) + inbox_push MCP tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ coverage/
 # Claude Code
 .claude/
 .playwright-mcp/
+# Stray screenshots at repo root (playwright captures, manual screen grabs).
+# UI assets live under ui/public/ or ui/src/assets/ — never at the root.
+/*.png
+/*.jpg
+/*.jpeg
 packages/ibkr/ref/source/JavaClient/
 packages/ibkr/ref/source/cppclient/
 packages/ibkr/ref/samples/Java/

--- a/src/core/inbox-store.spec.ts
+++ b/src/core/inbox-store.spec.ts
@@ -16,57 +16,91 @@ describe('InboxStore (in-memory)', () => {
     store = createMemoryInboxStore()
   })
 
-  it('append assigns id + ts and returns the entry', async () => {
+  it('append with comments only succeeds', async () => {
     const before = Date.now()
     const entry = await store.append({
       workspaceId: 'ws-1',
       workspaceLabel: 'chat-with-kimi',
-      text: 'hello',
-      kind: 'status',
+      comments: 'hey, can you check the SPY chart?',
+      kind: 'question',
     })
     expect(entry.id).toMatch(/^[0-9a-f-]{36}$/)
     expect(entry.workspaceId).toBe('ws-1')
-    expect(entry.workspaceLabel).toBe('chat-with-kimi')
-    expect(entry.text).toBe('hello')
-    expect(entry.kind).toBe('status')
+    expect(entry.comments).toBe('hey, can you check the SPY chart?')
+    expect(entry.docs).toBeUndefined()
     expect(entry.ts).toBeGreaterThanOrEqual(before)
+  })
+
+  it('append with docs only succeeds', async () => {
+    const entry = await store.append({
+      workspaceId: 'ws-1',
+      docs: [{ path: 'research/macro-2026-05-14.md' }],
+      kind: 'done',
+    })
+    expect(entry.docs).toEqual([{ path: 'research/macro-2026-05-14.md' }])
+    expect(entry.comments).toBeUndefined()
+  })
+
+  it('append with both docs and comments succeeds', async () => {
+    const entry = await store.append({
+      workspaceId: 'ws-1',
+      docs: [{ path: 'a.md' }, { path: 'b.md' }],
+      comments: 'two reports, b is more interesting',
+    })
+    expect(entry.docs).toHaveLength(2)
+    expect(entry.comments).toContain('two reports')
   })
 
   it('append rejects missing workspaceId', async () => {
     await expect(
       // @ts-expect-error — exercising runtime guard
-      store.append({ text: 'orphan' }),
+      store.append({ comments: 'orphan' }),
     ).rejects.toThrow(/workspaceId is required/)
   })
 
+  it('append rejects when both docs and comments are empty', async () => {
+    await expect(
+      store.append({ workspaceId: 'ws-1' }),
+    ).rejects.toThrow(/at least one of docs or comments/)
+    await expect(
+      store.append({ workspaceId: 'ws-1', docs: [], comments: '   ' }),
+    ).rejects.toThrow(/at least one of docs or comments/)
+  })
+
+  it('append rejects malformed doc entries', async () => {
+    await expect(
+      store.append({ workspaceId: 'ws-1', docs: [{ path: '' }] }),
+    ).rejects.toThrow(/non-empty `path`/)
+  })
+
   it('read returns entries newest-first', async () => {
-    await store.append({ workspaceId: 'ws-1', text: 'first' })
-    await store.append({ workspaceId: 'ws-1', text: 'second' })
-    await store.append({ workspaceId: 'ws-1', text: 'third' })
+    await store.append({ workspaceId: 'ws-1', comments: 'first' })
+    await store.append({ workspaceId: 'ws-1', comments: 'second' })
+    await store.append({ workspaceId: 'ws-1', comments: 'third' })
     const { entries, hasMore } = await store.read()
-    expect(entries.map((e) => e.text)).toEqual(['third', 'second', 'first'])
+    expect(entries.map((e) => e.comments)).toEqual(['third', 'second', 'first'])
     expect(hasMore).toBe(false)
   })
 
   it('read respects limit and reports hasMore', async () => {
-    for (let i = 0; i < 5; i++) await store.append({ workspaceId: 'ws-1', text: `n${i}` })
+    for (let i = 0; i < 5; i++) await store.append({ workspaceId: 'ws-1', comments: `n${i}` })
     const { entries, hasMore } = await store.read({ limit: 3 })
-    expect(entries.map((e) => e.text)).toEqual(['n4', 'n3', 'n2'])
+    expect(entries.map((e) => e.comments)).toEqual(['n4', 'n3', 'n2'])
     expect(hasMore).toBe(true)
   })
 
   it('read filters by workspaceId', async () => {
-    await store.append({ workspaceId: 'ws-a', text: 'a1' })
-    await store.append({ workspaceId: 'ws-b', text: 'b1' })
-    await store.append({ workspaceId: 'ws-a', text: 'a2' })
+    await store.append({ workspaceId: 'ws-a', comments: 'a1' })
+    await store.append({ workspaceId: 'ws-b', comments: 'b1' })
+    await store.append({ workspaceId: 'ws-a', comments: 'a2' })
     const { entries } = await store.read({ workspaceId: 'ws-a' })
-    expect(entries.map((e) => e.text)).toEqual(['a2', 'a1'])
+    expect(entries.map((e) => e.comments)).toEqual(['a2', 'a1'])
   })
 
   it('read uses `before` cursor to paginate older', async () => {
-    const e1 = await store.append({ workspaceId: 'ws-1', text: 'first' })
-    const e2 = await store.append({ workspaceId: 'ws-1', text: 'second' })
-    const e3 = await store.append({ workspaceId: 'ws-1', text: 'third' })
+    const e1 = await store.append({ workspaceId: 'ws-1', comments: 'first' })
+    const e2 = await store.append({ workspaceId: 'ws-1', comments: 'second' })
+    const e3 = await store.append({ workspaceId: 'ws-1', comments: 'third' })
     const { entries } = await store.read({ before: e3.id, limit: 100 })
     expect(entries.map((e) => e.id)).toEqual([e2.id, e1.id])
   })
@@ -74,22 +108,12 @@ describe('InboxStore (in-memory)', () => {
   it('onAppended fires on append, dispose stops further notifications', async () => {
     const seen: InboxEntry[] = []
     const dispose = store.onAppended((e) => seen.push(e))
-    await store.append({ workspaceId: 'ws-1', text: 'a' })
-    await store.append({ workspaceId: 'ws-1', text: 'b' })
+    await store.append({ workspaceId: 'ws-1', comments: 'a' })
+    await store.append({ workspaceId: 'ws-1', comments: 'b' })
     expect(seen).toHaveLength(2)
     dispose()
-    await store.append({ workspaceId: 'ws-1', text: 'c' })
+    await store.append({ workspaceId: 'ws-1', comments: 'c' })
     expect(seen).toHaveLength(2)
-  })
-
-  it('multiple subscribers all receive events', async () => {
-    const a: string[] = []
-    const b: string[] = []
-    store.onAppended((e) => a.push(e.text))
-    store.onAppended((e) => b.push(e.text))
-    await store.append({ workspaceId: 'ws-1', text: 'x' })
-    expect(a).toEqual(['x'])
-    expect(b).toEqual(['x'])
   })
 })
 
@@ -105,12 +129,17 @@ describe('InboxStore (JSONL persistence)', () => {
   })
 
   it('persists across new store instances on the same file', async () => {
-    await store.append({ workspaceId: 'ws-1', text: 'persisted', kind: 'done' })
+    await store.append({
+      workspaceId: 'ws-1',
+      docs: [{ path: 'report.md' }],
+      comments: 'final draft',
+      kind: 'done',
+    })
     const fresh = createInboxStore({ filePath: path })
     const { entries } = await fresh.read()
     expect(entries).toHaveLength(1)
-    expect(entries[0].text).toBe('persisted')
-    expect(entries[0].workspaceId).toBe('ws-1')
+    expect(entries[0].docs).toEqual([{ path: 'report.md' }])
+    expect(entries[0].comments).toBe('final draft')
     expect(entries[0].kind).toBe('done')
     await rm(dir, { recursive: true, force: true })
   })

--- a/src/core/inbox-store.spec.ts
+++ b/src/core/inbox-store.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createInboxStore,
+  createMemoryInboxStore,
+  type IInboxStore,
+  type InboxEntry,
+} from './inbox-store.js'
+
+describe('InboxStore (in-memory)', () => {
+  let store: IInboxStore
+
+  beforeEach(() => {
+    store = createMemoryInboxStore()
+  })
+
+  it('append assigns id + ts and returns the entry', async () => {
+    const before = Date.now()
+    const entry = await store.append({
+      workspaceId: 'ws-1',
+      workspaceLabel: 'chat-with-kimi',
+      text: 'hello',
+      kind: 'status',
+    })
+    expect(entry.id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(entry.workspaceId).toBe('ws-1')
+    expect(entry.workspaceLabel).toBe('chat-with-kimi')
+    expect(entry.text).toBe('hello')
+    expect(entry.kind).toBe('status')
+    expect(entry.ts).toBeGreaterThanOrEqual(before)
+  })
+
+  it('append rejects missing workspaceId', async () => {
+    await expect(
+      // @ts-expect-error — exercising runtime guard
+      store.append({ text: 'orphan' }),
+    ).rejects.toThrow(/workspaceId is required/)
+  })
+
+  it('read returns entries newest-first', async () => {
+    await store.append({ workspaceId: 'ws-1', text: 'first' })
+    await store.append({ workspaceId: 'ws-1', text: 'second' })
+    await store.append({ workspaceId: 'ws-1', text: 'third' })
+    const { entries, hasMore } = await store.read()
+    expect(entries.map((e) => e.text)).toEqual(['third', 'second', 'first'])
+    expect(hasMore).toBe(false)
+  })
+
+  it('read respects limit and reports hasMore', async () => {
+    for (let i = 0; i < 5; i++) await store.append({ workspaceId: 'ws-1', text: `n${i}` })
+    const { entries, hasMore } = await store.read({ limit: 3 })
+    expect(entries.map((e) => e.text)).toEqual(['n4', 'n3', 'n2'])
+    expect(hasMore).toBe(true)
+  })
+
+  it('read filters by workspaceId', async () => {
+    await store.append({ workspaceId: 'ws-a', text: 'a1' })
+    await store.append({ workspaceId: 'ws-b', text: 'b1' })
+    await store.append({ workspaceId: 'ws-a', text: 'a2' })
+    const { entries } = await store.read({ workspaceId: 'ws-a' })
+    expect(entries.map((e) => e.text)).toEqual(['a2', 'a1'])
+  })
+
+  it('read uses `before` cursor to paginate older', async () => {
+    const e1 = await store.append({ workspaceId: 'ws-1', text: 'first' })
+    const e2 = await store.append({ workspaceId: 'ws-1', text: 'second' })
+    const e3 = await store.append({ workspaceId: 'ws-1', text: 'third' })
+    const { entries } = await store.read({ before: e3.id, limit: 100 })
+    expect(entries.map((e) => e.id)).toEqual([e2.id, e1.id])
+  })
+
+  it('onAppended fires on append, dispose stops further notifications', async () => {
+    const seen: InboxEntry[] = []
+    const dispose = store.onAppended((e) => seen.push(e))
+    await store.append({ workspaceId: 'ws-1', text: 'a' })
+    await store.append({ workspaceId: 'ws-1', text: 'b' })
+    expect(seen).toHaveLength(2)
+    dispose()
+    await store.append({ workspaceId: 'ws-1', text: 'c' })
+    expect(seen).toHaveLength(2)
+  })
+
+  it('multiple subscribers all receive events', async () => {
+    const a: string[] = []
+    const b: string[] = []
+    store.onAppended((e) => a.push(e.text))
+    store.onAppended((e) => b.push(e.text))
+    await store.append({ workspaceId: 'ws-1', text: 'x' })
+    expect(a).toEqual(['x'])
+    expect(b).toEqual(['x'])
+  })
+})
+
+describe('InboxStore (JSONL persistence)', () => {
+  let dir: string
+  let path: string
+  let store: IInboxStore
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'oa-inbox-'))
+    path = join(dir, 'entries.jsonl')
+    store = createInboxStore({ filePath: path })
+  })
+
+  it('persists across new store instances on the same file', async () => {
+    await store.append({ workspaceId: 'ws-1', text: 'persisted', kind: 'done' })
+    const fresh = createInboxStore({ filePath: path })
+    const { entries } = await fresh.read()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].text).toBe('persisted')
+    expect(entries[0].workspaceId).toBe('ws-1')
+    expect(entries[0].kind).toBe('done')
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('returns empty when file does not exist', async () => {
+    const missing = createInboxStore({ filePath: join(dir, 'absent.jsonl') })
+    const { entries, hasMore } = await missing.read()
+    expect(entries).toEqual([])
+    expect(hasMore).toBe(false)
+    await rm(dir, { recursive: true, force: true })
+  })
+})

--- a/src/core/inbox-store.spec.ts
+++ b/src/core/inbox-store.spec.ts
@@ -22,7 +22,6 @@ describe('InboxStore (in-memory)', () => {
       workspaceId: 'ws-1',
       workspaceLabel: 'chat-with-kimi',
       comments: 'hey, can you check the SPY chart?',
-      kind: 'question',
     })
     expect(entry.id).toMatch(/^[0-9a-f-]{36}$/)
     expect(entry.workspaceId).toBe('ws-1')
@@ -35,7 +34,6 @@ describe('InboxStore (in-memory)', () => {
     const entry = await store.append({
       workspaceId: 'ws-1',
       docs: [{ path: 'research/macro-2026-05-14.md' }],
-      kind: 'done',
     })
     expect(entry.docs).toEqual([{ path: 'research/macro-2026-05-14.md' }])
     expect(entry.comments).toBeUndefined()
@@ -133,14 +131,12 @@ describe('InboxStore (JSONL persistence)', () => {
       workspaceId: 'ws-1',
       docs: [{ path: 'report.md' }],
       comments: 'final draft',
-      kind: 'done',
     })
     const fresh = createInboxStore({ filePath: path })
     const { entries } = await fresh.read()
     expect(entries).toHaveLength(1)
     expect(entries[0].docs).toEqual([{ path: 'report.md' }])
     expect(entries[0].comments).toBe('final draft')
-    expect(entries[0].kind).toBe('done')
     await rm(dir, { recursive: true, force: true })
   })
 

--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -1,24 +1,29 @@
 /**
- * InboxStore — workspace-scoped push surface. Parallel to NotificationsStore
- * but explicitly built for the workspace era: every entry is anchored to a
- * `workspaceId`, treating the inbox as "agent (employee) → user about
- * workspace (issue) progress" — Linear-inbox style.
+ * InboxStore — workspace-anchored push surface, Linear-inbox model.
  *
- * Why parallel to NotificationsStore instead of extending it: the older
- * store carries pre-workspace assumptions (heartbeat / cron / manual sources,
- * ConnectorCenter lastInteraction coupling, Telegram inline-on-active). Wiring
- * inbox semantics through that would require either widening NotificationSource
- * with a workspace-shaped sentinel and bolting on workspaceId everywhere, or
- * a backwards-compat shim that papers over the conflation. New track is
- * cheaper; old track stays in place serving its existing users and quietly
- * retires when the workspace surface absorbs its remaining use cases.
+ * Atomic concept here is the **Workspace**, not Linear's "Issue". The
+ * workspace's author (the AI agent) lives inside the workspace, and its
+ * work product is the workspace folder's files — not single comments
+ * authored at notification time. So an inbox entry carries:
  *
- * v0 contract: append-only, single JSONL at `data/inbox/entries.jsonl`,
- * `workspaceId` is required (no manual / sentinel-workspace entries — keeps
- * the inbox semantically clean from day one). No connector subscription,
- * no outputGate, no dedup. The write side is deliberately left without a
- * production caller in v0 — only a dev `/seed` HTTP endpoint exists — until
- * the workspace integration pathway is decided.
+ *   - `docs`     pointers to files in the workspace ("go read these")
+ *                — rendered live at view time, never snapshotted
+ *   - `comments` the agent's voice — markdown, the actual message body
+ *                ("hey boss, here's what I want to say about it")
+ *
+ * Both are optional but at least one must be present. Pointer-only on
+ * docs is deliberate (matches Linear's "inbox row is a notification, the
+ * issue is the SOR"): the workspace folder is its own version-controlled
+ * source of truth, so snapshotting into the inbox would just create a
+ * stale parallel copy. Workspace deletion → inbox tombstones; that's
+ * correct semantics, not a lifecycle bug.
+ *
+ * v0.5 contract: append-only JSONL at `data/inbox/entries.jsonl`,
+ * `workspaceId` required, at least one of {docs, comments} required.
+ * No connector subscription, no outputGate, no dedup. The production
+ * write path is still deliberately deferred — only a dev `/seed`
+ * endpoint exists until the workspace integration pathway (MCP tool +
+ * workspace identity) is decided.
  */
 
 import { randomUUID } from 'node:crypto'
@@ -28,12 +33,22 @@ import { EventEmitter } from 'node:events'
 
 export type InboxKind = 'status' | 'done' | 'blocked' | 'question'
 
+/** Pointer to a workspace file. Rendered live at view time. */
+export interface InboxDoc {
+  /** Path relative to the workspace root. */
+  path: string
+}
+
 export interface InboxInput {
   workspaceId: string
-  /** Display snapshot of the workspace label at write time. Optional because
-   *  the writer may not always have it; readers fall back to workspaceId. */
+  /** Display snapshot of the workspace label. Optional; readers fall
+   *  back to workspaceId. */
   workspaceLabel?: string
-  text: string
+  /** Workspace files to render. Each entry is a pointer — content is
+   *  fetched live from the workspace folder at view time. */
+  docs?: InboxDoc[]
+  /** Agent's message body (markdown). Renders below docs. */
+  comments?: string
   kind?: InboxKind
 }
 
@@ -43,28 +58,42 @@ export interface InboxEntry extends InboxInput {
 }
 
 export interface InboxReadOpts {
-  /** Newest-first slice limit. Default 100. */
   limit?: number
-  /** Cursor — return entries strictly older than this id. */
   before?: string
-  /** Filter by workspace. */
   workspaceId?: string
 }
 
 export interface IInboxStore {
   append(input: InboxInput): Promise<InboxEntry>
-  /** Returns entries newest-first up to `limit`. Empty array when file is missing. */
   read(opts?: InboxReadOpts): Promise<{ entries: InboxEntry[]; hasMore: boolean }>
-  /** Subscribe to live appends. Returns a dispose function. */
   onAppended(listener: (entry: InboxEntry) => void): () => void
 }
 
 const INBOX_FILE = join(process.cwd(), 'data', 'inbox', 'entries.jsonl')
 
+// ==================== Validation ====================
+
+function validateInput(input: InboxInput): void {
+  if (!input.workspaceId) {
+    throw new Error('InboxStore.append: workspaceId is required')
+  }
+  const hasDocs = (input.docs?.length ?? 0) > 0
+  const hasComments = (input.comments ?? '').trim().length > 0
+  if (!hasDocs && !hasComments) {
+    throw new Error('InboxStore.append: at least one of docs or comments must be present')
+  }
+  if (input.docs) {
+    for (const d of input.docs) {
+      if (!d.path || typeof d.path !== 'string') {
+        throw new Error('InboxStore.append: each doc must have a non-empty `path` string')
+      }
+    }
+  }
+}
+
 // ==================== JSONL store ====================
 
 export interface InboxStoreOptions {
-  /** Override the on-disk path; default `data/inbox/entries.jsonl`. */
   filePath?: string
 }
 
@@ -74,9 +103,7 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
   emitter.setMaxListeners(50)
 
   async function append(input: InboxInput): Promise<InboxEntry> {
-    if (!input.workspaceId) {
-      throw new Error('InboxStore.append: workspaceId is required')
-    }
+    validateInput(input)
     const entry: InboxEntry = {
       ...input,
       id: randomUUID(),
@@ -139,9 +166,7 @@ export function createMemoryInboxStore(): IInboxStore {
   emitter.setMaxListeners(50)
 
   async function append(input: InboxInput): Promise<InboxEntry> {
-    if (!input.workspaceId) {
-      throw new Error('InboxStore.append: workspaceId is required')
-    }
+    validateInput(input)
     const entry: InboxEntry = {
       ...input,
       id: randomUUID(),

--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -1,0 +1,174 @@
+/**
+ * InboxStore — workspace-scoped push surface. Parallel to NotificationsStore
+ * but explicitly built for the workspace era: every entry is anchored to a
+ * `workspaceId`, treating the inbox as "agent (employee) → user about
+ * workspace (issue) progress" — Linear-inbox style.
+ *
+ * Why parallel to NotificationsStore instead of extending it: the older
+ * store carries pre-workspace assumptions (heartbeat / cron / manual sources,
+ * ConnectorCenter lastInteraction coupling, Telegram inline-on-active). Wiring
+ * inbox semantics through that would require either widening NotificationSource
+ * with a workspace-shaped sentinel and bolting on workspaceId everywhere, or
+ * a backwards-compat shim that papers over the conflation. New track is
+ * cheaper; old track stays in place serving its existing users and quietly
+ * retires when the workspace surface absorbs its remaining use cases.
+ *
+ * v0 contract: append-only, single JSONL at `data/inbox/entries.jsonl`,
+ * `workspaceId` is required (no manual / sentinel-workspace entries — keeps
+ * the inbox semantically clean from day one). No connector subscription,
+ * no outputGate, no dedup. The write side is deliberately left without a
+ * production caller in v0 — only a dev `/seed` HTTP endpoint exists — until
+ * the workspace integration pathway is decided.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { readFile, appendFile, mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { EventEmitter } from 'node:events'
+
+export type InboxKind = 'status' | 'done' | 'blocked' | 'question'
+
+export interface InboxInput {
+  workspaceId: string
+  /** Display snapshot of the workspace label at write time. Optional because
+   *  the writer may not always have it; readers fall back to workspaceId. */
+  workspaceLabel?: string
+  text: string
+  kind?: InboxKind
+}
+
+export interface InboxEntry extends InboxInput {
+  id: string
+  ts: number
+}
+
+export interface InboxReadOpts {
+  /** Newest-first slice limit. Default 100. */
+  limit?: number
+  /** Cursor — return entries strictly older than this id. */
+  before?: string
+  /** Filter by workspace. */
+  workspaceId?: string
+}
+
+export interface IInboxStore {
+  append(input: InboxInput): Promise<InboxEntry>
+  /** Returns entries newest-first up to `limit`. Empty array when file is missing. */
+  read(opts?: InboxReadOpts): Promise<{ entries: InboxEntry[]; hasMore: boolean }>
+  /** Subscribe to live appends. Returns a dispose function. */
+  onAppended(listener: (entry: InboxEntry) => void): () => void
+}
+
+const INBOX_FILE = join(process.cwd(), 'data', 'inbox', 'entries.jsonl')
+
+// ==================== JSONL store ====================
+
+export interface InboxStoreOptions {
+  /** Override the on-disk path; default `data/inbox/entries.jsonl`. */
+  filePath?: string
+}
+
+export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
+  const filePath = opts.filePath ?? INBOX_FILE
+  const emitter = new EventEmitter()
+  emitter.setMaxListeners(50)
+
+  async function append(input: InboxInput): Promise<InboxEntry> {
+    if (!input.workspaceId) {
+      throw new Error('InboxStore.append: workspaceId is required')
+    }
+    const entry: InboxEntry = {
+      ...input,
+      id: randomUUID(),
+      ts: Date.now(),
+    }
+    await mkdir(dirname(filePath), { recursive: true })
+    await appendFile(filePath, JSON.stringify(entry) + '\n')
+    emitter.emit('appended', entry)
+    return entry
+  }
+
+  async function read(opts: InboxReadOpts = {}): Promise<{ entries: InboxEntry[]; hasMore: boolean }> {
+    let raw: string
+    try {
+      raw = await readFile(filePath, 'utf-8')
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { entries: [], hasMore: false }
+      }
+      throw err
+    }
+
+    let all = raw
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as InboxEntry)
+
+    if (opts.workspaceId) {
+      all = all.filter((e) => e.workspaceId === opts.workspaceId)
+    }
+
+    let scoped = all
+    if (opts.before) {
+      const idx = all.findIndex((e) => e.id === opts.before)
+      scoped = idx >= 0 ? all.slice(0, idx) : []
+    }
+
+    const limit = opts.limit ?? 100
+    const window = scoped.slice(-limit)
+    const entries = [...window].reverse()
+    const hasMore = window.length < scoped.length
+    return { entries, hasMore }
+  }
+
+  function onAppended(listener: (entry: InboxEntry) => void): () => void {
+    emitter.on('appended', listener)
+    return () => {
+      emitter.off('appended', listener)
+    }
+  }
+
+  return { append, read, onAppended }
+}
+
+// ==================== In-memory store (tests) ====================
+
+export function createMemoryInboxStore(): IInboxStore {
+  const entries: InboxEntry[] = []
+  const emitter = new EventEmitter()
+  emitter.setMaxListeners(50)
+
+  async function append(input: InboxInput): Promise<InboxEntry> {
+    if (!input.workspaceId) {
+      throw new Error('InboxStore.append: workspaceId is required')
+    }
+    const entry: InboxEntry = {
+      ...input,
+      id: randomUUID(),
+      ts: Date.now(),
+    }
+    entries.push(entry)
+    emitter.emit('appended', entry)
+    return entry
+  }
+
+  async function read(opts: InboxReadOpts = {}): Promise<{ entries: InboxEntry[]; hasMore: boolean }> {
+    let scoped = opts.workspaceId ? entries.filter((e) => e.workspaceId === opts.workspaceId) : entries
+    if (opts.before) {
+      const idx = scoped.findIndex((e) => e.id === opts.before)
+      scoped = idx >= 0 ? scoped.slice(0, idx) : []
+    }
+    const limit = opts.limit ?? 100
+    const window = scoped.slice(-limit)
+    return { entries: [...window].reverse(), hasMore: window.length < scoped.length }
+  }
+
+  function onAppended(listener: (entry: InboxEntry) => void): () => void {
+    emitter.on('appended', listener)
+    return () => {
+      emitter.off('appended', listener)
+    }
+  }
+
+  return { append, read, onAppended }
+}

--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -31,8 +31,6 @@ import { readFile, appendFile, mkdir } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { EventEmitter } from 'node:events'
 
-export type InboxKind = 'status' | 'done' | 'blocked' | 'question'
-
 /** Pointer to a workspace file. Rendered live at view time. */
 export interface InboxDoc {
   /** Path relative to the workspace root. */
@@ -49,7 +47,6 @@ export interface InboxInput {
   docs?: InboxDoc[]
   /** Agent's message body (markdown). Renders below docs. */
   comments?: string
-  kind?: InboxKind
 }
 
 export interface InboxEntry extends InboxInput {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,6 +15,7 @@ import type { ToolCenter } from './tool-center.js'
 import type { ListenerRegistry } from './listener-registry.js'
 import type { EventBus } from './event-bus.js'
 import type { INotificationsStore } from './notifications-store.js'
+import type { IInboxStore } from './inbox-store.js'
 
 export type { Config, WebChannel }
 
@@ -35,6 +36,10 @@ export interface EngineContext {
   connectorCenter: ConnectorCenter
   /** Canonical store of system notifications; connectors subscribe via onAppended. */
   notificationsStore: INotificationsStore
+  /** Workspace-anchored push surface (Linear-inbox style). v0: read path
+   *  wired, production write path deliberately deferred — only dev seed
+   *  endpoint exists until the workspace integration pathway is decided. */
+  inboxStore: IInboxStore
   agentCenter: AgentCenter
   eventLog: EventLog
   toolCallLog: ToolCallLog

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -1,0 +1,82 @@
+/**
+ * WorkspaceToolCenter — registry of **workspace-scoped tool factories**.
+ *
+ * Parallel to {@link ToolCenter} but inverted in a key way: ToolCenter holds
+ * concrete tool instances that don't care who is calling. WorkspaceToolCenter
+ * holds *factories* — each one takes a workspace identity (wsId, label,
+ * shared deps) and returns a concrete Tool whose execute() closes over that
+ * identity. This is how OpenAlice exposes the "workspace's reverse channel
+ * back to OpenAlice" surface (inbox_push and future workspace-scoped tools)
+ * without ever asking the AI agent to traffic its own workspaceId.
+ *
+ * The MCP server's `/mcp/:wsId` route invokes every factory with the URL's
+ * wsId at request time. From the agent's POV, `inbox_push({ docs, comments })`
+ * has no identity parameter — workspaceId is invisible, baked into the
+ * tool by the server. Forgery surface is zero because the URL is the
+ * only identity carrier and `.mcp.json` is per-workspace.
+ *
+ * Why a separate registry instead of marking ToolCenter tools as
+ * "workspace-scoped": the surface areas are genuinely different. ToolCenter
+ * is "OpenAlice's services for anyone with an MCP client" — trading, market
+ * data, news, brain. WorkspaceToolCenter is "this specific workspace's
+ * communication back to OpenAlice." Mixing them under one registry with a
+ * scope flag would tangle access control with tool execution, and external
+ * MCP consumers would see workspace-shaped tools they can't sensibly use.
+ */
+
+import type { Tool } from 'ai'
+import type { IInboxStore } from './inbox-store.js'
+
+// ==================== Context handed to factories ====================
+
+export interface WorkspaceToolContext {
+  /** The workspace's stable id. Filled by the MCP router from URL path. */
+  workspaceId: string
+  /** Snapshot of the workspace's display tag at build time. Factories can
+   *  pass this through to call sites (e.g. inboxStore.append's
+   *  workspaceLabel) so the inbox UI has a human-readable name even if
+   *  the workspace tag changes later. */
+  workspaceLabel: string
+  /** Shared inbox store — passed in so factories don't have to import
+   *  global state and tests can swap in a memory store. */
+  inboxStore: IInboxStore
+}
+
+// ==================== Factory shape ====================
+
+export interface WorkspaceToolFactory {
+  /** Tool name as the agent will see it (no namespace prefix needed — the
+   *  factory lives behind `/mcp/:wsId` which has its own catalog). */
+  name: string
+  /** Build a concrete Tool with workspaceId baked in. Called per MCP
+   *  request, so closure capture is the right pattern (no shared mutable
+   *  state between workspace requests). */
+  build(ctx: WorkspaceToolContext): Tool
+}
+
+// ==================== Center ====================
+
+export class WorkspaceToolCenter {
+  private factories: WorkspaceToolFactory[] = []
+
+  register(factory: WorkspaceToolFactory): void {
+    // Name collisions overwrite — same pattern as ToolCenter.
+    this.factories = this.factories.filter((f) => f.name !== factory.name)
+    this.factories.push(factory)
+  }
+
+  /** Build one concrete tool catalog for a specific workspace context.
+   *  Called from the MCP `/mcp/:wsId` route per request. */
+  build(ctx: WorkspaceToolContext): Record<string, Tool> {
+    const out: Record<string, Tool> = {}
+    for (const f of this.factories) {
+      out[f.name] = f.build(ctx)
+    }
+    return out
+  }
+
+  /** Names of registered factories. Useful for introspection / tests. */
+  list(): string[] {
+    return this.factories.map((f) => f.name)
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import { createSessionTools } from './tool/session.js'
 import { SessionStore } from './core/session.js'
 import { ConnectorCenter } from './core/connector-center.js'
 import { createNotificationsStore } from './core/notifications-store.js'
+import { createInboxStore } from './core/inbox-store.js'
 import { ToolCenter } from './core/tool-center.js'
 import { AgentCenter } from './core/agent-center.js'
 import { AgentWorkRunner } from './core/agent-work.js'
@@ -231,6 +232,7 @@ async function main() {
   // ==================== Notifications store + Connector Center ====================
 
   const notificationsStore = createNotificationsStore()
+  const inboxStore = createInboxStore()
   const connectorCenter = new ConnectorCenter({ eventLog, listenerRegistry, notificationsStore })
 
   // Session awareness tools (registered here because they need connectorCenter)
@@ -409,7 +411,7 @@ async function main() {
   // ==================== Engine Context ====================
 
   const ctx: EngineContext = {
-    config, connectorCenter, notificationsStore, agentCenter, eventLog, toolCallLog, heartbeat, cronEngine, toolCenter,
+    config, connectorCenter, notificationsStore, inboxStore, agentCenter, eventLog, toolCallLog, heartbeat, cronEngine, toolCenter,
     listenerRegistry,
     fire: createEventBus(eventLog),
     bbEngine: getSDKExecutor(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import type { Plugin, EngineContext, ReconnectResult } from './core/types.js'
 import { McpPlugin } from './server/mcp.js'
 import { TelegramPlugin } from './connectors/telegram/index.js'
 import { WebPlugin } from './webui/index.js'
+import { createWorkspaceServiceRef } from './webui/plugin.js'
 import { McpAskPlugin } from './connectors/mcp-ask/index.js'
 import { createThinkingTools } from './tool/thinking.js'
 import { UTAManager, createSnapshotService, createSnapshotScheduler } from './domain/trading/index.js'
@@ -31,6 +32,8 @@ import { ConnectorCenter } from './core/connector-center.js'
 import { createNotificationsStore } from './core/notifications-store.js'
 import { createInboxStore } from './core/inbox-store.js'
 import { ToolCenter } from './core/tool-center.js'
+import { WorkspaceToolCenter } from './core/workspace-tool-center.js'
+import { inboxPushFactory } from './tool/inbox-push.js'
 import { AgentCenter } from './core/agent-center.js'
 import { AgentWorkRunner } from './core/agent-work.js'
 import { createNotifyUserTool } from './tool/notify-user.js'
@@ -85,6 +88,11 @@ async function main() {
   // ==================== Tool Center (created early — UTAManager needs it) ====================
 
   const toolCenter = new ToolCenter()
+
+  // ==================== Workspace Tool Center (factories — instantiated per wsId at MCP request time) ====================
+
+  const workspaceToolCenter = new WorkspaceToolCenter()
+  workspaceToolCenter.register(inboxPushFactory)
 
   // ==================== Trading Account Manager ====================
 
@@ -328,16 +336,26 @@ async function main() {
   // Core plugins — always-on, not toggleable at runtime
   const corePlugins: Plugin[] = []
 
+  // Cross-plugin ref so McpPlugin can resolve workspaces for `/mcp/:wsId`
+  // even though WebPlugin (the service's actual creator) starts later.
+  const workspaceServiceRef = createWorkspaceServiceRef()
+
   // MCP Server is always active when a port is set — Claude Code provider depends on it for tools.
   // Lives at top-level config (not under connectors:) because it exports
   // ToolCenter outward rather than consuming chat input.
   if (config.mcp.port) {
-    corePlugins.push(new McpPlugin(toolCenter, config.mcp.port))
+    corePlugins.push(new McpPlugin(
+      toolCenter,
+      config.mcp.port,
+      workspaceToolCenter,
+      inboxStore,
+      () => workspaceServiceRef.current,
+    ))
   }
 
   // Web UI is always active (no enabled flag)
   if (config.connectors.web.port) {
-    corePlugins.push(new WebPlugin({ port: config.connectors.web.port }))
+    corePlugins.push(new WebPlugin({ port: config.connectors.web.port }, workspaceServiceRef))
   }
 
   // Optional plugins — toggleable at runtime via reconnectConnectors()

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -5,13 +5,30 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import type { Plugin, EngineContext } from '../core/types.js'
 import type { ToolCenter } from '../core/tool-center.js'
+import type { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
+import type { IInboxStore } from '../core/inbox-store.js'
+import type { WorkspaceService } from '../workspaces/service.js'
 import { extractMcpShape, wrapToolExecute } from '../core/mcp-export.js'
 
 /**
- * MCP Plugin — exposes tools via Streamable HTTP.
+ * MCP Plugin — exposes OpenAlice tools via Streamable HTTP, **two routes**:
  *
- * Holds a reference to ToolCenter and queries it per-request, so tool
- * changes (reconnect, disable/enable) are picked up automatically.
+ *   GET/POST /mcp           Workspace-independent surface (ToolCenter).
+ *                           Trading / market / news / brain / etc. — what
+ *                           OpenAlice provides to any MCP client. No
+ *                           identity required.
+ *
+ *   GET/POST /mcp/:wsId     Workspace-scoped surface (WorkspaceToolCenter).
+ *                           Just inbox_push for now; future tools that need
+ *                           workspaceId close over it via the factory
+ *                           pattern. The URL path IS the identity carrier —
+ *                           agent never sees or supplies workspaceId, and
+ *                           bootstrap.sh bakes the per-workspace URL into
+ *                           the workspace's own .mcp.json.
+ *
+ * Holds references to both registries and the WorkspaceService (for wsId
+ * registry lookup). Tools are rebuilt per-request so disable/enable +
+ * factory closure over wsId both work without restart.
  */
 export class McpPlugin implements Plugin {
   name = 'mcp'
@@ -20,24 +37,50 @@ export class McpPlugin implements Plugin {
   constructor(
     private toolCenter: ToolCenter,
     private port: number,
+    private workspaceToolCenter: WorkspaceToolCenter,
+    private inboxStore: IInboxStore,
+    /** Lazy because WorkspaceService is created later (deferred during web
+     *  plugin start); McpPlugin starts earlier. Resolved at request time. */
+    private getWorkspaceService: () => WorkspaceService | null,
   ) {}
 
   async start(_ctx: EngineContext) {
     const toolCenter = this.toolCenter
+    const workspaceToolCenter = this.workspaceToolCenter
+    const inboxStore = this.inboxStore
+    const getWorkspaceService = this.getWorkspaceService
 
-    const createMcpServer = async () => {
+    /** Build a per-request McpServer with the global ToolCenter catalog. */
+    const createGlobalMcpServer = async () => {
       const tools = await toolCenter.getMcpTools()
       const mcp = new McpServer({ name: 'open-alice', version: '1.0.0' })
-
       for (const [name, t] of Object.entries(tools)) {
         if (!t.execute) continue
-
         mcp.registerTool(name, {
           description: t.description,
           inputSchema: extractMcpShape(t),
         }, wrapToolExecute(t))
       }
+      return mcp
+    }
 
+    /** Build a per-request McpServer scoped to a specific workspace.
+     *  Each WorkspaceToolFactory is invoked with the URL's wsId so its
+     *  tools' execute() closes over that identity. */
+    const createWorkspaceMcpServer = (wsId: string, wsLabel: string) => {
+      const tools = workspaceToolCenter.build({
+        workspaceId: wsId,
+        workspaceLabel: wsLabel,
+        inboxStore,
+      })
+      const mcp = new McpServer({ name: 'open-alice-workspace', version: '1.0.0' })
+      for (const [name, t] of Object.entries(tools)) {
+        if (!t.execute) continue
+        mcp.registerTool(name, {
+          description: t.description,
+          inputSchema: extractMcpShape(t),
+        }, wrapToolExecute(t))
+      }
       return mcp
     }
 
@@ -52,13 +95,30 @@ export class McpPlugin implements Plugin {
 
     app.all('/mcp', async (c) => {
       const transport = new WebStandardStreamableHTTPServerTransport()
-      const mcp = await createMcpServer()
+      const mcp = await createGlobalMcpServer()
+      await mcp.connect(transport)
+      return transport.handleRequest(c.req.raw)
+    })
+
+    app.all('/mcp/:wsId', async (c) => {
+      const wsId = c.req.param('wsId')
+      const svc = getWorkspaceService()
+      if (!svc) {
+        // Workspace subsystem hasn't started yet — reject loudly rather
+        // than serving an empty catalog.
+        return c.text('workspace service unavailable', 503)
+      }
+      const meta = svc.registry.get(wsId)
+      if (!meta) return c.text('unknown workspace', 404)
+
+      const transport = new WebStandardStreamableHTTPServerTransport()
+      const mcp = createWorkspaceMcpServer(meta.id, meta.tag)
       await mcp.connect(transport)
       return transport.handleRequest(c.req.raw)
     })
 
     this.server = serve({ fetch: app.fetch, port: this.port }, (info) => {
-      console.log(`mcp plugin listening on http://localhost:${info.port}/mcp`)
+      console.log(`mcp plugin listening on http://localhost:${info.port}/mcp (+ /mcp/:wsId)`)
     })
   }
 

--- a/src/tool/inbox-push.ts
+++ b/src/tool/inbox-push.ts
@@ -1,0 +1,89 @@
+/**
+ * inbox_push — workspace's outbound channel to the user's inbox.
+ *
+ * This is a **workspace-scoped tool factory**. The agent inside a workspace
+ * sees only `{ docs?, comments? }` in the schema; the workspaceId is filled
+ * by the MCP router from the URL path (`/mcp/:wsId`) and closed over by
+ * the factory's build() at request time. Hiding workspaceId from the
+ * schema is deliberate: it makes forgery impossible (agent can't push to
+ * a different workspace's inbox) and removes a wsId parameter the agent
+ * would otherwise have to manage.
+ *
+ * Registered with WorkspaceToolCenter, exposed only at `/mcp/:wsId`. The
+ * generic `/mcp` route (workspace-independent tools) does not see it —
+ * external MCP consumers won't accidentally find a workspace-shaped tool
+ * they can't sensibly use.
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
+
+export const inboxPushFactory: WorkspaceToolFactory = {
+  name: 'inbox_push',
+  build(ctx: WorkspaceToolContext) {
+    return tool({
+      description: [
+        "Push an update to the user's inbox from this workspace.",
+        'Use this when you have something the user should see —',
+        'a finished analysis (point to the report file via `docs`),',
+        'a question back to the user (write it as `comments`),',
+        'a blocked task that needs input, or a status check-in.',
+        '',
+        '`docs` are paths relative to this workspace root. Each one',
+        'is rendered live in the inbox UI when the user opens the',
+        'entry — no snapshot is taken, so later edits to the file',
+        'will be reflected on subsequent reads.',
+        '',
+        '`comments` is markdown — your voice to the user about what',
+        'you did or want to ask. Keep it short and direct; if more',
+        'detail is needed put it in a doc and reference it.',
+        '',
+        'At least one of `docs` or `comments` must be present.',
+      ].join(' '),
+      inputSchema: z.object({
+        docs: z
+          .array(
+            z.object({
+              path: z
+                .string()
+                .min(1)
+                .describe(
+                  "Relative path to a file inside this workspace, e.g. 'research/macro-2026-05-14.md'.",
+                ),
+            }),
+          )
+          .optional()
+          .describe(
+            'Workspace files to surface in the inbox entry. Rendered live, not snapshotted.',
+          ),
+        comments: z
+          .string()
+          .optional()
+          .describe(
+            "Your message to the user (markdown). Renders below docs in the inbox detail pane.",
+          ),
+      }),
+      execute: async ({ docs, comments }) => {
+        try {
+          const entry = await ctx.inboxStore.append({
+            workspaceId: ctx.workspaceId,
+            workspaceLabel: ctx.workspaceLabel,
+            docs,
+            comments,
+          })
+          return {
+            ok: true as const,
+            entryId: entry.id,
+            ts: entry.ts,
+          }
+        } catch (err) {
+          return {
+            ok: false as const,
+            error: err instanceof Error ? err.message : String(err),
+          }
+        }
+      },
+    })
+  },
+}

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -25,6 +25,7 @@ import { createPersonaRoutes } from './routes/persona.js'
 import { createNewsRoutes } from './routes/news.js'
 import { createMarketRoutes } from './routes/market.js'
 import { createNotificationsRoutes } from './routes/notifications.js'
+import { createInboxRoutes } from './routes/inbox.js'
 import { createVersionRoutes } from './routes/version.js'
 import { mountOpenTypeBB } from '../server/opentypebb.js'
 import { buildSDKCredentials } from '../domain/market-data/credential-map.js'
@@ -121,6 +122,7 @@ export class WebPlugin implements Plugin {
     app.route('/api/notifications', createNotificationsRoutes({
       notificationsStore: ctx.notificationsStore,
     }))
+    app.route('/api/inbox', createInboxRoutes({ inboxStore: ctx.inboxStore }))
     app.route('/api/version', createVersionRoutes())
 
     // ==================== Workspaces (launcher-style PTY) ====================

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -30,6 +30,18 @@ import { createVersionRoutes } from './routes/version.js'
 import { mountOpenTypeBB } from '../server/opentypebb.js'
 import { buildSDKCredentials } from '../domain/market-data/credential-map.js'
 import { createWorkspaceService, type WorkspaceService } from '../workspaces/service.js'
+
+/** Cross-plugin hand-off for WorkspaceService. WebPlugin creates it
+ *  inside `start()`; McpPlugin needs it earlier for the `/mcp/:wsId`
+ *  route lookup. A small ref-box lets the late creator publish without
+ *  changing either plugin's constructor signature. */
+export interface WorkspaceServiceRef {
+  current: WorkspaceService | null
+}
+
+export function createWorkspaceServiceRef(): WorkspaceServiceRef {
+  return { current: null }
+}
 import { createWorkspaceRoutes } from './routes/workspaces.js'
 import { attachWorkspacesWS, type AttachedWS } from './workspaces-ws.js'
 import type { Server as HttpServer } from 'node:http'
@@ -48,7 +60,14 @@ export class WebPlugin implements Plugin {
   private workspaceService: WorkspaceService | null = null
   private workspacesWs: AttachedWS | null = null
 
-  constructor(private config: WebConfig) {}
+  constructor(
+    private config: WebConfig,
+    /** Optional cross-plugin ref that gets populated when the workspace
+     *  service finishes starting. McpPlugin reads through this to find
+     *  workspaces for the `/mcp/:wsId` route. Omitted in legacy callers
+     *  / tests; ignored when null. */
+    private workspaceServiceRef?: WorkspaceServiceRef,
+  ) {}
 
   async start(ctx: EngineContext) {
     // Load sub-channel definitions
@@ -129,6 +148,7 @@ export class WebPlugin implements Plugin {
     // Self-contained subsystem ported from auto-quant-launcher. Owns its own
     // state under ~/.openalice/workspaces/ and its own /api/workspaces/pty WS.
     this.workspaceService = await createWorkspaceService()
+    if (this.workspaceServiceRef) this.workspaceServiceRef.current = this.workspaceService
     app.route('/api/workspaces', createWorkspaceRoutes(this.workspaceService))
 
     // ==================== Mount opentypebb (market data HTTP) ====================
@@ -176,6 +196,7 @@ export class WebPlugin implements Plugin {
     if (this.workspaceService) {
       await this.workspaceService.dispose('plugin stop')
       this.workspaceService = null
+      if (this.workspaceServiceRef) this.workspaceServiceRef.current = null
     }
     this.server?.close()
   }

--- a/src/webui/routes/inbox.ts
+++ b/src/webui/routes/inbox.ts
@@ -4,15 +4,12 @@
  *   GET  /history?limit=&before=&workspaceId=   paginated, newest-first
  *   POST /seed                                  dev-only: append an entry
  *
- * The UI polls /history every 20s (mirrors notifications). The production
- * write path is deliberately not wired yet — Inbox v0 is a UI-shaped
- * commitment; the integration question (MCP tool from workspace? webhook?
- * something else?) is parked until product direction is decided. /seed
- * exists as a manual test entry point and will be removed once a real
- * writer lands.
+ * UI polls /history every 20s. Production write path is still deliberately
+ * deferred — only /seed exists until the workspace integration pathway
+ * (MCP tool + workspace identity) is decided.
  */
 import { Hono } from 'hono'
-import type { IInboxStore, InboxKind } from '../../core/inbox-store.js'
+import type { IInboxStore, InboxKind, InboxDoc } from '../../core/inbox-store.js'
 
 const VALID_KINDS: ReadonlySet<InboxKind> = new Set(['status', 'done', 'blocked', 'question'])
 
@@ -41,26 +38,47 @@ export function createInboxRoutes(deps: InboxRoutesDeps) {
     const b = body as Partial<{
       workspaceId: string
       workspaceLabel: string
-      text: string
+      docs: unknown
+      comments: string
       kind: string
     }>
     if (!b.workspaceId || typeof b.workspaceId !== 'string') {
       return c.json({ error: 'workspaceId required' }, 400)
     }
-    if (!b.text || typeof b.text !== 'string') {
-      return c.json({ error: 'text required' }, 400)
+
+    // Validate docs shape if present
+    let docs: InboxDoc[] | undefined
+    if (b.docs !== undefined) {
+      if (!Array.isArray(b.docs)) {
+        return c.json({ error: 'docs must be an array' }, 400)
+      }
+      docs = []
+      for (const d of b.docs) {
+        if (typeof d !== 'object' || d === null) {
+          return c.json({ error: 'each doc must be an object' }, 400)
+        }
+        const path = (d as { path?: unknown }).path
+        if (typeof path !== 'string' || !path) {
+          return c.json({ error: 'each doc must have a non-empty `path` string' }, 400)
+        }
+        docs.push({ path })
+      }
     }
+
+    const comments = typeof b.comments === 'string' ? b.comments : undefined
     const kind = b.kind && VALID_KINDS.has(b.kind as InboxKind) ? (b.kind as InboxKind) : undefined
+
     try {
       const entry = await deps.inboxStore.append({
         workspaceId: b.workspaceId,
         workspaceLabel: typeof b.workspaceLabel === 'string' ? b.workspaceLabel : undefined,
-        text: b.text,
+        docs,
+        comments,
         kind,
       })
       return c.json({ entry })
     } catch (err) {
-      return c.json({ error: String(err) }, 500)
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400)
     }
   })
 

--- a/src/webui/routes/inbox.ts
+++ b/src/webui/routes/inbox.ts
@@ -1,0 +1,68 @@
+/**
+ * Inbox HTTP route — read history + dev-only seed.
+ *
+ *   GET  /history?limit=&before=&workspaceId=   paginated, newest-first
+ *   POST /seed                                  dev-only: append an entry
+ *
+ * The UI polls /history every 20s (mirrors notifications). The production
+ * write path is deliberately not wired yet — Inbox v0 is a UI-shaped
+ * commitment; the integration question (MCP tool from workspace? webhook?
+ * something else?) is parked until product direction is decided. /seed
+ * exists as a manual test entry point and will be removed once a real
+ * writer lands.
+ */
+import { Hono } from 'hono'
+import type { IInboxStore, InboxKind } from '../../core/inbox-store.js'
+
+const VALID_KINDS: ReadonlySet<InboxKind> = new Set(['status', 'done', 'blocked', 'question'])
+
+export interface InboxRoutesDeps {
+  inboxStore: IInboxStore
+}
+
+export function createInboxRoutes(deps: InboxRoutesDeps) {
+  const app = new Hono()
+
+  app.get('/history', async (c) => {
+    const limit = Number(c.req.query('limit')) || 100
+    const before = c.req.query('before') || undefined
+    const workspaceId = c.req.query('workspaceId') || undefined
+    const result = await deps.inboxStore.read({ limit, before, workspaceId })
+    return c.json(result)
+  })
+
+  app.post('/seed', async (c) => {
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'invalid json' }, 400)
+    }
+    const b = body as Partial<{
+      workspaceId: string
+      workspaceLabel: string
+      text: string
+      kind: string
+    }>
+    if (!b.workspaceId || typeof b.workspaceId !== 'string') {
+      return c.json({ error: 'workspaceId required' }, 400)
+    }
+    if (!b.text || typeof b.text !== 'string') {
+      return c.json({ error: 'text required' }, 400)
+    }
+    const kind = b.kind && VALID_KINDS.has(b.kind as InboxKind) ? (b.kind as InboxKind) : undefined
+    try {
+      const entry = await deps.inboxStore.append({
+        workspaceId: b.workspaceId,
+        workspaceLabel: typeof b.workspaceLabel === 'string' ? b.workspaceLabel : undefined,
+        text: b.text,
+        kind,
+      })
+      return c.json({ entry })
+    } catch (err) {
+      return c.json({ error: String(err) }, 500)
+    }
+  })
+
+  return app
+}

--- a/src/webui/routes/inbox.ts
+++ b/src/webui/routes/inbox.ts
@@ -9,9 +9,7 @@
  * (MCP tool + workspace identity) is decided.
  */
 import { Hono } from 'hono'
-import type { IInboxStore, InboxKind, InboxDoc } from '../../core/inbox-store.js'
-
-const VALID_KINDS: ReadonlySet<InboxKind> = new Set(['status', 'done', 'blocked', 'question'])
+import type { IInboxStore, InboxDoc } from '../../core/inbox-store.js'
 
 export interface InboxRoutesDeps {
   inboxStore: IInboxStore
@@ -40,7 +38,6 @@ export function createInboxRoutes(deps: InboxRoutesDeps) {
       workspaceLabel: string
       docs: unknown
       comments: string
-      kind: string
     }>
     if (!b.workspaceId || typeof b.workspaceId !== 'string') {
       return c.json({ error: 'workspaceId required' }, 400)
@@ -66,7 +63,6 @@ export function createInboxRoutes(deps: InboxRoutesDeps) {
     }
 
     const comments = typeof b.comments === 'string' ? b.comments : undefined
-    const kind = b.kind && VALID_KINDS.has(b.kind as InboxKind) ? (b.kind as InboxKind) : undefined
 
     try {
       const entry = await deps.inboxStore.append({
@@ -74,7 +70,6 @@ export function createInboxRoutes(deps: InboxRoutesDeps) {
         workspaceLabel: typeof b.workspaceLabel === 'string' ? b.workspaceLabel : undefined,
         docs,
         comments,
-        kind,
       })
       return c.json({ entry })
     } catch (err) {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -182,6 +182,38 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     }
   });
 
+  /**
+   * Read a single UTF-8 text file from inside a workspace. Used by the
+   * Inbox detail pane to render `docs` pointers live (no snapshot — the
+   * workspace folder is the source of truth, see InboxStore doc).
+   *
+   * 404 when the workspace or the file is missing — callers (Inbox UI)
+   * use this to render tombstone states. Larger than 1 MiB returns 413
+   * so the inbox can't be weaponised into a large-file viewer.
+   */
+  app.get('/:id/file', async (c) => {
+    const id = c.req.param('id');
+    if (!validId(id)) return c.json({ error: 'not_found' }, 404);
+    const meta = svc.registry.get(id);
+    if (!meta) return c.json({ error: 'workspace_not_found' }, 404);
+    const p = c.req.query('path') ?? '';
+    if (!p) return c.json({ error: 'path required' }, 400);
+    try {
+      const content = await readWorkspaceFile(meta.dir, p);
+      if (content === null) return c.json({ error: 'file_not_found' }, 404);
+      if (content.length > 1024 * 1024) {
+        return c.json({ error: 'file_too_large', sizeBytes: content.length }, 413);
+      }
+      return c.json({ path: p, content });
+    } catch (err) {
+      if (err instanceof PathTraversal) {
+        return c.json({ error: 'invalid_path', message: err.message }, 400);
+      }
+      launcherLogger.warn('files.read_failed', { id, path: p, err });
+      return c.json({ error: 'read_failed', message: (err as Error).message }, 500);
+    }
+  });
+
   // ── sessions ─────────────────────────────────────────────────────────────
 
   app.post('/:id/sessions/spawn', async (c) => {

--- a/src/workspaces/templates/chat/bootstrap.sh
+++ b/src/workspaces/templates/chat/bootstrap.sh
@@ -25,10 +25,17 @@ fi
 mkdir -p "$OUT_DIR"
 cd "$OUT_DIR"
 
-# MCP config — leave ${AQ_LAUNCHER_REPO_ROOT} / ${OPENALICE_MCP_URL}
-# placeholders unexpanded so the agent CLI does its own expansion at spawn
-# time.
-cp "$AQ_TEMPLATE_FILES_DIR/mcp.json" .mcp.json
+# Workspace UUID — directory name. WorkspaceCreator names $OUT_DIR with the
+# random UUID it just assigned, so basename matches the registry's wsId.
+WS_ID="$(basename "$OUT_DIR")"
+
+# MCP config — leave ${OPENALICE_MCP_URL} placeholder unexpanded so the
+# agent CLI evaluates it at spawn time. The __WS_ID__ literal IS expanded
+# now: it gets baked into the `openalice-workspace` server URL so the
+# OpenAlice MCP `/mcp/:wsId` route can identify which workspace called
+# inbox_push and other workspace-scoped tools. wsId is invisible to the
+# agent — workspace identity rides the URL path, not a tool argument.
+sed "s|__WS_ID__|$WS_ID|g" "$AQ_TEMPLATE_FILES_DIR/mcp.json" > .mcp.json
 
 # Locate Alice's persona — prefer the user's live edit, fall back to the
 # shipped default. If neither is reachable (e.g. AQ_LAUNCHER_REPO_ROOT

--- a/src/workspaces/templates/chat/files/mcp.json
+++ b/src/workspaces/templates/chat/files/mcp.json
@@ -3,6 +3,10 @@
     "openalice": {
       "type": "streamable-http",
       "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"
+    },
+    "openalice-workspace": {
+      "type": "streamable-http",
+      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}/__WS_ID__"
     }
   }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,7 +16,7 @@ import { useWorkspace } from './tabs/store'
  * Each maps to one or more tab kinds via tabs/registry.ts (defaultSpecForActivity).
  */
 export type Page =
-  | 'chat' | 'workspaces' | 'portfolio' | 'news' | 'automation' | 'market'
+  | 'chat' | 'inbox' | 'workspaces' | 'portfolio' | 'news' | 'automation' | 'market'
   | 'trading-as-git'
   | 'settings' | 'dev'
 

--- a/ui/src/api/inbox.ts
+++ b/ui/src/api/inbox.ts
@@ -2,18 +2,33 @@ import { fetchJson } from './client'
 
 export type InboxKind = 'status' | 'done' | 'blocked' | 'question'
 
+export interface InboxDoc {
+  path: string
+}
+
 export interface InboxEntry {
   id: string
   ts: number
   workspaceId: string
   workspaceLabel?: string
-  text: string
+  /** Pointers to workspace files. Rendered live (no snapshot). */
+  docs?: InboxDoc[]
+  /** Agent's message body (markdown). Renders below docs. */
+  comments?: string
   kind?: InboxKind
 }
 
 export interface InboxHistoryResponse {
   entries: InboxEntry[]
   hasMore: boolean
+}
+
+export interface InboxSeedBody {
+  workspaceId: string
+  workspaceLabel?: string
+  docs?: InboxDoc[]
+  comments?: string
+  kind?: InboxKind
 }
 
 export const inboxApi = {
@@ -27,10 +42,8 @@ export const inboxApi = {
     return fetchJson(`/api/inbox/history?${qs}`)
   },
 
-  /** Dev-only — appends an inbox entry. The production write path is not
-   *  wired yet (see backend route doc). Useful for UI development and
-   *  manual smoke tests. */
-  async seed(body: { workspaceId: string; workspaceLabel?: string; text: string; kind?: InboxKind }): Promise<{ entry: InboxEntry }> {
+  /** Dev-only — append an inbox entry. */
+  async seed(body: InboxSeedBody): Promise<{ entry: InboxEntry }> {
     return fetchJson('/api/inbox/seed', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/ui/src/api/inbox.ts
+++ b/ui/src/api/inbox.ts
@@ -1,0 +1,40 @@
+import { fetchJson } from './client'
+
+export type InboxKind = 'status' | 'done' | 'blocked' | 'question'
+
+export interface InboxEntry {
+  id: string
+  ts: number
+  workspaceId: string
+  workspaceLabel?: string
+  text: string
+  kind?: InboxKind
+}
+
+export interface InboxHistoryResponse {
+  entries: InboxEntry[]
+  hasMore: boolean
+}
+
+export const inboxApi = {
+  async history(
+    opts: { limit?: number; before?: string; workspaceId?: string } = {},
+  ): Promise<InboxHistoryResponse> {
+    const qs = new URLSearchParams()
+    if (opts.limit != null) qs.set('limit', String(opts.limit))
+    if (opts.before) qs.set('before', opts.before)
+    if (opts.workspaceId) qs.set('workspaceId', opts.workspaceId)
+    return fetchJson(`/api/inbox/history?${qs}`)
+  },
+
+  /** Dev-only — appends an inbox entry. The production write path is not
+   *  wired yet (see backend route doc). Useful for UI development and
+   *  manual smoke tests. */
+  async seed(body: { workspaceId: string; workspaceLabel?: string; text: string; kind?: InboxKind }): Promise<{ entry: InboxEntry }> {
+    return fetchJson('/api/inbox/seed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  },
+}

--- a/ui/src/api/inbox.ts
+++ b/ui/src/api/inbox.ts
@@ -1,7 +1,5 @@
 import { fetchJson } from './client'
 
-export type InboxKind = 'status' | 'done' | 'blocked' | 'question'
-
 export interface InboxDoc {
   path: string
 }
@@ -15,7 +13,6 @@ export interface InboxEntry {
   docs?: InboxDoc[]
   /** Agent's message body (markdown). Renders below docs. */
   comments?: string
-  kind?: InboxKind
 }
 
 export interface InboxHistoryResponse {
@@ -28,7 +25,6 @@ export interface InboxSeedBody {
   workspaceLabel?: string
   docs?: InboxDoc[]
   comments?: string
-  kind?: InboxKind
 }
 
 export const inboxApi = {

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -18,6 +18,7 @@ import { newsApi } from './news'
 import { topologyApi } from './topology'
 import { marketApi } from './market'
 import { notificationsApi } from './notifications'
+import { inboxApi } from './inbox'
 import { versionApi } from './version'
 export const api = {
   chat: chatApi,
@@ -36,6 +37,7 @@ export const api = {
   topology: topologyApi,
   market: marketApi,
   notifications: notificationsApi,
+  inbox: inboxApi,
   version: versionApi,
 }
 

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,7 +1,8 @@
-import { type LucideIcon, MessageSquare, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare } from 'lucide-react'
+import { type LucideIcon, MessageSquare, Inbox, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare } from 'lucide-react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
 import type { ActivitySection, ViewSpec } from '../tabs/types'
+import { useUnreadInboxCount } from '../live/inbox-read'
 
 /**
  * Map ActivityBar page enum (visual layout grouping) to the ActivitySection
@@ -10,6 +11,7 @@ import type { ActivitySection, ViewSpec } from '../tabs/types'
 function activitySectionFor(page: Page): ActivitySection {
   switch (page) {
     case 'chat':           return 'chat'
+    case 'inbox':          return 'inbox'
     case 'workspaces':     return 'workspaces'
     case 'trading-as-git': return 'trading-as-git'
     case 'settings':       return 'settings'
@@ -58,6 +60,7 @@ const NAV_SECTIONS: NavSection[] = [
     sectionLabel: '',
     items: [
       { page: 'chat',           label: 'Chat',           icon: MessageSquare },
+      { page: 'inbox',          label: 'Inbox',          icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
       { page: 'workspaces',     label: 'Workspaces',     icon: TerminalSquare },
       { page: 'portfolio',      label: 'Portfolio',      icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
       { page: 'trading-as-git', label: 'Trading as Git', icon: GitBranch },
@@ -86,6 +89,7 @@ export function ActivityBar({ open, onClose }: ActivityBarProps) {
   const selectedSidebar = useWorkspace((state) => state.selectedSidebar)
   const setSidebar = useWorkspace((state) => state.setSidebar)
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
+  const unreadInbox = useUnreadInboxCount()
 
   return (
     <>
@@ -168,8 +172,16 @@ export function ActivityBar({ open, onClose }: ActivityBarProps) {
                         }`}
                         aria-hidden
                       />
-                      <span className="flex items-center justify-center w-5 h-5">
+                      <span className="relative flex items-center justify-center w-5 h-5">
                         <Icon size={18} strokeWidth={1.5} />
+                        {item.page === 'inbox' && unreadInbox > 0 && (
+                          <span
+                            aria-label={`${unreadInbox} unread`}
+                            className="absolute -top-1 -right-1 min-w-[14px] h-[14px] px-1 rounded-full bg-red text-[9px] font-semibold text-white tabular-nums flex items-center justify-center"
+                          >
+                            {unreadInbox > 99 ? '99+' : unreadInbox}
+                          </span>
+                        )}
                       </span>
                       <span className="md:hidden">{item.label}</span>
                     </button>

--- a/ui/src/components/ChatChannelListContainer.tsx
+++ b/ui/src/components/ChatChannelListContainer.tsx
@@ -18,8 +18,10 @@ import { SidebarRow } from './SidebarRow'
  *     OpenAlice's ChatHook. Required for connectors (Telegram / MCP Ask
  *     / webhook) which have no PTY to host a CLI in.
  *
- * Above both: Notifications — a system-push surface that shares this
- * sidebar because the unifying mental model is "everything Alice-shaped".
+ * The legacy Notifications row sits inside the Traditional section because
+ * the old NotificationsStore is a pre-Workspace artifact — heartbeat / cron
+ * pushes were designed for the traditional single-session chat surface.
+ * Workspace-anchored pushes have their own top-level Inbox activity.
  *
  * Active row tracking is derived from the focused tab — switching tabs
  * naturally shifts the highlight without bespoke wiring.
@@ -35,29 +37,6 @@ export function ChatChannelListContainer() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="py-0.5 space-y-0.5">
-        <SidebarRow
-          label={
-            <span className="flex items-center gap-2">
-              <Bell size={14} strokeWidth={1.8} className="shrink-0" />
-              <span>Notifications</span>
-            </span>
-          }
-          active={inboxActive}
-          onClick={() => openOrFocus({ kind: 'notifications-inbox', params: {} })}
-          trail={
-            unreadCount > 0 ? (
-              <span
-                className="min-w-[16px] h-[16px] px-1 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center"
-                aria-label={`${unreadCount} unread`}
-              >
-                {unreadCount > 99 ? '99+' : unreadCount}
-              </span>
-            ) : undefined
-          }
-        />
-      </div>
-
       <div className="flex-1 overflow-y-auto min-h-0">
         <ChatWorkspaceSection />
 
@@ -65,6 +44,26 @@ export function ChatChannelListContainer() {
           Traditional
         </div>
         <div className="mt-0.5">
+          <SidebarRow
+            label={
+              <span className="flex items-center gap-2">
+                <Bell size={14} strokeWidth={1.8} className="shrink-0" />
+                <span>Notifications</span>
+              </span>
+            }
+            active={inboxActive}
+            onClick={() => openOrFocus({ kind: 'notifications-inbox', params: {} })}
+            trail={
+              unreadCount > 0 ? (
+                <span
+                  className="min-w-[16px] h-[16px] px-1 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center"
+                  aria-label={`${unreadCount} unread`}
+                >
+                  {unreadCount > 99 ? '99+' : unreadCount}
+                </span>
+              ) : undefined
+            }
+          />
           <ChatChannelList
             channels={channels}
             activeChannel={focusedChannelId}

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -139,12 +139,36 @@ function InboxRow({
         </span>
       </div>
 
-      {/* Line 2: text preview */}
+      {/* Line 2: preview — comments first line if present, else docs[0].path */}
       <div className={`pl-3 text-[11px] truncate ${unread ? 'text-text-muted' : 'text-text-muted/70'}`}>
-        {entry.text}
+        {previewFor(entry)}
       </div>
     </div>
   )
+}
+
+// ==================== Preview ====================
+
+/** Build the second-line preview text for a sidebar row.
+ *  - If the entry has comments, use its first non-empty line (strip
+ *    markdown markers minimally — `#`, `>`, `*`, `-` leaders).
+ *  - Otherwise fall back to the first doc's path.
+ *  - Otherwise empty (shouldn't happen — store rejects empty entries).
+ */
+function previewFor(entry: InboxEntry): string {
+  const c = (entry.comments ?? '').trim()
+  if (c) {
+    const firstLine = c.split('\n').find((l) => l.trim().length > 0) ?? ''
+    return firstLine.replace(/^[#>*\-]+\s*/, '').trim()
+  }
+  if (entry.docs && entry.docs.length > 0) {
+    const d = entry.docs[0]
+    if (d) {
+      const suffix = entry.docs.length > 1 ? ` · +${entry.docs.length - 1} more` : ''
+      return `📄 ${d.path}${suffix}`
+    }
+  }
+  return ''
 }
 
 // ==================== Grouping ====================

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -14,13 +14,26 @@ import type { InboxEntry } from '../api/inbox'
  *
  * Selection state lives in `useInboxSelection` so it survives sidebar
  * remounts and is read by the detail page in the editor area.
+ *
+ * Read semantics: **selection marks read**. Every place that mutates
+ * `useInboxSelection` (click / j/k / default-select) also calls
+ * `markRead(id)` — touching an entry is the canonical signal that
+ * you've seen it. Bulk-on-visibility is deliberately avoided (see
+ * inbox-read.ts doc for the rationale).
  */
 export function InboxSidebar() {
   const entries = inboxLive.useStore((s) => s.entries)
   const loading = inboxLive.useStore((s) => s.loading)
   const selectedId = useInboxSelection((s) => s.selectedEntryId)
   const select = useInboxSelection((s) => s.select)
-  const lastSeen = useInboxRead((s) => s.lastSeenTs)
+  const readIds = useInboxRead((s) => s.readIds)
+  const markRead = useInboxRead((s) => s.markRead)
+
+  /** select + mark read in one. Used by every selection mutation site. */
+  const selectAndRead = (id: string) => {
+    select(id)
+    markRead(id)
+  }
 
   // Default-select latest on first non-empty load. Latch on selectedId
   // existing — once the user touches anything, never override.
@@ -29,10 +42,11 @@ export function InboxSidebar() {
     if (everSelectedRef.current) return
     if (entries.length === 0) return
     if (!selectedId) {
-      select(entries[0].id)
+      selectAndRead(entries[0].id)
     }
     everSelectedRef.current = true
-  }, [entries, selectedId, select])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entries, selectedId])
 
   // Keyboard nav — j/k move within the flat newest-first sequence.
   useEffect(() => {
@@ -43,11 +57,12 @@ export function InboxSidebar() {
       if (entries.length === 0) return
       const idx = entries.findIndex((x) => x.id === selectedId)
       const next = e.key === 'j' ? Math.min(entries.length - 1, idx + 1) : Math.max(0, idx - 1)
-      if (next !== idx && entries[next]) select(entries[next].id)
+      if (next !== idx && entries[next]) selectAndRead(entries[next].id)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [entries, selectedId, select])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entries, selectedId])
 
   const groups = useMemo(() => groupByBucket(entries), [entries])
 
@@ -79,8 +94,8 @@ export function InboxSidebar() {
                 key={entry.id}
                 entry={entry}
                 active={entry.id === selectedId}
-                unread={entry.ts > lastSeen}
-                onClick={() => select(entry.id)}
+                unread={!readIds[entry.id]}
+                onClick={() => selectAndRead(entry.id)}
               />
             ))}
           </div>

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { inboxLive } from '../live/inbox'
+import { useInboxRead } from '../live/inbox-read'
+import { useInboxSelection } from '../live/inbox-selection'
+import type { InboxEntry, InboxKind } from '../api/inbox'
+
+const KIND_DOT: Record<InboxKind, string> = {
+  status: 'bg-accent',
+  done: 'bg-green',
+  blocked: 'bg-red',
+  question: 'bg-amber-400',
+}
+
+/**
+ * Inbox sidebar list. Linear-style:
+ * - Date-grouped (Today / Yesterday / This week / Older), newest-first
+ * - Each row: workspace label · relative time · text preview · unread state
+ * - j/k keyboard navigation; Enter opens (no-op here, page is already
+ *   rendering the selected detail)
+ * - Default-selects the newest entry on first load if none is selected.
+ *
+ * Selection state lives in `useInboxSelection` so it survives sidebar
+ * remounts and is read by the detail page in the editor area.
+ */
+export function InboxSidebar() {
+  const entries = inboxLive.useStore((s) => s.entries)
+  const loading = inboxLive.useStore((s) => s.loading)
+  const selectedId = useInboxSelection((s) => s.selectedEntryId)
+  const select = useInboxSelection((s) => s.select)
+  const lastSeen = useInboxRead((s) => s.lastSeenTs)
+
+  // Default-select latest on first non-empty load. Latch on selectedId
+  // existing — once the user touches anything, never override.
+  const everSelectedRef = useRef(false)
+  useEffect(() => {
+    if (everSelectedRef.current) return
+    if (entries.length === 0) return
+    if (!selectedId) {
+      select(entries[0].id)
+    }
+    everSelectedRef.current = true
+  }, [entries, selectedId, select])
+
+  // Keyboard nav — j/k move within the flat newest-first sequence.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      if (e.key !== 'j' && e.key !== 'k') return
+      if (entries.length === 0) return
+      const idx = entries.findIndex((x) => x.id === selectedId)
+      const next = e.key === 'j' ? Math.min(entries.length - 1, idx + 1) : Math.max(0, idx - 1)
+      if (next !== idx && entries[next]) select(entries[next].id)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [entries, selectedId, select])
+
+  const groups = useMemo(() => groupByBucket(entries), [entries])
+
+  if (loading && entries.length === 0) {
+    return <div className="px-3 py-3 text-[12px] text-text-muted">Loading…</div>
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="px-3 py-4 text-[12px] text-text-muted/70 leading-relaxed">
+        No inbox messages.
+        <div className="mt-1 text-text-muted/50">
+          Workspaces will push status updates here.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto py-0.5">
+      {groups.map(([bucket, items]) => (
+        <div key={bucket} className="mb-1">
+          <div className="px-3 mt-2 mb-1 text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
+            {bucket}
+          </div>
+          <div className="flex flex-col">
+            {items.map((entry) => (
+              <InboxRow
+                key={entry.id}
+                entry={entry}
+                active={entry.id === selectedId}
+                unread={entry.ts > lastSeen}
+                onClick={() => select(entry.id)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function InboxRow({
+  entry, active, unread, onClick,
+}: {
+  entry: InboxEntry
+  active: boolean
+  unread: boolean
+  onClick: () => void
+}) {
+  const dotColor = entry.kind ? KIND_DOT[entry.kind] : 'bg-text-muted/30'
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }}
+      className={`group relative flex flex-col gap-0.5 px-3 py-2 cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
+        active ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary/50'
+      }`}
+    >
+      {active && (
+        <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />
+      )}
+
+      {/* Line 1: dot · workspace · time */}
+      <div className="flex items-center gap-1.5">
+        <span
+          aria-hidden
+          className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? dotColor : 'bg-transparent border border-text-muted/30'}`}
+        />
+        <span className={`flex-1 truncate text-[12px] ${unread ? 'font-medium text-text' : 'text-text'}`}>
+          {entry.workspaceLabel ?? entry.workspaceId}
+        </span>
+        <span className="shrink-0 text-[10px] text-text-muted/60 tabular-nums">
+          {formatRelative(entry.ts)}
+        </span>
+      </div>
+
+      {/* Line 2: text preview */}
+      <div className={`pl-3 text-[11px] truncate ${unread ? 'text-text-muted' : 'text-text-muted/70'}`}>
+        {entry.text}
+      </div>
+    </div>
+  )
+}
+
+// ==================== Grouping ====================
+
+type Bucket = 'Today' | 'Yesterday' | 'This week' | 'Older'
+
+function groupByBucket(entries: readonly InboxEntry[]): Array<[Bucket, InboxEntry[]]> {
+  const now = Date.now()
+  const startOfDay = new Date(now)
+  startOfDay.setHours(0, 0, 0, 0)
+  const today = startOfDay.getTime()
+  const yesterday = today - 86_400_000
+  const weekStart = today - 6 * 86_400_000
+
+  const buckets: Record<Bucket, InboxEntry[]> = {
+    Today: [],
+    Yesterday: [],
+    'This week': [],
+    Older: [],
+  }
+
+  for (const e of entries) {
+    if (e.ts >= today) buckets.Today.push(e)
+    else if (e.ts >= yesterday) buckets.Yesterday.push(e)
+    else if (e.ts >= weekStart) buckets['This week'].push(e)
+    else buckets.Older.push(e)
+  }
+
+  const order: Bucket[] = ['Today', 'Yesterday', 'This week', 'Older']
+  return order
+    .map((b): [Bucket, InboxEntry[]] => [b, buckets[b]])
+    .filter(([, items]) => items.length > 0)
+}
+
+function formatRelative(ts: number): string {
+  const diff = Date.now() - ts
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s`
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h`
+  return `${Math.floor(diff / 86_400_000)}d`
+}

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -2,14 +2,7 @@ import { useEffect, useMemo, useRef } from 'react'
 import { inboxLive } from '../live/inbox'
 import { useInboxRead } from '../live/inbox-read'
 import { useInboxSelection } from '../live/inbox-selection'
-import type { InboxEntry, InboxKind } from '../api/inbox'
-
-const KIND_DOT: Record<InboxKind, string> = {
-  status: 'bg-accent',
-  done: 'bg-green',
-  blocked: 'bg-red',
-  question: 'bg-amber-400',
-}
+import type { InboxEntry } from '../api/inbox'
 
 /**
  * Inbox sidebar list. Linear-style:
@@ -105,7 +98,6 @@ function InboxRow({
   unread: boolean
   onClick: () => void
 }) {
-  const dotColor = entry.kind ? KIND_DOT[entry.kind] : 'bg-text-muted/30'
   return (
     <div
       role="button"
@@ -125,11 +117,11 @@ function InboxRow({
         <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />
       )}
 
-      {/* Line 1: dot · workspace · time */}
+      {/* Line 1: unread dot · workspace · time */}
       <div className="flex items-center gap-1.5">
         <span
           aria-hidden
-          className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? dotColor : 'bg-transparent border border-text-muted/30'}`}
+          className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-accent' : 'bg-transparent'}`}
         />
         <span className={`flex-1 truncate text-[12px] ${unread ? 'font-medium text-text' : 'text-text'}`}>
           {entry.workspaceLabel ?? entry.workspaceId}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -280,6 +280,42 @@ export async function listFiles(id: string, relPath: string): Promise<DirListing
   return (await res.json()) as DirListing;
 }
 
+/**
+ * Read a single UTF-8 text file from inside a workspace. Returns a
+ * discriminated result so the caller (Inbox detail pane) can render
+ * tombstone variants without parsing error strings.
+ */
+export type ReadFileResult =
+  | { kind: 'ok'; content: string }
+  | { kind: 'workspace_missing' }
+  | { kind: 'file_missing' }
+  | { kind: 'too_large'; sizeBytes: number }
+  | { kind: 'invalid_path' }
+  | { kind: 'error'; message: string };
+
+export async function readWorkspaceFile(id: string, relPath: string): Promise<ReadFileResult> {
+  const qs = `?path=${encodeURIComponent(relPath)}`;
+  let res: Response;
+  try {
+    res = await fetch(`/api/workspaces/${encodeURIComponent(id)}/file${qs}`);
+  } catch (err) {
+    return { kind: 'error', message: (err as Error).message };
+  }
+  if (res.ok) {
+    const body = (await res.json()) as { content: string };
+    return { kind: 'ok', content: body.content };
+  }
+  // Map known error shapes to discriminated variants. Unknown → generic error.
+  const body = (await res.json().catch(() => null)) as { error?: string; sizeBytes?: number } | null;
+  switch (body?.error) {
+    case 'workspace_not_found': return { kind: 'workspace_missing' };
+    case 'file_not_found':      return { kind: 'file_missing' };
+    case 'file_too_large':      return { kind: 'too_large', sizeBytes: body.sizeBytes ?? 0 };
+    case 'invalid_path':        return { kind: 'invalid_path' };
+    default:                    return { kind: 'error', message: body?.error ?? `HTTP ${res.status}` };
+  }
+}
+
 // ── Agent provider config ───────────────────────────────────────────────────
 
 export interface AgentProfile {

--- a/ui/src/live/inbox-read.ts
+++ b/ui/src/live/inbox-read.ts
@@ -2,39 +2,72 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { inboxLive } from './inbox'
 
+/**
+ * Per-entry read tracking for the Inbox — Linear-style.
+ *
+ * Why per-entry, not a timestamp watermark: in an inbox-flow product,
+ * "read" and "unread" are state-machine categories of attention, not
+ * cosmetic indicators. Bulk-marking everything read on page visit (the
+ * watermark approach) destroys the user's ability to triage — open inbox
+ * with 10 unread items, look at one, all 10 silently become read. Per-entry
+ * tracking preserves the "you've actively touched this one" semantic.
+ *
+ * Read state lives client-side in localStorage. Persists across reloads
+ * but not across devices (single-tenant local-only product; cross-device
+ * sync would need a server-side store).
+ */
+
 interface InboxReadState {
-  /** Wall-clock ms of the latest inbox entry the user has seen. */
-  lastSeenTs: number
+  /** Set of entry ids the user has marked read. Object-shaped (not Set)
+   *  for Zustand `persist` compatibility — Set doesn't survive JSON. */
+  readIds: Record<string, true>
 }
 
 interface InboxReadActions {
+  /** Mark a single entry as read. Called by the sidebar when an entry
+   *  becomes selected (click, j/k nav, default-select-latest). */
+  markRead: (id: string) => void
+  /** Mark a single entry as unread — reverses markRead. UI affordance
+   *  to expose this (a context-menu "Mark unread" item, hover button,
+   *  shift+u shortcut) is parked for v1; the action is here so it's
+   *  trivial to wire when we decide to add it. */
+  markUnread: (id: string) => void
+  /** Mark every currently-loaded entry as read. Reserved for a future
+   *  explicit "Mark all as read" button — not auto-fired anywhere. */
   markAllRead: () => void
 }
 
-/**
- * Tracks "latest inbox entry timestamp the user has acknowledged."
- * Combined with `inboxLive.entries` this yields an unread count without
- * per-entry state. Persists to localStorage so unread state survives
- * reloads. Parallel to useNotificationsRead.
- */
 export const useInboxRead = create<InboxReadState & InboxReadActions>()(
   persist(
     (set) => ({
-      lastSeenTs: 0,
+      readIds: {},
+      markRead: (id) =>
+        set((s) => (s.readIds[id] ? s : { readIds: { ...s.readIds, [id]: true } })),
+      markUnread: (id) =>
+        set((s) => {
+          if (!s.readIds[id]) return s
+          const next = { ...s.readIds }
+          delete next[id]
+          return { readIds: next }
+        }),
       markAllRead: () => {
         const { entries } = inboxLive.getState()
         if (entries.length === 0) return
-        const latest = entries[0].ts
-        set((s) => (s.lastSeenTs >= latest ? s : { lastSeenTs: latest }))
+        set((s) => {
+          const next = { ...s.readIds }
+          for (const e of entries) next[e.id] = true
+          return { readIds: next }
+        })
       },
     }),
-    { name: 'openalice.inbox-read.v1', version: 1 },
+    { name: 'openalice.inbox-read.v2', version: 2 },
   ),
 )
 
+/** Activity-bar badge count: entries whose id isn't in `readIds`. */
 export function useUnreadInboxCount(): number {
-  const lastSeen = useInboxRead((s) => s.lastSeenTs)
+  const readIds = useInboxRead((s) => s.readIds)
   return inboxLive.useStore((s) =>
-    s.entries.reduce((n, e) => (e.ts > lastSeen ? n + 1 : n), 0),
+    s.entries.reduce((n, e) => (readIds[e.id] ? n : n + 1), 0),
   )
 }

--- a/ui/src/live/inbox-read.ts
+++ b/ui/src/live/inbox-read.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { inboxLive } from './inbox'
+
+interface InboxReadState {
+  /** Wall-clock ms of the latest inbox entry the user has seen. */
+  lastSeenTs: number
+}
+
+interface InboxReadActions {
+  markAllRead: () => void
+}
+
+/**
+ * Tracks "latest inbox entry timestamp the user has acknowledged."
+ * Combined with `inboxLive.entries` this yields an unread count without
+ * per-entry state. Persists to localStorage so unread state survives
+ * reloads. Parallel to useNotificationsRead.
+ */
+export const useInboxRead = create<InboxReadState & InboxReadActions>()(
+  persist(
+    (set) => ({
+      lastSeenTs: 0,
+      markAllRead: () => {
+        const { entries } = inboxLive.getState()
+        if (entries.length === 0) return
+        const latest = entries[0].ts
+        set((s) => (s.lastSeenTs >= latest ? s : { lastSeenTs: latest }))
+      },
+    }),
+    { name: 'openalice.inbox-read.v1', version: 1 },
+  ),
+)
+
+export function useUnreadInboxCount(): number {
+  const lastSeen = useInboxRead((s) => s.lastSeenTs)
+  return inboxLive.useStore((s) =>
+    s.entries.reduce((n, e) => (e.ts > lastSeen ? n + 1 : n), 0),
+  )
+}

--- a/ui/src/live/inbox-selection.ts
+++ b/ui/src/live/inbox-selection.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+/**
+ * Client-side selection state for the Inbox. Lives outside `ViewSpec` so
+ * that selecting a different entry from the sidebar doesn't churn tab
+ * identity (one Inbox tab, selection mutates inside it — Linear-style).
+ *
+ * Not persisted: selection is ephemeral UI state, no value to remember
+ * across reloads.
+ */
+
+interface InboxSelectionState {
+  selectedEntryId: string | null
+}
+
+interface InboxSelectionActions {
+  select: (id: string | null) => void
+}
+
+export const useInboxSelection = create<InboxSelectionState & InboxSelectionActions>()((set) => ({
+  selectedEntryId: null,
+  select: (id) => set({ selectedEntryId: id }),
+}))

--- a/ui/src/live/inbox.ts
+++ b/ui/src/live/inbox.ts
@@ -1,0 +1,47 @@
+import { api } from '../api'
+import type { InboxEntry } from '../api/inbox'
+import { createLiveStore } from './createLiveStore'
+
+/**
+ * Live inbox feed. 20s polling against `/api/inbox/history`. Mirrors the
+ * notifications live store — same rationale: passive feed, SSE not worth
+ * the kept-open-connection cost.
+ *
+ * Single shared connection via LiveStore refcount; multiple subscribers
+ * (sidebar list, detail page, Activity bar unread badge) share one timer.
+ */
+
+export interface InboxState {
+  entries: InboxEntry[]
+  /** True until the initial history fetch resolves. UI shows a skeleton. */
+  loading: boolean
+}
+
+const POLL_INTERVAL_MS = 20_000
+
+export const inboxLive = createLiveStore<InboxState>({
+  name: 'inbox',
+  initialState: { entries: [], loading: true },
+  subscribe: ({ apply }) => {
+    let disposed = false
+
+    async function refresh() {
+      try {
+        const { entries } = await api.inbox.history({ limit: 100 })
+        if (disposed) return
+        apply((prev) => ({ ...prev, entries, loading: false }))
+      } catch {
+        if (disposed) return
+        apply((prev) => ({ ...prev, loading: false }))
+      }
+    }
+
+    void refresh()
+    const intervalId = setInterval(refresh, POLL_INTERVAL_MS)
+
+    return () => {
+      disposed = true
+      clearInterval(intervalId)
+    }
+  },
+})

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { PageHeader } from '../components/PageHeader'
+import { MarkdownContent } from '../components/MarkdownContent'
 import { inboxLive } from '../live/inbox'
 import { useInboxRead } from '../live/inbox-read'
 import { useInboxSelection } from '../live/inbox-selection'
-import type { InboxEntry, InboxKind } from '../api/inbox'
+import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
+import type { InboxEntry, InboxKind, InboxDoc } from '../api/inbox'
 
 const KIND_COLORS: Record<InboxKind, string> = {
   status: 'bg-accent/15 text-accent',
@@ -24,17 +26,11 @@ interface InboxPageProps {
 }
 
 /**
- * Inbox detail pane — rendered in the editor area. The list lives in
- * `InboxSidebar` (Chat-sidebar-shape); selecting a row in the sidebar
- * updates `useInboxSelection`, which this component watches.
+ * Inbox detail pane. Renders the selected entry's docs (live from
+ * workspace) on top, comments (agent's markdown body) below — fixed
+ * order, mirroring Linear's issue-body + activity layout.
  *
- * Default-select-latest is handled by the sidebar (it owns the list);
- * this component just reflects whatever is selected. When nothing is
- * selected it shows an empty state.
- *
- * Mark-read: when this pane becomes visible AND there's a selection,
- * mark all newer-than-the-latest entries read. Mirrors the
- * NotificationsInboxPage timing.
+ * Selection is owned by `useInboxSelection`; the sidebar drives it.
  */
 export function InboxPage({ visible }: InboxPageProps) {
   const entries = inboxLive.useStore((s) => s.entries)
@@ -88,10 +84,14 @@ function EmptyState() {
 }
 
 function Detail({ entry, unread }: { entry: InboxEntry; unread: boolean }) {
+  const hasDocs = (entry.docs?.length ?? 0) > 0
+  const hasComments = (entry.comments ?? '').trim().length > 0
+
   return (
     <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
-      <div className="flex items-center gap-2 mb-3 flex-wrap">
-        <span className="text-[13px] font-medium text-text">
+      {/* Header: workspace · kind · timestamp */}
+      <div className="flex items-center gap-2 mb-4 flex-wrap">
+        <span className="text-[14px] font-medium text-text">
           {entry.workspaceLabel ?? entry.workspaceId}
         </span>
         {entry.kind && (
@@ -111,16 +111,109 @@ function Detail({ entry, unread }: { entry: InboxEntry; unread: boolean }) {
         </span>
       </div>
 
-      <div className="text-[13px] text-text whitespace-pre-wrap break-words leading-relaxed border-t border-border pt-4">
-        {entry.text}
-      </div>
+      {/* Docs — top, live render from workspace */}
+      {hasDocs && (
+        <div className="space-y-6">
+          {entry.docs!.map((doc) => (
+            <DocBlock key={doc.path} workspaceId={entry.workspaceId} doc={doc} />
+          ))}
+        </div>
+      )}
 
-      <div className="mt-6 flex items-center gap-2 text-[12px] text-text-muted">
-        <span className="font-mono text-text-muted/60">workspace: {entry.workspaceId}</span>
+      {/* Comments — bottom, agent's voice */}
+      {hasComments && (
+        <div className={`${hasDocs ? 'mt-8 pt-6 border-t border-border' : ''}`}>
+          <div className="text-[11px] font-medium text-text-muted/60 uppercase tracking-wider mb-3">
+            Comments
+          </div>
+          <MarkdownContent text={entry.comments!} />
+        </div>
+      )}
+
+      <div className="mt-8 pt-4 border-t border-border/50 text-[12px] text-text-muted/60 font-mono">
+        workspace: {entry.workspaceId}
       </div>
     </div>
   )
 }
+
+// ==================== Doc block (live fetch from workspace) ====================
+
+function DocBlock({ workspaceId, doc }: { workspaceId: string; doc: InboxDoc }) {
+  const [result, setResult] = useState<ReadFileResult | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setResult(null)
+    readWorkspaceFile(workspaceId, doc.path).then((r) => {
+      if (!cancelled) setResult(r)
+    })
+    return () => { cancelled = true }
+  }, [workspaceId, doc.path])
+
+  return (
+    <div className="rounded-lg border border-border bg-bg/50">
+      <div className="px-4 py-2 border-b border-border/50 flex items-center gap-2">
+        <span className="text-[11px] text-text-muted/70">📄</span>
+        <span className="text-[12px] font-mono text-text-muted">{doc.path}</span>
+      </div>
+      <div className="px-4 py-3">
+        {result === null ? (
+          <div className="text-[12px] text-text-muted">Loading…</div>
+        ) : result.kind === 'ok' ? (
+          <DocContent path={doc.path} content={result.content} />
+        ) : (
+          <DocTombstone result={result} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DocContent({ path, content }: { path: string; content: string }) {
+  const lower = path.toLowerCase()
+  if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
+    return <MarkdownContent text={content} />
+  }
+  if (lower.endsWith('.html') || lower.endsWith('.htm')) {
+    // DOMPurify sanitisation is inside MarkdownContent; for raw HTML we
+    // run it through the markdown renderer too — marked passes HTML
+    // through, then DOMPurify sanitises before insertion.
+    return <MarkdownContent text={content} />
+  }
+  // Plain-text fallback (.txt, .log, no extension, code files…)
+  return (
+    <pre className="text-[12px] text-text whitespace-pre-wrap font-mono leading-relaxed">
+      {content}
+    </pre>
+  )
+}
+
+function DocTombstone({ result }: { result: ReadFileResult }) {
+  const message = (() => {
+    switch (result.kind) {
+      case 'workspace_missing':
+        return 'Workspace no longer exists — it may have been deleted.'
+      case 'file_missing':
+        return 'File not found at this path — it may have been moved, renamed, or deleted in the workspace since this notification was sent.'
+      case 'too_large':
+        return `File too large to render in inbox (${(result.sizeBytes / 1024).toFixed(0)} KB). Open the workspace to view.`
+      case 'invalid_path':
+        return 'Invalid path.'
+      case 'error':
+        return `Could not read file: ${result.message}`
+      case 'ok':
+        return ''
+    }
+  })()
+  return (
+    <div className="text-[12px] text-text-muted italic">
+      {message}
+    </div>
+  )
+}
+
+// ==================== Date formatting ====================
 
 function formatAbsolute(ts: number): string {
   return new Date(ts).toLocaleString(undefined, {

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react'
 import { PageHeader } from '../components/PageHeader'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { inboxLive } from '../live/inbox'
-import { useInboxRead } from '../live/inbox-read'
 import { useInboxSelection } from '../live/inbox-selection'
 import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
 import type { InboxEntry, InboxDoc } from '../api/inbox'
 
 interface InboxPageProps {
+  /** Required by the tab registry shape; not used here — read state is
+   *  per-entry and driven by selection, not by page visibility. */
   visible: boolean
 }
 
@@ -17,17 +18,13 @@ interface InboxPageProps {
  * order, mirroring Linear's issue-body + activity layout.
  *
  * Selection is owned by `useInboxSelection`; the sidebar drives it.
+ * Read-state mutation happens in the sidebar at selection time — this
+ * pane just renders whatever is selected.
  */
-export function InboxPage({ visible }: InboxPageProps) {
+export function InboxPage(_props: InboxPageProps) {
   const entries = inboxLive.useStore((s) => s.entries)
   const loading = inboxLive.useStore((s) => s.loading)
   const selectedId = useInboxSelection((s) => s.selectedEntryId)
-  const markAllRead = useInboxRead((s) => s.markAllRead)
-  const lastSeen = useInboxRead((s) => s.lastSeenTs)
-
-  useEffect(() => {
-    if (visible && entries.length > 0) markAllRead()
-  }, [visible, entries.length, markAllRead])
 
   const selected = entries.find((e) => e.id === selectedId) ?? null
 
@@ -47,7 +44,7 @@ export function InboxPage({ visible }: InboxPageProps) {
             Select an entry from the sidebar.
           </div>
         ) : (
-          <Detail entry={selected} unread={selected.ts > lastSeen} />
+          <Detail entry={selected} />
         )}
       </div>
     </div>
@@ -69,22 +66,20 @@ function EmptyState() {
   )
 }
 
-function Detail({ entry, unread }: { entry: InboxEntry; unread: boolean }) {
+function Detail({ entry }: { entry: InboxEntry }) {
   const hasDocs = (entry.docs?.length ?? 0) > 0
   const hasComments = (entry.comments ?? '').trim().length > 0
 
   return (
     <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
-      {/* Header: workspace · timestamp */}
+      {/* Header: workspace · timestamp. No "New" chip — selection always
+       *  marks read, so by the time the detail pane renders the entry is
+       *  read by definition; the chip would only ever flash for one
+       *  render. The sidebar dot is the canonical unread signal. */}
       <div className="flex items-center gap-2 mb-4 flex-wrap">
         <span className="text-[14px] font-medium text-text">
           {entry.workspaceLabel ?? entry.workspaceId}
         </span>
-        {unread && (
-          <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/15 text-accent">
-            New
-          </span>
-        )}
         <span className="text-[11px] text-text-muted/70 tabular-nums ml-auto">
           {formatAbsolute(entry.ts)}
           <span className="mx-1.5 text-text-muted/40">·</span>

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -1,0 +1,138 @@
+import { useEffect } from 'react'
+import { PageHeader } from '../components/PageHeader'
+import { inboxLive } from '../live/inbox'
+import { useInboxRead } from '../live/inbox-read'
+import { useInboxSelection } from '../live/inbox-selection'
+import type { InboxEntry, InboxKind } from '../api/inbox'
+
+const KIND_COLORS: Record<InboxKind, string> = {
+  status: 'bg-accent/15 text-accent',
+  done: 'bg-green/15 text-green',
+  blocked: 'bg-red/15 text-red',
+  question: 'bg-amber-500/15 text-amber-400',
+}
+
+const KIND_LABELS: Record<InboxKind, string> = {
+  status: 'Status',
+  done: 'Done',
+  blocked: 'Blocked',
+  question: 'Question',
+}
+
+interface InboxPageProps {
+  visible: boolean
+}
+
+/**
+ * Inbox detail pane — rendered in the editor area. The list lives in
+ * `InboxSidebar` (Chat-sidebar-shape); selecting a row in the sidebar
+ * updates `useInboxSelection`, which this component watches.
+ *
+ * Default-select-latest is handled by the sidebar (it owns the list);
+ * this component just reflects whatever is selected. When nothing is
+ * selected it shows an empty state.
+ *
+ * Mark-read: when this pane becomes visible AND there's a selection,
+ * mark all newer-than-the-latest entries read. Mirrors the
+ * NotificationsInboxPage timing.
+ */
+export function InboxPage({ visible }: InboxPageProps) {
+  const entries = inboxLive.useStore((s) => s.entries)
+  const loading = inboxLive.useStore((s) => s.loading)
+  const selectedId = useInboxSelection((s) => s.selectedEntryId)
+  const markAllRead = useInboxRead((s) => s.markAllRead)
+  const lastSeen = useInboxRead((s) => s.lastSeenTs)
+
+  useEffect(() => {
+    if (visible && entries.length > 0) markAllRead()
+  }, [visible, entries.length, markAllRead])
+
+  const selected = entries.find((e) => e.id === selectedId) ?? null
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <PageHeader
+        title="Inbox"
+        description={`${entries.length} total · workspace status updates`}
+      />
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {loading && entries.length === 0 ? (
+          <div className="px-6 py-8 text-text-muted text-sm">Loading…</div>
+        ) : entries.length === 0 ? (
+          <EmptyState />
+        ) : !selected ? (
+          <div className="px-6 py-8 text-text-muted text-sm">
+            Select an entry from the sidebar.
+          </div>
+        ) : (
+          <Detail entry={selected} unread={selected.ts > lastSeen} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="px-6 py-16 text-center max-w-[520px] mx-auto">
+      <div className="text-[15px] text-text mb-2">No inbox messages yet</div>
+      <p className="text-[13px] text-text-muted leading-relaxed">
+        Workspaces will push status updates here as they work — finished
+        analysis, blocked tasks, questions back to you. The integration
+        path is still being designed; for now you can seed entries via
+        <code className="mx-1 px-1 py-0.5 rounded bg-bg-tertiary text-[11px]">POST /api/inbox/seed</code>
+        for testing.
+      </p>
+    </div>
+  )
+}
+
+function Detail({ entry, unread }: { entry: InboxEntry; unread: boolean }) {
+  return (
+    <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <span className="text-[13px] font-medium text-text">
+          {entry.workspaceLabel ?? entry.workspaceId}
+        </span>
+        {entry.kind && (
+          <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${KIND_COLORS[entry.kind]}`}>
+            {KIND_LABELS[entry.kind]}
+          </span>
+        )}
+        {unread && (
+          <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/15 text-accent">
+            New
+          </span>
+        )}
+        <span className="text-[11px] text-text-muted/70 tabular-nums ml-auto">
+          {formatAbsolute(entry.ts)}
+          <span className="mx-1.5 text-text-muted/40">·</span>
+          {formatRelative(entry.ts)}
+        </span>
+      </div>
+
+      <div className="text-[13px] text-text whitespace-pre-wrap break-words leading-relaxed border-t border-border pt-4">
+        {entry.text}
+      </div>
+
+      <div className="mt-6 flex items-center gap-2 text-[12px] text-text-muted">
+        <span className="font-mono text-text-muted/60">workspace: {entry.workspaceId}</span>
+      </div>
+    </div>
+  )
+}
+
+function formatAbsolute(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+function formatRelative(ts: number): string {
+  const diff = Date.now() - ts
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return `${Math.floor(diff / 86_400_000)}d ago`
+}

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -5,21 +5,7 @@ import { inboxLive } from '../live/inbox'
 import { useInboxRead } from '../live/inbox-read'
 import { useInboxSelection } from '../live/inbox-selection'
 import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
-import type { InboxEntry, InboxKind, InboxDoc } from '../api/inbox'
-
-const KIND_COLORS: Record<InboxKind, string> = {
-  status: 'bg-accent/15 text-accent',
-  done: 'bg-green/15 text-green',
-  blocked: 'bg-red/15 text-red',
-  question: 'bg-amber-500/15 text-amber-400',
-}
-
-const KIND_LABELS: Record<InboxKind, string> = {
-  status: 'Status',
-  done: 'Done',
-  blocked: 'Blocked',
-  question: 'Question',
-}
+import type { InboxEntry, InboxDoc } from '../api/inbox'
 
 interface InboxPageProps {
   visible: boolean
@@ -89,16 +75,11 @@ function Detail({ entry, unread }: { entry: InboxEntry; unread: boolean }) {
 
   return (
     <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
-      {/* Header: workspace · kind · timestamp */}
+      {/* Header: workspace · timestamp */}
       <div className="flex items-center gap-2 mb-4 flex-wrap">
         <span className="text-[14px] font-medium text-text">
           {entry.workspaceLabel ?? entry.workspaceId}
         </span>
-        {entry.kind && (
-          <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${KIND_COLORS[entry.kind]}`}>
-            {KIND_LABELS[entry.kind]}
-          </span>
-        )}
         {unread && (
           <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-accent/15 text-accent">
             New

--- a/ui/src/sections.tsx
+++ b/ui/src/sections.tsx
@@ -14,6 +14,7 @@
 import type { ComponentType } from 'react'
 import { ChatChannelListContainer } from './components/ChatChannelListContainer'
 import { NewChannelButton } from './components/NewChannelButton'
+import { InboxSidebar } from './components/InboxSidebar'
 import { WorkspacesSidebar } from './components/workspace/WorkspacesSidebar'
 import { PushApprovalPanel } from './components/PushApprovalPanel'
 import { SettingsCategoryList } from './components/SettingsCategoryList'
@@ -38,6 +39,10 @@ const SECTION_BY_KEY: Record<ActivitySection, SidebarSection> = {
     title: 'Chat',
     Secondary: ChatChannelListContainer,
     Actions: NewChannelButton,
+  },
+  inbox: {
+    title: 'Inbox',
+    Secondary: InboxSidebar,
   },
   workspaces: {
     title: 'Workspaces',

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -55,8 +55,11 @@ export function UrlAdopter() {
         <Route path="/dev" element={<Navigate to="/dev/connectors" replace />} />
         <Route path="/dev/:tab" element={<AdoptDev />} />
 
-        {/* Notifications inbox */}
+        {/* Notifications inbox (legacy — Chat sidebar) */}
         <Route path="/notifications" element={<AdoptStatic spec={{ kind: 'notifications-inbox', params: {} }} />} />
+
+        {/* Inbox (workspace-anchored, Linear-style) */}
+        <Route path="/inbox" element={<AdoptStatic spec={{ kind: 'inbox', params: {} }} />} />
 
         {/* Workspaces */}
         <Route path="/workspaces" element={<AdoptStatic spec={{ kind: 'workspace-list', params: {} }} />} />

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -19,6 +19,7 @@ import { NewsCollectorPage } from '../pages/NewsCollectorPage'
 import { UTADetailPage } from '../pages/UTADetailPage'
 import { DevPage } from '../pages/DevPage'
 import { NotificationsInboxPage } from '../pages/NotificationsInboxPage'
+import { InboxPage } from '../pages/InboxPage'
 import { WorkspaceListPage } from '../pages/WorkspaceListPage'
 import { WorkspacePage } from '../pages/WorkspacePage'
 
@@ -180,6 +181,13 @@ const notificationsInboxModule: ViewModule<'notifications-inbox'> = {
   Component: NotificationsInboxPage,
 }
 
+const inboxModule: ViewModule<'inbox'> = {
+  kind: 'inbox',
+  title: () => 'Inbox',
+  toUrl: () => '/inbox',
+  Component: InboxPage,
+}
+
 const workspaceListModule: ViewModule<'workspace-list'> = {
   kind: 'workspace-list',
   title: () => 'Workspaces',
@@ -219,6 +227,7 @@ export const VIEWS = {
   'uta-detail': utaDetailModule,
   dev: devModule,
   'notifications-inbox': notificationsInboxModule,
+  inbox: inboxModule,
   'workspace-list': workspaceListModule,
   workspace: workspaceModule,
 } as const satisfies { [K in ViewKind]: ViewModule<K> }

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -26,6 +26,7 @@ export type ViewSpec =
   | { kind: 'uta-detail';     params: { id: string } }
   | { kind: 'dev';            params: { tab: 'connectors' | 'tools' | 'sessions' | 'snapshots' | 'logs' | 'simulator' } }
   | { kind: 'notifications-inbox'; params: Record<string, never> }
+  | { kind: 'inbox';               params: Record<string, never> }
 
 export type ViewKind = ViewSpec['kind']
 
@@ -41,6 +42,7 @@ export type ViewKind = ViewSpec['kind']
  */
 export type ActivitySection =
   | 'chat'
+  | 'inbox'
   | 'workspaces'
   | 'trading-as-git'
   | 'settings'


### PR DESCRIPTION
## Summary

Adds a workspace-anchored Inbox system parallel to the legacy NotificationsStore. Linear-style mental model — workspace = atomic unit, agent inside it pushes docs (live-rendered from workspace files) + comments (markdown) to a per-entry-read inbox. The MCP server now exposes a per-workspace route (`/mcp/:wsId`) so the agent's inbox-push tool has workspaceId injected from URL identity, never asked of the agent.

Old Notifications system stays intact, relocated to the Traditional section of the Chat sidebar (signals its pre-Workspace lineage without breaking existing users). The legacy `notify_user` tool description is reworded to dissuade workspace-era agents from picking it accidentally.

## Per-session contributions

### 2026-05-15 — Inbox v0 + MCP integration

**v0 — backend store + sidebar + detail pane** (`31a30e3`):
- `InboxStore` JSONL at `data/inbox/entries.jsonl`, append-only, workspaceId required
- `GET /api/inbox/history` + dev-only `POST /api/inbox/seed`
- Activity bar Inbox icon (lucide `Inbox`) with red unread badge
- Linear-style two-column UI: sidebar list (date-grouped) + editor detail pane
- Selection state owned by `useInboxSelection` (Zustand) so one stable Inbox tab
- Old `🔔 Notifications` row moved from top of Chat sidebar to first row of Traditional section

**v0.5 — docs + comments schema, live workspace file render** (`606edb7`):
- `InboxEntry` schema: `docs?: Array<{path}>` + `comments?: string`, replacing flat `text`
- Workspace files rendered live (no snapshot; workspace git is SOR)
- New `GET /api/workspaces/:id/file?path=` (1 MiB cap, traversal-guarded, discriminated 404s)
- Tombstone fallback for missing files / deleted workspaces — loud not silent
- Multi-doc support: stack-rendered with per-doc path headers, comments always below docs

**Drop `kind` field** (`5500602`) — Linear inbox has no notification category chip; reverting an invented UI affordance keeps the schema tight (-43 LOC).

**Per-entry read state** (`bf5ad5a`):
- `lastSeenTs` watermark → `readIds: Record<string, true>`, localStorage v2
- Selection is the canonical read signal (click / j-k / default-select-latest all call `markRead`)
- "New" chip removed (would only flash one frame before selection marks read)
- `markUnread` action wired but UI not exposed (future hover/context-menu)

**inbox_push MCP tool via per-workspace `/mcp/:wsId` route** (`29739ef`):
- `WorkspaceToolCenter` — new registry for **factories** (each closes over wsId at request time)
- `src/server/mcp.ts` two routes: `/mcp` (global, 49 tools, ToolCenter) + `/mcp/:wsId` (workspace-scoped, currently just `inbox_push`)
- Schema sees only `{ docs?, comments? }` — workspaceId carried by URL, invisible to agent, forgery structurally impossible
- `WorkspaceServiceRef` cross-plugin hand-off so McpPlugin can resolve workspaces (WebPlugin starts later but registers the service first)
- `bootstrap.sh` bakes `__WS_ID__` placeholder into per-workspace `.mcp.json` URL; template now declares two MCP server entries
- Existing workspaces deliberately not migrated — Workspace is experimental, schema bumps don't get migration scripts

**Stray-screenshot gitignore** (`8072f58`) — block `/*.png /*.jpg /*.jpeg` at repo root after Playwright captures landed there during verification.

**Mark `notify_user` deprecated in description** (`675aab8`) — agents in workspace sessions occasionally reach for the legacy tool when `inbox_push` is correct. Reword description to lead with `[DEPRECATED — legacy Automation path only]`, forbid use from inside a workspace, point at `inbox_push`. Behaviour unchanged; tool stays registered because the heartbeat / cron / task.requested outputGate depends on the exact name.

Key commits: `31a30e3` `606edb7` `5500602` `bf5ad5a` `29739ef` `8072f58` `675aab8`

## Full commit log
```
675aab8 chore(tools): mark notify_user as deprecated in description
8072f58 chore(gitignore): block stray screenshots at repo root
29739ef feat(inbox): inbox_push MCP tool via per-workspace /mcp/:wsId route
bf5ad5a refactor(inbox): per-entry read state, drop watermark model
5500602 refactor(inbox): drop kind field — Linear inbox has no such category
606edb7 feat(inbox): docs + comments schema, live render from workspace
31a30e3 feat(inbox): add workspace-anchored Inbox v0 alongside legacy notifications
```

## Test plan
- [x] `npx tsc --noEmit` clean (backend + UI)
- [x] `pnpm test` — 1707/1707 passes (10 new InboxStore tests)
- [x] `pnpm --filter ./ui build` clean
- [x] End-to-end MCP: fresh workspace → `tools/list` returns `inbox_push` with no workspaceId in schema → `tools/call` lands real entry in inbox JSONL with workspaceId injected from URL
- [x] Browser verification (Playwright):
  - Activity bar Inbox icon shows correct unread badge
  - Sidebar list date-grouped, default-select-latest, j/k nav
  - Doc with real file → markdown renders
  - Doc with missing file → tombstone with friendly message
  - Multi-doc → stack rendering with per-doc headers
  - Comments-only / docs-only / mixed forms all render correctly
  - Per-entry read state (badge decrements 1 per click, not bulk)
  - Old `🔔 Notifications` row visible in Traditional section, unread state independent from Inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)