### PR TITLE
feat(workspace): central credentials — template injection + bidirectional config modal

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -796,6 +796,35 @@ export async function writeCredential(slug: string, credential: Credential): Pro
   await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
 }
 
+/**
+ * Add a credential to the central store, deduping by vendor/authType/apiKey/
+ * baseUrl (an identical credential reuses its existing slug). Returns the slug.
+ *
+ * Standalone counterpart to `extractCredentialFromProfile` for credentials that
+ * don't come from a profile — e.g. the workspace AI-config modal's "save to
+ * Alice" path, where a hand-entered provider is solidified into the central
+ * store so other workspaces (and future scheduling) can reuse it.
+ */
+export async function addCredential(credential: Credential): Promise<string> {
+  const config = await readAIProviderConfig()
+  const validated = credentialSchema.parse(credential)
+  const match = Object.entries(config.credentials).find(([, c]) =>
+    c.vendor === validated.vendor &&
+    c.authType === validated.authType &&
+    c.apiKey === validated.apiKey &&
+    c.baseUrl === validated.baseUrl,
+  )
+  if (match) return match[0]
+  const taken = new Set(Object.keys(config.credentials))
+  let n = 1
+  while (taken.has(`${validated.vendor}-${n}`)) n++
+  const slug = `${validated.vendor}-${n}`
+  config.credentials[slug] = validated
+  await mkdir(CONFIG_DIR, { recursive: true })
+  await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
+  return slug
+}
+
 /** Delete a credential. Errors if any profile still references it. */
 export async function deleteCredential(slug: string): Promise<void> {
   const config = await readAIProviderConfig()

--- a/src/core/credential-inference.ts
+++ b/src/core/credential-inference.ts
@@ -51,6 +51,26 @@ export function inferVendor(profile: ProfileLike): CredentialVendor {
   return 'custom'
 }
 
+/**
+ * Infer a credential vendor from the workspace AI-config modal's context — a
+ * CLI agent tab + the entered baseUrl. Unlike `inferVendor` (profile-shaped),
+ * this is the standalone "save to Alice" path where there's no profile/backend.
+ *
+ * A recognized baseUrl wins (GLM/MiniMax/Kimi/DeepSeek gateways); otherwise the
+ * agent decides: claude → anthropic, codex → openai. opencode/pi are
+ * OpenAI-compatible against arbitrary endpoints, so an unrecognized baseUrl
+ * falls back to 'custom' rather than guessing a first-party vendor.
+ */
+export function inferCredentialVendor(opts: { agent?: string; baseUrl?: string }): CredentialVendor {
+  const baseUrl = opts.baseUrl ?? ''
+  for (const [pattern, vendor] of VENDORS_BY_BASEURL) {
+    if (pattern.test(baseUrl)) return vendor
+  }
+  if (opts.agent === 'claude') return 'anthropic'
+  if (opts.agent === 'codex') return 'openai'
+  return 'custom'
+}
+
 export function inferAuthType(profile: ProfileLike): CredentialAuthType {
   if (profile.loginMethod === 'claudeai' || profile.loginMethod === 'codex-oauth') {
     return 'subscription'

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -18,6 +18,8 @@ import { logger as launcherLogger } from '../../workspaces/logger.js';
 import type { SessionRecord } from '../../workspaces/session-registry.js';
 import { HeadlessCapacityError, resumeFromRecord, type SessionFactoryContext, type WorkspaceService } from '../../workspaces/service.js';
 import type { WorkspaceAiCred } from '../../workspaces/cli-adapter.js';
+import { addCredential, readCredentials, type Credential } from '../../core/config.js';
+import { inferCredentialVendor } from '../../core/credential-inference.js';
 
 const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -817,6 +819,53 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
       if (code === 'ENOENT') return c.json({ profiles: [] });
       launcherLogger.warn('agent_profiles.read_failed', { err });
       return c.json({ error: 'profiles_read_failed', message: (err as Error).message }, 500);
+    }
+  });
+
+  // Central credential store, surfaced to the workspace AI-config modal. The
+  // "Load from saved credential" picker reads this list; the "Save to Alice"
+  // dialog POSTs here so a hand-entered provider becomes reusable. apiKey is
+  // returned so the picker can flash it into the form (same exposure as the
+  // legacy agent-profiles route; both are behind the admin-token gate).
+  app.get('/credentials', async (c) => {
+    try {
+      const credentials = await readCredentials();
+      const list = Object.entries(credentials).map(([slug, cred]) => ({
+        slug,
+        vendor: cred.vendor,
+        authType: cred.authType,
+        baseUrl: cred.baseUrl ?? null,
+        apiKey: cred.apiKey ?? null,
+      }));
+      return c.json({ credentials: list });
+    } catch (err) {
+      launcherLogger.warn('credentials.read_failed', { err });
+      return c.json({ error: 'credentials_read_failed', message: (err as Error).message }, 500);
+    }
+  });
+
+  app.post('/credentials', async (c) => {
+    const body = (await safeJson(c)) as
+      | { apiKey?: string; baseUrl?: string; agent?: string; vendor?: string }
+      | null;
+    const apiKey = body?.apiKey?.trim();
+    if (!apiKey) return c.json({ error: 'apiKey_required' }, 400);
+    const baseUrl = body?.baseUrl?.trim() || undefined;
+    // Subscriptions never flow through the workspace modal — these are always
+    // api-key credentials.
+    const cred: Credential = {
+      vendor: inferCredentialVendor({ agent: body?.agent, baseUrl }),
+      authType: 'api-key',
+      apiKey,
+      ...(baseUrl ? { baseUrl } : {}),
+    };
+    try {
+      const slug = await addCredential(cred);
+      launcherLogger.info('credentials.saved', { slug, vendor: cred.vendor });
+      return c.json({ slug, vendor: cred.vendor }, 201);
+    } catch (err) {
+      launcherLogger.warn('credentials.write_failed', { err });
+      return c.json({ error: 'credentials_write_failed', message: (err as Error).message }, 500);
     }
   });
 

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest'
+import { credentialToWorkspaceAiCred, injectWorkspaceCredentials } from './credential-injection.js'
+import { AdapterRegistry, type CliAdapter, type WorkspaceAiCred } from './cli-adapter.js'
+import type { Credential } from '@/core/config.js'
+import type { Logger } from './logger.js'
+
+const anthropicKey: Credential = { vendor: 'anthropic', authType: 'api-key', apiKey: 'sk-ant' }
+const minimaxIntl: Credential = {
+  vendor: 'minimax',
+  authType: 'api-key',
+  apiKey: 'mm-key',
+  baseUrl: 'https://api.minimax.io/anthropic',
+}
+const openaiKey: Credential = { vendor: 'openai', authType: 'api-key', apiKey: 'sk-oa' }
+const customGateway: Credential = {
+  vendor: 'custom',
+  authType: 'api-key',
+  apiKey: 'k',
+  baseUrl: 'https://gw.example.com/v1',
+}
+
+describe('credentialToWorkspaceAiCred', () => {
+  it('passes through apiKey + baseUrl and takes model from overrides', () => {
+    const cred = credentialToWorkspaceAiCred(minimaxIntl, 'claude', { model: 'MiniMax-M3' })
+    expect(cred.apiKey).toBe('mm-key')
+    expect(cred.baseUrl).toBe('https://api.minimax.io/anthropic')
+    expect(cred.model).toBe('MiniMax-M3')
+  })
+
+  it('credential carries no model — model is null without an override', () => {
+    const cred = credentialToWorkspaceAiCred(anthropicKey, 'claude')
+    expect(cred.model).toBeNull()
+  })
+
+  describe('claude → authMode', () => {
+    it('defaults to x-api-key for first-party Anthropic', () => {
+      const cred = credentialToWorkspaceAiCred(anthropicKey, 'claude', { model: 'claude-opus-4-8' })
+      expect(cred.authMode).toBe('x-api-key')
+    })
+
+    it('auto-promotes api.minimax.io to bearer', () => {
+      const cred = credentialToWorkspaceAiCred(minimaxIntl, 'claude', { model: 'MiniMax-M3' })
+      expect(cred.authMode).toBe('bearer')
+    })
+
+    it('explicit override wins', () => {
+      const cred = credentialToWorkspaceAiCred(anthropicKey, 'claude', { authMode: 'bearer' })
+      expect(cred.authMode).toBe('bearer')
+    })
+  })
+
+  describe('codex → wireApi', () => {
+    it('left undefined when not overridden (adapter defaults to chat)', () => {
+      const cred = credentialToWorkspaceAiCred(customGateway, 'codex', { model: 'gpt-5.5' })
+      expect(cred.wireApi).toBeUndefined()
+    })
+
+    it('passes an explicit wireApi through', () => {
+      const cred = credentialToWorkspaceAiCred(openaiKey, 'codex', { model: 'gpt-5.5', wireApi: 'responses' })
+      expect(cred.wireApi).toBe('responses')
+    })
+
+    it('never sets authMode for codex', () => {
+      const cred = credentialToWorkspaceAiCred(openaiKey, 'codex', { model: 'gpt-5.5' })
+      expect(cred.authMode).toBeUndefined()
+    })
+  })
+
+  describe('opencode / pi → plain chat (no adapter-specific knobs)', () => {
+    for (const agent of ['opencode', 'pi']) {
+      it(`${agent}: sets neither authMode nor wireApi`, () => {
+        const cred = credentialToWorkspaceAiCred(customGateway, agent, { model: 'some-model' })
+        expect(cred.authMode).toBeUndefined()
+        expect(cred.wireApi).toBeUndefined()
+        expect(cred.apiKey).toBe('k')
+        expect(cred.baseUrl).toBe('https://gw.example.com/v1')
+      })
+    }
+  })
+})
+
+interface WriteCall { id: string; dir: string; cred: WorkspaceAiCred }
+
+function stubAdapter(id: string, calls: WriteCall[], writeable = true): CliAdapter {
+  const adapter: CliAdapter = {
+    id,
+    displayName: id,
+    capabilities: { parallelPerCwd: true, resumeLast: false, resumeById: false, transcriptDiscovery: 'none' },
+    composeCommand: (base) => base,
+  }
+  if (writeable) {
+    ;(adapter as { writeAiConfig?: CliAdapter['writeAiConfig'] }).writeAiConfig = async (dir, cred) => {
+      calls.push({ id, dir, cred })
+    }
+  }
+  return adapter
+}
+
+function fakeLogger(): { logger: Logger; warns: string[] } {
+  const warns: string[] = []
+  const logger = {
+    warn: (msg: string) => { warns.push(msg) },
+    info: () => {},
+    debug: () => {},
+    error: () => {},
+    child: () => logger,
+  } as unknown as Logger
+  return { logger, warns }
+}
+
+describe('injectWorkspaceCredentials', () => {
+  const credentials: Record<string, Credential> = {
+    'openai-1': openaiKey,
+    'anthropic-1': anthropicKey,
+  }
+
+  it('writes AI config for each declared+enabled agent, mapping the credential', async () => {
+    const calls: WriteCall[] = []
+    const reg = new AdapterRegistry()
+    reg.register(stubAdapter('claude', calls))
+    reg.register(stubAdapter('codex', calls))
+    const { logger } = fakeLogger()
+
+    await injectWorkspaceCredentials({
+      dir: '/ws',
+      agents: ['claude', 'codex'],
+      agentCredentials: {
+        claude: { credentialSlug: 'anthropic-1', model: 'claude-opus-4-8' },
+        codex: { credentialSlug: 'openai-1', model: 'gpt-5.5' },
+      },
+      adapterRegistry: reg,
+      credentials,
+      logger,
+    })
+
+    expect(calls).toHaveLength(2)
+    const claudeCall = calls.find((c) => c.id === 'claude')!
+    expect(claudeCall.cred).toMatchObject({ apiKey: 'sk-ant', model: 'claude-opus-4-8', authMode: 'x-api-key' })
+    const codexCall = calls.find((c) => c.id === 'codex')!
+    expect(codexCall.cred).toMatchObject({ apiKey: 'sk-oa', model: 'gpt-5.5' })
+  })
+
+  it('skips (loud warn) an agent declared but not enabled on the workspace', async () => {
+    const calls: WriteCall[] = []
+    const reg = new AdapterRegistry()
+    reg.register(stubAdapter('claude', calls))
+    const { logger, warns } = fakeLogger()
+
+    await injectWorkspaceCredentials({
+      dir: '/ws',
+      agents: ['claude'], // codex NOT enabled
+      agentCredentials: { codex: { credentialSlug: 'openai-1', model: 'gpt-5.5' } },
+      adapterRegistry: reg,
+      credentials,
+      logger,
+    })
+
+    expect(calls).toHaveLength(0)
+    expect(warns).toContain('workspace.cred_inject_skip_disabled')
+  })
+
+  it('skips (loud warn) when the referenced credential slug is missing', async () => {
+    const calls: WriteCall[] = []
+    const reg = new AdapterRegistry()
+    reg.register(stubAdapter('claude', calls))
+    const { logger, warns } = fakeLogger()
+
+    await injectWorkspaceCredentials({
+      dir: '/ws',
+      agents: ['claude'],
+      agentCredentials: { claude: { credentialSlug: 'does-not-exist' } },
+      adapterRegistry: reg,
+      credentials,
+      logger,
+    })
+
+    expect(calls).toHaveLength(0)
+    expect(warns).toContain('workspace.cred_inject_missing_credential')
+  })
+})

