### PR TITLE
feat(uta): sub-account (multi-wallet) layer for CCXT brokers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.60.0-beta.1",
+  "version": "0.61.0-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/uta-protocol/src/types/broker.ts
+++ b/packages/uta-protocol/src/types/broker.ts
@@ -210,6 +210,37 @@ export interface AccountInfo {
   dayTradesRemaining?: number
 }
 
+// ==================== Sub-accounts ====================
+
+/**
+ * A sub-account (a.k.a. wallet / compartment) WITHIN a single broker
+ * connection. Most brokers have exactly one and never implement
+ * `listSubAccounts` — they are treated as having a single implicit 'default'
+ * sub-account, and the `subAccountId` selector on reads/writes is ignored for
+ * them end-to-end (every broker today except CCXT).
+ *
+ * The asymmetric case is CCXT separate-wallet venues (Binance: spot /
+ * USDⓈ-M / COIN-M live behind distinct endpoints) and, in future, IBKR
+ * linked / FA accounts under one login. There the SAME connection spans
+ * several trading compartments, so a READ can scope to one (or aggregate
+ * across all) and a WRITE must name its target — placing an order is
+ * irreversible, so the ambiguity is resolved up front, never defaulted.
+ *
+ * `kind` is editorial taxonomy for the UI, not a routing key:
+ *   - 'spot'        a cash / spot wallet
+ *   - 'derivatives' a futures / swap / margin wallet
+ *   - 'unified'     a single cross-margin account that IS the whole thing
+ * Funding / earn / staking wallets are deliberately NOT enumerated — Alice
+ * trades; it does not custody-manage them.
+ */
+export interface SubAccountRef {
+  /** Stable id used as the `subAccountId` selector, e.g. 'spot', 'derivatives'. */
+  id: string
+  /** User-facing label, e.g. 'Spot', 'USDⓈ-M Futures'. */
+  label: string
+  kind: 'spot' | 'derivatives' | 'unified'
+}
+
 // ==================== Market data ====================
 
 /**
@@ -417,10 +448,42 @@ export interface IBroker<TMeta = unknown> {
   cancelOrder(orderId: string, orderCancel?: OrderCancel): Promise<PlaceOrderResult>
   closePosition(contract: Contract, quantity?: Decimal): Promise<PlaceOrderResult>
 
+  // ---- Sub-accounts (wallets / compartments within one connection) ----
+
+  /**
+   * Enumerate the sub-accounts this connection spans. OPTIONAL — a broker that
+   * omits it is treated as having a single implicit 'default' sub-account, and
+   * the `subAccountId` selector is ignored for it (every broker today except
+   * CCXT separate-wallet venues). Implementations return >1 ONLY for genuinely
+   * separate-wallet venues (CCXT Binance: spot / USDⓈ-M / COIN-M). Trading
+   * compartments only — funding / earn wallets are never enumerated.
+   */
+  listSubAccounts?(): Promise<SubAccountRef[]>
+
+  /**
+   * Which sub-account id a given contract trades in — derived from the
+   * INSTRUMENT (CCXT: a spot symbol vs a perp symbol route to different
+   * wallets). OPTIONAL — the UTA layer uses it to validate that a write's
+   * declared `subAccountId` is consistent with the instrument, so "place this
+   * on spot" with a perp contract loud-refuses instead of silently landing in
+   * the wrong wallet. Brokers with a single sub-account omit it.
+   */
+  subAccountForContract?(contract: Contract): string | undefined
+
   // ---- Queries ----
 
-  getAccount(): Promise<AccountInfo>
-  getPositions(): Promise<Position[]>
+  /**
+   * Account equity. `subAccountId` OPTIONAL: omitted ⇒ AGGREGATE across every
+   * sub-account (the rolled-up netLiquidation); a specific id ⇒ just that
+   * wallet. Single-sub-account brokers ignore the arg.
+   */
+  getAccount(subAccountId?: string): Promise<AccountInfo>
+  /**
+   * Positions / holdings. `subAccountId` OPTIONAL: omitted ⇒ ALL sub-accounts;
+   * a specific id ⇒ just that wallet's positions. Single-sub-account brokers
+   * ignore the arg.
+   */
+  getPositions(subAccountId?: string): Promise<Position[]>
   getOrders(orderIds: string[]): Promise<OpenOrder[]>
   /**
    * Look up a single order. `symbolHint` is the broker-native localSymbol

--- a/packages/uta-protocol/src/types/git.ts
+++ b/packages/uta-protocol/src/types/git.ts
@@ -244,6 +244,14 @@ export interface SimulatePriceChangeResult {
 export interface StagePlaceOrderParams {
   aliceId: string
   symbol?: string
+  /**
+   * Target sub-account (wallet) for multi-sub-account brokers (CCXT Binance:
+   * 'spot' / 'derivatives'). REQUIRED when the broker exposes >1 sub-account —
+   * the UTA layer loud-refuses a write without it rather than guessing. Ignored
+   * by single-sub-account brokers. Not persisted in the Operation schema; it is
+   * validated against the instrument and stamped into the commit message.
+   */
+  subAccountId?: string
   action: 'BUY' | 'SELL'
   orderType: string
   totalQuantity?: string
@@ -278,6 +286,11 @@ export interface StageClosePositionParams {
   symbol?: string
   /** Empty / undefined closes the full position. */
   qty?: string
+  /**
+   * Target sub-account — same semantics as `StagePlaceOrderParams.subAccountId`.
+   * REQUIRED for multi-sub-account brokers, ignored otherwise.
+   */
+  subAccountId?: string
 }
 
 // ==================== Operation Helpers ====================

--- a/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
@@ -47,6 +47,74 @@ describe('UTA — read-only / keyless write guard', () => {
   })
 })
 
