### PR TITLE
Make Electron UTA follow trading mode

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -21,11 +21,15 @@
  */
 
 import { app, BrowserWindow, dialog, Menu, protocol } from 'electron'
+import { runRendererTradingModeSmoke } from './trading-mode-smoke.js'
+import { planUTATransition } from './uta-lifecycle.js'
 import {
   acquireGuardianRuntime,
   currentProcessStartedAt,
   inspectOpenAliceInstance,
+  resolveGuardianTradingMode,
   takeoverRequested,
+  type GuardianTradingModePlan,
   type RuntimeProcessLock,
 } from '@traderalice/guardian-runtime'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
@@ -46,7 +50,9 @@ let uta: ChildProcess | null = null
 let alice: ChildProcess | null = null
 let appQuitting = false
 let restartingUTA = false
+let pendingUTAMode: GuardianTradingModePlan | null = null
 let rendererOnboardingSmokeStarted = false
+let rendererTradingModeSmokeStarted = false
 let guardianRuntimeLock: RuntimeProcessLock | null = null
 
 const DEFAULT_WEB_PORT_START = 47331
@@ -146,6 +152,21 @@ async function readMcpConfigFile(userDataHome: string): Promise<{ enabled: boole
     enabled: rec['enabled'] === true,
     ...(rec['port'] !== undefined ? { port: parsePort(rec['port'], `${filePath} ("port")`) } : {}),
   }
