### PR TITLE
[codex] Update external PR contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,17 +13,39 @@ We actively welcome issues of all kinds:
 
 The more detail you provide, the faster we can act on it. Screenshots, logs, and steps to reproduce are always helpful.
 
-## Pull Requests — Not Accepted
+## Pull Requests — Welcome as Proposals
 
-**We do not accept external pull requests.** This is not a reflection on the quality of contributions — it's a security decision.
+External pull requests are welcome. We read them carefully and treat good PRs as
+high-signal contributions to the project.
 
-OpenAlice is a trading agent that executes real financial operations. Every line of code that runs has direct access to exchange accounts and API keys. Accepting external code — even well-intentioned code — introduces supply chain risk that we cannot afford. A single malicious dependency update, a subtle logic change in order execution, or a backdoor in a utility function could result in real financial loss.
+That said, we still do **not directly merge external PR branches**. OpenAlice is
+a trading agent that can connect to real broker accounts and API keys, so every
+line of code that runs has a security and financial-risk surface. The project is
+also still early: large architectural changes happen often, and maintainers need
+to keep authorship and integration responsibility tight while those boundaries
+are moving.
 
-We review and implement all changes internally to maintain full control over the security surface.
+In practice:
 
-## How to Contribute Without Code
+- Open a PR when you have a concrete fix, design, refactor, or implementation
+  idea.
+- Explain the problem, the tradeoffs, and why the approach fits OpenAlice.
+- Maintainers may use the PR as a reference, adapt it, or reimplement the idea
+  internally before it lands.
+- If your PR meaningfully shapes the project, we credit you in
+  [`CONTRIBUTORS.md`](./CONTRIBUTORS.md). That public credit is the contribution
+  record for externally proposed work, even when the final code is integrated by
+  maintainers.
 
-The best way to help is to **open an issue**. If you've found a bug or have an idea, file it — we read every issue and often ship fixes the same day. Your feedback directly shapes the roadmap.
+This policy is not about contribution quality. It is about keeping the trading
+security surface controlled while still recognizing the people whose ideas,
+reports, and PRs move the project forward.
+
+## Other Ways to Contribute
+
+Issues are still very welcome. If you've found a bug or have an idea, file it —
+we read every issue and often ship fixes quickly. Screenshots, logs, repro steps,
+broker/account mode, operating system, and expected-vs-actual behavior all help.
 
 ## Security Issues
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,9 +14,10 @@ work left a mark on it, you belong here.
   📖 docs · 🛡️ security · 🌍 translation · 💻 code _(rare — reimplemented with
   your consent)_
 - **How to earn one:** open an
-  [issue](https://github.com/TraderAlice/OpenAlice/issues) with an idea, a
-  report, or a design. If it lands in the project, we add you. Think we missed
-  crediting you? Say so in an issue or on Discord — we'll fix it.
+  [issue](https://github.com/TraderAlice/OpenAlice/issues) or PR with an idea,
+  report, design, or implementation proposal. If it lands in the project, we add
+  you. Think we missed crediting you? Say so in an issue or on Discord — we'll
+  fix it.
 - **Standouts (⭐):** a few people go notably above and beyond — high-signal,
   consistent, often right. They sit at the top.
 

--- a/README.md
+++ b/README.md
@@ -515,8 +515,9 @@ Stuck? Here's the recommended path, roughly in order:
 
 OpenAlice is sharper for the people who dig into it with us — the bugs they
 catch, the ideas they push, the UX edges they notice, the designs and reviews
-they bring. High-signal issues count here: if a report or suggestion changes
-the product, it gets credited. The people who've left a mark:
+they bring. High-signal issues and PR proposals count here: if a report,
+suggestion, or implementation proposal changes the product, it gets credited.
+The people who've left a mark:
 
 <!-- Standouts (⭐) first. Avatars come free from https://github.com/<handle>.png :
      <a href="https://github.com/HANDLE"><img src="https://github.com/HANDLE.png" width="56" height="56" alt="@HANDLE" /></a> -->


### PR DESCRIPTION
## Summary

- Reframe `CONTRIBUTING.md` so external PRs are welcomed as proposal/reference contributions.
- Clarify that OpenAlice still does not directly merge external PR branches because of trading security risk and the project’s early-stage architecture churn.
- Update contributor recognition text in `CONTRIBUTORS.md` and the README so valuable PR proposals are credited alongside high-signal issues.

## Validation

- `git diff --check -- CONTRIBUTING.md CONTRIBUTORS.md README.md`