+// ==================== Multi-sub-account write disambiguation ====================
+
+describe('UTA — sub-account write disambiguation', () => {
+  /** A MockBroker that pretends to be a separate-wallet venue (binance-shaped):
+   *  two sub-accounts, instrument routes by secType. */
+  function multiSubBroker(): MockBroker {
+    const b = new MockBroker()
+    ;(b as unknown as Record<string, unknown>).listSubAccounts = async () => ([
+      { id: 'spot', label: 'Spot', kind: 'spot' },
+      { id: 'derivatives', label: 'Futures', kind: 'derivatives' },
+    ])
+    ;(b as unknown as Record<string, unknown>).subAccountForContract = (c: Contract) =>
+      (c.secType === 'CRYPTO_PERP' || c.secType === 'FUT') ? 'derivatives' : 'spot'
+    return b
+  }
+
+  const placeParams = (subAccountId?: string) =>
+    ({ aliceId: 'mock-paper|AAPL', action: 'BUY', orderType: 'MKT', totalQuantity: '1', subAccountId } as never)
+
+  it('single-sub-account brokers need no selector and stamp nothing', async () => {
+    const { uta } = createUTA()  // plain MockBroker — one implicit default
+    await uta.listSubAccounts()
+    expect(() => uta.stagePlaceOrder(placeParams())).not.toThrow()
+    const res = uta.commit('buy AAPL')
+    expect(res.message).toBe('buy AAPL')  // no [sub:…] tag
+  })
+
+  it('multi-sub-account write WITHOUT a selector loud-refuses with the valid ids', async () => {
+    const { uta } = createUTA(multiSubBroker())
+    await uta.listSubAccounts()  // warm the cache
+    expect(() => uta.stagePlaceOrder(placeParams())).toThrow(/multiple sub-accounts.*spot.*derivatives/s)
+  })
+
+  it('multi-sub-account write WITH a valid, instrument-consistent selector stamps the commit message', async () => {
+    const { uta } = createUTA(multiSubBroker())
+    await uta.listSubAccounts()
+    expect(() => uta.stagePlaceOrder(placeParams('spot'))).not.toThrow()  // AAPL (STK) → spot
+    const res = uta.commit('buy AAPL')
+    expect(res.message).toBe('buy AAPL [sub:spot]')
+  })
+
+  it('rejects an unknown sub-account id', async () => {
+    const { uta } = createUTA(multiSubBroker())
+    await uta.listSubAccounts()
+    expect(() => uta.stagePlaceOrder(placeParams('funding'))).toThrow(/unknown sub-account "funding".*spot, derivatives/s)
+  })
+
+  it('rejects a selector that contradicts the instrument', async () => {
+    const { uta } = createUTA(multiSubBroker())
+    await uta.listSubAccounts()
+    // AAPL (STK) routes to 'spot'; asking for 'derivatives' is a wrong-wallet mistake.
+    expect(() => uta.stagePlaceOrder(placeParams('derivatives'))).toThrow(/trades in sub-account "spot", not "derivatives"/)
+  })
+
+  it('clears the staged sub-account between commits — no stamp bleed-through', async () => {
+    const { uta } = createUTA(multiSubBroker())
+    await uta.listSubAccounts()
+
+    uta.stagePlaceOrder(placeParams('spot'))
+    expect(uta.commit('first').message).toBe('first [sub:spot]')
+
+    // Second cycle: the tracker was cleared by the first commit, so this stamps
+    // only its own sub-account (not 'first's leftover 'spot' duplicated).
+    uta.stagePlaceOrder(placeParams('spot'))
+    expect(uta.commit('second').message).toBe('second [sub:spot]')
+  })
+})
+
 // ==================== Operation dispatch (via push) ====================
 
 describe('UTA — operation dispatch', () => {

--- a/services/uta/src/domain/trading/UnifiedTradingAccount.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.ts
@@ -9,7 +9,7 @@
 
 import Decimal from 'decimal.js'
 import { Contract, Order, ContractDescription, ContractDetails, UNSET_DECIMAL, UNSET_INTEGER, UNSET_DOUBLE } from '@traderalice/ibkr'
-import { BrokerError, type IBroker, type AccountInfo, type Position, type OpenOrder, type PlaceOrderResult, type Quote, type MarketClock, type AccountCapabilities, type BrokerHealth, type BrokerHealthInfo, type UTAReach, type UTATier, type TpSlParams, type Bar, type BarParams, type ExpandContractFilters, type ContractExpansion } from './brokers/types.js'
+import { BrokerError, type IBroker, type AccountInfo, type Position, type OpenOrder, type PlaceOrderResult, type Quote, type MarketClock, type AccountCapabilities, type BrokerHealth, type BrokerHealthInfo, type UTAReach, type UTATier, type TpSlParams, type Bar, type BarParams, type ExpandContractFilters, type ContractExpansion, type SubAccountRef } from './brokers/types.js'
 
 const REACH_RANK: Record<UTAReach, number> = { down: 0, connected: 1, readable: 2 }
 import { TradingGit } from './git/TradingGit.js'
@@ -109,6 +109,16 @@ export class UnifiedTradingAccount {
    *  probe and by live broker-call success/failure. */
   private _currentReach: UTAReach = 'down'
   private _connectPromise: Promise<void>
+  /** Sub-account (wallet) list, cached from the broker once it connects. Null
+   *  until first probed. Static per connection (CCXT derives it from venue
+   *  overrides — network-independent), so caching can't go stale. Drives the
+   *  write-disambiguation guard. */
+  private _subAccounts: SubAccountRef[] | null = null
+  /** Sub-account ids declared by writes staged-but-not-yet-committed, parallel
+   *  to the git staging area. Stamped into the commit message at commit time
+   *  (the ledger records the wallet without touching the Operation schema),
+   *  then cleared. */
+  private _stagedSubAccountIds: string[] = []
 
   constructor(broker: IBroker, options: UnifiedTradingAccountOptions = {}) {
     this.broker = broker
@@ -281,6 +291,12 @@ export class UnifiedTradingAccount {
   /** Initial broker connection — fire-and-forget from constructor. */
   private async _connect(): Promise<void> {
     this._currentReach = await this._attemptReach()
+    // Warm the sub-account cache once the transport is up, so the (sync)
+    // write-disambiguation guard has the list before any staging. Best-effort:
+    // a failure here must not break connection.
+    if (!this._disabled && this._currentReach !== 'down') {
+      try { await this._ensureSubAccounts() } catch { /* guard falls back to single-default */ }
+    }
     if (this._disabled) {
       console.warn(`UTA[${this.id}]: disabled — ${this._lastError}`)
       this._emitHealthChange()
@@ -479,12 +495,68 @@ export class UnifiedTradingAccount {
     }
   }
 
+  // ==================== Sub-accounts ====================
+
+  /** Fetch (and memoize) the broker's sub-account list. Brokers that don't
+   *  implement `listSubAccounts` collapse to a single implicit 'default'. */
+  private async _ensureSubAccounts(): Promise<SubAccountRef[]> {
+    if (this._subAccounts) return this._subAccounts
+    const list = this.broker.listSubAccounts ? await this.broker.listSubAccounts() : null
+    this._subAccounts = list && list.length ? list : [{ id: 'default', label: this.label, kind: 'unified' }]
+    return this._subAccounts
+  }
+
+  /** The sub-accounts (wallets) this connection spans. One element for ordinary
+   *  brokers; >1 only for separate-wallet venues (CCXT Binance: spot / futures). */
+  async listSubAccounts(): Promise<SubAccountRef[]> {
+    return this._ensureSubAccounts()
+  }
+
+  /**
+   * Resolve + validate the target sub-account for a WRITE. When the connection
+   * spans >1 sub-account, an explicit selector is REQUIRED (placing an order is
+   * irreversible — we never guess a wallet). The selector is also checked
+   * against the instrument: "place this on spot" with a perp contract
+   * loud-refuses. Returns the resolved id to stamp into the commit message, or
+   * undefined for single-sub-account brokers (nothing to disambiguate or stamp).
+   */
+  private _resolveWriteSubAccount(contract: Contract, requested?: string): string | undefined {
+    const subs = this._subAccounts ?? []
+    if (subs.length <= 1) return undefined  // single (or not-yet-probed) → nothing to disambiguate
+
+    const valid = subs.map(s => s.id).join(', ')
+    const expected = this.broker.subAccountForContract?.(contract)
+    const instr = contract.secType || 'this instrument'
+
+    if (!requested) {
+      throw new BrokerError('CONFIG',
+        `Account "${this.label}" has multiple sub-accounts (${subs.map(s => `${s.id} [${s.kind}]`).join(', ')}). ` +
+        `Re-issue this write with subAccountId` +
+        (expected ? `="${expected}" (where ${instr} trades).` : ` set to one of: ${valid}.`))
+    }
+    if (!subs.some(s => s.id === requested)) {
+      throw new BrokerError('CONFIG',
+        `Account "${this.label}": unknown sub-account "${requested}". Valid sub-accounts: ${valid}.`)
+    }
+    if (expected && expected !== requested) {
+      throw new BrokerError('CONFIG',
+        `Account "${this.label}": ${instr} trades in sub-account "${expected}", not "${requested}". ` +
+        `Re-issue with subAccountId="${expected}".`)
+    }
+    return requested
+  }
+
+  // ==================== Staging ====================
+
   stagePlaceOrder(params: StagePlaceOrderParams): AddResult {
     this._assertWritable()
     this._validatePlaceOrderParams(params)
     // Resolve aliceId → full contract via broker (fills secType, exchange, currency, conId, etc.)
     const contract = this.contractFromAliceId(params.aliceId)
     if (params.symbol) contract.symbol = params.symbol
+
+    const subAccountId = this._resolveWriteSubAccount(contract, params.subAccountId)
+    if (subAccountId) this._stagedSubAccountIds.push(subAccountId)
 
     const order = new Order()
     order.action = params.action
@@ -530,6 +602,9 @@ export class UnifiedTradingAccount {
     const contract = this.contractFromAliceId(params.aliceId)
     if (params.symbol) contract.symbol = params.symbol
 
+    const subAccountId = this._resolveWriteSubAccount(contract, params.subAccountId)
+    if (subAccountId) this._stagedSubAccountIds.push(subAccountId)
+
     return this.git.add({
       action: 'closePosition',
       contract,
@@ -545,7 +620,20 @@ export class UnifiedTradingAccount {
   // ==================== Git flow ====================
 
   commit(message: string): CommitPrepareResult {
-    return this.git.commit(message)
+    const result = this.git.commit(this._stampSubAccount(message))
+    // Sub-account intent is now baked into the persisted message — clear the
+    // transient tracker so the next staging batch starts clean.
+    this._stagedSubAccountIds = []
+    return result
+  }
+
+  /** Append a `[sub:…]` tag to the commit message recording which wallet(s) the
+   *  staged writes targeted. The ONLY place the sub-account is persisted — the
+   *  Operation / GitCommit schema is deliberately left untouched. No-op when no
+   *  multi-sub-account write was staged. */
+  private _stampSubAccount(message: string): string {
+    const ids = [...new Set(this._stagedSubAccountIds)]
+    return ids.length ? `${message} [sub:${ids.join(',')}]` : message
   }
 
   async push(): Promise<PushResult> {
@@ -562,6 +650,7 @@ export class UnifiedTradingAccount {
 
   async reject(reason?: string): Promise<RejectResult> {
     const result = await this.git.reject(reason)
+    this._stagedSubAccountIds = []
     Promise.resolve(this._onPostReject?.(this.id)).catch(() => {})
     return result
   }
@@ -758,9 +847,9 @@ export class UnifiedTradingAccount {
    * two surfaces agree by construction, at the cost of one extra broker
    * round-trip per account read (a 60s-poll path, not a hot path).
    */
-  async getAccount(): Promise<AccountInfo> {
-    const account = await this._callBroker(() => this.broker.getAccount())
-    const positions = await this.getPositions()
+  async getAccount(subAccountId?: string): Promise<AccountInfo> {
+    const account = await this._callBroker(() => this.broker.getAccount(subAccountId))
+    const positions = await this.getPositions(subAccountId)
     // Currency guard: position PnLs can only be summed when they all share
     // the account's base currency. Mixed-currency books (IBKR holding HKD +
     // USD lines) would otherwise blind-sum different units — the exact bug
@@ -779,8 +868,8 @@ export class UnifiedTradingAccount {
     return account
   }
 
-  async getPositions(): Promise<Position[]> {
-    const positions = await this._callBroker(() => this.broker.getPositions())
+  async getPositions(subAccountId?: string): Promise<Position[]> {
+    const positions = await this._callBroker(() => this.broker.getPositions(subAccountId))
     for (const p of positions) this.stampAliceId(p.contract)
     await this._reconcileWalletPositions(positions)
     return positions

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
@@ -830,29 +830,25 @@ describe('CcxtBroker — closePosition reduceOnly', () => {
 // ==================== getAccount ====================
 
 describe('CcxtBroker — getAccount', () => {
-  it('maps CCXT balance to AccountInfo', async () => {
+  it('netLiquidation = wallet equity; open derivative positions do NOT add their notional', async () => {
     const acc = makeAccount()
     setInitialized(acc, {})
 
     ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({
-      // Real CCXT shape: per-coin entries at top level. The aggregate
-      // free/used/total dicts also exist on real responses but our parser
-      // reads the per-coin form.
-      USDT: { free: 8000, used: 2000, total: 10000 },
+      // Per-coin entries; `total` already folds in margin + uPnL.
+      USDT: { free: 10000, used: 0, total: 10000 },
     })
-    // Positions must include contracts/contractSize/markPrice so the broker
-    // can reconstruct netLiquidation from fresh position market values.
+    // An open perp with a 5000 notional. The OLD model added markPrice*contracts
+    // to netLiq (→ 15000); the wallet-equity model adds NOTHING from positions —
+    // they only contribute uPnL to the display field (ANG-111).
     ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([
-      { contracts: 1, contractSize: 1, markPrice: 1500, unrealizedPnl: 500, realizedPnl: 100, side: 'long' },
-      { contracts: 1, contractSize: 1, markPrice: 500, unrealizedPnl: -200, realizedPnl: 50, side: 'long' },
+      { contracts: 1, contractSize: 1, markPrice: 5000, unrealizedPnl: 100, realizedPnl: 150, side: 'long' },
     ])
 
     const info = await acc.getAccount()
-    // netLiq = free (8000) + position market values (1500 + 500 = 2000) = 10000
-    expect(info.netLiquidation).toBe('10000')
-    expect(info.totalCashValue).toBe('8000')
-    expect(info.initMarginReq).toBe('2000')
-    expect(info.unrealizedPnL).toBe('300')
+    expect(info.netLiquidation).toBe('10000')   // wallet total — NOT 10000 + 5000 notional
+    expect(info.totalCashValue).toBe('10000')    // stablecoin total
+    expect(info.unrealizedPnL).toBe('100')        // display roll-up only
     expect(info.realizedPnL).toBe('150')
   })
 
@@ -876,9 +872,9 @@ describe('CcxtBroker — getAccount', () => {
     ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([])
 
     const info = await acc.getAccount()
-    expect(info.totalCashValue).toBe('1800')   // 1000 + 500 + 300
-    expect(info.initMarginReq).toBe('300')     // 200 + 0 + 100
-    expect(info.netLiquidation).toBe('1800')   // no positions, equity = cash
+    expect(info.totalCashValue).toBe('2100')   // stablecoin TOTAL: 1200 + 500 + 400
+    expect(info.netLiquidation).toBe('2100')   // no positions, equity = stablecoin total
+    expect(info.initMarginReq).toBe('0')       // no totalInitialMargin in this wallet's info
   })
 
   it('includes spot holdings value in netLiquidation', async () => {
@@ -900,6 +896,144 @@ describe('CcxtBroker — getAccount', () => {
     // netLiq = cash (1000) + spot value (0.5 * 60000 = 30000) = 31000
     expect(info.totalCashValue).toBe('1000')
     expect(info.netLiquidation).toBe('31000')
+  })
+
+  it('merges every wallet for separate-wallet venues + tolerates an unreachable wallet (binance)', async () => {
+    // Binance keeps spot / USDⓈ-M / COIN-M in separate wallets; getAccount must
+    // read all three and merge. A single fetchBalance() would see only spot and
+    // understate netLiq (the core ANG-111 bug). COIN-M often errors (-2015, not
+    // activated) and must be skipped, not crash the read.
+    const acc = makeAccount({ exchange: 'binance' })
+    setInitialized(acc, {})
+
+    const fb = vi.fn()
+      .mockResolvedValueOnce({ USDT: { total: 5000 } })                                  // spot wallet
+      .mockResolvedValueOnce({ USDT: { total: 4000 }, info: { totalInitialMargin: '7' } }) // USDⓈ-M wallet
+      .mockRejectedValueOnce(new Error('binance {"code":-2015,"msg":"permissions"}'))      // COIN-M: not activated
+    ;(acc as any).exchange.fetchBalance = fb
+    ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([])
+
+    const info = await acc.getAccount()
+    expect(fb).toHaveBeenCalledTimes(3)            // spot + future + delivery all attempted
+    expect(info.netLiquidation).toBe('9000')        // 5000 spot + 4000 futures (COIN-M skipped)
+    expect(info.totalCashValue).toBe('9000')
+    expect(info.initMarginReq).toBe('7')            // summed from the futures wallet's info
+  })
+})
+
+// ==================== sub-accounts ====================
+
+describe('CcxtBroker — sub-accounts', () => {
+  it('unified venues (bybit) expose a single default sub-account', async () => {
+    const acc = makeAccount()  // bybit — no subAccounts override
+    const subs = await acc.listSubAccounts()
+    expect(subs).toEqual([{ id: 'default', label: 'Account', kind: 'unified' }])
+  })
+
+  it('separate-wallet venues (binance) expose spot + derivatives', async () => {
+    const acc = makeAccount({ exchange: 'binance' })
+    const subs = await acc.listSubAccounts()
+    expect(subs).toEqual([
+      { id: 'spot', label: 'Spot', kind: 'spot' },
+      { id: 'derivatives', label: 'Futures', kind: 'derivatives' },
+    ])
+  })
+
+  it('subAccountForContract routes spot vs derivative instruments (binance)', () => {
+    const acc = makeAccount({ exchange: 'binance' })
+    const spot = new Contract(); spot.secType = 'CRYPTO'
+    const perp = new Contract(); perp.secType = 'CRYPTO_PERP'
+    expect(acc.subAccountForContract(spot)).toBe('spot')
+    expect(acc.subAccountForContract(perp)).toBe('derivatives')
+  })
+
+  it('subAccountForContract always answers the single id on unified venues', () => {
+    const acc = makeAccount()  // bybit
+    const perp = new Contract(); perp.secType = 'CRYPTO_PERP'
+    expect(acc.subAccountForContract(perp)).toBe('default')
+  })
+
+  it('getAccount(spot) reads ONLY the spot wallet and skips derivative PnL (binance)', async () => {
+    const acc = makeAccount({ exchange: 'binance' })
+    setInitialized(acc, {})
+
+    const fb = vi.fn().mockResolvedValue({ USDT: { total: 5000 } })
+    ;(acc as any).exchange.fetchBalance = fb
+    const fp = vi.fn().mockResolvedValue([])
+    ;(acc as any).exchange.fetchPositions = fp
+
+    const info = await acc.getAccount('spot')
+    expect(fb).toHaveBeenCalledTimes(1)              // only the spot wallet
+    expect(fb).toHaveBeenCalledWith({ type: 'spot' })
+    expect(fp).not.toHaveBeenCalled()                // spot scope → no derivative positions
+    expect(info.netLiquidation).toBe('5000')
+  })
+
+  it('getAccount(derivatives) reads the futures wallets + folds in perp uPnL (binance)', async () => {
+    const acc = makeAccount({ exchange: 'binance' })
+    setInitialized(acc, {})
+
+    const fb = vi.fn()
+      .mockResolvedValueOnce({ USDT: { total: 4000 }, info: { totalInitialMargin: '7' } }) // future
+      .mockRejectedValueOnce(new Error('binance {"code":-2015}'))                          // delivery skip
+    ;(acc as any).exchange.fetchBalance = fb
+    const fp = vi.fn().mockResolvedValue([
+      { contracts: 1, contractSize: 1, markPrice: 5000, unrealizedPnl: 120, side: 'long' },
+    ])
+    ;(acc as any).exchange.fetchPositions = fp
+
+    const info = await acc.getAccount('derivatives')
+    expect(fb).toHaveBeenCalledWith({ type: 'future' })
+    expect(fb).toHaveBeenCalledWith({ type: 'delivery' })
+    expect(fb).not.toHaveBeenCalledWith({ type: 'spot' })  // spot wallet NOT in this scope
+    expect(fp).toHaveBeenCalled()
+    expect(info.netLiquidation).toBe('4000')         // wallet equity, perp notional NOT added
+    expect(info.unrealizedPnL).toBe('120')           // display roll-up
+    expect(info.initMarginReq).toBe('7')
+  })
+
+  it('getAccount(unknown sub-account) loud-refuses with the valid ids (binance)', async () => {
+    const acc = makeAccount({ exchange: 'binance' })
+    setInitialized(acc, {})
+    ;(acc as any).exchange.fetchBalance = vi.fn().mockResolvedValue({ USDT: { total: 1 } })
+
+    await expect(acc.getAccount('funding')).rejects.toThrow(/unknown sub-account "funding".*spot, derivatives/s)
+  })
+
+  it('getPositions(spot) skips fetchPositions and returns only spot holdings (binance)', async () => {
+    const acc = makeAccount({ exchange: 'binance' })
+    setInitialized(acc, { 'BTC/USDT': makeSpotMarket('BTC', 'USDT', 'BTC/USDT') })
+
+    const fb = vi.fn().mockResolvedValue({ BTC: { total: 0.5 } })
+    ;(acc as any).exchange.fetchBalance = fb
+    const fp = vi.fn().mockResolvedValue([])
+    ;(acc as any).exchange.fetchPositions = fp
+    ;(acc as any).exchange.fetchTickers = vi.fn().mockResolvedValue({ 'BTC/USDT': { last: 60000 } })
+
+    const positions = await acc.getPositions('spot')
+    expect(fp).not.toHaveBeenCalled()                // no derivative positions in spot scope
+    expect(fb).toHaveBeenCalledWith({ type: 'spot' })
+    expect(positions).toHaveLength(1)
+    expect(positions[0].marketValue).toBe('30000')   // 0.5 BTC @ 60000
+  })
+
+  it('getPositions(derivatives) fetches positions, scoped to futures wallets (binance)', async () => {
+    const acc = makeAccount({ exchange: 'binance' })
+    setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })
+
+    const fb = vi.fn().mockResolvedValue({})  // no futures-wallet asset collateral
+    ;(acc as any).exchange.fetchBalance = fb
+    const fp = vi.fn().mockResolvedValue([
+      { symbol: 'BTC/USDT:USDT', contracts: 1, contractSize: 1, markPrice: 60000, entryPrice: 59000, unrealizedPnl: 1000, side: 'long' },
+    ])
+    ;(acc as any).exchange.fetchPositions = fp
+
+    const positions = await acc.getPositions('derivatives')
+    expect(fp).toHaveBeenCalled()
+    expect(fb).toHaveBeenCalledWith({ type: 'future' })
+    expect(fb).not.toHaveBeenCalledWith({ type: 'spot' })
+    expect(positions).toHaveLength(1)
+    expect(positions[0].side).toBe('long')
   })
 })
 

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -25,9 +25,9 @@ import {
   type TpSlParams,
   type Bar,
   type BarParams,
+  type SubAccountRef,
 } from '../types.js'
 import '../../contract-ext.js'
-import { aggregateAccountFromPositions } from '../../position-math.js'
 import { buildPosition } from '../contract-builder.js'
 import { CCXT_CREDENTIAL_FIELDS, type CcxtBrokerConfig, type CcxtMarket, type FundingRate, type OrderBook, type OrderBookLevel } from './ccxt-types.js'
 import { MAX_INIT_RETRIES, INIT_RETRY_BASE_MS } from './ccxt-types.js'
@@ -42,6 +42,7 @@ import {
 import { fuzzyRankContracts } from '../fuzzy-rank.js'
 import {
   type CcxtExchangeOverrides,
+  type CcxtSubAccountDef,
   exchangeOverrides,
   defaultFetchOrderById,
   defaultCancelOrderById,
@@ -49,6 +50,10 @@ import {
   defaultFetchPositions,
   defaultFetchAllOpenOrders,
 } from './overrides.js'
+
+/** The implicit single wallet a unified-account venue (okx / bybit UTA) exposes
+ *  — one plain fetchBalance() covers everything, so no selector is ever needed. */
+const UNIFIED_SUBACCOUNT: CcxtSubAccountDef = { id: 'default', label: 'Account', kind: 'unified', walletTypes: [] }
 
 // Treated as cash (1:1 to USD) when computing balances and as ineligible
 // for spot-position synthesis. Compared against `coin.toUpperCase()` so
@@ -651,16 +656,59 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
     return this.placeOrder(pos.contract, order, undefined, isDerivative ? { reduceOnly: true } : undefined)
   }
 
+  // ---- Sub-accounts ----
+
+  /** The sub-account decomposition for this venue: the override's list for
+   *  separate-wallet venues (binance), else the single unified default. */
+  private resolveSubAccounts(): CcxtSubAccountDef[] {
+    return this.overrides.subAccounts?.length ? this.overrides.subAccounts : [UNIFIED_SUBACCOUNT]
+  }
+
+  async listSubAccounts(): Promise<SubAccountRef[]> {
+    return this.resolveSubAccounts().map(s => ({ id: s.id, label: s.label, kind: s.kind }))
+  }
+
+  /** Which sub-account a contract trades in — derived from the instrument.
+   *  Derivatives (perp/future) → the 'derivatives' sub-account; everything else
+   *  → 'spot'. Single-sub-account venues always answer with that one id. */
+  subAccountForContract(contract: Contract): string | undefined {
+    const subs = this.resolveSubAccounts()
+    if (subs.length <= 1) return subs[0]?.id
+    const isDerivative = contract.secType === 'CRYPTO_PERP' || contract.secType === 'FUT'
+    const wantKind = isDerivative ? 'derivatives' : 'spot'
+    return (subs.find(s => s.kind === wantKind) ?? subs[0])?.id
+  }
+
+  /** Resolve a (possibly absent) selector to the sub-account defs in scope.
+   *  Omitted ⇒ all (aggregate); a known id ⇒ just that one; an unknown id ⇒
+   *  loud CONFIG error listing the valid ids (the agent reads it and retries). */
+  private scopedSubAccounts(subAccountId?: string): CcxtSubAccountDef[] {
+    const subs = this.resolveSubAccounts()
+    if (subAccountId == null) return subs
+    const match = subs.find(s => s.id === subAccountId)
+    if (!match) {
+      throw new BrokerError('CONFIG', `CcxtBroker[${this.id}]: unknown sub-account "${subAccountId}". Valid sub-accounts: ${subs.map(s => s.id).join(', ')}.`)
+    }
+    return [match]
+  }
+
+  /** CCXT balance `type`s to fetch for a scope. Empty array ⇒ undefined ⇒ a
+   *  single unscoped fetchBalance() (unified-default case). */
+  private walletTypesFor(subAccountId?: string): string[] | undefined {
+    const types = [...new Set(this.scopedSubAccounts(subAccountId).flatMap(s => s.walletTypes))]
+    return types.length ? types : undefined
+  }
+
   // ---- Queries ----
 
   /**
-   * Synthesize spot holdings (BTC/ETH/etc balances) into Position records.
+   * Synthesize asset holdings (BTC/ETH/etc balances) into Position records.
    *
    * CCXT's fetchPositions() only returns derivative positions
-   * (SWAP/FUTURES/MARGIN/OPTION); spot assets sit in fetchBalance() as
-   * per-currency entries. Without this synthesis, a UTA user holding only
-   * spot would see an empty positions list and a netLiquidation that
-   * reflects only their stablecoin balance.
+   * (SWAP/FUTURES/MARGIN/OPTION); plain asset balances sit in fetchBalance() as
+   * per-currency entries — and span multiple wallets on separate-wallet venues.
+   * Without this synthesis, a UTA user holding only spot would see an empty
+   * positions list and a netLiquidation that reflects only stablecoin balance.
    *
    * Treated as long positions priced at the current ticker — consistent
    * with how IBKR exposes equity holdings. avgCost is filled with markPrice
@@ -668,24 +716,30 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
    * (and bootstraps any unaccounted qty via `reconcileBalance` at observed
    * markPrice) — the `avgCostSource: 'wallet'` flag signals this.
    */
-  private async fetchSpotHoldings(prefetched?: Awaited<ReturnType<Exchange['fetchBalance']>>): Promise<Position[]> {
-    const balance = prefetched ?? await this.exchange.fetchBalance()
-    const bal = balance as unknown as Record<string, unknown>
+  private async fetchAssetHoldings(subAccountId?: string): Promise<Position[]> {
+    // The SAME fungible asset can sit in multiple wallets (e.g. BTC as a spot
+    // balance AND as futures-wallet collateral) — it's the same asset, so within
+    // the requested scope we aggregate by coin into ONE holding (ANG-111).
+    // Stablecoins are cash (valued in getAccount), not holdings here. The
+    // `subAccountId` selector narrows which wallets contribute: omitted ⇒ every
+    // wallet, 'spot' ⇒ the spot wallet, 'derivatives' ⇒ the futures wallets.
+    const { balances } = await this.gatherWalletBalances(subAccountId)
+
+    const qtyByCoin = new Map<string, Decimal>()
+    for (const b of balances) {
+      for (const [coin, entry] of Object.entries(b)) {
+        if (BALANCE_RESERVED_KEYS.has(coin)) continue
+        if (STABLECOIN_TO_USD.has(coin.toUpperCase())) continue
+        if (typeof entry !== 'object' || entry === null) continue
+        const total = new Decimal(String((entry as Record<string, unknown>)['total'] ?? 0))
+        if (total.lte(0)) continue
+        qtyByCoin.set(coin, (qtyByCoin.get(coin) ?? new Decimal(0)).plus(total))
+      }
+    }
 
     type Holding = { coin: string; quantity: Decimal; ccxtSymbol: string; market: CcxtMarket }
     const holdings: Holding[] = []
-
-    for (const [coin, entry] of Object.entries(bal)) {
-      if (BALANCE_RESERVED_KEYS.has(coin)) continue
-      if (STABLECOIN_TO_USD.has(coin.toUpperCase())) continue
-      if (typeof entry !== 'object' || entry === null) continue
-
-      const e = entry as Record<string, unknown>
-      const free = new Decimal(String(e['free'] ?? 0))
-      const used = new Decimal(String(e['used'] ?? 0))
-      const quantity = free.plus(used)
-      if (quantity.lte(0)) continue
-
+    for (const [coin, quantity] of qtyByCoin) {
       // Find the most preferred quote market for pricing this holding.
       let resolved: { ccxtSymbol: string; market: CcxtMarket } | null = null
       for (const quote of SPOT_QUOTE_PREFERENCE) {
@@ -697,10 +751,9 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
         }
       }
       if (!resolved) {
-        console.warn(`CcxtBroker[${this.id}]: spot holding ${coin} (${quantity.toString()}) — no <COIN>/USDT|USDC|USD spot market, skipping`)
+        console.warn(`CcxtBroker[${this.id}]: holding ${coin} (${quantity.toString()}) — no <COIN>/USDT|USDC|USD spot market, skipping`)
         continue
       }
-
       holdings.push({ coin, quantity, ...resolved })
     }
 
@@ -757,7 +810,40 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
     return result
   }
 
-  async getAccount(): Promise<AccountInfo> {
+  /**
+   * Fetch balances across the wallets in scope (ANG-111). Separate-wallet venues
+   * (binance: spot / USDⓈ-M / COIN-M behind distinct endpoints) declare
+   * `subAccounts`, each mapping to one or more CCXT balance `type`s; the
+   * `subAccountId` selector narrows which are fetched (omitted ⇒ every wallet).
+   * Unified venues (okx / bybit UTA — verified: spot/swap/contract all return the
+   * same pool) have no wallet types → one unscoped call. A per-wallet failure
+   * (e.g. an un-activated COIN-M wallet → -2015) is skipped loudly, not fatal.
+   * Also rolls up futures `totalInitialMargin` for the account's margin figure.
+   */
+  private async gatherWalletBalances(subAccountId?: string): Promise<{ balances: Array<Record<string, unknown>>; initMargin: Decimal }> {
+    const walletTypes = this.walletTypesFor(subAccountId)
+    const balances: Array<Record<string, unknown>> = []
+    let initMargin = new Decimal(0)
+    const accrue = (b: Record<string, unknown>) => {
+      balances.push(b)
+      const info = (b['info'] ?? {}) as Record<string, unknown>
+      if (info['totalInitialMargin'] !== undefined) initMargin = initMargin.plus(new Decimal(String(info['totalInitialMargin'])))
+    }
+    if (walletTypes?.length) {
+      for (const type of walletTypes) {
+        try {
+          accrue(await this.exchange.fetchBalance({ type }) as unknown as Record<string, unknown>)
+        } catch (err) {
+          console.warn(`CcxtBroker[${this.id}]: fetchBalance(${type}) skipped — ${err instanceof Error ? err.message.slice(0, 120) : String(err)}`)
+        }
+      }
+    } else {
+      accrue(await this.exchange.fetchBalance() as unknown as Record<string, unknown>)
+    }
+    return { balances, initMargin }
+  }
+
+  async getAccount(subAccountId?: string): Promise<AccountInfo> {
     // Keyless data sources have no account — return a zeroed one rather than
     // calling fetchBalance (which requires credentials). The federation excludes
     // keyless UTAs from equity aggregation, so this never shows as phantom cash.
@@ -766,81 +852,114 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
     }
     this.ensureInit()
 
+    // Derivative PnL only belongs to a scope that actually holds derivatives —
+    // a spot-only sub-account read must not fold in perp positions. (Validates
+    // the selector as a side effect: an unknown id throws here.)
+    const scoped = this.scopedSubAccounts(subAccountId)
+    const includesDerivatives = scoped.some(s => s.kind === 'derivatives' || s.kind === 'unified')
+
     try {
-      const [balance, rawPositions] = await Promise.all([
-        this.exchange.fetchBalance(),
-        this.exchange.fetchPositions(),
-      ])
-
-      const bal = balance as unknown as Record<string, unknown>
-
-      // Sum every stablecoin entry — not just USDT — into cash. OKX UTA
-      // and Binance both quote against multiple stablecoins (USDT, USDC,
-      // FDUSD, …) and a user can hold any of them.
-      let free = new Decimal(0)
-      let used = new Decimal(0)
-      for (const [coin, entry] of Object.entries(bal)) {
-        if (BALANCE_RESERVED_KEYS.has(coin)) continue
-        if (!STABLECOIN_TO_USD.has(coin.toUpperCase())) continue
-        if (typeof entry !== 'object' || entry === null) continue
-        const e = entry as Record<string, unknown>
-        free = free.plus(new Decimal(String(e['free'] ?? 0)))
-        used = used.plus(new Decimal(String(e['used'] ?? 0)))
+      // ── 1. Gather balances across the wallets in scope (ANG-111) ───────────
+      const { balances, initMargin } = await this.gatherWalletBalances(subAccountId)
+      if (balances.length === 0) {
+        throw new BrokerError('NETWORK', `CcxtBroker[${this.id}]: no wallet balance readable`)
       }
 
-      // Aggregate P&L and market value from derivative positions.
-      // We use position-level markPrice (which is fresh from the exchange's
-      // websocket feed) rather than balance.total (which is a cached wallet
-      // snapshot that may not update between funding/settlement cycles).
+      // ── 2. netLiquidation = Σ (every asset across every wallet) in USD ─────
+      // Each wallet's per-asset `total` already folds in margin + unrealized
+      // PnL (verified on binance futures: USDT total = walletBalance + uPnL),
+      // so summing wallet assets yields true equity. Positions NEVER enter this
+      // sum — adding their notional was the equity-overstatement bug. Stablecoins
+      // value at $1; everything else at its spot mark price.
+      let cash = new Decimal(0)
+      const qtyByCoin = new Map<string, Decimal>()
+      for (const b of balances) {
+        for (const [coin, entry] of Object.entries(b)) {
+          if (BALANCE_RESERVED_KEYS.has(coin)) continue
+          if (typeof entry !== 'object' || entry === null) continue
+          const total = new Decimal(String((entry as Record<string, unknown>)['total'] ?? 0))
+          if (total.lte(0)) continue
+          if (STABLECOIN_TO_USD.has(coin.toUpperCase())) cash = cash.plus(total)
+          else qtyByCoin.set(coin, (qtyByCoin.get(coin) ?? new Decimal(0)).plus(total))
+        }
+      }
+
+      let assetValue = new Decimal(0)
+      const priced: Array<{ coin: string; qty: Decimal; symbol: string }> = []
+      for (const [coin, qty] of qtyByCoin) {
+        let symbol: string | undefined
+        for (const quote of SPOT_QUOTE_PREFERENCE) {
+          const m = this.markets[`${coin}/${quote}`]
+          if (m && m.active !== false && m.type === 'spot') { symbol = `${coin}/${quote}`; break }
+        }
+        if (!symbol) { console.warn(`CcxtBroker[${this.id}]: balance asset ${coin} (${qty.toString()}) — no spot market to price, excluded from netLiq`); continue }
+        priced.push({ coin, qty, symbol })
+      }
+      if (priced.length) {
+        const symbols = priced.map(p => p.symbol)
+        let tickers: Record<string, { last?: number | null }> = {}
+        try {
+          tickers = await this.exchange.fetchTickers(symbols) as unknown as Record<string, { last?: number | null }>
+        } catch {
+          for (const s of symbols) {
+            try { tickers[s] = await this.exchange.fetchTicker(s) as unknown as { last?: number | null } } catch { /* warned below */ }
+          }
+        }
+        for (const p of priced) {
+          const last = tickers[p.symbol]?.last
+          if (last == null) { console.warn(`CcxtBroker[${this.id}]: no ticker for ${p.symbol} — ${p.coin} excluded from netLiq`); continue }
+          assetValue = assetValue.plus(p.qty.mul(new Decimal(String(last))))
+        }
+      }
+
+      // ── 3. unrealizedPnL: display roll-up of open derivative PnL ───────────
+      // (already baked into the wallet equity above, so NOT re-added to netLiq).
+      // Skipped for a spot-only scope — it has no derivative positions.
       let unrealizedPnL = new Decimal(0)
       let realizedPnL = new Decimal(0)
-      const aggregateInputs: Array<{ side: 'long' | 'short'; marketValue: string }> = []
-      for (const p of rawPositions) {
-        unrealizedPnL = unrealizedPnL.plus(new Decimal(String(p.unrealizedPnl ?? 0)))
-        realizedPnL = realizedPnL.plus(new Decimal(String((p as unknown as Record<string, unknown>).realizedPnl ?? 0)))
-
-        const contracts = new Decimal(String(p.contracts ?? 0)).abs()
-        const contractSize = new Decimal(String(p.contractSize ?? 1))
-        const quantity = contracts.mul(contractSize)
-        const markPrice = new Decimal(String(p.markPrice ?? 0))
-        const side: 'long' | 'short' = p.side === 'short' ? 'short' : 'long'
-        aggregateInputs.push({ side, marketValue: quantity.mul(markPrice).toString() })
+      if (includesDerivatives) {
+        try {
+          const rawPositions = await this.exchange.fetchPositions()
+          for (const p of rawPositions) {
+            unrealizedPnL = unrealizedPnL.plus(new Decimal(String(p.unrealizedPnl ?? 0)))
+            realizedPnL = realizedPnL.plus(new Decimal(String((p as unknown as Record<string, unknown>).realizedPnl ?? 0)))
+          }
+        } catch { /* positions are display-only here — don't fail the account read */ }
       }
-
-      // Fold spot holdings (BTC/ETH/etc balances) into position value.
-      // They behave like long positions — capital converted from cash into
-      // an asset — so they count toward netLiquidation, not totalCashValue.
-      const spotHoldings = await this.fetchSpotHoldings(balance)
-      for (const sp of spotHoldings) {
-        aggregateInputs.push({ side: 'long', marketValue: sp.marketValue })
-      }
-
-      const { netLiquidation } = aggregateAccountFromPositions(free, aggregateInputs)
 
       return {
         baseCurrency: 'USD',
-        netLiquidation: netLiquidation.toString(),
-        totalCashValue: free.toString(),
+        netLiquidation: cash.plus(assetValue).toString(),
+        totalCashValue: cash.toString(),
         unrealizedPnL: unrealizedPnL.toString(),
         realizedPnL: realizedPnL.toString(),
-        initMarginReq: used.toString(),
+        initMarginReq: initMargin.toString(),
       }
     } catch (err) {
       throw BrokerError.from(err)
     }
   }
 
-  async getPositions(): Promise<Position[]> {
+  async getPositions(subAccountId?: string): Promise<Position[]> {
     if (this.keyless) return []
     this.ensureInit()
+
+    // Derivative positions belong only to a scope that holds derivatives; a
+    // spot-only sub-account skips fetchPositions entirely. Asset holdings are
+    // scoped to the requested wallets inside fetchAssetHoldings. (Validates the
+    // selector — an unknown id throws here.)
+    const scoped = this.scopedSubAccounts(subAccountId)
+    const includesDerivatives = scoped.some(s => s.kind === 'derivatives' || s.kind === 'unified')
 
     try {
       const fetchOverride = this.overrides.fetchPositions
       const [raw, spotHoldings] = await Promise.all([
-        fetchOverride
-          ? fetchOverride(this.exchange, defaultFetchPositions)
-          : defaultFetchPositions(this.exchange),
-        this.fetchSpotHoldings(),
+        includesDerivatives
+          ? (fetchOverride
+              ? fetchOverride(this.exchange, defaultFetchPositions)
+              : defaultFetchPositions(this.exchange))
+          : Promise.resolve([] as Awaited<ReturnType<typeof defaultFetchPositions>>),
+        this.fetchAssetHoldings(subAccountId),
       ])
       const result: Position[] = []
 

--- a/services/uta/src/domain/trading/brokers/ccxt/overrides.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/overrides.ts
@@ -98,6 +98,30 @@ export interface CcxtExchangeOverrides {
     exchange: Exchange,
     defaultImpl: DefaultImpl<[Exchange], CcxtOrder[]>,
   ): Promise<CcxtOrder[]>
+
+  /** Sub-account (wallet / compartment) decomposition for SEPARATE-WALLET venues.
+   *  Binance keeps spot / USDⓈ-M / COIN-M in distinct wallets behind distinct
+   *  endpoints; each logical sub-account aggregates one or more CCXT balance
+   *  `type`s. Drives `listSubAccounts()`, scoped reads, and write disambiguation
+   *  (ANG-111). Leave undefined for UNIFIED-account venues (okx / bybit UTA),
+   *  where a single fetchBalance() returns the whole account — those expose one
+   *  implicit 'default' sub-account and never require a selector. A per-type
+   *  fetch failure (e.g. an un-activated COIN-M wallet → -2015) is skipped, not
+   *  fatal. */
+  subAccounts?: CcxtSubAccountDef[]
+}
+
+/** One CCXT sub-account: a logical wallet aggregating CCXT balance `type`s. */
+export interface CcxtSubAccountDef {
+  /** Selector id, e.g. 'spot' / 'derivatives'. */
+  id: string
+  /** User-facing label, e.g. 'Spot' / 'Futures'. */
+  label: string
+  /** Editorial taxonomy. 'unified' is reserved for the implicit single-wallet default. */
+  kind: 'spot' | 'derivatives' | 'unified'
+  /** CCXT balance `type`s this sub-account fetches and merges. Empty ⇒ a plain
+   *  unscoped fetchBalance() (the unified-default case). */
+  walletTypes: string[]
 }
 
 // ==================== Default implementations ====================
@@ -161,7 +185,20 @@ export async function defaultFetchAllOpenOrders(exchange: Exchange): Promise<Ccx
 
 // ==================== Registry ====================
 
+/** Binance keeps spot / USDⓈ-M / COIN-M in separate wallets behind separate
+ *  endpoints, so it splits into two trading sub-accounts: 'spot' (the spot
+ *  wallet) and 'derivatives' (USDⓈ-M `future` + COIN-M `delivery`, merged).
+ *  'delivery' is tolerated-on-failure — many accounts never activate COIN-M
+ *  (ANG-111). Reads aggregate across both unless scoped; writes must name one. */
+const binanceOverrides: CcxtExchangeOverrides = {
+  subAccounts: [
+    { id: 'spot', label: 'Spot', kind: 'spot', walletTypes: ['spot'] },
+    { id: 'derivatives', label: 'Futures', kind: 'derivatives', walletTypes: ['future', 'delivery'] },
+  ],
+}
+
 export const exchangeOverrides: Record<string, CcxtExchangeOverrides> = {
+  binance: binanceOverrides,
   bybit: bybitOverrides,
   hyperliquid: hyperliquidOverrides,
 }

--- a/services/uta/src/http/routes-trading.ts
+++ b/services/uta/src/http/routes-trading.ts
@@ -37,6 +37,7 @@ const placeOrderSchema = z.object({
   ocaGroup: z.string().optional(),
   takeProfit: z.object({ price: numericString }).optional(),
   stopLoss: z.object({ price: numericString, limitPrice: numericString.optional() }).optional(),
+  subAccountId: z.string().optional(),
   message,
 }).refine(
   (d) => d.totalQuantity != null || d.cashQty != null,
@@ -47,6 +48,7 @@ const closePositionSchema = z.object({
   aliceId: z.string().min(1),
   symbol: z.string().optional(),
   qty: numericString.optional(),
+  subAccountId: z.string().optional(),
   message,
 })
 
@@ -248,18 +250,26 @@ export function createTradingRoutes(ctx: UTAEngineContext) {
     }
   })
 
-  // Account info
+  // Sub-accounts (wallets) — one element for ordinary brokers, >1 for
+  // separate-wallet venues (CCXT Binance: spot / derivatives).
+  app.get('/uta/:id/subaccounts', async (c) => {
+    const account = resolveAccount(ctx, c)
+    if (!account) return c.json({ error: 'Account not found' }, 404)
+    return queryAccount(c, account, async () => ({ subAccounts: await account.listSubAccounts() }))
+  })
+
+  // Account info. `?subAccountId=` scopes to one wallet (omitted ⇒ aggregate).
   app.get('/uta/:id/account', async (c) => {
     const account = resolveAccount(ctx, c)
     if (!account) return c.json({ error: 'Account not found' }, 404)
-    return queryAccount(c, account, () => account.getAccount())
+    return queryAccount(c, account, () => account.getAccount(c.req.query('subAccountId')))
   })
 
-  // Positions
+  // Positions. `?subAccountId=` scopes to one wallet (omitted ⇒ all).
   app.get('/uta/:id/positions', async (c) => {
     const account = resolveAccount(ctx, c)
     if (!account) return c.json({ error: 'Account not found' }, 404)
-    return queryAccount(c, account, async () => ({ positions: await account.getPositions() }))
+    return queryAccount(c, account, async () => ({ positions: await account.getPositions(c.req.query('subAccountId')) }))
   })
 
   // Orders

--- a/src/services/uta-client/UTAAccountSDK.ts
+++ b/src/services/uta-client/UTAAccountSDK.ts
@@ -13,6 +13,7 @@
 import type {
   UTAClient,
   AccountInfo,
+  SubAccountRef,
   OrderHistoryEntry,
   TradeHistoryEntry,
   Position,
@@ -118,13 +119,23 @@ export class UTAAccountSDK {
 
   // ==================== Reads (existing routes) ====================
 
-  getAccount(): Promise<AccountInfo> {
-    return this.client.get<AccountInfo>(`/api/trading/uta/${encodeURIComponent(this.id)}/account`)
+  /** Sub-accounts (wallets) this connection spans — one for ordinary brokers,
+   *  >1 for separate-wallet venues (CCXT Binance: spot / derivatives). */
+  listSubAccounts(): Promise<SubAccountRef[]> {
+    return this.client
+      .get<{ subAccounts: SubAccountRef[] }>(`/api/trading/uta/${encodeURIComponent(this.id)}/subaccounts`)
+      .then((r) => r.subAccounts)
   }
 
-  getPositions(): Promise<Position[]> {
+  /** `subAccountId` scopes to one wallet; omitted ⇒ aggregate across all. */
+  getAccount(subAccountId?: string): Promise<AccountInfo> {
+    return this.client.get<AccountInfo>(`/api/trading/uta/${encodeURIComponent(this.id)}/account`, { subAccountId })
+  }
+
+  /** `subAccountId` scopes to one wallet; omitted ⇒ positions across all. */
+  getPositions(subAccountId?: string): Promise<Position[]> {
     return this.client
-      .get<{ positions: Position[] }>(`/api/trading/uta/${encodeURIComponent(this.id)}/positions`)
+      .get<{ positions: Position[] }>(`/api/trading/uta/${encodeURIComponent(this.id)}/positions`, { subAccountId })
       .then((r) => r.positions)
   }
 

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -239,12 +239,13 @@ hitting the broker, which otherwise expects the bare base ticker.`,
 If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.`,
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false)),
+        subAccountId: z.string().optional().describe('For multi-wallet venues (e.g. Binance: "spot" / "derivatives"), scope to one wallet. Omit for the aggregate across all wallets. Most brokers have a single wallet and ignore this.'),
       }).meta({ examples: [{ source: 'alpaca-paper' }] }),
-      execute: async ({ source }) => {
+      execute: async ({ source, subAccountId }) => {
         const targets = await manager.resolve(source)
         if (targets.length === 0) return await noAccountsError(manager, source)
         try {
-          const results = await Promise.all(targets.map(async (uta) => ({ source: uta.id, ...compactAccountInfo(await uta.getAccount()) })))
+          const results = await Promise.all(targets.map(async (uta) => ({ source: uta.id, ...compactAccountInfo(await uta.getAccount(subAccountId)) })))
           return results.length === 1 ? results[0] : results
         } catch (err) {
           return handleBrokerError(err)
@@ -258,8 +259,9 @@ If this tool returns an error with transient=true, wait a few seconds and retry 
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false)),
         symbol: z.string().optional().describe('Filter by ticker, or omit for all'),
+        subAccountId: z.string().optional().describe('For multi-wallet venues (e.g. Binance: "spot" / "derivatives"), scope to one wallet. Omit for holdings across all wallets.'),
       }).meta({ examples: [{ source: 'alpaca-paper' }] }),
-      execute: async ({ source, symbol }) => {
+      execute: async ({ source, symbol, subAccountId }) => {
         const targets = await manager.resolve(source)
         if (targets.length === 0) return { positions: [], ...(await noAccountsError(manager, source)) }
         // FX rates table — UTA's /fx-rates collects every currency in
@@ -286,8 +288,8 @@ If this tool returns an error with transient=true, wait a few seconds and retry 
           const allPositions: Array<Record<string, unknown>> = []
           const fxWarnings: string[] = []
           for (const uta of targets) {
-            const positions = await uta.getPositions()
-            const accountInfo = await uta.getAccount()
+            const positions = await uta.getPositions(subAccountId)
+            const accountInfo = await uta.getAccount(subAccountId)
 
             // Convert position market values to USD for cross-currency percentage calculations
             let totalMarketValueUsd = new Decimal(0)
@@ -568,6 +570,7 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
           price: z.string().describe('Stop loss trigger price'),
           limitPrice: z.string().optional().describe('Limit price for stop-limit SL (omit for stop-market)'),
         }).optional().describe('Stop loss order (single-level, full quantity)'),
+        subAccountId: z.string().optional().describe('Target wallet on multi-wallet venues (e.g. Binance: "spot" / "derivatives"). REQUIRED when the account spans multiple wallets — staging loud-refuses without it and lists the valid ids. Single-wallet brokers ignore it.'),
         commitMessage: z.string().optional().describe('Stage AND commit in one step with this message (your trading thesis). Push/approval still required.'),
       }).meta({ examples: [{ aliceId: 'alpaca-paper|AAPL', action: 'BUY', orderType: 'MKT', totalQuantity: '1', commitMessage: 'Entry: momentum breakout' }] }),
       execute: async ({ source, commitMessage, ...params }) => {
@@ -604,6 +607,7 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
         aliceId: z.string().describe('Contract ID (format: accountId|nativeKey, from searchContracts)'),
         symbol: z.string().optional().describe('Human-readable symbol. Optional.'),
         qty: positiveNumeric.optional().describe('Number of shares to sell. Decimal string. Default: sell all.'),
+        subAccountId: z.string().optional().describe('Target wallet on multi-wallet venues (e.g. Binance: "spot" / "derivatives"). REQUIRED when the account spans multiple wallets. Single-wallet brokers ignore it.'),
         commitMessage: z.string().optional().describe('Stage AND commit in one step with this message. Push/approval still required.'),
       }).meta({ examples: [{ aliceId: 'alpaca-paper|AAPL', commitMessage: 'Exit: thesis invalidated' }] }),
       execute: async ({ source, commitMessage, ...params }) => {

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -1,5 +1,5 @@
 import { fetchJson } from './client'
-import type { TradingAccount, UTASummary, AccountInfo, Position, WalletCommitLog, ReconnectResult, UTAConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, UTASnapshotSummary, EquityCurvePoint, PlaceOrderRequest, ClosePositionRequest, CancelOrderRequest, OrderErrorResponse, OrderHistoryEntry, TradeHistoryEntry } from './types'
+import type { TradingAccount, UTASummary, AccountInfo, SubAccountRef, Position, WalletCommitLog, ReconnectResult, UTAConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, UTASnapshotSummary, EquityCurvePoint, PlaceOrderRequest, ClosePositionRequest, CancelOrderRequest, OrderErrorResponse, OrderHistoryEntry, TradeHistoryEntry } from './types'
 
 /** Thrown by the one-shot order endpoints when the server returns non-2xx. Carries the phase. */
 export class OrderEntryError extends Error {
@@ -65,12 +65,20 @@ export const tradingApi = {
 
   /** Broker-side account info (cash, equity, margin) for a given UTA.
    *  Note `account` here is the *broker* account, distinct from the UTA. */
-  async utaAccount(utaId: string): Promise<AccountInfo> {
-    return fetchJson(`/api/trading/uta/${utaId}/account`)
+  async utaAccount(utaId: string, subAccountId?: string): Promise<AccountInfo> {
+    const qs = subAccountId ? `?subAccountId=${encodeURIComponent(subAccountId)}` : ''
+    return fetchJson(`/api/trading/uta/${utaId}/account${qs}`)
   },
 
-  async utaPositions(utaId: string): Promise<{ positions: Position[] }> {
-    return fetchJson(`/api/trading/uta/${utaId}/positions`)
+  async utaPositions(utaId: string, subAccountId?: string): Promise<{ positions: Position[] }> {
+    const qs = subAccountId ? `?subAccountId=${encodeURIComponent(subAccountId)}` : ''
+    return fetchJson(`/api/trading/uta/${utaId}/positions${qs}`)
+  },
+
+  /** Sub-accounts (wallets) a UTA spans — one for ordinary brokers,
+   *  >1 for separate-wallet venues (Binance: spot / derivatives). */
+  async utaSubAccounts(utaId: string): Promise<{ subAccounts: SubAccountRef[] }> {
+    return fetchJson(`/api/trading/uta/${utaId}/subaccounts`)
   },
 
   async utaOrders(utaId: string): Promise<{ orders: unknown[] }> {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -323,6 +323,14 @@ export interface AccountInfo {
   dayTradesRemaining?: number
 }
 
+/** A sub-account (wallet) within one broker connection. One for ordinary
+ *  brokers; >1 for separate-wallet venues (Binance: spot / derivatives). */
+export interface SubAccountRef {
+  id: string
+  label: string
+  kind: 'spot' | 'derivatives' | 'unified'
+}
+
 export interface Position {
   contract: {
     aliceId?: string
@@ -560,6 +568,8 @@ export interface PlaceOrderRequest {
   ocaGroup?: string
   takeProfit?: { price: string }
   stopLoss?: { price: string; limitPrice?: string }
+  /** Target wallet on multi-wallet venues — required when the account spans >1. */
+  subAccountId?: string
   message: string
 }
 
@@ -567,6 +577,8 @@ export interface ClosePositionRequest {
   aliceId: string
   symbol?: string
   qty?: string
+  /** Target wallet on multi-wallet venues — required when the account spans >1. */
+  subAccountId?: string
   message: string
 }
 

--- a/ui/src/components/uta/OrderEntryDialog.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Field, inputClass } from '../form'
 import { Dialog } from './Dialog'
 import { tradingApi, OrderEntryError } from '../../api/trading'
-import type { WalletPushResult, PlaceOrderRequest, ClosePositionRequest } from '../../api/types'
+import type { WalletPushResult, PlaceOrderRequest, ClosePositionRequest, SubAccountRef } from '../../api/types'
 
 // ==================== Modes ====================
 
@@ -14,6 +14,11 @@ interface Props {
   utaId: string
   mode: OrderEntryMode
   onClose: () => void
+  /** Sub-accounts (wallets) the UTA spans. >1 ⇒ the form shows a wallet picker
+   *  and requires a choice (the backend loud-refuses a write without one). */
+  subAccounts?: SubAccountRef[]
+  /** Pre-selected wallet (the page's current view scope). */
+  defaultSubAccountId?: string
   /** Called once after a *successful* push so the parent can refresh positions/orders without waiting for the polling tick. */
   onPushComplete?: (result: WalletPushResult) => void
 }
@@ -32,7 +37,7 @@ interface Props {
  *   - `close`: tiny confirm form with overridable qty for an existing
  *     position
  */
-export function OrderEntryDialog({ utaId, mode, onClose, onPushComplete }: Props) {
+export function OrderEntryDialog({ utaId, mode, onClose, subAccounts, defaultSubAccountId, onPushComplete }: Props) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<{ message: string; phase?: string } | null>(null)
   const [result, setResult] = useState<WalletPushResult | null>(null)
@@ -53,8 +58,8 @@ export function OrderEntryDialog({ utaId, mode, onClose, onPushComplete }: Props
         {result
           ? <PushResultPanel result={result} />
           : mode.kind === 'place'
-            ? <PlaceForm utaId={utaId} initialAliceId={mode.aliceId} submitting={submitting} error={error} setError={setError} setSubmitting={setSubmitting} setResult={setResult} onPushComplete={onPushComplete} />
-            : <CloseForm utaId={utaId} aliceId={mode.aliceId} initialQty={mode.quantity} symbol={mode.symbol} submitting={submitting} error={error} setError={setError} setSubmitting={setSubmitting} setResult={setResult} onPushComplete={onPushComplete} />
+            ? <PlaceForm utaId={utaId} initialAliceId={mode.aliceId} subAccounts={subAccounts} defaultSubAccountId={defaultSubAccountId} submitting={submitting} error={error} setError={setError} setSubmitting={setSubmitting} setResult={setResult} onPushComplete={onPushComplete} />
+            : <CloseForm utaId={utaId} aliceId={mode.aliceId} initialQty={mode.quantity} symbol={mode.symbol} subAccounts={subAccounts} defaultSubAccountId={defaultSubAccountId} submitting={submitting} error={error} setError={setError} setSubmitting={setSubmitting} setResult={setResult} onPushComplete={onPushComplete} />
         }
       </div>
 
@@ -87,12 +92,41 @@ function Header({ mode, onClose }: { mode: OrderEntryMode; onClose: () => void }
 
 interface SharedFormProps {
   utaId: string
+  subAccounts?: SubAccountRef[]
+  defaultSubAccountId?: string
   submitting: boolean
   error: { message: string; phase?: string } | null
   setError: (e: { message: string; phase?: string } | null) => void
   setSubmitting: (b: boolean) => void
   setResult: (r: WalletPushResult) => void
   onPushComplete?: (result: WalletPushResult) => void
+}
+
+/** Wallet picker for separate-wallet venues. Returns null (renders nothing)
+ *  when the account has a single wallet — the field only appears when a choice
+ *  is genuinely required. */
+function WalletPicker({ subAccounts, value, onChange }: {
+  subAccounts?: SubAccountRef[]
+  value: string
+  onChange: (id: string) => void
+}) {
+  if (!subAccounts || subAccounts.length <= 1) return null
+  return (
+    <Field label="Wallet — required">
+      <select className={inputClass} value={value} onChange={(e) => onChange(e.target.value)}>
+        {subAccounts.map(s => <option key={s.id} value={s.id}>{s.label}</option>)}
+      </select>
+      <p className="text-[11px] text-text-muted/60 mt-1">This venue has separate wallets; the order routes to the one you pick.</p>
+    </Field>
+  )
+}
+
+/** Initial wallet selection: the page's current scope if it names a real
+ *  wallet, else the first wallet. Empty when single-wallet (field is hidden). */
+function initialWallet(subAccounts?: SubAccountRef[], preferred?: string): string {
+  if (!subAccounts || subAccounts.length <= 1) return ''
+  if (preferred && subAccounts.some(s => s.id === preferred)) return preferred
+  return subAccounts[0].id
 }
 
 function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?: string }) {
@@ -105,12 +139,15 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
   const [tif, setTif] = useState('DAY')
   const [message, setMessage] = useState('')
   const [showAdvanced, setShowAdvanced] = useState(false)
+  const [subAccountId, setSubAccountId] = useState(() => initialWallet(p.subAccounts, p.defaultSubAccountId))
 
+  const multiWallet = (p.subAccounts?.length ?? 0) > 1
   const canSubmit =
     !!aliceId.trim() &&
     !!message.trim() &&
     (!!quantity.trim() || !!cashQty.trim()) &&
     (orderType !== 'LMT' || !!lmtPrice.trim()) &&
+    (!multiWallet || !!subAccountId) &&
     !p.submitting
 
   const handleSubmit = async () => {
@@ -126,6 +163,7 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
         ...(quantity.trim() && { totalQuantity: quantity.trim() }),
         ...(cashQty.trim() && { cashQty: cashQty.trim() }),
         ...(orderType === 'LMT' && lmtPrice.trim() && { lmtPrice: lmtPrice.trim() }),
+        ...(multiWallet && subAccountId && { subAccountId }),
       }
       const result = await tradingApi.placeOrder(p.utaId, body)
       p.setResult(result)
@@ -151,6 +189,8 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
           placeholder="okx-test|BTC/USDT"
         />
       </Field>
+
+      <WalletPicker subAccounts={p.subAccounts} value={subAccountId} onChange={setSubAccountId} />
 
       <div className="grid grid-cols-2 gap-3">
         <Field label="Action">
@@ -244,8 +284,10 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
 function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { aliceId: string; initialQty: string; symbol?: string }) {
   const [qty, setQty] = useState(initialQty)
   const [message, setMessage] = useState('')
+  const [subAccountId, setSubAccountId] = useState(() => initialWallet(p.subAccounts, p.defaultSubAccountId))
 
-  const canSubmit = !!message.trim() && !p.submitting
+  const multiWallet = (p.subAccounts?.length ?? 0) > 1
+  const canSubmit = !!message.trim() && (!multiWallet || !!subAccountId) && !p.submitting
 
   const handleSubmit = async () => {
     p.setError(null)
@@ -255,6 +297,7 @@ function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { al
         aliceId,
         ...(symbol && { symbol }),
         ...(qty.trim() && { qty: qty.trim() }),
+        ...(multiWallet && subAccountId && { subAccountId }),
         message: message.trim(),
       }
       const result = await tradingApi.closePosition(p.utaId, body)
@@ -277,6 +320,8 @@ function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { al
         <div className="text-[11px] text-text-muted uppercase tracking-wide">Closing</div>
         <div className="font-mono text-[13px] text-text">{aliceId}</div>
       </div>
+
+      <WalletPicker subAccounts={p.subAccounts} value={subAccountId} onChange={setSubAccountId} />
 
       <Field label="Quantity to close">
         <input

--- a/ui/src/demo/fixtures/trading.ts
+++ b/ui/src/demo/fixtures/trading.ts
@@ -2,6 +2,7 @@ import type {
   TradingAccount,
   UTASummary,
   AccountInfo,
+  SubAccountRef,
   Position,
   UTAConfig,
   EquityCurvePoint,
@@ -21,7 +22,7 @@ export const DEMO_UTA_CRYPTO = 'demo-crypto'
 export const demoTradingAccounts: TradingAccount[] = [
   { id: DEMO_UTA_PAPER, provider: 'alpaca', label: 'Alpaca Paper' },
   { id: DEMO_UTA_IBKR, provider: 'ibkr', label: 'IBKR Demo' },
-  { id: DEMO_UTA_CRYPTO, provider: 'ccxt', label: 'Binance Spot' },
+  { id: DEMO_UTA_CRYPTO, provider: 'ccxt', label: 'Binance' },
 ]
 
 const healthOk = {
@@ -49,7 +50,7 @@ export const demoUTASummaries: UTASummary[] = [
   },
   {
     id: DEMO_UTA_CRYPTO,
-    label: 'Binance Spot',
+    label: 'Binance',
     capabilities: { supportedSecTypes: ['CRYPTO'], supportedOrderTypes: ['MKT', 'LMT'] },
     health: healthOk,
   },
@@ -147,7 +148,40 @@ export const demoPositionsByUTA: Record<string, Position[]> = {
   [DEMO_UTA_CRYPTO]: [
     pos({ symbol: 'BTC/USDT', secType: 'CRYPTO', currency: 'USDT', qty: '0.18', avgCost: '64200.00', marketPrice: '66480.00' }),
     pos({ symbol: 'ETH/USDT', secType: 'CRYPTO', currency: 'USDT', qty: '1.5', avgCost: '3340.00', marketPrice: '3402.00' }),
+    pos({ symbol: 'BTC/USDT:USDT', secType: 'CRYPTO_PERP', currency: 'USDT', side: 'short', qty: '0.05', avgCost: '67100.00', marketPrice: '66480.00' }),
   ],
+}
+
+// ==================== Sub-accounts (wallets) ====================
+//
+// The crypto demo account is Binance-shaped: a separate-wallet venue with a
+// 'spot' and a 'derivatives' wallet. Every other demo UTA is single-wallet, so
+// the selector never renders for them. Reads scope by `?subAccountId=`; with no
+// selector the handler returns the aggregate (matches the live CCXT broker).
+
+const SINGLE_WALLET: SubAccountRef[] = [{ id: 'default', label: 'Account', kind: 'unified' }]
+
+export const demoSubAccountsByUTA: Record<string, SubAccountRef[]> = {
+  [DEMO_UTA_PAPER]: SINGLE_WALLET,
+  [DEMO_UTA_IBKR]: SINGLE_WALLET,
+  [DEMO_UTA_CRYPTO]: [
+    { id: 'spot', label: 'Spot', kind: 'spot' },
+    { id: 'derivatives', label: 'Futures', kind: 'derivatives' },
+  ],
+}
+
+/** Per-wallet account info for the crypto demo (spot + derivatives sum to the
+ *  aggregate in `demoAccountByUTA[DEMO_UTA_CRYPTO]`). */
+export const demoCryptoAccountBySub: Record<string, AccountInfo> = {
+  spot: { baseCurrency: 'USDT', netLiquidation: '11002.18', totalCashValue: '1104.20', unrealizedPnL: '503.40', realizedPnL: '-128.40' },
+  derivatives: { baseCurrency: 'USDT', netLiquidation: '4030.00', totalCashValue: '2000.00', unrealizedPnL: '-20.74', realizedPnL: '0.00', initMarginReq: '332.40' },
+}
+
+/** Per-wallet positions for the crypto demo: spot wallet holds the spot lines,
+ *  derivatives wallet holds the perp. */
+export const demoCryptoPositionsBySub: Record<string, Position[]> = {
+  spot: demoPositionsByUTA[DEMO_UTA_CRYPTO].filter(p => p.contract.secType === 'CRYPTO'),
+  derivatives: demoPositionsByUTA[DEMO_UTA_CRYPTO].filter(p => p.contract.secType === 'CRYPTO_PERP'),
 }
 
 // ==================== Equity curves ====================
@@ -383,6 +417,6 @@ export const demoTradeHistoryByUTA: Record<string, TradeHistoryEntry[]> = {
 export const demoUTAConfigs: UTAConfig[] = [
   { id: DEMO_UTA_PAPER, label: 'Alpaca Paper', presetId: 'alpaca-paper', enabled: true, guards: [], presetConfig: {} },
   { id: DEMO_UTA_IBKR, label: 'IBKR Demo', presetId: 'ibkr', enabled: true, guards: [], presetConfig: {} },
-  { id: DEMO_UTA_CRYPTO, label: 'Binance Spot', presetId: 'ccxt', enabled: true, guards: [], presetConfig: {} },
+  { id: DEMO_UTA_CRYPTO, label: 'Binance', presetId: 'ccxt', enabled: true, guards: [], presetConfig: {} },
 ]
 export const demoUTAConfig: UTAConfig = demoUTAConfigs[0]

--- a/ui/src/demo/handlers/trading.ts
+++ b/ui/src/demo/handlers/trading.ts
@@ -5,6 +5,10 @@ import {
   demoAccountByUTA,
   demoAccountInfo,
   demoPositionsByUTA,
+  demoSubAccountsByUTA,
+  demoCryptoAccountBySub,
+  demoCryptoPositionsBySub,
+  DEMO_UTA_CRYPTO,
   demoUTAConfigs,
   demoUTAConfig,
   demoEquityCurve,
@@ -57,12 +61,25 @@ export const tradingHandlers = [
     HttpResponse.json({ success: true, message: 'Demo mode — reconnect is a no-op.' }),
   ),
 
-  http.get('/api/trading/uta/:id/account', ({ params }) =>
-    HttpResponse.json(demoAccountByUTA[utaId(params)] ?? demoAccountInfo),
+  http.get('/api/trading/uta/:id/subaccounts', ({ params }) =>
+    HttpResponse.json({ subAccounts: demoSubAccountsByUTA[utaId(params)] ?? [{ id: 'default', label: 'Account', kind: 'unified' }] }),
   ),
-  http.get('/api/trading/uta/:id/positions', ({ params }) =>
-    HttpResponse.json({ positions: demoPositionsByUTA[utaId(params)] ?? [] }),
-  ),
+  http.get('/api/trading/uta/:id/account', ({ params, request }) => {
+    const id = utaId(params)
+    const sub = new URL(request.url).searchParams.get('subAccountId')
+    if (id === DEMO_UTA_CRYPTO && sub && demoCryptoAccountBySub[sub]) {
+      return HttpResponse.json(demoCryptoAccountBySub[sub])
+    }
+    return HttpResponse.json(demoAccountByUTA[id] ?? demoAccountInfo)
+  }),
+  http.get('/api/trading/uta/:id/positions', ({ params, request }) => {
+    const id = utaId(params)
+    const sub = new URL(request.url).searchParams.get('subAccountId')
+    if (id === DEMO_UTA_CRYPTO && sub && demoCryptoPositionsBySub[sub]) {
+      return HttpResponse.json({ positions: demoCryptoPositionsBySub[sub] })
+    }
+    return HttpResponse.json({ positions: demoPositionsByUTA[id] ?? [] })
+  }),
   http.get('/api/trading/uta/:id/orders', () => HttpResponse.json({ orders: [] })),
   http.get('/api/trading/uta/:id/order-history', ({ params }) =>
     HttpResponse.json({ orders: demoOrderHistoryByUTA[utaId(params)] ?? [] }),

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import type { ViewSpec } from '../tabs/types'
 import { api } from '../api'
 import { getIntlLocale } from '../lib/intl'
-import type { UTAConfig, BrokerPreset, AccountInfo, Position, BrokerHealthInfo, UTASnapshotSummary, EquityCurvePoint, OrderHistoryEntry, OrderHistoryStatus, TradeHistoryEntry } from '../api/types'
+import type { UTAConfig, BrokerPreset, AccountInfo, SubAccountRef, Position, BrokerHealthInfo, UTASnapshotSummary, EquityCurvePoint, OrderHistoryEntry, OrderHistoryStatus, TradeHistoryEntry } from '../api/types'
 import { useTradingConfig } from '../hooks/useTradingConfig'
 import { useAccountHealth } from '../hooks/useAccountHealth'
 import { PageHeader } from '../components/PageHeader'
@@ -35,6 +35,11 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   const [account, setAccount] = useState<AccountInfo | null>(null)
   const [positions, setPositions] = useState<Position[]>([])
   const [orders, setOrders] = useState<unknown[]>([])
+  // Sub-accounts (wallets). Empty/length-1 for ordinary brokers; >1 for
+  // separate-wallet venues (Binance: spot / derivatives). `selectedSub`
+  // undefined ⇒ the aggregate view across all wallets.
+  const [subAccounts, setSubAccounts] = useState<SubAccountRef[]>([])
+  const [selectedSub, setSelectedSub] = useState<string | undefined>(undefined)
   const [snapshots, setSnapshots] = useState<UTASnapshotSummary[]>([])
   const [editing, setEditing] = useState(false)
   const [orderMode, setOrderMode] = useState<OrderEntryMode | null>(null)
@@ -50,14 +55,28 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   const preset = useMemo<BrokerPreset | undefined>(() => presets.find(p => p.id === uta?.presetId), [presets, uta])
   const health: BrokerHealthInfo | undefined = id ? healthMap[id] : undefined
 
-  // Live polling — account/positions/orders refresh every 15s.
+  // Sub-account discovery — once per UTA. A failure (or a single-wallet
+  // broker) leaves the list empty, so the selector simply never renders.
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+    api.trading.utaSubAccounts(id)
+      .then(r => { if (!cancelled) setSubAccounts(r.subAccounts ?? []) })
+      .catch(() => { if (!cancelled) setSubAccounts([]) })
+    setSelectedSub(undefined)  // reset to aggregate when switching UTAs
+    return () => { cancelled = true }
+  }, [id])
+
+  // Live polling — account/positions/orders refresh every 15s. Account +
+  // positions scope to the selected wallet (undefined ⇒ aggregate); orders
+  // are not wallet-scoped (the venue order list is account-wide).
   const refreshLive = useCallback(async () => {
     if (!id) return
     setDataError(null)
     try {
       const [acct, pos, ord] = await Promise.all([
-        api.trading.utaAccount(id).catch(() => null),
-        api.trading.utaPositions(id).catch(() => ({ positions: [] as Position[] })),
+        api.trading.utaAccount(id, selectedSub).catch(() => null),
+        api.trading.utaPositions(id, selectedSub).catch(() => ({ positions: [] as Position[] })),
         api.trading.utaOrders(id).catch(() => ({ orders: [] as unknown[] })),
       ])
       setAccount(acct)
@@ -67,7 +86,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
     } catch (err) {
       setDataError(err instanceof Error ? err.message : String(err))
     }
-  }, [id])
+  }, [id, selectedSub])
 
   // Snapshots refresh more slowly (60s); same data feeds the NAV chart and
   // the 24h-delta anchor — no extra fetches needed.
@@ -223,7 +242,14 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
               screens it collapses to one column with the Account panel
               first — it's the summary. */}
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-4 items-start">
-            <div className="lg:order-2 lg:sticky lg:top-4 self-start min-w-0">
+            <div className="lg:order-2 lg:sticky lg:top-4 self-start min-w-0 space-y-3">
+              {subAccounts.length > 1 && (
+                <SubAccountSelector
+                  subAccounts={subAccounts}
+                  selected={selectedSub}
+                  onSelect={setSelectedSub}
+                />
+              )}
               <AccountPanel account={account} positions={positions} delta24h={delta24h} clock={clock} />
             </div>
 
@@ -272,6 +298,8 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
         <OrderEntryDialog
           utaId={uta.id}
           mode={orderMode}
+          subAccounts={subAccounts}
+          defaultSubAccountId={selectedSub}
           onClose={() => setOrderMode(null)}
           onPushComplete={() => { void refreshLive() }}
         />
@@ -289,6 +317,32 @@ function Shell({ title, children }: { title: string; children?: React.ReactNode 
       <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">
         <div className="max-w-[720px] mx-auto">{children}</div>
       </div>
+    </div>
+  )
+}
+
+// ==================== Sub-account selector ====================
+
+/** Segmented control for separate-wallet venues (Binance: spot / derivatives).
+ *  "All" is the aggregate (selected = undefined); each pill scopes the account
+ *  + positions view to one wallet. Only rendered when a UTA spans >1 wallet. */
+function SubAccountSelector({ subAccounts, selected, onSelect }: {
+  subAccounts: SubAccountRef[]
+  selected: string | undefined
+  onSelect: (id: string | undefined) => void
+}) {
+  const pill = (active: boolean) =>
+    `px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+      active ? 'bg-accent text-white' : 'text-text-muted hover:text-text hover:bg-surface-hover'
+    }`
+  return (
+    <div className="flex items-center gap-1 p-1 rounded-lg bg-surface border border-border">
+      <button type="button" className={pill(selected === undefined)} onClick={() => onSelect(undefined)}>All</button>
+      {subAccounts.map(s => (
+        <button key={s.id} type="button" className={pill(selected === s.id)} onClick={() => onSelect(s.id)} title={`${s.kind} wallet`}>
+          {s.label}
+        </button>
+      ))}
     </div>
   )
 }
@@ -329,9 +383,18 @@ function AccountPanel({ account, positions, delta24h, clock }: {
   const netLiq = Number(account.netLiquidation)
   const unrealized = Number(account.unrealizedPnL)
 
-  // Positions value = Σ marketValue of what the page already fetched — NOT
-  // netLiq − cash, which would bake in margin / quote-currency noise.
-  const positionsValue = sumFinite(positions.map(p => Number(p.marketValue)))
+  // Positions value = non-cash equity = netLiq − cash, so Cash + Positions
+  // Value ≡ Net Liquidation by construction. netLiq is now the sum of every
+  // wallet asset (stablecoins + priced holdings across spot/futures wallets,
+  // ANG-111); cash is the stablecoin slice, so the remainder is exactly the
+  // value of non-stablecoin holdings. Summing positions[].marketValue does NOT
+  // reconcile — it counts perp NOTIONAL (not equity) and omits non-stablecoin
+  // futures-wallet collateral. Fall back to the row sum only if netLiq/cash are
+  // unavailable.
+  const cashVal = Number(account.totalCashValue)
+  const positionsValue = Number.isFinite(netLiq) && Number.isFinite(cashVal)
+    ? netLiq - cashVal
+    : sumFinite(positions.map(p => Number(p.marketValue)))
   const utilizationPct = Number.isFinite(netLiq) && netLiq > 0
     ? (positionsValue / netLiq) * 100
     : null

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect, useCallback, useMemo } from 'react'
+import { Fragment, useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import type { ViewSpec } from '../tabs/types'
 import { api } from '../api'
@@ -70,8 +70,17 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   // Live polling — account/positions/orders refresh every 15s. Account +
   // positions scope to the selected wallet (undefined ⇒ aggregate); orders
   // are not wallet-scoped (the venue order list is account-wide).
+  //
+  // Latest-wins guard: scoped CCXT reads are slow (multi-wallet venues do
+  // several round-trips), so switching the sub-account pill twice quickly
+  // leaves two fetches in flight. Without this, the slower (older) response
+  // can land last and paint the WRONG wallet's data under the selected pill.
+  // Each call claims a sequence number; a response only applies if it's still
+  // the newest in flight.
+  const reqSeq = useRef(0)
   const refreshLive = useCallback(async () => {
     if (!id) return
+    const seq = ++reqSeq.current
     setDataError(null)
     try {
       const [acct, pos, ord] = await Promise.all([
@@ -79,11 +88,13 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
         api.trading.utaPositions(id, selectedSub).catch(() => ({ positions: [] as Position[] })),
         api.trading.utaOrders(id).catch(() => ({ orders: [] as unknown[] })),
       ])
+      if (seq !== reqSeq.current) return  // superseded by a newer refresh — discard
       setAccount(acct)
       setPositions(pos.positions)
       setOrders(ord.orders)
       setLastUpdated(new Date())
     } catch (err) {
+      if (seq !== reqSeq.current) return
       setDataError(err instanceof Error ? err.message : String(err))
     }
   }, [id, selectedSub])
@@ -247,7 +258,14 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
                 <SubAccountSelector
                   subAccounts={subAccounts}
                   selected={selectedSub}
-                  onSelect={setSelectedSub}
+                  onSelect={(sub) => {
+                    // Drop the previous wallet's numbers immediately so the
+                    // panel shows "Loading account info…" during the (slow,
+                    // multi-round-trip) scoped read instead of briefly painting
+                    // the old scope's net-liquidation under the new pill.
+                    setAccount(null)
+                    setSelectedSub(sub)
+                  }}
                 />
               )}
               <AccountPanel account={account} positions={positions} delta24h={delta24h} clock={clock} />


### PR DESCRIPTION
## Summary
- **New UTA sub-account layer.** CCXT separate-wallet venues (Binance: spot vs USDⓈ-M/COIN-M derivatives) expose one broker connection spanning *multiple* accounts — asymmetric to every other broker, which has a single implicit default. This adds a backward-compatible `SubAccountRef` abstraction (`id`/`label`/`kind: spot|derivatives|unified`) so a UTA can advertise the wallets it spans. Every non-CCXT broker (Alpaca/IBKR/Longbridge/Mock/LeverUp) is **untouched** — they report a single default and keep working via the optional `listSubAccounts?()` + ignored-optional-param contract.
- **Reads aggregate, writes disambiguate.** `getAccount`/`getPositions` take an optional `subAccountId` and scope to one wallet (omitted ⇒ aggregate across all wallets). Writes (`placeOrder`/`closePosition`) on a multi-wallet account **loudly refuse** when no selector is given — the error lists the valid ids + an instrument hint, so the AI reads it and self-corrects. No silent default routing. The guard lives in one place (`UnifiedTradingAccount`).
- **Ledger stamping without touching Trading-as-Git.** The chosen sub-account is appended to the commit message (` [sub:<ids>]`) rather than added to the `Operation`/`GitCommit` schema — deliberately keeping the Git layer's shape stable.
- **Frontend.** `UTADetailPage` renders an `All / Spot / Futures` selector **only** when a UTA spans >1 wallet (unified venues like OKX/Bybit show nothing). Selecting a pill scopes the account panel + positions. `OrderEntryDialog` gains a wallet picker. Demo handlers/fixtures updated to keep the marketing demo in sync (Binance demo is now multi-wallet).
- **Race fix (found while dogfooding).** Scoped CCXT reads are slow (multi-round-trip); switching pills twice quickly let an older response paint the wrong wallet's data under the selected pill. Fixed with a latest-wins sequence guard + clear-on-switch loading state.
- Bumps version to **0.61.0-beta.1**.

Verified end-to-end against the **Binance demo** account (demo funds only): full stage→commit→push trade cycle through the new `alice-uta` CLI, and the UI selector scoping confirmed via browser automation (All $20,585 / Spot $9,997 / Futures $10,588, matching the backend). Accounts left flat.

## Test plan
- [x] `npx tsc --noEmit` clean (Alice src)
- [x] `cd ui && npx tsc -b` clean (UI strict)
- [x] `pnpm -F @traderalice/uta-protocol typecheck` clean
- [x] `pnpm test` — 2195 passed, 6 skipped, 0 failed
- [x] Live dogfood: full trade cycle on Binance demo via CLI; UI scoping verified per-wallet

## Boundary touch
Touches **trading paths** (UTA core, CCXT broker, trading routes/SDK/tools). No auth/credential/migration changes. The Trading-as-Git schema is intentionally **not** modified — sub-account is carried in the commit message only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

