### PR TITLE
Non-blocking broker connect + systematic first-load skeletons

### DIFF
--- a/packages/uta-protocol/src/types/broker.ts
+++ b/packages/uta-protocol/src/types/broker.ts
@@ -13,12 +13,18 @@ import './contract-ext.js'
 
 // ==================== Errors ====================
 
-export type BrokerErrorCode = 'CONFIG' | 'AUTH' | 'NETWORK' | 'EXCHANGE' | 'MARKET_CLOSED' | 'UNKNOWN'
+export type BrokerErrorCode = 'CONFIG' | 'AUTH' | 'NETWORK' | 'EXCHANGE' | 'MARKET_CLOSED' | 'CONNECTING' | 'UNKNOWN'
 
 /**
  * Structured broker error.
  * - `permanent` errors (CONFIG, AUTH) disable the account — will not be retried.
  * - Transient errors (NETWORK, EXCHANGE, MARKET_CLOSED) trigger auto-recovery.
+ * - `CONNECTING` is a special transient marker: the account is not yet (or no
+ *   longer) ready — its initial broker connect is still in flight, or it's
+ *   offline and the recovery loop is actively reconnecting. It means "data
+ *   pending, retry shortly", NOT a failure: a read returns it WITHOUT blocking
+ *   on the slow connect and WITHOUT counting as a failure (so it never degrades
+ *   health or disables the account). Recovery keeps running underneath.
  */
 export class BrokerError extends Error {
   readonly code: BrokerErrorCode
@@ -382,6 +388,13 @@ export interface BrokerHealthInfo {
   lastSuccessAt?: Date
   lastFailureAt?: Date
   recovering: boolean
+  /** True while the account's INITIAL broker connect is still in flight (e.g.
+   *  CCXT loadMarkets, which can take tens of seconds). During this window
+   *  `status` is optimistically 'healthy' (reach defaults to target) but the
+   *  broker isn't actually ready, so reads return a transient CONNECTING marker
+   *  instead of blocking. The UI shows a "connecting…" state off this flag —
+   *  `status`/`reach` alone can't distinguish it from a genuinely-ready account. */
+  connecting: boolean
   disabled: boolean
 }
 

--- a/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
@@ -1418,3 +1418,56 @@ describe('UTA — getPositions wallet reconciliation', () => {
     await expect(uta.getPositions()).resolves.toBeDefined()
   })
 })
