### PR TITLE
feat: sector rotation map — GICS-11 (AI tool + API route + Market UI) (ANG-80)

### DIFF
--- a/src/domain/analysis/sector-rotation.spec.ts
+++ b/src/domain/analysis/sector-rotation.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Sector rotation compute unit tests.
+ *
+ * Synthetic histories: most sectors flat; XLK engineered to rotate IN (sharp
+ * recent price rise + volume surge), XLU to rotate OUT (recent decline + volume
+ * fade). Asserts ranking, structure, and the derived metrics.
+ */
+import { describe, it, expect } from 'vitest'
+import type { OhlcvData } from './indicator/types'
+import {
+  computeSectorRotation,
+  GICS_SECTOR_ETFS,
+  BENCHMARK_SYMBOL,
+} from './sector-rotation'
+
+const BARS = 150
+const d = (i: number) => new Date(Date.UTC(2025, 0, 1) + i * 86400000).toISOString().slice(0, 10)
+
+function series(closeFn: (i: number) => number, volFn: (i: number) => number): OhlcvData[] {
+  return Array.from({ length: BARS }, (_, i) => {
+    const close = closeFn(i)
+    return { date: d(i), open: close, high: close, low: close, close, volume: volFn(i) }
+  })
+}
+
+const flat = (): OhlcvData[] => series(() => 100, () => 1000)
+
+// XLK — rotating in: flat then a sharp last-20-bar rise + volume surge.
+const rotatingIn = (): OhlcvData[] =>
+  series(
+    (i) => (i <= 129 ? 100 : 100 + (i - 129) * 2),
+    (i) => (i <= 129 ? 1000 : 1000 + (i - 129) * 400),
+  )
+
+// XLU — rotating out: slow rise then a last-20-bar decline + volume fade.
+const rotatingOut = (): OhlcvData[] =>
+  series(
+    (i) => (i <= 129 ? 100 + i * 0.2 : 100 + 129 * 0.2 - (i - 129) * 1.5),
+    (i) => (i <= 129 ? 1000 : Math.max(100, 1000 - (i - 129) * 40)),
+  )
+
+function buildHistories(): Record<string, OhlcvData[]> {
+  const h: Record<string, OhlcvData[]> = { [BENCHMARK_SYMBOL]: flat() }
+  for (const e of GICS_SECTOR_ETFS) {
+    h[e.symbol] = e.symbol === 'XLK' ? rotatingIn() : e.symbol === 'XLU' ? rotatingOut() : flat()
+  }
+  return h
+}
+
+describe('computeSectorRotation', () => {
+  const result = computeSectorRotation(buildHistories())
+
+  it('returns all 11 sectors + the SPY benchmark separately', () => {
+    expect(result.sectors).toHaveLength(11)
+    expect(result.benchmark.symbol).toBe('SPY')
+    expect(result.sectors.some((s) => s.symbol === 'SPY')).toBe(false)
+  })
+
+  it('ranks the rotating-in sector first and rotating-out last', () => {
+    expect(result.sectors[0].symbol).toBe('XLK')
+    expect(result.sectors[result.sectors.length - 1].symbol).toBe('XLU')
+  })
+
+  it('rotation_score is sorted descending', () => {
+    const scores = result.sectors.map((s) => s.rotation_score ?? -Infinity)
+    for (let i = 1; i < scores.length; i++) expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i])
+  })
+
+  it('rotating-in scores positive, rotating-out negative', () => {
+    const xlk = result.sectors.find((s) => s.symbol === 'XLK')!
+    const xlu = result.sectors.find((s) => s.symbol === 'XLU')!
+    expect(xlk.rotation_score!).toBeGreaterThan(0)
+    expect(xlu.rotation_score!).toBeLessThan(0)
+  })
+
+  it('computes multi-period returns and rel_strength vs SPY', () => {
+    const xlk = result.sectors.find((s) => s.symbol === 'XLK')!
+    // close 100 → 140 over the last 21 bars = +40%
+    expect(xlk.returns['1M']).toBeCloseTo(0.4, 2)
+    // SPY is flat, so rel_strength == raw return
+    expect(xlk.rel_strength['1M']).toBeCloseTo(0.4, 2)
+    expect(result.benchmark.returns['1M']).toBe(0)
+  })
+
+  it('momentum_acceleration: positive for rotating-in, negative for rotating-out', () => {
+    expect(result.sectors.find((s) => s.symbol === 'XLK')!.momentum_acceleration!).toBeGreaterThan(0)
+    expect(result.sectors.find((s) => s.symbol === 'XLU')!.momentum_acceleration!).toBeLessThan(0)
+  })
+
+  it('dv_share is a normalized fraction summing to ~1 across sectors', () => {
+    const total = result.sectors.reduce((s, r) => s + (r.dv_share ?? 0), 0)
+    expect(total).toBeCloseTo(1, 2)
+  })
+
+  it('rotating-in shows rising volume share, rotating-out falling', () => {
+    expect(result.sectors.find((s) => s.symbol === 'XLK')!.dv_share_change!).toBeGreaterThan(0)
+    expect(result.sectors.find((s) => s.symbol === 'XLU')!.dv_share_change!).toBeLessThan(0)
+  })
+
+  it('asOf is the latest bar date', () => {
+    expect(result.asOf).toBe(d(BARS - 1))
+  })
+
+  it('a sector with no data sinks to the bottom with null score', () => {
+    const h = buildHistories()
+    h['XLF'] = []
+    const r = computeSectorRotation(h)
+    const xlf = r.sectors.find((s) => s.symbol === 'XLF')!
+    expect(xlf.rotation_score).toBeNull()
+    expect(xlf.bars).toBe(0)
+    expect(r.sectors[r.sectors.length - 1].symbol).toBe('XLF')
+  })
+})