+}
+
+function selectPort(
+  envKey: string,
+  fileValue: number | undefined,
+  fallback: number,
+): { value: number; explicitOrigin: string | null } {
+  const envRaw = process.env[envKey]
+  if (envRaw !== undefined && envRaw !== '') {
+    return { value: parsePort(envRaw, envKey), explicitOrigin: envKey }
+  }
+  if (fileValue !== undefined) {
+    return { value: fileValue, explicitOrigin: 'data/config/ports.json' }
+  }
+  return { value: fallback, explicitOrigin: null }
 }
 
 function parseEnabledEnv(raw: string | undefined): boolean | null {
@@ -255,19 +276,13 @@ async function claimPort(
   fileValue: number | undefined,
   probeStart: number,
 ): Promise<number> {
-  const envRaw = process.env[envKey]
-  const explicit =
-    envRaw !== undefined && envRaw !== ''
-      ? { value: parsePort(envRaw, envKey), origin: envKey }
-      : fileValue !== undefined
-        ? { value: fileValue, origin: 'data/config/ports.json' }
-        : null
-  if (explicit === null) return probeFreePort(probeStart)
+  const selected = selectPort(envKey, fileValue, probeStart)
+  if (selected.explicitOrigin === null) return probeFreePort(selected.value)
   try {
-    return await probeFreePort(explicit.value, explicit.value)
+    return await probeFreePort(selected.value, selected.value)
   } catch {
     throw new Error(
-      `[guardian] port ${explicit.value} (${name}, from ${explicit.origin}) is already in use — free it or configure another port`,
+      `[guardian] port ${selected.value} (${name}, from ${selected.explicitOrigin}) is already in use — free it or configure another port`,
     )
   }
 }
@@ -575,14 +590,15 @@ app.whenReady().then(async () => {
   const portsFile = await readPortsFile(homeEnv.OPENALICE_HOME)
   const mcpFile = await readMcpConfigFile(homeEnv.OPENALICE_HOME)
   const mcpEnabled = parseEnabledEnv(process.env['OPENALICE_MCP_ENABLED']) ?? mcpFile.enabled
-  const liteMode = isLiteModeEnv(process.env)
+  let tradingMode = await resolveGuardianTradingMode(process.env, homeEnv.OPENALICE_HOME)
   const mcpPort = mcpEnabled
     ? await claimPort('mcp', 'OPENALICE_MCP_PORT', portsFile.mcp ?? mcpFile.port, DEFAULT_WEB_PORT_START + 1)
     : null
-  const utaPort = liteMode
-    ? null
-    : await claimPort('uta', 'OPENALICE_UTA_PORT', portsFile.uta, mcpPort !== null ? mcpPort + 1 : DEFAULT_WEB_PORT_START + 1)
-  const utaUrl = utaPort !== null ? `http://127.0.0.1:${utaPort}` : null
+  const utaPortFallback = mcpPort !== null ? mcpPort + 1 : DEFAULT_WEB_PORT_START + 1
+  const utaPort = tradingMode.mode === 'lite'
+    ? selectPort('OPENALICE_UTA_PORT', portsFile.uta, utaPortFallback).value
+    : await claimPort('uta', 'OPENALICE_UTA_PORT', portsFile.uta, utaPortFallback)
+  const utaUrl = `http://127.0.0.1:${utaPort}`
   const launcherMode = app.isPackaged ? 'electron-packaged' : 'electron-dev'
   const runtimeEnv = resolveManagedRuntimeEnv({
     appHome: homeEnv.OPENALICE_APP_HOME,
@@ -604,7 +620,6 @@ app.whenReady().then(async () => {
   // Node runtime mode. Without it each spawn would open a new app window.
 
   const spawnUTA = (): ChildProcess => {
-    if (utaPort === null) throw new Error('spawnUTA called while OPENALICE_LITE_MODE disables UTA')
     const child = spawn(process.execPath, [utaEntry], {
       env: {
         ...process.env,
@@ -638,7 +653,7 @@ app.whenReady().then(async () => {
         OPENALICE_LOCAL_CLI_ON_WEB: '1',
         OPENALICE_TOOL_BASE_URL: toolBaseUrl,
         OPENALICE_TOOL_SOCKET: toolSocketPath,
-        ...(liteMode ? { OPENALICE_LITE_MODE: '1' } : { OPENALICE_UTA_URL: utaUrl ?? '' }),
+        OPENALICE_UTA_URL: utaUrl,
         OPENALICE_LAUNCHER: 'electron',
         OPENALICE_GUARDIAN_PID: String(process.pid),
         OPENALICE_GUARDIAN_STARTED_AT: String(guardianStartedAt),
@@ -672,11 +687,11 @@ app.whenReady().then(async () => {
   // sees when debugging startup, and "Electron app loading local HTTP" looks
   // deceptively similar to Docker/prod unless the launcher mode is named.
   console.log('')
-  console.log(`[guardian] mode     →  ${launcherMode}`)
+  console.log(`[guardian] mode     →  ${launcherMode}; trading=${tradingMode.mode} (${tradingMode.source}${tradingMode.envLocked ? ', env-locked' : ''})`)
   console.log(`[guardian] data     →  ${homeEnv.OPENALICE_HOME}`)
   console.log(`[guardian] app      →  ${homeEnv.OPENALICE_APP_HOME}`)
   console.log(`[guardian] runtime  →  ${piRuntime}`)
-  console.log(`[guardian] UTA      →  ${utaUrl ?? 'disabled (OPENALICE_LITE_MODE)'}`)
+  console.log(`[guardian] UTA      →  ${tradingMode.mode === 'lite' ? 'disabled (trading mode lite)' : utaUrl}`)
   console.log(`[guardian] Alice    →  app://openalice (Electron IPC)`)
   console.log(`[guardian] Tools    →  ${toolSocketPath}`)
   console.log(`[guardian] MCP      →  ${mcpPort !== null ? `http://127.0.0.1:${mcpPort}/mcp` : 'disabled'}`)
@@ -697,7 +712,7 @@ app.whenReady().then(async () => {
       return new Response(err instanceof Error ? err.message : String(err), { status: 503 })
     }
   })
-  if (utaUrl !== null) {
+  if (tradingMode.mode !== 'lite') {
     uta = spawnUTA()
     void waitForUTA(utaUrl).then((ready) => {
       if (ready) console.log(`[guardian] UTA ready pid=${uta?.pid ?? ''}`)
@@ -711,9 +726,12 @@ app.whenReady().then(async () => {
 
   // ── Restart-flag watcher: broker config changes touch the flag; SIGTERM
   // + respawn UTA without restarting Alice (mirrors prod.mjs). ────────────
-  if (utaUrl !== null) {
-    void startFlagWatcher(homeEnv.OPENALICE_HOME, utaUrl, spawnUTA)
-  }
+  void startFlagWatcher(homeEnv.OPENALICE_HOME, () => {
+    void (async () => {
+      tradingMode = await resolveGuardianTradingMode(process.env, homeEnv.OPENALICE_HOME)
+      await reconcileUTA(tradingMode, utaUrl, spawnUTA)
+    })().catch((err) => console.error('[guardian] UTA mode reconcile failed:', err))
+  })
 
   // No in-window menu bar on Windows/Linux — Electron's default
   // File/Edit/View/Window/Help renders *inside* the window there and is
@@ -781,6 +799,23 @@ app.whenReady().then(async () => {
               }
             })
         }
+        if (ready && process.env['OPENALICE_ELECTRON_SMOKE_TRADING_MODE'] === '1' && !rendererTradingModeSmokeStarted) {
+          rendererTradingModeSmokeStarted = true
+          void runRendererTradingModeSmoke(win)
+            .then((result) => {
+              console.log(
+                `[guardian] electron smoke trading mode → ok ${result.initialMode} -> ${result.activeMode} -> ${result.finalMode}`,
+              )
+              if (process.env['OPENALICE_ELECTRON_SMOKE_EXIT'] === '1') shutdown()
+            })
+            .catch((err) => {
+              console.error(`[guardian] electron smoke trading mode → failed: ${err instanceof Error ? err.message : String(err)}`)
+              if (process.env['OPENALICE_ELECTRON_SMOKE_EXIT'] === '1') {
+                process.exitCode = 1
+                shutdown()
+              }
+            })
+        }
       })
       .catch((err) => {
         console.error(`[guardian] renderer bridge probe failed: ${err instanceof Error ? err.message : String(err)}`)
@@ -791,24 +826,54 @@ app.whenReady().then(async () => {
   configureAutoUpdate(win, { beforeInstall: stopChildren })
 })
 
-async function restartUTA(utaUrl: string, spawnUTA: () => ChildProcess): Promise<void> {
-  if (restartingUTA || appQuitting) return
+async function stopUTAProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return
+  const exited = new Promise<void>((resolveExit) => child.once('exit', () => resolveExit()))
+  killTree(child, 'SIGTERM')
+  await Promise.race([exited, new Promise((resolveWait) => setTimeout(resolveWait, UTA_RESTART_GRACE_MS))])
+  if (child.exitCode === null) {
+    killTree(child, 'SIGKILL')
+    await exited
+  }
+}
+
+async function reconcileUTA(
+  mode: GuardianTradingModePlan,
+  utaUrl: string,
+  spawnUTA: () => ChildProcess,
+): Promise<void> {
+  if (appQuitting) return
+  pendingUTAMode = mode
+  if (restartingUTA) return
+
   restartingUTA = true
   try {
-    console.log('[guardian] restart-uta.flag triggered — restarting UTA')
-    const old = uta
-    if (old && old.exitCode === null) {
-      const exited = new Promise<void>((r) => old.once('exit', () => r()))
-      killTree(old, 'SIGTERM')
-      await Promise.race([exited, new Promise((r) => setTimeout(r, UTA_RESTART_GRACE_MS))])
-      if (old.exitCode === null) {
-        killTree(old, 'SIGKILL')
-        await exited
+    while (pendingUTAMode && !appQuitting) {
+      const targetMode = pendingUTAMode
+      pendingUTAMode = null
+      const running = uta !== null && uta.exitCode === null
+      const action = planUTATransition(targetMode.mode, running)
+      if (action === 'none') {
+        if (uta?.exitCode !== null) uta = null
+        continue
+      }
+
+      if (action === 'stop' || action === 'restart') {
+        console.log(action === 'stop'
+          ? '[guardian] trading mode lite — stopping UTA'
+          : `[guardian] trading mode ${targetMode.mode} — restarting UTA`)
+        const old = uta
+        if (old) await stopUTAProcess(old)
+        if (uta === old) uta = null
+      }
+
+      if (action === 'start' || action === 'restart') {
+        if (action === 'start') console.log(`[guardian] trading mode ${targetMode.mode} — starting UTA`)
+        uta = spawnUTA()
+        const ready = await waitForUTA(utaUrl)
+        console.log(ready ? '[guardian] UTA online' : '[guardian] UTA did not become ready')
       }
     }
-    uta = spawnUTA()
-    const ready = await waitForUTA(utaUrl)
-    console.log(ready ? '[guardian] UTA back online' : '[guardian] UTA did not come back up after restart')
   } finally {
     restartingUTA = false
   }
@@ -816,8 +881,7 @@ async function restartUTA(utaUrl: string, spawnUTA: () => ChildProcess): Promise
 
 async function startFlagWatcher(
   dataHome: string,
-  utaUrl: string,
-  spawnUTA: () => ChildProcess,
+  onTrigger: () => void,
 ): Promise<void> {
   const flagPath = resolve(dataHome, 'data', 'control', 'restart-uta.flag')
   const flagDir = dirname(flagPath)
@@ -828,7 +892,7 @@ async function startFlagWatcher(
     if (pending) clearTimeout(pending)
     pending = setTimeout(() => {
       pending = undefined
-      restartUTA(utaUrl, spawnUTA).catch((err) => console.error('[guardian] restartUTA threw:', err))
+      onTrigger()
     }, 100)
   }
   try {

--- a/apps/desktop/src/trading-mode-smoke.ts
+++ b/apps/desktop/src/trading-mode-smoke.ts
@@ -1,0 +1,71 @@
+import type { BrowserWindow } from 'electron'
+
+export interface TradingModeSmokeResult {
+  readonly initialMode: string
+  readonly activeMode: string
+  readonly activeStartedAt: string
+  readonly finalMode: string
+}
+
+export async function runRendererTradingModeSmoke(
+  win: BrowserWindow,
+): Promise<TradingModeSmokeResult> {
+  return win.webContents.executeJavaScript(`(async () => {
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+    const json = async (res) => {
+      const text = await res.text()
+      let body = null
+      try { body = text ? JSON.parse(text) : null } catch { body = text }
+      if (!res.ok) throw new Error(res.status + ' ' + text)
+      return body
+    }
+    const waitFor = async (label, predicate, timeoutMs = 30000) => {
+      const deadline = Date.now() + timeoutMs
+      let last = null
+      while (Date.now() < deadline) {
+        try {
+          const value = await predicate()
+          if (value) return value
+        } catch (err) {
+          last = err
+        }
+        await sleep(100)
+      }
+      throw new Error('Timed out waiting for ' + label + (last ? ': ' + (last.message || String(last)) : ''))
+    }
+    const putMode = async (base, mode) => json(await fetch('/api/config/trading', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...base, mode }),
+    }))
+
+    await waitFor('Electron preload bridge', () => Boolean(window.openAlice?.runtime))
+    const initial = await json(await fetch('/api/trading/status'))
+    if (initial.mode !== 'lite' || initial.available !== false) {
+      throw new Error('expected fresh lite mode without UTA, got ' + JSON.stringify(initial))
+    }
+
+    const tradingConfig = await json(await fetch('/api/config/trading'))
+    await putMode(tradingConfig, 'readonly')
+    const active = await waitFor('readonly UTA startup', async () => {
+      const status = await json(await fetch('/api/trading/status'))
+      return status.mode === 'readonly' && status.available === true && status.startedAt
+        ? status
+        : null
+    })
+
+    await putMode(tradingConfig, 'lite')
+    const final = await waitFor('lite mode restore', async () => {
+      const status = await json(await fetch('/api/trading/status'))
+      return status.mode === 'lite' && status.available === false ? status : null
+    })
+    await sleep(500)
+
+    return {
+      initialMode: initial.mode,
+      activeMode: active.mode,
+      activeStartedAt: active.startedAt,
+      finalMode: final.mode,
+    }
+  })()`, true) as Promise<TradingModeSmokeResult>
+}

--- a/apps/desktop/src/uta-lifecycle.spec.ts
+++ b/apps/desktop/src/uta-lifecycle.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { planUTATransition } from './uta-lifecycle.js'
+
+describe('planUTATransition', () => {
+  it.each([
+    { mode: 'lite', running: false, expected: 'none' },
+    { mode: 'lite', running: true, expected: 'stop' },
+    { mode: 'readonly', running: false, expected: 'start' },
+    { mode: 'readonly', running: true, expected: 'restart' },
+    { mode: 'pro', running: false, expected: 'start' },
+    { mode: 'pro', running: true, expected: 'restart' },
+  ] as const)('$mode with running=$running plans $expected', ({ mode, running, expected }) => {
+    expect(planUTATransition(mode, running)).toBe(expected)
+  })
+})

--- a/apps/desktop/src/uta-lifecycle.ts
+++ b/apps/desktop/src/uta-lifecycle.ts
@@ -1,0 +1,11 @@
+import type { GuardianTradingMode } from '@traderalice/guardian-runtime'
+
+export type UTATransition = 'none' | 'start' | 'stop' | 'restart'
+
+export function planUTATransition(
+  mode: GuardianTradingMode,
+  running: boolean,
+): UTATransition {
+  if (mode === 'lite') return running ? 'stop' : 'none'
+  return running ? 'restart' : 'start'
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "electron:smoke-toolchain": "node scripts/smoke-packaged-toolchain.mjs",
     "electron:smoke:packaged": "node scripts/desktop-packaged-smoke.mjs",
     "electron:smoke:onboarding": "node scripts/desktop-packaged-smoke.mjs --onboarding",
+    "electron:smoke:trading-mode": "node scripts/desktop-packaged-smoke.mjs --trading-mode",
     "electron:smoke:pty": "node scripts/desktop-pty-smoke.mjs",
     "electron:smoke:guardian-recovery": "node scripts/desktop-pty-smoke.mjs --guardian-recovery",
     "vendor:runtime": "node scripts/vendor-managed-runtime.mjs",

--- a/packages/guardian-runtime/src/index.ts
+++ b/packages/guardian-runtime/src/index.ts
@@ -1,2 +1,3 @@
 export * from './process-control.js'
 export * from './runtime-lock.js'
+export * from './trading-mode.js'

--- a/packages/guardian-runtime/src/trading-mode.spec.ts
+++ b/packages/guardian-runtime/src/trading-mode.spec.ts
@@ -1,0 +1,89 @@
+import { createCipheriv, randomBytes } from 'node:crypto'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { resolveGuardianTradingMode } from './trading-mode.js'
+
+describe('resolveGuardianTradingMode', () => {
+  let home: string
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'guardian-trading-mode-'))
+    await mkdir(join(home, 'data/config'), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true })
+  })
+
+  const writeConfig = async (name: string, value: unknown) => {
+    await writeFile(join(home, 'data/config', name), JSON.stringify(value))
+  }
+
+  it('prefers an env-locked mode over persisted state', async () => {
+    await writeConfig('trading.json', { mode: 'pro' })
+    await writeConfig('accounts.json', [{ id: 'alpaca' }])
+
+    await expect(resolveGuardianTradingMode({ OPENALICE_TRADING_MODE: 'readonly' }, home))
+      .resolves.toEqual({
+        mode: 'readonly',
+        source: 'env',
+        envLocked: true,
+        hasUTAConfig: true,
+      })
+  })
+
+  it('uses persisted mode before account-based inference', async () => {
+    await writeConfig('trading.json', { mode: 'lite' })
+    await writeConfig('accounts.json', [{ id: 'alpaca' }])
+
+    await expect(resolveGuardianTradingMode({}, home)).resolves.toMatchObject({
+      mode: 'lite',
+      source: 'config',
+      envLocked: false,
+      hasUTAConfig: true,
+    })
+  })
+
+  it('defaults fresh roots to lite and roots with accounts to pro', async () => {
+    await expect(resolveGuardianTradingMode({}, home)).resolves.toMatchObject({
+      mode: 'lite',
+      source: 'auto',
+      hasUTAConfig: false,
+    })
+
+    await writeConfig('accounts.json', [{ id: 'alpaca' }])
+    await expect(resolveGuardianTradingMode({}, home)).resolves.toMatchObject({
+      mode: 'pro',
+      source: 'auto',
+      hasUTAConfig: true,
+    })
+  })
+
+  it('detects accounts in the sealed credential envelope', async () => {
+    const key = randomBytes(32)
+    const iv = randomBytes(12)
+    const cipher = createCipheriv('aes-256-gcm', key, iv)
+    const data = Buffer.concat([
+      cipher.update(JSON.stringify([{ id: 'sealed-account' }]), 'utf8'),
+      cipher.final(),
+    ])
+    await writeFile(join(home, 'sealing.key'), key.toString('base64'))
+    await writeConfig('accounts.json', {
+      $sealed: 1,
+      alg: 'aes-256-gcm',
+      iv: iv.toString('base64'),
+      tag: cipher.getAuthTag().toString('base64'),
+      data: data.toString('base64'),
+    })
+
+    await expect(resolveGuardianTradingMode({}, home)).resolves.toMatchObject({
+      mode: 'pro',
+      source: 'auto',
+      hasUTAConfig: true,
+    })
+  })
+})

--- a/packages/guardian-runtime/src/trading-mode.ts
+++ b/packages/guardian-runtime/src/trading-mode.ts
@@ -1,0 +1,102 @@
+import { createDecipheriv } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+export type GuardianTradingMode = 'lite' | 'readonly' | 'pro'
+
+export interface GuardianTradingModePlan {
+  mode: GuardianTradingMode
+  source: 'env' | 'config' | 'auto'
+  envLocked: boolean
+  hasUTAConfig: boolean
+}
+
+export function isLiteModeEnv(env: NodeJS.ProcessEnv): boolean {
+  return truthyEnv(env['OPENALICE_LITE_MODE']) || truthyEnv(env['OPENALICE_UTA_DISABLED'])
+}
+
+export function parseGuardianTradingModeEnv(env: NodeJS.ProcessEnv): GuardianTradingMode | null {
+  const raw = env['OPENALICE_TRADING_MODE']?.trim().toLowerCase()
+  if (raw === 'lite' || raw === 'readonly' || raw === 'pro') return raw
+  return isLiteModeEnv(env) ? 'lite' : null
+}
+
+export async function resolveGuardianTradingMode(
+  env: NodeJS.ProcessEnv,
+  userDataHome: string,
+): Promise<GuardianTradingModePlan> {
+  const envMode = parseGuardianTradingModeEnv(env)
+  const configuredMode = await readPersistedTradingMode(userDataHome)
+  const hasUTAConfig = await hasPersistedUTAs(userDataHome)
+  if (envMode) return { mode: envMode, source: 'env', envLocked: true, hasUTAConfig }
+  if (configuredMode) return { mode: configuredMode, source: 'config', envLocked: false, hasUTAConfig }
+  return { mode: hasUTAConfig ? 'pro' : 'lite', source: 'auto', envLocked: false, hasUTAConfig }
+}
+
+async function readPersistedTradingMode(userDataHome: string): Promise<GuardianTradingMode | null> {
+  try {
+    const raw = JSON.parse(await readFile(resolve(
+      userDataHome,
+      'data',
+      'config',
+      'trading.json',
+    ), 'utf8')) as { mode?: unknown }
+    return raw.mode === 'lite' || raw.mode === 'readonly' || raw.mode === 'pro' ? raw.mode : null
+  } catch {
+    return null
+  }
+}
+
+async function hasPersistedUTAs(userDataHome: string): Promise<boolean> {
+  try {
+    const raw = JSON.parse(await readFile(resolve(
+      userDataHome,
+      'data',
+      'config',
+      'accounts.json',
+    ), 'utf8'))
+    const accounts = isSealedEnvelope(raw)
+      ? await unsealGuardianAccounts(userDataHome, raw)
+      : raw
+    return Array.isArray(accounts) && accounts.length > 0
+  } catch {
+    return false
+  }
+}
+
+function isSealedEnvelope(value: unknown): value is {
+  alg: string
+  iv: string
+  tag: string
+  data: string
+} {
+  return (
+    typeof value === 'object' && value !== null &&
+    (value as Record<string, unknown>)['$sealed'] === 1 &&
+    typeof (value as Record<string, unknown>)['iv'] === 'string' &&
+    typeof (value as Record<string, unknown>)['tag'] === 'string' &&
+    typeof (value as Record<string, unknown>)['data'] === 'string'
+  )
+}
+
+async function unsealGuardianAccounts(
+  userDataHome: string,
+  envelope: { alg: string; iv: string; tag: string; data: string },
+): Promise<unknown> {
+  if (envelope.alg !== 'aes-256-gcm') return []
+  const keyRaw = (await readFile(resolve(userDataHome, 'sealing.key'), 'utf8')).trim()
+  const key = Buffer.from(keyRaw, 'base64')
+  const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(envelope.iv, 'base64'))
+  decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'))
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(envelope.data, 'base64')),
+    decipher.final(),
+  ])
+  return JSON.parse(plaintext.toString('utf8')) as unknown
+}
+
+function truthyEnv(raw: string | undefined): boolean {
+  if (raw === undefined || raw === '') return false
+  const normalized = raw.toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on'
+}

--- a/scripts/desktop-packaged-smoke-plan.mjs
+++ b/scripts/desktop-packaged-smoke-plan.mjs
@@ -8,6 +8,7 @@ export const DESKTOP_PACKAGED_SMOKE_ARGS = new Set([
   '--real-data',
   '--signed',
   '--onboarding',
+  '--trading-mode',
   '--help',
   '-h',
 ])
@@ -16,6 +17,7 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
   const args = new Set(argv)
   const unknownArgs = [...args].filter((arg) => !DESKTOP_PACKAGED_SMOKE_ARGS.has(arg))
   const onboarding = args.has('--onboarding')
+  const tradingMode = args.has('--trading-mode')
   const realDataFlag = args.has('--real-data')
   const tempDataFlag = args.has('--temp-data')
   const errors = []
@@ -30,6 +32,12 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
   if (onboarding && realDataFlag) {
     errors.push('[desktop-smoke] --onboarding always uses isolated temp data; drop --real-data')
   }
+  if (tradingMode && realDataFlag) {
+    errors.push('[desktop-smoke] --trading-mode always uses isolated temp data; drop --real-data')
+  }
+  if (onboarding && tradingMode) {
+    errors.push('[desktop-smoke] choose either --onboarding or --trading-mode, not both')
+  }
 
   const skipBuild = args.has('--skip-build')
   const skipPack = args.has('--skip-pack')
@@ -40,7 +48,7 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
     warnings.push('[desktop-smoke] --onboarding with --skip-pack assumes the packaged app already contains that onboarding-enabled ui/dist')
   }
 
-  const tempData = onboarding || tempDataFlag
+  const tempData = onboarding || tradingMode || tempDataFlag
   const realData = !tempData
   const storageSuffix = env['VITE_OPENALICE_ONBOARDING_STORAGE_SUFFIX']?.trim() || opts.randomUUID?.() || randomUUID()
   const onboardingBuildEnv = onboarding ? {
@@ -58,7 +66,12 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
     OPENALICE_ELECTRON_SMOKE_ONBOARDING: '1',
     OPENALICE_ELECTRON_SMOKE_EXIT: '1',
   } : {}
-  const unsetLaunchEnv = onboarding ? [
+  const tradingModeLaunchEnv = tradingMode ? {
+    OPENALICE_MCP_ENABLED: '0',
+    OPENALICE_ELECTRON_SMOKE_TRADING_MODE: '1',
+    OPENALICE_ELECTRON_SMOKE_EXIT: '1',
+  } : {}
+  const unsetLaunchEnv = onboarding || tradingMode ? [
     'OPENALICE_TRADING_MODE',
     'OPENALICE_LITE_MODE',
     'OPENALICE_UTA_DISABLED',
@@ -71,6 +84,7 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
       help: args.has('--help') || args.has('-h'),
       keep: args.has('--keep'),
       onboarding,
+      tradingMode,
       realData,
       signed: args.has('--signed'),
       skipBuild,
@@ -78,7 +92,7 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
       tempData,
     },
     buildEnv: onboardingBuildEnv,
-    launchEnv: onboardingLaunchEnv,
+    launchEnv: { ...onboardingLaunchEnv, ...tradingModeLaunchEnv },
     unsetLaunchEnv,
   }
 }

--- a/scripts/desktop-packaged-smoke-plan.spec.ts
+++ b/scripts/desktop-packaged-smoke-plan.spec.ts
@@ -11,6 +11,7 @@ describe('buildDesktopPackagedSmokePlan', () => {
       onboarding: false,
       realData: true,
       tempData: false,
+      tradingMode: false,
     })
     expect(plan.buildEnv).toEqual({})
     expect(plan.launchEnv).toEqual({})
@@ -53,6 +54,38 @@ describe('buildDesktopPackagedSmokePlan', () => {
     const plan = buildDesktopPackagedSmokePlan(['--onboarding', '--real-data'])
 
     expect(plan.errors).toContain('[desktop-smoke] --onboarding always uses isolated temp data; drop --real-data')
+  })
+
+  it('makes the trading-mode lifecycle smoke isolated and self-terminating', () => {
+    const plan = buildDesktopPackagedSmokePlan(['--trading-mode'], {
+      OPENALICE_TRADING_MODE: 'pro',
+      OPENALICE_LITE_MODE: '1',
+    })
+
+    expect(plan.errors).toEqual([])
+    expect(plan.options).toMatchObject({
+      onboarding: false,
+      realData: false,
+      tempData: true,
+      tradingMode: true,
+    })
+    expect(plan.launchEnv).toEqual({
+      OPENALICE_MCP_ENABLED: '0',
+      OPENALICE_ELECTRON_SMOKE_TRADING_MODE: '1',
+      OPENALICE_ELECTRON_SMOKE_EXIT: '1',
+    })
+    expect(plan.unsetLaunchEnv).toEqual([
+      'OPENALICE_TRADING_MODE',
+      'OPENALICE_LITE_MODE',
+      'OPENALICE_UTA_DISABLED',
+    ])
+  })
+
+  it('rejects unsafe or contradictory trading-mode smoke flags', () => {
+    expect(buildDesktopPackagedSmokePlan(['--trading-mode', '--real-data']).errors)
+      .toContain('[desktop-smoke] --trading-mode always uses isolated temp data; drop --real-data')
+    expect(buildDesktopPackagedSmokePlan(['--trading-mode', '--onboarding']).errors)
+      .toContain('[desktop-smoke] choose either --onboarding or --trading-mode, not both')
   })
 
   it('rejects contradictory data flags', () => {

--- a/scripts/desktop-packaged-smoke.mjs
+++ b/scripts/desktop-packaged-smoke.mjs
@@ -8,7 +8,7 @@ import { buildDesktopPackagedSmokePlan } from './desktop-packaged-smoke-plan.mjs
 
 const repoRoot = resolve(import.meta.dirname, '..')
 const plan = buildDesktopPackagedSmokePlan(process.argv.slice(2), process.env)
-const { keep, onboarding, realData, signed, skipBuild, skipPack } = plan.options
+const { keep, onboarding, realData, signed, skipBuild, skipPack, tradingMode } = plan.options
 
 function printHelp() {
   console.log(`Usage: pnpm electron:smoke:packaged [options]
@@ -22,6 +22,8 @@ Options:
   --real-data    Use real data explicitly (default; kept for compatibility)
   --onboarding   Build with first-run guide enabled, use temp data, run an
                  automated renderer onboarding smoke, then exit
+  --trading-mode Use temp data, exercise lite -> readonly -> lite UTA lifecycle,
+                 then exit
   --signed       Allow local macOS code signing (default disables it)
   --keep         Keep the temporary smoke data directory after the app exits
   -h, --help     Show this help
@@ -120,7 +122,7 @@ const env = {
 
 for (const key of plan.unsetLaunchEnv) delete env[key]
 
-if (onboarding) {
+if (onboarding || tradingMode) {
   env.OPENALICE_UTA_PORT = String(await getAvailablePort())
 }
 
@@ -142,6 +144,9 @@ if (realData) {
 if (onboarding) {
   console.log('[desktop-smoke] onboarding smoke: enabled; app exits automatically after the renderer probe')
   console.log(`[desktop-smoke] onboarding UTA port: ${env.OPENALICE_UTA_PORT}`)
+} else if (tradingMode) {
+  console.log('[desktop-smoke] trading-mode smoke: lite -> readonly -> lite; app exits automatically')
+  console.log(`[desktop-smoke] trading-mode UTA port: ${env.OPENALICE_UTA_PORT}`)
 } else {
   console.log('[desktop-smoke] close the app window or press Ctrl-C here to stop')
 }

--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -19,12 +19,19 @@
  */
 
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process'
-import { createDecipheriv } from 'node:crypto'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { watch, mkdir, readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { dirname, basename, resolve } from 'node:path'
 import { probeFreePort } from '../probe-port.js'
+
+export {
+  isLiteModeEnv,
+  parseGuardianTradingModeEnv,
+  resolveGuardianTradingMode,
+  type GuardianTradingMode,
+  type GuardianTradingModePlan,
+} from '../../packages/guardian-runtime/src/trading-mode.js'
 
 export interface GuardianPorts {
   webPort: number
@@ -32,90 +39,6 @@ export interface GuardianPorts {
   utaPort: number
   /** Vite dev-server port — resolved by Guardian (dev only; prod has no Vite). */
   uiPort: number
-}
-
-export function isLiteModeEnv(env: NodeJS.ProcessEnv): boolean {
-  return truthyEnv(env['OPENALICE_LITE_MODE']) || truthyEnv(env['OPENALICE_UTA_DISABLED'])
-}
-
-export type GuardianTradingMode = 'lite' | 'readonly' | 'pro'
-
-export interface GuardianTradingModePlan {
-  mode: GuardianTradingMode
-  source: 'env' | 'config' | 'auto'
-  envLocked: boolean
-  hasUTAConfig: boolean
-}
-
-export function parseGuardianTradingModeEnv(env: NodeJS.ProcessEnv): GuardianTradingMode | null {
-  const raw = env['OPENALICE_TRADING_MODE']?.trim().toLowerCase()
-  if (raw === 'lite' || raw === 'readonly' || raw === 'pro') return raw
-  return isLiteModeEnv(env) ? 'lite' : null
-}
-
-export async function resolveGuardianTradingMode(
-  env: NodeJS.ProcessEnv,
-  userDataHome: string,
-): Promise<GuardianTradingModePlan> {
-  const envMode = parseGuardianTradingModeEnv(env)
-  const configuredMode = await readPersistedTradingMode(userDataHome)
-  const hasUTAConfig = await hasPersistedUTAs(userDataHome)
-  if (envMode) return { mode: envMode, source: 'env', envLocked: true, hasUTAConfig }
-  if (configuredMode) return { mode: configuredMode, source: 'config', envLocked: false, hasUTAConfig }
-  return { mode: hasUTAConfig ? 'pro' : 'lite', source: 'auto', envLocked: false, hasUTAConfig }
-}
-
-async function readPersistedTradingMode(userDataHome: string): Promise<GuardianTradingMode | null> {
-  try {
-    const raw = JSON.parse(await readFile(resolve(userDataHome, 'data', 'config', 'trading.json'), 'utf8')) as { mode?: unknown }
-    return raw.mode === 'lite' || raw.mode === 'readonly' || raw.mode === 'pro' ? raw.mode : null
-  } catch {
-    return null
-  }
-}
-
-async function hasPersistedUTAs(userDataHome: string): Promise<boolean> {
-  try {
-    const raw = JSON.parse(await readFile(resolve(userDataHome, 'data', 'config', 'accounts.json'), 'utf8'))
-    const accounts = isSealedEnvelope(raw)
-      ? await unsealGuardianAccounts(userDataHome, raw)
-      : raw
-    return Array.isArray(accounts) && accounts.length > 0
-  } catch {
-    return false
-  }
-}
-
-function isSealedEnvelope(value: unknown): value is { alg: string; iv: string; tag: string; data: string } {
-  return (
-    typeof value === 'object' && value !== null &&
-    (value as Record<string, unknown>)['$sealed'] === 1 &&
-    typeof (value as Record<string, unknown>)['iv'] === 'string' &&
-    typeof (value as Record<string, unknown>)['tag'] === 'string' &&
-    typeof (value as Record<string, unknown>)['data'] === 'string'
-  )
-}
-
-async function unsealGuardianAccounts(
-  userDataHome: string,
-  envelope: { alg: string; iv: string; tag: string; data: string },
-): Promise<unknown> {
-  if (envelope.alg !== 'aes-256-gcm') return []
-  const keyRaw = (await readFile(resolve(userDataHome, 'sealing.key'), 'utf8')).trim()
-  const key = Buffer.from(keyRaw, 'base64')
-  const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(envelope.iv, 'base64'))
-  decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'))
-  const plaintext = Buffer.concat([
-    decipher.update(Buffer.from(envelope.data, 'base64')),
-    decipher.final(),
-  ])
-  return JSON.parse(plaintext.toString('utf8')) as unknown
-}
-
-function truthyEnv(raw: string | undefined): boolean {
-  if (raw === undefined || raw === '') return false
-  const normalized = raw.toLowerCase()
-  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on'
 }
 
 // ── Port configuration (L1 → L2) ────────────────────────────


### PR DESCRIPTION
## Why

Electron used a startup-only UTA rule: it checked `OPENALICE_LITE_MODE` once, while dev and Docker Guardians already resolved `env > trading.json > accounts auto`. A fresh desktop install could therefore start UTA despite Alice selecting lite mode. Conversely, an Electron process started in lite mode installed no restart-flag watcher, so switching to readonly/pro could update configuration without starting UTA.

## What changed

- Move the existing Guardian trading-mode resolver into `@traderalice/guardian-runtime` and reuse it from dev and Electron.
- Preserve env locks, persisted `trading.json`, account-based auto inference, and sealed `accounts.json` support.
- Resolve the initial Electron trading mode before child startup.
- Keep `OPENALICE_UTA_URL` available to Alice without turning inferred lite into an env lock.
- Watch `restart-uta.flag` in every mode and reconcile UTA dynamically:
  - lite + running → stop
  - readonly/pro + stopped → start
  - readonly/pro + running → restart
- Queue the latest requested mode while a transition is active.
- Add a reusable packaged `lite → readonly → lite` smoke.

## Safety boundaries

- Runtime locks, Guardian takeover order, heartbeat semantics, and user-data migrations are unchanged.
- All real-process tests use disposable `OPENALICE_HOME` and `AQ_LAUNCHER_ROOT`.
- UTA remains optional: Alice, renderer, workspaces, Pi runtime discovery, and local CLI remain available without it.
- The branch is synchronized with current `dev`, including #487.

## Verification on latest dev

- Guardian runtime typecheck, 19 package tests, and build passed.
- Root and Desktop TypeScript checks passed.
- `pnpm test` — 191 files passed, 1 skipped; 2462 tests passed, 6 skipped.
- Guardian recovery smoke:
  - healthy duplicate blocked
  - explicit takeover stops the old owner first
  - crashed owner stale lock reclaimed
  - stubborn owner receives TERM then forced tree stop
- Real dev Guardian smoke:
  - UTA, Alice, and Vite start
  - UTA restart succeeds
  - teardown leaves no orphaned ports
- Electron guardian-recovery / PTY smoke:
  - prior owner takeover succeeds
  - renderer bridge and workspace shell PTY attach
  - CLI socket smoke passes
- Packaged app with disposable data:
  - starts in auto-lite without UTA
  - Alice, renderer, tool gateway, templates, and managed Pi path initialize
  - closes cleanly with no active workspace sessions
- Packaged trading-mode smoke:
  - lite starts with UTA absent
  - readonly starts UTA and reaches available
  - lite stops only UTA
  - Alice and renderer remain responsive through the full transition

## Review state

Reproduced on the latest `dev`. Ready to merge after the latest macOS/Windows package and Ubuntu/Windows dev-smoke checks are green.
