### PR TITLE
Fix workspace default agent runtime

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -195,6 +195,13 @@ export const aiProviderSchema = z.object({
    * `credentials`; a dangling slug is loud-skipped at injection, never fatal.
    */
   workspaceCredentialDefaults: z.record(z.string(), workspaceCredentialDefaultSchema).default({}),
+  /**
+   * User-level default runtime for new interactive workspace sessions. This is
+   * intentionally separate from workspace identity (`agents[]`) and from
+   * credential defaults: it answers "which agent TUI should a plain New Session
+   * start?" Shell is a utility adapter, not a valid stored default.
+   */
+  workspaceDefaultAgent: z.string().nullable().default(null),
 })
 
 export type AIProviderConfig = z.infer<typeof aiProviderSchema>
@@ -978,6 +985,18 @@ export async function writeWorkspaceCredentialDefaults(
     if (parsed.credentialSlug) cleaned[agentId] = parsed
   }
   config.workspaceCredentialDefaults = cleaned
+  await mkdir(CONFIG_DIR, { recursive: true })
+  await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
+}
+
+export async function readWorkspaceDefaultAgent(): Promise<string | null> {
+  const config = await readAIProviderConfig()
+  return config.workspaceDefaultAgent ?? null
+}
+
+export async function writeWorkspaceDefaultAgent(agentId: string | null): Promise<void> {
+  const config = await readAIProviderConfig()
+  config.workspaceDefaultAgent = agentId && agentId.trim() ? agentId.trim() : null
   await mkdir(CONFIG_DIR, { recursive: true })
   await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
 }

--- a/src/webui/routes/config-workspace-defaults.spec.ts
+++ b/src/webui/routes/config-workspace-defaults.spec.ts
@@ -12,6 +12,7 @@ import type { Credential, WorkspaceCredentialDefault } from '../../core/config.j
 
 let credStore: Record<string, Credential> = {}
 let defaultsStore: Record<string, WorkspaceCredentialDefault> = {}
+let defaultAgentStore: string | null = null
 
 vi.mock('../../core/config.js', async () => {
   const actual = await vi.importActual<typeof import('../../core/config.js')>('../../core/config.js')
@@ -19,11 +20,15 @@ vi.mock('../../core/config.js', async () => {
     ...actual,
     readCredentials: vi.fn(async () => ({ ...credStore })),
     readWorkspaceCredentialDefaults: vi.fn(async () => ({ ...defaultsStore })),
+    readWorkspaceDefaultAgent: vi.fn(async () => defaultAgentStore),
     writeWorkspaceCredentialDefaults: vi.fn(async (next: Record<string, WorkspaceCredentialDefault>) => {
       // Mirror the real writer: drop empty slugs.
       const cleaned: Record<string, WorkspaceCredentialDefault> = {}
       for (const [k, v] of Object.entries(next)) if (v.credentialSlug) cleaned[k] = v
       defaultsStore = cleaned
+    }),
+    writeWorkspaceDefaultAgent: vi.fn(async (agent: string | null) => {
+      defaultAgentStore = agent
     }),
   }
 })
@@ -48,6 +53,7 @@ beforeEach(() => {
     'chat-1': { vendor: 'custom', authType: 'api-key', apiKey: 'k', wires: { 'openai-chat': 'https://gw/v1' } },
   }
   defaultsStore = {}
+  defaultAgentStore = null
 })
 
 describe('GET /workspace-credential-defaults', () => {
@@ -67,6 +73,32 @@ describe('GET /workspace-credential-defaults', () => {
     // opencode/pi speak chat|anthropic|responses → every key qualifies.
     expect(new Set(compat.opencode)).toEqual(new Set(['anthropic-1', 'openai-1', 'chat-1']))
     expect(new Set(compat.pi)).toEqual(new Set(['anthropic-1', 'openai-1', 'chat-1']))
+  })
+})
+
+describe('GET/PUT /workspace-default-agent', () => {
+  it('round-trips a valid agent runtime default', async () => {
+    const routes = createConfigRoutes()
+    const put = await req(routes, 'PUT', '/workspace-default-agent', { agent: 'codex' })
+    expect(put.status).toBe(200)
+    expect(put.body).toEqual({ agent: 'codex' })
+    expect(defaultAgentStore).toBe('codex')
+
+    const get = await req(routes, 'GET', '/workspace-default-agent')
+    expect(get.body).toEqual({ agent: 'codex' })
+  })
+
+  it('does not persist shell or unknown ids as a default workload', async () => {
+    const routes = createConfigRoutes()
+    defaultAgentStore = 'codex'
+
+    const shell = await req(routes, 'PUT', '/workspace-default-agent', { agent: 'shell' })
+    expect(shell.body).toEqual({ agent: null })
+    expect(defaultAgentStore).toBeNull()
+
+    const unknown = await req(routes, 'PUT', '/workspace-default-agent', { agent: 'bogus' })
+    expect(unknown.body).toEqual({ agent: null })
+    expect(defaultAgentStore).toBeNull()
   })
 })
 

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -4,6 +4,7 @@ import {
   readCredentials, addCredential, deleteCredential, writeCredential, resolveCredential,
   credentialWires,
   readWorkspaceCredentialDefaults, writeWorkspaceCredentialDefaults,
+  readWorkspaceDefaultAgent, writeWorkspaceDefaultAgent,
   credentialVendorEnum, credentialWireShapeEnum,
   type ConfigSection, type Credential, type CredentialWireShape,
   type WorkspaceCredentialDefault,
@@ -211,6 +212,27 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
       }
       await writeWorkspaceCredentialDefaults(next)
       return c.json({ defaults: next })
