### PR TITLE
[codex] Downgrade inactive tab runtime

### DIFF
--- a/ui/src/components/MeasuredChartFrame.tsx
+++ b/ui/src/components/MeasuredChartFrame.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+interface ChartFrameSize {
+  width: number
+  height: number
+}
+
+interface MeasuredChartFrameProps {
+  className?: string
+  children: ReactNode | ((size: ChartFrameSize) => ReactNode)
+}
+
+/**
+ * Recharts' ResponsiveContainer warns when it mounts before its parent has a
+ * positive layout box. Flex/grid pages can briefly report width/height <= 0
+ * during route transitions, so gate chart mounting on a measured frame.
+ */
+export function MeasuredChartFrame({ className, children }: MeasuredChartFrameProps) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [size, setSize] = useState<ChartFrameSize | null>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const measure = () => {
+      const rect = el.getBoundingClientRect()
+      setSize(rect.width > 0 && rect.height > 0
+        ? { width: Math.floor(rect.width), height: Math.floor(rect.height) }
+        : null)
+    }
+
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  return (
+    <div ref={ref} className={className}>
+      {size ? (typeof children === 'function' ? children(size) : children) : null}
+    </div>
+  )
+}

--- a/ui/src/components/TabHost.tsx
+++ b/ui/src/components/TabHost.tsx
@@ -6,20 +6,14 @@ import { TabStrip } from './TabStrip'
 import { EmptyEditor } from './EmptyEditor'
 
 /**
- * The main editor area — replaces the old `<Routes>` block.
+ * Main content host.
  *
- * Renders every open tab in the focused group concurrently, hiding all but
- * the active one via CSS `display: none`. Reasoning:
- *
- * - Tabs that hold long-lived state (ChatPage's SSE / message buffers,
- *   in-progress charts) survive switching without re-fetch or re-mount.
- * - Components don't need to be aware of "tab-hosted vs route-hosted" —
- *   they just render normally; the host controls visibility.
- *
- * The `visible` prop threaded into each tab's component lets surfaces that
- * care (ChatPage's catch-up scroll) react to becoming visible.
- *
- * Mobile (< md): single-tab mode. Only the active tab renders, no strip.
+ * Tabs are now lightweight navigation history, not VS-Code-style runtime
+ * containers. By default only the active tab is mounted; inactive tabs keep
+ * their ViewSpec in the tab store but release component state, timers, charts,
+ * terminals, and other DOM-owned resources. A view can opt into
+ * `lifecycle: 'keep-mounted'` in tabs/registry when it genuinely needs a live
+ * background DOM.
  */
 export function TabHost() {
   const tabIds = useWorkspace((state) =>
@@ -42,9 +36,11 @@ export function TabHost() {
             const tab = tabsMap[id]
             if (!tab) return null
             const isActive = id === activeTabId
+            const view = getView(tab.spec.kind)
+            const keepMounted = view.lifecycle === 'keep-mounted'
             // Mobile: only render the active tab to avoid blowing memory and
             // because we don't even have a strip to switch tabs from.
-            if (!isDesktop && !isActive) return null
+            if (!isActive && (!isDesktop || !keepMounted)) return null
             return <TabFrame key={id} tab={tab} visible={isActive} />
           })
         )}
@@ -53,7 +49,7 @@ export function TabHost() {
   )
 }
 
