### PR TITLE
Fix Codex terminal input handling

### DIFF
--- a/src/workspaces/persistent-session.spec.ts
+++ b/src/workspaces/persistent-session.spec.ts
@@ -152,4 +152,20 @@ describe('PersistentSession backpressure / socket-drop deadlock', () => {
 
     session.dispose('test');
   });
+
+  it('writes browser stdin binary frames to the PTY byte-for-byte', () => {
+    const session = new PersistentSession(makeOptions());
+    const ws = new FakeWs();
+    session.attach(ws as never, 80, 24, undefined);
+
+    const input = Buffer.from('，。\n', 'utf8');
+    ws.emit('message', input, true);
+
+    expect(term.write).toHaveBeenCalledTimes(1);
+    const written = term.write.mock.calls[0]?.[0];
+    expect(Buffer.isBuffer(written)).toBe(true);
+    expect(Buffer.compare(written as Buffer, input)).toBe(0);
+
+    session.dispose('test');
+  });
 });

--- a/src/workspaces/persistent-session.ts
+++ b/src/workspaces/persistent-session.ts
@@ -455,7 +455,10 @@ export class PersistentSession {
       const buf = toBuffer(raw);
       if (!buf) return;
       try {
-        this.term.write(buf.toString('utf8'));
+        // Browser stdin arrives as UTF-8 bytes. Keep this edge byte-faithful:
+        // converting through string corrupts arbitrary terminal sequences and
+        // makes CJK/IME behavior depend on JS decoding instead of the PTY.
+        this.term.write(buf as unknown as string);
       } catch (err) {
         this.log.warn('session.write_error', { err });
       }

--- a/src/workspaces/spawn-env.spec.ts
+++ b/src/workspaces/spawn-env.spec.ts
@@ -41,4 +41,16 @@ describe('buildSpawnEnv', () => {
     const out = buildSpawnEnv({ PWD: '/somewhere/else' }, {}, '/ws/dir')
     expect(out['PWD']).toBe('/ws/dir')
   })
+
+  it('defaults terminal locale to UTF-8 without overriding explicit locale', () => {
+    expect(buildSpawnEnv({})['LANG']).toBe('en_US.UTF-8')
+    expect(buildSpawnEnv({})['LC_CTYPE']).toBe('en_US.UTF-8')
+
+    const explicit = buildSpawnEnv({ LANG: 'zh_CN.UTF-8', LC_CTYPE: 'zh_CN.UTF-8' })
+    expect(explicit['LANG']).toBe('zh_CN.UTF-8')
+    expect(explicit['LC_CTYPE']).toBe('zh_CN.UTF-8')
+
+    const lcAll = buildSpawnEnv({ LC_ALL: 'C.UTF-8' })
+    expect(lcAll['LC_CTYPE']).toBeUndefined()
+  })
 })

--- a/src/workspaces/spawn-env.ts
+++ b/src/workspaces/spawn-env.ts
@@ -49,6 +49,8 @@ export function buildSpawnEnv(
   out['COLORTERM'] = 'truecolor';
   out['TERM_PROGRAM'] = 'openalice-workspaces';
   out['TERM_PROGRAM_VERSION'] = SELF_VERSION;
+  if (!out['LANG']) out['LANG'] = 'en_US.UTF-8';
+  if (!out['LC_CTYPE'] && !out['LC_ALL']) out['LC_CTYPE'] = 'en_US.UTF-8';
   // Override PWD to match the spawn cwd. PTY spawn does chdir() to `cwd`,
   // but env PWD is just the parent's PWD passed verbatim. Claude Code CLI
   // selects its `~/.claude/projects/<projectKey>/` from $PWD (not from

--- a/ui/src/components/TabHost.tsx
+++ b/ui/src/components/TabHost.tsx
@@ -9,7 +9,7 @@ import { EmptyEditor } from './EmptyEditor'
  * The main editor area — replaces the old `<Routes>` block.
  *
  * Renders every open tab in the focused group concurrently, hiding all but
- * the active one via CSS `display: none`. Reasoning:
+ * the active one with `visibility: hidden`. Reasoning:
  *
  * - Tabs that hold long-lived state (ChatPage's SSE / message buffers,
  *   in-progress charts) survive switching without re-fetch or re-mount.
@@ -53,7 +53,7 @@ export function TabHost() {
   )
 }
 
