### PR TITLE
Fix updater import and move release tooling to pnpm 11

### DIFF
--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -1,5 +1,7 @@
 import { app, dialog, shell, type BrowserWindow } from 'electron'
-import { autoUpdater } from 'electron-updater'
+import electronUpdater from 'electron-updater'
+
+const { autoUpdater } = electronUpdater
 
 export interface AutoUpdateHooks {
   beforeInstall: () => Promise<void>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.70.0-beta.6",
+  "version": "0.70.0-beta.7",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/TraderAlice/OpenAlice.git"
   },
   "homepage": "https://traderalice.com",
-  "packageManager": "pnpm@10.29.2",
+  "packageManager": "pnpm@11.7.0",
   "dependencies": {
     "@alpacahq/alpaca-trade-api": "^3.1.3",
     "@anthropic-ai/sdk": "^0.96.0",
@@ -113,36 +113,6 @@
         "url": "https://download.openalice.ai/"
       }
     ]
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "node-pty",
-      "electron",
-      "dugite"
-    ],
-    "overrides": {
-      "@alpacahq/alpaca-trade-api>axios": "^0.32.0",
-      "@alpacahq/alpaca-trade-api>eslint": "-",
-      "protobufjs": "^7.5.8",
-      "fast-uri": "^3.1.2",
-      "qs": "^6.15.2",
-      "ip-address": "^10.1.1",
-      "tmp": "^0.2.6",
-      "form-data": "^4.0.6",
-      "undici@^6.0.0": "^6.27.0",
-      "undici@^7.0.0": "^7.28.0",
-      "ws@^7.0.0": "^7.5.11",
-      "ws@^8.0.0": "^8.20.1",
-      "lodash": "^4.18.0",
-      "path-to-regexp": "^8.4.0",
-      "msw>path-to-regexp": "^6.3.0",
-      "follow-redirects": "^1.16.0",
-      "express-rate-limit": "^8.2.2",
-      "picomatch": "^4.0.4",
-      "rollup": "^4.59.0",
-      "vitest>vite": "^7.3.5",
-      "@vitest/mocker>vite": "^7.3.5"
-    }
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.8",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,36 @@ packages:
   - packages/*
   - services/*
   - ui
+
+allowBuilds:
+  ccxt: false
+  dugite: true
+  electron: true
+  electron-winstaller: false
+  esbuild: false
+  msw: false
+  node-pty: true
+  protobufjs: false
+
+overrides:
+  '@alpacahq/alpaca-trade-api>axios': ^0.32.0
+  '@alpacahq/alpaca-trade-api>eslint': '-'
+  protobufjs: ^7.5.8
+  fast-uri: ^3.1.2
+  qs: ^6.15.2
+  ip-address: ^10.1.1
+  tmp: ^0.2.6
+  form-data: ^4.0.6
+  undici@^6.0.0: ^6.27.0
+  undici@^7.0.0: ^7.28.0
+  ws@^7.0.0: ^7.5.11
+  ws@^8.0.0: ^8.20.1
+  lodash: ^4.18.0
+  path-to-regexp: ^8.4.0
+  msw>path-to-regexp: ^6.3.0
+  follow-redirects: ^1.16.0
+  express-rate-limit: ^8.2.2
+  picomatch: ^4.0.4
+  rollup: ^4.59.0
+  vitest>vite: ^7.3.5
+  '@vitest/mocker>vite': ^7.3.5


### PR DESCRIPTION
## Summary
- bump the beta release to 0.70.0-beta.7
- import `electron-updater` through its CommonJS default export so the packaged ESM main process can start
- migrate pnpm settings from `package.json#pnpm` to `pnpm-workspace.yaml` for pnpm 11, including explicit build-script allow/deny entries

## Local validation
- `CI=true pnpm install --frozen-lockfile`
- `pnpm install --frozen-lockfile`
- `CI=true pnpm build`
- `CI=true pnpm exec turbo run build --force`
- `npx tsc --noEmit`
- `pnpm -F @traderalice/desktop typecheck`
- `CI=true pnpm test`
- `CSC_IDENTITY_AUTO_DISCOVERY=false CI=true pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --dir --publish never`
- launched the unpacked macOS app with a temporary HOME and ports 58331-58333 for 20s; it stayed running and booted UTA/Alice/Web UI without the `electron-updater` import crash
- `git diff --check`