### PR TITLE
traderhub CLI + hub-first rotation tool + README Data Hub + workspace docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alice runs on your own machine, because trading involves private keys and real m
 
 ### Research & Analysis
 
-- **Market data** — equity, crypto, commodity, currency, and macro data via TypeScript-native OpenBB engine. Unified cross-asset symbol search and technical indicator calculator
+- **Market data** — equity, crypto, commodity, currency, and macro data, **zero API keys out of the box**: low-frequency boards and datasets are served by the hosted **TraderHub** (https://traderhub.openalice.ai), with your own provider keys as the fallback path. Unified cross-asset symbol search and technical indicator calculator
 - **Fundamental research** — company profiles, financial statements, ratios, analyst estimates, earnings calendar, insider trading, and market movers. Currently deepest for equities, expanding to other asset classes
 - **News** — background RSS collection with archive search
 
@@ -206,6 +206,8 @@ agent runtime that drives trading decisions.
 
 **AI Provider** — Alice runs no model in-process; the model loop lives inside the native workspace CLI (Claude Code / Codex / opencode / Pi). What Alice keeps is a **credential vault**: api-key credentials, each declaring which wire shapes it can speak (Anthropic Messages / OpenAI Chat Completions / OpenAI Responses), injected into workspaces. Subscription logins (Claude Pro/Max, ChatGPT) live in the CLI's own login, not in Alice.
 
+**Data Hub (TraderHub)** — The hosted low-frequency data source. Market boards (macro, movers, calendars, global macro, Fed, shipping, term structure, sector rotation) and keyed datasets (FRED / EIA / BLS series, FMP calendars, FX rates) resolve **hub → your own keys → loud error**, so a fresh install needs zero data-provider accounts. Every payload is stamped with its serving path (`hub` / `local`) and staleness — explicit, never silent. The hub is a convenience layer, not a correctness dependency: switch it off (Settings › Market Data) or point `baseUrl` at a self-hosted instance and behavior falls back to exactly the bring-your-own-keys model. K-lines and quotes deliberately stay off the hub — realtime data comes from your broker (via UTA) or vendor, where the incentives live. Hub responses are shape-checked data only, never configuration.
+
 **Workspace** — A directory + git repo + persistent terminal session running a native agent CLI (`claude`, `codex`, `opencode`, `pi`, or `shell`) of your choice. OpenAlice plumbs its MCP servers into the workspace via `.mcp.json`, so the agent inside sees the workspace's local files plus OpenAlice's full tool surface (trading, market data, news, analysis). Workspaces live under `~/.openalice/workspaces/<wsId>/` — each is its own self-contained scratch directory the agent can read, write, and `git commit` inside. This is the recommended substrate for any non-trivial AI work: native prompt cache, native CLI rendering, no protocol shim between you and the model. Capability extensions (browser automation, third-party CLIs, custom scrapers) ship as new workspace **templates** rather than `src/` dependencies, keeping the main repo small.
 
 **Templates & satellite repos** — A workspace template is a bootstrap script + initial file set that materializes a workspace of a particular shape (today: `chat`, `auto-quant`). Templates are how OpenAlice's ecosystem grows without bloating the main repo: when a new capability (a research toolkit, a backtest harness, a custom MCP server) is worth packaging, it lives in its own **satellite repo** that a template clones at bootstrap time. The main repo deliberately doesn't accept ecosystem PRs — it owns the Trading domain and the workspace launcher; everything else routes through satellite repos referenced by templates. Means template authors can ship on their own cadence, and OpenAlice's `src/` stays small.
@@ -218,7 +220,7 @@ Chatting with Alice happens inside a **workspace**: a directory + git repo + a p
 
 - **Native prompt cache.** Claude Code, Codex, and the other agent CLIs implement vendor-specific cache control we can't replicate. On a long conversation this is often a 10× cost reduction.
 - **Native frontend.** TUI rendering, syntax highlighting, diff display — the CLI vendor has already tuned these for their model.
-- **Full tool surface.** The CLI sees the workspace's local files plus OpenAlice's MCP tools (trading, market data, news, analysis). No "greatest-common-denominator" trimming.
+- **Full tool surface.** The CLI sees the workspace's local files plus OpenAlice's MCP tools (trading, market data, news, analysis). No "greatest-common-denominator" trimming. Market data needs no API keys by default — the Data Hub serves it.
 - **No protocol shim.** Nothing sits between you and the model — whatever the CLI can do, you can do.
 
 The only requirement: the CLI binary has to be installed on the host running OpenAlice (the Docker image bundles `claude` and `codex`).
@@ -419,7 +421,7 @@ All config lives in `data/config/` as JSON files with Zod validation. Missing fi
 | `connectors.json` | Web/MCP server ports |
 | `web-subchannels.json` | Web UI chat sub-channel definitions (per-channel system prompt + disabled-tools overrides) |
 | `tools.json` | Tool enable/disable configuration |
-| `market-data.json` | Data backend (`typebb-sdk` / `openbb-api`), per-asset-class providers, provider API keys, embedded HTTP server config |
+| `market-data.json` | Data Hub (`enabled` / `baseUrl`), per-asset-class vendors, provider API keys (fallback when the hub is off or uncovered) |
 | `news.json` | RSS feeds, fetch interval, retention period |
 | `snapshot.json` | Account snapshot interval and retention |
 | `compaction.json` | Context window limits, auto-compaction thresholds |

--- a/default/skills/openalice-cli/SKILL.md
+++ b/default/skills/openalice-cli/SKILL.md
@@ -2,16 +2,15 @@
 name: openalice-cli
 description: >
   How to reach OpenAlice from your shell via the `alice*` CLIs. Two binaries:
-  `alice` for MARKET DATA (news, symbol search, equity fundamentals, macro/economy
-  series) and `alice-workspace` for AGENT COLLABORATION (push finished work to the
-  user's inbox, track entities). Both print JSON and are discoverable with
-  `--help`. Use whenever you need a number/headline/fundamental, or want to hand
-  work back to the user, and this workspace exposes the `alice*` commands instead
-  of (or alongside) the OpenAlice MCP tools: "look up AAPL", "what's Apple's
-  revenue", "search news for the Fed", "push my findings to the inbox", "track
-  this ticker". (For technical/quantitative analysis on price — RSI, moving
-  averages, multi-timeframe — see the `openalice-quant` skill.) Discover
-  everything live with `alice --help` / `alice-workspace --help` — do NOT guess flags.
+  `alice` for THIS WORKBENCH's research surfaces (news, cross-asset symbol
+  search, K-line quant analysis, calculator) and `alice-workspace` for AGENT
+  COLLABORATION (push finished work to the user's inbox, track entities). Both
+  print JSON and are discoverable with `--help`. Use for: "search news for the
+  Fed", "find the barId for AAPL", "compute RSI", "push my findings to the
+  inbox", "track this ticker". (LOW-FREQUENCY market data — fundamentals,
+  macro series, calendars, boards — lives on the separate `traderhub` CLI;
+  see the `traderhub` skill. Technical analysis manual: `openalice-quant`.)
+  Discover everything live with `--help` — do NOT guess flags.
 ---
 
 # Using the `alice*` CLIs
