### PR TITLE
Remember Quick Chat provider preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,8 @@ data/                          # PORTABLE user state — the back-up / migrate /
                                # e2e suites read creds from the global store —
                                # adopt a legacy checkout's data/ first (dev
                                # banner shows the mv). Subdirs (via dataPath()):
+                               # preferences.json (non-sensitive, installation-
+                               # wide interaction preferences only);
                                # config/ (JSON + sealed accounts/auth +
                                # _meta.json migration journal), _backup/,
                                # sessions/ (web/admin JSONL — NOT workspace

--- a/src/core/preferences.spec.ts
+++ b/src/core/preferences.spec.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  readPreferences,
+  readQuickChatPreferences,
+  rememberQuickChatCredential,
+} from './preferences.js'
+
+const roots: string[] = []
+
+async function preferenceFile(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-preferences-'))
+  roots.push(root)
+  return join(root, 'preferences.json')
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('preferences', () => {
+  it('treats a missing or malformed file as empty preferences', async () => {
+    const path = await preferenceFile()
+    expect(await readPreferences(path)).toEqual({
+      version: 1,
+      quickChat: { lastCredentialByAgent: {} },
+    })
+
+    await writeFile(path, '{not-json', 'utf-8')
+    expect(await readQuickChatPreferences(path)).toEqual({ lastCredentialByAgent: {} })
+  })
+
+  it('remembers independent credentials per agent without secret material', async () => {
+    const path = await preferenceFile()
+    await rememberQuickChatCredential('pi', 'minimax-1', path)
+    await rememberQuickChatCredential('opencode', 'glm-1', path)
+
+    expect(await readQuickChatPreferences(path)).toEqual({
+      lastCredentialByAgent: { pi: 'minimax-1', opencode: 'glm-1' },
+    })
+    const raw = await readFile(path, 'utf-8')
+    expect(raw).not.toContain('apiKey')
+    expect(raw).not.toContain('baseUrl')
+  })
+
+  it('clears one agent without disturbing the others', async () => {
+    const path = await preferenceFile()
+    await Promise.all([
+      rememberQuickChatCredential('pi', 'minimax-1', path),
+      rememberQuickChatCredential('opencode', 'glm-1', path),
+    ])
+    await rememberQuickChatCredential('pi', null, path)
+
+    expect(await readQuickChatPreferences(path)).toEqual({
+      lastCredentialByAgent: { opencode: 'glm-1' },
+    })
+  })
+})

--- a/src/core/preferences.ts
+++ b/src/core/preferences.ts
@@ -1,0 +1,85 @@
+/**
+ * Installation-wide, non-sensitive user preferences.
+ *
+ * This deliberately lives outside data/config/: preferences are conveniences
+ * learned from interaction, not operator-authored runtime configuration. The
+ * file must remain safe to inspect and copy — store opaque identifiers only,
+ * never credential values, tokens, endpoints, or other secrets.
+ */
+
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { z } from 'zod'
+
+import { dataPath } from './paths.js'
+
+const quickChatPreferencesSchema = z.object({
+  lastCredentialByAgent: z.record(z.string(), z.string()).default({}),
+})
+
+const preferencesSchema = z.object({
+  version: z.literal(1).default(1),
+  quickChat: quickChatPreferencesSchema.default({ lastCredentialByAgent: {} }),
+})
+
+export type QuickChatPreferences = z.infer<typeof quickChatPreferencesSchema>
+export type Preferences = z.infer<typeof preferencesSchema>
+
+function emptyPreferences(): Preferences {
+  return preferencesSchema.parse({})
+}
+
+export function preferencesPath(): string {
+  return dataPath('preferences.json')
+}
+
+/** Missing or malformed preferences are equivalent to no preference. */
+export async function readPreferences(path = preferencesPath()): Promise<Preferences> {
+  try {
+    return preferencesSchema.parse(JSON.parse(await readFile(path, 'utf-8')))
+  } catch {
+    return emptyPreferences()
+  }
+}
+
+export async function readQuickChatPreferences(path = preferencesPath()): Promise<QuickChatPreferences> {
+  const preferences = await readPreferences(path)
+  return {
+    lastCredentialByAgent: { ...preferences.quickChat.lastCredentialByAgent },
+  }
+}
+
+// Alice is single-writer at the process level, but two UI requests can still
+// arrive together. Serialize the read-modify-write cycle so neither update is
+// lost, then use temp+rename so a crash cannot leave truncated JSON behind.
+let mutationQueue: Promise<unknown> = Promise.resolve()
+
+export async function rememberQuickChatCredential(
+  agentId: string,
+  credentialSlug: string | null,
+  path = preferencesPath(),
+): Promise<QuickChatPreferences> {
+  const operation = mutationQueue.catch(() => undefined).then(async () => {
+    const preferences = await readPreferences(path)
+    const next = { ...preferences.quickChat.lastCredentialByAgent }
+    if (credentialSlug === null) delete next[agentId]
+    else next[agentId] = credentialSlug
+
+    const updated = preferencesSchema.parse({
+      ...preferences,
+      quickChat: { lastCredentialByAgent: next },
+    })
+    await mkdir(dirname(path), { recursive: true })
+    const tempPath = `${path}.${process.pid}.tmp`
+    try {
+      await writeFile(tempPath, JSON.stringify(updated, null, 2) + '\n', { mode: 0o600 })
+      await rename(tempPath, path)
+    } catch (error) {
+      await unlink(tempPath).catch(() => undefined)
+      throw error
+    }
+    return { lastCredentialByAgent: { ...next } }
+  })
+  mutationQueue = operation
+  return operation
+}

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -29,6 +29,7 @@ import { createEntityRoutes } from './routes/entities.js'
 import { createWikilinkRoutes } from './routes/wikilink.js'
 import { createVersionRoutes } from './routes/version.js'
 import { createAuthRoutes } from './routes/auth.js'
+import { createPreferencesRoutes } from './routes/preferences.js'
 import { createAuthMiddleware } from './middleware/auth.js'
 import { mountOpenTypeBB } from '../server/opentypebb.js'
 import { buildSDKCredentials } from '../domain/market-data/credential-map.js'
@@ -222,6 +223,7 @@ export class WebPlugin implements Plugin {
     app.route('/api/channels', createChannelsRoutes({ sessions, sseByChannel: this.sseByChannel }))
     app.route('/api/media', createMediaRoutes())
     app.route('/api/config', createConfigRoutes({ ctx }))
+    app.route('/api/preferences', createPreferencesRoutes())
     app.route('/api/market-data', createMarketDataRoutes(ctx))
     app.route('/api/events', createEventsRoutes({ ctx, ingestProducer: this.ingestProducer }))
     app.route('/api/topology', createTopologyRoutes(ctx))

--- a/src/webui/routes/preferences.spec.ts
+++ b/src/webui/routes/preferences.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createPreferencesRoutes } from './preferences.js'
+
+describe('preferences routes', () => {
+  it('reads the non-sensitive quick-chat preference map', async () => {
+    const read = vi.fn(async () => ({ lastCredentialByAgent: { pi: 'minimax-1' } }))
+    const app = createPreferencesRoutes({
+      readQuickChatPreferences: read,
+      rememberQuickChatCredential: vi.fn(),
+    })
+
+    const response = await app.request('/quick-chat')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ lastCredentialByAgent: { pi: 'minimax-1' } })
+    expect(read).toHaveBeenCalledOnce()
+  })
+
+  it('persists a provider choice for a loginless runtime', async () => {
+    const remember = vi.fn(async (agent: string, credentialSlug: string | null) => ({
+      lastCredentialByAgent: { [agent]: credentialSlug! },
+    }))
+    const app = createPreferencesRoutes({
+      readQuickChatPreferences: vi.fn(),
+      rememberQuickChatCredential: remember,
+    })
+
+    const response = await app.request('/quick-chat', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agent: 'pi', credentialSlug: 'minimax-1' }),
+    })
+    expect(response.status).toBe(200)
+    expect(remember).toHaveBeenCalledWith('pi', 'minimax-1')
+  })
+
+  it('rejects unknown runtimes and empty slugs without writing', async () => {
+    const remember = vi.fn()
+    const app = createPreferencesRoutes({
+      readQuickChatPreferences: vi.fn(),
+      rememberQuickChatCredential: remember,
+    })
+
+    for (const body of [
+      { agent: 'codex', credentialSlug: 'openai-1' },
+      { agent: 'pi', credentialSlug: '' },
+    ]) {
+      const response = await app.request('/quick-chat', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      expect(response.status).toBe(400)
+    }
+    expect(remember).not.toHaveBeenCalled()
+  })
+})

