### PR TITLE
Surface data freshness in bar search results & sort by recency

### DIFF
--- a/default/skills/alice-analysis/SKILL.md
+++ b/default/skills/alice-analysis/SKILL.md
@@ -3,8 +3,9 @@ name: alice-analysis
 description: >
   How to compute technical analysis with OpenAlice's Quant Calculator (v2) via
   `alice analysis` — a small Python/pandas-subset scripting language over
-  K-lines, keyed by barId so you compute on a SPECIFIC source (a broker's bars
-  matching what you trade, or a named vendor) and can batch many
+  K-lines, keyed by barId so you compute on a SPECIFIC source — prefer a
+  broker's bars (matches what you trade, realtime) over a free vendor like
+  yfinance (delayed fallback) — and can batch many
   timeframes/symbols/indicators in ONE call. Use whenever the task is
   technical/quantitative on price data: "RSI on BTC", "is AAPL above its
   200-day", "50/200 golden cross check", "multi-timeframe momentum", "how
@@ -24,8 +25,23 @@ of values). Get barIds from `alice analysis search-bars` first.
 
 ```bash
 alice analysis search-bars --query AAPL
-alice analysis quant --script $'s = bars("yfinance|AAPL", "1d", count=250, asset="equity")\nsma(s.close, 50)'
+# Pick a broker barId if one came back (realtime, matches your fills); fall back to a vendor only if not.
+alice analysis quant --script $'s = bars("alpaca-paper|AAPL", "1d", count=250)\nsma(s.close, 50)'
 ```
+
+## Choosing a source
+
+`search-bars` federates broker bars and vendor bars (freshest-first). Pick in
+this order:
+
+1. **A broker you actually trade** (`barCapability: "realtime"`) — freshest, and
+   the chart matches your fills. Always prefer this when it's in the results.
+2. **A paid vendor** (`fmp`, …) when no broker source exists.
+3. **`yfinance` — free fallback only.** Its end-of-day bars can lag a **day or
+   two**, so never use it for anything time-sensitive (a fresh signal, an entry
+   check) or to chart a live position when a broker source is available.
+
+Vendor barIds (`yfinance|…`, `fmp|…`) need `asset=`; broker barIds infer it.
 
 ## Language
 
@@ -80,6 +96,10 @@ Records: `bbands` → `{upper, middle, lower}`; `macd` → `{macd, signal, histo
 
 ## Examples
 
+> Examples below use `yfinance|…` for brevity (it's always available without a
+> broker). When you have a broker source for the symbol, swap its barId in —
+> see *Choosing a source*.
+
 ```python
 # Momentum % over the last 20 bars
 s = bars("yfinance|AAPL", "1d", count=60, asset="equity")
@@ -120,6 +140,8 @@ supported here).
 - Indicators return the latest **scalar** — never `[-1]` them; only raw columns
   are series.
 - Vendor barIds need `asset=`; broker barIds infer it.
+- **Source freshness:** `yfinance`/`fmp` are delayed (yfinance EOD can lag a day
+  or two). Prefer a broker barId for anything you trade or anything time-sensitive.
 - No conditionals/booleans (no `if`, no crossover operator) — compute the parts
   and compare in your own reasoning, or return them in a panel.
 - For arbitrary/looping logic beyond these primitives, spawn a separate

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -149,6 +149,7 @@ describe('searchBarSources — federated candidates', () => {
       barId: 'yfinance|AAPL', source: 'vendor', sourceId: 'yfinance', symbol: 'AAPL', assetClass: 'equity',
     })
     expect(out[0].label).toContain('AAPL')
+    expect(out[0].label).toContain('delayed') // freshness surfaced in the label, not just the structured field
   })
 
   it('unions UTA broker hits (barId = aliceId, secType → assetClass)', async () => {
@@ -167,6 +168,7 @@ describe('searchBarSources — federated candidates', () => {
       expect.objectContaining({ barId: 'alpaca-paper|AAPL', sourceId: 'alpaca-paper', symbol: 'AAPL', assetClass: 'equity', barCapability: 'realtime' }),
       expect.objectContaining({ barId: 'bybit-main|BTC/USDT:USDT', sourceId: 'bybit-main', symbol: 'BTC', assetClass: 'crypto', barCapability: 'realtime' }),
     ])
+    expect(uta[0].label).toContain('realtime') // broker freshness shown in the label too
     // vendor side still present (redundancy)
     expect(out.some((c) => c.source === 'vendor')).toBe(true)
   })

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -259,6 +259,19 @@ export function createBarService(deps: BarServiceDeps): BarService {
         }
       }
 
