### PR TITLE
Add per-agent workspace credential defaults (Settings › AI Provider)

### DIFF
--- a/src/core/config-workspace-cred-defaults.spec.ts
+++ b/src/core/config-workspace-cred-defaults.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Per-agent workspace credential defaults (the "inject my usual key on every new
+ * workspace" setting) round-trip through ai-provider-manager.json, and deleting
+ * the referenced credential prunes any default that pointed at it. config.ts
+ * resolves CONFIG_DIR at import, so each test re-imports under a fresh temp
+ * OPENALICE_HOME (config-accounts.spec.ts pattern).
+ */
+let home: string
+let savedHome: string | undefined
+
+async function loadConfigModule() {
+  vi.resetModules()
+  process.env['OPENALICE_HOME'] = home
+  return import('./config.js')
+}
+
+beforeEach(async () => {
+  savedHome = process.env['OPENALICE_HOME']
+  home = await mkdtemp(join(tmpdir(), 'oa-wsdef-'))
+})
+
+afterEach(async () => {
+  if (savedHome === undefined) delete process.env['OPENALICE_HOME']
+  else process.env['OPENALICE_HOME'] = savedHome
+  vi.resetModules()
+  await rm(home, { recursive: true, force: true })
+})
+
+describe('workspace credential defaults', () => {
+  it('defaults to an empty map when unset', async () => {
+    const config = await loadConfigModule()
+    expect(await config.readWorkspaceCredentialDefaults()).toEqual({})
+  })
+
+  it('round-trips a per-agent map and keeps the optional model', async () => {
+    const config = await loadConfigModule()
+    await config.writeWorkspaceCredentialDefaults({
+      opencode: { credentialSlug: 'openai-1', model: 'gpt-5.5' },
+      pi: { credentialSlug: 'anthropic-1' },
+    })
+    expect(await config.readWorkspaceCredentialDefaults()).toEqual({
+      opencode: { credentialSlug: 'openai-1', model: 'gpt-5.5' },
+      pi: { credentialSlug: 'anthropic-1' },
+    })
+  })
+
+  it('drops entries with an empty credentialSlug (the "don\'t seed" choice)', async () => {
+    const config = await loadConfigModule()
+    await config.writeWorkspaceCredentialDefaults({
+      opencode: { credentialSlug: 'openai-1' },
+      pi: { credentialSlug: '' },
+    })
+    expect(await config.readWorkspaceCredentialDefaults()).toEqual({
+      opencode: { credentialSlug: 'openai-1' },
+    })
+  })
+
+  it('coexists with the credential vault in the same file', async () => {
+    const config = await loadConfigModule()
+    const slug = await config.addCredential({ vendor: 'openai', authType: 'api-key', apiKey: 'sk-oa', wires: { 'openai-chat': '' } })
+    await config.writeWorkspaceCredentialDefaults({ opencode: { credentialSlug: slug } })
+    expect(await config.readCredentials()).toHaveProperty(slug)
+    expect(await config.readWorkspaceCredentialDefaults()).toEqual({ opencode: { credentialSlug: slug } })
+  })
+
+  it('deleting a credential prunes a default that referenced it', async () => {
+    const config = await loadConfigModule()
+    const slug = await config.addCredential({ vendor: 'openai', authType: 'api-key', apiKey: 'sk-oa', wires: { 'openai-chat': '' } })
+    await config.writeWorkspaceCredentialDefaults({
+      opencode: { credentialSlug: slug },
+      pi: { credentialSlug: 'kept-1' },
+    })
+    await config.deleteCredential(slug)
+    expect(await config.readWorkspaceCredentialDefaults()).toEqual({ pi: { credentialSlug: 'kept-1' } })
+  })
+})

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -161,6 +161,22 @@ export function credentialWires(cred: Credential): Partial<Record<CredentialWire
   return {}
 }
 
