### PR TITLE
fix(workspaces): unstick PTY on socket drop + dev terminal transport hardening

### DIFF
--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -610,7 +610,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     // we're ABOUT to do, before bootstrap or spawn. If a downstream step
     // diverges (e.g. claude CLI writes jsonl to a different projectKey),
     // we compare this against the transcript.watch.register trace.
-    launcherLogger.info('path.trace', {
+    launcherLogger.event('path.trace', {
       where: 'resume.attempt',
       wsId: id,
       recordId: token,

--- a/src/webui/workspaces-ws.ts
+++ b/src/webui/workspaces-ws.ts
@@ -84,6 +84,7 @@ export function attachWorkspacesWS(httpServer: HttpServer, svc: WorkspaceService
     if (!isOriginAllowed(req, svc)) {
       launcherLogger.warn('upgrade.origin_rejected', {
         origin: req.headers.origin ?? null,
+        host: req.headers.host ?? null,
         remoteAddress: req.socket.remoteAddress ?? null,
       });
       socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
@@ -139,6 +140,12 @@ export function attachWorkspacesWS(httpServer: HttpServer, svc: WorkspaceService
       rows,
       since: since ?? null,
       origin: req.headers.origin ?? null,
+      // Host the browser actually connected to. Discriminates the dev
+      // transport: `localhost:<backendPort>` = direct (proxy bypassed),
+      // `localhost:5173` = forwarded through the Vite dev proxy (which
+      // preserves the inbound Host). origin stays 5173 either way, so host is
+      // the only field that tells them apart.
+      host: req.headers.host ?? null,
       remoteAddress: req.socket.remoteAddress ?? null,
     });
     try {

--- a/src/workspaces/persistent-session.spec.ts
+++ b/src/workspaces/persistent-session.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for the backpressure-pause / socket-drop deadlock.
+ *
+ * The PTY read stream is paused when an attached WebSocket falls behind
+ * (bufferedAmount >= high watermark). If that socket then dies *while paused*
+ * — e.g. a vite ws-proxy ECONNRESET — the session must resume the PTY, or the
+ * child blocks forever on its next stdout write ("running along and then
+ * freezes"). These tests pin the resume on both the detach (socket dropped)
+ * and the attach-kick (a new client replaces the stalled one) paths.
+ *
+ * node-pty is mocked so we can drive onData / pause / resume deterministically
+ * without spawning a real child.
+ */
+
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as pty from 'node-pty';
+
+import { PersistentSession, type PersistentSessionOptions } from './persistent-session.js';
+import type { Logger } from './logger.js';
+
+vi.mock('node-pty', () => ({ spawn: vi.fn() }));
+
+const mockSpawn = vi.mocked(pty.spawn);
+
+/** Minimal IPty stand-in that lets the test inject PTY output and observe
+ *  pause/resume calls. */
+function makeFakeTerm() {
+  let dataCb: ((d: unknown) => void) | undefined;
+  return {
+    pid: 4321,
+    pause: vi.fn(),
+    resume: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    write: vi.fn(),
+    clear: vi.fn(),
+    onData: (cb: (d: unknown) => void) => {
+      dataCb = cb;
+      return { dispose: () => {} };
+    },
+    onExit: () => ({ dispose: () => {} }),
+    /** test helper — push bytes through the captured onData handler */
+    emitData: (d: Buffer) => dataCb?.(d),
+  };
+}
+
+/** ws.WebSocket stand-in: EventEmitter (for on/off) + send/close + the two
+ *  fields the backpressure logic reads. */
+class FakeWs extends EventEmitter {
+  readonly OPEN = 1;
+  readyState = 1;
+  bufferedAmount = 0;
+  send = vi.fn((data: unknown, optsOrCb?: unknown, cb?: unknown) => {
+    const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
+    if (typeof callback === 'function') callback(undefined);
+  });
+  close = vi.fn();
+}
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  event: () => {},
+  child: () => silentLogger,
+};
+
+function makeOptions(over: Partial<PersistentSessionOptions> = {}): PersistentSessionOptions {
+  return {
+    wsId: 'ws-1',
+    recordId: 'rec-1',
+    name: 'c1',
+    command: ['claude'],
+    cwd: '/tmp',
+    env: {},
+    initialCols: 80,
+    initialRows: 24,
+    logger: silentLogger,
+    replayBufferBytes: 1 << 20,
+    highWatermarkBytes: 1024, // small so one write trips backpressure
+    lowWatermarkBytes: 256,
+    onDisposed: () => {},
+    ...over,
+  };
+}
+
+describe('PersistentSession backpressure / socket-drop deadlock', () => {
+  let term: ReturnType<typeof makeFakeTerm>;
+
+  beforeEach(() => {
+    term = makeFakeTerm();
+    mockSpawn.mockReturnValue(term as unknown as pty.IPty);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resumes the PTY when a backpressure-paused socket drops (detach)', () => {
+    const session = new PersistentSession(makeOptions());
+    const ws = new FakeWs();
+    session.attach(ws as never, 80, 24, undefined);
+
+    // Socket is full: the next chunk of PTY output trips the high watermark
+    // and pauses the read stream.
+    ws.bufferedAmount = 2048;
+    term.emitData(Buffer.from('a lot of output'));
+    expect(term.pause).toHaveBeenCalledTimes(1);
+    expect(term.resume).not.toHaveBeenCalled();
+
+    // The socket dies mid-backpressure (ECONNRESET) → 'close' → detach().
+    ws.emit('close');
+
+    // Without the fix the PTY stays paused forever and the agent freezes.
+    expect(term.resume).toHaveBeenCalledTimes(1);
+
+    session.dispose('test');
+  });
+
+  it('resumes a stalled PTY when a new client kicks the old one (attach)', () => {
+    const session = new PersistentSession(makeOptions());
+    const ws1 = new FakeWs();
+    session.attach(ws1 as never, 80, 24, undefined);
+
+    ws1.bufferedAmount = 2048;
+    term.emitData(Buffer.from('a lot of output'));
+    expect(term.pause).toHaveBeenCalledTimes(1);
+
+    // A fresh tab attaches and kicks ws1. The new attach must un-stick the PTY
+    // even though the kick path (not detach) cleared the old socket.
+    const ws2 = new FakeWs();
+    session.attach(ws2 as never, 80, 24, undefined);
+
+    expect(term.resume).toHaveBeenCalledTimes(1);
+
+    session.dispose('test');
+  });
+
+  it('does not resume a PTY that was never paused', () => {
+    const session = new PersistentSession(makeOptions());
+    const ws = new FakeWs();
+    session.attach(ws as never, 80, 24, undefined);
+
+    // Output flows while the socket drains fine — no pause, no resume churn.
+    term.emitData(Buffer.from('small'));
+    ws.emit('close');
+
+    expect(term.pause).not.toHaveBeenCalled();
+    expect(term.resume).not.toHaveBeenCalled();
+
+    session.dispose('test');
+  });
+});

--- a/src/workspaces/persistent-session.ts
+++ b/src/workspaces/persistent-session.ts
@@ -305,7 +305,10 @@ export class PersistentSession {
     }
 
     this.ws = ws;
-    this.paused = false;
+    // A previous client may have dropped mid-backpressure, leaving the PTY
+    // paused at the OS level. Clearing only the flag (not resuming the term)
+    // would strand it paused forever; resumePty() un-sticks both.
+    this.resumePty();
     this.resize(cols, rows);
 
     // Compute replay window. Cold attach (since=undefined) replays the full
@@ -351,6 +354,12 @@ export class PersistentSession {
     const ws = this.ws;
     this.ws = null;
     this.unwireWs(ws);
+    // No consumer left — let the PTY run free into the in-memory ring buffer
+    // (onPtyData appends regardless of socket). If the socket dropped while
+    // we were backpressure-paused, NOT resuming here strands the PTY paused
+    // forever and the agent blocks on its next stdout write — the "running
+    // along and then freezes" symptom.
+    this.resumePty();
     if (this.cursorTimer) {
       clearInterval(this.cursorTimer);
       this.cursorTimer = null;
@@ -422,6 +431,19 @@ export class PersistentSession {
 
     if (this.buffer.tailSeq - this.lastCursorSeq >= CURSOR_BYTES_INTERVAL) {
       this.maybeSendCursor();
+    }
+  }
+
+  /** Un-pause the PTY read stream if backpressure paused it. Safe to call when
+   *  already running. Keeping the `paused` flag and the term stream in lockstep
+   *  is the whole point — clearing one without the other deadlocks the PTY. */
+  private resumePty(): void {
+    if (!this.paused) return;
+    this.paused = false;
+    try {
+      this.term.resume();
+    } catch {
+      // PTY may be dying; ignore.
     }
   }
 

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -501,7 +501,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       // raison d'être of the workspace-sessions.log file: any two fields that
       // should be equal but aren't are the bug, eyeball-comparable. Keep this
       // verbose; the file is grep-only, not human-tailed.
-      launcherLogger.info('path.trace', {
+      launcherLogger.event('path.trace', {
         where: 'session.spawn',
         wsId,
         recordId: ctx.recordId,

--- a/src/workspaces/transcript-watcher.ts
+++ b/src/workspaces/transcript-watcher.ts
@@ -160,7 +160,7 @@ export class TranscriptWatcher {
     // Compare watchDir + projectKey against the spawn path.trace; any
     // divergence means the CLI will write jsonl to a place we're not
     // watching, and resumeHint will never be populated.
-    this.logger.info('path.trace', {
+    this.logger.event('path.trace', {
       where: 'transcript.watch.register',
       wsId: session.wsId,
       recordId: session.recordId,

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -21,7 +21,7 @@ const DemoTerminalReplay = lazy(() =>
   import('../../demo/DemoTerminalReplay').then((m) => ({ default: m.DemoTerminalReplay })),
 );
 
-type Status = 'connecting' | 'connected' | 'closed' | 'error' | 'kicked';
+type Status = 'connecting' | 'reconnecting' | 'connected' | 'closed' | 'error' | 'kicked';
 
 interface ExitInfo {
   readonly code: number;
@@ -149,16 +149,24 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       rows: String(lastRows),
     });
     const url = `${wsUrl ?? defaultWsUrl()}?${params.toString()}`;
-    const ws = new WebSocket(url);
-    ws.binaryType = 'arraybuffer';
+
+    // The live socket is swapped out on every (re)connect; senders read it at
+    // call time so xterm's stdin/binary subs survive a reconnect untouched.
+    let activeWs: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let attempts = 0;
+    let hasConnectedOnce = false;
+    let teardown = false;
 
     const sendControl = (msg: ClientControlMessage): void => {
-      if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(msg));
+      const ws = activeWs;
+      if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(msg));
     };
 
     const encoder = new TextEncoder();
     const sendStdin = (data: string): void => {
-      if (ws.readyState === WebSocket.OPEN) ws.send(encoder.encode(data));
+      const ws = activeWs;
+      if (ws && ws.readyState === WebSocket.OPEN) ws.send(encoder.encode(data));
     };
 
     term.attachCustomKeyEventHandler((event) => {
@@ -184,73 +192,122 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     ro.observe(container);
     window.addEventListener('resize', handleResize);
 
-    ws.addEventListener('open', () => {
-      setStatus('connected');
-      term.focus();
-      handleResize();
-    });
+    // Backoff schedule for transient drops (vite ws-proxy ECONNRESET, server
+    // restart, sleep/wake). Cap the delay and the attempt count so a genuinely
+    // dead backend stops the loop instead of retrying forever.
+    const RECONNECT_BASE_MS = 500;
+    const RECONNECT_MAX_MS = 10_000;
+    const RECONNECT_MAX_ATTEMPTS = 12;
 
-    ws.addEventListener('message', (ev) => {
-      const data: unknown = ev.data;
-      if (typeof data === 'string') {
-        const msg = parseServerControl(data);
-        if (!msg) return;
-        switch (msg.type) {
-          case 'attached':
-            setPid(msg.pid);
-            setScrollbackTruncated(msg.scrollbackTruncated);
-            onAttachedRef.current?.(msg.sessionId);
-            break;
-          case 'cursor':
-            // No-op for now — see comment above on the URL `since` removal.
-            break;
-          case 'lifecycle':
-            if (msg.kind === 'child-exit') {
-              setChildExited(true);
-            } else if (msg.kind === 'child-respawn') {
-              setChildExited(false);
-            }
-            break;
-          case 'exit':
-            setExitInfo({ code: msg.code, signal: msg.signal });
-            break;
-        }
+    const scheduleReconnect = (): void => {
+      if (teardown) return;
+      if (attempts >= RECONNECT_MAX_ATTEMPTS) {
+        setStatus('closed');
         return;
       }
-      if (data instanceof ArrayBuffer) {
-        term.write(new Uint8Array(data));
-      }
-    });
+      attempts += 1;
+      setStatus('reconnecting');
+      const delay = Math.min(RECONNECT_BASE_MS * 2 ** (attempts - 1), RECONNECT_MAX_MS);
+      reconnectTimer = setTimeout(connect, delay);
+    };
 
-    ws.addEventListener('close', (ev) => {
-      // Server-side kick uses close code 4001 — separate from generic disconnect.
-      // 4404 = server doesn't know this session id (record paused or removed).
-      if (ev.code === 4001) {
-        setStatus('kicked');
-      } else if (ev.code === 4404) {
-        onSessionLostRef.current?.();
-        setStatus('closed');
-      } else {
-        setStatus('closed');
-      }
-    });
-    ws.addEventListener('error', () => setStatus('error'));
+    function connect(): void {
+      if (teardown) return;
+      const ws = new WebSocket(url);
+      ws.binaryType = 'arraybuffer';
+      activeWs = ws;
+      setStatus(hasConnectedOnce ? 'reconnecting' : 'connecting');
+
+      ws.addEventListener('open', () => {
+        attempts = 0;
+        // A reconnect re-attaches to a live xterm that already shows the
+        // pre-drop screen, but the server cold-replays its full ring buffer on
+        // every attach. Reset first so the replay repaints cleanly instead of
+        // duplicating scrollback. (First connect: xterm is already blank.)
+        if (hasConnectedOnce) term.reset();
+        hasConnectedOnce = true;
+        setStatus('connected');
+        term.focus();
+        handleResize();
+      });
+
+      ws.addEventListener('message', (ev) => {
+        const data: unknown = ev.data;
+        if (typeof data === 'string') {
+          const msg = parseServerControl(data);
+          if (!msg) return;
+          switch (msg.type) {
+            case 'attached':
+              setPid(msg.pid);
+              setScrollbackTruncated(msg.scrollbackTruncated);
+              onAttachedRef.current?.(msg.sessionId);
+              break;
+            case 'cursor':
+              // No-op for now — see comment above on the URL `since` removal.
+              break;
+            case 'lifecycle':
+              if (msg.kind === 'child-exit') {
+                setChildExited(true);
+              } else if (msg.kind === 'child-respawn') {
+                setChildExited(false);
+              }
+              break;
+            case 'exit':
+              setExitInfo({ code: msg.code, signal: msg.signal });
+              break;
+          }
+          return;
+        }
+        if (data instanceof ArrayBuffer) {
+          term.write(new Uint8Array(data));
+        }
+      });
+
+      ws.addEventListener('close', (ev) => {
+        if (activeWs !== ws) return; // superseded by a newer socket
+        activeWs = null;
+        // Server-side kick uses close code 4001 — separate from generic
+        // disconnect. 4404 = server doesn't know this session id (record paused
+        // or removed). Neither should reconnect: 4001 means another client owns
+        // the session, 4404 means it's gone.
+        if (ev.code === 4001) {
+          setStatus('kicked');
+          return;
+        }
+        if (ev.code === 4404) {
+          onSessionLostRef.current?.();
+          setStatus('closed');
+          return;
+        }
+        if (teardown) return;
+        // Transient drop (ECONNRESET, abnormal 1006, …) — try to self-heal.
+        scheduleReconnect();
+      });
+      // 'error' is always followed by 'close'; let the close handler drive the
+      // reconnect so we don't double-schedule.
+      ws.addEventListener('error', () => {});
+    }
 
     const stdinSub = term.onData(sendStdin);
     const binarySub = term.onBinary((d) => {
-      if (ws.readyState !== WebSocket.OPEN) return;
+      const ws = activeWs;
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
       const bytes = new Uint8Array(d.length);
       for (let i = 0; i < d.length; i++) bytes[i] = d.charCodeAt(i) & 0xff;
       ws.send(bytes);
     });
 
+    connect();
+
     return () => {
+      teardown = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
       stdinSub.dispose();
       binarySub.dispose();
       ro.disconnect();
       window.removeEventListener('resize', handleResize);
       try {
-        ws.close();
+        activeWs?.close();
       } catch {
         // ignore
       }
@@ -283,6 +340,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
 function StatusDot({ status }: { status: Status }): ReactElement {
   const colors: Record<Status, string> = {
     connecting: '#d29922',
+    reconnecting: '#d29922',
     connected: '#7ee787',
     closed: '#6e7681',
     error: '#ff7b72',
@@ -300,6 +358,20 @@ function StatusDot({ status }: { status: Status }): ReactElement {
 
 function defaultWsUrl(): string {
   const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  // Dev: connect straight to the backend port, bypassing the Vite proxy whose
+  // WS forwarding chokes on the terminal byte stream (read ECONNRESET) and adds
+  // a buffer+copy hop per frame. The backend's loopback auth passthrough admits
+  // the direct 127.0.0.1 connection, and the page's :5173 Origin is already in
+  // the backend allowlist (Guardian-injected) — see workspaces-ws.ts. Stripped
+  // from production builds (import.meta.env.DEV === false), so packaged /
+  // same-origin runs keep using location.host.
+  if (
+    import.meta.env.DEV &&
+    typeof __OPENALICE_DEV_BACKEND_PORT__ === 'number' &&
+    __OPENALICE_DEV_BACKEND_PORT__ > 0
+  ) {
+    return `${proto}//${window.location.hostname}:${__OPENALICE_DEV_BACKEND_PORT__}/api/workspaces/pty`;
+  }
   return `${proto}//${window.location.host}/api/workspaces/pty`;
 }
 

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+/**
+ * Backend port injected by vite.config.ts `define` (dev only). The PTY
+ * WebSocket connects directly to this port to skip the dev proxy. Replaced at
+ * build time with a numeric literal; declared via `typeof` guard at the call
+ * site so production builds (where it's undefined) don't ReferenceError.
+ */
+declare const __OPENALICE_DEV_BACKEND_PORT__: number
+
 interface ImportMetaEnv {
   readonly VITE_DEMO_MODE?: string
 }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -63,6 +63,17 @@ const { port: uiPort, strictPort } = readUiPort()
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // Inject the backend port as a compile-time constant so the dev client can
+  // open the PTY WebSocket *directly* against the backend, bypassing the Vite
+  // dev proxy. node-http-proxy's WS upgrade forwarding chokes under the
+  // terminal's high-throughput byte stream (read ECONNRESET), and adds a
+  // buffer+copy hop per frame. API traffic still goes through the proxy (low
+  // frequency, convenient). Dev-only: in production the UI is same-origin with
+  // the backend, so `location.host` is already correct and this is unused.
+  // `0` sentinel means "no override" — the client falls back to location.host.
+  define: {
+    __OPENALICE_DEV_BACKEND_PORT__: JSON.stringify(backendPort),
+  },
   // Dev server with API proxy to the backend.
   // Backend port is read from `data/config/connectors.json` (web.port) so
   // changing the backend port in one place propagates to Vite automatically.


### PR DESCRIPTION
## Summary
- **PTY backpressure deadlock (the freeze).** `detach()`/`attach()` cleared the `paused` flag without resuming the PTY read stream, so a socket dropped mid-backpressure (a vite ws-proxy `ECONNRESET`) left the child blocked on its next stdout write forever — the "runs along then freezes" symptom. Added `resumePty()` on both paths; the in-memory ring buffer absorbs output when no client is attached, so pausing a consumer-less PTY was never needed. New regression spec.
- **Terminal auto-reconnect.** The WS now reconnects with capped backoff instead of freezing on any drop; `term.reset()` before a reconnect's cold replay avoids duplicating scrollback. `4001` (kicked) / `4404` (gone) don't reconnect by design.
- **Dev transport bypass.** The terminal WS connects straight to the backend port in dev, skipping the vite proxy whose WS forwarding chokes on the terminal byte stream and adds a hop per frame. Gated to `import.meta.env.DEV` (stripped from prod same-origin builds). Loopback auth + the Guardian-injected `:5173` origin allowlist admit it unchanged.
- **Observability.** `upgrade.accepted` now logs `host` (direct = `localhost:<backendPort>`, proxied = `localhost:5173`; `origin` is `:5173` either way). The 3 `path.trace` traces drop info→event (file-only unless `WEB_TERMINAL_LOG_LEVEL=debug`) to de-noise `pnpm dev`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `cd ui && npx tsc -b` clean
- [x] `pnpm test` — 1972 passed (incl. new `persistent-session.spec.ts`)
- [x] `vite build` (production) clean — dev-only branch dead-code-eliminated
- [x] Live dev: `upgrade.accepted` confirmed `host:localhost:47331` (direct), terminal no longer laggy

## Boundary touch
None — no trading / auth / broker-credential / migration changes. Auth surface is read-only (relies on existing loopback passthrough + origin allowlist; no new bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
