### PR TITLE
Collapse workspace files in narrow content

### DIFF
--- a/ui/src/components/workspace/WorkspaceFilesToggle.tsx
+++ b/ui/src/components/workspace/WorkspaceFilesToggle.tsx
@@ -23,7 +23,7 @@ export function WorkspaceFilesToggle(): ReactElement {
       onClick={toggleFiles}
       aria-pressed={files}
       title={files ? t('workspace.hideFilesTitle') : t('workspace.showFilesTitle')}
-      className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] transition-colors ${
+      className={`workspace-files-toggle flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] transition-colors ${
         files
           ? 'text-text bg-bg-tertiary'
           : 'text-text-muted hover:text-text hover:bg-bg-tertiary'

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -310,6 +310,26 @@
   min-height: 0;
 }
 
+/* Measure the space actually left for WorkspacePage after the global rail and
+ * its contextual sidebar, rather than the browser viewport. At this width a
+ * fixed 360px Files column would leave the terminal too narrow to be useful.
+ * The persisted Files preference is left untouched, so the panel comes back
+ * automatically when the surrounding layout has room again. */
+.workspace-page-shell {
+  container-type: inline-size;
+}
+
+@container (max-width: 900px) {
+  .workspace-page-shell .workspace-view {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .workspace-page-shell .workspace-side,
+  .workspace-page-shell .workspace-files-toggle {
+    display: none;
+  }
+}
+
 /* Both side panels hidden (or auto-hidden on mobile) — collapse the
  * 360px aside column so the terminal pane fills the whole width. */
 .workspace-view.has-no-side {

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -129,7 +129,7 @@ export function WorkspacePage({ spec, visible }: Props) {
   // holds for the active path); when sessionId is null, the empty
   // state needs the full list to render resume/continue cards.
   return (
-    <div className="workspaces-root flex-1 min-h-0 flex flex-col">
+    <div className="workspaces-root workspace-page-shell flex-1 min-h-0 flex flex-col">
       {/* OpenAlice-side header bar above the launcher's WorkspaceView. The
        *  launcher component itself is byte-faithful; we add the AI-provider
        *  affordance here. */}


### PR DESCRIPTION
## Summary
- measure the actual Workspace page content width with a CSS container
- collapse the fixed 360px Files column when the remaining content area is 900px or narrower
- hide the Files toggle at that breakpoint without changing the persisted Files preference, so the panel returns automatically when space is available

## Verification
- live browser: 1280x720 viewport -> 882px Workspace container, single 858px content column, Files panel/toggle hidden, no horizontal overflow
- live browser: 1300x720 viewport -> 902px Workspace container, 506px + 360px columns, Files panel/toggle visible, no horizontal overflow
- live browser console: no warnings or errors
- `cd ui && npx tsc -b`
- `cd ui && pnpm build`
- `pnpm test` (2506 passed, 6 skipped)