### PR TITLE
fix(demo,ui): correct /api/news handler shape + bump persist version v4→v5

### DIFF
--- a/ui/src/demo/handlers/newsList.ts
+++ b/ui/src/demo/handlers/newsList.ts
@@ -1,37 +1,23 @@
 import { http, HttpResponse } from 'msw'
+import { demoNewsArticles } from '../fixtures/news'
+import type { NewsListResponse } from '../../api/types'
 
 /**
- * News demo handler — seeded articles for the showcase.
+ * News demo handler.
  *
- * (Previously also mocked the legacy /api/notifications/history feed; the
- * NotificationsStore surface was removed, so only the news list remains.
- * The `/api/news/collector` config endpoint is mocked separately in
- * news.ts.)
+ * `/api/news` returns `NewsListResponse = { items, count, lookback }` per
+ * ui/src/api/types.ts — NOT { articles, hasMore }. NewsPage does
+ * `setArticles(res.items)`; the wrong shape leaves articles=undefined and
+ * crashes the page on `[...articles].reverse()` in render.
  */
-
-const DEMO_ARTICLES = [
-  {
-    id: 'demo-news-1',
-    title: 'Fed holds rates steady; dot plot signals one cut in 2025',
-    source: 'Reuters',
-    url: 'https://example.com/news/fed-holds',
-    publishedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-    summary: 'The Federal Reserve kept its benchmark rate unchanged...',
-    tickers: ['SPY', 'TLT'],
-  },
-  {
-    id: 'demo-news-2',
-    title: 'NVIDIA unveils next-gen Blackwell Ultra accelerators',
-    source: 'Bloomberg',
-    url: 'https://example.com/news/nvidia-blackwell',
-    publishedAt: new Date(Date.now() - 1000 * 60 * 60 * 6).toISOString(),
-    summary: 'NVIDIA announced its Blackwell Ultra line...',
-    tickers: ['NVDA'],
-  },
-]
-
 export const newsListHandlers = [
-  http.get('/api/news', () => {
-    return HttpResponse.json({ articles: DEMO_ARTICLES, hasMore: false })
+  http.get('/api/news', ({ request }) => {
+    const lookback = new URL(request.url).searchParams.get('lookback') ?? '24h'
+    const body: NewsListResponse = {
+      items: demoNewsArticles,
+      count: demoNewsArticles.length,
+      lookback,
+    }
+    return HttpResponse.json(body)
   }),
 ]

--- a/ui/src/tabs/store.ts
+++ b/ui/src/tabs/store.ts
@@ -239,7 +239,11 @@ export const useWorkspace = create<WorkspaceStore>()(
       // TabStrip call getView() on a missing kind and crash on rehydrate;
       // bumping the version drops stale persisted state (no migrate fn —
       // schema bump clears, per this store's loud-fail contract).
-      version: 4,
+      // v5: the demo `/api/news` handler shape mismatch poisoned any
+      // session that had a news tab open — NewsPage's `[...articles]`
+      // throws when res.items is undefined, and the rehydrate replays
+      // that tab open on every reload. Bump clears the loop.
+      version: 5,
       // Persist only the data shape — actions are recreated by the store factory.
       partialize: (state) => ({
         tabs: state.tabs,


### PR DESCRIPTION
## Summary

Two coupled fixes for the news crash the user reported (demo mode):
clicking into News crashed the page AND poisoned the persisted UI
state so subsequent reloads kept crashing.

## What was wrong

### Fix 1: \`/api/news\` handler shape mismatch (the crash)

PR #232's legacy chat excision replaced the old news/notifications handler with a new \`ui/src/demo/handlers/newsList.ts\` that returned:

\`\`\`ts
{ articles: [...], hasMore: false }
\`\`\`

with each article shaped \`{ id, title, source, url, publishedAt, summary, tickers }\`.

But \`ui/src/api/types.ts\` defines the contract as \`NewsListResponse\`:

\`\`\`ts
{ items: NewsArticle[], count, lookback }
\`\`\`

with each \`NewsArticle\` shaped \`{ time, title, content, source, link, categories }\`.

\`NewsPage\` calls \`setArticles(res.items)\` — wrong shape → \`articles = undefined\` → render does \`[...articles].reverse()\` → throws "undefined is not iterable" as an unhandled exception.

**Fix:** rewires the handler to use \`demoNewsArticles\` (the PR-4 Stage 2 fixture that has the correct \`NewsArticle\` shape with 6 realistic items) and the correct \`{ items, count, lookback }\` wrapper.

### Fix 2: persist version bump v4 → v5 (the recovery)

A user who'd already opened the news tab has \`selectedSidebar:'news'\` + a news-kind tab persisted to \`localStorage["openalice.workspace.v2"]\`. Reload replays that selection → re-triggers the crash → loop. Even after the handler fix, anyone who hit the bug once stays stuck.

Bumping the zustand persist version from 4 to 5 makes rehydrate drop the poisoned state (no migrate function — schema bump clears, per the store's loud-fail contract; matches the v4 bump pattern from the legacy chat excision).

**Cost:** users with healthy state lose their open-tabs/layout. Necessary — they were on the crash path too if they navigated to news.

## Pattern note: same bug pattern as PR #235

PR #232 also introduced an inline ad-hoc type for the \`pushToolGate\` test probe that didn't match the real \`AgentWorkResultProbe\` interface (fixed in #235). This is the second case in the same merge where the rewrite introduced a structural shape mismatch that passed esbuild (no type enforcement) but breaks at runtime.

In both cases, importing/referencing the canonical type from \`ui/src/api/types.ts\` or \`src/core/agent-work.ts\` instead of writing inline shapes would have caught it at strict tsc time. Worth flagging for any future Stage-2-ish demo handler additions.

## Verification

| Check | Result |
|---|---|
| \`pnpm -F open-alice-ui exec tsc -b\` | clean |
| \`pnpm -F open-alice-ui build\` (prod) | main chunk has zero \`demoNewsArticles\` / fixture-string leaks |
| \`pnpm dev:demo\` + Playwright | \`/news\` lists 6 articles, expand-article click works, single zustand info log "couldn't be migrated since no migrate function was provided" is the expected v4→v5 dropping behavior |

## Boundary touch

\`ui/src/tabs/store.ts\` is non-demo UI code, but the change is a one-line version-number bump with a comment — same shape as v4's bump from PR #232 (commit 7415131 "bump tab-store persist version").

🤖 Generated with [Claude Code](https://claude.com/claude-code)