### PR TITLE
Global data root (~/.openalice) + sealed broker credentials

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,9 +275,24 @@ ui/                            # React frontend (Vite). auth/ holds the
                                # login gate; lives outside `src/` because
                                # it ships separately.
 
-data/                          # All persistent state (gitignored).
-                               # config/, sessions/, trading/, control/
-                               # (UTA restart flag), backups, etc.
+data/                          # All persistent state. Lives at
+                               # ~/.openalice/data by default — ONE global
+                               # store shared by pnpm dev / pnpm start /
+                               # the packaged app (configure brokers once,
+                               # not per checkout). OPENALICE_HOME overrides
+                               # the root: Docker sets /data; use
+                               # OPENALICE_HOME="$PWD" pnpm dev to pin a
+                               # checkout-local store when an experimental
+                               # branch shouldn't touch real data (its
+                               # migrations run against the real store
+                               # otherwise!). accounts.json is sealed at
+                               # rest (src/core/sealing.ts; key at
+                               # ~/.openalice/sealing.key, outside data/).
+                               # e2e suites read broker creds from the
+                               # global store — adopt a legacy checkout's
+                               # data/ first (the dev banner shows the mv).
+                               # Layout: config/, sessions/, trading/,
+                               # control/ (UTA restart flag), backups, etc.
 ```
 
 ## Key Architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,6 @@ COPY --from=build /src/scripts                    ./scripts
 # auth tokens + agent state persist across container rebuild.
 ENV OPENALICE_APP_HOME=/app \
     OPENALICE_HOME=/data \
-    OPENALICE_USER_DATA_HOME=/data \
     AQ_LAUNCHER_ROOT=/data/workspaces \
     HOME=/data/home \
     NODE_ENV=production \

--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ login screen on first browser visit, the session cookie lasts 7 days.
 docker logs openalice 2>&1 | grep -A1 'admin token'
 ```
 
-**Rotate the token** — delete `data/config/auth.json` and restart. The
+**Rotate the token** — delete `~/.openalice/data/config/auth.json` (in
+Docker: `<volume>/data/config/auth.json`) and restart. The
 next boot prints a fresh token and revokes all existing sessions.
 
 **Escape hatch** — `OPENALICE_DISABLE_AUTH=1` turns the gate off. Only
@@ -466,7 +467,7 @@ mutating API calls.
 
 ## Configuration
 
-All config lives in `data/config/` as JSON files with Zod validation. Missing files fall back to sensible defaults. You can edit these files directly or use the Web UI.
+All config lives in `~/.openalice/data/config/` as JSON files with Zod validation — one global store shared by dev checkouts and the desktop app (the `OPENALICE_HOME` env var overrides the root; Docker uses the mounted volume). Missing files fall back to sensible defaults. You can edit these files directly or use the Web UI — except `accounts.json`, which is sealed (encrypted at rest) and managed through the UI.
 
 **AI Provider** — The model runs inside the workspace CLI using its own login — e.g. your local Claude Code or Codex login, no API key needed. For api-key providers (Anthropic, OpenAI, Google, GLM, MiniMax, Kimi, DeepSeek, …), add credentials in the Web UI's **AI Provider** vault; each credential declares the wire shapes it speaks and gets injected into workspaces, picking the shape the target agent uses. Subscription logins stay in the CLI.
 
@@ -488,9 +489,9 @@ All config lives in `data/config/` as JSON files with Zod validation. Missing fi
 
 The persona prompt uses a **default + user override** pattern:
 
-| Default (git-tracked) | User override (gitignored) |
+| Default (git-tracked) | User override |
 |------------------------|---------------------------|
