### PR TITLE
Add Electron IPC transport and CLI smoke coverage

### DIFF
--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -1,0 +1,378 @@
+import { ipcMain, type WebContents } from 'electron'
+import type { ChildProcess, Serializable } from 'node:child_process'
+import { lstat, readFile, readdir, realpath, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { isAbsolute, join, normalize, resolve, sep } from 'node:path'
+
+interface WorkspaceMeta {
+  readonly id: string
+  readonly dir: string
+}
+
+interface FileEntry {
+  readonly name: string
+  readonly kind: 'file' | 'dir' | 'symlink' | 'other'
+  readonly sizeBytes: number | null
+  readonly mtime: string
+}
+
+export interface OpenAliceIpcOptions {
+  readonly mode: 'electron-dev' | 'electron-packaged'
+  readonly userDataHome: string
+  readonly appHome: string
+  readonly webPort: number | null
+  readonly mcpPort: number | null
+  readonly utaPort: number
+  readonly getAliceProcess: () => ChildProcess | null
+}
+
+const MSG_WEB_REQUEST = 'openalice:web:request'
+const MSG_WEB_RESPONSE = 'openalice:web:response'
+const MSG_PTY_CONNECT = 'openalice:pty:connect'
+const MSG_PTY_CLIENT = 'openalice:pty:client-message'
+const MSG_PTY_CLIENT_CLOSE = 'openalice:pty:client-close'
+const MSG_PTY_SERVER = 'openalice:pty:server-message'
+const MSG_PTY_SERVER_CLOSE = 'openalice:pty:server-close'
+
+interface PtyConnection {
+  readonly sender: WebContents
+}
+
+const ptyConnections = new Map<string, PtyConnection>()
+const pendingWebRequests = new Map<string, {
+  readonly resolve: (res: Response) => void
+  readonly reject: (err: Error) => void
+  readonly timer: ReturnType<typeof setTimeout>
+}>()
+
+class WorkspacePathTraversal extends Error {
+  constructor(readonly attempted: string) {
+    super(`refused to escape workspace: ${attempted}`)
+    this.name = 'WorkspacePathTraversal'
+  }
+}
+
+function workspaceLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+function validWorkspaceId(id: unknown): id is string {
+  return typeof id === 'string' && id.length > 0 && id.length <= 128
+}
+
+function validRelPath(path: unknown): path is string {
+  return typeof path === 'string' && path.length <= 4096
+}
+
+async function readWorkspaceMeta(id: string): Promise<WorkspaceMeta | null> {
+  const registryPath = resolve(workspaceLauncherRoot(), 'workspaces.json')
+  const raw = await readFile(registryPath, 'utf8')
+  const parsed = JSON.parse(raw) as { workspaces?: unknown[] }
+  const rows = Array.isArray(parsed.workspaces) ? parsed.workspaces : []
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') continue
+    const rec = row as Record<string, unknown>
+    if (rec['id'] === id && typeof rec['dir'] === 'string') {
+      return { id, dir: rec['dir'] }
+    }
+  }
+  return null
+}
+
+function resolveInsideWorkspace(workspaceDir: string, relPath: string): string {
+  const cleanRel = normalize(relPath || '.')
+  if (isAbsolute(cleanRel) || cleanRel === '..' || cleanRel.startsWith(`..${sep}`)) {
+    throw new WorkspacePathTraversal(relPath)
+  }
+  const abs = resolve(workspaceDir, cleanRel)
+  const workspaceAbs = resolve(workspaceDir)
+  if (abs !== workspaceAbs && !abs.startsWith(workspaceAbs + sep)) {
+    throw new WorkspacePathTraversal(relPath)
+  }
+  return abs
+}
+
+async function assertRealPathInsideWorkspace(workspaceDir: string, abs: string, relPath: string): Promise<void> {
+  const [workspaceReal, targetReal] = await Promise.all([
+    realpath(workspaceDir),
+    realpath(abs),
+  ])
+  if (targetReal !== workspaceReal && !targetReal.startsWith(workspaceReal + sep)) {
+    throw new WorkspacePathTraversal(relPath)
+  }
+}
+
+async function listWorkspaceDir(workspaceDir: string, relPath: string): Promise<{ path: string; entries: FileEntry[] }> {
+  const cleanRel = normalize(relPath || '.')
+  const abs = resolveInsideWorkspace(workspaceDir, relPath)
+  await assertRealPathInsideWorkspace(workspaceDir, abs, relPath)
+  const dirStat = await stat(abs)
+  if (!dirStat.isDirectory()) throw new Error(`not a directory: ${cleanRel}`)
+  const names = await readdir(abs)
+  const entries: FileEntry[] = []
+  for (const name of names) {
+    try {
+      const ls = await lstat(resolve(abs, name))
+      const kind: FileEntry['kind'] = ls.isSymbolicLink()
+        ? 'symlink'
+        : ls.isDirectory()
+          ? 'dir'
+          : ls.isFile()
+            ? 'file'
+            : 'other'
+      entries.push({
+        name,
+        kind,
+        sizeBytes: ls.isFile() ? ls.size : null,
+        mtime: ls.mtime.toISOString(),
+      })
+    } catch {
+      // Skip entries that disappear or become unreadable mid-list.
+    }
+  }
+  entries.sort((a, b) => {
+    if (a.kind === 'dir' && b.kind !== 'dir') return -1
+    if (a.kind !== 'dir' && b.kind === 'dir') return 1
+    return a.name.localeCompare(b.name)
+  })
+  return { path: cleanRel === '.' ? '' : cleanRel, entries }
+}
+
+function isENOENT(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && (err as { code?: string }).code === 'ENOENT'
+}
+
+/**
+ * Register Electron-only transports exposed through preload.ts.
+ *
+ * The HTTP/WS backend remains the compatibility plane for dev, Docker,
+ * self-hosted browsers, and future remote clients. IPC is the app-mode fast
+ * path for machine-local capabilities. This module owns the Electron-main side
+ * of workspace file read/list and PTY streaming; preload.ts keeps the renderer
+ * surface intentionally narrower than raw ipcRenderer.
+ */
+export function registerOpenAliceIpc(opts: OpenAliceIpcOptions): void {
+  ipcMain.handle('openalice:runtime:info', () => ({
+    mode: opts.mode,
+    transport: 'electron-ipc',
+    ports: { web: opts.webPort, mcp: opts.mcpPort, uta: opts.utaPort },
+    userDataHome: opts.userDataHome,
+    appHome: opts.appHome,
+  }))
+
+  ipcMain.handle('openalice:workspace:list-files', async (_event, input: unknown) => {
+    const body = input && typeof input === 'object' ? input as Record<string, unknown> : {}
+    if (!validWorkspaceId(body['id']) || !validRelPath(body['path'])) {
+      throw new Error('invalid workspace file request')
+    }
+    const meta = await readWorkspaceMeta(body['id'])
+    if (!meta) throw new Error('workspace_not_found')
+    return listWorkspaceDir(meta.dir, body['path'])
+  })
+
+  ipcMain.handle('openalice:workspace:read-file', async (_event, input: unknown) => {
+    const body = input && typeof input === 'object' ? input as Record<string, unknown> : {}
+    if (!validWorkspaceId(body['id']) || !validRelPath(body['path']) || body['path'].length === 0) {
+      return { kind: 'invalid_path' }
+    }
+    let meta: WorkspaceMeta | null
+    try {
+      meta = await readWorkspaceMeta(body['id'])
+    } catch (err) {
+      if (isENOENT(err)) return { kind: 'workspace_missing' }
+      return { kind: 'error', message: err instanceof Error ? err.message : String(err) }
+    }
+    if (!meta) return { kind: 'workspace_missing' }
+    try {
+      const abs = resolveInsideWorkspace(meta.dir, body['path'])
+      await assertRealPathInsideWorkspace(meta.dir, abs, body['path'])
+      const fileStat = await stat(abs)
+      if (fileStat.size > 1024 * 1024) return { kind: 'too_large', sizeBytes: fileStat.size }
+      const content = await readFile(abs, 'utf8')
+      return { kind: 'ok', content }
+    } catch (err) {
+      if (err instanceof WorkspacePathTraversal) return { kind: 'invalid_path' }
+      if (isENOENT(err)) return { kind: 'file_missing' }
+      return { kind: 'error', message: err instanceof Error ? err.message : String(err) }
+    }
+  })
+
+  ipcMain.on('openalice:pty:connect', (event, input: unknown) => {
+    const body = input && typeof input === 'object' ? input as Record<string, unknown> : {}
+    const connectionId = typeof body['connectionId'] === 'string' ? body['connectionId'] : ''
+    const sessionId = typeof body['sessionId'] === 'string' ? body['sessionId'] : ''
+    if (!connectionId || !sessionId) {
+      event.sender.send('openalice:pty:server-event', {
+        connectionId,
+        event: 'close',
+        code: 4000,
+        reason: 'session id required',
+      })
+      return
+    }
+    console.log(`[guardian] PTY bridge connect session=${sessionId} connection=${connectionId}`)
+    ptyConnections.set(connectionId, { sender: event.sender })
+
+    const sendToAlice = (msg: Serializable): void => {
+      const child = opts.getAliceProcess()
+      if (!child || !child.connected) {
+        event.sender.send('openalice:pty:server-event', {
+          connectionId,
+          event: 'close',
+          code: 1011,
+          reason: 'Alice IPC unavailable',
+        })
+        ptyConnections.delete(connectionId)
+        return
+      }
+      child.send(msg)
+    }
+
+    event.sender.once('destroyed', () => {
+      ptyConnections.delete(connectionId)
+      const child = opts.getAliceProcess()
+      if (child?.connected) child.send({ type: MSG_PTY_CLIENT_CLOSE, connectionId })
+    })
+
+    sendToAlice({
+      type: MSG_PTY_CONNECT,
+      connectionId,
+      sessionId,
+      cols: typeof body['cols'] === 'number' ? body['cols'] : 80,
+      rows: typeof body['rows'] === 'number' ? body['rows'] : 24,
+      since: typeof body['since'] === 'number' ? body['since'] : undefined,
+    })
+  })
+
+  ipcMain.on('openalice:pty:client-message', (event, input: unknown) => {
+    const body = input && typeof input === 'object' ? input as Record<string, unknown> : {}
+    const connectionId = typeof body['connectionId'] === 'string' ? body['connectionId'] : ''
+    const conn = connectionId ? ptyConnections.get(connectionId) : undefined
+    if (!conn || conn.sender !== event.sender) return
+    const child = opts.getAliceProcess()
+    if (!child?.connected) {
+      ptyConnections.delete(connectionId)
+      return
+    }
+    if (body['type'] === 'data') {
+      child.send({
+        type: MSG_PTY_CLIENT,
+        connectionId,
+        binary: true,
+        data: body['data'] as Serializable,
+      })
+    } else if (body['type'] === 'resize') {
+      child.send({
+        type: MSG_PTY_CLIENT,
+        connectionId,
+        binary: false,
+        data: JSON.stringify({ type: 'resize', cols: body['cols'], rows: body['rows'] }),
+      })
+    }
+  })
+
+  ipcMain.on('openalice:pty:client-close', (event, input: unknown) => {
+    const body = input && typeof input === 'object' ? input as Record<string, unknown> : {}
+    const connectionId = typeof body['connectionId'] === 'string' ? body['connectionId'] : ''
+    if (!connectionId) return
+    const conn = ptyConnections.get(connectionId)
+    if (conn && conn.sender !== event.sender) return
+    ptyConnections.delete(connectionId)
+    const child = opts.getAliceProcess()
+    if (child?.connected) child.send({ type: MSG_PTY_CLIENT_CLOSE, connectionId })
+  })
+}
+
+export async function fetchAliceWebRequest(request: Request, child: ChildProcess | null, timeoutMs = 30_000): Promise<Response> {
+  if (!child || !child.connected) {
+    return new Response('Alice IPC unavailable', { status: 503 })
+  }
+  const id = randomId()
+  const method = request.method.toUpperCase()
+  const body = method === 'GET' || method === 'HEAD'
+    ? undefined
+    : Buffer.from(await request.arrayBuffer())
+
+  return new Promise<Response>((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      pendingWebRequests.delete(id)
+      rejectPromise(new Error(`Alice IPC request timed out: ${method} ${request.url}`))
+    }, timeoutMs)
+    pendingWebRequests.set(id, { resolve: resolvePromise, reject: rejectPromise, timer })
+    child.send({
+      type: MSG_WEB_REQUEST,
+      id,
+      method,
+      url: request.url,
+      headers: [...request.headers.entries()],
+      ...(body ? { body } : {}),
+    })
+  })
+}
+
+export function handleOpenAliceIpcMessage(raw: unknown): boolean {
+  const msg = raw && typeof raw === 'object' ? raw as Record<string, unknown> : null
+  if (!msg || typeof msg['type'] !== 'string') return false
+  if (msg['type'] === MSG_WEB_RESPONSE) {
+    const id = typeof msg['id'] === 'string' ? msg['id'] : ''
+    const pending = pendingWebRequests.get(id)
+    if (!pending) return true
+    pendingWebRequests.delete(id)
+    clearTimeout(pending.timer)
+    const headers = Array.isArray(msg['headers']) ? msg['headers'] as [string, string][] : []
+    const status = typeof msg['status'] === 'number' ? msg['status'] : 500
+    pending.resolve(new Response(coerceResponseBody(msg['body']), {
+      status,
+      statusText: typeof msg['statusText'] === 'string' ? msg['statusText'] : undefined,
+      headers,
+    }))
+    return true
+  }
+  if (msg['type'] === MSG_PTY_SERVER) {
+    const connectionId = typeof msg['connectionId'] === 'string' ? msg['connectionId'] : ''
+    const conn = ptyConnections.get(connectionId)
+    if (!conn) return true
+    if (conn.sender.isDestroyed()) {
+      ptyConnections.delete(connectionId)
+      return true
+    }
+    conn.sender.send('openalice:pty:server-event', {
+      connectionId,
+      event: msg['binary'] === true ? 'data' : 'control',
+      data: msg['data'],
+    })
+    if (msg['binary'] !== true && typeof msg['data'] === 'string' && msg['data'].includes('"type":"attached"')) {
+      console.log(`[guardian] PTY bridge attached connection=${connectionId}`)
+    }
+    return true
+  }
+  if (msg['type'] === MSG_PTY_SERVER_CLOSE) {
+    const connectionId = typeof msg['connectionId'] === 'string' ? msg['connectionId'] : ''
+    const conn = ptyConnections.get(connectionId)
+    if (!conn) return true
+    if (!conn.sender.isDestroyed()) {
+      conn.sender.send('openalice:pty:server-event', {
+        connectionId,
+        event: 'close',
+        code: typeof msg['code'] === 'number' ? msg['code'] : 1000,
+        reason: typeof msg['reason'] === 'string' ? msg['reason'] : '',
+      })
+    }
+    ptyConnections.delete(connectionId)
+    return true
+  }
+  return false
+}
+
+function coerceResponseBody(raw: unknown): BodyInit | null {
+  if (raw === undefined || raw === null) return null
+  if (Buffer.isBuffer(raw)) return raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength) as ArrayBuffer
+  if (raw instanceof Uint8Array) return raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength) as ArrayBuffer
+  if (raw instanceof ArrayBuffer) return raw
+  if (typeof raw === 'string') return raw
+  return new ArrayBuffer(0)
+}
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -20,7 +20,7 @@
  * Out of scope (future iterations): tray icon, multi-window, native menus.
  */
 
