### PR TITLE
[codex] Use readable workspace and session ids

### DIFF
--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -40,8 +40,13 @@ function build(opts: { workspaces?: any[] } = {}) {
   const claude = { id: 'claude', namePrefix: 'c' };
   const shell = { id: 'shell', kind: 'utility', namePrefix: 'sh' };
   const adapters: Record<string, any> = { opencode, claude, shell };
-  const spawn = vi.fn(() => ({
-    recordId: 'rec-1', wsId: 'ws-1', name: 'o1', pid: 1, agentSessionId: null, startedAt: 1,
+  const spawn = vi.fn((_wsId: string, ctx: any) => ({
+    recordId: ctx.recordId,
+    wsId: 'ws-1',
+    name: ctx.recordName,
+    pid: 1,
+    agentSessionId: null,
+    startedAt: 1,
   }));
   const creator = { create: vi.fn(async () => ({ ok: true, workspace: META })) };
   const svc = {
@@ -53,11 +58,12 @@ function build(opts: { workspaces?: any[] } = {}) {
     adapters: { get: (id: string) => adapters[id] },
     sessionRegistry: {
       ensureLoaded: vi.fn(async () => {}),
+      findById: vi.fn(() => undefined),
       nextName: () => 'o1',
       create: vi.fn(async () => {}),
       remove: vi.fn(async () => {}),
     },
-    pool: { spawn },
+    pool: { spawn, get: vi.fn(() => undefined) },
     publicMeta: vi.fn(async () => META),
     config: { launcherRepoRoot: '/repo' },
   } as unknown as WorkspaceService;

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -194,7 +194,7 @@ describe('POST /:id/headless', () => {
 });
 
 describe('POST /:id/sessions/:sid/resume — concurrent coalescing (ANG-120)', () => {
-  const TOKEN = '00000000-0000-0000-0000-000000000001';
+  const TOKEN = 'claude-calm-amber-river';
 
   function buildResume() {
     const session = {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -7,7 +7,6 @@
  */
 
 import { Hono } from 'hono';
-import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { join, resolve as resolvePath } from 'node:path';
 
@@ -29,6 +28,7 @@ import type { SessionRecord } from '../../workspaces/session-registry.js';
 import type { WorkspaceMeta } from '../../workspaces/workspace-registry.js';
 import { HeadlessCapacityError, resumeFromRecord, type SessionFactoryContext, type WorkspaceService } from '../../workspaces/service.js';
 import { isAgentRuntime, type WorkspaceAiCred } from '../../workspaces/cli-adapter.js';
+import { generatePetnameId } from '../../workspaces/petname-id.js';
 import { addCredential, readCredentials, readWorkspaceDefaultAgent, setCredentialLastModel, credentialWires, credentialWireShapeEnum, type Credential } from '../../core/config.js';
 import { inferCredentialVendor, resolveAnthropicAuthMode } from '../../core/credential-inference.js';
 import {
@@ -47,13 +47,10 @@ import {
  */
 const LOGINLESS_AGENTS = new Set(['opencode', 'pi']);
 
-const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 // The spawn body's `resume` value is an AGENT-side session id, whose shape is
-// adapter-native: uuid for claude/codex/pi, `ses_<base62>` for opencode. The
-// launcher-side record ids in URL params stay strict-uuid (SESSION_ID_RE) —
-// this looser shape applies ONLY to the resume intent passed through to the
-// adapter's own resume flag.
+// adapter-native: uuid for claude/codex/pi, `ses_<base62>` for opencode. This
+// looser shape applies ONLY to the resume intent passed through to the adapter's
+// own resume flag; launcher-side record ids use `validId`.
 const AGENT_SESSION_ID_RE = /^[A-Za-z0-9_.-]{8,128}$/;
 
 /** Upper bound on a quick-chat seed prompt — matches the headless-dispatch cap. */
@@ -178,7 +175,12 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     }
     await svc.sessionRegistry.ensureLoaded(id);
     const prefix = adapter.namePrefix ?? adapter.id[0] ?? 's';
-    const recordId = randomUUID();
+    const recordId = generatePetnameId(adapter.id, {
+      fallbackPrefix: 'session',
+      isTaken: (candidate) =>
+        svc.sessionRegistry.findById(candidate) !== undefined ||
+        svc.pool.get(candidate) !== undefined,
+    });
     const recordName = svc.sessionRegistry.nextName(id, adapter.id, prefix);
     const nowIso = new Date().toISOString();
     const title = initialPrompt ? initialPrompt.slice(0, MAX_SESSION_TITLE) : undefined;
@@ -726,7 +728,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
     app.post(`/:id/sessions/:sid/${action}`, async (c) => {
       const id = c.req.param('id');
       const token = c.req.param('sid');
-      if (!validId(id) || !SESSION_ID_RE.test(token)) {
+      if (!validId(id) || !validId(token)) {
         return c.json({ error: 'not_found' }, 404);
       }
       const record = svc.sessionRegistry.get(id, token);
@@ -771,7 +773,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
   app.post('/:id/sessions/:sid/resume', async (c) => {
     const id = c.req.param('id');
     const token = c.req.param('sid');
-    if (!validId(id) || !SESSION_ID_RE.test(token)) {
+    if (!validId(id) || !validId(token)) {
       return c.json({ error: 'not_found' }, 404);
     }
     // Serialize concurrent resumes of this record (ANG-120 — see resumeInFlight).
@@ -921,7 +923,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
   app.get('/:id/sessions/:sid/diagnostics', async (c) => {
     const id = c.req.param('id');
     const token = c.req.param('sid');
-    if (!validId(id) || !SESSION_ID_RE.test(token)) {
+    if (!validId(id) || !validId(token)) {
       return c.json({ error: 'not_found' }, 404);
     }
     const meta = svc.registry.get(id);
@@ -1015,7 +1017,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
   app.post('/:id/sessions/:sid/probe', async (c) => {
     const id = c.req.param('id');
     const token = c.req.param('sid');
-    if (!validId(id) || !SESSION_ID_RE.test(token)) {
+    if (!validId(id) || !validId(token)) {
       return c.json({ error: 'not_found' }, 404);
     }
     let prompt: string;
@@ -1037,17 +1039,18 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
         ? Math.min(rawTimeout, 120_000)
         : 20_000;
       // resume override: 'auto' (default — follow record's resumeHint),
-      // 'fresh' (no resume flag), 'last' (force --continue), or a UUID
-      // string (force --resume <uuid>). Lets the probe seed a brand-new
-      // session before any real interaction has produced a transcript.
+      // 'fresh' (no resume flag), 'last' (force --continue), or an adapter-
+      // native session id string (force --resume/--session <id>). Lets the
+      // probe seed a brand-new session before any real interaction has produced
+      // a transcript.
       const rawResume = fields['resume'];
       if (rawResume !== undefined && rawResume !== 'auto') {
         if (rawResume === 'fresh') resumeOverride = 'none';
         else if (rawResume === 'last') resumeOverride = 'last';
-        else if (typeof rawResume === 'string' && SESSION_ID_RE.test(rawResume)) {
+        else if (typeof rawResume === 'string' && AGENT_SESSION_ID_RE.test(rawResume)) {
           resumeOverride = { sessionId: rawResume };
         } else {
-          return c.json({ error: 'bad_request', message: 'resume must be "auto", "fresh", "last", or a UUID' }, 400);
+          return c.json({ error: 'bad_request', message: 'resume must be "auto", "fresh", "last", or an agent session id' }, 400);
         }
       }
     } catch (err) {
@@ -1194,7 +1197,7 @@ export function createWorkspaceRoutes(svc: WorkspaceService): Hono {
   app.delete('/:id/sessions/:sid', async (c) => {
     const id = c.req.param('id');
     const token = c.req.param('sid');
-    if (!validId(id) || !SESSION_ID_RE.test(token)) {
+    if (!validId(id) || !validId(token)) {
       return c.json({ error: 'not_found' }, 404);
     }
     const record = svc.sessionRegistry.get(id, token);

--- a/src/workspaces/persistent-session.ts
+++ b/src/workspaces/persistent-session.ts
@@ -140,8 +140,8 @@ export class PersistentSession {
     // win32: resolve the bare CLI name to its real `.exe`, or wrap a `.cmd`/
     // `.ps1` npm shim through cmd.exe — ConPTY's CreateProcess only appends
     // `.exe`, so npm-shim CLIs (opencode, pi) otherwise never launch. No-op off
-    // Windows. The interactive command is flags + a uuid, so the shell wrap is
-    // injection-safe here. See win-command.ts.
+    // Windows. The interactive command is flags + launcher/adapter-generated
+    // ids, so the shell wrap is injection-safe here. See win-command.ts.
     const [argv0, ...args] = resolveLaunchCommand(this.opts.command, {
       env: this.opts.env,
     }).argv;

--- a/src/workspaces/petname-id.spec.ts
+++ b/src/workspaces/petname-id.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { generatePetnameId, normalizeIdPrefix, type RandomInt } from './petname-id.js'
+
+function sequence(...values: number[]): RandomInt {
+  let i = 0
+  return (exclusiveMax: number) => {
+    const value = values[i++] ?? 0
+    return value % exclusiveMax
+  }
+}
+
+describe('petname ids', () => {
+  it('normalizes prefixes into route-safe slugs', () => {
+    expect(normalizeIdPrefix('Auto Quant!!')).toBe('auto-quant')
+    expect(normalizeIdPrefix('***', 'workspace')).toBe('workspace')
+  })
+
+  it('generates a readable prefix + three-word id', () => {
+    expect(generatePetnameId('chat', { randomInt: sequence(0, 0, 0) })).toBe(
+      'chat-calm-amber-river',
+    )
+  })
+
+  it('retries when a generated id is already taken', () => {
+    const taken = new Set(['chat-calm-amber-river'])
+    const id = generatePetnameId('chat', {
+      randomInt: sequence(0, 0, 0, 1, 1, 1),
+      isTaken: (candidate) => taken.has(candidate),
+    })
+
+    expect(id).toBe('chat-clear-copper-harbor')
+  })
+})

--- a/src/workspaces/petname-id.ts
+++ b/src/workspaces/petname-id.ts
@@ -1,0 +1,175 @@
+import { randomInt as cryptoRandomInt } from 'node:crypto'
+
+/**
+ * Human-readable random ids for launcher-owned objects.
+ *
+ * These ids are meant to appear in URLs, logs, Inbox origins, CLI headers, and
+ * agent-visible environment without making humans or agents repeat UUID noise.
+ * The word lists are intentionally neutral: no finance, direction, risk, mood,
+ * or execution words that could bleed into trading context.
+ */
+
+const MAX_ATTEMPTS = 128
+const PREFIX_MAX = 24
+const DEFAULT_FALLBACK_PREFIX = 'item'
+
+const ADJECTIVES = [
+  'calm',
+  'clear',
+  'quiet',
+  'gentle',
+  'steady',
+  'bright',
+  'soft',
+  'fresh',
+  'plain',
+  'warm',
+  'cool',
+  'mild',
+  'light',
+  'smooth',
+  'open',
+  'still',
+  'even',
+  'tidy',
+  'simple',
+  'brisk',
+  'lucid',
+  'patient',
+  'modest',
+  'neat',
+  'solid',
+  'crisp',
+  'sunny',
+  'level',
+  'polished',
+  'rounded',
+  'nimble',
+  'stable',
+] as const
+
+const MATERIALS = [
+  'amber',
+  'copper',
+  'silver',
+  'pearl',
+  'marble',
+  'quartz',
+  'cedar',
+  'maple',
+  'willow',
+  'linen',
+  'cotton',
+  'paper',
+  'glass',
+  'stone',
+  'granite',
+  'slate',
+  'violet',
+  'indigo',
+  'olive',
+  'ivory',
+  'coral',
+  'saffron',
+  'mint',
+  'juniper',
+  'laurel',
+  'bamboo',
+  'canvas',
+  'clay',
+  'walnut',
+  'birch',
+  'brass',
+  'opal',
+] as const
+
+const PLACES = [
+  'river',
+  'harbor',
+  'meadow',
+  'lantern',
+  'compass',
+  'bridge',
+  'garden',
+  'valley',
+  'field',
+  'cloud',
+  'rain',
+  'orbit',
+  'notebook',
+  'pencil',
+  'window',
+  'studio',
+  'courtyard',
+  'terrace',
+  'path',
+  'grove',
+  'spring',
+  'brook',
+  'summit',
+  'cove',
+  'ridge',
+  'plaza',
+  'porch',
+  'tide',
+  'dawn',
+  'horizon',
+  'arch',
+  'marker',
+] as const
+
+export type RandomInt = (exclusiveMax: number) => number
+
+export interface PetnameOptions {
+  readonly fallbackPrefix?: string
+  readonly isTaken?: (id: string) => boolean
+  readonly maxAttempts?: number
+  readonly randomInt?: RandomInt
+}
+
+export function normalizeIdPrefix(input: string, fallback = DEFAULT_FALLBACK_PREFIX): string {
+  const normalized = input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, PREFIX_MAX)
+    .replace(/-+$/g, '')
+  return normalized || fallback
+}
+
+export function generatePetnameId(prefix: string, opts: PetnameOptions = {}): string {
+  const randomInt = opts.randomInt ?? cryptoRandomInt
+  const isTaken = opts.isTaken ?? (() => false)
+  const attempts = opts.maxAttempts ?? MAX_ATTEMPTS
+  const safePrefix = normalizeIdPrefix(prefix, opts.fallbackPrefix)
+
+  for (let i = 0; i < attempts; i += 1) {
+    const id = [
+      safePrefix,
+      pick(ADJECTIVES, randomInt),
+      pick(MATERIALS, randomInt),
+      pick(PLACES, randomInt),
+    ].join('-')
+    if (!isTaken(id)) return id
+  }
+
+  // Extremely unlikely unless the candidate space is exhausted or tests force
+  // collisions. Keep the fallback readable enough while guaranteeing progress.
+  for (let i = 0; i < attempts; i += 1) {
+    const id = [
+      safePrefix,
+      pick(ADJECTIVES, randomInt),
+      pick(MATERIALS, randomInt),
+      pick(PLACES, randomInt),
+      randomInt(10_000).toString().padStart(4, '0'),
+    ].join('-')
+    if (!isTaken(id)) return id
+  }
+
+  throw new Error(`could not allocate a petname id for prefix "${safePrefix}"`)
+}
+
+function pick<T>(items: readonly T[], randomInt: RandomInt): T {
+  return items[randomInt(items.length)]!
+}

--- a/src/workspaces/schedule/marker-store.ts
+++ b/src/workspaces/schedule/marker-store.ts
@@ -19,8 +19,9 @@ import { dirname } from 'node:path'
 
 import type { Logger } from '../logger.js'
 
-// A wsId is a uuid (no spaces), so a space cleanly delimits the wsId prefix from
-// an agent-authored taskId - the composite is an injective, opaque map key.
+// A wsId is a route-safe slug (no spaces), so a space cleanly delimits the wsId
+// prefix from an agent-authored taskId - the composite is an injective, opaque
+// map key.
 const SEP = ' '
 const composite = (wsId: string, taskId: string): string => `${wsId}${SEP}${taskId}`
 

--- a/src/workspaces/session-pool.ts
+++ b/src/workspaces/session-pool.ts
@@ -63,7 +63,7 @@ export interface LiveSessionInfo {
 }
 
 /**
- * Owns every live PTY, keyed by the record id (a stable uuid the
+ * Owns every live PTY, keyed by the record id (a stable launcher id the
  * SessionRegistry pre-allocates). One PersistentSession per id; one
  * attached WebSocket per session (second attach kicks the first). PTYs
  * exist only between spawn and dispose — restart wipes the pool but the

--- a/src/workspaces/session-registry.spec.ts
+++ b/src/workspaces/session-registry.spec.ts
@@ -26,13 +26,13 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true })
 })
 
-// Hex/UUID wsId so the on-disk `<wsId>.json` matches SESSION_FILE_RE and
-// bootFixup actually scans it on reload.
-const WS = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789'
+// Petname wsId so bootFixup proves it scans the new human-readable file shape.
+const WS = 'chat-calm-amber-river'
+const LEGACY_UUID_WS = '4894ef8b-66e1-4a41-a222-ba564e51a8c0'
 
 function rec(over: Partial<SessionRecord> = {}): SessionRecord {
   return {
-    id: 'sess-1',
+    id: 'claude-calm-amber-river',
     wsId: WS,
     agent: 'claude',
     name: 'c1',
@@ -49,25 +49,40 @@ describe('SessionRegistry persistence', () => {
   // server restart / registry reload even though flush had written it to disk.
   it('round-trips the session title across a reload', async () => {
     const reg = await SessionRegistry.load(root, noopLogger)
-    await reg.create(rec({ id: 'sess-1', title: "What's moving in semiconductors today?" }))
-    await reg.create(rec({ id: 'sess-2', name: 'c2', title: '解释一下美债收益率曲线倒挂' }))
-    await reg.create(rec({ id: 'sess-3', name: 'c3' })) // unseeded — no title
+    await reg.create(rec({
+      id: 'claude-calm-amber-river',
+      title: "What's moving in semiconductors today?",
+    }))
+    await reg.create(rec({
+      id: 'claude-clear-copper-harbor',
+      name: 'c2',
+      title: '解释一下美债收益率曲线倒挂',
+    }))
+    await reg.create(rec({ id: 'claude-quiet-silver-meadow', name: 'c3' })) // unseeded — no title
 
     // A fresh instance over the same dir = a server restart.
     const reloaded = await SessionRegistry.load(root, noopLogger)
     await reloaded.ensureLoaded(WS)
     const byId = new Map(reloaded.listFor(WS).map((r) => [r.id, r]))
 
-    expect(byId.get('sess-1')?.title).toBe("What's moving in semiconductors today?")
-    expect(byId.get('sess-2')?.title).toBe('解释一下美债收益率曲线倒挂') // CJK survives
-    expect(byId.get('sess-3')?.title).toBeUndefined() // unseeded stays nameless
+    expect(byId.get('claude-calm-amber-river')?.title).toBe(
+      "What's moving in semiconductors today?",
+    )
+    expect(byId.get('claude-clear-copper-harbor')?.title).toBe(
+      '解释一下美债收益率曲线倒挂',
+    ) // CJK survives
+    expect(byId.get('claude-quiet-silver-meadow')?.title).toBeUndefined() // unseeded stays nameless
   })
 
   // The exact path the user hit: a reload both flips orphaned running→paused
   // (bootFixup) AND must keep the title — they share the load codepath.
   it('keeps the title when bootFixup flips an orphaned running session to paused', async () => {
     const reg = await SessionRegistry.load(root, noopLogger)
-    await reg.create(rec({ id: 'sess-1', state: 'running', title: 'Build a thesis on NVDA' }))
+    await reg.create(rec({
+      id: 'claude-calm-amber-river',
+      state: 'running',
+      title: 'Build a thesis on NVDA',
+    }))
 
     const reloaded = await SessionRegistry.load(root, noopLogger)
     await reloaded.ensureLoaded(WS)
@@ -75,5 +90,22 @@ describe('SessionRegistry persistence', () => {
 
     expect(r?.state).toBe('paused') // orphaned running flipped on reload
     expect(r?.title).toBe('Build a thesis on NVDA') // …and the title is intact
+  })
+
+  it('keeps loading legacy UUID workspace files without a migration', async () => {
+    const reg = await SessionRegistry.load(root, noopLogger)
+    await reg.create(rec({
+      id: 'claude-clear-copper-harbor',
+      wsId: LEGACY_UUID_WS,
+      state: 'paused',
+      title: 'Legacy workspace still opens',
+    }))
+
+    const reloaded = await SessionRegistry.load(root, noopLogger)
+    await reloaded.ensureLoaded(LEGACY_UUID_WS)
+
+    expect(reloaded.get(LEGACY_UUID_WS, 'claude-clear-copper-harbor')?.title).toBe(
+      'Legacy workspace still opens',
+    )
   })
 })

--- a/src/workspaces/session-registry.ts
+++ b/src/workspaces/session-registry.ts
@@ -7,8 +7,9 @@ import type { Logger } from './logger.js';
 /**
  * Persistent session-identity record. Lives across server restart so the user
  * can pause a session today and resume it tomorrow. The `id` is the stable
- * uuid used in every cross-system reference (URL hash, WebSocket query, REST
- * route) — what we previously called `sessionToken` (transient, in-memory).
+ * launcher-owned record id used in every cross-system reference (URL hash,
+ * WebSocket query, REST route) — what we previously called `sessionToken`
+ * (transient, in-memory).
  *
  * `state` is the launcher's view: 'running' means we have a live PTY in the
  * pool keyed by this id; 'paused' means the record exists but no PTY. On a
@@ -47,7 +48,7 @@ interface FileShape {
   readonly records: SessionRecord[];
 }
 
-const SESSION_FILE_RE = /^[0-9a-f-]+\.json$/;
+const SESSION_FILE_RE = /^[A-Za-z0-9_-]+\.json$/;
 
 /**
  * Per-workspace persistent registry of SessionRecords. Each workspace gets
@@ -160,7 +161,7 @@ export class SessionRegistry {
     return this.byWs.get(wsId)?.get(id);
   }
 
-  /** Find a record by id without knowing its wsId (uniqueness assumed at uuid level). */
+  /** Find a record by id without knowing its wsId (record ids are global). */
   findById(id: string): SessionRecord | undefined {
     for (const records of this.byWs.values()) {
       const r = records.get(id);

--- a/src/workspaces/win-command.ts
+++ b/src/workspaces/win-command.ts
@@ -35,8 +35,8 @@ export interface ResolvedCommand {
    * shim (win32 only). Callers that append an UNTRUSTED positional arg (e.g. a
    * headless prompt) must NOT use this form — cmd.exe re-parses shell
    * metacharacters (`& | < > ^ %`) in that arg, which is a command-injection
-   * surface. The interactive/probe paths only ever pass flags + a uuid, so the
-   * wrap is safe there.
+   * surface. The interactive/probe paths only pass flags + trusted generated
+   * ids, so the wrap is safe there.
    */
   readonly viaShell: boolean;
 }

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -11,6 +11,7 @@ import type { AdapterRegistry } from './cli-adapter.js';
 import { injectWorkspaceContext } from './context-injector.js';
 import { injectWorkspaceCredentials } from './credential-injection.js';
 import type { Logger } from './logger.js';
+import { generatePetnameId } from './petname-id.js';
 import type { AgentCredentialDecl, TemplateRegistry } from './template-registry.js';
 import type { WorkspaceMeta, WorkspaceRegistry } from './workspace-registry.js';
 
@@ -137,7 +138,12 @@ export class WorkspaceCreator {
       }
     }
 
-    const id = randomUUID();
+    const id = generatePetnameId(templateName, {
+      fallbackPrefix: 'workspace',
+      isTaken: (candidate) =>
+        this.opts.registry.hasId(candidate) ||
+        existsSync(join(this.opts.workspacesRoot, candidate)),
+    });
     const dir = join(this.opts.workspacesRoot, id);
     const log = this.opts.logger.child({ tag, id, dir, template: templateName, agents });
 

--- a/src/workspaces/workspace-registry.ts
+++ b/src/workspaces/workspace-registry.ts
@@ -83,6 +83,10 @@ export class WorkspaceRegistry {
     return this.byId.get(id);
   }
 
+  hasId(id: string): boolean {
+    return this.byId.has(id);
+  }
+
   hasTag(tag: string): boolean {
     return this.tagsInUse.has(tag);
   }

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -249,7 +249,7 @@ export interface SpawnedSession {
 }
 
 export interface SpawnOptions {
-  /** `'last'` → adapter-specific "continue", any UUID → adapter-specific resume-by-id. */
+  /** `'last'` → adapter-specific "continue", any string → adapter-specific resume-by-id. */
   readonly resume?: 'last' | string;
   /** Explicit runtime/tool adapter for this spawn. */
   readonly agent?: string;

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -81,9 +81,8 @@ export function UrlAdopter() {
         {/* Workspaces */}
         <Route path="/workspaces" element={<AdoptStatic spec={{ kind: 'workspace-list', params: {} }} />} />
         {/* Template catalog routes must come before /workspaces/:wsId so the
-            static `templates` segment wins the match (it would otherwise
-            never collide — wsIds are UUIDs — but route specificity is the
-            defensive default). */}
+            static `templates` segment wins the match even if a workspace id is
+            a human-readable slug. */}
         <Route path="/workspaces/templates" element={<AdoptStatic spec={{ kind: 'template-catalog', params: {} }} />} />
         <Route path="/workspaces/templates/:name" element={<AdoptTemplateDetail />} />
         <Route path="/workspaces/:wsId/view/:path" element={<AdoptFileViewer />} />


### PR DESCRIPTION
## Summary

- Add a neutral petname id generator for launcher-owned ids.
- Generate new workspace ids as readable slugs like `chat-calm-amber-river` instead of UUIDs.
- Generate new OpenAlice session record ids as readable slugs like `claude-clear-copper-harbor` while preserving adapter-native resume ids.
- Keep legacy UUID workspace/session records readable with no migration.

## Why

AI agents and humans frequently have to repeat workspace and session ids in logs, URLs, CLI output, and workspace context. UUIDs add a lot of context noise. This keeps the internal uniqueness guarantees while making new launcher-owned ids easier to inspect and repeat.

## Validation

- `pnpm vitest run src/workspaces/petname-id.spec.ts src/workspaces/session-registry.spec.ts src/webui/routes/workspaces.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test`
- Manual API smoke on `localhost:5173`:
  - created temporary workspace `chat-brisk-canvas-plaza`
  - spawned shell session `shell-neat-juniper-grove`
  - paused session
  - deleted workspace with `purge=true`
  - confirmed no temporary workspace/session remained in `/api/workspaces`