### PR TITLE
feat(workspace): satellite-repo pattern + finance-research template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.20.0",
+  "version": "0.21.0-beta.2",
   "description": "File-based trading agent engine",
   "type": "module",
   "scripts": {

--- a/src/workspaces/templates/_common.sh
+++ b/src/workspaces/templates/_common.sh
@@ -1,0 +1,116 @@
+# Shared bash helpers for workspace bootstrap scripts.
+#
+# Sourced by templates/<name>/bootstrap.sh via:
+#   source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
+#
+# Each helper is self-contained and validates its own inputs. Helpers exit
+# non-zero on irrecoverable errors so the launcher (workspace-creator.ts)
+# surfaces the failure to the user via stderr.
+#
+# Templates that don't need a particular helper just don't call it —
+# auto-quant for example only uses setup_git_excludes because it has its
+# own clone-and-branch flow that init_workspace_dir would conflict with.
+
+# init_workspace_dir <out_dir>
+# Verifies $out_dir doesn't yet exist, creates it, cd's into it.
+init_workspace_dir() {
+  local out_dir="${1:?init_workspace_dir: out_dir required}"
+  if [[ -e "$out_dir" ]]; then
+    echo "outDir already exists: $out_dir" >&2
+    exit 2
+  fi
+  mkdir -p "$out_dir"
+  cd "$out_dir"
+}
+
+# extract_ws_id <out_dir>
+# Echoes the workspace UUID — by convention the basename of $out_dir
+# (the launcher names the directory with the random UUID it assigns).
+extract_ws_id() {
+  local out_dir="${1:?extract_ws_id: out_dir required}"
+  basename "$out_dir"
+}
+
+# write_mcp_config <ws_id> <template_files_dir>
+# Reads $template_files_dir/mcp.json, substitutes __WS_ID__ -> $ws_id,
+# writes result to ./.mcp.json in the current dir. ${OPENALICE_MCP_URL}
+# placeholder is left intact for the agent CLI to evaluate at spawn time.
+write_mcp_config() {
+  local ws_id="${1:?write_mcp_config: ws_id required}"
+  local files_dir="${2:?write_mcp_config: template_files_dir required}"
+  local src="$files_dir/mcp.json"
+  if [[ ! -f "$src" ]]; then
+    echo "write_mcp_config: missing $src" >&2
+    exit 3
+  fi
+  sed "s|__WS_ID__|$ws_id|g" "$src" > .mcp.json
+}
+
+# compose_persona_claude_md <template_files_dir> [repo_root]
+# Composes ./CLAUDE.md as: Alice persona + "---" separator + template CLAUDE.md.
+# Persona source: prefers $repo_root/data/brain/persona.md (live user edit),
+# falls back to $repo_root/default/persona.default.md (shipped default).
+# If $repo_root is unset/missing, skips persona prepend gracefully — the
+# template's own CLAUDE.md is still written. Also copies the result to
+# AGENTS.md so Codex / other AGENTS.md-aware CLIs see the same identity.
+compose_persona_claude_md() {
+  local files_dir="${1:?compose_persona_claude_md: template_files_dir required}"
+  local repo_root="${2:-${AQ_LAUNCHER_REPO_ROOT:-}}"
+  local template_md="$files_dir/CLAUDE.md"
+  if [[ ! -f "$template_md" ]]; then
+    echo "compose_persona_claude_md: missing $template_md" >&2
+    exit 4
+  fi
+  local persona_src=""
+  if [[ -n "$repo_root" ]]; then
+    if [[ -f "$repo_root/data/brain/persona.md" ]]; then
+      persona_src="$repo_root/data/brain/persona.md"
+    elif [[ -f "$repo_root/default/persona.default.md" ]]; then
+      persona_src="$repo_root/default/persona.default.md"
+    fi
+  fi
+  {
+    if [[ -n "$persona_src" ]]; then
+      cat "$persona_src"
+      printf '\n\n---\n\n'
+    fi
+    cat "$template_md"
+  } > CLAUDE.md
+  cp CLAUDE.md AGENTS.md
+}
+
+# setup_git_excludes [extra_path...]
+# Appends defensive entries to .git/info/exclude (per-clone, untracked).
+# Always includes:
+#   - .claude/settings.local.json   (workspace-specific Claude config)
+#   - .codex/auth.json              (workspace-local Codex auth)
+# Extra paths passed as args are appended too — useful for templates that
+# clone third-party content (e.g. finance-research clones .finance-skills/
+# and doesn't want git add . to swallow it).
+# Caller must ensure .git/ exists (run after `git init` or `git clone`).
+setup_git_excludes() {
+  if [[ ! -d .git ]]; then
+    echo "setup_git_excludes: no .git/ in $(pwd)" >&2
+    exit 5
+  fi
+  {
+    echo '.claude/settings.local.json'
+    echo '.codex/auth.json'
+    for extra in "$@"; do
+      echo "$extra"
+    done
+  } >> .git/info/exclude
+}
+
+# commit_initial <tag> <template_name>
+# `git add . && git commit` with a launcher-stamped author. Used by templates
+# that init their own git repo (chat, finance-research). auto-quant doesn't
+# call this — its `git clone --local` already produces a working tree at
+# the source's HEAD, and its bootstrap creates a new branch instead.
+commit_initial() {
+  local tag="${1:?commit_initial: tag required}"
+  local template_name="${2:?commit_initial: template_name required}"
+  git add .
+  git -c user.email=launcher@local -c user.name=launcher \
+      commit -q -m "$template_name: $tag"
+}

--- a/src/workspaces/templates/auto-quant/bootstrap.sh
+++ b/src/workspaces/templates/auto-quant/bootstrap.sh
@@ -79,10 +79,8 @@ git checkout -b "autoresearch/$TAG" >/dev/null
 # `.codex/auth.json`), the per-clone exclude keeps those secrets out of any
 # push to upstream Auto-Quant. Claude itself auto-ignores its file; this
 # entry is defense-in-depth.
-{
-  echo '.claude/settings.local.json'
-  echo '.codex/auth.json'
-} >> .git/info/exclude
+source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
+setup_git_excludes
 
 # 3. user_data/data is a real per-workspace directory. Auto-Quant's
 #    `.gitignore` already excludes `user_data/data/`, so prepare.py's output

--- a/src/workspaces/templates/chat/bootstrap.sh
+++ b/src/workspaces/templates/chat/bootstrap.sh
@@ -17,70 +17,16 @@ TAG="${1:?tag required}"
 OUT_DIR="${2:?outDir required}"
 : "${AQ_TEMPLATE_FILES_DIR:?AQ_TEMPLATE_FILES_DIR must be set by the launcher}"
 
-if [[ -e "$OUT_DIR" ]]; then
-  echo "outDir already exists: $OUT_DIR" >&2
-  exit 2
-fi
+source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 
-mkdir -p "$OUT_DIR"
-cd "$OUT_DIR"
+init_workspace_dir "$OUT_DIR"
+WS_ID="$(extract_ws_id "$OUT_DIR")"
 
-# Workspace UUID — directory name. WorkspaceCreator names $OUT_DIR with the
-# random UUID it just assigned, so basename matches the registry's wsId.
-WS_ID="$(basename "$OUT_DIR")"
-
-# MCP config — leave ${OPENALICE_MCP_URL} placeholder unexpanded so the
-# agent CLI evaluates it at spawn time. The __WS_ID__ literal IS expanded
-# now: it gets baked into the `openalice-workspace` server URL so the
-# OpenAlice MCP `/mcp/:wsId` route can identify which workspace called
-# inbox_push and other workspace-scoped tools. wsId is invisible to the
-# agent — workspace identity rides the URL path, not a tool argument.
-sed "s|__WS_ID__|$WS_ID|g" "$AQ_TEMPLATE_FILES_DIR/mcp.json" > .mcp.json
-
-# Locate Alice's persona — prefer the user's live edit, fall back to the
-# shipped default. If neither is reachable (e.g. AQ_LAUNCHER_REPO_ROOT
-# unset), skip the persona prepend gracefully.
-PERSONA_SRC=""
-if [[ -n "${AQ_LAUNCHER_REPO_ROOT:-}" ]]; then
-  if [[ -f "$AQ_LAUNCHER_REPO_ROOT/data/brain/persona.md" ]]; then
-    PERSONA_SRC="$AQ_LAUNCHER_REPO_ROOT/data/brain/persona.md"
-  elif [[ -f "$AQ_LAUNCHER_REPO_ROOT/default/persona.default.md" ]]; then
-    PERSONA_SRC="$AQ_LAUNCHER_REPO_ROOT/default/persona.default.md"
-  fi
-fi
-
-# Compose agent instructions: persona on top, workspace context below.
-{
-  if [[ -n "$PERSONA_SRC" ]]; then
-    cat "$PERSONA_SRC"
-    printf '\n\n---\n\n'
-  fi
-  cat "$AQ_TEMPLATE_FILES_DIR/CLAUDE.md"
-} > CLAUDE.md
-
-# Same content under AGENTS.md so Codex / other AGENTS.md-aware CLIs pick
-# up the same identity. Keeping a single source-of-truth (CLAUDE.md) avoids
-# drift; this is a literal copy, not a separate compose pass.
-cp CLAUDE.md AGENTS.md
+write_mcp_config "$WS_ID" "$AQ_TEMPLATE_FILES_DIR"
+compose_persona_claude_md "$AQ_TEMPLATE_FILES_DIR"
 
 git init -q
-
-# `.git/info/exclude` is per-clone, untracked. Preemptive defense for
-# files the OpenAlice UI may later write when the user configures
-# workspace-specific AI provider overrides:
-#   - .claude/settings.local.json — claude itself auto-ignores this, but
-#     the entry here defends against any future tooling reading from
-#     `.gitignore` instead of trusting claude's runtime behaviour.
-#   - .codex/auth.json — workspace-local codex auth (real file written
-#     by the UI when user configures a workspace-specific provider).
-#     Bootstrap doesn't create this; it's listed here so a configured
-#     workspace's secret never enters a push.
-{
-  echo '.claude/settings.local.json'
-  echo '.codex/auth.json'
-} >> .git/info/exclude
-
-git add .
-git -c user.email=launcher@local -c user.name=launcher commit -q -m "chat: $TAG"
+setup_git_excludes
+commit_initial "$TAG" chat
 
 echo "bootstrapped chat workspace '$TAG' at $OUT_DIR"

--- a/src/workspaces/templates/finance-research/bootstrap.sh
+++ b/src/workspaces/templates/finance-research/bootstrap.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Bootstrap a finance-research workspace: same skeleton as `chat`
 # (OpenAlice MCP wiring + Alice persona) plus a fresh clone of
-# himself65/finance-skills with three plugins installed at project scope.
+# himself65/finance-skills with SKILL.md trees copied into both Claude
+# Code's and Codex's project-local discovery paths.
 #
 # Contract:
 #   argv:  $1 = tag, $2 = outDir
@@ -10,22 +11,22 @@
 # exit:  0 ok, non-zero on any failure
 #
 # Design notes (do not "optimize" without re-reading):
+#   - Skill is a DISCOVERY structure, not a registration structure.
+#     `.claude/skills/<name>/SKILL.md` is auto-discovered by Claude Code
+#     when launched in this dir; `.agents/skills/<name>/SKILL.md` is
+#     auto-discovered by Codex (per developers.openai.com/codex/skills,
+#     verified 2026-05-15). So bootstrap is just: clone + cp. No
+#     `claude plugin install`, no `npx skills add`, no marketplace
+#     registration, no `~/.claude/plugins/` writes.
 #   - We git clone himself65/finance-skills FRESH on every workspace
-#     creation, intentionally NOT mirror-cached like Auto-Quant. The
-#     upstream clone-traffic is co-promotion of an open-source author
-#     who's part of the ecosystem we want to grow — saving our own
-#     bandwidth here would erase that signal. Don't refactor to a mirror.
-#   - Plugin install uses --scope project so workspace state lives in
-#     ./.claude/settings.json (extraKnownMarketplaces + enabledPlugins),
-#     not user-global ~/.claude/. Multiple finance-research workspaces
-#     coexist without colliding on per-project enabled state. The plugin
-#     binary cache at ~/.claude/plugins/cache/ IS shared across workspaces
-#     (content-addressed) — that's a feature, not a leak.
-#   - Plugin install is best-effort: a network blip or upstream renaming
-#     a plugin shouldn't fail the whole bootstrap. CLAUDE.md tells the
-#     user how to retry manually. The workspace itself stays usable
-#     against OpenAlice's own MCP tools even if the finance-skills layer
-#     never installs.
+#     creation, intentionally NOT mirror-cached like Auto-Quant. Upstream
+#     clone-traffic is co-promotion of an open-source author who's part
+#     of the ecosystem we want to grow.
+#   - Plugin selection (PLUGINS array) skips finance-startup-tools (not
+#     trading-related), finance-ui-tools (generative UI, off-scope), and
+#     finance-skill-creator (developer meta tool). Anyone wanting a
+#     different selection edits this array — there's no need for a
+#     config layer until that becomes a real ask.
 
 set -euo pipefail
 
@@ -37,11 +38,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
 
 FINANCE_SKILLS_REPO="https://github.com/himself65/finance-skills.git"
 FINANCE_SKILLS_DIR=".finance-skills"
-PLUGINS_TO_INSTALL=(
-  finance-market-analysis
-  finance-social-readers
-  finance-data-providers
-)
+PLUGINS=(market-analysis social-readers data-providers)
 
 init_workspace_dir "$OUT_DIR"
 WS_ID="$(extract_ws_id "$OUT_DIR")"
@@ -50,10 +47,11 @@ write_mcp_config "$WS_ID" "$AQ_TEMPLATE_FILES_DIR"
 compose_persona_claude_md "$AQ_TEMPLATE_FILES_DIR"
 
 git init -q
-# Exclude the cloned upstream repo from this workspace's commits — users
-# shouldn't accidentally `git add .` and bake the entire finance-skills
-# repo into their own workspace history.
-setup_git_excludes "$FINANCE_SKILLS_DIR/"
+# .finance-skills/ is the upstream clone; users shouldn't bake it into
+# their own commits. Per-skill excludes (added below) keep user-authored
+# skills in .claude/skills/<custom>/ trackable while keeping the bundled
+# upstream ones invisible to git status.
+setup_git_excludes "$FINANCE_SKILLS_DIR/" ".openalice-finance-info"
 
 # ── Clone finance-skills (best effort) ──────────────────────────────────
 FINANCE_OK=false
@@ -67,28 +65,39 @@ else
   echo "[finance-research] WARN: git clone failed; workspace usable without finance-skills" >&2
 fi
 
-# ── Register marketplace + install plugins (best effort) ────────────────
-INSTALLED_PLUGINS=()
-FAILED_PLUGINS=()
-if [[ "$FINANCE_OK" == "true" ]] && command -v claude >/dev/null 2>&1; then
-  echo "[finance-research] registering local marketplace ..." >&2
-  if claude plugin marketplace add "./$FINANCE_SKILLS_DIR" --scope project < /dev/null >&2; then
-    for plugin in "${PLUGINS_TO_INSTALL[@]}"; do
-      echo "[finance-research] installing $plugin ..." >&2
-      if claude plugin install "${plugin}@finance-skills" --scope project < /dev/null >&2; then
-        INSTALLED_PLUGINS+=("$plugin")
-      else
-        FAILED_PLUGINS+=("$plugin")
-        echo "[finance-research] WARN: install failed for $plugin" >&2
+# ── Copy SKILL.md trees into discovery paths ────────────────────────────
+SKILLS_INSTALLED=()
+SKILLS_FAILED=()
+if [[ "$FINANCE_OK" == "true" ]]; then
+  mkdir -p .claude/skills .agents/skills
+  for plugin in "${PLUGINS[@]}"; do
+    src="$FINANCE_SKILLS_DIR/plugins/$plugin/skills"
+    if [[ ! -d "$src" ]]; then
+      echo "[finance-research] WARN: missing $src in upstream" >&2
+      SKILLS_FAILED+=("$plugin/* (not in upstream)")
+      continue
+    fi
+    for skill_dir in "$src"/*/; do
+      [[ -d "$skill_dir" ]] || continue
+      name="$(basename "$skill_dir")"
+      # Loud-fail on collision rather than silent overwrite — if upstream
+      # ever ships two skills with the same name across plugins, we want
+      # to know.
+      if [[ -e ".claude/skills/$name" ]] || [[ -e ".agents/skills/$name" ]]; then
+        echo "[finance-research] WARN: skill name collision '$name'; skipping" >&2
+        SKILLS_FAILED+=("$name (collision)")
+        continue
       fi
+      cp -R "$skill_dir" ".claude/skills/$name"
+      cp -R "$skill_dir" ".agents/skills/$name"
+      # Per-skill excludes — keep the bundled skills out of `git add .`
+      # while leaving room for the user to author their own under
+      # .claude/skills/ or .agents/skills/.
+      echo ".claude/skills/$name" >> .git/info/exclude
+      echo ".agents/skills/$name" >> .git/info/exclude
+      SKILLS_INSTALLED+=("$name")
     done
-  else
-    echo "[finance-research] WARN: marketplace add failed; plugins not installed" >&2
-    FAILED_PLUGINS=("${PLUGINS_TO_INSTALL[@]}")
-  fi
-elif [[ "$FINANCE_OK" == "true" ]]; then
-  echo "[finance-research] WARN: 'claude' CLI not in PATH; plugins not installed" >&2
-  FAILED_PLUGINS=("${PLUGINS_TO_INSTALL[@]}")
+  done
 fi
 
 # ── Debug breadcrumb ────────────────────────────────────────────────────
@@ -100,17 +109,17 @@ fi
   echo "financeSkillsRepo: $FINANCE_SKILLS_REPO"
   echo "financeSkillsCloned: $FINANCE_OK"
   echo "financeSkillsCommit: ${FINANCE_COMMIT:-n/a}"
-  echo "installedPlugins: ${INSTALLED_PLUGINS[*]:-none}"
-  echo "failedPlugins: ${FAILED_PLUGINS[*]:-none}"
+  echo "skillsInstalled: ${SKILLS_INSTALLED[*]:-none}"
+  echo "skillsFailed: ${SKILLS_FAILED[*]:-none}"
+  echo "discoveryPaths:"
+  echo "  - .claude/skills/   (Claude Code)"
+  echo "  - .agents/skills/   (Codex)"
 } > .openalice-finance-info
-
-# .openalice-finance-info is internal — keep it out of user commits.
-echo '.openalice-finance-info' >> .git/info/exclude
 
 commit_initial "$TAG" finance-research
 
-if [[ ${#FAILED_PLUGINS[@]} -gt 0 ]]; then
-  echo "[finance-research] bootstrapped with WARN — see CLAUDE.md → Recovery to retry: ${FAILED_PLUGINS[*]}" >&2
+if [[ ${#SKILLS_FAILED[@]} -gt 0 ]]; then
+  echo "[finance-research] bootstrapped with WARN: ${SKILLS_FAILED[*]}" >&2
 fi
 
-echo "bootstrapped finance-research workspace '$TAG' at $OUT_DIR"
+echo "bootstrapped finance-research workspace '$TAG' at $OUT_DIR with ${#SKILLS_INSTALLED[@]} skills"

--- a/src/workspaces/templates/finance-research/bootstrap.sh
+++ b/src/workspaces/templates/finance-research/bootstrap.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Bootstrap a finance-research workspace: same skeleton as `chat`
+# (OpenAlice MCP wiring + Alice persona) plus a fresh clone of
+# himself65/finance-skills with three plugins installed at project scope.
+#
+# Contract:
+#   argv:  $1 = tag, $2 = outDir
+#   env:   AQ_TEMPLATE_FILES_DIR  — abs path to this template's files/
+#          AQ_LAUNCHER_REPO_ROOT  — abs path to the OpenAlice repo root
+# exit:  0 ok, non-zero on any failure
+#
+# Design notes (do not "optimize" without re-reading):
+#   - We git clone himself65/finance-skills FRESH on every workspace
+#     creation, intentionally NOT mirror-cached like Auto-Quant. The
+#     upstream clone-traffic is co-promotion of an open-source author
+#     who's part of the ecosystem we want to grow — saving our own
+#     bandwidth here would erase that signal. Don't refactor to a mirror.
+#   - Plugin install uses --scope project so workspace state lives in
+#     ./.claude/settings.json (extraKnownMarketplaces + enabledPlugins),
+#     not user-global ~/.claude/. Multiple finance-research workspaces
+#     coexist without colliding on per-project enabled state. The plugin
+#     binary cache at ~/.claude/plugins/cache/ IS shared across workspaces
+#     (content-addressed) — that's a feature, not a leak.
+#   - Plugin install is best-effort: a network blip or upstream renaming
+#     a plugin shouldn't fail the whole bootstrap. CLAUDE.md tells the
+#     user how to retry manually. The workspace itself stays usable
+#     against OpenAlice's own MCP tools even if the finance-skills layer
+#     never installs.
+
+set -euo pipefail
+
+TAG="${1:?tag required}"
+OUT_DIR="${2:?outDir required}"
+: "${AQ_TEMPLATE_FILES_DIR:?AQ_TEMPLATE_FILES_DIR must be set by the launcher}"
+
+source "$(dirname "${BASH_SOURCE[0]}")/../_common.sh"
+
+FINANCE_SKILLS_REPO="https://github.com/himself65/finance-skills.git"
+FINANCE_SKILLS_DIR=".finance-skills"
+PLUGINS_TO_INSTALL=(
+  finance-market-analysis
+  finance-social-readers
+  finance-data-providers
+)
+
+init_workspace_dir "$OUT_DIR"
+WS_ID="$(extract_ws_id "$OUT_DIR")"
+
+write_mcp_config "$WS_ID" "$AQ_TEMPLATE_FILES_DIR"
+compose_persona_claude_md "$AQ_TEMPLATE_FILES_DIR"
+
+git init -q
+# Exclude the cloned upstream repo from this workspace's commits — users
+# shouldn't accidentally `git add .` and bake the entire finance-skills
+# repo into their own workspace history.
+setup_git_excludes "$FINANCE_SKILLS_DIR/"
+
+# ── Clone finance-skills (best effort) ──────────────────────────────────
+FINANCE_OK=false
+FINANCE_COMMIT=""
+echo "[finance-research] cloning $FINANCE_SKILLS_REPO (shallow) ..." >&2
+if git clone --depth=1 --quiet "$FINANCE_SKILLS_REPO" "$FINANCE_SKILLS_DIR" >&2; then
+  FINANCE_OK=true
+  FINANCE_COMMIT="$(git -C "$FINANCE_SKILLS_DIR" rev-parse HEAD 2>/dev/null || echo unknown)"
+  echo "[finance-research] cloned at $FINANCE_COMMIT" >&2
+else
+  echo "[finance-research] WARN: git clone failed; workspace usable without finance-skills" >&2
+fi
+
+# ── Register marketplace + install plugins (best effort) ────────────────
+INSTALLED_PLUGINS=()
+FAILED_PLUGINS=()
+if [[ "$FINANCE_OK" == "true" ]] && command -v claude >/dev/null 2>&1; then
+  echo "[finance-research] registering local marketplace ..." >&2
+  if claude plugin marketplace add "./$FINANCE_SKILLS_DIR" --scope project < /dev/null >&2; then
+    for plugin in "${PLUGINS_TO_INSTALL[@]}"; do
+      echo "[finance-research] installing $plugin ..." >&2
+      if claude plugin install "${plugin}@finance-skills" --scope project < /dev/null >&2; then
+        INSTALLED_PLUGINS+=("$plugin")
+      else
+        FAILED_PLUGINS+=("$plugin")
+        echo "[finance-research] WARN: install failed for $plugin" >&2
+      fi
+    done
+  else
+    echo "[finance-research] WARN: marketplace add failed; plugins not installed" >&2
+    FAILED_PLUGINS=("${PLUGINS_TO_INSTALL[@]}")
+  fi
+elif [[ "$FINANCE_OK" == "true" ]]; then
+  echo "[finance-research] WARN: 'claude' CLI not in PATH; plugins not installed" >&2
+  FAILED_PLUGINS=("${PLUGINS_TO_INSTALL[@]}")
+fi
+
+# ── Debug breadcrumb ────────────────────────────────────────────────────
+{
+  echo "# OpenAlice finance-research workspace"
+  echo "createdAt: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "tag: $TAG"
+  echo "wsId: $WS_ID"
+  echo "financeSkillsRepo: $FINANCE_SKILLS_REPO"
+  echo "financeSkillsCloned: $FINANCE_OK"
+  echo "financeSkillsCommit: ${FINANCE_COMMIT:-n/a}"
+  echo "installedPlugins: ${INSTALLED_PLUGINS[*]:-none}"
+  echo "failedPlugins: ${FAILED_PLUGINS[*]:-none}"
+} > .openalice-finance-info
+
+# .openalice-finance-info is internal — keep it out of user commits.
+echo '.openalice-finance-info' >> .git/info/exclude
+
+commit_initial "$TAG" finance-research
+
+if [[ ${#FAILED_PLUGINS[@]} -gt 0 ]]; then
+  echo "[finance-research] bootstrapped with WARN — see CLAUDE.md → Recovery to retry: ${FAILED_PLUGINS[*]}" >&2
+fi
+
+echo "bootstrapped finance-research workspace '$TAG' at $OUT_DIR"

--- a/src/workspaces/templates/finance-research/files/CLAUDE.md
+++ b/src/workspaces/templates/finance-research/files/CLAUDE.md
@@ -1,16 +1,25 @@
 # Finance Research workspace
 
-This workspace bundles **[himself65/finance-skills](https://github.com/himself65/finance-skills)** — a community plugin marketplace by [@himself65](https://github.com/himself65) (面包) covering market data, valuation, earnings analysis, options payoff, and social/research feeds.
+This workspace bundles **[himself65/finance-skills](https://github.com/himself65/finance-skills)** — a community SKILL.md collection by [@himself65](https://github.com/himself65) (面包) covering market data, valuation, earnings analysis, options payoff, and social/research feeds.
+
+## How it's wired
+
+Bootstrap clones the upstream finance-skills repo (latest `main`) into `./.finance-skills/` and copies each SKILL.md tree into:
+
+- `.claude/skills/<name>/` — discovered automatically by **Claude Code** when launched here
+- `.agents/skills/<name>/` — discovered automatically by **Codex** (per [developers.openai.com/codex/skills](https://developers.openai.com/codex/skills))
+
+No global install, no marketplace registration, no `~/.claude/plugins/` writes. SKILL.md is a discovery format — files in well-known directories Just Work for both agents.
 
 ## What's installed
 
-Bootstrap clones the upstream finance-skills repo (latest `main`) into `./.finance-skills/` and installs three plugins at **project scope** (no user-global pollution):
+From three of the upstream plugin packs (skipping the ones off-scope for trading):
 
-- `finance-market-analysis` — yfinance market data, DCF/SOTP valuation, earnings preview/recap, ETF premium/discount, options payoff, SEPA/VCP, stock correlation & liquidity
-- `finance-social-readers` — Twitter/X, Discord, LinkedIn, Telegram, Y Combinator readers; opencli fallback for 90+ research feeds
-- `finance-data-providers` — Adanos sentiment, Funda AI fundamental research (MCP + REST), Hormuz Strait monitoring, TradingView desktop app reading
+- **finance-market-analysis** → `yfinance-data`, `company-valuation`, `earnings-preview`, `earnings-recap`, `estimate-analysis`, `etf-premium`, `options-payoff`, `saas-valuation-compression`, `sepa-strategy`, `stock-correlation`, `stock-liquidity`
+- **finance-social-readers** → `discord-reader`, `linkedin-reader`, `opencli-reader`, `telegram-reader`, `twitter-reader`, `yc-reader`
+- **finance-data-providers** → `finance-sentiment`, `funda-data`, `hormuz-strait`, `tradingview-reader`
 
-If the install missed any of those (network timeout, etc.), see the **Recovery** section at the bottom.
+See `.openalice-finance-info` for the exact upstream commit and the actual list of skills installed for this workspace.
 
 ## Two data layers — when to use which
 
@@ -23,26 +32,33 @@ Don't cross the streams: don't quote yfinance to make a UTA order routing call. 
 
 ## MCP wiring
 
-`.mcp.json` points at OpenAlice's MCP server (`http://127.0.0.1:3001/mcp` by default, or `$OPENALICE_MCP_URL`). The full OpenAlice tool surface — trading, market data, news, brain, indicators — is available alongside the finance-skills plugins.
+`.mcp.json` points at OpenAlice's MCP server (`http://127.0.0.1:3001/mcp` by default, or `$OPENALICE_MCP_URL`). The full OpenAlice tool surface — trading, market data, news, brain, indicators — is available alongside the bundled skills.
 
 To verify on first attach:
 
-1. Approve the MCP server when Claude Code prompts for trust
+1. Approve the MCP server when Claude Code / Codex prompts for trust
 2. Run `/mcp` — you should see `openalice · ✓ connected`
-3. Run `/plugin list` — you should see the three `finance-*` plugins enabled
+3. Run `/skills` — you should see the bundled finance skills alongside any built-in ones
 
 ## Upstream relationship
 
 `himself65/finance-skills` is an independent open-source project. We clone fresh from upstream on each new workspace creation — that gives the author visible GitHub traffic and ensures you always get their latest. We do not fork, mirror, or modify upstream. If a skill behaves unexpectedly, file the issue at the upstream repo, not OpenAlice.
 
-## Recovery (if bootstrap missed plugin install)
+## Recovery (if bootstrap missed any skills)
+
+If `.openalice-finance-info` shows `skillsFailed: ...` (e.g. the clone failed), re-run the copy manually:
 
 ```bash
 cd <this workspace>
-claude plugin marketplace add ./.finance-skills --scope project
-claude plugin install finance-market-analysis@finance-skills --scope project
-claude plugin install finance-social-readers@finance-skills --scope project
-claude plugin install finance-data-providers@finance-skills --scope project
+git clone --depth=1 https://github.com/himself65/finance-skills.git .finance-skills
+mkdir -p .claude/skills .agents/skills
+for plugin in market-analysis social-readers data-providers; do
+  for skill in .finance-skills/plugins/$plugin/skills/*/; do
+    name=$(basename "$skill")
+    cp -R "$skill" ".claude/skills/$name"
+    cp -R "$skill" ".agents/skills/$name"
+  done
+done
 ```
 
-Then restart your Claude Code session (the `--scope project` declarations are picked up at session start).
+Then your next `claude` / `codex` session in this dir picks them up — no restart of OpenAlice needed.

--- a/src/workspaces/templates/finance-research/files/CLAUDE.md
+++ b/src/workspaces/templates/finance-research/files/CLAUDE.md
@@ -1,0 +1,48 @@
+# Finance Research workspace
+
+This workspace bundles **[himself65/finance-skills](https://github.com/himself65/finance-skills)** — a community plugin marketplace by [@himself65](https://github.com/himself65) (面包) covering market data, valuation, earnings analysis, options payoff, and social/research feeds.
+
+## What's installed
+
+Bootstrap clones the upstream finance-skills repo (latest `main`) into `./.finance-skills/` and installs three plugins at **project scope** (no user-global pollution):
+
+- `finance-market-analysis` — yfinance market data, DCF/SOTP valuation, earnings preview/recap, ETF premium/discount, options payoff, SEPA/VCP, stock correlation & liquidity
+- `finance-social-readers` — Twitter/X, Discord, LinkedIn, Telegram, Y Combinator readers; opencli fallback for 90+ research feeds
+- `finance-data-providers` — Adanos sentiment, Funda AI fundamental research (MCP + REST), Hormuz Strait monitoring, TradingView desktop app reading
+
+If the install missed any of those (network timeout, etc.), see the **Recovery** section at the bottom.
+
+## Two data layers — when to use which
+
+This workspace gives you **two market-data surfaces** that overlap. Use them deliberately:
+
+1. **OpenAlice's own MCP tools** (`/mcp` → `openalice`) — quotes, fundamentals, indicators, news. These are the **Alice canonical layer** wired to FMP / typebb / OpenBB. **Use these when a number will inform a trading decision** (UTA, position sizing, order routing) so the data口径 stays consistent with what Alice's trading engine sees.
+2. **finance-skills** — yfinance, Funda AI, opencli, social readers. **Use these to cover angles Alice doesn't ship** (Yahoo Finance historical depth, SaaS valuation compression, social sentiment, peer-screened correlation studies, etc.).
+
+Don't cross the streams: don't quote yfinance to make a UTA order routing call. Don't quote Alice's MCP to do a Twitter sentiment scan.
+
+## MCP wiring
+
+`.mcp.json` points at OpenAlice's MCP server (`http://127.0.0.1:3001/mcp` by default, or `$OPENALICE_MCP_URL`). The full OpenAlice tool surface — trading, market data, news, brain, indicators — is available alongside the finance-skills plugins.
+
+To verify on first attach:
+
+1. Approve the MCP server when Claude Code prompts for trust
+2. Run `/mcp` — you should see `openalice · ✓ connected`
+3. Run `/plugin list` — you should see the three `finance-*` plugins enabled
+
+## Upstream relationship
+
+`himself65/finance-skills` is an independent open-source project. We clone fresh from upstream on each new workspace creation — that gives the author visible GitHub traffic and ensures you always get their latest. We do not fork, mirror, or modify upstream. If a skill behaves unexpectedly, file the issue at the upstream repo, not OpenAlice.
+
+## Recovery (if bootstrap missed plugin install)
+
+```bash
+cd <this workspace>
+claude plugin marketplace add ./.finance-skills --scope project
+claude plugin install finance-market-analysis@finance-skills --scope project
+claude plugin install finance-social-readers@finance-skills --scope project
+claude plugin install finance-data-providers@finance-skills --scope project
+```
+
+Then restart your Claude Code session (the `--scope project` declarations are picked up at session start).

--- a/src/workspaces/templates/finance-research/files/mcp.json
+++ b/src/workspaces/templates/finance-research/files/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "openalice": {
+      "type": "streamable-http",
+      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"
+    },
+    "openalice-workspace": {
+      "type": "streamable-http",
+      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}/__WS_ID__"
+    }
+  }
+}

