### PR TITLE
[codex] add macOS signing and auto update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,13 +141,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Per-platform desktop installers, attached to the release the `release`
-  # job already created (Option A — electron-builder only *builds*, softprops
-  # appends the artifact; release.yml stays the single owner of the release
-  # object + tag). Each runner builds only its own platform/arch, so each
+  # job already created. Each runner builds only its own platform/arch, so each
   # artifact carries just its matching native binary (longbridge, node-pty) —
-  # pnpm installs only the os/cpu-matching prebuilt. Unsigned for now: no
-  # Developer ID / Windows cert, so electron-builder emits unsigned packages
-  # (Gatekeeper right-click-open / SmartScreen on first run).
+  # pnpm installs only the os/cpu-matching prebuilt. macOS builds are signed and
+  # notarized through Developer ID secrets; Windows remains unsigned until a
+  # Windows code-signing certificate exists.
   build-desktop:
     needs: release
     if: needs.release.outputs.created == 'true'
@@ -186,10 +184,33 @@ jobs:
       - name: Build Alice + UTA + desktop shell
         run: pnpm electron:build
 
-      - name: Package installer (unsigned)
+      - name: Write Apple notarization API key
+        if: runner.os == 'macOS'
+        run: |
+          KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+
+      - name: Package macOS installer
+        if: runner.os == 'macOS'
         # electron-builder picks the target + arch from the host runner (mac
-        # arm64 / mac x64 / win x64). --publish never: build only, softprops
-        # does the upload so the release object has one owner.
+        # arm64). --publish never: build only, softprops does the upload so the
+        # release object has one owner.
+        run: pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never
+        env:
+          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Package Windows installer
+        if: runner.os == 'Windows'
+        # Windows remains unsigned until a Windows code-signing certificate is
+        # available.
         run: pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never
 
       - name: Attach installer to the release
@@ -198,4 +219,7 @@ jobs:
           tag_name: ${{ needs.release.outputs.tag }}
           files: |
             dist/electron-app/*.dmg
+            dist/electron-app/*.zip
+            dist/electron-app/*mac.yml
+            dist/electron-app/*.blockmap
             dist/electron-app/*.exe

--- a/apps/desktop/build/entitlements.mac.inherit.plist
+++ b/apps/desktop/build/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "electron": "^39.8.5",
     "electron-builder": "^26.0.0",
-    "electron-builder-squirrel-windows": "^26.0.0"
+    "electron-builder-squirrel-windows": "^26.0.0",
+    "electron-updater": "^6.8.9"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -1,0 +1,74 @@
+import { app, dialog, shell, type BrowserWindow } from 'electron'
+import { autoUpdater } from 'electron-updater'
+
+export interface AutoUpdateHooks {
+  beforeInstall: () => Promise<void>
+}
+
+export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks): void {
+  if (!app.isPackaged) return
+
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = false
+  autoUpdater.allowPrerelease = app.getVersion().includes('-')
+  autoUpdater.channel = channelForVersion(app.getVersion())
+  autoUpdater.allowDowngrade = false
+
+  autoUpdater.on('error', (err) => {
+    console.error('[updater] update check failed:', err)
+  })
+
+  autoUpdater.on('update-available', (info) => {
+    console.log(`[updater] update available: ${info.version}`)
+  })
+
+  autoUpdater.on('update-not-available', (info) => {
+    console.log(`[updater] no update available (latest=${info.version})`)
+  })
+
+  autoUpdater.on('download-progress', (progress) => {
+    console.log(`[updater] downloading ${progress.percent.toFixed(1)}%`)
+  })
+
+  autoUpdater.on('update-downloaded', (info) => {
+    void dialog
+      .showMessageBox(win, {
+        type: 'info',
+        title: 'OpenAlice — update ready',
+        message: `OpenAlice ${info.version} is ready to install.`,
+        detail: 'Restart OpenAlice to install the update. Running UTA and Alice child processes will be stopped gracefully first.',
+        buttons: ['Restart now', 'Later', 'View release'],
+        defaultId: 0,
+        cancelId: 1,
+      })
+      .then(async ({ response }) => {
+        if (response === 2) {
+          const releaseUrl = `https://github.com/TraderAlice/OpenAlice/releases/tag/v${info.version}`
+          void shell.openExternal(releaseUrl)
+          return
+        }
+        if (response !== 0) return
+        try {
+          await hooks.beforeInstall()
+          autoUpdater.quitAndInstall(false, true)
+        } catch (err) {
+          console.error('[updater] failed to prepare update install:', err)
+          await dialog.showMessageBox(win, {
+            type: 'error',
+            title: 'OpenAlice — update install failed',
+            message: 'OpenAlice could not prepare for the update.',
+            detail: err instanceof Error ? err.message : String(err),
+          })
+        }
+      })
+  })
+
+  void autoUpdater.checkForUpdates().catch((err) => {
+    console.error('[updater] checkForUpdates threw:', err)
+  })
+}
+
+function channelForVersion(version: string): string {
+  const prerelease = version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/)
+  return prerelease?.[1] ?? 'latest'
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -17,11 +17,10 @@
  * release surface with no TS-dev-tooling dependency, the same reason
  * probe-port.ts is duplicated rather than imported.
  *
- * Out of scope (future iterations): tray icon, full auto-update (L2 — needs
- * code signing, blocked by Squirrel.Mac), multi-window, native menus.
+ * Out of scope (future iterations): tray icon, multi-window, native menus.
  */
 
-import { app, BrowserWindow, dialog, shell, Menu } from 'electron'
+import { app, BrowserWindow, dialog, Menu } from 'electron'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { mkdir, readFile, watch } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
@@ -29,7 +28,7 @@ import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { probeFreePort } from './probe-port.js'
 import { relocateLegacyData } from './relocate-data.js'