+
+// ==================== Cold-start connecting gate ====================
+
+describe('UTA — connecting gate (non-blocking cold start)', () => {
+  it('reports connecting=true until the initial connect settles, then false', async () => {
+    const { uta } = createUTA()
+    expect(uta.getHealthInfo().connecting).toBe(true)
+    await uta.waitForConnect()
+    expect(uta.getHealthInfo().connecting).toBe(false)
+  })
+
+  it('a read during a SLOW connect fast-fails CONNECTING after the grace, without poisoning health', async () => {
+    vi.useFakeTimers()
+    try {
+      const broker = new MockBroker()
+      // Hang init() so the account is stuck in the connecting window — stands in
+      // for CCXT loadMarkets taking tens of seconds.
+      let release!: () => void
+      ;(broker as unknown as { init: () => Promise<void> }).init = () =>
+        new Promise<void>((resolve) => { release = resolve })
+
+      const { uta } = createUTA(broker)
+      expect(uta.getHealthInfo().connecting).toBe(true)
+
+      // Attach the rejection expectation BEFORE advancing time, so the
+      // rejection (which fires mid-advance) is never momentarily unhandled.
+      const assertion = expect(uta.getAccount()).rejects.toThrow(/still connecting/)
+      // Past the grace window — the read returns instead of blocking on init.
+      await vi.advanceTimersByTimeAsync(2_000)
+      await assertion
+
+      // The gate threw BEFORE the broker call, so it never registered as a
+      // failure: no counter bump, no premature recovery, account not disabled.
+      const h = uta.getHealthInfo()
+      expect(h.connecting).toBe(true)
+      expect(h.consecutiveFailures).toBe(0)
+      expect(h.recovering).toBe(false)
+      expect(h.disabled).toBe(false)
+
+      // Let the connect finish so timer/teardown is clean.
+      release()
+      await vi.runAllTimersAsync()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('serves a read normally once an instant broker has connected (grace not consumed)', async () => {
+    const { uta } = createUTA()
+    await uta.waitForConnect()
+    await expect(uta.getAccount()).resolves.toBeDefined()
+  })
+})

--- a/services/uta/src/domain/trading/UnifiedTradingAccount.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.ts
@@ -97,6 +97,12 @@ export class UnifiedTradingAccount {
   private static readonly OFFLINE_THRESHOLD = 6
   private static readonly RECOVERY_BASE_MS = 5_000
   private static readonly RECOVERY_MAX_MS = 60_000
+  /** Grace a read gives the INITIAL connect before it fast-fails with CONNECTING.
+   *  An instantly-connecting broker (mock, warm cache) settles within this and
+   *  serves real data; a slow one (CCXT loadMarkets, tens of seconds) blows past
+   *  it and the read returns "connecting" instead of blocking on the whole init.
+   *  Bounds the cold-start first-read to this, not the full connect time. */
+  private static readonly CONNECT_GRACE_MS = 1_500
 
   private _consecutiveFailures = 0
   private _lastError?: string
@@ -105,6 +111,14 @@ export class UnifiedTradingAccount {
   private _recoveryTimer?: ReturnType<typeof setTimeout>
   private _recovering = false
   private _disabled = false
+  /** True while the INITIAL broker connect is in flight (e.g. CCXT loadMarkets,
+   *  which can take tens of seconds). Reads during this window return fast with
+   *  a transient CONNECTING error instead of blocking on the slow connect — the
+   *  bug that made the whole UI hang ~30s on cold start while the optimistic
+   *  reach (below) reported "healthy". Flips false when `_connectPromise`
+   *  settles; never set true again (re-connects go through the recovery loop,
+   *  which has its own gate). Orthogonal to `_recovering`. */
+  private _connecting = true
   /** Current rung on the capability ladder. Updated by every connect/recovery
    *  probe and by live broker-call success/failure. */
   private _currentReach: UTAReach = 'down'
@@ -184,8 +198,13 @@ export class UnifiedTradingAccount {
       ? TradingGit.restore(options.savedState, gitConfig)
       : new TradingGit(gitConfig)
 
-    // Kick off broker connection asynchronously — UTA is usable immediately,
-    // broker queries will fail (tracked by health) until init succeeds.
+    // Kick off broker connection asynchronously — UTA is usable immediately;
+    // reads during the connect window return a fast transient CONNECTING marker
+    // (see `_connecting` / `_callBroker`) rather than blocking on init.
+    // `_connecting` is cleared INSIDE _connect() (right after the connect probe
+    // settles, before the health-change emit) so the first emitted health diff
+    // already carries connecting:false — clearing it here in a .finally would
+    // run after that emit and leave the UI stuck on "connecting".
     const p = this._connect()
     // Silence unhandled rejection in fire-and-forget path.
     // waitForConnect() returns the raw promise so callers can observe failures.
@@ -248,6 +267,7 @@ export class UnifiedTradingAccount {
       lastSuccessAt: this._lastSuccessAt,
       lastFailureAt: this._lastFailureAt,
       recovering: this._recovering,
+      connecting: this._connecting,
       disabled: this._disabled,
     }
   }
@@ -290,7 +310,17 @@ export class UnifiedTradingAccount {
 
   /** Initial broker connection — fire-and-forget from constructor. */
   private async _connect(): Promise<void> {
+    // Timed + logged: the connect duration is the cold-start cost this whole
+    // non-blocking path exists to absorb, so surface it on the console (a slow
+    // CCXT loadMarkets is otherwise an invisible ~30s stall).
+    const startedAt = Date.now()
+    console.log(`UTA[${this.id}]: connecting (target ${this.targetReach})…`)
     this._currentReach = await this._attemptReach()
+    // Initial connect has settled (reached, down, or disabled — _attemptReach
+    // never throws). Clear the connecting gate now, BEFORE any _emitHealthChange
+    // below, so the first health diff the UI receives reflects the real state.
+    // Re-connections go through the recovery loop, which has its own gating.
+    this._connecting = false
     // Warm the sub-account cache once the transport is up, so the (sync)
     // write-disambiguation guard has the list before any staging. Best-effort:
     // a failure here must not break connection.
@@ -305,7 +335,7 @@ export class UnifiedTradingAccount {
     if (this._reachedTarget()) {
       this._onSuccess()
       this._emitHealthChange()
-      console.log(`UTA[${this.id}]: ${this._currentReach} (${this.tier})`)
+      console.log(`UTA[${this.id}]: ${this._currentReach} (${this.tier}) in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`)
       return
     }
     // Below target → recover toward it.
@@ -313,17 +343,45 @@ export class UnifiedTradingAccount {
     this._startRecovery()
     this._emitHealthChange()
     if (this._currentReach === 'down') {
+      console.warn(`UTA[${this.id}]: unreachable after ${((Date.now() - startedAt) / 1000).toFixed(1)}s — ${this._lastError ?? 'no detail'} (recovering)`)
       throw new BrokerError('NETWORK', this._lastError ?? `Account "${this.label}" unreachable`)
     }
     // 'connected' but funded wants 'readable' — partial; recovery pursues it.
+  }
+
+  /** Race the initial connect against a short grace window. Resolves as soon as
+   *  the connect settles (an instant broker wins via microtask, well before the
+   *  timer) or the grace elapses (a slow broker). The caller re-checks
+   *  `_connecting` afterwards to decide whether to proceed or fast-fail. */
+  private _awaitConnectOrGrace(): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const grace = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, UnifiedTradingAccount.CONNECT_GRACE_MS)
+      timer.unref?.()
+    })
+    return Promise.race([this._connectPromise.catch(() => {}), grace])
+      .finally(() => { if (timer) clearTimeout(timer) })
   }
 
   private async _callBroker<T>(fn: () => Promise<T>): Promise<T> {
     if (this._disabled) {
       throw new BrokerError('CONFIG', `Account "${this.label}" is disabled due to configuration error: ${this._lastError}`)
     }
+    // Initial connect still in flight (e.g. CCXT loadMarkets). Give it a short
+    // grace: an instant broker settles within it and the read proceeds with real
+    // data; a slow one is still connecting afterwards and we return FAST instead
+    // of blocking on the whole init. Thrown BEFORE the try block, so it never
+    // reaches _onFailure: no failure counter, no health degrade, no premature
+    // recovery. The background connect keeps going; a later read gets real data.
+    // This is the fix for the ~30s cold-start hang.
+    if (this._connecting) {
+      await this._awaitConnectOrGrace()
+      if (this._connecting) {
+        throw new BrokerError('CONNECTING', `Account "${this.label}" is still connecting to the broker. Data will be available shortly.`)
+      }
+    }
     if (this.health === 'offline' && this._recovering) {
-      throw new BrokerError('NETWORK', `Account "${this.label}" is offline and reconnecting. Try again shortly.`)
+      throw new BrokerError('CONNECTING', `Account "${this.label}" is offline and reconnecting. Try again shortly.`)
     }
     try {
       const result = await fn()

--- a/src/services/uta-client/UTAAccountSDK.ts
+++ b/src/services/uta-client/UTAAccountSDK.ts
@@ -101,6 +101,7 @@ export class UTAAccountSDK {
       tier: 'trading',
       consecutiveFailures: 0,
       recovering: false,
+      connecting: false,
       disabled: false,
     }
   }

--- a/src/services/uta-client/UTAManagerSDK.spec.ts
+++ b/src/services/uta-client/UTAManagerSDK.spec.ts
@@ -11,7 +11,7 @@ import type { UTATier } from '@traderalice/uta-protocol'
 
 const summary = (id: string, tier: UTATier) => ({
   id, label: id, capabilities: {},
-  health: { status: 'healthy', reach: 'connected', tier, consecutiveFailures: 0, recovering: false },
+  health: { status: 'healthy', reach: 'connected', tier, consecutiveFailures: 0, recovering: false, connecting: false },
 })
 
 function fakeClient(utas: unknown[]) {

--- a/src/tool/trading.spec.ts
+++ b/src/tool/trading.spec.ts
@@ -11,7 +11,7 @@ import Decimal from 'decimal.js'
 import { BrokerError } from '@traderalice/uta-protocol'
 import { createTradingTools } from './trading.js'
 
-type AccOpts = { account?: Record<string, unknown>; positions?: unknown[]; orders?: unknown[]; fail?: boolean }
+type AccOpts = { account?: Record<string, unknown>; positions?: unknown[]; orders?: unknown[]; fail?: boolean; connecting?: boolean }
 
 const DEFAULT_ACCOUNT = { netLiquidation: '10000', baseCurrency: 'USD', totalCashValue: '10000', unrealizedPnL: '0', realizedPnL: '0' }
 
@@ -25,12 +25,19 @@ function pos(symbol: string) {
 }
 
 function fakeAccount(id: string, o: AccOpts) {
-  const boom = () => { throw new BrokerError('NETWORK', `${id} is offline and reconnecting`) }
+  // `fail` → a real transient outage (NETWORK) → degraded bucket.
+  // `connecting` → the broker connect is still in flight (CONNECTING, what
+  // _callBroker throws during the initial-connect window) → connecting bucket,
+  // NOT degraded.
+  const guard = () => {
+    if (o.connecting) throw new BrokerError('CONNECTING', `${id} is still connecting to the broker`)
+    if (o.fail) throw new BrokerError('NETWORK', `${id} is offline and reconnecting`)
+  }
   return {
     id, label: id,
-    getAccount: async () => { if (o.fail) boom(); return o.account ?? DEFAULT_ACCOUNT },
-    getPositions: async () => { if (o.fail) boom(); return o.positions ?? [] },
-    getOrders: async () => { if (o.fail) boom(); return o.orders ?? [] },
+    getAccount: async () => { guard(); return o.account ?? DEFAULT_ACCOUNT },
+    getPositions: async () => { guard(); return o.positions ?? [] },
+    getOrders: async () => { guard(); return o.orders ?? [] },
     getPendingOrderIds: () => [],
   }
 }
@@ -143,6 +150,68 @@ describe('trading tools — partial tolerance (#390)', () => {
     const res = await run(tools.getOrders, { groupBy: 'contract' }) as Record<string, unknown>
     expect(res['acc|BTC']).toBeDefined()
     expect(res.degraded).toBeUndefined()
+  })
+})
+
+/**
+ * Cold-start non-blocking — an account still establishing its broker connection
+ * surfaces as `connecting` (pending), NOT `degraded` (broken). This is what
+ * stops the UI/agent from reporting a cold-starting account as a failure, and
+ * is the aggregation half of the fix that made reads return fast instead of
+ * blocking ~30s on CCXT loadMarkets.
+ */
+describe('trading tools — connecting state (cold-start)', () => {
+  it('getPortfolio routes a still-connecting account to `connecting`, not `degraded`', async () => {
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', { positions: [pos('BTC')] }),
+      fakeAccount('okx-readonly', { connecting: true }),
+    ]))
+    const res = await run(tools.getPortfolio, {}) as {
+      positions: unknown[]; degraded?: unknown[]; connecting: Array<{ source: string; code: string; transient: boolean }>
+    }
+    expect(res.positions).toHaveLength(1)
+    expect(res.degraded).toBeUndefined()
+    expect(res.connecting).toHaveLength(1)
+    expect(res.connecting[0].source).toBe('okx-readonly')
+    expect(res.connecting[0].code).toBe('CONNECTING')
+    expect(res.connecting[0].transient).toBe(true)
+  })
+
+  it('getPortfolio splits a real failure (degraded) from a pending connect (connecting) in one response', async () => {
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', { positions: [pos('BTC')] }),
+      fakeAccount('bybit-readonly', { fail: true }),
+      fakeAccount('okx-readonly', { connecting: true }),
+    ]))
+    const res = await run(tools.getPortfolio, {}) as {
+      positions: unknown[]; degraded: Array<{ source: string }>; connecting: Array<{ source: string }>
+    }
+    expect(res.positions).toHaveLength(1)
+    expect(res.degraded).toHaveLength(1)
+    expect(res.degraded[0].source).toBe('bybit-readonly')
+    expect(res.connecting).toHaveLength(1)
+    expect(res.connecting[0].source).toBe('okx-readonly')
+  })
+
+  it('getOrders routes a connecting account to `connecting`, leaving `degraded` unset', async () => {
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', { orders: [] }),
+      fakeAccount('okx-readonly', { connecting: true }),
+    ]))
+    const res = await run(tools.getOrders, {}) as { orders: unknown[]; degraded?: unknown[]; connecting: Array<{ source: string }> }
+    expect(res.degraded).toBeUndefined()
+    expect(res.connecting).toHaveLength(1)
+    expect(res.connecting[0].source).toBe('okx-readonly')
+  })
+
+  it('getAccount surfaces a connecting account inline with code CONNECTING', async () => {
+    const tools = createTradingTools(fakeManager([
+      fakeAccount('binance-x', {}),
+      fakeAccount('okx-readonly', { connecting: true }),
+    ]))
+    const res = await run(tools.getAccount, {}) as Array<Record<string, unknown>>
+    expect(res).toHaveLength(2)
+    expect(res.find((r) => r.source === 'okx-readonly')?.code).toBe('CONNECTING')
   })
 })
 

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -56,19 +56,29 @@ type AccountFailure = { source: string } & ReturnType<typeof handleBrokerError>
  * nothing instead of their real Binance/Bitget holdings (issue #390). Here a
  * failed account degrades to a `{ source, ...error }` marker while the healthy
  * ones still return.
+ *
+ * `connecting` is split out from `failed`: a CONNECTING marker means the
+ * account's broker connect is still in flight (or it's reconnecting) — data is
+ * PENDING, not failed. Keeping it out of `failed`/`degraded` is what stops the
+ * UI (and the agent) from reporting a cold-starting account as a broken one.
+ * The per-account read returns this fast instead of blocking on the slow
+ * connect, so the aggregate resolves immediately with whatever is ready.
  */
 async function settlePerAccount<U extends { id: string }, T>(
   targets: readonly U[],
   fn: (uta: U) => Promise<T>,
-): Promise<{ ok: T[]; failed: AccountFailure[] }> {
+): Promise<{ ok: T[]; failed: AccountFailure[]; connecting: AccountFailure[] }> {
   const settled = await Promise.allSettled(targets.map((u) => fn(u)))
   const ok: T[] = []
   const failed: AccountFailure[] = []
+  const connecting: AccountFailure[] = []
   settled.forEach((r, i) => {
-    if (r.status === 'fulfilled') ok.push(r.value)
-    else failed.push({ source: targets[i].id, ...handleBrokerError(r.reason) })
+    if (r.status === 'fulfilled') { ok.push(r.value); return }
+    const marker = { source: targets[i].id, ...handleBrokerError(r.reason) }
+    if (marker.code === 'CONNECTING') connecting.push(marker)
+    else failed.push(marker)
   })
-  return { ok, failed }
+  return { ok, failed, connecting }
 }
 
 /**
@@ -274,7 +284,7 @@ hitting the broker, which otherwise expects the bare base ticker.`,
     getAccount: tool({
       description: `Query trading account info (netLiquidation, totalCashValue, buyingPower, unrealizedPnL, realizedPnL).
 If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.
-When multiple accounts are queried, a healthy account appears with its balances and a failed one appears as an entry with an \`error\` field (and \`source\`). ALWAYS surface failed accounts to the user — an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry.`,
+When multiple accounts are queried, a healthy account appears with its balances and a failed one appears as an entry with an \`error\` field (and \`source\`). ALWAYS surface failed accounts to the user — an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry. An entry with code="CONNECTING" is NOT a failure: that account is still establishing its broker connection and its data will populate on a later read — don't report it as broken.`,
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false)),
         subAccountId: z.string().optional().describe('For multi-wallet venues (e.g. Binance: "spot" / "derivatives"), scope to one wallet. Omit for the aggregate across all wallets. Most brokers have a single wallet and ignore this.'),
@@ -282,20 +292,21 @@ When multiple accounts are queried, a healthy account appears with its balances 
       execute: async ({ source, subAccountId }) => {
         const targets = await manager.resolve(source, { tradingOnly: true })
         if (targets.length === 0) return await noAccountsError(manager, source)
-        const { ok, failed } = await settlePerAccount(targets, async (uta) => ({ source: uta.id, ...compactAccountInfo(await uta.getAccount(subAccountId)) }))
+        const { ok, failed, connecting } = await settlePerAccount(targets, async (uta) => ({ source: uta.id, ...compactAccountInfo(await uta.getAccount(subAccountId)) }))
         // Single explicit account: keep the original shape (the account
-        // object, or the error directly).
-        if (targets.length === 1) return ok[0] ?? failed[0]
-        // Multi-account: healthy accounts + per-account error markers, so one
-        // offline broker can't blank the rest (issue #390).
-        return [...ok, ...failed]
+        // object, or the error / connecting marker directly).
+        if (targets.length === 1) return ok[0] ?? failed[0] ?? connecting[0]
+        // Multi-account: healthy accounts + per-account error / connecting
+        // markers, so one offline (or cold-starting) broker can't blank the
+        // rest (issue #390 + the cold-start non-blocking fix).
+        return [...ok, ...failed, ...connecting]
       },
     }),
 
     getPortfolio: tool({
       description: `Query current portfolio holdings. IMPORTANT: If result is an empty array [], you have no holdings.
 If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.
-If the result is an object with a \`degraded\` array, one or more accounts could not be read — the \`positions\` are only from the healthy accounts. ALWAYS tell the user which \`source\`(s) are degraded; an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry.`,
+If the result is an object with a \`degraded\` array, one or more accounts could not be read — the \`positions\` are only from the healthy accounts. ALWAYS tell the user which \`source\`(s) are degraded; an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry. A \`connecting\` array (separate from \`degraded\`) lists accounts still establishing their broker connection — their positions are pending, not missing; mention them as "connecting" and re-query shortly rather than reporting a problem.`,
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false)),
         symbol: z.string().optional().describe('Filter by ticker, or omit for all'),
@@ -326,7 +337,7 @@ If the result is an object with a \`degraded\` array, one or more accounts could
         }
         // Per-account so one offline/region-blocked account degrades to a
         // marker instead of zeroing every healthy account's holdings (#390).
-        const { ok, failed } = await settlePerAccount(targets, async (uta) => {
+        const { ok, failed, connecting } = await settlePerAccount(targets, async (uta) => {
           const positions = await uta.getPositions(subAccountId)
           const accountInfo = await uta.getAccount(subAccountId)
 
@@ -372,16 +383,18 @@ If the result is an object with a \`degraded\` array, one or more accounts could
 
         const allPositions = ok.flat()
         const allWarnings = [...new Set(fxWarningsFromRates)]
-        // Clean empty result only when nothing failed — don't report "no
-        // positions" when an account was actually unreachable.
-        if (allPositions.length === 0 && failed.length === 0 && allWarnings.length === 0) {
+        // Clean empty result only when nothing failed AND nothing is still
+        // connecting — don't report "no positions" when an account was actually
+        // unreachable or just hasn't finished its initial connect.
+        if (allPositions.length === 0 && failed.length === 0 && connecting.length === 0 && allWarnings.length === 0) {
           return { positions: [], message: 'No open positions.' }
         }
-        if (failed.length > 0 || allWarnings.length > 0) {
+        if (failed.length > 0 || connecting.length > 0 || allWarnings.length > 0) {
           return {
             positions: allPositions,
             ...(allWarnings.length > 0 && { fxWarnings: allWarnings }),
             ...(failed.length > 0 && { degraded: failed }),
+            ...(connecting.length > 0 && { connecting }),
           }
         }
         return allPositions
@@ -392,7 +405,7 @@ If the result is an object with a \`degraded\` array, one or more accounts could
       description: `Query orders by ID. If no orderIds provided, queries all pending (submitted) orders.
 Use groupBy: "contract" to group orders by contract/aliceId (useful with many positions + TPSL).
 If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.
-If the result is an object with a \`degraded\` array, one or more accounts could not be read — the orders are only from the healthy accounts. ALWAYS tell the user which \`source\`(s) are degraded; an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry.`,
+If the result is an object with a \`degraded\` array, one or more accounts could not be read — the orders are only from the healthy accounts. ALWAYS tell the user which \`source\`(s) are degraded; an entry with transient=false is a permanent (credentials/config) failure they must fix, not retry. A \`connecting\` array lists accounts still establishing their broker connection — their orders are pending, not missing; re-query shortly rather than reporting a problem.`,
       inputSchema: z.object({
         source: z.string().optional().describe(sourceDesc(false)),
         orderIds: z.array(z.string()).optional().describe('Order IDs to query. If omitted, queries all pending orders.'),
@@ -402,7 +415,7 @@ If the result is an object with a \`degraded\` array, one or more accounts could
         const targets = await manager.resolve(source, { tradingOnly: true })
         if (targets.length === 0) return []
         // Per-account so one offline account doesn't blank everyone's orders (#390).
-        const { ok, failed } = await settlePerAccount(targets, async (uta) => {
+        const { ok, failed, connecting } = await settlePerAccount(targets, async (uta) => {
           // SDK's getPendingOrderIds is a no-op returning []; the real
           // UnifiedTradingAccount returns the actual pending list. Both
           // satisfy the same call site so this works for Phase A's
@@ -412,6 +425,11 @@ If the result is an object with a \`degraded\` array, one or more accounts could
           return orders.map((o, i) => summarizeOrder(o, uta.id, ids[i]))
         })
         const summaries = ok.flat()
+        const markers = {
+          ...(failed.length > 0 && { degraded: failed }),
+          ...(connecting.length > 0 && { connecting }),
+        }
+        const hasMarkers = failed.length > 0 || connecting.length > 0
 
         if (groupBy === 'contract') {
           const grouped: Record<string, { symbol: string; orders: ReturnType<typeof summarizeOrder>[] }> = {}
@@ -420,9 +438,9 @@ If the result is an object with a \`degraded\` array, one or more accounts could
             if (!grouped[key]) grouped[key] = { symbol: s.symbol, orders: [] }
             grouped[key].orders.push(s)
           }
-          return failed.length > 0 ? { grouped, degraded: failed } : grouped
+          return hasMarkers ? { grouped, ...markers } : grouped
         }
-        return failed.length > 0 ? { orders: summaries, degraded: failed } : summaries
+        return hasMarkers ? { orders: summaries, ...markers } : summaries
       },
     }),
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -289,6 +289,10 @@ export interface BrokerHealthInfo {
   lastSuccessAt?: string
   lastFailureAt?: string
   recovering: boolean
+  /** True while the account's initial broker connect is still in flight; the UI
+   *  renders a "connecting…" state off this (status is optimistically 'healthy'
+   *  during the window, so it can't be inferred from status/reach). */
+  connecting: boolean
   disabled: boolean
 }
 