--- a/src/workspaces/templates/finance-research/template.json
+++ b/src/workspaces/templates/finance-research/template.json
@@ -1,0 +1,6 @@
+{
+  "displayName": "Finance Research",
+  "groupOrder": 30,
+  "description": "Finance research workspace bundling himself65/finance-skills (yfinance market data, valuation, earnings, social readers, sentiment). Cloned fresh from upstream on each workspace creation — credit and traffic flow back to the author. Plugins install at project scope; user-global Claude Code state stays clean.",
+  "defaultAgents": ["claude"]
+}

--- a/src/workspaces/templates/finance-research/template.json
+++ b/src/workspaces/templates/finance-research/template.json
@@ -1,6 +1,6 @@
 {
   "displayName": "Finance Research",
   "groupOrder": 30,
-  "description": "Finance research workspace bundling himself65/finance-skills (yfinance market data, valuation, earnings, social readers, sentiment). Cloned fresh from upstream on each workspace creation — credit and traffic flow back to the author. Plugins install at project scope; user-global Claude Code state stays clean.",
-  "defaultAgents": ["claude"]
+  "description": "Finance research workspace bundling himself65/finance-skills (yfinance market data, valuation, earnings, social readers, sentiment). SKILL.md files copied into project-local .claude/skills/ and .agents/skills/ — discovered natively by Claude Code AND Codex. Cloned fresh from upstream on each workspace creation; user-global state untouched.",
+  "defaultAgents": ["claude", "codex"]
 }