-import { app, BrowserWindow, dialog, Menu } from 'electron'
+import { app, BrowserWindow, dialog, Menu, protocol } from 'electron'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { mkdir, readFile, watch } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
@@ -29,6 +29,7 @@ import { dirname, join, resolve } from 'node:path'
 import { probeFreePort } from './probe-port.js'
 import { relocateLegacyData } from './relocate-data.js'
 import { configureAutoUpdate } from './auto-update.js'
+import { fetchAliceWebRequest, handleOpenAliceIpcMessage, registerOpenAliceIpc } from './ipc.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -43,6 +44,19 @@ const READY_TIMEOUT_MS = 30_000
 const UTA_READY_TIMEOUT_MS = 15_000
 const SIGTERM_GRACE_MS = 5_000
 const UTA_RESTART_GRACE_MS = 8_000
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'app',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
+      stream: true,
+    },
+  },
+])
 
 // ── Cross-platform process-tree kill ─────────────────────────
 // Inline mirror of scripts/guardian/shared.ts:killTree. UTA and Alice each
@@ -100,6 +114,35 @@ async function readPortsFile(userDataHome: string): Promise<Partial<Record<'web'
   return out
 }
 
+async function readMcpConfigFile(userDataHome: string): Promise<{ enabled: boolean; port?: number }> {
+  const filePath = resolve(userDataHome, 'data', 'config', 'mcp.json')
+  let raw: string
+  try {
+    raw = await readFile(filePath, 'utf8')
+  } catch {
+    return { enabled: false }
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`[guardian] ${filePath} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`[guardian] ${filePath} must be a JSON object like {"enabled":false,"port":47332}`)
+  }
+  const rec = parsed as Record<string, unknown>
+  return {
+    enabled: rec['enabled'] === true,
+    ...(rec['port'] !== undefined ? { port: parsePort(rec['port'], `${filePath} ("port")`) } : {}),
+  }
+}
+
+function parseEnabledEnv(raw: string | undefined): boolean | null {
+  if (raw === undefined || raw === '') return null
+  return raw === '1' || raw.toLowerCase() === 'true'
+}
+
 /** Explicit (env/file) port → assert free or throw; unset → probe upward. */
 async function claimPort(
   name: string,
@@ -124,19 +167,19 @@ async function claimPort(
   }
 }
 
-async function waitForAliceReady(port: number, timeoutMs = READY_TIMEOUT_MS): Promise<void> {
+async function waitForAliceReady(timeoutMs = READY_TIMEOUT_MS): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     try {
-      // 5xx still means the server is up; only treat connect errors as not-ready.
-      const res = await fetch(`http://127.0.0.1:${port}/`, { method: 'GET' })
+      // 5xx still means the app is reachable; only transport errors mean not-ready.
+      const res = await fetchAliceWebRequest(new Request('app://openalice/api/version'), alice, 1_000)
       if (res.status < 500) return
     } catch {
-      // ECONNREFUSED etc. — backend not bound yet
+      // child not listening on its IPC web transport yet
     }
     await new Promise((r) => setTimeout(r, 200))
   }
-  throw new Error(`Alice did not become ready on port ${port} within ${timeoutMs}ms`)
+  throw new Error(`Alice did not become ready over Electron IPC within ${timeoutMs}ms`)
 }
 
 async function waitForUTA(utaUrl: string, timeoutMs = UTA_READY_TIMEOUT_MS): Promise<boolean> {
@@ -151,6 +194,76 @@ async function waitForUTA(utaUrl: string, timeoutMs = UTA_READY_TIMEOUT_MS): Pro
     await new Promise((r) => setTimeout(r, 200))
   }
   return false
