### PR TITLE
Keep auth stable across backend hot reload

### DIFF
--- a/ui/src/auth/AuthContext.spec.tsx
+++ b/ui/src/auth/AuthContext.spec.tsx
@@ -1,0 +1,107 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getStatus: vi.fn(),
+}))
+
+vi.mock('./api', () => ({
+  getStatus: mocks.getStatus,
+}))
+
+import { AuthProvider, useAuth } from './AuthContext'
+import { AuthGate } from './AuthGate'
+
+function WorkspaceHarness() {
+  const { refresh } = useAuth()
+  return (
+    <>
+      <div>workspace-app</div>
+      <button type="button" onClick={() => void refresh()}>Refresh auth</button>
+    </>
+  )
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  mocks.getStatus.mockReset()
+  vi.useRealTimers()
+})
+
+describe('AuthProvider backend recovery', () => {
+  it('does not manufacture a login screen during a cold-start outage', async () => {
+    vi.useFakeTimers()
+    mocks.getStatus
+      .mockRejectedValueOnce(new Error('backend restarting'))
+      .mockResolvedValueOnce({ authed: true, tokenConfigured: true })
+
+    render(
+      <AuthProvider>
+        <AuthGate><WorkspaceHarness /></AuthGate>
+      </AuthProvider>,
+    )
+    await flushEffects()
+
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(screen.queryByText('workspace-app')).toBeNull()
+    expect(document.querySelector('input[type="password"]')).toBeNull()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250)
+    })
+
+    expect(screen.getByText('workspace-app')).toBeTruthy()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('keeps an authenticated app mounted while Alice restarts, then recovers', async () => {
+    vi.useFakeTimers()
+    mocks.getStatus
+      .mockResolvedValueOnce({ authed: true, tokenConfigured: true })
+      .mockRejectedValueOnce(new Error('backend restarting'))
+      .mockResolvedValueOnce({ authed: true, tokenConfigured: true })
+
+    render(
+      <AuthProvider>
+        <AuthGate><WorkspaceHarness /></AuthGate>
+      </AuthProvider>,
+    )
+    await flushEffects()
+    expect(screen.getByText('workspace-app')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh auth' }))
+    await flushEffects()
+
+    expect(screen.getByText('workspace-app')).toBeTruthy()
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(document.querySelector('input[type="password"]')).toBeNull()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250)
+    })
+
+    expect(screen.getByText('workspace-app')).toBeTruthy()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('still shows login for an explicit unauthenticated response', async () => {
+    mocks.getStatus.mockResolvedValueOnce({ authed: false, tokenConfigured: true })
+
+    render(
+      <AuthProvider>
+        <AuthGate><WorkspaceHarness /></AuthGate>
+      </AuthProvider>,
+    )
+    await flushEffects()
+
+    expect(screen.queryByText('workspace-app')).toBeNull()
+    expect(document.querySelector('input[type="password"]')).toBeTruthy()
+  })
+})

--- a/ui/src/auth/AuthContext.tsx
+++ b/ui/src/auth/AuthContext.tsx
@@ -11,18 +11,40 @@
  *                        a token. Defensive: shouldn't happen because
  *                        bootstrap runs at boot. Shows a setup hint.
  *
+ * A transport failure or 5xx is not a fourth auth decision: it preserves the
+ * last confirmed state and retries. On a cold mount it stays in loading; once
+ * authed it keeps the App mounted so backend hot reload cannot strand the UI.
+ *
  * A global window-level `app:unauthorized` event flips the state back to
  * 'login-required' — `fetchJson` dispatches it on any 401 (see api/client.ts).
  */
 
-import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
 import { getStatus, type AuthStatus } from './api'
 
 type AuthState = 'loading' | 'authed' | 'login-required' | 'no-token'
 
