### PR TITLE
fix(mcp): lock MCP/CLI listener to loopback, never honor BIND_HOST

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -28,11 +28,19 @@ import { registerCliRoutes } from './cli.js'
  *                           bootstrap.sh bakes the per-workspace URL into
  *                           the workspace's own .mcp.json.
  *
- *   GET  /cli/:wsId/:export/manifest   Same open posture, same identity-by-URL
- *   POST /cli/:wsId/:export/invoke     trick — the gateway for the workspace-local
- *                              `alice*` CLIs (`:export` = data | workspace; see
- *                              ./cli.ts). Reuses this server's open port so the
- *                              shim needs no token.
+ *   GET  /cli/:wsId/:export/manifest   Same identity-by-URL trick — the gateway
+ *   POST /cli/:wsId/:export/invoke     for the workspace-local `alice*` CLIs
+ *                              (`:export` = data | workspace; see ./cli.ts).
+ *                              Reuses this server's port so the shim needs no
+ *                              token.
+ *
+ * SECURITY POSTURE: this whole listener is UNAUTHENTICATED and binds
+ * 127.0.0.1 only (see the serve() call). The tool surface includes trading;
+ * its protection is the loopback boundary — every consumer (agent CLIs, the
+ * `alice*` shims) is a local workspace subprocess. There is no auth layer
+ * because there is intentionally no remote caller; the wsId in the path is
+ * routing, not a secret. Remote/multi-user access belongs to the web port,
+ * which gates on the admin token. Do NOT make this honor OPENALICE_BIND_HOST.
  *
  * Holds references to both registries and the WorkspaceService (for wsId
  * registry lookup). Tools are rebuilt per-request so disable/enable +
@@ -137,15 +145,22 @@ export class McpPlugin implements Plugin {
       getWorkspaceService,
     })
 
-    // Without an explicit hostname @hono/node-server listens on the wildcard
-    // address (all interfaces) — which exposed the FULL tool surface,
-    // trading included and auth-free, to the LAN. Default to loopback like
-    // the web plugin; OPENALICE_BIND_HOST is the explicit opt-out (Docker
-    // sets 0.0.0.0, where the container boundary is the gate — only the web
-    // port is published). Workspace CLIs always reach MCP via 127.0.0.1.
-    const bindHost = (process.env['OPENALICE_BIND_HOST'] ?? '127.0.0.1').trim()
-    this.server = serve({ fetch: app.fetch, port: this.port, hostname: bindHost }, (info) => {
-      console.log(`mcp plugin listening on http://${bindHost}:${info.port}/mcp (+ /mcp/:wsId)`)
+    // LOOPBACK-ONLY, ALWAYS — deliberately NOT honoring OPENALICE_BIND_HOST.
+    // This listener carries the full tool surface (trading included) and the
+    // CLI gateway with NO authentication: its security model is "only local
+    // processes can reach it". Its sole consumers are workspace subprocesses
+    // (native agent CLIs + the `alice*` shims), which run on the same host
+    // and always dial 127.0.0.1 — so there is no legitimate remote caller to
+    // serve. Remote access is the web port's job (47331), which gates on the
+    // admin token. Without an explicit hostname @hono/node-server binds the
+    // wildcard address, which exposed this surface to the LAN; pinning
+    // loopback closes that structurally rather than via an auth layer the
+    // zero-config CLI injection can't carry. In Docker, OPENALICE_BIND_HOST
+    // =0.0.0.0 still applies to the web plugin; MCP stays on container-local
+    // loopback and is reached by in-container workspaces — only 47331 is
+    // published, so nothing external could reach MCP regardless.
+    this.server = serve({ fetch: app.fetch, port: this.port, hostname: '127.0.0.1' }, (info) => {
+      console.log(`mcp plugin listening on http://127.0.0.1:${info.port}/mcp (+ /mcp/:wsId, /cli)`)
     })
   }
 


### PR DESCRIPTION
## Summary
Follow-up to #307. That PR made the MCP/CLI listener *default* to loopback but still let `OPENALICE_BIND_HOST` push it onto the wildcard address. This removes that option entirely for MCP.

**Why no opt-out is correct here:** the MCP/CLI listener is unauthenticated and carries the full tool surface (trading included). Its only consumers are local workspace subprocesses — the native agent CLIs and the `alice*` shims — which always dial `127.0.0.1`. There is no legitimate remote caller to serve; remote / multi-user access is the web port's job (47331), which gates on the admin token. So the listener binds `127.0.0.1` unconditionally and the security posture is documented in place: protection is the loopback boundary, not an auth layer (zero-config CLI injection can't carry a token; the `wsId` in the path is routing, not a secret).

In Docker, `BIND_HOST=0.0.0.0` still applies to the web plugin; MCP stays container-local loopback and only 47331 is published, so nothing external reaches it regardless.

Closes ANG-97.

## Test plan
- [x] `npx tsc --noEmit` clean; full suite 100 files / 1751 tests pass
- [x] Grep confirms `OPENALICE_BIND_HOST` is now read only by the web plugin (the authenticated remote surface)
- [x] Live (hot-reloaded dev instance): MCP listener on `127.0.0.1:47332`

## Boundary touch
**Yes — security.** Closes the last path by which the unauthenticated, trading-capable MCP/CLI surface could be bound to a public interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)