### PR TITLE
fix(uta,alpaca): single attached exit leg → oto, not bracket

### DIFF
--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
@@ -155,6 +155,60 @@ describe('AlpacaBroker — placeOrder()', () => {
     ])
   })
 
+  it('uses order_class "oto" (not "bracket") when only one exit leg is attached', async () => {
+    // Regression: a single stop_loss under order_class "bracket" is rejected
+    // 422 by Alpaca ("bracket orders require take_profit.limit_price"). One
+    // leg must go out as "oto", two legs as "bracket".
+    const createOrder = vi.fn().mockResolvedValue({ id: 'ord-oto', status: 'new' })
+    const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
+    ;(acc as any).client = { createOrder }
+    const contract = new Contract()
+    contract.aliceId = 'alpaca-paper|FCX'
+    contract.symbol = 'FCX'
+    contract.secType = 'STK'
+    contract.exchange = 'NYSE'
+    contract.currency = 'USD'
+
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal(90)
+    order.lmtPrice = new Decimal('65')
+
+    // Only a stop loss, no take profit — the case that 422'd in production.
+    const result = await acc.placeOrder(contract, order, { stopLoss: { price: '58' } })
+    expect(result.success).toBe(true)
+    const sent = createOrder.mock.calls[0][0]
+    expect(sent.order_class).toBe('oto')
+    expect(sent.stop_loss).toEqual({ stop_price: 58 })
+    expect(sent.take_profit).toBeUndefined()
+  })
+
+  it('uses order_class "bracket" when both exit legs are attached', async () => {
+    const createOrder = vi.fn().mockResolvedValue({ id: 'ord-br', status: 'new' })
+    const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
+    ;(acc as any).client = { createOrder }
+    const contract = new Contract()
+    contract.aliceId = 'alpaca-paper|AAPL'
+    contract.symbol = 'AAPL'
+    contract.secType = 'STK'
+    contract.exchange = 'NASDAQ'
+    contract.currency = 'USD'
+
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal(1)
+    order.lmtPrice = new Decimal('291.57')
+
+    const result = await acc.placeOrder(contract, order, {
+      takeProfit: { price: '297' },
+      stopLoss: { price: '285.5' },
+    })
+    expect(result.success).toBe(true)
+    expect(createOrder.mock.calls[0][0].order_class).toBe('bracket')
+  })
+
   it('omits legs for simple (non-bracket) placements', async () => {
     const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
     ;(acc as any).client = {

--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -294,9 +294,13 @@ export class AlpacaBroker implements IBroker {
       if (!order.trailingPercent.equals(UNSET_DECIMAL)) alpacaOrder.trail_percent = order.trailingPercent.toFixed()
       if (order.outsideRth) alpacaOrder.extended_hours = true
 
-      // Bracket order (TPSL)
+      // Attached exit legs (TPSL). Alpaca's `bracket` class REQUIRES both
+      // take_profit AND stop_loss — a single leg under `bracket` is rejected
+      // 422 ("bracket orders require take_profit.limit_price"). When only one
+      // leg is present, `oto` (one-triggers-other) is the correct class, which
+      // accepts either leg alone. So: two legs → bracket, one leg → oto.
       if (tpsl?.takeProfit || tpsl?.stopLoss) {
-        alpacaOrder.order_class = 'bracket'
+        alpacaOrder.order_class = (tpsl.takeProfit && tpsl.stopLoss) ? 'bracket' : 'oto'
         if (tpsl.takeProfit) {
           alpacaOrder.take_profit = { limit_price: parseFloat(tpsl.takeProfit.price) }
         }


### PR DESCRIPTION
## Summary
- Alpaca's `bracket` order_class requires **both** take_profit and stop_loss. The broker set `order_class='bracket'` whenever *either* leg was present, so a "limit entry + stop-loss only" order was rejected at push with `422 bracket orders require take_profit.limit_price` — after the user had already approved it.
- Fix routes by leg count: two legs → `bracket`, one leg → `oto` (one-triggers-other), which Alpaca accepts with a single leg. Single-stop orders now place as entry + held stop leg.
- Broader "catch venue constraints at stage time, not after push" work tracked separately in [ANG-108](https://linear.app/angelkawaii/issue/ANG-108/stage-time-validation-should-be-broker-aware-catch-venue-constraints).

## Test plan
- [x] `AlpacaBroker.spec.ts` 43/43 (added 2 regressions: single leg → `oto`, both legs → `bracket`)
- [x] Verified end-to-end on `alpaca-paper` via the original failing path (place → approve): FCX 1@\$50 + SL\$45 now submits as entry+stop instead of 422; cancel left the account flat, real orders untouched
- [ ] `pnpm test` (full suite — not re-run; change is isolated to AlpacaBroker + its spec)

## Boundary touch
Touches the trading execution path (UTA broker order placement, Alpaca). No auth / credential / migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)