### PR TITLE
Fix LongCat and Pi workspace runtime

### DIFF
--- a/src/ai-providers/preset-catalog.spec.ts
+++ b/src/ai-providers/preset-catalog.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { LONGCAT } from './preset-catalog.js';
+
+describe('LONGCAT preset', () => {
+  it('uses the versioned OpenAI base URL required by the OpenAI SDK', () => {
+    expect(LONGCAT.regions?.[0]?.wires['openai-chat']).toBe('https://api.longcat.chat/openai/v1');
+    const parsed = LONGCAT.zodSchema.parse({
+      backend: 'vercel-ai-sdk',
+      provider: 'openai-compatible',
+      apiKey: 'test-key',
+    }) as { baseUrl?: string };
+    expect(parsed.baseUrl).toBe('https://api.longcat.chat/openai/v1');
+  });
+});

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -307,13 +307,15 @@ export const LONGCAT: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('vercel-ai-sdk'),
     provider: z.literal('openai-compatible'),
-    baseUrl: z.string().default('https://api.longcat.chat/openai').describe('API endpoint'),
+    baseUrl: z.string().default('https://api.longcat.chat/openai/v1').describe('API endpoint'),
     model: z.string().default('LongCat-2.0').describe('Model'),
     apiKey: z.string().min(1).describe('LongCat API key'),
   }),
   regions: [
     { id: 'default', label: 'LongCat (api.longcat.chat)', wires: {
-      'openai-chat': 'https://api.longcat.chat/openai',
+      // The OpenAI SDK appends `/chat/completions` itself, so its base must
+      // include LongCat's required `/v1` segment.
+      'openai-chat': 'https://api.longcat.chat/openai/v1',
       anthropic: 'https://api.longcat.chat/anthropic',
     } },
   ],

--- a/src/core/credential-inference.spec.ts
+++ b/src/core/credential-inference.spec.ts
@@ -39,6 +39,10 @@ describe('resolveAnthropicAuthMode', () => {
     expect(resolveAnthropicAuthMode({ baseUrl: 'https://api.minimax.io/anthropic' })).toBe('bearer')
   })
 
+  it('infers bearer for LongCat anthropic compatibility', () => {
+    expect(resolveAnthropicAuthMode({ baseUrl: 'https://api.longcat.chat/anthropic' })).toBe('bearer')
+  })
+
   it('does NOT infer bearer for MiniMax China (minimaxi.com tolerates x-api-key)', () => {
     expect(resolveAnthropicAuthMode({ baseUrl: 'https://api.minimaxi.com/anthropic' })).toBe('x-api-key')
   })

--- a/src/core/credential-inference.ts
+++ b/src/core/credential-inference.ts
@@ -45,8 +45,8 @@ export function inferCredentialVendor(opts: { agent?: string; baseUrl?: string }
  * `x-api-key` is Anthropic's first-party standard and the safe default;
  * `bearer` sends `Authorization: Bearer`, which anthropic-compatible *gateways*
  * require. An explicit `authMode` always wins. Fallback inference is deliberately
- * narrow: only `api.minimax.io` (MiniMax's international endpoint) is
- * auto-promoted to bearer, because it's the one endpoint confirmed to *reject*
+ * narrow: confirmed bearer-only gateways (MiniMax international and LongCat's
+ * Anthropic compatibility endpoint) are auto-promoted because they *reject*
  * x-api-key with a 401. Other gateways stay at the default until confirmed —
  * over-promoting would silently break a working x-api-key setup.
  */
@@ -54,6 +54,6 @@ export function resolveAnthropicAuthMode(
   opts: { authMode?: 'x-api-key' | 'bearer'; baseUrl?: string },
 ): 'x-api-key' | 'bearer' {
   if (opts.authMode) return opts.authMode
-  if (/api\.minimax\.io/i.test(opts.baseUrl ?? '')) return 'bearer'
+  if (/api\.minimax\.io|api\.longcat\.chat/i.test(opts.baseUrl ?? '')) return 'bearer'
   return 'x-api-key'
 }

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -336,9 +336,10 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
     ]);
   });
 
