### PR TITLE
feat(demo): Stage 2 PR-2 — PTY transcript replay + recorder tool

### DIFF
--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -12,7 +12,7 @@ import {
   type ClientControlMessage,
 } from './protocol';
 import { darkTheme } from './theme';
-import { DemoTerminalStub } from '../../demo/DemoTerminalStub';
+import { DemoTerminalReplay } from '../../demo/DemoTerminalReplay';
 
 type Status = 'connecting' | 'connected' | 'closed' | 'error' | 'kicked';
 
@@ -67,7 +67,7 @@ export interface TerminalViewProps {
 }
 
 export function TerminalView(props: TerminalViewProps): ReactElement {
-  if (import.meta.env.VITE_DEMO_MODE) return <DemoTerminalStub label={props.label ?? props.wsId} />;
+  if (import.meta.env.VITE_DEMO_MODE) return <DemoTerminalReplay label={props.label ?? props.wsId} wsId={props.wsId} sessionId={props.sessionId} />;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [status, setStatus] = useState<Status>('connecting');
   const [pid, setPid] = useState<number | null>(null);

--- a/ui/src/demo/DemoTerminalReplay.tsx
+++ b/ui/src/demo/DemoTerminalReplay.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
+
+import { FitAddon } from '@xterm/addon-fit'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import { WebglAddon } from '@xterm/addon-webgl'
+import { Terminal as Xterm } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
+
+import { darkTheme } from '../components/workspace/theme'
+import { DemoTerminalStub } from './DemoTerminalStub'
+import { transcriptsByWorkspace } from './fixtures/transcripts'
+import type { Transcript } from './types'
+
+interface DemoTerminalReplayProps {
+  readonly label: string
+  readonly wsId: string
+  readonly sessionId: string
+}
+
+export function DemoTerminalReplay(props: DemoTerminalReplayProps): ReactElement {
+  const transcript = transcriptsByWorkspace[props.wsId]
+  if (!transcript) return <DemoTerminalStub label={props.label} />
+  return <ReplayPane key={props.sessionId} label={props.label} transcript={transcript} />
+}
+
+function ReplayPane({ label, transcript }: { label: string; transcript: Transcript }): ReactElement {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [done, setDone] = useState(false)
+  const [replayKey, setReplayKey] = useState(0)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const term = new Xterm({
+      theme: darkTheme,
+      fontFamily:
+        'ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", "DejaVu Sans Mono", monospace',
+      fontSize: 13,
+      lineHeight: 1.2,
+      cursorBlink: true,
+      allowProposedApi: true,
+      scrollback: 10_000,
+      disableStdin: true,
+      convertEol: false,
+    })
+
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.loadAddon(new WebLinksAddon())
+    term.open(container)
+
+    // Defer everything until xterm's renderer has actually mounted and
+    // computed dimensions. Calling fit() or term.write() in the same frame
+    // as term.open() triggers a "Cannot read properties of undefined
+    // (reading 'dimensions')" race inside Viewport.syncScrollArea.
+    let webgl: WebglAddon | null = null
+    let resizeObserver: ResizeObserver | null = null
+    let frameIdx = 0
+    let startTime = 0
+    let rafId = 0
+    let disposed = false
+    const speed = transcript.defaultSpeed ?? 1.0
+
+    const tick = (now: number) => {
+      if (disposed) return
+      if (startTime === 0) startTime = now
+      const elapsed = (now - startTime) * speed
+      while (frameIdx < transcript.frames.length && transcript.frames[frameIdx].atMs <= elapsed) {
+        term.write(b64ToBytes(transcript.frames[frameIdx].bytesB64))
+        frameIdx++
+      }
+      if (frameIdx < transcript.frames.length) {
+        rafId = requestAnimationFrame(tick)
+      } else {
+        setDone(true)
+      }
+    }
+
+    // Poll until the container has real dimensions before fitting + writing.
+    // ResizeObserver alone isn't sufficient: the flex/grid parent can resolve
+    // its size in a later layout pass than the first RAF, and starting writes
+    // into a 0-cell terminal leaves it stuck at default 80×24 and wrapping
+    // weirdly. Bound the poll so we never hang.
+    let pollTries = 0
+    const initId = window.setTimeout(function init() {
+      if (disposed) return
+      const width = container.clientWidth
+      const height = container.clientHeight
+      if ((width < 50 || height < 30) && pollTries < 40) {
+        pollTries++
+        window.setTimeout(init, 25)
+        return
+      }
+      try {
+        webgl = new WebglAddon()
+        term.loadAddon(webgl)
+      } catch {
+        // WebGL addon is best-effort; fall back to DOM renderer silently.
+      }
+      try { fit.fit() } catch { /* noop */ }
+      resizeObserver = new ResizeObserver(() => {
+        try { fit.fit() } catch { /* noop */ }
+      })
+      resizeObserver.observe(container)
+      rafId = requestAnimationFrame(tick)
+    }, 0)
+
+    return () => {
+      disposed = true
+      window.clearTimeout(initId)
+      cancelAnimationFrame(rafId)
+      resizeObserver?.disconnect()
+      webgl?.dispose()
+      term.dispose()
+    }
+  }, [transcript, replayKey])
+
+  return (
+    <div className="terminal-shell">
+      <header className="terminal-header">
+        <span className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-amber-400">
+          <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+          Replay
+        </span>
+        <span className="text-[11px] text-text-muted truncate">{label}</span>
+        <span className="flex-1" />
+        {done && (
+          <button
+            type="button"
+            onClick={() => setReplayKey((k) => k + 1)}
+            className="text-[11px] text-amber-400 hover:underline"
+          >
+            ↻ Replay again
+          </button>
+        )}
+      </header>
+      <div ref={containerRef} className="terminal-host" />
+    </div>
+  )
+}
+
+function b64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}

