### PR TITLE
feat(ui): Ask Alice as a chat-history sidebar — titles, day buckets, safer session controls

### DIFF
--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -83,6 +83,9 @@ function parseSeedPrompt(
   return { prompt: trimmed };
 }
 
+/** Max stored length of a session title (the seed message); the row truncates further. */
+const MAX_SESSION_TITLE = 200;
+
 /** The 201 body both `/:id/sessions/spawn` and `/quick-chat` return. */
 interface SpawnedSessionBody {
   readonly sessionId: string;
@@ -92,6 +95,8 @@ interface SpawnedSessionBody {
   readonly agent: string;
   readonly agentSessionId: string | null;
   readonly startedAt: number;
+  /** The seed message, when the session was seeded — its sidebar title. */
+  readonly title: string | null;
 }
 
 type SpawnSessionResult =
@@ -136,6 +141,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     const recordId = randomUUID();
     const recordName = svc.sessionRegistry.nextName(id, adapter.id, prefix);
     const nowIso = new Date().toISOString();
+    const title = initialPrompt ? initialPrompt.slice(0, MAX_SESSION_TITLE) : undefined;
     const record: SessionRecord = {
       id: recordId,
       wsId: id,
@@ -144,6 +150,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
       createdAt: nowIso,
       lastActiveAt: nowIso,
       state: 'running',
+      ...(title !== undefined ? { title } : {}),
     };
     try {
       await svc.sessionRegistry.create(record);
@@ -179,6 +186,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
           agent: adapter.id,
           agentSessionId: session.agentSessionId,
           startedAt: session.startedAt,
+          title: title ?? null,
         },
       };
     } catch (err) {

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -549,6 +549,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         agentSessionId: liveEntry?.agentSessionId ?? r.resumeHint?.value ?? null,
         pid: liveEntry?.pid ?? null,
         startedAt: liveEntry?.startedAt ?? null,
+        title: r.title ?? null,
       };
     });
     // Workspace AI provider override signals — read by the Overview