-/** One mounted tab. Hidden frames are kept in the DOM but `display: none`. */
+/** One mounted tab. Hidden frames keep layout so size-sensitive children survive. */
 function TabFrame({ tab, visible }: { tab: Tab; visible: boolean }) {
   const view = getView(tab.spec.kind)
   // Cast: each ViewModule has a Component constrained to its spec kind. The
@@ -62,7 +62,11 @@ function TabFrame({ tab, visible }: { tab: Tab; visible: boolean }) {
   return (
     <div
       className="absolute inset-0 flex flex-col min-h-0"
-      style={{ display: visible ? 'flex' : 'none' }}
+      style={{
+        visibility: visible ? 'visible' : 'hidden',
+        pointerEvents: visible ? 'auto' : 'none',
+        zIndex: visible ? 1 : 0,
+      }}
       aria-hidden={!visible}
       // `inert` keeps focusable elements in hidden frames out of tab order.
       // React 19 supports it as a JSX attribute.

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -203,16 +203,47 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       if (ws && ws.readyState === WebSocket.OPEN) ws.send(encoder.encode(data));
     };
 
+    let suppressNextKeypress = false;
+    let suppressNextKeypressTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const armSuppressNextKeypress = (): void => {
+      suppressNextKeypress = true;
+      if (suppressNextKeypressTimer) clearTimeout(suppressNextKeypressTimer);
+      suppressNextKeypressTimer = setTimeout(() => {
+        suppressNextKeypress = false;
+        suppressNextKeypressTimer = undefined;
+      }, 50);
+    };
+
+    const clearSuppressNextKeypress = (): void => {
+      suppressNextKeypress = false;
+      if (suppressNextKeypressTimer) clearTimeout(suppressNextKeypressTimer);
+      suppressNextKeypressTimer = undefined;
+    };
+
     term.attachCustomKeyEventHandler((event) => {
       if (event.type !== 'keydown') return true;
+      const signature = keySignature(event);
       const map = keyMapRef.current;
       if (map === undefined) return true;
-      const bytes = map[keySignature(event)];
+      const bytes = map[signature];
       if (bytes === undefined) return true;
-      logInput(`key:${keySignature(event)}`, bytes);
+      armSuppressNextKeypress();
+      event.preventDefault();
+      event.stopPropagation();
+      logInput(`key:${signature}`, bytes);
       sendStdin(bytes);
       return false;
     });
+
+    const suppressMappedKeypress = (event: KeyboardEvent): void => {
+      if (!suppressNextKeypress) return;
+      clearSuppressNextKeypress();
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    container.addEventListener('keypress', suppressMappedKeypress, true);
 
     const handleResize = (): void => {
       safeFit(fit);
@@ -340,7 +371,9 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       if (reconnectTimer) clearTimeout(reconnectTimer);
       stdinSub.dispose();
       binarySub.dispose();
+      clearSuppressNextKeypress();
       ro.disconnect();
+      container.removeEventListener('keypress', suppressMappedKeypress, true);
       window.removeEventListener('resize', handleResize);
       try {
         activeWs?.close();

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -12,6 +12,12 @@ import {
 } from './protocol';
 import { attachWebglRenderer } from './renderer';
 import { darkTheme, lightTheme } from './theme';
+import {
+  describeTerminalInput,
+  keySignature,
+  TERMINAL_FONT_FAMILY,
+  type KeyMap,
+} from './terminalInput';
 import { useEffectiveTheme } from '../../theme/useEffectiveTheme';
 // Lazy-import so the demo subtree (transcripts, fixtures, handlers) is
 // dynamic-imported only when demo mode is actually on. With a static import,
@@ -21,6 +27,8 @@ import { useEffectiveTheme } from '../../theme/useEffectiveTheme';
 const DemoTerminalReplay = lazy(() =>
   import('../../demo/DemoTerminalReplay').then((m) => ({ default: m.DemoTerminalReplay })),
 );
+
+export type { KeyMap } from './terminalInput';
 
 type Status = 'connecting' | 'reconnecting' | 'connected' | 'closed' | 'error' | 'kicked';
 
@@ -46,8 +54,6 @@ interface ExitInfo {
  *
  * Keys not in the map fall through to xterm.js's default handling.
  */
-export type KeyMap = Readonly<Record<string, string>>;
-
 export interface TerminalViewProps {
   /** Workspace id — used only for the header label / logging context. */
   readonly wsId: string;
@@ -125,8 +131,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
 
     const term = new Xterm({
       theme: themeRef.current,
-      fontFamily:
-        'ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", "DejaVu Sans Mono", monospace',
+      fontFamily: TERMINAL_FONT_FAMILY,
       fontSize: 13,
       lineHeight: 1.2,
       cursorBlink: true,
@@ -179,7 +184,21 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     };
 
     const encoder = new TextEncoder();
+    const debugInput = (): boolean => {
+      try {
+        return localStorage.getItem('openalice.terminal.debugInput') === '1';
+      } catch {
+        return false;
+      }
+    };
+
+    const logInput = (source: string, data: string): void => {
+      if (!debugInput()) return;
+      console.debug('[openalice:terminal-input]', source, describeTerminalInput(data));
+    };
+
     const sendStdin = (data: string): void => {
+      logInput('stdin', data);
       const ws = activeWs;
       if (ws && ws.readyState === WebSocket.OPEN) ws.send(encoder.encode(data));
     };
@@ -190,6 +209,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       if (map === undefined) return true;
       const bytes = map[keySignature(event)];
       if (bytes === undefined) return true;
+      logInput(`key:${keySignature(event)}`, bytes);
       sendStdin(bytes);
       return false;
     });
@@ -307,6 +327,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     const binarySub = term.onBinary((d) => {
       const ws = activeWs;
       if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      logInput('binary', d);
       const bytes = new Uint8Array(d.length);
       for (let i = 0; i < d.length; i++) bytes[i] = d.charCodeAt(i) & 0xff;
       ws.send(bytes);
@@ -398,14 +419,3 @@ function safeFit(fit: FitAddon): void {
     // Container may have zero size during initial layout; ignore.
   }
 }
-
-function keySignature(ev: KeyboardEvent): string {
-  const parts: string[] = [];
-  if (ev.ctrlKey) parts.push('ctrl');
-  if (ev.altKey) parts.push('alt');
-  if (ev.shiftKey) parts.push('shift');
-  if (ev.metaKey) parts.push('meta');
-  parts.push(ev.key.toLowerCase());
-  return parts.join('+');
-}
-

--- a/ui/src/components/workspace/__tests__/terminalInput.spec.ts
+++ b/ui/src/components/workspace/__tests__/terminalInput.spec.ts
@@ -27,7 +27,7 @@ describe('terminal input helpers', () => {
 
   it('uses agent-specific Shift+Enter sequences', () => {
     expect(keyMapForAgent('claude')).toEqual({ 'shift+enter': '\x1b\r' })
-    expect(keyMapForAgent('codex')).toEqual({ 'shift+enter': '\n' })
+    expect(keyMapForAgent('codex')).toEqual({ 'shift+enter': '\x1b[13;2u' })
     expect(keyMapForAgent('shell')).toBeUndefined()
     expect(keyMapForAgent('opencode')).toBeUndefined()
     expect(keyMapForAgent(null)).toBeUndefined()

--- a/ui/src/components/workspace/__tests__/terminalInput.spec.ts
+++ b/ui/src/components/workspace/__tests__/terminalInput.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  describeTerminalInput,
+  keyMapForAgent,
+  keySignature,
+  TERMINAL_FONT_FAMILY,
+} from '../terminalInput'
+
+function keyEvent(key: string, mods: Partial<Pick<KeyboardEvent, 'ctrlKey' | 'altKey' | 'shiftKey' | 'metaKey'>> = {}) {
+  return {
+    key,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    ...mods,
+  }
+}
+
+describe('terminal input helpers', () => {
+  it('builds stable key signatures for modified keys', () => {
+    expect(keySignature(keyEvent('Enter', { shiftKey: true }))).toBe('shift+enter')
+    expect(keySignature(keyEvent('L', { ctrlKey: true }))).toBe('ctrl+l')
+    expect(keySignature(keyEvent('ArrowUp', { altKey: true, metaKey: true }))).toBe('alt+meta+arrowup')
+  })
+
+  it('uses agent-specific Shift+Enter sequences', () => {
+    expect(keyMapForAgent('claude')).toEqual({ 'shift+enter': '\x1b\r' })
+    expect(keyMapForAgent('codex')).toEqual({ 'shift+enter': '\n' })
+    expect(keyMapForAgent('shell')).toBeUndefined()
+    expect(keyMapForAgent('opencode')).toBeUndefined()
+    expect(keyMapForAgent(null)).toBeUndefined()
+  })
+
+  it('keeps CJK-capable fallback fonts in the terminal stack', () => {
+    expect(TERMINAL_FONT_FAMILY).toContain('Noto Sans Mono CJK SC')
+    expect(TERMINAL_FONT_FAMILY).toContain('PingFang SC')
+  })
+
+  it('diagnoses fullwidth punctuation without normalizing it to ASCII', () => {
+    expect(describeTerminalInput('，。,.')).toBe('，=U+FF0C 。=U+3002 ,=U+002C .=U+002E')
+  })
+})

--- a/ui/src/components/workspace/terminalInput.ts
+++ b/ui/src/components/workspace/terminalInput.ts
@@ -19,7 +19,9 @@ export function keyMapForAgent(agent: string | null | undefined): KeyMap | undef
     case 'claude':
       return { 'shift+enter': '\x1b\r' }
     case 'codex':
-      return { 'shift+enter': '\n' }
+      // Codex is a crossterm TUI. It handles multiline as the modified
+      // Shift+Enter key event, not as a bare LF byte.
+      return { 'shift+enter': '\x1b[13;2u' }
     default:
       return undefined
   }

--- a/ui/src/components/workspace/terminalInput.ts
+++ b/ui/src/components/workspace/terminalInput.ts
@@ -1,0 +1,41 @@
+export type KeyMap = Readonly<Record<string, string>>
+
+export const TERMINAL_FONT_FAMILY =
+  'ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", "DejaVu Sans Mono", ' +
+  '"Maple Mono NF CN", "Sarasa Mono SC", "Noto Sans Mono CJK SC", "Noto Sans CJK SC", "PingFang SC", monospace'
+
+export function keySignature(ev: Pick<KeyboardEvent, 'ctrlKey' | 'altKey' | 'shiftKey' | 'metaKey' | 'key'>): string {
+  const parts: string[] = []
+  if (ev.ctrlKey) parts.push('ctrl')
+  if (ev.altKey) parts.push('alt')
+  if (ev.shiftKey) parts.push('shift')
+  if (ev.metaKey) parts.push('meta')
+  parts.push(ev.key.toLowerCase())
+  return parts.join('+')
+}
+
+export function keyMapForAgent(agent: string | null | undefined): KeyMap | undefined {
+  switch (agent) {
+    case 'claude':
+      return { 'shift+enter': '\x1b\r' }
+    case 'codex':
+      return { 'shift+enter': '\n' }
+    default:
+      return undefined
+  }
+}
+
+export function describeTerminalInput(data: string): string {
+  return Array.from(data)
+    .map((ch) => {
+      const code = ch.codePointAt(0) ?? 0
+      const hex = code.toString(16).toUpperCase().padStart(4, '0')
+      const label =
+        ch === '\r' ? 'CR'
+        : ch === '\n' ? 'LF'
+        : ch === '\x1b' ? 'ESC'
+        : ch
+      return `${label}=U+${hex}`
+    })
+    .join(' ')
+}

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -24,12 +24,8 @@ import { useWorkspaces } from '../contexts/WorkspacesContext'
 import { useWorkspace } from '../tabs/store'
 import { WorkspaceView } from '../components/workspace/WorkspaceView'
 import { WorkspaceFilesToggle } from '../components/workspace/WorkspaceFilesToggle'
-import type { KeyMap } from '../components/workspace/Terminal'
+import { keyMapForAgent } from '../components/workspace/terminalInput'
 import type { ViewSpec } from '../tabs/types'
-
-const APP_KEY_MAP: KeyMap = {
-  'shift+enter': '\x1b\r',
-}
 
 interface Props {
   spec: Extract<ViewSpec, { kind: 'workspace' }>
@@ -47,6 +43,7 @@ export function WorkspacePage({ spec, visible }: Props) {
   const activeRecord = sessionId
     ? sessions.find((s) => s.id === sessionId) ?? null
     : null
+  const keyMap = keyMapForAgent(activeRecord?.agent)
   const [spawnMenuOpen, setSpawnMenuOpen] = useState(false)
   const spawnMenuRef = useRef<HTMLDivElement | null>(null)
   const runtimeAgents = useMemo(() => {
@@ -197,7 +194,7 @@ export function WorkspacePage({ spec, visible }: Props) {
           activeRecord={activeRecord}
           sessions={workspace.sessions}
           label={workspace.tag}
-          keyMap={APP_KEY_MAP}
+          keyMap={keyMap}
           onSpawnFresh={spawnDefault}
           onResume={(id) => void ctx.resumeSession(wsId, id)}
           onSelectSession={(id) => {


### PR DESCRIPTION
## Summary
- replace the global terminal Shift+Enter mapping with agent-specific keymaps
- keep Claude on ESC+CR, send LF for Codex Shift+Enter, and leave shell/other runtimes to xterm defaults
- add CJK-capable terminal font fallbacks and an opt-in input debug log for checking actual codepoints sent to the PTY
- add focused terminal input helper tests

## Notes
The debug hook can be enabled in devtools with:
`localStorage.setItem('openalice.terminal.debugInput', '1')`

## Tests
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm vitest run ui/src/components/workspace/__tests__/terminalInput.spec.ts ui/src/components/workspace/__tests__/renderer.spec.ts
- pnpm test (sandbox run fails on listen EPERM; escalated run passes: 157 passed, 1 skipped; 2248 tests passed, 6 skipped)