### PR TITLE
docs: contributor recognition (CONTRIBUTORS.md + README wall + CLAUDE.md convention)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,6 +537,33 @@ flow.
 specific PR ("evaluate #N anyway, I know the author"), not a general
 "go ahead" earlier in the session.
 
+### Recognizing contributors — credit, don't merge
+
+We refuse external code, but the project stays open and community ideas /
+reports / designs genuinely shape it. Recognizing those people is deliberate
+operations (part of the growth flywheel), not a courtesy. It lives in two
+**hand-maintained** files — no script; the volume doesn't justify one:
+
+- **`CONTRIBUTORS.md`** — the credits ledger + a short "how recognition works"
+  guide. Each entry links to the actual change the person influenced, so it's a
+  record, not just a name on a wall.
+- **`README.md` → `## Contributors`** — the avatar wall + a pointer to the ledger.
+- Not to be confused with **`CONTRIBUTING.md`** (the rules doc). Mnemonic:
+  `-ING` = how to contribute; `-ORS` = who contributed.
+
+**To credit someone** (maintainer's call; standouts ⭐ go on top): hand-edit
+`CONTRIBUTORS.md` using the row template in its HTML comment — the avatar is free
+from `https://github.com/<handle>.png` (no token), link the "Shaped" cell to the
+PR / commit / issue they moved, pick a credit emoji from the list at the top of
+the file. Optionally add them to the README wall too.
+
+**IP-clean rule — NEVER `Co-Authored-By:` for a human.** That trailer asserts
+co-authorship (a copyright claim), which breaks the single-owner stance that is
+the whole reason we don't merge external code. Credit humans via the
+`CONTRIBUTORS` page, and — only if you want a git-level record — a non-authorship
+trailer (`Suggested-by:` / `Reported-by:` / `Reviewed-by: @handle`). Claude's
+`Co-Authored-By:` stays as-is (an AI asserts no copyright).
+
 ### Two collaboration modes — pick the right one first
 
 The whole workflow forks on one question:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,47 @@
+# Contributors
+
+OpenAlice is built and maintained in-house, and we **don't merge external pull
+requests** — anything that touches trading or keys has to be ours (see
+[CONTRIBUTING.md](./CONTRIBUTING.md) for why). But the project stays open, and
+the community's **ideas, bug reports, designs, and reviews genuinely shape it**.
+This page is the record of those people, and of what each one helped move.
+
+## How recognition works
+
+- We don't merge your code, but if your **idea / report / design / review**
+  shaped a change, you get credited here, with a link to the actual change you
+  influenced. It's a real record, not just a name on a wall.
+- **Credit types:**
+  🤔 ideas · 🎨 design · 🐛 bug report · 👀 review · 💬 question answered ·
+  📖 docs · 🛡️ security · 🌍 translation · 💻 code _(rare — reimplemented with
+  your consent)_
+- **How to earn one:** open an
+  [issue](https://github.com/TraderAlice/OpenAlice/issues) with an idea, a
+  report, or a design. If it lands in the project, we add you. Think we missed
+  crediting you? Say so in an issue or on Discord — we'll fix it.
+- **Standouts (⭐):** a few people go notably above and beyond — high-signal,
+  consistent, often right. They sit at the top.
+
+## The roll
+
+<!--
+  Maintainer note — adding someone:
+    • Put standouts (⭐) first; everyone else below, newest-ish at the bottom.
+    • The avatar comes free from  https://github.com/<handle>.png  — no token.
+    • Link each "Shaped" item to the PR / commit / issue it influenced.
+    • Pick credit emoji from the list above; honesty over generosity isn't the
+      goal here — credit them for what they actually moved.
+
+  Row template (copy this):
+
+  | ⭐ | <a href="https://github.com/HANDLE"><img src="https://github.com/HANDLE.png" width="40" height="40" alt="@HANDLE" /></a><br>[@HANDLE](https://github.com/HANDLE) | 🤔 🎨 | [what they shaped](LINK) |
+-->
+
+| | Contributor | Credits | Shaped |
+|:--:|---|:--:|---|
+| | _Be the first — open an issue with an idea or report._ [Issues →](https://github.com/TraderAlice/OpenAlice/issues) | | |
+
+---
+
+_This is the credits list (`CONTRIBUTORS`), not the contribution guide. For the
+rules — what we accept and why — see [`CONTRIBUTING.md`](./CONTRIBUTING.md)._

--- a/README.md
+++ b/README.md
@@ -512,6 +512,20 @@ Stuck? Here's the recommended path, roughly in order:
 
 [![Star History Chart](https://api.star-history.com/svg?repos=TraderAlice/OpenAlice&type=Date)](https://star-history.com/#TraderAlice/OpenAlice&Date)
 
+## Contributors
+
+We build OpenAlice in-house and [don't merge external PRs](./CONTRIBUTING.md) —
+but the community's ideas, reports, and designs shape it, and we credit every
+one. The people who've left a mark:
+
+<!-- Standouts (⭐) first. Avatars come free from https://github.com/<handle>.png :
+     <a href="https://github.com/HANDLE"><img src="https://github.com/HANDLE.png" width="56" height="56" alt="@HANDLE" /></a> -->
+<p>
+  <em>No one on the wall yet — <a href="https://github.com/TraderAlice/OpenAlice/issues">be the first</a>.</em>
+</p>
+
+**See the full list and what each person shaped** → [CONTRIBUTORS.md](./CONTRIBUTORS.md)
+
 ## License
 
 [AGPL-3.0](LICENSE)


### PR DESCRIPTION
## Summary
Stand up a lightweight, hand-maintained contributor-recognition surface. We don't merge external PRs, but the community's ideas / reports / designs shape the project, and recognizing those people is deliberate operations (part of the growth flywheel).

- **`CONTRIBUTORS.md`** — credits ledger + a short "how recognition works" guide. Each entry links to the actual change the person influenced (a record, not just a name); standouts pinned on top. Avatars are free from `github.com/<handle>.png` (no token). Empty "be the first" state + a maintainer row-template.
- **`README.md`** — a `## Contributors` section (avatar wall + pointer to the ledger), between Star History and License.
- **`CLAUDE.md`** — a `### Recognizing contributors — credit, don't merge` subsection next to the external-PR-refusal policy: where it lives, the `-ING`/`-ORS` filename split, how to credit someone, and the IP-clean rule — **never `Co-Authored-By` for a human** (asserts copyright, breaks single ownership); use `Suggested-by`/`Reported-by` trailers for a git-level record.

## Test plan
- [x] Docs-only; no code paths touched. Renders as standard Markdown.

## Boundary touch
None — documentation + a README section. No trading / auth / broker / migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
