### PR TITLE
[codex] Improve workspace CLI output and model context config

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -80,16 +80,20 @@ It's *what's on the plate* when you've lost the thread — scan it when you star
 **Reads are global, writes are local:**
 
 ```bash
-alice-workspace issue list                  # scan EVERY workspace's issue titles
+alice-workspace issue list                  # startup-safe summary: local + active urgent/high/medium rows
+alice-workspace issue list --mode detailed  # full global board, including low-priority scheduled noise
 alice-workspace issue show --id <name>      # one issue in full — body + run history + inbox reports (resolves the name across the board)
 alice-workspace issue create --title "…"    # a new issue on THIS workspace's board
 alice-workspace issue update --id <id> --status in_progress
 alice-workspace issue comment --id <id> --text "progress note / finding"
 ```
 
-Work it like a human board: `list` to scan titles, decide which matter, then
-`show --id <name>` to read those in full. `list` / `show` span the whole board (all
-workspaces); `create` / `update` / `comment` write **this** workspace's own
-`.alice/issues/` files (changing a peer's board is the human-approved peer-edit
-path). The full on-disk file model + self-scheduling (an issue with a `when`
-fires a headless run) lives in the **`self-scheduling`** skill.
+Work it like a human board: start with plain `list`, decide which focus rows
+matter, then `show --id <name>` to read those in full. Plain `list` is deliberately
+curated for startup so old low-priority scheduled items do not distract you; use
+`--mode detailed` only when you are auditing the full board. `list` / `show` span
+the whole board (all workspaces); `create` / `update` / `comment` write **this**
+workspace's own `.alice/issues/` files (changing a peer's board is the
+human-approved peer-edit path). The full on-disk file model + self-scheduling
+(an issue with a `when` fires a headless run) lives in the **`self-scheduling`**
+skill.

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -123,7 +123,7 @@ describe('issue_list / issue_show', () => {
   it('lists compact rows and shows one in full', async () => {
     await run(issueCreateFactory.build(ctx()), { id: 'a', title: 'Alpha', priority: 'high' })
     await run(issueCreateFactory.build(ctx()), { id: 'b', title: 'Beta' })
-    const list = await run(issueListFactory.build(ctx()), {})
+    const list = await run(issueListFactory.build(ctx()), { mode: 'detailed' })
     expect(list.ok).toBe(true)
     expect((list.issues as Array<{ id: string }>).map((i) => i.id).sort()).toEqual(['a', 'b'])
 
@@ -135,6 +135,7 @@ describe('issue_list / issue_show', () => {
   it('issue_list returns empty (not an error) when no issues dir exists', async () => {
     const list = await run(issueListFactory.build(ctx()), {})
     expect(list.ok).toBe(true)
+    expect(list.mode).toBe('summary')
     expect(list.issues).toEqual([])
   })
 
@@ -220,11 +221,16 @@ describe('global board (ctx.board present)', () => {
       },
       ...over,
     }
-    return ctx({ board })
+    return ctx({
+      workspaceId: 'ws-a',
+      workspaceLabel: 'auto-quant',
+      resolveWorkspace: (id) => (id === 'ws-a' ? { id, dir, tag: 'auto-quant' } : null),
+      board,
+    })
   }
 
   it('issue_list flattens rows across every workspace, tags collisions, surfaces invalid', async () => {
-    const list = await run(issueListFactory.build(boardCtx()), {})
+    const list = await run(issueListFactory.build(boardCtx()), { mode: 'detailed' })
     expect(list.ok).toBe(true)
     const rows = list.issues as Array<{
       id: string
@@ -243,6 +249,34 @@ describe('global board (ctx.board present)', () => {
     expect(rows.find((r) => r.id === 'shared-b')?.nameCollision).toBe(true)
     // unreadable workspace surfaced, not dropped
     expect(list.invalid).toEqual([{ wsId: 'ws-c', tag: 'broken', error: 'retired .alice/issue.json' }])
+  })
+
+  it('issue_list summary hides low-priority global noise but keeps local issues', async () => {
+    const list = await run(issueListFactory.build(boardCtx()), {})
+    expect(list.ok).toBe(true)
+    expect(list.mode).toBe('summary')
+    expect(list.issues).toEqual([
+      expect.objectContaining({
+        id: 'alpha',
+        priority: 'high',
+        workspace: 'auto-quant',
+      }),
+      expect.objectContaining({
+        id: 'shared-a',
+        priority: 'none',
+        workspace: 'auto-quant',
+        nameCollision: true,
+      }),
+    ])
+    expect(list.summary).toMatchObject({
+      total: 3,
+      focus: 2,
+      hiddenActive: 1,
+      hiddenLowPriority: 1,
+      terminal: 0,
+      invalid: 1,
+    })
+    expect(list.hint).toMatch(/--mode detailed/)
   })
 
   it('issue_show returns full detail for a unique name', async () => {

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -41,7 +41,7 @@ import {
   createIssue,
   updateIssueFields,
 } from '../workspaces/issues/mutate.js'
-import { flattenBoardRows } from '../workspaces/issues/board.js'
+import { flattenBoardRows, type BoardInvalidWorkspace, type BoardRow } from '../workspaces/issues/board.js'
 
 /** Resolve THIS workspace's absolute checkout dir, or a clean error. */
 function selfDir(ctx: WorkspaceToolContext): { ok: true; dir: string } | { ok: false; error: string } {
@@ -64,6 +64,84 @@ function rowOf(issue: IssueRecord) {
     priority: issue.priority,
     assignee: issue.assignee,
     scheduled: issue.when !== undefined,
+  }
+}
+
+const ISSUE_LIST_DEFAULT_LIMIT = 8
+const ISSUE_LIST_MAX_LIMIT = 50
+const ISSUE_LIST_FOCUS_PRIORITIES = new Set(['urgent', 'high', 'medium'])
+const TERMINAL_STATUSES = new Set(['done', 'canceled'])
+const PRIORITY_RANK: Record<string, number> = {
+  urgent: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  none: 4,
+}
+const STATUS_RANK: Record<string, number> = {
+  in_progress: 0,
+  todo: 1,
+  backlog: 2,
+  done: 3,
+  canceled: 4,
+}
+
+function compareIssueRows(a: BoardRow, b: BoardRow): number {
+  return (
+    (PRIORITY_RANK[a.priority] ?? 99) - (PRIORITY_RANK[b.priority] ?? 99) ||
+    (STATUS_RANK[a.status] ?? 99) - (STATUS_RANK[b.status] ?? 99) ||
+    Number(a.scheduled) - Number(b.scheduled) ||
+    a.workspace.tag.localeCompare(b.workspace.tag) ||
+    a.id.localeCompare(b.id)
+  )
+}
+
+function summarizeIssueRows(
+  rows: BoardRow[],
+  invalid: BoardInvalidWorkspace[],
+  selfWsId: string,
+  limit: number,
+) {
+  const active = rows.filter((row) => !TERMINAL_STATUSES.has(row.status))
+  const focus = active
+    .filter((row) => row.workspace.wsId === selfWsId || ISSUE_LIST_FOCUS_PRIORITIES.has(row.priority))
+    .sort(compareIssueRows)
+    .slice(0, limit)
+
+  const visibleKeys = new Set(focus.map((row) => `${row.workspace.wsId}/${row.id}`))
+  const hiddenActive = active.filter((row) => !visibleKeys.has(`${row.workspace.wsId}/${row.id}`))
+  const hiddenLowPriority = hiddenActive.filter((row) => !ISSUE_LIST_FOCUS_PRIORITIES.has(row.priority)).length
+  const hiddenOverflow = Math.max(0, active.length - focus.length - hiddenLowPriority)
+  const terminal = rows.length - active.length
+
+  return {
+    ok: true as const,
+    mode: 'summary' as const,
+    summary: {
+      total: rows.length,
+      focus: focus.length,
+      hiddenActive: hiddenActive.length,
+      hiddenLowPriority,
+      hiddenOverflow,
+      terminal,
+      invalid: invalid.length,
+    },
+    issues: focus.map((row) => ({
+      id: row.id,
+      title: row.title,
+      status: row.status,
+      priority: row.priority,
+      assignee: row.assignee,
+      scheduled: row.scheduled,
+      workspace: row.workspace.tag,
+      ...(row.nameCollision ? { nameCollision: true as const } : {}),
+    })),
+    invalid: invalid.map((row) => ({
+      workspace: row.tag,
+      ...(row.error ? { error: row.error } : {}),
+    })),
+    hint:
+      'Summary shows local issues plus active urgent/high/medium rows. Use `alice-workspace issue list --mode detailed` for the full board, then `alice-workspace issue show --id <id>` before acting.',
   }
 }
 
@@ -202,22 +280,47 @@ export const issueListFactory: WorkspaceToolFactory = {
   build(ctx: WorkspaceToolContext) {
     return tool({
       description: [
-        "List the whole issue board — every workspace's issues as title rows",
-        '(scan titles first; use issue_show to read one in full).',
+        'List the issue board for agent startup.',
         '',
-        'Each row carries id, title, status, priority, assignee, whether it',
-        "self-schedules, and the owning `workspace` ({ wsId, tag }). A row whose",
-        'title clashes across workspaces is flagged `nameCollision`. Workspaces',
-        'whose issues dir is unreadable are surfaced in `invalid`, not dropped.',
+        'Default `summary` mode is intentionally small: it shows local issues',
+        'plus active urgent/high/medium rows from the global board, hiding',
+        'low-priority scheduled noise behind counts. Use `mode:"detailed"`',
+        'when you are deliberately auditing the whole board.',
       ].join('\n'),
-      inputSchema: z.object({}),
-      execute: async () => {
+      inputSchema: z.object({
+        mode: z
+          .enum(['summary', 'detailed'])
+          .optional()
+          .describe('summary (default) returns a short startup-safe focus list; detailed returns every row.'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(ISSUE_LIST_MAX_LIMIT)
+          .optional()
+          .describe(`Max summary focus rows (default ${ISSUE_LIST_DEFAULT_LIMIT}; ignored in detailed mode).`),
+      }),
+      execute: async ({ mode, limit }) => {
         // GLOBAL board when the service-backed reader is wired (the
         // `alice-workspace` surface). Reads EVERY workspace's issues.
         if (ctx.board) {
           const snapshot = await ctx.board.snapshot()
           const { rows, invalid } = flattenBoardRows(snapshot)
-          return { ok: true as const, issues: rows, invalid }
+          if (mode === 'detailed') {
+            return {
+              ok: true as const,
+              mode: 'detailed' as const,
+              count: rows.length,
+              issues: rows.sort(compareIssueRows),
+              invalid,
+            }
+          }
+          return summarizeIssueRows(
+            rows,
+            invalid,
+            ctx.workspaceId,
+            limit ?? ISSUE_LIST_DEFAULT_LIMIT,
+          )
         }
         // FALLBACK (no service: older contexts / unit tests): this workspace's
         // own files only, preserving the original self-scoped behavior.
@@ -225,9 +328,28 @@ export const issueListFactory: WorkspaceToolFactory = {
         if (!dir.ok) return { ok: false as const, error: dir.error }
         const res = await readWorkspaceIssues(dir.dir)
         if (res.ok) {
-          return { ok: true as const, issues: res.issues.map(rowOf), invalid: res.invalid }
+          const rows = res.issues.map((issue) => ({
+            ...rowOf(issue),
+            workspace: { wsId: ctx.workspaceId, tag: ctx.workspaceLabel },
+            ...(issue.when !== undefined ? { scheduled: true } : { scheduled: false }),
+          }))
+          if (mode === 'detailed') {
+            return { ok: true as const, mode: 'detailed' as const, count: rows.length, issues: rows, invalid: res.invalid }
+          }
+          return summarizeIssueRows(
+            rows,
+            res.invalid.map((invalid) => ({
+              wsId: ctx.workspaceId,
+              tag: ctx.workspaceLabel,
+              error: `${invalid.id}: ${invalid.error}`,
+            })),
+            ctx.workspaceId,
+            limit ?? ISSUE_LIST_DEFAULT_LIMIT,
+          )
         }
-        if (res.reason === 'absent') return { ok: true as const, issues: [], invalid: [] }
+        if (res.reason === 'absent') {
+          return summarizeIssueRows([], [], ctx.workspaceId, limit ?? ISSUE_LIST_DEFAULT_LIMIT)
+        }
         return { ok: false as const, error: res.error }
       },
     })

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -101,6 +101,7 @@ describe('POST /quick-chat — loginless credential injection', () => {
     expect(cred.apiKey).toBe('sk-oa');
     expect(cred.wireShape).toBe('openai-chat');
     expect(cred.model).toBe('gpt-5.5'); // vendor flagship — no lastModel yet
+    expect(cred.contextWindow).toBe(1_000_000);
     // model remembered on the cred for next time
     expect(vi.mocked(setCredentialLastModel)).toHaveBeenCalledWith('openai-1', 'gpt-5.5');
     expect(spawn).toHaveBeenCalledOnce();

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -232,6 +232,16 @@ describe('opencodeAdapter AI-config', () => {
     });
   });
 
+  it('writes an explicit custom-model context window for opencode when provided', async () => {
+    await opencodeAdapter.writeAiConfig!(dir, {
+      baseUrl: 'https://cn.test/v1', apiKey: 'sk-o', model: 'deepseek-chat', contextWindow: 1_000_000,
+    });
+    expect(JSON.parse(await read('opencode.json')).provider.workspace.models['deepseek-chat']).toEqual({
+      name: 'deepseek-chat',
+      limit: { context: 1_000_000, output: 16_384 },
+    });
+  });
+
   it('honors wireShape — anthropic → @ai-sdk/anthropic, responses → @ai-sdk/openai', async () => {
     await opencodeAdapter.writeAiConfig!(dir, { baseUrl: 'https://x/anthropic', apiKey: 'k', model: 'glm-5.1', wireShape: 'anthropic' });
     expect(JSON.parse(await read('opencode.json')).provider.workspace.npm).toBe('@ai-sdk/anthropic');
@@ -247,10 +257,10 @@ describe('opencodeAdapter AI-config', () => {
 
   it('round-trips through readAiConfig (strips the provider/ prefix off model)', async () => {
     await opencodeAdapter.writeAiConfig!(dir, {
-      baseUrl: 'https://cn.test/v1', apiKey: 'sk-o', model: 'deepseek-chat',
+      baseUrl: 'https://cn.test/v1', apiKey: 'sk-o', model: 'deepseek-chat', contextWindow: 512_000,
     });
     expect(await opencodeAdapter.readAiConfig!(dir)).toEqual({
-      baseUrl: 'https://cn.test/v1', apiKey: 'sk-o', model: 'deepseek-chat', wireShape: 'openai-chat',
+      baseUrl: 'https://cn.test/v1', apiKey: 'sk-o', model: 'deepseek-chat', wireShape: 'openai-chat', contextWindow: 512_000,
     });
   });
 
@@ -395,6 +405,15 @@ describe('piAdapter AI-config', () => {
     });
   });
 
+  it('writes an explicit custom-model context window for Pi when provided', async () => {
+    await piAdapter.writeAiConfig!(dir, {
+      baseUrl: 'https://cn.test/v1', apiKey: 'sk-p', model: 'deepseek-chat', contextWindow: 1_000_000,
+    });
+    expect(JSON.parse(await read('.pi-agent/models.json')).providers.workspace.models).toEqual([
+      { id: 'deepseek-chat', contextWindow: 1_000_000 },
+    ]);
+  });
+
   it('honors wireShape — anthropic → anthropic-messages, responses → openai-responses', async () => {
     await piAdapter.writeAiConfig!(dir, { baseUrl: 'https://x/anthropic', apiKey: 'k', model: 'glm-5.1', wireShape: 'anthropic' });
     expect(JSON.parse(await read('.pi-agent/models.json')).providers.workspace.api).toBe('anthropic-messages');
@@ -410,10 +429,10 @@ describe('piAdapter AI-config', () => {
 
   it('round-trips through readAiConfig', async () => {
     await piAdapter.writeAiConfig!(dir, {
-      baseUrl: 'https://cn.test/v1', apiKey: 'sk-p', model: 'deepseek-chat',
+      baseUrl: 'https://cn.test/v1', apiKey: 'sk-p', model: 'deepseek-chat', contextWindow: 256_000,
     });
     expect(await piAdapter.readAiConfig!(dir)).toEqual({
-      baseUrl: 'https://cn.test/v1', apiKey: 'sk-p', model: 'deepseek-chat', wireShape: 'openai-chat',
+      baseUrl: 'https://cn.test/v1', apiKey: 'sk-p', model: 'deepseek-chat', wireShape: 'openai-chat', contextWindow: 256_000,
     });
   });
 

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -10,6 +10,7 @@ const execFileAsync = promisify(execFile);
 
 const OPENCODE_CONFIG_PATH = 'opencode.json';
 const OPENCODE_PROVIDER_NAME = 'workspace';
+const DEFAULT_OUTPUT_TOKENS = 16_384;
 // opencode's `@ai-sdk/openai-compatible` SDK is statically bundled into the
 // binary (no runtime `npm install`) and speaks `/v1/chat/completions` — the
 // right shape for OpenAI-compatible + Chinese gateways (DeepSeek/Qwen/Kimi/
@@ -17,6 +18,10 @@ const OPENCODE_PROVIDER_NAME = 'workspace';
 // overrides always use this SDK; an Anthropic-shape override would swap to
 // `@ai-sdk/anthropic` (also bundled) — deferred until there's a real case.
 const OPENCODE_SDK_NPM = '@ai-sdk/openai-compatible';
+
+function positiveNumber(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
 
 /**
  * opencode (github.com/anomalyco/opencode, formerly sst/opencode; MIT, by
@@ -153,7 +158,15 @@ export const opencodeAdapter: CliAdapter = {
       options,
     };
     if (cred.model) {
-      provider['models'] = { [cred.model]: { name: cred.model } };
+      const model: Record<string, unknown> = { name: cred.model };
+      const contextWindow = positiveNumber(cred.contextWindow);
+      if (contextWindow !== null) {
+        // opencode treats missing custom-model limits as 0, which disables its
+        // proactive context tracking. Supplying both fields satisfies its config
+        // schema while keeping output conservative and invisible in OpenAlice UI.
+        model['limit'] = { context: contextWindow, output: DEFAULT_OUTPUT_TOKENS };
+      }
+      provider['models'] = { [cred.model]: model };
     }
 
     const config: Record<string, unknown> = {
@@ -188,13 +201,17 @@ export const opencodeAdapter: CliAdapter = {
       const slash = top.indexOf('/');
       model = slash >= 0 ? top.slice(slash + 1) : top;
     }
+    const models = (ws['models'] ?? {}) as Record<string, Record<string, unknown>>;
+    const modelConfig = model ? models[model] : undefined;
+    const limit = (modelConfig?.['limit'] ?? {}) as Record<string, unknown>;
+    const contextWindow = positiveNumber(limit['context'] as number | null | undefined);
     if (baseUrl === null && apiKey === null && model === null) return null;
     // Reverse the npm package back to the wire shape.
     const npm = typeof ws['npm'] === 'string' ? (ws['npm'] as string) : '';
     const wireShape = npm === '@ai-sdk/anthropic' ? 'anthropic' as const
       : npm === '@ai-sdk/openai' ? 'openai-responses' as const
       : 'openai-chat' as const;
-    return { baseUrl, apiKey, model, wireShape };
+    return { baseUrl, apiKey, model, wireShape, ...(contextWindow ? { contextWindow } : {}) };
   },
 
   /**

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -18,6 +18,10 @@ const PI_MODELS_PATH = `${PI_AGENT_DIR}/models.json`;
 const PI_SETTINGS_PATH = `${PI_AGENT_DIR}/settings.json`;
 const PI_PROVIDER_NAME = 'workspace';
 
+function positiveNumber(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
+
 /**
  * Pi (github.com/earendil-works/pi, by Mario Zechner; MIT). Open-source agent
  * CLI — the second non-claude/openai channel after opencode ("two suppliers",
@@ -148,9 +152,14 @@ export const piAdapter: CliAdapter = {
     // Key written directly into the workspace file (same trust model as codex's
     // .codex/env.json / opencode's opencode.json).
     if (cred.apiKey) provider['apiKey'] = cred.apiKey;
-    // ModelDefinitionSchema requires only `id` (model-registry.js:108-109);
-    // TypeBox Type.Object rejects unknown props, so keep it to `{ id }`.
-    if (cred.model) provider['models'] = [{ id: cred.model }];
+    // Pi's custom model registry otherwise falls back to 128k. OpenAlice writes
+    // the context window when known so long-context models do not compact early.
+    if (cred.model) {
+      const model: Record<string, unknown> = { id: cred.model };
+      const contextWindow = positiveNumber(cred.contextWindow);
+      if (contextWindow !== null) model['contextWindow'] = contextWindow;
+      provider['models'] = [model];
+    }
 
     await writeWorkspaceFile(
       cwd,
@@ -182,12 +191,13 @@ export const piAdapter: CliAdapter = {
     const models = Array.isArray(p['models']) ? (p['models'] as Array<Record<string, unknown>>) : [];
     const first = models[0];
     const model = first && typeof first['id'] === 'string' ? (first['id'] as string) : null;
+    const contextWindow = first && positiveNumber(first['contextWindow'] as number | null | undefined);
     if (baseUrl === null && apiKey === null && model === null) return null;
     // Reverse the `api` field back to the wire shape.
     const api = p['api'];
     const wireShape = api === 'anthropic-messages' ? 'anthropic' as const
       : api === 'openai-responses' ? 'openai-responses' as const
       : 'openai-chat' as const;
-    return { baseUrl, apiKey, model, wireShape };
+    return { baseUrl, apiKey, model, wireShape, ...(contextWindow ? { contextWindow } : {}) };
   },
 };

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -76,6 +76,12 @@ export interface WorkspaceAiCred {
    * actually uses the shape the credential was created + tested with.
    */
   wireShape?: WireShape | null;
+  /**
+   * Model context window for runtimes that need an explicit custom-model limit
+   * (currently opencode/Pi). Optional so old workspace configs keep loading;
+   * injectors may choose a modern default for newly-written configs.
+   */
+  contextWindow?: number | null;
   /** Codex only — legacy/explicit wire_api; superseded by wireShape when set. */
   wireApi?: 'chat' | 'responses' | null;
   /** Claude only. */

--- a/src/workspaces/cli/bin/alice
+++ b/src/workspaces/cli/bin/alice
@@ -85,6 +85,18 @@ async function manifest(base) {
     const msg = r.body && r.body.error ? r.body.error : `HTTP ${r.status}`
     fail(typeof msg === 'string' ? msg : JSON.stringify(msg))
   }
+  if (!r.body || typeof r.body !== 'object' || !r.body.groups || typeof r.body.groups !== 'object') {
+    const kind =
+      typeof r.body === 'string' && r.body.trim().startsWith('<')
+        ? 'HTML'
+        : r.body === null
+          ? 'empty response'
+          : typeof r.body
+    fail(
+      `invalid OpenAlice CLI manifest from ${base}/manifest (${kind}) — ` +
+        'check OPENALICE_TOOL_URL / OPENALICE_TOOL_SOCKET and point at the tools endpoint, not the Vite UI page.',
+    )
+  }
   return r.body
 }
 

--- a/src/workspaces/cli/bin/alice-uta
+++ b/src/workspaces/cli/bin/alice-uta
@@ -85,6 +85,18 @@ async function manifest(base) {
     const msg = r.body && r.body.error ? r.body.error : `HTTP ${r.status}`
     fail(typeof msg === 'string' ? msg : JSON.stringify(msg))
   }
+  if (!r.body || typeof r.body !== 'object' || !r.body.groups || typeof r.body.groups !== 'object') {
+    const kind =
+      typeof r.body === 'string' && r.body.trim().startsWith('<')
+        ? 'HTML'
+        : r.body === null
+          ? 'empty response'
+          : typeof r.body
+    fail(
+      `invalid OpenAlice CLI manifest from ${base}/manifest (${kind}) — ` +
+        'check OPENALICE_TOOL_URL / OPENALICE_TOOL_SOCKET and point at the tools endpoint, not the Vite UI page.',
+    )
+  }
   return r.body
 }
 

--- a/src/workspaces/cli/bin/alice-workspace
+++ b/src/workspaces/cli/bin/alice-workspace
@@ -85,6 +85,18 @@ async function manifest(base) {
     const msg = r.body && r.body.error ? r.body.error : `HTTP ${r.status}`
     fail(typeof msg === 'string' ? msg : JSON.stringify(msg))
   }
+  if (!r.body || typeof r.body !== 'object' || !r.body.groups || typeof r.body.groups !== 'object') {
+    const kind =
+      typeof r.body === 'string' && r.body.trim().startsWith('<')
+        ? 'HTML'
+        : r.body === null
+          ? 'empty response'
+          : typeof r.body
+    fail(
+      `invalid OpenAlice CLI manifest from ${base}/manifest (${kind}) — ` +
+        'check OPENALICE_TOOL_URL / OPENALICE_TOOL_SOCKET and point at the tools endpoint, not the Vite UI page.',
+    )
+  }
   return r.body
 }
 

--- a/src/workspaces/cli/bin/traderhub
+++ b/src/workspaces/cli/bin/traderhub
@@ -85,6 +85,18 @@ async function manifest(base) {
     const msg = r.body && r.body.error ? r.body.error : `HTTP ${r.status}`
     fail(typeof msg === 'string' ? msg : JSON.stringify(msg))
   }
+  if (!r.body || typeof r.body !== 'object' || !r.body.groups || typeof r.body.groups !== 'object') {
+    const kind =
+      typeof r.body === 'string' && r.body.trim().startsWith('<')
+        ? 'HTML'
+        : r.body === null
+          ? 'empty response'
+          : typeof r.body
+    fail(
+      `invalid OpenAlice CLI manifest from ${base}/manifest (${kind}) — ` +
+        'check OPENALICE_TOOL_URL / OPENALICE_TOOL_SOCKET and point at the tools endpoint, not the Vite UI page.',
+    )
+  }
   return r.body
 }
 

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -87,6 +87,37 @@ describe('CLI shim copies', () => {
     }
   })
 
+  it('reports a wrong CLI endpoint instead of throwing on an HTML manifest response', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openalice-cli-shim-html-'))
+    const socketPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\openalice-cli-shim-html-${process.pid}-${Date.now()}`
+      : join(dir, 'tools.sock')
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' })
+      res.end('<!DOCTYPE html><html><body>Vite fallback</body></html>')
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, resolve)
+    })
+    try {
+      await expect(execFileAsync(process.execPath, [fileURLToPath(new URL('bin/alice-workspace', import.meta.url)), 'issue', 'list'], {
+        env: {
+          ...process.env,
+          AQ_WS_ID: 'ws1',
+          OPENALICE_TOOL_SOCKET: socketPath,
+          OPENALICE_TOOL_URL: '/cli',
+        },
+        timeout: 5_000,
+      })).rejects.toMatchObject({
+        stderr: expect.stringContaining('invalid OpenAlice CLI manifest'),
+      })
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   // Windows has no shebang concept — it resolves executables on PATH by
   // extension (PATHEXT). The extensionless shims trigger a "how do you want to
   // open this file?" association dialog on every invocation. A `.cmd` twin per

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -78,10 +78,16 @@ describe('credentialToWorkspaceAiCred', () => {
         expect(cred.wireShape).toBe('openai-chat')
         expect(cred.authMode).toBeUndefined()
         expect(cred.wireApi).toBeUndefined()
+        expect(cred.contextWindow).toBe(1_000_000)
         expect(cred.apiKey).toBe('k')
         expect(cred.baseUrl).toBe('https://gw.example.com/v1')
       })
     }
+  })
+
+  it('lets opencode/pi override the default context window', () => {
+    const cred = credentialToWorkspaceAiCred(chatOnlyGateway, 'pi', { model: 'some-model', contextWindow: 256_000 })!
+    expect(cred.contextWindow).toBe(256_000)
   })
 })
 

--- a/src/workspaces/credential-injection.ts
+++ b/src/workspaces/credential-injection.ts
@@ -34,6 +34,12 @@ export const AGENT_WIRE_PREFERENCE: Record<string, CredentialWireShape[]> = {
   pi: ['openai-chat', 'anthropic', 'openai-responses'],
 }
 
+// Modern coding models are commonly sold as long-context runtimes. Pi defaults
+// unknown custom models to 128k and opencode defaults unknown limits to 0, so
+// new OpenAlice injections state the assumption explicitly while keeping the
+// field overridable from the workspace config UI.
+export const DEFAULT_CONTEXT_WINDOW = 1_000_000
+
 /**
  * The subset of a credential vault an agent can actually be driven by: those
  * with at least one wire shape the agent speaks (see `pickAgentWire`). Used by
@@ -93,6 +99,8 @@ export function pickAgentWire(
 export interface CredentialInjectionOverrides {
   /** Model id to run. Required in practice (a credential has none). */
   model?: string
+  /** Context window to write for custom-model runtimes; defaults to 1M for opencode/Pi. */
+  contextWindow?: number | null
   /** Claude only — which header carries the key. Defaults via baseUrl heuristic. */
   authMode?: 'x-api-key' | 'bearer'
   /** Codex only — Responses vs Chat Completions. Adapter defaults to 'chat'. */
@@ -121,6 +129,10 @@ export function credentialToWorkspaceAiCred(
     // The chosen wire shape drives how the consuming adapter is configured
     // (which @ai-sdk package / api field / wire_api).
     wireShape: picked.shape,
+  }
+
+  if (agentId === 'opencode' || agentId === 'pi') {
+    cred.contextWindow = overrides.contextWindow ?? DEFAULT_CONTEXT_WINDOW
   }
 
   if (agentId === 'claude') {

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -50,11 +50,19 @@ type Tab = 'claude' | 'codex' | 'opencode' | 'pi'
 type Section = 'general' | 'ai'
 
 const TAB_LABEL: Record<Tab, string> = { claude: 'Claude Code', codex: 'Codex', opencode: 'opencode', pi: 'Pi' }
+const DEFAULT_CONTEXT_WINDOW = 1_000_000
+const CONTEXT_WINDOW_OPTIONS = [
+  { value: 128_000, label: '128K' },
+  { value: 256_000, label: '256K' },
+  { value: 512_000, label: '512K' },
+  { value: 1_000_000, label: '1M' },
+] as const
 
 interface FormState {
   baseUrl: string
   apiKey: string
   model: string
+  contextWindow: number
   /** The wire protocol — drives the test + how the adapter is configured. */
   wireShape: WireShape
   wireApi: 'chat' | 'responses'
@@ -73,7 +81,20 @@ const DEFAULT_WIRE_BY_TAB: Record<Tab, WireShape> = {
   pi: 'openai-chat',
 }
 
-const EMPTY_FORM: FormState = { baseUrl: '', apiKey: '', model: '', wireShape: 'anthropic', wireApi: 'responses', authMode: 'x-api-key' }
+const EMPTY_FORM: FormState = {
+  baseUrl: '',
+  apiKey: '',
+  model: '',
+  contextWindow: DEFAULT_CONTEXT_WINDOW,
+  wireShape: 'anthropic',
+  wireApi: 'responses',
+  authMode: 'x-api-key',
+}
+
+function normalizeContextWindow(value: number | null | undefined): number {
+  if (typeof value !== 'number') return DEFAULT_CONTEXT_WINDOW
+  return CONTEXT_WINDOW_OPTIONS.some((o) => o.value === value) ? value : DEFAULT_CONTEXT_WINDOW
+}
 
 function configToForm(cfg: AgentConfig | null, tab: Tab): FormState {
   if (!cfg) return { ...EMPTY_FORM, wireShape: DEFAULT_WIRE_BY_TAB[tab] }
@@ -81,6 +102,7 @@ function configToForm(cfg: AgentConfig | null, tab: Tab): FormState {
     baseUrl: cfg.baseUrl ?? '',
     apiKey: cfg.apiKey ?? '',
     model: cfg.model ?? '',
+    contextWindow: normalizeContextWindow(cfg.contextWindow),
     wireShape: cfg.wireShape ?? DEFAULT_WIRE_BY_TAB[tab],
     wireApi: 'responses',
     authMode: cfg.authMode === 'bearer' ? 'bearer' : 'x-api-key',
@@ -93,6 +115,9 @@ function formToConfig(form: FormState, agent: AgentId): AgentConfig {
     apiKey: form.apiKey.trim() || null,
     model: form.model.trim() || null,
     wireShape: form.wireShape,
+  }
+  if (agent === 'opencode' || agent === 'pi') {
+    return { ...cfg, contextWindow: form.contextWindow }
   }
   if (agent === 'codex') {
     return { ...cfg, wireApi: form.wireApi }
@@ -205,6 +230,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
       savedForm.apiKey !== form.apiKey ||
       savedForm.model !== form.model ||
       savedForm.wireShape !== form.wireShape ||
+      ((tab === 'opencode' || tab === 'pi') && savedForm.contextWindow !== form.contextWindow) ||
       (tab === 'claude' && savedForm.authMode !== form.authMode)
     )
   }, [bundle, form, tab])
@@ -642,6 +668,21 @@ export function WorkspaceAIConfigModal({ wsId, onClose }: Props) {
               <p className="text-[11px] text-text-muted/70 mt-1">Suggestions from the matched provider — or type any model id.</p>
             )}
           </div>
+
+          {(tab === 'opencode' || tab === 'pi') && (
+            <div>
+              <label className="block text-xs font-medium text-text-muted mb-1">Context window</label>
+              <select
+                value={form.contextWindow}
+                onChange={(e) => setForm({ ...form, contextWindow: Number(e.target.value) })}
+                className={inputClass}
+              >
+                {CONTEXT_WINDOW_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {tab === 'codex' && (
             <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-2">

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -507,6 +507,8 @@ export interface AgentConfig {
   readonly baseUrl: string | null;
   readonly apiKey: string | null;
   readonly model: string | null;
+  /** Optional custom-model context window for opencode/Pi provider overrides. */
+  readonly contextWindow?: number | null;
   /** Wire protocol the endpoint speaks — drives how the adapter is configured. */
   readonly wireShape?: WireShape | null;
   /** Codex only — wire format for the upstream API. */


### PR DESCRIPTION
## Summary

- Clean up workspace issue CLI output so default issue listings are quieter and agent-friendly, with detailed output available when needed.
- Harden workspace CLI shims so local tool routing reports clearer failures instead of silently falling into the wrong surface.
- Add an optional context window setting for opencode and Pi workspace AI configs, defaulting new injections to 1M with UI choices for 128K, 256K, 512K, and 1M.

## Why

Workspace agents were pulling noisy issue listings into context, which made startup context brittle. Pi also defaulted unknown custom models to a smaller context window, while opencode treats missing custom limits as unknown, so OpenAlice now writes an explicit, user-selectable context assumption for the runtimes that need it.

## Validation

- `pnpm vitest run src/tool/issue-tools.spec.ts src/server/cli.spec.ts src/workspaces/cli/shim.spec.ts src/workspaces/adapters/ai-config.spec.ts src/workspaces/credential-injection.spec.ts src/webui/routes/workspaces-quickchat.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `git diff --check`