### PR TITLE
Persist Inbox read state to files

### DIFF
--- a/src/core/inbox-store.spec.ts
+++ b/src/core/inbox-store.spec.ts
@@ -134,6 +134,22 @@ describe('InboxStore (in-memory)', () => {
     expect(await store.delete(a.id)).toBe(false)
   })
 
+  it('markRead and markUnread update per-entry readAt state', async () => {
+    const a = await store.append({ workspaceId: 'ws-1', comments: 'a' })
+    expect(await store.markRead(a.id, 1234)).toBe(true)
+    let result = await store.read()
+    expect(result.entries[0].readAt).toBe(1234)
+
+    expect(await store.markUnread(a.id)).toBe(true)
+    result = await store.read()
+    expect(result.entries[0].readAt).toBeUndefined()
+  })
+
+  it('markRead and markUnread return false for missing entries', async () => {
+    expect(await store.markRead('missing')).toBe(false)
+    expect(await store.markUnread('missing')).toBe(false)
+  })
+
   it('onRemoved fires on successful delete, dispose stops further notifications', async () => {
     const seen: string[] = []
     const dispose = store.onRemoved((id) => seen.push(id))
@@ -163,12 +179,14 @@ describe('InboxStore (in-memory)', () => {
 describe('InboxStore (JSONL persistence)', () => {
   let dir: string
   let path: string
+  let readStatePath: string
   let store: IInboxStore
 
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), 'oa-inbox-'))
     path = join(dir, 'entries.jsonl')
-    store = createInboxStore({ filePath: path })
+    readStatePath = join(dir, 'read-state.json')
+    store = createInboxStore({ filePath: path, readStatePath })
   })
 
   it('persists across new store instances on the same file', async () => {
@@ -177,7 +195,7 @@ describe('InboxStore (JSONL persistence)', () => {
       docs: [{ path: 'report.md' }],
       comments: 'final draft',
     })
-    const fresh = createInboxStore({ filePath: path })
+    const fresh = createInboxStore({ filePath: path, readStatePath })
     const { entries } = await fresh.read()
     expect(entries).toHaveLength(1)
     expect(entries[0].docs).toEqual([{ path: 'report.md' }])
@@ -197,7 +215,7 @@ describe('InboxStore (JSONL persistence)', () => {
       path,
       JSON.stringify({ id: 'legacy', ts: 1, workspaceId: 'ws-1', comments: 'old' }) + '\n',
     )
-    const fresh = createInboxStore({ filePath: path })
+    const fresh = createInboxStore({ filePath: path, readStatePath })
     const { entries } = await fresh.read()
     const legacy = entries.find((e) => e.id === 'legacy')
     const withOrigin = entries.find((e) => e.comments === 'with origin')
@@ -221,16 +239,65 @@ describe('InboxStore (JSONL persistence)', () => {
     expect(await store.delete(b.id)).toBe(true)
 
     // Re-open from disk — verify only a and c survive, in original order.
-    const fresh = createInboxStore({ filePath: path })
+    const fresh = createInboxStore({ filePath: path, readStatePath })
     const { entries } = await fresh.read()
     expect(entries.map((e) => e.id)).toEqual([c.id, a.id])
 
     // Deleting a non-existent id on disk is a no-op (returns false; file
     // contents unchanged).
     expect(await store.delete('does-not-exist')).toBe(false)
-    const fresh2 = createInboxStore({ filePath: path })
+    const fresh2 = createInboxStore({ filePath: path, readStatePath })
     const { entries: again } = await fresh2.read()
     expect(again.map((e) => e.id)).toEqual([c.id, a.id])
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('persists read state in a sidecar file without mutating entries JSONL', async () => {
+    const a = await store.append({ workspaceId: 'ws-1', comments: 'a' })
+    await store.markRead(a.id, 4567)
+
+    const fs = await import('node:fs/promises')
+    const entryLine = (await fs.readFile(path, 'utf-8')).trim()
+    expect(JSON.parse(entryLine)).not.toHaveProperty('readAt')
+
+    const fresh = createInboxStore({ filePath: path, readStatePath })
+    const { entries } = await fresh.read()
+    expect(entries[0].readAt).toBe(4567)
+    expect(JSON.parse(await fs.readFile(readStatePath, 'utf-8'))).toEqual({
+      version: 1,
+      read: { [a.id]: 4567 },
+    })
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('serializes concurrent read-state writes so marks do not clobber each other', async () => {
+    const entries = await Promise.all(
+      Array.from({ length: 8 }, (_, i) => store.append({ workspaceId: 'ws-1', comments: `n${i}` })),
+    )
+    await Promise.all(entries.map((entry, i) => store.markRead(entry.id, 1000 + i)))
+
+    const fresh = createInboxStore({ filePath: path, readStatePath })
+    const { entries: readBack } = await fresh.read()
+    expect(readBack.map((entry) => entry.readAt).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual(
+      Array.from({ length: 8 }, (_, i) => 1000 + i),
+    )
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('delete removes the entry and its sidecar read marker', async () => {
+    const a = await store.append({ workspaceId: 'ws-1', comments: 'a' })
+    await store.markRead(a.id, 999)
+    expect(await store.delete(a.id)).toBe(true)
+
+    const fresh = createInboxStore({ filePath: path, readStatePath })
+    const { entries } = await fresh.read()
+    expect(entries).toEqual([])
+
+    const fs = await import('node:fs/promises')
+    expect(JSON.parse(await fs.readFile(readStatePath, 'utf-8'))).toEqual({
+      version: 1,
+      read: {},
+    })
     await rm(dir, { recursive: true, force: true })
   })
 

--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -22,6 +22,12 @@
  * `workspaceId` required, at least one of {docs, comments} required.
  * No connector subscription, no outputGate, no dedup.
  *
+ * Read/unread is deliberately NOT written back into entries.jsonl. An entry is
+ * the immutable notification record; read state is mutable user-attention state
+ * and lives beside it in `data/inbox/read-state.json`. Keeping the two files
+ * separate preserves append-only inbox history while making read state shared
+ * across Electron, browser, and any other client using the same data root.
+ *
  * Write path: the production writer is the `inbox_push` MCP tool
  * (`tool/inbox-push.ts`), workspace-scoped via WorkspaceToolCenter at
  * `/mcp/:wsId` — the agent inside a workspace calls it; the wsId is
@@ -89,6 +95,8 @@ export interface InboxInput {
 export interface InboxEntry extends InboxInput {
   id: string
   ts: number
+  /** Server-side user-attention state. Absent means unread. */
+  readAt?: number
 }
 
 export interface InboxReadOpts {
@@ -100,6 +108,10 @@ export interface InboxReadOpts {
 export interface IInboxStore {
   append(input: InboxInput): Promise<InboxEntry>
   read(opts?: InboxReadOpts): Promise<{ entries: InboxEntry[]; hasMore: boolean }>
+  /** Mark an entry read. Returns false when the entry id does not exist. */
+  markRead(id: string, readAt?: number): Promise<boolean>
+  /** Mark an entry unread. Returns false when the entry id does not exist. */
+  markUnread(id: string): Promise<boolean>
   /** Hard-delete an entry by id. Returns true if removed, false if no
    *  entry matched. JSONL rewrites are atomic (tmp + rename). */
   delete(id: string): Promise<boolean>
@@ -109,6 +121,14 @@ export interface IInboxStore {
 }
 
 const INBOX_FILE = dataPath('inbox', 'entries.jsonl')
+const INBOX_READ_STATE_FILE = dataPath('inbox', 'read-state.json')
+
+interface InboxReadStateFile {
+  version: 1
+  read: Record<string, number>
+}
+
+const EMPTY_READ_STATE: InboxReadStateFile = { version: 1, read: {} }
 
 // ==================== Validation ====================
 
@@ -134,12 +154,71 @@ function validateInput(input: InboxInput): void {
 
 export interface InboxStoreOptions {
   filePath?: string
+  readStatePath?: string
 }
 
 export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
   const filePath = opts.filePath ?? INBOX_FILE
+  const readStatePath = opts.readStatePath ?? INBOX_READ_STATE_FILE
   const emitter = new EventEmitter()
   emitter.setMaxListeners(50)
+  let readStateQueue: Promise<void> = Promise.resolve()
+
+  function withReadStateLock<T>(fn: () => Promise<T>): Promise<T> {
+    const run = readStateQueue.then(fn, fn)
+    readStateQueue = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+
+  async function readReadState(): Promise<InboxReadStateFile> {
+    let raw: string
+    try {
+      raw = await readFile(readStatePath, 'utf-8')
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { ...EMPTY_READ_STATE, read: {} }
+      }
+      throw err
+    }
+    const parsed = JSON.parse(raw) as Partial<InboxReadStateFile>
+    return {
+      version: 1,
+      read: parsed.read && typeof parsed.read === 'object' ? parsed.read : {},
+    }
+  }
+
+  async function writeReadState(state: InboxReadStateFile): Promise<void> {
+    await mkdir(dirname(readStatePath), { recursive: true })
+    const tmp = `${readStatePath}.tmp`
+    await writeFile(tmp, JSON.stringify(state, null, 2) + '\n', 'utf-8')
+    await rename(tmp, readStatePath)
+  }
+
+  async function entryExists(id: string): Promise<boolean> {
+    let raw: string
+    try {
+      raw = await readFile(filePath, 'utf-8')
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return false
+      }
+      throw err
+    }
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const entry = JSON.parse(line) as InboxEntry
+        if (entry.id === id) return true
+      } catch {
+        // Ignore malformed lines here; read/delete preserve or surface them
+        // according to their own contracts.
+      }
+    }
+    return false
+  }
 
   async function append(input: InboxInput): Promise<InboxEntry> {
     validateInput(input)
@@ -165,10 +244,17 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
       throw err
     }
 
+    const readState = await readReadState()
     let all = raw
       .split('\n')
       .filter((l) => l.trim())
-      .map((l) => JSON.parse(l) as InboxEntry)
+      .map((l) => {
+        const entry = JSON.parse(l) as InboxEntry
+        const readAt = readState.read[entry.id]
+        return typeof readAt === 'number' && Number.isFinite(readAt) && readAt > 0
+          ? { ...entry, readAt }
+          : entry
+      })
 
     if (opts.workspaceId) {
       all = all.filter((e) => e.workspaceId === opts.workspaceId)
@@ -185,6 +271,27 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
     const entries = [...window].reverse()
     const hasMore = window.length < scoped.length
     return { entries, hasMore }
+  }
+
+  async function markRead(id: string, readAt = Date.now()): Promise<boolean> {
+    if (!await entryExists(id)) return false
+    await withReadStateLock(async () => {
+      const state = await readReadState()
+      state.read[id] = readAt
+      await writeReadState(state)
+    })
+    return true
+  }
+
+  async function markUnread(id: string): Promise<boolean> {
+    if (!await entryExists(id)) return false
+    await withReadStateLock(async () => {
+      const state = await readReadState()
+      if (!(id in state.read)) return
+      delete state.read[id]
+      await writeReadState(state)
+    })
+    return true
   }
 
   async function deleteEntry(id: string): Promise<boolean> {
@@ -222,6 +329,12 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
     const body = kept.length > 0 ? kept.join('\n') + '\n' : ''
     await writeFile(tmp, body, 'utf-8')
     await rename(tmp, filePath)
+    await withReadStateLock(async () => {
+      const state = await readReadState()
+      if (!(id in state.read)) return
+      delete state.read[id]
+      await writeReadState(state)
+    })
     emitter.emit('removed', id)
     return true
   }
@@ -240,7 +353,7 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
     }
   }
 
-  return { append, read, delete: deleteEntry, onAppended, onRemoved }
+  return { append, read, markRead, markUnread, delete: deleteEntry, onAppended, onRemoved }
 }
 
 // ==================== In-memory store (tests) ====================
@@ -281,6 +394,20 @@ export function createMemoryInboxStore(): IInboxStore {
     return true
   }
 
+  async function markRead(id: string, readAt = Date.now()): Promise<boolean> {
+    const entry = entries.find((e) => e.id === id)
+    if (!entry) return false
+    entry.readAt = readAt
+    return true
+  }
+
+  async function markUnread(id: string): Promise<boolean> {
+    const entry = entries.find((e) => e.id === id)
+    if (!entry) return false
+    delete entry.readAt
+    return true
+  }
+
   function onAppended(listener: (entry: InboxEntry) => void): () => void {
     emitter.on('appended', listener)
     return () => {
@@ -295,5 +422,5 @@ export function createMemoryInboxStore(): IInboxStore {
     }
   }
 
-  return { append, read, delete: deleteEntry, onAppended, onRemoved }
+  return { append, read, markRead, markUnread, delete: deleteEntry, onAppended, onRemoved }
 }

--- a/src/webui/routes/inbox.spec.ts
+++ b/src/webui/routes/inbox.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { createMemoryInboxStore } from '../../core/inbox-store.js'
+import { createInboxRoutes } from './inbox.js'
+
+describe('inbox routes', () => {
+  it('marks entries read and unread through HTTP', async () => {
+    const inboxStore = createMemoryInboxStore()
+    const entry = await inboxStore.append({ workspaceId: 'ws-1', comments: 'done' })
+    const app = createInboxRoutes({ inboxStore })
+
+    const readRes = await app.request(`/${entry.id}/read`, { method: 'PUT' })
+    expect(readRes.status).toBe(200)
+    const readBody = await readRes.json() as { ok: true; id: string; readAt: number }
+    expect(readBody.id).toBe(entry.id)
+    expect(readBody.readAt).toBeGreaterThan(0)
+
+    let history = await (await app.request('/history')).json() as {
+      entries: Array<{ id: string; readAt?: number }>
+    }
+    expect(history.entries[0]).toMatchObject({ id: entry.id, readAt: readBody.readAt })
+
+    const unreadRes = await app.request(`/${entry.id}/read`, { method: 'DELETE' })
+    expect(unreadRes.status).toBe(200)
+
+    history = await (await app.request('/history')).json() as {
+      entries: Array<{ id: string; readAt?: number }>
+    }
+    expect(history.entries[0]).toEqual({ id: entry.id, ts: entry.ts, workspaceId: 'ws-1', comments: 'done' })
+  })
+
+  it('returns 404 when marking a missing entry', async () => {
+    const app = createInboxRoutes({ inboxStore: createMemoryInboxStore() })
+    expect((await app.request('/missing/read', { method: 'PUT' })).status).toBe(404)
+    expect((await app.request('/missing/read', { method: 'DELETE' })).status).toBe(404)
+  })
+})

--- a/src/webui/routes/inbox.ts
+++ b/src/webui/routes/inbox.ts
@@ -1,12 +1,14 @@
 /**
  * Inbox HTTP route — read history + dev-only seed.
  *
- *   GET  /history?limit=&before=&workspaceId=   paginated, newest-first
- *   POST /seed                                  dev-only: append an entry
+ *   GET    /history?limit=&before=&workspaceId= paginated, newest-first
+ *   PUT    /:id/read                            mark one entry read
+ *   DELETE /:id/read                            mark one entry unread
+ *   POST   /seed                                dev-only: append an entry
  *
- * UI polls /history every 20s. Production write path is still deliberately
- * deferred — only /seed exists until the workspace integration pathway
- * (MCP tool + workspace identity) is decided.
+ * UI polls /history every 20s. Production writes still come from workspace
+ * tools (`inbox_push` via MCP/CLI gateway); `/seed` is only for manual/dev
+ * appends. Read/unread writes are user actions and stay in this HTTP surface.
  */
 import { Hono } from 'hono'
 import type { IInboxStore, InboxDoc } from '../../core/inbox-store.js'
@@ -24,6 +26,21 @@ export function createInboxRoutes(deps: InboxRoutesDeps) {
     const workspaceId = c.req.query('workspaceId') || undefined
     const result = await deps.inboxStore.read({ limit, before, workspaceId })
     return c.json(result)
+  })
+
+  app.put('/:id/read', async (c) => {
+    const id = c.req.param('id')
+    const readAt = Date.now()
+    const ok = await deps.inboxStore.markRead(id, readAt)
+    if (!ok) return c.json({ error: 'not_found' }, 404)
+    return c.json({ ok: true, id, readAt })
+  })
+
+  app.delete('/:id/read', async (c) => {
+    const id = c.req.param('id')
+    const ok = await deps.inboxStore.markUnread(id)
+    if (!ok) return c.json({ error: 'not_found' }, 404)
+    return c.json({ ok: true, id })
   })
 
   app.post('/seed', async (c) => {

--- a/ui/src/api/inbox.ts
+++ b/ui/src/api/inbox.ts
@@ -36,6 +36,8 @@ export interface InboxOrigin {
 export interface InboxEntry {
   id: string
   ts: number
+  /** Server-side read marker. Missing means unread. */
+  readAt?: number
   workspaceId: string
   workspaceLabel?: string
   /** Pointers to workspace files. Rendered live (no snapshot). */
@@ -88,5 +90,17 @@ export const inboxApi = {
     if (res.status === 204) return true
     if (res.status === 404) return false
     throw new Error(`inbox delete failed: ${res.status}`)
+  },
+
+  async markRead(id: string): Promise<{ ok: true; id: string; readAt: number }> {
+    return fetchJson(`/api/inbox/${encodeURIComponent(id)}/read`, {
+      method: 'PUT',
+    })
+  },
+
+  async markUnread(id: string): Promise<{ ok: true; id: string }> {
+    return fetchJson(`/api/inbox/${encodeURIComponent(id)}/read`, {
+      method: 'DELETE',
+    })
   },
 }

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -29,11 +29,17 @@ export function InboxSidebar() {
   const loading = inboxLive.useStore((s) => s.loading)
   const selectedId = useInboxSelection((s) => s.selectedEntryId)
   const select = useInboxSelection((s) => s.select)
-  const readIds = useInboxRead((s) => s.readIds)
   const markRead = useInboxRead((s) => s.markRead)
   const mode = useInboxViewMode((s) => s.mode)
 
   const threads = useMemo(() => groupThreads(entries), [entries])
+  const readIds = useMemo(() => {
+    const ids: Record<string, true> = {}
+    for (const entry of entries) {
+      if (entry.readAt) ids[entry.id] = true
+    }
+    return ids
+  }, [entries])
 
   // The visible order j/k and default-select walk: clustered order in
   // workspace mode, plain newest-first in time mode.

--- a/ui/src/demo/handlers/inbox.ts
+++ b/ui/src/demo/handlers/inbox.ts
@@ -8,5 +8,11 @@ export const inboxHandlers = [
   http.post('/api/inbox/seed', () =>
     HttpResponse.json({ error: 'Demo mode — inbox seed is disabled.' }, { status: 400 }),
   ),
+  http.put('/api/inbox/:id/read', ({ params }) =>
+    HttpResponse.json({ ok: true, id: String(params.id), readAt: Date.now() }),
+  ),
+  http.delete('/api/inbox/:id/read', ({ params }) =>
+    HttpResponse.json({ ok: true, id: String(params.id) }),
+  ),
   http.delete('/api/inbox/:id', () => new HttpResponse(null, { status: 204 })),
 ]

--- a/ui/src/live/activity-bar-collapse.ts
+++ b/ui/src/live/activity-bar-collapse.ts
@@ -18,10 +18,9 @@ reloadOnHotUpdate('live/activity-bar-collapse')
  * model can't represent "user explicitly expanded a default-collapsed
  * section".
  *
- * Persists to localStorage so the user's preference survives reloads.
- * Mirrors the `useInboxRead` shape — explicit user actions are stored;
- * key only gets pruned when the user-toggled-state matches the default
- * (avoids the store growing forever).
+ * Persists to localStorage so the user's preference survives reloads. A key
+ * only gets pruned when the user-toggled-state matches the default (avoids the
+ * store growing forever).
  */
 
 interface ActivityBarCollapseState {

--- a/ui/src/live/inbox-read.ts
+++ b/ui/src/live/inbox-read.ts
@@ -1,6 +1,10 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
-import { inboxLive } from './inbox'
+import { api } from '../api'
+import {
+  inboxLive,
+  refreshInbox,
+  setInboxReadAtOptimistically,
+} from './inbox'
 import { reloadOnHotUpdate } from '../lib/hmr'
 
 reloadOnHotUpdate('live/inbox-read')
@@ -15,16 +19,12 @@ reloadOnHotUpdate('live/inbox-read')
  * with 10 unread items, look at one, all 10 silently become read. Per-entry
  * tracking preserves the "you've actively touched this one" semantic.
  *
- * Read state lives client-side in localStorage. Persists across reloads
- * but not across devices (single-tenant local-only product; cross-device
- * sync would need a server-side store).
+ * Read state is server-side file state (`data/inbox/read-state.json`). The
+ * frontend only applies optimistic `readAt` updates into the loaded feed; the
+ * next `/api/inbox/history` poll remains authoritative. This matters for the
+ * desktop app: Electron, browser dev, and Docker/self-hosted clients should all
+ * see the same attention state when they share the same OpenAlice data root.
  */
-
-interface InboxReadState {
-  /** Set of entry ids the user has marked read. Object-shaped (not Set)
-   *  for Zustand `persist` compatibility — Set doesn't survive JSON. */
-  readIds: Record<string, true>
-}
 
 interface InboxReadActions {
   /** Mark a single entry as read. Called by the sidebar when an entry
@@ -40,37 +40,41 @@ interface InboxReadActions {
   markAllRead: () => void
 }
 
-export const useInboxRead = create<InboxReadState & InboxReadActions>()(
-  persist(
-    (set) => ({
-      readIds: {},
-      markRead: (id) =>
-        set((s) => (s.readIds[id] ? s : { readIds: { ...s.readIds, [id]: true } })),
-      markUnread: (id) =>
-        set((s) => {
-          if (!s.readIds[id]) return s
-          const next = { ...s.readIds }
-          delete next[id]
-          return { readIds: next }
-        }),
-      markAllRead: () => {
-        const { entries } = inboxLive.getState()
-        if (entries.length === 0) return
-        set((s) => {
-          const next = { ...s.readIds }
-          for (const e of entries) next[e.id] = true
-          return { readIds: next }
-        })
-      },
-    }),
-    { name: 'openalice.inbox-read.v2', version: 2 },
-  ),
-)
+export const useInboxRead = create<InboxReadActions>()(() => ({
+  markRead: (id) => {
+    const entry = inboxLive.getState().entries.find((e) => e.id === id)
+    if (entry?.readAt) return
+    const optimisticReadAt = Date.now()
+    setInboxReadAtOptimistically(id, optimisticReadAt)
+    void api.inbox.markRead(id)
+      .then((res) => setInboxReadAtOptimistically(id, res.readAt))
+      .catch(() => refreshInbox())
+  },
+  markUnread: (id) => {
+    setInboxReadAtOptimistically(id, null)
+    void api.inbox.markUnread(id)
+      .catch(() => refreshInbox())
+  },
+  markAllRead: () => {
+    const unread = inboxLive.getState().entries.filter((e) => !e.readAt)
+    if (unread.length === 0) return
+    const optimisticReadAt = Date.now()
+    for (const entry of unread) {
+      setInboxReadAtOptimistically(entry.id, optimisticReadAt)
+    }
+    void Promise.all(unread.map((entry) => api.inbox.markRead(entry.id)))
+      .then((results) => {
+        for (const result of results) {
+          setInboxReadAtOptimistically(result.id, result.readAt)
+        }
+      })
+      .catch(() => refreshInbox())
+  },
+}))
 
-/** Activity-bar badge count: entries whose id isn't in `readIds`. */
+/** Activity-bar badge count: loaded entries without a server read marker. */
 export function useUnreadInboxCount(): number {
-  const readIds = useInboxRead((s) => s.readIds)
   return inboxLive.useStore((s) =>
-    s.entries.reduce((n, e) => (readIds[e.id] ? n : n + 1), 0),
+    s.entries.reduce((n, e) => (e.readAt ? n : n + 1), 0),
   )
 }

--- a/ui/src/live/inbox.ts
+++ b/ui/src/live/inbox.ts
@@ -82,3 +82,20 @@ export function removeInboxOptimistically(id: string): void {
     entries: prev.entries.filter((e) => e.id !== id),
   }))
 }
+
+/** Optimistically mirror server-side read-state writes in the loaded feed.
+ *  The next /history poll remains authoritative and will reconcile drift. */
+export function setInboxReadAtOptimistically(id: string, readAt: number | null): void {
+  applyState?.((prev) => ({
+    ...prev,
+    entries: prev.entries.map((entry) => {
+      if (entry.id !== id) return entry
+      if (readAt == null) {
+        const next = { ...entry }
+        delete next.readAt
+        return next
+      }
+      return { ...entry, readAt }
+    }),
+  }))
+}


### PR DESCRIPTION
## Summary

Persist Inbox read/unread state in the OpenAlice data directory instead of browser localStorage.

- Keep `data/inbox/entries.jsonl` as the append-only Inbox notification log.
- Add a sidecar `data/inbox/read-state.json` for mutable per-entry `readAt` state.
- Return `readAt` from `/api/inbox/history` so every client reads the same attention state.
- Add `PUT /api/inbox/:id/read` and `DELETE /api/inbox/:id/read` for read/unread writes.
- Update the frontend to derive unread badges from server-provided `readAt`, with optimistic updates reconciled by the next history poll.
- Mock the new read endpoints in demo mode.

## Why

Inbox read state used to live in frontend localStorage (`openalice.inbox-read.v2`). That survives a reload in one browser profile, but it resets across Electron/browser clients, different frontend instances, and app-mode debugging. App packaging exposed that as the wrong ownership boundary: read/unread is user attention state and should follow the OpenAlice data root, not the UI cache.

The new sidecar file keeps mutable read state separate from the immutable Inbox event log, so marking an entry read does not rewrite `entries.jsonl`.

## Validation

- User manually tested the app flow and confirmed it works.
- `pnpm vitest run src/core/inbox-store.spec.ts src/webui/routes/inbox.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test`
- `git diff --check`
