### PR TITLE
feat(activitybar): Beta section — surface trading-related entries with lifecycle hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.21.0-beta.4",
+  "version": "0.21.0-beta.5",
   "description": "File-based trading agent engine",
   "type": "module",
   "scripts": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,7 @@ export type Page =
   | 'trading-as-git'
   | 'settings' | 'dev'
   | 'traditional-chat' | 'notifications-legacy' | 'connectors-legacy'
+  | 'trading-accounts'
 
 /** Track whether we're at a desktop viewport (md+ in Tailwind = ≥768px). */
 function useIsDesktop(): boolean {

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import { type LucideIcon, MessageSquare, MessagesSquare, Inbox, Bell, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Plug } from 'lucide-react'
+import { type LucideIcon, MessageSquare, MessagesSquare, Inbox, Bell, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Plug, Landmark } from 'lucide-react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
 import type { ActivitySection, ViewSpec } from '../tabs/types'
@@ -24,6 +24,7 @@ function activitySectionFor(page: Page): ActivitySection {
     case 'traditional-chat':     return 'traditional-chat'
     case 'notifications-legacy': return 'notifications-legacy'
     case 'connectors-legacy':    return 'connectors-legacy'
+    case 'trading-accounts':     return 'trading-accounts'
   }
 }
 
@@ -63,6 +64,11 @@ interface NavSection {
    *  default. Useful for "this section exists but isn't the recommended
    *  path" framing (Legacy). */
   defaultCollapsed?: boolean
+  /** Optional muted-text paragraph rendered between the section header
+   *  and its items (visible only when the section is expanded). Use
+   *  this to communicate lifecycle stage — e.g. Beta's "stuff here
+   *  works but expect churn" hint. Plain text; keep short. */
+  description?: string
 }
 
 const NAV_SECTIONS: NavSection[] = [
@@ -73,16 +79,34 @@ const NAV_SECTIONS: NavSection[] = [
   // to warrant direct access. Workspaces (the all-templates index)
   // sits alongside; the two aren't redundant: Workspaces = whole set,
   // Chat = chat-shape subset shortcut.
+  //
+  // Market / News are operational tools that work but aren't load-
+  // bearing — they live here because they don't need lifecycle
+  // labelling.
   {
     sectionLabel: '',
     items: [
-      { page: 'inbox',          label: 'Inbox',          icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
-      { page: 'workspaces',     label: 'Workspaces',     icon: TerminalSquare },
-      { page: 'chat',           label: 'Chat',           icon: MessageSquare },
-      { page: 'portfolio',      label: 'Portfolio',      icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
-      { page: 'trading-as-git', label: 'Trading as Git', icon: GitBranch },
-      { page: 'market',         label: 'Market',         icon: BarChart3 },
-      { page: 'news',           label: 'News',           icon: Newspaper, defaultTab: { kind: 'news', params: {} } },
+      { page: 'inbox',      label: 'Inbox',      icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
+      { page: 'workspaces', label: 'Workspaces', icon: TerminalSquare },
+      { page: 'chat',       label: 'Chat',       icon: MessageSquare },
+      { page: 'market',     label: 'Market',     icon: BarChart3 },
+      { page: 'news',       label: 'News',       icon: Newspaper, defaultTab: { kind: 'news', params: {} } },
+    ],
+  },
+  // Beta — functional but unstable. Goal: unified abstraction across
+  // broker accounts (Trading Accounts) + the Trading-as-Git workflow
+  // + the Portfolio view that surfaces it. Large engineering ahead,
+  // no fixed timeline — configurable today, but lock-in cost can
+  // change as the abstraction settles. Default-expanded because the
+  // items here are actively useful; the Beta label is the right
+  // amount of caution, not a hide.
+  {
+    sectionLabel: 'Beta',
+    description: 'Goal here is a unified abstraction across broker accounts (deposit/withdraw, options, futures, FX). Large engineering effort, no fixed timeline. Configure and try, but don\'t depend on schema or UX as stable yet.',
+    items: [
+      { page: 'trading-accounts', label: 'Trading Accounts', icon: Landmark, defaultTab: { kind: 'settings', params: { category: 'trading' } } },
+      { page: 'trading-as-git',   label: 'Trading as Git',   icon: GitBranch },
+      { page: 'portfolio',        label: 'Portfolio',        icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
     ],
   },
   {
@@ -200,6 +224,11 @@ export function ActivityBar({ open, onClose }: ActivityBarProps) {
                     />
                     <span>{section.sectionLabel}</span>
                   </button>
+                )}
+                {showItems && section.description && (
+                  <p className="px-3 mb-2 text-[11px] text-text-muted/60 leading-relaxed">
+                    {section.description}
+                  </p>
                 )}
                 {showItems && (
                   <div className="flex flex-col gap-0.5" id={`activity-section-${si}`}>

--- a/ui/src/components/SettingsCategoryList.tsx
+++ b/ui/src/components/SettingsCategoryList.tsx
@@ -18,11 +18,11 @@ interface CategoryItem {
 const CATEGORIES: CategoryItem[] = [
   { label: 'General', category: 'general' },
   { label: 'AI Provider', category: 'ai-provider' },
-  { label: 'Trading Accounts', category: 'trading', alsoActiveFor: ['uta-detail'] },
+  // Trading Accounts moved to its own ActivityBar Beta entry — see
+  // TradingAccountsBetaSidebar. The `settings/trading` ViewSpec is
+  // still the underlying tab.
   // Connectors moved to its own ActivityBar Legacy entry — see
-  // ConnectorsLegacySidebar. The `settings/connectors` ViewSpec is
-  // still the underlying tab, but it's reached from the Legacy
-  // section now, not from this Settings list.
+  // ConnectorsLegacySidebar.
   { label: 'MCP Server', category: 'mcp' },
   { label: 'Market Data', category: 'market-data' },
   { label: 'News Sources', category: 'news-collector' },

--- a/ui/src/components/TradingAccountsBetaSidebar.tsx
+++ b/ui/src/components/TradingAccountsBetaSidebar.tsx
@@ -1,0 +1,45 @@
+import { Landmark } from 'lucide-react'
+import { useWorkspace } from '../tabs/store'
+import { getFocusedTab } from '../tabs/types'
+import { SidebarRow } from './SidebarRow'
+
+/**
+ * Trading Accounts (Beta) sidebar.
+ *
+ * Trading account configuration was previously a sub-item under the
+ * Settings sidebar. Promoted to a top-level Beta entry because the
+ * cross-broker unification work is in active rearchitecture and the
+ * lifecycle stage warrants visibility at the ActivityBar level.
+ *
+ * Sidebar opens the existing `settings/trading` page (no new ViewSpec).
+ * The Beta-section description is rendered once at the ActivityBar
+ * section header — we don't duplicate it inside the sidebar itself.
+ */
+export function TradingAccountsBetaSidebar() {
+  const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
+  // Also light up when a `uta-detail` tab is focused — that's the
+  // sibling view that gets opened from inside the TradingPage.
+  const isActive =
+    (focused?.kind === 'settings' && focused.params.category === 'trading')
+    || focused?.kind === 'uta-detail'
+  const openOrFocus = useWorkspace((state) => state.openOrFocus)
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="py-0.5">
+        <SidebarRow
+          label={
+            <span className="flex items-center gap-2">
+              <Landmark size={14} strokeWidth={1.8} className="shrink-0" />
+              <span>Trading Accounts</span>
+            </span>
+          }
+          active={isActive}
+          onClick={() =>
+            openOrFocus({ kind: 'settings', params: { category: 'trading' } })
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/ui/src/sections.tsx
+++ b/ui/src/sections.tsx
@@ -16,6 +16,7 @@ import { ChatChannelListContainer } from './components/ChatChannelListContainer'
 import { TraditionalChatSidebar } from './components/TraditionalChatSidebar'
 import { NotificationsLegacySidebar } from './components/NotificationsLegacySidebar'
 import { ConnectorsLegacySidebar } from './components/ConnectorsLegacySidebar'
+import { TradingAccountsBetaSidebar } from './components/TradingAccountsBetaSidebar'
 import { NewChannelButton } from './components/NewChannelButton'
 import { InboxSidebar } from './components/InboxSidebar'
 import { WorkspacesSidebar } from './components/workspace/WorkspacesSidebar'
@@ -96,6 +97,10 @@ const SECTION_BY_KEY: Record<ActivitySection, SidebarSection> = {
   'connectors-legacy': {
     title: 'Connectors',
     Secondary: ConnectorsLegacySidebar,
+  },
+  'trading-accounts': {
+    title: 'Trading Accounts',
+    Secondary: TradingAccountsBetaSidebar,
   },
 }
 

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -54,6 +54,7 @@ export type ActivitySection =
   | 'traditional-chat'
   | 'notifications-legacy'
   | 'connectors-legacy'
+  | 'trading-accounts'
 
 export interface Tab {
   id: string


### PR DESCRIPTION
## Summary

Single-commit PR introducing a **Beta** section between top and System in the ActivityBar, with a section-level description paragraph explaining the lifecycle stage. Trading-related entries (Trading Accounts / Trading as Git / Portfolio) move here.

Plus version bump `0.21.0-beta.4 → 0.21.0-beta.5`.

## Per-session contributions

### 2026-05-16 — Beta section + trading-related promotion

`3f2d0d7`. Users were looking at Trading-as-Git like a stable feature and reporting bugs as if the UX were locked. It isn't — the unified-broker-account abstraction is a multi-month effort with no fixed completion timeline.

**Beta section** (default-expanded — these features still work; Beta label is the right amount of caution, not a hide) with a section-level description rendered once below the header:

> Goal here is a unified abstraction across broker accounts (deposit/withdraw, options, futures, FX). Large engineering effort, no fixed timeline. Configure and try, but don't depend on schema or UX as stable yet.

**Moves**:
- **Trading Accounts** promoted from Settings sub-list to Beta top-level (same pattern as Connectors → Legacy: new `TradingAccountsBetaSidebar`, underlying ViewSpec `settings/trading` unchanged)
- **Trading as Git** and **Portfolio** moved from top section to Beta
- **Settings sidebar** now lists 5 categories: General / AI Provider / MCP Server / Market Data / News Sources
- **`NavSection.description?: string`** added; ActivityBar renders it as a muted paragraph between the section header and items. Single source of truth — no duplicated banners across the 3 sidebars

**Top section shrinks to 5 entries**: Inbox / Workspaces / Chat / Market / News. Cleaner, primary-flow-only.

Version bump 0.21.0-beta.4 → 0.21.0-beta.5 so users notice the new section on update (release.yml on master push will produce the tag + GitHub Release automatically per memory `feedback_release_workflow_owns_tags`).

Key commit: `3f2d0d7`

## Full commit log
```
3f2d0d7 feat(activitybar): introduce Beta section; promote trading-related entries
```

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm --filter ./ui run build` clean
- [x] Browser verification (Playwright):
  - Top section now 5 items (Inbox / Workspaces / Chat / Market / News)
  - BETA header followed by description paragraph (visible only when expanded)
  - Beta items in order: Trading Accounts / Trading as Git / Portfolio
  - Settings sidebar 5 entries (no Trading Accounts, no Connectors)
  - Trading Accounts click → opens `settings/trading` page, sidebar shows TradingAccountsBetaSidebar
- [ ] On merge: release.yml produces `v0.21.0-beta.5` tag + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)