### PR TITLE
feat(entities): entity index — entity_upsert/entity_search MCP tools + Tracked tab with [[name]] backlinks

### DIFF
--- a/src/core/entity-backlinks.spec.ts
+++ b/src/core/entity-backlinks.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { scanBacklinks } from './entity-backlinks.js'
+import type { WorkspaceRegistry } from '../workspaces/workspace-registry.js'
+
+function fakeRegistry(workspaces: { id: string; tag: string; dir: string }[]): WorkspaceRegistry {
+  return { list: () => workspaces } as unknown as WorkspaceRegistry
+}
+
+describe('scanBacklinks', () => {
+  let root: string
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'oa-backlinks-'))
+  })
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('gathers [[name]] links across workspaces — case-insensitive, deduped per file, scaffolding skipped', async () => {
+    const ws1 = join(root, 'ws1')
+    const ws2 = join(root, 'ws2')
+    await mkdir(join(ws1, 'rotation'), { recursive: true })
+    await mkdir(join(ws1, '.git'), { recursive: true })
+    await mkdir(ws2, { recursive: true })
+
+    await writeFile(join(ws1, 'power.md'), 'buy [[vst]] and [[gev]]; [[VST]] again in the same file')
+    await writeFile(join(ws1, 'rotation', 'jun.md'), 'theme [[ai-data-center-power]] holds [[vst]]')
+    // Scaffolding / dot-dir / non-md must all be ignored.
+    await writeFile(join(ws1, 'CLAUDE.md'), 'persona text mentioning [[vst]] — must not count')
+    await writeFile(join(ws1, '.git', 'COMMIT_EDITMSG'), '[[vst]] inside .git')
+    await writeFile(join(ws1, 'notes.txt'), '[[vst]] in a .txt')
+    await writeFile(join(ws2, 'a.md'), 'only [[gev]] here')
+
+    const map = await scanBacklinks(
+      fakeRegistry([
+        { id: 'id1', tag: 'ws1', dir: ws1 },
+        { id: 'id2', tag: 'ws2', dir: ws2 },
+      ]),
+    )
+
+    // vst: power.md (deduped from two mentions) + rotation/jun.md — never the
+    // CLAUDE.md / .git / .txt files. All in ws1.
+    const vst = map.get('vst') ?? []
+    expect(vst.map((b) => b.path).sort()).toEqual(['power.md', join('rotation', 'jun.md')].sort())
+    expect(vst.every((b) => b.workspaceId === 'id1')).toBe(true)
+
+    // gev spans both workspaces.
+    const gev = map.get('gev') ?? []
+    expect(gev.map((b) => `${b.workspaceTag}:${b.path}`).sort()).toEqual(
+      ['ws1:power.md', 'ws2:a.md'].sort(),
+    )
+
+    // dashed topic name resolves.
+    expect((map.get('ai-data-center-power') ?? []).map((b) => b.path)).toEqual([
+      join('rotation', 'jun.md'),
+    ])
+
+    // Nothing leaked from scaffolding: vst has exactly two backlinks.
+    expect(vst).toHaveLength(2)
+  })
+
+  it('returns an empty map when no notes link anything', async () => {
+    const ws = join(root, 'ws')
+    await mkdir(ws, { recursive: true })
+    await writeFile(join(ws, 'plain.md'), 'no links here, just prose')
+    const map = await scanBacklinks(fakeRegistry([{ id: 'id', tag: 'ws', dir: ws }]))
+    expect(map.size).toBe(0)
+  })
+})

--- a/src/core/entity-backlinks.ts
+++ b/src/core/entity-backlinks.ts
@@ -1,0 +1,85 @@
+/**
+ * Backlink scanner — the reverse index for the entity store.
+ *
+ * Walks every workspace's markdown and collects which notes contain `[[name]]`
+ * links. This is a *mechanical gather of the links the agent already wrote*
+ * (Obsidian-style backlinks), NOT extraction — we never parse prose to infer
+ * entities or relations, only harvest authored `[[...]]` tokens.
+ *
+ * Computed on demand: the corpus is small (tens of workspaces, sub-MB of
+ * markdown). Dot-directories (.git, .claude, .agents, .codex, …) and the
+ * scaffolding files (CLAUDE.md / AGENTS.md / README.md) are skipped so injected
+ * persona / skill text can't produce phantom backlinks — only the agent's own
+ * notes count.
+ */
+
+import { readFile, readdir } from 'node:fs/promises'
+import { join, relative } from 'node:path'
+
+import type { WorkspaceRegistry } from '../workspaces/workspace-registry.js'
+
+export interface Backlink {
+  workspaceId: string
+  workspaceTag: string
+  /** Path of the note, relative to the workspace root. */
+  path: string
+}
+
+/** `[[name]]` where the inner text has no brackets or newline. */
+const WIKILINK_RE = /\[\[([^[\]\n]+)\]\]/g
+const SKIP_FILES = new Set(['CLAUDE.md', 'AGENTS.md', 'README.md'])
+
+async function listMarkdown(root: string): Promise<string[]> {
+  const out: string[] = []
+  async function walk(abs: string): Promise<void> {
+    // Inferred Dirent<string>[]; on an unreadable dir (race with deletion etc.)
+    // fall back to empty rather than aborting the whole scan.
+    const entries = await readdir(abs, { withFileTypes: true }).catch(() => [])
+    for (const e of entries) {
+      if (e.name.startsWith('.')) continue // .git / .claude / .agents / .codex / dotfiles
+      const child = join(abs, e.name)
+      if (e.isDirectory()) {
+        if (e.name === 'node_modules') continue
+        await walk(child)
+      } else if (e.isFile() && e.name.endsWith('.md') && !SKIP_FILES.has(e.name)) {
+        out.push(relative(root, child))
+      }
+    }
+  }
+  await walk(root)
+  return out
+}
+
+/**
+ * Scan all workspaces once. Returns a map from the lowercased `[[name]]` token
+ * to the notes referencing it (deduped per file — N mentions in one note count
+ * as one backlink). Callers look up by entity name (case-insensitive); tokens
+ * with no matching entity are simply never queried.
+ */
+export async function scanBacklinks(registry: WorkspaceRegistry): Promise<Map<string, Backlink[]>> {
+  const out = new Map<string, Backlink[]>()
+  for (const ws of registry.list()) {
+    const files = await listMarkdown(ws.dir)
+    for (const rel of files) {
+      let content: string
+      try {
+        content = await readFile(join(ws.dir, rel), 'utf-8')
+      } catch {
+        continue
+      }
+      const seenInFile = new Set<string>()
+      for (const m of content.matchAll(WIKILINK_RE)) {
+        const raw = m[1]
+        if (!raw) continue
+        const k = raw.trim().toLowerCase()
+        if (!k || seenInFile.has(k)) continue
+        seenInFile.add(k)
+        const link: Backlink = { workspaceId: ws.id, workspaceTag: ws.tag, path: rel }
+        const arr = out.get(k)
+        if (arr) arr.push(link)
+        else out.set(k, [link])
+      }
+    }
+  }
+  return out
+}

