### PR TITLE
[codex] prune packaged node metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.70.0-beta.3",
+  "version": "0.70.0-beta.4",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",
@@ -79,7 +79,11 @@
       "src/workspaces/templates/**",
       "services/uta/dist/**",
       "services/uta/package.json",
-      "package.json"
+      "package.json",
+      "!node_modules/**/*.d.ts",
+      "!node_modules/**/*.d.ts.map",
+      "!node_modules/**/*.map",
+      "!node_modules/**/_types/**"
     ],
     "mac": {
       "target": [


### PR DESCRIPTION
## Summary

- Bumps the prerelease version to `0.70.0-beta.4` after `v0.70.0-beta.3` still hit `EMFILE` during macOS signing even with `ulimit -n 65536`.
- Excludes runtime-unneeded `node_modules` metadata from Electron packaging: `*.d.ts`, `*.d.ts.map`, `*.map`, and `_types` trees.

## Root Cause

`v0.70.0-beta.3` confirmed the runner open-files limit was raised to `65536`, but electron-builder/codesign still failed while deep-signing the unpacked `asar:false` app bundle. The failure kept landing inside `viem` type/map files, which are not needed at runtime but substantially increase the file count that codesign traverses.

A local unsigned electron-builder dry-run confirmed the package now excludes those files: packaged `node_modules` file count dropped from about `24,830` to `17,153`, and `*.d.ts` / `*.map` / `_types` files are absent from the app bundle.

## Validation

- `npx tsc --noEmit`
- `/opt/homebrew/bin/pnpm -F @traderalice/desktop typecheck`
- `/opt/homebrew/bin/pnpm test`
- `git diff --check`
- `CSC_IDENTITY_AUTO_DISCOVERY=false /opt/homebrew/bin/pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --dir --publish never`
- confirmed packaged node metadata exclusions in `dist/electron-app/mac-arm64/OpenAlice.app`
- confirmed `v0.70.0-beta.4` does not exist before publishing
- repo secret grep for p8/p12/private-key literals