### PR TITLE
feat(workspace): expose safe inbox provenance

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -43,8 +43,10 @@ alice-workspace inbox read --limit 5         # latest 5 across all workspaces
 (`--self` narrows to entries THIS workspace pushed — their `docs` paths are
 relative to your own workspace root, so you can open them straight from the
 shell. Each entry also carries a `workspaceId`; for entries from OTHER
-workspaces, that's the handle to locate their files — see below. `--limit` caps
-the window, default 20.)
+workspaces, that's the handle to locate their files — see below. Agent-produced
+entries also carry safe `origin` provenance: `runId` / `sessionId`, `resumeId`,
+`issueId`, and `agent` when available. Native runtime session ids stay hidden.
+`--limit` caps the window, default 20.)
 
 **Read & edit a peer's files** — workspaces collaborate; another workspace's docs
 are reachable. Resolve the peer's absolute dir by its `workspaceId`, then use your

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -154,7 +154,11 @@ alice-workspace inbox push --doc <path> --comments "<summary>"
 
 The launcher binds the run/issue origin; the agent does not pass its own
 identity. A no-change check should exit silently rather than generating Inbox
-noise.
+noise. `alice-workspace inbox read` returns this safe provenance to internal
+agents as `origin` (`runId` / `sessionId`, `resumeId`, `issueId`, and `agent`
+when available). For append-only entries created before `resumeId` was stamped,
+the read path joins the stored run/session handle against the live registries;
+native runtime session ids remain backend-only.
 
 When a user opens an Inbox result, the frontend supplies its OpenAlice-owned
 `resumeId`. The backend `ResumeRegistry` resolves that identity to the native

--- a/src/core/workspace-tool-center.spec.ts
+++ b/src/core/workspace-tool-center.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { makeWorkspaceResolver } from './workspace-tool-center.js'
+import type { InboxEntry } from './inbox-store.js'
+import {
+  makeInboxEntryOriginResolver,
+  makeWorkspaceResolver,
+  toSafeInboxOrigin,
+} from './workspace-tool-center.js'
 
 type Meta = { id: string; dir: string; tag: string }
 
