### PR TITLE
Ask Alice: per-workspace "+" opens the composer scoped to that workspace

### DIFF
--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -24,7 +24,7 @@ const openaiKey: Credential = {
   vendor: 'openai', authType: 'api-key', apiKey: 'sk-oa', wires: { 'openai-chat': '' },
 };
 
-function build() {
+function build(opts: { workspaces?: any[] } = {}) {
   const META = { id: 'ws-1', dir: '/w', agents: ['claude', 'opencode'], template: 'chat', tag: 'chat-x' };
   const opencode = {
     id: 'opencode',
@@ -37,9 +37,12 @@ function build() {
   const spawn = vi.fn(() => ({
     recordId: 'rec-1', wsId: 'ws-1', name: 'o1', pid: 1, agentSessionId: null, startedAt: 1,
   }));
+  const creator = { create: vi.fn(async () => ({ ok: true, workspace: META })) };
   const svc = {
-    registry: { list: () => [] }, // → creator.create path (bypasses tag matching)
-    creator: { create: vi.fn(async () => ({ ok: true, workspace: META })) },
+    // Default []: today's tag never matches → creator.create path. Tests that
+    // exercise targetWsId pass the workspace in so registry resolves it by id.
+    registry: { list: () => opts.workspaces ?? [] },
+    creator,
     resolveAdapter: (_m: any, agentId?: string) => adapters[agentId ?? 'claude'] ?? claude,
     adapters: { get: (id: string) => adapters[id] },
     sessionRegistry: {
@@ -52,7 +55,7 @@ function build() {
     publicMeta: vi.fn(async () => META),
     config: { launcherRepoRoot: '/repo' },
   } as unknown as WorkspaceService;
-  return { app: createWorkspaceRoutes(svc), opencode, spawn };
+  return { app: createWorkspaceRoutes(svc), opencode, spawn, creator };
 }
 
 async function quickChat(app: any, body: unknown) {
@@ -114,5 +117,27 @@ describe('POST /quick-chat — loginless credential injection', () => {
     expect(r.status).toBe(201);
     expect(vi.mocked(readCredentials)).not.toHaveBeenCalled();
     expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  // targetWsId — the chat sidebar's per-workspace "+": spawn INTO the given
+  // workspace, not today's (so no creator.create).
+  it('targetWsId spawns into the given workspace, skipping find-or-create', async () => {
+    const { app, spawn, creator } = build({
+      workspaces: [{ id: 'ws-1', dir: '/w', agents: ['claude'], template: 'chat', tag: 'chat-x' }],
+    });
+    const r = await quickChat(app, { prompt: 'hi', agent: 'claude', targetWsId: 'ws-1' });
+    expect(r.status).toBe(201);
+    expect(creator.create).not.toHaveBeenCalled(); // reused, not created
+    expect(spawn).toHaveBeenCalledOnce();
+    expect((spawn.mock.calls[0] as any[])[0]).toBe('ws-1'); // spawned into the target
+  });
+
+  it('unknown targetWsId → 404 workspace_not_found, no spawn', async () => {
+    const { app, spawn, creator } = build();
+    const r = await quickChat(app, { prompt: 'hi', targetWsId: 'nope' });
+    expect(r.status).toBe(404);
+    expect(r.body.error).toBe('workspace_not_found');
+    expect(creator.create).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
   });
 });

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -601,6 +601,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     let prompt: string;
     let agentId: string | undefined;
     let credentialSlug: string | undefined;
+    let targetWsId: string | undefined;
     try {
       const body = await safeJson(c);
       const fields = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
@@ -614,6 +615,10 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
       // consulted for opencode/pi; claude/codex ignore it (own login).
       const rawSlug = fields['credentialSlug'];
       if (typeof rawSlug === 'string' && rawSlug.length > 0) credentialSlug = rawSlug;
+      // Optional: spawn into THIS existing workspace instead of today's. The
+      // chat sidebar's per-workspace "+" ("Ask Alice, but in this workspace").
+      const rawTarget = fields['targetWsId'];
+      if (typeof rawTarget === 'string' && rawTarget.length > 0) targetWsId = rawTarget;
     } catch (err) {
       return c.json({ error: 'bad_request', message: (err as Error).message }, 400);
     }
@@ -625,11 +630,19 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     // heavy (bash + git + skill injection) but happens at most once per day. The
     // find-or-create runs through `chatWsGate` so concurrent first-of-day
     // launches don't double-bootstrap.
-    const run = chatWsGate.catch(() => undefined).then(() => findOrCreateChatWorkspace());
-    chatWsGate = run;
-    const target = await run;
-    if (!target.ok) return c.json(target.body, target.status as 400 | 409 | 500);
-    const meta = target.meta;
+    let meta: WorkspaceMeta;
+    if (targetWsId) {
+      // Targeted: spawn a new session into the given existing workspace.
+      const found = svc.registry.list().find((w) => w.id === targetWsId);
+      if (!found) return c.json({ error: 'workspace_not_found' }, 404);
+      meta = found;
+    } else {
+      const run = chatWsGate.catch(() => undefined).then(() => findOrCreateChatWorkspace());
+      chatWsGate = run;
+      const target = await run;
+      if (!target.ok) return c.json(target.body, target.status as 400 | 409 | 500);
+      meta = target.meta;
+    }
 
     // A loginless runtime (opencode/pi) can't start without an AI config — seed
     // it from the vault before spawn. The dead-end (no compatible credential at

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -181,7 +181,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
             onDeleteSession={(sid) => ctx.requestDeleteSession(w.id, sid)}
             onConfigure={() => ctx.openAgentConfig(w.id)}
             onDelete={() => setPendingDelete(w)}
-            onSpawn={() => void ctx.spawn(w.id, { agent: w.agents[0] ?? 'claude' })}
+            onSpawn={() => openOrFocus({ kind: 'chat-landing', params: { targetWsId: w.id } })}
           />
         ))}
       </ul>

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -282,10 +282,12 @@ export async function quickChat(
   prompt: string,
   agent?: string,
   credentialSlug?: string,
+  targetWsId?: string,
 ): Promise<QuickChatResult> {
   const body: Record<string, unknown> = { prompt };
   if (agent !== undefined) body['agent'] = agent;
   if (credentialSlug !== undefined) body['credentialSlug'] = credentialSlug;
+  if (targetWsId !== undefined) body['targetWsId'] = targetWsId;
   const res = await fetch('/api/workspaces/quick-chat', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -68,7 +68,7 @@ interface WorkspacesContextValue {
    * session seeded with `prompt`, and focus into its terminal tab. Rejects on
    * failure so the composer can surface it.
    */
-  quickChat(prompt: string, agent?: string, credentialSlug?: string): Promise<void>
+  quickChat(prompt: string, agent?: string, credentialSlug?: string, targetWsId?: string): Promise<void>
   pauseSession(wsId: string, sessionId: string): Promise<void>
   resumeSession(wsId: string, sessionId: string): Promise<void>
   /**
@@ -186,8 +186,8 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   )
 
   const quickChat = useCallback(
-    async (prompt: string, agent?: string, credentialSlug?: string): Promise<void> => {
-      const { workspace, session } = await apiQuickChat(prompt, agent, credentialSlug)
+    async (prompt: string, agent?: string, credentialSlug?: string, targetWsId?: string): Promise<void> => {
+      const { workspace, session } = await apiQuickChat(prompt, agent, credentialSlug, targetWsId)
       const nowIso = new Date().toISOString()
       const newRecord: SessionRecord = {
         id: session.sessionId,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -133,6 +133,7 @@ export const en = {
     subheading: 'Ask Alice to research, analyze, or trade — your market data and tools are on tap.',
     targetHeading: 'New session in this workspace',
     targetSub: 'This conversation starts inside {{tag}} — pick a runtime and send.',
+    clearTarget: 'New chat instead',
     placeholder: 'Ask Alice…',
     workspaceType: 'Chat',
     defaultAgent: 'Default',

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -131,6 +131,8 @@ export const en = {
   chatLanding: {
     heading: 'What do you want to look into?',
     subheading: 'Ask Alice to research, analyze, or trade — your market data and tools are on tap.',
+    targetHeading: 'New session in this workspace',
+    targetSub: 'This conversation starts inside {{tag}} — pick a runtime and send.',
     placeholder: 'Ask Alice…',
     workspaceType: 'Chat',
     defaultAgent: 'Default',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -122,6 +122,7 @@ export const ja: Resources = {
     subheading: 'Alice にリサーチ・分析・取引を依頼できます——マーケットデータとツールはすぐ使えます。',
     targetHeading: 'このワークスペースで新規セッション',
     targetSub: 'この会話は {{tag}} 内に作成されます——ランタイムを選んで送信してください。',
+    clearTarget: '通常の新規チャットに切替',
     placeholder: 'Alice に質問…',
     workspaceType: 'チャット',
     defaultAgent: 'デフォルト',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -120,6 +120,8 @@ export const ja: Resources = {
   chatLanding: {
     heading: '今日は何を調べますか？',
     subheading: 'Alice にリサーチ・分析・取引を依頼できます——マーケットデータとツールはすぐ使えます。',
+    targetHeading: 'このワークスペースで新規セッション',
+    targetSub: 'この会話は {{tag}} 内に作成されます——ランタイムを選んで送信してください。',
     placeholder: 'Alice に質問…',
     workspaceType: 'チャット',
     defaultAgent: 'デフォルト',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -130,6 +130,7 @@ export const zhHant: Resources = {
     subheading: '讓 Alice 幫你研究、分析或交易——行情資料與工具都已就緒。',
     targetHeading: '在此 workspace 中新建工作階段',
     targetSub: '這段對話將在 {{tag}} 內建立——選個執行階段直接送出。',
+    clearTarget: '改為新對話',
     placeholder: '問 Alice…',
     workspaceType: '對話',
     defaultAgent: '預設',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -128,6 +128,8 @@ export const zhHant: Resources = {
   chatLanding: {
     heading: '今天想研究什麼？',
     subheading: '讓 Alice 幫你研究、分析或交易——行情資料與工具都已就緒。',
+    targetHeading: '在此 workspace 中新建工作階段',
+    targetSub: '這段對話將在 {{tag}} 內建立——選個執行階段直接送出。',
     placeholder: '問 Alice…',
     workspaceType: '對話',
     defaultAgent: '預設',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -122,6 +122,7 @@ export const zh: Resources = {
     subheading: '让 Alice 帮你研究、分析或交易——行情数据和工具都已就位。',
     targetHeading: '在此 workspace 中新建会话',
     targetSub: '这段对话将在 {{tag}} 内创建——选个运行时直接发送。',
+    clearTarget: '改为新对话',
     placeholder: '问 Alice…',
     workspaceType: '对话',
     defaultAgent: '默认',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -120,6 +120,8 @@ export const zh: Resources = {
   chatLanding: {
     heading: '今天想研究点什么？',
     subheading: '让 Alice 帮你研究、分析或交易——行情数据和工具都已就位。',
+    targetHeading: '在此 workspace 中新建会话',
+    targetSub: '这段对话将在 {{tag}} 内创建——选个运行时直接发送。',
     placeholder: '问 Alice…',
     workspaceType: '对话',
     defaultAgent: '默认',

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -8,10 +8,12 @@ import {
   Code2,
   Cpu,
   KeyRound,
+  LayoutGrid,
   Loader2,
   MessageSquare,
   Paperclip,
   Sparkles,
+  X,
   type LucideIcon,
 } from 'lucide-react'
 
@@ -266,9 +268,21 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
               <h1 className="text-xl md:text-2xl font-semibold text-text">
                 {t('chatLanding.targetHeading')}
               </h1>
-              <p className="text-sm text-text-muted">
-                {t('chatLanding.targetSub', { tag: targetWs.tag })}
-              </p>
+              <div className="flex items-center justify-center gap-2 pt-1">
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-accent/10 pl-2.5 pr-1.5 py-1 text-[12.5px] font-medium text-accent">
+                  <LayoutGrid className="w-3.5 h-3.5 shrink-0" />
+                  {targetWs.tag}
+                  <button
+                    type="button"
+                    onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
+                    aria-label={t('chatLanding.clearTarget')}
+                    title={t('chatLanding.clearTarget')}
+                    className="ml-0.5 rounded-full p-0.5 text-accent/70 hover:text-accent hover:bg-accent/20 transition-colors"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              </div>
             </>
           ) : (
             <>
@@ -278,7 +292,13 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
           )}
         </div>
 
-        <div className="bg-bg-secondary/60 border border-border/60 rounded-2xl px-3 pt-3 pb-2 transition-colors focus-within:border-accent/50">
+        <div
+          className={`rounded-2xl px-3 pt-3 pb-2 transition-colors ${
+            targetWs
+              ? 'bg-accent/[0.04] border border-accent/45 ring-1 ring-accent/15 focus-within:border-accent/70'
+              : 'bg-bg-secondary/60 border border-border/60 focus-within:border-accent/50'
+          }`}
+        >
           <textarea
             ref={textareaRef}
             value={value}

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -56,10 +56,17 @@ const AGENT_ICONS: Record<string, LucideIcon> = {
  * way — the bottom row shows the workspace type (Chat) and a small runtime
  * picker (the four agent CLIs), defaulting to the workspace's default agent.
  */
-export function ChatLandingPage() {
+export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: string } } }) {
   const { t } = useTranslation()
   const { quickChat, agents, workspaces } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
+
+  // Targeted launch: the chat sidebar's per-workspace "+" routes here with a
+  // targetWsId — "Ask Alice, but spawn the session in THIS workspace" rather
+  // than the default (today's chat workspace). Same composer; the send just
+  // carries the target.
+  const targetWsId = spec.params.targetWsId
+  const targetWs = targetWsId ? workspaces.find((w) => w.id === targetWsId) : undefined
 
   // The selectable agent runtimes = the agent CLIs (the bare shell has no agent
   // loop, so it can't be seeded with a first message).
@@ -89,7 +96,10 @@ export function ChatLandingPage() {
   // Default to the first INSTALLED CLI until the user picks one — so a fresh
   // box that only has, say, codex doesn't silently default to a missing claude.
   const firstInstalled = cliAgents.find(isInstalled)
-  const effectiveAgent = selectedAgent ?? firstInstalled?.id ?? cliAgents[0]?.id ?? null
+  // When targeting an existing workspace, default the picker to that
+  // workspace's own agent (the user can still switch).
+  const effectiveAgent =
+    selectedAgent ?? targetWs?.agents[0] ?? firstInstalled?.id ?? cliAgents[0]?.id ?? null
   const selectedInfo = cliAgents.find((a) => a.id === effectiveAgent) ?? null
   const SelectedIcon = selectedInfo ? AGENT_ICONS[selectedInfo.id] : undefined
   // Surface install guidance when the chosen runtime isn't on PATH.
@@ -208,6 +218,7 @@ export function ChatLandingPage() {
         prompt,
         effectiveAgent ?? undefined,
         needsCred ? (effectiveCred ?? undefined) : undefined,
+        targetWsId,
       )
       setValue('')
     } catch (err) {
@@ -250,8 +261,21 @@ export function ChatLandingPage() {
 
       <div className="relative z-10 w-full max-w-2xl flex flex-col gap-5">
         <div className="text-center space-y-1.5">
-          <h1 className="text-xl md:text-2xl font-semibold text-text">{t('chatLanding.heading')}</h1>
-          <p className="text-sm text-text-muted">{t('chatLanding.subheading')}</p>
+          {targetWs ? (
+            <>
+              <h1 className="text-xl md:text-2xl font-semibold text-text">
+                {t('chatLanding.targetHeading')}
+              </h1>
+              <p className="text-sm text-text-muted">
+                {t('chatLanding.targetSub', { tag: targetWs.tag })}
+              </p>
+            </>
+          ) : (
+            <>
+              <h1 className="text-xl md:text-2xl font-semibold text-text">{t('chatLanding.heading')}</h1>
+              <p className="text-sm text-text-muted">{t('chatLanding.subheading')}</p>
+            </>
+          )}
         </div>
 
         <div className="bg-bg-secondary/60 border border-border/60 rounded-2xl px-3 pt-3 pb-2 transition-colors focus-within:border-accent/50">

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -190,9 +190,13 @@ const trackedModule: ViewModule<'tracked'> = {
 
 const chatLandingModule: ViewModule<'chat-landing'> = {
   kind: 'chat-landing',
-  title: () => 'Ask Alice',
+  title: (spec, ctx) => {
+    if (!spec.params.targetWsId) return 'Ask Alice'
+    const tag = ctx.workspaces?.find((w) => w.id === spec.params.targetWsId)?.tag
+    return tag ? `New session · ${tag}` : 'New session'
+  },
   toUrl: () => '/chat',
-  Component: () => <ChatLandingPage />,
+  Component: ({ spec }) => <ChatLandingPage spec={spec} />,
 }
 
 const workspaceListModule: ViewModule<'workspace-list'> = {

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -30,7 +30,7 @@ export type ViewSpec =
   | { kind: 'dev';            params: { tab: 'tools' | 'snapshots' | 'logs' | 'simulator' } }
   | { kind: 'inbox';               params: Record<string, never> }
   | { kind: 'tracked';             params: Record<string, never> }
-  | { kind: 'chat-landing';        params: Record<string, never> }
+  | { kind: 'chat-landing';        params: { targetWsId?: string } }
   | { kind: 'file-viewer';         params: { wsId: string; path: string } }
 
 export type ViewKind = ViewSpec['kind']


### PR DESCRIPTION
## Summary
The chat sidebar's per-workspace "+" used to direct-spawn with the workspace's default agent — no agent choice, no first message. Reroute it through the existing Ask Alice composer, carrying a `targetWsId`:

- **New chat** (top) → composer → today's chat workspace (unchanged).
- A **workspace's "+"** → same composer, scoped: heading "New session in this workspace", an accent chip (`⊞ <tag> ✕`), an accent ring on the input, and the runtime picker defaulted to that workspace's agent. Send spawns the session **inside that workspace**. The ✕ drops back to a plain new chat.

Backend: `/quick-chat` takes an optional `targetWsId` — resolve that workspace instead of find-or-create-today; loginless cred injection, seed prompt, and spawn are all reused unchanged.

## Test plan
- [x] `tsc --noEmit` (Alice) + `tsc -b` (UI) clean
- [x] `workspaces-quickchat.spec.ts` 6/6 (added: targets the workspace / 404 when unknown)
- [x] Playwright: "+" opens the scoped composer (chip + accent ring + targeted heading), zero console/pageerrors

## Boundary touch
Touches the quick-chat workspace-launch route (`src/webui/routes/workspaces.ts`). No trading / auth / broker / migration code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
