### PR TITLE
docs(claude): add demo-mode subsystem guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,23 @@ wiring. When working on one of these, read its guide first:
   list of files to touch for each kind of change, plus a "common pitfalls"
   section for the kinds of things AI sessions have historically half-done.
 
+- **Demo mode** — `ui/src/demo/` (MSW handlers + fixtures, deployed to
+  Vercel as the marketing demo). When you change a frontend surface that
+  uses `/api/*` — new endpoint, modified response shape, new UI page,
+  new sidebar item, retired surface — check that the corresponding
+  `ui/src/demo/handlers/<domain>.ts` still matches. Three recent crashes
+  (PRs #235, #238, #240) all came from this pattern: a refactor changed
+  what production code returns / expects, but the demo handler kept the
+  old (or invented an ad-hoc) shape, and `pnpm test` didn't catch it
+  because esbuild doesn't enforce types. Cheap habits that prevent this:
+  - When writing a demo handler, import the canonical type from
+    `ui/src/api/types.ts` (or wherever the contract lives), don't inline
+    an ad-hoc shape.
+  - `pnpm -F open-alice-ui dev:demo` and walk the affected surface
+    before declaring the refactor done. The `[demo] unmocked …` catchAll
+    `console.warn` log will surface endpoints you've added but not
+    mocked; visible crashes will surface shape mismatches.
+
 ## Surfacing future work — Linear, not TODO.md
 
 When a session notices something worth fixing later but **out of scope


### PR DESCRIPTION
## Summary

Adds a Demo mode entry to CLAUDE.md's "Subsystem guides" section so future sessions check the parallel demo handlers when changing any \`/api/*\` surface — a habit that would have prevented the last three demo-crash PRs.

## Context

Three recent crashes — PR #235 (\`AgentWorkResultProbe\` shape), PR #238 (Chat sidebar empty because \`'demo-template'\` ≠ real \`'chat'\` template name), PR #240 (\`/api/news\` returned \`{articles, hasMore}\` instead of \`{items, count, lookback}\`) — all came from the same pattern. A refactor changed what production code returns or expects, but the parallel demo handler kept the old shape (or invented an ad-hoc one). \`pnpm test\` didn't catch it because esbuild doesn't enforce types; the breakage only surfaced when a visitor clicked into the broken surface.

The new entry sits next to the event/listener/producer guide and names two cheap habits that prevent this:

1. Import the canonical type from \`ui/src/api/types.ts\` (or wherever the contract lives) when writing a demo handler — don't inline an ad-hoc shape.
2. Run \`pnpm -F open-alice-ui dev:demo\` and walk the affected surface before declaring the refactor done. The catchAll's \`[demo] unmocked …\` warn surfaces missing endpoints; visible crashes surface shape mismatches.

## Diff scope

CLAUDE.md only — +17 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)