### PR TITLE
Gate releases on Workspace CLI acceptance

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -18,9 +18,17 @@ on:
       - "scripts/guardian/**"
       - "scripts/prepare-desktop-release-assets.mjs"
       - "scripts/smoke-packaged-toolchain.mjs"
+      - "scripts/workspace-acceptance-ai-mock.mjs"
       - "scripts/vendor-managed-runtime.mjs"
-      - "src/core/paths.ts"
-      - "src/core/runtime-profile.ts"
+      - "default/**"
+      - "src/ai-providers/**"
+      - "src/core/**"
+      - "src/server/cli.ts"
+      - "src/server/cli-commands.ts"
+      - "src/tool/**"
+      - "src/webui/plugin.ts"
+      - "src/webui/routes/issues.ts"
+      - "src/webui/routes/workspaces.ts"
       - "src/workspaces/**"
       - "services/uta/**"
   push:
@@ -41,9 +49,17 @@ on:
       - "scripts/guardian/**"
       - "scripts/prepare-desktop-release-assets.mjs"
       - "scripts/smoke-packaged-toolchain.mjs"
+      - "scripts/workspace-acceptance-ai-mock.mjs"
       - "scripts/vendor-managed-runtime.mjs"
-      - "src/core/paths.ts"
-      - "src/core/runtime-profile.ts"
+      - "default/**"
+      - "src/ai-providers/**"
+      - "src/core/**"
+      - "src/server/cli.ts"
+      - "src/server/cli-commands.ts"
+      - "src/tool/**"
+      - "src/webui/plugin.ts"
+      - "src/webui/routes/issues.ts"
+      - "src/webui/routes/workspaces.ts"
       - "src/workspaces/**"
       - "services/uta/**"
 
@@ -113,3 +129,17 @@ jobs:
 
       - name: Smoke packaged managed toolchain
         run: pnpm electron:smoke-toolchain
+
+      - name: Prove packaged Workspace CLI acceptance
+        run: pnpm electron:smoke:workspace --skip-build --skip-pack
+        timeout-minutes: 5
+        env:
+          OPENALICE_SMOKE_RECEIPT_PATH: ${{ runner.temp }}/openalice-workspace-acceptance.json
+
+      - name: Upload Workspace acceptance receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace-acceptance-${{ matrix.os }}
+          path: ${{ runner.temp }}/openalice-workspace-acceptance.json
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,17 @@ on:
 
 jobs:
   release:
+    name: Plan release candidate
     runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
