### PR TITLE
Gracefully disable updates without packaged metadata

### DIFF
--- a/apps/desktop/src/auto-update-policy.spec.ts
+++ b/apps/desktop/src/auto-update-policy.spec.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveAutoUpdateCapability } from './auto-update-policy.js'
+
+describe('resolveAutoUpdateCapability', () => {
+  it('stays disabled in Electron development mode', () => {
+    expect(resolveAutoUpdateCapability({
+      isPackaged: false,
+      resourcesPath: '/unused/resources',
+    })).toEqual({
+      enabled: false,
+      reason: 'not-packaged',
+      configPath: null,
+    })
+  })
+
+  it('treats a packaged directory without update metadata as non-updatable', () => {
+    const resourcesPath = mkdtempSync(join(tmpdir(), 'openalice-updater-missing-'))
+    try {
+      expect(resolveAutoUpdateCapability({ isPackaged: true, resourcesPath })).toEqual({
+        enabled: false,
+        reason: 'missing-config',
+        configPath: join(resourcesPath, 'app-update.yml'),
+      })
+    } finally {
+      rmSync(resourcesPath, { recursive: true, force: true })
+    }
+  })
+
+  it('enables updates only when packaged metadata exists', () => {
+    const resourcesPath = mkdtempSync(join(tmpdir(), 'openalice-updater-ready-'))
+    try {
+      const configPath = join(resourcesPath, 'app-update.yml')
+      writeFileSync(configPath, 'provider: generic\nurl: https://download.openalice.ai/\n')
+
+      expect(resolveAutoUpdateCapability({ isPackaged: true, resourcesPath })).toEqual({
+        enabled: true,
+        configPath,
+      })
+    } finally {
+      rmSync(resourcesPath, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/desktop/src/auto-update-policy.ts
+++ b/apps/desktop/src/auto-update-policy.ts
@@ -1,0 +1,33 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type AutoUpdateCapability =
+  | {
+      readonly enabled: true
+      readonly configPath: string
+    }
+  | {
+      readonly enabled: false
+      readonly reason: 'not-packaged'
+      readonly configPath: null
+    }
+  | {
+      readonly enabled: false
+      readonly reason: 'missing-config'
+      readonly configPath: string
+    }
+
+export function resolveAutoUpdateCapability(opts: {
+  readonly isPackaged: boolean
+  readonly resourcesPath: string
+}): AutoUpdateCapability {
+  if (!opts.isPackaged) {
+    return { enabled: false, reason: 'not-packaged', configPath: null }
+  }
+
+  const configPath = join(opts.resourcesPath, 'app-update.yml')
+  if (!existsSync(configPath)) {
+    return { enabled: false, reason: 'missing-config', configPath }
+  }
+  return { enabled: true, configPath }
+}

--- a/apps/desktop/src/auto-update.spec.ts
+++ b/apps/desktop/src/auto-update.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>()
+  return {
+    handlers,
+    app: {
+      isPackaged: false,
+      getVersion: vi.fn(() => '0.0.0'),
+    },
+    ipcMain: {
+      removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler)
+      }),
+    },
+    shell: {
+      openExternal: vi.fn(async () => {}),
+    },
+    autoUpdater: {
+      checkForUpdates: vi.fn(),
+    },
+  }
+})
+
+vi.mock('electron', () => ({
+  app: mocks.app,
+  ipcMain: mocks.ipcMain,
+  shell: mocks.shell,
+}))
+
+vi.mock('electron-updater', () => ({
+  default: { autoUpdater: mocks.autoUpdater },
+}))
+
+import { configureAutoUpdate } from './auto-update.js'
+
+describe('configureAutoUpdate', () => {
+  beforeEach(() => {
+    mocks.handlers.clear()
+    vi.clearAllMocks()
+    mocks.app.isPackaged = false
+  })
+
+  it('keeps updater IPC stable when the updater engine is disabled', async () => {
+    configureAutoUpdate({} as never, { beforeInstall: vi.fn(async () => {}) })
+
+    expect([...mocks.handlers.keys()]).toEqual([
+      'openalice:updater:get-status',
+      'openalice:updater:install-and-restart',
+      'openalice:updater:open-release',
+    ])
+    expect(mocks.autoUpdater.checkForUpdates).not.toHaveBeenCalled()
+
+    const getStatus = mocks.handlers.get('openalice:updater:get-status')
+    const install = mocks.handlers.get('openalice:updater:install-and-restart')
+    const openRelease = mocks.handlers.get('openalice:updater:open-release')
+    expect(await getStatus?.()).toBeNull()
+    await expect(install?.()).rejects.toThrow('No downloaded update is ready to install.')
+    await openRelease?.({}, undefined)
+    expect(mocks.shell.openExternal)
+      .toHaveBeenCalledWith('https://github.com/TraderAlice/OpenAlice/releases')
+  })
+})

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -1,5 +1,6 @@
 import { app, ipcMain, shell, type BrowserWindow } from 'electron'
 import electronUpdater from 'electron-updater'
+import { resolveAutoUpdateCapability } from './auto-update-policy.js'
 
 const { autoUpdater } = electronUpdater
 
@@ -16,8 +17,6 @@ export interface AutoUpdateHooks {
 }
 
 export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks): void {
-  if (!app.isPackaged) return
-
   let downloadedVersion: string | null = null
   let latestStatus: UpdaterStatus | null = null
 
@@ -52,6 +51,19 @@ export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks):
     return { ok: true }
   })
 