--- a/ui/src/demo/fixtures/transcripts/index.ts
+++ b/ui/src/demo/fixtures/transcripts/index.ts
@@ -1,0 +1,15 @@
+import type { Transcript } from '../../types'
+import { DEMO_WORKSPACE_ID } from '../workspaces'
+import { welcomeTranscript } from './welcome'
+
+/**
+ * Map workspace id → transcript. When the demo terminal renders for a
+ * given session, it looks up the workspace and plays the matching
+ * transcript if registered. No entry → falls back to DemoTerminalStub.
+ *
+ * Stage 2 ships exactly one hand-crafted placeholder. PR-3 wires in a
+ * real recorded session.
+ */
+export const transcriptsByWorkspace: Record<string, Transcript> = {
+  [DEMO_WORKSPACE_ID]: welcomeTranscript,
+}

--- a/ui/src/demo/fixtures/transcripts/welcome.ts
+++ b/ui/src/demo/fixtures/transcripts/welcome.ts
@@ -1,0 +1,73 @@
+import type { Transcript, TranscriptFrame } from '../../types'
+
+// Hand-crafted placeholder transcript. Replace with a real recorded session
+// (see ui/src/demo/recorder/README.md) when one is captured.
+
+const enc = new TextEncoder()
+function b64(s: string): string {
+  const bytes = enc.encode(s)
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin)
+}
+
+const frames: TranscriptFrame[] = []
+let cursor = 0
+
+function add(deltaMs: number, text: string): void {
+  cursor += deltaMs
+  frames.push({ atMs: cursor, bytesB64: b64(text) })
+}
+
+function typeOut(text: string, perCharMs = 35): void {
+  for (const ch of text) add(perCharMs, ch)
+}
+
+// Banner
+add(0, '\x1b[2J\x1b[H')
+add(80, '\x1b[1;36m╭───────────────────────────────╮\x1b[0m\r\n')
+add(40, '\x1b[1;36m│\x1b[0m  \x1b[1mClaude Code\x1b[0m \x1b[2m· workspace demo\x1b[0m  \x1b[1;36m│\x1b[0m\r\n')
+add(40, '\x1b[1;36m╰───────────────────────────────╯\x1b[0m\r\n')
+add(600, '\r\n')
+add(0, "Hi! I'm Claude. Ask me anything about this workspace.\r\n\r\n")
+
+// User prompt
+add(1200, '\x1b[1;32m❯\x1b[0m ')
+add(700, '')
+typeOut('what does this project do?')
+add(400, '\r\n\r\n')
+
+// Tool calls
+add(500, '\x1b[2m⏵ Reading\x1b[0m \x1b[36mREADME.md\x1b[0m\r\n')
+add(900, '\x1b[2m⏵ Reading\x1b[0m \x1b[36mCLAUDE.md\x1b[0m\r\n')
+add(1100, '\x1b[2m⏵ Listing\x1b[0m \x1b[36msrc/\x1b[0m\r\n')
+add(800, '\r\n')
+
+// Response — chunked to feel like streaming
+add(600, 'OpenAlice is a \x1b[1mfile-driven AI trading agent\x1b[0m. The architecture\r\n')
+add(60, 'splits into two long-running processes supervised by Guardian:\r\n\r\n')
+add(400, '  \x1b[36m•\x1b[0m \x1b[1mAlice\x1b[0m — the agent runtime: provider routing, workspaces,\r\n')
+add(40, '    tool center, listeners. Lives in \x1b[2msrc/\x1b[0m.\r\n')
+add(200, '  \x1b[36m•\x1b[0m \x1b[1mUTA\x1b[0m — broker connections + git-like trade approval\r\n')
+add(40, '    state. Isolated for credential safety. Lives in\r\n')
+add(40, '    \x1b[2mservices/uta/\x1b[0m.\r\n\r\n')
+
+add(700, 'They communicate over HTTP via a typed protocol\r\n')
+add(40, '(\x1b[2m@traderalice/uta-protocol\x1b[0m). The split means broker\r\n')
+add(40, "credentials never enter the agent process.\r\n\r\n")
+
+add(800, "You're looking at a \x1b[1mWorkspace\x1b[0m right now — Alice's\r\n")
+add(40, 'capability extension surface. Each workspace spawns a\r\n')
+add(40, 'native CLI agent (\x1b[36mclaude\x1b[0m, \x1b[36mcodex\x1b[0m, or \x1b[36mshell\x1b[0m) in an isolated\r\n')
+add(40, "PTY. New capabilities ship as templates, not core code.\r\n\r\n")
+
+add(1000, '\x1b[2mWhat would you like to dig into?\x1b[0m\r\n\r\n')
+add(400, '\x1b[1;32m❯\x1b[0m ')
+add(400, '\x1b[5m▁\x1b[0m') // blinking underscore
+
+export const welcomeTranscript: Transcript = {
+  label: 'Workspace intro',
+  durationMs: cursor + 500,
+  defaultSpeed: 1.0,
+  frames,
+}

