### PR TITLE
fix(codex): avoid responses.stream() finalizer crash on ChatGPT subscription endpoint

### DIFF
--- a/src/ai-providers/codex/codex-provider.ts
+++ b/src/ai-providers/codex/codex-provider.ts
@@ -69,17 +69,27 @@ export class CodexProvider implements AIProvider {
     const instructions = await this.getSystemPrompt()
 
     try {
-      // Use streaming — the ChatGPT subscription endpoint may not support non-streaming
-      const stream = client.responses.stream({
+      // Use raw streaming via responses.create({ stream: true }) — NOT
+      // responses.stream(). The latter runs a final-response parser
+      // (maybeParseResponse) when the stream closes; the ChatGPT subscription
+      // endpoint sometimes emits a `response.completed` without the `output`
+      // shape that parser expects, crashing with "Cannot read properties of
+      // undefined (reading 'map')" even though the text deltas streamed fine.
+      // create({ stream: true }) hands back raw events with no final parse.
+      const stream = await client.responses.create({
         model,
         instructions,
         input: [{ role: 'user' as const, content: prompt }],
         store: false,
+        stream: true,
       })
 
       let text = ''
       for await (const event of stream) {
         if (event.type === 'response.output_text.delta') text += event.delta
+        else if (event.type === 'error') throw new Error(`Codex stream error: ${event.message}`)
+        else if (event.type === 'response.failed')
+          throw new Error(`Codex response failed: ${event.response.error?.message ?? 'unknown error'}`)
       }
 
       return { text: text || '(no output)', media: [] }
@@ -137,12 +147,16 @@ export class CodexProvider implements AIProvider {
       let stepText = ''
 
       try {
-        const stream = client.responses.stream({
+        // Raw streaming via create({ stream: true }), not responses.stream() —
+        // see ask() for why the stream() helper's final-response parser crashes
+        // on the ChatGPT subscription endpoint.
+        const stream = await client.responses.create({
           model,
           instructions,
           input,
           tools: tools.length > 0 ? tools : undefined,
           store: false, // Required by ChatGPT subscription endpoint
+          stream: true,
         })
 
         for await (const event of stream) {
@@ -160,6 +174,12 @@ export class CodexProvider implements AIProvider {
                 arguments: item.arguments,
               })
             }
+          } else if (event.type === 'error') {
+            throw new Error(`Codex stream error: ${event.message}`)
+          } else if (event.type === 'response.failed') {
+            throw new Error(`Codex response failed: ${event.response.error?.message ?? 'unknown error'}`)
+          } else if (event.type === 'response.incomplete') {
+            throw new Error(`Codex response incomplete: ${event.response.incomplete_details?.reason ?? 'unknown reason'}`)
           }
         }
       } catch (err: any) {


### PR DESCRIPTION
## Summary
- Fixes #226 — selecting the **Codex (Subscription)** provider and hitting **Test connection** crashes with `Cannot read properties of undefined (reading 'map')`. Root cause: `client.responses.stream()` runs a final-response parser (`maybeParseResponse`) when the stream closes, and the ChatGPT subscription endpoint sometimes sends a `response.completed` without the `output` shape that parser expects — so it throws *after* the text deltas have already streamed fine.
- Switched both call sites (`ask()` and the `toolLoop` in `generate()`) from `responses.stream()` to `responses.create({ stream: true })`, which yields **raw** events with no final-parse step. We already only consume raw events (`output_text.delta` / `output_item.done`), so nothing else changes.
- Added explicit handling for `error` / `response.failed` / `response.incomplete` stream events so genuine API failures surface clearly instead of being swallowed.

Live repro path: `AIProviderPage` → `POST /api/config/profiles/test` → `testWithProfile` → `router.askForTest` → `CodexProvider.ask()`. Also covers the `generate()` path used by AgentWork autonomous runs.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` slice (`src/core` + `src/ai-providers`) — 562 passed
- [ ] Manual: configure a Codex Subscription profile, click Test connection, confirm it returns the model reply instead of the `.map()` crash *(needs a live ChatGPT OAuth session — can't run in CI)*

> Note: `codex.e2e.spec.ts` still calls `responses.stream()` directly as test scaffolding; left untouched (live-OAuth gated, excluded from CI). Worth migrating for consistency in a follow-up.

## Boundary touch
Touches the Codex provider under GenerateRouter — no trading / broker / UTA / migration code. CLAUDE.md flags GenerateRouter changes for review; this is a targeted bugfix within one backend, not a routing/shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