-      # Whether this run actually cut a new release (version was bumped). The
-      # desktop build matrix gates on this — a full per-platform Electron build
-      # is expensive (mac runners bill 10×), so it must NOT run on every master
-      # push, only when a new tag/release was created.
+      # Whether this push introduces a version that does not have a tag yet.
+      # The tag and GitHub Release are deliberately created only after every
+      # platform builds and passes Workspace acceptance.
       created: ${{ !github.event.inputs.mirror_tag && steps.check.outputs.exists == 'false' }}
       tag: ${{ github.event.inputs.mirror_tag || steps.version.outputs.tag }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
 
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +64,7 @@ jobs:
         run: |
           # Generate notes for this version only (since last tag).
           # --tag labels the about-to-be-created version: git-cliff runs
-          # BEFORE the tag exists (it's created in the next step), so without
+          # BEFORE the tag exists (it's created only after candidate acceptance), so without
           # this the section header falls back to "[Unreleased]" instead of
           # the version. See cliff.toml's `{% if version %}` template.
           TAG="${{ steps.version.outputs.tag }}"
@@ -74,18 +75,16 @@ jobs:
             git-cliff "$LAST_TAG"..HEAD --tag "$TAG" --output notes.md
           fi
 
-      - name: Create tag and GitHub Release
+      - name: Preserve release notes for gated publication
         if: steps.check.outputs.exists == 'false' && !github.event.inputs.mirror_tag
-        uses: softprops/action-gh-release@v2
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: ${{ steps.version.outputs.tag }}
-          body_path: notes.md
-          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
-          generate_release_notes: false
+          name: release-notes
+          path: notes.md
+          if-no-files-found: error
 
-  # Per-platform desktop installers, attached to the release the `release`
-  # job already created. Each runner builds only its own platform/arch, so each
+  # Per-platform desktop installers are built and acceptance-tested before any
+  # tag or GitHub Release exists. Each runner builds only its own platform/arch, so each
   # artifact carries just its matching native binary (longbridge, node-pty) —
   # pnpm installs only the os/cpu-matching prebuilt. macOS builds are signed and
   # notarized through Developer ID secrets; Windows remains unsigned until a
@@ -105,7 +104,7 @@ jobs:
             arch: x64
     runs-on: ${{ matrix.os }}
     permissions:
-      contents: write # upload release assets
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -163,6 +162,21 @@ jobs:
         # available.
         run: pnpm -F @traderalice/desktop exec electron-builder --projectDir ../.. --publish never --${{ matrix.arch }}
 
+      - name: Prove release candidate Workspace CLI acceptance
+        run: pnpm electron:smoke:workspace --skip-build --skip-pack
+        timeout-minutes: 5
+        env:
+          OPENALICE_SMOKE_RECEIPT_PATH: ${{ runner.temp }}/openalice-workspace-acceptance.json
+
+      - name: Preserve release acceptance receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-acceptance-${{ runner.os }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/openalice-workspace-acceptance.json
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Prepare update channel aliases
         shell: bash
         env:
@@ -177,20 +191,61 @@ jobs:
             --version "$VERSION"
           rm -f dist/electron-app/builder-debug.yml
 
-      - name: Attach installer to the release
-        uses: softprops/action-gh-release@v2
+      - name: Preserve accepted release assets
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ needs.release.outputs.tag }}
-          files: |
+          name: release-assets-${{ runner.os }}-${{ matrix.arch }}
+          path: |
             dist/electron-app/*.dmg
             dist/electron-app/*.zip
             dist/electron-app/*.yml
             dist/electron-app/*.blockmap
             dist/electron-app/*.exe
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  publish-release:
+    name: Publish accepted release
+    needs: [release, build-desktop]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+          path: dist/release-notes
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-assets-*
+          path: dist/release-assets
+          merge-multiple: true
+
+      - name: Create tag and GitHub Release from accepted candidates
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release.outputs.tag }}
+          name: ${{ needs.release.outputs.tag }}
+          body_path: dist/release-notes/notes.md
+          prerelease: ${{ needs.release.outputs.prerelease == 'true' }}
+          generate_release_notes: false
+          target_commitish: ${{ github.sha }}
+          fail_on_unmatched_files: true
+          files: |
+            dist/release-assets/*.dmg
+            dist/release-assets/*.zip
+            dist/release-assets/*.yml
+            dist/release-assets/*.blockmap
+            dist/release-assets/*.exe
 
   mirror-release-assets:
-    needs: [release, build-desktop]
-    if: always() && ((needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success') || github.event.inputs.mirror_tag)
+    needs: [release, publish-release]
+    if: always() && ((needs.release.outputs.created == 'true' && needs.publish-release.result == 'success') || github.event.inputs.mirror_tag)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -22,6 +22,7 @@
 
 import { app, BrowserWindow, dialog, Menu, protocol, session } from 'electron'
 import { runRendererTradingModeSmoke } from './trading-mode-smoke.js'
+import { runRendererWorkspaceAcceptanceSmoke } from './workspace-acceptance-smoke.js'
 import { planUTATransition } from './uta-lifecycle.js'
 import {
   acquireGuardianRuntime,
@@ -34,7 +35,7 @@ import {
 } from '@traderalice/guardian-runtime'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { existsSync, statSync } from 'node:fs'
-import { mkdir, readFile, watch } from 'node:fs/promises'
+import { mkdir, readFile, watch, writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { homedir } from 'node:os'
 import { delimiter, dirname, join, resolve } from 'node:path'
@@ -54,6 +55,7 @@ let restartingUTA = false
 let pendingUTAMode: GuardianTradingModePlan | null = null
 let rendererOnboardingSmokeStarted = false
 let rendererTradingModeSmokeStarted = false
+let rendererWorkspaceAcceptanceSmokeStarted = false
 let guardianRuntimeLock: RuntimeProcessLock | null = null
 
 const DEFAULT_WEB_PORT_START = 47331
@@ -871,6 +873,42 @@ app.whenReady().then(async () => {
                 shutdown()
               }
             })
+        }
+        if (
+          ready &&
+          process.env['OPENALICE_ELECTRON_SMOKE_WORKSPACE_ACCEPTANCE'] === '1' &&
+          !rendererWorkspaceAcceptanceSmokeStarted
+        ) {
+          rendererWorkspaceAcceptanceSmokeStarted = true
+          const aiBaseUrl = process.env['OPENALICE_WORKSPACE_ACCEPTANCE_AI_BASE_URL']?.trim()
+          const receiptPath = process.env['OPENALICE_SMOKE_RECEIPT_PATH']?.trim()
+          if (!aiBaseUrl || !receiptPath) {
+            console.error('[guardian] electron smoke workspace acceptance → failed: AI base URL or receipt path missing')
+            process.exitCode = 1
+            if (process.env['OPENALICE_ELECTRON_SMOKE_EXIT'] === '1') shutdown()
+          } else {
+            void runRendererWorkspaceAcceptanceSmoke(win, aiBaseUrl)
+              .then(async (result) => {
+                await writeFile(receiptPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8')
+                const failedChecks = Object.entries(result.checks)
+                  .filter(([, ok]) => ok !== true)
+                  .map(([name]) => name)
+                if (failedChecks.length > 0) {
+                  throw new Error(
+                    `${result.error ?? 'Workspace acceptance failed'}; failed checks: ${failedChecks.join(', ')}`,
+                  )
+                }
+                console.log(`[guardian] electron smoke workspace acceptance → ok ${JSON.stringify(result)}`)
+                if (process.env['OPENALICE_ELECTRON_SMOKE_EXIT'] === '1') shutdown()
+              })
+              .catch((err) => {
+                console.error(`[guardian] electron smoke workspace acceptance → failed: ${err instanceof Error ? err.message : String(err)}`)
+                if (process.env['OPENALICE_ELECTRON_SMOKE_EXIT'] === '1') {
+                  process.exitCode = 1
+                  shutdown()
+                }
+              })
+          }
         }
       })
       .catch((err) => {

--- a/apps/desktop/src/workspace-acceptance-smoke.spec.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { runRendererWorkspaceAcceptanceSmoke } from './workspace-acceptance-smoke.js'
+
+describe('Workspace acceptance renderer source', () => {
+  it('preserves literal newline escapes until Git Bash receives the command', async () => {
+    const executeJavaScript = vi.fn(async () => ({}))
+    const win = { webContents: { executeJavaScript } }
+
+    await runRendererWorkspaceAcceptanceSmoke(win as never, 'http://127.0.0.1:1234/v1')
+    const source = executeJavaScript.mock.calls[0]?.[0] ?? ''
+
+    for (const marker of ['CLI_ENV', 'CLI_MANIFESTS', 'GIT', 'WORKSPACE_CLI_CONTRACT']) {
+      expect(source).toContain(`"printf '__OPENALICE_%s_OK__\\\\n' '${marker}'"`)
+    }
+  })
+})

--- a/apps/desktop/src/workspace-acceptance-smoke.spec.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.spec.ts
@@ -13,5 +13,6 @@ describe('Workspace acceptance renderer source', () => {
     for (const marker of ['CLI_ENV', 'CLI_MANIFESTS', 'GIT', 'WORKSPACE_CLI_CONTRACT']) {
       expect(source).toContain(`"printf '__OPENALICE_%s_OK__\\\\n' '${marker}'"`)
     }
+    expect(source).toContain('__OPENALICE_WORKSPACE_CLI_STEP_FAILED__ %s %s\\\\n%s\\\\n')
   })
 })

--- a/apps/desktop/src/workspace-acceptance-smoke.spec.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.spec.ts
@@ -13,7 +13,7 @@ describe('Workspace acceptance renderer source', () => {
     for (const marker of ['CLI_ENV', 'CLI_MANIFESTS', 'GIT', 'WORKSPACE_CLI_CONTRACT']) {
       expect(source).toContain(`"printf '__OPENALICE_%s_OK__\\\\n' '${marker}'"`)
     }
-    expect(source).toContain('__OPENALICE_WORKSPACE_CLI_STEP_FAILED__ %s %s\\\\n%s\\\\n')
+    expect(source).toContain('__OPENALICE_WORKSPACE_%s_FAILED__ %s %s\\\\n%s\\\\n')
     expect(() => new Function(`return ${source}`)).not.toThrow()
   })
 })

--- a/apps/desktop/src/workspace-acceptance-smoke.spec.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.spec.ts
@@ -14,5 +14,6 @@ describe('Workspace acceptance renderer source', () => {
       expect(source).toContain(`"printf '__OPENALICE_%s_OK__\\\\n' '${marker}'"`)
     }
     expect(source).toContain('__OPENALICE_WORKSPACE_CLI_STEP_FAILED__ %s %s\\\\n%s\\\\n')
+    expect(() => new Function(`return ${source}`)).not.toThrow()
   })
 })

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -127,18 +127,18 @@ export async function runRendererWorkspaceAcceptanceSmoke(
           'command -v alice-workspace >/dev/null',
           'command -v traderhub >/dev/null',
           'command -v alice-uta >/dev/null',
-          "printf '__OPENALICE_%s_OK__\\n' 'CLI_ENV'",
+          "printf '__OPENALICE_%s_OK__\\\\n' 'CLI_ENV'",
           'alice --help >/dev/null',
           'alice-workspace --help >/dev/null',
           'traderhub --help >/dev/null',
           'alice-uta --help >/dev/null',
-          "printf '__OPENALICE_%s_OK__\\n' 'CLI_MANIFESTS'",
+          "printf '__OPENALICE_%s_OK__\\\\n' 'CLI_MANIFESTS'",
           'git rev-parse --is-inside-work-tree | grep -qx true',
-          "printf '__OPENALICE_%s_OK__\\n' 'GIT'",
+          "printf '__OPENALICE_%s_OK__\\\\n' 'GIT'",
           'alice-workspace issue create --id ' + shellIssueId + ' --title "OpenAlice shell CLI contract" >/dev/null',
           'alice-workspace issue show --id ' + shellIssueId + ' >/dev/null',
           // Split the sentinel so terminal command echo cannot satisfy it.
-          "printf '__OPENALICE_%s_OK__\\n' 'WORKSPACE_CLI_CONTRACT'",
+          "printf '__OPENALICE_%s_OK__\\\\n' 'WORKSPACE_CLI_CONTRACT'",
         ].join('; ')
         bridge.send(connectionId, new TextEncoder().encode(command + '\\r'))
         await marker

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -87,7 +87,7 @@ export async function runRendererWorkspaceAcceptanceSmoke(
         markerReject = reject
       })
       const attachedTimer = setTimeout(() => attachedReject(new Error('PTY attached timeout')), 10000)
-      const markerTimer = setTimeout(() => markerReject(new Error('Workspace CLI contract timeout: ' + output.slice(-4000))), 30000)
+      const markerTimer = setTimeout(() => markerReject(new Error('Workspace CLI contract timeout: ' + output.slice(-4000))), 20000)
       connectionId = bridge.connect({ sessionId, cols: 120, rows: 32 })
       const offMessage = bridge.onMessage(connectionId, (msg) => {
         if (msg.type === 'control') {
@@ -119,7 +119,6 @@ export async function runRendererWorkspaceAcceptanceSmoke(
       try {
         await attached
         const command = [
-          'set -e',
           'test "$AQ_WS_ID" = "' + workspaceId + '"',
           'test -n "$OPENALICE_TOOL_URL"',
           'test -n "$OPENALICE_TOOL_SOCKET"',
@@ -139,7 +138,7 @@ export async function runRendererWorkspaceAcceptanceSmoke(
           'alice-workspace issue show --id ' + shellIssueId + ' >/dev/null',
           // Split the sentinel so terminal command echo cannot satisfy it.
           "printf '__OPENALICE_%s_OK__\\\\n' 'WORKSPACE_CLI_CONTRACT'",
-        ].join('; ')
+        ].join(' && ')
         bridge.send(connectionId, new TextEncoder().encode(command + '\\r'))
         await marker
         checks.shellCliRoundTrip = true

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -123,6 +123,7 @@ export async function runRendererWorkspaceAcceptanceSmoke(
       })
       try {
         await attached
+        const stepHelper = 'oa_step() { oa_label="$1"; shift; oa_output=$("$@" 2>&1); oa_status=$?; if test "$oa_status" -ne 0; then printf "__OPENALICE_WORKSPACE_%s_FAILED__ %s %s\\\\n%s\\\\n" "CLI_STEP" "$oa_label" "$oa_status" "$oa_output"; return "$oa_status"; fi; }'
         const command = [
           'test "$AQ_WS_ID" = "' + workspaceId + '"',
           'test -n "$OPENALICE_TOOL_URL"',
@@ -135,9 +136,6 @@ export async function runRendererWorkspaceAcceptanceSmoke(
           // Capture a failing command's stderr and report it through stdout.
           // Electron's Windows GUI binary can otherwise make a child stderr
           // failure look like a silent PTY timeout.
-          // Split the failure sentinel too, so terminal command echo cannot
-          // reject the contract before the helper has executed.
-          'oa_step() { oa_label="$1"; shift; oa_output=$("$@" 2>&1); oa_status=$?; if test "$oa_status" -ne 0; then printf "__OPENALICE_WORKSPACE_%s_FAILED__ %s %s\\\\n%s\\\\n" "CLI_STEP" "$oa_label" "$oa_status" "$oa_output"; return "$oa_status"; fi; }',
           'oa_step alice-manifest alice --help',
           'oa_step alice-workspace-manifest alice-workspace --help',
           'oa_step traderhub-manifest traderhub --help',
@@ -150,6 +148,10 @@ export async function runRendererWorkspaceAcceptanceSmoke(
           // Split the sentinel so terminal command echo cannot satisfy it.
           "printf '__OPENALICE_%s_OK__\\\\n' 'WORKSPACE_CLI_CONTRACT'",
         ].join(' && ')
+        // Keep each PTY write below the Windows ConPTY input boundary. The
+        // helper is a separate shell line so adding diagnostics cannot
+        // truncate the contract's trailing carriage return.
+        bridge.send(connectionId, new TextEncoder().encode(stepHelper + '\\r'))
         bridge.send(connectionId, new TextEncoder().encode(command + '\\r'))
         await marker
         checks.shellCliRoundTrip = true

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -44,6 +44,7 @@ export async function runRendererWorkspaceAcceptanceSmoke(
     const shellIssueId = '${SHELL_ISSUE_ID}'
     const agentIssueId = '${AGENT_ISSUE_ID}'
     const shellMarker = '__OPENALICE_WORKSPACE_CLI_CONTRACT_OK__'
+    const shellFailureMarker = '__OPENALICE_WORKSPACE_CLI_STEP_FAILED__'
     const checks = {
       workspaceCreated: false,
       gitReady: false,
@@ -106,6 +107,10 @@ export async function runRendererWorkspaceAcceptanceSmoke(
         if (output.includes('__OPENALICE_CLI_ENV_OK__')) checks.cliEnvironmentInjected = true
         if (output.includes('__OPENALICE_CLI_MANIFESTS_OK__')) checks.allCliManifestsLoaded = true
         if (output.includes('__OPENALICE_GIT_OK__')) checks.gitReady = true
+        if (output.includes(shellFailureMarker)) {
+          clearTimeout(markerTimer)
+          markerReject(new Error('Workspace CLI contract step failed: ' + output.slice(-4000)))
+        }
         if (output.includes(shellMarker)) {
           clearTimeout(markerTimer)
           markerResolve(output)
@@ -127,10 +132,14 @@ export async function runRendererWorkspaceAcceptanceSmoke(
           'command -v traderhub >/dev/null',
           'command -v alice-uta >/dev/null',
           "printf '__OPENALICE_%s_OK__\\\\n' 'CLI_ENV'",
-          'alice --help >/dev/null',
-          'alice-workspace --help >/dev/null',
-          'traderhub --help >/dev/null',
-          'alice-uta --help >/dev/null',
+          // Capture a failing command's stderr and report it through stdout.
+          // Electron's Windows GUI binary can otherwise make a child stderr
+          // failure look like a silent PTY timeout.
+          "oa_step() { oa_label=\"$1\"; shift; oa_output=$(\"$@\" 2>&1); oa_status=$?; if test \"$oa_status\" -ne 0; then printf '__OPENALICE_WORKSPACE_CLI_STEP_FAILED__ %s %s\\\\n%s\\\\n' \"$oa_label\" \"$oa_status\" \"$oa_output\"; return \"$oa_status\"; fi; }",
+          'oa_step alice-manifest alice --help',
+          'oa_step alice-workspace-manifest alice-workspace --help',
+          'oa_step traderhub-manifest traderhub --help',
+          'oa_step alice-uta-manifest alice-uta --help',
           "printf '__OPENALICE_%s_OK__\\\\n' 'CLI_MANIFESTS'",
           'git rev-parse --is-inside-work-tree | grep -qx true',
           "printf '__OPENALICE_%s_OK__\\\\n' 'GIT'",

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -135,7 +135,9 @@ export async function runRendererWorkspaceAcceptanceSmoke(
           // Capture a failing command's stderr and report it through stdout.
           // Electron's Windows GUI binary can otherwise make a child stderr
           // failure look like a silent PTY timeout.
-          'oa_step() { oa_label="$1"; shift; oa_output=$("$@" 2>&1); oa_status=$?; if test "$oa_status" -ne 0; then printf "__OPENALICE_WORKSPACE_CLI_STEP_FAILED__ %s %s\\\\n%s\\\\n" "$oa_label" "$oa_status" "$oa_output"; return "$oa_status"; fi; }',
+          // Split the failure sentinel too, so terminal command echo cannot
+          // reject the contract before the helper has executed.
+          'oa_step() { oa_label="$1"; shift; oa_output=$("$@" 2>&1); oa_status=$?; if test "$oa_status" -ne 0; then printf "__OPENALICE_WORKSPACE_%s_FAILED__ %s %s\\\\n%s\\\\n" "CLI_STEP" "$oa_label" "$oa_status" "$oa_output"; return "$oa_status"; fi; }',
           'oa_step alice-manifest alice --help',
           'oa_step alice-workspace-manifest alice-workspace --help',
           'oa_step traderhub-manifest traderhub --help',

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -135,7 +135,7 @@ export async function runRendererWorkspaceAcceptanceSmoke(
           // Capture a failing command's stderr and report it through stdout.
           // Electron's Windows GUI binary can otherwise make a child stderr
           // failure look like a silent PTY timeout.
-          "oa_step() { oa_label=\"$1\"; shift; oa_output=$(\"$@\" 2>&1); oa_status=$?; if test \"$oa_status\" -ne 0; then printf '__OPENALICE_WORKSPACE_CLI_STEP_FAILED__ %s %s\\\\n%s\\\\n' \"$oa_label\" \"$oa_status\" \"$oa_output\"; return \"$oa_status\"; fi; }",
+          'oa_step() { oa_label="$1"; shift; oa_output=$("$@" 2>&1); oa_status=$?; if test "$oa_status" -ne 0; then printf "__OPENALICE_WORKSPACE_CLI_STEP_FAILED__ %s %s\\\\n%s\\\\n" "$oa_label" "$oa_status" "$oa_output"; return "$oa_status"; fi; }',
           'oa_step alice-manifest alice --help',
           'oa_step alice-workspace-manifest alice-workspace --help',
           'oa_step traderhub-manifest traderhub --help',

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -136,7 +136,7 @@ export async function runRendererWorkspaceAcceptanceSmoke(
           // Capture a failing command's stderr and report it through stdout.
           // Electron's Windows GUI binary can otherwise make a child stderr
           // failure look like a silent PTY timeout.
-          'oa_step alice-manifest alice --help',
+          'oa_step alice-manifest env OPENALICE_CLI_DEBUG=1 alice --help',
           'oa_step alice-workspace-manifest alice-workspace --help',
           'oa_step traderhub-manifest traderhub --help',
           'oa_step alice-uta-manifest alice-uta --help',

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -1,0 +1,244 @@
+import type { BrowserWindow } from 'electron'
+
+export interface WorkspaceAcceptanceReceipt {
+  readonly schemaVersion: 1
+  readonly mode: 'packaged-electron'
+  readonly workspaceType: 'chat'
+  readonly runtime: 'pi'
+  readonly transport: 'electron-pty+tool-socket'
+  readonly workspaceId: string
+  readonly durationMs: number
+  readonly error?: string
+  readonly checks: {
+    readonly workspaceCreated: boolean
+    readonly gitReady: boolean
+    readonly cliEnvironmentInjected: boolean
+    readonly allCliManifestsLoaded: boolean
+    readonly shellCliRoundTrip: boolean
+    readonly managedPiAssistantReply: boolean
+    readonly managedPiCliSideEffect: boolean
+    readonly cleanupComplete: boolean
+  }
+}
+
+const ACCEPTANCE_MARKER = 'OPENALICE_PACKAGED_WORKSPACE_CLI_ACCEPTANCE'
+const SHELL_ISSUE_ID = 'openalice-shell-cli-contract'
+const AGENT_ISSUE_ID = 'openalice-agent-cli-acceptance'
+const ASSISTANT_TEXT = 'OpenAlice Workspace CLI acceptance completed.'
+
+/**
+ * Execute the release acceptance path through the same sandboxed renderer,
+ * preload PTY bridge, app:// API transport, Workspace environment composer,
+ * managed Pi adapter, and CLI gateway used by the product.
+ */
+export async function runRendererWorkspaceAcceptanceSmoke(
+  win: BrowserWindow,
+  aiBaseUrl: string,
+): Promise<WorkspaceAcceptanceReceipt> {
+  const serializedBaseUrl = JSON.stringify(aiBaseUrl)
+  return win.webContents.executeJavaScript(`(async () => {
+    const startedAt = Date.now()
+    const bridge = window.openAlice?.pty
+    if (!bridge) throw new Error('window.openAlice.pty missing')
+    const aiBaseUrl = ${serializedBaseUrl}
+    const shellIssueId = '${SHELL_ISSUE_ID}'
+    const agentIssueId = '${AGENT_ISSUE_ID}'
+    const shellMarker = '__OPENALICE_WORKSPACE_CLI_CONTRACT_OK__'
+    const checks = {
+      workspaceCreated: false,
+      gitReady: false,
+      cliEnvironmentInjected: false,
+      allCliManifestsLoaded: false,
+      shellCliRoundTrip: false,
+      managedPiAssistantReply: false,
+      managedPiCliSideEffect: false,
+      cleanupComplete: false,
+    }
+    const json = async (res) => {
+      const text = await res.text()
+      let body = null
+      try { body = text ? JSON.parse(text) : null } catch { body = text }
+      if (!res.ok) throw new Error(res.status + ' ' + text)
+      return body
+    }
+    const issueExists = (snapshot, workspaceId, issueId) => {
+      const owner = snapshot?.workspaces?.find((row) => row.wsId === workspaceId)
+      return Boolean(owner?.issues?.some((issue) => issue.id === issueId))
+    }
+    const decode = (value) => {
+      if (typeof value === 'string') return value
+      if (value instanceof Uint8Array) return new TextDecoder().decode(value)
+      if (value?.buffer instanceof ArrayBuffer) return new TextDecoder().decode(new Uint8Array(value.buffer))
+      return String(value ?? '')
+    }
+    const runShellContract = async (workspaceId, sessionId) => {
+      let connectionId = ''
+      let output = ''
+      let attachedResolve
+      let attachedReject
+      let markerResolve
+      let markerReject
+      const attached = new Promise((resolve, reject) => {
+        attachedResolve = resolve
+        attachedReject = reject
+      })
+      const marker = new Promise((resolve, reject) => {
+        markerResolve = resolve
+        markerReject = reject
+      })
+      const attachedTimer = setTimeout(() => attachedReject(new Error('PTY attached timeout')), 10000)
+      const markerTimer = setTimeout(() => markerReject(new Error('Workspace CLI contract timeout: ' + output.slice(-4000))), 30000)
+      connectionId = bridge.connect({ sessionId, cols: 120, rows: 32 })
+      const offMessage = bridge.onMessage(connectionId, (msg) => {
+        if (msg.type === 'control') {
+          try {
+            const control = JSON.parse(decode(msg.data))
+            if (control.type === 'attached') {
+              clearTimeout(attachedTimer)
+              attachedResolve(control)
+            }
+          } catch {
+            // Non-JSON terminal control frames are not part of this contract.
+          }
+          return
+        }
+        output += decode(msg.data)
+        if (output.includes('__OPENALICE_CLI_ENV_OK__')) checks.cliEnvironmentInjected = true
+        if (output.includes('__OPENALICE_CLI_MANIFESTS_OK__')) checks.allCliManifestsLoaded = true
+        if (output.includes('__OPENALICE_GIT_OK__')) checks.gitReady = true
+        if (output.includes(shellMarker)) {
+          clearTimeout(markerTimer)
+          markerResolve(output)
+        }
+      })
+      const offClose = bridge.onClose(connectionId, (event) => {
+        const error = new Error('PTY closed before Workspace CLI contract completed: ' + event.code + ' ' + event.reason)
+        attachedReject(error)
+        markerReject(error)
+      })
+      try {
+        await attached
+        const command = [
+          'set -e',
+          'test "$AQ_WS_ID" = "' + workspaceId + '"',
+          'test -n "$OPENALICE_TOOL_URL"',
+          'test -n "$OPENALICE_TOOL_SOCKET"',
+          'command -v alice >/dev/null',
+          'command -v alice-workspace >/dev/null',
+          'command -v traderhub >/dev/null',
+          'command -v alice-uta >/dev/null',
+          "printf '__OPENALICE_%s_OK__\\n' 'CLI_ENV'",
+          'alice --help >/dev/null',
+          'alice-workspace --help >/dev/null',
+          'traderhub --help >/dev/null',
+          'alice-uta --help >/dev/null',
+          "printf '__OPENALICE_%s_OK__\\n' 'CLI_MANIFESTS'",
+          'git rev-parse --is-inside-work-tree | grep -qx true',
+          "printf '__OPENALICE_%s_OK__\\n' 'GIT'",
+          'alice-workspace issue create --id ' + shellIssueId + ' --title "OpenAlice shell CLI contract" >/dev/null',
+          'alice-workspace issue show --id ' + shellIssueId + ' >/dev/null',
+          // Split the sentinel so terminal command echo cannot satisfy it.
+          "printf '__OPENALICE_%s_OK__\\n' 'WORKSPACE_CLI_CONTRACT'",
+        ].join('; ')
+        bridge.send(connectionId, new TextEncoder().encode(command + '\\r'))
+        await marker
+        checks.shellCliRoundTrip = true
+      } finally {
+        clearTimeout(attachedTimer)
+        clearTimeout(markerTimer)
+        offMessage()
+        offClose()
+        if (connectionId) bridge.close(connectionId)
+      }
+    }
+
+    const tag = 'acceptance-' + Date.now().toString(36)
+    let workspaceId = ''
+    let shellSessionId = ''
+    let failure = null
+    try {
+      const created = await json(await fetch('/api/workspaces', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tag, template: 'chat', agents: ['shell', 'pi'] }),
+      }))
+      workspaceId = created.workspace.id
+      checks.workspaceCreated = true
+
+      const spawned = await json(await fetch('/api/workspaces/' + encodeURIComponent(workspaceId) + '/sessions/spawn', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ agent: 'shell' }),
+      }))
+      shellSessionId = spawned.sessionId
+      await runShellContract(workspaceId, shellSessionId)
+
+      const shellIssues = await json(await fetch('/api/issues'))
+      if (!issueExists(shellIssues, workspaceId, shellIssueId)) {
+        throw new Error('shell CLI issue side effect was not visible through /api/issues')
+      }
+
+      await json(await fetch('/api/workspaces/' + encodeURIComponent(workspaceId) + '/agent-config/pi', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          baseUrl: aiBaseUrl,
+          apiKey: 'oa_test_ok',
+          model: 'openalice-workspace-acceptance',
+          wireShape: 'openai-chat',
+        }),
+      }))
+
+      const headless = await json(await fetch('/api/workspaces/' + encodeURIComponent(workspaceId) + '/headless', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          agent: 'pi',
+          wait: true,
+          timeoutMs: 120000,
+          prompt: '${ACCEPTANCE_MARKER}: execute the requested Workspace CLI acceptance action, then report completion.',
+        }),
+      }))
+      if (headless.killed || headless.exitCode !== 0) {
+        throw new Error('managed Pi headless run failed: ' + JSON.stringify({
+          exitCode: headless.exitCode,
+          killed: headless.killed,
+          stderrTail: headless.stderrTail,
+        }))
+      }
+      if (headless.assistantText?.trim() !== '${ASSISTANT_TEXT}') {
+        throw new Error('managed Pi assistant reply was not decoded: ' + JSON.stringify(headless.assistantText))
+      }
+      checks.managedPiAssistantReply = true
+
+      const agentIssues = await json(await fetch('/api/issues'))
+      if (!issueExists(agentIssues, workspaceId, agentIssueId)) {
+        throw new Error('managed Pi CLI issue side effect was not visible through /api/issues')
+      }
+      checks.managedPiCliSideEffect = true
+    } catch (err) {
+      failure = err
+    } finally {
+      if (workspaceId && shellSessionId) {
+        await fetch('/api/workspaces/' + encodeURIComponent(workspaceId) + '/sessions/' + encodeURIComponent(shellSessionId) + '/pause', {
+          method: 'POST',
+        }).catch(() => {})
+      }
+      if (workspaceId) {
+        const deleted = await fetch('/api/workspaces/' + encodeURIComponent(workspaceId), { method: 'DELETE' }).catch(() => null)
+        checks.cleanupComplete = Boolean(deleted?.ok)
+      }
+    }
+    return {
+      schemaVersion: 1,
+      mode: 'packaged-electron',
+      workspaceType: 'chat',
+      runtime: 'pi',
+      transport: 'electron-pty+tool-socket',
+      workspaceId,
+      durationMs: Date.now() - startedAt,
+      ...(failure ? { error: failure.message || String(failure) } : {}),
+      checks,
+    }
+  })()`, true) as Promise<WorkspaceAcceptanceReceipt>
+}

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -63,8 +63,10 @@ and Windows launchers execute the explicit `openalice-cli.cjs` payload through
 the Electron executable recorded in `OPENALICE_MANAGED_PI_NODE_PATH`, with
 `ELECTRON_RUN_AS_NODE=1`. When the POSIX launcher is reached from managed Git
 Bash, it normalizes Windows-native launcher and Electron paths through
