### PR TITLE
chore(release): 0.21.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.21.0-beta.2",
+  "version": "0.21.0-beta.3",
   "description": "File-based trading agent engine",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Re-bump to recover the 0.21.0 release pipeline. The 0.21.0-beta.2
commit landed on master (PR #190) but the auto-release didn't fire
because I manually pushed the tag before merge — `release.yml` owns
tag creation and short-circuits when the tag already exists. This
bump lets the workflow run its intended end-to-end flow (commit only,
no manual tag, workflow creates tag + Release on master push).

## Per-session contributions

### 2026-05-15 — Release pipeline recovery (0.21.0-beta.2 → beta.3)

- Bump package.json: `0.21.0-beta.2` → `0.21.0-beta.3`
- No code changes; same content delta as beta.2
- `v0.21.0-beta.2` tag stays as orphan (no GitHub Release attached) — harmless because the in-app update banner reads from `gh release list`, not raw tags
- Lesson recorded: `release.yml` owns tag creation; **never** `git tag` before merging
- Key commit: `b71c4c3`

## Full commit log

```
b71c4c3 chore(release): bump version to 0.21.0-beta.3
```

## Test plan

- [x] `npx tsc --noEmit` clean (no source changes since beta.2)
- [x] `pnpm test` passes (no source changes since beta.2)
- [ ] After merge: confirm `release.yml` workflow creates `v0.21.0-beta.3` tag + Pre-release on GitHub Releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)