### PR TITLE
Ask Alice per-workspace spawn + Automation polish + credit @walkonbothsides

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,16 +1,14 @@
 # Contributors
 
-OpenAlice is built and maintained in-house, and we **don't merge external pull
-requests** — anything that touches trading or keys has to be ours (see
-[CONTRIBUTING.md](./CONTRIBUTING.md) for why). But the project stays open, and
-the community's **ideas, bug reports, designs, and reviews genuinely shape it**.
-This page is the record of those people, and of what each one helped move.
+OpenAlice is shaped by the people who dig into it with us — and this page is the
+record of who they are and what each one moved. The project stays open; if your
+work left a mark on it, you belong here.
 
 ## How recognition works
 
-- We don't merge your code, but if your **idea / report / design / review**
-  shaped a change, you get credited here, with a link to the actual change you
-  influenced. It's a real record, not just a name on a wall.
+- If your **report, idea, design, or review** shaped a change, you're credited
+  here — with a link to the actual change you influenced. A real record, not
+  just a name on a wall.
 - **Credit types:**
   🤔 ideas · 🎨 design · 🐛 bug report · 👀 review · 💬 question answered ·
   📖 docs · 🛡️ security · 🌍 translation · 💻 code _(rare — reimplemented with
@@ -41,6 +39,7 @@ This page is the record of those people, and of what each one helped move.
 |:--:|---|:--:|---|
 | | <a href="https://github.com/2233admin"><img src="https://github.com/2233admin.png" width="40" height="40" alt="@2233admin" /></a><br>[@2233admin](https://github.com/2233admin) | 🎨 | [Linear dark-shell design pass — palette & navigation density re-traced into the app](https://github.com/TraderAlice/OpenAlice/pull/302) |
 | | <a href="https://github.com/lvysssss"><img src="https://github.com/lvysssss.png" width="40" height="40" alt="@lvysssss" /></a><br>[@lvysssss](https://github.com/lvysssss) | 🐛 🤔 | [Windows workspace-launch blockers — diagnosed the bootstrap path/bash failures and the extensionless CLI-shim file-association dialog, with verified repros](https://github.com/TraderAlice/OpenAlice/issues/364) |
+| | <a href="https://github.com/walkonbothsides"><img src="https://github.com/walkonbothsides.png" width="40" height="40" alt="@walkonbothsides" /></a><br>[@walkonbothsides](https://github.com/walkonbothsides) | 🐛 | [OKX showed no spot holdings — reported the broker reporting no spot, which traced to a partial CCXT market-load that silently dropped spot markets and understated netLiquidation](https://github.com/TraderAlice/OpenAlice/commit/d7711887a19629414698678827a79a405797f17d) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -513,8 +513,8 @@ Stuck? Here's the recommended path, roughly in order:
 
 ## Contributors
 
-We build OpenAlice in-house and [don't merge external PRs](./CONTRIBUTING.md) —
-but the community's ideas, reports, and designs shape it, and we credit every
+OpenAlice is sharper for the people who dig into it with us — the bugs they
+catch, the ideas they push, the designs and reviews they bring. Credit to every
 one. The people who've left a mark:
 
 <!-- Standouts (⭐) first. Avatars come free from https://github.com/<handle>.png :
@@ -522,6 +522,7 @@ one. The people who've left a mark:
 <p>
   <a href="https://github.com/2233admin"><img src="https://github.com/2233admin.png" width="56" height="56" alt="@2233admin" /></a>
   <a href="https://github.com/lvysssss"><img src="https://github.com/lvysssss.png" width="56" height="56" alt="@lvysssss" /></a>
+  <a href="https://github.com/walkonbothsides"><img src="https://github.com/walkonbothsides.png" width="56" height="56" alt="@walkonbothsides" /></a>
 </p>
 
 **See the full list and what each person shaped** → [CONTRIBUTORS.md](./CONTRIBUTORS.md)

--- a/ui/src/components/AutomationSidebar.tsx
+++ b/ui/src/components/AutomationSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Activity, CalendarClock, ChevronDown, ChevronRight, Code2, Webhook, Workflow } from 'lucide-react'
 
 import { useWorkspace } from '../tabs/store'
 import { getFocusedTab, type ViewSpec } from '../tabs/types'
@@ -9,16 +9,16 @@ import { SidebarRow } from './SidebarRow'
 type AutomationSection = Extract<ViewSpec, { kind: 'automation' }>['params']['section']
 
 const PRIMARY = [
-  { labelKey: 'automation.schedules', section: 'schedules' },
-  { labelKey: 'automation.runs', section: 'runs' },
-  { labelKey: 'automation.api', section: 'api' },
+  { labelKey: 'automation.schedules', section: 'schedules', Icon: CalendarClock },
+  { labelKey: 'automation.runs', section: 'runs', Icon: Activity },
+  { labelKey: 'automation.api', section: 'api', Icon: Code2 },
 ] as const
 
 // The old event-bus surfaces — demoted under a collapsed "Legacy" group so they
 // stay reachable without crowding the primary automation rows.
 const LEGACY = [
-  { labelKey: 'automation.flow', section: 'flow' },
-  { labelKey: 'automation.webhook', section: 'webhook' },
+  { labelKey: 'automation.flow', section: 'flow', Icon: Workflow },
+  { labelKey: 'automation.webhook', section: 'webhook', Icon: Webhook },
 ] as const
 
 type AutomationItem = (typeof PRIMARY)[number] | (typeof LEGACY)[number]
@@ -45,6 +45,7 @@ export function AutomationSidebar() {
       key={item.section}
       label={t(item.labelKey)}
       active={activeSection === item.section}
+      icon={<item.Icon size={14} strokeWidth={2} className="text-text-muted/70" aria-hidden />}
       onClick={() => openOrFocus({ kind: 'automation', params: { section: item.section } })}
     />
   )

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -181,6 +181,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
             onDeleteSession={(sid) => ctx.requestDeleteSession(w.id, sid)}
             onConfigure={() => ctx.openAgentConfig(w.id)}
             onDelete={() => setPendingDelete(w)}
+            onSpawn={() => void ctx.spawn(w.id, { agent: w.agents[0] ?? 'claude' })}
           />
         ))}
       </ul>
@@ -216,6 +217,8 @@ interface ChatWorkspaceRowProps {
   onDeleteSession: (sid: string) => void
   onConfigure: () => void
   onDelete: () => void
+  /** Spawn a fresh agent session in THIS workspace (and open it). */
+  onSpawn: () => void
 }
 
 function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
@@ -271,6 +274,20 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               {w.sessions.length}
             </span>
           )}
