### PR TITLE
fix(workspaces): auto-trust project MCP servers in claude adapter spawns

### DIFF
--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -29,6 +29,27 @@ afterEach(async () => {
 const read = (rel: string): Promise<string> => readFile(join(dir, rel), 'utf8');
 
 describe('claudeAdapter AI-config', () => {
+  // Project-scoped `.mcp.json` servers park at "Pending approval" until the
+  // user approves — and each workspace dir is a fresh project key, so every
+  // spawn carries the auto-trust setting (see AUTOTRUST_SETTINGS in claude.ts).
+  const SETTINGS_FLAG = ['--settings', '{"enableAllProjectMcpServers":true}'];
+
+  it('composeCommand: fresh spawn injects the MCP auto-trust settings', () => {
+    expect(claudeAdapter.composeCommand(['claude'], { cwd: dir, env: {} })).toEqual([
+      'claude', ...SETTINGS_FLAG,
+    ]);
+  });
+
+  it('composeCommand: by-id resume keeps the settings flag before --resume', () => {
+    expect(claudeAdapter.composeCommand(['claude'], { cwd: dir, env: {}, resume: { sessionId: 'abc-123' } }))
+      .toEqual(['claude', ...SETTINGS_FLAG, '--resume', 'abc-123']);
+  });
+
+  it('composeCommand: "last" resume throws (intentionally unsupported)', () => {
+    expect(() => claudeAdapter.composeCommand(['claude'], { cwd: dir, env: {}, resume: 'last' }))
+      .toThrow(/"last" resume not supported/);
+  });
+
   it('writes full x-api-key config byte-exact', async () => {
     await claudeAdapter.writeAiConfig!(dir, {
       baseUrl: 'https://api.test/v1', apiKey: 'sk-123', model: 'claude-x', authMode: 'x-api-key',
@@ -275,6 +296,8 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
   it('claude: -p --output-format json -- <prompt> (prompt after -- terminator, never --bare)', () => {
     expect(claudeAdapter.composeHeadlessCommand!(['claude'], ctx(), 'do x')).toEqual([
       'claude',
+      '--settings',
+      '{"enableAllProjectMcpServers":true}',
       '-p',
       '--output-format',
       'json',

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -9,6 +9,20 @@ const SESSION_FILE_RE = /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a
 
 const CLAUDE_SETTINGS_PATH = '.claude/settings.local.json';
 
+/**
+ * Claude Code parks project-scoped `.mcp.json` servers at "⏸ Pending
+ * approval" (the trust gate for VCS-shared MCP config) until the user
+ * approves them — and every workspace dir is a fresh project key, so an
+ * interactive session would re-prompt on every new workspace. Inject the
+ * auto-trust setting at spawn instead of writing it into
+ * `.claude/settings.local.json`, whose lifecycle `writeAiConfig` owns (the
+ * file is deleted wholesale on AI-config reset). Headless `-p` connects to
+ * project servers without approval today (verified on 2.1.170), but gets the
+ * same flag so automation doesn't silently lose MCP if a future version
+ * closes that gap.
+ */
+const AUTOTRUST_SETTINGS = '{"enableAllProjectMcpServers":true}';
+
 /** dashed-cwd convention used by Claude Code's project store. */
 function projectKey(workspaceDir: string): string {
   const abs = resolve(workspaceDir);
@@ -48,13 +62,14 @@ export const claudeAdapter: CliAdapter = {
   },
 
   composeCommand(base: readonly string[], ctx: SpawnContext): readonly string[] {
-    if (ctx.resume === undefined) return base;
+    const cmd = [...base, '--settings', AUTOTRUST_SETTINGS];
+    if (ctx.resume === undefined) return cmd;
     if (ctx.resume === 'last') {
       throw new Error(
         'claude adapter: "last" resume not supported — use --resume <sessionId> or undefined (fresh)',
       );
     }
-    return [...base, '--resume', ctx.resume.sessionId];
+    return [...cmd, '--resume', ctx.resume.sessionId];
   },
 
   // Headless: `claude -p` is non-interactive and exits at the turn boundary.
@@ -64,7 +79,7 @@ export const claudeAdapter: CliAdapter = {
   // end-of-options terminator, so a prompt that starts with `-`/`--` isn't
   // mis-parsed as a flag (verified: without `--`, claude errors out).
   composeHeadlessCommand(base: readonly string[], _ctx: SpawnContext, prompt: string): readonly string[] {
-    return [...base, '-p', '--output-format', 'json', '--', prompt];
+    return [...base, '--settings', AUTOTRUST_SETTINGS, '-p', '--output-format', 'json', '--', prompt];
   },
 
   async writeAiConfig(cwd: string, cred: WorkspaceAiCred): Promise<void> {


### PR DESCRIPTION
## Summary
- Claude Code gates project-scoped `.mcp.json` servers behind "⏸ Pending approval", and every workspace dir is a fresh project key — interactive claude workspaces prompted for manual MCP approval on every new workspace.
- Inject `--settings '{"enableAllProjectMcpServers":true}'` in the claude adapter's `composeCommand` + `composeHeadlessCommand` so OpenAlice's MCP servers connect at spawn.
- Headless was never broken: verified on 2.1.170 that a fresh, never-approved dir running `claude -p` connects to the project `.mcp.json` server and sees the full `mcp__openalice__*` surface. The flag on the headless path is cheap insurance in case a future CLI version closes that gap.
- CLI-flag injection rather than writing `.claude/settings.local.json` — that file's lifecycle belongs to `writeAiConfig` (deleted wholesale on AI-config reset).

Issue surfaced by external PR #244 (not merged per main-repo policy; root cause independently reproduced and fixed in-house).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/workspaces` — 107/107 pass (new composeCommand specs + updated headless golden)
- [x] Live repro on claude 2.1.170 against a running backend: fresh dir without flag → `⏸ Pending approval`; with flag → `✔ Connected`
- [x] Live headless control: `claude -p` in a fresh unapproved dir lists the full `mcp__openalice__*` toolset (automation path unaffected before and after)

## Boundary touch
None — workspace launcher adapter only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)