### PR TITLE
feat(discovery): add dollar_volume (traded notional) — the absolute volume axis

### DIFF
--- a/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
@@ -116,12 +116,19 @@ export async function getPredefinedScreener(
     const vol = result.regularMarketVolume
     const avgVol = result.averageDailyVolume3Month
     const sharesOut = result.sharesOutstanding
+    const price = result.regularMarketPrice
     result.relative_volume =
       typeof vol === 'number' && typeof avgVol === 'number' && avgVol > 0 ? vol / avgVol : null
     result.turnover =
       typeof vol === 'number' && typeof sharesOut === 'number' && sharesOut > 0
         ? vol / sharesOut
         : null
+    // dollar_volume (price × volume) is the cross-ticker-comparable absolute:
+    // raw share volume isn't (1M shares means different money at $5 vs $500).
+    // This is the unit that aggregates to a sector. relative_volume answers
+    // "unusual for itself?"; dollar_volume answers "how much money is here?".
+    result.dollar_volume =
+      typeof vol === 'number' && typeof price === 'number' ? vol * price : null
 
     if (result.regularMarketChange != null && result.regularMarketVolume != null) {
       output.push(result)

--- a/packages/opentypebb/src/providers/yfinance/utils/references.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/references.ts
@@ -379,8 +379,9 @@ export const YF_SCREENER_ALIAS_DICT: Record<string, string> = {
 
 export const YFPredefinedScreenerDataSchema = EquityPerformanceDataSchema.extend({
   avg_volume: z.number().nullable().default(null).describe('Average daily trading volume over the trailing 3 months.'),
-  relative_volume: z.number().nullable().default(null).describe("Today's volume divided by the 3-month average volume. >1 means trading heavier than usual; the right-side, cross-ticker-comparable read of volume."),
+  relative_volume: z.number().nullable().default(null).describe("Today's volume divided by the 3-month average volume. >1 means trading heavier than usual; the relative, intra-ticker read — 'unusual for itself?'."),
   turnover: z.number().nullable().default(null).describe("Today's volume divided by shares outstanding — share turnover, more sensitive for small caps."),
+  dollar_volume: z.number().nullable().default(null).describe("Price × volume — traded notional. The cross-ticker-comparable absolute read of volume ('how much money is here?'), and the unit that aggregates to a sector."),
   open: z.number().nullable().default(null).describe('Open price for the day.'),
   high: z.number().nullable().default(null).describe('High price for the day.'),
   low: z.number().nullable().default(null).describe('Low price for the day.'),

--- a/packages/opentypebb/src/standard-models/equity-discovery.ts
+++ b/packages/opentypebb/src/standard-models/equity-discovery.ts
@@ -26,8 +26,9 @@ export const EquityDiscoveryDataSchema = z.object({
   // screeners); null elsewhere. relative_volume = volume / 3-month average, the
   // cross-ticker-comparable read of whether a name is trading unusually.
   avg_volume: z.number().nullable().default(null).describe('Average daily trading volume over the trailing 3 months.'),
-  relative_volume: z.number().nullable().default(null).describe("Today's volume divided by the 3-month average. >1 means heavier than usual."),
+  relative_volume: z.number().nullable().default(null).describe("Today's volume divided by the 3-month average. >1 means heavier than usual (relative, intra-ticker read)."),
   turnover: z.number().nullable().default(null).describe("Today's volume divided by shares outstanding (share turnover)."),
+  dollar_volume: z.number().nullable().default(null).describe("Price × volume — traded notional. The cross-ticker-comparable absolute read; aggregates to a sector."),
 }).passthrough()
 
 export type EquityDiscoveryData = z.infer<typeof EquityDiscoveryDataSchema>

--- a/src/tool/equity.ts
+++ b/src/tool/equity.ts
@@ -138,20 +138,27 @@ If unsure about the symbol, use marketSearchForResearch to find it.`,
 Returns top gainers, losers, or most actively traded stocks. Use this to get a
 pulse on what the market is trading today.
 
-Each row carries volume-context fields beyond raw price/volume:
-- relative_volume — today's volume / its 3-month average. THIS is how to read
-  volume: raw "most active" is just the usual mega-caps (AAPL, TSLA always
-  trade billions). relative_volume >2 surfaces stocks trading genuinely
-  unusually — the right-side, cross-ticker-comparable signal.
+Each row carries volume-context fields beyond raw price/volume. Volume has two
+orthogonal readings — use the one that fits the question:
+- relative_volume — today's volume / its 3-month average. The RELATIVE,
+  intra-ticker read: "is this name unusual for itself?". raw "most active" is
+  just the usual mega-caps (AAPL, TSLA always trade billions); relative_volume
+  >2 surfaces genuine anomalies. Use for event/spike detection.
+- dollar_volume — price × volume (traded notional). The ABSOLUTE,
+  cross-ticker-comparable read: "how much money is actually here?". This is the
+  unit that compares across tickers and aggregates to a sector (raw share
+  volume can't — 1M shares is different money at $5 vs $500). Use for capital
+  weight / cross-sector work / tradability.
 - turnover — volume / shares outstanding (more sensitive for small caps).
 - avg_volume — the 3-month baseline.
 
-Set sortBy="relative_volume" to rank by unusual volume instead of the default
-(price move for gainers/losers, absolute volume for active). Volume-context
-fields are populated on the default yfinance data only.`,
+Set sortBy to re-rank: "relative_volume" for unusual volume, "dollar_volume"
+for where the money is. Default keeps the provider ranking (price move for
+gainers/losers, absolute share volume for active). Volume-context fields are
+populated on the default yfinance data only.`,
       inputSchema: z.object({
         type: z.enum(['gainers', 'losers', 'active']).describe('"gainers" for top price gainers, "losers" for top losers, "active" for most actively traded by absolute volume'),
-        sortBy: z.enum(['default', 'relative_volume']).optional().describe('"default" keeps the provider ranking; "relative_volume" re-ranks by unusual volume (today vs 3-month average), surfacing genuine volume spikes over ever-active mega-caps'),
+        sortBy: z.enum(['default', 'relative_volume', 'dollar_volume']).optional().describe('"default" keeps the provider ranking; "relative_volume" re-ranks by unusual volume (today vs 3-month avg); "dollar_volume" re-ranks by traded notional (price × volume) — where the money actually is'),
       }).meta({ examples: [{ type: 'active', sortBy: 'relative_volume' }] }),
       execute: async ({ type, sortBy }) => {
         let rows: EquityDiscoveryData[]
@@ -167,10 +174,10 @@ fields are populated on the default yfinance data only.`,
             break
         }
 
-        if (sortBy === 'relative_volume') {
-          // Rank by unusual volume; rows missing relative_volume sink to the bottom.
+        if (sortBy === 'relative_volume' || sortBy === 'dollar_volume') {
+          // Re-rank by the chosen volume axis; rows missing it sink to the bottom.
           rows = [...rows].sort(
-            (a, b) => (b.relative_volume ?? -Infinity) - (a.relative_volume ?? -Infinity),
+            (a, b) => (b[sortBy] ?? -Infinity) - (a[sortBy] ?? -Infinity),
           )
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #269. That PR added `relative_volume` (the intra-ticker "unusual for itself?" read); this adds its orthogonal counterpart, `dollar_volume` (price × volume — traded notional), the **absolute, cross-ticker-comparable** read: "how much money is actually here?".

Why it matters: raw share volume isn't comparable across tickers (1M shares is wildly different money at $5 vs $500), so it can't aggregate to a sector. Dollar volume can — it's the primitive cross-sector analysis needs, and it doubles as a tradability/liquidity gate for position sizing.

- Compute `dollar_volume` in `getPredefinedScreener` from `regularMarketPrice × regularMarketVolume` (both already in the screener payload — no extra request).
- Field added to both `EquityDiscoveryDataSchema` (canonical type) and the yfinance screener schema.
- `equityDiscover` `sortBy` gains `"dollar_volume"` next to `"relative_volume"`; the tool description now frames volume as two orthogonal axes.

Live check against yahoo: by share volume the active list tops out at NVDA / NOK / BB; by `dollar_volume` it's **MU ($53B @ $996, only 54M shares)** — NOK and BB drop off entirely (~$2B / ~$1B notional despite 95–123M shares). Share count points at the wrong place; notional doesn't.

## Test plan
- [x] `npx tsc --noEmit` clean (Alice src)
- [x] `pnpm -F @traderalice/opentypebb exec tsc --noEmit` clean
- [x] `pnpm test` — 1759 passed
- [x] Live yahoo discovery exercised — `dollar_volume` populated, sort verified

## Boundary touch
Market-data spine (`packages/opentypebb` screener + discovery standard model) + the equity discovery tool. No trading / auth / broker-credential / migration paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
