### PR TITLE
feat(workspaces): Windows compat + onboarding docs hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ pnpm test           # Unit tests
 
 `pnpm build` uses tsup which is lenient — `tsc --noEmit` catches strict type errors that tsup ignores.
 
+### Cross-platform note
+
+Workspace bootstrap scripts (`src/workspaces/templates/*/bootstrap.sh`) are bash-based. On Windows they require `bash` from Git for Windows (default install) or WSL2. `workspace-creator.ts` already platform-branches the spawn so the same script paths work on win32 — when adding a new template, write bash as usual, but **don't** add POSIX-only commands without checking they ship with Git for Windows's bundled MSYS env (sed/cp/mkdir/basename/printf/source/[[ ]] all work; obscure tools like `jq` do not). See README's *Windows* section for the user-facing story.
+
 ## Subsystem guides
 
 Some parts of this codebase are structured in ways that aren't obvious from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,10 +295,60 @@ need real fix-ups (that's the cost of an invasive refactor — and
 the reason you isolated it in the first place).
 
 **Decision rule for the next session that starts work:** if `master`
-is currently ahead of `dev` (because a refactor branch just landed
-there), do `git checkout dev && git merge origin/master` *before*
-starting any new feature work. Otherwise your new commits will land
-on a stale baseline.
+is currently ahead of `dev`, do `git checkout dev && git merge origin/master`
+*before* starting any new feature work. Otherwise your new commits
+will land on a stale baseline.
+
+Common reasons `master` would be ahead of `dev`:
+- An invasive refactor branch just landed (above flow).
+- A Claude Code cloud session opened a `claude/<short-desc>-XXXXX`
+  branch and merged it straight to master without going through `dev`
+  — typically for a time-sensitive fix the cloud agent shipped while
+  the human wasn't around (see next subsection).
+
+When the side-channel was content-bearing (not just a refactor) **dev
+is genuinely behind master in code**, not just in merge-commit objects.
+Skipping the sync lands new dev commits on stale code.
+
+One quirk to recognize: a single `git merge origin/master` into dev
+often surfaces a Discord/webhook notification like *"N new commits on
+dev"* where N is much larger than what the side branch actually added.
+Most of those N are **historical PR-merge commits** that have been
+accumulating on master for weeks (each dev → master PR creates a
+merge commit that exists only on master). The sync drags them onto
+dev in one go. The webhook reports commit-object count, not
+content-delta. Expected, not a sign anything's broken.
+
+### Emergency hotfix via cloud `claude/*` side branch
+
+A Claude Code cloud session can open a branch named
+`claude/<short-desc>-XXXXX`, PR straight to master, and merge it
+without touching `dev`. This is the right move for **genuine
+emergencies** the user isn't around to handle on dev (a runtime
+error blocking users, a CORS misconfiguration, a hotfix that can't
+wait for the next dev → master cycle). The cloud session uses it
+because:
+
+- Cloud sessions don't see in-flight local dev state and shouldn't
+  destabilize it
+- The fix is small and reviewable in isolation
+- Waiting for the user to bounce dev for a hotfix is silly when the
+  cloud agent already has a working tree
+
+**What this means for the next local session:**
+
+1. `git fetch origin && git log --oneline origin/dev..origin/master`
+   shows commits master has that dev doesn't — if there's anything
+   from a `claude/*` branch, dev needs the sync.
+2. `git checkout dev && git merge origin/master && git push origin dev`
+   (clean FF in typical case).
+3. Resume normal work on dev.
+
+**What this means for the cloud session deciding whether to side-branch:**
+default to opening a dev → master PR like everyone else. Only branch
+straight to master for fixes that meet *both*: (a) production-impacting
+or user-blocking, and (b) sub-100-line scope reviewable end-to-end in
+one sitting. Anything bigger or speculative goes through dev.
 
 **Parallel work happens in the cloud, not in local worktrees.** For a
 project this size, spinning up multiple local worktrees costs more

