### PR TITLE
feat(ai-providers): Bearer auth for Anthropic-compatible gateways (MiniMax intl)

### DIFF
--- a/src/ai-providers/agent-sdk/agent-sdk-provider.ts
+++ b/src/ai-providers/agent-sdk/agent-sdk-provider.ts
@@ -16,6 +16,7 @@ import type { AgentSdkConfig, AgentSdkOverride } from './query.js'
 import { toTextHistory } from '../../core/session.js'
 import { buildChatHistoryPrompt, DEFAULT_MAX_HISTORY } from '../utils.js'
 import { readAgentConfig, resolveProfile, type ResolvedProfile } from '../../core/config.js'
+import { resolveAnthropicAuthMode } from '../../core/credential-inference.js'
 import { createChannel } from '../../core/async-channel.js'
 import { askAgentSdk } from './query.js'
 import { buildAgentSdkMcpServer } from './tool-bridge.js'
@@ -51,6 +52,7 @@ export class AgentSdkProvider implements AIProvider {
     const override: AgentSdkOverride = {
       model: effectiveProfile.model, apiKey: effectiveProfile.apiKey, baseUrl: effectiveProfile.baseUrl,
       loginMethod: effectiveProfile.loginMethod as 'api-key' | 'claudeai' | undefined,
+      authMode: resolveAnthropicAuthMode(effectiveProfile),
     }
     const mcpServer = await this.buildMcpServer()
     const result = await askAgentSdk(prompt, config, override, mcpServer)
@@ -75,7 +77,7 @@ export class AgentSdkProvider implements AIProvider {
     // Build override from resolved profile
     const profile = opts?.profile
     const override: AgentSdkOverride | undefined = profile
-      ? { model: profile.model, apiKey: profile.apiKey, baseUrl: profile.baseUrl, loginMethod: profile.loginMethod as 'api-key' | 'claudeai' | undefined }
+      ? { model: profile.model, apiKey: profile.apiKey, baseUrl: profile.baseUrl, loginMethod: profile.loginMethod as 'api-key' | 'claudeai' | undefined, authMode: resolveAnthropicAuthMode(profile) }
       : undefined
     const mcpServer = await this.buildMcpServer(opts?.disabledTools)
 

--- a/src/ai-providers/agent-sdk/query.spec.ts
+++ b/src/ai-providers/agent-sdk/query.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { buildAuthEnv } from './query.js'
+
+describe('buildAuthEnv', () => {
+  it('x-api-key mode (default): sets ANTHROPIC_API_KEY, clears AUTH_TOKEN', () => {
+    const env = buildAuthEnv({}, { apiKey: 'sk-x', loginMethod: 'api-key' })
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-x')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+    expect(env.CLAUDE_CODE_SIMPLE).toBe('1')
+  })
+
+  it('absent authMode behaves as x-api-key', () => {
+    const env = buildAuthEnv({}, { apiKey: 'sk-x' })
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-x')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+  })
+
+  it('bearer mode: sets ANTHROPIC_AUTH_TOKEN, clears API_KEY', () => {
+    const env = buildAuthEnv({}, { apiKey: 'sk-mm', authMode: 'bearer', loginMethod: 'api-key' })
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('sk-mm')
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(env.CLAUDE_CODE_SIMPLE).toBe('1')
+  })
+
+  it('never sets BOTH key vars — bearer clears an inherited API_KEY', () => {
+    const env = buildAuthEnv(
+      { ANTHROPIC_API_KEY: 'stale-inherited' },
+      { apiKey: 'sk-mm', authMode: 'bearer' },
+    )
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('sk-mm')
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+  })
+
+  it('never sets BOTH key vars — x-api-key clears an inherited AUTH_TOKEN', () => {
+    const env = buildAuthEnv(
+      { ANTHROPIC_AUTH_TOKEN: 'stale-inherited' },
+      { apiKey: 'sk-x', authMode: 'x-api-key' },
+    )
+    expect(env.ANTHROPIC_API_KEY).toBe('sk-x')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+  })
+
+  it('OAuth mode (claudeai): strips both API_KEY and CLAUDE_CODE_SIMPLE, ignores authMode', () => {
+    const env = buildAuthEnv(
+      { ANTHROPIC_API_KEY: 'inherited', CLAUDE_CODE_SIMPLE: '1' },
+      { loginMethod: 'claudeai', apiKey: 'ignored', authMode: 'bearer' },
+    )
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+    expect(env.CLAUDE_CODE_SIMPLE).toBeUndefined()
+  })
+
+  it('preserves unrelated env vars', () => {
+    const env = buildAuthEnv({ PATH: '/usr/bin', HOME: '/home/u' }, { apiKey: 'sk-x' })
+    expect(env.PATH).toBe('/usr/bin')
+    expect(env.HOME).toBe('/home/u')
+  })
+
+  it('no apiKey in api-key mode: leaves key vars unset but still forces CLAUDE_CODE_SIMPLE', () => {
+    const env = buildAuthEnv({}, { loginMethod: 'api-key' })
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+    expect(env.CLAUDE_CODE_SIMPLE).toBe('1')
+  })
+})

--- a/src/ai-providers/agent-sdk/query.ts
+++ b/src/ai-providers/agent-sdk/query.ts
@@ -40,6 +40,14 @@ export interface AgentSdkOverride {
   apiKey?: string
   baseUrl?: string
   loginMethod?: 'api-key' | 'claudeai'
+  /**
+   * api-key mode only: which env var carries the key, and thus which header
+   * the spawned CLI sends. `bearer` → ANTHROPIC_AUTH_TOKEN (Authorization:
+   * Bearer), for anthropic-compatible gateways like MiniMax international.
+   * Default/absent → ANTHROPIC_API_KEY (x-api-key). Ignored under claudeai
+   * (OAuth) login. Mirrors the workspace .claude/settings.local.json writer.
+   */
+  authMode?: 'x-api-key' | 'bearer'
 }
 
 export interface AgentSdkMessage {
@@ -51,6 +59,54 @@ export interface AgentSdkResult {
   text: string
   ok: boolean
   messages: AgentSdkMessage[]
+}
+
+// ==================== Auth env construction ====================
+
+/**
+ * Build the env block handed to the spawned Claude Code CLI, applying the
+ * profile's auth choice. Pure + exported so the auth invariant is unit-tested
+ * without spawning a subprocess.
+ *
+ * Invariants:
+ * - OAuth (loginMethod=claudeai): strip ANTHROPIC_API_KEY + CLAUDE_CODE_SIMPLE
+ *   so the CLI uses the local `claude login` session, not an inherited key.
+ * - api-key + bearer: set ANTHROPIC_AUTH_TOKEN (CLI sends `Authorization:
+ *   Bearer`), clear ANTHROPIC_API_KEY. This is MiniMax's documented setup and
+ *   what api.minimax.io requires.
+ * - api-key + x-api-key (default): set ANTHROPIC_API_KEY, clear
+ *   ANTHROPIC_AUTH_TOKEN.
+ * - api-key mode never leaves BOTH key vars set — Claude Code warns on
+ *   dual-set and gateways can reject ambiguous auth. We always clear the
+ *   counterpart so a stale inherited process.env value can't leak the wrong
+ *   header.
+ */
+export function buildAuthEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  override?: AgentSdkOverride,
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...baseEnv }
+  const isOAuthMode = (override?.loginMethod ?? 'api-key') === 'claudeai'
+
+  if (isOAuthMode) {
+    delete env.ANTHROPIC_API_KEY
+    delete env.CLAUDE_CODE_SIMPLE
+    return env
+  }
+
+  const apiKey = override?.apiKey
+  if (apiKey) {
+    if (override?.authMode === 'bearer') {
+      env.ANTHROPIC_AUTH_TOKEN = apiKey
+      delete env.ANTHROPIC_API_KEY
+    } else {
+      env.ANTHROPIC_API_KEY = apiKey
+      delete env.ANTHROPIC_AUTH_TOKEN
+    }
+  }
+  // Force API key mode — disable OAuth even if a local login exists.
+  env.CLAUDE_CODE_SIMPLE = '1'
+  return env
 }
 
 // ==================== Tool lists ====================
@@ -148,22 +204,9 @@ export async function askAgentSdk(
   const finalDisallowed = [...disallowedTools, ...modeDisallowed]
 
   // Build env with authentication — override carries resolved profile values
+  const env = buildAuthEnv(process.env, override)
   const loginMethod = override?.loginMethod ?? 'api-key'
-  const isOAuthMode = loginMethod === 'claudeai'
-
-  const env: Record<string, string | undefined> = { ...process.env }
-  if (isOAuthMode) {
-    // Force OAuth by removing any inherited API key
-    delete env.ANTHROPIC_API_KEY
-    delete env.CLAUDE_CODE_SIMPLE
-  } else {
-    const apiKey = override?.apiKey
-    if (apiKey) env.ANTHROPIC_API_KEY = apiKey
-    // Force API key mode — disable OAuth even if local login exists
-    env.CLAUDE_CODE_SIMPLE = '1'
-  }
   const baseUrl = override?.baseUrl
-  if (baseUrl) env.ANTHROPIC_BASE_URL = baseUrl
 
   // Opt-in debug: set ALICE_SDK_DEBUG=1 to turn on the SDK's verbose stderr
   // + capture every child-process stderr chunk into logs/agent-sdk-debug.log.

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -199,11 +199,16 @@ export const MINIMAX: PresetDef = {
   description: 'MiniMax models via Claude Agent SDK (Anthropic-compatible)',
   category: 'third-party',
   defaultName: 'MiniMax',
-  hint: 'China console: minimaxi.com — International console: minimax.io. API keys are region-locked.',
+  hint: 'China console: minimaxi.com — International console: minimax.io. API keys are region-locked. MiniMax authenticates via Authorization: Bearer; the international endpoint (api.minimax.io) rejects x-api-key.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
     baseUrl: z.string().default('https://api.minimaxi.com/anthropic').describe('API endpoint'),
+    // MiniMax's documented integration uses Authorization: Bearer for every
+    // endpoint, and the international site (api.minimax.io) only accepts
+    // Bearer. Default to it so both endpoints work without the user having to
+    // know the split. Surfaced to the per-workspace config's "Apply" path.
+    authMode: z.enum(['x-api-key', 'bearer']).default('bearer').describe('Auth header'),
     model: z.string().default('MiniMax-M2.7').describe('Model'),
     apiKey: z.string().min(1).describe('MiniMax API key'),
   }),

--- a/src/ai-providers/sdk-adapters.spec.ts
+++ b/src/ai-providers/sdk-adapters.spec.ts
@@ -174,6 +174,44 @@ describe('resolveTestAdapter (fallback)', () => {
   })
 })
 
+// ==================== resolveTestAdapter — authMode threading ====================
+
+describe('resolveTestAdapter (authMode threads onto anthropic-shape adapters)', () => {
+  const cred: Credential = { vendor: 'minimax', authType: 'api-key', apiKey: 'k', baseUrl: 'https://api.minimax.io/anthropic' }
+
+  it('explicit authMode=bearer reaches the vercel-anthropic config', () => {
+    const profile: ResolvedProfile = { backend: 'agent-sdk', model: 'm', preset: 'minimax', authMode: 'bearer' }
+    const decl = resolveTestAdapter(profile, PRESET_CATALOG)
+    expect(decl.id).toBe('vercel-anthropic')
+    expect((decl.config(cred) as { authMode?: string }).authMode).toBe('bearer')
+  })
+
+  it('inferred bearer (minimax.io baseUrl, no explicit authMode) reaches the config', () => {
+    const profile: ResolvedProfile = {
+      backend: 'agent-sdk', model: 'm', preset: 'minimax', baseUrl: 'https://api.minimax.io/anthropic',
+    }
+    const decl = resolveTestAdapter(profile, PRESET_CATALOG)
+    expect((decl.config(cred) as { authMode?: string }).authMode).toBe('bearer')
+  })
+
+  it('x-api-key default leaves authMode off the config (byte-identical to pre-change)', () => {
+    const profile: ResolvedProfile = { backend: 'agent-sdk', model: 'm', preset: 'deepseek' }
+    const decl = resolveTestAdapter(profile, PRESET_CATALOG)
+    const cfg = decl.config({ vendor: 'deepseek', authType: 'api-key', apiKey: 'k', baseUrl: 'https://api.deepseek.com/anthropic' })
+    expect('authMode' in cfg).toBe(false)
+  })
+
+  it('threads onto the agent-sdk adapter too (Claude OAuth subscription unaffected: x-api-key default)', () => {
+    const profile: ResolvedProfile = {
+      backend: 'agent-sdk', model: 'm', preset: 'custom', loginMethod: 'api-key',
+      baseUrl: 'https://api.minimax.io/anthropic',
+    }
+    const decl = resolveTestAdapter(profile, PRESET_CATALOG)
+    expect(decl.id).toBe('agent-sdk')
+    expect((decl.config(cred) as { authMode?: string }).authMode).toBe('bearer')
+  })
+})
+
 // ==================== invokeAdapter end-to-end ====================
 
 describe('invokeAdapter (vercel-* invokers wire correctly)', () => {
@@ -196,6 +234,40 @@ describe('invokeAdapter (vercel-* invokers wire correctly)', () => {
     expect(mockGenerateText).toHaveBeenCalledWith({
       model: 'anthropic-model-instance',
       prompt: 'Hi',
+    })
+  })
+
+  it('vercel-anthropic invoker sends authToken (not apiKey) in bearer mode', async () => {
+    const decl: SdkAdapterDeclaration = {
+      id: 'vercel-anthropic',
+      config: (c) => ({ apiKey: c.apiKey, baseURL: c.baseUrl, authMode: 'bearer' }),
+    }
+    const cred: Credential = { vendor: 'minimax', authType: 'api-key', apiKey: 'sk-mm', baseUrl: 'https://api.minimax.io/anthropic' }
+
+    await invokeAdapter(decl, cred, 'MiniMax-M2.7', 'Hi', { providers: {} })
+
+    const { createAnthropic } = await import('@ai-sdk/anthropic')
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: undefined,
+      authToken: 'sk-mm',
+      baseURL: 'https://api.minimax.io/anthropic',
+    })
+  })
+
+  it('vercel-anthropic invoker sends apiKey (not authToken) when authMode absent', async () => {
+    const decl: SdkAdapterDeclaration = {
+      id: 'vercel-anthropic',
+      config: (c) => ({ apiKey: c.apiKey, baseURL: c.baseUrl }),
+    }
+    const cred: Credential = { vendor: 'anthropic', authType: 'api-key', apiKey: 'sk-ant' }
+
+    await invokeAdapter(decl, cred, 'claude-opus-4-7', 'Hi', { providers: {} })
+
+    const { createAnthropic } = await import('@ai-sdk/anthropic')
+    expect(createAnthropic).toHaveBeenCalledWith({
+      apiKey: 'sk-ant',
+      authToken: undefined,
+      baseURL: undefined,
     })
   })
 

--- a/src/ai-providers/sdk-adapters.ts
+++ b/src/ai-providers/sdk-adapters.ts
@@ -24,6 +24,7 @@
 import type { Credential, ResolvedProfile } from '../core/config.js'
 import type { AIProvider, ProviderResult } from './types.js'
 import { PRESET_CATALOG } from './preset-catalog.js'
+import { resolveAnthropicAuthMode } from '../core/credential-inference.js'
 
 // ==================== Adapter ids and typed configs ====================
 
@@ -92,9 +93,9 @@ export function getSdkAdapterInfo(): SdkAdapterInfo[] {
  * standard. Don't normalize; pass through as-is.
  */
 export interface SdkConfigByAdapter {
-  'agent-sdk':        { apiKey?: string; baseUrl?: string; loginMethod: 'api-key' | 'claudeai' }
+  'agent-sdk':        { apiKey?: string; baseUrl?: string; loginMethod: 'api-key' | 'claudeai'; authMode?: 'x-api-key' | 'bearer' }
   'codex':            { apiKey?: string; baseUrl?: string; loginMethod: 'api-key' | 'codex-oauth' }
-  'vercel-anthropic': { apiKey?: string; baseURL?: string }
+  'vercel-anthropic': { apiKey?: string; baseURL?: string; authMode?: 'x-api-key' | 'bearer' }
   'vercel-openai':    { apiKey?: string; baseURL?: string }
   'vercel-google':    { apiKey?: string; baseURL?: string }
 }
@@ -130,8 +131,13 @@ export const SDK_INVOKERS: { [K in SdkAdapterId]: SdkInvoker<K> } = {
     async invoke(config, model, prompt) {
       const { createAnthropic } = await import('@ai-sdk/anthropic')
       const { generateText } = await import('ai')
+      // Bearer mode → `authToken` (Authorization: Bearer); default → `apiKey`
+      // (x-api-key). Exactly one, matching the real-session auth so the Test
+      // button can't pass-while-chat-fails (or vice versa).
+      const bearer = config.authMode === 'bearer'
       const client = createAnthropic({
-        apiKey: config.apiKey,
+        apiKey: bearer ? undefined : config.apiKey,
+        authToken: bearer ? config.apiKey : undefined,
         baseURL: config.baseURL || undefined,
       })
       const result = await generateText({ model: client(model), prompt })
@@ -175,6 +181,7 @@ export const SDK_INVOKERS: { [K in SdkAdapterId]: SdkInvoker<K> } = {
         apiKey: config.apiKey,
         baseUrl: config.baseUrl,
         loginMethod: config.loginMethod,
+        authMode: config.authMode,
       })
     },
   },
@@ -212,6 +219,18 @@ export function resolveTestAdapter(
   profile: ResolvedProfile,
   presets: Array<{ id: string; sdkAdapters?: { available: SdkAdapterDeclaration[]; test: SdkAdapterId } }>,
 ): SdkAdapterDeclaration {
+  // Anthropic-shape adapters carry an auth header mode (x-api-key vs Bearer)
+  // that lives on the profile, not the credential. Resolve it once and wrap
+  // the chosen declaration so the test request uses the same header the real
+  // session would — otherwise a MiniMax-international profile tests-green but
+  // chats-401 (or vice versa).
+  return withAuthMode(pickTestAdapter(profile, presets), resolveAnthropicAuthMode(profile))
+}
+
+function pickTestAdapter(
+  profile: ResolvedProfile,
+  presets: Array<{ id: string; sdkAdapters?: { available: SdkAdapterDeclaration[]; test: SdkAdapterId } }>,
+): SdkAdapterDeclaration {
   if (profile.preset) {
     const preset = presets.find((p) => p.id === profile.preset)
     if (preset?.sdkAdapters) {
@@ -243,6 +262,31 @@ export function resolveTestAdapter(
     return { id: 'vercel-google', config: (c) => ({ apiKey: c.apiKey, baseURL: c.baseUrl }) }
   }
   return { id: 'vercel-anthropic', config: (c) => ({ apiKey: c.apiKey, baseURL: c.baseUrl }) }
+}
+
+/**
+ * Inject Bearer mode into the two anthropic-shape adapters' config output.
+ * Only `bearer` is injected — `x-api-key` is the default and the invokers
+ * treat an absent authMode as x-api-key, so omitting it keeps the config
+ * minimal (and leaves the common first-party-Anthropic path byte-identical).
+ * Other adapters (codex / vercel-openai / vercel-google) carry no authMode
+ * and pass through untouched. The preset config builders take a Credential
+ * (which has no authMode), so this is where the profile's choice joins in.
+ */
+function withAuthMode(
+  decl: SdkAdapterDeclaration,
+  authMode: 'x-api-key' | 'bearer',
+): SdkAdapterDeclaration {
+  if (authMode !== 'bearer') return decl
+  if (decl.id === 'vercel-anthropic') {
+    const base = decl.config
+    return { id: 'vercel-anthropic', config: (c) => ({ ...base(c), authMode }) }
+  }
+  if (decl.id === 'agent-sdk') {
+    const base = decl.config
+    return { id: 'agent-sdk', config: (c) => ({ ...base(c), authMode }) }
+  }
+  return decl
 }
 
 /**

--- a/src/ai-providers/vercel-ai-sdk/model-factory.ts
+++ b/src/ai-providers/vercel-ai-sdk/model-factory.ts
@@ -6,6 +6,7 @@
 
 import type { LanguageModel } from 'ai'
 import type { ResolvedProfile } from '../../core/config.js'
+import { resolveAnthropicAuthMode } from '../../core/credential-inference.js'
 
 /** Result includes the model plus a cache key for change detection. */
 export interface ModelFromConfig {
@@ -24,7 +25,16 @@ export async function createModelFromProfile(profile: ResolvedProfile): Promise<
   switch (p) {
     case 'anthropic': {
       const { createAnthropic } = await import('@ai-sdk/anthropic')
-      const client = createAnthropic({ apiKey: apiKey || undefined, baseURL: url || undefined })
+      // @ai-sdk/anthropic sends `Authorization: Bearer` when given `authToken`,
+      // else `x-api-key` from `apiKey` — exactly one, mirroring the raw SDK and
+      // the agent-sdk env split. Bearer is required by anthropic-compatible
+      // gateways (e.g. MiniMax international); see resolveAnthropicAuthMode.
+      const bearer = resolveAnthropicAuthMode(profile) === 'bearer'
+      const client = createAnthropic({
+        apiKey: bearer ? undefined : (apiKey || undefined),
+        authToken: bearer ? (apiKey || undefined) : undefined,
+        baseURL: url || undefined,
+      })
       return { model: client(m), key }
     }
     case 'openai': {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -75,6 +75,15 @@ const baseProfileFields = {
   baseUrl: z.string().optional(),
   apiKey: z.string().optional(),
   /**
+   * Anthropic-shape only: which HTTP header carries the key. 'x-api-key' is
+   * Anthropic first-party (default when absent); 'bearer' sends Authorization:
+   * Bearer, required by anthropic-compatible gateways like MiniMax's
+   * international endpoint. Currently consumed by the per-workspace AI config
+   * "Apply from profile" path (surfaced via /agent-profiles); the in-process
+   * GenerateRouter runtime does not yet honor it — see ANG follow-up.
+   */
+  authMode: z.enum(['x-api-key', 'bearer']).optional(),
+  /**
    * Pointer into aiProviderSchema.credentials. When present, resolveProfile()
    * joins the credential's apiKey/baseUrl into the resolved shape (profile's
    * own inline values still win if set — transitional).

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -733,6 +733,10 @@ export interface ResolvedProfile {
   baseUrl?: string
   loginMethod?: string
   provider?: string
+  /** Anthropic-shape only: which header carries the key (x-api-key vs Bearer).
+   *  Consumed via resolveAnthropicAuthMode() at the auth-header construction
+   *  sites (agent-sdk env, vercel anthropic client, test-path adapter). */
+  authMode?: 'x-api-key' | 'bearer'
   /** Pointer into AIProviderConfig.credentials. Preserved on the resolved
    *  shape so callers can fetch the credential separately when needed. */
   credentialSlug?: string

--- a/src/core/credential-inference.spec.ts
+++ b/src/core/credential-inference.spec.ts
@@ -4,6 +4,7 @@ import {
   inferAuthType,
   hasExtractableCredential,
   profileToCredential,
+  resolveAnthropicAuthMode,
   type ProfileLike,
 } from './credential-inference.js'
 
@@ -109,5 +110,32 @@ describe('profileToCredential', () => {
       vendor: 'anthropic',
       authType: 'subscription',
     })
+  })
+})
+
+describe('resolveAnthropicAuthMode', () => {
+  it('explicit authMode wins over everything', () => {
+    expect(resolveAnthropicAuthMode({ authMode: 'bearer' })).toBe('bearer')
+    expect(resolveAnthropicAuthMode({ authMode: 'x-api-key' })).toBe('x-api-key')
+    // explicit x-api-key beats the .io baseUrl inference
+    expect(resolveAnthropicAuthMode({ authMode: 'x-api-key', baseUrl: 'https://api.minimax.io/anthropic' }))
+      .toBe('x-api-key')
+  })
+
+  it('infers bearer for MiniMax international (api.minimax.io)', () => {
+    expect(resolveAnthropicAuthMode({ baseUrl: 'https://api.minimax.io/anthropic' })).toBe('bearer')
+  })
+
+  it('does NOT infer bearer for MiniMax China (minimaxi.com tolerates x-api-key)', () => {
+    expect(resolveAnthropicAuthMode({ baseUrl: 'https://api.minimaxi.com/anthropic' })).toBe('x-api-key')
+  })
+
+  it('defaults to x-api-key for first-party Anthropic and unconfirmed gateways', () => {
+    expect(resolveAnthropicAuthMode({})).toBe('x-api-key')
+    expect(resolveAnthropicAuthMode({ baseUrl: 'https://api.anthropic.com' })).toBe('x-api-key')
+    // GLM / Kimi / DeepSeek left at default until confirmed — over-promoting
+    // would break a working x-api-key setup.
+    expect(resolveAnthropicAuthMode({ baseUrl: 'https://api.z.ai/api/anthropic' })).toBe('x-api-key')
+    expect(resolveAnthropicAuthMode({ baseUrl: 'https://api.deepseek.com/anthropic' })).toBe('x-api-key')
   })
 })

--- a/src/core/credential-inference.ts
+++ b/src/core/credential-inference.ts
@@ -58,6 +58,32 @@ export function inferAuthType(profile: ProfileLike): CredentialAuthType {
   return 'api-key'
 }
 
+/**
+ * Resolve which HTTP header carries the key for an Anthropic-shape request
+ * (agent-sdk backend, or vercel-ai-sdk with provider=anthropic).
+ *
+ * `x-api-key` is Anthropic's first-party standard and the safe default;
+ * `bearer` sends `Authorization: Bearer`, which anthropic-compatible
+ * *gateways* require. An explicit `authMode` on the profile always wins —
+ * that's the per-profile choice the wizard / Apply path stores.
+ *
+ * Fallback inference is deliberately narrow: only `api.minimax.io` (MiniMax's
+ * international endpoint) is auto-promoted to bearer, because it's the one
+ * endpoint confirmed to *reject* x-api-key with a 401. This lets pre-existing
+ * MiniMax-international profiles (created before the authMode field landed)
+ * work without being recreated. The China endpoint (minimaxi.com) tolerates
+ * x-api-key, and other gateways (GLM, Kimi, DeepSeek) are left at the default
+ * until confirmed otherwise — over-promoting would silently break a working
+ * x-api-key setup.
+ */
+export function resolveAnthropicAuthMode(
+  profile: { authMode?: 'x-api-key' | 'bearer'; baseUrl?: string },
+): 'x-api-key' | 'bearer' {
+  if (profile.authMode) return profile.authMode
+  if (/api\.minimax\.io/i.test(profile.baseUrl ?? '')) return 'bearer'
+  return 'x-api-key'
+}
+
 /** Whether the profile's inline fields contain a credential to extract. */
 export function hasExtractableCredential(profile: ProfileLike): boolean {
   if (profile.apiKey) return true

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -711,6 +711,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
         baseUrl: typeof p.baseUrl === 'string' ? p.baseUrl : null,
         apiKey: typeof p.apiKey === 'string' ? p.apiKey : null,
         model: typeof p.model === 'string' ? p.model : null,
+        authMode: p.authMode === 'bearer' ? 'bearer' : p.authMode === 'x-api-key' ? 'x-api-key' : null,
       }));
       return c.json({ profiles: list });
     } catch (err) {
@@ -814,6 +815,7 @@ interface ProfileShape {
   baseUrl?: unknown;
   apiKey?: unknown;
   model?: unknown;
+  authMode?: unknown;
 }
 
 interface AgentConfigInput {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -784,7 +784,12 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
 
     try {
       const result = agent === 'claude'
-        ? await probeAnthropic({ baseUrl, apiKey, model })
+        ? await probeAnthropic({
+            baseUrl,
+            apiKey,
+            model,
+            authMode: body?.authMode === 'bearer' ? 'bearer' : 'x-api-key',
+          })
         : await probeOpenAI({
             baseUrl,
             apiKey,
@@ -816,12 +821,15 @@ interface AgentConfigInput {
   apiKey?: string;
   model?: string;
   wireApi?: 'chat' | 'responses';
+  /** Claude only — which header carries the key (see ClaudeProbeInput). */
+  authMode?: 'x-api-key' | 'bearer';
 }
 
 interface ClaudeConfigShape {
   baseUrl: string | null;
   apiKey: string | null;
   model: string | null;
+  authMode: 'x-api-key' | 'bearer';
 }
 
 interface CodexConfigShape {
@@ -848,10 +856,16 @@ async function readClaudeConfig(workspaceDir: string): Promise<ClaudeConfigShape
   }
   const env = (parsed['env'] ?? {}) as Record<string, unknown>;
   const baseUrl = typeof env['ANTHROPIC_BASE_URL'] === 'string' ? (env['ANTHROPIC_BASE_URL'] as string) : null;
-  const apiKey = typeof env['ANTHROPIC_API_KEY'] === 'string' ? (env['ANTHROPIC_API_KEY'] as string) : null;
+  // The key lives in exactly one of two env vars depending on auth mode:
+  // ANTHROPIC_API_KEY → x-api-key header, ANTHROPIC_AUTH_TOKEN → Bearer.
+  // Which one is present tells us the mode to surface back to the modal.
+  const xApiKey = typeof env['ANTHROPIC_API_KEY'] === 'string' ? (env['ANTHROPIC_API_KEY'] as string) : null;
+  const authToken = typeof env['ANTHROPIC_AUTH_TOKEN'] === 'string' ? (env['ANTHROPIC_AUTH_TOKEN'] as string) : null;
+  const authMode: 'x-api-key' | 'bearer' = authToken !== null ? 'bearer' : 'x-api-key';
+  const apiKey = authToken ?? xApiKey;
   const model = typeof parsed['model'] === 'string' ? (parsed['model'] as string) : null;
   if (baseUrl === null && apiKey === null && model === null) return null;
-  return { baseUrl, apiKey, model };
+  return { baseUrl, apiKey, model, authMode };
 }
 
 async function writeClaudeConfig(workspaceDir: string, cfg: AgentConfigInput): Promise<void> {
@@ -867,7 +881,15 @@ async function writeClaudeConfig(workspaceDir: string, cfg: AgentConfigInput): P
   const out: Record<string, unknown> = {};
   const env: Record<string, string> = {};
   if (cfg.baseUrl) env['ANTHROPIC_BASE_URL'] = cfg.baseUrl;
-  if (cfg.apiKey) env['ANTHROPIC_API_KEY'] = cfg.apiKey;
+  // Write the key into exactly one env var. Bearer-mode gateways (MiniMax
+  // international, proxy front-ends) read ANTHROPIC_AUTH_TOKEN → the CLI sends
+  // `Authorization: Bearer`. Default x-api-key mode uses ANTHROPIC_API_KEY.
+  // Never write both: Claude Code warns on dual-set, and the two headers
+  // together can be rejected as ambiguous auth.
+  if (cfg.apiKey) {
+    if (cfg.authMode === 'bearer') env['ANTHROPIC_AUTH_TOKEN'] = cfg.apiKey;
+    else env['ANTHROPIC_API_KEY'] = cfg.apiKey;
+  }
   if (Object.keys(env).length > 0) out['env'] = env;
   if (cfg.model) out['model'] = cfg.model;
   await writeWorkspaceFile(workspaceDir, CLAUDE_SETTINGS_PATH, JSON.stringify(out, null, 2) + '\n');

--- a/src/workspaces/agent-probe.spec.ts
+++ b/src/workspaces/agent-probe.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Probe auth-header regression coverage.
+ *
+ * The whole point of the Workspace AI config Test button is that it sends the
+ * key the *same way* the real CLI session will. For Claude that means the auth
+ * mode must pick exactly one header: `x-api-key` (Anthropic first-party) or
+ * `Authorization: Bearer` (anthropic-compatible gateways like MiniMax's
+ * international endpoint, which 401s x-api-key). These tests pin a real probe
+ * call against a local server and assert the wire headers.
+ */
+
+import { createServer, type Server } from 'node:http';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { probeAnthropic } from './agent-probe.js';
+
+interface Captured {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+let server: Server;
+let baseUrl: string;
+let captured: Captured | null;
+
+beforeEach(async () => {
+  captured = null;
+  server = createServer((req, res) => {
+    captured = { headers: req.headers };
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          model: 'x',
+          content: [{ type: 'text', text: 'pong' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const addr = server.address();
+  if (addr === null || typeof addr === 'string') throw new Error('no server address');
+  // A path-bearing baseURL ('/anthropic') mirrors MiniMax's real shape and
+  // guards against the SDK dropping the path segment.
+  baseUrl = `http://127.0.0.1:${addr.port}/anthropic`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+describe('probeAnthropic auth header', () => {
+  it('defaults to x-api-key (Anthropic first-party)', async () => {
+    const out = await probeAnthropic({ baseUrl, apiKey: 'sk-default', model: 'm' });
+    expect(out.text).toBe('pong');
+    expect(captured?.headers['x-api-key']).toBe('sk-default');
+    expect(captured?.headers['authorization']).toBeUndefined();
+  });
+
+  it('uses x-api-key when authMode is x-api-key', async () => {
+    await probeAnthropic({ baseUrl, apiKey: 'sk-xak', model: 'm', authMode: 'x-api-key' });
+    expect(captured?.headers['x-api-key']).toBe('sk-xak');
+    expect(captured?.headers['authorization']).toBeUndefined();
+  });
+
+  it('uses Authorization: Bearer (and NOT x-api-key) when authMode is bearer', async () => {
+    await probeAnthropic({ baseUrl, apiKey: 'mm-key', model: 'm', authMode: 'bearer' });
+    expect(captured?.headers['authorization']).toBe('Bearer mm-key');
+    // Critical: never send both — dual auth can be rejected as ambiguous.
+    expect(captured?.headers['x-api-key']).toBeUndefined();
+  });
+
+  it('preserves the baseURL path segment', async () => {
+    await probeAnthropic({ baseUrl, apiKey: 'sk-path', model: 'm' });
+    // request landed on /anthropic/v1/messages, proving the path wasn't dropped
+    expect(captured).not.toBeNull();
+  });
+});

--- a/src/workspaces/agent-probe.ts
+++ b/src/workspaces/agent-probe.ts
@@ -19,6 +19,14 @@ export interface ClaudeProbeInput {
   baseUrl: string;
   apiKey: string;
   model: string;
+  /**
+   * Which HTTP header carries the key. `x-api-key` is Anthropic's first-party
+   * standard (the default); `bearer` sends `Authorization: Bearer <key>`,
+   * which is what most anthropic-compatible *gateways* expect (MiniMax's
+   * international endpoint, OpenRouter-style proxies, etc.). Mirrors the
+   * ANTHROPIC_API_KEY vs ANTHROPIC_AUTH_TOKEN split the real session uses.
+   */
+  authMode?: 'x-api-key' | 'bearer';
 }
 
 export interface CodexProbeInput {
@@ -29,7 +37,12 @@ export interface CodexProbeInput {
 }
 
 export async function probeAnthropic(input: ClaudeProbeInput): Promise<ProbeResult> {
-  const client = new Anthropic({ apiKey: input.apiKey, baseURL: input.baseUrl });
+  // `authToken` makes the SDK send `Authorization: Bearer`; `apiKey` makes it
+  // send `x-api-key`. Pick exactly one — sending both can trip gateways that
+  // reject ambiguous auth, and Anthropic's own API now 401s OAuth-via-Bearer.
+  const client = input.authMode === 'bearer'
+    ? new Anthropic({ authToken: input.apiKey, baseURL: input.baseUrl })
+    : new Anthropic({ apiKey: input.apiKey, baseURL: input.baseUrl });
   const msg = await client.messages.create({
     model: input.model,
     max_tokens: 32,

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -35,6 +35,11 @@ interface FormState {
   apiKey: string
   model: string
   wireApi: 'chat' | 'responses'
+  // Claude-only: which header carries the key. 'x-api-key' is Anthropic's
+  // first-party default; 'bearer' (Authorization: Bearer) is what most
+  // anthropic-compatible gateways want — MiniMax's international endpoint
+  // (api.minimax.io) only accepts Bearer, which is why x-api-key 401s there.
+  authMode: 'x-api-key' | 'bearer'
 }
 
 // codex-cli ≥ 0.130 hard-rejects `wire_api = "chat"`. The AgentConfig schema
@@ -43,7 +48,7 @@ interface FormState {
 // codex provider — a stale 'chat' loaded from disk is normalized on display,
 // so the next Save silently corrects it.
 // Ref: github.com/openai/codex/discussions/7782
-const EMPTY_FORM: FormState = { baseUrl: '', apiKey: '', model: '', wireApi: 'responses' }
+const EMPTY_FORM: FormState = { baseUrl: '', apiKey: '', model: '', wireApi: 'responses', authMode: 'x-api-key' }
 
 function configToForm(cfg: AgentConfig | null): FormState {
   if (!cfg) return EMPTY_FORM
@@ -52,6 +57,7 @@ function configToForm(cfg: AgentConfig | null): FormState {
     apiKey: cfg.apiKey ?? '',
     model: cfg.model ?? '',
     wireApi: 'responses',
+    authMode: cfg.authMode === 'bearer' ? 'bearer' : 'x-api-key',
   }
 }
 
@@ -64,7 +70,7 @@ function formToConfig(form: FormState, agent: AgentId): AgentConfig {
   if (agent === 'codex') {
     return { ...cfg, wireApi: form.wireApi }
   }
-  return cfg
+  return { ...cfg, authMode: form.authMode }
 }
 
 // Test result is per-tab so switching tabs doesn't lose the other agent's
@@ -83,7 +89,8 @@ function formsMatch(a: FormState, b: FormState, agent: AgentId): boolean {
     a.baseUrl === b.baseUrl &&
     a.apiKey === b.apiKey &&
     a.model === b.model &&
-    (agent !== 'codex' || a.wireApi === b.wireApi)
+    (agent !== 'codex' || a.wireApi === b.wireApi) &&
+    (agent !== 'claude' || a.authMode === b.authMode)
   )
 }
 
@@ -127,7 +134,8 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
       savedForm.baseUrl !== form.baseUrl ||
       savedForm.apiKey !== form.apiKey ||
       savedForm.model !== form.model ||
-      (tab === 'codex' && savedForm.wireApi !== form.wireApi)
+      (tab === 'codex' && savedForm.wireApi !== form.wireApi) ||
+      (tab === 'claude' && savedForm.authMode !== form.authMode)
     )
   }, [bundle, form, tab])
 
@@ -139,6 +147,9 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
       baseUrl: p.baseUrl ?? '',
       apiKey: p.apiKey ?? '',
       model: p.model ?? '',
+      // A profile may pin its auth mode (e.g. a MiniMax-international profile
+      // needs Bearer); fall back to x-api-key when it doesn't say.
+      authMode: p.authMode === 'bearer' ? 'bearer' : 'x-api-key',
     })
   }
 
@@ -189,6 +200,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
       apiKey: form.apiKey.trim(),
       model: form.model.trim(),
       wireApi: form.wireApi,
+      authMode: form.authMode,
     }
     setTesting(true)
     try {
@@ -197,6 +209,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
         apiKey: snapshot.apiKey,
         model: snapshot.model,
         ...(tab === 'codex' ? { wireApi: snapshot.wireApi } : {}),
+        ...(tab === 'claude' ? { authMode: snapshot.authMode } : {}),
       })
       setResult(
         r.ok
@@ -320,6 +333,30 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
               </button>
             </div>
           </div>
+
+          {tab === 'claude' && (
+            <div>
+              <label className="block text-xs font-medium text-text-muted mb-1">Auth header</label>
+              <select
+                value={form.authMode}
+                onChange={(e) => setForm({ ...form, authMode: e.target.value as FormState['authMode'] })}
+                className={inputClass}
+              >
+                <option value="x-api-key">x-api-key — Anthropic default</option>
+                <option value="bearer">Authorization: Bearer — gateways (MiniMax intl, proxies)</option>
+              </select>
+              <p className="text-[11px] text-text-muted/80 leading-snug mt-1">
+                Anthropic first-party uses <code className="font-mono text-[10.5px]">x-api-key</code>.
+                Switch to <code className="font-mono text-[10.5px]">Bearer</code> for
+                anthropic-compatible gateways that authenticate via{' '}
+                <code className="font-mono text-[10.5px]">Authorization: Bearer</code> — e.g.
+                MiniMax's international endpoint (<code className="font-mono text-[10.5px]">api.minimax.io</code>),
+                which rejects x-api-key. Written as{' '}
+                <code className="font-mono text-[10.5px]">ANTHROPIC_AUTH_TOKEN</code> instead of{' '}
+                <code className="font-mono text-[10.5px]">ANTHROPIC_API_KEY</code>.
+              </p>
+            </div>
+          )}
 
           <div>
             <label className="block text-xs font-medium text-text-muted mb-1">Model</label>

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -375,6 +375,8 @@ export interface AgentProfile {
   readonly baseUrl: string | null;
   readonly apiKey: string | null;
   readonly model: string | null;
+  /** Claude only — which header carries the key, if the profile pins one. */
+  readonly authMode?: 'x-api-key' | 'bearer' | null;
 }
 
 export interface AgentConfig {
@@ -383,6 +385,12 @@ export interface AgentConfig {
   readonly model: string | null;
   /** Codex only — wire format for the upstream API. */
   readonly wireApi?: 'chat' | 'responses' | null;
+  /**
+   * Claude only — `x-api-key` (Anthropic first-party default) vs `bearer`
+   * (`Authorization: Bearer`, for anthropic-compatible gateways like MiniMax
+   * international). Mirrors ANTHROPIC_API_KEY vs ANTHROPIC_AUTH_TOKEN.
+   */
+  readonly authMode?: 'x-api-key' | 'bearer';
 }
 
 export interface AgentConfigBundle {
@@ -436,6 +444,8 @@ export interface AgentTestInput {
   readonly model: string;
   /** Codex only. */
   readonly wireApi?: 'chat' | 'responses';
+  /** Claude only. */
+  readonly authMode?: 'x-api-key' | 'bearer';
 }
 
 export async function testAgentConfig(


### PR DESCRIPTION
## Summary

- OpenAlice only ever sent the Anthropic key via `x-api-key`. Gateways that authenticate with `Authorization: Bearer` — notably MiniMax's international endpoint `api.minimax.io` — reject that with a 401, while the China endpoint (`minimaxi.com`) tolerates it. This adds per-profile Bearer support end-to-end.
- **Workspace path** (commit 1): Claude AI-config modal gains an "Auth header" dropdown (x-api-key vs Bearer); probe + `.claude/settings.local.json` writer/reader carry the mode, emitting exactly one of `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`.
- **Profile + preset wiring** (commit 2): profile schema gains optional `authMode`; `/agent-profiles` surfaces it so "Apply from profile" pre-fills the right mode; MiniMax preset defaults to Bearer (correct for both `.com` and `.io`).
- **Legacy chat-path runtime** (commit 3, ANG-72): GenerateRouter now honors `authMode`. Single source of truth `resolveAnthropicAuthMode(profile)` — explicit choice wins; otherwise infers `bearer` **only** for `api.minimax.io` so pre-existing MiniMax-intl profiles work without recreation. Three header-construction sites consume it: agent-sdk env (`buildAuthEnv`, never dual-sets the two key vars), vercel-ai-sdk anthropic client (`authToken` vs `apiKey`), and the AI-Provider Test button (so test mirrors the real session instead of passing-while-chat-401s).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm test` passes (1811 passing; +18 new: `buildAuthEnv` invariants, `resolveAnthropicAuthMode` decision table, adapter threading + invoker authToken translation)
- [ ] Manual: configure a MiniMax-international profile (`api.minimax.io`) with a real key and confirm chat + Test button both succeed (key is region-locked; deferred to whoever has one)

## Boundary touch
Touches **auth** — AI-provider credential handling only (which header carries the model API key). No broker / trading / UTA / migration surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPhP1PsJR9A3PVz1BjQUw1)_