### PR TITLE
[codex] keep Ask Alice workspace routes in chat

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -56,7 +56,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
     [ctx.workspaces],
   )
 
-  const isWsFocus = focused?.kind === 'workspace'
+  const isWsFocus = focused?.kind === 'workspace' && focused.params.source === 'chat'
   const selection = isWsFocus
     ? { wsId: focused.params.wsId, sessionId: focused.params.sessionId ?? null }
     : null
@@ -155,7 +155,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
           presetTemplate={CHAT_TEMPLATE}
           onCreated={(workspace) => {
             ctx.refresh()
-            openOrFocus({ kind: 'workspace', params: { wsId: workspace.id } })
+            openOrFocus({ kind: 'workspace', params: { wsId: workspace.id, source: 'chat' } })
           }}
           onClose={() => setShowCreate(false)}
         />
@@ -195,14 +195,16 @@ export function ChatWorkspaceSection(): ReactElement | null {
               const recent = mostRecentSession(w.sessions)
               openOrFocus({
                 kind: 'workspace',
-                params: recent ? { wsId: w.id, sessionId: recent.id } : { wsId: w.id },
+                params: recent
+                  ? { wsId: w.id, sessionId: recent.id, source: 'chat' }
+                  : { wsId: w.id, source: 'chat' },
               })
             }}
             onOpenSession={(sid) =>
-              openOrFocus({ kind: 'workspace', params: { wsId: w.id, sessionId: sid } })
+              openOrFocus({ kind: 'workspace', params: { wsId: w.id, sessionId: sid, source: 'chat' } })
             }
             onPauseSession={(sid) => void ctx.pauseSession(w.id, sid)}
-            onResumeSession={(sid) => void ctx.resumeSession(w.id, sid)}
+            onResumeSession={(sid) => void ctx.resumeSession(w.id, sid, 'chat')}
             onDeleteSession={(sid) => ctx.requestDeleteSession(w.id, sid)}
             onConfigure={() => ctx.openAgentConfig(w.id)}
             onDelete={() => setPendingDelete(w)}

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -47,6 +47,7 @@ import {
   type Workspace,
 } from '../components/workspace/api'
 import { useWorkspace } from '../tabs/store'
+import type { WorkspaceSource } from '../tabs/types'
 import { WorkspacesContext, type SpawnOpts } from './workspaces-context'
 
 const LIST_POLL_MS = 3000
@@ -128,7 +129,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   }, [hasLoaded, workspaces, closeTab])
 
   const spawn = useCallback(
-    async (wsId: string, opts: SpawnOpts = {}): Promise<void> => {
+    async (wsId: string, opts: SpawnOpts = {}, source?: WorkspaceSource): Promise<void> => {
       try {
         const sess = await spawnSession(wsId, opts)
         const nowIso = new Date().toISOString()
@@ -150,7 +151,14 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
             w.id === wsId ? { ...w, sessions: [...w.sessions, newRecord] } : w,
           ),
         )
-        openOrFocus({ kind: 'workspace', params: { wsId, sessionId: sess.sessionId } })
+        openOrFocus({
+          kind: 'workspace',
+          params: {
+            wsId,
+            sessionId: sess.sessionId,
+            ...(source ? { source } : {}),
+          },
+        })
         void refresh()
       } catch (err) {
         console.error('workspaces.spawn_failed', { wsId, opts, err })
@@ -198,7 +206,10 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         }
         return [{ ...workspace, sessions: withRecord(workspace.sessions) }, ...prev]
       })
-      openOrFocus({ kind: 'workspace', params: { wsId: workspace.id, sessionId: session.sessionId } })
+      openOrFocus({
+        kind: 'workspace',
+        params: { wsId: workspace.id, sessionId: session.sessionId, source: 'chat' },
+      })
       void refresh()
     },
     [refresh, openOrFocus],
