### PR TITLE
Fix reference board and portfolio edge cases

### DIFF
--- a/src/core/entity-backlinks.spec.ts
+++ b/src/core/entity-backlinks.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { scanBacklinks } from './entity-backlinks.js'
+import { normalizeBacklinkPath, scanBacklinks } from './entity-backlinks.js'
 import type { WorkspaceRegistry } from '../workspaces/workspace-registry.js'
 
 function fakeRegistry(workspaces: { id: string; tag: string; dir: string }[]): WorkspaceRegistry {
@@ -43,7 +43,7 @@ describe('scanBacklinks', () => {
     // vst: power.md (deduped from two mentions) + rotation/jun.md — never the
     // CLAUDE.md / .git / .txt files. All in ws1.
     const vst = map.get('vst') ?? []
-    expect(vst.map((b) => b.path).sort()).toEqual(['power.md', join('rotation', 'jun.md')].sort())
+    expect(vst.map((b) => b.path).sort()).toEqual(['power.md', 'rotation/jun.md'].sort())
     expect(vst.every((b) => b.workspaceId === 'id1')).toBe(true)
 
     // gev spans both workspaces.
@@ -54,7 +54,7 @@ describe('scanBacklinks', () => {
 
     // dashed topic name resolves.
     expect((map.get('ai-data-center-power') ?? []).map((b) => b.path)).toEqual([
-      join('rotation', 'jun.md'),
+      'rotation/jun.md',
     ])
 
     // Nothing leaked from scaffolding: vst has exactly two backlinks.
@@ -79,8 +79,8 @@ describe('scanBacklinks', () => {
     // [[vst]] resolves, and its backlink path is the issue-note path (so the UI
     // can detect issue-notes by the `.alice/issues/` prefix).
     const vst = map.get('vst') ?? []
-    expect(vst.map((b) => b.path)).toEqual([join('.alice', 'issues', 'morning-scan.md')])
-    expect(map.get('refactor-fetcher')?.[0]?.path).toBe(join('.alice', 'issues', 'cleanup.md'))
+    expect(vst.map((b) => b.path)).toEqual(['.alice/issues/morning-scan.md'])
+    expect(map.get('refactor-fetcher')?.[0]?.path).toBe('.alice/issues/cleanup.md')
     // Nothing leaked from .alice/other or .claude.
     expect(map.has('ghost')).toBe(false)
   })
@@ -91,5 +91,10 @@ describe('scanBacklinks', () => {
     await writeFile(join(ws, 'plain.md'), 'no links here, just prose')
     const map = await scanBacklinks(fakeRegistry([{ id: 'id', tag: 'ws', dir: ws }]))
     expect(map.size).toBe(0)
+  })
+
+  it('normalizes Windows separators so UI path-prefix checks are portable', () => {
+    expect(normalizeBacklinkPath(String.raw`.alice\issues\morning-scan.md`)).toBe('.alice/issues/morning-scan.md')
+    expect(normalizeBacklinkPath(String.raw`rotation\jun.md`)).toBe('rotation/jun.md')
   })
 })

--- a/src/core/entity-backlinks.ts
+++ b/src/core/entity-backlinks.ts
@@ -37,6 +37,10 @@ export interface Backlink {
 const WIKILINK_RE = /\[\[([^[\]\n]+)\]\]/g
 const SKIP_FILES = new Set(['CLAUDE.md', 'AGENTS.md', 'README.md'])
 
+export function normalizeBacklinkPath(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
 async function listMarkdown(root: string): Promise<string[]> {
   const out: string[] = []
 
@@ -47,7 +51,7 @@ async function listMarkdown(root: string): Promise<string[]> {
     const entries = await readdir(abs, { withFileTypes: true }).catch(() => [])
     for (const e of entries) {
       if (e.isFile() && e.name.endsWith('.md') && !SKIP_FILES.has(e.name)) {
-        out.push(relative(root, join(abs, e.name)))
+        out.push(normalizeBacklinkPath(relative(root, join(abs, e.name))))
       }
     }
   }
@@ -68,7 +72,7 @@ async function listMarkdown(root: string): Promise<string[]> {
         }
         await walk(child)
       } else if (e.isFile() && e.name.endsWith('.md') && !SKIP_FILES.has(e.name)) {
-        out.push(relative(root, child))
+        out.push(normalizeBacklinkPath(relative(root, child)))
       }
     }
   }

--- a/src/domain/market-data/reference/macro.spec.ts
+++ b/src/domain/market-data/reference/macro.spec.ts
@@ -43,6 +43,23 @@ describe('macro board', () => {
     expect(cpi.unit).toBe('percent')
   })
 
+  it('derives CPI YoY by matching the same date one year earlier, not by row offset', async () => {
+    const rows = mkRows().filter((r) => r.date !== '2025-10-01')
+    const board = await fetchMacroBoard(mkEconomyClient(rows))
+    const cpi = board.cards.find((c) => c.id === 'CPI_YOY')!
+    const nov = cpi.points.find((p) => p.date === '2025-11-01')
+
+    expect(nov?.value).toBeCloseTo(3, 5)
+  })
+
+  it('skips CPI YoY points when the matching prior-year date is absent', async () => {
+    const rows = mkRows().filter((r) => r.date !== '2024-11-01')
+    const board = await fetchMacroBoard(mkEconomyClient(rows))
+    const cpi = board.cards.find((c) => c.id === 'CPI_YOY')!
+
+    expect(cpi.points.some((p) => p.date === '2025-11-01')).toBe(false)
+  })
+
   it('propagates the upstream failure (missing FRED key) loudly', async () => {
     const client = { fredSeries: async () => { throw new Error('FRED api_key required') } } as unknown as EconomyClientLike
     await expect(fetchMacroBoard(client)).rejects.toThrow(/FRED/)

--- a/src/domain/market-data/reference/macro.ts
+++ b/src/domain/market-data/reference/macro.ts
@@ -47,6 +47,25 @@ const CPI_INDEX = 'CPIAUCSL'
 
 const MAX_POINTS = 90
 
+function sameDatePreviousYear(date: string): string | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date)
+  if (!m) return null
+  return `${Number(m[1]) - 1}-${m[2]}-${m[3]}`
+}
+
+function deriveCpiYoy(cpi: MacroPoint[]): MacroPoint[] {
+  const byDate = new Map(cpi.map((p) => [p.date, p.value]))
+  const out: MacroPoint[] = []
+  for (const p of cpi) {
+    const baseDate = sameDatePreviousYear(p.date)
+    if (!baseDate) continue
+    const base = byDate.get(baseDate)
+    if (typeof base !== 'number' || !Number.isFinite(base) || base === 0) continue
+    out.push({ date: p.date, value: ((p.value / base) - 1) * 100 })
+  }
+  return out
+}
+
 export async function fetchMacroBoard(economyClient: EconomyClientLike): Promise<MacroBoard> {
   // 2 years of history: enough for a 12-month YoY base plus a sparkline.
   const start = new Date()
@@ -80,11 +99,10 @@ export async function fetchMacroBoard(economyClient: EconomyClientLike): Promise
 
   const cards = CURATED.map((s) => card(s, pointsOf(s.id)))
 
-  // CPI YoY — monthly index, so YoY = value 12 observations back.
+  // CPI YoY — monthly index; match the same calendar observation one year
+  // earlier instead of assuming FRED returned a gap-free monthly sequence.
   const cpi = pointsOf(CPI_INDEX)
-  const yoy: MacroPoint[] = cpi
-    .map((p, i) => (i >= 12 ? { date: p.date, value: ((p.value / cpi[i - 12].value) - 1) * 100 } : null))
-    .filter((p): p is MacroPoint => p !== null)
+  const yoy = deriveCpiYoy(cpi)
   cards.splice(5, 0, card({ id: 'CPI_YOY', label: 'CPI YoY', unit: 'percent' }, yoy))
 
   return {

--- a/ui/src/components/market/useReferenceBoard.spec.ts
+++ b/ui/src/components/market/useReferenceBoard.spec.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useReferenceBoard } from './useReferenceBoard'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('useReferenceBoard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('marks a cold first load as slow after the configured threshold', async () => {
+    const pending = deferred<{ ok: true }>()
+    const fetcher = vi.fn(() => pending.promise)
+    const { result } = renderHook(() => useReferenceBoard(fetcher, 60_000, { slowMs: 100 }))
+
+    expect(result.current.loading).toBe(true)
+    expect(result.current.slow).toBe(false)
+
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(result.current.loading).toBe(true)
+    expect(result.current.slow).toBe(true)
+
+    await act(async () => {
+      pending.resolve({ ok: true })
+      await pending.promise
+    })
+
+    expect(result.current.data).toEqual({ ok: true })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.slow).toBe(false)
+  })
+
+  it('does not flash slow when the first load resolves before the threshold', async () => {
+    const pending = deferred<{ rows: number[] }>()
+    const fetcher = vi.fn(() => pending.promise)
+    const { result } = renderHook(() => useReferenceBoard(fetcher, 60_000, { slowMs: 100 }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(50)
+      pending.resolve({ rows: [1] })
+      await pending.promise
+    })
+
+    expect(result.current.data).toEqual({ rows: [1] })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.slow).toBe(false)
+  })
+
+  it('surfaces errors and lets callers retry', async () => {
+    const fetcher = vi
+      .fn<() => Promise<{ value: number }>>()
+      .mockRejectedValueOnce(new Error('calendar failed'))
+      .mockResolvedValueOnce({ value: 42 })
+
+    const { result } = renderHook(() => useReferenceBoard(fetcher, 60_000, { slowMs: 100 }))
+
+    await act(async () => {
+      await flushPromises()
+    })
+
+    expect(result.current.error).toBe('calendar failed')
+    expect(result.current.loading).toBe(false)
+    expect(result.current.slow).toBe(false)
+
+    await act(async () => {
+      await result.current.retry()
+    })
+
+    expect(result.current.data).toEqual({ value: 42 })
+    expect(result.current.error).toBeNull()
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+})

--- a/ui/src/components/market/useReferenceBoard.ts
+++ b/ui/src/components/market/useReferenceBoard.ts
@@ -1,37 +1,62 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 /**
  * The one fetch-and-poll hook for board-shaped data — replaces the
  * hand-rolled useState×4 + useEffect + setInterval block every board view
  * used to copy. Polling (not SSE) per the low-frequency-surface rule.
  */
-export function useReferenceBoard<T>(fetcher: () => Promise<T>, refreshMs: number) {
+export function useReferenceBoard<T>(
+  fetcher: () => Promise<T>,
+  refreshMs: number,
+  options: { slowMs?: number } = {},
+) {
   const [data, setData] = useState<T | null>(null)
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
   const [loading, setLoading] = useState(true)
+  const [slow, setSlow] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const dataRef = useRef<T | null>(null)
+  const aliveRef = useRef(true)
+  const slowMs = options.slowMs ?? 5_000
 
-  useEffect(() => {
-    let alive = true
-    const load = async () => {
-      try {
-        const res = await fetcher()
-        if (!alive) return
-        setData(res)
-        setUpdatedAt(new Date())
-        setError(null)
-      } catch (err) {
-        if (!alive) return
-        setError(err instanceof Error ? err.message : 'Failed to load')
-      } finally {
-        if (alive) setLoading(false)
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    let slowTimer: ReturnType<typeof setTimeout> | null = null
+    if (dataRef.current == null) {
+      setSlow(false)
+      slowTimer = setTimeout(() => {
+        if (aliveRef.current && dataRef.current == null) setSlow(true)
+      }, slowMs)
+    }
+    try {
+      const res = await fetcher()
+      if (!aliveRef.current) return
+      dataRef.current = res
+      setData(res)
+      setUpdatedAt(new Date())
+      setError(null)
+    } catch (err) {
+      if (!aliveRef.current) return
+      setError(err instanceof Error ? err.message : 'Failed to load')
+    } finally {
+      if (slowTimer) clearTimeout(slowTimer)
+      if (aliveRef.current) {
+        setLoading(false)
+        setSlow(false)
       }
     }
+  }, [fetcher, slowMs])
+
+  useEffect(() => {
+    aliveRef.current = true
     load()
     const timer = setInterval(load, refreshMs)
-    return () => { alive = false; clearInterval(timer) }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetcher is a stable module-level api fn
-  }, [refreshMs])
+    return () => {
+      aliveRef.current = false
+      clearInterval(timer)
+    }
+  }, [load, refreshMs])
 
-  return { data, updatedAt, loading, error }
+  return { data, updatedAt, loading, slow, error, retry: load }
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -147,6 +147,7 @@ export const en = {
     logs: 'Logs',
     off: 'off',
     delete: 'Delete',
+    retry: 'Retry',
   },
   chat: {
     newChat: 'New chat',
@@ -408,6 +409,7 @@ export const en = {
     colDollarVolume: '$ Volume',
     boardCalendar: 'Calendar',
     calendarSubtitle: 'Upcoming earnings, IPOs and ex-dividend dates.',
+    calendarSlowLoading: 'Still fetching the calendar — first load can take a while.',
     calEarnings: 'Earnings',
     calIpos: 'IPOs',
     calDividends: 'Dividends',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -136,6 +136,7 @@ export const ja: Resources = {
     logs: 'ログ',
     off: 'オフ',
     delete: '削除',
+    retry: '再試行',
   },
   chat: {
     newChat: '新しいチャット',
@@ -397,6 +398,7 @@ export const ja: Resources = {
     colDollarVolume: '売買代金',
     boardCalendar: 'カレンダー',
     calendarSubtitle: '今後の決算・IPO・権利落ち日。',
+    calendarSlowLoading: 'カレンダーを取得中です。初回読み込みには少し時間がかかる場合があります。',
     calEarnings: '決算',
     calIpos: 'IPO',
     calDividends: '配当',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -144,6 +144,7 @@ export const zhHant: Resources = {
     logs: '日誌',
     off: '關閉',
     delete: '刪除',
+    retry: '重試',
   },
   chat: {
     newChat: '新對話',
@@ -405,6 +406,7 @@ export const zhHant: Resources = {
     colDollarVolume: '成交額',
     boardCalendar: '財經日曆',
     calendarSubtitle: '近期財報、IPO 與除息日。',
+    calendarSlowLoading: '財經日曆仍在載入，首次開啟可能需要久一點。',
     calEarnings: '財報',
     calIpos: 'IPO',
     calDividends: '股息',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -136,6 +136,7 @@ export const zh: Resources = {
     logs: '日志',
     off: '关闭',
     delete: '删除',
+    retry: '重试',
   },
   chat: {
     newChat: '新对话',
@@ -397,6 +398,7 @@ export const zh: Resources = {
     colDollarVolume: '成交额',
     boardCalendar: '财经日历',
     calendarSubtitle: '近期财报、IPO 与除息日。',
+    calendarSlowLoading: '财经日历仍在加载，首次打开可能需要久一点。',
     calEarnings: '财报',
     calIpos: 'IPO',
     calDividends: '分红',

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -155,7 +155,7 @@ type CalendarList = 'earnings' | 'ipos' | 'dividends'
 
 function CalendarBoardView() {
   const { t } = useTranslation()
-  const { data, updatedAt, loading, error } = useReferenceBoard<CalendarBoard>(referenceApi.calendar, 30 * 60 * 1000)
+  const { data, updatedAt, loading, slow, error, retry } = useReferenceBoard<CalendarBoard>(referenceApi.calendar, 30 * 60 * 1000)
   const [list, setList] = useState<CalendarList>('earnings')
 
   return (
@@ -188,9 +188,20 @@ function CalendarBoardView() {
           ))}
         </div>
 
-        {loading && !data && <CenteredLoading label={t('common.loading')} />}
+        {loading && !data && (
+          <CenteredLoading label={slow ? t('market.calendarSlowLoading') : t('common.loading')} />
+        )}
         {error && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{error}</div>
+          <div className="flex items-center justify-between gap-3 text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">
+            <span className="min-w-0 break-words">{error}</span>
+            <button
+              type="button"
+              onClick={retry}
+              className="shrink-0 text-[12px] font-medium text-red hover:text-red/80"
+            >
+              {t('common.retry')}
+            </button>
+          </div>
         )}
         {/* Per-list upstream failure — loud, with the provider's own message. */}
         {data?.errors?.[list] && (

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -15,6 +15,7 @@ import { contractPrimary } from '../lib/contract-display'
 import { displayProviderForUTA, filterAccountTierUTAs } from '../lib/uta-account-filter'
 import { TradingModeGate } from '../components/TradingModeGate'
 import { ensureTradingModePolling, useTradingMode } from '../live/trading-mode'
+import { computeTodayDelta, type CurvePointSummary } from './portfolio-metrics'
 
 // ==================== Types ====================
 
@@ -54,8 +55,8 @@ const EMPTY: PortfolioData = { equity: null, accounts: [], fxRates: [] }
 const CUTOFF_24H_MS = 24 * 60 * 60 * 1000
 
 interface CurveSummary {
-  total: { values: number[]; firstAtCutoff: number | null; latest: number | null }
-  perAccount: Record<string, { values: number[]; firstAtCutoff: number | null; latest: number | null }>
+  total: CurvePointSummary
+  perAccount: Record<string, CurvePointSummary>
 }
 
 /** Trailing-24h baseline + sparkline values, both at the aggregate level
@@ -391,7 +392,7 @@ function NoAccountsEmpty() {
 
 function HeroMetrics({ equity, curve }: {
   equity: AggregatedEquity | null
-  curve: { values: number[]; firstAtCutoff: number | null; latest: number | null } | null
+  curve: CurvePointSummary | null
 }) {
   if (!equity) {
     return (
@@ -409,12 +410,11 @@ function HeroMetrics({ equity, curve }: {
   // Today PnL — same shape as TradingPage hero. Suppress when no baseline
   // is available yet (fresh portfolio with no 24h history).
   let todayDelta: { value: string; sign: 'up' | 'down' | 'flat' } | undefined
-  if (curve && curve.latest != null && curve.firstAtCutoff != null) {
-    const delta = curve.latest - curve.firstAtCutoff
-    const pct = curve.firstAtCutoff !== 0 ? (delta / curve.firstAtCutoff) * 100 : 0
+  const computedTodayDelta = computeTodayDelta(curve)
+  if (computedTodayDelta) {
     todayDelta = {
-      value: `${fmtPnl(delta, 'USD')} (${fmtPctSigned(pct)}) today`,
-      sign: signFromDelta(delta),
+      value: `${fmtPnl(computedTodayDelta.delta, 'USD')} (${fmtPctSigned(computedTodayDelta.pct)}) today`,
+      sign: computedTodayDelta.sign,
     }
   }
 
@@ -512,7 +512,7 @@ const HEALTH_DOT: Record<string, string> = {
 
 function AccountStrip({ sources, perAccountCurve }: {
   sources: Array<{ id: string; label: string; provider: string; equity: string; unrealizedPnL: number; error?: string; health?: string; disabled?: boolean; connecting?: boolean }>
-  perAccountCurve: Record<string, { values: number[]; firstAtCutoff: number | null; latest: number | null }>
+  perAccountCurve: Record<string, CurvePointSummary>
 }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
@@ -529,9 +529,7 @@ function AccountStrip({ sources, perAccountCurve }: {
             : (HEALTH_DOT[s.health ?? 'healthy'] ?? 'bg-text-muted')
 
         const curve = perAccountCurve[s.id]
-        const todayDelta = curve && curve.latest != null && curve.firstAtCutoff != null
-          ? curve.latest - curve.firstAtCutoff
-          : null
+        const todayDelta = computeTodayDelta(curve ?? null)
         const showSpark = !isDisabled && !isOffline && !isConnecting && curve && curve.values.length >= 2
 
         return (
@@ -553,9 +551,9 @@ function AccountStrip({ sources, perAccountCurve }: {
                     ? <span className="text-red text-[11px]">Reconnecting…</span>
                     : (
                       <span className="text-[11px] tabular-nums">
-                        {todayDelta != null && Number.isFinite(todayDelta) ? (
-                          <span className={todayDelta >= 0 ? 'text-green' : 'text-red'}>
-                            {todayDelta >= 0 ? '▲' : '▼'} {fmtPnl(todayDelta)} today
+                        {todayDelta ? (
+                          <span className={todayDelta.delta >= 0 ? 'text-green' : 'text-red'}>
+                            {todayDelta.delta >= 0 ? '▲' : '▼'} {fmtPnl(todayDelta.delta)} today
                           </span>
                         ) : s.unrealizedPnL !== 0 ? (
                           <span className={s.unrealizedPnL >= 0 ? 'text-green' : 'text-red'}>

--- a/ui/src/pages/portfolio-metrics.spec.ts
+++ b/ui/src/pages/portfolio-metrics.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeTodayDelta } from './portfolio-metrics'
+
+describe('computeTodayDelta', () => {
+  it('computes delta and percent from a positive baseline', () => {
+    expect(computeTodayDelta({ firstAtCutoff: 100, latest: 110 })).toEqual({
+      delta: 10,
+      pct: 10,
+      sign: 'up',
+    })
+    expect(computeTodayDelta({ firstAtCutoff: 100, latest: 95 })).toEqual({
+      delta: -5,
+      pct: -5,
+      sign: 'down',
+    })
+  })
+
+  it('keeps a zero move visible when the baseline is valid', () => {
+    expect(computeTodayDelta({ firstAtCutoff: 100, latest: 100 })).toEqual({
+      delta: 0,
+      pct: 0,
+      sign: 'flat',
+    })
+  })
+
+  it('suppresses missing, zero, negative and non-finite baselines', () => {
+    expect(computeTodayDelta(null)).toBeNull()
+    expect(computeTodayDelta({ firstAtCutoff: null, latest: 100 })).toBeNull()
+    expect(computeTodayDelta({ firstAtCutoff: 0, latest: 100 })).toBeNull()
+    expect(computeTodayDelta({ firstAtCutoff: -10, latest: 100 })).toBeNull()
+    expect(computeTodayDelta({ firstAtCutoff: Number.NaN, latest: 100 })).toBeNull()
+    expect(computeTodayDelta({ firstAtCutoff: 100, latest: Number.POSITIVE_INFINITY })).toBeNull()
+  })
+})

--- a/ui/src/pages/portfolio-metrics.ts
+++ b/ui/src/pages/portfolio-metrics.ts
@@ -1,0 +1,25 @@
+export type CurvePointSummary = {
+  values: number[]
+  firstAtCutoff: number | null
+  latest: number | null
+}
+
+export type TodayDelta = {
+  delta: number
+  pct: number
+  sign: 'up' | 'down' | 'flat'
+}
+
+export function computeTodayDelta(curve: Pick<CurvePointSummary, 'firstAtCutoff' | 'latest'> | null): TodayDelta | null {
+  if (!curve || curve.latest == null || curve.firstAtCutoff == null) return null
+  const latest = Number(curve.latest)
+  const baseline = Number(curve.firstAtCutoff)
+  if (!Number.isFinite(latest) || !Number.isFinite(baseline) || baseline <= 0) return null
+
+  const delta = latest - baseline
+  return {
+    delta,
+    pct: (delta / baseline) * 100,
+    sign: delta > 0 ? 'up' : delta < 0 ? 'down' : 'flat',
+  }
+}


### PR DESCRIPTION
## Summary

- Normalize tracked backlink paths to POSIX separators so Windows issue-note backlinks still match UI prefix checks.
- Derive Macro CPI YoY from the same calendar date one year earlier instead of assuming FRED rows are gap-free.
- Suppress Portfolio daily PnL when the trailing-24h baseline is missing, zero, negative, or non-finite.
- Add Calendar board cold-start slow-load feedback plus a retry action for load failures.

## Validation

- `pnpm exec vitest run src/core/entity-backlinks.spec.ts src/domain/market-data/reference/macro.spec.ts ui/src/pages/portfolio-metrics.spec.ts ui/src/components/market/useReferenceBoard.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test`
