### PR TITLE
feat(inbox): jump-to-workspace reply bar + notify_user deprecation

### DIFF
--- a/src/tool/notify-user.ts
+++ b/src/tool/notify-user.ts
@@ -2,46 +2,55 @@ import { tool } from 'ai'
 import { z } from 'zod'
 
 /**
- * notify_user — Alice's structured way to express "deliver this to
- * the user" intent during autonomous work.
+ * notify_user — **DEPRECATED legacy tool**.
  *
- * Used by the heartbeat trigger source to replace the legacy STATUS
- * regex protocol (`STATUS: HEARTBEAT_OK | CHAT_YES + CONTENT: ...`).
- * The runner-side outputGate inspects the captured tool calls in
- * `ProviderResult.toolCalls`; if `notify_user` was invoked, the gate
- * routes the tool's `text` arg through the configured dedup window
- * and into `connectorCenter.notify`.
+ * Exists only to serve the Automation legacy path (heartbeat / cron /
+ * external `task.requested`) which pre-dates Workspace. The AgentWork
+ * outputGate inspects `ProviderResult.toolCalls` for this name and
+ * routes the `text` arg through dedup → `connectorCenter.notify` →
+ * the legacy NotificationsStore.
+ *
+ * Workspace-era agents should use `inbox_push` (exposed at
+ * `/mcp/:wsId`) instead — it writes to the new workspace-anchored
+ * Inbox and supports docs + comments. `notify_user` plain-text
+ * notifications are a strictly lesser surface and exist only so the
+ * pre-Workspace Automation flows keep working until they retire.
  *
  * **Why no side-effects in execute**: the actual delivery is gated
- * by the AgentWork outputGate (heartbeat applies dedup, future
- * triggers might apply other policies). Putting `connectorCenter.notify`
- * inside the tool's execute would make those gates impossible without
- * per-tool-instance source state. The runner-side gate is the right
- * control point. The tool's job is purely to signal intent + arguments.
+ * by the AgentWork outputGate; this tool is intent-only and the
+ * runner is the control point.
  *
- * Globally registered by ToolCenter — every session sees it in its
- * tool catalog. But only sessions whose persona prompt teaches Alice
- * when to call it (today: heartbeat) actually exercise it. cron and
- * task-router sessions don't reference it in their preambles, so AI
- * keeps its current "every reply pushes" behaviour.
+ * Globally registered by ToolCenter — visible to every session. The
+ * description below tries to dissuade workspace agents from picking
+ * it accidentally; if you find a workspace agent still reaching for
+ * it, treat that as a description-tuning bug, not a tool-registration
+ * one (removing it would break the heartbeat / cron paths that
+ * legitimately depend on it).
  */
 export function createNotifyUserTool() {
   return {
     notify_user: tool({
       description: [
-        'Send a notification to the user. Use this during autonomous',
-        'work (heartbeat / cron / external task) when something is',
-        'worth surfacing — a market event, a finished analysis,',
-        'a heads-up. Write the body in the user\'s language. Do not',
-        'call this redundantly — one call per cycle is the norm. If',
-        'nothing is worth flagging, simply do not call this tool.',
+        '[DEPRECATED — legacy Automation path only]',
+        'Send a plain-text notification through the legacy',
+        'NotificationsStore.',
+        '',
+        'Do NOT use this tool if you are inside a Workspace —',
+        'use `inbox_push` instead (exposed at the workspace-scoped',
+        'MCP server). `inbox_push` supports doc references + markdown',
+        'comments and is the correct path for workspace agents.',
+        '',
+        'This tool exists only for pre-Workspace Automation flows',
+        '(heartbeat / cron / external task.requested triggers) whose',
+        'AgentWork outputGate inspects this tool call. If neither of',
+        'those is your context, do not call this.',
       ].join(' '),
       inputSchema: z.object({
         text: z
           .string()
           .min(1)
           .describe(
-            'The notification body, in the user\'s language. Keep it concise — under ~300 chars where possible.',
+            'The notification body, in the user\'s language. Keep it concise — under ~300 chars where possible. Plain text only; markdown is not rendered downstream.',
           ),
         urgency: z
           .enum(['info', 'important'])


### PR DESCRIPTION
## Summary

Follow-ups to the freshly-merged Inbox v0 (PR #187):

1. **Jump-to-workspace as a Linear-style reply bar** below the inbox detail pane's comments — replacing the original floating CTA which was buried below long doc content and read as an awkward "open" button rather than a continuation of the conversation.
2. **Legacy `notify_user` tool description** reworded to lead with `[DEPRECATED]` and forbid workspace-era use.

## Per-session contributions

### 2026-05-15 — Inbox reply bar + notify_user deprecation

**Jump-to-workspace iteration** (commits `28325dd` → `d1cfded`):
- v1 attempt (`28325dd`): floating "Open <tag> →" button + clickable workspace-label-as-button at top — too easy to miss; user reported "this button position is weird, hard to figure out what to do"
- v2 reshape (`d1cfded`): Linear-style **reply input bar** immediately after the comments markdown — full-width, bordered, "Reply in <tag>…" placeholder, → arrow. Mirrors Linear's "Leave a reply…" bar at the bottom of an issue's activity thread; the bar visually IS the next message in the conversation, so the action of clicking is intuitive ("I want to respond, so I click here")
- Single-click navigates the same as before — opens the workspace tab + switches sidebar to Workspaces, landing the user in the workspace's session list ready to chat back
- Top-of-pane workspace label reverted to plain text — the bar below is the unambiguous primary affordance now
- Tombstone for deleted workspaces: bar replaced with italic "Workspace no longer exists — nowhere to reply."
- Browser-verified end-to-end on both alive and deleted workspace entries

**`notify_user` deprecation marker** (`675aab8`):
- Description leads with `[DEPRECATED — legacy Automation path only]`
- Explicit "do NOT use this tool if you are inside a Workspace — use `inbox_push` instead"
- Behaviour unchanged — tool stays globally registered because the heartbeat / cron / `task.requested` outputGate matches on the same name

Key commits: `675aab8` `28325dd` `d1cfded`

## Full commit log
```
d1cfded refactor(inbox): jump-to-workspace as Linear-style reply bar, not floating button
28325dd feat(inbox): jump-to-workspace CTA below comments
675aab8 chore(tools): mark notify_user as deprecated in description
```

## Test plan
- [x] `npx tsc --noEmit` clean (backend + UI)
- [x] `pnpm --filter ./ui build` clean
- [x] Behaviour unchanged for `notify_user` — heartbeat / cron AgentWork outputGate still matches on the same tool name
- [x] Browser verification (Playwright):
  - Alive workspace: reply bar visible right under comments, click → workspace tab + sidebar switches to Workspaces
  - Deleted workspace: strikethrough label, italic tombstone replaces reply bar, no navigation
  - Workspace label at top is plain (no button styling) — primary entry is the bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)