+/**
+ * A user-level default that seeds a freshly-created workspace's per-agent AI
+ * config from a vault credential — the "inject my usual key on every launch"
+ * setting. Keyed by agentId (`claude` / `codex` / `opencode` / `pi`).
+ * `credentialSlug` points into `credentials`; `model` is the optional run model
+ * (absent ⇒ resolved from the cred's `lastModel`, then the vendor flagship).
+ * Structurally a superset-compatible mirror of the workspaces layer's
+ * `AgentCredentialDecl`, so the creator can merge the two and feed
+ * `injectWorkspaceCredentials` directly.
+ */
+export const workspaceCredentialDefaultSchema = z.object({
+  credentialSlug: z.string(),
+  model: z.string().optional(),
+})
+export type WorkspaceCredentialDefault = z.infer<typeof workspaceCredentialDefaultSchema>
+
 export const aiProviderSchema = z.object({
   apiKeys: apiKeysSchema.default({}),
   /**
@@ -171,6 +187,14 @@ export const aiProviderSchema = z.object({
    * existing files keep them on disk until rewritten, where they're ignored.)
    */
   credentials: z.record(z.string(), credentialSchema).default({}),
+  /**
+   * Per-agent default credential seeded into EVERY new workspace at create time
+   * (agentId → {credentialSlug, model?}). The user-level counterpart to a
+   * template's `agentCredentials`: set a default cred per agent once and skip the
+   * per-workspace AI-config modal on each launch. References slugs in
+   * `credentials`; a dangling slug is loud-skipped at injection, never fatal.
+   */
+  workspaceCredentialDefaults: z.record(z.string(), workspaceCredentialDefaultSchema).default({}),
 })
 
 export type AIProviderConfig = z.infer<typeof aiProviderSchema>
@@ -886,6 +910,39 @@ export async function setCredentialLastModel(slug: string, model: string): Promi
 export async function deleteCredential(slug: string): Promise<void> {
   const config = await readAIProviderConfig()
   delete config.credentials[slug]
+  // Drop any workspace-default that pointed at the now-gone slug, so the
+  // Settings dropdown never shows a dangling default (injection would skip it
+  // anyway, but a stale default reads as "still configured").
+  for (const [agentId, def] of Object.entries(config.workspaceCredentialDefaults)) {
+    if (def.credentialSlug === slug) delete config.workspaceCredentialDefaults[agentId]
+  }
+  await mkdir(CONFIG_DIR, { recursive: true })
+  await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
+}
+
+/**
+ * Read the per-agent default credentials seeded into new workspaces
+ * (agentId → {credentialSlug, model?}). Empty map when unset.
+ */
+export async function readWorkspaceCredentialDefaults(): Promise<Record<string, WorkspaceCredentialDefault>> {
+  const config = await readAIProviderConfig()
+  return { ...config.workspaceCredentialDefaults }
+}
+
+/**
+ * Replace the per-agent workspace-default credential map. Entries with an empty
+ * `credentialSlug` are dropped (the UI's "don't seed this agent" choice).
+ */
+export async function writeWorkspaceCredentialDefaults(
+  defaults: Record<string, WorkspaceCredentialDefault>,
+): Promise<void> {
+  const config = await readAIProviderConfig()
+  const cleaned: Record<string, WorkspaceCredentialDefault> = {}
+  for (const [agentId, def] of Object.entries(defaults)) {
+    const parsed = workspaceCredentialDefaultSchema.parse(def)
+    if (parsed.credentialSlug) cleaned[agentId] = parsed
+  }
+  config.workspaceCredentialDefaults = cleaned
   await mkdir(CONFIG_DIR, { recursive: true })
   await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
 }

