### PR TITLE
feat(ui): Traditional Chinese (zh-Hant) + top-nav page i18n coverage

### DIFF
--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -14,6 +14,7 @@ import { initReactI18next } from 'react-i18next'
 import { en } from './locales/en'
 import { zh } from './locales/zh'
 import { ja } from './locales/ja'
+import { zhHant } from './locales/zh-Hant'
 import { type AppLocale, setAppLocale } from '../lib/intl'
 import { useLocaleStore, readInitialLocale } from './store'
 
@@ -23,11 +24,12 @@ export const resources = {
   en: { translation: en },
   zh: { translation: zh },
   ja: { translation: ja },
+  'zh-Hant': { translation: zhHant },
 }
 
 function applyLocale(locale: AppLocale): void {
   setAppLocale(locale) // formatters (lib/intl, lib/format) follow
-  document.documentElement.lang = locale // drives :lang(ja) font swap in index.css
+  document.documentElement.lang = locale // drives :lang(ja)/:lang(zh-Hant) font swap in index.css
   void i18n.changeLanguage(locale)
 }
 

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1,0 +1,170 @@
+import type { Resources } from './en'
+
+/**
+ * 繁體中文 (Traditional Chinese, Hant script). Typed as `Resources` → must
+ * match en's key structure exactly.
+ *
+ * Locale id is the SCRIPT subtag `zh-Hant` (Traditional Han), not a region
+ * tag — deliberately neutral. Vocabulary follows common Traditional-Chinese
+ * software conventions (伺服器 / 檔案 / 載入 / 儲存 / 設定 / 資料 / 搜尋 …).
+ * Content is UI chrome only — no geographic or other non-technical terms.
+ */
+export const zhHant: Resources = {
+  nav: {
+    item: {
+      inbox: '收件匣',
+      tracked: '追蹤',
+      chat: '對話',
+      workspaces: '工作區',
+      market: '市場',
+      news: '新聞',
+      tradingAsGit: '交易即 Git',
+      portfolio: '投資組合',
+      automation: '自動化',
+      settings: '設定',
+      dev: '開發',
+    },
+    section: {
+      beta: '測試版',
+      system: '系統',
+    },
+    betaDescription:
+      '功能可用，但尚不穩定。Trading-as-Git 與投資組合呈現的是跨券商的統一狀態，其底層抽象仍在定型中——可以試用，但請勿依賴其 schema 或 UX 的穩定性。自動化能運行，但在目前的 Harness 架構下其觸發鏈尚未閉合，因此在 Harness 排程落地前無法端對端觸發。券商連線設定位於 設定 → 交易。',
+    unread: '{{count}} 則未讀',
+    about: '關於{{label}}',
+  },
+  settings: {
+    title: '設定',
+    tab: {
+      settings: '設定',
+      tools: '工具',
+    },
+    language: {
+      title: '語言',
+      description: '介面語言，立即生效。',
+    },
+    category: {
+      general: '一般',
+      aiProvider: 'AI 供應商',
+      trading: '交易',
+      mcpServer: 'MCP 伺服器',
+      marketData: '市場資料',
+      newsSources: '新聞來源',
+    },
+    agent: {
+      title: '智慧體',
+      description: '控制 AI 的檔案系統與工具權限。變更會在下一次請求時生效。',
+      evolutionMode: '進化模式',
+      evolutionOn: '完整專案存取權——AI 可修改原始碼',
+      evolutionOff: '沙箱模式——AI 只能編輯 data/brain/',
+    },
+    persona: {
+      title: '人設',
+      description: '定義 Alice 個性與行為的系統提示詞。變更會在下次伺服器重新啟動後生效。',
+      loadError: '載入人設失敗',
+      saveError: '儲存失敗',
+      loading: '載入中…',
+      saving: '儲存中…',
+      save: '儲存',
+      saved: '已儲存',
+      unsaved: '有未儲存的變更',
+    },
+    compaction: {
+      title: '壓縮',
+      description: '上下文視窗管理。當對話長度接近 最大上下文 減 最大輸出 tokens 時，較早的訊息會被自動摘要以釋放空間。',
+      maxContextTokens: '最大上下文 Tokens',
+      maxOutputTokens: '最大輸出 Tokens',
+    },
+    tools: {
+      summary: '{{groups}} 個分組共 {{tools}} 個工具——變更會在下次 AI 請求時生效',
+      emptyTitle: '尚未註冊任何工具。',
+      emptyDescription: '引擎啟動後工具會顯示在這裡。',
+      group: {
+        thinking: '思考工具集',
+        cron: 'Cron 排程器',
+        equity: '股票資料',
+        cryptoData: '加密貨幣資料',
+        currencyData: '貨幣資料',
+        news: '新聞',
+        newsArchive: '新聞封存',
+        analysis: '分析工具集',
+        cryptoTrading: '加密貨幣交易',
+        securitiesTrading: '證券交易',
+      },
+    },
+  },
+  common: {
+    loading: '載入中…',
+    searching: '搜尋中…',
+    tools: '工具',
+    logs: '日誌',
+    off: '關閉',
+  },
+  dev: {
+    snapshots: '快照',
+  },
+  simulator: {
+    title: '模擬器',
+  },
+  market: {
+    searchPlaceholder: '搜尋資產…',
+    browseSection: '瀏覽',
+    browseMarkets: '瀏覽市場',
+    searchResults: '搜尋結果',
+    noMatches: '無相符項目',
+    watchlist: '自選',
+    emptyWatchlistHint: '在詳細頁面將資產釘選到這裡。',
+    removeFromWatchlist: '移除 {{symbol}}',
+    sectorRotation: '類股輪動',
+    rotationSubtitle: '資金在 11 個 GICS 類股之間的輪動。',
+    asOf: '截至',
+    rotationMethodology: '計算方式',
+    quadRotatingIn: '輪入',
+    quadImproving: '回暖',
+    quadWeakening: '走弱',
+    quadRotatingOut: '輪出',
+    axisRelStrength: '相對 SPY 強弱（1M）',
+    axisVolumeShare: '成交額佔比 Δ',
+    colSector: '類股',
+    colScore: '輪動分',
+    colVsBench: 'vs {{sym}}',
+    colRvol: 'RVOL',
+    colVolShareDelta: '佔比 Δ',
+  },
+  portfolio: {
+    overview: '總覽',
+    allAccounts: '所有帳戶',
+    accounts: '帳戶',
+    noAccountsYet: '尚無帳戶。請在 設定 → 交易 中新增。',
+  },
+  automation: {
+    flow: '流程',
+    heartbeat: '心跳',
+    cronJobs: 'Cron 任務',
+    webhook: 'Webhook',
+  },
+  news: {
+    allNews: '所有新聞',
+  },
+  tracked: {
+    nothingTrackedYet: '尚未追蹤任何項目。',
+    backlinksTooltip: '{{count}} 則筆記連結到此',
+  },
+  inbox: {
+    noMessages: '收件匣是空的。',
+    emptyHint: '工作區會將狀態更新推送到這裡。',
+    dateToday: '今天',
+    dateYesterday: '昨天',
+    dateThisWeek: '本週',
+    dateOlder: '更早',
+  },
+  auth: {
+    heading: '登入 OpenAlice',
+    instruction: '貼上首次啟動時顯示的管理員權杖。',
+    adminTokenLabel: '管理員權杖',
+    signingIn: '登入中…',
+    signIn: '登入',
+    noTokenHeading: '未設定管理員權杖',
+    loginFailed: '登入失敗',
+  },
+}