-`cygpath` before execution. Source/dev falls back to `node` from the contributor
-environment. Keep the public commands as launchers: executing extensionless
+`cygpath` before execution and excludes `OPENALICE_TOOL_URL` plus
+`OPENALICE_TOOL_SOCKET` from MSYS environment conversion. In particular,
+`/cli` is an application route and must not become a Git installation path.
+Source/dev falls back to `node` from the contributor environment. Keep the public commands as launchers: executing extensionless
 JavaScript directly makes behavior depend on the host Node version and the
 nearest `package.json` module type.
 

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -61,7 +61,9 @@ Workspace-facing OpenAlice commands (`alice`, `alice-workspace`, `traderhub`,
 and `alice-uta`) also do not depend on a host Node installation. Their POSIX
 and Windows launchers execute the explicit `openalice-cli.cjs` payload through
 the Electron executable recorded in `OPENALICE_MANAGED_PI_NODE_PATH`, with
-`ELECTRON_RUN_AS_NODE=1`. Source/dev falls back to `node` from the contributor
+`ELECTRON_RUN_AS_NODE=1`. When the POSIX launcher is reached from managed Git
+Bash, it normalizes Windows-native launcher and Electron paths through
+`cygpath` before execution. Source/dev falls back to `node` from the contributor
 environment. Keep the public commands as launchers: executing extensionless
 JavaScript directly makes behavior depend on the host Node version and the
 nearest `package.json` module type.

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -217,6 +217,38 @@ Keep these true together:
 
 ## Verification
 