+export const AUTH_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 3_000] as const
+
+export function authRetryDelayMs(attempt: number): number {
+  const index = Math.max(0, Math.min(attempt - 1, AUTH_RETRY_DELAYS_MS.length - 1))
+  return AUTH_RETRY_DELAYS_MS[index]
+}
+
 interface AuthContextValue {
   state: AuthState
   status: AuthStatus | null
+  /** The last status check was inconclusive because Alice is unavailable.
+   *  Keep the last confirmed auth decision while retrying. */
+  backendUnavailable: boolean
   /** Re-check /api/auth/status. Called after login success. */
   refresh: () => Promise<void>
   /** Locally flip state to login-required (e.g. after logout). */
@@ -46,20 +68,53 @@ function deriveState(status: AuthStatus | null): AuthState {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<AuthStatus | null>(null)
+  const [backendUnavailable, setBackendUnavailable] = useState(false)
+  const [retryAttempt, setRetryAttempt] = useState(0)
+  const mountedRef = useRef(false)
+  const requestGenerationRef = useRef(0)
   const state = deriveState(status)
 
   const refresh = useCallback(async () => {
-    const next = await getStatus()
-    setStatus(next)
+    const generation = ++requestGenerationRef.current
+    try {
+      const next = await getStatus()
+      if (!mountedRef.current || generation !== requestGenerationRef.current) return
+      setStatus(next)
+      setBackendUnavailable(false)
+      setRetryAttempt(0)
+    } catch {
+      if (!mountedRef.current || generation !== requestGenerationRef.current) return
+      // Absence of an answer is not an authentication decision. Preserve the
+      // last confirmed status (and therefore the mounted App) while Alice's
+      // watch process comes back, then retry with a short capped backoff.
+      setBackendUnavailable(true)
+      setRetryAttempt((attempt) => attempt + 1)
+    }
   }, [])
 
   const markUnauthorized = useCallback(() => {
+    requestGenerationRef.current += 1
     setStatus({ authed: false, tokenConfigured: true })
+    setBackendUnavailable(false)
+    setRetryAttempt(0)
   }, [])
 
   useEffect(() => {
+    mountedRef.current = true
     void refresh()
+    return () => {
+      mountedRef.current = false
+      requestGenerationRef.current += 1
+    }
   }, [refresh])
+
+  useEffect(() => {
+    if (!backendUnavailable) return
+    const timer = window.setTimeout(() => {
+      void refresh()
+    }, authRetryDelayMs(retryAttempt))
+    return () => window.clearTimeout(timer)
+  }, [backendUnavailable, refresh, retryAttempt])
 
   // Wire the global unauthorized signal — any fetchJson 401 flips us
   // back to the login page, killing whatever the user was doing. This
@@ -72,7 +127,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [markUnauthorized])
 
   return (
-    <AuthContext.Provider value={{ state, status, refresh, markUnauthorized }}>
+    <AuthContext.Provider value={{
+      state,
+      status,
+      backendUnavailable,
+      refresh,
+      markUnauthorized,
+    }}>
       {children}
     </AuthContext.Provider>
   )

--- a/ui/src/auth/AuthGate.tsx
+++ b/ui/src/auth/AuthGate.tsx
@@ -9,21 +9,41 @@
  */
 
 import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useAuth } from './AuthContext'
 import { LoginPage, NoTokenPage } from './LoginPage'
 import { Spinner } from '../components/StateViews'
 
+function ReconnectNotice() {
+  const { t } = useTranslation()
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed left-1/2 top-4 z-[80] flex -translate-x-1/2 items-center gap-2 rounded-lg border border-border bg-bg-secondary/95 px-3 py-2 text-[12px] text-text-muted shadow-lg backdrop-blur-sm"
+    >
+      <Spinner size="sm" />
+      <span>{t('auth.reconnecting')}</span>
+    </div>
+  )
+}
+
 export function AuthGate({ children }: { children: ReactNode }) {
-  const { state } = useAuth()
+  const { state, backendUnavailable } = useAuth()
+  const { t } = useTranslation()
 
   if (state === 'loading') {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-bg">
+      <div className="min-h-screen flex flex-col items-center justify-center gap-3 bg-bg text-[12px] text-text-muted">
         <Spinner />
+        {backendUnavailable && <span role="status">{t('auth.reconnecting')}</span>}
       </div>
     )
   }
-  if (state === 'login-required') return <LoginPage />
-  if (state === 'no-token') return <NoTokenPage />
-  return <>{children}</>
+  return (
+    <>
+      {state === 'login-required' ? <LoginPage /> : state === 'no-token' ? <NoTokenPage /> : children}
+      {backendUnavailable && <ReconnectNotice />}
+    </>
+  )
 }

--- a/ui/src/auth/api.spec.ts
+++ b/ui/src/auth/api.spec.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AuthStatusUnavailableError, getStatus } from './api'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('auth status API', () => {
+  it('keeps backend outages distinct from an authentication denial', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 502,
+    })))
+
+    await expect(getStatus()).rejects.toMatchObject({
+      name: 'AuthStatusUnavailableError',
+      status: 502,
+    } satisfies Partial<AuthStatusUnavailableError>)
+  })
+
+  it('returns an explicit unauthenticated decision from a healthy backend', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ authed: false, tokenConfigured: true }),
+    })))
+
+    await expect(getStatus()).resolves.toEqual({ authed: false, tokenConfigured: true })
+  })
+
+  it('keeps an explicit 401 as an authentication denial', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 401,
+    })))
+
+    await expect(getStatus()).resolves.toEqual({ authed: false, tokenConfigured: true })
+  })
+
+  it('treats network and malformed-response failures as unavailable', async () => {
+    const fetch = vi.fn()
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ nope: true }) })
+    vi.stubGlobal('fetch', fetch)
+
+    await expect(getStatus()).rejects.toBeInstanceOf(AuthStatusUnavailableError)
+    await expect(getStatus()).rejects.toBeInstanceOf(AuthStatusUnavailableError)
+  })
+})

