### PR TITLE
Add workspace settings metadata editor

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -25,7 +25,7 @@ import { ConfirmDialog } from '../ConfirmDialog'
 import { deleteWorkspace, type SessionRecord, type Workspace } from './api'
 import { CreateWorkspaceDialog } from './CreateWorkspaceDialog'
 import { SessionRow } from './Sidebar'
-import { workspaceDisplayName, workspaceDisplayTitle } from './display'
+import { workspaceDisplayTitle } from './display'
 
 const CHAT_TEMPLATE = 'chat'
 
@@ -35,7 +35,6 @@ const DAILY_TAG_RE = /^chat-[a-z]{3}\d{1,2}$/
 /** Friendly label for a chat workspace: Today / Yesterday / "Jun 14" for daily
  *  buckets, the raw tag for user-named workspaces. */
 function chatLabel(w: Workspace, todayLabel: string, yesterdayLabel: string): string {
-  if (w.displayName?.trim()) return workspaceDisplayName(w)
   if (!DAILY_TAG_RE.test(w.tag)) return w.tag
   const created = new Date(w.createdAt)
   if (Number.isNaN(created.getTime())) return w.tag
@@ -253,6 +252,8 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
   const hasRunning = w.sessions.some((s) => s.state === 'running')
   const [expanded, setExpanded] = useState(true)
   const isSelected = props.selection?.wsId === w.id && props.selection.sessionId === null
+  const displayName = w.displayName?.trim()
+  const subtitle = displayName && displayName !== props.label ? displayName : null
 
   const statusClass = hasRunning
     ? 'bg-green'
@@ -292,8 +293,15 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
           className="flex-1 min-w-0 flex items-center gap-2 text-left"
         >
           <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusClass}`} aria-hidden="true" />
-          <span className="truncate font-medium" title={workspaceDisplayTitle(w)}>
-            {props.label}
+          <span className="min-w-0 flex-1">
+            <span className="block truncate font-medium" title={workspaceDisplayTitle(w)}>
+              {props.label}
+            </span>
+            {subtitle && (
+              <span className="block truncate text-[11px] leading-3 text-text-muted/65" title={subtitle}>
+                {subtitle}
+              </span>
+            )}
           </span>
           {w.sessions.length > 0 && (
             <span className="text-[11px] text-text-muted/45 tabular-nums shrink-0">
@@ -323,8 +331,8 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               props.onConfigure()
             }}
             className="w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-secondary"
-            title={t('settings.category.aiProvider')}
-            aria-label={t('settings.category.aiProvider')}
+            title="Workspace settings"
+            aria-label="Workspace settings"
           >
             <SettingsIcon size={12} strokeWidth={2} />
           </button>

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -446,7 +446,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
           <button
             type="button"
             className={`${rowAction()} opacity-0 group-hover:opacity-100 focus-visible:opacity-100`}
-            title="configure AI provider for this workspace"
+            title="Configure this workspace"
             onClick={() => props.onConfigureWorkspace?.(w.id)}
           >
             <SettingsIcon size={12} strokeWidth={2} />

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -1,14 +1,16 @@
 /**
- * Per-workspace AI provider config modal.
+ * Per-workspace settings modal.
  *
  * Workspaces are VS-Code-style "open folders" — each owns its CLI config
  * files (.claude/settings.local.json, .codex/config.toml + env.json). This
- * modal is the visual editor for those files. Files are the source of
- * truth; the modal reads + writes via the workspace API. Restart any open
- * sessions for changes to take effect (env is read at CLI startup).
+ * modal is the visual editor for those files plus the workspace's
+ * self-describing metadata. Files are the source of truth; the modal reads +
+ * writes via the workspace API. Restart any open sessions for AI-provider
+ * changes to take effect (env is read at CLI startup).
  */
 
 import { useEffect, useMemo, useState } from 'react'
+import { Bot, Info, Settings, X } from 'lucide-react'
 import {
   getAgentConfig,
   listCredentials,
@@ -24,6 +26,7 @@ import { api, type Preset, type WireShape } from '../../api'
 import { baseUrlToVendor, vendorPreset, presetModels, pickAgentWire } from '../../lib/presetHelpers'
 import { ModelCombobox } from '../credentials/PresetFields'
 import { useTestGate } from '../../lib/useTestGate'
+import { useWorkspaces } from '../../contexts/workspaces-context'
 
 // The agent tab implies a default vendor when the baseUrl alone can't say:
 // claude → Anthropic, codex → OpenAI; opencode/pi run anything so they have no
@@ -44,6 +47,7 @@ const inputClass =
   'w-full bg-bg-secondary border border-border rounded-md px-3 py-2 text-[13px] text-text placeholder:text-text-muted/60 focus:outline-none focus:border-accent'
 
 type Tab = 'claude' | 'codex' | 'opencode' | 'pi'
+type Section = 'general' | 'ai'
 
 const TAB_LABEL: Record<Tab, string> = { claude: 'Claude Code', codex: 'Codex', opencode: 'opencode', pi: 'Pi' }
 
@@ -117,7 +121,16 @@ function testKey(form: FormState, agent: AgentId): string {
 }
 
 export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
+  const { workspaces, saveWorkspaceMetadata } = useWorkspaces()
+  const workspace = workspaces.find((w) => w.id === wsId) ?? null
+  const workspaceLabel = workspace?.displayName?.trim() || workspace?.tag || wsId
+  const [section, setSection] = useState<Section>('general')
   const [tab, setTab] = useState<Tab>('claude')
+  const [metadataFormWsId, setMetadataFormWsId] = useState<string | null>(null)
+  const [displayName, setDisplayName] = useState('')
+  const [description, setDescription] = useState('')
+  const [metadataSaving, setMetadataSaving] = useState(false)
+  const [metadataSavedFlash, setMetadataSavedFlash] = useState(false)
   const [credentials, setCredentials] = useState<SavedCredential[]>([])
   const [bundle, setBundle] = useState<AgentConfigBundle | null>(null)
   const [claudeForm, setClaudeForm] = useState<FormState>(EMPTY_FORM)
@@ -140,6 +153,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
   const opencodeGate = useTestGate()
   const piGate = useTestGate()
   const [presets, setPresets] = useState<Preset[]>([])
+
+  useEffect(() => {
+    if (metadataFormWsId === wsId) return
+    if (!workspace) return
+    setDisplayName(workspace.displayName ?? '')
+    setDescription(workspace.description ?? '')
+    setMetadataFormWsId(wsId)
+  }, [metadataFormWsId, workspace, wsId])
 
   useEffect(() => {
     void Promise.all([listCredentials(), getAgentConfig(wsId)])
@@ -280,6 +301,34 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
   const canTest =
     !!form.baseUrl.trim() && !!form.apiKey.trim() && !!form.model.trim()
 
+  const stableTag = workspace?.tag || wsId
+  const savedDisplayName = workspace?.displayName ?? ''
+  const savedDescription = workspace?.description ?? ''
+  const normalizedDisplayName = displayName.trim()
+  const normalizedDescription = description.trim()
+  const metadataDirty =
+    normalizedDisplayName !== savedDisplayName ||
+    normalizedDescription !== savedDescription
+
+  const handleSaveMetadata = async () => {
+    setError(null)
+    setMetadataSaving(true)
+    try {
+      await saveWorkspaceMetadata(wsId, {
+        displayName: normalizedDisplayName || null,
+        description: normalizedDescription || null,
+      })
+      setDisplayName(normalizedDisplayName)
+      setDescription(normalizedDescription)
+      setMetadataSavedFlash(true)
+      setTimeout(() => setMetadataSavedFlash(false), 1800)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setMetadataSaving(false)
+    }
+  }
+
   const handleTest = () => {
     if (!canTest) return
     // The result is bound to `key` (the current form's tested fields). If the
@@ -309,19 +358,143 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
       onMouseDown={handleBackdropMouseDown}
     >
       <div
-        className="bg-bg border border-border rounded-xl shadow-2xl w-full max-w-xl max-h-[85vh] flex flex-col"
+        className="bg-bg border border-border rounded-xl shadow-2xl w-[calc(100vw-24px)] max-w-3xl max-h-[85vh] flex flex-col"
         onMouseDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
-          <h2 className="text-[15px] font-semibold text-text">Workspace AI Provider</h2>
-          <button onClick={onClose} className="text-text-muted hover:text-text transition-colors">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
+          <div className="min-w-0">
+            <h2 className="text-[15px] font-semibold text-text">Workspace Settings</h2>
+            <p className="mt-0.5 truncate text-[11px] text-text-muted">{workspaceLabel}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-text-muted hover:bg-bg-tertiary hover:text-text transition-colors"
+            aria-label="Close workspace settings"
+            title="Close"
+          >
+            <X size={18} />
           </button>
         </div>
 
+        <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
+          <aside className="flex w-full shrink-0 gap-1 border-b border-border bg-bg-secondary/25 p-2 sm:block sm:w-40 sm:border-b-0 sm:border-r">
+            <button
+              type="button"
+              onClick={() => setSection('general')}
+              className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:w-full ${
+                section === 'general'
+                  ? 'bg-accent/10 text-accent'
+                  : 'text-text-muted hover:bg-bg-tertiary hover:text-text'
+              }`}
+            >
+              <Settings size={15} />
+              <span>General</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setSection('ai')}
+              className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:mt-1 sm:w-full ${
+                section === 'ai'
+                  ? 'bg-accent/10 text-accent'
+                  : 'text-text-muted hover:bg-bg-tertiary hover:text-text'
+              }`}
+            >
+              <Bot size={15} />
+              <span>AI Provider</span>
+            </button>
+          </aside>
+
+          <div className="min-w-0 flex flex-1 flex-col">
+            {section === 'general' && (
+              <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex-1 overflow-y-auto p-4">
+                  <div className="max-w-xl space-y-4">
+                  <div>
+                    <label className="block text-xs font-medium text-text-muted mb-1">Display name</label>
+                    <input
+                      value={displayName}
+                      onChange={(e) => setDisplayName(e.target.value)}
+                      maxLength={80}
+                      placeholder={stableTag}
+                      className={inputClass}
+                    />
+                    <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-text-muted/70">
+                      <span>Shown in the workspace list and tab titles.</span>
+                      <span>{displayName.length}/80</span>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="block text-xs font-medium text-text-muted mb-1">Description</label>
+                    <textarea
+                      value={description}
+                      onChange={(e) => setDescription(e.target.value)}
+                      maxLength={240}
+                      rows={5}
+                      placeholder="Short note for recognizing this workspace."
+                      className={`${inputClass} min-h-28 resize-y leading-relaxed`}
+                    />
+                    <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-text-muted/70">
+                      <span>Shown on workspace overview cards.</span>
+                      <span>{description.length}/240</span>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-border bg-bg-secondary/30 p-3">
+                    <div className="flex items-start gap-2">
+                      <Info size={14} className="mt-0.5 shrink-0 text-text-muted" />
+                      <div className="min-w-0">
+                        <div className="text-[11px] font-medium uppercase tracking-wide text-text-muted">Stable tag</div>
+                        <div className="mt-1 truncate font-mono text-[12px] text-text">{stableTag}</div>
+                        <p className="mt-1 text-[11px] leading-snug text-text-muted/75">
+                          The tag stays stable for paths and launcher bookkeeping; the display name is the human-facing label.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {error && (
+                    <div className="rounded-md border border-red/40 bg-red/10 text-red text-[12px] px-3 py-2">
+                      {error}
+                    </div>
+                  )}
+                  {metadataSavedFlash && (
+                    <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
+                      Saved to <code className="font-mono text-[11.5px]">.alice/workspace.json</code>.
+                    </div>
+                  )}
+                  </div>
+                </div>
+                <div className="flex flex-col gap-2 border-t border-border bg-bg-secondary/30 p-3 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-[11px] text-text-muted/75">
+                    Stored in <code className="font-mono text-[11.5px]">.alice/workspace.json</code>.
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      disabled={metadataSaving}
+                      className="px-3 py-2 rounded-md text-text-muted hover:text-text text-[13px] disabled:opacity-40"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleSaveMetadata}
+                      disabled={metadataSaving || !metadataDirty}
+                      className="px-4 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
+                    >
+                      {metadataSaving ? 'Saving…' : 'Save'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {section === 'ai' && (
+              <>
         {/* Tabs */}
         <div className="flex border-b border-border bg-bg-secondary/50">
           {(['claude', 'codex', 'opencode', 'pi'] as const).map((id) => (
@@ -597,7 +770,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between gap-2 p-3 border-t border-border bg-bg-secondary/30">
+        <div className="flex flex-col gap-2 p-3 border-t border-border bg-bg-secondary/30 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex gap-2">
             <button
               onClick={handleReset}
@@ -607,7 +780,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
               Reset to global default
             </button>
           </div>
-          <div className="flex gap-2">
+          <div className="flex justify-end gap-2">
             <button
               onClick={onClose}
               disabled={saving}
@@ -636,6 +809,10 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
               >
                 {saving ? 'Saving…' : 'Save'}
               </button>
+            )}
+          </div>
+        </div>
+              </>
             )}
           </div>
         </div>

--- a/ui/src/components/workspace/WorkspaceFilesToggle.tsx
+++ b/ui/src/components/workspace/WorkspaceFilesToggle.tsx
@@ -6,7 +6,7 @@ import { useWorkspaceSidePanels } from '../../live/workspace-side-panels'
 /**
  * Top-bar toggle for the workspace right pane (the Files panel). One click
  * folds the whole column away so the terminal gets full width, instead of
- * leaving a narrow always-on column. Lives next to "AI Provider" in
+ * leaving a narrow always-on column. Lives next to "Settings" in
  * WorkspacePage's header; replaces the old Layout popover.
  *
  * State is user-level + persisted (fold it once, it stays folded) — see

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -367,9 +367,11 @@ export async function deleteWorkspace(id: string): Promise<boolean> {
   return res.ok;
 }
 
+export type WorkspaceMetadataPatch = { displayName?: string | null; description?: string | null };
+
 export async function updateWorkspaceMetadata(
   id: string,
-  metadata: { displayName?: string; description?: string },
+  metadata: WorkspaceMetadataPatch,
 ): Promise<Workspace> {
   const res = await fetch(`/api/workspaces/${encodeURIComponent(id)}/metadata`, {
     method: 'PATCH',

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -239,13 +239,23 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
     [refresh, openOrFocus],
   )
 
-  const renameWorkspace = useCallback(
-    async (wsId: string, displayName: string): Promise<void> => {
-      const updated = await updateWorkspaceMetadata(wsId, { displayName })
+  const saveWorkspaceMetadata = useCallback(
+    async (
+      wsId: string,
+      metadata: { displayName?: string | null; description?: string | null },
+    ): Promise<void> => {
+      const updated = await updateWorkspaceMetadata(wsId, metadata)
       setWorkspaces((prev) => prev.map((w) => (w.id === wsId ? updated : w)))
       void refresh()
     },
     [refresh],
+  )
+
+  const renameWorkspace = useCallback(
+    async (wsId: string, displayName: string): Promise<void> => {
+      await saveWorkspaceMetadata(wsId, { displayName })
+    },
+    [saveWorkspaceMetadata],
   )
 
   const deleteSession = useCallback(
@@ -302,6 +312,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         resumeSession,
         requestDeleteSession,
         openAgentConfig: (wsId: string) => setConfiguringWsId(wsId),
+        saveWorkspaceMetadata,
         renameWorkspace,
       }}
     >

--- a/ui/src/contexts/workspaces-context.ts
+++ b/ui/src/contexts/workspaces-context.ts
@@ -30,6 +30,10 @@ export interface WorkspacesContextValue {
   resumeSession(wsId: string, sessionId: string): Promise<void>
   requestDeleteSession(wsId: string, sessionId: string): void
   openAgentConfig(wsId: string): void
+  saveWorkspaceMetadata(
+    wsId: string,
+    metadata: { displayName?: string | null; description?: string | null },
+  ): Promise<void>
   renameWorkspace(wsId: string, displayName: string): Promise<void>
 }
 

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw'
 import { demoChatWorkspace, demoWorkspaces, demoTemplates } from '../fixtures/workspaces'
 import { demoWorkspaceFiles } from '../fixtures/inbox'
+import type { WorkspaceMetadataPatch } from '../../components/workspace/api'
 
 export const workspacesHandlers = [
   http.get('/api/workspaces', () => HttpResponse.json({ workspaces: demoWorkspaces })),
@@ -12,6 +13,28 @@ export const workspacesHandlers = [
   ),
   http.delete('/api/workspaces/:id', () => HttpResponse.json(true)),
   http.post('/api/workspaces/:id/stop', () => HttpResponse.json(true)),
+  http.patch('/api/workspaces/:id/metadata', async ({ params, request }) => {
+    const workspace = demoWorkspaces.find((w) => w.id === String(params.id))
+    if (!workspace) return HttpResponse.json({ error: 'not_found' }, { status: 404 })
+    const mutableWorkspace = workspace as { displayName?: string; description?: string }
+
+    const body = (await request.json().catch(() => ({}))) as WorkspaceMetadataPatch
+    if ('displayName' in body) {
+      if (body.displayName == null || body.displayName.trim() === '') {
+        delete mutableWorkspace.displayName
+      } else {
+        mutableWorkspace.displayName = body.displayName.trim()
+      }
+    }
+    if ('description' in body) {
+      if (body.description == null || body.description.trim() === '') {
+        delete mutableWorkspace.description
+      } else {
+        mutableWorkspace.description = body.description.trim()
+      }
+    }
+    return HttpResponse.json({ workspace })
+  }),
 
   http.get('/api/workspaces/templates', () => HttpResponse.json({ templates: demoTemplates })),
   http.get('/api/workspaces/templates/:name/readme', () =>

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -176,13 +176,13 @@ export function WorkspacePage({ spec, visible }: Props) {
             type="button"
             onClick={() => ctx.openAgentConfig(wsId)}
             className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
-            title="Configure this workspace's AI provider (claude / codex)"
+            title="Configure this workspace"
           >
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="12" cy="12" r="3" />
               <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
             </svg>
-            AI Provider
+            Settings
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- turn the workspace gear modal into Workspace Settings with General and AI Provider sections
- add General fields for workspace display name and description, saved through the existing metadata PATCH endpoint
- show chat workspace display names under the date label when present
- update workspace settings entry labels and keep the demo metadata PATCH handler in sync

Closes #385

## Validation
- cd ui && npx tsc -b
- npx tsc --noEmit
- pnpm test
- git diff --check
- checked http://localhost:5173/chat in the in-app browser: General opens by default, AI Provider still renders the existing provider config, and the chat sidebar keeps the date label as the primary row