### PR TITLE
feat(uta): add INDstocks (INDmoney) broker adapter — Indian equities

### DIFF
--- a/packages/uta-protocol/src/brokers/preset-catalog.ts
+++ b/packages/uta-protocol/src/brokers/preset-catalog.ts
@@ -15,7 +15,7 @@ import { createHash, randomBytes } from 'node:crypto'
 
 // ==================== Types ====================
 
-export type BrokerEngine = 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'mock'
+export type BrokerEngine = 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'indstocks' | 'mock'
 
 export interface ModeOption {
   id: string
@@ -432,6 +432,39 @@ export const LONGBRIDGE_PRESET: BrokerPresetDef = {
   isPaper: (d) => d.mode === 'paper',
 }
 
+export const INDSTOCKS_PRESET: BrokerPresetDef = {
+  id: 'indstocks',
+  label: 'INDmoney (Indian Equities)',
+  description: 'INDstocks API — NSE / BSE equities. Live only (no paper). Equity-first; F&O is on the roadmap.',
+  category: 'recommended',
+  // The `accessToken` is the SEBI-mandated daily secret: it expires every 24h
+  // and has NO refresh endpoint — you regenerate it from web.indstocks.com → API
+  // and paste a fresh one each session. `userId` is the STABLE identity we
+  // fingerprint on: fingerprinting the token would mint a new UTA id (orphaning
+  // the commit log) on every rotation. There is no sandbox — orders are live.
+  hint: 'INDstocks tokens **expire every 24h** and cannot be auto-refreshed. Regenerate at web.indstocks.com → API and update **Access Token** each session. **Client ID** is your stable INDstocks account id (from your profile). ⚠️ No paper/sandbox — every order is real money; test with tiny quantities. ⚠️ **Selling holdings via API needs DDPI active** (CDSL eDIS) in your INDmoney account — without it, sell orders fail with a generic server error.',
+  defaultName: 'indstocks-main',
+  badge: 'IN',
+  badgeColor: 'text-accent',
+  engine: 'indstocks',
+  guardCategory: 'securities',
+  zodSchema: z.object({
+    userId: z.string().min(1).describe('Client ID'),
+    accessToken: z.string().min(1).describe('Access Token'),
+  }),
+  subtitleFields: [
+    { field: 'userId', prefix: 'INDmoney · ' },
+  ],
+  writeOnlyFields: ['accessToken'],
+  // Fingerprint on the STABLE userId, never the daily token.
+  fingerprintFields: ['userId'],
+  toEngineConfig: (d) => ({
+    userId: d.userId,
+    accessToken: d.accessToken,
+  }),
+  isPaper: () => false,   // no paper environment exists
+}
+
 // ==================== Other ecosystem brokers (lower-tier, isolated) ====================
 
 export const LEVERUP_PRESET: BrokerPresetDef = {
@@ -508,6 +541,7 @@ export const BROKER_PRESET_CATALOG: BrokerPresetDef[] = [
   IBKR_PRESET,
   ALPACA_PRESET,
   LONGBRIDGE_PRESET,
+  INDSTOCKS_PRESET,
   HYPERLIQUID_PRESET,
   // ---- Crypto ----
   BINANCE_PRESET,

--- a/packages/uta-protocol/src/brokers/presets.ts
+++ b/packages/uta-protocol/src/brokers/presets.ts
@@ -11,7 +11,7 @@
  */
 
 import { z } from 'zod'
-import { BROKER_PRESET_CATALOG, type BrokerPresetDef, type ModeOption, type SubtitleSegment } from './preset-catalog.js'
+import { BROKER_PRESET_CATALOG, type BrokerEngine, type BrokerPresetDef, type ModeOption, type SubtitleSegment } from './preset-catalog.js'
 
 // ==================== Serialized shape (sent to frontend) ====================
 
@@ -24,7 +24,7 @@ export interface SerializedBrokerPreset {
   defaultName: string
   badge: string
   badgeColor: string
-  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'mock'
+  engine: BrokerEngine
   guardCategory: 'crypto' | 'securities'
   modes?: ModeOption[]
   subtitleFields: SubtitleSegment[]

--- a/services/uta/src/domain/trading/brokers/index.ts
+++ b/services/uta/src/domain/trading/brokers/index.ts
@@ -44,3 +44,7 @@ export type { CcxtBrokerConfig } from './ccxt/index.js'
 // IBKR
 export { IbkrBroker } from './ibkr/index.js'
 export type { IbkrBrokerConfig } from './ibkr/index.js'
+
+// INDstocks (INDmoney — Indian equities)
+export { IndstocksBroker } from './indstocks/index.js'
+export type { IndstocksBrokerConfig } from './indstocks/index.js'

--- a/services/uta/src/domain/trading/brokers/indstocks/IndstocksBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/indstocks/IndstocksBroker.spec.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Decimal from 'decimal.js'
+import { Contract, Order } from '@traderalice/ibkr'
+import { IndstocksBroker } from './IndstocksBroker.js'
+import { makeContract } from './indstocks-contracts.js'
+import { BrokerError } from '../types.js'
+import type { IndstocksInstrument } from './indstocks-types.js'
+import '../../contract-ext.js'
+
+// ==================== IndstocksClient mock ====================
+// init() constructs `new IndstocksClient(token)` internally, so the module is
+// mocked. Method-level tests bypass init() and inject a plain fake into
+// (broker as any).client + (broker as any).catalog instead.
+
+vi.mock('./indstocks-client.js', () => {
+  const IndstocksClient = vi.fn(function (this: any) {
+    this.getProfile = vi.fn().mockResolvedValue({ status: 'success' })
+    this.getInstruments = vi.fn().mockResolvedValue([])
+    this.getFunds = vi.fn()
+    this.getHoldings = vi.fn()
+    this.getPositions = vi.fn()
+    this.placeOrder = vi.fn()
+    this.modifyOrder = vi.fn()
+    this.cancelOrder = vi.fn()
+    this.getOrder = vi.fn()
+    this.getOrderBook = vi.fn()
+    this.getQuotes = vi.fn()
+    this.getHistorical = vi.fn()
+    this.setToken = vi.fn()
+  })
+  return { IndstocksClient }
+})
+
+// ==================== ws mock (controllable fake socket) ====================
+
+vi.mock('ws', () => {
+  class FakeWS {
+    static instances: FakeWS[] = []
+    handlers: Record<string, Array<(...a: any[]) => void>> = {}
+    sent: string[] = []
+    constructor(public url: string, public opts: any) { FakeWS.instances.push(this) }
+    on(ev: string, cb: (...a: any[]) => void) { (this.handlers[ev] ??= []).push(cb); return this }
+    send(d: string) { this.sent.push(d) }
+    close() { this.emit('close') }
+    emit(ev: string, ...args: any[]) { (this.handlers[ev] ?? []).forEach(h => h(...args)) }
+  }
+  return { default: FakeWS }
+})
+
+// Catalog with one NSE equity (RELIANCE → security_id 2885).
+const RELIANCE: IndstocksInstrument = {
+  securityId: '2885',
+  tradingSymbol: 'RELIANCE',
+  exch: 'NSE',
+  segment: 'E',
+  instrumentName: 'EQUITY',
+  customSymbol: 'Reliance Industries',
+}
+const catalog = () => new Map<string, IndstocksInstrument>([['NSE:RELIANCE', RELIANCE]])
+
+function broker() {
+  return new IndstocksBroker({ accessToken: 'tok', userId: 'CLIENT1' })
+}
+
+// ==================== init() ====================
+
+describe('IndstocksBroker — init()', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('throws CONFIG when no access token is configured', async () => {
+    const b = new IndstocksBroker({ accessToken: '', userId: 'CLIENT1' })
+    await expect(b.init()).rejects.toThrow('No INDstocks access token')
+  })
+
+  it('resolves when the token probe (getProfile) succeeds', async () => {
+    const b = broker()
+    await expect(b.init()).resolves.toBeUndefined()
+  })
+
+  it('HALTS immediately on a 403/AUTH token error — no retries (daily-token wall)', async () => {
+    const b = broker()
+    const { IndstocksClient } = await import('./indstocks-client.js')
+    const getProfile = vi.fn().mockRejectedValue(
+      new BrokerError('AUTH', 'INDstocks access token expired or invalid.'),
+    )
+    ;(IndstocksClient as any).mockImplementationOnce(function (this: any) {
+      this.getProfile = getProfile
+      this.getInstruments = vi.fn().mockResolvedValue([])
+    })
+    await expect(b.init()).rejects.toThrow(/token expired or invalid/i)
+    // Permanent AUTH error must NOT be retried — exactly one probe.
+    expect(getProfile).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transient (non-permanent) error before giving up', async () => {
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: any) => { fn(); return 0 as any })
+    const b = broker()
+    const { IndstocksClient } = await import('./indstocks-client.js')
+    const getProfile = vi.fn().mockRejectedValue(new Error('network blip'))
+    ;(IndstocksClient as any).mockImplementationOnce(function (this: any) {
+      this.getProfile = getProfile
+      this.getInstruments = vi.fn().mockResolvedValue([])
+    })
+    await expect(b.init()).rejects.toThrow('network blip')
+    expect(getProfile.mock.calls.length).toBeGreaterThan(1)
+  })
+})
+
+// ==================== searchContracts() ====================
+
+describe('IndstocksBroker — searchContracts()', () => {
+  it('returns [] for an empty pattern', async () => {
+    expect(await broker().searchContracts('')).toEqual([])
+  })
+
+  it('echoes an uppercased contract when the catalog has not loaded', async () => {
+    const results = await broker().searchContracts('reliance')
+    expect(results).toHaveLength(1)
+    expect(results[0].contract.symbol).toBe('RELIANCE')
+  })
+
+  it('fuzzy-matches against a loaded catalog', async () => {
+    const b = broker()
+    ;(b as any).catalog = catalog()
+    const results = await b.searchContracts('RELIANCE')
+    expect(results.some(r => r.contract.symbol === 'RELIANCE')).toBe(true)
+  })
+})
+
+// ==================== placeOrder() ====================
+
+describe('IndstocksBroker — placeOrder()', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  function armed() {
+    const b = broker()
+    const placeOrder = vi.fn().mockResolvedValue({
+      status: 'success',
+      data: { order_id: 'DRV-1', order_status: 'O-PENDING' },
+    })
+    ;(b as any).client = { placeOrder }
+    ;(b as any).catalog = catalog()
+    return { b, placeOrder }
+  }
+
+  it('maps a LIMIT order to the INDstocks body and returns the order id', async () => {
+    const { b, placeOrder } = armed()
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal(10)
+    order.lmtPrice = new Decimal('1450.5')
+    order.tif = 'DAY'
+
+    const res = await b.placeOrder(makeContract('RELIANCE'), order)
+    expect(res.success).toBe(true)
+    expect(res.orderId).toBe('DRV-1')
+    expect(placeOrder).toHaveBeenCalledWith(expect.objectContaining({
+      txn_type: 'BUY',
+      exchange: 'NSE',
+      segment: 'EQUITY',
+      order_type: 'LIMIT',
+      validity: 'DAY',
+      security_id: '2885',
+      qty: 10,
+      algo_id: '99999',
+      limit_price: 1450.5,
+    }))
+  })
+
+  it('maps a MARKET order with no limit_price', async () => {
+    const { b, placeOrder } = armed()
+    const order = new Order()
+    order.action = 'SELL'
+    order.orderType = 'MKT'
+    order.totalQuantity = new Decimal(5)
+
+    const res = await b.placeOrder(makeContract('RELIANCE'), order)
+    expect(res.success).toBe(true)
+    const body = placeOrder.mock.calls[0][0]
+    expect(body.order_type).toBe('MARKET')
+    expect(body.txn_type).toBe('SELL')
+    expect(body.limit_price).toBeUndefined()
+  })
+
+  it('fails on a catalog miss (cannot resolve security_id)', async () => {
+    const b = broker()
+    ;(b as any).client = { placeOrder: vi.fn() }
+    ;(b as any).catalog = catalog()
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'MKT'
+    order.totalQuantity = new Decimal(1)
+    const res = await b.placeOrder(makeContract('UNKNOWNCO'), order)
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/catalog miss/i)
+  })
+
+  it('routes attached TP/SL to a GTT smart order and returns the child leg', async () => {
+    const b = broker()
+    const placeSmartOrder = vi.fn().mockResolvedValue({
+      status: 'success',
+      data: { order_data: [{
+        order_id: 'EQ-100',
+        order_status: 'CREATED',
+        child_order_details: { order_id: 'GTT-200', order_status: 'CREATED' },
+      }] },
+    })
+    const placeOrder = vi.fn()
+    ;(b as any).client = { placeSmartOrder, placeOrder }
+    ;(b as any).catalog = catalog()
+
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'LMT'
+    order.totalQuantity = new Decimal(1)
+    order.lmtPrice = new Decimal('1450')
+
+    const res = await b.placeOrder(makeContract('RELIANCE'), order, {
+      stopLoss: { price: '1400' },
+      takeProfit: { price: '1550' },
+    })
+    expect(placeOrder).not.toHaveBeenCalled()   // bracket → smart order, not /order
+    expect(res.success).toBe(true)
+    expect(res.orderId).toBe('EQ-100')
+    expect(res.legs).toEqual([{ orderId: 'GTT-200', kind: 'stopLoss' }])
+    const body = placeSmartOrder.mock.calls[0][0]
+    expect(body.sl_trigger_price).toBe(1400)
+    expect(body.tgt_trigger_price).toBe(1550)
+    expect(body.security_id).toBe('2885')
+  })
+
+  it('refuses a zero/unset quantity', async () => {
+    const { b } = armed()
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'MKT'
+    order.totalQuantity = new Decimal(0)
+    const res = await b.placeOrder(makeContract('RELIANCE'), order)
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/positive integer/i)
+  })
+})
+
+// ==================== cancelOrder() ====================
+
+describe('IndstocksBroker — cancelOrder()', () => {
+  it('returns Cancelled state on success', async () => {
+    const b = broker()
+    ;(b as any).client = { cancelOrder: vi.fn().mockResolvedValue({ status: 'success' }) }
+    const res = await b.cancelOrder('DRV-1')
+    expect(res.success).toBe(true)
+    expect(res.orderState?.status).toBe('Cancelled')
+  })
+})
+
+// ==================== getPositions() ====================
+
+describe('IndstocksBroker — getPositions()', () => {
+  it('maps holdings (long, LTP-enriched) and short positions, in INR', async () => {
+    // Verified live shape: holdings have symbol/total_qty/avg_price, no LTP →
+    // broker batches /market/quotes/ltp (security_id is the NSE id).
+    const b = broker()
+    ;(b as any).client = {
+      getHoldings: vi.fn().mockResolvedValue({ data: [{
+        symbol: 'RELIANCE', security_id: '2885', total_qty: 10, avg_price: 1400,
+      }] }),
+      getLtp: vi.fn().mockResolvedValue({ data: { 'NSE_2885': { live_price: 1450 } } }),
+      getPositions: vi.fn().mockResolvedValue({ data: [{
+        trading_symbol: 'TCS', exchange: 'NSE',
+        net_quantity: -5, average_price: 3800, last_traded_price: 3750,
+      }] }),
+    }
+    const positions = await b.getPositions()
+    expect(positions).toHaveLength(2)
+
+    const reliance = positions.find(p => p.contract.symbol === 'RELIANCE')!
+    expect(reliance.side).toBe('long')
+    expect(reliance.currency).toBe('INR')
+    expect(reliance.quantity.toString()).toBe('10')
+    expect(reliance.marketPrice).toBe('1450')
+    expect(reliance.unrealizedPnL).toBe('500')   // (1450-1400)*10, derived from live LTP
+
+    const tcs = positions.find(p => p.contract.symbol === 'TCS')!
+    expect(tcs.side).toBe('short')
+    expect(tcs.quantity.toString()).toBe('5')
+  })
+})
+
+// ==================== getAccount() ====================
+
+describe('IndstocksBroker — getAccount()', () => {
+  it('reports INR cash, direct unrealized PnL, and CNC buying power', async () => {
+    // Verified live /funds shape: withdrawal_balance / unrealized_pnl /
+    // detailed_avl_balance.eq_cnc.
+    const b = broker()
+    ;(b as any).client = {
+      getFunds: vi.fn().mockResolvedValue({ data: {
+        withdrawal_balance: 100000, unrealized_pnl: 500, realized_pnl: 0,
+        detailed_avl_balance: { eq_cnc: 250000 },
+      } }),
+      getHoldings: vi.fn().mockResolvedValue({ data: [{
+        symbol: 'RELIANCE', security_id: '2885', total_qty: 10, avg_price: 1400,
+      }] }),
+      getLtp: vi.fn().mockResolvedValue({ data: { 'NSE_2885': { live_price: 1450 } } }),
+      getPositions: vi.fn().mockResolvedValue({ data: [] }),
+    }
+    const acc = await b.getAccount()
+    expect(acc.baseCurrency).toBe('INR')
+    expect(acc.totalCashValue).toBe('100000')
+    expect(acc.unrealizedPnL).toBe('500')
+    expect(acc.buyingPower).toBe('250000')
+    expect(acc.netLiquidation).toBe('114500')   // cash 100000 + MV 14500
+  })
+})
+
+// ==================== getQuote() ====================
+
+describe('IndstocksBroker — getQuote()', () => {
+  it('builds the scrip-code, maps live_price → last, parses depth bid/ask (comma strings)', async () => {
+    // Verified live shape: bid/ask nested in market_depth[code].depth[0] as
+    // comma-formatted strings ("1,455.00").
+    const b = broker()
+    const getQuotes = vi.fn().mockResolvedValue({
+      data: { 'NSE_2885': {
+        live_price: 1455.25, day_high: 1460, day_low: 1450, volume: 1200000,
+        market_depth: { 'NSE_2885': { depth: [
+          { buy: { quantity: '1,055', price: '1,455.00' }, sell: { quantity: '0.00', price: '1,455.50' } },
+        ] } },
+      } },
+    })
+    ;(b as any).client = { getQuotes }
+    ;(b as any).catalog = catalog()
+
+    const q = await b.getQuote(makeContract('RELIANCE'))
+    expect(getQuotes).toHaveBeenCalledWith(['NSE_2885'])
+    expect(q.last).toBe('1455.25')
+    expect(q.bid).toBe('1455')
+    expect(q.ask).toBe('1455.5')
+    expect(q.high).toBe('1460')
+    expect(q.contract.symbol).toBe('RELIANCE')
+  })
+})
+
+// ==================== capabilities + identity ====================
+
+describe('IndstocksBroker — capabilities & identity', () => {
+  it('declares STK with MKT/LMT order types', () => {
+    const caps = broker().getCapabilities()
+    expect(caps.supportedSecTypes).toEqual(['STK'])
+    expect(caps.supportedOrderTypes).toEqual(['MKT', 'LMT'])
+    expect(caps.historicalBars?.supported).toBe(true)
+  })
+
+  it('round-trips nativeKey ↔ contract', () => {
+    const b = broker()
+    const c = makeContract('RELIANCE')
+    const key = b.getNativeKey(c)
+    expect(key).toBe('RELIANCE')
+    expect(b.resolveNativeKey(key).symbol).toBe('RELIANCE')
+  })
+
+  it('reports market clock with a boolean isOpen and a timestamp', async () => {
+    const clock = await broker().getMarketClock()
+    expect(typeof clock.isOpen).toBe('boolean')
+    expect(clock.timestamp).toBeInstanceOf(Date)
+  })
+})
+
+// ==================== order-update stream ====================
+
+describe('IndstocksBroker — streamOrderUpdates()', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  async function fakeWsClass() {
+    return (await import('ws')).default as any
+  }
+
+  it('subscribes on open and forwards order updates, ignoring heartbeats', async () => {
+    const updates: any[] = []
+    const stream = broker().streamOrderUpdates({ onUpdate: u => updates.push(u) })
+    const FakeWS = await fakeWsClass()
+    const sock = FakeWS.instances.at(-1)
+
+    sock.emit('open')
+    expect(JSON.parse(sock.sent[0])).toEqual({ action: 'subscribe', mode: 'order_updates' })
+    // Auth header carried at handshake.
+    expect(sock.opts.headers.Authorization).toBe('tok')
+
+    sock.emit('message', JSON.stringify({ type: 'order', order_id: 'O-1', order_status: 'PARTIALLY_EXECUTED', filled_quantity: 5 }))
+    sock.emit('message', JSON.stringify({ heartbeat: true }))   // ignored
+    expect(updates).toHaveLength(1)
+    expect(updates[0].order_id).toBe('O-1')
+
+    stream.stop()
+  })
+
+  it('calls onAuthError on a 403 handshake (expired daily token) without reconnecting', async () => {
+    const onAuthError = vi.fn()
+    broker().streamOrderUpdates({ onUpdate: () => {}, onAuthError })
+    const FakeWS = await fakeWsClass()
+    const sock = FakeWS.instances.at(-1)
+    sock.emit('unexpected-response', {}, { statusCode: 403 })
+    expect(onAuthError).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ==================== fromConfig() ====================
+
+describe('IndstocksBroker — fromConfig()', () => {
+  it('derives a stable id from userId (not the rotating token)', () => {
+    const b = IndstocksBroker.fromConfig({ id: 'indstocks-CLIENT1', brokerConfig: { accessToken: 'tok', userId: 'CLIENT1' } })
+    expect(b.id).toBe('indstocks-CLIENT1')
+    expect(b.label).toBe('INDmoney')
+  })
+})

--- a/services/uta/src/domain/trading/brokers/indstocks/IndstocksBroker.ts
+++ b/services/uta/src/domain/trading/brokers/indstocks/IndstocksBroker.ts
@@ -1,0 +1,595 @@
+/**
+ * IndstocksBroker — IBroker adapter for INDstocks (INDmoney's trading API).
+ *
+ * Scope v1: Indian EQUITIES on NSE/BSE (secType STK). F&O (FUT/OPT) is
+ * deferred — see TODOs. No paper/sandbox exists upstream, so this trades the
+ * LIVE environment only; test with tiny quantities.
+ *
+ * Daily-token reality (SEBI): the access token expires every 24h with no
+ * refresh endpoint. A 403 maps to a permanent BrokerError('AUTH'), which the
+ * UTA recovery loop treats as "disable + surface to the user" — i.e. trading
+ * halts and the health/Inbox surface tells them to paste a fresh token. There
+ * is intentionally NO attempt to auto-renew.  (See indstocks-client.ts.)
+ *
+ * STATUS: SCAFFOLD. Structure + REST wiring are real; raw field names follow
+ * the public docs and MUST be verified against live responses. Order-product
+ * selection, F&O, holidays, and the order-update WebSocket are marked TODO.
+ */
+
+import { z } from 'zod'
+import Decimal from 'decimal.js'
+import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL } from '@traderalice/ibkr'
+import {
+  BrokerError,
+  type IBroker,
+  type AccountCapabilities,
+  type AccountInfo,
+  type Position,
+  type PlaceOrderResult,
+  type PlaceOrderLeg,
+  type OpenOrder,
+  type Quote,
+  type MarketClock,
+  type BrokerConfigField,
+  type TpSlParams,
+  type Bar,
+  type BarParams,
+} from '../types.js'
+import '../../contract-ext.js'
+import type { IndstocksBrokerConfig, IndstocksInstrument, IndstocksOrderRaw, IndstocksLtpRaw } from './indstocks-types.js'
+import {
+  makeContract,
+  resolveSymbol,
+  scripCode,
+  makeOrderState,
+  ibkrOrderTypeToInd,
+  ibkrTifToInd,
+  algoIdFor,
+  IND_INTERVAL,
+  DEFAULT_EXCHANGE,
+} from './indstocks-contracts.js'
+import { buildPosition } from '../contract-builder.js'
+import { fuzzyRankContracts, type FuzzyRankInput } from '../fuzzy-rank.js'
+import { IndstocksClient, type IndPlaceOrderBody, type IndSmartOrderBody } from './indstocks-client.js'
+import { IndstocksOrderStream, type IndstocksOrderStreamHandlers } from './indstocks-stream.js'
+
+/** Decimal from a loose string|number|null. */
+const dec = (v: string | number | undefined | null, d = '0'): Decimal =>
+  new Decimal(v == null || v === '' ? d : String(v))
+
+/** Decimal from a comma-formatted string ("1,318.10") — INDstocks market depth. */
+const decLoose = (v: string | number | undefined | null): Decimal =>
+  new Decimal((v == null ? '0' : String(v)).replace(/,/g, '') || '0')
+
+/**
+ * Default product for orders. INDstocks needs CNC | INTRADAY | MARGIN, but the
+ * IBKR Order has no product field. v1 defaults to CNC (delivery).
+ * TODO: thread product through (per-order override or account-level default).
+ */
+const DEFAULT_PRODUCT = 'CNC'
+
+const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000
+const NSE_OPEN_MIN = 9 * 60 + 15     // 09:15 IST
+const NSE_CLOSE_MIN = 15 * 60 + 30   // 15:30 IST
+
+export class IndstocksBroker implements IBroker {
+  // ---- Self-registration ----
+
+  static configSchema = z.object({
+    accessToken: z.string().min(1),
+    userId: z.string().min(1),
+  })
+
+  static configFields: BrokerConfigField[] = [
+    { name: 'userId', type: 'text', label: 'INDstocks Client ID', required: true, description: 'Stable account identifier (from your INDstocks profile).' },
+    { name: 'accessToken', type: 'password', label: 'Access Token', required: true, sensitive: true, description: 'Daily token from web.indstocks.com → API. Expires every 24h; paste a fresh one each session.' },
+  ]
+
+  static fromConfig(config: { id: string; label?: string; brokerConfig: Record<string, unknown> }): IndstocksBroker {
+    const bc = IndstocksBroker.configSchema.parse(config.brokerConfig)
+    return new IndstocksBroker({
+      id: config.id,
+      label: config.label,
+      accessToken: bc.accessToken,
+      userId: bc.userId,
+    })
+  }
+
+  // ---- Instance ----
+
+  readonly id: string
+  readonly label: string
+
+  private readonly config: IndstocksBrokerConfig
+  private client!: IndstocksClient
+  /** symbol catalog keyed `${EXCH}:${SYMBOL}`. null = not loaded yet. */
+  private catalog: Map<string, IndstocksInstrument> | null = null
+
+  constructor(config: IndstocksBrokerConfig) {
+    this.config = config
+    this.id = config.id ?? `indstocks-${config.userId}`
+    this.label = config.label ?? 'INDmoney'
+  }
+
+  // ---- Lifecycle ----
+
+  private static readonly MAX_INIT_RETRIES = 4
+  private static readonly INIT_RETRY_BASE_MS = 1000
+
+  async init(): Promise<void> {
+    if (!this.config.accessToken) {
+      throw new BrokerError('CONFIG', 'No INDstocks access token configured.')
+    }
+    this.client = new IndstocksClient(this.config.accessToken)
+
+    let lastErr: unknown
+    for (let attempt = 1; attempt <= IndstocksBroker.MAX_INIT_RETRIES; attempt++) {
+      try {
+        // Probe token validity. A 403 here throws a permanent AUTH error
+        // (client.request) and bails immediately — no point retrying an
+        // expired daily token.
+        await this.client.getProfile()
+        console.log(`IndstocksBroker[${this.id}]: connected (live)`)
+        this.refreshCatalog().catch((err) => {
+          console.warn(`IndstocksBroker[${this.id}]: initial catalog load failed:`, err instanceof Error ? err.message : err)
+        })
+        return
+      } catch (err) {
+        if (err instanceof BrokerError && err.permanent) throw err   // AUTH/CONFIG: don't retry
+        lastErr = err
+        if (attempt < IndstocksBroker.MAX_INIT_RETRIES) {
+          const delay = IndstocksBroker.INIT_RETRY_BASE_MS * 2 ** (attempt - 1)
+          console.warn(`IndstocksBroker[${this.id}]: init attempt ${attempt} failed, retrying in ${delay}ms...`)
+          await new Promise(r => setTimeout(r, delay))
+        }
+      }
+    }
+    throw lastErr
+  }
+
+  async close(): Promise<void> {
+    // REST is stateless; nothing to tear down. TODO: close order-update WS.
+  }
+
+  // ---- Contract search (EnumeratingCatalog) ----
+
+  async refreshCatalog(): Promise<void> {
+    const rows = await this.client.getInstruments('equity')
+    const next = new Map<string, IndstocksInstrument>()
+    for (const r of rows) {
+      next.set(`${r.exch.toUpperCase()}:${r.tradingSymbol.toUpperCase()}`, r)
+    }
+    this.catalog = next
+    console.log(`IndstocksBroker[${this.id}]: catalog loaded (${next.size} equity instruments)`)
+  }
+
+  async searchContracts(pattern: string): Promise<ContractDescription[]> {
+    if (!pattern) return []
+    if (this.catalog == null) {
+      const desc = new ContractDescription()
+      desc.contract = makeContract(pattern.toUpperCase())
+      return [desc]
+    }
+    const entries: FuzzyRankInput[] = []
+    for (const r of this.catalog.values()) {
+      const c = makeContract(r.tradingSymbol, r.exch || DEFAULT_EXCHANGE)
+      if (r.customSymbol) c.description = r.customSymbol
+      if (r.exch) c.primaryExchange = r.exch
+      entries.push({ contract: c, name: r.customSymbol })
+    }
+    return fuzzyRankContracts(entries, pattern)
+  }
+
+  async getContractDetails(query: Contract): Promise<ContractDetails | null> {
+    const symbol = resolveSymbol(query)
+    if (!symbol) return null
+    const details = new ContractDetails()
+    details.contract = makeContract(symbol, query.exchange || DEFAULT_EXCHANGE)
+    details.validExchanges = 'NSE,BSE'
+    details.orderTypes = 'MKT,LMT'
+    details.stockType = 'COMMON'
+    return details
+  }
+
+  // ---- Trading operations ----
+
+  async placeOrder(contract: Contract, order: Order, tpsl?: TpSlParams): Promise<PlaceOrderResult> {
+    const inst = this.lookupInstrument(contract)
+    if (!inst) return { success: false, error: `Cannot resolve ${contract.symbol} to an INDstocks security_id (catalog miss).` }
+
+    const orderType = ibkrOrderTypeToInd(order.orderType)
+    const qty = order.totalQuantity.equals(UNSET_DECIMAL) ? 0 : Number(order.totalQuantity.toFixed(0))
+    if (qty <= 0) return { success: false, error: 'INDstocks requires a positive integer share quantity.' }
+    const exchange = inst.exch || DEFAULT_EXCHANGE
+
+    const base: IndPlaceOrderBody = {
+      txn_type: order.action.toUpperCase() === 'SELL' ? 'SELL' : 'BUY',
+      exchange,
+      segment: 'EQUITY',
+      product: DEFAULT_PRODUCT,
+      order_type: orderType,
+      validity: ibkrTifToInd(order.tif),
+      security_id: inst.securityId,
+      qty,
+      algo_id: algoIdFor(exchange),
+    }
+    if (orderType === 'LIMIT' && !order.lmtPrice.equals(UNSET_DECIMAL)) {
+      base.limit_price = Number(order.lmtPrice.toFixed())
+    }
+
+    // Attached TP/SL → GTT smart order. The protective legs are created with
+    // the entry and arm only after it fills; their ids ride back as `legs`.
+    if (tpsl?.takeProfit || tpsl?.stopLoss) {
+      return this.placeSmartOrder(base, tpsl)
+    }
+
+    try {
+      const res = await this.client.placeOrder(base)
+      const d = res.data
+      if (!d?.order_id) {
+        // Live finding: a SELL of holdings on an account without DDPI (CDSL
+        // eDIS) active comes back as a generic InternalServerException with no
+        // order_id. Add a hint so the failure is actionable, not mysterious.
+        const msg = res.message ?? 'INDstocks returned no order_id.'
+        const hint = base.txn_type === 'SELL' && /internal server|exception/i.test(msg)
+          ? ' (selling holdings via API requires DDPI/eDIS active in your INDmoney account)'
+          : ''
+        return { success: false, error: msg + hint }
+      }
+      return { success: true, orderId: d.order_id, orderState: makeOrderState(d.order_status ?? 'PENDING') }
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  /** Entry + GTT SL/TP legs in one POST /smart/order (OCO when both present). */
+  private async placeSmartOrder(base: IndPlaceOrderBody, tpsl: TpSlParams): Promise<PlaceOrderResult> {
+    const body: IndSmartOrderBody = { ...base }
+    if (tpsl.stopLoss) {
+      body.sl_trigger_price = Number(tpsl.stopLoss.price)
+      body.sl_limit_price = Number(tpsl.stopLoss.limitPrice ?? tpsl.stopLoss.price)
+    }
+    if (tpsl.takeProfit) {
+      body.tgt_trigger_price = Number(tpsl.takeProfit.price)
+      body.tgt_limit_price = Number(tpsl.takeProfit.price)
+    }
+    try {
+      const res = await this.client.placeSmartOrder(body)
+      const rows = res.data?.order_data ?? []
+      if (!rows.length || !rows[0]?.order_id) {
+        return { success: false, error: res.message ?? 'INDstocks smart order returned no order_id.' }
+      }
+      const parent = rows[0]
+      // Surface GTT child legs so the ledger tracks them from birth. Exact
+      // SL-vs-TP attribution isn't in the documented single-child response —
+      // default a lone child to the stop-loss (the protective leg).
+      // TODO: refine once the live OCO response shape is confirmed.
+      const legs: PlaceOrderLeg[] = []
+      for (const r of rows) {
+        const child = r.child_order_details
+        if (child?.order_id) {
+          legs.push({ orderId: child.order_id, kind: tpsl.stopLoss ? 'stopLoss' : 'takeProfit' })
+        }
+      }
+      return {
+        success: true,
+        orderId: parent.order_id,
+        orderState: makeOrderState(parent.order_status ?? 'CREATED'),
+        ...(legs.length ? { legs } : {}),
+      }
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  /**
+   * Opt-in push stream of order fills over the order-updates WebSocket. NOT
+   * part of the (poll-based) IBroker contract — the caller owns start/stop.
+   * TODO: wire into the UTA order-sync poller to cut pending-lane latency.
+   */
+  streamOrderUpdates(handlers: IndstocksOrderStreamHandlers): IndstocksOrderStream {
+    const stream = new IndstocksOrderStream(this.config.accessToken, handlers)
+    stream.start()
+    return stream
+  }
+
+  async modifyOrder(orderId: string, changes: Partial<Order>): Promise<PlaceOrderResult> {
+    const patch: Record<string, unknown> = { order_id: orderId }
+    if (changes.totalQuantity != null && !changes.totalQuantity.equals(UNSET_DECIMAL)) patch.qty = Number(changes.totalQuantity.toFixed(0))
+    if (changes.lmtPrice != null && !changes.lmtPrice.equals(UNSET_DECIMAL)) patch.limit_price = Number(changes.lmtPrice.toFixed())
+    if (changes.tif) patch.validity = ibkrTifToInd(changes.tif)
+    try {
+      const res = await this.client.modifyOrder(patch)
+      return { success: true, orderId: res.data?.order_id ?? orderId, orderState: makeOrderState(res.data?.order_status ?? 'MODIFIED') }
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  async cancelOrder(orderId: string): Promise<PlaceOrderResult> {
+    try {
+      await this.client.cancelOrder(orderId)
+      const orderState = new OrderState()
+      orderState.status = 'Cancelled'
+      return { success: true, orderId, orderState }
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  async closePosition(contract: Contract, quantity?: Decimal): Promise<PlaceOrderResult> {
+    const symbol = resolveSymbol(contract)
+    if (!symbol) return { success: false, error: 'Cannot resolve contract to INDstocks symbol.' }
+    const positions = await this.getPositions()
+    const pos = positions.find(p => p.contract.symbol === symbol)
+    if (!pos) return { success: false, error: `No open position for ${symbol}.` }
+
+    const order = new Order()
+    order.action = pos.side === 'long' ? 'SELL' : 'BUY'
+    order.orderType = 'MKT'
+    order.totalQuantity = quantity ?? pos.quantity.abs()
+    order.tif = 'DAY'
+    return this.placeOrder(contract, order)
+  }
+
+  // ---- Queries ----
+
+  async getAccount(): Promise<AccountInfo> {
+    try {
+      const [funds, positions] = await Promise.all([this.client.getFunds(), this.getPositions()])
+      const d = funds.data ?? {}
+      const cash = dec(d.withdrawal_balance ?? d.sod_balance)
+      const posMV = positions.reduce((s, p) => s.plus(dec(p.marketValue)), new Decimal(0))
+      const unrealizedPnL = d.unrealized_pnl != null
+        ? dec(d.unrealized_pnl)
+        : positions.reduce((s, p) => s.plus(dec(p.unrealizedPnL)), new Decimal(0))
+      const buyingPower = d.detailed_avl_balance?.eq_cnc
+      return {
+        baseCurrency: 'INR',
+        netLiquidation: cash.plus(posMV).toString(),
+        totalCashValue: cash.toString(),
+        unrealizedPnL: unrealizedPnL.toString(),
+        ...(d.realized_pnl != null ? { realizedPnL: dec(d.realized_pnl).toString() } : {}),
+        ...(buyingPower != null ? { buyingPower: dec(buyingPower).toString() } : {}),
+      }
+    } catch (err) {
+      throw BrokerError.from(err)
+    }
+  }
+
+  async getPositions(): Promise<Position[]> {
+    try {
+      const [holdings, positions] = await Promise.all([
+        this.client.getHoldings().then(r => r.data ?? []).catch(() => []),
+        this.client.getPositions('equity').then(r => r.data ?? []).catch(() => []),
+      ])
+      const out: Position[] = []
+
+      // Holdings carry no market price — batch-fetch LTP (security_id is the
+      // NSE id) and fold it in so marketValue / PnL are live, not flat at cost.
+      const heldCodes = holdings.filter(h => h.security_id).map(h => scripCode(DEFAULT_EXCHANGE, h.security_id))
+      const ltp: Record<string, IndstocksLtpRaw> = heldCodes.length
+        ? await this.client.getLtp(heldCodes).then(r => r.data ?? {}).catch(() => ({}))
+        : {}
+
+      // Delivery holdings — always long.
+      for (const h of holdings) {
+        const symbol = (h.symbol ?? '').toUpperCase()
+        if (!symbol) continue
+        const code = scripCode(DEFAULT_EXCHANGE, h.security_id)
+        const live = ltp[code]?.live_price
+        const marketPrice = live != null ? dec(live) : dec(h.avg_price)
+        out.push(buildPosition({
+          contract: makeContract(symbol, DEFAULT_EXCHANGE),
+          currency: 'INR',
+          side: 'long',
+          quantity: dec(h.total_qty),
+          avgCost: dec(h.avg_price).toString(),
+          marketPrice: marketPrice.toString(),
+          realizedPnL: '0',
+          multiplier: '1',
+        }))
+      }
+
+      // Intraday / open positions — sign of net_quantity gives side.
+      for (const p of positions) {
+        const symbol = (p.trading_symbol ?? '').toUpperCase()
+        if (!symbol) continue
+        const qty = dec(p.net_quantity)
+        if (qty.isZero()) continue
+        out.push(buildPosition({
+          contract: makeContract(symbol, p.exchange || DEFAULT_EXCHANGE),
+          currency: 'INR',
+          side: qty.isNegative() ? 'short' : 'long',
+          quantity: qty.abs(),
+          avgCost: dec(p.average_price).toString(),
+          marketPrice: dec(p.last_traded_price).toString(),
+          realizedPnL: '0',
+          // TODO: F&O multiplier from instrument LOT_UNITS once F&O is in scope.
+          multiplier: dec(p.multiplier, '1').toString(),
+          ...(p.market_value != null ? { marketValue: dec(p.market_value).abs().toString() } : {}),
+          ...(p.pnl_absolute != null ? { unrealizedPnL: dec(p.pnl_absolute).toString() } : {}),
+        }))
+      }
+      return out
+    } catch (err) {
+      throw BrokerError.from(err)
+    }
+  }
+
+  async getOrders(orderIds: string[]): Promise<OpenOrder[]> {
+    const out: OpenOrder[] = []
+    for (const id of orderIds) {
+      const o = await this.getOrder(id)
+      if (o) out.push(o)
+    }
+    return out
+  }
+
+  async getOrder(orderId: string): Promise<OpenOrder | null> {
+    try {
+      const res = await this.client.getOrder(orderId)
+      return res.data ? this.mapOpenOrder(res.data) : null
+    } catch {
+      return null
+    }
+  }
+
+  async getOpenOrders(): Promise<OpenOrder[]> {
+    try {
+      const res = await this.client.getOrderBook()
+      const working = new Set(['Submitted'])
+      return (res.data ?? [])
+        .map(o => this.mapOpenOrder(o))
+        .filter(o => working.has(o.orderState.status))
+    } catch (err) {
+      throw BrokerError.from(err)
+    }
+  }
+
+  async getQuote(contract: Contract): Promise<Quote> {
+    const inst = this.lookupInstrument(contract)
+    if (!inst) throw new BrokerError('EXCHANGE', `Cannot resolve ${contract.symbol} to an INDstocks scrip-code.`)
+    try {
+      const code = scripCode(inst.exch || DEFAULT_EXCHANGE, inst.securityId)
+      const res = await this.client.getQuotes([code])
+      const q = res.data?.[code]
+      if (!q) throw new BrokerError('EXCHANGE', `No quote returned for ${code}.`)
+      const last = dec(q.live_price)
+      // bid/ask live in market_depth[code].depth[0] as comma-strings; fall back
+      // to last when depth is empty (illiquid / one-sided book).
+      const top = q.market_depth?.[code]?.depth?.[0]
+      const bid = top?.buy?.price ? decLoose(top.buy.price) : last
+      const ask = top?.sell?.price ? decLoose(top.sell.price) : last
+      return {
+        contract: makeContract(inst.tradingSymbol, inst.exch || DEFAULT_EXCHANGE),
+        last: last.toString(),
+        bid: (bid.isZero() ? last : bid).toString(),
+        ask: (ask.isZero() ? last : ask).toString(),
+        volume: dec(q.volume).toString(),
+        ...(q.day_high != null ? { high: dec(q.day_high).toString() } : {}),
+        ...(q.day_low != null ? { low: dec(q.day_low).toString() } : {}),
+        timestamp: new Date(),
+      }
+    } catch (err) {
+      throw BrokerError.from(err)
+    }
+  }
+
+  async getHistorical(contract: Contract, params: BarParams): Promise<Bar[]> {
+    const inst = this.lookupInstrument(contract)
+    if (!inst) throw new BrokerError('EXCHANGE', `Cannot resolve ${contract.symbol} to an INDstocks scrip-code.`)
+    const interval = IND_INTERVAL[params.interval]
+    const end = params.end ?? new Date()
+    // INDstocks caps the range per interval (1d / 7d / 14d / 1y). Default to a
+    // 7-day lookback when no start is given. TODO: enforce the per-interval cap.
+    const start = params.start ?? new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000)
+    try {
+      const code = scripCode(inst.exch || DEFAULT_EXCHANGE, inst.securityId)
+      const res = await this.client.getHistorical(interval, code, start.getTime(), end.getTime())
+      const candles = res.data ?? []
+      const bars = candles.map(([ts, o, h, l, c, v]): Bar => ({
+        timestamp: new Date(ts),
+        open: String(o), high: String(h), low: String(l), close: String(c), volume: String(v),
+      }))
+      return params.limit ? bars.slice(-params.limit) : bars
+    } catch (err) {
+      throw BrokerError.from(err)
+    }
+  }
+
+  // ---- Capabilities ----
+
+  getCapabilities(): AccountCapabilities {
+    return {
+      supportedSecTypes: ['STK'],              // TODO: add FUT/OPT for F&O.
+      supportedOrderTypes: ['MKT', 'LMT'],     // no native STP (GTT only).
+      historicalBars: {
+        supported: true,
+        quality: 'realtime',
+        supportedBarSizes: ['1m', '5m', '15m', '30m', '1h', '4h', '1d', '1w'],
+      },
+    }
+  }
+
+  assetClassFor(): 'equity' {
+    return 'equity'
+  }
+
+  async getMarketClock(): Promise<MarketClock> {
+    // Hardcoded NSE/BSE regular session, IST (UTC+5:30), Mon–Fri.
+    // TODO: honour the NSE holiday calendar + special muhurat sessions.
+    const now = new Date()
+    const ist = now.getTime() + IST_OFFSET_MS
+    const dayMs = 24 * 60 * 60 * 1000
+    const istMidnight = Math.floor(ist / dayMs) * dayMs
+    const minsOfDay = Math.floor((ist - istMidnight) / 60000)
+    const dow = new Date(istMidnight).getUTCDay()   // 0=Sun..6=Sat in IST terms
+    const isWeekday = dow >= 1 && dow <= 5
+    const isOpen = isWeekday && minsOfDay >= NSE_OPEN_MIN && minsOfDay < NSE_CLOSE_MIN
+
+    const openUtc = (offsetDays: number) => new Date(istMidnight + offsetDays * dayMs + NSE_OPEN_MIN * 60000 - IST_OFFSET_MS)
+    const closeUtc = new Date(istMidnight + NSE_CLOSE_MIN * 60000 - IST_OFFSET_MS)
+
+    let nextOpen: Date | undefined
+    if (!isOpen) {
+      // Walk forward to the next weekday's open (skips Sat/Sun; NOT holidays).
+      let d = minsOfDay < NSE_OPEN_MIN && isWeekday ? 0 : 1
+      for (let i = 0; i < 7; i++) {
+        const cand = (dow + d) % 7
+        if (cand >= 1 && cand <= 5) break
+        d++
+      }
+      nextOpen = openUtc(d)
+    }
+    return {
+      isOpen,
+      ...(isOpen ? { nextClose: closeUtc } : {}),
+      ...(nextOpen ? { nextOpen } : {}),
+      timestamp: now,
+    }
+  }
+
+  // ---- Contract identity ----
+
+  getNativeKey(contract: Contract): string {
+    return contract.symbol
+  }
+
+  resolveNativeKey(nativeKey: string): Contract {
+    return makeContract(nativeKey)
+  }
+
+  // ---- Internal ----
+
+  private lookupInstrument(contract: Contract): IndstocksInstrument | null {
+    const symbol = resolveSymbol(contract)
+    if (!symbol || this.catalog == null) return null
+    const exch = (contract.exchange || DEFAULT_EXCHANGE).toUpperCase()
+    return this.catalog.get(`${exch}:${symbol}`)
+      ?? this.catalog.get(`${DEFAULT_EXCHANGE}:${symbol}`)
+      ?? null
+  }
+
+  private mapOpenOrder(o: IndstocksOrderRaw): OpenOrder {
+    const symbol = (o.trading_symbol ?? o.security_id ?? '').toUpperCase()
+    const contract = makeContract(symbol, o.exchange || DEFAULT_EXCHANGE)
+
+    const order = new Order()
+    order.action = o.txn_type?.toUpperCase() === 'SELL' ? 'SELL' : 'BUY'
+    order.totalQuantity = dec(o.qty)
+    order.orderType = (o.order_type ?? 'MARKET').toUpperCase() === 'MARKET' ? 'MKT' : 'LMT'
+    if (o.limit_price != null) order.lmtPrice = dec(o.limit_price)
+    if (o.validity) order.tif = o.validity.toUpperCase()
+    if (o.filled_qty != null) order.filledQuantity = dec(o.filled_qty)
+    order.orderId = 0   // INDstocks ids are strings; real id rides on OpenOrder.orderId
+
+    return {
+      contract,
+      order,
+      orderState: makeOrderState(o.order_status, o.reject_reason ?? undefined),
+      orderId: o.order_id,
+      ...(o.average_price != null ? { avgFillPrice: dec(o.average_price).toString() } : {}),
+    }
+  }
+}

--- a/services/uta/src/domain/trading/brokers/indstocks/index.ts
+++ b/services/uta/src/domain/trading/brokers/indstocks/index.ts
@@ -1,0 +1,4 @@
+export { IndstocksBroker } from './IndstocksBroker.js'
+export type { IndstocksBrokerConfig } from './indstocks-types.js'
+export { IndstocksOrderStream } from './indstocks-stream.js'
+export type { IndstocksOrderStreamHandlers } from './indstocks-stream.js'

--- a/services/uta/src/domain/trading/brokers/indstocks/indstocks-client.ts
+++ b/services/uta/src/domain/trading/brokers/indstocks/indstocks-client.ts
@@ -1,0 +1,239 @@
+/**
+ * Thin REST client for the INDstocks API. There is no maintained official
+ * Node SDK, so this hand-rolls fetch calls against the documented endpoints.
+ *
+ * Auth: `Authorization: <accessToken>` header (NO "Bearer" prefix — per docs).
+ * Token expiry surfaces as HTTP 403 `TokenException`; `request()` maps that to
+ * a permanent BrokerError('AUTH') so the UTA recovery loop DISABLES the account
+ * (stops retry-spamming) and the health surface tells the user to regenerate
+ * the token at web.indstocks.com.
+ */
+
+import { BrokerError } from '../types.js'
+import type {
+  IndstocksFundsRaw,
+  IndstocksHoldingRaw,
+  IndstocksPositionRaw,
+  IndstocksProfileRaw,
+  IndstocksPlaceOrderRaw,
+  IndstocksSmartOrderRaw,
+  IndstocksOrderRaw,
+  IndstocksQuoteRaw,
+  IndstocksLtpRaw,
+  IndstocksInstrument,
+  IndstocksCandle,
+} from './indstocks-types.js'
+
+const BASE_URL = 'https://api.indstocks.com'
+
+/** Body for POST /order. */
+export interface IndPlaceOrderBody {
+  txn_type: 'BUY' | 'SELL'
+  exchange: string            // NSE | BSE
+  segment: string             // EQUITY | DERIVATIVE
+  product: string             // CNC | INTRADAY | MARGIN
+  order_type: string          // LIMIT | MARKET
+  validity: string            // DAY | IOC
+  security_id: string
+  qty: number
+  algo_id: string
+  limit_price?: number
+  is_amo?: boolean
+}
+
+/**
+ * Body for POST /smart/order — the entry order plus optional GTT SL/TP legs.
+ * Both leg pairs present ⇒ OCO. The legs arm only after the parent fills.
+ */
+export interface IndSmartOrderBody extends IndPlaceOrderBody {
+  /** TRIGGER also valid here in addition to LIMIT/MARKET. */
+  trigger_price?: number
+  trigger_limit_price?: number
+  /** Stop-loss leg. */
+  sl_trigger_price?: number
+  sl_limit_price?: number
+  /** Target / take-profit leg. */
+  tgt_trigger_price?: number
+  tgt_limit_price?: number
+}
+
+export class IndstocksClient {
+  constructor(private accessToken: string) {}
+
+  /** Swap in a freshly-pasted daily token without rebuilding the broker. */
+  setToken(token: string): void {
+    this.accessToken = token
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: this.accessToken,      // no "Bearer" prefix (per docs)
+      'Content-Type': 'application/json',
+    }
+  }
+
+  /** Core request → JSON. Maps 403/TokenException to a permanent AUTH error. */
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    let res: Response
+    try {
+      res = await fetch(`${BASE_URL}${path}`, {
+        method,
+        headers: this.headers(),
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      })
+    } catch (err) {
+      // Transport failure → transient NETWORK (recovery loop retries).
+      throw BrokerError.from(err, 'NETWORK')
+    }
+
+    if (res.status === 403) {
+      // TokenException — daily token expired/invalid/revoked. Permanent so the
+      // account is disabled until the user pastes a fresh token. (Daily wall.)
+      throw new BrokerError(
+        'AUTH',
+        'INDstocks access token expired or invalid. Tokens last 24h — regenerate at ' +
+        'web.indstocks.com → API, then update this account in Settings.',
+      )
+    }
+    if (res.status === 401) {
+      throw new BrokerError('AUTH', 'INDstocks rejected the access token (401).')
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw BrokerError.from(new Error(`INDstocks ${method} ${path} → ${res.status} ${text}`))
+    }
+    return res.json() as Promise<T>
+  }
+
+  /** GET text (for the CSV instruments master). */
+  private async requestText(path: string): Promise<string> {
+    const res = await fetch(`${BASE_URL}${path}`, { method: 'GET', headers: this.headers() })
+    if (res.status === 403 || res.status === 401) {
+      throw new BrokerError('AUTH', 'INDstocks token expired/invalid — regenerate at web.indstocks.com.')
+    }
+    if (!res.ok) throw BrokerError.from(new Error(`INDstocks GET ${path} → ${res.status}`))
+    return res.text()
+  }
+
+  // ---- Account / token ----
+
+  /** Token-validity probe. Used at init(). */
+  getProfile(): Promise<IndstocksProfileRaw> {
+    return this.request('GET', '/user/profile')
+  }
+
+  getFunds(): Promise<IndstocksFundsRaw> {
+    return this.request('GET', '/funds')
+  }
+
+  // ---- Portfolio ----
+
+  getHoldings(): Promise<{ data: IndstocksHoldingRaw[] }> {
+    return this.request('GET', '/portfolio/holdings')
+  }
+
+  getPositions(segment?: 'equity' | 'derivative'): Promise<{ data: IndstocksPositionRaw[] }> {
+    const q = segment ? `?segment=${segment}` : ''
+    return this.request('GET', `/portfolio/positions${q}`)
+  }
+
+  // ---- Orders ----
+
+  placeOrder(body: IndPlaceOrderBody): Promise<IndstocksPlaceOrderRaw> {
+    return this.request('POST', '/order', body)
+  }
+
+  modifyOrder(body: Record<string, unknown>): Promise<IndstocksPlaceOrderRaw> {
+    return this.request('POST', '/order/modify', body)
+  }
+
+  cancelOrder(orderId: string): Promise<IndstocksPlaceOrderRaw> {
+    return this.request('POST', '/order/cancel', { order_id: orderId })
+  }
+
+  // ---- Smart orders (GTT — stop-loss / target legs) ----
+
+  placeSmartOrder(body: IndSmartOrderBody): Promise<IndstocksSmartOrderRaw> {
+    return this.request('POST', '/smart/order', body)
+  }
+
+  modifySmartOrder(body: Record<string, unknown>): Promise<IndstocksSmartOrderRaw> {
+    return this.request('POST', '/smart/order/modify', body)
+  }
+
+  cancelSmartOrder(orderId: string): Promise<IndstocksSmartOrderRaw> {
+    return this.request('POST', '/smart/order/cancel', { order_id: orderId })
+  }
+
+  getOrder(orderId: string): Promise<{ data: IndstocksOrderRaw }> {
+    return this.request('GET', `/order?order_id=${encodeURIComponent(orderId)}`)
+  }
+
+  getOrderBook(): Promise<{ data: IndstocksOrderRaw[] }> {
+    return this.request('GET', '/order-book')
+  }
+
+  // ---- Market data ----
+
+  /** Full quotes for up to 1000 scrip-codes (`NSE_3045,NFO_51011`). */
+  getQuotes(scripCodes: string[]): Promise<{ data: Record<string, IndstocksQuoteRaw> }> {
+    const q = encodeURIComponent(scripCodes.join(','))
+    return this.request('GET', `/market/quotes/full?scrip-codes=${q}`)
+  }
+
+  /** Lightweight last-traded-price for up to 1000 scrip-codes. */
+  getLtp(scripCodes: string[]): Promise<{ data: Record<string, IndstocksLtpRaw> }> {
+    const q = encodeURIComponent(scripCodes.join(','))
+    return this.request('GET', `/market/quotes/ltp?scrip-codes=${q}`)
+  }
+
+  /** GET /market/historical/{interval}. Times are epoch milliseconds. */
+  getHistorical(
+    interval: string,
+    scripCode: string,
+    startMs: number,
+    endMs: number,
+  ): Promise<{ data: IndstocksCandle[] }> {
+    const q = `scrip-codes=${encodeURIComponent(scripCode)}&start_time=${startMs}&end_time=${endMs}`
+    return this.request('GET', `/market/historical/${interval}?${q}`)
+  }
+
+  /**
+   * Instruments master (CSV). `source` ∈ equity | fno | index.
+   * Naive CSV parse (split on newlines/commas) — fine for the documented
+   * comma-only master. TODO: swap for a quote-aware CSV parser if any field
+   * can contain commas.
+   */
+  async getInstruments(source: 'equity' | 'fno' | 'index'): Promise<IndstocksInstrument[]> {
+    const csv = await this.requestText(`/market/instruments?source=${source}`)
+    const lines = csv.trim().split(/\r?\n/)
+    if (lines.length < 2) return []
+    const header = lines[0].split(',').map(h => h.trim())
+    const idx = (name: string) => header.indexOf(name)
+    const iSec = idx('SECURITY_ID')
+    const iSym = idx('TRADING_SYMBOL')
+    const iExch = idx('EXCH')
+    const iSeg = idx('SEGMENT')
+    const iName = idx('INSTRUMENT_NAME')
+    const iCustom = idx('CUSTOM_SYMBOL')
+    const iLot = idx('LOT_UNITS')
+    const iTick = idx('TICK_SIZE')
+
+    const out: IndstocksInstrument[] = []
+    for (let i = 1; i < lines.length; i++) {
+      const c = lines[i].split(',')
+      if (!c[iSec] || !c[iSym]) continue
+      out.push({
+        securityId: c[iSec].trim(),
+        tradingSymbol: c[iSym].trim(),
+        exch: (c[iExch] ?? '').trim(),
+        segment: (c[iSeg] ?? '').trim(),
+        instrumentName: (c[iName] ?? '').trim(),
+        customSymbol: iCustom >= 0 ? c[iCustom]?.trim() : undefined,
+        lotUnits: iLot >= 0 ? c[iLot]?.trim() : undefined,
+        tickSize: iTick >= 0 ? c[iTick]?.trim() : undefined,
+      })
+    }
+    return out
+  }
+}

--- a/services/uta/src/domain/trading/brokers/indstocks/indstocks-contracts.ts
+++ b/services/uta/src/domain/trading/brokers/indstocks/indstocks-contracts.ts
@@ -1,0 +1,123 @@
+/**
+ * Contract-resolution helpers for INDstocks.
+ *
+ * INDstocks identifies a tradeable instrument by `SECURITY_ID` (+ exchange),
+ * resolved from the instruments-master CSV. Inside OpenAlice we key on the
+ * human-readable trading symbol (like Alpaca keys on ticker); the broker
+ * resolves symbol → SECURITY_ID via its in-memory catalog at call time.
+ *
+ * v1 is equity-only (secType STK). F&O (FUT/OPT) — lot sizes, expiries,
+ * strikes — is deferred; see the TODOs.
+ */
+
+import { Contract, OrderState } from '@traderalice/ibkr'
+import '../../contract-ext.js'
+import { buildContract } from '../contract-builder.js'
+import type { BarInterval } from '../types.js'
+
+/** Default Indian exchange when a symbol is given without one (v1: NSE). */
+export const DEFAULT_EXCHANGE = 'NSE'
+
+/**
+ * Normalized BarInterval → INDstocks `{interval}` path segment.
+ * Docs: second (1s..15s), minute (1m..30m), hour (60m..240m), day/week/month.
+ * Range caps differ per tier (1d / 7d / 14d / 1y) — enforce at call site.
+ */
+export const IND_INTERVAL: Record<BarInterval, string> = {
+  '1m': '1m', '5m': '5m', '15m': '15m', '30m': '30m',
+  '1h': '60m', '4h': '240m', '1d': '1d', '1w': '1w',
+}
+
+/** Build a fully-validated equity Contract for an INDstocks symbol. */
+export function makeContract(symbol: string, exchange: string = DEFAULT_EXCHANGE): Contract {
+  return buildContract({
+    symbol: symbol.toUpperCase(),
+    secType: 'STK',
+    exchange,
+    currency: 'INR',
+  })
+}
+
+/**
+ * Resolve a Contract to an INDstocks trading symbol. Equity-only for v1:
+ * reject anything whose secType is set and not STK.
+ */
+export function resolveSymbol(contract: Contract): string | null {
+  if (!contract.symbol) return null
+  if (contract.secType && contract.secType !== 'STK') return null
+  return contract.symbol.toUpperCase()
+}
+
+/** Scrip-code used by quote/historical endpoints: `${EXCH}_${SECURITY_ID}`. */
+export function scripCode(exch: string, securityId: string): string {
+  return `${exch}_${securityId}`
+}
+
+/**
+ * Map an INDstocks order_status to an IBKR-style OrderState status.
+ * Full status vocabulary (docs):
+ *   QUEUED, O-PENDING, SL-PENDING, PROCESSING, ABORTED, INITIATED, SUCCESS,
+ *   CANCELLED, MODIFIED, PENDING, EXPIRED, FAILED, PARTIALLY FILLED,
+ *   PARTIALLY FILLED - CANCELLED, PARTIALLY FILLED - EXPIRED.
+ */
+export function mapIndOrderStatus(status: string): string {
+  const s = status.toUpperCase()
+  switch (s) {
+    case 'SUCCESS':
+    case 'FILLED':
+      return 'Filled'
+    case 'CANCELLED':
+    case 'EXPIRED':
+    case 'ABORTED':
+    case 'PARTIALLY FILLED - CANCELLED':
+    case 'PARTIALLY FILLED - EXPIRED':
+      return 'Cancelled'
+    case 'FAILED':
+      return 'Inactive'
+    case 'QUEUED':
+    case 'O-PENDING':
+    case 'SL-PENDING':
+    case 'PROCESSING':
+    case 'INITIATED':
+    case 'PENDING':
+    case 'MODIFIED':
+    case 'PARTIALLY FILLED':
+      return 'Submitted'   // still working
+    default:
+      return 'Submitted'
+  }
+}
+
+/** Build an IBKR OrderState from an INDstocks status string. */
+export function makeOrderState(status: string, rejectReason?: string): OrderState {
+  const s = new OrderState()
+  s.status = mapIndOrderStatus(status)
+  if (rejectReason) s.rejectReason = rejectReason
+  return s
+}
+
+// ==================== Order-field mapping (IBKR → INDstocks) ====================
+
+/** IBKR orderType → INDstocks `order_type`. v1 supports LIMIT/MARKET only. */
+export function ibkrOrderTypeToInd(orderType: string): string {
+  switch (orderType) {
+    case 'MKT': return 'MARKET'
+    case 'LMT': return 'LIMIT'
+    // STP / STP LMT have no native normal-order equivalent — stop-loss lives
+    // in the separate GTT "smart orders" API. TODO: wire GTT for STP support.
+    default: return 'LIMIT'
+  }
+}
+
+/** IBKR TIF → INDstocks `validity`. Only DAY/IOC exist. */
+export function ibkrTifToInd(tif: string): string {
+  return tif === 'IOC' ? 'IOC' : 'DAY'
+}
+
+/**
+ * `algo_id` is a required, exchange-specific constant in the place-order body.
+ * Docs: 99999 (NSE), 9999999999999999 (BSE).
+ */
+export function algoIdFor(exchange: string): string {
+  return exchange.toUpperCase() === 'BSE' ? '9999999999999999' : '99999'
+}

--- a/services/uta/src/domain/trading/brokers/indstocks/indstocks-stream.ts
+++ b/services/uta/src/domain/trading/brokers/indstocks/indstocks-stream.ts
@@ -1,0 +1,105 @@
+/**
+ * INDstocks order-update WebSocket.
+ *
+ *   wss://ws-order-updates.indstocks.com/api/v1/ws/trades
+ *   - auth: `Authorization: <accessToken>` header at handshake
+ *   - subscribe: {"action":"subscribe","mode":"order_updates"} (no instruments)
+ *   - server pushes {type:"order", order_id, order_status, filled_quantity, ...}
+ *   - periodic heartbeats arrive without order fields → ignored
+ *
+ * This is NOT part of the IBroker contract (which is poll-based: the UTA
+ * order-sync poller calls getOrder/getOpenOrders on a timer). It's opt-in
+ * push infrastructure: a consumer can construct this to get fills the instant
+ * they happen instead of waiting for the next poll.
+ *
+ * TODO (integration): have the UTA order-sync poller subscribe to this and
+ * collapse its pending-lane polling to a fallback. Until then it stands alone.
+ *
+ * NOTE on the daily token: a 403 at handshake (expired token) surfaces as an
+ * error/close; `onAuthError` fires so the caller can stop reconnecting and
+ * prompt the user to regenerate — same daily-token wall as the REST side.
+ */
+
+import WebSocket from 'ws'
+import type { IndstocksOrderUpdate } from './indstocks-types.js'
+
+const ORDER_WS_URL = 'wss://ws-order-updates.indstocks.com/api/v1/ws/trades'
+
+export interface IndstocksOrderStreamHandlers {
+  onUpdate: (u: IndstocksOrderUpdate) => void
+  onAuthError?: () => void
+  onError?: (err: Error) => void
+}
+
+export class IndstocksOrderStream {
+  private ws: WebSocket | null = null
+  private stopped = false
+  private retry = 0
+  private static readonly MAX_BACKOFF_MS = 30_000
+
+  constructor(
+    private accessToken: string,
+    private readonly handlers: IndstocksOrderStreamHandlers,
+  ) {}
+
+  /** Swap in a fresh daily token; takes effect on the next (re)connect. */
+  setToken(token: string): void {
+    this.accessToken = token
+  }
+
+  start(): void {
+    this.stopped = false
+    this.connect()
+  }
+
+  stop(): void {
+    this.stopped = true
+    this.ws?.close()
+    this.ws = null
+  }
+
+  private connect(): void {
+    if (this.stopped) return
+    const ws = new WebSocket(ORDER_WS_URL, { headers: { Authorization: this.accessToken } })
+    this.ws = ws
+
+    ws.on('open', () => {
+      this.retry = 0
+      ws.send(JSON.stringify({ action: 'subscribe', mode: 'order_updates' }))
+    })
+
+    ws.on('message', (raw: WebSocket.RawData) => {
+      let msg: unknown
+      try {
+        msg = JSON.parse(raw.toString())
+      } catch {
+        return   // non-JSON heartbeat / keepalive
+      }
+      const m = msg as Partial<IndstocksOrderUpdate>
+      // Order updates carry order_id; heartbeats don't. Filter on that.
+      if (m && typeof m.order_id === 'string' && m.order_status != null) {
+        this.handlers.onUpdate(m as IndstocksOrderUpdate)
+      }
+    })
+
+    ws.on('unexpected-response', (_req, res) => {
+      // 401/403 at handshake = bad/expired daily token. Don't hammer-reconnect.
+      if (res.statusCode === 401 || res.statusCode === 403) {
+        this.stopped = true
+        this.handlers.onAuthError?.()
+      }
+    })
+
+    ws.on('error', (err: Error) => {
+      this.handlers.onError?.(err)
+    })
+
+    ws.on('close', () => {
+      this.ws = null
+      if (this.stopped) return
+      const delay = Math.min(IndstocksOrderStream.MAX_BACKOFF_MS, 1000 * 2 ** this.retry)
+      this.retry++
+      setTimeout(() => this.connect(), delay)
+    })
+  }
+}

--- a/services/uta/src/domain/trading/brokers/indstocks/indstocks-types.ts
+++ b/services/uta/src/domain/trading/brokers/indstocks/indstocks-types.ts
@@ -1,0 +1,198 @@
+/**
+ * INDstocks (INDmoney) broker — config + raw API shapes.
+ *
+ * Source: https://api-docs.indstocks.com  (base https://api.indstocks.com)
+ *
+ * NOTE ON CREDENTIALS: INDstocks (like every SEBI-regulated Indian broker)
+ * issues an access token that EXPIRES EVERY 24h and can only be regenerated
+ * manually from web.indstocks.com — there is no refresh endpoint. So:
+ *   - `accessToken` is the daily-rotated secret (writeOnly in the preset).
+ *   - `userId` is the STABLE identity (INDstocks client id) and is what we
+ *     fingerprint the UTA on — fingerprinting the token would mint a brand-new
+ *     account id (and orphan the git commit log) every single day.
+ *
+ * Field names below mirror the documented JSON. They are marked best-effort:
+ * the public docs don't publish full response schemas, so confirm against a
+ * live response before trusting any individual field. (TODO: verify live.)
+ */
+
+export interface IndstocksBrokerConfig {
+  id?: string
+  label?: string
+  /** Daily-rotated access token (Authorization header, no "Bearer" prefix). */
+  accessToken: string
+  /** Stable INDstocks client/user id — used for identity, NOT auth. */
+  userId: string
+}
+
+// ==================== REST raw shapes (best-effort, verify live) ====================
+
+/** GET /user/profile — used purely as a token-validity probe at init(). */
+export interface IndstocksProfileRaw {
+  status: string
+  data?: {
+    user_id?: string
+    email?: string
+    first_name?: string
+    last_name?: string
+    ucc?: string
+    is_nse_onboarded?: boolean
+    is_bse_onboarded?: boolean
+  }
+}
+
+/** GET /funds (verified live shape). All values are numbers, INR. */
+export interface IndstocksFundsRaw {
+  status: string
+  data: {
+    sod_balance?: number          // start-of-day balance
+    withdrawal_balance?: number   // withdrawable cash
+    realized_pnl?: number
+    unrealized_pnl?: number
+    brokerage?: number
+    /** Product-wise available balance. */
+    detailed_avl_balance?: {
+      eq_cnc?: number
+      eq_mis?: number
+      eq_mtf?: number
+      [k: string]: number | undefined
+    }
+    [k: string]: unknown
+  }
+}
+
+/**
+ * GET /portfolio/holdings — delivery (Demat) holdings (verified live shape).
+ * NOTE: holdings carry NO exchange and NO LTP. `security_id` is the NSE id;
+ * market price must be fetched separately (we batch /market/quotes/ltp).
+ */
+export interface IndstocksHoldingRaw {
+  symbol: string
+  security_id: string
+  isin?: string
+  total_qty: number
+  avg_price: number
+  used_qty?: number
+  t1_qty?: number
+  dp_qty?: number
+}
+
+/** GET /portfolio/positions — intraday / F&O open positions. */
+export interface IndstocksPositionRaw {
+  trading_symbol?: string
+  security_id?: string
+  exchange?: string
+  segment?: string
+  product?: string
+  net_quantity: string | number
+  average_price: string | number
+  last_traded_price: string | number
+  market_value?: string | number
+  pnl_absolute?: string | number
+  multiplier?: string | number
+}
+
+/** POST /order response. */
+export interface IndstocksPlaceOrderRaw {
+  status: string
+  data?: {
+    order_id: string
+    order_status: string
+  }
+  message?: string
+}
+
+/** GET /order / GET /order-book row. */
+export interface IndstocksOrderRaw {
+  order_id: string
+  security_id?: string
+  trading_symbol?: string
+  exchange?: string
+  segment?: string
+  product?: string
+  txn_type: string            // BUY | SELL
+  order_type: string          // LIMIT | MARKET
+  validity?: string           // DAY | IOC
+  order_status: string        // see IND_ORDER_STATUS map
+  qty: string | number
+  filled_qty?: string | number
+  remaining_qty?: string | number
+  limit_price?: string | number
+  average_price?: string | number   // avg fill price
+  reject_reason?: string | null
+}
+
+/**
+ * POST /smart/order response (GTT / multi-leg). `order_data` holds the parent
+ * order(s); each may carry a `child_order_details` GTT leg (the SL/TP trigger
+ * that arms only after the parent fills).
+ */
+export interface IndstocksSmartOrderRaw {
+  status: string
+  message?: string
+  data?: {
+    order_data?: Array<{
+      order_id: string
+      order_status: string
+      child_order_details?: {
+        order_id: string
+        order_status: string
+      }
+    }>
+  }
+}
+
+/**
+ * Order-update message pushed over wss://ws-order-updates.indstocks.com.
+ * `type` is "order"; heartbeats arrive without these fields and are ignored.
+ */
+export interface IndstocksOrderUpdate {
+  type?: string
+  order_id: string
+  order_status: string
+  filled_quantity?: number
+  remaining_quantity?: number
+  average_price?: number
+  timestamp?: number
+}
+
+/** One bid/ask level inside market_depth (prices/qtys are comma-strings). */
+export interface IndstocksDepthLevel {
+  buy: { quantity: string; price: string }
+  sell: { quantity: string; price: string }
+}
+
+/**
+ * GET /market/quotes/full row, keyed by scrip-code in the response map
+ * (verified live shape). bid/ask are NOT top-level — they live in
+ * `market_depth[scrip].depth[0]` as comma-formatted strings ("1,318.10").
+ */
+export interface IndstocksQuoteRaw {
+  live_price?: number
+  day_open?: number
+  day_high?: number
+  day_low?: number
+  prev_close?: number
+  volume?: number
+  market_depth?: Record<string, { depth?: IndstocksDepthLevel[] }>
+}
+
+/** GET /market/quotes/ltp row — just the live price. */
+export interface IndstocksLtpRaw {
+  live_price?: number
+}
+
+/** One row of the GET /market/instruments CSV master after parsing. */
+export interface IndstocksInstrument {
+  securityId: string          // SECURITY_ID  — used in order/quote calls
+  tradingSymbol: string       // TRADING_SYMBOL — e.g. "RELIANCE"
+  exch: string                // EXCH — NSE | BSE
+  segment: string             // SEGMENT — E (equity) | FNO
+  instrumentName: string      // INSTRUMENT_NAME — EQUITY | FUTSTK | ...
+  customSymbol?: string       // CUSTOM_SYMBOL — descriptive name
+  lotUnits?: string           // LOT_UNITS — F&O lot size
+  tickSize?: string           // TICK_SIZE
+}
+
+/** Historical candle: [timestamp(ms), open, high, low, close, volume]. */
+export type IndstocksCandle = [number, number, number, number, number, number]

--- a/services/uta/src/domain/trading/brokers/presets.spec.ts
+++ b/services/uta/src/domain/trading/brokers/presets.spec.ts
@@ -43,6 +43,7 @@ const SAMPLE_CONFIGS: Record<string, Record<string, unknown>> = {
   alpaca:          { mode: 'paper', apiKey: 'k', apiSecret: 's' },
   'ibkr-tws':      { host: '127.0.0.1', port: 7497, clientId: 0 },
   longbridge:      { mode: 'live', appKey: 'k', appSecret: 's', accessToken: 't' },
+  indstocks:       { userId: 'u', accessToken: 't' },
   'ccxt-custom':   { exchange: 'kucoin', apiKey: 'k', secret: 's' },
   'leverup-monad': {
     mode: 'testnet',

--- a/services/uta/src/domain/trading/brokers/registry.ts
+++ b/services/uta/src/domain/trading/brokers/registry.ts
@@ -16,6 +16,7 @@ import { AlpacaBroker } from './alpaca/AlpacaBroker.js'
 import { IbkrBroker } from './ibkr/IbkrBroker.js'
 import { LeverupBroker } from './others/leverup/index.js'
 import { LongbridgeBroker } from './longbridge/index.js'
+import { IndstocksBroker } from './indstocks/index.js'
 import { MockBroker } from './mock/MockBroker.js'
 import type { BrokerEngine } from '@traderalice/uta-protocol'
 
@@ -47,6 +48,10 @@ export const BROKER_ENGINE_REGISTRY: Record<BrokerEngine, BrokerEngineEntry> = {
   longbridge: {
     configSchema: LongbridgeBroker.configSchema,
     fromConfig: LongbridgeBroker.fromConfig,
+  },
+  indstocks: {
+    configSchema: IndstocksBroker.configSchema,
+    fromConfig: IndstocksBroker.fromConfig,
   },
   mock: {
     configSchema: MockBroker.configSchema,


### PR DESCRIPTION
## Summary

Adds an `IBroker` adapter for **INDstocks** (INDmoney's trading API), wiring NSE/BSE Indian equities into UTA as a first-class broker engine — OpenAlice's first Indian-market broker.

- New `services/uta/src/domain/trading/brokers/indstocks/` — `IndstocksBroker` (full `IBroker` surface: lifecycle, contract search, place/modify/cancel/close, account/positions/orders, quotes, historical bars, market clock), hand-rolled REST client, contract/symbol mapping, order-update WebSocket stream, types, and a 22-test spec.
- `BrokerEngine` extended with `'indstocks'`; `registry.ts` + brokers `index.ts` wired; `presets.ts` `SerializedBrokerPreset.engine` de-duplicated to reuse `BrokerEngine`.
- `INDSTOCKS_PRESET` added to the broker preset catalog (Recommended / securities) with credential fields (stable **Client ID** + daily **Access Token**) and hints documenting the SEBI 24h-token reality and the DDPI-for-sells requirement.
- Preset fingerprints on the stable `userId`, **never** the daily `accessToken` (the token rotates every 24h — fingerprinting it would mint a new UTA id and orphan the commit log on each rotation).

## Scope & known limits (intentional — tracked as in-file TODOs)

- **Equities only.** F&O (FUT/OPT) deferred — upstream option-chain/greeks are "Coming Soon".
- **LIVE only.** INDstocks exposes no paper/sandbox; orders are real money. Test with tiny quantities.
- **Daily token, no refresh.** A 403 maps to a permanent `BrokerError('AUTH')` → halt + surface to the user (paste a fresh token). Never auto-renewed.
- **Selling holdings needs DDPI/eDIS active** in the INDmoney account; without it the venue returns a generic `InternalServerException` with no order_id — the adapter maps this to an actionable error hint rather than a mysterious failure.
- Field mappings follow the public docs and were spot-checked against live responses, but the broker is labelled **SCAFFOLD**: it has **not** been run through the UTA live-testing S1–S12 catalog (that catalog mandates demo accounts, which INDstocks doesn't provide). The successful order_id → cancel round-trip is still unproven (DDPI- and funds-blocked on the test account).

Treat this as a **live-only / experimental** broker until a full live-venue pass lands.

## Test plan

- [x] `npx tsc --noEmit` (Alice `src/`) — clean
- [x] `pnpm -F @traderalice/uta-protocol typecheck` — clean
- [x] `pnpm test` (whole monorepo) — **2053/2053 passing** (139 files), incl. the new 22-test `IndstocksBroker.spec.ts` and the `presets.spec.ts` catalog round-trip guard
- [ ] UTA live-testing S1–S12 against a real INDstocks account (deferred — no demo account exists upstream)

## Boundary touch

Trading / broker / credentials. New broker engine + credential preset; touches `services/uta` broker registry and `uta-protocol` preset catalog. No changes to FX, sealing, snapshots, or guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYGa4ykf6Suq3DZnSxVVKb