-import { checkForUpdate } from './update-check.js'
+import { configureAutoUpdate } from './auto-update.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -308,24 +307,7 @@ app.whenReady().then(async () => {
   })
   win.loadURL(`http://localhost:${webPort}/`)
 
-  // L1 update check — non-blocking; surfaces a dialog only when a newer
-  // release exists. Never gates launch, never auto-downloads (no signing).
-  void checkForUpdate(app.getVersion()).then((update) => {
-    if (!update) return
-    void dialog
-      .showMessageBox(win, {
-        type: 'info',
-        title: 'OpenAlice — update available',
-        message: `A newer version of OpenAlice is available: ${update.version}`,
-        detail: `You're on ${app.getVersion()}. Download the new version from the release page.`,
-        buttons: ['Download', 'Later'],
-        defaultId: 0,
-        cancelId: 1,
-      })
-      .then(({ response }) => {
-        if (response === 0) void shell.openExternal(update.url)
-      })
-  })
+  configureAutoUpdate(win, { beforeInstall: stopChildren })
 })
 
 async function restartUTA(utaUrl: string, spawnUTA: () => ChildProcess): Promise<void> {
@@ -378,35 +360,30 @@ async function startFlagWatcher(
   }
 }
 
-/** Cascade tree-kill both children, then exit once they're gone. */
-function shutdown(): void {
-  if (appQuitting) return
+/** Cascade tree-kill both children. */
+async function stopChildren(): Promise<void> {
   appQuitting = true
   const children = [uta, alice].filter((c): c is ChildProcess => c != null && c.exitCode === null && !c.killed)
-  if (children.length === 0) {
-    app.exit(0)
-    return
-  }
+  if (children.length === 0) return
   console.log(`[guardian] shutting down — SIGTERM → ${children.length} child(ren)`)
-  let remaining = children.length
-  const done = (): void => {
-    if (--remaining <= 0) {
-      clearTimeout(sigkill)
-      app.exit(0)
-    }
-  }
-  for (const c of children) {
-    c.once('exit', done)
-    killTree(c, 'SIGTERM')
-  }
-  const sigkill = setTimeout(() => {
-    for (const c of children) {
+  await Promise.all(
+    children.map(async (c) => {
+      const exited = new Promise<void>((r) => c.once('exit', () => r()))
+      killTree(c, 'SIGTERM')
+      await Promise.race([exited, new Promise((r) => setTimeout(r, SIGTERM_GRACE_MS))])
       if (c.exitCode === null && !c.killed) {
         console.warn(`[guardian] child pid=${c.pid} did not exit after ${SIGTERM_GRACE_MS}ms → SIGKILL`)
         killTree(c, 'SIGKILL')
+        await exited
       }
-    }
-  }, SIGTERM_GRACE_MS)
+    }),
+  )
+}
+
+/** Cascade tree-kill both children, then exit once they're gone. */
+function shutdown(): void {
+  if (appQuitting) return
+  void stopChildren().finally(() => app.exit(0))
 }
 
 app.on('before-quit', (e) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.70.0-beta.0",
+  "version": "0.70.0-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",
@@ -83,9 +83,15 @@
     ],
     "mac": {
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ],
-      "category": "public.app-category.finance"
+      "category": "public.app-category.finance",
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.inherit.plist",
+      "notarize": true,
+      "gatekeeperAssess": false
     },
     "win": {
       "target": [
@@ -95,7 +101,14 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
-    }
+    },
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "TraderAlice",
+        "repo": "OpenAlice"
+      }
+    ]
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       electron-builder-squirrel-windows:
         specifier: ^26.0.0
         version: 26.15.2(dmg-builder@26.15.2)
+      electron-updater:
+        specifier: ^6.8.9
+        version: 6.8.9
 
   packages/ibkr:
     dependencies:
@@ -2125,6 +2128,9 @@ packages:
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
@@ -2844,6 +2850,13 @@ packages:
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -3733,6 +3746,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -6009,6 +6025,19 @@ snapshots:
 
   electron-to-chromium@1.5.313: {}
 
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
@@ -6743,6 +6772,10 @@ snapshots:
   lines-and-columns@1.2.4: {}
 
   load-tsconfig@0.2.5: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash@4.18.1: {}
 
@@ -7679,6 +7712,8 @@ snapshots:
       semver: 5.7.2
 
   tiny-invariant@1.3.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary

- Bumps the prerelease version to `0.70.0-beta.1` so the release workflow creates a fresh tag/release instead of skipping the already-published `v0.70.0-beta.0`.
- Adds the Electron auto-update path for packaged desktop builds via `electron-updater`.
- Configures macOS Developer ID signing, hardened runtime entitlements, notarization, GitHub publish metadata, and zip metadata generation for updates.
- Updates the release workflow to use the Apple notarization API key and macOS signing secrets while leaving Windows unsigned.

## Notes

This is the first macOS release path wired for signed/notarized DMGs. The repository now expects these Actions secrets to exist: `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, `APPLE_API_KEY_P8`, `MACOS_CSC_LINK`, and `MACOS_CSC_KEY_PASSWORD`.

No certificate/private-key material is committed to the repo. I also confirmed `v0.70.0-beta.1` does not exist on GitHub, so merging this to `master` should run the release path and build the first signed/notarized desktop artifacts.

## Validation

- `npx tsc --noEmit`
- `/opt/homebrew/bin/pnpm -F @traderalice/desktop typecheck`
- `/opt/homebrew/bin/pnpm test`
- `git diff --check`
- `CSC_IDENTITY_AUTO_DISCOVERY=false /opt/homebrew/bin/pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --dir --publish never`
- repo secret grep for p8/p12/private-key literals