### PR TITLE
rolling: inbox delete + activitybar Linear + Chat split + Legacy section + readme cleanup + AI provider polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,15 +246,6 @@ On first run, defaults are auto-copied to the user override path. Edit the user 
 
 OpenAlice is a pnpm monorepo with Turborepo build orchestration. See [docs/project-structure.md](docs/project-structure.md) for the full file tree.
 
-## Roadmap to v1
-
-OpenAlice is in pre-release. All planned v1 milestones are now complete — remaining work is testing and stabilization.
-
-- [x] **Tool confirmation** — achieved through Trading-as-Git's push approval mechanism. Order execution requires explicit user approval at the push step, similar to merging a PR
-- [x] **Trading-as-Git stable interface** — the core workflow (stage → commit → push → approval) is stable and running in production
-- [x] **IBKR broker** — Interactive Brokers integration via TWS/Gateway. `IbkrBroker` bridges the callback-based `@traderalice/ibkr` SDK to the Promise-based `IBroker` interface via `RequestBridge`. Supports all IBroker methods including conId-based contract resolution
-- [x] **Account snapshot & analytics** — periodic and event-driven snapshots with equity curve visualization, configurable intervals, and carry-forward for data gaps
-
 ## Getting Help
 
 Stuck? Here's the recommended path, roughly in order:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.21.0-beta.3",
+  "version": "0.21.0-beta.4",
   "description": "File-based trading agent engine",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@ai-sdk/openai": "^3.0.30",
     "@alpacahq/alpaca-trade-api": "^3.1.3",
     "@anthropic-ai/claude-agent-sdk": "^0.2.72",
+    "@anthropic-ai/sdk": "^0.96.0",
     "@grammyjs/auto-retry": "^2.0.2",
     "@hono/node-server": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.72
         version: 0.2.72(zod@4.3.6)
+      '@anthropic-ai/sdk':
+        specifier: ^0.96.0
+        version: 0.96.0(zod@4.3.6)
       '@grammyjs/auto-retry':
         specifier: ^2.0.2
         version: 2.0.2(grammy@1.40.0)
@@ -322,6 +325,15 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.96.0':
+    resolution: {integrity: sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -1158,6 +1170,9 @@ packages:
   '@sinclair/typebox@0.34.48':
     resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1953,6 +1968,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2172,6 +2190,10 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -2865,6 +2887,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3000,6 +3025,9 @@ packages:
   trim-repeated@1.0.0:
     resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
     engines: {node: '>=0.10.0'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -3472,6 +3500,13 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.34.5
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+
+  '@anthropic-ai/sdk@0.96.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -4064,6 +4099,8 @@ snapshots:
       '@scure/base': 1.2.6
 
   '@sinclair/typebox@0.34.48': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4893,6 +4930,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
@@ -5111,6 +5150,11 @@ snapshots:
       - '@noble/hashes'
 
   jsesc@3.1.0: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -5731,6 +5775,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -5851,6 +5900,8 @@ snapshots:
   trim-repeated@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/src/core/inbox-store.spec.ts
+++ b/src/core/inbox-store.spec.ts
@@ -103,6 +103,30 @@ describe('InboxStore (in-memory)', () => {
     expect(entries.map((e) => e.id)).toEqual([e2.id, e1.id])
   })
 
+  it('delete removes an entry and returns true; missing id returns false', async () => {
+    const a = await store.append({ workspaceId: 'ws-1', comments: 'a' })
+    await store.append({ workspaceId: 'ws-1', comments: 'b' })
+    expect(await store.delete(a.id)).toBe(true)
+    const { entries } = await store.read()
+    expect(entries.map((e) => e.comments)).toEqual(['b'])
+    expect(await store.delete('does-not-exist')).toBe(false)
+    expect(await store.delete(a.id)).toBe(false)
+  })
+
+  it('onRemoved fires on successful delete, dispose stops further notifications', async () => {
+    const seen: string[] = []
+    const dispose = store.onRemoved((id) => seen.push(id))
+    const a = await store.append({ workspaceId: 'ws-1', comments: 'a' })
+    const b = await store.append({ workspaceId: 'ws-1', comments: 'b' })
+    await store.delete(a.id)
+    await store.delete(b.id)
+    expect(seen).toEqual([a.id, b.id])
+    dispose()
+    const c = await store.append({ workspaceId: 'ws-1', comments: 'c' })
+    await store.delete(c.id)
+    expect(seen).toHaveLength(2)
+  })
+
   it('onAppended fires on append, dispose stops further notifications', async () => {
     const seen: InboxEntry[] = []
     const dispose = store.onAppended((e) => seen.push(e))
@@ -145,6 +169,36 @@ describe('InboxStore (JSONL persistence)', () => {
     const { entries, hasMore } = await missing.read()
     expect(entries).toEqual([])
     expect(hasMore).toBe(false)
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('delete rewrites the JSONL atomically; missing entries do not corrupt the file', async () => {
+    const a = await store.append({ workspaceId: 'ws-1', comments: 'a' })
+    const b = await store.append({ workspaceId: 'ws-1', comments: 'b' })
+    const c = await store.append({ workspaceId: 'ws-1', comments: 'c' })
+    expect(await store.delete(b.id)).toBe(true)
+
+    // Re-open from disk — verify only a and c survive, in original order.
+    const fresh = createInboxStore({ filePath: path })
+    const { entries } = await fresh.read()
+    expect(entries.map((e) => e.id)).toEqual([c.id, a.id])
+
+    // Deleting a non-existent id on disk is a no-op (returns false; file
+    // contents unchanged).
+    expect(await store.delete('does-not-exist')).toBe(false)
+    const fresh2 = createInboxStore({ filePath: path })
+    const { entries: again } = await fresh2.read()
+    expect(again.map((e) => e.id)).toEqual([c.id, a.id])
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('delete leaves no tmp file on the side', async () => {
+    const a = await store.append({ workspaceId: 'ws-1', comments: 'a' })
+    await store.delete(a.id)
+    const fs = await import('node:fs/promises')
+    const entries = await fs.readdir(dir)
+    expect(entries).toContain('entries.jsonl')
+    expect(entries).not.toContain('entries.jsonl.tmp')
     await rm(dir, { recursive: true, force: true })
   })
 })

--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -27,7 +27,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { readFile, appendFile, mkdir } from 'node:fs/promises'
+import { readFile, appendFile, mkdir, writeFile, rename } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { EventEmitter } from 'node:events'
 
@@ -63,7 +63,12 @@ export interface InboxReadOpts {
 export interface IInboxStore {
   append(input: InboxInput): Promise<InboxEntry>
   read(opts?: InboxReadOpts): Promise<{ entries: InboxEntry[]; hasMore: boolean }>
+  /** Hard-delete an entry by id. Returns true if removed, false if no
+   *  entry matched. JSONL rewrites are atomic (tmp + rename). */
+  delete(id: string): Promise<boolean>
   onAppended(listener: (entry: InboxEntry) => void): () => void
+  /** Subscribe to live removals. Returns a dispose function. */
+  onRemoved(listener: (id: string) => void): () => void
 }
 
 const INBOX_FILE = join(process.cwd(), 'data', 'inbox', 'entries.jsonl')
@@ -145,6 +150,45 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
     return { entries, hasMore }
   }
 
+  async function deleteEntry(id: string): Promise<boolean> {
+    let raw: string
+    try {
+      raw = await readFile(filePath, 'utf-8')
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return false
+      }
+      throw err
+    }
+    const lines = raw.split('\n').filter((l) => l.trim())
+    let removed = false
+    const kept: string[] = []
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as InboxEntry
+        if (entry.id === id) {
+          removed = true
+          continue
+        }
+        kept.push(line)
+      } catch {
+        // Preserve unparseable lines so a malformed entry can't be used to
+        // accidentally wipe the file via delete().
+        kept.push(line)
+      }
+    }
+    if (!removed) return false
+
+    // Atomic rewrite — tmp + rename. Crash mid-write leaves the previous
+    // file intact instead of producing a half-truncated JSONL.
+    const tmp = `${filePath}.tmp`
+    const body = kept.length > 0 ? kept.join('\n') + '\n' : ''
+    await writeFile(tmp, body, 'utf-8')
+    await rename(tmp, filePath)
+    emitter.emit('removed', id)
+    return true
+  }
+
   function onAppended(listener: (entry: InboxEntry) => void): () => void {
     emitter.on('appended', listener)
     return () => {
@@ -152,7 +196,14 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
     }
   }
 
-  return { append, read, onAppended }
+  function onRemoved(listener: (id: string) => void): () => void {
+    emitter.on('removed', listener)
+    return () => {
+      emitter.off('removed', listener)
+    }
+  }
+
+  return { append, read, delete: deleteEntry, onAppended, onRemoved }
 }
 
 // ==================== In-memory store (tests) ====================
@@ -185,6 +236,14 @@ export function createMemoryInboxStore(): IInboxStore {
     return { entries: [...window].reverse(), hasMore: window.length < scoped.length }
   }
 
+  async function deleteEntry(id: string): Promise<boolean> {
+    const idx = entries.findIndex((e) => e.id === id)
+    if (idx < 0) return false
+    entries.splice(idx, 1)
+    emitter.emit('removed', id)
+    return true
+  }
+
   function onAppended(listener: (entry: InboxEntry) => void): () => void {
     emitter.on('appended', listener)
     return () => {
@@ -192,5 +251,12 @@ export function createMemoryInboxStore(): IInboxStore {
     }
   }
 
-  return { append, read, onAppended }
+  function onRemoved(listener: (id: string) => void): () => void {
+    emitter.on('removed', listener)
+    return () => {
+      emitter.off('removed', listener)
+    }
+  }
+
+  return { append, read, delete: deleteEntry, onAppended, onRemoved }
 }

--- a/src/webui/routes/inbox.ts
+++ b/src/webui/routes/inbox.ts
@@ -77,5 +77,16 @@ export function createInboxRoutes(deps: InboxRoutesDeps) {
     }
   })
 
