### PR TITLE
fix(workspaces): stop multi-session terminal freeze (ANG-120) + cut 0.51.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.51.0-beta.2",
+  "version": "0.51.0-beta.3",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -136,3 +136,61 @@ describe('POST /:id/headless', () => {
     expect(r.body.error).toBe('capacity');
   });
 });
+
+describe('POST /:id/sessions/:sid/resume — concurrent coalescing (ANG-120)', () => {
+  const TOKEN = '00000000-0000-0000-0000-000000000001';
+
+  function buildResume() {
+    const session = {
+      recordId: TOKEN,
+      wsId: 'ws-1',
+      name: 'c1',
+      pid: 4242,
+      startedAt: 1,
+      waitForFirstExit: vi.fn(async () => null), // stays up
+    };
+    let live: unknown = undefined; // what pool.get returns; set once spawned
+    const spawn = vi.fn(() => {
+      live = session;
+      return session;
+    });
+    const record = {
+      id: TOKEN,
+      wsId: 'ws-1',
+      agent: 'claude',
+      name: 'c1',
+      state: 'paused',
+      resumeHint: { kind: 'agent-session-id', value: 'aid' },
+    };
+    const adapter = { id: 'claude', capabilities: { resumeById: true, resumeLast: false } };
+    const svc = {
+      sessionRegistry: { get: () => record, update: vi.fn(async () => {}) },
+      pool: { get: () => live, spawn, disposeToken: vi.fn() },
+      registry: { get: () => ({ id: 'ws-1', dir: '/w', agents: ['claude'] }) },
+      adapters: { get: () => adapter },
+      computeSpawnPlan: () => ({
+        spawnCwd: '/w',
+        envPWD: '/w',
+        transcriptDir: null,
+        projectKey: 'k',
+        composedCommand: ['claude'],
+        resumeMode: 'by-id',
+        resumeId: 'aid',
+      }),
+      config: { launcherRepoRoot: '/repo' },
+    } as unknown as WorkspaceService;
+    return { app: createWorkspaceRoutes(svc), spawn };
+  }
+
+  it('two simultaneous resumes spawn the agent exactly once', async () => {
+    const { app, spawn } = buildResume();
+    const path = `/ws-1/sessions/${TOKEN}/resume`;
+    const [a, b] = await Promise.all([post(app, path), post(app, path)]);
+
+    expect(spawn).toHaveBeenCalledOnce(); // no double-spawn racing one transcript
+    // both succeed: one really resumed, the other coalesced to alreadyRunning
+    expect(a.body.ok).toBe(true);
+    expect(b.body.ok).toBe(true);
+    expect([a.body, b.body].filter((x) => x.alreadyRunning)).toHaveLength(1);
+  });
+});

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -43,6 +43,14 @@ const AGENT_SESSION_ID_RE = /^[A-Za-z0-9_.-]{8,128}$/;
 /** Upper bound on a quick-chat seed prompt — matches the headless-dispatch cap. */
 const MAX_SEED_PROMPT = 16000;
 
+// In-flight resume coalescing, keyed `${wsId}::${recordId}`. A frontend
+// double-fire (two POST /resume within ms — ANG-120) would otherwise both pass
+// the "already running?" gate while the session is still paused and each call
+// pool.spawn() → two agent processes racing on one transcript. Later callers
+// await the in-flight resume; the in-lock pool.get() re-check then yields
+// alreadyRunning instead of a second spawn.
+const resumeInFlight = new Map<string, Promise<unknown>>();
+
 /** The template quick-chat reuses-or-creates its workspace from. */
 const QUICK_CHAT_TEMPLATE = 'chat';
 
@@ -590,121 +598,140 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     if (!validId(id) || !SESSION_ID_RE.test(token)) {
       return c.json({ error: 'not_found' }, 404);
     }
