### PR TITLE
fix(workspace): launch opencode/pi from the frontend on Windows

### DIFF
--- a/src/workspaces/headless-task.ts
+++ b/src/workspaces/headless-task.ts
@@ -23,6 +23,7 @@
 import { spawn } from 'node:child_process';
 
 import type { Logger } from './logger.js';
+import { resolveLaunchCommand } from './win-command.js';
 
 const KILL_GRACE_MS = 5_000;
 const OUTPUT_TAIL_BYTES = 16 * 1024;
@@ -78,7 +79,7 @@ function makeTailSink(maxBytes: number): { push(c: Buffer): void; text(): string
 
 export async function runHeadlessTask(args: HeadlessTaskArgs): Promise<HeadlessTaskResult> {
   const { command, cwd, env, timeoutMs, logger } = args;
-  const [argv0, ...argv1] = command;
+  const [argv0] = command;
   if (!argv0) throw new Error('headless: empty command');
 
   const start = Date.now();
@@ -88,14 +89,35 @@ export async function runHeadlessTask(args: HeadlessTaskArgs): Promise<HeadlessT
   const outSink = makeTailSink(OUTPUT_TAIL_BYTES);
   const errSink = makeTailSink(OUTPUT_TAIL_BYTES);
 
-  // KNOWN GAP (win32): plain shell-less spawn of a bare CLI name (`claude` etc.)
-  // won't resolve the npm `.cmd` shim on Windows (post-CVE-2024-27980 Node
-  // disabled that), so headless tasks ENOENT on win32. The interactive pool
-  // avoids this by using node-pty (ConPTY resolves shims). NOT fixed with
-  // `shell:true` — that would re-parse the prompt arg through cmd.exe and
-  // re-open shell injection. Proper fix = resolve the shim path / cross-spawn.
-  // Tracked for follow-up; primary targets (macOS dev, Linux cloud) are fine.
-  const child = spawn(argv0, argv1, {
+  // win32: resolve the bare CLI name against PATH × PATHEXT. Native-exe agents
+  // (claude.exe, codex.exe) resolve to a direct path and run headless fine. But
+  // npm-shim agents (opencode, pi → a `.cmd`) would have to run through cmd.exe,
+  // and the headless PROMPT is the trailing arg — routing it through cmd.exe
+  // re-parses shell metacharacters (CVE-2024-27980 territory), a real injection
+  // surface. So shim agents stay headless-unsupported on Windows; we fail with a
+  // clear, recorded reason instead of a silent ENOENT. (Interactive launch of
+  // the same agents works — see win-command.ts / persistent-session.ts.)
+  const resolved = resolveLaunchCommand(command, { env });
+  if (resolved.viaShell) {
+    logger.error('headless.win32_shim_unsupported', { command: argv0 });
+    return {
+      command,
+      cwd,
+      exitCode: -1,
+      signal: null,
+      killed: false,
+      durationMs: Date.now() - start,
+      stdoutTail: '',
+      stderrTail:
+        `win32: "${argv0}" is an npm .cmd shim; headless dispatch is unsupported ` +
+        `on Windows (routing the task prompt through cmd.exe is a shell-injection ` +
+        `surface). Native-exe agents (claude, codex) run headless; run shim agents ` +
+        `(opencode, pi) interactively instead.`,
+    };
+  }
+  const [spawnFile, ...spawnArgs] = resolved.argv;
+  if (!spawnFile) throw new Error('headless: empty command after resolution');
+  const child = spawn(spawnFile, spawnArgs, {
     cwd,
     env: env as NodeJS.ProcessEnv,
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/workspaces/persistent-session.ts
+++ b/src/workspaces/persistent-session.ts
@@ -7,6 +7,7 @@ import {
   type ServerControlMessage,
 } from './protocol.js';
 import { ReplayBuffer } from './replay-buffer.js';
+import { resolveLaunchCommand } from './win-command.js';
 
 export interface PersistentSessionOptions {
   /** The workspace this session belongs to (for routing, logging, cwd context). */
@@ -116,7 +117,17 @@ export class PersistentSession {
   }
 
   private spawnChild(): pty.IPty {
-    const [argv0, ...args] = this.opts.command;
+    if (this.opts.command.length === 0) {
+      throw new Error('command must contain at least one argv element');
+    }
+    // win32: resolve the bare CLI name to its real `.exe`, or wrap a `.cmd`/
+    // `.ps1` npm shim through cmd.exe — ConPTY's CreateProcess only appends
+    // `.exe`, so npm-shim CLIs (opencode, pi) otherwise never launch. No-op off
+    // Windows. The interactive command is flags + a uuid, so the shell wrap is
+    // injection-safe here. See win-command.ts.
+    const [argv0, ...args] = resolveLaunchCommand(this.opts.command, {
+      env: this.opts.env,
+    }).argv;
     if (!argv0) throw new Error('command must contain at least one argv element');
 
     const term = pty.spawn(argv0, args, {

--- a/src/workspaces/probe.ts
+++ b/src/workspaces/probe.ts
@@ -27,6 +27,7 @@ import { join } from 'node:path';
 import * as pty from 'node-pty';
 
 import type { Logger } from './logger.js';
+import { resolveLaunchCommand } from './win-command.js';
 
 export interface HeadlessProbeArgs {
   readonly command: readonly string[];
@@ -69,7 +70,12 @@ const KILL_GRACE_MS = 500;
 export async function runHeadlessProbe(args: HeadlessProbeArgs): Promise<HeadlessProbeResult> {
   const { command, cwd, env, transcriptDir, transcriptFileRe, prompt, timeoutMs, logger } = args;
 
-  const [argv0, ...argv1Composed] = command;
+  // win32: resolve the bare CLI name to a real `.exe` or a cmd.exe-wrapped
+  // `.cmd` shim before the prompt is appended — same ConPTY limitation the
+  // interactive pool handles. Without this, probing opencode/pi on Windows
+  // ENOENTs and the agent can never be enabled. The probe prompt is a fixed
+  // launcher-internal ping (no untrusted input), so the shim wrap is safe.
+  const [argv0, ...argv1Composed] = resolveLaunchCommand(command, { env }).argv;
   if (!argv0) throw new Error('probe: empty command');
   const argv1 = [...argv1Composed, prompt];
 

--- a/src/workspaces/win-command.spec.ts
+++ b/src/workspaces/win-command.spec.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveLaunchCommand } from './win-command.js';
+
+// A fake Windows PATHEXT — order intentionally puts .CMD before .EXE to prove
+// the resolver prefers a real executable regardless of PATHEXT ordering.
+const PATHEXT = '.CMD;.EXE;.BAT;.PS1';
+
+let dir: string;
+let env: NodeJS.ProcessEnv;
+
+async function touch(name: string): Promise<void> {
+  await writeFile(join(dir, name), '');
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'wincmd-'));
+  env = { PATH: dir, PATHEXT, ComSpec: 'C:\\Windows\\System32\\cmd.exe' };
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('resolveLaunchCommand', () => {
+  it('is the identity function off win32', () => {
+    const r = resolveLaunchCommand(['pi', '--continue'], { platform: 'linux', env });
+    expect(r).toEqual({ argv: ['pi', '--continue'], viaShell: false });
+  });
+
+  it('win32: a native .exe resolves to its full path, run directly', async () => {
+    await touch('codex.exe');
+    const r = resolveLaunchCommand(['codex', 'exec'], { platform: 'win32', env });
+    expect(r.viaShell).toBe(false);
+    expect(r.argv).toEqual([join(dir, 'codex.exe'), 'exec']);
+  });
+
+  it('win32: a .cmd npm shim is wrapped through cmd.exe', async () => {
+    await touch('pi.cmd');
+    const r = resolveLaunchCommand(['pi', '--session-id', 'abc'], { platform: 'win32', env });
+    expect(r.viaShell).toBe(true);
+    expect(r.argv).toEqual([
+      'C:\\Windows\\System32\\cmd.exe',
+      '/d',
+      '/c',
+      join(dir, 'pi.cmd'),
+      '--session-id',
+      'abc',
+    ]);
+  });
+
+  it('win32: prefers .exe over a .cmd shim when both exist', async () => {
+    await touch('opencode.cmd');
+    await touch('opencode.exe');
+    const r = resolveLaunchCommand(['opencode', 'run'], { platform: 'win32', env });
+    expect(r.viaShell).toBe(false);
+    expect(r.argv).toEqual([join(dir, 'opencode.exe'), 'run']);
+  });
+
+  it('win32: an unresolved name passes through unchanged (fails loudly later)', () => {
+    const r = resolveLaunchCommand(['nope', '--x'], { platform: 'win32', env });
+    expect(r).toEqual({ argv: ['nope', '--x'], viaShell: false });
+  });
+
+  it('win32: a name with an explicit extension is trusted, not re-resolved', async () => {
+    await touch('pi.cmd');
+    const r = resolveLaunchCommand(['pi.cmd', '-p'], { platform: 'win32', env });
+    expect(r).toEqual({ argv: ['pi.cmd', '-p'], viaShell: false });
+  });
+
+  it('win32: a name that is already a path is trusted as-is', () => {
+    const r = resolveLaunchCommand(['C:\\tools\\pi', '-p'], { platform: 'win32', env });
+    expect(r).toEqual({ argv: ['C:\\tools\\pi', '-p'], viaShell: false });
+  });
+
+  it('win32: searches multiple PATH entries', async () => {
+    const other = await mkdtemp(join(tmpdir(), 'wincmd2-'));
+    try {
+      await writeFile(join(other, 'claude.exe'), '');
+      const r = resolveLaunchCommand(['claude'], {
+        platform: 'win32',
+        env: { ...env, PATH: `${dir}${delimiter}${other}` },
+      });
+      expect(r.argv).toEqual([join(other, 'claude.exe')]);
+    } finally {
+      await rm(other, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to a default PATHEXT when the env var is absent', async () => {
+    await touch('pi.cmd');
+    const r = resolveLaunchCommand(['pi'], {
+      platform: 'win32',
+      env: { PATH: dir, ComSpec: 'cmd.exe' },
+    });
+    expect(r.viaShell).toBe(true);
+    expect(r.argv[0]).toBe('cmd.exe');
+    expect(r.argv).toContain(join(dir, 'pi.cmd'));
+  });
+
+  it('handles an empty argv', () => {
+    expect(resolveLaunchCommand([], { platform: 'win32', env })).toEqual({
+      argv: [],
+      viaShell: false,
+    });
+  });
+});

--- a/src/workspaces/win-command.ts
+++ b/src/workspaces/win-command.ts
@@ -1,0 +1,101 @@
+/**
+ * Cross-platform launch-command resolution for the workspace spawners.
+ *
+ * The bug this fixes: the agent CLIs are spawned by BARE NAME (`opencode`,
+ * `pi`, `claude`, `codex`). On Windows, node-pty hands that name straight to
+ * ConPTY's `CreateProcessW`, which searches PATH but only ever appends `.exe`
+ * — it never tries `.cmd`/`.bat`. So:
+ *
+ *   - claude / codex ship NATIVE executables (`claude.exe`, `codex.exe`) →
+ *     resolve fine.
+ *   - opencode / pi install as npm shims — on Windows that's a `.cmd` (+ a
+ *     `.ps1` and an extensionless sh script), NO `.exe`. CreateProcess looking
+ *     for `opencode.exe` / `pi.exe` finds nothing → the workspace never
+ *     launches. This is the "Windows can't start opencode/pi from the
+ *     frontend" report.
+ *
+ * Fix: on win32, do the PATH × PATHEXT lookup ourselves.
+ *   - resolves to a real executable (.exe/.com) → spawn that full path directly.
+ *   - resolves to a batch shim (.cmd/.bat)      → spawn via `cmd.exe /d /c
+ *     <shim> <args>` (CreateProcess cannot execute a batch file directly; it
+ *     must go through the command interpreter).
+ *   - not found, or the caller already passed a path / an explicit extension →
+ *     passthrough unchanged (let it fail loudly with the original name).
+ *
+ * On non-Windows this is the identity function: the kernel reads shebangs and a
+ * bare-name PATH lookup finds shell-script shims fine.
+ */
+import { existsSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+
+export interface ResolvedCommand {
+  readonly argv: readonly string[];
+  /**
+   * True iff the command was wrapped through `cmd.exe` to run a `.cmd`/`.bat`
+   * shim (win32 only). Callers that append an UNTRUSTED positional arg (e.g. a
+   * headless prompt) must NOT use this form — cmd.exe re-parses shell
+   * metacharacters (`& | < > ^ %`) in that arg, which is a command-injection
+   * surface. The interactive/probe paths only ever pass flags + a uuid, so the
+   * wrap is safe there.
+   */
+  readonly viaShell: boolean;
+}
+
+const DEFAULT_PATHEXT = '.COM;.EXE;.BAT;.CMD';
+
+export function resolveLaunchCommand(
+  argv: readonly string[],
+  opts: { platform?: NodeJS.Platform; env?: NodeJS.ProcessEnv } = {},
+): ResolvedCommand {
+  const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
+  if (platform !== 'win32' || argv.length === 0) return { argv, viaShell: false };
+
+  const [name, ...rest] = argv;
+  if (!name) return { argv, viaShell: false };
+  // Caller gave an explicit path or extension → trust it, don't re-resolve.
+  if (name.includes('/') || name.includes('\\') || /\.[^.\\/]+$/.test(name)) {
+    return { argv, viaShell: false };
+  }
+
+  const resolved = lookupOnWindowsPath(name, env);
+  if (!resolved) return { argv, viaShell: false }; // fail loudly with original name
+
+  const dot = resolved.lastIndexOf('.');
+  const ext = dot >= 0 ? resolved.slice(dot).toLowerCase() : '';
+  if (ext === '.cmd' || ext === '.bat') {
+    const comspec = env['ComSpec'] || env['COMSPEC'] || 'cmd.exe';
+    // /d skips any AutoRun registry command; /c runs then exits. The shim path
+    // is a single arg (node-pty/Node quote it if it contains spaces); cmd's
+    // default rule preserves a single quoted-executable + bare args correctly.
+    return { argv: [comspec, '/d', '/c', resolved, ...rest], viaShell: true };
+  }
+  return { argv: [resolved, ...rest], viaShell: false };
+}
+
+function lookupOnWindowsPath(name: string, env: NodeJS.ProcessEnv): string | null {
+  const exts = (env['PATHEXT'] ?? DEFAULT_PATHEXT)
+    .split(';')
+    .map((e) => e.trim())
+    .filter(Boolean)
+    .sort((a, b) => rank(a) - rank(b)); // prefer a real .exe over a .cmd shim
+  // Windows env var casing is unstable across hosts; check both.
+  const dirs = (env['PATH'] ?? env['Path'] ?? '').split(delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      // PATHEXT is conventionally uppercase but npm shims are lowercase on disk.
+      // Windows' filesystem is case-insensitive, so we normalize the appended
+      // extension to lowercase for a clean, deterministic command string.
+      const candidate = join(dir, name + ext.toLowerCase());
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function rank(ext: string): number {
+  const e = ext.toLowerCase();
+  if (e === '.exe' || e === '.com') return 0;
+  if (e === '.cmd' || e === '.bat') return 1;
+  return 2;
+}


### PR DESCRIPTION
## Summary
- **Fixes: opencode/pi can't be launched from the frontend on Windows.** ConPTY's `CreateProcess` only appends `.exe` when resolving a bare command name from PATH — it never tries `.cmd`/`.bat`. `claude`/`codex` ship native `.exe`s (resolved fine, which masked the bug); `opencode`/`pi` install as npm shims (only a `.cmd`/`.ps1` exists, no `.exe`) → spawned by bare name they ENOENT and the workspace never launches. Community-reported on Windows.
- Adds `resolveLaunchCommand` (`src/workspaces/win-command.ts`): on win32, do the `PATH × PATHEXT` lookup ourselves — native `.exe` spawned directly, `.cmd`/`.bat` shim wrapped through `cmd.exe /d /c`. No-op off Windows.
- Wired into both node-pty spawn sites (`persistent-session` interactive, `probe` agent-detection), where args are flags + a uuid so the shell wrap is injection-safe.
- Headless dispatch gets the same resolution: native-exe agents (claude/codex) now run headless on win32 too. `.cmd`-shim agents stay headless-unsupported on Windows — the task prompt is the trailing arg and routing it through cmd.exe would re-parse shell metacharacters (a real injection surface) — but now fail with a clear, recorded reason instead of a silent ENOENT.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` passes (1844)
- [x] New `win-command.spec.ts` — 10 cases, deterministically drives the win32 branch (exe direct / cmd wrap / exe-preferred-over-cmd / multi-PATH / PATHEXT fallback / passthrough)
- [x] mac boot smoke (`pnpm test:smoke`) HARD checks pass
- [ ] **Real Windows launch** — NOT covered by CI. The `dev-smoke` Windows job boots the guardian stack (tsx/pnpm shims), not workspace agent CLIs, so it neither caught this nor verifies the fix. The unit test verifies the resolution *logic* cross-platform but not real ConPTY spawn. Needs a manual check on a Windows box with opencode/pi installed. Follow-up option: add a real `node-pty` spawn assertion (temp `.cmd`) to the windows-latest matrix.

## Boundary touch
None — workspace launcher spawn plumbing only; no trading / auth / broker / migration surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