--- a/src/webui/routes/config-workspace-defaults.spec.ts
+++ b/src/webui/routes/config-workspace-defaults.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * config routes — GET/PUT /workspace-credential-defaults (the per-agent
+ * "inject my usual key on every new workspace" setting).
+ *
+ * Mocks core/config.js read/write with an in-memory store so we don't touch the
+ * real data/ dir; the real `compatibleCredentials` wire funnel is exercised so
+ * the GET's per-agent options reflect actual wire compatibility.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Credential, WorkspaceCredentialDefault } from '../../core/config.js'
+
+let credStore: Record<string, Credential> = {}
+let defaultsStore: Record<string, WorkspaceCredentialDefault> = {}
+
+vi.mock('../../core/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../core/config.js')>('../../core/config.js')
+  return {
+    ...actual,
+    readCredentials: vi.fn(async () => ({ ...credStore })),
+    readWorkspaceCredentialDefaults: vi.fn(async () => ({ ...defaultsStore })),
+    writeWorkspaceCredentialDefaults: vi.fn(async (next: Record<string, WorkspaceCredentialDefault>) => {
+      // Mirror the real writer: drop empty slugs.
+      const cleaned: Record<string, WorkspaceCredentialDefault> = {}
+      for (const [k, v] of Object.entries(next)) if (v.credentialSlug) cleaned[k] = v
+      defaultsStore = cleaned
+    }),
+  }
+})
+
+import { createConfigRoutes } from './config.js'
+
+async function req(routes: ReturnType<typeof createConfigRoutes>, method: 'GET' | 'PUT', path: string, body?: unknown) {
+  const init: RequestInit = { method }
+  if (body !== undefined) {
+    init.headers = { 'Content-Type': 'application/json' }
+    init.body = JSON.stringify(body)
+  }
+  const res = await routes.request(path, init)
+  const json = await res.json().catch(() => null)
+  return { status: res.status, body: json as Record<string, unknown> | null }
+}
+
+beforeEach(() => {
+  credStore = {
+    'anthropic-1': { vendor: 'anthropic', authType: 'api-key', apiKey: 'sk-ant', wires: { anthropic: '' } },
+    'openai-1': { vendor: 'openai', authType: 'api-key', apiKey: 'sk-oa', wires: { 'openai-responses': '', 'openai-chat': '' } },
+    'chat-1': { vendor: 'custom', authType: 'api-key', apiKey: 'k', wires: { 'openai-chat': 'https://gw/v1' } },
+  }
+  defaultsStore = {}
+})
+
+describe('GET /workspace-credential-defaults', () => {
+  it('returns current defaults + per-agent compatible slugs (wire funnel)', async () => {
+    const routes = createConfigRoutes()
+    defaultsStore = { opencode: { credentialSlug: 'openai-1', model: 'gpt-5.5' } }
+
+    const { status, body } = await req(routes, 'GET', '/workspace-credential-defaults')
+    expect(status).toBe(200)
+    expect(body!.defaults).toEqual({ opencode: { credentialSlug: 'openai-1', model: 'gpt-5.5' } })
+
+    const compat = body!.compatibleByAgent as Record<string, string[]>
+    // claude speaks anthropic only.
+    expect(compat.claude).toEqual(['anthropic-1'])
+    // codex is Responses-only → only the openai key qualifies (chat-only excluded).
+    expect(compat.codex).toEqual(['openai-1'])
+    // opencode/pi speak chat|anthropic|responses → every key qualifies.
+    expect(new Set(compat.opencode)).toEqual(new Set(['anthropic-1', 'openai-1', 'chat-1']))
+    expect(new Set(compat.pi)).toEqual(new Set(['anthropic-1', 'openai-1', 'chat-1']))
+  })
+})
+
+describe('PUT /workspace-credential-defaults', () => {
+  it('replaces the map, keeps optional model, persists via the writer', async () => {
+    const routes = createConfigRoutes()
+    const { status, body } = await req(routes, 'PUT', '/workspace-credential-defaults', {
+      defaults: {
+        opencode: { credentialSlug: 'openai-1', model: 'gpt-5.5' },
+        pi: { credentialSlug: 'anthropic-1' },
+      },
+    })
+    expect(status).toBe(200)
+    expect(body!.defaults).toEqual({
+      opencode: { credentialSlug: 'openai-1', model: 'gpt-5.5' },
+      pi: { credentialSlug: 'anthropic-1' },
+    })
+    expect(defaultsStore).toEqual(body!.defaults)
+  })
+
+  it('drops an agent whose credentialSlug is empty ("don\'t seed")', async () => {
+    const routes = createConfigRoutes()
+    const { body } = await req(routes, 'PUT', '/workspace-credential-defaults', {
+      defaults: { opencode: { credentialSlug: 'openai-1' }, pi: { credentialSlug: '' } },
+    })
+    expect(body!.defaults).toEqual({ opencode: { credentialSlug: 'openai-1' } })
+  })
+
+  it('ignores unknown agent keys (only the four defaultable agents pass through)', async () => {
+    const routes = createConfigRoutes()
+    const { body } = await req(routes, 'PUT', '/workspace-credential-defaults', {
+      defaults: { shell: { credentialSlug: 'openai-1' }, bogus: { credentialSlug: 'x' } },
+    })
+    expect(body!.defaults).toEqual({})
+  })
+
+  it('clears all defaults on an empty body', async () => {
+    const routes = createConfigRoutes()
+    defaultsStore = { opencode: { credentialSlug: 'openai-1' } }
+    const { body } = await req(routes, 'PUT', '/workspace-credential-defaults', { defaults: {} })
+    expect(body!.defaults).toEqual({})
+    expect(defaultsStore).toEqual({})
+  })
+})

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -3,9 +3,12 @@ import {
   loadConfig, writeConfigSection, validSections,
   readCredentials, addCredential, deleteCredential, writeCredential, resolveCredential,
   credentialWires,
+  readWorkspaceCredentialDefaults, writeWorkspaceCredentialDefaults,
   credentialVendorEnum, credentialWireShapeEnum,
   type ConfigSection, type Credential, type CredentialWireShape,
+  type WorkspaceCredentialDefault,
 } from '../../core/config.js'
