### PR TITLE
Inbox origin Phase 2 — interactive-session provenance (agent-invisible)

### DIFF
--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -50,12 +50,13 @@ export interface InboxDoc {
  * link the UI cross-references on: an inbox card → its originating run/issue,
  * an issue detail → the inbox reports it produced.
  *
- * First cut is issue/run-level, headless only (`kind:'headless'`): `runId` is
- * set for every dispatched run, `issueId` when a scheduled issue fired it,
- * `agent` from the run record. `sessionId` + `kind:'interactive'` are reserved
- * for Phase 2 (a pre-allocated session record id via a future AQ_SESSION_ID) —
- * the object is structured now so it grows without reshaping. Absent on
- * interactive/manual pushes that carry no run header → `origin` is undefined.
+ * Two live kinds: `kind:'headless'` (a dispatched run — `runId` always, set from
+ * the spawn-injected AQ_RUN_ID and resolved against the HeadlessTaskRegistry;
+ * `issueId` when a scheduled issue fired it) and `kind:'interactive'` (a
+ * human-attended PTY session — `sessionId`, the pre-allocated SessionRegistry
+ * record id, set from the spawn-injected AQ_SESSION_ID and resolved against the
+ * session registry). `agent` comes off the authoritative record in both. Absent
+ * on manual pushes that carry no header → `origin` is undefined.
  */
 export interface InboxOrigin {
   kind: 'headless' | 'interactive' | 'manual'
@@ -63,7 +64,7 @@ export interface InboxOrigin {
   runId?: string
   /** The scheduled issue that fired the run, when applicable. */
   issueId?: string
-  /** Reserved for Phase 2 interactive sessions (pre-allocated record id). */
+  /** The interactive session's pre-allocated SessionRegistry record id. */
   sessionId?: string
   /** The agent CLI id (claude/codex/…) from the run record. */
   agent?: string

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -199,6 +199,12 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
             ? { taskId: 'run-7', issueId: 'macro-scan', agent: 'opencode' }
             : null,
       },
+      sessionRegistry: {
+        get: (wsId: string, id: string) =>
+          wsId === 'ws1' && id === 'sess-1'
+            ? { id: 'sess-1', wsId: 'ws1', agent: 'claude' }
+            : undefined,
+      },
     }
     const wtc = new WorkspaceToolCenter()
     wtc.register(inboxPushFactory)
@@ -245,6 +251,33 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
     await pushWith(app, { 'x-openalice-run': 'ghost' })
     const { entries } = await inboxStore.read({ workspaceId: 'ws1' })
     expect(entries[0].origin).toBeUndefined()
+  })
+
+  it('stamps an interactive origin from a valid session header (validated against the registry)', async () => {
+    const { app, inboxStore } = makeOriginApp()
+    const res = await pushWith(app, { 'x-openalice-session': 'sess-1' })
+    expect(res.status).toBe(200)
+    const { entries } = await inboxStore.read({ workspaceId: 'ws1' })
+    expect(entries[0].origin).toEqual({ kind: 'interactive', sessionId: 'sess-1', agent: 'claude' })
+  })
+
+  it('a forged session id resolves to no origin (registry is the authority)', async () => {
+    const { app, inboxStore } = makeOriginApp()
+    await pushWith(app, { 'x-openalice-session': 'forged' })
+    const { entries } = await inboxStore.read({ workspaceId: 'ws1' })
+    expect(entries[0].origin).toBeUndefined()
+  })
+
+  it('the run header wins when both run and session headers are present', async () => {
+    const { app, inboxStore } = makeOriginApp()
+    await pushWith(app, { 'x-openalice-run': 'run-7', 'x-openalice-session': 'sess-1' })
+    const { entries } = await inboxStore.read({ workspaceId: 'ws1' })
+    expect(entries[0].origin).toEqual({
+      kind: 'headless',
+      runId: 'run-7',
+      issueId: 'macro-scan',
+      agent: 'opencode',
+    })
   })
 
   it('inbox_push input schema has NO origin / runId / issueId param (agent never self-identifies)', () => {

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -178,10 +178,19 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
     if (!mappedToolNames(c.req.param('export')).has(toolName)) {
       return c.json({ error: `Unknown CLI command tool: ${toolName || '(none)'}` }, 404)
     }
-    // Out-of-band run identity (agent never sees it): the `alice` shim forwards
-    // the spawn-injected AQ_RUN_ID here, resolved server-side to an authoritative
-    // origin and baked into the scoped tools (e.g. inbox_push auto-link).
-    const origin = resolveInboxOrigin(c.req.header('x-openalice-run'), getWorkspaceService)
+    // Out-of-band identity (agent never sees it): the `alice` shim forwards the
+    // spawn-injected AQ_RUN_ID (headless) / AQ_SESSION_ID (interactive) here as
+    // mutually-exclusive headers, resolved server-side to an authoritative origin
+    // and baked into the scoped tools (e.g. inbox_push auto-link). The session
+    // header is validated against THIS workspace's session registry.
+    const origin = resolveInboxOrigin(
+      {
+        run: c.req.header('x-openalice-run'),
+        session: c.req.header('x-openalice-session'),
+        wsId: r.ws.id,
+      },
+      getWorkspaceService,
+    )
     const tool = exportCatalog(r.exp, r.ws, origin).resolve(toolName)
     if (!tool) return c.json({ error: `Tool not available: ${toolName}` }, 404)
 

--- a/src/server/inbox-origin.spec.ts
+++ b/src/server/inbox-origin.spec.ts
@@ -3,35 +3,105 @@ import { resolveInboxOrigin } from './inbox-origin.js'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-function svc(records: Record<string, { taskId: string; issueId?: string; agent: string }>) {
-  return { headlessTasks: { get: (id: string) => records[id] ?? null } }
+/** Build a structural fake service with both authorities. */
+function svc(opts: {
+  headless?: Record<string, { taskId: string; issueId?: string; agent: string }>
+  sessions?: Record<string, Record<string, { id: string; wsId: string; agent: string }>>
+} = {}) {
+  return {
+    headlessTasks: { get: (id: string) => opts.headless?.[id] ?? null },
+    sessionRegistry: {
+      get: (wsId: string, id: string) => opts.sessions?.[wsId]?.[id],
+    },
+  }
 }
 
-describe('resolveInboxOrigin', () => {
+describe('resolveInboxOrigin — headless (Phase 1)', () => {
   it('builds a headless origin from the authoritative record', () => {
-    const origin = resolveInboxOrigin('run-7', () =>
-      svc({ 'run-7': { taskId: 'run-7', issueId: 'macro', agent: 'claude' } }) as any,
+    const origin = resolveInboxOrigin({ run: 'run-7' }, () =>
+      svc({ headless: { 'run-7': { taskId: 'run-7', issueId: 'macro', agent: 'claude' } } }) as any,
     )
     expect(origin).toEqual({ kind: 'headless', runId: 'run-7', issueId: 'macro', agent: 'claude' })
   })
 
   it('omits issueId when the run had none (manual/external dispatch)', () => {
-    const origin = resolveInboxOrigin('run-8', () =>
-      svc({ 'run-8': { taskId: 'run-8', agent: 'opencode' } }) as any,
+    const origin = resolveInboxOrigin({ run: 'run-8' }, () =>
+      svc({ headless: { 'run-8': { taskId: 'run-8', agent: 'opencode' } } }) as any,
     )
     expect(origin).toEqual({ kind: 'headless', runId: 'run-8', agent: 'opencode' })
   })
 
-  it('undefined for a missing/blank header (interactive case)', () => {
-    expect(resolveInboxOrigin(undefined, () => svc({}) as any)).toBeUndefined()
-    expect(resolveInboxOrigin('   ', () => svc({}) as any)).toBeUndefined()
+  it('undefined for a missing/blank run header (no session either)', () => {
+    expect(resolveInboxOrigin({}, () => svc() as any)).toBeUndefined()
+    expect(resolveInboxOrigin({ run: '   ' }, () => svc() as any)).toBeUndefined()
   })
 
   it('undefined for an unknown run id (no fabricated link)', () => {
-    expect(resolveInboxOrigin('ghost', () => svc({}) as any)).toBeUndefined()
+    expect(resolveInboxOrigin({ run: 'ghost' }, () => svc() as any)).toBeUndefined()
   })
 
   it('undefined when the workspace service is not up yet', () => {
-    expect(resolveInboxOrigin('run-7', () => null)).toBeUndefined()
+    expect(resolveInboxOrigin({ run: 'run-7' }, () => null)).toBeUndefined()
+  })
+})
+
+describe('resolveInboxOrigin — interactive (Phase 2)', () => {
+  it('builds an interactive origin from a valid session header (validated against the registry)', () => {
+    const origin = resolveInboxOrigin({ session: 'sess-1', wsId: 'ws1' }, () =>
+      svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+    )
+    expect(origin).toEqual({ kind: 'interactive', sessionId: 'sess-1', agent: 'codex' })
+  })
+
+  it('undefined for an unknown/forged session id (no fabricated link)', () => {
+    expect(
+      resolveInboxOrigin({ session: 'forged', wsId: 'ws1' }, () =>
+        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+      ),
+    ).toBeUndefined()
+  })
+
+  it('undefined when the session belongs to a different workspace (wsId-scoped lookup)', () => {
+    // The id exists, but not under the route's wsId — the authority is scoped.
+    expect(
+      resolveInboxOrigin({ session: 'sess-1', wsId: 'ws2' }, () =>
+        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+      ),
+    ).toBeUndefined()
+  })
+
+  it('undefined when the session header is present but wsId is missing', () => {
+    expect(
+      resolveInboxOrigin({ session: 'sess-1' }, () =>
+        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+      ),
+    ).toBeUndefined()
+  })
+
+  it('undefined when the workspace service is not up yet', () => {
+    expect(resolveInboxOrigin({ session: 'sess-1', wsId: 'ws1' }, () => null)).toBeUndefined()
+  })
+})
+
+describe('resolveInboxOrigin — precedence + both-absent', () => {
+  it('a resolvable run header wins over a present session header', () => {
+    const origin = resolveInboxOrigin({ run: 'run-7', session: 'sess-1', wsId: 'ws1' }, () =>
+      svc({
+        headless: { 'run-7': { taskId: 'run-7', issueId: 'macro', agent: 'claude' } },
+        sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } },
+      }) as any,
+    )
+    expect(origin).toEqual({ kind: 'headless', runId: 'run-7', issueId: 'macro', agent: 'claude' })
+  })
+
+  it('falls through to the session header when the run id is unknown', () => {
+    const origin = resolveInboxOrigin({ run: 'ghost', session: 'sess-1', wsId: 'ws1' }, () =>
+      svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+    )
+    expect(origin).toEqual({ kind: 'interactive', sessionId: 'sess-1', agent: 'codex' })
+  })
+
+  it('undefined when both headers are absent (manual case)', () => {
+    expect(resolveInboxOrigin({ wsId: 'ws1' }, () => svc() as any)).toBeUndefined()
   })
 })

--- a/src/server/inbox-origin.ts
+++ b/src/server/inbox-origin.ts
@@ -1,51 +1,108 @@
 /**
- * Shared `x-openalice-run` → {@link InboxOrigin} resolver for the two
- * workspace-scoped route mounts (`/mcp/:wsId` and `/cli/:wsId/:export/invoke`).
+ * Shared header → {@link InboxOrigin} resolver for the two workspace-scoped
+ * route mounts (`/mcp/:wsId` and `/cli/:wsId/:export/invoke`).
  *
- * Both routes read the SAME out-of-band header and resolve it the SAME way, so
- * the resolution lives here once — they can't drift. The header is the only
- * carrier of run identity; it's injected at spawn (AQ_RUN_ID, headless only),
- * forwarded by OpenAlice-owned transport (the `alice` CLI shim / a native-MCP
- * static header), and NEVER supplied by the agent in a tool call.
+ * Both routes read the SAME out-of-band headers and resolve them the SAME way,
+ * so the resolution lives here once — they can't drift. There are two carriers,
+ * mutually exclusive per spawn:
  *
- * Authority is the {@link HeadlessTaskRegistry}, not the request: we look the
- * run up by taskId and read `issueId` / `agent` off the stored record. A header
- * that doesn't match a known run resolves to `undefined` (no origin) — so a
- * forged or stale value can't fabricate a link.
+ *   - `x-openalice-run`     — HEADLESS run identity. Injected as `AQ_RUN_ID`
+ *                             (the run's taskId) into the headless spawn env;
+ *                             resolved against the {@link HeadlessTaskRegistry}.
+ *   - `x-openalice-session` — INTERACTIVE session identity. Injected as
+ *                             `AQ_SESSION_ID` (the pre-allocated SessionRegistry
+ *                             record id) into the interactive PTY spawn env;
+ *                             resolved against the SessionRegistry, scoped by the
+ *                             route's wsId.
+ *
+ * Both are forwarded by OpenAlice-owned transport (the `alice` CLI shim / a
+ * native-MCP static header) and NEVER supplied by the agent in a tool call — the
+ * agent never traffics its own identity (symmetric for both kinds).
+ *
+ * Authority is the registry, not the request: we look the id up and read the
+ * provenance off the STORED record. A header that doesn't match a known record
+ * resolves to `undefined` (no origin) — so a forged or stale value can't
+ * fabricate a link, for either kind.
+ *
+ * Precedence: a resolvable run header wins (headless is the authoritative
+ * automation path); only when there's no headless run do we consider the
+ * session header.
  */
 
 import type { InboxOrigin } from '../core/inbox-store.js'
 
-/** Minimal structural view of the bits this resolver needs — kept structural so
+/** Minimal structural views of the bits this resolver needs — kept structural so
  *  the server layer doesn't hard-depend on the workspaces/ module shapes. */
 interface HeadlessRecordLike {
   readonly taskId: string
   readonly issueId?: string
   readonly agent: string
 }
+interface SessionRecordLike {
+  readonly id: string
+  readonly wsId: string
+  readonly agent: string
+}
 interface WorkspaceServiceLike {
   headlessTasks: { get(taskId: string): HeadlessRecordLike | null }
+  /** Synchronous in-memory lookup of a live session record (already loaded —
+   *  the session is running because its agent is the one calling inbox_push). */
+  sessionRegistry: { get(wsId: string, id: string): SessionRecordLike | undefined }
+}
+
+/** The out-of-band header trio a workspace-scoped route reads off the request. */
+export interface InboxOriginHeaders {
+  /** `x-openalice-run` — headless run identity (taskId). */
+  run?: string
+  /** `x-openalice-session` — interactive session identity (record id). */
+  session?: string
+  /** The workspace id from the route path — scopes the session lookup. */
+  wsId?: string
 }
 
 /**
- * Resolve the `x-openalice-run` header value to an {@link InboxOrigin}.
+ * Resolve the request's origin headers to an {@link InboxOrigin}.
  *
- * Returns `undefined` when there is no header, the workspace service isn't up,
- * or the run id matches no record — in all those cases the push simply carries
- * no origin (the interactive / manual case).
+ * Returns `undefined` when there is no resolvable header, the workspace service
+ * isn't up, or no id matches a record — in all those cases the push simply
+ * carries no origin (the manual case).
  */
 export function resolveInboxOrigin(
-  runHeader: string | undefined,
+  headers: InboxOriginHeaders,
   getWorkspaceService: () => WorkspaceServiceLike | null,
 ): InboxOrigin | undefined {
-  const runId = runHeader?.trim()
-  if (!runId) return undefined
-  const rec = getWorkspaceService()?.headlessTasks.get(runId) ?? null
-  if (!rec) return undefined
-  return {
-    kind: 'headless',
-    runId: rec.taskId,
-    ...(rec.issueId ? { issueId: rec.issueId } : {}),
-    ...(rec.agent ? { agent: rec.agent } : {}),
+  const svc = getWorkspaceService()
+
+  // 1) HEADLESS — a resolvable run header always wins (the automation path).
+  const runId = headers.run?.trim()
+  if (runId) {
+    const rec = svc?.headlessTasks.get(runId) ?? null
+    if (rec) {
+      return {
+        kind: 'headless',
+        runId: rec.taskId,
+        ...(rec.issueId ? { issueId: rec.issueId } : {}),
+        ...(rec.agent ? { agent: rec.agent } : {}),
+      }
+    }
+    // A present-but-unknown run id falls through to the session header rather
+    // than fabricating a link — symmetric with the unknown-session case below.
   }
+
+  // 2) INTERACTIVE — validate the session id against the SessionRegistry
+  //    (authority, scoped by the route's wsId). A forged/unknown id → undefined.
+  const sessionId = headers.session?.trim()
+  const wsId = headers.wsId?.trim()
+  if (sessionId && wsId && svc) {
+    const rec = svc.sessionRegistry.get(wsId, sessionId)
+    if (rec) {
+      return {
+        kind: 'interactive',
+        sessionId: rec.id,
+        ...(rec.agent ? { agent: rec.agent } : {}),
+      }
+    }
+  }
+
+  return undefined
 }

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -130,7 +130,7 @@ export class McpPlugin implements Plugin {
     app.use('*', cors({
       origin: '*',
       allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
-      allowHeaders: ['Content-Type', 'mcp-session-id', 'Last-Event-ID', 'mcp-protocol-version', 'x-openalice-run'],
+      allowHeaders: ['Content-Type', 'mcp-session-id', 'Last-Event-ID', 'mcp-protocol-version', 'x-openalice-run', 'x-openalice-session'],
       exposeHeaders: ['mcp-session-id', 'mcp-protocol-version'],
     }))
 
@@ -152,10 +152,19 @@ export class McpPlugin implements Plugin {
       const meta = svc.registry.get(wsId)
       if (!meta) return c.text('unknown workspace', 404)
 
-      // Out-of-band run identity (agent never sees it): the spawn-injected
-      // AQ_RUN_ID rides this header from native-MCP server config, resolved
-      // server-side to an authoritative origin and baked into the tools.
-      const origin = resolveInboxOrigin(c.req.header('x-openalice-run'), getWorkspaceService)
+      // Out-of-band identity (agent never sees it): the spawn-injected AQ_RUN_ID
+      // (headless) / AQ_SESSION_ID (interactive) rides these mutually-exclusive
+      // headers, resolved server-side to an authoritative origin and baked into
+      // the tools. The session header is validated against THIS workspace's
+      // session registry.
+      const origin = resolveInboxOrigin(
+        {
+          run: c.req.header('x-openalice-run'),
+          session: c.req.header('x-openalice-session'),
+          wsId: meta.id,
+        },
+        getWorkspaceService,
+      )
 
       const transport = new WebStandardStreamableHTTPServerTransport()
       const mcp = createWorkspaceMcpServer(meta.id, meta.tag, origin)

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -213,6 +213,27 @@ describe('opencodeAdapter AI-config', () => {
     });
   });
 
+  it('stamps x-openalice-run on the workspace server when AQ_RUN_ID is present (headless)', () => {
+    const env = opencodeAdapter.composeEnv!({ cwd: dir, env: { ...mcpEnv, AQ_RUN_ID: 'run-7' } });
+    const cfg = JSON.parse(env['OPENCODE_CONFIG_CONTENT']!);
+    expect(cfg.mcp['openalice-workspace'].headers).toEqual({ 'x-openalice-run': 'run-7' });
+    // never on the global server
+    expect(cfg.mcp.openalice.headers).toBeUndefined();
+  });
+
+  it('stamps x-openalice-session on the workspace server when AQ_SESSION_ID is present (interactive)', () => {
+    const env = opencodeAdapter.composeEnv!({ cwd: dir, env: { ...mcpEnv, AQ_SESSION_ID: 'rec-9' } });
+    const cfg = JSON.parse(env['OPENCODE_CONFIG_CONTENT']!);
+    expect(cfg.mcp['openalice-workspace'].headers).toEqual({ 'x-openalice-session': 'rec-9' });
+    expect(cfg.mcp.openalice.headers).toBeUndefined();
+  });
+
+  it('run header wins when both are present (mutually exclusive, matching the shim)', () => {
+    const env = opencodeAdapter.composeEnv!({ cwd: dir, env: { ...mcpEnv, AQ_RUN_ID: 'run-7', AQ_SESSION_ID: 'rec-9' } });
+    const cfg = JSON.parse(env['OPENCODE_CONFIG_CONTENT']!);
+    expect(cfg.mcp['openalice-workspace'].headers).toEqual({ 'x-openalice-run': 'run-7' });
+  });
+
   it('composeEnv throws loud when MCP url is missing from spawn env', () => {
     expect(() => opencodeAdapter.composeEnv!({ cwd: dir, env: {} })).toThrow(/OPENALICE_MCP_URL/);
   });

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -143,20 +143,28 @@ export const opencodeAdapter: CliAdapter = {
     if (!workspaceId) {
       throw new Error('opencode adapter: AQ_WS_ID missing from spawn env');
     }
-    // Agent-INVISIBLE run identity: on a HEADLESS spawn the launcher injects
-    // AQ_RUN_ID into the env (interactive spawns never carry it). opencode's
-    // remote-MCP config supports a static `headers` map, so we stamp the run id
+    // Agent-INVISIBLE origin identity: a spawn carries AQ_RUN_ID XOR
+    // AQ_SESSION_ID — a HEADLESS spawn injects AQ_RUN_ID (the run's taskId),
+    // an INTERACTIVE spawn injects AQ_SESSION_ID (the pre-allocated
+    // SessionRegistry record id); a probe carries neither. opencode's
+    // remote-MCP config supports a static `headers` map, so we stamp the id
     // onto the workspace server entry — the server then resolves the entry's
-    // origin from it. This is spawn-time server config, NOT a tool argument, so
-    // the agent never sees or supplies it. Only on `openalice-workspace` (the
+    // origin from it. This is the native-MCP twin of the `alice` CLI shim's
+    // header forwarding: spawn-time server config, NOT a tool argument, so the
+    // agent never sees or supplies it. Only on `openalice-workspace` (the
     // scoped surface that owns inbox_push); the global `openalice` server has no
-    // per-run identity.
+    // per-spawn identity. Mutually exclusive headers, matching the shim.
     const runId = ctx.env['AQ_RUN_ID'];
+    const sessionId = ctx.env['AQ_SESSION_ID'];
     const wsServer: Record<string, unknown> = {
       type: 'remote',
       url: `${mcpUrl}/${workspaceId}`,
       enabled: true,
-      ...(runId ? { headers: { 'x-openalice-run': runId } } : {}),
+      ...(runId
+        ? { headers: { 'x-openalice-run': runId } }
+        : sessionId
+          ? { headers: { 'x-openalice-session': sessionId } }
+          : {}),
     };
     const inline = {
       mcp: {

--- a/src/workspaces/cli/bin/alice
+++ b/src/workspaces/cli/bin/alice
@@ -81,14 +81,17 @@ async function manifest(base) {
 }
 
 async function invoke(base, tool, args) {
-  // Agent-invisible run identity: the launcher injects AQ_RUN_ID into the
-  // HEADLESS spawn env only (mirrors how it injects AQ_WS_ID for the path).
-  // Forward it out-of-band as a header — NOT in the tool args, NOT in the path —
-  // so the gateway can server-side-resolve the entry's origin without the agent
-  // ever trafficking its own run identity. Absent on interactive spawns.
+  // Agent-invisible identity, forwarded out-of-band as a header — NOT in the
+  // tool args, NOT in the path — so the gateway can server-side-resolve the
+  // entry's origin without the agent ever trafficking its own identity. The
+  // launcher injects exactly one per spawn (mirrors how it injects AQ_WS_ID for
+  // the path): AQ_RUN_ID on a HEADLESS spawn, AQ_SESSION_ID on an INTERACTIVE
+  // one. So at most one of these headers is ever sent.
   const headers = { 'Content-Type': 'application/json' }
   const runId = process.env.AQ_RUN_ID
   if (runId) headers['x-openalice-run'] = runId
+  const sessionId = process.env.AQ_SESSION_ID
+  if (sessionId) headers['x-openalice-session'] = sessionId
   const r = await fetchJson(base + '/invoke', {
     method: 'POST',
     headers,

--- a/src/workspaces/cli/bin/alice-uta
+++ b/src/workspaces/cli/bin/alice-uta
@@ -81,14 +81,17 @@ async function manifest(base) {
 }
 
 async function invoke(base, tool, args) {
-  // Agent-invisible run identity: the launcher injects AQ_RUN_ID into the
-  // HEADLESS spawn env only (mirrors how it injects AQ_WS_ID for the path).
-  // Forward it out-of-band as a header — NOT in the tool args, NOT in the path —
-  // so the gateway can server-side-resolve the entry's origin without the agent
-  // ever trafficking its own run identity. Absent on interactive spawns.
+  // Agent-invisible identity, forwarded out-of-band as a header — NOT in the
+  // tool args, NOT in the path — so the gateway can server-side-resolve the
+  // entry's origin without the agent ever trafficking its own identity. The
+  // launcher injects exactly one per spawn (mirrors how it injects AQ_WS_ID for
+  // the path): AQ_RUN_ID on a HEADLESS spawn, AQ_SESSION_ID on an INTERACTIVE
+  // one. So at most one of these headers is ever sent.
   const headers = { 'Content-Type': 'application/json' }
   const runId = process.env.AQ_RUN_ID
   if (runId) headers['x-openalice-run'] = runId
+  const sessionId = process.env.AQ_SESSION_ID
+  if (sessionId) headers['x-openalice-session'] = sessionId
   const r = await fetchJson(base + '/invoke', {
     method: 'POST',
     headers,

--- a/src/workspaces/cli/bin/alice-workspace
+++ b/src/workspaces/cli/bin/alice-workspace
@@ -81,14 +81,17 @@ async function manifest(base) {
 }
 
 async function invoke(base, tool, args) {
-  // Agent-invisible run identity: the launcher injects AQ_RUN_ID into the
-  // HEADLESS spawn env only (mirrors how it injects AQ_WS_ID for the path).
-  // Forward it out-of-band as a header — NOT in the tool args, NOT in the path —
-  // so the gateway can server-side-resolve the entry's origin without the agent
-  // ever trafficking its own run identity. Absent on interactive spawns.
+  // Agent-invisible identity, forwarded out-of-band as a header — NOT in the
+  // tool args, NOT in the path — so the gateway can server-side-resolve the
+  // entry's origin without the agent ever trafficking its own identity. The
+  // launcher injects exactly one per spawn (mirrors how it injects AQ_WS_ID for
+  // the path): AQ_RUN_ID on a HEADLESS spawn, AQ_SESSION_ID on an INTERACTIVE
+  // one. So at most one of these headers is ever sent.
   const headers = { 'Content-Type': 'application/json' }
   const runId = process.env.AQ_RUN_ID
   if (runId) headers['x-openalice-run'] = runId
+  const sessionId = process.env.AQ_SESSION_ID
+  if (sessionId) headers['x-openalice-session'] = sessionId
   const r = await fetchJson(base + '/invoke', {
     method: 'POST',
     headers,

--- a/src/workspaces/cli/bin/traderhub
+++ b/src/workspaces/cli/bin/traderhub
@@ -81,14 +81,17 @@ async function manifest(base) {
 }
 
 async function invoke(base, tool, args) {
-  // Agent-invisible run identity: the launcher injects AQ_RUN_ID into the
-  // HEADLESS spawn env only (mirrors how it injects AQ_WS_ID for the path).
-  // Forward it out-of-band as a header — NOT in the tool args, NOT in the path —
-  // so the gateway can server-side-resolve the entry's origin without the agent
-  // ever trafficking its own run identity. Absent on interactive spawns.
+  // Agent-invisible identity, forwarded out-of-band as a header — NOT in the
+  // tool args, NOT in the path — so the gateway can server-side-resolve the
+  // entry's origin without the agent ever trafficking its own identity. The
+  // launcher injects exactly one per spawn (mirrors how it injects AQ_WS_ID for
+  // the path): AQ_RUN_ID on a HEADLESS spawn, AQ_SESSION_ID on an INTERACTIVE
+  // one. So at most one of these headers is ever sent.
   const headers = { 'Content-Type': 'application/json' }
   const runId = process.env.AQ_RUN_ID
   if (runId) headers['x-openalice-run'] = runId
+  const sessionId = process.env.AQ_SESSION_ID
+  if (sessionId) headers['x-openalice-session'] = sessionId
   const r = await fetchJson(base + '/invoke', {
     method: 'POST',
     headers,

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -318,11 +318,15 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     adapter: CliAdapter,
     resume: SessionFactoryContext['resume'],
     initialPrompt?: string,
-    // Per-spawn env on TOP of the shared base — used ONLY by the headless path to
-    // inject AQ_RUN_ID (the run's taskId). Deliberately a param, NOT folded into
-    // baseEnv: interactive/probe spawns must NOT carry a run identity, and merging
-    // it before adapter.composeEnv() lets an MCP-config adapter (opencode) read it
-    // and emit the out-of-band header.
+    // Per-spawn env on TOP of the shared base — the identity-injection seam.
+    // Two MUTUALLY-EXCLUSIVE uses (a spawn carries AQ_RUN_ID XOR AQ_SESSION_ID):
+    //   - the headless path injects AQ_RUN_ID (the run's taskId);
+    //   - the interactive POOL factory injects AQ_SESSION_ID (the pre-allocated
+    //     SessionRegistry record id).
+    // Deliberately a param, NOT folded into baseEnv: the probe spawn must carry
+    // NEITHER, and the two live spawns each carry exactly one. Merging it before
+    // adapter.composeEnv() lets an MCP-config adapter (opencode) read it and emit
+    // the matching out-of-band header.
     extraEnv?: Record<string, string>,
   ): {
     command: readonly string[];
@@ -745,6 +749,15 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         // Seed only on a genuinely fresh spawn (not a resume that an id-assigning
         // adapter rewrote into a `{ sessionId }` intent).
         isFresh ? ctx.initialPrompt : undefined,
+        // INTERACTIVE-only session identity: the pre-allocated SessionRegistry
+        // record id (= what the pool keys by). Mirrors the headless path's
+        // AQ_RUN_ID, but injected HERE in the pool factory — the sole interactive
+        // PTY-spawn seam. The headless dispatch and the offline probe call
+        // composeSpawnInputs directly (NOT through the pool), so neither ever
+        // carries AQ_SESSION_ID; a spawn carries AQ_RUN_ID XOR AQ_SESSION_ID. The
+        // `alice` shim forwards it as the `x-openalice-session` header, resolved
+        // server-side against the session registry — agent never sees it.
+        { AQ_SESSION_ID: ctx.recordId },
       );
 
       // path.trace — single line capturing every path the spawn touches. The

--- a/ui/src/api/inbox.ts
+++ b/ui/src/api/inbox.ts
@@ -13,10 +13,11 @@ export interface InboxDoc {
  * cross-references on — an inbox card → its originating run/issue, an issue
  * detail → the inbox reports it produced.
  *
- * First cut is issue/run-level, headless only (`kind:'headless'`): `runId` is
- * set for every dispatched run, `issueId` when a scheduled issue fired it,
- * `agent` from the run record. `sessionId` + `kind:'interactive'` are reserved
- * for Phase 2. Absent on interactive/manual pushes → `origin` is undefined.
+ * Two live kinds: `kind:'headless'` (a dispatched run — `runId` always, `issueId`
+ * when a scheduled issue fired it) and `kind:'interactive'` (a human-attended
+ * session — `sessionId`, the pre-allocated record id, navigable to that session
+ * tab). `agent` (claude/codex/…) comes off the authoritative record in both.
+ * Absent on manual pushes that carried no header → `origin` is undefined.
  */
 export type InboxOriginKind = 'headless' | 'interactive' | 'manual'
 
@@ -26,7 +27,7 @@ export interface InboxOrigin {
   runId?: string
   /** The scheduled issue that fired the run, when applicable (filename stem). */
   issueId?: string
-  /** Reserved for Phase 2 interactive sessions (pre-allocated record id). */
+  /** The interactive session's pre-allocated record id (navigable to its tab). */
   sessionId?: string
   /** The agent CLI id (claude/codex/…) from the run record. */
   agent?: string

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatRelativeTime, getIntlLocale } from '../lib/intl'
-import { ArrowRight, Bot, ChevronRight, ListChecks, MessageSquare, Trash2 } from 'lucide-react'
+import { ArrowRight, Bot, ChevronRight, ListChecks, MessageSquare, Terminal, Trash2 } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { FileContentView } from '../components/FileContentView'
@@ -155,6 +155,10 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
   // (there's no per-run detail surface to open).
   const origin = entry.origin
   const issueId = origin?.issueId
+  // Interactive provenance — the human-attended session this push came from
+  // (server-stamped from AQ_SESSION_ID, validated against the session registry).
+  // Navigable: opens/focuses that exact session tab.
+  const sessionId = origin?.kind === 'interactive' ? origin.sessionId : undefined
   // Resolve the issue id (a filename stem) to its display title via the warm,
   // process-cached board snapshot — a cheap path (no extra fetch on the hot
   // line). Falls back to the stem when the board hasn't resolved it.
@@ -178,6 +182,16 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
     if (!issueId) return
     setSidebar('issue')
     openOrFocus({ kind: 'issue-detail', params: { wsId: entry.workspaceId, id: issueId } })
+  }
+
+  // Jump to the originating interactive session — reuses the same
+  // workspace-tab open/focus wiring as the reply bar, pinned to the session id
+  // (WorkspaceView focuses the matching session record). Switch the sidebar to
+  // Workspaces so the sessions list shows alongside the tab.
+  const openSession = () => {
+    if (!wsAlive || !sessionId) return
+    setSidebar('workspaces')
+    openOrFocus({ kind: 'workspace', params: { wsId: entry.workspaceId, sessionId } })
   }
 
   return (
@@ -204,6 +218,17 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
           >
             <ListChecks size={12} strokeWidth={1.75} className="shrink-0" />
             <span className="truncate max-w-[220px]">from {issueTitle ?? issueId}</span>
+          </button>
+        ) : sessionId ? (
+          <button
+            type="button"
+            onClick={openSession}
+            disabled={!wsAlive}
+            title={`From session ${sessionId}`}
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-text-muted/80 hover:text-accent hover:bg-accent/10 transition-colors disabled:opacity-50 disabled:hover:text-text-muted/80 disabled:hover:bg-transparent disabled:cursor-default"
+          >
+            <Terminal size={12} strokeWidth={1.75} className="shrink-0" />
+            <span className="truncate max-w-[220px]">from session{origin?.agent ? ` · ${origin.agent}` : ''}</span>
           </button>
         ) : origin?.runId ? (
           <span


### PR DESCRIPTION
## Summary

- **Phase 2 of inbox origin** — an interactive (human-attended) session's `inbox_push` now stamps `origin {kind:'interactive', sessionId, agent}`, symmetric with the shipped headless path. Every inbox entry now knows its source, and an interactive entry can jump to the exact originating session.
- Mechanism (mirrors Phase 1; the agent never traffics its own identity): the pre-allocated `SessionRegistry` record id is injected as `AQ_SESSION_ID` into the **interactive PTY spawn only** (the pool factory — headless dispatch and the offline probe bypass the pool, so a spawn carries `AQ_RUN_ID` **XOR** `AQ_SESSION_ID`). The `alice` CLI shim (+3 byte-identical copies) and the opencode native-MCP twin forward it as an `x-openalice-session` header. `resolveInboxOrigin` validates it against the `SessionRegistry` scoped by the route's `wsId` (the run header still wins; a forged/unknown id → no origin), so origin is bound server-side from the authoritative record.
- UI: a "from session" breadcrumb on interactive inbox entries reuses the existing `openOrFocus` workspace-tab wiring to focus that session.

## Test plan
- [x] `npx tsc --noEmit` clean (root)
- [x] `cd ui && npx tsc -b` clean
- [x] `pnpm test` — 2164 passed / 150 files / 0 failures
- [x] master in sync (0 behind) before push

## Boundary touch
- None. `inbox_push` schema and the `InboxOrigin` shape are unchanged (`sessionId`/`kind:'interactive'` were already reserved) → **no migration**. No trading / auth / broker-credential paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