--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ pnpm dev
 
 Open [localhost:3002](http://localhost:3002) and start chatting. No API keys or config needed — the default setup uses your local Claude Code login (Claude Pro/Max subscription).
 
+### Windows
+
+OpenAlice's Workspace feature spawns bash-based bootstrap scripts to materialize new workspaces, so a POSIX shell environment is required:
+
+- **Recommended:** install [Git for Windows](https://gitforwindows.org/) and accept the default *"Use Git from the Windows Command Prompt"* option during setup — this puts `bash` plus the POSIX utilities the scripts depend on (`sed`, `cp`, `mkdir`, `basename`, `printf`, etc.) on your PATH.
+- **Alternative:** run OpenAlice from inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) — the Linux env handles everything natively.
+
+Native `cmd.exe` / PowerShell alone are not supported (no `bash`, no POSIX utilities). If `bash` isn't on PATH when you create a workspace, the bootstrap fails with an inline hint pointing back here.
+
+Note: we don't currently dogfood OpenAlice on Windows, so the broader experience (PTY rendering, file watching, paths with spaces) may have rough edges. Bug reports very welcome.
+
 ## Configuration
 
 All config lives in `data/config/` as JSON files with Zod validation. Missing files fall back to sensible defaults. You can edit these files directly or use the Web UI.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ graph TB
 
 **AI Provider** — The AI backend that powers Alice. Claude (via Agent SDK, supports OAuth login or API key) or Vercel AI SDK (Anthropic, OpenAI, Google). Switchable at runtime — no restart needed.
 
+**Workspace** — A directory + git repo + persistent terminal session running a native agent CLI (`claude`, `codex`, or `shell`) of your choice. OpenAlice plumbs its MCP servers into the workspace via `.mcp.json`, so the agent inside sees the workspace's local files plus OpenAlice's full tool surface (trading, market data, news, brain). Workspaces live under `~/.openalice/workspaces/<wsId>/` — each is its own self-contained scratch directory the agent can read, write, and `git commit` inside. This is the recommended substrate for any non-trivial AI work: native prompt cache, native CLI rendering, no protocol shim between you and the model. Capability extensions (browser automation, third-party CLIs, custom scrapers) ship as new workspace **templates** rather than `src/` dependencies, keeping the main repo small.
+
+**Inbox** — Workspace-to-user push channel. Agents working inside a workspace call the `inbox_push` MCP tool to surface docs (rendered live from workspace files) plus markdown commentary in a dedicated Inbox tab. The user reads, then clicks the reply bar at the bottom of the entry to jump back into the workspace's session and continue the conversation there. Inbox is distinct from the legacy **Notifications** surface (now demoted into the Chat sidebar's Traditional section) — that one is reserved for pre-Workspace Automation flows (heartbeat / cron pushes).
+
 ## Two kinds of chat
 
 OpenAlice ships two paths for chatting with Alice. They have very different performance characteristics, and picking the right one matters more than it looks.

