### PR TITLE
feat(ui/workspace): always-visible "New session" button in workspace header

### DIFF
--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useEffect } from 'react'
+import { Plus } from 'lucide-react'
 import '@xterm/xterm/css/xterm.css'
 
 import { useWorkspaces } from '../contexts/WorkspacesContext'
@@ -85,6 +86,15 @@ export function WorkspacePage({ spec, visible }: Props) {
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-bg-secondary/30 shrink-0">
         <span className="text-[12px] text-text-muted font-medium">{workspace.tag}</span>
         <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => void ctx.spawn(wsId, {})}
+            className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
+            title="Spawn a fresh session in this workspace (⌘T)"
+          >
+            <Plus size={13} strokeWidth={2.25} aria-hidden="true" />
+            New session
+          </button>
           <WorkspaceFilesToggle />
           <button
             type="button"


### PR DESCRIPTION
## Summary
- Spawning a fresh session was only reachable in-view via the "+ Start a new session" CTA at the **bottom** of the empty-state card list — with several sessions you had to scroll past all of them to find it (⌘T worked but isn't discoverable).
- Added a **"New session" button to the workspace header** (next to Files / AI Provider), so spawning is always one click away regardless of scroll position. The bottom CTA stays for the centered zero-session case.

## Test plan
- [x] `cd ui && npx tsc -b` clean
- [ ] Open a workspace with several sessions → "New session" visible top-right without scrolling → click spawns a fresh session
- [x] No `/api/*` shape change → demo handlers unaffected

## Boundary touch
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)