### PR TITLE
Promote release metadata fix for v0.75.0-beta

### DIFF
--- a/scripts/prepare-desktop-release-assets.mjs
+++ b/scripts/prepare-desktop-release-assets.mjs
@@ -24,16 +24,16 @@ export function prepareBuildMetadata({ outDir, platform, arch, version }) {
   const channel = prereleaseChannel(version)
 
   if (normalizedPlatform === 'macos' || normalizedPlatform === 'darwin') {
-    const source = 'latest-mac.yml'
+    // electron-builder names generic-provider metadata after the configured
+    // prerelease channel (for example beta-mac.yml), while stable builds use
+    // latest-mac.yml. Do not assume every build starts from the stable name.
+    const source = `${channel}-mac.yml`
     if (!existsSync(join(outDir, source))) {
       throw new Error(`[release-assets] missing ${source} for macOS ${arch}`)
     }
 
     if (arch === 'arm64') {
-      copyIfPresent(outDir, source, ['latest-mac-arm64.yml'])
-      if (channel !== 'latest') {
-        copyIfPresent(outDir, source, [`${channel}-mac.yml`, `${channel}-mac-arm64.yml`])
-      }
+      copyIfPresent(outDir, source, ['latest-mac-arm64.yml', `${channel}-mac-arm64.yml`])
       return
     }
 
@@ -44,8 +44,9 @@ export function prepareBuildMetadata({ outDir, platform, arch, version }) {
       if (channel !== 'latest') {
         copyIfPresent(outDir, source, [`${channel}-mac-intel.yml`, `${channel}-intel-mac.yml`])
       }
-      // Keep the established latest-mac.yml owned by the arm64 build. Intel
-      // clients request the architecture-specific compatibility alias above.
+      // Keep the generic channel metadata owned by the arm64 build. Intel
+      // clients request the architecture-specific compatibility alias above,
+      // and merged release artifacts must not contain two competing copies.
       rmSync(join(outDir, source), { force: true })
       return
     }

--- a/scripts/prepare-desktop-release-assets.spec.ts
+++ b/scripts/prepare-desktop-release-assets.spec.ts
@@ -18,22 +18,22 @@ function withTempDir(run: (dir: string) => void) {
 describe('prepareBuildMetadata', () => {
   it('keeps arm64 canonical metadata and gives Intel its own feeds', () => {
     withTempDir((dir) => {
-      writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.3-beta\n')
+      writeFileSync(join(dir, 'beta-mac.yml'), 'version: 1.2.3-beta\n')
       prepareBuildMetadata({ outDir: dir, platform: 'macOS', arch: 'x64', version: '1.2.3-beta' })
 
       expect(readFileSync(join(dir, 'latest-mac-intel.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'latest-intel-mac.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'beta-mac-intel.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'beta-intel-mac.yml'), 'utf8')).toContain('1.2.3-beta')
-      expect(() => readFileSync(join(dir, 'latest-mac.yml'))).toThrow()
+      expect(() => readFileSync(join(dir, 'beta-mac.yml'))).toThrow()
     })
 
     withTempDir((dir) => {
-      writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.3-beta\n')
+      writeFileSync(join(dir, 'beta-mac.yml'), 'version: 1.2.3-beta\n')
       prepareBuildMetadata({ outDir: dir, platform: 'macOS', arch: 'arm64', version: '1.2.3-beta' })
 
-      expect(readFileSync(join(dir, 'latest-mac.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'beta-mac.yml'), 'utf8')).toContain('1.2.3-beta')
+      expect(readFileSync(join(dir, 'beta-mac-arm64.yml'), 'utf8')).toContain('1.2.3-beta')
       expect(readFileSync(join(dir, 'latest-mac-arm64.yml'), 'utf8')).toContain('1.2.3-beta')
     })
   })


### PR DESCRIPTION
## Summary
- promote the prerelease update-metadata fix from `dev`
- unblock the already-gated `v0.75.0-beta` release without changing its version

The prior release run built and accepted the packaged Windows and macOS candidates but correctly stopped before creating a tag because the alias step expected `latest-mac.yml` instead of electron-builder's real `beta-mac.yml`.

## Validation
- PR #520: all CI and packaged smoke checks green on Windows, Apple Silicon Mac, and Intel Mac
- 2498 tests passed locally; 6 skipped
- no `v0.75.0-beta` tag or partial GitHub Release was created