### PR TITLE
Make chat workspace picker scrollable

### DIFF
--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -152,6 +152,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   const [recentChatWorkspaceId, setRecentChatWorkspaceId] = useState<string | null>(null)
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false)
   const workspaceBoxRef = useRef<HTMLDivElement>(null)
+  const activeWorkspaceOptionRef = useRef<HTMLButtonElement>(null)
   const selectedChatWorkspace = useMemo(
     () => resolveChatWorkspaceTarget(
       workspaces,
@@ -392,6 +393,17 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     return () => document.removeEventListener('mousedown', onDown)
   }, [workspaceMenuOpen])
 
+  // The picker opens upward from the composer. Keep the active option inside
+  // its own scroll viewport so a long Workspace history cannot push recent or
+  // currently selected targets beyond the top of the window.
+  useEffect(() => {
+    if (!workspaceMenuOpen) return
+    const frame = requestAnimationFrame(() => {
+      activeWorkspaceOptionRef.current?.scrollIntoView({ block: 'nearest' })
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [workspaceMenuOpen, workspaceTarget?.id])
+
   const submit = async () => {
     const prompt = value.trim()
     if (!prompt || launching) return
@@ -548,13 +560,14 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 {workspaceMenuOpen && targetWs === undefined && chatWorkspaceOptions.length > 0 && (
                   <div
                     role="menu"
-                    className="absolute bottom-full left-0 z-10 mb-1 min-w-[220px] max-w-[320px] py-1 rounded-lg border border-border/70 bg-bg-secondary shadow-lg"
+                    className="absolute bottom-full left-0 z-10 mb-1 max-h-[min(24rem,calc(100vh-8rem))] min-w-[220px] max-w-[320px] overflow-y-auto overscroll-contain rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg [scrollbar-gutter:stable]"
                   >
                     {chatWorkspaceOptions.map((workspace) => {
                       const active = workspace.id === workspaceTarget?.id
                       return (
                         <button
                           key={workspace.id}
+                          ref={active ? activeWorkspaceOptionRef : undefined}
                           type="button"
                           role="menuitem"
                           onClick={() => {


### PR DESCRIPTION
## What changed

- cap the upward-opening Chat Workspace picker to the available viewport
- enable contained vertical scrolling for long Workspace histories
- automatically scroll the currently selected Workspace into view whenever the picker opens
- reserve scrollbar space so labels do not shift as scrolling becomes available

## Root cause

The picker rendered every Chat Workspace in an unconstrained absolutely positioned menu. With a long history, the menu extended above the viewport and the browser clipped the newest rows. Because the menu itself had no overflow behavior, those rows could not be reached by scrolling.

## User impact

Recent targets such as `chat-jul10` remain visible when the picker opens, while every older Workspace remains reachable through the menu's own scrollbar.

## Validation

- `pnpm test` (2485 passed, 6 skipped)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- live `/chat` verification: 384px menu height, 638px scroll content, full 256px scroll range, selected and final options both reachable