### PR TITLE
docs(tools): correct global-macro board provider label (OECD → FRED/OECD/BIS/World Bank)

### DIFF
--- a/src/tool/reference-board.ts
+++ b/src/tool/reference-board.ts
@@ -25,7 +25,7 @@ Available boards:
 - macro: 14 US macro series cards — rates, labor, CPI YoY, oil, dollar, M2, sentiment (FRED)
 - valuation: S&P 500 PE / Shiller CAPE / earnings yield / dividend yield (multpl)
 - term-structure: BTC/ETH futures curve with annualized basis vs perpetual (Deribit)
-- global-macro: 7 countries × CPI/short-rate/CLI/house/equity indices (OECD)
+- global-macro: 7 countries × CPI/short-rate/CLI/house/equity indices (OECD + BIS + World Bank, via FRED; CPI annual, rest monthly — check each cell's date)
 - shipping: daily transit volume at 6 maritime chokepoints (IMF PortWatch)
 - fed: balance sheet, primary dealer positioning, FOMC documents
 


### PR DESCRIPTION
## Summary
- `marketGetBoard`'s global-macro board was tagged **"(OECD)"**, but the board is served from **FRED**, which redistributes **OECD** (CLI / short-rate / equity index) + **BIS** (real house prices) + **World Bank** (annual CPI). Updated the label to match.
- Surfaced the cadence gotcha for the agent: **CPI is annual, the other four columns are monthly** — read each cell's `date` before comparing (otherwise a 2024 CPI gets read as current).

Context: TraderHub re-sourced this board OECD→FRED because OECD's SDMX endpoint TLS-fingerprint-bans server-side Node. Live OECD egress (for a fresh CPI again) is tracked in **ANG-135**.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Description-only string change — no behavior path touched
- [x] Verified live end-to-end via `marketGetBoard` global-macro: returns `provider: fred`, `origin: hub`, all 7×5 cells populated

## Boundary touch
None — agent-facing description string only; no trading / auth / broker-credential / migration paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
