### PR TITLE
feat(tool): expose ETF tools to the agent (ANG-79) — thematic-ETF self-serve

### DIFF
--- a/packages/opentypebb/src/providers/yfinance/index.ts
+++ b/packages/opentypebb/src/providers/yfinance/index.ts
@@ -34,6 +34,7 @@ import { YFinanceIndexHistoricalFetcher } from './models/index-historical.js'
 import { YFinanceFuturesHistoricalFetcher } from './models/futures-historical.js'
 import { YFinanceAvailableIndicesFetcher } from './models/available-indices.js'
 import { YFinanceEtfInfoFetcher } from './models/etf-info.js'
+import { YFinanceEtfSearchFetcher } from './models/etf-search.js'
 import { YFinanceEquityScreenerFetcher } from './models/equity-screener.js'
 import { YFinanceFuturesCurveFetcher } from './models/futures-curve.js'
 import { YFinanceOptionsChainsFetcher } from './models/options-chains.js'
@@ -75,6 +76,7 @@ export const yfinanceProvider = new Provider({
     FuturesHistorical: YFinanceFuturesHistoricalFetcher,
     AvailableIndices: YFinanceAvailableIndicesFetcher,
     EtfInfo: YFinanceEtfInfoFetcher,
+    EtfSearch: YFinanceEtfSearchFetcher,
     EquityScreener: YFinanceEquityScreenerFetcher,
     FuturesCurve: YFinanceFuturesCurveFetcher,
     OptionsChains: YFinanceOptionsChainsFetcher,

--- a/packages/opentypebb/src/providers/yfinance/models/etf-search.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/etf-search.ts
@@ -1,0 +1,53 @@
+/**
+ * Yahoo Finance ETF Search Model.
+ *
+ * No OpenBB Python counterpart (openbb_yfinance has no etf_search). Added so
+ * theme/keyword ETF lookup works keyless: FMP's etf_search hits company-screener
+ * which filters by financials, not name, so "robotics" returns junk. Yahoo's
+ * fuzzy search name-matches and tags ETFs via quoteType, which is exactly what
+ * thematic discovery needs.
+ */
+
+import { z } from 'zod'
+import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
+import { EtfSearchQueryParamsSchema, EtfSearchDataSchema } from '../../../standard-models/etf-search.js'
+import { searchYahooFinance } from '../utils/helpers.js'
+
+export const YFinanceEtfSearchQueryParamsSchema = EtfSearchQueryParamsSchema
+export type YFinanceEtfSearchQueryParams = z.infer<typeof YFinanceEtfSearchQueryParamsSchema>
+
+export const YFinanceEtfSearchDataSchema = EtfSearchDataSchema.extend({
+  exchange: z.string().nullable().default(null).describe('The exchange the ETF trades on.'),
+  quote_type: z.string().nullable().default(null).describe('The quote type of the asset.'),
+}).passthrough()
+export type YFinanceEtfSearchData = z.infer<typeof YFinanceEtfSearchDataSchema>
+
+export class YFinanceEtfSearchFetcher extends Fetcher {
+  static override transformQuery(params: Record<string, unknown>): YFinanceEtfSearchQueryParams {
+    return YFinanceEtfSearchQueryParamsSchema.parse(params)
+  }
+
+  static override async extractData(
+    query: YFinanceEtfSearchQueryParams,
+    credentials: Record<string, string> | null,
+  ): Promise<Record<string, unknown>[]> {
+    if (!query.query) return []
+
+    const quotes = await searchYahooFinance(query.query)
+    return quotes
+      .filter((q: any) => String(q.quoteType ?? '').toUpperCase() === 'ETF')
+      .map((q: any) => ({
+        symbol: q.symbol ?? '',
+        name: q.longname ?? q.shortname ?? null,
+        exchange: q.exchDisp ?? null,
+        quote_type: q.quoteType ?? null,
+      }))
+  }
+
+  static override transformData(
+    query: YFinanceEtfSearchQueryParams,
+    data: Record<string, unknown>[],
+  ): YFinanceEtfSearchData[] {
+    return data.map(d => YFinanceEtfSearchDataSchema.parse(d))
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { createTradingTools } from './tool/trading.js'
 import { SymbolIndex } from './domain/market-data/equity/index.js'
 import { CommodityCatalog } from './domain/market-data/commodity/index.js'
 import { createEquityTools } from './tool/equity.js'
+import { createEtfTools } from './tool/etf.js'
 import { getSDKExecutor, buildRouteMap, SDKEquityClient, SDKCryptoClient, SDKCurrencyClient, SDKEtfClient, SDKIndexClient, SDKDerivativesClient, SDKCommodityClient, SDKEconomyClient } from './domain/market-data/client/typebb/index.js'
 import type { EquityClientLike, CryptoClientLike, CurrencyClientLike, EtfClientLike, IndexClientLike, DerivativesClientLike, CommodityClientLike, EconomyClientLike } from './domain/market-data/client/types.js'
 import { buildSDKCredentials } from './domain/market-data/credential-map.js'
@@ -199,6 +200,9 @@ async function main() {
   toolCenter.register(createCronTools(cronEngine), 'cron')
   toolCenter.register(createMarketSearchTools(marketSearch), 'market-search')
   toolCenter.register(createEquityTools(equityClient), 'equity')
+  if (etfClient) {
+    toolCenter.register(createEtfTools(etfClient), 'etf')
+  }
   if (config.news.enabled) {
     toolCenter.register(createNewsArchiveTools(newsStore), 'news')
   }

--- a/src/tool/etf.ts
+++ b/src/tool/etf.ts
@@ -1,0 +1,103 @@
+/**
+ * ETF AI Tools
+ *
+ * etfSearch / etfGetInfo / etfGetHoldings / etfGetSectors:
+ *   thin bridge to the openTypeBB etf-router endpoints. Lets the agent
+ *   self-serve thematic ETFs — find a theme's ETF, then read whether the
+ *   theme actually attracted capital (the reflexivity read; see etfGetInfo).
+ *
+ * Provider note: ETF search/holdings/sectors are FMP-only; ETF info is served
+ * by yfinance (keyless) which also carries the reflexivity fields
+ * (total_assets / category / inception_date / volume_avg).
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { EtfClientLike } from '@/domain/market-data/client/types'
+
+export function createEtfTools(etfClient: EtfClientLike) {
+  return {
+    etfSearch: tool({
+      description: `Find ETFs by keyword or theme.
+
+Use this to locate the ETF(s) for a specific theme (e.g. "robotics", "uranium",
+"cybersecurity", "semiconductors") — the broad GICS sector ETFs are handled
+elsewhere; this is for going one level deeper into a specific theme.
+
+Reflexivity read: the *existence* of a thematic ETF means an issuer judged the
+theme had enough capital behind it to support a fund — a market-validated
+signal. But that signal is coarse and LATE (thematic ETFs cluster near theme
+peaks). After finding candidates, call etfGetInfo to gauge how much capital
+actually showed up (AUM × volume) before trusting the theme.`,
+      inputSchema: z.object({
+        query: z.string().describe('Theme or keyword, e.g. "robotics", "uranium", "semiconductor"'),
+        limit: z.number().int().positive().optional().describe('Max results (default: provider default)'),
+      }).meta({ examples: [{ query: 'robotics' }] }),
+      execute: async ({ query, limit }) => {
+        // yfinance: keyless, and name/theme-matches (FMP's etf_search hits
+        // company-screener which filters by financials, not name).
+        const params: Record<string, unknown> = { query, provider: 'yfinance' }
+        if (limit) params.limit = limit
+        return await etfClient.search(params)
+      },
+    }),
+
+    etfGetInfo: tool({
+      description: `Get an ETF's profile — issuer, category, inception date, AUM
+(total_assets), NAV, and average volume.
+
+This is the reflexivity gauge for a theme. Existence is binary; capital is
+graded — read it as a thermometer, not a switch:
+- AUM × dollar volume = how much money the theme actually attracted. High on
+  both = real; low AUM + thin volume = a zombie ETF = a bet that did NOT pay
+  off = an anti-signal for the theme.
+- A young inception_date (< ~1 year) on a fund already trading heavy = the
+  theme is in its reflexive acceleration phase — the most interesting case.
+- Caveat: thematic ETFs launch near theme tops and on average underperform
+  after launch. Treat all of this as right-side confirmation / an attention
+  radar, NOT as early alpha.
+
+If unsure of the ticker, use etfSearch first.`,
+      inputSchema: z.object({
+        symbol: z.string().describe('ETF ticker, e.g. "XLK", "SMH", "BOTZ"'),
+      }).meta({ examples: [{ symbol: 'SMH' }] }),
+      execute: async ({ symbol }) => {
+        // yfinance: keyless, and carries total_assets / category / inception_date / volume_avg.
+        const info = await etfClient.getInfo({ symbol, provider: 'yfinance' }).catch(() => [])
+        return info[0] ?? null
+      },
+    }),
+
+    etfGetHoldings: tool({
+      description: `Get an ETF's holdings — the underlying positions and their weights.
+
+Use this to see what's actually inside an ETF, and to catch single-name
+concentration that a sector/theme label hides (e.g. a "tech" ETF that is really
+a bet on two mega-caps). Complements etfGetSectors.
+
+If unsure of the ticker, use etfSearch first.`,
+      inputSchema: z.object({
+        symbol: z.string().describe('ETF ticker, e.g. "XLK", "SMH"'),
+      }).meta({ examples: [{ symbol: 'XLK' }] }),
+      execute: async ({ symbol }) => {
+        return await etfClient.getHoldings({ symbol, provider: 'fmp' })
+      },
+    }),
+
+    etfGetSectors: tool({
+      description: `Get an ETF's sector breakdown — its exposure weight per GICS sector.
+
+Use this to understand what an ETF actually bets on across sectors (a thematic
+ETF often spans several), or to confirm a broad sector ETF is as pure as its
+name implies.
+
+If unsure of the ticker, use etfSearch first.`,
+      inputSchema: z.object({
+        symbol: z.string().describe('ETF ticker, e.g. "XLK", "SMH"'),
+      }).meta({ examples: [{ symbol: 'XLK' }] }),
+      execute: async ({ symbol }) => {
+        return await etfClient.getSectors({ symbol, provider: 'fmp' })
+      },
+    }),
+  }
+}


### PR DESCRIPTION
## Summary
Implements [ANG-79](https://linear.app/angelkawaii/issue/ANG-79). The `EtfClientLike` domain capability existed but nothing bridged it to a tool, so the agent could find an ETF ticker but never evaluate one. This adds `src/tool/etf.ts` (registered in `main.ts` when `etfClient` exists), enabling the self-serve thematic-ETF flow that the sector-rotation design (ANG-80) depends on: enumerate big sectors; let the AI go find specific themes itself.

New tools:
- **etfSearch** — keyword/theme → ETF tickers.
- **etfGetInfo** — issuer / category / inception / AUM / NAV / avg volume. The reflexivity gauge, with the reading baked into the description: AUM × volume = did the theme actually attract capital; young inception + heavy volume = reflexive acceleration; zombie (low AUM + thin volume) = anti-signal; thematic ETFs launch near tops → right-side radar, not early alpha.
- **etfGetHoldings / etfGetSectors** — what's actually inside (single-name concentration a label hides).

Provider routing: `etfGetInfo` uses **yfinance (keyless)** — it carries the reflexivity fields; holdings/sectors are FMP-only.

## Drive-by fix: ETF search was broken
FMP's `etf_search` hits `company-screener`, which filters by financials, not name — so `"robotics"` returned junk (VOO, bond ETFs). Added a **yfinance `EtfSearch` fetcher** backed by yahoo fuzzy search (keyless, name-matches, tags ETFs via `quoteType`) and pointed the tool at it.

Live verification:
- `etfSearch`: robotics→BOTZ/ARKQ, uranium→URA/URNM, cybersecurity→CIBR/HACK/BUG.
- `etfGetInfo` SMH → AUM $67.8B, category Technology, inception 2011-12-20, avg-vol 9.6M.

## Test plan
- [x] `npx tsc --noEmit` clean (Alice)
- [x] `pnpm -F @traderalice/opentypebb exec tsc --noEmit` clean
- [x] `pnpm test` — 1759 passed
- [x] Live yahoo/FMP exercised end-to-end (search across 3 themes, getInfo, sectors)

## Boundary touch
Market-data spine (`packages/opentypebb` — new yfinance EtfSearch fetcher) + new agent tool surface. No trading / auth / broker-credential / migration paths.

Unblocks ANG-80 (GICS-11 sector rotation map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
