### PR TITLE
feat(workspaces): template catalog + README convention + version lineage

### DIFF
--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -33,8 +33,27 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
         ...(t.displayName !== undefined ? { displayName: t.displayName } : {}),
         ...(t.groupOrder !== undefined ? { groupOrder: t.groupOrder } : {}),
         defaultAgents: t.defaultAgents,
+        version: t.version,
+        hasReadme: t.readmePath !== undefined,
       })),
     });
+  });
+
+  // Raw README markdown (frontmatter included — the client strips it before
+  // rendering). 404 when the template doesn't ship a README yet; we don't
+  // synthesize a placeholder. Cheap on-demand disk read, no cache.
+  app.get('/templates/:name/readme', async (c) => {
+    const name = c.req.param('name');
+    const tpl = svc.templates.get(name);
+    if (!tpl) return c.json({ error: 'unknown_template' }, 404);
+    if (!tpl.readmePath) return c.json({ error: 'no_readme' }, 404);
+    try {
+      const raw = await readFile(tpl.readmePath, 'utf8');
+      return c.body(raw, 200, { 'content-type': 'text/markdown; charset=utf-8' });
+    } catch (err) {
+      launcherLogger.warn('template.readme_read_failed', { name, err });
+      return c.json({ error: 'read_failed', message: (err as Error).message }, 500);
+    }
   });
 
   app.get('/agents', (c) => {

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -22,7 +22,7 @@ import { ScrollbackStore } from './scrollback-store.js';
 import { SessionPool, type SessionFactoryContext } from './session-pool.js';
 import { SessionRegistry, type SessionRecord } from './session-registry.js';
 import { buildSpawnEnv } from './spawn-env.js';
-import { TemplateRegistry } from './template-registry.js';
+import { readReadmeVersion, TemplateRegistry } from './template-registry.js';
 import { TranscriptWatcher } from './transcript-watcher.js';
 import { WorkspaceCreator } from './workspace-creator.js';
 import { WorkspaceRegistry, type WorkspaceMeta } from './workspace-registry.js';
@@ -140,6 +140,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       description: 'legacy AQ_BOOTSTRAP_SCRIPT entry — migrate to a real template',
       bootstrapScript: config.legacyBootstrapScript,
       filesDir: '',
+      templateDir: '',
+      version: '0.0.0',
       defaultAgents: ['claude'],
     });
   }
@@ -338,7 +340,37 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       claude: existsSync(join(w.dir, '.claude', 'settings.local.json')),
       codex: existsSync(join(w.dir, '.codex')),
     };
-    return { ...w, sessions, agentOverride };
+    // Version lineage + upgrade hint. We read the instance README's
+    // frontmatter for the "current" version each list call — cheap (one
+    // file read per workspace) and authoritative: the agent self-upgrades
+    // by bumping that frontmatter, so reading it live makes the badge
+    // disappear without any extra plumbing.
+    let currentVersion: string | undefined;
+    let upgradeAvailable: { from: string; to: string } | null = null;
+    if (w.template) {
+      const tpl = templates.get(w.template);
+      if (tpl) {
+        const instanceReadme = join(w.dir, 'README.md');
+        const fromInstance = existsSync(instanceReadme)
+          ? await readReadmeVersion(instanceReadme).catch(() => undefined)
+          : undefined;
+        currentVersion = fromInstance ?? w.spawnedFromVersion;
+        // Surface the badge when the template has moved past whatever
+        // version the instance self-claims. `compareVersions` returns 1
+        // when tpl.version > currentVersion. Missing currentVersion (and
+        // no spawnedFromVersion) → no signal, don't guess.
+        if (currentVersion && compareVersions(tpl.version, currentVersion) > 0) {
+          upgradeAvailable = { from: currentVersion, to: tpl.version };
+        }
+      }
+    }
+    return {
+      ...w,
+      sessions,
+      agentOverride,
+      ...(currentVersion !== undefined ? { currentVersion } : {}),
+      upgradeAvailable,
+    };
   };
 
   const dispose = async (reason: string): Promise<void> => {
@@ -369,3 +401,28 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
 }
 
 export type { SessionFactoryContext };
+
+/**
+ * Compare two dotted-version strings (e.g. "1.0.0" vs "1.2.3"). Returns
+ * 1 if a > b, -1 if a < b, 0 if equal. Non-numeric segments fall back to
+ * lexical comparison so a template author who writes `version: 1.0.0-rc1`
+ * still gets sensible ordering. Deliberately not pulling in semver — the
+ * field is convention, not contract; this is enough to drive a badge.
+ */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.');
+  const pb = b.split('.');
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const sa = pa[i] ?? '0';
+    const sb = pb[i] ?? '0';
+    const na = Number(sa);
+    const nb = Number(sb);
+    if (Number.isFinite(na) && Number.isFinite(nb)) {
+      if (na !== nb) return na > nb ? 1 : -1;
+    } else {
+      if (sa !== sb) return sa > sb ? 1 : -1;
+    }
+  }
+  return 0;
+}