--- a/ui/src/auth/AuthGate.tsx
+++ b/ui/src/auth/AuthGate.tsx
@@ -9,18 +9,17 @@
  */
 
 import type { ReactNode } from 'react'
-import { useTranslation } from 'react-i18next'
 import { useAuth } from './AuthContext'
 import { LoginPage, NoTokenPage } from './LoginPage'
+import { Spinner } from '../components/StateViews'
 
 export function AuthGate({ children }: { children: ReactNode }) {
   const { state } = useAuth()
-  const { t } = useTranslation()
 
   if (state === 'loading') {
     return (
       <div className="min-h-screen flex items-center justify-center bg-bg">
-        <div className="text-[12px] text-text-muted">{t('common.loading')}</div>
+        <Spinner />
       </div>
     )
   }

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -7,6 +7,7 @@ import { useInboxRead } from '../live/inbox-read'
 import { useInboxSelection } from '../live/inbox-selection'
 import { useInboxViewMode } from '../live/inbox-view-mode'
 import { groupThreads, previewForEntry } from '../live/inbox-threads'
+import { Skeleton } from './StateViews'
 import type { InboxEntry } from '../api/inbox'
 
 /**
@@ -74,7 +75,16 @@ export function InboxSidebar() {
   }, [ordered, selectedId])
 
   if (loading && entries.length === 0) {
-    return <div className="px-3 py-3 text-[12px] text-text-muted">{t('common.loading')}</div>
+    return (
+      <div className="flex flex-col py-1" aria-hidden="true">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-1.5 px-3 py-2">
+            <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="h-2.5 w-3/4" />
+          </div>
+        ))}
+      </div>
+    )
   }
 
   if (entries.length === 0) {

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -23,6 +23,7 @@ import { useWikilinkHandler } from '../live/wikilink'
 import { useWorkspace } from '../tabs/store'
 import { CadencePill, PriorityIndicator, STATUS_META } from './IssuesBoard'
 import { MarkdownContent } from './MarkdownContent'
+import { CenteredLoading } from './StateViews'
 
 // Run-status pill tints — mirrors AutomationRunsSection's STATUS_STYLE so the
 // Activity feed reads the same as the headless-runs panel.
@@ -611,7 +612,7 @@ export function IssueDetail({ wsId, id }: { wsId: string; id: string }) {
       <div className="mx-auto max-w-4xl px-4 py-5 md:px-6">
         {backToBoard}
         {loading ? (
-          <div className="text-sm text-muted">Loading…</div>
+          <CenteredLoading />
         ) : (
           <div className="rounded-lg border border-border bg-bg-secondary px-6 py-12 text-center">
             <ListChecks size={24} className="mx-auto text-muted/50" />

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -17,6 +17,7 @@ import type { IssueListItem, IssuePriority, IssueStatus, IssueWorkspace } from '
 import type { ScheduleWhen } from '../api/schedule'
 import { useIssues } from '../hooks/useIssues'
 import { useWorkspace } from '../tabs/store'
+import { CenteredLoading } from './StateViews'
 
 // ==================== Cadence pill (lifted from AutomationSchedulesSection) ====================
 
@@ -269,7 +270,7 @@ export function IssuesBoard() {
   // Keep showing any snapshot we have (incl. the warm cache) rather than
   // flipping to a loading/error screen on a transient refresh failure.
   if (!data) {
-    if (loading) return <div className="text-sm text-muted">Loading…</div>
+    if (loading) return <CenteredLoading />
     return <div className="text-sm text-red-400">Failed to load issues: {error}</div>
   }
 

--- a/ui/src/components/PortfolioSidebar.tsx
+++ b/ui/src/components/PortfolioSidebar.tsx
@@ -4,6 +4,7 @@ import { useWorkspace } from '../tabs/store'
 import { getFocusedTab } from '../tabs/types'
 import { SidebarRow } from './SidebarRow'
 import { SidebarSectionHeader } from './SidebarSectionHeader'
+import { SidebarRowsSkeleton } from './StateViews'
 
 /**
  * Portfolio sidebar — Overview + per-UTA accounts.
@@ -39,7 +40,7 @@ export function PortfolioSidebar() {
         </SidebarSectionHeader>
 
         {loading ? (
-          <p className="px-3 py-2 text-[12px] text-text-muted/70">{t('common.loading')}</p>
+          <SidebarRowsSkeleton rows={3} />
         ) : utas.length === 0 ? (
           <p className="px-3 py-2 text-[12px] text-text-muted/70 leading-relaxed">
             {t('portfolio.noAccountsYet')}

--- a/ui/src/components/PushApprovalPanel.tsx
+++ b/ui/src/components/PushApprovalPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import { Skeleton } from './StateViews'
 import { formatRelativeTime, getIntlLocale } from '../lib/intl'
 import { api } from '../api'
 import { isUnsetDecimal } from '../lib/format'
@@ -110,6 +111,9 @@ export function PushApprovalPanel() {
   const [confirmingPush, setConfirmingPush] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<{ accountId: string; data: WalletPushResult } | null>(null)
   const [error, setError] = useState<string | null>(null)
+  // False until the first poll resolves, so the panel shows a skeleton on cold
+  // load instead of an immediate (misleading) "No pending operations".
+  const [loaded, setLoaded] = useState(false)
   // History UTA filter — null = show every account's commits merged. Holds
   // an accountId when narrowed to one account's log.
   const [historyFilter, setHistoryFilter] = useState<string | null>(null)
@@ -143,7 +147,7 @@ export function PushApprovalPanel() {
       setStaged(stagedResults)
       setPending(pendingResults)
       setHistory(historyResults)
-    } catch { /* ignore */ }
+    } catch { /* ignore */ } finally { setLoaded(true) }
   }, [])
 
   useEffect(() => {
@@ -360,6 +364,15 @@ export function PushApprovalPanel() {
                 <button onClick={() => setError(null)} className="ml-2 text-text-muted hover:text-text">Dismiss</button>
               </div>
             )}
+          </div>
+        ) : !loaded ? (
+          <div className="px-3 py-3 space-y-3" aria-hidden="true">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-2.5 w-24" />
+                <Skeleton className="h-7 w-full rounded" />
+              </div>
+            ))}
           </div>
         ) : !hasStaged ? (
           <div className="px-3 py-4 text-[12px] text-text-muted/70 leading-relaxed">

--- a/ui/src/components/StateViews.tsx
+++ b/ui/src/components/StateViews.tsx
@@ -40,6 +40,29 @@ export function CenteredLoading({ label }: { label?: string }) {
   )
 }
 
