### PR TITLE
feat(analysis): Retrospective / Time-Machine primitives — as-of snapshot, backtest, dated news, freshness contract

### DIFF
--- a/default/skills/alice-analysis/SKILL.md
+++ b/default/skills/alice-analysis/SKILL.md
@@ -71,7 +71,7 @@ index them** (`sma(s.close, 50)`, not `sma(...)[-1]`).
 ## Panels — batch many computations in one call
 
 The result can be a **labeled dict** or a **positional list** (each entry a single
-value, max 50). Use this instead of calling the tool N times:
+value, max 200). Use this instead of calling the tool N times:
 
 ```python
 h1  = bars("binance-readonly|BTC/USDT", "1h",  count=250)
@@ -80,6 +80,23 @@ h12 = bars("binance-readonly|BTC/USDT", "12h", count=250)
 { "1h": rsi(h1.close, 14), "4h": rsi(h4.close, 14), "12h": rsi(h12.close, 14) }
 ```
 → `{ "1h": 53.2, "4h": 48.9, "12h": 61.4 }`
+
+## Sibling verbs — dated reads & backtests
+
+`quant` returns latest scalars with no dates. When you need the time axis or a
+hypothetical trade, reach for these instead (see the `retrospective` skill for
+the full workflow):
+
+- **`alice analysis snapshot --query XLE [--asOf YYYY-MM-DD]`** — the honest
+  as-of read: DATED bars (never past `asOf` — no lookahead), the latest print
+  (close + vs-prevClose + day high/low + amplitude), compact levels, and a
+  **freshness contract** (`isLatestActual` / `staleTradingDays`). Use this for
+  "what does/did X look like", not a hand-rolled quant dump.
+- **`alice analysis simulate --query XLE --entryDate … --exitRule …`** —
+  backtest one entry + one exit (`trailing_stop`/`ma_break`/`stop`/`target`/
+  `hold`); returns entry/exit, returnPct, MFE/MAE.
+- **`alice analysis quant … --dates`** — opt-in date axis on a quant result
+  (`dates[barId]`), to map a dumped series back to days.
 
 ## Function catalog
 

--- a/default/skills/retrospective/SKILL.md
+++ b/default/skills/retrospective/SKILL.md
@@ -49,13 +49,15 @@ it.**
 1. **Snapshot the anchor (no lookahead).** Reconstruct the moment with
    `asOf` — bars never run past it.
    ```bash
-   alice analysis snapshot --query XLE --asOf 2026-04-03
+   alice analysis snapshot --query XLE --asOf 2026-04-03            # summary
+   alice analysis snapshot --query XLE --asOf 2026-04-03 --bars 30  # + dated path
    ```
-   Read the dated `bars`, the `latest` print (close, vs-prevClose, day
-   high/low, **amplitude** — a sleepy vs-prevClose number hides an intraday
-   plunge-and-recover), and `levels` (sma20/50, rsi14, distance from the period
-   high — the "how far off the top" feel). This is the honest "what did it look
-   like then".
+   Read the `latest` print (close, vs-prevClose, day high/low, **amplitude** —
+   a sleepy vs-prevClose number hides an intraday plunge-and-recover) and
+   `levels` (sma20/50, rsi14, distance from the period high — the "how far off
+   the top" feel). The snapshot is **summary-only by default** (the dated path
+   can be large); add `--bars N` when you actually need the per-day series.
+   `windowBars` tells you how many are available.
 
 2. **Align the catalysts to the price.** Pull the news IN the window,
    oldest-first, and lay the timestamps against the bars.

