### PR TITLE
fix(remote-access): same-origin PTY WS upgrade + trusted-proxy-gated X-Forwarded-* trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,66 @@ for how to retrieve the first-run token from `docker logs`.
   Debians don't have, and workspace bootstrap scripts need `bash` + POSIX
   utils. Alpine doesn't qualify on either count (musl libc, no bash).
 
+## Remote access (Tailscale / LAN / reverse proxy)
+
+Once the bind + admin token basics are in place, OpenAlice works over
+any network path. Ordered from most to least recommended:
+
+**Tailscale / VPN / LAN — direct.** Bind a non-loopback interface and
+log in with the admin token. No origin configuration needed: the UI,
+the API, and the workspace PTY WebSocket all accept same-origin
+requests regardless of which host you reached them through — a LAN IP,
+a Tailscale IP, a MagicDNS name.
+
+```bash
+OPENALICE_BIND_HOST=0.0.0.0 node dist/main.js   # the Docker image already binds 0.0.0.0
+```
+
+Then open `http://<machine-ip-or-tailnet-name>:47331` and paste the
+admin token. Tailscale Serve also works (and gives you HTTPS for free) —
+point it at `127.0.0.1:47331` and you don't even need to change the bind.
+
+**Reverse proxy (Caddy / nginx) — for HTTPS or a domain.** Terminate
+TLS at the proxy and tell Alice which peer to trust:
+
+```bash
+OPENALICE_TRUSTED_PROXIES=127.0.0.1   # the proxy's IP, as Alice sees it
+```
+
+Two things to know:
+
+- Setting `OPENALICE_TRUSTED_PROXIES` disables the localhost bypass —
+  required, since every request now arrives from the proxy's IP. It also
+  makes Alice honor `X-Forwarded-Proto` / `X-Forwarded-For` from that
+  peer (and only that peer).
+- The proxy must pass through `Host`, the WebSocket `Upgrade` headers,
+  and `X-Forwarded-Proto` (so the session cookie is marked `Secure`).
+  Caddy's `reverse_proxy` does all three out of the box. For nginx:
+
+  ```nginx
+  location / {
+    proxy_pass http://127.0.0.1:47331;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+  ```
+
+**Public internet.** Mechanically the same as the reverse-proxy setup,
+but think twice: this is a trading workbench holding broker
+credentials. Prefer keeping it inside a tailnet/VPN; if you do expose
+it, HTTPS is non-negotiable and proxy-level auth (basic auth, OAuth
+proxy, client certs) in front of Alice's own token gate is worth the
+extra step.
+
+**Cross-origin topologies** (UI served from a different origin than the
+backend — none of the setups above need this): allowlist the UI's
+origin explicitly with `WEB_TERMINAL_ALLOWED_ORIGINS=<origin>[,…]` for
+the PTY WebSocket and `OPENALICE_CSRF_TRUSTED_ORIGINS=<origin>[,…]` for
+mutating API calls.
+
 ## Configuration
 
 All config lives in `data/config/` as JSON files with Zod validation. Missing files fall back to sensible defaults. You can edit these files directly or use the Web UI.

--- a/safe/playbooks/07-websocket-auth.md
+++ b/safe/playbooks/07-websocket-auth.md
@@ -114,9 +114,15 @@ in.
   6-character workspace SIDs. Unauth attackers can't reach the upgrade
   path now, but an authenticated curious user could enumerate. Sessions
   should be ≥128-bit entropy if we plan multi-user later.
-- **Origin header on upgrade**: handler already rejects non-allowlisted
-  Origins (`isOriginAllowed`). Verify this fires before auth (it should,
-  to leak less).
+- **Origin header on upgrade**: handler rejects cross-origin browsers
+  before auth (`isWsOriginAllowed`, unit-specced in
+  `src/webui/workspaces-ws.spec.ts`). Same-origin — Origin host equal
+  to the Host header — is always allowed (2026-06-11; previously a
+  static localhost-only allowlist, which broke documented LAN/Tailscale
+  self-hosting). A browser's Origin is not forgeable from a foreign
+  page, so same-origin acceptance admits exactly the pages Alice served
+  itself; the `WEB_TERMINAL_ALLOWED_ORIGINS` allowlist covers
+  cross-origin topologies.
 - **Slowloris on upgrade**: holding an upgrade handshake open without
   finishing — Node default timeouts should kill, but verify.
 

