### PR TITLE
fix(release): honor prerelease metadata channels

### DIFF
--- a/scripts/prepare-desktop-release-assets.mjs
+++ b/scripts/prepare-desktop-release-assets.mjs
@@ -24,16 +24,16 @@ export function prepareBuildMetadata({ outDir, platform, arch, version }) {
   const channel = prereleaseChannel(version)
 
   if (normalizedPlatform === 'macos' || normalizedPlatform === 'darwin') {
-    const source = 'latest-mac.yml'
+    // electron-builder names generic-provider metadata after the configured
+    // prerelease channel (for example beta-mac.yml), while stable builds use
+    // latest-mac.yml. Do not assume every build starts from the stable name.
+    const source = `${channel}-mac.yml`
     if (!existsSync(join(outDir, source))) {
       throw new Error(`[release-assets] missing ${source} for macOS ${arch}`)
     }
 
     if (arch === 'arm64') {
-      copyIfPresent(outDir, source, ['latest-mac-arm64.yml'])
-      if (channel !== 'latest') {
-        copyIfPresent(outDir, source, [`${channel}-mac.yml`, `${channel}-mac-arm64.yml`])
-      }
+      copyIfPresent(outDir, source, ['latest-mac-arm64.yml', `${channel}-mac-arm64.yml`])
       return
     }
 
@@ -44,8 +44,9 @@ export function prepareBuildMetadata({ outDir, platform, arch, version }) {
       if (channel !== 'latest') {
         copyIfPresent(outDir, source, [`${channel}-mac-intel.yml`, `${channel}-intel-mac.yml`])
       }
-      // Keep the established latest-mac.yml owned by the arm64 build. Intel
-      // clients request the architecture-specific compatibility alias above.
+      // Keep the generic channel metadata owned by the arm64 build. Intel
+      // clients request the architecture-specific compatibility alias above,
+      // and merged release artifacts must not contain two competing copies.
       rmSync(join(outDir, source), { force: true })
       return
     }

--- a/scripts/prepare-desktop-release-assets.spec.ts
+++ b/scripts/prepare-desktop-release-assets.spec.ts
@@ -18,22 +18,22 @@ function withTempDir(run: (dir: string) => void) {
 describe('prepareBuildMetadata', () => {
   it('keeps arm64 canonical metadata and gives Intel its own feeds', () => {
     withTempDir((dir) => {
-      writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.3-beta\n')
+      writeFileSync(join(dir, 'beta-mac.yml'), 'version: 1.2.3-beta\n')
       prepareBuildMetadata({ outDir: dir, platform: 'macOS', arch: 'x64', version: '1.2.3-beta' })
 
       expect(readFileSync(join(dir, 'latest-mac-intel.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'latest-intel-mac.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'beta-mac-intel.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'beta-intel-mac.yml'), 'utf8')).toContain('1.2.3-beta')
-      expect(() => readFileSync(join(dir, 'latest-mac.yml'))).toThrow()
+      expect(() => readFileSync(join(dir, 'beta-mac.yml'))).toThrow()
     })
 
     withTempDir((dir) => {
-      writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.3-beta\n')
+      writeFileSync(join(dir, 'beta-mac.yml'), 'version: 1.2.3-beta\n')
       prepareBuildMetadata({ outDir: dir, platform: 'macOS', arch: 'arm64', version: '1.2.3-beta' })
 
-      expect(readFileSync(join(dir, 'latest-mac.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'beta-mac.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(readFileSync(join(dir, 'beta-mac-arm64.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'latest-mac-arm64.yml'), 'utf8')).toContain('1.2.3-beta')
     })
   })


### PR DESCRIPTION
## Summary
- read macOS update metadata from electron-builder's actual prerelease channel name (`beta-mac.yml`)
- keep arm64 generic metadata and generate architecture aliases
- remove Intel generic metadata before artifacts are merged so it cannot overwrite the arm64 feed
- update release-asset tests to model real beta output

## Verification
- `npx tsc --noEmit`
- `pnpm test` (2498 passed, 6 skipped)
- local alias preparation against packaged `beta-mac.yml`
- failed v0.75.0-beta release already proved Windows and macOS ARM packaged Workspace CLI acceptance; publication stayed gated