### PR TITLE
fix(desktop): drop in-window menu bar + surface real bootstrap errors

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -21,7 +21,7 @@
  * code signing, blocked by Squirrel.Mac), multi-window, native menus.
  */
 
-import { app, BrowserWindow, dialog, shell } from 'electron'
+import { app, BrowserWindow, dialog, shell, Menu } from 'electron'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { mkdir, readFile, watch } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
@@ -284,6 +284,17 @@ app.whenReady().then(async () => {
   // ── Restart-flag watcher: broker config changes touch the flag; SIGTERM
   // + respawn UTA without restarting Alice (mirrors prod.mjs). ────────────
   void startFlagWatcher(homeEnv.OPENALICE_HOME, utaUrl, spawnUTA)
+
+  // No in-window menu bar on Windows/Linux — Electron's default
+  // File/Edit/View/Window/Help renders *inside* the window there and is
+  // meaningless for a single-window web-UI app (it never shows on macOS,
+  // where menus live in the system bar). macOS keeps a minimal menu so the
+  // app menu + copy/paste/select-all accelerators still work.
+  Menu.setApplicationMenu(
+    process.platform === 'darwin'
+      ? Menu.buildFromTemplate([{ role: 'appMenu' }, { role: 'editMenu' }, { role: 'windowMenu' }])
+      : null,
+  )
 
   const win = new BrowserWindow({
     width: 1280,

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -157,10 +157,19 @@ export class WorkspaceCreator {
         exitCode: result.exitCode,
         stderr: result.stderr.slice(0, 4000),
       });
+      // Surface the actual reason in the message, not just the exit code —
+      // a null exit code (spawn failure: bash-not-found on Windows, timeout)
+      // rendered as "code unknown" tells the user nothing, while result.stderr
+      // already carries the why (e.g. the Git-for-Windows install hint).
+      const reason = result.stderr.trim();
+      const headline =
+        result.exitCode === null
+          ? 'bootstrap could not start'
+          : `bootstrap script exited with code ${result.exitCode}`;
       return {
         ok: false,
         code: 'bootstrap_failed',
-        message: `bootstrap script exited with code ${result.exitCode ?? 'unknown'}`,
+        message: reason ? `${headline}:\n${reason.slice(-500)}` : headline,
         stderr: result.stderr,
         ...(result.exitCode !== null ? { exitCode: result.exitCode } : {}),
       };


### PR DESCRIPTION
## Summary
Two papercuts from dogfooding the packaged Windows build:
- **In-window menu bar**: Electron's default File/Edit/View/Window/Help renders inside the window on Windows/Linux (never shows on macOS). Set a minimal menu on macOS (keeps copy/paste/select-all accelerators), none on Win/Linux.
- **Opaque bootstrap errors**: a failed workspace bootstrap showed "exited with code unknown" (null exit code from a spawn failure) instead of the real reason already in `result.stderr` (e.g. the bash-not-found / install-Git-for-Windows hint). Now surfaces the stderr tail.

## Test plan
- [x] `npx tsc --noEmit` clean, `pnpm -F @traderalice/desktop typecheck` clean
- [x] `vitest run src/workspaces/workspace-creator` green

## Boundary touch
Desktop shell + a workspace error message only. No trading/auth/broker/migration logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)