@@ -23,8 +22,9 @@ this workspace** (especially if the MCP tools aren't reliably available to you).
 
 | Binary | For | Groups |
 |---|---|---|
-| `alice` | **Market data** (read) | `news`, `market`, `equity`, `economy`, `analysis`, `think` |
+| `alice` | **Workbench research** (read) | `news`, `market`, `analysis`, `think` |
 | `alice-workspace` | **Agent collaboration** | `inbox`, `track` |
+| `traderhub` | **Low-frequency market data** — see the `traderhub` skill | `board`, `equity`, `etf`, `economy`, `global`, `shipping`, `fed`, `crypto`, `index` |
 
 ## Discover, don't guess
 
@@ -47,15 +47,16 @@ alice-workspace <group> <verb> [--flag value]
 - **Output is JSON on stdout.** Pipe it: `alice market search --query AAPL | jq '.results[0]'`.
 - **A non-zero exit means it failed**; the error goes to stderr. Check it.
 
-## Market data — `alice`
+## Workbench research — `alice`
 
-**Find a symbol, then pull fundamentals:**
+**Find a symbol** (returns barIds — the operational handle for charts/quant):
 
 ```bash
 alice market search --query "apple"
-alice equity profile --symbol AAPL
-alice equity financials --symbol AAPL --type income --period annual --limit 5
 ```
+
+(Fundamentals, ratios, calendars and macro series live on `traderhub` —
+e.g. `traderhub equity profile --symbol AAPL`.)
 
 **Scan news, then read one article by its stable id** (the `id` is stable — you
 do **not** need to repeat `--lookback` to read it):
@@ -65,10 +66,9 @@ alice news grep --pattern "interest rate" --lookback 2d
 alice news read --id <id-from-the-results>
 ```
 
-**Macro / metadata filters** (`--meta` is repeatable):
+**Metadata filters** (`--meta` is repeatable):
 
 ```bash
-alice economy fred-series --symbol UNRATE --limit 12
 alice news grep --pattern BTC --meta source=coindesk --meta category=crypto
 ```
 

--- a/default/skills/traderhub/SKILL.md
+++ b/default/skills/traderhub/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: traderhub
+description: >
+  How to pull LOW-FREQUENCY market data from the `traderhub` CLI: finished
+  market boards (macro, movers, calendars, global macro, Fed, shipping,
+  term structure, sector rotation), equity fundamentals (profile, financials,
+  ratios, estimates, insiders, short interest), ETF drilldowns, FRED/BLS/EIA
+  macro series, OECD cross-country indicators, IMF PortWatch shipping, and
+  Deribit crypto curves. Use whenever you need a macro number, a fundamental,
+  a calendar, or a ready-made board: "what's CPI", "AAPL ratios", "earnings
+  this week", "which sectors are rotating in", "Suez canal traffic", "Fed
+  balance sheet". Data is served hub-first (hosted TraderHub) with local
+  fallback — no API keys needed. Discover flags live with
+  `traderhub <group> <verb> --help`; do NOT guess flags.
+---
+
+# `traderhub` — low-frequency market data
+
+One binary for everything that updates on hours-to-quarters cadence. It talks
+to the same backend as the `openalice` MCP tools; output is JSON on stdout
+(pipe to `jq`), non-zero exit = failure with the reason on stderr.
+
+```
+traderhub <group> <verb> [--flag value]
+traderhub --help                  # all groups
+traderhub <group> <verb> --help   # a verb's flags
+```
+
+**Not here:** K-lines/quotes (realtime — see `alice analysis` + the
+`openalice-quant` skill), news (`alice news`), trading (MCP only).
+
+## Reach for a BOARD before assembling primitives
+
+Boards are the finished product — pre-aggregated, cached, one call:
+
+```bash
+traderhub board get --board macro          # 14 US macro cards (rates, CPI YoY, labor, oil, M2…)
+traderhub board get --board movers         # gainers/losers/active + 4 screener lists
+traderhub board get --board calendar       # earnings + IPOs + ex-dividends, 14d window
+traderhub board get --board calendar --days 30
+traderhub board get --board valuation      # S&P 500 PE / CAPE / yields
+traderhub board get --board term-structure # BTC/ETH futures curve + annualized basis
+traderhub board get --board global-macro   # 7 countries × CPI/rates/CLI/house/equity
+traderhub board get --board shipping       # 6 maritime chokepoints, daily transit
+traderhub board get --board fed            # balance sheet + dealer positioning + FOMC docs
+traderhub board rotation                   # GICS sector rotation table (capital flow lens)
+```
+
+Every payload carries `meta`: `origin` ("hub" = hosted TraderHub, "local" =
+this instance's own keys), `stale: true` = upstream refresh failed, you're
+seeing the last good snapshot — say so if it matters to the conclusion.
+
+## Equity fundamentals
+
+```bash
+traderhub equity profile --symbol AAPL
+traderhub equity financials --symbol AAPL --type income --period annual --limit 5
+traderhub equity ratios --symbol AAPL --period annual --limit 5   # ttm=include by default
+traderhub equity estimates --symbol NVDA                          # analyst consensus + price targets
+traderhub equity insiders --symbol NVDA --limit 20                # Form-4 transactions
+traderhub equity short-interest --symbol GME                      # short shares/ratio/float %
+traderhub equity earnings --start-date 2026-06-15 --end-date 2026-06-30
+traderhub equity discover --list gainers                          # or: losers, active,
+                                   # undervalued_growth, growth_tech, small_caps, undervalued_large
+```
+
+## ETF drilldown (the theme workflow)
+
+Broad sectors come from `board rotation`; for a specific theme go one level
+deeper:
+
+```bash
+traderhub etf search --query uranium
+traderhub etf info --symbol URA
+traderhub etf holdings --symbol URA       # top constituents
+traderhub etf sectors --symbol XLK        # sector weights (decimal fractions)
+```
+
+## US macro series (FRED / BLS / EIA)
+
+Workflow: **search for the series id first**, then pull observations.
+
+```bash
+traderhub economy fred-search --query "core pce"
+traderhub economy fred-series --symbol PCEPILFE --limit 24    # limit = latest N
+traderhub economy fred-series --symbol "GDP,UNRATE" --start-date 2020-01-01
+traderhub economy fred-regional --symbol WIPCPI               # state-level cross-section
+traderhub economy bls-search --query "average hourly earnings"
+traderhub economy bls-series --symbol CES0500000003
+traderhub economy petroleum --category crude_oil_stocks       # EIA weekly
+traderhub economy energy --category retail_gasoline           # EIA short-term outlook
+traderhub economy euro-bop --report-type main                 # ECB euro-area balance of payments
+```
+
+## Cross-country (OECD)
+
+Country flag takes slugs, comma-separable:
+`united_states, china, japan, germany, united_kingdom, india, brazil, france,
+italy, canada, australia, south_korea`.
+
+```bash
+traderhub global cpi --country china,japan --transform yoy
+traderhub global rates --country united_states --duration short
+traderhub global leading --country germany          # CLI: 100 = trend, above & rising = expansion
+traderhub global house --country canada             # real house price index, 2015=100
+traderhub global share --country japan              # equity index, 2015=100
+traderhub global retail --country united_kingdom
+```
+
+## Shipping (IMF PortWatch) / Fed / crypto curves
+
+```bash
+traderhub shipping port-search --query shanghai
+traderhub shipping port-volume --port-id <id-from-search>
+traderhub shipping chokepoint --name suez           # daily vessels + tonnage
+traderhub fed documents                             # FOMC statements/minutes/projections links
+traderhub fed balance-sheet                         # WALCL/TREAST/MBS series
+traderhub fed dealers                               # primary dealer net positions (NY Fed)
+traderhub crypto options --symbol BTC               # Deribit chains (BTC/ETH/PAXG)
+traderhub crypto futures --symbol ETH
+traderhub index search --query "S&P"                # CBOE index directory
+```
+
+## Units — read before comparing numbers
+
+- `percent_change` on movers/discover rows is a **fraction** (0.052 = +5.2%).
+- `dividend_yield`, ETF `weight` are **decimal fractions** (0.012 = 1.2%).
+- OECD `cpi --transform yoy` and `rates` are **percent units** (3.72 = 3.72%).
+- FRED series come in the unit FRED publishes (check the series title).
+- `dollar_volume` is price × volume — the only volume number comparable
+  ACROSS tickers; `rvol` (volume vs its own 20d average) is the
+  unusual-for-itself signal.

--- a/src/main.ts
+++ b/src/main.ts
@@ -213,7 +213,7 @@ async function main() {
   // — calculateQuant (v2, barId-keyed) supersedes it and the two descriptions
   // confused the model / bloated context. The code remains for now.
   toolCenter.register(createQuantTools({ barService }), 'quant')
-  toolCenter.register(createSectorRotationTools(equityClient), 'sector-rotation')
+  toolCenter.register(createSectorRotationTools(equityClient, config.marketData.hub), 'sector-rotation')
   if (derivativesClient) {
     toolCenter.register(createDerivativesTools(derivativesClient), 'derivatives')
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import { createQuantTools } from './tool/quant.js'
 import { createBarService } from './domain/market-data/bars/index.js'
 import { createReferenceData } from './domain/market-data/reference/service.js'
 import { createSectorRotationTools } from './tool/sector-rotation.js'
+import { createReferenceBoardTools } from './tool/reference-board.js'
 import { createDerivativesTools } from './tool/derivatives.js'
 import { createIndexTools } from './tool/indices.js'
 import { createEconomyTools } from './tool/economy.js'
@@ -202,6 +203,7 @@ async function main() {
 
   toolCenter.register(createCronTools(cronEngine), 'cron')
   toolCenter.register(createMarketSearchTools(marketSearch), 'market-search')
+  toolCenter.register(createReferenceBoardTools(reference), 'market-board')
   toolCenter.register(createEquityTools(equityClient), 'equity')
   if (etfClient) {
     toolCenter.register(createEtfTools(etfClient), 'etf')

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -11,6 +11,12 @@
  *                                            COLLABORATION (inbox push + entity
  *                                            tracking); scoped per workspace,
  *                                            launcher-universal (survives a domain swap).
+ *   - `traderhub`       (key `traderhub`) → global ToolCenter — LOW-FREQUENCY
+ *                                            market data via the TraderHub-first
+ *                                            client chain (boards, fundamentals,
+ *                                            macro series, calendars). Named after
+ *                                            the hosted hub so the binary name IS
+ *                                            the domain name.
  *   - `alice-uta`       (key `uta`)       → RESERVED. trading/cron live here once
  *                                            the AI<->human boundary review greenlights
  *                                            irreversible broker mutations. Not exposed yet.
@@ -47,13 +53,39 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       market: {
         search: 'marketSearchForResearch',
       },
+      analysis: {
+        'search-bars': 'searchBars',
+        quant: 'calculateQuant',
+      },
+      think: {
+        calc: 'calculate',
+      },
+    },
+  },
+  traderhub: {
+    binary: 'traderhub',
+    scope: 'global',
+    description: 'Low-frequency market data — boards, fundamentals, macro, calendars (TraderHub-first)',
+    commands: {
+      board: {
+        get: 'marketGetBoard',
+        rotation: 'sectorRotation',
+      },
       equity: {
         profile: 'equityGetProfile',
         financials: 'equityGetFinancials',
         ratios: 'equityGetRatios',
         earnings: 'equityGetEarningsCalendar',
         insiders: 'equityGetInsiderTrading',
+        'short-interest': 'equityGetShortInterest',
+        estimates: 'equityGetEstimates',
         discover: 'equityDiscover',
+      },
+      etf: {
+        search: 'etfSearch',
+        info: 'etfGetInfo',
+        holdings: 'etfGetHoldings',
+        sectors: 'etfGetSectors',
       },
       economy: {
         'fred-search': 'economyFredSearch',
@@ -63,13 +95,32 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
         'bls-series': 'economyBlsSeries',
         energy: 'economyEnergyOutlook',
         petroleum: 'economyPetroleumStatus',
+        'euro-bop': 'economyEuroAreaBop',
       },
-      analysis: {
-        'search-bars': 'searchBars',
-        quant: 'calculateQuant',
+      global: {
+        cpi: 'economyCountryCpi',
+        rates: 'economyCountryRates',
+        leading: 'economyLeadingIndicator',
+        retail: 'economyCountryRetail',
+        house: 'economyCountryHousePrices',
+        share: 'economyCountrySharePrices',
       },
-      think: {
-        calc: 'calculate',
+      shipping: {
+        'port-search': 'economyPortSearch',
+        'port-volume': 'economyPortVolume',
+        chokepoint: 'economyChokepointVolume',
+      },
+      fed: {
+        documents: 'economyFomcDocuments',
+        'balance-sheet': 'economyFedBalanceSheet',
+        dealers: 'economyDealerPositioning',
+      },
+      crypto: {
+        options: 'cryptoOptionsChains',
+        futures: 'cryptoFuturesInstruments',
+      },
+      index: {
+        search: 'indexSearch',
       },
     },
   },
@@ -95,8 +146,9 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
 }
 
 /**
- * Map a PATH binary name to its export key. `alice` → `data`; `alice-<x>` → `<x>`
- * (e.g. `alice-workspace` → `workspace`). Mirrored in the shim (bin/alice).
+ * Map a PATH binary name to its export key. `alice` → `data`; `alice-<x>` →
+ * `<x>`; any other bare name (e.g. `traderhub`) is its own key. Mirrored in
+ * the shim (bin/alice).
  */
 export function exportKeyForBinary(binary: string): string {
   return binary === 'alice' ? 'data' : binary.replace(/^alice-/, '')

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -29,7 +29,7 @@ import { registerCliRoutes } from './cli.js'
  *                           the workspace's own .mcp.json.
  *
  *   GET  /cli/:wsId/:export/manifest   Same identity-by-URL trick — the gateway
- *   POST /cli/:wsId/:export/invoke     for the workspace-local `alice*` CLIs
+ *   POST /cli/:wsId/:export/invoke     for the workspace-local CLIs (alice*, traderhub)
  *                              (`:export` = data | workspace; see ./cli.ts).
  *                              Reuses this server's port so the shim needs no
  *                              token.
@@ -149,7 +149,7 @@ export class McpPlugin implements Plugin {
     // This listener carries the full tool surface (trading included) and the
     // CLI gateway with NO authentication: its security model is "only local
     // processes can reach it". Its sole consumers are workspace subprocesses
-    // (native agent CLIs + the `alice*` shims), which run on the same host
+    // (native agent CLIs + the CLI shims), which run on the same host
     // and always dial 127.0.0.1 — so there is no legitimate remote caller to
     // serve. Remote access is the web port's job (47331), which gates on the
     // admin token. Without an explicit hostname @hono/node-server binds the

--- a/src/tool/reference-board.ts
+++ b/src/tool/reference-board.ts
@@ -1,0 +1,54 @@
+/**
+ * Board reads for agents — the same reference boards the UI renders
+ * (hub-first with local fallback), as one MCP tool. Before this, agents
+ * could only compose board-grade views from primitives; now
+ * `marketGetBoard` / `traderhub board get` serves the finished product.
+ */
+
+import { z } from 'zod'
+import { tool } from 'ai'
+import type { ReferenceDataService } from '@/domain/market-data/reference/types.js'
+
+const BOARDS = [
+  'movers', 'calendar', 'macro', 'valuation',
+  'term-structure', 'global-macro', 'shipping', 'fed',
+] as const
+
+export function createReferenceBoardTools(reference: ReferenceDataService) {
+  return {
+    marketGetBoard: tool({
+      description: `Read a finished market board — the same boards the OpenAlice UI renders.
+
+Available boards:
+- movers: gainers/losers/most-active + value/growth/size screener lists (intraday)
+- calendar: upcoming earnings, IPOs and ex-dividend dates (14-day window by default)
+- macro: 14 US macro series cards — rates, labor, CPI YoY, oil, dollar, M2, sentiment (FRED)
+- valuation: S&P 500 PE / Shiller CAPE / earnings yield / dividend yield (multpl)
+- term-structure: BTC/ETH futures curve with annualized basis vs perpetual (Deribit)
+- global-macro: 7 countries × CPI/short-rate/CLI/house/equity indices (OECD)
+- shipping: daily transit volume at 6 maritime chokepoints (IMF PortWatch)
+- fed: balance sheet, primary dealer positioning, FOMC documents
+
+meta.origin tells you who served it ('hub' = hosted TraderHub, 'local' = this
+instance's own keys); meta.stale means the upstream refresh failed and you are
+seeing the last good snapshot. For sector rotation use the sectorRotation tool.`,
+      inputSchema: z.object({
+        board: z.enum(BOARDS).describe('Which board to read'),
+        days: z.number().int().positive().max(370).optional()
+          .describe('calendar only: forward window in days (default 14)'),
+      }).meta({ examples: [{ board: 'macro' }] }),
+      execute: async ({ board, days }) => {
+        switch (board) {
+          case 'movers': return reference.movers()
+          case 'calendar': return reference.calendar(days ? { days } : undefined)
+          case 'macro': return reference.macro()
+          case 'valuation': return reference.valuation()
+          case 'term-structure': return reference.termStructure()
+          case 'global-macro': return reference.globalMacro()
+          case 'shipping': return reference.shipping()
+          case 'fed': return reference.fed()
+        }
+      },
+    }),
+  }
+}

--- a/src/tool/sector-rotation.ts
+++ b/src/tool/sector-rotation.ts
@@ -10,9 +10,14 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import type { EquityClientLike } from '@/domain/market-data/client/types'
-import { fetchSectorRotation } from '@/domain/analysis/sector-rotation.js'
+import { fetchSectorRotation, type SectorRotationResult } from '@/domain/analysis/sector-rotation.js'
+import { createHubFetcher, markLocal, type HubConfig } from '@/domain/market-data/reference/hub.js'
+import type { ReferenceMeta } from '@/domain/market-data/reference/types.js'
 
-export function createSectorRotationTools(equityClient: EquityClientLike) {
+export function createSectorRotationTools(equityClient: EquityClientLike, hub?: HubConfig) {
+  // Same hub-first resolution as the /api/market/sector-rotation route —
+  // the agent and the UI must read the same board.
+  const viaHub = createHubFetcher(hub)
   return {
     sectorRotation: tool({
       description: `Read sector rotation — which GICS sectors capital is rotating into or out of.
@@ -34,7 +39,12 @@ This is the broad-sector lens. For a specific theme (robotics, uranium, cybersec
 ...) use etfSearch + etfGetInfo to go one level deeper. See the methodology field for the
 exact definitions and the fund-flow-proxy caveat.`,
       inputSchema: z.object({}).meta({ examples: [{}] }),
-      execute: async () => fetchSectorRotation(equityClient),
+      execute: async (): Promise<SectorRotationResult & { meta: ReferenceMeta }> => {
+        const fromHub = await viaHub<SectorRotationResult & { meta: ReferenceMeta }>('rotation')
+        if (fromHub) return fromHub
+        const local = await fetchSectorRotation(equityClient)
+        return markLocal({ ...local, meta: { provider: 'yfinance', asOf: local.asOf } })
+      },
     }),
   }
 }

--- a/src/workspaces/cli/bin/traderhub
+++ b/src/workspaces/cli/bin/traderhub
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/*
+ * alice* — OpenAlice workspace CLIs.
+ *
+ * A thin argv -> JSON -> HTTP forwarder over the /cli gateway (see
+ * src/server/cli.ts). It owns no schema and no business logic: the gateway
+ * validates + executes, the manifest drives --help, so new capabilities appear
+ * here with zero changes to this file.
+ *
+ * ONE file, shipped under each export name as a byte-identical copy (`alice`,
+ * `alice-workspace`, …). It self-detects which export it is from argv[0]
+ * (`alice` -> data, `alice-<x>` -> <x>) and talks to `/cli/<wsId>/<export>/*`.
+ *
+ * Runs from a workspace PTY shell, reading env the launcher already injects per
+ * spawn (OPENALICE_MCP_URL + AQ_WS_ID). Deliberately written with NO import /
+ * export and NO top-level await, so node runs it identically whether it treats
+ * the file as ESM or CommonJS — and with zero Alice imports, so there is nothing
+ * to build (dev and prod behave the same). Uses only global fetch / process.
+ *
+ *   alice                              list command groups (data export)
+ *   alice-workspace inbox push ...     collaboration export
+ *   <bin> <group> <verb> --help        show a verb's flags
+ *   <bin> <group> <verb> [--flags]     run it; JSON to stdout
+ */
+
+// The binary name this was invoked as — set in main() from argv; drives the
+// export selection and all help/error text.
+let BIN = 'alice'
+
+async function main() {
+  const argv = process.argv.slice(2)
+
+  // Self-detect the export: `alice` -> data, `alice-<x>` -> <x>.
+  BIN = (process.argv[1] || 'alice').split(/[\\/]/).pop() || 'alice'
+  const exportKey = BIN === 'alice' ? 'data' : BIN.replace(/^alice-/, '')
+
+  const mcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
+  const wsId = process.env.AQ_WS_ID
+  if (!wsId) {
+    fail('AQ_WS_ID is not set — run from inside an OpenAlice workspace.')
+  }
+  // Derive the CLI base from the MCP URL: .../mcp -> .../cli/<wsId>/<export>
+  const base = mcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli') + '/' + wsId + '/' + exportKey
+
+  const wantsHelp = argv.includes('--help') || argv.includes('-h')
+  const positionals = argv.filter((a) => !a.startsWith('-'))
+  const group = positionals[0]
+  const verb = positionals[1]
+
+  // `<bin>` / `<bin> --help` -> group listing
+  if (!group) return printGroups(await manifest(base))
+
+  const m = await manifest(base)
+  const groupCmds = m.groups[group]
+  if (!groupCmds) fail(`unknown group "${group}". Run \`${BIN}\` to list groups.`)
+
+  // `<bin> <group>` / `<bin> <group> --help` -> verb listing
+  if (!verb || (wantsHelp && !m.groups[group][verb])) return printVerbs(group, groupCmds)
+
+  const cmd = groupCmds[verb]
+  if (!cmd) fail(`unknown command "${group} ${verb}". Run \`${BIN} ${group}\` to list verbs.`)
+
+  // `alice <group> <verb> --help` -> flag listing
+  if (wantsHelp) return printVerbHelp(group, verb, cmd)
+
+  // Run it.
+  const args = parseFlags(argv.slice(argv.indexOf(verb) + 1))
+  const res = await invoke(base, cmd.tool, args)
+  process.stdout.write(res.endsWith('\n') ? res : res + '\n')
+}
+
+// ---- HTTP -----------------------------------------------------------------
+
+async function manifest(base) {
+  const r = await fetchJson(base + '/manifest', { method: 'GET' })
+  if (!r.ok) {
+    const msg = r.body && r.body.error ? r.body.error : `HTTP ${r.status}`
+    fail(typeof msg === 'string' ? msg : JSON.stringify(msg))
+  }
+  return r.body
+}
+
+async function invoke(base, tool, args) {
+  const r = await fetchJson(base + '/invoke', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tool, args }),
+  })
+  if (!r.ok) {
+    const msg = r.body && r.body.error ? r.body.error : `HTTP ${r.status}`
+    fail(typeof msg === 'string' ? msg : JSON.stringify(msg))
+  }
+  const blocks = (r.body && r.body.content) || []
+  return blocks
+    .map((b) => (b && b.type === 'text' ? b.text : b ? `[${b.type}]` : ''))
+    .join('\n')
+}
+
+async function fetchJson(url, opts) {
+  let resp
+  try {
+    resp = await fetch(url, opts)
+  } catch (e) {
+    fail(`cannot reach OpenAlice at ${url} — is the backend running? (${e && e.message})`)
+  }
+  let body = null
+  const text = await resp.text()
+  try {
+    body = text ? JSON.parse(text) : null
+  } catch {
+    body = text
+  }
+  return { ok: resp.ok, status: resp.status, body }
+}
+
+// ---- flag parsing ---------------------------------------------------------
+
+function parseFlags(tokens) {
+  const args = {}
+  const meta = {}
+  for (let i = 0; i < tokens.length; i++) {
+    let tok = tokens[i]
+    if (!tok.startsWith('--')) continue
+    tok = tok.slice(2)
+    let key, val
+    const eq = tok.indexOf('=')
+    if (eq >= 0) {
+      key = tok.slice(0, eq)
+      val = tok.slice(eq + 1)
+    } else {
+      key = tok
+      const next = tokens[i + 1]
+      if (next === undefined || next.startsWith('--')) {
+        val = 'true' // bare flag -> boolean-ish; gateway coerces as needed
+      } else {
+        val = next
+        i++
+      }
+    }
+    if (key === 'meta') {
+      // repeatable: --meta key=value -> metadataFilter
+      const e = val.indexOf('=')
+      if (e >= 0) meta[val.slice(0, e)] = val.slice(e + 1)
+    } else {
+      args[key] = val
+    }
+  }
+  if (Object.keys(meta).length) args.metadataFilter = meta
+  return args
+}
+
+// ---- help rendering -------------------------------------------------------
+
+function printGroups(m) {
+  const groups = Object.keys(m.groups)
+  const width = Math.max(...groups.map((g) => g.length), 1)
+  out(`OpenAlice CLI — ${BIN} <group> <verb> [--flags]`)
+  if (m.description) out(m.description)
+  out('')
+  for (const g of groups) {
+    out(`  ${g.padEnd(width)}  ${Object.keys(m.groups[g]).join(', ')}`)
+  }
+  out(`\nRun \`${BIN} <group>\` or \`${BIN} <group> <verb> --help\` for details.`)
+  if (m.unmapped && m.unmapped.length) {
+    out(`\n(${m.unmapped.length} tool(s) reachable via MCP but not this CLI)`)
+  }
+}
+
+function printVerbs(group, cmds) {
+  const verbs = Object.keys(cmds)
+  const width = Math.max(...verbs.map((v) => v.length), 1)
+  out(`${BIN} ${group} <verb> [--flags]\n`)
+  for (const v of verbs) {
+    out(`  ${v.padEnd(width)}  ${firstLine(cmds[v].description)}`)
+  }
+}
+
+function printVerbHelp(group, verb, cmd) {
+  out(`${BIN} ${group} ${verb} [--flags]\n`)
+  if (cmd.description) out(cmd.description + '\n')
+  const props = (cmd.schema && cmd.schema.properties) || {}
+  const required = new Set((cmd.schema && cmd.schema.required) || [])
+  const names = Object.keys(props)
+  if (!names.length) return out('(no flags)')
+  out('Flags:')
+  for (const n of names) {
+    const p = props[n] || {}
+    const type = p.type || (p.enum ? 'enum' : '')
+    const req = required.has(n) ? ' (required)' : ''
+    out(`  --${n}${type ? ' <' + type + '>' : ''}${req}   ${firstLine(p.description || '')}`)
+  }
+}
+
+// ---- util -----------------------------------------------------------------
+
+function firstLine(s) {
+  return (s || '').split('\n')[0]
+}
+function out(s) {
+  process.stdout.write(s + '\n')
+}
+function fail(msg) {
+  process.stderr.write(BIN + ': ' + msg + '\n')
+  process.exit(1)
+}
+
+main().catch((e) => fail(e && e.stack ? e.stack : String(e)))

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -9,7 +9,7 @@ import { describe, it, expect } from 'vitest'
  * against drift — if they diverge, one binary would lag behind a shim fix.
  * Add a new copy here whenever a new `alice-*` export ships.
  */
