### PR TITLE
feat(ai-config): refresh provider model catalog to current lineups

### DIFF
--- a/src/ai-providers/agent-sdk/query.ts
+++ b/src/ai-providers/agent-sdk/query.ts
@@ -239,7 +239,7 @@ export async function askAgentSdk(
       options: {
         cwd,
         env,
-        model: override?.model ?? 'claude-opus-4-7',
+        model: override?.model ?? 'claude-opus-4-8',
         maxTurns,
         allowedTools: finalAllowed,
         disallowedTools: finalDisallowed,

--- a/src/ai-providers/codex/codex-provider.ts
+++ b/src/ai-providers/codex/codex-provider.ts
@@ -27,7 +27,7 @@ const logger = pino({
 
 const DEFAULT_OAUTH_BASE_URL = 'https://chatgpt.com/backend-api/codex'
 const DEFAULT_API_BASE_URL = 'https://api.openai.com/v1'
-const DEFAULT_MODEL = 'gpt-5.4'
+const DEFAULT_MODEL = 'gpt-5.5'
 
 // ==================== Provider ====================
 

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -68,11 +68,11 @@ export const CLAUDE_OAUTH: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('claudeai'),
-    model: z.string().default('claude-opus-4-7').describe('Model'),
+    model: z.string().default('claude-opus-4-8').describe('Model'),
   }),
   models: [
+    { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
     { id: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
-    { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
     { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   ],
   sdkAdapters: {
@@ -93,12 +93,12 @@ export const CLAUDE_API: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
-    model: z.string().default('claude-opus-4-7').describe('Model'),
+    model: z.string().default('claude-opus-4-8').describe('Model'),
     apiKey: z.string().min(1).describe('Anthropic API key'),
   }),
   models: [
+    { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
     { id: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
-    { id: 'claude-opus-4-6', label: 'Claude Opus 4.6' },
     { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
     { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
   ],
@@ -124,9 +124,10 @@ export const CODEX_OAUTH: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('codex'),
     loginMethod: z.literal('codex-oauth'),
-    model: z.string().default('gpt-5.4').describe('Model'),
+    model: z.string().default('gpt-5.5').describe('Model'),
   }),
   models: [
+    { id: 'gpt-5.5', label: 'GPT 5.5' },
     { id: 'gpt-5.4', label: 'GPT 5.4' },
     { id: 'gpt-5.4-mini', label: 'GPT 5.4 Mini' },
   ],
@@ -147,10 +148,11 @@ export const CODEX_API: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('codex'),
     loginMethod: z.literal('api-key'),
-    model: z.string().default('gpt-5.4').describe('Model'),
+    model: z.string().default('gpt-5.5').describe('Model'),
     apiKey: z.string().min(1).describe('OpenAI API key'),
   }),
   models: [
+    { id: 'gpt-5.5', label: 'GPT 5.5' },
     { id: 'gpt-5.4', label: 'GPT 5.4' },
     { id: 'gpt-5.4-mini', label: 'GPT 5.4 Mini' },
   ],
@@ -175,12 +177,13 @@ export const GEMINI: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('vercel-ai-sdk'),
     provider: z.literal('google'),
-    model: z.string().default('gemini-2.5-flash').describe('Model'),
+    model: z.string().default('gemini-3.5-flash').describe('Model'),
     apiKey: z.string().min(1).describe('Google AI API key'),
   }),
   models: [
+    { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
+    { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash-Lite' },
     { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-    { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
   ],
   writeOnlyFields: ['apiKey'],
   sdkAdapters: {
@@ -209,7 +212,7 @@ export const MINIMAX: PresetDef = {
     // Bearer. Default to it so both endpoints work without the user having to
     // know the split. Surfaced to the per-workspace config's "Apply" path.
     authMode: z.enum(['x-api-key', 'bearer']).default('bearer').describe('Auth header'),
-    model: z.string().default('MiniMax-M2.7').describe('Model'),
+    model: z.string().default('MiniMax-M3').describe('Model'),
     apiKey: z.string().min(1).describe('MiniMax API key'),
   }),
   endpoints: [
@@ -217,6 +220,7 @@ export const MINIMAX: PresetDef = {
     { id: 'https://api.minimax.io/anthropic', label: 'International (minimax.io)' },
   ],
   models: [
+    { id: 'MiniMax-M3', label: 'MiniMax M3' },
     { id: 'MiniMax-M2.7', label: 'MiniMax M2.7' },
   ],
   writeOnlyFields: ['apiKey'],
@@ -240,12 +244,12 @@ export const GLM: PresetDef = {
   description: 'Zhipu GLM models via Claude Agent SDK (Anthropic-compatible)',
   category: 'third-party',
   defaultName: 'GLM',
-  hint: 'China console: bigmodel.cn — International console: z.ai. API keys are region-locked. Latest GLM 5.1 is China-only for now.',
+  hint: 'China console: bigmodel.cn — International console: z.ai. API keys are region-locked. GLM 5.1 is the current flagship, served on both regions.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
     baseUrl: z.string().default('https://open.bigmodel.cn/api/anthropic').describe('API endpoint'),
-    model: z.string().default('glm-4.7').describe('Model'),
+    model: z.string().default('glm-5.1').describe('Model'),
     apiKey: z.string().min(1).describe('GLM API key'),
   }),
   endpoints: [
@@ -253,9 +257,8 @@ export const GLM: PresetDef = {
     { id: 'https://api.z.ai/api/anthropic', label: 'International (z.ai)' },
   ],
   models: [
-    { id: 'glm-5.1', label: 'GLM 5.1 (China only)' },
+    { id: 'glm-5.1', label: 'GLM 5.1' },
     { id: 'glm-4.7', label: 'GLM 4.7' },
-    { id: 'glm-4.6', label: 'GLM 4.6 — 200K (China only)' },
     { id: 'glm-4.5-air', label: 'GLM 4.5 Air' },
   ],
   writeOnlyFields: ['apiKey'],

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -94,14 +94,14 @@ const baseProfileFields = {
 export const agentSdkProfileSchema = z.object({
   ...baseProfileFields,
   backend: z.literal('agent-sdk'),
-  model: z.string().default('claude-opus-4-7'),
+  model: z.string().default('claude-opus-4-8'),
   loginMethod: z.enum(['api-key', 'claudeai']).default('api-key'),
 })
 
 export const codexProfileSchema = z.object({
   ...baseProfileFields,
   backend: z.literal('codex'),
-  model: z.string().default('gpt-5.4'),
+  model: z.string().default('gpt-5.5'),
   loginMethod: z.enum(['api-key', 'codex-oauth']).default('codex-oauth'),
 })
 
@@ -109,7 +109,7 @@ export const vercelProfileSchema = z.object({
   ...baseProfileFields,
   backend: z.literal('vercel-ai-sdk'),
   provider: z.string().default('anthropic'),
-  model: z.string().default('claude-opus-4-7'),
+  model: z.string().default('claude-opus-4-8'),
 })
 
 export const profileSchema = z.discriminatedUnion('backend', [
@@ -130,7 +130,7 @@ export const aiProviderSchema = z.object({
     z.string(),
     profileSchema,
   ).default({
-    default: { backend: 'agent-sdk', model: 'claude-opus-4-7', loginMethod: 'claudeai' },
+    default: { backend: 'agent-sdk', model: 'claude-opus-4-8', loginMethod: 'claudeai' },
   }),
   activeProfile: z.string().default('default'),
 })


### PR DESCRIPTION
## Summary
- The AI provider preset catalog hardcodes the selectable models per provider; several had drifted behind the providers' current releases. Most visibly, **OpenAI Codex (Subscription)** only offered GPT 5.4 / 5.4 Mini, so users couldn't select **GPT 5.5** (now Codex's default model). **Closes #284.**
- Refreshed every preset against the provider's official model docs: Codex (+gpt-5.5, default), Claude (+claude-opus-4-8, default; dropped opus-4-6), Gemini (2.5 line → gemini-3.5-flash/3.1-flash-lite/2.5-pro), MiniMax (+MiniMax-M3, default), GLM (glm-5.1 now served internationally on z.ai → dropped "China only" + dropped EOL glm-4.6). Kimi (k2.6) / DeepSeek (v4) were already current.
- Bumped the runtime fallback defaults that apply when a profile omits a model (`config.ts` profile schemas, `codex-provider`, `agent-sdk` query) to match. The legacy migration schema and migration bodies are left frozen.

> Note: this is the data-only refresh to unblock #284. The structural fix — the model field is rendered as a locked `oneOf` dropdown so any unlisted model is unreachable, which is why this class of issue recurs every model release — is tracked for the follow-up AI-config refactor.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` passes (1844 tests)
- [x] Model ids verified against official provider docs (OpenAI Codex, Anthropic, Google Gemini, z.ai/GLM, MiniMax, Moonshot, DeepSeek)

## Boundary touch
None — touches AI provider config presets / defaults only; no trading / auth / broker / migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
