### PR TITLE
[codex] Fix inbox markdown comment rendering

### DIFF
--- a/ui/src/components/MarkdownContent.spec.ts
+++ b/ui/src/components/MarkdownContent.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderMarkdownHtml } from './MarkdownContent'
+
+describe('renderMarkdownHtml', () => {
+  it('keeps GFM strikethrough enabled by default', () => {
+    const html = renderMarkdownHtml('Keep ~~this~~ struck.')
+
+    expect(html).toContain('<del>this</del>')
+  })
+
+  it('can disable strikethrough for financial agent comments', () => {
+    const html = renderMarkdownHtml(
+      'Tough stock at ~$197 — wait for reclaim-and-hold 50d (~$188); value lower.',
+      { strikethrough: false },
+    )
+
+    expect(html).not.toContain('<del>')
+    expect(html).toContain('~$197')
+    expect(html).toContain('(~$188)')
+  })
+
+  it('preserves other GFM inline behavior when strikethrough is disabled', () => {
+    const html = renderMarkdownHtml('Source: http://example.com and [[stock-glw]].', {
+      strikethrough: false,
+    })
+
+    expect(html).toContain('<a href="http://example.com">http://example.com</a>')
+    expect(html).toContain('class="wikilink"')
+  })
+
+  it('keeps exact code-span wikilinks as code by default', () => {
+    const html = renderMarkdownHtml('Tracked `[[stock-glw]]`.')
+
+    expect(html).toContain('<code>[[stock-glw]]</code>')
+    expect(html).not.toContain('class="wikilink"')
+  })
+
+  it('can render exact code-span wikilinks as entity links for inbox comments', () => {
+    const html = renderMarkdownHtml('Tracked `[[stock-glw]]` + `[[ai-data-center-power]]`.', {
+      codeSpanWikilinks: true,
+      strikethrough: false,
+    })
+
+    expect(html).not.toContain('<code>')
+    expect(html).toContain('data-entity="stock-glw"')
+    expect(html).toContain('data-entity="ai-data-center-power"')
+  })
+})

--- a/ui/src/components/MarkdownContent.tsx
+++ b/ui/src/components/MarkdownContent.tsx
@@ -33,38 +33,64 @@ function escapeHtml(s: string): string {
  * are case-insensitive); MarkdownContent delegates the actual navigation
  * on click so this module stays a pure string renderer.
  */