-/** One mounted tab. Hidden frames are kept in the DOM but `display: none`. */
+/** One mounted view frame. Hidden frames exist only for keep-mounted views. */
 function TabFrame({ tab, visible }: { tab: Tab; visible: boolean }) {
   const view = getView(tab.spec.kind)
   // Cast: each ViewModule has a Component constrained to its spec kind. The
@@ -61,6 +57,8 @@ function TabFrame({ tab, visible }: { tab: Tab; visible: boolean }) {
   const Component = view.Component as React.ComponentType<{ spec: typeof tab.spec; visible: boolean }>
   return (
     <div
+      data-view-frame={tab.spec.kind}
+      data-view-visible={visible ? 'true' : 'false'}
       className="absolute inset-0 flex flex-col min-h-0"
       style={{ display: visible ? 'flex' : 'none' }}
       aria-hidden={!visible}

--- a/ui/src/components/market/SeriesCard.tsx
+++ b/ui/src/components/market/SeriesCard.tsx
@@ -1,4 +1,4 @@
-import { LineChart, Line, ResponsiveContainer, YAxis } from 'recharts'
+import { LineChart, Line, YAxis } from 'recharts'
 import type { MacroSeriesCard } from '../../api/reference'
 
 /**
@@ -25,12 +25,10 @@ export function SeriesCard({ card, label, emptyText }: { card: MacroSeriesCard; 
         </div>
         <div className="w-28 h-9">
           {!empty && (
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={card.points} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
-                <YAxis hide domain={['dataMin', 'dataMax']} />
-                <Line type="monotone" dataKey="value" stroke="var(--color-accent)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
-              </LineChart>
-            </ResponsiveContainer>
+            <LineChart width={112} height={36} data={card.points} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
+              <YAxis hide domain={['dataMin', 'dataMax']} />
+              <Line type="monotone" dataKey="value" stroke="var(--color-accent)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
+            </LineChart>
           )}
         </div>
       </div>

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { LineChart, Line, ResponsiveContainer, YAxis, XAxis, Tooltip } from 'recharts'
+import { LineChart, Line, YAxis, XAxis, Tooltip } from 'recharts'
 import { useReferenceBoard } from '../components/market/useReferenceBoard'
 import { BoardMeta } from '../components/market/BoardMeta'
 import { PageHeader } from '../components/PageHeader'
 import { CenteredLoading } from '../components/StateViews'
 import { SeriesCard } from '../components/market/SeriesCard'
+import { MeasuredChartFrame } from '../components/MeasuredChartFrame'
 import {
   referenceApi,
   type MoversBoard, type MoverRow, type ReferenceMeta, type CalendarBoard,
@@ -423,9 +424,9 @@ function TermCurveCard({ curve }: { curve: TermCurve }) {
         )}
         {regime && <span className="text-[11px] uppercase tracking-wide text-text-muted/70">{regime}</span>}
       </div>
-      <div className="h-40">
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartData} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
+      <MeasuredChartFrame className="h-40">
+        {({ width, height }) => (
+          <LineChart width={width} height={height} data={chartData} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
             <XAxis dataKey="label" tick={{ fontSize: 10, fill: '#7d8590' }} stroke="#7d8590" />
             <YAxis domain={['dataMin', 'dataMax']} tick={{ fontSize: 10, fill: '#7d8590' }} stroke="#7d8590" width={70}
               tickFormatter={(v: number) => v.toLocaleString('en-US')} />
@@ -436,8 +437,8 @@ function TermCurveCard({ curve }: { curve: TermCurve }) {
             />
             <Line type="monotone" dataKey="price" stroke="var(--color-accent)" strokeWidth={1.5} dot={{ r: 2.5 }} isAnimationActive={false} />
           </LineChart>
-        </ResponsiveContainer>
-      </div>
+        )}
+      </MeasuredChartFrame>
       <div className="flex flex-wrap gap-1.5">
         {curve.points.map((p) => (
           <span key={p.expiration} className="text-[11px] px-1.5 py-0.5 rounded bg-bg-tertiary/60 font-mono" title={`${p.daysToExpiry ?? '—'}d`}>
@@ -575,9 +576,9 @@ function ChokepointCard({ curve }: { curve: ShippingCurve }) {
           </span>
         )}
       </div>
-      <div className="h-28">
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+      <MeasuredChartFrame className="h-28">
+        {({ width, height }) => (
+          <LineChart width={width} height={height} data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
             <XAxis dataKey="label" tick={{ fontSize: 9, fill: '#7d8590' }} stroke="#7d8590" minTickGap={28} />
             <YAxis tick={{ fontSize: 9, fill: '#7d8590' }} stroke="#7d8590" width={36}
               tickFormatter={(v: number) => v.toFixed(1)} domain={['auto', 'auto']} />
@@ -587,8 +588,8 @@ function ChokepointCard({ curve }: { curve: ShippingCurve }) {
             />
             <Line type="monotone" dataKey="mt" stroke="var(--color-accent)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
           </LineChart>
-        </ResponsiveContainer>
-      </div>
+        )}
+      </MeasuredChartFrame>
     </div>
   )
 }

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -48,12 +48,24 @@ interface ViewProps<K extends ViewKind> {
   visible: boolean
 }
 
+export type ViewLifecycle = 'active-only' | 'keep-mounted'
+
 export interface ViewModule<K extends ViewKind> {
   kind: K
   /** Tab title — derived from spec each render so e.g. channel renames propagate. */
   title(spec: Extract<ViewSpec, { kind: K }>, ctx: TitleCtx): string
   /** URL the active tab projects onto window.location (via replaceState). */
   toUrl(spec: Extract<ViewSpec, { kind: K }>): string
+  /**
+   * Runtime policy while the view's tab is not focused.
+   *
+   * Default is `active-only`: the tab store remembers navigation state, but
+   * the component unmounts when hidden. This matches the post-editor-tabs UI
+   * where tabs are lightweight history/bookmarks, not VS-Code-style runtime
+   * containers. Use `keep-mounted` only for views that truly need a live DOM
+   * while backgrounded.
+   */
+  lifecycle?: ViewLifecycle
   /** The actual page component. Ignores `visible` unless it needs catch-up behaviour. */
   Component: ComponentType<ViewProps<K>>
 }


### PR DESCRIPTION
## Summary

- Treat inactive tabs as lightweight navigation state by default instead of keeping every opened view mounted in the DOM.
- Add an explicit `lifecycle: 'keep-mounted'` escape hatch for views that truly need a live background DOM.
- Fix Recharts layout warnings in market views by avoiding `ResponsiveContainer` for fixed microcharts and measuring larger chart frames before rendering.

## Why

The frontend has moved away from a VS Code-style editor surface toward a workflow app where the tab strip is hidden by default. Keeping every opened tab mounted still carried the old runtime cost: hidden charts, terminals, timers, and page state remained alive in the background.

This change makes tab history cheap while leaving a clear opt-in for the rare view that needs to stay mounted.

## Validation

- `cd ui && npx tsc -b`
- Browser console check on `/market`, `/market/boards/macro`, `/market/boards/term-structure`, `/market/boards/shipping`, `/automation/*`, and `/chat`
- `pnpm test`