--- a/src/core/entity-store.spec.ts
+++ b/src/core/entity-store.spec.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, rm, writeFile, readdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createEntityStore,
+  createMemoryEntityStore,
+  type Entity,
+  type IEntityStore,
+} from './entity-store.js'
+
+describe('EntityStore (in-memory)', () => {
+  let store: IEntityStore
+
+  beforeEach(() => {
+    store = createMemoryEntityStore()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('upsert creates an entity and stamps createdAt', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1000)
+    const e = await store.upsert({ name: 'vst', type: 'asset', description: 'Vistra, TX power' })
+    expect(e).toEqual<Entity>({
+      name: 'vst',
+      type: 'asset',
+      description: 'Vistra, TX power',
+      createdAt: 1000,
+    })
+  })
+
+  it('upsert trims name + description', async () => {
+    const e = await store.upsert({ name: '  vst  ', type: 'asset', description: '  Vistra  ' })
+    expect(e.name).toBe('vst')
+    expect(e.description).toBe('Vistra')
+  })
+
+  it('upsert rejects empty name', async () => {
+    await expect(
+      store.upsert({ name: '   ', type: 'asset', description: 'x' }),
+    ).rejects.toThrow(/name is required/)
+  })
+
+  it('upsert rejects a name with spaces', async () => {
+    await expect(
+      store.upsert({ name: 'ai power', type: 'topic', description: 'x' }),
+    ).rejects.toThrow(/no spaces/)
+  })
+
+  it('upsert rejects empty description', async () => {
+    await expect(
+      store.upsert({ name: 'vst', type: 'asset', description: '   ' }),
+    ).rejects.toThrow(/description is required/)
+  })
+
+  it('upsert rejects an invalid type', async () => {
+    await expect(
+      // @ts-expect-error — exercising the runtime guard
+      store.upsert({ name: 'vst', type: 'stonk', description: 'x' }),
+    ).rejects.toThrow(/type must be/)
+  })
+
+  it('upsert is idempotent on name: updates fields, keeps createdAt, no duplicate', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1000)
+    const first = await store.upsert({ name: 'vst', type: 'asset', description: 'Vistra' })
+    expect(first.createdAt).toBe(1000)
+
+    vi.setSystemTime(5000)
+    const second = await store.upsert({ name: 'vst', type: 'asset', description: 'Vistra Energy (updated)' })
+    expect(second.createdAt).toBe(1000) // preserved
+    expect(second.description).toBe('Vistra Energy (updated)')
+
+    const all = await store.list()
+    expect(all).toHaveLength(1)
+  })
+
+  it('keys case-insensitively: [[VST]] and [[vst]] are one entity', async () => {
+    await store.upsert({ name: 'VST', type: 'asset', description: 'first' })
+    await store.upsert({ name: 'vst', type: 'asset', description: 'second' })
+    const all = await store.list()
+    expect(all).toHaveLength(1)
+    expect(await store.get('Vst')).not.toBeNull()
+    expect((await store.get('vSt'))?.description).toBe('second')
+  })
+
+  it('list returns newest-created first', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1000)
+    await store.upsert({ name: 'a', type: 'topic', description: 'x' })
+    vi.setSystemTime(2000)
+    await store.upsert({ name: 'b', type: 'topic', description: 'x' })
+    vi.setSystemTime(3000)
+    await store.upsert({ name: 'c', type: 'topic', description: 'x' })
+    const all = await store.list()
+    expect(all.map((e) => e.name)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('search matches name or description, case-insensitive; empty lists all', async () => {
+    await store.upsert({ name: 'vst', type: 'asset', description: 'Vistra, Texas power producer' })
+    await store.upsert({ name: 'gev', type: 'asset', description: 'GE Vernova, grid + power equipment' })
+    await store.upsert({ name: 'ai-data-center-power', type: 'topic', description: 'datacenter electricity demand' })
+
+    expect((await store.search('texas')).map((e) => e.name)).toEqual(['vst'])
+    expect((await store.search('POWER')).map((e) => e.name).sort()).toEqual(
+      ['ai-data-center-power', 'gev', 'vst'].sort(),
+    )
+    expect((await store.search('gev')).map((e) => e.name)).toEqual(['gev'])
+    expect(await store.search('')).toHaveLength(3)
+  })
+
+  it('delete removes by name (case-insensitive); missing returns false', async () => {
+    await store.upsert({ name: 'vst', type: 'asset', description: 'x' })
+    await store.upsert({ name: 'gev', type: 'asset', description: 'y' })
+    expect(await store.delete('VST')).toBe(true)
+    expect((await store.list()).map((e) => e.name)).toEqual(['gev'])
+    expect(await store.delete('nope')).toBe(false)
+  })
+
+  it('onChanged fires on upsert + delete; dispose stops it', async () => {
+    let count = 0
+    const dispose = store.onChanged(() => { count++ })
+    await store.upsert({ name: 'vst', type: 'asset', description: 'x' })
+    await store.upsert({ name: 'vst', type: 'asset', description: 'y' }) // update still notifies
+    await store.delete('vst')
+    expect(count).toBe(3)
+    dispose()
+    await store.upsert({ name: 'gev', type: 'asset', description: 'z' })
+    expect(count).toBe(3)
+  })
+})
+
+describe('EntityStore (JSONL persistence)', () => {
+  let dir: string
+  let path: string
+  let store: IEntityStore
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'oa-entities-'))
+    path = join(dir, 'entities.jsonl')
+    store = createEntityStore({ filePath: path })
+  })
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('persists across new store instances on the same file', async () => {
+    await store.upsert({ name: 'vst', type: 'asset', description: 'Vistra' })
+    const fresh = createEntityStore({ filePath: path })
+    const all = await fresh.list()
+    expect(all).toHaveLength(1)
+    expect(all[0]!.name).toBe('vst')
+    expect(all[0]!.type).toBe('asset')
+  })
+
+  it('returns empty when file does not exist', async () => {
+    const missing = createEntityStore({ filePath: join(dir, 'absent.jsonl') })
+    expect(await missing.list()).toEqual([])
+    expect(await missing.get('vst')).toBeNull()
+    expect(await missing.search('x')).toEqual([])
+  })
+
+  it('upsert preserves an existing createdAt read from disk', async () => {
+    // Seed a record with a known-old createdAt, then update via upsert.
+    await writeFile(
+      path,
+      JSON.stringify({ name: 'vst', description: 'old', type: 'asset', createdAt: 1000 }) + '\n',
+      'utf-8',
+    )
+    const updated = await store.upsert({ name: 'vst', type: 'asset', description: 'new' })
+    expect(updated.createdAt).toBe(1000)
+    expect(updated.description).toBe('new')
+
+    const fresh = createEntityStore({ filePath: path })
+    const all = await fresh.list()
+    expect(all).toHaveLength(1)
+    expect(all[0]!.createdAt).toBe(1000)
+    expect(all[0]!.description).toBe('new')
+  })
+
+  it('upsert rewrites the file deduped (no duplicate lines), atomically', async () => {
+    await store.upsert({ name: 'vst', type: 'asset', description: 'a' })
+    await store.upsert({ name: 'gev', type: 'asset', description: 'b' })
+    await store.upsert({ name: 'VST', type: 'asset', description: 'a2' }) // same entity, new casing
+
+    const fresh = createEntityStore({ filePath: path })
+    const all = await fresh.list()
+    expect(all).toHaveLength(2)
+    expect((await fresh.get('vst'))?.description).toBe('a2')
+
+    // No tmp file left behind.
+    expect(await readdir(dir)).not.toContain('entities.jsonl.tmp')
+  })
+
+  it('delete rewrites atomically and persists', async () => {
+    await store.upsert({ name: 'vst', type: 'asset', description: 'a' })
+    await store.upsert({ name: 'gev', type: 'asset', description: 'b' })
+    expect(await store.delete('vst')).toBe(true)
+
+    const fresh = createEntityStore({ filePath: path })
+    expect((await fresh.list()).map((e) => e.name)).toEqual(['gev'])
+    expect(await readdir(dir)).not.toContain('entities.jsonl.tmp')
+  })
+})

