### PR TITLE
fix(market-data): Alpaca SIP→IEX fallback + honest per-broker bar capability

### DIFF
--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
@@ -873,3 +873,45 @@ describe('AlpacaBroker — getCapabilities()', () => {
     expect(caps.supportedOrderTypes).toEqual(['MKT', 'LMT', 'STP', 'STP LMT', 'TRAIL'])
   })
 })
+
+describe('AlpacaBroker — getHistorical() feed handling', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  async function* barGen(rows: any[]) { for (const r of rows) yield r }
+  const ROW = { Timestamp: '2026-06-25T05:00:00Z', OpenPrice: 1, HighPrice: 2, LowPrice: 0.5, ClosePrice: 1.5, Volume: 100 }
+  const recentSip403 = Object.assign(new Error('Request failed with status code 403'), {
+    response: { status: 403, data: { message: 'subscription does not permit querying recent SIP data' } },
+  })
+
+  it('requests the full SIP tape by default', async () => {
+    const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
+    const getBarsV2 = vi.fn(() => barGen([ROW]))
+    ;(acc as any).client = { getBarsV2 }
+    const bars = await acc.getHistorical(Object.assign(new Contract(), { symbol: 'SPY' }), { interval: '1d' } as any)
+    expect(getBarsV2).toHaveBeenCalledTimes(1)
+    expect(getBarsV2).toHaveBeenCalledWith('SPY', expect.objectContaining({ feed: 'sip' }))
+    expect(bars).toHaveLength(1)
+  })
+
+  it('falls back to IEX when SIP denies the recent window (403)', async () => {
+    const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
+    const getBarsV2 = vi.fn((_sym: string, opts: any) => {
+      if (opts.feed === 'sip') throw recentSip403
+      return barGen([ROW])
+    })
+    ;(acc as any).client = { getBarsV2 }
+    const bars = await acc.getHistorical(Object.assign(new Contract(), { symbol: 'SPY' }), { interval: '1m' } as any)
+    expect(getBarsV2).toHaveBeenCalledTimes(2)
+    expect(getBarsV2).toHaveBeenNthCalledWith(2, 'SPY', expect.objectContaining({ feed: 'iex' }))
+    expect(bars).toHaveLength(1)
+  })
+
+  it('does NOT fall back on a non-SIP error (propagates)', async () => {
+    const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
+    const err500 = Object.assign(new Error('boom'), { response: { status: 500 } })
+    const getBarsV2 = vi.fn(() => { throw err500 })
+    ;(acc as any).client = { getBarsV2 }
+    await expect(acc.getHistorical(Object.assign(new Contract(), { symbol: 'SPY' }), { interval: '1d' } as any)).rejects.toThrow()
+    expect(getBarsV2).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -91,6 +91,13 @@ function alpacaErrorMessage(err: unknown): string {
   return base
 }
 
+/** The free-tier "you can't query the last ~15 min of SIP data" gate — a 403
+ *  whose body says exactly that. The signal to retry the same window on IEX. */
+function isRecentSipDenied(err: unknown): boolean {
+  const status = (err as { response?: { status?: number } })?.response?.status
+  return status === 403 && /recent SIP data/i.test(alpacaErrorMessage(err))
+}
+
 export class AlpacaBroker implements IBroker {
   // ---- Self-registration ----
 
@@ -511,13 +518,14 @@ export class AlpacaBroker implements IBroker {
     const symbol = resolveSymbol(contract)
     if (!symbol) throw new BrokerError('EXCHANGE', 'Cannot resolve contract to Alpaca symbol')
     const timeframe = ALPACA_TIMEFRAME[params.interval]
-    try {
-      const opts: Record<string, unknown> = { timeframe, adjustment: 'all' }
-      if (params.start) opts.start = params.start.toISOString()
-      if (params.end) opts.end = params.end.toISOString()
-      if (params.limit) opts.limit = params.limit
+    const baseOpts: Record<string, unknown> = { timeframe, adjustment: 'all' }
+    if (params.start) baseOpts.start = params.start.toISOString()
+    if (params.end) baseOpts.end = params.end.toISOString()
+    if (params.limit) baseOpts.limit = params.limit
+
+    const drain = async (feed: 'sip' | 'iex'): Promise<Bar[]> => {
       const bars: Bar[] = []
-      const gen = this.client.getBarsV2(symbol, opts) as AsyncGenerator<AlpacaBarRaw>
+      const gen = this.client.getBarsV2(symbol, { ...baseOpts, feed }) as AsyncGenerator<AlpacaBarRaw>
       for await (const b of gen) {
         bars.push({
           timestamp: new Date(b.Timestamp),
@@ -529,6 +537,26 @@ export class AlpacaBroker implements IBroker {
         })
       }
       return bars
+    }
+
+    try {
+      // SIP = the full consolidated tape (the right feed for history/backtest —
+      // real volume, real closes). The free tier can't query the last ~15 min of
+      // SIP, so a window that reaches "now" 403s; fall back to IEX (free
+      // real-time, but only IEX's ~2-3% of the tape) for that case so a recent
+      // request degrades to thinner data instead of dying. (Alpaca's OWN data
+      // endpoint serves both feeds; this never touches a third-party vendor.)
+      try {
+        return await drain('sip')
+      } catch (err) {
+        if (isRecentSipDenied(err)) {
+          console.warn(
+            `AlpacaBroker[${this.id}]: SIP denied recent data for ${symbol} (${timeframe}) — falling back to IEX (thinner tape). Free tier can't query the last ~15min of SIP.`,
+          )
+          return await drain('iex')
+        }
+        throw err
+      }
     } catch (err) {
       throw BrokerError.from(err)
     }

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -150,6 +150,30 @@ describe('getBars — UTA branch', () => {
     expect(getHistorical).toHaveBeenCalledWith({ aliceId: 'alpaca-paper|AAPL' }, expect.objectContaining({ interval: '1d' }))
   })
 
+  it('reports the broker\'s HONEST bar quality (alpaca free = iex), not a blanket realtime', async () => {
+    const utaManager: UtaBarGateway = {
+      has: async (id) => id === 'alpaca-paper',
+      get: async () => ({ getHistorical: async () => WIRE }),
+      searchContracts: async () => [],
+      getBarCapabilities: async () => ({ 'alpaca-paper': 'iex' }),
+    }
+    const svc = createBarService(makeDeps({ utaManager }))
+    const { meta } = await svc.getBars({ barId: 'alpaca-paper|AAPL' }, { interval: '1d' })
+    expect(meta.barCapability).toBe('iex')
+  })
+
+  it('falls back to realtime when the gateway cannot surface a quality', async () => {
+    const utaManager: UtaBarGateway = {
+      has: async (id) => id === 'alpaca-paper',
+      get: async () => ({ getHistorical: async () => WIRE }),
+      searchContracts: async () => [],
+      // no getBarCapabilities
+    }
+    const svc = createBarService(makeDeps({ utaManager }))
+    const { meta } = await svc.getBars({ barId: 'alpaca-paper|AAPL' }, { interval: '1d' })
+    expect(meta.barCapability).toBe('realtime')
+  })
+
   it('renders a daily broker bar date-only even when stamped at the session open (no 05:00 / DST noise)', async () => {
     // Alpaca stamps a daily bar at the premarket open (04:00/05:00 ET in UTC),
     // which also flips an hour across DST — render the calendar day, not an instant.

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -227,6 +227,11 @@ export function createBarService(deps: BarServiceDeps): BarService {
   async function getUtaBars(sourceId: string, barId: string, opts: GetBarsOpts): Promise<BarsResult> {
     const acct = await deps.utaManager.get(sourceId)
     if (!acct) throw new Error(`UTA source "${sourceId}" not found for barId "${barId}"`)
+    // The broker's HONEST entitlement (Alpaca free = 'iex', CCXT = 'realtime'),
+    // not a blanket 'realtime'. Falls back to 'realtime' when the gateway can't
+    // surface it (mocks / brokers that declare no quality).
+    const caps: Record<string, BarCapability> = (await deps.utaManager.getBarCapabilities?.()) ?? {}
+    const cap: BarCapability = caps[sourceId] ?? 'realtime'
     // Mirror the vendor branch: a count-only request becomes a START WINDOW we
     // over-fetch and then tail-slice (finalize keeps the most-recent `count`).
     // We deliberately do NOT forward `count` as the broker's `limit`. Alpaca's
@@ -251,7 +256,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
         source: 'uta',
         sourceId,
         barId,
-        barCapability: 'realtime',
+        barCapability: cap,
         ...computeFreshness(bars[bars.length - 1]?.date ?? '', opts, () => new Date()),
       }),
     }
@@ -263,10 +268,12 @@ export function createBarService(deps: BarServiceDeps): BarService {
       // Federate vendor (OpenTypeBB) + broker (UTA) search. allSettled so one
       // side failing (e.g. no UTA configured) doesn't kill the other. Flat
       // candidates, no cross-source dedup — redundancy is the feature.
-      const [vendorRes, utaRes] = await Promise.allSettled([
+      const [vendorRes, utaRes, capsRes] = await Promise.allSettled([
         aggregateSymbolSearch(deps.marketSearch, query, limit),
         deps.utaManager.searchContracts(query),
+        deps.utaManager.getBarCapabilities?.() ?? Promise.resolve<Record<string, BarCapability>>({}),
       ])
+      const caps: Record<string, BarCapability> = capsRes.status === 'fulfilled' ? capsRes.value : {}
       const out: BarSourceCandidate[] = []
 
       if (vendorRes.status === 'fulfilled') {
@@ -296,6 +303,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
           const barId = hit.contract.aliceId
           if (!barId) continue // need the operational identity to fetch later
           const symbol = hit.contract.symbol || hit.contract.localSymbol || ''
+          const cap: BarCapability = caps[hit.source] ?? 'realtime'
           out.push({
             barId,
             source: 'uta',
@@ -304,8 +312,10 @@ export function createBarService(deps: BarServiceDeps): BarService {
             // Venue-decided asset class is authoritative; secType is only a
             // broker-blind fallback (and wrong for e.g. a CCXT dated future).
             assetClass: hit.assetClass ?? secTypeToAssetClass(hit.contract.secType),
-            label: (symbol ? `${symbol} (${hit.source})` : barId) + ' · realtime',
-            barCapability: 'realtime',
+            // Honest entitlement in the label too (Alpaca free = 'iex'), not a
+            // blanket 'realtime'.
+            label: (symbol ? `${symbol} (${hit.source})` : barId) + ` · ${cap}`,
+            barCapability: cap,
           })
         }
       }

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -143,6 +143,11 @@ export interface UtaBarGateway {
   get(id: string): Promise<UtaBarAccount | undefined>
   /** Flat contract-search hits across all accounts (for searchBarSources). */
   searchContracts(pattern: string): Promise<ContractSearchHit[]>
+  /** sourceId → declared historical-bar quality, so the federated layer reports
+   *  the BROKER's honest entitlement (Alpaca free = 'iex', CCXT = 'realtime')
+   *  instead of blanket-labeling every broker source 'realtime'. Optional: a
+   *  gateway that can't surface it falls back to 'realtime'. */
+  getBarCapabilities?(): Promise<Record<string, BarCapability>>
 }
 
 export interface BarServiceDeps {

--- a/src/services/uta-client/UTAManagerSDK.ts
+++ b/src/services/uta-client/UTAManagerSDK.ts
@@ -108,6 +108,19 @@ export class UTAManagerSDK {
     return all.some((u) => u.id === id)
   }
 
+  /** sourceId → declared historical-bar quality, for the federated bar layer to
+   *  report each broker's honest entitlement (Alpaca free = 'iex', CCXT =
+   *  'realtime') rather than blanket-labeling broker sources 'realtime'. */
+  async getBarCapabilities(): Promise<Record<string, 'realtime' | 'iex' | 'delayed' | 'subscription'>> {
+    const all = await this.listUTAs()
+    const out: Record<string, 'realtime' | 'iex' | 'delayed' | 'subscription'> = {}
+    for (const u of all) {
+      const q = u.capabilities.historicalBars?.quality
+      if (q) out[u.id] = q
+    }
+    return out
+  }
+
   /** UTAManager exposed `size` as a sync getter — SDK can't avoid the
    *  HTTP round-trip, so this is a method. Callsites become
    *  `await manager.size()`. */

--- a/src/tool/source-resolve.spec.ts
+++ b/src/tool/source-resolve.spec.ts
@@ -15,13 +15,14 @@ describe('resolveBarSource', () => {
     expect(r).toEqual({ ref: { barId: 'alpaca|XLE' } })
   })
 
-  it('auto-pick prefers a non-derivative over a same-freshness perp (perp = backup)', async () => {
-    // search returns the crypto perp FIRST (as the live UTA search does), but the
-    // equity should still win — a perp tracking a ticker is a backup, not the default.
+  it('auto-pick prefers the real equity over a FRESHER crypto perp (perp = backup)', async () => {
+    // The honest case: search returns the crypto perps FIRST and they're 'realtime',
+    // while the Alpaca equity is only 'iex' (free tier). Freshness alone would pick
+    // the synthetic perp — non-derivative-first keeps a bare ticker on the equity.
     const svc = svcWith([
       { barId: 'binance|XLE/USDT:USDT', barCapability: 'realtime', assetClass: 'crypto' },
       { barId: 'okx|XLE/USDT:USDT', barCapability: 'realtime', assetClass: 'crypto' },
-      { barId: 'alpaca|XLE', barCapability: 'realtime', assetClass: 'equity' },
+      { barId: 'alpaca|XLE', barCapability: 'iex', assetClass: 'equity' },
     ])
     const r = await resolveBarSource(svc, { query: 'XLE' })
     expect('error' in r).toBe(false)

--- a/src/tool/source-resolve.ts
+++ b/src/tool/source-resolve.ts
@@ -2,11 +2,13 @@
  * Shared bar-source resolution for the snapshot / simulate tools.
  *
  * A pinned barId always wins. For a bare symbol we auto-pick the BEST single
- * source: freshest first (realtime broker > delayed vendor), and within the
- * freshest tier a NON-derivative beats a derivative — so a plain equity/spot
- * ("alpaca|XLE") is preferred over a perp tracking the same ticker
- * ("binance|XLE/USDT:USDT"). Crypto perps stay valid candidates (and a fine
- * backup), they're just not the default pick for a bare ticker.
+ * source by: (1) NON-derivative before derivative — the real equity/spot is the
+ * default, a perp tracking the same ticker is a backup — then (2) freshest. The
+ * order matters: once a broker reports its honest entitlement, Alpaca's equity
+ * is 'iex' while a Binance XLE perp is 'realtime', so freshness alone would put
+ * the synthetic perp first; non-derivative-first keeps a bare ticker on the real
+ * contract. (For a genuine crypto query the spot is non-derivative too, so it
+ * still wins over its own perp.)
  */
 
 import type { BarService, BarCapability } from '@/domain/market-data/bars/index'
@@ -49,10 +51,12 @@ export async function resolveBarSource(
     return { error: `No bar source found for "${input.query}". Try searchBars to see candidates, or pass a barId.` }
   }
   const best = [...candidates].sort((a, b) => {
+    const da = Number(isDerivative(a.barId))
+    const db = Number(isDerivative(b.barId))
+    if (da !== db) return da - db // non-derivative (the real contract) first
     const fa = a.barCapability ? FRESHNESS_RANK[a.barCapability] : 5
     const fb = b.barCapability ? FRESHNESS_RANK[b.barCapability] : 5
-    if (fa !== fb) return fa - fb
-    return Number(isDerivative(a.barId)) - Number(isDerivative(b.barId))
+    return fa - fb // then freshest
   })[0]
 
   const assetClass = best.assetClass !== 'unknown' ? (best.assetClass as AssetClass) : undefined


### PR DESCRIPTION
## Summary
- **SIP→IEX fallback** — free-tier Alpaca 403s on any intraday window reaching the last ~15 min of the SIP tape ("subscription does not permit querying recent SIP data"). `AlpacaBroker.getHistorical` now tries SIP first (full tape) and degrades to IEX (free real-time, thin tape) on *that specific* 403 instead of dying. Both feeds are Alpaca's own data endpoint — no third-party vendor. A `console.warn` marks the degrade.
- **Honest bar capability** — the federated layer blanket-labeled broker sources `realtime`. `UTAManagerSDK.getBarCapabilities()` now reports each broker's declared quality (Alpaca free → `iex`, CCXT → `realtime`), threaded into `BarMeta` + search labels.
- **Auto-pick stays on the real contract** — an honest `iex` label would let a fresher Binance XLE *perp* outrank the Alpaca equity. `resolveBarSource` now sorts non-derivative-first **then** by freshness, so a bare ticker stays on the real equity while a genuine crypto query still lands on its spot.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 2055 passed (141 files), incl. 3 new AlpacaBroker feed tests, 2 bar-service capability tests, updated source-resolve perp test
- [x] Live CLI: `searchBars XLE` → alpaca `· iex`, perps `· realtime`; `marketSnapshot XLE` auto-picks the alpaca equity despite the fresher perps; 1m intraday snapshot returns recent bars end-to-end

## Boundary touch
UTA broker data path (`AlpacaBroker.getHistorical`) + federated bar layer (capability projection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