--- a/ui/src/demo/recorder/README.md
+++ b/ui/src/demo/recorder/README.md
@@ -1,0 +1,60 @@
+# Recording a real PTY transcript
+
+The demo terminal can replay a recorded session if a matching transcript
+fixture is registered. To capture one from your live dev environment:
+
+## Steps
+
+1. Run the full app (NOT demo mode):
+   ```bash
+   pnpm dev
+   ```
+2. Open the UI at `http://localhost:5173/`. In the browser DevTools console:
+   ```js
+   __demoRecord.start()
+   ```
+3. Create a workspace and open a terminal session as normal. Interact —
+   type commands, let Claude / Codex / shell respond, do whatever you want
+   the demo viewer to see.
+4. When you're done, stop and download:
+   ```js
+   __demoRecord.stop('claude-research-may-2026')   // any label
+   ```
+   Browser downloads `transcript-claude-research-may-2026-<ts>.json`.
+5. Move the JSON into `ui/src/demo/fixtures/transcripts/` and register it
+   in `index.ts`:
+   ```ts
+   import claudeResearch from './claude-research-may-2026.json'
+   export const transcriptsByWorkspace: Record<string, Transcript> = {
+     [DEMO_WORKSPACE_ID]: claudeResearch as Transcript,
+   }
+   ```
+6. Switch to demo mode (`pnpm -F open-alice-ui dev:demo`) and verify the
+   transcript plays back.
+
+## Format
+
+```ts
+{
+  label: string,
+  durationMs: number,
+  frames: [{ atMs: number, bytesB64: string }, ...]
+}
+```
+
+`bytesB64` is base64-encoded raw PTY output bytes — what the server sent
+down the WebSocket. The replay player decodes and feeds them straight to
+xterm.js via `term.write(uint8array)`. ANSI escapes, cursor moves, and
+colors all replay faithfully because they're already in the bytes.
+
+## Caveats
+
+- The recorder only listens to server → client frames. Your typed input
+  isn't recorded — that's fine for replay (the terminal shows what the
+  user sees, not their keystrokes).
+- Don't record sessions that contain secrets — the transcript ships as a
+  static asset in the demo bundle. Sanity-check the JSON before
+  committing.
+- The recorder monkey-patches `window.WebSocket` while active. It only
+  taps URLs matching `/api/workspaces/pty`; other WebSocket connections
+  (none today, but future-proofing) are passed through unchanged.

--- a/ui/src/demo/recorder/index.ts
+++ b/ui/src/demo/recorder/index.ts
@@ -1,0 +1,3 @@
+// Side-effect import: attaches window.__demoRecord. Only loaded in
+// regular dev mode (NOT demo mode) — see main.tsx.
+import './recorder'