--- a/src/domain/analysis/sector-rotation.ts
+++ b/src/domain/analysis/sector-rotation.ts
@@ -1,0 +1,261 @@
+/**
+ * Sector rotation — cross-sectional comparison of the GICS sector ETFs on
+ * multi-period momentum and the two volume axes, to read where capital is
+ * rotating (ANG-80).
+ *
+ * The launcher enumerates ONLY the broad sector ETFs (stable, ~MECE coordinate
+ * system). Specific themes are reached by the agent via the ETF tools (etfSearch
+ * / etfGetInfo), not enumerated here.
+ *
+ * This module is pure: `computeSectorRotation` takes already-fetched OHLCV
+ * histories and returns the ranked table. Fetching lives in the tool layer.
+ */
+
+import type { OhlcvData } from './indicator/types.js'
+
+export interface SectorEtf {
+  symbol: string
+  sector: string
+}
+
+/** The 11 SPDR Select Sector ETFs (GICS). The enumerated rotation universe. */
+export const GICS_SECTOR_ETFS: SectorEtf[] = [
+  { symbol: 'XLK', sector: 'Technology' },
+  { symbol: 'XLC', sector: 'Communication Services' },
+  { symbol: 'XLY', sector: 'Consumer Discretionary' },
+  { symbol: 'XLP', sector: 'Consumer Staples' },
+  { symbol: 'XLE', sector: 'Energy' },
+  { symbol: 'XLF', sector: 'Financials' },
+  { symbol: 'XLV', sector: 'Health Care' },
+  { symbol: 'XLI', sector: 'Industrials' },
+  { symbol: 'XLB', sector: 'Materials' },
+  { symbol: 'XLRE', sector: 'Real Estate' },
+  { symbol: 'XLU', sector: 'Utilities' },
+]
+
+/** Broad-market anchor for relative strength (beat/lag the tape). */
+export const BENCHMARK_SYMBOL = 'SPY'
+
+/** Trading-day lookbacks per period label. */
+export const PERIOD_DAYS = { '1D': 1, '1W': 5, '1M': 21, '3M': 63, '6M': 126 } as const
+export type RotationPeriod = keyof typeof PERIOD_DAYS
+
+/** Trailing window for average dollar-volume / RVOL baselines. */
+const VOLUME_BASELINE_DAYS = 20
+
+export interface SectorRotationRow {
+  symbol: string
+  sector: string
+  /** Cumulative % return over each lookback (fraction, e.g. 0.034 = +3.4%). */
+  returns: Record<RotationPeriod, number | null>
+  /** Return minus the benchmark's over the same lookback. */
+  rel_strength: Record<RotationPeriod, number | null>
+  /** Per-trading-day pace of the 1W window minus the 3M window. >0 = accelerating. */
+  momentum_acceleration: number | null
+  /** Latest traded notional (close × volume). */
+  dollar_volume: number | null
+  /** This sector's share of the 11-set's total dollar volume today. */
+  dv_share: number | null
+  /** dv_share minus the sector's share computed off 20-day-average dollar volume.
+   *  >0 = taking a bigger slice of sector volume than its recent norm = rotating in. */
+  dv_share_change: number | null
+  /** Today's volume / 20-day average volume. */
+  rvol: number | null
+  /** Blended cross-sectional rank: mean of z(momentum_acceleration) and
+   *  z(dv_share_change) across the 11 sectors. Higher = rotating in. Null if
+   *  neither input is available. */
+  rotation_score: number | null
+  bars: number
+}
+
+export interface SectorRotationResult {
+  asOf: string
+  benchmark: { symbol: string; returns: Record<RotationPeriod, number | null> }
+  /** Sorted by rotation_score desc; rows with a null score sink to the bottom. */
+  sectors: SectorRotationRow[]
+  methodology: string
+}
+
+// ──────────────────────────── helpers ────────────────────────────
+
+function sortAsc(data: OhlcvData[]): OhlcvData[] {
+  return [...data].sort((a, b) => a.date.localeCompare(b.date))
+}
+
+/** Cumulative return over the last `nDays` bars, or null if not enough data. */
+function periodReturn(closes: number[], nDays: number): number | null {
+  if (closes.length < nDays + 1) return null
+  const last = closes[closes.length - 1]
+  const prior = closes[closes.length - 1 - nDays]
+  if (prior === 0) return null
+  return last / prior - 1
+}
+
+function mean(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length
+}
+
+/** Population standard deviation. */
+function stdev(xs: number[]): number {
+  if (xs.length < 2) return 0
+  const m = mean(xs)
+  return Math.sqrt(mean(xs.map((x) => (x - m) ** 2)))
+}
+
+/** Z-score a value against a population; 0 if the population can't discriminate. */
+function zscore(value: number, population: number[]): number {
+  const sd = stdev(population)
+  if (sd === 0) return 0
+  return (value - mean(population)) / sd
+}
+
+function round(n: number | null, places: number): number | null {
+  if (n === null || !Number.isFinite(n)) return null
+  return parseFloat(n.toFixed(places))
+}
+
+// ─────────────────────── per-ETF raw metrics ───────────────────────
+
+interface RawMetrics {
+  symbol: string
+  sector: string
+  closes: number[]
+  returns: Record<RotationPeriod, number | null>
+  momentumAccel: number | null
+  dvToday: number | null
+  dvBase: number | null
+  rvol: number | null
+  bars: number
+}
+
+function rawMetrics(symbol: string, sector: string, history: OhlcvData[]): RawMetrics {
+  const sorted = sortAsc(history)
+  const closes = sorted.map((d) => d.close)
+  const vols = sorted.map((d) => d.volume ?? 0)
+
+  const returns = {} as Record<RotationPeriod, number | null>
+  for (const [label, n] of Object.entries(PERIOD_DAYS)) {
+    returns[label as RotationPeriod] = periodReturn(closes, n)
+  }
+
+  // Momentum acceleration: per-trading-day pace of the short window vs the long.
+  const r1w = returns['1W']
+  const r3m = returns['3M']
+  const momentumAccel =
+    r1w !== null && r3m !== null ? r1w / PERIOD_DAYS['1W'] - r3m / PERIOD_DAYS['3M'] : null
+
+  // Dollar volume: latest, and the trailing baseline average.
+  const n = sorted.length
+  const dvToday = n > 0 ? closes[n - 1] * vols[n - 1] : null
+  let dvBase: number | null = null
+  let rvol: number | null = null
+  if (n >= VOLUME_BASELINE_DAYS + 1) {
+    const dvSeries: number[] = []
+    let volSum = 0
+    for (let i = n - VOLUME_BASELINE_DAYS; i < n; i++) dvSeries.push(closes[i] * vols[i])
+    for (let i = n - VOLUME_BASELINE_DAYS - 1; i < n - 1; i++) volSum += vols[i]
+    dvBase = mean(dvSeries)
+    const avgVol = volSum / VOLUME_BASELINE_DAYS
+    rvol = avgVol > 0 ? vols[n - 1] / avgVol : null
+  }
+
+  return { symbol, sector, closes, returns, momentumAccel, dvToday, dvBase, rvol, bars: n }
+}
+
+// ──────────────────────────── compute ────────────────────────────
+
+const METHODOLOGY =
+  'rotation_score = mean of cross-sectional z-scores of momentum_acceleration ' +
+  '(1W per-day pace minus 3M per-day pace) and dv_share_change (today\'s share of ' +
+  'the 11-sector dollar volume minus its share off the 20-day average). Ranked desc = ' +
+  'rotating in. CAVEAT: ETF dollar volume approximates sector capital but misses ' +
+  'single-name concentration, and is distorted by creation/redemption & hedging flows — ' +
+  'a proxy for fund flow, not a clean read.'
+
+/**
+ * Compute the sector rotation table from pre-fetched daily OHLCV histories.
+ * `histories` is keyed by symbol and must include the GICS sector ETFs; the
+ * benchmark (SPY) is optional but enables rel_strength.
+ */
+export function computeSectorRotation(
+  histories: Record<string, OhlcvData[]>,
+): SectorRotationResult {
+  const benchRaw = histories[BENCHMARK_SYMBOL]
+    ? rawMetrics(BENCHMARK_SYMBOL, 'Benchmark', histories[BENCHMARK_SYMBOL])
+    : null
+
+  const raws = GICS_SECTOR_ETFS.map((e) =>
+    rawMetrics(e.symbol, e.sector, histories[e.symbol] ?? []),
+  )
+
+  // Dollar-volume shares (sector universe only; exclude the benchmark).
+  const totalToday = raws.reduce((s, r) => s + (r.dvToday ?? 0), 0)
+  const totalBase = raws.reduce((s, r) => s + (r.dvBase ?? 0), 0)
+
+  const shareChanges = new Map<string, number | null>()
+  for (const r of raws) {
+    if (r.dvToday !== null && r.dvBase !== null && totalToday > 0 && totalBase > 0) {
+      shareChanges.set(r.symbol, r.dvToday / totalToday - r.dvBase / totalBase)
+    } else {
+      shareChanges.set(r.symbol, null)
+    }
+  }
+
+  // Cross-sectional populations for z-scoring.
+  const accelPop = raws.map((r) => r.momentumAccel).filter((x): x is number => x !== null)
+  const sharePop = [...shareChanges.values()].filter((x): x is number => x !== null)
+
+  const rows: SectorRotationRow[] = raws.map((r) => {
+    const relStrength = {} as Record<RotationPeriod, number | null>
+    for (const label of Object.keys(PERIOD_DAYS) as RotationPeriod[]) {
+      const sr = r.returns[label]
+      const br = benchRaw?.returns[label] ?? null
+      relStrength[label] = sr !== null && br !== null ? round(sr - br, 4) : null
+    }
+
+    const shareChange = shareChanges.get(r.symbol) ?? null
+    const zAccel = r.momentumAccel !== null ? zscore(r.momentumAccel, accelPop) : null
+    const zShare = shareChange !== null ? zscore(shareChange, sharePop) : null
+    const zParts = [zAccel, zShare].filter((x): x is number => x !== null)
+    const rotationScore = zParts.length > 0 ? mean(zParts) : null
+
+    const roundedReturns = {} as Record<RotationPeriod, number | null>
+    for (const label of Object.keys(PERIOD_DAYS) as RotationPeriod[]) {
+      roundedReturns[label] = round(r.returns[label], 4)
+    }
+
+    return {
+      symbol: r.symbol,
+      sector: r.sector,
+      returns: roundedReturns,
+      rel_strength: relStrength,
+      momentum_acceleration: round(r.momentumAccel, 6),
+      dollar_volume: round(r.dvToday, 0),
+      dv_share: r.dvToday !== null && totalToday > 0 ? round(r.dvToday / totalToday, 4) : null,
+      dv_share_change: round(shareChange, 4),
+      rvol: round(r.rvol, 2),
+      rotation_score: round(rotationScore, 3),
+      bars: r.bars,
+    }
+  })
+
+  rows.sort((a, b) => (b.rotation_score ?? -Infinity) - (a.rotation_score ?? -Infinity))
+
+  const benchReturns = {} as Record<RotationPeriod, number | null>
+  for (const label of Object.keys(PERIOD_DAYS) as RotationPeriod[]) {
+    benchReturns[label] = round(benchRaw?.returns[label] ?? null, 4)
+  }
+
+  // asOf = latest bar date across the inputs (no clock dependency).
+  const allDates = Object.values(histories)
+    .flatMap((h) => h.map((d) => d.date))
+    .sort()
+  const asOf = allDates.length > 0 ? allDates[allDates.length - 1] : ''
+
+  return {
+    asOf,
+    benchmark: { symbol: BENCHMARK_SYMBOL, returns: benchReturns },
+    sectors: rows,
+    methodology: METHODOLOGY,
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import { OpenBBCommodityClient } from './domain/market-data/client/openbb-api/co
 import { OpenBBEconomyClient } from './domain/market-data/client/openbb-api/economy-client.js'
 import { createMarketSearchTools } from './tool/market.js'
 import { createAnalysisTools } from './tool/analysis.js'
+import { createSectorRotationTools } from './tool/sector-rotation.js'
 import { createEconomyTools } from './tool/economy.js'
 import { SessionStore } from './core/session.js'
 import { createInboxStore } from './core/inbox-store.js'
@@ -207,6 +208,7 @@ async function main() {
     toolCenter.register(createNewsArchiveTools(newsStore), 'news')
   }
   toolCenter.register(createAnalysisTools(equityClient, cryptoClient, currencyClient, commodityClient), 'analysis')
+  toolCenter.register(createSectorRotationTools(equityClient), 'sector-rotation')
   toolCenter.register(createEconomyTools(economyClient, commodityClient), 'economy')
 
   console.log(`tool-center: ${toolCenter.list().length} tools registered`)

--- a/src/tool/sector-rotation.ts
+++ b/src/tool/sector-rotation.ts
@@ -1,0 +1,74 @@
+/**
+ * Sector Rotation Tool
+ *
+ * sectorRotation: cross-sectional view of the 11 GICS sector ETFs (+ SPY anchor)
+ *   on multi-period momentum and the two volume axes, ranked by a blended
+ *   rotation score. Pure orchestration: fetch daily histories, hand to the
+ *   domain compute (`domain/analysis/sector-rotation`).
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { EquityClientLike } from '@/domain/market-data/client/types'
+import type { OhlcvData } from '@/domain/analysis/indicator/types'
+import {
+  GICS_SECTOR_ETFS,
+  BENCHMARK_SYMBOL,
+  computeSectorRotation,
+} from '@/domain/analysis/sector-rotation.js'
+
+/** Calendar days of daily history to pull — enough for the 6M (126-bar) lookback
+ *  plus the 20-day volume baseline, with headroom for holidays/weekends. */
+const LOOKBACK_CALENDAR_DAYS = 300
+
+function startDate(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - LOOKBACK_CALENDAR_DAYS)
+  return d.toISOString().slice(0, 10)
+}
+
+export function createSectorRotationTools(equityClient: EquityClientLike) {
+  return {
+    sectorRotation: tool({
+      description: `Read sector rotation — which GICS sectors capital is rotating into or out of.
+
+Compares the 11 SPDR sector ETFs (XLK/XLF/XLV/XLY/XLP/XLE/XLI/XLB/XLU/XLRE/XLC)
+plus SPY as the benchmark, across 1D/1W/1M/3M/6M, on two volume axes
+(dollar-volume share + RVOL) and price momentum.
+
+Each row carries: returns + rel_strength (vs SPY) per period; momentum_acceleration
+(short-window pace vs long-window pace); dollar_volume and dv_share (capital weight);
+dv_share_change (this sector taking a bigger/smaller slice of sector volume than its
+recent norm — the rotation signal); rvol; and rotation_score.
+
+rotation_score is the blended cross-sectional rank (momentum acceleration + dollar-volume
+share change). Rows come sorted by it, descending — top = rotating in, bottom = rotating
+out. SPY is returned separately as the benchmark.
+
+This is the broad-sector lens. For a specific theme (robotics, uranium, cybersecurity,
+...) use etfSearch + etfGetInfo to go one level deeper. See the methodology field for the
+exact definitions and the fund-flow-proxy caveat.`,
+      inputSchema: z.object({}).meta({ examples: [{}] }),
+      execute: async () => {
+        const start_date = startDate()
+        const symbols = [...GICS_SECTOR_ETFS.map((e) => e.symbol), BENCHMARK_SYMBOL]
+
+        const fetched = await Promise.all(
+          symbols.map(async (symbol) => {
+            const raw = await equityClient
+              .getHistorical({ symbol, start_date, interval: '1d' })
+              .catch(() => [] as Array<Record<string, unknown>>)
+            const data = (raw as Array<Record<string, unknown>>).filter(
+              (d): d is Record<string, unknown> & OhlcvData =>
+                d.close != null && typeof d.date === 'string',
+            ) as OhlcvData[]
+            return [symbol, data] as const
+          }),
+        )
+
+        const histories: Record<string, OhlcvData[]> = Object.fromEntries(fetched)
+        return computeSectorRotation(histories)
+      },
+    }),
+  }
+}


### PR DESCRIPTION
## Summary
Implements [ANG-80](https://linear.app/angelkawaii/issue/ANG-80) end-to-end: a right-side "where is capital rotating" surface across the 11 GICS sector ETFs (+ SPY anchor), as an AI tool, an HTTP route, and a Market-area visualization. Scope expanded from the original tool-only cut to include the UI (per Ame's "直接做轮动图吧, 放到 Market").

### Backend
- **`domain/analysis/sector-rotation.ts`** — pure `computeSectorRotation` (multi-period returns, rel-strength vs SPY, `momentum_acceleration`, `dollar_volume`, `dv_share` + `dv_share_change`, `rvol`, blended cross-sectional `rotation_score`) + a `fetchSectorRotation(equityClient)` service shared by the tool and route.
- **`sectorRotation` AI tool** — one-liner over the service.
- **`GET /api/market/sector-rotation`** — thin route; `equityClient` now exposed on `EngineContext` (like `marketSearch`).

### Frontend (Market activity)
- **`MarketRotationPage`** — momentum × volume-share **quadrant scatter** (recharts): x = rel-strength vs SPY (1M), y = dollar-volume-share change, dots colored by `rotation_score`, four labeled quadrants (rotating in / improving / weakening / rotating out) — plus a **ranked table** sorted by score, and the methodology + fund-flow-proxy caveat inline. Polls every 5 min.
- Registered `market-rotation` view kind (types / registry / `UrlAdopter` deep link `/market/rotation`); sidebar row under Browse.
- i18n en/zh/ja (SPY / RVOL / GICS kept English per the accuracy-over-coverage convention).
- Demo: snapshot fixture + MSW handler matching `SectorRotationResult` (canonical type imported, no ad-hoc shape).

## Design decisions (with Ame)
- Enumerate **only broad sectors**; specific themes via the ETF tools (ANG-79), not enumerated.
- Score = **momentum acceleration + volume-share change**, not raw return — surfaces the *turn*, not what's extended.
- Quadrant + table; UI shipped now (was deferred, pulled forward at Ame's request).

## Live verification
- Backend over live yahoo: **XLF tops the score** (volume-share +7.6%, RVOL 1.63) while **XLK** (strongest raw momentum, 3M +37.8%) ranks mid — extended, not accelerating.
- The quadrant visually separates "rotating in" (top-right) from "rotating out" (bottom-left).

## Test plan
- [x] `npx tsc --noEmit` (Alice) clean
- [x] `cd ui && npx tsc -b` clean (strict)
- [x] `pnpm test` — 1769 passed (incl. 10 sector-rotation compute specs)
- [x] Live yahoo run; demo fixture validated against the API contract

## Boundary touch
New analysis domain module, market route, agent tool, and Market UI. Adds `equityClient` to `EngineContext`. No trading / auth / broker-credential / migration paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
