### PR TITLE
Restore Intel Mac package and release coverage

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/desktop-packaged-smoke.mjs"
       - "scripts/desktop-packaged-smoke-plan.mjs"
       - "scripts/guardian/**"
+      - "scripts/prepare-desktop-release-assets.mjs"
       - "scripts/smoke-packaged-toolchain.mjs"
       - "scripts/vendor-managed-runtime.mjs"
       - "src/core/paths.ts"
@@ -38,6 +39,7 @@ on:
       - "scripts/desktop-packaged-smoke.mjs"
       - "scripts/desktop-packaged-smoke-plan.mjs"
       - "scripts/guardian/**"
+      - "scripts/prepare-desktop-release-assets.mjs"
       - "scripts/smoke-packaged-toolchain.mjs"
       - "scripts/vendor-managed-runtime.mjs"
       - "src/core/paths.ts"
@@ -53,7 +55,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-latest]
+        include:
+          - os: macos-14
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
+          - os: windows-latest
+            arch: x64
 
     steps:
       - uses: actions/checkout@v4
@@ -98,7 +106,7 @@ jobs:
             ulimit -n 65536 || ulimit -n 32768 || ulimit -n 16384 || ulimit -n 10240
             echo "open files limit: $(ulimit -n)"
           fi
-          pnpm -F @traderalice/desktop exec electron-builder --dir --projectDir ../.. --publish never
+          pnpm -F @traderalice/desktop exec electron-builder --dir --projectDir ../.. --publish never --${{ matrix.arch }}
 
       - name: Assert packaged resource layout
         run: pnpm electron:assert-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 (Intel/x64) dropped: GitHub's x64 mac runners queue for
-        # tens of minutes and routinely never allocate, hanging the whole
-        # release run — and Intel Macs are a shrinking base Apple stopped
-        # selling in 2023 (arm64 covers every Mac since). Re-add if real
-        # demand appears, ideally cross-built off the arm64 runner.
-        os: [macos-14, windows-latest] # arm64 dmg / x64 nsis
+        include:
+          - os: macos-14
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
+          - os: windows-latest
+            arch: x64
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write # upload release assets
@@ -144,13 +145,12 @@ jobs:
 
       - name: Package macOS installer
         if: runner.os == 'macOS'
-        # electron-builder picks the target + arch from the host runner (mac
-        # arm64). --publish never: build only, softprops does the upload so the
-        # release object has one owner.
+        # Build on the matching native host so pnpm and electron-builder both
+        # select the correct native dependencies for arm64 or Intel.
         run: |
           ulimit -n 65536 || ulimit -n 32768 || ulimit -n 16384 || ulimit -n 10240
           echo "open files limit: $(ulimit -n)"
-          pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never
+          pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never --${{ matrix.arch }}
         env:
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
@@ -161,34 +161,21 @@ jobs:
         if: runner.os == 'Windows'
         # Windows remains unsigned until a Windows code-signing certificate is
         # available.
-        run: pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never
+        run: pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never --${{ matrix.arch }}
 
       - name: Prepare update channel aliases
         shell: bash
+        env:
+          RELEASE_PLATFORM: ${{ runner.os }}
+          RELEASE_ARCH: ${{ matrix.arch }}
         run: |
-          node - <<'NODE'
-          const fs = require('fs')
-          const path = require('path')
-          const version = require('./package.json').version
-          const match = version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/)
-          if (!match) process.exit(0)
-
-          const channel = match[1]
-          const outDir = path.join('dist', 'electron-app')
-          const aliases = [
-            ['latest-mac.yml', `${channel}-mac.yml`],
-            ['latest.yml', `${channel}.yml`],
-          ]
-
-          for (const [source, target] of aliases) {
-            const sourcePath = path.join(outDir, source)
-            if (!fs.existsSync(sourcePath)) continue
-            fs.copyFileSync(sourcePath, path.join(outDir, target))
-            console.log(`Created ${target} from ${source}`)
-          }
-
-          fs.rmSync(path.join(outDir, 'builder-debug.yml'), { force: true })
-          NODE
+          VERSION=$(node -p "require('./package.json').version")
+          node scripts/prepare-desktop-release-assets.mjs build \
+            --out-dir dist/electron-app \
+            --platform "$RELEASE_PLATFORM" \
+            --arch "$RELEASE_ARCH" \
+            --version "$VERSION"
+          rm -f dist/electron-app/builder-debug.yml
 
       - name: Attach installer to the release
         uses: softprops/action-gh-release@v2
