### PR TITLE
chore(release): 0.51.0-beta.5

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,6 +40,7 @@ This page is the record of those people, and of what each one helped move.
 | | Contributor | Credits | Shaped |
 |:--:|---|:--:|---|
 | | <a href="https://github.com/2233admin"><img src="https://github.com/2233admin.png" width="40" height="40" alt="@2233admin" /></a><br>[@2233admin](https://github.com/2233admin) | 🎨 | [Linear dark-shell design pass — palette & navigation density re-traced into the app](https://github.com/TraderAlice/OpenAlice/pull/302) |
+| | <a href="https://github.com/lvysssss"><img src="https://github.com/lvysssss.png" width="40" height="40" alt="@lvysssss" /></a><br>[@lvysssss](https://github.com/lvysssss) | 🐛 🤔 | [Windows workspace-launch blockers — diagnosed the bootstrap path/bash failures and the extensionless CLI-shim file-association dialog, with verified repros](https://github.com/TraderAlice/OpenAlice/issues/364) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ one. The people who've left a mark:
      <a href="https://github.com/HANDLE"><img src="https://github.com/HANDLE.png" width="56" height="56" alt="@HANDLE" /></a> -->
 <p>
   <a href="https://github.com/2233admin"><img src="https://github.com/2233admin.png" width="56" height="56" alt="@2233admin" /></a>
+  <a href="https://github.com/lvysssss"><img src="https://github.com/lvysssss.png" width="56" height="56" alt="@lvysssss" /></a>
 </p>
 
 **See the full list and what each person shaped** → [CONTRIBUTORS.md](./CONTRIBUTORS.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.51.0-beta.4",
+  "version": "0.51.0-beta.5",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary
Release bump 0.51.0-beta.4 → 0.51.0-beta.5. Merging to master triggers `release.yml` (tag + GitHub Release + dmg/exe builds).

Since beta.4:
- **#369** Windows `.cmd` twins for the alice CLI shims — kills the "How do you want to open this file?" dialog that popped on every shim invocation inside a Windows workspace PTY (**closes #364**).
- Credits **@lvysssss** in CONTRIBUTORS.md + the README wall for the detailed #364 repro (bug report → idea, not a co-authorship claim).

## Test plan
- [x] tsc + `pnpm test` green on master head (2027 tests)
- [ ] release.yml cuts `v0.51.0-beta.5` + builds dmg + exe
- [ ] Windows: confirm no file-association dialog on workspace launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
