### PR TITLE
[codex] Add issue default agent settings

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -204,6 +204,12 @@ export const aiProviderSchema = z.object({
    * start?" Shell is a utility adapter, not a valid stored default.
    */
   workspaceDefaultAgent: z.string().nullable().default(null),
+  /**
+   * User-level default runtime for issue-triggered headless work. This stays
+   * separate from `workspaceDefaultAgent`: users often want Codex/Claude for
+   * interactive chat, but Pi/opencode for scheduled scans.
+   */
+  issueDefaultAgent: z.string().nullable().default(null),
 })
 
 export type AIProviderConfig = z.infer<typeof aiProviderSchema>
@@ -1005,6 +1011,18 @@ export async function readWorkspaceDefaultAgent(): Promise<string | null> {
 export async function writeWorkspaceDefaultAgent(agentId: string | null): Promise<void> {
   const config = await readAIProviderConfig()
   config.workspaceDefaultAgent = agentId && agentId.trim() ? agentId.trim() : null
+  await mkdir(CONFIG_DIR, { recursive: true })
+  await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
+}
+
+export async function readIssueDefaultAgent(): Promise<string | null> {
+  const config = await readAIProviderConfig()
+  return config.issueDefaultAgent ?? null
+}
+
+export async function writeIssueDefaultAgent(agentId: string | null): Promise<void> {
+  const config = await readAIProviderConfig()
+  config.issueDefaultAgent = agentId && agentId.trim() ? agentId.trim() : null
   await mkdir(CONFIG_DIR, { recursive: true })
   await writeFile(resolve(CONFIG_DIR, 'ai-provider-manager.json'), JSON.stringify(config, null, 2) + '\n')
 }

--- a/src/webui/routes/config-workspace-defaults.spec.ts
+++ b/src/webui/routes/config-workspace-defaults.spec.ts
@@ -13,6 +13,7 @@ import type { Credential, WorkspaceCredentialDefault } from '../../core/config.j
 let credStore: Record<string, Credential> = {}
 let defaultsStore: Record<string, WorkspaceCredentialDefault> = {}
 let defaultAgentStore: string | null = null
+let issueDefaultAgentStore: string | null = null
 
 vi.mock('../../core/config.js', async () => {
   const actual = await vi.importActual<typeof import('../../core/config.js')>('../../core/config.js')
@@ -21,6 +22,7 @@ vi.mock('../../core/config.js', async () => {
     readCredentials: vi.fn(async () => ({ ...credStore })),
     readWorkspaceCredentialDefaults: vi.fn(async () => ({ ...defaultsStore })),
     readWorkspaceDefaultAgent: vi.fn(async () => defaultAgentStore),
+    readIssueDefaultAgent: vi.fn(async () => issueDefaultAgentStore),
     writeWorkspaceCredentialDefaults: vi.fn(async (next: Record<string, WorkspaceCredentialDefault>) => {
       // Mirror the real writer: drop empty slugs.
       const cleaned: Record<string, WorkspaceCredentialDefault> = {}
@@ -29,6 +31,9 @@ vi.mock('../../core/config.js', async () => {
     }),
     writeWorkspaceDefaultAgent: vi.fn(async (agent: string | null) => {
       defaultAgentStore = agent
+    }),
+    writeIssueDefaultAgent: vi.fn(async (agent: string | null) => {
+      issueDefaultAgentStore = agent
     }),
     addCredential: vi.fn(async (credential: Credential) => {
       const slug = `${credential.vendor}-${Object.keys(credStore).length + 1}`
@@ -67,6 +72,7 @@ beforeEach(() => {
   }
   defaultsStore = {}
   defaultAgentStore = null
+  issueDefaultAgentStore = null
 })
 
 describe('GET /workspace-credential-defaults', () => {
@@ -131,6 +137,32 @@ describe('GET/PUT /workspace-default-agent', () => {
     const unknown = await req(routes, 'PUT', '/workspace-default-agent', { agent: 'bogus' })
     expect(unknown.body).toEqual({ agent: null })
     expect(defaultAgentStore).toBeNull()
+  })
+})
+
+describe('GET/PUT /issue-default-agent', () => {
+  it('round-trips a valid issue runtime default', async () => {
+    const routes = createConfigRoutes()
+    const put = await req(routes, 'PUT', '/issue-default-agent', { agent: 'pi' })
+    expect(put.status).toBe(200)
+    expect(put.body).toEqual({ agent: 'pi' })
+    expect(issueDefaultAgentStore).toBe('pi')
+
+    const get = await req(routes, 'GET', '/issue-default-agent')
+    expect(get.body).toEqual({ agent: 'pi' })
+  })
+
+  it('does not persist shell or unknown ids as an issue default', async () => {
+    const routes = createConfigRoutes()
+    issueDefaultAgentStore = 'pi'
+
+    const shell = await req(routes, 'PUT', '/issue-default-agent', { agent: 'shell' })
+    expect(shell.body).toEqual({ agent: null })
+    expect(issueDefaultAgentStore).toBeNull()
+
+    const unknown = await req(routes, 'PUT', '/issue-default-agent', { agent: 'bogus' })
+    expect(unknown.body).toEqual({ agent: null })
+    expect(issueDefaultAgentStore).toBeNull()
   })
 })
 

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -4,6 +4,7 @@ import {
   readCredentials, addCredential, deleteCredential, writeCredential, resolveCredential,
   credentialWires,
   readWorkspaceCredentialDefaults, writeWorkspaceCredentialDefaults,
+  readIssueDefaultAgent, writeIssueDefaultAgent,
   readWorkspaceDefaultAgent, writeWorkspaceDefaultAgent,
   credentialVendorEnum, credentialWireShapeEnum,
   type ConfigSection, type Credential, type CredentialWireShape,
@@ -241,6 +242,27 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
         ? body.agent
         : null
       await writeWorkspaceDefaultAgent(agent)
+      return c.json({ agent })
+    } catch (err) {
+      return c.json({ error: String(err) }, 400)
+    }
+  })
+
+  app.get('/issue-default-agent', async (c) => {
+    try {
+      return c.json({ agent: await readIssueDefaultAgent() })
+    } catch (err) {
+      return c.json({ error: String(err) }, 500)
+    }
+  })
+
+  app.put('/issue-default-agent', async (c) => {
+    try {
+      const body = await c.req.json<{ agent?: string | null }>()
+      const agent = typeof body.agent === 'string' && DEFAULTABLE_AGENTS.includes(body.agent as typeof DEFAULTABLE_AGENTS[number])
+        ? body.agent
+        : null
+      await writeIssueDefaultAgent(agent)
       return c.json({ agent })
     } catch (err) {
       return c.json({ error: String(err) }, 400)

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -86,7 +86,7 @@ export const issueFrontmatterSchema = z.object({
   when: issueWhenSchema.optional(),
   /** Prompt fired on schedule; if absent, the fire prompt falls back to title+body. */
   what: z.string().min(1).optional(),
-  /** Which agent runtime to run the scheduled fire with; omitted uses the user default / first runtime. */
+  /** Which agent runtime to run the scheduled fire with; omitted uses the issue default / workspace default / first runtime. */
   agent: z.string().min(1).optional(),
 })
 export type IssueFrontmatter = z.infer<typeof issueFrontmatterSchema>

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -54,7 +54,7 @@ export interface MarkerStore {
 
 export interface ScheduleScannerDeps {
   registry: WorkspaceRegistry
-  resolveAdapter: (meta: WorkspaceMeta, agentId?: string) => CliAdapter
+  resolveAdapter: (meta: WorkspaceMeta, agentId?: string) => CliAdapter | Promise<CliAdapter>
   dispatch: (
     meta: WorkspaceMeta,
     adapter: CliAdapter,
@@ -208,7 +208,7 @@ export class ScheduleScanner {
     agentId: string | undefined,
     nowMs: number,
   ): Promise<void> {
-    const adapter = this.deps.resolveAdapter(ws, agentId)
+    const adapter = await this.deps.resolveAdapter(ws, agentId)
     if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
       this.deps.logger.warn('schedule.adapter_not_headless', { wsId: ws.id, taskId, agent: adapter.id })
       return

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -13,6 +13,7 @@ import { existsSync } from 'node:fs';
 import { basename, delimiter as pathDelimiter, join } from 'node:path';
 
 import { cliBinPath } from '@/core/paths.js';
+import { readIssueDefaultAgent, readWorkspaceDefaultAgent } from '@/core/config.js';
 
 import { claudeAdapter } from './adapters/claude.js';
 import { codexAdapter } from './adapters/codex.js';
@@ -314,6 +315,28 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     }
     return adapters.resolve(null);
   };
+
+  const firstWorkspaceRuntime = (wsMeta: WorkspaceMeta): string | undefined =>
+    wsMeta.agents.find((id) => {
+      const adapter = adapters.get(id);
+      return adapter ? isAgentRuntime(adapter) : false;
+    });
+
+  const validRuntimeForWorkspace = (wsMeta: WorkspaceMeta, agentId: string | null): string | undefined => {
+    if (!agentId || !wsMeta.agents.includes(agentId)) return undefined;
+    const adapter = adapters.get(agentId);
+    return adapter && isAgentRuntime(adapter) ? agentId : undefined;
+  };
+
+  /**
+   * Default for scheduled issues with no frontmatter `agent`: issue-specific
+   * setting first, then the interactive workspace default for backwards
+   * continuity, then the workspace's first enabled runtime.
+   */
+  const resolveIssueDefaultAgentId = async (wsMeta: WorkspaceMeta): Promise<string | undefined> =>
+    validRuntimeForWorkspace(wsMeta, await readIssueDefaultAgent().catch(() => null)) ??
+    validRuntimeForWorkspace(wsMeta, await readWorkspaceDefaultAgent().catch(() => null)) ??
+    firstWorkspaceRuntime(wsMeta);
 
   /**
    * Single source of truth for "given a workspace + adapter + resume intent,
@@ -626,7 +649,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   );
   const scheduleScanner = new ScheduleScanner({
     registry,
-    resolveAdapter,
+    resolveAdapter: async (ws, agentId) => resolveAdapter(
+      ws,
+      agentId ?? await resolveIssueDefaultAgentId(ws),
+    ),
     dispatch: dispatchHeadlessTaskMethod,
     markers: scheduleMarkers,
     logger: launcherLogger.child({ scope: 'schedule' }),

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -168,6 +168,7 @@ function AssigneeEditor({
 
 function AgentEditor({
   value,
+  issueDefaultAgent,
   defaultAgent,
   options,
   readiness,
@@ -176,6 +177,7 @@ function AgentEditor({
   onConfigure,
 }: {
   value?: string
+  issueDefaultAgent: string | null
   defaultAgent: string | null
   options: readonly { id: string; displayName: string; installed?: boolean }[]
   readiness: Readonly<Record<string, AgentCredentialReadiness>>
@@ -184,11 +186,14 @@ function AgentEditor({
   onConfigure: (agent: AgentId) => void
 }) {
   const selected = value ?? ''
+  const issueDefaultInOptions = issueDefaultAgent && options.some((a) => a.id === issueDefaultAgent) ? issueDefaultAgent : null
   const defaultInOptions = defaultAgent && options.some((a) => a.id === defaultAgent) ? defaultAgent : null
-  const effectiveAgent = value || defaultInOptions || options[0]?.id || null
+  const effectiveAgent = value || issueDefaultInOptions || defaultInOptions || options[0]?.id || null
   const canConfigure = isConfigurableAgent(effectiveAgent)
-  const defaultLabel = defaultInOptions
-    ? `Default (${options.find((a) => a.id === defaultAgent)?.displayName ?? defaultAgent})`
+  const defaultLabel = issueDefaultInOptions
+    ? `Default (${options.find((a) => a.id === issueDefaultInOptions)?.displayName ?? issueDefaultInOptions})`
+    : defaultInOptions
+    ? `Default (${options.find((a) => a.id === defaultInOptions)?.displayName ?? defaultInOptions}, workspace)`
     : 'Default'
 
   return (
@@ -239,6 +244,7 @@ function PropertiesRail({
   issue,
   wsTag,
   agentOptions,
+  issueDefaultAgent,
   defaultAgent,
   agentReadiness,
   saving,
@@ -249,6 +255,7 @@ function PropertiesRail({
   issue: IssueDetailIssue
   wsTag?: string
   agentOptions: readonly { id: string; displayName: string; installed?: boolean }[]
+  issueDefaultAgent: string | null
   defaultAgent: string | null
   agentReadiness: Readonly<Record<string, AgentCredentialReadiness>>
   saving: boolean
@@ -257,8 +264,9 @@ function PropertiesRail({
   onConfigureAgent: (agent: AgentId) => void
 }) {
   const meta = STATUS_META[issue.status]
+  const issueDefaultInOptions = issueDefaultAgent && agentOptions.some((a) => a.id === issueDefaultAgent) ? issueDefaultAgent : null
   const defaultInOptions = defaultAgent && agentOptions.some((a) => a.id === defaultAgent) ? defaultAgent : null
-  const effectiveAgent = issue.agent || defaultInOptions || agentOptions[0]?.id || null
+  const effectiveAgent = issue.agent || issueDefaultInOptions || defaultInOptions || agentOptions[0]?.id || null
   const selectedReadiness = effectiveAgent ? agentReadiness[effectiveAgent] : undefined
   const agentNeedsCredential = selectedReadiness?.requiresCredential === true && !selectedReadiness.ready
   return (
@@ -309,6 +317,7 @@ function PropertiesRail({
         <EditRow label="Agent">
           <AgentEditor
             value={issue.agent}
+            issueDefaultAgent={issueDefaultAgent}
             defaultAgent={defaultAgent}
             options={agentOptions}
             readiness={agentReadiness}
@@ -628,7 +637,7 @@ export function IssueDetail({
 }: IssueDetailProps) {
   const { data, error, loading, mutate } = useIssueDetail(wsId, id)
   const { data: board } = useIssues()
-  const { agents, defaultAgent, openAgentConfig, workspaces } = useWorkspaces()
+  const { agents, defaultAgent, issueDefaultAgent, openAgentConfig, workspaces } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
   const selectInboxEntry = useInboxSelection((s) => s.select)
@@ -800,6 +809,7 @@ export function IssueDetail({
           issue={issue}
           wsTag={wsTag}
           agentOptions={agentOptions}
+          issueDefaultAgent={issueDefaultAgent}
           defaultAgent={defaultAgent}
           agentReadiness={agentReadiness}
           saving={saving}

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -190,7 +190,7 @@ interface BoardRow {
 interface AgentRuntime {
   id: string
   displayName: string
-  source: 'override' | 'default' | 'workspace'
+  source: 'override' | 'issue-default' | 'workspace-default' | 'workspace'
 }
 
 /** Normalised collision key — title, trimmed + lowercased. Mirrors the server's
@@ -207,6 +207,7 @@ function resolveAgentRuntime(
   issue: IssueListItem,
   workspace: { agents: readonly string[] } | null,
   agents: readonly { id: string; displayName: string; kind?: 'agent' | 'utility' }[],
+  issueDefaultAgent: string | null,
   defaultAgent: string | null,
 ): AgentRuntime | undefined {
   if (issue.agent) {
@@ -217,9 +218,13 @@ function resolveAgentRuntime(
     const agent = agents.find((a) => a.id === id)
     return agent ? agent.kind !== 'utility' : id !== 'shell'
   })
-  const defaultId = defaultAgent && runtimeIds.includes(defaultAgent) ? defaultAgent : null
-  if (defaultId) {
-    return { id: defaultId, displayName: agentName(defaultId, agents), source: 'default' }
+  const issueDefaultId = issueDefaultAgent && runtimeIds.includes(issueDefaultAgent) ? issueDefaultAgent : null
+  if (issueDefaultId) {
+    return { id: issueDefaultId, displayName: agentName(issueDefaultId, agents), source: 'issue-default' }
+  }
+  const workspaceDefaultId = defaultAgent && runtimeIds.includes(defaultAgent) ? defaultAgent : null
+  if (workspaceDefaultId) {
+    return { id: workspaceDefaultId, displayName: agentName(workspaceDefaultId, agents), source: 'workspace-default' }
   }
   const fallbackId = runtimeIds[0]
   return fallbackId
@@ -233,7 +238,9 @@ function AgentRuntimePill({ runtime }: { runtime: AgentRuntime }) {
   const title =
     runtime.source === 'override'
       ? `Agent runtime override: ${runtime.displayName}`
-      : runtime.source === 'default'
+      : runtime.source === 'issue-default'
+        ? `Agent runtime: ${runtime.displayName} (issue default)`
+      : runtime.source === 'workspace-default'
         ? `Agent runtime: ${runtime.displayName} (workspace default)`
         : `Agent runtime: ${runtime.displayName} (workspace fallback)`
   return (
@@ -376,7 +383,7 @@ function InvalidWorkspaces({ workspaces }: { workspaces: IssueWorkspace[] }) {
  */
 export function IssuesBoard() {
   const { data, error, loading } = useIssues()
-  const { agents, defaultAgent, workspaces: workspaceMetas } = useWorkspaces()
+  const { agents, defaultAgent, issueDefaultAgent, workspaces: workspaceMetas } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
   const [collapsed, setCollapsed] = useState<Set<IssueStatus>>(new Set())
@@ -434,6 +441,7 @@ export function IssuesBoard() {
         issue,
         workspaceMetas.find((workspace) => workspace.id === w.wsId) ?? null,
         agents,
+        issueDefaultAgent,
         defaultAgent,
       ),
       dupOthers: issue.nameCollision

--- a/ui/src/components/SettingsCategoryList.tsx
+++ b/ui/src/components/SettingsCategoryList.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { SlidersHorizontal, Bot, CandlestickChart, Plug, LineChart, Newspaper } from 'lucide-react'
+import { SlidersHorizontal, Bot, CandlestickChart, ListChecks, Plug, LineChart, Newspaper } from 'lucide-react'
 import { useWorkspace } from '../tabs/store'
 import { getFocusedTab } from '../tabs/types'
 import { SidebarRow } from './SidebarRow'
@@ -8,6 +8,7 @@ const CATEGORIES = [
   { labelKey: 'settings.category.general',     category: 'general',        Icon: SlidersHorizontal },
   { labelKey: 'settings.category.aiProvider',  category: 'ai-provider',    Icon: Bot },
   { labelKey: 'settings.category.trading',     category: 'trading',        Icon: CandlestickChart },
+  { labelKey: 'settings.category.issues',      category: 'issues',         Icon: ListChecks },
   // Connectors moved to its own ActivityBar Legacy entry — see
   // ConnectorsLegacySidebar.
   { labelKey: 'settings.category.mcpServer',   category: 'mcp',            Icon: Plug },

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -215,6 +215,27 @@ export async function setWorkspaceDefaultAgent(agent: string | null): Promise<st
   return body.agent ?? null;
 }
 
+export async function getIssueDefaultAgent(): Promise<string | null> {
+  const res = await fetch('/api/config/issue-default-agent');
+  if (!res.ok) return null;
+  const body = (await res.json()) as { agent?: string | null };
+  return body.agent ?? null;
+}
+
+export async function setIssueDefaultAgent(agent: string | null): Promise<string | null> {
+  const res = await fetch('/api/config/issue-default-agent', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agent }),
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => '');
+    throw new Error(`set issue default agent failed: ${res.status} ${msg}`);
+  }
+  const body = (await res.json()) as { agent?: string | null };
+  return body.agent ?? null;
+}
+
 // ── sessions ─────────────────────────────────────────────────────────────────
 //
 // V3.S4 — single SessionRecord type that covers both running PTYs and paused

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -32,6 +32,7 @@ import { WorkspaceAIConfigModal } from '../components/workspace/WorkspaceAIConfi
 import {
   deleteSession as apiDeleteSession,
   type AgentId,
+  getIssueDefaultAgent,
   getWorkspaceDefaultAgent,
   listAgents,
   listTemplates,
@@ -39,6 +40,7 @@ import {
   pauseSession as apiPauseSession,
   quickChat as apiQuickChat,
   resumeSession as apiResumeSession,
+  setIssueDefaultAgent as apiSetIssueDefaultAgent,
   setWorkspaceDefaultAgent as apiSetWorkspaceDefaultAgent,
   spawnSession,
   updateWorkspaceMetadata,
@@ -59,6 +61,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   const [templatesLoaded, setTemplatesLoaded] = useState(false)
   const [agents, setAgents] = useState<AgentInfo[]>([])
   const [defaultAgent, setDefaultAgentState] = useState<string | null>(null)
+  const [issueDefaultAgent, setIssueDefaultAgentState] = useState<string | null>(null)
   const [listError, setListError] = useState<string | null>(null)
   // Don't reconcile orphan tabs until we've successfully fetched the
   // workspaces list at least once — otherwise the initial `[]` looks like
@@ -100,6 +103,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
       .finally(() => setTemplatesLoaded(true))
     void listAgents().then(setAgents).catch(() => setAgents([]))
     void getWorkspaceDefaultAgent().then(setDefaultAgentState).catch(() => setDefaultAgentState(null))
+    void getIssueDefaultAgent().then(setIssueDefaultAgentState).catch(() => setIssueDefaultAgentState(null))
   }, [])
 
   // Reconcile tabs against the workspaces list. If a workspace or session
@@ -171,6 +175,11 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
   const setDefaultAgent = useCallback(async (agent: string | null): Promise<void> => {
     const saved = await apiSetWorkspaceDefaultAgent(agent)
     setDefaultAgentState(saved)
+  }, [])
+
+  const setIssueDefaultAgent = useCallback(async (agent: string | null): Promise<void> => {
+    const saved = await apiSetIssueDefaultAgent(agent)
+    setIssueDefaultAgentState(saved)
   }, [])
 
   const quickChat = useCallback(
@@ -320,12 +329,14 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         templates,
         agents,
         defaultAgent,
+        issueDefaultAgent,
         listError,
         hasLoaded,
         templatesLoaded,
         refresh,
         spawn,
         setDefaultAgent,
+        setIssueDefaultAgent,
         quickChat,
         pauseSession,
         resumeSession,

--- a/ui/src/contexts/workspaces-context.ts
+++ b/ui/src/contexts/workspaces-context.ts
@@ -19,6 +19,7 @@ export interface WorkspacesContextValue {
   readonly templates: readonly TemplateInfo[]
   readonly agents: readonly AgentInfo[]
   readonly defaultAgent: string | null
+  readonly issueDefaultAgent: string | null
   readonly listError: string | null
   /** True once the first workspaces-list fetch has resolved. */
   readonly hasLoaded: boolean
@@ -27,6 +28,7 @@ export interface WorkspacesContextValue {
   refresh(): void
   spawn(wsId: string, opts?: SpawnOpts, source?: WorkspaceSource): Promise<void>
   setDefaultAgent(agent: string | null): Promise<void>
+  setIssueDefaultAgent(agent: string | null): Promise<void>
   quickChat(prompt: string, agent?: string, credentialSlug?: string, targetWsId?: string): Promise<void>
   pauseSession(wsId: string, sessionId: string): Promise<void>
   resumeSession(wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void>

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -67,4 +67,15 @@ export const configKeysHandlers = [
     const body = (await request.json().catch(() => ({}))) as { defaults?: unknown }
     return HttpResponse.json({ defaults: body.defaults ?? {} })
   }),
+
+  http.get('/api/config/workspace-default-agent', () => HttpResponse.json({ agent: 'claude' })),
+  http.put('/api/config/workspace-default-agent', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { agent?: unknown }
+    return HttpResponse.json({ agent: typeof body.agent === 'string' ? body.agent : null })
+  }),
+  http.get('/api/config/issue-default-agent', () => HttpResponse.json({ agent: 'pi' })),
+  http.put('/api/config/issue-default-agent', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { agent?: unknown }
+    return HttpResponse.json({ agent: typeof body.agent === 'string' ? body.agent : null })
+  }),
 ]

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -61,6 +61,7 @@ export const en = {
       general: 'General',
       aiProvider: 'AI Provider',
       trading: 'Trading',
+      issues: 'Issues',
       mcpServer: 'MCP Server',
       marketData: 'Market Data',
       newsSources: 'News Sources',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -50,6 +50,7 @@ export const ja: Resources = {
       general: '一般',
       aiProvider: 'AI プロバイダー',
       trading: '取引',
+      issues: 'Issues',
       mcpServer: 'MCP サーバー',
       marketData: 'マーケットデータ',
       newsSources: 'ニュースソース',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -58,6 +58,7 @@ export const zhHant: Resources = {
       general: '一般',
       aiProvider: 'AI 供應商',
       trading: '交易',
+      issues: 'Issues',
       mcpServer: 'MCP 伺服器',
       marketData: '市場資料',
       newsSources: '新聞來源',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -50,6 +50,7 @@ export const zh: Resources = {
       general: '通用',
       aiProvider: 'AI 提供商',
       trading: '交易',
+      issues: 'Issues',
       mcpServer: 'MCP 服务器',
       marketData: '市场数据',
       newsSources: '新闻源',

--- a/ui/src/pages/IssuePage.tsx
+++ b/ui/src/pages/IssuePage.tsx
@@ -1,5 +1,8 @@
+import { Settings } from 'lucide-react'
+
 import { PageHeader } from '../components/PageHeader'
 import { IssuesBoard } from '../components/IssuesBoard'
+import { useWorkspace } from '../tabs/store'
 
 /**
  * Issues — the global, Linear-style board aggregating every workspace's issues
@@ -9,11 +12,23 @@ import { IssuesBoard } from '../components/IssuesBoard'
  * a route here.
  */
 export function IssuePage() {
+  const openOrFocus = useWorkspace((s) => s.openOrFocus)
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader
         title="Issues"
         description="Work tracked across every workspace — what each agent is doing, and what's scheduled to run."
+        right={
+          <button
+            type="button"
+            onClick={() => openOrFocus({ kind: 'settings', params: { category: 'issues' } })}
+            title="Issue settings"
+            aria-label="Issue settings"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-bg-secondary text-muted transition-colors hover:border-accent/50 hover:text-text"
+          >
+            <Settings size={15} aria-hidden />
+          </button>
+        }
       />
       <div className="flex-1 min-h-0 overflow-y-auto px-4 md:px-6 py-5">
         <IssuesBoard />

--- a/ui/src/pages/IssueSettingsPage.tsx
+++ b/ui/src/pages/IssueSettingsPage.tsx
@@ -1,0 +1,81 @@
+import { useMemo, useState } from 'react'
+import { Bot } from 'lucide-react'
+
+import { ConfigSection, Field, inputClass } from '../components/form'
+import { PageHeader } from '../components/PageHeader'
+import { SaveIndicator } from '../components/SaveIndicator'
+import { useWorkspaces } from '../contexts/workspaces-context'
+
+export function IssueSettingsPage() {
+  const { agents, defaultAgent, issueDefaultAgent, setIssueDefaultAgent } = useWorkspaces()
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+
+  const runtimeAgents = useMemo(
+    () => agents.filter((agent) => agent.kind !== 'utility'),
+    [agents],
+  )
+  const workspaceDefault = defaultAgent
+    ? runtimeAgents.find((agent) => agent.id === defaultAgent)
+    : null
+
+  const save = async (next: string | null) => {
+    setStatus('saving')
+    try {
+      await setIssueDefaultAgent(next)
+      setStatus('saved')
+      window.setTimeout(() => setStatus('idle'), 1800)
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PageHeader
+        title="Issue Settings"
+        description="Defaults for scheduled issue runs and issue-owned headless work."
+      />
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8">
+        <div className="mx-auto max-w-[880px]">
+          <ConfigSection
+            title="Default agent runtime"
+            description="Used when an issue does not set its own agent frontmatter. Explicit issue runtime overrides still win."
+          >
+            <Field
+              label="Agent runtime"
+              description={
+                workspaceDefault
+                  ? `Unset uses the workspace session default (${workspaceDefault.displayName}), then the workspace's first enabled runtime.`
+                  : "Unset uses the workspace's first enabled runtime."
+              }
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <div className="relative flex-1">
+                  <Bot
+                    size={14}
+                    aria-hidden
+                    className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-muted/60"
+                  />
+                  <select
+                    value={issueDefaultAgent ?? ''}
+                    disabled={status === 'saving'}
+                    onChange={(event) => void save(event.target.value || null)}
+                    className={`${inputClass} pl-9`}
+                  >
+                    <option value="">Use workspace default</option>
+                    {runtimeAgents.map((agent) => (
+                      <option key={agent.id} value={agent.id}>
+                        {agent.displayName}{agent.installed === false ? ' (missing)' : ''}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <SaveIndicator status={status} />
+              </div>
+            </Field>
+          </ConfigSection>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -58,6 +58,7 @@ export function UrlAdopter() {
         <Route path="/settings" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'general' } }} />} />
         <Route path="/settings/ai-provider" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'ai-provider' } }} />} />
         <Route path="/settings/trading" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'trading' } }} />} />
+        <Route path="/settings/issues" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'issues' } }} />} />
         <Route path="/settings/mcp" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'mcp' } }} />} />
         <Route path="/settings/market-data" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'market-data' } }} />} />
         <Route path="/settings/news-collector" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'news-collector' } }} />} />

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -5,6 +5,7 @@ import type { ViewKind, ViewSpec } from './types'
 import { PortfolioPage } from '../pages/PortfolioPage'
 import { TradingAsGitPage } from '../pages/TradingAsGitPage'
 import { IssuePage } from '../pages/IssuePage'
