### PR TITLE
STP orders actually reach CCXT venues — round-3 dogfood catch

### DIFF
--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -476,7 +476,27 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         }
       }
 
-      const ccxtOrderType = ibkrOrderTypeToCcxt(order.orderType)
+      // Conditional orders: ccxt's convention is BASE type (market/limit) +
+      // params.triggerPrice — ccxt routes each venue to its algo endpoint.
+      // The old lowercase passthrough sent okx a literal ordType "stp"
+      // (51000 Parameter error, observed live), which meant the documented
+      // "place a separate stop" path didn't work either. TRAIL* stays
+      // refused until venue-verified — same rule as attached TP/SL.
+      let ccxtOrderType = ibkrOrderTypeToCcxt(order.orderType)
+      if (order.orderType === 'STP' || order.orderType === 'STP LMT') {
+        if (order.auxPrice.equals(UNSET_DECIMAL)) {
+          return { success: false, error: `${order.orderType} requires auxPrice (the stop trigger price).` }
+        }
+        params.triggerPrice = order.auxPrice.toNumber()
+        ccxtOrderType = order.orderType === 'STP' ? 'market' : 'limit'
+      } else if (order.orderType === 'TRAIL' || order.orderType === 'TRAIL LIMIT') {
+        return {
+          success: false,
+          error:
+            `${order.orderType} is not verified to reach ${this.exchangeName} through ccxt — refusing rather ` +
+            `than risking a silently mis-typed order. Use STP / STP LMT, or manage the trail manually.`,
+        }
+      }
       const side = order.action.toLowerCase() as 'buy' | 'sell'
       // CCXT SDK expects number for price — convert at the wire boundary.
       const refPrice = ccxtOrderType === 'limit' && !order.lmtPrice.equals(UNSET_DECIMAL)


### PR DESCRIPTION
## Summary
- **There was no working stop-loss route on okx at all**: `ibkrOrderTypeToCcxt` lowercased `STP` into a literal ordType `"stp"` → okx 51000 — so the "place a separate stop" path that the TPSL refusal gate recommends was also broken. Caught by a multi-op commit dogfood (entry + protective stop in one approval): entry filled, stop rejected, loud mixed-result narration (the state machine behaved exactly as designed).
- Fix per CCXT's real convention: conditional orders keep the **base type + `params.triggerPrice`**; ccxt routes per-venue. STP → market+trigger, STP LMT → limit+trigger. **Live-verified on okx demo**: accepted into the algo namespace, tracked as `submitted` across poller passes (the `{stop:true}` getOrder fallback finds it — absence from the regular listing does not mis-terminal it), and cancellable through the TaG flow.
- TRAIL / TRAIL LIMIT now refuse loudly until venue-verified (same rule as attached TP/SL).
- Bonus observation for ANG-103: okx algo orders are invisible even to `fetchOpenOrders({trigger:true})` with default params — the trigger-namespace listing work is confirmed necessary.

## Test plan
- [x] `pnpm test` 1895 passing
- [x] Live okx demo: STP place → track (2+ poller passes, stays working) → cancel via TaG; account left flat, 0 staged

## Boundary touch
CCXT order-type mapping (order entry path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)