--- a/src/webui/routes/preferences.ts
+++ b/src/webui/routes/preferences.ts
@@ -1,0 +1,55 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+
+import {
+  readQuickChatPreferences,
+  rememberQuickChatCredential,
+  type QuickChatPreferences,
+} from '../../core/preferences.js'
+
+const LOGINLESS_AGENTS = ['opencode', 'pi'] as const
+
+const quickChatPreferenceUpdateSchema = z.object({
+  agent: z.enum(LOGINLESS_AGENTS),
+  credentialSlug: z.string().trim().min(1).max(128).nullable(),
+})
+
+interface PreferenceRouteDeps {
+  readQuickChatPreferences(): Promise<QuickChatPreferences>
+  rememberQuickChatCredential(agent: string, credentialSlug: string | null): Promise<QuickChatPreferences>
+}
+
+const defaultDeps: PreferenceRouteDeps = {
+  readQuickChatPreferences: () => readQuickChatPreferences(),
+  rememberQuickChatCredential: (agent, credentialSlug) =>
+    rememberQuickChatCredential(agent, credentialSlug),
+}
+
+export function createPreferencesRoutes(deps: PreferenceRouteDeps = defaultDeps) {
+  const app = new Hono()
+
+  app.get('/quick-chat', async (c) => {
+    try {
+      return c.json(await deps.readQuickChatPreferences())
+    } catch (error) {
+      return c.json({ error: 'preferences_read_failed', message: String(error) }, 500)
+    }
+  })
+
+  app.put('/quick-chat', async (c) => {
+    const parsed = quickChatPreferenceUpdateSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_quick_chat_preference' }, 400)
+    }
+    try {
+      return c.json(await deps.rememberQuickChatCredential(
+        parsed.data.agent,
+        parsed.data.credentialSlug,
+      ))
+    } catch (error) {
+      return c.json({ error: 'preferences_write_failed', message: String(error) }, 500)
+    }
+  })
+
+  return app
+}

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -18,6 +18,7 @@ import { inboxApi } from './inbox'
 import { entitiesApi } from './entities'
 import { versionApi } from './version'
 import { headlessApi } from './headless'
