### PR TITLE
[codex] fix macOS release signing file limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,10 @@ jobs:
         # electron-builder picks the target + arch from the host runner (mac
         # arm64). --publish never: build only, softprops does the upload so the
         # release object has one owner.
-        run: pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never
+        run: |
+          ulimit -n 10240
+          echo "open files limit: $(ulimit -n)"
+          pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never
         env:
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.70.0-beta.1",
+  "version": "0.70.0-beta.2",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary

- Bumps the prerelease version to `0.70.0-beta.2` so the release workflow creates a fresh release after `v0.70.0-beta.1` failed during macOS packaging.
- Raises the macOS packaging step open-files limit before running `electron-builder`.

## Root Cause

The first signed macOS release attempt successfully reached Developer ID signing with `Developer ID Application: Longtai Xie (8VBA8Q9766)`, but failed inside `Package macOS installer` with:

```text
EMFILE: too many open files
```

This is caused by deep-signing the unpacked app while `asar:false` leaves a very large `node_modules` tree inside the app bundle.

## Validation

- `npx tsc --noEmit`
- `/opt/homebrew/bin/pnpm -F @traderalice/desktop typecheck`
- `/opt/homebrew/bin/pnpm test`
- `git diff --check`
- confirmed `v0.70.0-beta.2` does not exist before publishing
- repo secret grep for p8/p12/private-key literals