+import { compatibleCredentials } from '../../workspaces/credential-injection.js'
 
 /** Validate a `{ [wireShape]: baseUrl }` body into a typed wires map. */
 function parseWires(raw: unknown): Partial<Record<CredentialWireShape, string>> {
@@ -154,6 +157,62 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
       return c.json({ ok: true, response: r.text })
     } catch (err) {
       return c.json({ ok: false, error: err instanceof Error ? err.message : String(err) })
+    }
+  })
+
+  // ============ Default Workspace Credentials (per-agent) ============
+  //
+  // The user-level "inject my usual key on every new workspace" setting. A
+  // per-agent map of {credentialSlug, model?} that the workspace creator seeds
+  // into each new workspace's file-based AI config at create time — sparing the
+  // user the per-workspace AI-config modal. References the vault above.
+
+  const DEFAULTABLE_AGENTS = ['claude', 'codex', 'opencode', 'pi'] as const
+
+  /**
+   * GET /workspace-credential-defaults — the current per-agent defaults plus,
+   * for the picker, the vault slugs each agent can actually be driven by (the
+   * wire-shape funnel computed server-side, so the UI stays dumb).
+   */
+  app.get('/workspace-credential-defaults', async (c) => {
+    try {
+      const [defaults, creds] = await Promise.all([
+        readWorkspaceCredentialDefaults(),
+        readCredentials(),
+      ])
+      const compatibleByAgent: Record<string, string[]> = {}
+      for (const agent of DEFAULTABLE_AGENTS) {
+        compatibleByAgent[agent] = compatibleCredentials(creds, agent).map(([slug]) => slug)
+      }
+      return c.json({ defaults, compatibleByAgent })
+    } catch (err) {
+      return c.json({ error: String(err) }, 500)
+    }
+  })
+
+  /**
+   * PUT /workspace-credential-defaults — replace the whole per-agent map. Body:
+   * `{ defaults: { [agentId]: { credentialSlug, model? } } }`. An empty/absent
+   * `credentialSlug` for an agent clears its default (handled in the writer).
+   */
+  app.put('/workspace-credential-defaults', async (c) => {
+    try {
+      const body = await c.req.json<{ defaults?: Record<string, WorkspaceCredentialDefault> }>()
+      const incoming = body.defaults ?? {}
+      const next: Record<string, WorkspaceCredentialDefault> = {}
+      for (const agent of DEFAULTABLE_AGENTS) {
+        const def = incoming[agent]
+        if (def && typeof def.credentialSlug === 'string' && def.credentialSlug) {
+          next[agent] = {
+            credentialSlug: def.credentialSlug,
+            ...(typeof def.model === 'string' && def.model ? { model: def.model } : {}),
+          }
+        }
+      }
+      await writeWorkspaceCredentialDefaults(next)
+      return c.json({ defaults: next })
+    } catch (err) {
+      return c.json({ error: String(err) }, 400)
     }
   })
 

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -5,13 +5,13 @@ import { join } from 'node:path';
 
 import { exec as gitExec } from 'dugite';
 
