### PR TITLE
Prioritize active sidebar sessions

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -26,10 +26,11 @@ import { Skeleton } from '../StateViews'
 import { useWorkspace } from '../../tabs/store'
 import { getFocusedTab } from '../../tabs/types'
 import { ConfirmDialog } from '../ConfirmDialog'
-import { deleteWorkspace, type SessionRecord, type Workspace } from './api'
+import { deleteWorkspace, type Workspace } from './api'
 import { CreateWorkspaceDialog } from './CreateWorkspaceDialog'
 import { SessionRow } from './Sidebar'
 import { workspaceDisplayTitle } from './display'
+import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order'
 import { preferencesApi } from '../../api/preferences'
 
 const CHAT_TEMPLATE = 'chat'
@@ -48,16 +49,18 @@ export function ChatWorkspaceSection(): ReactElement | null {
   const focused = useWorkspace((s) => getFocusedTab(s)?.spec)
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
 
-  const chatWorkspaces = useMemo(
-    () => ctx.workspaces.filter((w) => w.template === CHAT_TEMPLATE),
-    [ctx.workspaces],
-  )
-  const showListError = Boolean(ctx.listError && ctx.workspaces.length === 0)
-
   const isWsFocus = focused?.kind === 'workspace' && focused.params.source === 'chat'
   const selection = isWsFocus
     ? { wsId: focused.params.wsId, sessionId: focused.params.sessionId ?? null }
     : null
+  const chatWorkspaces = useMemo(
+    () => orderWorkspacesForSidebar(
+      ctx.workspaces.filter((workspace) => workspace.template === CHAT_TEMPLATE),
+      selection,
+    ),
+    [ctx.workspaces, selection],
+  )
+  const showListError = Boolean(ctx.listError && ctx.workspaces.length === 0)
 
   const chatTemplate = ctx.templates.find((tpl) => tpl.name === CHAT_TEMPLATE)
   const [pendingDelete, setPendingDelete] = useState<Workspace | null>(null)
@@ -170,11 +173,11 @@ export function ChatWorkspaceSection(): ReactElement | null {
             selection={selection}
             onOpen={() => {
               rememberChatWorkspace(w.id)
-              const recent = mostRecentSession(w.sessions)
+              const preferred = orderSessionsForSidebar(w.sessions, null)[0]
               openOrFocus({
                 kind: 'workspace',
-                params: recent
-                  ? { wsId: w.id, sessionId: recent.id, source: 'chat' }
+                params: preferred
+                  ? { wsId: w.id, sessionId: preferred.id, source: 'chat' }
                   : { wsId: w.id, source: 'chat' },
               })
             }}
@@ -208,13 +211,6 @@ export function ChatWorkspaceSection(): ReactElement | null {
   )
 }
 
-function mostRecentSession(sessions: readonly SessionRecord[]): SessionRecord | undefined {
-  if (sessions.length === 0) return undefined
-  return [...sessions].sort(
-    (a, b) => new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime(),
-  )[0]
-}
-
 interface ChatWorkspaceRowProps {
   workspace: Workspace
   label: string
@@ -238,6 +234,13 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
   const isSelected = props.selection?.wsId === w.id && props.selection.sessionId === null
   const displayName = w.displayName?.trim()
   const subtitle = displayName && displayName !== props.label ? displayName : null
+  const orderedSessions = useMemo(
+    () => orderSessionsForSidebar(
+      w.sessions,
+      props.selection?.wsId === w.id ? props.selection.sessionId : null,
+    ),
+    [w.sessions, w.id, props.selection],
+  )
 
   const statusClass = hasRunning
     ? 'bg-green'
@@ -335,9 +338,9 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
           </button>
         </span>
       </div>
-      {expanded && w.sessions.length > 0 && (
+      {expanded && orderedSessions.length > 0 && (
         <div className="ml-[18px] border-l border-border/50">
-          {w.sessions.map((s) => (
+          {orderedSessions.map((s) => (
             <SessionRow
               key={s.id}
               session={s}

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
 import { CreateWorkspaceDialog } from './CreateWorkspaceDialog';
 import { Skeleton } from '../StateViews';
 import { workspaceDisplayName, workspaceDisplayTitle } from './display';
+import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order';
 
 /**
  * Workspace launcher sidebar.
@@ -81,6 +82,10 @@ export function Sidebar(props: SidebarProps): ReactElement {
   const { t } = useTranslation();
   const [showCreate, setShowCreate] = useState(false);
   const showListError = Boolean(props.listError && props.workspaces.length === 0);
+  const orderedWorkspaces = useMemo(
+    () => orderWorkspacesForSidebar(props.workspaces, props.selection),
+    [props.workspaces, props.selection],
+  );
 
   // Headless runs, polled once for the whole tree (not per-workspace) and
   // grouped client-side. Low-frequency passive surface → plain polling.
@@ -183,7 +188,7 @@ export function Sidebar(props: SidebarProps): ReactElement {
       {showListError && <div className="px-3 py-2 text-[12px] text-red">{props.listError}</div>}
 
       <div className="flex flex-col mt-0.5">
-        {props.workspaces.map((w) => (
+        {orderedWorkspaces.map((w) => (
           <WorkspaceRow
             key={w.id}
             workspace={w}
@@ -303,6 +308,13 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   const isSelected = props.selection?.wsId === w.id && props.selection.sessionId === null;
   const hasRunning = w.sessions.some((s) => s.state === 'running');
   const runningCount = w.sessions.filter((s) => s.state === 'running').length;
+  const orderedSessions = useMemo(
+    () => orderSessionsForSidebar(
+      w.sessions,
+      props.selection?.wsId === w.id ? props.selection.sessionId : null,
+    ),
+    [w.sessions, w.id, props.selection],
+  );
 
   const [spawnMenuOpen, setSpawnMenuOpen] = useState(false);
   const plusBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -473,9 +485,9 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
         </button>
       </div>
 
-      {w.sessions.length > 0 && (
+      {orderedSessions.length > 0 && (
         <div className="ml-[18px] border-l border-border/50">
-          {w.sessions.map((s) => (
+          {orderedSessions.map((s) => (
             <SessionRow
               key={s.id}
               session={s}

--- a/ui/src/components/workspace/sidebar-order.spec.ts
+++ b/ui/src/components/workspace/sidebar-order.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionRecord, Workspace } from './api'
+import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order'
+
+function session(
+  id: string,
+  state: SessionRecord['state'],
+  lastActiveAt: string,
+): SessionRecord {
+  return {
+    id,
+    wsId: 'ws',
+    agent: 'pi',
+    name: id,
+    createdAt: lastActiveAt,
+    lastActiveAt,
+    state,
+    agentSessionId: null,
+    pid: state === 'running' ? 1 : null,
+    startedAt: state === 'running' ? 1 : null,
+    title: id,
+  }
+}
+
+function workspace(
+  id: string,
+  createdAt: string,
+  sessions: readonly SessionRecord[],
+): Workspace {
+  return {
+    id,
+    tag: id,
+    dir: `/tmp/${id}`,
+    createdAt,
+    template: 'chat',
+    agents: ['pi'],
+    sessions: sessions.map((record) => ({ ...record, wsId: id })),
+  }
+}
+
+describe('sidebar attention order', () => {
+  it('lifts the selected workspace, then running workspaces, then recent activity', () => {
+    const selectedOld = workspace('selected-old', '2026-01-01T00:00:00Z', [
+      session('selected-session', 'paused', '2026-01-01T00:00:00Z'),
+    ])
+    const runningOld = workspace('running-old', '2026-02-01T00:00:00Z', [
+      session('running-session', 'running', '2026-02-01T00:00:00Z'),
+    ])
+    const recentPaused = workspace('recent-paused', '2026-07-01T00:00:00Z', [
+      session('recent-session', 'paused', '2026-07-10T00:00:00Z'),
+    ])
+    const olderPaused = workspace('older-paused', '2026-06-01T00:00:00Z', [
+      session('older-session', 'paused', '2026-07-09T00:00:00Z'),
+    ])
+
+    expect(orderWorkspacesForSidebar(
+      [olderPaused, recentPaused, runningOld, selectedOld],
+      { wsId: selectedOld.id, sessionId: 'selected-session' },
+    ).map((candidate) => candidate.id)).toEqual([
+      'selected-old',
+      'running-old',
+      'recent-paused',
+      'older-paused',
+    ])
+  })
+
+  it('uses workspace creation time when no session activity exists', () => {
+    const older = workspace('older', '2026-07-01T00:00:00Z', [])
+    const newer = workspace('newer', '2026-07-10T00:00:00Z', [])
+
+    expect(orderWorkspacesForSidebar([older, newer], null).map((candidate) => candidate.id))
+      .toEqual(['newer', 'older'])
+  })
+
+  it('lifts the selected session, then running sessions, then recent activity', () => {
+    const selectedOld = session('selected-old', 'paused', '2026-01-01T00:00:00Z')
+    const runningOld = session('running-old', 'running', '2026-02-01T00:00:00Z')
+    const recentPaused = session('recent-paused', 'paused', '2026-07-10T00:00:00Z')
+    const olderPaused = session('older-paused', 'paused', '2026-07-09T00:00:00Z')
+
+    expect(orderSessionsForSidebar(
+      [olderPaused, recentPaused, runningOld, selectedOld],
+      selectedOld.id,
+    ).map((candidate) => candidate.id)).toEqual([
+      'selected-old',
+      'running-old',
+      'recent-paused',
+      'older-paused',
+    ])
+  })
+})

--- a/ui/src/components/workspace/sidebar-order.ts
+++ b/ui/src/components/workspace/sidebar-order.ts
@@ -1,0 +1,66 @@
+import type { SessionRecord, Workspace } from './api'
+
+export interface SidebarSelection {
+  readonly wsId: string
+  readonly sessionId: string | null
+}
+
+function timestamp(value: string): number {
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function workspaceActivityMs(workspace: Workspace): number {
+  const sessionActivity = workspace.sessions.map((session) => timestamp(session.lastActiveAt))
+  return sessionActivity.length > 0
+    ? Math.max(timestamp(workspace.createdAt), ...sessionActivity)
+    : timestamp(workspace.createdAt)
+}
+
+/**
+ * Rank the workspace tree by current attention, then by recency. Selection is
+ * deliberately UI-local: opening an old Inbox-linked session should lift its
+ * whole workspace immediately without rewriting durable session timestamps.
+ */
+export function orderWorkspacesForSidebar(
+  workspaces: readonly Workspace[],
+  selection: SidebarSelection | null,
+): Workspace[] {
+  return [...workspaces].sort((a, b) => {
+    const selected = Number(b.id === selection?.wsId) - Number(a.id === selection?.wsId)
+    if (selected !== 0) return selected
+
+    const running = Number(b.sessions.some((session) => session.state === 'running'))
+      - Number(a.sessions.some((session) => session.state === 'running'))
+    if (running !== 0) return running
+
+    const activity = workspaceActivityMs(b) - workspaceActivityMs(a)
+    if (activity !== 0) return activity
+
+    const created = timestamp(b.createdAt) - timestamp(a.createdAt)
+    if (created !== 0) return created
+    return a.id.localeCompare(b.id)
+  })
+}
+
+/** Selected and running sessions are the ones most likely to need attention;
+ * within the same state, the latest activity wins. */
+export function orderSessionsForSidebar(
+  sessions: readonly SessionRecord[],
+  selectedSessionId: string | null,
+): SessionRecord[] {
+  return [...sessions].sort((a, b) => {
+    const selected = Number(b.id === selectedSessionId) - Number(a.id === selectedSessionId)
+    if (selected !== 0) return selected
+
+    const running = Number(b.state === 'running') - Number(a.state === 'running')
+    if (running !== 0) return running
+
+    const activity = timestamp(b.lastActiveAt) - timestamp(a.lastActiveAt)
+    if (activity !== 0) return activity
+
+    const created = timestamp(b.createdAt) - timestamp(a.createdAt)
+    if (created !== 0) return created
+    return a.id.localeCompare(b.id)
+  })
+}


### PR DESCRIPTION
## What changed

- add a shared attention-based ordering policy for Workspace sidebars
- rank the currently selected workspace/session first, then running sessions, then recent activity
- fall back to workspace/session creation time for deterministic ordering
- apply the same policy to both Ask Alice and the general Workspaces sidebar
- make workspace-row opening choose the same preferred session shown first
- add focused tests for selected, running, recent, and creation-time fallback behavior

## Root cause

Both sidebars rendered backend arrays directly. Workspace metadata arrived in creation-time order, while the session registry returned sessions oldest-first. Inbox-to-session navigation could therefore focus a valid old workspace without moving it anywhere near the visible part of the sidebar.

## User impact

Inbox-linked and currently active work now stays near the top of the navigation tree. The selected session remains first inside its workspace, running work stays ahead of paused history, and inactive items decay naturally by last activity.

## Validation

- `pnpm test` (2485 passed, 6 skipped)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- browser verification on `/chat` and the general Workspaces sidebar using live Workspace data