### PR TITLE
fix(market-data): count-only broker bar requests collapsed to one in-progress bar

### DIFF
--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -139,6 +139,28 @@ describe('getBars — UTA branch', () => {
     expect(meta).toMatchObject({ source: 'uta', sourceId: 'alpaca-paper', barId: 'alpaca-paper|AAPL', barCapability: 'realtime' })
     expect(getHistorical).toHaveBeenCalledWith({ aliceId: 'alpaca-paper|AAPL' }, expect.objectContaining({ interval: '1d' }))
   })
+
+  it('count-only request becomes a START WINDOW, not a broker `limit` (alpaca count-anchoring bug)', async () => {
+    // A count-only request must reach the broker as a start-bounded window — NOT
+    // as `limit: count` with no start. Alpaca's getBarsV2 anchors `limit` to a
+    // default start and returns the FIRST N bars ascending, so `1d count=60`
+    // collapsed to a single in-progress daily bar. We over-fetch a window and
+    // tail-slice instead. Regression guard for the 2026-06-25 repro.
+    const getHistorical = vi.fn(async (_ref: unknown, params: { start?: Date; limit?: number }) => {
+      void params
+      return WIRE
+    })
+    const utaManager: UtaBarGateway = {
+      has: async (id) => id === 'alpaca-paper',
+      get: async () => ({ getHistorical }),
+      searchContracts: async () => [],
+    }
+    const svc = createBarService(makeDeps({ utaManager }))
+    await svc.getBars({ barId: 'alpaca-paper|AAPL' }, { interval: '1d', count: 60 })
+    const params = getHistorical.mock.calls[0][1]
+    expect(params.start).toBeInstanceOf(Date)       // count → synthesized start window
+    expect(params.limit).toBeUndefined()            // count is NOT forwarded as limit
+  })
 })
 
 describe('searchBarSources — federated candidates', () => {

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -191,11 +191,20 @@ export function createBarService(deps: BarServiceDeps): BarService {
   async function getUtaBars(sourceId: string, barId: string, opts: GetBarsOpts): Promise<BarsResult> {
     const acct = await deps.utaManager.get(sourceId)
     if (!acct) throw new Error(`UTA source "${sourceId}" not found for barId "${barId}"`)
+    // Mirror the vendor branch: a count-only request becomes a START WINDOW we
+    // over-fetch and then tail-slice (finalize keeps the most-recent `count`).
+    // We deliberately do NOT forward `count` as the broker's `limit`. Alpaca's
+    // getBarsV2 — and any API that anchors `limit` to a default *start* and
+    // returns the FIRST N bars ascending — would otherwise collapse a count-only
+    // request to the in-progress session: a single daily bar timestamped at the
+    // premarket open, or just the first minutes of an intraday series, instead
+    // of the most recent N. (Reproduced 2026-06-25 against alpaca paper: `1d
+    // count=60` → 1 bar timestamped 04:00; `1m count=50` → 08:00–08:49.)
+    const start = opts.start ?? (opts.count != null ? startDateFor(opts) : undefined)
     const params: BarParams = {
       interval: toBarInterval(opts.interval),
-      start: opts.start ? new Date(opts.start) : undefined,
+      start: start ? new Date(start) : undefined,
       end: (opts.end ?? opts.asOf) ? new Date((opts.end ?? opts.asOf)!) : undefined,
-      limit: opts.count,
     }
     const wireBars = await acct.getHistorical({ aliceId: barId }, params)
     const bars = finalize(wireBars.map(barToOhlcv), opts.count)


### PR DESCRIPTION
## Summary
- The federated bar layer's **UTA (broker) branch** never sized a start window from `count` — it passed `start: undefined` through and relied on the broker's `limit`. Alpaca's `getBarsV2` anchors `limit` to a **default start** and returns the FIRST N bars ascending, so `bars("alpaca|SPY","1d",count=60)` collapsed to a **single** in-progress daily bar (stamped at the 04:00 premarket open), and `1m count=50` returned the first 50 minutes of the session instead of the latest. A "看盘状态" read then used that one bar's close as the current price — smoothing a high-open → dump → recover day into a flat green print.
- Fix mirrors the vendor branch in `getUtaBars`: a count-only request becomes a **start window** we over-fetch and tail-slice (`finalize` keeps the most-recent `count`), and `count` is **no longer forwarded as the broker's `limit`** (on a first-N-from-start API that would drop the newest bars). Broker-agnostic — fixes any broker with the same `limit` convention.
- Regression guard added: a count-only UTA request must reach the broker with a `start` Date and **no** `limit`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm test` — 138 files / 2030 tests pass
- [x] **Live CLI repro** against alpaca paper (`alice analysis quant`):

  | call | before | after |
  |---|---|---|
  | `1d count=60` | 1 bar @ 04:00 | **60 bars** 03-31→06-25 |
  | `1d count=250` | 1 bar | **250 bars** |
  | `15m count=50` | 08:00→20:15 (first-of-day) | 11:30→23:45 (latest) |
  | `1m count=50` | 08:00→08:49 | 23:09→23:59 (latest) |
  | `1d start/end` | 69 bars | 69 bars (unchanged) |

## Boundary touch
Touches the broker historical-data read path (Alice market-data → UTA `getHistorical`). Read-only — no order placement, credentials, or migrations.

## Follow-ups (not in this PR — from the same 2026-06-25 report)
- `marketStatus`-style read with vs-prevClose / day high·low / dist-from-high / amplitude / high-vol flag (product decision)
- eastmoney as a second realtime source + dual-source disagreement flag (likely satellite)
- search-bars freshness ranking surfaces crypto `SPY/USDT` perps above the real equity for an equity-ticker query (→ Linear)
- alpaca free-tier SIP 403 on the most-recent 1–2 days — graceful `end` retreat (→ Linear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
