### PR TITLE
UTA: listing-driven sync — hanging stop/TP orders cost zero per pass

### DIFF
--- a/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
@@ -643,6 +643,81 @@ describe('UTA — sync', () => {
     expect(result.updates[0].filledPrice).toBe('149.2')
   })
 
+  it('listing mode: getOrder is spent ONLY on orders absent from the open-orders listing', async () => {
+    const { uta, broker } = createUTA()
+
+    // Two pending limit orders; one fills (vanishes from the listing).
+    uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', symbol: 'AAPL', action: 'BUY', orderType: 'LMT', totalQuantity: '10', lmtPrice: '150' })
+    uta.commit('a'); const a = (await uta.push()).submitted[0]!.orderId!
+    uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', symbol: 'AAPL', action: 'BUY', orderType: 'LMT', totalQuantity: '5', lmtPrice: '140' })
+    uta.commit('b'); const b = (await uta.push()).submitted[0]!.orderId!
+    broker.fillOrder(a, { price: '149' })
+
+    const getOrderSpy = vi.spyOn(broker, 'getOrder')
+    const result = await uta.sync()
+
+    // Transition pass: the confirm step polls ONLY the vanished order (a).
+    // (_getState's snapshot read adds delegated getOrder calls via
+    // getOrders — those happen once per pass WITH updates, not per order
+    // per pass, so assert on the confirm call specifically.)
+    expect(getOrderSpy.mock.calls.filter((c) => c[0] === a && c.length > 1)).toHaveLength(1)
+    expect(result.updatedCount).toBe(1)
+    expect(uta.getPendingOrderIds().map((p) => p.orderId)).toEqual([b])
+
+    // Steady-state pass: order b hangs (still in the listing) — ZERO
+    // getOrder calls. A stop/TP parked for weeks costs one listing per
+    // pass for the whole account, not one poll per order.
+    getOrderSpy.mockClear()
+    const second = await uta.sync()
+    expect(second.updatedCount).toBe(0)
+    expect(getOrderSpy).not.toHaveBeenCalled()
+  })
+
+  it('per-order fallback: brokers without a listing API still detect fills', async () => {
+    const { uta, broker } = createUTA()
+    // Simulate a venue with no open-orders enumeration.
+    ;(broker as { getOpenOrders?: unknown }).getOpenOrders = undefined
+
+    uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', symbol: 'AAPL', action: 'BUY', orderType: 'LMT', totalQuantity: '10', lmtPrice: '150' })
+    uta.commit('limit buy')
+    const orderId = (await uta.push()).submitted[0]!.orderId!
+    broker.fillPendingOrder(orderId, 149)
+
+    const result = await uta.sync()
+    expect(result.updatedCount).toBe(1)
+    expect(result.updates[0].currentStatus).toBe('filled')
+  })
+
+  it('per-order fallback: hangers back off (5min cadence after an hour)', async () => {
+    vi.useFakeTimers()
+    try {
+      const { uta, broker } = createUTA()
+      ;(broker as { getOpenOrders?: unknown }).getOpenOrders = undefined
+
+      uta.stagePlaceOrder({ aliceId: 'mock-paper|AAPL', symbol: 'AAPL', action: 'BUY', orderType: 'LMT', totalQuantity: '10', lmtPrice: '150' })
+      uta.commit('limit buy')
+      await uta.push()
+
+      const getOrderSpy = vi.spyOn(broker, 'getOrder')
+      await uta.sync() // fresh — polls (registers firstSeen)
+      expect(getOrderSpy).toHaveBeenCalledTimes(1)
+
+      // Two hours later, two syncs 10s apart: only the first polls.
+      vi.advanceTimersByTime(2 * 60 * 60_000)
+      await uta.sync()
+      vi.advanceTimersByTime(10_000)
+      await uta.sync()
+      expect(getOrderSpy).toHaveBeenCalledTimes(2)
+
+      // 5 minutes on, it's due again.
+      vi.advanceTimersByTime(5 * 60_000)
+      await uta.sync()
+      expect(getOrderSpy).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('passes the operation localSymbol as the broker symbolHint', async () => {
     const { uta, broker } = createUTA()
 
@@ -674,6 +749,44 @@ describe('UTA — sync', () => {
     broker.setOrders([])
     const result = await uta.sync()
     expect(result.updatedCount).toBe(0)
+  })
+})
+
+// ==================== reconcile race guard ====================
+
+describe('UTA — wallet reconcile defers while orders are in flight', () => {
+  it('drift is not booked at mark price while the aliceId has a pending order; residual reconciles after settlement', async () => {
+    const { uta, broker } = createUTA()
+    const aliceId = 'mock-paper|AAPL'
+    broker.setPositions([
+      makePosition({
+        contract: makeContract({ aliceId }),
+        quantity: new Decimal(10),
+        avgCost: '150',
+        marketPrice: '160',
+        avgCostSource: 'wallet',
+      }),
+    ])
+
+    // In-flight order on the same aliceId.
+    uta.stagePlaceOrder({ aliceId, symbol: 'AAPL', action: 'BUY', orderType: 'LMT', totalQuantity: '5', lmtPrice: '150' })
+    uta.commit('limit buy')
+    const orderId = (await uta.push()).submitted[0]!.orderId!
+
+    // The dfb01435 race: positions read while the fill is in flight must
+    // NOT record drift as a mark-price reconcile.
+    await uta.getPositions()
+    expect(uta.log({ limit: 10 }).some((c) => c.message.startsWith('reconcile:'))).toBe(false)
+
+    // Order settles and syncs (fill enters cost basis at execution price).
+    broker.fillPendingOrder(orderId, 149)
+    await uta.sync()
+
+    // No in-flight orders left — the TRUE residual (the pre-existing 10
+    // that no order explains) reconciles now.
+    await uta.getPositions()
+    const reconcile = uta.log({ limit: 10 }).find((c) => c.message.startsWith('reconcile:'))
+    expect(reconcile).toBeDefined()
   })
 })
 

--- a/services/uta/src/domain/trading/UnifiedTradingAccount.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.ts
@@ -534,6 +534,23 @@ export class UnifiedTradingAccount {
     return this.git.status()
   }
 
+  /**
+   * Sync cost model — two strategies, picked by broker capability:
+   *
+   * LISTING (broker has getOpenOrders): ONE listing call covers every
+   * pending order. An order still present is alive — zero further calls,
+   * no matter how long it hangs (stop-loss / take-profit orders can sit
+   * for weeks; per-order polling would be 8.6k calls/day EACH). An order
+   * ABSENT from the listing transitioned — only then is getOrder spent to
+   * confirm the terminal state + execution data. Absence alone is never
+   * trusted as terminal: conditional/algo orders on some venues live in a
+   * different listing namespace, so a vanished-but-still-Submitted confirm
+   * is treated as "still working".
+   *
+   * PER-ORDER (no listing capability): poll each pending order with
+   * age-based backoff — fresh orders (likely marketable) every pass, then
+   * 1m, then 5m once they've proven to be hangers.
+   */
   async sync(opts?: { delayMs?: number }): Promise<SyncResult> {
     const pendingOrders = this.git.getPendingOrderIds()
     if (pendingOrders.length === 0) {
@@ -543,9 +560,24 @@ export class UnifiedTradingAccount {
     // Optional delay — gives exchange APIs time to settle before querying
     if (opts?.delayMs) await new Promise(r => setTimeout(r, opts.delayMs))
 
+    let candidates = pendingOrders
+    if (this.broker.getOpenOrders) {
+      const listing = await this._callBroker(() => this.broker.getOpenOrders!())
+      const openIds = new Set(listing.map((o) => o.orderId).filter(Boolean))
+      // Present in the listing → alive, skip. (A just-placed order missing
+      // due to listing lag is also safe: its confirm returns Submitted.)
+      candidates = pendingOrders.filter((p) => !openIds.has(p.orderId))
+    } else {
+      candidates = pendingOrders.filter((p) => this._pollBackoffDue(p.orderId))
+    }
+
+    if (candidates.length === 0) {
+      return { hash: '', updatedCount: 0, updates: [] }
+    }
+
     const updates: OrderStatusUpdate[] = []
 
-    for (const { orderId, symbol, localSymbol } of pendingOrders) {
+    for (const { orderId, symbol, localSymbol } of candidates) {
       const brokerOrder = await this._callBroker(() => this.broker.getOrder(orderId, localSymbol))
       if (!brokerOrder) continue
 
@@ -594,6 +626,28 @@ export class UnifiedTradingAccount {
 
   getPendingOrderIds(): Array<{ orderId: string; symbol: string; localSymbol?: string }> {
     return this.git.getPendingOrderIds()
+  }
+
+  /** firstSeen/lastPolled per pending order — drives the per-order polling
+   *  backoff for brokers without a listing API. In-memory only: a restart
+   *  resets every order to "fresh", which just means one eager poll. */
+  private _pollState = new Map<string, { firstSeenAt: number; lastPolledAt: number }>()
+
+  private _pollBackoffDue(orderId: string): boolean {
+    const now = Date.now()
+    const state = this._pollState.get(orderId)
+    if (!state) {
+      this._pollState.set(orderId, { firstSeenAt: now, lastPolledAt: now })
+      return true
+    }
+    const age = now - state.firstSeenAt
+    // <2min old: every pass (marketable orders resolve here). <1h: every
+    // 60s. Older: every 5min — it's a hanger (stop/take-profit), awareness
+    // latency of minutes changes nothing about the execution itself.
+    const interval = age < 2 * 60_000 ? 0 : age < 60 * 60_000 ? 60_000 : 5 * 60_000
+    if (now - state.lastPolledAt < interval) return false
+    state.lastPolledAt = now
+    return true
   }
 
   /**
@@ -687,6 +741,20 @@ export class UnifiedTradingAccount {
     const walletPositions = positions.filter(p => p.avgCostSource === 'wallet')
     if (walletPositions.length === 0) return
 
+    // Race guard (observed live as commit dfb01435): a fill can land on the
+    // exchange between the broker's position read and the poller's sync
+    // pass. The position already shows the new quantity, but the projection
+    // doesn't include the fill yet — naive drift detection would book it as
+    // a reconcileBalance at the OBSERVATION-TIME mark price, polluting cost
+    // basis with the wrong price and double-counting once sync records the
+    // real execution. While an aliceId has in-flight orders, its drift
+    // belongs to sync; reconcile only what no pending order can explain.
+    // True residuals (fee-in-kind dust, external transfers racing an open
+    // order) get reconciled on the next pass after the order settles.
+    const inFlight = new Set(
+      this.git.getPendingOrderIds().map((p) => p.aliceId).filter(Boolean),
+    )
+
     for (const p of walletPositions) {
       const aliceId = p.contract.aliceId
       if (!aliceId) continue
@@ -697,8 +765,11 @@ export class UnifiedTradingAccount {
       const drift = p.quantity.minus(projectedQty)
 
       // Tolerance: dust-level differences (sub-1e-8) come from precision
-      // round-trips, not from real balance changes.
-      if (drift.abs().gt(new Decimal('1e-8'))) {
+      // round-trips, not from real balance changes. The in-flight guard
+      // only suppresses RECORDING — the avgCost/PnL projection below still
+      // applies, so a position with a weeks-long hanging stop order keeps
+      // its real cost basis on screen throughout.
+      if (!inFlight.has(aliceId) && drift.abs().gt(new Decimal('1e-8'))) {
         // Bootstrap price: prefer broker-reported avgCost when non-zero
         // (Mock externalTrade, future CCXT-with-fetchMyTrades, anything
         // that observed a real fill price). Fall back to markPrice only

--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -75,6 +75,22 @@ function ibkrTifToAlpaca(tif: string): string {
   }
 }
 
+/**
+ * Surface Alpaca's response body in failures. The SDK throws axios-shaped
+ * errors whose message is just "Request failed with status code 422" — the
+ * actual reason ("order is not cancelable", observed live when cancelling
+ * during the after-hours pending_new window) lives in response.data and was
+ * being dropped, leaving the git record and the UI with an opaque code.
+ */
+function alpacaErrorMessage(err: unknown): string {
+  const base = err instanceof Error ? err.message : String(err)
+  const data = (err as { response?: { data?: unknown } })?.response?.data
+  if (data && typeof data === 'object') {
+    return `${base} — alpaca: ${JSON.stringify(data)}`
+  }
+  return base
+}
+
 export class AlpacaBroker implements IBroker {
   // ---- Self-registration ----
 
@@ -299,7 +315,7 @@ export class AlpacaBroker implements IBroker {
         orderState: makeOrderState(result.status),
       }
     } catch (err) {
-      return { success: false, error: err instanceof Error ? err.message : String(err) }
+      return { success: false, error: alpacaErrorMessage(err) }
     }
   }
 
@@ -320,7 +336,7 @@ export class AlpacaBroker implements IBroker {
         orderState: makeOrderState(result.status),
       }
     } catch (err) {
-      return { success: false, error: err instanceof Error ? err.message : String(err) }
+      return { success: false, error: alpacaErrorMessage(err) }
     }
   }
 
@@ -331,7 +347,7 @@ export class AlpacaBroker implements IBroker {
       orderState.status = 'Cancelled'
       return { success: true, orderId, orderState }
     } catch (err) {
-      return { success: false, error: err instanceof Error ? err.message : String(err) }
+      return { success: false, error: alpacaErrorMessage(err) }
     }
   }
 
@@ -365,7 +381,7 @@ export class AlpacaBroker implements IBroker {
         orderState: makeOrderState(result.status),
       }
     } catch (err) {
-      return { success: false, error: err instanceof Error ? err.message : String(err) }
+      return { success: false, error: alpacaErrorMessage(err) }
     }
   }
 

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -47,6 +47,7 @@ import {
   defaultCancelOrderById,
   defaultPlaceOrder,
   defaultFetchPositions,
+  defaultFetchAllOpenOrders,
 } from './overrides.js'
 
 // Treated as cash (1:1 to USD) when computing balances and as ineligible
@@ -891,7 +892,10 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
     if (this.keyless) return []
     this.ensureInit()
     try {
-      const raw = await this.exchange.fetchOpenOrders()
+      const fetchOverride = this.overrides.fetchAllOpenOrders
+      const raw = fetchOverride
+        ? await fetchOverride(this.exchange, defaultFetchAllOpenOrders)
+        : await defaultFetchAllOpenOrders(this.exchange)
       const converted: OpenOrder[] = []
       for (const o of raw) {
         // convertCcxtOrder also seeds the orderId→symbol cache, so an

--- a/services/uta/src/domain/trading/brokers/ccxt/exchanges/bybit.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/exchanges/bybit.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { Exchange, Order as CcxtOrder } from 'ccxt'
+import { bybitOverrides } from './bybit.js'
+
+function fakeOrder(id: string, symbol: string): CcxtOrder {
+  return { id, symbol } as CcxtOrder
+}
+
+describe('bybitOverrides.fetchAllOpenOrders', () => {
+  it('sweeps spot + swap categories and merges by id', async () => {
+    // The live failure mode this guards: defaultType is 'swap', so an
+    // unscoped fetchOpenOrders() silently returns only swap orders while a
+    // real spot order sits open (observed on bybit demo, no error raised).
+    const byType: Record<string, CcxtOrder[]> = {
+      spot: [fakeOrder('s1', 'ETH/USDT')],
+      swap: [fakeOrder('w1', 'BTC/USDT:USDT'), fakeOrder('s1', 'ETH/USDT')], // overlap dedupes
+    }
+    const exchange = {
+      fetchOpenOrders: vi.fn(async (_s, _since, _limit, params: { type: string }) => byType[params.type] ?? []),
+    } as unknown as Exchange
+
+    const result = await bybitOverrides.fetchAllOpenOrders!(exchange, async () => [])
+    expect(result.map((o) => o.id).sort()).toEqual(['s1', 'w1'])
+    expect((exchange.fetchOpenOrders as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[3])).toEqual([
+      { type: 'spot' },
+      { type: 'swap' },
+    ])
+  })
+
+  it('throws when a category fails — partial listings must not ghost real orders', async () => {
+    const exchange = {
+      fetchOpenOrders: vi.fn(async (_s, _since, _limit, params: { type: string }) => {
+        if (params.type === 'swap') throw new Error('bybit 10016 service error')
+        return [fakeOrder('s1', 'ETH/USDT')]
+      }),
+    } as unknown as Exchange
+
+    await expect(bybitOverrides.fetchAllOpenOrders!(exchange, async () => [])).rejects.toThrow('10016')
+  })
+})

--- a/services/uta/src/domain/trading/brokers/ccxt/exchanges/bybit.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/exchanges/bybit.ts
@@ -29,4 +29,25 @@ export const bybitOverrides: CcxtExchangeOverrides = {
   },
 
   // cancelOrderById: not overridden — default { stop: true } fallback works for Bybit
+
+  /**
+   * Bybit's open-orders listing is category-scoped, and the broker config
+   * sets defaultType 'swap' — an unscoped fetchOpenOrders() silently
+   * returns ONLY swap orders (observed live: a real open spot order,
+   * empty list, no error). Sweep every category the account trades and
+   * merge. Throws if any category fails — a partial listing would ghost
+   * real orders out of absence-detection and external observation, which
+   * is worse than observation being loudly off (same rule as full-spectrum
+   * market loading).
+   */
+  async fetchAllOpenOrders(exchange: Exchange, _defaultImpl): Promise<CcxtOrder[]> {
+    const merged = new Map<string, CcxtOrder>()
+    for (const type of ['spot', 'swap'] as const) {
+      const orders = await exchange.fetchOpenOrders(undefined, undefined, undefined, { type })
+      for (const o of orders) {
+        if (o.id) merged.set(o.id, o)
+      }
+    }
+    return Array.from(merged.values())
+  },
 }

--- a/services/uta/src/domain/trading/brokers/ccxt/overrides.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/overrides.ts
@@ -71,6 +71,15 @@ export interface CcxtExchangeOverrides {
     exchange: Exchange,
     defaultImpl: DefaultImpl<[Exchange], CcxtPosition[]>,
   ): Promise<CcxtPosition[]>
+
+  /** List ALL open orders across every market type the account trades.
+   *  Override when the venue's listing endpoint is category-scoped and the
+   *  unscoped call silently returns a subset (bybit: defaultType 'swap'
+   *  hides spot orders — observed live, no error raised). */
+  fetchAllOpenOrders?(
+    exchange: Exchange,
+    defaultImpl: DefaultImpl<[Exchange], CcxtOrder[]>,
+  ): Promise<CcxtOrder[]>
 }
 
 // ==================== Default implementations ====================
@@ -118,6 +127,18 @@ export async function defaultPlaceOrder(
 /** Default: pass straight through to ccxt.fetchPositions. */
 export async function defaultFetchPositions(exchange: Exchange): Promise<CcxtPosition[]> {
   return await exchange.fetchPositions()
+}
+
+/**
+ * Default: one unscoped fetchOpenOrders call. Verified live on OKX — its
+ * pending-orders endpoint is NOT instType-scoped, so a single call returns
+ * spot + swap together. Do NOT assume that generalizes: ccxt has no
+ * semantics here, it's an SDK over whatever the venue does. Exchanges whose
+ * listing is category-scoped (bybit) get their own override; new exchanges
+ * should be probed live before trusting this default.
+ */
+export async function defaultFetchAllOpenOrders(exchange: Exchange): Promise<CcxtOrder[]> {
+  return await exchange.fetchOpenOrders()
 }
 
 // ==================== Registry ====================

--- a/services/uta/src/domain/trading/git/TradingGit.spec.ts
+++ b/services/uta/src/domain/trading/git/TradingGit.spec.ts
@@ -688,7 +688,9 @@ describe('TradingGit', () => {
 
       const pending = gitP.getPendingOrderIds()
       expect(pending).toHaveLength(1)
-      expect(pending[0]).toEqual({ orderId: 'lmt-1', symbol: 'AAPL' })
+      // localSymbol/aliceId ride along when the operation's contract has
+      // them — broker lookup hint + reconcile race guard respectively.
+      expect(pending[0]).toMatchObject({ orderId: 'lmt-1', symbol: 'AAPL' })
     })
 
     it('excludes orders that have been synced to filled', async () => {

--- a/services/uta/src/domain/trading/git/TradingGit.ts
+++ b/services/uta/src/domain/trading/git/TradingGit.ts
@@ -589,7 +589,7 @@ export class TradingGit implements ITradingGit {
     return { hash, updatedCount: updates.length, updates }
   }
 
-  getPendingOrderIds(): Array<{ orderId: string; symbol: string; localSymbol?: string }> {
+  getPendingOrderIds(): Array<{ orderId: string; symbol: string; localSymbol?: string; aliceId?: string }> {
     // Scan newest→oldest to find latest known status per orderId
     const orderStatus = new Map<string, string>()
 
@@ -602,7 +602,7 @@ export class TradingGit implements ITradingGit {
     }
 
     // Collect orders still pending
-    const pending: Array<{ orderId: string; symbol: string; localSymbol?: string }> = []
+    const pending: Array<{ orderId: string; symbol: string; localSymbol?: string; aliceId?: string }> = []
     const seen = new Set<string>()
 
     for (const commit of this.commits) {
@@ -618,11 +618,16 @@ export class TradingGit implements ITradingGit {
           // Broker-native symbol for symbol-scoped order lookups (CCXT).
           // Persisted with the operation, so it survives process restarts
           // where the broker's in-memory orderId→symbol cache is empty.
-          const localSymbol =
-            (op?.action === 'placeOrder' || op?.action === 'closePosition' || op?.action === 'observeExternalOrder')
-              ? op.contract?.localSymbol || undefined
-              : undefined
-          pending.push({ orderId: result.orderId, symbol, ...(localSymbol && { localSymbol }) })
+          const hasContract =
+            op?.action === 'placeOrder' || op?.action === 'closePosition' || op?.action === 'observeExternalOrder'
+          const localSymbol = hasContract ? op.contract?.localSymbol || undefined : undefined
+          const aliceId = hasContract ? op.contract?.aliceId || undefined : undefined
+          pending.push({
+            orderId: result.orderId,
+            symbol,
+            ...(localSymbol && { localSymbol }),
+            ...(aliceId && { aliceId }),
+          })
           seen.add(result.orderId)
         }
       }

--- a/services/uta/src/domain/trading/git/interfaces.ts
+++ b/services/uta/src/domain/trading/git/interfaces.ts
@@ -55,7 +55,7 @@ export interface ITradingGit {
   /** `localSymbol` is the broker-native symbol from the order's operation
    *  contract — passed to IBroker.getOrder as the symbolHint so lookups
    *  survive restarts (CCXT's order API is symbol-scoped). */
-  getPendingOrderIds(): Array<{ orderId: string; symbol: string; localSymbol?: string }>
+  getPendingOrderIds(): Array<{ orderId: string; symbol: string; localSymbol?: string; aliceId?: string }>
   /** Squash externally-observed open orders into one [observed] commit. */
   recordObservedOrders(params: {
     observed: Array<{ contract: Contract; order: Order; orderId: string }>


### PR DESCRIPTION
## Summary
- **Fast lane restructured around listings** (design discussion: long-lived conditional orders broke the per-order polling cost model — a parked stop-loss meant 8.6k getOrder calls/day each). With `getOpenOrders`: ONE listing per pass covers all pending orders; present = alive (zero calls however long it hangs), absent = transitioned → only then getOrder confirms terminal state + execution data. Absence is never trusted as terminal (algo orders can live in a different listing namespace). Without listing capability: per-order polling with age backoff (every pass <2min → 1m → 5m).
- **ANG-102 #3 race guard**: wallet drift-reconcile defers while the aliceId has in-flight orders — the drift belongs to sync (real execution price), not a mark-price reconcileBalance double-booking a fill that landed between the position read and the sync pass. avgCost/PnL projection still applies during deferral.

## Test plan
- [x] `pnpm test` 1876 passing (new: listing-mode zero-cost steady state, capability fallback, fake-timer backoff schedule, reconcile-defer-then-residual)
- [x] **Live on OKX demo**: two far hangers untouched across passes; marketable order filled & synced in **6.1s** under listing mode; cancels detected; and the money shot — sell fill synced @1677.39 with the reconcile in the same second releasing only the 0.00001 fee dust (true residual), where the old code would have booked the full quantity at mark price.

## Boundary touch
Trading order state machine internals (sync strategy, reconcile timing). No wire/protocol changes beyond an optional aliceId field on the pending-order projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)