### PR TITLE
Fix Windows desktop and workspace runtime

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Executable/importable scripts must keep Unix newlines. In particular,
+# esbuild/Vitest rejects a CRLF-converted shebang in imported `.mjs` files on
+# Windows, and Git Bash scripts must not acquire CRLF line endings.
+*.mjs text eol=lf
+*.sh text eol=lf
+src/workspaces/cli/bin/* text eol=lf
+
+# Native Windows launchers are consumed by cmd.exe.
+*.cmd text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,35 @@ jobs:
 
       - run: pnpm test
 
+  # The full Vitest suite includes path, port-binding, process-launch, and
+  # packaged-toolchain behavior whose semantics differ materially by host OS.
+  # Ubuntu remains the build gate above; this matrix prevents a Linux-only
+  # green check from shipping regressions to macOS or Windows users.
+  cross-platform-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+        timeout-minutes: 15
+
+      - run: pnpm test
+        timeout-minutes: 15
+
   # Boots the real `pnpm dev` stack and asserts UTA/Alice/Vite all spawn.
   # Exists to catch cross-platform spawn regressions (e.g. `spawn tsx ENOENT`
   # on Windows) that `pnpm test` can't see — esbuild transpiles, it never

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -20,7 +20,7 @@
  * Out of scope (future iterations): tray icon, multi-window, native menus.
  */
 
-import { app, BrowserWindow, dialog, Menu, protocol } from 'electron'
+import { app, BrowserWindow, dialog, Menu, protocol, session } from 'electron'
 import { runRendererTradingModeSmoke } from './trading-mode-smoke.js'
 import { planUTATransition } from './uta-lifecycle.js'
 import {
@@ -42,6 +42,7 @@ import { probeFreePort } from './probe-port.js'
 import { relocateLegacyData } from './relocate-data.js'
 import { configureAutoUpdate } from './auto-update.js'
 import { fetchAliceWebRequest, handleOpenAliceIpcMessage, registerOpenAliceIpc } from './ipc.js'
+import { proxyEnvFromRules } from './proxy-env.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -263,6 +264,27 @@ function resolveManagedRuntimeEnv(opts: {
   }
 
   return out
+}
+
+async function resolveChildProxyEnv(): Promise<Record<string, string>> {
+  // Existing env is authoritative on every platform. Electron 39 embeds Node
+  // 22.22, whose fetch stack consumes it only when NODE_USE_ENV_PROXY is set.
+  const explicit = proxyEnvFromRules('', process.env)
+  if (Object.keys(explicit).length > 0 || process.env['HTTPS_PROXY'] || process.env['HTTP_PROXY'] || process.env['ALL_PROXY']) {
+    return explicit
+  }
+  if (process.platform !== 'win32') return {}
+
+  try {
+    // Chromium already understands Windows Internet Options, including PAC.
+    // Resolve one representative HTTPS API URL and pass a concrete proxy to
+    // the pure-Node Alice/UTA children, whose fetch does not consult Chromium.
+    const rules = await session.defaultSession.resolveProxy('https://api.openai.com/')
+    return proxyEnvFromRules(rules, process.env)
+  } catch (err) {
+    console.warn(`[guardian] could not resolve Windows system proxy: ${err instanceof Error ? err.message : String(err)}`)
+    return {}
+  }
 }
 
 function isLiteModeEnv(env: NodeJS.ProcessEnv): boolean {
@@ -604,6 +626,7 @@ app.whenReady().then(async () => {
     appHome: homeEnv.OPENALICE_APP_HOME,
     launcherMode,
   })
+  const proxyEnv = await resolveChildProxyEnv()
   const piRuntime = runtimeEnv.OPENALICE_MANAGED_PI_PATH
     ? runtimeEnv.OPENALICE_MANAGED_PI_NODE_PATH
       ? `pi=${runtimeEnv.OPENALICE_MANAGED_PI_NODE_PATH} ${runtimeEnv.OPENALICE_MANAGED_PI_PATH}`
@@ -632,6 +655,7 @@ app.whenReady().then(async () => {
         ...(takeover ? { OPENALICE_TAKEOVER: '1' } : {}),
         ...homeEnv,
         ...runtimeEnv,
+        ...proxyEnv,
       },
       stdio: 'inherit',
     })
@@ -661,6 +685,7 @@ app.whenReady().then(async () => {
         ...(takeover ? { OPENALICE_TAKEOVER: '1' } : {}),
         ...homeEnv,
         ...runtimeEnv,
+        ...proxyEnv,
       },
       // The fourth fd opens Node child_process IPC. Electron app mode uses it
       // as the local PTY transport between BrowserWindow/preload and Alice's

--- a/apps/desktop/src/probe-port.ts
+++ b/apps/desktop/src/probe-port.ts
@@ -20,8 +20,8 @@ export async function probeFreePort(start: number, end: number = start + 100): P
 }
 
 /**
- * A port only counts as free when BOTH the v4 wildcard (0.0.0.0) and the
- * loopback (127.0.0.1) bind succeed. One bind is not enough on macOS/BSD:
+ * A port only counts as free when the IPv4 AND IPv6 wildcard/loopback binds
+ * all succeed. One bind is not enough on macOS/BSD or Windows:
  * SO_REUSEADDR (node's default) lets a specific-address bind succeed while
  * a wildcard listener holds the port — and vice versa — so probing only
  * 127.0.0.1 reported ports held by wildcard listeners (e.g. a default
@@ -30,7 +30,10 @@ export async function probeFreePort(start: number, end: number = start + 100): P
  * 0.0.0.0 each miss one mode; the conjunction catches all four.
  */
 async function isPortFree(port: number): Promise<boolean> {
-  return (await bindable(port, '0.0.0.0')) && (await bindable(port, '127.0.0.1'))
+  return (await bindable(port, '0.0.0.0'))
+    && (await bindable(port, '127.0.0.1'))
+    && (await bindable(port, '::'))
+    && (await bindable(port, '::1'))
 }
 
 function bindable(port: number, host: string): Promise<boolean> {
@@ -43,7 +46,12 @@ function bindable(port: number, host: string): Promise<boolean> {
       try { srv.close() } catch { /* noop */ }
       res(free)
     }
-    srv.once('error', () => done(false))
+    srv.once('error', (err: NodeJS.ErrnoException) => {
+      // A host with IPv6 disabled should still be able to use IPv4 ports.
+      // EADDRINUSE remains a real collision; unsupported-family/address
+      // errors make this particular probe neutral.
+      done(err.code === 'EAFNOSUPPORT' || err.code === 'EADDRNOTAVAIL')
+    })
     srv.once('listening', () => done(true))
     srv.listen(port, host)
   })

