### PR TITLE
[codex] desktop update prompt

### DIFF
--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -1,7 +1,15 @@
-import { app, dialog, shell, type BrowserWindow } from 'electron'
+import { app, ipcMain, shell, type BrowserWindow } from 'electron'
 import electronUpdater from 'electron-updater'
 
 const { autoUpdater } = electronUpdater
+
+type UpdaterStatus = {
+  phase: 'available' | 'downloading' | 'downloaded' | 'error'
+  version?: string
+  percent?: number
+  releaseUrl?: string
+  message?: string
+}
 
 export interface AutoUpdateHooks {
   beforeInstall: () => Promise<void>
@@ -9,6 +17,40 @@ export interface AutoUpdateHooks {
 
 export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks): void {
   if (!app.isPackaged) return
+
+  let downloadedVersion: string | null = null
+  let latestStatus: UpdaterStatus | null = null
+
+  const releaseUrlFor = (version: string): string =>
+    `https://github.com/TraderAlice/OpenAlice/releases/tag/v${version}`
+
+  const sendStatus = (status: UpdaterStatus) => {
+    latestStatus = status
+    if (win.isDestroyed()) return
+    win.webContents.send('openalice:updater:status', status)
+  }
+
+  ipcMain.removeHandler('openalice:updater:get-status')
+  ipcMain.handle('openalice:updater:get-status', () => latestStatus)
+
+  ipcMain.removeHandler('openalice:updater:install-and-restart')
+  ipcMain.handle('openalice:updater:install-and-restart', async () => {
+    if (!downloadedVersion) throw new Error('No downloaded update is ready to install.')
+    await hooks.beforeInstall()
+    autoUpdater.quitAndInstall(false, true)
+    return { ok: true }
+  })
+
+  ipcMain.removeHandler('openalice:updater:open-release')
+  ipcMain.handle('openalice:updater:open-release', async (_event, version: unknown) => {
+    const target = typeof version === 'string' && version.length > 0 ? version : downloadedVersion
+    if (!target) {
+      await shell.openExternal('https://github.com/TraderAlice/OpenAlice/releases')
+      return { ok: true }
+    }
+    await shell.openExternal(releaseUrlFor(target))
+    return { ok: true }
+  })
 
   autoUpdater.autoDownload = true
   autoUpdater.autoInstallOnAppQuit = false
@@ -22,6 +64,7 @@ export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks):
 
   autoUpdater.on('update-available', (info) => {
     console.log(`[updater] update available: ${info.version}`)
+    sendStatus({ phase: 'available', version: info.version, releaseUrl: releaseUrlFor(info.version) })
   })
 
   autoUpdater.on('update-not-available', (info) => {
@@ -30,39 +73,12 @@ export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks):
 
   autoUpdater.on('download-progress', (progress) => {
     console.log(`[updater] downloading ${progress.percent.toFixed(1)}%`)
+    sendStatus({ phase: 'downloading', percent: progress.percent })
   })
 
   autoUpdater.on('update-downloaded', (info) => {
-    void dialog
-      .showMessageBox(win, {
-        type: 'info',
-        title: 'OpenAlice — update ready',
-        message: `OpenAlice ${info.version} is ready to install.`,
-        detail: 'Restart OpenAlice to install the update. Running UTA and Alice child processes will be stopped gracefully first.',
-        buttons: ['Restart now', 'Later', 'View release'],
-        defaultId: 0,
-        cancelId: 1,
-      })
-      .then(async ({ response }) => {
-        if (response === 2) {
-          const releaseUrl = `https://github.com/TraderAlice/OpenAlice/releases/tag/v${info.version}`
-          void shell.openExternal(releaseUrl)
-          return
-        }
-        if (response !== 0) return
-        try {
-          await hooks.beforeInstall()
-          autoUpdater.quitAndInstall(false, true)
-        } catch (err) {
-          console.error('[updater] failed to prepare update install:', err)
-          await dialog.showMessageBox(win, {
-            type: 'error',
-            title: 'OpenAlice — update install failed',
-            message: 'OpenAlice could not prepare for the update.',
-            detail: err instanceof Error ? err.message : String(err),
-          })
-        }
-      })
+    downloadedVersion = info.version
+    sendStatus({ phase: 'downloaded', version: info.version, releaseUrl: releaseUrlFor(info.version) })
   })
 
   void autoUpdater.checkForUpdates().catch((err) => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -21,7 +21,14 @@ interface PtyListeners {
   readonly close: Set<(msg: { code: number; reason: string }) => void>
 }
 
+type UpdaterStatus =
+  | { phase: 'available'; version?: string; releaseUrl?: string }
+  | { phase: 'downloading'; version?: string; percent?: number }
+  | { phase: 'downloaded'; version: string; releaseUrl: string }
+  | { phase: 'error'; message: string }
+
 const ptyListeners = new Map<string, PtyListeners>()
+const updaterListeners = new Set<(status: UpdaterStatus) => void>()
 
 function randomId(): string {
   return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
@@ -63,9 +70,55 @@ ipcRenderer.on('openalice:pty:server-event', (_event, raw: unknown) => {
   }
 })
 
+ipcRenderer.on('openalice:updater:status', (_event, raw: unknown) => {
+  if (!raw || typeof raw !== 'object') return
+  const rec = raw as Record<string, unknown>
+  const phase = rec['phase']
+  if (phase === 'downloaded') {
+    const version = typeof rec['version'] === 'string' ? rec['version'] : ''
+    const releaseUrl = typeof rec['releaseUrl'] === 'string' ? rec['releaseUrl'] : ''
+    if (!version || !releaseUrl) return
+    for (const cb of updaterListeners) cb({ phase, version, releaseUrl })
+    return
+  }
+  if (phase === 'error') {
+    const message = typeof rec['message'] === 'string' ? rec['message'] : 'Update check failed.'
+    for (const cb of updaterListeners) cb({ phase, message })
+    return
+  }
+  if (phase === 'available') {
+    for (const cb of updaterListeners) {
+      cb({
+        phase,
+        ...(typeof rec['version'] === 'string' ? { version: rec['version'] } : {}),
+        ...(typeof rec['releaseUrl'] === 'string' ? { releaseUrl: rec['releaseUrl'] } : {}),
+      })
+    }
+    return
+  }
+  if (phase === 'downloading') {
+    for (const cb of updaterListeners) {
+      cb({
+        phase,
+        ...(typeof rec['version'] === 'string' ? { version: rec['version'] } : {}),
+        ...(typeof rec['percent'] === 'number' ? { percent: rec['percent'] } : {}),
+      })
+    }
+  }
+})
+
 const api = {
   runtime: {
     info: () => ipcRenderer.invoke('openalice:runtime:info'),
+  },
+  updater: {
+    getStatus: () => ipcRenderer.invoke('openalice:updater:get-status'),
+    onStatus: (cb: (status: UpdaterStatus) => void) => {
+      updaterListeners.add(cb)
+      return () => updaterListeners.delete(cb)
+    },
+    installAndRestart: () => ipcRenderer.invoke('openalice:updater:install-and-restart'),
+    openRelease: (version?: string) => ipcRenderer.invoke('openalice:updater:open-release', version),
   },
   workspace: {
     listFiles: (input: { id: string; path: string }) =>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { ActivityBar } from './components/ActivityBar'
 import { TabHost } from './components/TabHost'
+import { DesktopUpdatePrompt } from './components/DesktopUpdatePrompt'
 import { UpdateBanner } from './components/UpdateBanner'
 import { DemoBanner } from './demo/DemoBanner'
 import { DemoAnalytics } from './demo/DemoAnalytics'
@@ -101,6 +102,7 @@ function AppShell() {
       {import.meta.env.VITE_DEMO_MODE && <DemoBanner />}
       {import.meta.env.VITE_DEMO_MODE && <DemoAnalytics />}
       <UpdateBanner />
+      <DesktopUpdatePrompt />
       <div className="flex flex-1 min-h-0">
         <ActivityBar
           open={sidebarOpen}

--- a/ui/src/components/DesktopUpdatePrompt.tsx
+++ b/ui/src/components/DesktopUpdatePrompt.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+import { Download, ExternalLink, RefreshCcw, X } from 'lucide-react'
+import { Dialog } from './uta/Dialog'
+
+type UpdateStatus =
+  | { phase: 'available'; version?: string; releaseUrl?: string }
+  | { phase: 'downloading'; version?: string; percent?: number }
+  | { phase: 'downloaded'; version: string; releaseUrl: string }
+  | { phase: 'error'; message: string }
+
+function previewStatus(): UpdateStatus | null {
+  if (!import.meta.env.DEV || typeof window === 'undefined') return null
+  const params = new URLSearchParams(window.location.search)
+  if (params.get('updatePrompt') !== '1') return null
+  const version = params.get('updateVersion') || '0.74.0-beta'
+  return {
+    phase: 'downloaded',
+    version,
+    releaseUrl: `https://github.com/TraderAlice/OpenAlice/releases/tag/v${version}`,
+  }
+}
+
+export function DesktopUpdatePrompt() {
+  const [status, setStatus] = useState<UpdateStatus | null>(() => previewStatus())
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const updater = window.openAlice?.updater
+    if (!updater) return
+
+    void updater.getStatus()
+      .then((next) => {
+        if (next?.phase === 'downloaded') setStatus(next)
+      })
+      .catch(() => {})
+
+    return updater.onStatus((next) => {
+      if (next.phase !== 'downloaded') return
+      setError(null)
+      setStatus(next)
+    })
+  }, [])
+
+  if (status?.phase !== 'downloaded') return null
+
+  const handleInstall = async () => {
+    const updater = window.openAlice?.updater
+    if (!updater) {
+      setStatus(null)
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      await updater.installAndRestart()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setBusy(false)
+    }
+  }
+
+  const handleRelease = async () => {
+    const updater = window.openAlice?.updater
+    if (updater) {
+      await updater.openRelease(status.version)
+      return
+    }
+    window.open(status.releaseUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <Dialog onClose={busy ? () => {} : () => setStatus(null)} width="w-[480px]">
+      <div className="px-5 py-4 border-b border-border flex items-center gap-3">
+        <div className="h-9 w-9 rounded-lg border border-accent/30 bg-accent-dim/30 text-accent flex items-center justify-center shrink-0">
+          <Download size={18} strokeWidth={1.8} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-[15px] font-semibold text-text leading-snug">Update ready</h2>
+          <p className="text-[12px] text-text-muted truncate">OpenAlice v{status.version}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setStatus(null)}
+          disabled={busy}
+          className="h-8 w-8 rounded-md text-text-muted hover:text-text hover:bg-bg-tertiary disabled:opacity-40 flex items-center justify-center transition-colors"
+          aria-label="Close update prompt"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      <div className="px-5 py-4 space-y-3">
+        <p className="text-[13px] leading-relaxed text-text">
+          The update has been downloaded and is ready to install.
+        </p>
+        <p className="text-[12px] leading-relaxed text-text-muted">
+          Restarting will stop Alice and UTA gracefully, then reopen OpenAlice on the new version.
+        </p>
+        {error && (
+          <div className="rounded-lg border border-red/30 bg-red/10 px-3 py-2 text-[12px] leading-relaxed text-red">
+            {error}
+          </div>
+        )}
+      </div>
+
+      <div className="px-5 py-3 border-t border-border flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => setStatus(null)}
+          disabled={busy}
+          className="btn-secondary"
+        >
+          Later
+        </button>
+        <button
+          type="button"
+          onClick={handleRelease}
+          disabled={busy}
+          className="btn-secondary inline-flex items-center justify-center gap-2"
+        >
+          <ExternalLink size={14} />
+          View release
+        </button>
+        <button
+          type="button"
+          onClick={handleInstall}
+          disabled={busy}
+          className="btn-primary inline-flex items-center justify-center gap-2"
+        >
+          <RefreshCcw size={14} />
+          {busy ? 'Preparing...' : 'Restart now'}
+        </button>
+      </div>
+    </Dialog>
+  )
+}

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -3,6 +3,7 @@ import { api } from '../api'
 import type { VersionInfo } from '../api/types'
 
 const SKIP_STORAGE_KEY = 'openalice.update.skipVersion'
+type RuntimeMode = 'browser' | 'electron-dev' | 'electron-packaged'
 
 /**
  * Top-of-app banner shown when GitHub Releases reports a version newer
@@ -15,17 +16,19 @@ const SKIP_STORAGE_KEY = 'openalice.update.skipVersion'
  *    when a newer version is released.
  *  - "×" close — session-only dismiss (until next page load).
  *
- * Self-hosted source distribution: when the user wants to actually
- * update, they run `git pull && pnpm build && restart` in their
- * terminal. We don't auto-execute (Electron auto-update will
- * eventually handle that path natively).
+ * The action text is runtime-aware: source/Docker installs update from git,
+ * while packaged Electron is handled by the native auto-updater.
  */
 export function UpdateBanner() {
   const [info, setInfo] = useState<VersionInfo | null>(null)
+  const [runtimeMode, setRuntimeMode] = useState<RuntimeMode>('browser')
   const [sessionDismissed, setSessionDismissed] = useState(false)
 
   useEffect(() => {
     api.version.get().then(setInfo).catch(() => {})
+    window.openAlice?.runtime.info()
+      .then((runtime) => setRuntimeMode(runtime.mode))
+      .catch(() => setRuntimeMode('browser'))
   }, [])
 
   if (!info || !info.hasUpdate || !info.latest) return null
@@ -54,15 +57,21 @@ export function UpdateBanner() {
         </svg>
       </span>
       <span className="flex-1 min-w-0 truncate">
-        <span className="font-semibold">v{info.latest}</span> is available
-        {' '}<span className="text-text-muted">(you have v{info.current})</span>
+        <span className="font-semibold">v{info.latest}</span> available
+        {' '}<span className="text-text-muted hidden sm:inline">(you have v{info.current})</span>
         {info.publishedAt && (
-          <span className="text-text-muted"> · released {info.publishedAt.slice(0, 10)}</span>
+          <span className="text-text-muted hidden lg:inline"> · released {info.publishedAt.slice(0, 10)}</span>
         )}
       </span>
-      <span className="text-text-muted shrink-0 hidden md:inline">
-        Run <code className="text-accent bg-bg-tertiary px-1 rounded">git pull &amp;&amp; pnpm build</code> to update
-      </span>
+      {runtimeMode === 'electron-packaged' ? (
+        <span className="text-text-muted shrink-0 hidden md:inline">
+          Desktop updater will prompt when the download is ready
+        </span>
+      ) : (
+        <span className="text-text-muted shrink-0 hidden md:inline">
+          Run <code className="text-accent bg-bg-tertiary px-1 rounded">git pull &amp;&amp; pnpm build</code> to update
+        </span>
+      )}
       {info.releaseUrl && (
         <a
           href={info.releaseUrl}
@@ -70,7 +79,9 @@ export function UpdateBanner() {
           rel="noopener noreferrer"
           className="text-accent hover:underline shrink-0"
         >
-          Release notes →
+          <span className="hidden sm:inline">Release notes</span>
+          <span className="sm:hidden">Notes</span>
+          {' '}→
         </a>
       )}
       <button
@@ -78,7 +89,8 @@ export function UpdateBanner() {
         className="text-text-muted hover:text-text shrink-0 text-[11px]"
         title="Don't show this update again"
       >
-        Skip this version
+        <span className="hidden sm:inline">Skip this version</span>
+        <span className="sm:hidden">Skip</span>
       </button>
       <button
         onClick={handleDismiss}
@@ -94,4 +106,3 @@ export function UpdateBanner() {
     </div>
   )
 }
-

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -32,6 +32,23 @@ interface Window {
         appHome: string
       }>
     }
+    readonly updater?: {
+      getStatus(): Promise<
+        | { phase: 'available'; version?: string; releaseUrl?: string }
+        | { phase: 'downloading'; version?: string; percent?: number }
+        | { phase: 'downloaded'; version: string; releaseUrl: string }
+        | { phase: 'error'; message: string }
+        | null
+      >
+      onStatus(cb: (status:
+        | { phase: 'available'; version?: string; releaseUrl?: string }
+        | { phase: 'downloading'; version?: string; percent?: number }
+        | { phase: 'downloaded'; version: string; releaseUrl: string }
+        | { phase: 'error'; message: string }
+      ) => void): () => void
+      installAndRestart(): Promise<unknown>
+      openRelease(version?: string): Promise<unknown>
+    }
     readonly workspace: {
       listFiles(input: { id: string; path: string }): Promise<{
         path: string


### PR DESCRIPTION
## Summary

- Replace the packaged Electron native update-ready dialog with a renderer-owned OpenAlice modal.
- Add a narrow updater IPC/preload bridge for status, release links, and restart/install actions.
- Make the global update banner runtime-aware and more responsive on narrow widths.

## Why

Packaged Electron should not tell users to run `git pull && pnpm build`, and the native OS dialog was not styleable enough for the app experience. The updater now keeps Electron main responsible for update/install side effects while the renderer owns the user-facing prompt.

## Validation

- `cd ui && npx tsc -b`
- `pnpm -F @traderalice/desktop typecheck`
- `pnpm -F @traderalice/desktop build`
- `npx tsc --noEmit`
- `pnpm test`
- `git diff --check`
- Browser preview at `http://127.0.0.1:5173/chat?updatePrompt=1` across desktop, 430px, 360px, and 320px widths