@@ -31,5 +36,77 @@ describe('makeWorkspaceResolver', () => {
     expect(resolve('ws9')).toBeNull()
     map['ws9'] = { id: 'ws9', dir: '/wsroot/ws9', tag: 'Late' }
     expect(resolve('ws9')).toEqual({ id: 'ws9', dir: '/wsroot/ws9', tag: 'Late' })
+  })
+})
+
+describe('makeInboxEntryOriginResolver', () => {
+  const entry = (origin: InboxEntry['origin']): InboxEntry => ({
+    id: 'inbox-1',
+    ts: 1,
+    workspaceId: 'ws2',
+    comments: 'hello',
+    ...(origin ? { origin } : {}),
+  })
+
+  it('backfills a headless resumeId from the durable run registry', () => {
+    const resolve = makeInboxEntryOriginResolver(() => ({
+      headlessTasks: {
+        get: (id) => id === 'run-1' ? { resumeId: 'resume-run-1' } : null,
+      },
+      sessionRegistry: { get: () => undefined },
+    }))
+
+    expect(resolve(entry({ kind: 'headless', runId: 'run-1', agent: 'pi' })))
+      .toEqual({
+        kind: 'headless',
+        runId: 'run-1',
+        resumeId: 'resume-run-1',
+        agent: 'pi',
+      })
+  })
+
+  it('backfills an interactive resumeId from the workspace session registry', () => {
+    const resolve = makeInboxEntryOriginResolver(() => ({
+      headlessTasks: { get: () => null },
+      sessionRegistry: {
+        get: (wsId, id) => wsId === 'ws2' && id === 'session-1'
+          ? { resumeId: 'resume-session-1' }
+          : undefined,
+      },
+    }))
+
+    expect(resolve(entry({ kind: 'interactive', sessionId: 'session-1' })))
+      .toEqual({
+        kind: 'interactive',
+        sessionId: 'session-1',
+        resumeId: 'resume-session-1',
+      })
+  })
+
+  it('preserves stored provenance when it is already complete or unresolvable', () => {
+    const resolve = makeInboxEntryOriginResolver(() => null)
+    const complete = { kind: 'headless' as const, runId: 'run-1', resumeId: 'resume-1' }
+
+    expect(resolve(entry(complete))).toEqual(complete)
+    expect(resolve(entry({ kind: 'manual' }))).toEqual({ kind: 'manual' })
+    expect(resolve(entry(undefined))).toBeUndefined()
+  })
+
+  it('whitelists public fields from legacy append-only origin objects', () => {
+    const dirty = {
+      kind: 'headless' as const,
+      runId: 'run-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+      agentSessionId: 'native-secret',
+      arbitrary: true,
+    } as InboxEntry['origin']
+
+    expect(toSafeInboxOrigin(dirty)).toEqual({
+      kind: 'headless',
+      runId: 'run-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+    })
   })
 })

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -25,7 +25,7 @@
  */
 
 import type { Tool } from 'ai'
-import type { IInboxStore, InboxOrigin } from './inbox-store.js'
+import type { IInboxStore, InboxEntry, InboxOrigin } from './inbox-store.js'
 import type { IEntityStore } from './entity-store.js'
 // TYPE-ONLY: the global-issue-board shapes. Importing them as types keeps
 // core/ free of any runtime dependency on the workspaces/ module (no
@@ -56,6 +56,12 @@ export interface WorkspaceToolContext {
    *  it needs the live WorkspaceService (created after this center); the two
    *  build sites (cli.ts, mcp.ts) inject a lazy closure, tests may omit it. */
   resolveWorkspace?: (id: string) => { id: string; dir: string; tag: string } | null
+  /**
+   * Return safe provenance an agent may use to follow up on an Inbox entry.
+   * Older append-only entries can be enriched from live run/session registries
+   * without rewriting their stored history.
+   */
+  resolveInboxOrigin?: (entry: InboxEntry) => InboxOrigin | undefined
   /** Agent-INVISIBLE run provenance, resolved server-side from the
    *  `x-openalice-run` header by the MCP / CLI route (never supplied by the
    *  agent). Factories pass it through to call sites (e.g. inbox_push →
@@ -123,6 +129,13 @@ interface WorkspaceRegistryLike {
   registry: { get(id: string): { id: string; dir: string; tag: string } | undefined }
 }
 
+interface InboxOriginRegistryLike {
+  headlessTasks: { get(id: string): { resumeId: string } | null }
+  sessionRegistry: {
+    get(wsId: string, id: string): { resumeId: string } | undefined
+  }
+}
+
 /**
  * Build the `resolveWorkspace` closure both tool-context build sites
  * (cli.ts, mcp.ts) inject. Single source so the two never drift. Lazy over
@@ -137,5 +150,46 @@ export function makeWorkspaceResolver(
   return (id) => {
     const meta = getService()?.registry.get(id)
     return meta ? { id: meta.id, dir: meta.dir, tag: meta.tag } : null
+  }
+}
+
+/**
+ * Resolve agent-visible Inbox provenance without exposing native runtime ids.
+ * New entries already carry resumeId; older ones are joined at read time.
+ */
+export function makeInboxEntryOriginResolver(
+  getService: () => InboxOriginRegistryLike | null,
+): NonNullable<WorkspaceToolContext['resolveInboxOrigin']> {
+  return (entry) => {
+    const origin = toSafeInboxOrigin(entry.origin)
+    if (!origin || origin.resumeId) return origin
+
+    if (origin.kind === 'headless' && origin.runId) {
+      const resumeId = getService()?.headlessTasks.get(origin.runId)?.resumeId
+      return resumeId ? { ...origin, resumeId } : origin
+    }
+
+    if (origin.kind === 'interactive' && origin.sessionId) {
+      const resumeId = getService()?.sessionRegistry.get(
+        entry.workspaceId,
+        origin.sessionId,
+      )?.resumeId
+      return resumeId ? { ...origin, resumeId } : origin
+    }
+
+    return origin
+  }
+}
+
+/** Runtime whitelist for append-only entries that may contain legacy fields. */
+export function toSafeInboxOrigin(origin: InboxOrigin | undefined): InboxOrigin | undefined {
+  if (!origin || !['headless', 'interactive', 'manual'].includes(origin.kind)) return undefined
+  return {
+    kind: origin.kind,
+    ...(typeof origin.runId === 'string' ? { runId: origin.runId } : {}),
+    ...(typeof origin.issueId === 'string' ? { issueId: origin.issueId } : {}),
+    ...(typeof origin.sessionId === 'string' ? { sessionId: origin.sessionId } : {}),
+    ...(typeof origin.resumeId === 'string' ? { resumeId: origin.resumeId } : {}),
+    ...(typeof origin.agent === 'string' ? { agent: origin.agent } : {}),
   }
 }

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -27,7 +27,11 @@ import type { Hono } from 'hono'
 import { z } from 'zod'
 import type { Tool } from 'ai'
 import type { ToolCenter } from '../core/tool-center.js'
-import { type WorkspaceToolCenter, makeWorkspaceResolver } from '../core/workspace-tool-center.js'
+import {
+  type WorkspaceToolCenter,
+  makeInboxEntryOriginResolver,
+  makeWorkspaceResolver,
+} from '../core/workspace-tool-center.js'
 import type { IInboxStore, InboxOrigin } from '../core/inbox-store.js'
 import type { IEntityStore } from '../core/entity-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
@@ -85,6 +89,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
         // the in-workspace cross-workspace addressing path. Shared with the
         // mcp.ts build site so the two never drift.
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),
+        resolveInboxOrigin: makeInboxEntryOriginResolver(getWorkspaceService),
         ...(svc
           ? {
               board: {

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -5,7 +5,11 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import type { Plugin, EngineContext } from '../core/types.js'
 import type { ToolCenter } from '../core/tool-center.js'
-import { type WorkspaceToolCenter, makeWorkspaceResolver } from '../core/workspace-tool-center.js'
+import {
+  type WorkspaceToolCenter,
+  makeInboxEntryOriginResolver,
+  makeWorkspaceResolver,
+} from '../core/workspace-tool-center.js'
 import type { IInboxStore } from '../core/inbox-store.js'
 import type { IEntityStore } from '../core/entity-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
@@ -101,6 +105,7 @@ export class McpPlugin implements Plugin {
         // Parity with the CLI gateway so external MCP consumers get the same
         // workspace_path resolution — shared helper, so the two can't drift.
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),
+        resolveInboxOrigin: makeInboxEntryOriginResolver(getWorkspaceService),
         ...(svc
           ? {
               board: {

--- a/src/tool/inbox-read.spec.ts
+++ b/src/tool/inbox-read.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { Tool } from 'ai'
 import { inboxReadFactory } from './inbox-read.js'
-import { createMemoryInboxStore } from '../core/inbox-store.js'
+import { createMemoryInboxStore, type InboxOrigin } from '../core/inbox-store.js'
 import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
 
 const WS = 'ws-self'
@@ -20,6 +20,7 @@ async function run(tool: Tool, args: Record<string, unknown>) {
       workspace: string
       comments?: string
       docs: string[]
+      origin?: InboxOrigin
     }>
   }
 }
@@ -27,9 +28,27 @@ async function run(tool: Tool, args: Record<string, unknown>) {
 async function seeded(): Promise<WorkspaceToolContext> {
   const inboxStore = createMemoryInboxStore()
   await inboxStore.append({ workspaceId: WS, workspaceLabel: 'Mine', docs: [{ path: 'a.md' }], comments: 'first' })
-  await inboxStore.append({ workspaceId: OTHER, workspaceLabel: 'Theirs', comments: 'from elsewhere' })
+  await inboxStore.append({
+    workspaceId: OTHER,
+    workspaceLabel: 'Theirs',
+    comments: 'from elsewhere',
+    origin: {
+      kind: 'headless',
+      runId: 'run-peer',
+      issueId: 'daily-scan',
+      agent: 'pi',
+    },
+  })
   await inboxStore.append({ workspaceId: WS, workspaceLabel: 'Mine', docs: [{ path: 'b.md' }, { path: 'c.md' }] })
-  return { workspaceId: WS, workspaceLabel: 'Mine', inboxStore, entityStore: {} as never }
+  return {
+    workspaceId: WS,
+    workspaceLabel: 'Mine',
+    inboxStore,
+    entityStore: {} as never,
+    resolveInboxOrigin: (entry) => entry.origin?.runId === 'run-peer'
+      ? { ...entry.origin, resumeId: 'resume-peer' }
+      : entry.origin,
+  }
 }
 
 describe('inbox_read', () => {
@@ -61,6 +80,20 @@ describe('inbox_read', () => {
     expect(foreign?.workspaceId).toBe(OTHER)
     // self entries carry this workspace's own id
     expect(res.entries.filter((e) => e.mine).every((e) => e.workspaceId === WS)).toBe(true)
+  })
+
+  it('surfaces safe, enriched provenance for following up with the originating agent', async () => {
+    const tool = inboxReadFactory.build(await seeded())
+    const res = await run(tool, {})
+    const foreign = res.entries.find((entry) => !entry.mine)
+
+    expect(foreign?.origin).toEqual({
+      kind: 'headless',
+      runId: 'run-peer',
+      resumeId: 'resume-peer',
+      issueId: 'daily-scan',
+      agent: 'pi',
+    })
   })
 
   it('`limit` caps the newest-first window and reports hasMore', async () => {

--- a/src/tool/inbox-read.ts
+++ b/src/tool/inbox-read.ts
@@ -21,7 +21,11 @@
 
 import { tool } from 'ai'
 import { z } from 'zod'
-import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import {
+  toSafeInboxOrigin,
+  type WorkspaceToolFactory,
+  type WorkspaceToolContext,
+} from '../core/workspace-tool-center.js'
 
 const DEFAULT_LIMIT = 20
 
@@ -37,6 +41,8 @@ export const inboxReadFactory: WorkspaceToolFactory = {
         "Pass `self` to limit the list to entries THIS workspace pushed; their `docs` paths are relative to your own workspace root, so you can open them directly with your shell (cat / read the path).",
         '',
         'Entries from other workspaces each carry a `workspaceId` — resolve it with `workspace_path` (CLI: `alice-workspace peer path`) to locate and read that peer\'s files.',
+        '',
+        'When an entry came from an agent run/session, `origin` carries its safe OpenAlice provenance (`runId` / `sessionId`, `resumeId`, `issueId`, `agent`). Native runtime session ids are never exposed.',
         '',
         `\`limit\` caps how many most-recent entries come back (newest first; default ${DEFAULT_LIMIT}).`,
       ].join('\n'),
@@ -64,19 +70,23 @@ export const inboxReadFactory: WorkspaceToolFactory = {
             ok: true as const,
             count: entries.length,
             hasMore,
-            entries: entries.map((e) => ({
-              id: e.id,
-              ts: new Date(e.ts).toISOString(),
-              // mine === true → the doc paths below are relative to your own
-              // workspace root and you can open them with shell tools.
-              mine: e.workspaceId === ctx.workspaceId,
-              // The dir-resolvable id (vs the human `workspace` label). For a
-              // peer entry, feed this to `workspace_path` to locate its files.
-              workspaceId: e.workspaceId,
-              workspace: e.workspaceLabel ?? e.workspaceId,
-              comments: e.comments,
-              docs: (e.docs ?? []).map((d) => d.path),
-            })),
+            entries: entries.map((e) => {
+              const origin = toSafeInboxOrigin(ctx.resolveInboxOrigin?.(e) ?? e.origin)
+              return {
+                id: e.id,
+                ts: new Date(e.ts).toISOString(),
+                // mine === true → the doc paths below are relative to your own
+                // workspace root and you can open them with shell tools.
+                mine: e.workspaceId === ctx.workspaceId,
+                // The dir-resolvable id (vs the human `workspace` label). For a
+                // peer entry, feed this to `workspace_path` to locate its files.
+                workspaceId: e.workspaceId,
+                workspace: e.workspaceLabel ?? e.workspaceId,
+                comments: e.comments,
+                docs: (e.docs ?? []).map((d) => d.path),
+                ...(origin ? { origin } : {}),
+              }
+            }),
           }
         } catch (err) {
           return {


### PR DESCRIPTION
## Summary
- expose safe Inbox provenance through `alice-workspace inbox read`
- backfill missing `resumeId` values for legacy append-only entries by joining their stored run/session handle against the live registries
- whitelist public origin fields so historical `agentSessionId` or arbitrary extra fields never cross the Workspace CLI/MCP boundary
- document the provenance contract for agents and maintainers

## Real scenario
From workspace `headless-chain-jul11`, the real CLI can now trace:

- Inbox `0509fdc8-...` to issue `trump-semis-oil-thesis`, Pi, run `52eef140-...`, and resume `c1bbb653-...`
- Inbox `6d4ba2ec-...` to issue `financial-industrial-rotation-scan`, Pi, run `87a208ec-...`, and resume `a9bcdaab-...`

The first historical entry contained an undeclared native `agentSessionId`; the public projection strips it.

## Verification
- `pnpm vitest run src/core/workspace-tool-center.spec.ts src/tool/inbox-read.spec.ts src/server/cli.spec.ts src/server/cli-commands.spec.ts src/workspaces/cli/shim.spec.ts` (53 passed)
- `npx tsc --noEmit`
- `pnpm test` (2534 passed, 6 skipped)
- real `alice-workspace inbox read --limit 2` through `http://127.0.0.1:47332/cli`

## Boundary touch
- Workspace CLI/MCP read projection and append-only Inbox provenance
- no persisted data rewrite or migration
- no native runtime session ids exposed
- no trading, credential, Guardian, UI, or package changes

## Follow-up
This PR only makes the originating conversation addressable. A separate contribution will add the CLI command that asks that conversation and reads the resulting headless reply.
