### PR TITLE
[codex] Polish activity bar rail controls

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -182,6 +182,7 @@ function AppShell() {
         <ActivityBar
           open={sidebarOpen}
           onClose={() => setSidebarOpen(false)}
+          desktopStatic={isDesktop}
           sidebarVisible={showSidebarPanel || secondaryOpen}
           onItemActivated={(landedOn) => {
             // Drill-down for any viewport without a static sidebar (<1024):
@@ -312,4 +313,3 @@ function MobileSecondaryDrawer({ open, section, onClose, onBack }: MobileSeconda
     </>
   )
 }
-

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import { type LucideIcon, MessageSquare, Inbox, Telescope, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Info, ListChecks } from 'lucide-react'
+import { type LucideIcon, MessageSquare, Inbox, Telescope, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Info, ListChecks, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { useState } from 'react'
 import { type Page } from '../App'
 import { findSectionForActivity } from '../sections'
@@ -34,6 +34,8 @@ function activitySectionFor(page: Page): ActivitySection {
 interface ActivityBarProps {
   open: boolean
   onClose: () => void
+  /** True once the rail is static (>= md). The compact rail is desktop-only. */
+  desktopStatic?: boolean
   /**
    * Whether the secondary sidebar is actually on screen right now (a static
    * panel on wide, or the open drawer on narrow). Re-clicking the active
@@ -174,7 +176,7 @@ const NAV_SECTIONS: NavSection[] = [
  * lifecycle stages and the section labels are how we'll later
  * communicate that. Mostly-icon view would hide the differentiation.
  */
-export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = true }: ActivityBarProps) {
+export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = true, desktopStatic = true }: ActivityBarProps) {
   const { t } = useTranslation()
   const selectedSidebar = useWorkspace((state) => state.selectedSidebar)
   const setSidebar = useWorkspace((state) => state.setSidebar)
@@ -183,6 +185,9 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
   const pendingPush = usePendingPushCount()
   const collapsedSections = useActivityBarCollapse((s) => s.collapsedSections)
   const setCollapsed = useActivityBarCollapse((s) => s.setCollapsed)
+  const railCollapsed = useActivityBarCollapse((s) => s.railCollapsed)
+  const setRailCollapsed = useActivityBarCollapse((s) => s.setRailCollapsed)
+  const compactRail = railCollapsed && desktopStatic
 
   return (
     <>
@@ -198,28 +203,28 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
        *  page with backdrop. Desktop: static column flush left. */}
       <aside
         className={`
-          w-[280px] md:w-[188px] h-full flex flex-col shrink-0
+          w-[280px] ${railCollapsed ? 'md:w-[60px]' : 'md:w-[188px]'} h-full flex flex-col shrink-0
           bg-bg-tertiary
           border-r border-border/80
-          fixed z-50 top-0 left-0 transition-transform duration-200
+          fixed z-50 top-0 left-0 transition-[transform,width] duration-200
           ${open ? 'translate-x-0' : '-translate-x-full'}
-          md:static md:translate-x-0 md:z-auto md:transition-none
+          md:static md:translate-x-0 md:z-auto
         `}
       >
         {/* Branding — h-10 to line up with the Sidebar header + TabStrip
             (all three top surfaces share the 40px header rhythm). */}
-        <div className="h-10 px-4 flex items-center gap-2.5 shrink-0">
+        <div className={`h-10 mb-2 flex items-center shrink-0 ${compactRail ? 'pl-[22px] pr-4 gap-2.5 md:gap-0 md:pr-0' : 'pl-[22px] pr-4 gap-2.5'}`}>
           <img
             src="/alice.ico"
             alt="Alice"
-            className="w-6 h-6 rounded-full ring-1 ring-border shadow-[0_0_14px_var(--color-accent-dim)]"
+            className="w-6 h-6 shrink-0 rounded-full ring-1 ring-border shadow-[0_0_14px_var(--color-accent-dim)]"
             draggable={false}
           />
-          <h1 className="min-w-0 flex-1 truncate text-[15px] font-semibold text-text">OpenAlice</h1>
+          <h1 className={`min-w-0 flex-1 truncate text-[15px] font-semibold text-text ${compactRail ? 'md:hidden' : ''}`}>OpenAlice</h1>
         </div>
 
         {/* Navigation */}
-        <nav className="flex-1 flex flex-col px-3 overflow-y-auto pb-3">
+        <nav className={`flex-1 flex flex-col overflow-x-hidden overflow-y-auto pb-3 ${compactRail ? 'px-3 md:items-start' : 'px-3'}`}>
           {NAV_SECTIONS.map((section, si) => {
             const labeled = section.sectionLabel.length > 0
             // User toggle wins over default. The collapse store stores
@@ -230,10 +235,21 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
             const isCollapsed = labeled && (
               stored !== undefined ? stored : Boolean(section.defaultCollapsed)
             )
-            const showItems = !isCollapsed
+            const showItems = compactRail ? true : !isCollapsed
             return (
-              <div key={si} className={si > 0 ? 'mt-4' : ''}>
-                {labeled && (
+              <div
+                key={si}
+                className={
+                  compactRail && si > 0
+                    ? 'mt-3 border-t border-border/70 pt-3 md:w-11'
+                    : si > 0
+                      ? 'mt-4'
+                      : compactRail
+                        ? 'md:w-11'
+                        : ''
+                }
+              >
+                {labeled && !compactRail && (
                   <SectionHeader
                     label={section.labelKey ? t(section.labelKey) : section.sectionLabel}
                     description={section.descriptionKey ? t(section.descriptionKey) : undefined}
@@ -290,7 +306,11 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
                           type="button"
                           onClick={handleClick}
                           title={t(item.labelKey)}
-                          className={`relative flex min-h-[34px] items-center gap-3 rounded-md px-3 py-1.5 text-[13px] transition-colors text-left ${
+                          className={`relative flex min-h-[34px] items-center rounded-md text-[13px] transition-colors text-left ${
+                            compactRail
+                              ? 'md:h-9 md:w-11 md:min-h-9 md:justify-center md:gap-0 md:px-0 md:py-0'
+                              : 'gap-3 px-3 py-1.5'
+                          } ${
                             isActive
                               ? 'bg-accent-dim text-text'
                               : 'text-text-muted hover:text-text hover:bg-overlay'
@@ -306,11 +326,13 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
                           <span className="relative flex items-center justify-center w-5 h-5 shrink-0">
                             <Icon size={16} strokeWidth={1.75} />
                           </span>
-                          <span className="flex-1 truncate">{t(item.labelKey)}</span>
+                          <span className={`flex-1 truncate ${compactRail ? 'md:hidden' : ''}`}>{t(item.labelKey)}</span>
                           {item.page === 'inbox' && unreadInbox > 0 && (
                             <span
                               aria-label={t('nav.unread', { count: unreadInbox })}
-                              className="shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center"
+                              className={`shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center ${
+                                compactRail ? 'md:absolute md:-right-1 md:-top-1 md:h-4 md:min-w-4 md:px-1 md:text-[9px]' : ''
+                              }`}
                             >
                               {unreadInbox > 99 ? '99+' : unreadInbox}
                             </span>
@@ -318,7 +340,9 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
                           {item.page === 'trading-as-git' && pendingPush > 0 && (
                             <span
                               aria-label={t('nav.pendingPush', { count: pendingPush })}
-                              className="shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center"
+                              className={`shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center ${
+                                compactRail ? 'md:absolute md:-right-1 md:-top-1 md:h-4 md:min-w-4 md:px-1 md:text-[9px]' : ''
+                              }`}
                             >
                               {pendingPush > 99 ? '99+' : pendingPush}
                             </span>
@@ -333,11 +357,20 @@ export function ActivityBar({ open, onClose, onItemActivated, sidebarVisible = t
           })}
         </nav>
 
-        {/* Footer — global toggles pinned to the bottom of the rail.
-            py-1.5 matches the nav-item rhythm above (the top border
-            already provides the separation). */}
-        <div className="shrink-0 border-t border-border px-3 py-1.5">
+        {/* Footer — global icon controls pinned to the bottom of the rail. */}
+        <div className={`shrink-0 px-4 flex items-center ${compactRail ? 'py-2 md:flex-col md:items-start md:px-4 md:gap-1' : 'border-t border-border py-1.5 justify-between gap-2'}`}>
           <ThemeToggle />
+          <button
+            type="button"
+            onClick={() => setRailCollapsed(!railCollapsed)}
+            title={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
+            aria-label={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
+            className="hidden h-9 w-9 shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text md:flex"
+          >
+            {railCollapsed
+              ? <PanelLeftOpen size={17} strokeWidth={1.75} aria-hidden />
+              : <PanelLeftClose size={17} strokeWidth={1.75} aria-hidden />}
+          </button>
         </div>
       </aside>
     </>

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -1,24 +1,18 @@
 /**
- * The color-theme toggle that lives in the ActivityBar footer. One button
- * that cycles auto → light → dark → auto; the icon + label reflect the
- * CURRENT mode, the tooltip names the NEXT one. Styled to match the nav rows
- * above it (same height, padding, hover) so the rail reads as one column.
+ * The color-theme toggle that lives in the ActivityBar footer. One icon
+ * button cycles auto → light → dark → auto. The icon reflects the concrete
+ * effective palette (sun / moon); auto adds a tiny badge instead of using an
+ * abstract monitor icon.
  *
  * State is the theme store (ui/src/theme/store); the side-effect module
  * applies `<html data-theme>`, CSS does the rest. No prop drilling.
  */
 
-import { Monitor, Moon, Sun } from 'lucide-react'
-import type { LucideIcon } from 'lucide-react'
+import { Moon, Sun } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { useThemeStore, type AppTheme } from '../theme/store'
-
-const ICON: Record<AppTheme, LucideIcon> = {
-  auto: Monitor,
-  light: Sun,
-  dark: Moon,
-}
+import { useEffectiveTheme } from '../theme/useEffectiveTheme'
 
 /** What the NEXT click switches to (auto → light → dark → auto). */
 const NEXT: Record<AppTheme, AppTheme> = {
@@ -31,7 +25,8 @@ export function ThemeToggle() {
   const { t } = useTranslation()
   const theme = useThemeStore((s) => s.theme)
   const cycle = useThemeStore((s) => s.cycleTheme)
-  const Icon = ICON[theme]
+  const effectiveTheme = useEffectiveTheme()
+  const Icon = effectiveTheme === 'dark' ? Moon : Sun
 
   return (
     <button
@@ -39,12 +34,17 @@ export function ThemeToggle() {
       onClick={cycle}
       title={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
       aria-label={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
-      className="relative flex min-h-[34px] w-full items-center gap-3 rounded-md px-3 py-1.5 text-left text-[13px] text-text-muted transition-colors hover:bg-overlay hover:text-text"
+      className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
     >
-      <span className="relative flex h-5 w-5 shrink-0 items-center justify-center">
-        <Icon size={16} strokeWidth={1.75} />
-      </span>
-      <span className="flex-1 truncate">{t(`theme.mode.${theme}`)}</span>
+      <Icon size={17} strokeWidth={1.75} aria-hidden />
+      {theme === 'auto' && (
+        <span
+          className="absolute right-0 top-0 rounded-[3px] border border-border bg-bg-tertiary px-[2px] py-px text-[7px] font-semibold leading-none text-text-muted shadow-sm"
+          aria-hidden
+        >
+          Auto
+        </span>
+      )}
     </button>
   )
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -37,6 +37,8 @@ export const en = {
     unread: '{{count}} unread',
     pendingPush: '{{count}} pending to push',
     about: 'About {{label}}',
+    collapseRail: 'Collapse activity bar',
+    expandRail: 'Expand activity bar',
   },
   settings: {
     title: 'Settings',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -26,6 +26,8 @@ export const ja: Resources = {
     unread: '未読 {{count}} 件',
     pendingPush: 'プッシュ待ち {{count}} 件',
     about: '{{label}}について',
+    collapseRail: 'アクティビティバーを折りたたむ',
+    expandRail: 'アクティビティバーを展開',
   },
   settings: {
     title: '設定',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -34,6 +34,8 @@ export const zhHant: Resources = {
     unread: '{{count}} 則未讀',
     pendingPush: '{{count}} 筆待推送',
     about: '關於{{label}}',
+    collapseRail: '收合活動列',
+    expandRail: '展開活動列',
   },
   settings: {
     title: '設定',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -26,6 +26,8 @@ export const zh: Resources = {
     unread: '{{count}} 条未读',
     pendingPush: '{{count}} 笔待推送',
     about: '关于{{label}}',
+    collapseRail: '折叠活动栏',
+    expandRail: '展开活动栏',
   },
   settings: {
     title: '设置',

--- a/ui/src/live/activity-bar-collapse.ts
+++ b/ui/src/live/activity-bar-collapse.ts
@@ -26,6 +26,7 @@ reloadOnHotUpdate('live/activity-bar-collapse')
 
 interface ActivityBarCollapseState {
   collapsedSections: Record<string, boolean>
+  railCollapsed: boolean
 }
 
 interface ActivityBarCollapseActions {
@@ -33,12 +34,14 @@ interface ActivityBarCollapseActions {
    *  `defaultCollapsed` so the store can prune the key when the user's
    *  preference now matches the default — keeps localStorage tight. */
   setCollapsed: (name: string, collapsed: boolean, defaultCollapsed?: boolean) => void
+  setRailCollapsed: (collapsed: boolean) => void
 }
 
 export const useActivityBarCollapse = create<ActivityBarCollapseState & ActivityBarCollapseActions>()(
   persist(
     (set) => ({
       collapsedSections: {},
+      railCollapsed: false,
       setCollapsed: (name, collapsed, defaultCollapsed) =>
         set((s) => {
           const next = { ...s.collapsedSections }
@@ -49,7 +52,8 @@ export const useActivityBarCollapse = create<ActivityBarCollapseState & Activity
           }
           return { collapsedSections: next }
         }),
+      setRailCollapsed: (collapsed) => set({ railCollapsed: collapsed }),
     }),
-    { name: 'openalice.activitybar-sections.v1', version: 1 },
+    { name: 'openalice.activitybar-sections.v1', version: 2 },
   ),
 )


### PR DESCRIPTION
## Summary

- Replace the full-width theme row with a compact icon-only control that still communicates Auto via a small badge.
- Add a desktop-only collapsible Activity Bar rail with persisted state and an expand/collapse icon button.
- Align the brand avatar, activity icons, active indicator, footer controls, and compact rail spacing so the collapsed state does not visually jump.
- Hide horizontal overflow in the compact nav so the browser does not expose a horizontal scrollbar above the theme control.

## Root Cause

The compact rail introduced icon-only controls, but the nav buttons were wider than the padded scroll container. Because the nav used `overflow-y-auto`, the browser also exposed horizontal overflow as a scrollbar in the collapsed rail. The brand/avatar and activity icon positions also had separate padding/centering rules, which made their collapsed positions drift slightly from the expanded layout.

## Validation

- Browser-verified on `http://localhost:5173/chat`: compact rail icon centers remain aligned at x=34, the active bar stays fixed, and `overflowX` is hidden while vertical scrolling remains auto.
- `npx tsc --noEmit`
- `cd ui && ../node_modules/.bin/tsc -b`
- `pnpm test`