### PR TITLE
feat(guardian): configurable ports via data/config/ports.json + env

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -21,6 +21,7 @@
 
 import { app, BrowserWindow } from 'electron'
 import { spawn, type ChildProcess } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { probeFreePort } from './probe-port.js'
@@ -34,6 +35,69 @@ let appQuitting = false
 const DEFAULT_WEB_PORT_START = 47331
 const READY_TIMEOUT_MS = 30_000
 const SIGTERM_GRACE_MS = 5_000
+
+// ── Port configuration ──────────────────────────────────────
+// Inline mirror of scripts/guardian/shared.ts (the desktop package is a
+// separate release surface — same reason probe-port.ts is duplicated).
+// Keep semantics in sync: env > data/config/ports.json > default; broken
+// or in-use explicit config fails loud.
+
+function parsePort(raw: unknown, origin: string): number {
+  const n = typeof raw === 'number' ? raw : Number(raw)
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(`[guardian] invalid port ${JSON.stringify(raw)} from ${origin} — expected an integer in 1..65535`)
+  }
+  return n
+}
+
+async function readPortsFile(userDataHome: string): Promise<Partial<Record<'web' | 'mcp' | 'uta', number>>> {
+  const filePath = resolve(userDataHome, 'data', 'config', 'ports.json')
+  let raw: string
+  try {
+    raw = await readFile(filePath, 'utf8')
+  } catch {
+    return {}
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`[guardian] ${filePath} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`[guardian] ${filePath} must be a JSON object like {"web":47331,"mcp":47332,"uta":47333}`)
+  }
+  const out: Partial<Record<'web' | 'mcp' | 'uta', number>> = {}
+  for (const name of ['web', 'mcp', 'uta'] as const) {
+    const v = (parsed as Record<string, unknown>)[name]
+    if (v !== undefined) out[name] = parsePort(v, `${filePath} ("${name}")`)
+  }
+  return out
+}
+
+/** Explicit (env/file) port → assert free or throw; unset → probe upward. */
+async function claimPort(
+  name: string,
+  envKey: string,
+  fileValue: number | undefined,
+  probeStart: number,
+): Promise<number> {
+  const envRaw = process.env[envKey]
+  const explicit =
+    envRaw !== undefined && envRaw !== ''
+      ? { value: parsePort(envRaw, envKey), origin: envKey }
+      : fileValue !== undefined
+        ? { value: fileValue, origin: 'data/config/ports.json' }
+        : null
+  if (explicit === null) return probeFreePort(probeStart)
+  try {
+    return await probeFreePort(explicit.value, explicit.value)
+  } catch {
+    throw new Error(
+      `[guardian] port ${explicit.value} (${name}, from ${explicit.origin}) is already in use — free it or configure another port`,
+    )
+  }
+}
 
 async function waitForBackendReady(port: number, timeoutMs = READY_TIMEOUT_MS): Promise<void> {
   const deadline = Date.now() + timeoutMs
@@ -51,9 +115,6 @@ async function waitForBackendReady(port: number, timeoutMs = READY_TIMEOUT_MS): 
 }
 
 app.whenReady().then(async () => {
-  const webPort = await probeFreePort(DEFAULT_WEB_PORT_START)
-  const mcpPort = await probeFreePort(webPort + 1)
-
   // Build output lives at <repo>/dist/electron/main.js and <repo>/dist/main.js
   // (sibling directories at <repo>/dist/). The desktop package source is at
   // apps/desktop/src/ but tsconfig.outDir is ../../dist/electron, so this
@@ -79,6 +140,15 @@ app.whenReady().then(async () => {
         OPENALICE_APP_HOME: repoRoot,
       }
 
+  // Port precedence: env (OPENALICE_*_PORT) > data/config/ports.json (under
+  // the user-data home, same L1 file the dev/prod guardians read) > probe
+  // from the default. Explicitly configured ports fail loud when taken —
+  // the user pinned them; silently drifting would break their bookmarks /
+  // firewall rules. Unconfigured ports keep the probe-upward behavior.
+  const portsFile = await readPortsFile(homeEnv.OPENALICE_HOME)
+  const webPort = await claimPort('web', 'OPENALICE_WEB_PORT', portsFile.web, DEFAULT_WEB_PORT_START)
+  const mcpPort = await claimPort('mcp', 'OPENALICE_MCP_PORT', portsFile.mcp, webPort + 1)
+
   backend = spawn(process.execPath, [backendEntry], {
     env: {
       ...process.env,
@@ -90,6 +160,14 @@ app.whenReady().then(async () => {
       ELECTRON_RUN_AS_NODE: '1',
       OPENALICE_WEB_PORT: String(webPort),
       OPENALICE_MCP_PORT: String(mcpPort),
+      // The desktop shell doesn't spawn UTA yet (Alice expects a Guardian
+      // to provide OPENALICE_UTA_URL — known gap in the Electron topology).
+      // Forward a ports.json uta value anyway so the L1 file behaves
+      // uniformly once that wiring lands; explicit env still wins via the
+      // ...process.env spread above.
+      ...(portsFile.uta !== undefined && !process.env['OPENALICE_UTA_PORT']
+        ? { OPENALICE_UTA_PORT: String(portsFile.uta) }
+        : {}),
       // Hint for the backend (future use): we're under Electron, not a
       // bare `node dist/main.js`. Today nothing reads this; future
       // graceful-shutdown / update-flow code can branch on it.

--- a/scripts/guardian/dev.ts
+++ b/scripts/guardian/dev.ts
@@ -17,7 +17,9 @@
 import { resolve } from 'node:path'
 import type { ChildProcess } from 'node:child_process'
 import {
-  probePorts,
+  readPortsFile,
+  resolvePortConfig,
+  planPorts,
   spawnChild,
   waitForHttp,
   installCascadeShutdown,
@@ -27,8 +29,9 @@ import {
 } from './shared.js'
 
 async function main(): Promise<void> {
-  const ports = await probePorts()
   const dataHome = process.cwd()
+  // env (OPENALICE_*_PORT) > data/config/ports.json > default+probe.
+  const ports = await planPorts(resolvePortConfig(process.env, await readPortsFile(dataHome)))
   const flagPath = resolve(dataHome, 'data/control/restart-uta.flag')
 
   console.log('')

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -23,14 +23,57 @@
  */
 
 import { spawn } from 'node:child_process'
-import { mkdir, watch } from 'node:fs/promises'
+import { mkdir, readFile, watch } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
 
-const WEB_PORT = Number(process.env.OPENALICE_WEB_PORT ?? 47331)
-const MCP_PORT = Number(process.env.OPENALICE_MCP_PORT ?? 47332)
-const UTA_PORT = Number(process.env.OPENALICE_UTA_PORT ?? 47333)
 const DATA_HOME = process.env.OPENALICE_USER_DATA_HOME ?? '/data'
+
+// Port precedence: env (OPENALICE_*_PORT) > data/config/ports.json > default.
+// Mirrors scripts/guardian/shared.ts (kept inline — the runtime image ships
+// no TS tooling). Broken explicit config fails loud rather than silently
+// falling back; an in-use port fails at bind, also loud.
+function parsePort(raw, origin) {
+  const n = typeof raw === 'number' ? raw : Number(raw)
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(`[guardian/prod] invalid port ${JSON.stringify(raw)} from ${origin} — expected an integer in 1..65535`)
+  }
+  return n
+}
+
+async function readPortsFile(userDataHome) {
+  const filePath = resolve(userDataHome, 'data', 'config', 'ports.json')
+  let raw
+  try {
+    raw = await readFile(filePath, 'utf8')
+  } catch {
+    return {}
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`[guardian/prod] ${filePath} is not valid JSON: ${err?.message ?? err}`)
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`[guardian/prod] ${filePath} must be a JSON object like {"web":47331,"mcp":47332,"uta":47333}`)
+  }
+  const out = {}
+  for (const name of ['web', 'mcp', 'uta']) {
+    if (parsed[name] !== undefined) out[name] = parsePort(parsed[name], `${filePath} ("${name}")`)
+  }
+  return out
+}
+
+const portsFile = await readPortsFile(DATA_HOME)
+const pickPort = (envKey, fileValue, fallback) => {
+  const envRaw = process.env[envKey]
+  if (envRaw !== undefined && envRaw !== '') return parsePort(envRaw, envKey)
+  return fileValue ?? fallback
+}
+const WEB_PORT = pickPort('OPENALICE_WEB_PORT', portsFile.web, 47331)
+const MCP_PORT = pickPort('OPENALICE_MCP_PORT', portsFile.mcp, 47332)
+const UTA_PORT = pickPort('OPENALICE_UTA_PORT', portsFile.uta, 47333)
 const FLAG_PATH = resolve(DATA_HOME, 'data/control/restart-uta.flag')
 const UTA_URL = `http://127.0.0.1:${UTA_PORT}`
 

--- a/scripts/guardian/shared.spec.ts
+++ b/scripts/guardian/shared.spec.ts
@@ -1,0 +1,83 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { readPortsFile, resolvePortConfig } from './shared.js'
+
+let home: string
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), 'guardian-ports-'))
+})
+afterEach(async () => {
+  await rm(home, { recursive: true, force: true })
+})
+
+async function writePortsFile(content: string): Promise<void> {
+  await mkdir(join(home, 'data', 'config'), { recursive: true })
+  await writeFile(join(home, 'data', 'config', 'ports.json'), content)
+}
+
+describe('readPortsFile', () => {
+  it('missing file → empty config (defaults apply downstream)', async () => {
+    expect(await readPortsFile(home)).toEqual({})
+  })
+
+  it('reads partial config — only the keys present', async () => {
+    await writePortsFile('{ "web": 12345 }')
+    expect(await readPortsFile(home)).toEqual({ web: 12345 })
+  })
+
+  it('reads all three ports', async () => {
+    await writePortsFile('{ "web": 18331, "mcp": 18332, "uta": 18333 }')
+    expect(await readPortsFile(home)).toEqual({ web: 18331, mcp: 18332, uta: 18333 })
+  })
+
+  it('fails loud on broken JSON instead of silently defaulting', async () => {
+    await writePortsFile('{ web: oops')
+    await expect(readPortsFile(home)).rejects.toThrow(/not valid JSON/)
+  })
+
+  it('fails loud on a non-object payload', async () => {
+    await writePortsFile('[47331]')
+    await expect(readPortsFile(home)).rejects.toThrow(/must be a JSON object/)
+  })
+
+  it('fails loud on a non-integer / out-of-range port value', async () => {
+    await writePortsFile('{ "web": "47331x" }')
+    await expect(readPortsFile(home)).rejects.toThrow(/invalid port/)
+    await writePortsFile('{ "mcp": 70000 }')
+    await expect(readPortsFile(home)).rejects.toThrow(/invalid port/)
+  })
+})
+
+describe('resolvePortConfig', () => {
+  it('defaults when neither env nor file provide a value', () => {
+    expect(resolvePortConfig({}, {})).toEqual({
+      web: { value: 47331, source: 'default' },
+      mcp: { value: 47332, source: 'default' },
+      uta: { value: 47333, source: 'default' },
+    })
+  })
+
+  it('file beats default; env beats file', () => {
+    const cfg = resolvePortConfig(
+      { OPENALICE_WEB_PORT: '15000' },
+      { web: 12345, mcp: 12346 },
+    )
+    expect(cfg.web).toEqual({ value: 15000, source: 'env' })
+    expect(cfg.mcp).toEqual({ value: 12346, source: 'file' })
+    expect(cfg.uta).toEqual({ value: 47333, source: 'default' })
+  })
+
+  it('empty-string env var is treated as unset', () => {
+    const cfg = resolvePortConfig({ OPENALICE_WEB_PORT: '' }, { web: 12345 })
+    expect(cfg.web).toEqual({ value: 12345, source: 'file' })
+  })
+
+  it('fails loud on a malformed env value', () => {
+    expect(() => resolvePortConfig({ OPENALICE_MCP_PORT: 'banana' }, {})).toThrow(/invalid port/)
+  })
+})