+  /** Hard-delete an inbox entry. 204 on success, 404 when no entry
+   *  matches. Matches the "archive" affordance in the inbox UI, but
+   *  the semantics are full removal — we don't have an "underlying
+   *  issue" the way Linear does, so the entry IS the artifact. */
+  app.delete('/:id', async (c) => {
+    const id = c.req.param('id')
+    const removed = await deps.inboxStore.delete(id)
+    if (!removed) return c.json({ error: 'not_found' }, 404)
+    return c.body(null, 204)
+  })
+
   return app
 }

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'node:crypto';
 import { readFile, rm } from 'node:fs/promises';
 import { join, resolve as resolvePath } from 'node:path';
 
+import { probeAnthropic, probeOpenAI } from '../../workspaces/agent-probe.js';
 import { listDir, PathTraversal, readWorkspaceFile, writeWorkspaceFile } from '../../workspaces/file-service.js';
 import { gitLog, gitStatus } from '../../workspaces/git-service.js';
 import { logger as launcherLogger } from '../../workspaces/logger.js';
@@ -520,6 +521,42 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
       if (err instanceof PathTraversal) return c.json({ error: 'invalid_path' }, 400);
       launcherLogger.warn('agent_config.write_failed', { id, agent, err });
       return c.json({ error: 'write_failed', message: (err as Error).message }, 500);
+    }
+  });
+
+  // Probe live provider with the form state (does NOT touch workspace files —
+  // tests exactly what the user sees in the modal, before they hit Save).
+  app.post('/:id/agent-config/:agent/test', async (c) => {
+    const id = c.req.param('id');
+    const agent = c.req.param('agent');
+    if (!validId(id)) return c.json({ ok: false, error: 'invalid_id' }, 400);
+    if (agent !== 'claude' && agent !== 'codex') {
+      return c.json({ ok: false, error: 'unknown_agent' }, 400);
+    }
+
+    const body = (await safeJson(c)) as AgentConfigInput | null;
+    const baseUrl = typeof body?.baseUrl === 'string' ? body.baseUrl.trim() : '';
+    const apiKey = typeof body?.apiKey === 'string' ? body.apiKey.trim() : '';
+    const model = typeof body?.model === 'string' ? body.model.trim() : '';
+    if (!baseUrl || !apiKey || !model) {
+      return c.json({ ok: false, error: 'baseUrl, apiKey, and model are all required' }, 400);
+    }
+
+    try {
+      const result = agent === 'claude'
+        ? await probeAnthropic({ baseUrl, apiKey, model })
+        : await probeOpenAI({
+            baseUrl,
+            apiKey,
+            model,
+            wireApi: body?.wireApi === 'chat' ? 'chat' : 'responses',
+          });
+      return c.json({ ok: true, response: result.text });
+    } catch (err) {
+      const e = err as { status?: number; message?: string };
+      const msg = e.status ? `${e.status} ${e.message ?? 'error'}` : (e.message ?? String(err));
+      launcherLogger.info('agent_config.test_failed', { id, agent, msg });
+      return c.json({ ok: false, error: msg });
     }
   });
 

--- a/src/workspaces/agent-probe.ts
+++ b/src/workspaces/agent-probe.ts
@@ -1,0 +1,61 @@
+/**
+ * Per-workspace AI provider probes — used by the Workspace AI config modal's
+ * Test button. Sends a minimal "Hi" prompt to verify baseUrl + apiKey + model
+ * end-to-end. Returns the model's reply text on success so the UI can show
+ * "the AI actually spoke back."
+ *
+ * Lives in `src/workspaces/` rather than inlined in the route so future
+ * surfaces (Telegram /workspace test, CLI) can reuse the same probe.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import OpenAI from 'openai';
+
+export interface ProbeResult {
+  text: string;
+}
+
+export interface ClaudeProbeInput {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+export interface CodexProbeInput {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  wireApi: 'chat' | 'responses';
+}
+
+export async function probeAnthropic(input: ClaudeProbeInput): Promise<ProbeResult> {
+  const client = new Anthropic({ apiKey: input.apiKey, baseURL: input.baseUrl });
+  const msg = await client.messages.create({
+    model: input.model,
+    max_tokens: 32,
+    messages: [{ role: 'user', content: 'Hi' }],
+  });
+  const text = msg.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+  return { text };
+}
+
+export async function probeOpenAI(input: CodexProbeInput): Promise<ProbeResult> {
+  const client = new OpenAI({ apiKey: input.apiKey, baseURL: input.baseUrl });
+  if (input.wireApi === 'responses') {
+    const resp = await client.responses.create({
+      model: input.model,
+      input: 'Hi',
+      max_output_tokens: 32,
+    });
+    return { text: resp.output_text ?? '' };
+  }
+  const resp = await client.chat.completions.create({
+    model: input.model,
+    messages: [{ role: 'user', content: 'Hi' }],
+    max_tokens: 32,
+  });
+  return { text: resp.choices[0]?.message?.content ?? '' };
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,6 +19,7 @@ export type Page =
   | 'chat' | 'inbox' | 'workspaces' | 'portfolio' | 'news' | 'automation' | 'market'
   | 'trading-as-git'
   | 'settings' | 'dev'
+  | 'traditional-chat' | 'notifications-legacy'
 
 /** Track whether we're at a desktop viewport (md+ in Tailwind = ≥768px). */
 function useIsDesktop(): boolean {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,7 +19,7 @@ export type Page =
   | 'chat' | 'inbox' | 'workspaces' | 'portfolio' | 'news' | 'automation' | 'market'
   | 'trading-as-git'
   | 'settings' | 'dev'
-  | 'traditional-chat' | 'notifications-legacy'
+  | 'traditional-chat' | 'notifications-legacy' | 'connectors-legacy'
 
 /** Track whether we're at a desktop viewport (md+ in Tailwind = ≥768px). */
 function useIsDesktop(): boolean {

--- a/ui/src/api/inbox.ts
+++ b/ui/src/api/inbox.ts
@@ -46,4 +46,15 @@ export const inboxApi = {
       body: JSON.stringify(body),
     })
   },
