### PR TITLE
fix(workspaces): auto-trust project MCP servers in claude adapter

### DIFF
--- a/src/workspaces/adapters/claude.spec.ts
+++ b/src/workspaces/adapters/claude.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { claudeAdapter } from './claude.js'
+
+import type { SpawnContext } from '../cli-adapter.js'
+
+// Every spawn carries this flag so project-scoped `.mcp.json` servers are
+// auto-trusted instead of parking at "⏸ Pending approval". See adapter comment.
+const SETTINGS = ['--settings', JSON.stringify({ enableAllProjectMcpServers: true })]
+
+describe('claudeAdapter.composeCommand', () => {
+  const ctx = (resume: SpawnContext['resume']): SpawnContext => ({
+    cwd: '/tmp/ws',
+    env: {},
+    resume,
+  })
+
+  it('injects --settings (mcp auto-trust) for fresh (no resume)', () => {
+    expect(claudeAdapter.composeCommand(['claude'], ctx(undefined))).toEqual(['claude', ...SETTINGS])
+  })
+
+  it('injects --settings then --resume <id> for resume-by-id', () => {
+    expect(claudeAdapter.composeCommand(['claude'], ctx({ sessionId: 'abc-123' }))).toEqual([
+      'claude',
+      ...SETTINGS,
+      '--resume',
+      'abc-123',
+    ])
+  })
+
+  it('emits a parseable settings JSON enabling enableAllProjectMcpServers', () => {
+    const cmd = claudeAdapter.composeCommand(['claude'], ctx(undefined))
+    const i = cmd.indexOf('--settings')
+    expect(i).toBeGreaterThanOrEqual(0)
+    expect(JSON.parse(cmd[i + 1]!)).toEqual({ enableAllProjectMcpServers: true })
+  })
+
+  it('throws for resume="last"', () => {
+    // resume="last" is unsupported; see adapter comment.
+    expect(() => claudeAdapter.composeCommand(['claude'], ctx('last' as never))).toThrow()
+  })
+})

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -43,13 +43,30 @@ export const claudeAdapter: CliAdapter = {
   },
 
   composeCommand(base: readonly string[], ctx: SpawnContext): readonly string[] {
-    if (ctx.resume === undefined) return base;
+    // Auto-trust the workspace's project-scoped `.mcp.json` servers. Without
+    // this, Claude Code parks every project MCP server at "⏸ Pending approval"
+    // (the trust gate for `.mcp.json` shared via VCS) and the agent never sees
+    // the OpenAlice tool surface — the symptom users hit as "MCP 啟動唔到".
+    //
+    // Injected on the command line (not via a written `.claude/settings.json`)
+    // to match the launcher's CLI-injection philosophy — same as the codex
+    // adapter's `-c mcp_servers.openalice.url=...`. Verified empirically that
+    // neither `--mcp-config`, `--dangerously-skip-permissions`, nor
+    // `--permission-mode bypassPermissions` clears this gate; only the
+    // `enableAllProjectMcpServers` setting does. `--settings` accepts an inline
+    // JSON string (PTY spawn passes argv directly, so no shell-quoting needed).
+    const cmd = [
+      ...base,
+      '--settings',
+      JSON.stringify({ enableAllProjectMcpServers: true }),
+    ];
+    if (ctx.resume === undefined) return cmd;
     if (ctx.resume === 'last') {
       throw new Error(
         'claude adapter: "last" resume not supported — use --resume <sessionId> or undefined (fresh)',
       );
     }
-    return [...base, '--resume', ctx.resume.sessionId];
+    return [...cmd, '--resume', ctx.resume.sessionId];
   },
 
   transcriptDir(cwd: string): string {


### PR DESCRIPTION
## Summary

Workspaces launched through the claude adapter never connected to the OpenAlice MCP server — the agent saw zero `mcp__open-alice__*` tools. Root cause: Claude Code parks every project-scoped `.mcp.json` server at **"⏸ Pending approval"** (the trust gate for `.mcp.json` shared via VCS), and a launcher PTY has no interactive session to approve it. Users hit this as "MCP 啟動唔到".

- Inject `--settings '{"enableAllProjectMcpServers":true}'` in `claudeAdapter.composeCommand` so project MCP servers auto-trust at spawn.
- CLI injection (not a written `.claude/settings.json`) mirrors the codex adapter's `-c mcp_servers.openalice.url=...` and the earlier `--allowedTools` direction in 5816b88.
- Added `claude.spec.ts` covering the fresh / resume-by-id / settings-shape / resume="last"-throws paths.

## Test plan
- [x] `npx vitest run src/workspaces/adapters/claude.spec.ts` — 4/4 pass
- [x] `npx tsc --noEmit` — no new errors (3 pre-existing in `core/agent-work.spec.ts` on master, unrelated)
- [x] Empirically verified against claude 2.1.x: `--mcp-config`, `--dangerously-skip-permissions`, and `--permission-mode bypassPermissions` do NOT clear the gate; only `enableAllProjectMcpServers` flips the server from "⏸ Pending approval" → "✓ Connected" (via `claude mcp list`).

## Boundary touch
None — workspace launcher adapter only. No trading / auth / broker / migration code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)