--- a/src/workspaces/session-registry.ts
+++ b/src/workspaces/session-registry.ts
@@ -33,6 +33,13 @@ export interface SessionRecord {
   state: 'running' | 'paused';
   resumeHint?: { kind: 'agent-session-id'; value: string };
   scrollbackFile?: string;
+  /**
+   * The user's first message, captured when the session is seeded (quick-chat).
+   * Surfaced as a human-readable title in the chat sidebar instead of the sticky
+   * `c1` name. Only present for seeded sessions; absent ones fall back to `name`.
+   * Stored capped — we don't need the whole prompt for a one-line title.
+   */
+  readonly title?: string;
 }
 
 interface FileShape {

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -90,13 +90,14 @@ interface NavSection {
 
 const NAV_SECTIONS: NavSection[] = [
   // Top — primary nav, always visible (no header, not collapsible).
-  // Mental model: Chat (Ask Alice) is the everyday entry — for most
-  // sessions the chat-template workspace is all you need, so it sits
-  // high. Workspaces (the all-templates index) is the power-user
-  // surface for hands-on session management; the two aren't redundant
-  // (Workspaces = whole set, Chat = chat-shape subset shortcut), but
-  // because day-to-day work rarely leaves Ask Alice, Workspaces sits
-  // at the bottom of this group rather than alongside Chat.
+  // Mental model: Chat (Ask Alice) is THE entry — for an AI product the
+  // chat surface is the front door (how you use the thing), so it sits at
+  // the very top, above Inbox (which is task sync, not the core loop).
+  // Workspaces (the all-templates index) is the power-user surface for
+  // hands-on session management; the two aren't redundant (Workspaces =
+  // whole set, Chat = chat-shape subset shortcut), but because day-to-day
+  // work rarely leaves Ask Alice, Workspaces sits at the bottom of this
+  // group rather than alongside Chat.
   //
   // Market / News are operational tools that work but aren't load-
   // bearing — they live here because they don't need lifecycle
@@ -104,9 +105,9 @@ const NAV_SECTIONS: NavSection[] = [
   {
     sectionLabel: '',
     items: [
+      { page: 'chat',       labelKey: 'nav.item.chat',       icon: MessageSquare, defaultTab: { kind: 'chat-landing', params: {} } },
       { page: 'inbox',      labelKey: 'nav.item.inbox',      icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
       { page: 'tracked',    labelKey: 'nav.item.tracked',    icon: Telescope, defaultTab: { kind: 'tracked', params: {} } },
-      { page: 'chat',       labelKey: 'nav.item.chat',       icon: MessageSquare, defaultTab: { kind: 'chat-landing', params: {} } },
       { page: 'market',     labelKey: 'nav.item.market',     icon: BarChart3 },
       { page: 'news',       labelKey: 'nav.item.news',       icon: Newspaper, defaultTab: { kind: 'news', params: {} } },
       { page: 'workspaces', labelKey: 'nav.item.workspaces', icon: TerminalSquare },

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -12,15 +12,16 @@
  * this surface is for chatting, not workspace management.
  */
 
-import { useMemo, useState, type ReactElement } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronRight, Plus, Settings as SettingsIcon, X } from 'lucide-react'
+import { ChevronDown, ChevronRight, FolderPlus, Plus, Settings as SettingsIcon, X } from 'lucide-react'
 
 import { useWorkspaces } from '../../contexts/WorkspacesContext'
 import { useWorkspace } from '../../tabs/store'
 import { getFocusedTab } from '../../tabs/types'
 import { ConfirmDialog } from '../ConfirmDialog'
 import { deleteWorkspace, type SessionRecord, type Workspace } from './api'
+import { CreateWorkspaceDialog } from './CreateWorkspaceDialog'
 import { SessionRow } from './Sidebar'
 
 const CHAT_TEMPLATE = 'chat'
@@ -59,6 +60,19 @@ export function ChatWorkspaceSection(): ReactElement | null {
 
   const chatTemplate = ctx.templates.find((tpl) => tpl.name === CHAT_TEMPLATE)
   const [pendingDelete, setPendingDelete] = useState<Workspace | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close the "more" menu on an outside click.
+  useEffect(() => {
+    if (!menuOpen) return
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [menuOpen])
 
   const handleConfirmDelete = async (): Promise<void> => {
     if (!pendingDelete) return
@@ -77,17 +91,69 @@ export function ChatWorkspaceSection(): ReactElement | null {
 
   return (
     <>
-      {/* Primary action — start a new conversation (the Ask Alice composer). */}
+      {/* Primary action: New chat (the Ask Alice composer). The split caret
+          keeps the power-user "New workspace" (named, custom tag) reachable. */}
       <div className="px-2 pt-2 pb-1.5">
-        <button
-          type="button"
-          onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
-          className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-border/60 bg-bg-tertiary/30 text-[13px] font-medium text-text-muted transition-colors hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/60"
-        >
-          <Plus size={15} strokeWidth={2.25} />
-          <span>{t('chat.newChat')}</span>
-        </button>
+        <div className="flex items-stretch gap-1">
+          <button
+            type="button"
+            onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
+            className="flex-1 min-w-0 flex items-center gap-2 px-3 py-2 rounded-lg border border-border/60 bg-bg-tertiary/30 text-[13px] font-medium text-text-muted transition-colors hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/60"
+          >
+            <Plus size={15} strokeWidth={2.25} className="shrink-0" />
+            <span className="truncate">{t('chat.newChat')}</span>
+          </button>
+          <div ref={menuRef} className="relative shrink-0">
+            <button
+              type="button"
+              onClick={() => setMenuOpen((o) => !o)}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              aria-label={t('chat.moreOptions')}
+              title={t('chat.moreOptions')}
+              className={`h-full px-2 flex items-center justify-center rounded-lg border transition-colors ${
+                menuOpen
+                  ? 'border-accent/50 bg-bg-tertiary/60 text-text'
+                  : 'border-border/60 bg-bg-tertiary/30 text-text-muted hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/60'
+              }`}
+            >
+              <ChevronDown size={14} strokeWidth={2.25} />
+            </button>
+            {menuOpen && (
+              <div
+                role="menu"
+                className="absolute right-0 top-full mt-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setMenuOpen(false)
+                    setShowCreate(true)
+                  }}
+                  className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-text transition-colors hover:bg-bg-tertiary"
+                >
+                  <FolderPlus size={14} strokeWidth={2} className="shrink-0 text-text-muted" />
+                  <span>{t('chat.newWorkspace')}</span>
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
+
+      {showCreate && (
+        <CreateWorkspaceDialog
+          templates={ctx.templates}
+          agents={ctx.agents}
+          presetTemplate={CHAT_TEMPLATE}
+          onCreated={(workspace) => {
+            ctx.refresh()
+            openOrFocus({ kind: 'workspace', params: { wsId: workspace.id } })
+          }}
+          onClose={() => setShowCreate(false)}
+        />
+      )}
 
       <ul className="py-0.5">
         {chatWorkspaces.length === 0 && !ctx.listError && (

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -178,7 +178,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
             }
             onPauseSession={(sid) => void ctx.pauseSession(w.id, sid)}
             onResumeSession={(sid) => void ctx.resumeSession(w.id, sid)}
-            onDeleteSession={(sid) => void ctx.deleteSession(w.id, sid)}
+            onDeleteSession={(sid) => ctx.requestDeleteSession(w.id, sid)}
             onConfigure={() => ctx.openAgentConfig(w.id)}
             onDelete={() => setPendingDelete(w)}
           />

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -1,15 +1,15 @@
 /**
- * "Workspace chat" section embedded inside the Chat activity sidebar.
+ * "Ask Alice" secondary sidebar — your chat history.
  *
- * Visual rhythm matches the Traditional channels list below — single
- * row per workspace, with a collapsible session sub-tree. Status dot
- * prefix conveys running/idle without needing a "4h" trailing meta.
+ * Reads as a conversation list: a prominent "New chat" action on top (opens the
+ * Ask Alice composer), then chat workspaces newest-first. Each workspace is a
+ * day's bucket — daily ones (`chat-jun15`) are relabelled Today / Yesterday /
+ * "Jun 14" so the list reads like chat history; user-named ones (`nvda-thesis`)
+ * keep their tag. Sessions hang underneath as the day's individual
+ * conversations, resumable on click.
  *
- * The create form is hidden behind a `+` toggle in the section header;
- * when opened, the tag input pre-fills with a date-based default
- * (`chat-may13`, `chat-may13-2`, …) so users can hit enter without
- * typing. Power-user spawn-by-agent stays in the Workspaces activity
- * — this sidebar is for "pick a conversation and continue".
+ * Named-workspace creation (a custom tag) lives in the Workspaces activity —
+ * this surface is for chatting, not workspace management.
  */
 
 import { useMemo, useState, type ReactElement } from 'react'
@@ -22,9 +22,24 @@ import { getFocusedTab } from '../../tabs/types'
 import { ConfirmDialog } from '../ConfirmDialog'
 import { deleteWorkspace, type SessionRecord, type Workspace } from './api'
 import { SessionRow } from './Sidebar'
-import { CreateWorkspaceDialog } from './CreateWorkspaceDialog'
 
 const CHAT_TEMPLATE = 'chat'
+
+/** Auto-generated daily tag shape (`chat-jun15`) — these get a friendly date label. */
+const DAILY_TAG_RE = /^chat-[a-z]{3}\d{1,2}$/
+
+/** Friendly label for a chat workspace: Today / Yesterday / "Jun 14" for daily
+ *  buckets, the raw tag for user-named workspaces. */
+function chatLabel(w: Workspace, todayLabel: string, yesterdayLabel: string): string {
+  if (!DAILY_TAG_RE.test(w.tag)) return w.tag
+  const created = new Date(w.createdAt)
+  if (Number.isNaN(created.getTime())) return w.tag
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+  const diffDays = Math.round((startOfDay(new Date()) - startOfDay(created)) / 86_400_000)
+  if (diffDays <= 0) return todayLabel
+  if (diffDays === 1) return yesterdayLabel
+  return created.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
 
 export function ChatWorkspaceSection(): ReactElement | null {
   const { t } = useTranslation()
@@ -43,8 +58,6 @@ export function ChatWorkspaceSection(): ReactElement | null {
     : null
 
   const chatTemplate = ctx.templates.find((tpl) => tpl.name === CHAT_TEMPLATE)
-
-  const [showCreate, setShowCreate] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<Workspace | null>(null)
 
   const handleConfirmDelete = async (): Promise<void> => {
@@ -59,59 +72,40 @@ export function ChatWorkspaceSection(): ReactElement | null {
 
   if (!chatTemplate) return null
 
+  const todayLabel = t('chat.today')
+  const yesterdayLabel = t('chat.yesterday')
+
   return (
     <>
-      <div className="px-3 mt-2 flex items-baseline gap-2">
-        <h3 className="text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
-          {t('chat.workspaceChatHeader')}
-        </h3>
-        <span className="text-[10px] text-text-muted/50">{t('chat.recommended')}</span>
+      {/* Primary action — start a new conversation (the Ask Alice composer). */}
+      <div className="px-2 pt-2 pb-1.5">
         <button
           type="button"
-          onClick={() => setShowCreate(true)}
-          className="ml-auto w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-secondary"
-          title={t('chat.newChatWorkspace')}
-          aria-label={t('chat.newChatWorkspace')}
+          onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
+          className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-border/60 bg-bg-tertiary/30 text-[13px] font-medium text-text-muted transition-colors hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/60"
         >
-          <Plus size={13} strokeWidth={2.25} />
+          <Plus size={15} strokeWidth={2.25} />
+          <span>{t('chat.newChat')}</span>
         </button>
       </div>
-
-      {showCreate && (
-        <CreateWorkspaceDialog
-          templates={ctx.templates}
-          agents={ctx.agents}
-          presetTemplate={CHAT_TEMPLATE}
-          onCreated={(workspace) => {
-            ctx.refresh()
-            openOrFocus({ kind: 'workspace', params: { wsId: workspace.id } })
-          }}
-          onClose={() => setShowCreate(false)}
-        />
-      )}
 
       <ul className="py-0.5">
         {chatWorkspaces.length === 0 && !ctx.listError && (
           <li className="px-3 py-2 text-[12px] text-text-muted/60">{t('chat.noChatWorkspacesYet')}</li>
         )}
-        {ctx.listError && (
-          <li className="px-3 py-1 text-[11px] text-red">{ctx.listError}</li>
-        )}
+        {ctx.listError && <li className="px-3 py-1 text-[11px] text-red">{ctx.listError}</li>}
         {chatWorkspaces.map((w) => (
           <ChatWorkspaceRow
             key={w.id}
             workspace={w}
+            label={chatLabel(w, todayLabel, yesterdayLabel)}
             selection={selection}
             onOpen={() => {
               const recent = mostRecentSession(w.sessions)
-              if (recent) {
-                openOrFocus({
-                  kind: 'workspace',
-                  params: { wsId: w.id, sessionId: recent.id },
-                })
-              } else {
-                openOrFocus({ kind: 'workspace', params: { wsId: w.id } })
-              }
+              openOrFocus({
+                kind: 'workspace',
+                params: recent ? { wsId: w.id, sessionId: recent.id } : { wsId: w.id },
+              })
             }}
             onOpenSession={(sid) =>
               openOrFocus({ kind: 'workspace', params: { wsId: w.id, sessionId: sid } })
@@ -138,9 +132,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
   )
 }
 
-function mostRecentSession(
-  sessions: readonly SessionRecord[],
-): SessionRecord | undefined {
+function mostRecentSession(sessions: readonly SessionRecord[]): SessionRecord | undefined {
   if (sessions.length === 0) return undefined
   return [...sessions].sort(
     (a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime(),
@@ -149,6 +141,7 @@ function mostRecentSession(
 
 interface ChatWorkspaceRowProps {
   workspace: Workspace
+  label: string
   selection: { wsId: string; sessionId: string | null } | null
   onOpen: () => void
   onOpenSession: (sid: string) => void
@@ -164,8 +157,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
   const w = props.workspace
   const hasRunning = w.sessions.some((s) => s.state === 'running')
   const [expanded, setExpanded] = useState(true)
-  const isSelected =
-    props.selection?.wsId === w.id && props.selection.sessionId === null
+  const isSelected = props.selection?.wsId === w.id && props.selection.sessionId === null
 
   const statusClass = hasRunning
     ? 'bg-green'
@@ -176,15 +168,12 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
   return (
     <li className="group relative">
       <div
-        className={`flex items-center gap-1 px-3 py-1 text-[13px] cursor-pointer transition-colors ${
+        className={`flex items-center gap-1 pl-2 pr-2 py-1 text-[13px] cursor-pointer transition-colors ${
           isSelected ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
         }`}
       >
         {isSelected && (
-          <span
-            aria-hidden="true"
-            className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent"
-          />
+          <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />
         )}
         <button
           type="button"
@@ -192,28 +181,30 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
             e.stopPropagation()
             setExpanded((v) => !v)
           }}
-          className="w-3 h-4 flex items-center justify-center text-text-muted/60 hover:text-text"
+          className="w-4 h-5 flex items-center justify-center text-text-muted/50 hover:text-text shrink-0"
           aria-label={expanded ? t('chat.collapseSessions') : t('chat.expandSessions')}
           title={expanded ? t('chat.collapseSessions') : t('chat.expandSessions')}
         >
           {expanded ? (
-            <ChevronDown size={11} strokeWidth={2.25} />
+            <ChevronDown size={12} strokeWidth={2.25} />
           ) : (
-            <ChevronRight size={11} strokeWidth={2.25} />
+            <ChevronRight size={12} strokeWidth={2.25} />
           )}
         </button>
         <button
           type="button"
           onClick={props.onOpen}
-          className="flex-1 min-w-0 flex items-center gap-1.5 text-left"
+          className="flex-1 min-w-0 flex items-center gap-2 text-left"
         >
-          <span
-            className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusClass}`}
-            aria-hidden="true"
-          />
-          <span className="truncate" title={w.tag}>
-            {w.tag}
+          <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusClass}`} aria-hidden="true" />
+          <span className="truncate font-medium" title={w.tag}>
+            {props.label}
           </span>
+          {w.sessions.length > 0 && (
+            <span className="text-[11px] text-text-muted/45 tabular-nums shrink-0">
+              {w.sessions.length}
+            </span>
+          )}
         </button>
         <span className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
           <button

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { formatRelativeTime } from '../../lib/intl';
 import type { ReactElement } from 'react';
-import { Cpu, LayoutGrid, Library, Sparkles, Terminal, type LucideIcon } from 'lucide-react';
+import { Bot, Code2, Cpu, LayoutGrid, Library, Pause, Play, Sparkles, Terminal, X, type LucideIcon } from 'lucide-react';
 
 import { headlessApi, type HeadlessTaskRecord } from '../../api/headless';
 import {
@@ -209,6 +209,8 @@ function agentPrefix(id: string): string {
 const AGENT_ICONS: Record<string, LucideIcon> = {
   claude: Sparkles,
   codex: Cpu,
+  opencode: Code2,
+  pi: Bot,
   shell: Terminal,
 };
 
@@ -487,7 +489,6 @@ export function SessionRow(props: SessionRowProps): ReactElement {
           <AgentBadgeGlyph agentId={s.agent} />
         </span>
         <span className="sidebar-session-name">{s.name}</span>
-        {tidShort && <span className="sidebar-session-tid">{tidShort}</span>}
         {isPaused && <span className="sidebar-session-state">paused</span>}
       </button>
       {isPaused ? (
@@ -495,36 +496,39 @@ export function SessionRow(props: SessionRowProps): ReactElement {
           type="button"
           className="sidebar-session-action sidebar-session-resume"
           title="resume this session"
+          aria-label="resume this session"
           onClick={(e) => {
             e.stopPropagation();
             props.onResume();
           }}
         >
-          ▸
+          <Play size={11} strokeWidth={2.25} fill="currentColor" />
         </button>
       ) : (
         <button
           type="button"
           className="sidebar-session-action sidebar-session-pause"
           title="pause this session"
+          aria-label="pause this session"
           onClick={(e) => {
             e.stopPropagation();
             props.onPause();
           }}
         >
-          ■
+          <Pause size={11} strokeWidth={2.25} fill="currentColor" />
         </button>
       )}
       <button
         type="button"
         className="sidebar-session-action sidebar-session-delete"
         title="delete this session"
+        aria-label="delete this session"
         onClick={(e) => {
           e.stopPropagation();
           props.onDelete();
         }}
       >
-        ×
+        <X size={12} strokeWidth={2.5} />
       </button>
     </li>
   );

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { formatRelativeTime } from '../../lib/intl';
 import type { ReactElement } from 'react';
-import { Bot, Code2, Cpu, LayoutGrid, Library, Pause, Play, Sparkles, Terminal, X, type LucideIcon } from 'lucide-react';
+import { Bot, Code2, Cpu, LayoutGrid, Library, Play, Sparkles, Square, Terminal, X, type LucideIcon } from 'lucide-react';
 
 import { headlessApi, type HeadlessTaskRecord } from '../../api/headless';
 import {
@@ -473,28 +473,35 @@ export interface SessionRowProps {
 export function SessionRow(props: SessionRowProps): ReactElement {
   const s = props.session;
   const isPaused = s.state === 'paused';
+  // Title: the captured first message (seeded sessions), else the sticky name.
+  const display = s.title?.trim() || s.name;
   const tidShort = s.agentSessionId ? s.agentSessionId.slice(0, 8) : null;
-  const titleParts: string[] = [`agent ${s.agent}`];
-  if (s.pid !== null) titleParts.push(`pid ${s.pid}`);
-  if (tidShort) titleParts.push(tidShort);
-  if (isPaused) titleParts.push('paused');
-  const title = titleParts.join(' · ');
+  const metaParts: string[] = [`agent ${s.agent}`];
+  if (s.pid !== null) metaParts.push(`pid ${s.pid}`);
+  if (tidShort) metaParts.push(tidShort);
+  if (isPaused) metaParts.push('paused');
+  const meta = metaParts.join(' · ');
+  // Full message on hover when it's been truncated, then the technical meta.
+  const tooltip = s.title?.trim() ? `${s.title.trim()}\n${meta}` : meta;
 
   return (
     <li
       className={`sidebar-session ${props.isActive ? 'is-active' : ''} ${isPaused ? 'is-paused' : ''}`}
     >
-      <button type="button" className="sidebar-session-main" onClick={props.onSelect} title={title}>
+      <button type="button" className="sidebar-session-main" onClick={props.onSelect} title={tooltip}>
         <span className={`sidebar-agent-badge is-${s.agent} ${isPaused ? 'is-paused' : ''}`}>
           <AgentBadgeGlyph agentId={s.agent} />
         </span>
-        <span className="sidebar-session-name">{s.name}</span>
-        {isPaused && <span className="sidebar-session-state">paused</span>}
+        <span className="sidebar-session-name">{display}</span>
       </button>
+      {/* Right-aligned, always-visible state-as-action: a running session shows
+          STOP (■, click to pause it); a paused one shows PLAY (▶, click to
+          resume). The glyph is the at-a-glance state AND the action; the shape
+          stays put on the right edge regardless of title length. */}
       {isPaused ? (
         <button
           type="button"
-          className="sidebar-session-action sidebar-session-resume"
+          className="sidebar-session-action sidebar-session-resume is-persistent"
           title="resume this session"
           aria-label="resume this session"
           onClick={(e) => {
@@ -502,20 +509,20 @@ export function SessionRow(props: SessionRowProps): ReactElement {
             props.onResume();
           }}
         >
-          <Play size={11} strokeWidth={2.25} fill="currentColor" />
+          <Play size={11} strokeWidth={0} fill="currentColor" />
         </button>
       ) : (
         <button
           type="button"
-          className="sidebar-session-action sidebar-session-pause"
-          title="pause this session"
-          aria-label="pause this session"
+          className="sidebar-session-action sidebar-session-pause is-persistent"
+          title="stop this session"
+          aria-label="stop this session"
           onClick={(e) => {
             e.stopPropagation();
             props.onPause();
           }}
         >
-          <Pause size={11} strokeWidth={2.25} fill="currentColor" />
+          <Square size={10} strokeWidth={0} fill="currentColor" />
         </button>
       )}
       <button

--- a/ui/src/components/workspace/WorkspacesSidebar.tsx
+++ b/ui/src/components/workspace/WorkspacesSidebar.tsx
@@ -44,7 +44,7 @@ export function WorkspacesSidebar() {
         onSpawn={(wsId, opts?: SpawnOpts) => void ctx.spawn(wsId, opts)}
         onPauseSession={(wsId, id) => void ctx.pauseSession(wsId, id)}
         onResumeSession={(wsId, id) => void ctx.resumeSession(wsId, id)}
-        onDeleteSession={(wsId, id) => void ctx.deleteSession(wsId, id)}
+        onDeleteSession={(wsId, id) => ctx.requestDeleteSession(wsId, id)}
         onChanged={() => void ctx.refresh()}
         onConfigureWorkspace={(wsId) => ctx.openAgentConfig(wsId)}
         onOpenOverview={() => openOrFocus({ kind: 'workspace-list', params: {} })}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -192,6 +192,8 @@ export interface SessionRecord {
   readonly agentSessionId: string | null;
   readonly pid: number | null;
   readonly startedAt: number | null;
+  /** First message (seeded sessions) — the sidebar title; null → fall back to `name`. */
+  readonly title: string | null;
 }
 
 export interface SpawnedSession {
@@ -202,6 +204,7 @@ export interface SpawnedSession {
   readonly startedAt: number;
   readonly agent: string;
   readonly agentSessionId: string | null;
+  readonly title: string | null;
 }
 
 export interface SpawnOptions {

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -429,6 +429,14 @@
   background: rgba(126, 231, 135, 0.18);
   color: #7ee787;
 }
+.sidebar-agent-badge.is-opencode {
+  background: rgba(188, 140, 255, 0.18);
+  color: #bc8cff;
+}
+.sidebar-agent-badge.is-pi {
+  background: rgba(247, 120, 186, 0.18);
+  color: #f778ba;
+}
 .sidebar-agent-badge.is-shell {
   background: rgba(210, 153, 34, 0.18);
   color: #d29922;
@@ -446,16 +454,6 @@
 }
 .sidebar-session.is-active .sidebar-session-name {
   color: var(--accent);
-}
-
-.sidebar-session-tid {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 10px;
-  color: var(--fg-dim);
-  font-variant-numeric: tabular-nums;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .sidebar-session-age {
@@ -504,18 +502,24 @@
 }
 
 .sidebar-session-state {
-  font-size: 10px;
+  margin-left: auto;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   color: var(--fg-dim);
-  font-style: italic;
+  opacity: 0.7;
 }
 
 .sidebar-session-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: none;
   border: 0;
   color: var(--fg-dim);
-  padding: 0 8px;
+  padding: 0 6px;
   cursor: pointer;
-  font-size: 11px;
   opacity: 0;
   transition: opacity 80ms, color 80ms;
 }

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -384,7 +384,9 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 3px 8px 3px 4px;
+  /* Taller than a plain id row — these now carry a real message title, which
+     needs vertical room to stay legible (esp. CJK at small sizes). */
+  padding: 6px 8px 6px 4px;
   flex: 1 1 auto;
   cursor: pointer;
   text-align: left;
@@ -447,9 +449,16 @@
 }
 
 .sidebar-session-name {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 12px;
-  font-weight: 600;
+  /* Sans (not mono) — these now carry real message titles (incl. CJK), which
+     read poorly in a monospace face. Truncate to one line; the action glyph
+     and delete stay right-aligned regardless of how long the title is. */
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--fg);
 }
 .sidebar-session.is-active .sidebar-session-name {
@@ -501,16 +510,6 @@
   color: var(--accent);
 }
 
-.sidebar-session-state {
-  margin-left: auto;
-  font-size: 9px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--fg-dim);
-  opacity: 0.7;
-}
-
 .sidebar-session-action {
   display: inline-flex;
   align-items: center;
@@ -518,7 +517,7 @@
   background: none;
   border: 0;
   color: var(--fg-dim);
-  padding: 0 6px;
+  padding: 0 5px;
   cursor: pointer;
   opacity: 0;
   transition: opacity 80ms, color 80ms;
@@ -527,15 +526,16 @@
 .sidebar-session.is-active .sidebar-session-action {
   opacity: 1;
 }
+/* The state-as-action glyph (stop/resume) stays visible at rest — it's the
+   at-a-glance running/paused indicator — just dimmed until the row is hovered. */
+.sidebar-session-action.is-persistent {
+  opacity: 0.5;
+}
 .sidebar-session-pause:hover {
   color: #d29922;
 }
-.sidebar-session-resume {
-  color: #7ee787;
-  font-size: 13px;
-}
 .sidebar-session-resume:hover {
-  color: #95eea0;
+  color: #7ee787;
 }
 .sidebar-session-delete:hover {
   color: var(--danger);

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -25,8 +25,11 @@ import {
   type ReactNode,
 } from 'react'
 
+import { useTranslation } from 'react-i18next'
+
 import '../components/workspace/workspaces.css'
 
+import { ConfirmDialog } from '../components/ConfirmDialog'
 import { WorkspaceAIConfigModal } from '../components/workspace/WorkspaceAIConfigModal'
 import {
   deleteSession as apiDeleteSession,
@@ -68,7 +71,12 @@ interface WorkspacesContextValue {
   quickChat(prompt: string, agent?: string): Promise<void>
   pauseSession(wsId: string, sessionId: string): Promise<void>
   resumeSession(wsId: string, sessionId: string): Promise<void>
-  deleteSession(wsId: string, sessionId: string): Promise<void>
+  /**
+   * Request session deletion — opens a confirm dialog (delete is destructive
+   * and the row's × sits right next to the open-conversation hit area, so a
+   * misclick shouldn't nuke a session). The actual delete runs on confirm.
+   */
+  requestDeleteSession(wsId: string, sessionId: string): void
   /** Open the per-workspace AI-provider config modal for `wsId`. */
   openAgentConfig(wsId: string): void
 }
@@ -90,6 +98,8 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   // button share one modal instance — and the modal survives activity
   // switches (rendered here, not inside an activity-scoped component).
   const [configuringWsId, setConfiguringWsId] = useState<string | null>(null)
+  const [pendingSessionDelete, setPendingSessionDelete] = useState<{ wsId: string; sessionId: string } | null>(null)
+  const { t } = useTranslation()
 
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const closeTab = useWorkspace((s) => s.closeTab)
@@ -129,10 +139,10 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
     }
     const tabsSnap = useWorkspace.getState().tabs
     for (const tabId of Object.keys(tabsSnap)) {
-      const t = tabsSnap[tabId]
-      if (!t || t.spec.kind !== 'workspace') continue
-      const wsId = t.spec.params.wsId
-      const sid = t.spec.params.sessionId
+      const tab = tabsSnap[tabId]
+      if (!tab || tab.spec.kind !== 'workspace') continue
+      const wsId = tab.spec.params.wsId
+      const sid = tab.spec.params.sessionId
       if (!validW.has(wsId)) {
         closeTab(tabId)
         continue
@@ -262,8 +272,8 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
       // reconcile effect — gives instant UI feedback).
       const tabsSnap = useWorkspace.getState().tabs
       for (const tabId of Object.keys(tabsSnap)) {
-        const t = tabsSnap[tabId]
-        if (t && t.spec.kind === 'workspace' && t.spec.params.sessionId === sessionId) {
+        const tab = tabsSnap[tabId]
+        if (tab && tab.spec.kind === 'workspace' && tab.spec.params.sessionId === sessionId) {
           closeTab(tabId)
         }
       }
@@ -272,6 +282,19 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
     },
     [refresh, closeTab],
   )
+
+  // Public delete = confirm first (the × sits next to the open-conversation hit
+  // area; a misclick shouldn't nuke a session). The provider owns the dialog.
+  const requestDeleteSession = useCallback((wsId: string, sessionId: string): void => {
+    setPendingSessionDelete({ wsId, sessionId })
+  }, [])
+
+  const pendingDeleteSession = pendingSessionDelete
+    ? (workspaces.find((w) => w.id === pendingSessionDelete.wsId)?.sessions
+        .find((s) => s.id === pendingSessionDelete.sessionId) ?? null)
+    : null
+  const pendingDeleteLabel =
+    pendingDeleteSession?.title?.trim() || pendingDeleteSession?.name || ''
 
   return (
     <WorkspacesContext.Provider
@@ -285,7 +308,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         quickChat,
         pauseSession,
         resumeSession,
-        deleteSession,
+        requestDeleteSession,
         openAgentConfig: (wsId: string) => setConfiguringWsId(wsId),
       }}
     >
@@ -294,6 +317,20 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         <WorkspaceAIConfigModal
           wsId={configuringWsId}
           onClose={() => setConfiguringWsId(null)}
+        />
+      )}
+      {pendingSessionDelete !== null && (
+        <ConfirmDialog
+          title={t('chat.deleteSessionTitle')}
+          message={t('chat.deleteSessionMessage', {
+            title: pendingDeleteLabel || pendingSessionDelete.sessionId,
+          })}
+          confirmLabel={t('common.delete')}
+          onConfirm={async () => {
+            await deleteSession(pendingSessionDelete.wsId, pendingSessionDelete.sessionId)
+            setPendingSessionDelete(null)
+          }}
+          onClose={() => setPendingSessionDelete(null)}
         />
       )}
     </WorkspacesContext.Provider>

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -159,6 +159,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
           agentSessionId: sess.agentSessionId,
           pid: sess.pid,
           startedAt: sess.startedAt,
+          title: sess.title,
         }
         setWorkspaces((prev) =>
           prev.map((w) =>
@@ -189,6 +190,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         agentSessionId: session.agentSessionId,
         pid: session.pid,
         startedAt: session.startedAt,
+        title: session.title,
       }
       // Upsert so the terminal slot mounts immediately (before the 3s poll):
       // append to the reused workspace, or insert the just-created one. The

--- a/ui/src/demo/fixtures/workspaces.ts
+++ b/ui/src/demo/fixtures/workspaces.ts
@@ -42,18 +42,59 @@ export const demoWorkspace: Workspace = {
 export const DEMO_CHAT_WORKSPACE_ID = 'demo-chat-ws'
 export const DEMO_CHAT_SESSION_ID = 'demo-chat-session'
 
-const demoChatSession: SessionRecord = {
-  id: DEMO_CHAT_SESSION_ID,
-  wsId: DEMO_CHAT_WORKSPACE_ID,
-  agent: 'claude',
-  name: 'c1',
-  createdAt: new Date().toISOString(),
-  lastActiveAt: new Date().toISOString(),
-  state: 'running',
-  agentSessionId: null,
-  pid: 0,
-  startedAt: Date.now(),
-}
+// A small spread of agents + states so the sidebar shows the full session
+// styling (per-agent badge colours for claude/codex/opencode/pi, the paused
+// treatment, and the hover pause/resume/delete icons).
+const demoChatSessions: SessionRecord[] = [
+  {
+    id: DEMO_CHAT_SESSION_ID,
+    wsId: DEMO_CHAT_WORKSPACE_ID,
+    agent: 'claude',
+    name: 'c1',
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+    state: 'running',
+    agentSessionId: null,
+    pid: 0,
+    startedAt: Date.now(),
+  },
+  {
+    id: 'demo-chat-x1',
+    wsId: DEMO_CHAT_WORKSPACE_ID,
+    agent: 'codex',
+    name: 'x1',
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+    state: 'running',
+    agentSessionId: '019eb75e-0b1b-7fa2',
+    pid: 0,
+    startedAt: Date.now(),
+  },
+  {
+    id: 'demo-chat-o1',
+    wsId: DEMO_CHAT_WORKSPACE_ID,
+    agent: 'opencode',
+    name: 'o1',
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+    state: 'paused',
+    agentSessionId: 'ses_148a17c1bffe',
+    pid: null,
+    startedAt: null,
+  },
+  {
+    id: 'demo-chat-p1',
+    wsId: DEMO_CHAT_WORKSPACE_ID,
+    agent: 'pi',
+    name: 'p1',
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+    state: 'paused',
+    agentSessionId: '6850b4d0-1c2e',
+    pid: null,
+    startedAt: null,
+  },
+]
 
 export const demoChatWorkspace: Workspace = {
   id: DEMO_CHAT_WORKSPACE_ID,
@@ -64,8 +105,8 @@ export const demoChatWorkspace: Workspace = {
   spawnedFromVersion: '0.1.0',
   currentVersion: '0.1.0',
   upgradeAvailable: null,
-  agents: ['claude', 'codex'],
-  sessions: [demoChatSession],
+  agents: ['claude', 'codex', 'opencode', 'pi'],
+  sessions: demoChatSessions,
   agentOverride: { claude: false, codex: false, opencode: false, pi: false },
 }
 

--- a/ui/src/demo/fixtures/workspaces.ts
+++ b/ui/src/demo/fixtures/workspaces.ts
@@ -19,6 +19,7 @@ const demoSession: SessionRecord = {
   agentSessionId: null,
   pid: 0,
   startedAt: Date.now(),
+  title: "What jumped out from Apple's Q1 earnings?",
 }
 
 export const demoWorkspace: Workspace = {
@@ -57,6 +58,7 @@ const demoChatSessions: SessionRecord[] = [
     agentSessionId: null,
     pid: 0,
     startedAt: Date.now(),
+    title: "What's moving in semiconductors today?",
   },
   {
     id: 'demo-chat-x1',
@@ -69,6 +71,7 @@ const demoChatSessions: SessionRecord[] = [
     agentSessionId: '019eb75e-0b1b-7fa2',
     pid: 0,
     startedAt: Date.now(),
+    title: 'Build a thesis on NVDA',
   },
   {
     id: 'demo-chat-o1',
@@ -81,6 +84,7 @@ const demoChatSessions: SessionRecord[] = [
     agentSessionId: 'ses_148a17c1bffe',
     pid: null,
     startedAt: null,
+    title: 'Scan the EV supply chain for bottlenecks',
   },
   {
     id: 'demo-chat-p1',
@@ -93,6 +97,7 @@ const demoChatSessions: SessionRecord[] = [
     agentSessionId: '6850b4d0-1c2e',
     pid: null,
     startedAt: null,
+    title: '解释一下美债收益率曲线倒挂意味着什么',
   },
 ]
 

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -57,6 +57,7 @@ export const workspacesHandlers = [
       startedAt: Date.now(),
       agent: 'claude',
       agentSessionId: null,
+      title: null,
     }),
   ),
 
@@ -75,6 +76,7 @@ export const workspacesHandlers = [
           startedAt: Date.now(),
           agent: 'claude',
           agentSessionId: null,
+          title: null,
         },
       },
       { status: 201 },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -107,6 +107,8 @@ export const en = {
   },
   chat: {
     newChat: 'New chat',
+    newWorkspace: 'New workspace',
+    moreOptions: 'More options',
     today: 'Today',
     yesterday: 'Yesterday',
     collapseSessions: 'Collapse sessions',

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -116,6 +116,8 @@ export const en = {
     deleteWorkspace: 'Delete workspace',
     deleteWorkspaceTitle: 'Delete chat workspace',
     deleteWorkspaceMessage: "Delete chat workspace {{tag}}? The files on disk are kept; only the launcher's registry entry is removed. Any open tab for it will close.",
+    deleteSessionTitle: 'Delete conversation',
+    deleteSessionMessage: 'Delete "{{title}}"? This removes the conversation and its history. The workspace stays.',
     noChatWorkspacesYet: 'no chat workspaces yet',
   },
   chatLanding: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -106,9 +106,9 @@ export const en = {
     delete: 'Delete',
   },
   chat: {
-    workspaceChatHeader: 'Workspace chat',
-    recommended: 'recommended',
-    newChatWorkspace: 'New chat workspace',
+    newChat: 'New chat',
+    today: 'Today',
+    yesterday: 'Yesterday',
     collapseSessions: 'Collapse sessions',
     expandSessions: 'Expand sessions',
     deleteWorkspace: 'Delete workspace',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -96,6 +96,8 @@ export const ja: Resources = {
   },
   chat: {
     newChat: '新しいチャット',
+    newWorkspace: '新しいワークスペース',
+    moreOptions: 'その他のオプション',
     today: '今日',
     yesterday: '昨日',
     collapseSessions: 'セッションを折りたたむ',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -105,6 +105,8 @@ export const ja: Resources = {
     deleteWorkspace: 'ワークスペースを削除',
     deleteWorkspaceTitle: 'チャットワークスペースを削除',
     deleteWorkspaceMessage: 'チャットワークスペース {{tag}} を削除しますか？ディスク上のファイルは保持され、ランチャーの登録エントリのみが削除されます。開いているタブはすべて閉じます。',
+    deleteSessionTitle: '会話を削除',
+    deleteSessionMessage: '「{{title}}」を削除しますか？会話とその履歴が削除されます。ワークスペースは残ります。',
     noChatWorkspacesYet: 'チャットワークスペースはまだありません',
   },
   chatLanding: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -95,9 +95,9 @@ export const ja: Resources = {
     delete: '削除',
   },
   chat: {
-    workspaceChatHeader: 'ワークスペースチャット',
-    recommended: '推奨',
-    newChatWorkspace: '新しいチャットワークスペース',
+    newChat: '新しいチャット',
+    today: '今日',
+    yesterday: '昨日',
     collapseSessions: 'セッションを折りたたむ',
     expandSessions: 'セッションを展開',
     deleteWorkspace: 'ワークスペースを削除',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -104,6 +104,8 @@ export const zhHant: Resources = {
   },
   chat: {
     newChat: '新對話',
+    newWorkspace: '新增工作區',
+    moreOptions: '更多選項',
     today: '今天',
     yesterday: '昨天',
     collapseSessions: '收合工作階段',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -113,6 +113,8 @@ export const zhHant: Resources = {
     deleteWorkspace: '刪除工作區',
     deleteWorkspaceTitle: '刪除對話工作區',
     deleteWorkspaceMessage: '刪除對話工作區 {{tag}}？磁碟上的檔案會保留，只移除發射架的註冊記錄。它任何開啟的分頁都會關閉。',
+    deleteSessionTitle: '刪除對話',
+    deleteSessionMessage: '刪除「{{title}}」？這會移除該對話及其歷史，工作區保留。',
     noChatWorkspacesYet: '尚無對話工作區',
   },
   chatLanding: {

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -103,9 +103,9 @@ export const zhHant: Resources = {
     delete: '刪除',
   },
   chat: {
-    workspaceChatHeader: '工作區對話',
-    recommended: '推薦',
-    newChatWorkspace: '新增對話工作區',
+    newChat: '新對話',
+    today: '今天',
+    yesterday: '昨天',
     collapseSessions: '收合工作階段',
     expandSessions: '展開工作階段',
     deleteWorkspace: '刪除工作區',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -96,6 +96,8 @@ export const zh: Resources = {
   },
   chat: {
     newChat: '新对话',
+    newWorkspace: '新建工作区',
+    moreOptions: '更多选项',
     today: '今天',
     yesterday: '昨天',
     collapseSessions: '收起会话',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -105,6 +105,8 @@ export const zh: Resources = {
     deleteWorkspace: '删除工作区',
     deleteWorkspaceTitle: '删除对话工作区',
     deleteWorkspaceMessage: '删除对话工作区 {{tag}}？磁盘上的文件会保留，只移除发射架的注册记录。它任何打开的标签页都会关闭。',
+    deleteSessionTitle: '删除对话',
+    deleteSessionMessage: '删除「{{title}}」？这会移除该对话及其历史，工作区保留。',
     noChatWorkspacesYet: '还没有对话工作区',
   },
   chatLanding: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -95,9 +95,9 @@ export const zh: Resources = {
     delete: '删除',
   },
   chat: {
-    workspaceChatHeader: '工作区对话',
-    recommended: '推荐',
-    newChatWorkspace: '新建对话工作区',
+    newChat: '新对话',
+    today: '今天',
+    yesterday: '昨天',
     collapseSessions: '收起会话',
     expandSessions: '展开会话',
     deleteWorkspace: '删除工作区',

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -26,8 +26,10 @@ export function UrlAdopter() {
   return (
     <>
       <Routes>
-        {/* Root → Inbox (the workspace-anchored landing). */}
-        <Route path="/" element={<Navigate to="/inbox" replace />} />
+        {/* Root → Ask Alice. An AI product should open on how-to-use-it (the
+            chat front door), not an information summary (Inbox is task sync, à
+            la Linear — but Linear's comms live in Slack; ours live here). */}
+        <Route path="/" element={<Navigate to="/chat" replace />} />
 
         {/* Activities */}
         {/* /chat → the "Ask Alice" quick-chat landing (composer). Legacy


### PR DESCRIPTION
## Summary
Follow-on UI work on the "Ask Alice" surface, turning the secondary sidebar into a real chat history.

- **Ask Alice is the primary entry**: moved to the top of the nav (above Inbox) and `/` now lands on it — an AI product should open on the chat front door, not Inbox (task sync).
- **Sidebar redesign**: dropped the jargon "WORKSPACE CHAT" header; a prominent **split-button** — wide "New chat" (opens the composer) + a caret dropdown for "New workspace" (the named/custom-tag create dialog). Day-framed labels (Today / Yesterday / "Jun 14") so it reads like conversation history; user-named workspaces keep their tag.
- **Session titles from the first message**: capture the seed message as the session title (threaded `title` from `SessionRecord` → publicMeta → `SpawnedSession` → UI); the row shows it (truncated, sans, CJK-legible) and falls back to the `c1` name when unseeded. No LLM title generation.
- **State-as-action glyph**: replaced the "PAUSED" text with a right-aligned, always-visible icon — running shows STOP (■, click to pause), paused shows PLAY (▶, click to resume). Per-agent badge colours now cover all four CLIs.
- **Confirm before deleting a session**: the × sat next to the open-conversation hit area, so a misclick nuked a session. Deletion now routes through a provider-managed ConfirmDialog, centralized in the `useWorkspaces()` session hook (`requestDeleteSession`); both call sites go through it.

## Test plan
- [x] `npx tsc --noEmit` clean (Alice `src/`)
- [x] `cd ui && npx tsc -b` clean (UI strict)
- [x] `pnpm test` passes (1946/1946)
- [x] Demo walked in-browser per change (nav order, default landing, split-button + New workspace dialog, titles incl. CJK, stop/play alignment, delete-confirm); 0 console errors

## Boundary touch
Adds a `title` field to `SessionRecord` (experimental workspace schema — no migration per convention; old records lack it and fall back to the name). No trading / auth / broker-credential changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
