### PR TITLE
fix(tests): isolate session-store specs from shared on-disk file

### DIFF
--- a/src/services/auth/session-store.spec.ts
+++ b/src/services/auth/session-store.spec.ts
@@ -4,9 +4,10 @@
  * Writes to `data/config/sessions.json`; cleans up in beforeEach.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
-import { readFile, unlink, writeFile } from 'node:fs/promises'
-import { dataPath } from '@/core/paths.js'
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   createSession,
   validateAndTouch,
@@ -17,7 +18,22 @@ import {
   _unlinkFile,
 } from './session-store.js'
 
-const SESSIONS_FILE = dataPath('config', 'sessions.json')
+// Redirect the store at a private temp file (via the OPENALICE_SESSIONS_FILE
+// seam) so this file never touches the real data/config/sessions.json and
+// can't race with other specs (e.g. auth.spec.ts) under parallel runs.
+let tmpDir: string
+let SESSIONS_FILE: string
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'oa-session-store-'))
+  SESSIONS_FILE = join(tmpDir, 'sessions.json')
+  process.env['OPENALICE_SESSIONS_FILE'] = SESSIONS_FILE
+})
+
+afterAll(async () => {
+  delete process.env['OPENALICE_SESSIONS_FILE']
+  await rm(tmpDir, { recursive: true, force: true })
+})
 
 beforeEach(async () => {
   await _reset()

--- a/src/services/auth/session-store.ts
+++ b/src/services/auth/session-store.ts
@@ -21,7 +21,13 @@ import { dataPath } from '@/core/paths.js'
 const SID_BYTES = 32
 const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000  // 7 days
 
-const SESSIONS_FILE = () => dataPath('config', 'sessions.json')
+// Resolved lazily on every call so the path can be redirected at runtime.
+// `OPENALICE_SESSIONS_FILE` is a test-only seam (same spirit as the
+// `_reset` / `_unlinkFile` exports below): specs point it at a private
+// temp file so parallel test files don't race on — or clobber — the real
+// `data/config/sessions.json`. Production never sets it.
+const SESSIONS_FILE = () =>
+  process.env['OPENALICE_SESSIONS_FILE'] || dataPath('config', 'sessions.json')
 
 export interface SessionRecord {
   sid: string

--- a/src/webui/middleware/auth.spec.ts
+++ b/src/webui/middleware/auth.spec.ts
@@ -7,7 +7,10 @@
  * is fed via a mocked `c.env.incoming.socket.remoteAddress`.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { Hono } from 'hono'
 import {
   createAuthMiddleware,
@@ -19,6 +22,22 @@ import {
   revokeAllSessions,
   _reset,
 } from '@/services/auth/session-store.js'
+
+// These tests create real sessions through the store. Redirect it at a
+// private temp file (OPENALICE_SESSIONS_FILE seam) so we neither clobber the
+// operator's real data/config/sessions.json nor race session-store.spec.ts
+// over the shared file under parallel runs.
+let tmpDir: string
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'oa-auth-mw-'))
+  process.env['OPENALICE_SESSIONS_FILE'] = join(tmpDir, 'sessions.json')
+})
+
+afterAll(async () => {
+  delete process.env['OPENALICE_SESSIONS_FILE']
+  await rm(tmpDir, { recursive: true, force: true })
+})
 
 function makeApp(opts: Parameters<typeof createAuthMiddleware>[0]) {
   const app = new Hono()


### PR DESCRIPTION
## Summary
- `session-store.spec.ts` and `auth.spec.ts` both read/write the **real** `data/config/sessions.json` and share `session-store.ts`'s module-level cache. Under Vitest's default parallel file execution they race — `session-store`'s `beforeEach` deletes the file while `auth`'s `createSession()` / `revokeAllSessions()` write it. Result: intermittent failures like `revokeAllSessions wipes everything` (expects 3, gets 4) or `persists across cache reset` returning null, only on multi-core / loaded machines. It also clobbered the operator's real login sessions.
- Added a lazily-read `OPENALICE_SESSIONS_FILE` seam to `session-store.ts` (same spirit as the existing `_reset` / `_unlinkFile` test seams; unset in production → zero behavior change) and pointed each spec at its own `mkdtemp` file. The two files no longer share state and never touch the real `sessions.json`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] the two previously-colliding specs run 3× in a row, all green
- [x] `pnpm test` passes (90 files / 1701 tests)
- [x] real `data/config/sessions.json` left untouched after the run (confirms tests no longer write it)

## Boundary touch
Touches `src/services/auth/` (auth/session store) and its tests — no change to runtime auth behavior; the new env var is a test-only seam that production never sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUqaSQritri1NUgishMjes)_