### PR TITLE
Bundle fd with the managed desktop runtime

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,15 +29,15 @@ import {
   type RuntimeProcessLock,
 } from '@traderalice/guardian-runtime'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
-import { existsSync, statSync } from 'node:fs'
 import { mkdir, readFile, watch } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { homedir } from 'node:os'
-import { delimiter, dirname, join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { probeFreePort } from './probe-port.js'
 import { relocateLegacyData } from './relocate-data.js'
 import { configureAutoUpdate } from './auto-update.js'
 import { fetchAliceWebRequest, handleOpenAliceIpcMessage, registerOpenAliceIpc } from './ipc.js'
+import { resolveManagedRuntimeEnv } from './managed-runtime.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -157,91 +157,6 @@ function truthyEnv(raw: string | undefined): boolean {
   if (raw === undefined || raw === '') return false
   const normalized = raw.toLowerCase()
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on'
-}
-
-function existingFile(path: string): string | null {
-  try {
-    return existsSync(path) && statSync(path).isFile() ? path : null
-  } catch {
-    return null
-  }
-}
-
-function existingDir(path: string): string | null {
-  try {
-    return existsSync(path) && statSync(path).isDirectory() ? path : null
-  } catch {
-    return null
-  }
-}
-
-function resolveManagedRuntimeEnv(opts: {
-  readonly appHome: string
-  readonly launcherMode: 'electron-dev' | 'electron-packaged'
-}): Record<string, string> {
-  const out: Record<string, string> = {
-    OPENALICE_RUNTIME_PROFILE: opts.launcherMode,
-  }
-  const platformArch = `${process.platform}-${process.arch}`
-
-  const managedPiCli = existingFile(join(
-    opts.appHome,
-    'vendor',
-    'pi',
-    'node_modules',
-    '@earendil-works',
-    'pi-coding-agent',
-    'dist',
-    'cli.js',
-  ))
-  const managedPiBinary = existingFile(join(
-    opts.appHome,
-    'vendor',
-    'pi',
-    platformArch,
-    process.platform === 'win32' ? 'pi.exe' : 'pi',
-  ))
-  if (managedPiCli) {
-    out.OPENALICE_MANAGED_PI_PATH = managedPiCli
-    out.OPENALICE_MANAGED_PI_NODE_PATH = process.execPath
-  } else if (managedPiBinary) {
-    out.OPENALICE_MANAGED_PI_PATH = managedPiBinary
-  }
-
-  const toolchainPaths: string[] = []
-  if (process.platform === 'win32') {
-    const gitDir = existingDir(join(opts.appHome, 'vendor', 'git', platformArch))
-    if (gitDir) {
-      out.OPENALICE_MANAGED_GIT_DIR = gitDir
-      out.LOCAL_GIT_DIRECTORY = gitDir
-
-      const gitBin =
-        existingFile(join(gitDir, 'cmd', 'git.exe')) ??
-        existingFile(join(gitDir, 'bin', 'git.exe')) ??
-        existingFile(join(gitDir, 'mingw64', 'bin', 'git.exe')) ??
-        existingFile(join(gitDir, 'clangarm64', 'bin', 'git.exe'))
-      if (gitBin) out.OPENALICE_MANAGED_GIT_BIN = gitBin
-
-      const shellPath =
-        existingFile(join(gitDir, 'bin', 'bash.exe')) ??
-        existingFile(join(gitDir, 'usr', 'bin', 'bash.exe'))
-      if (shellPath) out.OPENALICE_MANAGED_SHELL_PATH = shellPath
-
-      for (const rel of ['cmd', 'bin', 'usr/bin', 'mingw64/bin', 'clangarm64/bin']) {
-        const dir = existingDir(join(gitDir, ...rel.split('/')))
-        if (dir) toolchainPaths.push(dir)
-      }
-    }
-  } else if (opts.launcherMode === 'electron-packaged') {
-    const shellPath = existingFile('/bin/bash') ?? existingFile('/bin/sh')
-    if (shellPath) out.OPENALICE_MANAGED_SHELL_PATH = shellPath
-  }
-
-  if (toolchainPaths.length > 0) {
-    out.OPENALICE_MANAGED_TOOLCHAIN_PATH = toolchainPaths.join(delimiter)
-  }
-
-  return out
 }
 
 function isLiteModeEnv(env: NodeJS.ProcessEnv): boolean {

--- a/apps/desktop/src/managed-runtime.spec.ts
+++ b/apps/desktop/src/managed-runtime.spec.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveManagedRuntimeEnv } from './managed-runtime.js'
+
+function touch(path: string) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, '')
+}
+
+describe('resolveManagedRuntimeEnv', () => {
+  it('exposes packaged Pi and managed fd through the toolchain path', () => {
+    const appHome = mkdtempSync(join(tmpdir(), 'openalice-managed-runtime-'))
+    try {
+      const piCli = join(
+        appHome,
+        'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
+      )
+      const fdDir = join(appHome, 'vendor/tools/darwin-arm64')
+      touch(piCli)
+      touch(join(fdDir, 'fd'))
+
+      const env = resolveManagedRuntimeEnv({
+        appHome,
+        launcherMode: 'electron-packaged',
+        platform: 'darwin',
+        arch: 'arm64',
+        execPath: '/Applications/OpenAlice.app/Contents/MacOS/OpenAlice',
+      })
+
+      expect(env.OPENALICE_RUNTIME_PROFILE).toBe('electron-packaged')
+      expect(env.OPENALICE_MANAGED_PI_PATH).toBe(piCli)
+      expect(env.OPENALICE_MANAGED_PI_NODE_PATH)
+        .toBe('/Applications/OpenAlice.app/Contents/MacOS/OpenAlice')
+      expect(env.OPENALICE_MANAGED_TOOLCHAIN_PATH).toBe(fdDir)
+    } finally {
+      rmSync(appHome, { recursive: true, force: true })
+    }
+  })
+
+  it('does not advertise an empty managed tools directory', () => {
+    const appHome = mkdtempSync(join(tmpdir(), 'openalice-managed-runtime-empty-'))
+    try {
+      mkdirSync(join(appHome, 'vendor/tools/darwin-arm64'), { recursive: true })
+
+      const env = resolveManagedRuntimeEnv({
+        appHome,
+        launcherMode: 'electron-dev',
+        platform: 'darwin',
+        arch: 'arm64',
+      })
+
+      expect(env.OPENALICE_MANAGED_TOOLCHAIN_PATH).toBeUndefined()
+    } finally {
+      rmSync(appHome, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps managed fd ahead of the existing Windows Git toolchain', () => {
+    const appHome = mkdtempSync(join(tmpdir(), 'openalice-managed-runtime-win-'))
+    try {
+      const fdDir = join(appHome, 'vendor/tools/win32-x64')
+      const gitDir = join(appHome, 'vendor/git/win32-x64')
+      touch(join(fdDir, 'fd.exe'))
+      touch(join(gitDir, 'cmd/git.exe'))
+      touch(join(gitDir, 'bin/bash.exe'))
+      mkdirSync(join(gitDir, 'usr/bin'), { recursive: true })
+      mkdirSync(join(gitDir, 'mingw64/bin'), { recursive: true })
+
+      const env = resolveManagedRuntimeEnv({
+        appHome,
+        launcherMode: 'electron-packaged',
+        platform: 'win32',
+        arch: 'x64',
+      })
+
+      expect(env.OPENALICE_MANAGED_GIT_BIN).toBe(join(gitDir, 'cmd/git.exe'))
+      expect(env.OPENALICE_MANAGED_SHELL_PATH).toBe(join(gitDir, 'bin/bash.exe'))
+      expect(env.OPENALICE_MANAGED_TOOLCHAIN_PATH?.split(delimiter)).toEqual([
+        fdDir,
+        join(gitDir, 'cmd'),
+        join(gitDir, 'bin'),
+        join(gitDir, 'usr/bin'),
+        join(gitDir, 'mingw64/bin'),
+      ])
+    } finally {
+      rmSync(appHome, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/desktop/src/managed-runtime.ts
+++ b/apps/desktop/src/managed-runtime.ts
@@ -1,0 +1,102 @@
+import { existsSync, statSync } from 'node:fs'
+import { delimiter, join } from 'node:path'
+
+export interface ManagedRuntimeEnvOptions {
+  readonly appHome: string
+  readonly launcherMode: 'electron-dev' | 'electron-packaged'
+  readonly platform?: NodeJS.Platform
+  readonly arch?: string
+  readonly execPath?: string
+}
+
+function existingFile(path: string): string | null {
+  try {
+    return existsSync(path) && statSync(path).isFile() ? path : null
+  } catch {
+    return null
+  }
+}
+
+function existingDir(path: string): string | null {
+  try {
+    return existsSync(path) && statSync(path).isDirectory() ? path : null
+  } catch {
+    return null
+  }
+}
+
+export function resolveManagedRuntimeEnv(opts: ManagedRuntimeEnvOptions): Record<string, string> {
+  const platform = opts.platform ?? process.platform
+  const arch = opts.arch ?? process.arch
+  const platformArch = `${platform}-${arch}`
+  const out: Record<string, string> = {
+    OPENALICE_RUNTIME_PROFILE: opts.launcherMode,
+  }
+
+  const managedPiCli = existingFile(join(
+    opts.appHome,
+    'vendor',
+    'pi',
+    'node_modules',
+    '@earendil-works',
+    'pi-coding-agent',
+    'dist',
+    'cli.js',
+  ))
+  const managedPiBinary = existingFile(join(
+    opts.appHome,
+    'vendor',
+    'pi',
+    platformArch,
+    platform === 'win32' ? 'pi.exe' : 'pi',
+  ))
+  if (managedPiCli) {
+    out.OPENALICE_MANAGED_PI_PATH = managedPiCli
+    out.OPENALICE_MANAGED_PI_NODE_PATH = opts.execPath ?? process.execPath
+  } else if (managedPiBinary) {
+    out.OPENALICE_MANAGED_PI_PATH = managedPiBinary
+  }
+
+  const toolchainPaths: string[] = []
+  const managedToolsDir = existingDir(join(opts.appHome, 'vendor', 'tools', platformArch))
+  const managedFd = managedToolsDir
+    ? existingFile(join(managedToolsDir, platform === 'win32' ? 'fd.exe' : 'fd'))
+    : null
+  if (managedToolsDir && managedFd) {
+    toolchainPaths.push(managedToolsDir)
+  }
+
+  if (platform === 'win32') {
+    const gitDir = existingDir(join(opts.appHome, 'vendor', 'git', platformArch))
+    if (gitDir) {
+      out.OPENALICE_MANAGED_GIT_DIR = gitDir
+      out.LOCAL_GIT_DIRECTORY = gitDir
+
+      const gitBin =
+        existingFile(join(gitDir, 'cmd', 'git.exe')) ??
+        existingFile(join(gitDir, 'bin', 'git.exe')) ??
+        existingFile(join(gitDir, 'mingw64', 'bin', 'git.exe')) ??
+        existingFile(join(gitDir, 'clangarm64', 'bin', 'git.exe'))
+      if (gitBin) out.OPENALICE_MANAGED_GIT_BIN = gitBin
+
+      const shellPath =
+        existingFile(join(gitDir, 'bin', 'bash.exe')) ??
+        existingFile(join(gitDir, 'usr', 'bin', 'bash.exe'))
+      if (shellPath) out.OPENALICE_MANAGED_SHELL_PATH = shellPath
+
+      for (const rel of ['cmd', 'bin', 'usr/bin', 'mingw64/bin', 'clangarm64/bin']) {
+        const dir = existingDir(join(gitDir, ...rel.split('/')))
+        if (dir) toolchainPaths.push(dir)
+      }
+    }
+  } else if (opts.launcherMode === 'electron-packaged') {
+    const shellPath = existingFile('/bin/bash') ?? existingFile('/bin/sh')
+    if (shellPath) out.OPENALICE_MANAGED_SHELL_PATH = shellPath
+  }
+
+  if (toolchainPaths.length > 0) {
+    out.OPENALICE_MANAGED_TOOLCHAIN_PATH = toolchainPaths.join(delimiter)
+  }
+
+  return out
+}

--- a/scripts/assert-desktop-package.mjs
+++ b/scripts/assert-desktop-package.mjs
@@ -47,7 +47,7 @@ export function assertDesktopPackage(options = {}) {
 
   const platform = options.platform ?? platformFromAppRoot(appRoot)
   const arch = options.arch ?? process.arch
-  const platformArch = platform === 'win32' ? `win32-${arch}` : null
+  const platformArch = `${platform}-${arch}`
   const requiredFiles = [...BASE_REQUIRED_FILES, ...platformRequiredFiles(platform, platformArch)]
   const missing = requiredFiles.filter((file) => !existsSync(join(appRoot, file)))
   if (missing.length > 0) {
@@ -71,7 +71,15 @@ export function assertDesktopPackage(options = {}) {
     errors.push(`[desktop-package] unexpected manifest.pi.cli: ${JSON.stringify(manifest?.pi?.cli)}`)
   }
 
-  if (platform === 'win32' && platformArch) {
+  const fd = manifest?.fd?.[platformArch]
+  const expectedFdPath = managedFdPath(platform, platformArch)
+  if (!fd) {
+    errors.push(`[desktop-package] expected manifest.fd.${platformArch} for managed fd`)
+  } else if (normalizeManifestPath(fd.path) !== expectedFdPath) {
+    errors.push(`[desktop-package] unexpected manifest.fd.${platformArch}.path: ${JSON.stringify(fd.path)}`)
+  }
+
+  if (platform === 'win32') {
     const git = manifest?.git?.[platformArch]
     if (!git) {
       errors.push(`[desktop-package] expected manifest.git.${platformArch} for Windows managed Git Bash`)
@@ -103,12 +111,19 @@ export function platformFromAppRoot(appRoot) {
 }
 
 function platformRequiredFiles(platform, platformArch) {
-  if (platform !== 'win32' || !platformArch) return []
-  return [
+  const files = []
+  files.push(managedFdPath(platform, platformArch))
+  if (platform !== 'win32') return files
+  files.push(
     `vendor/git/${platformArch}/cmd/git.exe`,
     `vendor/git/${platformArch}/bin/bash.exe`,
     `vendor/git/${platformArch}/bin/sh.exe`,
-  ]
+  )
+  return files
+}
+
+function managedFdPath(platform, platformArch) {
+  return `vendor/tools/${platformArch}/${platform === 'win32' ? 'fd.exe' : 'fd'}`
 }
 
 function normalizeManifestPath(value) {
@@ -123,6 +138,7 @@ function main() {
   }
   console.log(`[desktop-package] app resources OK: ${relative(repoRoot, result.appRoot)}`)
   console.log(`[desktop-package] managed Pi: ${result.manifest.pi.version} (${result.manifest.pi.mode})`)
+  console.log(`[desktop-package] managed fd: ${result.manifest.fd[result.platformArch].version} (${result.platformArch})`)
   if (result.platform === 'win32') {
     const git = result.manifest.git[result.platformArch]
     console.log(`[desktop-package] managed Git Bash: ${git.version} (${result.platformArch})`)

--- a/scripts/assert-desktop-package.spec.ts
+++ b/scripts/assert-desktop-package.spec.ts
@@ -22,27 +22,35 @@ function writeBasePackage(appRoot: string, manifest: unknown) {
   writePackageFile(appRoot, 'vendor/manifest.json', JSON.stringify(manifest))
 }
 
-function piManifest() {
+function runtimeManifest(platformArch: string, fdPath: string) {
   return {
     pi: {
       version: '0.80.3',
       mode: 'npm',
       cli: PI_CLI,
     },
+    fd: {
+      [platformArch]: {
+        version: '10.4.2',
+        path: fdPath,
+      },
+    },
   }
 }
 
 describe('assertDesktopPackage', () => {
-  it('does not require vendor Git in macOS packages', () => {
+  it('requires managed fd but not vendor Git in macOS packages', () => {
     const root = mkdtempSync(join(tmpdir(), 'openalice-package-mac-'))
     try {
       const appRoot = join(root, 'mac-arm64/OpenAlice.app/Contents/Resources/app')
-      writeBasePackage(appRoot, piManifest())
+      writeBasePackage(appRoot, runtimeManifest('darwin-arm64', 'vendor/tools/darwin-arm64/fd'))
+      writePackageFile(appRoot, 'vendor/tools/darwin-arm64/fd')
 
       const result = assertDesktopPackage({ packageRoot: root, repoRoot: root, arch: 'arm64' })
 
       expect(result.ok).toBe(true)
       expect(result.platform).toBe('darwin')
+      expect(result.platformArch).toBe('darwin-arm64')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -52,7 +60,7 @@ describe('assertDesktopPackage', () => {
     const root = mkdtempSync(join(tmpdir(), 'openalice-package-win-missing-'))
     try {
       const appRoot = join(root, 'win-unpacked/resources/app')
-      writeBasePackage(appRoot, piManifest())
+      writeBasePackage(appRoot, runtimeManifest('win32-x64', 'vendor/tools/win32-x64/fd.exe'))
 
       const result = assertDesktopPackage({ packageRoot: root, repoRoot: root, arch: 'x64' })
 
@@ -60,6 +68,7 @@ describe('assertDesktopPackage', () => {
       expect(result.errors.join('\n')).toContain('vendor/git/win32-x64/cmd/git.exe')
       expect(result.errors.join('\n')).toContain('vendor/git/win32-x64/bin/bash.exe')
       expect(result.errors.join('\n')).toContain('expected manifest.git.win32-x64')
+      expect(result.errors.join('\n')).toContain('vendor/tools/win32-x64/fd.exe')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -70,7 +79,7 @@ describe('assertDesktopPackage', () => {
     try {
       const appRoot = join(root, 'win-unpacked/resources/app')
       writeBasePackage(appRoot, {
-        ...piManifest(),
+        ...runtimeManifest('win32-x64', 'vendor/tools/win32-x64/fd.exe'),
         git: {
           'win32-x64': {
             version: '2.55.0.2',
@@ -84,6 +93,7 @@ describe('assertDesktopPackage', () => {
       writePackageFile(appRoot, 'vendor/git/win32-x64/cmd/git.exe')
       writePackageFile(appRoot, 'vendor/git/win32-x64/bin/bash.exe')
       writePackageFile(appRoot, 'vendor/git/win32-x64/bin/sh.exe')
+      writePackageFile(appRoot, 'vendor/tools/win32-x64/fd.exe')
 
       const result = assertDesktopPackage({ packageRoot: root, repoRoot: root, arch: 'x64' })
 

--- a/scripts/smoke-packaged-toolchain.mjs
+++ b/scripts/smoke-packaged-toolchain.mjs
@@ -36,6 +36,18 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
     expectStdout: /\b0\.80\.3\b/,
   })
 
+  const fd = packageResult.manifest.fd?.[packageResult.platformArch]
+  if (!fd) {
+    errors.push(`[packaged-toolchain] missing managed fd manifest entry ${packageResult.platformArch}`)
+    return { ok: false, errors, commands }
+  }
+  commands.push({
+    label: 'managed fd',
+    command: join(packageResult.appRoot, fd.path),
+    args: ['--version'],
+    expectStdout: /^fd 10\.4\.2$/m,
+  })
+
   if (packageResult.platform === 'win32') {
     const git = packageResult.manifest.git?.[packageResult.platformArch]
     if (!git) {

--- a/scripts/smoke-packaged-toolchain.spec.ts
+++ b/scripts/smoke-packaged-toolchain.spec.ts
@@ -25,10 +25,15 @@ describe('buildPackagedToolchainSmokePlan', () => {
         errors: [],
         appRoot,
         platform: 'darwin',
-        platformArch: null,
+        platformArch: 'darwin-arm64',
         manifest: {
           pi: {
             cli: 'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
+          },
+          fd: {
+            'darwin-arm64': {
+              path: 'vendor/tools/darwin-arm64/fd',
+            },
           },
         },
       })
@@ -37,6 +42,7 @@ describe('buildPackagedToolchainSmokePlan', () => {
       expect(plan.commands.map((command) => command.label)).toEqual([
         'packaged Electron Node mode',
         'managed Pi through packaged Electron Node',
+        'managed fd',
       ])
       expect(packagedElectronExecutable(appRoot, 'darwin')?.replaceAll('\\', '/'))
         .toContain('OpenAlice.app/Contents/MacOS/OpenAlice')
@@ -60,6 +66,11 @@ describe('buildPackagedToolchainSmokePlan', () => {
           pi: {
             cli: 'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
           },
+          fd: {
+            'win32-x64': {
+              path: 'vendor/tools/win32-x64/fd.exe',
+            },
+          },
           git: {
             'win32-x64': {
               path: 'vendor/git/win32-x64',
@@ -76,12 +87,13 @@ describe('buildPackagedToolchainSmokePlan', () => {
       expect(plan.commands.map((command) => command.label)).toEqual([
         'packaged Electron Node mode',
         'managed Pi through packaged Electron Node',
+        'managed fd',
         'managed git.exe',
         'managed bash.exe',
         'managed sh.exe can resolve git and bash on PATH',
       ])
-      expect(plan.commands[2].command.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/cmd/git.exe')
-      expect(plan.commands[4].env?.PATH.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/mingw64/bin')
+      expect(plan.commands[3].command.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/cmd/git.exe')
+      expect(plan.commands[5].env?.PATH.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/mingw64/bin')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -93,7 +105,7 @@ describe('buildPackagedToolchainSmokePlan', () => {
       errors: [],
       appRoot: '/tmp/missing/OpenAlice.app/Contents/Resources/app',
       platform: 'darwin',
-      platformArch: null,
+      platformArch: 'darwin-arm64',
       manifest: {
         pi: {
           cli: 'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',

--- a/scripts/vendor-managed-runtime.mjs
+++ b/scripts/vendor-managed-runtime.mjs
@@ -55,13 +55,54 @@ const WINDOWS_GIT_RUNTIMES = {
   },
 }
 
+const FD_VERSION = '10.4.2'
+const FD_RELEASE_BASE = `https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}`
+const FD_RUNTIMES = {
+  darwin: {
+    arm64: {
+      platformArch: 'darwin-arm64',
+      assetName: `fd-v${FD_VERSION}-aarch64-apple-darwin.tar.gz`,
+      sha256: '623dc0afc81b92e4d4606b380d7bc91916ba7b97814263e554d50923a39e480a',
+      binaryName: 'fd',
+    },
+  },
+  win32: {
+    x64: {
+      platformArch: 'win32-x64',
+      assetName: `fd-v${FD_VERSION}-x86_64-pc-windows-msvc.zip`,
+      sha256: 'b2816e506390a89941c63c9187d58a3cc10e9a55f2ef0685f9ea0eccaf7c98c8',
+      binaryName: 'fd.exe',
+    },
+    arm64: {
+      platformArch: 'win32-arm64',
+      assetName: `fd-v${FD_VERSION}-aarch64-pc-windows-msvc.zip`,
+      sha256: '4f9110c2d5b33a7f760bfa5510f4c113d828109f7277d421b1053a9943c0fc92',
+      binaryName: 'fd.exe',
+    },
+  },
+  linux: {
+    x64: {
+      platformArch: 'linux-x64',
+      assetName: `fd-v${FD_VERSION}-x86_64-unknown-linux-gnu.tar.gz`,
+      sha256: 'def59805cd14b5651b68990855f426ad087f3b96881296d963910431ba3143c8',
+      binaryName: 'fd',
+    },
+    arm64: {
+      platformArch: 'linux-arm64',
+      assetName: `fd-v${FD_VERSION}-aarch64-unknown-linux-gnu.tar.gz`,
+      sha256: '6c51f7c5446b3338b1e401ff15dc194c590bb2fa64fd43ff3278300f073adec5',
+      binaryName: 'fd',
+    },
+  },
+}
+
 function printHelp() {
   console.log(`Usage: pnpm vendor:runtime [options]
 
 Prepare managed workspace runtimes under vendor/.
 
 Options:
-  --force    Remove and reinstall vendor/pi even if it already matches
+  --force    Reinstall managed runtimes even if they already match
   -h, --help Show this help
 `)
 }
@@ -70,8 +111,57 @@ async function main() {
   parseArgs(process.argv.slice(2))
   await mkdir(vendorRoot, { recursive: true })
   await vendorPi()
+  const fdSpec = await vendorFd()
   const gitSpec = await vendorWindowsGit()
-  await writeManifest(gitSpec)
+  await writeManifest(fdSpec, gitSpec)
+}
+
+async function vendorFd() {
+  const spec = resolveFdRuntimeSpec()
+  if (!spec) {
+    console.log(`[vendor-runtime] managed fd skipped on unsupported host ${process.platform}-${process.arch}`)
+    return null
+  }
+
+  const existingManifest = readManifest()
+  if (
+    !force &&
+    existingManifest?.fd?.[spec.platformArch]?.version === spec.version &&
+    existingManifest?.fd?.[spec.platformArch]?.sha256 === spec.sha256 &&
+    existsSync(resolve(repoRoot, spec.path))
+  ) {
+    console.log(`[vendor-runtime] fd ${spec.version} already present at ${spec.path}`)
+    return spec
+  }
+
+  const runtimeRoot = resolve(repoRoot, spec.root)
+  console.log(`[vendor-runtime] preparing fd ${spec.version} at ${relativeForLog(runtimeRoot)}`)
+  await rm(runtimeRoot, { recursive: true, force: true })
+  await mkdir(runtimeRoot, { recursive: true })
+
+  const bytes = await download(spec.url)
+  verifySha256(bytes, spec.sha256, spec.url)
+
+  const tmpRoot = await mkdtemp(resolve(tmpdir(), 'openalice-fd-'))
+  const archivePath = resolve(tmpRoot, basename(spec.url))
+  try {
+    await writeFile(archivePath, bytes)
+    run('extract managed fd', 'tar', [
+      '-xf',
+      archivePath,
+      '-C',
+      runtimeRoot,
+      '--strip-components=1',
+    ])
+  } finally {
+    await rm(tmpRoot, { recursive: true, force: true })
+  }
+
+  if (!existsSync(resolve(repoRoot, spec.path))) {
+    throw new Error(`fd extraction missing required binary: ${spec.path}`)
+  }
+  console.log(`[vendor-runtime] fd -> ${spec.path}`)
+  return spec
 }
 
 function parseArgs(argv) {
@@ -203,7 +293,7 @@ function readManifest() {
   }
 }
 
-export function buildVendorRuntimeManifest(gitSpec = null) {
+export function buildVendorRuntimeManifest(fdSpec = null, gitSpec = null) {
   const manifest = {
     pi: {
       version: PI_VERSION,
@@ -212,6 +302,17 @@ export function buildVendorRuntimeManifest(gitSpec = null) {
       cli: relativeForManifest(piCliPath),
       node: 'electron',
     },
+  }
+  if (fdSpec) {
+    manifest.fd = {
+      [fdSpec.platformArch]: {
+        version: fdSpec.version,
+        distribution: 'sharkdp/fd',
+        url: fdSpec.url,
+        sha256: fdSpec.sha256,
+        path: fdSpec.path,
+      },
+    }
   }
   if (gitSpec) {
     manifest.git = {
@@ -231,10 +332,30 @@ export function buildVendorRuntimeManifest(gitSpec = null) {
   return manifest
 }
 
-async function writeManifest(gitSpec) {
-  const manifest = buildVendorRuntimeManifest(gitSpec)
+async function writeManifest(fdSpec, gitSpec) {
+  const manifest = buildVendorRuntimeManifest(fdSpec, gitSpec)
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n')
   console.log(`[vendor-runtime] manifest -> ${relativeForLog(manifestPath)}`)
+}
+
+export function resolveFdRuntimeSpec(opts = {}) {
+  const platform = opts.platform ?? process.platform
+  const arch = opts.arch ?? process.arch
+  const platformRuntimes = FD_RUNTIMES[platform]
+  if (!platformRuntimes) return null
+  const runtime = platformRuntimes[arch]
+  if (!runtime) {
+    throw new Error(`unsupported ${platform} architecture for managed fd runtime: ${arch}`)
+  }
+  const root = `vendor/tools/${runtime.platformArch}`
+  return {
+    version: FD_VERSION,
+    platformArch: runtime.platformArch,
+    url: `${FD_RELEASE_BASE}/${runtime.assetName}`,
+    sha256: runtime.sha256,
+    root,
+    path: `${root}/${runtime.binaryName}`,
+  }
 }
 
 export function resolveWindowsGitRuntimeSpec(opts = {}) {

--- a/scripts/vendor-managed-runtime.spec.ts
+++ b/scripts/vendor-managed-runtime.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildVendorRuntimeManifest,
   requiredWindowsGitFiles,
+  resolveFdRuntimeSpec,
   resolveWindowsGitRuntimeSpec,
 } from './vendor-managed-runtime.mjs'
 
@@ -32,12 +33,49 @@ describe('vendor managed runtime helpers', () => {
     ])
   })
 
-  it('writes Git metadata only when a Windows Git spec is provided', () => {
-    const macManifest = buildVendorRuntimeManifest(null)
-    expect(macManifest.git).toBeUndefined()
+  it('pins fd for the supported desktop release targets', () => {
+    expect(resolveFdRuntimeSpec({ platform: 'darwin', arch: 'arm64' })).toMatchObject({
+      version: '10.4.2',
+      platformArch: 'darwin-arm64',
+      path: 'vendor/tools/darwin-arm64/fd',
+      sha256: '623dc0afc81b92e4d4606b380d7bc91916ba7b97814263e554d50923a39e480a',
+    })
+    expect(resolveFdRuntimeSpec({ platform: 'win32', arch: 'x64' })).toMatchObject({
+      version: '10.4.2',
+      platformArch: 'win32-x64',
+      path: 'vendor/tools/win32-x64/fd.exe',
+      sha256: 'b2816e506390a89941c63c9187d58a3cc10e9a55f2ef0685f9ea0eccaf7c98c8',
+    })
+    expect(resolveFdRuntimeSpec({ platform: 'win32', arch: 'arm64' })).toMatchObject({
+      platformArch: 'win32-arm64',
+      path: 'vendor/tools/win32-arm64/fd.exe',
+    })
+    expect(resolveFdRuntimeSpec({ platform: 'linux', arch: 'x64' })).toMatchObject({
+      platformArch: 'linux-x64',
+      path: 'vendor/tools/linux-x64/fd',
+      sha256: 'def59805cd14b5651b68990855f426ad087f3b96881296d963910431ba3143c8',
+    })
+    expect(resolveFdRuntimeSpec({ platform: 'linux', arch: 'arm64' })).toMatchObject({
+      platformArch: 'linux-arm64',
+      path: 'vendor/tools/linux-arm64/fd',
+    })
+    expect(resolveFdRuntimeSpec({ platform: 'freebsd', arch: 'x64' })).toBeNull()
+    expect(() => resolveFdRuntimeSpec({ platform: 'darwin', arch: 'x64' }))
+      .toThrow('unsupported darwin architecture')
+  })
 
-    const spec = resolveWindowsGitRuntimeSpec({ platform: 'win32', arch: 'x64' })
-    const winManifest = buildVendorRuntimeManifest(spec)
+  it('writes platform-specific fd and Git metadata', () => {
+    const macFd = resolveFdRuntimeSpec({ platform: 'darwin', arch: 'arm64' })
+    const macManifest = buildVendorRuntimeManifest(macFd, null)
+    expect(macManifest.git).toBeUndefined()
+    expect(macManifest.fd['darwin-arm64']).toMatchObject({
+      distribution: 'sharkdp/fd',
+      path: 'vendor/tools/darwin-arm64/fd',
+    })
+
+    const winFd = resolveFdRuntimeSpec({ platform: 'win32', arch: 'x64' })
+    const winGit = resolveWindowsGitRuntimeSpec({ platform: 'win32', arch: 'x64' })
+    const winManifest = buildVendorRuntimeManifest(winFd, winGit)
     expect(winManifest.git['win32-x64']).toMatchObject({
       distribution: 'PortableGit',
       path: 'vendor/git/win32-x64',
@@ -45,5 +83,6 @@ describe('vendor managed runtime helpers', () => {
       shellPath: 'bin/bash.exe',
       shPath: 'bin/sh.exe',
     })
+    expect(winManifest.fd['win32-x64'].path).toBe('vendor/tools/win32-x64/fd.exe')
   })
 })


### PR DESCRIPTION
## Why

Managed Pi deliberately runs with `PI_OFFLINE=1` so desktop startup never downloads tools behind the user’s back. The packaged runtime did not include `fd`, which made Pi report `fd not found. Offline mode enabled, skipping download.` and left file discovery degraded on machines without a system install.

## What changed

- Pin `fd` 10.4.2 from the official sharkdp/fd release with per-asset SHA-256 checksums.
- Vendor platform-specific binaries under `vendor/tools/<platform>-<arch>/` for macOS arm64, Windows x64/arm64, and Linux x64/arm64.
- Put the verified platform tool directory onto the existing `OPENALICE_MANAGED_TOOLCHAIN_PATH`; no second PATH mechanism was added.
- Extract managed runtime environment resolution into a pure helper and test that fd is advertised only when its binary exists, including coexistence with Windows PortableGit.
- Extend package assertions and packaged toolchain smoke tests to require and execute the managed fd binary.

## Boundaries

- No Homebrew, system PATH, user workspace, credentials, or global agent state is modified.
- Pi remains offline-safe; runtime auto-downloads are not enabled.
- The generated `vendor/` payload remains ignored and is produced during packaging.
- Intel macOS is not modeled because the current upstream release no longer publishes that asset; the current OpenAlice macOS release lane is arm64.
- This is independent of #481.

## Verification

- `pnpm test` — 188 files passed, 1 skipped; 2450 tests passed, 6 skipped.
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm electron:build`
- Real `pnpm vendor:runtime --force` download, SHA verification, extraction, and reuse check.
- Fresh unsigned macOS directory package.
- `pnpm electron:assert-package`
- `pnpm electron:smoke-toolchain` — packaged Electron Node, managed Pi 0.80.3, and managed fd 10.4.2 all executed successfully.
- `pnpm electron:smoke:onboarding` — isolated packaged app reached Pi `ready/managed-runtime` and exited cleanly.

## Review gate

Draft contribution only. Please do not merge until manual review; CI should also validate the Windows ZIP extraction and packaged smoke on a native Windows runner.