--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -20,8 +20,8 @@
 
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process'
 import { setTimeout as sleep } from 'node:timers/promises'
-import { watch, mkdir } from 'node:fs/promises'
-import { dirname, basename } from 'node:path'
+import { watch, mkdir, readFile } from 'node:fs/promises'
+import { dirname, basename, resolve } from 'node:path'
 import { probeFreePort } from '../probe-port.js'
 
 export interface GuardianPorts {
@@ -30,16 +30,117 @@ export interface GuardianPorts {
   utaPort: number
 }
 
-/** Probe all three ports starting from defaults. Returns triple. */
-export async function probePorts(opts: {
-  webStart?: number
-  utaStart?: number
-} = {}): Promise<GuardianPorts> {
-  const webStart = opts.webStart ?? 47331
-  const utaStart = opts.utaStart ?? 47333
-  const webPort = await probeFreePort(webStart)
-  const mcpPort = await probeFreePort(webPort + 1)
-  const utaPort = await probeFreePort(Math.max(utaStart, mcpPort + 1))
+// ── Port configuration (L1 → L2) ────────────────────────────
+//
+// Ports are spawn-time-fixed: Guardian (L2) resolves them once and injects
+// them into the children via env (see memory:port-architecture-3-layers).
+// User-facing configuration lives in L1 — `data/config/ports.json`:
+//
+//   { "web": 47331, "mcp": 47332, "uta": 47333 }   (all keys optional)
+//
+// Deliberately a data/config file and NOT a dotenv file: the data dir is the
+// one location every topology agrees on (dev repo, docker volume, Electron
+// userData), and OpenAlice does not want an env file that invites API keys —
+// those belong in the credential vault UI.
+//
+// Precedence per port: explicit env (OPENALICE_*_PORT) > ports.json > default.
+// An EXPLICITLY configured port that is already taken fails loud — silently
+// drifting off a value the user pinned would be worse than aborting. Only
+// unconfigured ports keep the probe-upward-from-default behavior.
+
+const PORT_DEFAULTS = { web: 47331, mcp: 47332, uta: 47333 } as const
+
+export type PortName = keyof typeof PORT_DEFAULTS
+
+export interface PortChoice {
+  value: number
+  /** Where the value came from — only 'default' ports may drift via probing. */
+  source: 'env' | 'file' | 'default'
+}
+
+export type PortConfig = Record<PortName, PortChoice>
+
+const ENV_KEYS: Record<PortName, string> = {
+  web: 'OPENALICE_WEB_PORT',
+  mcp: 'OPENALICE_MCP_PORT',
+  uta: 'OPENALICE_UTA_PORT',
+}
+
+function parsePort(raw: unknown, origin: string): number {
+  const n = typeof raw === 'number' ? raw : Number(raw)
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(`[guardian] invalid port ${JSON.stringify(raw)} from ${origin} — expected an integer in 1..65535`)
+  }
+  return n
+}
+
+/**
+ * Read `data/config/ports.json` under `userDataHome`. Missing file → {}.
+ * Present-but-broken (bad JSON / non-integer values) fails loud — a typo in
+ * explicit config should abort the boot, not silently fall back to defaults.
+ */
+export async function readPortsFile(userDataHome: string): Promise<Partial<Record<PortName, number>>> {
+  const filePath = resolve(userDataHome, 'data', 'config', 'ports.json')
+  let raw: string
+  try {
+    raw = await readFile(filePath, 'utf8')
+  } catch {
+    return {}
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`[guardian] ${filePath} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`[guardian] ${filePath} must be a JSON object like {"web":47331,"mcp":47332,"uta":47333}`)
+  }
+  const out: Partial<Record<PortName, number>> = {}
+  for (const name of Object.keys(PORT_DEFAULTS) as PortName[]) {
+    const v = (parsed as Record<string, unknown>)[name]
+    if (v !== undefined) out[name] = parsePort(v, `${filePath} ("${name}")`)
+  }
+  return out
+}
+
+/** Resolve each port's value + source: env > ports.json > default. */
+export function resolvePortConfig(
+  env: NodeJS.ProcessEnv,
+  file: Partial<Record<PortName, number>>,
+): PortConfig {
+  const pick = (name: PortName): PortChoice => {
+    const envRaw = env[ENV_KEYS[name]]
+    if (envRaw !== undefined && envRaw !== '') {
+      return { value: parsePort(envRaw, ENV_KEYS[name]), source: 'env' }
+    }
+    const fromFile = file[name]
+    if (fromFile !== undefined) return { value: fromFile, source: 'file' }
+    return { value: PORT_DEFAULTS[name], source: 'default' }
+  }
+  return { web: pick('web'), mcp: pick('mcp'), uta: pick('uta') }
+}
+
+/**
+ * Turn a resolved PortConfig into bindable ports. Explicit (env/file) ports
+ * assert-free and fail loud when taken; default ports probe upward (web from
+ * 47331, mcp from web+1, uta from max(47333, mcp+1)) — the historical
+ * collision-dodging behavior.
+ */
+export async function planPorts(cfg: PortConfig): Promise<GuardianPorts> {
+  const claim = async (name: PortName, choice: PortChoice, probeStart: number): Promise<number> => {
+    if (choice.source === 'default') return probeFreePort(probeStart)
+    try {
+      return await probeFreePort(choice.value, choice.value)
+    } catch {
+      throw new Error(
+        `[guardian] port ${choice.value} (${name}, from ${choice.source === 'env' ? ENV_KEYS[name] : 'data/config/ports.json'}) is already in use — free it or configure another port`,
+      )
+    }
+  }
+  const webPort = await claim('web', cfg.web, PORT_DEFAULTS.web)
+  const mcpPort = await claim('mcp', cfg.mcp, webPort + 1)
+  const utaPort = await claim('uta', cfg.uta, Math.max(PORT_DEFAULTS.uta, mcpPort + 1))
   return { webPort, mcpPort, utaPort }
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
         test: {
           name: 'node',
           environment: 'node',
-          include: ['src/**/*.spec.*', 'packages/**/*.spec.*', 'services/**/*.spec.*', 'apps/**/*.spec.*'],
+          include: ['src/**/*.spec.*', 'packages/**/*.spec.*', 'services/**/*.spec.*', 'apps/**/*.spec.*', 'scripts/**/*.spec.*'],
           exclude: ['**/*.e2e.spec.*', '**/*.bbProvider.spec.*', '**/node_modules/**'],
         },
       },


### PR DESCRIPTION
## Summary
- User-facing port config lands in **L1**: `data/config/ports.json` (`{"web":…,"mcp":…,"uta":…}`, all keys optional), read by all three L2 launchers — dev guardian, prod guardian, Electron shell — before spawn.
- Precedence per port: env (`OPENALICE_WEB_PORT` / `OPENALICE_MCP_PORT` / `OPENALICE_UTA_PORT`, now honored by dev + Electron too; previously prod-only) > `ports.json` > default.
- **Explicitly configured ports fail loud when taken** (with source attribution in the error); only unconfigured ports keep the probe-upward collision dodging. Broken `ports.json` (bad JSON / non-integer) also fails loud instead of silently defaulting.
- Deliberately a `data/config` file, not a dotenv file: the data dir is the one location every topology agrees on (dev repo, docker volume, Electron userData), and we don't want an env file that invites API keys — those belong in the credential vault UI.
- Port changes apply on restart (spawn-time-fixed env channel). `scripts/**` specs now run under vitest's node project.

Requested in #282.

## Test plan
- [x] New `scripts/guardian/shared.spec.ts` — 10 tests (file parsing tolerance/loudness, env>file>default precedence, empty-string env treated as unset)
- [x] Full suite: 1746 tests pass; root `tsc --noEmit` clean; `pnpm -F @traderalice/desktop typecheck` clean
- [x] Live verification: explicit busy port (env and file sources) → loud abort with attribution; free file port `{"web":18331}` → mcp probes 18332, uta stays 47333; no config → 47331/47332/47333

## Boundary touch
None — launcher/port plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)