--- a/src/core/entity-store.ts
+++ b/src/core/entity-store.ts
@@ -1,0 +1,232 @@
+/**
+ * EntityStore — the durable, cross-workspace index of things the user is
+ * tracking. Sibling of {@link InboxStore}: same file-backed, no-DB shape, but
+ * the atomic concept is an **entity** (a tracked asset or topic) rather than a
+ * push notification.
+ *
+ * An entity is a *deliberately created* anchor, not an extracted one. The
+ * agent calls `entity_upsert` when it decides something is worth tracking;
+ * the notes it writes then point at the entity with Obsidian-style `[[name]]`
+ * links. We never parse prose to infer entities or relations — the design
+ * principle is "complexity lives in the semantic layer (the name + the
+ * description + the authored `[[]]` links), not in the schema." The whole
+ * record is four fields.
+ *
+ * Keyed by `name`, not an opaque id: the name is already a stable semantic
+ * key (a ticker for an asset, a kebab phrase for a topic) and doubles as the
+ * `[[name]]` link target. Matching is case-insensitive so `[[VST]]` and
+ * `[[vst]]` don't fragment into two. Storage is the *current state* (one JSONL
+ * line per entity, last write wins), rewritten atomically (tmp + rename) on
+ * each upsert/delete — the set is a small curated watchlist, not a log.
+ */
+
+import { readFile, mkdir, writeFile, rename } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { EventEmitter } from 'node:events'
+
+import { dataPath } from '@/core/paths.js'
+
+export type EntityType = 'asset' | 'topic'
+
+export interface EntityInput {
+  /** Short, kebab, no whitespace. The key, and the `[[name]]` link target.
+   *  For an `asset` use the ticker so view-time enrichment can join. */
+  name: string
+  /** Free text "what is this" — disambiguates the terse name. */
+  description: string
+  type: EntityType
+}
+
+export interface Entity extends EntityInput {
+  /** Epoch ms the entity was first tracked. Preserved across upserts. */
+  createdAt: number
+}
+
+export interface IEntityStore {
+  /** Create or update by `name` (case-insensitive). An update keeps the
+   *  original `createdAt` and overwrites description/type. */
+  upsert(input: EntityInput): Promise<Entity>
+  /** All entities, most-recently-created first. */
+  list(): Promise<Entity[]>
+  get(name: string): Promise<Entity | null>
+  /** Substring match on name + description (case-insensitive). Empty query
+   *  returns everything. Used by the agent's pre-create dedup check and the
+   *  Tracked-tab search box. */
+  search(query: string): Promise<Entity[]>
+  delete(name: string): Promise<boolean>
+  onChanged(listener: () => void): () => void
+}
+
+const ENTITY_FILE = dataPath('entities', 'entities.jsonl')
+
+/** Case-insensitive identity key for a name. */
+const keyOf = (name: string): string => name.trim().toLowerCase()
+
+// ==================== Validation ====================
+
+function validateInput(input: EntityInput): void {
+  const name = input.name?.trim() ?? ''
+  if (!name) {
+    throw new Error('EntityStore.upsert: name is required')
+  }
+  if (/\s/.test(name)) {
+    throw new Error(
+      'EntityStore.upsert: name must contain no spaces (kebab-case or ticker, e.g. "vst" or "ai-data-center-power")',
+    )
+  }
+  if (!(input.description ?? '').trim()) {
+    throw new Error('EntityStore.upsert: description is required (it disambiguates the short name)')
+  }
+  if (input.type !== 'asset' && input.type !== 'topic') {
+    throw new Error('EntityStore.upsert: type must be "asset" or "topic"')
+  }
+}
+
+function matches(e: Entity, q: string): boolean {
+  return e.name.toLowerCase().includes(q) || e.description.toLowerCase().includes(q)
+}
+
+const byNewest = (a: Entity, b: Entity): number => b.createdAt - a.createdAt
+
+// ==================== JSONL store ====================
+
+export interface EntityStoreOptions {
+  filePath?: string
+}
+
+export function createEntityStore(opts: EntityStoreOptions = {}): IEntityStore {
+  const filePath = opts.filePath ?? ENTITY_FILE
+  const emitter = new EventEmitter()
+  emitter.setMaxListeners(50)
+
+  async function readAll(): Promise<Entity[]> {
+    let raw: string
+    try {
+      raw = await readFile(filePath, 'utf-8')
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return []
+      }
+      throw err
+    }
+    return raw
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as Entity)
+  }
+
+  async function writeAll(entities: Entity[]): Promise<void> {
+    await mkdir(dirname(filePath), { recursive: true })
+    const body = entities.length > 0 ? entities.map((e) => JSON.stringify(e)).join('\n') + '\n' : ''
+    // Atomic rewrite — tmp + rename, same as InboxStore.delete. Current-state
+    // file (deduped by name), not an append log, so upsert is a read-modify-write.
+    const tmp = `${filePath}.tmp`
+    await writeFile(tmp, body, 'utf-8')
+    await rename(tmp, filePath)
+  }
+
+  async function upsert(input: EntityInput): Promise<Entity> {
+    validateInput(input)
+    const all = await readAll()
+    const k = keyOf(input.name)
+    const idx = all.findIndex((e) => keyOf(e.name) === k)
+    const existing = idx >= 0 ? all[idx] : undefined
+    const entity: Entity = {
+      name: input.name.trim(),
+      description: input.description.trim(),
+      type: input.type,
+      createdAt: existing?.createdAt ?? Date.now(),
+    }
+    if (idx >= 0) all[idx] = entity
+    else all.push(entity)
+    await writeAll(all)
+    emitter.emit('changed')
+    return entity
+  }
+
+  async function list(): Promise<Entity[]> {
+    return (await readAll()).sort(byNewest)
+  }
+
+  async function get(name: string): Promise<Entity | null> {
+    const k = keyOf(name)
+    return (await readAll()).find((e) => keyOf(e.name) === k) ?? null
+  }
+
+  async function search(query: string): Promise<Entity[]> {
+    const q = query.trim().toLowerCase()
+    const all = await list()
+    return q ? all.filter((e) => matches(e, q)) : all
+  }
+
+  async function deleteEntity(name: string): Promise<boolean> {
+    const k = keyOf(name)
+    const all = await readAll()
+    const next = all.filter((e) => keyOf(e.name) !== k)
+    if (next.length === all.length) return false
+    await writeAll(next)
+    emitter.emit('changed')
+    return true
+  }
+
+  function onChanged(listener: () => void): () => void {
+    emitter.on('changed', listener)
+    return () => {
+      emitter.off('changed', listener)
+    }
+  }
+
+  return { upsert, list, get, search, delete: deleteEntity, onChanged }
+}
+
+// ==================== In-memory store (tests) ====================
+
+export function createMemoryEntityStore(): IEntityStore {
+  const byKey = new Map<string, Entity>()
+  const emitter = new EventEmitter()
+  emitter.setMaxListeners(50)
+
+  async function upsert(input: EntityInput): Promise<Entity> {
+    validateInput(input)
+    const k = keyOf(input.name)
+    const existing = byKey.get(k)
+    const entity: Entity = {
+      name: input.name.trim(),
+      description: input.description.trim(),
+      type: input.type,
+      createdAt: existing?.createdAt ?? Date.now(),
+    }
+    byKey.set(k, entity)
+    emitter.emit('changed')
+    return entity
+  }
+
+  async function list(): Promise<Entity[]> {
+    return [...byKey.values()].sort(byNewest)
+  }
+
+  async function get(name: string): Promise<Entity | null> {
+    return byKey.get(keyOf(name)) ?? null
+  }
+
+  async function search(query: string): Promise<Entity[]> {
+    const q = query.trim().toLowerCase()
+    const all = await list()
+    return q ? all.filter((e) => matches(e, q)) : all
+  }
+
+  async function deleteEntity(name: string): Promise<boolean> {
+    const removed = byKey.delete(keyOf(name))
+    if (removed) emitter.emit('changed')
+    return removed
+  }
+
+  function onChanged(listener: () => void): () => void {
+    emitter.on('changed', listener)
+    return () => {
+      emitter.off('changed', listener)
+    }
+  }
+
+  return { upsert, list, get, search, delete: deleteEntity, onChanged }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -12,6 +12,7 @@ import type { ToolCenter } from './tool-center.js'
 import type { ListenerRegistry } from './listener-registry.js'
 import type { EventBus } from './event-bus.js'
 import type { IInboxStore } from './inbox-store.js'
+import type { IEntityStore } from './entity-store.js'
 
 export type { Config, WebChannel }
 
@@ -37,6 +38,10 @@ export interface EngineContext {
    *  autonomous trigger sources (cron / task), which append directly
    *  under a synthetic `automation:<source>` workspace id. */
   inboxStore: IInboxStore
+  /** Durable cross-workspace tracked-index (assets / topics). Written by
+   *  workspace agents via the entity_upsert MCP tool; read by the Tracked
+   *  tab. Notes point at entities with `[[name]]` links. */
+  entityStore: IEntityStore
   /** Provider router — resolves the active profile to an AIProvider and
    *  drives one-shot / test calls. The in-process agent loop (formerly
    *  AgentCenter) is retired; the model loop now runs inside the native

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -26,6 +26,7 @@
 
 import type { Tool } from 'ai'
 import type { IInboxStore } from './inbox-store.js'
+import type { IEntityStore } from './entity-store.js'
 
 // ==================== Context handed to factories ====================
 
@@ -40,6 +41,10 @@ export interface WorkspaceToolContext {
   /** Shared inbox store — passed in so factories don't have to import
    *  global state and tests can swap in a memory store. */
   inboxStore: IInboxStore
+  /** Shared entity store — the durable cross-workspace tracked-index that
+   *  entity_upsert / entity_search read and write. Same injection rationale
+   *  as inboxStore. */
+  entityStore: IEntityStore
 }
 
 // ==================== Factory shape ====================

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,9 @@ import { createInboxStore } from './core/inbox-store.js'
 import { ToolCenter } from './core/tool-center.js'
 import { WorkspaceToolCenter } from './core/workspace-tool-center.js'
 import { inboxPushFactory } from './tool/inbox-push.js'
+import { createEntityStore } from './core/entity-store.js'
+import { entityUpsertFactory } from './tool/entity-upsert.js'
+import { entitySearchFactory } from './tool/entity-search.js'
 import { AgentWorkRunner } from './core/agent-work.js'
 import { GenerateRouter } from './core/ai-provider-manager.js'
 import { VercelAIProvider } from './ai-providers/vercel-ai-sdk/vercel-provider.js'
@@ -89,6 +92,8 @@ async function main() {
 
   const workspaceToolCenter = new WorkspaceToolCenter()
   workspaceToolCenter.register(inboxPushFactory)
+  workspaceToolCenter.register(entityUpsertFactory)
+  workspaceToolCenter.register(entitySearchFactory)
 
   // ==================== UTA SDK (HTTP boundary) ====================
   //
@@ -223,6 +228,10 @@ async function main() {
 
   const inboxStore = createInboxStore()
 
+  // ==================== Entity store (durable cross-workspace tracked-index) ====================
+
+  const entityStore = createEntityStore()
+
   // ==================== AgentWork runner — shared by all autonomous trigger sources ====================
   //
   // Drives the AI loop via GenerateRouter directly (no AgentCenter
@@ -326,6 +335,7 @@ async function main() {
       config.mcp.port,
       workspaceToolCenter,
       inboxStore,
+      entityStore,
       () => workspaceServiceRef.current,
     ))
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -357,7 +357,7 @@ async function main() {
   // ==================== Engine Context ====================
 
   const ctx: EngineContext = {
-    config, inboxStore, router, eventLog, toolCallLog, heartbeat, cronEngine, toolCenter,
+    config, inboxStore, entityStore, router, eventLog, toolCallLog, heartbeat, cronEngine, toolCenter,
     listenerRegistry,
     fire: createEventBus(eventLog),
     bbEngine: getSDKExecutor(),

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -23,6 +23,7 @@ function makeApp(): Hono {
     toolCenter,
     workspaceToolCenter: new WorkspaceToolCenter(),
     inboxStore: {} as never,
+    entityStore: {} as never,
     getWorkspaceService: () => fakeSvc as never,
   }
 

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -26,6 +26,7 @@ import type { Tool } from 'ai'
 import type { ToolCenter } from '../core/tool-center.js'
 import type { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
 import type { IInboxStore } from '../core/inbox-store.js'
+import type { IEntityStore } from '../core/entity-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
 import { extractMcpShape, wrapToolExecute } from '../core/mcp-export.js'
 import { CLI_COMMANDS, mappedToolNames } from './cli-commands.js'
@@ -34,6 +35,10 @@ export interface CliGatewayDeps {
   toolCenter: ToolCenter
   workspaceToolCenter: WorkspaceToolCenter
   inboxStore: IInboxStore
+  /** Threaded through so workspace-scoped tools can be built; entity tools
+   *  stay off the CLI surface (not in CLI_COMMANDS) but the build context
+   *  still needs the store. */
+  entityStore: IEntityStore
   /** Lazy — WorkspaceService is created after McpPlugin starts. */
   getWorkspaceService: () => WorkspaceService | null
 }
@@ -42,7 +47,7 @@ type WsMeta = { id: string; tag: string }
 
 /** Mount /cli/:wsId/* onto an existing Hono app (the MCP server's app). */
 export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
-  const { toolCenter, workspaceToolCenter, inboxStore, getWorkspaceService } = deps
+  const { toolCenter, workspaceToolCenter, inboxStore, entityStore, getWorkspaceService } = deps
 
   /** Resolve + validate the workspace from the URL path. */
   const resolveWs = (wsId: string): { meta: WsMeta } | { error: 'unavailable' | 'unknown' } => {
@@ -61,6 +66,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
       workspaceId: ws.id,
       workspaceLabel: ws.tag,
       inboxStore,
+      entityStore,
     })
     return wsTools[name] ?? null
   }

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -7,6 +7,7 @@ import type { Plugin, EngineContext } from '../core/types.js'
 import type { ToolCenter } from '../core/tool-center.js'
 import type { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
 import type { IInboxStore } from '../core/inbox-store.js'
+import type { IEntityStore } from '../core/entity-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
 import { extractMcpShape, wrapToolExecute } from '../core/mcp-export.js'
 import { registerCliRoutes } from './cli.js'
@@ -20,8 +21,8 @@ import { registerCliRoutes } from './cli.js'
  *                           identity required.
  *
  *   GET/POST /mcp/:wsId     Workspace-scoped surface (WorkspaceToolCenter).
- *                           Just inbox_push for now; future tools that need
- *                           workspaceId close over it via the factory
+ *                           inbox_push + entity_upsert / entity_search; tools
+ *                           that need workspaceId close over it via the factory
  *                           pattern. The URL path IS the identity carrier —
  *                           agent never sees or supplies workspaceId, and
  *                           bootstrap.sh bakes the per-workspace URL into
@@ -45,6 +46,7 @@ export class McpPlugin implements Plugin {
     private port: number,
     private workspaceToolCenter: WorkspaceToolCenter,
     private inboxStore: IInboxStore,
+    private entityStore: IEntityStore,
     /** Lazy because WorkspaceService is created later (deferred during web
      *  plugin start); McpPlugin starts earlier. Resolved at request time. */
     private getWorkspaceService: () => WorkspaceService | null,
@@ -54,6 +56,7 @@ export class McpPlugin implements Plugin {
     const toolCenter = this.toolCenter
     const workspaceToolCenter = this.workspaceToolCenter
     const inboxStore = this.inboxStore
+    const entityStore = this.entityStore
     const getWorkspaceService = this.getWorkspaceService
 
     /** Build a per-request McpServer with the global ToolCenter catalog. */
@@ -78,6 +81,7 @@ export class McpPlugin implements Plugin {
         workspaceId: wsId,
         workspaceLabel: wsLabel,
         inboxStore,
+        entityStore,
       })
       const mcp = new McpServer({ name: 'open-alice-workspace', version: '1.0.0' })
       for (const [name, t] of Object.entries(tools)) {
@@ -128,6 +132,7 @@ export class McpPlugin implements Plugin {
       toolCenter,
       workspaceToolCenter,
       inboxStore,
+      entityStore,
       getWorkspaceService,
     })
 

--- a/src/tool/entity-search.ts
+++ b/src/tool/entity-search.ts
@@ -1,0 +1,52 @@
+/**
+ * entity_search — the agent's live lookup of what the user is already
+ * tracking, so it reuses an existing `[[name]]` instead of creating a
+ * near-duplicate.
+ *
+ * Why a live tool and not injected context: a workspace's context (CLAUDE.md
+ * etc.) is written once, at creation time. A long-running workspace would be
+ * blind to entities created after it started — so a static "here are the
+ * tracked entities" snapshot can't keep dedup honest. This tool reads the
+ * store fresh on every call.
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
+
+export const entitySearchFactory: WorkspaceToolFactory = {
+  name: 'entity_search',
+  build(ctx: WorkspaceToolContext) {
+    return tool({
+      description: [
+        "Search the user's tracked entities by name or description.",
+        'Call this before creating a new entity, to reuse an existing name and avoid duplicates',
+        '(write `[[vst]]` consistently rather than also inventing `[[vistra]]`).',
+        'Pass an empty query to list everything currently tracked.',
+      ].join(' '),
+      inputSchema: z.object({
+        query: z
+          .string()
+          .optional()
+          .describe(
+            'Substring matched against entity name + description (case-insensitive). Empty or omitted = list all.',
+          ),
+      }),
+      execute: async ({ query }) => {
+        try {
+          const entities = await ctx.entityStore.search(query ?? '')
+          return {
+            ok: true as const,
+            entities: entities.map((e) => ({ name: e.name, type: e.type, description: e.description })),
+          }
+        } catch (err) {
+          return {
+            ok: false as const,
+            error: err instanceof Error ? err.message : String(err),
+          }
+        }
+      },
+    })
+  },
+}

--- a/src/tool/entity-upsert.ts
+++ b/src/tool/entity-upsert.ts
@@ -1,0 +1,79 @@
+/**
+ * entity_upsert — the agent's deliberate "track this" action.
+ *
+ * A **workspace-scoped tool factory** (same shape as inbox_push): the agent
+ * sees only `{ name, type, description }`; the workspace identity is closed
+ * over by the factory at request time and never trafficked by the agent.
+ *
+ * The entity is created here; the *link* lives in the notes. After calling
+ * this, the agent writes `[[name]]` inside the markdown it produces, and the
+ * Tracked index gathers every note that contains that link. We deliberately
+ * do not extract entities from prose — the agent authors both the entity and
+ * the links, on purpose, as it works.
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
+
+export const entityUpsertFactory: WorkspaceToolFactory = {
+  name: 'entity_upsert',
+  build(ctx: WorkspaceToolContext) {
+    return tool({
+      description: [
+        "Create or update an entity in the user's durable tracked-index — the running watchlist of",
+        'things worth following across sessions. Call this the moment you decide something deserves',
+        "tracking: a ticker you're watching (`asset`) or a theme that groups several of them (`topic`).",
+        '',
+        'Then, in the markdown you write, point at it with an Obsidian-style link: `[[name]]`. That',
+        'link is the whole mechanism — the index gathers every note containing `[[name]]`, so the user',
+        'can later open the entity and see every file that references it.',
+        '',
+        'Fields:',
+        '- name: short, NO spaces, kebab-case. It is both the key and the `[[name]]` you write in prose,',
+        '  so keep it terse and reuse it exactly. For an `asset` use the ticker (e.g. "vst") so the app',
+        '  can pull live quotes; for a `topic` use a short phrase (e.g. "ai-data-center-power").',
+        '- description: one line — what this is. The short name is ambiguous alone; this disambiguates it',
+        '  (e.g. name "vst" -> "Vistra, Texas independent power producer driven by AI datacenter demand").',
+        '- type: "asset" (a tradable instrument — has a ticker) or "topic" (a theme grouping assets).',
+        '',
+        'Before creating, prefer reusing an existing name: call entity_search first so you write',
+        '`[[vst]]` consistently instead of fragmenting into both `[[vst]]` and `[[vistra]]`.',
+      ].join('\n'),
+      inputSchema: z.object({
+        name: z
+          .string()
+          .min(1)
+          .describe(
+            'Short kebab/ticker key, no spaces. The `[[name]]` link target. e.g. "vst" or "ai-data-center-power".',
+          ),
+        type: z
+          .enum(['asset', 'topic'])
+          .describe('"asset" = a tradable instrument (name = its ticker); "topic" = a theme grouping assets.'),
+        description: z
+          .string()
+          .min(1)
+          .describe(
+            'One line: what this is, disambiguating the short name. e.g. "Vistra, Texas independent power producer".',
+          ),
+      }),
+      execute: async ({ name, type, description }) => {
+        try {
+          const entity = await ctx.entityStore.upsert({ name, type, description })
+          return {
+            ok: true as const,
+            name: entity.name,
+            link: `[[${entity.name}]]`,
+            createdAt: entity.createdAt,
+          }
+        } catch (err) {
+          return {
+            ok: false as const,
+            error: err instanceof Error ? err.message : String(err),
+          }
+        }
+      },
+    })
+  },
+}

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -22,6 +22,7 @@ import { createPersonaRoutes } from './routes/persona.js'
 import { createNewsRoutes } from './routes/news.js'
 import { createMarketRoutes } from './routes/market.js'
 import { createInboxRoutes } from './routes/inbox.js'
+import { createEntityRoutes } from './routes/entities.js'
 import { createVersionRoutes } from './routes/version.js'
 import { createAuthRoutes } from './routes/auth.js'
 import { createAuthMiddleware } from './middleware/auth.js'
@@ -215,6 +216,13 @@ export class WebPlugin implements Plugin {
     })
     if (this.workspaceServiceRef) this.workspaceServiceRef.current = this.workspaceService
     app.route('/api/workspaces', createWorkspaceRoutes(this.workspaceService))
+    // Tracked entities — read surface for the Tracked tab. Mounted here (not
+    // with the other /api/* routes above) because backlink scanning needs the
+    // workspace registry, which only exists once workspaceService is created.
+    app.route(
+      '/api/entities',
+      createEntityRoutes({ entityStore: ctx.entityStore, registry: this.workspaceService.registry }),
+    )
 
     // ==================== Mount opentypebb (market data HTTP) ====================
     // opentypebb is Alice's first-class market-data package; its router is

--- a/src/webui/routes/entities.ts
+++ b/src/webui/routes/entities.ts
@@ -1,0 +1,47 @@
+/**
+ * Entity HTTP route — the Tracked tab's read surface.
+ *
+ *   GET /          list all tracked entities, each with a backlink count
+ *   GET /:name     one entity + its backlinks (the notes that link `[[name]]`)
+ *
+ * Writes happen via the `entity_upsert` MCP tool, not here — creation is the
+ * agent's job from inside a workspace. Backlinks are computed on demand by
+ * scanning workspace markdown (see core/entity-backlinks.ts); the route stays
+ * thin and delegates.
+ */
+
+import { Hono } from 'hono'
+
+import type { IEntityStore } from '../../core/entity-store.js'
+import type { WorkspaceRegistry } from '../../workspaces/workspace-registry.js'
+import { scanBacklinks } from '../../core/entity-backlinks.js'
+
+export interface EntityRoutesDeps {
+  entityStore: IEntityStore
+  registry: WorkspaceRegistry
+}
+
+export function createEntityRoutes(deps: EntityRoutesDeps) {
+  const app = new Hono()
+
+  app.get('/', async (c) => {
+    const [entities, backlinks] = await Promise.all([
+      deps.entityStore.list(),
+      scanBacklinks(deps.registry),
+    ])
+    const items = entities.map((e) => ({
+      ...e,
+      backlinkCount: backlinks.get(e.name.toLowerCase())?.length ?? 0,
+    }))
+    return c.json({ entities: items })
+  })
+
+  app.get('/:name', async (c) => {
+    const entity = await deps.entityStore.get(c.req.param('name'))
+    if (!entity) return c.json({ error: 'not_found' }, 404)
+    const backlinks = await scanBacklinks(deps.registry)
+    return c.json({ entity, backlinks: backlinks.get(entity.name.toLowerCase()) ?? [] })
+  })
+
+  return app
+}

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -36,6 +36,20 @@ file(s) you produced plus a short note on what it is and why it matters.
 Don't make them come looking in the workspace; surface the result. (One-way
 for now — they read the inbox; they don't reply through it.)
 
+## Tracking assets & topics worth following
+
+When you surface something the user will want to keep an eye on over time — a
+ticker you're watching, a theme that ties several together — register it with
+`entity_upsert` (an `asset` is a tradable instrument, named by its ticker; a
+`topic` is a theme that groups them). Then, in the notes you write, link to it
+with `[[name]]` — e.g. `[[vst]]`, `[[ai-data-center-power]]`.
+
+Those links are the index: the user's Tracked tab gathers every note that
+references `[[name]]`, so a week later they can open `[[vst]]` and see its whole
+story across your files without re-reading them. Before creating one, call
+`entity_search` to reuse an existing name instead of fragmenting it (`[[vst]]`
+vs `[[vistra]]`).
+
 Otherwise, use this workspace however you like. The CWD is its own git
 repo (commits stay local), and any files you create or edit are scoped
 to this workspace.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,7 +17,7 @@ import { getFocusedTab } from './tabs/types'
  * Each maps to one or more tab kinds via tabs/registry.ts (defaultSpecForActivity).
  */
 export type Page =
-  | 'chat' | 'inbox' | 'workspaces' | 'portfolio' | 'news' | 'automation' | 'market'
+  | 'chat' | 'inbox' | 'tracked' | 'workspaces' | 'portfolio' | 'news' | 'automation' | 'market'
   | 'trading-as-git'
   | 'settings' | 'dev'
 

--- a/ui/src/api/entities.ts
+++ b/ui/src/api/entities.ts
@@ -1,0 +1,36 @@
+import { fetchJson } from './client'
+
+export type EntityType = 'asset' | 'topic'
+
+export interface Entity {
+  name: string
+  description: string
+  type: EntityType
+  createdAt: number
+}
+
+export interface EntityListItem extends Entity {
+  /** How many notes reference this entity via `[[name]]`. */
+  backlinkCount: number
+}
+
+export interface Backlink {
+  workspaceId: string
+  workspaceTag: string
+  /** Path of the note, relative to the workspace root. */
+  path: string
+}
+
+export interface EntityDetail {
+  entity: Entity
+  backlinks: Backlink[]
+}
+
+export const entitiesApi = {
+  async list(): Promise<{ entities: EntityListItem[] }> {
+    return fetchJson('/api/entities')
+  },
+  async get(name: string): Promise<EntityDetail> {
+    return fetchJson(`/api/entities/${encodeURIComponent(name)}`)
+  },
+}

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -15,6 +15,7 @@ import { newsApi } from './news'
 import { topologyApi } from './topology'
 import { marketApi } from './market'
 import { inboxApi } from './inbox'
+import { entitiesApi } from './entities'
 import { versionApi } from './version'
 export const api = {
   config: configApi,
@@ -30,6 +31,7 @@ export const api = {
   topology: topologyApi,
   market: marketApi,
   inbox: inboxApi,
+  entities: entitiesApi,
   version: versionApi,
 }
 

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import { type LucideIcon, MessageSquare, Inbox, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Info } from 'lucide-react'
+import { type LucideIcon, MessageSquare, Inbox, Telescope, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Info } from 'lucide-react'
 import { useState } from 'react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
@@ -14,6 +14,7 @@ function activitySectionFor(page: Page): ActivitySection {
   switch (page) {
     case 'chat':                 return 'chat'
     case 'inbox':                return 'inbox'
+    case 'tracked':              return 'tracked'
     case 'workspaces':           return 'workspaces'
     case 'trading-as-git':       return 'trading-as-git'
     case 'settings':             return 'settings'
@@ -91,6 +92,7 @@ const NAV_SECTIONS: NavSection[] = [
     sectionLabel: '',
     items: [
       { page: 'inbox',      label: 'Inbox',      icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
+      { page: 'tracked',    label: 'Tracked',    icon: Telescope, defaultTab: { kind: 'tracked', params: {} } },
       { page: 'chat',       label: 'Chat',       icon: MessageSquare },
       { page: 'workspaces', label: 'Workspaces', icon: TerminalSquare },
       { page: 'market',     label: 'Market',     icon: BarChart3 },

--- a/ui/src/components/TrackedSidebar.tsx
+++ b/ui/src/components/TrackedSidebar.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react'
+import { TrendingUp, Hash } from 'lucide-react'
+import { entitiesLive } from '../live/entities'
+import { useTrackedSelection } from '../live/tracked-selection'
+
+/**
+ * Tracked sidebar — the watchlist. A flat list of entities (assets + topics),
+ * newest-first, each row showing a type glyph, the kebab name, and how many
+ * notes link to it. Selection lives in `useTrackedSelection` so it survives
+ * remounts and is read by TrackedPage in the editor area.
+ */
+export function TrackedSidebar() {
+  const entities = entitiesLive.useStore((s) => s.entities)
+  const loading = entitiesLive.useStore((s) => s.loading)
+  const selected = useTrackedSelection((s) => s.selectedName)
+  const select = useTrackedSelection((s) => s.select)
+
+  // Default-select the first entity once, on first non-empty load. Latch so
+  // the user's later picks are never overridden.
+  const everSelectedRef = useRef(false)
+  useEffect(() => {
+    if (everSelectedRef.current) return
+    if (entities.length === 0) return
+    if (!selected) select(entities[0]!.name)
+    everSelectedRef.current = true
+  }, [entities, selected, select])
+
+  if (loading && entities.length === 0) {
+    return <div className="px-3 py-3 text-[12px] text-text-muted">Loading…</div>
+  }
+
+  if (entities.length === 0) {
+    return (
+      <div className="px-3 py-4 text-[12px] text-text-muted/70 leading-relaxed">
+        Nothing tracked yet.
+        <div className="mt-1 text-text-muted/50">
+          Agents register assets &amp; topics with the{' '}
+          <code className="text-[11px]">entity_upsert</code> tool, then link to them with{' '}
+          <code className="text-[11px]">[[name]]</code> in their notes.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto py-0.5">
+      {entities.map((e) => {
+        const active = e.name === selected
+        const Icon = e.type === 'asset' ? TrendingUp : Hash
+        return (
+          <button
+            key={e.name}
+            type="button"
+            onClick={() => select(e.name)}
+            title={e.description}
+            className={`group relative flex items-center gap-2 px-3 py-1.5 text-left transition-colors ${
+              active ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
+            }`}
+          >
+            {active && <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />}
+            <Icon size={13} strokeWidth={1.75} className="shrink-0 text-text-muted/70" aria-hidden />
+            <span className="flex-1 truncate font-mono text-[12px]">{e.name}</span>
+            {e.backlinkCount > 0 && (
+              <span
+                className="shrink-0 text-[10px] text-text-muted/60 tabular-nums"
+                title={`${e.backlinkCount} notes link here`}
+              >
+                {e.backlinkCount}
+              </span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/src/demo/fixtures/entities.ts
+++ b/ui/src/demo/fixtures/entities.ts
@@ -1,0 +1,60 @@
+import type { EntityListItem, EntityDetail } from '../../api/entities'
+
+/**
+ * Demo tracked-entities — mirrors the real chat-jun3 power / AI-infra graph
+ * so the marketing demo shows the actual shape: a few assets + the theme that
+ * ties them together, each referenced across the dated rotation notes.
+ */
+export const demoEntities: EntityListItem[] = [
+  {
+    name: 'vst',
+    type: 'asset',
+    description: 'Vistra — Texas independent power producer, a primary play on AI datacenter electricity demand.',
+    createdAt: 1_717_300_000_000,
+    backlinkCount: 3,
+  },
+  {
+    name: 'vrt',
+    type: 'asset',
+    description: 'Vertiv — datacenter power & liquid cooling; the cleanest "AI-infra electricity" expression.',
+    createdAt: 1_717_250_000_000,
+    backlinkCount: 2,
+  },
+  {
+    name: 'ai-data-center-power',
+    type: 'topic',
+    description:
+      'The through-line: AI datacenter electricity demand connecting power utilities, AI-infra, and electrical picks-and-shovels.',
+    createdAt: 1_717_100_000_000,
+    backlinkCount: 4,
+  },
+]
+
+const ws = { workspaceId: 'demo-ws-1', workspaceTag: 'chat-jun3' }
+
+export const demoEntityDetail: Record<string, EntityDetail> = {
+  vst: {
+    entity: demoEntities[0]!,
+    backlinks: [
+      { ...ws, path: 'power_buy_points_2026-06-02.md' },
+      { ...ws, path: 'rotation/2026-06-02.md' },
+      { ...ws, path: 'rotation/ai-chain-2026-06-02.md' },
+    ],
+  },
+  vrt: {
+    entity: demoEntities[1]!,
+    backlinks: [
+      { ...ws, path: 'rotation/ai-chain-2026-06-02.md' },
+      { ...ws, path: 'rotation/missed-rightside-2026-06-02.md' },
+    ],
+  },
+  'ai-data-center-power': {
+    entity: demoEntities[2]!,
+    backlinks: [
+      { ...ws, path: 'power_buy_points_2026-06-02.md' },
+      { ...ws, path: 'rotation/2026-06-02.md' },
+      { ...ws, path: 'rotation/ai-chain-2026-06-02.md' },
+      { ...ws, path: 'rotation/missed-rightside-2026-06-02.md' },
+    ],
+  },
+}

--- a/ui/src/demo/handlers/entities.ts
+++ b/ui/src/demo/handlers/entities.ts
@@ -1,0 +1,11 @@
+import { http, HttpResponse } from 'msw'
+import { demoEntities, demoEntityDetail } from '../fixtures/entities'
+
+export const entitiesHandlers = [
+  http.get('/api/entities', () => HttpResponse.json({ entities: demoEntities })),
+  http.get('/api/entities/:name', ({ params }) => {
+    const detail = demoEntityDetail[String(params['name']).toLowerCase()]
+    if (!detail) return HttpResponse.json({ error: 'not_found' }, { status: 404 })
+    return HttpResponse.json(detail)
+  }),
+]

--- a/ui/src/demo/handlers/index.ts
+++ b/ui/src/demo/handlers/index.ts
@@ -3,6 +3,7 @@ import { tradingHandlers } from './trading'
 import { workspacesHandlers } from './workspaces'
 import { eventsHandlers } from './events'
 import { inboxHandlers } from './inbox'
+import { entitiesHandlers } from './entities'
 import { personaHeartbeatHandlers } from './personaHeartbeat'
 import { cronHandlers } from './cron'
 import { toolsSimulatorHandlers } from './toolsSimulator'
@@ -22,6 +23,7 @@ export const handlers = [
   ...workspacesHandlers,
   ...eventsHandlers,
   ...inboxHandlers,
+  ...entitiesHandlers,
   ...personaHeartbeatHandlers,
   ...cronHandlers,
   ...toolsSimulatorHandlers,

--- a/ui/src/live/entities.ts
+++ b/ui/src/live/entities.ts
@@ -1,0 +1,54 @@
+import { api } from '../api'
+import type { EntityListItem } from '../api/entities'
+import { createLiveStore } from './createLiveStore'
+
+/**
+ * Live tracked-entity feed. 20s polling against `/api/entities`. Same
+ * rationale as the inbox live store — a passive, low-frequency feed where
+ * SSE isn't worth the kept-open connection. One shared timer via the
+ * LiveStore refcount; sidebar + page subscribe to the same store.
+ */
+
+export interface EntitiesState {
+  entities: EntityListItem[]
+  /** True until the initial list fetch resolves. */
+  loading: boolean
+}
+
+const POLL_INTERVAL_MS = 20_000
+
+let triggerRefresh: (() => void) | null = null
+
+export const entitiesLive = createLiveStore<EntitiesState>({
+  name: 'entities',
+  initialState: { entities: [], loading: true },
+  subscribe: ({ apply }) => {
+    let disposed = false
+
+    async function refresh() {
+      try {
+        const { entities } = await api.entities.list()
+        if (disposed) return
+        apply((prev) => ({ ...prev, entities, loading: false }))
+      } catch {
+        if (disposed) return
+        apply((prev) => ({ ...prev, loading: false }))
+      }
+    }
+
+    triggerRefresh = refresh
+    void refresh()
+    const intervalId = setInterval(refresh, POLL_INTERVAL_MS)
+
+    return () => {
+      disposed = true
+      clearInterval(intervalId)
+      triggerRefresh = null
+    }
+  },
+})
+
+/** Force an immediate refresh from /api/entities. */
+export function refreshEntities(): void {
+  triggerRefresh?.()
+}

--- a/ui/src/live/tracked-selection.ts
+++ b/ui/src/live/tracked-selection.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+
+/**
+ * Client-side selection state for the Tracked tab. Lives outside `ViewSpec`
+ * so picking a different entity from the sidebar doesn't churn tab identity
+ * (one Tracked tab, selection mutates inside it — same model as the Inbox).
+ *
+ * Not persisted: ephemeral UI state, no value across reloads.
+ */
+
+interface TrackedSelectionState {
+  selectedName: string | null
+}
+
+interface TrackedSelectionActions {
+  select: (name: string | null) => void
+}
+
+export const useTrackedSelection = create<TrackedSelectionState & TrackedSelectionActions>()(
+  (set) => ({
+    selectedName: null,
+    select: (name) => set({ selectedName: name }),
+  }),
+)

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react'
+import { TrendingUp, Hash, FileText } from 'lucide-react'
+import { PageHeader } from '../components/PageHeader'
+import { api } from '../api'
+import { entitiesLive } from '../live/entities'
+import { useTrackedSelection } from '../live/tracked-selection'
+import { useWorkspace } from '../tabs/store'
+import type { EntityDetail, Backlink } from '../api/entities'
+
+/**
+ * Tracked detail pane. Shows the selected entity's description (the
+ * disambiguation) plus its backlinks — the notes that reference it via
+ * `[[name]]`. That backlink list IS the "this thing across all my files"
+ * view the user wanted; clicking a note opens its workspace.
+ *
+ * Selection is owned by `useTrackedSelection` (the sidebar drives it). The
+ * list + counts come from the polling store; per-entity backlinks are
+ * fetched on selection.
+ */
+export function TrackedPage() {
+  const entities = entitiesLive.useStore((s) => s.entities)
+  const loading = entitiesLive.useStore((s) => s.loading)
+  const selectedName = useTrackedSelection((s) => s.selectedName)
+
+  const [detail, setDetail] = useState<EntityDetail | null>(null)
+  useEffect(() => {
+    if (!selectedName) {
+      setDetail(null)
+      return
+    }
+    let cancelled = false
+    setDetail(null)
+    api.entities
+      .get(selectedName)
+      .then((d) => {
+        if (!cancelled) setDetail(d)
+      })
+      .catch(() => {
+        if (!cancelled) setDetail(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedName])
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <PageHeader title="Tracked" description={`${entities.length} tracked · assets & topics`} />
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {loading && entities.length === 0 ? (
+          <div className="px-6 py-8 text-text-muted text-sm">Loading…</div>
+        ) : entities.length === 0 ? (
+          <EmptyState />
+        ) : !selectedName || !detail ? (
+          <div className="px-6 py-8 text-text-muted text-sm">Select an entity from the sidebar.</div>
+        ) : (
+          <Detail detail={detail} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="px-6 py-16 text-center max-w-[520px] mx-auto">
+      <div className="text-[15px] text-text mb-2">Nothing tracked yet</div>
+      <p className="text-[13px] text-text-muted leading-relaxed">
+        As an agent works, it registers the assets and topics worth following with the
+        <code className="mx-1 px-1 py-0.5 rounded bg-bg-tertiary text-[11px]">entity_upsert</code>
+        tool, and links to them from its notes with
+        <code className="mx-1 px-1 py-0.5 rounded bg-bg-tertiary text-[11px]">[[name]]</code>. They
+        show up here as a running watchlist — each with the notes that reference it.
+      </p>
+    </div>
+  )
+}
+
+function Detail({ detail }: { detail: EntityDetail }) {
+  const { entity, backlinks } = detail
+  const Icon = entity.type === 'asset' ? TrendingUp : Hash
+  return (
+    <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
+      <div className="flex items-center gap-2.5 mb-2">
+        <Icon size={20} strokeWidth={1.75} className="shrink-0 text-text-muted" aria-hidden />
+        <h2 className="text-[20px] font-semibold font-mono text-text">{entity.name}</h2>
+        <span className="text-[11px] px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted uppercase tracking-wide">
+          {entity.type}
+        </span>
+      </div>
+      <p className="text-[14px] text-text-muted leading-relaxed mb-6">{entity.description}</p>
+
+      <div className="text-[11px] font-medium text-text-muted/60 uppercase tracking-wider mb-3">
+        Referenced in {backlinks.length} {backlinks.length === 1 ? 'note' : 'notes'}
+      </div>
+      {backlinks.length === 0 ? (
+        <div className="text-[13px] text-text-muted/70 italic">
+          No notes link <span className="font-mono">[[{entity.name}]]</span> yet.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {backlinks.map((b, i) => (
+            <BacklinkRow key={`${b.workspaceId}:${b.path}:${i}`} backlink={b} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BacklinkRow({ backlink }: { backlink: Backlink }) {
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+  const setSidebar = useWorkspace((s) => s.setSidebar)
+  const open = () => {
+    setSidebar('workspaces')
+    openOrFocus({ kind: 'workspace', params: { wsId: backlink.workspaceId } })
+  }
+  return (
+    <button
+      type="button"
+      onClick={open}
+      title={`Open ${backlink.workspaceTag}`}
+      className="group flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-bg-tertiary/30 hover:bg-bg-tertiary hover:border-accent/40 transition-colors text-left"
+    >
+      <FileText
+        size={14}
+        strokeWidth={1.75}
+        className="shrink-0 text-text-muted/70 group-hover:text-accent transition-colors"
+        aria-hidden
+      />
+      <span className="flex-1 min-w-0 truncate font-mono text-[12px] text-text">{backlink.path}</span>
+      <span className="shrink-0 text-[11px] text-text-muted/60">{backlink.workspaceTag}</span>
+    </button>
+  )
+}

--- a/ui/src/sections.tsx
+++ b/ui/src/sections.tsx
@@ -22,6 +22,7 @@
 import type { ComponentType } from 'react'
 import { ChatChannelListContainer } from './components/ChatChannelListContainer'
 import { InboxSidebar } from './components/InboxSidebar'
+import { TrackedSidebar } from './components/TrackedSidebar'
 import { WorkspacesSidebar } from './components/workspace/WorkspacesSidebar'
 import { PushApprovalPanel } from './components/PushApprovalPanel'
 import { SettingsCategoryList } from './components/SettingsCategoryList'
@@ -52,6 +53,10 @@ const SECTION_BY_KEY: Record<ActivitySection, SidebarSection> = {
   inbox: {
     title: 'Inbox',
     Secondary: InboxSidebar,
+  },
+  tracked: {
+    title: 'Tracked',
+    Secondary: TrackedSidebar,
   },
   workspaces: {
     title: 'Workspaces',

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -64,6 +64,9 @@ export function UrlAdopter() {
         {/* Inbox (workspace-anchored, Linear-style) */}
         <Route path="/inbox" element={<AdoptStatic spec={{ kind: 'inbox', params: {} }} />} />
 
+        {/* Tracked (entity index) */}
+        <Route path="/tracked" element={<AdoptStatic spec={{ kind: 'tracked', params: {} }} />} />
+
         {/* Workspaces */}
         <Route path="/workspaces" element={<AdoptStatic spec={{ kind: 'workspace-list', params: {} }} />} />
         {/* Template catalog routes must come before /workspaces/:wsId so the
@@ -206,6 +209,7 @@ function SetSidebarOnly({ section }: { section: import('./types').ActivitySectio
 function specToSection(spec: ViewSpec): ActivitySection {
   switch (spec.kind) {
     case 'inbox':              return 'inbox'
+    case 'tracked':            return 'tracked'
     case 'workspace':
     case 'workspace-list':
     case 'template-catalog':

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -16,6 +16,7 @@ import { NewsCollectorPage } from '../pages/NewsCollectorPage'
 import { UTADetailPage } from '../pages/UTADetailPage'
 import { DevPage } from '../pages/DevPage'
 import { InboxPage } from '../pages/InboxPage'
+import { TrackedPage } from '../pages/TrackedPage'
 import { WorkspaceListPage } from '../pages/WorkspaceListPage'
 import { WorkspacePage } from '../pages/WorkspacePage'
 import { TemplateCatalogPage } from '../pages/TemplateCatalogPage'
@@ -160,6 +161,13 @@ const inboxModule: ViewModule<'inbox'> = {
   Component: InboxPage,
 }
 
+const trackedModule: ViewModule<'tracked'> = {
+  kind: 'tracked',
+  title: () => 'Tracked',
+  toUrl: () => '/tracked',
+  Component: () => <TrackedPage />,
+}
+
 const workspaceListModule: ViewModule<'workspace-list'> = {
   kind: 'workspace-list',
   title: () => 'Workspaces',
@@ -212,6 +220,7 @@ export const VIEWS = {
   'uta-detail': utaDetailModule,
   dev: devModule,
   inbox: inboxModule,
+  tracked: trackedModule,
   'workspace-list': workspaceListModule,
   workspace: workspaceModule,
   'template-catalog': templateCatalogModule,

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -27,6 +27,7 @@ export type ViewSpec =
   | { kind: 'uta-detail';     params: { id: string } }
   | { kind: 'dev';            params: { tab: 'tools' | 'snapshots' | 'logs' | 'simulator' } }
   | { kind: 'inbox';               params: Record<string, never> }
+  | { kind: 'tracked';             params: Record<string, never> }
 
 export type ViewKind = ViewSpec['kind']
 
@@ -43,6 +44,7 @@ export type ViewKind = ViewSpec['kind']
 export type ActivitySection =
   | 'chat'
   | 'inbox'
+  | 'tracked'
   | 'workspaces'
   | 'trading-as-git'
   | 'settings'


### PR DESCRIPTION
## Summary
A new **entity index** — an Obsidian-style `[[name]]` layer over the markdown agents produce, so the user stops forgetting what's being tracked across dated notes.

- **Agent side (MCP):** `entity_upsert` registers a tracked thing (an `asset` named by its ticker, or a `topic` that groups several); `entity_search` lets the agent reuse an existing name before creating, to avoid fragmenting (`[[vst]]` vs `[[vistra]]`). The agent then writes `[[name]]` in its notes. Both are workspace-scoped (wsId closed over by the factory, never trafficked) and **MCP-only** (not on the `alice` CLI), mirroring `inbox_push`.
- **User side:** a new **Tracked** tab (peer to Inbox) — the watchlist of every entity, and a detail pane showing each one's description plus its **backlinks** (the notes that reference it via `[[name]]`). That backlink list is the "this thing across all my files" view.
- **Design:** minimal 4-field schema `{name, description, type, createdAt}`. Relations and the index live as authored `[[name]]` links in the notes, **never extracted** — backlinks are a mechanical gather of links the agent already wrote, not inference. The store is a global file-backed JSONL spine (`data/entities/`), sibling of `InboxStore`; backlinks are scanned on demand.
- **Pure-additive:** new store / tools / route / tab + additive wiring (a threaded param, a registry entry). No existing behavior changed. The chat workspace instruction gains a short nudge to use the tools (like the existing `inbox_push` nudge).

## Test plan
- [x] `tsc --noEmit` (Alice) + `tsc -b` (UI) clean
- [x] `vitest` node + ui projects green (1752); new `entity-store.spec` (17) + `entity-backlinks.spec` (2)
- [x] manual: an agent in a live chat workspace created entities + `[[name]]` links; the Tracked tab listed them and their backlinks resolved back to the right notes; `entity_search` returned them from a second workspace
- [ ] follow-up (not in this PR): UI/UX polish; Phase 3 — `[[name]]` clickable rendering in the shared `MarkdownContent`; optional asset price/RSI enrichment

## Boundary touch
None. No trading / auth / broker / migration surface — a new file-backed store, two MCP tools, a read-only route, and UI. No migration needed (the store is created on first write; nothing transforms existing user data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