+  // Keep the renderer IPC contract stable in dev and non-updatable directory
+  // packages. Only the updater engine itself depends on packaged metadata.
+  const capability = resolveAutoUpdateCapability({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+  })
+  if (!capability.enabled) {
+    if (capability.reason === 'missing-config') {
+      console.info(`[updater] disabled: update metadata not found at ${capability.configPath}`)
+    }
+    return
+  }
+
   autoUpdater.autoDownload = true
   autoUpdater.autoInstallOnAppQuit = false
   autoUpdater.allowPrerelease = app.getVersion().includes('-')
@@ -81,9 +93,10 @@ export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks):
     sendStatus({ phase: 'downloaded', version: info.version, releaseUrl: releaseUrlFor(info.version) })
   })
 
-  void autoUpdater.checkForUpdates().catch((err) => {
-    console.error('[updater] checkForUpdates threw:', err)
-  })
+  // electron-updater emits the same rejection through its `error` event
+  // before rethrowing it from this promise. The event handler above owns the
+  // diagnostic; consume the promise rejection so one failure is logged once.
+  void autoUpdater.checkForUpdates().catch(() => {})
 }
 
 function channelForVersion(version: string): string {


### PR DESCRIPTION
## Why

`electron-builder --dir` creates a packaged Electron app for local validation but does not include the internal `Resources/app-update.yml` used by `electron-updater`. OpenAlice treated that non-updatable package like a broken updater, logging the same ENOENT failure twice during every packaged smoke.

The first preflight pass also exposed an older IPC contract gap: returning before updater setup left the renderer calling `openalice:updater:get-status` with no registered handler. The UI swallowed the rejection, but Electron still logged a handler error.

## What changed

- Add a small capability policy that enables the updater only for packaged builds with `app-update.yml` present.
- Keep updater IPC handlers registered in dev, local directory packages, and release packages; disabled builds return a null status instead of throwing a missing-handler error.
- Log one explicit info line when a packaged build has no update metadata.
- Keep real updater errors visible through the existing `error` event while consuming its rethrown Promise rejection to avoid duplicate diagnostics.
- Cover dev, missing-metadata, release-metadata, and disabled IPC behavior with focused tests.

## Boundaries

- Release channel, generic download URL, download/install behavior, and signed release packaging are unchanged.
- No test-only environment bypass and no fabricated `app-update.yml` were added.
- Real metadata parse, network, and download failures are still reported.
- The installed `/Applications/OpenAlice.app` was checked locally and contains `Contents/Resources/app-update.yml`, so it follows the existing enabled path.
- Reference: https://www.electron.build/docs/features/auto-update/

## Verification

- `pnpm test` — 189 files passed, 1 skipped; 2450 tests passed, 6 skipped.
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F @traderalice/desktop build`
- `pnpm electron:smoke:onboarding` on a fresh unsigned directory package.
- Repeated packaged smoke after stabilizing IPC: exactly one readable updater-disabled line, no `app-update.yml` ENOENT stack, no duplicate updater error, no missing IPC handler error, and onboarding completed with Pi `ready/managed-runtime`.

## Review gate

Draft contribution only. Please do not merge until manual review.