### PR TITLE
docs(claude-md): correct stale logging convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,7 +471,10 @@ headless workspace dispatch (cron → workspace).
 - Strict TypeScript, ES2023 target
 - Zod for config, TypeBox for tool parameter schemas
 - `decimal.js` for financial math
-- Pino logger → `logs/engine.log`
+- Logging: the workspace launcher writes structured JSON to
+  `logs/workspace-sessions.log` (`src/workspaces/logger.ts`); the main
+  process logs via `console`. (`pino` is a declared dep but currently
+  unused — don't assume a central pino sink exists.)
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md` listed `Pino logger → logs/engine.log` under Conventions, but `pino` is a **declared-but-unused** dependency and nothing writes `engine.log`. The only structured logger is the workspace launcher's hand-rolled one (`src/workspaces/logger.ts` → `logs/workspace-sessions.log`); the main process logs via `console`.
- Replaced the line with an accurate description so no one chases a central pino sink that doesn't exist (this session nearly did).

## Test plan
- [x] Docs-only; no code change. Nothing to build/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