+
+  /** Hard-delete an inbox entry. Returns true on success, false if
+   *  the entry didn't exist (server replied 404). */
+  async delete(id: string): Promise<boolean> {
+    const res = await fetch(`/api/inbox/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    })
+    if (res.status === 204) return true
+    if (res.status === 404) return false
+    throw new Error(`inbox delete failed: ${res.status}`)
+  },
 }

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,8 +1,9 @@
-import { type LucideIcon, MessageSquare, Inbox, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare } from 'lucide-react'
+import { type LucideIcon, MessageSquare, Inbox, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown } from 'lucide-react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
 import type { ActivitySection, ViewSpec } from '../tabs/types'
 import { useUnreadInboxCount } from '../live/inbox-read'
+import { useActivityBarCollapse } from '../live/activity-bar-collapse'
 
 /**
  * Map ActivityBar page enum (visual layout grouping) to the ActivitySection
@@ -85,11 +86,26 @@ const NAV_SECTIONS: NavSection[] = [
 
 // ==================== ActivityBar ====================
 
+/**
+ * Linear-style left nav. 220px wide on all viewports; on mobile (<md)
+ * it slides in over the page from the left, on desktop it's a static
+ * column. Top section (no header) is the pinned-nav block — Chat,
+ * Inbox, Workspaces, etc. — always visible. Labeled sections (Agent,
+ * System) get collapsible chevron headers; collapse state persists
+ * to localStorage.
+ *
+ * The wider layout (vs VS Code's 56px icon-only column) is deliberate
+ * for OpenAlice's current phase: items in the bar live in different
+ * lifecycle stages and the section labels are how we'll later
+ * communicate that. Mostly-icon view would hide the differentiation.
+ */
 export function ActivityBar({ open, onClose }: ActivityBarProps) {
   const selectedSidebar = useWorkspace((state) => state.selectedSidebar)
   const setSidebar = useWorkspace((state) => state.setSidebar)
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
   const unreadInbox = useUnreadInboxCount()
+  const collapsedSections = useActivityBarCollapse((s) => s.collapsedSections)
+  const toggleSection = useActivityBarCollapse((s) => s.toggleSection)
 
   return (
     <>
@@ -101,95 +117,117 @@ export function ActivityBar({ open, onClose }: ActivityBarProps) {
         onClick={onClose}
       />
 
-      {/* ActivityBar — mobile: 220px slide-in with labels; desktop: 56px icon-only column */}
+      {/* ActivityBar — 220px on all viewports. Mobile: slide-in over
+       *  page with backdrop. Desktop: static column flush left. */}
       <aside
         className={`
-          w-[220px] md:w-14 h-full flex flex-col shrink-0
-          bg-bg-secondary md:bg-bg
-          border-r border-border md:border-r-0
+          w-[220px] h-full flex flex-col shrink-0
+          bg-bg-secondary
+          border-r border-border
           fixed z-50 top-0 left-0 transition-transform duration-200
           ${open ? 'translate-x-0' : '-translate-x-full'}
           md:static md:translate-x-0 md:z-auto md:transition-none
         `}
       >
         {/* Branding */}
-        <div className="px-5 md:px-0 md:justify-center py-4 flex items-center gap-2.5">
+        <div className="px-5 py-4 flex items-center gap-2.5">
           <img
             src="/alice.ico"
             alt="Alice"
             className="w-7 h-7 rounded-lg ring-1 ring-accent/25 shadow-[0_0_8px_rgba(88,166,255,0.15)]"
             draggable={false}
           />
-          <h1 className="text-[15px] font-semibold text-text md:hidden">OpenAlice</h1>
+          <h1 className="text-[15px] font-semibold text-text">OpenAlice</h1>
         </div>
 
         {/* Navigation */}
-        <nav className="flex-1 flex flex-col px-2 md:px-1.5 overflow-y-auto">
-          {NAV_SECTIONS.map((section, si) => (
-            <div key={si} className={si > 0 ? 'mt-4 md:mt-2' : ''}>
-              {section.sectionLabel && (
-                <p className="px-3 mb-1 text-[11px] font-medium text-text-muted/50 uppercase tracking-wider md:hidden">
-                  {section.sectionLabel}
-                </p>
-              )}
-              <div className="flex flex-col gap-0.5">
-                {section.items.map((item) => {
-                  const sec = activitySectionFor(item.page)
-                  const isActive = selectedSidebar === sec
-                  const Icon = item.icon
-                  const handleClick = () => {
-                    onClose()
-                    if (selectedSidebar === sec) {
-                      // Same section re-clicked: toggle sidebar off. Don't
-                      // touch the focused tab — collapsing the sidebar
-                      // shouldn't change what's in the editor.
-                      setSidebar(null)
-                    } else {
-                      setSidebar(sec)
-                      // Activities with a meaningful default landing (e.g.
-                      // Portfolio overview) jump straight to it. Sidebar-only
-                      // activities (Chat, Settings, Trading-as-Git, …) leave
-                      // tab focus alone — user picks from the sidebar.
-                      if (item.defaultTab) openOrFocus(item.defaultTab)
-                    }
-                  }
-                  return (
-                    <button
-                      key={item.page}
-                      type="button"
-                      onClick={handleClick}
-                      title={item.label}
-                      className={`relative flex items-center gap-3 px-3 py-2 md:px-0 md:py-2.5 md:rounded-none md:justify-center rounded-lg text-sm transition-colors text-left ${
-                        isActive
-                          ? 'bg-bg-tertiary text-text md:bg-transparent'
-                          : 'text-text-muted hover:text-text hover:bg-bg-tertiary/50 md:hover:bg-bg-secondary'
+        <nav className="flex-1 flex flex-col px-2 overflow-y-auto pb-3">
+          {NAV_SECTIONS.map((section, si) => {
+            const labeled = section.sectionLabel.length > 0
+            const isCollapsed = labeled && Boolean(collapsedSections[section.sectionLabel])
+            const showItems = !isCollapsed
+            return (
+              <div key={si} className={si > 0 ? 'mt-4' : ''}>
+                {labeled && (
+                  <button
+                    type="button"
+                    onClick={() => toggleSection(section.sectionLabel)}
+                    className="w-full flex items-center gap-1.5 px-3 mb-1 py-1 text-[11px] font-medium text-text-muted/60 hover:text-text-muted uppercase tracking-wider transition-colors"
+                    aria-expanded={!isCollapsed}
+                    aria-controls={`activity-section-${si}`}
+                  >
+                    <ChevronDown
+                      size={12}
+                      strokeWidth={2.25}
+                      className={`shrink-0 transition-transform duration-150 ${
+                        isCollapsed ? '-rotate-90' : 'rotate-0'
                       }`}
-                    >
-                      {/* Active indicator — left vertical bar, desktop only */}
-                      <span
-                        className={`absolute left-0 top-2 bottom-2 w-[2px] rounded-r-full bg-accent transition-opacity duration-150 hidden md:block ${
-                          isActive ? 'opacity-100' : 'opacity-0'
-                        }`}
-                        aria-hidden
-                      />
-                      <span className="relative flex items-center justify-center w-5 h-5">
-                        <Icon size={18} strokeWidth={1.5} />
-                        {item.page === 'inbox' && unreadInbox > 0 && (
+                      aria-hidden
+                    />
+                    <span>{section.sectionLabel}</span>
+                  </button>
+                )}
+                {showItems && (
+                  <div className="flex flex-col gap-0.5" id={`activity-section-${si}`}>
+                    {section.items.map((item) => {
+                      const sec = activitySectionFor(item.page)
+                      const isActive = selectedSidebar === sec
+                      const Icon = item.icon
+                      const handleClick = () => {
+                        onClose()
+                        if (selectedSidebar === sec) {
+                          // Same section re-clicked: toggle sidebar off. Don't
+                          // touch the focused tab — collapsing the sidebar
+                          // shouldn't change what's in the editor.
+                          setSidebar(null)
+                        } else {
+                          setSidebar(sec)
+                          // Activities with a meaningful default landing (e.g.
+                          // Portfolio overview) jump straight to it. Sidebar-only
+                          // activities (Chat, Settings, Trading-as-Git, …) leave
+                          // tab focus alone — user picks from the sidebar.
+                          if (item.defaultTab) openOrFocus(item.defaultTab)
+                        }
+                      }
+                      return (
+                        <button
+                          key={item.page}
+                          type="button"
+                          onClick={handleClick}
+                          title={item.label}
+                          className={`relative flex items-center gap-3 px-3 py-1.5 rounded-md text-[13px] transition-colors text-left ${
+                            isActive
+                              ? 'bg-bg-tertiary text-text'
+                              : 'text-text-muted hover:text-text hover:bg-bg-tertiary/50'
+                          }`}
+                        >
+                          {/* Active indicator — left vertical bar */}
                           <span
-                            aria-label={`${unreadInbox} unread`}
-                            className="absolute -top-1 -right-1 min-w-[14px] h-[14px] px-1 rounded-full bg-red text-[9px] font-semibold text-white tabular-nums flex items-center justify-center"
-                          >
-                            {unreadInbox > 99 ? '99+' : unreadInbox}
+                            className={`absolute left-0 top-1.5 bottom-1.5 w-[2px] rounded-r-full bg-accent transition-opacity duration-150 ${
+                              isActive ? 'opacity-100' : 'opacity-0'
+                            }`}
+                            aria-hidden
+                          />
+                          <span className="relative flex items-center justify-center w-5 h-5 shrink-0">
+                            <Icon size={16} strokeWidth={1.75} />
                           </span>
-                        )}
-                      </span>
-                      <span className="md:hidden">{item.label}</span>
-                    </button>
-                  )
-                })}
+                          <span className="flex-1 truncate">{item.label}</span>
+                          {item.page === 'inbox' && unreadInbox > 0 && (
+                            <span
+                              aria-label={`${unreadInbox} unread`}
+                              className="shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center"
+                            >
+                              {unreadInbox > 99 ? '99+' : unreadInbox}
+                            </span>
+                          )}
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
               </div>
-            </div>
-          ))}
+            )
+          })}
         </nav>
 
       </aside>

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import { type LucideIcon, MessageSquare, Inbox, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown } from 'lucide-react'
+import { type LucideIcon, MessageSquare, MessagesSquare, Inbox, Bell, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown } from 'lucide-react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
 import type { ActivitySection, ViewSpec } from '../tabs/types'
@@ -11,16 +11,18 @@ import { useActivityBarCollapse } from '../live/activity-bar-collapse'
  */
 function activitySectionFor(page: Page): ActivitySection {
   switch (page) {
-    case 'chat':           return 'chat'
-    case 'inbox':          return 'inbox'
-    case 'workspaces':     return 'workspaces'
-    case 'trading-as-git': return 'trading-as-git'
-    case 'settings':       return 'settings'
-    case 'dev':            return 'dev'
-    case 'market':         return 'market'
-    case 'portfolio':      return 'portfolio'
-    case 'automation':     return 'automation'
-    case 'news':           return 'news'
+    case 'chat':                 return 'chat'
+    case 'inbox':                return 'inbox'
+    case 'workspaces':           return 'workspaces'
+    case 'trading-as-git':       return 'trading-as-git'
+    case 'settings':             return 'settings'
+    case 'dev':                  return 'dev'
+    case 'market':               return 'market'
+    case 'portfolio':            return 'portfolio'
+    case 'automation':           return 'automation'
+    case 'news':                 return 'news'
+    case 'traditional-chat':     return 'traditional-chat'
+    case 'notifications-legacy': return 'notifications-legacy'
   }
 }
 
@@ -54,15 +56,28 @@ interface NavLeaf {
 interface NavSection {
   sectionLabel: string
   items: NavLeaf[]
+  /** When true, the section starts collapsed on a user's first visit
+   *  (or after they clear localStorage). User-toggled collapse state
+   *  still wins — `defaultCollapsed` only fills in the absence-of-key
+   *  default. Useful for "this section exists but isn't the recommended
+   *  path" framing (Legacy). */
+  defaultCollapsed?: boolean
 }
 
 const NAV_SECTIONS: NavSection[] = [
+  // Top — primary nav, always visible (no header, not collapsible).
+  // Mental model: Workspace is the atom for all work units. Chat is
+  // the high-frequency subset's shortcut — chat-template workspaces
+  // got their own top-level entry because that flow is common enough
+  // to warrant direct access. Workspaces (the all-templates index)
+  // sits alongside; the two aren't redundant: Workspaces = whole set,
+  // Chat = chat-shape subset shortcut.
   {
     sectionLabel: '',
     items: [
-      { page: 'chat',           label: 'Chat',           icon: MessageSquare },
       { page: 'inbox',          label: 'Inbox',          icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
       { page: 'workspaces',     label: 'Workspaces',     icon: TerminalSquare },
+      { page: 'chat',           label: 'Chat',           icon: MessageSquare },
       { page: 'portfolio',      label: 'Portfolio',      icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
       { page: 'trading-as-git', label: 'Trading as Git', icon: GitBranch },
       { page: 'market',         label: 'Market',         icon: BarChart3 },
@@ -70,16 +85,22 @@ const NAV_SECTIONS: NavSection[] = [
     ],
   },
   {
-    sectionLabel: 'Agent',
-    items: [
-      { page: 'automation', label: 'Automation', icon: Zap, defaultTab: { kind: 'automation', params: { section: 'flow' } } },
-    ],
-  },
-  {
     sectionLabel: 'System',
     items: [
       { page: 'settings', label: 'Settings', icon: Settings },
       { page: 'dev',      label: 'Dev',      icon: Code2 },
+    ],
+  },
+  // Legacy — pre-Workspace surfaces kept around for backwards-compat
+  // and connector flows that can't host a CLI. Default-collapsed so
+  // the "this isn't the recommended path" signal is visually loud.
+  {
+    sectionLabel: 'Legacy',
+    defaultCollapsed: true,
+    items: [
+      { page: 'traditional-chat',     label: 'Traditional chat', icon: MessagesSquare },
+      { page: 'notifications-legacy', label: 'Notifications',    icon: Bell, defaultTab: { kind: 'notifications-inbox', params: {} } },
+      { page: 'automation',           label: 'Automation',       icon: Zap, defaultTab: { kind: 'automation', params: { section: 'flow' } } },
     ],
   },
 ]
@@ -105,7 +126,7 @@ export function ActivityBar({ open, onClose }: ActivityBarProps) {
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
   const unreadInbox = useUnreadInboxCount()
   const collapsedSections = useActivityBarCollapse((s) => s.collapsedSections)
-  const toggleSection = useActivityBarCollapse((s) => s.toggleSection)
+  const setCollapsed = useActivityBarCollapse((s) => s.setCollapsed)
 
   return (
     <>
@@ -144,14 +165,25 @@ export function ActivityBar({ open, onClose }: ActivityBarProps) {
         <nav className="flex-1 flex flex-col px-2 overflow-y-auto pb-3">
           {NAV_SECTIONS.map((section, si) => {
             const labeled = section.sectionLabel.length > 0
-            const isCollapsed = labeled && Boolean(collapsedSections[section.sectionLabel])
+            // User toggle wins over default. The collapse store stores
+            // user's explicit preference (true/false); absence means
+            // "fall back to defaultCollapsed". Once the user touches a
+            // section, their preference is sticky.
+            const stored = labeled ? collapsedSections[section.sectionLabel] : undefined
+            const isCollapsed = labeled && (
+              stored !== undefined ? stored : Boolean(section.defaultCollapsed)
+            )
             const showItems = !isCollapsed
             return (
               <div key={si} className={si > 0 ? 'mt-4' : ''}>
                 {labeled && (
                   <button
                     type="button"
-                    onClick={() => toggleSection(section.sectionLabel)}
+                    onClick={() => setCollapsed(
+                      section.sectionLabel,
+                      !isCollapsed,
+                      section.defaultCollapsed,
+                    )}
                     className="w-full flex items-center gap-1.5 px-3 mb-1 py-1 text-[11px] font-medium text-text-muted/60 hover:text-text-muted uppercase tracking-wider transition-colors"
                     aria-expanded={!isCollapsed}
                     aria-controls={`activity-section-${si}`}

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import { type LucideIcon, MessageSquare, MessagesSquare, Inbox, Bell, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown } from 'lucide-react'
+import { type LucideIcon, MessageSquare, MessagesSquare, Inbox, Bell, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Plug } from 'lucide-react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
 import type { ActivitySection, ViewSpec } from '../tabs/types'
@@ -23,6 +23,7 @@ function activitySectionFor(page: Page): ActivitySection {
     case 'news':                 return 'news'
     case 'traditional-chat':     return 'traditional-chat'
     case 'notifications-legacy': return 'notifications-legacy'
+    case 'connectors-legacy':    return 'connectors-legacy'
   }
 }
 
@@ -100,6 +101,7 @@ const NAV_SECTIONS: NavSection[] = [
     items: [
       { page: 'traditional-chat',     label: 'Traditional chat', icon: MessagesSquare },
       { page: 'notifications-legacy', label: 'Notifications',    icon: Bell, defaultTab: { kind: 'notifications-inbox', params: {} } },
+      { page: 'connectors-legacy',    label: 'Connectors',       icon: Plug, defaultTab: { kind: 'settings', params: { category: 'connectors' } } },
       { page: 'automation',           label: 'Automation',       icon: Zap, defaultTab: { kind: 'automation', params: { section: 'flow' } } },
     ],
   },

--- a/ui/src/components/ChatChannelListContainer.tsx
+++ b/ui/src/components/ChatChannelListContainer.tsx
@@ -1,88 +1,23 @@
-import { Bell, HelpCircle } from 'lucide-react'
-import { useChannels } from '../contexts/ChannelsContext'
-import { useWorkspace } from '../tabs/store'
-import { getFocusedTab } from '../tabs/types'
-import { useUnreadNotificationsCount } from '../live/notifications-read'
-import { ChatChannelList } from './ChatChannelList'
 import { ChatWorkspaceSection } from './workspace/ChatWorkspaceSection'
-import { SidebarRow } from './SidebarRow'
 
 /**
- * Chat activity sidebar. Two conceptual sections:
+ * Chat activity sidebar — **workspace chat only**.
  *
- *   - **Workspace chat** (recommended) — chat-template workspaces, each
- *     wrapping a native CLI session (claude / codex / shell). Native
- *     prompt cache + native frontend; the path most users should default
- *     to. See README "Two kinds of chat".
- *   - **Traditional chat** — the original /chat channels backed by
- *     OpenAlice's ChatHook. Required for connectors (Telegram / MCP Ask
- *     / webhook) which have no PTY to host a CLI in.
+ * Mental model: Workspace is the atom for any unit of work; "Chat" is
+ * the top-level shortcut for the chat-shape Workspace subset. Clicking
+ * the Chat icon in the ActivityBar lands here, where the user sees
+ * chat-template workspaces (each one is its own conversation thread
+ * with `claude` / `codex` / `shell`).
  *
- * The legacy Notifications row sits inside the Traditional section because
- * the old NotificationsStore is a pre-Workspace artifact — heartbeat / cron
- * pushes were designed for the traditional single-session chat surface.
- * Workspace-anchored pushes have their own top-level Inbox activity.
- *
- * Active row tracking is derived from the focused tab — switching tabs
- * naturally shifts the highlight without bespoke wiring.
+ * Traditional `/chat` channels and the legacy NotificationsStore inbox
+ * have moved to the Legacy section of the ActivityBar — they're
+ * pre-Workspace artifacts that don't share this surface anymore.
  */
 export function ChatChannelListContainer() {
-  const { channels, openEditDialog, deleteChannel } = useChannels()
-  const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
-  const focusedKind = focused?.kind
-  const focusedChannelId = focusedKind === 'chat' ? focused.params.channelId : ''
-  const inboxActive = focusedKind === 'notifications-inbox'
-  const openOrFocus = useWorkspace((state) => state.openOrFocus)
-  const unreadCount = useUnreadNotificationsCount()
-
   return (
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto min-h-0">
         <ChatWorkspaceSection />
-
-        <div className="px-3 mt-3 text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
-          Traditional
-        </div>
-        <div className="mt-0.5">
-          <SidebarRow
-            label={
-              <span className="flex items-center gap-2">
-                <Bell size={14} strokeWidth={1.8} className="shrink-0" />
-                <span>Notifications</span>
-              </span>
-            }
-            active={inboxActive}
-            onClick={() => openOrFocus({ kind: 'notifications-inbox', params: {} })}
-            trail={
-              unreadCount > 0 ? (
-                <span
-                  className="min-w-[16px] h-[16px] px-1 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center"
-                  aria-label={`${unreadCount} unread`}
-                >
-                  {unreadCount > 99 ? '99+' : unreadCount}
-                </span>
-              ) : undefined
-            }
-          />
-          <ChatChannelList
-            channels={channels}
-            activeChannel={focusedChannelId}
-            onSelect={(id) => openOrFocus({ kind: 'chat', params: { channelId: id } })}
-            onEdit={openEditDialog}
-            onDelete={deleteChannel}
-          />
-        </div>
-
-        <a
-          href="https://github.com/TraderAlice/OpenAlice#two-kinds-of-chat"
-          target="_blank"
-          rel="noreferrer"
-          className="mx-3 my-3 flex items-center gap-1.5 text-[11px] text-text-muted/70 hover:text-text transition-colors"
-          title="Open README — Two kinds of chat"
-        >
-          <HelpCircle size={11} strokeWidth={2} aria-hidden="true" />
-          <span>Why two kinds of chat?</span>
-        </a>
       </div>
     </div>
   )

--- a/ui/src/components/ConnectorsLegacySidebar.tsx
+++ b/ui/src/components/ConnectorsLegacySidebar.tsx
@@ -1,0 +1,48 @@
+import { Plug } from 'lucide-react'
+import { useWorkspace } from '../tabs/store'
+import { getFocusedTab } from '../tabs/types'
+import { SidebarRow } from './SidebarRow'
+
+/**
+ * Legacy Connectors sidebar.
+ *
+ * The pre-Workspace push delivery surfaces — Telegram bot, MCP Ask,
+ * Web SSE channel routing. Lives in the ActivityBar's Legacy section
+ * because the broader connector architecture is slated for rework as
+ * Workspace becomes the load-bearing surface; the existing connector
+ * config still functions and remains the path for Telegram / MCP Ask
+ * users until the replacement lands.
+ *
+ * Sidebar opens the existing `settings/connectors` page (no separate
+ * ViewSpec needed — the page already lives under settings).
+ */
+export function ConnectorsLegacySidebar() {
+  const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
+  const isActive =
+    focused?.kind === 'settings' && focused.params.category === 'connectors'
+  const openOrFocus = useWorkspace((state) => state.openOrFocus)
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-3 py-2 text-[11px] text-text-muted/70 leading-relaxed border-b border-border/40">
+        Legacy push-delivery surfaces — Telegram bot, MCP Ask, webhook
+        routing. Slated for rework as Workspace replaces global chat;
+        the current config still works for now.
+      </div>
+      <div className="py-0.5">
+        <SidebarRow
+          label={
+            <span className="flex items-center gap-2">
+              <Plug size={14} strokeWidth={1.8} className="shrink-0" />
+              <span>Connectors</span>
+            </span>
+          }
+          active={isActive}
+          onClick={() =>
+            openOrFocus({ kind: 'settings', params: { category: 'connectors' } })
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/NotificationsLegacySidebar.tsx
+++ b/ui/src/components/NotificationsLegacySidebar.tsx
@@ -1,0 +1,54 @@
+import { Bell } from 'lucide-react'
+import { useWorkspace } from '../tabs/store'
+import { getFocusedTab } from '../tabs/types'
+import { useUnreadNotificationsCount } from '../live/notifications-read'
+import { SidebarRow } from './SidebarRow'
+
+/**
+ * Legacy NotificationsStore sidebar.
+ *
+ * The pre-Workspace push surface — populated by heartbeat / cron / the
+ * `/api/dev/send` manual channel via `connectorCenter.notify`. Lives in
+ * the ActivityBar's Legacy section because the current push channel for
+ * workspace agents is Inbox, not Notifications.
+ *
+ * Sidebar just opens the existing NotificationsInboxPage tab; no
+ * secondary structure (filter dropdown lives inside the page itself).
+ */
+export function NotificationsLegacySidebar() {
+  const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
+  const isActive = focused?.kind === 'notifications-inbox'
+  const openOrFocus = useWorkspace((state) => state.openOrFocus)
+  const unreadCount = useUnreadNotificationsCount()
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-3 py-2 text-[11px] text-text-muted/70 leading-relaxed border-b border-border/40">
+        Legacy push surface — fed by heartbeat / cron AgentCenter pings.
+        Workspace agents push to the new Inbox tab now.
+      </div>
+      <div className="py-0.5">
+        <SidebarRow
+          label={
+            <span className="flex items-center gap-2">
+              <Bell size={14} strokeWidth={1.8} className="shrink-0" />
+              <span>Notifications</span>
+            </span>
+          }
+          active={isActive}
+          onClick={() => openOrFocus({ kind: 'notifications-inbox', params: {} })}
+          trail={
+            unreadCount > 0 ? (
+              <span
+                className="min-w-[16px] h-[16px] px-1 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center"
+                aria-label={`${unreadCount} unread`}
+              >
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </span>
+            ) : undefined
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/SettingsCategoryList.tsx
+++ b/ui/src/components/SettingsCategoryList.tsx
@@ -19,7 +19,10 @@ const CATEGORIES: CategoryItem[] = [
   { label: 'General', category: 'general' },
   { label: 'AI Provider', category: 'ai-provider' },
   { label: 'Trading Accounts', category: 'trading', alsoActiveFor: ['uta-detail'] },
-  { label: 'Connectors', category: 'connectors' },
+  // Connectors moved to its own ActivityBar Legacy entry — see
+  // ConnectorsLegacySidebar. The `settings/connectors` ViewSpec is
+  // still the underlying tab, but it's reached from the Legacy
+  // section now, not from this Settings list.
   { label: 'MCP Server', category: 'mcp' },
   { label: 'Market Data', category: 'market-data' },
   { label: 'News Sources', category: 'news-collector' },

--- a/ui/src/components/TraditionalChatSidebar.tsx
+++ b/ui/src/components/TraditionalChatSidebar.tsx
@@ -1,0 +1,54 @@
+import { HelpCircle } from 'lucide-react'
+import { useChannels } from '../contexts/ChannelsContext'
+import { useWorkspace } from '../tabs/store'
+import { getFocusedTab } from '../tabs/types'
+import { ChatChannelList } from './ChatChannelList'
+
+/**
+ * Traditional chat sidebar — legacy `/chat` channels backed by
+ * OpenAlice's ChatHook (the pre-Workspace single-session AI surface).
+ *
+ * Kept around specifically because Telegram / MCP Ask / webhook
+ * callbacks have no terminal to host a CLI in — those connector
+ * surfaces still land here. Lives in the ActivityBar's Legacy section
+ * because, for any user with a shell, Workspace chat is the
+ * recommended path.
+ */
+export function TraditionalChatSidebar() {
+  const { channels, openEditDialog, deleteChannel } = useChannels()
+  const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
+  const focusedChannelId = focused?.kind === 'chat' ? focused.params.channelId : ''
+  const openOrFocus = useWorkspace((state) => state.openOrFocus)
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto min-h-0">
+        <div className="px-3 py-2 text-[11px] text-text-muted/70 leading-relaxed border-b border-border/40">
+          Legacy single-session AI chat — kept for connector flows
+          (Telegram, MCP Ask, webhook callbacks) that can't host a CLI.
+          Use Workspace chat for everything else.
+        </div>
+        <div className="mt-0.5">
+          <ChatChannelList
+            channels={channels}
+            activeChannel={focusedChannelId}
+            onSelect={(id) => openOrFocus({ kind: 'chat', params: { channelId: id } })}
+            onEdit={openEditDialog}
+            onDelete={deleteChannel}
+          />
+        </div>
+
+        <a
+          href="https://github.com/TraderAlice/OpenAlice#two-kinds-of-chat"
+          target="_blank"
+          rel="noreferrer"
+          className="mx-3 my-3 flex items-center gap-1.5 text-[11px] text-text-muted/70 hover:text-text transition-colors"
+          title="Open README — Two kinds of chat"
+        >
+          <HelpCircle size={11} strokeWidth={2} aria-hidden="true" />
+          <span>Why two kinds of chat?</span>
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -37,10 +37,12 @@ interface FormState {
   wireApi: 'chat' | 'responses'
 }
 
-// codex-cli ≥ 0.130 dropped the legacy `wire_api = "chat"` shape; "responses"
-// is now the only supported value (see github.com/openai/codex/discussions/7782).
-// We still surface "chat" as a labelled-deprecated option so users on older
-// codex builds aren't surprised, but the default is "responses".
+// codex-cli ≥ 0.130 hard-rejects `wire_api = "chat"`. The AgentConfig schema
+// still carries `wireApi` (the backend writer / file IO is shared with other
+// codex-shaped configs), but this modal locks it to "responses" for every
+// codex provider — a stale 'chat' loaded from disk is normalized on display,
+// so the next Save silently corrects it.
+// Ref: github.com/openai/codex/discussions/7782
 const EMPTY_FORM: FormState = { baseUrl: '', apiKey: '', model: '', wireApi: 'responses' }
 
 function configToForm(cfg: AgentConfig | null): FormState {
@@ -49,7 +51,7 @@ function configToForm(cfg: AgentConfig | null): FormState {
     baseUrl: cfg.baseUrl ?? '',
     apiKey: cfg.apiKey ?? '',
     model: cfg.model ?? '',
-    wireApi: (cfg.wireApi as 'chat' | 'responses') ?? 'responses',
+    wireApi: 'responses',
   }
 }
 
@@ -333,18 +335,17 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
           </div>
 
           {tab === 'codex' && (
-            <div>
-              <label className="block text-xs font-medium text-text-muted mb-1">
-                Wire Format
-              </label>
-              <select
-                value={form.wireApi}
-                onChange={(e) => setForm({ ...form, wireApi: e.target.value as 'chat' | 'responses' })}
-                className={inputClass}
-              >
-                <option value="responses">responses (OpenAI Responses API — required by codex ≥ 0.130)</option>
-                <option value="chat">chat (legacy, OpenAI Chat Completions — removed in codex 0.130+)</option>
-              </select>
+            <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-2">
+              <p className="text-[12px] text-text-muted leading-relaxed">
+                <strong className="text-text">Wire format is locked to <code className="font-mono text-[11.5px]">responses</code>.</strong>{' '}
+                Codex 0.130+ hard-rejects <code className="font-mono text-[11.5px]">wire_api = "chat"</code> and only speaks the OpenAI Responses API.
+              </p>
+              <p className="text-[12px] text-text-muted leading-relaxed">
+                <strong className="text-text">Chat-only providers</strong> (DeepSeek, Qwen, Moonshot, GLM, LM Studio, vLLM, llama.cpp, etc.) don't expose a Responses endpoint and won't work here directly.
+                Run a translation proxy and point Base URL at it — e.g.{' '}
+                <strong className="text-text">OpenRouter</strong> (hosted, BYOK) or{' '}
+                <strong className="text-text">VibeAround</strong> (local) both speak Responses on the wire and forward to Chat Completions backends.
+              </p>
             </div>
           )}
 

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -13,6 +13,7 @@ import {
   getAgentConfig,
   listAgentProfiles,
   saveAgentConfig,
+  testAgentConfig,
   type AgentConfig,
   type AgentConfigBundle,
   type AgentId,
@@ -64,6 +65,26 @@ function formToConfig(form: FormState, agent: AgentId): AgentConfig {
   return cfg
 }
 
+// Test result is per-tab so switching tabs doesn't lose the other agent's
+// verdict, AND each result is bound to the exact form snapshot it was tested
+// against — editing any field invalidates it (Save re-locks). This is the
+// "test-before-save" linkage: Save only enables when the *current* form has a
+// matching successful test.
+interface TestResult {
+  kind: 'pass' | 'fail'
+  snapshot: FormState
+  message: string  // model reply on pass, error on fail
+}
+
+function formsMatch(a: FormState, b: FormState, agent: AgentId): boolean {
+  return (
+    a.baseUrl === b.baseUrl &&
+    a.apiKey === b.apiKey &&
+    a.model === b.model &&
+    (agent !== 'codex' || a.wireApi === b.wireApi)
+  )
+}
+
 export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
   const [tab, setTab] = useState<Tab>('claude')
   const [profiles, setProfiles] = useState<AgentProfile[]>([])
@@ -75,6 +96,9 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [savedFlash, setSavedFlash] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [claudeResult, setClaudeResult] = useState<TestResult | null>(null)
+  const [codexResult, setCodexResult] = useState<TestResult | null>(null)
 
   useEffect(() => {
     void Promise.all([listAgentProfiles(), getAgentConfig(wsId)])
@@ -89,6 +113,10 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
 
   const form = tab === 'claude' ? claudeForm : codexForm
   const setForm = tab === 'claude' ? setClaudeForm : setCodexForm
+  const result = tab === 'claude' ? claudeResult : codexResult
+  const setResult = tab === 'claude' ? setClaudeResult : setCodexResult
+  const resultMatchesCurrent = !!result && formsMatch(result.snapshot, form, tab)
+  const testPassedForCurrent = result?.kind === 'pass' && resultMatchesCurrent
   const dirty = useMemo(() => {
     if (!bundle) return false
     const saved = tab === 'claude' ? bundle.claude : bundle.codex
@@ -146,14 +174,56 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
     }
   }
 
+  const canTest =
+    !!form.baseUrl.trim() && !!form.apiKey.trim() && !!form.model.trim()
+
+  const handleTest = async () => {
+    if (!canTest) return
+    // Freeze the form snapshot at click time — async race protection: if the
+    // user starts editing while the request is in flight, the result we get
+    // back is still bound to *what was tested*, not what's currently typed.
+    const snapshot: FormState = {
+      baseUrl: form.baseUrl.trim(),
+      apiKey: form.apiKey.trim(),
+      model: form.model.trim(),
+      wireApi: form.wireApi,
+    }
+    setTesting(true)
+    try {
+      const r = await testAgentConfig(wsId, tab, {
+        baseUrl: snapshot.baseUrl,
+        apiKey: snapshot.apiKey,
+        model: snapshot.model,
+        ...(tab === 'codex' ? { wireApi: snapshot.wireApi } : {}),
+      })
+      setResult(
+        r.ok
+          ? { kind: 'pass', snapshot, message: r.response ?? '' }
+          : { kind: 'fail', snapshot, message: r.error ?? 'unknown error' },
+      )
+    } catch (err) {
+      setResult({ kind: 'fail', snapshot, message: (err as Error).message })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  // Backdrop close uses onMouseDown (not onClick) so that text-selection
+  // drags that start inside an input and release outside the card don't
+  // count as a backdrop click and dismiss the modal — that's what was
+  // making the window "flash" on what felt like random clicks.
+  const handleBackdropMouseDown = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose()
+  }
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
       <div
         className="bg-bg border border-border rounded-xl shadow-2xl w-full max-w-xl max-h-[85vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
@@ -288,6 +358,34 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
               Saved. Pause + resume any open session to reload.
             </div>
           )}
+          {testing && (
+            <div className="rounded-md border border-border bg-bg-secondary text-text-muted text-[12px] px-3 py-2">
+              Testing…
+            </div>
+          )}
+          {!testing && result?.kind === 'pass' && resultMatchesCurrent && (
+            <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
+              <div className="font-medium mb-0.5">
+                Test passed — {tab === 'claude' ? 'Anthropic' : 'OpenAI'} replied:
+              </div>
+              <div className="text-text whitespace-pre-wrap break-words font-mono text-[11.5px]">
+                {result.message || '(empty reply)'}
+              </div>
+            </div>
+          )}
+          {!testing && result?.kind === 'fail' && resultMatchesCurrent && (
+            <div className="rounded-md border border-red/40 bg-red/10 text-red text-[12px] px-3 py-2">
+              <div className="font-medium mb-0.5">Test failed:</div>
+              <div className="whitespace-pre-wrap break-words font-mono text-[11.5px]">
+                {result.message}
+              </div>
+            </div>
+          )}
+          {!testing && result && !resultMatchesCurrent && (
+            <div className="rounded-md border border-yellow-400/30 bg-yellow-400/5 text-yellow-400/90 text-[12px] px-3 py-2">
+              Form changed since last test — re-test before saving.
+            </div>
+          )}
 
           <p className="text-[11px] text-text-muted/80 leading-snug pt-1">
             Empty fields fall back to the CLI's global default. Changes apply to
@@ -300,13 +398,23 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
 
         {/* Footer */}
         <div className="flex items-center justify-between gap-2 p-3 border-t border-border bg-bg-secondary/30">
-          <button
-            onClick={handleReset}
-            disabled={saving}
-            className="px-3 py-2 rounded-md border border-border text-text-muted hover:text-text text-[12px] disabled:opacity-40"
-          >
-            Reset to global default
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={handleReset}
+              disabled={saving}
+              className="px-3 py-2 rounded-md border border-border text-text-muted hover:text-text text-[12px] disabled:opacity-40"
+            >
+              Reset to global default
+            </button>
+            <button
+              onClick={handleTest}
+              disabled={!canTest || testing || saving}
+              title={!canTest ? 'Fill base URL, API key, and model first' : undefined}
+              className="px-3 py-2 rounded-md border border-border text-text-muted hover:text-text text-[12px] disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {testing ? 'Testing…' : 'Test'}
+            </button>
+          </div>
           <div className="flex gap-2">
             <button
               onClick={onClose}
@@ -317,7 +425,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
             </button>
             <button
               onClick={handleSave}
-              disabled={saving || !dirty}
+              disabled={saving || !dirty || !testPassedForCurrent}
+              title={
+                !dirty
+                  ? undefined
+                  : !testPassedForCurrent
+                  ? 'Click Test and get a passing reply before saving'
+                  : undefined
+              }
               className="px-4 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
             >
               {saving ? 'Saving…' : 'Save'}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -371,3 +371,37 @@ export async function saveAgentConfig(
     throw new Error(`save agent config failed: ${res.status} ${msg}`);
   }
 }
+
+export interface AgentTestResult {
+  readonly ok: boolean;
+  readonly response?: string;
+  readonly error?: string;
+}
+
+export interface AgentTestInput {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly model: string;
+  /** Codex only. */
+  readonly wireApi?: 'chat' | 'responses';
+}
+
+export async function testAgentConfig(
+  wsId: string,
+  agent: AgentId,
+  cfg: AgentTestInput,
+): Promise<AgentTestResult> {
+  const res = await fetch(
+    `/api/workspaces/${encodeURIComponent(wsId)}/agent-config/${agent}/test`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(cfg),
+    },
+  );
+  try {
+    return (await res.json()) as AgentTestResult;
+  } catch {
+    return { ok: false, error: `HTTP ${res.status}` };
+  }
+}

--- a/ui/src/live/activity-bar-collapse.ts
+++ b/ui/src/live/activity-bar-collapse.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+/**
+ * Per-section collapse state for the ActivityBar.
+ *
+ * Keyed by the section's `sectionLabel` string (e.g. "Agent", "System").
+ * Sections with an empty label (the top pinned-nav block) are never
+ * collapsible — they don't get an entry here either way.
+ *
+ * Persists to localStorage so the user's collapse preference survives
+ * reloads. Default is expanded (absence-of-key = not-collapsed). Mirrors
+ * the shape of `useInboxRead` — explicit set on collapse, key-removal
+ * on expand — so the persisted state shrinks back to {} when fully
+ * expanded.
+ */
+
+interface ActivityBarCollapseState {
+  collapsedSections: Record<string, true>
+}
+
+interface ActivityBarCollapseActions {
+  toggleSection: (name: string) => void
+  isCollapsed: (name: string) => boolean
+}
+
+export const useActivityBarCollapse = create<ActivityBarCollapseState & ActivityBarCollapseActions>()(
+  persist(
+    (set, get) => ({
+      collapsedSections: {},
+      toggleSection: (name) =>
+        set((s) => {
+          const next = { ...s.collapsedSections }
+          if (next[name]) delete next[name]
+          else next[name] = true
+          return { collapsedSections: next }
+        }),
+      isCollapsed: (name) => Boolean(get().collapsedSections[name]),
+    }),
+    { name: 'openalice.activitybar-sections.v1', version: 1 },
+  ),
+)

--- a/ui/src/live/activity-bar-collapse.ts
+++ b/ui/src/live/activity-bar-collapse.ts
@@ -4,38 +4,48 @@ import { persist } from 'zustand/middleware'
 /**
  * Per-section collapse state for the ActivityBar.
  *
- * Keyed by the section's `sectionLabel` string (e.g. "Agent", "System").
+ * Keyed by the section's `sectionLabel` string (e.g. "System", "Legacy").
  * Sections with an empty label (the top pinned-nav block) are never
  * collapsible — they don't get an entry here either way.
  *
- * Persists to localStorage so the user's collapse preference survives
- * reloads. Default is expanded (absence-of-key = not-collapsed). Mirrors
- * the shape of `useInboxRead` — explicit set on collapse, key-removal
- * on expand — so the persisted state shrinks back to {} when fully
- * expanded.
+ * Stores the **user's explicit preference**: `true` = collapsed,
+ * `false` = expanded, absent = "use the section's `defaultCollapsed`
+ * (or expanded if unset)". Three-state is necessary because some
+ * sections (Legacy) default-collapsed; a two-state present/absent
+ * model can't represent "user explicitly expanded a default-collapsed
+ * section".
+ *
+ * Persists to localStorage so the user's preference survives reloads.
+ * Mirrors the `useInboxRead` shape — explicit user actions are stored;
+ * key only gets pruned when the user-toggled-state matches the default
+ * (avoids the store growing forever).
  */
 
 interface ActivityBarCollapseState {
-  collapsedSections: Record<string, true>
+  collapsedSections: Record<string, boolean>
 }
 
 interface ActivityBarCollapseActions {
-  toggleSection: (name: string) => void
-  isCollapsed: (name: string) => boolean
+  /** Set the user's explicit preference for a section. Pass
+   *  `defaultCollapsed` so the store can prune the key when the user's
+   *  preference now matches the default — keeps localStorage tight. */
+  setCollapsed: (name: string, collapsed: boolean, defaultCollapsed?: boolean) => void
 }
 
 export const useActivityBarCollapse = create<ActivityBarCollapseState & ActivityBarCollapseActions>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       collapsedSections: {},
-      toggleSection: (name) =>
+      setCollapsed: (name, collapsed, defaultCollapsed) =>
         set((s) => {
           const next = { ...s.collapsedSections }
-          if (next[name]) delete next[name]
-          else next[name] = true
+          if (collapsed === Boolean(defaultCollapsed)) {
+            delete next[name]
+          } else {
+            next[name] = collapsed
+          }
           return { collapsedSections: next }
         }),
-      isCollapsed: (name) => Boolean(get().collapsedSections[name]),
     }),
     { name: 'openalice.activitybar-sections.v1', version: 1 },
   ),

--- a/ui/src/live/inbox.ts
+++ b/ui/src/live/inbox.ts
@@ -9,6 +9,11 @@ import { createLiveStore } from './createLiveStore'
  *
  * Single shared connection via LiveStore refcount; multiple subscribers
  * (sidebar list, detail page, Activity bar unread badge) share one timer.
+ *
+ * Two side-channel helpers (`refreshInbox` / `removeInboxOptimistically`)
+ * are exported alongside for the delete flow: optimistic removal flips
+ * the entry out of state immediately so the UI doesn't lag the
+ * DELETE round-trip, then a refresh confirms truth from the server.
  */
 
 export interface InboxState {
@@ -18,6 +23,13 @@ export interface InboxState {
 }
 
 const POLL_INTERVAL_MS = 20_000
+
+/** Module-level setter populated by the subscribe callback so external
+ *  callers can mutate state through the same `apply` channel. Null when
+ *  no subscriber is mounted; calls become no-ops in that window which
+ *  is harmless (delete actions originate from mounted UI). */
+let applyState: ((next: InboxState | ((prev: InboxState) => InboxState)) => void) | null = null
+let triggerRefresh: (() => void) | null = null
 
 export const inboxLive = createLiveStore<InboxState>({
   name: 'inbox',
@@ -36,12 +48,34 @@ export const inboxLive = createLiveStore<InboxState>({
       }
     }
 
+    applyState = apply
+    triggerRefresh = refresh
+
     void refresh()
     const intervalId = setInterval(refresh, POLL_INTERVAL_MS)
 
     return () => {
       disposed = true
       clearInterval(intervalId)
+      applyState = null
+      triggerRefresh = null
     }
   },
 })
+
+/** Force an immediate refresh from /api/inbox/history. Used after
+ *  a DELETE to reconcile state with the server. Safe to call even
+ *  with no subscriber mounted (no-op). */
+export function refreshInbox(): void {
+  triggerRefresh?.()
+}
+
+/** Optimistically remove an entry from the in-memory list before the
+ *  DELETE round-trip completes. Pairs with `refreshInbox()` after the
+ *  request lands so server state is the source of truth either way. */
+export function removeInboxOptimistically(id: string): void {
+  applyState?.((prev) => ({
+    ...prev,
+    entries: prev.entries.filter((e) => e.id !== id),
+  }))
+}

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -1,17 +1,19 @@
-import { useEffect, useState } from 'react'
-import { ArrowRight, MessageSquare } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { ArrowRight, MessageSquare, Trash2 } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
 import { MarkdownContent } from '../components/MarkdownContent'
-import { inboxLive } from '../live/inbox'
+import { api } from '../api'
+import { inboxLive, refreshInbox, removeInboxOptimistically } from '../live/inbox'
 import { useInboxSelection } from '../live/inbox-selection'
+import { useInboxRead } from '../live/inbox-read'
 import { useWorkspace } from '../tabs/store'
 import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
 import type { InboxEntry, InboxDoc } from '../api/inbox'
 
 interface InboxPageProps {
-  /** Required by the tab registry shape; not used here — read state is
-   *  per-entry and driven by selection, not by page visibility. */
+  /** Gates the page-level Delete/Backspace shortcut so background
+   *  inbox tabs don't intercept the keypress. */
   visible: boolean
 }
 
@@ -22,14 +24,68 @@ interface InboxPageProps {
  *
  * Selection is owned by `useInboxSelection`; the sidebar drives it.
  * Read-state mutation happens in the sidebar at selection time — this
- * pane just renders whatever is selected.
+ * pane just renders whatever is selected. Delete is owned here (both
+ * the button in the Detail header and the Delete/Backspace shortcut)
+ * because it needs access to the full entry list to advance selection
+ * to the next entry after removal.
  */
-export function InboxPage(_props: InboxPageProps) {
+export function InboxPage({ visible }: InboxPageProps) {
   const entries = inboxLive.useStore((s) => s.entries)
   const loading = inboxLive.useStore((s) => s.loading)
   const selectedId = useInboxSelection((s) => s.selectedEntryId)
+  const select = useInboxSelection((s) => s.select)
+  const markRead = useInboxRead((s) => s.markRead)
 
   const selected = entries.find((e) => e.id === selectedId) ?? null
+
+  /** Hard-delete an entry. Optimistically removes from local state,
+   *  advances selection to the next-older entry (or previous if last),
+   *  fires the DELETE request, then forces a refresh to reconcile with
+   *  the server. Match Linear's "archive removes from view, focus
+   *  advances" feel — no confirmation dialog. */
+  const handleDelete = useCallback(async (id: string) => {
+    const idx = entries.findIndex((e) => e.id === id)
+    if (idx < 0) return
+
+    // entries is sorted newest-first; "the one after this" is the next
+    // older entry. Fall back to the previous (newer) if we deleted the
+    // tail; null if the list becomes empty.
+    const nextId = entries[idx + 1]?.id ?? entries[idx - 1]?.id ?? null
+
+    removeInboxOptimistically(id)
+    if (nextId) {
+      select(nextId)
+      markRead(nextId)
+    } else {
+      select(null)
+    }
+
+    try {
+      await api.inbox.delete(id)
+    } catch {
+      // best-effort — refreshInbox below will reconcile if the server
+      // disagreed (e.g. concurrent change re-introduced the entry).
+    }
+    refreshInbox()
+  }, [entries, select, markRead])
+
+  // Delete / Backspace shortcut. Gated on `visible` so a background
+  // inbox tab doesn't intercept; gated on `selectedId` so the
+  // keypress only fires when there's something to delete.
+  useEffect(() => {
+    if (!visible) return
+    if (!selectedId) return
+    function onKey(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      if (e.key !== 'Delete' && e.key !== 'Backspace') return
+      e.preventDefault()
+      // selectedId is captured by the closure; safe to use.
+      void handleDelete(selectedId!)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [visible, selectedId, handleDelete])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -47,7 +103,7 @@ export function InboxPage(_props: InboxPageProps) {
             Select an entry from the sidebar.
           </div>
         ) : (
-          <Detail entry={selected} />
+          <Detail entry={selected} onDelete={() => handleDelete(selected.id)} />
         )}
       </div>
     </div>
@@ -69,7 +125,7 @@ function EmptyState() {
   )
 }
 
-function Detail({ entry }: { entry: InboxEntry }) {
+function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }) {
   const hasDocs = (entry.docs?.length ?? 0) > 0
   const hasComments = (entry.comments ?? '').trim().length > 0
 
@@ -95,10 +151,13 @@ function Detail({ entry }: { entry: InboxEntry }) {
 
   return (
     <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
-      {/* Header: workspace · timestamp. Plain text — the primary navigation
-       *  affordance sits at the bottom of the comments thread (Linear-style
-       *  reply input). Making the label itself a button was too subtle and
-       *  the user didn't expect to click a heading. */}
+      {/* Header: workspace · timestamp · delete. Plain text label —
+       *  the primary navigation affordance sits at the bottom of the
+       *  comments thread (Linear-style reply input). Trash button is
+       *  always visible, muted by default with accent-red on hover —
+       *  Linear's archive affordance equivalent. Hard delete (no undo
+       *  modal); keyboard parity via Delete / Backspace at the page
+       *  level. */}
       <div className="flex items-center gap-2 mb-4 flex-wrap">
         <span
           className={`text-[14px] font-medium ${
@@ -113,6 +172,15 @@ function Detail({ entry }: { entry: InboxEntry }) {
           <span className="mx-1.5 text-text-muted/40">·</span>
           {formatRelative(entry.ts)}
         </span>
+        <button
+          type="button"
+          onClick={onDelete}
+          className="p-1 rounded text-text-muted/50 hover:text-red hover:bg-red/10 transition-colors"
+          title="Delete this entry (Delete / Backspace)"
+          aria-label="Delete this inbox entry"
+        >
+          <Trash2 size={14} strokeWidth={1.75} />
+        </button>
       </div>
 
       {/* Docs — top, live render from workspace */}

--- a/ui/src/sections.tsx
+++ b/ui/src/sections.tsx
@@ -13,6 +13,8 @@
 
 import type { ComponentType } from 'react'
 import { ChatChannelListContainer } from './components/ChatChannelListContainer'
+import { TraditionalChatSidebar } from './components/TraditionalChatSidebar'
+import { NotificationsLegacySidebar } from './components/NotificationsLegacySidebar'
 import { NewChannelButton } from './components/NewChannelButton'
 import { InboxSidebar } from './components/InboxSidebar'
 import { WorkspacesSidebar } from './components/workspace/WorkspacesSidebar'
@@ -35,10 +37,12 @@ export interface SidebarSection {
 }
 
 const SECTION_BY_KEY: Record<ActivitySection, SidebarSection> = {
+  // Chat is the workspace-chat shortcut now — the "夺舍" of the Chat
+  // shortcut by chat-template workspaces. Channel creation is no longer
+  // an Action here; that affordance moved to traditional-chat.
   chat: {
     title: 'Chat',
     Secondary: ChatChannelListContainer,
-    Actions: NewChannelButton,
   },
   inbox: {
     title: 'Inbox',
@@ -75,6 +79,18 @@ const SECTION_BY_KEY: Record<ActivitySection, SidebarSection> = {
   news: {
     title: 'News',
     Secondary: NewsSidebar,
+  },
+  // Legacy entries — pre-Workspace artifacts. Sidebars include a
+  // muted explanatory note so users opening them understand the
+  // lifecycle context.
+  'traditional-chat': {
+    title: 'Traditional chat',
+    Secondary: TraditionalChatSidebar,
+    Actions: NewChannelButton,
+  },
+  'notifications-legacy': {
+    title: 'Notifications',
+    Secondary: NotificationsLegacySidebar,
   },
 }
 

--- a/ui/src/sections.tsx
+++ b/ui/src/sections.tsx
@@ -15,6 +15,7 @@ import type { ComponentType } from 'react'
 import { ChatChannelListContainer } from './components/ChatChannelListContainer'
 import { TraditionalChatSidebar } from './components/TraditionalChatSidebar'
 import { NotificationsLegacySidebar } from './components/NotificationsLegacySidebar'
+import { ConnectorsLegacySidebar } from './components/ConnectorsLegacySidebar'
 import { NewChannelButton } from './components/NewChannelButton'
 import { InboxSidebar } from './components/InboxSidebar'
 import { WorkspacesSidebar } from './components/workspace/WorkspacesSidebar'
@@ -91,6 +92,10 @@ const SECTION_BY_KEY: Record<ActivitySection, SidebarSection> = {
   'notifications-legacy': {
     title: 'Notifications',
     Secondary: NotificationsLegacySidebar,
+  },
+  'connectors-legacy': {
+    title: 'Connectors',
+    Secondary: ConnectorsLegacySidebar,
   },
 }
 

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -51,6 +51,8 @@ export type ActivitySection =
   | 'portfolio'
   | 'automation'
   | 'news'
+  | 'traditional-chat'
+  | 'notifications-legacy'
 
 export interface Tab {
   id: string

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -53,6 +53,7 @@ export type ActivitySection =
   | 'news'
   | 'traditional-chat'
   | 'notifications-legacy'
+  | 'connectors-legacy'
 
 export interface Tab {
   id: string


### PR DESCRIPTION
## Summary

Multiple PR rolling on dev → master this cycle, ending with a `0.21.0-beta.4` bump. Themes:

1. **Inbox** — per-entry hard delete (`feat`)
2. **ActivityBar** — Linear-style widened layout + collapsible sections, then **lifecycle-stage split**: Chat icon repurposed as workspace-chat shortcut; Legacy section (default-collapsed) holds Traditional chat + Notifications + Connectors + Automation
3. **Workspace AI provider** — test-before-save gating + Codex wire_api fix (parallel session)
4. **README** — drop the stale "Roadmap to v1" section
5. **Release** — beta bump so users notice the new layout

## Per-session contributions

### 2026-05-16 (latest) — Version bump

`61230a2` — 0.21.0-beta.3 → 0.21.0-beta.4. Layout shift this cycle is meaningful enough that the beta tag should advance so users notice they're on the new visual / nav shape. Per memory `feedback_release_workflow_owns_tags`: only commit + push, the release.yml workflow on master push creates the tag + GitHub Release.

### 2026-05-16 — Connectors → Legacy

`aede78c` — promote Connectors out of the Settings sub-list into a top-level Legacy ActivityBar entry. Same pattern as Traditional chat / Notifications: new `ConnectorsLegacySidebar` with muted banner + single SidebarRow opening `/settings/connectors`. Settings sidebar loses its "Connectors" item.

### 2026-05-16 — Chat split + Legacy section

`77d8c2a` — Workspace is the atom; Chat is the chat-template subset shortcut. Traditional /chat and the legacy NotificationsStore moved into a default-collapsed Legacy section together with Automation. Three-state collapse store (`Record<string, boolean>`) so default-collapsed sections remember "user explicitly expanded" as a sticky preference.

### 2026-05-16 — ActivityBar Linear-style refactor

`6d811fd` — desktop ActivityBar widened 56px → 220px, labels + section headers visible, chevron toggles, collapse state persisted to localStorage.

### 2026-05-16 — Inbox per-entry delete

`6ddef3c` — Linear-style archive affordance, hard-delete semantics. Trash icon + `Delete` / `Backspace` keyboard; atomic JSONL rewrite on the server; selection advances to next-older entry. 8 new tests.

### 2026-05-16 — Roadmap drop

`a733b1e` — `-9 / +0` README cleanup of the stale "all v1 milestones complete" section.

Plus `b289b89` and `303394c` from a parallel session (workspace AI provider improvements).

## Full commit log
```
61230a2 chore(release): bump version to 0.21.0-beta.4
aede78c feat(activitybar): promote Connectors to Legacy section, drop from Settings
77d8c2a feat(activitybar): split Chat into workspace-shortcut + Legacy section
b289b89 feat(workspace): lock Codex wire_api to "responses" + chat-only provider hint
303394c feat(workspace): AI provider test button with test-before-save gating
6d811fd refactor(activitybar): Linear-style widened sidebar with collapsible sections
6ddef3c feat(inbox): per-entry delete (trash button + Delete shortcut)
a733b1e docs(readme): drop "Roadmap to v1" section
```

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm --filter ./ui run build` clean
- [x] Inbox delete: trash icon + Delete key both work; selection advances
- [x] ActivityBar Linear-style widening: labels visible, sections collapsible, persistence across reload
- [x] Chat icon = workspace-chat-only sidebar
- [x] Legacy section default-collapsed; user expand state sticky; collapse-back prunes store to `{}`
- [x] Traditional chat / Notifications / Connectors / Automation all land at their previous sidebars + tabs from inside Legacy
- [x] Settings sidebar lists only General / AI Provider / Trading Accounts / MCP Server / Market Data / News Sources
- [x] `grep -n "Roadmap" README.md` returns nothing
- [ ] On merge: release.yml produces tag `v0.21.0-beta.4` + GitHub Release automatically (no manual tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)