### PR TITLE
chore(release): 0.51.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.51.0-beta.3",
+  "version": "0.51.0-beta.4",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary
Release bump 0.51.0-beta.3 → 0.51.0-beta.4. Merging to master triggers `release.yml` (tag + GitHub Release + desktop dmg/exe builds).

Since beta.3:
- **#366** auto-detect installed agent runtimes + frontend install guidance (no more silent ENOENT for a missing CLI).
- **#367** quick-chat AI-config injection for loginless runtimes (opencode/pi) — they can now launch from the composer instead of dead-ending on a missing key; zero-cred bounces to Settings › AI Provider.

## Test plan
- [x] tsc (Alice + UI) clean, `pnpm test` green on master head
- [ ] release.yml cuts `v0.51.0-beta.4` + builds dmg + exe
- [ ] bare-Windows acceptance (now have a Windows device): install the exe without Git for Windows → create a workspace → open claude+opencode tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
