### PR TITLE
feat(analysis): right-side volume signals — RVOL/OBV/MFI/VWAP + relative-volume movers

### DIFF
--- a/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
@@ -60,7 +60,12 @@ export async function getPredefinedScreener(
   for (let attempt = 0; attempt < 2; attempt++) {
     const yf = getYF()
     try {
-      result = await (yf as any).screener({ scrIds: scrId, count })
+      // validateResult: false — Yahoo keeps adding fields to the screener
+      // response (predefined screeners gained a large includeFields set),
+      // tripping yahoo-finance2's strict ScreenerResult schema. Same treatment
+      // as search() below. We only read the whitelisted SCREENER_FIELDS anyway.
+      // moduleOptions (validateResult) is the THIRD arg — screener(overrides, queryOpts, moduleOpts).
+      result = await (yf as any).screener({ scrIds: scrId, count }, undefined, { validateResult: false })
       recordYFSuccess()
       break
     } catch (err) {
@@ -104,6 +109,19 @@ export async function getPredefinedScreener(
     for (const k of SCREENER_FIELDS) {
       result[k] = item[k] ?? null
     }
+
+    // Derive right-side volume reads while the raw yahoo keys are still present.
+    // These snake_case keys aren't in the alias dict, so they pass straight
+    // through applyAliases + the schema's passthrough() to the consumer.
+    const vol = result.regularMarketVolume
+    const avgVol = result.averageDailyVolume3Month
+    const sharesOut = result.sharesOutstanding
+    result.relative_volume =
+      typeof vol === 'number' && typeof avgVol === 'number' && avgVol > 0 ? vol / avgVol : null
+    result.turnover =
+      typeof vol === 'number' && typeof sharesOut === 'number' && sharesOut > 0
+        ? vol / sharesOut
+        : null
 
     if (result.regularMarketChange != null && result.regularMarketVolume != null) {
       output.push(result)

--- a/packages/opentypebb/src/providers/yfinance/utils/references.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/references.ts
@@ -327,6 +327,7 @@ export const SCREENER_FIELDS = [
   'regularMarketChange',
   'regularMarketChangePercent',
   'regularMarketVolume',
+  'averageDailyVolume3Month',
   'regularMarketOpen',
   'regularMarketDayHigh',
   'regularMarketDayLow',
@@ -355,6 +356,7 @@ export const YF_SCREENER_ALIAS_DICT: Record<string, string> = {
   change: 'regularMarketChange',
   percent_change: 'regularMarketChangePercent',
   volume: 'regularMarketVolume',
+  avg_volume: 'averageDailyVolume3Month',
   open: 'regularMarketOpen',
   high: 'regularMarketDayHigh',
   low: 'regularMarketDayLow',
@@ -376,6 +378,9 @@ export const YF_SCREENER_ALIAS_DICT: Record<string, string> = {
 }
 
 export const YFPredefinedScreenerDataSchema = EquityPerformanceDataSchema.extend({
+  avg_volume: z.number().nullable().default(null).describe('Average daily trading volume over the trailing 3 months.'),
+  relative_volume: z.number().nullable().default(null).describe("Today's volume divided by the 3-month average volume. >1 means trading heavier than usual; the right-side, cross-ticker-comparable read of volume."),
+  turnover: z.number().nullable().default(null).describe("Today's volume divided by shares outstanding — share turnover, more sensitive for small caps."),
   open: z.number().nullable().default(null).describe('Open price for the day.'),
   high: z.number().nullable().default(null).describe('High price for the day.'),
   low: z.number().nullable().default(null).describe('Low price for the day.'),

--- a/packages/opentypebb/src/standard-models/equity-discovery.ts
+++ b/packages/opentypebb/src/standard-models/equity-discovery.ts
@@ -22,6 +22,12 @@ export const EquityDiscoveryDataSchema = z.object({
   change: z.number().nullable().default(null).describe('Change in price.'),
   percent_change: z.number().nullable().default(null).describe('Percent change in price.'),
   volume: z.number().nullable().default(null).describe('Trading volume.'),
+  // Right-side volume context — populated by providers that carry it (yfinance
+  // screeners); null elsewhere. relative_volume = volume / 3-month average, the
+  // cross-ticker-comparable read of whether a name is trading unusually.
+  avg_volume: z.number().nullable().default(null).describe('Average daily trading volume over the trailing 3 months.'),
+  relative_volume: z.number().nullable().default(null).describe("Today's volume divided by the 3-month average. >1 means heavier than usual."),
+  turnover: z.number().nullable().default(null).describe("Today's volume divided by shares outstanding (share turnover)."),
 }).passthrough()
 
 export type EquityDiscoveryData = z.infer<typeof EquityDiscoveryDataSchema>

--- a/src/domain/analysis/indicator/calculator.spec.ts
+++ b/src/domain/analysis/indicator/calculator.spec.ts
@@ -219,6 +219,40 @@ describe('technical indicators', () => {
   })
 })
 
+// ==================== 成交量指标（右侧） ====================
+
+describe('volume indicators', () => {
+  it('RVOL returns latest volume relative to its baseline (>1 here, volume trends up)', async () => {
+    const result = (await calc("RVOL(VOLUME('AAPL', '1d'), 20)")).value as number
+    expect(typeof result).toBe('number')
+    expect(result).toBeGreaterThan(1)
+    expect(result).toBeLessThan(2)
+  })
+
+  it('OBV sums volume on up-closes — mock rises monotonically, so = Σ volume[1..49]', async () => {
+    // closes strictly increasing → every bar adds its volume; bar 48 volume is null→0
+    const result = (await calc("OBV(CLOSE('AAPL', '1d'), VOLUME('AAPL', '1d'))")).value as number
+    expect(result).toBe(59770)
+  })
+
+  it('MFI is 100 when typical price rises monotonically (all positive money flow)', async () => {
+    const result = (await calc("MFI(HIGH('AAPL', '1d'), LOW('AAPL', '1d'), CLOSE('AAPL', '1d'), VOLUME('AAPL', '1d'), 14)")).value as number
+    expect(result).toBe(100)
+  })
+
+  it('VWAP returns a volume-weighted price inside the price range', async () => {
+    const result = (await calc("VWAP(HIGH('AAPL', '1d'), LOW('AAPL', '1d'), CLOSE('AAPL', '1d'), VOLUME('AAPL', '1d'))")).value as number
+    expect(typeof result).toBe('number')
+    // typical price spans ~100→149; higher-volume bars sit at the top, so VWAP skews high
+    expect(result).toBeGreaterThan(124)
+    expect(result).toBeLessThan(150)
+  })
+
+  it('RVOL throws on insufficient data', async () => {
+    await expect(calc("RVOL(VOLUME('AAPL', '1d'), 100)")).rejects.toThrow(/RVOL requires/)
+  })
+})
+
 // ==================== 复合表达式 ====================
 
 describe('complex expressions', () => {

--- a/src/domain/analysis/indicator/calculator.ts
+++ b/src/domain/analysis/indicator/calculator.ts
@@ -301,6 +301,30 @@ export class IndicatorCalculator {
         evaluatedArgs[3] as number,
       )
 
+    // Volume (right-side) indicators
+    if (name === 'RVOL')
+      return Technical.RVOL(evaluatedArgs[0] as number[] | TrackedValues, evaluatedArgs[1] as number)
+    if (name === 'OBV')
+      return Technical.OBV(
+        evaluatedArgs[0] as number[] | TrackedValues,
+        evaluatedArgs[1] as number[] | TrackedValues,
+      )
+    if (name === 'MFI')
+      return Technical.MFI(
+        evaluatedArgs[0] as number[] | TrackedValues,
+        evaluatedArgs[1] as number[] | TrackedValues,
+        evaluatedArgs[2] as number[] | TrackedValues,
+        evaluatedArgs[3] as number[] | TrackedValues,
+        evaluatedArgs[4] as number,
+      )
+    if (name === 'VWAP')
+      return Technical.VWAP(
+        evaluatedArgs[0] as number[] | TrackedValues,
+        evaluatedArgs[1] as number[] | TrackedValues,
+        evaluatedArgs[2] as number[] | TrackedValues,
+        evaluatedArgs[3] as number[] | TrackedValues,
+      )
+
     throw new Error(`Unknown function: ${name}`)
   }
 

--- a/src/domain/analysis/indicator/functions/technical.ts
+++ b/src/domain/analysis/indicator/functions/technical.ts
@@ -1,7 +1,8 @@
 /**
  * Technical indicator functions — 纯数学计算
  *
- * RSI, BBANDS, MACD, ATR
+ * Trend / momentum:  RSI, BBANDS, MACD, ATR
+ * Volume (right-side): RVOL, OBV, MFI, VWAP
  * 接受 number[] 或 TrackedValues（自动提取 values）
  */
 
@@ -130,4 +131,134 @@ export function ATR(
   }
 
   return atr
+}
+
+/**
+ * Relative Volume (RVOL) — latest bar's volume divided by the average of the
+ * preceding `period` bars. The single most useful right-side read: absolute
+ * volume is meaningless across tickers (10M shares is huge for one, noise for
+ * another); RVOL normalizes it against the symbol's own baseline. >1 means
+ * the bar is trading heavier than usual; a 2–3+ print on a move is the
+ * volume-confirmation signal momentum traders look for.
+ */
+export function RVOL(volumes: NumericInput, period: number = 20): number {
+  const v = toValues(volumes)
+  if (v.length < period + 1) {
+    throw new Error(`RVOL requires at least ${period + 1} data points, got ${v.length}`)
+  }
+
+  const latest = v[v.length - 1]
+  const prior = v.slice(-period - 1, -1) // the `period` bars before the latest
+  const avg = prior.reduce((acc, val) => acc + val, 0) / period
+
+  if (avg === 0) {
+    throw new Error('RVOL requires a non-zero average baseline volume')
+  }
+
+  return latest / avg
+}
+
+/**
+ * On-Balance Volume (OBV) — running total that adds the bar's volume on an
+ * up-close and subtracts it on a down-close. Returns the latest cumulative
+ * value; its slope (vs price) is what carries the accumulation/distribution
+ * signal. Pair with CLOSE and VOLUME of the same length.
+ */
+export function OBV(closes: NumericInput, volumes: NumericInput): number {
+  const c = toValues(closes)
+  const vol = toValues(volumes)
+  if (c.length !== vol.length || c.length < 2) {
+    throw new Error(
+      `OBV requires closes and volumes of equal length (>= 2), got ${c.length} and ${vol.length}`,
+    )
+  }
+
+  let obv = 0
+  for (let i = 1; i < c.length; i++) {
+    if (c[i] > c[i - 1]) obv += vol[i]
+    else if (c[i] < c[i - 1]) obv -= vol[i]
+    // unchanged close: OBV unchanged
+  }
+
+  return obv
+}
+
+/**
+ * Money Flow Index (MFI) — a volume-weighted RSI on the typical price
+ * ((H+L+C)/3), bounded 0–100. Above ~80 = overbought on heavy money inflow,
+ * below ~20 = oversold. Needs highs/lows/closes/volumes of equal length.
+ */
+export function MFI(
+  highs: NumericInput,
+  lows: NumericInput,
+  closes: NumericInput,
+  volumes: NumericInput,
+  period: number = 14,
+): number {
+  const h = toValues(highs)
+  const l = toValues(lows)
+  const c = toValues(closes)
+  const vol = toValues(volumes)
+  if (
+    h.length !== l.length ||
+    l.length !== c.length ||
+    c.length !== vol.length ||
+    h.length < period + 1
+  ) {
+    throw new Error(`MFI requires at least ${period + 1} data points for all arrays`)
+  }
+
+  const typical = h.map((_, i) => (h[i] + l[i] + c[i]) / 3)
+
+  let positiveFlow = 0
+  let negativeFlow = 0
+  for (let i = h.length - period; i < h.length; i++) {
+    const rawFlow = typical[i] * vol[i]
+    if (typical[i] > typical[i - 1]) positiveFlow += rawFlow
+    else if (typical[i] < typical[i - 1]) negativeFlow += rawFlow
+  }
+
+  if (negativeFlow === 0) return 100
+  const moneyRatio = positiveFlow / negativeFlow
+  return 100 - 100 / (1 + moneyRatio)
+}
+
+/**
+ * Volume-Weighted Average Price (VWAP) over the supplied series — the average
+ * price weighted by volume at each bar, using the typical price ((H+L+C)/3).
+ * Price above VWAP = buyers in control over the window. Needs
+ * highs/lows/closes/volumes of equal length.
+ */
+export function VWAP(
+  highs: NumericInput,
+  lows: NumericInput,
+  closes: NumericInput,
+  volumes: NumericInput,
+): number {
+  const h = toValues(highs)
+  const l = toValues(lows)
+  const c = toValues(closes)
+  const vol = toValues(volumes)
+  if (
+    h.length !== l.length ||
+    l.length !== c.length ||
+    c.length !== vol.length ||
+    h.length < 1
+  ) {
+    throw new Error('VWAP requires high/low/close/volume arrays of equal length (>= 1)')
+  }
+
+  let priceVolume = 0
+  let totalVolume = 0
+  for (let i = 0; i < h.length; i++) {
+    const typical = (h[i] + l[i] + c[i]) / 3
+    priceVolume += typical * vol[i]
+    totalVolume += vol[i]
+  }
+
+  if (totalVolume === 0) {
+    throw new Error('VWAP requires non-zero total volume')
+  }
+
+  return priceVolume / totalVolume
 }

--- a/src/tool/analysis.ts
+++ b/src/tool/analysis.ts
@@ -102,16 +102,24 @@ Data access (returns array — use [-1] for latest value):
 Statistics (returns a single number — do NOT use [-1]):
   SMA(data, period), EMA, STDEV, MAX, MIN, SUM, AVERAGE.
 
-Technical (returns a single number or object — do NOT use [-1]):
+Technical — trend / momentum (returns a single number or object — do NOT use [-1]):
   RSI(data, 14) → number.  BBANDS(data, 20, 2) → {upper, middle, lower}.
   MACD(data, 12, 26, 9) → {macd, signal, histogram}.  ATR(highs, lows, closes, 14) → number.
 
+Technical — volume / right-side confirmation (returns a single number):
+  RVOL(VOLUME(...), 20) → relative volume: latest bar vs its 20-bar average. >1 = heavier than usual; 2-3+ on a move = volume-confirmed. The right way to read volume — raw VOLUME is not comparable across tickers.
+  OBV(CLOSE(...), VOLUME(...)) → on-balance volume (accumulation/distribution).
+  MFI(HIGH(...), LOW(...), CLOSE(...), VOLUME(...), 14) → money-flow index, 0-100 (volume-weighted RSI).
+  VWAP(HIGH(...), LOW(...), CLOSE(...), VOLUME(...)) → volume-weighted average price; price above it = buyers in control.
+
 Arithmetic: +, -, *, / operators between numbers. E.g. CLOSE(...)[-1] - SMA(..., 50).
+Note: arithmetic needs scalars on both sides, so reduce a series with [-1] or a function first — e.g. RVOL via formula is VOLUME(...)[-1] / SMA(VOLUME(...), 20), or just call RVOL(VOLUME(...), 20).
 
 Examples:
   SMA(CLOSE('AAPL', '1d'), 50)              → equity 50-day moving average
   RSI(CLOSE('BTCUSD', '1d'), 14)            → crypto RSI (single number, no [-1])
-  CLOSE('EURUSD', '1d')[-1]                 → latest forex close (needs [-1])
+  RVOL(VOLUME('AAPL', '1d'), 20)            → is AAPL trading on unusual volume today?
+  VWAP(HIGH('TSLA','1d'), LOW('TSLA','1d'), CLOSE('TSLA','1d'), VOLUME('TSLA','1d'))
   CLOSE('gold', '1d')[-1]                   → latest gold price (canonical name)
 
 Returns { value, dataRange } where dataRange shows the actual date span of the data used.

--- a/src/tool/equity.ts
+++ b/src/tool/equity.ts
@@ -9,6 +9,7 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import type { EquityClientLike } from '@/domain/market-data/client/types'
+import type { EquityDiscoveryData } from '@traderalice/opentypebb'
 
 export function createEquityTools(equityClient: EquityClientLike) {
   return {
@@ -134,20 +135,46 @@ If unsure about the symbol, use marketSearchForResearch to find it.`,
     equityDiscover: tool({
       description: `Discover trending stocks in the market right now.
 
-Returns top gainers, losers, or most actively traded stocks.
-Use this to get a pulse on what the market is trading today.`,
+Returns top gainers, losers, or most actively traded stocks. Use this to get a
+pulse on what the market is trading today.
+
+Each row carries volume-context fields beyond raw price/volume:
+- relative_volume — today's volume / its 3-month average. THIS is how to read
+  volume: raw "most active" is just the usual mega-caps (AAPL, TSLA always
+  trade billions). relative_volume >2 surfaces stocks trading genuinely
+  unusually — the right-side, cross-ticker-comparable signal.
+- turnover — volume / shares outstanding (more sensitive for small caps).
+- avg_volume — the 3-month baseline.
+
+Set sortBy="relative_volume" to rank by unusual volume instead of the default
+(price move for gainers/losers, absolute volume for active). Volume-context
+fields are populated on the default yfinance data only.`,
       inputSchema: z.object({
-        type: z.enum(['gainers', 'losers', 'active']).describe('"gainers" for top price gainers, "losers" for top losers, "active" for most actively traded by volume'),
-      }).meta({ examples: [{ type: 'gainers' }] }),
-      execute: async ({ type }) => {
+        type: z.enum(['gainers', 'losers', 'active']).describe('"gainers" for top price gainers, "losers" for top losers, "active" for most actively traded by absolute volume'),
+        sortBy: z.enum(['default', 'relative_volume']).optional().describe('"default" keeps the provider ranking; "relative_volume" re-ranks by unusual volume (today vs 3-month average), surfacing genuine volume spikes over ever-active mega-caps'),
+      }).meta({ examples: [{ type: 'active', sortBy: 'relative_volume' }] }),
+      execute: async ({ type, sortBy }) => {
+        let rows: EquityDiscoveryData[]
         switch (type) {
           case 'gainers':
-            return await equityClient.getGainers()
+            rows = await equityClient.getGainers()
+            break
           case 'losers':
-            return await equityClient.getLosers()
+            rows = await equityClient.getLosers()
+            break
           case 'active':
-            return await equityClient.getActive()
+            rows = await equityClient.getActive()
+            break
         }
+
+        if (sortBy === 'relative_volume') {
+          // Rank by unusual volume; rows missing relative_volume sink to the bottom.
+          rows = [...rows].sort(
+            (a, b) => (b.relative_volume ?? -Infinity) - (a.relative_volume ?? -Infinity),
+          )
+        }
+
+        return rows
       },
     }),
   }


### PR DESCRIPTION
## Summary

Alice's analysis surface leaned too "left-side" (valuation/mean-reversion); this adds the right-side volume layer, both on the launcher side. The core reframe: **volume's information is relative, not absolute** — raw volume isn't comparable across tickers, so every read is normalized against the symbol's own baseline.

- **Indicator engine** — new `RVOL` / `OBV` / `MFI` / `VWAP` pure functions (`technical.ts`) + calculator dispatch. `RVOL(VOLUME(...), 20)` = latest bar vs its 20-bar average; the `calculateIndicator` tool description now lists them and warns that arithmetic needs scalar operands (the `executeBinaryOp` foot-gun that stops the agent hand-rolling RVOL).
- **Discovery / movers** — gainers/losers/active rows now carry `relative_volume` (vol / 3-month avg) and `turnover` (vol / shares-out), computed in `getPredefinedScreener` from `averageDailyVolume3Month` (added to the screener field whitelist → **zero extra requests**). `equityDiscover` gains `sortBy="relative_volume"` so "most active" surfaces genuine unusual volume instead of ever-active mega-caps. Fields live on the canonical `EquityDiscoveryDataSchema` (one source of truth).
- **Drive-by fix (same path was dead)** — `screener()` never passed `validateResult:false`, so yahoo's recently-expanded `includeFields` tripped yahoo-finance2's strict `ScreenerResult` schema and threw. gainers/losers/active were all broken against live yahoo, independent of this feature. Mirrors the existing `search()` fix; `validateResult` is `screener()`'s **third** arg.

Verified live against yahoo: absolute "most active" #1 was **NVDA at RVOL 1.01** (normal volume, no signal); relative-volume ranking surfaced **RDW (+15.1%, 2.3×)** and **AVGO (−12.6%, 3.3×)** — the events the absolute list buries.

Out of scope (deferred by design): tool-description/template steering (the 11:1 left-lean lives in skill/template land), and the sector-rotation / fund-flow spine (data is thin, separate track).

## Test plan
- [x] `npx tsc --noEmit` clean (Alice src)
- [x] `pnpm -F @traderalice/opentypebb exec tsc --noEmit` clean
- [x] `pnpm test` — 1759 passed (incl. 5 new volume-indicator specs)
- [x] Live yahoo discovery exercised end-to-end via throwaway script (RVOL/turnover populated, sort verified, screener no longer throws)

## Boundary touch
Touches market-data spine (`packages/opentypebb` yfinance screener + discovery standard model) and the analysis tool surface. No trading / auth / broker-credential / migration paths. The `validateResult:false` change widens what the screener tolerates from yahoo (read-only, whitelisted-field extraction downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
