### PR TITLE
Fix desktop updater packaging and mirror releases to R2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,31 @@ jobs:
         # available.
         run: pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never
 
+      - name: Prepare update channel aliases
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require('fs')
+          const path = require('path')
+          const version = require('./package.json').version
+          const match = version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/)
+          if (!match) process.exit(0)
+
+          const channel = match[1]
+          const outDir = path.join('dist', 'electron-app')
+          const aliases = [
+            ['latest-mac.yml', `${channel}-mac.yml`],
+            ['latest.yml', `${channel}.yml`],
+          ]
+
+          for (const [source, target] of aliases) {
+            const sourcePath = path.join(outDir, source)
+            if (!fs.existsSync(sourcePath)) continue
+            fs.copyFileSync(sourcePath, path.join(outDir, target))
+            console.log(`Created ${target} from ${source}`)
+          }
+          NODE
+
       - name: Attach installer to the release
         uses: softprops/action-gh-release@v2
         with:
@@ -223,6 +248,79 @@ jobs:
           files: |
             dist/electron-app/*.dmg
             dist/electron-app/*.zip
-            dist/electron-app/*mac.yml
+            dist/electron-app/*.yml
             dist/electron-app/*.blockmap
             dist/electron-app/*.exe
+
+  mirror-release-assets:
+    needs: [release, build-desktop]
+    if: needs.release.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          mkdir -p dist/r2-upload
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir dist/r2-upload --clobber
+
+      - name: Prepare CDN update channel aliases
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          if [[ "$VERSION" != *-* ]]; then
+            exit 0
+          fi
+
+          CHANNEL="${VERSION#*-}"
+          CHANNEL="${CHANNEL%%.*}"
+
+          if [ -f dist/r2-upload/latest-mac.yml ]; then
+            cp dist/r2-upload/latest-mac.yml "dist/r2-upload/${CHANNEL}-mac.yml"
+          fi
+
+          if [ -f dist/r2-upload/latest.yml ]; then
+            cp dist/r2-upload/latest.yml "dist/r2-upload/${CHANNEL}.yml"
+          fi
+
+      - name: Install AWS CLI
+        run: |
+          python3 -m pip install --user awscli
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Mirror release assets to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_EC2_METADATA_DISABLED: true
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          aws s3 cp dist/r2-upload "s3://${R2_BUCKET}/" \
+            --recursive \
+            --exclude "*.yml" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --endpoint-url "$ENDPOINT"
+
+          aws s3 cp dist/r2-upload "s3://${R2_BUCKET}/" \
+            --recursive \
+            --exclude "*" \
+            --include "*.yml" \
+            --cache-control "no-cache" \
+            --content-type "text/yaml" \
+            --endpoint-url "$ENDPOINT"
+
+      - name: Verify CDN metadata
+        env:
+          DOWNLOAD_BASE_URL: ${{ secrets.DOWNLOAD_BASE_URL }}
+        run: |
+          BASE_URL="${DOWNLOAD_BASE_URL%/}"
+          curl -fsSI "${BASE_URL}/latest-mac.yml"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.70.0-beta.4",
+  "version": "0.70.0-beta.5",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",
@@ -51,6 +51,7 @@
     "ccxt": "^4.5.38",
     "decimal.js": "^10.6.0",
     "dugite": "3.2.2",
+    "electron-updater": "^6.8.9",
     "grammy": "^1.40.0",
     "hono": "^4.12.21",
     "longbridge": "^4.0.5",
@@ -108,9 +109,8 @@
     },
     "publish": [
       {
-        "provider": "github",
-        "owner": "TraderAlice",
-        "repo": "OpenAlice"
+        "provider": "generic",
+        "url": "https://download.openalice.ai/"
       }
     ]
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       dugite:
         specifier: 3.2.2
         version: 3.2.2
+      electron-updater:
+        specifier: ^6.8.9
+        version: 6.8.9
       grammy:
         specifier: ^1.40.0
         version: 1.40.0(encoding@0.1.13)


### PR DESCRIPTION
## Summary
- move electron-updater into the root runtime dependencies so packaged desktop builds can resolve it at launch
- bump the release to v0.70.0-beta.5
- switch packaged auto-update metadata to the Cloudflare R2 generic provider at https://download.openalice.ai/
- keep GitHub Release uploads, add beta/latest update metadata aliases, and mirror release assets to the R2 bucket via the new repository secrets

## Validation
- npx tsc --noEmit
- pnpm -F @traderalice/desktop typecheck
- pnpm test
- CSC_IDENTITY_AUTO_DISCOVERY=false pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --dir --publish never
- confirmed the dry-run packaged app includes node_modules/electron-updater
- ruby YAML parse check for .github/workflows/release.yml

## Notes
- v0.70.0-beta.4 can still discover v0.70.0-beta.5 through GitHub Releases. v0.70.0-beta.5 and later use the CDN-backed generic updater provider.