@@ -221,7 +232,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   )
 
   const resumeSession = useCallback(
-    async (wsId: string, sessionId: string): Promise<void> => {
+    async (wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void> => {
       const resp = await apiResumeSession(wsId, sessionId)
       if (resp) {
         setWorkspaces((prev) =>
@@ -233,7 +244,14 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
           }),
         )
       }
-      openOrFocus({ kind: 'workspace', params: { wsId, sessionId } })
+      openOrFocus({
+        kind: 'workspace',
+        params: {
+          wsId,
+          sessionId,
+          ...(source ? { source } : {}),
+        },
+      })
       void refresh()
     },
     [refresh, openOrFocus],

--- a/ui/src/contexts/workspaces-context.ts
+++ b/ui/src/contexts/workspaces-context.ts
@@ -4,6 +4,7 @@ import type {
   TemplateInfo,
   Workspace,
 } from '../components/workspace/api'
+import type { WorkspaceSource } from '../tabs/types'
 
 export interface SpawnOpts {
   readonly resume?: 'last' | string
@@ -23,11 +24,11 @@ export interface WorkspacesContextValue {
   /** True once the templates fetch has settled (success OR failure). */
   readonly templatesLoaded: boolean
   refresh(): void
-  spawn(wsId: string, opts?: SpawnOpts): Promise<void>
+  spawn(wsId: string, opts?: SpawnOpts, source?: WorkspaceSource): Promise<void>
   setDefaultAgent(agent: string | null): Promise<void>
   quickChat(prompt: string, agent?: string, credentialSlug?: string, targetWsId?: string): Promise<void>
   pauseSession(wsId: string, sessionId: string): Promise<void>
-  resumeSession(wsId: string, sessionId: string): Promise<void>
+  resumeSession(wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void>
   requestDeleteSession(wsId: string, sessionId: string): void
   openAgentConfig(wsId: string): void
   saveWorkspaceMetadata(

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -37,6 +37,7 @@ export function WorkspacePage({ spec, visible }: Props) {
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const wsId = spec.params.wsId
   const sessionId = spec.params.sessionId ?? null
+  const source = spec.params.source
 
   const workspace = ctx.workspaces.find((w) => w.id === wsId)
   const sessions = workspace?.sessions ?? []
@@ -66,12 +67,12 @@ export function WorkspacePage({ spec, visible }: Props) {
   const spawnWithAgent = async (agentId: string, saveDefault: boolean): Promise<void> => {
     setSpawnMenuOpen(false)
     if (saveDefault) await ctx.setDefaultAgent(agentId)
-    await ctx.spawn(wsId, { agent: agentId })
+    await ctx.spawn(wsId, { agent: agentId }, source)
   }
 
   const spawnDefault = (): void => {
     if (defaultAgentEnabled && ctx.defaultAgent) {
-      void ctx.spawn(wsId, { agent: ctx.defaultAgent })
+      void ctx.spawn(wsId, { agent: ctx.defaultAgent }, source)
       return
     }
     setSpawnMenuOpen((v) => !v)
@@ -196,11 +197,18 @@ export function WorkspacePage({ spec, visible }: Props) {
           label={workspace.tag}
           keyMap={keyMap}
           onSpawnFresh={spawnDefault}
-          onResume={(id) => void ctx.resumeSession(wsId, id)}
+          onResume={(id) => void ctx.resumeSession(wsId, id, source)}
           onSelectSession={(id) => {
             // Running session — already alive on the server, just
             // navigate. Mirrors the sidebar's onSelectSession path.
-            openOrFocus({ kind: 'workspace', params: { wsId, sessionId: id } })
+            openOrFocus({
+              kind: 'workspace',
+              params: {
+                wsId,
+                sessionId: id,
+                ...(source ? { source } : {}),
+              },
+            })
           }}
           onSessionLost={() => {
             // 4404 from the WS upgrade — the session is gone server-side.

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -36,6 +36,8 @@ export function UrlAdopter() {
             /chat/:channelId (the retired traditional-chat channels) still
             redirects to Inbox so stale bookmarks land on a live surface. */}
         <Route path="/chat" element={<AdoptStatic spec={{ kind: 'chat-landing', params: {} }} />} />
+        <Route path="/chat/workspaces/:wsId" element={<AdoptChatWorkspace />} />
+        <Route path="/chat/workspaces/:wsId/s/:sessionId" element={<AdoptChatWorkspace />} />
         <Route path="/chat/:channelId" element={<Navigate to="/inbox" replace />} />
         <Route path="/portfolio" element={<AdoptStatic spec={{ kind: 'portfolio', params: {} }} />} />
         <Route path="/issues" element={<AdoptStatic spec={{ kind: 'issue', params: {} }} />} />
@@ -209,7 +211,15 @@ function AdoptAutomation() {
 function AdoptWorkspace() {
   const { wsId, sessionId } = useParams<{ wsId: string; sessionId?: string }>()
   if (!wsId) return <Navigate to="/workspaces" replace />
-  const params: { wsId: string; sessionId?: string } = { wsId }
+  const params: Extract<ViewSpec, { kind: 'workspace' }>['params'] = { wsId }
+  if (sessionId) params.sessionId = sessionId
+  return <AdoptStatic spec={{ kind: 'workspace', params }} />
+}
+
+function AdoptChatWorkspace() {
+  const { wsId, sessionId } = useParams<{ wsId: string; sessionId?: string }>()
+  if (!wsId) return <Navigate to="/chat" replace />
+  const params: Extract<ViewSpec, { kind: 'workspace' }>['params'] = { wsId, source: 'chat' }
   if (sessionId) params.sessionId = sessionId
   return <AdoptStatic spec={{ kind: 'workspace', params }} />
 }
@@ -262,7 +272,7 @@ function specToSection(spec: ViewSpec): ActivitySection {
     case 'tracked':            return 'tracked'
     case 'tracked-issue-detail': return 'tracked'
     case 'chat-landing':       return 'chat'
-    case 'workspace':
+    case 'workspace':          return spec.params.source === 'chat' ? 'chat' : 'workspaces'
     case 'workspace-list':
     case 'template-catalog':
     case 'template-detail':

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -256,7 +256,10 @@ const workspaceModule: ViewModule<'workspace'> = {
     return `${tag} · ${name}`
   },
   toUrl: (spec) => {
-    const base = `/workspaces/${encodeURIComponent(spec.params.wsId)}`
+    const base =
+      spec.params.source === 'chat'
+        ? `/chat/workspaces/${encodeURIComponent(spec.params.wsId)}`
+        : `/workspaces/${encodeURIComponent(spec.params.wsId)}`
     const sid = spec.params.sessionId
     return sid ? `${base}/s/${encodeURIComponent(sid)}` : base
   },

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -13,9 +13,11 @@
  * a data-model change.
  */
 
+export type WorkspaceSource = 'chat'
+
 export type ViewSpec =
   | { kind: 'workspace-list'; params: Record<string, never> }
-  | { kind: 'workspace';      params: { wsId: string; sessionId?: string } }
+  | { kind: 'workspace';      params: { wsId: string; sessionId?: string; source?: WorkspaceSource } }
   | { kind: 'template-catalog'; params: Record<string, never> }
   | { kind: 'template-detail';  params: { name: string } }
   | { kind: 'portfolio';      params: Record<string, never> }


### PR DESCRIPTION
## Summary
- add chat-scoped workspace URLs under /chat/workspaces so refresh restores the Ask Alice container
- carry the chat source through quick chat, chat sidebar opens, resume, and in-page session switches
- keep ordinary /workspaces routes mapped to the Workspaces management sidebar

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- git diff --check origin/master..HEAD
- pnpm test (passed with normal local networking; sandbox run failed on listen EPERM for port-based tests)
- in-app browser: /chat -> open Today chat workspace -> refresh stayed on /chat/workspaces/... with Ask Alice active; direct /workspaces/... still opens Workspaces