-    const record = svc.sessionRegistry.get(id, token);
-    if (!record) return c.json({ error: 'not_found' }, 404);
-    if (record.state === 'running' && svc.pool.get(token)) {
-      return c.json({ ok: true, alreadyRunning: true });
-    }
-    const meta = svc.registry.get(id);
-    if (!meta) return c.json({ error: 'workspace_not_found' }, 404);
-    const adapter = svc.adapters.get(record.agent);
-    if (!adapter) {
-      return c.json({
-        error: 'unknown_agent',
-        message: `record references unknown adapter: ${record.agent}`,
-      }, 500);
-    }
-    const resume = resumeFromRecord(record, adapter);
-    const plan = svc.computeSpawnPlan(meta, adapter, resume);
-    // path.trace at the moment the resume decision is taken — captures what
-    // we're ABOUT to do, before bootstrap or spawn. If a downstream step
-    // diverges (e.g. claude CLI writes jsonl to a different projectKey),
-    // we compare this against the transcript.watch.register trace.
-    launcherLogger.event('path.trace', {
-      where: 'resume.attempt',
-      wsId: id,
-      recordId: token,
-      agent: adapter.id,
-      wsDir: meta.dir,
-      spawnCwd: plan.spawnCwd,
-      envPWD: plan.envPWD,
-      transcriptDir: plan.transcriptDir,
-      projectKey: plan.projectKey,
-      composedCommand: plan.composedCommand,
-      resumeMode: plan.resumeMode,
-      resumeId: plan.resumeId,
-      resumeHintInRecord: record.resumeHint ?? null,
-    });
+    // Serialize concurrent resumes of this record (ANG-120 — see resumeInFlight).
+    // A later double-fire awaits the in-flight resume, then doResume()'s in-lock
+    // pool.get() re-check short-circuits it to alreadyRunning instead of spawning
+    // a second agent on the same transcript.
+    const lockKey = `${id}::${token}`;
+    const inFlight = resumeInFlight.get(lockKey);
+    if (inFlight) await inFlight.catch(() => undefined);
+    const run = doResume();
+    resumeInFlight.set(lockKey, run);
     try {
-      if (adapter.bootstrap) {
-        await adapter.bootstrap({
-          wsId: id,
-          cwd: meta.dir,
-          launcherRepoRoot: svc.config.launcherRepoRoot,
-        });
+      return await run;
+    } finally {
+      if (resumeInFlight.get(lockKey) === run) resumeInFlight.delete(lockKey);
+    }
+
+    async function doResume() {
+      const record = svc.sessionRegistry.get(id, token);
+      if (!record) return c.json({ error: 'not_found' }, 404);
+      // Re-check INSIDE the lock: a concurrent resume that just settled may have
+      // already spawned this session.
+      if (svc.pool.get(token)) {
+        return c.json({ ok: true, alreadyRunning: true });
       }
-    } catch (err) {
-      launcherLogger.error('adapter.bootstrap_failed_on_resume', { id, agent: adapter.id, err });
-      return c.json({ error: 'bootstrap_failed', message: (err as Error).message }, 500);
-    }
-    let initialReplayBytes: Buffer | null = null;
-    if (record.agent === 'shell' && record.scrollbackFile) {
-      initialReplayBytes = await svc.scrollbackStore.read(record.scrollbackFile);
-    }
-    try {
-      const ctx: SessionFactoryContext = {
-        ...(resume !== undefined ? { resume } : {}),
-        agentId: record.agent,
-        recordId: record.id,
-        recordName: record.name,
-        ...(initialReplayBytes ? { initialReplayBytes } : {}),
-      };
-      const session = svc.pool.spawn(id, ctx);
-      // Give the child a brief window to prove it stays up. If it exits
-      // within ~800ms (claude --continue against a stale projectKey, broken
-      // .mcp.json, missing trust, etc.) we'd otherwise return 200 OK while
-      // the pool respawn-loops itself into a circuit breaker behind the
-      // user's back. Surface the failure so the caller knows resume failed.
-      const earlyExit = await session.waitForFirstExit(800);
-      if (earlyExit) {
-        svc.pool.disposeToken(token, 'resume_early_exit');
-        await svc.sessionRegistry
-          .update(id, token, { state: 'paused', lastActiveAt: new Date().toISOString() })
-          .catch(() => undefined);
-        launcherLogger.warn('workspace.session_resume_early_exit', {
-          id,
-          sessionId: token,
-          agent: adapter.id,
-          code: earlyExit.code,
-          signal: earlyExit.signal,
-        });
+      const meta = svc.registry.get(id);
+      if (!meta) return c.json({ error: 'workspace_not_found' }, 404);
+      const adapter = svc.adapters.get(record.agent);
+      if (!adapter) {
         return c.json({
-          error: 'spawn_died',
-          message: `agent exited within startup window (code=${earlyExit.code})`,
-          exitCode: earlyExit.code,
-          signal: earlyExit.signal,
+          error: 'unknown_agent',
+          message: `record references unknown adapter: ${record.agent}`,
         }, 500);
       }
-      if (record.scrollbackFile) {
-        await svc.scrollbackStore.remove(record.scrollbackFile);
-        delete (record as { scrollbackFile?: string }).scrollbackFile;
+      const resume = resumeFromRecord(record, adapter);
+      const plan = svc.computeSpawnPlan(meta, adapter, resume);
+      // path.trace at the moment the resume decision is taken — captures what
+      // we're ABOUT to do, before bootstrap or spawn. If a downstream step
+      // diverges (e.g. claude CLI writes jsonl to a different projectKey),
+      // we compare this against the transcript.watch.register trace.
+      launcherLogger.event('path.trace', {
+        where: 'resume.attempt',
+        wsId: id,
+        recordId: token,
+        agent: adapter.id,
+        wsDir: meta.dir,
+        spawnCwd: plan.spawnCwd,
+        envPWD: plan.envPWD,
+        transcriptDir: plan.transcriptDir,
+        projectKey: plan.projectKey,
+        composedCommand: plan.composedCommand,
+        resumeMode: plan.resumeMode,
+        resumeId: plan.resumeId,
+        resumeHintInRecord: record.resumeHint ?? null,
+      });
+      try {
+        if (adapter.bootstrap) {
+          await adapter.bootstrap({
+            wsId: id,
+            cwd: meta.dir,
+            launcherRepoRoot: svc.config.launcherRepoRoot,
+          });
+        }
+      } catch (err) {
+        launcherLogger.error('adapter.bootstrap_failed_on_resume', { id, agent: adapter.id, err });
+        return c.json({ error: 'bootstrap_failed', message: (err as Error).message }, 500);
       }
-      await svc.sessionRegistry
-        .update(id, token, { state: 'running', lastActiveAt: new Date().toISOString() })
-        .catch((err) =>
-          launcherLogger.warn('session_registry.resume_update_failed', { id, token, err }),
-        );
-      launcherLogger.info('workspace.session_resumed', {
-        id,
-        sessionId: token,
-        name: session.name,
-        pid: session.pid,
-        agent: adapter.id,
-        resume: resume === undefined ? null : resume === 'last' ? 'last' : resume.sessionId,
-        scrollbackBytes: initialReplayBytes?.length ?? 0,
-      });
-      return c.json({
-        ok: true,
-        sessionId: session.recordId,
-        wsId: session.wsId,
-        name: session.name,
-        pid: session.pid,
-        agent: adapter.id,
-        startedAt: session.startedAt,
-      });
-    } catch (err) {
-      launcherLogger.error('workspace.session_resume_failed', { id, token, err });
-      return c.json({ error: 'resume_failed', message: (err as Error).message }, 500);
+      let initialReplayBytes: Buffer | null = null;
+      if (record.agent === 'shell' && record.scrollbackFile) {
+        initialReplayBytes = await svc.scrollbackStore.read(record.scrollbackFile);
+      }
+      try {
+        const ctx: SessionFactoryContext = {
+          ...(resume !== undefined ? { resume } : {}),
+          agentId: record.agent,
+          recordId: record.id,
+          recordName: record.name,
+          ...(initialReplayBytes ? { initialReplayBytes } : {}),
+        };
+        const session = svc.pool.spawn(id, ctx);
+        // Give the child a brief window to prove it stays up. If it exits
+        // within ~800ms (claude --continue against a stale projectKey, broken
+        // .mcp.json, missing trust, etc.) we'd otherwise return 200 OK while
+        // the pool respawn-loops itself into a circuit breaker behind the
+        // user's back. Surface the failure so the caller knows resume failed.
+        const earlyExit = await session.waitForFirstExit(800);
+        if (earlyExit) {
+          svc.pool.disposeToken(token, 'resume_early_exit');
+          await svc.sessionRegistry
+            .update(id, token, { state: 'paused', lastActiveAt: new Date().toISOString() })
+            .catch(() => undefined);
+          launcherLogger.warn('workspace.session_resume_early_exit', {
+            id,
+            sessionId: token,
+            agent: adapter.id,
+            code: earlyExit.code,
+            signal: earlyExit.signal,
+          });
+          return c.json({
+            error: 'spawn_died',
+            message: `agent exited within startup window (code=${earlyExit.code})`,
+            exitCode: earlyExit.code,
+            signal: earlyExit.signal,
+          }, 500);
+        }
+        if (record.scrollbackFile) {
+          await svc.scrollbackStore.remove(record.scrollbackFile);
+          delete (record as { scrollbackFile?: string }).scrollbackFile;
+        }
+        await svc.sessionRegistry
+          .update(id, token, { state: 'running', lastActiveAt: new Date().toISOString() })
+          .catch((err) =>
+            launcherLogger.warn('session_registry.resume_update_failed', { id, token, err }),
+          );
+        launcherLogger.info('workspace.session_resumed', {
+          id,
+          sessionId: token,
+          name: session.name,
+          pid: session.pid,
+          agent: adapter.id,
+          resume: resume === undefined ? null : resume === 'last' ? 'last' : resume.sessionId,
+          scrollbackBytes: initialReplayBytes?.length ?? 0,
+        });
+        return c.json({
+          ok: true,
+          sessionId: session.recordId,
+          wsId: session.wsId,
+          name: session.name,
+          pid: session.pid,
+          agent: adapter.id,
+          startedAt: session.startedAt,
+        });
+      } catch (err) {
+        launcherLogger.error('workspace.session_resume_failed', { id, token, err });
+        return c.json({ error: 'resume_failed', message: (err as Error).message }, 500);
+      }
     }
   });
 

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -36,33 +36,25 @@ export interface WorkspaceViewProps {
 }
 
 export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
-  // Only running records get a mounted terminal slot. Same persist-across-
-  // tab-switch trick from V2.S3 (commit 0f21914): keep them in the DOM,
-  // toggle visibility via CSS so switching sessions is a CSS toggle, not a
-  // WS reconnect + replay.
+  // Mount ONLY this tab's own pinned session. Each session is its own tab with
+  // its own WorkspaceView, and TabHost keeps every tab mounted (display:none
+  // when inactive) — so a session's terminal already persists across tab
+  // switches without a WS reconnect. Mounting *every* running session here (the
+  // old single-shared-view design) duplicates each session's <TerminalView>
+  // into every open tab: a session open in N tabs then gets N WebSockets
+  // fighting over its single-attach PTY → kick/reconnect war that wedges the
+  // session (ANG-120 — e.g. claude froze whenever an opencode tab was also open).
   //
-  // When no session is pinned (empty state landing — e.g. coming from an
-  // Inbox jump), short-circuit to []: the empty state renders inline
-  // cards for the user to pick a session, and we shouldn't mount
-  // terminals for every running session in the workspace just to keep
-  // them warm (defeats the one-session-per-tab WS optimisation).
-  const runningSlots = useMemo<readonly SessionRecord[]>(() => {
-    if (props.sessionId === null) return [];
-    const running = props.sessions.filter((s) => s.state === 'running');
-    // Brief race after a fresh spawn: selection.sessionId is set but the
-    // optimistic update may have completed *after* render, or the user pinned
-    // a session that the next poll hasn't surfaced yet. If the pinned record
-    // is running but not in our list, virtually-append so its slot mounts
-    // immediately. React reconciles by `key` when the real entry lands.
-    if (
-      props.activeRecord !== null &&
-      props.activeRecord.state === 'running' &&
-      !running.some((s) => s.id === props.sessionId)
-    ) {
-      return [...running, props.activeRecord];
-    }
-    return running;
-  }, [props.sessions, props.sessionId, props.activeRecord]);
+  // activeRecord is null when sessionId is null (empty-state landing) or during
+  // the brief post-spawn race before the record lands in the list — both
+  // correctly render no slot (the CTA / paused-CTA path covers them).
+  const runningSlots = useMemo<readonly SessionRecord[]>(
+    () =>
+      props.activeRecord !== null && props.activeRecord.state === 'running'
+        ? [props.activeRecord]
+        : [],
+    [props.activeRecord],
+  );
 
   // Right-pane state machine:
   //  - no selection.sessionId → CTA ("start a new session")


### PR DESCRIPTION
Fixes **ANG-120** (claude froze when an opencode tab was also open) at both layers, and cuts **0.51.0-beta.3** — the release used to verify bare-Windows workspace creation (it also carries #363's native bootstrap, already on master).

## Changes
1. **Frontend root cause** — `WorkspaceView` mounted a `<TerminalView>` for *every* running session, so with N session tabs each running session got N WebSockets fighting over its single-attach PTY (kick/reconnect war). Now mounts only the tab's own pinned session; `TabHost` already keeps each tab warm via `display:none`.
2. **Backend defense-in-depth** — the resume route had a check-then-spawn race: two `POST /resume` within ms both passed the "already running?" gate while paused and each `pool.spawn()` → two `claude --resume` racing one transcript. Now coalesces concurrent resumes per `${wsId}::${recordId}` (await in-flight, in-lock `pool.get()` re-check → alreadyRunning). Regression test: two simultaneous resumes spawn once.
3. **chore(release): 0.51.0-beta.3** — triggers the per-platform build so the cloud Windows box can dogfood native-bootstrap + the freeze fix.

## Test plan
- [x] `npx tsc --noEmit` + `cd ui && npx tsc -b` clean
- [x] `pnpm test` — 2004 passing (incl. the resume-coalescing regression)
- [ ] bare Windows: install the beta.3 exe (no Git for Windows) → create chat + auto-quant workspaces, open claude + opencode tabs → no freeze

## Boundary touch
UI + one webui route (resume). No trading/auth/broker/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)