### PR TITLE
Animate sidebar attention reordering

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -31,6 +31,7 @@ import { CreateWorkspaceDialog } from './CreateWorkspaceDialog'
 import { SessionRow } from './Sidebar'
 import { workspaceDisplayTitle } from './display'
 import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order'
+import { useReorderMotion } from './useReorderMotion'
 import { preferencesApi } from '../../api/preferences'
 
 const CHAT_TEMPLATE = 'chat'
@@ -59,6 +60,9 @@ export function ChatWorkspaceSection(): ReactElement | null {
       selection,
     ),
     [ctx.workspaces, selection],
+  )
+  const workspaceListRef = useReorderMotion<HTMLUListElement>(
+    chatWorkspaces.map((workspace) => workspace.id),
   )
   const showListError = Boolean(ctx.listError && ctx.workspaces.length === 0)
 
@@ -131,7 +135,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
         />
       )}
 
-      <ul className="py-0.5">
+      <ul ref={workspaceListRef} className="py-0.5">
         {/* Cold load: the list is empty because it hasn't fetched yet, NOT
             because there are no chats — show a skeleton instead of flashing the
             "no chats yet" empty text (or a blank pane) until the first list
@@ -241,6 +245,9 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
     ),
     [w.sessions, w.id, props.selection],
   )
+  const sessionListRef = useReorderMotion<HTMLDivElement>(
+    orderedSessions.map((session) => session.id),
+  )
 
   const statusClass = hasRunning
     ? 'bg-green'
@@ -249,7 +256,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
       : 'border border-border'
 
   return (
-    <li className="group relative">
+    <li className="group relative" data-reorder-id={w.id}>
       <div
         className={`flex items-center gap-1 pl-2 pr-2 py-1 text-[13px] cursor-pointer transition-colors ${
           isSelected ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
@@ -339,10 +346,11 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
         </span>
       </div>
       {expanded && orderedSessions.length > 0 && (
-        <div className="ml-[18px] border-l border-border/50">
+        <div ref={sessionListRef} className="ml-[18px] border-l border-border/50">
           {orderedSessions.map((s) => (
             <SessionRow
               key={s.id}
+              reorderId={s.id}
               session={s}
               isActive={props.selection?.sessionId === s.id}
               onSelect={() => props.onOpenSession(s.id)}

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -16,6 +16,7 @@ import { CreateWorkspaceDialog } from './CreateWorkspaceDialog';
 import { Skeleton } from '../StateViews';
 import { workspaceDisplayName, workspaceDisplayTitle } from './display';
 import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order';
+import { useReorderMotion } from './useReorderMotion';
 
 /**
  * Workspace launcher sidebar.
@@ -85,6 +86,9 @@ export function Sidebar(props: SidebarProps): ReactElement {
   const orderedWorkspaces = useMemo(
     () => orderWorkspacesForSidebar(props.workspaces, props.selection),
     [props.workspaces, props.selection],
+  );
+  const workspaceListRef = useReorderMotion<HTMLDivElement>(
+    orderedWorkspaces.map((workspace) => workspace.id),
   );
 
   // Headless runs, polled once for the whole tree (not per-workspace) and
@@ -187,10 +191,11 @@ export function Sidebar(props: SidebarProps): ReactElement {
       )}
       {showListError && <div className="px-3 py-2 text-[12px] text-red">{props.listError}</div>}
 
-      <div className="flex flex-col mt-0.5">
+      <div ref={workspaceListRef} className="flex flex-col mt-0.5">
         {orderedWorkspaces.map((w) => (
           <WorkspaceRow
             key={w.id}
+            reorderId={w.id}
             workspace={w}
             agents={props.agents}
             defaultAgent={props.defaultAgent}
@@ -242,6 +247,7 @@ function NavRow({
 }
 
 export interface WorkspaceRowProps {
+  readonly reorderId?: string;
   readonly workspace: Workspace;
   readonly agents: readonly AgentInfo[];
   readonly defaultAgent: string | null;
@@ -315,6 +321,9 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
     ),
     [w.sessions, w.id, props.selection],
   );
+  const sessionListRef = useReorderMotion<HTMLDivElement>(
+    orderedSessions.map((session) => session.id),
+  );
 
   const [spawnMenuOpen, setSpawnMenuOpen] = useState(false);
   const plusBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -375,7 +384,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
       : 'border border-border';
 
   return (
-    <div>
+    <div data-reorder-id={props.reorderId}>
       <div
         className={`group relative flex items-center gap-1 pl-3 pr-2 py-1.5 text-[12px] transition-colors ${
           isSelected ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
@@ -486,10 +495,11 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
       </div>
 
       {orderedSessions.length > 0 && (
-        <div className="ml-[18px] border-l border-border/50">
+        <div ref={sessionListRef} className="ml-[18px] border-l border-border/50">
           {orderedSessions.map((s) => (
             <SessionRow
               key={s.id}
+              reorderId={s.id}
               session={s}
               isActive={props.selection?.wsId === w.id && props.selection.sessionId === s.id}
               onSelect={() => props.onSelectSession(w.id, s.id)}
@@ -608,6 +618,7 @@ function HeadlessTaskRow(props: {
 }
 
 export interface SessionRowProps {
+  reorderId?: string;
   session: SessionRecord;
   isActive: boolean;
   onSelect: () => void;
@@ -633,6 +644,7 @@ export function SessionRow(props: SessionRowProps): ReactElement {
 
   return (
     <div
+      data-reorder-id={props.reorderId}
       className={`group relative flex items-center gap-1.5 pl-3 pr-2 py-1.5 text-[12px] transition-colors ${
         props.isActive ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary/50'
       }`}

--- a/ui/src/components/workspace/useReorderMotion.spec.tsx
+++ b/ui/src/components/workspace/useReorderMotion.spec.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useReorderMotion } from './useReorderMotion'
+
+const originalAnimate = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'animate')
+const animateMock = vi.fn<(
+  keyframes: Keyframe[] | PropertyIndexedKeyframes | null,
+  options?: number | KeyframeAnimationOptions,
+) => Animation>(() => ({
+  addEventListener: vi.fn(),
+  cancel: vi.fn(),
+}) as unknown as Animation)
+
+function rect(top: number, height = 32): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    right: 200,
+    bottom: top + height,
+    width: 200,
+    height,
+    toJSON: () => ({}),
+  }
+}
+
+function Harness({ ids }: { ids: readonly string[] }) {
+  const ref = useReorderMotion<HTMLDivElement>(ids)
+  return (
+    <div ref={ref}>
+      {ids.map((id) => <div key={id} data-reorder-id={id}>{id}</div>)}
+    </div>
+  )
+}
+
+beforeEach(() => {
+  animateMock.mockClear()
+  vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: false })))
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    const parent = this.parentElement
+    if (!parent) return rect(0)
+    const index = Array.from(parent.children).indexOf(this)
+    return rect(index * 32)
+  })
+  Object.defineProperty(HTMLElement.prototype, 'animate', {
+    configurable: true,
+    value: animateMock,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  if (originalAnimate) {
+    Object.defineProperty(HTMLElement.prototype, 'animate', originalAnimate)
+  } else {
+    delete (HTMLElement.prototype as Partial<HTMLElement>)['animate']
+  }
+})
+
+describe('useReorderMotion', () => {
+  it('animates rows from their previous positions after the order changes', () => {
+    const view = render(<Harness ids={['a', 'b']} />)
+    expect(animateMock).not.toHaveBeenCalled()
+
+    view.rerender(<Harness ids={['b', 'a']} />)
+
+    expect(animateMock).toHaveBeenCalledTimes(2)
+    const startTransforms = animateMock.mock.calls.map(([frames]) => (
+      (frames as Keyframe[] | null)?.[0]?.transform
+    ))
+    expect(startTransforms).toContain('translate3d(0, 32px, 0) scale(0.985)')
+    expect(startTransforms).toContain('translate3d(0, -32px, 0) scale(0.985)')
+  })
+
+  it('does not animate when the operating system requests reduced motion', () => {
+    vi.mocked(window.matchMedia).mockReturnValue({ matches: true } as MediaQueryList)
+    const view = render(<Harness ids={['a', 'b']} />)
+    view.rerender(<Harness ids={['b', 'a']} />)
+
+    expect(animateMock).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/components/workspace/useReorderMotion.ts
+++ b/ui/src/components/workspace/useReorderMotion.ts
@@ -1,0 +1,73 @@
+import { useLayoutEffect, useRef } from 'react'
+
+const REORDER_DURATION_MS = 360
+const REORDER_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)'
+
+function measureChildren(container: HTMLElement): Map<string, number> {
+  const containerTop = container.getBoundingClientRect().top
+  const positions = new Map<string, number>()
+  for (const child of Array.from(container.children)) {
+    if (!(child instanceof HTMLElement)) continue
+    const id = child.dataset.reorderId
+    if (!id) continue
+    positions.set(id, child.getBoundingClientRect().top - containerTop)
+  }
+  return positions
+}
+
+/**
+ * Animate direct children from their previous vertical position to their new
+ * sorted position. This is a small FLIP transition: layout remains the source
+ * of truth while transforms bridge the visual jump between two orders.
+ */
+export function useReorderMotion<T extends HTMLElement>(orderedIds: readonly string[]) {
+  const containerRef = useRef<T | null>(null)
+  const previousPositions = useRef(new Map<string, number>())
+  const animations = useRef(new Map<string, Animation>())
+  const orderKey = orderedIds.join('\u001f')
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    for (const animation of animations.current.values()) animation.cancel()
+    animations.current.clear()
+
+    const nextPositions = measureChildren(container)
+    const reduceMotion = typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    if (!reduceMotion && previousPositions.current.size > 0) {
+      for (const child of Array.from(container.children)) {
+        if (!(child instanceof HTMLElement)) continue
+        const id = child.dataset.reorderId
+        if (!id) continue
+        const previousTop = previousPositions.current.get(id)
+        const nextTop = nextPositions.get(id)
+        if (previousTop === undefined || nextTop === undefined) continue
+
+        const deltaY = previousTop - nextTop
+        if (Math.abs(deltaY) < 1) continue
+        const overshoot = Math.sign(deltaY) * -2
+        const animation = child.animate(
+          [
+            { transform: `translate3d(0, ${deltaY}px, 0) scale(0.985)` },
+            { transform: `translate3d(0, ${overshoot}px, 0) scale(1.006)`, offset: 0.78 },
+            { transform: 'translate3d(0, 0, 0) scale(1)' },
+          ],
+          { duration: REORDER_DURATION_MS, easing: REORDER_EASING },
+        )
+        animations.current.set(id, animation)
+        animation.addEventListener('finish', () => animations.current.delete(id), { once: true })
+      }
+    }
+
+    previousPositions.current = nextPositions
+    return () => {
+      for (const animation of animations.current.values()) animation.cancel()
+      animations.current.clear()
+    }
+  }, [orderKey])
+
+  return containerRef
+}


### PR DESCRIPTION
## What changed

- add a reusable FLIP-based vertical reorder animation using the native Web Animations API
- animate both Workspace-level and Session-level attention sorting
- apply the motion consistently to Ask Alice and the general Workspaces sidebar
- use a visible 360ms spring-like easing with a subtle overshoot and scale response
- retain the operating-system reduced-motion accessibility fallback
- add focused tests for displacement direction and reduced-motion behavior

## Why

Attention sorting correctly moved the selected/running Session and its Workspace toward the top, but the DOM reorder happened in a single frame. With a long sidebar, that instant jump made it difficult to visually track where the active context went.

## User impact

Rows now visibly travel from their old position to the new ranked position. Nested Session and Workspace animations compose, so the user's eye can follow the activated Session together with its parent Workspace instead of seeing the tree flash into a new order.

## Validation

- `pnpm test` (2487 passed, 6 skipped)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- live Session-page verification with two Workspace reorders and no browser console errors