### PR TITLE
fix(workspaces): Windows .cmd twins for alice CLI shims (closes #364)

### DIFF
--- a/src/workspaces/cli/bin/alice-uta.cmd
+++ b/src/workspaces/cli/bin/alice-uta.cmd
@@ -1,0 +1,1 @@
+@node "%~dp0alice-uta" %*

--- a/src/workspaces/cli/bin/alice-workspace.cmd
+++ b/src/workspaces/cli/bin/alice-workspace.cmd
@@ -1,0 +1,1 @@
+@node "%~dp0alice-workspace" %*

--- a/src/workspaces/cli/bin/alice.cmd
+++ b/src/workspaces/cli/bin/alice.cmd
@@ -1,0 +1,1 @@
+@node "%~dp0alice" %*

--- a/src/workspaces/cli/bin/traderhub.cmd
+++ b/src/workspaces/cli/bin/traderhub.cmd
@@ -1,0 +1,1 @@
+@node "%~dp0traderhub" %*

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -27,4 +27,19 @@ describe('CLI shim copies', () => {
     expect(src).toContain('process.argv[1]') // derives BIN from how it was invoked
     expect(src).toContain('exportKey') // routes to the per-export gateway path
   })
+
+  // Windows has no shebang concept — it resolves executables on PATH by
+  // extension (PATHEXT). The extensionless shims trigger a "how do you want to
+  // open this file?" association dialog on every invocation. A `.cmd` twin per
+  // export fixes it (ANG / issue #364). Each MUST invoke its OWN shim, because
+  // the shim self-detects its export from argv[1] — a `.cmd` pointing at the
+  // wrong shim would route to the wrong gateway export.
+  it('every export ships a Windows `.cmd` twin that runs its own shim', () => {
+    for (const name of EXPORT_BINARIES) {
+      const cmd = read(`${name}.cmd`).toString('utf8')
+      expect(cmd, `${name}.cmd should run node on its sibling shim`)
+        .toContain(`@node "%~dp0${name}"`)
+      expect(cmd, `${name}.cmd should forward args`).toContain('%*')
+    }
+  })
 })


### PR DESCRIPTION
## Summary
The workspace CLI shims (`alice` / `alice-workspace` / `alice-uta` / `traderhub`) are extensionless Node scripts that rely on a Unix shebang. Windows resolves executables on PATH by extension (PATHEXT) and has no shebang concept, so an extensionless shim has no association → every invocation popped a **"How do you want to open this file?"** dialog inside the workspace PTY (community issue #364, Problem 2).

- Add a `.cmd` twin per export. `cliBinPath()` prepends the whole bin dir to PATH and `build.files` already ships `src/workspaces/cli/**`, so PATHEXT finds the twins with **no deploy change**.
- Each `.cmd` runs its **own** sibling shim (`@node "%~dp0<name>" %*`) — the shim self-detects its export from `argv[1]`, so a `.cmd` pointing at the wrong shim would route to the wrong gateway export.
- Shims stay byte-identical (existing drift test still guards them); `.cmd` content lives outside them. macOS/Linux ignore `.cmd`.

**Issue #364, Problem 1** (`bootstrap.sh` exit 127 on Windows) was already resolved by **#363** — it eliminated bash for built-in templates (`bootstrap.mjs` on bundled Node + `dugite` git) instead of patching Git-Bash path handling — so this PR closes the remaining half.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 2027 passing (new `shim.spec.ts` case: every export ships a `.cmd` twin that runs its own shim + forwards args)
- [ ] Manual (Windows): launch a workspace, confirm `alice` / `traderhub` run with no file-association dialog

## Credit
Reported by @lvysssss in #364 (detailed, verified repro). Per CONTRIBUTORS policy this is credited via a `Reported-by:` trailer, not a co-authorship trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
