### PR TITLE
Fix page sidebar workspace height regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.71.0-beta",
+  "version": "0.72.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -157,7 +157,7 @@ export function PageSidebarLayout({
           {sidebarPanel}
         </div>
         <ResizeHandle width={width} maxWidth={maxWidth} onPointerDown={beginResize} />
-        <div className="min-w-0 flex-1">
+        <div className="min-h-0 min-w-0 flex flex-1 flex-col">
           {children}
         </div>
       </div>
@@ -178,7 +178,7 @@ export function PageSidebarLayout({
         </button>
         <span className="min-w-0 truncate text-[13px] font-semibold text-text">{title}</span>
       </div>
-      <div className="flex-1 min-h-0">{children}</div>
+      <div className="flex min-h-0 flex-1 flex-col">{children}</div>
 
       <div
         className={`absolute inset-0 z-30 bg-black/40 transition-opacity duration-200 ${


### PR DESCRIPTION
## Summary\n- fix page-owned sidebar content containers so workspace terminals inherit full height\n- bump product version to 0.72.0-beta\n\n## Verification\n- cd ui && npx tsc -b\n- npx tsc --noEmit\n- git diff --check\n- browser verified /chat/workspaces/:wsId/s/:sessionId after reload: terminal-shell 576px, xterm 527px\n