### PR TITLE
feat(skills): pre-trade pipeline — build-thesis + sector-rotation (tool-agnostic)

### DIFF
--- a/default/skills/build-thesis/SKILL.md
+++ b/default/skills/build-thesis/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: build-thesis
+description: >
+  Build a two-sided, falsifiable thesis on a specific name — the left side
+  (does the number stand up, and where do you differ from consensus) and the
+  right side (is the market itself favoring this — sector, capital, macro,
+  trend). Use when the user has a ticker but no conviction yet: "is the NVDA
+  thesis real", "build a thesis on X", "should I believe the X story", "bull
+  and bear case for Y", "stress-test my view on Z", "is X already priced in",
+  "left side or right side on X", "everyone's buying Y, should I". This is the
+  have-a-name / no-conviction step — it picks up where a value-chain scan hands
+  off ("the next question: is the thesis real?") and turns a name into a thesis
+  you can act on and later monitor.
+---
+
+# Build a two-sided thesis on a name
+
+Turn "everyone's talking about NVDA — should I believe it?" into a thesis with
+a spine: what has to be true, where you differ from the crowd, and what would
+prove you wrong.
+
+Judge the name from BOTH sides. Most real money is medium- or short-term and
+can't wait for value to revert — so the **right side** (is the market actually
+favoring this?) is usually what drives realized P&L. Don't stop at "it's cheap."
+
+## Procedure (don't answer from memory — run the tools)
+
+0. **Anchor the comparison set.** The right side is *relative* — "strong" only
+   means something against peers. If a value-chain map for this name's theme
+   exists in the dossier (from `scan-value-chain`), use it as the peer/chain
+   set. If not, sketch the chain first: without it you don't know what to
+   compare against.
+
+1. **State the claim** in one sentence — what has to happen for this to work.
+
+2. **LEFT side — does the number stand up, and where do you differ from consensus?**
+   - Your own quant: valuation against its own history and against chain peers;
+     the 2–3 assumptions the value actually rests on.
+   - Others' quant: where consensus / estimates sit — and the part that matters,
+     your **variant view**: where you disagree with the street, and why. No
+     variant view, no edge.
+   - *What must be true (left):* the load-bearing valuation assumptions.
+   - *Disconfirming signals (left):* what would break the fundamental case.
+
+3. **RIGHT side — is the market itself favoring this?** (cross-sectional, on the
+   chain from step 0)
+   - Relative strength: this name vs its layer peers vs the chain vs the market —
+     leader or laggard? (a laggard is either a left-side setup or a falling
+     knife — say which.)
+   - Where capital is rotating: into this node/name, or out of it. Flow data is
+     thin — read it through price/volume momentum, market breadth (what's
+     leading vs lagging), and the news narrative.
+   - Sector + macro tailwind: is the whole chain on the right side of macro, or
+     is this name swimming against it?
+   - *What must be true (right):* the trend / flow / sector strength that must
+     persist.
+   - *Disconfirming signals (right):* momentum break, capital rotating out, the
+     chain rolling over. (These are exactly the hooks a position monitor watches.)
+
+4. **Consensus & priced-in.** Is this already the consensus trade? Has the easy
+   money gone? A correct left+right thesis that everyone already holds is a
+   crowded trade, not an edge — and the variant view is where any edge survives.
+
+5. **Verdict.** Combine the sides → is the thesis real, and is the opportunity a
+   **left-side entry** (early, cheap, market not yet confirming) or a
+   **right-side entry** (market confirming, pay up for lower timing risk) — or
+   neither. Often the chain map points you off the crowded leader toward a
+   less-crowded name carrying the marginal strength.
+
+## Output — write it into the dossier
+
+Persist the thesis as `<theme>/notes/<TICKER>.md` in the dossier the value-chain
+scan started (confirm the layout with the user if none exists — don't impose
+one). The per-name note is the living thesis: the claim, both sides, what-must-
+be-true, and the disconfirming-signal watchlist. Next session reads it and
+updates it as the signals move — never re-derives from zero. The right-side
+disconfirming signals are the baton to a position-monitor step.
+
+## Worked example: NVDA (illustrative — run it fresh for any name)
+
+**Claim:** NVDA keeps compounding data-center revenue because hyperscaler capex
+hasn't peaked and it stays the market's chosen way to own AI silicon.
+
+**Left:** rich vs its own history and vs the chain on most multiples — not a
+value bargain. Consensus already models years of data-center growth; the only
+variant views with edge are narrow ("does CoWoS/HBM supply cap the growth the
+street is modeling?" / "does custom silicon — TPU, Trainium — quietly take
+share?"). *Must be true:* capex doesn't peak, ~dominant accelerator share holds,
+margins hold. *Breaks if:* a data-center guide-down, margin compression,
+visible custom-silicon share loss.
+
+**Right:** the leader of the AI-silicon chain, riding a whole-chain tailwind —
+strong on relative-strength. But anchored on the chain map, the *marginal*
+strength has migrated downstream of the headline name, to the HBM + advanced-
+packaging bottleneck (MU / SK Hynix / Amkor). *Must be true:* the AI-capex
+narrative persists and NVDA stays the chosen leader. *Breaks if:* momentum
+rolls over, a "capex peak" narrative takes hold, money rotates from NVDA to the
+laggards or out of the chain.
+
+**Priced-in:** NVDA is *the* consensus AI trade — extremely crowded. Left+right
+can both hold and the edge still be thin.
+
+**Verdict:** left = fair-to-rich (no left-side bargain), right = leader but
+crowded. The chain map's tell is that the cleaner right-side trade with less
+crowding may be the bottleneck names, not NVDA itself — which is the kind of
+call this two-sided + chain-anchored read surfaces and a single-name glance
+misses.

--- a/default/skills/scan-value-chain/SKILL.md
+++ b/default/skills/scan-value-chain/SKILL.md
@@ -18,27 +18,25 @@ Turn a theme the user can't yet act on into a short list of names worth
 digging into. The point is NOT a data dump — it's "where is the interesting
 thing, and why."
 
-## Procedure (don't answer from memory — run the tools)
+## Procedure (don't answer from memory — go to the data)
 
 1. **Decompose the chain, not a flat list.** Break the theme into structural
    layers — upstream (inputs, equipment, IP) → midstream (manufacture, core
    product) → downstream (demand, end-market). Place the real names in each
-   layer with `marketSearchForResearch`. The value is the structure itself:
-   who supplies whom, where the margin/bottleneck sits, who's a
-   picks-and-shovels play. This is the meta-method — apply it to ANY theme,
-   don't hardcode one taxonomy.
-2. **Quick read per node.** Across the candidates: `equityGetProfile`
-   (valuation snapshot), `equityGetEarningsCalendar` (near catalysts),
-   `calculateIndicator` (stretched vs basing on its own trend). Wide and
-   cheap — you're triaging, not deep-diving.
+   layer. The value is the structure itself: who supplies whom, where the
+   margin/bottleneck sits, who's a picks-and-shovels play. This is the
+   meta-method — apply it to ANY theme, don't hardcode one taxonomy.
+2. **Quick read per node.** Across the candidates, pull a quick read from the
+   data: a valuation snapshot, any near-term catalysts, and where each trades
+   vs its own trend (stretched or basing). Wide and cheap — you're triaging,
+   not deep-diving.
 3. **Find the divergence.** Surface 3–6 names where there's something to pull
    on: cheap vs its layer, margin shifting along the chain, a catalyst close,
    a leader/laggard gap. Drop the rest — a scan that returns everything
    returns nothing.
-4. **Frame the top-down driver.** Is the theme live right now? Tie it to
-   macro: rate/capex cycle via `economyFredSeries`, energy via the EIA tools,
-   plus any news cluster from `grepNews` — the macro frame is what separates a
-   live theme from noise.
+4. **Frame the top-down driver.** Is the theme live right now? Tie it to macro
+   — the rate/capex cycle, energy, any news cluster around the theme — the
+   macro frame is what separates a live theme from noise.
 5. **Hand off to research.** For each surfaced name: one-line WHY + the next
    question to answer (the "is the thesis real" question). That next question
    is the baton to the deeper research step.
@@ -93,8 +91,8 @@ headline GPU names. ASML is the single most concentrated upstream choke point.
 
 **Top-down frame:** semis run on three clocks — hyperscaler
 **capex**, the **rate** cycle (long-duration growth multiples), and the
-**memory inventory / pricing** cycle. Tie the scan to these via the FRED
-series + news archive.
+**memory inventory / pricing** cycle. Tie the scan to these via the macro and
+news data.
 
 **Proposed file structure** (confirm / adjust with the user — don't impose):
 

--- a/default/skills/sector-rotation/SKILL.md
+++ b/default/skills/sector-rotation/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: sector-rotation
+description: >
+  Read what's moving across the whole market right now — which sectors are
+  surging vs crashing, and where capital is rotating between them, across long /
+  medium / short timeframes. The right-side, top-of-funnel "what is the market
+  actually doing" read. Use when the user has no specific target and wants the
+  lay of the land: "what's hot right now", "what sectors are surging / crashing",
+  "where is money rotating", "what's leading and lagging", "is this risk-on or
+  risk-off", "what should I be looking at this week", "show me the rotation
+  map". Hands the standout movers off to a value-chain scan to dig into.
+---
+
+# Sector rotation — what's moving and where money is going
+
+Rotation between sectors is often a clearer trend than anything inside a single
+value chain. This is the right-side read most real (medium/short-term) trading
+runs on — and the thing you'll open most often. The point is not a gainers
+list; it's "where is money rotating, on what timeframe, and does it hold
+together."
+
+## Procedure (don't answer from memory — go to the data)
+
+1. **Rank the field across timeframes.** Look at sector/theme performance and
+   momentum over long, medium, and short windows. The signal isn't any single
+   window — it's how they line up:
+   - long up + short up → established uptrend (real, but maybe late)
+   - long up + short down → pullback in an uptrend (buy-the-dip, not a top)
+   - long down + short up → a bounce or early rotation-in — decide which
+   - long down + short down → downtrend (avoid, or watch for capitulation)
+2. **Map the rotation, not just the levels.** Rotation is a FROM → TO: money
+   leaving sectors that were strong and are now breaking, going into ones
+   turning up. Name both ends. A one-day pop with nothing behind it is noise,
+   not rotation.
+3. **Confirm or doubt it.** A rotation is trustworthy when timeframes, market
+   breadth (what's leading vs lagging beneath the index), and the news narrative
+   point the same way. When only the shortest timeframe moves, distrust it.
+4. **Overlay the macro regime.** Rotations make sense inside a regime — risk-on
+   vs risk-off, rates up vs down, early vs late cycle. Tie what you see to the
+   macro picture: does the rotation fit a coherent story, or is it noise? A
+   rotation that contradicts the regime is either early (valuable) or wrong.
+5. **Hand off the standouts.** For each surging/crashing sector worth a look,
+   give a one-line read and the next move — usually "decompose this one"
+   (a value-chain scan) to find the names carrying the move.
+
+## Output — persist a dated snapshot
+
+Rotation is about change over time, so write a **dated** snapshot
+(`rotation/<date>.md`, or whatever layout the user agrees) rather than
+overwriting one file. The latest snapshot is the current read; the series is the
+rotation itself — next session diffs against the last one ("what changed since
+Tuesday"). Don't impose a layout; settle it with the user, then CRUD the series.
+
+## Worked example (schematic — illustrates the read, NOT the current tape)
+
+Run this live; the tape moves daily. The shape to produce:
+
+| sector | long | mid | short | read |
+|---|---|---|---|---|
+| A | strong | strong | pulling back | buy-the-dip in an uptrend — not a top |
+| B | weak | turning up | surging | early rotation-in **if** breadth + news confirm; else a dead-cat bounce |
+| C | strong | rolling over | down | distribution — money leaving; a FROM end |
+| D | weak | weak | down | downtrend, no read |
+
+**Rotation call:** money rotating C → B (out of the rolling-over leader into the
+turning-up laggard). **Confirm:** is B's strength broad (many names) or one
+ticker? does the news support a reason? **Regime fit:** does C → B match the
+macro regime (e.g. a rates move favoring B's profile), or is it a head-fake?
+**Hand off:** B looks like the live thread → decompose B's value chain next to
+find which names carry it.

--- a/src/workspaces/templates/chat/template.json
+++ b/src/workspaces/templates/chat/template.json
@@ -5,5 +5,5 @@
   "defaultAgents": ["claude", "codex"],
   "injectMcp": true,
   "injectPersona": true,
-  "bundledSkills": ["scan-value-chain"]
+  "bundledSkills": ["scan-value-chain", "build-thesis", "sector-rotation"]
 }


### PR DESCRIPTION
## Summary

The pre-trade skill pipeline that didn't make #246's merge window. Two new analysis skills bundled into the chat workspace, completing the right-side pre-trade flow:

```
sector-rotation (what's moving / where capital rotates, multi-timeframe)
  → scan-value-chain (decompose a hot chain into candidates)
  → build-thesis (a name's left + right sides, falsifiable)
```

- **build-thesis** — two-sided thesis: left (does the number stand up + your variant view vs consensus) and right (is the market favoring this — relative strength on the chain, rotation, macro), each with what-must-be-true + disconfirming signals. The right side anchors on the value-chain map (right is cross-sectional — you need the comparison set first).
- **sector-rotation** — the right-side, top-of-funnel "what is the market doing" read; the daily-driver / retention surface.
- All three skills are now **tool-agnostic** — they describe the analysis ("go to the data, assess X") and never name specific MCP tools, so they survive the in-flight data-source rework. Removed the hardcoded tool names from scan-value-chain too.

## Test plan
- [x] No CJK / no hardcoded tool names in any skill (grep-verified)
- [x] chat/template.json valid JSON; bundles all three skills
- [ ] Live: create a chat workspace, run the pipeline (deferred to tomorrow)

## Boundary touch
None — shipped default skill content + one template manifest. No code, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
