### PR TITLE
fix(ports): wildcard-aware port probe + bind MCP to loopback by default

### DIFF
--- a/apps/desktop/src/probe-port.ts
+++ b/apps/desktop/src/probe-port.ts
@@ -19,7 +19,21 @@ export async function probeFreePort(start: number, end: number = start + 100): P
   throw new Error(`probeFreePort: no free port in range ${start}..${end}`)
 }
 
-function isPortFree(port: number): Promise<boolean> {
+/**
+ * A port only counts as free when BOTH the v4 wildcard (0.0.0.0) and the
+ * loopback (127.0.0.1) bind succeed. One bind is not enough on macOS/BSD:
+ * SO_REUSEADDR (node's default) lets a specific-address bind succeed while
+ * a wildcard listener holds the port — and vice versa — so probing only
+ * 127.0.0.1 reported ports held by wildcard listeners (e.g. a default
+ * `serve({ port })` with no hostname) as free. Empirical matrix (macOS,
+ * node 22): holder default/`::`/0.0.0.0/127.0.0.1 × probe 127.0.0.1 OR
+ * 0.0.0.0 each miss one mode; the conjunction catches all four.
+ */
+async function isPortFree(port: number): Promise<boolean> {
+  return (await bindable(port, '0.0.0.0')) && (await bindable(port, '127.0.0.1'))
+}
+
+function bindable(port: number, host: string): Promise<boolean> {
   return new Promise((res) => {
     const srv = createServer()
     let settled = false
@@ -31,6 +45,6 @@ function isPortFree(port: number): Promise<boolean> {
     }
     srv.once('error', () => done(false))
     srv.once('listening', () => done(true))
-    srv.listen(port, '127.0.0.1')
+    srv.listen(port, host)
   })
 }

--- a/scripts/probe-port.spec.ts
+++ b/scripts/probe-port.spec.ts
@@ -1,0 +1,59 @@
+import { createServer, type Server } from 'node:net'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { probeFreePort } from './probe-port.js'
+
+// High, unlikely-to-collide base; each test offsets to stay independent.
+const BASE = 28460
+
+let held: Server[] = []
+
+function hold(port: number, host?: string): Promise<Server> {
+  return new Promise((res, rej) => {
+    const srv = createServer()
+    srv.once('error', rej)
+    srv.once('listening', () => {
+      held.push(srv)
+      res(srv)
+    })
+    if (host === undefined) srv.listen(port) // node default — wildcard, dual-stack
+    else srv.listen(port, host)
+  })
+}
+
+afterEach(async () => {
+  await Promise.all(held.map((s) => new Promise((r) => s.close(r))))
+  held = []
+})
+
+describe('probeFreePort', () => {
+  it('returns the start port when it is genuinely free', async () => {
+    expect(await probeFreePort(BASE)).toBe(BASE)
+  })
+
+  it('skips a port held on the loopback address', async () => {
+    await hold(BASE + 10, '127.0.0.1')
+    expect(await probeFreePort(BASE + 10)).toBe(BASE + 11)
+  })
+
+  it('skips a port held by a default (wildcard) listener — the MCP-shaped regression', async () => {
+    // This is how `serve({ port })` with no hostname listens. On macOS/BSD a
+    // 127.0.0.1-only probe reports this port as free (SO_REUSEADDR lets the
+    // specific bind coexist), which handed instance B a port instance A was
+    // actively serving on.
+    await hold(BASE + 20)
+    expect(await probeFreePort(BASE + 20)).toBe(BASE + 21)
+  })
+
+  it('skips a port held on the v4 wildcard 0.0.0.0', async () => {
+    await hold(BASE + 30, '0.0.0.0')
+    expect(await probeFreePort(BASE + 30)).toBe(BASE + 31)
+  })
+
+  it('fails loud when the whole window is held', async () => {
+    await hold(BASE + 40, '127.0.0.1')
+    await hold(BASE + 41, '127.0.0.1')
+    await expect(probeFreePort(BASE + 40, BASE + 41)).rejects.toThrow(/no free port/)
+  })
+})

--- a/scripts/probe-port.ts
+++ b/scripts/probe-port.ts
@@ -22,7 +22,21 @@ export async function probeFreePort(start: number, end: number = start + 100): P
   throw new Error(`probeFreePort: no free port in range ${start}..${end}`)
 }
 
