### PR TITLE
refactor(ui): move Automation from Legacy to Beta in sidebar nav

### DIFF
--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -100,18 +100,25 @@ const NAV_SECTIONS: NavSection[] = [
       { page: 'news',       label: 'News',       icon: Newspaper, defaultTab: { kind: 'news', params: {} } },
     ],
   },
-  // Beta — functional but unstable. The underlying cross-broker
-  // unification (UTA abstraction, FX/options/futures) is in active
-  // rearchitecture. Portfolio surfaces that state; Trading-as-Git is
-  // the operations side (pending broker writes). Broker connection
-  // CRUD lives under Settings → Trading, not here — it's a config
-  // surface, not a state/ops one.
+  // Beta — functional but not yet dependable. Two distinct reasons
+  // land an entry here:
+  //  - Cross-broker unification (UTA abstraction, FX/options/futures)
+  //    is in active rearchitecture. Portfolio surfaces that state;
+  //    Trading-as-Git is the operations side (pending broker writes).
+  //    The data runs; the schema/UX underneath isn't settled.
+  //  - Automation runs fine in isolation, but its trigger chain isn't
+  //    closed in the current Harness architecture — nothing fires it
+  //    end-to-end yet, so it's effectively unusable today. Once
+  //    Harness scheduling lands it gets wired back up.
+  // Broker connection CRUD lives under Settings → Trading, not here —
+  // it's a config surface, not a state/ops one.
   {
     sectionLabel: 'Beta',
-    description: 'Cross-broker unified state + ops surfaces. The abstraction underneath is still being settled — try them, but don\'t depend on schema or UX as stable yet. Broker connection setup lives in Settings → Trading.',
+    description: 'Functional but not yet dependable. Trading-as-Git and Portfolio surface cross-broker unified state whose underlying abstraction is still being settled — try them, but don\'t depend on schema or UX as stable yet. Automation runs, but its trigger chain isn\'t closed in the current Harness architecture, so it can\'t fire end-to-end until Harness scheduling lands. Broker connection setup lives in Settings → Trading.',
     items: [
       { page: 'trading-as-git', label: 'Trading as Git', icon: GitBranch },
       { page: 'portfolio',      label: 'Portfolio',      icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
+      { page: 'automation',     label: 'Automation',     icon: Zap, defaultTab: { kind: 'automation', params: { section: 'flow' } } },
     ],
   },
   {
@@ -131,7 +138,6 @@ const NAV_SECTIONS: NavSection[] = [
       { page: 'traditional-chat',     label: 'Traditional chat', icon: MessagesSquare },
       { page: 'notifications-legacy', label: 'Notifications',    icon: Bell, defaultTab: { kind: 'notifications-inbox', params: {} } },
       { page: 'connectors-legacy',    label: 'Connectors',       icon: Plug, defaultTab: { kind: 'settings', params: { category: 'connectors' } } },
-      { page: 'automation',           label: 'Automation',       icon: Zap, defaultTab: { kind: 'automation', params: { section: 'flow' } } },
     ],
   },
 ]


### PR DESCRIPTION
## Summary
- Automation isn't deprecated — it runs fine on its own. What's missing is the **trigger chain**: in the current Harness architecture nothing fires it end-to-end yet, so it's effectively unusable today. Once Harness scheduling lands it gets wired back up — a Beta condition, not a Legacy one.
- Move the `automation` nav entry out of the default-collapsed **Legacy** section into **Beta** (after Portfolio).
- Rewrite the Beta section `description` + the comment block to spell out the two now-distinct reasons an entry sits in Beta (cross-broker rearchitecture vs Automation's unclosed trigger chain).
- Entry-relocation only; deeper excision of Automation comes in a follow-up.

## Test plan
- [ ] `cd ui && tsc -b` clean — change is type-trivial (relocated an existing nav-leaf; `Zap` import still used, no new symbols). Not run in this worktree (deps not installed here).
- [ ] Visual: Automation now appears under the Beta header, gone from Legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)