### PR TITLE
Hub integration: zero-key OOTB — boards, FRED/EIA/BLS, calendars

### DIFF
--- a/packages/opentypebb/src/core/provider/utils/hub-proxy.ts
+++ b/packages/opentypebb/src/core/provider/utils/hub-proxy.ts
@@ -1,0 +1,31 @@
+/**
+ * Hub-proxy credential sentinel.
+ *
+ * A credential value of the form `hub:<baseUrl>` means "no user key —
+ * route this provider's requests through the TraderHub keyed proxy at
+ * <baseUrl> instead". The hub injects its own key upstream; the fetcher
+ * keeps building paths/params/transforms exactly as for the real origin,
+ * so response shapes cannot drift.
+ *
+ * Only origin-centralized providers participate (fred / eia / bls).
+ */
+
+export interface KeyedOrigin {
+  /** Real user key, or '' when routing via hub (hub injects its own). */
+  key: string
+  /** Origin to build request URLs against. */
+  origin: string
+}
+
+export function resolveKeyedOrigin(
+  rawKey: string | undefined | null,
+  realOrigin: string,
+  providerSegment: string,
+): KeyedOrigin {
+  const value = (rawKey ?? '').trim()
+  if (value.startsWith('hub:')) {
+    const hub = value.slice('hub:'.length).replace(/\/+$/, '')
+    return { key: '', origin: `${hub}/api/proxy/${providerSegment}` }
+  }
+  return { key: value, origin: realOrigin }
+}

--- a/packages/opentypebb/src/providers/bls/models/bls-series.ts
+++ b/packages/opentypebb/src/providers/bls/models/bls-series.ts
@@ -8,11 +8,12 @@ import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { BlsSeriesQueryParamsSchema, BlsSeriesDataSchema } from '../../../standard-models/bls-series.js'
 import { EmptyDataError } from '../../../core/provider/utils/errors.js'
 import { amakeRequest } from '../../../core/provider/utils/helpers.js'
+import { resolveKeyedOrigin } from '../../../core/provider/utils/hub-proxy.js'
 
 export const BLSBlsSeriesQueryParamsSchema = BlsSeriesQueryParamsSchema
 export type BLSBlsSeriesQueryParams = z.infer<typeof BLSBlsSeriesQueryParamsSchema>
 