--- a/ui/src/i18n/useLocale.ts
+++ b/ui/src/i18n/useLocale.ts
@@ -19,4 +19,5 @@ export const LOCALE_LABELS: Record<AppLocale, string> = {
   en: 'English',
   zh: '中文',
   ja: '日本語',
+  'zh-Hant': '繁體中文',
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -35,6 +35,16 @@
     "Meiryo", "Noto Sans JP", sans-serif;
 }
 
+/* Traditional Chinese (Hant script) gets a Traditional-first sans stack so
+   shared Han characters render in Traditional forms, not the Simplified ones
+   the default stack would pick. Scoped via <html lang="zh-Hant"> — region-
+   neutral (serves both Taiwan and Hong Kong Traditional readers). */
+:root:lang(zh-Hant) {
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "PingFang TC", "Microsoft JhengHei", "Noto Sans TC",
+    "Noto Sans CJK TC", sans-serif;
+}
+
 html,
 body,
 #root {

--- a/ui/src/lib/intl.ts
+++ b/ui/src/lib/intl.ts
@@ -15,13 +15,15 @@
  * workspace name) — those stay 'en' so generated ids don't shift with locale.
  */
 
-export type AppLocale = 'en' | 'zh' | 'ja'
+export type AppLocale = 'en' | 'zh' | 'ja' | 'zh-Hant'
 
-/** App locale → BCP-47 tag handed to the Intl.* APIs. */
+/** App locale → BCP-47 tag handed to the Intl.* APIs. `zh-Hant` is the
+ *  Traditional-Han SCRIPT subtag (region-neutral), not a region tag. */
 const BCP47: Record<AppLocale, string> = {
   en: 'en-US',
   zh: 'zh-CN',
   ja: 'ja-JP',
+  'zh-Hant': 'zh-Hant',
 }
 
 let _appLocale: AppLocale = 'en'

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -19,7 +19,7 @@ function LanguageSection() {
   return (
     <ConfigSection title={t('settings.language.title')} description={t('settings.language.description')}>
       <div className="flex gap-2 py-1">
-        {(['en', 'zh', 'ja'] as const).map((l) => (
+        {(['en', 'zh', 'ja', 'zh-Hant'] as const).map((l) => (
           <button
             key={l}
             type="button"


### PR DESCRIPTION
## Summary
Adds **Traditional Chinese (繁體中文)** as the 4th UI locale, on top of the existing en / 中文 / 日本語.

- Uses the Traditional-Han **script** subtag `zh-Hant` (region-neutral), not a region tag — one Traditional catalog serves all Traditional-Chinese readers. Picker label is the neutral script name `繁體中文`.
- `ui/src/i18n/locales/zh-Hant.ts` — full Traditional catalog, structurally enforced against the English source via the `Resources` type. Vocabulary follows common Traditional-Chinese software/finance conventions (伺服器 / 檔案 / 載入 / 儲存 / 設定 / 搜尋 / 權杖 / 類股…). Technical/jargon terms stay English per the existing "accuracy over coverage" rule (Harness, MCP, Cron, Webhook, Trading as Git).
- `AppLocale` + `BCP47` + `LOCALE_LABELS` + i18n `resources` + the Settings picker extended to 4 locales.
- `:root:lang(zh-Hant)` Traditional-first font stack (PingFang TC / Microsoft JhengHei / Noto Sans TC) so Han glyphs render in Traditional forms.

Content is UI chrome only — no geographic or other non-technical terms.

## Test plan
- [x] `cd ui && tsc -b` clean — the `Resources` type guarantees zh-Hant has the exact same keys as the English source (no missing/extra)
- [x] `pnpm test --project ui` — 38/38
- [ ] Reviewer: pick 繁體中文 in Settings and eyeball the rail / sidebars / Settings / login (`<html lang="zh-Hant">` flips the font stack to Traditional)

## Boundary touch
None. Pure additive UI-string + font-stack change; no auth/trading/migration surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