-function isPortFree(port: number): Promise<boolean> {
+/**
+ * A port only counts as free when BOTH the v4 wildcard (0.0.0.0) and the
+ * loopback (127.0.0.1) bind succeed. One bind is not enough on macOS/BSD:
+ * SO_REUSEADDR (node's default) lets a specific-address bind succeed while
+ * a wildcard listener holds the port — and vice versa — so probing only
+ * 127.0.0.1 reported ports held by wildcard listeners (e.g. a default
+ * `serve({ port })` with no hostname) as free. Empirical matrix (macOS,
+ * node 22): holder default/`::`/0.0.0.0/127.0.0.1 × probe 127.0.0.1 OR
+ * 0.0.0.0 each miss one mode; the conjunction catches all four.
+ */
+async function isPortFree(port: number): Promise<boolean> {
+  return (await bindable(port, '0.0.0.0')) && (await bindable(port, '127.0.0.1'))
+}
+
+function bindable(port: number, host: string): Promise<boolean> {
   return new Promise((res) => {
     const srv = createServer()
     let settled = false
@@ -34,6 +48,6 @@ function isPortFree(port: number): Promise<boolean> {
     }
     srv.once('error', () => done(false))
     srv.once('listening', () => done(true))
-    srv.listen(port, '127.0.0.1')
+    srv.listen(port, host)
   })
 }

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -137,8 +137,15 @@ export class McpPlugin implements Plugin {
       getWorkspaceService,
     })
 
-    this.server = serve({ fetch: app.fetch, port: this.port }, (info) => {
-      console.log(`mcp plugin listening on http://localhost:${info.port}/mcp (+ /mcp/:wsId)`)
+    // Without an explicit hostname @hono/node-server listens on the wildcard
+    // address (all interfaces) — which exposed the FULL tool surface,
+    // trading included and auth-free, to the LAN. Default to loopback like
+    // the web plugin; OPENALICE_BIND_HOST is the explicit opt-out (Docker
+    // sets 0.0.0.0, where the container boundary is the gate — only the web
+    // port is published). Workspace CLIs always reach MCP via 127.0.0.1.
+    const bindHost = (process.env['OPENALICE_BIND_HOST'] ?? '127.0.0.1').trim()
+    this.server = serve({ fetch: app.fetch, port: this.port, hostname: bindHost }, (info) => {
+      console.log(`mcp plugin listening on http://${bindHost}:${info.port}/mcp (+ /mcp/:wsId)`)
     })
   }
 


### PR DESCRIPTION
## Summary
- **MCP server no longer listens on all interfaces.** `serve({ port })` without a hostname binds the wildcard address, which exposed the full MCP tool surface (trading included, no auth) to the LAN — while the web plugin carefully defaults to loopback with a public-bind safety gate. MCP now defaults to `127.0.0.1` and honors `OPENALICE_BIND_HOST` (Docker sets `0.0.0.0`; only the web port is published there).
- **Port probe is now wildcard-aware.** `isPortFree` bound only `127.0.0.1`; on macOS/BSD, SO_REUSEADDR lets a specific bind succeed while a wildcard listener holds the port, so wildcard-held ports (exactly how MCP listened) read as free. Reproduced live: with instance A on 47331–47333, the probe handed instance B `webPort=47332` — A's MCP port. A port now counts as free only when **both** `0.0.0.0` and `127.0.0.1` bind succeed (4×4 holder/probe matrix in the code comment). Both `probe-port.ts` copies updated in sync.
- New `scripts/probe-port.spec.ts` regression suite (5 tests), including the wildcard-holder case.

## Test plan
- [x] `npx vitest run scripts` — 15/15 (10 port-config + 5 new probe)
- [x] Full suite 100 files / 1751 tests pass; root `tsc --noEmit` + desktop typecheck clean
- [x] Live before/after: old probe gave second instance `47332` while held; fixed probe gives `47334/47335/47336`
- [x] Live MCP bind: `lsof` shows `*:47332` (wildcard) → `127.0.0.1:47332` after the fix

## Boundary touch
**Yes — security exposure**: MCP (which carries trading tools, auth-free) was LAN-reachable on every dev/desktop machine by default. This PR closes the default exposure. The deeper question — MCP has no auth at all even when `OPENALICE_BIND_HOST=0.0.0.0` is set deliberately (web gates on admin token; MCP doesn't) — is filed separately in Linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)