+import { preferencesApi } from './preferences'
 export const api = {
   config: configApi,
   events: eventsApi,
@@ -35,6 +36,7 @@ export const api = {
   entities: entitiesApi,
   version: versionApi,
   headless: headlessApi,
+  preferences: preferencesApi,
 }
 
 // Re-export all types for convenience

--- a/ui/src/api/preferences.ts
+++ b/ui/src/api/preferences.ts
@@ -1,0 +1,22 @@
+import { fetchJson, headers } from './client'
+
+export interface QuickChatPreferences {
+  lastCredentialByAgent: Record<string, string>
+}
+
+export const preferencesApi = {
+  getQuickChat(): Promise<QuickChatPreferences> {
+    return fetchJson('/api/preferences/quick-chat')
+  },
+
+  rememberQuickChatCredential(
+    agent: 'opencode' | 'pi',
+    credentialSlug: string | null,
+  ): Promise<QuickChatPreferences> {
+    return fetchJson('/api/preferences/quick-chat', {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({ agent, credentialSlug }),
+    })
+  },
+}

--- a/ui/src/demo/handlers/index.ts
+++ b/ui/src/demo/handlers/index.ts
@@ -15,6 +15,7 @@ import { agentStatusHandlers } from './agentStatus'
 import { newsListHandlers } from './newsList'
 import { devMiscHandlers } from './devMisc'
 import { headlessHandlers } from './headless'
+import { preferencesHandlers } from './preferences'
 import { catchAllHandlers } from './catchAll'
 
 // Order matters: catchAll must be LAST. MSW resolves handlers in registration
@@ -38,5 +39,6 @@ export const handlers = [
   ...newsListHandlers,
   ...devMiscHandlers,
   ...headlessHandlers,
+  ...preferencesHandlers,
   ...catchAllHandlers,
 ]

--- a/ui/src/demo/handlers/preferences.ts
+++ b/ui/src/demo/handlers/preferences.ts
@@ -1,0 +1,25 @@
+import { http, HttpResponse } from 'msw'
+
+const lastCredentialByAgent: Record<string, string> = { pi: 'minimax-1' }
+
+export const preferencesHandlers = [
+  http.get('/api/preferences/quick-chat', () =>
+    HttpResponse.json({ lastCredentialByAgent: { ...lastCredentialByAgent } }),
+  ),
+  http.put('/api/preferences/quick-chat', async ({ request }) => {
+    const body = (await request.json().catch(() => null)) as {
+      agent?: unknown
+      credentialSlug?: unknown
+    } | null
+    if (
+      !body ||
+      (body.agent !== 'opencode' && body.agent !== 'pi') ||
+      (typeof body.credentialSlug !== 'string' && body.credentialSlug !== null)
+    ) {
+      return HttpResponse.json({ error: 'invalid_quick_chat_preference' }, { status: 400 })
+    }
+    if (body.credentialSlug === null) delete lastCredentialByAgent[body.agent]
+    else lastCredentialByAgent[body.agent] = body.credentialSlug
+    return HttpResponse.json({ lastCredentialByAgent: { ...lastCredentialByAgent } })
+  }),
+]

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -115,14 +115,14 @@ export const workspacesHandlers = [
   http.post('/api/workspaces/agent-runtime-readiness/probe', () =>
     HttpResponse.json(demoAgentRuntimeReadiness),
   ),
-  // One sample vault credential so the quick-chat runtime picker (opencode/pi)
-  // shows a populated dropdown — a clean showcase, not a "go configure" prompt.
-  // `?agent=` filtering is a no-op here (the sample speaks openai-chat, which
-  // every loginless runtime accepts).
+  // Two sample vault credentials let the quick-chat demo show that a remembered
+  // provider can win over the first compatible option. Both speak openai-chat,
+  // which every loginless runtime accepts.
   http.get('/api/workspaces/credentials', () =>
     HttpResponse.json({
       credentials: [
         { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-chat': '' }, lastModel: 'gpt-5.5', apiKey: null },
+        { slug: 'minimax-1', vendor: 'minimax', label: 'MiniMax', authType: 'api-key', wires: { 'openai-chat': '' }, lastModel: 'MiniMax-M2.1', apiKey: null },
       ],
     }),
   ),
@@ -220,8 +220,8 @@ export const workspacesHandlers = [
           hasWorkspaceConfig: false,
           hasUsableWorkspaceConfig: false,
           detectedCredentialSlug: null,
-          compatibleCredentialSlugs: ['openai-1'],
-          injectableCredentialSlugs: ['openai-1'],
+          compatibleCredentialSlugs: ['openai-1', 'minimax-1'],
+          injectableCredentialSlugs: ['openai-1', 'minimax-1'],
         },
         pi: {
           agent: 'pi',
@@ -231,8 +231,8 @@ export const workspacesHandlers = [
           hasWorkspaceConfig: false,
           hasUsableWorkspaceConfig: false,
           detectedCredentialSlug: null,
-          compatibleCredentialSlugs: ['openai-1'],
-          injectableCredentialSlugs: ['openai-1'],
+          compatibleCredentialSlugs: ['openai-1', 'minimax-1'],
+          injectableCredentialSlugs: ['openai-1', 'minimax-1'],
         },
       },
     }),

--- a/ui/src/pages/ChatLandingPage.spec.ts
+++ b/ui/src/pages/ChatLandingPage.spec.ts
@@ -77,7 +77,53 @@ describe('resolveChatCredential', () => {
     expect(resolveChatCredential(credentials, null, null, true)).toBeNull()
   })
 
+  it('uses a configured workspace default before the remembered quick-chat choice', () => {
+    expect(resolveChatCredential(
+      credentials,
+      null,
+      null,
+      false,
+      'saved-b',
+      'saved-a',
+    )).toBe('saved-b')
+  })
+
+  it('uses the remembered quick-chat choice before the first credential', () => {
+    expect(resolveChatCredential(
+      credentials,
+      null,
+      null,
+      false,
+      null,
+      'saved-b',
+    )).toBe('saved-b')
+  })
+
+  it('keeps the workspace credential ahead of global defaults and history', () => {
+    expect(resolveChatCredential(
+      credentials,
+      null,
+      'saved-b',
+      true,
+      'saved-a',
+      'saved-a',
+    )).toBe('saved-b')
+  })
+
+  it('does not expose a global fallback while workspace detection is pending', () => {
+    expect(resolveChatCredential(
+      credentials,
+      null,
+      null,
+      false,
+      'saved-a',
+      'saved-b',
+      false,
+    )).toBeNull()
+  })
+
   it('does not claim a deleted credential is available', () => {
     expect(resolveChatCredential(credentials, null, 'missing', true)).toBeNull()
+    expect(resolveChatCredential(credentials, 'missing', null, false, null, 'saved-b')).toBe('saved-b')
   })
 })

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -32,6 +32,8 @@ import {
   type SavedCredential,
 } from '../components/workspace/api'
 import { useWorkspace } from '../tabs/store'
