### PR TITLE
Shorten CI feedback loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,83 @@ on:
     branches: [master, dev]
   pull_request:
     branches: [dev, master]
+  # Keep a full cross-platform safety net for lightweight PRs that intentionally
+  # skip the expensive host matrix. Scheduled workflows run from the default
+  # branch, while checkout below points the jobs at the current dev branch.
+  schedule:
+    - cron: "0 19 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Agent-driven iterations often supersede an earlier commit before its Windows
+# job finishes. Keep only the latest PR/dev run while never cancelling a master
+# or scheduled validation.
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' }}
 
 jobs:
+  # UI and prose changes are built and tested on Ubuntu, but do not need to
+  # repeat the host-sensitive runtime suite on macOS and Windows. This is a
+  # deliberately narrow allowlist: every other path keeps the full matrix.
+  change-scope:
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    outputs:
+      cross_platform: ${{ steps.changes.outputs.cross_platform }}
+
+    steps:
+      - name: Classify changed paths
+        id: changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName !== "pull_request") {
+              core.info("Non-PR validation keeps the full platform matrix.");
+              core.setOutput("cross_platform", "true");
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+            const paths = files.flatMap((file) =>
+              file.previous_filename
+                ? [file.filename, file.previous_filename]
+                : [file.filename],
+            );
+            const isLightweight = (path) =>
+              path.startsWith("ui/") ||
+              path.startsWith("docs/") ||
+              /^[^/]+\.md$/i.test(path) ||
+              path === "LICENSE";
+            const platformSensitive = paths.filter((path) => !isLightweight(path));
+            const runCrossPlatform = paths.length === 0 || platformSensitive.length > 0;
+
+            core.info(`Changed paths: ${paths.join(", ") || "none reported"}`);
+            if (platformSensitive.length > 0) {
+              core.info(`Full matrix required by: ${platformSensitive.join(", ")}`);
+            } else {
+              core.info("Only UI/docs paths changed; Ubuntu remains the PR gate.");
+            }
+            core.setOutput("cross_platform", String(runCrossPlatform));
+
   build-and-test:
+    # A dev push is the already-tested result of merging a PR. It gets the
+    # focused post-merge smoke below instead of repeating the whole PR suite.
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - uses: pnpm/action-setup@v4
 
@@ -31,6 +101,8 @@ jobs:
   # Ubuntu remains the build gate above; this matrix prevents a Linux-only
   # green check from shipping regressions to macOS or Windows users.
   cross-platform-test:
+    needs: change-scope
+    if: needs.change-scope.outputs.cross_platform == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +111,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - uses: pnpm/action-setup@v4
 
@@ -62,6 +136,8 @@ jobs:
   # control: if Windows goes red while Ubuntu stays green, it's a real platform
   # diff, not a harness bug. See scripts/guardian/smoke.ts.
   dev-smoke:
+    needs: change-scope
+    if: needs.change-scope.outputs.cross_platform == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -70,6 +146,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - uses: pnpm/action-setup@v4
 
@@ -85,6 +163,31 @@ jobs:
       # Exercises duplicate-start rejection, graceful takeover, crash-stale
       # reclamation, heartbeat renewal, and forced recovery with real child
       # processes before the heavier full-stack boot smoke.
+      - run: pnpm test:guardian-recovery
+        timeout-minutes: 3
+
+      - run: pnpm test:smoke
+        timeout-minutes: 8
+
+  # Merging a green PR changes the commit SHA but normally not its tested tree.
+  # Keep a cheap real-process integration check on dev without paying for a
+  # second complete Linux/macOS/Windows pass.
+  post-merge-dev-smoke:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'
+
       - run: pnpm test:guardian-recovery
         timeout-minutes: 3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Classify changed paths
         id: changes
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             if (context.eventName !== "pull_request") {

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -108,6 +108,27 @@ Do not append agent-vendor advertising or automatic co-author trailers.
 Credit human reports, designs, or reviews through `CONTRIBUTORS.md` and links to
 the issue/PR that shaped the work.
 
+## CI Feedback Lanes
+
+CI distinguishes pre-merge confidence from post-merge integration so routine
+agent iterations do not wait for the same full matrix twice:
+
+- Every PR to `dev` or `master` runs the Ubuntu build and test gate.
+- PRs whose complete diff is limited to `ui/`, `docs/`, or root documentation
+  skip the macOS/Windows runtime matrix. Any other path keeps the full matrix.
+- Superseded runs for the same PR are cancelled. Only the latest head is a
+  merge candidate.
+- A push to `dev` runs the focused Ubuntu Guardian/full-stack smoke instead of
+  repeating the PR's complete build, test, and cross-platform jobs.
+- A push to `master` always runs the complete matrix.
+- Once this workflow version reaches the default `master` branch, the scheduled
+  validation checks out current `dev` and runs the complete matrix, providing a
+  daily cross-platform backstop for lightweight PRs.
+
+Keep the lightweight-path allowlist narrow. Changes to dependencies, runtime,
+Guardian, Electron, packaging, scripts, workflows, or any unclassified path
+must continue through Windows and macOS before merge.
+
 ## Merge and Cleanup
 
 The normal merge method is a merge commit:


### PR DESCRIPTION
## Summary
- cancel superseded PR and dev CI runs so agent-driven iterations do not wait behind stale Windows jobs
- keep Ubuntu build/test for every PR, while narrowly skipping the macOS/Windows runtime matrix for UI/docs-only diffs
- replace the duplicate full `push: dev` suite with a focused Ubuntu Guardian/full-stack smoke
- retain full validation for master, unclassified changes, and the nightly dev backstop after this workflow reaches the default branch
- document the CI feedback lanes in the development workflow owner guide

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- path classifier cases for UI-only, docs-only, dependency, workflow, and empty diffs
- `npx tsc --noEmit`
- `pnpm test` (204 files passed, 1 skipped; 2487 tests passed, 6 skipped)
- `pnpm test:guardian-recovery`
- `pnpm test:smoke`

## Boundary touch
- CI and development workflow only; no trading, auth, credentials, migrations, runtime implementation, or packaging changes
