### PR TITLE
fix(ui/sidebar): move Chat above Workspaces in top nav

### DIFF
--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -95,8 +95,8 @@ const NAV_SECTIONS: NavSection[] = [
     sectionLabel: '',
     items: [
       { page: 'inbox',      label: 'Inbox',      icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
-      { page: 'workspaces', label: 'Workspaces', icon: TerminalSquare },
       { page: 'chat',       label: 'Chat',       icon: MessageSquare },
+      { page: 'workspaces', label: 'Workspaces', icon: TerminalSquare },
       { page: 'market',     label: 'Market',     icon: BarChart3 },
       { page: 'news',       label: 'News',       icon: Newspaper, defaultTab: { kind: 'news', params: {} } },
     ],


### PR DESCRIPTION
## Summary
Reorder the ActivityBar top section so Chat sits directly under Inbox, above Workspaces. Chat is the high-frequency shortcut (per the existing comment in the same block); putting the high-frequency entry above the index entry matches user muscle memory.

## Per-session contributions
### 2026-05-22 — ActivityBar Chat/Workspaces reorder
- Swap order of `chat` and `workspaces` items in `NAV_SECTIONS[0].items` (`ui/src/components/ActivityBar.tsx`).
- No routing / store / behavior change — one-line array reorder.
- Key commits: `537cfa3`

## Full commit log
```
537cfa3 fix(ui/sidebar): move Chat above Workspaces in top nav
```

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` passes (1738 / 1738)
- [ ] Visual check in dev: top nav reads Inbox → Chat → Workspaces → Market → News

🤖 Generated with [Claude Code](https://claude.com/claude-code)