-const wikilinkExtension: TokenizerAndRendererExtension = {
-  name: 'wikilink',
-  level: 'inline',
-  start(src: string) {
-    return src.indexOf('[[')
-  },
-  tokenizer(src: string) {
-    const m = /^\[\[([^[\]\n]+)\]\]/.exec(src)
-    if (!m) return undefined
-    return { type: 'wikilink', raw: m[0], text: m[1]!.trim() }
-  },
-  renderer(token) {
-    const name = token.text as string
-    const key = name.toLowerCase()
-    return `<a class="wikilink" data-entity="${escapeHtml(key)}">${escapeHtml(name)}</a>`
-  },
+function createWikilinkExtension(opts: { codeSpanWikilinks: boolean }): TokenizerAndRendererExtension {
+  return {
+    name: 'wikilink',
+    level: 'inline',
+    start(src: string) {
+      const plain = src.indexOf('[[')
+      if (!opts.codeSpanWikilinks) return plain
+      const quoted = src.indexOf('`[[')
+      if (plain < 0) return quoted
+      if (quoted < 0) return plain
+      return Math.min(plain, quoted)
+    },
+    tokenizer(src: string) {
+      const quoted = opts.codeSpanWikilinks ? /^`\[\[([^[\]\n]+)\]\]`/.exec(src) : null
+      if (quoted) return { type: 'wikilink', raw: quoted[0], text: quoted[1]!.trim() }
+      const plain = /^\[\[([^[\]\n]+)\]\]/.exec(src)
+      if (!plain) return undefined
+      return { type: 'wikilink', raw: plain[0], text: plain[1]!.trim() }
+    },
+    renderer(token) {
+      const name = token.text as string
+      const key = name.toLowerCase()
+      return `<a class="wikilink" data-entity="${escapeHtml(key)}">${escapeHtml(name)}</a>`
+    },
+  }
 }
 
-// Shared Marked instance (parser config is stateless — safe to reuse).
-const marked = new Marked(
-  markedHighlight({
-    langPrefix: 'hljs language-',
-    highlight(code, lang) {
-      if (lang && hljs.getLanguage(lang)) {
-        return hljs.highlight(code, { language: lang }).value
-      }
-      return hljs.highlightAuto(code).value
-    },
-  }),
-  { breaks: true },
-)
-marked.use({ extensions: [wikilinkExtension] })
+function createMarked(opts: { strikethrough: boolean; codeSpanWikilinks: boolean }): Marked {
+  const instance = new Marked(
+    markedHighlight({
+      langPrefix: 'hljs language-',
+      highlight(code, lang) {
+        if (lang && hljs.getLanguage(lang)) {
+          return hljs.highlight(code, { language: lang }).value
+        }
+        return hljs.highlightAuto(code).value
+      },
+    }),
+    { breaks: true },
+  )
+  instance.use({ extensions: [createWikilinkExtension({ codeSpanWikilinks: opts.codeSpanWikilinks })] })
+  if (!opts.strikethrough) {
+    instance.use({
+      tokenizer: {
+        del() {
+          return undefined
+        },
+      },
+    })
+  }
+  return instance
+}
+
+// Shared Marked instances (parser config is stateless — safe to reuse).
+const markedWithStrikethrough = createMarked({ strikethrough: true, codeSpanWikilinks: false })
+const markedWithoutStrikethrough = createMarked({ strikethrough: false, codeSpanWikilinks: false })
+const markedWithCodeSpanWikilinks = createMarked({ strikethrough: true, codeSpanWikilinks: true })
+const markedComment = createMarked({ strikethrough: false, codeSpanWikilinks: true })
 
 const COPY_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`
 const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`
@@ -85,6 +111,16 @@ interface MarkdownContentProps {
   text: string
   className?: string
   /**
+   * GitHub-flavoured `~~delete~~` rendering. Disable on terse agent comments
+   * because financial prose often uses `~$123` for approximate prices.
+   */
+  strikethrough?: boolean
+  /**
+   * Treat an exact code span like `` `[[name]]` `` as a wikilink. Inbox
+   * comments often quote entity refs this way, but they should still navigate.
+   */
+  codeSpanWikilinks?: boolean
+  /**
    * Click handler for `[[name]]` wikilinks, receiving the lowercased entity
    * key. Defaults to jumping to the Tracked activity (see useWikilinkHandler).
    * Pass an explicit handler to override (e.g. tests, alternate surfaces).
@@ -92,15 +128,35 @@ interface MarkdownContentProps {
   onWikilink?: (entityKey: string) => void
 }
 
-export function MarkdownContent({ text, className, onWikilink }: MarkdownContentProps) {
+export function renderMarkdownHtml(
+  text: string,
+  opts: { strikethrough?: boolean; codeSpanWikilinks?: boolean } = {},
+): string {
+  const parser = opts.codeSpanWikilinks
+    ? opts.strikethrough === false
+      ? markedComment
+      : markedWithCodeSpanWikilinks
+    : opts.strikethrough === false
+      ? markedWithoutStrikethrough
+      : markedWithStrikethrough
+  const raw = DOMPurify.sanitize(parser.parse(text) as string)
+  return addCodeBlockWrappers(raw)
+}
+
+export function MarkdownContent({
+  text,
+  className,
+  strikethrough = true,
+  codeSpanWikilinks = false,
+  onWikilink,
+}: MarkdownContentProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const defaultWikilink = useWikilinkHandler()
   const wikilink = onWikilink ?? defaultWikilink
 
   const html = useMemo(() => {
-    const raw = DOMPurify.sanitize(marked.parse(text) as string)
-    return addCodeBlockWrappers(raw)
-  }, [text])
+    return renderMarkdownHtml(text, { strikethrough, codeSpanWikilinks })
+  }, [text, strikethrough, codeSpanWikilinks])
 
   const handleClick = useCallback(
     (e: MouseEvent) => {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -295,9 +295,11 @@ body {
    tuned empirically; candidate prose tier for the semantic scale. */
 .markdown-content {
   font-size: 15px;
+  overflow-wrap: break-word;
 }
 .markdown-content p {
   margin: 0.5em 0;
+  text-wrap: pretty;
 }
 .markdown-content p:first-child {
   margin-top: 0;
@@ -322,6 +324,9 @@ body {
   background: var(--color-bg-tertiary);
   padding: 2px 6px;
   border-radius: 4px;
+  overflow-wrap: anywhere;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 .markdown-content ul,
 .markdown-content ol {
@@ -337,15 +342,20 @@ body {
 }
 .markdown-content li {
   margin: 0.25em 0;
+  text-wrap: pretty;
 }
 .markdown-content li::marker {
   color: var(--color-text-muted);
 }
 /* Obsidian-style [[name]] wikilinks → clickable entity references. */
 .markdown-content a.wikilink {
+  display: inline-block;
+  max-width: 100%;
   color: var(--color-accent);
   cursor: pointer;
   text-decoration: none;
+  vertical-align: baseline;
+  overflow-wrap: anywhere;
   border-bottom: 1px dashed color-mix(in srgb, var(--color-accent) 45%, transparent);
 }
 .markdown-content a.wikilink:hover {
@@ -379,6 +389,7 @@ body {
 .markdown-content a {
   color: var(--color-accent);
   text-decoration: none;
+  overflow-wrap: anywhere;
 }
 .markdown-content a:hover {
   text-decoration: underline;

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -294,6 +294,8 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
         <div className={`${hasDocs ? 'mt-6 pt-6 border-t border-border' : ''}`}>
           <MarkdownContent
             text={entry.comments!}
+            strikethrough={false}
+            codeSpanWikilinks
             className="leading-relaxed text-text/90"
           />
         </div>


### PR DESCRIPTION
## Summary

- make Inbox comments tolerant of agent-written financial prose such as `~$197 ... (~$188)` so it no longer renders as strikethrough
- render exact code-span wikilinks like `` `[[stock-glw]]` `` as clickable entity links in Inbox comments
- tighten shared markdown wrapping rules so long inline code, URLs, and wikilinks do not create awkward or overflowing lines

## Why

Inbox comments are short agent-to-user messages, and agents commonly mix approximate prices, tracked entity refs, and inline Markdown. The old renderer let GFM strikethrough and code spans produce misleading visual output: approximate-price text became `<del>`, and entity refs became wide code chips instead of navigable links.

## Validation

- `pnpm exec vitest run ui/src/components/MarkdownContent.spec.ts --project ui`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `git diff --check`
- browser-verified `/inbox`: no `<del>`/`<s>` nodes, code-span entity refs render as three wikilinks, and 760px width has no horizontal overflow