### PR TITLE
feat(automation): cron → headless Workspace dispatch (replaces in-process AgentWork)

### DIFF
--- a/src/core/agent-event.ts
+++ b/src/core/agent-event.ts
@@ -111,6 +111,9 @@ const CronFireSchema = Type.Object({
   jobId: Type.String(),
   jobName: Type.String(),
   payload: Type.String(),
+  // Dispatch target (headless workspace run). Optional for pre-headless jobs.
+  workspaceId: Type.Optional(Type.String()),
+  agent: Type.Optional(Type.String()),
 })
 
 const MessageReceivedSchema = Type.Object({

--- a/src/main.ts
+++ b/src/main.ts
@@ -276,9 +276,15 @@ async function main() {
 
   // ==================== Cron Listener ====================
 
-  const cronSession = new SessionStore('cron/default')
-  await cronSession.restore()
-  const cronListener = createCronListener({ agentWorkListener, registry: listenerRegistry, session: cronSession })
+  // Cross-plugin ref so the cron listener (and McpPlugin) can reach the
+  // WorkspaceService even though WebPlugin — its actual creator — starts later.
+  // `ref.current` is null until the plugin boots; an early cron fire is a loud
+  // skip (see cron listener). Created here so cron dispatch can hold it.
+  const workspaceServiceRef = createWorkspaceServiceRef()
+
+  // Cron fires now dispatch a headless Workspace run (job → workspace+agent),
+  // not the legacy in-process AgentWork path.
+  const cronListener = createCronListener({ registry: listenerRegistry, workspaceServiceRef })
   await cronListener.start()
 
   // Snapshot scheduler lives in UTA after Step 6 — Alice no longer
@@ -328,9 +334,8 @@ async function main() {
   // Core plugins — always-on, not toggleable at runtime
   const corePlugins: Plugin[] = []
 
-  // Cross-plugin ref so McpPlugin can resolve workspaces for `/mcp/:wsId`
-  // even though WebPlugin (the service's actual creator) starts later.
-  const workspaceServiceRef = createWorkspaceServiceRef()
+  // workspaceServiceRef is created earlier (Cron Listener section) so cron
+  // dispatch shares the same box the WebPlugin fills on start.
 
   // MCP Server is always active when a port is set — Claude Code provider depends on it for tools.
   // Lives at top-level config (not under connectors:) because it exports

--- a/src/migrations/0008_disable_targetless_cron_jobs.spec.ts
+++ b/src/migrations/0008_disable_targetless_cron_jobs.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { join, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
+import { disableTargetlessCronJobs } from './0008_disable_targetless_cron_jobs/index.js'
+
+function tempPath(ext: string): string {
+  return join(tmpdir(), `migration-0008-${randomUUID()}.${ext}`)
+}
+
+interface RawJob {
+  id: string
+  name: string
+  enabled: boolean
+  workspaceId?: string
+  agent?: string
+}
+
+function makeJob(name: string, opts: { enabled?: boolean; workspaceId?: string } = {}): RawJob {
+  return {
+    id: randomUUID().slice(0, 8),
+    name,
+    enabled: opts.enabled ?? true,
+    ...(opts.workspaceId !== undefined ? { workspaceId: opts.workspaceId } : {}),
+  }
+}
+
+async function writeJobs(path: string, jobs: RawJob[]): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, JSON.stringify({ jobs }, null, 2))
+}
+
+async function readJobs(path: string): Promise<{ jobs: RawJob[] }> {
+  return JSON.parse(await readFile(path, 'utf-8')) as { jobs: RawJob[] }
+}
+
+describe('0008_disable_targetless_cron_jobs', () => {
+  let jobsPath: string
+
+  beforeEach(() => {
+    jobsPath = tempPath('json')
+  })
+
+  afterEach(async () => {
+    await rm(jobsPath, { force: true })
+  })
+
+  it('disables enabled jobs that have no workspaceId', async () => {
+    await writeJobs(jobsPath, [
+      makeJob('legacy', { enabled: true }),
+      makeJob('targeted', { enabled: true, workspaceId: 'ws-1' }),
+    ])
+
+    const result = await disableTargetlessCronJobs(jobsPath)
+
+    expect(result.disabled).toEqual(['legacy'])
+    const after = await readJobs(jobsPath)
+    expect(after.jobs.find((j) => j.name === 'legacy')!.enabled).toBe(false)
+    expect(after.jobs.find((j) => j.name === 'targeted')!.enabled).toBe(true)
+  })
+
+  it('leaves already-disabled targetless jobs untouched', async () => {
+    await writeJobs(jobsPath, [makeJob('legacy-off', { enabled: false })])
+    const result = await disableTargetlessCronJobs(jobsPath)
+    expect(result.disabled).toEqual([])
+  })
+
+  it('no-op when every job has a workspaceId', async () => {
+    await writeJobs(jobsPath, [
+      makeJob('a', { workspaceId: 'ws-1' }),
+      makeJob('b', { workspaceId: 'ws-2' }),
+    ])
+    const result = await disableTargetlessCronJobs(jobsPath)
+    expect(result.disabled).toEqual([])
+  })
+
+  it('no-op when file does not exist', async () => {
+    const result = await disableTargetlessCronJobs(jobsPath)
+    expect(result.disabled).toEqual([])
+  })
+
+  it('idempotent — second run leaves the file byte-for-byte unchanged', async () => {
+    await writeJobs(jobsPath, [
+      makeJob('legacy', { enabled: true }),
+      makeJob('targeted', { enabled: true, workspaceId: 'ws-1' }),
+    ])
+
+    await disableTargetlessCronJobs(jobsPath)
+    const afterFirst = await readFile(jobsPath, 'utf-8')
+
+    const result = await disableTargetlessCronJobs(jobsPath)
+    const afterSecond = await readFile(jobsPath, 'utf-8')
+
+    expect(result.disabled).toEqual([])
+    expect(afterSecond).toBe(afterFirst)
+  })
+})

--- a/src/migrations/0008_disable_targetless_cron_jobs/index.ts
+++ b/src/migrations/0008_disable_targetless_cron_jobs/index.ts
@@ -1,0 +1,100 @@
+/**
+ * 0008_disable_targetless_cron_jobs — disable pre-headless cron jobs that
+ * have no target workspace.
+ *
+ * Cron jobs used to fire into the in-process AgentWork path (a prompt with no
+ * workspace). That path is gone: a cron job now dispatches a headless run into
+ * a chosen workspace (`workspaceId` + `agent`). A legacy job carries no
+ * `workspaceId`, so on every fire the new listener would log a loud "no target
+ * workspace" error and do nothing — the exact orphan-cron noise the 0004
+ * incident warns about.
+ *
+ * This migration disables (does NOT delete) any enabled job lacking a
+ * `workspaceId`, so it stops firing on upgrade. The job stays visible in the
+ * Automation UI for the user to re-target (assign a workspace + agent) or
+ * delete. Internal `__*__` jobs were already pruned by 0004.
+ *
+ * Idempotent: re-running finds no enabled-and-targetless jobs and leaves the
+ * file byte-for-byte unchanged. No-op when the file doesn't exist.
+ */
+
+import { readFile, writeFile, mkdir, rename } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type { Migration } from '../types.js'
+import { dataPath } from '@/core/paths.js'
+
+const DEFAULT_JOBS_PATH = dataPath('cron', 'jobs.json')
+
+interface RawJob {
+  id?: string
+  name?: string
+  enabled?: boolean
+  workspaceId?: unknown
+  [k: string]: unknown
+}
+
+interface JobsFile {
+  jobs: RawJob[]
+}
+
+function hasWorkspace(job: RawJob): boolean {
+  return typeof job.workspaceId === 'string' && job.workspaceId.length > 0
+}
+
+/**
+ * Disable enabled jobs with no target workspace, write back atomically.
+ * Exported so the spec can drive it against a temp path. Returns the
+ * names/ids of the jobs it disabled.
+ */
+export async function disableTargetlessCronJobs(
+  jobsFilePath: string = DEFAULT_JOBS_PATH,
+): Promise<{ disabled: string[] }> {
+  let raw: string
+  try {
+    raw = await readFile(jobsFilePath, 'utf-8')
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { disabled: [] }
+    }
+    throw err
+  }
+
+  const data = JSON.parse(raw) as JobsFile
+  if (!Array.isArray(data.jobs)) return { disabled: [] }
+
+  const disabled: string[] = []
+  for (const job of data.jobs) {
+    if (job?.enabled === true && !hasWorkspace(job)) {
+      job.enabled = false
+      disabled.push(job.name ?? job.id ?? '(unnamed)')
+    }
+  }
+
+  if (disabled.length === 0) return { disabled: [] }
+
+  await mkdir(dirname(jobsFilePath), { recursive: true })
+  const tmp = `${jobsFilePath}.${process.pid}.${randomUUID().slice(0, 8)}.tmp`
+  await writeFile(tmp, JSON.stringify(data, null, 2), 'utf-8')
+  await rename(tmp, jobsFilePath)
+
+  for (const name of disabled) {
+    console.log(`[migration 0008] disabled targetless cron job ${name} — assign a workspace + agent to re-enable`)
+  }
+
+  return { disabled }
+}
+
+export const migration: Migration = {
+  id: '0008_disable_targetless_cron_jobs',
+  appVersion: '0.40.0-beta.3',
+  introducedAt: '2026-06-08',
+  affects: ['cron/jobs.json'],
+  summary:
+    'Disable enabled cron jobs that have no target workspace (legacy AgentWork-era jobs) so they stop firing into the retired path.',
+  rationale:
+    'Cron now dispatches headless Workspace runs (workspaceId + agent). Targetless jobs would error loudly on every fire; disable them so the user can re-target or delete.',
+  up: async () => {
+    await disableTargetlessCronJobs()
+  },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -14,3 +14,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0005_extract_mcp_from_connectors` | 0.10.0-beta.3 | 2026-05-12 | connectors.json, mcp.json | Move connectors.mcp → top-level mcp.json (MCP server is a ToolCenter export, not a chat-input connector) |
 | `0006_retire_brain` | 0.10.0-beta.5 | 2026-05-13 | brain/commit.json, brain/frontal-lobe.md | Delete orphan data/brain/{commit.json,frontal-lobe.md} after Brain retirement (persona.md / heartbeat.md retained) |
 | `0007_retire_legacy_chat` | 0.30.0-beta.1 | 2026-05-31 | connectors.json, sessions/notifications.jsonl | Strip dead telegram/mcpAsk from connectors.json (keep web) + delete orphan notifications.jsonl after legacy chat cluster removal |
+| `0008_disable_targetless_cron_jobs` | 0.40.0-beta.3 | 2026-06-08 | cron/jobs.json | Disable enabled cron jobs that have no target workspace (legacy AgentWork-era jobs) so they stop firing into the retired path. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -19,6 +19,7 @@ import { migration as migration_0004_prune_internal_cron_jobs } from './0004_pru
 import { migration as migration_0005_extract_mcp_from_connectors } from './0005_extract_mcp_from_connectors/index.js'
 import { migration as migration_0006_retire_brain } from './0006_retire_brain/index.js'
 import { migration as migration_0007_retire_legacy_chat } from './0007_retire_legacy_chat/index.js'
+import { migration as migration_0008_disable_targetless_cron_jobs } from './0008_disable_targetless_cron_jobs/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0001_initial_unified,
@@ -28,4 +29,5 @@ export const REGISTRY: Migration[] = [
   migration_0005_extract_mcp_from_connectors,
   migration_0006_retire_brain,
   migration_0007_retire_legacy_chat,
+  migration_0008_disable_targetless_cron_jobs,
 ]

--- a/src/task/cron/engine.ts
+++ b/src/task/cron/engine.ts
@@ -41,6 +41,15 @@ export interface CronJob {
   enabled: boolean
   schedule: CronSchedule
   payload: string
+  /**
+   * The workspace this job fires into. A cron job is "run this prompt in that
+   * workspace, headless". Optional only for backward-compat with pre-headless
+   * jobs (migration 0008 disables those); a job that fires without a
+   * workspaceId is a loud no-op in the listener.
+   */
+  workspaceId?: string
+  /** Which enabled CLI adapter to run — claude / codex / pi / opencode. */
+  agent?: string
   state: CronJobState
   createdAt: number
 }
@@ -49,6 +58,9 @@ export interface CronFirePayload {
   jobId: string
   jobName: string
   payload: string
+  /** Dispatch target — threaded through so the listener needn't re-read the store. */
+  workspaceId?: string
+  agent?: string
 }
 
 // ==================== CRUD Types ====================
@@ -58,6 +70,8 @@ export interface CronJobCreate {
   schedule: CronSchedule
   payload: string
   enabled?: boolean
+  workspaceId?: string
+  agent?: string
 }
 
 export interface CronJobPatch {
@@ -65,6 +79,8 @@ export interface CronJobPatch {
   schedule?: CronSchedule
   payload?: string
   enabled?: boolean
+  workspaceId?: string
+  agent?: string
 }
 
 // ==================== Engine Interface ====================
@@ -177,6 +193,8 @@ export function createCronEngine(opts: CronEngineOpts): CronEngine {
         jobId: job.id,
         jobName: job.name,
         payload: job.payload,
+        ...(job.workspaceId !== undefined ? { workspaceId: job.workspaceId } : {}),
+        ...(job.agent !== undefined ? { agent: job.agent } : {}),
       } satisfies CronFirePayload)
 
       job.state.lastStatus = 'ok'
@@ -235,6 +253,8 @@ export function createCronEngine(opts: CronEngineOpts): CronEngine {
         enabled: params.enabled ?? true,
         schedule: params.schedule,
         payload: params.payload,
+        ...(params.workspaceId !== undefined ? { workspaceId: params.workspaceId } : {}),
+        ...(params.agent !== undefined ? { agent: params.agent } : {}),
         state: {
           nextRunAtMs: computeNextRun(params.schedule, currentMs),
           lastRunAtMs: null,
@@ -261,6 +281,8 @@ export function createCronEngine(opts: CronEngineOpts): CronEngine {
       if (patch.name !== undefined) job.name = patch.name
       if (patch.payload !== undefined) job.payload = patch.payload
       if (patch.enabled !== undefined) job.enabled = patch.enabled
+      if (patch.workspaceId !== undefined) job.workspaceId = patch.workspaceId
+      if (patch.agent !== undefined) job.agent = patch.agent
 
       if (patch.schedule !== undefined) {
         job.schedule = patch.schedule

--- a/src/task/cron/listener.spec.ts
+++ b/src/task/cron/listener.spec.ts
@@ -4,218 +4,192 @@ import { tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import { createEventLog, type EventLog } from '../../core/event-log.js'
 import { createListenerRegistry, type ListenerRegistry } from '../../core/listener-registry.js'
-import { createCronListener, type CronListener } from './listener.js'
-import { SessionStore } from '../../core/session.js'
+import {
+  createCronListener,
+  type CronListener,
+  type WorkspaceServiceBox,
+  type CronDispatchLogger,
+} from './listener.js'
 import type { CronFirePayload } from './engine.js'
-import { createMemoryInboxStore, type IInboxStore } from '../../core/inbox-store.js'
-import { AgentWorkRunner } from '../../core/agent-work.js'
-import { createAgentWorkListener, type AgentWorkListener } from '../../core/agent-work-listener.js'
-import type { GenerateRouter } from '../../core/ai-provider-manager.js'
-import type { AgentWorkDonePayload, AgentWorkErrorPayload } from '../../core/agent-event.js'
+import type { WorkspaceService } from '../../workspaces/service.js'
 
 function tempPath(ext: string): string {
   return join(tmpdir(), `cron-listener-test-${randomUUID()}.${ext}`)
 }
 
-// ==================== Mock router ====================
+// ==================== Fake WorkspaceService ====================
 //
-// Post-AgentCenter-retirement the runner drives GenerateRouter directly:
-// router.resolve() → provider.generate(entries, prompt, opts), consuming
-// the ProviderEvent stream up to the terminal `done` event. The mock
-// records the prompt it was driven with and can be set to throw.
+// The listener uses a narrow slice: registry.get(id) → meta, resolveAdapter,
+// dispatchHeadlessTask. We fake exactly that and record dispatch calls.
 
-function createMockRouter(initialText = 'AI reply') {
-  let response = initialText
-  let shouldFail = false
-  const calls: Array<{ prompt: string }> = []
-  const provider = {
-    providerTag: 'vercel-ai' as const,
-    async *generate(_entries: unknown, prompt: string) {
-      calls.push({ prompt })
-      if (shouldFail) throw new Error('engine error')
-      yield { type: 'done' as const, result: { text: response, media: [], toolCalls: [] } }
+interface DispatchCall {
+  wsId: string
+  adapterId: string
+  prompt: string
+  timeoutMs: number
+}
+
+function makeService(opts: {
+  workspaces: Record<string, { id: string; tag: string; agents: string[] }>
+  headless?: boolean
+  dispatch?: () => Promise<{ taskId: string }>
+}): { svc: WorkspaceService; calls: DispatchCall[] } {
+  const calls: DispatchCall[] = []
+  const headless = opts.headless ?? true
+  const svc = {
+    registry: { get: (id: string) => opts.workspaces[id] },
+    resolveAdapter: (meta: { agents: string[] }, agentId?: string) => ({
+      id: agentId ?? meta.agents[0] ?? 'claude',
+      capabilities: { headless },
+    }),
+    dispatchHeadlessTask: async (
+      meta: { id: string },
+      adapter: { id: string },
+      prompt: string,
+      timeoutMs: number,
+    ) => {
+      calls.push({ wsId: meta.id, adapterId: adapter.id, prompt, timeoutMs })
+      return opts.dispatch ? opts.dispatch() : { taskId: 'task-1' }
     },
-  }
-  const router = { resolve: async () => ({ provider, profile: {} }) } as unknown as GenerateRouter
+  } as unknown as WorkspaceService
+  return { svc, calls }
+}
+
+function captureLogger(): { logger: CronDispatchLogger; errors: string[]; infos: string[] } {
+  const errors: string[] = []
+  const infos: string[] = []
   return {
-    router,
-    calls,
-    setResponse(text: string) { response = text },
-    setShouldFail(val: boolean) { shouldFail = val },
-    callCount() { return calls.length },
+    logger: { info: (m) => infos.push(m), warn: () => {}, error: (m) => errors.push(m) },
+    errors,
+    infos,
   }
 }
 
-describe('cron listener', () => {
+describe('cron listener → headless dispatch', () => {
   let eventLog: EventLog
   let registry: ListenerRegistry
   let cronListener: CronListener
-  let agentWorkListener: AgentWorkListener
-  let mockRouter: ReturnType<typeof createMockRouter>
-  let session: SessionStore
-  let inboxStore: IInboxStore
+  let ref: WorkspaceServiceBox
+  let cap: ReturnType<typeof captureLogger>
+
+  async function fire(payload: CronFirePayload): Promise<void> {
+    await eventLog.append('cron.fire', payload)
+  }
 
   beforeEach(async () => {
     eventLog = await createEventLog({ logPath: tempPath('jsonl') })
     registry = createListenerRegistry(eventLog)
     await registry.start()
-    mockRouter = createMockRouter()
-    session = new SessionStore(`test/cron-${randomUUID()}`)
-    inboxStore = createMemoryInboxStore()
-
-    const runner = new AgentWorkRunner({
-      router: mockRouter.router,
-      inboxStore,
-    })
-    agentWorkListener = createAgentWorkListener({ runner, registry })
-    await agentWorkListener.start()
-
-    cronListener = createCronListener({
-      agentWorkListener,
-      registry,
-      session,
-    })
+    ref = { current: null }
+    cap = captureLogger()
+    cronListener = createCronListener({ registry, workspaceServiceRef: ref, logger: cap.logger })
     await cronListener.start()
   })
 
   afterEach(async () => {
     cronListener.stop()
-    agentWorkListener.stop()
     await registry.stop()
     await eventLog._resetForTest()
   })
 
-  // ==================== Basic functionality ====================
-
-  describe('event handling', () => {
-    it('emits agent.work.requested on cron.fire', async () => {
-      await eventLog.append('cron.fire', {
-        jobId: 'abc12345',
-        jobName: 'test-job',
-        payload: 'Check the market',
-      } satisfies CronFirePayload)
-
-      await vi.waitFor(() => {
-        expect(eventLog.recent({ type: 'agent.work.requested' })).toHaveLength(1)
-      })
-
-      const req = eventLog.recent({ type: 'agent.work.requested' })[0].payload as { source: string; prompt: string; metadata: { jobId: string; jobName: string } }
-      expect(req.source).toBe('cron')
-      expect(req.prompt).toBe('Check the market')
-      expect(req.metadata).toEqual({ jobId: 'abc12345', jobName: 'test-job' })
+  it('dispatches a headless run for a job targeting a workspace + agent', async () => {
+    const { svc, calls } = makeService({
+      workspaces: { 'ws-1': { id: 'ws-1', tag: 'research', agents: ['claude', 'codex'] } },
     })
+    ref.current = svc
 
-    it('downstream agent.work.done payload carries source=cron + reply', async () => {
-      await eventLog.append('cron.fire', {
-        jobId: 'abc12345',
-        jobName: 'test-job',
-        payload: 'Do something',
-      } satisfies CronFirePayload)
+    await fire({ jobId: 'j1', jobName: 'morning-scan', payload: 'Scan the market', workspaceId: 'ws-1', agent: 'codex' })
 
-      await vi.waitFor(() => {
-        expect(eventLog.recent({ type: 'agent.work.done' })).toHaveLength(1)
-      })
-
-      const done = eventLog.recent({ type: 'agent.work.done' })[0]
-      const payload = done.payload as AgentWorkDonePayload
-      expect(payload.source).toBe('cron')
-      expect(payload.reply).toBe('AI reply')
-      expect(payload.durationMs).toBeGreaterThanOrEqual(0)
-      expect(payload.delivered).toBe(true)
-      expect(payload.metadata).toMatchObject({ jobId: 'abc12345', jobName: 'test-job' })
-      // causality: done is caused by the requested event, which is caused by fire
-      expect(typeof done.causedBy).toBe('number')
-    })
-
-    it('drops internal __*__ job names without forwarding to agent-work', async () => {
-      // Pump-driven services (heartbeat / snapshot) reserve the `__*__`
-      // namespace. Migration 0004 prunes any such entries from the on-disk
-      // cron store on upgrade, but a downgrade / manual edit / future
-      // refactor could re-introduce one. The listener guard is the last
-      // line of defense — orphan exists on disk but never reaches AI.
-      await eventLog.append('cron.fire', {
-        jobId: '18128a16',
-        jobName: '__snapshot__',
-        payload: '',
-      } satisfies CronFirePayload)
-
-      await new Promise((r) => setTimeout(r, 50))
-
-      expect(eventLog.recent({ type: 'agent.work.requested' })).toHaveLength(0)
-      expect(mockRouter.callCount()).toBe(0)
-    })
-
-    it('does not react to other event types', async () => {
-      await eventLog.append('message.received' as never, { channel: 'web', to: 'x', prompt: 'p' })
-      await new Promise((r) => setTimeout(r, 50))
-      expect(mockRouter.callCount()).toBe(0)
-    })
+    await vi.waitFor(() => expect(calls).toHaveLength(1))
+    expect(calls[0]).toMatchObject({ wsId: 'ws-1', adapterId: 'codex', prompt: 'Scan the market' })
+    expect(calls[0].timeoutMs).toBeGreaterThan(0)
   })
 
-  // ==================== Delivery ====================
-
-  describe('delivery', () => {
-    it('appends AI reply to the inbox under automation:cron', async () => {
-      await eventLog.append('cron.fire', {
-        jobId: 'abc12345',
-        jobName: 'test-job',
-        payload: 'Hello',
-      } satisfies CronFirePayload)
-
-      await vi.waitFor(() => {
-        expect(eventLog.recent({ type: 'agent.work.done' })).toHaveLength(1)
-      })
-
-      const { entries } = await inboxStore.read()
-      expect(entries).toHaveLength(1)
-      expect(entries[0].comments).toBe('AI reply')
-      expect(entries[0].workspaceId).toBe('automation:cron')
+  it('defaults to the workspace default agent when none is named', async () => {
+    const { svc, calls } = makeService({
+      workspaces: { 'ws-1': { id: 'ws-1', tag: 'research', agents: ['pi', 'claude'] } },
     })
+    ref.current = svc
+
+    await fire({ jobId: 'j1', jobName: 'scan', payload: 'go', workspaceId: 'ws-1' })
+
+    await vi.waitFor(() => expect(calls).toHaveLength(1))
+    expect(calls[0].adapterId).toBe('pi')
   })
 
-  // ==================== Error handling ====================
+  it('loud-skips a job with no target workspace', async () => {
+    const { svc, calls } = makeService({ workspaces: {} })
+    ref.current = svc
 
-  describe('error handling', () => {
-    it('emits agent.work.error on engine failure', async () => {
-      mockRouter.setShouldFail(true)
+    await fire({ jobId: 'j1', jobName: 'legacy', payload: 'go' })
 
-      await eventLog.append('cron.fire', {
-        jobId: 'abc12345',
-        jobName: 'test-job',
-        payload: 'Will fail',
-      } satisfies CronFirePayload)
-
-      await vi.waitFor(() => {
-        expect(eventLog.recent({ type: 'agent.work.error' })).toHaveLength(1)
-      })
-
-      const err = eventLog.recent({ type: 'agent.work.error' })[0].payload as AgentWorkErrorPayload
-      expect(err.source).toBe('cron')
-      expect(err.error).toBe('engine error')
-      expect(err.metadata).toMatchObject({ jobId: 'abc12345', jobName: 'test-job' })
-    })
+    await vi.waitFor(() => expect(cap.errors.some((e) => e.includes('no target workspace'))).toBe(true))
+    expect(calls).toHaveLength(0)
   })
 
-  // ==================== Lifecycle ====================
+  it('loud-skips when the workspace service is not ready yet', async () => {
+    ref.current = null // plugin not booted
+    await fire({ jobId: 'j1', jobName: 'early', payload: 'go', workspaceId: 'ws-1', agent: 'claude' })
+    await vi.waitFor(() => expect(cap.errors.some((e) => e.includes('not ready'))).toBe(true))
+  })
 
-  describe('lifecycle', () => {
-    it('stops emitting after registry.stop()', async () => {
-      await registry.stop()
+  it('loud-skips an unknown target workspace', async () => {
+    const { svc, calls } = makeService({ workspaces: {} })
+    ref.current = svc
+    await fire({ jobId: 'j1', jobName: 'gone', payload: 'go', workspaceId: 'deleted-ws', agent: 'claude' })
+    await vi.waitFor(() => expect(cap.errors.some((e) => e.includes('unknown workspace'))).toBe(true))
+    expect(calls).toHaveLength(0)
+  })
 
-      await eventLog.append('cron.fire', {
-        jobId: 'abc12345',
-        jobName: 'test-job',
-        payload: 'Should not fire',
-      } satisfies CronFirePayload)
-
-      await new Promise((r) => setTimeout(r, 50))
-
-      expect(mockRouter.callCount()).toBe(0)
+  it('loud-skips when the named agent is not enabled on the workspace', async () => {
+    const { svc, calls } = makeService({
+      workspaces: { 'ws-1': { id: 'ws-1', tag: 'research', agents: ['claude'] } },
     })
+    ref.current = svc
+    await fire({ jobId: 'j1', jobName: 'bad-agent', payload: 'go', workspaceId: 'ws-1', agent: 'codex' })
+    await vi.waitFor(() => expect(cap.errors.some((e) => e.includes('not enabled'))).toBe(true))
+    expect(calls).toHaveLength(0)
+  })
 
-    it('is idempotent on repeated start()', async () => {
-      await cronListener.start()
-      // No error
+  it('loud-logs a dispatch failure (e.g. capacity) without throwing', async () => {
+    const { svc } = makeService({
+      workspaces: { 'ws-1': { id: 'ws-1', tag: 'research', agents: ['claude'] } },
+      dispatch: async () => { throw new Error('headless capacity reached') },
     })
+    ref.current = svc
+    await fire({ jobId: 'j1', jobName: 'busy', payload: 'go', workspaceId: 'ws-1', agent: 'claude' })
+    await vi.waitFor(() => expect(cap.errors.some((e) => e.includes('dispatch failed'))).toBe(true))
+  })
+
+  it('drops internal __*__ job names without dispatching', async () => {
+    const { svc, calls } = makeService({
+      workspaces: { 'ws-1': { id: 'ws-1', tag: 'research', agents: ['claude'] } },
+    })
+    ref.current = svc
+    await fire({ jobId: 'snap', jobName: '__snapshot__', payload: '', workspaceId: 'ws-1' })
+    await new Promise((r) => setTimeout(r, 50))
+    expect(calls).toHaveLength(0)
+    expect(cap.errors).toHaveLength(0)
+  })
+
+  it('does not react to other event types', async () => {
+    const { svc, calls } = makeService({
+      workspaces: { 'ws-1': { id: 'ws-1', tag: 'research', agents: ['claude'] } },
+    })
+    ref.current = svc
+    await eventLog.append('message.received' as never, { channel: 'web', to: 'x', prompt: 'p' })
+    await new Promise((r) => setTimeout(r, 50))
+    expect(calls).toHaveLength(0)
+  })
+
+  it('stops dispatching after registry.stop()', async () => {
+    const { svc, calls } = makeService({
+      workspaces: { 'ws-1': { id: 'ws-1', tag: 'research', agents: ['claude'] } },
+    })
+    ref.current = svc
+    await registry.stop()
+    await fire({ jobId: 'j1', jobName: 'after-stop', payload: 'go', workspaceId: 'ws-1', agent: 'claude' })
+    await new Promise((r) => setTimeout(r, 50))
+    expect(calls).toHaveLength(0)
   })
 })

--- a/src/task/cron/listener.ts
+++ b/src/task/cron/listener.ts
@@ -1,103 +1,112 @@
 /**
- * Cron Listener — translates user-defined cron job fires into
- * canonical `agent.work.requested` events. The agent-work-listener
- * picks them up and runs the AI dispatch pipeline.
+ * Cron Listener — dispatches a cron fire into a headless Workspace run.
  *
- * Serial-execution lock so concurrent fires don't overlap. No output
- * policy lives here — every successful cron reply is delivered to the
- * Inbox (the AgentWork default). The source config registered here
- * doesn't reference any output gate, so the default deliver-result.text
- * behaviour wins; each cron reply lands as an inbox entry under the
- * synthetic `automation:cron` workspace.
+ * A cron job is "run this prompt in that workspace, headless". On `cron.fire`
+ * the listener resolves the job's target workspace + agent and calls
+ * `WorkspaceService.dispatchHeadlessTask` (fire-and-forget; the agent reports
+ * back via `inbox_push`, the launcher only tracks the run in the headless task
+ * registry → Runs panel). It emits nothing onto the event tape.
  *
- * Internal jobs (heartbeat / snapshot) no longer live in the cron
- * engine — they each own their own Pump. Migration 0004 prunes any
- * `__*__` orphan entries from the on-disk store on upgrade; a
- * defensive guard in handle() catches anything that slips back in.
+ * Concurrency is bounded by the headless task registry's own cap (it throws
+ * HeadlessCapacityError when full), so there's no serial lock here — multiple
+ * due jobs can dispatch in the same tick.
+ *
+ * Failures are LOUD, never silent: a job with no target workspace, a missing
+ * workspace, a disabled agent, or a capacity rejection logs an error (and the
+ * job simply doesn't run this fire). Migration 0008 disables pre-headless jobs
+ * that have no workspaceId so they don't error on every interval.
+ *
+ * The WorkspaceService is reached through a ref-box because it's constructed
+ * later than the cron wiring (inside the web plugin). `ref.current` is null
+ * until the plugin has started; an early fire is a loud skip.
  */
 
-import type { EventLogEntry } from '../../core/event-log.js'
-import type { CronFirePayload } from '../../core/agent-event.js'
-import { SessionStore } from '../../core/session.js'
-import type { Listener, ListenerContext } from '../../core/listener.js'
+import type { Listener } from '../../core/listener.js'
 import type { ListenerRegistry } from '../../core/listener-registry.js'
-import type { AgentWorkListener, AgentWorkSourceConfig } from '../../core/agent-work-listener.js'
+import type { WorkspaceService } from '../../workspaces/service.js'
 
-const CRON_EMITS = ['agent.work.requested'] as const
-type CronEmits = typeof CRON_EMITS
+/** Headless run timeout per fire (matches the HTTP headless route's ceiling). */
+const DEFAULT_HEADLESS_TIMEOUT_MS = 30 * 60_000
+
+/** Structural ref-box; satisfied by the web plugin's WorkspaceServiceRef. */
+export interface WorkspaceServiceBox {
+  current: WorkspaceService | null
+}
+
+export interface CronDispatchLogger {
+  info(msg: string): void
+  warn(msg: string): void
+  error(msg: string): void
+}
 
 export interface CronListenerOpts {
-  agentWorkListener: AgentWorkListener
   /** Registry to auto-register this listener with. */
   registry: ListenerRegistry
-  /** Optional: inject a session for testing. Otherwise creates a dedicated cron session. */
-  session?: SessionStore
+  /** Box holding the WorkspaceService once the web plugin has constructed it. */
+  workspaceServiceRef: WorkspaceServiceBox
+  /** Headless run timeout per fire. */
+  timeoutMs?: number
+  /** Loud-failure sink; defaults to console. */
+  logger?: CronDispatchLogger
 }
 
 export interface CronListener {
   start(): Promise<void>
   stop(): void
-  readonly listener: Listener<'cron.fire', CronEmits>
+  readonly listener: Listener<'cron.fire'>
 }
 
 export function createCronListener(opts: CronListenerOpts): CronListener {
-  const { agentWorkListener, registry } = opts
-  const session = opts.session ?? new SessionStore('cron/default')
-
-  let processing = false
-  let registered = false
-
-  const sourceConfig: AgentWorkSourceConfig = {
-    source: 'cron',
-    session,
-    preamble: (metadata) => {
-      const jobName = (metadata as { jobName?: string } | undefined)?.jobName
-      return `You are operating in the cron job context (session: cron/default${jobName ? `, job: ${jobName}` : ''}). This is an automated cron job execution.`
-    },
-    // No output gate — every successful reply is delivered to the Inbox
-    // (default AgentWork behaviour matches today's cron semantics).
-    buildDoneMetadata: (req) => {
-      const m = req.metadata as { jobId?: string; jobName?: string }
-      return { jobId: m.jobId, jobName: m.jobName }
-    },
-    buildErrorMetadata: (req) => {
-      const m = req.metadata as { jobId?: string; jobName?: string }
-      return { jobId: m.jobId, jobName: m.jobName }
-    },
+  const { registry, workspaceServiceRef } = opts
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_HEADLESS_TIMEOUT_MS
+  const log: CronDispatchLogger = opts.logger ?? {
+    info: (m) => console.log(m),
+    warn: (m) => console.warn(m),
+    error: (m) => console.error(m),
   }
 
-  const listener: Listener<'cron.fire', CronEmits> = {
+  let registered = false
+
+  const listener: Listener<'cron.fire'> = {
     name: 'cron-router',
     subscribes: 'cron.fire',
-    emits: CRON_EMITS,
-    async handle(
-      entry: EventLogEntry<CronFirePayload>,
-      ctx: ListenerContext<CronEmits>,
-    ): Promise<void> {
-      const payload = entry.payload
+    async handle(entry): Promise<void> {
+      const { jobId, jobName, payload, workspaceId, agent } = entry.payload
+      const tag = `job ${jobId} (${jobName})`
 
-      if (payload.jobName.startsWith('__') && payload.jobName.endsWith('__')) {
-        // Internal namespace reserved for Pump-owned services
-        // (heartbeat / snapshot). Migration 0004 prunes these from the
-        // on-disk cron store; this guard catches the case where an
-        // orphan slips back in (downgrade, manual edit, regression).
+      // Internal namespace reserved for Pump-owned services (heartbeat /
+      // snapshot). Migration 0004 prunes these; this guard catches orphans.
+      if (jobName.startsWith('__') && jobName.endsWith('__')) return
+
+      if (!workspaceId) {
+        log.error(`cron-dispatch: ${tag} has no target workspace — skipping. Assign a workspace + agent to this job.`)
+        return
+      }
+      const svc = workspaceServiceRef.current
+      if (!svc) {
+        log.error(`cron-dispatch: workspace service not ready — ${tag} skipped this fire.`)
+        return
+      }
+      const meta = svc.registry.get(workspaceId)
+      if (!meta) {
+        log.error(`cron-dispatch: ${tag} targets unknown workspace "${workspaceId}" — skipping.`)
+        return
+      }
+      if (agent && !meta.agents.includes(agent)) {
+        log.error(`cron-dispatch: ${tag} agent "${agent}" is not enabled on workspace "${workspaceId}" — skipping.`)
+        return
+      }
+      const adapter = svc.resolveAdapter(meta, agent)
+      if (!adapter.capabilities.headless) {
+        log.error(`cron-dispatch: agent "${adapter.id}" has no headless mode — ${tag} skipped.`)
         return
       }
 
-      if (processing) {
-        console.warn(`cron-listener: skipping job ${payload.jobId} (already processing)`)
-        return
-      }
-
-      processing = true
       try {
-        await ctx.emit('agent.work.requested', {
-          source: 'cron',
-          prompt: payload.payload,
-          metadata: { jobId: payload.jobId, jobName: payload.jobName },
-        })
-      } finally {
-        processing = false
+        const { taskId } = await svc.dispatchHeadlessTask(meta, adapter, payload, timeoutMs)
+        log.info(`cron-dispatch: ${tag} → workspace "${meta.tag}" (${adapter.id}), headless task ${taskId}`)
+      } catch (err) {
+        log.error(`cron-dispatch: ${tag} dispatch failed: ${err instanceof Error ? err.message : String(err)}`)
       }
     },
   }
@@ -107,7 +116,6 @@ export function createCronListener(opts: CronListenerOpts): CronListener {
     async start() {
       if (registered) return
       registry.register(listener)
-      agentWorkListener.registerSource(sourceConfig)
       registered = true
     },
     stop() {

--- a/src/task/cron/tools.ts
+++ b/src/task/cron/tools.ts
@@ -49,8 +49,10 @@ export function createCronTools(cronEngine: CronEngine) {
     cronAdd: tool({
       description:
         'Create a new scheduled job.\n\n' +
-        'The job will fire according to the schedule and deliver the payload text to you\n' +
-        'as a system event during the next heartbeat tick.\n\n' +
+        'On schedule, the job runs its payload as a prompt inside a target workspace,\n' +
+        'headless (the workspace agent runs it and reports back via the Inbox). Set\n' +
+        'workspaceId + agent so the job has somewhere to run — a job with no workspace\n' +
+        'is a no-op when it fires.\n\n' +
         'Schedule types:\n' +
         '- at: One-shot at a specific time. E.g. { kind: "at", at: "2025-06-01T14:00:00Z" }\n' +
         '- every: Repeating interval. E.g. { kind: "every", every: "2h" } or { kind: "every", every: "30m" }\n' +
@@ -58,15 +60,13 @@ export function createCronTools(cronEngine: CronEngine) {
         "Returns the new job's id.",
       inputSchema: z.object({
         name: z.string().describe('Short descriptive name for the job, e.g. "Check ETH funding rate"'),
-        payload: z.string().describe('The reminder/instruction text delivered to you when the job fires'),
+        payload: z.string().describe('The prompt the workspace agent runs when the job fires'),
         schedule: scheduleSchema.optional().describe('When the job should run'),
         enabled: z.boolean().optional().describe('Whether the job starts enabled (default: true)'),
-        sessionTarget: z
-          .enum(['main', 'isolated'])
-          .optional()
-          .describe('Where to run: "main" injects into heartbeat session (default), "isolated" runs in a fresh session'),
+        workspaceId: z.string().optional().describe('Target workspace id the headless run executes in'),
+        agent: z.string().optional().describe('Which enabled CLI agent to run: claude / codex / pi / opencode (defaults to the workspace default)'),
       }),
-      execute: async ({ name, payload, schedule, enabled }) => {
+      execute: async ({ name, payload, schedule, enabled, workspaceId, agent }) => {
         if (!schedule) {
           return { error: 'schedule is required' }
         }
@@ -75,6 +75,8 @@ export function createCronTools(cronEngine: CronEngine) {
           payload,
           schedule,
           enabled,
+          ...(workspaceId !== undefined ? { workspaceId } : {}),
+          ...(agent !== undefined ? { agent } : {}),
         })
         return { id }
       },
@@ -91,14 +93,12 @@ export function createCronTools(cronEngine: CronEngine) {
         payload: z.string().optional().describe('New payload text'),
         schedule: scheduleSchema.optional().describe('New schedule'),
         enabled: z.boolean().optional().describe('Enable or disable the job'),
-        sessionTarget: z
-          .enum(['main', 'isolated'])
-          .optional()
-          .describe('New session target'),
+        workspaceId: z.string().optional().describe('New target workspace id'),
+        agent: z.string().optional().describe('New target agent: claude / codex / pi / opencode'),
       }),
-      execute: async ({ id, name, payload, schedule, enabled }) => {
+      execute: async ({ id, name, payload, schedule, enabled, workspaceId, agent }) => {
         try {
-          await cronEngine.update(id, { name, payload, schedule, enabled })
+          await cronEngine.update(id, { name, payload, schedule, enabled, workspaceId, agent })
           return { ok: true }
         } catch (err) {
           return { error: err instanceof Error ? err.message : String(err) }

--- a/src/webui/routes/cron.ts
+++ b/src/webui/routes/cron.ts
@@ -17,6 +17,8 @@ export function createCronRoutes(ctx: EngineContext) {
         payload: string
         schedule: { kind: string; at?: string; every?: string; cron?: string }
         enabled?: boolean
+        workspaceId?: string
+        agent?: string
       }>()
       if (!body.name || !body.payload || !body.schedule?.kind) {
         return c.json({ error: 'name, payload, and schedule are required' }, 400)
@@ -26,6 +28,8 @@ export function createCronRoutes(ctx: EngineContext) {
         payload: body.payload,
         schedule: body.schedule as CronSchedule,
         enabled: body.enabled,
+        ...(typeof body.workspaceId === 'string' ? { workspaceId: body.workspaceId } : {}),
+        ...(typeof body.agent === 'string' ? { agent: body.agent } : {}),
       })
       return c.json({ id })
     } catch (err) {

--- a/ui/src/api/cron.ts
+++ b/ui/src/api/cron.ts
@@ -8,7 +8,7 @@ export const cronApi = {
     return res.json()
   },
 
-  async add(params: { name: string; payload: string; schedule: CronSchedule; enabled?: boolean }): Promise<{ id: string }> {
+  async add(params: { name: string; payload: string; schedule: CronSchedule; enabled?: boolean; workspaceId?: string; agent?: string }): Promise<{ id: string }> {
     const res = await fetch('/api/cron/jobs', {
       method: 'POST',
       headers,
@@ -21,7 +21,7 @@ export const cronApi = {
     return res.json()
   },
 
-  async update(id: string, patch: Partial<{ name: string; payload: string; schedule: CronSchedule; enabled: boolean }>): Promise<void> {
+  async update(id: string, patch: Partial<{ name: string; payload: string; schedule: CronSchedule; enabled: boolean; workspaceId: string; agent: string }>): Promise<void> {
     const res = await fetch(`/api/cron/jobs/${id}`, {
       method: 'PUT',
       headers,

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -284,6 +284,10 @@ export interface CronJob {
   enabled: boolean
   schedule: CronSchedule
   payload: string
+  /** Target workspace the job's prompt runs in, headless. */
+  workspaceId?: string
+  /** Which enabled CLI agent runs it — claude / codex / pi / opencode. */
+  agent?: string
   state: CronJobState
   createdAt: number
 }

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -8,6 +8,7 @@ import { useAutoSave } from '../hooks/useAutoSave'
 import { PageHeader } from '../components/PageHeader'
 import { AutomationFlowSection } from './AutomationFlowSection'
 import { AutomationWebhookSection } from './AutomationWebhookSection'
+import { listWorkspaces, type Workspace } from '../components/workspace/api'
 import { AutomationRunsSection } from './AutomationRunsSection'
 import type { ViewSpec } from '../tabs/types'
 
@@ -383,9 +384,10 @@ function CronSection() {
     <div className="flex flex-col gap-3">
       <div className="rounded-lg border border-border/50 bg-bg-secondary/50 px-4 py-3">
         <p className="text-[13px] text-text-muted leading-relaxed">
-          Cron jobs fire events on the dispatch bus at scheduled intervals.
-          Each job's payload is sent to Alice as a prompt — use them for periodic checks, reports, or any recurring task.
-          Internal jobs (heartbeat, snapshot) are managed by their own tabs.
+          On schedule, a cron job runs its payload as a prompt inside the workspace
+          you pick — headless. The workspace agent runs it and reports back via the
+          Inbox; the run shows up live in the Runs tab. Use them for periodic checks,
+          reports, or any recurring task.
         </p>
       </div>
       {error && <div className="text-xs text-red">{error}</div>}
@@ -492,6 +494,16 @@ function CronJobCard({ job, onToggle, onRunNow, onDelete }: {
       {expanded && (
         <div className="border-t border-border/50 px-4 py-3 text-xs space-y-2">
           <div>
+            <span className="text-text-muted">Runs in: </span>
+            {job.workspaceId ? (
+              <span className="text-text font-mono">
+                {job.workspaceId}{job.agent ? ` · ${job.agent}` : ' · default agent'}
+              </span>
+            ) : (
+              <span className="text-red">no workspace — won't run (assign one)</span>
+            )}
+          </div>
+          <div>
             <span className="text-text-muted">Payload: </span>
             <pre className="inline text-text whitespace-pre-wrap break-all">{job.payload}</pre>
           </div>
@@ -511,13 +523,27 @@ function AddCronJobForm({ onClose, onCreated }: { onClose: () => void; onCreated
   const [payload, setPayload] = useState('')
   const [schedKind, setSchedKind] = useState<'every' | 'cron' | 'at'>('every')
   const [schedValue, setSchedValue] = useState('1h')
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([])
+  const [workspaceId, setWorkspaceId] = useState('')
+  const [agent, setAgent] = useState('')
   const [error, setError] = useState('')
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    void listWorkspaces().then(setWorkspaces).catch(() => setWorkspaces([]))
+  }, [])
+
+  // Agent options follow the picked workspace's enabled adapters.
+  const agentOptions = workspaces.find((w) => w.id === workspaceId)?.agents ?? []
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!name.trim() || !payload.trim()) {
       setError('Name and payload are required')
+      return
+    }
+    if (!workspaceId) {
+      setError('Pick the workspace this job runs in')
       return
     }
 
@@ -529,7 +555,13 @@ function AddCronJobForm({ onClose, onCreated }: { onClose: () => void; onCreated
     setSaving(true)
     setError('')
     try {
-      await api.cron.add({ name: name.trim(), payload: payload.trim(), schedule })
+      await api.cron.add({
+        name: name.trim(),
+        payload: payload.trim(),
+        schedule,
+        workspaceId,
+        ...(agent ? { agent } : {}),
+      })
       onCreated()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Create failed')
@@ -552,6 +584,33 @@ function AddCronJobForm({ onClose, onCreated }: { onClose: () => void; onCreated
         onChange={(e) => setName(e.target.value)}
         className="w-full bg-bg-tertiary border border-border rounded-md px-3 py-2 text-sm text-text outline-none focus:border-accent"
       />
+
+      {/* Where the job runs — a workspace + one of its enabled agents, headless. */}
+      <div className="flex gap-2">
+        <select
+          value={workspaceId}
+          onChange={(e) => { setWorkspaceId(e.target.value); setAgent('') }}
+          className="flex-1 bg-bg-tertiary border border-border rounded-md px-2 py-2 text-sm text-text outline-none focus:border-accent"
+        >
+          <option value="">
+            {workspaces.length === 0 ? '— no workspaces —' : '— run in workspace… —'}
+          </option>
+          {workspaces.map((w) => (
+            <option key={w.id} value={w.id}>{w.tag}</option>
+          ))}
+        </select>
+        <select
+          value={agent}
+          onChange={(e) => setAgent(e.target.value)}
+          disabled={!workspaceId}
+          className="bg-bg-tertiary border border-border rounded-md px-2 py-2 text-sm text-text outline-none focus:border-accent disabled:opacity-40"
+        >
+          <option value="">{workspaceId ? 'default agent' : 'agent'}</option>
+          {agentOptions.map((a) => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+      </div>
 
       <textarea
         placeholder="Payload / instruction text"


### PR DESCRIPTION
## Summary
PR2 of the AI-config collapse. Wires autonomous **cron** onto the headless Workspace dispatch primitive — the step that makes the new automation actually *run an agent*. A cron job is now "run this prompt in that workspace, headless"; the workspace agent runs it and reports back via the Inbox (live in the Runs panel).

> **Stacked on #290** (base = `feat/central-credentials-template-injection`). Merge #290 first; GitHub will retarget this to `master`. Stacking lets you test the full story in one tree: template-inject a credential → workspace boots ready → cron fires → headless run uses it → Inbox.

- **Schema**: `CronJob` + `CronFirePayload` gain `workspaceId` + `agent` (the explicit CLI — `claude` / `codex` / `pi` / `opencode`). Threaded through add / update / fire.
- **Listener rewrite**: on `cron.fire` the cron listener resolves the target workspace + adapter from a `WorkspaceService` ref and calls `dispatchHeadlessTask`, instead of emitting `agent.work.requested` into the legacy in-process path. Failures are **loud** — no target / unknown workspace / disabled agent / capacity / service-not-ready each log an error and skip, never a silent orphan-fire.
- **Wiring**: `workspaceServiceRef` is created before the cron listener in `main.ts` and injected; `WebPlugin` fills it on start (an early fire is a loud skip).
- **Surfaces**: cron HTTP route + `cronAdd`/`cronUpdate` MCP tools accept the target (tool descriptions updated off the stale "heartbeat tick" model). The AutomationPage cron form gains workspace + agent selectors (agent options follow the picked workspace's enabled adapters); the job card shows the target.
- **Migration 0008**: disables enabled cron jobs lacking a `workspaceId` (legacy AgentWork-era jobs) so they stop firing into the retired path — left visible for the user to re-target or delete.

### Scope
Cron only. Webhook ingest + heartbeat still ride AgentWork; they and the whole in-process World B (GenerateRouter / providers / AgentWork) are removed in PR3 — after which AgentWork has no callers.

## Test plan
- [x] `npx tsc --noEmit` clean (Alice)
- [x] `cd ui && npx tsc -b` clean
- [x] `pnpm test` — 1864 passed (cron listener spec rewritten to headless-dispatch; migration 0008 spec added)
- [ ] Manual: configure a workspace's provider (or seed via a template per #290), create a cron job targeting it (+ pick an agent), hit ▶ Run now → a headless task appears in the Runs panel and the agent posts to the Inbox. Then create a job with no workspace (via an old `jobs.json`) and confirm it's disabled on boot + a targetless fire logs a loud error.

## Boundary touch
Touches the cron job schema (`data/cron/jobs.json`) — migration 0008 reshapes it (raw-fs, idempotent). No trading / broker / auth changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