--- a/src/workspaces/template-registry.ts
+++ b/src/workspaces/template-registry.ts
@@ -25,6 +25,21 @@ export interface TemplateMeta {
   readonly bootstrapScript: string;
   /** Absolute path to the template's `files/` directory (may not exist). */
   readonly filesDir: string;
+  /** Absolute path to the template root (parent of `files/`). */
+  readonly templateDir: string;
+  /**
+   * Absolute path to the template's `README.md`. Undefined if the template
+   * doesn't ship one yet. Future templates should always ship one — VSC's
+   * convention: README is the canonical human-facing description.
+   */
+  readonly readmePath?: string;
+  /**
+   * Template version, declared in README frontmatter. Used for the
+   * lineage-based upgrade hint (compare a workspace's spawned-from version
+   * against the current template version). Templates without a README, or
+   * without a `version:` key, fall back to "0.0.0".
+   */
+  readonly version: string;
   /**
    * Adapter ids the template wants enabled by default in new workspaces
    * (the create form pre-checks these). Sourced from `template.json`'s
@@ -66,6 +81,9 @@ export class TemplateRegistry {
       }
       const filesDir = join(templateDir, 'files');
       const tplMeta = await readTemplateMeta(join(templateDir, 'template.json'));
+      const readmePath = join(templateDir, 'README.md');
+      const hasReadme = existsSync(readmePath);
+      const version = hasReadme ? await readReadmeVersion(readmePath) : '0.0.0';
       const meta: TemplateMeta = {
         name,
         ...(tplMeta.description !== undefined ? { description: tplMeta.description } : {}),
@@ -73,6 +91,9 @@ export class TemplateRegistry {
         ...(tplMeta.groupOrder !== undefined ? { groupOrder: tplMeta.groupOrder } : {}),
         bootstrapScript,
         filesDir,
+        templateDir,
+        ...(hasReadme ? { readmePath } : {}),
+        version,
         defaultAgents: tplMeta.defaultAgents,
       };
       reg.byName.set(name, meta);
@@ -115,6 +136,54 @@ interface ParsedTemplateMeta {
   readonly displayName?: string;
   readonly groupOrder?: number;
   readonly defaultAgents: readonly string[];
+}
+
+/**
+ * Read the `version:` field from a README's YAML frontmatter. We keep this
+ * deliberately tiny — full YAML support is overkill for what is, by design,
+ * a single string field. Anything more structured belongs in `template.json`,
+ * not in README frontmatter (the frontmatter is the human-facing
+ * description's metadata, not a config surface).
+ *
+ * Returns "0.0.0" when:
+ *   - the file is unreadable
+ *   - there's no frontmatter block (no `---` at the very top)
+ *   - the frontmatter has no `version:` key
+ *   - the value isn't a non-empty string
+ */
+export async function readReadmeVersion(readmePath: string): Promise<string> {
+  try {
+    const raw = await readFile(readmePath, 'utf8');
+    return extractVersion(raw);
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function extractVersion(raw: string): string {
+  // Frontmatter must be at the very top — no leading whitespace except a BOM.
+  const text = raw.replace(/^﻿/, '');
+  if (!text.startsWith('---')) return '0.0.0';
+  // Find the closing fence. Must start at column 0 on its own line.
+  const closeRe = /^---\s*$/m;
+  const remainder = text.slice(3);
+  const closeMatch = closeRe.exec(remainder);
+  if (!closeMatch || closeMatch.index === undefined) return '0.0.0';
+  const block = remainder.slice(0, closeMatch.index);
+  // Naive line-by-line parse — sufficient for `version: 1.0.0` and
+  // `version: "1.0.0"`. Quoted strings get unquoted.
+  for (const line of block.split(/\r?\n/)) {
+    const m = /^\s*version\s*:\s*(.+?)\s*$/.exec(line);
+    if (m && m[1]) {
+      let v = m[1];
+      // Strip surrounding quotes if present.
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+        v = v.slice(1, -1);
+      }
+      if (v.length > 0) return v;
+    }
+  }
+  return '0.0.0';
 }
 
 async function readTemplateMeta(path: string): Promise<ParsedTemplateMeta> {

--- a/src/workspaces/templates/_common.sh
+++ b/src/workspaces/templates/_common.sh
@@ -79,6 +79,30 @@ compose_persona_claude_md() {
   cp CLAUDE.md AGENTS.md
 }
 
+# copy_readme [template_root]
+# Copies $template_root/README.md into the current dir (the workspace root)
+# so the workspace is self-describing on disk. The instance README is the
+# agent's territory from this point on — body and frontmatter (including
+# `version:`) can both drift. The pristine template README stays in source
+# tree under $template_root and is what the showcase page renders.
+#
+# $template_root defaults to $AQ_TEMPLATE_ROOT (injected by the launcher).
+# No-op if no README.md exists at the template root — templates without a
+# README work fine, they just don't get a self-description file. That's a
+# soft convention, not a hard contract.
+copy_readme() {
+  local template_root="${1:-${AQ_TEMPLATE_ROOT:-}}"
+  if [[ -z "$template_root" ]]; then
+    echo "copy_readme: no template_root (set AQ_TEMPLATE_ROOT or pass arg)" >&2
+    return 0
+  fi
+  local src="$template_root/README.md"
+  if [[ ! -f "$src" ]]; then
+    return 0
+  fi
+  cp "$src" README.md
+}
+
 # setup_git_excludes [extra_path...]
 # Appends defensive entries to .git/info/exclude (per-clone, untracked).
 # Always includes:

--- a/src/workspaces/templates/auto-quant/README.md
+++ b/src/workspaces/templates/auto-quant/README.md
@@ -1,0 +1,31 @@
+---
+version: 1.0.0
+---
+
+# Auto-Quant
+
+An autoresearch coworker that clones the public [Auto-Quant](https://github.com/TraderAlice/Auto-Quant) repo and iterates on quantitative trading strategies inside its own branch.
+
+## What this workspace does
+
+Spawns a workspace as a local Auto-Quant clone on its own `autoresearch/<tag>` branch. The agent runs the existing prepare / backtest / optimize pipeline, edits strategies under `user_data/strategies/`, logs results to `results.tsv`, and commits as it goes — so every iteration leaves an auditable git trail.
+
+## When to spawn this
+
+- You want to test a new strategy idea (mean-reversion, momentum, factor combinations) and let the agent iterate on parameters.
+- You're exploring how to combine multiple indicators against Auto-Quant's existing data layout.
+- You want a backtest loop that runs alongside other workspaces without sharing data directories.
+
+Each workspace gets its own `user_data/data/`. First run, the agent runs `uv run prepare.py` to fetch OHLCV from Binance. This isolation is deliberate: different runs may want different timeframes or symbols, and a shared cache would silently mix incompatible files across workspace generations.
+
+## What you'll see in Inbox
+
+- Backtest result summaries (Sharpe, drawdown, key periods) as the agent finishes runs.
+- Strategy diff notes when the agent commits a meaningful iteration.
+
+## Parameters
+
+- **Tag** — becomes the branch name (`autoresearch/<tag>`).
+- **Agents** — default Claude; Codex works too if you prefer.
+
+Power-user override: set `AQ_TEMPLATE_DIR` in the launcher env to point at a pre-existing Auto-Quant clone (e.g. one you've already populated with data).

--- a/src/workspaces/templates/auto-quant/bootstrap.sh
+++ b/src/workspaces/templates/auto-quant/bootstrap.sh
@@ -98,4 +98,10 @@ fi
 # 4. results.tsv header — the agent appends rows from here on out.
 printf 'commit\tevent\tstrategy_name\tsharpe\tmax_dd\tnote\n' > results.tsv
 
+# Intentionally NOT calling copy_readme here: the workspace IS an Auto-Quant
+# clone, so its working tree already carries Auto-Quant's own README.md,
+# which is the right one for the agent / user opening the folder. Our
+# template-level README.md lives in templates/auto-quant/README.md and
+# powers the showcase page — it isn't meant to land in the instance.
+
 echo "bootstrapped autoresearch/$TAG at $OUT_DIR"

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,0 +1,34 @@
+---
+version: 1.0.0
+---
+
+# Chat
+
+A general-purpose Alice workspace. The agent boots with OpenAlice's full MCP tool surface — trading actions, market data, news, technical analysis, brain memory — and Alice's persona pre-loaded as CLAUDE.md / AGENTS.md.
+
+## What this workspace does
+
+This is the closest equivalent to "talk to Alice about anything trading-related." There's no pre-baked task, no specific data layout. The agent can quote tickers, place trades against your UTA accounts, pull news, run indicators, and remember conversations across sessions through the brain memory tools.
+
+## When to spawn this
+
+- You want a long-running thread with Alice that isn't tied to a specific research artifact or autoresearch loop.
+- You're exploring an idea and don't yet know which Harness fits — Chat is the no-commitment starting point.
+- You want quick access to the full MCP tool surface without setting up Auto-Quant clones or finance-skill trees.
+
+## What you'll see in Inbox
+
+(v1: Inbox is one-way — the agent posts; you don't reply through it.)
+
+Things Alice will route here:
+- Trade execution confirmations (when she places orders on your behalf).
+- Market alerts she's been watching for you.
+- Anything she flags as worth re-reading later.
+
+## Parameters
+
+When spawning, you'll configure:
+- **Tag** — short identifier for this workspace (lowercase, dashes ok).
+- **Agents** — which CLI runtimes to enable (default: Claude + Codex).
+
+That's it. No template-specific parameters — everything else is shaped by what you say to the agent.

--- a/src/workspaces/templates/chat/bootstrap.sh
+++ b/src/workspaces/templates/chat/bootstrap.sh
@@ -24,6 +24,7 @@ WS_ID="$(extract_ws_id "$OUT_DIR")"
 
 write_mcp_config "$WS_ID" "$AQ_TEMPLATE_FILES_DIR"
 compose_persona_claude_md "$AQ_TEMPLATE_FILES_DIR"
+copy_readme
 
 git init -q
 setup_git_excludes

--- a/src/workspaces/templates/finance-research/README.md
+++ b/src/workspaces/templates/finance-research/README.md
@@ -1,0 +1,34 @@
+---
+version: 1.0.0
+---
+
+# Finance Research
+
+A research-focused coworker bundled with [himself65/finance-skills](https://github.com/himself65/finance-skills) — equity fundamentals via yfinance, valuation models, earnings analysis, social-feed readers, sentiment scoring.
+
+## What this workspace does
+
+Spawns a workspace with two skill libraries pre-installed:
+- `.claude/skills/` for Claude Code's auto-discovery
+- `.agents/skills/` for Codex's auto-discovery
+
+Both layers load the same SKILL.md trees (market-analysis, social-readers, data-providers) without needing any package install or marketplace registration. The agent has Alice's persona on top of OpenAlice's MCP surface, so it can pivot between research and trading inside one thread.
+
+## When to spawn this
+
+- You're researching a specific company or sector and want yfinance + valuation tooling ready to go.
+- You're combining fundamental analysis with social-feed scraping (Reddit, Twitter, etc. via the bundled readers).
+- You want a session that can answer "is this overvalued vs comparables" without you assembling the data path yourself.
+
+## What you'll see in Inbox
+
+- Research notes the agent writes up for your review.
+- Valuation summaries with the data points she pulled to back them.
+- Sentiment shifts she flags from the social readers.
+
+## Parameters
+
+- **Tag** — short identifier for this workspace.
+- **Agents** — default Claude + Codex (both discover the same skill trees).
+
+Finance-skills is cloned fresh on every spawn — no shared cache. Keeps upstream traffic visible to its maintainer, who's part of the ecosystem we want to grow.

--- a/src/workspaces/templates/finance-research/bootstrap.sh
+++ b/src/workspaces/templates/finance-research/bootstrap.sh
@@ -45,6 +45,7 @@ WS_ID="$(extract_ws_id "$OUT_DIR")"
 
 write_mcp_config "$WS_ID" "$AQ_TEMPLATE_FILES_DIR"
 compose_persona_claude_md "$AQ_TEMPLATE_FILES_DIR"
+copy_readme
 
 git init -q
 # .finance-skills/ is the upstream clone; users shouldn't bake it into

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -108,6 +108,7 @@ export class WorkspaceCreator {
       {
         AQ_TEMPLATE_DIR: this.opts.bootstrapEnv.templateDir,
         AQ_TEMPLATE_FILES_DIR: template.filesDir,
+        AQ_TEMPLATE_ROOT: template.templateDir,
         AQ_LAUNCHER_REPO_ROOT: this.opts.bootstrapEnv.launcherRepoRoot,
         // AQ_LAUNCHER_ROOT is intentionally NOT set here. bootstrap.sh's
         // ${AQ_LAUNCHER_ROOT:-$HOME/.openalice/workspaces} default matches
@@ -155,6 +156,7 @@ export class WorkspaceCreator {
       dir,
       createdAt: new Date().toISOString(),
       template: templateName,
+      spawnedFromVersion: template.version,
       agents,
     };
     await this.opts.registry.add(workspace);

--- a/src/workspaces/workspace-registry.ts
+++ b/src/workspaces/workspace-registry.ts
@@ -15,6 +15,16 @@ export interface WorkspaceMeta {
   /** Template that created this workspace. Optional for backward compatibility with pre-templates entries. */
   readonly template?: string;
   /**
+   * Immutable lineage: the template's `version` at the moment this workspace
+   * was spawned. Written once by the creator, never updated. Used by the
+   * Overview UI to display "from {template} v{spawnedFromVersion}" and as a
+   * fallback when the instance's own README is unreadable.
+   *
+   * Pre-version-tracking rows (loaded from older `workspaces.json`) are
+   * missing this field — treat as unknown rather than back-filling.
+   */
+  readonly spawnedFromVersion?: string;
+  /**
    * Adapter ids enabled in this workspace. Order is significant: the first
    * entry is the default for one-click spawns. Legacy rows (missing this
    * field) are normalized to `['claude']` at load time.
@@ -143,6 +153,12 @@ function validateFile(value: unknown): WorkspaceMeta[] {
       createdAt: e['createdAt'],
       agents: agents.length > 0 ? agents : ['claude'],
     };
-    return typeof e['template'] === 'string' ? { ...base, template: e['template'] } : base;
+    let withTemplate: WorkspaceMeta = typeof e['template'] === 'string'
+      ? { ...base, template: e['template'] }
+      : base;
+    if (typeof e['spawnedFromVersion'] === 'string') {
+      withTemplate = { ...withTemplate, spawnedFromVersion: e['spawnedFromVersion'] };
+    }
+    return withTemplate;
   });
 }

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { ChevronRight, Cpu, ScrollText, Settings, Sparkles, Terminal, type LucideIcon } from 'lucide-react'
+import { ArrowUpCircle, ChevronRight, Cpu, GitBranch, ScrollText, Settings, Sparkles, Terminal, type LucideIcon } from 'lucide-react'
 import type { GitLogEntry, Workspace } from './api'
 
 /**
@@ -43,6 +43,13 @@ interface Props {
   onOpen: () => void
   onOpenSession: (sessionId: string) => void
   onConfigure?: () => void
+  /**
+   * Open the template's detail page — used by the upgrade badge so the
+   * user (or the agent reading the page) can see what's new before
+   * deciding to self-upgrade. Optional; when absent the badge still
+   * displays but isn't clickable.
+   */
+  onOpenTemplate?: (templateName: string) => void
 }
 
 export function OverviewCard({
@@ -51,6 +58,7 @@ export function OverviewCard({
   onOpen,
   onOpenSession,
   onConfigure,
+  onOpenTemplate,
 }: Props) {
   const w = workspace
   const hasRunning = w.sessions.some((s) => s.state === 'running')
@@ -92,6 +100,21 @@ export function OverviewCard({
             Active {relativeTime(lastActivityMs)}
           </p>
         </div>
+        {w.upgradeAvailable && w.template && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onOpenTemplate?.(w.template!)
+            }}
+            disabled={!onOpenTemplate}
+            title={`Template moved from v${w.upgradeAvailable.from} → v${w.upgradeAvailable.to}. The agent can self-upgrade by reading the new README and updating this workspace.`}
+            className="shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/40 hover:border-accent/80 hover:bg-accent/10 transition-colors disabled:cursor-default disabled:hover:border-accent/40 disabled:hover:bg-transparent"
+          >
+            <ArrowUpCircle size={10} strokeWidth={2.25} />
+            <span>v{w.upgradeAvailable.to}</span>
+          </button>
+        )}
       </div>
 
       {/* Sessions */}
@@ -134,8 +157,16 @@ export function OverviewCard({
       </div>
 
       {/* Footer — only rendered when there's something to show */}
-      {(overrideAgents.length > 0 || lastCommit) && (
+      {(overrideAgents.length > 0 || lastCommit || (w.template && w.spawnedFromVersion)) && (
         <div className="border-t border-border pt-3 space-y-1.5">
+          {w.template && w.spawnedFromVersion && (
+            <div className="flex items-center gap-2 text-[11px] text-text-muted">
+              <GitBranch size={11} strokeWidth={2.25} className="shrink-0" />
+              <span className="truncate">
+                from {w.template} v{w.spawnedFromVersion}
+              </span>
+            </div>
+          )}
           {overrideAgents.length > 0 && onConfigure && (
             <button
               type="button"

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { FormEvent, ReactElement } from 'react';
-import { Cpu, LayoutGrid, Sparkles, Terminal, type LucideIcon } from 'lucide-react';
+import { Cpu, LayoutGrid, Library, Sparkles, Terminal, type LucideIcon } from 'lucide-react';
 
 import {
   createWorkspace,
@@ -43,6 +43,10 @@ export interface SidebarProps {
   readonly onOpenOverview?: () => void;
   /** True when the Workspaces Overview tab is currently focused — highlights the pinned row. */
   readonly overviewActive?: boolean;
+  /** Open the Templates catalog tab (one card per workspace template). */
+  readonly onOpenTemplates?: () => void;
+  /** True when a Templates tab (catalog or detail) is currently focused. */
+  readonly templatesActive?: boolean;
 }
 
 export function Sidebar(props: SidebarProps): ReactElement {
@@ -191,6 +195,19 @@ export function Sidebar(props: SidebarProps): ReactElement {
             >
               <LayoutGrid size={13} strokeWidth={2.25} aria-hidden="true" />
               <span>Overview</span>
+            </button>
+          </li>
+        )}
+        {props.onOpenTemplates && (
+          <li className="sidebar-overview-row">
+            <button
+              type="button"
+              className={`sidebar-overview-btn${props.templatesActive ? ' is-active' : ''}`}
+              onClick={props.onOpenTemplates}
+              title="Browse workspace templates"
+            >
+              <Library size={13} strokeWidth={2.25} aria-hidden="true" />
+              <span>Templates</span>
             </button>
           </li>
         )}

--- a/ui/src/components/workspace/TemplateCard.tsx
+++ b/ui/src/components/workspace/TemplateCard.tsx
@@ -1,0 +1,80 @@
+import { Cpu, Sparkles, Terminal, type LucideIcon } from 'lucide-react'
+
+import type { TemplateInfo } from './api'
+
+/**
+ * Catalog card for a workspace template. Mirrors the visual idiom of
+ * OverviewCard (border + rounded-lg + bg-bg-secondary + hover) so the
+ * Workspaces activity feels like one design system. Click → opens the
+ * detail tab where the README and spawn form live.
+ */
+
+const AGENT_ICONS: Record<string, LucideIcon> = {
+  claude: Sparkles,
+  codex: Cpu,
+  shell: Terminal,
+}
+
+function AgentGlyph({ agent }: { agent: string }) {
+  const Icon = AGENT_ICONS[agent]
+  if (Icon) return <Icon size={12} strokeWidth={2.25} aria-hidden="true" />
+  return <span aria-hidden="true" className="text-[11px] font-mono">·</span>
+}
+
+function humanize(name: string): string {
+  return (
+    name
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(' ') || name
+  )
+}
+
+interface Props {
+  template: TemplateInfo
+  onOpen: () => void
+}
+
+export function TemplateCard({ template: t, onOpen }: Props) {
+  const title = t.displayName ?? humanize(t.name)
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="group rounded-lg border border-border bg-bg-secondary hover:bg-bg-tertiary/40 hover:border-border/80 transition-colors cursor-pointer p-4 flex flex-col gap-3 text-left"
+    >
+      <div className="flex items-start gap-2.5">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2">
+            <h3 className="text-[14px] font-semibold text-text truncate" title={t.name}>
+              {title}
+            </h3>
+            <span className="text-[11px] font-mono text-text-muted tabular-nums">
+              v{t.version}
+            </span>
+          </div>
+          {t.description && (
+            <p className="text-[12px] text-text-muted line-clamp-3 mt-1">
+              {t.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="border-t border-border pt-3 flex items-center gap-3">
+        <div className="text-[10px] uppercase tracking-wider text-text-muted/70">
+          Default agents
+        </div>
+        <div className="flex items-center gap-2 text-text-muted">
+          {t.defaultAgents.map((a) => (
+            <span key={a} className="flex items-center gap-1 text-[11px]">
+              <AgentGlyph agent={a} />
+              <span>{a}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/ui/src/components/workspace/WorkspacesSidebar.tsx
+++ b/ui/src/components/workspace/WorkspacesSidebar.tsx
@@ -23,6 +23,8 @@ export function WorkspacesSidebar() {
       }
     : null
   const overviewActive = focused?.kind === 'workspace-list'
+  const templatesActive =
+    focused?.kind === 'template-catalog' || focused?.kind === 'template-detail'
 
   return (
     <div className="workspaces-root workspaces-sidebar-frame">
@@ -47,6 +49,8 @@ export function WorkspacesSidebar() {
         onConfigureWorkspace={(wsId) => ctx.openAgentConfig(wsId)}
         onOpenOverview={() => openOrFocus({ kind: 'workspace-list', params: {} })}
         overviewActive={overviewActive}
+        onOpenTemplates={() => openOrFocus({ kind: 'template-catalog', params: {} })}
+        templatesActive={templatesActive}
       />
     </div>
   )

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -10,6 +10,26 @@ export interface Workspace {
   readonly dir: string;
   readonly createdAt: string;
   readonly template?: string;
+  /**
+   * The template version at the moment this workspace was spawned. Pinned
+   * once — system-written, never updated. Used to render lineage in the
+   * Overview card ("from {template} v{spawnedFromVersion}").
+   */
+  readonly spawnedFromVersion?: string;
+  /**
+   * The instance's currently self-reported version, read from
+   * `<workspace>/README.md` frontmatter on every list call. The agent can
+   * mutate this when self-upgrading. Falls back to `spawnedFromVersion`
+   * if the instance README is missing or has no version frontmatter.
+   */
+  readonly currentVersion?: string;
+  /**
+   * Set when the template (in source tree) is at a higher version than the
+   * instance currently self-claims. Informational only — clicking the
+   * badge jumps the user to the template's detail page; nothing in the
+   * launcher applies migrations. Agent self-upgrade is the resolution path.
+   */
+  readonly upgradeAvailable?: { from: string; to: string } | null;
   /** Adapter ids enabled for this workspace; agents[0] is the default for `+`. */
   readonly agents: readonly string[];
   /**
@@ -85,6 +105,10 @@ export interface TemplateInfo {
    *  a declared `groupOrder` sort after declared ones, by name. */
   readonly groupOrder?: number;
   readonly defaultAgents: readonly string[];
+  /** Template version, declared in README frontmatter. "0.0.0" when missing. */
+  readonly version: string;
+  /** True if the template ships a README.md (showcase detail page can load it). */
+  readonly hasReadme: boolean;
 }
 
 export async function listTemplates(): Promise<TemplateInfo[]> {
@@ -92,6 +116,34 @@ export async function listTemplates(): Promise<TemplateInfo[]> {
   if (!res.ok) throw new Error(`list templates failed: ${res.status}`);
   const body = (await res.json()) as { templates: TemplateInfo[] };
   return body.templates;
+}
+
+/**
+ * Fetch a template's raw README markdown. Strips YAML frontmatter before
+ * returning — frontmatter is metadata, not content the user should see.
+ * Returns null when the template has no README.
+ */
+export async function fetchTemplateReadme(name: string): Promise<string | null> {
+  const res = await fetch(`/api/workspaces/templates/${encodeURIComponent(name)}/readme`);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`fetch readme failed: ${res.status}`);
+  const raw = await res.text();
+  return stripFrontmatter(raw);
+}
+
+/**
+ * Strip a leading YAML frontmatter block (`---` ... `---`) so the rendered
+ * README body doesn't show the metadata to the user. Conservative: only
+ * strips when frontmatter is at column 0; anything else passes through.
+ */
+function stripFrontmatter(raw: string): string {
+  const text = raw.replace(/^﻿/, '');
+  if (!text.startsWith('---')) return text;
+  const closeMatch = /^---\s*$/m.exec(text.slice(3));
+  if (!closeMatch || closeMatch.index === undefined) return text;
+  // Skip past the closing fence and any trailing newline.
+  const tailStart = 3 + closeMatch.index + closeMatch[0].length;
+  return text.slice(tailStart).replace(/^\r?\n/, '');
 }
 
 export interface AgentCapabilities {

--- a/ui/src/pages/TemplateCatalogPage.tsx
+++ b/ui/src/pages/TemplateCatalogPage.tsx
@@ -1,0 +1,72 @@
+/**
+ * Workspace template catalog.
+ *
+ * Grid of TemplateCards — one per discovered template — answering "what
+ * kinds of coworkers can OpenAlice hire for you?". Click a card to drill
+ * into its README and spawn form (TemplateDetailPage).
+ *
+ * This page is the discovery surface for the Workspace ecosystem. As more
+ * first-party templates land (and eventually third-party ones), this is
+ * where they show up. v1: just the grid. No categories, no filters, no
+ * search — at 3-10 templates that infrastructure is premature.
+ */
+
+import { useMemo } from 'react'
+
+import { useWorkspaces } from '../contexts/WorkspacesContext'
+import { useWorkspace } from '../tabs/store'
+import { TemplateCard } from '../components/workspace/TemplateCard'
+
+export function TemplateCatalogPage() {
+  const { templates } = useWorkspaces()
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+
+  // Sort by groupOrder (ascending), then name. Same idiom as the Overview
+  // section ordering so users see the same shape twice over.
+  const sorted = useMemo(() => {
+    return [...templates].sort((a, b) => {
+      const ao = a.groupOrder ?? Number.POSITIVE_INFINITY
+      const bo = b.groupOrder ?? Number.POSITIVE_INFINITY
+      if (ao !== bo) return ao - bo
+      return a.name.localeCompare(b.name)
+    })
+  }, [templates])
+
+  if (sorted.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-text-muted px-6">
+        <h2 className="text-lg font-medium text-text mb-2">Templates</h2>
+        <p className="text-sm max-w-md text-center">
+          No templates discovered. Check the launcher's templates directory.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="max-w-5xl mx-auto px-6 py-6">
+        <div className="mb-6">
+          <h2 className="text-[18px] font-semibold text-text">Workspace templates</h2>
+          <p className="text-[12px] text-text-muted mt-1 max-w-2xl">
+            Each template spawns a workspace with a specific shape — what tools the
+            agent has, what files start in the folder, what kind of work it's set
+            up for. Pick one to see what it does, then create an instance.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {sorted.map((t) => (
+            <TemplateCard
+              key={t.name}
+              template={t}
+              onOpen={() =>
+                openOrFocus({ kind: 'template-detail', params: { name: t.name } })
+              }
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/TemplateDetailPage.tsx
+++ b/ui/src/pages/TemplateDetailPage.tsx
@@ -1,0 +1,226 @@
+/**
+ * Workspace template detail.
+ *
+ * Renders the template's README (via MarkdownContent) alongside a spawn
+ * form. This is the in-flow staffing surface — read what shape of
+ * coworker this Harness produces, fill the parameters, hire one.
+ *
+ * The instance the agent starts modifying from here will diverge over
+ * time; this page describes the **starting shape**. The README on disk
+ * inside the spawned workspace is the agent's territory thereafter.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { FormEvent } from 'react'
+
+import { MarkdownContent } from '../components/MarkdownContent'
+import { useWorkspaces } from '../contexts/WorkspacesContext'
+import { useWorkspace } from '../tabs/store'
+import {
+  createWorkspace,
+  fetchTemplateReadme,
+} from '../components/workspace/api'
+
+const TAG_HINT = 'a-z, 0-9, "-", "_", up to 33 chars'
+const TAG_RE = /^[a-z0-9][a-z0-9_-]{0,32}$/
+
+interface Props {
+  spec: { kind: 'template-detail'; params: { name: string } }
+}
+
+function humanize(name: string): string {
+  return (
+    name
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(' ') || name
+  )
+}
+
+export function TemplateDetailPage({ spec }: Props) {
+  const { templates, agents, refresh } = useWorkspaces()
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+
+  const templateName = spec.params.name
+  const template = useMemo(
+    () => templates.find((t) => t.name === templateName),
+    [templates, templateName],
+  )
+
+  // README — fetched lazily once per template (no cache across mounts; the
+  // catalog is small enough that re-fetch on tab open is fine).
+  const [readme, setReadme] = useState<string | null>(null)
+  const [readmeError, setReadmeError] = useState<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    setReadme(null)
+    setReadmeError(null)
+    void fetchTemplateReadme(templateName)
+      .then((md) => {
+        if (cancelled) return
+        if (md === null) setReadmeError('This template doesn\'t ship a README yet.')
+        else setReadme(md)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setReadmeError((err as Error).message)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [templateName])
+
+  // Spawn form state — same shape as the sidebar's inline form, but laid
+  // out as a panel rather than a compact column.
+  const [tag, setTag] = useState('')
+  const [pickedAgents, setPickedAgents] = useState<Set<string> | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  // Reset form state when the user navigates to a different template tab.
+  useEffect(() => {
+    setTag('')
+    setPickedAgents(null)
+    setCreateError(null)
+  }, [templateName])
+
+  const checkedAgents: ReadonlySet<string> = useMemo(() => {
+    if (pickedAgents) return pickedAgents
+    return new Set(template?.defaultAgents ?? ['claude'])
+  }, [pickedAgents, template])
+
+  const toggleAgent = (id: string): void => {
+    setPickedAgents((prev) => {
+      const base = prev ?? new Set(template?.defaultAgents ?? ['claude'])
+      const next = new Set(base)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const submit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault()
+    if (!template) return
+    const t = tag.trim()
+    if (!TAG_RE.test(t)) {
+      setCreateError(`invalid tag (${TAG_HINT})`)
+      return
+    }
+    if (checkedAgents.size === 0) {
+      setCreateError('pick at least one agent')
+      return
+    }
+    setCreating(true)
+    setCreateError(null)
+    const result = await createWorkspace(t, template.name, Array.from(checkedAgents))
+    setCreating(false)
+    if (result.ok) {
+      refresh()
+      openOrFocus({ kind: 'workspace', params: { wsId: result.workspace.id } })
+    } else {
+      const msg = result.error.message ?? result.error.error ?? `HTTP ${result.status}`
+      setCreateError(msg)
+    }
+  }
+
+  if (!template) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-text-muted px-6">
+        <h2 className="text-lg font-medium text-text mb-2">Template not found</h2>
+        <p className="text-sm">No template named <code className="font-mono">{templateName}</code>.</p>
+      </div>
+    )
+  }
+
+  const title = template.displayName ?? humanize(template.name)
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="max-w-4xl mx-auto px-6 py-6">
+        <div className="mb-6 flex items-baseline gap-3">
+          <h2 className="text-[20px] font-semibold text-text">{title}</h2>
+          <span className="text-[12px] font-mono text-text-muted tabular-nums">
+            v{template.version}
+          </span>
+        </div>
+
+        {/* README body */}
+        <div className="rounded-lg border border-border bg-bg-secondary px-6 py-5 mb-6">
+          {readme === null && readmeError === null && (
+            <p className="text-[12px] text-text-muted italic">Loading README…</p>
+          )}
+          {readmeError && (
+            <p className="text-[12px] text-text-muted italic">{readmeError}</p>
+          )}
+          {readme && <MarkdownContent text={readme} />}
+        </div>
+
+        {/* Spawn form */}
+        <form onSubmit={submit} className="rounded-lg border border-border bg-bg-secondary px-6 py-5 space-y-4">
+          <div className="flex items-baseline justify-between">
+            <h3 className="text-[14px] font-semibold text-text">Spawn a workspace</h3>
+            <span className="text-[11px] text-text-muted">
+              from {template.name} v{template.version}
+            </span>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="tpl-detail-tag" className="block text-[11px] uppercase tracking-wider text-text-muted/70">
+              Tag
+            </label>
+            <input
+              id="tpl-detail-tag"
+              ref={inputRef}
+              type="text"
+              placeholder="e.g. may1"
+              value={tag}
+              onChange={(e) => setTag(e.target.value)}
+              disabled={creating}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+              className="w-full px-3 py-2 text-[13px] bg-bg border border-border rounded font-mono text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent"
+            />
+            <p className="text-[11px] text-text-muted/70">{TAG_HINT}</p>
+          </div>
+
+          {agents.length > 0 && (
+            <div className="space-y-1.5">
+              <div className="text-[11px] uppercase tracking-wider text-text-muted/70">Agents</div>
+              <div className="flex items-center gap-3 flex-wrap">
+                {agents.map((a) => (
+                  <label key={a.id} className="flex items-center gap-1.5 text-[12px] text-text" title={a.displayName}>
+                    <input
+                      type="checkbox"
+                      checked={checkedAgents.has(a.id)}
+                      onChange={() => toggleAgent(a.id)}
+                      disabled={creating}
+                    />
+                    <span>{a.id}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {createError && (
+            <div className="text-[12px] text-red">{createError}</div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={creating || tag.length === 0}
+              className="btn-primary"
+            >
+              {creating ? 'Creating…' : 'Create workspace'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/WorkspaceListPage.tsx
+++ b/ui/src/pages/WorkspaceListPage.tsx
@@ -178,6 +178,9 @@ export function WorkspaceListPage() {
                       })
                     }
                     onConfigure={() => openAgentConfig(w.id)}
+                    onOpenTemplate={(name) =>
+                      openOrFocus({ kind: 'template-detail', params: { name } })
+                    }
                   />
                 ))}
               </div>

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -69,6 +69,12 @@ export function UrlAdopter() {
 
         {/* Workspaces */}
         <Route path="/workspaces" element={<AdoptStatic spec={{ kind: 'workspace-list', params: {} }} />} />
+        {/* Template catalog routes must come before /workspaces/:wsId so the
+            static `templates` segment wins the match (it would otherwise
+            never collide — wsIds are UUIDs — but route specificity is the
+            defensive default). */}
+        <Route path="/workspaces/templates" element={<AdoptStatic spec={{ kind: 'template-catalog', params: {} }} />} />
+        <Route path="/workspaces/templates/:name" element={<AdoptTemplateDetail />} />
         <Route path="/workspaces/:wsId" element={<AdoptWorkspace />} />
         <Route path="/workspaces/:wsId/s/:sessionId" element={<AdoptWorkspace />} />
 
@@ -164,6 +170,12 @@ function AdoptWorkspace() {
   const params: { wsId: string; sessionId?: string } = { wsId }
   if (sessionId) params.sessionId = sessionId
   return <AdoptStatic spec={{ kind: 'workspace', params }} />
+}
+
+function AdoptTemplateDetail() {
+  const { name } = useParams<{ name: string }>()
+  if (!name) return <Navigate to="/workspaces/templates" replace />
+  return <AdoptStatic spec={{ kind: 'template-detail', params: { name } }} />
 }
 
 function RedirectUtaDetail() {

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -22,6 +22,8 @@ import { NotificationsInboxPage } from '../pages/NotificationsInboxPage'
 import { InboxPage } from '../pages/InboxPage'
 import { WorkspaceListPage } from '../pages/WorkspaceListPage'
 import { WorkspacePage } from '../pages/WorkspacePage'
+import { TemplateCatalogPage } from '../pages/TemplateCatalogPage'
+import { TemplateDetailPage } from '../pages/TemplateDetailPage'
 
 /**
  * Central registry mapping each ViewKind to its render component and URL
@@ -214,6 +216,20 @@ const workspaceModule: ViewModule<'workspace'> = {
   Component: WorkspacePage,
 }
 
+const templateCatalogModule: ViewModule<'template-catalog'> = {
+  kind: 'template-catalog',
+  title: () => 'Templates',
+  toUrl: () => '/workspaces/templates',
+  Component: () => <TemplateCatalogPage />,
+}
+
+const templateDetailModule: ViewModule<'template-detail'> = {
+  kind: 'template-detail',
+  title: (spec) => `Template · ${spec.params.name}`,
+  toUrl: (spec) => `/workspaces/templates/${encodeURIComponent(spec.params.name)}`,
+  Component: ({ spec }) => <TemplateDetailPage spec={spec} />,
+}
+
 // ==================== Aggregate ====================
 
 export const VIEWS = {
@@ -230,6 +246,8 @@ export const VIEWS = {
   inbox: inboxModule,
   'workspace-list': workspaceListModule,
   workspace: workspaceModule,
+  'template-catalog': templateCatalogModule,
+  'template-detail': templateDetailModule,
 } as const satisfies { [K in ViewKind]: ViewModule<K> }
 
 /** Untyped lookup — narrow at the call site by inspecting `spec.kind`. */

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -17,6 +17,8 @@ export type ViewSpec =
   | { kind: 'chat';           params: { channelId: string } }
   | { kind: 'workspace-list'; params: Record<string, never> }
   | { kind: 'workspace';      params: { wsId: string; sessionId?: string } }
+  | { kind: 'template-catalog'; params: Record<string, never> }
+  | { kind: 'template-detail';  params: { name: string } }
   | { kind: 'portfolio';      params: Record<string, never> }
   | { kind: 'automation';     params: { section: 'flow' | 'heartbeat' | 'cron' | 'webhook' } }
   | { kind: 'news';           params: Record<string, never> }


### PR DESCRIPTION
## Summary

Workspace templates self-describe via README + YAML frontmatter (VSC-extension convention scaled down). UI surfaces a Templates catalog + per-template detail page. Workspaces carry immutable spawned-from lineage; an "upgrade available" badge lights up when the template moves past the instance's self-claimed version, leaving resolution to agent self-upgrade — no migration code.

## Per-session contributions

### 2026-05-22 — Workspace template catalog + README + version lineage

- Template `README.md` at template root is the canonical self-description (YAML frontmatter for metadata, currently `version:`; body is soft-convention). Backend parses the frontmatter; new endpoint `GET /api/workspaces/templates/:name/readme` serves the raw markdown.
- Each spawned workspace gets the template's README copied into the instance folder (via new `_common.sh::copy_readme` helper). Agent owns it from there — body and `version:` frontmatter can both drift. Auto-quant intentionally opts out (clones already have upstream README).
- `workspaces.json` records `spawnedFromVersion` (immutable lineage). `publicMeta` reads instance README frontmatter live to compute `currentVersion` + `upgradeAvailable`. Agent bumping instance version clears the badge naturally.
- Frontend: new Templates catalog (`/workspaces/templates`) + detail (`/workspaces/templates/:name`) with README rendered via existing `MarkdownContent` + a spawn form. Sidebar gets a Templates button next to Overview. Overview card adds a lineage row + upgrade badge.
- 3 first-party READMEs at `version: 1.0.0`: chat / auto-quant / finance-research.
- Key commits: `b22dfd7`

## Full commit log

```
b22dfd7 feat(workspaces): template catalog + README convention + version lineage
```

## Test plan

- [x] `npx tsc --noEmit` clean (root + ui)
- [x] `pnpm test` — 94 files, 1738 tests passing
- [x] Manual: catalog renders 3 cards at `/workspaces/templates`; detail page renders README via MarkdownContent at `/workspaces/templates/chat`
- [ ] Manual: spawn from detail page → workspace appears in Overview with lineage row + instance has copied README on disk
- [ ] Manual: bump `templates/chat/README.md` to `version: 2.0.0` → existing chat instance Overview card shows "v2.0.0 available" badge
- [ ] Manual: simulate agent self-upgrade (edit instance README frontmatter to `version: 2.0.0`) → badge clears on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)