### PR TITLE
fix(core): use AgentWorkResultProbe in agent-work spec gate

### DIFF
--- a/src/core/agent-work.spec.ts
+++ b/src/core/agent-work.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { AgentWorkRunner, type AgentWorkRequest, type AgentWorkEmitFn } from './agent-work.js'
+import { AgentWorkRunner, type AgentWorkRequest, type AgentWorkEmitFn, type AgentWorkResultProbe } from './agent-work.js'
 import type { GenerateRouter } from './ai-provider-manager.js'
 import type { ISessionStore } from './session.js'
 import { createMemoryInboxStore, type IInboxStore } from './inbox-store.js'
@@ -390,7 +390,7 @@ describe('AgentWorkRunner — tool-inspecting outputGate', () => {
    *  deliver a tool's args instead of the raw model text. This is the
    *  generic idiom the (now-deleted) notify_user gate relied on; the
    *  AgentWork primitive still guarantees it works for any tool name. */
-  function pushToolGate(probe: { text: string; media: never[]; toolCalls: ReadonlyArray<ToolCallSummary> }) {
+  function pushToolGate(probe: AgentWorkResultProbe) {
     const call = probe.toolCalls.find((c) => c.name === 'push')
     if (!call) return { kind: 'skip' as const, reason: 'ack', payload: { reason: 'ack' } }
     const text = ((call.input ?? {}) as { text?: string }).text ?? ''


### PR DESCRIPTION
## Summary

After PR #232 (legacy chat cluster excision) landed, root \`npx tsc --noEmit\` is red on \`src/core/agent-work.spec.ts\`. The \`pushToolGate\` helper inline-typed its probe argument with \`media: never[]\`, but the real \`AgentWorkResultProbe\` interface (\`agent-work.ts:40\`) has \`media: MediaAttachment[]\`. Strict tsc rejects this where \`pushToolGate\` is passed as an \`outputGate\` (3 call sites: lines 406 / 414 / 424).

Vitest + esbuild didn't catch it — esbuild doesn't enforce types, and the rewired AgentWorkRunner happens to never actually feed media into the probe at runtime, so the test logic works fine. The strict typecheck is the only place this surfaces.

## The fix

One conceptual change: import \`AgentWorkResultProbe\` from \`agent-work.ts\` and use it directly instead of repeating an ad-hoc inline shape. Eliminates the source of drift.

```diff
-import { AgentWorkRunner, type AgentWorkRequest, type AgentWorkEmitFn } from './agent-work.js'
+import { AgentWorkRunner, type AgentWorkRequest, type AgentWorkEmitFn, type AgentWorkResultProbe } from './agent-work.js'
...
-function pushToolGate(probe: { text: string; media: never[]; toolCalls: ReadonlyArray<ToolCallSummary> }) {
+function pushToolGate(probe: AgentWorkResultProbe) {
```

## Process note

Memory \`feedback_no_tail_on_diagnostic_capture\` + the four typecheck scopes documented in CLAUDE.md flag this exact failure mode: \`pnpm test\` is green, but \`npx tsc --noEmit\` red. Worth noting because this is the second occurrence (first was ANG-65, services/uta). Pre-commit verification block in CLAUDE.md says **always run root \`npx tsc --noEmit\` if touching \`src/\`** — easy to skip for big refactors when local feedback is already green via tests.

## Verification

- \`npx tsc --noEmit\` (Alice strict): clean
- \`pnpm vitest run src/core/agent-work.spec.ts\`: 37/37 pass
- \`pnpm test\` (full suite): unchanged (already green pre-fix)

## Boundary touch

None — test file only, no production code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)