+}
+
+async function runRendererPtySmoke(win: BrowserWindow): Promise<void> {
+  const keepWorkspace = process.env['OPENALICE_ELECTRON_SMOKE_KEEP_WORKSPACE'] === '1'
+  const result = await win.webContents.executeJavaScript(`(async () => {
+    const bridge = window.openAlice?.pty
+    if (!bridge) throw new Error('window.openAlice.pty missing')
+    const tag = 'electron-smoke-' + Date.now().toString(36)
+    const json = async (res) => {
+      const text = await res.text()
+      let body = null
+      try { body = text ? JSON.parse(text) : null } catch { body = text }
+      if (!res.ok) throw new Error(res.status + ' ' + text)
+      return body
+    }
+    let workspaceId = ''
+    let sessionId = ''
+    let connectionId = ''
+    try {
+      const created = await json(await fetch('/api/workspaces', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tag, template: 'chat', agents: ['shell'] }),
+      }))
+      workspaceId = created.workspace.id
+      const spawned = await json(await fetch('/api/workspaces/' + encodeURIComponent(workspaceId) + '/sessions/spawn', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ agent: 'shell' }),
+      }))
+      sessionId = spawned.sessionId
+      const attached = await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('PTY attached timeout')), 10000)
+        connectionId = bridge.connect({ sessionId, cols: 80, rows: 24 })
+        const offMessage = bridge.onMessage(connectionId, (msg) => {
+          if (msg.type !== 'control') return
+          const text = typeof msg.data === 'string' ? msg.data : String(msg.data ?? '')
+          try {
+            const control = JSON.parse(text)
+            if (control.type === 'attached') {
+              clearTimeout(timer)
+              offMessage()
+              offClose()
+              resolve(control)
+            }
+          } catch {
+            // Ignore non-JSON terminal control frames.
+          }
+        })
+        const offClose = bridge.onClose(connectionId, (ev) => {
+          clearTimeout(timer)
+          offMessage()
+          offClose()
+          reject(new Error('PTY closed before attach: ' + ev.code))
+        })
+      })
+      return { ok: true, workspaceId, sessionId, attached }
+    } finally {
+      if (connectionId) bridge.close(connectionId)
+      if (!${keepWorkspace ? 'true' : 'false'}) {
+        if (workspaceId && sessionId) {
+          await fetch('/api/workspaces/' + encodeURIComponent(workspaceId) + '/sessions/' + encodeURIComponent(sessionId) + '/pause', { method: 'POST' }).catch(() => {})
+        }
+        if (workspaceId) {
+          await fetch('/api/workspaces/' + encodeURIComponent(workspaceId), { method: 'DELETE' }).catch(() => {})
+        }
+      }
+    }
+  })()`, true) as { ok?: boolean; workspaceId?: string; sessionId?: string }
+  console.log(`[guardian] electron smoke pty → ok workspace=${result.workspaceId ?? ''} session=${result.sessionId ?? ''}`)
 }
 
 app.whenReady().then(async () => {
@@ -210,10 +323,18 @@ app.whenReady().then(async () => {
   // the user pinned them; silently drifting would break their bookmarks /
   // firewall rules. Unconfigured ports keep the probe-upward behavior.
   const portsFile = await readPortsFile(homeEnv.OPENALICE_HOME)
-  const webPort = await claimPort('web', 'OPENALICE_WEB_PORT', portsFile.web, DEFAULT_WEB_PORT_START)
-  const mcpPort = await claimPort('mcp', 'OPENALICE_MCP_PORT', portsFile.mcp, webPort + 1)
-  const utaPort = await claimPort('uta', 'OPENALICE_UTA_PORT', portsFile.uta, mcpPort + 1)
+  const mcpFile = await readMcpConfigFile(homeEnv.OPENALICE_HOME)
+  const mcpEnabled = parseEnabledEnv(process.env['OPENALICE_MCP_ENABLED']) ?? mcpFile.enabled
+  const mcpPort = mcpEnabled
+    ? await claimPort('mcp', 'OPENALICE_MCP_PORT', portsFile.mcp ?? mcpFile.port, DEFAULT_WEB_PORT_START + 1)
+    : null
+  const utaPort = await claimPort('uta', 'OPENALICE_UTA_PORT', portsFile.uta, mcpPort !== null ? mcpPort + 1 : DEFAULT_WEB_PORT_START + 1)
   const utaUrl = `http://127.0.0.1:${utaPort}`
+  const launcherMode = app.isPackaged ? 'electron-packaged' : 'electron-dev'
+  const toolBaseUrl = '/cli'
+  const toolSocketPath = process.platform === 'win32'
+    ? `\\\\.\\pipe\\openalice-${process.pid}-tools`
+    : join(app.getPath('temp'), `openalice-${process.pid}-tools.sock`)
 
   // ── Child spawns ────────────────────────────────────────────
   // Both children run as pure Node, not nested Electron main processes —
@@ -244,8 +365,12 @@ app.whenReady().then(async () => {
       env: {
         ...process.env,
         ELECTRON_RUN_AS_NODE: '1',
-        OPENALICE_WEB_PORT: String(webPort),
-        OPENALICE_MCP_PORT: String(mcpPort),
+        OPENALICE_WEB_TRANSPORT: 'ipc',
+        ...(mcpPort !== null ? { OPENALICE_MCP_PORT: String(mcpPort) } : {}),
+        OPENALICE_MCP_ENABLED: mcpEnabled ? '1' : '0',
+        OPENALICE_LOCAL_CLI_ON_WEB: '1',
+        OPENALICE_TOOL_BASE_URL: toolBaseUrl,
+        OPENALICE_TOOL_SOCKET: toolSocketPath,
         // The fix: Alice hard-requires OPENALICE_UTA_URL at boot
         // (src/main.ts) and throws without it. The pre-UTA desktop shell
         // never set it, so the packaged app crashed on launch.
@@ -253,7 +378,17 @@ app.whenReady().then(async () => {
         OPENALICE_LAUNCHER: 'electron',
         ...homeEnv,
       },
-      stdio: 'inherit',
+      // The fourth fd opens Node child_process IPC. Electron app mode uses it
+      // as the local PTY transport between BrowserWindow/preload and Alice's
+      // WorkspaceService, while HTTP/WS remains the browser/dev/Docker plane.
+      stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+      serialization: 'advanced',
+    })
+    child.on('message', (msg) => {
+      if (!handleOpenAliceIpcMessage(msg)) {
+        // No-op today; keeps the IPC pipe extensible without silently hiding
+        // malformed messages while we build out app-mode transports.
+      }
     })
     child.once('exit', (code, signal) => {
       if (appQuitting) return
@@ -264,8 +399,34 @@ app.whenReady().then(async () => {
   }
 
   // ── Boot order: UTA first, then Alice pointed at it ─────────
-  console.log(`[guardian] UTA   → ${utaUrl}`)
-  console.log(`[guardian] Alice → http://127.0.0.1:${webPort}`)
+  // Keep this banner explicit: desktop logs are often the only thing a user
+  // sees when debugging startup, and "Electron app loading local HTTP" looks
+  // deceptively similar to Docker/prod unless the launcher mode is named.
+  console.log('')
+  console.log(`[guardian] mode     →  ${launcherMode}`)
+  console.log(`[guardian] data     →  ${homeEnv.OPENALICE_HOME}`)
+  console.log(`[guardian] app      →  ${homeEnv.OPENALICE_APP_HOME}`)
+  console.log(`[guardian] UTA      →  ${utaUrl}`)
+  console.log(`[guardian] Alice    →  app://openalice (Electron IPC)`)
+  console.log(`[guardian] Tools    →  ${toolSocketPath}`)
+  console.log(`[guardian] MCP      →  ${mcpPort !== null ? `http://127.0.0.1:${mcpPort}/mcp` : 'disabled'}`)
+  console.log('')
+  registerOpenAliceIpc({
+    mode: launcherMode,
+    userDataHome: homeEnv.OPENALICE_HOME,
+    appHome: homeEnv.OPENALICE_APP_HOME,
+    webPort: null,
+    mcpPort,
+    utaPort,
+    getAliceProcess: () => alice,
+  })
+  protocol.handle('app', async (request) => {
+    try {
+      return await fetchAliceWebRequest(request, alice)
+    } catch (err) {
+      return new Response(err instanceof Error ? err.message : String(err), { status: 503 })
+    }
+  })
   uta = spawnUTA()
   const utaReady = await waitForUTA(utaUrl)
   if (!utaReady) {
@@ -280,8 +441,8 @@ app.whenReady().then(async () => {
   console.log(`[guardian] UTA ready pid=${uta.pid}`)
 
   alice = spawnAlice()
-  console.log(`[guardian] Alice pid=${alice.pid} webPort=${webPort} mcpPort=${mcpPort}`)
-  await waitForAliceReady(webPort)
+  console.log(`[guardian] Alice pid=${alice.pid} web=ipc mcpPort=${mcpPort ?? 'disabled'}`)
+  await waitForAliceReady()
 
   // ── Restart-flag watcher: broker config changes touch the flag; SIGTERM
   // + respawn UTA without restarting Alice (mirrors prod.mjs). ────────────
@@ -306,9 +467,45 @@ app.whenReady().then(async () => {
       preload: resolve(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
+      // Keep preload in Electron's full preload environment. The renderer page
+      // stays isolated and has no Node globals, but the preload itself imports
+      // Electron modules and exposes the app-mode transport bridge.
+      sandbox: false,
     },
   })
-  win.loadURL(`http://localhost:${webPort}/`)
+  win.webContents.on('preload-error', (_event, preloadPath, error) => {
+    console.error(`[guardian] renderer preload failed path=${preloadPath}: ${error.message}`)
+  })
+  win.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+    console.error(`[guardian] renderer load failed code=${errorCode} url=${validatedURL}: ${errorDescription}`)
+  })
+  win.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+    if (level < 2) return
+    console.log(`[renderer] ${sourceId}:${line} ${message}`)
+  })
+  win.webContents.on('did-finish-load', () => {
+    void win.webContents.executeJavaScript('Boolean(window.openAlice?.pty && window.openAlice?.runtime)', true)
+      .then((ready) => {
+        console.log(`[guardian] renderer bridge → ${ready ? 'ready' : 'missing'}`)
+        if (ready && process.env['OPENALICE_ELECTRON_SMOKE_PTY'] === '1') {
+          void runRendererPtySmoke(win)
+            .then(() => {
+              if (process.env['OPENALICE_ELECTRON_SMOKE_EXIT'] === '1') shutdown()
+            })
+            .catch((err) => {
+              console.error(`[guardian] electron smoke pty → failed: ${err instanceof Error ? err.message : String(err)}`)
+              if (process.env['OPENALICE_ELECTRON_SMOKE_EXIT'] === '1') {
+                process.exitCode = 1
+                shutdown()
+              }
+            })
+        }
+      })
+      .catch((err) => {
+        console.error(`[guardian] renderer bridge probe failed: ${err instanceof Error ? err.message : String(err)}`)
+      })
+  })
+  win.loadURL('app://openalice/')
 
   configureAutoUpdate(win, { beforeInstall: stopChildren })
 })

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,10 +1,114 @@
 /**
- * Renderer preload bridge (MVP — intentionally empty).
+ * Renderer preload bridge.
  *
- * The renderer talks to the backend via plain HTTP/WS over the localhost
- * port the guardian chose, so it doesn't need any special IPC surface to
- * function. Future iterations may add native-shell calls (system file
- * dialogs, menu actions, tray badge updates) via
- * `contextBridge.exposeInMainWorld(...)` here.
+ * Keep this surface narrow and explicit. The renderer stays sandboxed
+ * (`nodeIntegration:false`, `contextIsolation:true`) and receives only the
+ * Electron-native capabilities we intentionally expose. Browser/Docker/dev
+ * builds do not have this object, so the web UI can choose:
+ *
+ *   Electron app → window.openAlice.* IPC transport
+ *   Browser/dev/Docker → HTTP + WebSocket transport
+ *
+ * First app-mode slices: workspace file read/list and PTY streaming. The
+ * backend still serves HTTP/WS for dev, Docker, and self-hosted browsers; the
+ * preload bridge is the faster local capability surface for Electron.
  */
-export {}
+
+import { contextBridge, ipcRenderer } from 'electron'
+
+interface PtyListeners {
+  readonly message: Set<(msg: { type: 'data' | 'control'; data: unknown }) => void>
+  readonly close: Set<(msg: { code: number; reason: string }) => void>
+}
+
+const ptyListeners = new Map<string, PtyListeners>()
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function listenersFor(connectionId: string): PtyListeners {
+  let listeners = ptyListeners.get(connectionId)
+  if (!listeners) {
+    listeners = { message: new Set(), close: new Set() }
+    ptyListeners.set(connectionId, listeners)
+  }
+  return listeners
+}
+
+function cleanupPty(connectionId: string): void {
+  ptyListeners.delete(connectionId)
+}
+
+ipcRenderer.on('openalice:pty:server-event', (_event, raw: unknown) => {
+  const msg = raw && typeof raw === 'object'
+    ? raw as { connectionId?: unknown; event?: unknown; data?: unknown; code?: unknown; reason?: unknown }
+    : {}
+  const connectionId = typeof msg.connectionId === 'string' ? msg.connectionId : ''
+  if (!connectionId) return
+  const listeners = ptyListeners.get(connectionId)
+  if (!listeners) return
+  if (msg.event === 'close') {
+    for (const cb of listeners.close) {
+      cb({
+        code: typeof msg.code === 'number' ? msg.code : 1000,
+        reason: typeof msg.reason === 'string' ? msg.reason : '',
+      })
+    }
+    cleanupPty(connectionId)
+    return
+  }
+  if (msg.event === 'data' || msg.event === 'control') {
+    for (const cb of listeners.message) cb({ type: msg.event, data: msg.data })
+  }
+})
+
+const api = {
+  runtime: {
+    info: () => ipcRenderer.invoke('openalice:runtime:info'),
+  },
+  workspace: {
+    listFiles: (input: { id: string; path: string }) =>
+      ipcRenderer.invoke('openalice:workspace:list-files', input),
+    readFile: (input: { id: string; path: string }) =>
+      ipcRenderer.invoke('openalice:workspace:read-file', input),
+  },
+  pty: {
+    connect: (input: { sessionId: string; cols: number; rows: number; since?: number }) => {
+      const connectionId = randomId()
+      listenersFor(connectionId)
+      // Keep the Electron transport on ordinary ipcRenderer events instead of
+      // transferring a MessagePort. Packaged app renderers run sandboxed under
+      // app://, and avoiding a second port lifecycle makes PTY attach failures
+      // visible instead of silently stranding the shell stream.
+      ipcRenderer.send('openalice:pty:connect', { connectionId, ...input })
+      return connectionId
+    },
+    send: (connectionId: string, data: Uint8Array) => {
+      ipcRenderer.send('openalice:pty:client-message', { connectionId, type: 'data', data })
+    },
+    resize: (connectionId: string, cols: number, rows: number) => {
+      ipcRenderer.send('openalice:pty:client-message', { connectionId, type: 'resize', cols, rows })
+    },
+    close: (connectionId: string) => {
+      ipcRenderer.send('openalice:pty:client-close', { connectionId })
+      cleanupPty(connectionId)
+    },
+    onMessage: (
+      connectionId: string,
+      cb: (msg: { type: 'data' | 'control'; data: unknown }) => void,
+    ) => {
+      listenersFor(connectionId).message.add(cb)
+      return () => listenersFor(connectionId).message.delete(cb)
+    },
+    onClose: (
+      connectionId: string,
+      cb: (msg: { code: number; reason: string }) => void,
+    ) => {
+      listenersFor(connectionId).close.add(cb)
+      return () => listenersFor(connectionId).close.delete(cb)
+    },
+  },
+}
+
+contextBridge.exposeInMainWorld('openAlice', api)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "electron:dev": "pnpm electron:build && pnpm -F @traderalice/desktop dev",
     "electron:pack": "pnpm electron:build && pnpm -F @traderalice/desktop pack",
     "electron:smoke:packaged": "node scripts/desktop-packaged-smoke.mjs",
+    "electron:smoke:pty": "node scripts/desktop-pty-smoke.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",

--- a/scripts/desktop-pty-smoke.mjs
+++ b/scripts/desktop-pty-smoke.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+import { execFile, spawn, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { createServer } from 'node:net'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const repoRoot = new URL('..', import.meta.url).pathname
+const args = new Set(process.argv.slice(2))
+const skipBuild = args.has('--skip-build')
+const keep = args.has('--keep')
+const timeoutMs = 90_000
+const knownArgs = new Set(['--skip-build', '--keep', '--help', '-h'])
+const unknownArgs = [...args].filter((arg) => !knownArgs.has(arg))
+
+if (args.has('--help') || args.has('-h')) {
+  console.log(`Usage: pnpm electron:smoke:pty [--skip-build] [--keep]
+
+Launch Electron with isolated data and assert the renderer preload PTY bridge
+can attach to a real workspace shell session, then assert the injected CLI shim
+can read its manifest over the Electron-only tool socket. This opens no product
+web port; only the UTA HTTP port is bound on 127.0.0.1 for the test process.
+`)
+  process.exit(0)
+}
+
+if (unknownArgs.length > 0) {
+  console.error(`[desktop-pty-smoke] unknown option(s): ${unknownArgs.join(', ')}`)
+  process.exit(1)
+}
+
+function run(label, command, commandArgs) {
+  console.log(`\n[desktop-pty-smoke] ${label}`)
+  const result = spawnSync(command, commandArgs, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: process.env,
+  })
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}
+
+function freePort() {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const server = createServer()
+    server.once('error', rejectPromise)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      server.close(() => {
+        if (address && typeof address === 'object') resolvePromise(address.port)
+        else rejectPromise(new Error('failed to allocate port'))
+      })
+    })
+  })
+}
+
+if (!skipBuild) run('build Electron runtime', 'pnpm', ['electron:build'])
+
+const smokeRoot = mkdtempSync(join(tmpdir(), 'openalice-electron-pty-smoke-'))
+const utaPort = await freePort()
+
+console.log('\n[desktop-pty-smoke] launching Electron PTY smoke')
+console.log(`[desktop-pty-smoke] data: ${join(smokeRoot, 'home')}`)
+console.log(`[desktop-pty-smoke] workspaces: ${join(smokeRoot, 'workspaces')}`)
+console.log(`[desktop-pty-smoke] uta port: ${utaPort}`)
+
+const child = spawn('pnpm', ['-F', '@traderalice/desktop', 'dev'], {
+  cwd: join(repoRoot, 'apps', 'desktop'),
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: {
+    ...process.env,
+    OPENALICE_HOME: join(smokeRoot, 'home'),
+    AQ_LAUNCHER_ROOT: join(smokeRoot, 'workspaces'),
+    OPENALICE_GLOBAL_DIR: join(smokeRoot, 'global'),
+    OPENALICE_UTA_PORT: String(utaPort),
+    OPENALICE_ELECTRON_SMOKE_PTY: '1',
+    OPENALICE_ELECTRON_SMOKE_KEEP_WORKSPACE: '1',
+  },
+})
+
+let settled = false
+let output = ''
+let ptyPassed = false
+let cliStarted = false
+let socketPath = ''
+let workspaceId = ''
+
+const finish = (code, message) => {
+  if (settled) return
+  settled = true
+  clearTimeout(timer)
+  if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM')
+  if (!keep) rmSync(smokeRoot, { recursive: true, force: true })
+  if (message) console.log(message)
+  process.exit(code)
+}
+
+const maybeRunCliSmoke = () => {
+  if (!ptyPassed || cliStarted || !socketPath || !workspaceId) return
+  cliStarted = true
+  const cliPath = join(repoRoot, 'src', 'workspaces', 'cli', 'bin', 'alice')
+  execFile(process.execPath, [cliPath], {
+    env: {
+      ...process.env,
+      AQ_WS_ID: workspaceId,
+      OPENALICE_TOOL_SOCKET: socketPath,
+      OPENALICE_TOOL_URL: '/cli',
+    },
+    timeout: 10_000,
+  }, (err, stdout, stderr) => {
+    if (err) {
+      console.error(stdout)
+      console.error(stderr)
+      finish(1, `\n[desktop-pty-smoke] CLI socket smoke failed: ${err.message}`)
+      return
+    }
+    if (!stdout.includes('OpenAlice CLI')) {
+      console.error(stdout)
+      finish(1, '\n[desktop-pty-smoke] CLI socket smoke failed: manifest output missing')
+      return
+    }
+    console.log('[desktop-pty-smoke] CLI socket smoke -> ok')
+    finish(0, '\n[desktop-pty-smoke] passed')
+  })
+}
+
+const onData = (chunk) => {
+  const text = chunk.toString()
+  output += text
+  process.stdout.write(text)
+  const socketMatch = text.match(/local tool gateway listening on (.+)/)
+  if (socketMatch?.[1]) socketPath = socketMatch[1].trim()
+  if (text.includes('electron smoke pty → ok') || text.includes('electron smoke pty -> ok')) {
+    ptyPassed = true
+    const workspaceMatch = text.match(/electron smoke pty (?:→|->) ok workspace=([^ ]+)/)
+    if (workspaceMatch?.[1]) workspaceId = workspaceMatch[1]
+    maybeRunCliSmoke()
+  }
+  if (text.includes('electron smoke pty → failed') || text.includes('electron smoke pty -> failed')) {
+    finish(1, '\n[desktop-pty-smoke] failed')
+  }
+  maybeRunCliSmoke()
+}
+
+child.stdout.on('data', onData)
+child.stderr.on('data', onData)
+
+const timer = setTimeout(() => {
+  console.error('\n[desktop-pty-smoke] timed out')
+  console.error(output.split('\n').slice(-80).join('\n'))
+  finish(1)
+}, timeoutMs)
+
+child.on('exit', (code, signal) => {
+  if (settled) return
+  finish(code ?? (signal ? 1 : 0), `\n[desktop-pty-smoke] Electron exited before smoke passed code=${code} signal=${signal}`)
+})

--- a/scripts/guardian/dev.ts
+++ b/scripts/guardian/dev.ts
@@ -58,9 +58,13 @@ async function main(): Promise<void> {
   const flagPath = resolve(dataHome, 'data/control/restart-uta.flag')
 
   console.log('')
+  console.log(`[guardian] mode     →  dev (Guardian + UTA + Alice + Vite)`)
+  console.log(`[guardian] data     →  ${dataHome}`)
+  console.log(`[guardian] app      →  ${process.cwd()}`)
   console.log(`[guardian] UTA      →  http://127.0.0.1:${ports.utaPort}`)
   console.log(`[guardian] Alice    →  http://localhost:${ports.webPort}`)
-  console.log(`[guardian] MCP      →  http://localhost:${ports.mcpPort}/mcp`)
+  console.log(`[guardian] Tools    →  http://127.0.0.1:${ports.mcpPort}/cli`)
+  console.log(`[guardian] MCP      →  optional on http://127.0.0.1:${ports.mcpPort}/mcp`)
   console.log(`[guardian] UI       →  http://localhost:${ports.uiPort}`)
   console.log(`[guardian] flag     →  ${flagPath}`)
   console.log('')
@@ -71,6 +75,7 @@ async function main(): Promise<void> {
     // Children must resolve the same user-data root the Guardian watches —
     // src/core/paths.ts reads OPENALICE_HOME; never rely on cwd inheritance.
     OPENALICE_HOME: dataHome,
+    OPENALICE_LAUNCHER: 'dev',
   }
 
   // ── UTA spec (re-used by Guardian for restart) ────────────
@@ -102,6 +107,7 @@ async function main(): Promise<void> {
       ...baseEnv,
       OPENALICE_WEB_PORT: String(ports.webPort),
       OPENALICE_MCP_PORT: String(ports.mcpPort),
+      OPENALICE_TOOL_BASE_URL: `http://127.0.0.1:${ports.mcpPort}/cli`,
       // Where the UI actually lives — consumed by the workspace WS-origin
       // allowlist (src/workspaces/config.ts buildDefaultOrigins).
       OPENALICE_UI_PORT: String(ports.uiPort),

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -88,8 +88,12 @@ let aliceChild = null
 let restartingUTA = false
 
 console.log('[guardian/prod] starting')
+console.log('[guardian/prod] mode  → docker/prod')
+console.log(`[guardian/prod] data  → ${DATA_HOME}`)
 console.log(`[guardian/prod] UTA   → ${UTA_URL}`)
 console.log(`[guardian/prod] Alice → http://0.0.0.0:${WEB_PORT}`)
+console.log(`[guardian/prod] Tools → http://127.0.0.1:${MCP_PORT}/cli`)
+console.log(`[guardian/prod] MCP   → optional on http://127.0.0.1:${MCP_PORT}/mcp`)
 console.log(`[guardian/prod] flag  → ${FLAG_PATH}`)
 
 function makeUTASpec() {
@@ -100,6 +104,7 @@ function makeUTASpec() {
       ...process.env,
       OPENALICE_UTA_PORT: String(UTA_PORT),
       OPENALICE_HOME: DATA_HOME,
+      OPENALICE_LAUNCHER: 'docker',
     },
   }
 }
@@ -121,8 +126,10 @@ function spawnAlice() {
       ...process.env,
       OPENALICE_WEB_PORT: String(WEB_PORT),
       OPENALICE_MCP_PORT: String(MCP_PORT),
+      OPENALICE_TOOL_BASE_URL: `http://127.0.0.1:${MCP_PORT}/cli`,
       OPENALICE_UTA_URL: UTA_URL,
       OPENALICE_HOME: DATA_HOME,
+      OPENALICE_LAUNCHER: 'docker',
     },
     stdio: 'inherit',
   })

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -336,8 +336,9 @@ const compactionSchema = z.object({
  * and stays in connectors.
  */
 const mcpSchema = z.object({
+  enabled: z.boolean().default(false),
   port: z.number().int().positive().default(3001),
-}).default({ port: 3001 })
+}).default({ enabled: false, port: 3001 })
 
 const connectorsSchema = z.object({
   web: z.object({ port: z.number().int().positive().default(3002) }).default({ port: 3002 }),

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -74,7 +74,7 @@ export function templatesPath(): string {
 /**
  * Dir holding the workspace-local `alice` CLI shim, prepended to each PTY's
  * PATH so a native agent can run `alice ...` from its shell. A single shared,
- * env-driven script (it reads OPENALICE_MCP_URL + AQ_WS_ID at runtime), so it
+ * env-driven script (it reads OPENALICE_TOOL_URL + AQ_WS_ID at runtime), so it
  * is NOT written into individual workspaces and never enters their git repos.
  *
  * Rides APP_RESOURCES_HOME exactly like templatesPath(): repo source in dev,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,6 +9,7 @@ import type { Config, WebChannel } from './config.js'
 import type { EventLog } from './event-log.js'
 import type { ToolCallLog } from './tool-call-log.js'
 import type { ToolCenter } from './tool-center.js'
+import type { WorkspaceToolCenter } from './workspace-tool-center.js'
 import type { ListenerRegistry } from './listener-registry.js'
 import type { EventBus } from './event-bus.js'
 import type { IInboxStore } from './inbox-store.js'
@@ -45,6 +46,7 @@ export interface EngineContext {
   eventLog: EventLog
   toolCallLog: ToolCallLog
   toolCenter: ToolCenter
+  workspaceToolCenter: WorkspaceToolCenter
   listenerRegistry: ListenerRegistry
   /** Ergonomic in-process producer facade. Use this to fire events from
    *  plugins / hacks / extension code instead of plumbing eventLog. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { printLegacyDataNotice } from './core/legacy-data-notice.js'
 import { dataPath, defaultPath } from '@/core/paths.js'
 import type { Plugin, EngineContext } from './core/types.js'
 import { McpPlugin } from './server/mcp.js'
+import { LocalToolGatewayPlugin } from './server/local-tool-gateway.js'
 import { WebPlugin } from './webui/index.js'
 import { createWorkspaceServiceRef } from './webui/plugin.js'
 import { createThinkingTools } from './tool/thinking.js'
@@ -303,10 +304,21 @@ async function main() {
   // workspaceServiceRef is created earlier (Cron Listener section) so cron
   // dispatch shares the same box the WebPlugin fills on start.
 
-  // MCP Server is always active when a port is set — Claude Code provider depends on it for tools.
-  // Lives at top-level config (not under connectors:) because it exports
-  // ToolCenter outward rather than consuming chat input.
-  if (config.mcp.port) {
+  const envMcpEnabled = process.env['OPENALICE_MCP_ENABLED']
+  const mcpEnabled = envMcpEnabled === '1'
+    || ((envMcpEnabled === undefined || envMcpEnabled === '') && config.mcp.enabled === true)
+  const localCliOnWeb = process.env['OPENALICE_LOCAL_CLI_ON_WEB'] === '1'
+  const webTransport = process.env['OPENALICE_WEB_TRANSPORT'] === 'ipc' ? 'ipc' : 'http'
+  const toolBaseUrl = process.env['OPENALICE_TOOL_BASE_URL']
+    ?? (localCliOnWeb
+      ? `http://127.0.0.1:${config.connectors.web.port}/cli`
+      : `http://127.0.0.1:${config.mcp.port}/cli`)
+  const mcpBaseUrl = mcpEnabled ? `http://127.0.0.1:${config.mcp.port}/mcp` : undefined
+
+  // MCP is optional. The workspace CLI gateway is the default local tool path;
+  // when it cannot safely ride the loopback web listener, keep it on a
+  // loopback-only side listener.
+  if (mcpEnabled && config.mcp.port) {
     corePlugins.push(new McpPlugin(
       toolCenter,
       config.mcp.port,
@@ -315,12 +327,28 @@ async function main() {
       entityStore,
       () => workspaceServiceRef.current,
     ))
+  } else if (!localCliOnWeb && config.mcp.port) {
+    corePlugins.push(new LocalToolGatewayPlugin(config.mcp.port, {
+      toolCenter,
+      workspaceToolCenter,
+      inboxStore,
+      entityStore,
+      getWorkspaceService: () => workspaceServiceRef.current,
+    }))
   }
 
   // Web UI is always active (no enabled flag)
   if (config.connectors.web.port) {
     corePlugins.push(new WebPlugin(
-      { port: config.connectors.web.port, mcpPort: config.mcp.port },
+      {
+        port: config.connectors.web.port,
+        mcpPort: config.mcp.port,
+        toolBaseUrl,
+        ...(mcpBaseUrl ? { mcpBaseUrl } : {}),
+        localCliOnWeb,
+        listen: webTransport !== 'ipc',
+        ...(process.env['OPENALICE_TOOL_SOCKET'] ? { cliSocketPath: process.env['OPENALICE_TOOL_SOCKET'] } : {}),
+      },
       workspaceServiceRef,
     ))
   }
@@ -335,6 +363,7 @@ async function main() {
 
   const ctx: EngineContext = {
     config, inboxStore, entityStore, eventLog, toolCallLog, toolCenter,
+    workspaceToolCenter,
     listenerRegistry,
     fire: createEventBus(eventLog),
     bbEngine: getSDKExecutor(),

--- a/src/server/local-tool-gateway.ts
+++ b/src/server/local-tool-gateway.ts
@@ -1,0 +1,60 @@
+/**
+ * Local Tool Gateway — loopback-only HTTP surface for workspace CLI shims.
+ *
+ * `alice`, `alice-workspace`, `traderhub`, and `alice-uta` are intentionally
+ * plain shell commands inside a workspace. They need a local argv->tool bridge,
+ * but they do not need the MCP protocol. Keeping this gateway separate lets
+ * Electron/dev reuse the web listener for `/cli` while Docker/public-web
+ * topologies can keep an unauthenticated CLI surface on a private loopback
+ * port.
+ */
+
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { serve } from '@hono/node-server'
+import type { Plugin, EngineContext } from '../core/types.js'
+import type { ToolCenter } from '../core/tool-center.js'
+import type { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
+import type { IInboxStore } from '../core/inbox-store.js'
+import type { IEntityStore } from '../core/entity-store.js'
+import type { WorkspaceService } from '../workspaces/service.js'
+import { registerCliRoutes } from './cli.js'
+
+export interface LocalToolGatewayDeps {
+  readonly toolCenter: ToolCenter
+  readonly workspaceToolCenter: WorkspaceToolCenter
+  readonly inboxStore: IInboxStore
+  readonly entityStore: IEntityStore
+  readonly getWorkspaceService: () => WorkspaceService | null
+}
+
+export function mountLocalToolGateway(app: Hono, deps: LocalToolGatewayDeps): void {
+  registerCliRoutes(app, deps)
+}
+
+export class LocalToolGatewayPlugin implements Plugin {
+  name = 'local-tool-gateway'
+  private server: ReturnType<typeof serve> | null = null
+
+  constructor(
+    private port: number,
+    private deps: LocalToolGatewayDeps,
+  ) {}
+
+  async start(_ctx: EngineContext) {
+    const app = new Hono()
+    app.use('*', cors({
+      origin: '*',
+      allowMethods: ['GET', 'POST', 'OPTIONS'],
+      allowHeaders: ['Content-Type', 'x-openalice-run', 'x-openalice-session'],
+    }))
+    mountLocalToolGateway(app, this.deps)
+    this.server = serve({ fetch: app.fetch, port: this.port, hostname: '127.0.0.1' }, (info) => {
+      console.log(`local tool gateway listening on http://127.0.0.1:${info.port}/cli`)
+    })
+  }
+
+  async stop() {
+    this.server?.close()
+  }
+}

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -1,7 +1,8 @@
 import { Hono, type Context } from 'hono'
 import { cors } from 'hono/cors'
-import { serve } from '@hono/node-server'
+import { createAdaptorServer, serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
+import { rm } from 'node:fs/promises'
 import { uiBundlePath } from '@/core/paths.js'
 import type { Plugin, EngineContext } from '../core/types.js'
 import type { ProducerHandle } from '../core/producer.js'
@@ -47,15 +48,26 @@ export function createWorkspaceServiceRef(): WorkspaceServiceRef {
 import { createWorkspaceRoutes } from './routes/workspaces.js'
 import { createHeadlessRoutes } from './routes/headless.js'
 import { attachWorkspacesWS, type AttachedWS } from './workspaces-ws.js'
+import { attachWorkspacesIpc, type AttachedWorkspaceIpc } from './workspaces-ipc.js'
+import { attachWebIpc, type AttachedWebIpc } from './web-ipc.js'
+import { mountLocalToolGateway } from '../server/local-tool-gateway.js'
 import type { Server as HttpServer } from 'node:http'
 
 export interface WebConfig {
   /** Effective web port (env-overridden if guardian injected, else from config file). */
   port: number
-  /** Effective MCP port — passed through to workspace service so the
-   *  PTY-injected `OPENALICE_MCP_URL` env points at the live backend
-   *  (not the template-baked default). */
+  /** Effective MCP/local-tool port retained for legacy logs and config. */
   mcpPort: number
+  /** Base URL used by workspace `alice*` CLI shims. */
+  toolBaseUrl: string
+  /** Optional MCP protocol URL. Absent when the MCP server is disabled. */
+  mcpBaseUrl?: string
+  /** Mount unauthenticated /cli on this web listener. Safe only on loopback. */
+  localCliOnWeb?: boolean
+  /** Start the TCP HTTP listener. Electron app mode sets this false. */
+  listen?: boolean
+  /** Optional Unix socket / named pipe for workspace CLI shims in app mode. */
+  cliSocketPath?: string
 }
 
 export class WebPlugin implements Plugin {
@@ -66,6 +78,9 @@ export class WebPlugin implements Plugin {
   private ingestProducer?: ProducerHandle<readonly ['agent.work.requested']>
   private workspaceService: WorkspaceService | null = null
   private workspacesWs: AttachedWS | null = null
+  private workspacesIpc: AttachedWorkspaceIpc | null = null
+  private webIpc: AttachedWebIpc | null = null
+  private cliSocketServer: HttpServer | null = null
 
   constructor(
     private config: WebConfig,
@@ -149,10 +164,28 @@ export class WebPlugin implements Plugin {
 
     app.use('/api/*', cors())
 
+    if (this.config.localCliOnWeb) {
+      if (bindIsPublic) {
+        throw new Error('Refusing to mount unauthenticated /cli on a non-loopback web listener')
+      }
+      // Electron/dev can reuse the loopback web listener for workspace CLI
+      // shims, eliminating the old default MCP/CLI side port. Docker/public-web
+      // keeps this off and uses a separate loopback-only local tool gateway.
+      mountLocalToolGateway(app, {
+        toolCenter: ctx.toolCenter,
+        workspaceToolCenter: ctx.workspaceToolCenter,
+        inboxStore: ctx.inboxStore,
+        entityStore: ctx.entityStore,
+        getWorkspaceService: () => this.workspaceServiceRef?.current ?? this.workspaceService,
+      })
+    }
+
     // ==================== Auth gate ====================
     //
-    // The gate sits between CORS and every route mount. Public surface
-    // (/api/auth/*, /api/version, /login, static assets, /mcp) is
+    // The gate sits between CORS and every normal route mount. When enabled,
+    // local `/cli` is mounted above this gate only on a loopback listener; all
+    // public web surfaces stay below the auth middleware.
+    // Public surface (/api/auth/*, /api/version, /login, static assets, /mcp) is
     // allowlisted inside the middleware itself. Localhost requests
     // bypass when no trusted proxy is configured — preserving the
     // zero-friction dev UX. See safe/playbooks/{01,02,03}-*.md for the
@@ -217,8 +250,12 @@ export class WebPlugin implements Plugin {
     this.workspaceService = await createWorkspaceService({
       webPort: this.config.port,
       mcpPort: this.config.mcpPort,
+      toolBaseUrl: this.config.toolBaseUrl,
+      ...(this.config.cliSocketPath ? { toolSocketPath: this.config.cliSocketPath } : {}),
+      mcpBaseUrl: this.config.mcpBaseUrl,
       inboxStore: ctx.inboxStore,
     })
+    this.workspacesIpc = attachWorkspacesIpc(this.workspaceService)
     if (this.workspaceServiceRef) this.workspaceServiceRef.current = this.workspaceService
     app.route('/api/workspaces', createWorkspaceRoutes(this.workspaceService))
     app.route('/api/headless', createHeadlessRoutes(this.workspaceService))
@@ -260,6 +297,33 @@ export class WebPlugin implements Plugin {
     app.use('/*', serveStatic({ root: uiRoot }))
     app.get('*', serveStatic({ root: uiRoot, path: 'index.html' }))
 
+    this.webIpc = attachWebIpc(app)
+
+    if (this.config.cliSocketPath) {
+      if (process.platform !== 'win32') await rm(this.config.cliSocketPath, { force: true })
+      const server = createAdaptorServer({ fetch: (request, env) => app.fetch(request, env) }) as HttpServer
+      await new Promise<void>((resolveListen, rejectListen) => {
+        const onError = (err: Error) => {
+          server.off('listening', onListening)
+          rejectListen(err)
+        }
+        const onListening = () => {
+          server.off('error', onError)
+          resolveListen()
+        }
+        server.once('error', onError)
+        server.once('listening', onListening)
+        server.listen(this.config.cliSocketPath)
+      })
+      this.cliSocketServer = server
+      console.log(`local tool gateway listening on ${this.config.cliSocketPath}`)
+    }
+
+    if (this.config.listen === false) {
+      console.log('web plugin listening over Electron IPC')
+      return
+    }
+
     // ==================== Start server ====================
     // Default hostname is 127.0.0.1 — public-internet exposure requires
     // explicit `OPENALICE_BIND_HOST=0.0.0.0` (gated by the safety check
@@ -279,6 +343,12 @@ export class WebPlugin implements Plugin {
     this.sseByChannel.clear()
     this.ingestProducer?.dispose()
     this.ingestProducer = undefined
+    this.webIpc?.dispose()
+    this.webIpc = null
+    this.cliSocketServer?.close()
+    this.cliSocketServer = null
+    this.workspacesIpc?.dispose()
+    this.workspacesIpc = null
     this.workspacesWs?.dispose()
     this.workspacesWs = null
     if (this.workspaceService) {

--- a/src/webui/web-ipc.ts
+++ b/src/webui/web-ipc.ts
@@ -1,0 +1,89 @@
+/**
+ * Electron web transport for the Alice Hono app.
+ *
+ * In desktop mode the renderer loads `app://openalice/...`; Electron main
+ * forwards those requests over child_process IPC and this module dispatches
+ * them directly through `app.fetch()`. Dev/browser/Docker still use the HTTP
+ * listener owned by WebPlugin.
+ */
+
+import type { Hono } from 'hono'
+
+const MSG_WEB_REQUEST = 'openalice:web:request'
+const MSG_WEB_RESPONSE = 'openalice:web:response'
+
+interface WebRequestMessage {
+  readonly type: typeof MSG_WEB_REQUEST
+  readonly id: string
+  readonly method: string
+  readonly url: string
+  readonly headers: readonly [string, string][]
+  readonly body?: unknown
+}
+
+export interface AttachedWebIpc {
+  dispose(): void
+}
+
+export function attachWebIpc(app: Hono): AttachedWebIpc {
+  if (!process.send || process.env['OPENALICE_WEB_TRANSPORT'] !== 'ipc') {
+    return { dispose: () => {} }
+  }
+
+  const onMessage = (raw: unknown): void => {
+    const msg = raw && typeof raw === 'object' ? raw as WebRequestMessage : null
+    if (!msg || msg.type !== MSG_WEB_REQUEST || typeof msg.id !== 'string') return
+
+    void (async () => {
+      try {
+        const init: RequestInit = {
+          method: msg.method,
+          headers: new Headers(Array.isArray(msg.headers) ? msg.headers : []),
+        }
+        if (msg.method !== 'GET' && msg.method !== 'HEAD') {
+          const body = coerceBody(msg.body)
+          if (body) init.body = body
+        }
+        const req = new Request(msg.url, init)
+        // Mirror loopback HTTP semantics for the auth middleware. The request
+        // did not cross a network boundary; it came from Electron main over the
+        // child IPC pipe.
+        const res = await app.fetch(req, {
+          incoming: { socket: { remoteAddress: '127.0.0.1' } },
+        } as never)
+        const body = Buffer.from(await res.arrayBuffer())
+        process.send?.({
+          type: MSG_WEB_RESPONSE,
+          id: msg.id,
+          status: res.status,
+          statusText: res.statusText,
+          headers: [...res.headers.entries()],
+          body,
+        })
+      } catch (err) {
+        process.send?.({
+          type: MSG_WEB_RESPONSE,
+          id: msg.id,
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: [['content-type', 'text/plain; charset=utf-8']],
+          body: Buffer.from(err instanceof Error ? err.message : String(err)),
+        })
+      }
+    })()
+  }
+
+  process.on('message', onMessage)
+  return {
+    dispose: () => process.off('message', onMessage),
+  }
+}
+
+function coerceBody(raw: unknown): BodyInit | undefined {
+  if (raw === undefined || raw === null) return undefined
+  if (Buffer.isBuffer(raw)) return raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength) as ArrayBuffer
+  if (raw instanceof Uint8Array) return raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength) as ArrayBuffer
+  if (raw instanceof ArrayBuffer) return raw
+  if (typeof raw === 'string') return raw
+  return new ArrayBuffer(0)
+}

--- a/src/webui/workspaces-ipc.ts
+++ b/src/webui/workspaces-ipc.ts
@@ -1,0 +1,151 @@
+/**
+ * Electron IPC transport for workspace PTY sessions.
+ *
+ * Browser/dev/Docker keep using `/api/workspaces/pty` WebSocket. In Electron,
+ * the renderer talks to Electron main through a MessagePort, and Electron main
+ * talks to this Alice child process over Node child_process IPC. This keeps
+ * the PersistentSession byte semantics in one place while removing the
+ * renderer → localhost WebSocket hop in app mode.
+ */
+
+import { EventEmitter } from 'node:events'
+import type { WebSocket } from 'ws'
+
+import { logger as launcherLogger } from '../workspaces/logger.js'
+import type { WorkspaceService } from '../workspaces/service.js'
+
+const MSG_CONNECT = 'openalice:pty:connect'
+const MSG_CLIENT = 'openalice:pty:client-message'
+const MSG_CLIENT_CLOSE = 'openalice:pty:client-close'
+const MSG_SERVER = 'openalice:pty:server-message'
+const MSG_SERVER_CLOSE = 'openalice:pty:server-close'
+
+type BridgeMessage =
+  | { type: typeof MSG_CONNECT; connectionId: string; sessionId: string; cols: number; rows: number; since?: number }
+  | { type: typeof MSG_CLIENT; connectionId: string; binary: boolean; data: unknown }
+  | { type: typeof MSG_CLIENT_CLOSE; connectionId: string }
+
+class IpcPtySocket extends EventEmitter {
+  readonly OPEN = 1
+  readyState = 1
+  bufferedAmount = 0
+
+  constructor(readonly connectionId: string) {
+    super()
+  }
+
+  send(data: string | Buffer, opts?: { binary?: boolean }, cb?: (err?: Error) => void): void {
+    if (!process.send || this.readyState !== this.OPEN) {
+      cb?.(new Error('IPC PTY socket is closed'))
+      return
+    }
+    const binary = opts?.binary ?? Buffer.isBuffer(data)
+    process.send({ type: MSG_SERVER, connectionId: this.connectionId, binary, data }, (err) => cb?.(err ?? undefined))
+  }
+
+  close(code = 1000, reason = ''): void {
+    if (this.readyState !== this.OPEN) return
+    this.readyState = 3
+    try {
+      process.send?.({ type: MSG_SERVER_CLOSE, connectionId: this.connectionId, code, reason })
+    } catch {
+      // Parent may already be gone.
+    }
+    this.emit('close', code, reason)
+  }
+
+  receive(raw: unknown, isBinary: boolean): void {
+    if (this.readyState !== this.OPEN) return
+    this.emit('message', coerceBuffer(raw), isBinary)
+  }
+
+  clientClosed(): void {
+    if (this.readyState !== this.OPEN) return
+    this.readyState = 3
+    this.emit('close', 1000, 'client closed')
+  }
+}
+
+export interface AttachedWorkspaceIpc {
+  dispose(): void
+}
+
+export function attachWorkspacesIpc(svc: WorkspaceService): AttachedWorkspaceIpc {
+  if (!process.send || process.env['OPENALICE_LAUNCHER'] !== 'electron') {
+    return { dispose: () => {} }
+  }
+
+  const sockets = new Map<string, IpcPtySocket>()
+
+  const close = (connectionId: string, code: number, reason: string): void => {
+    try {
+      process.send?.({ type: MSG_SERVER_CLOSE, connectionId, code, reason })
+    } catch {
+      // Parent may already be gone.
+    }
+  }
+
+  const onMessage = (raw: unknown): void => {
+    const msg = raw && typeof raw === 'object' ? raw as BridgeMessage : null
+    if (!msg || typeof msg.type !== 'string') return
+
+    if (msg.type === MSG_CONNECT) {
+      const connectionId = typeof msg.connectionId === 'string' ? msg.connectionId : ''
+      const sessionId = typeof msg.sessionId === 'string' ? msg.sessionId.slice(0, 64) : ''
+      if (!connectionId || !sessionId) {
+        if (connectionId) close(connectionId, 4000, 'session id required')
+        return
+      }
+      if (!svc.pool.get(sessionId)) {
+        close(connectionId, 4404, 'session not found')
+        return
+      }
+      const socket = new IpcPtySocket(connectionId)
+      sockets.set(connectionId, socket)
+      socket.once('close', () => sockets.delete(connectionId))
+      const cols = clamp(msg.cols, 80, 1, 1000)
+      const rows = clamp(msg.rows, 24, 1, 1000)
+      const since = typeof msg.since === 'number' && Number.isFinite(msg.since) && msg.since >= 0 ? msg.since : undefined
+      const ok = svc.pool.attachById(sessionId, socket as unknown as WebSocket, cols, rows, since)
+      if (!ok) socket.close(4404, 'session not found')
+      launcherLogger.event('ipc_pty.attached', { connectionId, sessionId, cols, rows })
+      console.log(`ipc pty attached: session=${sessionId} connection=${connectionId} size=${cols}x${rows}`)
+      return
+    }
+
+    if (msg.type === MSG_CLIENT) {
+      const socket = sockets.get(typeof msg.connectionId === 'string' ? msg.connectionId : '')
+      if (!socket) return
+      socket.receive(msg.data, msg.binary === true)
+      return
+    }
+
+    if (msg.type === MSG_CLIENT_CLOSE) {
+      const socket = sockets.get(typeof msg.connectionId === 'string' ? msg.connectionId : '')
+      socket?.clientClosed()
+    }
+  }
+
+  process.on('message', onMessage)
+  return {
+    dispose: () => {
+      process.off('message', onMessage)
+      for (const socket of sockets.values()) socket.close(1000, 'ipc bridge disposed')
+      sockets.clear()
+    },
+  }
+}
+
+function coerceBuffer(raw: unknown): Buffer {
+  if (Buffer.isBuffer(raw)) return raw
+  if (raw instanceof Uint8Array) return Buffer.from(raw)
+  if (raw instanceof ArrayBuffer) return Buffer.from(raw)
+  if (typeof raw === 'string') return Buffer.from(raw, 'utf8')
+  return Buffer.alloc(0)
+}
+
+function clamp(raw: unknown, fallback: number, lo: number, hi: number): number {
+  const n = typeof raw === 'number' ? Math.floor(raw) : Number.NaN
+  if (!Number.isFinite(n)) return fallback
+  return Math.max(lo, Math.min(hi, n))
+}

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -234,8 +234,9 @@ describe('opencodeAdapter AI-config', () => {
     expect(cfg.mcp['openalice-workspace'].headers).toEqual({ 'x-openalice-run': 'run-7' });
   });
 
-  it('composeEnv throws loud when MCP url is missing from spawn env', () => {
-    expect(() => opencodeAdapter.composeEnv!({ cwd: dir, env: {} })).toThrow(/OPENALICE_MCP_URL/);
+  it('composeEnv skips MCP injection when MCP is disabled', () => {
+    const env = opencodeAdapter.composeEnv!({ cwd: dir, env: {} });
+    expect(env['OPENCODE_CONFIG_CONTENT']).toBeUndefined();
   });
 
   it('composeCommand: fresh is the bare binary; resume uses top-level flags', () => {

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -198,44 +198,11 @@ describe('codexAdapter AI-config', () => {
 describe('opencodeAdapter AI-config', () => {
   const mcpEnv = { OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp', AQ_WS_ID: 'ws-abc' };
 
-  it('injects both MCP servers + hermetic flags via composeEnv inline config', () => {
+  it('keeps OpenAlice MCP out of opencode env even when an MCP URL is present', () => {
     const env = opencodeAdapter.composeEnv!({ cwd: dir, env: mcpEnv });
     expect(env['OPENCODE_DISABLE_MODELS_FETCH']).toBe('1');
     expect(env['OPENCODE_DISABLE_AUTOUPDATE']).toBe('1');
     expect(env['OPENCODE_DISABLE_LSP_DOWNLOAD']).toBe('1');
-    expect(JSON.parse(env['OPENCODE_CONFIG_CONTENT']!)).toEqual({
-      mcp: {
-        openalice: { type: 'remote', url: 'http://127.0.0.1:47332/mcp', enabled: true },
-        'openalice-workspace': {
-          type: 'remote', url: 'http://127.0.0.1:47332/mcp/ws-abc', enabled: true,
-        },
-      },
-    });
-  });
-
-  it('stamps x-openalice-run on the workspace server when AQ_RUN_ID is present (headless)', () => {
-    const env = opencodeAdapter.composeEnv!({ cwd: dir, env: { ...mcpEnv, AQ_RUN_ID: 'run-7' } });
-    const cfg = JSON.parse(env['OPENCODE_CONFIG_CONTENT']!);
-    expect(cfg.mcp['openalice-workspace'].headers).toEqual({ 'x-openalice-run': 'run-7' });
-    // never on the global server
-    expect(cfg.mcp.openalice.headers).toBeUndefined();
-  });
-
-  it('stamps x-openalice-session on the workspace server when AQ_SESSION_ID is present (interactive)', () => {
-    const env = opencodeAdapter.composeEnv!({ cwd: dir, env: { ...mcpEnv, AQ_SESSION_ID: 'rec-9' } });
-    const cfg = JSON.parse(env['OPENCODE_CONFIG_CONTENT']!);
-    expect(cfg.mcp['openalice-workspace'].headers).toEqual({ 'x-openalice-session': 'rec-9' });
-    expect(cfg.mcp.openalice.headers).toBeUndefined();
-  });
-
-  it('run header wins when both are present (mutually exclusive, matching the shim)', () => {
-    const env = opencodeAdapter.composeEnv!({ cwd: dir, env: { ...mcpEnv, AQ_RUN_ID: 'run-7', AQ_SESSION_ID: 'rec-9' } });
-    const cfg = JSON.parse(env['OPENCODE_CONFIG_CONTENT']!);
-    expect(cfg.mcp['openalice-workspace'].headers).toEqual({ 'x-openalice-run': 'run-7' });
-  });
-
-  it('composeEnv skips MCP injection when MCP is disabled', () => {
-    const env = opencodeAdapter.composeEnv!({ cwd: dir, env: {} });
     expect(env['OPENCODE_CONFIG_CONTENT']).toBeUndefined();
   });
 
@@ -348,7 +315,7 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
     ]);
   });
 
-  it('opencode: run --format json -- <prompt> (MCP via env, not flags)', () => {
+  it('opencode: run --format json -- <prompt> (tools via CLI shims)', () => {
     expect(opencodeAdapter.composeHeadlessCommand!(['opencode'], ctx(), 'do x')).toEqual([
       'opencode',
       'run',

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -71,12 +71,9 @@ export const codexAdapter: CliAdapter = {
   },
 
   /**
-   * Always prepends `-c mcp_servers.openalice.url="..."` and the workspace
-   * scoped `openalice-workspace` server so OpenAlice MCP is visible
-   * per-spawn without writing to `~/.codex/config.toml`. The
-   * flag overrides any same-key entry in the read config.toml (verified
-   * empirically), and adds a new key when none exists — safe in both
-   * default and override modes.
+   * Prepends MCP server flags only when OpenAlice's optional MCP server is
+   * enabled. The default tool path is CLI-mode (`alice*` shell commands), so a
+   * workspace must still spawn even when no MCP URL is present.
    */
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
     const head = codexMcpHead(ctx);
@@ -307,19 +304,17 @@ export const codexAdapter: CliAdapter = {
 };
 
 /**
- * The `codex -c mcp_servers.*` head shared by interactive `composeCommand` and
- * headless `composeHeadlessCommand` — so the two never drift on MCP wiring.
+ * Optional `codex -c mcp_servers.*` head. When MCP is disabled, return the
+ * bare codex command and let the workspace use the injected `alice*` CLIs.
  *
- * Reads OPENALICE_MCP_URL / AQ_WS_ID from the spawn-bound env (which service.ts
- * populates with the backend's actual MCP port), NOT process.env — the backend
- * env only carries OPENALICE_MCP_PORT; the URL is composed per-spawn and
- * injected via buildSpawnEnv. Reading process.env here used to fall back to the
- * historical 3001 hardcode and route codex at a dead port.
+ * Reads OPENALICE_MCP_URL / AQ_WS_ID from the spawn-bound env. The URL exists
+ * only when the optional MCP server is enabled; otherwise the workspace uses
+ * the injected `alice*` CLI tools.
  */
 function codexMcpHead(ctx: SpawnContext): string[] {
   const mcpUrl = ctx.env['OPENALICE_MCP_URL'];
   if (!mcpUrl) {
-    throw new Error('codex adapter: OPENALICE_MCP_URL missing from spawn env');
+    return ['codex'];
   }
   const workspaceId = ctx.env['AQ_WS_ID'];
   if (!workspaceId) {

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -130,14 +130,12 @@ export const opencodeAdapter: CliAdapter = {
       OPENCODE_DISABLE_LSP_DOWNLOAD: '1',
     };
 
-    // Inject OpenAlice's MCP servers per-spawn via inline config. Read from the
-    // spawn-bound env (service.ts populates the real MCP port per spawn), NOT
-    // process.env — mirrors codexAdapter.composeCommand. Fail loud if missing:
-    // a workspace silently spawned without trading context is worse than a hard
-    // error (matches the codebase's loud-failure stance).
+    // Inject OpenAlice's MCP servers only when the optional MCP server is
+    // enabled. CLI-mode (`alice*` shell commands) is the default tool path, so a
+    // missing MCP URL is fine and should not block workspace spawn.
     const mcpUrl = ctx.env['OPENALICE_MCP_URL'];
     if (!mcpUrl) {
-      throw new Error('opencode adapter: OPENALICE_MCP_URL missing from spawn env');
+      return env;
     }
     const workspaceId = ctx.env['AQ_WS_ID'];
     if (!workspaceId) {

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -26,18 +26,13 @@ const OPENCODE_SDK_NPM = '@ai-sdk/openai-compatible';
  * that codex's Responses-only lock can't touch.
  *
  * Contract VERIFIED against opencode 1.16.0 on macOS (`opencode --help` +
- * an `opencode debug config` injection smoke, 2026-06):
+ * an `opencode debug config` provider-config smoke, 2026-06):
  *
- *   - MCP injection: opencode reads config from many layers; the strongest
- *     knob a launcher controls is `OPENCODE_CONFIG_CONTENT` (inline JSON in
- *     env, precedence below only MDM-managed config, deep-MERGED with the
- *     workspace's own `opencode.json`). We inject OpenAlice's two MCP servers
- *     there in `composeEnv` — the `mcp` block merges in without clobbering the
- *     `provider` block written to `opencode.json`. This is the cleaner analogue
- *     of codex's per-spawn `-c mcp_servers...` flags. Verified via
- *     `opencode debug config`: the file's `provider` and the env's `mcp` block
- *     both land in the resolved config (disjoint top-level keys; remeda
- *     mergeDeep), and `$schema` passes opencode's strict top-level-key check.
+ *   - Tool access: OpenAlice tools are exposed through the injected
+ *     `alice*` / `traderhub` CLI shims, not opencode's native MCP config.
+ *     We intentionally do not set `OPENCODE_CONFIG_CONTENT`: leaving opencode's
+ *     native config surface alone avoids hidden app-mode ports and keeps the
+ *     workspace tooling path identical to pi/shell/headless CLI usage.
  *
  *   - Provider override: `opencode.json` `provider.<name>` with a custom
  *     `baseURL` + `apiKey` + a top-level default `model = "<provider>/<id>"`.
@@ -86,9 +81,9 @@ export const opencodeAdapter: CliAdapter = {
   },
 
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
-    // MCP is injected via OPENCODE_CONFIG_CONTENT (composeEnv), not flags, so
-    // the command head is just the binary + a resume flag (if any). Resume is a
-    // top-level flag on the bare TUI — verified against opencode 1.16.0.
+    // Tool access is via the injected CLI shims, so the command head is just
+    // the binary + a resume flag (if any). Resume is a top-level flag on the
+    // bare TUI — verified against opencode 1.16.0.
     const head = ['opencode'];
     if (ctx.resume === undefined) {
       // Quick-chat seed: `opencode --prompt <text>` opens the TUI seeded with
@@ -103,10 +98,9 @@ export const opencodeAdapter: CliAdapter = {
   },
 
   // Headless: `opencode run <prompt>` is non-interactive and exits at the turn
-  // boundary. MCP rides OPENCODE_CONFIG_CONTENT (composeEnv, same as
-  // interactive) so the agent reaches inbox_push; prompt is the trailing
-  // positional after a `--` end-of-options terminator (so a `-`-leading prompt
-  // isn't read as a flag).
+  // boundary. Tool access is via the injected CLI shims and bundled skills;
+  // prompt is the trailing positional after a `--` end-of-options terminator
+  // (so a `-`-leading prompt isn't read as a flag).
   composeHeadlessCommand(_base: readonly string[], _ctx: SpawnContext, prompt: string): readonly string[] {
     return ['opencode', 'run', '--format', 'json', '--', prompt];
   },
@@ -130,47 +124,6 @@ export const opencodeAdapter: CliAdapter = {
       OPENCODE_DISABLE_LSP_DOWNLOAD: '1',
     };
 
-    // Inject OpenAlice's MCP servers only when the optional MCP server is
-    // enabled. CLI-mode (`alice*` shell commands) is the default tool path, so a
-    // missing MCP URL is fine and should not block workspace spawn.
-    const mcpUrl = ctx.env['OPENALICE_MCP_URL'];
-    if (!mcpUrl) {
-      return env;
-    }
-    const workspaceId = ctx.env['AQ_WS_ID'];
-    if (!workspaceId) {
-      throw new Error('opencode adapter: AQ_WS_ID missing from spawn env');
-    }
-    // Agent-INVISIBLE origin identity: a spawn carries AQ_RUN_ID XOR
-    // AQ_SESSION_ID — a HEADLESS spawn injects AQ_RUN_ID (the run's taskId),
-    // an INTERACTIVE spawn injects AQ_SESSION_ID (the pre-allocated
-    // SessionRegistry record id); a probe carries neither. opencode's
-    // remote-MCP config supports a static `headers` map, so we stamp the id
-    // onto the workspace server entry — the server then resolves the entry's
-    // origin from it. This is the native-MCP twin of the `alice` CLI shim's
-    // header forwarding: spawn-time server config, NOT a tool argument, so the
-    // agent never sees or supplies it. Only on `openalice-workspace` (the
-    // scoped surface that owns inbox_push); the global `openalice` server has no
-    // per-spawn identity. Mutually exclusive headers, matching the shim.
-    const runId = ctx.env['AQ_RUN_ID'];
-    const sessionId = ctx.env['AQ_SESSION_ID'];
-    const wsServer: Record<string, unknown> = {
-      type: 'remote',
-      url: `${mcpUrl}/${workspaceId}`,
-      enabled: true,
-      ...(runId
-        ? { headers: { 'x-openalice-run': runId } }
-        : sessionId
-          ? { headers: { 'x-openalice-session': sessionId } }
-          : {}),
-    };
-    const inline = {
-      mcp: {
-        openalice: { type: 'remote', url: mcpUrl, enabled: true },
-        'openalice-workspace': wsServer,
-      },
-    };
-    env['OPENCODE_CONFIG_CONTENT'] = JSON.stringify(inline);
     return env;
   },
 

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -164,10 +164,12 @@ export interface CliAdapter {
    * the process consumes `prompt` and EXITS at the turn boundary (vs the
    * interactive TUI that waits for input). The adapter places `prompt` at the
    * CLI-correct position (claude right after `-p`; codex/opencode/pi trailing).
-   * MUST keep the SAME MCP injection as `composeCommand` so the agent can reach
-   * `inbox_push`. Present iff `capabilities.headless` is true.
+   * MUST keep the same tool-access strategy as `composeCommand`: modern
+   * OpenAlice workspaces prefer the injected `alice*` / `traderhub` CLI shims,
+   * while adapter-native MCP is optional and adapter-specific. Present iff
+   * `capabilities.headless` is true.
    *   claude:   [...base, -p, <prompt>, --output-format, json]   // never --bare
-   *   codex:    [codex, -c mcp…, exec, --json, <prompt>]
+   *   codex:    [codex, exec, --json, <prompt>]                  // MCP optional
    *   opencode: [opencode, run, --format, json, <prompt>]
    *   pi:       [pi, -p, --mode, json, <prompt>]
    */

--- a/src/workspaces/cli/bin/alice
+++ b/src/workspaces/cli/bin/alice
@@ -12,7 +12,7 @@
  * (`alice` -> data, `alice-<x>` -> <x>) and talks to `/cli/<wsId>/<export>/*`.
  *
  * Runs from a workspace PTY shell, reading env the launcher already injects per
- * spawn (OPENALICE_MCP_URL + AQ_WS_ID). Deliberately written with NO import /
+ * spawn (OPENALICE_TOOL_URL + AQ_WS_ID). Deliberately written with NO import /
  * export and NO top-level await, so node runs it identically whether it treats
  * the file as ESM or CommonJS — and with zero Alice imports, so there is nothing
  * to build (dev and prod behave the same). Uses only global fetch / process.
@@ -34,13 +34,21 @@ async function main() {
   BIN = (process.argv[1] || 'alice').split(/[\\/]/).pop() || 'alice'
   const exportKey = BIN === 'alice' ? 'data' : BIN.replace(/^alice-/, '')
 
-  const mcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
+  const toolSocket = process.env.OPENALICE_TOOL_SOCKET
+  const toolUrl = process.env.OPENALICE_TOOL_URL
+  const legacyMcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
   const wsId = process.env.AQ_WS_ID
   if (!wsId) {
     fail('AQ_WS_ID is not set — run from inside an OpenAlice workspace.')
   }
-  // Derive the CLI base from the MCP URL: .../mcp -> .../cli/<wsId>/<export>
-  const base = mcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli') + '/' + wsId + '/' + exportKey
+  // Prefer the dedicated CLI base. Fall back to legacy MCP-derived config so
+  // older workspace envs keep working: .../mcp -> .../cli/<wsId>/<export>.
+  const gateway = toolSocket
+    ? (toolUrl || '/cli').replace(/\/+$/, '')
+    : toolUrl
+      ? toolUrl.replace(/\/+$/, '')
+      : legacyMcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli')
+  const base = gateway + '/' + wsId + '/' + exportKey
 
   const wantsHelp = argv.includes('--help') || argv.includes('-h')
   const positionals = argv.filter((a) => !a.startsWith('-'))
@@ -111,6 +119,9 @@ async function invoke(base, tool, args) {
 }
 
 async function fetchJson(url, opts) {
+  if (process.env.OPENALICE_TOOL_SOCKET && url.startsWith('/')) {
+    return fetchSocketJson(process.env.OPENALICE_TOOL_SOCKET, url, opts)
+  }
   let resp
   try {
     resp = await fetch(url, opts)
@@ -125,6 +136,30 @@ async function fetchJson(url, opts) {
     body = text
   }
   return { ok: resp.ok, status: resp.status, body }
+}
+
+async function fetchSocketJson(socketPath, path, opts) {
+  const http = await import('node:http')
+  return new Promise((resolve) => {
+    const req = http.request({
+      socketPath,
+      path,
+      method: opts && opts.method ? opts.method : 'GET',
+      headers: opts && opts.headers ? opts.headers : undefined,
+    }, (res) => {
+      let raw = ''
+      res.setEncoding('utf8')
+      res.on('data', (chunk) => { raw += chunk })
+      res.on('end', () => {
+        let body = null
+        try { body = raw ? JSON.parse(raw) : null } catch { body = raw }
+        resolve({ ok: res.statusCode >= 200 && res.statusCode < 300, status: res.statusCode, body })
+      })
+    })
+    req.on('error', (e) => fail(`cannot reach OpenAlice at ${socketPath}${path} — is the backend running? (${e && e.message})`))
+    if (opts && opts.body) req.write(opts.body)
+    req.end()
+  })
 }
 
 // ---- flag parsing ---------------------------------------------------------

--- a/src/workspaces/cli/bin/alice-uta
+++ b/src/workspaces/cli/bin/alice-uta
@@ -12,7 +12,7 @@
  * (`alice` -> data, `alice-<x>` -> <x>) and talks to `/cli/<wsId>/<export>/*`.
  *
  * Runs from a workspace PTY shell, reading env the launcher already injects per
- * spawn (OPENALICE_MCP_URL + AQ_WS_ID). Deliberately written with NO import /
+ * spawn (OPENALICE_TOOL_URL + AQ_WS_ID). Deliberately written with NO import /
  * export and NO top-level await, so node runs it identically whether it treats
  * the file as ESM or CommonJS — and with zero Alice imports, so there is nothing
  * to build (dev and prod behave the same). Uses only global fetch / process.
@@ -34,13 +34,21 @@ async function main() {
   BIN = (process.argv[1] || 'alice').split(/[\\/]/).pop() || 'alice'
   const exportKey = BIN === 'alice' ? 'data' : BIN.replace(/^alice-/, '')
 
-  const mcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
+  const toolSocket = process.env.OPENALICE_TOOL_SOCKET
+  const toolUrl = process.env.OPENALICE_TOOL_URL
+  const legacyMcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
   const wsId = process.env.AQ_WS_ID
   if (!wsId) {
     fail('AQ_WS_ID is not set — run from inside an OpenAlice workspace.')
   }
-  // Derive the CLI base from the MCP URL: .../mcp -> .../cli/<wsId>/<export>
-  const base = mcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli') + '/' + wsId + '/' + exportKey
+  // Prefer the dedicated CLI base. Fall back to legacy MCP-derived config so
+  // older workspace envs keep working: .../mcp -> .../cli/<wsId>/<export>.
+  const gateway = toolSocket
+    ? (toolUrl || '/cli').replace(/\/+$/, '')
+    : toolUrl
+      ? toolUrl.replace(/\/+$/, '')
+      : legacyMcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli')
+  const base = gateway + '/' + wsId + '/' + exportKey
 
   const wantsHelp = argv.includes('--help') || argv.includes('-h')
   const positionals = argv.filter((a) => !a.startsWith('-'))
@@ -111,6 +119,9 @@ async function invoke(base, tool, args) {
 }
 
 async function fetchJson(url, opts) {
+  if (process.env.OPENALICE_TOOL_SOCKET && url.startsWith('/')) {
+    return fetchSocketJson(process.env.OPENALICE_TOOL_SOCKET, url, opts)
+  }
   let resp
   try {
     resp = await fetch(url, opts)
@@ -125,6 +136,30 @@ async function fetchJson(url, opts) {
     body = text
   }
   return { ok: resp.ok, status: resp.status, body }
+}
+
+async function fetchSocketJson(socketPath, path, opts) {
+  const http = await import('node:http')
+  return new Promise((resolve) => {
+    const req = http.request({
+      socketPath,
+      path,
+      method: opts && opts.method ? opts.method : 'GET',
+      headers: opts && opts.headers ? opts.headers : undefined,
+    }, (res) => {
+      let raw = ''
+      res.setEncoding('utf8')
+      res.on('data', (chunk) => { raw += chunk })
+      res.on('end', () => {
+        let body = null
+        try { body = raw ? JSON.parse(raw) : null } catch { body = raw }
+        resolve({ ok: res.statusCode >= 200 && res.statusCode < 300, status: res.statusCode, body })
+      })
+    })
+    req.on('error', (e) => fail(`cannot reach OpenAlice at ${socketPath}${path} — is the backend running? (${e && e.message})`))
+    if (opts && opts.body) req.write(opts.body)
+    req.end()
+  })
 }
 
 // ---- flag parsing ---------------------------------------------------------

--- a/src/workspaces/cli/bin/alice-workspace
+++ b/src/workspaces/cli/bin/alice-workspace
@@ -12,7 +12,7 @@
  * (`alice` -> data, `alice-<x>` -> <x>) and talks to `/cli/<wsId>/<export>/*`.
  *
  * Runs from a workspace PTY shell, reading env the launcher already injects per
- * spawn (OPENALICE_MCP_URL + AQ_WS_ID). Deliberately written with NO import /
+ * spawn (OPENALICE_TOOL_URL + AQ_WS_ID). Deliberately written with NO import /
  * export and NO top-level await, so node runs it identically whether it treats
  * the file as ESM or CommonJS — and with zero Alice imports, so there is nothing
  * to build (dev and prod behave the same). Uses only global fetch / process.
@@ -34,13 +34,21 @@ async function main() {
   BIN = (process.argv[1] || 'alice').split(/[\\/]/).pop() || 'alice'
   const exportKey = BIN === 'alice' ? 'data' : BIN.replace(/^alice-/, '')
 
-  const mcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
+  const toolSocket = process.env.OPENALICE_TOOL_SOCKET
+  const toolUrl = process.env.OPENALICE_TOOL_URL
+  const legacyMcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
   const wsId = process.env.AQ_WS_ID
   if (!wsId) {
     fail('AQ_WS_ID is not set — run from inside an OpenAlice workspace.')
   }
-  // Derive the CLI base from the MCP URL: .../mcp -> .../cli/<wsId>/<export>
-  const base = mcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli') + '/' + wsId + '/' + exportKey
+  // Prefer the dedicated CLI base. Fall back to legacy MCP-derived config so
+  // older workspace envs keep working: .../mcp -> .../cli/<wsId>/<export>.
+  const gateway = toolSocket
+    ? (toolUrl || '/cli').replace(/\/+$/, '')
+    : toolUrl
+      ? toolUrl.replace(/\/+$/, '')
+      : legacyMcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli')
+  const base = gateway + '/' + wsId + '/' + exportKey
 
   const wantsHelp = argv.includes('--help') || argv.includes('-h')
   const positionals = argv.filter((a) => !a.startsWith('-'))
@@ -111,6 +119,9 @@ async function invoke(base, tool, args) {
 }
 
 async function fetchJson(url, opts) {
+  if (process.env.OPENALICE_TOOL_SOCKET && url.startsWith('/')) {
+    return fetchSocketJson(process.env.OPENALICE_TOOL_SOCKET, url, opts)
+  }
   let resp
   try {
     resp = await fetch(url, opts)
@@ -125,6 +136,30 @@ async function fetchJson(url, opts) {
     body = text
   }
   return { ok: resp.ok, status: resp.status, body }
+}
+
+async function fetchSocketJson(socketPath, path, opts) {
+  const http = await import('node:http')
+  return new Promise((resolve) => {
+    const req = http.request({
+      socketPath,
+      path,
+      method: opts && opts.method ? opts.method : 'GET',
+      headers: opts && opts.headers ? opts.headers : undefined,
+    }, (res) => {
+      let raw = ''
+      res.setEncoding('utf8')
+      res.on('data', (chunk) => { raw += chunk })
+      res.on('end', () => {
+        let body = null
+        try { body = raw ? JSON.parse(raw) : null } catch { body = raw }
+        resolve({ ok: res.statusCode >= 200 && res.statusCode < 300, status: res.statusCode, body })
+      })
+    })
+    req.on('error', (e) => fail(`cannot reach OpenAlice at ${socketPath}${path} — is the backend running? (${e && e.message})`))
+    if (opts && opts.body) req.write(opts.body)
+    req.end()
+  })
 }
 
 // ---- flag parsing ---------------------------------------------------------

--- a/src/workspaces/cli/bin/traderhub
+++ b/src/workspaces/cli/bin/traderhub
@@ -12,7 +12,7 @@
  * (`alice` -> data, `alice-<x>` -> <x>) and talks to `/cli/<wsId>/<export>/*`.
  *
  * Runs from a workspace PTY shell, reading env the launcher already injects per
- * spawn (OPENALICE_MCP_URL + AQ_WS_ID). Deliberately written with NO import /
+ * spawn (OPENALICE_TOOL_URL + AQ_WS_ID). Deliberately written with NO import /
  * export and NO top-level await, so node runs it identically whether it treats
  * the file as ESM or CommonJS — and with zero Alice imports, so there is nothing
  * to build (dev and prod behave the same). Uses only global fetch / process.
@@ -34,13 +34,21 @@ async function main() {
   BIN = (process.argv[1] || 'alice').split(/[\\/]/).pop() || 'alice'
   const exportKey = BIN === 'alice' ? 'data' : BIN.replace(/^alice-/, '')
 
-  const mcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
+  const toolSocket = process.env.OPENALICE_TOOL_SOCKET
+  const toolUrl = process.env.OPENALICE_TOOL_URL
+  const legacyMcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
   const wsId = process.env.AQ_WS_ID
   if (!wsId) {
     fail('AQ_WS_ID is not set — run from inside an OpenAlice workspace.')
   }
-  // Derive the CLI base from the MCP URL: .../mcp -> .../cli/<wsId>/<export>
-  const base = mcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli') + '/' + wsId + '/' + exportKey
+  // Prefer the dedicated CLI base. Fall back to legacy MCP-derived config so
+  // older workspace envs keep working: .../mcp -> .../cli/<wsId>/<export>.
+  const gateway = toolSocket
+    ? (toolUrl || '/cli').replace(/\/+$/, '')
+    : toolUrl
+      ? toolUrl.replace(/\/+$/, '')
+      : legacyMcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli')
+  const base = gateway + '/' + wsId + '/' + exportKey
 
   const wantsHelp = argv.includes('--help') || argv.includes('-h')
   const positionals = argv.filter((a) => !a.startsWith('-'))
@@ -111,6 +119,9 @@ async function invoke(base, tool, args) {
 }
 
 async function fetchJson(url, opts) {
+  if (process.env.OPENALICE_TOOL_SOCKET && url.startsWith('/')) {
+    return fetchSocketJson(process.env.OPENALICE_TOOL_SOCKET, url, opts)
+  }
   let resp
   try {
     resp = await fetch(url, opts)
@@ -125,6 +136,30 @@ async function fetchJson(url, opts) {
     body = text
   }
   return { ok: resp.ok, status: resp.status, body }
+}
+
+async function fetchSocketJson(socketPath, path, opts) {
+  const http = await import('node:http')
+  return new Promise((resolve) => {
+    const req = http.request({
+      socketPath,
+      path,
+      method: opts && opts.method ? opts.method : 'GET',
+      headers: opts && opts.headers ? opts.headers : undefined,
+    }, (res) => {
+      let raw = ''
+      res.setEncoding('utf8')
+      res.on('data', (chunk) => { raw += chunk })
+      res.on('end', () => {
+        let body = null
+        try { body = raw ? JSON.parse(raw) : null } catch { body = raw }
+        resolve({ ok: res.statusCode >= 200 && res.statusCode < 300, status: res.statusCode, body })
+      })
+    })
+    req.on('error', (e) => fail(`cannot reach OpenAlice at ${socketPath}${path} — is the backend running? (${e && e.message})`))
+    if (opts && opts.body) req.write(opts.body)
+    req.end()
+  })
 }
 
 // ---- flag parsing ---------------------------------------------------------

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -1,7 +1,15 @@
+import { execFile } from 'node:child_process'
 import { readFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
 
 import { describe, it, expect } from 'vitest'
+
+const execFileAsync = promisify(execFile)
 
 /**
  * The CLI shim is ONE file shipped under each export name as a byte-identical
@@ -26,6 +34,57 @@ describe('CLI shim copies', () => {
     const src = read('alice').toString('utf8')
     expect(src).toContain('process.argv[1]') // derives BIN from how it was invoked
     expect(src).toContain('exportKey') // routes to the per-export gateway path
+  })
+
+  it('stays ESM-safe when Node treats extensionless shims as modules', () => {
+    const src = read('alice').toString('utf8')
+    expect(src).not.toContain('require(')
+    expect(src).toContain("await import('node:http')")
+  })
+
+  it('can fetch a manifest over OPENALICE_TOOL_SOCKET when executed as an ES module', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openalice-cli-shim-'))
+    const socketPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\openalice-cli-shim-${process.pid}-${Date.now()}`
+      : join(dir, 'tools.sock')
+    const seen: string[] = []
+    const server = createServer((req, res) => {
+      seen.push(req.url ?? '')
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        description: 'test manifest',
+        groups: {
+          market: {
+            search: {
+              tool: 'marketSearchForResearch',
+              description: 'Search market data',
+              inputSchema: { type: 'object', properties: {} },
+            },
+          },
+        },
+      }))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, resolve)
+    })
+    try {
+      const { stdout } = await execFileAsync(process.execPath, [fileURLToPath(new URL('bin/alice', import.meta.url))], {
+        env: {
+          ...process.env,
+          AQ_WS_ID: 'ws1',
+          OPENALICE_TOOL_SOCKET: socketPath,
+          OPENALICE_TOOL_URL: '/cli',
+        },
+        timeout: 5_000,
+      })
+      expect(stdout).toContain('OpenAlice CLI')
+      expect(stdout).toContain('market')
+      expect(seen).toEqual(['/cli/ws1/data/manifest'])
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 
   // Windows has no shebang concept — it resolves executables on PATH by

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -188,11 +188,14 @@ export interface WorkspaceService {
 export interface CreateWorkspaceServiceOptions {
   /** Backend's bound web port — used to derive the CORS allowlist. */
   readonly webPort: number;
-  /** Backend's bound MCP port — injected as `OPENALICE_MCP_URL` into each
-   *  PTY's env so workspace `mcp.json` templates' `${OPENALICE_MCP_URL:-...}`
-   *  fallback bridge resolves to the live backend (not whatever was the
-   *  default in template files). */
+  /** Legacy MCP/local-tool port retained for callers that still print it. */
   readonly mcpPort: number;
+  /** Base URL used by the injected `alice*` CLI shims, usually `/cli`. */
+  readonly toolBaseUrl: string;
+  /** Optional Unix socket / named pipe used by `alice*` in Electron app mode. */
+  readonly toolSocketPath?: string;
+  /** Optional MCP protocol URL. Absent when MCP is disabled. */
+  readonly mcpBaseUrl?: string;
   /** The global inbox store, so `issueDetail` can join the inbox reports an
    *  issue produced (entries stamped `origin.issueId`) in the domain layer —
    *  every surface (HTTP / CLI / MCP) gets the join, not just the route.
@@ -341,14 +344,15 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     const baseEnv = buildSpawnEnv(process.env, {
       AQ_WS_ID: ws.id,
       AQ_LAUNCHER_REPO_ROOT: config.launcherRepoRoot,
-      // Tells workspace templates' `${OPENALICE_MCP_URL:-...}` substitution
-      // where to find the backend's MCP endpoint at spawn time. Without
-      // this, Claude Code / Codex inside the workspace would fall back to
-      // the template-default port literal which may not match the actual
-      // backend (guardian can pick a different port if the default is taken).
-      OPENALICE_MCP_URL: `http://127.0.0.1:${opts.mcpPort}/mcp`,
+      // Local tool gateway for the injected `alice*` CLI shims. Electron/dev
+      // can point this at the web listener's `/cli`; Docker/public-web can keep
+      // it on a separate loopback-only port. This is the default agent tool
+      // path and does not require MCP to be enabled.
+      OPENALICE_TOOL_URL: opts.toolBaseUrl,
+      ...(opts.toolSocketPath ? { OPENALICE_TOOL_SOCKET: opts.toolSocketPath } : {}),
+      ...(opts.mcpBaseUrl ? { OPENALICE_MCP_URL: opts.mcpBaseUrl } : {}),
       // Prepend the `alice` CLI shim dir so the workspace agent can invoke it
-      // from its shell (it reads OPENALICE_MCP_URL + AQ_WS_ID above). Shared
+      // from its shell (it reads OPENALICE_TOOL_URL + AQ_WS_ID above). Shared
       // script — not written into the workspace, so it never pollutes the
       // workspace's git repo.
       PATH: `${cliBinPath()}${pathDelimiter}${process.env.PATH ?? ''}`,

--- a/src/workspaces/spawn-env.spec.ts
+++ b/src/workspaces/spawn-env.spec.ts
@@ -45,6 +45,25 @@ describe('buildSpawnEnv', () => {
     expect(out['PWD']).toBe('/ws/dir')
   })
 
+  it('strips launcher-owned tool/MCP env from the parent and only trusts extras', () => {
+    const out = buildSpawnEnv(
+      {
+        OPENALICE_MCP_URL: 'http://stale/mcp',
+        OPENALICE_TOOL_URL: 'http://stale/cli',
+        OPENALICE_TOOL_SOCKET: '/tmp/stale.sock',
+        OPENCODE_CONFIG_CONTENT: '{"mcp":{"stale":true}}',
+      },
+      {
+        OPENALICE_TOOL_URL: '/cli',
+        OPENALICE_TOOL_SOCKET: '/tmp/current.sock',
+      },
+    )
+    expect(out['OPENALICE_MCP_URL']).toBeUndefined()
+    expect(out['OPENCODE_CONFIG_CONTENT']).toBeUndefined()
+    expect(out['OPENALICE_TOOL_URL']).toBe('/cli')
+    expect(out['OPENALICE_TOOL_SOCKET']).toBe('/tmp/current.sock')
+  })
+
   it('defaults terminal locale to UTF-8 without overriding explicit locale', () => {
     expect(buildSpawnEnv({})['LANG']).toBe('en_US.UTF-8')
     expect(buildSpawnEnv({})['LC_CTYPE']).toBe('en_US.UTF-8')

--- a/src/workspaces/spawn-env.ts
+++ b/src/workspaces/spawn-env.ts
@@ -21,6 +21,10 @@ import { delimiter, join } from 'node:path';
 const STRIP_EXACT = new Set<string>([
   'TERM_PROGRAM',
   'TERM_PROGRAM_VERSION',
+  'OPENALICE_MCP_URL',
+  'OPENALICE_TOOL_URL',
+  'OPENALICE_TOOL_SOCKET',
+  'OPENCODE_CONFIG_CONTENT',
 ]);
 
 const STRIP_PREFIXES = [

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -181,6 +181,7 @@ export interface AppConfig {
  * stays under connectors.
  */
 export interface McpConfig {
+  enabled: boolean
   port: number
 }
 

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -32,6 +32,115 @@ export type { KeyMap } from './terminalInput';
 
 type Status = 'connecting' | 'reconnecting' | 'connected' | 'closed' | 'error' | 'kicked';
 
+interface SocketMessageEventLike {
+  readonly data: unknown;
+}
+
+interface SocketCloseEventLike {
+  readonly code: number;
+}
+
+interface SocketLike {
+  readonly OPEN: number;
+  readyState: number;
+  binaryType?: BinaryType;
+  send(data: string | Uint8Array): void;
+  close(): void;
+  addEventListener(type: 'open', cb: () => void): void;
+  addEventListener(type: 'message', cb: (ev: SocketMessageEventLike) => void): void;
+  addEventListener(type: 'close', cb: (ev: SocketCloseEventLike) => void): void;
+  addEventListener(type: 'error', cb: () => void): void;
+}
+
+class ElectronPtySocket implements SocketLike {
+  readonly OPEN = 1;
+  readonly CLOSED = 3;
+  readyState = 0;
+
+  private readonly connectionId: string;
+  private readonly bridge: NonNullable<Window['openAlice']>['pty'];
+  private readonly listeners = {
+    open: new Set<() => void>(),
+    message: new Set<(ev: SocketMessageEventLike) => void>(),
+    close: new Set<(ev: SocketCloseEventLike) => void>(),
+    error: new Set<() => void>(),
+  };
+  private readonly unsubscribers: Array<() => void> = [];
+  private opened = false;
+
+  constructor(input: { sessionId: string; cols: number; rows: number }) {
+    const bridge = window.openAlice?.pty;
+    if (!bridge) throw new Error('Electron PTY bridge is unavailable');
+    this.bridge = bridge;
+    this.connectionId = bridge.connect(input);
+    this.unsubscribers.push(
+      bridge.onMessage(this.connectionId, (msg) => {
+        if (msg.type === 'control') {
+          const text = typeof msg.data === 'string' ? msg.data : String(msg.data ?? '');
+          const control = parseServerControl(text);
+          if (control?.type === 'attached') this.emitOpen();
+          this.emitMessage(text);
+        } else {
+          this.emitMessage(toArrayBuffer(msg.data));
+        }
+      }),
+      bridge.onClose(this.connectionId, (msg) => {
+        this.readyState = this.CLOSED;
+        for (const cb of this.listeners.close) cb({ code: msg.code });
+        this.cleanup();
+      }),
+    );
+  }
+
+  send(data: string | Uint8Array): void {
+    if (this.readyState !== this.OPEN) return;
+    if (typeof data === 'string') {
+      const parsed = parseResizeControl(data);
+      if (parsed) this.bridge.resize(this.connectionId, parsed.cols, parsed.rows);
+      return;
+    }
+    this.bridge.send(this.connectionId, data);
+  }
+
+  close(): void {
+    if (this.readyState === this.CLOSED) return;
+    this.readyState = this.CLOSED;
+    this.bridge.close(this.connectionId);
+    this.cleanup();
+  }
+
+  addEventListener(type: 'open', cb: () => void): void;
+  addEventListener(type: 'message', cb: (ev: SocketMessageEventLike) => void): void;
+  addEventListener(type: 'close', cb: (ev: SocketCloseEventLike) => void): void;
+  addEventListener(type: 'error', cb: () => void): void;
+  addEventListener(
+    type: 'open' | 'message' | 'close' | 'error',
+    cb: (() => void) | ((ev: SocketMessageEventLike | SocketCloseEventLike) => void),
+  ): void {
+    if (type === 'open') {
+      this.listeners.open.add(cb as () => void);
+      if (this.readyState === this.OPEN) queueMicrotask(cb as () => void);
+    } else if (type === 'message') this.listeners.message.add(cb as (ev: SocketMessageEventLike) => void);
+    else if (type === 'close') this.listeners.close.add(cb as (ev: SocketCloseEventLike) => void);
+    else this.listeners.error.add(cb as () => void);
+  }
+
+  private emitMessage(data: unknown): void {
+    for (const cb of this.listeners.message) cb({ data });
+  }
+
+  private emitOpen(): void {
+    if (this.opened || this.readyState === this.CLOSED) return;
+    this.opened = true;
+    this.readyState = this.OPEN;
+    for (const cb of this.listeners.open) cb();
+  }
+
+  private cleanup(): void {
+    for (const unsub of this.unsubscribers.splice(0)) unsub();
+  }
+}
+
 interface ExitInfo {
   readonly code: number;
   readonly signal: number | null;
@@ -171,7 +280,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
 
     // The live socket is swapped out on every (re)connect; senders read it at
     // call time so xterm's stdin/binary subs survive a reconnect untouched.
-    let activeWs: WebSocket | null = null;
+    let activeWs: SocketLike | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let attempts = 0;
     let hasConnectedOnce = false;
@@ -182,7 +291,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
 
     const sendControl = (msg: ClientControlMessage): void => {
       const ws = activeWs;
-      if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(msg));
+      if (ws && ws.readyState === ws.OPEN) ws.send(JSON.stringify(msg));
     };
 
     const encoder = new TextEncoder();
@@ -202,7 +311,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     const sendStdin = (data: string): void => {
       logInput('stdin', data);
       const ws = activeWs;
-      if (ws && ws.readyState === WebSocket.OPEN) ws.send(encoder.encode(data));
+      if (ws && ws.readyState === ws.OPEN) ws.send(encoder.encode(data));
     };
 
     const safeFocus = (): void => {
@@ -302,7 +411,12 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
 
     function connect(): void {
       if (teardown) return;
-      const ws = new WebSocket(currentUrl());
+      // Electron app mode has a preload PTY bridge, so it can bypass the
+      // renderer -> localhost WebSocket hop. Browser/dev/Docker keep the
+      // WebSocket path with the exact same xterm lifecycle.
+      const ws: SocketLike = window.openAlice?.pty
+        ? new ElectronPtySocket({ sessionId, cols: lastCols, rows: lastRows })
+        : new WebSocket(currentUrl());
       ws.binaryType = 'arraybuffer';
       activeWs = ws;
       setStatus(hasConnectedOnce ? 'reconnecting' : 'connecting');
@@ -381,7 +495,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     const stdinSub = term.onData(sendStdin);
     const binarySub = term.onBinary((d) => {
       const ws = activeWs;
-      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      if (!ws || ws.readyState !== ws.OPEN) return;
       logInput('binary', d);
       const bytes = new Uint8Array(d.length);
       for (let i = 0; i < d.length; i++) bytes[i] = d.charCodeAt(i) & 0xff;
@@ -499,4 +613,29 @@ function safeFit(fit: FitAddon): void {
   } catch {
     // Container may have zero size during initial layout; ignore.
   }
+}
+
+function parseResizeControl(data: string): { cols: number; rows: number } | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== 'object') return null;
+  const msg = value as Record<string, unknown>;
+  if (msg['type'] !== 'resize') return null;
+  const cols = typeof msg['cols'] === 'number' ? msg['cols'] : Number.NaN;
+  const rows = typeof msg['rows'] === 'number' ? msg['rows'] : Number.NaN;
+  if (!Number.isFinite(cols) || !Number.isFinite(rows) || cols <= 0 || rows <= 0) return null;
+  return { cols: Math.floor(cols), rows: Math.floor(rows) };
+}
+
+function toArrayBuffer(data: unknown): ArrayBuffer {
+  if (data instanceof ArrayBuffer) return data;
+  if (data instanceof Uint8Array) {
+    return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+  }
+  if (Array.isArray(data)) return new Uint8Array(data).buffer;
+  return new Uint8Array().buffer;
 }

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -447,7 +447,16 @@ export interface DirListing {
   readonly entries: readonly FileEntry[];
 }
 
+function electronWorkspaceBridge(): NonNullable<Window['openAlice']>['workspace'] | undefined {
+  return typeof window !== 'undefined' ? window.openAlice?.workspace : undefined;
+}
+
 export async function listFiles(id: string, relPath: string): Promise<DirListing> {
+  // Electron app mode has a native file transport. Browser/dev/Docker keep the
+  // HTTP path, which is still the right shape for self-hosting and ordinary
+  // browser debugging.
+  const bridge = electronWorkspaceBridge();
+  if (bridge) return bridge.listFiles({ id, path: relPath });
   const qs = relPath ? `?path=${encodeURIComponent(relPath)}` : '';
   const res = await fetch(`/api/workspaces/${encodeURIComponent(id)}/files${qs}`);
   if (!res.ok) throw new Error(`list files failed: ${res.status}`);
@@ -468,6 +477,8 @@ export type ReadFileResult =
   | { kind: 'error'; message: string };
 
 export async function readWorkspaceFile(id: string, relPath: string): Promise<ReadFileResult> {
+  const bridge = electronWorkspaceBridge();
+  if (bridge) return bridge.readFile({ id, path: relPath });
   const qs = `?path=${encodeURIComponent(relPath)}`;
   let res: Response;
   try {

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -16,7 +16,7 @@ export const configKeysHandlers = [
       compaction: { maxContextTokens: 0, maxOutputTokens: 0 },
       snapshot: { enabled: false, every: '1h' },
       trading: { observeExternalOrdersEvery: '15m' },
-      mcp: { port: 47332 },
+      mcp: { enabled: false, port: 47332 },
       marketData: {
         enabled: true,
         providers: { equity: 'yfinance', crypto: 'yfinance', currency: 'yfinance', commodity: 'yfinance' },

--- a/ui/src/pages/MCPPage.tsx
+++ b/ui/src/pages/MCPPage.tsx
@@ -25,7 +25,7 @@ export function MCPPage() {
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader
         title="MCP Server"
-        description="Streamable-HTTP endpoint that exposes OpenAlice's ToolCenter to external MCP clients. Changes require a restart."
+        description="Optional Streamable-HTTP endpoint for external MCP clients. Workspace tools use the built-in CLI gateway by default."
         right={<SaveIndicator status={status} onRetry={retry} />}
       />
 
@@ -34,12 +34,23 @@ export function MCPPage() {
           <div className="max-w-[880px] mx-auto">
             <ConfigSection
               title="HTTP Server"
-              description="Listening port for the streamable-HTTP MCP endpoint (path: /mcp)."
+              description="Disabled by default. Enable only when you intentionally want another local MCP client to call OpenAlice."
             >
+              <Field label="Enabled">
+                <label className="inline-flex items-center gap-2 text-[13px] text-text">
+                  <input
+                    type="checkbox"
+                    checked={config.enabled}
+                    onChange={(e) => updateConfig({ enabled: e.target.checked })}
+                  />
+                  Run the MCP endpoint
+                </label>
+              </Field>
               <Field label="Port">
                 <input
                   className={inputClass}
                   type="number"
+                  disabled={!config.enabled}
                   value={config.port}
                   onChange={(e) => updateConfig({ port: Number(e.target.value) })}
                 />

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -15,3 +15,55 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+interface Window {
+  /**
+   * Electron preload bridge. Undefined in browser/dev/Docker surfaces, where
+   * the app keeps using HTTP + WebSocket. Keep this declaration narrow and in
+   * sync with apps/desktop/src/preload.ts; never expose raw ipcRenderer.
+   */
+  readonly openAlice?: {
+    readonly runtime: {
+      info(): Promise<{
+        mode: 'electron-dev' | 'electron-packaged'
+        transport: 'electron-ipc'
+        ports: { web: number | null; mcp: number | null; uta: number }
+        userDataHome: string
+        appHome: string
+      }>
+    }
+    readonly workspace: {
+      listFiles(input: { id: string; path: string }): Promise<{
+        path: string
+        entries: ReadonlyArray<{
+          name: string
+          kind: 'file' | 'dir' | 'symlink' | 'other'
+          sizeBytes: number | null
+          mtime: string
+        }>
+      }>
+      readFile(input: { id: string; path: string }): Promise<
+        | { kind: 'ok'; content: string }
+        | { kind: 'workspace_missing' }
+        | { kind: 'file_missing' }
+        | { kind: 'too_large'; sizeBytes: number }
+        | { kind: 'invalid_path' }
+        | { kind: 'error'; message: string }
+      >
+    }
+    readonly pty: {
+      connect(input: { sessionId: string; cols: number; rows: number; since?: number }): string
+      send(connectionId: string, data: Uint8Array): void
+      resize(connectionId: string, cols: number, rows: number): void
+      close(connectionId: string): void
+      onMessage(
+        connectionId: string,
+        cb: (msg: { type: 'data' | 'control'; data: unknown }) => void,
+      ): () => void
+      onClose(
+        connectionId: string,
+        cb: (msg: { code: number; reason: string }) => void,
+      ): () => void
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR moves the desktop app path toward an Electron-native transport while keeping the browser/dev/Docker HTTP path intact.

- Add Electron `app://openalice` loading and a preload bridge for renderer-to-Alice IPC.
- Route workspace file APIs and PTY shell traffic over Electron IPC in app mode; keep HTTP/WS as the web fallback.
- Add a local CLI gateway over Unix socket / named pipe for Electron mode so `alice*` and `traderhub` shims do not require MCP or an exposed MCP port.
- Make the MCP server optional and disabled by default in desktop app mode, while preserving explicit opt-in.
- Add `electron:smoke:pty` coverage for renderer PTY attach and CLI socket manifest behavior.
- Remove OpenCode's old OpenAlice MCP env/config injection and strip stale launcher env from spawned agents.

## Why

Desktop app mode should not be forced through the same localhost web server shape used by browser/dev/Docker deployments. This reduces default port exposure, avoids fragile localhost coupling for the app shell, and keeps UTA separate because that process is intentionally designed as a detachable trusted trading sidecar.

The OpenCode cleanup closes the last obvious MCP injection trace: OpenCode now relies on the same CLI shim/tool socket path as the other agents, and inherited stale MCP/tool env is scrubbed before spawning sessions.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm vitest run src/workspaces/cli/shim.spec.ts src/server/cli.spec.ts`
- `pnpm vitest run src/workspaces/adapters/ai-config.spec.ts src/workspaces/spawn-env.spec.ts`
- `pnpm electron:build && pnpm electron:smoke:pty --skip-build`
- `git diff --check`