--- a/ui/src/auth/api.ts
+++ b/ui/src/auth/api.ts
@@ -12,14 +12,48 @@ export interface AuthStatus {
   session?: { createdAt: string; lastSeenAt: string }
 }
 
+/** The auth backend could not answer authoritatively. This is deliberately
+ * different from `{ authed: false }`: a restart window must never manufacture
+ * a logout decision. */
+export class AuthStatusUnavailableError extends Error {
+  readonly status: number | null
+
+  constructor(message: string, options: { status?: number; cause?: unknown } = {}) {
+    super(message, { cause: options.cause })
+    this.name = 'AuthStatusUnavailableError'
+    this.status = options.status ?? null
+  }
+}
+
 export async function getStatus(): Promise<AuthStatus> {
-  const res = await fetch('/api/auth/status', { credentials: 'same-origin' })
-  if (!res.ok) {
-    // If the backend can't even serve /status, treat as "auth required"
-    // pessimistically — better than locking the user out of the login page.
+  let res: Response
+  try {
+    res = await fetch('/api/auth/status', { credentials: 'same-origin' })
+  } catch (cause) {
+    throw new AuthStatusUnavailableError('Auth status request failed', { cause })
+  }
+  if (res.status === 401) {
     return { authed: false, tokenConfigured: true }
   }
-  return res.json()
+  if (!res.ok) {
+    throw new AuthStatusUnavailableError(`Auth status returned HTTP ${res.status}`, {
+      status: res.status,
+    })
+  }
+  let body: unknown
+  try {
+    body = await res.json()
+  } catch (cause) {
+    throw new AuthStatusUnavailableError('Auth status returned invalid JSON', { cause })
+  }
+  if (
+    typeof body !== 'object' || body === null ||
+    typeof (body as Partial<AuthStatus>).authed !== 'boolean' ||
+    typeof (body as Partial<AuthStatus>).tokenConfigured !== 'boolean'
+  ) {
+    throw new AuthStatusUnavailableError('Auth status returned an invalid payload')
+  }
+  return body as AuthStatus
 }
 
 export async function login(token: string): Promise<{ ok: boolean; error?: string }> {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -627,6 +627,7 @@ export const en = {
     signIn: 'Sign in',
     noTokenHeading: 'No admin token configured',
     loginFailed: 'Login failed',
+    reconnecting: 'Reconnecting to OpenAlice…',
   },
 } as const
 

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -614,5 +614,6 @@ export const ja: Resources = {
     signIn: 'サインイン',
     noTokenHeading: '管理者トークンが設定されていません',
     loginFailed: 'ログインに失敗しました',
+    reconnecting: 'OpenAlice に再接続しています…',
   },
 }

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -622,5 +622,6 @@ export const zhHant: Resources = {
     signIn: '登入',
     noTokenHeading: '未設定管理員權杖',
     loginFailed: '登入失敗',
+    reconnecting: '正在重新連線 OpenAlice…',
   },
 }

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -614,5 +614,6 @@ export const zh: Resources = {
     signIn: '登录',
     noTokenHeading: '未配置管理员令牌',
     loginFailed: '登录失败',
+    reconnecting: '正在重新连接 OpenAlice…',
   },
 }


### PR DESCRIPTION
## Summary
- distinguish temporary auth-backend outages from an explicit authentication denial
- keep an already authenticated App mounted while Alice restarts and retry status checks with capped backoff
- show a lightweight reconnect state on cold load instead of the admin-token login screen
- preserve explicit 401 and authed:false behavior as real login gates

## Test plan
- pnpm -C ui exec tsc -b
- pnpm exec vitest run ui/src/auth/api.spec.ts ui/src/auth/AuthContext.spec.tsx scripts/guardian/dev-hot-reload.spec.ts
- bash ~/.codex/skills/openalice-guardian-recovery/scripts/run-checks.sh /Users/ame/2604dev/OpenAlice full
- pnpm electron:smoke:pty
- isolated browser test: Vite auth proxy returns ECONNREFUSED, UI shows reconnecting without a token field, restored backend returns to the App without reload or login

## Boundary touch
Auth entry path only. This does not change backend authorization, token/session storage, cookies, localhost passthrough, Guardian ownership, or runtime locks.