-| `default/persona.default.md` | `data/brain/persona.md` |
+| `default/persona.default.md` | `~/.openalice/data/brain/persona.md` |
 
 On first run, defaults are auto-copied to the user override path. Edit the user files to customize without touching version control.
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -19,12 +19,14 @@
  * graceful-shutdown UX polish, multi-window, native menu integration.
  */
 
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, dialog } from 'electron'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
-import { dirname, resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import { probeFreePort } from './probe-port.js'
+import { relocateLegacyData } from './relocate-data.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -122,23 +124,41 @@ app.whenReady().then(async () => {
   const backendEntry = resolve(__dirname, '..', 'main.js')
 
   // Two homes — user data vs app resources. See src/core/paths.ts for why
-  // they're split. In packaged builds the OS-standard locations apply; in
-  // dev (pnpm electron:dev) we now invoke electron with cwd=apps/desktop/,
-  // so we pin both homes to the repo root explicitly — preserves the
-  // pre-split behavior where the backend fell back to process.cwd() and
-  // saw the working repo.
+  // they're split. User data lives at ~/.openalice in BOTH branches — one
+  // store shared with `pnpm dev` and bare `pnpm start`, so accounts are
+  // configured once, not per topology. App resources stay lifecycle-owned:
+  // .app/Contents/Resources when packaged, the repo in dev.
   const repoRoot = resolve(__dirname, '..', '..')
+  const userDataHome = join(homedir(), '.openalice')
   const homeEnv = app.isPackaged
     ? {
-        // ~/Library/Application Support/<productName>/ on macOS
-        OPENALICE_HOME: app.getPath('userData'),
+        OPENALICE_HOME: userDataHome,
         // .app/Contents/Resources/ — sibling of app.asar
         OPENALICE_APP_HOME: dirname(app.getAppPath()),
       }
     : {
-        OPENALICE_HOME: repoRoot,
+        OPENALICE_HOME: userDataHome,
         OPENALICE_APP_HOME: repoRoot,
       }
+
+  // Pre-global-root installs kept user data under Electron's userData dir.
+  // Move it once, BEFORE ports.json is read from the new root and before the
+  // backend boots (it would run migrations against an empty store). On
+  // failure: surface and quit — booting beside the user's real data would
+  // fork their trading history.
+  if (app.isPackaged) {
+    try {
+      await relocateLegacyData(app.getPath('userData'), userDataHome)
+    } catch (err) {
+      dialog.showErrorBox(
+        'OpenAlice — data relocation failed',
+        `Could not move the user data store from\n${app.getPath('userData')}/data\nto\n${userDataHome}/data\n\n` +
+          `${err instanceof Error ? err.message : String(err)}\n\nNothing was deleted. Please move the directory manually, then relaunch.`,
+      )
+      app.quit()
+      return
+    }
+  }
 
   // Port precedence: env (OPENALICE_*_PORT) > data/config/ports.json (under
   // the user-data home, same L1 file the dev/prod guardians read) > probe

--- a/apps/desktop/src/relocate-data.spec.ts
+++ b/apps/desktop/src/relocate-data.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { relocateLegacyData } from './relocate-data.js'
+
+describe('relocateLegacyData', () => {
+  let legacyRoot: string
+  let newRoot: string
+
+  beforeEach(async () => {
+    legacyRoot = await mkdtemp(join(tmpdir(), 'oa-legacy-'))
+    newRoot = await mkdtemp(join(tmpdir(), 'oa-new-'))
+    // mkdtemp creates newRoot itself; relocate must tolerate it existing
+    // while <newRoot>/data does not.
+  })
+
+  afterEach(async () => {
+    await rm(legacyRoot, { recursive: true, force: true })
+    await rm(newRoot, { recursive: true, force: true })
+  })
+
+  async function seedLegacyStore(): Promise<void> {
+    await mkdir(join(legacyRoot, 'data', 'config'), { recursive: true })
+    await writeFile(join(legacyRoot, 'data', 'config', 'accounts.json'), '[{"id":"x"}]')
+  }
+
+  it('moves the legacy data dir into the new root', async () => {
+    await seedLegacyStore()
+    const result = await relocateLegacyData(legacyRoot, newRoot)
+    expect(result).toBe('moved')
+    expect(await readFile(join(newRoot, 'data', 'config', 'accounts.json'), 'utf8')).toBe('[{"id":"x"}]')
+    expect(existsSync(join(legacyRoot, 'data'))).toBe(false)
+    expect(existsSync(join(legacyRoot, 'DATA-MOVED.txt'))).toBe(true)
+  })
+
+  it('no-ops when there is no legacy store', async () => {
+    expect(await relocateLegacyData(legacyRoot, newRoot)).toBe('skipped')
+    expect(existsSync(join(newRoot, 'data'))).toBe(false)
+  })
+
+  it('never clobbers an existing new store (new store wins)', async () => {
+    await seedLegacyStore()
+    await mkdir(join(newRoot, 'data', 'config'), { recursive: true })
+    await writeFile(join(newRoot, 'data', 'config', 'accounts.json'), '[{"id":"newer"}]')
+
+    expect(await relocateLegacyData(legacyRoot, newRoot)).toBe('skipped')
+    expect(await readFile(join(newRoot, 'data', 'config', 'accounts.json'), 'utf8')).toBe('[{"id":"newer"}]')
+    // legacy store untouched — user can still inspect/merge manually
+    expect(await readFile(join(legacyRoot, 'data', 'config', 'accounts.json'), 'utf8')).toBe('[{"id":"x"}]')
+  })
+
+  it('is idempotent across repeated boots', async () => {
+    await seedLegacyStore()
+    expect(await relocateLegacyData(legacyRoot, newRoot)).toBe('moved')
+    expect(await relocateLegacyData(legacyRoot, newRoot)).toBe('skipped')
+  })
+
+  it('sweeps a stale partial copy from a crashed previous run', async () => {
+    await seedLegacyStore()
+    await mkdir(join(newRoot, '.data.relocating'), { recursive: true })
+    await writeFile(join(newRoot, '.data.relocating', 'partial.json'), '{}')
+
+    expect(await relocateLegacyData(legacyRoot, newRoot)).toBe('moved')
+    expect(existsSync(join(newRoot, '.data.relocating'))).toBe(false)
+    expect(existsSync(join(newRoot, 'data', 'config', 'accounts.json'))).toBe(true)
+  })
+})

--- a/apps/desktop/src/relocate-data.ts
+++ b/apps/desktop/src/relocate-data.ts
@@ -1,0 +1,52 @@
+/**
+ * One-time relocation of the packaged app's user data store.
+ *
+ * Until the global-root change, the packaged backend kept user data under
+ * Electron's userData dir (~/Library/Application Support/OpenAlice/data on
+ * macOS). The user-data home is now ~/.openalice — shared with `pnpm dev`
+ * and bare `pnpm start` — so an existing store must move once, before the
+ * shell reads ports.json from the new root or spawns the backend (which
+ * would run migrations against an empty store).
+ *
+ * Scope: ONLY `<userData>/data` moves. userData also holds Electron's
+ * browser-profile state (Cache, Local Storage, …) which must stay.
+ *
+ * Crash safety:
+ *   - same-volume: a single rename — atomic, nothing to clean up.
+ *   - cross-volume (EXDEV): copy into `<newRoot>/.data.relocating`, then
+ *     rename into place. A crash mid-copy leaves only the tmp dir, which is
+ *     swept and re-copied on next boot; a crash after the commit rename is
+ *     absorbed by the idempotency guard. The legacy dir is kept as
+ *     `data.relocated` — never deleted, it's the user's trading history.
+ */
+
+import { existsSync } from 'node:fs'
+import { cp, mkdir, rename, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export async function relocateLegacyData(legacyRoot: string, newRoot: string): Promise<'moved' | 'skipped'> {
+  const legacyData = join(legacyRoot, 'data')
+  const newData = join(newRoot, 'data')
+  // Idempotent: nothing to move, or the new store already exists (in which
+  // case it wins — it may have newer state from a dev/pnpm-start session).
+  if (!existsSync(legacyData) || existsSync(newData)) return 'skipped'
+
+  await mkdir(newRoot, { recursive: true })
+  const tmp = join(newRoot, '.data.relocating')
+  await rm(tmp, { recursive: true, force: true }) // sweep a stale partial copy
+
+  try {
+    await rename(legacyData, newData) // atomic same-volume fast path
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err
+    await cp(legacyData, tmp, { recursive: true })
+    await rename(tmp, newData) // atomic commit
+    await rename(legacyData, `${legacyData}.relocated`) // keep as backup
+  }
+
+  await writeFile(
+    join(legacyRoot, 'DATA-MOVED.txt'),
+    `OpenAlice user data moved to ${newData} on ${new Date().toISOString()}\n`,
+  )
+  return 'moved'
+}

--- a/safe/knowledge/config-files.md
+++ b/safe/knowledge/config-files.md
@@ -18,7 +18,7 @@ auth implementation. `restart-uta.flag` already exists.
 
 | Path | Contents | Sensitivity |
 |---|---|---|
-| `data/config/accounts.json` | broker UTA configs — **including API keys & secrets** | **Critical** — direct broker theft |
+| `data/config/accounts.json` | broker UTA configs incl. API keys — **sealed** (AES-256-GCM envelope; key at `<userDataHome>/sealing.key`, outside `data/`) | **Critical** — needs file + key; key theft = direct broker theft |
 | `data/config/ai-provider-manager.json` | AI provider keys (Claude/OpenAI/Anthropic) | **High** — credential theft |
 | `data/config/connectors.json` | Telegram bot token + allowed chat IDs | **High** — bot impersonation |
 | `data/config/cron/jobs.json` | scheduled task definitions | **Medium** — silent code execution paths |
@@ -31,13 +31,10 @@ auth implementation. `restart-uta.flag` already exists.
 
 ## File permissions
 
-There's no explicit chmod in any OpenAlice code today. Files are written
-with whatever umask the process has — usually `644` (world-readable). For
-a self-host user on a multi-user host, **anyone with shell access to the
-host can read accounts.json plaintext** today.
-
-After auth lands, `auth.json` and `sessions.json` should be created with
-`600` (owner-only). This is an open finding.
+`auth.json`, `accounts.json`, and `sealing.key` are written `600`
+(owner-only, chmod re-applied best-effort for platforms that ignore the
+writeFile mode). Other config files are written with the process umask —
+usually `644` — but contain lower-sensitivity state.
 
 ## Sample `accounts.json` (sanitized)
 
@@ -64,9 +61,14 @@ After auth lands, `auth.json` and `sessions.json` should be created with
 ]
 ```
 
-`apiKey` and `apiSecret` are **plaintext**. There's no encryption-at-rest.
-The threat model accepts this (host root = game over anyway), but it does
-mean any read-primitive on this file = full broker compromise.
+That's the LOGICAL shape (what the API layer sees, masked over HTTP). At
+rest the file is a sealed envelope —
+`{"$sealed":1,"alg":"aes-256-gcm","iv":…,"tag":…,"data":…}` — keyed by
+`<userDataHome>/sealing.key` (deliberately outside the portable `data/`
+subtree). A read-primitive on the file alone no longer yields broker
+credentials; file + key does. Same-user code execution still equals
+compromise (the key is readable by design); the structural answer to that
+tier is the detached-UTA split, not at-rest crypto.
 
 ## Sample `ai-provider-manager.json` (sanitized)
 
@@ -94,9 +96,10 @@ Same situation — plaintext API keys.
 
 The base data directory is resolved by `src/core/paths.ts`:
 
-- In dev: `process.cwd()/data/` (i.e., the repo root)
-- In Docker: `OPENALICE_USER_DATA_HOME` env (default `/data`, the mounted volume)
-- In Electron (future): `app.getPath('userData')/data/`
+- Default (dev, bare `pnpm start`, Electron): `~/.openalice/data/` — one
+  global store shared across checkouts and the desktop app
+- Override: `OPENALICE_HOME` env (Docker sets `/data`;
+  `OPENALICE_HOME="$PWD"` pins a checkout-local store)
 
 An attacker who can convince OpenAlice to read or write a path **outside**
 its data root would have a serious primitive. The relevant functions to
@@ -113,8 +116,8 @@ audit:
 For static reconnaissance without changing anything:
 
 ```bash
-# What UTAs are configured?
-cat data/config/accounts.json | jq '[.[] | {id, presetId, enabled, mode: .presetConfig.mode}]'
+# What UTAs are configured? (file is sealed — use the masked HTTP surface)
+curl -s http://localhost:47331/api/trading/config/ | jq '.utas[] | {id, presetId, enabled}'
 
 # What broker preset types exist?
 curl -s http://localhost:47331/api/trading/config/broker-presets | jq '.presets[].id'
@@ -146,8 +149,8 @@ usually aren't — `data/` is `.gitignore`d).
 
 ## Out-of-tree paths
 
-The `OPENALICE_USER_DATA_HOME` env var (defaulting to `/data` in Docker,
-cwd in dev) controls the root. An attacker who can influence env vars
+The `OPENALICE_HOME` env var (defaulting to `~/.openalice`; `/data` in
+Docker) controls the root. An attacker who can influence env vars
 (e.g., via container escape or shell-level compromise) can redirect Alice
 to read/write a different `data/` tree.
 

--- a/scripts/guardian/dev.ts
+++ b/scripts/guardian/dev.ts
@@ -15,6 +15,8 @@
  */
 
 import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { existsSync } from 'node:fs'
 import type { ChildProcess } from 'node:child_process'
 import {
   readPortsFile,
@@ -29,7 +31,28 @@ import {
 } from './shared.js'
 
 async function main(): Promise<void> {
-  const dataHome = process.cwd()
+  // One global store by default (~/.openalice) — shared with the packaged
+  // app. `OPENALICE_HOME=$PWD pnpm dev` pins a checkout-local store for
+  // experiments that shouldn't touch real data.
+  const dataHome = process.env['OPENALICE_HOME'] ?? resolve(homedir(), '.openalice')
+
+  // Legacy adoption notice: this checkout has a pre-global-root data/ store
+  // and the global one is still virgin. Never auto-move — multiple worktrees
+  // may each carry a ./data and only the user knows which is canonical.
+  if (
+    !process.env['OPENALICE_HOME'] &&
+    existsSync(resolve(process.cwd(), 'data', 'config')) &&
+    !existsSync(resolve(dataHome, 'data', 'config'))
+  ) {
+    console.warn('[guardian] ──────────────────────────────────────────────────────')
+    console.warn(`[guardian] Found existing data/ in this checkout (${resolve(process.cwd(), 'data')}).`)
+    console.warn(`[guardian] OpenAlice now stores user data in ${dataHome}/data.`)
+    console.warn(`[guardian] To adopt this checkout's data, stop the stack and run:`)
+    console.warn(`[guardian]   mv "$PWD/data" "${dataHome}/data"`)
+    console.warn('[guardian] Continuing with a fresh store. (Old behavior: OPENALICE_HOME="$PWD" pnpm dev)')
+    console.warn('[guardian] ──────────────────────────────────────────────────────')
+  }
+
   // env (OPENALICE_*_PORT) > data/config/ports.json > default+probe.
   const ports = await planPorts(resolvePortConfig(process.env, await readPortsFile(dataHome)))
   const flagPath = resolve(dataHome, 'data/control/restart-uta.flag')

--- a/scripts/guardian/dev.ts
+++ b/scripts/guardian/dev.ts
@@ -45,7 +45,9 @@ async function main(): Promise<void> {
   const baseEnv = {
     ...process.env,
     NODE_OPTIONS: `${process.env['NODE_OPTIONS'] ?? ''} --conditions=openalice-source`.trim(),
-    OPENALICE_USER_DATA_HOME: dataHome,
+    // Children must resolve the same user-data root the Guardian watches —
+    // src/core/paths.ts reads OPENALICE_HOME; never rely on cwd inheritance.
+    OPENALICE_HOME: dataHome,
   }
 
   // ── UTA spec (re-used by Guardian for restart) ────────────

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -12,7 +12,7 @@
  * Lifecycle:
  *   - spawn UTA, poll /__uta/health until 200 (≤ 15s) or abort
  *   - spawn Alice with OPENALICE_UTA_URL pointing at the local UTA
- *   - watch `${OPENALICE_USER_DATA_HOME}/data/control/restart-uta.flag`
+ *   - watch `${OPENALICE_HOME}/data/control/restart-uta.flag`
  *     for UI-triggered broker config changes; SIGTERM + respawn UTA
  *     when it changes (debounced 100ms)
  *   - SIGTERM/SIGINT from tini cascades to both children, then exit
@@ -27,7 +27,12 @@ import { mkdir, readFile, watch } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
 
-const DATA_HOME = process.env.OPENALICE_USER_DATA_HOME ?? '/data'
+const DATA_HOME = process.env.OPENALICE_HOME
+  ?? process.env.OPENALICE_USER_DATA_HOME // deprecated alias, one-release courtesy
+  ?? '/data'
+if (!process.env.OPENALICE_HOME && process.env.OPENALICE_USER_DATA_HOME) {
+  console.warn('[guardian/prod] OPENALICE_USER_DATA_HOME is deprecated — set OPENALICE_HOME instead')
+}
 
 // Port precedence: env (OPENALICE_*_PORT) > data/config/ports.json > default.
 // Mirrors scripts/guardian/shared.ts (kept inline — the runtime image ships
@@ -94,7 +99,7 @@ function makeUTASpec() {
     env: {
       ...process.env,
       OPENALICE_UTA_PORT: String(UTA_PORT),
-      OPENALICE_USER_DATA_HOME: DATA_HOME,
+      OPENALICE_HOME: DATA_HOME,
     },
   }
 }
@@ -117,7 +122,7 @@ function spawnAlice() {
       OPENALICE_WEB_PORT: String(WEB_PORT),
       OPENALICE_MCP_PORT: String(MCP_PORT),
       OPENALICE_UTA_URL: UTA_URL,
-      OPENALICE_USER_DATA_HOME: DATA_HOME,
+      OPENALICE_HOME: DATA_HOME,
     },
     stdio: 'inherit',
   })

--- a/scripts/guardian/smoke.ts
+++ b/scripts/guardian/smoke.ts
@@ -96,6 +96,11 @@ async function fetchHealth(utaPort: number): Promise<UtaHealth | null> {
 
 async function main(): Promise<void> {
   const root = process.cwd()
+  // Pin the user-data home to the checkout so the smoke harness and the
+  // Guardian under test agree on where data/control/ lives, independent of
+  // the production default (~/.openalice). The SOFT restart check below
+  // watches this flag path — if the two sides ever derived different roots,
+  // that check would silently stop testing anything.
   const flagPath = resolve(root, 'data/control/restart-uta.flag')
 
   // ── Spawn the full stack ──────────────────────────────────
@@ -105,7 +110,7 @@ async function main(): Promise<void> {
   // does internally).
   const child: ChildProcess = spawn('pnpm', ['dev'], {
     cwd: root,
-    env: process.env,
+    env: { ...process.env, OPENALICE_HOME: root },
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: !IS_WIN,
     shell: IS_WIN,

--- a/scripts/migrate-order-sentinels.ts
+++ b/scripts/migrate-order-sentinels.ts
@@ -26,14 +26,13 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync, renameSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+import { dataPath } from '../src/core/paths.js'
 
 const LEGACY_UNSET_DOUBLE = Number.MAX_VALUE  // = 1.7976931348623157e+308
 const PRICE_FIELDS = ['lmtPrice', 'auxPrice', 'trailStopPrice', 'trailingPercent', 'cashQty'] as const
 
-const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
-const TRADING_DIR = join(REPO_ROOT, 'data', 'trading')
+const TRADING_DIR = dataPath('trading')
 
 interface Commit {
   hash?: string

--- a/services/uta/src/domain/trading/snapshot/store.ts
+++ b/services/uta/src/domain/trading/snapshot/store.ts
@@ -17,10 +17,11 @@
 
 import { readFile, writeFile, appendFile, rename, mkdir, unlink } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { dataPath } from '@/core/paths.js'
 import type { UTASnapshot, SnapshotIndex } from './types.js'
 
 const CHUNK_SIZE = 50
-const DEFAULT_BASE_DIR = 'data/trading'
+const DEFAULT_BASE_DIR = dataPath('trading')
 
 export interface SnapshotStoreOptions {
   baseDir?: string

--- a/src/core/config-accounts.spec.ts
+++ b/src/core/config-accounts.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, readFile, readdir, rm, stat, writeFile, mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir, platform } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * readUTAsConfig / writeUTAsConfig round-trip through the sealed at-rest
+ * format. config.ts resolves CONFIG_DIR at import, so each test re-imports
+ * under a fresh temp OPENALICE_HOME (global-provider-keys.spec.ts pattern).
+ */
+let home: string
+let configDir: string
+let savedHome: string | undefined
+
+async function loadConfigModule() {
+  vi.resetModules()
+  process.env['OPENALICE_HOME'] = home
+  const config = await import('./config.js')
+  const sealing = await import('./sealing.js')
+  return { config, sealing }
+}
+
+beforeEach(async () => {
+  savedHome = process.env['OPENALICE_HOME']
+  home = await mkdtemp(join(tmpdir(), 'oa-accounts-'))
+  configDir = join(home, 'data', 'config')
+})
+
+afterEach(async () => {
+  if (savedHome === undefined) delete process.env['OPENALICE_HOME']
+  else process.env['OPENALICE_HOME'] = savedHome
+  vi.resetModules()
+  await rm(home, { recursive: true, force: true })
+})
+
+const ACCOUNT = {
+  id: 'okx-test',
+  presetId: 'okx',
+  presetConfig: { apiKey: 'plain-api-key', secret: 'plain-secret' },
+}
+
+describe('UTA accounts at-rest sealing', () => {
+  it('write → sealed envelope on disk (0600), read → original records', async () => {
+    const { config, sealing } = await loadConfigModule()
+    await config.writeUTAsConfig([ACCOUNT] as never)
+
+    const path = join(configDir, 'accounts.json')
+    const onDisk = JSON.parse(await readFile(path, 'utf-8'))
+    expect(sealing.isSealedEnvelope(onDisk)).toBe(true)
+    expect(JSON.stringify(onDisk)).not.toContain('plain-secret')
+    if (platform() !== 'win32') {
+      expect((await stat(path)).mode & 0o777).toBe(0o600)
+    }
+
+    const back = await config.readUTAsConfig()
+    expect(back).toHaveLength(1)
+    expect(back[0].id).toBe('okx-test')
+    expect(back[0].presetConfig).toEqual(ACCOUNT.presetConfig)
+  })
+
+  it('first run seeds a sealed empty store and the sealing key', async () => {
+    const { config } = await loadConfigModule()
+    expect(await config.readUTAsConfig()).toEqual([])
+    expect(existsSync(join(configDir, 'accounts.json'))).toBe(true)
+    expect(existsSync(join(home, 'sealing.key'))).toBe(true)
+  })
+
+  it('still reads a legacy plaintext array (pre-0009 store)', async () => {
+    const { config } = await loadConfigModule()
+    await mkdir(configDir, { recursive: true })
+    await writeFile(join(configDir, 'accounts.json'), JSON.stringify([ACCOUNT], null, 2))
+
+    const back = await config.readUTAsConfig()
+    expect(back).toHaveLength(1)
+    expect(back[0].presetConfig['apiKey']).toBe('plain-api-key')
+  })
+
+  it('quarantines an unreadable sealed store and recovers with an empty one', async () => {
+    const { config, sealing } = await loadConfigModule()
+    await config.writeUTAsConfig([ACCOUNT] as never)
+    await rm(join(home, 'sealing.key')) // simulate data/ copied to a machine without the key
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      expect(await config.readUTAsConfig()).toEqual([])
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('could not be unsealed'))
+    } finally {
+      errSpy.mockRestore()
+    }
+
+    // Original preserved under a quarantine name, fresh sealed store seeded.
+    const files = await readdir(configDir)
+    expect(files.some((f) => f.startsWith('accounts.json.sealed-unreadable-'))).toBe(true)
+    const reseeded = JSON.parse(await readFile(join(configDir, 'accounts.json'), 'utf-8'))
+    expect(sealing.isSealedEnvelope(reseeded)).toBe(true)
+    // A new key was minted by the reseed, so subsequent reads work again.
+    expect(await config.readUTAsConfig()).toEqual([])
+  })
+})

--- a/src/core/config.spec.ts
+++ b/src/core/config.spec.ts
@@ -13,6 +13,19 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn().mockResolvedValue(undefined),
   mkdir: vi.fn().mockResolvedValue(undefined),
   unlink: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined),
+  chmod: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Identity-mock the sealing layer: it's unit-tested in sealing.spec.ts (and
+// round-tripped against real disk in config-accounts.spec.ts). Identity keeps
+// this file's on-disk JSON assertions readable, and spares the mocked
+// fs/promises from having to simulate the key file.
+vi.mock('./sealing.js', () => ({
+  isSealedEnvelope: () => false,
+  seal: async (v: unknown) => v,
+  unseal: async (v: unknown) => v,
 }))
 
 import { readFile, writeFile, mkdir } from 'fs/promises'

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod'
-import { readFile, writeFile, mkdir, unlink, rm } from 'fs/promises'
+import { readFile, writeFile, mkdir, unlink, rm, rename, chmod } from 'fs/promises'
 import { resolve, join, dirname } from 'path'
 import { homedir } from 'os'
 import { newsCollectorSchema } from '../domain/news/config.js'
 import { runMigrations } from '../migrations/runner.js'
 import { dataPath } from '@/core/paths.js'
+import { isSealedEnvelope, seal, unseal } from './sealing.js'
 
 const CONFIG_DIR = dataPath('config')
 
@@ -599,16 +600,49 @@ function migrateLegacyUTA(raw: Record<string, unknown>): Record<string, unknown>
   return null
 }
 
+/**
+ * Write the accounts file sealed (AES-256-GCM envelope, see sealing.ts) and
+ * owner-only. Every accounts.json write funnels here so no code path can
+ * regress to plaintext credentials at rest.
+ */
+async function writeAccountsFile(validated: UTAConfig[]): Promise<void> {
+  await mkdir(CONFIG_DIR, { recursive: true })
+  const path = resolve(CONFIG_DIR, 'accounts.json')
+  await writeFile(path, JSON.stringify(await seal(validated), null, 2) + '\n', { mode: 0o600 })
+  await chmod(path, 0o600).catch(() => { /* noop — platform without chmod */ })
+}
+
 // File name on disk stays `accounts.json` — internal-only, never
 // user-visible. Renaming would require another migration block; cost
 // outweighs benefit. The on-disk schema is the new UTA shape.
 export async function readUTAsConfig(): Promise<UTAConfig[]> {
-  const raw = await loadJsonFile('accounts.json')
+  let raw = await loadJsonFile('accounts.json')
   if (raw === undefined) {
-    // Seed empty file on first run
-    await mkdir(CONFIG_DIR, { recursive: true })
-    await writeFile(resolve(CONFIG_DIR, 'accounts.json'), '[]\n')
+    // Seed empty (sealed) file on first run — also materializes sealing.key
+    // early, so later credential writes never race key creation.
+    await writeAccountsFile([])
     return []
+  }
+
+  // Sealed envelope — the normal at-rest shape. A plain array is the legacy
+  // plaintext form: still readable (migration 0009 reseals it at boot).
+  if (isSealedEnvelope(raw)) {
+    try {
+      raw = await unseal(raw)
+    } catch (err) {
+      // Recoverable, loudly: quarantine the unreadable file (never delete —
+      // it's the user's broker config, the key may resurface) and continue
+      // with an empty store so the app still boots.
+      const quarantine = resolve(CONFIG_DIR, `accounts.json.sealed-unreadable-${Date.now()}`)
+      await rename(resolve(CONFIG_DIR, 'accounts.json'), quarantine)
+      console.error(
+        `accounts.json could not be unsealed: ${err instanceof Error ? err.message : String(err)}\n` +
+        `The file was preserved at ${quarantine}. Starting with an empty account store — ` +
+        `re-enter broker credentials in Settings → Trading.`,
+      )
+      await writeAccountsFile([])
+      return []
+    }
   }
 
   // Auto-migrate the pre-preset shape ({type, brokerConfig}) into the
@@ -639,7 +673,7 @@ export async function readUTAsConfig(): Promise<UTAConfig[]> {
     )
 
     const validated = utasFileSchema.parse(migrated)
-    await writeFile(resolve(CONFIG_DIR, 'accounts.json'), JSON.stringify(validated, null, 2) + '\n')
+    await writeAccountsFile(validated)
     return validated
   }
 
@@ -648,8 +682,7 @@ export async function readUTAsConfig(): Promise<UTAConfig[]> {
 
 export async function writeUTAsConfig(utas: UTAConfig[]): Promise<void> {
   const validated = utasFileSchema.parse(utas)
-  await mkdir(CONFIG_DIR, { recursive: true })
-  await writeFile(resolve(CONFIG_DIR, 'accounts.json'), JSON.stringify(validated, null, 2) + '\n')
+  await writeAccountsFile(validated)
 }
 
 /**

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -660,7 +660,7 @@ export async function writeUTAsConfig(utas: UTAConfig[]): Promise<void> {
  * No-op if the directory doesn't exist; never touches `data/config/`.
  */
 export async function wipeUTATradingData(id: string): Promise<void> {
-  const dir = resolve('data', 'trading', id)
+  const dir = dataPath('trading', id)
   await rm(dir, { recursive: true, force: true })
 }
 

--- a/src/core/event-log.ts
+++ b/src/core/event-log.ts
@@ -12,6 +12,7 @@
 
 import { appendFile, readFile, mkdir, unlink } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { dataPath } from './paths.js'
 import type { AgentEventMap } from './agent-event.js'
 import { validateEventPayload } from './agent-event.js'
 
@@ -113,7 +114,7 @@ export async function createEventLog(opts?: {
   /** Max entries in the in-memory ring buffer. Default: 500. */
   bufferSize?: number
 }): Promise<EventLog> {
-  const logPath = opts?.logPath ?? 'data/event-log/events.jsonl'
+  const logPath = opts?.logPath ?? dataPath('event-log', 'events.jsonl')
   const bufferSize = opts?.bufferSize ?? DEFAULT_BUFFER_SIZE
 
   // Ensure directory exists

--- a/src/core/legacy-data-notice.ts
+++ b/src/core/legacy-data-notice.ts
@@ -1,0 +1,41 @@
+/**
+ * One-shot startup notice for checkouts that predate the global data root.
+ *
+ * Until mid-2026 the default user-data home was process.cwd(), so every
+ * checkout grew its own `./data/`. The default is now ~/.openalice — shared
+ * across dev checkouts, `pnpm start`, and the packaged app. When a legacy
+ * store exists next to the running process but the global store is still
+ * virgin, tell the user how to adopt it. NEVER auto-move: multiple
+ * worktrees may each carry a `./data/`, and only the user knows which one
+ * (if any) is canonical.
+ *
+ * Silent whenever OPENALICE_HOME is set explicitly (guardian children,
+ * docker, deliberate checkout-local pins) — the operator already chose.
+ */
+
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { dataPath, defaultUserDataHome } from './paths.js'
+
+export function legacyDataNoticeLines(opts?: { cwd?: string }): string[] {
+  if (process.env['OPENALICE_HOME']) return []
+  const cwd = opts?.cwd ?? process.cwd()
+  const legacyConfig = resolve(cwd, 'data', 'config')
+  // `data/config/` is the tripwire — `data/control/` alone is flag debris.
+  if (!existsSync(legacyConfig)) return []
+  if (existsSync(dataPath('config'))) return []
+  return [
+    `Found an existing data/ store in this checkout (${resolve(cwd, 'data')}).`,
+    `OpenAlice now keeps user data in ${defaultUserDataHome}/data — shared across checkouts and the desktop app.`,
+    `To adopt this checkout's data:  mv "${resolve(cwd, 'data')}" "${defaultUserDataHome}/data"`,
+    `Continuing with a fresh store. (Pin the old behavior with OPENALICE_HOME="$PWD".)`,
+  ]
+}
+
+/** Print the notice to stderr if applicable. Returns true when shown. */
+export function printLegacyDataNotice(prefix = '[openalice]'): boolean {
+  const lines = legacyDataNoticeLines()
+  if (lines.length === 0) return false
+  for (const line of lines) console.warn(`${prefix} ${line}`)
+  return true
+}

--- a/src/core/paths.spec.ts
+++ b/src/core/paths.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { resolve } from 'node:path'
+import { homedir } from 'node:os'
 
 /**
  * paths.ts reads env into module-level consts at import time, so each
@@ -46,9 +47,9 @@ describe('dataPath', () => {
     expect(dataPath('brain', 'persona.md')).toBe('/tmp/oa-test/data/brain/persona.md')
   })
 
-  it('falls back to process.cwd() when OPENALICE_HOME is unset', async () => {
+  it('falls back to ~/.openalice when OPENALICE_HOME is unset', async () => {
     const { dataPath } = await loadPaths()
-    expect(dataPath('config')).toBe(resolve(process.cwd(), 'data/config'))
+    expect(dataPath('config')).toBe(resolve(homedir(), '.openalice', 'data/config'))
   })
 
   it('returns the base data dir when called with no parts', async () => {
@@ -106,7 +107,7 @@ describe('two homes are independent', () => {
   it('setting OPENALICE_APP_HOME does not move USER_DATA_HOME', async () => {
     const { dataPath, defaultPath } = await loadPaths({ OPENALICE_APP_HOME: '/tmp/resources' })
     expect(defaultPath('x')).toBe('/tmp/resources/default/x')
-    expect(dataPath('config')).toBe(resolve(process.cwd(), 'data/config'))
+    expect(dataPath('config')).toBe(resolve(homedir(), '.openalice', 'data/config'))
   })
 
   it('both env vars can be set together (packaged-app shape)', async () => {
@@ -131,9 +132,10 @@ describe('userDataHome / appResourcesHome exports', () => {
     expect(m.appResourcesHome).toBe('/tmp/app-home')
   })
 
-  it('fall back to cwd when env unset (matches helper fallback)', async () => {
+  it('fall back to defaults when env unset (user data: ~/.openalice; app resources: cwd)', async () => {
     const m = await loadPaths()
-    expect(m.userDataHome).toBe(process.cwd())
+    expect(m.userDataHome).toBe(resolve(homedir(), '.openalice'))
+    expect(m.userDataHome).toBe(m.defaultUserDataHome)
     expect(m.appResourcesHome).toBe(process.cwd())
   })
 })

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -5,12 +5,17 @@
  *
  *   USER_DATA_HOME    user-produced state (config, sessions, broker
  *                     git-like commits, brain files, etc.). Survives
- *                     app upgrades and reinstalls. In production, set by
- *                     the guardian (apps/desktop/src/main.ts) to a
- *                     platform-standard location like ~/Library/Application
- *                     Support/OpenAlice/. In dev (pnpm dev / pnpm
- *                     electron:dev), the guardian pins it to the repo
- *                     root so contributors see their working data.
+ *                     app upgrades and reinstalls. Default: ~/.openalice —
+ *                     ONE store shared by every topology (pnpm dev, pnpm
+ *                     start, packaged Electron), so broker credentials and
+ *                     trading state are configured once, not per checkout.
+ *                     Guardians still inject OPENALICE_HOME explicitly so
+ *                     parent and children never derive the root twice;
+ *                     `OPENALICE_HOME=$PWD pnpm dev` pins a checkout-local
+ *                     store when an experiment shouldn't touch real data.
+ *                     The `data/` subtree under it is the portable part
+ *                     (back up / migrate / share THAT); machine-bound
+ *                     secrets like sealing.key live beside it, not in it.
  *
  *   APP_RESOURCES_HOME   files shipped with the app (default templates,
  *                        the UI bundle). Replaced wholesale on app
@@ -24,8 +29,14 @@
  */
 
 import { resolve } from 'node:path'
+import { homedir } from 'node:os'
 
-const USER_DATA_HOME = process.env['OPENALICE_HOME'] ?? process.cwd()
+/** Default user-data root when OPENALICE_HOME is unset. Shared with the
+ *  workspace launcher (~/.openalice/workspaces) and the global provider-key
+ *  store (~/.openalice/provider-keys.json) — one OpenAlice home. */
+const DEFAULT_USER_DATA_HOME = resolve(homedir(), '.openalice')
+
+const USER_DATA_HOME = process.env['OPENALICE_HOME'] ?? DEFAULT_USER_DATA_HOME
 const APP_RESOURCES_HOME = process.env['OPENALICE_APP_HOME'] ?? process.cwd()
 
 /** Path under `data/` — user-produced state. */
@@ -77,6 +88,10 @@ export function cliBinPath(): string {
 
 /** Effective USER_DATA_HOME — exported for diagnostics / migration logic. */
 export const userDataHome = USER_DATA_HOME
+
+/** The built-in default home (~/.openalice), independent of env overrides.
+ *  Used by legacy-data adoption notices to phrase "where data lives now". */
+export const defaultUserDataHome = DEFAULT_USER_DATA_HOME
 
 /** Effective APP_RESOURCES_HOME — exported for diagnostics. */
 export const appResourcesHome = APP_RESOURCES_HOME

--- a/src/core/sealing.spec.ts
+++ b/src/core/sealing.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir, platform } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * sealing.ts resolves the key path from userDataHome at call time, and
+ * paths.ts resolves userDataHome from env at import time — so each test
+ * gets a fresh temp home via resetModules + env (same pattern as
+ * paths.spec.ts / global-provider-keys.spec.ts).
+ */
+let home: string
+let savedHome: string | undefined
+
+async function loadSealing() {
+  vi.resetModules()
+  process.env['OPENALICE_HOME'] = home
+  return await import('./sealing.js')
+}
+
+beforeEach(async () => {
+  savedHome = process.env['OPENALICE_HOME']
+  home = await mkdtemp(join(tmpdir(), 'oa-sealing-'))
+})
+
+afterEach(async () => {
+  if (savedHome === undefined) delete process.env['OPENALICE_HOME']
+  else process.env['OPENALICE_HOME'] = savedHome
+  vi.resetModules()
+  await rm(home, { recursive: true, force: true })
+})
+
+describe('seal / unseal', () => {
+  it('round-trips a JSON value', async () => {
+    const { seal, unseal } = await loadSealing()
+    const value = [{ id: 'okx-1', presetConfig: { apiKey: 'k', secret: 's' } }]
+    const envelope = await seal(value)
+    expect(envelope.$sealed).toBe(1)
+    expect(envelope.alg).toBe('aes-256-gcm')
+    await expect(unseal(envelope)).resolves.toEqual(value)
+  })
+
+  it('ciphertext does not contain the plaintext secret', async () => {
+    const { seal } = await loadSealing()
+    const envelope = await seal({ secret: 'super-secret-broker-key' })
+    expect(JSON.stringify(envelope)).not.toContain('super-secret-broker-key')
+  })
+
+  it('creates the key file on first seal, owner-only', async () => {
+    const { seal, sealingKeyPath } = await loadSealing()
+    expect(existsSync(sealingKeyPath())).toBe(false)
+    await seal({})
+    expect(sealingKeyPath()).toBe(join(home, 'sealing.key'))
+    expect(existsSync(sealingKeyPath())).toBe(true)
+    if (platform() !== 'win32') {
+      const mode = (await stat(sealingKeyPath())).mode & 0o777
+      expect(mode).toBe(0o600)
+    }
+  })
+
+  it('reuses the same key across seals (stable at-rest identity)', async () => {
+    const { seal, unseal, sealingKeyPath } = await loadSealing()
+    await seal({ first: true })
+    const keyBefore = await readFile(sealingKeyPath(), 'utf-8')
+    const second = await seal({ second: true })
+    expect(await readFile(sealingKeyPath(), 'utf-8')).toBe(keyBefore)
+    await expect(unseal(second)).resolves.toEqual({ second: true })
+  })
+
+  it('throws UnsealError when the key file is missing', async () => {
+    const { seal, unseal, sealingKeyPath, UnsealError } = await loadSealing()
+    const envelope = await seal({ x: 1 })
+    await rm(sealingKeyPath())
+    await expect(unseal(envelope)).rejects.toBeInstanceOf(UnsealError)
+    await expect(unseal(envelope)).rejects.toThrow(/does not exist/)
+  })
+
+  it('throws UnsealError when the key was replaced (auth tag mismatch)', async () => {
+    const { seal, unseal, sealingKeyPath, UnsealError } = await loadSealing()
+    const envelope = await seal({ x: 1 })
+    const { randomBytes } = await import('node:crypto')
+    await writeFile(sealingKeyPath(), randomBytes(32).toString('base64'))
+    await expect(unseal(envelope)).rejects.toBeInstanceOf(UnsealError)
+    await expect(unseal(envelope)).rejects.toThrow(/does not authenticate/)
+  })
+
+  it('throws UnsealError on a malformed key file', async () => {
+    const { seal, unseal, sealingKeyPath, UnsealError } = await loadSealing()
+    const envelope = await seal({ x: 1 })
+    await writeFile(sealingKeyPath(), 'bm90LWEta2V5\n') // base64("not-a-key") — wrong length
+    await expect(unseal(envelope)).rejects.toBeInstanceOf(UnsealError)
+  })
+})
+
+describe('isSealedEnvelope', () => {
+  it('accepts envelopes and rejects everything else', async () => {
+    const { seal, isSealedEnvelope } = await loadSealing()
+    expect(isSealedEnvelope(await seal([]))).toBe(true)
+    expect(isSealedEnvelope([])).toBe(false)
+    expect(isSealedEnvelope([{ id: 'x' }])).toBe(false) // legacy plaintext array
+    expect(isSealedEnvelope(null)).toBe(false)
+    expect(isSealedEnvelope({ $sealed: 2, iv: '', tag: '', data: '' })).toBe(false)
+    expect(isSealedEnvelope({ $sealed: 1, iv: '', tag: '' })).toBe(false) // missing data
+  })
+})

--- a/src/core/sealing.ts
+++ b/src/core/sealing.ts
@@ -1,0 +1,137 @@
+/**
+ * At-rest sealing for secret-bearing config files (broker credentials).
+ *
+ * AES-256-GCM envelope around the file's JSON payload. The key is a random
+ * 32-byte machine-bound secret at `<userDataHome>/sealing.key` — deliberately
+ * OUTSIDE the portable `data/` subtree, so backing up / sharing / syncing
+ * `data/` never carries the material needed to read the credentials inside
+ * it. Auto-generated on first seal; zero user interaction.
+ *
+ * What this buys (honest threat model):
+ *   - `data/` leaving the machine (backup, cloud sync, "send me your data
+ *     dir" debugging) no longer leaks broker keys.
+ *   - casual reads — grep, screenshots, an agent `cat`ing the file — see
+ *     ciphertext.
+ * What it does NOT buy: same-user malware or a compromised Alice process
+ * can read the key file exactly like we do. The structural answer to that
+ * is the detached-UTA split, not at-rest crypto.
+ *
+ * The envelope is versioned ($sealed/alg) so the key can later move into an
+ * OS keychain (Electron safeStorage) without a format break.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { userDataHome } from './paths.js'
+
+const ALG = 'aes-256-gcm'
+const KEY_BYTES = 32
+const IV_BYTES = 12
+
+export interface SealedEnvelope {
+  $sealed: 1
+  alg: typeof ALG
+  iv: string
+  tag: string
+  data: string
+}
+
+/** Raised when a sealed file exists but its key doesn't (data/ moved to a
+ *  new machine, key file deleted) or the ciphertext fails authentication. */
+export class UnsealError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message)
+    this.name = 'UnsealError'
+  }
+}
+
+export function sealingKeyPath(): string {
+  return resolve(userDataHome, 'sealing.key')
+}
+
+export function isSealedEnvelope(value: unknown): value is SealedEnvelope {
+  return (
+    typeof value === 'object' && value !== null &&
+    (value as Record<string, unknown>)['$sealed'] === 1 &&
+    typeof (value as Record<string, unknown>)['iv'] === 'string' &&
+    typeof (value as Record<string, unknown>)['tag'] === 'string' &&
+    typeof (value as Record<string, unknown>)['data'] === 'string'
+  )
+}
+
+async function readKey(): Promise<Buffer | undefined> {
+  try {
+    const raw = (await readFile(sealingKeyPath(), 'utf-8')).trim()
+    const key = Buffer.from(raw, 'base64')
+    if (key.length !== KEY_BYTES) {
+      throw new UnsealError(`sealing key at ${sealingKeyPath()} is malformed (${key.length} bytes after base64-decode, expected ${KEY_BYTES})`)
+    }
+    return key
+  } catch (err: unknown) {
+    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined
+    }
+    throw err
+  }
+}
+
+async function loadOrCreateKey(): Promise<Buffer> {
+  const existing = await readKey()
+  if (existing) return existing
+  const key = randomBytes(KEY_BYTES)
+  const path = sealingKeyPath()
+  await mkdir(dirname(path), { recursive: true })
+  // Owner-only, same belt-and-braces as auth/token-store.ts — writeFile's
+  // `mode` is ignored on some platforms, so chmod again best-effort.
+  await writeFile(path, key.toString('base64') + '\n', { mode: 0o600 })
+  await chmod(path, 0o600).catch(() => { /* noop — platform without chmod */ })
+  return key
+}
+
+/** Encrypt a JSON-serializable value into an envelope. Creates the sealing
+ *  key on first use. */
+export async function seal(value: unknown): Promise<SealedEnvelope> {
+  const key = await loadOrCreateKey()
+  const iv = randomBytes(IV_BYTES)
+  const cipher = createCipheriv(ALG, key, iv)
+  const plaintext = Buffer.from(JSON.stringify(value), 'utf-8')
+  const data = Buffer.concat([cipher.update(plaintext), cipher.final()])
+  return {
+    $sealed: 1,
+    alg: ALG,
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    data: data.toString('base64'),
+  }
+}
+
+/** Decrypt an envelope back to its JSON value. Throws UnsealError when the
+ *  key is missing or the ciphertext doesn't authenticate. */
+export async function unseal<T = unknown>(envelope: SealedEnvelope): Promise<T> {
+  if (envelope.alg !== ALG) {
+    throw new UnsealError(`unsupported sealing algorithm "${envelope.alg}" — this build only knows ${ALG}`)
+  }
+  const key = await readKey()
+  if (!key) {
+    throw new UnsealError(
+      `sealed file requires the machine key at ${sealingKeyPath()}, which does not exist — ` +
+      `if this data/ was copied from another machine, re-enter the credentials there`,
+    )
+  }
+  try {
+    const decipher = createDecipheriv(ALG, key, Buffer.from(envelope.iv, 'base64'))
+    decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'))
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(envelope.data, 'base64')),
+      decipher.final(),
+    ])
+    return JSON.parse(plaintext.toString('utf-8')) as T
+  } catch (err) {
+    throw new UnsealError(
+      `failed to unseal: ciphertext does not authenticate against ${sealingKeyPath()} ` +
+      `(key replaced, or file corrupted)`,
+      err,
+    )
+  }
+}

