### PR TITLE
feat(trading): AI auto-trading master switch (#95) — replaces dead evolution mode

### DIFF
--- a/src/ai-providers/utils.spec.ts
+++ b/src/ai-providers/utils.spec.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   stripImageData,
-  resolveToolPermissions,
   buildChatHistoryPrompt,
-  NORMAL_ALLOWED_TOOLS,
-  EVOLUTION_ALLOWED_TOOLS,
-  NORMAL_EXTRA_DISALLOWED,
-  EVOLUTION_EXTRA_DISALLOWED,
   DEFAULT_MAX_HISTORY,
 } from './utils.js'
 
@@ -58,44 +53,6 @@ describe('stripImageData', () => {
   })
 })
 
-// ==================== resolveToolPermissions ====================
-
-describe('resolveToolPermissions', () => {
-  it('should return normal defaults when no options', () => {
-    const { allowed, disallowed } = resolveToolPermissions({})
-    expect(allowed).toEqual(NORMAL_ALLOWED_TOOLS)
-    expect(disallowed).toEqual(NORMAL_EXTRA_DISALLOWED)
-  })
-
-  it('should return evolution defaults when evolutionMode is true', () => {
-    const { allowed, disallowed } = resolveToolPermissions({ evolutionMode: true })
-    expect(allowed).toEqual(EVOLUTION_ALLOWED_TOOLS)
-    expect(disallowed).toEqual(EVOLUTION_EXTRA_DISALLOWED)
-  })
-
-  it('should use explicit allowedTools when provided', () => {
-    const custom = ['MyTool', 'AnotherTool']
-    const { allowed } = resolveToolPermissions({ allowedTools: custom })
-    expect(allowed).toEqual(custom)
-  })
-
-  it('should not use explicit allowedTools when array is empty', () => {
-    const { allowed } = resolveToolPermissions({ allowedTools: [] })
-    expect(allowed).toEqual(NORMAL_ALLOWED_TOOLS)
-  })
-
-  it('should merge disallowedTools with mode defaults', () => {
-    const { disallowed } = resolveToolPermissions({ disallowedTools: ['Dangerous'] })
-    expect(disallowed).toContain('Dangerous')
-    expect(disallowed).toContain('Bash')
-  })
-
-  it('should merge disallowedTools with evolution defaults (empty)', () => {
-    const { disallowed } = resolveToolPermissions({ evolutionMode: true, disallowedTools: ['Dangerous'] })
-    expect(disallowed).toEqual(['Dangerous'])
-  })
-})
-
 // ==================== buildChatHistoryPrompt ====================
 
 describe('buildChatHistoryPrompt', () => {
@@ -130,19 +87,6 @@ describe('buildChatHistoryPrompt', () => {
 // ==================== Constants ====================
 
 describe('constants', () => {
-  it('should have Bash in evolution allowed tools but not normal', () => {
-    expect(EVOLUTION_ALLOWED_TOOLS).toContain('Bash')
-    expect(NORMAL_ALLOWED_TOOLS).not.toContain('Bash')
-  })
-
-  it('should have Bash in normal disallowed', () => {
-    expect(NORMAL_EXTRA_DISALLOWED).toContain('Bash')
-  })
-
-  it('should have empty evolution disallowed', () => {
-    expect(EVOLUTION_EXTRA_DISALLOWED).toHaveLength(0)
-  })
-
   it('should have a positive DEFAULT_MAX_HISTORY', () => {
     expect(DEFAULT_MAX_HISTORY).toBeGreaterThan(0)
   })

--- a/src/ai-providers/utils.ts
+++ b/src/ai-providers/utils.ts
@@ -21,41 +21,6 @@ export function stripImageData(raw: string): string {
   } catch { return raw }
 }
 
-// ==================== Tool Permission Lists ====================
-
-/** Tools pre-approved in normal mode (no Bash). */
-export const NORMAL_ALLOWED_TOOLS = [
-  'Read', 'Write', 'Edit', 'Glob', 'Grep', 'WebSearch', 'WebFetch',
-  'mcp__open-alice__*',
-]
-
-/** Tools pre-approved in evolution mode (includes Bash). */
-export const EVOLUTION_ALLOWED_TOOLS = [
-  'Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebSearch', 'WebFetch',
-  'mcp__open-alice__*',
-]
-
-/** Extra tools to disallow in normal mode. */
-export const NORMAL_EXTRA_DISALLOWED = ['Bash']
-
-/** Extra tools to disallow in evolution mode. */
-export const EVOLUTION_EXTRA_DISALLOWED: string[] = []
-
-/** Resolve tool permissions based on evolution mode and explicit overrides. */
-export function resolveToolPermissions(opts: {
-  evolutionMode?: boolean
-  allowedTools?: string[]
-  disallowedTools?: string[]
-}): { allowed: string[]; disallowed: string[] } {
-  const { evolutionMode = false, allowedTools = [], disallowedTools = [] } = opts
-  const modeAllowed = evolutionMode ? EVOLUTION_ALLOWED_TOOLS : NORMAL_ALLOWED_TOOLS
-  const modeDisallowed = evolutionMode ? EVOLUTION_EXTRA_DISALLOWED : NORMAL_EXTRA_DISALLOWED
-  return {
-    allowed: allowedTools.length > 0 ? allowedTools : modeAllowed,
-    disallowed: [...disallowedTools, ...modeDisallowed],
-  }
-}
-
 // ==================== Chat History Prompt ====================
 
 export interface TextHistoryEntry {

--- a/src/core/config.spec.ts
+++ b/src/core/config.spec.ts
@@ -133,7 +133,7 @@ describe('readAgentConfig', () => {
     fileNotFound()
     const cfg = await readAgentConfig()
     expect(cfg.maxSteps).toBe(20)
-    expect(cfg.evolutionMode).toBe(false)
+    expect(cfg.allowAiTrading).toBe(false)
   })
 
   it('parses maxSteps from file', async () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -201,7 +201,12 @@ export type AIProviderConfig = z.infer<typeof aiProviderSchema>
 
 const agentSchema = z.object({
   maxSteps: z.number().int().positive().default(20),
-  evolutionMode: z.boolean().default(false),
+  /** Master switch for AI-initiated trade execution. When false (default),
+   *  `tradingPush` only stages + asks the user to approve in the Web UI; when
+   *  true, the AI may push committed operations straight to the broker. Gated
+   *  in the UI behind a danger warning + double-confirm. Per-account `readOnly`
+   *  still wins (read-only accounts can't stage in the first place). */
+  allowAiTrading: z.boolean().default(false),
   claudeCode: z.object({
     allowedTools: z.array(z.string()).optional(),
     disallowedTools: z.array(z.string()).default([

--- a/src/main.ts
+++ b/src/main.ts
@@ -215,9 +215,12 @@ async function main() {
 
   toolCenter.register(createThinkingTools(), 'thinking')
 
-  // One unified set of trading tools — routes via `source` parameter at runtime
+  // One unified set of trading tools — routes via `source` parameter at runtime.
+  // The getter reads `config.agent.allowAiTrading` live (config is mutated in
+  // place on Settings writes), so toggling AI trading takes effect without a
+  // restart.
   toolCenter.register(
-    createTradingTools(utaManager),
+    createTradingTools(utaManager, () => config.agent.allowAiTrading),
     'trading',
   )
 

--- a/src/tool/trading.spec.ts
+++ b/src/tool/trading.spec.ts
@@ -145,3 +145,39 @@ describe('trading tools — partial tolerance (#390)', () => {
     expect(res.degraded).toBeUndefined()
   })
 })
+
+describe('tradingPush — AI-trading gate (#95)', () => {
+  function pushFixture() {
+    let pushed = 0
+    const uta = {
+      id: 'binance-demo',
+      status: async () => ({ pendingMessage: 'ready to push', staged: [], pendingHash: 'h1' }),
+      push: async () => { pushed++; return { hash: 'h1', message: 'sent', operationCount: 1, submitted: [{}], rejected: [] } },
+    }
+    const manager = { resolve: async () => [uta] } as never
+    return { manager, pushed: () => pushed }
+  }
+
+  it('does NOT execute the push when AI trading is disabled — returns a manual-approval message', async () => {
+    const { manager, pushed } = pushFixture()
+    const tools = createTradingTools(manager, () => false)
+    const res = await run(tools.tradingPush, {}) as { message: string }
+    expect(pushed()).toBe(0)
+    expect(res.message).toMatch(/manual approval|disabled/i)
+  })
+
+  it('executes the push to the broker when AI trading is enabled', async () => {
+    const { manager, pushed } = pushFixture()
+    const tools = createTradingTools(manager, () => true)
+    const res = await run(tools.tradingPush, {}) as { results: Array<{ source: string }> }
+    expect(pushed()).toBe(1)
+    expect(res.results[0].source).toBe('binance-demo')
+  })
+
+  it('fails closed — no flag getter defaults to disabled (no push)', async () => {
+    const { manager, pushed } = pushFixture()
+    const tools = createTradingTools(manager)
+    await run(tools.tradingPush, {})
+    expect(pushed()).toBe(0)
+  })
+})

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -173,7 +173,17 @@ async function stageAndMaybeCommit(
   }
 }
 
-export function createTradingTools(manager: UTAManagerSDK): Record<string, Tool> {
+/**
+ * @param manager        UTA SDK manager (account resolution + FX).
+ * @param allowAiTrading  Live getter for the `agent.allowAiTrading` master
+ *   switch. Read at call time (not captured) so toggling it in Settings takes
+ *   effect without a restart. Gates `tradingPush`: false ⇒ stage + ask the user
+ *   to approve in the Web UI; true ⇒ the AI pushes to the broker directly.
+ */
+export function createTradingTools(
+  manager: UTAManagerSDK,
+  allowAiTrading: () => boolean = () => false,
+): Record<string, Tool> {
   return {
     listUTAs: tool({
       description: 'List all registered trading accounts with their id, provider, label, and capabilities.',
@@ -692,7 +702,11 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
     }),
 
     tradingPush: tool({
-      description: 'Trading push requires manual approval — call tradingStatus to show the user what is pending, then ask them to approve it on the Web UI (Trading as Git page, or the account detail page).',
+      description: `Push committed operations to the broker — the final, real execution step.
+
+By DEFAULT this does NOT execute: it returns the pending operations and you must ask the user to approve them in the Web UI (Trading as Git page, or the account detail page).
+
+ONLY if the operator has enabled "Allow AI to push trades" in Settings does this execute directly — committed operations are sent to the broker as live orders. Use deliberately.`,
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false, 'If omitted, checks all accounts.')),
       }).meta({ examples: [{ source: 'alpaca-paper' }] }),
@@ -710,13 +724,28 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
           }
           return { message: 'No committed operations to push.' }
         }
-        return {
-          message: 'Push requires manual approval. Tell the user to review and approve the pending operations in the Web UI (Trading as Git page, or the account detail page).',
-          pending: pending.map(({ uta, status }) => ({
-            source: uta.id,
-            ...compactStatus(status),
-          })),
+        // Gate: AI-initiated execution is OFF by default. Without the operator's
+        // explicit opt-in, surface the pending ops for manual Web-UI approval
+        // rather than sending live orders to the broker.
+        if (!allowAiTrading()) {
+          return {
+            message: 'Push requires manual approval (AI trading is disabled). Tell the user to review and approve the pending operations in the Web UI (Trading as Git page, or the account detail page).',
+            pending: pending.map(({ uta, status }) => ({
+              source: uta.id,
+              ...compactStatus(status),
+            })),
+          }
         }
+        // AI trading enabled — execute for real. Each push() sends the committed
+        // operations to the broker. Per-account failures degrade individually.
+        const results = await Promise.all(pending.map(async ({ uta }) => {
+          try {
+            return { source: uta.id, ...compactPushResult(await uta.push()) }
+          } catch (err) {
+            return { source: uta.id, ...handleBrokerError(err) }
+          }
+        }))
+        return { message: 'AI trading is enabled — pushed committed operations to the broker.', results }
       },
     }),
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -162,7 +162,7 @@ export interface AIProviderConfig {
 export interface AppConfig {
   aiProvider: AIProviderConfig
   engine: Record<string, unknown>
-  agent: { evolutionMode: boolean; claudeCode: Record<string, unknown> }
+  agent: { allowAiTrading: boolean; claudeCode: Record<string, unknown> }
   compaction: { maxContextTokens: number; maxOutputTokens: number }
   snapshot: {
     enabled: boolean

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -12,7 +12,7 @@ export const configKeysHandlers = [
     HttpResponse.json({
       aiProvider: { apiKeys: {}, profiles: {}, activeProfile: '' },
       engine: {},
-      agent: { evolutionMode: false, claudeCode: {} },
+      agent: { allowAiTrading: false, claudeCode: {} },
       compaction: { maxContextTokens: 0, maxOutputTokens: 0 },
       snapshot: { enabled: false, every: '1h' },
       trading: { observeExternalOrdersEvery: '15m' },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -65,10 +65,14 @@ export const en = {
     },
     agent: {
       title: 'Agent',
-      description: 'Controls file-system and tool permissions for the AI. Changes apply on the next request.',
-      evolutionMode: 'Evolution Mode',
-      evolutionOn: 'Full project access — AI can modify source code',
-      evolutionOff: 'Sandbox mode — AI can only edit data/brain/',
+      description: 'Controls what the AI may do on your behalf. Changes apply on the next request.',
+      allowAiTrading: 'Allow AI to push trades',
+      allowAiTradingOn: 'ON — the AI can send orders to the broker by itself, without asking you each time.',
+      allowAiTradingOff: 'OFF — the AI can stage and propose trades, but every push needs your approval in the Web UI.',
+      allowAiTradingWarning: 'AI auto-trading is ON. The AI can place, modify and cancel real orders on its own. Per-account read-only still applies.',
+      allowAiTradingConfirmTitle: 'Enable AI auto-trading?',
+      allowAiTradingConfirmBody: 'This lets the AI send live orders to your broker without asking you each time. The UTA trading interface is still unstable and may have precision or parameter issues. Strongly discouraged on real-money accounts — use a paper / demo account.',
+      allowAiTradingConfirmCta: 'Enable auto-trading',
     },
     persona: {
       title: 'Persona',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -54,10 +54,14 @@ export const ja: Resources = {
     },
     agent: {
       title: 'エージェント',
-      description: 'AI のファイルシステムとツールの権限を制御します。変更は次のリクエストで反映されます。',
-      evolutionMode: '進化モード',
-      evolutionOn: 'プロジェクト全体へのアクセス——AI はソースコードを変更できます',
-      evolutionOff: 'サンドボックスモード——AI は data/brain/ のみ編集できます',
+      description: 'AI があなたの代わりに行えることを制御します。変更は次のリクエストで反映されます。',
+      allowAiTrading: 'AI による自動発注を許可',
+      allowAiTradingOn: 'ON——AI は毎回確認することなく、自分でブローカーに注文を送信できます。',
+      allowAiTradingOff: 'OFF——AI は取引をステージ・提案できますが、push のたびに Web UI での承認が必要です。',
+      allowAiTradingWarning: 'AI 自動取引が ON です。AI は自分で発注・変更・取消を行えます。口座ごとの読み取り専用設定は引き続き有効です。',
+      allowAiTradingConfirmTitle: 'AI 自動取引を有効にしますか？',
+      allowAiTradingConfirmBody: '有効にすると、AI は毎回確認することなくブローカーに実際の注文を送信できます。UTA の取引インターフェースはまだ不安定で、精度やパラメータの問題がある可能性があります。実資金の口座での使用は強く非推奨です——ペーパー / デモ口座を使用してください。',
+      allowAiTradingConfirmCta: '自動取引を有効化',
     },
     persona: {
       title: 'ペルソナ',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -62,10 +62,14 @@ export const zhHant: Resources = {
     },
     agent: {
       title: '智慧體',
-      description: '控制 AI 的檔案系統與工具權限。變更會在下一次請求時生效。',
-      evolutionMode: '進化模式',
-      evolutionOn: '完整專案存取權——AI 可修改原始碼',
-      evolutionOff: '沙箱模式——AI 只能編輯 data/brain/',
+      description: '控制 AI 可以代你做什麼。變更會在下一次請求時生效。',
+      allowAiTrading: '允許 AI 自動下單',
+      allowAiTradingOn: '開啟——AI 可自行向券商發送訂單，無需每次徵求你的同意。',
+      allowAiTradingOff: '關閉——AI 可以暫存並提議交易，但每次 push 都需要你在 Web UI 中核准。',
+      allowAiTradingWarning: 'AI 自動交易已開啟。AI 可自行下單、改單、撤單。每帳戶的唯讀設定仍然生效。',
+      allowAiTradingConfirmTitle: '開啟 AI 自動交易？',
+      allowAiTradingConfirmBody: '開啟後，AI 可在不徵求你同意的情況下向券商發送真實訂單。UTA 交易介面目前仍不穩定，可能存在精度或參數問題。強烈不建議在實盤帳戶上使用——請使用模擬 / demo 帳戶。',
+      allowAiTradingConfirmCta: '開啟自動交易',
     },
     persona: {
       title: '人設',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -54,10 +54,14 @@ export const zh: Resources = {
     },
     agent: {
       title: '智能体',
-      description: '控制 AI 的文件系统与工具权限。更改在下一次请求时生效。',
-      evolutionMode: '进化模式',
-      evolutionOn: '完整项目访问权——AI 可修改源代码',
-      evolutionOff: '沙盒模式——AI 只能编辑 data/brain/',
+      description: '控制 AI 可以代你做什么。更改在下一次请求时生效。',
+      allowAiTrading: '允许 AI 自动下单',
+      allowAiTradingOn: '开启——AI 可自行向券商发送订单，无需每次征求你的同意。',
+      allowAiTradingOff: '关闭——AI 可以暂存并提议交易，但每次 push 都需要你在 Web UI 中批准。',
+      allowAiTradingWarning: 'AI 自动交易已开启。AI 可自行下单、改单、撤单。每账户的只读设置仍然生效。',
+      allowAiTradingConfirmTitle: '开启 AI 自动交易？',
+      allowAiTradingConfirmBody: '开启后，AI 可在不征求你同意的情况下向券商发送真实订单。UTA 交易接口目前仍不稳定，可能存在精度或参数问题。强烈不建议在实盘账户上使用——请使用模拟 / demo 账户。',
+      allowAiTradingConfirmCta: '开启自动交易',
     },
     persona: {
       title: '人设',

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { api, type AppConfig } from '../api'
 import type { ToolInfo } from '../api/tools'
 import { Toggle } from '../components/Toggle'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 import { SaveIndicator } from '../components/SaveIndicator'
 import { ConfigSection, Field, inputClass } from '../components/form'
 import { useAutoSave } from '../hooks/useAutoSave'
@@ -64,6 +65,70 @@ function LanguageSection() {
   )
 }
 
+// ==================== AI Trading Toggle ====================
+
+/**
+ * Master switch for AI-initiated trade execution (issue #95). OFF by default;
+ * enabling it requires a deliberate danger-confirm (turning it OFF is
+ * immediate). While ON, a persistent red banner keeps the risk visible.
+ */
+function AiTradingToggle({
+  config,
+  setConfig,
+}: {
+  config: AppConfig
+  setConfig: React.Dispatch<React.SetStateAction<AppConfig | null>>
+}) {
+  const { t } = useTranslation()
+  const [confirming, setConfirming] = useState(false)
+  const enabled = config.agent?.allowAiTrading || false
+
+  const persist = useCallback(async (v: boolean) => {
+    await api.config.updateSection('agent', { ...config.agent, allowAiTrading: v })
+    setConfig((c) => (c ? { ...c, agent: { ...c.agent, allowAiTrading: v } } : c))
+  }, [config.agent, setConfig])
+
+  const onToggle = (v: boolean) => {
+    if (v) {
+      setConfirming(true) // enabling is dangerous → confirm first, persist on confirm
+    } else {
+      void persist(false).catch(() => { /* toggle stays on if the write fails */ })
+    }
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-4 py-1">
+        <div className="flex-1">
+          <span className="text-sm font-medium text-text">{t('settings.agent.allowAiTrading')}</span>
+          <p className="text-[12px] text-text-muted mt-0.5 leading-relaxed">
+            {enabled ? t('settings.agent.allowAiTradingOn') : t('settings.agent.allowAiTradingOff')}
+          </p>
+        </div>
+        <Toggle checked={enabled} onChange={onToggle} />
+      </div>
+      {enabled && (
+        <div className="mt-2 rounded-md border border-red/30 bg-red/5 px-3 py-2 text-[12px] text-red leading-relaxed">
+          ⚠ {t('settings.agent.allowAiTradingWarning')}
+        </div>
+      )}
+      {confirming && (
+        <ConfirmDialog
+          title={t('settings.agent.allowAiTradingConfirmTitle')}
+          message={t('settings.agent.allowAiTradingConfirmBody')}
+          confirmLabel={t('settings.agent.allowAiTradingConfirmCta')}
+          variant="danger"
+          onConfirm={async () => {
+            try { await persist(true) } catch { /* stays off — write failed */ }
+            setConfirming(false)
+          }}
+          onClose={() => setConfirming(false)}
+        />
+      )}
+    </>
+  )
+}
+
 // ==================== Settings Section ====================
 
 function SettingsSection() {
@@ -87,29 +152,7 @@ function SettingsSection() {
 
         {/* Agent */}
         <ConfigSection title={t('settings.agent.title')} description={t('settings.agent.description')}>
-          <div className="flex items-center justify-between gap-4 py-1">
-            <div className="flex-1">
-              <span className="text-sm font-medium text-text">
-                {t('settings.agent.evolutionMode')}
-              </span>
-              <p className="text-[12px] text-text-muted mt-0.5 leading-relaxed">
-                {config.agent?.evolutionMode
-                  ? t('settings.agent.evolutionOn')
-                  : t('settings.agent.evolutionOff')}
-              </p>
-            </div>
-            <Toggle
-              checked={config.agent?.evolutionMode || false}
-              onChange={async (v) => {
-                try {
-                  await api.config.updateSection('agent', { ...config.agent, evolutionMode: v })
-                  setConfig((c) => c ? { ...c, agent: { ...c.agent, evolutionMode: v } } : c)
-                } catch {
-                  // Toggle doesn't flip on failure
-                }
-              }}
-            />
-          </div>
+          <AiTradingToggle config={config} setConfig={setConfig} />
         </ConfigSection>
 
         {/* Persona */}


### PR DESCRIPTION
## Summary
- **AI auto-trading master switch** (issue #95). `config.agent.allowAiTrading` (default `false`) lets the AI push committed operations to the broker itself, instead of only staging and asking the user to approve every push in the Web UI. Replaces the vestigial `evolutionMode` flag (dead since the v0.40 in-process-loop removal — `resolveToolPermissions` had no runtime caller). Zod strips the old key on load; **no migration needed**.
- **Single execution gate** in the `tradingPush` tool — the one `uta.push()` chokepoint, shared by MCP and the CLI `uta git push` (which maps to the same tool). `OFF` ⇒ stage + ask for Web-UI approval (today's behaviour); `ON` ⇒ the AI executes the push. **Fail-closed** default; per-account `readOnly` still blocks at stage time; live getter so the toggle works without a restart.
- **Settings › Agent**: the toggle now gates real money — danger **double-confirm** on enable, a persistent red warning banner while on, and copy (en/zh/ja/zh-Hant) spelling out that the UTA interface is still unstable and this is strongly discouraged on real-money accounts.

## Test plan
- [x] Alice `tsc --noEmit` + UI `tsc -b` clean
- [x] `pnpm test` — 2224 passed (3 new `tradingPush` gate tests: off ⇒ no push, on ⇒ executes, no-getter ⇒ fail-closed; dead evolution-mode tests removed)
- [x] Gate completeness verified by grep — single `uta.push()` chokepoint; CLI `git push` verb → `tradingPush`
- [x] Manually run by maintainer (works)

## Boundary touch
**Trading execution path.** Adds an opt-in, default-OFF path for AI-initiated broker execution. Gate is fail-closed and `readOnly` accounts stay protected at stage time. Hard process-level isolation (approval at a detached UTA) is deferred to the future UTA split, per design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