+import { configApi, type WorkspaceCredentialDefault } from '../api/config'
+import { preferencesApi } from '../api/preferences'
 
 /** Agent runtimes with no login of their own — they need an injected AI config
  *  to start (claude/codex carry their own CLI login). Mirrors the backend's
@@ -87,15 +89,22 @@ export function resolveChatCredential(
   pickedCredential: string | null,
   detectedCredential: string | null,
   workspaceCredentialReady: boolean,
+  workspaceDefaultCredential: string | null = null,
+  lastCredential: string | null = null,
+  workspaceCredentialResolved = true,
 ): string | null {
-  if (pickedCredential !== null) return pickedCredential
-  if (
-    detectedCredential !== null &&
-    credentials?.some((credential) => credential.slug === detectedCredential)
-  ) {
-    return detectedCredential
-  }
-  return workspaceCredentialReady ? null : (credentials?.[0]?.slug ?? null)
+  const available = (slug: string | null): slug is string => (
+    slug !== null && credentials?.some((credential) => credential.slug === slug) === true
+  )
+  if (available(pickedCredential)) return pickedCredential
+  // An existing workspace owns its provider choice. Do not briefly expose (or
+  // submit) a global fallback while its on-disk config is still being detected.
+  if (!workspaceCredentialResolved) return null
+  if (available(detectedCredential)) return detectedCredential
+  if (workspaceCredentialReady) return null
+  if (available(workspaceDefaultCredential)) return workspaceDefaultCredential
+  if (available(lastCredential)) return lastCredential
+  return credentials?.[0]?.slug ?? null
 }
 
 /**
@@ -183,6 +192,11 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   // The cred today's chat workspace is already configured with, if it exists.
   const [detectedCred, setDetectedCred] = useState<string | null>(null)
   const [agentReadiness, setAgentReadiness] = useState<AgentCredentialReadiness | null>(null)
+  const [credentialWorkspaceResolved, setCredentialWorkspaceResolved] = useState(false)
+  const [workspaceCredentialDefaults, setWorkspaceCredentialDefaults] = useState<
+    Record<string, WorkspaceCredentialDefault>
+  >({})
+  const [lastCredentialByAgent, setLastCredentialByAgent] = useState<Record<string, string>>({})
   const [credMenuOpen, setCredMenuOpen] = useState(false)
   const credBoxRef = useRef<HTMLDivElement>(null)
 
@@ -203,16 +217,25 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   // both; claude/codex never show the picker.
   useEffect(() => {
     let live = true
-    const refresh = () => {
+    const refreshCredentials = () => {
       void listAgentCredentials('opencode')
         .then((list) => { if (live) setCreds(list) })
         .catch(() => { if (live) setCreds([]) })
     }
-    refresh()
-    window.addEventListener('openalice:credentials-changed', refresh)
+    void Promise.all([
+      listAgentCredentials('opencode').catch(() => []),
+      preferencesApi.getQuickChat().catch(() => ({ lastCredentialByAgent: {} })),
+      configApi.getWorkspaceCredentialDefaults().catch(() => ({ defaults: {}, compatibleByAgent: {} })),
+    ]).then(([list, preferences, defaults]) => {
+      if (!live) return
+      setCreds(list)
+      setLastCredentialByAgent(preferences.lastCredentialByAgent)
+      setWorkspaceCredentialDefaults(defaults.defaults)
+    })
+    window.addEventListener('openalice:credentials-changed', refreshCredentials)
     return () => {
       live = false
-      window.removeEventListener('openalice:credentials-changed', refresh)
+      window.removeEventListener('openalice:credentials-changed', refreshCredentials)
     }
   }, [])
 
@@ -230,15 +253,24 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     if (!needsCred || effectiveAgent === null || credentialWorkspace === null || credentialWorkspace === undefined) {
       setDetectedCred(null)
       setAgentReadiness(null)
+      setCredentialWorkspaceResolved(true)
       return
     }
     let live = true
-    detectWorkspaceCredential(credentialWorkspace.id, effectiveAgent)
-      .then((r) => { if (live) setDetectedCred(r.slug) })
-      .catch(() => { if (live) setDetectedCred(null) })
-    getAgentReadiness(credentialWorkspace.id)
-      .then((bundle) => { if (live) setAgentReadiness(bundle.agents[effectiveAgent] ?? null) })
-      .catch(() => { if (live) setAgentReadiness(null) })
+    setCredentialWorkspaceResolved(false)
+    void Promise.allSettled([
+      detectWorkspaceCredential(credentialWorkspace.id, effectiveAgent),
+      getAgentReadiness(credentialWorkspace.id),
+    ]).then(([detected, readiness]) => {
+      if (!live) return
+      setDetectedCred(detected.status === 'fulfilled' ? detected.value.slug : null)
+      setAgentReadiness(
+        readiness.status === 'fulfilled'
+          ? readiness.value.agents[effectiveAgent] ?? null
+          : null,
+      )
+      setCredentialWorkspaceResolved(true)
+    })
     return () => { live = false }
   }, [needsCred, effectiveAgent, credentialWorkspace])
 
@@ -249,6 +281,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     agentReadiness.source === 'workspace-config'
   const noCreds =
     needsCred &&
+    credentialWorkspaceResolved &&
     !workspaceCredReady &&
     !selectedRuntimeUsesGlobalConfig &&
     creds !== null &&
@@ -260,6 +293,9 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     pickedCred,
     detectedCred,
     workspaceCredReady,
+    effectiveAgent ? workspaceCredentialDefaults[effectiveAgent]?.credentialSlug ?? null : null,
+    effectiveAgent ? lastCredentialByAgent[effectiveAgent] ?? null : null,
+    credentialWorkspaceResolved,
   )
   const credInfo = creds?.find((c) => c.slug === effectiveCred) ?? null
   // Warn when sending will overwrite the workspace's existing cred with a
@@ -284,7 +320,11 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
 
   // A missing runtime choice should open the picker, not leave a mysteriously
   // disabled send button. submit() already handles that branch.
-  const canSend = value.trim().length > 0 && !launching
+  const credentialSelectionReady =
+    !needsCred ||
+    selectedRuntimeUsesGlobalConfig ||
+    (creds !== null && credentialWorkspaceResolved)
+  const canSend = value.trim().length > 0 && !launching && credentialSelectionReady
 
   // Close the agent menu on an outside click.
   useEffect(() => {
@@ -301,6 +341,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   const submit = async () => {
     const prompt = value.trim()
     if (!prompt || launching) return
+    if (!credentialSelectionReady) return
     if (effectiveAgent === null) {
       setAgentMenuOpen(true)
       return
@@ -463,6 +504,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                           role="menuitem"
                           onClick={() => {
                             setSelectedAgent(a.id)
+                            setPickedCred(null)
                             void setDefaultAgent(a.id)
                             setAgentMenuOpen(false)
                           }}
@@ -524,6 +566,15 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                             role="menuitem"
                             onClick={() => {
                               setPickedCred(cr.slug)
+                              if (effectiveAgent === 'opencode' || effectiveAgent === 'pi') {
+                                setLastCredentialByAgent((current) => ({
+                                  ...current,
+                                  [effectiveAgent]: cr.slug,
+                                }))
+                                void preferencesApi.rememberQuickChatCredential(effectiveAgent, cr.slug)
+                                  .then((preferences) => setLastCredentialByAgent(preferences.lastCredentialByAgent))
+                                  .catch(() => undefined)
+                              }
                               setCredMenuOpen(false)
                             }}
                             className={`w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : 'text-text'}`}


### PR DESCRIPTION
## Summary
- add a dedicated non-sensitive data/preferences.json store and authenticated preferences API
- remember the last Quick Chat credential independently for Pi and opencode
- keep existing workspace credentials and configured workspace defaults ahead of recent history, with deleted credentials ignored
- wait for workspace credential detection before showing or submitting a global fallback
- add demo coverage with two providers so the remembered-choice path is visible

## Storage boundary
- preferences contain credential slugs only
- this flow does not write AI provider credentials, API keys, endpoints, or the credential manager file
- writes are serialized and use a temporary file plus atomic rename

## Test plan
- pnpm test
- pnpm -C ui exec tsc -b
- npx tsc --noEmit
- pnpm electron:build
- pnpm electron:smoke:pty
- browser demo: Pi resolves the remembered second provider; a manual provider choice survives switching runtimes