### PR TITLE
[codex] Update Chat workspace collaboration prompt

### DIFF
--- a/default/skills/alice-uta/SKILL.md
+++ b/default/skills/alice-uta/SKILL.md
@@ -92,5 +92,6 @@ alice-uta sim price-change --help      # MockBroker only — move a mock price f
 
 ## Not here
 
-- **Scheduling (cron) is not on any CLI** and is unavailable in-workspace — if
-  the user wants a recurring run, say so rather than improvising.
+- **Scheduling is not in `alice-uta`.** Recurring/headless workspace work is
+  issue-backed: use `alice-workspace issue create` or write
+  `.alice/issues/<id>.md` with a `when` field (see the `self-scheduling` skill).

--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -88,7 +88,7 @@ alice-workspace issue comment --id <id> --text "progress note / finding"
 ```
 
 Work it like a human board: `list` to scan titles, decide which matter, then
-`show <name>` to read those in full. `list` / `show` span the whole board (all
+`show --id <name>` to read those in full. `list` / `show` span the whole board (all
 workspaces); `create` / `update` / `comment` write **this** workspace's own
 `.alice/issues/` files (changing a peer's board is the human-approved peer-edit
 path). The full on-disk file model + self-scheduling (an issue with a `when`

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -18,6 +18,12 @@ description: >
 
 # Issues & self-scheduling — `.alice/issues/<id>.md`
 
+OpenAlice treats an issue as a collaboration object, not just a timer. It is the
+durable place to put trading follow-up, monitoring work, open questions,
+handoffs, and scheduled checks. Status, priority, and assignee tell humans and
+agents what deserves attention; `when` is the extra field that lets an issue
+summon a headless agent run.
+
 This workspace owns its work as **one markdown file per issue** in `.alice/issues/`
 at its own root. Each file is YAML frontmatter (the structured fields) plus a
 markdown body (the human description).
@@ -89,7 +95,7 @@ alice-workspace issue create --title "Pre-market brief" --priority high \
 The verb set is `list` / `show` / `create` / `update` / `comment` (no `delete` —
 remove an issue by deleting its file, see Notes). **Reads are global, writes are
 local:** `list` and `show` read the whole board across **every** workspace —
-scan titles with `list`, decide which matter, then `show <name>` to read those
+scan titles with `list`, decide which matter, then `show --id <name>` to read those
 in full (the natural way to work a board) — while `create` / `update` /
 `comment` write **this** workspace's own `.alice/issues/` files (changing a
 peer's board is the human-approved peer-edit path). The examples below show the

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Chat
@@ -11,31 +11,34 @@ CLIs on its PATH — and Alice's persona pre-loaded as CLAUDE.md / AGENTS.md.
 ## What this workspace does
 
 This is the closest equivalent to "talk to Alice about anything
-trading-related." There's no pre-baked task, no specific data layout. The
-agent can quote tickers, pull boards and fundamentals, search the
-collected-RSS archive, and run indicators. The bundled `opencli-reader`
-skill additionally teaches it to reach long-tail sources (social sentiment,
-options flow, global news frontpages) through the optional community
-`opencli` CLI — it will ask before assuming you have it.
+trading-related," but it is still a workspace, not a stateless chat room. The
+agent can quote tickers, pull boards and fundamentals, search the collected-RSS
+archive, run indicators, write research files, track entities with `[[name]]`,
+and turn follow-up into `.alice/issues/<id>.md` work items. The bundled
+`opencli-reader` skill additionally teaches it to reach long-tail sources
+(social sentiment, options flow, global news frontpages) through the optional
+community `opencli` CLI — it will ask before assuming you have it.
 
 Trading runs through the `alice-uta` CLI against your UTA accounts — orders go
-through the trading-as-git approval flow. Scheduling (cron) isn't on the CLI
-and is unavailable in-workspace.
+through the trading-as-git approval flow. Recurring/headless work runs through
+scheduled issues: add a `when` field to an issue and the launcher fires it as a
+headless workspace run.
 
 ## When to spawn this
 
 - You want a long-running thread with Alice that isn't tied to a specific research artifact or autoresearch loop.
 - You're exploring an idea and don't yet know which workspace the job needs — Chat is the no-commitment starting point.
 - You want quick access to Alice's full data surface without setting up Auto-Quant clones or finance-skill trees.
+- You want to turn a loose market concern into a durable issue, tracked entity, Inbox report, or scheduled check.
 
 ## What you'll see in Inbox
 
 (v1: Inbox is one-way — the agent posts; you don't reply through it.)
 
 Things Alice will route here:
-- Trade execution confirmations (when she places orders on your behalf).
-- Market alerts she's been watching for you.
-- Anything she flags as worth re-reading later.
+- Research notes, thesis updates, and market snapshots worth re-reading later.
+- Reports produced by scheduled issues or headless runs.
+- Trade execution summaries or staged-operation notes when trading work happens.
 
 ## Parameters
 

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -1,5 +1,23 @@
 # Chat workspace
 
+Chat is not a stateless Q&A box. Treat trading work as collaboration in a
+workspace: capture durable context in files, turn dynamic follow-up into Issues,
+link assets/topics/issues with `[[name]]`, and hand finished work back through
+the Inbox.
+
+Default working habit:
+
+- If the user asks a quick one-off question, answer it directly.
+- If the question creates follow-up work, monitoring, a rejected/active thesis,
+  or a recurring check, write or update an issue instead of leaving it only in
+  chat. Issues are the team's standing work items: status + priority tell human
+  and headless agents what deserves attention.
+- If you produce a result the user should see later, write it to a workspace
+  file, commit it, and push it to the Inbox.
+- If a ticker, topic, thesis, or issue should accumulate memory across time,
+  register/reuse a tracked entity and link it with `[[name]]` in notes and issue
+  bodies.
+
 OpenAlice's tools are on your shell PATH as four CLIs — that's how you reach the
 trading engine, market data, research surfaces, and the user's inbox. They're
 already there, no setup. Each has a skill with the full manual; this is the map.
@@ -23,8 +41,9 @@ traderhub board get --board macro   # a finished macro board in one call
 
 Output is JSON on stdout; a non-zero exit means it failed (reason on stderr).
 **To place a trade, that's `alice-uta`** — resolve the contract first and report
-every result. Scheduling (cron) is not on any CLI and is unavailable
-in-workspace — if the user wants a recurring run, say so rather than improvising.
+every result. Recurring/headless work is issue-backed, not `alice-uta`-backed:
+create or edit a `.alice/issues/<id>.md` issue with a `when` field (or use
+`alice-workspace issue create --when ...`) and write a complete `what` prompt.
 
 ## Beyond Alice's data — `opencli` (optional, read-only)
 
@@ -72,18 +91,36 @@ always fine. Collaboration runs on git, so:
 
 ## Issues — your standing work list
 
-An issue board spans every workspace and persists intent across sessions — it's
-what's on the plate when you're not sure what's on the plate. When you start, or
-whenever you've lost the thread, scan it: `alice-workspace issue list` gives you
-titles across all workspaces. Read like a human — scan titles, decide which
-matter, then drill into those with `alice-workspace issue show <name>`, which
-returns one issue in full (body + run history + inbox reports). You pass the
-issue's **name**, not a workspace id — `show` resolves it for you.
+An issue board spans every workspace and persists intent across sessions. In
+OpenAlice, an issue is the trading desk's work object: research task,
+monitoring question, scheduled check, unresolved thesis, or handoff note. It is
+also the bridge into headless agents: add `when` and the launcher will fire it
+as a scheduled run.
+
+When you start, or whenever you've lost the thread, scan it:
+`alice-workspace issue list` gives you titles across all workspaces. Read like a
+human — scan titles, use status/priority/assignee to judge urgency, then drill
+into those with `alice-workspace issue show --id <name>`, which returns one
+issue in full (body + run history + inbox reports). You pass the issue's
+**name**, not a workspace id — `show` resolves it for you.
 
 ```bash
 alice-workspace issue list                 # scan every workspace's issue titles
