### PR TITLE
fix: surface K-line fetch errors instead of masking them as "no data" (#375)

### DIFF
--- a/packages/opentypebb/src/core/provider/utils/errors.ts
+++ b/packages/opentypebb/src/core/provider/utils/errors.ts
@@ -57,3 +57,45 @@ export class NetworkUnreachableError extends OpenBBError {
     this.host = host
   }
 }
+
+/**
+ * Raised when a data provider refused to serve THIS client rather than
+ * returning data — most commonly HTTP 429 ("Too Many Requests"), but also a
+ * 401/403 + crumb/cookie/consent failure that is itself a symptom of the
+ * provider fingerprint-blocking an unofficial client (e.g. Yahoo throttles the
+ * yfinance-style crumb handshake, so even auth fails behind a 429).
+ *
+ * The distinction from EmptyDataError is the whole point (see issue #375): the
+ * symbol is NOT missing data — the request was rejected before any data came
+ * back. Masking this as "no historical data" sent agents down the wrong path,
+ * treating a transient, client-side-fixable block as a delisted/empty symbol.
+ * The message states the cause and the remedies explicitly so the agent retries
+ * later or switches source instead of giving up on the symbol.
+ */
+export class RateLimitedError extends OpenBBError {
+  readonly provider: string
+  readonly symbol?: string
+  readonly status?: number
+
+  constructor(
+    provider: string,
+    detail: string,
+    opts: { symbol?: string; status?: number; original?: unknown } = {},
+  ) {
+    const who = opts.symbol ? ` for "${opts.symbol}"` : ''
+    const code = opts.status ? ` HTTP ${opts.status}` : ''
+    super(
+      `RATE_LIMITED:${code} ${provider} refused to serve this client${who} (${detail}). ` +
+      `This is NOT a missing-data condition — the request was rejected before any data was returned, ` +
+      `typically because ${provider} throttles / fingerprint-blocks the unofficial client by IP and request shape. ` +
+      `Do NOT conclude the symbol has no history. Remedies: wait a few minutes and retry; ` +
+      `switch data source (e.g. an "fmp|<symbol>" barId if an FMP key is configured, or a connected broker's barId); ` +
+      `or change the outbound IP / network.`,
+      opts.original,
+    )
+    this.name = 'RateLimitedError'
+    this.provider = provider
+    this.symbol = opts.symbol
+    this.status = opts.status
+  }
+}

--- a/packages/opentypebb/src/index.ts
+++ b/packages/opentypebb/src/index.ts
@@ -34,7 +34,7 @@ export { Router, type CommandDef, type CommandHandler } from './core/app/router.
 
 // Utilities
 export { amakeRequest, applyAliases, replaceEmptyStrings, buildQueryString } from './core/provider/utils/helpers.js'
-export { OpenBBError, EmptyDataError, UnauthorizedError, NetworkUnreachableError } from './core/provider/utils/errors.js'
+export { OpenBBError, EmptyDataError, UnauthorizedError, NetworkUnreachableError, RateLimitedError } from './core/provider/utils/errors.js'
 
 // App loader — convenience functions to create a fully-loaded system
 export { createRegistry, createExecutor, loadAllRouters } from './core/api/app-loader.js'

--- a/packages/opentypebb/src/providers/yfinance/models/crypto-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/crypto-historical.ts
@@ -6,8 +6,7 @@
 import { z } from 'zod'
 import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { CryptoHistoricalQueryParamsSchema, CryptoHistoricalDataSchema } from '../../../standard-models/crypto-historical.js'