-const EXPORT_BINARIES = ['alice', 'alice-workspace']
+const EXPORT_BINARIES = ['alice', 'alice-workspace', 'traderhub']
 
 const read = (name: string) =>
   readFileSync(fileURLToPath(new URL(`bin/${name}`, import.meta.url)))

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -48,12 +48,12 @@ describe('resolveInjection (toolAccess)', () => {
     const t = makeTemplate({ injectMcp: true, bundledSkills: ['scan-value-chain'] });
     const r = resolveInjection(t, 'cli');
     expect(r.injectMcp).toBe('inbox');
-    expect(r.bundledSkills).toEqual(['scan-value-chain', 'openalice-cli']);
+    expect(r.bundledSkills).toEqual(['scan-value-chain', 'openalice-cli', 'traderhub']);
   });
 
   it('cli mode does not duplicate an already-present openalice-cli', () => {
     const t = makeTemplate({ injectMcp: true, bundledSkills: ['openalice-cli'] });
-    expect(resolveInjection(t, 'cli').bundledSkills).toEqual(['openalice-cli']);
+    expect(resolveInjection(t, 'cli').bundledSkills).toEqual(['openalice-cli', 'traderhub']);
   });
 
   it('a non-injectable template (injectMcp false) ignores toolAccess', () => {

--- a/src/workspaces/context-injector.ts
+++ b/src/workspaces/context-injector.ts
@@ -61,8 +61,8 @@ const MCP_JSON_INBOX_ONLY = `{
 /** Launcher-level option: where the agent reaches Alice's data tools. */
 export type ToolAccess = 'mcp' | 'cli';
 
-/** The launcher-level skill teaching the `alice` CLI; added in CLI mode. */
-const CLI_TOOLS_SKILL = 'openalice-cli';
+/** Launcher-level skills teaching the CLIs (`alice*` + `traderhub`); added in CLI mode. */
+const CLI_TOOLS_SKILLS = ['openalice-cli', 'traderhub'];
 
 /**
  * Resolve a template's injection config against the launcher-level `toolAccess`
@@ -75,10 +75,8 @@ const CLI_TOOLS_SKILL = 'openalice-cli';
 export function resolveInjection(template: TemplateMeta, toolAccess: ToolAccess): TemplateMeta {
   if (template.injectMcp !== true) return template;
   if (toolAccess !== 'cli') return template;
-  const bundledSkills = template.bundledSkills.includes(CLI_TOOLS_SKILL)
-    ? template.bundledSkills
-    : [...template.bundledSkills, CLI_TOOLS_SKILL];
-  return { ...template, injectMcp: 'inbox', bundledSkills };
+  const missing = CLI_TOOLS_SKILLS.filter((skill) => !template.bundledSkills.includes(skill));
+  return { ...template, injectMcp: 'inbox', bundledSkills: [...template.bundledSkills, ...missing] };
 }
 
 export async function injectWorkspaceContext(opts: {

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -1,33 +1,38 @@
 # Chat workspace
 
 OpenAlice's market/data tools are available here — reachable through the
-OpenAlice MCP server and/or the `alice` CLI on your shell PATH, depending on how
+OpenAlice MCP server and/or the CLIs on your shell PATH, depending on how
 this workspace was launched. Check what's actually wired before you start:
 
 - `/mcp` — shows the connected OpenAlice MCP server(s)
-- `alice --help` — lists the CLI command groups (when `alice` is on PATH)
+- `traderhub --help` / `alice --help` — the CLI command groups (when on PATH)
 
 Use whichever is available; if a data tool isn't where you expect, check the
 other. Trading and scheduling stay on MCP by design.
 
-## OpenAlice CLIs (`alice`, `alice-workspace`)
+## OpenAlice CLIs (`traderhub`, `alice`, `alice-workspace`)
 
-Two CLIs on your shell PATH, split by what they touch — handy for a quick
+Three CLIs on your shell PATH, split by what they touch — handy for a quick
 lookup, a pipe, or a grep without a tool round-trip:
 
 ```bash
-alice --help                       # MARKET DATA: news/market/equity/economy/analysis/think
-alice market search --query AAPL   # find a symbol
+traderhub --help                   # LOW-FREQUENCY MARKET DATA: boards, fundamentals,
+                                   #   macro series, calendars, ETF, shipping, Fed
+traderhub board get --board macro  # a finished board in one call
+traderhub equity profile --symbol AAPL
+
+alice --help                       # WORKBENCH: news/market-search/analysis/think
+alice market search --query AAPL   # find a symbol (barIds for charts/quant)
 alice news grep --pattern BTC      # search collected news, then…
 alice news read --id <id>          # …read one article by its stable id
 
 alice-workspace --help             # COLLABORATION: inbox push + entity tracking
 ```
 
-Both hit the same backend the MCP tools do. Output is JSON on stdout; a non-zero
+All hit the same backend the MCP tools do. Output is JSON on stdout; a non-zero
 exit means it failed. (If this workspace has no `openalice` MCP tool server, the
-`alice*` CLIs are how you reach OpenAlice — the bundled `openalice-cli` skill is
-the full playbook.)
+CLIs are how you reach OpenAlice — the bundled `traderhub` and `openalice-cli`
+skills are the full playbooks.)
 
 ## Handing work back to the user
 

--- a/src/workspaces/templates/finance-research/files/instruction.md
+++ b/src/workspaces/templates/finance-research/files/instruction.md
@@ -25,7 +25,7 @@ See `.openalice-finance-info` for the exact upstream commit and the actual list 
 
 This workspace gives you **two market-data surfaces** that overlap. Use them deliberately:
 
-1. **OpenAlice's own MCP tools** (`/mcp` → `openalice`) — quotes, fundamentals, indicators, news. These are the **Alice canonical layer** wired to FMP / typebb / OpenBB. **Use these when a number will inform a trading decision** (UTA, position sizing, order routing) so the data口径 stays consistent with what Alice's trading engine sees.
+1. **OpenAlice's own MCP tools** (`/mcp` → `openalice`) — quotes, fundamentals, indicators, news. These are the **Alice canonical layer**: low-frequency data is served hub-first from the hosted TraderHub with the instance's own provider keys as fallback. **Use these when a number will inform a trading decision** (UTA, position sizing, order routing) so the data口径 stays consistent with what Alice's trading engine sees.
 2. **finance-skills** — yfinance, Funda AI, opencli, social readers. **Use these to cover angles Alice doesn't ship** (Yahoo Finance historical depth, SaaS valuation compression, social sentiment, peer-screened correlation studies, etc.).
 
 Don't cross the streams: don't quote yfinance to make a UTA order routing call. Don't quote Alice's MCP to do a Twitter sentiment scan.
@@ -34,7 +34,7 @@ Don't cross the streams: don't quote yfinance to make a UTA order routing call. 
 
 `.mcp.json` points at OpenAlice's MCP server (`http://127.0.0.1:47332/mcp` by default, or `$OPENALICE_MCP_URL`). The full OpenAlice tool surface — trading, market data, news, indicators — is available alongside the bundled skills.
 
-The same **Alice canonical layer** is also on your shell PATH as the `alice` CLI (`alice --help`, `alice market search --query AAPL`, `alice news grep --pattern …` → `alice news read --id …`). Use it for quick scripted lookups — it's the same data口径 as the `openalice` MCP tools (trading/cron stay MCP-only).
+The same **Alice canonical layer** is also on your shell PATH as CLIs: `traderhub` for low-frequency market data (`traderhub board get --board macro`, `traderhub equity profile --symbol AAPL` — see the `traderhub` skill) and `alice` for workbench surfaces (`alice market search --query AAPL`, `alice news grep --pattern …` → `alice news read --id …`). Same data口径 as the `openalice` MCP tools (trading/cron stay MCP-only).
 
 To verify on first attach:
 


### PR DESCRIPTION
## Summary
- The sectorRotation MCP/CLI tool was the one injection surface still bypassing the hub: agents triggered 12 fresh Yahoo history fetches per call while the UI route served the hub board. The tool now resolves hub → local exactly like the route, and returns `meta.origin` so agents see provenance too.

## Test plan
- [x] `npx tsc --noEmit` clean, `pnpm test` 1804 green

## Boundary touch
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)