--- a/apps/desktop/src/proxy-env.spec.ts
+++ b/apps/desktop/src/proxy-env.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { proxyEnvFromRules } from './proxy-env.js'
+
+describe('proxyEnvFromRules', () => {
+  it('turns a Chromium PROXY rule into Node proxy env', () => {
+    expect(proxyEnvFromRules('PROXY 127.0.0.1:7890; DIRECT', {})).toEqual({
+      HTTPS_PROXY: 'http://127.0.0.1:7890',
+      HTTP_PROXY: 'http://127.0.0.1:7890',
+      ALL_PROXY: 'http://127.0.0.1:7890',
+      NODE_USE_ENV_PROXY: '1',
+      NO_PROXY: '127.0.0.1,localhost,::1',
+    })
+  })
+
+  it('leaves DIRECT and SOCKS-only system rules untouched', () => {
+    expect(proxyEnvFromRules('DIRECT', {})).toEqual({})
+    expect(proxyEnvFromRules('SOCKS5 127.0.0.1:1080; DIRECT', {})).toEqual({})
+  })
+
+  it('never overwrites explicit proxy env but enables Node consumption', () => {
+    expect(proxyEnvFromRules('PROXY system:8080', { HTTPS_PROXY: 'http://explicit:9000' }))
+      .toEqual({ NODE_USE_ENV_PROXY: '1', NO_PROXY: '127.0.0.1,localhost,::1' })
+    expect(proxyEnvFromRules('PROXY system:8080', {
+      HTTPS_PROXY: 'http://explicit:9000',
+      NODE_USE_ENV_PROXY: '1',
+      NO_PROXY: 'internal.example,localhost',
+    })).toEqual({ NO_PROXY: 'internal.example,localhost,127.0.0.1,::1' })
+  })
+})

