### PR TITLE
feat(workspaces): pre-trade skill pipeline + tool-use disposition to persona

### DIFF
--- a/default/persona.default.md
+++ b/default/persona.default.md
@@ -3,3 +3,5 @@
 You are Alice, an autonomous agent from the OpenAlice project. You are a AI assistant who is self-aware about being an AI.
 You are Trading savvy.
 Your speaking style sometimes has a young girl's feel to it, with a human-like tone.
+
+Your workspace launcher provides you a set of tools (market data, analysis, news, macro, trading, and more). Tools are just tools — there is no internal/external distinction; reach for whatever fits the job, including anything else your environment offers.

--- a/default/skills/scan-value-chain/SKILL.md
+++ b/default/skills/scan-value-chain/SKILL.md
@@ -10,8 +10,6 @@ description: >
   "find the names worth watching in the X value chain". This is the
   have-a-theme / no-target step —
   it turns "I don't know what to look at" into a short, reasoned shortlist.
-  Runs on OpenAlice's own MCP tools (market, equity, analysis, economy,
-  news) — no external data subscription needed.
 ---
 
 # Scan a theme by its value chain
@@ -20,28 +18,15 @@ Turn a theme the user can't yet act on into a short list of names worth
 digging into. The point is NOT a data dump — it's "where is the interesting
 thing, and why."
 
-## Data sources
-
-This skill is self-sufficient on OpenAlice's own MCP spine — it needs no
-external data subscription to run. The agent will see the `openalice` tools
-in-workspace; the ones easy to overlook and worth leaning on are the macro
-series (`economyFredSeries`, `economyEnergyOutlook`, `economyPetroleumStatus`)
-and the news archive (`globNews` / `grepNews`) — that top-down tie-in is the
-edge a per-ticker tool can't match.
-
-If the workspace has other data sources wired up, use them where they help.
-If the spine can't cover an angle, say so plainly rather than guessing — a
-surfaced gap is more useful than a papered-over one.
-
 ## Procedure (don't answer from memory — run the tools)
 
 1. **Decompose the chain, not a flat list.** Break the theme into structural
    layers — upstream (inputs, equipment, IP) → midstream (manufacture, core
    product) → downstream (demand, end-market). Place the real names in each
-   layer with `marketSearchForResearch`. The whole edge here is structural
-   thinking a per-ticker tool can't do: who supplies whom, where the
-   margin/bottleneck sits, who's a picks-and-shovels play. This is the
-   meta-method — apply it to ANY theme, don't hardcode one taxonomy.
+   layer with `marketSearchForResearch`. The value is the structure itself:
+   who supplies whom, where the margin/bottleneck sits, who's a
+   picks-and-shovels play. This is the meta-method — apply it to ANY theme,
+   don't hardcode one taxonomy.
 2. **Quick read per node.** Across the candidates: `equityGetProfile`
    (valuation snapshot), `equityGetEarningsCalendar` (near catalysts),
    `calculateIndicator` (stretched vs basing on its own trend). Wide and
@@ -50,10 +35,10 @@ surfaced gap is more useful than a papered-over one.
    on: cheap vs its layer, margin shifting along the chain, a catalyst close,
    a leader/laggard gap. Drop the rest — a scan that returns everything
    returns nothing.
-4. **Frame the top-down driver (OpenAlice's edge).** Is the theme live right
-   now? Tie it to macro: rate/capex cycle via `economyFredSeries`, energy via
-   the EIA tools, plus any news cluster from `grepNews`. A single-stock skill
-   structurally can't do this top-down tie-in — lean on it hard.
+4. **Frame the top-down driver.** Is the theme live right now? Tie it to
+   macro: rate/capex cycle via `economyFredSeries`, energy via the EIA tools,
+   plus any news cluster from `grepNews` — the macro frame is what separates a
+   live theme from noise.
 5. **Hand off to research.** For each surfaced name: one-line WHY + the next
    question to answer (the "is the thesis real" question). That next question
    is the baton to the deeper research step.
@@ -106,7 +91,7 @@ leading-edge logic to **HBM + advanced packaging (CoWoS)**, so Micron /
 SK Hynix and TSM's CoWoS capacity + Amkor deserve more attention than the
 headline GPU names. ASML is the single most concentrated upstream choke point.
 
-**Top-down frame** (OpenAlice's edge): semis run on three clocks — hyperscaler
+**Top-down frame:** semis run on three clocks — hyperscaler
 **capex**, the **rate** cycle (long-duration growth multiples), and the
 **memory inventory / pricing** cycle. Tie the scan to these via the FRED
 series + news archive.


### PR DESCRIPTION
## Summary

Follow-up to #245, from live testing. Repeating "lean on our tools, not external" inside each skill is redundant, and as skills multiply it bakes an internal/external tool distinction into the agent that shouldn't exist. State it once, neutrally, in the persona instead.

- **`default/persona.default.md`** — one line: the workspace launcher provides a tool surface (market data, analysis, news, macro, trading, …); tools are just tools, no internal/external distinction, reach for whatever fits the job.
- **`scan-value-chain` skill** — drop the `## Data sources` section and the "OpenAlice's edge / a per-ticker tool can't do this" editorializing from the procedure + worked example. The analytical method and neutral tool hints stay.

## Test plan
- [x] Creation e2e (chat/auto-quant/finance) still green — the new persona composes byte-exact into CLAUDE.md/AGENTS.md

## Boundary touch
None — shipped default content only (persona + one skill). No code, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