+import { IssueSettingsPage } from '../pages/IssueSettingsPage'
 import { IssueDetailPage } from '../pages/IssueDetailPage'
 import { TrackedIssueDetailPage } from '../pages/TrackedIssueDetailPage'
 import { AutomationPage } from '../pages/AutomationPage'
@@ -245,6 +246,7 @@ const settingsCategoryTitle: Record<
   general: 'Settings',
   'ai-provider': 'AI Provider',
   trading: 'Trading',
+  issues: 'Issues',
   mcp: 'MCP Server',
   'market-data': 'Market Data',
   'news-collector': 'News Sources',
@@ -255,6 +257,7 @@ function SettingsRouter({ spec }: ViewProps<'settings'>) {
     case 'general': return <SettingsPage />
     case 'ai-provider': return <AIProviderPage />
     case 'trading': return <TradingPage />
+    case 'issues': return <IssueSettingsPage />
     case 'mcp': return <MCPPage />
     case 'market-data': return <MarketDataPage />
     case 'news-collector': return <NewsCollectorPage />

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -31,7 +31,7 @@ export type ViewSpec =
   | { kind: 'market-rotation'; params: Record<string, never> }
   | { kind: 'market-board';   params: { board: 'movers' | 'calendar' | 'macro' | 'term-structure' | 'global-macro' | 'shipping' | 'fed' } }
   | { kind: 'market-detail';  params: { assetClass: 'equity' | 'crypto' | 'currency' | 'commodity'; symbol: string; source?: string } }
-  | { kind: 'settings';       params: { category: 'general' | 'ai-provider' | 'trading' | 'mcp' | 'market-data' | 'news-collector' } }
+  | { kind: 'settings';       params: { category: 'general' | 'ai-provider' | 'trading' | 'issues' | 'mcp' | 'market-data' | 'news-collector' } }
   | { kind: 'uta-detail';     params: { id: string } }
   | { kind: 'dev';            params: { tab: 'tools' | 'snapshots' | 'logs' | 'simulator' } }
   | { kind: 'inbox';               params: Record<string, never> }


### PR DESCRIPTION
## Summary

- Add a separate issue default agent runtime setting for scheduled/headless issue runs.
- Add Settings -> Issues plus a gear entry from the Issues board.
- Resolve issue runtime display and scheduler fallback as: issue override -> issue default -> workspace default -> first workspace runtime.

## Why

Issue automation often wants a cheaper headless runtime such as Pi while interactive chat keeps using Codex or Claude. Keeping this separate avoids changing the user's normal workspace/session default just to route scheduled issue work.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm vitest run src/webui/routes/config-workspace-defaults.spec.ts src/workspaces/schedule/scanner.spec.ts`
- `pnpm test`
- In-app browser: verified `/issues` settings entry opens `/settings/issues` and the default runtime picker renders.