### PR TITLE
feat(workspace): inbox reply bar + landing session cards + 0.20.0 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.10.0-beta.5",
+  "version": "0.20.0",
   "description": "File-based trading agent engine",
   "type": "module",
   "scripts": {

--- a/ui/src/components/workspace/ResumeCta.tsx
+++ b/ui/src/components/workspace/ResumeCta.tsx
@@ -160,7 +160,7 @@ function FauxTuiBackdrop(): ReactElement {
   );
 }
 
-function prefixOf(agent: string): string {
+export function prefixOf(agent: string): string {
   if (agent === 'claude') return 'c';
   if (agent === 'codex') return 'x';
   if (agent === 'shell') return 'sh';
@@ -173,7 +173,7 @@ function absoluteTime(iso: string): string {
   return t.toLocaleString();
 }
 
-function relativeTime(iso: string): string {
+export function relativeTime(iso: string): string {
   const t = new Date(iso).getTime();
   if (!Number.isFinite(t)) return '';
   const dMs = Date.now() - t;

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import type { ReactElement } from 'react';
+import { MessageSquare } from 'lucide-react';
 
 import type { SessionRecord } from './api';
 import { FilesPanel } from './FilesPanel';
 import { GitPanel } from './GitPanel';
-import { ResumeCta } from './ResumeCta';
+import { ResumeCta, prefixOf, relativeTime } from './ResumeCta';
 import { TerminalView, type KeyMap } from './Terminal';
 
 export interface WorkspaceViewProps {
@@ -14,15 +15,21 @@ export interface WorkspaceViewProps {
   /** Resolved record matching `sessionId`. null if `sessionId` is null OR the record was just deleted. */
   readonly activeRecord: SessionRecord | null;
   /**
-   * All session records for this workspace (running + paused). Running ones
-   * get a mounted TerminalView; paused ones don't render slots but appear in
-   * the sidebar for resume.
+   * All session records for this workspace (running + paused). When a
+   * session is pinned (`sessionId !== null`), this drives the running
+   * terminal slots; when no session is pinned, the empty state lists
+   * these as resume/continue cards so the user can pick up an existing
+   * conversation instead of being pushed toward a fresh spawn.
    */
   readonly sessions: readonly SessionRecord[];
   readonly label?: string;
   readonly keyMap?: KeyMap;
   readonly onSpawnFresh: () => void;
   readonly onResume: (sessionId: string) => void;
+  /** Navigate to an already-running session without re-spawning it. The
+   *  empty-state cards call this for running entries; resume-spawn for
+   *  paused entries goes through `onResume`. */
+  readonly onSelectSession: (sessionId: string) => void;
   readonly onSessionLost: () => void;
 }
 
@@ -31,7 +38,14 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
   // tab-switch trick from V2.S3 (commit 0f21914): keep them in the DOM,
   // toggle visibility via CSS so switching sessions is a CSS toggle, not a
   // WS reconnect + replay.
+  //
+  // When no session is pinned (empty state landing — e.g. coming from an
+  // Inbox jump), short-circuit to []: the empty state renders inline
+  // cards for the user to pick a session, and we shouldn't mount
+  // terminals for every running session in the workspace just to keep
+  // them warm (defeats the one-session-per-tab WS optimisation).
   const runningSlots = useMemo<readonly SessionRecord[]>(() => {
+    if (props.sessionId === null) return [];
     const running = props.sessions.filter((s) => s.state === 'running');
     // Brief race after a fresh spawn: selection.sessionId is set but the
     // optimistic update may have completed *after* render, or the user pinned
@@ -39,7 +53,6 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
     // is running but not in our list, virtually-append so its slot mounts
     // immediately. React reconciles by `key` when the real entry lands.
     if (
-      props.sessionId !== null &&
       props.activeRecord !== null &&
       props.activeRecord.state === 'running' &&
       !running.some((s) => s.id === props.sessionId)
@@ -64,7 +77,14 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
   return (
     <div className="workspace-view">
       <div className="workspace-terminal">
-        {showEmptyCta && <Cta onSpawn={props.onSpawnFresh} />}
+        {showEmptyCta && (
+          <EmptyState
+            sessions={props.sessions}
+            onResume={props.onResume}
+            onSelectSession={props.onSelectSession}
+            onSpawn={props.onSpawnFresh}
+          />
+        )}
         {showPausedCta && props.activeRecord && (
           <ResumeCta
             record={props.activeRecord}
@@ -98,18 +118,117 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
   );
 }
 
-function Cta({ onSpawn }: { onSpawn: () => void }): ReactElement {
+/**
+ * Empty-state when no session is pinned.
+ *
+ * Two shapes:
+ *
+ *  1. Workspace has 0 sessions → fall back to the original single-CTA
+ *     spawn UI. Same copy as before to avoid regressing users who use
+ *     the keyboard.
+ *
+ *  2. Workspace has 1+ sessions → render them as inline resume/continue
+ *     cards (sorted by `lastActiveAt` desc), with "Start a new session"
+ *     demoted to a secondary affordance below. This is the path users
+ *     hit when jumping from the Inbox reply bar — the notification was
+ *     authored by a specific existing session, and the cards make it
+ *     easy to pick the right one instead of being pushed toward a
+ *     fresh spawn.
+ *
+ * We deliberately don't try to detect or highlight "the session that
+ * sent the inbox entry" — would require threading session identity
+ * through the inbox_push MCP path, and Claude Code / Codex don't
+ * surface their own session id to tools they call. Chronological list
+ * is enough; users read the timestamps.
+ */
+function EmptyState(props: {
+  sessions: readonly SessionRecord[];
+  onResume: (sessionId: string) => void;
+  onSelectSession: (sessionId: string) => void;
+  onSpawn: () => void;
+}): ReactElement {
+  if (props.sessions.length === 0) {
+    return (
+      <div className="workspace-cta">
+        <p className="workspace-cta-text">
+          No session yet — start one to begin a conversation in this workspace.
+        </p>
+        <button type="button" className="workspace-cta-btn" onClick={props.onSpawn}>
+          Start a new session
+        </button>
+        <p className="workspace-cta-hint">
+          <kbd>⌘T</kbd> works too.
+        </p>
+      </div>
+    );
+  }
+
+  // Sort newest-first by lastActiveAt; defensive against ISO parse failures.
+  const ordered = [...props.sessions].sort((a, b) => {
+    const at = new Date(a.lastActiveAt).getTime();
+    const bt = new Date(b.lastActiveAt).getTime();
+    return (Number.isFinite(bt) ? bt : 0) - (Number.isFinite(at) ? at : 0);
+  });
+
   return (
-    <div className="workspace-cta">
-      <p className="workspace-cta-text">
-        No session selected. Pick one from the sidebar, or:
-      </p>
-      <button type="button" className="workspace-cta-btn" onClick={onSpawn}>
-        Start a new session
+    <div className="workspace-empty-state">
+      <h2 className="workspace-empty-heading">Pick up where you left off</h2>
+      <ul className="workspace-empty-list">
+        {ordered.map((s) => (
+          <SessionCard
+            key={s.id}
+            record={s}
+            onClick={() => {
+              if (s.state === 'paused') props.onResume(s.id);
+              else props.onSelectSession(s.id);
+            }}
+          />
+        ))}
+      </ul>
+      <div className="workspace-empty-divider">
+        <span>or</span>
+      </div>
+      <button
+        type="button"
+        className="workspace-empty-secondary-btn"
+        onClick={props.onSpawn}
+      >
+        + Start a new session
       </button>
       <p className="workspace-cta-hint">
         <kbd>⌘T</kbd> works too.
       </p>
     </div>
+  );
+}
+
+function SessionCard(props: {
+  record: SessionRecord;
+  onClick: () => void;
+}): ReactElement {
+  const r = props.record;
+  const isPaused = r.state === 'paused';
+  return (
+    <li className="workspace-empty-card">
+      <span className={`sidebar-agent-badge is-${r.agent}`}>
+        {prefixOf(r.agent)}
+      </span>
+      <div className="workspace-empty-card-meta">
+        <span className="workspace-empty-card-name">{r.name}</span>
+        <span className="workspace-empty-card-state">
+          {isPaused ? 'paused · ' : 'active · '}
+          {relativeTime(r.lastActiveAt)}
+        </span>
+      </div>
+      <button
+        type="button"
+        className="workspace-empty-card-btn"
+        onClick={props.onClick}
+        aria-label={isPaused ? `Resume ${r.name}` : `Open ${r.name}`}
+      >
+        <MessageSquare size={13} strokeWidth={2.25} aria-hidden="true" />
+        <span>Continue</span>
+      </button>
+    </li>
   );
 }

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -904,6 +904,119 @@
   font-size: 10px;
 }
 
+/* Empty state with session list. Rendered in the main pane when no
+   session is pinned AND the workspace has 1+ existing sessions.
+   Pushes "Continue an existing session" over "Start a new one" since
+   inbox jumps almost always want continuity, not fresh spawn. */
+.workspace-empty-state {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 32px 24px;
+  overflow-y: auto;
+}
+.workspace-empty-heading {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: 0.2px;
+}
+.workspace-empty-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 520px;
+}
+.workspace-empty-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  transition: border-color 0.12s, background 0.12s;
+}
+.workspace-empty-card:hover {
+  border-color: var(--accent);
+  background: var(--panel);
+}
+.workspace-empty-card-meta {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.workspace-empty-card-name {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.workspace-empty-card-state {
+  font-size: 10px;
+  color: var(--fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.workspace-empty-card-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--accent);
+  color: var(--bg);
+  border: 0;
+  padding: 6px 12px;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: filter 0.12s;
+}
+.workspace-empty-card-btn:hover {
+  filter: brightness(1.1);
+}
+.workspace-empty-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  max-width: 520px;
+  margin: 6px 0 2px;
+  color: var(--fg-dim);
+  font-size: 11px;
+}
+.workspace-empty-divider::before,
+.workspace-empty-divider::after {
+  content: "";
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--border);
+}
+.workspace-empty-secondary-btn {
+  background: transparent;
+  color: var(--fg-dim);
+  border: 1px dashed var(--border);
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+}
+.workspace-empty-secondary-btn:hover {
+  color: var(--fg);
+  border-color: var(--fg-dim);
+}
+
 .workspace-side {
   display: grid;
   grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react'
+import { ArrowRight } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { inboxLive } from '../live/inbox'
 import { useInboxSelection } from '../live/inbox-selection'
+import { useWorkspace } from '../tabs/store'
+import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
 import type { InboxEntry, InboxDoc } from '../api/inbox'
 
@@ -70,16 +73,48 @@ function Detail({ entry }: { entry: InboxEntry }) {
   const hasDocs = (entry.docs?.length ?? 0) > 0
   const hasComments = (entry.comments ?? '').trim().length > 0
 
+  // Workspace liveness — drives whether the jump-to-workspace affordance
+  // is enabled. A deleted workspace's inbox entry stays as a record but
+  // has nowhere to navigate to.
+  const { workspaces } = useWorkspaces()
+  const aliveWorkspace = workspaces.find((w) => w.id === entry.workspaceId) ?? null
+  const wsAlive = aliveWorkspace !== null
+  const displayLabel = aliveWorkspace?.tag ?? entry.workspaceLabel ?? entry.workspaceId
+
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+  const setSidebar = useWorkspace((s) => s.setSidebar)
+
+  const openWorkspace = () => {
+    if (!wsAlive) return
+    // Switch the sidebar to Workspaces so the user sees the sessions list
+    // alongside the workspace tab (analogue to "open the issue then IM in
+    // chat" — they need both views).
+    setSidebar('workspaces')
+    openOrFocus({ kind: 'workspace', params: { wsId: entry.workspaceId } })
+  }
+
   return (
     <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
-      {/* Header: workspace · timestamp. No "New" chip — selection always
+      {/* Header: workspace · timestamp. Workspace label is a button when
+       *  the workspace still exists. No "New" chip — selection always
        *  marks read, so by the time the detail pane renders the entry is
        *  read by definition; the chip would only ever flash for one
        *  render. The sidebar dot is the canonical unread signal. */}
       <div className="flex items-center gap-2 mb-4 flex-wrap">
-        <span className="text-[14px] font-medium text-text">
-          {entry.workspaceLabel ?? entry.workspaceId}
-        </span>
+        {wsAlive ? (
+          <button
+            type="button"
+            onClick={openWorkspace}
+            className="text-[14px] font-medium text-text hover:text-accent transition-colors cursor-pointer"
+            title={`Open workspace ${displayLabel}`}
+          >
+            {displayLabel}
+          </button>
+        ) : (
+          <span className="text-[14px] font-medium text-text-muted/70 line-through" title="Workspace no longer exists">
+            {displayLabel}
+          </span>
+        )}
         <span className="text-[11px] text-text-muted/70 tabular-nums ml-auto">
           {formatAbsolute(entry.ts)}
           <span className="mx-1.5 text-text-muted/40">·</span>
@@ -106,7 +141,28 @@ function Detail({ entry }: { entry: InboxEntry }) {
         </div>
       )}
 
-      <div className="mt-8 pt-4 border-t border-border/50 text-[12px] text-text-muted/60 font-mono">
+      {/* Jump-to-workspace CTA. The Linear analogue is "open issue from the
+       *  inbox notification" — except OpenAlice's atom is a workspace, so
+       *  the action takes the user from a read-only inbox view into the
+       *  workspace's live chat where they can reply to the agent. */}
+      <div className="mt-8 pt-5 border-t border-border/50">
+        {wsAlive ? (
+          <button
+            type="button"
+            onClick={openWorkspace}
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-accent/15 text-accent text-[12px] font-medium hover:bg-accent/25 transition-colors"
+          >
+            <span>Open {displayLabel}</span>
+            <ArrowRight size={13} strokeWidth={2} />
+          </button>
+        ) : (
+          <span className="text-[12px] text-text-muted/60 italic">
+            Workspace no longer exists — nowhere to navigate.
+          </span>
+        )}
+      </div>
+
+      <div className="mt-4 text-[11px] text-text-muted/40 font-mono">
         workspace: {entry.workspaceId}
       </div>
     </div>

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, MessageSquare } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { inboxLive } from '../live/inbox'
@@ -95,26 +95,19 @@ function Detail({ entry }: { entry: InboxEntry }) {
 
   return (
     <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
-      {/* Header: workspace · timestamp. Workspace label is a button when
-       *  the workspace still exists. No "New" chip — selection always
-       *  marks read, so by the time the detail pane renders the entry is
-       *  read by definition; the chip would only ever flash for one
-       *  render. The sidebar dot is the canonical unread signal. */}
+      {/* Header: workspace · timestamp. Plain text — the primary navigation
+       *  affordance sits at the bottom of the comments thread (Linear-style
+       *  reply input). Making the label itself a button was too subtle and
+       *  the user didn't expect to click a heading. */}
       <div className="flex items-center gap-2 mb-4 flex-wrap">
-        {wsAlive ? (
-          <button
-            type="button"
-            onClick={openWorkspace}
-            className="text-[14px] font-medium text-text hover:text-accent transition-colors cursor-pointer"
-            title={`Open workspace ${displayLabel}`}
-          >
-            {displayLabel}
-          </button>
-        ) : (
-          <span className="text-[14px] font-medium text-text-muted/70 line-through" title="Workspace no longer exists">
-            {displayLabel}
-          </span>
-        )}
+        <span
+          className={`text-[14px] font-medium ${
+            wsAlive ? 'text-text' : 'text-text-muted/70 line-through'
+          }`}
+          title={wsAlive ? undefined : 'Workspace no longer exists'}
+        >
+          {displayLabel}
+        </span>
         <span className="text-[11px] text-text-muted/70 tabular-nums ml-auto">
           {formatAbsolute(entry.ts)}
           <span className="mx-1.5 text-text-muted/40">·</span>
@@ -141,24 +134,30 @@ function Detail({ entry }: { entry: InboxEntry }) {
         </div>
       )}
 
-      {/* Jump-to-workspace CTA. The Linear analogue is "open issue from the
-       *  inbox notification" — except OpenAlice's atom is a workspace, so
-       *  the action takes the user from a read-only inbox view into the
-       *  workspace's live chat where they can reply to the agent. */}
-      <div className="mt-8 pt-5 border-t border-border/50">
+      {/* Reply bar — the navigation entry point. Linear-style: a wide bar
+       *  appended to the comments thread, visually styled like a chat
+       *  input. The action isn't actually sending — clicking opens the
+       *  workspace tab + switches the sidebar so the user can pick a
+       *  session and chat back to the agent there. v2 could pre-fill the
+       *  workspace chat input with whatever the user types here; for v1
+       *  the bar is single-click navigation. */}
+      <div className="mt-6">
         {wsAlive ? (
           <button
             type="button"
             onClick={openWorkspace}
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-accent/15 text-accent text-[12px] font-medium hover:bg-accent/25 transition-colors"
+            className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-border bg-bg-tertiary/40 hover:bg-bg-tertiary hover:border-accent/40 transition-colors text-left group"
           >
-            <span>Open {displayLabel}</span>
-            <ArrowRight size={13} strokeWidth={2} />
+            <MessageSquare size={15} strokeWidth={1.75} className="shrink-0 text-text-muted/70 group-hover:text-accent transition-colors" />
+            <span className="flex-1 text-[13px] text-text-muted/80 group-hover:text-text transition-colors">
+              Reply in <span className="font-medium text-text">{displayLabel}</span>…
+            </span>
+            <ArrowRight size={15} strokeWidth={1.75} className="shrink-0 text-text-muted/60 group-hover:text-accent group-hover:translate-x-0.5 transition-all" />
           </button>
         ) : (
-          <span className="text-[12px] text-text-muted/60 italic">
-            Workspace no longer exists — nowhere to navigate.
-          </span>
+          <div className="px-4 py-3 text-[12px] text-text-muted/60 italic border-t border-border/40 pt-4">
+            Workspace no longer exists — nowhere to reply.
+          </div>
         )}
       </div>
 

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -20,6 +20,7 @@ import { useEffect } from 'react'
 import '@xterm/xterm/css/xterm.css'
 
 import { useWorkspaces } from '../contexts/WorkspacesContext'
+import { useWorkspace } from '../tabs/store'
 import { WorkspaceView } from '../components/workspace/WorkspaceView'
 import type { KeyMap } from '../components/workspace/Terminal'
 import type { ViewSpec } from '../tabs/types'
@@ -35,6 +36,7 @@ interface Props {
 
 export function WorkspacePage({ spec, visible }: Props) {
   const ctx = useWorkspaces()
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const wsId = spec.params.wsId
   const sessionId = spec.params.sessionId ?? null
 
@@ -69,10 +71,11 @@ export function WorkspacePage({ spec, visible }: Props) {
     )
   }
 
-  // One session per tab: pass only this tab's record to WorkspaceView so it
-  // mounts a single TerminalView. TabHost's display:none keeps hidden tabs'
-  // xterm + WS alive, so tab switching doesn't re-mount or re-stream — the
-  // launcher's old multi-slot-in-one-pane trick is moot at this layer.
+  // Sessions list: pass the full workspace.sessions. WorkspaceView's
+  // `runningSlots` is gated on sessionId so the multi-terminal mount
+  // only happens when a session is pinned (one session per tab still
+  // holds for the active path); when sessionId is null, the empty
+  // state needs the full list to render resume/continue cards.
   return (
     <div className="workspaces-root flex-1 min-h-0 flex flex-col">
       {/* OpenAlice-side header bar above the launcher's WorkspaceView. The
@@ -99,11 +102,16 @@ export function WorkspacePage({ spec, visible }: Props) {
           wsId={wsId}
           sessionId={sessionId}
           activeRecord={activeRecord}
-          sessions={activeRecord ? [activeRecord] : []}
+          sessions={workspace.sessions}
           label={workspace.tag}
           keyMap={APP_KEY_MAP}
           onSpawnFresh={() => void ctx.spawn(wsId, {})}
           onResume={(id) => void ctx.resumeSession(wsId, id)}
+          onSelectSession={(id) => {
+            // Running session — already alive on the server, just
+            // navigate. Mirrors the sidebar's onSelectSession path.
+            openOrFocus({ kind: 'workspace', params: { wsId, sessionId: id } })
+          }}
           onSessionLost={() => {
             // 4404 from the WS upgrade — the session is gone server-side.
             // Refresh the list; the reconcile effect will close this tab.


### PR DESCRIPTION
## Summary

Polishes the inbox → workspace jump path end-to-end, then bumps the
version to mark the generation shift Workspace + Inbox represents:

1. **Reply bar** in the Inbox detail pane — Linear-style wide bar at
   the bottom of the comments thread; clicking opens the workspace tab
   and switches the sidebar to Workspaces.
2. **Workspace landing empty state** rewrite — when no session is
   pinned (i.e. straight off the inbox jump), surface the workspace's
   existing sessions inline as resume/continue cards sorted
   newest-first, with `Start a new session` demoted to a dashed
   secondary button below. The previous empty state had only the
   "start new" CTA, which was the wrong default for an inbox jump:
   the notification was authored by an existing session and continuity
   is the whole point.
3. **0.20.0** — version bump. Workspace + Inbox have replaced the
   single-session Traditional Chat as the recommended path; that's
   not patch-level work, it's a generation shift from 0.10 → 0.20.
   Skipping 0.11–0.19 deliberately so the version reflects how much
   of the original chat design has been replaced.

## Per-session contributions

### 2026-05-15 — Inbox → workspace polish + 0.20 bump

**Reply bar** (`28325dd` → `d1cfded`):
- v1 attempt (`28325dd`): floating `Open <tag> →` button below comments + clickable workspace label at top. User feedback: "this button position is weird, hard to figure out what to do" — buried below long doc content and "Open" didn't read like a continuation
- v2 reshape (`d1cfded`): full-width bordered bar styled like a chat input, immediately following the comments markdown. Placeholder `Reply in <tag>…` with 💬 icon left and → arrow right. Mirrors Linear's reply input at the bottom of an issue's activity thread — the bar visually IS the next message
- Tombstone for deleted workspaces: bar replaced with italic "Workspace no longer exists — nowhere to reply."
- Single-click navigation; deliberately NOT a real input that prefills workspace chat. Workspace doesn't bind to a specific chat tool, so abstracting over "the workspace's chat input" would commit to a surface still moving on the Claude Code / Codex CLI side (memory note `feedback_fear_abstraction_under_shipping_pressure`)

**Workspace landing empty state** (`46ee82e`):
- `WorkspaceView` previously showed `No session selected. Pick one from the sidebar, or: [Start a new session]` — equal weight to two paths but the sidebar hint was low-discoverability and the prominent button pushed users to discard inbox context
- New shape: when `workspace.sessions.length > 0`, render `Pick up where you left off` heading + session cards sorted by `lastActiveAt` desc + `or` divider + dashed-outline `+ Start a new session` secondary button. Empty-workspace fallback (no sessions) keeps the original single-CTA spawn UI verbatim for regression safety
- Session card per row: agent badge (`c` / `x` / `sh`), session name, `PAUSED · 5 min ago` / `ACTIVE · 2 hours ago` state chip, `Continue` button. Clicking the Continue button:
  - paused → `ctx.resumeSession(wsId, id)` (re-spawns PTY, then navigates)
  - running → `openOrFocus({ kind: 'workspace', params: { wsId, sessionId } })` (just navigates; the PTY is already alive)
- `WorkspaceView.runningSlots` short-circuits to `[]` when `sessionId === null` so passing the full `workspace.sessions` doesn't trigger multi-terminal mount per tab — the one-session-per-tab WS optimisation is preserved on the active path
- `prefixOf` + `relativeTime` hoisted out of `ResumeCta` as exports for reuse
- **Out of scope**: auto-detecting which session sent the inbox entry (would require threading sessionId through `inbox_push`, no clean way to get it from Claude Code / Codex), auto-resuming the latest paused session (user confirmed via Plan-mode question that always-show-card is preferred — explicit choice, no surprise)

**0.20.0 bump** (`1853add`) — Workspace + Inbox now reshape the chat surface end-to-end; legacy Traditional Chat is the fallback now, not the recommended path. Generation shift, not patch.

Key commits: `28325dd` `d1cfded` `46ee82e` `1853add`

## Full commit log
```
1853add chore(release): bump version to 0.20.0
46ee82e feat(workspace): session cards in no-session empty state
d1cfded refactor(inbox): jump-to-workspace as Linear-style reply bar, not floating button
28325dd feat(inbox): jump-to-workspace CTA below comments
```

## Test plan
- [x] `npx tsc --noEmit` clean (backend + UI)
- [x] `pnpm --filter ./ui build` clean
- [x] Browser verification (Playwright):
  - Inbox detail pane: reply bar visible right under comments, click → workspace tab + sidebar switches to Workspaces
  - Workspace landing (no session pinned): empty state shows session cards sorted newest-first, "Pick up where you left off" heading, dashed-outline `Start a new session` secondary button
  - Click `Continue` on a paused session → URL updates to `/workspaces/<wsId>/s/<sessionId>` + terminal slot mounts + sidebar marks session running
  - Deleted workspace inbox entry: strikethrough label + italic tombstone replaces reply bar, no navigation
- [ ] Workspace with 0 sessions: fall-back single-CTA empty state (regression check; not actively tested but unchanged code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)