### PR TITLE
feat(uta): risk visibility (#387) + proxy bridging (#384) + partial-tolerant aggregation (#390)

### DIFF
--- a/packages/uta-protocol/src/types/broker.ts
+++ b/packages/uta-protocol/src/types/broker.ts
@@ -62,6 +62,31 @@ export class BrokerError extends Error {
 // ==================== Position ====================
 
 /**
+ * Venue risk metadata for a leveraged-derivative position (crypto perps /
+ * futures). Grouped into its own struct — rather than added as loose
+ * top-level fields — so the base Position stays aligned with IBKR's
+ * updatePortfolio() shape. IBKR itself keeps margin/leverage OFF the
+ * position: init/maint margin live on `OrderState`, and account-wide margin
+ * lives in the account-summary tags (ExcessLiquidity, MaintMarginReq, …),
+ * because there leverage is a cross-margin *account* concept, not a
+ * per-position one. On CCXT isolated/cross perps it genuinely IS
+ * per-position, so we surface it here.
+ *
+ * Absent (`Position.risk === undefined`) for spot holdings and for
+ * equity/cash brokers that don't expose per-position leverage. Numeric
+ * fields are strings for the same float-safety reason as the monetary
+ * fields on Position.
+ */
+export interface PositionRisk {
+  /** Effective leverage on the position, e.g. `'50'` for 50×. */
+  leverage?: string
+  /** Estimated liquidation price, denominated in the position's `currency`. */
+  liquidationPrice?: string
+  /** Margin mode the position runs under. */
+  marginMode?: 'cross' | 'isolated'
+}
+
+/**
  * Unified position/holding.
  * Field names aligned with IBKR EWrapper.updatePortfolio() parameters.
  */
@@ -101,6 +126,13 @@ export interface Position {
    * Undefined defaults to `'broker'` (current behavior, back-compat).
    */
   avgCostSource?: 'broker' | 'wallet'
+  /**
+   * Venue risk metadata for leveraged derivatives (see {@link PositionRisk}).
+   * Undefined for spot and for brokers without per-position leverage — so
+   * a consumer reading `position.risk?.leverage` gets `undefined` rather
+   * than a misleading implicit 1×.
+   */
+  risk?: PositionRisk
 }
 
 // ==================== Order result ====================

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
@@ -5,7 +5,7 @@
  * Tests focus on pure logic: searchContracts sorting/filtering, cancelOrder cache,
  * placeOrder notional conversion, and the constructor error path.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import Decimal from 'decimal.js'
 import { Contract, Order, UNSET_DOUBLE, UNSET_DECIMAL } from '@traderalice/ibkr'
 
@@ -108,6 +108,66 @@ describe('CcxtBroker — constructor', () => {
   it('defaults id to exchange-main', () => {
     const acc = makeAccount()
     expect(acc.id).toBe('bybit-main')
+  })
+
+  // ---- Env proxy bridging (issue #384) ----
+
+  describe('env proxy', () => {
+    const saved = { ...process.env }
+    beforeEach(() => {
+      for (const k of ['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'http_proxy', 'https_proxy', 'all_proxy']) delete process.env[k]
+    })
+    afterEach(() => { process.env = { ...saved } })
+
+    // CCXT's checkProxySettings() throws InvalidProxySettings if MORE THAN ONE
+    // of httpProxy/httpsProxy/socksProxy is set, so the invariant we must hold
+    // is "at most one proxy property set".
+    const proxiesSet = (ex: any) => [ex.httpProxy, ex.httpsProxy, ex.socksProxy].filter(Boolean)
+
+    it('sets exactly one proxy property (httpsProxy) from HTTPS_PROXY', () => {
+      process.env.HTTPS_PROXY = 'http://127.0.0.1:7897'
+      const ex = (makeAccount() as any).exchange
+      expect(ex.httpsProxy).toBe('http://127.0.0.1:7897')
+      expect(proxiesSet(ex)).toHaveLength(1)
+    })
+
+    it('collapses the common HTTP_PROXY + HTTPS_PROXY pair to a single httpsProxy (no InvalidProxySettings)', () => {
+      // clash/v2ray etc. export BOTH to the same local proxy — must not set two props.
+      process.env.HTTP_PROXY = 'http://127.0.0.1:7890'
+      process.env.HTTPS_PROXY = 'http://127.0.0.1:7890'
+      const ex = (makeAccount() as any).exchange
+      expect(proxiesSet(ex)).toHaveLength(1)
+      expect(ex.httpsProxy).toBe('http://127.0.0.1:7890')
+      expect(ex.httpProxy).toBeUndefined()
+    })
+
+    it('uses HTTP_PROXY as httpsProxy when only HTTP_PROXY is set', () => {
+      process.env.HTTP_PROXY = 'http://127.0.0.1:7890'
+      const ex = (makeAccount() as any).exchange
+      expect(ex.httpsProxy).toBe('http://127.0.0.1:7890')
+      expect(proxiesSet(ex)).toHaveLength(1)
+    })
+
+    it('routes a socks-only ALL_PROXY to socksProxy alone', () => {
+      process.env.ALL_PROXY = 'socks5://127.0.0.1:7897'
+      const ex = (makeAccount() as any).exchange
+      expect(ex.socksProxy).toBe('socks5://127.0.0.1:7897')
+      expect(proxiesSet(ex)).toHaveLength(1)
+    })
+
+    it('prefers an http(s) proxy over a socks ALL_PROXY (single prop)', () => {
+      process.env.HTTPS_PROXY = 'http://127.0.0.1:7890'
+      process.env.ALL_PROXY = 'socks5://127.0.0.1:7897'
+      const ex = (makeAccount() as any).exchange
+      expect(ex.httpsProxy).toBe('http://127.0.0.1:7890')
+      expect(ex.socksProxy).toBeUndefined()
+      expect(proxiesSet(ex)).toHaveLength(1)
+    })
+
+    it('does not touch proxy props when no proxy env is set', () => {
+      const ex = (makeAccount() as any).exchange
+      expect(proxiesSet(ex)).toHaveLength(0)
+    })
   })
 })
 
@@ -1057,6 +1117,7 @@ describe('CcxtBroker — getPositions', () => {
         leverage: 5,
         initialMargin: 23200,
         liquidationPrice: 48000,
+        marginMode: 'isolated',
       },
     ])
 
@@ -1068,6 +1129,64 @@ describe('CcxtBroker — getPositions', () => {
     expect(positions[0].avgCost).toBe('58000')
     expect(positions[0].marketPrice).toBe('60000')
     expect(positions[0].avgCostSource).toBe('broker')
+  })
+
+  it('surfaces leverage/liquidationPrice/marginMode in position.risk', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })
+
+    ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([
+      {
+        symbol: 'BTC/USDT:USDT', contracts: 0.002, contractSize: 1,
+        markPrice: 60000, entryPrice: 65790, unrealizedPnl: -11.49, side: 'long',
+        leverage: 50, liquidationPrice: 58800, marginMode: 'cross',
+      },
+    ])
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    // Numeric CCXT fields are stringified (float-safety, same as the
+    // monetary fields) and grouped under `risk`.
+    expect(positions[0].risk).toEqual({
+      leverage: '50',
+      liquidationPrice: '58800',
+      marginMode: 'cross',
+    })
+  })
+
+  it('omits risk when the venue reports no leverage data', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })
+
+    ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([
+      // No leverage / liquidationPrice / marginMode at all.
+      { symbol: 'BTC/USDT:USDT', contracts: 1, contractSize: 1, markPrice: 60000, entryPrice: 58000, unrealizedPnl: 2000, side: 'long' },
+    ])
+
+    const positions = await acc.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].risk).toBeUndefined()
+  })
+
+  it('drops a zero liquidationPrice but keeps the other risk fields', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })
+    ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([
+      // Cross perp: leverage + marginMode reported, liquidationPrice 0 (not computed).
+      { symbol: 'BTC/USDT:USDT', contracts: 1, contractSize: 1, markPrice: 60000, entryPrice: 58000, unrealizedPnl: 2000, side: 'long', leverage: 50, liquidationPrice: 0, marginMode: 'cross' },
+    ])
+    const positions = await acc.getPositions()
+    expect(positions[0].risk).toEqual({ leverage: '50', marginMode: 'cross' })
+  })
+
+  it('keeps marginMode alone when leverage and liqPrice are absent/zero', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })
+    ;(acc as any).exchange.fetchPositions = vi.fn().mockResolvedValue([
+      { symbol: 'BTC/USDT:USDT', contracts: 1, contractSize: 1, markPrice: 60000, entryPrice: 58000, unrealizedPnl: 2000, side: 'long', leverage: 0, marginMode: 'isolated' },
+    ])
+    const positions = await acc.getPositions()
+    expect(positions[0].risk).toEqual({ marginMode: 'isolated' })
   })
 
   it('skips zero-size positions', async () => {
@@ -1149,6 +1268,7 @@ describe('CcxtBroker — getPositions', () => {
     expect(btc.unrealizedPnL).toBe('0')
     expect(btc.contract.localSymbol).toBe('BTC/USDT')   // CCXT wire format (broker-native uniqueness)
     expect(btc.avgCostSource).toBe('wallet')           // signals UTA to reconstruct cost
+    expect(btc.risk).toBeUndefined()                   // spot holdings never carry leverage risk
   })
 
   it('combines free + used into spot quantity', async () => {

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod'
 import ccxt from 'ccxt'
 import Decimal from 'decimal.js'
-import type { Exchange, Order as CcxtOrder } from 'ccxt'
+import type { Exchange, Order as CcxtOrder, Position as CcxtRawPosition } from 'ccxt'
 import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL } from '@traderalice/ibkr'
 import {
   BrokerError,
@@ -17,6 +17,7 @@ import {
   type AccountCapabilities,
   type AccountInfo,
   type Position,
+  type PositionRisk,
   type PlaceOrderResult,
   type OpenOrder,
   type Quote,
@@ -54,6 +55,56 @@ import {
 /** The implicit single wallet a unified-account venue (okx / bybit UTA) exposes
  *  — one plain fetchBalance() covers everything, so no selector is ever needed. */
 const UNIFIED_SUBACCOUNT: CcxtSubAccountDef = { id: 'default', label: 'Account', kind: 'unified', walletTypes: [] }
+
+/**
+ * Pull leveraged-derivative risk metadata (leverage / liquidation price /
+ * margin mode) off a raw CCXT position. Returns `undefined` when the venue
+ * reported none — so the built Position carries no `risk` key at all rather
+ * than a bag of undefineds (spot holdings, or exchanges that omit these).
+ *
+ * Zeroes are treated as absent: a real leveraged position never has
+ * `leverage === 0` or `liquidationPrice === 0` (CCXT reports 0 when the field
+ * isn't computed), and surfacing a 0 liquidation price would read as
+ * "liquidates at $0", which is worse than absent. Numeric fields are
+ * stringified for the same float-safety reason as Position's monetary fields.
+ */
+function ccxtPositionRisk(p: CcxtRawPosition): PositionRisk | undefined {
+  const risk: PositionRisk = {}
+  if (p.leverage != null && p.leverage > 0) risk.leverage = String(p.leverage)
+  if (p.liquidationPrice != null && p.liquidationPrice > 0) risk.liquidationPrice = String(p.liquidationPrice)
+  if (p.marginMode === 'cross' || p.marginMode === 'isolated') risk.marginMode = p.marginMode
+  return Object.keys(risk).length > 0 ? risk : undefined
+}
+
+/**
+ * Bridge the process's outbound-proxy env vars onto a CCXT exchange instance.
+ *
+ * CCXT's Node fetch path does NOT honor the shell's HTTP_PROXY/HTTPS_PROXY on
+ * its own — the proxy must be set explicitly on the instance
+ * (`exchange.httpsProxy` / `.httpProxy` / `.socksProxy`); Node's native fetch
+ * likewise ignores those env vars unless a global undici dispatcher is
+ * installed. So a user in a geo-restricted region whose shell already routes
+ * everything through a local proxy (the common Binance/Bitget case) would see
+ * the browser reach the exchange while UTA's connection silently fails. We
+ * mirror the standard env vars onto the instance here. No-op when none are
+ * set. See issue #384 (bakabird's repro confirmed the per-instance fix).
+ */
+function applyEnvProxy(exchange: Exchange): void {
+  // CCXT forbids setting more than ONE of httpProxy / httpsProxy / socksProxy
+  // on an instance — checkProxySettings() throws InvalidProxySettings on the
+  // first request if two are set. The common clash/v2ray setup exports BOTH
+  // HTTP_PROXY and HTTPS_PROXY pointing at the same local proxy, so we must
+  // collapse to a single property rather than set each from its own env var.
+  // Exchange REST is HTTPS, so the chosen proxy carries all traffic via
+  // httpsProxy (or socksProxy for a socks:// URL). Precedence:
+  // HTTPS_PROXY > HTTP_PROXY > ALL_PROXY.
+  const proxy = process.env.HTTPS_PROXY || process.env.https_proxy
+    || process.env.HTTP_PROXY || process.env.http_proxy
+    || process.env.ALL_PROXY || process.env.all_proxy
+  if (!proxy) return
+  if (/^socks/i.test(proxy)) exchange.socksProxy = proxy
+  else exchange.httpsProxy = proxy
+}
 
 // Treated as cash (1:1 to USD) when computing balances and as ineligible
 // for spot-position synthesis. Compared against `coin.toUpperCase()` so
@@ -194,6 +245,11 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       if (v !== undefined) credentials[field] = v
     }
     this.exchange = new ExchangeClass(credentials)
+
+    // Route through the process's outbound proxy (if any) BEFORE the first
+    // request — loadMarkets() in init() is the first network call. CCXT won't
+    // pick up HTTP(S)_PROXY env on its own. See issue #384.
+    applyEnvProxy(this.exchange)
 
     if (config.sandbox) {
       try {
@@ -993,6 +1049,10 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
           // multiplier is canonical 1 here.
           multiplier: '1',
           avgCostSource: 'broker',
+          // Leveraged-derivative risk picture (leverage / liq price / margin
+          // mode). Spot holdings below never get one — they go through
+          // fetchAssetHoldings, which doesn't pass `risk`.
+          risk: ccxtPositionRisk(p),
         }))
       }
 

--- a/services/uta/src/domain/trading/brokers/ccxt/ccxt-types.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/ccxt-types.ts
@@ -55,14 +55,6 @@ export const INIT_RETRY_BASE_MS = envInt('CCXT_INIT_RETRY_BASE_MS', 500)
 // ==================== CCXT-specific types (not part of IBroker) ====================
 
 import type { Contract } from '@traderalice/ibkr'
-import type { Position } from '../types.js'
-
-/** Position with crypto-specific fields (leverage, margin, liquidation). */
-export interface CcxtPosition extends Position {
-  leverage?: number
-  margin?: number
-  liquidationPrice?: number
-}
 
 export interface FundingRate {
   contract: Contract

--- a/services/uta/src/domain/trading/brokers/contract-builder.ts
+++ b/services/uta/src/domain/trading/brokers/contract-builder.ts
@@ -18,7 +18,7 @@
 
 import { Contract } from '@traderalice/ibkr'
 import Decimal from 'decimal.js'
-import type { Position } from './types.js'
+import type { Position, PositionRisk } from './types.js'
 import { assertContract, type SecType } from '../contract-discipline.js'
 import { derivePositionMath } from '../position-math.js'
 
@@ -94,6 +94,9 @@ export interface BuildPositionInput {
   /** Pre-computed unrealizedPnL — see marketValue. */
   unrealizedPnL?: string
   avgCostSource?: 'broker' | 'wallet'
+  /** Venue risk metadata (leverage/liqPrice/marginMode) for leveraged
+   *  derivatives. Passed through verbatim; omitted ⇒ no `risk` on output. */
+  risk?: PositionRisk
 }
 
 /**
@@ -153,5 +156,6 @@ export function buildPosition(input: BuildPositionInput): Position {
     realizedPnL: input.realizedPnL,
     multiplier,
     ...(input.avgCostSource && { avgCostSource: input.avgCostSource }),
+    ...(input.risk && { risk: input.risk }),
   }
 }

--- a/services/uta/src/main.ts
+++ b/services/uta/src/main.ts
@@ -41,6 +41,17 @@ async function main(): Promise<void> {
   const startedAt = new Date().toISOString()
   console.log(`[uta] bootstrap @ ${startedAt}`)
 
+  // Surface outbound-proxy config at startup so a user behind a proxy can
+  // confirm UTA saw it — CCXT exchange instances are bridged onto it per
+  // broker (see CcxtBroker.applyEnvProxy / issue #384). Credentials in the
+  // URL (user:pass@) are redacted.
+  const outboundProxy = process.env.HTTPS_PROXY || process.env.https_proxy
+    || process.env.HTTP_PROXY || process.env.http_proxy
+    || process.env.ALL_PROXY || process.env.all_proxy
+  if (outboundProxy) {
+    console.log(`[uta] outbound proxy detected (${outboundProxy.replace(/\/\/[^@/]*@/, '//***@')}) — bridging into CCXT exchanges`)
+  }
+
   const config = await loadConfig()
 
   // ==================== Trading-only dependencies ====================

--- a/src/services/uta-client/UTAManagerSDK.spec.ts
+++ b/src/services/uta-client/UTAManagerSDK.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * UTAManagerSDK.resolve tier filtering (issue #390).
+ *
+ * `tradingOnly` drops keyless 'data'-tier sources (binance-readonly etc.) from
+ * the no-source aggregate so a region-blocked public-data account can't blank
+ * a user's portfolio. An explicit source still resolves a data-tier account.
+ */
+import { describe, it, expect } from 'vitest'
+import { UTAManagerSDK } from './UTAManagerSDK.js'
+import type { UTATier } from '@traderalice/uta-protocol'
+
+const summary = (id: string, tier: UTATier) => ({
+  id, label: id, capabilities: {},
+  health: { status: 'healthy', reach: 'connected', tier, consecutiveFailures: 0, recovering: false },
+})
+
+function fakeClient(utas: unknown[]) {
+  return {
+    get: async (path: string) => {
+      if (path === '/api/trading/uta') return { utas }
+      throw new Error(`unexpected GET ${path}`)
+    },
+  } as never
+}
+
+const UTAS = [
+  summary('alpaca-paper', 'trading'),
+  summary('ibkr', 'account'),
+  summary('binance-readonly', 'data'),
+  summary('okx-readonly', 'data'),
+]
+
+describe('UTAManagerSDK.resolve — tier filter (#390)', () => {
+  it('includes every account by default (back-compat, no opts)', async () => {
+    const m = new UTAManagerSDK({ client: fakeClient(UTAS) })
+    const ids = (await m.resolve()).map((u) => u.id).sort()
+    expect(ids).toEqual(['alpaca-paper', 'binance-readonly', 'ibkr', 'okx-readonly'])
+  })
+
+  it('drops data-tier sources when tradingOnly + no source', async () => {
+    const m = new UTAManagerSDK({ client: fakeClient(UTAS) })
+    const ids = (await m.resolve(undefined, { tradingOnly: true })).map((u) => u.id).sort()
+    expect(ids).toEqual(['alpaca-paper', 'ibkr'])
+  })
+
+  it('still resolves an explicit data-tier source even with tradingOnly', async () => {
+    const m = new UTAManagerSDK({ client: fakeClient(UTAS) })
+    const ids = (await m.resolve('binance-readonly', { tradingOnly: true })).map((u) => u.id)
+    expect(ids).toEqual(['binance-readonly'])
+  })
+
+  it('does not filter on an explicit source even when it matches a prefix', async () => {
+    const m = new UTAManagerSDK({ client: fakeClient(UTAS) })
+    const ids = (await m.resolve('alpaca', { tradingOnly: true })).map((u) => u.id)
+    expect(ids).toEqual(['alpaca-paper'])
+  })
+})

--- a/src/services/uta-client/UTAManagerSDK.ts
+++ b/src/services/uta-client/UTAManagerSDK.ts
@@ -77,12 +77,23 @@ export class UTAManagerSDK {
   }
 
   /** Async equivalent of `UTAManager.resolve(source?)`. Filters by id or
-   *  provider prefix when `source` is given. */
-  async resolve(source?: string): Promise<UTAAccountSDK[]> {
+   *  provider prefix when `source` is given.
+   *
+   *  `tradingOnly` (used by the user-portfolio aggregations — account /
+   *  portfolio / orders) drops keyless **'data'-tier** sources
+   *  (binance-readonly, okx-readonly, bybit-readonly) from the no-source
+   *  aggregate: they hold no user positions or orders, so including them only
+   *  adds failure surface — a region-blocked public-data source must not blank
+   *  the whole portfolio (issue #390). An explicit `source` still resolves a
+   *  data-tier account (you can query it directly). */
+  async resolve(source?: string, opts?: { tradingOnly?: boolean }): Promise<UTAAccountSDK[]> {
     const all = await this.listUTAs()
-    const matches = source
+    let matches = source
       ? all.filter((u) => u.id === source || u.id.startsWith(`${source}-`))
       : all
+    if (!source && opts?.tradingOnly) {
+      matches = matches.filter((u) => u.health.tier !== 'data')
+    }
     return matches.map((u) => new UTAAccountSDK({ client: this.client, id: u.id, label: u.label }))
   }
 

--- a/src/tool/trading.spec.ts
+++ b/src/tool/trading.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Trading tool aggregation — partial-tolerance (issue #390).
+ *
+ * One offline / region-blocked account must NOT blank every healthy account's
+ * data. These tests drive a fake manager whose accounts selectively reject,
+ * and assert the aggregating tools (getAccount / getPortfolio / getOrders)
+ * degrade per-account instead of throwing the whole result away.
+ */
+import { describe, it, expect } from 'vitest'
+import Decimal from 'decimal.js'
+import { BrokerError } from '@traderalice/uta-protocol'
+import { createTradingTools } from './trading.js'
+
+type AccOpts = { account?: Record<string, unknown>; positions?: unknown[]; orders?: unknown[]; fail?: boolean }
+
+const DEFAULT_ACCOUNT = { netLiquidation: '10000', baseCurrency: 'USD', totalCashValue: '10000', unrealizedPnL: '0', realizedPnL: '0' }
+
+function pos(symbol: string) {
+  return {
+    contract: { symbol, secType: 'CRYPTO', aliceId: `acc|${symbol}` },
+    currency: 'USD', side: 'long',
+    quantity: new Decimal(1), avgCost: '100', marketPrice: '110',
+    marketValue: '110', unrealizedPnL: '10', realizedPnL: '0',
+  }
+}
+
+function fakeAccount(id: string, o: AccOpts) {
+  const boom = () => { throw new BrokerError('NETWORK', `${id} is offline and reconnecting`) }
+  return {
+    id, label: id,
+    getAccount: async () => { if (o.fail) boom(); return o.account ?? DEFAULT_ACCOUNT },
+    getPositions: async () => { if (o.fail) boom(); return o.positions ?? [] },
+    getOrders: async () => { if (o.fail) boom(); return o.orders ?? [] },
+    getPendingOrderIds: () => [],
+  }
+}
+
+function fakeManager(accounts: ReturnType<typeof fakeAccount>[]) {
+  return {
+    resolve: async (_source?: string, _opts?: { tradingOnly?: boolean }) => accounts,
+    listUTAs: async () => accounts.map((a) => ({ id: a.id, label: a.label })),
+    getFxRates: async () => [],
+  } as never
+}
+
+// The AI-SDK tool wrapper exposes `.execute(args, options)`; our impls ignore
+// the second arg. Typed loosely to dodge the Tool's strict ToolExecuteFunction
+// param variance.
+function run(tool: { execute?: unknown }, args: unknown): Promise<unknown> {
+  return (tool.execute as (a: unknown, o: unknown) => Promise<unknown>)(args, {})
+}
+
+describe('trading tools — partial tolerance (#390)', () => {
+  it('getPortfolio returns healthy holdings + a degraded marker when one account is offline', async () => {
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', { positions: [pos('BTC')] }),
+      fakeAccount('bybit-readonly', { fail: true }),
+    ]))
+    const res = await run(tools.getPortfolio, {}) as { positions: unknown[]; degraded: Array<{ source: string; transient: boolean }> }
+    expect(res.positions).toHaveLength(1)
+    expect(res.degraded).toHaveLength(1)
+    expect(res.degraded[0].source).toBe('bybit-readonly')
+    expect(res.degraded[0].transient).toBe(true)
+  })
+
+  it('getPortfolio returns a bare positions array (no degraded key) when all healthy', async () => {
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', { positions: [pos('BTC')] }),
+      fakeAccount('alpaca', { positions: [pos('AAPL')] }),
+    ]))
+    const res = await run(tools.getPortfolio, {}) as unknown[]
+    expect(Array.isArray(res)).toBe(true)
+    expect(res).toHaveLength(2)
+  })
+
+  it('getAccount yields healthy account + error marker for the offline one', async () => {
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', {}),
+      fakeAccount('bybit-readonly', { fail: true }),
+    ]))
+    const res = await run(tools.getAccount, {}) as Array<Record<string, unknown>>
+    expect(res).toHaveLength(2)
+    const healthy = res.find((r) => r.source === 'binance-x')!
+    const broken = res.find((r) => r.source === 'bybit-readonly')!
+    expect(healthy.netLiquidation).toBeDefined()
+    expect(broken.error).toBeDefined()
+    expect(broken.transient).toBe(true)
+  })
+
+  it('getAccount with a single offline account returns the error object directly', async () => {
+    const tools = createTradingTools(fakeManager([fakeAccount('bybit-readonly', { fail: true })]))
+    const res = await run(tools.getAccount, {}) as Record<string, unknown>
+    expect(Array.isArray(res)).toBe(false)
+    expect(res.error).toBeDefined()
+    expect(res.source).toBe('bybit-readonly')
+  })
+
+  it('getAccount with a single healthy account returns the account object directly', async () => {
+    const tools = createTradingTools(fakeManager([fakeAccount('binance-x', {})]))
+    const res = await run(tools.getAccount, {}) as Record<string, unknown>
+    expect(Array.isArray(res)).toBe(false)
+    expect(res.source).toBe('binance-x')
+    expect(res.netLiquidation).toBeDefined()
+    expect(res.error).toBeUndefined()
+  })
+
+  it('getOrders returns healthy orders + degraded marker when one account is offline', async () => {
+    const order = {
+      orderId: 'o1', contract: { symbol: 'BTC', aliceId: 'acc|BTC' },
+      orderState: { status: 'Submitted' }, order: { orderId: 1 },
+    }
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', { orders: [order] }),
+      fakeAccount('bybit-readonly', { fail: true }),
+    ]))
+    const res = await run(tools.getOrders, {}) as { orders: unknown[]; degraded: Array<{ source: string }> }
+    expect(res.orders).toHaveLength(1)
+    expect(res.degraded).toHaveLength(1)
+    expect(res.degraded[0].source).toBe('bybit-readonly')
+  })
+
+  it('getOrders groupBy:contract degrades into { grouped, degraded } when an account fails', async () => {
+    const order = {
+      orderId: 'o1', contract: { symbol: 'BTC', aliceId: 'acc|BTC' },
+      orderState: { status: 'Submitted' }, order: { orderId: 1 },
+    }
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', { orders: [order] }),
+      fakeAccount('bybit-readonly', { fail: true }),
+    ]))
+    const res = await run(tools.getOrders, { groupBy: 'contract' }) as { grouped: Record<string, unknown>; degraded: Array<{ source: string }> }
+    expect(res.grouped['acc|BTC']).toBeDefined()
+    expect(res.degraded).toHaveLength(1)
+    expect(res.degraded[0].source).toBe('bybit-readonly')
+  })
+
+  it('getOrders groupBy:contract returns the bare grouped map when all healthy', async () => {
+    const order = {
+      orderId: 'o1', contract: { symbol: 'BTC', aliceId: 'acc|BTC' },
+      orderState: { status: 'Submitted' }, order: { orderId: 1 },
+    }
+    const tools = createTradingTools(fakeManager([fakeAccount('binance-x', { orders: [order] })]))
+    const res = await run(tools.getOrders, { groupBy: 'contract' }) as Record<string, unknown>
+    expect(res['acc|BTC']).toBeDefined()
+    expect(res.degraded).toBeUndefined()
+  })
+})

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -44,6 +44,33 @@ function handleBrokerError(err: unknown): { error: string; code: string; transie
   }
 }
 
