### PR TITLE
Refine chat sidebar action hierarchy

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { WorkspacesContext, type WorkspacesContextValue } from '../../contexts/workspaces-context'
+import { i18n } from '../../i18n'
+import type { TemplateInfo, Workspace } from './api'
+import { ChatWorkspaceSection } from './ChatWorkspaceSection'
+
+const { openOrFocus } = vi.hoisted(() => ({ openOrFocus: vi.fn() }))
+
+vi.mock('../../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: typeof openOrFocus }) => unknown) =>
+    selector({ openOrFocus }),
+}))
+
+vi.mock('../../tabs/types', () => ({
+  getFocusedTab: () => null,
+}))
+
+const chatTemplate: TemplateInfo = {
+  name: 'chat',
+  defaultAgents: ['pi'],
+  version: '1.0.0',
+  hasReadme: true,
+}
+
+const chatWorkspace: Workspace = {
+  id: 'chat-1',
+  tag: 'chat-jul11',
+  dir: '/tmp/chat-jul11',
+  createdAt: '2026-07-11T00:00:00.000Z',
+  template: 'chat',
+  agents: ['pi'],
+  sessions: [],
+}
+
+function workspaceContext(workspaces: readonly Workspace[]): WorkspacesContextValue {
+  return {
+    workspaces,
+    templates: [chatTemplate],
+    agents: [],
+    defaultAgent: 'pi',
+    issueDefaultAgent: null,
+    listError: null,
+    hasLoaded: true,
+    templatesLoaded: true,
+    refresh: vi.fn(),
+    spawn: vi.fn(async () => undefined),
+    openHeadlessRun: vi.fn(async () => undefined),
+    setDefaultAgent: vi.fn(async () => undefined),
+    setIssueDefaultAgent: vi.fn(async () => undefined),
+    quickChat: vi.fn(async () => 'session-1'),
+    pauseSession: vi.fn(async () => undefined),
+    resumeSession: vi.fn(async () => undefined),
+    requestDeleteSession: vi.fn(),
+    openAgentConfig: vi.fn(),
+    saveWorkspaceMetadata: vi.fn(async () => undefined),
+    renameWorkspace: vi.fn(async () => undefined),
+  }
+}
+
+function renderSection(workspaces: readonly Workspace[] = [chatWorkspace]) {
+  return render(
+    <WorkspacesContext.Provider value={workspaceContext(workspaces)}>
+      <ChatWorkspaceSection />
+    </WorkspacesContext.Provider>,
+  )
+}
+
+beforeEach(async () => {
+  openOrFocus.mockReset()
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('ChatWorkspaceSection actions', () => {
+  it('keeps conversation creation primary and scopes workspace creation to the workspace list', () => {
+    renderSection()
+
+    const newChat = screen.getByRole('button', { name: 'New chat' })
+    const newWorkspace = screen.getByRole('button', { name: 'New workspace' })
+    const workspaceHeading = screen.getByText('Workspaces', { selector: 'span' })
+    const newSession = screen.getByRole('button', { name: 'New conversation in this workspace' })
+
+    expect(newChat.className).toContain('w-full')
+    expect(newChat.textContent).toBe('New chat')
+    expect(workspaceHeading.parentElement?.contains(newWorkspace)).toBe(true)
+    expect(newWorkspace.querySelector('.lucide-folder-plus')).toBeTruthy()
+    expect(newSession.querySelector('.lucide-message-square-plus')).toBeTruthy()
+
+    fireEvent.click(newChat)
+    expect(openOrFocus).toHaveBeenCalledWith({ kind: 'chat-landing', params: {} })
+
+    fireEvent.click(newSession)
+    expect(openOrFocus).toHaveBeenCalledWith({
+      kind: 'chat-landing',
+      params: { targetWsId: chatWorkspace.id },
+    })
+  })
+
+  it('keeps an explicit workspace action in the empty state', () => {
+    renderSection([])
+
+    expect(screen.getByText(i18n.t('chat.noChatWorkspacesYet'))).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: 'New workspace' })).toHaveLength(2)
+  })
+})

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -11,7 +11,15 @@
 
 import { useMemo, useState, type ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronRight, FolderPlus, Plus, Settings as SettingsIcon, X } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronRight,
+  FolderPlus,
+  MessageSquarePlus,
+  Plus,
+  Settings as SettingsIcon,
+  X,
+} from 'lucide-react'
 
 import { useWorkspaces } from '../../contexts/workspaces-context'
 import { Skeleton } from '../StateViews'