-alice-workspace issue show ai-power-rotation   # then read one in full, by name
+alice-workspace issue show --id ai-power-rotation   # then read one in full, by name
+alice-workspace issue create --title "Watch AI power names" --priority high
 ```
+
+For recurring work, create a scheduled issue instead of inventing a side channel:
+
+```bash
+alice-workspace issue create --title "Pre-market power brief" --priority high \
+  --when '{"kind":"cron","cron":"30 8 * * 1-5"}' \
+  --what "Check AI power infrastructure names, write research/premarket-power.md, then push it to Inbox if there is a material update."
+```
+
+Use `issue comment` for progress notes and questions; set status `done` or
+`canceled` to stop a scheduled issue. The full file model is in the
+`self-scheduling` skill.
 
 ## Tracking assets & topics worth following
 
@@ -96,10 +133,11 @@ like `ccj` means nothing to a non-trader (or to you, weeks later). For an
 Then link to it in your notes with `[[name]]` — e.g. `[[stock-vst]]`,
 `[[ai-data-center-power]]`.
 
-Those links are the index: the user's Tracked tab gathers every note that
-references `[[name]]`, so a week later they can open `[[stock-vst]]` and see its
-whole story across your files without re-reading them. Before creating one, call
-`alice-workspace track search` to reuse an existing name instead of fragmenting it.
+Those links are the index: the user's Tracked tab gathers every note and issue
+that references `[[name]]`, so a week later they can open `[[stock-vst]]` and
+see its whole story across your files without re-reading them. Before creating
+one, call `alice-workspace track search` to reuse an existing name instead of
+fragmenting it.
 
 Otherwise, use this workspace however you like. The CWD is its own git
 repo (commits stay local, no remote to push to) — which is also the


### PR DESCRIPTION
## Summary

- Reframe the Chat workspace prompt around the trading-collaboration model: files for durable context, Issues for follow-up/monitoring/scheduled work, Inbox for delivery, and `[[name]]` links for tracked memory.
- Update the Chat template README to describe scheduled issues as the recurring/headless work path and bump the template version to `1.2.0`.
- Align related injected skills so agents are not told scheduling is unavailable, and fix `issue show` examples to use the actual `--id` flag.

## Why

The new Issue system is now a core collaboration primitive rather than a side feature. New Chat workspaces should teach agents to turn dynamic trading work into inspectable issue/file/entity/Inbox artifacts instead of treating chat as a stateless answer box.

## Validation

- `git diff --check`
- `pnpm vitest run src/workspaces/context-injector.spec.ts src/workspaces/workspace-creation.e2e.spec.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/workspaces/workspace-creation.e2e.spec.ts`