+### Workspace acceptance contract
+
+`pnpm electron:smoke:workspace` is the release-facing definition of an
+actually usable packaged Workspace. It runs against isolated temporary data
+and a deterministic local OpenAI-compatible provider; it never reads a real
+API key or depends on external model availability.
+
+The smoke creates one real Chat Workspace and proves both layers of the product
+contract:
+
+1. A shell Session, reached through the Electron preload PTY bridge, receives
+   the production-composed Workspace environment. It resolves `alice`,
+   `alice-workspace`, `traderhub`, and `alice-uta`, loads every CLI manifest over
+   the Electron tool socket, verifies Git, and creates then reads an issue with
+   the real `alice-workspace` shim.
+2. The packaged managed Pi runtime performs a deterministic `bash` tool call
+   that invokes `alice-workspace issue create`. The smoke accepts the run only
+   when structured assistant output is decoded and the created issue is visible
+   from the external `/api/issues` surface.
+
+The second assertion deliberately uses an observable Workspace side effect,
+not a model claiming that a command succeeded. The run emits a versioned JSON
+receipt whose individual checks make PATH, injection, CLI transport, runtime
+output, tool use, and cleanup failures distinguishable. The Desktop Package
+Smoke matrix preserves these receipts as CI artifacts. Release candidates run
+the same acceptance on all three platform/architecture builds before any tag or
+GitHub Release is created; only accepted installers are then published.
+
+Do not replace the actual shims with direct tool-function calls in this smoke:
+that would stop covering argv parsing, manifest discovery, managed Node,
+Workspace identity headers, and the Electron-only socket transport.
+
 For runtime or packaging changes, run the focused local tests first:
 
 ```bash
@@ -238,6 +270,7 @@ pnpm vendor:runtime
 pnpm -F @traderalice/desktop exec electron-builder --dir --projectDir ../.. --publish never
 pnpm electron:assert-package
 pnpm electron:smoke-toolchain
+pnpm electron:smoke:workspace --skip-build --skip-pack
 ```
 
 On Windows, the standard `electron-builder` step rebuilds native dependencies

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "electron:smoke:packaged": "node scripts/desktop-packaged-smoke.mjs",
     "electron:smoke:onboarding": "node scripts/desktop-packaged-smoke.mjs --onboarding",
     "electron:smoke:trading-mode": "node scripts/desktop-packaged-smoke.mjs --trading-mode",
+    "electron:smoke:workspace": "node scripts/desktop-packaged-smoke.mjs --workspace-acceptance",
     "electron:smoke:pty": "node scripts/desktop-pty-smoke.mjs",
     "electron:smoke:guardian-recovery": "node scripts/desktop-pty-smoke.mjs --guardian-recovery",
     "vendor:runtime": "node scripts/vendor-managed-runtime.mjs",

--- a/scripts/desktop-packaged-smoke-plan.mjs
+++ b/scripts/desktop-packaged-smoke-plan.mjs
@@ -9,6 +9,7 @@ export const DESKTOP_PACKAGED_SMOKE_ARGS = new Set([
   '--signed',
   '--onboarding',
   '--trading-mode',
+  '--workspace-acceptance',
   '--help',
   '-h',
 ])
@@ -18,6 +19,7 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
   const unknownArgs = [...args].filter((arg) => !DESKTOP_PACKAGED_SMOKE_ARGS.has(arg))
   const onboarding = args.has('--onboarding')
   const tradingMode = args.has('--trading-mode')
+  const workspaceAcceptance = args.has('--workspace-acceptance')
   const realDataFlag = args.has('--real-data')
   const tempDataFlag = args.has('--temp-data')
   const errors = []
@@ -35,8 +37,11 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
   if (tradingMode && realDataFlag) {
     errors.push('[desktop-smoke] --trading-mode always uses isolated temp data; drop --real-data')
   }
-  if (onboarding && tradingMode) {
-    errors.push('[desktop-smoke] choose either --onboarding or --trading-mode, not both')
+  if (workspaceAcceptance && realDataFlag) {
+    errors.push('[desktop-smoke] --workspace-acceptance always uses isolated temp data; drop --real-data')
+  }
+  if ([onboarding, tradingMode, workspaceAcceptance].filter(Boolean).length > 1) {
+    errors.push('[desktop-smoke] choose only one automated smoke mode: --onboarding, --trading-mode, or --workspace-acceptance')
   }
 
   const skipBuild = args.has('--skip-build')
@@ -48,7 +53,7 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
     warnings.push('[desktop-smoke] --onboarding with --skip-pack assumes the packaged app already contains that onboarding-enabled ui/dist')
   }
 
-  const tempData = onboarding || tradingMode || tempDataFlag
+  const tempData = onboarding || tradingMode || workspaceAcceptance || tempDataFlag
   const realData = !tempData
   const storageSuffix = env['VITE_OPENALICE_ONBOARDING_STORAGE_SUFFIX']?.trim() || opts.randomUUID?.() || randomUUID()
   const onboardingBuildEnv = onboarding ? {
@@ -71,7 +76,12 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
     OPENALICE_ELECTRON_SMOKE_TRADING_MODE: '1',
     OPENALICE_ELECTRON_SMOKE_EXIT: '1',
   } : {}
-  const unsetLaunchEnv = onboarding || tradingMode ? [
+  const workspaceAcceptanceLaunchEnv = workspaceAcceptance ? {
+    OPENALICE_MCP_ENABLED: '0',
+    OPENALICE_ELECTRON_SMOKE_WORKSPACE_ACCEPTANCE: '1',
+    OPENALICE_ELECTRON_SMOKE_EXIT: '1',
+  } : {}
+  const unsetLaunchEnv = onboarding || tradingMode || workspaceAcceptance ? [
     'OPENALICE_TRADING_MODE',
     'OPENALICE_LITE_MODE',
     'OPENALICE_UTA_DISABLED',
@@ -90,9 +100,14 @@ export function buildDesktopPackagedSmokePlan(argv, env = process.env, opts = {}
       skipBuild,
       skipPack,
       tempData,
+      workspaceAcceptance,
     },
     buildEnv: onboardingBuildEnv,
-    launchEnv: { ...onboardingLaunchEnv, ...tradingModeLaunchEnv },
+    launchEnv: {
+      ...onboardingLaunchEnv,
+      ...tradingModeLaunchEnv,
+      ...workspaceAcceptanceLaunchEnv,
+    },
     unsetLaunchEnv,
   }
 }

--- a/scripts/desktop-packaged-smoke-plan.spec.ts
+++ b/scripts/desktop-packaged-smoke-plan.spec.ts
@@ -12,6 +12,7 @@ describe('buildDesktopPackagedSmokePlan', () => {
       realData: true,
       tempData: false,
       tradingMode: false,
+      workspaceAcceptance: false,
     })
     expect(plan.buildEnv).toEqual({})
     expect(plan.launchEnv).toEqual({})
