### PR TITLE
[codex] polish responsive navigation surfaces

### DIFF
--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -160,10 +160,8 @@ const NAV_SECTIONS: NavSection[] = [
 // ==================== ActivityBar ====================
 
 /**
- * Linear-style left nav. 200px wide on desktop; on mobile (<md) it
- * slides in over the page from the left as a 280px drawer (matching
- * the secondary drawer so a drill-in doesn't jump width), on desktop
- * it's a static column. The recessed-rail look comes from bg-tertiary
+ * Linear-style left nav. Mobile uses a drawer; desktop keeps a compact
+ * text rail. The recessed-rail look comes from bg-tertiary
  * (one elevation step up from the secondary Sidebar and the base main
  * pane) — rail → sidebar → main read as three distinct tiers. Top
  * section (no header) is the pinned-nav block — Chat, Inbox,
@@ -200,7 +198,7 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
        *  page with backdrop. Desktop: static column flush left. */}
       <aside
         className={`
-          w-[280px] md:w-[200px] h-full flex flex-col shrink-0
+          w-[280px] md:w-[188px] h-full flex flex-col shrink-0
           bg-bg-tertiary
           border-r border-border/80
           fixed z-50 top-0 left-0 transition-transform duration-200
@@ -292,7 +290,7 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
                           type="button"
                           onClick={handleClick}
                           title={t(item.labelKey)}
-                          className={`relative flex items-center gap-3 px-3 py-1.5 rounded-md text-[13px] transition-colors text-left ${
+                          className={`relative flex min-h-[34px] items-center gap-3 rounded-md px-3 py-1.5 text-[13px] transition-colors text-left ${
                             isActive
                               ? 'bg-accent-dim text-text'
                               : 'text-text-muted hover:text-text hover:bg-overlay'
@@ -385,9 +383,10 @@ function SectionHeader({
         <button
           type="button"
           onClick={onToggleCollapse}
-          className="flex-1 flex items-center gap-1.5 py-1 text-[12px] font-semibold text-text-muted/75 hover:text-text-muted transition-colors text-left"
+          className="flex-1 flex min-h-7 items-center gap-1.5 py-1 text-[12px] font-semibold text-text-muted/75 hover:text-text-muted transition-colors text-left"
           aria-expanded={!isCollapsed}
           aria-controls={controlsId}
+          title={label}
         >
           <ChevronDown
             size={12}
@@ -403,7 +402,7 @@ function SectionHeader({
           <button
             type="button"
             onClick={() => setHintOpen((o) => !o)}
-            className={`flex items-center justify-center p-0.5 transition-colors ${
+            className={`flex min-h-7 min-w-7 items-center justify-center p-0.5 transition-colors ${
               hintOpen ? 'text-text-muted' : 'text-text-muted/50 hover:text-text-muted'
             }`}
             aria-label={t('nav.about', { label })}

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -161,7 +161,7 @@ function ToggleBtn({
       title={title}
       aria-label={title}
       aria-pressed={active}
-      className={`flex items-center justify-center w-6 h-6 transition-colors ${
+      className={`flex items-center justify-center w-8 h-8 transition-colors ${
         active ? 'bg-bg-tertiary text-text' : 'text-text-muted/60 hover:text-text hover:bg-bg-tertiary/50'
       }`}
     >
@@ -241,7 +241,7 @@ function ClusterRow({
           onClick()
         }
       }}
-      className={`group relative flex items-center gap-1.5 pl-3 pr-3 py-1.5 cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
+      className={`group relative grid min-h-11 grid-cols-[auto_minmax(0,1fr)] gap-x-1.5 gap-y-0.5 pl-3 pr-3 py-1.5 cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
         active ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary/50'
       }`}
     >
@@ -250,12 +250,12 @@ function ClusterRow({
       )}
       <span
         aria-hidden
-        className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-accent' : 'bg-transparent'}`}
+        className={`mt-[7px] shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-accent' : 'bg-transparent'}`}
       />
-      <span className={`flex-1 truncate text-[11px] ${unread ? 'text-text-muted' : 'text-text-muted/70'}`}>
+      <span className={`min-w-0 truncate text-[11px] leading-5 ${unread ? 'text-text-muted' : 'text-text-muted/70'}`}>
         {previewForEntry(entry)}
       </span>
-      <span className="shrink-0 text-[10px] text-text-muted/50 tabular-nums">
+      <span className="col-start-2 text-[10px] text-text-muted/50 tabular-nums">
         {formatRelativeTime(entry.ts)}
       </span>
     </div>
@@ -320,7 +320,7 @@ function TimeRow({
           onClick()
         }
       }}
-      className={`group relative flex flex-col gap-0.5 px-3 py-2 cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
+      className={`group relative flex min-h-14 flex-col gap-0.5 px-3 py-2 cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
         active ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary/50'
       }`}
     >

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -512,7 +512,21 @@ function WikilinkPicker({
  * server-returned detail — authoritative, refetch-free). Scheduling/agent/firing
  * markers stay read-only (they're driven by frontmatter the agent owns).
  */
-export function IssueDetail({ wsId, id }: { wsId: string; id: string }) {
+interface IssueDetailProps {
+  wsId: string
+  id: string
+  backLabel?: string
+  onBack?: () => void
+  onOpenIssue?: (ref: WikilinkIssueRef) => void
+}
+
+export function IssueDetail({
+  wsId,
+  id,
+  backLabel = 'Issues',
+  onBack,
+  onOpenIssue,
+}: IssueDetailProps) {
   const { data, error, loading, mutate } = useIssueDetail(wsId, id)
   const { data: board } = useIssues()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
@@ -531,9 +545,14 @@ export function IssueDetail({ wsId, id }: { wsId: string; id: string }) {
 
   const gotoIssue = useCallback(
     (ref: WikilinkIssueRef) => {
+      if (onOpenIssue) {
+        onOpenIssue(ref)
+        return
+      }
+      setSidebar('issue')
       openOrFocus({ kind: 'issue-detail', params: { wsId: ref.wsId, id: ref.id } })
     },
-    [openOrFocus],
+    [onOpenIssue, openOrFocus, setSidebar],
   )
 
   // Open the Inbox at a specific entry (the issue→inbox cross-link). Mirrors the
@@ -601,10 +620,17 @@ export function IssueDetail({ wsId, id }: { wsId: string; id: string }) {
   const backToBoard = (
     <button
       type="button"
-      onClick={() => openOrFocus({ kind: 'issue', params: {} })}
+      onClick={() => {
+        if (onBack) {
+          onBack()
+          return
+        }
+        setSidebar('issue')
+        openOrFocus({ kind: 'issue', params: {} })
+      }}
       className="mb-4 inline-flex items-center gap-1.5 text-xs text-muted transition-colors hover:text-text"
     >
-      <ArrowLeft size={13} /> Issues
+      <ArrowLeft size={13} /> {backLabel}
     </button>
   )
 

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -234,10 +234,13 @@ function InvalidWorkspaces({ workspaces }: { workspaces: IssueWorkspace[] }) {
 export function IssuesBoard() {
   const { data, error, loading } = useIssues()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
+  const setSidebar = useWorkspace((s) => s.setSidebar)
   const [collapsed, setCollapsed] = useState<Set<IssueStatus>>(new Set())
 
-  const openRow = (row: BoardRow) =>
+  const openRow = (row: BoardRow) => {
+    setSidebar('issue')
     openOrFocus({ kind: 'issue-detail', params: { wsId: row.wsId, id: row.issue.id } })
+  }
 
   const toggle = (status: IssueStatus) =>
     setCollapsed((prev) => {

--- a/ui/src/components/SidebarRow.tsx
+++ b/ui/src/components/SidebarRow.tsx
@@ -53,7 +53,7 @@ export function SidebarRow({ label, active = false, onClick, icon, trail, title,
           onClick()
         }
       }}
-      className={`group relative flex items-center gap-1.5 px-3 py-1.5 text-[13px] cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
+      className={`group relative flex min-h-10 items-center gap-1.5 px-3 py-2 text-[13px] cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
         active
           ? 'bg-bg-tertiary text-text'
           : 'text-text hover:bg-bg-tertiary/50'

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -39,7 +39,7 @@ export function ThemeToggle() {
       onClick={cycle}
       title={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
       aria-label={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
-      className="relative flex w-full items-center gap-3 rounded-md px-3 py-1.5 text-left text-[13px] text-text-muted transition-colors hover:bg-overlay hover:text-text"
+      className="relative flex min-h-[34px] w-full items-center gap-3 rounded-md px-3 py-1.5 text-left text-[13px] text-text-muted transition-colors hover:bg-overlay hover:text-text"
     >
       <span className="relative flex h-5 w-5 shrink-0 items-center justify-center">
         <Icon size={16} strokeWidth={1.75} />

--- a/ui/src/components/TrackedSidebar.tsx
+++ b/ui/src/components/TrackedSidebar.tsx
@@ -4,9 +4,9 @@ import { TrendingUp, Hash } from 'lucide-react'
 import { entitiesLive } from '../live/entities'
 import { useTrackedSelection } from '../live/tracked-selection'
 import { useWorkspace } from '../tabs/store'
-import { SidebarRow } from './SidebarRow'
 import { SidebarSectionHeader } from './SidebarSectionHeader'
 import { SidebarRowsSkeleton } from './StateViews'
+import type { EntityListItem } from '../api/entities'
 
 /**
  * Tracked sidebar — the watchlist. A flat list of entities (assets + topics),
@@ -21,6 +21,7 @@ export function TrackedSidebar() {
   const selected = useTrackedSelection((s) => s.selectedName)
   const select = useTrackedSelection((s) => s.select)
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
+  const setSidebar = useWorkspace((s) => s.setSidebar)
 
   // Default-select the first entity once, on first non-empty load. Latch so
   // the user's later picks are never overridden.
@@ -31,6 +32,13 @@ export function TrackedSidebar() {
     if (!selected) select(entities[0]!.name)
     everSelectedRef.current = true
   }, [entities, selected, select])
+
+  useEffect(() => {
+    if (!selected) return
+    const selectedRow = [...document.querySelectorAll<HTMLElement>('[data-tracked-entity]')]
+      .find((el) => el.dataset.trackedEntity === selected)
+    selectedRow?.scrollIntoView({ block: 'center' })
+  }, [selected, entities])
 
   if (loading && entities.length === 0) {
     return (
@@ -53,33 +61,18 @@ export function TrackedSidebar() {
     )
   }
 
-  const renderRow = (e: (typeof entities)[number]) => {
-    const Icon = e.type === 'asset' ? TrendingUp : Hash
-    const openEntity = () => {
-      select(e.name)
-      openOrFocus({ kind: 'tracked', params: {} })
-    }
-    return (
-      <SidebarRow
-        key={e.name}
-        active={e.name === selected}
-        onClick={openEntity}
-        title={e.description}
-        icon={<Icon size={13} strokeWidth={1.75} className="text-text-muted/70" aria-hidden />}
-        label={<span className="font-mono text-[12px]">{e.name}</span>}
-        trail={
-          e.backlinkCount > 0 ? (
-            <span
-              className="text-[10px] text-text-muted/60 tabular-nums"
-              title={t('tracked.backlinksTooltip', { count: e.backlinkCount })}
-            >
-              {e.backlinkCount}
-            </span>
-          ) : undefined
-        }
-      />
-    )
-  }
+  const renderRow = (entity: EntityListItem) => (
+    <TrackedEntityRow
+      key={entity.name}
+      entity={entity}
+      active={entity.name === selected}
+      onClick={() => {
+        select(entity.name)
+        setSidebar('tracked')
+        openOrFocus({ kind: 'tracked', params: {} })
+      }}
+    />
+  )
 
   // Partition into Assets / Topics so the watchlist reads as a grouped
   // navigator, not one undifferentiated run (newest-first within each).
@@ -87,19 +80,116 @@ export function TrackedSidebar() {
   const topics = entities.filter((e) => e.type !== 'asset')
 
   return (
-    <div className="flex flex-col h-full overflow-y-auto py-1">
+    <div className="flex flex-col h-full overflow-y-auto py-2">
       {assets.length > 0 && (
-        <>
-          <SidebarSectionHeader>{t('tracked.assets')}</SidebarSectionHeader>
-          {assets.map(renderRow)}
-        </>
+        <div className="mb-2">
+          <SidebarSectionHeader trailing={<SectionCount count={assets.length} />}>
+            {t('tracked.assets')}
+          </SidebarSectionHeader>
+          <div className="px-2">
+            {assets.map(renderRow)}
+          </div>
+        </div>
       )}
       {topics.length > 0 && (
-        <>
-          <SidebarSectionHeader>{t('tracked.topics')}</SidebarSectionHeader>
-          {topics.map(renderRow)}
-        </>
+        <div className="mb-2">
+          <SidebarSectionHeader trailing={<SectionCount count={topics.length} />}>
+            {t('tracked.topics')}
+          </SidebarSectionHeader>
+          <div className="px-2">
+            {topics.map(renderRow)}
+          </div>
+        </div>
       )}
     </div>
   )
+}
+
+function SectionCount({ count }: { count: number }) {
+  return (
+    <span className="rounded-full bg-bg-tertiary px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-text-muted/65">
+      {count}
+    </span>
+  )
+}
+
+function TrackedEntityRow({
+  entity,
+  active,
+  onClick,
+}: {
+  entity: EntityListItem
+  active: boolean
+  onClick: () => void
+}) {
+  const { t } = useTranslation()
+  const Icon = entity.type === 'asset' ? TrendingUp : Hash
+  const display = displayName(entity)
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-tracked-entity={entity.name}
+      onClick={onClick}
+      title={entity.description}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }}
+      className={`group relative mb-0.5 grid min-h-[38px] grid-cols-[24px_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2.5 py-1.5 outline-none transition-colors ${
+        active
+          ? 'bg-accent-dim text-text shadow-[inset_2px_0_0_var(--color-accent)]'
+          : 'text-text-muted hover:bg-overlay hover:text-text focus-visible:bg-overlay'
+      }`}
+    >
+      <span
+        className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${
+          active ? 'bg-bg/60 text-accent' : 'bg-bg-tertiary/55 text-text-muted/70 group-hover:text-text-muted'
+        }`}
+        aria-hidden
+      >
+        <Icon size={13} strokeWidth={1.8} />
+      </span>
+
+      <span className="min-w-0">
+        {display.prefix ? (
+          <span className="flex min-w-0 items-baseline gap-1.5">
+            <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-text-muted/55">
+              {display.prefix}
+            </span>
+            <span className={`truncate text-[12.5px] ${active ? 'font-semibold text-text' : 'font-medium'}`}>
+              {display.rest}
+            </span>
+          </span>
+        ) : (
+          <span className={`block truncate text-[12.5px] ${active ? 'font-semibold text-text' : 'font-medium'}`}>
+            {display.rest}
+          </span>
+        )}
+      </span>
+
+      {entity.backlinkCount > 0 && (
+        <span
+          className={`min-w-[20px] rounded-full px-1.5 py-0.5 text-center text-[10px] font-medium tabular-nums ${
+            active ? 'bg-bg/75 text-text-muted' : 'bg-bg-tertiary/70 text-text-muted/65'
+          }`}
+          title={t('tracked.backlinksTooltip', { count: entity.backlinkCount })}
+        >
+          {entity.backlinkCount}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function displayName(entity: EntityListItem): { prefix: string | null; rest: string } {
+  if (entity.type !== 'asset') return { prefix: null, rest: entity.name }
+  const dash = entity.name.indexOf('-')
+  if (dash <= 0 || dash === entity.name.length - 1) return { prefix: null, rest: entity.name }
+  return {
+    prefix: entity.name.slice(0, dash),
+    rest: entity.name.slice(dash + 1),
+  }
 }

--- a/ui/src/components/market/SeriesCard.tsx
+++ b/ui/src/components/market/SeriesCard.tsx
@@ -9,23 +9,23 @@ import type { MacroSeriesCard } from '../../api/reference'
 export function SeriesCard({ card, label, emptyText }: { card: MacroSeriesCard; label: string; emptyText: string }) {
   const empty = card.points.length === 0
   return (
-    <div className="border border-border rounded-md bg-bg-secondary/40 px-3 py-2.5 flex flex-col gap-1.5">
+    <div className="min-w-0 border border-border rounded-md bg-bg-secondary/40 px-3 py-2.5 flex flex-col gap-1.5">
       <div className="flex items-baseline justify-between gap-2">
         <span className="text-[12px] text-text-muted truncate" title={card.id}>{label}</span>
         <span className="text-[10px] text-text-muted/50 shrink-0">{card.latestDate ?? ''}</span>
       </div>
-      <div className="flex items-end justify-between gap-2">
-        <div className="flex items-baseline gap-2">
-          <span className="text-[20px] font-semibold text-text font-mono">{fmtSeriesValue(card, card.latest)}</span>
+      <div className="flex min-w-0 items-end justify-between gap-2">
+        <div className="flex min-w-0 items-baseline gap-2">
+          <span className="shrink-0 text-[20px] font-semibold text-text font-mono">{fmtSeriesValue(card, card.latest)}</span>
           {card.change != null && card.change !== 0 && (
             <span className={`text-[11px] font-mono ${card.change > 0 ? 'text-green' : 'text-red'}`}>
               {card.change > 0 ? '+' : ''}{card.unit === 'count' ? fmtCompactNum(card.change) : card.change.toFixed(2)}
             </span>
           )}
         </div>
-        <div className="w-28 h-9">
+        <div className="h-9 w-24 shrink-0">
           {!empty && (
-            <LineChart width={112} height={36} data={card.points} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
+            <LineChart width={96} height={36} data={card.points} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
               <YAxis hide domain={['dataMin', 'dataMax']} />
               <Line type="monotone" dataKey="value" stroke="var(--color-accent)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
             </LineChart>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -11,17 +11,17 @@
    (ui/src/theme) and mirrored pre-paint by the inline script in index.html.
    ============================================================ */
 @theme {
-  /* Daybreak — light (default). Cream paper · engraved navy · alice-blue. */
-  --color-bg: #f7f4ec;
-  --color-bg-secondary: #f0ebdd;
-  --color-bg-tertiary: #e5decb;
-  --color-border: #d8d0bc;
+  /* Daybreak — light (default). Warm paper · engraved navy · alice-blue. */
+  --color-bg: #fbfaf6;
+  --color-bg-secondary: #f1ede4;
+  --color-bg-tertiary: #e4dccb;
+  --color-border: #d8d2c4;
   --color-text: #1c2a41;
   --color-text-muted: #5e6573;
   --color-accent: #2f62b0;
   --color-accent-dim: rgba(47, 98, 176, 0.14);
   --color-user-bubble: #2f62b0;
-  --color-assistant-bubble: #fbf8f0;
+  --color-assistant-bubble: #fffdf8;
   --color-notification-bg: #fbf1d6;
   --color-notification-border: #c99a2e;
   --color-green: #2e8b6f;
@@ -32,8 +32,8 @@
   /* Elevation overlays — theme-aware "subtle wash on hover / active".
      Light darkens with navy ink; dark lightens with white. Components use
      `bg-overlay` / `bg-overlay-strong`; raw CSS uses `var(--color-overlay)`. */
-  --color-overlay: rgba(28, 42, 65, 0.05);
-  --color-overlay-strong: rgba(28, 42, 65, 0.085);
+  --color-overlay: rgba(28, 42, 65, 0.045);
+  --color-overlay-strong: rgba(28, 42, 65, 0.075);
 
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
     "Microsoft YaHei", "Hiragino Sans GB", "Noto Sans CJK SC", sans-serif;
@@ -131,6 +131,7 @@ body,
 body {
   background: var(--app-bg-wash), var(--color-bg);
   color: var(--color-text);
+  overflow: hidden;
   transition: background-color 0.4s ease, color 0.4s ease;
 }
 

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -261,7 +261,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   }
 
   return (
-    <div className="relative h-full w-full overflow-auto bg-bg flex flex-col items-center justify-center px-4 py-8 md:px-6 md:py-10">
+    <div className="relative h-full w-full overflow-auto bg-bg flex flex-col items-center justify-center px-4 py-6 md:px-6 md:py-10">
       {/* Ask-Alice backdrop — full-bleed, responsive-only layers (gradient wash
           + faint grid). The #302 mock's %-positioned circle / diagonal bars were
           dropped: they drift on portrait and read as pixel-placed art, not a
@@ -272,7 +272,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
         <div className="absolute inset-0 opacity-[0.06] [background-image:linear-gradient(to_right,var(--color-text)_1px,transparent_1px),linear-gradient(to_bottom,var(--color-text)_1px,transparent_1px)] [background-size:96px_96px]" />
       </div>
 
-      <div className="relative z-10 w-full max-w-2xl flex flex-col gap-5">
+      <div className="relative z-10 w-full max-w-2xl flex flex-col gap-4 md:gap-5">
         <div className="text-center space-y-1.5">
           {targetWs ? (
             <>
@@ -297,14 +297,14 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
             </>
           ) : (
             <>
-              <h1 className="text-xl md:text-2xl font-semibold text-text">{t('chatLanding.heading')}</h1>
-              <p className="text-sm text-text-muted">{t('chatLanding.subheading')}</p>
+              <h1 className="text-[19px] md:text-2xl font-semibold text-text leading-tight">{t('chatLanding.heading')}</h1>
+              <p className="text-[13px] md:text-sm text-text-muted leading-relaxed">{t('chatLanding.subheading')}</p>
             </>
           )}
         </div>
 
         <div
-          className={`rounded-2xl px-3 pt-3 pb-2 transition-colors ${
+          className={`rounded-xl md:rounded-2xl px-3 pt-3 pb-2 transition-colors ${
             targetWs
               ? 'bg-accent/[0.04] border border-accent/45 ring-1 ring-accent/15 focus-within:border-accent/70'
               : 'bg-bg-secondary/60 border border-border/60 focus-within:border-accent/50'
@@ -318,12 +318,12 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
             placeholder={t('chatLanding.placeholder')}
             rows={3}
             autoFocus
-            className="w-full bg-transparent resize-none outline-none text-text placeholder:text-text-muted/50 text-[15px] px-2 py-1.5 min-h-[72px] max-h-[40vh]"
+            className="w-full bg-transparent resize-none outline-none text-text placeholder:text-text-muted/50 text-[15px] px-2 py-1.5 min-h-[92px] md:min-h-[72px] max-h-[40vh]"
           />
-          <div className="flex items-center justify-between px-1 pt-1">
-            <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-2 px-1 pt-1 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               {/* Workspace type (Chat). Static — quick-chat always targets the chat template. */}
-              <span className="inline-flex items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2 py-1 rounded-md">
+              <span className="inline-flex min-h-8 items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md">
                 <MessageSquare className="w-3 h-3" />
                 {t('chatLanding.workspaceType')}
               </span>
@@ -337,10 +337,10 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                   aria-haspopup="menu"
                   aria-expanded={agentMenuOpen}
                   aria-label={t('chatLanding.selectAgent')}
-                  className="inline-flex items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2 py-1 rounded-md transition-colors hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md transition-colors hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {SelectedIcon ? <SelectedIcon className="w-3 h-3" /> : null}
-                  {selectedInfo?.displayName ?? t('chatLanding.selectAgent')}
+                  <span className="truncate">{selectedInfo?.displayName ?? t('chatLanding.selectAgent')}</span>
                   <ChevronDown className="w-3 h-3 opacity-60" />
                 </button>
                 {agentMenuOpen && targetCliAgents.length > 0 && (
@@ -386,7 +386,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 <button
                   type="button"
                   onClick={goConfigureProvider}
-                  className="inline-flex items-center gap-1.5 text-[11px] text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2 py-1 rounded-md transition-colors hover:bg-amber-500/20"
+                  className="inline-flex min-h-8 items-center gap-1.5 text-[11px] text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2.5 py-1 rounded-md transition-colors hover:bg-amber-500/20"
                 >
                   <KeyRound className="w-3 h-3" />
                   {t('chatLanding.configureProvider')}
@@ -400,10 +400,10 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                     aria-haspopup="menu"
                     aria-expanded={credMenuOpen}
                     aria-label={t('chatLanding.selectCredential')}
-                    className="inline-flex items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2 py-1 rounded-md transition-colors hover:text-text"
+                    className="inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md transition-colors hover:text-text"
                   >
                     <KeyRound className="w-3 h-3" />
-                    {credInfo?.slug ?? t('chatLanding.selectCredential')}
+                    <span className="truncate">{credInfo?.slug ?? t('chatLanding.selectCredential')}</span>
                     <ChevronDown className="w-3 h-3 opacity-60" />
                   </button>
                   {credMenuOpen && (
@@ -435,13 +435,13 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 </div>
               )}
             </div>
-            <div className="flex items-center gap-1.5">
+            <div className="flex items-center justify-end gap-1.5">
               <button
                 type="button"
                 disabled
                 title={t('chatLanding.attachSoon')}
                 aria-label={t('chatLanding.attach')}
-                className="w-8 h-8 rounded-lg flex items-center justify-center text-text-muted/50 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="w-10 h-10 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center text-text-muted/50 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 <Paperclip className="w-4 h-4" />
               </button>
@@ -451,7 +451,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 disabled={!canSend}
                 title={t('chatLanding.send')}
                 aria-label={t('chatLanding.send')}
-                className="w-8 h-8 rounded-lg flex items-center justify-center bg-accent text-white transition-colors hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="w-10 h-10 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center bg-accent text-white transition-colors hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {launching ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowUp className="w-4 h-4" />}
               </button>
@@ -526,15 +526,15 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
           </div>
         )}
 
-        <div className="flex flex-wrap items-center gap-2 px-1">
-          <span className="text-[11px] text-text-muted/70">{t('chatLanding.examplesLabel')}</span>
+        <div className="scrollbar-hide -mx-4 flex items-center gap-2 overflow-x-auto px-4 pb-1 md:mx-0 md:flex-wrap md:overflow-visible md:px-1 md:pb-0">
+          <span className="shrink-0 text-[11px] text-text-muted/70">{t('chatLanding.examplesLabel')}</span>
           {[t('chatLanding.ex1'), t('chatLanding.ex2'), t('chatLanding.ex3')].map((ex) => (
             <button
               key={ex}
               type="button"
               onClick={() => useExample(ex)}
               disabled={launching}
-              className="text-[12px] text-text-muted bg-bg-secondary/60 border border-border/50 rounded-full px-3 py-1 transition-colors hover:border-accent/40 hover:text-text disabled:opacity-40"
+              className="shrink-0 min-h-8 text-[12px] text-text-muted bg-bg-secondary/60 border border-border/50 rounded-full px-3 py-1 transition-colors hover:border-accent/40 hover:text-text disabled:opacity-40"
             >
               {ex}
             </button>

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -10,12 +10,13 @@
  */
 
 import { useEffect, useState } from 'react'
-import { FileText } from 'lucide-react'
+import { ArrowLeft, FileText } from 'lucide-react'
 
 import { FileContentView } from '../components/FileContentView'
 import { CenteredLoading } from '../components/StateViews'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
+import { useWorkspace } from '../tabs/store'
 import type { ViewSpec } from '../tabs/types'
 
 interface Props {
@@ -25,6 +26,8 @@ interface Props {
 export function FileViewerPage({ spec }: Props) {
   const { wsId, path } = spec.params
   const { workspaces } = useWorkspaces()
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+  const setSidebar = useWorkspace((s) => s.setSidebar)
   const tag = workspaces.find((w) => w.id === wsId)?.tag ?? wsId.slice(0, 8)
 
   const [result, setResult] = useState<ReadFileResult | null>(null)
@@ -39,9 +42,23 @@ export function FileViewerPage({ spec }: Props) {
     }
   }, [wsId, path])
 
+  const openWorkspace = () => {
+    setSidebar('workspaces')
+    openOrFocus({ kind: 'workspace', params: { wsId } })
+  }
+
   return (
     <div className="h-full flex flex-col min-h-0">
       <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-bg-secondary/30 shrink-0">
+        <button
+          type="button"
+          onClick={openWorkspace}
+          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2 text-[12px] font-medium text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text"
+          title={`Back to ${tag}`}
+        >
+          <ArrowLeft size={14} strokeWidth={1.8} aria-hidden />
+          <span className="hidden sm:inline">Back</span>
+        </button>
         <FileText size={13} strokeWidth={1.75} className="shrink-0 text-text-muted/70" aria-hidden />
         <span className="font-mono text-[12px] text-text truncate" title={path}>
           {path}

--- a/ui/src/pages/MarketPage.tsx
+++ b/ui/src/pages/MarketPage.tsx
@@ -36,7 +36,7 @@ export function MarketPage() {
             <div className="text-[12px] text-text-muted/70 border border-border rounded-md px-3 py-2">{stripError}</div>
           )}
           {!strip && !stripError && (
-            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4" aria-hidden="true">
+            <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(210px,1fr))]" aria-hidden="true">
               {Array.from({ length: 4 }).map((_, i) => (
                 <div key={i} className="border border-border rounded-md bg-bg-secondary/40 px-3 py-2.5 flex flex-col gap-1.5">
                   <Skeleton className="h-3 w-20 rounded" />
@@ -46,7 +46,7 @@ export function MarketPage() {
             </div>
           )}
           {strip && (
-            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(210px,1fr))]">
               {strip.cards.map((c) => (
                 <SeriesCard key={c.id} card={c} label={valuationLabel(c.id, t) ?? c.label} emptyText={t('market.noMatches')} />
               ))}

--- a/ui/src/pages/TrackedIssueDetailPage.tsx
+++ b/ui/src/pages/TrackedIssueDetailPage.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+
+import { IssueDetail } from '../components/IssueDetail'
+import type { WikilinkIssueRef } from '../api/issues'
+import { useWorkspace } from '../tabs/store'
+import type { ViewSpec } from '../tabs/types'
+
+/**
+ * Issue detail rendered inside the Tracked container.
+ *
+ * The issue body/properties are the same component used by the global Issues
+ * board, but the navigation contract is different: backlinks opened from
+ * Tracked should return to Tracked, not jump up to the global board.
+ */
+export function TrackedIssueDetailPage({
+  spec,
+}: {
+  spec: Extract<ViewSpec, { kind: 'tracked-issue-detail' }>
+}) {
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+  const setSidebar = useWorkspace((s) => s.setSidebar)
+  const { wsId, id } = spec.params
+
+  const openTracked = useCallback(() => {
+    setSidebar('tracked')
+    openOrFocus({ kind: 'tracked', params: {} })
+  }, [openOrFocus, setSidebar])
+
+  const openTrackedIssue = useCallback(
+    (ref: WikilinkIssueRef) => {
+      setSidebar('tracked')
+      openOrFocus({
+        kind: 'tracked-issue-detail',
+        params: { wsId: ref.wsId, id: ref.id },
+      })
+    },
+    [openOrFocus, setSidebar],
+  )
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <IssueDetail
+          wsId={wsId}
+          id={id}
+          backLabel="Tracked"
+          onBack={openTracked}
+          onOpenIssue={openTrackedIssue}
+        />
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -159,12 +159,15 @@ function issueIdFromPath(path: string): string | null {
 
 function BacklinkRow({ backlink }: { backlink: Backlink }) {
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
+  const setSidebar = useWorkspace((s) => s.setSidebar)
   const issueId = issueIdFromPath(backlink.path)
   const open = () => {
     if (issueId) {
-      // Issue note → its wsId-precise board detail, not a raw file.
+      // Issue note opened from Tracked stays in the Tracked container: same
+      // detail component, but Back returns to the entity/backlink context.
+      setSidebar('tracked')
       openOrFocus({
-        kind: 'issue-detail',
+        kind: 'tracked-issue-detail',
         params: { wsId: backlink.workspaceId, id: issueId },
       })
       return

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -75,6 +75,7 @@ export function UrlAdopter() {
 
         {/* Tracked (entity index) */}
         <Route path="/tracked" element={<AdoptStatic spec={{ kind: 'tracked', params: {} }} />} />
+        <Route path="/tracked/issues/:wsId/:id" element={<AdoptTrackedIssueDetail />} />
 
         {/* Workspaces */}
         <Route path="/workspaces" element={<AdoptStatic spec={{ kind: 'workspace-list', params: {} }} />} />
@@ -165,6 +166,12 @@ function AdoptIssueDetail() {
   return <AdoptStatic spec={{ kind: 'issue-detail', params: { wsId, id } }} />
 }
 
+function AdoptTrackedIssueDetail() {
+  const { wsId, id } = useParams<{ wsId: string; id: string }>()
+  if (!wsId || !id) return <Navigate to="/tracked" replace />
+  return <AdoptStatic spec={{ kind: 'tracked-issue-detail', params: { wsId, id } }} />
+}
+
 function AdoptUtaDetail() {
   const { id } = useParams<{ id: string }>()
   if (!id) return <Navigate to="/settings/trading" replace />
@@ -253,6 +260,7 @@ function specToSection(spec: ViewSpec): ActivitySection {
   switch (spec.kind) {
     case 'inbox':              return 'inbox'
     case 'tracked':            return 'tracked'
+    case 'tracked-issue-detail': return 'tracked'
     case 'chat-landing':       return 'chat'
     case 'workspace':
     case 'workspace-list':

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -5,6 +5,7 @@ import type { ViewKind, ViewSpec } from './types'
 import { PortfolioPage } from '../pages/PortfolioPage'
 import { IssuePage } from '../pages/IssuePage'
 import { IssueDetailPage } from '../pages/IssueDetailPage'
+import { TrackedIssueDetailPage } from '../pages/TrackedIssueDetailPage'
 import { AutomationPage } from '../pages/AutomationPage'
 import { NewsPage } from '../pages/NewsPage'
 import { MarketPage } from '../pages/MarketPage'
@@ -93,6 +94,14 @@ const issueDetailModule: ViewModule<'issue-detail'> = {
   toUrl: (spec) =>
     `/issues/${encodeURIComponent(spec.params.wsId)}/${encodeURIComponent(spec.params.id)}`,
   Component: ({ spec }) => <IssueDetailPage spec={spec} />,
+}
+
+const trackedIssueDetailModule: ViewModule<'tracked-issue-detail'> = {
+  kind: 'tracked-issue-detail',
+  title: (spec) => spec.params.id,
+  toUrl: (spec) =>
+    `/tracked/issues/${encodeURIComponent(spec.params.wsId)}/${encodeURIComponent(spec.params.id)}`,
+  Component: ({ spec }) => <TrackedIssueDetailPage spec={spec} />,
 }
 
 const automationSectionTitle: Record<
@@ -283,6 +292,7 @@ const VIEWS = {
   portfolio: portfolioModule,
   issue: issueModule,
   'issue-detail': issueDetailModule,
+  'tracked-issue-detail': trackedIssueDetailModule,
   automation: automationModule,
   news: newsModule,
   'market-list': marketListModule,

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -21,6 +21,7 @@ export type ViewSpec =
   | { kind: 'portfolio';      params: Record<string, never> }
   | { kind: 'issue';          params: Record<string, never> }
   | { kind: 'issue-detail';   params: { wsId: string; id: string } }
+  | { kind: 'tracked-issue-detail'; params: { wsId: string; id: string } }
   | { kind: 'automation';     params: { section: 'runs' | 'api' | 'flow' | 'webhook' } }
   | { kind: 'news';           params: Record<string, never> }
   | { kind: 'market-list';    params: Record<string, never> }


### PR DESCRIPTION
## Summary

- Tighten the desktop/mobile navigation chrome and responsive surfaces across ActivityBar, Chat, Inbox, Market, and Tracked.
- Add a reliable workspace back button for file viewer detail pages.
- Fix Tracked/Issue navigation state by rendering issue details in the correct container: global Issues details still return to the board, while Tracked-opened issue details return to Tracked.

## Why

The frontend had a few state and layout seams where the visible container did not match the user journey. The main behavioral fix is that clicking an issue backlink from Tracked no longer drops the user into the global Issues flow and then returns to the large board.

## Validation

- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- Browser-verified Tracked -> issue detail -> Back returns to `/tracked`
- Browser-verified `/issues/:wsId/:id` -> Back still returns to `/issues`