@@ -206,9 +193,11 @@ jobs:
     if: always() && ((needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success') || github.event.inputs.mirror_tag)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -222,81 +211,22 @@ jobs:
           TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
           DOWNLOAD_BASE_URL: ${{ secrets.DOWNLOAD_BASE_URL }}
         run: |
-          node - <<'NODE'
-          const fs = require('fs')
-          const path = require('path')
+          node scripts/prepare-desktop-release-assets.mjs mirror \
+            --out-dir dist/r2-upload \
+            --tag "$TAG" \
+            --base-url "${DOWNLOAD_BASE_URL:-https://download.openalice.ai}" \
+            --repository "$GITHUB_REPOSITORY"
 
-          const outDir = path.join('dist', 'r2-upload')
-          const tag = process.env.TAG
-          const version = tag.replace(/^v/, '')
-          const baseUrl = (process.env.DOWNLOAD_BASE_URL || 'https://download.openalice.ai').replace(/\/+$/, '')
-          const releaseNotesUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/releases/tag/${tag}`
-
-          fs.rmSync(path.join(outDir, 'builder-debug.yml'), { force: true })
-
-          const names = () => fs.readdirSync(outDir)
-          const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-          const versionPattern = escapeRegExp(version)
-          const find = (pattern) => names().find((name) => pattern.test(name))
-          const copyAlias = (source, alias) => {
-            if (!source) return null
-            if (source === alias) return alias
-            fs.copyFileSync(path.join(outDir, source), path.join(outDir, alias))
-            console.log(`Created ${alias} from ${source}`)
-            return alias
-          }
-          const parseYamlScalar = (content, key) => {
-            const match = content.match(new RegExp(`(?:^|\\n)${key}:\\s*['"]?([^'"\\n]+)['"]?`))
-            return match?.[1]?.trim() || null
-          }
-
-          if (version.includes('-')) {
-            const channel = version.split('-')[1].split('.')[0]
-            copyAlias(find(/^latest-mac\.yml$/), `${channel}-mac.yml`)
-            copyAlias(find(/^latest\.yml$/), `${channel}.yml`)
-          }
-
-          const macArm64Dmg = find(new RegExp(`^OpenAlice-${versionPattern}-arm64\\.dmg$`))
-          const macArm64Zip = find(new RegExp(`^OpenAlice-${versionPattern}-arm64-mac\\.zip$`))
-          const windowsX64Exe = find(new RegExp(`^OpenAlice\\.Setup\\.${versionPattern}\\.exe$`))
-          const windowsX64Blockmap = find(new RegExp(`^OpenAlice\\.Setup\\.${versionPattern}\\.exe\\.blockmap$`))
-
-          copyAlias(macArm64Dmg, 'mac-arm64.dmg')
-          copyAlias(macArm64Zip, 'mac-arm64.zip')
-          copyAlias(windowsX64Exe, 'windows-x64.exe')
-
-          const betaYmlPath = path.join(outDir, 'beta.yml')
-          const windowsFeedExe = fs.existsSync(betaYmlPath)
-            ? parseYamlScalar(fs.readFileSync(betaYmlPath, 'utf8'), 'path')
-            : null
-          if (windowsFeedExe?.endsWith('.exe')) {
-            copyAlias(windowsX64Exe, windowsFeedExe)
-            copyAlias(windowsX64Blockmap, `${windowsFeedExe}.blockmap`)
-          }
-
-          const manifest = {
-            version,
-            publishedAt: new Date().toISOString(),
-            releaseNotesUrl,
-            feeds: {
-              mac: `${baseUrl}/${version.includes('-') ? `${version.split('-')[1].split('.')[0]}-mac.yml` : 'latest-mac.yml'}`,
-              windows: `${baseUrl}/${version.includes('-') ? `${version.split('-')[1].split('.')[0]}.yml` : 'latest.yml'}`,
-            },
-            macArm64Dmg: `${baseUrl}/mac-arm64.dmg`,
-            macArm64Zip: macArm64Zip ? `${baseUrl}/mac-arm64.zip` : null,
-            windowsX64Exe: windowsX64Exe ? `${baseUrl}/windows-x64.exe` : null,
-            versioned: {
-              macArm64Dmg: macArm64Dmg ? `${baseUrl}/${macArm64Dmg}` : null,
-              macArm64Zip: macArm64Zip ? `${baseUrl}/${macArm64Zip}` : null,
-              windowsX64Exe: windowsX64Exe ? `${baseUrl}/${windowsX64Exe}` : null,
-            },
-          }
-
-          fs.writeFileSync(
-            path.join(outDir, 'manifest.json'),
-            `${JSON.stringify(manifest, null, 2)}\n`,
-          )
-          NODE
+      - name: Publish architecture-specific macOS update metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
+        run: |
+          shopt -s nullglob
+          files=(dist/r2-upload/*-mac-intel.yml dist/r2-upload/*-intel-mac.yml dist/r2-upload/latest-mac-arm64.yml)
+          if ((${#files[@]})); then
+            gh release upload "$TAG" "${files[@]}" --repo "$GITHUB_REPOSITORY" --clobber
+          fi
 
       - name: Install AWS CLI
         run: |
@@ -320,6 +250,8 @@ jobs:
             --exclude "manifest.json" \
             --exclude "mac-arm64.dmg" \
             --exclude "mac-arm64.zip" \
+            --exclude "mac-x64.dmg" \
+            --exclude "mac-x64.zip" \
             --exclude "windows-x64.exe" \
             --cache-control "public, max-age=31536000, immutable" \
             --endpoint-url "$ENDPOINT"
@@ -346,6 +278,20 @@ jobs:
 
           if [ -f dist/r2-upload/mac-arm64.zip ]; then
             aws s3 cp dist/r2-upload/mac-arm64.zip "s3://${R2_BUCKET}/mac-arm64.zip" \
+              --cache-control "no-cache" \
+              --content-type "application/zip" \
+              --endpoint-url "$ENDPOINT"
+          fi
+
+          if [ -f dist/r2-upload/mac-x64.dmg ]; then
+            aws s3 cp dist/r2-upload/mac-x64.dmg "s3://${R2_BUCKET}/mac-x64.dmg" \
+              --cache-control "no-cache" \
+              --content-type "application/x-apple-diskimage" \
+              --endpoint-url "$ENDPOINT"
+          fi
+
+          if [ -f dist/r2-upload/mac-x64.zip ]; then
+            aws s3 cp dist/r2-upload/mac-x64.zip "s3://${R2_BUCKET}/mac-x64.zip" \
               --cache-control "no-cache" \
               --content-type "application/zip" \
               --endpoint-url "$ENDPOINT"
@@ -384,6 +330,15 @@ jobs:
           curl -fsSI "${BASE_URL}/${WINDOWS_METADATA}"
           curl -fsSI "${BASE_URL}/OpenAlice-${VERSION}-arm64.dmg"
           curl -fsSI "${BASE_URL}/mac-arm64.dmg"
+          if [ -f dist/r2-upload/mac-x64.dmg ]; then
+            curl -fsSI "${BASE_URL}/mac-x64.dmg"
+          fi
+          if [ -f dist/r2-upload/mac-x64.zip ]; then
+            curl -fsSI "${BASE_URL}/mac-x64.zip"
+          fi
+          if [ -f "dist/r2-upload/${CHANNEL}-mac-intel.yml" ]; then
+            curl -fsSI "${BASE_URL}/${CHANNEL}-mac-intel.yml"
+          fi
           curl -fsSI "${BASE_URL}/windows-x64.exe"
           curl -fsSI "${BASE_URL}/manifest.json"
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ There is no Postgres or Redis to provision. Config, sessions, issues, inbox entr
 
 Pick the run path that matches your machine:
 
-- **macOS** - use the signed Apple Silicon desktop build: [macOS install](https://openalice.ai/docs/getting-started/install-macos).
+- **macOS** - use the signed Apple Silicon or Intel desktop build: [macOS install](https://openalice.ai/docs/getting-started/install-macos).
 - **Windows** - run from source today: [Windows install](https://openalice.ai/docs/getting-started/install-windows).
-- **Linux, Intel Mac, contributors, debugging** - use the source path: [Source & Dev](https://openalice.ai/docs/getting-started/developer-setup).
+- **Linux, contributors, debugging** - use the source path: [Source & Dev](https://openalice.ai/docs/getting-started/developer-setup).
 - **Server or always-on machine** - use Docker Compose: [Docker deployment](https://openalice.ai/docs/deployment/docker).
 
 The source path is still the best early-adopter path because it gives you logs and local code:

--- a/apps/desktop/src/auto-update.spec.ts
+++ b/apps/desktop/src/auto-update.spec.ts
@@ -33,7 +33,24 @@ vi.mock('electron-updater', () => ({
   default: { autoUpdater: mocks.autoUpdater },
 }))
 
-import { configureAutoUpdate } from './auto-update.js'
+import { channelForVersion, configureAutoUpdate } from './auto-update.js'
+
+describe('channelForVersion', () => {
+  it('keeps Apple Silicon on the canonical mac feed', () => {
+    expect(channelForVersion('1.2.3', 'darwin', 'arm64')).toBe('latest')
+    expect(channelForVersion('1.2.3-beta.4', 'darwin', 'arm64')).toBe('beta')
+  })
+
+  it('routes Intel builds to architecture-specific mac feeds', () => {
+    expect(channelForVersion('1.2.3', 'darwin', 'x64')).toBe('latest-intel')
+    expect(channelForVersion('1.2.3-beta.4', 'darwin', 'x64')).toBe('beta-intel')
+  })
+
+  it('does not route Windows x64 through the Intel Mac feed', () => {
+    expect(channelForVersion('1.2.3', 'win32', 'x64')).toBe('latest')
+    expect(channelForVersion('1.2.3-beta.4', 'win32', 'x64')).toBe('beta')
+  })
+})
 
 describe('configureAutoUpdate', () => {
   beforeEach(() => {

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -67,7 +67,7 @@ export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks):
   autoUpdater.autoDownload = true
   autoUpdater.autoInstallOnAppQuit = false
   autoUpdater.allowPrerelease = app.getVersion().includes('-')
-  autoUpdater.channel = channelForVersion(app.getVersion())
+  autoUpdater.channel = channelForVersion(app.getVersion(), process.platform, process.arch)
   autoUpdater.allowDowngrade = false
 
   autoUpdater.on('error', (err) => {
@@ -99,7 +99,11 @@ export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks):
   void autoUpdater.checkForUpdates().catch(() => {})
 }
 
-function channelForVersion(version: string): string {
+export function channelForVersion(version: string, platform: NodeJS.Platform, arch: string): string {
   const prerelease = version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/)
-  return prerelease?.[1] ?? 'latest'
+  const channel = prerelease?.[1] ?? 'latest'
+  // GenericProvider appends "-mac" to this channel. Intel therefore requests
+  // latest-intel-mac.yml / beta-intel-mac.yml, which are compatibility aliases
+  // of the public latest-mac-intel.yml / beta-mac-intel.yml feeds.
+  return platform === 'darwin' && arch === 'x64' ? `${channel}-intel` : channel
 }

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -245,8 +245,14 @@ such as `node-pty` and therefore requires Visual Studio Build Tools with the
 C++ desktop workload. This is a source-build prerequisite only; users running
 the produced OpenAlice installer do not need Visual Studio.
 
-The `Desktop Package Smoke` workflow runs the macOS and Windows package
-matrix. A release-facing change should also verify a clean-machine flow:
+The `Desktop Package Smoke` workflow runs native Apple Silicon, Intel macOS,
+and Windows package jobs. macOS release builds remain separate rather than
+universal so native dependencies are installed, built, signed, and notarized
+on their matching architecture. Apple Silicon uses the canonical
+`latest-mac.yml` update feed; Intel uses `latest-mac-intel.yml` with the
+electron-updater compatibility alias `latest-intel-mac.yml`.
+
+A release-facing change should also verify a clean-machine flow:
 
 1. launch the packaged app with no system Node, Git, Bash, or Pi assumption;
 2. add one compatible AI credential;

--- a/scripts/prepare-desktop-release-assets.mjs
+++ b/scripts/prepare-desktop-release-assets.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { copyFileSync, existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+function prereleaseChannel(version) {
+  return version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/)?.[1] ?? 'latest'
+}
+
+function copyIfPresent(outDir, source, targets) {
+  const sourcePath = join(outDir, source)
+  if (!existsSync(sourcePath)) return false
+  for (const target of targets) {
+    if (target === source) continue
+    copyFileSync(sourcePath, join(outDir, target))
+    console.log(`[release-assets] ${source} -> ${target}`)
+  }
+  return true
+}
+
+export function prepareBuildMetadata({ outDir, platform, arch, version }) {
+  const normalizedPlatform = platform.toLowerCase()
+  const channel = prereleaseChannel(version)
+
+  if (normalizedPlatform === 'macos' || normalizedPlatform === 'darwin') {
+    const source = 'latest-mac.yml'
+    if (!existsSync(join(outDir, source))) {
+      throw new Error(`[release-assets] missing ${source} for macOS ${arch}`)
+    }
+
+    if (arch === 'arm64') {
+      copyIfPresent(outDir, source, ['latest-mac-arm64.yml'])
+      if (channel !== 'latest') {
+        copyIfPresent(outDir, source, [`${channel}-mac.yml`, `${channel}-mac-arm64.yml`])
+      }
+      return
+    }
+
+    if (arch === 'x64') {
+      const primary = 'latest-mac-intel.yml'
+      const updaterAlias = 'latest-intel-mac.yml'
+      copyIfPresent(outDir, source, [primary, updaterAlias])
+      if (channel !== 'latest') {
+        copyIfPresent(outDir, source, [`${channel}-mac-intel.yml`, `${channel}-intel-mac.yml`])
+      }
+      // Keep the established latest-mac.yml owned by the arm64 build. Intel
+      // clients request the architecture-specific compatibility alias above.
+      rmSync(join(outDir, source), { force: true })
+      return
+    }
+
+    throw new Error(`[release-assets] unsupported macOS architecture: ${arch}`)
+  }
+
+  if (normalizedPlatform === 'windows' || normalizedPlatform === 'win32') {
+    if (channel !== 'latest') copyIfPresent(outDir, 'latest.yml', [`${channel}.yml`])
+    return
+  }
+
+  throw new Error(`[release-assets] unsupported release platform: ${platform}`)
+}
+
+function findFirst(names, candidates) {
+  return candidates.find((candidate) => names.includes(candidate)) ?? null
+}
+
+function copyAlias(outDir, source, alias) {
+  if (!source) return null
+  if (source !== alias) {
+    copyFileSync(join(outDir, source), join(outDir, alias))
+    console.log(`[release-assets] ${source} -> ${alias}`)
+  }
+  return alias
+}
+
+export function prepareMirrorAssets({ outDir, tag, baseUrl, repository }) {
+  const version = tag.replace(/^v/, '')
+  const channel = prereleaseChannel(version)
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+  const names = readdirSync(outDir)
+  const macArm64Dmg = findFirst(names, [`OpenAlice-${version}-arm64.dmg`])
+  const macArm64Zip = findFirst(names, [`OpenAlice-${version}-arm64-mac.zip`])
+  const macX64Dmg = findFirst(names, [`OpenAlice-${version}-x64.dmg`, `OpenAlice-${version}.dmg`])
+  const macX64Zip = findFirst(names, [`OpenAlice-${version}-x64-mac.zip`, `OpenAlice-${version}-mac.zip`])
+  const windowsX64Exe = findFirst(names, [`OpenAlice.Setup.${version}.exe`])
+  const windowsX64Blockmap = findFirst(names, [`OpenAlice.Setup.${version}.exe.blockmap`])
+
+  copyAlias(outDir, macArm64Dmg, 'mac-arm64.dmg')
+  copyAlias(outDir, macArm64Zip, 'mac-arm64.zip')
+  copyAlias(outDir, macX64Dmg, 'mac-x64.dmg')
+  copyAlias(outDir, macX64Zip, 'mac-x64.zip')
+  copyAlias(outDir, windowsX64Exe, 'windows-x64.exe')
+
+  if (channel !== 'latest') {
+    copyIfPresent(outDir, 'latest-mac.yml', [`${channel}-mac.yml`])
+    copyIfPresent(outDir, 'latest-mac-intel.yml', [`${channel}-mac-intel.yml`])
+    copyIfPresent(outDir, 'latest-intel-mac.yml', [`${channel}-intel-mac.yml`])
+    copyIfPresent(outDir, 'latest.yml', [`${channel}.yml`])
+  }
+
+  const windowsMetadata = join(outDir, `${channel === 'latest' ? 'latest' : channel}.yml`)
+  const windowsFeedExe = existsSync(windowsMetadata)
+    ? parseYamlScalar(readFileSync(windowsMetadata, 'utf8'), 'path')
+    : null
+  if (windowsFeedExe?.endsWith('.exe')) {
+    copyAlias(outDir, windowsX64Exe, windowsFeedExe)
+    copyAlias(outDir, windowsX64Blockmap, `${windowsFeedExe}.blockmap`)
+  }
+
+  const urlFor = (name) => name ? `${normalizedBaseUrl}/${name}` : null
+  const releaseNotesUrl = `https://github.com/${repository}/releases/tag/${tag}`
+  const intelFeed = `${channel}-mac-intel.yml`
+  const manifest = {
+    version,
+    publishedAt: new Date().toISOString(),
+    releaseNotesUrl,
+    feeds: {
+      mac: `${normalizedBaseUrl}/${channel}-mac.yml`,
+      macArm64: `${normalizedBaseUrl}/${channel}-mac.yml`,
+      macIntel: existsSync(join(outDir, intelFeed)) ? `${normalizedBaseUrl}/${intelFeed}` : null,
+      windows: `${normalizedBaseUrl}/${channel}.yml`,
+    },
+    macArm64Dmg: urlFor(macArm64Dmg && 'mac-arm64.dmg'),
+    macArm64Zip: urlFor(macArm64Zip && 'mac-arm64.zip'),
+    macX64Dmg: urlFor(macX64Dmg && 'mac-x64.dmg'),
+    macX64Zip: urlFor(macX64Zip && 'mac-x64.zip'),
+    windowsX64Exe: urlFor(windowsX64Exe && 'windows-x64.exe'),
+    versioned: {
+      macArm64Dmg: urlFor(macArm64Dmg),
+      macArm64Zip: urlFor(macArm64Zip),
+      macX64Dmg: urlFor(macX64Dmg),
+      macX64Zip: urlFor(macX64Zip),
+      windowsX64Exe: urlFor(windowsX64Exe),
+    },
+  }
+
+  writeFileSync(join(outDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+  rmSync(join(outDir, 'builder-debug.yml'), { force: true })
+  return manifest
+}
+
+function parseYamlScalar(content, key) {
+  const match = content.match(new RegExp(`(?:^|\\n)${key}:\\s*['"]?([^'"\\n]+)['"]?`))
+  return match?.[1]?.trim() || null
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv
+  const values = {}
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index]
+    const value = rest[index + 1]
+    if (!key?.startsWith('--') || value == null) throw new Error(`[release-assets] invalid arguments: ${rest.join(' ')}`)
+    values[key.slice(2)] = value
+  }
+  return { command, values }
+}
+
+function requireValues(values, keys) {
+  for (const key of keys) {
+    if (!values[key]) throw new Error(`[release-assets] missing --${key}`)
+  }
+}
+
+function main() {
+  const { command, values } = parseArgs(process.argv.slice(2))
+  if (command === 'build') {
+    requireValues(values, ['out-dir', 'platform', 'arch', 'version'])
+    prepareBuildMetadata({
+      outDir: resolve(values['out-dir']),
+      platform: values.platform,
+      arch: values.arch,
+      version: values.version,
+    })
+    return
+  }
+  if (command === 'mirror') {
+    requireValues(values, ['out-dir', 'tag', 'base-url', 'repository'])
+    prepareMirrorAssets({
+      outDir: resolve(values['out-dir']),
+      tag: values.tag,
+      baseUrl: values['base-url'],
+      repository: values.repository,
+    })
+    return
+  }
+  throw new Error(`[release-assets] expected build or mirror command, got ${basename(command || '') || 'nothing'}`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}

--- a/scripts/prepare-desktop-release-assets.spec.ts
+++ b/scripts/prepare-desktop-release-assets.spec.ts
@@ -1,0 +1,95 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { prepareBuildMetadata, prepareMirrorAssets } from './prepare-desktop-release-assets.mjs'
+
+function withTempDir(run: (dir: string) => void) {
+  const dir = mkdtempSync(join(tmpdir(), 'openalice-release-assets-'))
+  try {
+    run(dir)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('prepareBuildMetadata', () => {
+  it('keeps arm64 canonical metadata and gives Intel its own feeds', () => {
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.3-beta\n')
+      prepareBuildMetadata({ outDir: dir, platform: 'macOS', arch: 'x64', version: '1.2.3-beta' })
+
+      expect(readFileSync(join(dir, 'latest-mac-intel.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(readFileSync(join(dir, 'latest-intel-mac.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(readFileSync(join(dir, 'beta-mac-intel.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(readFileSync(join(dir, 'beta-intel-mac.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(() => readFileSync(join(dir, 'latest-mac.yml'))).toThrow()
+    })
+
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.3-beta\n')
+      prepareBuildMetadata({ outDir: dir, platform: 'macOS', arch: 'arm64', version: '1.2.3-beta' })
+
+      expect(readFileSync(join(dir, 'latest-mac.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(readFileSync(join(dir, 'beta-mac.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(readFileSync(join(dir, 'latest-mac-arm64.yml'), 'utf8')).toContain('1.2.3-beta')
+    })
+  })
+})
+
+describe('prepareMirrorAssets', () => {
+  it('publishes distinct arm64 and Intel aliases and manifest entries', () => {
+    withTempDir((dir) => {
+      const files = [
+        'OpenAlice-1.2.3-beta-arm64.dmg',
+        'OpenAlice-1.2.3-beta-arm64-mac.zip',
+        'OpenAlice-1.2.3-beta.dmg',
+        'OpenAlice-1.2.3-beta-mac.zip',
+        'OpenAlice.Setup.1.2.3-beta.exe',
+        'OpenAlice.Setup.1.2.3-beta.exe.blockmap',
+      ]
+      for (const file of files) writeFileSync(join(dir, file), file)
+      writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.3-beta\n')
+      writeFileSync(join(dir, 'latest-mac-intel.yml'), 'version: 1.2.3-beta\n')
+      writeFileSync(join(dir, 'latest-intel-mac.yml'), 'version: 1.2.3-beta\n')
+      writeFileSync(join(dir, 'latest.yml'), 'version: 1.2.3-beta\npath: OpenAlice.Setup.1.2.3-beta.exe\n')
+      mkdirSync(join(dir, 'unused'))
+
+      const manifest = prepareMirrorAssets({
+        outDir: dir,
+        tag: 'v1.2.3-beta',
+        baseUrl: 'https://download.openalice.ai/',
+        repository: 'TraderAlice/OpenAlice',
+      })
+
+      expect(readFileSync(join(dir, 'mac-arm64.dmg'), 'utf8')).toContain('arm64')
+      expect(readFileSync(join(dir, 'mac-x64.dmg'), 'utf8')).toBe('OpenAlice-1.2.3-beta.dmg')
+      expect(readFileSync(join(dir, 'beta-mac-intel.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(readFileSync(join(dir, 'beta-intel-mac.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(manifest.feeds.macIntel).toBe('https://download.openalice.ai/beta-mac-intel.yml')
+      expect(manifest.macX64Dmg).toBe('https://download.openalice.ai/mac-x64.dmg')
+      expect(manifest.versioned.macX64Zip).toBe('https://download.openalice.ai/OpenAlice-1.2.3-beta-mac.zip')
+    })
+  })
+
+  it('keeps old arm64-only releases mirrorable without claiming an Intel feed', () => {
+    withTempDir((dir) => {
+      writeFileSync(join(dir, 'OpenAlice-1.2.2-arm64.dmg'), 'arm64 dmg')
+      writeFileSync(join(dir, 'OpenAlice-1.2.2-arm64-mac.zip'), 'arm64 zip')
+      writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.2\n')
+
+      const manifest = prepareMirrorAssets({
+        outDir: dir,
+        tag: 'v1.2.2',
+        baseUrl: 'https://download.openalice.ai',
+        repository: 'TraderAlice/OpenAlice',
+      })
+
+      expect(manifest.feeds.macIntel).toBeNull()
+      expect(manifest.macX64Dmg).toBeNull()
+      expect(manifest.macArm64Dmg).toBe('https://download.openalice.ai/mac-arm64.dmg')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a native `macos-15-intel` x64 lane to Desktop Package Smoke and the signed/notarized release matrix
- keep Apple Silicon on `latest-mac.yml`, publish Intel separately as `latest-mac-intel.yml`, and route Intel auto-updates through an electron-updater-compatible alias
- publish stable `mac-x64.dmg` / `mac-x64.zip` CDN aliases and expose Intel assets and feeds in `manifest.json`
- extract release-asset aliasing into a tested Node script while preserving old arm64-only release mirroring
- update the runtime owner guide and macOS install overview

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/desktop-package-smoke.yml .github/workflows/release.yml`
- `node --check scripts/prepare-desktop-release-assets.mjs`
- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm test` (205 files passed, 1 skipped; 2493 tests passed, 6 skipped)
- `pnpm electron:smoke:packaged --temp-data` (arm64 packaged app built and launched; stopped after ready)
- `pnpm electron:assert-package`
- `pnpm electron:smoke-toolchain`
- replayed `v0.73.0-beta` release assets through the new mirror preparation script

## Boundary touch
- desktop packaging, macOS auto-update feeds, release assets, and CDN mirroring
- no trading, credentials, or persisted user-data changes

## Residual gate
- the new `macos-15-intel` Desktop Package Smoke job is the authoritative x64 package/toolchain verification and must pass before merge
