### PR TITLE
fix(guardian): make Windows `pnpm dev` work end-to-end (spawn + flag watcher + tree-kill) — verified by CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,33 @@ jobs:
       - run: pnpm build
 
       - run: pnpm test
+
+  # Boots the real `pnpm dev` stack and asserts UTA/Alice/Vite all spawn.
+  # Exists to catch cross-platform spawn regressions (e.g. `spawn tsx ENOENT`
+  # on Windows) that `pnpm test` can't see — esbuild transpiles, it never
+  # spawns the children. Runs on Windows (the at-risk OS) plus Ubuntu as a
+  # control: if Windows goes red while Ubuntu stays green, it's a real platform
+  # diff, not a harness bug. See scripts/guardian/smoke.ts.
+  dev-smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # Skip the Electron desktop shell — the smoke only needs UTA/Alice/UI,
+      # and this avoids a large electron download on the Windows runner.
+      - run: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'
+
+      - run: pnpm test:smoke
+        timeout-minutes: 8

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:bbProvider": "vitest run --config vitest.bbProvider.config.ts",
+    "test:smoke": "tsx scripts/guardian/smoke.ts",
     "postinstall": "node scripts/fix-pty-perms.mjs"
   },
   "keywords": [

--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -18,7 +18,7 @@
  * SIGTERMs + respawns UTA without restarting Alice.
  */
 
-import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process'
+import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { watch, mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
@@ -71,6 +71,27 @@ export function spawnChild(spec: SpawnSpec): ChildProcess {
     child.stderr?.on('data', (buf: Buffer) => writePrefixed(process.stderr, buf, tag))
   }
   return child
+}
+
+/**
+ * Kill a child *and its descendants*, cross-platform.
+ *
+ * On Windows the dev children spawn through a shell (see spawnChild), so the
+ * ChildProcess handle points at the `cmd.exe` wrapper — `child.kill()` reaps
+ * the wrapper but orphans the real `node`/`tsx` grandchild, which keeps
+ * holding its port. That breaks UTA restart (the fresh UTA can't bind the
+ * still-occupied port) and leaves zombies on shutdown. `taskkill /T` walks
+ * the whole process tree; `/F` is the only reliable kill for a detached
+ * console child. POSIX has no wrapper, so a direct signal is correct and
+ * keeps graceful SIGTERM (which taskkill /F can't offer anyway).
+ */
+export function killTree(child: ChildProcess, signal: NodeJS.Signals = 'SIGTERM'): void {
+  if (child.pid == null) return
+  if (process.platform === 'win32') {
+    try { spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F']) } catch { /* already gone */ }
+  } else {
+    try { child.kill(signal) } catch { /* already gone */ }
+  }
 }
 
 function writePrefixed(stream: NodeJS.WriteStream, buf: Buffer, tag: string): void {
@@ -144,13 +165,13 @@ export function installCascadeShutdown(opts: CascadeOpts): CascadeControl {
     stopping = true
     for (const c of children) {
       if (c.exitCode === null && !c.killed) {
-        try { c.kill('SIGTERM') } catch { /* noop */ }
+        killTree(c, 'SIGTERM')
       }
     }
     setTimeout(() => {
       for (const c of children) {
         if (c.exitCode === null && !c.killed) {
-          try { c.kill('SIGKILL') } catch { /* noop */ }
+          killTree(c, 'SIGKILL')
         }
       }
       process.exit(0)
@@ -234,10 +255,10 @@ export class UTAController {
       const old = this.child
       this.cascade?.expectExit(old)
       const exited = new Promise<void>((resolve) => old.once('exit', () => resolve()))
-      try { old.kill('SIGTERM') } catch { /* noop */ }
+      killTree(old, 'SIGTERM')
       await Promise.race([exited, sleep(8_000)])
       if (old.exitCode === null) {
-        try { old.kill('SIGKILL') } catch { /* noop */ }
+        killTree(old, 'SIGKILL')
         await exited
       }
 

--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -21,7 +21,7 @@
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { watch, mkdir } from 'node:fs/promises'
-import { dirname } from 'node:path'
+import { dirname, basename } from 'node:path'
 import { probeFreePort } from '../probe-port.js'
 
 export interface GuardianPorts {
@@ -326,9 +326,4 @@ export async function startFlagWatcher(opts: FlagWatchOpts): Promise<() => void>
   })().catch(() => { /* swallow — already logged */ })
 
   return () => abort.abort()
-}
-
-function basename(p: string): string {
-  const i = p.lastIndexOf('/')
-  return i >= 0 ? p.slice(i + 1) : p
 }

--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -57,6 +57,12 @@ export function spawnChild(spec: SpawnSpec): ChildProcess {
   const child = spawn(spec.command, spec.args, {
     env: spec.env,
     stdio: spec.prefixLogs ? ['inherit', 'pipe', 'pipe'] : 'inherit',
+    // On Windows the dev commands (`tsx`, `pnpm`) are `.cmd` shims in
+    // node_modules/.bin. Node's spawn won't apply PATHEXT resolution to find
+    // them without a shell, so a bare `spawn('tsx', …)` throws ENOENT. POSIX
+    // resolves the bin dir directly, so keep shell off there. Args here have
+    // no spaces, so shell quoting isn't a concern.
+    shell: process.platform === 'win32',
   } satisfies SpawnOptions)
 
   if (spec.prefixLogs) {

--- a/scripts/guardian/smoke.ts
+++ b/scripts/guardian/smoke.ts
@@ -202,22 +202,23 @@ async function main(): Promise<void> {
     console.log('✓ UTA restarted cleanly (startedAt changed)')
     summary(`✅ UTA restart on ${process.platform}: clean re-spawn.`)
   } else {
-    console.warn('⚠️  UTA did NOT re-spawn within timeout after restart flag — likely an orphaned old UTA holding the port (Windows shell-wrapper kill). This is the known option-A gap; trigger for tree-kill / option B.')
-    summary(`⚠️ UTA restart on ${process.platform}: did not re-spawn (suspected orphan holding port).`)
+    console.warn('⚠️  UTA did NOT re-spawn within timeout after the restart flag. Either the flag watcher never fired or the old UTA was not reaped (port still held). This is the broker-config restart path — see scripts/guardian/shared.ts startFlagWatcher + UTAController.restart.')
+    summary(`⚠️ UTA restart on ${process.platform}: did not re-spawn — broker-config restart path is broken.`)
   }
 
   // ── SOFT: teardown orphan check ───────────────────────────
-  // Ask Guardian to shut down, then see whether the ports actually freed.
-  // A lingering bound port after shutdown == orphaned grandchild process.
+  // Tree-kill the whole stack, then check the ports actually freed. A port
+  // still bound after a tree-kill means a process escaped the tree (e.g. a
+  // shell-wrapped grandchild detached from its wrapper on Windows).
   console.log('\n— teardown orphan check —')
-  try { child.kill() } catch { /* noop */ }
-  await sleep(6_000)
+  forceCleanup()
+  await sleep(5_000)
   const stillUta = await portBound(utaPort)
   const stillWeb = await portBound(webPort)
   if (stillUta || stillWeb) {
     const which = [stillUta && `UTA:${utaPort}`, stillWeb && `Alice:${webPort}`].filter(Boolean).join(', ')
-    console.warn(`⚠️  Ports still bound after shutdown (orphan processes): ${which}`)
-    summary(`⚠️ Teardown orphans on ${process.platform}: ${which} still bound.`)
+    console.warn(`⚠️  Ports still bound after tree-kill (a process escaped the tree): ${which}`)
+    summary(`⚠️ Teardown on ${process.platform}: ${which} still bound after tree-kill.`)
   } else {
     console.log('✓ Clean teardown — no orphaned ports')
     summary(`✅ Teardown on ${process.platform}: clean, no orphans.`)

--- a/scripts/guardian/smoke.ts
+++ b/scripts/guardian/smoke.ts
@@ -1,0 +1,224 @@
+/**
+ * Guardian dev smoke test.
+ *
+ * Boots the full `pnpm dev` stack (UTA → Alice → Vite) as a black box,
+ * verifies all three children actually spawned and bound their ports, then
+ * exercises the UTA restart path and checks for orphaned processes on
+ * teardown.
+ *
+ * Why this exists: Guardian spawns its children with bare commands (`tsx`,
+ * `pnpm`). On Windows those are `.cmd` shims that Node's spawn won't resolve
+ * without a shell — a regression there throws `spawn tsx ENOENT` at boot and
+ * is invisible to `pnpm test` (esbuild transpile, no real spawn). This runs
+ * the real spawn path on a real OS in CI. See scripts/guardian/shared.ts
+ * `spawnChild`.
+ *
+ * Two tiers of check:
+ *   - HARD (gates exit code): all three children boot, no ENOENT. This is the
+ *     contract a cross-platform spawn fix must keep.
+ *   - SOFT (logged, never fails the run): UTA restart re-spawns cleanly, and
+ *     teardown leaves no orphan processes holding ports. These probe the
+ *     known-fragile Windows kill path (killing a shell-wrapped child kills the
+ *     wrapper, not the grandchild). We want the signal in CI logs without
+ *     blocking the boot fix on a separately-scoped teardown concern.
+ *
+ * Runnable locally on POSIX too (`pnpm test:smoke`) — there it's the control
+ * case where everything already works, useful for validating the harness
+ * itself when you can't run Windows.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { connect } from 'node:net'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { appendFileSync } from 'node:fs'
+
+const IS_WIN = process.platform === 'win32'
+const BOOT_TIMEOUT_MS = 120_000
+const RESTART_TIMEOUT_MS = 30_000
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+/** Append a line to the GitHub step summary if running in Actions. No-op locally. */
+function summary(line: string): void {
+  const f = process.env['GITHUB_STEP_SUMMARY']
+  if (f) {
+    try { appendFileSync(f, line + '\n') } catch { /* best effort */ }
+  }
+}
+
+/** True if something is listening on the port (connection accepted). */
+function portBound(port: number, host = '127.0.0.1'): Promise<boolean> {
+  return new Promise((res) => {
+    const sock = connect({ port, host })
+    const done = (bound: boolean) => {
+      sock.destroy()
+      res(bound)
+    }
+    sock.setTimeout(1_000)
+    sock.once('connect', () => done(true))
+    sock.once('timeout', () => done(false))
+    sock.once('error', () => done(false))
+  })
+}
+
+async function waitForPortFree(port: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (!(await portBound(port))) return true
+    await sleep(500)
+  }
+  return false
+}
+
+interface UtaHealth { ok: boolean; startedAt: string; utas: number }
+
+async function fetchHealth(utaPort: number): Promise<UtaHealth | null> {
+  try {
+    const r = await fetch(`http://127.0.0.1:${utaPort}/__uta/health`)
+    if (!r.ok) return null
+    return (await r.json()) as UtaHealth
+  } catch {
+    return null
+  }
+}
+
+async function main(): Promise<void> {
+  const root = process.cwd()
+  const flagPath = resolve(root, 'data/control/restart-uta.flag')
+
+  // ── Spawn the full stack ──────────────────────────────────
+  // POSIX: detached so the whole process group can be force-killed on cleanup.
+  // Windows: shell so the `pnpm` .cmd shim resolves (this outer spawn is the
+  // harness, not the code under test — the code under test is what Guardian
+  // does internally).
+  const child: ChildProcess = spawn('pnpm', ['dev'], {
+    cwd: root,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: !IS_WIN,
+    shell: IS_WIN,
+  })
+
+  let out = ''
+  const onData = (buf: Buffer) => {
+    const s = buf.toString('utf8')
+    out += s
+    process.stdout.write(s) // mirror dev output into CI logs
+  }
+  child.stdout?.on('data', onData)
+  child.stderr?.on('data', onData)
+
+  let childExited = false
+  child.once('exit', () => { childExited = true })
+
+  // Force-kill the whole tree. On Windows taskkill /T walks the process tree
+  // (the orphan-prone case); on POSIX kill the process group.
+  const forceCleanup = () => {
+    if (childExited || child.pid == null) return
+    try {
+      if (IS_WIN) {
+        spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'])
+      } else {
+        process.kill(-child.pid, 'SIGKILL')
+      }
+    } catch { /* already gone */ }
+  }
+
+  const fail = (msg: string): never => {
+    console.error(`\n❌ SMOKE FAIL: ${msg}`)
+    summary(`❌ **Guardian smoke failed (${process.platform})**: ${msg}`)
+    forceCleanup()
+    process.exit(1)
+  }
+
+  // ── HARD: wait for boot, no ENOENT ────────────────────────
+  const deadline = Date.now() + BOOT_TIMEOUT_MS
+  const waitFor = async (label: string, ok: () => boolean | Promise<boolean>): Promise<void> => {
+    while (Date.now() < deadline) {
+      if (/spawn .* ENOENT/.test(out)) fail(`ENOENT during boot — a child failed to spawn:\n${out.slice(-600)}`)
+      if (childExited) fail(`stack exited before "${label}":\n${out.slice(-600)}`)
+      if (await ok()) { console.log(`✓ ${label}`); return }
+      await sleep(500)
+    }
+    fail(`timed out waiting for "${label}" (${BOOT_TIMEOUT_MS / 1000}s):\n${out.slice(-600)}`)
+  }
+
+  // Parse the ports Guardian prints in its banner (robust to port-probe shifts).
+  await waitFor('guardian banner printed', () => /Alice\s+→\s+http:\/\/localhost:\d+/.test(out))
+  const utaPort = Number(/UTA\s+→\s+http:\/\/127\.0\.0\.1:(\d+)/.exec(out)?.[1])
+  const webPort = Number(/Alice\s+→\s+http:\/\/localhost:(\d+)/.exec(out)?.[1])
+  if (!utaPort || !webPort) fail(`could not parse ports from banner:\n${out.slice(-600)}`)
+  console.log(`  parsed ports → UTA:${utaPort} Alice:${webPort}`)
+
+  // UTA tsx spawn worked → health responds.
+  let health: UtaHealth | null = null
+  await waitFor('UTA health 200 (uta child spawned)', async () => {
+    health = await fetchHealth(utaPort)
+    return health !== null
+  })
+  const startedAt0 = health!.startedAt
+
+  // Alice tsx spawn worked → web plugin bound its port.
+  await waitFor('Alice listening (alice child spawned)', () => portBound(webPort))
+
+  // Vite pnpm spawn worked → it announces a Local URL.
+  await waitFor('Vite dev server up (vite child spawned)', () => /\[vite\][^\n]*localhost:\d+/i.test(out))
+
+  console.log('\n✅ HARD checks passed — all three children spawned and bound.')
+  summary(`✅ **Guardian boot smoke passed (${process.platform})** — UTA/Alice/Vite all spawned.`)
+
+  // ── SOFT: UTA restart (never fails the run) ───────────────
+  // Triggers the same flag Alice touches after a broker-config change. On
+  // Windows this is the path most likely to expose the shell-wrapper kill
+  // problem: old UTA orphaned holding the port → new UTA can't bind.
+  console.log('\n— SOFT checks (logged, do not affect exit code) —')
+  let restartOk = false
+  try {
+    await mkdir(dirname(flagPath), { recursive: true })
+    await writeFile(flagPath, `smoke ${startedAt0}`)
+    const rDeadline = Date.now() + RESTART_TIMEOUT_MS
+    while (Date.now() < rDeadline) {
+      const h = await fetchHealth(utaPort)
+      if (h && h.startedAt !== startedAt0) { restartOk = true; break }
+      await sleep(500)
+    }
+  } catch { /* reported below */ }
+  if (restartOk) {
+    console.log('✓ UTA restarted cleanly (startedAt changed)')
+    summary(`✅ UTA restart on ${process.platform}: clean re-spawn.`)
+  } else {
+    console.warn('⚠️  UTA did NOT re-spawn within timeout after restart flag — likely an orphaned old UTA holding the port (Windows shell-wrapper kill). This is the known option-A gap; trigger for tree-kill / option B.')
+    summary(`⚠️ UTA restart on ${process.platform}: did not re-spawn (suspected orphan holding port).`)
+  }
+
+  // ── SOFT: teardown orphan check ───────────────────────────
+  // Ask Guardian to shut down, then see whether the ports actually freed.
+  // A lingering bound port after shutdown == orphaned grandchild process.
+  console.log('\n— teardown orphan check —')
+  try { child.kill() } catch { /* noop */ }
+  await sleep(6_000)
+  const stillUta = await portBound(utaPort)
+  const stillWeb = await portBound(webPort)
+  if (stillUta || stillWeb) {
+    const which = [stillUta && `UTA:${utaPort}`, stillWeb && `Alice:${webPort}`].filter(Boolean).join(', ')
+    console.warn(`⚠️  Ports still bound after shutdown (orphan processes): ${which}`)
+    summary(`⚠️ Teardown orphans on ${process.platform}: ${which} still bound.`)
+  } else {
+    console.log('✓ Clean teardown — no orphaned ports')
+    summary(`✅ Teardown on ${process.platform}: clean, no orphans.`)
+  }
+
+  // Ensure the CI runner is left clean regardless of the above.
+  forceCleanup()
+  await waitForPortFree(utaPort, 10_000)
+  console.log('\n✅ Smoke complete (HARD checks passed).')
+  process.exit(0)
+}
+
+main().catch((err: unknown) => {
+  console.error('smoke harness error:', err)
+  process.exit(1)
+})

--- a/scripts/guardian/smoke.ts
+++ b/scripts/guardian/smoke.ts
@@ -27,7 +27,7 @@
  * itself when you can't run Windows.
  */
 
-import { spawn, type ChildProcess } from 'node:child_process'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { connect } from 'node:net'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { resolve, dirname } from 'node:path'
@@ -39,6 +39,15 @@ const RESTART_TIMEOUT_MS = 30_000
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms))
+}
+
+// CI (GitHub Actions) forces color, so child output carries ANSI SGR codes
+// even through a pipe — e.g. `http://localhost:\x1b[1m5173`. Strip them before
+// matching or readiness regexes break (a `localhost:\d+` won't see the digit).
+// eslint-disable-next-line no-control-regex
+const ANSI = /\x1b\[[0-9;]*m/g
+function stripAnsi(s: string): string {
+  return s.replace(ANSI, '')
 }
 
 /** Append a line to the GitHub step summary if running in Actions. No-op locally. */
@@ -102,11 +111,13 @@ async function main(): Promise<void> {
     shell: IS_WIN,
   })
 
+  // `out` holds ANSI-stripped text for matching; raw output is mirrored to the
+  // CI log so colors are still readable there.
   let out = ''
   const onData = (buf: Buffer) => {
     const s = buf.toString('utf8')
-    out += s
-    process.stdout.write(s) // mirror dev output into CI logs
+    out += stripAnsi(s)
+    process.stdout.write(s)
   }
   child.stdout?.on('data', onData)
   child.stderr?.on('data', onData)
@@ -120,7 +131,8 @@ async function main(): Promise<void> {
     if (childExited || child.pid == null) return
     try {
       if (IS_WIN) {
-        spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'])
+        // spawnSync so the tree is actually reaped before process.exit().
+        spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'])
       } else {
         process.kill(-child.pid, 'SIGKILL')
       }


### PR DESCRIPTION
## Summary
A Windows user hit `spawn tsx ENOENT` the moment they ran `pnpm dev`. Tracing it through CI surfaced **three independent Windows bugs** on the `pnpm dev` path — and #2/#3 only mattered once #1 was fixed, so they'd have hit a second wall the instant they configured a broker:

1. **Boot crash** — Guardian spawned its children (`tsx`, `pnpm`) with bare commands; on Windows those are `.cmd` shims Node's `spawn` won't resolve without a shell. Fix: `shell: process.platform === 'win32'` in `spawnChild`.
2. **Broker-config restart silently dead** — the flag watcher compared the `fs.watch` event filename against a hand-rolled `basename()` that only split on `/`. On Windows (`\` paths) it returned the whole path, never matched, and the UTA restart never fired. Fix: use `node:path` `basename`.
3. **Restart/shutdown orphaned processes** — with the shell wrapper from #1, `child.kill()` reaps the `cmd.exe` wrapper but leaves the real node grandchild holding its port → fresh UTA can't bind. Fix: cross-platform `killTree` (`taskkill /T /F` on Windows) wired into cascade shutdown and `UTAController.restart`.

`pnpm test` is blind to all of this (esbuild transpiles, never spawns), so this also adds a `dev-smoke` CI job (matrix: `windows-latest` + `ubuntu-latest` control) that boots the real stack and asserts UTA/Alice/Vite all spawn — plus soft probes for the restart path and orphan teardown. Each of bugs #2 and #3 was caught by that smoke, not by a human.

## Test plan
- [x] `npx tsc --noEmit` clean (Alice src); targeted tsc on the guardian scripts clean
- [x] `pnpm test:smoke` green locally on macOS (POSIX control): HARD + restart + teardown all pass
- [x] `dev-smoke (ubuntu-latest)` green in CI
- [x] `dev-smoke (windows-latest)` green in CI — HARD passes, **and** SOFT now passes: `[guardian] restarting UTA` fires, UTA re-spawns (`startedAt` changes), teardown leaves no orphan ports (runner reports no leftover pids)
- [x] `build-and-test` green

## Boundary touch
Touches Guardian process supervision and the UTA restart (`restart-uta.flag`) lifecycle only — no broker code, no auth, no migrations, no credential paths. The smoke writes the restart flag but never reads or mutates broker config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
