### PR TITLE
fix(guardian): resolve tsx to .CMD on Windows for cmd.exe spawned children

### DIFF
--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -161,7 +161,19 @@ export interface SpawnSpec {
 }
 
 export function spawnChild(spec: SpawnSpec): ChildProcess {
-  const child = spawn(spec.command, spec.args, {
+  let { command, args } = spec
+
+  // ponytail: Windows cmd.exe spawned by Node has the MSYS/MinGW bash PATH but
+  // not the .bin dir. Resolve known commands to their full paths so cmd.exe can
+  // find them without needing PATH hacks at the system level.
+  if (process.platform === 'win32') {
+    const binDir = resolve(process.cwd(), 'node_modules', '.bin')
+    if (command === 'tsx') {
+      command = `${binDir}\\tsx.CMD`
+    }
+  }
+
+  const child = spawn(command, args, {
     env: spec.env,
     stdio: spec.prefixLogs ? ['inherit', 'pipe', 'pipe'] : 'inherit',
     // On Windows the dev commands (`tsx`, `pnpm`) are `.cmd` shims in


### PR DESCRIPTION
## Problem

On Windows, `spawnChild()` in `scripts/guardian/shared.ts` calls `spawn('tsx', ...)` with `shell: true`.
Node.js on Windows uses `cmd.exe` as the shell, but `cmd.exe` does not have `node_modules/.bin` in its PATH — the MSYS/MinGW bash PATH that the developer sees does not propagate to `cmd.exe`.

The existing code comments acknowledge this problem but never implemented the fix:

```ts
// On Windows the dev commands (`tsx`, `pnpm`) are `.cmd` shims in
// node_modules/.bin. Node's spawn won't apply PATHEXT resolution to find
// them without a shell, so a bare `spawn('tsx', …)` throws ENOENT. POSIX
// resolves the bin dir directly, so keep shell off there.
// ...
shell: process.platform === 'win32',
```

`tsx` is available as a `.CMD` batch file at `node_modules/.bin/tsx.CMD` on Windows.

## Fix

When `command === 'tsx'` on `win32`, resolve to the absolute `.CMD` shim path. This is targeted — only affects `tsx` on Windows, does not change other commands or other platforms.

```ts
if (process.platform === 'win32') {
  const binDir = resolve(process.cwd(), 'node_modules', '.bin')
  if (command === 'tsx') {
    command = `${binDir}\\tsx.CMD`
  }
}
```

## Testing

- Dev server starts correctly on Windows: `/bin/sh node_modules/.bin/tsx scripts/guardian/dev.ts`
- All 4 ports respond: UTA (:47333), Alice (:47331), MCP (:47332), UI (:5173)

## Notes

- The pre-push test suite has pre-existing Windows path separator failures (e.g. `paths.spec.ts` expects `/` but receives `\`) unrelated to this change.
- `pnpm dev` on Windows also requires running via bash due to the tsx shebang issue (`#!/bin/sh` in `.bin/tsx`); that is a separate issue outside the scope of this PR.
