### PR TITLE
ui: workspace right pane + legacy chat route cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keep the build context lean. Anything not strictly needed for `pnpm
+# install` + `pnpm build` shouldn't be sent to the daemon — speeds up
+# every COPY and avoids accidentally baking your local state into the
+# image.
+
+# Per-machine state
+data
+logs
+*.log
+
+# Build artifacts (we rebuild inside the image)
+dist
+**/dist
+node_modules
+**/node_modules
+ui/.vite
+electron/dist
+
+# Editor / IDE
+.vscode
+.idea
+.DS_Store
+
+# VCS + CI
+.git
+.github
+
+# Test scratch / browser fixtures
+.playwright-mcp
+coverage
+.nyc_output
+
+# Docker artifacts themselves (don't ship the recipe into the recipe)
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,90 @@
+# OpenAlice — server / self-host image.
+#
+# Two-stage build: full toolchain in `build`, slim runtime with only what's
+# needed to run `node dist/main.js` plus the bundled agent CLIs.
+#
+# Target audience: VPS self-hosters running Workspace chat. Auth is the
+# user's responsibility — `docker exec -it openalice claude` once after
+# first up, then OpenAlice is good to go.
+
+# ─── build stage ──────────────────────────────────────────
+FROM node:22-trixie AS build
+WORKDIR /src
+
+# pnpm via corepack (ships with Node 22). Pin the version we develop with
+# so the install plan is reproducible.
+RUN corepack enable && corepack prepare pnpm@10.29.2 --activate
+
+# Cache-friendly: copy only manifests first so the dep-resolution layer
+# stays warm across source-only changes. `scripts/` joins this layer
+# because the root postinstall hook (`fix-pty-perms.mjs`) runs at the end
+# of `pnpm install` and must already exist on disk.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY scripts ./scripts
+COPY packages/ibkr/package.json packages/ibkr/
+COPY packages/opentypebb/package.json packages/opentypebb/
+COPY ui/package.json ui/
+
+RUN pnpm install --frozen-lockfile
+
+# Source + build. `pnpm build` runs `turbo run build` (workspace packages
+# + UI Vite build) then `tsup` bundles the backend into `dist/main.js`.
+COPY . .
+RUN pnpm build
+
+# Strip dev deps before the runtime stage harvests node_modules. With
+# `electron` + `electron-builder` (each ~500MB) in devDependencies, this
+# is the difference between a 2.9GB image and a sub-1GB image. `CI=true`
+# satisfies pnpm's "won't remove modules without TTY confirmation" check.
+RUN CI=true pnpm prune --prod --config.ignore-scripts=true
+
+# ─── runtime stage ────────────────────────────────────────
+FROM node:22-trixie-slim AS runtime
+WORKDIR /app
+
+# Bash + POSIX utils are required by workspace bootstrap.sh scripts;
+# bookworm-slim already ships them. We install the two agent CLIs
+# globally so they're on PATH for the PTY sessions OpenAlice spawns.
+#
+# Both come from npm (codex's npm package is a thin wrapper that pulls
+# down the Rust binary on install). Smoke-checking versions at build time
+# fails the build loud if either package broke.
+RUN npm install -g \
+        @anthropic-ai/claude-code \
+        @openai/codex \
+    && claude --version \
+    && codex --version \
+    && npm cache clean --force
+
+# Production artifacts.
+COPY --from=build /src/dist                       ./dist
+COPY --from=build /src/ui/dist                    ./ui/dist
+COPY --from=build /src/default                    ./default
+COPY --from=build /src/src/workspaces/templates   ./src/workspaces/templates
+# tsup bundles backend deps into dist/main.js where possible, but a few
+# native modules (notably node-pty) stay as runtime requires.
+COPY --from=build /src/node_modules               ./node_modules
+COPY --from=build /src/package.json               ./package.json
+# Workspace packages — node_modules/@traderalice/* are pnpm symlinks
+# resolving to `packages/*/dist` via relative paths. Without these,
+# `import('@traderalice/ibkr')` from the bundled dist/main.js fails
+# with ERR_MODULE_NOT_FOUND at startup.
+COPY --from=build /src/packages                   ./packages
+
+# Two-home model — see src/core/paths.ts.
+#   /app  = APP_RESOURCES_HOME  (image content, baked in)
+#   /data = USER_DATA_HOME      (the volume the user mounts)
+# HOME redirects ~/.claude / ~/.codex / ~/.config etc. into the volume so
+# auth tokens + agent state persist across container rebuild.
+ENV OPENALICE_APP_HOME=/app \
+    OPENALICE_HOME=/data \
+    AQ_LAUNCHER_ROOT=/data/workspaces \
+    HOME=/data/home \
+    NODE_ENV=production \
+    OPENALICE_WEB_PORT=47331 \
+    OPENALICE_MCP_PORT=47332
+
+VOLUME ["/data"]
+EXPOSE 47331
+
+CMD ["node", "dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -294,6 +294,42 @@ Native `cmd.exe` / PowerShell alone are not supported (no `bash`, no POSIX utili
 
 Note: we don't currently dogfood OpenAlice on Windows, so the broader experience (PTY rendering, file watching, paths with spaces) may have rough edges. Bug reports very welcome.
 
+## Run on a server (Docker)
+
+For self-hosting on a VPS or always-on box. The image bundles `claude` and
+`codex` CLIs — no host install needed.
+
+```bash
+git clone https://github.com/TraderAlice/OpenAlice.git
+cd OpenAlice
+docker compose up -d --build
+```
+
+First-time auth (one-shot — credentials persist in the data volume so the
+container can be rebuilt without losing them):
+
+```bash
+docker exec -it openalice claude        # OAuth: paste URL into any browser
+docker exec -it openalice codex login   # same dance for codex
+```
+
+Then open `http://<your-server>:47331` in a browser.
+
+**Notes**
+
+- All state — config, workspaces, claude/codex credentials, logs — lives in
+  the `openalice-data` named volume. `docker compose down -v` is the
+  factory reset.
+- Already have claude/codex auth on the host? Skip the `docker exec` step
+  by uncommenting the bind-mount lines in `docker-compose.yml` to reuse
+  your local `~/.claude` and `~/.codex`.
+- The MCP server (port 47332) is intentionally **not** exposed externally;
+  it's consumed by the CLIs running inside the container only.
+- The base image is `node:22-trixie-slim` (Debian 13) because several
+  native deps (notably `longbridge`) ship glibc 2.39 binaries that older
+  Debians don't have, and workspace bootstrap scripts need `bash` + POSIX
+  utils. Alpine doesn't qualify on either count (musl libc, no bash).
+
 ## Configuration
 
 All config lives in `data/config/` as JSON files with Zod validation. Missing files fall back to sensible defaults. You can edit these files directly or use the Web UI.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+# Single-service compose for OpenAlice self-hosting.
+#
+# First time:
+#   docker compose up -d --build
+#   docker exec -it openalice claude        # OAuth — paste URL into a browser
+#   docker exec -it openalice codex login   # same for codex (if you use it)
+#
+# After that the volume holds your auth + workspaces + config across
+# restarts and image rebuilds. Tear-down + factory reset:
+#   docker compose down -v        # also nukes the volume
+#
+# Already have claude/codex auth on the host? Skip the docker exec step by
+# uncommenting the bind-mount lines below.
+
+services:
+  openalice:
+    build: .
+    image: openalice:local
+    container_name: openalice
+    restart: unless-stopped
+    ports:
+      # Web UI. The MCP server (47332) is intentionally NOT exposed — it's
+      # only consumed by the CLIs running inside this container.
+      - "47331:47331"
+    volumes:
+      - openalice-data:/data
+      # Optional: reuse host auth instead of authenticating inside the
+      # container. Bind-mount your local credentials read-only.
+      # - ${HOME}/.claude:/data/home/.claude:ro
+      # - ${HOME}/.codex:/data/home/.codex:ro
+    # Keep stdin/tty open so `docker exec -it openalice claude` can run
+    # the interactive OAuth flow.
+    stdin_open: true
+    tty: true
+
+volumes:
+  openalice-data:

--- a/ui/src/components/workspace/FilesPanel.tsx
+++ b/ui/src/components/workspace/FilesPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
+import { ChevronDown } from 'lucide-react';
 
 import { listFiles, type DirListing, type FileEntry } from './api';
 
@@ -13,6 +14,7 @@ export function FilesPanel(props: FilesPanelProps): ReactElement {
   const [path, setPath] = useState('');
   const [listing, setListing] = useState<DirListing | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
     let alive = true;
@@ -53,52 +55,72 @@ export function FilesPanel(props: FilesPanelProps): ReactElement {
   const breadcrumb = path.split('/').filter(Boolean);
 
   return (
-    <section className="panel files-panel">
+    <section className={`panel files-panel${collapsed ? ' is-collapsed' : ''}`}>
       <header className="panel-header">
+        <button
+          type="button"
+          className="panel-collapse"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-label={collapsed ? 'Expand files panel' : 'Collapse files panel'}
+          aria-expanded={!collapsed}
+        >
+          <ChevronDown
+            size={11}
+            strokeWidth={2.25}
+            className={`panel-collapse-chev${collapsed ? ' is-collapsed' : ''}`}
+            aria-hidden
+          />
+        </button>
         <span className="panel-title">files</span>
-        <nav className="files-breadcrumb">
-          <button
-            type="button"
-            className="files-crumb"
-            onClick={() => setPath('')}
-            disabled={path === ''}
-          >
-            ~
-          </button>
-          {breadcrumb.map((seg, i) => (
-            <span key={i} className="files-crumb-seg">
-              <span className="files-crumb-sep">/</span>
-              <button
-                type="button"
-                className="files-crumb"
-                onClick={() => setPath(breadcrumb.slice(0, i + 1).join('/'))}
-                disabled={i === breadcrumb.length - 1}
-              >
-                {seg}
-              </button>
-            </span>
-          ))}
-        </nav>
+        {!collapsed && (
+          <nav className="files-breadcrumb">
+            <button
+              type="button"
+              className="files-crumb"
+              onClick={() => setPath('')}
+              disabled={path === ''}
+            >
+              ~
+            </button>
+            {breadcrumb.map((seg, i) => (
+              <span key={i} className="files-crumb-seg">
+                <span className="files-crumb-sep">/</span>
+                <button
+                  type="button"
+                  className="files-crumb"
+                  onClick={() => setPath(breadcrumb.slice(0, i + 1).join('/'))}
+                  disabled={i === breadcrumb.length - 1}
+                >
+                  {seg}
+                </button>
+              </span>
+            ))}
+          </nav>
+        )}
       </header>
 
-      {error && <div className="panel-error">{error}</div>}
+      {!collapsed && (
+        <>
+          {error && <div className="panel-error">{error}</div>}
 
-      <ul className="files-list">
-        {listing?.entries.length === 0 && !error && (
-          <li className="panel-empty">empty</li>
-        )}
-        {listing?.entries.map((e) => (
-          <li
-            key={e.name}
-            className={`files-row files-${e.kind}`}
-            onClick={() => enter(e)}
-          >
-            <span className="files-icon">{iconFor(e)}</span>
-            <span className="files-name">{e.name}</span>
-            <span className="files-meta">{formatMeta(e)}</span>
-          </li>
-        ))}
-      </ul>
+          <ul className="files-list">
+            {listing?.entries.length === 0 && !error && (
+              <li className="panel-empty">empty</li>
+            )}
+            {listing?.entries.map((e) => (
+              <li
+                key={e.name}
+                className={`files-row files-${e.kind}`}
+                onClick={() => enter(e)}
+              >
+                <span className="files-icon">{iconFor(e)}</span>
+                <span className="files-name">{e.name}</span>
+                <span className="files-meta">{formatMeta(e)}</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </section>
   );
 }

--- a/ui/src/components/workspace/GitPanel.tsx
+++ b/ui/src/components/workspace/GitPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
+import { ChevronDown } from 'lucide-react';
 
 import { getGitLog, getGitStatus, type GitLogEntry, type GitStatus } from './api';
 
@@ -14,6 +15,7 @@ export function GitPanel(props: GitPanelProps): ReactElement {
   const [status, setStatus] = useState<GitStatus | null>(null);
   const [entries, setEntries] = useState<GitLogEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
     let alive = true;
@@ -46,44 +48,108 @@ export function GitPanel(props: GitPanelProps): ReactElement {
   }, [props.wsId]);
 
   return (
-    <section className="panel git-panel">
+    <section className={`panel git-panel${collapsed ? ' is-collapsed' : ''}`}>
       <header className="panel-header">
+        <button
+          type="button"
+          className="panel-collapse"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-label={collapsed ? 'Expand git panel' : 'Collapse git panel'}
+          aria-expanded={!collapsed}
+        >
+          <ChevronDown
+            size={11}
+            strokeWidth={2.25}
+            className={`panel-collapse-chev${collapsed ? ' is-collapsed' : ''}`}
+            aria-hidden
+          />
+        </button>
         <span className="panel-title">git</span>
         {status?.branch && <span className="panel-pill">{status.branch}</span>}
         {status?.clean === false && <span className="panel-pill panel-pill-dirty">{status.files.length} changed</span>}
       </header>
 
-      {error && <div className="panel-error">{error}</div>}
+      {!collapsed && (
+        <>
+          {error && <div className="panel-error">{error}</div>}
 
-      {status && status.files.length > 0 && (
-        <ul className="git-status-list">
-          {status.files.map((f) => (
-            <li key={f.path} className="git-status-row">
-              <span className="git-status-code">{renderStatus(f.status)}</span>
-              <span className="git-status-path">{f.path}</span>
-            </li>
-          ))}
-        </ul>
+          {status && status.files.length > 0 && (
+            <ul className="git-status-list">
+              {status.files.map((f) => (
+                <li key={f.path} className="git-status-row">
+                  <GitStatusBadge code={f.status} />
+                  <span className="git-status-path">{f.path}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <ul className="git-log-list">
+            {entries.length === 0 && !error && (
+              <li className="panel-empty">no commits yet</li>
+            )}
+            {entries.map((e) => (
+              <li key={e.hash} className="git-log-row" title={e.authorTime}>
+                <span className="git-log-hash">{e.hash}</span>
+                <span className="git-log-time">{e.relTime}</span>
+                <span className="git-log-subject">{e.subject}</span>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
-
-      <ul className="git-log-list">
-        {entries.length === 0 && !error && (
-          <li className="panel-empty">no commits yet</li>
-        )}
-        {entries.map((e) => (
-          <li key={e.hash} className="git-log-row" title={e.authorTime}>
-            <span className="git-log-hash">{e.hash}</span>
-            <span className="git-log-time">{e.relTime}</span>
-            <span className="git-log-subject">{e.subject}</span>
-          </li>
-        ))}
-      </ul>
     </section>
   );
 }
 
-function renderStatus(s: string): string {
-  // Compact rendering of the porcelain 2-char code. We surface the meaningful
-  // letter; trailing/leading space becomes a dot for visibility.
-  return s.replace(/ /g, '·');
+type StatusTone = 'untracked' | 'modified' | 'staged' | 'deleted' | 'renamed' | 'conflict' | 'ignored' | 'unknown';
+
+interface StatusDecoded {
+  readonly label: string;
+  readonly tone: StatusTone;
+}
+
+/**
+ * Translate a 2-char git porcelain v1 code into a human label + tone.
+ *
+ * Porcelain XY: X = index (staged) state, Y = working tree state.
+ * Precedence here: conflict > untracked/ignored > deleted > renamed >
+ * staged > modified. That order matches what's actionable to a user
+ * looking at the panel — a `??` row means "this is new, decide whether
+ * to track it"; an `MM` row means "you staged a version but have unstaged
+ * changes on top," surfaced as "modified" to keep the label terse (hover
+ * the original code in the tooltip for the precise state).
+ */
+function decodeStatus(code: string): StatusDecoded {
+  const X = code[0] ?? ' ';
+  const Y = code[1] ?? ' ';
+
+  // Merge / unmerged conflicts: any of DD, AU, UD, UA, DU, AA, UU
+  if (X === 'U' || Y === 'U' || (X === 'A' && Y === 'A') || (X === 'D' && Y === 'D')) {
+    return { label: 'conflict', tone: 'conflict' };
+  }
+  if (X === '?' && Y === '?') return { label: 'untracked', tone: 'untracked' };
+  if (X === '!' && Y === '!') return { label: 'ignored', tone: 'ignored' };
+  if (Y === 'D' || X === 'D') return { label: 'deleted', tone: 'deleted' };
+  if (X === 'R' || Y === 'R') return { label: 'renamed', tone: 'renamed' };
+  if (X === 'C' || Y === 'C') return { label: 'copied', tone: 'staged' };
+  // Index has any change but no working-tree delta → fully staged
+  if (X !== ' ' && Y === ' ') return { label: 'staged', tone: 'staged' };
+  // Working tree has changes (with or without prior staging)
+  if (Y === 'M' || X === 'M') return { label: 'modified', tone: 'modified' };
+  if (X === 'A') return { label: 'added', tone: 'staged' };
+
+  return { label: code.trim() || '·', tone: 'unknown' };
+}
+
+function GitStatusBadge({ code }: { code: string }): ReactElement {
+  const { label, tone } = decodeStatus(code);
+  return (
+    <span
+      className={`git-status-badge is-${tone}`}
+      title={`porcelain: ${code.replace(/ /g, '·')}`}
+    >
+      {label}
+    </span>
+  );
 }

--- a/ui/src/components/workspace/WorkspaceLayoutPopover.tsx
+++ b/ui/src/components/workspace/WorkspaceLayoutPopover.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
+import { PanelRight } from 'lucide-react'
+
+import { useWorkspaceSidePanels } from '../../live/workspace-side-panels'
+
+/**
+ * Top-bar button that opens a small popover for toggling the workspace
+ * right-pane side panels. Lives next to "AI Provider" in WorkspacePage's
+ * header.
+ *
+ * Click outside closes the popover. State is user-level (not per-
+ * workspace) — see `useWorkspaceSidePanels` for rationale.
+ */
+export function WorkspaceLayoutPopover(): ReactElement {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const prefs = useWorkspaceSidePanels()
+
+  useEffect(() => {
+    if (!open) return
+    const handle = (e: MouseEvent): void => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [open])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
+        title="Show / hide right-pane panels"
+        aria-expanded={open}
+      >
+        <PanelRight size={13} strokeWidth={1.8} aria-hidden />
+        Layout
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Workspace layout"
+          className="absolute right-0 top-full mt-1 w-[220px] z-50 p-2 rounded-md bg-bg-tertiary border border-border shadow-lg text-[12px] text-text"
+        >
+          <div className="px-1 pb-1 text-[10px] uppercase tracking-wider text-text-muted/60 font-medium">
+            Side panels
+          </div>
+          <CheckboxRow
+            label="Git"
+            checked={prefs.git}
+            onChange={(v) => prefs.setPanel('git', v)}
+          />
+          <CheckboxRow
+            label="Files"
+            checked={prefs.files}
+            onChange={(v) => prefs.setPanel('files', v)}
+          />
+          <div className="my-1.5 border-t border-border" />
+          <CheckboxRow
+            label="Auto-hide on mobile"
+            checked={prefs.autoHideMobile}
+            onChange={prefs.setAutoHideMobile}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CheckboxRow({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}): ReactElement {
+  return (
+    <label className="flex items-center gap-2 px-1 py-1 rounded hover:bg-bg-secondary/50 cursor-pointer select-none">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="accent-accent"
+      />
+      <span>{label}</span>
+    </label>
+  )
+}

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -7,6 +7,8 @@ import { FilesPanel } from './FilesPanel';
 import { GitPanel } from './GitPanel';
 import { ResumeCta, prefixOf, relativeTime } from './ResumeCta';
 import { TerminalView, type KeyMap } from './Terminal';
+import { useIsDesktop } from '../../live/use-is-desktop';
+import { useWorkspaceSidePanels } from '../../live/workspace-side-panels';
 
 export interface WorkspaceViewProps {
   readonly wsId: string;
@@ -74,8 +76,19 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
     props.activeRecord.state === 'paused';
   const showEmptyCta = props.sessionId === null;
 
+  // Side panel visibility. User-level prefs control which of git/files
+  // render; mobile gets a separate kill-switch so the 360px right column
+  // doesn't eat half a phone screen.
+  const isDesktop = useIsDesktop();
+  const sidePrefs = useWorkspaceSidePanels();
+  const mobileSuppresses = !isDesktop && sidePrefs.autoHideMobile;
+  const showGit = sidePrefs.git && !mobileSuppresses;
+  const showFiles = sidePrefs.files && !mobileSuppresses;
+  const showAside = showGit || showFiles;
+  const viewClass = `workspace-view${showAside ? '' : ' has-no-side'}`;
+
   return (
-    <div className="workspace-view">
+    <div className={viewClass}>
       <div className="workspace-terminal">
         {showEmptyCta && (
           <EmptyState
@@ -110,10 +123,12 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
             );
           })}
       </div>
-      <aside className="workspace-side">
-        <GitPanel wsId={props.wsId} />
-        <FilesPanel wsId={props.wsId} />
-      </aside>
+      {showAside && (
+        <aside className="workspace-side">
+          {showGit && <GitPanel wsId={props.wsId} />}
+          {showFiles && <FilesPanel wsId={props.wsId} />}
+        </aside>
+      )}
     </div>
   );
 }

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -828,6 +828,12 @@
   min-height: 0;
 }
 
+/* Both side panels hidden (or auto-hidden on mobile) — collapse the
+ * 360px aside column so the terminal pane fills the whole width. */
+.workspace-view.has-no-side {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .workspace-terminal {
   display: flex;
   flex-direction: column;
@@ -1018,10 +1024,20 @@
 }
 
 .workspace-side {
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   gap: 12px;
   min-height: 0;
+}
+.workspace-side > .panel {
+  flex: 1 1 0;
+  min-height: 0;
+}
+/* A collapsed panel becomes header-only (no body), so we want it to take
+ * just its intrinsic height instead of fighting the sibling for the
+ * 1fr split. The other panel then claims the freed space. */
+.workspace-side > .panel.is-collapsed {
+  flex: 0 0 auto;
 }
 
 /* ── Side panels (shared chrome) ──────────────────────────────────────────── */
@@ -1047,6 +1063,39 @@
   color: var(--fg-dim);
   user-select: none;
   flex: 0 0 auto;
+}
+
+/* Collapsed panels have no body, so the header's bottom-border becomes
+ * a stray seam in the side stack. Drop it. */
+.panel.is-collapsed > .panel-header {
+  border-bottom: 0;
+}
+
+.panel-collapse {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-right: -2px;
+  background: none;
+  border: 0;
+  border-radius: 3px;
+  color: var(--fg-dim);
+  cursor: pointer;
+  flex: 0 0 auto;
+  transition: background 0.12s, color 0.12s;
+}
+.panel-collapse:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+}
+
+.panel-collapse-chev {
+  transition: transform 0.15s;
+}
+.panel-collapse-chev.is-collapsed {
+  transform: rotate(-90deg);
 }
 
 .panel-title {
@@ -1097,22 +1146,74 @@
 
 .git-status-row {
   display: flex;
-  gap: 10px;
-  padding: 2px 12px;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 12px;
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 12px;
 }
 
-.git-status-code {
-  color: #d29922;
-  white-space: pre;
+.git-status-badge {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-family: inherit;
+  letter-spacing: 0.2px;
+  text-transform: lowercase;
+  white-space: nowrap;
+  border: 1px solid transparent;
 }
+.git-status-badge.is-untracked {
+  background: rgba(110, 118, 129, 0.18);
+  color: var(--fg-dim);
+  border-color: rgba(110, 118, 129, 0.25);
+}
+.git-status-badge.is-modified {
+  background: rgba(210, 153, 34, 0.16);
+  color: #d29922;
+  border-color: rgba(210, 153, 34, 0.25);
+}
+.git-status-badge.is-staged {
+  background: rgba(126, 231, 135, 0.16);
+  color: #7ee787;
+  border-color: rgba(126, 231, 135, 0.25);
+}
+.git-status-badge.is-deleted {
+  background: rgba(255, 123, 114, 0.16);
+  color: var(--danger);
+  border-color: rgba(255, 123, 114, 0.28);
+}
+.git-status-badge.is-renamed {
+  background: rgba(121, 192, 255, 0.16);
+  color: var(--accent);
+  border-color: rgba(121, 192, 255, 0.25);
+}
+.git-status-badge.is-conflict {
+  background: rgba(255, 123, 114, 0.22);
+  color: #ff7b72;
+  border-color: rgba(255, 123, 114, 0.4);
+  font-weight: 600;
+}
+.git-status-badge.is-ignored {
+  background: rgba(110, 118, 129, 0.10);
+  color: var(--fg-dim);
+  opacity: 0.7;
+}
+.git-status-badge.is-unknown {
+  background: rgba(110, 118, 129, 0.10);
+  color: var(--fg-dim);
+}
+
 .git-status-path {
   color: var(--fg);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .git-log-list {

--- a/ui/src/live/use-is-desktop.ts
+++ b/ui/src/live/use-is-desktop.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Track whether the viewport is at desktop width (Tailwind's `md` = 768px).
+ * Returns false on mobile/tablet portrait. SSR-safe: defaults to true.
+ */
+export function useIsDesktop(): boolean {
+  const query = '(min-width: 768px)'
+  const [matches, setMatches] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia(query).matches : true,
+  )
+  useEffect(() => {
+    const mq = window.matchMedia(query)
+    const handler = (): void => setMatches(mq.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+  return matches
+}

--- a/ui/src/live/workspace-side-panels.ts
+++ b/ui/src/live/workspace-side-panels.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+/**
+ * User preference for which workspace right-pane side panels render.
+ *
+ * Stored at the user level (not per-workspace) — every workspace has the
+ * same Git + Files panels, so a per-workspace toggle would be friction
+ * for no payoff.
+ *
+ * `autoHideMobile` controls whether the entire right column hides at
+ * sub-md viewports. Default true: on a phone, the right column eating
+ * 360px is a worse experience than not seeing git/files at all. Users
+ * can flip it off if they actually want both on a small screen.
+ */
+
+interface WorkspaceSidePanelsState {
+  git: boolean
+  files: boolean
+  autoHideMobile: boolean
+}
+
+interface WorkspaceSidePanelsActions {
+  setPanel: (key: 'git' | 'files', enabled: boolean) => void
+  setAutoHideMobile: (enabled: boolean) => void
+}
+
+export const useWorkspaceSidePanels = create<WorkspaceSidePanelsState & WorkspaceSidePanelsActions>()(
+  persist(
+    (set) => ({
+      git: true,
+      files: true,
+      autoHideMobile: true,
+      setPanel: (key, enabled) => set({ [key]: enabled } as Pick<WorkspaceSidePanelsState, 'git' | 'files'>),
+      setAutoHideMobile: (enabled) => set({ autoHideMobile: enabled }),
+    }),
+    { name: 'openalice.workspace.side-panels.v1', version: 1 },
+  ),
+)

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -22,6 +22,7 @@ import '@xterm/xterm/css/xterm.css'
 import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { useWorkspace } from '../tabs/store'
 import { WorkspaceView } from '../components/workspace/WorkspaceView'
+import { WorkspaceLayoutPopover } from '../components/workspace/WorkspaceLayoutPopover'
 import type { KeyMap } from '../components/workspace/Terminal'
 import type { ViewSpec } from '../tabs/types'
 
@@ -83,18 +84,21 @@ export function WorkspacePage({ spec, visible }: Props) {
        *  affordance here. */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-bg-secondary/30 shrink-0">
         <span className="text-[12px] text-text-muted font-medium">{workspace.tag}</span>
-        <button
-          type="button"
-          onClick={() => ctx.openAgentConfig(wsId)}
-          className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
-          title="Configure this workspace's AI provider (claude / codex)"
-        >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="3" />
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-          </svg>
-          AI Provider
-        </button>
+        <div className="flex items-center gap-1">
+          <WorkspaceLayoutPopover />
+          <button
+            type="button"
+            onClick={() => ctx.openAgentConfig(wsId)}
+            className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
+            title="Configure this workspace's AI provider (claude / codex)"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+            AI Provider
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 min-h-0 flex flex-col p-3">

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -31,8 +31,13 @@ export function UrlAdopter() {
         <Route path="/" element={<Navigate to="/inbox" replace />} />
 
         {/* Activities */}
-        <Route path="/chat" element={<AdoptStatic spec={{ kind: 'chat', params: { channelId: 'default' } }} />} />
-        <Route path="/chat/:channelId" element={<AdoptChat />} />
+        {/* Traditional Chat is now in the ActivityBar's Legacy section —
+            redirect the bare /chat and /chat/:channelId URLs to /inbox so
+            UrlSync's writes from a previously-focused chat tab don't drag
+            users back into the legacy view on every reload. Traditional
+            Chat itself stays reachable via ActivityBar → Legacy. */}
+        <Route path="/chat" element={<Navigate to="/inbox" replace />} />
+        <Route path="/chat/:channelId" element={<Navigate to="/inbox" replace />} />
         <Route path="/portfolio" element={<AdoptStatic spec={{ kind: 'portfolio', params: {} }} />} />
         <Route path="/automation" element={<Navigate to="/automation/flow" replace />} />
         <Route path="/automation/:section" element={<AdoptAutomation />} />
@@ -97,12 +102,6 @@ export function UrlAdopter() {
  */
 function AdoptStatic({ spec }: { spec: ViewSpec }) {
   useAdopt(spec)
-  return null
-}
-
-function AdoptChat() {
-  const { channelId = 'default' } = useParams<{ channelId?: string }>()
-  useAdopt({ kind: 'chat', params: { channelId } })
   return null
 }
 


### PR DESCRIPTION
## Summary
UI polish on the workspace right pane (collapsible Git/Files panels, mobile auto-hide, Layout popover, Git status as labeled badges) and a routing fix so legacy `/chat` URLs stop dragging users back into Traditional Chat on reload.

## Per-session contributions

### 2026-05-22 — Workspace right-pane controls + legacy chat redirect
- **Workspace right-pane redesign**: each side panel header gets a chevron to collapse to header-only (sibling panel expands to fill); new `[Layout]` button next to AI Provider in WorkspacePage opens a popover with Git/Files toggles + "Auto-hide on mobile" switch; <768px viewports default-hide the right column so the terminal isn't crushed on phones.
- **Git status as labeled badges**: porcelain 2-char codes (`??`, `·M`, `MM`, `UU`…) now render as `untracked` / `modified` / `staged` / `deleted` / `renamed` / `conflict` / `ignored` badges with tone colours. Raw porcelain stays in the hover tooltip for power users. Resolves the recurring "what's that `?`" confusion.
- **Legacy /chat route redirect**: yesterday's `/` → `/inbox` change only covered the root + fallback. The bare `/chat` and `/chat/:channelId` routes still adopted a chat-kind spec, and `UrlSync` writing `/chat/foo` from a persisted focused tab kept dragging users into Traditional Chat. Both routes now `Navigate to=/inbox`. Traditional Chat is still reachable via ActivityBar → Legacy.
- Key commits: `b156b7e`, `f6ac188`

## Full commit log

```
f6ac188 fix(ui/routing): redirect /chat URLs to /inbox
b156b7e feat(ui/workspace): collapsible side panels + Git status labels
fd084da feat(docker): self-host image with bundled claude + codex CLIs
```

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Restart Electron and verify: workspace right-pane chevrons collapse each panel, Layout popover toggles Git/Files visibility, narrow viewport hides the aside, untracked file shows an "untracked" grey badge
- [ ] Refresh app — no longer lands on Traditional Chat; URL `/chat/foo` typed manually redirects to `/inbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)