### PR TITLE
[codex] refine AI provider presets

### DIFF
--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -141,13 +141,13 @@ export const CODEX_API: PresetDef = {
   writeOnlyFields: ['apiKey'],
 }
 
-// ==================== Official: Gemini ====================
+// ==================== Third-party: Gemini ====================
 
 export const GEMINI: PresetDef = {
   id: 'gemini',
   label: 'Google Gemini',
   description: 'Google AI via API key',
-  category: 'official',
+  category: 'third-party',
   defaultName: 'Google Gemini',
   zodSchema: z.object({
     backend: z.literal('vercel-ai-sdk'),
@@ -350,12 +350,12 @@ export const PRESET_CATALOG: PresetDef[] = [
   CLAUDE_API,
   CODEX_OAUTH,
   CODEX_API,
-  GEMINI,
   MINIMAX,
   GLM,
   KIMI,
   DEEPSEEK,
   LONGCAT,
+  GEMINI,
   CUSTOM,
 ]
 

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -295,6 +295,33 @@ export const DEEPSEEK: PresetDef = {
   writeOnlyFields: ['apiKey'],
 }
 
+// ==================== Third-party: LongCat (Meituan) ====================
+
+export const LONGCAT: PresetDef = {
+  id: 'longcat',
+  label: 'LongCat (Meituan)',
+  description: 'Meituan LongCat via OpenAI-compatible API',
+  category: 'third-party',
+  defaultName: 'LongCat',
+  hint: 'Uses the OpenAI-compatible endpoint you tested locally. This preset declares OpenAI Chat only; use opencode or Pi for this credential unless LongCat adds a Responses-compatible endpoint later.',
+  zodSchema: z.object({
+    backend: z.literal('vercel-ai-sdk'),
+    provider: z.literal('openai-compatible'),
+    baseUrl: z.string().default('https://api.longcat.chat/openai').describe('API endpoint'),
+    model: z.string().default('longcat-2.0').describe('Model'),
+    apiKey: z.string().min(1).describe('LongCat API key'),
+  }),
+  regions: [
+    { id: 'default', label: 'LongCat (api.longcat.chat)', wires: {
+      'openai-chat': 'https://api.longcat.chat/openai',
+    } },
+  ],
+  models: [
+    { id: 'longcat-2.0', label: 'LongCat 2.0' },
+  ],
+  writeOnlyFields: ['apiKey'],
+}
+
 // ==================== Custom ====================
 
 export const CUSTOM: PresetDef = {
@@ -328,6 +355,7 @@ export const PRESET_CATALOG: PresetDef[] = [
   GLM,
   KIMI,
   DEEPSEEK,
+  LONGCAT,
   CUSTOM,
 ]
 
@@ -348,4 +376,5 @@ export const DEFAULT_MODEL_BY_VENDOR: Record<string, string> = {
   glm: 'glm-5.2',
   kimi: 'kimi-k2.7-code',
   deepseek: 'deepseek-v4-pro',
+  longcat: 'longcat-2.0',
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -122,6 +122,8 @@ export type CredentialWireShape = z.infer<typeof credentialWireShapeEnum>
 
 export const credentialSchema = z.object({
   vendor: credentialVendorEnum,
+  /** Human-readable label shown in pickers. Slug stays the stable reference id. */
+  label: z.string().trim().max(80).transform((s) => s || undefined).optional(),
   authType: credentialAuthTypeEnum,
   /** Present for api-key credentials; absent for subscription credentials. */
   apiKey: z.string().optional(),
@@ -918,7 +920,10 @@ export async function addCredential(credential: Credential): Promise<string> {
   )
   if (match) {
     // Upgrade the existing record's wires/endpoint in place (don't duplicate).
-    config.credentials[match[0]] = validated
+    config.credentials[match[0]] = {
+      ...validated,
+      ...(validated.label ?? match[1].label ? { label: validated.label ?? match[1].label } : {}),
+    }
     await mkdir(CONFIG_DIR, { recursive: true })
     await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
     return match[0]

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -102,7 +102,7 @@ const apiKeysSchema = z.object({
 
 export const credentialVendorEnum = z.enum([
   'anthropic', 'openai', 'google',
-  'minimax', 'glm', 'kimi', 'deepseek', 'custom',
+  'minimax', 'glm', 'kimi', 'deepseek', 'longcat', 'custom',
 ])
 export type CredentialVendor = z.infer<typeof credentialVendorEnum>
 

--- a/src/core/credential-inference.spec.ts
+++ b/src/core/credential-inference.spec.ts
@@ -11,6 +11,7 @@ describe('inferCredentialVendor', () => {
     expect(inferCredentialVendor({ baseUrl: 'https://api.minimax.io/anthropic' })).toBe('minimax')
     expect(inferCredentialVendor({ baseUrl: 'https://api.moonshot.cn/v1' })).toBe('kimi')
     expect(inferCredentialVendor({ baseUrl: 'https://api.deepseek.com' })).toBe('deepseek')
+    expect(inferCredentialVendor({ baseUrl: 'https://api.longcat.chat/openai' })).toBe('longcat')
   })
 
   it('falls back to the agent when the baseUrl is unrecognized', () => {

--- a/src/core/credential-inference.ts
+++ b/src/core/credential-inference.ts
@@ -17,13 +17,14 @@ const VENDORS_BY_BASEURL: Array<[RegExp, CredentialVendor]> = [
   [/minimaxi\.com|minimax\.io/i, 'minimax'],
   [/moonshot\.cn|moonshot\.ai/i, 'kimi'],
   [/deepseek\.com/i, 'deepseek'],
+  [/longcat\.chat/i, 'longcat'],
 ]
 
 /**
  * Infer a credential vendor from the workspace AI-config modal's context — a
  * CLI agent tab + the entered baseUrl.
  *
- * A recognized baseUrl wins (GLM/MiniMax/Kimi/DeepSeek gateways); otherwise the
+ * A recognized baseUrl wins (GLM/MiniMax/Kimi/DeepSeek/LongCat gateways); otherwise the
  * agent decides: claude → anthropic, codex → openai. opencode/pi are
  * OpenAI-compatible against arbitrary endpoints, so an unrecognized baseUrl
  * falls back to 'custom' rather than guessing a first-party vendor.

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -70,6 +70,7 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
       const list = Object.entries(creds).map(([slug, cred]) => ({
         slug,
         vendor: cred.vendor,
+        ...(cred.label ? { label: cred.label } : {}),
         authType: cred.authType,
         wires: credentialWires(cred), // derives from legacy {baseUrl,wireShape} too
         apiKey: cred.apiKey ?? null,
@@ -84,13 +85,15 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
   /** POST /credentials — add an api-key credential (deduped by key). Returns slug. */
   app.post('/credentials', async (c) => {
     try {
-      const body = await c.req.json<{ vendor?: string; wires?: unknown; apiKey?: string }>()
+      const body = await c.req.json<{ vendor?: string; label?: string; wires?: unknown; apiKey?: string }>()
       const apiKey = body.apiKey?.trim()
       if (!apiKey) return c.json({ error: 'apiKey is required' }, 400)
       const vendorParse = credentialVendorEnum.safeParse(body.vendor)
+      const label = body.label?.trim()
       const wires = parseWires(body.wires)
       const cred: Credential = {
         vendor: vendorParse.success ? vendorParse.data : 'custom',
+        ...(label ? { label } : {}),
         authType: 'api-key',
         apiKey,
         ...(Object.keys(wires).length ? { wires } : {}),
@@ -106,13 +109,15 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
   app.put('/credentials/:slug', async (c) => {
     try {
       const slug = c.req.param('slug')
-      const body = await c.req.json<{ vendor?: string; wires?: unknown; apiKey?: string }>()
+      const body = await c.req.json<{ vendor?: string; label?: string; wires?: unknown; apiKey?: string }>()
       const existing = await resolveCredential(slug)
       const apiKey = body.apiKey?.trim() || existing.apiKey
       const vendorParse = credentialVendorEnum.safeParse(body.vendor)
+      const label = body.label?.trim()
       const wires = parseWires(body.wires)
       const cred: Credential = {
         vendor: vendorParse.success ? vendorParse.data : existing.vendor,
+        ...(label || existing.label ? { label: label || existing.label } : {}),
         authType: 'api-key',
         ...(apiKey ? { apiKey } : {}),
         ...(Object.keys(wires).length ? { wires } : { ...(existing.wires ? { wires: existing.wires } : {}) }),

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -1236,6 +1236,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
       const list = entries.map(([slug, cred]) => ({
         slug,
         vendor: cred.vendor,
+        ...(cred.label ? { label: cred.label } : {}),
         authType: cred.authType,
         wires: credentialWires(cred), // shape → endpoint; the modal picks one per agent
         ...(cred.lastModel ? { lastModel: cred.lastModel } : {}),
@@ -1250,17 +1251,19 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
 
   app.post('/credentials', async (c) => {
     const body = (await safeJson(c)) as
-      | { apiKey?: string; baseUrl?: string; agent?: string; vendor?: string; wireShape?: string }
+      | { apiKey?: string; baseUrl?: string; agent?: string; vendor?: string; label?: string; wireShape?: string }
       | null;
     const apiKey = body?.apiKey?.trim();
     if (!apiKey) return c.json({ error: 'apiKey_required' }, 400);
     const baseUrl = body?.baseUrl?.trim() || undefined;
+    const label = body?.label?.trim();
     const wireParse = credentialWireShapeEnum.safeParse(body?.wireShape);
     // The workspace modal saves a single hand-entered shape; capture it as a
     // one-entry wires map (the vault can later add more shapes for the same key —
     // dedup-by-key upgrades in place). Subscriptions never flow through here.
     const cred: Credential = {
       vendor: inferCredentialVendor({ agent: body?.agent, baseUrl }),
+      ...(label ? { label } : {}),
       authType: 'api-key',
       apiKey,
       ...(wireParse.success ? { wires: { [wireParse.data]: baseUrl ?? '' } } : (baseUrl ? { wires: {} } : {})),

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -257,6 +257,7 @@ describe('resolveInjectionModel', () => {
   it('falls back to the vendor flagship when no lastModel', () => {
     expect(resolveInjectionModel({ vendor: 'anthropic' })).toBe('claude-opus-4-8')
     expect(resolveInjectionModel({ vendor: 'glm' })).toBe('glm-5.2')
+    expect(resolveInjectionModel({ vendor: 'longcat' })).toBe('longcat-2.0')
   })
 
   it('returns null for a vendor with no catalog default (custom)', () => {

--- a/ui/src/api/config.ts
+++ b/ui/src/api/config.ts
@@ -37,7 +37,7 @@ export const configApi = {
     return res.json()
   },
 
-  async addCredential(input: { vendor: string; wires: Partial<Record<WireShape, string>>; apiKey: string }): Promise<{ slug: string; vendor: string }> {
+  async addCredential(input: { vendor: string; label?: string; wires: Partial<Record<WireShape, string>>; apiKey: string }): Promise<{ slug: string; vendor: string }> {
     const res = await fetch('/api/config/credentials', { method: 'POST', headers, body: JSON.stringify(input) })
     if (!res.ok) {
       const err = await res.json().catch(() => ({ error: 'Failed to add credential' }))
@@ -46,7 +46,7 @@ export const configApi = {
     return res.json()
   },
 
-  async updateCredential(slug: string, input: { vendor: string; wires: Partial<Record<WireShape, string>>; apiKey?: string }): Promise<void> {
+  async updateCredential(slug: string, input: { vendor: string; label?: string; wires: Partial<Record<WireShape, string>>; apiKey?: string }): Promise<void> {
     const res = await fetch(`/api/config/credentials/${encodeURIComponent(slug)}`, { method: 'PUT', headers, body: JSON.stringify(input) })
     if (!res.ok) {
       const err = await res.json().catch(() => ({ error: 'Failed to update credential' }))
@@ -114,6 +114,7 @@ export interface WorkspaceCredentialDefaultsResponse {
 export interface CredentialSummary {
   slug: string
   vendor: string
+  label?: string
   authType: 'api-key' | 'subscription'
   /** Wire capabilities: each shape this key speaks → its endpoint baseUrl. */
   wires: Partial<Record<WireShape, string>>

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -37,7 +37,7 @@ export interface Profile {
 
 export type CredentialVendor =
   | 'anthropic' | 'openai' | 'google'
-  | 'minimax' | 'glm' | 'kimi' | 'deepseek'
+  | 'minimax' | 'glm' | 'kimi' | 'deepseek' | 'longcat'
   | 'custom'
 
 export type CredentialAuthType = 'api-key' | 'subscription'

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -540,7 +540,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
                         const picked = pickAgentWire(cred.wires, tab)
                         return (
                           <option key={cred.slug} value={cred.slug}>
-                            {cred.slug}{picked?.baseUrl ? ` · ${picked.baseUrl}` : ''}
+                            {(cred.label?.trim() || cred.slug)}{picked?.baseUrl ? ` · ${picked.baseUrl}` : ''}
                           </option>
                         )
                       })}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -527,6 +527,7 @@ export type AgentId = 'claude' | 'codex' | 'opencode' | 'pi';
 export interface SavedCredential {
   readonly slug: string;
   readonly vendor: string;
+  readonly label?: string;
   readonly authType: 'api-key' | 'subscription';
   /** Wire capabilities: each shape this key speaks → its endpoint baseUrl. */
   readonly wires: Partial<Record<WireShape, string>>;
@@ -568,6 +569,7 @@ export async function saveCredential(input: {
   apiKey: string;
   baseUrl?: string;
   agent?: AgentId;
+  label?: string;
   wireShape?: WireShape;
 }): Promise<{ slug: string; vendor: string }> {
   const res = await fetch('/api/workspaces/credentials', {

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -39,8 +39,8 @@ export const configKeysHandlers = [
   http.get('/api/config/credentials', () =>
     HttpResponse.json({
       credentials: [
-        { slug: 'anthropic-1', vendor: 'anthropic', authType: 'api-key', wires: { anthropic: '' }, apiKey: null, hasApiKey: true },
-        { slug: 'openai-1', vendor: 'openai', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true },
+        { slug: 'anthropic-1', vendor: 'anthropic', label: 'Anthropic', authType: 'api-key', wires: { anthropic: '' }, apiKey: null, hasApiKey: true },
+        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true },
       ],
     }),
   ),

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -61,7 +61,7 @@ export const workspacesHandlers = [
   http.get('/api/workspaces/credentials', () =>
     HttpResponse.json({
       credentials: [
-        { slug: 'openai-1', vendor: 'openai', authType: 'api-key', wires: { 'openai-chat': '' }, lastModel: 'gpt-5.5', apiKey: null },
+        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-chat': '' }, lastModel: 'gpt-5.5', apiKey: null },
       ],
     }),
   ),

--- a/ui/src/lib/presetHelpers.ts
+++ b/ui/src/lib/presetHelpers.ts
@@ -96,6 +96,7 @@ export const VENDOR_BY_PRESET: Record<string, string> = {
   glm: 'glm',
   kimi: 'kimi',
   deepseek: 'deepseek',
+  longcat: 'longcat',
   custom: 'custom',
 }
 
@@ -112,6 +113,7 @@ const VENDOR_BY_BASEURL: Array<[RegExp, string]> = [
   [/minimaxi\.com|minimax\.io/i, 'minimax'],
   [/moonshot\.cn|moonshot\.ai/i, 'kimi'],
   [/deepseek\.com/i, 'deepseek'],
+  [/longcat\.chat/i, 'longcat'],
 ]
 
 /**

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -451,18 +451,13 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
     gate.reset()
   }
 
-  const presetGroups = useMemo(() => {
+  const visiblePresets = useMemo(() => {
     const q = presetQuery.trim().toLowerCase()
-    const visible = q
+    return q
       ? presets.filter((p) =>
           [p.label, p.description, p.id].some((text) => text.toLowerCase().includes(q)),
         )
       : presets
-    return [
-      { key: 'official', label: 'Official', items: visible.filter((p) => p.category === 'official') },
-      { key: 'third-party', label: 'Third-party', items: visible.filter((p) => p.category === 'third-party') },
-      { key: 'custom', label: 'Custom', items: visible.filter((p) => p.category === 'custom') },
-    ].filter((g) => g.items.length > 0)
   }, [presetQuery, presets])
 
   // The fields the test covers — editing any of them re-locks Save.
@@ -535,35 +530,25 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
                 placeholder="Search providers..."
                 autoFocus
               />
-              <div className="space-y-3">
-                {presetGroups.map((group) => (
-                  <div key={group.key}>
-                    <div className="mb-1.5 flex items-center justify-between px-1">
-                      <span className="text-[10px] font-semibold uppercase tracking-wide text-text-muted/65">
-                        {group.label}
+              <div className="overflow-hidden rounded-lg border border-border bg-bg">
+                {visiblePresets.map((p) => (
+                  <button
+                    key={p.id}
+                    onClick={() => pickPreset(p)}
+                    className="flex min-h-[46px] w-full items-center gap-3 border-b border-border/60 px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-bg-tertiary/60"
+                  >
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-[12.5px] font-medium text-text">{p.label}</span>
+                      <span className="block truncate text-[10.5px] text-text-muted">{p.description}</span>
+                    </span>
+                    {p.category === 'custom' && (
+                      <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted">
+                        free-form
                       </span>
-                      <span className="text-[10px] text-text-muted/50 tabular-nums">{group.items.length}</span>
-                    </div>
-                    <div className="overflow-hidden rounded-lg border border-border bg-bg">
-                      {group.items.map((p) => (
-                        <button
-                          key={p.id}
-                          onClick={() => pickPreset(p)}
-                          className="flex min-h-[46px] w-full items-center gap-3 border-b border-border/60 px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-bg-tertiary/60"
-                        >
-                          <span className="min-w-0 flex-1">
-                            <span className="block truncate text-[12.5px] font-medium text-text">{p.label}</span>
-                            <span className="block truncate text-[10.5px] text-text-muted">{p.description}</span>
-                          </span>
-                          <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted">
-                            {p.category === 'custom' ? 'free-form' : p.category}
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
+                    )}
+                  </button>
                 ))}
-                {presetGroups.length === 0 && (
+                {visiblePresets.length === 0 && (
                   <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-[12px] text-text-muted">
                     No providers match “{presetQuery}”.
                   </p>

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -29,6 +29,10 @@ import { useTestGate } from '../lib/useTestGate'
 
 const SHAPE_ORDER: WireShape[] = ['anthropic', 'openai-chat', 'openai-responses']
 
+function credentialLabel(cred: Pick<CredentialSummary, 'slug' | 'vendor' | 'label'>): string {
+  return cred.label?.trim() || cred.slug
+}
+
 /** Find the region whose wires match a stored credential (for edit mode). */
 function matchRegionId(preset: Preset | null, wires: Partial<Record<WireShape, string>>): string | undefined {
   const shapes = Object.keys(wires) as WireShape[]
@@ -154,7 +158,10 @@ export function AIProviderPage() {
                 <div key={cred.slug} className="flex items-center gap-3 rounded-lg border border-border bg-bg px-4 py-3">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-[13px] font-medium text-text">{cred.vendor}</span>
+                      <span className="text-[13px] font-medium text-text">{credentialLabel(cred)}</span>
+                      {cred.label && (
+                        <span className="text-[11px] text-text-muted">{cred.vendor}</span>
+                      )}
                       <span className="text-[11px] text-text-muted font-mono">{cred.slug}</span>
                       {(SHAPE_ORDER.filter((s) => s in cred.wires)).map((s) => (
                         <span key={s} className="text-[10px] text-text-muted border border-border rounded px-1">{WIRE_SHAPE_SHORT[s]}</span>
@@ -282,7 +289,7 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
 
   const credLabel = (slug: string) => {
     const c = credentials.find((x) => x.slug === slug)
-    return c ? `${c.vendor} · ${slug}` : slug
+    return c ? `${credentialLabel(c)} · ${slug}` : slug
   }
 
   const setAgentDefault = async (agentId: string, slug: string) => {
@@ -405,6 +412,7 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
   )
   // Custom (free-form) provider — one shape + a hand-typed endpoint.
   const customInit = cred ? (SHAPE_ORDER.find((s) => s in (cred.wires ?? {})) ?? 'openai-chat') : 'openai-chat'
+  const [customName, setCustomName] = useState<string>(cred?.label ?? '')
   const [customShape, setCustomShape] = useState<WireShape>(customInit)
   const [customUrl, setCustomUrl] = useState<string>(cred?.wires?.[customInit] ?? '')
   const [apiKey, setApiKey] = useState(cred?.apiKey ?? '')
@@ -461,17 +469,25 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
   const handleSave = async () => {
     if (!preset) return
     if (Object.keys(wires).length === 0) { setError('Pick a region / endpoint first'); return }
+    const customLabel = customName.trim()
+    if (isCustom && !customLabel) { setError('Provider name is required'); return }
     const vendor = VENDOR_BY_PRESET[preset.id] ?? 'custom'
     setSaving(true); setError('')
     try {
       if (mode === 'edit' && cred) {
         await api.config.updateCredential(cred.slug, {
           vendor, wires,
+          ...(isCustom ? { label: customLabel } : {}),
           ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
         })
       } else {
         if (!apiKey.trim()) { setError('API key is required'); setSaving(false); return }
-        await api.config.addCredential({ vendor, wires, apiKey: apiKey.trim() })
+        await api.config.addCredential({
+          vendor,
+          wires,
+          apiKey: apiKey.trim(),
+          ...(isCustom ? { label: customLabel } : {}),
+        })
       }
       await onSaved()
     } catch (err) {
@@ -527,6 +543,15 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
 
               {isCustom ? (
                 <>
+                  <Field label="Provider name" description="A readable name for this custom credential in pickers.">
+                    <input
+                      className={inputClass}
+                      value={customName}
+                      onChange={(e) => setCustomName(e.target.value)}
+                      placeholder="e.g. OpenRouter work key"
+                      maxLength={80}
+                    />
+                  </Field>
                   <Field label="API mode" description="Which wire protocol your endpoint speaks.">
                     <select className={inputClass} value={customShape} onChange={(e) => { setCustomShape(e.target.value as WireShape); gate.reset() }}>
                       {SHAPE_ORDER.map((s) => <option key={s} value={s}>{WIRE_SHAPE_SHORT[s]}</option>)}

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -416,6 +416,7 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
   const [customShape, setCustomShape] = useState<WireShape>(customInit)
   const [customUrl, setCustomUrl] = useState<string>(cred?.wires?.[customInit] ?? '')
   const [apiKey, setApiKey] = useState(cred?.apiKey ?? '')
+  const [presetQuery, setPresetQuery] = useState('')
   const [showKey, setShowKey] = useState(false)
   const [model, setModel] = useState('')
   const [saving, setSaving] = useState(false)
@@ -449,6 +450,20 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
     setError('')
     gate.reset()
   }
+
+  const presetGroups = useMemo(() => {
+    const q = presetQuery.trim().toLowerCase()
+    const visible = q
+      ? presets.filter((p) =>
+          [p.label, p.description, p.id].some((text) => text.toLowerCase().includes(q)),
+        )
+      : presets
+    return [
+      { key: 'official', label: 'Official', items: visible.filter((p) => p.category === 'official') },
+      { key: 'third-party', label: 'Third-party', items: visible.filter((p) => p.category === 'third-party') },
+      { key: 'custom', label: 'Custom', items: visible.filter((p) => p.category === 'custom') },
+    ].filter((g) => g.items.length > 0)
+  }, [presetQuery, presets])
 
   // The fields the test covers — editing any of them re-locks Save.
   const testKey = `${JSON.stringify(wires)}|${apiKey.trim()}|${model.trim()}`
@@ -512,17 +527,48 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
 
         <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
           {!preset ? (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              {presets.map((p) => (
-                <button
-                  key={p.id}
-                  onClick={() => pickPreset(p)}
-                  className="flex flex-col items-start gap-0.5 p-3 rounded-lg border border-border bg-bg hover:bg-bg-tertiary hover:border-accent/40 transition-all text-left"
-                >
-                  <span className="text-[12px] font-medium text-text">{p.label}</span>
-                  <span className="text-[10px] text-text-muted leading-snug">{p.description}</span>
-                </button>
-              ))}
+            <div className="space-y-3">
+              <input
+                className={inputClass}
+                value={presetQuery}
+                onChange={(e) => setPresetQuery(e.target.value)}
+                placeholder="Search providers..."
+                autoFocus
+              />
+              <div className="space-y-3">
+                {presetGroups.map((group) => (
+                  <div key={group.key}>
+                    <div className="mb-1.5 flex items-center justify-between px-1">
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-text-muted/65">
+                        {group.label}
+                      </span>
+                      <span className="text-[10px] text-text-muted/50 tabular-nums">{group.items.length}</span>
+                    </div>
+                    <div className="overflow-hidden rounded-lg border border-border bg-bg">
+                      {group.items.map((p) => (
+                        <button
+                          key={p.id}
+                          onClick={() => pickPreset(p)}
+                          className="flex min-h-[46px] w-full items-center gap-3 border-b border-border/60 px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-bg-tertiary/60"
+                        >
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-[12.5px] font-medium text-text">{p.label}</span>
+                            <span className="block truncate text-[10.5px] text-text-muted">{p.description}</span>
+                          </span>
+                          <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted">
+                            {p.category === 'custom' ? 'free-form' : p.category}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                {presetGroups.length === 0 && (
+                  <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-[12px] text-text-muted">
+                    No providers match “{presetQuery}”.
+                  </p>
+                )}
+              </div>
             </div>
           ) : (
             <>

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -403,7 +403,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                     className="inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md transition-colors hover:text-text"
                   >
                     <KeyRound className="w-3 h-3" />
-                    <span className="truncate">{credInfo?.slug ?? t('chatLanding.selectCredential')}</span>
+                    <span className="truncate">{credInfo?.label?.trim() || credInfo?.slug || t('chatLanding.selectCredential')}</span>
                     <ChevronDown className="w-3 h-3 opacity-60" />
                   </button>
                   {credMenuOpen && (
@@ -424,7 +424,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                             }}
                             className={`w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : 'text-text'}`}
                           >
-                            <span className="flex-1 truncate">{cr.slug}</span>
+                            <span className="flex-1 truncate">{cr.label?.trim() || cr.slug}</span>
                             <span className="text-[10px] text-text-muted/70 shrink-0">{cr.vendor}</span>
                             {active && <Check className="w-3.5 h-3.5 shrink-0" />}
                           </button>


### PR DESCRIPTION
## Summary

- Add a first-class LongCat credential preset using the OpenAI-compatible endpoint that was validated locally.
- Store and display a human-readable label for custom AI provider credentials while keeping the slug stable as the reference id.
- Flatten the Add credential provider picker into a single searchable list instead of Official/Third-party groups.
- Move Gemini below LongCat in the preset order and treat it as a regular API-key preset rather than a privileged official option.

## Why

PR #420 was merged at its first UI-navigation commit, so the AI Provider follow-up work needs its own PR. This keeps the credential creation surface aligned with the actual user flow: subscriptions live in CLI login, while this page helps users add API-key credentials quickly.

## Validation

- `git diff --check origin/master..HEAD`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- Browser-verified the flattened picker has no Official/Third-party labels and LongCat appears before Gemini
