### PR TITLE
chore(release): 0.42.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.41.0-beta.1",
+  "version": "0.42.0-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary
- Bump version 0.41.0-beta.1 → 0.42.0-beta.1 (root package.json only, same as previous bumps).
- On merge, release.yml reads the version from master, creates tag v0.42.0-beta.1 and publishes the prerelease with git-cliff notes — no manual tagging.
- Release window: PRs #301–#328. Headline items: reopenable headless sessions (#326), ~/.openalice data root + sealed broker credentials (migration 0009), UTA order-lifecycle close (#325/#327/#328), CLI-default tool access + alice-uta (#319/#320), self-host port hardening, market-data settings revamp.

## Test plan
- [x] master synced; full suite green on the merged tree (1870 tests)
- [x] version string is the only change in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)