--- a/default/skills/retrospective/SKILL.md
+++ b/default/skills/retrospective/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: retrospective
+description: >
+  Subjective retrospective / time-machine analysis: rewind a name to a past
+  point, reconstruct what it looked like THEN (no future knowledge), align the
+  news catalysts to the price path, and pressure-test "if I'd entered there,
+  would it have worked?". Use when the question is about a past moment or a
+  hypothetical entry: "rewind XLE to early April", "what did NVDA look like
+  before earnings", "if we'd bought energy after the Iran headline, easy
+  money?", "replay the SMH spike — policy or earnings?", "was there an entry
+  signal at the time", "would an 8% trailing stop have saved me", "event study
+  on the Hormuz escalation". It strings together the as-of snapshot, the
+  date-windowed news, and the backtest into one honest replay — and it is
+  ruthless about data freshness, because a retro built on a stale or
+  future-leaking price is worse than no retro.
+---
+
+# Retrospective / Time-Machine analysis
+
+Rewind a name to a moment, see it as it was THEN, attribute the move to
+catalysts, and test whether a tradeable edge actually existed. The whole value
+is honesty: **no lookahead** (never use a price the moment didn't yet know) and
+**no stale data** (never report yesterday's close as "now").
+
+The tools (run them — don't answer from memory):
+`alice analysis snapshot`, `alice analysis simulate`, `alice rss window`,
+`alice rss grep` / `read`. (See the `alice`, `alice-analysis` skills for the
+quant scripting language.)
+
+## The freshness gate — DO THIS FIRST, every time
+
+Every snapshot/quant result carries a freshness contract:
+`asOf`, `isLatestActual`, `staleTradingDays`, and a `freshnessWarning` when the
+data does not reach the anchor. **Before you state any "current" number, check
+it.**
+
+- `isLatestActual: false` → the close you're holding is STALE. Do not call it
+  the current price. Say "as of <date>, N trading days behind" and, for
+  anything live, pull a realtime broker source.
+- A free vendor (yfinance) lags a day or two and a free broker tier (alpaca
+  SIP) may not have today yet. An overnight catalyst can land in exactly that
+  blind spot — the classic trap is reporting a flat green close while the real
+  reaction already happened after the bar you can see.
+- `snapshot --query <SYM>` auto-picks the freshest source (realtime broker >
+  delayed vendor). Prefer it over hand-fetching from a delayed vendor.
+
+## Procedure
+
+1. **Snapshot the anchor (no lookahead).** Reconstruct the moment with
+   `asOf` — bars never run past it.
+   ```bash
+   alice analysis snapshot --query XLE --asOf 2026-04-03
+   ```
+   Read the dated `bars`, the `latest` print (close, vs-prevClose, day
+   high/low, **amplitude** — a sleepy vs-prevClose number hides an intraday
+   plunge-and-recover), and `levels` (sma20/50, rsi14, distance from the period
+   high — the "how far off the top" feel). This is the honest "what did it look
+   like then".
+
+2. **Align the catalysts to the price.** Pull the news IN the window,
+   oldest-first, and lay the timestamps against the bars.
+   ```bash
+   alice rss window --from 2026-04-01 --to 2026-04-10 --pattern "Iran|oil|OPEC"
+   ```
+   Each hit has an ISO `time` — put it next to the bar it moved. This is how you
+   answer "was the spike policy or earnings". Coverage is the user's SUBSCRIBED
+   feeds only: an empty window means "not in the feeds", NOT "nothing happened"
+   — say so, and don't pretend you saw everything. (Cookie-gated sources —
+   Barchart options flow, Reddit sentiment — are unreachable from a headless
+   run; if the call needs them, flag the gap rather than imply full coverage.)
+
+3. **Test the entry (backtest the hypothesis).** "If I'd bought at the anchor,
+   would a stop/exit have worked?"
+   ```bash
+   alice analysis simulate --query XLE --entryDate 2026-04-03 \
+     --exitRule trailing_stop --exitPct 8
+   # also try: --exitRule ma_break --exitPeriod 50   (trend exit)
+   #           --exitRule hold                        (just measure to now)
+   ```
+   Read `entry`/`exit` (date·price·reason), `returnPct`, and **MFE/MAE** (the
+   best and worst it went while you held — the round trip a single end-number
+   hides). `open: true` means it never triggered the exit; the return is
+   mark-to-market, not realized. Compare a couple of exit rules — the
+   interesting finding is usually "the move was real but giving it back to a
+   loose stop ate most of it", or vice-versa.
+
+4. **Map the index to dates when you need the path in a quant script.** Most
+   reads are covered by snapshot; when you must compute over the series and want
+   the date axis, add `--dates` to `alice analysis quant` (it returns
+   `dates[barId]` so you can map a dumped value back to its day).
+
+## Write it down honestly
+
+A retro is only worth as much as its weakest assumption. State, every time:
+- the **asOf** and that the analysis used no later data,
+- the **source + freshness** of every "current" number,
+- what you **couldn't see** (feeds didn't cover it / cookie-gated / SIP didn't
+  have the latest day) — name the gap rather than paper over it.
+
+The failure mode this skill exists to prevent: a confident call built on a
+stale or future-leaking price. When in doubt, distrust the data before the
+market.

--- a/src/domain/analysis/calc-v2/evaluator.spec.ts
+++ b/src/domain/analysis/calc-v2/evaluator.spec.ts
@@ -178,10 +178,18 @@ describe('calc-v2 evaluator', () => {
   })
 
   it('caps panel size', async () => {
-    const entries = Array.from({ length: 51 }, (_, i) => `"k${i}": 1`).join(', ')
+    const entries = Array.from({ length: 201 }, (_, i) => `"k${i}": 1`).join(', ')
     const r = await run(`{ ${entries} }`, mockBars([1, 2, 3]))
     expect(r.error?.kind).toBe('type')
-    expect(r.error?.message).toMatch(/at most 50/)
+    expect(r.error?.message).toMatch(/at most 200/)
+  })
+
+  it('dates opt-in: attaches the per-source date axis', async () => {
+    const svc = mockBars([1, 2, 3, 4, 5])
+    const off = await runScript(`s = bars("x","1d",asset="equity")\ns.close[-1]`, { barService: svc })
+    expect(off.dates).toBeUndefined() // off by default
+    const on = await runScript(`s = bars("x","1d",asset="equity")\ns.close[-1]`, { barService: svc }, 4, { withDates: true })
+    expect(on.dates?.['yfinance|AAPL']).toEqual(['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05'])
   })
 
   it('a panel entry can be an indicator record (nested)', async () => {

--- a/src/domain/analysis/calc-v2/evaluator.ts
+++ b/src/domain/analysis/calc-v2/evaluator.ts
@@ -28,6 +28,14 @@ export interface CalcOutput {
   value: CalcValue
   /** Sources actually fetched, keyed by barId. */
   dataRange: Record<string, DataSourceMeta>
+  /** Per-source date axis (ascending), keyed by barId — only when withDates. Lets
+   *  the caller map a dumped series back to dates without a second snapshot call. */
+  dates?: Record<string, string[]>
+}
+
+export interface EvalOpts {
+  /** Attach each source's date axis to the output (opt-in; off by default). */
+  withDates?: boolean
 }
 
 // ---- runtime values ----
@@ -44,17 +52,23 @@ type V =
 
 const SERIES_COLUMNS = ['open', 'high', 'low', 'close', 'volume'] as const
 /** A panel (list/dict result) batches many computations in one call — but each
- *  entry is still a single value, so the output stays small. Cap the count. */
-const MAX_PANEL = 50
+ *  entry is still a single value, so the output stays small. Cap the count.
+ *  Raised from 50: dumping a multi-bar axis (one entry per bar) shouldn't have to
+ *  split into two calls for a few months of dailies. */
+const MAX_PANEL = 200
 
-export async function evaluate(program: Program, deps: CalcDeps): Promise<CalcOutput> {
+export async function evaluate(program: Program, deps: CalcDeps, opts: EvalOpts = {}): Promise<CalcOutput> {
   const env = new Map<string, V>()
   const dataRange: Record<string, DataSourceMeta> = {}
+  const dates: Record<string, string[]> = {}
 
-  const fetchBars = async (barId: string, opts: GetBarsOpts, assetClass: AssetClass | undefined): Promise<BarsResult> => {
+  const fetchBars = async (barId: string, fetchOpts: GetBarsOpts, assetClass: AssetClass | undefined): Promise<BarsResult> => {
     const ref = assetClass ? { barId, assetClass } : { barId }
-    const r = await deps.barService.getBars(ref, opts)
-    if (r.meta.barId) dataRange[r.meta.barId] = r.meta
+    const r = await deps.barService.getBars(ref, fetchOpts)
+    if (r.meta.barId) {
+      dataRange[r.meta.barId] = r.meta
+      if (opts.withDates) dates[r.meta.barId] = r.bars.map((b) => b.date)
+    }
     return r
   }
 
@@ -169,12 +183,13 @@ export async function evaluate(program: Program, deps: CalcDeps): Promise<CalcOu
     env.set(b.name, await evalExpr(b.value))
   }
   const out = await evalExpr(program.result)
+  const tail = opts.withDates ? { dataRange, dates } : { dataRange }
   switch (out.k) {
-    case 'num': return { value: out.v, dataRange }
-    case 'str': return { value: out.v, dataRange }
-    case 'rec': return { value: out.v, dataRange }
-    case 'list': return { value: out.items, dataRange }
-    case 'dict': return { value: out.map, dataRange }
+    case 'num': return { value: out.v, ...tail }
+    case 'str': return { value: out.v, ...tail }
+    case 'rec': return { value: out.v, ...tail }
+    case 'list': return { value: out.items, ...tail }
+    case 'dict': return { value: out.map, ...tail }
     default: {
       const what = out.k === 'series' ? 'a series' : 'a series column'
       throw new CalcError({ kind: 'type', message: `The result is ${what}, not a value — reduce it with [-1] or an indicator (e.g. sma(s.close, 50)), or return a panel like { "1h": rsi(s.close, 14) }`, line: program.result.pos.line })

--- a/src/domain/analysis/calc-v2/index.ts
+++ b/src/domain/analysis/calc-v2/index.ts
@@ -16,15 +16,26 @@ export interface RunResult {
   value?: CalcValue
   /** Sources actually fetched, keyed by barId (source/provider/capability). */
   dataRange?: Record<string, DataSourceMeta>
+  /** Per-source date axis (ascending) — present only when `dates` was requested. */
+  dates?: Record<string, string[]>
   /** Present iff the script failed — actionable for self-correction. */
   error?: CalcDiagnostic
 }
 
-export async function runScript(script: string, deps: CalcDeps, precision = 4): Promise<RunResult> {
+export async function runScript(
+  script: string,
+  deps: CalcDeps,
+  precision = 4,
+  opts: { withDates?: boolean } = {},
+): Promise<RunResult> {
   try {
     const program = parse(script)
-    const out = await evaluate(program, deps)
-    return { value: round(out.value, precision), dataRange: out.dataRange }
+    const out = await evaluate(program, deps, opts)
+    return {
+      value: round(out.value, precision),
+      dataRange: out.dataRange,
+      ...(out.dates ? { dates: out.dates } : {}),
+    }
   } catch (e) {
     if (e instanceof CalcError) return { error: e.diagnostic }
     throw e

--- a/src/domain/analysis/simulate.spec.ts
+++ b/src/domain/analysis/simulate.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { simulate, type SimulateResult } from './simulate.js'
+import type { BarService } from '@/domain/market-data/bars/index'
+import type { OhlcvBar } from '@/domain/market-data/bars/types'
+
+function makeBars(closes: number[]): OhlcvBar[] {
+  return closes.map((c, i) => ({
+    date: `2026-04-${String(i + 1).padStart(2, '0')}`,
+    open: c, high: c + 0.5, low: c - 0.5, close: c, volume: 1000,
+  }))
+}
+function svcOf(bars: OhlcvBar[]): BarService {
+  return {
+    searchBarSources: async () => [],
+    getBars: async () => ({
+      bars,
+      meta: { symbol: 'XLE', from: bars[0]?.date ?? '', to: bars[bars.length - 1]?.date ?? '', bars: bars.length, source: 'uta', barId: 'alpaca|XLE', asOf: bars[bars.length - 1]?.date ?? '' },
+    }),
+  } as unknown as BarService
+}
+const ok = (r: SimulateResult | { error: string }): SimulateResult => {
+  if ('error' in r) throw new Error(r.error)
+  return r
+}
+
+describe('simulate', () => {
+  it('trailing_stop exits when close falls pct% from the running peak', async () => {
+    // up to 110 then drop to 99 (−10% from peak 110)
+    const svc = svcOf(makeBars([100, 105, 110, 108, 99]))
+    const r = ok(await simulate(svc, { barId: 'alpaca|XLE' } as never, {
+      entryDate: '2026-04-01', exit: { type: 'trailing_stop', pct: 8 },
+    }))
+    expect(r.entry).toMatchObject({ date: '2026-04-01', price: 100 })
+    expect(r.exit).not.toBeNull()
+    expect(r.exit!.date).toBe('2026-04-05') // 99 is −10% from 110 peak (> 8%)
+    expect(r.open).toBe(false)
+    expect(r.mfePct).toBeGreaterThan(0) // ran up to 110.5 high
+  })
+
+  it('ma_break exits on the first close below its SMA', async () => {
+    // slow climb then a sharp drop below the 3-bar SMA
+    const svc = svcOf(makeBars([50, 51, 52, 53, 54, 45]))
+    const r = ok(await simulate(svc, { barId: 'alpaca|XLE' } as never, {
+      entryDate: '2026-04-03', exit: { type: 'ma_break', period: 3 },
+    }))
+    expect(r.exit).not.toBeNull()
+    expect(r.exit!.date).toBe('2026-04-06') // close 45 < SMA3
+    expect(r.exit!.reason).toMatch(/SMA3/)
+  })
+
+  it('hold never exits — return is mark-to-market to the last bar', async () => {
+    const svc = svcOf(makeBars([100, 110, 120]))
+    const r = ok(await simulate(svc, { barId: 'alpaca|XLE' } as never, {
+      entryDate: '2026-04-01', exit: { type: 'hold' },
+    }))
+    expect(r.open).toBe(true)
+    expect(r.exit).toBeNull()
+    expect(r.returnPct).toBe(20) // 100 → 120
+    expect(r.note).toMatch(/open/)
+  })
+
+  it('target exits on the first close at/above +pct%', async () => {
+    const svc = svcOf(makeBars([100, 103, 106]))
+    const r = ok(await simulate(svc, { barId: 'alpaca|XLE' } as never, {
+      entryDate: '2026-04-01', exit: { type: 'target', pct: 5 },
+    }))
+    expect(r.exit!.date).toBe('2026-04-03') // 106 ≥ +5%
+    expect(r.returnPct).toBe(6)
+  })
+
+  it('errors when the entry date is past the available window', async () => {
+    const svc = svcOf(makeBars([100, 101]))
+    const r = await simulate(svc, { barId: 'alpaca|XLE' } as never, {
+      entryDate: '2026-09-01', exit: { type: 'hold' },
+    })
+    expect('error' in r).toBe(true)
+  })
+})

--- a/src/domain/analysis/simulate.ts
+++ b/src/domain/analysis/simulate.ts
@@ -155,6 +155,14 @@ export async function simulate(
   const step = Math.max(1, Math.ceil(held.length / 20))
   const path = held.filter((_, i) => i % step === 0 || i === held.length - 1).map((b) => ({ date: b.date, close: px(b.close) }))
 
+  // The requested entry date may have been a weekend/holiday — we entered the
+  // next session. Say so, rather than silently using a different date.
+  const slipped = entryBar.date.slice(0, 10) !== opts.entryDate.slice(0, 10)
+  const notes = [
+    ...(slipped ? [`Requested entryDate ${opts.entryDate} was not a trading day; entered the next session ${entryBar.date.slice(0, 10)}.`] : []),
+    ...(exit === null ? [`Still open at asOf ${asOf} — return is mark-to-market, not realized.`] : []),
+  ]
+
   return {
     symbol: meta.symbol,
     barId: meta.barId,
@@ -172,6 +180,6 @@ export async function simulate(
     peak,
     trough,
     path,
-    ...(exit === null ? { note: `Still open at asOf ${asOf} — return is mark-to-market, not realized.` } : {}),
+    ...(notes.length ? { note: notes.join(' ') } : {}),
   }
 }

--- a/src/domain/analysis/simulate.ts
+++ b/src/domain/analysis/simulate.ts
@@ -1,0 +1,177 @@
+/**
+ * simulate — the "if I'd entered here, with this exit, what happened" backtest.
+ *
+ * A path-dependent walk over dated bars from an entry date to `asOf` (no
+ * lookahead past it), applying ONE built-in exit rule. Answers the recurring
+ * retro question — "buy XLE on the war headline, does a trailing stop / MA break
+ * save you?" — that was otherwise hand-rolled in Python every time.
+ *
+ * Built-in exit rules (v1):
+ *   trailing_stop(pct)  exit when close falls `pct`% from the running peak close
+ *   ma_break(period)    exit on the first close below its `period`-bar SMA
+ *   stop(pct)           exit when close falls `pct`% below entry
+ *   target(pct)         exit when close rises `pct`% above entry
+ *   hold                never exit — measure entry → asOf
+ *
+ * Reports entry/exit (date·price·reason), return, MFE/MAE (max favorable/adverse
+ * excursion), peak/trough, and a sampled path to narrate. Lives in
+ * domain/analysis (analysis → market-data dependency direction).
+ */
+
+import type { BarService, BarSourceRef, BarSourceKind } from '@/domain/market-data/bars/index'
+
+export type ExitRule =
+  | { type: 'trailing_stop'; pct: number }
+  | { type: 'ma_break'; period: number }
+  | { type: 'stop'; pct: number }
+  | { type: 'target'; pct: number }
+  | { type: 'hold' }
+
+export interface SimulateOpts {
+  /** Enter at the close of the first bar on/after this date (YYYY-MM-DD). */
+  entryDate: string
+  exit: ExitRule
+  interval?: string
+  /** Evaluate only up to here (YYYY-MM-DD, no lookahead past it). Default: now. */
+  asOf?: string
+}
+
+export interface SimulateResult {
+  symbol: string
+  barId?: string
+  source?: BarSourceKind
+  interval: string
+  asOf: string
+  rule: ExitRule
+  entry: { date: string; price: number }
+  exit: { date: string; price: number; reason: string } | null
+  /** True when no exit triggered by asOf — position still open. */
+  open: boolean
+  barsHeld: number
+  /** Entry → exit (or entry → last bar if still open), %. */
+  returnPct: number
+  /** Max favorable / adverse excursion over the hold, % (intrabar high/low vs entry). */
+  mfePct: number
+  maePct: number
+  peak: { date: string; price: number }
+  trough: { date: string; price: number }
+  /** ≤20 sampled (date, close) points across the hold, for narration. */
+  path: Array<{ date: string; close: number }>
+  note?: string
+}
+
+function pct(a: number, b: number): number {
+  return Number((((a - b) / b) * 100).toFixed(2))
+}
+function px(v: number): number {
+  return Number(v.toFixed(4))
+}
+
+export async function simulate(
+  barService: BarService,
+  ref: BarSourceRef,
+  opts: SimulateOpts,
+): Promise<SimulateResult | { error: string }> {
+  const interval = opts.interval ?? '1d'
+  const rule = opts.exit
+  // Pad the fetch window BEFORE the entry so an MA rule has history to define the
+  // moving average at the entry bar. Non-MA rules don't need it (harmless).
+  const lookback = rule.type === 'ma_break' ? rule.period : 0
+  const bufferDays = Math.ceil((lookback + 10) * 1.6)
+  const start = new Date(`${opts.entryDate}T00:00:00Z`)
+  start.setUTCDate(start.getUTCDate() - bufferDays)
+  const startStr = start.toISOString().slice(0, 10)
+
+  const { bars, meta } = await barService.getBars(ref, {
+    interval,
+    start: startStr,
+    ...(opts.asOf ? { end: opts.asOf } : {}),
+  })
+  const asOf = meta.asOf ?? opts.asOf ?? new Date().toISOString().slice(0, 10)
+
+  // First bar on/after the requested entry date.
+  const entryIdx = bars.findIndex((b) => b.date.slice(0, 10) >= opts.entryDate)
+  if (entryIdx === -1 || bars.length === 0) {
+    return { error: `No bars on/after ${opts.entryDate} for ${meta.barId ?? meta.symbol} (window ${meta.from}…${meta.to}). Check the date and source.` }
+  }
+  const entryBar = bars[entryIdx]
+  const entryPrice = entryBar.close
+  const closes = bars.map((b) => b.close)
+
+  const rollingSma = (i: number, period: number): number | null => {
+    if (i - period + 1 < 0) return null
+    let s = 0
+    for (let k = i - period + 1; k <= i; k++) s += closes[k]
+    return s / period
+  }
+
+  let peakClose = entryPrice
+  let peak = { date: entryBar.date, price: entryPrice }
+  let trough = { date: entryBar.date, price: entryPrice }
+  let mfe = 0
+  let mae = 0
+  let exit: SimulateResult['exit'] = null
+
+  for (let i = entryIdx; i < bars.length; i++) {
+    const b = bars[i]
+    // excursions use intrabar extremes vs entry
+    mfe = Math.max(mfe, pct(b.high, entryPrice))
+    mae = Math.min(mae, pct(b.low, entryPrice))
+    if (b.high > peak.price) peak = { date: b.date, price: px(b.high) }
+    if (b.low < trough.price) trough = { date: b.date, price: px(b.low) }
+    if (b.close > peakClose) peakClose = b.close
+
+    // exit checks evaluate from the bar AFTER entry (you can't exit the bar you enter on the close of)
+    if (i === entryIdx) continue
+    let reason: string | null = null
+    switch (rule.type) {
+      case 'trailing_stop':
+        if (b.close <= peakClose * (1 - rule.pct / 100)) reason = `close ${px(b.close)} fell ${rule.pct}% from peak ${px(peakClose)}`
+        break
+      case 'ma_break': {
+        const ma = rollingSma(i, rule.period)
+        if (ma != null && b.close < ma) reason = `close ${px(b.close)} broke below SMA${rule.period} ${px(ma)}`
+        break
+      }
+      case 'stop':
+        if (b.close <= entryPrice * (1 - rule.pct / 100)) reason = `close ${px(b.close)} hit −${rule.pct}% stop`
+        break
+      case 'target':
+        if (b.close >= entryPrice * (1 + rule.pct / 100)) reason = `close ${px(b.close)} hit +${rule.pct}% target`
+        break
+      case 'hold':
+        break
+    }
+    if (reason) {
+      exit = { date: b.date, price: px(b.close), reason }
+      break
+    }
+  }
+
+  const lastHeldIdx = exit ? bars.findIndex((b) => b.date === exit!.date) : bars.length - 1
+  const exitPrice = exit ? exit.price : bars[bars.length - 1].close
+  const barsHeld = lastHeldIdx - entryIdx
+  const held = bars.slice(entryIdx, lastHeldIdx + 1)
+  const step = Math.max(1, Math.ceil(held.length / 20))
+  const path = held.filter((_, i) => i % step === 0 || i === held.length - 1).map((b) => ({ date: b.date, close: px(b.close) }))
+
+  return {
+    symbol: meta.symbol,
+    barId: meta.barId,
+    source: meta.source,
+    interval,
+    asOf,
+    rule,
+    entry: { date: entryBar.date, price: px(entryPrice) },
+    exit,
+    open: exit === null,
+    barsHeld,
+    returnPct: pct(exitPrice, entryPrice),
+    mfePct: mfe,
+    maePct: mae,
+    peak,
+    trough,
+    path,
+    ...(exit === null ? { note: `Still open at asOf ${asOf} — return is mark-to-market, not realized.` } : {}),
+  }
+}

--- a/src/domain/analysis/snapshot.spec.ts
+++ b/src/domain/analysis/snapshot.spec.ts
@@ -27,20 +27,29 @@ function mockService(bars: OhlcvBar[], metaOver: Partial<BarMeta> = {}): BarServ
 }
 
 describe('getSnapshot', () => {
-  it('returns dated bars + latest print + levels', async () => {
+  it('summary by default (no bars dumped), latest print + levels computed over the window', async () => {
     const closes = Array.from({ length: 25 }, (_, i) => 50 + i) // 50..74
     const svc = mockService(makeBars(closes))
     const snap = await getSnapshot(svc, { barId: 'alpaca|XLE' } as never, { count: 25 })
-    // dated bars survive
-    expect(snap.bars).toHaveLength(25)
-    expect(snap.bars[0]).toMatchObject({ date: '2026-04-01', close: 50 })
+    // bars are opt-in — empty by default, but the window size is reported
+    expect(snap.bars).toHaveLength(0)
+    expect(snap.windowBars).toBe(25)
     // latest print: close 74, prevClose 73, +1.37%
     expect(snap.latest).toMatchObject({ date: '2026-04-25', close: 74, prevClose: 73 })
     expect(snap.latest!.changePct).toBeCloseTo(1.37, 1)
-    // levels: sma20 present (≥20 bars), rsi present, period high from highs
+    // levels computed over the full window even though no bars were returned
     expect(snap.levels!.sma20).not.toBeNull()
     expect(snap.levels!.periodHigh).toBe(75) // last high = 74+1
     expect(snap.levels!.distFromHighPct).toBeLessThanOrEqual(0)
+  })
+
+  it('returns the last `barsOut` dated bars when the path is requested', async () => {
+    const closes = Array.from({ length: 25 }, (_, i) => 50 + i)
+    const svc = mockService(makeBars(closes))
+    const snap = await getSnapshot(svc, { barId: 'alpaca|XLE' } as never, { count: 25, barsOut: 5 })
+    expect(snap.bars).toHaveLength(5)
+    expect(snap.bars.map((b) => b.close)).toEqual([70, 71, 72, 73, 74]) // last 5
+    expect(snap.windowBars).toBe(25) // still computed over all 25
   })
 
   it('surfaces a LOUD freshness warning when data does not reach the anchor', async () => {

--- a/src/domain/analysis/snapshot.spec.ts
+++ b/src/domain/analysis/snapshot.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { getSnapshot } from './snapshot.js'
+import type { BarService } from '@/domain/market-data/bars/index'
+import type { OhlcvBar, BarMeta } from '@/domain/market-data/bars/types'
+
+/** Build N ascending daily bars from a close path; high/low straddle close. */
+function makeBars(closes: number[]): OhlcvBar[] {
+  return closes.map((c, i) => ({
+    date: `2026-04-${String(i + 1).padStart(2, '0')}`,
+    open: c - 0.5, high: c + 1, low: c - 1, close: c, volume: 1000 + i,
+  }))
+}
+
+function mockService(bars: OhlcvBar[], metaOver: Partial<BarMeta> = {}): BarService {
+  return {
+    searchBarSources: async () => [],
+    getBars: async () => ({
+      bars,
+      meta: {
+        symbol: 'XLE', from: bars[0]?.date ?? '', to: bars[bars.length - 1]?.date ?? '',
+        bars: bars.length, source: 'uta', barId: 'alpaca|XLE', barCapability: 'realtime',
+        asOf: bars[bars.length - 1]?.date ?? '', isLatestActual: true, staleTradingDays: 0,
+        ...metaOver,
+      },
+    }),
+  } as unknown as BarService
+}
+
+describe('getSnapshot', () => {
+  it('returns dated bars + latest print + levels', async () => {
+    const closes = Array.from({ length: 25 }, (_, i) => 50 + i) // 50..74
+    const svc = mockService(makeBars(closes))
+    const snap = await getSnapshot(svc, { barId: 'alpaca|XLE' } as never, { count: 25 })
+    // dated bars survive
+    expect(snap.bars).toHaveLength(25)
+    expect(snap.bars[0]).toMatchObject({ date: '2026-04-01', close: 50 })
+    // latest print: close 74, prevClose 73, +1.37%
+    expect(snap.latest).toMatchObject({ date: '2026-04-25', close: 74, prevClose: 73 })
+    expect(snap.latest!.changePct).toBeCloseTo(1.37, 1)
+    // levels: sma20 present (≥20 bars), rsi present, period high from highs
+    expect(snap.levels!.sma20).not.toBeNull()
+    expect(snap.levels!.periodHigh).toBe(75) // last high = 74+1
+    expect(snap.levels!.distFromHighPct).toBeLessThanOrEqual(0)
+  })
+
+  it('surfaces a LOUD freshness warning when data does not reach the anchor', async () => {
+    const svc = mockService(makeBars([50, 51, 52]), { isLatestActual: false, staleTradingDays: 2, asOf: '2026-04-07' })
+    const snap = await getSnapshot(svc, { barId: 'alpaca|XLE' } as never, { asOf: '2026-04-07' })
+    expect(snap.isLatestActual).toBe(false)
+    expect(snap.staleTradingDays).toBe(2)
+    expect(snap.freshnessWarning).toMatch(/NOT seeing the latest/)
+  })
+
+  it('handles an empty window honestly', async () => {
+    const svc = mockService([])
+    const snap = await getSnapshot(svc, { barId: 'alpaca|XLE' } as never, {})
+    expect(snap.bars).toHaveLength(0)
+    expect(snap.latest).toBeNull()
+    expect(snap.levels).toBeNull()
+  })
+})

--- a/src/domain/analysis/snapshot.ts
+++ b/src/domain/analysis/snapshot.ts
@@ -27,8 +27,11 @@ export interface SnapshotOpts {
   asOf?: string
   /** Bar interval. Default '1d'. */
   interval?: string
-  /** Bars of dated context to return + compute over. Default 90. */
+  /** Analysis window FETCHED for the levels (sma50 needs ≥50). Default 90. */
   count?: number
+  /** How many recent dated bars to RETURN in `bars` (default 0 = summary only —
+   *  the dated path is opt-in so a "how's X" read stays light). Capped at count. */
+  barsOut?: number
 }
 
 export interface SnapshotBar {
@@ -64,6 +67,9 @@ export interface SnapshotResult {
     /** (high − low) / prevClose, %. The intraday range a single vs-prevClose number hides. */
     dayAmplitudePct: number | null
   } | null
+  /** How many bars are in the analysis window (the levels were computed over
+   *  these). The `bars` array may hold fewer — request more with barsOut. */
+  windowBars: number
   /** Compact technical state AS OF the anchor (over the returned window). */
   levels: {
     sma20: number | null
@@ -75,7 +81,8 @@ export interface SnapshotResult {
     distFromHighPct: number
     distFromLowPct: number
   } | null
-  /** Dated OHLCV, ascending, ≤ asOf. The dated series the quant tool can't emit. */
+  /** Recent dated OHLCV, ascending, ≤ asOf (the last `barsOut`; empty by default).
+   *  The dated series the quant tool can't emit — opt in with barsOut. */
   bars: SnapshotBar[]
 }
 
@@ -121,8 +128,13 @@ export async function getSnapshot(
   }
 
   if (bars.length === 0) {
-    return { ...base, latest: null, levels: null, bars: [] }
+    return { ...base, windowBars: 0, latest: null, levels: null, bars: [] }
   }
+
+  // Dated path is opt-in (barsOut) so a summary read stays light — the levels
+  // are still computed over the full fetched window either way.
+  const barsOut = Math.max(0, Math.min(opts.barsOut ?? 0, bars.length))
+  const outBars = barsOut > 0 ? bars.slice(-barsOut) : []
 
   const closes = bars.map((b) => b.close)
   const last = bars[bars.length - 1]
@@ -132,6 +144,7 @@ export async function getSnapshot(
 
   return {
     ...base,
+    windowBars: bars.length,
     latest: {
       date: last.date,
       close: r(last.close)!,
@@ -150,7 +163,7 @@ export async function getSnapshot(
       distFromHighPct: r(((last.close - periodHigh) / periodHigh) * 100, 2)!,
       distFromLowPct: r(((last.close - periodLow) / periodLow) * 100, 2)!,
     },
-    bars: bars.map((b) => ({
+    bars: outBars.map((b) => ({
       date: b.date, open: b.open, high: b.high, low: b.low, close: b.close, volume: b.volume,
     })),
   }

--- a/src/domain/analysis/snapshot.ts
+++ b/src/domain/analysis/snapshot.ts
@@ -1,0 +1,157 @@
+/**
+ * As-of snapshot — the honest "what did it look like at time T" primitive.
+ *
+ * The Retrospective / Time-Machine workflow's load-bearing read. Unlike the quant
+ * calculator (latest scalars, dateless), a snapshot returns:
+ *   - DATED OHLCV bars up to (and never past) `asOf` — no lookahead, the命门 of
+ *     an honest retro,
+ *   - the most-recent ACTUAL bar at/before `asOf` as the "current as of T" print
+ *     (close + vs-prevClose + day high/low + amplitude),
+ *   - a compact technical state (sma20/50, rsi14, period high/low, distance from
+ *     high/low),
+ *   - and the FRESHNESS CONTRACT from the bar layer (asOf / isLatestActual /
+ *     staleTradingDays) surfaced LOUDLY — a delayed source that stopped a day
+ *     behind the anchor is the failure mode this exists to prevent.
+ *
+ * Lives in `domain/analysis` (not `domain/market-data`): it consumes the bar
+ * service AND the indicator stat lib, and the dependency direction is
+ * analysis → market-data, never the reverse.
+ */
+
+import type { BarService, BarSourceRef, BarCapability, BarSourceKind } from '@/domain/market-data/bars/index'
+import { SMA } from './indicator/functions/statistics.js'
+import { RSI } from './indicator/functions/technical.js'
+
+export interface SnapshotOpts {
+  /** Point-in-time anchor (YYYY-MM-DD). Bars never run past it (no lookahead). Default: now. */
+  asOf?: string
+  /** Bar interval. Default '1d'. */
+  interval?: string
+  /** Bars of dated context to return + compute over. Default 90. */
+  count?: number
+}
+
+export interface SnapshotBar {
+  date: string
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number | null
+}
+
+export interface SnapshotResult {
+  symbol: string
+  barId?: string
+  source?: BarSourceKind
+  barCapability?: BarCapability
+  interval: string
+  /** Effective anchor. */
+  asOf: string
+  /** LOUD freshness: did the data reach `asOf`? */
+  isLatestActual: boolean
+  staleTradingDays: number
+  /** Human banner — present only when the data is stale relative to the anchor. */
+  freshnessWarning?: string
+  /** The most recent ACTUAL bar ≤ asOf — the honest "current as of T". */
+  latest: {
+    date: string
+    close: number
+    prevClose: number | null
+    changePct: number | null
+    dayHigh: number
+    dayLow: number
+    /** (high − low) / prevClose, %. The intraday range a single vs-prevClose number hides. */
+    dayAmplitudePct: number | null
+  } | null
+  /** Compact technical state AS OF the anchor (over the returned window). */
+  levels: {
+    sma20: number | null
+    sma50: number | null
+    rsi14: number | null
+    periodHigh: number
+    periodLow: number
+    /** (close − periodHigh)/periodHigh, % (≤0). "How far off the high" — the dump-from-high feel. */
+    distFromHighPct: number
+    distFromLowPct: number
+  } | null
+  /** Dated OHLCV, ascending, ≤ asOf. The dated series the quant tool can't emit. */
+  bars: SnapshotBar[]
+}
+
+function r(v: number | null, dp = 4): number | null {
+  return v == null || !Number.isFinite(v) ? null : Number(v.toFixed(dp))
+}
+function safe(fn: () => number): number | null {
+  try { const v = fn(); return Number.isFinite(v) ? v : null } catch { return null }
+}
+
+export async function getSnapshot(
+  barService: BarService,
+  ref: BarSourceRef,
+  opts: SnapshotOpts = {},
+): Promise<SnapshotResult> {
+  const interval = opts.interval ?? '1d'
+  const count = opts.count ?? 90
+  // `end` (not just asOf) is what actually caps the upper bound in BOTH branches
+  // — pass both so the window is sized AND clamped to the anchor (no lookahead).
+  const { bars, meta } = await barService.getBars(ref, {
+    interval,
+    count,
+    ...(opts.asOf ? { end: opts.asOf, asOf: opts.asOf } : {}),
+  })
+
+  const asOf = meta.asOf ?? opts.asOf ?? new Date().toISOString().slice(0, 10)
+  const isLatestActual = meta.isLatestActual ?? true
+  const staleTradingDays = meta.staleTradingDays ?? 0
+  const warning = !isLatestActual && bars.length > 0
+    ? `⚠ Data ends ${bars[bars.length - 1].date.slice(0, 10)}, but you anchored as-of ${asOf} — ${staleTradingDays} trading day(s) behind. You are NOT seeing the latest print; treat this close as stale, not "current".`
+    : undefined
+
+  const base = {
+    symbol: meta.symbol,
+    barId: meta.barId,
+    source: meta.source,
+    barCapability: meta.barCapability,
+    interval,
+    asOf,
+    isLatestActual,
+    staleTradingDays,
+    ...(warning ? { freshnessWarning: warning } : {}),
+  }
+
+  if (bars.length === 0) {
+    return { ...base, latest: null, levels: null, bars: [] }
+  }
+
+  const closes = bars.map((b) => b.close)
+  const last = bars[bars.length - 1]
+  const prevClose = bars.length >= 2 ? bars[bars.length - 2].close : null
+  const periodHigh = Math.max(...bars.map((b) => b.high))
+  const periodLow = Math.min(...bars.map((b) => b.low))
+
+  return {
+    ...base,
+    latest: {
+      date: last.date,
+      close: r(last.close)!,
+      prevClose: r(prevClose),
+      changePct: r(prevClose != null ? ((last.close - prevClose) / prevClose) * 100 : null, 2),
+      dayHigh: r(last.high)!,
+      dayLow: r(last.low)!,
+      dayAmplitudePct: r(prevClose != null ? ((last.high - last.low) / prevClose) * 100 : null, 2),
+    },
+    levels: {
+      sma20: r(closes.length >= 20 ? safe(() => SMA(closes, 20)) : null),
+      sma50: r(closes.length >= 50 ? safe(() => SMA(closes, 50)) : null),
+      rsi14: r(closes.length >= 15 ? safe(() => RSI(closes, 14)) : null, 2),
+      periodHigh: r(periodHigh)!,
+      periodLow: r(periodLow)!,
+      distFromHighPct: r(((last.close - periodHigh) / periodHigh) * 100, 2)!,
+      distFromLowPct: r(((last.close - periodLow) / periodLow) * 100, 2)!,
+    },
+    bars: bars.map((b) => ({
+      date: b.date, open: b.open, high: b.high, low: b.low, close: b.close, volume: b.volume,
+    })),
+  }
+}

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -150,6 +150,23 @@ describe('getBars — UTA branch', () => {
     expect(getHistorical).toHaveBeenCalledWith({ aliceId: 'alpaca-paper|AAPL' }, expect.objectContaining({ interval: '1d' }))
   })
 
+  it('renders a daily broker bar date-only even when stamped at the session open (no 05:00 / DST noise)', async () => {
+    // Alpaca stamps a daily bar at the premarket open (04:00/05:00 ET in UTC),
+    // which also flips an hour across DST — render the calendar day, not an instant.
+    const dailyWire = [
+      { timestamp: '2026-02-17T05:00:00.000Z', open: '1', high: '2', low: '0.5', close: '1.5', volume: '100' },
+      { timestamp: '2026-06-25T04:00:00.000Z', open: '2', high: '3', low: '1', close: '2.5', volume: '200' },
+    ] as unknown as Bar[]
+    const utaManager: UtaBarGateway = {
+      has: async (id) => id === 'alpaca-paper',
+      get: async () => ({ getHistorical: async () => dailyWire }),
+      searchContracts: async () => [],
+    }
+    const svc = createBarService(makeDeps({ utaManager }))
+    const { bars } = await svc.getBars({ barId: 'alpaca-paper|AAPL' }, { interval: '1d' })
+    expect(bars.map((b) => b.date)).toEqual(['2026-02-17', '2026-06-25']) // date-only, no time, no DST flip
+  })
+
   it('count-only request becomes a START WINDOW, not a broker `limit` (alpaca count-anchoring bug)', async () => {
     // A count-only request must reach the broker as a start-bounded window — NOT
     // as `limit: count` with no start. Alpaca's getBarsV2 anchors `limit` to a

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -83,6 +83,16 @@ describe('getBars — vendor branch', () => {
     expect(bars.map((b) => b.date)).toEqual(['2024-01-02', '2024-01-03'])
   })
 
+  it('freshness contract: marks data stale when it does not reach the asOf anchor', async () => {
+    const svc = createBarService(makeDeps())
+    // RAW ends 2024-01-03. Anchor AT the last bar → current.
+    const cur = await svc.getBars({ symbol: 'AAPL', assetClass: 'equity' }, { interval: '1d', end: '2024-01-03' })
+    expect(cur.meta).toMatchObject({ asOf: '2024-01-03', isLatestActual: true, staleTradingDays: 0 })
+    // Anchor a week later (3 trading days past the last bar) → stale + LOUD.
+    const stale = await svc.getBars({ symbol: 'AAPL', assetClass: 'equity' }, { interval: '1d', end: '2024-01-08' })
+    expect(stale.meta).toMatchObject({ asOf: '2024-01-08', isLatestActual: false, staleTradingDays: 3 })
+  })
+
   it('caps at MAX_BARS', async () => {
     const big = Array.from({ length: 6000 }, (_, i) => ({
       date: `2000-01-01T${String(i).padStart(5, '0')}`, open: 1, high: 1, low: 1, close: 1, volume: 1,

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -103,17 +103,22 @@ function isFullBar(d: Record<string, unknown>): boolean {
   return d.close != null && d.open != null && d.high != null && d.low != null
 }
 
-function dateOf(bar: Bar): string {
+function dateOf(bar: Bar, interval?: string): string {
   // Bar.timestamp is typed Date, but it crosses the Alice↔UTA HTTP wire as an
   // ISO string (JSON has no Date) — normalize either form before formatting.
   const iso = new Date(bar.timestamp).toISOString()
-  // Daily/weekly bars land at UTC midnight → keep date-only; intraday keeps time.
-  return iso.endsWith('T00:00:00.000Z') ? iso.slice(0, 10) : iso.slice(0, 19).replace('T', ' ')
+  // A daily/weekly bar is a calendar day, not an instant — render date-only even
+  // when a broker stamps it at the session open (e.g. Alpaca's 04:00/05:00 ET,
+  // which also flips an hour across DST and looks like a bug). Intraday keeps
+  // its time; a UTC-midnight stamp is date-only regardless.
+  const daily = interval === '1d' || interval === '1w'
+  if (daily || iso.endsWith('T00:00:00.000Z')) return iso.slice(0, 10)
+  return iso.slice(0, 19).replace('T', ' ')
 }
 
-function barToOhlcv(bar: Bar): OhlcvBar {
+function barToOhlcv(bar: Bar, interval?: string): OhlcvBar {
   return {
-    date: dateOf(bar),
+    date: dateOf(bar, interval),
     open: Number(bar.open),
     high: Number(bar.high),
     low: Number(bar.low),
@@ -238,7 +243,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
       end: (opts.end ?? opts.asOf) ? new Date((opts.end ?? opts.asOf)!) : undefined,
     }
     const wireBars = await acct.getHistorical({ aliceId: barId }, params)
-    const bars = finalize(wireBars.map(barToOhlcv), opts.count)
+    const bars = finalize(wireBars.map((b) => barToOhlcv(b, params.interval)), opts.count)
     const symbol = parseBarId(barId)?.nativeSymbol ?? barId
     return {
       bars,

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -132,6 +132,36 @@ function buildMeta(symbol: string, bars: OhlcvBar[], extra: Partial<BarMeta>): B
   }
 }
 
+/** Trading-day gap between two YYYY-MM-DD dates (Mon–Fri; holidays ignored, so
+ *  a holiday inflates the gap by ≤1 — acceptable for a staleness signal). */
+function tradingDaysBetween(fromISO: string, toISO: string): number {
+  const a = new Date(`${fromISO}T00:00:00Z`)
+  const b = new Date(`${toISO}T00:00:00Z`)
+  if (!(b.getTime() > a.getTime())) return 0
+  let days = 0
+  const d = new Date(a)
+  while (d.getTime() < b.getTime()) {
+    d.setUTCDate(d.getUTCDate() + 1)
+    const wd = d.getUTCDay()
+    if (wd !== 0 && wd !== 6) days++
+  }
+  return days
+}
+
+/** Freshness contract — did the data actually reach the requested point-in-time?
+ *  Anchor = explicit end/asOf, else today. The point is to make a delayed source
+ *  that silently stopped a day behind "now" LOUD, not to mask it as current. */
+function computeFreshness(
+  lastBarDate: string,
+  opts: GetBarsOpts,
+  now: () => Date,
+): Pick<BarMeta, 'asOf' | 'isLatestActual' | 'staleTradingDays'> {
+  if (!lastBarDate) return {}
+  const anchor = (opts.end ?? opts.asOf ?? now().toISOString().slice(0, 10)).slice(0, 10)
+  const gap = tradingDaysBetween(lastBarDate.slice(0, 10), anchor)
+  return { asOf: anchor, isLatestActual: gap === 0, staleTradingDays: gap }
+}
+
 /** Sort ascending, cap to MAX_BARS (keep most-recent), then truncate to `count`. */
 function finalize(data: OhlcvBar[], count?: number): OhlcvBar[] {
   data.sort((a, b) => a.date.localeCompare(b.date))
@@ -183,6 +213,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
         barId: formatBarId(provider, symbol),
         provider,
         barCapability: VENDOR_CAPABILITY[provider],
+        ...computeFreshness(filtered[filtered.length - 1]?.date ?? '', opts, () => new Date()),
       }),
     }
   }
@@ -216,6 +247,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
         sourceId,
         barId,
         barCapability: 'realtime',
+        ...computeFreshness(bars[bars.length - 1]?.date ?? '', opts, () => new Date()),
       }),
     }
   }

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -71,6 +71,17 @@ export interface BarMeta {
   barId?: string
   provider?: string
   barCapability?: BarCapability
+  // ---- freshness contract ----
+  // The point-in-time the request was anchored to (opts.end ?? asOf ?? today),
+  // and whether the data actually REACHES it. A delayed vendor silently
+  // stopping a day behind "now" is the failure mode this makes loud: never let
+  // a stale `to` masquerade as the current price.
+  /** Effective anchor of the request (YYYY-MM-DD): explicit end/asOf, else today. */
+  asOf?: string
+  /** True when the last bar reaches `asOf` (no trading-day gap); false = stale. */
+  isLatestActual?: boolean
+  /** Trading-day gap between the last bar and `asOf` (0 when current). */
+  staleTradingDays?: number
 }
 
 export interface BarSourceCandidate {

--- a/src/domain/news/query/archive.spec.ts
+++ b/src/domain/news/query/archive.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { globRss, grepRss, readRss, type NewsToolContext } from './archive'
+import { globRss, grepRss, readRss, windowRss, type NewsToolContext } from './archive'
 import type { NewsItem } from '../types'
 
 describe('news tools (pure functions)', () => {
@@ -289,6 +289,27 @@ describe('news tools (pure functions)', () => {
       })
 
       expect(results).toHaveLength(1)
+    })
+  })
+
+  describe('result dates + windowRss', () => {
+    it('glob/grep results carry an ISO publish time (timeline without re-reading)', async () => {
+      const g = await globRss(createContext(), { pattern: 'BTC' })
+      expect(g[0].time).toBe('2025-01-01T08:00:00.000Z')
+      const gr = await grepRss(createContext(), { pattern: 'Ethereum' })
+      expect(gr[0].time).toBe('2025-01-01T10:00:00.000Z')
+    })
+
+    it('windowRss returns OLDEST-first for timeline alignment', async () => {
+      const out = await windowRss(createContext(), {})
+      expect(out.map((r) => r.id)).toEqual([10, 20, 30, 40]) // ascending by time
+      expect(out[0].time).toBe('2025-01-01T08:00:00.000Z')
+    })
+
+    it('windowRss with a pattern filters + attaches matched text', async () => {
+      const out = await windowRss(createContext(), { pattern: 'Bitcoin' })
+      expect(out.map((r) => r.id)).toEqual([10, 30]) // both mention Bitcoin, oldest-first
+      expect(out[0].matchedText).toMatch(/Bitcoin/)
     })
   })
 })

--- a/src/domain/news/query/archive.ts
+++ b/src/domain/news/query/archive.ts
@@ -10,6 +10,10 @@ import { z } from 'zod'
 import type { INewsProvider, NewsItem } from '../types.js'
 
 const NEWS_LIMIT = 500
+/** Default cap on windowRss OUTPUT — a wide date window can match hundreds; we
+ *  bound what's returned and report how many were omitted, rather than wall the
+ *  caller's context. */
+const WINDOW_DEFAULT_LIMIT = 40
 
 // ==================== Pure functions (testable) ====================
 
@@ -260,7 +264,7 @@ Example: windowRss({ from: "2026-06-20", to: "2026-06-26", pattern: "Iran|oil" }
         pattern: z.string().optional().describe('Optional regex over title+content. Omit for everything in the window.'),
         contextChars: z.number().int().positive().optional().describe('Context chars around a pattern match (default 50).'),
         metadataFilter: z.record(z.string(), z.string()).optional().describe('Filter by metadata key-value (e.g. source).'),
-        limit: z.number().int().positive().optional().describe('Max results (default: all in window).'),
+        limit: z.number().int().positive().optional().describe(`Max results returned (default ${WINDOW_DEFAULT_LIMIT}). A wide window can match hundreds; raise this, or narrow the pattern/window. The result reports total + how many were omitted.`),
       }).meta({ examples: [{ from: '2026-06-20', to: '2026-06-26', pattern: 'Iran|oil' }] }),
       execute: async ({ from, to, pattern, contextChars, metadataFilter, limit }) => {
         const startTime = new Date(from)
@@ -268,10 +272,23 @@ Example: windowRss({ from: "2026-06-20", to: "2026-06-26", pattern: "Iran|oil" }
         if (Number.isNaN(startTime.getTime()) || Number.isNaN(endTime.getTime())) {
           return { error: 'from/to must be YYYY-MM-DD or ISO dates.' }
         }
-        return windowRss(
+        // Fetch ALL matches in the window, then bound the OUTPUT (a wide window can
+        // be a wall of hundreds) — and say how many we left out, oldest-first.
+        const all = await windowRss(
           { getNews: () => provider.getNewsV2({ startTime, endTime, limit: 5000 }) },
-          { pattern, contextChars, metadataFilter, limit },
+          { pattern, contextChars, metadataFilter },
         )
+        const cap = limit ?? WINDOW_DEFAULT_LIMIT
+        const results = all.slice(0, cap)
+        const omitted = all.length - results.length
+        return {
+          from: startTime.toISOString(),
+          to: endTime.toISOString(),
+          total: all.length,
+          shown: results.length,
+          ...(omitted > 0 ? { omitted, note: `${omitted} more match(es) in this window are not shown (oldest-first; showing the earliest ${results.length}). Narrow the pattern/window, or raise limit.` } : {}),
+          results,
+        }
       },
     }),
 

--- a/src/domain/news/query/archive.ts
+++ b/src/domain/news/query/archive.ts
@@ -20,6 +20,8 @@ export interface NewsToolContext {
 
 export interface GlobRssResult {
   id: number
+  /** Publish time (ISO) — so matches can be put on a timeline without reading each. */
+  time: string
   title: string
   contentLength: number
   metadata: string
@@ -27,9 +29,20 @@ export interface GlobRssResult {
 
 export interface GrepRssResult {
   id: number
+  /** Publish time (ISO) — so matches can be put on a timeline without reading each. */
+  time: string
   title: string
   matchedText: string
   contentLength: number
+  metadata: string
+}
+
+export interface WindowRssResult {
+  id: number
+  time: string
+  title: string
+  /** Present only when a pattern was given (the matched snippet). */
+  matchedText?: string
   metadata: string
 }
 
@@ -65,6 +78,7 @@ export async function globRss(
 
     results.push({
       id: item.id,
+      time: new Date(item.time).toISOString(),
       title: item.title,
       contentLength: item.content.length,
       metadata: truncateMetadata(item.metadata),
@@ -110,6 +124,7 @@ export async function grepRss(
 
     results.push({
       id: item.id,
+      time: new Date(item.time).toISOString(),
       title: item.title,
       matchedText,
       contentLength: item.content.length,
@@ -122,6 +137,41 @@ export async function grepRss(
   }
 
   return results
+}
+
+/** Articles within a time window (event study) — optionally pattern-filtered,
+ *  returned OLDEST-first so they line up against a price path. The window itself
+ *  is set by the caller's `getNews` (provider start/endTime). */
+export async function windowRss(
+  context: NewsToolContext,
+  options: { pattern?: string; metadataFilter?: Record<string, string>; contextChars?: number; limit?: number },
+): Promise<WindowRssResult[]> {
+  const news = await context.getNews()
+  const regex = options.pattern ? new RegExp(options.pattern, 'i') : null
+  const contextChars = options.contextChars ?? 50
+  const out: WindowRssResult[] = []
+
+  for (const item of news) {
+    if (options.metadataFilter && !matchesMetadataFilter(item.metadata, options.metadataFilter)) continue
+    let matchedText: string | undefined
+    if (regex) {
+      const searchText = `${item.title}\n${item.content}`
+      const m = regex.exec(searchText)
+      if (!m) continue
+      const s = Math.max(0, m.index - contextChars)
+      const e = Math.min(searchText.length, m.index + m[0].length + contextChars)
+      matchedText = `${s > 0 ? '...' : ''}${searchText.slice(s, e)}${e < searchText.length ? '...' : ''}`
+    }
+    out.push({
+      id: item.id,
+      time: new Date(item.time).toISOString(),
+      title: item.title,
+      ...(matchedText ? { matchedText } : {}),
+      metadata: truncateMetadata(item.metadata),
+    })
+  }
+  out.sort((a, b) => a.time.localeCompare(b.time)) // oldest-first for timeline alignment
+  return options.limit ? out.slice(0, options.limit) : out
 }
 
 /** Read full news content by stable id (like "cat") */
@@ -191,6 +241,35 @@ Example: grepRss({ pattern: "interest rate", lookback: "2d" })`,
       execute: async ({ pattern, lookback, contextChars, metadataFilter, limit }) => {
         return grepRss(
           { getNews: () => provider.getNewsV2({ endTime: new Date(), lookback, limit: NEWS_LIMIT }) },
+          { pattern, contextChars, metadataFilter, limit },
+        )
+      },
+    }),
+
+    windowRss: tool({
+      description: `Articles within a DATE WINDOW (event study), oldest-first — for aligning news against a price path ("what hit between the gap-up and the fade").
+
+Returns id + ISO time + title (+ matched snippet when a pattern is given), sorted oldest→newest so the timeline lines up with bars. Pair with marketSnapshot/simulate to attribute a move to a catalyst.
+
+Coverage is the user's SUBSCRIBED RSS feeds only (not the news at large) — an empty window means "nothing in the subscribed feeds for that span", not "nothing happened". Pass a \`pattern\` to filter, or omit it to get everything in the window.
+
+Example: windowRss({ from: "2026-06-20", to: "2026-06-26", pattern: "Iran|oil" })`,
+      inputSchema: z.object({
+        from: z.string().describe('Window start (YYYY-MM-DD or ISO).'),
+        to: z.string().optional().describe('Window end (YYYY-MM-DD or ISO). Default: now.'),
+        pattern: z.string().optional().describe('Optional regex over title+content. Omit for everything in the window.'),
+        contextChars: z.number().int().positive().optional().describe('Context chars around a pattern match (default 50).'),
+        metadataFilter: z.record(z.string(), z.string()).optional().describe('Filter by metadata key-value (e.g. source).'),
+        limit: z.number().int().positive().optional().describe('Max results (default: all in window).'),
+      }).meta({ examples: [{ from: '2026-06-20', to: '2026-06-26', pattern: 'Iran|oil' }] }),
+      execute: async ({ from, to, pattern, contextChars, metadataFilter, limit }) => {
+        const startTime = new Date(from)
+        const endTime = to ? new Date(to) : new Date()
+        if (Number.isNaN(startTime.getTime()) || Number.isNaN(endTime.getTime())) {
+          return { error: 'from/to must be YYYY-MM-DD or ISO dates.' }
+        }
+        return windowRss(
+          { getNews: () => provider.getNewsV2({ startTime, endTime, limit: 5000 }) },
           { pattern, contextChars, metadataFilter, limit },
         )
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,8 @@ import type { EquityClientLike, CryptoClientLike, CurrencyClientLike, EtfClientL
 import { buildSDKCredentials } from './domain/market-data/credential-map.js'
 import { createMarketSearchTools } from './tool/market.js'
 import { createQuantTools } from './tool/quant.js'
+import { createSnapshotTools } from './tool/snapshot.js'
+import { createSimulateTools } from './tool/simulate.js'
 import { createBarService } from './domain/market-data/bars/index.js'
 import { createReferenceData } from './domain/market-data/reference/service.js'
 import { createSectorRotationTools } from './tool/sector-rotation.js'
@@ -219,6 +221,8 @@ async function main() {
   // — calculateQuant (v2, barId-keyed) supersedes it and the two descriptions
   // confused the model / bloated context. The code remains for now.
   toolCenter.register(createQuantTools({ barService }), 'quant')
+  toolCenter.register(createSnapshotTools(barService), 'snapshot')
+  toolCenter.register(createSimulateTools(barService), 'simulate')
   toolCenter.register(createSectorRotationTools(equityClient, config.marketData.hub), 'sector-rotation')
   if (derivativesClient) {
     toolCenter.register(createDerivativesTools(derivativesClient), 'derivatives')

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -12,6 +12,8 @@ import { createMarketSearchTools } from '../tool/market.js'
 import { createEquityTools } from '../tool/equity.js'
 import { createEconomyTools } from '../tool/economy.js'
 import { createQuantTools } from '../tool/quant.js'
+import { createSnapshotTools } from '../tool/snapshot.js'
+import { createSimulateTools } from '../tool/simulate.js'
 import { createThinkingTools } from '../tool/thinking.js'
 import { inboxPushFactory } from '../tool/inbox-push.js'
 import { inboxReadFactory } from '../tool/inbox-read.js'
@@ -35,6 +37,8 @@ describe('CLI_EXPORTS — data export (global tools)', () => {
   tc.register(createEquityTools(any), 'equity')
   tc.register(createNewsArchiveTools(any), 'rss')
   tc.register(createQuantTools(any), 'quant')
+  tc.register(createSnapshotTools(any), 'snapshot')
+  tc.register(createSimulateTools(any), 'simulate')
   tc.register(createEconomyTools(any, any), 'economy')
 
   it('every mapped verb resolves to a registered global tool', () => {

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -55,6 +55,8 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       rss: {
         glob: 'globRss',
         grep: 'grepRss',
+        // window: date-bounded, oldest-first — for aligning catalysts to a price path.
+        window: 'windowRss',
         read: 'readRss',
       },
       market: {
@@ -63,6 +65,10 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       analysis: {
         'search-bars': 'searchBars',
         quant: 'calculateQuant',
+        // Honest as-of read (dated bars, no-lookahead, freshness contract) + a
+        // path-dependent backtest. The Retrospective / Time-Machine primitives.
+        snapshot: 'marketSnapshot',
+        simulate: 'simulate',
       },
       think: {
         calc: 'calculate',

--- a/src/tool/quant.ts
+++ b/src/tool/quant.ts
@@ -95,9 +95,10 @@ switch source, or fix the barId), and tell the user if data is simply unavailabl
       inputSchema: z.object({
         script: z.string().describe('The quant script (let-bindings + a final result expression).'),
         precision: z.number().int().min(0).max(10).optional().describe('Decimal places (default 4).'),
+        dates: z.stringbool().optional().describe('Opt-in: also return each source\'s date axis (dates[barId] = ["YYYY-MM-DD", …]) so a dumped series can be mapped to dates. Off by default. For a full dated snapshot, prefer marketSnapshot.'),
       }).meta({ examples: [{ script: 's = bars("yfinance|AAPL", "1d", count=250, asset="equity")\nsma(s.close, 50)' }] }),
-      execute: async ({ script, precision }) => {
-        return runScript(script, deps, precision ?? 4)
+      execute: async ({ script, precision, dates }) => {
+        return runScript(script, deps, precision ?? 4, { withDates: dates ?? false })
       },
     }),
   }

--- a/src/tool/simulate.ts
+++ b/src/tool/simulate.ts
@@ -1,0 +1,69 @@
+/**
+ * Simulate / backtest — MCP tool.
+ *
+ * Wraps `simulate` (domain/analysis): enter at a date, apply one built-in exit
+ * rule, walk dated bars to asOf (no lookahead), report the round-trip. Same
+ * freshest-source resolution as marketSnapshot — a bare symbol auto-picks a
+ * realtime broker over a delayed vendor.
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { BarService } from '@/domain/market-data/bars/index'
+import { simulate, type ExitRule } from '@/domain/analysis/simulate'
+import { resolveBarSource } from './source-resolve.js'
+
+export function createSimulateTools(barService: BarService) {
+  return {
+    simulate: tool({
+      description: `Backtest ONE entry + ONE exit rule over dated bars (no lookahead past asOf). Answers "if I'd bought X on date D, would <exit rule> have saved me?" — the reusable version of hand-rolling an equity path in Python.
+
+Exit rules (pass exitRule + its param):
+  - trailing_stop  exitPct=N   → exit when close falls N% from the running peak
+  - ma_break       exitPeriod=N → exit on the first close below its N-bar SMA
+  - stop           exitPct=N   → exit when close falls N% below entry
+  - target         exitPct=N   → exit when close rises N% above entry
+  - hold                        → never exit; measure entry → asOf
+
+Returns entry/exit (date·price·reason), returnPct, MFE/MAE (max favorable/adverse excursion %), peak/trough, and a sampled path. open=true means no exit triggered by asOf (return is mark-to-market). Source: a barId pins one; a bare symbol/query auto-picks the freshest (realtime broker > delayed vendor).`,
+      inputSchema: z.object({
+        query: z.string().optional().describe('Symbol/keyword — auto-picks the freshest source. Omit if barId given.'),
+        barId: z.string().optional().describe('Pin a source, e.g. "alpaca-paper|XLE". Wins over query.'),
+        asset: z.enum(['equity', 'crypto', 'currency', 'commodity']).optional().describe('Needed only for a VENDOR barId/symbol.'),
+        entryDate: z.string().describe('Enter at the close of the first bar on/after this date (YYYY-MM-DD).'),
+        exitRule: z.enum(['trailing_stop', 'ma_break', 'stop', 'target', 'hold']).describe('Which built-in exit.'),
+        exitPct: z.number().positive().optional().describe('Percent for trailing_stop / stop / target.'),
+        exitPeriod: z.number().int().positive().optional().describe('SMA period for ma_break.'),
+        interval: z.string().optional().describe('Bar interval (default "1d").'),
+        asOf: z.string().optional().describe('Evaluate up to here (YYYY-MM-DD). Default: now.'),
+      }).meta({ examples: [{ query: 'XLE', entryDate: '2026-04-01', exitRule: 'trailing_stop', exitPct: 8 }] }),
+      execute: async ({ query, barId, asset, entryDate, exitRule, exitPct, exitPeriod, interval, asOf }) => {
+        // Build the exit rule from flat params, validating the required param.
+        let exit: ExitRule
+        switch (exitRule) {
+          case 'trailing_stop': case 'stop': case 'target':
+            if (exitPct == null) return { error: `exitRule "${exitRule}" needs exitPct (a percent).` }
+            exit = { type: exitRule, pct: exitPct }
+            break
+          case 'ma_break':
+            if (exitPeriod == null) return { error: 'exitRule "ma_break" needs exitPeriod (the SMA length).' }
+            exit = { type: 'ma_break', period: exitPeriod }
+            break
+          case 'hold':
+            exit = { type: 'hold' }
+            break
+        }
+
+        const resolved = await resolveBarSource(barService, { query, barId, asset })
+        if ('error' in resolved) return resolved
+
+        return simulate(barService, resolved.ref as never, {
+          entryDate,
+          exit,
+          ...(interval ? { interval } : {}),
+          ...(asOf ? { asOf } : {}),
+        })
+      },
+    }),
+  }
+}

--- a/src/tool/snapshot.ts
+++ b/src/tool/snapshot.ts
@@ -35,15 +35,17 @@ FRESHNESS IS LOAD-BEARING. The result carries asOf / isLatestActual / staleTradi
         asset: z.enum(['equity', 'crypto', 'currency', 'commodity']).optional().describe('Asset class — needed only for a VENDOR barId/symbol; broker barIds infer it.'),
         asOf: z.string().optional().describe('Point-in-time YYYY-MM-DD. Bars never run past it (no lookahead). Default: now.'),
         interval: z.string().optional().describe('Bar interval (default "1d").'),
-        count: z.number().int().positive().optional().describe('Bars of dated context (default 90).'),
-      }).meta({ examples: [{ query: 'XLE' }, { query: 'NVDA', asOf: '2026-04-15' }] }),
-      execute: async ({ query, barId, asset, asOf, interval, count }) => {
+        count: z.number().int().positive().optional().describe('Analysis window fetched for the levels (default 90; sma50 needs ≥50). NOT the output size.'),
+        bars: z.number().int().nonnegative().optional().describe('How many recent dated bars to RETURN in `bars` (default 0 = summary only — latest + levels + freshness). Set e.g. 30/90 when you need the dated path (it can be large). `windowBars` tells how many are available.'),
+      }).meta({ examples: [{ query: 'XLE' }, { query: 'NVDA', asOf: '2026-04-15', bars: 30 }] }),
+      execute: async ({ query, barId, asset, asOf, interval, count, bars }) => {
         const resolved = await resolveBarSource(barService, { query, barId, asset })
         if ('error' in resolved) return resolved
         const snap = await getSnapshot(barService, resolved.ref as never, {
           ...(asOf ? { asOf } : {}),
           ...(interval ? { interval } : {}),
           ...(count ? { count } : {}),
+          ...(bars != null ? { barsOut: bars } : {}),
         })
         return resolved.pickedFrom ? { ...snap, autoPickedSource: resolved.pickedFrom } : snap
       },

--- a/src/tool/snapshot.ts
+++ b/src/tool/snapshot.ts
@@ -1,0 +1,52 @@
+/**
+ * Market Snapshot — MCP tool.
+ *
+ * The honest as-of read for "what did/does it look like at time T". Wraps
+ * `getSnapshot` (domain/analysis) over the federated bar service, and — given a
+ * bare symbol instead of a barId — resolves to the FRESHEST source (realtime
+ * broker before delayed vendor), so the analyst's natural reach lands on the
+ * live price, not a delayed vendor that silently stopped a day behind. That
+ * source mis-wiring (analysis CLI defaults to delayed; realtime hid in the
+ * trading CLI) is the gap this closes.
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { BarService } from '@/domain/market-data/bars/index'
+import { getSnapshot } from '@/domain/analysis/snapshot'
+import { resolveBarSource } from './source-resolve.js'
+
+export function createSnapshotTools(barService: BarService) {
+  return {
+    marketSnapshot: tool({
+      description: `Honest as-of snapshot of a symbol: DATED bars (no lookahead past asOf), the most-recent ACTUAL print (close + vs-prevClose + day high/low + amplitude), a compact technical state (sma20/50, rsi14, distance from period high/low), AND a loud freshness contract.
+
+Use this — not calculateQuant — whenever the question is "what does/did X look like" or "rewind X to a date":
+  - "how's XLE right now" → marketSnapshot --query XLE
+  - "what did NVDA look like on 2026-04-15" → marketSnapshot --query NVDA --asOf 2026-04-15
+Why it beats hand-rolling from quant: quant returns latest scalars with NO dates and CANNOT emit a dated series; snapshot returns the dated path AND guarantees no-lookahead at asOf.
+
+Source: pass a barId (from searchBars) to pin one, OR a bare symbol/query — then it auto-picks the FRESHEST source (realtime broker > delayed vendor). For a vendor symbol you may need asset=.
+
+FRESHNESS IS LOAD-BEARING. The result carries asOf / isLatestActual / staleTradingDays, and a freshnessWarning when the data does not reach the anchor. If isLatestActual is false, the "latest" close is STALE — do not report it as the current price (this is the exact trap that turns an overnight catalyst into a missed/【misread】move). Prefer a realtime broker source for anything time-sensitive.`,
+      inputSchema: z.object({
+        query: z.string().optional().describe('Symbol or keyword (e.g. "XLE", "NVDA"). Auto-picks the freshest source. Omit if barId is given.'),
+        barId: z.string().optional().describe('Pin a specific source, e.g. "alpaca-paper|XLE". Takes precedence over query.'),
+        asset: z.enum(['equity', 'crypto', 'currency', 'commodity']).optional().describe('Asset class — needed only for a VENDOR barId/symbol; broker barIds infer it.'),
+        asOf: z.string().optional().describe('Point-in-time YYYY-MM-DD. Bars never run past it (no lookahead). Default: now.'),
+        interval: z.string().optional().describe('Bar interval (default "1d").'),
+        count: z.number().int().positive().optional().describe('Bars of dated context (default 90).'),
+      }).meta({ examples: [{ query: 'XLE' }, { query: 'NVDA', asOf: '2026-04-15' }] }),
+      execute: async ({ query, barId, asset, asOf, interval, count }) => {
+        const resolved = await resolveBarSource(barService, { query, barId, asset })
+        if ('error' in resolved) return resolved
+        const snap = await getSnapshot(barService, resolved.ref as never, {
+          ...(asOf ? { asOf } : {}),
+          ...(interval ? { interval } : {}),
+          ...(count ? { count } : {}),
+        })
+        return resolved.pickedFrom ? { ...snap, autoPickedSource: resolved.pickedFrom } : snap
+      },
+    }),
+  }
+}

--- a/src/tool/source-resolve.spec.ts
+++ b/src/tool/source-resolve.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { resolveBarSource } from './source-resolve.js'
+import type { BarService } from '@/domain/market-data/bars/index'
+
+function svcWith(candidates: Array<{ barId: string; barCapability?: string; assetClass?: string }>): BarService {
+  return {
+    searchBarSources: async () => candidates,
+    getBars: async () => ({ bars: [], meta: {} }),
+  } as unknown as BarService
+}
+
+describe('resolveBarSource', () => {
+  it('a pinned barId wins, no search', async () => {
+    const r = await resolveBarSource(svcWith([]), { barId: 'alpaca|XLE' })
+    expect(r).toEqual({ ref: { barId: 'alpaca|XLE' } })
+  })
+
+  it('auto-pick prefers a non-derivative over a same-freshness perp (perp = backup)', async () => {
+    // search returns the crypto perp FIRST (as the live UTA search does), but the
+    // equity should still win — a perp tracking a ticker is a backup, not the default.
+    const svc = svcWith([
+      { barId: 'binance|XLE/USDT:USDT', barCapability: 'realtime', assetClass: 'crypto' },
+      { barId: 'okx|XLE/USDT:USDT', barCapability: 'realtime', assetClass: 'crypto' },
+      { barId: 'alpaca|XLE', barCapability: 'realtime', assetClass: 'equity' },
+    ])
+    const r = await resolveBarSource(svc, { query: 'XLE' })
+    expect('error' in r).toBe(false)
+    if ('error' in r) return
+    expect(r.ref).toMatchObject({ barId: 'alpaca|XLE', assetClass: 'equity' })
+  })
+
+  it('still prefers a fresher source over freshness ties', async () => {
+    const svc = svcWith([
+      { barId: 'yfinance|AAPL', barCapability: 'delayed', assetClass: 'equity' },
+      { barId: 'alpaca|AAPL', barCapability: 'realtime', assetClass: 'equity' },
+    ])
+    const r = await resolveBarSource(svc, { query: 'AAPL' })
+    if ('error' in r) throw new Error(r.error)
+    expect(r.ref).toMatchObject({ barId: 'alpaca|AAPL' })
+  })
+
+  it('a crypto query still resolves to the crypto source', async () => {
+    const svc = svcWith([{ barId: 'binance|BTC/USDT', barCapability: 'realtime', assetClass: 'crypto' }])
+    const r = await resolveBarSource(svc, { query: 'BTC' })
+    if ('error' in r) throw new Error(r.error)
+    expect(r.ref).toMatchObject({ barId: 'binance|BTC/USDT', assetClass: 'crypto' })
+  })
+
+  it('errors with neither query nor barId, and on no candidates', async () => {
+    expect('error' in (await resolveBarSource(svcWith([]), {}))).toBe(true)
+    expect('error' in (await resolveBarSource(svcWith([]), { query: 'NOPE' }))).toBe(true)
+  })
+})

--- a/src/tool/source-resolve.ts
+++ b/src/tool/source-resolve.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared bar-source resolution for the snapshot / simulate tools.
+ *
+ * A pinned barId always wins. For a bare symbol we auto-pick the BEST single
+ * source: freshest first (realtime broker > delayed vendor), and within the
+ * freshest tier a NON-derivative beats a derivative — so a plain equity/spot
+ * ("alpaca|XLE") is preferred over a perp tracking the same ticker
+ * ("binance|XLE/USDT:USDT"). Crypto perps stay valid candidates (and a fine
+ * backup), they're just not the default pick for a bare ticker.
+ */
+
+import type { BarService, BarCapability } from '@/domain/market-data/bars/index'
+import { parseBarId } from '@/domain/market-data/bars/index'
+import type { AssetClass } from '@/domain/market-data/aggregate-search'
+
+const FRESHNESS_RANK: Record<BarCapability, number> = {
+  realtime: 0, iex: 1, subscription: 2, delayed: 3, free: 4,
+}
+
+type AssetArg = 'equity' | 'crypto' | 'currency' | 'commodity'
+export type ResolvedRef =
+  | { barId: string; assetClass?: AssetArg }
+  | { symbol: string; assetClass: AssetArg }
+
+export interface ResolveResult {
+  ref: ResolvedRef
+  /** Human note on what was auto-picked (undefined when a barId was pinned). */
+  pickedFrom?: string
+}
+
+/** A perp/swap/dated derivative carries a quote-currency or expiry segment in
+ *  its native symbol (`XLE/USDT:USDT`, `BTC/USD:USD-310613`). A plain ticker
+ *  ("XLE") or spot pair without the `:` does not. */
+function isDerivative(barId: string): boolean {
+  return (parseBarId(barId)?.nativeSymbol ?? '').includes(':')
+}
+
+export async function resolveBarSource(
+  barService: BarService,
+  input: { query?: string; barId?: string; asset?: AssetArg },
+): Promise<ResolveResult | { error: string }> {
+  if (input.barId) {
+    return { ref: { barId: input.barId, ...(input.asset ? { assetClass: input.asset } : {}) } }
+  }
+  if (!input.query) return { error: 'Pass either query (a symbol) or barId.' }
+
+  const candidates = await barService.searchBarSources(input.query, { limit: 12 })
+  if (candidates.length === 0) {
+    return { error: `No bar source found for "${input.query}". Try searchBars to see candidates, or pass a barId.` }
+  }
+  const best = [...candidates].sort((a, b) => {
+    const fa = a.barCapability ? FRESHNESS_RANK[a.barCapability] : 5
+    const fb = b.barCapability ? FRESHNESS_RANK[b.barCapability] : 5
+    if (fa !== fb) return fa - fb
+    return Number(isDerivative(a.barId)) - Number(isDerivative(b.barId))
+  })[0]
+
+  const assetClass = best.assetClass !== 'unknown' ? (best.assetClass as AssetClass) : undefined
+  return {
+    ref: { barId: best.barId, ...(assetClass ? { assetClass: assetClass as AssetArg } : {}) },
+    pickedFrom: `${best.barId} (${best.barCapability ?? 'unknown'})`,
+  }
+}

--- a/src/workspaces/templates/chat/template.json
+++ b/src/workspaces/templates/chat/template.json
@@ -5,5 +5,5 @@
   "defaultAgents": ["claude", "codex"],
   "injectTools": true,
   "injectPersona": true,
-  "bundledSkills": ["scan-value-chain", "build-thesis", "sector-rotation", "opencli-reader"]
+  "bundledSkills": ["scan-value-chain", "build-thesis", "sector-rotation", "retrospective", "opencli-reader"]
 }


### PR DESCRIPTION
## Summary
Scenario-driven from a live XLE retrospective ("rewind to the Iran/Hormuz move — was there an easy entry?"). Hand-rolling it surfaced a stack of gaps; this lands the primitives so subjective retro/backtest becomes a repeatable capability, not Python toil. Primitives go in the injected tool layer; the workflow is a thin skill on top.

- **Freshness contract** (P0) — every bar series carries `asOf` / `isLatestActual` / `staleTradingDays`; snapshot raises a LOUD `freshnessWarning` when the data doesn't reach the anchor. This is the fix for the trap where a delayed source silently stops a day behind "now" and an overnight catalyst gets misread.
- **`marketSnapshot`** — honest as-of read: DATED bars (no lookahead past `asOf`), the most-recent ACTUAL print (close + vs-prevClose + day high/low + **amplitude**), compact levels (sma20/50, rsi14, dist-from-period-high), + the freshness contract. A bare symbol auto-picks the freshest source (realtime broker > delayed vendor; a non-derivative beats a same-freshness perp — a ticker lands on the equity, not a synthetic `XLE/USDT` perp; perps stay valid backups).
- **`simulate`** — path-dependent backtest: one entry + one exit rule (`trailing_stop`/`ma_break`/`stop`/`target`/`hold`), no lookahead; returns entry/exit, returnPct, MFE/MAE, peak/trough, sampled path.
- **`rss window`** — date-bounded news, oldest-first, timestamped (event study); glob/grep results now carry `time` too.
- **`quant --dates`** opt-in date axis; panel cap 50 → 200.
- **`retrospective` skill** — ties them into one freshness-first / no-lookahead / event-aligned workflow; bundled into the chat template.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm test` — 141 files / 2048 tests pass (incl. new freshness / snapshot / simulate / source-resolve / windowRss / dates specs)
- [x] **Live via the `alice` CLI** against alpaca paper:

  | call | result |
  |---|---|
  | `snapshot --query XLE` | alpaca equity, 90 bars, `isLatestActual=false staleTradingDays=1` (free SIP lacks today — loudly flagged) |
  | `snapshot --query XLE --asOf 2026-04-03` | bars end 2026-04-02 — no lookahead |
  | `simulate --query XLE --entryDate 2026-04-03 --exitRule trailing_stop --exitPct 8` | exit 04-17 **−7.8%**, MFE +1.84 / MAE −10.5 |
  | `rss window --from … --to … --pattern "Iran\|oil"` | oldest-first, timestamped |
  | `quant … --dates` | `dates[barId]` axis attached |

## Boundary touch
Read-only market-data / analysis surface (Alice → UTA `getHistorical`, news archive). No order placement, credentials, or migrations.

## Deferred (not in this PR)
- Broadening news coverage beyond the user's subscribed RSS feeds (needs an external news API).
- A headless auth bridge for cookie-gated sources (Barchart options flow, Reddit sentiment) — for now the skill tells the agent to flag the gap, not fake coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