--- a/src/workspaces/credential-injection.ts
+++ b/src/workspaces/credential-injection.ts
@@ -1,0 +1,113 @@
+/**
+ * Bridge from Alice's central credential store to a workspace's per-CLI AI
+ * config.
+ *
+ * The central store (`aiProviderSchema.credentials` in `core/config.ts`) holds
+ * the vendor-neutral secret: `{ vendor, authType, apiKey?, baseUrl? }`. Each CLI
+ * adapter instead consumes a `WorkspaceAiCred` (`cli-adapter.ts`) and renders it
+ * into its own file format. A credential carries no model — model is always a
+ * per-use choice — so the caller supplies it (plus the adapter-specific
+ * `authMode` / `wireApi` knobs) via `overrides`.
+ *
+ * This is the one place that maps Credential → WorkspaceAiCred, used by
+ * template-driven injection at workspace-create time and reusable by any future
+ * "apply credential to workspace" path.
+ */
+
+import { resolveAnthropicAuthMode } from '@/core/credential-inference.js'
+import type { Credential } from '@/core/config.js'
+import type { AdapterRegistry, WorkspaceAiCred } from './cli-adapter.js'
+import type { Logger } from './logger.js'
+import type { AgentCredentialDecl } from './template-registry.js'
+
+export interface CredentialInjectionOverrides {
+  /** Model id to run. Required in practice (a credential has none). */
+  model?: string
+  /** Claude only — which header carries the key. Defaults via baseUrl heuristic. */
+  authMode?: 'x-api-key' | 'bearer'
+  /** Codex only — Responses vs Chat Completions. Adapter defaults to 'chat'. */
+  wireApi?: 'chat' | 'responses'
+}
+
+/**
+ * Map a central Credential into the `WorkspaceAiCred` the given agent's adapter
+ * expects. `agentId` selects which adapter-specific field is populated:
+ *   - claude → `authMode` (derived via `resolveAnthropicAuthMode`)
+ *   - codex  → `wireApi` (only when explicitly overridden; else adapter default)
+ *   - opencode / pi → neither (plain OpenAI-compatible Chat Completions)
+ */
+export function credentialToWorkspaceAiCred(
+  credential: Pick<Credential, 'apiKey' | 'baseUrl'>,
+  agentId: string,
+  overrides: CredentialInjectionOverrides = {},
+): WorkspaceAiCred {
+  const cred: WorkspaceAiCred = {
+    baseUrl: credential.baseUrl ?? null,
+    apiKey: credential.apiKey ?? null,
+    model: overrides.model ?? null,
+  }
+
+  if (agentId === 'claude') {
+    cred.authMode = resolveAnthropicAuthMode({
+      authMode: overrides.authMode,
+      baseUrl: credential.baseUrl,
+    })
+  } else if (agentId === 'codex') {
+    // Leave undefined when not overridden so the codex adapter applies its own
+    // default ('chat'); only custom-baseUrl providers write a wire_api at all.
+    if (overrides.wireApi) cred.wireApi = overrides.wireApi
+  }
+
+  return cred
+}
+
+/**
+ * Seed a freshly-created workspace's per-agent AI config from a template's
+ * `agentCredentials` declaration + Alice's central credential store.
+ *
+ * MUST run AFTER the launcher's initial commit: `writeAiConfig` writes the
+ * secret into `.claude/settings.local.json` / `.codex/env.json` / `opencode.json`
+ * / `.pi-agent/`, which `_common.sh`'s `setup_git_excludes` keeps out of git —
+ * but only post-commit are we certain the key never lands in the initial commit.
+ *
+ * Every miss (agent not enabled, no adapter, credential slug absent) is a loud
+ * `warn` + skip, never a hard failure — a workspace that boots without a seeded
+ * provider is still usable (the user configures it manually). Best-effort.
+ */
+export async function injectWorkspaceCredentials(opts: {
+  readonly dir: string
+  readonly agents: readonly string[]
+  readonly agentCredentials: Readonly<Record<string, AgentCredentialDecl>>
+  readonly adapterRegistry: AdapterRegistry
+  readonly credentials: Record<string, Credential>
+  readonly logger: Logger
+}): Promise<void> {
+  const { dir, agents, agentCredentials, adapterRegistry, credentials, logger } = opts
+  for (const [agentId, decl] of Object.entries(agentCredentials)) {
+    if (!agents.includes(agentId)) {
+      logger.warn('workspace.cred_inject_skip_disabled', { agentId })
+      continue
+    }
+    const adapter = adapterRegistry.get(agentId)
+    if (!adapter?.writeAiConfig) {
+      logger.warn('workspace.cred_inject_skip_no_adapter', { agentId })
+      continue
+    }
+    const credential = credentials[decl.credentialSlug]
+    if (!credential) {
+      logger.warn('workspace.cred_inject_missing_credential', {
+        agentId, credentialSlug: decl.credentialSlug,
+      })
+      continue
+    }
+    const wsCred = credentialToWorkspaceAiCred(credential, agentId, {
+      ...(decl.model !== undefined ? { model: decl.model } : {}),
+      ...(decl.authMode !== undefined ? { authMode: decl.authMode } : {}),
+      ...(decl.wireApi !== undefined ? { wireApi: decl.wireApi } : {}),
+    })
+    await adapter.writeAiConfig(dir, wsCred)
+    logger.info('workspace.cred_injected', {
+      agentId, credentialSlug: decl.credentialSlug, ...(decl.model ? { model: decl.model } : {}),
+    })
+  }
+}

