### PR TITLE
[codex] Fix release CDN verification script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,20 +446,12 @@ jobs:
           curl -fsSI "${BASE_URL}/manifest.json"
 
           WINDOWS_FEED_EXE=$(
-            WINDOWS_METADATA="$WINDOWS_METADATA" node - <<'NODE'
-            const fs = require('fs')
-            const metadata = process.env.WINDOWS_METADATA
-            const content = fs.readFileSync(`dist/r2-upload/${metadata}`, 'utf8')
-            const match = content.match(/(?:^|\n)path:\s*['"]?([^'"\n]+)['"]?/)
-            process.stdout.write(match?.[1]?.trim() || '')
-            NODE
+            WINDOWS_METADATA="$WINDOWS_METADATA" node -e "const fs=require('fs');const content=fs.readFileSync('dist/r2-upload/'+process.env.WINDOWS_METADATA,'utf8');const match=content.match(/(?:^|\\n)path:\\s*['\"]?([^'\"\\n]+)['\"]?/);process.stdout.write(match?.[1]?.trim()||'')"
           )
 
           if [ -n "$WINDOWS_FEED_EXE" ]; then
             WINDOWS_FEED_URL=$(
-              WINDOWS_FEED_EXE="$WINDOWS_FEED_EXE" node - <<'NODE'
-              process.stdout.write(encodeURI(process.env.WINDOWS_FEED_EXE))
-              NODE
+              WINDOWS_FEED_EXE="$WINDOWS_FEED_EXE" node -e "process.stdout.write(encodeURI(process.env.WINDOWS_FEED_EXE))"
             )
             curl -fsSI "${BASE_URL}/${WINDOWS_FEED_URL}"
             curl -fsSI "${BASE_URL}/${WINDOWS_FEED_URL}.blockmap"


### PR DESCRIPTION
## Summary

Fixes the release mirror verification step that failed after assets were already uploaded.

- replaces nested here-doc command substitutions with `node -e`
- keeps the same checks for beta feeds, stable download aliases, manifest, Windows feed exe, and blockmap

## Validation

- Parsed the generated workflow YAML locally
- Ran `git diff --check` on the generated workflow diff
- Confirmed current CDN assets are already 200 after the previous mirror run