@@ -85,7 +86,40 @@ describe('buildDesktopPackagedSmokePlan', () => {
     expect(buildDesktopPackagedSmokePlan(['--trading-mode', '--real-data']).errors)
       .toContain('[desktop-smoke] --trading-mode always uses isolated temp data; drop --real-data')
     expect(buildDesktopPackagedSmokePlan(['--trading-mode', '--onboarding']).errors)
-      .toContain('[desktop-smoke] choose either --onboarding or --trading-mode, not both')
+      .toContain('[desktop-smoke] choose only one automated smoke mode: --onboarding, --trading-mode, or --workspace-acceptance')
+  })
+
+  it('makes Workspace acceptance isolated, self-terminating, and provider-independent', () => {
+    const plan = buildDesktopPackagedSmokePlan(['--workspace-acceptance'], {
+      OPENALICE_TRADING_MODE: 'pro',
+    })
+
+    expect(plan.errors).toEqual([])
+    expect(plan.options).toMatchObject({
+      onboarding: false,
+      realData: false,
+      tempData: true,
+      tradingMode: false,
+      workspaceAcceptance: true,
+    })
+    expect(plan.buildEnv).toEqual({})
+    expect(plan.launchEnv).toEqual({
+      OPENALICE_MCP_ENABLED: '0',
+      OPENALICE_ELECTRON_SMOKE_WORKSPACE_ACCEPTANCE: '1',
+      OPENALICE_ELECTRON_SMOKE_EXIT: '1',
+    })
+    expect(plan.unsetLaunchEnv).toEqual([
+      'OPENALICE_TRADING_MODE',
+      'OPENALICE_LITE_MODE',
+      'OPENALICE_UTA_DISABLED',
+    ])
+  })
+
+  it('rejects unsafe or contradictory Workspace acceptance flags', () => {
+    expect(buildDesktopPackagedSmokePlan(['--workspace-acceptance', '--real-data']).errors)
+      .toContain('[desktop-smoke] --workspace-acceptance always uses isolated temp data; drop --real-data')
+    expect(buildDesktopPackagedSmokePlan(['--workspace-acceptance', '--onboarding']).errors)
+      .toContain('[desktop-smoke] choose only one automated smoke mode: --onboarding, --trading-mode, or --workspace-acceptance')
   })
 
   it('rejects contradictory data flags', () => {

--- a/scripts/desktop-packaged-smoke.mjs
+++ b/scripts/desktop-packaged-smoke.mjs
@@ -1,15 +1,26 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
-import { createServer as createHttpServer } from 'node:http'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { createServer as createNetServer } from 'node:net'
 import { homedir, tmpdir } from 'node:os'
 import { delimiter, join, resolve } from 'node:path'
+import { assertDesktopPackage } from './assert-desktop-package.mjs'
 import { buildDesktopPackagedSmokePlan } from './desktop-packaged-smoke-plan.mjs'
+import { packagedElectronExecutable } from './smoke-packaged-toolchain.mjs'
+import { startWorkspaceAcceptanceAiMock } from './workspace-acceptance-ai-mock.mjs'
 
 const repoRoot = resolve(import.meta.dirname, '..')
 const plan = buildDesktopPackagedSmokePlan(process.argv.slice(2), process.env)
-const { keep, onboarding, realData, signed, skipBuild, skipPack, tradingMode } = plan.options
+const {
+  keep,
+  onboarding,
+  realData,
+  signed,
+  skipBuild,
+  skipPack,
+  tradingMode,
+  workspaceAcceptance,
+} = plan.options
 
 function printHelp() {
   console.log(`Usage: pnpm electron:smoke:packaged [options]
@@ -25,6 +36,9 @@ Options:
                  automated renderer onboarding smoke, then exit
   --trading-mode Use temp data, exercise lite -> readonly -> lite UTA lifecycle,
                  then exit
+  --workspace-acceptance
+                 Use temp data and prove a packaged Chat Workspace can execute
+                 every injected CLI plus managed Pi using a CLI side effect
   --signed       Allow local macOS code signing (default disables it)
   --keep         Keep the temporary smoke data directory after the app exits
   -h, --help     Show this help
@@ -54,15 +68,6 @@ function run(label, command, commandArgs, extraEnv = {}) {
   if (result.status !== 0) process.exit(result.status ?? 1)
 }
 
-function findPackagedApp() {
-  const candidates = [
-    'dist/electron-app/mac-arm64/OpenAlice.app',
-    'dist/electron-app/mac/OpenAlice.app',
-    'dist/electron-app/OpenAlice.app',
-  ].map((p) => resolve(repoRoot, p))
-  return candidates.find((p) => existsSync(join(p, 'Contents', 'MacOS', 'OpenAlice'))) ?? null
-}
-
 function getAvailablePort() {
   return new Promise((resolve, reject) => {
     const server = createNetServer()
@@ -80,82 +85,21 @@ function getAvailablePort() {
   })
 }
 
-function completionStream(text) {
-  const id = 'chatcmpl-openalice-onboarding'
-  const created = Math.floor(Date.now() / 1000)
-  const chunk = (choices, usage) => JSON.stringify({
-    id,
-    object: 'chat.completion.chunk',
-    created,
-    model: 'openalice-onboarding-test',
-    choices,
-    ...(usage ? { usage } : {}),
-  })
-  return [
-    `data: ${chunk([{ index: 0, delta: { role: 'assistant' }, finish_reason: null }])}`,
-    `data: ${chunk([{ index: 0, delta: { content: text }, finish_reason: null }])}`,
-    `data: ${chunk([{ index: 0, delta: {}, finish_reason: 'stop' }], {
-      prompt_tokens: 8,
-      completion_tokens: 8,
-      total_tokens: 16,
-    })}`,
-    'data: [DONE]',
-    '',
-  ].join('\n\n')
-}
-
-async function startPackagedOnboardingAiMock() {
-  const server = createHttpServer((req, res) => {
-    if (req.method === 'GET' && req.url === '/healthz') {
-      res.writeHead(200, { 'content-type': 'application/json' })
-      res.end(JSON.stringify({ ok: true }))
-      return
-    }
-    if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
-      res.writeHead(404, { 'content-type': 'application/json' })
-      res.end(JSON.stringify({ error: { message: 'Not found' } }))
-      return
-    }
-    if (req.headers.authorization !== 'Bearer oa_test_ok') {
-      res.writeHead(401, { 'content-type': 'application/json' })
-      res.end(JSON.stringify({ error: { message: 'Invalid onboarding test key' } }))
-      return
-    }
-    req.resume()
-    req.on('end', () => {
-      res.writeHead(200, {
-        'content-type': 'text/event-stream; charset=utf-8',
-        'cache-control': 'no-cache',
-        connection: 'keep-alive',
-      })
-      res.end(completionStream('OpenAlice packaged onboarding is ready.'))
-    })
-  })
-  await new Promise((resolve, reject) => {
-    server.once('error', reject)
-    server.listen(0, '127.0.0.1', () => {
-      server.off('error', reject)
-      resolve()
-    })
-  })
-  return server
-}
-
-if (process.platform !== 'darwin') {
+if (process.platform !== 'darwin' && !workspaceAcceptance) {
   console.error('[desktop-smoke] packaged .app smoke currently runs on macOS only')
   process.exit(1)
 }
 
-const onboardingAiMock = onboarding ? await startPackagedOnboardingAiMock() : null
-if (onboardingAiMock) {
-  const address = onboardingAiMock.address()
-  if (!address || typeof address === 'string') {
-    throw new Error('packaged onboarding AI mock did not bind a TCP port')
+const aiMock = onboarding || workspaceAcceptance ? await startWorkspaceAcceptanceAiMock() : null
+if (aiMock) {
+  if (onboarding) {
+    plan.buildEnv.VITE_OPENALICE_ONBOARDING_AI_BASE_URL = aiMock.baseUrl
+    plan.launchEnv.OPENALICE_ONBOARDING_AI_BASE_URL = aiMock.baseUrl
   }
-  const baseUrl = `http://127.0.0.1:${address.port}/v1`
-  plan.buildEnv.VITE_OPENALICE_ONBOARDING_AI_BASE_URL = baseUrl
-  plan.launchEnv.OPENALICE_ONBOARDING_AI_BASE_URL = baseUrl
-  console.log(`[desktop-smoke] onboarding AI mock: ${baseUrl}`)
+  if (workspaceAcceptance) {
+    plan.launchEnv.OPENALICE_WORKSPACE_ACCEPTANCE_AI_BASE_URL = aiMock.baseUrl
+  }
+  console.log(`[desktop-smoke] AI mock: ${aiMock.baseUrl}`)
 }
 
 if (!skipBuild) run('build desktop bundle', 'pnpm', ['electron:build'], plan.buildEnv)
@@ -169,9 +113,13 @@ if (!skipPack) {
   )
 }
 
-const appPath = findPackagedApp()
-if (!appPath) {
-  console.error('[desktop-smoke] OpenAlice.app not found under dist/electron-app; run without --skip-pack first')
+const packageResult = assertDesktopPackage()
+const appPath = packageResult.appRoot
+  ? packagedElectronExecutable(packageResult.appRoot, packageResult.platform)
+  : null
+if (!packageResult.ok || !appPath || !existsSync(appPath)) {
+  for (const error of packageResult.errors) console.error(error)
+  console.error('[desktop-smoke] packaged OpenAlice executable not found; run without --skip-pack first')
   process.exit(1)
 }
 
@@ -196,7 +144,7 @@ const env = {
 
 for (const key of plan.unsetLaunchEnv) delete env[key]
 
-if (onboarding || tradingMode) {
+if (onboarding || tradingMode || workspaceAcceptance) {
   env.OPENALICE_UTA_PORT = String(await getAvailablePort())
 }
 
@@ -205,6 +153,11 @@ if (!realData && smokeHome && smokeWorkspaces && smokeGlobal) {
   env.AQ_LAUNCHER_ROOT = smokeWorkspaces
   env.OPENALICE_GLOBAL_DIR = smokeGlobal
 }
+
+const receiptPath = workspaceAcceptance
+  ? process.env['OPENALICE_SMOKE_RECEIPT_PATH']?.trim() || join(smokeRoot, 'workspace-acceptance-receipt.json')
+  : null
+if (receiptPath) env.OPENALICE_SMOKE_RECEIPT_PATH = receiptPath
 
 console.log('\n[desktop-smoke] launching packaged app')
 console.log(`[desktop-smoke] app: ${appPath}`)
@@ -221,18 +174,22 @@ if (onboarding) {
 } else if (tradingMode) {
   console.log('[desktop-smoke] trading-mode smoke: lite -> readonly -> lite; app exits automatically')
   console.log(`[desktop-smoke] trading-mode UTA port: ${env.OPENALICE_UTA_PORT}`)
+} else if (workspaceAcceptance) {
+  console.log('[desktop-smoke] workspace acceptance: packaged CLI contract + managed Pi side effect')
+  console.log(`[desktop-smoke] acceptance receipt: ${receiptPath}`)
+  console.log(`[desktop-smoke] acceptance UTA port: ${env.OPENALICE_UTA_PORT}`)
 } else {
   console.log('[desktop-smoke] close the app window or press Ctrl-C here to stop')
 }
 
-const child = spawn(join(appPath, 'Contents', 'MacOS', 'OpenAlice'), [], {
+const child = spawn(appPath, [], {
   cwd: repoRoot,
   stdio: 'inherit',
   env,
 })
 
 const cleanup = () => {
-  onboardingAiMock?.close()
+  aiMock?.server.close()
   if (keep || realData || !smokeRoot) return
   rmSync(smokeRoot, { recursive: true, force: true })
 }
@@ -245,10 +202,34 @@ process.on('SIGTERM', () => {
 })
 
 child.on('exit', (code, signal) => {
+  let finalCode = code ?? 0
+  if (!signal && workspaceAcceptance && finalCode === 0) {
+    try {
+      const receipt = JSON.parse(readFileSync(receiptPath, 'utf8'))
+      const failedChecks = Object.entries(receipt.checks ?? {})
+        .filter(([, ok]) => ok !== true)
+        .map(([name]) => name)
+      if (failedChecks.length > 0) throw new Error(`failed receipt checks: ${failedChecks.join(', ')}`)
+      if (aiMock.stats.acceptanceToolTurns < 1 || aiMock.stats.acceptanceFinalTurns < 1) {
+        throw new Error(`mock did not observe both Pi turns: ${JSON.stringify(aiMock.stats)}`)
+      }
+      console.log(`[desktop-smoke] workspace acceptance receipt: ${JSON.stringify(receipt)}`)
+    } catch (err) {
+      finalCode = 1
+      console.error(`[desktop-smoke] invalid workspace acceptance receipt: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
   cleanup()
   if (signal) {
     process.kill(process.pid, signal)
     return
   }
-  process.exit(code ?? 0)
+  process.exit(finalCode)
 })
+
+if (onboarding || tradingMode || workspaceAcceptance) {
+  setTimeout(() => {
+    console.error('[desktop-smoke] automated packaged smoke timed out')
+    child.kill('SIGTERM')
+  }, 180_000).unref()
+}

--- a/scripts/smoke-packaged-toolchain.mjs
+++ b/scripts/smoke-packaged-toolchain.mjs
@@ -99,6 +99,20 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
       expectStatus: 1,
       expectStderr: /alice: AQ_WS_ID is not set/,
     })
+    commands.push({
+      label: 'Workspace CLI transport env through managed Git Bash',
+      command: bashExe,
+      args: ['--noprofile', '--norc', '-c', 'alice --help'],
+      env: {
+        ...winEnv,
+        AQ_WS_ID: 'workspace-toolchain-smoke',
+        OPENALICE_TOOL_URL: '/cli',
+        OPENALICE_TOOL_SOCKET: '\\\\.\\pipe\\openalice-toolchain-missing',
+        OPENALICE_CLI_DEBUG: '1',
+      },
+      expectStatus: 1,
+      expectStdout: /"toolUrl":"\/cli"/,
+    })
   }
 
   return { ok: errors.length === 0, errors, commands }

--- a/scripts/smoke-packaged-toolchain.mjs
+++ b/scripts/smoke-packaged-toolchain.mjs
@@ -58,13 +58,15 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
     const gitExe = join(gitRoot, git.gitBin)
     const bashExe = join(gitRoot, git.shellPath)
     const shExe = join(gitRoot, git.shPath)
+    const workspaceCliDir = join(packageResult.appRoot, 'src', 'workspaces', 'cli', 'bin')
     const toolchainPath = (Array.isArray(git.toolchainPaths) ? git.toolchainPaths : ['cmd', 'bin', 'usr/bin'])
       .map((entry) => join(gitRoot, entry))
       .join(delimiter)
     const winEnv = {
-      PATH: [toolchainPath, process.env['PATH']].filter(Boolean).join(delimiter),
+      PATH: [workspaceCliDir, toolchainPath, process.env['PATH']].filter(Boolean).join(delimiter),
       CHERE_INVOKING: '1',
       MSYSTEM: packageResult.platformArch.endsWith('arm64') ? 'CLANGARM64' : 'MINGW64',
+      OPENALICE_MANAGED_PI_NODE_PATH: electron,
     }
 
     commands.push({
@@ -88,6 +90,14 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
       ],
       env: winEnv,
       expectStdout: /OPENALICE_SH_OK[\s\S]*git version [\s\S]*GNU bash/,
+    })
+    commands.push({
+      label: 'Workspace CLI launcher through managed Git Bash',
+      command: bashExe,
+      args: ['--noprofile', '--norc', '-c', 'alice --help'],
+      env: winEnv,
+      expectStatus: 1,
+      expectStderr: /alice: AQ_WS_ID is not set/,
     })
   }
 

--- a/scripts/smoke-packaged-toolchain.spec.ts
+++ b/scripts/smoke-packaged-toolchain.spec.ts
@@ -82,11 +82,13 @@ describe('buildPackagedToolchainSmokePlan', () => {
         'managed bash.exe',
         'managed sh.exe can resolve git and bash on PATH',
         'Workspace CLI launcher through managed Git Bash',
+        'Workspace CLI transport env through managed Git Bash',
       ])
       expect(plan.commands[3].command.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/cmd/git.exe')
       expect(plan.commands[5].env?.PATH.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/mingw64/bin')
       expect(plan.commands[6].env?.OPENALICE_MANAGED_PI_NODE_PATH.replaceAll('\\', '/'))
         .toContain('win-unpacked/OpenAlice.exe')
+      expect(plan.commands[7].env?.OPENALICE_TOOL_URL).toBe('/cli')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/scripts/smoke-packaged-toolchain.spec.ts
+++ b/scripts/smoke-packaged-toolchain.spec.ts
@@ -81,9 +81,12 @@ describe('buildPackagedToolchainSmokePlan', () => {
         'managed git.exe',
         'managed bash.exe',
         'managed sh.exe can resolve git and bash on PATH',
+        'Workspace CLI launcher through managed Git Bash',
       ])
       expect(plan.commands[3].command.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/cmd/git.exe')
       expect(plan.commands[5].env?.PATH.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/mingw64/bin')
+      expect(plan.commands[6].env?.OPENALICE_MANAGED_PI_NODE_PATH.replaceAll('\\', '/'))
+        .toContain('win-unpacked/OpenAlice.exe')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/scripts/workspace-acceptance-ai-mock.mjs
+++ b/scripts/workspace-acceptance-ai-mock.mjs
@@ -1,0 +1,145 @@
+import { createServer } from 'node:http'
+
+export const WORKSPACE_ACCEPTANCE_MARKER = 'OPENALICE_PACKAGED_WORKSPACE_CLI_ACCEPTANCE'
+export const WORKSPACE_ACCEPTANCE_AGENT_ISSUE_ID = 'openalice-agent-cli-acceptance'
+export const WORKSPACE_ACCEPTANCE_ASSISTANT_TEXT = 'OpenAlice Workspace CLI acceptance completed.'
+
+function chunk(id, choices, usage) {
+  return JSON.stringify({
+    id,
+    object: 'chat.completion.chunk',
+    created: Math.floor(Date.now() / 1000),
+    model: 'openalice-workspace-acceptance',
+    choices,
+    ...(usage ? { usage } : {}),
+  })
+}
+
+function sse(chunks) {
+  return [...chunks.map((entry) => `data: ${entry}`), 'data: [DONE]', ''].join('\n\n')
+}
+
+export function textCompletionStream(text, id = 'chatcmpl-openalice-smoke') {
+  return sse([
+    chunk(id, [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }]),
+    chunk(id, [{ index: 0, delta: { content: text }, finish_reason: null }]),
+    chunk(id, [{ index: 0, delta: {}, finish_reason: 'stop' }], {
+      prompt_tokens: 8,
+      completion_tokens: 8,
+      total_tokens: 16,
+    }),
+  ])
+}
+
+export function cliToolCallStream(id = 'chatcmpl-openalice-cli-tool') {
+  const command = [
+    'alice-workspace issue create',
+    `--id ${WORKSPACE_ACCEPTANCE_AGENT_ISSUE_ID}`,
+    '--title "OpenAlice agent CLI acceptance"',
+  ].join(' ')
+  return sse([
+    chunk(id, [{
+      index: 0,
+      delta: {
+        role: 'assistant',
+        tool_calls: [{
+          index: 0,
+          id: 'call_openalice_workspace_cli',
+          type: 'function',
+          function: { name: 'bash', arguments: JSON.stringify({ command }) },
+        }],
+      },
+      finish_reason: null,
+    }]),
+    chunk(id, [{ index: 0, delta: {}, finish_reason: 'tool_calls' }], {
+      prompt_tokens: 8,
+      completion_tokens: 8,
+      total_tokens: 16,
+    }),
+  ])
+}
+
+function requestHasToolResult(body) {
+  return Array.isArray(body?.messages) && body.messages.some((message) => message?.role === 'tool')
+}
+
+async function readJson(req) {
+  const chunks = []
+  for await (const chunk of req) chunks.push(chunk)
+  const text = Buffer.concat(chunks).toString('utf8')
+  return text ? JSON.parse(text) : {}
+}
+
+/**
+ * Deterministic OpenAI-compatible provider used only by packaged acceptance.
+ * The first acceptance turn asks Pi's built-in bash tool to execute the real
+ * Workspace CLI. The second turn acknowledges the tool result. Ordinary
+ * readiness probes still receive a plain assistant response.
+ */
+export async function startWorkspaceAcceptanceAiMock() {
+  const stats = {
+    readinessTurns: 0,
+    acceptanceToolTurns: 0,
+    acceptanceFinalTurns: 0,
+  }
+  const server = createServer(async (req, res) => {
+    if (req.method === 'GET' && req.url === '/healthz') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true }))
+      return
+    }
+    if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
+      res.writeHead(404, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: { message: 'Not found' } }))
+      return
+    }
+    if (req.headers.authorization !== 'Bearer oa_test_ok') {
+      res.writeHead(401, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: { message: 'Invalid smoke test key' } }))
+      return
+    }
+
+    try {
+      const body = await readJson(req)
+      const isAcceptance = JSON.stringify(body).includes(WORKSPACE_ACCEPTANCE_MARKER)
+      let payload
+      if (!isAcceptance) {
+        stats.readinessTurns += 1
+        payload = textCompletionStream('OpenAlice packaged runtime is ready.')
+      } else if (requestHasToolResult(body)) {
+        stats.acceptanceFinalTurns += 1
+        payload = textCompletionStream(WORKSPACE_ACCEPTANCE_ASSISTANT_TEXT)
+      } else {
+        stats.acceptanceToolTurns += 1
+        payload = cliToolCallStream()
+      }
+      res.writeHead(200, {
+        'content-type': 'text/event-stream; charset=utf-8',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      })
+      res.end(payload)
+    } catch (err) {
+      res.writeHead(400, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: { message: err instanceof Error ? err.message : String(err) } }))
+    }
+  })
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    server.close()
+    throw new Error('workspace acceptance AI mock did not bind a TCP port')
+  }
+  return {
+    server,
+    stats,
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+  }
+}

--- a/scripts/workspace-acceptance-ai-mock.spec.ts
+++ b/scripts/workspace-acceptance-ai-mock.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  cliToolCallStream,
+  textCompletionStream,
+  WORKSPACE_ACCEPTANCE_AGENT_ISSUE_ID,
+  WORKSPACE_ACCEPTANCE_ASSISTANT_TEXT,
+} from './workspace-acceptance-ai-mock.mjs'
+
+function dataPayloads(stream: string) {
+  return stream
+    .split('\n\n')
+    .filter((line) => line.startsWith('data: {'))
+    .map((line) => JSON.parse(line.slice('data: '.length)))
+}
+
+describe('workspace acceptance AI mock', () => {
+  it('drives Pi through its real bash tool into the Workspace CLI', () => {
+    const payloads = dataPayloads(cliToolCallStream())
+    const call = payloads[0].choices[0].delta.tool_calls[0]
+
+    expect(call.function.name).toBe('bash')
+    expect(JSON.parse(call.function.arguments).command).toContain(
+      `alice-workspace issue create --id ${WORKSPACE_ACCEPTANCE_AGENT_ISSUE_ID}`,
+    )
+    expect(payloads.at(-1).choices[0].finish_reason).toBe('tool_calls')
+  })
+
+  it('returns a structured final assistant reply after the tool result', () => {
+    const payloads = dataPayloads(textCompletionStream(WORKSPACE_ACCEPTANCE_ASSISTANT_TEXT))
+
+    expect(payloads[1].choices[0].delta.content).toBe(WORKSPACE_ACCEPTANCE_ASSISTANT_TEXT)
+    expect(payloads.at(-1).choices[0].finish_reason).toBe('stop')
+  })
+})

--- a/src/workspaces/cli/bin/alice
+++ b/src/workspaces/cli/bin/alice
@@ -51,6 +51,13 @@ if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
     # translate the first argument for a renamed OpenAlice.exe.
     converted=$(cygpath -w "$payload" 2>/dev/null || true)
     if [ -n "$converted" ]; then payload=$converted; fi
+    # `/cli` is an application route, not a POSIX filesystem path. Preserve
+    # both transport values when MSYS prepares the native Electron child env.
+    case "${MSYS2_ENV_CONV_EXCL:-}" in
+      '') MSYS2_ENV_CONV_EXCL='OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET' ;;
+      *) MSYS2_ENV_CONV_EXCL="$MSYS2_ENV_CONV_EXCL;OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET" ;;
+    esac
+    export MSYS2_ENV_CONV_EXCL
   fi
   exec "$managed_node" "$payload" "$@"
 fi

--- a/src/workspaces/cli/bin/alice
+++ b/src/workspaces/cli/bin/alice
@@ -1,13 +1,19 @@
 #!/bin/sh
 set -eu
 
-# Public command name drives the gateway export in the shared JS payload.
-OPENALICE_CLI_BIN=${0##*/}
-export OPENALICE_CLI_BIN
-
 # Resolve the payload beside this launcher without dirname/readlink so the
 # packaged path still works with an intentionally empty host PATH.
 launcher=$0
+case "$launcher" in
+  *\\*)
+    # A managed Git Bash receives Windows-native PATH entries from Electron.
+    # Normalize a `D:\...\alice` argv[0] before deriving the sibling payload.
+    if command -v cygpath >/dev/null 2>&1; then
+      converted=$(cygpath -u "$launcher" 2>/dev/null || true)
+      if [ -n "$converted" ]; then launcher=$converted; fi
+    fi
+    ;;
+esac
 case "$launcher" in
   */*) ;;
   *)
@@ -15,6 +21,10 @@ case "$launcher" in
     if [ -n "$resolved" ]; then launcher=$resolved; fi
     ;;
 esac
+
+# Public command name drives the gateway export in the shared JS payload.
+OPENALICE_CLI_BIN=${launcher##*/}
+export OPENALICE_CLI_BIN
 case "$launcher" in
   */*) launcher_dir=${launcher%/*} ;;
   *) launcher_dir=. ;;
@@ -23,9 +33,18 @@ esac
 # Packaged Electron exposes its Node-capable executable through the managed Pi
 # runtime. Source/dev keeps the ordinary host-node fallback.
 if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
+  managed_node=$OPENALICE_MANAGED_PI_NODE_PATH
+  case "$managed_node" in
+    *\\*|[A-Za-z]:*)
+      if command -v cygpath >/dev/null 2>&1; then
+        converted=$(cygpath -u "$managed_node" 2>/dev/null || true)
+        if [ -n "$converted" ]; then managed_node=$converted; fi
+      fi
+      ;;
+  esac
   ELECTRON_RUN_AS_NODE=1
   export ELECTRON_RUN_AS_NODE
-  exec "$OPENALICE_MANAGED_PI_NODE_PATH" "$launcher_dir/openalice-cli.cjs" "$@"
+  exec "$managed_node" "$launcher_dir/openalice-cli.cjs" "$@"
 fi
 
 exec node "$launcher_dir/openalice-cli.cjs" "$@"

--- a/src/workspaces/cli/bin/alice
+++ b/src/workspaces/cli/bin/alice
@@ -44,7 +44,15 @@ if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
   esac
   ELECTRON_RUN_AS_NODE=1
   export ELECTRON_RUN_AS_NODE
-  exec "$managed_node" "$launcher_dir/openalice-cli.cjs" "$@"
+  payload=$launcher_dir/openalice-cli.cjs
+  if command -v cygpath >/dev/null 2>&1; then
+    # Electron is a native Windows process. Give it a native payload path
+    # explicitly instead of relying on MSYS' executable-name heuristics to
+    # translate the first argument for a renamed OpenAlice.exe.
+    converted=$(cygpath -w "$payload" 2>/dev/null || true)
+    if [ -n "$converted" ]; then payload=$converted; fi
+  fi
+  exec "$managed_node" "$payload" "$@"
 fi
 
 exec node "$launcher_dir/openalice-cli.cjs" "$@"

--- a/src/workspaces/cli/bin/alice-uta
+++ b/src/workspaces/cli/bin/alice-uta
@@ -51,6 +51,13 @@ if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
     # translate the first argument for a renamed OpenAlice.exe.
     converted=$(cygpath -w "$payload" 2>/dev/null || true)
     if [ -n "$converted" ]; then payload=$converted; fi
+    # `/cli` is an application route, not a POSIX filesystem path. Preserve
+    # both transport values when MSYS prepares the native Electron child env.
+    case "${MSYS2_ENV_CONV_EXCL:-}" in
+      '') MSYS2_ENV_CONV_EXCL='OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET' ;;
+      *) MSYS2_ENV_CONV_EXCL="$MSYS2_ENV_CONV_EXCL;OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET" ;;
+    esac
+    export MSYS2_ENV_CONV_EXCL
   fi
   exec "$managed_node" "$payload" "$@"
 fi

--- a/src/workspaces/cli/bin/alice-uta
+++ b/src/workspaces/cli/bin/alice-uta
@@ -1,13 +1,19 @@
 #!/bin/sh
 set -eu
 
-# Public command name drives the gateway export in the shared JS payload.
-OPENALICE_CLI_BIN=${0##*/}
-export OPENALICE_CLI_BIN
-
 # Resolve the payload beside this launcher without dirname/readlink so the
 # packaged path still works with an intentionally empty host PATH.
 launcher=$0
+case "$launcher" in
+  *\\*)
+    # A managed Git Bash receives Windows-native PATH entries from Electron.
+    # Normalize a `D:\...\alice` argv[0] before deriving the sibling payload.
+    if command -v cygpath >/dev/null 2>&1; then
+      converted=$(cygpath -u "$launcher" 2>/dev/null || true)
+      if [ -n "$converted" ]; then launcher=$converted; fi
+    fi
+    ;;
+esac
 case "$launcher" in
   */*) ;;
   *)
@@ -15,6 +21,10 @@ case "$launcher" in
     if [ -n "$resolved" ]; then launcher=$resolved; fi
     ;;
 esac
+
+# Public command name drives the gateway export in the shared JS payload.
+OPENALICE_CLI_BIN=${launcher##*/}
+export OPENALICE_CLI_BIN
 case "$launcher" in
   */*) launcher_dir=${launcher%/*} ;;
   *) launcher_dir=. ;;
@@ -23,9 +33,18 @@ esac
 # Packaged Electron exposes its Node-capable executable through the managed Pi
 # runtime. Source/dev keeps the ordinary host-node fallback.
 if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
+  managed_node=$OPENALICE_MANAGED_PI_NODE_PATH
+  case "$managed_node" in
+    *\\*|[A-Za-z]:*)
+      if command -v cygpath >/dev/null 2>&1; then
+        converted=$(cygpath -u "$managed_node" 2>/dev/null || true)
+        if [ -n "$converted" ]; then managed_node=$converted; fi
+      fi
+      ;;
+  esac
   ELECTRON_RUN_AS_NODE=1
   export ELECTRON_RUN_AS_NODE
-  exec "$OPENALICE_MANAGED_PI_NODE_PATH" "$launcher_dir/openalice-cli.cjs" "$@"
+  exec "$managed_node" "$launcher_dir/openalice-cli.cjs" "$@"
 fi
 
 exec node "$launcher_dir/openalice-cli.cjs" "$@"

--- a/src/workspaces/cli/bin/alice-uta
+++ b/src/workspaces/cli/bin/alice-uta
@@ -44,7 +44,15 @@ if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
   esac
   ELECTRON_RUN_AS_NODE=1
   export ELECTRON_RUN_AS_NODE
-  exec "$managed_node" "$launcher_dir/openalice-cli.cjs" "$@"
+  payload=$launcher_dir/openalice-cli.cjs
+  if command -v cygpath >/dev/null 2>&1; then
+    # Electron is a native Windows process. Give it a native payload path
+    # explicitly instead of relying on MSYS' executable-name heuristics to
+    # translate the first argument for a renamed OpenAlice.exe.
+    converted=$(cygpath -w "$payload" 2>/dev/null || true)
+    if [ -n "$converted" ]; then payload=$converted; fi
+  fi
+  exec "$managed_node" "$payload" "$@"
 fi
 
 exec node "$launcher_dir/openalice-cli.cjs" "$@"

--- a/src/workspaces/cli/bin/alice-workspace
+++ b/src/workspaces/cli/bin/alice-workspace
@@ -51,6 +51,13 @@ if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
     # translate the first argument for a renamed OpenAlice.exe.
     converted=$(cygpath -w "$payload" 2>/dev/null || true)
     if [ -n "$converted" ]; then payload=$converted; fi
+    # `/cli` is an application route, not a POSIX filesystem path. Preserve
+    # both transport values when MSYS prepares the native Electron child env.
+    case "${MSYS2_ENV_CONV_EXCL:-}" in
+      '') MSYS2_ENV_CONV_EXCL='OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET' ;;
+      *) MSYS2_ENV_CONV_EXCL="$MSYS2_ENV_CONV_EXCL;OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET" ;;
+    esac
+    export MSYS2_ENV_CONV_EXCL
   fi
   exec "$managed_node" "$payload" "$@"
 fi

--- a/src/workspaces/cli/bin/alice-workspace
+++ b/src/workspaces/cli/bin/alice-workspace
@@ -1,13 +1,19 @@
 #!/bin/sh
 set -eu
 
-# Public command name drives the gateway export in the shared JS payload.
-OPENALICE_CLI_BIN=${0##*/}
-export OPENALICE_CLI_BIN
-
 # Resolve the payload beside this launcher without dirname/readlink so the
 # packaged path still works with an intentionally empty host PATH.
 launcher=$0
+case "$launcher" in
+  *\\*)
+    # A managed Git Bash receives Windows-native PATH entries from Electron.
+    # Normalize a `D:\...\alice` argv[0] before deriving the sibling payload.
+    if command -v cygpath >/dev/null 2>&1; then
+      converted=$(cygpath -u "$launcher" 2>/dev/null || true)
+      if [ -n "$converted" ]; then launcher=$converted; fi
+    fi
+    ;;
+esac
 case "$launcher" in
   */*) ;;
   *)
@@ -15,6 +21,10 @@ case "$launcher" in
     if [ -n "$resolved" ]; then launcher=$resolved; fi
     ;;
 esac
+
+# Public command name drives the gateway export in the shared JS payload.
+OPENALICE_CLI_BIN=${launcher##*/}
+export OPENALICE_CLI_BIN
 case "$launcher" in
   */*) launcher_dir=${launcher%/*} ;;
   *) launcher_dir=. ;;
@@ -23,9 +33,18 @@ esac
 # Packaged Electron exposes its Node-capable executable through the managed Pi
 # runtime. Source/dev keeps the ordinary host-node fallback.
 if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
+  managed_node=$OPENALICE_MANAGED_PI_NODE_PATH
+  case "$managed_node" in
+    *\\*|[A-Za-z]:*)
+      if command -v cygpath >/dev/null 2>&1; then
+        converted=$(cygpath -u "$managed_node" 2>/dev/null || true)
+        if [ -n "$converted" ]; then managed_node=$converted; fi
+      fi
+      ;;
+  esac
   ELECTRON_RUN_AS_NODE=1
   export ELECTRON_RUN_AS_NODE
-  exec "$OPENALICE_MANAGED_PI_NODE_PATH" "$launcher_dir/openalice-cli.cjs" "$@"
+  exec "$managed_node" "$launcher_dir/openalice-cli.cjs" "$@"
 fi
 
 exec node "$launcher_dir/openalice-cli.cjs" "$@"

--- a/src/workspaces/cli/bin/alice-workspace
+++ b/src/workspaces/cli/bin/alice-workspace
@@ -44,7 +44,15 @@ if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
   esac
   ELECTRON_RUN_AS_NODE=1
   export ELECTRON_RUN_AS_NODE
-  exec "$managed_node" "$launcher_dir/openalice-cli.cjs" "$@"
+  payload=$launcher_dir/openalice-cli.cjs
+  if command -v cygpath >/dev/null 2>&1; then
+    # Electron is a native Windows process. Give it a native payload path
+    # explicitly instead of relying on MSYS' executable-name heuristics to
+    # translate the first argument for a renamed OpenAlice.exe.
+    converted=$(cygpath -w "$payload" 2>/dev/null || true)
+    if [ -n "$converted" ]; then payload=$converted; fi
+  fi
+  exec "$managed_node" "$payload" "$@"
 fi
 
 exec node "$launcher_dir/openalice-cli.cjs" "$@"

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -53,6 +53,7 @@ async function main() {
       ? toolUrl.replace(/\/+$/, '')
       : legacyMcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli')
   const base = gateway + '/' + wsId + '/' + exportKey
+  debug('runtime', { bin: BIN, wsId, toolSocket, toolUrl, base })
 
   const wantsHelp = argv.includes('--help') || argv.includes('-h')
   const positionals = argv.filter((a) => !a.startsWith('-'))
@@ -156,6 +157,7 @@ async function fetchJson(url, opts) {
 
 async function fetchSocketJson(socketPath, path, opts) {
   const http = await import('node:http')
+  debug('socket.request', { socketPath, path, method: opts && opts.method ? opts.method : 'GET' })
   return new Promise((resolve) => {
     const req = http.request({
       socketPath,
@@ -169,10 +171,14 @@ async function fetchSocketJson(socketPath, path, opts) {
       res.on('end', () => {
         let body = null
         try { body = raw ? JSON.parse(raw) : null } catch { body = raw }
+        debug('socket.response', { path, status: res.statusCode, bytes: raw.length })
         resolve({ ok: res.statusCode >= 200 && res.statusCode < 300, status: res.statusCode, body })
       })
     })
-    req.on('error', (e) => fail(`cannot reach OpenAlice at ${socketPath}${path} — is the backend running? (${e && e.message})`))
+    req.on('error', (e) => {
+      debug('socket.error', { socketPath, path, code: e && e.code, message: e && e.message })
+      fail(`cannot reach OpenAlice at ${socketPath}${path} — is the backend running? (${e && e.message})`)
+    })
     if (opts && opts.body) req.write(opts.body)
     req.end()
   })
@@ -276,6 +282,10 @@ function firstLine(s) {
 }
 function out(s) {
   process.stdout.write(s + '\n')
+}
+function debug(label, value) {
+  if (process.env.OPENALICE_CLI_DEBUG !== '1') return
+  out('[openalice-cli-debug] ' + label + ' ' + JSON.stringify(value))
 }
 function fail(msg) {
   process.stderr.write(BIN + ': ' + msg + '\n')

--- a/src/workspaces/cli/bin/traderhub
+++ b/src/workspaces/cli/bin/traderhub
@@ -51,6 +51,13 @@ if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
     # translate the first argument for a renamed OpenAlice.exe.
     converted=$(cygpath -w "$payload" 2>/dev/null || true)
     if [ -n "$converted" ]; then payload=$converted; fi
+    # `/cli` is an application route, not a POSIX filesystem path. Preserve
+    # both transport values when MSYS prepares the native Electron child env.
+    case "${MSYS2_ENV_CONV_EXCL:-}" in
+      '') MSYS2_ENV_CONV_EXCL='OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET' ;;
+      *) MSYS2_ENV_CONV_EXCL="$MSYS2_ENV_CONV_EXCL;OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET" ;;
+    esac
+    export MSYS2_ENV_CONV_EXCL
   fi
   exec "$managed_node" "$payload" "$@"
 fi

--- a/src/workspaces/cli/bin/traderhub
+++ b/src/workspaces/cli/bin/traderhub
@@ -1,13 +1,19 @@
 #!/bin/sh
 set -eu
 
-# Public command name drives the gateway export in the shared JS payload.
-OPENALICE_CLI_BIN=${0##*/}
-export OPENALICE_CLI_BIN
-
 # Resolve the payload beside this launcher without dirname/readlink so the
 # packaged path still works with an intentionally empty host PATH.
 launcher=$0
+case "$launcher" in
+  *\\*)
+    # A managed Git Bash receives Windows-native PATH entries from Electron.
+    # Normalize a `D:\...\alice` argv[0] before deriving the sibling payload.
+    if command -v cygpath >/dev/null 2>&1; then
+      converted=$(cygpath -u "$launcher" 2>/dev/null || true)
+      if [ -n "$converted" ]; then launcher=$converted; fi
+    fi
+    ;;
+esac
 case "$launcher" in
   */*) ;;
   *)
@@ -15,6 +21,10 @@ case "$launcher" in
     if [ -n "$resolved" ]; then launcher=$resolved; fi
     ;;
 esac
+
+# Public command name drives the gateway export in the shared JS payload.
+OPENALICE_CLI_BIN=${launcher##*/}
+export OPENALICE_CLI_BIN
 case "$launcher" in
   */*) launcher_dir=${launcher%/*} ;;
   *) launcher_dir=. ;;
@@ -23,9 +33,18 @@ esac
 # Packaged Electron exposes its Node-capable executable through the managed Pi
 # runtime. Source/dev keeps the ordinary host-node fallback.
 if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
+  managed_node=$OPENALICE_MANAGED_PI_NODE_PATH
+  case "$managed_node" in
+    *\\*|[A-Za-z]:*)
+      if command -v cygpath >/dev/null 2>&1; then
+        converted=$(cygpath -u "$managed_node" 2>/dev/null || true)
+        if [ -n "$converted" ]; then managed_node=$converted; fi
+      fi
+      ;;
+  esac
   ELECTRON_RUN_AS_NODE=1
   export ELECTRON_RUN_AS_NODE
-  exec "$OPENALICE_MANAGED_PI_NODE_PATH" "$launcher_dir/openalice-cli.cjs" "$@"
+  exec "$managed_node" "$launcher_dir/openalice-cli.cjs" "$@"
 fi
 
 exec node "$launcher_dir/openalice-cli.cjs" "$@"

--- a/src/workspaces/cli/bin/traderhub
+++ b/src/workspaces/cli/bin/traderhub
@@ -44,7 +44,15 @@ if [ -n "${OPENALICE_MANAGED_PI_NODE_PATH:-}" ]; then
   esac
   ELECTRON_RUN_AS_NODE=1
   export ELECTRON_RUN_AS_NODE
-  exec "$managed_node" "$launcher_dir/openalice-cli.cjs" "$@"
+  payload=$launcher_dir/openalice-cli.cjs
+  if command -v cygpath >/dev/null 2>&1; then
+    # Electron is a native Windows process. Give it a native payload path
+    # explicitly instead of relying on MSYS' executable-name heuristics to
+    # translate the first argument for a renamed OpenAlice.exe.
+    converted=$(cygpath -w "$payload" 2>/dev/null || true)
+    if [ -n "$converted" ]; then payload=$converted; fi
+  fi
+  exec "$managed_node" "$payload" "$@"
 fi
 
 exec node "$launcher_dir/openalice-cli.cjs" "$@"

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -49,6 +49,8 @@ describe('CLI launchers and payload', () => {
     expect(src).toContain('cygpath -u "$launcher"')
     expect(src).toContain('cygpath -u "$managed_node"')
     expect(src).toContain('cygpath -w "$payload"')
+    expect(src).toContain('MSYS2_ENV_CONV_EXCL')
+    expect(src).toContain('OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET')
     expect(src).toContain('openalice-cli.cjs')
     expect(src).not.toContain('/usr/bin/env node')
   })

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -48,6 +48,7 @@ describe('CLI launchers and payload', () => {
     expect(src).toContain('OPENALICE_MANAGED_PI_NODE_PATH')
     expect(src).toContain('cygpath -u "$launcher"')
     expect(src).toContain('cygpath -u "$managed_node"')
+    expect(src).toContain('cygpath -w "$payload"')
     expect(src).toContain('openalice-cli.cjs')
     expect(src).not.toContain('/usr/bin/env node')
   })

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -46,6 +46,8 @@ describe('CLI launchers and payload', () => {
     const src = canonical.toString('utf8')
     expect(src).toContain('#!/bin/sh')
     expect(src).toContain('OPENALICE_MANAGED_PI_NODE_PATH')
+    expect(src).toContain('cygpath -u "$launcher"')
+    expect(src).toContain('cygpath -u "$managed_node"')
     expect(src).toContain('openalice-cli.cjs')
     expect(src).not.toContain('/usr/bin/env node')
   })

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -93,7 +93,10 @@ describe('CLI launchers and payload', () => {
           AQ_WS_ID: 'ws1',
           OPENALICE_TOOL_SOCKET: socketPath,
           OPENALICE_TOOL_URL: '/cli',
+          OPENALICE_CLI_DEBUG: '1',
       })
+      expect(stdout).toContain('[openalice-cli-debug] runtime')
+      expect(stdout).toContain('[openalice-cli-debug] socket.response')
       expect(stdout).toContain('OpenAlice CLI')
       expect(stdout).toContain('market')
       expect(seen).toEqual(['/cli/ws1/data/manifest'])


### PR DESCRIPTION
## Summary
- add a packaged Electron Workspace acceptance harness that creates an isolated Chat Workspace and exercises the production PTY, Workspace environment, tool socket, Git, and all four injected CLI shims
- drive bundled managed Pi with a deterministic local OpenAI-compatible provider, require Pi to invoke `alice-workspace`, decode its structured assistant reply, and verify the resulting issue from outside the Workspace
- fix the Windows Git Bash path exposed by the new gate: POSIX CLI launchers now normalize Windows-native launcher and packaged Electron Node paths before executing the shared payload
- emit and preserve versioned JSON acceptance receipts with separate checks for creation, Git, injection, manifests, shell CLI round-trip, Pi output, Pi CLI side effect, and cleanup
- run the acceptance on Apple Silicon, Intel macOS, and Windows package-smoke candidates and on every release candidate
- reorder releases so tag/GitHub Release creation happens only after all three platform builds pass acceptance; accepted installers are handed to publication through CI artifacts

## Verification
- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm test` — 2497 passed, 6 skipped
- focused CLI/headless/package smoke specs — 56 passed
- `pnpm electron:smoke:pty --skip-build`
- local unsigned arm64 package build
- `pnpm electron:assert-package`
- `pnpm electron:smoke-toolchain`
- `pnpm electron:smoke:workspace --skip-build --skip-pack` — all 8 receipt checks passed
- external receipt-path verification — all checks passed
- Windows CI failure receipts verified the harness stops at the exact failed contract stage; nested Bash escaping now has a regression spec
- `pnpm electron:smoke:onboarding`
- release/package workflow YAML syntax validation

## Boundary touch
- runtime, Electron IPC/PTY, packaged managed Pi, Workspace CLI injection, package CI, and release publication
- no trading behavior, persisted user migration, or real credentials; all acceptance state is isolated and the provider is local/deterministic