+/** A per-account degradation marker: which account failed, and why. */
+type AccountFailure = { source: string } & ReturnType<typeof handleBrokerError>
+
+/**
+ * Run `fn` against every target account, tolerating per-account failure.
+ *
+ * Without this, one offline / region-blocked account (e.g. a `bybit-readonly`
+ * data source whose proxy exit node is geo-blocked) rejects the whole
+ * `Promise.all` and blanks EVERY healthy account's data — the user sees
+ * nothing instead of their real Binance/Bitget holdings (issue #390). Here a
+ * failed account degrades to a `{ source, ...error }` marker while the healthy
+ * ones still return.
+ */
+async function settlePerAccount<U extends { id: string }, T>(
+  targets: readonly U[],
+  fn: (uta: U) => Promise<T>,
+): Promise<{ ok: T[]; failed: AccountFailure[] }> {
+  const settled = await Promise.allSettled(targets.map((u) => fn(u)))
+  const ok: T[] = []
+  const failed: AccountFailure[] = []
+  settled.forEach((r, i) => {
+    if (r.status === 'fulfilled') ok.push(r.value)
+    else failed.push({ source: targets[i].id, ...handleBrokerError(r.reason) })
+  })
+  return { ok, failed }
+}
+
 /**
  * Summarize an OpenOrder for AI consumption. Uses the value-tolerant
  * compactors (NOT order.field.equals(...)) because over HTTP the Order's
@@ -236,33 +263,36 @@ hitting the broker, which otherwise expects the bare base ticker.`,
 
     getAccount: tool({
       description: `Query trading account info (netLiquidation, totalCashValue, buyingPower, unrealizedPnL, realizedPnL).
-If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.`,
+If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.
+When multiple accounts are queried, a healthy account appears with its balances and a failed one appears as an entry with an \`error\` field (and \`source\`). ALWAYS surface failed accounts to the user — an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry.`,
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false)),
         subAccountId: z.string().optional().describe('For multi-wallet venues (e.g. Binance: "spot" / "derivatives"), scope to one wallet. Omit for the aggregate across all wallets. Most brokers have a single wallet and ignore this.'),
       }).meta({ examples: [{ source: 'alpaca-paper' }] }),
       execute: async ({ source, subAccountId }) => {
-        const targets = await manager.resolve(source)
+        const targets = await manager.resolve(source, { tradingOnly: true })
         if (targets.length === 0) return await noAccountsError(manager, source)
-        try {
-          const results = await Promise.all(targets.map(async (uta) => ({ source: uta.id, ...compactAccountInfo(await uta.getAccount(subAccountId)) })))
-          return results.length === 1 ? results[0] : results
-        } catch (err) {
-          return handleBrokerError(err)
-        }
+        const { ok, failed } = await settlePerAccount(targets, async (uta) => ({ source: uta.id, ...compactAccountInfo(await uta.getAccount(subAccountId)) }))
+        // Single explicit account: keep the original shape (the account
+        // object, or the error directly).
+        if (targets.length === 1) return ok[0] ?? failed[0]
+        // Multi-account: healthy accounts + per-account error markers, so one
+        // offline broker can't blank the rest (issue #390).
+        return [...ok, ...failed]
       },
     }),
 
     getPortfolio: tool({
       description: `Query current portfolio holdings. IMPORTANT: If result is an empty array [], you have no holdings.
-If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.`,
+If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.
+If the result is an object with a \`degraded\` array, one or more accounts could not be read — the \`positions\` are only from the healthy accounts. ALWAYS tell the user which \`source\`(s) are degraded; an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry.`,
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false)),
         symbol: z.string().optional().describe('Filter by ticker, or omit for all'),
         subAccountId: z.string().optional().describe('For multi-wallet venues (e.g. Binance: "spot" / "derivatives"), scope to one wallet. Omit for holdings across all wallets.'),
       }).meta({ examples: [{ source: 'alpaca-paper' }] }),
       execute: async ({ source, symbol, subAccountId }) => {
-        const targets = await manager.resolve(source)
+        const targets = await manager.resolve(source, { tradingOnly: true })
         if (targets.length === 0) return { positions: [], ...(await noAccountsError(manager, source)) }
         // FX rates table — UTA's /fx-rates collects every currency in
         // use server-side and returns a flat lookup. Locally we treat
@@ -284,92 +314,105 @@ If this tool returns an error with transient=true, wait a few seconds and retry 
           const rate = fxLookup.get(currency) ?? 1
           return new Decimal(amount).mul(rate).toString()
         }
-        try {
-          const allPositions: Array<Record<string, unknown>> = []
-          const fxWarnings: string[] = []
-          for (const uta of targets) {
-            const positions = await uta.getPositions(subAccountId)
-            const accountInfo = await uta.getAccount(subAccountId)
+        // Per-account so one offline/region-blocked account degrades to a
+        // marker instead of zeroing every healthy account's holdings (#390).
+        const { ok, failed } = await settlePerAccount(targets, async (uta) => {
+          const positions = await uta.getPositions(subAccountId)
+          const accountInfo = await uta.getAccount(subAccountId)
 
-            // Convert position market values to USD for cross-currency percentage calculations
-            let totalMarketValueUsd = new Decimal(0)
-            const posUsdValues: Decimal[] = []
-            for (const pos of positions) {
-              posUsdValues.push(new Decimal(fxToUsd(pos.marketValue, pos.currency)))
-              totalMarketValueUsd = totalMarketValueUsd.plus(posUsdValues[posUsdValues.length - 1])
-            }
-
-            // Account netLiq in USD for equity percentage
-            const netLiqUsd = new Decimal(fxToUsd(accountInfo.netLiquidation, accountInfo.baseCurrency))
-
-            let idx = 0
-            for (const pos of positions) {
-              if (symbol && symbol !== 'all' && pos.contract.symbol !== symbol) { idx++; continue }
-              const mvUsd = posUsdValues[idx]
-              const percentOfEquity = netLiqUsd.gt(0) ? mvUsd.div(netLiqUsd).mul(100) : new Decimal(0)
-              const percentOfPortfolio = totalMarketValueUsd.gt(0) ? mvUsd.div(totalMarketValueUsd).mul(100) : new Decimal(0)
-              allPositions.push({
-                source: uta.id, symbol: pos.contract.symbol,
-                // secType + aliceId disambiguate same-symbol positions (ETH
-                // spot vs ETH perp render identically without them) and give
-                // the agent the exact id closePosition needs.
-                secType: pos.contract.secType,
-                aliceId: pos.contract.aliceId,
-                currency: pos.currency, side: pos.side,
-                quantity: pos.quantity.toString(), avgCost: price(pos.avgCost), marketPrice: price(pos.marketPrice),
-                marketValue: money(pos.marketValue), unrealizedPnL: money(pos.unrealizedPnL), realizedPnL: money(pos.realizedPnL),
-                percentageOfEquity: `${percentOfEquity.toFixed(1)}%`,
-                percentageOfPortfolio: `${percentOfPortfolio.toFixed(1)}%`,
-              })
-              idx++
-            }
+          // Convert position market values to USD for cross-currency percentage calculations
+          let totalMarketValueUsd = new Decimal(0)
+          const posUsdValues: Decimal[] = []
+          for (const pos of positions) {
+            posUsdValues.push(new Decimal(fxToUsd(pos.marketValue, pos.currency)))
+            totalMarketValueUsd = totalMarketValueUsd.plus(posUsdValues[posUsdValues.length - 1])
           }
-          if (allPositions.length === 0) return { positions: [], message: 'No open positions.' }
-          const allWarnings = [...new Set([...fxWarnings, ...fxWarningsFromRates])]
-          if (allWarnings.length > 0) return { positions: allPositions, fxWarnings: allWarnings }
-          return allPositions
-        } catch (err) {
-          return handleBrokerError(err)
+
+          // Account netLiq in USD for equity percentage
+          const netLiqUsd = new Decimal(fxToUsd(accountInfo.netLiquidation, accountInfo.baseCurrency))
+
+          const rows: Array<Record<string, unknown>> = []
+          let idx = 0
+          for (const pos of positions) {
+            if (symbol && symbol !== 'all' && pos.contract.symbol !== symbol) { idx++; continue }
+            const mvUsd = posUsdValues[idx]
+            const percentOfEquity = netLiqUsd.gt(0) ? mvUsd.div(netLiqUsd).mul(100) : new Decimal(0)
+            const percentOfPortfolio = totalMarketValueUsd.gt(0) ? mvUsd.div(totalMarketValueUsd).mul(100) : new Decimal(0)
+            rows.push({
+              source: uta.id, symbol: pos.contract.symbol,
+              // secType + aliceId disambiguate same-symbol positions (ETH
+              // spot vs ETH perp render identically without them) and give
+              // the agent the exact id closePosition needs.
+              secType: pos.contract.secType,
+              aliceId: pos.contract.aliceId,
+              currency: pos.currency, side: pos.side,
+              quantity: pos.quantity.toString(), avgCost: price(pos.avgCost), marketPrice: price(pos.marketPrice),
+              marketValue: money(pos.marketValue), unrealizedPnL: money(pos.unrealizedPnL), realizedPnL: money(pos.realizedPnL),
+              percentageOfEquity: `${percentOfEquity.toFixed(1)}%`,
+              percentageOfPortfolio: `${percentOfPortfolio.toFixed(1)}%`,
+              // Leveraged-derivative risk (crypto perps): leverage,
+              // liquidation price, margin mode. Present ⇒ this is NOT a 1×
+              // spot position — size the downside accordingly.
+              ...(pos.risk && { risk: pos.risk }),
+            })
+            idx++
+          }
+          return rows
+        })
+
+        const allPositions = ok.flat()
+        const allWarnings = [...new Set(fxWarningsFromRates)]
+        // Clean empty result only when nothing failed — don't report "no
+        // positions" when an account was actually unreachable.
+        if (allPositions.length === 0 && failed.length === 0 && allWarnings.length === 0) {
+          return { positions: [], message: 'No open positions.' }
         }
+        if (failed.length > 0 || allWarnings.length > 0) {
+          return {
+            positions: allPositions,
+            ...(allWarnings.length > 0 && { fxWarnings: allWarnings }),
+            ...(failed.length > 0 && { degraded: failed }),
+          }
+        }
+        return allPositions
       },
     }),
 
     getOrders: tool({
       description: `Query orders by ID. If no orderIds provided, queries all pending (submitted) orders.
 Use groupBy: "contract" to group orders by contract/aliceId (useful with many positions + TPSL).
-If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.`,
+If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.
+If the result is an object with a \`degraded\` array, one or more accounts could not be read — the orders are only from the healthy accounts. ALWAYS tell the user which \`source\`(s) are degraded; an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry.`,
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false)),
         orderIds: z.array(z.string()).optional().describe('Order IDs to query. If omitted, queries all pending orders.'),
         groupBy: z.enum(['contract']).optional().describe('Group orders by contract (aliceId)'),
       }).meta({ examples: [{ source: 'alpaca-paper' }] }),
       execute: async ({ source, orderIds, groupBy }) => {
-        const targets = await manager.resolve(source)
+        const targets = await manager.resolve(source, { tradingOnly: true })
         if (targets.length === 0) return []
-        try {
-          const summaries = (await Promise.all(targets.map(async (uta) => {
-            // SDK's getPendingOrderIds is a no-op returning []; the real
-            // UnifiedTradingAccount returns the actual pending list. Both
-            // satisfy the same call site so this works for Phase A's
-            // dual-impl world.
-            const ids = orderIds ?? uta.getPendingOrderIds().map(p => p.orderId)
-            const orders = await uta.getOrders(ids)
-            return orders.map((o, i) => summarizeOrder(o, uta.id, ids[i]))
-          }))).flat()
+        // Per-account so one offline account doesn't blank everyone's orders (#390).
+        const { ok, failed } = await settlePerAccount(targets, async (uta) => {
+          // SDK's getPendingOrderIds is a no-op returning []; the real
+          // UnifiedTradingAccount returns the actual pending list. Both
+          // satisfy the same call site so this works for Phase A's
+          // dual-impl world.
+          const ids = orderIds ?? uta.getPendingOrderIds().map(p => p.orderId)
+          const orders = await uta.getOrders(ids)
+          return orders.map((o, i) => summarizeOrder(o, uta.id, ids[i]))
+        })
+        const summaries = ok.flat()
 
-          if (groupBy === 'contract') {
-            const grouped: Record<string, { symbol: string; orders: ReturnType<typeof summarizeOrder>[] }> = {}
-            for (const s of summaries) {
-              const key = s.aliceId || s.symbol
-              if (!grouped[key]) grouped[key] = { symbol: s.symbol, orders: [] }
-              grouped[key].orders.push(s)
-            }
-            return grouped
+        if (groupBy === 'contract') {
+          const grouped: Record<string, { symbol: string; orders: ReturnType<typeof summarizeOrder>[] }> = {}
+          for (const s of summaries) {
+            const key = s.aliceId || s.symbol
+            if (!grouped[key]) grouped[key] = { symbol: s.symbol, orders: [] }
+            grouped[key].orders.push(s)
           }
-          return summaries
-        } catch (err) {
-          return handleBrokerError(err)
+          return failed.length > 0 ? { grouped, degraded: failed } : grouped
         }
+        return failed.length > 0 ? { orders: summaries, degraded: failed } : summaries
       },
     }),
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -354,6 +354,14 @@ export interface Position {
   marketValue: string
   unrealizedPnL: string
   realizedPnL: string
+  /** Leveraged-derivative risk metadata (crypto perps/futures). Absent for
+   *  spot and brokers without per-position leverage. Mirrors uta-protocol's
+   *  PositionRisk. */
+  risk?: {
+    leverage?: string
+    liquidationPrice?: string
+    marginMode?: 'cross' | 'isolated'
+  }
 }
 
 export interface WalletCommitLog {


### PR DESCRIPTION
## Summary
Three community-reported UTA issues (all by **bakabird**), implemented in-house. They interleave the same files (`CcxtBroker.ts`, `trading.ts`), so they ship together.

- **#387 — surface CCXT leverage on positions.** Crypto-perp risk (leverage / liquidation price / margin mode) was fetched from CCXT then dropped, so Alice rated a 50× position as if it were 1× spot. Adds a **grouped `PositionRisk` struct** on `Position` rather than loose top-level fields — IBKR itself keeps margin off the position (`OrderState` / account-summary tags), so the base shape stays IBKR-aligned and `getPositions` still returns `Position[]` (no type fork). Deletes the dormant `CcxtPosition extends Position` dead type. Zeroes treated as absent. Surfaced in the AI portfolio tool + mirrored on the UI `Position` type.
- **#384 — bridge the process proxy into CCXT.** CCXT's Node fetch ignores `HTTP(S)_PROXY` env; the proxy must be set on the instance, which UTA never did — so users behind a proxy (geo-restricted Binance/Bitget) saw the browser reach the venue while UTA silently failed. `applyEnvProxy` sets **exactly one** of `httpsProxy`/`socksProxy` (CCXT throws `InvalidProxySettings` if more than one proxy prop is set — the common `HTTP_PROXY`+`HTTPS_PROXY` pair must collapse to one), precedence HTTPS > HTTP > ALL. Redacted startup log in `main.ts`.
- **#390 — partial-tolerant portfolio aggregation.** One offline / region-blocked account (a geo-blocked `bybit-readonly` data source) rejected the whole `Promise.all` and blanked **every** healthy account. `getAccount`/`getPortfolio`/`getOrders` now degrade per-account via `settlePerAccount` (`allSettled`): healthy accounts return, failed ones become `{source, ...error}` markers, and the tool descriptions instruct the AI to always surface degraded accounts (`transient=false` ⇒ permanent, user must fix). `UTAManagerSDK.resolve(source, {tradingOnly})` also drops keyless **data-tier** sources from the no-source user aggregate (they hold no user positions).

**Dogfooded on the live demo accounts:** okx perp `leverage:3`, hyperliquid `leverage:10`, binance cross perp `marginMode:cross` (leverage correctly omitted); spot/equity rows carry no `risk`; the 3 `*-readonly` data accounts are excluded from the portfolio while all 5 funded accounts still return.

**Adversarial multi-dimension review** (subagent workflow) ran before commit and caught: the proxy multi-property **blocker** (would have broken every CCXT broker under the common `HTTP_PROXY`+`HTTPS_PROXY` setup — strictly worse than the bug it fixed), the undocumented `degraded` AI contract, and a risk-field test gap. All three fixed in this PR.

## Test plan
- [x] `npx tsc --noEmit` (Alice) clean
- [x] `pnpm -F @traderalice/uta-protocol typecheck` clean
- [x] `cd ui && npx tsc -b` clean
- [x] `pnpm test` — 2217 passed, 6 skipped, 0 failed (new specs: CcxtBroker risk+proxy, `trading.spec.ts`, `UTAManagerSDK.spec.ts`)
- [x] Live CLI dogfood on demo accounts (above)

## Boundary touch
Touches **trading paths** (CCXT broker, UTA aggregation tool, SDK resolve). No auth/credential/migration changes. The Trading-as-Git schema is untouched.

## Stacking
Built on top of **#399** (sub-accounts) — base is `UTA-issue`, not `master`, so the diff is just this trio. Merge after #399 (or retarget to `master` once #399 lands). No version bump here — flag me if you want this released distinctly (would bump to `0.62.0-beta.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