--- a/ui/src/demo/recorder/recorder.ts
+++ b/ui/src/demo/recorder/recorder.ts
@@ -1,0 +1,107 @@
+import type { Transcript, TranscriptFrame } from '../types'
+
+const PTY_URL_PATTERN = /\/api\/workspaces\/pty(\?|$)/
+const STORAGE_HINT = '__demoRecord'
+
+let active = false
+let originalWS: typeof WebSocket | null = null
+let frames: TranscriptFrame[] = []
+let startTs = 0
+
+function bytesToB64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+  return btoa(binary)
+}
+
+export function startRecording(): void {
+  if (active) {
+    console.warn('[recorder] already active — call __demoRecord.stop() first')
+    return
+  }
+  originalWS = window.WebSocket
+  frames = []
+  startTs = Date.now()
+
+  // Constructor proxy: tap only PTY connections, pass others through unchanged.
+  const Recorder = function (
+    this: WebSocket,
+    url: string | URL,
+    protocols?: string | string[],
+  ): WebSocket {
+    const ws = new originalWS!(url, protocols)
+    if (PTY_URL_PATTERN.test(String(url))) {
+      ws.addEventListener('message', (ev: MessageEvent) => {
+        if (ev.data instanceof ArrayBuffer) {
+          frames.push({ atMs: Date.now() - startTs, bytesB64: bytesToB64(ev.data) })
+        } else if (ev.data instanceof Blob) {
+          ev.data.arrayBuffer().then((buf) => {
+            frames.push({ atMs: Date.now() - startTs, bytesB64: bytesToB64(buf) })
+          })
+        }
+      })
+    }
+    return ws
+  } as unknown as typeof WebSocket
+
+  // Copy static fields so callers that do `WebSocket.OPEN` etc. still work.
+  Recorder.prototype = originalWS.prototype
+  Object.assign(Recorder, {
+    CONNECTING: originalWS.CONNECTING,
+    OPEN: originalWS.OPEN,
+    CLOSING: originalWS.CLOSING,
+    CLOSED: originalWS.CLOSED,
+  })
+
+  window.WebSocket = Recorder
+  active = true
+  console.info('[recorder] PTY recording started — interact with the terminal, then call __demoRecord.stop(label)')
+}
+
+export function stopRecording(label = 'recorded'): Transcript | null {
+  if (!active) {
+    console.warn('[recorder] not active')
+    return null
+  }
+  if (originalWS) window.WebSocket = originalWS
+  active = false
+
+  const transcript: Transcript = {
+    label,
+    durationMs: frames.length > 0 ? frames[frames.length - 1].atMs + 500 : 0,
+    frames,
+  }
+
+  // Trigger download
+  const blob = new Blob([JSON.stringify(transcript, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `transcript-${slug(label)}-${Date.now()}.json`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+
+  console.info(`[recorder] stopped · ${frames.length} frames · ${transcript.durationMs}ms · downloaded`)
+  return transcript
+}
+
+function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'recording'
+}
+
+// Auto-attach to window for dev-console use. Only loaded in dev mode by main.tsx,
+// so this side effect is invisible to demo / prod builds.
+declare global {
+  interface Window {
+    [STORAGE_HINT]?: {
+      start: typeof startRecording
+      stop: typeof stopRecording
+    }
+  }
+}
+
+window.__demoRecord = { start: startRecording, stop: stopRecording }
+console.info('[recorder] ready · run __demoRecord.start() in console before opening a terminal')

--- a/ui/src/demo/types.ts
+++ b/ui/src/demo/types.ts
@@ -1,0 +1,17 @@
+export interface TranscriptFrame {
+  /** Milliseconds since the start of the recording. */
+  readonly atMs: number
+  /** Base64-encoded PTY bytes (what the server sent down the WebSocket). */
+  readonly bytesB64: string
+}
+
+export interface Transcript {
+  /** Human-readable label shown in the demo terminal header. */
+  readonly label: string
+  /** Total duration in ms — `frames[last].atMs + tail`. */
+  readonly durationMs: number
+  /** Replay speed hint (1.0 = real time). Player may override. */
+  readonly defaultSpeed?: number
+  /** Frame sequence in ascending atMs order. */
+  readonly frames: readonly TranscriptFrame[]
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -9,6 +9,10 @@ import './index.css'
 
 if (import.meta.env.VITE_DEMO_MODE) {
   await (await import('./demo')).startWorker()
+} else if (import.meta.env.DEV) {
+  // Dev-only: expose window.__demoRecord for capturing real PTY transcripts.
+  // See ui/src/demo/recorder/README.md.
+  await import('./demo/recorder')
 }
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary

The demo terminal now **plays back a recorded PTY transcript** through xterm.js instead of showing a static "terminal disabled" stub. Workspaces without a registered transcript still fall back to the stub from PR-1.

Stacks on top of PR #221 (Vercel + skeleton).

## What changed

### Transcript format

```ts
// ui/src/demo/types.ts
interface Transcript {
  label: string
  durationMs: number
  defaultSpeed?: number          // 1.0 = real-time
  frames: readonly TranscriptFrame[]
}
interface TranscriptFrame {
  atMs: number                   // milliseconds since start
  bytesB64: string               // base64-encoded raw PTY bytes
}
```

`bytesB64` is the raw bytes the PTY WebSocket sent down. ANSI escapes, cursor positioning, colors all replay 1:1 because they ride along inside the bytes — no re-parsing needed.

### Replay component

`ui/src/demo/DemoTerminalReplay.tsx` — instantiated by `Terminal.tsx` when `VITE_DEMO_MODE` is on. Looks up a transcript by `wsId`; renders the stub from PR-1 if none registered. For sessions WITH a transcript:

- Spins up xterm with the same theme + addons (FitAddon, WebLinks, WebGL) as the real Terminal
- **Polls the container until it has real dimensions** before fitting + writing — fixes an xterm "Cannot read properties of undefined (reading 'dimensions')" race in `Viewport.syncScrollArea` that fires when fit() or term.write() runs before the renderer is fully laid out, AND avoids the "default 80×24 stuck at narrow width" failure mode where writes go to a 0-cell terminal
- Schedules `term.write` at recorded timestamps via `requestAnimationFrame`
- End of transcript → ↻ Replay again button

### Recorder tool

`ui/src/demo/recorder/recorder.ts` — dev-mode helper that monkey-patches `window.WebSocket` to tap PTY frames. Usage:

```js
// In browser DevTools console while running `pnpm dev` (NOT demo mode):
__demoRecord.start()
// interact with terminal as normal
__demoRecord.stop('claude-research-may-2026')
// browser downloads transcript-claude-research-may-2026-<ts>.json
```

`main.tsx` auto-loads it in dev (not demo, not prod) so the recorder is always available alongside the real backend. URLs not matching `/api/workspaces/pty` pass through unchanged — limited blast radius.

See `ui/src/demo/recorder/README.md` for the full record-and-register flow.

### Placeholder transcript

`ui/src/demo/fixtures/transcripts/welcome.ts` — hand-crafted Claude-Code-style intro: banner, typed user query, tool calls, multi-paragraph response describing OpenAlice's architecture. **Placeholder only** — PR-3 swaps this out for a real recorded session captured via the recorder tool.

Registered in `fixtures/transcripts/index.ts` keyed to `DEMO_WORKSPACE_ID`. Adding more workspaces with their own transcripts is a one-line addition there.

## Verification

| Check | Result |
|---|---|
| `pnpm -F open-alice-ui exec tsc -b` | clean |
| `pnpm -F open-alice-ui build:demo` | 277KB demo chunk + 2.83MB main, no console warnings beyond pre-existing chunk-size info |
| `pnpm -F open-alice-ui build` (prod) | zero `__demoRecord` / `DemoTerminalReplay` / `transcriptsByWorkspace` / `welcomeTranscript` / `startRecording` / `stopRecording` / `VITE_DEMO_MODE` refs in dist (the single `recorder` substring match is an unrelated `audio_get_recorder_count` string inside a transitive dep) |
| `pnpm dev:demo` + Playwright | transcript plays end-to-end, ANSI colors + bold + dim render correctly, line wrapping respects container width, "Replay again" button restarts cleanly |

Screenshot at end of replay attached in the PR thread (final-frame state shows the agent's full response with proper tool-call formatting and bullet styling).

## Test plan

- [x] tsc -b clean
- [x] Build prod (no demo flag) — zero demo refs in dist
- [x] Build demo + Playwright smoke
- [x] Replay completes; ↻ button works
- [ ] Manual: user runs `pnpm dev`, exercises `__demoRecord.start()` / `stop()` on a real terminal session, replaces `welcome.ts` placeholder with the real transcript (= PR-3's job to land)

## Out of scope (deferred)

- The real recorded transcript (PR-3 captures it once the user runs a flagship session)
- Multiple transcripts per workspace, transcript selection UI (Stage 3 if ever)
- Speed controls / scrubber (current replay is auto-play, fixed real-time)

## Boundary touch

None — no trading / auth / broker / migrations code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)