### PR TITLE
[codex] Fix packaged credential injection smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Thumbs.db
 
 # Build cache
 *.tsbuildinfo
+/*.tgz
 
 # Test
 coverage/

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -163,11 +163,14 @@ app.whenReady().then(async () => {
   const utaEntry = resolve(repoRoot, 'services', 'uta', 'dist', 'uta.js')
 
   // Two homes — user data vs app resources. See src/core/paths.ts for why
-  // they're split. User data lives at ~/.openalice in BOTH branches — one
-  // store shared with `pnpm dev` and bare `pnpm start`, so accounts are
-  // configured once, not per topology. App resources stay lifecycle-owned:
+  // they're split. User data lives at ~/.openalice by default in BOTH branches
+  // — one store shared with `pnpm dev` and bare `pnpm start`, so accounts are
+  // configured once, not per topology. An explicit OPENALICE_HOME is honored
+  // for local packaged smoke tests, where we need app.isPackaged=true without
+  // touching the user's real store. App resources stay lifecycle-owned:
   // .app/Contents/Resources when packaged, the repo in dev.
-  const userDataHome = join(homedir(), '.openalice')
+  const explicitUserDataHome = process.env['OPENALICE_HOME']?.trim()
+  const userDataHome = explicitUserDataHome || join(homedir(), '.openalice')
   const homeEnv = app.isPackaged
     ? {
         OPENALICE_HOME: userDataHome,
@@ -187,7 +190,7 @@ app.whenReady().then(async () => {
   // backend boots (it would run migrations against an empty store). On
   // failure: surface and quit — booting beside the user's real data would
   // fork their trading history.
-  if (app.isPackaged) {
+  if (app.isPackaged && !explicitUserDataHome) {
     try {
       await relocateLegacyData(app.getPath('userData'), userDataHome)
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "electron:build": "pnpm build && pnpm electron:tsc",
     "electron:dev": "pnpm electron:build && pnpm -F @traderalice/desktop dev",
     "electron:pack": "pnpm electron:build && pnpm -F @traderalice/desktop pack",
+    "electron:smoke:packaged": "node scripts/desktop-packaged-smoke.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",

--- a/scripts/desktop-packaged-smoke.mjs
+++ b/scripts/desktop-packaged-smoke.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { delimiter, join, resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dirname, '..')
+const args = new Set(process.argv.slice(2))
+const skipBuild = args.has('--skip-build')
+const skipPack = args.has('--skip-pack')
+const keep = args.has('--keep')
+const tempData = args.has('--temp-data')
+const realDataFlag = args.has('--real-data')
+const signed = args.has('--signed')
+const help = args.has('--help') || args.has('-h')
+const knownArgs = new Set(['--skip-build', '--skip-pack', '--keep', '--temp-data', '--real-data', '--signed', '--help', '-h'])
+const unknownArgs = [...args].filter((arg) => !knownArgs.has(arg))
+
+function printHelp() {
+  console.log(`Usage: pnpm electron:smoke:packaged [options]
+
+Build, pack, and launch the local unsigned OpenAlice.app with app.isPackaged=true.
+
+Options:
+  --skip-build   Reuse the existing dist/ backend and desktop JS
+  --skip-pack    Reuse the existing dist/electron-app/OpenAlice.app
+  --temp-data    Use isolated temporary data/workspace/global stores
+  --real-data    Use real data explicitly (default; kept for compatibility)
+  --signed       Allow local macOS code signing (default disables it)
+  --keep         Keep the temporary smoke data directory after the app exits
+  -h, --help     Show this help
+`)
+}
+
+if (help) {
+  printHelp()
+  process.exit(0)
+}
+
+if (unknownArgs.length > 0) {
+  console.error(`[desktop-smoke] unknown option(s): ${unknownArgs.join(', ')}`)
+  printHelp()
+  process.exit(1)
+}
+
+if (tempData && realDataFlag) {
+  console.error('[desktop-smoke] choose either --temp-data or --real-data, not both')
+  process.exit(1)
+}
+
+const realData = !tempData
+
+function run(label, command, commandArgs, extraEnv = {}) {
+  console.log(`\n[desktop-smoke] ${label}`)
+  const result = spawnSync(command, commandArgs, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: { ...process.env, ...extraEnv },
+  })
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}
+
+function findPackagedApp() {
+  const candidates = [
+    'dist/electron-app/mac-arm64/OpenAlice.app',
+    'dist/electron-app/mac/OpenAlice.app',
+    'dist/electron-app/OpenAlice.app',
+  ].map((p) => resolve(repoRoot, p))
+  return candidates.find((p) => existsSync(join(p, 'Contents', 'MacOS', 'OpenAlice'))) ?? null
+}
+
+if (process.platform !== 'darwin') {
+  console.error('[desktop-smoke] packaged .app smoke currently runs on macOS only')
+  process.exit(1)
+}
+
+if (!skipBuild) run('build desktop bundle', 'pnpm', ['electron:build'])
+if (!skipPack) {
+  run(
+    signed ? 'pack signed app directory' : 'pack unsigned app directory',
+    'pnpm',
+    ['-F', '@traderalice/desktop', 'run', 'pack'],
+    signed ? {} : { CSC_IDENTITY_AUTO_DISCOVERY: 'false' },
+  )
+}
+
+const appPath = findPackagedApp()
+if (!appPath) {
+  console.error('[desktop-smoke] OpenAlice.app not found under dist/electron-app; run without --skip-pack first')
+  process.exit(1)
+}
+
+const smokeRoot = realData ? null : mkdtempSync(join(tmpdir(), 'openalice-desktop-smoke-'))
+const smokeHome = smokeRoot ? join(smokeRoot, 'home') : null
+const smokeWorkspaces = smokeRoot ? join(smokeRoot, 'workspaces') : null
+const smokeGlobal = smokeRoot ? join(smokeRoot, 'global') : null
+
+const pathAdditions = [
+  process.env['OPENALICE_EXTRA_AGENT_PATH'],
+  join(homedir(), 'Library', 'pnpm'),
+  join(homedir(), '.npm-global', 'bin'),
+  join(homedir(), '.local', 'bin'),
+].filter(Boolean)
+
+const env = {
+  ...process.env,
+  PATH: [process.env['PATH'], ...pathAdditions].filter(Boolean).join(delimiter),
+  OPENALICE_EXTRA_AGENT_PATH: pathAdditions.join(delimiter),
+}
+
+if (!realData && smokeHome && smokeWorkspaces && smokeGlobal) {
+  env.OPENALICE_HOME = smokeHome
+  env.AQ_LAUNCHER_ROOT = smokeWorkspaces
+  env.OPENALICE_GLOBAL_DIR = smokeGlobal
+}
+
+console.log('\n[desktop-smoke] launching packaged app')
+console.log(`[desktop-smoke] app: ${appPath}`)
+if (realData) {
+  console.log('[desktop-smoke] data: real ~/.openalice (default)')
+} else if (smokeHome && smokeWorkspaces && smokeGlobal) {
+  console.log(`[desktop-smoke] data: ${smokeHome}`)
+  console.log(`[desktop-smoke] workspaces: ${smokeWorkspaces}`)
+  console.log(`[desktop-smoke] global provider keys: ${smokeGlobal}`)
+}
+console.log('[desktop-smoke] close the app window or press Ctrl-C here to stop')
+
+const child = spawn(join(appPath, 'Contents', 'MacOS', 'OpenAlice'), [], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+  env,
+})
+
+const cleanup = () => {
+  if (keep || realData || !smokeRoot) return
+  rmSync(smokeRoot, { recursive: true, force: true })
+}
+
+process.on('SIGINT', () => {
+  child.kill('SIGTERM')
+})
+process.on('SIGTERM', () => {
+  child.kill('SIGTERM')
+})
+
+child.on('exit', (code, signal) => {
+  cleanup()
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 0)
+})

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -300,24 +300,25 @@ export const DEEPSEEK: PresetDef = {
 export const LONGCAT: PresetDef = {
   id: 'longcat',
   label: 'LongCat (Meituan)',
-  description: 'Meituan LongCat via OpenAI-compatible API',
+  description: 'Meituan LongCat via OpenAI-compatible and Anthropic APIs',
   category: 'third-party',
   defaultName: 'LongCat',
-  hint: 'Uses the OpenAI-compatible endpoint you tested locally. This preset declares OpenAI Chat only; use opencode or Pi for this credential unless LongCat adds a Responses-compatible endpoint later.',
+  hint: 'Declares LongCat\'s OpenAI-compatible and Anthropic endpoints. Use Claude/OpenCode/Pi for this credential unless LongCat adds a Responses-compatible endpoint later.',
   zodSchema: z.object({
     backend: z.literal('vercel-ai-sdk'),
     provider: z.literal('openai-compatible'),
     baseUrl: z.string().default('https://api.longcat.chat/openai').describe('API endpoint'),
-    model: z.string().default('longcat-2.0').describe('Model'),
+    model: z.string().default('LongCat-2.0').describe('Model'),
     apiKey: z.string().min(1).describe('LongCat API key'),
   }),
   regions: [
     { id: 'default', label: 'LongCat (api.longcat.chat)', wires: {
       'openai-chat': 'https://api.longcat.chat/openai',
+      anthropic: 'https://api.longcat.chat/anthropic',
     } },
   ],
   models: [
-    { id: 'longcat-2.0', label: 'LongCat 2.0' },
+    { id: 'LongCat-2.0', label: 'LongCat 2.0' },
   ],
   writeOnlyFields: ['apiKey'],
 }
@@ -376,5 +377,5 @@ export const DEFAULT_MODEL_BY_VENDOR: Record<string, string> = {
   glm: 'glm-5.2',
   kimi: 'kimi-k2.7-code',
   deepseek: 'deepseek-v4-pro',
-  longcat: 'longcat-2.0',
+  longcat: 'LongCat-2.0',
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -920,9 +920,11 @@ export async function addCredential(credential: Credential): Promise<string> {
   )
   if (match) {
     // Upgrade the existing record's wires/endpoint in place (don't duplicate).
+    const existing = match[1]
     config.credentials[match[0]] = {
       ...validated,
-      ...(validated.label ?? match[1].label ? { label: validated.label ?? match[1].label } : {}),
+      ...(validated.label ?? existing.label ? { label: validated.label ?? existing.label } : {}),
+      ...(validated.lastModel ?? existing.lastModel ? { lastModel: validated.lastModel ?? existing.lastModel } : {}),
     }
     await mkdir(CONFIG_DIR, { recursive: true })
     await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')

--- a/src/webui/routes/config-workspace-defaults.spec.ts
+++ b/src/webui/routes/config-workspace-defaults.spec.ts
@@ -30,12 +30,25 @@ vi.mock('../../core/config.js', async () => {
     writeWorkspaceDefaultAgent: vi.fn(async (agent: string | null) => {
       defaultAgentStore = agent
     }),
+    addCredential: vi.fn(async (credential: Credential) => {
+      const slug = `${credential.vendor}-${Object.keys(credStore).length + 1}`
+      credStore[slug] = credential
+      return slug
+    }),
+    resolveCredential: vi.fn(async (slug: string) => {
+      const cred = credStore[slug]
+      if (!cred) throw new Error(`Unknown credential: "${slug}"`)
+      return cred
+    }),
+    writeCredential: vi.fn(async (slug: string, credential: Credential) => {
+      credStore[slug] = credential
+    }),
   }
 })
 
 import { createConfigRoutes } from './config.js'
 
-async function req(routes: ReturnType<typeof createConfigRoutes>, method: 'GET' | 'PUT', path: string, body?: unknown) {
+async function req(routes: ReturnType<typeof createConfigRoutes>, method: 'GET' | 'POST' | 'PUT', path: string, body?: unknown) {
   const init: RequestInit = { method }
   if (body !== undefined) {
     init.headers = { 'Content-Type': 'application/json' }
@@ -73,6 +86,25 @@ describe('GET /workspace-credential-defaults', () => {
     // opencode/pi speak chat|anthropic|responses → every key qualifies.
     expect(new Set(compat.opencode)).toEqual(new Set(['anthropic-1', 'openai-1', 'chat-1']))
     expect(new Set(compat.pi)).toEqual(new Set(['anthropic-1', 'openai-1', 'chat-1']))
+  })
+})
+
+describe('POST /credentials', () => {
+  it('stores lastModel so custom provider injection has a default model', async () => {
+    const routes = createConfigRoutes()
+
+    const { status, body } = await req(routes, 'POST', '/credentials', {
+      vendor: 'custom',
+      label: 'Gateway',
+      apiKey: 'sk-gw',
+      wires: { 'openai-chat': 'https://gw/v1' },
+      lastModel: 'longmao-chat',
+    })
+
+    expect(status).toBe(201)
+    const slug = body!.slug
+    expect(typeof slug).toBe('string')
+    expect(credStore[slug as string]).toMatchObject({ lastModel: 'longmao-chat' })
   })
 })
 

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -85,11 +85,12 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
   /** POST /credentials — add an api-key credential (deduped by key). Returns slug. */
   app.post('/credentials', async (c) => {
     try {
-      const body = await c.req.json<{ vendor?: string; label?: string; wires?: unknown; apiKey?: string }>()
+      const body = await c.req.json<{ vendor?: string; label?: string; wires?: unknown; apiKey?: string; lastModel?: string }>()
       const apiKey = body.apiKey?.trim()
       if (!apiKey) return c.json({ error: 'apiKey is required' }, 400)
       const vendorParse = credentialVendorEnum.safeParse(body.vendor)
       const label = body.label?.trim()
+      const lastModel = body.lastModel?.trim()
       const wires = parseWires(body.wires)
       const cred: Credential = {
         vendor: vendorParse.success ? vendorParse.data : 'custom',
@@ -97,6 +98,7 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
         authType: 'api-key',
         apiKey,
         ...(Object.keys(wires).length ? { wires } : {}),
+        ...(lastModel ? { lastModel } : {}),
       }
       const slug = await addCredential(cred)
       return c.json({ slug, vendor: cred.vendor }, 201)
@@ -109,11 +111,12 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
   app.put('/credentials/:slug', async (c) => {
     try {
       const slug = c.req.param('slug')
-      const body = await c.req.json<{ vendor?: string; label?: string; wires?: unknown; apiKey?: string }>()
+      const body = await c.req.json<{ vendor?: string; label?: string; wires?: unknown; apiKey?: string; lastModel?: string }>()
       const existing = await resolveCredential(slug)
       const apiKey = body.apiKey?.trim() || existing.apiKey
       const vendorParse = credentialVendorEnum.safeParse(body.vendor)
       const label = body.label?.trim()
+      const lastModel = body.lastModel?.trim() || existing.lastModel
       const wires = parseWires(body.wires)
       const cred: Credential = {
         vendor: vendorParse.success ? vendorParse.data : existing.vendor,
@@ -121,6 +124,7 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
         authType: 'api-key',
         ...(apiKey ? { apiKey } : {}),
         ...(Object.keys(wires).length ? { wires } : { ...(existing.wires ? { wires: existing.wires } : {}) }),
+        ...(lastModel ? { lastModel } : {}),
       }
       await writeCredential(slug, cred)
       return c.json({ slug })

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -257,7 +257,7 @@ describe('resolveInjectionModel', () => {
   it('falls back to the vendor flagship when no lastModel', () => {
     expect(resolveInjectionModel({ vendor: 'anthropic' })).toBe('claude-opus-4-8')
     expect(resolveInjectionModel({ vendor: 'glm' })).toBe('glm-5.2')
-    expect(resolveInjectionModel({ vendor: 'longcat' })).toBe('longcat-2.0')
+    expect(resolveInjectionModel({ vendor: 'longcat' })).toBe('LongCat-2.0')
   })
 
   it('returns null for a vendor with no catalog default (custom)', () => {

--- a/ui/src/api/config.ts
+++ b/ui/src/api/config.ts
@@ -37,7 +37,7 @@ export const configApi = {
     return res.json()
   },
 
-  async addCredential(input: { vendor: string; label?: string; wires: Partial<Record<WireShape, string>>; apiKey: string }): Promise<{ slug: string; vendor: string }> {
+  async addCredential(input: { vendor: string; label?: string; wires: Partial<Record<WireShape, string>>; apiKey: string; lastModel?: string }): Promise<{ slug: string; vendor: string }> {
     const res = await fetch('/api/config/credentials', { method: 'POST', headers, body: JSON.stringify(input) })
     if (!res.ok) {
       const err = await res.json().catch(() => ({ error: 'Failed to add credential' }))
@@ -46,7 +46,7 @@ export const configApi = {
     return res.json()
   },
 
-  async updateCredential(slug: string, input: { vendor: string; label?: string; wires: Partial<Record<WireShape, string>>; apiKey?: string }): Promise<void> {
+  async updateCredential(slug: string, input: { vendor: string; label?: string; wires: Partial<Record<WireShape, string>>; apiKey?: string; lastModel?: string }): Promise<void> {
     const res = await fetch(`/api/config/credentials/${encodeURIComponent(slug)}`, { method: 'PUT', headers, body: JSON.stringify(input) })
     if (!res.ok) {
       const err = await res.json().catch(() => ({ error: 'Failed to update credential' }))
@@ -121,4 +121,6 @@ export interface CredentialSummary {
   /** The stored key (admin-gated; lets the edit form round-trip it). */
   apiKey: string | null
   hasApiKey: boolean
+  /** Last model successfully used with this key, reused by quick-chat injection. */
+  lastModel?: string
 }

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -418,7 +418,7 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
   const [apiKey, setApiKey] = useState(cred?.apiKey ?? '')
   const [presetQuery, setPresetQuery] = useState('')
   const [showKey, setShowKey] = useState(false)
-  const [model, setModel] = useState('')
+  const [model, setModel] = useState(cred?.lastModel ?? '')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const gate = useTestGate()
@@ -489,6 +489,7 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
           vendor, wires,
           ...(isCustom ? { label: customLabel } : {}),
           ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+          ...(model.trim() ? { lastModel: model.trim() } : {}),
         })
       } else {
         if (!apiKey.trim()) { setError('API key is required'); setSaving(false); return }
@@ -497,6 +498,7 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
           wires,
           apiKey: apiKey.trim(),
           ...(isCustom ? { label: customLabel } : {}),
+          ...(model.trim() ? { lastModel: model.trim() } : {}),
         })
       }
       await onSaved()
@@ -633,7 +635,7 @@ function CredentialModal({ mode, cred, presets, onClose, onSaved }: {
                 </div>
               </Field>
 
-              <Field label="Test model" description="Used only to verify the key — not stored on the credential (the model is chosen per workspace).">
+              <Field label="Test model" description="Used to verify the key and remembered as the default for quick-chat injection. Workspaces can still choose a different model.">
                 <ModelCombobox value={model} suggestions={models} onChange={setModel} />
               </Field>
 


### PR DESCRIPTION
## Summary

- add a local packaged Electron smoke command that launches the packed `.app` with `app.isPackaged=true` before release artifacts go out
- fix LongCat provider metadata so it declares both OpenAI Chat and Anthropic endpoints with `LongCat-2.0` as the default model
- persist `lastModel` through credential add/edit so loginless quick-chat injection gives OpenCode/Pi a concrete model instead of a key-only provider

## Root Cause

The packaged quick-chat path did write provider config for OpenCode/Pi, but the LongCat credential had no remembered model. In packaged smoke, model fetching is disabled, so the runtime could receive the key and endpoint while still having no model to run.

## Validation

- `pnpm vitest run src/workspaces/credential-injection.spec.ts src/webui/routes/config-workspace-defaults.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- checked the running packaged backend reports OpenCode/Pi using `custom-1` with `LongCat-2.0` after local data repair