--- a/src/webui/middleware/auth.ts
+++ b/src/webui/middleware/auth.ts
@@ -118,10 +118,20 @@ export function createAuthMiddleware(opts: AuthMiddlewareOptions): MiddlewareHan
 }
 
 /** Extracts the Node socket-level remote address from the Hono context. */
-function getSocketRemoteAddress(c: Context): string | undefined {
+export function getSocketRemoteAddress(c: Context): string | undefined {
   // @hono/node-server exposes the raw Node IncomingMessage as c.env.incoming
   const env = c.env as { incoming?: { socket?: { remoteAddress?: string } } } | undefined
   return env?.incoming?.socket?.remoteAddress
+}
+
+/**
+ * Normalize an IP literal for comparison: strip the IPv6 zone suffix
+ * (fe80::1%eth0 → fe80::1) and unwrap IPv4-mapped IPv6
+ * (::ffff:10.0.0.5 → 10.0.0.5).
+ */
+export function normalizeIp(ip: string): string {
+  const cleaned = ip.split('%')[0]
+  return cleaned.startsWith('::ffff:') ? cleaned.slice(7) : cleaned
 }
 
 /**
@@ -130,10 +140,7 @@ function getSocketRemoteAddress(c: Context): string | undefined {
  */
 export function isLoopbackIp(ip: string): boolean {
   if (!ip) return false
-  // Strip IPv6 zone suffix (fe80::1%eth0 → fe80::1)
-  const cleaned = ip.split('%')[0]
-  // IPv4-mapped IPv6
-  const norm = cleaned.startsWith('::ffff:') ? cleaned.slice(7) : cleaned
+  const norm = normalizeIp(ip)
   if (norm === '::1') return true
   // IPv4 — accept the entire 127.0.0.0/8 range, not just 127.0.0.1
   if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(norm)) return true

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -160,7 +160,7 @@ export class WebPlugin implements Plugin {
     const csrfTrustedOrigins = (process.env['OPENALICE_CSRF_TRUSTED_ORIGINS'] ?? '')
       .split(',').map((s) => s.trim()).filter(Boolean)
     const authDisabled = process.env['OPENALICE_DISABLE_AUTH'] === '1'
-    app.route('/api/auth', createAuthRoutes())
+    app.route('/api/auth', createAuthRoutes({ trustedProxies }))
     app.use('*', createAuthMiddleware({
       trustedProxies,
       csrfTrustedOrigins,

--- a/src/webui/routes/auth.spec.ts
+++ b/src/webui/routes/auth.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Auth route tests — focused on the session-cookie `Secure` flag and
+ * X-Forwarded-* trust gating in /api/auth/login.
+ *
+ * The rule under test: forwarded headers are honored only when the
+ * socket peer is a configured trusted proxy. Otherwise any client could
+ * send `X-Forwarded-Proto: https` over plain HTTP and coerce a `Secure`
+ * cookie the browser would then drop (login appears broken).
+ *
+ * `verifyToken` is mocked so these tests don't write data/config/auth.json
+ * (token-store.spec.ts owns that file; parallel workers would race).
+ * Sessions go to a private temp file via the OPENALICE_SESSIONS_FILE seam.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Hono } from 'hono'
+
+vi.mock('@/services/auth/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/auth/index.js')>()
+  return {
+    ...actual,
+    verifyToken: vi.fn(async (token: string) => token === 'test-admin-token'),
+  }
+})
+
+import { createAuthRoutes, type AuthRouteOptions } from './auth.js'
+import { _reset, revokeAllSessions } from '@/services/auth/session-store.js'
+
+let tmpDir: string
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'oa-auth-routes-'))
+  process.env['OPENALICE_SESSIONS_FILE'] = join(tmpDir, 'sessions.json')
+})
+
+afterAll(async () => {
+  delete process.env['OPENALICE_SESSIONS_FILE']
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+beforeEach(async () => {
+  await _reset()
+  await revokeAllSessions()
+})
+
+function makeApp(opts: AuthRouteOptions = {}) {
+  const app = new Hono()
+  app.route('/api/auth', createAuthRoutes(opts))
+  return app
+}
+
+function envWithIp(ip: string) {
+  return { incoming: { socket: { remoteAddress: ip } } }
+}
+
+async function login(
+  app: Hono,
+  ip: string,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return app.request('/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify({ token: 'test-admin-token' }),
+  }, envWithIp(ip))
+}
+
+describe('login cookie Secure flag — X-Forwarded-Proto trust gating', () => {
+  it('XFP https from a non-proxy peer is ignored → cookie NOT Secure', async () => {
+    const app = makeApp({ trustedProxies: [] })
+    const res = await login(app, '203.0.113.5', { 'x-forwarded-proto': 'https' })
+    expect(res.status).toBe(200)
+    const cookie = res.headers.get('set-cookie') ?? ''
+    expect(cookie).toContain('alice_session=')
+    expect(cookie).not.toMatch(/;\s*Secure/i)
+  })
+
+  it('XFP https from the trusted proxy → cookie Secure', async () => {
+    const app = makeApp({ trustedProxies: ['10.0.0.5'] })
+    const res = await login(app, '10.0.0.5', { 'x-forwarded-proto': 'https' })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('set-cookie') ?? '').toMatch(/;\s*Secure/i)
+  })
+
+  it('trusted proxy peer matches IPv4-mapped IPv6 socket address', async () => {
+    const app = makeApp({ trustedProxies: ['10.0.0.5'] })
+    const res = await login(app, '::ffff:10.0.0.5', { 'x-forwarded-proto': 'https' })
+    expect(res.headers.get('set-cookie') ?? '').toMatch(/;\s*Secure/i)
+  })
+
+  it('XFP https from an untrusted peer while a proxy IS configured → NOT Secure', async () => {
+    const app = makeApp({ trustedProxies: ['10.0.0.5'] })
+    const res = await login(app, '203.0.113.5', { 'x-forwarded-proto': 'https' })
+    expect(res.headers.get('set-cookie') ?? '').not.toMatch(/;\s*Secure/i)
+  })
+
+  it('trusted proxy without XFP (plain-HTTP upstream) → NOT Secure', async () => {
+    const app = makeApp({ trustedProxies: ['10.0.0.5'] })
+    const res = await login(app, '10.0.0.5')
+    expect(res.headers.get('set-cookie') ?? '').not.toMatch(/;\s*Secure/i)
+  })
+
+  it('forceSecureCookie: true overrides detection', async () => {
+    const app = makeApp({ forceSecureCookie: true })
+    const res = await login(app, '203.0.113.5')
+    expect(res.headers.get('set-cookie') ?? '').toMatch(/;\s*Secure/i)
+  })
+
+  it('wrong token still 401s (mock sanity check)', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/auth/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'wrong' }),
+    }, envWithIp('203.0.113.5'))
+    expect(res.status).toBe(401)
+    expect(res.headers.get('set-cookie')).toBeNull()
+  })
+})

