### PR TITLE
FMP revival fixes: insider aliases + sector weight units

### DIFF
--- a/packages/opentypebb/src/providers/fmp/models/etf-sectors.ts
+++ b/packages/opentypebb/src/providers/fmp/models/etf-sectors.ts
@@ -39,6 +39,13 @@ export class FMPEtfSectorsFetcher extends Fetcher {
   ): FMPEtfSectorsData[] {
     const results = data.map((d) => {
       const aliased = applyAliases(d, ALIAS_DICT)
+      // Normalize percent → decimal (99.69 → 0.9969): the package-wide
+      // weight convention (FMP holdings already does this), and what the
+      // yfinance fallback returns — consumers must never see different
+      // units depending on which provider served.
+      if (typeof aliased.weight === 'number') {
+        aliased.weight = aliased.weight / 100
+      }
       return FMPEtfSectorsDataSchema.parse(aliased)
     })
     // Sort by weight descending

--- a/packages/opentypebb/src/providers/fmp/models/insider-trading.ts
+++ b/packages/opentypebb/src/providers/fmp/models/insider-trading.ts
@@ -21,6 +21,9 @@ export type FMPInsiderTradingQueryParams = z.infer<typeof FMPInsiderTradingQuery
 
 // --- Data ---
 
+// Field names per the FMP *stable* insider-trading response (the old
+// dict carried legacy-v4 names — 'cik', and upstream's typo'd
+// 'acquistionOrDisposition' — which left dates/types null).
 const ALIAS_DICT: Record<string, string> = {
   owner_cik: 'reportingCik',
   owner_name: 'reportingName',
@@ -28,9 +31,12 @@ const ALIAS_DICT: Record<string, string> = {
   ownership_type: 'directOrIndirect',
   security_type: 'securityName',
   transaction_price: 'price',
-  acquisition_or_disposition: 'acquistionOrDisposition',
+  transaction_type: 'transactionType',
+  transaction_date: 'transactionDate',
+  filing_date: 'filingDate',
+  acquisition_or_disposition: 'acquisitionOrDisposition',
   filing_url: 'link',
-  company_cik: 'cik',
+  company_cik: 'companyCik',
 }
 
 export const FMPInsiderTradingDataSchema = InsiderTradingDataSchema.extend({


### PR DESCRIPTION
## Summary
- FMP account revived — live-tested every FMP-preferred surface. Calendar board fully back (256 earnings / 23 IPOs / 1123 ex-dividends), ratios + insider + ETF sectors now served by FMP; ETF holdings is tier-restricted (402) on the current plan and the yfinance fallback covers it automatically.
- Two latent bugs only live cross-provider testing could expose:
  - **Insider-trading aliases** still used legacy-v4 field names (including upstream's typo'd `acquistionOrDisposition`) and never mapped `transactionDate`/`filingDate`/`transactionType` — FMP rows came back with null dates/types. Aligned to the stable endpoint.
  - **Sector-weight units differed by provider**: FMP returned percent points (99.69) where the yfinance fallback returns decimals (0.99). Normalized FMP to the package-wide decimal convention — consumers must never see provider-dependent units.

## Test plan
- [x] `npx tsc --noEmit` clean; `pnpm test` 1787 tests green
- [x] Live verification against FMP stable endpoints (calendar/ratios/insider/sectors) and the 402 fallback path

## Boundary touch
None — market-data provider layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)