### PR TITLE
Federated K-line sources in the market page + venue-decided asset class

### DIFF
--- a/packages/uta-protocol/src/types/broker.ts
+++ b/packages/uta-protocol/src/types/broker.ts
@@ -364,6 +364,16 @@ export interface IBroker<TMeta = unknown> {
    */
   getHistorical?(contract: Contract, params: BarParams): Promise<Bar[]>
 
+  /**
+   * The asset class a contract belongs to, decided by the VENUE — not by the
+   * instrument's claimed type. A crypto exchange's "AAPL" is a synthetic /
+   * custodial token, so CcxtBroker reports everything as 'crypto' regardless of
+   * secType; IBKR/Alpaca map per real instrument. Optional — when absent, the
+   * consumer falls back to a secType heuristic (which is broker-blind and wrong
+   * for e.g. a CCXT dated future, hence this hook).
+   */
+  assetClassFor?(contract: Contract): 'equity' | 'crypto' | 'currency' | 'commodity' | 'unknown'
+
   // ---- Capabilities ----
 
   getCapabilities(): AccountCapabilities

--- a/packages/uta-protocol/src/types/manager.ts
+++ b/packages/uta-protocol/src/types/manager.ts
@@ -50,4 +50,7 @@ export interface ContractSearchHit {
   source: string
   contract: ContractDescription['contract']
   derivativeSecTypes: string[]
+  /** Venue-decided asset class (the broker's `assetClassFor`) — authoritative
+   *  over a secType heuristic. Absent ⇒ consumer falls back to secType. */
+  assetClass?: 'equity' | 'crypto' | 'currency' | 'commodity' | 'unknown'
 }

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -928,6 +928,13 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
 
   // ---- Capabilities ----
 
+  /** A crypto exchange's instruments are crypto — period. Even a listed "AAPL"
+   *  is a synthetic/custodial token here, not the real equity; secType (spot /
+   *  CRYPTO_PERP / FUT / OPT) is the instrument shape, not the asset class. */
+  assetClassFor(): 'crypto' {
+    return 'crypto'
+  }
+
   getCapabilities(): AccountCapabilities {
     return {
       supportedSecTypes: ['CRYPTO', 'CRYPTO_PERP'],

--- a/services/uta/src/domain/trading/contract-search.ts
+++ b/services/uta/src/domain/trading/contract-search.ts
@@ -43,7 +43,7 @@ export async function searchTradeableContracts(
   // whole sweep — the original AI tool used try/catch in a for-loop for the
   // same reason. Promise.allSettled lets it run concurrently.
   const settled = await Promise.allSettled(
-    targets.map(async (uta) => ({ id: uta.id, results: await uta.searchContracts(brokerPattern) })),
+    targets.map(async (uta) => ({ id: uta.id, broker: uta.broker, results: await uta.searchContracts(brokerPattern) })),
   )
   for (const r of settled) {
     if (r.status !== 'fulfilled') continue
@@ -52,6 +52,9 @@ export async function searchTradeableContracts(
         source: r.value.id,
         contract: desc.contract,
         derivativeSecTypes: desc.derivativeSecTypes,
+        // Venue decides the asset class (a crypto exchange's "stock" is synthetic
+        // crypto); falls back to a secType heuristic downstream when absent.
+        assetClass: r.value.broker.assetClassFor?.(desc.contract),
       })
     }
   }

--- a/services/uta/src/domain/trading/keyless-data-uta.spec.ts
+++ b/services/uta/src/domain/trading/keyless-data-uta.spec.ts
@@ -29,6 +29,13 @@ describe('keyless data UTA injection (createBroker)', () => {
     })
   }
 
+  it('reports every contract as crypto (a crypto venue\'s "stock" is synthetic)', () => {
+    const broker = createBroker(cfgFor('okx')) as unknown as { assetClassFor(c: unknown): string }
+    // Even a "FUT" or a tokenized-equity-looking contract → crypto, by venue.
+    expect(broker.assetClassFor({ symbol: 'BTC', secType: 'FUT' })).toBe('crypto')
+    expect(broker.assetClassFor({ symbol: 'AAPL', secType: 'STK' })).toBe('crypto')
+  })
+
   it('keyless account-reads return empty without auth (no fetchBalance / no init)', async () => {
     const broker = createBroker(cfgFor('binance')) as unknown as {
       getAccount(): Promise<{ totalCashValue: string; netLiquidation: string }>

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -171,6 +171,24 @@ describe('searchBarSources — federated candidates', () => {
     expect(out.some((c) => c.source === 'vendor')).toBe(true)
   })
 
+  it('venue-decided assetClass wins over the secType heuristic (CCXT future ≠ commodity)', async () => {
+    const utaManager = {
+      has: async () => true,
+      get: async () => undefined,
+      searchContracts: async () => [
+        // A CCXT dated future: secType FUT (would heuristically → commodity), but
+        // the venue says crypto → crypto must win.
+        { source: 'okx-readonly', contract: { aliceId: 'okx-readonly|BTC/USDT:USDT-240628', symbol: 'BTC', secType: 'FUT' }, derivativeSecTypes: [], assetClass: 'crypto' },
+        // No venue hint → falls back to the secType heuristic (FUT → commodity).
+        { source: 'ibkr', contract: { aliceId: 'ibkr|CL', symbol: 'CL', secType: 'FUT' }, derivativeSecTypes: [] },
+      ],
+    } as never
+    const out = await createBarService(makeDeps({ utaManager })).searchBarSources('BTC')
+    const uta = out.filter((c) => c.source === 'uta')
+    expect(uta[0]).toMatchObject({ sourceId: 'okx-readonly', assetClass: 'crypto' })
+    expect(uta[1]).toMatchObject({ sourceId: 'ibkr', assetClass: 'commodity' })
+  })
+
   it('survives one side failing (vendor still returns if UTA throws)', async () => {
     const utaManager = {
       has: async () => true,

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -232,6 +232,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
             source: 'vendor',
             sourceId: provider,
             symbol,
+            name: r.name ?? undefined,
             assetClass: r.assetClass,
             label: r.name ? `${symbol} · ${r.name} (${provider})` : `${symbol} (${provider})`,
             barCapability: VENDOR_CAPABILITY[provider],

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -250,7 +250,9 @@ export function createBarService(deps: BarServiceDeps): BarService {
             source: 'uta',
             sourceId: hit.source,
             symbol,
-            assetClass: secTypeToAssetClass(hit.contract.secType),
+            // Venue-decided asset class is authoritative; secType is only a
+            // broker-blind fallback (and wrong for e.g. a CCXT dated future).
+            assetClass: hit.assetClass ?? secTypeToAssetClass(hit.contract.secType),
             label: symbol ? `${symbol} (${hit.source})` : `${barId}`,
             barCapability: 'realtime',
           })

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -78,6 +78,8 @@ export interface BarSourceCandidate {
   source: BarSourceKind
   sourceId: string
   symbol: string
+  /** Human-readable asset name (vendor results) — for the search list. */
+  name?: string
   assetClass: AssetClass | 'unknown'
   label: string
   barCapability?: BarCapability

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -20,6 +20,7 @@ import { createAgentStatusRoutes } from './routes/agent-status.js'
 import { createPersonaRoutes } from './routes/persona.js'
 import { createNewsRoutes } from './routes/news.js'
 import { createMarketRoutes } from './routes/market.js'
+import { createBarsRoutes } from './routes/bars.js'
 import { createInboxRoutes } from './routes/inbox.js'
 import { createEntityRoutes } from './routes/entities.js'
 import { createVersionRoutes } from './routes/version.js'
@@ -202,6 +203,7 @@ export class WebPlugin implements Plugin {
     app.route('/api/agent-status', createAgentStatusRoutes(ctx))
     app.route('/api/news', createNewsRoutes(ctx))
     app.route('/api/market', createMarketRoutes(ctx))
+    app.route('/api/bars', createBarsRoutes(ctx))
     app.route('/api/persona', createPersonaRoutes())
     app.route('/api/inbox', createInboxRoutes({ inboxStore: ctx.inboxStore }))
     app.route('/api/version', createVersionRoutes())

--- a/src/webui/routes/bars.spec.ts
+++ b/src/webui/routes/bars.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { createBarsRoutes } from './bars.js'
+import type { EngineContext } from '../../core/types.js'
+
+function mkCtx(overrides?: Partial<EngineContext['barService']>): EngineContext {
+  return {
+    barService: {
+      searchBarSources: async (q: string) => [
+        { barId: `yfinance|${q}`, source: 'vendor', sourceId: 'yfinance', symbol: q, assetClass: 'equity', label: q, barCapability: 'delayed' },
+      ],
+      getBars: async (ref: { barId?: string }) => ({
+        bars: [{ date: '2024-01-01', open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 }],
+        meta: { symbol: 'AAPL', from: '2024-01-01', to: '2024-01-01', bars: 1, source: 'vendor', sourceId: 'yfinance', barId: ref.barId ?? 'yfinance|AAPL', provider: 'yfinance', barCapability: 'delayed' },
+      }),
+      ...overrides,
+    },
+  } as unknown as EngineContext
+}
+
+describe('bars routes', () => {
+  it('GET /search returns federated candidates', async () => {
+    const res = await createBarsRoutes(mkCtx()).request('/search?query=AAPL')
+    const body = await res.json()
+    expect(body.count).toBe(1)
+    expect(body.candidates[0].barId).toBe('yfinance|AAPL')
+  })
+
+  it('GET /search with empty query → no candidates (no fetch)', async () => {
+    const res = await createBarsRoutes(mkCtx()).request('/search?query=')
+    expect((await res.json()).candidates).toEqual([])
+  })
+
+  it('GET / by barId returns bars + meta (explicit provider)', async () => {
+    const res = await createBarsRoutes(mkCtx()).request('/?barId=yfinance|AAPL&interval=1d')
+    const body = await res.json()
+    expect(body.results).toHaveLength(1)
+    expect(body.meta.sourceId).toBe('yfinance')
+    expect(body.meta.barId).toBe('yfinance|AAPL')
+  })
+
+  it('GET / without barId or symbol → 400', async () => {
+    const res = await createBarsRoutes(mkCtx()).request('/?interval=1d')
+    expect(res.status).toBe(400)
+  })
+
+  it('GET / surfaces a getBars failure as { error }, not a crash', async () => {
+    const ctx = mkCtx({ getBars: async () => { throw new Error('Vendor barId needs an assetClass') } })
+    const res = await createBarsRoutes(ctx).request('/?barId=yfinance|AAPL&interval=1d')
+    const body = await res.json()
+    expect(body.results).toBeNull()
+    expect(body.error).toMatch(/assetClass/)
+  })
+})

--- a/src/webui/routes/bars.ts
+++ b/src/webui/routes/bars.ts
@@ -1,0 +1,61 @@
+/**
+ * Federated K-line routes — `/api/bars/*`.
+ *
+ * The frontend chart's source-aware data path. Unlike the vendor-only
+ * `/api/market-data-v1/*` passthrough, this goes through the federated bar
+ * service: one symbol can have many bar sources (vendor + each connected
+ * broker), each named by barId and tagged with a capability (realtime/iex/
+ * delayed). Disambiguation is by EXPLICIT provider, never an internal rule —
+ * the UI shows which source a chart came from and lets the user switch.
+ */
+
+import { Hono } from 'hono'
+import type { EngineContext } from '../../core/types.js'
+import type { BarSourceRef, GetBarsOpts } from '../../domain/market-data/bars/index.js'
+import type { AssetClass } from '../../domain/market-data/aggregate-search.js'
+
+export function createBarsRoutes(ctx: EngineContext): Hono {
+  const app = new Hono()
+
+  // GET /api/bars/search?query=&limit= → federated source candidates (barIds),
+  // each with source/sourceId/assetClass/label/barCapability for the picker.
+  app.get('/search', async (c) => {
+    const query = (c.req.query('query') ?? '').trim()
+    const limit = Number(c.req.query('limit') ?? 20)
+    if (!query) return c.json({ candidates: [], count: 0 })
+    const candidates = await ctx.barService.searchBarSources(query, { limit })
+    return c.json({ candidates, count: candidates.length })
+  })
+
+  // GET /api/bars?barId=&interval=&count=&start=&end=&assetClass=
+  //  or ?symbol=&assetClass=&interval=  (vendor-default, when no barId chosen yet)
+  app.get('/', async (c) => {
+    const interval = c.req.query('interval') ?? '1d'
+    const barId = c.req.query('barId')
+    const symbol = c.req.query('symbol')
+    const assetClass = c.req.query('assetClass') as AssetClass | undefined
+    const count = c.req.query('count')
+    const start = c.req.query('start')
+    const end = c.req.query('end')
+
+    let ref: BarSourceRef
+    if (barId) ref = assetClass ? { barId, assetClass } : { barId }
+    else if (symbol && assetClass) ref = { symbol, assetClass }
+    else return c.json({ results: null, meta: null, error: 'provide barId, or symbol + assetClass' }, 400)
+
+    const opts: GetBarsOpts = { interval }
+    if (count) opts.count = Number(count)
+    if (start) opts.start = start
+    if (end) opts.end = end
+
+    try {
+      const { bars, meta } = await ctx.barService.getBars(ref, opts)
+      return c.json({ results: bars, meta })
+    } catch (err) {
+      // Loud-but-graceful: the chart shows the message, doesn't crash.
+      return c.json({ results: null, meta: null, error: err instanceof Error ? err.message : String(err) })
+    }
+  })
+
+  return app
+}

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -127,3 +127,67 @@ export const marketApi = {
     cashflow: (symbol: string) => equityEndpoint<FinancialStatementRow>('fundamental/cash', { symbol }),
   },
 }
+
+// ==================== Federated bars (multi-source K-lines) ====================
+
+export type BarSource = 'vendor' | 'uta'
+export type BarCapability = 'realtime' | 'iex' | 'delayed' | 'subscription' | 'free'
+
+/** A selectable K-line source for a symbol — the provider is always explicit
+ *  (TradingView-style "symbol · provider"); sources are never normalized away. */
+export interface BarSourceCandidate {
+  barId: string
+  source: BarSource
+  sourceId: string
+  symbol: string
+  assetClass: AssetClass | 'unknown'
+  label: string
+  barCapability?: BarCapability
+}
+
+/** Provenance of the bars currently shown — the explicit "who provided this". */
+export interface BarMeta {
+  symbol: string
+  from: string
+  to: string
+  bars: number
+  source: BarSource
+  sourceId: string
+  barId: string
+  provider: string
+  barCapability?: BarCapability
+}
+
+export interface BarsResponse {
+  results: HistoricalBar[] | null
+  meta: BarMeta | null
+  error?: string
+}
+
+export const barsApi = {
+  /** Federated source candidates (barIds across vendors + connected brokers). */
+  async searchSources(query: string, limit = 20): Promise<{ candidates: BarSourceCandidate[]; count: number }> {
+    const qs = new URLSearchParams({ query, limit: String(limit) })
+    return fetchJson(`/api/bars/search?${qs}`)
+  },
+
+  /** Bars for an explicit source (barId) or the vendor default (symbol+assetClass). */
+  async bars(params: {
+    barId?: string
+    symbol?: string
+    assetClass?: AssetClass
+    interval: string
+    count?: number
+    start?: string
+    end?: string
+  }): Promise<BarsResponse> {
+    const qs = new URLSearchParams({ interval: params.interval })
+    if (params.barId) qs.set('barId', params.barId)
+    if (params.symbol) qs.set('symbol', params.symbol)
+    if (params.assetClass) qs.set('assetClass', params.assetClass)
+    if (params.count != null) qs.set('count', String(params.count))
+    if (params.start) qs.set('start', params.start)
+    if (params.end) qs.set('end', params.end)
+    return fetchJson(`/api/bars?${qs}`)
+  },
+}

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -140,6 +140,7 @@ export interface BarSourceCandidate {
   source: BarSource
   sourceId: string
   symbol: string
+  name?: string
   assetClass: AssetClass | 'unknown'
   label: string
   barCapability?: BarCapability

--- a/ui/src/components/MarketSidebar.tsx
+++ b/ui/src/components/MarketSidebar.tsx
@@ -1,24 +1,29 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { marketApi, type SearchResult, type AssetClass } from '../api/market'
+import { type AssetClass, type BarSourceCandidate } from '../api/market'
+import { useAssetSearch } from './market/useAssetSearch'
 import { useWorkspace } from '../tabs/store'
 import { useWatchlist } from '../tabs/watchlist-store'
 import { getFocusedTab, type ViewSpec } from '../tabs/types'
 import { SidebarRow } from './SidebarRow'
 
-const ASSET_CLASS_COLORS: Record<AssetClass, string> = {
+const ASSET_CLASS_COLORS: Record<string, string> = {
   equity: 'bg-accent/15 text-accent',
   crypto: 'bg-amber-500/15 text-amber-400',
   currency: 'bg-green/15 text-green',
   commodity: 'bg-purple-500/15 text-purple-400',
+  unknown: 'bg-bg-tertiary text-text-muted',
 }
 
-function resultSymbol(r: SearchResult): string {
-  return r.symbol ?? r.id ?? ''
+const CAPABILITY_COLOR: Record<string, string> = {
+  realtime: 'text-green', iex: 'text-accent', delayed: 'text-text-muted/70',
+  subscription: 'text-amber-400', free: 'text-text-muted/70',
 }
 
-function resultKey(r: SearchResult): string {
-  return `${r.assetClass}:${r.symbol ?? r.id ?? Math.random()}`
+/** A crypto venue's "AAPL" is synthetic — the route segment still needs a valid
+ *  asset class, so map 'unknown' to a sane default. */
+function routeAssetClass(c: BarSourceCandidate['assetClass']): AssetClass {
+  return c === 'unknown' ? 'equity' : c
 }
 
 /**
@@ -33,8 +38,8 @@ function resultKey(r: SearchResult): string {
 export function MarketSidebar() {
   const { t } = useTranslation()
   const [query, setQuery] = useState('')
-  const [results, setResults] = useState<SearchResult[]>([])
-  const [loading, setLoading] = useState(false)
+  // Shared with the main search box — one search logic, no drift.
+  const { results, loading } = useAssetSearch(query)
 
   const watchlist = useWatchlist((s) => s.entries)
   const removeFromWatchlist = useWatchlist((s) => s.remove)
@@ -42,37 +47,16 @@ export function MarketSidebar() {
 
   const focusedSpec = useWorkspace((state) => getFocusedTab(state)?.spec)
   const isFocused = (kind: ViewSpec['kind']) => focusedSpec?.kind === kind
-  const isFocusedDetail = (assetClass: AssetClass, symbol: string) =>
+  const isFocusedDetail = (assetClass: string, symbol: string, source?: string) =>
     focusedSpec?.kind === 'market-detail' &&
     focusedSpec.params.assetClass === assetClass &&
-    focusedSpec.params.symbol === symbol
+    focusedSpec.params.symbol === symbol &&
+    (source === undefined || focusedSpec.params.source === source)
 
-  useEffect(() => {
-    const q = query.trim()
-    if (!q) {
-      setResults([])
-      setLoading(false)
-      return
-    }
-    setLoading(true)
-    const timer = setTimeout(async () => {
-      try {
-        const res = await marketApi.search(q, 20)
-        setResults(res.results)
-      } catch (err) {
-        console.error('search failed', err)
-        setResults([])
-      } finally {
-        setLoading(false)
-      }
-    }, 300)
-    return () => clearTimeout(timer)
-  }, [query])
-
-  const handleSelectResult = (r: SearchResult) => {
-    const sym = resultSymbol(r)
-    if (!sym) return
-    openOrFocus({ kind: 'market-detail', params: { assetClass: r.assetClass, symbol: sym } })
+  const handleSelectResult = (c: BarSourceCandidate) => {
+    if (!c.symbol) return
+    // Open the chart on THIS exact provider (source = barId).
+    openOrFocus({ kind: 'market-detail', params: { assetClass: routeAssetClass(c.assetClass), symbol: c.symbol, source: c.barId } })
   }
 
   return (
@@ -111,23 +95,20 @@ export function MarketSidebar() {
             {!loading && results.length === 0 && (
               <p className="px-3 py-1 text-[12px] text-text-muted/60">{t('market.noMatches')}</p>
             )}
-            {results.map((r) => {
-              const sym = resultSymbol(r)
-              return (
-                <SidebarRow
-                  key={resultKey(r)}
-                  label={
-                    <span className="flex items-center gap-1.5 truncate">
-                      <span className="font-mono font-semibold truncate">{sym}</span>
-                      {r.name && <span className="text-text-muted truncate">{r.name}</span>}
-                    </span>
-                  }
-                  active={isFocusedDetail(r.assetClass, sym)}
-                  onClick={() => handleSelectResult(r)}
-                  trail={<AssetClassChip cls={r.assetClass} />}
-                />
-              )
-            })}
+            {results.map((c) => (
+              <SidebarRow
+                key={c.barId}
+                label={
+                  <span className="flex items-center gap-1.5 min-w-0">
+                    <span className="font-mono font-semibold shrink-0">{c.symbol}</span>
+                    {c.name && <span className="text-text-muted truncate">{c.name}</span>}
+                  </span>
+                }
+                active={isFocusedDetail(routeAssetClass(c.assetClass), c.symbol, c.barId)}
+                onClick={() => handleSelectResult(c)}
+                trail={<SourceTrail c={c} />}
+              />
+            ))}
           </>
         )}
 
@@ -175,10 +156,25 @@ export function MarketSidebar() {
   )
 }
 
-function AssetClassChip({ cls }: { cls: AssetClass }) {
+function AssetClassChip({ cls }: { cls: string }) {
   return (
-    <span className={`shrink-0 text-[9px] uppercase tracking-wide px-1 rounded ${ASSET_CLASS_COLORS[cls]}`}>
+    <span className={`shrink-0 text-[9px] uppercase tracking-wide px-1 rounded ${ASSET_CLASS_COLORS[cls] ?? ASSET_CLASS_COLORS.unknown}`}>
       {cls}
+    </span>
+  )
+}
+
+/** Explicit provider + freshness + asset class for a search hit — this is how
+ *  same-symbol sources are disambiguated (TradingView-style). */
+function SourceTrail({ c }: { c: BarSourceCandidate }) {
+  // Provider is the disambiguator; keep it compact so the ticker is never
+  // crushed. (Asset class is shown in the wider main search box, not here.)
+  return (
+    <span className="flex items-center gap-1 shrink-0" title={`${c.barId}${c.barCapability ? ` · ${c.barCapability}` : ''}`}>
+      <span className="text-[10px] text-text/75 font-medium truncate max-w-[96px]">{c.sourceId}</span>
+      {c.barCapability && (
+        <span className={`text-[9px] ${CAPABILITY_COLOR[c.barCapability] ?? 'text-text-muted'}`}>{c.barCapability}</span>
+      )}
     </span>
   )
 }

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -88,7 +88,8 @@ export function KlinePanel({ selection }: Props) {
   const [meta, setMeta] = useState<BarMeta | null>(null)
   const [candidates, setCandidates] = useState<BarSourceCandidate[]>([])
   // null = vendor default for this symbol; a barId = an explicitly-picked source.
-  const [selectedBarId, setSelectedBarId] = useState<string | null>(null)
+  // Seed from the URL so the very first fetch is the right source (no vendor flicker).
+  const [selectedBarId, setSelectedBarId] = useState<string | null>(sourceParam)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -10,7 +10,7 @@ import {
   type CandlestickData,
   type HistogramData,
 } from 'lightweight-charts'
-import { marketApi, type AssetClass, type HistoricalBar } from '../../api/market'
+import { barsApi, type AssetClass, type HistoricalBar, type BarSourceCandidate, type BarMeta } from '../../api/market'
 
 type Interval = '1m' | '5m' | '1h' | '1d'
 type Timeframe = '1D' | '5D' | '1M' | '3M' | '1Y' | '5Y' | 'All'
@@ -83,7 +83,10 @@ export function KlinePanel({ selection }: Props) {
   }
 
   const [bars, setBars] = useState<HistoricalBar[] | null>(null)
-  const [provider, setProvider] = useState<string | null>(null)
+  const [meta, setMeta] = useState<BarMeta | null>(null)
+  const [candidates, setCandidates] = useState<BarSourceCandidate[]>([])
+  // null = vendor default for this symbol; a barId = an explicitly-picked source.
+  const [selectedBarId, setSelectedBarId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -142,53 +145,63 @@ export function KlinePanel({ selection }: Props) {
     chartRef.current?.timeScale().applyOptions({ timeVisible: INTRADAY.has(interval) })
   }, [interval])
 
-  // Fetch bars on any of: symbol, interval, timeframe. Re-polls periodically
-  // so a long-open tab doesn't show yesterday's bars as if they were live.
+  // Discover the available bar sources for this symbol (populates the picker).
+  // Reset the picked source whenever the symbol changes → falls back to vendor.
   useEffect(() => {
-    if (!selection) { setBars(null); setProvider(null); setError(null); return }
+    setSelectedBarId(null)
+    setCandidates([])
+    if (!selection || selection.assetClass === 'commodity') return
+    let cancelled = false
+    barsApi.searchSources(selection.symbol, 12)
+      .then((r) => { if (!cancelled) setCandidates(r.candidates) })
+      .catch(() => { if (!cancelled) setCandidates([]) })
+    return () => { cancelled = true }
+  }, [selection])
+
+  // Fetch bars: an explicitly-picked source (barId) or the vendor default
+  // (symbol+assetClass). Re-polls so a long-open tab doesn't show stale bars.
+  useEffect(() => {
+    if (!selection) { setBars(null); setMeta(null); setError(null); return }
     if (selection.assetClass === 'commodity') {
       setBars(null)
-      setProvider(null)
+      setMeta(null)
       setError('Commodity K-line support is coming in the next step.')
       return
     }
     let cancelled = false
-    const fetch = (isInitial: boolean) => {
+    const run = (isInitial: boolean) => {
       if (isInitial) setLoading(true)
       setError(null)
       const days = daysForTimeframe(tf)
-      const opts: { interval: string; startDate?: string } = { interval }
-      if (days != null) opts.startDate = startDateFromToday(days)
+      const params: Parameters<typeof barsApi.bars>[0] = { interval }
+      if (selectedBarId) params.barId = selectedBarId
+      else { params.symbol = selection.symbol; params.assetClass = selection.assetClass }
+      if (days != null) params.start = startDateFromToday(days)
 
-      marketApi.historical(selection.assetClass, selection.symbol, opts)
+      barsApi.bars(params)
         .then((res) => {
           if (cancelled) return
           if (res.error || !res.results) {
-            setError(res.error ?? 'No data returned.')
-            setBars(null)
-            setProvider(null)
+            setError(res.error ?? 'No data returned.'); setBars(null); setMeta(null)
           } else if (res.results.length === 0) {
-            setError('No bars in this range.')
-            setBars([])
-            setProvider(res.provider || null)
+            setError('No bars in this range.'); setBars([]); setMeta(res.meta)
           } else {
-            setBars(res.results)
-            setProvider(res.provider || null)
+            setBars(res.results); setMeta(res.meta)
           }
         })
         .catch((e) => {
           if (cancelled) return
-          setError(e instanceof Error ? e.message : String(e)); setBars(null); setProvider(null)
+          setError(e instanceof Error ? e.message : String(e)); setBars(null); setMeta(null)
         })
         .finally(() => { if (!cancelled && isInitial) setLoading(false) })
     }
-    fetch(true)
+    run(true)
     // 60s for intraday intervals (1m/5m/1h) because each tick is a fresh bar;
     // 5min for daily because a refresh within a single day is cosmetic.
     const pollMs = INTRADAY.has(interval) ? 60_000 : 300_000
-    const timer = setInterval(() => fetch(false), pollMs)
+    const timer = setInterval(() => run(false), pollMs)
     return () => { cancelled = true; clearInterval(timer) }
-  }, [selection, interval, tf])
+  }, [selection, selectedBarId, interval, tf])
 
   // Push bars into chart and fit.
   useEffect(() => {
@@ -222,14 +235,27 @@ export function KlinePanel({ selection }: Props) {
     return `${selection.symbol} · ${selection.assetClass}`
   }, [selection])
 
+  // Source options for the picker — always include the currently-shown provider
+  // (even if it wasn't in the search results), so the dropdown reflects reality.
+  const sourceOptions = useMemo<BarSourceCandidate[]>(() => {
+    const opts = [...candidates]
+    if (meta?.barId && !opts.some((c) => c.barId === meta.barId)) {
+      opts.unshift({ barId: meta.barId, source: meta.source, sourceId: meta.sourceId, symbol: meta.symbol, assetClass: 'unknown', label: meta.sourceId, barCapability: meta.barCapability })
+    }
+    return opts
+  }, [candidates, meta])
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between py-2 px-1 gap-3 flex-wrap">
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-[13px] font-medium text-text truncate">{title}</span>
-          {provider && (
-            <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
-              {provider}
+          {meta && (
+            <span
+              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium"
+              title={`Provider: ${meta.barId}${meta.barCapability ? ` (${meta.barCapability})` : ''}`}
+            >
+              {meta.sourceId}{meta.barCapability ? ` · ${meta.barCapability}` : ''}
             </span>
           )}
           {bars && bars.length > 0 && (
@@ -239,6 +265,23 @@ export function KlinePanel({ selection }: Props) {
           )}
         </div>
         <div className="flex items-center gap-5 flex-wrap">
+          {sourceOptions.length > 1 && (
+            <label className="flex items-center gap-2">
+              <span className="text-[11px] uppercase tracking-wide text-text-muted/70">Source</span>
+              <select
+                value={selectedBarId ?? meta?.barId ?? ''}
+                onChange={(e) => setSelectedBarId(e.target.value || null)}
+                className="bg-bg-tertiary border border-border rounded px-2 py-1 text-[12px] text-text cursor-pointer max-w-[240px]"
+                title="Which provider's K-line to show — sources are never merged; you pick"
+              >
+                {sourceOptions.map((c) => (
+                  <option key={c.barId} value={c.barId}>
+                    {c.sourceId} · {c.symbol}{c.barCapability ? ` (${c.barCapability})` : ''}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
           <label className="flex items-center gap-2">
             <span className="text-[11px] uppercase tracking-wide text-text-muted/70">Interval</span>
             <div className="flex border border-border rounded overflow-hidden" title="Candle width (how much time each bar covers)">

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -62,6 +62,8 @@ export function KlinePanel({ selection }: Props) {
   const [searchParams, setSearchParams] = useSearchParams()
   const interval = parseInterval(searchParams.get('interval'))
   const tf = parseTimeframe(searchParams.get('range'))
+  // The provider picked at search time (a barId), if any — opens the chart on it.
+  const sourceParam = searchParams.get('source')
 
   // Local setter named `selectInterval` rather than `setInterval` so it
   // doesn't shadow the global timer function we use for polling below.
@@ -146,9 +148,10 @@ export function KlinePanel({ selection }: Props) {
   }, [interval])
 
   // Discover the available bar sources for this symbol (populates the picker).
-  // Reset the picked source whenever the symbol changes → falls back to vendor.
+  // Seed the picked source from the URL (?source=barId, set at search time);
+  // otherwise null → vendor default.
   useEffect(() => {
-    setSelectedBarId(null)
+    setSelectedBarId(sourceParam)
     setCandidates([])
     if (!selection || selection.assetClass === 'commodity') return
     let cancelled = false
@@ -156,7 +159,7 @@ export function KlinePanel({ selection }: Props) {
       .then((r) => { if (!cancelled) setCandidates(r.candidates) })
       .catch(() => { if (!cancelled) setCandidates([]) })
     return () => { cancelled = true }
-  }, [selection])
+  }, [selection, sourceParam])
 
   // Fetch bars: an explicitly-picked source (barId) or the vendor default
   // (symbol+assetClass). Re-polls so a long-open tab doesn't show stale bars.

--- a/ui/src/components/market/SearchBox.tsx
+++ b/ui/src/components/market/SearchBox.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { barsApi, type BarSourceCandidate, type AssetClass } from '../../api/market'
+import { type BarSourceCandidate, type AssetClass } from '../../api/market'
+import { useAssetSearch } from './useAssetSearch'
 
 const ASSET_CLASS_COLORS: Record<string, string> = {
   equity: 'bg-accent/15 text-accent',
@@ -22,36 +23,13 @@ export function SearchBox() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const [query, setQuery] = useState('')
-  const [results, setResults] = useState<BarSourceCandidate[]>([])
-  const [loading, setLoading] = useState(false)
+  // Shared with the market sidebar — one federated search logic, no drift.
+  const { results, loading } = useAssetSearch(query)
   const [open, setOpen] = useState(false)
   const [highlight, setHighlight] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    const q = query.trim()
-    if (!q) {
-      setResults([])
-      setLoading(false)
-      return
-    }
-    setLoading(true)
-    const timer = setTimeout(async () => {
-      try {
-        // Federated source search: each result is a specific provider's K-line
-        // (vendor or a connected broker), labeled explicitly — no merging.
-        const res = await barsApi.searchSources(q, 24)
-        setResults(res.candidates)
-        setHighlight(0)
-      } catch (e) {
-        console.error('search failed', e)
-        setResults([])
-      } finally {
-        setLoading(false)
-      }
-    }, 300)
-    return () => clearTimeout(timer)
-  }, [query])
+  useEffect(() => { setHighlight(0) }, [results])
 
   useEffect(() => {
     const onClickAway = (e: MouseEvent) => {

--- a/ui/src/components/market/SearchBox.tsx
+++ b/ui/src/components/market/SearchBox.tsx
@@ -1,27 +1,28 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { marketApi, type SearchResult, type AssetClass } from '../../api/market'
+import { barsApi, type BarSourceCandidate, type AssetClass } from '../../api/market'
 
-const ASSET_CLASS_COLORS: Record<AssetClass, string> = {
+const ASSET_CLASS_COLORS: Record<string, string> = {
   equity: 'bg-accent/15 text-accent',
   crypto: 'bg-amber-500/15 text-amber-400',
   currency: 'bg-green/15 text-green',
   commodity: 'bg-purple-500/15 text-purple-400',
+  unknown: 'bg-bg-tertiary text-text-muted',
 }
 
-function resultKey(r: SearchResult): string {
-  return `${r.assetClass}:${r.symbol ?? r.id ?? Math.random()}`
-}
-
-function resultSymbol(r: SearchResult): string {
-  return r.symbol ?? r.id ?? ''
+const CAPABILITY_COLOR: Record<string, string> = {
+  realtime: 'text-green',
+  iex: 'text-accent',
+  delayed: 'text-text-muted',
+  subscription: 'text-amber-400',
+  free: 'text-text-muted',
 }
 
 export function SearchBox() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const [query, setQuery] = useState('')
-  const [results, setResults] = useState<SearchResult[]>([])
+  const [results, setResults] = useState<BarSourceCandidate[]>([])
   const [loading, setLoading] = useState(false)
   const [open, setOpen] = useState(false)
   const [highlight, setHighlight] = useState(0)
@@ -37,8 +38,10 @@ export function SearchBox() {
     setLoading(true)
     const timer = setTimeout(async () => {
       try {
-        const res = await marketApi.search(q, 20)
-        setResults(res.results)
+        // Federated source search: each result is a specific provider's K-line
+        // (vendor or a connected broker), labeled explicitly — no merging.
+        const res = await barsApi.searchSources(q, 24)
+        setResults(res.candidates)
         setHighlight(0)
       } catch (e) {
         console.error('search failed', e)
@@ -60,17 +63,18 @@ export function SearchBox() {
     return () => document.removeEventListener('mousedown', onClickAway)
   }, [])
 
-  const handleSelect = (r: SearchResult) => {
-    const sym = resultSymbol(r)
-    if (!sym) return
+  const handleSelect = (r: BarSourceCandidate) => {
+    if (!r.symbol) return
     setOpen(false)
     setQuery('')
-    // Preserve K-line interval/range across symbol switches so the user's
-    // preferred view settings carry over.
-    const qs = searchParams.toString()
+    // Carry the chosen source (barId) so the chart opens on THAT provider, and
+    // preserve interval/range across switches.
+    const next = new URLSearchParams(searchParams)
+    next.set('source', r.barId)
+    const assetClass: AssetClass = r.assetClass === 'unknown' ? 'equity' : r.assetClass
     navigate({
-      pathname: `/market/${r.assetClass}/${encodeURIComponent(sym)}`,
-      search: qs ? `?${qs}` : '',
+      pathname: `/market/${assetClass}/${encodeURIComponent(r.symbol)}`,
+      search: `?${next.toString()}`,
     })
   }
 
@@ -110,18 +114,25 @@ export function SearchBox() {
           )}
           {results.map((r, i) => (
             <button
-              key={resultKey(r)}
+              key={r.barId}
               onClick={() => handleSelect(r)}
               onMouseEnter={() => setHighlight(i)}
               className={`w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] cursor-pointer transition-colors ${
                 i === highlight ? 'bg-bg-tertiary' : ''
               }`}
             >
-              <span className="font-mono font-semibold text-text">{resultSymbol(r)}</span>
+              <span className="font-mono font-semibold text-text shrink-0">{r.symbol}</span>
               {r.name && (
-                <span className="text-text-muted truncate flex-1">— {r.name}</span>
+                <span className="text-text-muted truncate flex-1 min-w-0">— {r.name}</span>
               )}
-              <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded font-medium ${ASSET_CLASS_COLORS[r.assetClass]}`}>
+              {/* Explicit provider — this is how same-symbol sources are disambiguated. */}
+              <span className="ml-auto flex items-center gap-1 shrink-0 text-[11px] text-text-muted">
+                <span className="font-medium text-text/80">{r.sourceId}</span>
+                {r.barCapability && (
+                  <span className={CAPABILITY_COLOR[r.barCapability] ?? 'text-text-muted'}>· {r.barCapability}</span>
+                )}
+              </span>
+              <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded font-medium shrink-0 ${ASSET_CLASS_COLORS[r.assetClass] ?? ASSET_CLASS_COLORS.unknown}`}>
                 {r.assetClass}
               </span>
             </button>

--- a/ui/src/components/market/useAssetSearch.ts
+++ b/ui/src/components/market/useAssetSearch.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { barsApi, type BarSourceCandidate } from '../../api/market'
+
+/**
+ * The single source of truth for asset search — used by BOTH the market sidebar
+ * and the main search box, so their logic can't drift apart again. Debounced
+ * (300ms) federated source search: each result is a specific provider's K-line
+ * (vendor or a connected broker), with the provider always explicit — never
+ * merged. Pick a result → open the chart on exactly that source.
+ */
+export function useAssetSearch(query: string, limit = 24): { results: BarSourceCandidate[]; loading: boolean } {
+  const [results, setResults] = useState<BarSourceCandidate[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const q = query.trim()
+    if (!q) { setResults([]); setLoading(false); return }
+    setLoading(true)
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      try {
+        const res = await barsApi.searchSources(q, limit)
+        if (!cancelled) setResults(res.candidates)
+      } catch (e) {
+        console.error('asset search failed', e)
+        if (!cancelled) setResults([])
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }, 300)
+    return () => { cancelled = true; clearTimeout(timer) }
+  }, [query, limit])
+
+  return { results, loading }
+}

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -39,8 +39,8 @@ export const marketHandlers = [
     const q = (new URL(request.url).searchParams.get('query') ?? '').toUpperCase()
     if (!q.includes('AAPL') && !q.includes('APPLE')) return HttpResponse.json({ candidates: [], count: 0 })
     const candidates: BarSourceCandidate[] = [
-      { barId: 'yfinance|AAPL', source: 'vendor', sourceId: 'yfinance', symbol: 'AAPL', assetClass: 'equity', label: 'AAPL', barCapability: 'delayed' },
-      { barId: 'alpaca-paper|AAPL', source: 'uta', sourceId: 'alpaca-paper', symbol: 'AAPL', assetClass: 'equity', label: 'AAPL', barCapability: 'iex' },
+      { barId: 'yfinance|AAPL', source: 'vendor', sourceId: 'yfinance', symbol: 'AAPL', name: 'Apple Inc.', assetClass: 'equity', label: 'AAPL', barCapability: 'delayed' },
+      { barId: 'alpaca-paper|AAPL', source: 'uta', sourceId: 'alpaca-paper', symbol: 'AAPL', name: 'Apple Inc.', assetClass: 'equity', label: 'AAPL', barCapability: 'iex' },
     ]
     return HttpResponse.json({ candidates, count: candidates.length })
   }),

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -5,6 +5,7 @@ import {
   demoMarketEmpty,
   demoSectorRotation,
 } from '../fixtures/market'
+import type { BarSourceCandidate, BarMeta } from '../../api/market'
 
 const AAPL = 'AAPL'
 
@@ -31,6 +32,34 @@ export const marketHandlers = [
 
   // Sector rotation — static snapshot fixture.
   http.get('/api/market/sector-rotation', () => HttpResponse.json(demoSectorRotation)),
+
+  // ---- federated bars (multi-source K-lines) ----
+  // AAPL has two demo sources so the source picker is exercised.
+  http.get('/api/bars/search', ({ request }) => {
+    const q = (new URL(request.url).searchParams.get('query') ?? '').toUpperCase()
+    if (!q.includes('AAPL') && !q.includes('APPLE')) return HttpResponse.json({ candidates: [], count: 0 })
+    const candidates: BarSourceCandidate[] = [
+      { barId: 'yfinance|AAPL', source: 'vendor', sourceId: 'yfinance', symbol: 'AAPL', assetClass: 'equity', label: 'AAPL', barCapability: 'delayed' },
+      { barId: 'alpaca-paper|AAPL', source: 'uta', sourceId: 'alpaca-paper', symbol: 'AAPL', assetClass: 'equity', label: 'AAPL', barCapability: 'iex' },
+    ]
+    return HttpResponse.json({ candidates, count: candidates.length })
+  }),
+  http.get('/api/bars', ({ request }) => {
+    const url = new URL(request.url)
+    const barId = url.searchParams.get('barId')
+    const symbol = (url.searchParams.get('symbol') ?? '').toUpperCase()
+    if (!(barId?.includes('AAPL') || symbol === AAPL)) {
+      return HttpResponse.json({ results: null, meta: null, error: 'No demo data for this symbol.' })
+    }
+    const results = demoMarketAAPL.historical.results
+    const sourceId = barId ? barId.split('|')[0] : 'yfinance'
+    const meta: BarMeta = {
+      symbol: 'AAPL', from: results[0]?.date ?? '', to: results[results.length - 1]?.date ?? '', bars: results.length,
+      source: sourceId === 'alpaca-paper' ? 'uta' : 'vendor', sourceId, barId: barId ?? `${sourceId}|AAPL`,
+      provider: sourceId, barCapability: sourceId === 'alpaca-paper' ? 'iex' : 'delayed',
+    }
+    return HttpResponse.json({ results, meta })
+  }),
 
   // ---- equity data ----
   http.get('/api/market-data-v1/:assetClass/price/historical', ({ request, params }) => {

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Navigate, Route, Routes, useParams } from 'react-router-dom'
+import { Navigate, Route, Routes, useParams, useSearchParams } from 'react-router-dom'
 import { useWorkspace } from './store'
 import { specEquals, type ActivitySection, type ViewSpec } from './types'
 import { getView } from './registry'
@@ -114,10 +114,12 @@ function AdoptStatic({ spec }: { spec: ViewSpec }) {
 
 function AdoptMarketDetail() {
   const { assetClass, symbol } = useParams<{ assetClass: string; symbol: string }>()
+  const [search] = useSearchParams()
   const valid: ReadonlyArray<string> = ['equity', 'crypto', 'currency', 'commodity']
   if (!assetClass || !symbol || !valid.includes(assetClass)) {
     return <Navigate to="/market" replace />
   }
+  const source = search.get('source') ?? undefined
   return (
     <AdoptStatic
       spec={{
@@ -125,6 +127,7 @@ function AdoptMarketDetail() {
         params: {
           assetClass: assetClass as Extract<ViewSpec, { kind: 'market-detail' }>['params']['assetClass'],
           symbol,
+          ...(source ? { source } : {}),
         },
       }}
     />

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -105,7 +105,8 @@ const marketDetailModule: ViewModule<'market-detail'> = {
   kind: 'market-detail',
   title: (spec) => `${spec.params.symbol}`,
   toUrl: (spec) =>
-    `/market/${spec.params.assetClass}/${encodeURIComponent(spec.params.symbol)}`,
+    `/market/${spec.params.assetClass}/${encodeURIComponent(spec.params.symbol)}` +
+    (spec.params.source ? `?source=${encodeURIComponent(spec.params.source)}` : ''),
   Component: MarketDetailPage,
 }
 

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -23,7 +23,7 @@ export type ViewSpec =
   | { kind: 'news';           params: Record<string, never> }
   | { kind: 'market-list';    params: Record<string, never> }
   | { kind: 'market-rotation'; params: Record<string, never> }
-  | { kind: 'market-detail';  params: { assetClass: 'equity' | 'crypto' | 'currency' | 'commodity'; symbol: string } }
+  | { kind: 'market-detail';  params: { assetClass: 'equity' | 'crypto' | 'currency' | 'commodity'; symbol: string; source?: string } }
   | { kind: 'settings';       params: { category: 'general' | 'ai-provider' | 'trading' | 'mcp' | 'market-data' | 'news-collector' } }
   | { kind: 'uta-detail';     params: { id: string } }
   | { kind: 'dev';            params: { tab: 'tools' | 'snapshots' | 'logs' | 'simulator' } }


### PR DESCRIPTION
## Summary

Wire the federated bar layer into the **market page** (Phase 3) and make the asset search source-aware — disambiguation by EXPLICIT provider, never an internal rule (the barId / quant-calculator philosophy, now in the UI).

- **Chart source picker** — `/api/bars` + `/api/bars/search` routes through `ctx.barService`; KlinePanel gains a TradingView-style Source dropdown + a provider badge (`sourceId · realtime/iex/delayed`). Volume already rendered; lightweight-charts is TradingView's own engine.
- **Source-aware search, unified** — there were two market search boxes (sidebar + main) with copy-pasted-then-diverged logic; extracted one shared `useAssetSearch` hook so they can't drift again. Both now show the explicit provider per result; the ticker never truncates. Clicking a result opens the chart on that exact source (threaded through the tab system: market-detail spec gains `source`, `toUrl` emits `?source`, KlinePanel seeds from it).
- **Asset class is venue-decided** — a crypto exchange's contracts are crypto, full stop (a listed "AAPL" is a synthetic/custodial token; a CCXT dated future is a crypto future, not a commodity). `IBroker.assetClassFor` (CcxtBroker → 'crypto') flows onto `ContractSearchHit`; the federated candidate uses it over the secType heuristic. Fixes search results tagged both "commodity" and "crypto" from one crypto venue.

## Test plan
- [x] Alice `tsc --noEmit` clean
- [x] `cd ui && tsc -b` clean
- [x] `services/uta` typecheck — 0 errors
- [x] `pnpm test` — 1729 passing
- [x] **Live Playwright walk (demo):** "aapl" → two labeled sources (yfinance·delayed, alpaca-paper·iex); clicking alpaca opens `/market/equity/AAPL?source=alpaca-paper|AAPL` with the ALPACA-PAPER·IEX badge + candles + volume.

## Boundary touch
Touches `uta-protocol` (`IBroker.assetClassFor`, `ContractSearchHit.assetClass`), CcxtBroker, and contract-search (venue asset class). No broker credentials change; read-only path. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
