### PR TITLE
fix(workspace): inject workspace-scoped MCP server into codex sessions

### DIFF
--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -71,6 +71,47 @@ describe('claudeAdapter AI-config', () => {
 });
 
 describe('codexAdapter AI-config', () => {
+  it('injects both global and workspace MCP servers into fresh commands', () => {
+    expect(codexAdapter.composeCommand(['ignored'], {
+      cwd: dir,
+      env: {
+        OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp',
+        AQ_WS_ID: 'ws-abc',
+      },
+    })).toEqual([
+      'codex',
+      '-c',
+      'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
+      '-c',
+      'mcp_servers."openalice-workspace".url="http://127.0.0.1:47332/mcp/ws-abc"',
+    ]);
+  });
+
+  it('preserves both MCP servers when resuming codex sessions', () => {
+    const env = {
+      OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp',
+      AQ_WS_ID: 'ws-abc',
+    };
+    expect(codexAdapter.composeCommand([], { cwd: dir, env, resume: 'last' })).toEqual([
+      'codex',
+      '-c',
+      'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
+      '-c',
+      'mcp_servers."openalice-workspace".url="http://127.0.0.1:47332/mcp/ws-abc"',
+      'resume',
+      '--last',
+    ]);
+    expect(codexAdapter.composeCommand([], { cwd: dir, env, resume: { sessionId: 'rollout-id' } })).toEqual([
+      'codex',
+      '-c',
+      'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
+      '-c',
+      'mcp_servers."openalice-workspace".url="http://127.0.0.1:47332/mcp/ws-abc"',
+      'resume',
+      'rollout-id',
+    ]);
+  });
+
   it('writes full provider config byte-exact (config.toml + env.json)', async () => {
     await codexAdapter.writeAiConfig!(dir, {
       baseUrl: 'https://oai.test/v1', apiKey: 'sk-c', model: 'gpt-x', wireApi: 'responses',

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -36,9 +36,9 @@ const CODEX_PROVIDER_NAME = 'workspace';
  *      Adapter doesn't set `CODEX_HOME`. Codex reads the user's global
  *      `~/.codex/auth.json` + `~/.codex/config.toml` — exactly what a
  *      vanilla `codex` invocation in any project does. The OpenAlice MCP
- *      server is wired via the per-invocation `-c mcp_servers.openalice.url=...`
- *      flag in `composeCommand` below, so MCP is visible without
- *      polluting the user's global config.
+ *      servers are wired via per-invocation `-c mcp_servers...url=...`
+ *      flags in `composeCommand` below, so MCP is visible without polluting
+ *      the user's global config.
  *
  *   2. **Override (user-configured via OpenAlice UI).** Workspace has its
  *      own `.codex/{config.toml, env.json[, auth.json]}`. Adapter sets
@@ -63,8 +63,9 @@ export const codexAdapter: CliAdapter = {
   },
 
   /**
-   * Always prepends `-c mcp_servers.openalice.url="..."` so OpenAlice MCP
-   * is visible per-spawn without writing to `~/.codex/config.toml`. The
+   * Always prepends `-c mcp_servers.openalice.url="..."` and the workspace
+   * scoped `openalice-workspace` server so OpenAlice MCP is visible
+   * per-spawn without writing to `~/.codex/config.toml`. The
    * flag overrides any same-key entry in the read config.toml (verified
    * empirically), and adds a new key when none exists — safe in both
    * default and override modes.
@@ -81,7 +82,17 @@ export const codexAdapter: CliAdapter = {
     if (!mcpUrl) {
       throw new Error('codex adapter: OPENALICE_MCP_URL missing from spawn env');
     }
-    const head = ['codex', '-c', `mcp_servers.openalice.url="${mcpUrl}"`];
+    const workspaceId = ctx.env['AQ_WS_ID'];
+    if (!workspaceId) {
+      throw new Error('codex adapter: AQ_WS_ID missing from spawn env');
+    }
+    const head = [
+      'codex',
+      '-c',
+      `mcp_servers.openalice.url="${mcpUrl}"`,
+      '-c',
+      `mcp_servers."openalice-workspace".url="${mcpUrl}/${workspaceId}"`,
+    ];
     if (ctx.resume === undefined) return head;
     if (ctx.resume === 'last') return [...head, 'resume', '--last'];
     return [...head, 'resume', ctx.resume.sessionId];
@@ -104,8 +115,8 @@ export const codexAdapter: CliAdapter = {
     }
 
     // Provider override. config.toml carries only model / model_provider /
-    // [model_providers.*] — the OpenAlice MCP server entry is wired per-spawn
-    // via this adapter's `-c mcp_servers.openalice.url=...` flag, so we
+    // [model_providers.*] — the OpenAlice MCP server entries are wired per-spawn
+    // via this adapter's `-c mcp_servers...url=...` flags, so we
     // don't repeat it here.
     let toml = '';
     if (cred.model) toml += `model = ${tomlString(cred.model)}\n`;


### PR DESCRIPTION
## Summary
- Codex workspace sessions were only getting the **global** OpenAlice MCP server (`mcp_servers.openalice` → `/mcp`) injected. The **workspace-scoped** `openalice-workspace` server (the `/mcp/:wsId` surface that exposes per-workspace tools — `inbox_push`, `entity_upsert`, `entity_search`) was never wired into codex, so codex-backed agents silently couldn't reach any workspace-scoped tool. The claude path already had it (written into `.mcp.json` by `context-injector.ts`); only codex was missing it.
- `codex.ts composeCommand` now also prepends `-c mcp_servers."openalice-workspace".url="${mcpUrl}/${AQ_WS_ID}"`, reusing the exact canonical server name the claude side uses, and guards on `AQ_WS_ID` the same way it already guards `OPENALICE_MCP_URL`.
- Added codex `composeCommand` specs covering both the fresh-spawn and resume (`--last` + explicit sessionId) paths, asserting both servers land in the right order.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 96 files / 1754 tests pass (incl. 2 new codex injection specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