--- a/src/workspaces/template-registry.ts
+++ b/src/workspaces/template-registry.ts
@@ -4,6 +4,22 @@ import { join, resolve } from 'node:path';
 
 import type { Logger } from './logger.js';
 
+/**
+ * A template's declaration that an enabled agent should be seeded, at
+ * workspace-create time, from a named credential in Alice's central store.
+ * `credentialSlug` points into `aiProviderSchema.credentials`; `model` and the
+ * adapter-specific knobs feed `credentialToWorkspaceAiCred`. Sourced from
+ * `template.json`'s `agentCredentials` map (agentId → decl).
+ */
+export interface AgentCredentialDecl {
+  readonly credentialSlug: string;
+  readonly model?: string;
+  /** Claude only. */
+  readonly authMode?: 'x-api-key' | 'bearer';
+  /** Codex only. */
+  readonly wireApi?: 'chat' | 'responses';
+}
+
 export interface TemplateMeta {
   readonly name: string;
   readonly description?: string;
@@ -62,6 +78,13 @@ export interface TemplateMeta {
   readonly injectMcp: boolean | 'inbox';
   readonly injectPersona: boolean;
   readonly bundledSkills: readonly string[];
+  /**
+   * Optional per-agent credential seeding. When present, the launcher writes
+   * each declared agent's workspace AI config at create time from the named
+   * central credential — so a workspace boots ready-to-run without a manual
+   * UI step. Agents not listed are left to fall back to the CLI's global login.
+   */
+  readonly agentCredentials?: Readonly<Record<string, AgentCredentialDecl>>;
 }
 
 /**
@@ -113,6 +136,7 @@ export class TemplateRegistry {
         injectMcp: tplMeta.injectMcp,
         injectPersona: tplMeta.injectPersona,
         bundledSkills: tplMeta.bundledSkills,
+        ...(tplMeta.agentCredentials !== undefined ? { agentCredentials: tplMeta.agentCredentials } : {}),
       };
       reg.byName.set(name, meta);
     }
@@ -157,6 +181,7 @@ interface ParsedTemplateMeta {
   readonly injectMcp: boolean | 'inbox';
   readonly injectPersona: boolean;
   readonly bundledSkills: readonly string[];
+  readonly agentCredentials?: Readonly<Record<string, AgentCredentialDecl>>;
 }
 
 /**
@@ -240,6 +265,7 @@ async function readTemplateMeta(path: string): Promise<ParsedTemplateMeta> {
           (s): s is string => typeof s === 'string' && !s.includes('/') && !s.includes('..'),
         )
       : [];
+    const agentCredentials = parseAgentCredentials(obj['agentCredentials']);
     return {
       ...(description !== undefined ? { description } : {}),
       ...(displayName !== undefined ? { displayName } : {}),
@@ -248,9 +274,37 @@ async function readTemplateMeta(path: string): Promise<ParsedTemplateMeta> {
       injectMcp,
       injectPersona,
       bundledSkills,
+      ...(agentCredentials !== undefined ? { agentCredentials } : {}),
     };
   } catch {
     return fallback;
   }
+}
+
+/**
+ * Parse the optional `agentCredentials` map from a template.json. Shape:
+ *   { "<agentId>": { "credentialSlug": "openai-1", "model": "gpt-5.5",
+ *                    "authMode"?: "x-api-key"|"bearer", "wireApi"?: "chat"|"responses" } }
+ * Entries missing a string `credentialSlug` are dropped. Returns undefined when
+ * nothing valid is present (so the field stays absent on the meta).
+ */
+function parseAgentCredentials(raw: unknown): Record<string, AgentCredentialDecl> | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const out: Record<string, AgentCredentialDecl> = {};
+  for (const [agentId, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value !== 'object' || value === null) continue;
+    const v = value as Record<string, unknown>;
+    if (typeof v['credentialSlug'] !== 'string' || v['credentialSlug'].length === 0) continue;
+    const decl: AgentCredentialDecl = { credentialSlug: v['credentialSlug'] };
+    if (typeof v['model'] === 'string') (decl as { model?: string }).model = v['model'];
+    if (v['authMode'] === 'x-api-key' || v['authMode'] === 'bearer') {
+      (decl as { authMode?: 'x-api-key' | 'bearer' }).authMode = v['authMode'];
+    }
+    if (v['wireApi'] === 'chat' || v['wireApi'] === 'responses') {
+      (decl as { wireApi?: 'chat' | 'responses' }).wireApi = v['wireApi'];
+    }
+    out[agentId] = decl;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 

--- a/src/workspaces/templates/_common.sh
+++ b/src/workspaces/templates/_common.sh
@@ -66,6 +66,10 @@ copy_readme() {
 #   - .codex/auth.json              (workspace-local Codex auth)
 #   - .codex/env.json               (workspace-local Codex API-key bridge)
 #   - .codex/config.toml            (workspace-local Codex provider config)
+#   - opencode.json                 (workspace-local opencode provider config)
+#   - .pi-agent/                    (workspace-local Pi provider + settings)
+# All five carry a per-workspace API key once a provider is configured (UI or
+# template-injected), so they must never reach a commit.
 # Extra paths passed as args are appended too — useful for templates that
 # clone third-party content (e.g. finance-research clones .finance-skills/
 # and doesn't want git add . to swallow it).
@@ -80,6 +84,8 @@ setup_git_excludes() {
     echo '.codex/auth.json'
     echo '.codex/env.json'
     echo '.codex/config.toml'
+    echo 'opencode.json'
+    echo '.pi-agent/'
     for extra in "$@"; do
       echo "$extra"
     done

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -3,8 +3,11 @@ import { randomUUID } from 'node:crypto';
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { readCredentials } from '@/core/config.js';
+
 import type { AdapterRegistry } from './cli-adapter.js';
 import { injectWorkspaceContext, resolveInjection, type ToolAccess } from './context-injector.js';
+import { injectWorkspaceCredentials } from './credential-injection.js';
 import type { Logger } from './logger.js';
 import type { TemplateRegistry } from './template-registry.js';
 import type { WorkspaceMeta, WorkspaceRegistry } from './workspace-registry.js';
@@ -183,6 +186,26 @@ export class WorkspaceCreator {
         });
       } catch (err) {
         log.warn('adapter.bootstrap_failed', { agent: a, err });
+      }
+    }
+
+    // Template-declared credential seeding — runs POST-commit so the secret
+    // never lands in the initial commit (the adapter config files are kept out
+    // of git by `_common.sh`'s excludes; post-commit is the belt-and-braces).
+    // Best-effort: a miss warns + skips, the workspace stays usable.
+    if (template.agentCredentials) {
+      try {
+        const credentials = await readCredentials();
+        await injectWorkspaceCredentials({
+          dir,
+          agents,
+          agentCredentials: template.agentCredentials,
+          adapterRegistry: this.opts.adapterRegistry,
+          credentials,
+          logger: log,
+        });
+      } catch (err) {
+        log.warn('cred_inject.failed', { err });
       }
     }
 

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -11,13 +11,14 @@
 import { useEffect, useMemo, useState } from 'react'
 import {
   getAgentConfig,
-  listAgentProfiles,
+  listCredentials,
   saveAgentConfig,
+  saveCredential,
   testAgentConfig,
   type AgentConfig,
   type AgentConfigBundle,
   type AgentId,
-  type AgentProfile,
+  type SavedCredential,
 } from './api'
 
 interface Props {
@@ -102,17 +103,22 @@ function formsMatch(a: FormState, b: FormState, agent: AgentId): boolean {
 
 export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
   const [tab, setTab] = useState<Tab>('claude')
-  const [profiles, setProfiles] = useState<AgentProfile[]>([])
+  const [credentials, setCredentials] = useState<SavedCredential[]>([])
   const [bundle, setBundle] = useState<AgentConfigBundle | null>(null)
   const [claudeForm, setClaudeForm] = useState<FormState>(EMPTY_FORM)
   const [codexForm, setCodexForm] = useState<FormState>(EMPTY_FORM)
   const [opencodeForm, setOpencodeForm] = useState<FormState>(EMPTY_FORM)
   const [piForm, setPiForm] = useState<FormState>(EMPTY_FORM)
-  const [pickedProfile, setPickedProfile] = useState<string>('')
+  const [pickedCredential, setPickedCredential] = useState<string>('')
   const [showKey, setShowKey] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [savedFlash, setSavedFlash] = useState(false)
+  // Push-back prompt: shown after a successful Save when the just-saved key
+  // isn't already in Alice's central store — offers to solidify it for reuse.
+  const [offerSaveCred, setOfferSaveCred] = useState(false)
+  const [savingCred, setSavingCred] = useState(false)
+  const [credFlash, setCredFlash] = useState<string | null>(null)
   const [testing, setTesting] = useState(false)
   const [claudeResult, setClaudeResult] = useState<TestResult | null>(null)
   const [codexResult, setCodexResult] = useState<TestResult | null>(null)
@@ -120,9 +126,9 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
   const [piResult, setPiResult] = useState<TestResult | null>(null)
 
   useEffect(() => {
-    void Promise.all([listAgentProfiles(), getAgentConfig(wsId)])
-      .then(([ps, b]) => {
-        setProfiles(ps)
+    void Promise.all([listCredentials(), getAgentConfig(wsId)])
+      .then(([creds, b]) => {
+        setCredentials(creds)
         setBundle(b)
         setClaudeForm(configToForm(b.claude))
         setCodexForm(configToForm(b.codex))
@@ -151,17 +157,18 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
     )
   }, [bundle, form, tab])
 
-  const applyProfile = () => {
-    const p = profiles.find((x) => x.name === pickedProfile)
-    if (!p) return
+  const applyCredential = () => {
+    const cred = credentials.find((x) => x.slug === pickedCredential)
+    if (!cred) return
+    // A credential carries no model — that's a per-workspace choice — so we
+    // flash baseUrl + key only and leave the model field for the user.
+    // Auth mode: api.minimax.io needs Bearer; default x-api-key otherwise.
+    const bearer = /api\.minimax\.io/i.test(cred.baseUrl ?? '')
     setForm({
       ...form,
-      baseUrl: p.baseUrl ?? '',
-      apiKey: p.apiKey ?? '',
-      model: p.model ?? '',
-      // A profile may pin its auth mode (e.g. a MiniMax-international profile
-      // needs Bearer); fall back to x-api-key when it doesn't say.
-      authMode: p.authMode === 'bearer' ? 'bearer' : 'x-api-key',
+      baseUrl: cred.baseUrl ?? '',
+      apiKey: cred.apiKey ?? '',
+      authMode: bearer ? 'bearer' : 'x-api-key',
     })
   }
 
@@ -174,10 +181,37 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
       setBundle(fresh)
       setSavedFlash(true)
       setTimeout(() => setSavedFlash(false), 1800)
+      // Offer to solidify a hand-entered key into Alice's central store — but
+      // only when it isn't already there (loaded-from-credential, or re-typed
+      // an existing one, shouldn't re-prompt).
+      const key = form.apiKey.trim()
+      const url = form.baseUrl.trim()
+      const known = credentials.some((c) => c.apiKey === key && (c.baseUrl ?? '') === url)
+      setOfferSaveCred(!!key && !known)
     } catch (err) {
       setError((err as Error).message)
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleSaveCredential = async () => {
+    setSavingCred(true)
+    setError(null)
+    try {
+      const { slug } = await saveCredential({
+        apiKey: form.apiKey.trim(),
+        ...(form.baseUrl.trim() ? { baseUrl: form.baseUrl.trim() } : {}),
+        agent: tab,
+      })
+      setCredentials(await listCredentials())
+      setOfferSaveCred(false)
+      setCredFlash(`Saved to Alice as “${slug}” — reusable in any workspace.`)
+      setTimeout(() => setCredFlash(null), 2600)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setSavingCred(false)
     }
   }
 
@@ -280,32 +314,41 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
 
         {/* Body */}
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
-          {/* Quick pick */}
+          {/* Quick pick — load a saved credential into the form */}
           <div className="rounded-lg border border-border bg-bg-secondary/30 p-3">
             <label className="block text-xs font-medium text-text-muted mb-2">
-              Apply from OpenAlice profile
+              Load from saved credential
             </label>
             <div className="flex gap-2">
               <select
-                value={pickedProfile}
-                onChange={(e) => setPickedProfile(e.target.value)}
+                value={pickedCredential}
+                onChange={(e) => setPickedCredential(e.target.value)}
                 className={inputClass + ' flex-1'}
+                disabled={credentials.length === 0}
               >
-                <option value="">— select a profile —</option>
-                {profiles.map((p) => (
-                  <option key={p.name} value={p.name}>
-                    {p.name}
+                <option value="">
+                  {credentials.length === 0 ? '— none saved yet —' : '— select a credential —'}
+                </option>
+                {credentials.map((cred) => (
+                  <option key={cred.slug} value={cred.slug}>
+                    {cred.slug}
+                    {cred.baseUrl ? ` · ${cred.baseUrl}` : ''}
                   </option>
                 ))}
               </select>
               <button
-                onClick={applyProfile}
-                disabled={!pickedProfile}
+                onClick={applyCredential}
+                disabled={!pickedCredential}
                 className="px-3 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
               >
-                Apply
+                Load
               </button>
             </div>
+            <p className="text-[11px] text-text-muted/80 leading-snug mt-1.5">
+              Fills base URL + key from a credential Alice already holds. Pick a
+              model below — credentials don't carry one. Or just type a new one;
+              you'll be offered to save it after Test + Save.
+            </p>
           </div>
 
           {/* Manual fields */}
@@ -438,6 +481,34 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
           {savedFlash && (
             <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
               Saved. Pause + resume any open session to reload.
+            </div>
+          )}
+          {offerSaveCred && (
+            <div className="rounded-md border border-accent/40 bg-accent/10 text-text text-[12px] px-3 py-2.5 flex items-center justify-between gap-3">
+              <span className="leading-snug">
+                Save this provider to Alice so other workspaces can reuse it?
+              </span>
+              <div className="flex gap-2 shrink-0">
+                <button
+                  onClick={() => setOfferSaveCred(false)}
+                  disabled={savingCred}
+                  className="px-2.5 py-1 rounded-md border border-border text-text-muted hover:text-text text-[12px] disabled:opacity-40"
+                >
+                  Not now
+                </button>
+                <button
+                  onClick={handleSaveCredential}
+                  disabled={savingCred}
+                  className="px-2.5 py-1 rounded-md bg-accent text-bg text-[12px] font-medium disabled:opacity-40 hover:bg-accent/90"
+                >
+                  {savingCred ? 'Saving…' : 'Save to Alice'}
+                </button>
+              </div>
+            </div>
+          )}
+          {credFlash && (
+            <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
+              {credFlash}
             </div>
           )}
           {testing && (

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -413,6 +413,46 @@ export async function listAgentProfiles(): Promise<AgentProfile[]> {
   return body.profiles;
 }
 
+// ── Central credential store ──────────────────────────────────────────────
+//
+// Alice's reusable credentials (`data/config/ai-provider-manager.json`). The
+// modal's "Load from saved credential" picker reads these; "Save to Alice"
+// writes a new one. apiKey is returned so a picked credential can be flashed
+// into the form (same exposure as agent-profiles; admin-token gated).
+
+export interface SavedCredential {
+  readonly slug: string;
+  readonly vendor: string;
+  readonly authType: 'api-key' | 'subscription';
+  readonly baseUrl: string | null;
+  readonly apiKey: string | null;
+}
+
+export async function listCredentials(): Promise<SavedCredential[]> {
+  const res = await fetch('/api/workspaces/credentials');
+  if (!res.ok) throw new Error(`list credentials failed: ${res.status}`);
+  const body = (await res.json()) as { credentials: SavedCredential[] };
+  return body.credentials;
+}
+
+/** Persist a hand-entered provider as a reusable central credential. Returns the slug. */
+export async function saveCredential(input: {
+  apiKey: string;
+  baseUrl?: string;
+  agent?: AgentId;
+}): Promise<{ slug: string; vendor: string }> {
+  const res = await fetch('/api/workspaces/credentials', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => '');
+    throw new Error(`save credential failed: ${res.status} ${msg}`);
+  }
+  return (await res.json()) as { slug: string; vendor: string };
+}
+
 export async function getAgentConfig(wsId: string): Promise<AgentConfigBundle> {
   const res = await fetch(`/api/workspaces/${encodeURIComponent(wsId)}/agent-config`);
   if (!res.ok) throw new Error(`get agent config failed: ${res.status}`);

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -20,6 +20,10 @@ export const workspacesHandlers = [
 
   http.get('/api/workspaces/agents', () => HttpResponse.json({ agents: [] })),
   http.get('/api/workspaces/agent-profiles', () => HttpResponse.json({ profiles: [] })),
+  http.get('/api/workspaces/credentials', () => HttpResponse.json({ credentials: [] })),
+  http.post('/api/workspaces/credentials', () =>
+    HttpResponse.json({ slug: 'custom-1', vendor: 'custom' }, { status: 201 }),
+  ),
 
   http.get('/api/workspaces/:id/git/log', () => HttpResponse.json({ entries: [] })),
   http.get('/api/workspaces/:id/git/status', () =>


### PR DESCRIPTION
## Summary
First of three PRs collapsing the AI-config story onto Workspace-native execution (per the agreed refactor plan). This one makes Alice's **existing central credential store** the single source for provider credentials and lets it flow into workspaces **both directions**, without touching the legacy GenerateRouter/profile machinery.

- **Credential → WorkspaceAiCred mapping** — new `src/workspaces/credential-injection.ts` (`credentialToWorkspaceAiCred`). A credential carries no model (that's a per-use choice), so the caller supplies model + the adapter-specific knobs: claude `authMode` (via the existing `resolveAnthropicAuthMode`), codex `wireApi`.
- **Template-driven injection** — `TemplateMeta.agentCredentials` (`{ agentId: { credentialSlug, model?, authMode?, wireApi? } }`, parsed from `template.json`). `injectWorkspaceCredentials` writes each declared agent's AI config at create time through the adapter's existing `writeAiConfig`, so a workspace boots ready-to-run with no manual UI step. Best-effort: a miss (agent not enabled / no adapter / credential slug absent) is a loud warn + skip, never a hard create failure.
- **Bidirectional modal** (`WorkspaceAIConfigModal`) — keeps free-text entry; the quick-pick now **loads from saved credentials** (not profiles); after a successful Save of a hand-entered key it offers **"Save to Alice"** so the credential is solidified into the central store and reusable in any workspace / future scheduling. Backed by new `GET/POST /api/workspaces/credentials`, `addCredential` (dedupe + slug-gen), and `inferCredentialVendor`.

### Security
Injection runs **after** the launcher's initial commit so a key never lands in the first commit. `_common.sh setup_git_excludes` now also excludes `opencode.json` + `.pi-agent/` — previously only claude/codex config files were excluded, a latent key-leak for the other two adapters even on the existing manual-config path.

### Scope
World B (GenerateRouter / in-process providers / AgentWork) is **untouched** and keeps running. Wiring cron/heartbeat/webhook onto headless Workspace dispatch (PR2) and deleting World B (PR3) follow.

## Test plan
- [x] `npx tsc --noEmit` clean (Alice src)
- [x] `cd ui && npx tsc -b` clean
- [x] `pnpm test` — 1857 passed (adds `credential-injection.spec.ts`: mapping + injection-orchestration coverage)
- [ ] Manual: create a workspace from a template declaring `agentCredentials`; confirm `.claude/settings.local.json` / `.codex/config.toml` are seeded and not committed (`git status` clean), and the modal's load/save-back loop round-trips a credential

## Boundary touch
Touches credential storage (`core/config.ts` credentials) + a new credential read/write HTTP surface. No trading / broker / auth-token / migration changes. Credential `apiKey` is returned by `GET /api/workspaces/credentials` for the picker — same exposure as the pre-existing `agent-profiles` route, behind the admin-token gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