+    } catch (err) {
+      return c.json({ error: String(err) }, 400)
+    }
+  })
+
+  app.get('/workspace-default-agent', async (c) => {
+    try {
+      return c.json({ agent: await readWorkspaceDefaultAgent() })
+    } catch (err) {
+      return c.json({ error: String(err) }, 500)
+    }
+  })
+
+  app.put('/workspace-default-agent', async (c) => {
+    try {
+      const body = await c.req.json<{ agent?: string | null }>()
+      const agent = typeof body.agent === 'string' && DEFAULTABLE_AGENTS.includes(body.agent as typeof DEFAULTABLE_AGENTS[number])
+        ? body.agent
+        : null
+      await writeWorkspaceDefaultAgent(agent)
+      return c.json({ agent })
     } catch (err) {
       return c.json({ error: String(err) }, 400)
     }

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -10,14 +10,19 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { createWorkspaceRoutes } from './workspaces.js';
-import { readCredentials, setCredentialLastModel, type Credential } from '../../core/config.js';
+import { readCredentials, readWorkspaceDefaultAgent, setCredentialLastModel, type Credential } from '../../core/config.js';
 import type { WorkspaceService } from '../../workspaces/service.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 vi.mock('../../core/config.js', async (importActual) => {
   const actual = await importActual<typeof import('../../core/config.js')>();
-  return { ...actual, readCredentials: vi.fn(), setCredentialLastModel: vi.fn(async () => {}) };
+  return {
+    ...actual,
+    readCredentials: vi.fn(),
+    readWorkspaceDefaultAgent: vi.fn(async () => null),
+    setCredentialLastModel: vi.fn(async () => {}),
+  };
 });
 
 const openaiKey: Credential = {
@@ -33,7 +38,8 @@ function build(opts: { workspaces?: any[] } = {}) {
     readAiConfig: vi.fn(async () => null), // workspace has no prior config
   };
   const claude = { id: 'claude', namePrefix: 'c' };
-  const adapters: Record<string, any> = { opencode, claude };
+  const shell = { id: 'shell', kind: 'utility', namePrefix: 'sh' };
+  const adapters: Record<string, any> = { opencode, claude, shell };
   const spawn = vi.fn(() => ({
     recordId: 'rec-1', wsId: 'ws-1', name: 'o1', pid: 1, agentSessionId: null, startedAt: 1,
   }));
@@ -69,6 +75,7 @@ async function quickChat(app: any, body: unknown) {
 
 beforeEach(() => {
   vi.mocked(readCredentials).mockReset();
+  vi.mocked(readWorkspaceDefaultAgent).mockResolvedValue(null);
   vi.mocked(setCredentialLastModel).mockClear();
 });
 
@@ -130,6 +137,27 @@ describe('POST /quick-chat — loginless credential injection', () => {
     expect(creator.create).not.toHaveBeenCalled(); // reused, not created
     expect(spawn).toHaveBeenCalledOnce();
     expect((spawn.mock.calls[0] as any[])[0]).toBe('ws-1'); // spawned into the target
+  });
+
+  it('omitted agent ignores shell at agents[0] and uses the first agent runtime', async () => {
+    const { app, spawn } = build({
+      workspaces: [{ id: 'ws-1', dir: '/w', agents: ['shell', 'claude'], template: 'chat', tag: 'chat-x' }],
+    });
+    const r = await quickChat(app, { prompt: 'hi', targetWsId: 'ws-1' });
+    expect(r.status).toBe(201);
+    expect(spawn).toHaveBeenCalledOnce();
+    expect((spawn.mock.calls[0] as any[])[1].agentId).toBe('claude');
+  });
+
+  it('omitted agent honors a configured default runtime when enabled', async () => {
+    vi.mocked(readWorkspaceDefaultAgent).mockResolvedValue('opencode');
+    vi.mocked(readCredentials).mockResolvedValue({ 'openai-1': openaiKey });
+    const { app, spawn } = build({
+      workspaces: [{ id: 'ws-1', dir: '/w', agents: ['shell', 'claude', 'opencode'], template: 'chat', tag: 'chat-x' }],
+    });
+    const r = await quickChat(app, { prompt: 'hi', targetWsId: 'ws-1' });
+    expect(r.status).toBe(201);
+    expect((spawn.mock.calls[0] as any[])[1].agentId).toBe('opencode');
   });
 
   it('unknown targetWsId → 404 workspace_not_found, no spawn', async () => {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -28,8 +28,8 @@ import { readWorkspaceMetadata, workspaceMetadataSchema, writeWorkspaceMetadata 
 import type { SessionRecord } from '../../workspaces/session-registry.js';
 import type { WorkspaceMeta } from '../../workspaces/workspace-registry.js';
 import { HeadlessCapacityError, resumeFromRecord, type SessionFactoryContext, type WorkspaceService } from '../../workspaces/service.js';
-import type { WorkspaceAiCred } from '../../workspaces/cli-adapter.js';
-import { addCredential, readCredentials, setCredentialLastModel, credentialWires, credentialWireShapeEnum, type Credential } from '../../core/config.js';
+import { isAgentRuntime, type WorkspaceAiCred } from '../../workspaces/cli-adapter.js';
+import { addCredential, readCredentials, readWorkspaceDefaultAgent, setCredentialLastModel, credentialWires, credentialWireShapeEnum, type Credential } from '../../core/config.js';
 import { inferCredentialVendor, resolveAnthropicAuthMode } from '../../core/credential-inference.js';
 import {
   compatibleCredentials,
@@ -130,6 +130,18 @@ type SpawnSessionResult =
 export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
   const app = new Hono();
 
+  const resolveDefaultAgentId = async (meta: WorkspaceMeta): Promise<string | undefined> => {
+    const configured = await readWorkspaceDefaultAgent().catch(() => null);
+    if (configured && meta.agents.includes(configured)) {
+      const adapter = svc.adapters.get(configured);
+      if (adapter && isAgentRuntime(adapter)) return configured;
+    }
+    return meta.agents.find((id) => {
+      const adapter = svc.adapters.get(id);
+      return adapter ? isAgentRuntime(adapter) : false;
+    });
+  };
+
   /**
    * Spawn one interactive PTY session in an existing workspace — the shared
    * core of `POST /:id/sessions/spawn` and `POST /quick-chat` (so the two never
@@ -147,8 +159,12 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     },
   ): Promise<SpawnSessionResult> {
     const id = meta.id;
-    const { agentId, resume, initialPrompt } = opts;
-    if (agentId && !svc.adapters.get(agentId)) {
+    const { resume, initialPrompt } = opts;
+    const agentId = opts.agentId ?? await resolveDefaultAgentId(meta);
+    if (!agentId) {
+      return { ok: false, status: 400, body: { error: 'no_agent_runtime', message: 'workspace has no agent runtime enabled' } };
+    }
+    if (!svc.adapters.get(agentId)) {
       return { ok: false, status: 400, body: { error: 'unknown_agent', message: `no adapter: ${agentId}` } };
     }
     const adapter = svc.resolveAdapter(meta, agentId);
@@ -185,7 +201,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     try {
       const ctx: SessionFactoryContext = {
         ...(resume !== undefined ? { resume } : {}),
-        ...(agentId !== undefined ? { agentId } : {}),
+        agentId,
         ...(initialPrompt !== undefined ? { initialPrompt } : {}),
         recordId,
         recordName,
@@ -379,6 +395,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
         return {
           id: a.id,
           displayName: a.displayName,
+          kind: isAgentRuntime(a) ? 'agent' : 'utility',
           capabilities: a.capabilities,
           installed: av?.installed ?? true,
           binPath: av?.path ?? null,
@@ -687,7 +704,10 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     // it from the vault before spawn. The dead-end (no compatible credential at
     // all) returns 400 no_ai_credential so the composer bounces to Settings
     // instead of spawning an agent that'll instantly die on a missing key.
-    const effectiveAgent = svc.resolveAdapter(meta, agentId).id;
+    const effectiveAgent = agentId ?? await resolveDefaultAgentId(meta);
+    if (!effectiveAgent) {
+      return c.json({ error: 'no_agent_runtime', message: 'workspace has no agent runtime enabled' }, 400);
+    }
     if (LOGINLESS_AGENTS.has(effectiveAgent)) {
       const inject = await injectLoginlessCredential(meta, effectiveAgent, credentialSlug);
       if (!inject.ok) return c.json(inject.body, inject.status as 400);
@@ -1118,11 +1138,16 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     // An explicit agent must be one ENABLED on this workspace — else
     // resolveAdapter would honor it and spawn a CLI with no provider config
     // injected (silent fallback to the user's global config). Omitting `agent`
-    // (→ workspace default) stays fine.
+    // resolves through the user default / first enabled agent runtime, never
+    // through utility adapters such as shell.
     if (agentId && !meta.agents.includes(agentId)) {
       return c.json({ error: 'agent_not_enabled', message: `agent "${agentId}" not enabled on this workspace` }, 400);
     }
-    const adapter = svc.resolveAdapter(meta, agentId);
+    const effectiveAgentId = agentId ?? await resolveDefaultAgentId(meta);
+    if (!effectiveAgentId) {
+      return c.json({ error: 'no_agent_runtime', message: 'workspace has no agent runtime enabled' }, 400);
+    }
+    const adapter = svc.resolveAdapter(meta, effectiveAgentId);
     if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
       return c.json({ error: 'no_headless', message: `adapter "${adapter.id}" has no headless mode` }, 400);
     }

--- a/src/workspaces/adapters/shell.ts
+++ b/src/workspaces/adapters/shell.ts
@@ -13,6 +13,7 @@ import type { CliAdapter, SpawnContext } from '../cli-adapter.js';
 export const shellAdapter: CliAdapter = {
   id: 'shell',
   displayName: 'Shell',
+  kind: 'utility',
   namePrefix: 'sh',
   capabilities: {
     parallelPerCwd: true,

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -97,6 +97,12 @@ export interface CliAdapter {
   readonly id: string;                          // 'claude' | 'codex' | 'shell'
   readonly displayName: string;
   /**
+   * Launch surface category. Agent runtimes run a coding-agent TUI and can be
+   * used as the default workload. Utility adapters are explicit tools such as a
+   * bare shell and must never be selected by an omitted `agent`.
+   */
+  readonly kind?: 'agent' | 'utility';
+  /**
    * Canonical PATH binary name this adapter spawns (`claude`, `codex`,
    * `opencode`, `pi`). Consumed by `agent-detect.ts` to tell the frontend
    * whether the runtime is actually installed on the host. Omit for adapters
@@ -226,6 +232,10 @@ export interface CliAdapter {
 
   /** Subprocess discovery (capabilities.transcriptDiscovery === 'subprocess'). */
   listOnDisk?(cwd: string): Promise<readonly OnDiskSession[]>;
+}
+
+export function isAgentRuntime(adapter: CliAdapter): boolean {
+  return adapter.kind !== 'utility' && adapter.id !== 'shell';
 }
 
 export class AdapterRegistry {

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -86,7 +86,7 @@ export const issueFrontmatterSchema = z.object({
   when: issueWhenSchema.optional(),
   /** Prompt fired on schedule; if absent, the fire prompt falls back to title+body. */
   what: z.string().min(1).optional(),
-  /** Which adapter to run the scheduled fire with; defaults to the ws default agent. */
+  /** Which agent runtime to run the scheduled fire with; omitted uses the user default / first runtime. */
   agent: z.string().min(1).optional(),
 })
 export type IssueFrontmatter = z.infer<typeof issueFrontmatterSchema>

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -19,7 +19,7 @@ import { codexAdapter } from './adapters/codex.js';
 import { opencodeAdapter } from './adapters/opencode.js';
 import { piAdapter } from './adapters/pi.js';
 import { shellAdapter } from './adapters/shell.js';
-import { AdapterRegistry, type CliAdapter } from './cli-adapter.js';
+import { AdapterRegistry, isAgentRuntime, type CliAdapter } from './cli-adapter.js';
 import { loadConfig, type ServerConfig } from './config.js';
 import { logger as launcherLogger } from './logger.js';
 import { runHeadlessProbe, type HeadlessProbeResult } from './probe.js';
@@ -297,7 +297,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       const a = adapters.get(agentId);
       if (a) return a;
     }
-    const fromWorkspace = wsMeta.agents[0];
+    const fromWorkspace = wsMeta.agents.find((id) => {
+      const a = adapters.get(id);
+      return a ? isAgentRuntime(a) : false;
+    });
     if (fromWorkspace) {
       const a = adapters.get(fromWorkspace);
       if (a) return a;

--- a/src/workspaces/workspace-creator.spec.ts
+++ b/src/workspaces/workspace-creator.spec.ts
@@ -43,7 +43,7 @@ function setPlatform(value: NodeJS.Platform): void {
 }
 
 describe('resolveCreateAgents — single home of the agent policy', () => {
-  const ALL = ['claude', 'codex', 'opencode', 'pi'];
+  const ALL = ['claude', 'codex', 'opencode', 'pi', 'shell'];
 
   it('enables EVERY registered adapter when the caller pins nothing', () => {
     // The quick-chat bug: it called create() with no explicit set, so it used
@@ -51,16 +51,22 @@ describe('resolveCreateAgents — single home of the agent policy', () => {
     expect(resolveCreateAgents(undefined, ['claude', 'codex'], ALL)).toEqual(ALL);
   });
 
-  it('honors template defaultAgents only as the ORDER head (agents[0] default)', () => {
+  it('honors template defaultAgents as the agent-runtime order head', () => {
     // A template that wants codex first still gets all four, codex leading.
     expect(resolveCreateAgents(undefined, ['codex'], ALL)).toEqual([
-      'codex', 'claude', 'opencode', 'pi',
+      'codex', 'claude', 'opencode', 'pi', 'shell',
     ]);
   });
 
   it('first-wins dedupes when the head repeats a registered id', () => {
     expect(resolveCreateAgents(undefined, ['pi', 'claude'], ALL)).toEqual([
-      'pi', 'claude', 'codex', 'opencode',
+      'pi', 'claude', 'codex', 'opencode', 'shell',
+    ]);
+  });
+
+  it('keeps shell enabled but never ahead of agent runtimes', () => {
+    expect(resolveCreateAgents(undefined, ['shell', 'codex'], ALL)).toEqual([
+      'codex', 'claude', 'opencode', 'pi', 'shell',
     ]);
   });
 

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -61,9 +61,9 @@ const TAG_RE = /^[a-z0-9][a-z0-9_-]{0,32}$/;
  * - An explicit `agentsRequested` (a caller pinning a subset) wins verbatim.
  * - Otherwise a workspace gets EVERY registered adapter enabled; restricting
  *   it was a create-time decision with no first-action basis. The template's
- *   `defaultAgents` is honored only as the HEAD of the list (first-wins
- *   dedupe), so `agents[0]` — the "spawn a new session" default — follows
- *   template intent without limiting what's available.
+ *   `defaultAgents` is honored as an ordering hint for agent runtimes, while
+ *   utility adapters such as `shell` are kept at the tail so they never become
+ *   an implicit workload.
  *
  * This used to live in the frontend create hook alone, which silently left
  * backend-only callers (quick-chat) on the bare-`defaultAgents` set.
@@ -74,7 +74,12 @@ export function resolveCreateAgents(
   allAdapterIds: readonly string[],
 ): readonly string[] {
   if (agentsRequested && agentsRequested.length > 0) return agentsRequested;
-  return [...new Set([...templateDefaultAgents, ...allAdapterIds])];
+  const utility = new Set(['shell']);
+  const ordered = [...new Set([...templateDefaultAgents, ...allAdapterIds])];
+  return [
+    ...ordered.filter((id) => !utility.has(id)),
+    ...ordered.filter((id) => utility.has(id)),
+  ];
 }
 
 /**

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -44,6 +44,7 @@ export interface SidebarProps {
   readonly workspaces: readonly Workspace[];
   readonly templates: readonly TemplateInfo[];
   readonly agents: readonly AgentInfo[];
+  readonly defaultAgent: string | null;
   readonly listError: string | null;
   /** True once the first workspaces-list fetch has resolved — gates the empty
    *  state vs. a cold-load skeleton. */
@@ -52,6 +53,7 @@ export interface SidebarProps {
   readonly onSelectWorkspace: (wsId: string) => void;
   readonly onSelectSession: (wsId: string, sessionId: string) => void;
   readonly onSpawn: (wsId: string, opts?: SpawnOpts) => void;
+  readonly onSetDefaultAgent: (agent: string | null) => void;
   readonly onPauseSession: (wsId: string, sessionId: string) => void;
   readonly onResumeSession: (wsId: string, sessionId: string) => void;
   readonly onDeleteSession: (wsId: string, sessionId: string) => void;
@@ -178,11 +180,13 @@ export function Sidebar(props: SidebarProps): ReactElement {
             key={w.id}
             workspace={w}
             agents={props.agents}
+            defaultAgent={props.defaultAgent}
             selection={props.selection}
             headlessTasks={headlessByWs.get(w.id) ?? []}
             onSelectWorkspace={props.onSelectWorkspace}
             onSelectSession={props.onSelectSession}
             onSpawn={props.onSpawn}
+            onSetDefaultAgent={props.onSetDefaultAgent}
             onPauseSession={props.onPauseSession}
             onResumeSession={props.onResumeSession}
             onDeleteSession={props.onDeleteSession}
@@ -226,12 +230,14 @@ function NavRow({
 export interface WorkspaceRowProps {
   readonly workspace: Workspace;
   readonly agents: readonly AgentInfo[];
+  readonly defaultAgent: string | null;
   readonly selection: Selection | null;
   /** This workspace's headless (automation) runs, newest-first. */
   readonly headlessTasks?: readonly HeadlessTaskRecord[];
   readonly onSelectWorkspace: (wsId: string) => void;
   readonly onSelectSession: (wsId: string, sessionId: string) => void;
   readonly onSpawn: (wsId: string, opts?: SpawnOpts) => void;
+  readonly onSetDefaultAgent: (agent: string | null) => void;
   readonly onPauseSession: (wsId: string, sessionId: string) => void;
   readonly onResumeSession: (wsId: string, sessionId: string) => void;
   readonly onDeleteSession: (wsId: string, sessionId: string) => void;
@@ -290,6 +296,14 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   const [spawnMenuOpen, setSpawnMenuOpen] = useState(false);
   const plusBtnRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLUListElement | null>(null);
+  const enabledAgents = w.agents
+    .map((id) => props.agents.find((a) => a.id === id))
+    .filter((a): a is AgentInfo => !!a);
+  const runtimeAgents = enabledAgents.filter((a) => a.kind !== 'utility');
+  const utilityAgents = enabledAgents.filter((a) => a.kind === 'utility');
+  const defaultAgentEnabled =
+    props.defaultAgent !== null &&
+    runtimeAgents.some((a) => a.id === props.defaultAgent);
 
   useEffect(() => {
     if (!spawnMenuOpen) return;
@@ -312,8 +326,8 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   }, [spawnMenuOpen]);
 
   const onPlusClick = (): void => {
-    if (w.agents.length <= 1) {
-      props.onSpawn(w.id, { agent: w.agents[0] ?? 'claude' });
+    if (defaultAgentEnabled && props.defaultAgent) {
+      props.onSpawn(w.id, { agent: props.defaultAgent });
       return;
     }
     setSpawnMenuOpen((v) => !v);
@@ -321,12 +335,14 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
 
   const onMenuPick = (agentId: string): void => {
     setSpawnMenuOpen(false);
+    const agent = props.agents.find((a) => a.id === agentId);
+    if (agent && agent.kind !== 'utility') props.onSetDefaultAgent(agentId);
     props.onSpawn(w.id, { agent: agentId });
   };
 
   const plusTitle =
-    w.agents.length === 1
-      ? `spawn a new ${agentLabel(w.agents[0]!, props.agents)} session`
+    defaultAgentEnabled && props.defaultAgent
+      ? `spawn a new ${agentLabel(props.defaultAgent, props.agents)} session`
       : 'spawn a new session…';
 
   const statusClass = hasRunning
@@ -372,14 +388,14 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
             <Pencil size={12} strokeWidth={2} />
           </button>
         )}
-        {w.agents.length > 0 && (
+        {enabledAgents.length > 0 && (
           <div className="relative shrink-0">
             <button
               ref={plusBtnRef}
               type="button"
               className={rowAction()}
               title={plusTitle}
-              aria-haspopup={w.agents.length > 1}
+              aria-haspopup="menu"
               aria-expanded={spawnMenuOpen}
               onClick={onPlusClick}
             >
@@ -391,17 +407,34 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
                 role="menu"
                 className="absolute right-0 top-full mt-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
               >
-                {w.agents.map((agentId) => (
-                  <li key={agentId}>
+                {runtimeAgents.map((agent) => (
+                  <li key={agent.id}>
                     <button
                       type="button"
                       role="menuitem"
                       className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-text transition-colors hover:bg-bg-tertiary"
-                      onClick={() => onMenuPick(agentId)}
+                      onClick={() => onMenuPick(agent.id)}
                     >
                       <Plus size={12} strokeWidth={2.25} className="shrink-0 text-text-muted" />
-                      <span className="flex-1 truncate">{agentLabel(agentId, props.agents)}</span>
-                      <span className="text-[10px] font-mono text-text-muted/60">{agentPrefix(agentId)}</span>
+                      <span className="flex-1 truncate">{agent.displayName}</span>
+                      <span className="text-[10px] font-mono text-text-muted/60">{agentPrefix(agent.id)}</span>
+                    </button>
+                  </li>
+                ))}
+                {runtimeAgents.length > 0 && utilityAgents.length > 0 && (
+                  <li aria-hidden="true" className="my-1 border-t border-border/70" />
+                )}
+                {utilityAgents.map((agent) => (
+                  <li key={agent.id}>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text"
+                      onClick={() => onMenuPick(agent.id)}
+                    >
+                      <Terminal size={12} strokeWidth={2.25} className="shrink-0 text-text-muted" />
+                      <span className="flex-1 truncate">{agent.displayName}</span>
+                      <span className="text-[10px] font-mono text-text-muted/60">{agentPrefix(agent.id)}</span>
                     </button>
                   </li>
                 ))}

--- a/ui/src/components/workspace/WorkspacesSidebar.tsx
+++ b/ui/src/components/workspace/WorkspacesSidebar.tsx
@@ -32,6 +32,7 @@ export function WorkspacesSidebar() {
         workspaces={ctx.workspaces}
         templates={ctx.templates}
         agents={ctx.agents}
+        defaultAgent={ctx.defaultAgent}
         listError={ctx.listError}
         hasLoaded={ctx.hasLoaded}
         selection={selection}
@@ -43,6 +44,7 @@ export function WorkspacesSidebar() {
           openOrFocus({ kind: 'workspace', params: { wsId, sessionId } })
         }}
         onSpawn={(wsId, opts?: SpawnOpts) => void ctx.spawn(wsId, opts)}
+        onSetDefaultAgent={(agent) => void ctx.setDefaultAgent(agent)}
         onPauseSession={(wsId, id) => void ctx.pauseSession(wsId, id)}
         onResumeSession={(wsId, id) => void ctx.resumeSession(wsId, id)}
         onDeleteSession={(wsId, id) => ctx.requestDeleteSession(wsId, id)}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -38,7 +38,7 @@ export interface Workspace {
    * launcher applies migrations. Agent self-upgrade is the resolution path.
    */
   readonly upgradeAvailable?: { from: string; to: string } | null;
-  /** Adapter ids enabled for this workspace; agents[0] is the default for `+`. */
+  /** Adapter ids enabled for this workspace. Default runtime lives in user config. */
   readonly agents: readonly string[];
   /**
    * Single ordered list of all session records (running + paused) the
@@ -175,6 +175,7 @@ export interface AgentCapabilities {
 export interface AgentInfo {
   readonly id: string;
   readonly displayName: string;
+  readonly kind?: 'agent' | 'utility';
   readonly capabilities: AgentCapabilities;
   /**
    * Whether the runtime's CLI was found on the host PATH. Backend-probed per
@@ -191,6 +192,27 @@ export async function listAgents(): Promise<AgentInfo[]> {
   if (!res.ok) throw new Error(`list agents failed: ${res.status}`);
   const body = (await res.json()) as { agents: AgentInfo[] };
   return body.agents;
+}
+
+export async function getWorkspaceDefaultAgent(): Promise<string | null> {
+  const res = await fetch('/api/config/workspace-default-agent');
+  if (!res.ok) return null;
+  const body = (await res.json()) as { agent?: string | null };
+  return body.agent ?? null;
+}
+
+export async function setWorkspaceDefaultAgent(agent: string | null): Promise<string | null> {
+  const res = await fetch('/api/config/workspace-default-agent', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agent }),
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => '');
+    throw new Error(`set workspace default agent failed: ${res.status} ${msg}`);
+  }
+  const body = (await res.json()) as { agent?: string | null };
+  return body.agent ?? null;
 }
 
 // ── sessions ─────────────────────────────────────────────────────────────────
@@ -229,7 +251,7 @@ export interface SpawnedSession {
 export interface SpawnOptions {
   /** `'last'` → adapter-specific "continue", any UUID → adapter-specific resume-by-id. */
   readonly resume?: 'last' | string;
-  /** Override workspace's default adapter (workspace.agents[0]). */
+  /** Explicit runtime/tool adapter for this spawn. */
   readonly agent?: string;
   /**
    * Seed a FRESH session with a first user message — the quick-chat launch

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -33,12 +33,14 @@ import { ConfirmDialog } from '../components/ConfirmDialog'
 import { WorkspaceAIConfigModal } from '../components/workspace/WorkspaceAIConfigModal'
 import {
   deleteSession as apiDeleteSession,
+  getWorkspaceDefaultAgent,
   listAgents,
   listTemplates,
   listWorkspaces,
   pauseSession as apiPauseSession,
   quickChat as apiQuickChat,
   resumeSession as apiResumeSession,
+  setWorkspaceDefaultAgent as apiSetWorkspaceDefaultAgent,
   spawnSession,
   updateWorkspaceMetadata,
   type AgentInfo,
@@ -61,6 +63,7 @@ interface WorkspacesContextValue {
   readonly workspaces: readonly Workspace[]
   readonly templates: readonly TemplateInfo[]
   readonly agents: readonly AgentInfo[]
+  readonly defaultAgent: string | null
   readonly listError: string | null
   /** True once the first workspaces-list fetch has resolved. Until then an
    *  empty list means "not loaded yet", not "no workspaces" — the sidebar shows
@@ -74,6 +77,7 @@ interface WorkspacesContextValue {
   readonly templatesLoaded: boolean
   refresh(): void
   spawn(wsId: string, opts?: SpawnOpts): Promise<void>
+  setDefaultAgent(agent: string | null): Promise<void>
   /**
    * Quick-chat launch: reuse-or-create the chat workspace, spawn a fresh
    * session seeded with `prompt`, and focus into its terminal tab. Rejects on
@@ -101,6 +105,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   const [templates, setTemplates] = useState<TemplateInfo[]>([])
   const [templatesLoaded, setTemplatesLoaded] = useState(false)
   const [agents, setAgents] = useState<AgentInfo[]>([])
+  const [defaultAgent, setDefaultAgentState] = useState<string | null>(null)
   const [listError, setListError] = useState<string | null>(null)
   // Don't reconcile orphan tabs until we've successfully fetched the
   // workspaces list at least once — otherwise the initial `[]` looks like
@@ -141,6 +146,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
       .catch(() => setTemplates([]))
       .finally(() => setTemplatesLoaded(true))
     void listAgents().then(setAgents).catch(() => setAgents([]))
+    void getWorkspaceDefaultAgent().then(setDefaultAgentState).catch(() => setDefaultAgentState(null))
   }, [])
 
   // Reconcile tabs against the workspaces list. If a workspace or session
@@ -201,6 +207,11 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
     },
     [refresh, openOrFocus],
   )
+
+  const setDefaultAgent = useCallback(async (agent: string | null): Promise<void> => {
+    const saved = await apiSetWorkspaceDefaultAgent(agent)
+    setDefaultAgentState(saved)
+  }, [])
 
   const quickChat = useCallback(
     async (prompt: string, agent?: string, credentialSlug?: string, targetWsId?: string): Promise<void> => {
@@ -328,11 +339,13 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         workspaces,
         templates,
         agents,
+        defaultAgent,
         listError,
         hasLoaded,
         templatesLoaded,
         refresh,
         spawn,
+        setDefaultAgent,
         quickChat,
         pauseSession,
         resumeSession,

--- a/ui/src/hooks/useCreateWorkspace.ts
+++ b/ui/src/hooks/useCreateWorkspace.ts
@@ -45,12 +45,12 @@ interface UseCreateWorkspaceState {
  * agent-checkbox state + submit handler. They've drifted in small ways
  * over time; bundling here keeps them in lockstep.
  *
- * Agent policy lives in the backend (`WorkspaceCreator.create`): every
- * workspace gets every registered adapter enabled, template-headed so
- * `agents[0]` (the new-session default) follows template intent. This hook
- * sends NO agent set, so the form, quick-chat, and headless all converge on
- * that one source of truth — it used to expand the list here, which silently
- * left backend-only callers (quick-chat) on the bare-defaultAgents set.
+ * Adapter enablement policy lives in the backend (`WorkspaceCreator.create`):
+ * every workspace gets every registered adapter enabled, with template
+ * defaults kept only as ordering hints. The user's default runtime is stored
+ * separately; `shell` is a utility adapter, not a default workload candidate.
+ * This hook sends NO agent set, so the form, quick-chat, and headless all
+ * converge on that one source of truth.
  */
 export function useCreateWorkspace(opts: UseCreateWorkspaceOpts): UseCreateWorkspaceState {
   const [tag, setTag] = useState('')

--- a/ui/src/pages/AutomationApiSection.tsx
+++ b/ui/src/pages/AutomationApiSection.tsx
@@ -90,7 +90,7 @@ the watchlist — movers, gaps, and overnight headlines that move the thesis.`}<
         <Block>{`POST /api/workspaces/:id/headless
 {
   "prompt": "<the instruction for the run>",
-  "agent": "claude",      // optional; defaults to the workspace's default agent
+  "agent": "claude",      // optional; uses the saved default agent runtime
   "timeoutMs": 1800000,   // optional
   "wait": false           // optional; true = block and return the run's result
 }

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -340,7 +340,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                   className="inline-flex items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2 py-1 rounded-md transition-colors hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {SelectedIcon ? <SelectedIcon className="w-3 h-3" /> : null}
-                  {selectedInfo?.displayName ?? t('chatLanding.defaultAgent')}
+                  {selectedInfo?.displayName ?? t('chatLanding.selectAgent')}
                   <ChevronDown className="w-3 h-3 opacity-60" />
                 </button>
                 {agentMenuOpen && targetCliAgents.length > 0 && (

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -56,11 +56,11 @@ const AGENT_ICONS: Record<string, LucideIcon> = {
  * session seeded with that message (the agent CLI opens already working on it),
  * and focuses into the session's terminal tab. No template/CLI pickers in the
  * way — the bottom row shows the workspace type (Chat) and a small runtime
- * picker (the four agent CLIs), defaulting to the workspace's default agent.
+ * picker for agent CLIs. Shell is not an agent runtime and is excluded here.
  */
 export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: string } } }) {
   const { t } = useTranslation()
-  const { quickChat, agents, workspaces } = useWorkspaces()
+  const { quickChat, agents, workspaces, defaultAgent, setDefaultAgent } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
 
   // Targeted launch: the chat sidebar's per-workspace "+" routes here with a
@@ -72,7 +72,10 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
 
   // The selectable agent runtimes = the agent CLIs (the bare shell has no agent
   // loop, so it can't be seeded with a first message).
-  const cliAgents = agents.filter((a) => a.id !== 'shell')
+  const cliAgents = agents.filter((a) => a.kind !== 'utility')
+  const targetCliAgents = targetWs
+    ? cliAgents.filter((a) => targetWs.agents.includes(a.id))
+    : cliAgents
 
   const [value, setValue] = useState('')
   const [launching, setLaunching] = useState(false)
@@ -85,24 +88,28 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   // Backend probes the host PATH and reports `installed` per agent. Treat a
   // missing value as installed (older backend / don't gate on a stale shape).
   const isInstalled = (a: { installed?: boolean }) => a.installed !== false
-  const anyInstalled = cliAgents.some(isInstalled)
+  const anyInstalled = targetCliAgents.some(isInstalled)
   // Whether the `/agents` fetch has actually landed. Before it does, `agents`
   // is `[]` and `anyInstalled` is falsely false — which would flash the
   // "nothing installed, go install something" nudge on every page load until
   // the request resolves. The backend registers claude/codex/opencode/pi/shell
   // unconditionally, so a loaded list always has ≥1 CLI agent; an empty
-  // `cliAgents` means "still loading" (or the fetch failed) — in both cases we
+  // `targetCliAgents` means "still loading" (or the fetch failed) — in both cases we
   // must NOT assert that the host is missing its runtimes.
-  const agentsKnown = cliAgents.length > 0
+  const agentsKnown = targetCliAgents.length > 0
 
-  // Default to the first INSTALLED CLI until the user picks one — so a fresh
-  // box that only has, say, codex doesn't silently default to a missing claude.
-  const firstInstalled = cliAgents.find(isInstalled)
-  // When targeting an existing workspace, default the picker to that
-  // workspace's own agent (the user can still switch).
+  // Prefer the user-level runtime default when it is valid for this target.
+  // Without a saved default, require the user to pick an agent once; the pick is
+  // persisted as the next default runtime.
+  const defaultAgentUsable =
+    defaultAgent !== null &&
+    targetCliAgents.some((a) => a.id === defaultAgent) &&
+    (!targetWs || targetWs.agents.includes(defaultAgent))
+  const selectedAgentUsable =
+    selectedAgent !== null && targetCliAgents.some((a) => a.id === selectedAgent)
   const effectiveAgent =
-    selectedAgent ?? targetWs?.agents[0] ?? firstInstalled?.id ?? cliAgents[0]?.id ?? null
-  const selectedInfo = cliAgents.find((a) => a.id === effectiveAgent) ?? null
+    (selectedAgentUsable ? selectedAgent : null) ?? (defaultAgentUsable ? defaultAgent : null)
+  const selectedInfo = targetCliAgents.find((a) => a.id === effectiveAgent) ?? null
   const SelectedIcon = selectedInfo ? AGENT_ICONS[selectedInfo.id] : undefined
   // Surface install guidance when the chosen runtime isn't on PATH.
   const selectedMissing = selectedInfo != null && !isInstalled(selectedInfo)
@@ -188,7 +195,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     openOrFocus({ kind: 'settings', params: { category: 'ai-provider' } })
   }
 
-  const canSend = value.trim().length > 0 && !launching && !noCreds
+  const canSend = value.trim().length > 0 && !launching && !noCreds && effectiveAgent !== null
 
   // Close the agent menu on an outside click.
   useEffect(() => {
@@ -205,6 +212,10 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   const submit = async () => {
     const prompt = value.trim()
     if (!prompt || launching) return
+    if (effectiveAgent === null) {
+      setAgentMenuOpen(true)
+      return
+    }
     // A loginless runtime with no configured provider can't launch — send the
     // user to set one up instead of spawning an agent that'll die immediately.
     if (noCreds) {
@@ -218,7 +229,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
       // stays open in the background, so clear it for next time.
       await quickChat(
         prompt,
-        effectiveAgent ?? undefined,
+        effectiveAgent,
         needsCred ? (effectiveCred ?? undefined) : undefined,
         targetWsId,
       )
@@ -322,7 +333,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 <button
                   type="button"
                   onClick={() => setAgentMenuOpen((o) => !o)}
-                  disabled={cliAgents.length === 0}
+                  disabled={targetCliAgents.length === 0}
                   aria-haspopup="menu"
                   aria-expanded={agentMenuOpen}
                   aria-label={t('chatLanding.selectAgent')}
@@ -332,12 +343,12 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                   {selectedInfo?.displayName ?? t('chatLanding.defaultAgent')}
                   <ChevronDown className="w-3 h-3 opacity-60" />
                 </button>
-                {agentMenuOpen && cliAgents.length > 0 && (
+                {agentMenuOpen && targetCliAgents.length > 0 && (
                   <div
                     role="menu"
                     className="absolute bottom-full left-0 mb-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
                   >
-                    {cliAgents.map((a) => {
+                    {targetCliAgents.map((a) => {
                       const Icon = AGENT_ICONS[a.id]
                       const active = a.id === effectiveAgent
                       const missing = !isInstalled(a)
@@ -348,6 +359,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                           role="menuitem"
                           onClick={() => {
                             setSelectedAgent(a.id)
+                            void setDefaultAgent(a.id)
                             setAgentMenuOpen(false)
                           }}
                           className={`w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : missing ? 'text-text-muted/60' : 'text-text'}`}

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -16,7 +16,7 @@
  * keeps running on the server. Use the sidebar's × to actually delete.
  */
 
-import { useEffect } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Plus } from 'lucide-react'
 import '@xterm/xterm/css/xterm.css'
 
@@ -47,6 +47,38 @@ export function WorkspacePage({ spec, visible }: Props) {
   const activeRecord = sessionId
     ? sessions.find((s) => s.id === sessionId) ?? null
     : null
+  const [spawnMenuOpen, setSpawnMenuOpen] = useState(false)
+  const spawnMenuRef = useRef<HTMLDivElement | null>(null)
+  const runtimeAgents = useMemo(() => {
+    if (!workspace) return []
+    return workspace.agents
+      .map((id) => ctx.agents.find((a) => a.id === id))
+      .filter((a): a is NonNullable<typeof a> => !!a && a.kind !== 'utility')
+  }, [ctx.agents, workspace])
+  const utilityAgents = useMemo(() => {
+    if (!workspace) return []
+    return workspace.agents
+      .map((id) => ctx.agents.find((a) => a.id === id))
+      .filter((a): a is NonNullable<typeof a> => !!a && a.kind === 'utility')
+  }, [ctx.agents, workspace])
+  const defaultAgentEnabled =
+    ctx.defaultAgent !== null &&
+    workspace?.agents.includes(ctx.defaultAgent) === true &&
+    runtimeAgents.some((a) => a.id === ctx.defaultAgent)
+
+  const spawnWithAgent = async (agentId: string, saveDefault: boolean): Promise<void> => {
+    setSpawnMenuOpen(false)
+    if (saveDefault) await ctx.setDefaultAgent(agentId)
+    await ctx.spawn(wsId, { agent: agentId })
+  }
+
+  const spawnDefault = (): void => {
+    if (defaultAgentEnabled && ctx.defaultAgent) {
+      void ctx.spawn(wsId, { agent: ctx.defaultAgent })
+      return
+    }
+    setSpawnMenuOpen((v) => !v)
+  }
 
   // Cmd+T / Ctrl+T: spawn fresh session in this workspace; only when this
   // tab is visible, to avoid double-spawns when multiple workspace tabs are
@@ -59,11 +91,29 @@ export function WorkspacePage({ spec, visible }: Props) {
       if (e.shiftKey || e.altKey) return
       e.preventDefault()
       e.stopPropagation()
-      void ctx.spawn(wsId, {})
+      spawnDefault()
     }
     document.addEventListener('keydown', handler, { capture: true })
     return () => document.removeEventListener('keydown', handler, { capture: true })
-  }, [visible, ctx, wsId])
+  }, [visible, ctx, wsId, defaultAgentEnabled])
+
+  useEffect(() => {
+    if (!spawnMenuOpen) return
+    const onDocClick = (e: MouseEvent): void => {
+      if (spawnMenuRef.current?.contains(e.target as Node)) return
+      setSpawnMenuOpen(false)
+    }
+    const onEsc = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setSpawnMenuOpen(false)
+    }
+    const tid = setTimeout(() => document.addEventListener('click', onDocClick), 0)
+    document.addEventListener('keydown', onEsc)
+    return () => {
+      clearTimeout(tid)
+      document.removeEventListener('click', onDocClick)
+      document.removeEventListener('keydown', onEsc)
+    }
+  }, [spawnMenuOpen])
 
   if (!workspace) {
     return (
@@ -86,15 +136,44 @@ export function WorkspacePage({ spec, visible }: Props) {
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-bg-secondary/30 shrink-0">
         <span className="text-[12px] text-text-muted font-medium">{workspace.tag}</span>
         <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => void ctx.spawn(wsId, {})}
-            className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
-            title="Spawn a fresh session in this workspace (⌘T)"
-          >
-            <Plus size={13} strokeWidth={2.25} aria-hidden="true" />
-            New session
-          </button>
+          <div ref={spawnMenuRef} className="relative">
+            <button
+              type="button"
+              onClick={spawnDefault}
+              className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
+              title="Spawn a fresh session in this workspace (⌘T)"
+            >
+              <Plus size={13} strokeWidth={2.25} aria-hidden="true" />
+              New session
+            </button>
+            {spawnMenuOpen && (
+              <div className="absolute right-0 top-full mt-1 w-44 rounded-md border border-border bg-bg-secondary shadow-lg py-1 z-20">
+                {runtimeAgents.map((agent) => (
+                  <button
+                    key={agent.id}
+                    type="button"
+                    onClick={() => void spawnWithAgent(agent.id, true)}
+                    className="w-full px-3 py-1.5 text-left text-[12px] text-text-muted hover:text-text hover:bg-bg-tertiary"
+                  >
+                    {agent.displayName}
+                  </button>
+                ))}
+                {utilityAgents.length > 0 && runtimeAgents.length > 0 && (
+                  <div className="my-1 border-t border-border" />
+                )}
+                {utilityAgents.map((agent) => (
+                  <button
+                    key={agent.id}
+                    type="button"
+                    onClick={() => void spawnWithAgent(agent.id, false)}
+                    className="w-full px-3 py-1.5 text-left text-[12px] text-text-muted hover:text-text hover:bg-bg-tertiary"
+                  >
+                    {agent.displayName}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
           <WorkspaceFilesToggle />
           <button
             type="button"
@@ -119,7 +198,7 @@ export function WorkspacePage({ spec, visible }: Props) {
           sessions={workspace.sessions}
           label={workspace.tag}
           keyMap={APP_KEY_MAP}
-          onSpawnFresh={() => void ctx.spawn(wsId, {})}
+          onSpawnFresh={spawnDefault}
           onResume={(id) => void ctx.resumeSession(wsId, id)}
           onSelectSession={(id) => {
             // Running session — already alive on the server, just


### PR DESCRIPTION
## Summary
- add a user-level workspace default agent runtime setting and config API
- classify shell as a utility adapter so omitted-agent paths never resolve to shell
- update Workspace/Chat launch UI to require an explicit runtime choice before saving a default
- keep shell available only as an explicit spawn option

## Tests
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm vitest run src/workspaces/workspace-creator.spec.ts src/webui/routes/workspaces-quickchat.spec.ts src/webui/routes/workspaces.spec.ts src/webui/routes/config-workspace-defaults.spec.ts
- pnpm test (sandbox run fails on listen EPERM; escalated run passes: 156 passed, 1 skipped; 2244 tests passed, 6 skipped)