### PR TITLE
Add session controller and root locks

### DIFF
--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -241,6 +241,9 @@ export function registerOpenAliceIpc(opts: OpenAliceIpcOptions): void {
       cols: typeof body['cols'] === 'number' ? body['cols'] : 80,
       rows: typeof body['rows'] === 'number' ? body['rows'] : 24,
       since: typeof body['since'] === 'number' ? body['since'] : undefined,
+      controllerId: typeof body['controllerId'] === 'string' ? body['controllerId'] : undefined,
+      controllerKind: typeof body['controllerKind'] === 'string' ? body['controllerKind'] : 'electron',
+      takeover: body['takeover'] === true,
     })
   })
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -74,7 +74,15 @@ const api = {
       ipcRenderer.invoke('openalice:workspace:read-file', input),
   },
   pty: {
-    connect: (input: { sessionId: string; cols: number; rows: number; since?: number }) => {
+    connect: (input: {
+      sessionId: string
+      cols: number
+      rows: number
+      since?: number
+      controllerId?: string
+      controllerKind?: string
+      takeover?: boolean
+    }) => {
       const connectionId = randomId()
       listenersFor(connectionId)
       // Keep the Electron transport on ordinary ipcRenderer events instead of

--- a/scripts/guardian/dev.ts
+++ b/scripts/guardian/dev.ts
@@ -116,6 +116,16 @@ async function main(): Promise<void> {
     prefixLogs: true,
   })
 
+  const aliceReady = await waitForHttp(`http://127.0.0.1:${ports.webPort}/api/version`, { timeoutMs: 20_000 })
+  if (!aliceReady) {
+    console.error(`[guardian] Alice failed to come up within 20s — aborting before Vite starts`)
+    console.error(`[guardian] If another OpenAlice/Electron instance is running on the same data root, stop it or run dev with an isolated OPENALICE_HOME/AQ_LAUNCHER_ROOT.`)
+    try { alice.kill('SIGTERM') } catch { /* noop */ }
+    try { uta.process.kill('SIGTERM') } catch { /* noop */ }
+    process.exit(1)
+  }
+  console.log(`[guardian] Alice ready`)
+
   // ── Vite ──────────────────────────────────────────────────
   const vite: ChildProcess = spawnChild({
     name: 'vite',

--- a/src/webui/workspaces-ipc.ts
+++ b/src/webui/workspaces-ipc.ts
@@ -21,7 +21,17 @@ const MSG_SERVER = 'openalice:pty:server-message'
 const MSG_SERVER_CLOSE = 'openalice:pty:server-close'
 
 type BridgeMessage =
-  | { type: typeof MSG_CONNECT; connectionId: string; sessionId: string; cols: number; rows: number; since?: number }
+  | {
+      type: typeof MSG_CONNECT
+      connectionId: string
+      sessionId: string
+      cols: number
+      rows: number
+      since?: number
+      controllerId?: string
+      controllerKind?: string
+      takeover?: boolean
+    }
   | { type: typeof MSG_CLIENT; connectionId: string; binary: boolean; data: unknown }
   | { type: typeof MSG_CLIENT_CLOSE; connectionId: string }
 
@@ -106,8 +116,17 @@ export function attachWorkspacesIpc(svc: WorkspaceService): AttachedWorkspaceIpc
       const cols = clamp(msg.cols, 80, 1, 1000)
       const rows = clamp(msg.rows, 24, 1, 1000)
       const since = typeof msg.since === 'number' && Number.isFinite(msg.since) && msg.since >= 0 ? msg.since : undefined
-      const ok = svc.pool.attachById(sessionId, socket as unknown as WebSocket, cols, rows, since)
-      if (!ok) socket.close(4404, 'session not found')
+      const controllerId = typeof msg.controllerId === 'string' ? msg.controllerId.slice(0, 128) : ''
+      const controllerKind = typeof msg.controllerKind === 'string' ? msg.controllerKind.slice(0, 32) : 'electron'
+      const result = svc.pool.attachById(
+        sessionId,
+        socket as unknown as WebSocket,
+        cols,
+        rows,
+        since,
+        controllerId ? { controllerId, controllerKind, takeover: msg.takeover === true } : undefined,
+      )
+      if (!result.ok && result.reason === 'missing') socket.close(4404, 'session not found')
       launcherLogger.event('ipc_pty.attached', { connectionId, sessionId, cols, rows })
       console.log(`ipc pty attached: session=${sessionId} connection=${connectionId} size=${cols}x${rows}`)
       return

--- a/src/webui/workspaces-ws.ts
+++ b/src/webui/workspaces-ws.ts
@@ -120,6 +120,9 @@ export function attachWorkspacesWS(httpServer: HttpServer, svc: WorkspaceService
     const rows = clampQuery(url.searchParams.get('rows'), 24, 1, 1000);
     const sinceRaw = url.searchParams.get('since');
     const since = sinceRaw === null ? undefined : parseSince(sinceRaw);
+    const controllerId = cleanToken(url.searchParams.get('client'), 128);
+    const controllerKind = cleanToken(url.searchParams.get('kind'), 32) ?? 'web';
+    const takeover = url.searchParams.get('takeover') === '1';
 
     const sessionId = (url.searchParams.get('session') ?? '').slice(0, 64);
     if (!sessionId) {
@@ -139,6 +142,9 @@ export function attachWorkspacesWS(httpServer: HttpServer, svc: WorkspaceService
       cols,
       rows,
       since: since ?? null,
+      controllerId: controllerId ?? null,
+      controllerKind,
+      takeover,
       origin: req.headers.origin ?? null,
       // Host the browser actually connected to. Discriminates the dev
       // transport: `localhost:<backendPort>` = direct (proxy bypassed),
@@ -149,7 +155,17 @@ export function attachWorkspacesWS(httpServer: HttpServer, svc: WorkspaceService
       remoteAddress: req.socket.remoteAddress ?? null,
     });
     try {
-      svc.pool.attachById(sessionId, ws, cols, rows, since);
+      const result = svc.pool.attachById(
+        sessionId,
+        ws,
+        cols,
+        rows,
+        since,
+        controllerId ? { controllerId, controllerKind, takeover } : undefined,
+      );
+      if (!result.ok && result.reason === 'missing') {
+        try { ws.close(4404, 'session not found'); } catch { /* ignore */ }
+      }
     } catch (err) {
       launcherLogger.error('pool.attach_failed', { sessionId, err });
       try { ws.close(1011, 'attach failed'); } catch { /* ignore */ }
@@ -212,4 +228,10 @@ function parseSince(raw: string): number | undefined {
   const n = Number.parseInt(raw, 10);
   if (!Number.isFinite(n) || n < 0) return undefined;
   return n;
+}
+
+function cleanToken(raw: string | null, max: number): string | undefined {
+  if (raw === null) return undefined;
+  const value = raw.trim().slice(0, max);
+  return value.length > 0 ? value : undefined;
 }

--- a/src/workspaces/persistent-session.spec.ts
+++ b/src/workspaces/persistent-session.spec.ts
@@ -169,3 +169,66 @@ describe('PersistentSession backpressure / socket-drop deadlock', () => {
     session.dispose('test');
   });
 });
+
+describe('PersistentSession controller lease', () => {
+  let term: ReturnType<typeof makeFakeTerm>;
+
+  beforeEach(() => {
+    term = makeFakeTerm();
+    mockSpawn.mockReturnValue(term as unknown as pty.IPty);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a second controller without kicking the current controller', () => {
+    const session = new PersistentSession(makeOptions());
+    const ws1 = new FakeWs();
+    const ws2 = new FakeWs();
+
+    const first = session.attach(ws1 as never, 80, 24, undefined, {
+      controllerId: 'web:tab-a',
+      controllerKind: 'web',
+    });
+    expect(first.ok).toBe(true);
+
+    const second = session.attach(ws2 as never, 80, 24, undefined, {
+      controllerId: 'web:tab-b',
+      controllerKind: 'web',
+    });
+
+    expect(second).toEqual({
+      ok: false,
+      reason: 'locked',
+      owner: { id: 'web:tab-a', kind: 'web' },
+    });
+    expect(ws1.close).not.toHaveBeenCalled();
+    expect(ws2.close).toHaveBeenCalledWith(4409, 'session locked by another controller');
+
+    session.dispose('test');
+  });
+
+  it('allows an explicit takeover and kicks the previous controller', () => {
+    const session = new PersistentSession(makeOptions());
+    const ws1 = new FakeWs();
+    const ws2 = new FakeWs();
+
+    expect(session.attach(ws1 as never, 80, 24, undefined, {
+      controllerId: 'web:tab-a',
+      controllerKind: 'web',
+    }).ok).toBe(true);
+
+    const takeover = session.attach(ws2 as never, 80, 24, undefined, {
+      controllerId: 'telegram:chat-1',
+      controllerKind: 'telegram',
+      takeover: true,
+    });
+
+    expect(takeover.ok).toBe(true);
+    expect(ws1.close).toHaveBeenCalledWith(4001, 'kicked by new attach');
+    expect(ws2.close).not.toHaveBeenCalled();
+
+    session.dispose('test');
+  });
+});

--- a/src/workspaces/persistent-session.ts
+++ b/src/workspaces/persistent-session.ts
@@ -36,6 +36,22 @@ export interface PersistentSessionOptions {
   readonly initialReplayBytes?: Buffer;
 }
 
+export interface SessionControllerClaim {
+  readonly controllerId: string;
+  readonly controllerKind: string;
+  /** Explicit user/operator action: replace the current controller. */
+  readonly takeover?: boolean;
+}
+
+export interface SessionControllerOwner {
+  readonly id: string;
+  readonly kind: string;
+}
+
+export type SessionAttachResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: 'locked'; readonly owner: SessionControllerOwner };
+
 const MAX_DIM = 1000;
 const CURSOR_TICK_MS = 2000;
 const CURSOR_BYTES_INTERVAL = 64 * 1024;
@@ -71,6 +87,7 @@ export class PersistentSession {
   private messageHandler: ((raw: unknown, isBinary: boolean) => void) | null = null;
   private closeHandler: (() => void) | null = null;
   private errorHandler: (() => void) | null = null;
+  private controller: SessionControllerOwner | null = null;
   private currentCols: number;
   private currentRows: number;
   private respawnTimes: number[] = [];
@@ -281,15 +298,40 @@ export class PersistentSession {
     this.log.info('session.agent_id_detected', { agentSessionId: id });
   }
 
-  /** Swap in `ws` as the attached client; kick the previous one if any. */
-  attach(ws: WebSocket, cols: number, rows: number, since: number | undefined): void {
+  /** Swap in `ws` as the attached client. A controller claim makes ownership
+   *  explicit: a second controller is rejected unless it deliberately takes
+   *  over. This is the shared rule for browser, Electron IPC, future IM bridges,
+   *  and any debug client that can write to the PTY. */
+  attach(
+    ws: WebSocket,
+    cols: number,
+    rows: number,
+    since: number | undefined,
+    claim?: SessionControllerClaim,
+  ): SessionAttachResult {
     if (this.disposed) {
       try {
         ws.close(1011, 'session disposed');
       } catch {
         // ignore
       }
-      return;
+      return { ok: false, reason: 'locked', owner: this.controller ?? { id: 'disposed', kind: 'session' } };
+    }
+
+    const owner = normalizeClaim(claim);
+    if (
+      owner &&
+      this.ws !== null &&
+      this.controller !== null &&
+      this.controller.id !== owner.id &&
+      !claim?.takeover
+    ) {
+      try {
+        ws.close(4409, 'session locked by another controller');
+      } catch {
+        // ignore
+      }
+      return { ok: false, reason: 'locked', owner: this.controller };
     }
 
     // Kick previous client.
@@ -305,6 +347,7 @@ export class PersistentSession {
     }
 
     this.ws = ws;
+    this.controller = owner;
     // A previous client may have dropped mid-backpressure, leaving the PTY
     // paused at the OS level. Clearing only the flag (not resuming the term)
     // would strand it paused forever; resumePty() un-sticks both.
@@ -345,7 +388,9 @@ export class PersistentSession {
       replayFromSeq: slice.effectiveSeq,
       replayBytes: slice.bytes.length,
       scrollbackTruncated,
+      controller: this.controller,
     });
+    return { ok: true };
   }
 
   /** Drop the current client without killing the PTY. */
@@ -353,6 +398,7 @@ export class PersistentSession {
     if (this.ws === null) return;
     const ws = this.ws;
     this.ws = null;
+    this.controller = null;
     this.unwireWs(ws);
     // No consumer left — let the PTY run free into the in-memory ring buffer
     // (onPtyData appends regardless of socket). If the socket dropped while
@@ -387,6 +433,7 @@ export class PersistentSession {
     if (ws !== null) {
       this.unwireWs(ws);
       this.ws = null;
+      this.controller = null;
       try {
         ws.close(1000, `disposed: ${reason}`);
       } catch {
@@ -541,6 +588,11 @@ export class PersistentSession {
     this.lastCursorSeq = seq;
     this.sendControl({ type: 'cursor', seq });
   }
+}
+
+function normalizeClaim(claim: SessionControllerClaim | undefined): SessionControllerOwner | null {
+  if (!claim?.controllerId) return null;
+  return { id: claim.controllerId, kind: claim.controllerKind || 'unknown' };
 }
 
 function toBuffer(raw: unknown): Buffer | null {

--- a/src/workspaces/process-lock.spec.ts
+++ b/src/workspaces/process-lock.spec.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  WorkspaceRootLockedError,
+  acquireWorkspaceProcessLock,
+} from './process-lock.js'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'oa-root-lock-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('workspace process root lock', () => {
+  it('prevents two Alice backends from owning the same launcher root', async () => {
+    const first = await acquireWorkspaceProcessLock(root, {
+      owner: { pid: 111, hostname: 'host-a' },
+      isProcessAlive: () => true,
+    })
+
+    await expect(
+      acquireWorkspaceProcessLock(root, {
+        owner: { pid: 222, hostname: 'host-b' },
+        isProcessAlive: () => true,
+      }),
+    ).rejects.toBeInstanceOf(WorkspaceRootLockedError)
+
+    await first.release()
+    const second = await acquireWorkspaceProcessLock(root, {
+      owner: { pid: 222, hostname: 'host-b' },
+      isProcessAlive: () => true,
+    })
+    await second.release()
+  })
+
+  it('reclaims a stale lock when the recorded owner process is gone', async () => {
+    const stale = await acquireWorkspaceProcessLock(root, {
+      owner: { pid: 111, hostname: 'host-a' },
+      isProcessAlive: () => true,
+    })
+
+    const fresh = await acquireWorkspaceProcessLock(root, {
+      owner: { pid: 222, hostname: 'host-b' },
+      isProcessAlive: (pid) => pid !== 111,
+    })
+
+    const owner = JSON.parse(await readFile(join(root, 'state', 'runtime.lock', 'owner.json'), 'utf8')) as {
+      pid: number
+      hostname: string
+    }
+    expect(owner.pid).toBe(222)
+    expect(owner.hostname).toBe('host-b')
+
+    // The stale handle must not remove the fresh owner when it later releases.
+    await stale.release()
+    await fresh.release()
+  })
+})

--- a/src/workspaces/process-lock.ts
+++ b/src/workspaces/process-lock.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { hostname as osHostname } from 'node:os'
+import { dirname, join } from 'node:path'
+
+export interface WorkspaceRootLockOwner {
+  readonly pid: number
+  readonly hostname: string
+  readonly token: string
+  readonly acquiredAt: string
+}
+
+export interface WorkspaceProcessLock {
+  readonly lockDir: string
+  readonly owner: WorkspaceRootLockOwner
+  release(): Promise<void>
+}
+
+export interface WorkspaceProcessLockOptions {
+  readonly owner?: Partial<Pick<WorkspaceRootLockOwner, 'pid' | 'hostname'>>
+  readonly isProcessAlive?: (pid: number, hostname: string) => boolean
+}
+
+export class WorkspaceRootLockedError extends Error {
+  constructor(
+    readonly lockDir: string,
+    readonly owner: WorkspaceRootLockOwner | null,
+  ) {
+    super(owner
+      ? `OpenAlice launcher root is already locked by pid ${owner.pid} on ${owner.hostname}`
+      : `OpenAlice launcher root is already locked: ${lockDir}`)
+    this.name = 'WorkspaceRootLockedError'
+  }
+}
+
+const LOCK_DIR_REL = join('state', 'runtime.lock')
+const OWNER_FILE = 'owner.json'
+
+/**
+ * Cross-process owner lock for one launcher root. The workspace/session state
+ * files under this root are not safe to mutate from two Alice backend
+ * processes at once: boot fixup, session registry flushes, scrollback, and task
+ * registries all assume a single writer. `mkdir` is the atomic operation here,
+ * and the owner token keeps a stale handle from deleting a newer lock.
+ */
+export async function acquireWorkspaceProcessLock(
+  launcherRoot: string,
+  opts: WorkspaceProcessLockOptions = {},
+): Promise<WorkspaceProcessLock> {
+  const lockDir = join(launcherRoot, LOCK_DIR_REL)
+  const owner: WorkspaceRootLockOwner = {
+    pid: opts.owner?.pid ?? process.pid,
+    hostname: opts.owner?.hostname ?? osHostname(),
+    token: randomUUID(),
+    acquiredAt: new Date().toISOString(),
+  }
+  const isProcessAlive = opts.isProcessAlive ?? defaultIsProcessAlive
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await mkdir(lockDir)
+      await writeOwner(lockDir, owner)
+      return makeLock(lockDir, owner)
+    } catch (err) {
+      if (!isErrno(err, 'ENOENT') && !isErrno(err, 'EEXIST')) throw err
+      if (isErrno(err, 'ENOENT')) {
+        await mkdir(dirname(lockDir), { recursive: true })
+        continue
+      }
+
+      const existing = await readOwner(lockDir).catch(() => null)
+      if (existing && isProcessAlive(existing.pid, existing.hostname)) {
+        throw new WorkspaceRootLockedError(lockDir, existing)
+      }
+      await rm(lockDir, { recursive: true, force: true })
+    }
+  }
+
+  const existing = await readOwner(lockDir).catch(() => null)
+  throw new WorkspaceRootLockedError(lockDir, existing)
+}
+
+function makeLock(lockDir: string, owner: WorkspaceRootLockOwner): WorkspaceProcessLock {
+  return {
+    lockDir,
+    owner,
+    release: async () => {
+      const current = await readOwner(lockDir).catch(() => null)
+      if (current?.token !== owner.token) return
+      await rm(lockDir, { recursive: true, force: true })
+    },
+  }
+}
+
+async function writeOwner(lockDir: string, owner: WorkspaceRootLockOwner): Promise<void> {
+  await writeFile(join(lockDir, OWNER_FILE), JSON.stringify(owner, null, 2) + '\n', 'utf8')
+}
+
+async function readOwner(lockDir: string): Promise<WorkspaceRootLockOwner> {
+  const raw = await readFile(join(lockDir, OWNER_FILE), 'utf8')
+  const parsed = JSON.parse(raw) as Partial<WorkspaceRootLockOwner>
+  if (
+    typeof parsed.pid !== 'number' ||
+    typeof parsed.hostname !== 'string' ||
+    typeof parsed.token !== 'string' ||
+    typeof parsed.acquiredAt !== 'string'
+  ) {
+    throw new Error('invalid workspace root lock owner')
+  }
+  return {
+    pid: parsed.pid,
+    hostname: parsed.hostname,
+    token: parsed.token,
+    acquiredAt: parsed.acquiredAt,
+  }
+}
+
+function defaultIsProcessAlive(pid: number, hostname: string): boolean {
+  if (hostname !== osHostname()) return true
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isErrno(err: unknown, code: string): boolean {
+  return err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === code
+}

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -22,6 +22,7 @@ import { shellAdapter } from './adapters/shell.js';
 import { AdapterRegistry, isAgentRuntime, type CliAdapter } from './cli-adapter.js';
 import { loadConfig, type ServerConfig } from './config.js';
 import { logger as launcherLogger } from './logger.js';
+import { acquireWorkspaceProcessLock } from './process-lock.js';
 import { runHeadlessProbe, type HeadlessProbeResult } from './probe.js';
 import { runHeadlessTask, type HeadlessTaskResult } from './headless-task.js';
 import { ScheduleMarkerStore } from './schedule/marker-store.js';
@@ -222,6 +223,7 @@ export function resumeFromRecord(
 export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions): Promise<WorkspaceService> {
   const config = loadConfig({ webPort: opts.webPort });
   const inboxStore = opts.inboxStore;
+  const processLock = await acquireWorkspaceProcessLock(config.launcherRoot);
 
   const registry = await WorkspaceRegistry.load(
     `${config.launcherRoot}/workspaces.json`,
@@ -897,6 +899,9 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     scheduleScanner.stop();
     pool.disposeAll('plugin shutdown');
     transcriptWatcher.disposeAll();
+    await processLock.release().catch((err) =>
+      launcherLogger.warn('workspaces.process_lock_release_failed', { err }),
+    );
   };
 
   return {

--- a/src/workspaces/session-pool.ts
+++ b/src/workspaces/session-pool.ts
@@ -4,6 +4,8 @@ import type { CliAdapter } from './cli-adapter.js';
 import type { Logger } from './logger.js';
 import {
   PersistentSession,
+  type SessionAttachResult,
+  type SessionControllerClaim,
   type PersistentSessionOptions,
 } from './persistent-session.js';
 import type { TranscriptWatcher } from './transcript-watcher.js';
@@ -121,11 +123,11 @@ export class SessionPool {
     cols: number,
     rows: number,
     since: number | undefined,
-  ): boolean {
+    claim?: SessionControllerClaim,
+  ): SessionAttachResult | { readonly ok: false; readonly reason: 'missing' } {
     const session = this.sessions.get(recordId);
-    if (!session) return false;
-    session.attach(ws, cols, rows, since);
-    return true;
+    if (!session) return { ok: false, reason: 'missing' };
+    return session.attach(ws, cols, rows, since, claim);
   }
 
   get(recordId: string): PersistentSession | undefined {

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -30,7 +30,7 @@ const DemoTerminalReplay = lazy(() =>
 
 export type { KeyMap } from './terminalInput';
 
-type Status = 'connecting' | 'reconnecting' | 'connected' | 'closed' | 'error' | 'kicked';
+type Status = 'connecting' | 'reconnecting' | 'connected' | 'closed' | 'error' | 'kicked' | 'locked';
 
 interface SocketMessageEventLike {
   readonly data: unknown;
@@ -68,7 +68,7 @@ class ElectronPtySocket implements SocketLike {
   private readonly unsubscribers: Array<() => void> = [];
   private opened = false;
 
-  constructor(input: { sessionId: string; cols: number; rows: number }) {
+  constructor(input: { sessionId: string; cols: number; rows: number; controllerId: string; takeover?: boolean }) {
     const bridge = window.openAlice?.pty;
     if (!bridge) throw new Error('Electron PTY bridge is unavailable');
     this.bridge = bridge;
@@ -203,10 +203,14 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
   const [scrollbackTruncated, setScrollbackTruncated] = useState(false);
   const [exitInfo, setExitInfo] = useState<ExitInfo | null>(null);
   const [childExited, setChildExited] = useState(false);
+  const takeoverNextAttachRef = useRef(false);
+  const connectRef = useRef<(() => void) | null>(null);
 
   const wsId = props.wsId;
   const wsUrl = props.wsUrl;
   const sessionId = props.sessionId;
+  const controllerIdRef = useRef<string>('');
+  if (!controllerIdRef.current) controllerIdRef.current = getTerminalControllerId();
 
   const keyMapRef = useRef<KeyMap | undefined>(props.keyMap);
   keyMapRef.current = props.keyMap;
@@ -274,7 +278,10 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
         session: sessionId,
         cols: String(lastCols),
         rows: String(lastRows),
+        client: controllerIdRef.current,
+        kind: 'web',
       });
+      if (takeoverNextAttachRef.current) params.set('takeover', '1');
       return `${wsUrl ?? defaultWsUrl()}?${params.toString()}`;
     };
 
@@ -415,7 +422,13 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       // renderer -> localhost WebSocket hop. Browser/dev/Docker keep the
       // WebSocket path with the exact same xterm lifecycle.
       const ws: SocketLike = window.openAlice?.pty
-        ? new ElectronPtySocket({ sessionId, cols: lastCols, rows: lastRows })
+        ? new ElectronPtySocket({
+            sessionId,
+            cols: lastCols,
+            rows: lastRows,
+            controllerId: controllerIdRef.current,
+            takeover: takeoverNextAttachRef.current,
+          })
         : new WebSocket(currentUrl());
       ws.binaryType = 'arraybuffer';
       activeWs = ws;
@@ -423,6 +436,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
 
       ws.addEventListener('open', () => {
         attempts = 0;
+        takeoverNextAttachRef.current = false;
         // A reconnect re-attaches to a live xterm that already shows the
         // pre-drop screen, but the server cold-replays its full ring buffer on
         // every attach. Reset first so the replay repaints cleanly instead of
@@ -478,6 +492,10 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
           setStatus('kicked');
           return;
         }
+        if (ev.code === 4409) {
+          setStatus('locked');
+          return;
+        }
         if (ev.code === 4404) {
           onSessionLostRef.current?.();
           setStatus('closed');
@@ -491,6 +509,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       // reconnect so we don't double-schedule.
       ws.addEventListener('error', () => {});
     }
+    connectRef.current = connect;
 
     const stdinSub = term.onData(sendStdin);
     const binarySub = term.onBinary((d) => {
@@ -542,6 +561,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       } catch {
         // ignore
       }
+      if (connectRef.current === connect) connectRef.current = null;
       webgl?.dispose();
       term.dispose();
       termRef.current = null;
@@ -563,6 +583,20 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
               }`
             : ''}
         </span>
+        {status === 'locked' && (
+          <button
+            type="button"
+            className="terminal-header-action"
+            onClick={() => {
+              takeoverNextAttachRef.current = true;
+              setStatus('connecting');
+              connectRef.current?.();
+            }}
+            title="take over this session"
+          >
+            take over
+          </button>
+        )}
       </header>
       <div ref={containerRef} className="terminal-host" />
     </div>
@@ -577,6 +611,7 @@ function StatusDot({ status }: { status: Status }): ReactElement {
     closed: '#6e7681',
     error: '#ff7b72',
     kicked: '#d2a8ff',
+    locked: '#d2a8ff',
   };
   return (
     <span
@@ -586,6 +621,17 @@ function StatusDot({ status }: { status: Status }): ReactElement {
       aria-label={status}
     />
   );
+}
+
+function getTerminalControllerId(): string {
+  return `web:${randomId()}`;
+}
+
+function randomId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
 
 function defaultWsUrl(): string {

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -848,6 +848,22 @@
   font-variant-numeric: tabular-nums;
 }
 
+.terminal-header-action {
+  height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--color-bg-secondary);
+  color: var(--fg);
+  font-size: 11px;
+  line-height: 22px;
+}
+
+.terminal-header-action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .status-dot {
   width: 8px;
   height: 8px;
@@ -872,4 +888,3 @@
 .terminal-host .xterm-viewport {
   background-color: transparent !important;
 }
-

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -52,7 +52,15 @@ interface Window {
       >
     }
     readonly pty: {
-      connect(input: { sessionId: string; cols: number; rows: number; since?: number }): string
+      connect(input: {
+        sessionId: string
+        cols: number
+        rows: number
+        since?: number
+        controllerId?: string
+        controllerKind?: string
+        takeover?: boolean
+      }): string
       send(connectionId: string, data: Uint8Array): void
       resize(connectionId: string, cols: number, rows: number): void
       close(connectionId: string): void


### PR DESCRIPTION
## Summary

Add two explicit ownership layers for workspace sessions:

- Add a launcher-root process lock (`state/runtime.lock`) so two Alice backend processes cannot mutate the same workspace/session state root at the same time.
- Add session controller ownership to `PersistentSession.attach()` so a session has one active controller unless another client explicitly takes over.
- Pass controller identity through both browser WebSocket PTY and Electron IPC PTY transports.
- Show a `locked` terminal state instead of reconnecting forever, with a `take over` action for explicit control transfer.
- Make `pnpm dev` wait for Alice readiness before starting Vite, so a locked/failed Alice backend does not look like an `/api/auth/status` proxy/auth failure.

## Why

Desktop/app mode exposed a deeper ownership problem: multiple frontends, future IM bridges, or multiple backend processes can all try to control the same agent runtime. The old model silently let the latest attach kick the prior one, while two backend processes sharing the same launcher root could corrupt session state through boot fixup and registry writes.

This PR separates the layers:

- process lock = only one Alice backend owns a launcher root;
- controller lease = only one interaction endpoint controls a live PTY session;
- takeover = explicit user/operator action, not accidental last-writer-wins.

## Validation

- TDD red/green for root lock and session controller ownership.
- `pnpm vitest run src/workspaces/process-lock.spec.ts src/workspaces/persistent-session.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm test`
- `git diff --check`

## Notes

If Electron is already running on the default data/workspace root, `pnpm dev` is expected to fail to start Alice unless the dev run uses an isolated `OPENALICE_HOME` and `AQ_LAUNCHER_ROOT`. The dev guardian now surfaces that as an Alice startup/root ownership problem instead of letting Vite emit misleading auth proxy errors.