### PR DESCRIPTION
## Summary

Establishes the **satellite-repo pattern** as the official channel for
community/third-party content on the OpenAlice Workspace shelf — main
repo holds only manifest + bootstrap, content lives upstream. First
instance: `finance-research` template bundling
[himself65/finance-skills](https://github.com/himself65/finance-skills)
with SKILL.md trees discovered natively by both Claude Code AND Codex,
zero global-state pollution.

This unlocks ecosystem growth without breaching the OpenAlice rule that
**main repo never accepts external PRs** (UTA private-key handling
makes that non-negotiable). External content reaches users via Workspace
templates that clone upstream on demand.

## Per-session contributions

### 2026-05-15 — Satellite-repo workspace pattern + finance-research template

- **`finance-research` template** at `src/workspaces/templates/finance-research/`. Bootstrap clones `himself65/finance-skills` shallow and copies SKILL.md trees into both `.claude/skills/` (Claude Code) and `.agents/skills/` (Codex). 21 skills from 3 plugin packs (market-analysis / social-readers / data-providers). Bootstrap completes in ~2.1s, defaultAgents = `["claude", "codex"]`.
- **No registration ceremony**. Skill is a discovery format, not a registration system — bootstrap is just `git clone` + two `cp` loops, no `claude plugin install` / `npx skills add` / marketplace dance, no writes to `~/.claude/plugins/`. Workspace deletion fully removes all traces.
- **Why fresh-clone, not mirror-cache**: each new workspace = visible GitHub clone event back to the upstream author, intentional co-promotion (opposite of `auto-quant`'s mirror-cache optimization, on purpose).
- **`_common.sh` shared bootstrap lib** at `src/workspaces/templates/_common.sh`. Extracts `init_workspace_dir` / `extract_ws_id` / `write_mcp_config` / `compose_persona_claude_md` / `setup_git_excludes` / `commit_initial`. Refactored `chat/bootstrap.sh` (86→30 lines) and `auto-quant/bootstrap.sh` (just `setup_git_excludes` swap) to use it. Done now to prevent drift across what's about to be 3+ templates.
- Version bump to `0.21.0-beta.2`.
- Key commits: `5192a32`, `a8da862`, `c827428`

## Full commit log

```
c827428 chore(release): bump version to 0.21.0-beta.2
a8da862 refactor(workspace): finance-research uses cp-discovery, not plugin install
5192a32 feat(workspace): finance-research template + satellite-repo pattern
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` passes (1707 tests, 90 files)
- [x] Bash bootstrap e2e for `finance-research`: 2.1s, 21 skills installed under both discovery paths, zero `~/.claude/plugins/` pollution
- [x] Verified Claude Code discovers `.claude/skills/<name>/` (canary skill `oa-test-skill` shows in `/skills`)
- [x] Verified Codex discovers `.agents/skills/<name>/` (same canary appears in `codex exec` skill list)
- [x] Refactored `chat/bootstrap.sh` produces byte-identical output (persona prepend, MCP wiring with `__WS_ID__` substitution, AGENTS.md copy, `.git/info/exclude` defaults)
- [ ] Dashboard renders **Finance Research** card after dev server restart (template-registry is startup-time scan; not validated in browser this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)