### PR TITLE
Keep Pi trust compatible across runtime modes

### DIFF
--- a/scripts/assert-desktop-package.spec.ts
+++ b/scripts/assert-desktop-package.spec.ts
@@ -25,7 +25,7 @@ function writeBasePackage(appRoot: string, manifest: unknown) {
 function piManifest() {
   return {
     pi: {
-      version: '0.80.3',
+      version: '0.80.6',
       mode: 'npm',
       cli: PI_CLI,
     },

--- a/scripts/smoke-packaged-toolchain.mjs
+++ b/scripts/smoke-packaged-toolchain.mjs
@@ -33,7 +33,7 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
     command: electron,
     args: [piCli, '--version'],
     env: { ELECTRON_RUN_AS_NODE: '1' },
-    expectStdout: /\b0\.80\.3\b/,
+    expectStdout: /\b0\.80\.6\b/,
   })
 
   if (packageResult.platform === 'win32') {

--- a/scripts/vendor-managed-runtime.mjs
+++ b/scripts/vendor-managed-runtime.mjs
@@ -25,18 +25,18 @@ const piCliPath = resolve(
 const knownArgs = new Set(['--force', '--help', '-h'])
 let force = false
 
-const PI_VERSION = '0.80.3'
+const PI_VERSION = '0.80.6'
 const PI_RELEASE_BASE = `https://github.com/earendil-works/pi/releases/download/v${PI_VERSION}`
 const PI_ASSETS = [
   {
     name: 'package.json',
     url: `${PI_RELEASE_BASE}/pi-coding-agent-install-package.json`,
-    sha256: 'ba96c5a6183936a113a7a48de45fdae8cd4489a22f4cc481fbce74afae85b6c7',
+    sha256: 'ee080db64c3732daea5547bd6d9809465ffa236ef6099051e64a16753e48b795',
   },
   {
     name: 'package-lock.json',
     url: `${PI_RELEASE_BASE}/pi-coding-agent-install-package-lock.json`,
-    sha256: '0d32c0854a23486ee80f7c82b9fad4bb5b03a380c649d5af105ad1a3c88fc54d',
+    sha256: '0f409bf498507f93bfbde3dc6f2b4c83bc58bdea2e2f5eabf3053cc2a81568d4',
   },
 ]
 

--- a/scripts/vendor-managed-runtime.spec.ts
+++ b/scripts/vendor-managed-runtime.spec.ts
@@ -7,6 +7,10 @@ import {
 } from './vendor-managed-runtime.mjs'
 
 describe('vendor managed runtime helpers', () => {
+  it('pins the managed Pi release', () => {
+    expect(buildVendorRuntimeManifest(null).pi.version).toBe('0.80.6')
+  })
+
   it('does not select a managed Git runtime on non-Windows hosts', () => {
     expect(resolveWindowsGitRuntimeSpec({ platform: 'darwin', arch: 'arm64' })).toBeNull()
     expect(resolveWindowsGitRuntimeSpec({ platform: 'linux', arch: 'x64' })).toBeNull()

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -336,10 +336,9 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
     ]);
   });
 
-  it('pi: --approve -p --mode json <prompt> (bare trailing positional — pi rejects --)', () => {
+  it('pi: -p --mode json <prompt> (bare trailing positional — pi rejects --)', () => {
     expect(piAdapter.composeHeadlessCommand!(['pi'], ctx(), 'do x')).toEqual([
       'pi',
-      '--approve',
       '-p',
       '--mode',
       'json',
@@ -366,17 +365,17 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
 describe('piAdapter AI-config', () => {
   const mcpEnv = { OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp', AQ_WS_ID: 'ws-abc' };
 
-  it('composeCommand: approves launcher-owned workspaces before fresh or resumed runs', () => {
-    expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env: mcpEnv })).toEqual(['pi', '--approve']);
+  it('composeCommand leaves project trust to Pi and the user', () => {
+    expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env: mcpEnv })).toEqual(['pi']);
     expect(piAdapter.composeCommand([], { cwd: dir, env: mcpEnv, resume: 'last' }))
-      .toEqual(['pi', '--approve', '--continue']);
+      .toEqual(['pi', '--continue']);
     expect(piAdapter.composeCommand([], { cwd: dir, env: mcpEnv, resume: { sessionId: 'sess-1' } }))
-      .toEqual(['pi', '--approve', '--session-id', 'sess-1']);
+      .toEqual(['pi', '--session-id', 'sess-1']);
   });
 
   it('composeCommand uses managed Pi binary path when the spawn env provides one', () => {
     const env = { ...mcpEnv, OPENALICE_MANAGED_PI_PATH: '/app/vendor/pi/pi' };
-    expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env })).toEqual(['/app/vendor/pi/pi', '--approve']);
+    expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env })).toEqual(['/app/vendor/pi/pi']);
     expect(piAdapter.composeHeadlessCommand!([], { cwd: dir, env }, 'hello')).toEqual([
       '/app/vendor/pi/pi', '--approve', '-p', '--mode', 'json', 'hello',
     ]);
@@ -391,7 +390,6 @@ describe('piAdapter AI-config', () => {
     expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env })).toEqual([
       '/Applications/OpenAlice.app/Contents/MacOS/OpenAlice',
       '/app/vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
-      '--approve',
     ]);
     expect(piAdapter.composeHeadlessCommand!([], { cwd: dir, env }, 'hello')).toEqual([
       '/Applications/OpenAlice.app/Contents/MacOS/OpenAlice',

--- a/src/workspaces/adapters/interactive-seed.spec.ts
+++ b/src/workspaces/adapters/interactive-seed.spec.ts
@@ -63,7 +63,7 @@ describe('interactive seed — composeCommand initialPrompt', () => {
 
     it('pi: bare trailing positional, NO `--` terminator', () => {
       const argv = piAdapter.composeCommand([], ctx({ initialPrompt: PROMPT }));
-      expect(argv).toEqual(['pi', '--approve', PROMPT]);
+      expect(argv).toEqual(['pi', PROMPT]);
       expect(argv).not.toContain('--');
     });
   });
@@ -76,7 +76,7 @@ describe('interactive seed — composeCommand initialPrompt', () => {
       expect(opencodeAdapter.composeCommand([], ctx())).toEqual(['opencode']);
     });
     it('pi', () => {
-      expect(piAdapter.composeCommand([], ctx())).toEqual(['pi', '--approve']);
+      expect(piAdapter.composeCommand([], ctx())).toEqual(['pi']);
     });
   });
 
@@ -114,7 +114,7 @@ describe('interactive seed — composeCommand initialPrompt', () => {
       [],
       ctx({ resume: { sessionId: 'assigned-uuid-1234' }, initialPrompt: PROMPT }),
     );
-    expect(argv).toEqual(['pi', '--approve', '--session-id', 'assigned-uuid-1234', PROMPT]);
+    expect(argv).toEqual(['pi', '--session-id', 'assigned-uuid-1234', PROMPT]);
   });
 
   it('shell ignores initialPrompt entirely (no agent to receive it)', () => {

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -14,7 +14,7 @@ import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js';
 // officially discovers shared project skills from `<cwd>/.agents/skills`
 // (walking ancestors to the repo root), so OpenAlice can use the same canonical
 // copy as Codex without maintaining a duplicate `<cwd>/.pi/skills` tree.
-// Verified against Pi 0.78.1 and the bundled 0.80.3.
+// Verified against Pi 0.78.1 and the bundled 0.80.6.
 const PI_AGENT_DIR = '.pi-agent';
 const PI_MODELS_PATH = `${PI_AGENT_DIR}/models.json`;
 const PI_SETTINGS_PATH = `${PI_AGENT_DIR}/settings.json`;
@@ -24,11 +24,18 @@ function positiveNumber(value: number | null | undefined): number | null {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
 }
 
-function piCommandHead(env: Readonly<Record<string, string>>): readonly string[] {
+function piCommandHead(env: Readonly<Record<string, string | undefined>>): readonly string[] {
   const profile = runtimeProfileFromEnv(env);
   if (!profile.managedPiPath) return ['pi'];
   if (profile.managedPiNodePath) return [profile.managedPiNodePath, profile.managedPiPath];
   return [profile.managedPiPath];
+}
+
+function piHeadlessApproveArgs(env: Readonly<Record<string, string | undefined>>): readonly string[] {
+  // The packaged app always uses OpenAlice's pinned managed Pi. Contributor
+  // dev intentionally uses whatever `pi` is on PATH; its install/version/trust
+  // policy belongs to that developer, so do not attach version-specific flags.
+  return runtimeProfileFromEnv(env).managedPiPath ? ['--approve'] : [];
 }
 
 /**
@@ -86,10 +93,11 @@ export const piAdapter: CliAdapter = {
     // Tools come from the CLI-injection path (alice on PATH + shared
     // .agents/skills), not flags — so the command head is just the binary + a
     // resume flag (if any).
-    // OpenAlice creates and owns the workspace, so approve its project-local
-    // resources for this invocation instead of blocking a fresh chat on Pi's
-    // interactive trust prompt. This does not mutate the user's global policy.
-    const head = [...piCommandHead(ctx.env), '--approve'];
+    // Pi 0.79+ asks the user to trust project-local resources on interactive
+    // startup. Do not answer that security decision for them: the prompt makes
+    // the `.agents/skills` boundary visible, and omitting the flag also keeps
+    // external Pi 0.78.x runtimes (which predate `--approve`) compatible.
+    const head = [...piCommandHead(ctx.env)];
     // Quick-chat seed: `pi [--session-id <id>] <messages…>` opens the
     // interactive TUI seeded with that first message. UNLIKE the other adapters,
     // pi appends the seed REGARDLESS of the resume branch: pi assigns its own id
@@ -107,14 +115,22 @@ export const piAdapter: CliAdapter = {
   },
 
   // Headless: `pi -p <prompt>` is non-interactive and exits at the turn
-  // boundary. Shared skills auto-load from `<cwd>/.agents/skills` (process cwd =
-  // workspace), and the alice* CLI shims remain on PATH, so the agent reaches
-  // inbox_push without any extra flag or MCP bridge. NOTE: pi
+  // boundary, so there is nobody to answer Pi 0.79+'s project-trust prompt.
+  // The packaged app explicitly approves its pinned managed Pi; contributor
+  // dev leaves its external Pi untouched. Interactive sessions above always
+  // leave the decision to the user. NOTE: pi
   // REJECTS a `--` end-of-options terminator ("Unknown option: --", verified
   // 0.78.1), so the prompt is a bare trailing positional — a prompt literally
   // starting with `-`/`--` is unprotected on pi (rare for task prompts).
   composeHeadlessCommand(_base: readonly string[], _ctx: SpawnContext, prompt: string): readonly string[] {
-    return [...piCommandHead(_ctx.env), '--approve', '-p', '--mode', 'json', prompt];
+    return [
+      ...piCommandHead(_ctx.env),
+      ...piHeadlessApproveArgs(_ctx.env),
+      '-p',
+      '--mode',
+      'json',
+      prompt,
+    ];
   },
 
   // pi `--mode json` line 1 is `{"type":"session","id":…,"cwd":…}` — pi mints


### PR DESCRIPTION
## Summary

- leave interactive Pi project trust to the user
- pass `--approve` only to the pinned managed Pi in headless packaged runs
- leave contributor-managed PATH Pi untouched in `pnpm dev`
- upgrade the bundled managed Pi from 0.80.3 to 0.80.6

No migration or cleanup is performed for existing workspace skill directories.

## Verification

- `npx tsc --noEmit`
- `pnpm test` — 2507 passed, 6 skipped
- focused adapter/runtime tests — 70 passed
- packaging helper tests — 10 passed
- workspace creation E2E — 3 passed
- `pnpm electron:smoke:packaged --temp-data`
- `pnpm electron:assert-package`
- `pnpm electron:smoke-toolchain`

The packaged smoke confirmed the app uses its bundled Pi 0.80.6 through packaged Electron Node mode.