### PR TITLE
ci(release): pass --tag to git-cliff so notes aren't headed "[Unreleased]"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,17 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         id: notes
         run: |
-          # Generate notes for this version only (since last tag)
+          # Generate notes for this version only (since last tag).
+          # --tag labels the about-to-be-created version: git-cliff runs
+          # BEFORE the tag exists (it's created in the next step), so without
+          # this the section header falls back to "[Unreleased]" instead of
+          # the version. See cliff.toml's `{% if version %}` template.
+          TAG="${{ steps.version.outputs.tag }}"
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -z "$LAST_TAG" ]; then
-            git-cliff --output notes.md
+            git-cliff --tag "$TAG" --output notes.md
           else
-            git-cliff "$LAST_TAG"..HEAD --output notes.md
+            git-cliff "$LAST_TAG"..HEAD --tag "$TAG" --output notes.md
           fi
 
       - name: Create tag and GitHub Release


### PR DESCRIPTION
## Summary
git-cliff runs in the release workflow's "Generate release notes" step **before** the tag is created (next step), so with no version it fell to `cliff.toml`'s `## [Unreleased]` branch — the v0.60.0-beta.1 notes were headed "[Unreleased]". Pass `--tag <version>` so the section is headed with the actual version (`## [0.60.0-beta.1] - <date>`).

Independent CI-only fix. Does not re-cut a release: the version stays 0.60.0-beta.1 and that tag already exists, so `release.yml` skips on this push.

## Test plan
- [x] Workflow YAML change only; takes effect on the next version bump
- [x] The already-published v0.60.0-beta.1 release notes were hand-corrected to the versioned heading

## Boundary touch
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