--- a/src/core/session.spec.ts
+++ b/src/core/session.spec.ts
@@ -443,19 +443,19 @@ describe('MemorySessionStore', () => {
 describe('SessionStore', () => {
   let tmpDir: string
 
-  // HACK: SessionStore uses SESSIONS_DIR = join(process.cwd(), 'data', 'sessions') which is
-  // a module-level constant, so we can't redirect it. We test using the default path
-  // by cleaning up after ourselves instead.
-  // To keep tests isolated we use a custom sessionId that won't clash.
+  // SessionStore's SESSIONS_DIR is a module-level dataPath('sessions') const;
+  // vitest.setup.ts pins OPENALICE_HOME to a temp dir, so writes land in the
+  // sandbox. A unique sessionId keeps parallel files from clashing; cleanup
+  // sweeps the same dataPath the store writes to.
 
   const testId = `test-session-${Date.now()}`
 
   afterEach(async () => {
     // Clean up session file written during test
-    const { join: pathJoin } = await import('node:path')
+    const { dataPath } = await import('@/core/paths.js')
     const { rm: fsRm } = await import('node:fs/promises')
     try {
-      await fsRm(pathJoin(process.cwd(), 'data', 'sessions', `${testId}.jsonl`), { force: true })
+      await fsRm(dataPath('sessions', `${testId}.jsonl`), { force: true })
     } catch { /* ignore */ }
   })
 

--- a/src/core/tool-call-log.ts
+++ b/src/core/tool-call-log.ts
@@ -14,6 +14,7 @@
 
 import { appendFile, readFile, mkdir, unlink } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { dataPath } from './paths.js'
 
 // ==================== Types ====================
 
@@ -80,7 +81,7 @@ export interface ToolCallLog {
 // ==================== Defaults ====================
 
 const DEFAULT_BUFFER_SIZE = 500
-const DEFAULT_LOG_PATH = 'data/tool-calls/tool-calls.jsonl'
+const DEFAULT_LOG_PATH = dataPath('tool-calls', 'tool-calls.jsonl')
 
 // ==================== Implementation ====================
 

--- a/src/domain/news/store.ts
+++ b/src/domain/news/store.ts
@@ -13,9 +13,10 @@
 import { appendFile, readFile, mkdir } from 'node:fs/promises'
 import { createHash } from 'node:crypto'
 import { dirname } from 'node:path'
+import { dataPath } from '../../core/paths.js'
 import type { INewsProvider, GetNewsV2Options, NewsItem, NewsRecord } from './types.js'
 
-const DEFAULT_LOG_PATH = 'data/news-collector/news.jsonl'
+const DEFAULT_LOG_PATH = dataPath('news-collector', 'news.jsonl')
 const DEFAULT_MAX_IN_MEMORY = 2000
 const DEFAULT_RETENTION_DAYS = 7
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { dirname } from 'path'
 // as of 0.40 — the model loop runs inside the native workspace CLIs; autonomous
 // runs go through headless workspace dispatch (cron → workspace).
 import { loadConfig } from './core/config.js'
+import { printLegacyDataNotice } from './core/legacy-data-notice.js'
 import { dataPath, defaultPath } from '@/core/paths.js'
 import type { Plugin, EngineContext } from './core/types.js'
 import { McpPlugin } from './server/mcp.js'
@@ -67,6 +68,11 @@ async function readWithDefault(target: string, defaultFile: string): Promise<str
 }
 
 async function main() {
+  // Before migrations create the new config dir: if this checkout carries a
+  // pre-global-root data/ store, tell the user how to adopt it (covers bare
+  // `pnpm start`; guardian children get OPENALICE_HOME so this stays quiet).
+  printLegacyDataNotice('[alice]')
+
   const config = await loadConfig()
 
   // ==================== Event Log ====================

--- a/src/migrations/0009_seal_broker_credentials/index.spec.ts
+++ b/src/migrations/0009_seal_broker_credentials/index.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import type { MigrationContext } from '../types.js'
+
+let home: string
+let configDir: string
+let savedHome: string | undefined
+
+/** Migration + sealing both resolve userDataHome at module load. */
+async function loadMigration() {
+  vi.resetModules()
+  process.env['OPENALICE_HOME'] = home
+  const { migration } = await import('./index.js')
+  const sealing = await import('@/core/sealing.js')
+  return { migration, sealing }
+}
+
+function makeCtx(): MigrationContext {
+  return {
+    readJson: async <T = unknown>(filename: string): Promise<T | undefined> => {
+      try {
+        return JSON.parse(await readFile(resolve(configDir, filename), 'utf-8')) as T
+      } catch (err: unknown) {
+        if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+        throw err
+      }
+    },
+    writeJson: async (filename: string, data: unknown) => {
+      await writeFile(resolve(configDir, filename), JSON.stringify(data, null, 2) + '\n')
+    },
+    removeJson: async (filename: string) => {
+      await rm(resolve(configDir, filename), { force: true })
+    },
+    configDir: () => configDir,
+  }
+}
+
+beforeEach(async () => {
+  savedHome = process.env['OPENALICE_HOME']
+  home = await mkdtemp(join(tmpdir(), 'oa-mig0009-'))
+  configDir = join(home, 'data', 'config')
+  await mkdir(configDir, { recursive: true })
+})
+
+afterEach(async () => {
+  if (savedHome === undefined) delete process.env['OPENALICE_HOME']
+  else process.env['OPENALICE_HOME'] = savedHome
+  vi.resetModules()
+  await rm(home, { recursive: true, force: true })
+})
+
+describe('0009_seal_broker_credentials', () => {
+  const accounts = [{ id: 'okx-1', presetId: 'okx', presetConfig: { apiKey: 'k', secret: 'sup3r' } }]
+
+  it('seals a plaintext array in place', async () => {
+    const { migration, sealing } = await loadMigration()
+    await writeFile(join(configDir, 'accounts.json'), JSON.stringify(accounts, null, 2))
+
+    await migration.up(makeCtx())
+
+    const onDisk = JSON.parse(await readFile(join(configDir, 'accounts.json'), 'utf-8'))
+    expect(sealing.isSealedEnvelope(onDisk)).toBe(true)
+    expect(JSON.stringify(onDisk)).not.toContain('sup3r')
+    await expect(sealing.unseal(onDisk)).resolves.toEqual(accounts)
+  })
+
+  it('is idempotent — a sealed file is left byte-for-byte unchanged', async () => {
+    const { migration } = await loadMigration()
+    await writeFile(join(configDir, 'accounts.json'), JSON.stringify(accounts, null, 2))
+    await migration.up(makeCtx())
+    const afterFirst = await readFile(join(configDir, 'accounts.json'), 'utf-8')
+
+    await migration.up(makeCtx())
+    expect(await readFile(join(configDir, 'accounts.json'), 'utf-8')).toBe(afterFirst)
+  })
+
+  it('no-ops when the file is missing', async () => {
+    const { migration } = await loadMigration()
+    await expect(migration.up(makeCtx())).resolves.toBeUndefined()
+  })
+
+  it('leaves unrecognized content untouched for a human', async () => {
+    const { migration } = await loadMigration()
+    const weird = JSON.stringify({ not: 'an array' }, null, 2)
+    await writeFile(join(configDir, 'accounts.json'), weird)
+    await migration.up(makeCtx())
+    expect(await readFile(join(configDir, 'accounts.json'), 'utf-8')).toBe(weird)
+  })
+})

--- a/src/migrations/0009_seal_broker_credentials/index.ts
+++ b/src/migrations/0009_seal_broker_credentials/index.ts
@@ -1,0 +1,41 @@
+/**
+ * 0009_seal_broker_credentials — seal the plaintext accounts.json at rest.
+ *
+ * Broker credentials lived as plaintext JSON in data/config/accounts.json.
+ * The store is now sealed (AES-256-GCM envelope, machine-bound key at
+ * <userDataHome>/sealing.key — see src/core/sealing.ts). The read/write
+ * path already handles both shapes; this migration makes sealing EAGER at
+ * first boot after upgrade, so plaintext credentials don't linger on disk
+ * until the next config change happens to rewrite the file.
+ *
+ * Also tightens the file to owner-only (0600), matching every future write.
+ *
+ * Idempotent: a sealed envelope (or a missing file) is a no-op. Non-array
+ * non-envelope content is left untouched for a human to look at — sealing
+ * unrecognized bytes would just bury the problem.
+ */
+
+import { writeFile, chmod } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { Migration } from '../types.js'
+import { isSealedEnvelope, seal } from '@/core/sealing.js'
+
+const FILENAME = 'accounts.json'
+
+export const migration: Migration = {
+  id: '0009_seal_broker_credentials',
+  appVersion: '0.41.0-beta.2',
+  introducedAt: '2026-06-11',
+  affects: ['accounts.json'],
+  summary: 'Seal broker credentials at rest (AES-256-GCM envelope + 0600), replacing plaintext accounts.json',
+  up: async (ctx) => {
+    const raw = await ctx.readJson(FILENAME)
+    if (raw === undefined) return // fresh install — read path seeds sealed
+    if (isSealedEnvelope(raw)) return // already at target shape
+    if (!Array.isArray(raw)) return // unrecognized — leave for a human
+
+    const path = resolve(ctx.configDir(), FILENAME)
+    await writeFile(path, JSON.stringify(await seal(raw), null, 2) + '\n', { mode: 0o600 })
+    await chmod(path, 0o600).catch(() => { /* noop — platform without chmod */ })
+  },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -8,3 +8,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | ID | App Version | Date | Affects | Summary |
 |----|-------------|------|---------|---------|
 | `0008_disable_targetless_cron_jobs` | 0.40.0-beta.3 | 2026-06-08 | cron/jobs.json | Disable enabled cron jobs that have no target workspace (legacy AgentWork-era jobs) so they stop firing into the retired path. |
+| `0009_seal_broker_credentials` | 0.41.0-beta.2 | 2026-06-11 | accounts.json | Seal broker credentials at rest (AES-256-GCM envelope + 0600), replacing plaintext accounts.json |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -20,7 +20,9 @@
 
 import type { Migration } from './types.js'
 import { migration as migration_0008_disable_targetless_cron_jobs } from './0008_disable_targetless_cron_jobs/index.js'
+import { migration as migration_0009_seal_broker_credentials } from './0009_seal_broker_credentials/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
+  migration_0009_seal_broker_credentials,
 ]

--- a/src/services/uta-supervisor/restart-trigger.ts
+++ b/src/services/uta-supervisor/restart-trigger.ts
@@ -15,11 +15,12 @@
 
 import { writeFile, rename, mkdir } from 'fs/promises'
 import { dirname } from 'path'
+import { dataPath } from '@/core/paths.js'
 
 export interface TriggerOpts {
   /** UTA service base URL. Default: process.env.OPENALICE_UTA_URL. */
   utaUrl?: string
-  /** Project-relative path to flag. Default: `data/control/restart-uta.flag`. */
+  /** Flag path. Default: `dataPath('control', 'restart-uta.flag')`. */
   flagPath?: string
   /** Total wait budget for new UTA to come back. Default 20s. */
   timeoutMs?: number
@@ -56,7 +57,7 @@ export async function triggerUTARestart(opts: TriggerOpts = {}): Promise<Trigger
   if (!utaUrl) {
     return { triggered: false, ready: false, error: 'OPENALICE_UTA_URL not set' }
   }
-  const flagPath = opts.flagPath ?? `${process.cwd()}/data/control/restart-uta.flag`
+  const flagPath = opts.flagPath ?? dataPath('control', 'restart-uta.flag')
   const healthUrl = `${utaUrl.replace(/\/$/, '')}/__uta/health`
   const timeoutMs = opts.timeoutMs ?? 20_000
   const intervalMs = opts.intervalMs ?? 200

--- a/src/task/cron/engine.ts
+++ b/src/task/cron/engine.ts
@@ -18,6 +18,7 @@ import { randomUUID } from 'node:crypto'
 import type { ListenerRegistry } from '../../core/listener-registry.js'
 import type { ProducerHandle } from '../../core/producer.js'
 import { parseDuration } from '../../core/duration.js'
+import { dataPath } from '../../core/paths.js'
 
 export { parseDuration }
 
@@ -115,7 +116,7 @@ export function createCronEngine(opts: CronEngineOpts): CronEngine {
     name: PRODUCER_NAME,
     emits: CRON_EMITS,
   })
-  const storePath = opts.storePath ?? 'data/cron/jobs.json'
+  const storePath = opts.storePath ?? dataPath('cron', 'jobs.json')
   const now = opts.now ?? Date.now
 
   let jobs: CronJob[] = []

--- a/src/webui/routes/trading-config.spec.ts
+++ b/src/webui/routes/trading-config.spec.ts
@@ -137,6 +137,23 @@ describe('POST /uta — derived id creation', () => {
     const second = await req(routes, 'POST', '/uta', { presetId: 'mock-simulator', presetConfig })
     expect(second.status).toBe(409)
   })
+
+  it('201 response echoes credentials MASKED; the store keeps them intact', async () => {
+    const routes = makeRoutes()
+    const { status, body } = await req(routes, 'POST', '/uta', {
+      presetId: 'okx',
+      presetConfig: { mode: 'live', apiKey: 'live-api-key-1234', secret: 'live-secret-5678', password: 'p4ss' },
+    })
+    expect(status).toBe(201)
+    const echoed = (body as { presetConfig: Record<string, string> }).presetConfig
+    expect(echoed.apiKey).toBe('****1234')
+    expect(echoed.secret).toBe('****5678')
+    expect(echoed.password).toBe('****')
+    // Persisted record keeps the real values — masking is response-only.
+    const stored = (utaStore[0] as { presetConfig: Record<string, string> }).presetConfig
+    expect(stored.apiKey).toBe('live-api-key-1234')
+    expect(stored.secret).toBe('live-secret-5678')
+  })
 })
 
 // ==================== PUT /uta/:id ====================
@@ -193,6 +210,30 @@ describe('PUT /uta/:id — edit-only', () => {
       presetConfig: { mode: 'live', apiKey: 'k', secret: 's', password: 'p' },
     })
     expect(status).toBe(400)
+  })
+
+  it('200 response echoes credentials MASKED after a rotation', async () => {
+    const routes = makeRoutes()
+    const created = await req(routes, 'POST', '/uta', {
+      presetId: 'okx',
+      presetConfig: { mode: 'live', apiKey: 'old-key-0000', secret: 'old-sec-0000', password: 'p' },
+    })
+    const id = (created.body as { id: string }).id
+
+    const edited = await req(routes, 'PUT', `/uta/${id}`, {
+      id,
+      presetId: 'okx',
+      enabled: true,
+      guards: [],
+      presetConfig: { mode: 'live', apiKey: 'new-key-9999', secret: 'new-sec-8888', password: 'p' },
+    })
+    expect(edited.status).toBe(200)
+    const echoed = (edited.body as { presetConfig: Record<string, string> }).presetConfig
+    expect(echoed.apiKey).toBe('****9999')
+    expect(echoed.secret).toBe('****8888')
+    // Rotation actually landed in the store, unmasked.
+    const stored = (utaStore[0] as { presetConfig: Record<string, string> }).presetConfig
+    expect(stored.apiKey).toBe('new-key-9999')
   })
 })
 

