### PR TITLE
ci(desktop): drop macos-13 (Intel) from the desktop build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-13, windows-latest] # arm64 dmg / x64 dmg / x64 nsis
+        # macos-13 (Intel/x64) dropped: GitHub's x64 mac runners queue for
+        # tens of minutes and routinely never allocate, hanging the whole
+        # release run — and Intel Macs are a shrinking base Apple stopped
+        # selling in 2023 (arm64 covers every Mac since). Re-add if real
+        # demand appears, ideally cross-built off the arm64 runner.
+        os: [macos-14, windows-latest] # arm64 dmg / x64 nsis
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write # upload release assets


### PR DESCRIPTION
## Summary
Drop `macos-13` (Intel/x64) from the desktop build matrix. On the first real run (v0.51.0-beta.2) the x64 mac runner queued 20+ minutes and never allocated, hanging the whole release run — while `macos-14` (arm64 dmg) and `windows-latest` (x64 nsis) both built and published in ~3–5 min. Intel Macs are a shrinking base (Apple stopped selling them in 2023; arm64 covers every Mac since), not worth blocking every release on a runner that won't allocate.

Matrix is now `macos-14 + windows-latest`. Re-add later if there's real Intel-Mac demand, ideally cross-built off the arm64 runner.

## Test plan
- [x] release.yml parses (js-yaml)
- [ ] takes effect on the next version bump (matrix-only change; no release cut by this PR)

## Boundary touch
CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)