### PR TITLE
fix(workspaces): de-stale chat / finance-research / auto-quant templates

### DIFF
--- a/src/workspaces/templates/auto-quant/template.json
+++ b/src/workspaces/templates/auto-quant/template.json
@@ -1,6 +1,6 @@
 {
   "displayName": "Auto-Quant",
   "groupOrder": 20,
-  "description": "Auto-Quant autoresearch workspace — clones the public Auto-Quant repo on first use (~/.openalice/workspaces/auto-quant-mirror), then makes per-workspace local clones with an autoresearch/<tag> branch and symlinked .feather data. Set AQ_TEMPLATE_DIR to override the source location.",
+  "description": "Auto-Quant autoresearch workspace — clones the public Auto-Quant repo on first use (~/.openalice/workspaces/auto-quant-mirror), then makes per-workspace local clones with an autoresearch/<tag> branch and isolated per-workspace data. Set AQ_TEMPLATE_DIR to override the source location.",
   "defaultAgents": ["claude", "codex"]
 }

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -4,16 +4,16 @@ version: 1.0.0
 
 # Chat
 
-A general-purpose Alice workspace. The agent boots with OpenAlice's full MCP tool surface — trading actions, market data, news, technical analysis, brain memory — and Alice's persona pre-loaded as CLAUDE.md / AGENTS.md.
+A general-purpose Alice workspace. The agent boots with OpenAlice's full MCP tool surface — trading actions, market data, news, technical analysis — and Alice's persona pre-loaded as CLAUDE.md / AGENTS.md.
 
 ## What this workspace does
 
-This is the closest equivalent to "talk to Alice about anything trading-related." There's no pre-baked task, no specific data layout. The agent can quote tickers, place trades against your UTA accounts, pull news, run indicators, and remember conversations across sessions through the brain memory tools.
+This is the closest equivalent to "talk to Alice about anything trading-related." There's no pre-baked task, no specific data layout. The agent can quote tickers, place trades against your UTA accounts, pull news, and run indicators.
 
 ## When to spawn this
 
 - You want a long-running thread with Alice that isn't tied to a specific research artifact or autoresearch loop.
-- You're exploring an idea and don't yet know which Harness fits — Chat is the no-commitment starting point.
+- You're exploring an idea and don't yet know which workspace the job needs — Chat is the no-commitment starting point.
 - You want quick access to the full MCP tool surface without setting up Auto-Quant clones or finance-skill trees.
 
 ## What you'll see in Inbox

--- a/src/workspaces/templates/chat/files/CLAUDE.md
+++ b/src/workspaces/templates/chat/files/CLAUDE.md
@@ -1,9 +1,9 @@
 # Chat workspace
 
 This workspace is wired to OpenAlice via MCP. `.mcp.json` points at
-OpenAlice's MCP server (`http://127.0.0.1:3001/mcp` by default, or
+OpenAlice's MCP server (`http://127.0.0.1:47332/mcp` by default, or
 `$OPENALICE_MCP_URL`). The full OpenAlice tool surface — trading, market
-data, news, brain, indicators — is available from inside here.
+data, news, indicators — is available from inside here.
 
 To verify the wiring on first attach:
 

--- a/src/workspaces/templates/chat/files/mcp.json
+++ b/src/workspaces/templates/chat/files/mcp.json
@@ -2,11 +2,11 @@
   "mcpServers": {
     "openalice": {
       "type": "streamable-http",
-      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"
+      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:47332/mcp}"
     },
     "openalice-workspace": {
       "type": "streamable-http",
-      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}/__WS_ID__"
+      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:47332/mcp}/__WS_ID__"
     }
   }
 }

--- a/src/workspaces/templates/chat/template.json
+++ b/src/workspaces/templates/chat/template.json
@@ -1,6 +1,6 @@
 {
   "displayName": "Chat",
   "groupOrder": 10,
-  "description": "Chat workspace wired to OpenAlice's MCP server — full trading/market/brain tool surface available to the agent.",
+  "description": "Chat workspace wired to OpenAlice's MCP server — full trading/market tool surface available to the agent.",
   "defaultAgents": ["claude", "codex"]
 }

--- a/src/workspaces/templates/finance-research/files/CLAUDE.md
+++ b/src/workspaces/templates/finance-research/files/CLAUDE.md
@@ -32,7 +32,7 @@ Don't cross the streams: don't quote yfinance to make a UTA order routing call. 
 
 ## MCP wiring
 
-`.mcp.json` points at OpenAlice's MCP server (`http://127.0.0.1:3001/mcp` by default, or `$OPENALICE_MCP_URL`). The full OpenAlice tool surface — trading, market data, news, brain, indicators — is available alongside the bundled skills.
+`.mcp.json` points at OpenAlice's MCP server (`http://127.0.0.1:47332/mcp` by default, or `$OPENALICE_MCP_URL`). The full OpenAlice tool surface — trading, market data, news, indicators — is available alongside the bundled skills.
 
 To verify on first attach:
 

--- a/src/workspaces/templates/finance-research/files/mcp.json
+++ b/src/workspaces/templates/finance-research/files/mcp.json
@@ -2,11 +2,11 @@
   "mcpServers": {
     "openalice": {
       "type": "streamable-http",
-      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}"
+      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:47332/mcp}"
     },
     "openalice-workspace": {
       "type": "streamable-http",
-      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:3001/mcp}/__WS_ID__"
+      "url": "${OPENALICE_MCP_URL:-http://127.0.0.1:47332/mcp}/__WS_ID__"
     }
   }
 }


### PR DESCRIPTION
## Summary

The per-template files seeded into every workspace had drifted from current reality. Doc/JSON only — no TS touched.

- **brain (retired, migration 0006) — most malignant.** `files/CLAUDE.md` is composed into the agent's *live* CLAUDE.md at bootstrap, so every spawned session was told it has "brain memory tools" that no longer exist (zero brain/memory tools registered in ToolCenter). Removed from chat + finance-research `files/CLAUDE.md`, `chat/template.json`, and the `chat/README.md` "remember conversations through the brain memory tools" claim.
- **MCP port 3001 → 47332.** 3001 is a dead historical hardcode ("a port nothing listens on" — see `adapters/codex.ts`); the real port is injected per-spawn via `OPENALICE_MCP_URL` (`service.ts`), default 47332. Fixed the never-firing fallback in both `mcp.json` files + the "by default" prose in both `files/CLAUDE.md`.
- **auto-quant/template.json: "symlinked .feather data" → "isolated per-workspace data."** The old copy was the *opposite* of the actual bootstrap + README, which deliberately give each workspace its own real data dir to avoid cross-generation cache mixing.
- **terminology:** `chat/README.md` "which Harness fits" → "which workspace the job needs" (Harness stays the umbrella concept; the concrete choice is a workspace).

## Test plan
- [x] All 5 template `*.json` files validated as parseable JSON
- [x] `grep -rn 3001 src/workspaces/templates` → no residual
- [x] `grep -rni "brain\|Harness" chat finance-research` → no residual
- [ ] No TS touched → tsc/test gate N/A

## Boundary touch
None — workspace template docs/config only. No trading / auth / broker / migration code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