-import { readCredentials } from '@/core/config.js';
+import { readCredentials, readWorkspaceCredentialDefaults } from '@/core/config.js';
 
 import type { AdapterRegistry } from './cli-adapter.js';
 import { injectWorkspaceContext } from './context-injector.js';
 import { injectWorkspaceCredentials } from './credential-injection.js';
 import type { Logger } from './logger.js';
-import type { TemplateRegistry } from './template-registry.js';
+import type { AgentCredentialDecl, TemplateRegistry } from './template-registry.js';
 import type { WorkspaceMeta, WorkspaceRegistry } from './workspace-registry.js';
 
 export interface BootstrapEnv {
@@ -221,24 +221,34 @@ export class WorkspaceCreator {
       }
     }
 
-    // Template-declared credential seeding — runs POST-commit so the secret
-    // never lands in the initial commit (the adapter config files are kept out
-    // of git by `_common.sh`'s excludes; post-commit is the belt-and-braces).
-    // Best-effort: a miss warns + skips, the workspace stays usable.
-    if (template.agentCredentials) {
-      try {
+    // Credential seeding — runs POST-commit so the secret never lands in the
+    // initial commit (the adapter config files are kept out of git by
+    // `_common.sh`'s excludes; post-commit is the belt-and-braces). The source
+    // is the user's per-agent workspace defaults (Settings › AI Provider) merged
+    // with any template-declared `agentCredentials` — the template wins per agent
+    // (explicit per-template intent), though in practice no in-repo template
+    // declares them, so the user defaults are the effective source. Best-effort:
+    // a miss (disabled agent, dangling slug, incompatible wire) warns + skips,
+    // the workspace stays usable.
+    try {
+      const userDefaults = await readWorkspaceCredentialDefaults();
+      const effective: Record<string, AgentCredentialDecl> = {
+        ...userDefaults,
+        ...(template.agentCredentials ?? {}),
+      };
+      if (Object.keys(effective).length > 0) {
         const credentials = await readCredentials();
         await injectWorkspaceCredentials({
           dir,
           agents,
-          agentCredentials: template.agentCredentials,
+          agentCredentials: effective,
           adapterRegistry: this.opts.adapterRegistry,
           credentials,
           logger: log,
         });
-      } catch (err) {
-        log.warn('cred_inject.failed', { err });
       }
+    } catch (err) {
+      log.warn('cred_inject.failed', { err });
     }
 
     const workspace: WorkspaceMeta = {

--- a/ui/src/api/config.ts
+++ b/ui/src/api/config.ts
@@ -73,6 +73,41 @@ export const configApi = {
     return res.json()
   },
 
+  // ============ Default Workspace Credentials (per-agent) ============
+
+  async getWorkspaceCredentialDefaults(): Promise<WorkspaceCredentialDefaultsResponse> {
+    const res = await fetch('/api/config/workspace-credential-defaults')
+    if (!res.ok) throw new Error('Failed to load workspace credential defaults')
+    return res.json()
+  },
+
+  async setWorkspaceCredentialDefaults(
+    defaults: Record<string, WorkspaceCredentialDefault>,
+  ): Promise<{ defaults: Record<string, WorkspaceCredentialDefault> }> {
+    const res = await fetch('/api/config/workspace-credential-defaults', {
+      method: 'PUT', headers, body: JSON.stringify({ defaults }),
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: 'Failed to save defaults' }))
+      throw new Error(err.error || 'Failed to save defaults')
+    }
+    return res.json()
+  },
+
+}
+
+/** A per-agent default credential seeded into new workspaces. */
+export interface WorkspaceCredentialDefault {
+  credentialSlug: string
+  model?: string
+}
+
+/** GET /workspace-credential-defaults — current defaults + per-agent picker options. */
+export interface WorkspaceCredentialDefaultsResponse {
+  /** agentId → default cred. Absent agent = no default seeded. */
+  defaults: Record<string, WorkspaceCredentialDefault>
+  /** agentId → vault slugs the agent can actually be driven by (wire funnel). */
+  compatibleByAgent: Record<string, string[]>
 }
 
 /** A central credential as the vault lists it. */

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -41,4 +41,16 @@ export const configKeysHandlers = [
   http.put('/api/config/credentials/:slug', () => HttpResponse.json({ slug: 'custom-1' })),
   http.delete('/api/config/credentials/:slug', () => HttpResponse.json({ success: true })),
   http.post('/api/config/credentials/test', () => HttpResponse.json({ ok: true, response: 'Hi!' })),
+
+  // Per-agent default workspace credentials (AI Provider page)
+  http.get('/api/config/workspace-credential-defaults', () =>
+    HttpResponse.json({
+      defaults: {},
+      compatibleByAgent: { claude: [], codex: [], opencode: [], pi: [] },
+    }),
+  ),
+  http.put('/api/config/workspace-credential-defaults', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { defaults?: unknown }
+    return HttpResponse.json({ defaults: body.defaults ?? {} })
+  }),
 ]

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -33,8 +33,16 @@ export const configKeysHandlers = [
 
   http.get('/api/config/presets', () => HttpResponse.json({ presets: [] })),
 
-  // Credential vault (AI Provider page)
-  http.get('/api/config/credentials', () => HttpResponse.json({ credentials: [] })),
+  // Credential vault (AI Provider page) — a small representative set so the
+  // page (and the per-agent default pickers) render with content in the demo.
+  http.get('/api/config/credentials', () =>
+    HttpResponse.json({
+      credentials: [
+        { slug: 'anthropic-1', vendor: 'anthropic', authType: 'api-key', wires: { anthropic: '' }, apiKey: null, hasApiKey: true },
+        { slug: 'openai-1', vendor: 'openai', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true },
+      ],
+    }),
+  ),
   http.post('/api/config/credentials', () =>
     HttpResponse.json({ slug: 'custom-1', vendor: 'custom' }, { status: 201 }),
   ),
@@ -45,8 +53,13 @@ export const configKeysHandlers = [
   // Per-agent default workspace credentials (AI Provider page)
   http.get('/api/config/workspace-credential-defaults', () =>
     HttpResponse.json({
-      defaults: {},
-      compatibleByAgent: { claude: [], codex: [], opencode: [], pi: [] },
+      defaults: { opencode: { credentialSlug: 'openai-1' } },
+      compatibleByAgent: {
+        claude: ['anthropic-1'],
+        codex: ['openai-1'],
+        opencode: ['anthropic-1', 'openai-1'],
+        pi: ['anthropic-1', 'openai-1'],
+      },
     }),
   ),
   http.put('/api/config/workspace-credential-defaults', async ({ request }) => {

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -16,7 +16,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import { api, type Preset, type WireShape } from '../api'
-import type { CredentialSummary } from '../api/config'
+import type { CredentialSummary, WorkspaceCredentialDefaultsResponse } from '../api/config'
 import { PageHeader } from '../components/PageHeader'
 import { PageLoading } from '../components/StateViews'
 import { Field, inputClass } from '../components/form'
@@ -228,6 +228,9 @@ export function AIProviderPage() {
             </div>
           </section>
         </div>
+
+        {/* ============== Default workspace credentials ============== */}
+        <WorkspaceDefaultsSection credentials={credentials} />
       </div>
 
       {modal && (
@@ -240,6 +243,137 @@ export function AIProviderPage() {
         />
       )}
     </div>
+  )
+}
+
+// ==================== Default workspace credentials ====================
+//
+// A user-level "inject my usual key on every new workspace" setting. Per agent,
+// pick a vault credential to seed into each new workspace's file-based AI config
+// at create time. opencode/pi are the primary case (loginless — they need a key
+// to run); Claude Code / Codex run on their own CLI login by default, so they're
+// behind an "advanced" reveal — present (some users drive them via an unofficial
+// API key) but never pushed.
+
+const PRIMARY_DEFAULT_AGENTS = [
+  { id: 'opencode', name: 'opencode' },
+  { id: 'pi', name: 'Pi' },
+] as const
+
+const ADVANCED_DEFAULT_AGENTS = [
+  { id: 'claude', name: 'Claude Code' },
+  { id: 'codex', name: 'Codex' },
+] as const
+
+function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSummary[] }) {
+  const [data, setData] = useState<WorkspaceCredentialDefaultsResponse | null>(null)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const reload = () =>
+    api.config.getWorkspaceCredentialDefaults()
+      .then(setData)
+      .catch(() => setData({ defaults: {}, compatibleByAgent: {} }))
+
+  // Re-derive when the vault changes (a deleted cred drops from compatible lists,
+  // and the backend also clears any default that pointed at it).
+  useEffect(() => { void reload() }, [credentials])
+
+  const credLabel = (slug: string) => {
+    const c = credentials.find((x) => x.slug === slug)
+    return c ? `${c.vendor} · ${slug}` : slug
+  }
+
+  const setAgentDefault = async (agentId: string, slug: string) => {
+    if (!data) return
+    const nextDefaults = { ...data.defaults }
+    if (slug) nextDefaults[agentId] = { credentialSlug: slug }
+    else delete nextDefaults[agentId]
+    setSaving(true); setError('')
+    setData({ ...data, defaults: nextDefaults }) // optimistic
+    try {
+      const res = await api.config.setWorkspaceCredentialDefaults(nextDefaults)
+      setData((d) => (d ? { ...d, defaults: res.defaults } : d))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+      await reload()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const renderAgent = (agent: { id: string; name: string }, note?: string) => {
+    const options = data?.compatibleByAgent[agent.id] ?? []
+    const current = data?.defaults[agent.id]?.credentialSlug ?? ''
+    return (
+      <div key={agent.id} className="flex items-center gap-3 rounded-lg border border-border bg-bg px-4 py-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2">
+            <span className="text-[13px] font-medium text-text">{agent.name}</span>
+            <span className="text-[11px] text-text-muted font-mono">{agent.id}</span>
+          </div>
+          {note && <p className="text-[11px] text-text-muted mt-0.5 leading-snug">{note}</p>}
+          {options.length === 0 && (
+            <p className="text-[11px] text-text-muted/70 mt-0.5 leading-snug">No compatible credential in the vault yet.</p>
+          )}
+        </div>
+        <select
+          className={inputClass + ' max-w-[240px]'}
+          value={current}
+          disabled={saving || options.length === 0}
+          onChange={(e) => void setAgentDefault(agent.id, e.target.value)}
+        >
+          <option value="">Don’t seed</option>
+          {options.map((slug) => <option key={slug} value={slug}>{credLabel(slug)}</option>)}
+        </select>
+      </div>
+    )
+  }
+
+  return (
+    <section className="max-w-[1100px] mx-auto mt-6">
+      <div className="rounded-lg border border-border/50 bg-bg-secondary/50 px-4 py-3 mb-4">
+        <p className="text-[13px] text-text-muted leading-relaxed">
+          Seed a default credential into every <em>new</em> workspace, so you don’t open the
+          per-workspace AI config each time. It’s written into the workspace’s own agent config
+          files at create — existing workspaces are untouched, and you can still override any
+          workspace afterwards. opencode and Pi need a key to run; Claude Code and Codex normally
+          run on their own CLI login (<code className="font-mono text-[11.5px]">claude login</code> /{' '}
+          <code className="font-mono text-[11.5px]">codex login</code>) and don’t need this.
+        </p>
+      </div>
+
+      <h2 className="text-[13px] font-semibold text-text uppercase tracking-wide mb-3">Default workspace credentials</h2>
+
+      {!data ? (
+        <p className="text-[12px] text-text-muted">Loading…</p>
+      ) : (
+        <div className="space-y-2.5">
+          {PRIMARY_DEFAULT_AGENTS.map((a) => renderAgent(a))}
+
+          <button
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="text-[11px] text-text-muted hover:text-text transition-colors pt-1"
+          >
+            {showAdvanced ? '▾' : '▸'} Advanced — Claude Code / Codex (unofficial API)
+          </button>
+
+          {showAdvanced && (
+            <>
+              <p className="text-[11px] text-text-muted/80 leading-snug px-1">
+                Only set these if you drive Claude Code / Codex through an unofficial API key
+                instead of their built-in login. A default here overwrites the CLI login in each
+                new workspace.
+              </p>
+              {ADVANCED_DEFAULT_AGENTS.map((a) => renderAgent(a))}
+            </>
+          )}
+
+          {error && <p className="text-[12px] text-red">{error}</p>}
+        </div>
+      )}
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary

Adds a user-level "inject my usual key on every new workspace" setting to the AI Provider page. Users can now set a default credential per agent (opencode, Pi, Claude Code, Codex) that will be seeded into each new workspace's agent config at creation time, eliminating the need to configure the per-workspace AI settings modal on every launch.

## Key Changes

**Backend (Core Config)**
- Added `WorkspaceCredentialDefault` schema and `workspaceCredentialDefaults` field to `AIProviderConfig` (stored in `ai-provider-manager.json` alongside the credential vault)
- Implemented `readWorkspaceCredentialDefaults()` and `writeWorkspaceCredentialDefaults()` to persist per-agent defaults
- When a credential is deleted, any workspace default referencing it is automatically pruned (prevents stale references)

**API Routes**
- `GET /workspace-credential-defaults` — returns current defaults plus per-agent compatible credential slugs (computed via the wire-shape funnel, so the UI picker only shows credentials each agent can actually use)
- `PUT /workspace-credential-defaults` — replaces the entire per-agent map; empty `credentialSlug` values are dropped (the "don't seed" choice)

**Workspace Creator**
- Merges user-level workspace defaults with template-declared `agentCredentials` (template wins per agent for explicit per-template intent)
- Passes the merged map to `injectWorkspaceCredentials` at workspace creation time

**Frontend (React)**
- New `WorkspaceDefaultsSection` component on the AI Provider page
- Primary agents (opencode, Pi) always visible; advanced agents (Claude Code, Codex) behind a collapsible reveal (since they normally run on built-in CLI login)
- Per-agent dropdown picker showing compatible credentials from the vault
- Optimistic UI updates with error recovery

**Tests**
- `src/core/config-workspace-cred-defaults.spec.ts` — round-trip persistence, empty-slug filtering, coexistence with credential vault, credential deletion pruning
- `src/webui/routes/config-workspace-defaults.spec.ts` — GET/PUT routes, wire-shape funnel, unknown agent filtering, empty-body clearing

**Demo Mode**
- Updated MSW handlers to mock the new endpoints with representative credential data

## Implementation Details

- Defaults are stored in the same `ai-provider-manager.json` file as the credential vault, under a separate `workspaceCredentialDefaults` key
- The optional `model` field on defaults is preserved through round-trips (allows per-agent model override at the user level)
- Wire-shape compatibility is computed server-side so the UI stays dumb and the picker always reflects actual agent capabilities
- Credential deletion is the only operation that mutates defaults (via `deleteCredential`); all other mutations go through the explicit `writeWorkspaceCredentialDefaults` API

https://claude.ai/code/session_01Fjo3owgAEnm7aSjygWFc7y