### PR TITLE
feat(demo): Stage 2 PR-1 — Vercel-deployable + visual skeleton

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from './components/Sidebar'
 import { TabHost } from './components/TabHost'
 import { ChannelConfigModal } from './components/ChannelConfigModal'
 import { UpdateBanner } from './components/UpdateBanner'
+import { DemoBanner } from './demo/DemoBanner'
 import { ChannelsProvider, useChannels } from './contexts/ChannelsContext'
 import { WorkspacesProvider } from './contexts/WorkspacesContext'
 import { findSectionForActivity } from './sections'
@@ -120,6 +121,7 @@ function AppShell() {
 
   return (
     <div className="flex flex-col h-full">
+      {import.meta.env.VITE_DEMO_MODE && <DemoBanner />}
       <UpdateBanner />
       <div className="flex flex-1 min-h-0">
         <ActivityBar

--- a/ui/src/demo/DemoBanner.tsx
+++ b/ui/src/demo/DemoBanner.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react'
+
+export function DemoBanner(): ReactElement {
+  return (
+    <div className="flex items-center gap-3 px-4 py-1.5 bg-amber-500/10 border-b border-amber-500/40 text-[12px] text-text shrink-0">
+      <span className="shrink-0 inline-flex items-center gap-1.5 font-semibold text-amber-400 uppercase tracking-wider text-[10px]">
+        <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+        Demo
+      </span>
+      <span className="flex-1 min-w-0 truncate text-text-muted">
+        You&apos;re looking at a snapshot of OpenAlice with recorded data. Mutations don&apos;t persist; the agent terminal is replayed.
+      </span>
+      <a
+        href="https://github.com/TraderAlice/OpenAlice"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-amber-400 hover:underline shrink-0 font-medium"
+      >
+        Install →
+      </a>
+    </div>
+  )
+}

--- a/ui/src/demo/DemoTerminalStub.tsx
+++ b/ui/src/demo/DemoTerminalStub.tsx
@@ -7,15 +7,31 @@ interface DemoTerminalStubProps {
 export function DemoTerminalStub({ label }: DemoTerminalStubProps): ReactElement {
   return (
     <div className="flex h-full w-full items-center justify-center bg-zinc-950 p-8 text-zinc-400">
-      <div className="max-w-md text-center">
-        <div className="mb-2 font-mono text-xs uppercase tracking-wider text-zinc-500">
+      <div className="max-w-md text-left space-y-3">
+        <div className="font-mono text-[11px] uppercase tracking-wider text-zinc-500">
           {label}
         </div>
-        <div className="text-sm">
-          <span className="font-semibold text-zinc-300">Demo mode — terminal disabled.</span>
+        <div className="text-base font-semibold text-zinc-200">
+          Agent terminal
         </div>
-        <div className="mt-2 text-xs text-zinc-500">
-          The PTY backend isn&apos;t wired up in demo mode. Run a real Alice instance to use this terminal.
+        <div className="text-sm leading-relaxed text-zinc-400">
+          In a real OpenAlice install, this pane is a live PTY running{' '}
+          <span className="text-zinc-300">Claude Code</span>,{' '}
+          <span className="text-zinc-300">Codex</span>, or{' '}
+          <span className="text-zinc-300">shell</span> — the AI agent drives it directly: reads files, runs commands, reports back.
+        </div>
+        <div className="text-xs text-zinc-500">
+          Demo mode shows the workspace structure without a live process.
+        </div>
+        <div className="pt-2">
+          <a
+            href="https://github.com/TraderAlice/OpenAlice"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-xs font-medium text-amber-400 hover:underline"
+          >
+            Install OpenAlice locally →
+          </a>
         </div>
       </div>
     </div>

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -63,5 +63,9 @@ export default defineConfig({
     // and eliminates the "rm -rf dist → dist/ui never rebuilds" footgun.
     outDir: 'dist',
     emptyOutDir: true,
+    // ES2022 unlocks top-level await — used in main.tsx for the demo-mode
+    // dynamic import. All evergreen browsers (Chrome 89+, Safari 15+,
+    // Firefox 89+) support it; we have no legacy IE/old-Edge constraint.
+    target: 'es2022',
   },
 })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm -F open-alice-ui build:demo",
+  "outputDirectory": "ui/dist",
+  "installCommand": "pnpm install --frozen-lockfile --filter='!@traderalice/desktop'",
+  "framework": null,
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary

First PR in the Stage 2 series (demo mode → marketing-grade). Lands the **Vercel deployment surface** + the **visual signal** that "this is a demo, not the real product". The richer pieces (PTY replay, flagship scenario, fixture depth) come in PR-2 / PR-3 / PR-4.

After this merges, you can wire the repo into Vercel and deploy directly — no per-platform tweaks needed.

## What changed

### Vercel wiring

`vercel.json` at repo root:
- `buildCommand: pnpm -F open-alice-ui build:demo`
- `installCommand: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'` (skips Electron, ~1G saved)
- `outputDirectory: ui/dist`
- SPA rewrites: any unmatched route → `/index.html` (BrowserRouter hard-refresh works)

### Demo banner

`ui/src/demo/DemoBanner.tsx` — sticky amber top bar shown ONLY in demo mode:

> 🟠 **DEMO** · You're looking at a snapshot of OpenAlice with recorded data. Mutations don't persist; the agent terminal is replayed. · **Install →**

Mounted in `App.tsx` next to the existing `UpdateBanner`, gated by `import.meta.env.VITE_DEMO_MODE` so production builds tree-shake it out. Persistent (no dismiss) — it's the "this is a demo, not real" signal.

### Terminal stub polish

Replaces Stage 1's minimal "terminal disabled" message with product-tone copy:

> **Agent terminal**
>
> In a real OpenAlice install, this pane is a live PTY running **Claude Code**, **Codex**, or **shell** — the AI agent drives it directly: reads files, runs commands, reports back.
>
> Demo mode shows the workspace structure without a live process.
>
> [Install OpenAlice locally →]

### Vite target bump

`build.target: 'es2022'` — unlocks top-level await (main.tsx's conditional demo-mode dynamic import). All evergreen browsers Chrome 89+ / Safari 15+ / Firefox 89+ support it; no legacy constraint.

## Architecture notes (why client-side MSW on Vercel)

Vercel is hybrid (Functions / Edge), not static-only. We could run server code. We don't — by design:

- Same bundle runs `dev:demo` locally and on Vercel ⇒ deployment ≡ dev
- Host-portable: swap to Netlify / Cloudflare Pages / a CDN bucket with zero migration
- Demo data is mocked anyway; Vercel Functions would just be a worse MSW

**The principle is permanent**: OpenAlice never proxies LLM calls. Workspace agents spawn local `claude` / `codex` CLI processes using the user's own login. There is no "Stage 3 unlock" where demo gets a live LLM Function — that path is structurally closed (broker-credentials-style BYO is the moat).

## Verification

| Check | Result |
|---|---|
| `pnpm -F open-alice-ui exec tsc -b` | clean |
| `pnpm -F open-alice-ui build` (no demo flag) — bundle audit | 0 `msw` / `VITE_DEMO_MODE` / `DemoBanner` / `DemoTerminalStub` refs in `dist/assets/*.js` |
| `pnpm -F open-alice-ui build:demo` | produces 277KB demo chunk + 2.82MB main, dynamic-imported under `VITE_DEMO_MODE` |
| `pnpm install --frozen-lockfile --filter='!@traderalice/desktop'` (Vercel installCommand) | runs clean, ~750M install |
| `pnpm -F open-alice-ui preview --port 5180` + Playwright deep-link to `/workspaces/demo-ws/s/demo-session` | 0 console errors, SPA routing works, banner + terminal stub render |

## Test plan

- [x] `npx tsc -b` clean in ui/
- [x] Prod bundle has zero demo refs
- [x] Demo bundle builds, dynamic-import structure preserved
- [x] Vite preview deep-link works (= SPA rewrite story works)
- [x] Banner + stub render correctly in browser
- [ ] Manual: deploy to Vercel and confirm preview URL works end-to-end (deferred to user; this PR just makes it deployable)

## What's next (deferred to subsequent Stage 2 PRs)

- **PR-2** — `DemoTerminalReplay` + browser-side recording tool + first real transcript
- **PR-3** — Scripted SSE timelines + Inbox flagship report fixture + cross-references
- **PR-4** — Secondary fixture depth (multi-UTA, equity curves, news, cron, topology)

## Boundary touch

None — no trading / auth / broker / migrations code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)