### PR TITLE
feat(market-data): reach global equities via yfinance online search

### DIFF
--- a/packages/opentypebb/src/providers/yfinance/index.ts
+++ b/packages/opentypebb/src/providers/yfinance/index.ts
@@ -15,6 +15,7 @@ import { YFinanceKeyMetricsFetcher } from './models/key-metrics.js'
 import { YFinancePriceTargetConsensusFetcher } from './models/price-target-consensus.js'
 import { YFinanceCryptoSearchFetcher } from './models/crypto-search.js'
 import { YFinanceCurrencySearchFetcher } from './models/currency-search.js'
+import { YFinanceEquitySearchFetcher } from './models/equity-search.js'
 import { YFinanceCryptoHistoricalFetcher } from './models/crypto-historical.js'
 import { YFinanceCurrencyHistoricalFetcher } from './models/currency-historical.js'
 import { YFinanceBalanceSheetFetcher } from './models/balance-sheet.js'
@@ -61,6 +62,7 @@ export const yfinanceProvider = new Provider({
     BalanceSheet: YFinanceBalanceSheetFetcher,
     IncomeStatement: YFinanceIncomeStatementFetcher,
     CashFlowStatement: YFinanceCashFlowStatementFetcher,
+    EquitySearch: YFinanceEquitySearchFetcher,
     CryptoSearch: YFinanceCryptoSearchFetcher,
     CurrencyPairs: YFinanceCurrencySearchFetcher,
     CryptoHistorical: YFinanceCryptoHistoricalFetcher,

--- a/packages/opentypebb/src/providers/yfinance/models/equity-search.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/equity-search.ts
@@ -1,0 +1,60 @@
+/**
+ * Yahoo Finance Equity Search Model.
+ *
+ * Online fuzzy symbol search via Yahoo's /v1/finance/search endpoint. Unlike the
+ * SEC-backed local SymbolIndex (US-only), this reaches global exchanges — China
+ * A-shares (600519.SS / 000001.SZ), Taiwan (2330.TW), Vietnam (VIC.VN), HK, etc.
+ * The returned `symbol` is Yahoo's own ticker, so it feeds straight back into
+ * EquityHistorical to pull bars — discovery and quote share one namespace.
+ *
+ * Yahoo only matches Latin/pinyin company names (a CJK query like "茅台" returns
+ * nothing); we deliberately leave that to the AI caller, which knows
+ * 茅台 = Kweichow Moutai = 600519.SS.
+ *
+ * Maps to: openbb_yfinance equity search (Yahoo search quotes, EQUITY only).
+ */
+
+import { z } from 'zod'
+import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
+import { EquitySearchQueryParamsSchema, EquitySearchDataSchema } from '../../../standard-models/equity-search.js'
+import { searchYahooFinance } from '../utils/helpers.js'
+
+export const YFinanceEquitySearchQueryParamsSchema = EquitySearchQueryParamsSchema
+export type YFinanceEquitySearchQueryParams = z.infer<typeof YFinanceEquitySearchQueryParamsSchema>
+
+export const YFinanceEquitySearchDataSchema = EquitySearchDataSchema.extend({
+  exchange: z.string().nullable().default(null).describe('The exchange the security trades on.'),
+  quote_type: z.string().nullable().default(null).describe('The quote type of the asset.'),
+}).passthrough()
+export type YFinanceEquitySearchData = z.infer<typeof YFinanceEquitySearchDataSchema>
+
+export class YFinanceEquitySearchFetcher extends Fetcher {
+  static override transformQuery(params: Record<string, unknown>): YFinanceEquitySearchQueryParams {
+    return YFinanceEquitySearchQueryParamsSchema.parse(params)
+  }
+
+  static override async extractData(
+    query: YFinanceEquitySearchQueryParams,
+    _credentials: Record<string, string> | null,
+  ): Promise<Record<string, unknown>[]> {
+    if (!query.query) return []
+
+    const quotes = await searchYahooFinance(query.query)
+    return quotes
+      .filter((q: any) => q.quoteType === 'EQUITY')
+      .map((q: any) => ({
+        symbol: q.symbol ?? '',
+        name: q.longname ?? q.shortname ?? null,
+        exchange: q.exchDisp ?? null,
+        quote_type: q.quoteType ?? null,
+      }))
+      .filter((q) => q.symbol)
+  }
+
+  static override transformData(
+    query: YFinanceEquitySearchQueryParams,
+    data: Record<string, unknown>[],
+  ): YFinanceEquitySearchData[] {
+    return data.map(d => YFinanceEquitySearchDataSchema.parse(d))
+  }
+}

--- a/src/domain/market-data/__tests__/bbProviders/analysis.bbProvider.spec.ts
+++ b/src/domain/market-data/__tests__/bbProviders/analysis.bbProvider.spec.ts
@@ -27,7 +27,7 @@ function makeBarService(
   commodity = 'yfinance',
 ) {
   return createBarService({
-    marketSearch: { symbolIndex: {} as never, cryptoClient, currencyClient, commodityCatalog: {} as never },
+    marketSearch: { symbolIndex: {} as never, equityClient: {} as never, cryptoClient, currencyClient, commodityCatalog: {} as never },
     equityClient, cryptoClient, currencyClient, commodityClient,
     utaManager: { has: async () => false, get: async () => undefined, searchContracts: async () => [] },
     vendorProviders: { equity: 'yfinance', crypto: 'yfinance', currency: 'yfinance', commodity },

--- a/src/domain/market-data/__tests__/bbProviders/bars.bbProvider.spec.ts
+++ b/src/domain/market-data/__tests__/bbProviders/bars.bbProvider.spec.ts
@@ -22,7 +22,7 @@ function build(provider: string, creds: Record<string, string>): BarService {
   const currencyClient = new SDKCurrencyClient(executor, 'currency', provider, creds, routeMap)
   const commodityClient = new SDKCommodityClient(executor, 'commodity', provider, creds, routeMap)
   return createBarService({
-    marketSearch: { symbolIndex: {} as never, cryptoClient, currencyClient, commodityCatalog: {} as never },
+    marketSearch: { symbolIndex: {} as never, equityClient: {} as never, cryptoClient, currencyClient, commodityCatalog: {} as never },
     equityClient, cryptoClient, currencyClient, commodityClient,
     utaManager: { has: async () => false, get: async () => undefined, searchContracts: async () => [] },
     vendorProviders: { equity: provider, crypto: provider, currency: provider, commodity: provider },

--- a/src/domain/market-data/__tests__/bbProviders/calc-v2.bbProvider.spec.ts
+++ b/src/domain/market-data/__tests__/bbProviders/calc-v2.bbProvider.spec.ts
@@ -17,7 +17,7 @@ import { runScript } from '@/domain/analysis/calc-v2/index.js'
 function build(provider: string, creds: Record<string, string>): BarService {
   const ex = getSDKExecutor(); const rm = buildRouteMap()
   return createBarService({
-    marketSearch: { symbolIndex: {} as never, cryptoClient: new SDKCryptoClient(ex, 'crypto', provider, creds, rm), currencyClient: new SDKCurrencyClient(ex, 'currency', provider, creds, rm), commodityCatalog: {} as never },
+    marketSearch: { symbolIndex: {} as never, equityClient: {} as never, cryptoClient: new SDKCryptoClient(ex, 'crypto', provider, creds, rm), currencyClient: new SDKCurrencyClient(ex, 'currency', provider, creds, rm), commodityCatalog: {} as never },
     equityClient: new SDKEquityClient(ex, 'equity', provider, creds, rm),
     cryptoClient: new SDKCryptoClient(ex, 'crypto', provider, creds, rm),
     currencyClient: new SDKCurrencyClient(ex, 'currency', provider, creds, rm),

--- a/src/domain/market-data/aggregate-search.ts
+++ b/src/domain/market-data/aggregate-search.ts
@@ -12,12 +12,13 @@
  */
 import type { SymbolIndex } from './equity/symbol-index.js'
 import type { CommodityCatalog } from './commodity/commodity-catalog.js'
-import type { CryptoClientLike, CurrencyClientLike } from './client/types.js'
+import type { CryptoClientLike, CurrencyClientLike, EquityClientLike } from './client/types.js'
 
 export type AssetClass = 'equity' | 'crypto' | 'currency' | 'commodity'
 
 export interface MarketSearchDeps {
   symbolIndex: SymbolIndex
+  equityClient: EquityClientLike
   cryptoClient: CryptoClientLike
   currencyClient: CurrencyClientLike
   commodityCatalog: CommodityCatalog
@@ -69,6 +70,7 @@ export async function aggregateSymbolSearch(
   const q = query.trim()
   if (!q) return []
 
+  // Local SEC index — US-only, zero-latency, authoritative for US tickers.
   const equityResults = deps.symbolIndex
     .search(q, limit)
     .map((r) => ({ ...r, assetClass: 'equity' as const }))
@@ -77,9 +79,14 @@ export async function aggregateSymbolSearch(
     .search(q, limit)
     .map((r) => ({ ...r, assetClass: 'commodity' as const }))
 
-  const [cryptoSettled, currencySettled] = await Promise.allSettled([
+  const [cryptoSettled, currencySettled, equityOnlineSettled] = await Promise.allSettled([
     deps.cryptoClient.search({ query: q, provider: 'yfinance' }),
     deps.currencyClient.search({ query: q, provider: 'yfinance' }),
+    // Yahoo online search — reaches global exchanges (CN A-share .SS/.SZ, TW .TW,
+    // VN .VN, HK, …) the SEC index can't. Returned tickers are Yahoo-native, so
+    // they feed straight into getHistorical. Force yfinance regardless of the
+    // configured equity provider, same as crypto/currency above.
+    deps.equityClient.search({ query: q, provider: 'yfinance', is_symbol: false }),
   ])
 
   const cryptoResults = (cryptoSettled.status === 'fulfilled' ? cryptoSettled.value : []).map(
@@ -93,8 +100,26 @@ export async function aggregateSymbolSearch(
     })
     .map((r) => ({ ...r, assetClass: 'currency' as const }))
 
+  // Merge online equity hits, de-duped against the local SEC index by symbol —
+  // US names overlap both sources; keep the local entry (richer, authoritative).
+  const seenEquity = new Set(
+    equityResults.map((r) => String((r as Record<string, unknown>).symbol ?? '').toUpperCase()),
+  )
+  const equityOnlineResults = (equityOnlineSettled.status === 'fulfilled' ? equityOnlineSettled.value : [])
+    .filter((r) => {
+      const sym = String((r as Record<string, unknown>).symbol ?? '').toUpperCase()
+      if (!sym || seenEquity.has(sym)) return false
+      seenEquity.add(sym)
+      return true
+    })
+    .map((r) => {
+      const o = r as Record<string, unknown>
+      return { ...o, symbol: String(o.symbol), assetClass: 'equity' as const }
+    })
+
   const all: MarketSearchResult[] = [
     ...equityResults,
+    ...equityOnlineResults,
     ...cryptoResults,
     ...currencyResults,
     ...commodityResults,

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -26,6 +26,7 @@ function makeDeps(over: Partial<BarServiceDeps> = {}): BarServiceDeps {
   return {
     marketSearch: {
       symbolIndex: { search: () => [{ symbol: 'AAPL', name: 'Apple Inc.' }] },
+      equityClient: { search: async () => [] },
       cryptoClient: { search: async () => [] },
       currencyClient: { search: async () => [] },
       commodityCatalog: { search: () => [] },

--- a/src/main.ts
+++ b/src/main.ts
@@ -171,7 +171,7 @@ async function main() {
   const commodityCatalog = new CommodityCatalog()
   commodityCatalog.load()
 
-  const marketSearch = { symbolIndex, cryptoClient, currencyClient, commodityCatalog }
+  const marketSearch = { symbolIndex, equityClient, cryptoClient, currencyClient, commodityCatalog }
 
   // Federated bar layer — vendor (OpenTypeBB) + broker (UTA) OHLCV behind one
   // barId-keyed interface. Vendor branch live now; UTA branch lands with Phase 1.


### PR DESCRIPTION
## Summary
- Equity symbol discovery was US-only (local SEC index). Crypto/currency already federate Yahoo's online search — equity was the lone gap.
- Add a yfinance `EquitySearch` model (Yahoo `/v1/finance/search`, EQUITY only) and merge its hits into `aggregateSymbolSearch`, de-duped against the SEC index by symbol. `MarketSearchDeps` gains `equityClient`; wired at the composition root.
- `searchBars` / `marketSearchForResearch` now reach global equities — CN A-shares, HK, TW, VN, EU, JP, KR — answering the recurring community asks (A-share, then a wave of FR users). Tickers are Yahoo-native, so they feed straight into `getHistorical`; discovery and quote share one namespace. CJK-name recall is deliberately left to the AI caller (搜"茅台"无果 → AI 自己换 "Kweichow Moutai" / 600519.SS). No country is enumerated — the channel asks Yahoo's global index, so new markets are covered by default.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm -F @traderalice/opentypebb typecheck` clean
- [x] `pnpm test` — 150 files / 2164 passed
- [x] Real in-process loop (`searchBarSources` → `getBars`, the path the tools call): Moutai → `600519.SS` → 250 live bars; EU `MC.PA`/`SAP.DE`/`AIR.PA`/`ASML.AS`; JP `7203.T`; KR `005930.KS` — all return live bars

## Notes
- Known, intentionally-unhandled quirk: for multi-listed names Yahoo often ranks DR/ADR above the primary listing (LVMH → Thai DR before `MC.PA`). The candidate list still contains the primary; left to the AI to pick. These tools are AI-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
