### PR TITLE
fix(uta): export utaConfigSchema from uta-protocol — unbreaks test-connection

### DIFF
--- a/packages/uta-protocol/src/schemas/index.ts
+++ b/packages/uta-protocol/src/schemas/index.ts
@@ -7,5 +7,25 @@
  * lifts each route.
  */
 
-export {}
+import { z } from 'zod'
+
+const guardConfigSchema = z.object({
+  type: z.string(),
+  options: z.record(z.string(), z.unknown()).default({}),
+})
+
+export const utaConfigSchema = z.object({
+  id: z.string(),
+  label: z.string().optional(),
+  presetId: z.string(),
+  enabled: z.boolean().default(true),
+  guards: z.array(guardConfigSchema).default([]),
+  presetConfig: z.record(z.string(), z.unknown()).default({}),
+  ephemeral: z.boolean().optional(),
+}).refine((u) => u.ephemeral !== true || u.presetId === 'mock-simulator', {
+  message: 'ephemeral: true is only allowed on mock-simulator UTAs (would destroy real broker history at next boot)',
+  path: ['ephemeral'],
+})
+
+export type UTAConfig = z.infer<typeof utaConfigSchema>
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -315,44 +315,10 @@ export type WebChannel = z.infer<typeof webSubchannelSchema>
 
 // ==================== UTA Config ====================
 
-const guardConfigSchema = z.object({
-  type: z.string(),
-  options: z.record(z.string(), z.unknown()).default({}),
-})
-
-/**
- * One Unified Trading Account. The user-facing concept — one preset
- * (OKX, Bybit, IBKR, …) plus credentials, guards, and an enabled flag.
- *
- * Distinct from `AccountInfo` (which is broker-side: cash, equity,
- * margin returned by `IBroker.getAccount()`). Two different "account"s.
- */
-export const utaConfigSchema = z.object({
-  id: z.string(),
-  label: z.string().optional(),
-  /** Broker preset id — resolves to engine + form schema via BROKER_PRESET_CATALOG. */
-  presetId: z.string(),
-  enabled: z.boolean().default(true),
-  guards: z.array(guardConfigSchema).default([]),
-  /** User-filled form values, validated against the preset's own zodSchema. */
-  presetConfig: z.record(z.string(), z.unknown()).default({}),
-  /**
-   * Test/throwaway UTA — purged at every server startup (config entry
-   * removed + `data/trading/<id>/` wiped) and dropped immediately when
-   * deleted via the UTA-config DELETE endpoint. For fixture-based testing:
-   * each session starts from a clean slate, no cross-session cost-basis
-   * pollution. Only allowed on `mock-simulator` preset; setting it on a
-   * real broker would silently destroy account history on next boot.
-   */
-  ephemeral: z.boolean().optional(),
-}).refine((u) => u.ephemeral !== true || u.presetId === 'mock-simulator', {
-  message: 'ephemeral: true is only allowed on mock-simulator UTAs (would destroy real broker history at next boot)',
-  path: ['ephemeral'],
-})
+import { utaConfigSchema, type UTAConfig } from '@traderalice/uta-protocol'
+export { utaConfigSchema, UTAConfig }
 
 export const utasFileSchema = z.array(utaConfigSchema)
-
-export type UTAConfig = z.infer<typeof utaConfigSchema>
 
 // ==================== Unified Config Type ====================
 


### PR DESCRIPTION
## Summary

Fixes a runtime TypeError that crashes the UTA service when testing any exchange connection (observed on Bitget, affects all presets):

```
Cannot read properties of undefined (reading 'parse')
```

## Root Cause

`services/uta/src/http/routes-trading.ts:191` imports `utaConfigSchema` from `@traderalice/uta-protocol`:

```typescript
const { utaConfigSchema } = await import('@traderalice/uta-protocol')
const utaConfig = utaConfigSchema.parse({ ...body, id: body.id ?? '__test__' })
```

But `packages/uta-protocol/src/schemas/index.ts` was empty (`export {}`). The destructured `utaConfigSchema` is `undefined`, and `.parse()` on `undefined` throws.

## Fix

- **Add** `utaConfigSchema` + `guardConfigSchema` to `packages/uta-protocol/src/schemas/index.ts` (the canonical location the UTA service already expects)
- **Replace** the duplicate definition in `src/core/config.ts` with a re-export from the protocol package, keeping the existing public API intact

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Create a new UTA with any exchange preset → "Test Connection" no longer crashes with TypeError
- [ ] Existing imports of `utaConfigSchema` from `src/core/config.ts` still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)