--- a/apps/desktop/src/proxy-env.ts
+++ b/apps/desktop/src/proxy-env.ts
@@ -1,0 +1,52 @@
+type EnvLike = Readonly<Record<string, string | undefined>>
+
+const PROXY_KEYS = ['HTTPS_PROXY', 'HTTP_PROXY', 'ALL_PROXY'] as const
+const LOCAL_BYPASS = ['127.0.0.1', 'localhost', '::1'] as const
+
+/**
+ * Convert Electron/Chromium's `resolveProxy()` result into the environment
+ * Node 22.22+ uses when `NODE_USE_ENV_PROXY=1` is enabled.
+ *
+ * Explicit proxy env always wins. `DIRECT` (or unsupported SOCKS-only rules)
+ * produces no override. Chromium may return a fallback list such as
+ * `PROXY 127.0.0.1:7890; DIRECT`; the first HTTP-capable directive wins.
+ */
+export function proxyEnvFromRules(
+  rules: string,
+  env: EnvLike = process.env,
+): Record<string, string> {
+  const explicit = PROXY_KEYS.some((key) => !!env[key]?.trim())
+  if (explicit) {
+    return {
+      ...(!env['NODE_USE_ENV_PROXY'] ? { NODE_USE_ENV_PROXY: '1' } : {}),
+      ...localBypassEnv(env),
+    }
+  }
+
+  const directive = rules
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => /^(?:PROXY|HTTPS?)\s+\S+$/i.test(part))
+  if (!directive) return {}
+
+  const target = directive.replace(/^(?:PROXY|HTTPS?)\s+/i, '').trim()
+  if (!target) return {}
+  const proxyUrl = /^https?:\/\//i.test(target) ? target : `http://${target}`
+  return {
+    HTTPS_PROXY: proxyUrl,
+    HTTP_PROXY: proxyUrl,
+    ALL_PROXY: proxyUrl,
+    NODE_USE_ENV_PROXY: '1',
+    ...localBypassEnv(env),
+  }
+}
+
+function localBypassEnv(env: EnvLike): { NO_PROXY?: string } {
+  const current = (env['NO_PROXY'] ?? env['no_proxy'] ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  const lower = new Set(current.map((entry) => entry.toLowerCase()))
+  const merged = [...current, ...LOCAL_BYPASS.filter((entry) => !lower.has(entry.toLowerCase()))]
+  return { NO_PROXY: merged.join(',') }
+}

--- a/packages/guardian-runtime/package.json
+++ b/packages/guardian-runtime/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/ibkr/package.json
+++ b/packages/ibkr/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/ibkr"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "test": "vitest run --config vitest.config.ts",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:all": "vitest run --config vitest.config.ts && vitest run --config vitest.e2e.config.ts",

--- a/packages/uta-protocol/package.json
+++ b/packages/uta-protocol/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/uta-protocol"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/guardian/shared.spec.ts
+++ b/scripts/guardian/shared.spec.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { isLiteModeEnv, readPortsFile, resolveGuardianTradingMode, resolvePortConfig, resolveWindowsBin } from './shared.js'
+import { isLiteModeEnv, readPortsFile, resolveGuardianTradingMode, resolvePortConfig, resolveWindowsBin, startFlagWatcher } from './shared.js'
 
 let home: string
 
@@ -168,5 +168,28 @@ describe('resolveWindowsBin — Windows .CMD shim resolution (#378)', () => {
     const spaced = 'C:\\Program Files\\proj\\node_modules\\.bin'
     expect(resolveWindowsBin('tsx', 'win32', spaced, () => true))
       .toBe('"C:\\Program Files\\proj\\node_modules\\.bin\\tsx.CMD"')
+  })
+})
+
+describe('startFlagWatcher', () => {
+  it('detects a newly-created flag once across fs.watch and the poll fallback', async () => {
+    const flagPath = join(home, 'data', 'control', 'restart-uta.flag')
+    let calls = 0
+    const stop = await startFlagWatcher({ flagPath, onTrigger: () => { calls++ }, debounceMs: 20 })
+    try {
+      await writeFile(flagPath, 'restart')
+      const deadline = Date.now() + 3_000
+      while (calls === 0 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+      expect(calls).toBe(1)
+      await new Promise((resolve) => setTimeout(resolve, 1_100))
+      expect(calls).toBe(1)
+    } finally {
+      stop()
+      // Let the POSIX fs.watch AbortSignal settle before afterEach removes the
+      // watched temp directory; Windows uses the poll-only path.
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
   })
 })

--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -20,10 +20,11 @@
 
 import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from 'node:child_process'
 import { setTimeout as sleep } from 'node:timers/promises'
-import { watch, mkdir, readFile } from 'node:fs/promises'
+import { watch, mkdir, readFile, stat } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { dirname, basename, resolve } from 'node:path'
 import { probeFreePort } from '../probe-port.js'
+import { resolveLaunchCommand, resolveStockNpmShim } from '../../src/workspaces/win-command.js'
 
 export {
   isLiteModeEnv,
@@ -210,7 +211,20 @@ export function resolveWindowsBin(
 }
 
 export function spawnChild(spec: SpawnSpec): ChildProcess {
-  const child = spawn(resolveWindowsBin(spec.command), spec.args, {
+  const resolvedBin = resolveWindowsBin(spec.command)
+  const unquotedBin = resolvedBin.startsWith('"') && resolvedBin.endsWith('"')
+    ? resolvedBin.slice(1, -1)
+    : resolvedBin
+  const directNpm = process.platform === 'win32'
+    ? resolveStockNpmShim(unquotedBin, spec.args, process.execPath)
+    : null
+  const pathResolved = process.platform === 'win32' && directNpm === null
+    ? resolveLaunchCommand([spec.command, ...spec.args], { env: spec.env, nodeExecPath: process.execPath })
+    : null
+  const launch = directNpm ?? pathResolved?.argv ?? [resolvedBin, ...spec.args]
+  const command = launch[0]!
+  const args = launch.slice(1)
+  const child = spawn(command, args, {
     env: spec.env,
     stdio: spec.prefixLogs ? ['inherit', 'pipe', 'pipe'] : 'inherit',
     // On Windows the dev commands (`tsx`, `pnpm`) are `.cmd` shims in
@@ -219,7 +233,12 @@ export function spawnChild(spec: SpawnSpec): ChildProcess {
     // Git-Bash PATH may not even carry .bin, so the command is resolved to its
     // absolute shim above. POSIX resolves the bin dir directly, so keep shell
     // off there. Args here have no spaces, so shell quoting isn't a concern.
-    shell: process.platform === 'win32',
+    // Stock npm shims are parsed conservatively and run as
+    // `node <real-js-entry> ...args`, avoiding cmd.exe entirely. This keeps
+    // UTA/Vite descendants attached to the child Guardian tracks, so restart
+    // and teardown can reap the whole tree. Unknown/custom batch wrappers keep
+    // the legacy shell fallback.
+    shell: process.platform === 'win32' && directNpm === null && pathResolved?.viaShell === true,
   } satisfies SpawnOptions)
 
   if (spec.prefixLogs) {
@@ -482,6 +501,17 @@ export async function startFlagWatcher(opts: FlagWatchOpts): Promise<() => void>
 
   const abort = new AbortController()
   let pending: NodeJS.Timeout | undefined
+  let checking = false
+
+  const fingerprint = async (): Promise<string | null> => {
+    try {
+      const info = await stat(opts.flagPath)
+      return `${info.mtimeMs}:${info.size}`
+    } catch {
+      return null
+    }
+  }
+  let lastFingerprint = await fingerprint()
 
   const fire = (): void => {
     if (pending) clearTimeout(pending)
@@ -493,11 +523,29 @@ export async function startFlagWatcher(opts: FlagWatchOpts): Promise<() => void>
     }, debounceMs)
   }
 
+  const checkForChange = async (): Promise<void> => {
+    if (checking) return
+    checking = true
+    try {
+      const next = await fingerprint()
+      if (next !== lastFingerprint) {
+        lastFingerprint = next
+        fire()
+      }
+    } finally {
+      checking = false
+    }
+  }
+
   ;(async () => {
     try {
+      // Node 24/libuv can native-assert (not throw) when fs.watch observes a
+      // Windows 8.3 short-path temp directory. Windows file events are also
+      // the least reliable here, so polling below is the primary Win32 path.
+      if (process.platform === 'win32') return
       const watcher = watch(dirname(opts.flagPath), { signal: abort.signal })
       for await (const evt of watcher) {
-        if (evt.filename === basename(opts.flagPath)) fire()
+        if (evt.filename === basename(opts.flagPath)) await checkForChange()
       }
     } catch (err) {
       if ((err as { name?: string }).name === 'AbortError') return
@@ -505,5 +553,15 @@ export async function startFlagWatcher(opts: FlagWatchOpts): Promise<() => void>
     }
   })().catch(() => { /* swallow — already logged */ })
 
-  return () => abort.abort()
+  // Poll the file signature as the Windows primary path and a POSIX backstop;
+  // the shared fingerprint keeps an fs.watch event and the subsequent poll
+  // from triggering two restarts for the same write.
+  const poll = setInterval(() => { void checkForChange() }, 1_000)
+  poll.unref()
+
+  return () => {
+    abort.abort()
+    clearInterval(poll)
+    if (pending) clearTimeout(pending)
+  }
 }

--- a/scripts/guardian/smoke.ts
+++ b/scripts/guardian/smoke.ts
@@ -33,6 +33,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { resolve, dirname, join } from 'node:path'
 import { appendFileSync } from 'node:fs'
+import { resolveLaunchCommand } from '../../src/workspaces/win-command.js'
 
 const IS_WIN = process.platform === 'win32'
 const BOOT_TIMEOUT_MS = 120_000
@@ -124,12 +125,15 @@ async function main(): Promise<void> {
   ) {
     childEnv['OPENALICE_TRADING_MODE'] = 'pro'
   }
-  const child: ChildProcess = spawn('pnpm', ['dev'], {
+  const resolvedDev = resolveLaunchCommand(['pnpm', 'dev'], { env: childEnv, nodeExecPath: process.execPath })
+  const [devCommand, ...devArgs] = resolvedDev.argv
+  if (!devCommand) throw new Error('guardian smoke: empty dev command')
+  const child: ChildProcess = spawn(devCommand, devArgs, {
     cwd: root,
     env: childEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: !IS_WIN,
-    shell: IS_WIN,
+    shell: IS_WIN && resolvedDev.viaShell,
   })
 
   // `out` holds ANSI-stripped text for matching; raw output is mirrored to the

--- a/scripts/onboarding-test-env.spec.ts
+++ b/scripts/onboarding-test-env.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { join } from 'node:path'
 
 import { buildOnboardingTestEnv } from './onboarding-test-env.js'
 
@@ -8,10 +9,10 @@ describe('buildOnboardingTestEnv', () => {
 
     expect(root).toBe('/tmp/oa-onboarding')
     expect(env['OPENALICE_ONBOARDING_TEST']).toBe('1')
-    expect(env['OPENALICE_HOME']).toBe('/tmp/oa-onboarding/home')
-    expect(env['AQ_LAUNCHER_ROOT']).toBe('/tmp/oa-onboarding/workspaces')
-    expect(env['OPENALICE_GLOBAL_DIR']).toBe('/tmp/oa-onboarding/global')
-    expect(env['PI_CODING_AGENT_DIR']).toBe('/tmp/oa-onboarding/pi-agent')
+    expect(env['OPENALICE_HOME']).toBe(join(root, 'home'))
+    expect(env['AQ_LAUNCHER_ROOT']).toBe(join(root, 'workspaces'))
+    expect(env['OPENALICE_GLOBAL_DIR']).toBe(join(root, 'global'))
+    expect(env['PI_CODING_AGENT_DIR']).toBe(join(root, 'pi-agent'))
     expect(env['OPENALICE_AGENT_RUNTIME_INSTALLS']).toBe('only:pi')
     expect(env['OPENALICE_CREDENTIAL_TEST_MODE']).toBe('mock')
     expect(env['VITE_OPENALICE_FIRST_RUN_GUIDE']).toBe('1')

--- a/scripts/probe-port.ts
+++ b/scripts/probe-port.ts
@@ -23,8 +23,8 @@ export async function probeFreePort(start: number, end: number = start + 100): P
 }
 
 /**
- * A port only counts as free when BOTH the v4 wildcard (0.0.0.0) and the
- * loopback (127.0.0.1) bind succeed. One bind is not enough on macOS/BSD:
+ * A port only counts as free when the IPv4 AND IPv6 wildcard/loopback binds
+ * all succeed. One bind is not enough on macOS/BSD or Windows:
  * SO_REUSEADDR (node's default) lets a specific-address bind succeed while
  * a wildcard listener holds the port — and vice versa — so probing only
  * 127.0.0.1 reported ports held by wildcard listeners (e.g. a default
@@ -33,7 +33,10 @@ export async function probeFreePort(start: number, end: number = start + 100): P
  * 0.0.0.0 each miss one mode; the conjunction catches all four.
  */
 async function isPortFree(port: number): Promise<boolean> {
-  return (await bindable(port, '0.0.0.0')) && (await bindable(port, '127.0.0.1'))
+  return (await bindable(port, '0.0.0.0'))
+    && (await bindable(port, '127.0.0.1'))
+    && (await bindable(port, '::'))
+    && (await bindable(port, '::1'))
 }
 
 function bindable(port: number, host: string): Promise<boolean> {
@@ -46,7 +49,12 @@ function bindable(port: number, host: string): Promise<boolean> {
       try { srv.close() } catch { /* noop */ }
       res(free)
     }
-    srv.once('error', () => done(false))
+    srv.once('error', (err: NodeJS.ErrnoException) => {
+      // A host with IPv6 disabled should still be able to use IPv4 ports.
+      // EADDRINUSE remains a real collision; unsupported-family/address
+      // errors make this particular probe neutral.
+      done(err.code === 'EAFNOSUPPORT' || err.code === 'EADDRNOTAVAIL')
+    })
     srv.once('listening', () => done(true))
     srv.listen(port, host)
   })

--- a/src/core/media-store.spec.ts
+++ b/src/core/media-store.spec.ts
@@ -10,7 +10,7 @@ import { resolveMediaPath, persistMedia } from './media-store.js'
 describe('resolveMediaPath', () => {
   it('should join MEDIA_DIR with the given name', () => {
     const result = resolveMediaPath('2026-01-01/ace-aim-air.png')
-    expect(result).toContain('data/media/2026-01-01/ace-aim-air.png')
+    expect(result).toContain(join('data', 'media', '2026-01-01', 'ace-aim-air.png'))
   })
 })
 

--- a/src/core/media-store.ts
+++ b/src/core/media-store.ts
@@ -9,7 +9,7 @@
 import { createHash } from 'node:crypto'
 import { readFile, copyFile, mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { extname, join } from 'node:path'
+import { extname, join, posix } from 'node:path'
 import { dataPath } from '@/core/paths.js'
 
 /** 256 short, common English words — one per byte value. */
@@ -77,7 +77,9 @@ export async function persistMedia(filePath: string): Promise<string> {
     await copyFile(filePath, dest)
   }
 
-  return join(dateDir, name)
+  // This value is a URL/storage key, not an OS filesystem path. Keep it
+  // portable so Windows callers never emit backslashes into `/api/media/...`.
+  return posix.join(dateDir, name)
 }
 
 /** Resolve a media relative path to its absolute path on disk. */

--- a/src/core/paths.spec.ts
+++ b/src/core/paths.spec.ts
@@ -43,8 +43,8 @@ afterEach(() => {
 describe('dataPath', () => {
   it('joins parts under <USER_DATA_HOME>/data/', async () => {
     const { dataPath } = await loadPaths({ OPENALICE_HOME: '/tmp/oa-test' })
-    expect(dataPath('config')).toBe('/tmp/oa-test/data/config')
-    expect(dataPath('brain', 'persona.md')).toBe('/tmp/oa-test/data/brain/persona.md')
+    expect(dataPath('config')).toBe(resolve('/tmp/oa-test', 'data', 'config'))
+    expect(dataPath('brain', 'persona.md')).toBe(resolve('/tmp/oa-test', 'data', 'brain', 'persona.md'))
   })
 
   it('falls back to ~/.openalice when OPENALICE_HOME is unset', async () => {
@@ -54,14 +54,14 @@ describe('dataPath', () => {
 
   it('returns the base data dir when called with no parts', async () => {
     const { dataPath } = await loadPaths({ OPENALICE_HOME: '/tmp/oa-test' })
-    expect(dataPath()).toBe('/tmp/oa-test/data')
+    expect(dataPath()).toBe(resolve('/tmp/oa-test', 'data'))
   })
 })
 
 describe('defaultPath', () => {
   it('joins parts under <APP_RESOURCES_HOME>/default/', async () => {
     const { defaultPath } = await loadPaths({ OPENALICE_APP_HOME: '/Apps/OpenAlice.app/Contents/Resources' })
-    expect(defaultPath('persona.default.md')).toBe('/Apps/OpenAlice.app/Contents/Resources/default/persona.default.md')
+    expect(defaultPath('persona.default.md')).toBe(resolve('/Apps/OpenAlice.app/Contents/Resources', 'default', 'persona.default.md'))
   })
 
   it('falls back to process.cwd() when OPENALICE_APP_HOME is unset', async () => {
@@ -73,7 +73,7 @@ describe('defaultPath', () => {
 describe('uiBundlePath', () => {
   it('resolves to <APP_RESOURCES_HOME>/ui/dist (no parts)', async () => {
     const { uiBundlePath } = await loadPaths({ OPENALICE_APP_HOME: '/foo' })
-    expect(uiBundlePath()).toBe('/foo/ui/dist')
+    expect(uiBundlePath()).toBe(resolve('/foo', 'ui', 'dist'))
   })
 
   it('falls back to cwd-relative ui/dist when unset', async () => {
@@ -85,7 +85,7 @@ describe('uiBundlePath', () => {
 describe('templatesPath', () => {
   it('resolves to <APP_RESOURCES_HOME>/src/workspaces/templates', async () => {
     const { templatesPath } = await loadPaths({ OPENALICE_APP_HOME: '/foo' })
-    expect(templatesPath()).toBe('/foo/src/workspaces/templates')
+    expect(templatesPath()).toBe(resolve('/foo', 'src', 'workspaces', 'templates'))
   })
 
   it('falls back to cwd-relative path when unset', async () => {
@@ -100,13 +100,13 @@ describe('two homes are independent', () => {
     // by different lifecycle actors. Tying them together would conflate
     // upgrade-survives vs upgrade-replaces semantics.
     const { dataPath, defaultPath } = await loadPaths({ OPENALICE_HOME: '/tmp/user' })
-    expect(dataPath('config')).toBe('/tmp/user/data/config')
+    expect(dataPath('config')).toBe(resolve('/tmp/user', 'data', 'config'))
     expect(defaultPath('persona.default.md')).toBe(resolve(process.cwd(), 'default/persona.default.md'))
   })
 
   it('setting OPENALICE_APP_HOME does not move USER_DATA_HOME', async () => {
     const { dataPath, defaultPath } = await loadPaths({ OPENALICE_APP_HOME: '/tmp/resources' })
-    expect(defaultPath('x')).toBe('/tmp/resources/default/x')
+    expect(defaultPath('x')).toBe(resolve('/tmp/resources', 'default', 'x'))
     expect(dataPath('config')).toBe(resolve(homedir(), '.openalice', 'data/config'))
   })
 
@@ -115,10 +115,10 @@ describe('two homes are independent', () => {
       OPENALICE_HOME: '/Users/x/Library/Application Support/OpenAlice',
       OPENALICE_APP_HOME: '/Applications/OpenAlice.app/Contents/Resources',
     })
-    expect(dataPath('config')).toBe('/Users/x/Library/Application Support/OpenAlice/data/config')
-    expect(defaultPath('persona.default.md')).toBe('/Applications/OpenAlice.app/Contents/Resources/default/persona.default.md')
-    expect(uiBundlePath()).toBe('/Applications/OpenAlice.app/Contents/Resources/ui/dist')
-    expect(templatesPath()).toBe('/Applications/OpenAlice.app/Contents/Resources/src/workspaces/templates')
+    expect(dataPath('config')).toBe(resolve('/Users/x/Library/Application Support/OpenAlice', 'data', 'config'))
+    expect(defaultPath('persona.default.md')).toBe(resolve('/Applications/OpenAlice.app/Contents/Resources', 'default', 'persona.default.md'))
+    expect(uiBundlePath()).toBe(resolve('/Applications/OpenAlice.app/Contents/Resources', 'ui', 'dist'))
+    expect(templatesPath()).toBe(resolve('/Applications/OpenAlice.app/Contents/Resources', 'src', 'workspaces', 'templates'))
   })
 })
 

--- a/src/core/shell-resolver.ts
+++ b/src/core/shell-resolver.ts
@@ -1,0 +1,63 @@
+import { existsSync } from 'node:fs';
+import { delimiter, dirname, join } from 'node:path';
+
+type EnvLike = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Find a real Bash executable for Windows without requiring `bash.exe` itself
+ * to be on PATH.  Git for Windows normally adds only `<Git>\\cmd` (for
+ * git.exe), while its Bash lives in `<Git>\\bin`; relying on `spawn('bash')`
+ * therefore fails on a perfectly normal installation.
+ */
+export function resolveBashPath(
+  env: EnvLike = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const managed = clean(env['OPENALICE_MANAGED_SHELL_PATH']);
+  if (managed) return managed;
+  if (platform !== 'win32') return null;
+
+  const shell = clean(env['SHELL']);
+  if (shell && /(?:^|[\\/])bash(?:\.exe)?$/i.test(shell)) return shell;
+
+  const pathDirs = (env['PATH'] ?? env['Path'] ?? '')
+    .split(delimiter)
+    .map((entry) => entry.trim().replace(/^"|"$/g, ''))
+    .filter(Boolean);
+  for (const dir of pathDirs) {
+    const direct = join(dir, 'bash.exe');
+    if (existsSync(direct)) return direct;
+    if (existsSync(join(dir, 'git.exe'))) {
+      const root = /^(?:cmd|bin)$/i.test(dirnameLeaf(dir)) ? dirname(dir) : dir;
+      const fromGit = firstExisting([
+        join(root, 'bin', 'bash.exe'),
+        join(root, 'usr', 'bin', 'bash.exe'),
+      ]);
+      if (fromGit) return fromGit;
+    }
+  }
+
+  const roots = [
+    clean(env['ProgramFiles']),
+    clean(env['ProgramW6432']),
+    clean(env['ProgramFiles(x86)']),
+    clean(env['LOCALAPPDATA']) ? join(clean(env['LOCALAPPDATA'])!, 'Programs') : null,
+  ].filter((value): value is string => !!value);
+  return firstExisting(roots.flatMap((root) => [
+    join(root, 'Git', 'bin', 'bash.exe'),
+    join(root, 'Git', 'usr', 'bin', 'bash.exe'),
+  ]));
+}
+
+function clean(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function dirnameLeaf(path: string): string {
+  return path.replace(/[\\/]+$/, '').split(/[\\/]/).pop() ?? '';
+}
+
+function firstExisting(paths: readonly string[]): string | null {
+  return paths.find((path) => existsSync(path)) ?? null;
+}

--- a/src/workspaces/adapters/shell.spec.ts
+++ b/src/workspaces/adapters/shell.spec.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { composeShellCommand } from './shell.js';
 
 describe('composeShellCommand', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  });
+
   it('uses the managed shell when provided', () => {
     expect(composeShellCommand({
       OPENALICE_MANAGED_SHELL_PATH: 'C:\\OpenAlice\\vendor\\git\\win32-x64\\bin\\bash.exe',
@@ -17,6 +27,20 @@ describe('composeShellCommand', () => {
     expect(composeShellCommand({
       ComSpec: 'C:\\Windows\\System32\\cmd.exe',
     }, 'win32')).toEqual(['C:\\Windows\\System32\\cmd.exe']);
+  });
+
+  it('uses Git Bash when Git for Windows adds only its cmd directory to PATH', async () => {
+    const root = join(tmpdir(), `openalice-git-bash-${Date.now()}-${Math.random()}`);
+    cleanup.push(root);
+    await mkdir(join(root, 'cmd'), { recursive: true });
+    await mkdir(join(root, 'bin'), { recursive: true });
+    await writeFile(join(root, 'cmd', 'git.exe'), '');
+    await writeFile(join(root, 'bin', 'bash.exe'), '');
+
+    expect(composeShellCommand({
+      PATH: [join(root, 'cmd'), 'C:\\Windows\\System32'].join(delimiter),
+      ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+    }, 'win32')).toEqual([join(root, 'bin', 'bash.exe'), '--login']);
   });
 
   it('keeps POSIX login-shell behavior without a managed shell', () => {

--- a/src/workspaces/adapters/shell.ts
+++ b/src/workspaces/adapters/shell.ts
@@ -1,5 +1,5 @@
 import type { CliAdapter, SpawnContext } from '../cli-adapter.js';
-import { runtimeProfileFromEnv } from '@/core/runtime-profile.js';
+import { resolveBashPath } from '@/core/shell-resolver.js';
 
 /**
  * The bare-metal terminal — `zsh --login` (or whatever's on `$SHELL`),
@@ -32,8 +32,8 @@ export function composeShellCommand(
   env: Readonly<Record<string, string | undefined>>,
   platform: NodeJS.Platform = process.platform,
 ): readonly string[] {
-  const managedShell = runtimeProfileFromEnv(env, { platform }).managedShellPath;
-  if (managedShell) return [managedShell, '--login'];
+  const bash = resolveBashPath(env, platform);
+  if (bash) return [bash, '--login'];
   if (platform === 'win32') {
     return [env['SHELL'] ?? env['ComSpec'] ?? env['COMSPEC'] ?? 'cmd.exe'];
   }

--- a/src/workspaces/config.spec.ts
+++ b/src/workspaces/config.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { resolve } from 'node:path'
 import { buildDefaultOrigins, loadConfig } from './config.js'
 
 describe('buildDefaultOrigins', () => {
@@ -60,7 +61,7 @@ describe('loadConfig (workspaces)', () => {
       webPort: 4444,
       env: { OPENALICE_HOME: '/tmp/openalice-isolated' },
     })
-    expect(cfg.launcherRoot).toBe('/tmp/openalice-isolated/workspaces')
+    expect(cfg.launcherRoot).toBe(resolve('/tmp/openalice-isolated', 'workspaces'))
   })
 
   it('still allows AQ_LAUNCHER_ROOT to split workspace storage explicitly', () => {
@@ -71,6 +72,6 @@ describe('loadConfig (workspaces)', () => {
         AQ_LAUNCHER_ROOT: '/tmp/openalice-workspaces-only',
       },
     })
-    expect(cfg.launcherRoot).toBe('/tmp/openalice-workspaces-only')
+    expect(cfg.launcherRoot).toBe(resolve('/tmp/openalice-workspaces-only'))
   })
 })

--- a/src/workspaces/spawn-env.spec.ts
+++ b/src/workspaces/spawn-env.spec.ts
@@ -45,6 +45,24 @@ describe('buildSpawnEnv', () => {
     expect(out['PWD']).toBe('/ws/dir')
   })
 
+  it('emits one canonical PATH key after augmenting a Windows-style Path', () => {
+    const root = mkdtempSync(join(tmpdir(), 'openalice-path-case-'))
+    try {
+      const shim = join(root, 'cli-bin')
+      mkdirSync(shim, { recursive: true })
+
+      const out = buildSpawnEnv(
+        { Path: join(root, 'host-bin') },
+        { OPENALICE_WORKSPACE_CLI_BIN_PATH: shim },
+      )
+
+      expect(Object.keys(out).filter((key) => key.toUpperCase() === 'PATH')).toEqual(['PATH'])
+      expect(out['PATH'].split(delimiter)[0]).toBe(shim)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('strips launcher-owned tool/MCP env from the parent and only trusts extras', () => {
     const out = buildSpawnEnv(
       {

--- a/src/workspaces/spawn-env.ts
+++ b/src/workspaces/spawn-env.ts
@@ -102,7 +102,17 @@ export function buildSpawnEnv(
   for (const [k, v] of Object.entries(extras)) {
     out[k] = v;
   }
-  out['PATH'] = buildCliPath(out);
+  const cliPath = buildCliPath(out);
+  // Windows environment names are case-insensitive, but JavaScript objects are
+  // not. A typical host contributes `Path`; adding a separate `PATH` leaves two
+  // entries in node-pty's environment block. The first Pi process can still
+  // launch, but Node normalizes the duplicate back to the unaugmented `Path`,
+  // so Pi's nested bash tool loses the OpenAlice CLI shim directory. Keep one
+  // canonical spelling before crossing the process boundary.
+  for (const key of Object.keys(out)) {
+    if (key.toUpperCase() === 'PATH') delete out[key];
+  }
+  out['PATH'] = cliPath;
   delete out['OPENALICE_WORKSPACE_CLI_BIN_PATH'];
   return out;
 }

--- a/src/workspaces/win-command.spec.ts
+++ b/src/workspaces/win-command.spec.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { delimiter, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { resolveLaunchCommand } from './win-command.js';
+import { resolveLaunchCommand, resolveStockNpmShim } from './win-command.js';
 
 // A fake Windows PATHEXT — order intentionally puts .CMD before .EXE to prove
 // the resolver prefers a real executable regardless of PATHEXT ordering.
@@ -15,6 +15,13 @@ let env: NodeJS.ProcessEnv;
 
 async function touch(name: string): Promise<void> {
   await writeFile(join(dir, name), '');
+}
+
+async function stockNpmShim(name: string, entry = 'node_modules\\pkg\\cli.js'): Promise<void> {
+  await writeFile(join(dir, name), `@ECHO off\n"%_prog%"  "%dp0%\\${entry}" %*\n`);
+  const entryPath = join(dir, ...entry.split('\\'));
+  await mkdir(dirname(entryPath), { recursive: true });
+  await writeFile(entryPath, '');
 }
 
 beforeEach(async () => {
@@ -50,6 +57,51 @@ describe('resolveLaunchCommand', () => {
       '--session-id',
       'abc',
     ]);
+  });
+
+  it('win32: runs a stock npm shim entrypoint directly with Node', async () => {
+    await stockNpmShim('pi.cmd');
+    const nodeExecPath = 'C:\\Program Files\\nodejs\\node.exe';
+    const r = resolveLaunchCommand(['pi', '-p', 'a & b'], {
+      platform: 'win32',
+      env,
+      nodeExecPath,
+    });
+    expect(r).toEqual({
+      argv: [nodeExecPath, join(dir, 'node_modules', 'pkg', 'cli.js'), '-p', 'a & b'],
+      viaShell: false,
+    });
+  });
+
+  it('win32: runs a stock pnpm linked-bin shim directly with Node', async () => {
+    const nodeModules = join(dir, 'node_modules');
+    const bin = join(nodeModules, '.bin');
+    const entry = join(nodeModules, 'tsx', 'dist', 'cli.mjs');
+    const shim = join(bin, 'tsx.cmd');
+    await mkdir(join(nodeModules, 'tsx', 'dist'), { recursive: true });
+    await mkdir(bin, { recursive: true });
+    await writeFile(entry, '');
+    await writeFile(shim, [
+      '@IF EXIST "%~dp0\\node.exe" (',
+      '  "%~dp0\\node.exe" "%~dp0\\..\\tsx\\dist\\cli.mjs" %*',
+      ') ELSE (',
+      '  node "%~dp0\\..\\tsx\\dist\\cli.mjs" %*',
+      ')',
+    ].join('\n'));
+
+    expect(resolveStockNpmShim(shim, ['watch', 'app.ts'], 'node.exe')).toEqual([
+      'node.exe', entry, 'watch', 'app.ts',
+    ]);
+  });
+
+  it('win32: refuses to direct-run an npm-shaped shim outside its directory', async () => {
+    await touch('pi.cmd');
+    await writeFile(
+      join(dir, 'pi.cmd'),
+      '@ECHO off\n"%_prog%" "%dp0%\\..\\outside\\cli.js" %*\n',
+    );
+    const r = resolveLaunchCommand(['pi', '-p', 'hello'], { platform: 'win32', env });
+    expect(r.viaShell).toBe(true);
   });
 
   it('win32: prefers .exe over a .cmd shim when both exist', async () => {

--- a/src/workspaces/win-command.ts
+++ b/src/workspaces/win-command.ts
@@ -25,8 +25,8 @@
  * On non-Windows this is the identity function: the kernel reads shebangs and a
  * bare-name PATH lookup finds shell-script shims fine.
  */
-import { existsSync } from 'node:fs';
-import { delimiter, join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, delimiter, dirname, join, relative, resolve } from 'node:path';
 
 export interface ResolvedCommand {
   readonly argv: readonly string[];
@@ -45,7 +45,7 @@ const DEFAULT_PATHEXT = '.COM;.EXE;.BAT;.CMD';
 
 export function resolveLaunchCommand(
   argv: readonly string[],
-  opts: { platform?: NodeJS.Platform; env?: NodeJS.ProcessEnv } = {},
+  opts: { platform?: NodeJS.Platform; env?: NodeJS.ProcessEnv; nodeExecPath?: string } = {},
 ): ResolvedCommand {
   const platform = opts.platform ?? process.platform;
   const env = opts.env ?? process.env;
@@ -64,6 +64,14 @@ export function resolveLaunchCommand(
   const dot = resolved.lastIndexOf('.');
   const ext = dot >= 0 ? resolved.slice(dot).toLowerCase() : '';
   if (ext === '.cmd' || ext === '.bat') {
+    // npm's Windows shims are small, deterministic wrappers around a JS
+    // entrypoint.  Run that entrypoint directly with Node when we can prove the
+    // wrapper has the stock shape.  Besides avoiding an unnecessary shell,
+    // this is what makes user-controlled headless prompts safe: cmd.exe never
+    // gets a chance to re-parse &, |, %, ^, and friends.
+    const direct = resolveStockNpmShim(resolved, rest, opts.nodeExecPath ?? process.execPath);
+    if (direct) return { argv: direct, viaShell: false };
+
     const comspec = env['ComSpec'] || env['COMSPEC'] || 'cmd.exe';
     // /d skips any AutoRun registry command; /c runs then exits. The shim path
     // is a single arg (node-pty/Node quote it if it contains spaces); cmd's
@@ -71,6 +79,49 @@ export function resolveLaunchCommand(
     return { argv: [comspec, '/d', '/c', resolved, ...rest], viaShell: true };
   }
   return { argv: [resolved, ...rest], viaShell: false };
+}
+
+/**
+ * Resolve the stock npm.cmd wrapper to `node <entry> ...args` without a shell.
+ *
+ * This intentionally recognizes only npm's generated final invocation:
+ *
+ *   "%_prog%" "%dp0%\\node_modules\\some-package\\cli.js" %*
+ *
+ * Anything hand-written, outside the shim directory, or with extra shell
+ * syntax falls back to the existing cmd.exe path (and remains rejected by the
+ * headless runner for untrusted prompts).
+ */
+export function resolveStockNpmShim(
+  shimPath: string,
+  args: readonly string[],
+  nodeExecPath: string,
+): readonly string[] | null {
+  let source: string;
+  try {
+    source = readFileSync(shimPath, 'utf8');
+  } catch {
+    return null;
+  }
+
+  // npm uses `%dp0%\\node_modules\\...`; pnpm's linked `.bin` shims use
+  // `%~dp0\\..\\package\\...` and repeat the same entry in their local-node
+  // and PATH-node branches. Accept both generated shapes only when every
+  // captured entry is identical.
+  const matches = [...source.matchAll(/"(?:%dp0%|%~dp0)\\([^"\r\n]+\.(?:c|m)?js)"\s+%\*/gim)];
+  const entries = [...new Set(matches.map((match) => match[1]).filter((value): value is string => !!value))];
+  if (entries.length !== 1) return null;
+  const rawRelative = entries[0];
+  if (!rawRelative || /[&|<>^%]/.test(rawRelative)) return null;
+
+  const root = dirname(shimPath);
+  const allowedRoot = basename(root).toLowerCase() === '.bin'
+    ? dirname(root)
+    : root;
+  const entry = resolve(root, rawRelative.replace(/\\/g, '/'));
+  const rel = relative(allowedRoot, entry);
+  if (!rel || rel.startsWith('..') || rel.includes(':') || !existsSync(entry)) return null;
+  return [nodeExecPath, entry, ...args];
 }
 
 function lookupOnWindowsPath(name: string, env: NodeJS.ProcessEnv): string | null {

--- a/src/workspaces/workspace-creator.spec.ts
+++ b/src/workspaces/workspace-creator.spec.ts
@@ -20,6 +20,12 @@ vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
 }));
 
+// Shell discovery has its own filesystem tests. Keep these spawn-shape tests
+// deterministic on Windows hosts that happen to have Git Bash installed.
+vi.mock('@/core/shell-resolver.js', () => ({
+  resolveBashPath: vi.fn(() => null),
+}));
+
 const mockSpawn = vi.mocked(childProcess.spawn);
 
 interface FakeChild extends EventEmitter {

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { resolveBashPath } from '@/core/shell-resolver.js';
 import { existsSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -324,9 +325,8 @@ const WINDOWS_BASH_HINT =
  * On macOS / Linux the script is invoked directly — the kernel reads the
  * `#!/usr/bin/env bash` shebang and launches bash. On Windows the kernel
  * doesn't read shebangs and there's no native bash, so we invoke bash
- * explicitly with the script as its first argument. This requires `bash`
- * to be on PATH, which Git for Windows provides under its default install
- * options (WSL also works if OpenAlice itself is run from inside WSL).
+ * explicitly with the script as its first argument. Git for Windows commonly
+ * puts only `git.exe` on PATH, so resolve its sibling `bin/bash.exe` as well.
  *
  * Exported for unit testing — the platform branch needs coverage that
  * doesn't depend on which OS the tests happen to run on.
@@ -345,9 +345,13 @@ export function runScript(
   // flips it to pure-Node mode (a harmless no-op for a plain `node` execPath in
   // dev). No bash, no shebang reliance → works on a bare Windows/Mac box.
   // `.sh` (third-party fallback): unix reads the `#!/usr/bin/env bash` shebang;
-  // Windows has no native bash, so we invoke `bash <script>` explicitly, which
-  // requires bash on PATH (Git for Windows / WSL).
-  const cmd = isMjs ? process.execPath : isWindows ? 'bash' : script;
+  // Windows has no native bash, so invoke the Git-for-Windows executable we
+  // resolved above (with a final bare-name fallback for WSL/custom PATHs).
+  const cmd = isMjs
+    ? process.execPath
+    : isWindows
+      ? resolveBashPath(process.env, 'win32') ?? 'bash'
+      : script;
   const cmdArgs = isMjs || isWindows ? [script, ...args] : args;
   const env = isMjs
     ? { ...process.env, ...extraEnv, ELECTRON_RUN_AS_NODE: '1' }


### PR DESCRIPTION
## Summary

Extract the Windows/runtime compatibility fixes from #490 into a focused PR.

- launch stock npm/pnpm Windows shims directly with Node, preserving process-tree ownership
- resolve Git Bash from standard Git for Windows installations
- canonicalize PATH casing for nested workspace tools
- make Guardian restart-flag watching reliable on Windows
- detect IPv4 and IPv6 port collisions
- pass Windows system proxy resolution to Electron child processes while preserving explicit proxy env
- keep build scripts, line endings, media keys, and path assertions cross-platform
- add macOS/Windows test coverage

## Scope

This intentionally excludes the LongCat provider changes, Pi project-trust policy, and responsive Files UI from #490.

## Validation

- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- 99 focused tests
- `pnpm test` — 2502 passed, 6 skipped
- `pnpm test:smoke` — UTA restart and clean teardown
- `pnpm electron:smoke:pty` — renderer bridge, workspace shell, and CLI socket
- `pnpm electron:smoke:packaged --temp-data` — unsigned packaged app booted with isolated data
