### PR TITLE
[codex] tune ActivityBar responsive breakpoints

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -37,13 +37,15 @@ function useMediaQuery(query: string): boolean {
 /**
  * Three breakpoints drive the responsive shell:
  *  - <768  (phone):  rail = drawer (hamburger), sidebar = drawer (drill-in)
- *  - 768–1179 (narrow desktop): rail = compact static icon column.
+ *  - 768–959 (small desktop): rail = compact static icon column.
  *    Page-owned sidebars stay static here, so the business navigator does not
  *    disappear just because the app is in a partial-width browser window.
- *  - ≥1180 (roomy desktop): rail can expand to text labels.
+ *  - 960–1279 (narrow desktop): rail keeps text labels in a slimmer column.
+ *  - ≥1280 (roomy desktop): rail gets its full text width.
  */
 const useIsDesktop = () => useMediaQuery('(min-width: 768px)') // rail static
-const useIsRoomy = () => useMediaQuery('(min-width: 1180px)') // text rail allowed
+const useHasRailText = () => useMediaQuery('(min-width: 960px)') // text rail allowed
+const useHasFullRail = () => useMediaQuery('(min-width: 1280px)') // full rail width
 
 export function App() {
   return (
@@ -59,7 +61,9 @@ function AppShell() {
   useLocale()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const isDesktop = useIsDesktop() // ≥768 — rail is a static column
-  const isRoomy = useIsRoomy() // ≥1180 — full text rail is allowed
+  const hasRailText = useHasRailText() // ≥960 — text rail is allowed
+  const hasFullRail = useHasFullRail() // ≥1280 — full rail width
+  const railMode = !isDesktop ? 'full' : hasFullRail ? 'full' : hasRailText ? 'narrow' : 'compact'
 
   // When the rail becomes a static column, drop its mobile drawer state.
   useEffect(() => {
@@ -108,7 +112,7 @@ function AppShell() {
           open={sidebarOpen}
           onClose={() => setSidebarOpen(false)}
           desktopStatic={isDesktop}
-          compactRailForced={isDesktop && !isRoomy}
+          railMode={railMode}
         />
         <div className="flex-1 min-h-0">
           {mainContent}

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,5 +1,5 @@
 import { type LucideIcon, MessageSquare, Inbox, Telescope, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Info, ListChecks, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
 import type { ActivitySection, ViewSpec } from '../tabs/types'
@@ -129,6 +129,20 @@ const NAV_SECTIONS: NavSection[] = [
   },
 ]
 
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia(query).matches : false,
+  )
+  useEffect(() => {
+    const mq = window.matchMedia(query)
+    const handler = () => setMatches(mq.matches)
+    setMatches(mq.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [query])
+  return matches
+}
+
 // ==================== ActivityBar ====================
 
 /**
@@ -162,6 +176,8 @@ export function ActivityBar({
   const railCollapsed = useActivityBarCollapse((s) => s.railCollapsed)
   const setRailCollapsed = useActivityBarCollapse((s) => s.setRailCollapsed)
   const compactRail = desktopStatic && (compactRailForced || railCollapsed)
+  const shortRailHeight = useMediaQuery('(max-height: 700px)')
+  const denseRail = compactRail && shortRailHeight
 
   return (
     <>
@@ -187,18 +203,18 @@ export function ActivityBar({
       >
         {/* Branding — h-10 to line up with the Sidebar header + TabStrip
             (all three top surfaces share the 40px header rhythm). */}
-        <div className={`h-10 mb-2 flex items-center shrink-0 ${compactRail ? 'pl-[22px] pr-4 gap-2.5 md:gap-0 md:pr-0' : 'pl-[22px] pr-4 gap-2.5'}`}>
+        <div className={`${denseRail ? 'h-10 mb-2 md:h-7 md:mb-0.5' : 'h-10 mb-2'} flex items-center shrink-0 ${compactRail ? 'pl-[22px] pr-4 gap-2.5 md:gap-0 md:pr-0' : 'pl-[22px] pr-4 gap-2.5'}`}>
           <img
             src="/alice.ico"
             alt="Alice"
-            className="w-6 h-6 shrink-0 rounded-full ring-1 ring-border shadow-[0_0_14px_var(--color-accent-dim)]"
+            className={`${denseRail ? 'w-6 h-6 md:w-5 md:h-5' : 'w-6 h-6'} shrink-0 rounded-full ring-1 ring-border shadow-[0_0_14px_var(--color-accent-dim)]`}
             draggable={false}
           />
           <h1 className={`min-w-0 flex-1 truncate text-[15px] font-semibold text-text ${compactRail ? 'md:hidden' : ''}`}>OpenAlice</h1>
         </div>
 
         {/* Navigation */}
-        <nav className={`flex-1 flex flex-col overflow-x-hidden overflow-y-auto pb-3 ${compactRail ? 'px-3 md:items-start' : 'px-3'}`}>
+        <nav className={`flex-1 flex flex-col overflow-x-hidden overflow-y-auto ${denseRail ? 'pb-3 md:pb-0.5' : 'pb-3'} ${compactRail ? 'px-3 md:items-start' : 'px-3'}`}>
           {NAV_SECTIONS.map((section, si) => {
             const labeled = section.sectionLabel.length > 0
             // User toggle wins over default. The collapse store stores
@@ -215,11 +231,11 @@ export function ActivityBar({
                 key={si}
                 className={
                   compactRail && si > 0
-                    ? 'mt-3 border-t border-border/70 pt-3 md:w-11'
+                    ? `${denseRail ? 'mt-3 pt-3 md:mt-0.5 md:pt-0.5 md:w-8' : 'mt-3 pt-3 md:w-11'} border-t border-border/70`
                     : si > 0
                       ? 'mt-4'
                       : compactRail
-                        ? 'md:w-11'
+                        ? denseRail ? 'md:w-8' : 'md:w-11'
                         : ''
                 }
               >
@@ -238,7 +254,7 @@ export function ActivityBar({
                   />
                 )}
                 {showItems && (
-                  <div className="flex flex-col gap-1" id={`activity-section-${si}`}>
+                  <div className={`flex flex-col ${denseRail ? 'gap-1 md:gap-px' : 'gap-1'}`} id={`activity-section-${si}`}>
                     {section.items.map((item) => {
                       const sec = activitySectionFor(item.page)
                       const isActive = selectedSidebar === sec
@@ -256,7 +272,9 @@ export function ActivityBar({
                           title={t(item.labelKey)}
                           className={`relative flex min-h-[34px] items-center rounded-md text-[13px] transition-colors text-left ${
                             compactRail
-                              ? 'md:h-9 md:w-11 md:min-h-9 md:justify-center md:gap-0 md:px-0 md:py-0'
+                              ? denseRail
+                                ? 'md:h-[26px] md:w-8 md:min-h-[26px] md:justify-center md:gap-0 md:px-0 md:py-0'
+                                : 'md:h-9 md:w-11 md:min-h-9 md:justify-center md:gap-0 md:px-0 md:py-0'
                               : 'gap-3 px-3 py-1.5'
                           } ${
                             isActive
@@ -266,13 +284,13 @@ export function ActivityBar({
                         >
                           {/* Active indicator — left vertical bar */}
                           <span
-                            className={`absolute left-0 top-1.5 bottom-1.5 w-[2px] rounded-r-full bg-accent transition-opacity duration-150 ${
+                            className={`absolute left-0 ${denseRail ? 'top-1.5 bottom-1.5 md:top-0.5 md:bottom-0.5' : 'top-1.5 bottom-1.5'} w-[2px] rounded-r-full bg-accent transition-opacity duration-150 ${
                               isActive ? 'opacity-100' : 'opacity-0'
                             }`}
                             aria-hidden
                           />
-                          <span className="relative flex items-center justify-center w-5 h-5 shrink-0">
-                            <Icon size={16} strokeWidth={1.75} />
+                          <span className={`relative flex items-center justify-center w-5 h-5 shrink-0 ${denseRail ? 'md:w-3.5 md:h-3.5' : ''}`}>
+                            <Icon size={denseRail ? 14 : 16} strokeWidth={1.75} />
                           </span>
                           <span className={`flex-1 truncate ${compactRail ? 'md:hidden' : ''}`}>{t(item.labelKey)}</span>
                           {item.page === 'inbox' && unreadInbox > 0 && (
@@ -306,19 +324,19 @@ export function ActivityBar({
         </nav>
 
         {/* Footer — global icon controls pinned to the bottom of the rail. */}
-        <div className={`shrink-0 px-4 flex items-center ${compactRail ? 'py-2 md:flex-col md:items-start md:px-4 md:gap-1' : 'border-t border-border py-1.5 justify-between gap-2'}`}>
-          <ThemeToggle />
+        <div className={`shrink-0 px-4 flex items-center ${compactRail ? `${denseRail ? 'py-2 md:py-0.5 md:gap-px' : 'py-2 md:gap-1'} md:flex-col md:items-start md:px-4` : 'border-t border-border py-1.5 justify-between gap-2'}`}>
+          <ThemeToggle compact={denseRail} />
           {!compactRailForced && (
             <button
               type="button"
               onClick={() => setRailCollapsed(!railCollapsed)}
               title={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
               aria-label={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
-              className="hidden h-9 w-9 shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text md:flex"
+              className={`hidden ${denseRail ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text md:flex`}
             >
               {railCollapsed
-                ? <PanelLeftOpen size={17} strokeWidth={1.75} aria-hidden />
-                : <PanelLeftClose size={17} strokeWidth={1.75} aria-hidden />}
+                ? <PanelLeftOpen size={denseRail ? 14 : 17} strokeWidth={1.75} aria-hidden />
+                : <PanelLeftClose size={denseRail ? 14 : 17} strokeWidth={1.75} aria-hidden />}
             </button>
           )}
         </div>

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -35,6 +35,8 @@ interface ActivityBarProps {
   onClose: () => void
   /** True once the rail is static (>= md). The compact rail is desktop-only. */
   desktopStatic?: boolean
+  /** Static desktop rail width chosen by App's shell breakpoints. */
+  railMode?: 'compact' | 'narrow' | 'full'
   /** Force the static rail into icon-only mode at narrow desktop widths. */
   compactRailForced?: boolean
 }
@@ -163,6 +165,7 @@ export function ActivityBar({
   open,
   onClose,
   desktopStatic = true,
+  railMode = 'full',
   compactRailForced = false,
 }: ActivityBarProps) {
   const { t } = useTranslation()
@@ -175,9 +178,14 @@ export function ActivityBar({
   const setCollapsed = useActivityBarCollapse((s) => s.setCollapsed)
   const railCollapsed = useActivityBarCollapse((s) => s.railCollapsed)
   const setRailCollapsed = useActivityBarCollapse((s) => s.setRailCollapsed)
-  const compactRail = desktopStatic && (compactRailForced || railCollapsed)
   const shortRailHeight = useMediaQuery('(max-height: 700px)')
-  const denseRail = compactRail && shortRailHeight
+  const veryShortRailHeight = useMediaQuery('(max-height: 520px)')
+  const forcedCompactRail = desktopStatic && (
+    compactRailForced || railMode === 'compact' || veryShortRailHeight
+  )
+  const compactRail = desktopStatic && (forcedCompactRail || railCollapsed)
+  const narrowRail = desktopStatic && railMode === 'narrow' && !compactRail
+  const denseRail = desktopStatic && shortRailHeight
 
   return (
     <>
@@ -193,7 +201,7 @@ export function ActivityBar({
        *  page with backdrop. Desktop: static column flush left. */}
       <aside
         className={`
-          w-[280px] ${compactRail ? 'md:w-[60px]' : 'md:w-[188px]'} h-full flex flex-col shrink-0
+          w-[280px] ${compactRail ? 'md:w-[60px]' : narrowRail ? 'md:w-[152px]' : 'md:w-[188px]'} h-full flex flex-col shrink-0
           bg-bg-tertiary
           border-r border-border/80
           fixed z-50 top-0 left-0 transition-[transform,width] duration-200
@@ -203,7 +211,7 @@ export function ActivityBar({
       >
         {/* Branding — h-10 to line up with the Sidebar header + TabStrip
             (all three top surfaces share the 40px header rhythm). */}
-        <div className={`${denseRail ? 'h-10 mb-2 md:h-7 md:mb-0.5' : 'h-10 mb-2'} flex items-center shrink-0 ${compactRail ? 'pl-[22px] pr-4 gap-2.5 md:gap-0 md:pr-0' : 'pl-[22px] pr-4 gap-2.5'}`}>
+        <div className={`${denseRail ? 'h-10 mb-2 md:h-7 md:mb-0.5' : 'h-10 mb-2'} flex items-center shrink-0 ${compactRail ? 'pl-[22px] pr-4 gap-2.5 md:gap-0 md:pr-0' : narrowRail ? 'pl-[18px] pr-3 gap-2' : 'pl-[22px] pr-4 gap-2.5'}`}>
           <img
             src="/alice.ico"
             alt="Alice"
@@ -214,7 +222,7 @@ export function ActivityBar({
         </div>
 
         {/* Navigation */}
-        <nav className={`flex-1 flex flex-col overflow-x-hidden overflow-y-auto ${denseRail ? 'pb-3 md:pb-0.5' : 'pb-3'} ${compactRail ? 'px-3 md:items-start' : 'px-3'}`}>
+        <nav className={`flex-1 flex flex-col overflow-x-hidden overflow-y-auto ${denseRail ? 'pb-3 md:pb-0.5' : 'pb-3'} ${compactRail ? 'px-3 md:items-start' : narrowRail ? 'px-2.5' : 'px-3'}`}>
           {NAV_SECTIONS.map((section, si) => {
             const labeled = section.sectionLabel.length > 0
             // User toggle wins over default. The collapse store stores
@@ -233,7 +241,7 @@ export function ActivityBar({
                   compactRail && si > 0
                     ? `${denseRail ? 'mt-3 pt-3 md:mt-0.5 md:pt-0.5 md:w-8' : 'mt-3 pt-3 md:w-11'} border-t border-border/70`
                     : si > 0
-                      ? 'mt-4'
+                      ? denseRail ? 'mt-2' : 'mt-4'
                       : compactRail
                         ? denseRail ? 'md:w-8' : 'md:w-11'
                         : ''
@@ -270,12 +278,14 @@ export function ActivityBar({
                           type="button"
                           onClick={handleClick}
                           title={t(item.labelKey)}
-                          className={`relative flex min-h-[34px] items-center rounded-md text-[13px] transition-colors text-left ${
+                          className={`relative flex items-center rounded-md transition-colors text-left ${
                             compactRail
                               ? denseRail
                                 ? 'md:h-[26px] md:w-8 md:min-h-[26px] md:justify-center md:gap-0 md:px-0 md:py-0'
                                 : 'md:h-9 md:w-11 md:min-h-9 md:justify-center md:gap-0 md:px-0 md:py-0'
-                              : 'gap-3 px-3 py-1.5'
+                              : denseRail
+                                ? `min-h-[28px] ${narrowRail ? 'gap-2 px-2' : 'gap-2.5 px-2.5'} py-1 text-[12px]`
+                                : `min-h-[34px] ${narrowRail ? 'gap-2 px-2.5' : 'gap-3 px-3'} py-1.5 text-[13px]`
                           } ${
                             isActive
                               ? 'bg-accent-dim text-text'
@@ -324,9 +334,9 @@ export function ActivityBar({
         </nav>
 
         {/* Footer — global icon controls pinned to the bottom of the rail. */}
-        <div className={`shrink-0 px-4 flex items-center ${compactRail ? `${denseRail ? 'py-2 md:py-0.5 md:gap-px' : 'py-2 md:gap-1'} md:flex-col md:items-start md:px-4` : 'border-t border-border py-1.5 justify-between gap-2'}`}>
+        <div className={`shrink-0 flex items-center ${compactRail ? `${denseRail ? 'py-2 md:py-0.5 md:gap-px' : 'py-2 md:gap-1'} px-4 md:flex-col md:items-start md:px-4` : `${narrowRail ? 'px-3' : 'px-4'} border-t border-border py-1.5 justify-between gap-2`}`}>
           <ThemeToggle compact={denseRail} />
-          {!compactRailForced && (
+          {!forcedCompactRail && (
             <button
               type="button"
               onClick={() => setRailCollapsed(!railCollapsed)}

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -21,7 +21,7 @@ const NEXT: Record<AppTheme, AppTheme> = {
   dark: 'auto',
 }
 
-export function ThemeToggle() {
+export function ThemeToggle({ compact = false }: { compact?: boolean }) {
   const { t } = useTranslation()
   const theme = useThemeStore((s) => s.theme)
   const cycle = useThemeStore((s) => s.cycleTheme)
@@ -34,12 +34,12 @@ export function ThemeToggle() {
       onClick={cycle}
       title={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
       aria-label={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
-      className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
+      className={`relative flex ${compact ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text`}
     >
-      <Icon size={17} strokeWidth={1.75} aria-hidden />
+      <Icon size={compact ? 14 : 17} strokeWidth={1.75} aria-hidden />
       {theme === 'auto' && (
         <span
-          className="absolute right-0 top-0 rounded-[3px] border border-border bg-bg-tertiary px-[2px] py-px text-[7px] font-semibold leading-none text-text-muted shadow-sm"
+          className={`absolute right-0 top-0 rounded-[3px] border border-border bg-bg-tertiary px-[2px] py-px text-[7px] ${compact ? 'md:text-[6px]' : ''} font-semibold leading-none text-text-muted shadow-sm`}
           aria-hidden
         >
           Auto


### PR DESCRIPTION
## Summary

- Split the desktop ActivityBar into stepped rail modes: compact icon rail below 960px, narrow text rail from 960px to 1279px, and full text rail at 1280px and up.
- Keep the short-height dense rail behavior, but let text rails tighten their spacing before falling back to icon-only at very short heights.
- Preserve the manual collapse affordance whenever the rail is not forced compact by width or height.

## Why

The previous desktop breakpoint compressed every window below 1180px into icon-only mode, which made medium-width containers feel over-constrained. The rail now has a middle state, so partial-width desktop windows can keep labels without stealing the full sidebar width. Extremely short windows still get the dense icon rail to avoid an internal rail scrollbar.

## Validation

- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test`
- `git diff --check`
- Demo-mode browser measurements at 900, 959, 960, 1100, 1279, and 1280px widths
- Demo-mode browser measurements at 1177x559, 1100x520, and 1100x440; rail nav does not overflow