-  it('pi: -p --mode json <prompt> (bare trailing positional — pi rejects --)', () => {
+  it('pi: --approve -p --mode json <prompt> (bare trailing positional — pi rejects --)', () => {
     expect(piAdapter.composeHeadlessCommand!(['pi'], ctx(), 'do x')).toEqual([
       'pi',
+      '--approve',
       '-p',
       '--mode',
       'json',
@@ -365,19 +366,19 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
 describe('piAdapter AI-config', () => {
   const mcpEnv = { OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp', AQ_WS_ID: 'ws-abc' };
 
-  it('composeCommand: fresh is bare; resume uses top-level --continue / --session-id', () => {
-    expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env: mcpEnv })).toEqual(['pi']);
+  it('composeCommand: approves launcher-owned workspaces before fresh or resumed runs', () => {
+    expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env: mcpEnv })).toEqual(['pi', '--approve']);
     expect(piAdapter.composeCommand([], { cwd: dir, env: mcpEnv, resume: 'last' }))
-      .toEqual(['pi', '--continue']);
+      .toEqual(['pi', '--approve', '--continue']);
     expect(piAdapter.composeCommand([], { cwd: dir, env: mcpEnv, resume: { sessionId: 'sess-1' } }))
-      .toEqual(['pi', '--session-id', 'sess-1']);
+      .toEqual(['pi', '--approve', '--session-id', 'sess-1']);
   });
 
   it('composeCommand uses managed Pi binary path when the spawn env provides one', () => {
     const env = { ...mcpEnv, OPENALICE_MANAGED_PI_PATH: '/app/vendor/pi/pi' };
-    expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env })).toEqual(['/app/vendor/pi/pi']);
+    expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env })).toEqual(['/app/vendor/pi/pi', '--approve']);
     expect(piAdapter.composeHeadlessCommand!([], { cwd: dir, env }, 'hello')).toEqual([
-      '/app/vendor/pi/pi', '-p', '--mode', 'json', 'hello',
+      '/app/vendor/pi/pi', '--approve', '-p', '--mode', 'json', 'hello',
     ]);
   });
 
