### PR TITLE
chore(release): 0.75.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.73.0-beta",
+  "version": "0.75.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary
- bump the OpenAlice desktop release version from `0.73.0-beta` to `0.75.0-beta`
- prepare the current `dev` line for promotion to the stable `master` lane

## Verification
- `node -e` version assertion (`0.75.0-beta`)
- `npx tsc --noEmit`
- `pnpm test` (2498 passed, 6 skipped)
- `pnpm electron:smoke:workspace` (fresh packaged app, Workspace acceptance 8/8)

## Boundary touch
- release metadata and desktop packaging version only
- no trading, credential, migration, onboarding, or runtime behavior change