+      // Order by freshness so the agent's default pick is the freshest source:
+      // broker bars (realtime) float above delayed vendors (yfinance/fmp). The
+      // list stays fully redundant — this is only the suggested ordering; every
+      // candidate is still returned. (Array.sort is stable → within-source order
+      // is preserved.)
+      const FRESHNESS_RANK: Record<BarCapability, number> = {
+        realtime: 0, iex: 1, subscription: 2, delayed: 3, free: 4,
+      }
+      out.sort(
+        (a, b) =>
+          (a.barCapability ? FRESHNESS_RANK[a.barCapability] : 5) -
+          (b.barCapability ? FRESHNESS_RANK[b.barCapability] : 5),
+      )
       return out
     },
 

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -227,6 +227,8 @@ export function createBarService(deps: BarServiceDeps): BarService {
         for (const r of vendorRes.value) {
           const symbol = String(r.symbol ?? r.id ?? '')
           const provider = deps.vendorProviders[r.assetClass]
+          const cap = VENDOR_CAPABILITY[provider]
+          const base = r.name ? `${symbol} · ${r.name} (${provider})` : `${symbol} (${provider})`
           out.push({
             barId: formatBarId(provider, symbol),
             source: 'vendor',
@@ -234,8 +236,11 @@ export function createBarService(deps: BarServiceDeps): BarService {
             symbol,
             name: r.name ?? undefined,
             assetClass: r.assetClass,
-            label: r.name ? `${symbol} · ${r.name} (${provider})` : `${symbol} (${provider})`,
-            barCapability: VENDOR_CAPABILITY[provider],
+            // Surface freshness IN the label, not just the structured barCapability
+            // field, so the agent can't miss that a vendor source is delayed even
+            // when it deliberately falls back to one (yfinance/fmp are EOD-delayed).
+            label: cap ? `${base} · ${cap}` : base,
+            barCapability: cap,
           })
         }
       }
@@ -253,7 +258,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
             // Venue-decided asset class is authoritative; secType is only a
             // broker-blind fallback (and wrong for e.g. a CCXT dated future).
             assetClass: hit.assetClass ?? secTypeToAssetClass(hit.contract.secType),
-            label: symbol ? `${symbol} (${hit.source})` : `${barId}`,
+            label: (symbol ? `${symbol} (${hit.source})` : barId) + ' · realtime',
             barCapability: 'realtime',
           })
         }

