### PR TITLE
docs(claude-md): add README maintenance discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,32 @@ Unfinished items there compound over time if they're forgotten.
   add it with enough context (symptom + suspected location) that the
   next person can start without re-derivation.
 
+## Working with README.md
+
+`README.md` is the public-facing positioning artifact. It accumulates
+debt fast because day-to-day changes rarely feel "README-worthy"
+individually — but a quarter's worth of small shifts can leave the
+README narrating an obsolete mental model. The right time to audit is
+**right after** a large-scale change ships, while context is fresh.
+
+- **After finishing a large-scale change**, scan the README for sections
+  that still describe the pre-change state. "Large-scale" means: a new
+  top-level concept landed (e.g. Workspace, Inbox); a module was
+  retired (e.g. Brain); an existing layer's responsibilities reshaped
+  (e.g. Automation split into scheduling + execution); a generation
+  version bump. Bug fixes, refactors that don't change user-facing
+  surface, and internal renames do **not** trigger an audit.
+- **Before making any README edits, ask the user how to frame the
+  changes** — the README is product positioning, not just docs.
+  Framing decisions ("is Automation legacy or is it reframed into two
+  layers?", "is Brain retired or trimmed?") belong to the user, not to
+  the AI. Present what you'd propose to change, get direction, then
+  edit.
+- **Don't churn marketing copy** — the three pillars, the tagline,
+  the hero — leave alone unless the user explicitly opens that
+  conversation. Frequent reframing of top-of-funnel copy is worse
+  than slightly-stale-but-consistent copy.
+
 ## Migrations
 
 `data/config/` and other persisted user state evolve across releases.


### PR DESCRIPTION
## Summary

Postmortem note from PR #194: the README had drifted ~1 generation (Brain still listed as current, Automation as a single-layer feature category, Workspace + Inbox only in Key Concepts) before that PR cleaned it up. Root cause was no documented trigger condition for "check the README". Individual changes rarely feel README-worthy, so the doc accumulates debt.

Adds a `Working with README.md` section in CLAUDE.md right after `Working with TODO.md`, matching the same shape. Three rules:

1. **Trigger condition**: large-scale change shipped (new top-level concept, retired module, layer responsibilities reshaped, generation version bump). Bug fixes / refactors / renames don't trigger.
2. **Ask user how to frame BEFORE editing**: README is positioning copy. Framing is a product decision the user owns, not the AI.
3. **Don't churn marketing copy**: hero / pillars / tagline left alone unless user explicitly opens that conversation.

## Per-session contributions

### 2026-05-16 — README discipline addition

Single commit, +26 / -0 in CLAUDE.md. Same voice and structure as the existing `Working with TODO.md` section. Aimed at future sessions: when a large-scale change ships, the trigger is clear and the right action is "ask before editing", not "go ahead and rewrite".

Key commit: `d8e274c`

## Full commit log
```
d8e274c docs(claude-md): add README maintenance discipline
```

## Test plan
- [x] CLAUDE.md scans cleanly — new section sits between TODO.md and Migrations
- [ ] Next large-scale change actually triggers a README audit before edits — to be observed in subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)