### PR TITLE
Allow Pi startup networking

### DIFF
--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -401,10 +401,10 @@ describe('piAdapter AI-config', () => {
     ]);
   });
 
-  it('composeEnv sets PI_OFFLINE always; PI_CODING_AGENT_DIR only in override mode', async () => {
+  it('composeEnv leaves Pi startup networking to the base env and redirects only in override mode', async () => {
     // No .pi-agent yet → no redirect.
     const before = piAdapter.composeEnv!({ cwd: dir, env: mcpEnv });
-    expect(before['PI_OFFLINE']).toBe('1');
+    expect(before['PI_OFFLINE']).toBeUndefined();
     expect(before['PI_CODING_AGENT_DIR']).toBeUndefined();
     // After writing a provider override, the agent dir is redirected.
     await piAdapter.writeAiConfig!(dir, { baseUrl: 'https://cn.test/v1', apiKey: 'sk-p', model: 'deepseek-chat' });

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -126,11 +126,11 @@ export const piAdapter: CliAdapter = {
   },
 
   composeEnv(ctx: SpawnContext): Record<string, string> {
-    const env: Record<string, string> = {
-      // Disable startup-only network ops (version check / install ping). Does
-      // NOT block the `alice` CLI or the LLM call (verified pi 0.78.1).
-      PI_OFFLINE: '1',
-    };
+    // Do not force PI_OFFLINE. OpenAlice is a networked product and Pi may
+    // download missing runtime tools during startup. A user or launcher can
+    // still opt into Pi's offline behavior by setting PI_OFFLINE in the base
+    // process environment, which composeSpawnInputs preserves.
+    const env: Record<string, string> = {};
     // Override mode only: redirect the agent dir to the workspace's models.json.
     // Absent ⇒ unset ⇒ Pi uses the user's global ~/.pi/agent (its normal state).
     const piAgentDir = join(ctx.cwd, PI_AGENT_DIR);


### PR DESCRIPTION
## Summary

- Stop forcing `PI_OFFLINE=1` on every Pi workspace spawn.
- Let Pi use its normal startup networking for missing tools and extensions.
- Preserve an explicitly supplied `PI_OFFLINE` value through the existing base process environment.
- Make no changes to `vendor/`, Electron packaging, or the platform build matrix.

## Why

OpenAlice is already a networked trading-agent product. Forcing Pi into offline startup mode creates missing-tool failures, while solving each failure by bundling another platform binary expands an already costly Windows/macOS packaging surface.

This narrow runtime-policy change replaces the managed-`fd` packaging approach in #482.

## Test plan

- [x] `pnpm exec vitest run src/workspaces/adapters/ai-config.spec.ts` — 46 passed
- [x] `npx tsc --noEmit`
- [x] `pnpm test` — 189 files passed, 1 skipped; 2450 tests passed, 6 skipped

## Boundary touch

Pi spawn environment only. No trading, credentials, migrations, Electron package layout, or vendor runtime changes.

## Review state

Draft contribution PR. Do not merge until manually reviewed.