-const BLS_API_URL = 'https://api.bls.gov/publicAPI/v2/timeseries/data/'
+const BLS_TIMESERIES_PATH = '/publicAPI/v2/timeseries/data/'
 
 interface BlsApiResponse {
   status: string
@@ -41,7 +42,8 @@ export class BLSBlsSeriesFetcher extends Fetcher {
     credentials: Record<string, string> | null,
   ): Promise<Record<string, unknown>[]> {
     const seriesIds = query.symbol.split(',').map(s => s.trim()).filter(Boolean)
-    const apiKey = credentials?.bls_api_key ?? ''
+    const { key: apiKey, origin } = resolveKeyedOrigin(
+      credentials?.bls_api_key, 'https://api.bls.gov', 'bls')
 
     const startYear = query.start_date ? query.start_date.slice(0, 4) : String(new Date().getFullYear() - 10)
     const endYear = query.end_date ? query.end_date.slice(0, 4) : String(new Date().getFullYear())
@@ -53,7 +55,7 @@ export class BLSBlsSeriesFetcher extends Fetcher {
     }
     if (apiKey) body.registrationkey = apiKey
 
-    const data = await amakeRequest<BlsApiResponse>(BLS_API_URL, {
+    const data = await amakeRequest<BlsApiResponse>(`${origin}${BLS_TIMESERIES_PATH}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/packages/opentypebb/src/providers/eia/models/petroleum-status-report.ts
+++ b/packages/opentypebb/src/providers/eia/models/petroleum-status-report.ts
@@ -9,11 +9,12 @@ import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { PetroleumStatusReportQueryParamsSchema, PetroleumStatusReportDataSchema } from '../../../standard-models/petroleum-status-report.js'
 import { EmptyDataError } from '../../../core/provider/utils/errors.js'
 import { amakeRequest } from '../../../core/provider/utils/helpers.js'
+import { resolveKeyedOrigin } from '../../../core/provider/utils/hub-proxy.js'
 
 export const EIAPetroleumStatusReportQueryParamsSchema = PetroleumStatusReportQueryParamsSchema
 export type EIAPetroleumStatusReportQueryParams = z.infer<typeof EIAPetroleumStatusReportQueryParamsSchema>
 
-const EIA_API_URL = 'https://api.eia.gov/v2/petroleum/sum/sndw/data/'
+const EIA_PETROLEUM_PATH = '/v2/petroleum/sum/sndw/data'
 
 // Map categories to EIA series IDs
 const CATEGORY_SERIES: Record<string, { series: string; unit: string }> = {
@@ -46,7 +47,8 @@ export class EIAPetroleumStatusReportFetcher extends Fetcher {
     query: EIAPetroleumStatusReportQueryParams,
     credentials: Record<string, string> | null,
   ): Promise<Record<string, unknown>[]> {
-    const apiKey = credentials?.eia_api_key ?? credentials?.api_key ?? ''
+    const { key: apiKey, origin } = resolveKeyedOrigin(
+      credentials?.eia_api_key ?? credentials?.api_key, 'https://api.eia.gov', 'eia')
     const catInfo = CATEGORY_SERIES[query.category]
     if (!catInfo) throw new EmptyDataError(`Unknown category: ${query.category}`)
 
@@ -54,7 +56,6 @@ export class EIAPetroleumStatusReportFetcher extends Fetcher {
     // see https://www.eia.gov/opendata/documentation.php. The JSON form
     // is silently rejected with HTTP 403 on most endpoints.
     const params = new URLSearchParams({
-      api_key: apiKey,
       frequency: 'weekly',
       'data[0]': 'value',
       'facets[series][]': catInfo.series,
@@ -65,8 +66,9 @@ export class EIAPetroleumStatusReportFetcher extends Fetcher {
 
     if (query.start_date) params.set('start', query.start_date)
     if (query.end_date) params.set('end', query.end_date)
+    if (apiKey) params.set('api_key', apiKey)
 
-    const url = `${EIA_API_URL}?${params.toString()}`
+    const url = `${origin}${EIA_PETROLEUM_PATH}?${params.toString()}`
     const data = await amakeRequest<EiaResponse>(url)
 
     const results: Record<string, unknown>[] = []

--- a/packages/opentypebb/src/providers/eia/models/short-term-energy-outlook.ts
+++ b/packages/opentypebb/src/providers/eia/models/short-term-energy-outlook.ts
@@ -8,11 +8,12 @@ import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { ShortTermEnergyOutlookQueryParamsSchema, ShortTermEnergyOutlookDataSchema } from '../../../standard-models/short-term-energy-outlook.js'
 import { EmptyDataError } from '../../../core/provider/utils/errors.js'
 import { amakeRequest } from '../../../core/provider/utils/helpers.js'
+import { resolveKeyedOrigin } from '../../../core/provider/utils/hub-proxy.js'
 
 export const EIAShortTermEnergyOutlookQueryParamsSchema = ShortTermEnergyOutlookQueryParamsSchema
 export type EIAShortTermEnergyOutlookQueryParams = z.infer<typeof EIAShortTermEnergyOutlookQueryParamsSchema>
 
-const EIA_STEO_URL = 'https://api.eia.gov/v2/steo/data/'
+const EIA_STEO_PATH = '/v2/steo/data'
 
 // Map categories to EIA STEO series
 const CATEGORY_SERIES: Record<string, { series: string; unit: string }> = {
@@ -45,7 +46,8 @@ export class EIAShortTermEnergyOutlookFetcher extends Fetcher {
     query: EIAShortTermEnergyOutlookQueryParams,
     credentials: Record<string, string> | null,
   ): Promise<Record<string, unknown>[]> {
-    const apiKey = credentials?.eia_api_key ?? credentials?.api_key ?? ''
+    const { key: apiKey, origin } = resolveKeyedOrigin(
+      credentials?.eia_api_key ?? credentials?.api_key, 'https://api.eia.gov', 'eia')
     const catInfo = CATEGORY_SERIES[query.category]
     if (!catInfo) throw new EmptyDataError(`Unknown STEO category: ${query.category}`)
 
@@ -53,7 +55,6 @@ export class EIAShortTermEnergyOutlookFetcher extends Fetcher {
     // see https://www.eia.gov/opendata/documentation.php. The JSON form
     // is silently rejected with HTTP 403 on most endpoints.
     const params = new URLSearchParams({
-      api_key: apiKey,
       frequency: 'monthly',
       'data[0]': 'value',
       'facets[seriesId][]': catInfo.series,
@@ -64,8 +65,9 @@ export class EIAShortTermEnergyOutlookFetcher extends Fetcher {
 
     if (query.start_date) params.set('start', query.start_date.slice(0, 7)) // YYYY-MM
     if (query.end_date) params.set('end', query.end_date.slice(0, 7))
+    if (apiKey) params.set('api_key', apiKey)
 
-    const url = `${EIA_STEO_URL}?${params.toString()}`
+    const url = `${origin}${EIA_STEO_PATH}?${params.toString()}`
     const data = await amakeRequest<EiaSteoResponse>(url)
 
     // Determine current date to flag forecasts

--- a/packages/opentypebb/src/providers/federal_reserve/utils/fred-helpers.ts
+++ b/packages/opentypebb/src/providers/federal_reserve/utils/fred-helpers.ts
@@ -7,6 +7,7 @@
 
 import { amakeRequest } from '../../../core/provider/utils/helpers.js'
 import { EmptyDataError } from '../../../core/provider/utils/errors.js'
+import { resolveKeyedOrigin } from '../../../core/provider/utils/hub-proxy.js'
 
 const FRED_BASE = 'https://api.stlouisfed.org/fred'
 const GEOFRED_BASE = 'https://api.stlouisfed.org/geofred'
@@ -38,9 +39,13 @@ function buildFredUrl(
   apiKey: string,
   base: string = FRED_BASE,
 ): string {
-  const url = new URL(`${base}/${endpoint}`)
+  // `hub:<url>` sentinel → route via the TraderHub keyed proxy (it
+  // injects its own key); path layout under the origin is identical.
+  const { key, origin } = resolveKeyedOrigin(apiKey, 'https://api.stlouisfed.org', 'fred')
+  const tree = base === GEOFRED_BASE ? 'geofred' : 'fred'
+  const url = new URL(`${origin}/${tree}/${endpoint}`)
   url.searchParams.set('file_type', 'json')
-  if (apiKey) url.searchParams.set('api_key', apiKey)
+  if (key) url.searchParams.set('api_key', key)
   for (const [k, v] of Object.entries(params)) {
     if (v !== undefined && v !== null && v !== '') {
       url.searchParams.set(k, String(v))

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -258,6 +258,13 @@ const marketDataSchema = z.object({
     biztoc: z.string().optional(),
   }).default({}),
   backend: z.enum(['typebb-sdk', 'openbb-api']).default('typebb-sdk'),
+  /** Hosted reference-data hub (TraderHub). Enabled by default: anonymous
+   *  GETs of public boards, no user data attached; one switch to opt out.
+   *  Self-hosters point baseUrl at their own instance. */
+  hub: z.object({
+    enabled: z.boolean().default(true),
+    baseUrl: z.string().default('https://traderhub.openalice.ai'),
+  }).default({ enabled: true, baseUrl: 'https://traderhub.openalice.ai' }),
 })
 
 const compactionSchema = z.object({

--- a/src/domain/market-data/__tests__/credential-map.spec.ts
+++ b/src/domain/market-data/__tests__/credential-map.spec.ts
@@ -71,3 +71,30 @@ describe('two-table contract — divergence is intentional', () => {
     expect(buildSDKCredentials({ fred: 'k' })).toEqual({ federal_reserve_api_key: 'k' })
   })
 })
+
+describe('buildSDKCredentials hub sentinel', () => {
+  const hub = { enabled: true, baseUrl: 'https://hub.test' }
+
+  it('fills missing fred/eia/bls with the hub sentinel', () => {
+    const creds = buildSDKCredentials({}, hub)
+    expect(creds.federal_reserve_api_key).toBe('hub:https://hub.test')
+    expect(creds.eia_api_key).toBe('hub:https://hub.test')
+    expect(creds.bls_api_key).toBe('hub:https://hub.test')
+  })
+
+  it('user keys always win over the hub', () => {
+    const creds = buildSDKCredentials({ fred: 'real-key' }, hub)
+    expect(creds.federal_reserve_api_key).toBe('real-key')
+    expect(creds.eia_api_key).toBe('hub:https://hub.test')
+  })
+
+  it('injects nothing when the hub is disabled or absent', () => {
+    expect(buildSDKCredentials({}, { enabled: false, baseUrl: 'x' })).toEqual({})
+    expect(buildSDKCredentials({})).toEqual({})
+  })
+
+  it('never touches non-hub providers (fmp has no proxy)', () => {
+    const creds = buildSDKCredentials({}, hub)
+    expect(creds.fmp_api_key).toBeUndefined()
+  })
+})

--- a/src/domain/market-data/__tests__/hub-data.spec.ts
+++ b/src/domain/market-data/__tests__/hub-data.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withHubCalendars } from '../hub-data.js'
+import type { EquityClientLike } from '../client/types.js'
+
+const HUB = { enabled: true, baseUrl: 'https://hub.test' }
+
+function fakeClient(rows: unknown[]): EquityClientLike {
+  return {
+    getCalendarEarnings: vi.fn(async () => rows),
+    getCalendarIpo: vi.fn(async () => rows),
+    getCalendarDividend: vi.fn(async () => rows),
+    getGainers: vi.fn(async () => [{ symbol: 'LOCAL' }]),
+  } as unknown as EquityClientLike
+}
+
+describe('withHubCalendars', () => {
+  const fetchSpy = vi.fn()
+  beforeEach(() => {
+    vi.useFakeTimers()
+    fetchSpy.mockReset()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  const params = { provider: 'fmp', start_date: '2026-06-11', end_date: '2026-06-25' }
+
+  it('serves calendar rows from the hub dataset endpoint', async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify([{ symbol: 'HUB' }])))
+    const local = fakeClient([{ symbol: 'LOCAL' }])
+    const wrapped = withHubCalendars(local, HUB)
+    const rows = await wrapped.getCalendarEarnings(params)
+    expect(rows).toEqual([{ symbol: 'HUB' }])
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://hub.test/api/data/earnings-calendar?from=2026-06-11&to=2026-06-25')
+    expect(local.getCalendarEarnings).not.toHaveBeenCalled()
+  })
+
+  it('bypasses the hub for params it does not understand', async () => {
+    const local = fakeClient([{ symbol: 'LOCAL' }])
+    const wrapped = withHubCalendars(local, HUB)
+    const rows = await wrapped.getCalendarDividend({ ...params, symbol: 'AAPL' })
+    expect(rows).toEqual([{ symbol: 'LOCAL' }])
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to local on hub failure and opens the breaker', async () => {
+    fetchSpy.mockResolvedValue(new Response('down', { status: 502 }))
+    const local = fakeClient([{ symbol: 'LOCAL' }])
+    const wrapped = withHubCalendars(local, HUB)
+    expect(await wrapped.getCalendarIpo(params)).toEqual([{ symbol: 'LOCAL' }])
+    expect(await wrapped.getCalendarIpo(params)).toEqual([{ symbol: 'LOCAL' }])
+    expect(fetchSpy).toHaveBeenCalledTimes(1) // breaker open on the second call
+  })
+
+  it('leaves non-calendar methods untouched (bound to the real client)', async () => {
+    const local = fakeClient([])
+    const wrapped = withHubCalendars(local, HUB)
+    expect(await wrapped.getGainers()).toEqual([{ symbol: 'LOCAL' }])
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when the hub is disabled', () => {
+    const local = fakeClient([])
+    expect(withHubCalendars(local, { enabled: false, baseUrl: 'x' })).toBe(local)
+    expect(withHubCalendars(local, undefined)).toBe(local)
+  })
+})

--- a/src/domain/market-data/credential-map.ts
+++ b/src/domain/market-data/credential-map.ts
@@ -79,6 +79,17 @@ export function buildCredentialsHeader(
  */
 export function buildSDKCredentials(
   providerKeys: Record<string, string | undefined> | undefined,
+  hub?: { enabled: boolean; baseUrl: string },
 ): Record<string, string> {
-  return applyMapping(providerKeys, sdkKeyMapping)
+  const mapped = applyMapping(providerKeys, sdkKeyMapping)
+  // Hub-proxy sentinel: for origin-centralized keyed providers, a missing
+  // user key becomes `hub:<baseUrl>` — the SDK fetcher swaps the upstream
+  // origin for the TraderHub keyed proxy (which injects its own key) and
+  // keeps its own transforms. User keys always win over the hub.
+  if (hub?.enabled && hub.baseUrl) {
+    for (const field of ['federal_reserve_api_key', 'eia_api_key', 'bls_api_key']) {
+      if (!mapped[field]) mapped[field] = `hub:${hub.baseUrl}`
+    }
+  }
+  return mapped
 }

--- a/src/domain/market-data/hub-data.ts
+++ b/src/domain/market-data/hub-data.ts
@@ -1,0 +1,69 @@
+/**
+ * Hub-first wrappers at the client-method seam.
+ *
+ * Client methods ARE the endpoint catalog: wrapping here means tools, the
+ * CLI, and the reference boards all inherit hub coverage with zero changes.
+ *
+ * v1 covers the FMP calendars (parameterized windows; the boards only
+ * cache the default window). FRED/EIA/BLS ride the credential sentinel
+ * instead (see credential-map.ts) — their fetchers swap origins, which
+ * covers every method of those families at once.
+ */
+
+import type { EquityClientLike } from './client/types.js'
+import type { HubConfig } from './reference/hub.js'
+
+const CALENDAR_DATASETS: Record<string, string> = {
+  getCalendarEarnings: 'earnings-calendar',
+  getCalendarIpo: 'ipos-calendar',
+  getCalendarDividend: 'dividends-calendar',
+}
+
+/** Params the hub dataset understands — anything else bypasses the hub. */
+const KNOWN_PARAMS = new Set(['provider', 'start_date', 'end_date'])
+
+const TIMEOUT_MS = 5_000
+const BREAKER_MS = 60_000
+
+export function withHubCalendars(client: EquityClientLike, hub: HubConfig | undefined): EquityClientLike {
+  if (!hub?.enabled || !hub.baseUrl) return client
+  const base = hub.baseUrl.replace(/\/+$/, '')
+  let downUntil = 0
+
+  const wrap = (method: keyof EquityClientLike, dataset: string) =>
+    async (params?: Record<string, unknown>): Promise<unknown[]> => {
+      const local = () => (client[method] as (p?: Record<string, unknown>) => Promise<unknown[]>)(params)
+      const p = params ?? {}
+      const from = p.start_date
+      const to = p.end_date
+      const hasUnknownParams = Object.keys(p).some((k) => !KNOWN_PARAMS.has(k))
+      if (hasUnknownParams || typeof from !== 'string' || typeof to !== 'string' || Date.now() < downUntil) {
+        return local()
+      }
+      try {
+        const res = await fetch(`${base}/api/data/${dataset}?from=${from}&to=${to}`, {
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+          headers: { Accept: 'application/json' },
+        })
+        if (!res.ok) throw new Error(`hub returned ${res.status}`)
+        const rows: unknown = await res.json()
+        if (!Array.isArray(rows)) throw new Error('hub returned a non-array shape')
+        return rows
+      } catch {
+        downUntil = Date.now() + BREAKER_MS
+        return local()
+      }
+    }
+
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'string' && prop in CALENDAR_DATASETS) {
+        return wrap(prop as keyof EquityClientLike, CALENDAR_DATASETS[prop])
+      }
+      // Bind to the target, not the proxy — class internals (private
+      // fields) must see their real `this`.
+      const value = Reflect.get(target, prop, target)
+      return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value
+    },
+  })
+}

--- a/src/domain/market-data/reference/hub.spec.ts
+++ b/src/domain/market-data/reference/hub.spec.ts
@@ -39,17 +39,29 @@ describe('createHubFetcher', () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('falls to null on HTTP errors and opens the breaker', async () => {
+  it('HTTP errors fall to null WITHOUT tripping the breaker (board-specific failure)', async () => {
     fetchSpy.mockResolvedValue(new Response('nope', { status: 502 }))
     const viaHub = createHubFetcher({ enabled: true, baseUrl: 'https://hub.test' }, { breakerMs: 60_000 })
     expect(await viaHub<Board>('macro')).toBeNull()
-    // Breaker open: no second fetch inside the window.
     expect(await viaHub<Board>('macro')).toBeNull()
+    // Reachable hub answering 502 = retried every call, no backoff.
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('transport failures trip a PER-BOARD breaker — siblings keep fetching', async () => {
+    fetchSpy.mockRejectedValue(new TypeError('network down'))
+    const viaHub = createHubFetcher({ enabled: true, baseUrl: 'https://hub.test' }, { breakerMs: 60_000 })
+    expect(await viaHub<Board>('global-macro')).toBeNull()
+    // Same board: breaker open, no second fetch.
+    expect(await viaHub<Board>('global-macro')).toBeNull()
     expect(fetchSpy).toHaveBeenCalledTimes(1)
-    // Breaker closes after the window.
+    // Different board: NOT gated by the sibling's breaker.
+    // (Fresh Response per call — a body is single-read.)
+    fetchSpy.mockImplementation(() => Promise.resolve(new Response(JSON.stringify(board(3)))))
+    expect((await viaHub<Board>('macro'))?.value).toBe(3)
+    // Original board recovers after the window.
     vi.advanceTimersByTime(61_000)
-    fetchSpy.mockResolvedValue(new Response(JSON.stringify(board(2))))
-    expect((await viaHub<Board>('macro'))?.value).toBe(2)
+    expect((await viaHub<Board>('global-macro'))?.value).toBe(3)
   })
 
   it('rejects non-contract shapes (data boundary: shape-checked, never trusted)', async () => {

--- a/src/domain/market-data/reference/hub.spec.ts
+++ b/src/domain/market-data/reference/hub.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createHubFetcher, markLocal } from './hub.js'
+import type { ReferenceMeta } from './types.js'
+
+type Board = { value: number; meta: ReferenceMeta }
+const board = (value: number): Board => ({ value, meta: { provider: 'fred', asOf: '2026-06-11T00:00:00Z' } })
+
+describe('createHubFetcher', () => {
+  const fetchSpy = vi.fn()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    fetchSpy.mockReset()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('serves hub payloads stamped origin=hub', async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(board(1))))
+    const viaHub = createHubFetcher({ enabled: true, baseUrl: 'https://hub.test' })
+    const result = await viaHub<Board>('macro')
+    expect(result?.value).toBe(1)
+    expect(result?.meta.origin).toBe('hub')
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://hub.test/api/reference/macro')
+  })
+
+  it('returns null when disabled — and never fetches', async () => {
+    const viaHub = createHubFetcher({ enabled: false, baseUrl: 'https://hub.test' })
+    expect(await viaHub<Board>('macro')).toBeNull()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns null on undefined config (local-only deps)', async () => {
+    const viaHub = createHubFetcher(undefined)
+    expect(await viaHub<Board>('macro')).toBeNull()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls to null on HTTP errors and opens the breaker', async () => {
+    fetchSpy.mockResolvedValue(new Response('nope', { status: 502 }))
+    const viaHub = createHubFetcher({ enabled: true, baseUrl: 'https://hub.test' }, { breakerMs: 60_000 })
+    expect(await viaHub<Board>('macro')).toBeNull()
+    // Breaker open: no second fetch inside the window.
+    expect(await viaHub<Board>('macro')).toBeNull()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    // Breaker closes after the window.
+    vi.advanceTimersByTime(61_000)
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(board(2))))
+    expect((await viaHub<Board>('macro'))?.value).toBe(2)
+  })
+
+  it('rejects non-contract shapes (data boundary: shape-checked, never trusted)', async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ rows: [] })))
+    const viaHub = createHubFetcher({ enabled: true, baseUrl: 'https://hub.test' })
+    expect(await viaHub<Board>('macro')).toBeNull()
+  })
+})
+
+describe('markLocal', () => {
+  it('stamps origin=local without touching the rest of meta', () => {
+    const stamped = markLocal(board(7))
+    expect(stamped.meta).toMatchObject({ provider: 'fred', origin: 'local' })
+    expect(stamped.value).toBe(7)
+  })
+})

--- a/src/domain/market-data/reference/hub.ts
+++ b/src/domain/market-data/reference/hub.ts
@@ -1,0 +1,67 @@
+/**
+ * TraderHub client — the hosted-boards seam.
+ *
+ * The hub (https://traderhub.openalice.ai, self-hostable via baseUrl) serves
+ * the same reference contract this module builds locally, but with its own
+ * upstream keys and caching. Resolution order per board:
+ *
+ *   hub (enabled + reachable) → local build (user's own keys) → loud error
+ *
+ * The hub is a convenience layer, never a correctness dependency: with it
+ * disabled or down, behavior is exactly the pre-hub behavior. meta.origin
+ * says which path served — loud, never silent.
+ *
+ * Security boundary: hub responses are DATA only. Shape-checked, never
+ * interpreted as configuration or instructions.
+ */
+
+import type { ReferenceMeta } from './types.js'
+
+export interface HubConfig {
+  enabled: boolean
+  baseUrl: string
+}
+
+/** Official hosted hub. Overridable via marketData.hub.baseUrl. */
+export const DEFAULT_HUB_URL = 'https://traderhub.openalice.ai'
+
+const TIMEOUT_MS = 5_000
+/** After a failure, skip the hub for this long — one timeout is annoying,
+ *  paying it on every board load is a tax. */
+const BREAKER_MS = 60_000
+
+export type HubFetcher = <T extends { meta: ReferenceMeta }>(board: string) => Promise<T | null>
+
+/** Returns null when the hub is disabled, open-circuited, unreachable, or
+ *  returns a non-contract shape — the caller falls through to local. */
+export function createHubFetcher(cfg: HubConfig | undefined, opts?: { timeoutMs?: number; breakerMs?: number }): HubFetcher {
+  const timeoutMs = opts?.timeoutMs ?? TIMEOUT_MS
+  const breakerMs = opts?.breakerMs ?? BREAKER_MS
+  let downUntil = 0
+
+  return async function hubBoard<T extends { meta: ReferenceMeta }>(board: string): Promise<T | null> {
+    if (!cfg?.enabled || !cfg.baseUrl) return null
+    if (Date.now() < downUntil) return null
+    try {
+      const res = await fetch(`${cfg.baseUrl.replace(/\/$/, '')}/api/reference/${board}`, {
+        signal: AbortSignal.timeout(timeoutMs),
+        headers: { Accept: 'application/json' },
+      })
+      if (!res.ok) throw new Error(`hub returned ${res.status}`)
+      const data: unknown = await res.json()
+      if (!data || typeof data !== 'object' || !('meta' in data)) {
+        throw new Error('hub returned a non-contract shape')
+      }
+      const payload = data as T
+      return { ...payload, meta: { ...payload.meta, origin: 'hub' as const } }
+    } catch {
+      downUntil = Date.now() + breakerMs
+      return null
+    }
+  }
+}
+
+/** Stamp a locally-built board so the origin is always explicit. */
+export function markLocal<T extends { meta: ReferenceMeta }>(board: T): T {
+  return { ...board, meta: { ...board.meta, origin: 'local' as const } }
+}

--- a/src/domain/market-data/reference/hub.ts
+++ b/src/domain/market-data/reference/hub.ts
@@ -37,25 +37,35 @@ export type HubFetcher = <T extends { meta: ReferenceMeta }>(board: string) => P
 export function createHubFetcher(cfg: HubConfig | undefined, opts?: { timeoutMs?: number; breakerMs?: number }): HubFetcher {
   const timeoutMs = opts?.timeoutMs ?? TIMEOUT_MS
   const breakerMs = opts?.breakerMs ?? BREAKER_MS
-  let downUntil = 0
+  // Per-board breakers, tripped ONLY by transport-level failures
+  // (timeout / network). An HTTP error is the hub being REACHABLE and
+  // telling us one board is down — that must never gate the others:
+  // a shared breaker once let a single 502ing board knock siblings onto
+  // their local path, where each board's cache pinned the downgrade for
+  // its full TTL. One bad board may only poison itself.
+  const downUntil = new Map<string, number>()
 
   return async function hubBoard<T extends { meta: ReferenceMeta }>(board: string): Promise<T | null> {
     if (!cfg?.enabled || !cfg.baseUrl) return null
-    if (Date.now() < downUntil) return null
+    if (Date.now() < (downUntil.get(board) ?? 0)) return null
+    let res: Response
     try {
-      const res = await fetch(`${cfg.baseUrl.replace(/\/$/, '')}/api/reference/${board}`, {
+      res = await fetch(`${cfg.baseUrl.replace(/\/$/, '')}/api/reference/${board}`, {
         signal: AbortSignal.timeout(timeoutMs),
         headers: { Accept: 'application/json' },
       })
-      if (!res.ok) throw new Error(`hub returned ${res.status}`)
+    } catch {
+      // Transport failure — hub unreachable; back off for this board.
+      downUntil.set(board, Date.now() + breakerMs)
+      return null
+    }
+    try {
+      if (!res.ok) return null // board-specific upstream failure; no breaker
       const data: unknown = await res.json()
-      if (!data || typeof data !== 'object' || !('meta' in data)) {
-        throw new Error('hub returned a non-contract shape')
-      }
+      if (!data || typeof data !== 'object' || !('meta' in data)) return null
       const payload = data as T
       return { ...payload, meta: { ...payload.meta, origin: 'hub' as const } }
     } catch {
-      downUntil = Date.now() + breakerMs
       return null
     }
   }

--- a/src/domain/market-data/reference/service.ts
+++ b/src/domain/market-data/reference/service.ts
@@ -13,6 +13,7 @@ import { fetchGlobalMacro, type GlobalMacroBoard } from './global-macro.js'
 import { fetchShipping, type ShippingBoard } from './shipping.js'
 import { fetchFedBoard, type FedBoard } from './fed.js'
 import { cachedBoard } from './cache.js'
+import { createHubFetcher, markLocal, type HubConfig } from './hub.js'
 
 export interface ReferenceDataDeps {
   equityClient: EquityClientLike
@@ -26,6 +27,8 @@ export interface ReferenceDataDeps {
    *  the client routes by its constructed default, so the label is the
    *  REQUESTED provider (same caveat as the bar layer's vendor meta). */
   equityProvider: string
+  /** Hosted-hub config (marketData.hub). Undefined = local-only. */
+  hub?: HubConfig
 }
 
 /** Rows per movers list — enough for a board, small enough to stay snappy. */
@@ -53,7 +56,11 @@ const TTL = {
 } as const
 
 export function createReferenceData(deps: ReferenceDataDeps): ReferenceDataService {
+  const viaHub = createHubFetcher(deps.hub)
+
   const movers = cachedBoard(TTL.movers, async (): Promise<MoversBoard> => {
+    const hub = await viaHub<MoversBoard>('movers')
+    if (hub) return hub
     // One list failing must not kill the board — same resilience rule as
     // the federated search fan-out.
     const [gainers, losers, active, uvGrowth, gTech, smallCaps, uvLarge] = await Promise.allSettled([
@@ -75,11 +82,13 @@ export function createReferenceData(deps: ReferenceDataDeps): ReferenceDataServi
       growthTech: rows(gTech),
       smallCaps: rows(smallCaps),
       undervaluedLarge: rows(uvLarge),
-      meta: { provider: deps.equityProvider, asOf: new Date().toISOString() },
+      meta: { provider: deps.equityProvider, asOf: new Date().toISOString(), origin: 'local' },
     }
   })
 
   const calendarCached = cachedBoard(TTL.calendar, async (): Promise<CalendarBoard> => {
+    const hub = await viaHub<CalendarBoard>('calendar')
+    if (hub) return hub
     const days = CALENDAR_DAYS
     const start = new Date()
     const end = new Date(start.getTime() + days * 24 * 60 * 60 * 1000)
@@ -117,27 +126,35 @@ export function createReferenceData(deps: ReferenceDataDeps): ReferenceDataServi
       dividends: rows(dividends),
       window,
       ...(Object.keys(errors).length ? { errors } : {}),
-      meta: { provider: 'fmp', asOf: new Date().toISOString() },
+      meta: { provider: 'fmp', asOf: new Date().toISOString(), origin: 'local' },
     }
   })
 
-  const macro = cachedBoard(TTL.macro, () => fetchMacroBoard(deps.economyClient))
-  const globalMacro = cachedBoard(TTL.globalMacro, () => fetchGlobalMacro(deps.economyClient))
-  const shipping = cachedBoard(TTL.shipping, () => fetchShipping(deps.economyClient))
-  const fed = cachedBoard(TTL.fed, () => fetchFedBoard(deps.economyClient))
+  const macro = cachedBoard(TTL.macro, async () =>
+    (await viaHub<MacroBoard>('macro')) ?? markLocal(await fetchMacroBoard(deps.economyClient)))
+  const globalMacro = cachedBoard(TTL.globalMacro, async () =>
+    (await viaHub<GlobalMacroBoard>('global-macro')) ?? markLocal(await fetchGlobalMacro(deps.economyClient)))
+  const shipping = cachedBoard(TTL.shipping, async () =>
+    (await viaHub<ShippingBoard>('shipping')) ?? markLocal(await fetchShipping(deps.economyClient)))
+  const fed = cachedBoard(TTL.fed, async () =>
+    (await viaHub<FedBoard>('fed')) ?? markLocal(await fetchFedBoard(deps.economyClient)))
 
-  const termStructure = cachedBoard(TTL.termStructure, () => {
+  const termStructure = cachedBoard(TTL.termStructure, async () => {
+    const hub = await viaHub<TermStructureBoard>('term-structure')
+    if (hub) return hub
     if (!deps.derivativesClient) {
-      return Promise.reject(new Error('Term structure requires the typebb-sdk market-data backend (derivatives client unavailable).'))
+      throw new Error('Term structure requires the typebb-sdk market-data backend (derivatives client unavailable).')
     }
-    return fetchTermStructure(deps.derivativesClient)
+    return markLocal(await fetchTermStructure(deps.derivativesClient))
   })
 
-  const valuation = cachedBoard(TTL.valuation, () => {
+  const valuation = cachedBoard(TTL.valuation, async () => {
+    const hub = await viaHub<ValuationStrip>('valuation')
+    if (hub) return hub
     if (!deps.indexClient) {
-      return Promise.reject(new Error('Valuation strip requires the typebb-sdk market-data backend (index client unavailable).'))
+      throw new Error('Valuation strip requires the typebb-sdk market-data backend (index client unavailable).')
     }
-    return fetchValuationStrip(deps.indexClient)
+    return markLocal(await fetchValuationStrip(deps.indexClient))
   })
 
   return {

--- a/src/domain/market-data/reference/types.ts
+++ b/src/domain/market-data/reference/types.ts
@@ -35,6 +35,9 @@ export interface ReferenceMeta {
   /** Set when a payload is served from the reference cache (in-process
    *  today, the hosted hub tomorrow — same field either way). */
   cachedAt?: string
+  /** Which path served this payload: the hosted hub or a local build.
+   *  Absent only on payloads predating the hub seam. */
+  origin?: 'hub' | 'local'
   /** True when the upstream refresh FAILED and this is the last good
    *  payload — stale-while-error. Surfaces loudly, never silently. */
   stale?: boolean

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { SymbolIndex } from './domain/market-data/equity/index.js'
 import { CommodityCatalog } from './domain/market-data/commodity/index.js'
 import { createEquityTools } from './tool/equity.js'
 import { createEtfTools } from './tool/etf.js'
+import { withHubCalendars } from './domain/market-data/hub-data.js'
 import { getSDKExecutor, buildRouteMap, SDKEquityClient, SDKCryptoClient, SDKCurrencyClient, SDKEtfClient, SDKIndexClient, SDKDerivativesClient, SDKCommodityClient, SDKEconomyClient } from './domain/market-data/client/typebb/index.js'
 import type { EquityClientLike, CryptoClientLike, CurrencyClientLike, EtfClientLike, IndexClientLike, DerivativesClientLike, CommodityClientLike, EconomyClientLike } from './domain/market-data/client/types.js'
 import { buildSDKCredentials } from './domain/market-data/credential-map.js'
@@ -154,7 +155,7 @@ async function main() {
   } else {
     const executor = getSDKExecutor()
     const routeMap = buildRouteMap()
-    const credentials = buildSDKCredentials(config.marketData.providerKeys)
+    const credentials = buildSDKCredentials(config.marketData.providerKeys, config.marketData.hub)
     equityClient = new SDKEquityClient(executor, 'equity', providers.equity, credentials, routeMap)
     cryptoClient = new SDKCryptoClient(executor, 'crypto', providers.crypto, credentials, routeMap)
     currencyClient = new SDKCurrencyClient(executor, 'currency', providers.currency, credentials, routeMap)
@@ -186,6 +187,10 @@ async function main() {
     utaManager,
     vendorProviders: config.marketData.providers,
   })
+
+  // Hub-first calendars: tools, CLI and boards all inherit through the
+  // client seam. No-op when the hub is disabled.
+  equityClient = withHubCalendars(equityClient, config.marketData.hub)
 
   // Reference-data contract — board-shaped low-frequency data (movers, macro,
   // calendar, …). Alice's own standard; the future hosted-hub seam.

--- a/src/main.ts
+++ b/src/main.ts
@@ -195,6 +195,7 @@ async function main() {
     derivativesClient,
     indexClient,
     equityProvider: config.marketData.providers.equity,
+    hub: config.marketData.hub,
   })
 
   // ==================== Tool Registration ====================

--- a/src/webui/routes/market.ts
+++ b/src/webui/routes/market.ts
@@ -10,10 +10,14 @@
 import { Hono } from 'hono'
 import type { EngineContext } from '../../core/types.js'
 import { aggregateSymbolSearch } from '../../domain/market-data/aggregate-search.js'
-import { fetchSectorRotation } from '../../domain/analysis/sector-rotation.js'
+import { fetchSectorRotation, type SectorRotationResult } from '../../domain/analysis/sector-rotation.js'
+import { createHubFetcher } from '../../domain/market-data/reference/hub.js'
+import type { ReferenceMeta } from '../../domain/market-data/reference/types.js'
+import type { EquityClientLike } from '../../domain/market-data/client/types.js'
 
 export function createMarketRoutes(ctx: EngineContext): Hono {
   const app = new Hono()
+  const rotationViaHub = createHubFetcher(ctx.config.marketData.hub)
 
   app.get('/search', async (c) => {
     const query = c.req.query('query') ?? ''
@@ -24,8 +28,40 @@ export function createMarketRoutes(ctx: EngineContext): Hono {
   })
 
   // GICS sector rotation map — same compute as the sectorRotation AI tool.
+  // Hub-first: the hosted hub computes the same board (meta.origin says so).
   app.get('/sector-rotation', async (c) => {
-    return c.json(await fetchSectorRotation(ctx.equityClient))
+    const hub = await rotationViaHub<SectorRotationResult & { meta: ReferenceMeta }>('rotation')
+    if (hub) return c.json(hub)
+    const local = await fetchSectorRotation(ctx.equityClient)
+    return c.json({ ...local, meta: { provider: ctx.config.marketData.providers.equity, asOf: local.asOf, origin: 'local' as const } })
+  })
+
+  // First-party per-symbol equity endpoints — the detail-page panels'
+  // replacement for the legacy /api/market-data-v1 passthrough (divorce
+  // step: migrate consumers, then kill the compat layer). Same response
+  // envelope ({results, provider}) so the UI swap is URL-only.
+  const EQUITY_ENDPOINTS: Record<string, keyof EquityClientLike> = {
+    profile: 'getProfile',
+    metrics: 'getKeyMetrics',
+    ratios: 'getFinancialRatios',
+    balance: 'getBalanceSheet',
+    income: 'getIncomeStatement',
+    cash: 'getCashFlow',
+  }
+  app.get('/equity/:endpoint', async (c) => {
+    const method = EQUITY_ENDPOINTS[c.req.param('endpoint')]
+    if (!method) {
+      return c.json({ error: `Unknown equity endpoint. Available: ${Object.keys(EQUITY_ENDPOINTS).join(', ')}` }, 404)
+    }
+    const symbol = c.req.query('symbol')
+    if (!symbol) return c.json({ error: 'symbol is required' }, 400)
+    try {
+      const fn = ctx.equityClient[method] as (p: Record<string, unknown>) => Promise<unknown[]>
+      const results = await fn.call(ctx.equityClient, { symbol })
+      return c.json({ results, provider: ctx.config.marketData.providers.equity })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 502)
+    }
   })
 
   return app

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -50,13 +50,21 @@ export type FinancialRatios = Record<string, unknown>
 export type KeyMetrics = Record<string, unknown>
 export type FinancialStatementRow = Record<string, unknown>
 
+/** First-party per-symbol endpoints (same {results, provider} envelope). */
 function equityEndpoint<T>(
   path: string,
   params: Record<string, string | number> = {},
 ): Promise<OBBjectResponse<T>> {
   const qs = new URLSearchParams()
   for (const [k, v] of Object.entries(params)) qs.set(k, String(v))
-  return fetchJson(`/api/market-data-v1/equity/${path}?${qs}`)
+  return fetchJson(`/api/market/equity/${path}?${qs}`)
+}
+
+/** Quote is realtime-family (operational identity, like K-lines) — it stays
+ *  on the legacy passthrough until the bar-layer/UTA quote arc takes it. */
+function quoteEndpoint<T>(symbol: string): Promise<OBBjectResponse<T>> {
+  const qs = new URLSearchParams({ symbol })
+  return fetchJson(`/api/market-data-v1/equity/price/quote?${qs}`)
 }
 
 export type RotationPeriod = '1D' | '1W' | '1M' | '3M' | '6M'
@@ -78,6 +86,8 @@ export interface SectorRotationRow {
 
 export interface SectorRotationResult {
   asOf: string
+  /** Present on hub-served (and new local) responses. */
+  meta?: { provider: string; asOf: string; origin?: 'hub' | 'local'; stale?: boolean }
   benchmark: { symbol: string; returns: Record<RotationPeriod, number | null> }
   /** Sorted by rotation_score desc; null-score rows at the bottom. */
   sectors: SectorRotationRow[]
@@ -119,12 +129,12 @@ export const marketApi = {
   /** Equity-specific endpoints — Alice infers provider from config, no ?provider=. */
   equity: {
     profile: (symbol: string) => equityEndpoint<EquityProfile>('profile', { symbol }),
-    quote: (symbol: string) => equityEndpoint<EquityQuote>('price/quote', { symbol }),
-    metrics: (symbol: string) => equityEndpoint<KeyMetrics>('fundamental/metrics', { symbol }),
-    ratios: (symbol: string) => equityEndpoint<FinancialRatios>('fundamental/ratios', { symbol }),
-    balance: (symbol: string) => equityEndpoint<FinancialStatementRow>('fundamental/balance', { symbol }),
-    income: (symbol: string) => equityEndpoint<FinancialStatementRow>('fundamental/income', { symbol }),
-    cashflow: (symbol: string) => equityEndpoint<FinancialStatementRow>('fundamental/cash', { symbol }),
+    quote: (symbol: string) => quoteEndpoint<EquityQuote>(symbol),
+    metrics: (symbol: string) => equityEndpoint<KeyMetrics>('metrics', { symbol }),
+    ratios: (symbol: string) => equityEndpoint<FinancialRatios>('ratios', { symbol }),
+    balance: (symbol: string) => equityEndpoint<FinancialStatementRow>('balance', { symbol }),
+    income: (symbol: string) => equityEndpoint<FinancialStatementRow>('income', { symbol }),
+    cashflow: (symbol: string) => equityEndpoint<FinancialStatementRow>('cash', { symbol }),
   },
 }
 

--- a/ui/src/api/reference.ts
+++ b/ui/src/api/reference.ts
@@ -14,6 +14,10 @@ export interface ReferenceMeta {
   provider: string
   asOf: string
   cachedAt?: string
+  /** Which path served: the hosted hub or a local build with your keys. */
+  origin?: 'hub' | 'local'
+  /** Upstream refresh failed; this is the last good payload. */
+  stale?: boolean
 }
 
 /** One row of a movers list (gainers / losers / active). */

--- a/ui/src/components/market/BoardMeta.tsx
+++ b/ui/src/components/market/BoardMeta.tsx
@@ -1,0 +1,31 @@
+import type { ReferenceMeta } from '../../api/reference'
+
+/**
+ * The one meta line for board headers — single source word, not a badge
+ * parade. Grammar:
+ *
+ *   hub-served  → "· hub"      (upstream provider lives in the tooltip)
+ *   local build → "· <provider>"
+ *   stale       → amber STALE chip — the only chip, because it's the only
+ *                 state that should interrupt reading.
+ *
+ * Full provenance (provider · origin · asOf) is always on hover.
+ */
+export function BoardMeta({ meta, extra }: { meta: ReferenceMeta; extra?: string }) {
+  const sourceWord = meta.origin === 'hub' ? 'hub' : meta.provider
+  const detail = [
+    `upstream: ${meta.provider}`,
+    meta.origin ? `served by: ${meta.origin}` : null,
+    meta.asOf ? `asOf: ${meta.asOf}` : null,
+    meta.cachedAt ? `cached: ${meta.cachedAt}` : null,
+  ].filter(Boolean).join(' · ')
+  return (
+    <span className="text-text-muted/50" title={detail}>
+      {extra && <> · {extra}</>}
+      {' · '}{sourceWord}
+      {meta.stale && (
+        <span className="ml-1.5 text-[9px] uppercase tracking-wide px-1 py-px rounded bg-amber-500/15 text-amber-400">stale</span>
+      )}
+    </span>
+  )
+}

--- a/ui/src/components/market/FinancialStatementsPanel.tsx
+++ b/ui/src/components/market/FinancialStatementsPanel.tsx
@@ -102,14 +102,9 @@ export function FinancialStatementsPanel({ symbol }: Props) {
   const rows = entry?.rows ?? []
   const rowDefs = ROWS[tab]
 
-  const endpointFor: Record<Tab, string> = {
-    balance: '/equity/fundamental/balance',
-    income: '/equity/fundamental/income',
-    cashflow: '/equity/fundamental/cash',
-  }
   const info = [
     entry?.provider ? `Source: ${entry.provider}` : 'Source: (unknown)',
-    `Endpoint: /api/market-data-v1${endpointFor[tab]}`,
+    `Endpoint: /api/market/equity/${tab === 'cashflow' ? 'cash' : tab}`,
     'Annual periods, most recent first. Values scaled (K / M / B / T).',
     'Blank cells are line items this provider doesn\u2019t report for the current period.',
   ].join('\n')

--- a/ui/src/components/market/ProfilePanel.tsx
+++ b/ui/src/components/market/ProfilePanel.tsx
@@ -41,7 +41,7 @@ export function ProfilePanel({ symbol }: Props) {
 
   const info = [
     provider ? `Source: ${provider}` : 'Source: (unknown)',
-    'Endpoint: /api/market-data-v1/equity/profile',
+    'Endpoint: /api/market/equity/profile',
     'Company overview: sector, industry, leadership, location, headcount.',
     'Field coverage varies by provider; blank rows are fields the source doesn\u2019t report.',
   ].join('\n')

--- a/ui/src/components/market/useReferenceBoard.ts
+++ b/ui/src/components/market/useReferenceBoard.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * The one fetch-and-poll hook for board-shaped data — replaces the
+ * hand-rolled useState×4 + useEffect + setInterval block every board view
+ * used to copy. Polling (not SSE) per the low-frequency-surface rule.
+ */
+export function useReferenceBoard<T>(fetcher: () => Promise<T>, refreshMs: number) {
+  const [data, setData] = useState<T | null>(null)
+  const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    const load = async () => {
+      try {
+        const res = await fetcher()
+        if (!alive) return
+        setData(res)
+        setUpdatedAt(new Date())
+        setError(null)
+      } catch (err) {
+        if (!alive) return
+        setError(err instanceof Error ? err.message : 'Failed to load')
+      } finally {
+        if (alive) setLoading(false)
+      }
+    }
+    load()
+    const timer = setInterval(load, refreshMs)
+    return () => { alive = false; clearInterval(timer) }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetcher is a stable module-level api fn
+  }, [refreshMs])
+
+  return { data, updatedAt, loading, error }
+}

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -79,13 +79,13 @@ export const marketHandlers = [
     }
     return HttpResponse.json(demoMarketAAPL.historical)
   }),
-  http.get('/api/market-data-v1/equity/profile', aaplOnly(demoMarketAAPL.profile)),
+  http.get('/api/market/equity/profile', aaplOnly(demoMarketAAPL.profile)),
   http.get('/api/market-data-v1/equity/price/quote', aaplOnly(demoMarketAAPL.quote)),
-  http.get('/api/market-data-v1/equity/fundamental/metrics', aaplOnly(demoMarketAAPL.metrics)),
-  http.get('/api/market-data-v1/equity/fundamental/ratios', aaplOnly(demoMarketAAPL.ratios)),
-  http.get('/api/market-data-v1/equity/fundamental/balance', aaplOnly(demoMarketAAPL.balance)),
-  http.get('/api/market-data-v1/equity/fundamental/income', aaplOnly(demoMarketAAPL.income)),
-  http.get('/api/market-data-v1/equity/fundamental/cash', aaplOnly(demoMarketAAPL.cash)),
+  http.get('/api/market/equity/metrics', aaplOnly(demoMarketAAPL.metrics)),
+  http.get('/api/market/equity/ratios', aaplOnly(demoMarketAAPL.ratios)),
+  http.get('/api/market/equity/balance', aaplOnly(demoMarketAAPL.balance)),
+  http.get('/api/market/equity/income', aaplOnly(demoMarketAAPL.income)),
+  http.get('/api/market/equity/cash', aaplOnly(demoMarketAAPL.cash)),
 
   http.post('/api/market-data/test-provider', () => HttpResponse.json({ ok: true })),
 ]

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -142,10 +142,17 @@ function listLabel(k: MoversList, t: ReturnType<typeof useTranslation>['t']): st
   }
 }
 
-/** Explicit provider label — same disambiguation philosophy as bar sources. */
+/** Explicit provider label — same disambiguation philosophy as bar sources.
+ *  provider = upstream provenance; origin = which path served (hub vs your
+ *  own keys). Both explicit, neither silent. */
 function ProviderBadge({ meta }: { meta: ReferenceMeta }) {
   return (
-    <span className="text-text-muted/50"> · {meta.provider}</span>
+    <span className="text-text-muted/50">
+      {' · '}{meta.provider}
+      {meta.origin === 'hub' && <span className="ml-1.5 text-[9px] uppercase tracking-wide px-1 py-px rounded bg-accent/15 text-accent">hub</span>}
+      {meta.origin === 'local' && <span className="ml-1.5 text-[9px] uppercase tracking-wide px-1 py-px rounded bg-bg-tertiary text-text-muted">local</span>}
+      {meta.stale && <span className="ml-1.5 text-[9px] uppercase tracking-wide px-1 py-px rounded bg-amber-500/15 text-amber-400">stale</span>}
+    </span>
   )
 }
 
@@ -229,7 +236,7 @@ function CalendarBoardView() {
         description={
           <>
             {t('market.calendarSubtitle')}
-            {data && <span className="text-text-muted/50"> · {data.window.start} → {data.window.end} · {data.meta.provider}</span>}
+            {data && <><span className="text-text-muted/50"> · {data.window.start} → {data.window.end}</span><ProviderBadge meta={data.meta} /></>}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -404,7 +411,7 @@ function MacroBoardView() {
         description={
           <>
             {t('market.macroSubtitle')}
-            {data && <span className="text-text-muted/50"> · {data.meta.provider}</span>}
+            {data && <ProviderBadge meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -485,7 +492,7 @@ function TermStructureBoardView() {
         description={
           <>
             {t('market.termSubtitle')}
-            {data && <span className="text-text-muted/50"> · {data.meta.provider}</span>}
+            {data && <ProviderBadge meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -592,7 +599,7 @@ function GlobalMacroBoardView() {
         description={
           <>
             {t('market.globalMacroSubtitle')}
-            {data && <span className="text-text-muted/50"> · {data.meta.provider}</span>}
+            {data && <ProviderBadge meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -685,7 +692,7 @@ function ShippingBoardView() {
         description={
           <>
             {t('market.shippingSubtitle')}
-            {data && <span className="text-text-muted/50"> · {data.meta.provider}</span>}
+            {data && <ProviderBadge meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -778,7 +785,7 @@ function FedBoardView() {
         description={
           <>
             {t('market.fedSubtitle')}
-            {data && <span className="text-text-muted/50"> · {data.meta.provider}</span>}
+            {data && <ProviderBadge meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LineChart, Line, ResponsiveContainer, YAxis, XAxis, Tooltip } from 'recharts'
+import { useReferenceBoard } from '../components/market/useReferenceBoard'
+import { BoardMeta } from '../components/market/BoardMeta'
 import { PageHeader } from '../components/PageHeader'
 import { SeriesCard } from '../components/market/SeriesCard'
 import {
@@ -58,32 +60,8 @@ type MoversList = 'gainers' | 'losers' | 'active' | 'undervaluedGrowth' | 'growt
 
 function MoversBoardView() {
   const { t } = useTranslation()
-  const [data, setData] = useState<MoversBoard | null>(null)
+  const { data, updatedAt, loading, error } = useReferenceBoard<MoversBoard>(referenceApi.movers, REFRESH_MS)
   const [list, setList] = useState<MoversList>('gainers')
-  const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    const load = async () => {
-      try {
-        const res = await referenceApi.movers()
-        if (!alive) return
-        setData(res)
-        setUpdatedAt(new Date())
-        setError(null)
-      } catch (err) {
-        if (!alive) return
-        setError(err instanceof Error ? err.message : 'Failed to load')
-      } finally {
-        if (alive) setLoading(false)
-      }
-    }
-    load()
-    const timer = setInterval(load, REFRESH_MS)
-    return () => { alive = false; clearInterval(timer) }
-  }, [])
 
   const rows = data?.[list] ?? []
 
@@ -94,7 +72,7 @@ function MoversBoardView() {
         description={
           <>
             {t('market.moversSubtitle')}
-            {data && <ProviderBadge meta={data.meta} />}
+            {data && <BoardMeta meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -140,20 +118,6 @@ function listLabel(k: MoversList, t: ReturnType<typeof useTranslation>['t']): st
     case 'smallCaps': return t('market.moversSmallCaps')
     case 'undervaluedLarge': return t('market.moversUndervaluedLarge')
   }
-}
-
-/** Explicit provider label — same disambiguation philosophy as bar sources.
- *  provider = upstream provenance; origin = which path served (hub vs your
- *  own keys). Both explicit, neither silent. */
-function ProviderBadge({ meta }: { meta: ReferenceMeta }) {
-  return (
-    <span className="text-text-muted/50">
-      {' · '}{meta.provider}
-      {meta.origin === 'hub' && <span className="ml-1.5 text-[9px] uppercase tracking-wide px-1 py-px rounded bg-accent/15 text-accent">hub</span>}
-      {meta.origin === 'local' && <span className="ml-1.5 text-[9px] uppercase tracking-wide px-1 py-px rounded bg-bg-tertiary text-text-muted">local</span>}
-      {meta.stale && <span className="ml-1.5 text-[9px] uppercase tracking-wide px-1 py-px rounded bg-amber-500/15 text-amber-400">stale</span>}
-    </span>
-  )
 }
 
 function MoversTable({ rows }: { rows: MoverRow[] }) {
@@ -202,32 +166,8 @@ type CalendarList = 'earnings' | 'ipos' | 'dividends'
 
 function CalendarBoardView() {
   const { t } = useTranslation()
-  const [data, setData] = useState<CalendarBoard | null>(null)
+  const { data, updatedAt, loading, error } = useReferenceBoard<CalendarBoard>(referenceApi.calendar, 30 * 60 * 1000)
   const [list, setList] = useState<CalendarList>('earnings')
-  const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    const load = async () => {
-      try {
-        const res = await referenceApi.calendar()
-        if (!alive) return
-        setData(res)
-        setUpdatedAt(new Date())
-        setError(null)
-      } catch (err) {
-        if (!alive) return
-        setError(err instanceof Error ? err.message : 'Failed to load')
-      } finally {
-        if (alive) setLoading(false)
-      }
-    }
-    load()
-    const timer = setInterval(load, 30 * 60 * 1000)
-    return () => { alive = false; clearInterval(timer) }
-  }, [])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -236,7 +176,7 @@ function CalendarBoardView() {
         description={
           <>
             {t('market.calendarSubtitle')}
-            {data && <><span className="text-text-muted/50"> · {data.window.start} → {data.window.end}</span><ProviderBadge meta={data.meta} /></>}
+            {data && <BoardMeta meta={data.meta} extra={`${data.window.start} → ${data.window.end}`} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -378,31 +318,7 @@ function CalTable({ head, rightCols = [], children }: { head: string[]; rightCol
 
 function MacroBoardView() {
   const { t } = useTranslation()
-  const [data, setData] = useState<MacroBoard | null>(null)
-  const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    const load = async () => {
-      try {
-        const res = await referenceApi.macro()
-        if (!alive) return
-        setData(res)
-        setUpdatedAt(new Date())
-        setError(null)
-      } catch (err) {
-        if (!alive) return
-        setError(err instanceof Error ? err.message : 'Failed to load')
-      } finally {
-        if (alive) setLoading(false)
-      }
-    }
-    load()
-    const timer = setInterval(load, 30 * 60 * 1000)
-    return () => { alive = false; clearInterval(timer) }
-  }, [])
+  const { data, updatedAt, loading, error } = useReferenceBoard<MacroBoard>(referenceApi.macro, 30 * 60 * 1000)
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -411,7 +327,7 @@ function MacroBoardView() {
         description={
           <>
             {t('market.macroSubtitle')}
-            {data && <ProviderBadge meta={data.meta} />}
+            {data && <BoardMeta meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -459,31 +375,7 @@ function macroLabel(card: MacroSeriesCard, t: ReturnType<typeof useTranslation>[
 
 function TermStructureBoardView() {
   const { t } = useTranslation()
-  const [data, setData] = useState<TermStructureBoard | null>(null)
-  const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    const load = async () => {
-      try {
-        const res = await referenceApi.termStructure()
-        if (!alive) return
-        setData(res)
-        setUpdatedAt(new Date())
-        setError(null)
-      } catch (err) {
-        if (!alive) return
-        setError(err instanceof Error ? err.message : 'Failed to load')
-      } finally {
-        if (alive) setLoading(false)
-      }
-    }
-    load()
-    const timer = setInterval(load, 5 * 60 * 1000)
-    return () => { alive = false; clearInterval(timer) }
-  }, [])
+  const { data, updatedAt, loading, error } = useReferenceBoard<TermStructureBoard>(referenceApi.termStructure, 5 * 60 * 1000)
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -492,7 +384,7 @@ function TermStructureBoardView() {
         description={
           <>
             {t('market.termSubtitle')}
-            {data && <ProviderBadge meta={data.meta} />}
+            {data && <BoardMeta meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -566,31 +458,7 @@ function TermCurveCard({ curve }: { curve: TermCurve }) {
 
 function GlobalMacroBoardView() {
   const { t } = useTranslation()
-  const [data, setData] = useState<GlobalMacroBoard | null>(null)
-  const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    const load = async () => {
-      try {
-        const res = await referenceApi.globalMacro()
-        if (!alive) return
-        setData(res)
-        setUpdatedAt(new Date())
-        setError(null)
-      } catch (err) {
-        if (!alive) return
-        setError(err instanceof Error ? err.message : 'Failed to load')
-      } finally {
-        if (alive) setLoading(false)
-      }
-    }
-    load()
-    const timer = setInterval(load, 60 * 60 * 1000)
-    return () => { alive = false; clearInterval(timer) }
-  }, [])
+  const { data, updatedAt, loading, error } = useReferenceBoard<GlobalMacroBoard>(referenceApi.globalMacro, 60 * 60 * 1000)
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -599,7 +467,7 @@ function GlobalMacroBoardView() {
         description={
           <>
             {t('market.globalMacroSubtitle')}
-            {data && <ProviderBadge meta={data.meta} />}
+            {data && <BoardMeta meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -659,31 +527,7 @@ function GlobalCell({ cell, fmt, colorBy }: { cell: GlobalMacroCell; fmt: (v: nu
 
 function ShippingBoardView() {
   const { t } = useTranslation()
-  const [data, setData] = useState<ShippingBoard | null>(null)
-  const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    const load = async () => {
-      try {
-        const res = await referenceApi.shipping()
-        if (!alive) return
-        setData(res)
-        setUpdatedAt(new Date())
-        setError(null)
-      } catch (err) {
-        if (!alive) return
-        setError(err instanceof Error ? err.message : 'Failed to load')
-      } finally {
-        if (alive) setLoading(false)
-      }
-    }
-    load()
-    const timer = setInterval(load, 60 * 60 * 1000)
-    return () => { alive = false; clearInterval(timer) }
-  }, [])
+  const { data, updatedAt, loading, error } = useReferenceBoard<ShippingBoard>(referenceApi.shipping, 60 * 60 * 1000)
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -692,7 +536,7 @@ function ShippingBoardView() {
         description={
           <>
             {t('market.shippingSubtitle')}
-            {data && <ProviderBadge meta={data.meta} />}
+            {data && <BoardMeta meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -752,31 +596,7 @@ function ChokepointCard({ curve }: { curve: ShippingCurve }) {
 
 function FedBoardView() {
   const { t } = useTranslation()
-  const [data, setData] = useState<FedBoard | null>(null)
-  const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    const load = async () => {
-      try {
-        const res = await referenceApi.fed()
-        if (!alive) return
-        setData(res)
-        setUpdatedAt(new Date())
-        setError(null)
-      } catch (err) {
-        if (!alive) return
-        setError(err instanceof Error ? err.message : 'Failed to load')
-      } finally {
-        if (alive) setLoading(false)
-      }
-    }
-    load()
-    const timer = setInterval(load, 60 * 60 * 1000)
-    return () => { alive = false; clearInterval(timer) }
-  }, [])
+  const { data, updatedAt, loading, error } = useReferenceBoard<FedBoard>(referenceApi.fed, 60 * 60 * 1000)
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -785,7 +605,7 @@ function FedBoardView() {
         description={
           <>
             {t('market.fedSubtitle')}
-            {data && <ProviderBadge meta={data.meta} />}
+            {data && <BoardMeta meta={data.meta} />}
           </>
         }
         live={{ lastUpdated: updatedAt }}

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -117,16 +117,16 @@ export function MarketDataPage() {
 
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-5">
         <div className={`max-w-[880px] mx-auto ${!enabled ? 'opacity-40 pointer-events-none' : ''}`}>
-          {/* Asset Providers — route selection only, no keys */}
-          <AssetProvidersSection
-            providers={providers}
-            onProviderChange={handleProviderChange}
-          />
-
-          {/* Data Hub — hosted boards, zero-key out of the box */}
+          {/* Data Hub — the primary low-frequency source, zero-key OOTB */}
           <HubSection
             hub={hub}
             onChange={(next) => updateConfigImmediate({ hub: next })}
+          />
+
+          {/* Vendor routing — charts + fallback when the hub is off/uncovered */}
+          <AssetProvidersSection
+            providers={providers}
+            onProviderChange={handleProviderChange}
           />
 
           {/* API Keys — unified credential management */}
@@ -160,8 +160,8 @@ function AssetProvidersSection({
 }) {
   return (
     <ConfigSection
-      title="Asset Providers"
-      description="Select a data provider for each asset class. API keys are managed separately below."
+      title="Vendor Routing"
+      description="Per-asset-class vendor for charts (K-lines) and as fallback when the Data Hub is off or doesn't cover an endpoint. Low-frequency data defaults to the hub above."
     >
       <div className="space-y-3">
         {Object.entries(PROVIDER_OPTIONS).map(([asset, options]) => {

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -86,6 +86,7 @@ export function MarketDataPage() {
   const apiUrl = (config.apiUrl as string) || 'http://localhost:6900'
   const providers = (config.providers ?? { equity: 'yfinance', crypto: 'yfinance', currency: 'yfinance', commodity: 'yfinance' }) as Record<string, string>
   const providerKeys = (config.providerKeys ?? {}) as Record<string, string>
+  const hub = (config.hub ?? { enabled: true, baseUrl: 'https://traderhub.openalice.ai' }) as { enabled: boolean; baseUrl: string }
 
   const handleProviderChange = (asset: string, provider: string) => {
     updateConfigImmediate({ providers: { ...providers, [asset]: provider } })
@@ -120,6 +121,12 @@ export function MarketDataPage() {
           <AssetProvidersSection
             providers={providers}
             onProviderChange={handleProviderChange}
+          />
+
+          {/* Data Hub — hosted boards, zero-key out of the box */}
+          <HubSection
+            hub={hub}
+            onChange={(next) => updateConfigImmediate({ hub: next })}
           />
 
           {/* API Keys — unified credential management */}
@@ -317,5 +324,38 @@ function AdvancedSection({
         </div>
       )}
     </div>
+  )
+}
+
+// ==================== Data Hub ====================
+
+function HubSection({
+  hub,
+  onChange,
+}: {
+  hub: { enabled: boolean; baseUrl: string }
+  onChange: (next: { enabled: boolean; baseUrl: string }) => void
+}) {
+  return (
+    <section className="mb-8">
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-[13px] font-semibold">Data Hub</h2>
+        <Toggle size="sm" checked={hub.enabled} onChange={(v) => onChange({ ...hub, enabled: v })} />
+      </div>
+      <p className="text-[12px] text-text-muted mb-3">
+        Boards are served from the hosted TraderHub when available — no API keys needed.
+        Your own keys below are used as fallback when the hub is off or unreachable.
+        Anonymous reads of public data; self-hosters can point this at their own instance.
+      </p>
+      {hub.enabled && (
+        <input
+          type="text"
+          value={hub.baseUrl}
+          onChange={(e) => onChange({ ...hub, baseUrl: e.target.value })}
+          placeholder="https://traderhub.openalice.ai"
+          className="w-full max-w-[420px] px-2.5 py-1.5 bg-bg text-text border border-border rounded-md text-[12px] font-mono outline-none focus:border-accent"
+        />
+      )}
+    </section>
   )
 }

--- a/ui/src/pages/MarketPage.tsx
+++ b/ui/src/pages/MarketPage.tsx
@@ -28,7 +28,7 @@ export function MarketPage() {
         <div className="flex flex-col gap-2">
           <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-muted/60">
             {t('market.valuationTitle')}
-            {strip && <span className="ml-2 normal-case font-normal tracking-normal text-text-muted/50">{strip.meta.provider}</span>}
+            {strip && <span className="ml-2 normal-case font-normal tracking-normal text-text-muted/50">{strip.meta.provider}{strip.meta.origin === 'hub' ? ' · hub' : strip.meta.origin === 'local' ? ' · local' : ''}{strip.meta.stale ? ' · stale' : ''}</span>}
           </h3>
           {stripError && (
             <div className="text-[12px] text-text-muted/70 border border-border rounded-md px-3 py-2">{stripError}</div>

--- a/ui/src/pages/MarketPage.tsx
+++ b/ui/src/pages/MarketPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { BoardMeta } from '../components/market/BoardMeta'
 import { PageHeader } from '../components/PageHeader'
 import { SearchBox } from '../components/market/SearchBox'
 import { SeriesCard } from '../components/market/SeriesCard'
@@ -28,7 +29,7 @@ export function MarketPage() {
         <div className="flex flex-col gap-2">
           <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-muted/60">
             {t('market.valuationTitle')}
-            {strip && <span className="ml-2 normal-case font-normal tracking-normal text-text-muted/50">{strip.meta.provider}{strip.meta.origin === 'hub' ? ' · hub' : strip.meta.origin === 'local' ? ' · local' : ''}{strip.meta.stale ? ' · stale' : ''}</span>}
+            {strip && <span className="ml-2 normal-case font-normal tracking-normal"><BoardMeta meta={strip.meta} /></span>}
           </h3>
           {stripError && (
             <div className="text-[12px] text-text-muted/70 border border-border rounded-md px-3 py-2">{stripError}</div>

--- a/ui/src/pages/MarketRotationPage.tsx
+++ b/ui/src/pages/MarketRotationPage.tsx
@@ -81,7 +81,7 @@ export function MarketRotationPage() {
         description={
           <>
             {t('market.rotationSubtitle')}
-            {data && <span className="text-text-muted/50"> · {t('market.asOf')} {data.asOf}</span>}
+            {data && <span className="text-text-muted/50"> · {t('market.asOf')} {data.asOf}{data.meta?.origin === 'hub' ? ' · hub' : data.meta?.origin === 'local' ? ' · local' : ''}</span>}
           </>
         }
         live={{ lastUpdated: updatedAt }}

--- a/ui/src/pages/MarketRotationPage.tsx
+++ b/ui/src/pages/MarketRotationPage.tsx
@@ -5,6 +5,7 @@ import {
   ScatterChart, Scatter, Cell, LabelList, ReferenceLine,
   XAxis, YAxis, Tooltip, ResponsiveContainer,
 } from 'recharts'
+import { BoardMeta } from '../components/market/BoardMeta'
 import { PageHeader } from '../components/PageHeader'
 import { marketApi, type SectorRotationResult, type SectorRotationRow } from '../api/market'
 
@@ -81,7 +82,7 @@ export function MarketRotationPage() {
         description={
           <>
             {t('market.rotationSubtitle')}
-            {data && <span className="text-text-muted/50"> · {t('market.asOf')} {data.asOf}{data.meta?.origin === 'hub' ? ' · hub' : data.meta?.origin === 'local' ? ' · local' : ''}</span>}
+            {data && <><span className="text-text-muted/50"> · {t('market.asOf')} {data.asOf}</span>{data.meta && <BoardMeta meta={data.meta} />}</>}
           </>
         }
         live={{ lastUpdated: updatedAt }}


### PR DESCRIPTION
## Summary
Two-phase hub integration. A fresh install with ZERO configured keys now gets all 8 boards AND the full FRED/EIA/BLS tool families AND parameterized FMP calendars, served via https://traderhub.openalice.ai. User keys always win; hub off/down = exactly the pre-hub behavior.

**Phase A — boards (hub → local → loud):**
- All 8 reference boards hub-first with `meta.origin = 'hub' | 'local'` on every payload; 5s timeout + 60s circuit breaker.
- term-structure/valuation try the hub before the missing-client refusal → they now work on the openbb-api backend too.
- `marketData.hub {enabled: true, baseUrl}` + Settings › Market Data "Data Hub" section.

**Phase C — endpoint grain (client methods = the endpoint catalog):**
- Credential sentinel: missing fred/eia/bls keys become `hub:<baseUrl>`; SDK fetchers swap the upstream origin for the hub keyed proxy and keep their own transforms — shapes cannot drift, and every method of those families is covered at once (series/search/regional/releases/STEO/…).
- `withHubCalendars(equityClient)`: FMP calendar methods hub-first for parameterized windows (boards only cache the default window); unknown params bypass; breaker + local fallback.
- Hub responses are shape-checked data only — never configuration (trust boundary in `reference/hub.ts`).

Hub-side counterparts (TraderHub repo): allowlisted keyed proxy `/api/proxy/{fred,eia,bls}` + `/api/data/*-calendar` datasets, Redis-cached with stale-while-error.

## Test plan
- [x] `npx tsc --noEmit` + `cd ui && npx tsc -b` clean; `pnpm -F @traderalice/opentypebb build` clean
- [x] `pnpm test` 1802 green (hub fetcher ×7, calendar wrapper ×5, credential sentinel ×4 new specs)
- [x] Keyless live e2e through the hub: FRED DFF 3.62 / BLS CPI 335.1 / EIA 260 rows / earnings calendar 310 rows
- [x] Boards live seam test: throwing local clients + real hub → `origin: 'hub'`

## Boundary touch
None — market-data read path only. Hub data is shape-checked, never interpreted as config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)