### PR TITLE
[codex] raise macOS release file limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         # arm64). --publish never: build only, softprops does the upload so the
         # release object has one owner.
         run: |
-          ulimit -n 10240
+          ulimit -n 65536 || ulimit -n 32768 || ulimit -n 16384 || ulimit -n 10240
           echo "open files limit: $(ulimit -n)"
           pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.70.0-beta.2",
+  "version": "0.70.0-beta.3",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary

- Bumps the prerelease version to `0.70.0-beta.3` after `v0.70.0-beta.2` still hit `EMFILE` during macOS signing.
- Raises the macOS packaging step open-files limit to `65536`, with fallback values down to the previous `10240`.

## Root Cause

`v0.70.0-beta.2` confirmed the previous `ulimit -n 10240` was applied, but codesigning the unpacked `asar:false` app still exceeded that limit. The app bundle contains roughly 24k files under packaged `node_modules`, so 10240 is not high enough for the current deep-signing path.

This keeps the runtime model unchanged for the first certificate release; a later hardening pass should reduce the signing surface by pruning packaged runtime files or moving toward an asar/asarUnpack layout carefully.

## Validation

- `npx tsc --noEmit`
- `/opt/homebrew/bin/pnpm -F @traderalice/desktop typecheck`
- `/opt/homebrew/bin/pnpm test`
- `git diff --check`
- confirmed `v0.70.0-beta.3` does not exist before publishing
- repo secret grep for p8/p12/private-key literals