### PR TITLE
Fix packaged app agent runtime detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.70.0-beta.7",
+  "version": "0.70.0-beta.8",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -61,7 +61,7 @@ export class HeadlessCapacityError extends Error {
 import { ScrollbackStore } from './scrollback-store.js';
 import { SessionPool, type SessionFactoryContext } from './session-pool.js';
 import { SessionRegistry, type SessionRecord } from './session-registry.js';
-import { buildSpawnEnv } from './spawn-env.js';
+import { buildCliPath, buildSpawnEnv } from './spawn-env.js';
 import { readReadmeVersion, TemplateRegistry } from './template-registry.js';
 import { readWorkspaceMetadata } from './workspace-metadata.js';
 import { TranscriptWatcher } from './transcript-watcher.js';
@@ -811,9 +811,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
 
   const detectAgents = (): Record<string, AgentAvailability> => {
     const out: Record<string, AgentAvailability> = {};
+    const env = { ...process.env, PATH: buildCliPath(process.env) };
     for (const a of adapters.list()) {
       // No declared binary (shell → `$SHELL`) is always available.
-      out[a.id] = a.binary ? detectBinary(a.binary) : { installed: true, path: null };
+      out[a.id] = a.binary ? detectBinary(a.binary, { env }) : { installed: true, path: null };
     }
     return out;
   };

--- a/src/workspaces/spawn-env.spec.ts
+++ b/src/workspaces/spawn-env.spec.ts
@@ -1,5 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
 import { describe, it, expect } from 'vitest'
-import { buildSpawnEnv } from './spawn-env.js'
+import { buildCliPath, buildSpawnEnv } from './spawn-env.js'
 
 /**
  * Guards the precedence the git-identity injection leans on: per-workspace
@@ -52,5 +55,60 @@ describe('buildSpawnEnv', () => {
 
     const lcAll = buildSpawnEnv({ LC_ALL: 'C.UTF-8' })
     expect(lcAll['LC_CTYPE']).toBeUndefined()
+  })
+
+  it.skipIf(process.platform === 'win32')('adds common user CLI bins missing from GUI app PATH', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openalice-home-'))
+    try {
+      const localBin = join(home, '.local/bin')
+      const pnpmHome = join(home, 'Library/pnpm')
+      mkdirSync(localBin, { recursive: true })
+      mkdirSync(pnpmHome, { recursive: true })
+
+      const path = buildCliPath({ HOME: home, PATH: '/usr/bin:/bin' })
+        .split(delimiter)
+
+      expect(path).toContain(localBin)
+      expect(path).toContain(pnpmHome)
+      expect(path).toContain('/usr/bin')
+      expect(path).toContain('/bin')
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it.skipIf(process.platform === 'win32')('honors OPENALICE_EXTRA_AGENT_PATH for custom CLI installs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'openalice-agent-bin-'))
+    try {
+      const path = buildCliPath({
+        HOME: tmpdir(),
+        PATH: '/usr/bin:/bin',
+        OPENALICE_EXTRA_AGENT_PATH: dir,
+      }).split(delimiter)
+
+      expect(path[0]).toBe(dir)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it.skipIf(process.platform === 'win32')('augments an explicit PATH override from spawn extras', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openalice-home-'))
+    try {
+      const localBin = join(home, '.local/bin')
+      mkdirSync(localBin, { recursive: true })
+
+      const out = buildSpawnEnv(
+        { HOME: home, PATH: '/usr/bin:/bin' },
+        { PATH: '/app/cli-bin:/usr/bin:/bin' },
+      )
+      const path = out['PATH'].split(delimiter)
+
+      expect(path).toContain('/app/cli-bin')
+      expect(path).toContain(localBin)
+      expect(path).toContain('/usr/bin')
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
   })
 })

--- a/src/workspaces/spawn-env.ts
+++ b/src/workspaces/spawn-env.ts
@@ -14,6 +14,10 @@
  * have, then announce ourselves with `TERM_PROGRAM=auto-quant-launcher`.
  */
 
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
 const STRIP_EXACT = new Set<string>([
   'TERM_PROGRAM',
   'TERM_PROGRAM_VERSION',
@@ -32,6 +36,27 @@ const STRIP_PREFIXES = [
 ];
 
 const SELF_VERSION = '0.1.0';
+
+const POSIX_SYSTEM_BIN_DIRS = [
+  '/opt/homebrew/bin',
+  '/opt/homebrew/sbin',
+  '/usr/local/bin',
+  '/usr/local/sbin',
+  '/usr/bin',
+  '/bin',
+  '/usr/sbin',
+  '/sbin',
+] as const;
+
+const POSIX_USER_BIN_DIRS = [
+  '.local/bin',
+  '.npm-global/bin',
+  'Library/pnpm',
+  '.yarn/bin',
+  '.bun/bin',
+  '.cargo/bin',
+  '.volta/bin',
+] as const;
 
 export function buildSpawnEnv(
   parent: NodeJS.ProcessEnv,
@@ -68,7 +93,44 @@ export function buildSpawnEnv(
   for (const [k, v] of Object.entries(extras)) {
     out[k] = v;
   }
+  out['PATH'] = buildCliPath(out);
   return out;
+}
+
+/**
+ * Build a PATH suitable for launching user-installed agent CLIs from a GUI app.
+ *
+ * macOS apps launched from Finder do not inherit the user's login-shell PATH,
+ * so Homebrew / pnpm / ~/.local installs disappear even though `codex` or
+ * `claude` works in Terminal. Keep this pure and synchronous: it is used both
+ * for `/agents` availability probes and for the actual PTY spawn env.
+ */
+export function buildCliPath(env: NodeJS.ProcessEnv = process.env): string {
+  const path = env['PATH'] ?? env['Path'] ?? '';
+  if (process.platform === 'win32') return path;
+
+  const home = env['HOME'] ?? homedir();
+  const pathEntries = path.split(delimiter);
+  const candidates = [
+    ...(env['OPENALICE_EXTRA_AGENT_PATH'] ?? '').split(delimiter),
+    ...pathEntries,
+    env['PNPM_HOME'],
+    ...POSIX_USER_BIN_DIRS.map((p) => join(home, p)),
+    ...POSIX_SYSTEM_BIN_DIRS,
+  ];
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of candidates) {
+    const dir = raw?.trim();
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+    // Keep existing PATH entries even if the directory is currently missing:
+    // they came from the host and may be intentional. For inferred fallbacks,
+    // include only real directories to avoid bloating every spawned shell.
+    if (pathEntries.includes(dir) || existsSync(dir)) out.push(dir);
+  }
+  return out.join(delimiter);
 }
 
 function shouldStrip(name: string): boolean {


### PR DESCRIPTION
## Summary
- augment workspace agent PATHs for macOS GUI launches so Homebrew, pnpm, and user-local CLI installs are visible
- use the same augmented PATH for /api/workspaces/agents detection and PTY spawn envs
- bump to 0.70.0-beta.8 for the packaged-app fix release

## Verification
- pnpm vitest run src/workspaces/spawn-env.spec.ts src/workspaces/agent-detect.spec.ts
- npx tsc --noEmit
- CI=true pnpm test
- CI=true pnpm build
- manual: launched dist/main.js with PATH=/usr/bin:/bin and confirmed /api/workspaces/agents resolves claude/codex/opencode/pi; beta.7 on 47331 returns all false under the same machine