+        </button>
+        {/* Always-visible "+" — spawn a fresh agent runtime in THIS day's
+            workspace (vs "New chat" which starts a whole new one). */}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            props.onSpawn()
+          }}
+          className="shrink-0 w-5 h-5 rounded flex items-center justify-center text-text-muted/50 hover:text-text hover:bg-bg-secondary transition-colors"
+          title={t('chat.newSession')}
+          aria-label={t('chat.newSession')}
+        >
+          <Plus size={13} strokeWidth={2.25} />
         </button>
         <span className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
           <button

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -114,6 +114,7 @@ export const en = {
   },
   chat: {
     newChat: 'New chat',
+    newSession: 'New session in this chat',
     newWorkspace: 'New workspace',
     moreOptions: 'More options',
     today: 'Today',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -103,6 +103,7 @@ export const ja: Resources = {
   },
   chat: {
     newChat: '新しいチャット',
+    newSession: 'このチャットで新規セッション',
     newWorkspace: '新しいワークスペース',
     moreOptions: 'その他のオプション',
     today: '今日',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -111,6 +111,7 @@ export const zhHant: Resources = {
   },
   chat: {
     newChat: '新對話',
+    newSession: '在此對話中新建工作階段',
     newWorkspace: '新增工作區',
     moreOptions: '更多選項',
     today: '今天',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -103,6 +103,7 @@ export const zh: Resources = {
   },
   chat: {
     newChat: '新对话',
+    newSession: '在此对话中新建会话',
     newWorkspace: '新建工作区',
     moreOptions: '更多选项',
     today: '今天',

--- a/ui/src/pages/AutomationApiSection.tsx
+++ b/ui/src/pages/AutomationApiSection.tsx
@@ -18,7 +18,7 @@ function Block({ children }: { children: string }) {
 
 export function AutomationApiSection() {
   return (
-    <div className="max-w-prose space-y-6 text-sm leading-relaxed">
+    <div className="max-w-prose mx-auto space-y-6 text-sm leading-relaxed">
       <section className="space-y-2">
         <h2 className="text-base font-semibold text-text">Workspace automation</h2>
         <p className="text-muted">

--- a/ui/src/pages/AutomationSchedulesSection.tsx
+++ b/ui/src/pages/AutomationSchedulesSection.tsx
@@ -247,7 +247,7 @@ export function AutomationSchedulesSection() {
 
   if (declared.length === 0) {
     return (
-      <div className="max-w-3xl space-y-3">
+      <div className="max-w-4xl mx-auto space-y-3">
         {staleBanner}
         <div className="rounded-lg border border-dashed border-border px-6 py-12 text-center">
           <CalendarClock size={24} className="mx-auto text-muted/50" />
@@ -265,7 +265,7 @@ export function AutomationSchedulesSection() {
   }
 
   return (
-    <div className="max-w-3xl space-y-3">
+    <div className="max-w-4xl mx-auto space-y-3">
       {staleBanner}
       <div className="flex items-center justify-end">
         <ViewToggle view={view} onChange={setView} />


### PR DESCRIPTION
## Summary
- **Ask Alice** — add an always-visible "+" on each chat workspace row to spawn a fresh agent session in THAT workspace (was only possible via "New chat" = a whole new workspace). Uses the workspace's default agent + the launcher's spawn-and-open path.
- **Automation** — center the Schedules + API content (was `max-w-*` without `mx-auto`, jammed left on a wide pane); add leading icons to the sidebar rows (Schedules/Runs/API + legacy).
- **Contributors** — credit @walkonbothsides (🐛) for reporting OKX showing no spot holdings (fixed in d771188); warm up the README + CONTRIBUTORS framing (drop the defensive "we don't merge external PRs" lead that read oddly / framed contributors as non-coders — policy still in CONTRIBUTING.md).

## Test plan
- [x] `tsc -b` (UI) clean
- [x] Playwright: Ask Alice spawn "+" renders on each row, Automation content centered (symmetric gutters), zero console/pageerrors

## Boundary touch
None — frontend + docs. (ctx.spawn is the existing launcher path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