@@ -390,10 +391,12 @@ describe('piAdapter AI-config', () => {
     expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env })).toEqual([
       '/Applications/OpenAlice.app/Contents/MacOS/OpenAlice',
       '/app/vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
+      '--approve',
     ]);
     expect(piAdapter.composeHeadlessCommand!([], { cwd: dir, env }, 'hello')).toEqual([
       '/Applications/OpenAlice.app/Contents/MacOS/OpenAlice',
       '/app/vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
+      '--approve',
       '-p',
       '--mode',
       'json',

--- a/src/workspaces/adapters/interactive-seed.spec.ts
+++ b/src/workspaces/adapters/interactive-seed.spec.ts
@@ -63,12 +63,12 @@ describe('interactive seed — composeCommand initialPrompt', () => {
 
     it('pi: bare trailing positional, NO `--` terminator', () => {
       const argv = piAdapter.composeCommand([], ctx({ initialPrompt: PROMPT }));
-      expect(argv).toEqual(['pi', PROMPT]);
+      expect(argv).toEqual(['pi', '--approve', PROMPT]);
       expect(argv).not.toContain('--');
     });
   });
 
-  describe('no prompt → unchanged base command', () => {
+  describe('no prompt → no seed argument', () => {
     it('claude', () => {
       expect(claudeAdapter.composeCommand(['claude'], ctx())).not.toContain(PROMPT);
     });
@@ -76,7 +76,7 @@ describe('interactive seed — composeCommand initialPrompt', () => {
       expect(opencodeAdapter.composeCommand([], ctx())).toEqual(['opencode']);
     });
     it('pi', () => {
-      expect(piAdapter.composeCommand([], ctx())).toEqual(['pi']);
+      expect(piAdapter.composeCommand([], ctx())).toEqual(['pi', '--approve']);
     });
   });
 
@@ -114,7 +114,7 @@ describe('interactive seed — composeCommand initialPrompt', () => {
       [],
       ctx({ resume: { sessionId: 'assigned-uuid-1234' }, initialPrompt: PROMPT }),
     );
-    expect(argv).toEqual(['pi', '--session-id', 'assigned-uuid-1234', PROMPT]);
+    expect(argv).toEqual(['pi', '--approve', '--session-id', 'assigned-uuid-1234', PROMPT]);
   });
 
   it('shell ignores initialPrompt entirely (no agent to receive it)', () => {

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -84,7 +84,10 @@ export const piAdapter: CliAdapter = {
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
     // Tools come from the CLI-injection path (alice on PATH + .pi/skills), not
     // flags — so the command head is just the binary + a resume flag (if any).
-    const head = piCommandHead(ctx.env);
+    // OpenAlice creates and owns the workspace, so approve its project-local
+    // resources for this invocation instead of blocking a fresh chat on Pi's
+    // interactive trust prompt. This does not mutate the user's global policy.
+    const head = [...piCommandHead(ctx.env), '--approve'];
     // Quick-chat seed: `pi [--session-id <id>] <messages…>` opens the
     // interactive TUI seeded with that first message. UNLIKE the other adapters,
     // pi appends the seed REGARDLESS of the resume branch: pi assigns its own id
@@ -108,7 +111,7 @@ export const piAdapter: CliAdapter = {
   // 0.78.1), so the prompt is a bare trailing positional — a prompt literally
   // starting with `-`/`--` is unprotected on pi (rare for task prompts).
   composeHeadlessCommand(_base: readonly string[], _ctx: SpawnContext, prompt: string): readonly string[] {
-    return [...piCommandHead(_ctx.env), '-p', '--mode', 'json', prompt];
+    return [...piCommandHead(_ctx.env), '--approve', '-p', '--mode', 'json', prompt];
   },
 
   // pi `--mode json` line 1 is `{"type":"session","id":…,"cwd":…}` — pi mints

--- a/src/workspaces/agent-probe.spec.ts
+++ b/src/workspaces/agent-probe.spec.ts
@@ -11,10 +11,11 @@
 
 import { createServer, type Server } from 'node:http';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { probeAnthropic } from './agent-probe.js';
+import { probeAnthropic, probeOpenAI } from './agent-probe.js';
 
 interface Captured {
   headers: Record<string, string | string[] | undefined>;
+  url: string | undefined;
 }
 
 let server: Server;
@@ -24,22 +25,21 @@ let captured: Captured | null;
 beforeEach(async () => {
   captured = null;
   server = createServer((req, res) => {
-    captured = { headers: req.headers };
+    captured = { headers: req.headers, url: req.url };
     let body = '';
     req.on('data', (c) => (body += c));
     req.on('end', () => {
       res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(
-        JSON.stringify({
-          id: 'msg_1',
-          type: 'message',
-          role: 'assistant',
-          model: 'x',
-          content: [{ type: 'text', text: 'pong' }],
-          stop_reason: 'end_turn',
+      res.end(req.url?.endsWith('/chat/completions')
+        ? JSON.stringify({
+          id: 'chatcmpl_1', object: 'chat.completion', created: 0, model: 'x',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'pong' }, finish_reason: 'stop' }],
+        })
+        : JSON.stringify({
+          id: 'msg_1', type: 'message', role: 'assistant', model: 'x',
+          content: [{ type: 'text', text: 'pong' }], stop_reason: 'end_turn',
           usage: { input_tokens: 1, output_tokens: 1 },
-        }),
-      );
+        }));
     });
   });
   await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
@@ -79,5 +79,19 @@ describe('probeAnthropic auth header', () => {
     await probeAnthropic({ baseUrl, apiKey: 'sk-path', model: 'm' });
     // request landed on /anthropic/v1/messages, proving the path wasn't dropped
     expect(captured).not.toBeNull();
+  });
+});
+
+describe('probeOpenAI auth header', () => {
+  it('uses Bearer auth and preserves a versioned base path', async () => {
+    const out = await probeOpenAI({
+      baseUrl: baseUrl.replace('/anthropic', '/openai/v1'),
+      apiKey: 'sk-openai',
+      model: 'm',
+      wireApi: 'chat',
+    });
+    expect(out.text).toBe('pong');
+    expect(captured?.headers['authorization']).toBe('Bearer sk-openai');
+    expect(captured?.url).toBe('/openai/v1/chat/completions');
   });
 });

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -89,7 +89,7 @@ describe('injectWorkspaceContext — persona', () => {
 });
 
 describe('injectWorkspaceContext — skills', () => {
-  it('copies a bundled skill into all three CLI discovery paths', async () => {
+  it('copies a bundled skill into the canonical shared discovery paths', async () => {
     await injectWorkspaceContext({
       template: makeTemplate({ bundledSkills: ['scan-value-chain'] }),
       wsId: 'ws-abc',
@@ -97,8 +97,8 @@ describe('injectWorkspaceContext — skills', () => {
     });
     const expected = await readFile(defaultPath('skills', 'scan-value-chain', 'SKILL.md'), 'utf8');
     expect(await read('.claude/skills/scan-value-chain/SKILL.md')).toBe(expected);  // Claude Code
-    expect(await read('.agents/skills/scan-value-chain/SKILL.md')).toBe(expected);  // Codex (+ opencode default)
-    expect(await read('.pi/skills/scan-value-chain/SKILL.md')).toBe(expected);      // Pi
+    expect(await read('.agents/skills/scan-value-chain/SKILL.md')).toBe(expected);  // Codex + Pi
+    expect(existsSync(join(dir, '.pi/skills'))).toBe(false);                        // no Pi collision copy
   });
 
   it('injects the per-CLI playbooks (alice* + traderhub) for a tool-bearing template', async () => {
@@ -109,8 +109,9 @@ describe('injectWorkspaceContext — skills', () => {
     });
     for (const name of ['alice', 'alice-analysis', 'alice-uta', 'alice-workspace', 'traderhub', 'scan-value-chain']) {
       expect(existsSync(join(dir, '.claude/skills', name, 'SKILL.md')), name).toBe(true);
-      expect(existsSync(join(dir, '.pi/skills', name, 'SKILL.md')), name).toBe(true);
+      expect(existsSync(join(dir, '.agents/skills', name, 'SKILL.md')), name).toBe(true);
     }
+    expect(existsSync(join(dir, '.pi/skills'))).toBe(false);
   });
 
   it('does not inject CLI playbooks when the template is not tool-bearing', async () => {
@@ -131,6 +132,21 @@ describe('injectWorkspaceContext — skills', () => {
     });
     expect(existsSync(join(dir, '.claude/skills/self-scheduling/SKILL.md'))).toBe(true);
     expect(existsSync(join(dir, '.agents/skills/self-scheduling/SKILL.md'))).toBe(true);
-    expect(existsSync(join(dir, '.pi/skills/self-scheduling/SKILL.md'))).toBe(true);
+    expect(existsSync(join(dir, '.pi/skills/self-scheduling/SKILL.md'))).toBe(false);
+  });
+
+  it('leaves a legacy .pi/skills directory untouched', async () => {
+    const legacy = join(dir, '.pi/skills/custom/SKILL.md');
+    await mkdir(join(dir, '.pi/skills/custom'), { recursive: true });
+    await writeFile(legacy, 'legacy user skill\n');
+
+    await injectWorkspaceContext({
+      template: makeTemplate({ bundledSkills: ['scan-value-chain'] }),
+      wsId: 'ws-abc',
+      dir,
+    });
+
+    expect(await read('.pi/skills/custom/SKILL.md')).toBe('legacy user skill\n');
+    expect(existsSync(join(dir, '.pi/skills/scan-value-chain/SKILL.md'))).toBe(false);
   });
 });

--- a/src/workspaces/context-injector.ts
+++ b/src/workspaces/context-injector.ts
@@ -71,19 +71,19 @@ export async function injectWorkspaceContext(opts: {
     ]),
   ];
   if (skills.length > 0) {
-    // Each agent CLI discovers skills from its own dir: Claude Code reads
-    // `.claude/skills`, Codex reads `.agents/skills`, Pi reads `.pi/skills`.
-    // (opencode reads `.claude/skills` + `.agents/skills` by default via its
-    // Claude-Code compat, so the two below already cover it — no `.opencode`
-    // copy needed unless OPENCODE_DISABLE_CLAUDE_CODE is ever set.)
+    // Claude Code reads `.claude/skills`; Codex and current Pi both read the
+    // shared `.agents/skills` path. Do not also copy into `.pi/skills`: Pi
+    // discovers both locations and reports every duplicate as a startup
+    // collision, which can bury the first user prompt. Existing workspaces are
+    // intentionally left alone; this only defines the canonical layout for new
+    // workspaces. (OpenCode reads `.claude/skills` + `.agents/skills` through
+    // its Claude-Code compatibility layer, so no `.opencode` copy is needed.)
     await mkdir(join(dir, '.claude/skills'), { recursive: true });
     await mkdir(join(dir, '.agents/skills'), { recursive: true });
-    await mkdir(join(dir, '.pi/skills'), { recursive: true });
     for (const name of skills) {
       const src = defaultPath('skills', name);
       await cp(src, join(dir, '.claude/skills', name), { recursive: true });
       await cp(src, join(dir, '.agents/skills', name), { recursive: true });
-      await cp(src, join(dir, '.pi/skills', name), { recursive: true });
     }
   }
 }

--- a/src/workspaces/workspace-creation.e2e.spec.ts
+++ b/src/workspaces/workspace-creation.e2e.spec.ts
@@ -109,7 +109,6 @@ describe('chat workspace create: bootstrap → inject → commit', () => {
       'CLAUDE.md', 'AGENTS.md', 'README.md',
       '.claude/skills/scan-value-chain/SKILL.md',
       '.agents/skills/scan-value-chain/SKILL.md',
-      '.pi/skills/scan-value-chain/SKILL.md',
       // per-CLI playbooks injected for every tool-bearing template
       '.claude/skills/alice/SKILL.md',
       '.claude/skills/alice-analysis/SKILL.md',
@@ -172,7 +171,8 @@ describe('chat workspace create — CLI-only injection (no MCP)', () => {
     expect(existsSync(join(dir, '.claude/skills/alice-uta/SKILL.md'))).toBe(true);   // trading skill discoverable
     expect(existsSync(join(dir, '.claude/skills/traderhub/SKILL.md'))).toBe(true);
     expect(existsSync(join(dir, '.claude/skills/scan-value-chain/SKILL.md'))).toBe(true);
-    expect(existsSync(join(dir, '.pi/skills/alice-uta/SKILL.md'))).toBe(true);  // Pi discovers .pi/skills
+    expect(existsSync(join(dir, '.agents/skills/alice-uta/SKILL.md'))).toBe(true); // Pi shares .agents/skills
+    expect(existsSync(join(dir, '.pi/skills'))).toBe(false);                       // avoid duplicate discovery
     expect((await run('git', ['-C', dir, 'status', '--porcelain'])).trim()).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Extract the remaining LongCat and Pi runtime work from #490.

- use LongCat's versioned OpenAI base URL
- send LongCat Anthropic-compatible credentials as Bearer auth
- approve OpenAlice-managed project resources for interactive and headless Pi runs
- use the shared `.agents/skills` path for new workspaces so current Pi does not report duplicate `.pi/skills` collisions
- preserve existing workspace `.pi/skills` directories without migration or deletion
- add strict provider, auth-header, adapter, injection, and workspace-creation coverage

Closes #485.

## Validation

- `npx tsc --noEmit`
- 81 focused unit tests
- workspace creation E2E: 3 passed
- `pnpm test`: 2506 passed, 6 skipped
- bundled Pi 0.80.3 interactive startup with 11 injected skills and no collision section
- `pnpm electron:smoke:pty`
- `pnpm electron:smoke:packaged --temp-data`