--- a/src/workspaces/workspace-creator.spec.ts
+++ b/src/workspaces/workspace-creator.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for runScript() — focuses on the platform branch added for
+ * Windows compatibility. The actual subprocess is mocked; we only
+ * verify the spawn call shape (cmd + args) and the ENOENT-on-Windows
+ * error message.
+ *
+ * We can't run the real bash on a non-Windows CI when testing the
+ * win32 branch (and vice versa on Windows), so this test stubs
+ * `process.platform` and `child_process.spawn` to exercise both
+ * branches deterministically regardless of where vitest runs.
+ */
+
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runScript } from './workspace-creator.js';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+  exitCode: number | null;
+}
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  child.exitCode = null;
+  return child;
+}
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+describe('runScript platform branching', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    mockSpawn.mockReset();
+  });
+
+  it('on macOS / Linux, spawns the script directly so kernel reads the shebang', async () => {
+    setPlatform('darwin');
+    const child = makeFakeChild();
+    mockSpawn.mockReturnValue(child as unknown as childProcess.ChildProcess);
+
+    const promise = runScript('/tmp/foo/bootstrap.sh', ['tag-1', '/out'], { FOO: 'bar' }, 60_000);
+    child.emit('close', 0);
+    const res = await promise;
+
+    expect(res.ok).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      '/tmp/foo/bootstrap.sh',
+      ['tag-1', '/out'],
+      expect.objectContaining({
+        env: expect.objectContaining({ FOO: 'bar' }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+    );
+  });
+
+  it('on win32, wraps bash with the script as first arg (kernel does not read shebang)', async () => {
+    setPlatform('win32');
+    const child = makeFakeChild();
+    mockSpawn.mockReturnValue(child as unknown as childProcess.ChildProcess);
+
+    const promise = runScript(
+      'C:\\Users\\me\\templates\\chat\\bootstrap.sh',
+      ['tag-1', 'C:\\out'],
+      {},
+      60_000,
+    );
+    child.emit('close', 0);
+    const res = await promise;
+
+    expect(res.ok).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'bash',
+      ['C:\\Users\\me\\templates\\chat\\bootstrap.sh', 'tag-1', 'C:\\out'],
+      expect.any(Object),
+    );
+  });
+
+  it('on win32, ENOENT spawn error surfaces a Git-for-Windows install hint', async () => {
+    setPlatform('win32');
+    const child = makeFakeChild();
+    mockSpawn.mockReturnValue(child as unknown as childProcess.ChildProcess);
+
+    const promise = runScript('C:\\bootstrap.sh', [], {}, 60_000);
+    child.emit('error', new Error('spawn bash ENOENT'));
+    const res = await promise;
+
+    expect(res.ok).toBe(false);
+    expect(res.stderr).toMatch(/spawn bash ENOENT/);
+    expect(res.stderr).toMatch(/gitforwindows\.org/);
+    expect(res.stderr).toMatch(/WSL2/);
+  });
+
+  it('on macOS / Linux, ENOENT does NOT add the Windows hint', async () => {
+    setPlatform('darwin');
+    const child = makeFakeChild();
+    mockSpawn.mockReturnValue(child as unknown as childProcess.ChildProcess);
+
+    const promise = runScript('/tmp/missing.sh', [], {}, 60_000);
+    child.emit('error', new Error('spawn /tmp/missing.sh ENOENT'));
+    const res = await promise;
+
+    expect(res.ok).toBe(false);
+    expect(res.stderr).not.toMatch(/gitforwindows\.org/);
+  });
+});

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -170,14 +170,36 @@ interface RunResult {
   readonly exitCode: number | null;
 }
 