-import { EmptyDataError } from '../../../core/provider/utils/errors.js'
-import { getHistoricalData } from '../utils/helpers.js'
+import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 import { INTERVALS_DICT } from '../utils/references.js'
 
 export const YFinanceCryptoHistoricalQueryParamsSchema = CryptoHistoricalQueryParamsSchema.extend({
@@ -62,7 +61,7 @@ export class YFinanceCryptoHistoricalFetcher extends Fetcher {
       if (r.status === 'fulfilled') allData.push(...r.value)
     }
 
-    if (!allData.length) throw new EmptyDataError('No crypto historical data returned')
+    if (!allData.length) throw emptyHistoricalError(results, 'No crypto historical data returned')
     return allData
   }
 

--- a/packages/opentypebb/src/providers/yfinance/models/currency-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/currency-historical.ts
@@ -6,8 +6,7 @@
 import { z } from 'zod'
 import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { CurrencyHistoricalQueryParamsSchema, CurrencyHistoricalDataSchema } from '../../../standard-models/currency-historical.js'
-import { EmptyDataError } from '../../../core/provider/utils/errors.js'
-import { getHistoricalData } from '../utils/helpers.js'
+import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 import { INTERVALS_DICT } from '../utils/references.js'
 
 export const YFinanceCurrencyHistoricalQueryParamsSchema = CurrencyHistoricalQueryParamsSchema.extend({
@@ -62,7 +61,7 @@ export class YFinanceCurrencyHistoricalFetcher extends Fetcher {
       if (r.status === 'fulfilled') allData.push(...r.value)
     }
 
-    if (!allData.length) throw new EmptyDataError('No currency historical data returned')
+    if (!allData.length) throw emptyHistoricalError(results, 'No currency historical data returned')
     return allData
   }
 

--- a/packages/opentypebb/src/providers/yfinance/models/equity-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/equity-historical.ts
@@ -6,8 +6,7 @@
 import { z } from 'zod'
 import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { EquityHistoricalQueryParamsSchema, EquityHistoricalDataSchema } from '../../../standard-models/equity-historical.js'
-import { EmptyDataError } from '../../../core/provider/utils/errors.js'
-import { getHistoricalData } from '../utils/helpers.js'
+import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 import { INTERVALS_DICT } from '../utils/references.js'
 
 export const YFinanceEquityHistoricalQueryParamsSchema = EquityHistoricalQueryParamsSchema.extend({
@@ -61,7 +60,7 @@ export class YFinanceEquityHistoricalFetcher extends Fetcher {
       if (r.status === 'fulfilled') allData.push(...r.value)
     }
 
-    if (!allData.length) throw new EmptyDataError('No historical data returned')
+    if (!allData.length) throw emptyHistoricalError(results, 'No historical data returned')
     return allData
   }
 

--- a/packages/opentypebb/src/providers/yfinance/models/futures-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/futures-historical.ts
@@ -6,8 +6,7 @@
 import { z } from 'zod'
 import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { FuturesHistoricalQueryParamsSchema, FuturesHistoricalDataSchema } from '../../../standard-models/futures-historical.js'
-import { EmptyDataError } from '../../../core/provider/utils/errors.js'
-import { getHistoricalData } from '../utils/helpers.js'
+import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 import { INTERVALS_DICT, MONTHS } from '../utils/references.js'
 
 export const YFinanceFuturesHistoricalQueryParamsSchema = FuturesHistoricalQueryParamsSchema.extend({
@@ -102,7 +101,7 @@ export class YFinanceFuturesHistoricalFetcher extends Fetcher {
       if (r.status === 'fulfilled') allData.push(...r.value)
     }
 
-    if (!allData.length) throw new EmptyDataError('No futures historical data returned')
+    if (!allData.length) throw emptyHistoricalError(results, 'No futures historical data returned')
     return allData
   }
 

--- a/packages/opentypebb/src/providers/yfinance/models/index-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/index-historical.ts
@@ -6,8 +6,7 @@
 import { z } from 'zod'
 import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { IndexHistoricalQueryParamsSchema, IndexHistoricalDataSchema } from '../../../standard-models/index-historical.js'
-import { EmptyDataError } from '../../../core/provider/utils/errors.js'
-import { getHistoricalData } from '../utils/helpers.js'
+import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 import { INTERVALS_DICT, INDICES } from '../utils/references.js'
 
 export const YFinanceIndexHistoricalQueryParamsSchema = IndexHistoricalQueryParamsSchema.extend({
@@ -113,7 +112,7 @@ export class YFinanceIndexHistoricalFetcher extends Fetcher {
       if (r.status === 'fulfilled') allData.push(...r.value)
     }
 
-    if (!allData.length) throw new EmptyDataError('No index historical data returned')
+    if (!allData.length) throw emptyHistoricalError(results, 'No index historical data returned')
     return allData
   }
 

--- a/packages/opentypebb/src/providers/yfinance/utils/helpers.spec.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/helpers.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression tests for the Yahoo Finance error-surfacing path.
+ * @see https://github.com/TraderAlice/OpenAlice/issues/375
+ *
+ * Before the fix, a Yahoo rate-limit (HTTP 429 on the K-line / crumb endpoint)
+ * made every per-symbol fetch reject; the historical models' Promise.allSettled
+ * kept only fulfilled rows and then threw a generic
+ * `EmptyDataError('No historical data returned')`. That masked a transient,
+ * fixable client-side block as if the symbol genuinely had no history. These
+ * tests pin the two helpers that now surface the real cause.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { classifyYahooFetchError, emptyHistoricalError } from './helpers.js'
+import {
+  EmptyDataError,
+  OpenBBError,
+  NetworkUnreachableError,
+  RateLimitedError,
+} from '../../../core/provider/utils/errors.js'
+
+/** Build a yahoo-finance2-style HTTPError (name='HTTPError', numeric `.code`). */
+function httpError(status: number, message: string): Error {
+  const e = new Error(message) as Error & { code?: number }
+  e.name = 'HTTPError'
+  e.code = status
+  return e
+}
+
+describe('classifyYahooFetchError (issue #375)', () => {
+  it('maps HTTP 429 to a RateLimitedError that explains it is NOT missing data', () => {
+    const out = classifyYahooFetchError('MU', httpError(429, 'Edge: Too Many Requests'))
+    expect(out).toBeInstanceOf(RateLimitedError)
+    expect(out.message).toMatch(/RATE_LIMITED/)
+    expect(out.message).toMatch(/HTTP 429/)
+    expect(out.message).toMatch(/MU/)
+    expect(out.message).toMatch(/NOT a missing-data/)
+    // remediation must be actionable, not just a status echo
+    expect(out.message).toMatch(/retry|switch data source/i)
+  })
+
+  it('maps a bare "Too Many Requests" message (no numeric code) to RateLimitedError', () => {
+    expect(classifyYahooFetchError('AAPL', new Error('Too Many Requests')))
+      .toBeInstanceOf(RateLimitedError)
+  })
+
+  it('treats 401 / 403 / crumb failures as the same Yahoo-block syndrome', () => {
+    expect(classifyYahooFetchError('AAPL', httpError(401, 'Unauthorized'))).toBeInstanceOf(RateLimitedError)
+    expect(classifyYahooFetchError('AAPL', httpError(403, 'Forbidden'))).toBeInstanceOf(RateLimitedError)
+    expect(classifyYahooFetchError('AAPL', new Error('Failed to obtain crumb'))).toBeInstanceOf(RateLimitedError)
+  })
+
+  it('maps a DNS/connection failure to NetworkUnreachableError', () => {
+    const net = new TypeError('fetch failed') as TypeError & { cause?: unknown }
+    net.cause = Object.assign(new Error('getaddrinfo ENOTFOUND finance.yahoo.com'), { code: 'ENOTFOUND' })
+    expect(classifyYahooFetchError('AAPL', net)).toBeInstanceOf(NetworkUnreachableError)
+  })
+
+  it('passes an unrecognized error through unchanged (never masks)', () => {
+    const weird = new Error('something totally different')
+    expect(classifyYahooFetchError('AAPL', weird)).toBe(weird)
+  })
+})
+
+describe('emptyHistoricalError (issue #375)', () => {
+  it('re-throws the sole rejection verbatim, preserving its type + message', () => {
+    const rl = new RateLimitedError('Yahoo Finance', 'Too Many Requests', { symbol: 'MU', status: 429 })
+    const results: PromiseSettledResult<unknown>[] = [{ status: 'rejected', reason: rl }]
+    expect(emptyHistoricalError(results, 'No historical data returned')).toBe(rl)
+  })
+
+  it('re-throws verbatim when many symbols hit the same wall (uniform rate-limit)', () => {
+    const a = new RateLimitedError('Yahoo Finance', 'Too Many Requests', { status: 429 })
+    const b = new RateLimitedError('Yahoo Finance', 'Too Many Requests', { status: 429 })
+    const results: PromiseSettledResult<unknown>[] = [
+      { status: 'rejected', reason: a },
+      { status: 'rejected', reason: b },
+    ]
+    const out = emptyHistoricalError(results, 'No historical data returned')
+    expect(out).toBeInstanceOf(RateLimitedError)
+    expect(out).toBe(a)
+  })
+
+  it('aggregates distinct failure reasons across symbols', () => {
+    const results: PromiseSettledResult<unknown>[] = [
+      { status: 'rejected', reason: new Error('Too Many Requests') },
+      { status: 'rejected', reason: new Error('Quote not found for symbol XYZ') },
+    ]
+    const out = emptyHistoricalError(results, 'No historical data returned')
+    expect(out).toBeInstanceOf(OpenBBError)
+    expect(out.message).toMatch(/Too Many Requests/)
+    expect(out.message).toMatch(/Quote not found/)
+  })
+
+  it('falls back to a plain EmptyDataError when there were no rejections', () => {
+    const results: PromiseSettledResult<unknown>[] = [{ status: 'fulfilled', value: [] }]
+    const out = emptyHistoricalError(results, 'No historical data returned')
+    expect(out).toBeInstanceOf(EmptyDataError)
+    expect(out.message).toBe('No historical data returned')
+  })
+})

--- a/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
@@ -7,7 +7,7 @@
  */
 
 import YahooFinance from 'yahoo-finance2'
-import { EmptyDataError } from '../../../core/provider/utils/errors.js'
+import { EmptyDataError, OpenBBError, NetworkUnreachableError, RateLimitedError } from '../../../core/provider/utils/errors.js'
 import { SCREENER_FIELDS } from './references.js'
 
 // Singleton Yahoo Finance instance — reset on persistent failures
@@ -23,6 +23,93 @@ function getYF(): InstanceType<typeof YahooFinance> {
 
 function recordYFSuccess(): void { _yfFailCount = 0 }
 function recordYFFailure(): void { _yfFailCount++ }
+
+/**
+ * The HTTP status yahoo-finance2 attaches to its `HTTPError` as `.code`
+ * (see yahoo-finance2 lib/yahooFinanceFetch.js: `error.code = response.status`).
+ * Returns the numeric status only — string error codes (ENOTFOUND etc.) are
+ * not statuses and must not be mistaken for one.
+ */
+function httpStatusOf(err: unknown): number | undefined {
+  const code = (err as { code?: unknown } | null)?.code
+  return typeof code === 'number' && code >= 100 && code < 600 ? code : undefined
+}
+
+/** Flatten an error (name + message + `.cause` chain) into one searchable string. */
+function errorHaystack(err: unknown, depth = 0): string {
+  if (err == null || depth > 4) return ''
+  if (err instanceof Error) {
+    const cause = (err as Error & { cause?: unknown }).cause
+    return [err.name, err.message, errorHaystack(cause, depth + 1)].filter(Boolean).join(' ')
+  }
+  return String(err)
+}
+
+/**
+ * Translate whatever yahoo-finance2 throws into a typed, self-explanatory error.
+ *
+ * Yahoo serves the K-line endpoints to the unofficial client behind a
+ * crumb/cookie handshake and throttles by IP + request fingerprint. When that
+ * throttle trips, the library throws an `HTTPError` with `.code = 429` (or a
+ * 401/403 on the crumb step — itself usually a downstream 429). Left raw, those
+ * surface as an opaque "Edge: Too Many Requests"; worse, the per-symbol fan-out's
+ * `Promise.allSettled` used to swallow them into "No historical data" entirely
+ * (issue #375). Map them to errors that say what's actually wrong:
+ *   - 429 / "too many requests" / rate-limit  → RateLimitedError (retry / switch source)
+ *   - 401 / 403 / crumb / cookie / consent     → RateLimitedError (same Yahoo-block syndrome)
+ *   - DNS / TLS / connection failures           → NetworkUnreachableError (do-not-retry)
+ *   - anything else                             → passed through unchanged (never masked)
+ */
+export function classifyYahooFetchError(symbol: string, err: unknown): Error {
+  const status = httpStatusOf(err)
+  const hay = errorHaystack(err)
+  const detail = err instanceof Error ? (err.message || err.name) : String(err)
+
+  if (status === 429 || /too many requests|rate.?limit(ed)?/i.test(hay)) {
+    return new RateLimitedError('Yahoo Finance', detail, { symbol, status: status ?? 429, original: err })
+  }
+  if (status === 401 || status === 403 || /\bcrumb\b|invalid cookie|consent|unauthorized|forbidden/i.test(hay)) {
+    return new RateLimitedError('Yahoo Finance', detail, { symbol, status, original: err })
+  }
+  if (/fetch failed|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|socket hang up|UNABLE_TO_VERIFY|SELF_SIGNED/i.test(hay)) {
+    return new NetworkUnreachableError('finance.yahoo.com', detail, err)
+  }
+  return err instanceof Error ? err : new Error(detail)
+}
+
+/**
+ * Build the error to throw when a per-symbol historical fan-out produced zero
+ * rows. The yfinance `*-historical` models fetch each symbol under
+ * `Promise.allSettled` and keep only fulfilled rows; when EVERY fetch fails we
+ * must surface WHY rather than a bare "no data" (issue #375 — a Yahoo rate-limit
+ * failed all symbols and the old generic EmptyDataError masked a transient block
+ * as missing history).
+ *
+ *   - rejections sharing one distinct cause (single symbol, or all symbols hit
+ *     the same wall) → re-throw it verbatim so its type + actionable text survive
+ *     (a RateLimitedError stays a RateLimitedError).
+ *   - rejections with several distinct causes → aggregate the messages.
+ *   - no rejections (every fetch resolved empty — defensive; getHistoricalData
+ *     throws on empty, so this is unreachable today) → plain EmptyDataError.
+ */
+export function emptyHistoricalError(
+  results: PromiseSettledResult<unknown>[],
+  emptyMessage: string,
+): Error {
+  const failures = results.filter(
+    (r): r is PromiseRejectedResult => r.status === 'rejected',
+  )
+  if (failures.length === 0) return new EmptyDataError(emptyMessage)
+
+  const distinct = [...new Set(
+    failures.map((f) => (f.reason instanceof Error ? f.reason.message : String(f.reason))),
+  )]
+  if (distinct.length === 1) {
+    const reason = failures[0].reason
+    return reason instanceof Error ? reason : new Error(distinct[0])
+  }
+  return new OpenBBError(`${emptyMessage}: every symbol failed — ${distinct.join(' | ')}`)
+}
 
 /** Retry a function up to maxRetries times with delay between attempts */
 async function withRetry<T>(fn: () => Promise<T>, maxRetries = 2, delayMs = 1000): Promise<T> {
@@ -215,7 +302,17 @@ export async function getHistoricalData(
     period1,
     period2,
     interval: interval as any,
-  }))
+  })).catch((err: unknown) => {
+    // A failed K-line fetch is almost always Yahoo throttling / blocking the
+    // unofficial client (HTTP 429 / crumb auth), NOT a symbol with no history.
+    // Bump the failure counter so a stale crumb is refreshed on the next call,
+    // and rethrow a typed, self-explanatory error instead of letting an opaque
+    // "Edge: Too Many Requests" — or, worse, a swallowed "No historical data" —
+    // reach the agent (issue #375).
+    recordYFFailure()
+    throw classifyYahooFetchError(symbol, err)
+  })
+  recordYFSuccess()
 
   if (!chartResult?.quotes?.length) {
     throw new EmptyDataError(`No historical data for ${symbol}`)

--- a/src/domain/analysis/calc-v2/errors.ts
+++ b/src/domain/analysis/calc-v2/errors.ts
@@ -14,6 +14,8 @@ export type CalcErrorKind =
   | 'type'              // sma("x", 50) — arg 1 must be a series
   | 'insufficient-bars' // rsi(length=300) but the series has 120 bars
   | 'reflex'            // .rolling().mean() / np.mean() / .iloc — Python habit, redirect
+  | 'data-source'       // bars(...) fetch failed upstream (vendor rate-limit / network /
+                        // bad barId) — NOT a script bug; the fix is operational, not an edit
 
 export interface CalcDiagnostic {
   kind: CalcErrorKind

--- a/src/domain/analysis/calc-v2/evaluator.spec.ts
+++ b/src/domain/analysis/calc-v2/evaluator.spec.ts
@@ -17,6 +17,14 @@ function mockBars(closes: number[], barId = 'yfinance|AAPL'): BarService {
   } as unknown as BarService
 }
 
+/** Mock bar service whose getBars always rejects — simulates a vendor failure. */
+function failingBars(message: string): BarService {
+  return {
+    searchBarSources: async () => [],
+    getBars: async () => { throw new Error(message) },
+  } as unknown as BarService
+}
+
 const run = (script: string, svc: BarService) => runScript(script, { barService: svc })
 
 describe('calc-v2 evaluator', () => {
@@ -48,6 +56,40 @@ describe('calc-v2 evaluator', () => {
     expect(r.value).toBeUndefined()
     expect(r.error?.kind).toBe('insufficient-bars')
     expect(r.error?.message).toMatch(/needs ≥100 bars/)
+  })
+
+  // issue #375: a failed K-line fetch is an upstream/data problem, not a script
+  // bug. The quant calculator (an AI harness) must hand the agent a clean signal
+  // (kind:"data-source" + an operational suggestion), not a misleading "type".
+  describe('bars() fetch failures surface as kind:"data-source"', () => {
+    it('passes the real rate-limit cause through and suggests retry/switch (not a script edit)', async () => {
+      const rl = 'RATE_LIMITED: HTTP 429 Yahoo Finance refused to serve this client for "MU" (Edge: Too Many Requests). This is NOT a missing-data condition.'
+      const r = await run(`s = bars("yfinance|MU","1d",asset="equity")\nsma(s.close, 50)`, failingBars(rl))
+      expect(r.value).toBeUndefined()
+      expect(r.error?.kind).toBe('data-source')
+      expect(r.error?.message).toContain('bars("yfinance|MU") failed')
+      expect(r.error?.message).toContain('RATE_LIMITED')        // real cause reaches the agent
+      expect(r.error?.suggestion).toMatch(/retry|switch source/i)
+      expect(r.error?.suggestion).toMatch(/not a script error/i)
+    })
+
+    it('flags a network failure as data-source with a do-not-retry-blindly hint', async () => {
+      const r = await run(
+        `s = bars("yfinance|AAPL","1d",asset="equity")\nsma(s.close, 50)`,
+        failingBars('NETWORK_UNREACHABLE: cannot reach finance.yahoo.com from this machine (ENOTFOUND).'),
+      )
+      expect(r.error?.kind).toBe('data-source')
+      expect(r.error?.suggestion).toMatch(/unreachable|different source|network/i)
+    })
+
+    it('falls back to a barId/availability hint for an unrecognized fetch error', async () => {
+      const r = await run(
+        `s = bars("bogus","1d",asset="equity")\nsma(s.close, 50)`,
+        failingBars('Invalid barId "bogus" (expected "sourceId|nativeSymbol")'),
+      )
+      expect(r.error?.kind).toBe('data-source')
+      expect(r.error?.suggestion).toMatch(/barId/)
+    })
   })
 
   it('unknown-function with did-you-mean', async () => {

--- a/src/domain/analysis/calc-v2/evaluator.ts
+++ b/src/domain/analysis/calc-v2/evaluator.ts
@@ -143,7 +143,12 @@ export async function evaluate(program: Program, deps: CalcDeps): Promise<CalcOu
     try {
       r = await fetchBars(barId, opts, assetClass)
     } catch (err) {
-      throw new CalcError({ kind: 'type', message: `bars("${barId}") failed: ${err instanceof Error ? err.message : String(err)}`, line: e.pos.line, col: e.pos.col })
+      // A bars(...) fetch failure is NOT a script bug — the expression is fine,
+      // the data pipe failed (vendor rate-limit / network / bad barId). Tag it
+      // 'data-source' (not 'type') and attach an operational next step so the
+      // agent retries / switches source instead of rewriting a correct script.
+      const detail = err instanceof Error ? err.message : String(err)
+      throw new CalcError({ kind: 'data-source', message: `bars("${barId}") failed: ${detail}`, line: e.pos.line, col: e.pos.col, suggestion: barFetchSuggestion(detail) })
     }
     if (r.bars.length === 0) throw new CalcError({ kind: 'insufficient-bars', message: `bars("${barId}", "${interval}") returned no data`, line: e.pos.line, col: e.pos.col })
     return { k: 'series', barId, r }
@@ -201,6 +206,22 @@ function asNum(v: V, ctx: string, line: number): number {
 function asStr(v: V, fn: string, argIdx: number, line: number): string {
   if (v.k === 'str') return v.v
   throw new CalcError({ kind: 'type', message: `${fn} arg ${argIdx} must be a string`, line })
+}
+
+/**
+ * Map a bars(...) fetch failure to an operational next step for the agent.
+ * Matches the typed prefixes the data layer emits (RATE_LIMITED: /
+ * NETWORK_UNREACHABLE:) — no coupling to the provider's error classes — so the
+ * suggestion stays accurate whichever vendor/broker the barId resolved to.
+ */
+function barFetchSuggestion(detail: string): string {
+  if (/^RATE_LIMITED:|rate.?limit|too many requests|\b429\b/i.test(detail)) {
+    return 'Not a script error — the data source throttled/blocked this client. Wait a few minutes and retry, or switch source (an "fmp|<symbol>" barId if an FMP key is set, or a connected broker barId).'
+  }
+  if (/^NETWORK_UNREACHABLE:|cannot reach|unreachable|\bDNS\b|proxy/i.test(detail)) {
+    return 'Not a script error — the data source was unreachable from this network. Do not retry blindly; try a different source, or surface the network/VPN issue to the user.'
+  }
+  return 'Not a script error in the math — check the barId is one returned by searchBars/searchContracts (vendor barIds also need asset=). If the source genuinely has no data for this symbol/interval, try another source.'
 }
 
 // ---- function registry (reuses indicator math) ----

--- a/src/tool/quant.ts
+++ b/src/tool/quant.ts
@@ -81,7 +81,12 @@ or compare sources in one script, e.g. basis check:
   a.close[-1] - b.close[-1]
 
 Returns { value, dataRange } on success, or { error: { kind, message, suggestion } }
-on failure — read the error and fix the script (it pinpoints the problem).`,
+on failure. Most kinds are script problems — read the error and fix the script (it
+pinpoints the problem). The exception is kind:"data-source": the K-line fetch itself
+failed (vendor rate-limited/blocked this client, network down, or a bad barId) — that
+is NOT a script bug. Do not rewrite the expression; follow the suggestion (retry later,
+switch source, or fix the barId), and tell the user if data is simply unavailable.`,
+
       inputSchema: z.object({
         script: z.string().describe('The quant script (let-bindings + a final result expression).'),
         precision: z.number().int().min(0).max(10).optional().describe('Decimal places (default 4).'),


### PR DESCRIPTION
## Summary

Fixes #375 — a Yahoo rate-limit (HTTP 429 on the chart/crumb endpoint) made K-line fetches fail, but the error reached the agent as a harmless `No historical data returned`, as if the symbol genuinely had no history. Two layers were swallowing the real cause:

- **Provider layer (root cause).** The five yfinance `*-historical` models fan out per symbol with `Promise.allSettled`, kept only `fulfilled` rows, then threw a generic `EmptyDataError` — **discarding every rejection reason**. Now:
  - New typed `RateLimitedError` (opentypebb) whose message states it is **NOT** a missing-data condition and lists remedies (retry / switch source / change IP).
  - `classifyYahooFetchError` maps yahoo-finance2's `HTTPError.code` (429 → rate-limited; 401/403/crumb → same block syndrome) and network failures (→ `NetworkUnreachableError`); unknown errors pass through unchanged (never masked).
  - `getHistoricalData` classifies the failure and records it so a stale crumb is refreshed next call.
  - `emptyHistoricalError` re-throws the real rejection reason(s) instead of a generic message; wired into all five models (equity / crypto / currency / index / futures).

- **Quant harness signal.** `calculateQuant` is mostly used by the AI, so its structured error *is* the signal it acts on. A `bars()` fetch failure was tagged `kind:"type"` — and the tool tells the agent to "fix the script", which is wrong for an upstream failure. Now bar-fetch failures get a dedicated `kind:"data-source"` plus an operational `suggestion` (retry / switch source / fix the barId), so the agent stops rewriting a correct expression. The real cause still reaches it verbatim in `message`.

What the agent now sees when a symbol is rate-limited:

```json
{ "error": {
  "kind": "data-source",
  "message": "bars(\"yfinance|MU\") failed: RATE_LIMITED: HTTP 429 Yahoo Finance refused to serve this client for \"MU\" (Edge: Too Many Requests). This is NOT a missing-data condition …",
  "suggestion": "Not a script error — the data source throttled/blocked this client. Wait a few minutes and retry, or switch source …"
} }
```

Note: this fixes the *signal* (the agent now knows it's a transient block and what to do) — it does not make the rate-limit itself go away.

## Test plan
- [x] `npx tsc --noEmit` clean (Alice src/) + `pnpm -F @traderalice/opentypebb typecheck` clean
- [x] `pnpm test` passes (138 files / 2027 tests), including new specs:
  - `packages/opentypebb/.../yfinance/utils/helpers.spec.ts` — `classifyYahooFetchError` + `emptyHistoricalError`
  - `src/domain/analysis/calc-v2/evaluator.spec.ts` — `bars()` fetch failures surface as `kind:"data-source"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014CrdZSGuodZqmQFMNBdLyi)_