--- a/src/webui/routes/trading-config.ts
+++ b/src/webui/routes/trading-config.ts
@@ -148,7 +148,9 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
       notifyUTAReload()
 
       ctx.utaManager.reconnectUTA(id).catch(() => {})
-      return c.json(validated, 201)
+      // Echo masked — plaintext credentials never leave the server, and the
+      // client's local state stays shape-identical to what GET / returns.
+      return c.json(maskSecrets({ ...validated }), 201)
     } catch (err) {
       if (err instanceof Error && err.name === 'ZodError') {
         return c.json({ error: 'Validation failed', details: JSON.parse(err.message) }, 400)
@@ -201,7 +203,8 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
         ctx.utaManager.reconnectUTA(id).catch(() => {})
       }
 
-      return c.json(validated)
+      // Echo masked — same reasoning as POST.
+      return c.json(maskSecrets({ ...validated }))
     } catch (err) {
       if (err instanceof Error && err.name === 'ZodError') {
         return c.json({ error: 'Validation failed', details: JSON.parse(err.message) }, 400)

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -128,11 +128,14 @@ export function TradingPage() {
           presets={presets}
           onSave={async (uta) => {
             const created = await tc.createUTA(uta)
-            const result = await tc.reconnectUTA(created.id)
-            if (!result.success) {
-              throw new Error(result.error || 'Connection failed')
-            }
+            // Persisted — close NOW. The first broker connection runs in the
+            // background and the list's health badge tracks it (Reconnecting
+            // → Connected/Offline); credential validity has its own explicit
+            // Test step in the wizard. Holding the dialog open on a failed
+            // first connect lies about an already-created UTA — re-clicking
+            // Save can only 409.
             setShowAdd(false)
+            void tc.reconnectUTA(created.id).catch(() => {})
             // Trigger a fresh fetch so the new UTA shows live numbers right away.
             void api.trading.equity().then(setEquity).catch(() => {})
             return created

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         test: {
           name: 'node',
           environment: 'node',
+          setupFiles: ['./vitest.setup.ts'],
           include: ['src/**/*.spec.*', 'packages/**/*.spec.*', 'services/**/*.spec.*', 'apps/**/*.spec.*', 'scripts/**/*.spec.*'],
           exclude: ['**/*.e2e.spec.*', '**/*.bbProvider.spec.*', '**/node_modules/**'],
         },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,22 @@
+/**
+ * Global test hermeticity: pin OPENALICE_HOME to a per-worker temp dir so
+ * module-level `dataPath(...)` constants (session store, auth store, config,
+ * event log, …) never resolve into the developer's real data root. Without
+ * this, any spec that touches a store would read/write the real
+ * `~/.openalice/data` once the default user-data home moves off cwd.
+ *
+ * Runs before each test file's module graph is imported (vitest setupFiles
+ * semantics); the env guard makes it once-per-worker. Specs that need a
+ * specific home (paths.spec, global-provider-keys.spec) still override via
+ * vi.resetModules() + their own env handling — this is only the fallback.
+ *
+ * Deliberately NOT wired into vitest.e2e.config.ts: the e2e suite reads real
+ * broker credentials from the real store by design.
+ */
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+if (!process.env['OPENALICE_HOME']) {
+  process.env['OPENALICE_HOME'] = mkdtempSync(join(tmpdir(), 'oa-vitest-'))
+}


### PR DESCRIPTION
## Summary
- **User-data root unified at `~/.openalice`** — one store shared by `pnpm dev`, bare `pnpm start`, and the packaged app; broker accounts get configured once, not per checkout. `OPENALICE_HOME` overrides (Docker `/data` unchanged; `OPENALICE_HOME="$PWD" pnpm dev` pins a checkout-local store). Legacy checkout stores get a manual-adoption banner (never auto-moved — multiple worktrees have no canonical answer); packaged Electron auto-relocates its single `userData/data` store crash-safely on first launch.
- **Broker credentials sealed at rest** — `accounts.json` is now an AES-256-GCM envelope, keyed by `~/.openalice/sealing.key` (0600, auto-generated, outside the portable `data/` subtree, so backing up / sharing `data/` no longer carries the key). Migration 0009 reseals existing plaintext stores at first boot; an unreadable store (data copied without its key) is quarantined loudly, never deleted.
- **Leak fixes along the way**: POST/PUT `/uta` no longer echo plaintext credentials (now masked like GET); env naming unified on `OPENALICE_HOME` (guardians previously injected a variable nothing read); 8 cwd-relative `data/` literals routed through `dataPath()` — several were latent Electron bugs (UTA wipe path, restart-flag trigger).
- **Test hermeticity**: vitest pins `OPENALICE_HOME` to a temp dir per worker so specs can never touch the real store; the smoke harness pins the checkout so its restart-flag check keeps testing the path it watches.

## Test plan
- [x] `npx tsc --noEmit` clean (root + apps/desktop)
- [x] `pnpm test` — 1848 passing (new: sealing round-trip / plaintext compat / key-loss quarantine / migration 0009 idempotency / Electron relocation / masked echoes)
- [x] `pnpm test:smoke` — full stack boots on the new root, UTA restart-flag chain verified end-to-end
- [ ] Manual: walk Settings → Trading on a fresh store; confirm on-disk `accounts.json` is a `$sealed` envelope, 0600

## Boundary touch
Trading credentials (at-rest sealing + response masking), migrations (0009), data-root relocation (Electron + guardian bootstrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)