--- a/src/webui/routes/auth.ts
+++ b/src/webui/routes/auth.ts
@@ -9,7 +9,7 @@
  * round-trip. It reveals nothing beyond `{ authed: boolean }`.
  */
 
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { setCookie, deleteCookie } from 'hono/cookie'
 import { z } from 'zod'
 import {
@@ -19,7 +19,12 @@ import {
   validateAndTouch,
   getTokenInfo,
 } from '@/services/auth/index.js'
-import { SESSION_COOKIE_NAME, isLoopbackIp } from '../middleware/auth.js'
+import {
+  SESSION_COOKIE_NAME,
+  isLoopbackIp,
+  normalizeIp,
+  getSocketRemoteAddress,
+} from '../middleware/auth.js'
 
 const loginSchema = z.object({
   token: z.string().min(1, 'token is required'),
@@ -27,13 +32,22 @@ const loginSchema = z.object({
 
 export interface AuthRouteOptions {
   /** Should `Set-Cookie` mark the session cookie `Secure`? Set true in
-   *  prod (HTTPS behind reverse proxy). Auto-detected from headers when
-   *  not provided. */
+   *  prod (HTTPS behind reverse proxy). Auto-detected from
+   *  X-Forwarded-Proto when not provided — but only for requests
+   *  arriving from a trusted proxy. */
   forceSecureCookie?: boolean
+  /** Trusted reverse-proxy IPs. X-Forwarded-* headers are honored only
+   *  when the request's socket peer is one of these — otherwise any
+   *  client could send `X-Forwarded-Proto: https` over plain HTTP and
+   *  coerce a `Secure` cookie the browser would then silently drop
+   *  (login appears broken). Same list as the middleware's
+   *  `trustedProxies`. */
+  trustedProxies?: string[]
 }
 
 export function createAuthRoutes(opts: AuthRouteOptions = {}) {
   const app = new Hono()
+  const trustedProxies = new Set((opts.trustedProxies ?? []).map(normalizeIp))
 
   /**
    * Returns whether the current request is authenticated, plus minimal
@@ -47,11 +61,8 @@ export function createAuthRoutes(opts: AuthRouteOptions = {}) {
     // loopback socket, report authed:true even without a cookie. This
     // keeps `pnpm dev` zero-friction — the UI never bounces to the
     // login page in single-user local mode.
-    const trustedProxies = (process.env['OPENALICE_TRUSTED_PROXIES'] ?? '')
-      .split(',').map((s) => s.trim()).filter(Boolean)
-    if (trustedProxies.length === 0) {
-      const env = c.env as { incoming?: { socket?: { remoteAddress?: string } } } | undefined
-      const remote = env?.incoming?.socket?.remoteAddress ?? ''
+    if (trustedProxies.size === 0) {
+      const remote = getSocketRemoteAddress(c) ?? ''
       if (isLoopbackIp(remote)) {
         return c.json({ authed: true, tokenConfigured: tokenInfo.exists, passthrough: 'localhost' })
       }
@@ -96,11 +107,12 @@ export function createAuthRoutes(opts: AuthRouteOptions = {}) {
       return c.json({ error: 'Invalid token' }, 401)
     }
 
+    const fromTrustedProxy = isTrustedProxyPeer(c, trustedProxies)
     const userAgent = c.req.header('user-agent') ?? undefined
-    const ip = readClientIp(c) ?? undefined
+    const ip = readClientIp(c, fromTrustedProxy) ?? undefined
     const session = await createSession({ userAgent, ip })
 
-    const secure = opts.forceSecureCookie ?? isLikelyHttps(c)
+    const secure = opts.forceSecureCookie ?? (fromTrustedProxy && isForwardedHttps(c))
     setCookie(c, SESSION_COOKIE_NAME, session.sid, {
       httpOnly: true,
       sameSite: 'Lax',
@@ -140,26 +152,30 @@ function readSidFromCookie(cookieHeader: string): string | null {
   return null
 }
 
-/**
- * Best-effort: detect whether the original client request was HTTPS,
- * so the `Secure` flag can be set on the cookie. Reverse proxies set
- * `X-Forwarded-Proto`; we only trust it if a proxy IP is configured to
- * be trusted — otherwise an attacker could send `X-Forwarded-Proto: https`
- * to coerce `Secure` to be set on an HTTP cookie that the browser
- * would then drop.
- */
-function isLikelyHttps(c: { req: { header: (n: string) => string | undefined }; env?: unknown }): boolean {
-  const proto = c.req.header('x-forwarded-proto')
-  if (proto?.split(',')[0]?.trim().toLowerCase() === 'https') return true
-  return false
+/** True when the request's socket peer is one of the trusted proxy IPs. */
+function isTrustedProxyPeer(c: Context, trustedProxies: ReadonlySet<string>): boolean {
+  if (trustedProxies.size === 0) return false
+  const remote = getSocketRemoteAddress(c)
+  return remote ? trustedProxies.has(normalizeIp(remote)) : false
 }
 
-function readClientIp(c: { req: { header: (n: string) => string | undefined }; env?: unknown }): string | null {
-  const xff = c.req.header('x-forwarded-for')
-  if (xff) {
-    const first = xff.split(',')[0]?.trim()
+/**
+ * Whether the trusted proxy says the original client request was HTTPS.
+ * Only call after `isTrustedProxyPeer` — from any other peer the header
+ * is attacker-controlled (see AuthRouteOptions.trustedProxies). Without
+ * a proxy in front there is no TLS terminator, the connection is plain
+ * HTTP, and `Secure` must not be set.
+ */
+function isForwardedHttps(c: Context): boolean {
+  const proto = c.req.header('x-forwarded-proto')
+  return proto?.split(',')[0]?.trim().toLowerCase() === 'https'
+}
+
+function readClientIp(c: Context, fromTrustedProxy: boolean): string | null {
+  if (fromTrustedProxy) {
+    const xff = c.req.header('x-forwarded-for')
+    const first = xff?.split(',')[0]?.trim()
     if (first) return first
   }
-  const env = c.env as { incoming?: { socket?: { remoteAddress?: string } } } | undefined
-  return env?.incoming?.socket?.remoteAddress ?? null
+  return getSocketRemoteAddress(c) ?? null
 }

--- a/src/webui/workspaces-ws.spec.ts
+++ b/src/webui/workspaces-ws.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Origin gate for the PTY WebSocket upgrade — unit tests for
+ * `isWsOriginAllowed`. The upgrade path itself is event-driven on
+ * `http.Server` and is exercised via integration (see
+ * safe/playbooks/07-websocket-auth.md); the origin decision is pure
+ * and testable here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isWsOriginAllowed } from './workspaces-ws.js';
+
+function cfg(origins: string[] = [], allowAnyOrigin = false) {
+  return { allowAnyOrigin, allowedOrigins: new Set(origins) };
+}
+
+describe('isWsOriginAllowed', () => {
+  it('allows same-origin via a LAN / Tailscale IP (the #upgrade.origin_rejected case)', () => {
+    expect(isWsOriginAllowed('http://100.64.1.2:47331', '100.64.1.2:47331', cfg())).toBe(true);
+    expect(isWsOriginAllowed('http://192.168.1.50:47331', '192.168.1.50:47331', cfg())).toBe(true);
+  });
+
+  it('allows same-origin via a domain (reverse proxy forwarding Host)', () => {
+    expect(isWsOriginAllowed('https://alice.example.com', 'alice.example.com', cfg())).toBe(true);
+  });
+
+  it('rejects cross-origin even when auth would pass', () => {
+    expect(isWsOriginAllowed('http://evil.example.com', '100.64.1.2:47331', cfg())).toBe(false);
+  });
+
+  it('rejects same host but different port (true cross-origin)', () => {
+    expect(isWsOriginAllowed('http://100.64.1.2:9999', '100.64.1.2:47331', cfg())).toBe(false);
+  });
+
+  it('still honors the static allowlist for cross-origin topologies (Vite dev)', () => {
+    const c = cfg(['http://localhost:5173']);
+    expect(isWsOriginAllowed('http://localhost:5173', 'localhost:47331', c)).toBe(true);
+  });
+
+  it('allows missing Origin (non-browser callers; auth still gates)', () => {
+    expect(isWsOriginAllowed(undefined, 'localhost:47331', cfg())).toBe(true);
+    expect(isWsOriginAllowed('', 'localhost:47331', cfg())).toBe(true);
+  });
+
+  it('rejects unparseable Origin (including the literal "null" from sandboxed iframes)', () => {
+    expect(isWsOriginAllowed('null', 'localhost:47331', cfg())).toBe(false);
+    expect(isWsOriginAllowed('not a url', 'localhost:47331', cfg())).toBe(false);
+  });
+
+  it('rejects cross-origin when Host header is absent', () => {
+    expect(isWsOriginAllowed('http://100.64.1.2:47331', undefined, cfg())).toBe(false);
+  });
+
+  it('wildcard allowAnyOrigin admits everything', () => {
+    expect(isWsOriginAllowed('http://evil.example.com', 'localhost:47331', cfg([], true))).toBe(true);
+  });
+});

--- a/src/webui/workspaces-ws.ts
+++ b/src/webui/workspaces-ws.ts
@@ -158,11 +158,38 @@ export function attachWorkspacesWS(httpServer: HttpServer, svc: WorkspaceService
 }
 
 function isOriginAllowed(req: IncomingMessage, svc: WorkspaceService): boolean {
-  const cfg = svc.config;
+  return isWsOriginAllowed(req.headers.origin, req.headers.host, svc.config);
+}
+
+/**
+ * Origin gate for the PTY WS upgrade. Mirrors the HTTP middleware's CSRF
+ * rule (`isAllowedOrigin` in middleware/auth.ts): a same-origin request —
+ * Origin host equal to the Host the browser actually connected to — is
+ * always allowed, so direct access through any bind (LAN IP, Tailscale
+ * IP, a domain) works without configuration. A browser's Origin is not
+ * forgeable from a foreign page, so this admits exactly the pages we
+ * served ourselves. The static allowlist covers cross-origin topologies
+ * (Vite dev on 5173, future cloud demo) and stays env-extensible via
+ * WEB_TERMINAL_ALLOWED_ORIGINS.
+ */
+export function isWsOriginAllowed(
+  origin: string | undefined,
+  host: string | undefined,
+  cfg: { readonly allowAnyOrigin: boolean; readonly allowedOrigins: ReadonlySet<string> },
+): boolean {
   if (cfg.allowAnyOrigin) return true;
-  const origin = req.headers.origin;
+  // Non-browser callers (websocat, CLI tooling) send no Origin — allowed
+  // here; the auth gate still applies.
   if (typeof origin !== 'string' || origin.length === 0) return true;
-  return cfg.allowedOrigins.has(origin);
+  if (cfg.allowedOrigins.has(origin)) return true;
+  if (host) {
+    try {
+      return new URL(origin).host === host;
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }
 
 function clampQuery(raw: string | null, fallback: number, lo: number, hi: number): number {


### PR DESCRIPTION
## Summary
- **Fixes the community-reported Tailscale/LAN self-hosting breakage** (`upgrade.origin_rejected`): the PTY WebSocket origin gate was a static localhost-only allowlist; now it accepts same-origin upgrades (Origin host == Host header), mirroring the HTTP middleware's CSRF rule. Any direct bind — LAN IP, Tailscale IP, domain — works with zero config; cross-origin still 403s.
- **X-Forwarded-Proto / X-Forwarded-For are now only honored from a configured trusted proxy** (`OPENALICE_TRUSTED_PROXIES`). Previously trusted unconditionally, contradicting the in-code comment and playbook 03 — any client could coerce a `Secure` cookie over plain HTTP and break login.
- New README **"Remote access"** section: Tailscale/VPN/LAN direct (recommended), reverse-proxy recipe (nginx header block; Caddy works out of the box), public-internet caveats, cross-origin env vars (`WEB_TERMINAL_ALLOWED_ORIGINS`, `OPENALICE_CSRF_TRUSTED_ORIGINS`).
- Playbook 07 updated to the new origin contract; new unit specs for both behaviors.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` passes (113 files / 1820 tests, incl. new `workspaces-ws.spec.ts` + `routes/auth.spec.ts`)
- [x] End-to-end on a real non-loopback path (same code path as Tailscale): bound `0.0.0.0`, browser via LAN IP `192.168.31.49:47331` → admin-token login → resumed a paused workspace session → WS upgrade accepted, received `{"type":"attached",pid:…}` from the live claude PTY
- [x] Negative control: forged `Origin: http://evil.example.com` upgrade → `403` + `upgrade.origin_rejected` log

## Boundary touch
Auth boundary: WS origin gate semantics (same-origin acceptance — browser Origin is not forgeable from a foreign page, so this admits exactly pages Alice served itself) and forwarded-header trust (strictly narrowed, never widened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)