+// ==================== Skeleton ====================
+
+/** Theme-aware shimmer placeholder for first-load states. Size + radius come
+ *  from `className` (e.g. "h-4 w-24 rounded"), so callers compose the real
+ *  layout's shapes — a metric row, a table row, a chart box — out of these
+ *  blocks instead of leaving a blank pane. The shimmer is the `.skeleton` class
+ *  in index.css; it honors prefers-reduced-motion. Decorative → aria-hidden. */
+export function Skeleton({ className = '' }: { className?: string }) {
+  return <div className={`skeleton rounded-md ${className}`} aria-hidden="true" />
+}
+
+/** A stack of skeleton lines, the last one short like a paragraph tail. Handy
+ *  for text blocks and list rows where you just need "some lines are loading". */
+export function SkeletonText({ lines = 3, className = '' }: { lines?: number; className?: string }) {
+  return (
+    <div className={`flex flex-col gap-2 ${className}`} aria-hidden="true">
+      {Array.from({ length: lines }).map((_, i) => (
+        <div key={i} className={`skeleton h-3 rounded ${i === lines - 1 ? 'w-2/3' : 'w-full'}`} />
+      ))}
+    </div>
+  )
+}
+
 // ==================== EmptyState ====================
 
 interface EmptyStateProps {

--- a/ui/src/components/StateViews.tsx
+++ b/ui/src/components/StateViews.tsx
@@ -63,6 +63,25 @@ export function SkeletonText({ lines = 3, className = '' }: { lines?: number; cl
   )
 }
 
+/** Skeleton rows for a secondary sidebar list during cold load — matches
+ *  `SidebarRow`'s `px-3 py-1.5` rhythm so the placeholder sits exactly where the
+ *  real nav rows will. `icon` adds a leading glyph block (for sidebars whose rows
+ *  lead with an icon, e.g. Tracked). Varied widths keep it from looking like a
+ *  barcode. */
+export function SidebarRowsSkeleton({ rows = 5, icon = false }: { rows?: number; icon?: boolean }) {
+  const widths = ['w-32', 'w-24', 'w-28', 'w-20']
+  return (
+    <div aria-hidden="true">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center gap-1.5 px-3 py-1.5">
+          {icon && <Skeleton className="h-3 w-3 rounded shrink-0" />}
+          <Skeleton className={`h-3 rounded ${widths[i % widths.length]}`} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 // ==================== EmptyState ====================
 
 interface EmptyStateProps {

--- a/ui/src/components/TrackedSidebar.tsx
+++ b/ui/src/components/TrackedSidebar.tsx
@@ -5,6 +5,7 @@ import { entitiesLive } from '../live/entities'
 import { useTrackedSelection } from '../live/tracked-selection'
 import { SidebarRow } from './SidebarRow'
 import { SidebarSectionHeader } from './SidebarSectionHeader'
+import { SidebarRowsSkeleton } from './StateViews'
 
 /**
  * Tracked sidebar — the watchlist. A flat list of entities (assets + topics),
@@ -30,7 +31,11 @@ export function TrackedSidebar() {
   }, [entities, selected, select])
 
   if (loading && entities.length === 0) {
-    return <div className="px-3 py-3 text-[12px] text-text-muted">{t('common.loading')}</div>
+    return (
+      <div className="flex flex-col h-full overflow-y-auto py-1">
+        <SidebarRowsSkeleton rows={6} icon />
+      </div>
+    )
   }
 
   if (entities.length === 0) {

--- a/ui/src/components/market/FinancialStatementsPanel.tsx
+++ b/ui/src/components/market/FinancialStatementsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { marketApi, type FinancialStatementRow } from '../../api/market'
 import { Card } from './Card'
+import { Skeleton } from '../StateViews'
 import { fmtMoneyShort } from './format'
 
 type Tab = 'balance' | 'income' | 'cashflow'
@@ -130,7 +131,36 @@ export function FinancialStatementsPanel({ symbol }: Props) {
         </div>
       }
     >
-      {loading && !entry && <div className="p-3 text-[12px] text-text-muted">Loading…</div>}
+      {loading && !entry && (
+        <table aria-hidden="true" className="w-full text-[12px] border-collapse">
+          <thead>
+            <tr className="border-b border-border/60">
+              <th className="text-left px-3 py-2 sticky left-0 bg-bg-secondary/30">
+                <Skeleton className="h-3 w-10 rounded" />
+              </th>
+              {Array.from({ length: 4 }).map((_, i) => (
+                <th key={i} className="px-3 py-2">
+                  <Skeleton className="h-3 w-12 rounded ml-auto" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 5 }).map((_, r) => (
+              <tr key={r} className="border-b border-border/30 last:border-b-0">
+                <td className="px-3 py-1.5">
+                  <Skeleton className="h-3 w-28 rounded" />
+                </td>
+                {Array.from({ length: 4 }).map((_, c) => (
+                  <td key={c} className="px-3 py-1.5">
+                    <Skeleton className="h-3 w-14 rounded ml-auto" />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
       {entry?.error && <div className="p-3 text-[12px] text-red">{entry.error}</div>}
       {!entry?.error && rows.length === 0 && !loading && (
         <div className="p-3 text-[12px] text-text-muted">No data.</div>

--- a/ui/src/components/market/KeyMetricsPanel.tsx
+++ b/ui/src/components/market/KeyMetricsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { marketApi, type KeyMetrics, type FinancialRatios } from '../../api/market'
+import { Skeleton } from '../StateViews'
 import { Card } from './Card'
 import { fmtNumber, fmtPercent, fmtMoneyShort } from './format'
 
@@ -92,7 +93,16 @@ export function KeyMetricsPanel({ symbol }: Props) {
 
   return (
     <Card title="Key Metrics" info={info}>
-      {loading && <div className="text-[12px] text-text-muted">Loading…</div>}
+      {loading && (
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-[12px]" aria-hidden="true">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-baseline justify-between border-b border-border/30 py-1 last:border-b-0">
+              <Skeleton className="h-3 w-16 rounded" />
+              <Skeleton className="h-3 w-12 rounded" />
+            </div>
+          ))}
+        </dl>
+      )}
       {error && !loading && <div className="text-[12px] text-red">{error}</div>}
       {!loading && !error && data && (
         <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-[12px]">

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -11,6 +11,7 @@ import {
   type HistogramData,
 } from 'lightweight-charts'
 import { barsApi, type AssetClass, type HistoricalBar, type BarSourceCandidate, type BarMeta } from '../../api/market'
+import { Skeleton } from '../StateViews'
 
 type Interval = '1m' | '5m' | '1h' | '1d'
 type Timeframe = '1D' | '5D' | '1M' | '3M' | '1Y' | '5Y' | 'All'
@@ -326,6 +327,11 @@ export function KlinePanel({ selection }: Props) {
         {!selection && (
           <div className="absolute inset-0 flex items-center justify-center text-[13px] text-text-muted">
             Pick an asset to see the K-line.
+          </div>
+        )}
+        {selection && loading && !bars && (
+          <div className="absolute inset-0 p-2" aria-hidden="true">
+            <Skeleton className="w-full h-full rounded" />
           </div>
         )}
         {selection && loading && (

--- a/ui/src/components/market/ProfilePanel.tsx
+++ b/ui/src/components/market/ProfilePanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { marketApi, type EquityProfile } from '../../api/market'
+import { Skeleton } from '../StateViews'
 import { Card } from './Card'
 import { fmtInt } from './format'
 
@@ -48,7 +49,14 @@ export function ProfilePanel({ symbol }: Props) {
 
   return (
     <Card title="Profile" info={info}>
-      {loading && <div className="text-[12px] text-text-muted">Loading…</div>}
+      {loading && (
+        <div className="flex flex-col gap-3" aria-hidden="true">
+          <Skeleton className="h-3 w-40 rounded" />
+          <Skeleton className="h-3 w-52 rounded" />
+          <Skeleton className="h-3 w-32 rounded" />
+          <Skeleton className="h-3 w-44 rounded" />
+        </div>
+      )}
       {error && !loading && <div className="text-[12px] text-red">{error}</div>}
       {!loading && !error && profile && (
         <div className="flex flex-col gap-3 text-[12px]">

--- a/ui/src/components/market/QuoteHeader.tsx
+++ b/ui/src/components/market/QuoteHeader.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { marketApi, type EquityQuote } from '../../api/market'
+import { Skeleton } from '../StateViews'
 import { fmtNumber, fmtMoneyShort, fmtPercent, fmtInt } from './format'
 
 interface Props {
@@ -35,32 +36,51 @@ export function QuoteHeader({ symbol }: Props) {
   const change = quote?.change as number | undefined
   const changePct = quote?.change_percent as number | undefined
   const up = (change ?? 0) >= 0
+  // First-load: no quote yet and no error → show skeletons in place of the
+  // (otherwise dash-filled) value slots. `quote` stays set across the 60s
+  // re-poll, so this won't flash on a background refetch.
+  const loading = !quote && !error
 
   return (
     <div className="flex flex-wrap items-end gap-x-6 gap-y-2 px-4 py-3 border border-border rounded bg-bg-secondary/30">
       <div className="flex flex-col min-w-0">
         <div className="flex items-baseline gap-2 min-w-0">
           <span className="text-[20px] font-semibold text-text tracking-tight">{symbol}</span>
-          {name && <span className="text-[13px] text-text-muted truncate">{name}</span>}
-          {exchange && (
-            <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
-              {exchange}
-            </span>
-          )}
-          {provider && (
-            <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
-              {provider}
-            </span>
+          {loading ? (
+            <Skeleton className="h-3.5 w-28 rounded" />
+          ) : (
+            <>
+              {name && <span className="text-[13px] text-text-muted truncate">{name}</span>}
+              {exchange && (
+                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
+                  {exchange}
+                </span>
+              )}
+              {provider && (
+                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
+                  {provider}
+                </span>
+              )}
+            </>
           )}
         </div>
         <div className="flex items-baseline gap-3 mt-1">
           <span className="text-[22px] font-mono font-semibold text-text">
-            {fmtNumber(lastPrice)}
+            {loading ? (
+              <Skeleton className="inline-block h-6 w-28 rounded align-baseline" />
+            ) : (
+              fmtNumber(lastPrice)
+            )}
           </span>
-          {change != null && changePct != null && (
-            <span className={`text-[13px] font-medium ${up ? 'text-green' : 'text-red'}`}>
-              {up ? '+' : ''}{fmtNumber(change)} ({up ? '+' : ''}{fmtPercent(changePct)})
-            </span>
+          {loading ? (
+            <Skeleton className="h-3.5 w-24 rounded" />
+          ) : (
+            change != null &&
+            changePct != null && (
+              <span className={`text-[13px] font-medium ${up ? 'text-green' : 'text-red'}`}>
+                {up ? '+' : ''}{fmtNumber(change)} ({up ? '+' : ''}{fmtPercent(changePct)})
+              </span>
+            )
           )}
         </div>
       </div>
@@ -68,16 +88,16 @@ export function QuoteHeader({ symbol }: Props) {
       {/* Bid / ask intentionally omitted — they're real-time L1 quote data
           that belongs at the execution layer (UTA), not in analysis. */}
       <dl className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-x-4 gap-y-1 text-[11px]">
-        <Field label="Open"      value={fmtNumber(quote?.open)} />
-        <Field label="Prev"      value={fmtNumber(quote?.prev_close)} />
-        <Field label="High"      value={fmtNumber(quote?.high)} />
-        <Field label="Low"       value={fmtNumber(quote?.low)} />
-        <Field label="Volume"    value={fmtInt(quote?.volume)} />
-        <Field label="Mkt Cap"   value={fmtMoneyShort(quote?.market_cap)} />
-        <Field label="52W High"  value={fmtNumber(quote?.year_high)} />
-        <Field label="52W Low"   value={fmtNumber(quote?.year_low)} />
-        <Field label="MA50"      value={fmtNumber(quote?.ma50)} />
-        <Field label="MA200"     value={fmtNumber(quote?.ma200)} />
+        <Field label="Open"      value={fmtNumber(quote?.open)}        loading={loading} />
+        <Field label="Prev"      value={fmtNumber(quote?.prev_close)}  loading={loading} />
+        <Field label="High"      value={fmtNumber(quote?.high)}        loading={loading} />
+        <Field label="Low"       value={fmtNumber(quote?.low)}         loading={loading} />
+        <Field label="Volume"    value={fmtInt(quote?.volume)}         loading={loading} />
+        <Field label="Mkt Cap"   value={fmtMoneyShort(quote?.market_cap)} loading={loading} />
+        <Field label="52W High"  value={fmtNumber(quote?.year_high)}   loading={loading} />
+        <Field label="52W Low"   value={fmtNumber(quote?.year_low)}    loading={loading} />
+        <Field label="MA50"      value={fmtNumber(quote?.ma50)}        loading={loading} />
+        <Field label="MA200"     value={fmtNumber(quote?.ma200)}       loading={loading} />
       </dl>
 
       {error && <div className="w-full text-[11px] text-red">{error}</div>}
@@ -85,11 +105,13 @@ export function QuoteHeader({ symbol }: Props) {
   )
 }
 
-function Field({ label, value }: { label: string; value: string }) {
+function Field({ label, value, loading }: { label: string; value: string; loading?: boolean }) {
   return (
     <div className="flex flex-col min-w-0">
       <dt className="text-text-muted/60 uppercase tracking-wide">{label}</dt>
-      <dd className="font-mono text-text truncate">{value}</dd>
+      <dd className="font-mono text-text truncate">
+        {loading ? <Skeleton className="h-3 w-12 rounded mt-0.5" /> : value}
+      </dd>
     </div>
   )
 }

--- a/ui/src/components/uta/HealthBadge.tsx
+++ b/ui/src/components/uta/HealthBadge.tsx
@@ -19,6 +19,12 @@ export function HealthBadge({ health, size = 'sm' }: { health?: BrokerHealthInfo
 
   if (health.disabled) return pill('text-text-muted', 'bg-text-muted/40', 'Disabled', health.lastError)
 
+  // Initial broker connect still in flight. `status` is optimistically 'healthy'
+  // during this window, so this must be checked BEFORE the switch — otherwise a
+  // cold-starting account misleadingly reads "Connected" while its data is still
+  // loading. Pulses to signal work-in-progress, not a steady state.
+  if (health.connecting) return pill('text-accent', 'bg-accent', 'Connecting...', health.lastError, true)
+
   switch (health.status) {
     case 'healthy':
       // At target reach. The label tells the user the account's role.

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -86,7 +86,11 @@ export function ChatWorkspaceSection(): ReactElement | null {
     }
   }
 
-  if (!chatTemplate) return null
+  // Don't collapse the whole section while templates are still loading — doing
+  // so hid the cold-load skeleton (and the New-chat CTA) during the exact 30s
+  // window we want to fill, leaving a blank pane. Only bail once templates are
+  // known-loaded AND there genuinely is no chat template (broken deployment).
+  if (ctx.templatesLoaded && !chatTemplate) return null
 
   const todayLabel = t('chat.today')
   const yesterdayLabel = t('chat.yesterday')

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -18,6 +18,7 @@ import { ChevronDown, ChevronRight, FolderPlus, Plus, Settings as SettingsIcon, 
 
 import { getIntlLocale } from '../../lib/intl'
 import { useWorkspaces } from '../../contexts/WorkspacesContext'
+import { Skeleton } from '../StateViews'
 import { useWorkspace } from '../../tabs/store'
 import { getFocusedTab } from '../../tabs/types'
 import { ConfirmDialog } from '../ConfirmDialog'
@@ -156,7 +157,26 @@ export function ChatWorkspaceSection(): ReactElement | null {
       )}
 
       <ul className="py-0.5">
-        {chatWorkspaces.length === 0 && !ctx.listError && (
+        {/* Cold load: the list is empty because it hasn't fetched yet, NOT
+            because there are no chats — show a skeleton instead of flashing the
+            "no chats yet" empty text (or a blank pane) until the first list
+            lands. */}
+        {!ctx.hasLoaded && !ctx.listError && (
+          <li aria-hidden="true">
+            {Array.from({ length: 3 }).map((_, g) => (
+              <div key={g} className="mb-1.5">
+                <div className="px-3 py-1.5"><Skeleton className="h-2.5 w-14" /></div>
+                {Array.from({ length: 2 }).map((_, r) => (
+                  <div key={r} className="flex items-center gap-2 px-3 py-1.5">
+                    <Skeleton className="h-3 w-3 rounded" />
+                    <Skeleton className={`h-3 ${r === 0 ? 'w-32' : 'w-24'}`} />
+                  </div>
+                ))}
+              </div>
+            ))}
+          </li>
+        )}
+        {ctx.hasLoaded && chatWorkspaces.length === 0 && !ctx.listError && (
           <li className="px-3 py-2 text-[12px] text-text-muted/60">{t('chat.noChatWorkspacesYet')}</li>
         )}
         {ctx.listError && <li className="px-3 py-1 text-[11px] text-red">{ctx.listError}</li>}

--- a/ui/src/components/workspace/FilesPanel.tsx
+++ b/ui/src/components/workspace/FilesPanel.tsx
@@ -3,6 +3,7 @@ import { formatRelativeTime } from '../../lib/intl';
 import type { ReactElement } from 'react';
 
 import { listFiles, type DirListing, type FileEntry } from './api';
+import { Skeleton } from '../StateViews';
 import { useWorkspace } from '../../tabs/store';
 
 const POLL_MS = 5000;
@@ -93,6 +94,17 @@ export function FilesPanel(props: FilesPanelProps): ReactElement {
       {error && <div className="panel-error">{error}</div>}
 
       <ul className="files-list">
+        {!listing && !error &&
+          Array.from({ length: 6 }).map((_, i) => (
+            <li key={i} className="files-row" aria-hidden="true">
+              <span className="files-icon">
+                <Skeleton className="h-4 w-4 rounded" />
+              </span>
+              <span className="files-name">
+                <Skeleton className="h-3.5 w-32 rounded" />
+              </span>
+            </li>
+          ))}
         {listing?.entries.length === 0 && !error && (
           <li className="panel-empty">empty</li>
         )}

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   type Workspace,
 } from './api';
 import { CreateWorkspaceDialog } from './CreateWorkspaceDialog';
+import { Skeleton } from '../StateViews';
 
 /**
  * Workspace launcher sidebar.
@@ -43,6 +44,9 @@ export interface SidebarProps {
   readonly templates: readonly TemplateInfo[];
   readonly agents: readonly AgentInfo[];
   readonly listError: string | null;
+  /** True once the first workspaces-list fetch has resolved — gates the empty
+   *  state vs. a cold-load skeleton. */
+  readonly hasLoaded: boolean;
   readonly selection: Selection | null;
   readonly onSelectWorkspace: (wsId: string) => void;
   readonly onSelectSession: (wsId: string, sessionId: string) => void;
@@ -151,7 +155,17 @@ export function Sidebar(props: SidebarProps): ReactElement {
         />
       )}
 
-      {props.workspaces.length === 0 && !props.listError && (
+      {!props.hasLoaded && !props.listError && (
+        <div className="flex flex-col mt-0.5" aria-hidden="true">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-2 px-3 py-2">
+              <Skeleton className="h-4 w-4 rounded" />
+              <Skeleton className={`h-3 ${i % 2 === 0 ? 'w-32' : 'w-24'}`} />
+            </div>
+          ))}
+        </div>
+      )}
+      {props.hasLoaded && props.workspaces.length === 0 && !props.listError && (
         <div className="px-3 py-2 text-[12px] text-text-muted/60">No workspaces yet</div>
       )}
       {props.listError && <div className="px-3 py-2 text-[12px] text-red">{props.listError}</div>}

--- a/ui/src/components/workspace/WorkspacesSidebar.tsx
+++ b/ui/src/components/workspace/WorkspacesSidebar.tsx
@@ -33,6 +33,7 @@ export function WorkspacesSidebar() {
         templates={ctx.templates}
         agents={ctx.agents}
         listError={ctx.listError}
+        hasLoaded={ctx.hasLoaded}
         selection={selection}
         onSelectWorkspace={(wsId) => {
           if (wsId.length === 0) return

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -65,6 +65,12 @@ interface WorkspacesContextValue {
    *  empty list means "not loaded yet", not "no workspaces" — the sidebar shows
    *  a skeleton instead of a blank pane / empty state. */
   readonly hasLoaded: boolean
+  /** True once the templates fetch has settled (success OR failure). Until then
+   *  an empty `templates` means "not loaded yet", not "no templates" — surfaces
+   *  that null-render or show a "no X configured" state when a template is
+   *  missing MUST gate on this, or they collapse to a blank pane during the
+   *  cold-start window (e.g. the Ask Alice sidebar hides its own skeleton). */
+  readonly templatesLoaded: boolean
   refresh(): void
   spawn(wsId: string, opts?: SpawnOpts): Promise<void>
   /**
@@ -90,6 +96,7 @@ const WorkspacesContext = createContext<WorkspacesContextValue | null>(null)
 export function WorkspacesProvider({ children }: { children: ReactNode }) {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
   const [templates, setTemplates] = useState<TemplateInfo[]>([])
+  const [templatesLoaded, setTemplatesLoaded] = useState(false)
   const [agents, setAgents] = useState<AgentInfo[]>([])
   const [listError, setListError] = useState<string | null>(null)
   // Don't reconcile orphan tabs until we've successfully fetched the
@@ -126,7 +133,10 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   }, [refresh])
 
   useEffect(() => {
-    void listTemplates().then(setTemplates).catch(() => setTemplates([]))
+    void listTemplates()
+      .then(setTemplates)
+      .catch(() => setTemplates([]))
+      .finally(() => setTemplatesLoaded(true))
     void listAgents().then(setAgents).catch(() => setAgents([]))
   }, [])
 
@@ -308,6 +318,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         agents,
         listError,
         hasLoaded,
+        templatesLoaded,
         refresh,
         spawn,
         quickChat,

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -61,6 +61,10 @@ interface WorkspacesContextValue {
   readonly templates: readonly TemplateInfo[]
   readonly agents: readonly AgentInfo[]
   readonly listError: string | null
+  /** True once the first workspaces-list fetch has resolved. Until then an
+   *  empty list means "not loaded yet", not "no workspaces" — the sidebar shows
+   *  a skeleton instead of a blank pane / empty state. */
+  readonly hasLoaded: boolean
   refresh(): void
   spawn(wsId: string, opts?: SpawnOpts): Promise<void>
   /**
@@ -303,6 +307,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         templates,
         agents,
         listError,
+        hasLoaded,
         refresh,
         spawn,
         quickChat,

--- a/ui/src/demo/fixtures/trading.ts
+++ b/ui/src/demo/fixtures/trading.ts
@@ -32,6 +32,7 @@ const healthOk = {
   consecutiveFailures: 0,
   lastSuccessAt: new Date().toISOString(),
   recovering: false,
+  connecting: false,
   disabled: false,
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -195,6 +195,35 @@ body {
   animation-delay: 0.3s;
 }
 
+/* Skeleton placeholder — theme-aware shimmer for first-load states. The block
+   is the tertiary surface (reads on both the page bg and bg-secondary cards); a
+   soft overlay band sweeps across at an ambient cadence (sibling to live-pulse's
+   2.4s, a touch quicker so it reads as "loading" without feeling anxious). Size
+   + radius come from the element's own utility classes. Honors reduced motion. */
+@keyframes skeleton-sweep {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+.skeleton {
+  background-color: var(--color-bg-tertiary);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--color-overlay-strong) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: skeleton-sweep 1.6s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    background-image: none;
+    opacity: 0.7;
+  }
+}
+
 /* ==================== Button utility classes ==================== */
 
 .btn-primary {

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -18,7 +18,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { api, type Preset, type WireShape } from '../api'
 import type { CredentialSummary, WorkspaceCredentialDefaultsResponse } from '../api/config'
 import { PageHeader } from '../components/PageHeader'
-import { PageLoading } from '../components/StateViews'
+import { PageLoading, Skeleton } from '../components/StateViews'
 import { Field, inputClass } from '../components/form'
 import { ModelCombobox } from '../components/credentials/PresetFields'
 import {
@@ -347,7 +347,17 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
       <h2 className="text-[13px] font-semibold text-text uppercase tracking-wide mb-3">Default workspace credentials</h2>
 
       {!data ? (
-        <p className="text-[12px] text-text-muted">Loading…</p>
+        <div className="space-y-2.5" aria-hidden="true">
+          {PRIMARY_DEFAULT_AGENTS.map((a) => (
+            <div key={a.id} className="flex items-center gap-3 rounded-lg border border-border bg-bg px-4 py-3">
+              <div className="flex-1 min-w-0 space-y-1.5">
+                <Skeleton className="h-3.5 w-28 rounded" />
+                <Skeleton className="h-2.5 w-44 rounded" />
+              </div>
+              <Skeleton className="h-8 w-[240px] max-w-[240px] rounded" />
+            </div>
+          ))}
+        </div>
       ) : (
         <div className="space-y-2.5">
           {PRIMARY_DEFAULT_AGENTS.map((a) => renderAgent(a))}

--- a/ui/src/pages/AutomationRunsSection.tsx
+++ b/ui/src/pages/AutomationRunsSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { api } from '../api'
 import type { HeadlessOutput, HeadlessTaskRecord, HeadlessTaskStatus } from '../api/headless'
+import { Skeleton } from '../components/StateViews'
 import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { formatRelativeTime } from '../lib/intl'
 
@@ -113,7 +114,20 @@ export function AutomationRunsSection() {
   }, [load])
 
   if (error) return <div className="text-sm text-red-400">Failed to load runs: {error}</div>
-  if (!tasks) return <div className="text-sm text-muted">Loading…</div>
+  if (!tasks)
+    return (
+      <div className="space-y-2" aria-hidden="true">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 border-b border-border/50 py-2">
+            <Skeleton className="h-5 w-16 rounded" />
+            <Skeleton className="h-4 w-20 rounded" />
+            <Skeleton className="h-4 flex-1 rounded" />
+            <Skeleton className="h-4 w-24 rounded" />
+            <Skeleton className="h-4 w-16 rounded" />
+          </div>
+        ))}
+      </div>
+    )
   if (tasks.length === 0) {
     return (
       <div className="text-sm text-muted">

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react'
 import { FileText } from 'lucide-react'
 
 import { FileContentView } from '../components/FileContentView'
+import { CenteredLoading } from '../components/StateViews'
 import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
 import type { ViewSpec } from '../tabs/types'
@@ -50,7 +51,7 @@ export function FileViewerPage({ spec }: Props) {
       <div className="flex-1 overflow-y-auto min-h-0">
         <div className="max-w-[820px] mx-auto px-6 py-6">
           {result === null ? (
-            <div className="text-[12px] text-text-muted">Loading…</div>
+            <CenteredLoading />
           ) : (
             <FileContentView path={path} result={result} />
           )}

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { formatRelativeTime, getIntlLocale } from '../lib/intl'
 import { ArrowRight, Bot, ChevronRight, ListChecks, MessageSquare, Terminal, Trash2 } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
+import { Skeleton } from '../components/StateViews'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { FileContentView } from '../components/FileContentView'
 import { api } from '../api'
@@ -96,7 +97,7 @@ export function InboxPage({ visible }: InboxPageProps) {
       />
       <div className="flex-1 overflow-y-auto min-h-0">
         {loading && entries.length === 0 ? (
-          <div className="px-6 py-8 text-text-muted text-sm">{t('common.loading')}</div>
+          <InboxLoadingSkeleton />
         ) : entries.length === 0 ? (
           <EmptyState />
         ) : !selected ? (
@@ -111,6 +112,19 @@ export function InboxPage({ visible }: InboxPageProps) {
           />
         )}
       </div>
+    </div>
+  )
+}
+
+function InboxLoadingSkeleton() {
+  return (
+    <div aria-hidden="true" className="px-6 py-4">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="py-3 border-b border-border/40">
+          <Skeleton className="h-4 w-2/3 rounded mb-2" />
+          <Skeleton className="h-3 w-2/5 rounded" />
+        </div>
+      ))}
     </div>
   )
 }

--- a/ui/src/pages/LogsPage.tsx
+++ b/ui/src/pages/LogsPage.tsx
@@ -1,8 +1,22 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { api, type EventLogEntry, type ToolCallRecord } from '../api'
 import { getIntlLocale } from '../lib/intl'
+import { Skeleton } from '../components/StateViews'
 
 // ==================== Helpers ====================
+
+/** First-load placeholder for a log list — a short stack of skeleton rows. */
+function LogRowsSkeleton() {
+  return (
+    <div aria-hidden="true">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="px-3 py-1.5 border-t border-border/50 first:border-t-0">
+          <Skeleton className="h-3.5 w-full rounded" />
+        </div>
+      ))}
+    </div>
+  )
+}
 
 function formatDateTime(ts: number): string {
   const d = new Date(ts)
@@ -151,7 +165,7 @@ function EventLogSection() {
         className="flex-1 min-h-0 bg-bg rounded-lg border border-border overflow-y-auto font-mono text-xs"
       >
         {loading && entries.length === 0 ? (
-          <div className="px-4 py-8 text-center text-text-muted">Loading...</div>
+          <LogRowsSkeleton />
         ) : entries.length === 0 ? (
           <div className="px-4 py-8 text-center text-text-muted">No events yet</div>
         ) : (
@@ -355,7 +369,7 @@ function ToolCallLogSection() {
         className="flex-1 min-h-0 bg-bg rounded-lg border border-border overflow-y-auto font-mono text-xs"
       >
         {loading && entries.length === 0 ? (
-          <div className="px-4 py-8 text-center text-text-muted">Loading...</div>
+          <LogRowsSkeleton />
         ) : entries.length === 0 ? (
           <div className="px-4 py-8 text-center text-text-muted">No tool calls yet</div>
         ) : (

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -5,6 +5,7 @@ import { ConfigSection, Field, inputClass } from '../components/form'
 import { Toggle } from '../components/Toggle'
 import { useConfigPage } from '../hooks/useConfigPage'
 import { PageHeader } from '../components/PageHeader'
+import { CenteredLoading } from '../components/StateViews'
 
 type MarketDataConfig = Record<string, unknown>
 
@@ -198,7 +199,7 @@ export function MarketDataPage() {
       <div className="flex flex-col flex-1 min-h-0">
         <PageHeader title="Market Data" description="Structured financial data — prices, fundamentals, macro indicators." />
         <div className="flex-1 flex items-center justify-center">
-          <p className="text-[13px] text-text-muted">Loading...</p>
+          <CenteredLoading />
         </div>
       </div>
     )

--- a/ui/src/pages/MarketPage.tsx
+++ b/ui/src/pages/MarketPage.tsx
@@ -4,6 +4,7 @@ import { BoardMeta } from '../components/market/BoardMeta'
 import { PageHeader } from '../components/PageHeader'
 import { SearchBox } from '../components/market/SearchBox'
 import { SeriesCard } from '../components/market/SeriesCard'
+import { Skeleton } from '../components/StateViews'
 import { referenceApi, type ValuationStrip } from '../api/reference'
 
 export function MarketPage() {
@@ -33,6 +34,16 @@ export function MarketPage() {
           </h3>
           {stripError && (
             <div className="text-[12px] text-text-muted/70 border border-border rounded-md px-3 py-2">{stripError}</div>
+          )}
+          {!strip && !stripError && (
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4" aria-hidden="true">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="border border-border rounded-md bg-bg-secondary/40 px-3 py-2.5 flex flex-col gap-1.5">
+                  <Skeleton className="h-3 w-20 rounded" />
+                  <Skeleton className="h-6 w-24 rounded" />
+                </div>
+              ))}
+            </div>
           )}
           {strip && (
             <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">

--- a/ui/src/pages/NewsPage.tsx
+++ b/ui/src/pages/NewsPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { formatRelativeTime } from '../lib/intl'
 import { api, type NewsArticle } from '../api'
 import { PageHeader } from '../components/PageHeader'
-import { EmptyState } from '../components/StateViews'
+import { EmptyState, Skeleton } from '../components/StateViews'
 
 // ==================== Helpers ====================
 
@@ -158,7 +158,14 @@ export function NewsPage() {
           {/* Article list */}
           <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border border-border bg-bg">
             {loading && articles.length === 0 ? (
-              <div className="px-4 py-8 text-center text-text-muted">{t('common.loading')}</div>
+              <div className="divide-y divide-border/50">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="px-4 py-3">
+                    <Skeleton className="h-3.5 w-3/4" />
+                    <Skeleton className="h-2.5 w-1/3 mt-2" />
+                  </div>
+                ))}
+              </div>
             ) : articles.length === 0 ? (
               <EmptyState title={t('news.noArticles')} description={t('news.noArticlesDescription')} />
             ) : (

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -4,7 +4,7 @@ import { useAutoSave } from '../hooks/useAutoSave'
 import { useAccountHealth } from '../hooks/useAccountHealth'
 import { useWorkspace } from '../tabs/store'
 import { PageHeader } from '../components/PageHeader'
-import { EmptyState } from '../components/StateViews'
+import { EmptyState, Skeleton } from '../components/StateViews'
 import { EquityCurve } from '../components/EquityCurve'
 import { SnapshotDetail } from '../components/SnapshotDetail'
 import { Toggle } from '../components/Toggle'
@@ -238,6 +238,7 @@ export function PortfolioPage() {
         <div className="flex gap-6 items-start">
           {/* Main column */}
           <div className="flex-1 min-w-0 space-y-5">
+            {!lastRefresh ? <PortfolioSkeleton /> : <>
             <HeroMetrics equity={data.equity} curve={aggregateCurve?.total ?? null} />
 
             {curvePoints.length > 0 && (
@@ -288,6 +289,7 @@ export function PortfolioPage() {
             {allWalletLogs.length > 0 && (
               <TradeLog commits={allWalletLogs} />
             )}
+            </>}
           </div>
 
           {/* Right sidebar — FX rates */}
@@ -414,6 +416,63 @@ function HeroMetrics({ equity, curve }: {
           value={fmtPnl(realized, 'USD')}
           valueSign={signFromDelta(realized)}
         />
+      </div>
+    </div>
+  )
+}
+
+// ==================== Cold-start skeleton ====================
+
+/** First-load placeholder for the portfolio main column. Mirrors the real
+ *  layout's shapes (hero metrics → curve → account strip → positions) so the
+ *  page reads as "loading this" rather than a blank white pane while the broker
+ *  reads (which can be slow on a cold connect) come back. */
+function PortfolioSkeleton() {
+  return (
+    <div className="space-y-5" aria-hidden="true">
+      {/* Hero metrics */}
+      <div className="rounded-lg border border-border bg-bg-secondary p-5">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-9 w-48 mt-3" />
+        <div className="flex gap-8 mt-5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-2.5 w-16" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Equity curve */}
+      <Skeleton className="h-[220px] w-full rounded-lg" />
+      {/* Account strip */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 px-3.5 py-3 rounded-lg border border-border bg-bg-secondary">
+            <Skeleton className="h-1.5 w-1.5 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-2.5 w-16" />
+            </div>
+            <Skeleton className="h-8 w-20" />
+          </div>
+        ))}
+      </div>
+      {/* Positions table */}
+      <div className="rounded-lg border border-border overflow-hidden">
+        <div className="px-4 py-2.5 border-b border-border bg-bg-secondary">
+          <Skeleton className="h-3 w-32" />
+        </div>
+        <div className="divide-y divide-border">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 px-4 py-3.5">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-16 ml-auto" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -213,7 +213,7 @@ export function PortfolioPage() {
     const acct = data.accounts.find(a => a.id === eq.id)
     const unrealizedPnL = acct?.positions.reduce((sum, p) => sum + Number(p.unrealizedPnL), 0) ?? 0
     const hInfo = healthMap[eq.id]
-    return { ...eq, provider: acct?.provider ?? '', unrealizedPnL, error: acct?.error, health: eq.health, disabled: hInfo?.disabled ?? false }
+    return { ...eq, provider: acct?.provider ?? '', unrealizedPnL, error: acct?.error, health: eq.health, disabled: hInfo?.disabled ?? false, connecting: hInfo?.connecting ?? false }
   })
 
   return (
@@ -428,37 +428,44 @@ const HEALTH_DOT: Record<string, string> = {
 }
 
 function AccountStrip({ sources, perAccountCurve }: {
-  sources: Array<{ id: string; label: string; provider: string; equity: string; unrealizedPnL: number; error?: string; health?: string; disabled?: boolean }>
+  sources: Array<{ id: string; label: string; provider: string; equity: string; unrealizedPnL: number; error?: string; health?: string; disabled?: boolean; connecting?: boolean }>
   perAccountCurve: Record<string, { values: number[]; firstAtCutoff: number | null; latest: number | null }>
 }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
       {sources.map(s => {
         const isDisabled = s.disabled
-        const isOffline = s.health === 'offline' && !isDisabled
+        // Initial connect in flight — distinct from offline. `health` is
+        // optimistically 'healthy' here, so this can only come from the flag.
+        const isConnecting = !!s.connecting && !isDisabled
+        const isOffline = s.health === 'offline' && !isDisabled && !isConnecting
         const dotColor = isDisabled
           ? 'bg-text-muted/40'
-          : (HEALTH_DOT[s.health ?? 'healthy'] ?? 'bg-text-muted')
+          : isConnecting
+            ? 'bg-accent'
+            : (HEALTH_DOT[s.health ?? 'healthy'] ?? 'bg-text-muted')
 
         const curve = perAccountCurve[s.id]
         const todayDelta = curve && curve.latest != null && curve.firstAtCutoff != null
           ? curve.latest - curve.firstAtCutoff
           : null
-        const showSpark = !isDisabled && !isOffline && curve && curve.values.length >= 2
+        const showSpark = !isDisabled && !isOffline && !isConnecting && curve && curve.values.length >= 2
 
         return (
           <div key={s.id} className={`flex items-center gap-3 px-3.5 py-3 rounded-lg border border-border bg-bg-secondary ${isOffline || isDisabled ? 'opacity-60' : ''}`}>
-            <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor}`} />
+            <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor} ${isConnecting ? 'animate-pulse' : ''}`} />
             <div className="flex-1 min-w-0">
               <div className="flex items-baseline justify-between gap-2">
                 <span className="text-text font-medium text-[13px] truncate">{s.label}</span>
-                {!isDisabled && !isOffline && (
+                {!isDisabled && !isOffline && !isConnecting && (
                   <span className="text-text-muted tabular-nums text-[13px]">{fmt(Number(s.equity))}</span>
                 )}
               </div>
               <div className="flex items-baseline justify-between gap-2 mt-0.5">
                 {isDisabled
                   ? <span className="text-text-muted text-[11px]">Disabled</span>
+                  : isConnecting
+                    ? <span className="text-accent text-[11px]">Connecting...</span>
                   : isOffline
                     ? <span className="text-red text-[11px]">Reconnecting…</span>
                     : (

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TrendingUp, Hash, FileText, ListChecks } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
-import { PageLoading } from '../components/StateViews'
+import { PageLoading, Skeleton } from '../components/StateViews'
 import { api } from '../api'
 import { entitiesLive } from '../live/entities'
 import { useTrackedSelection } from '../live/tracked-selection'
@@ -57,7 +57,7 @@ export function TrackedPage() {
       />
       <div className="flex-1 overflow-y-auto min-h-0">
         {loading && entities.length === 0 ? (
-          <PageLoading />
+          <TrackedListSkeleton />
         ) : entities.length === 0 ? (
           <EmptyState />
         ) : !selectedName ? (
@@ -68,6 +68,27 @@ export function TrackedPage() {
           <Detail detail={detail} />
         )}
       </div>
+    </div>
+  )
+}
+
+// First-load placeholder for the tracked-entity list (icon + name + count tag),
+// mirroring the BacklinkRow chrome so the swap to real rows is seamless.
+function TrackedListSkeleton() {
+  const widths = ['w-24', 'w-32', 'w-28', 'w-36', 'w-20', 'w-28']
+  return (
+    <div className="flex flex-col gap-1 max-w-[820px] mx-auto py-6 px-4 md:px-8" aria-hidden="true">
+      {widths.map((w, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-bg-tertiary/30"
+        >
+          <Skeleton className="h-3.5 w-3.5 rounded shrink-0" />
+          <Skeleton className={`h-3.5 ${w} rounded`} />
+          <div className="flex-1" />
+          <Skeleton className="h-3 w-10 rounded shrink-0" />
+        </div>
+      ))}
     </div>
   )
 }

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Field, inputClass } from '../components/form'
+import { Skeleton } from '../components/StateViews'
 import { SDKSelector } from '../components/SDKSelector'
 import type { SDKOption } from '../components/SDKSelector'
 import { useTradingConfig } from '../hooks/useTradingConfig'
@@ -145,7 +146,22 @@ export function TradingPage() {
     openOrFocus({ kind: 'uta-detail', params: { id } })
   }
 
-  if (tc.loading) return <PageShell subtitle="Loading..." />
+  if (tc.loading) return (
+    <PageShell subtitle="Configure your UTAs (Unified Trading Accounts).">
+      <div className="max-w-[820px] mx-auto space-y-2.5" aria-hidden="true">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 px-4 py-3.5 rounded-lg border border-border bg-bg-secondary">
+            <Skeleton className="h-9 w-9 rounded-lg" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-3.5 w-32" />
+              <Skeleton className="h-2.5 w-20" />
+            </div>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        ))}
+      </div>
+    </PageShell>
+  )
   if (tc.error) {
     return (
       <PageShell subtitle="Failed to load trading configuration.">

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -7,7 +7,7 @@ import type { UTAConfig, BrokerPreset, AccountInfo, SubAccountRef, Position, Bro
 import { useTradingConfig } from '../hooks/useTradingConfig'
 import { useAccountHealth } from '../hooks/useAccountHealth'
 import { PageHeader } from '../components/PageHeader'
-import { EmptyState } from '../components/StateViews'
+import { EmptyState, Skeleton } from '../components/StateViews'
 import { ReconnectButton } from '../components/ReconnectButton'
 import { Toggle } from '../components/Toggle'
 import { HealthBadge } from '../components/uta/HealthBadge'
@@ -272,6 +272,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
             </div>
 
             <div className="lg:order-1 min-w-0 space-y-5">
+              {!lastUpdated ? <UTADetailMainSkeleton /> : <>
               {curvePoints.length >= 2 && (
                 <EquityCurve
                   points={curvePoints}
@@ -292,6 +293,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
               />
 
               <OrdersArea utaId={id} openOrders={orders} />
+              </>}
             </div>
           </div>
         </div>
@@ -380,6 +382,32 @@ function sumFinite(values: number[]): number {
  * fabricated zero. (Live examples: Alpaca has no realizedPnL; CCXT/okx has
  * realizedPnL but no buyingPower.)
  */
+/** Cold-start placeholder for the UTA-detail main column (curve + positions +
+ *  orders), shown until the first live read lands — instead of a blank pane or
+ *  a misleading "No open positions" while the (sometimes slow) broker read runs. */
+function UTADetailMainSkeleton() {
+  return (
+    <div className="space-y-5" aria-hidden="true">
+      <Skeleton className="h-[220px] w-full rounded-lg" />
+      <div className="rounded-lg border border-border overflow-hidden">
+        <div className="px-4 py-2.5 border-b border-border bg-bg-secondary">
+          <Skeleton className="h-3 w-28" />
+        </div>
+        <div className="divide-y divide-border">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 px-4 py-3.5">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-16 ml-auto" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function AccountPanel({ account, positions, delta24h, clock, connecting }: {
   account: AccountInfo | null
   positions: Position[]
@@ -395,10 +423,19 @@ function AccountPanel({ account, positions, delta24h, clock, connecting }: {
         )}
         {/* During the initial broker connect, say so explicitly — "connecting"
             reads as progress, where a bare "Loading…" that lingers 30s reads
-            as a stall. */}
-        <p className={`text-[13px] ${connecting ? 'text-accent' : 'text-text-muted'}`}>
+            as a stall. Skeleton rows below stand in for the metric list so the
+            panel has shape instead of a single line of text. */}
+        <p className={`text-[12px] mb-3.5 ${connecting ? 'text-accent' : 'text-text-muted'}`}>
           {connecting ? 'Connecting to broker…' : 'Loading account info…'}
         </p>
+        <div className="space-y-3.5" aria-hidden="true">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-3 w-14" />
+            </div>
+          ))}
+        </div>
       </div>
     )
   }

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -180,7 +180,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
       }))
   }, [snapshots, id])
 
-  if (tc.loading) return <Shell title="Loading…" />
+  if (tc.loading) return <Shell title={id ?? 'UTA'}><UTADetailMainSkeleton /></Shell>
   if (!id) return <Shell title="UTA not specified" />
   if (!uta) {
     return (

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -268,7 +268,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
                   }}
                 />
               )}
-              <AccountPanel account={account} positions={positions} delta24h={delta24h} clock={clock} />
+              <AccountPanel account={account} positions={positions} delta24h={delta24h} clock={clock} connecting={health?.connecting ?? false} />
             </div>
 
             <div className="lg:order-1 min-w-0 space-y-5">
@@ -380,11 +380,12 @@ function sumFinite(values: number[]): number {
  * fabricated zero. (Live examples: Alpaca has no realizedPnL; CCXT/okx has
  * realizedPnL but no buyingPower.)
  */
-function AccountPanel({ account, positions, delta24h, clock }: {
+function AccountPanel({ account, positions, delta24h, clock, connecting }: {
   account: AccountInfo | null
   positions: Position[]
   delta24h: Delta24h | null
   clock: MarketClockState
+  connecting?: boolean
 }) {
   if (!account) {
     return (
@@ -392,7 +393,12 @@ function AccountPanel({ account, positions, delta24h, clock }: {
         {clock != null && (
           <div className="text-[12px] mb-3"><MarketClockChip clock={clock} /></div>
         )}
-        <p className="text-[13px] text-text-muted">Loading account info…</p>
+        {/* During the initial broker connect, say so explicitly — "connecting"
+            reads as progress, where a bare "Loading…" that lingers 30s reads
+            as a stall. */}
+        <p className={`text-[13px] ${connecting ? 'text-accent' : 'text-text-muted'}`}>
+          {connecting ? 'Connecting to broker…' : 'Loading account info…'}
+        </p>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- **Non-blocking broker connect.** Reads no longer block on the slow CCXT cold-start (full-spectrum `loadMarkets`, ~30s). During connect, requests fast-fail with a transient `CONNECTING` state (via a short grace-race) instead of awaiting the broker. Honors the "disconnect ≠ dead" rule: `CONNECTING` is never `permanent`, recovery/reconnect is untouched, and a timeout fails one request without disabling the account. Adds `connecting` to `BrokerHealthInfo` + a "Connecting…" UI state (HealthBadge / AccountStrip / AccountPanel).
- **Systematic first-load skeletons.** New `Skeleton` / `SidebarRowsSkeleton` shimmer primitives (theme-aware, `prefers-reduced-motion`-safe), applied across every central + secondary data surface — portfolio, UTA detail, trading, market panels (quote/kline/financials/metrics/profile), all sidebars (Ask Alice, Workspaces, Portfolio, Tracked, Inbox), inbox/news/issues/logs/files/market pages, AuthGate boot. A cold backend now shows content-shaped placeholders instead of blank panes / bare "Loading…" text. Each is gated on the real first-load signal so it never flashes on a background poll.
- **Fix: Ask Alice sidebar blank on cold start.** The skeleton was dead code behind `if (!chatTemplate) return null`, which fired during cold-load (templates fetch unresolved → `templates` is `[]`) and short-circuited the whole section. Added a `templatesLoaded` flag and gated the null-render on `templatesLoaded && !chatTemplate`. Verified live (Playwright route-throttle): the panel renders the New-chat CTA + skeleton instead of blank.

## Test plan
- [x] `npx tsc --noEmit` (Alice src) clean
- [x] `cd ui && npx tsc -b` clean
- [x] `pnpm test` — 2231 passed | 6 skipped | 0 failed
- [x] Live cold-load verification of the Ask Alice skeleton (loopback dev auto-auth + `/api/workspaces*` throttle)

## Boundary touch
Touches UTA/trading paths: `UnifiedTradingAccount` connect-gating + timing logs, `BrokerError` new `CONNECTING` code, `tool/trading.ts` connecting bucket, and the `uta-protocol` `BrokerHealthInfo` shape (`connecting` field). No auth/credential/migration changes; broker recovery semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
