### PR TITLE
fix(workspace/codex): unquote `openalice-workspace` MCP key in -c override

### DIFF
--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -83,7 +83,7 @@ describe('codexAdapter AI-config', () => {
       '-c',
       'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
       '-c',
-      'mcp_servers."openalice-workspace".url="http://127.0.0.1:47332/mcp/ws-abc"',
+      'mcp_servers.openalice-workspace.url="http://127.0.0.1:47332/mcp/ws-abc"',
     ]);
   });
 
@@ -97,7 +97,7 @@ describe('codexAdapter AI-config', () => {
       '-c',
       'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
       '-c',
-      'mcp_servers."openalice-workspace".url="http://127.0.0.1:47332/mcp/ws-abc"',
+      'mcp_servers.openalice-workspace.url="http://127.0.0.1:47332/mcp/ws-abc"',
       'resume',
       '--last',
     ]);
@@ -106,7 +106,7 @@ describe('codexAdapter AI-config', () => {
       '-c',
       'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
       '-c',
-      'mcp_servers."openalice-workspace".url="http://127.0.0.1:47332/mcp/ws-abc"',
+      'mcp_servers.openalice-workspace.url="http://127.0.0.1:47332/mcp/ws-abc"',
       'resume',
       'rollout-id',
     ]);

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -91,7 +91,12 @@ export const codexAdapter: CliAdapter = {
       '-c',
       `mcp_servers.openalice.url="${mcpUrl}"`,
       '-c',
-      `mcp_servers."openalice-workspace".url="${mcpUrl}/${workspaceId}"`,
+      // `openalice-workspace` is a valid TOML bare key (hyphen is allowed in
+      // bare keys), so it needs NO quoting. Quoting the segment as
+      // `"openalice-workspace"` made codex carry the literal quotes into the
+      // MCP server name, which then failed codex's own `^[a-zA-Z0-9_-]+$`
+      // name check ("Invalid MCP server name '\"openalice-workspace\"'").
+      `mcp_servers.openalice-workspace.url="${mcpUrl}/${workspaceId}"`,
     ];
     if (ctx.resume === undefined) return head;
     if (ctx.resume === 'last') return [...head, 'resume', '--last'];


### PR DESCRIPTION
## Summary
- Codex workspace spawns failed to start the `openalice-workspace` MCP server: `Invalid MCP server name '"openalice-workspace"': must match pattern ^[a-zA-Z0-9_-]+$`.
- Root cause: the adapter passed `-c mcp_servers."openalice-workspace".url=...`. Codex carried the literal double quotes into the server name, which then failed its own name check. `openalice-workspace` is a valid TOML bare key (hyphen allowed), so the segment needs no quoting — dropped the quotes.
- Updated the three `ai-config.spec.ts` assertions that had locked in the buggy quoted form.

## Test plan
- [x] `npx vitest run src/workspaces/adapters/ai-config.spec.ts` — 14 passed
- [x] `npx tsc --noEmit` clean
- [ ] Manual: start a codex workspace; both `openalice` and `openalice-workspace` MCP servers connect without the warning

## Boundary touch
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