--- a/src/tool/analysis.ts
+++ b/src/tool/analysis.ts
@@ -34,9 +34,9 @@ function buildContext(
 export function createAnalysisTools(barService: BarService) {
   return {
     calculateIndicator: tool({
-      description: `Calculate technical indicators by ticker (vendor data, auto-selected). Quick path for "what's AAPL's RSI".
+      description: `Calculate technical indicators by ticker (vendor data, auto-selected — typically yfinance, whose end-of-day bars can lag a day or two). Quick path for "what's AAPL's RSI" when freshness doesn't matter.
 
-For a SPECIFIC source (a broker's K-lines matching a held position's symbology), or to mix sources in one expression, use **calculateQuant** instead — it's barId-keyed. This tool (calculateIndicator) is the simpler vendor-default path: plain ticker + asset class, no barId. Note the syntax differs: HERE functions are UPPERCASE in a formula string (SMA(CLOSE('AAPL','1d'),50)); calculateQuant uses a lowercase pandas-style script (sma(s.close, 50)).
+For anything you trade, or anything time-sensitive, prefer **calculateQuant** — it's barId-keyed, so you can target a broker's realtime K-lines (matching a held position's symbology) or mix sources in one expression. This tool (calculateIndicator) is the simpler vendor-default path: plain ticker + asset class, no barId. Note the syntax differs: HERE functions are UPPERCASE in a formula string (SMA(CLOSE('AAPL','1d'),50)); calculateQuant uses a lowercase pandas-style script (sma(s.close, 50)).
 
 Asset classes: "equity" for stocks, "crypto" for cryptocurrencies, "currency" for forex pairs, "commodity" for commodities (use canonical names: gold, crude_oil, copper, etc.).
 

--- a/src/tool/quant.ts
+++ b/src/tool/quant.ts
@@ -17,15 +17,18 @@ export function createQuantTools(deps: CalcDeps) {
     searchBars: tool({
       description: `Find K-line sources for a symbol — returns barIds to paste into calculateQuant's bars(...).
 
-Federates vendors (yfinance/fmp) AND connected brokers (alpaca-paper, binance-readonly, …).
-Each candidate carries:
+Federates connected brokers (alpaca-paper, binance-readonly, …) AND vendors (fmp, yfinance).
+Candidates come back freshest-first. Each carries:
   - barId: use directly, e.g. bars("<barId>", "1d", count=250).
     · broker barIds ("accountId|symbol") need NO asset= in bars().
     · vendor barIds ("provider|symbol") need asset="equity|crypto|currency|commodity".
   - source: "uta" (broker) | "vendor"
-  - barCapability: "realtime" | "delayed" | "iex" | "subscription" — prefer the freshest.
-The same asset appears from multiple sources (redundancy is expected) — pick by capability,
-and by whether it's a broker you actually trade (so the chart matches your fills).`,
+  - barCapability: "realtime" | "delayed" | "iex" | "subscription".
+Source preference: a broker you actually trade (realtime, and the chart matches your fills) >
+a paid vendor (fmp, …) > yfinance. yfinance is a FREE FALLBACK only — its end-of-day bars can
+lag a day or two, so don't use it for anything time-sensitive or to chart a live position when
+a broker source exists. The same asset appears from multiple sources (redundancy is expected);
+default to the freshest broker candidate.`,
       inputSchema: z.object({
         query: z.string().describe('Symbol or keyword, e.g. "AAPL", "BTC", "bitcoin"'),
         limit: z.number().int().positive().optional().describe('Max candidates (default 20)'),
@@ -46,8 +49,10 @@ A script is one or more \`name = bars(...)\` bindings followed by a final result
   sma(s.close, 50) - sma(s.close, 200)
 
 bars(barId, interval, count=, asOf=, start=, end=, asset=):
-  - barId: "{source}|{symbol}" from searchContracts (broker, e.g. "alpaca-paper|AAPL",
-    "binance-readonly|BTC/USDT") or a vendor ("yfinance|AAPL", "fmp|AAPL").
+  - barId: "{source}|{symbol}" from searchBars (broker, e.g. "alpaca-paper|AAPL",
+    "binance-readonly|BTC/USDT") or a vendor ("yfinance|AAPL", "fmp|AAPL"). Prefer a broker
+    barId for anything you trade or anything time-sensitive — yfinance is a delayed free
+    fallback (EOD bars can lag a day or two).
   - interval: "1m" "5m" "15m" "30m" "1h" "4h" "1d" "1w".
   - count=N: number of most-recent bars (the natural window for indicators).
   - asset=: REQUIRED for vendor barIds — "equity" | "crypto" | "currency" | "commodity".


### PR DESCRIPTION
## Summary

Improve the bar source selection experience by making data freshness explicit in search results and ordering candidates by recency. Users now see at a glance whether a source is realtime or delayed, and broker sources (freshest) float above vendor sources in the results.

## Changes

- **Bar search results now surface freshness in labels**: Broker sources show "· realtime", vendor sources show their capability (e.g., "· delayed" for yfinance). This makes the freshness distinction visible even when users deliberately fall back to a delayed vendor.

- **Results sorted by freshness**: `searchBarSources` now orders candidates by `barCapability` (realtime → iex → subscription → delayed → free), so the agent's default pick is the freshest available source. Redundancy is preserved — all candidates still returned, just reordered.

- **Documentation & guidance expanded**: 
  - Added "Choosing a source" section to `SKILL.md` with explicit preference order: broker you trade > paid vendor > yfinance (free fallback only).
  - Clarified that yfinance EOD bars can lag a day or two, so it's unsuitable for time-sensitive signals or live position charting.
  - Updated tool descriptions in `quant.ts` and `analysis.ts` to emphasize broker preference and yfinance's delayed nature.
  - Added example disclaimer noting that examples use yfinance for brevity, but users should swap in broker barIds when available.

- **Example updated**: Changed `quant` example from `yfinance|AAPL` to `alpaca-paper|AAPL` to model the preferred pattern.

- **Tests updated**: Added assertions that freshness is surfaced in labels for both vendor and broker sources.

## Implementation Details

- Freshness ranking defined as `FRESHNESS_RANK` enum in `bar-service.ts`, applied via stable `Array.sort()` to preserve within-source ordering.
- Label formatting now includes capability string (e.g., `"AAPL · yfinance (yfinance) · delayed"`) so users see freshness without needing to cross-reference the structured `barCapability` field.
- Broker labels also updated to include "· realtime" for consistency and clarity.

https://claude.ai/code/session_01UieToxDQhjXqkRTrLKX5ih