@@ -77,27 +85,33 @@ export function ChatWorkspaceSection(): ReactElement | null {
 
   return (
     <>
-      {/* A conversation is a Session inside the recent Chat Workspace; creating
-          a new Workspace is a separate, explicit context-boundary action. */}
-      <div className="px-2 pt-2 pb-1.5">
-        <div className="grid grid-cols-2 gap-1">
-          <button
-            type="button"
-            onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
-            className="min-w-0 flex items-center justify-center gap-1.5 px-2 py-2 rounded-lg border border-border/60 bg-bg-tertiary/30 text-[12px] font-medium text-text-muted transition-colors hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/60"
-          >
-            <Plus size={14} strokeWidth={2.25} className="shrink-0" />
-            <span className="truncate">{t('chat.newChat')}</span>
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowCreate(true)}
-            className="min-w-0 flex items-center justify-center gap-1.5 px-2 py-2 rounded-lg border border-border/60 bg-bg-tertiary/15 text-[12px] font-medium text-text-muted transition-colors hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/50"
-          >
-            <FolderPlus size={14} strokeWidth={2} className="shrink-0" />
-            <span className="truncate">{t('chat.newWorkspace')}</span>
-          </button>
-        </div>
+      {/* Starting a conversation is the primary action. Creating a Workspace is
+          a lower-frequency context-boundary action attached to the list it
+          affects, rather than a competing half-width CTA. */}
+      <div className="px-2 pt-2 pb-1">
+        <button
+          type="button"
+          onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
+          className="flex w-full items-center gap-2 rounded-lg border border-accent/25 bg-accent/10 px-3 py-2.5 text-left text-[13px] font-medium text-text transition-colors hover:border-accent/45 hover:bg-accent/15"
+        >
+          <Plus size={15} strokeWidth={2.25} className="shrink-0 text-accent" />
+          <span>{t('chat.newChat')}</span>
+        </button>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 px-3 pb-1 pt-1.5">
+        <span className="min-w-0 truncate text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted/60">
+          {t('nav.item.workspaces')}
+        </span>
+        <button
+          type="button"
+          onClick={() => setShowCreate(true)}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-muted/65 transition-colors hover:bg-bg-tertiary hover:text-text"
+          title={t('chat.newWorkspace')}
+          aria-label={t('chat.newWorkspace')}
+        >
+          <FolderPlus size={14} strokeWidth={2} />
+        </button>
       </div>
 
       {showCreate && (
@@ -135,7 +149,17 @@ export function ChatWorkspaceSection(): ReactElement | null {
           </li>
         )}
         {ctx.hasLoaded && chatWorkspaces.length === 0 && !showListError && (
-          <li className="px-3 py-2 text-[12px] text-text-muted/60">{t('chat.noChatWorkspacesYet')}</li>
+          <li className="px-3 py-2.5">
+            <p className="text-[12px] text-text-muted/60">{t('chat.noChatWorkspacesYet')}</p>
+            <button
+              type="button"
+              onClick={() => setShowCreate(true)}
+              className="mt-2 inline-flex items-center gap-1.5 text-[12px] font-medium text-text-muted transition-colors hover:text-text"
+            >
+              <FolderPlus size={13} strokeWidth={2} />
+              <span>{t('chat.newWorkspace')}</span>
+            </button>
+          </li>
         )}
         {showListError && <li className="px-3 py-1 text-[11px] text-red">{ctx.listError}</li>}
         {chatWorkspaces.map((w) => (
@@ -269,8 +293,9 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
             </span>
           )}
         </button>
-        {/* Always-visible "+" — spawn a fresh agent runtime in THIS day's
-            workspace (vs "New chat" which starts a whole new one). */}
+        {/* Always-visible conversation action for THIS workspace. The icon is
+            intentionally distinct from the global New chat and New workspace
+            actions so three different meanings do not collapse into bare +s. */}
         <button
           type="button"
           onClick={(e) => {
@@ -281,7 +306,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
           title={t('chat.newSession')}
           aria-label={t('chat.newSession')}
         >
-          <Plus size={13} strokeWidth={2.25} />
+          <MessageSquarePlus size={13} strokeWidth={2.1} />
         </button>
         <span className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
           <button


### PR DESCRIPTION
## What changed

- make `New chat` the full-width primary action in the Ask Alice sidebar
- move `New workspace` into the Workspaces section header and keep an explicit empty-state action
- replace the ambiguous per-workspace `+` with a message-square-plus icon
- add focused tests for action hierarchy, routing, icon semantics, and the empty state

## Why

The two equal half-width buttons truncated to `New c…` and `New w…` at the supported 200px sidebar width, while also presenting a frequent conversation action and an infrequent context-boundary action as peers.

## Impact

The sidebar now stays readable across narrow and wide layouts without changing Chat Workspace lifecycle or routing behavior.

## Validation

- `pnpm test` (2482 passed, 6 skipped)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- browser verification at 200px, 260px, and 320px sidebar widths with no horizontal overflow