### PR TITLE
feat(trading): add read-only Schwab portfolio support

### DIFF
--- a/packages/uta-protocol/src/brokers/preset-catalog.ts
+++ b/packages/uta-protocol/src/brokers/preset-catalog.ts
@@ -15,7 +15,7 @@ import { createHash, randomBytes } from 'node:crypto'
 
 // ==================== Types ====================
 
-export type BrokerEngine = 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'mock'
+export type BrokerEngine = 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'schwab' | 'mock'
 
 export interface ModeOption {
   id: string
@@ -432,6 +432,47 @@ export const LONGBRIDGE_PRESET: BrokerPresetDef = {
   isPaper: (d) => d.mode === 'paper',
 }
 
+export const SCHWAB_PRESET: BrokerPresetDef = {
+  id: 'schwab',
+  label: 'Schwab (Portfolio)',
+  description: 'Charles Schwab Trader API — OAuth-backed, read-only portfolio access for US securities accounts.',
+  category: 'recommended',
+  hint: 'Schwab is portfolio-only here: fill `clientId`, `clientSecret`, and either a `refreshToken` or a `tokenPath` pointing at a Schwab OAuth token JSON. OpenAlice will refresh the access token automatically and persist the updated token back to that file. If your Schwab login spans multiple linked accounts, set `accountNumber` to pin one account; otherwise OpenAlice aggregates them.',
+  defaultName: 'schwab-portfolio',
+  badge: 'CS',
+  badgeColor: 'text-blue-400',
+  engine: 'schwab',
+  guardCategory: 'securities',
+  zodSchema: z.object({
+    clientId: z.string().min(1).describe('Client ID'),
+    clientSecret: z.string().min(1).describe('Client Secret'),
+    refreshToken: z.string().min(1).optional().describe('Refresh Token (optional if tokenPath points at a token JSON)'),
+    tokenPath: z.string().min(1).optional().describe('OAuth Token File Path'),
+    accountNumber: z.string().optional().describe('Account Number (optional; aggregates all linked accounts if blank)'),
+  }).superRefine((data, ctx) => {
+    if (!data.refreshToken && !data.tokenPath) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['refreshToken'],
+        message: 'Provide either refreshToken or tokenPath',
+      })
+    }
+  }),
+  subtitleFields: [
+    { field: 'accountNumber', prefix: 'Schwab · ' },
+  ],
+  writeOnlyFields: ['clientSecret', 'refreshToken'],
+  fingerprintFields: ['clientId', 'accountNumber'],
+  toEngineConfig: (d) => ({
+    clientId: d.clientId,
+    clientSecret: d.clientSecret,
+    ...(d.refreshToken ? { refreshToken: d.refreshToken } : {}),
+    ...(d.tokenPath ? { tokenPath: d.tokenPath } : {}),
+    ...(d.accountNumber ? { accountNumber: d.accountNumber } : {}),
+  }),
+  isPaper: () => false,
+}
+
 // ==================== Other ecosystem brokers (lower-tier, isolated) ====================
 
 export const LEVERUP_PRESET: BrokerPresetDef = {
@@ -508,6 +549,7 @@ export const BROKER_PRESET_CATALOG: BrokerPresetDef[] = [
   IBKR_PRESET,
   ALPACA_PRESET,
   LONGBRIDGE_PRESET,
+  SCHWAB_PRESET,
   HYPERLIQUID_PRESET,
   // ---- Crypto ----
   BINANCE_PRESET,

--- a/packages/uta-protocol/src/brokers/presets.ts
+++ b/packages/uta-protocol/src/brokers/presets.ts
@@ -24,7 +24,7 @@ export interface SerializedBrokerPreset {
   defaultName: string
   badge: string
   badgeColor: string
-  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'mock'
+  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'schwab' | 'mock'
   guardCategory: 'crypto' | 'securities'
   modes?: ModeOption[]
   subtitleFields: SubtitleSegment[]

--- a/services/uta/src/domain/trading/brokers/index.ts
+++ b/services/uta/src/domain/trading/brokers/index.ts
@@ -44,3 +44,7 @@ export type { CcxtBrokerConfig } from './ccxt/index.js'
 // IBKR
 export { IbkrBroker } from './ibkr/index.js'
 export type { IbkrBrokerConfig } from './ibkr/index.js'
+
+// Schwab
+export { SchwabBroker } from './schwab/index.js'
+export type { SchwabBrokerConfig } from './schwab/index.js'

--- a/services/uta/src/domain/trading/brokers/presets.spec.ts
+++ b/services/uta/src/domain/trading/brokers/presets.spec.ts
@@ -25,6 +25,7 @@ import {
   ALPACA_PRESET,
   IBKR_PRESET,
   LONGBRIDGE_PRESET,
+  SCHWAB_PRESET,
   CCXT_CUSTOM_PRESET,
   SIMULATOR_PRESET,
   BUILTIN_BROKER_PRESETS,
@@ -43,6 +44,7 @@ const SAMPLE_CONFIGS: Record<string, Record<string, unknown>> = {
   alpaca:          { mode: 'paper', apiKey: 'k', apiSecret: 's' },
   'ibkr-tws':      { host: '127.0.0.1', port: 7497, clientId: 0 },
   longbridge:      { mode: 'live', appKey: 'k', appSecret: 's', accessToken: 't' },
+  schwab:          { clientId: 'cid', clientSecret: 'secret', refreshToken: 'refresh' },
   'ccxt-custom':   { exchange: 'kucoin', apiKey: 'k', secret: 's' },
   'leverup-monad': {
     mode: 'testnet',
@@ -156,6 +158,16 @@ describe('preset → engine config translation', () => {
     expect(cfg.paper).toBe(false)
   })
 
+  it('Schwab passes OAuth fields straight through to the engine', () => {
+    const cfg = SCHWAB_PRESET.toEngineConfig({ clientId: 'cid', clientSecret: 'secret', refreshToken: 'refresh', accountNumber: '1234' })
+    expect(cfg).toMatchObject({
+      clientId: 'cid',
+      clientSecret: 'secret',
+      refreshToken: 'refresh',
+      accountNumber: '1234',
+    })
+  })
+
   it('IBKR passes host/port/clientId straight through', () => {
     const cfg = IBKR_PRESET.toEngineConfig({ host: '10.0.0.5', port: 7496, clientId: 7 })
     expect(cfg).toMatchObject({ host: '10.0.0.5', port: 7496, clientId: 7 })
@@ -233,6 +245,13 @@ describe('BUILTIN_BROKER_PRESETS', () => {
     expect(props.apiKey.writeOnly).toBe(true)
     expect(props.secret.writeOnly).toBe(true)
     expect(props.password.writeOnly).toBe(true)
+  })
+
+  it('Schwab marks secret fields writeOnly', () => {
+    const schwab = BUILTIN_BROKER_PRESETS.find(p => p.id === 'schwab')!
+    const props = (schwab.schema as { properties: Record<string, { writeOnly?: boolean }> }).properties
+    expect(props.clientSecret.writeOnly).toBe(true)
+    expect(props.refreshToken.writeOnly).toBe(true)
   })
 })
 

--- a/services/uta/src/domain/trading/brokers/registry.ts
+++ b/services/uta/src/domain/trading/brokers/registry.ts
@@ -16,6 +16,7 @@ import { AlpacaBroker } from './alpaca/AlpacaBroker.js'
 import { IbkrBroker } from './ibkr/IbkrBroker.js'
 import { LeverupBroker } from './others/leverup/index.js'
 import { LongbridgeBroker } from './longbridge/index.js'
+import { SchwabBroker } from './schwab/index.js'
 import { MockBroker } from './mock/MockBroker.js'
 import type { BrokerEngine } from '@traderalice/uta-protocol'
 
@@ -47,6 +48,10 @@ export const BROKER_ENGINE_REGISTRY: Record<BrokerEngine, BrokerEngineEntry> = {
   longbridge: {
     configSchema: LongbridgeBroker.configSchema,
     fromConfig: LongbridgeBroker.fromConfig,
+  },
+  schwab: {
+    configSchema: SchwabBroker.configSchema,
+    fromConfig: SchwabBroker.fromConfig,
   },
   mock: {
     configSchema: MockBroker.configSchema,

--- a/services/uta/src/domain/trading/brokers/schwab/SchwabBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/schwab/SchwabBroker.spec.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import Decimal from 'decimal.js'
+import { Contract } from '@traderalice/ibkr'
+import '../../contract-ext.js'
+
+let home: string
+let savedHome: string | undefined
+let tokenPath: string
+
+async function loadBrokerModule() {
+  vi.resetModules()
+  process.env['OPENALICE_HOME'] = home
+  const [broker, sealing] = await Promise.all([
+    import('./SchwabBroker.js'),
+    import('@/core/sealing.js'),
+  ])
+  return { SchwabBroker: broker.SchwabBroker, sealing }
+}
+
+describe('SchwabBroker', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    savedHome = process.env['OPENALICE_HOME']
+    home = await mkdtemp(resolve(tmpdir(), 'openalice-schwab-'))
+    tokenPath = join(home, 'data', 'trading', 'schwab-test', 'schwab-token.json')
+    fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/v1/oauth/token')) {
+        return new Response(JSON.stringify({
+          access_token: 'access-1',
+          refresh_token: 'refresh-1',
+          expires_in: 1800,
+          token_type: 'Bearer',
+        }), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      if (url.includes('/trader/v1/accounts')) {
+        return new Response(JSON.stringify([
+          {
+            accountNumber: '123456789',
+            currentBalances: {
+              cashBalance: '1000.00',
+              liquidationValue: '1500.00',
+              buyingPower: '2000.00',
+            },
+            positions: [
+              {
+                symbol: 'AAPL',
+                longQuantity: 1,
+                averagePrice: '450.00',
+                marketValue: '500.00',
+                currentDayProfitLoss: '50.00',
+                instrument: {
+                  assetType: 'EQUITY',
+                  symbol: 'AAPL',
+                  description: 'Apple Inc.',
+                  exchange: 'NASDAQ',
+                  currency: 'USD',
+                },
+              },
+            ],
+          },
+        ]), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      throw new Error(`unexpected fetch: ${url} ${init?.method ?? 'GET'}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(async () => {
+    if (savedHome === undefined) delete process.env['OPENALICE_HOME']
+    else process.env['OPENALICE_HOME'] = savedHome
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('refreshes token, seals the token file, and reads account / positions', async () => {
+    const { SchwabBroker, sealing } = await loadBrokerModule()
+    const broker = new SchwabBroker({
+      id: 'schwab-test',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      refreshToken: 'refresh-initial',
+    })
+
+    await expect(broker.init()).resolves.toBeUndefined()
+    expect(fetchMock).toHaveBeenCalled()
+
+    const account = await broker.getAccount()
+    expect(account.baseCurrency).toBe('USD')
+    expect(account.netLiquidation).toBe('1500')
+    expect(account.totalCashValue).toBe('1000')
+    expect(account.unrealizedPnL).toBe('50')
+
+    const positions = await broker.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].contract.symbol).toBe('AAPL')
+    expect(positions[0].contract.secType).toBe('STK')
+    expect(positions[0].quantity.toString()).toBe('1')
+
+    const persisted = JSON.parse(await readFile(tokenPath, 'utf-8'))
+    expect(sealing.isSealedEnvelope(persisted)).toBe(true)
+    expect(JSON.stringify(persisted)).not.toContain('access-1')
+    expect(JSON.stringify(persisted)).not.toContain('refresh-1')
+    if (process.platform !== 'win32') {
+      expect((await stat(tokenPath)).mode & 0o777).toBe(0o600)
+    }
+  })
+
+  it('loads a pre-sealed token file without calling the refresh endpoint', async () => {
+    const { SchwabBroker, sealing } = await loadBrokerModule()
+    await mkdir(resolve(tokenPath, '..'), { recursive: true })
+    await writeFile(tokenPath, JSON.stringify(await sealing.seal({
+      access_token: 'cached-access',
+      refresh_token: 'cached-refresh',
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    }), null, 2) + '\n')
+
+    const broker = new SchwabBroker({
+      id: 'schwab-test',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      tokenPath: './schwab-token.json',
+    })
+
+    await expect(broker.init()).resolves.toBeUndefined()
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/v1/oauth/token'))).toBe(false)
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/trader/v1/accounts'))).toBe(true)
+  })
+
+  it('refuses tokenPath values outside the account trading data dir', async () => {
+    const { SchwabBroker } = await loadBrokerModule()
+    const broker = new SchwabBroker({
+      id: 'schwab-test',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      refreshToken: 'refresh',
+      tokenPath: join(home, 'escape.json'),
+    })
+
+    await expect(broker.init()).rejects.toThrow(/tokenPath must stay inside/i)
+    expect(existsSync(join(home, 'escape.json'))).toBe(false)
+  })
+
+  it('uses hashValue as a fallback account selector', async () => {
+    const { SchwabBroker } = await loadBrokerModule()
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/v1/oauth/token')) {
+        return new Response(JSON.stringify({
+          access_token: 'access-1',
+          refresh_token: 'refresh-1',
+          expires_in: 1800,
+          token_type: 'Bearer',
+        }), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      if (url.includes('/trader/v1/accounts')) {
+        return new Response(JSON.stringify([
+          {
+            accountNumber: 'primary-account',
+            hashValue: 'shadow-account',
+            currentBalances: {
+              cashBalance: '1000.00',
+              liquidationValue: '1500.00',
+            },
+            positions: [
+              {
+                symbol: 'MSFT',
+                longQuantity: 2,
+                marketValue: '600.00',
+                instrument: {
+                  assetType: 'EQUITY',
+                  symbol: 'MSFT',
+                  description: 'Microsoft Corp.',
+                  exchange: 'NASDAQ',
+                  currency: 'USD',
+                },
+              },
+            ],
+          },
+        ]), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+
+    const broker = new SchwabBroker({
+      id: 'schwab-test',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      refreshToken: 'refresh-initial',
+      accountNumber: 'shadow-account',
+    })
+
+    await expect(broker.init()).resolves.toBeUndefined()
+    const positions = await broker.getPositions()
+    expect(positions).toHaveLength(1)
+    expect(positions[0].contract.symbol).toBe('MSFT')
+  })
+
+  it('round-trips option native keys', async () => {
+    const { SchwabBroker } = await loadBrokerModule()
+    const broker = new SchwabBroker({
+      clientId: 'cid',
+      clientSecret: 'secret',
+      refreshToken: 'refresh',
+      tokenPath,
+    })
+    const contract = new Contract()
+    contract.symbol = 'AAPL'
+    contract.secType = 'OPT'
+    contract.exchange = 'SMART'
+    contract.currency = 'USD'
+    contract.lastTradeDateOrContractMonth = '20261217'
+    contract.right = 'C'
+    contract.strike = 150
+    contract.multiplier = '100'
+
+    const nativeKey = broker.getNativeKey(contract)
+    const restored = broker.resolveNativeKey(nativeKey)
+    expect(restored.secType).toBe('OPT')
+    expect(restored.symbol).toBe('AAPL')
+    expect(restored.lastTradeDateOrContractMonth).toBe('20261217')
+    expect(restored.right).toBe('C')
+    expect(restored.strike).toBe(150)
+    expect(restored.multiplier).toBe('100')
+  })
+
+  it('refuses writes with a clear read-only error', async () => {
+    const { SchwabBroker } = await loadBrokerModule()
+    const broker = new SchwabBroker({
+      clientId: 'cid',
+      clientSecret: 'secret',
+      refreshToken: 'refresh',
+      tokenPath,
+    })
+    const result = await broker.placeOrder(new Contract(), {} as never)
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/read-only/i)
+  })
+})

--- a/services/uta/src/domain/trading/brokers/schwab/SchwabBroker.ts
+++ b/services/uta/src/domain/trading/brokers/schwab/SchwabBroker.ts
@@ -1,0 +1,811 @@
+/**
+ * SchwabBroker — read-only IBroker adapter for Charles Schwab Trader API.
+ *
+ * This broker is intentionally portfolio-focused:
+ * - OAuth access is handled with Schwab refresh tokens.
+ * - Account and position reads are supported.
+ * - Order writes are refused at the broker boundary.
+ *
+ * The goal for OpenAlice is Schwab portfolio visibility without pretending
+ * we have a production-grade Schwab order router.
+ */
+
+import { z } from 'zod'
+import Decimal from 'decimal.js'
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { dirname, isAbsolute, relative, resolve } from 'node:path'
+import { Contract, ContractDescription, ContractDetails, Order } from '@traderalice/ibkr'
+import {
+  BrokerError,
+  type IBroker,
+  type AccountCapabilities,
+  type AccountInfo,
+  type Position,
+  type PlaceOrderResult,
+  type OpenOrder,
+  type Quote,
+  type MarketClock,
+  type BrokerConfigField,
+  type TpSlParams,
+} from '../types.js'
+import '../../contract-ext.js'
+import { dataPath } from '@/core/paths.js'
+import { isSealedEnvelope, seal, unseal } from '@/core/sealing.js'
+import { buildContract, buildPosition } from '../contract-builder.js'
+import { aggregateAccountFromPositions } from '../../position-math.js'
+
+const SCHWAB_API_BASE = 'https://api.schwabapi.com'
+const SCHWAB_OAUTH_TOKEN_URL = `${SCHWAB_API_BASE}/v1/oauth/token`
+const SCHWAB_TRADER_BASE = `${SCHWAB_API_BASE}/trader/v1`
+const TOKEN_REFRESH_MARGIN_MS = 60_000
+
+export interface SchwabBrokerConfig {
+  id?: string
+  label?: string
+  clientId: string
+  clientSecret: string
+  refreshToken?: string
+  tokenPath?: string
+  accountNumber?: string
+}
+
+interface SchwabTokenState {
+  accessToken?: string
+  refreshToken?: string
+  expiresAtMs?: number
+  raw?: Record<string, unknown>
+}
+
+interface SchwabBalanceRaw {
+  cashBalance?: number | string
+  liquidationValue?: number | string
+  buyingPower?: number | string
+  availableFunds?: number | string
+  maintenanceRequirement?: number | string
+  maintenanceMargin?: number | string
+  initialMarginRequirement?: number | string
+  dayTradingBuyingPower?: number | string
+  longMarketValue?: number | string
+  shortMarketValue?: number | string
+  unrealizedPnL?: number | string
+  realizedPnL?: number | string
+}
+
+interface SchwabInstrumentRaw {
+  assetType?: string
+  symbol?: string
+  description?: string
+  exchange?: string
+  primaryExchange?: string
+  currency?: string
+  underlyingSymbol?: string
+  putCall?: string
+  expirationDate?: string
+  strikePrice?: number | string
+  multiplier?: number | string
+}
+
+interface SchwabPositionRaw {
+  instrument?: SchwabInstrumentRaw
+  symbol?: string
+  longQuantity?: number | string
+  shortQuantity?: number | string
+  averagePrice?: number | string
+  averageLongPrice?: number | string
+  averageShortPrice?: number | string
+  marketPrice?: number | string
+  marketValue?: number | string
+  currentDayProfitLoss?: number | string
+  currentDayProfitLossPercentage?: number | string
+  longOpenProfitLoss?: number | string
+  shortOpenProfitLoss?: number | string
+  assetType?: string
+}
+
+interface SchwabAccountRaw {
+  accountNumber?: string
+  hashValue?: string
+  currentBalances?: SchwabBalanceRaw
+  aggregatedBalance?: SchwabBalanceRaw
+  positions?: SchwabPositionRaw[]
+  orderStrategies?: unknown[]
+  securitiesAccount?: SchwabAccountRaw
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+function toStr(v: unknown): string | undefined {
+  if (v == null) return undefined
+  const s = String(v).trim()
+  return s ? s : undefined
+}
+
+function toDecimal(v: unknown, fallback = '0'): Decimal {
+  const s = toStr(v) ?? fallback
+  return new Decimal(s)
+}
+
+function numFrom(v: unknown): number | undefined {
+  if (v == null || v === '') return undefined
+  const n = Number(v)
+  return Number.isFinite(n) ? n : undefined
+}
+
+function trimDecimal(v: string): string {
+  if (!v.includes('.')) return v
+  return v.replace(/\.?0+$/, '')
+}
+
+function formatDateLike(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const s = value.trim()
+  if (!s) return undefined
+  return s.replace(/-/g, '')
+}
+
+function parsePutCall(value: string | undefined): 'C' | 'P' | undefined {
+  const v = value?.trim().toUpperCase()
+  if (!v) return undefined
+  if (v === 'CALL' || v === 'C') return 'C'
+  if (v === 'PUT' || v === 'P') return 'P'
+  return undefined
+}
+
+function normalizeAccountPayload(payload: unknown): SchwabAccountRaw[] {
+  const unwrap = (row: unknown): SchwabAccountRaw | null => {
+    if (!isRecord(row)) return null
+    if (isRecord(row.securitiesAccount)) return row.securitiesAccount as SchwabAccountRaw
+    return row as SchwabAccountRaw
+  }
+
+  if (Array.isArray(payload)) return payload.map(unwrap).filter((v): v is SchwabAccountRaw => v !== null)
+  if (!isRecord(payload)) return []
+  if (Array.isArray(payload.accounts)) return payload.accounts.map(unwrap).filter((v): v is SchwabAccountRaw => v !== null)
+  if (Array.isArray(payload.securitiesAccounts)) return payload.securitiesAccounts.map(unwrap).filter((v): v is SchwabAccountRaw => v !== null)
+  if (payload.securitiesAccount) {
+    const row = unwrap(payload.securitiesAccount)
+    return row ? [row] : []
+  }
+  return []
+}
+
+function makeStockContract(symbol: string, description?: string, exchange = 'SMART', currency = 'USD'): Contract {
+  return buildContract({
+    symbol,
+    secType: 'STK',
+    exchange,
+    currency,
+    localSymbol: symbol,
+    description,
+  })
+}
+
+function makeOptionContract(input: {
+  symbol: string
+  expiry: string
+  strike: number
+  right: 'C' | 'P'
+  multiplier: string
+  description?: string
+  exchange?: string
+  currency?: string
+  localSymbol?: string
+}): Contract {
+  return buildContract({
+    symbol: input.symbol,
+    secType: 'OPT',
+    exchange: input.exchange ?? 'SMART',
+    currency: input.currency ?? 'USD',
+    localSymbol: input.localSymbol ?? input.symbol,
+    lastTradeDateOrContractMonth: input.expiry,
+    strike: input.strike,
+    right: input.right,
+    multiplier: input.multiplier,
+    description: input.description,
+  })
+}
+
+export class SchwabBroker implements IBroker {
+  static configSchema = z.object({
+    clientId: z.string().min(1),
+    clientSecret: z.string().min(1),
+    refreshToken: z.string().min(1).optional(),
+    tokenPath: z.string().min(1).optional(),
+    accountNumber: z.string().optional(),
+  }).superRefine((data, ctx) => {
+    if (!data.refreshToken && !data.tokenPath) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['refreshToken'],
+        message: 'Provide either refreshToken or tokenPath',
+      })
+    }
+  })
+
+  static configFields: BrokerConfigField[] = [
+    { name: 'clientId', type: 'text', label: 'Client ID', required: true },
+    { name: 'clientSecret', type: 'password', label: 'Client Secret', required: true, sensitive: true },
+    { name: 'refreshToken', type: 'password', label: 'Refresh Token', sensitive: true, description: 'Optional if tokenPath points to an OAuth token JSON file.' },
+    { name: 'tokenPath', type: 'text', label: 'Token Path', description: 'Optional path under this account\'s trading data dir for a Schwab OAuth token JSON file. OpenAlice will refresh and persist the token here, sealed at rest.' },
+    { name: 'accountNumber', type: 'text', label: 'Account Number', description: 'Optional; leave blank to aggregate every linked account under the login.' },
+  ]
+
+  static fromConfig(config: { id: string; label?: string; brokerConfig: Record<string, unknown> }): SchwabBroker {
+    const bc = SchwabBroker.configSchema.parse(config.brokerConfig)
+    return new SchwabBroker({
+      id: config.id,
+      label: config.label,
+      clientId: bc.clientId,
+      clientSecret: bc.clientSecret,
+      refreshToken: bc.refreshToken,
+      tokenPath: bc.tokenPath,
+      accountNumber: bc.accountNumber,
+    })
+  }
+
+  readonly id: string
+  readonly label: string
+
+  private readonly cfg: SchwabBrokerConfig
+  private tokenState: SchwabTokenState | null = null
+  private initialized = false
+
+  constructor(cfg: SchwabBrokerConfig) {
+    this.cfg = cfg
+    this.id = cfg.id ?? (cfg.accountNumber ? `schwab-${cfg.accountNumber}` : 'schwab-portfolio')
+    this.label = cfg.label ?? (cfg.accountNumber ? `Schwab ${cfg.accountNumber}` : 'Schwab Portfolio')
+  }
+
+  private get tokenPath(): string {
+    const baseDir = dataPath('trading', this.id)
+    const candidate = this.cfg.tokenPath ?? 'schwab-token.json'
+    const path = isAbsolute(candidate) ? resolve(candidate) : resolve(baseDir, candidate)
+    const rel = relative(baseDir, path)
+    if (rel.startsWith('..') || rel === '..' || isAbsolute(rel)) {
+      throw new BrokerError('CONFIG', `Schwab tokenPath must stay inside ${baseDir}.`)
+    }
+    return path
+  }
+
+  async init(): Promise<void> {
+    await this.ensureToken(false)
+    const rows = await this.fetchAccounts().catch((err) => {
+      throw this.toBrokerError(err)
+    })
+    if (rows.length === 0) {
+      throw new BrokerError(
+        'CONFIG',
+        this.cfg.accountNumber
+          ? `Schwab account "${this.cfg.accountNumber}" not found for this login.`
+          : 'Schwab Trader API returned no accessible accounts for this login.',
+      )
+    }
+    this.initialized = true
+    console.log(`SchwabBroker[${this.id}]: connected (${this.cfg.accountNumber ? `account=${this.cfg.accountNumber}` : 'all linked accounts'})`)
+  }
+
+  async close(): Promise<void> {
+    // No persistent client handles.
+  }
+
+  // ==================== Public reads ====================
+
+  async searchContracts(pattern: string): Promise<ContractDescription[]> {
+    if (!pattern) return []
+    const symbol = pattern.trim().toUpperCase()
+    if (!symbol) return []
+    const desc = new ContractDescription()
+    desc.contract = makeStockContract(symbol, `Schwab ${symbol}`)
+    desc.derivativeSecTypes = ['OPT']
+    return [desc]
+  }
+
+  async getContractDetails(query: Contract): Promise<ContractDetails | null> {
+    if (!query.symbol) return null
+    const details = new ContractDetails()
+    details.contract = query.secType === 'OPT' && query.lastTradeDateOrContractMonth && query.strike != null && query.right
+      ? buildContract({
+          symbol: query.symbol,
+          secType: 'OPT',
+          exchange: query.exchange || 'SMART',
+          currency: query.currency || 'USD',
+          localSymbol: query.localSymbol || query.symbol,
+          lastTradeDateOrContractMonth: query.lastTradeDateOrContractMonth,
+          strike: Number(query.strike),
+          right: query.right as 'C' | 'P',
+          multiplier: query.multiplier || '100',
+          description: query.description,
+        })
+      : makeStockContract(query.symbol, query.description, query.exchange || 'SMART', query.currency || 'USD')
+    details.longName = query.description || query.symbol
+    details.orderTypes = 'MKT,LMT,STP,STP LMT,TRAIL'
+    return details
+  }
+
+  async placeOrder(_contract: Contract, _order: Order, _tpsl?: TpSlParams): Promise<PlaceOrderResult> {
+    return { success: false, error: 'Schwab support in OpenAlice is read-only. Order placement is disabled.' }
+  }
+
+  async modifyOrder(_orderId: string, _changes: Partial<Order>): Promise<PlaceOrderResult> {
+    return { success: false, error: 'Schwab support in OpenAlice is read-only. Order modification is disabled.' }
+  }
+
+  async cancelOrder(_orderId: string): Promise<PlaceOrderResult> {
+    return { success: false, error: 'Schwab support in OpenAlice is read-only. Order cancellation is disabled.' }
+  }
+
+  async closePosition(_contract: Contract, _quantity?: Decimal): Promise<PlaceOrderResult> {
+    return { success: false, error: 'Schwab support in OpenAlice is read-only. Closing positions is disabled.' }
+  }
+
+  async getOrder(_orderId: string): Promise<OpenOrder | null> {
+    return null
+  }
+
+  async getAccount(subAccountId?: string): Promise<AccountInfo> {
+    const rows = await this.fetchAccounts(subAccountId)
+    if (rows.length === 0) {
+      throw new BrokerError('CONFIG', this.cfg.accountNumber
+        ? `Schwab account "${this.cfg.accountNumber}" not found for this login.`
+        : 'No Schwab accounts returned by the Trader API.')
+    }
+
+    const positions = rows.flatMap((row) => this.mapPositions(row))
+    const cash = rows.reduce((sum, row) => sum.plus(this.balanceValue(row, 'cashBalance') ?? 0), new Decimal(0))
+    const buyingPower = rows.reduce((sum, row) => sum.plus(this.balanceValue(row, 'buyingPower') ?? 0), new Decimal(0))
+    const maintMarginReq = rows.reduce((sum, row) => sum.plus(this.balanceValue(row, 'maintenanceRequirement') ?? 0), new Decimal(0))
+    const initMarginReq = rows.reduce((sum, row) => sum.plus(this.balanceValue(row, 'initialMarginRequirement') ?? 0), new Decimal(0))
+
+    const fallback = aggregateAccountFromPositions(cash, positions)
+    const netLiq = rows.reduce((sum, row) => {
+      const v = this.balanceValue(row, 'liquidationValue')
+      return sum.plus(v ?? 0)
+    }, new Decimal(0))
+
+    const unrealized = positions.reduce((sum, pos) => sum.plus(pos.unrealizedPnL), new Decimal(0))
+    const realized = rows.reduce((sum, row) => sum.plus(this.balanceValue(row, 'realizedPnL') ?? 0), new Decimal(0))
+
+    return {
+      baseCurrency: 'USD',
+      netLiquidation: (netLiq.gt(0) ? netLiq : fallback.netLiquidation).toString(),
+      totalCashValue: cash.toString(),
+      unrealizedPnL: unrealized.toString(),
+      realizedPnL: realized.toString(),
+      buyingPower: buyingPower.gt(0) ? buyingPower.toString() : undefined,
+      initMarginReq: initMarginReq.gt(0) ? initMarginReq.toString() : undefined,
+      maintMarginReq: maintMarginReq.gt(0) ? maintMarginReq.toString() : undefined,
+    }
+  }
+
+  async getPositions(subAccountId?: string): Promise<Position[]> {
+    const rows = await this.fetchAccounts(subAccountId)
+    return rows.flatMap((row) => this.mapPositions(row))
+  }
+
+  async getOrders(_orderIds: string[]): Promise<OpenOrder[]> {
+    return []
+  }
+
+  async getQuote(_contract: Contract): Promise<Quote> {
+    throw new BrokerError('CONFIG', 'Schwab quote lookup is not implemented yet. OpenAlice only uses Schwab for portfolio reads.')
+  }
+
+  async getMarketClock(): Promise<MarketClock> {
+    return this.usMarketClock()
+  }
+
+  getCapabilities(): AccountCapabilities {
+    return {
+      supportedSecTypes: ['STK', 'OPT', 'FUND'],
+      supportedOrderTypes: [],
+    }
+  }
+
+  getNativeKey(contract: Contract): string {
+    const symbol = contract.symbol || contract.localSymbol || 'UNKNOWN'
+    const secType = (contract.secType || 'STK').toUpperCase()
+    if (secType === 'OPT' || secType === 'FOP') {
+      const expiry = contract.lastTradeDateOrContractMonth || ''
+      const right = (contract.right || '').toUpperCase()
+      const strike = trimDecimal(String(contract.strike ?? ''))
+      const multiplier = trimDecimal(String(contract.multiplier || '100'))
+      return ['OPT', symbol, expiry, right, strike, multiplier].join('|')
+    }
+    if (secType === 'FUT') {
+      return ['FUT', symbol, contract.lastTradeDateOrContractMonth || '', trimDecimal(String(contract.multiplier || '1'))].join('|')
+    }
+    return ['STK', symbol].join('|')
+  }
+
+  resolveNativeKey(nativeKey: string): Contract {
+    const parts = nativeKey.split('|')
+    if (parts.length === 0) return makeStockContract(nativeKey)
+
+    if (parts[0] === 'OPT') {
+      const [, symbol, expiry, right, strike, multiplier] = parts
+      if (symbol && expiry && (right === 'C' || right === 'P') && strike) {
+        return makeOptionContract({
+          symbol,
+          expiry,
+          right,
+          strike: Number(strike),
+          multiplier: multiplier || '100',
+          localSymbol: symbol,
+          exchange: 'SMART',
+          currency: 'USD',
+        })
+      }
+    }
+
+    if (parts[0] === 'FUT') {
+      const [, symbol, expiry, multiplier] = parts
+      if (symbol) {
+        return buildContract({
+          symbol,
+          secType: 'FUT',
+          exchange: 'SMART',
+          currency: 'USD',
+          localSymbol: symbol,
+          lastTradeDateOrContractMonth: expiry || undefined,
+          multiplier: multiplier || '1',
+        })
+      }
+    }
+
+    return makeStockContract(parts[1] || nativeKey)
+  }
+
+  // ==================== Internal helpers ====================
+
+  private async ensureToken(forceRefresh = false): Promise<SchwabTokenState> {
+    if (!this.tokenState) {
+      this.tokenState = await this.loadTokenState()
+    }
+    if (forceRefresh || this.needsRefresh(this.tokenState)) {
+      this.tokenState = await this.refreshToken(this.tokenState)
+      await this.persistTokenState(this.tokenState)
+    }
+    return this.tokenState
+  }
+
+  private needsRefresh(state: SchwabTokenState): boolean {
+    if (!state.accessToken) return true
+    if (!state.expiresAtMs) return false
+    return Date.now() >= state.expiresAtMs - TOKEN_REFRESH_MARGIN_MS
+  }
+
+  private async loadTokenState(): Promise<SchwabTokenState> {
+    let fileState: Record<string, unknown> = {}
+    try {
+      const raw = JSON.parse(await readFile(this.tokenPath, 'utf-8'))
+      if (isSealedEnvelope(raw)) {
+        const unsealed = await unseal<unknown>(raw)
+        if (isRecord(unsealed)) fileState = unsealed
+      } else if (isRecord(raw)) {
+        fileState = raw
+      }
+    } catch {
+      fileState = {}
+    }
+
+    const expiresAtMs = this.extractExpiresAtMs(fileState)
+    return {
+      accessToken: toStr(fileState.access_token) ?? toStr(fileState.accessToken) ?? toStr(fileState.access_token_value) ?? toStr(fileState.access) ?? undefined,
+      refreshToken: toStr(fileState.refresh_token) ?? toStr(fileState.refreshToken) ?? this.cfg.refreshToken ?? undefined,
+      expiresAtMs,
+      raw: Object.keys(fileState).length > 0 ? fileState : undefined,
+    }
+  }
+
+  private extractExpiresAtMs(raw: Record<string, unknown>): number | undefined {
+    const candidates = [
+      raw.expires_at,
+      raw.expiresAt,
+      raw.expires_at_ms,
+      raw.expiresAtMs,
+      raw.access_token_expires_at,
+    ]
+    for (const candidate of candidates) {
+      if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+        return candidate > 1e12 ? candidate : Date.now() + candidate * 1000
+      }
+      if (typeof candidate === 'string' && candidate) {
+        const asNum = Number(candidate)
+        if (Number.isFinite(asNum)) {
+          return asNum > 1e12 ? asNum : Date.now() + asNum * 1000
+        }
+        const asDate = new Date(candidate)
+        if (!Number.isNaN(asDate.getTime())) return asDate.getTime()
+      }
+    }
+    return undefined
+  }
+
+  private async refreshToken(previous: SchwabTokenState): Promise<SchwabTokenState> {
+    const refreshToken = previous.refreshToken ?? this.cfg.refreshToken
+    if (!refreshToken) {
+      throw new BrokerError(
+        'CONFIG',
+        `No Schwab refresh token available. Provide refreshToken or tokenPath, then retry. The token file can be generated with Schwab OAuth tooling and will be kept up to date automatically.`,
+      )
+    }
+
+    const basic = Buffer.from(`${this.cfg.clientId}:${this.cfg.clientSecret}`).toString('base64')
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    })
+
+    let response: Response
+    try {
+      response = await fetch(SCHWAB_OAUTH_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${basic}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body,
+      })
+    } catch (err) {
+      throw BrokerError.from(err, 'NETWORK')
+    }
+
+    if (!response.ok) {
+      const msg = await this.responseErrorMessage(response)
+      throw new BrokerError(response.status === 401 ? 'AUTH' : 'NETWORK', `Schwab token refresh failed: ${msg}`)
+    }
+
+    const json = await response.json().catch(() => ({}))
+    if (!isRecord(json) || !toStr(json.access_token ?? json.accessToken)) {
+      throw new BrokerError('AUTH', 'Schwab token refresh succeeded but the response did not contain an access token.')
+    }
+
+    const expiresIn = numFrom(json.expires_in ?? json.expiresIn)
+    return {
+      accessToken: toStr(json.access_token ?? json.accessToken) ?? undefined,
+      refreshToken: toStr(json.refresh_token ?? json.refreshToken) ?? refreshToken,
+      expiresAtMs: expiresIn ? Date.now() + expiresIn * 1000 : previous.expiresAtMs,
+      raw: { ...(previous.raw ?? {}), ...(json as Record<string, unknown>) },
+    }
+  }
+
+  private async persistTokenState(state: SchwabTokenState): Promise<void> {
+    const raw = {
+      ...(state.raw ?? {}),
+      access_token: state.accessToken,
+      refresh_token: state.refreshToken,
+      expires_at: state.expiresAtMs ? new Date(state.expiresAtMs).toISOString() : undefined,
+    }
+    await mkdir(dirname(this.tokenPath), { recursive: true })
+    await writeFile(this.tokenPath, JSON.stringify(await seal(raw), null, 2) + '\n', { mode: 0o600 })
+  }
+
+  private async apiFetch(path: string, init: RequestInit = {}, retry = true): Promise<Response> {
+    const token = await this.ensureToken()
+    if (!token.accessToken) {
+      throw new BrokerError('AUTH', 'No Schwab access token available.')
+    }
+
+    const headers = new Headers(init.headers ?? {})
+    headers.set('Authorization', `Bearer ${token.accessToken}`)
+    headers.set('Accept', 'application/json')
+    if (init.body && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json')
+    }
+
+    const response = await fetch(`${SCHWAB_TRADER_BASE}${path}`, {
+      ...init,
+      headers,
+    }).catch((err) => {
+      throw BrokerError.from(err, 'NETWORK')
+    })
+
+    if (response.status === 401 && retry) {
+      this.tokenState = await this.refreshToken(token)
+      await this.persistTokenState(this.tokenState)
+      return this.apiFetch(path, init, false)
+    }
+
+    if (!response.ok) {
+      const msg = await this.responseErrorMessage(response)
+      const code = response.status === 401 ? 'AUTH' : response.status === 403 ? 'EXCHANGE' : 'NETWORK'
+      throw new BrokerError(code, `Schwab API ${path} failed (${response.status}): ${msg}`)
+    }
+    return response
+  }
+
+  private async responseErrorMessage(response: Response): Promise<string> {
+    const text = await response.text().catch(() => '')
+    if (!text) return response.statusText || 'Unknown error'
+    try {
+      const parsed = JSON.parse(text)
+      if (isRecord(parsed)) {
+        return toStr(parsed.error) ?? toStr(parsed.message) ?? JSON.stringify(parsed)
+      }
+    } catch {
+      // plain text body
+    }
+    return text.slice(0, 500)
+  }
+
+  private async fetchAccounts(subAccountId?: string): Promise<SchwabAccountRaw[]> {
+    const response = await this.apiFetch('/accounts?fields=positions')
+    const payload = await response.json().catch(() => ({}))
+    const rows = normalizeAccountPayload(payload)
+    const selected = this.selectRows(rows, subAccountId)
+    if (selected.length > 0) return selected
+    if (toStr(subAccountId) || toStr(this.cfg.accountNumber)) return []
+    return rows
+  }
+
+  private selectRows(rows: SchwabAccountRaw[], subAccountId?: string): SchwabAccountRaw[] {
+    const wanted = toStr(subAccountId) ?? toStr(this.cfg.accountNumber)
+    if (!wanted) return rows
+    const matches = rows.filter((row) => toStr(row.accountNumber) === wanted)
+    if (matches.length > 0) return matches
+    return rows.filter((row) => toStr(row.hashValue) === wanted)
+  }
+
+  private mapPositions(row: SchwabAccountRaw): Position[] {
+    const out: Position[] = []
+    for (const raw of row.positions ?? []) {
+      const mapped = this.mapPosition(raw)
+      if (mapped) out.push(mapped)
+    }
+    return out
+  }
+
+  private mapPosition(raw: SchwabPositionRaw): Position | null {
+    const instrument = raw.instrument ?? {}
+    const assetType = (instrument.assetType ?? raw.assetType ?? '').toUpperCase()
+    const symbol = toStr(instrument.underlyingSymbol ?? instrument.symbol ?? raw.symbol)
+    if (!symbol) return null
+
+    if (assetType === 'OPTION') {
+      const expiry = formatDateLike(instrument.expirationDate)
+      const right = parsePutCall(instrument.putCall)
+      const strike = numFrom(instrument.strikePrice)
+      if (!expiry || !right || strike == null) return null
+      const contract = makeOptionContract({
+        symbol,
+        expiry,
+        strike,
+        right,
+        multiplier: trimDecimal(String(instrument.multiplier ?? 100)),
+        description: instrument.description ?? raw.symbol ?? symbol,
+        exchange: toStr(instrument.exchange ?? instrument.primaryExchange) ?? 'SMART',
+        currency: toStr(instrument.currency) ?? 'USD',
+        localSymbol: toStr(raw.symbol ?? instrument.symbol ?? symbol) ?? symbol,
+      })
+      return this.buildPositionFromRow(contract, raw, true)
+    }
+
+    if (assetType === 'FUTURE') {
+      const expiry = formatDateLike(instrument.expirationDate)
+      const contract = buildContract({
+        symbol,
+        secType: 'FUT',
+        exchange: toStr(instrument.exchange ?? instrument.primaryExchange) ?? 'SMART',
+        currency: toStr(instrument.currency) ?? 'USD',
+        localSymbol: toStr(raw.symbol ?? instrument.symbol ?? symbol) ?? symbol,
+        lastTradeDateOrContractMonth: expiry,
+        multiplier: trimDecimal(String(instrument.multiplier ?? 1)) || '1',
+        description: instrument.description ?? raw.symbol ?? symbol,
+      })
+      return this.buildPositionFromRow(contract, raw, false)
+    }
+
+    const contract = makeStockContract(
+      symbol,
+      instrument.description ?? raw.symbol ?? symbol,
+      toStr(instrument.exchange ?? instrument.primaryExchange) ?? 'SMART',
+      toStr(instrument.currency) ?? 'USD',
+    )
+    return this.buildPositionFromRow(contract, raw, false)
+  }
+
+  private buildPositionFromRow(contract: Contract, raw: SchwabPositionRaw, derivative = false): Position {
+    const longQty = toDecimal(raw.longQuantity)
+    const shortQty = toDecimal(raw.shortQuantity)
+    const netQty = longQty.minus(shortQty)
+    const quantity = netQty.abs()
+    const side = netQty.isNegative() ? 'short' : 'long'
+    const multiplier = trimDecimal(String(contract.multiplier || (derivative ? '100' : '1'))) || '1'
+
+    const marketValueRaw = raw.marketValue != null ? toDecimal(raw.marketValue).abs() : null
+    const marketPrice = marketValueRaw && quantity.gt(0)
+      ? marketValueRaw.div(quantity).toString()
+      : toStr(raw.marketPrice)
+        ?? toStr(raw.averagePrice)
+        ?? toStr(raw.averageLongPrice)
+        ?? toStr(raw.averageShortPrice)
+        ?? '0'
+    const avgCost = toStr(
+      side === 'short'
+        ? raw.averageShortPrice ?? raw.averagePrice ?? raw.averageLongPrice ?? marketPrice
+        : raw.averageLongPrice ?? raw.averagePrice ?? raw.averageShortPrice ?? marketPrice,
+    ) ?? marketPrice
+
+    const marketValue = marketValueRaw?.toString()
+      ?? quantity.mul(marketPrice).mul(multiplier).toString()
+    const realizedPnL = toStr((raw as Record<string, unknown>).realizedPnL) ?? '0'
+
+    return buildPosition({
+      contract,
+      currency: contract.currency || 'USD',
+      side,
+      quantity,
+      avgCost,
+      marketPrice,
+      marketValue,
+      unrealizedPnL: toStr(raw.longOpenProfitLoss ?? raw.shortOpenProfitLoss) ?? undefined,
+      realizedPnL,
+      multiplier,
+      avgCostSource: 'broker',
+    })
+  }
+
+  private balanceValue(row: SchwabAccountRaw, field: keyof SchwabBalanceRaw): Decimal | undefined {
+    const balance = row.currentBalances ?? row.aggregatedBalance ?? {}
+    const raw = balance[field]
+    return raw == null || raw === '' ? undefined : new Decimal(raw)
+  }
+
+  private toBrokerError(err: unknown): BrokerError {
+    return err instanceof BrokerError ? err : BrokerError.from(err)
+  }
+
+  private usMarketClock(): MarketClock {
+    const now = new Date()
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/New_York',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    }).formatToParts(now)
+
+    const pick = (type: string): string => parts.find((p) => p.type === type)?.value ?? '0'
+    const year = Number(pick('year'))
+    const month = Number(pick('month'))
+    const day = Number(pick('day'))
+    const hour = Number(pick('hour'))
+    const minute = Number(pick('minute'))
+    const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay()
+    const minutes = hour * 60 + minute
+    const openMinutes = 9 * 60 + 30
+    const closeMinutes = 16 * 60
+    const isWeekday = weekday >= 1 && weekday <= 5
+    const isOpen = isWeekday && minutes >= openMinutes && minutes < closeMinutes
+
+    const nextOpen = isOpen
+      ? undefined
+      : (() => {
+          const next = new Date(now)
+          const addDays = (days: number) => next.setDate(next.getDate() + days)
+          if (weekday === 6) addDays(2)
+          else if (weekday === 0) addDays(1)
+          else if (minutes >= closeMinutes) addDays(1)
+          if (next.getDay() === 6) addDays(2)
+          if (next.getDay() === 0) addDays(1)
+          next.setHours(9, 30, 0, 0)
+          return next
+        })()
+
+    const nextClose = isOpen
+      ? (() => {
+          const close = new Date(now)
+          close.setHours(16, 0, 0, 0)
+          return close
+        })()
+      : undefined
+
+    return { isOpen, nextOpen, nextClose, timestamp: now }
+  }
+}

--- a/services/uta/src/domain/trading/brokers/schwab/index.ts
+++ b/services/uta/src/domain/trading/brokers/schwab/index.ts
@@ -1,0 +1,2 @@
+export { SchwabBroker } from './SchwabBroker.js'
+export type { SchwabBrokerConfig } from './SchwabBroker.js'

--- a/src/webui/routes/trading-config.ts
+++ b/src/webui/routes/trading-config.ts
@@ -140,6 +140,7 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
         enabled: body.enabled !== false,
         guards: Array.isArray(body.guards) ? body.guards : [],
         presetConfig,
+        readOnly: preset.id === 'schwab' ? true : body.readOnly === true,
         ...(body.ephemeral === true ? { ephemeral: true as const } : {}),
       }
       const validated = utaConfigSchema.parse(candidate)
@@ -185,6 +186,9 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
       unmaskSecrets(body, existing as unknown as Record<string, unknown>)
 
       const validated = utaConfigSchema.parse(body)
+      if (validated.presetId === 'schwab') {
+        validated.readOnly = true
+      }
       const idx = accounts.findIndex((a) => a.id === id)
       accounts[idx] = validated
       await writeUTAsConfig(accounts)

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -545,7 +545,7 @@ export interface BrokerPreset {
   defaultName: string
   badge: string
   badgeColor: string
-  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'mock'
+  engine: 'ccxt' | 'alpaca' | 'ibkr' | 'leverup' | 'longbridge' | 'schwab' | 'mock'
   guardCategory: 'crypto' | 'securities'
   modes?: ModeOption[]
   subtitleFields: SubtitleField[]


### PR DESCRIPTION
Adds Schwab portfolio UTA support with token handling and portfolio reads. The broker remains read-only: no order placement or write operations are enabled.\n\nThis branch has been squashed to a single commit as requested.

TESTED locally: 

<img width="871" height="406" alt="SCR-20260629-rghi" src="https://github.com/user-attachments/assets/977a60be-dd19-470e-8858-f645ac46f228" />
