### PR TITLE
feat(i18n): add app locale foundation

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,6 +10,7 @@ import { findSectionForActivity } from './sections'
 import { UrlAdopter } from './tabs/UrlAdopter'
 import { useWorkspace } from './tabs/store'
 import { getFocusedTab } from './tabs/types'
+import { resolveAppLocale } from './i18n/locale'
 
 /**
  * Activity-bar pages — only items that appear as icons in the ActivityBar.
@@ -51,6 +52,12 @@ function AppShell() {
   const section = findSectionForActivity(selectedSidebar)
   const isDesktop = useIsDesktop()
   const showSidebarPanel = isDesktop && section != null
+  const appLocale = useMemo(() => resolveAppLocale(), [])
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    document.documentElement.setAttribute('lang', appLocale === 'zh' ? 'zh-CN' : 'en-US')
+  }, [appLocale])
 
   // Auto-close the mobile secondary drawer once the user picks a sub-item.
   // We snapshot the focused tab at drawer-open time (see openSecondaryDrawer

--- a/ui/src/i18n/locale.ts
+++ b/ui/src/i18n/locale.ts
@@ -1,0 +1,25 @@
+export type AppLocale = 'en' | 'zh'
+
+export const APP_LOCALE_KEY = 'openalice-settings-locale'
+
+export function resolveAppLocale(): AppLocale {
+  if (typeof window === 'undefined') return 'en'
+
+  try {
+    const raw = localStorage.getItem(APP_LOCALE_KEY)
+    if (raw === 'zh' || raw === 'en') return raw
+  } catch {
+    // ignore storage access errors
+  }
+
+  const browser = (window.navigator?.language || '').toLowerCase()
+  return browser.startsWith('zh') ? 'zh' : 'en'
+}
+
+export function saveAppLocale(locale: AppLocale) {
+  try {
+    localStorage.setItem(APP_LOCALE_KEY, locale)
+  } catch {
+    // ignore storage write errors
+  }
+}


### PR DESCRIPTION
## Summary
- Add minimal i18n locale foundation utilities without any UI copy migration.
- New file: ui/src/i18n/locale.ts
  - AppLocale ('en' | 'zh')
  - resolveAppLocale(): AppLocale (localStorage + fallback)
  - saveAppLocale(locale): persist
- App.tsx now initializes html lang via resolveAppLocale() so locale context can be added incrementally.

## Scope
- P1 foundation only. No page/sidebar copy localization changes.

## Notes
- This is prepared for downstream PRs to pick up and complete zh/en migrations.