### PR TITLE
fix(entities): recover self-describing asset naming dropped from #258 merge

### DIFF
--- a/src/tool/entity-search.ts
+++ b/src/tool/entity-search.ts
@@ -22,7 +22,7 @@ export const entitySearchFactory: WorkspaceToolFactory = {
       description: [
         "Search the user's tracked entities by name or description.",
         'Call this before creating a new entity, to reuse an existing name and avoid duplicates',
-        '(write `[[vst]]` consistently rather than also inventing `[[vistra]]`).',
+        '(write `[[stock-vst]]` consistently rather than also inventing `[[vst]]`).',
         'Pass an empty query to list everything currently tracked.',
       ].join(' '),
       inputSchema: z.object({

--- a/src/tool/entity-upsert.ts
+++ b/src/tool/entity-upsert.ts
@@ -31,22 +31,24 @@ export const entityUpsertFactory: WorkspaceToolFactory = {
         'can later open the entity and see every file that references it.',
         '',
         'Fields:',
-        '- name: short, NO spaces, kebab-case. It is both the key and the `[[name]]` you write in prose,',
-        '  so keep it terse and reuse it exactly. For an `asset` use the ticker (e.g. "vst") so the app',
-        '  can pull live quotes; for a `topic` use a short phrase (e.g. "ai-data-center-power").',
-        '- description: one line — what this is. The short name is ambiguous alone; this disambiguates it',
-        '  (e.g. name "vst" -> "Vistra, Texas independent power producer driven by AI datacenter demand").',
+        '- name: short, NO spaces, kebab-case, and SELF-DESCRIBING — a bare ticker like "ccj" is opaque',
+        '  to anyone who is not a trader (and to you, weeks later). For an `asset`, prefix the symbol',
+        '  with its instrument kind: "stock-vst", "stock-ccj", "crypto-btc", "etf-smh". For a `topic`,',
+        '  a short phrase: "ai-data-center-power". The name is both the key and the `[[name]]` you write',
+        '  in prose, so keep it terse and reuse it exactly.',
+        '- description: one line — the full identity the terse name leaves out (e.g. name "stock-vst" ->',
+        '  "Vistra, Texas independent power producer driven by AI datacenter electricity demand").',
         '- type: "asset" (a tradable instrument — has a ticker) or "topic" (a theme grouping assets).',
         '',
         'Before creating, prefer reusing an existing name: call entity_search first so you write',
-        '`[[vst]]` consistently instead of fragmenting into both `[[vst]]` and `[[vistra]]`.',
+        '`[[stock-vst]]` consistently instead of fragmenting it (e.g. also inventing `[[vst]]`).',
       ].join('\n'),
       inputSchema: z.object({
         name: z
           .string()
           .min(1)
           .describe(
-            'Short kebab/ticker key, no spaces. The `[[name]]` link target. e.g. "vst" or "ai-data-center-power".',
+            'Self-describing, kebab, no spaces. The `[[name]]` link target. Asset = kind-prefixed symbol ("stock-vst", "crypto-btc"); topic = a phrase ("ai-data-center-power").',
           ),
         type: z
           .enum(['asset', 'topic'])

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -40,15 +40,16 @@ for now — they read the inbox; they don't reply through it.)
 
 When you surface something the user will want to keep an eye on over time — a
 ticker you're watching, a theme that ties several together — register it with
-`entity_upsert` (an `asset` is a tradable instrument, named by its ticker; a
-`topic` is a theme that groups them). Then, in the notes you write, link to it
-with `[[name]]` — e.g. `[[vst]]`, `[[ai-data-center-power]]`.
+`entity_upsert`. Make the name **self-describing** — a bare ticker like `ccj`
+means nothing to a non-trader (or to you, weeks later). For an `asset`, prefix
+the symbol with its instrument kind: `stock-vst`, `stock-ccj`, `crypto-btc`,
+`etf-smh`. For a `topic`, a short phrase: `ai-data-center-power`. Then link to it
+in your notes with `[[name]]` — e.g. `[[stock-vst]]`, `[[ai-data-center-power]]`.
 
 Those links are the index: the user's Tracked tab gathers every note that
-references `[[name]]`, so a week later they can open `[[vst]]` and see its whole
-story across your files without re-reading them. Before creating one, call
-`entity_search` to reuse an existing name instead of fragmenting it (`[[vst]]`
-vs `[[vistra]]`).
+references `[[name]]`, so a week later they can open `[[stock-vst]]` and see its
+whole story across your files without re-reading them. Before creating one, call
+`entity_search` to reuse an existing name instead of fragmenting it.
 
 Otherwise, use this workspace however you like. The CWD is its own git
 repo (commits stay local), and any files you create or edit are scoped

--- a/ui/src/demo/fixtures/entities.ts
+++ b/ui/src/demo/fixtures/entities.ts
@@ -7,14 +7,14 @@ import type { EntityListItem, EntityDetail } from '../../api/entities'
  */
 export const demoEntities: EntityListItem[] = [
   {
-    name: 'vst',
+    name: 'stock-vst',
     type: 'asset',
     description: 'Vistra — Texas independent power producer, a primary play on AI datacenter electricity demand.',
     createdAt: 1_717_300_000_000,
     backlinkCount: 3,
   },
   {
-    name: 'vrt',
+    name: 'stock-vrt',
     type: 'asset',
     description: 'Vertiv — datacenter power & liquid cooling; the cleanest "AI-infra electricity" expression.',
     createdAt: 1_717_250_000_000,
@@ -33,7 +33,7 @@ export const demoEntities: EntityListItem[] = [
 const ws = { workspaceId: 'demo-ws-1', workspaceTag: 'chat-jun3' }
 
 export const demoEntityDetail: Record<string, EntityDetail> = {
-  vst: {
+  'stock-vst': {
     entity: demoEntities[0]!,
     backlinks: [
       { ...ws, path: 'power_buy_points_2026-06-02.md' },
@@ -41,7 +41,7 @@ export const demoEntityDetail: Record<string, EntityDetail> = {
       { ...ws, path: 'rotation/ai-chain-2026-06-02.md' },
     ],
   },
-  vrt: {
+  'stock-vrt': {
     entity: demoEntities[1]!,
     backlinks: [
       { ...ws, path: 'rotation/ai-chain-2026-06-02.md' },


### PR DESCRIPTION
## Summary
Recovers the self-describing asset-naming convention that was authored for the entity index but **dropped from PR #258's merge**. The PR head lagged behind a late push, so the merge landed at the prior commit (`3898669`) — the same GitHub stale-head behavior that bit #257. Master currently ships the entity index with bare tickers (`vst`); this restores the intended convention.

- `asset` names are **kind-prefixed**: `stock-vst`, `crypto-ccj`→`crypto-btc`, `etf-smh`. A bare ticker is opaque to a non-trader (and to the model). `topic` names stay descriptive phrases (`ai-data-center-power`).
- Taught, not enforced (minimal schema): updated consistently in the `entity_upsert` + `entity_search` tool descriptions, the chat workspace instruction, and the demo fixtures, so they can't conflict.

Mechanically this is commit `10fe5ae` cherry-picked onto current master — clean, since its parent (`3898669`) is already in master.

## Test plan
- [x] `tsc --noEmit` (Alice) + `tsc -b` (UI) clean
- [x] golden injection test was green when authored

## Boundary touch
None — tool descriptions + one instruction file + demo fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