-function runScript(
+const WINDOWS_BASH_HINT =
+  'hint: bash not found on PATH. Install Git for Windows (accept the default ' +
+  '"Use Git from the Windows Command Prompt" option) from https://gitforwindows.org/, ' +
+  'or run OpenAlice from inside WSL2.';
+
+/**
+ * Run a bootstrap script.
+ *
+ * On macOS / Linux the script is invoked directly — the kernel reads the
+ * `#!/usr/bin/env bash` shebang and launches bash. On Windows the kernel
+ * doesn't read shebangs and there's no native bash, so we invoke bash
+ * explicitly with the script as its first argument. This requires `bash`
+ * to be on PATH, which Git for Windows provides under its default install
+ * options (WSL also works if OpenAlice itself is run from inside WSL).
+ *
+ * Exported for unit testing — the platform branch needs coverage that
+ * doesn't depend on which OS the tests happen to run on.
+ */
+export function runScript(
   script: string,
   args: readonly string[],
   extraEnv: { [key: string]: string },
   timeoutMs: number,
 ): Promise<RunResult> {
+  const isWindows = process.platform === 'win32';
+  const cmd = isWindows ? 'bash' : script;
+  const cmdArgs = isWindows ? [script, ...args] : args;
+
   return new Promise((resolve) => {
-    const child = spawn(script, args, {
+    const child = spawn(cmd, cmdArgs, {
       env: { ...process.env, ...extraEnv },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -200,10 +222,15 @@ function runScript(
 
     child.on('error', (err) => {
       clearTimeout(timer);
+      const errMsg = (err as Error).message;
+      // ENOENT on Windows when we tried `bash` means Git Bash / WSL bash
+      // isn't on PATH — surface the install hint right next to the failure.
+      const hinted =
+        isWindows && /ENOENT/i.test(errMsg) ? `${errMsg}\n${WINDOWS_BASH_HINT}` : errMsg;
       resolve({
         ok: false,
         stdout: Buffer.concat(stdoutChunks).toString('utf8'),
-        stderr: `${(err as Error).message}\n${Buffer.concat(stderrChunks).toString('utf8')}`,
+        stderr: `${hinted}\n${Buffer.concat(stderrChunks).toString('utf8')}`,
         exitCode: null,
       });
     });


### PR DESCRIPTION
## Summary

Rolling dev → master batch for the post-0.20.0 cycle, mixing two
threads:

1. **Onboarding docs hardening** — fresh Claude sessions kept
   re-deriving what Workspace / Inbox are from scratch because the
   README's Key Concepts section never named them. After the post-#192
   sync-confusion incident, CLAUDE.md's branch-decision rules also
   gained explicit coverage of the cloud `claude/*` hotfix flow.
2. **Feature: Windows compatibility for Workspace bootstrap** — the
   existing `spawn(bootstrapScript, ...)` flow doesn't survive on
   Windows (no native bash, kernel doesn't read shebangs). Platform-
   branched `runScript()` so the same bash scripts run via Git Bash
   (Git for Windows default install) or WSL2. ENOENT surfaces an
   inline install hint. Mac/Linux behavior is byte-identical.
   PTY / file-watch / paths-with-spaces Windows polish remains out
   of scope until a community user dogfoods.

## Per-session contributions

### 2026-05-16 — Windows compat + CLAUDE.md cloud-hotfix rule + tests backfill

- **CLAUDE.md cloud `claude/*` hotfix flow** (`3c206b8`). PR #192's CORS fix landed on master via a `claude/*` cloud side branch while user wasn't around — surfaced the gap that the old "Decision rule" paragraph framed master-ahead-of-dev as refactor-only. Generalized the rule, added two failure modes (content-behind vs merge-commit-object-behind), explained the *"N new commits on dev"* webhook quirk, added gating criteria for cloud sessions choosing side-branch vs dev.
- **Workspace Windows compat** (`3089479`). `runScript()` platform-branch: `spawn('bash', [script, ...args])` on win32. Inline Git-for-Windows install hint on ENOENT. New `workspace-creator.spec.ts` with 4 tests covering both platform branches via mocked `spawn` + `Object.defineProperty(process, 'platform', ...)` so they pass regardless of where CI runs (this module previously had zero direct test coverage). README's Windows section sets expectations honestly (we don't dogfood on Windows; expect rough edges in PTY/watcher; report back). CLAUDE.md Cross-platform note added so future sessions adding templates know the POSIX-tool whitelist.

Key commits: `3c206b8`, `3089479`

### 2026-05-16 — README: Workspace + Inbox

- Added two Key Concepts entries placed after AI Provider and before "Two kinds of chat"
- Phrasing keeps the existing one-paragraph-per-concept idiom
- No edits to Architecture diagram, Features list, or any other section — kept the change "稍微" (slight) per user direction

Key commits: `5c2a94c`

## Full commit log
```
3089479 feat(workspaces): Windows compat via Git for Windows bash wrap
5c2a94c docs(readme): add Workspace + Inbox to Key Concepts
3c206b8 docs(claude.md): cover cloud claude/* side-branch hotfix pattern
```

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` passes (1711 tests, 91 files — +4 from new workspace-creator.spec.ts)
- [x] Mac manual regression: chat + finance-research bootstrap byte-identical to pre-change (persona prepend, MCP wiring with `__WS_ID__` sub, `.git/info/exclude`, 21 skills double-discovery)
- [x] User confirmed Mac side not broken
- [ ] Windows manual verification — deferred to community dogfooder (no Windows hardware on this side); failure mode hint embedded in error path so they can self-diagnose
- [x] README renders correctly on GitHub
- [x] CLAUDE.md branch-decision rules cover both refactor-branch and `claude/*` cloud-hotfix flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)