### PR TITLE
Add durable Session provenance and safe workspace indexes

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Agent collaboration on your shell PATH via the `alice-workspace` CLI: push
   finished work to the user's Inbox (`inbox push`, with repeatable `--doc`
   file attachments), read the inbox back (`inbox read`, `--self` for your own
-  pushes), locate a peer workspace's files to read/edit them (`peer path`),
+  pushes), locate a peer workspace's files (`peer path`) and product Sessions
+  (`peer sessions`),
   track entities across workspaces (`track`), and read & manage the
   cross-workspace issue board (`issue list`/`show`/`create`/`update`/`comment`).
   Use for: "push my findings to the inbox", "surface this report to the user",
@@ -55,6 +56,7 @@ own file tools:
 ```bash
 # --id is the `workspaceId` from an inbox_read entry (a uuid), e.g.:
 alice-workspace peer path --id 550e8400-e29b-41d4-a716-446655440000
+alice-workspace peer sessions --id 550e8400-e29b-41d4-a716-446655440000
 # -> { path: "/…/workspaces/550e8400-…", tag, id }
 # then read <path>/<the doc path from the inbox entry> with your native tools
 ```
@@ -84,7 +86,8 @@ It's *what's on the plate* when you've lost the thread — scan it when you star
 ```bash
 alice-workspace issue list                  # startup-safe summary: local + active urgent/high/medium rows
 alice-workspace issue list --mode detailed  # full global board, including low-priority scheduled noise
-alice-workspace issue show --id <name>      # one issue in full — body + run history + inbox reports (resolves the name across the board)
+alice-workspace issue show --id <name>      # compact issue + resumeId run/report references
+alice-workspace issue show --id <name> --mode detailed  # every execution prompt + full reports
 alice-workspace issue create --title "…"    # a new issue on THIS workspace's board
 alice-workspace issue update --id <id> --status in_progress
 alice-workspace issue comment --id <id> --text "progress note / finding"

--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -43,8 +43,10 @@ alice-workspace inbox read --limit 5         # latest 5 across all workspaces
 (`--self` narrows to entries THIS workspace pushed — their `docs` paths are
 relative to your own workspace root, so you can open them straight from the
 shell. Each entry also carries a `workspaceId`; for entries from OTHER
-workspaces, that's the handle to locate their files — see below. `--limit` caps
-the window, default 20.)
+workspaces, that's the handle to locate their files — see below. Agent-produced
+entries also carry safe `origin` provenance: `runId` / `sessionId`, `resumeId`,
+`issueId`, and `agent` when available. Native runtime session ids stay hidden.
+`--limit` caps the window, default 20.)
 
 **Read & edit a peer's files** — workspaces collaborate; another workspace's docs
 are reachable. Resolve the peer's absolute dir by its `workspaceId`, then use your

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -364,6 +364,9 @@ useful without starting or messaging an agent.
 Phase 1 answers “what produced or changed this, and which Session was
 responsible?” It owns:
 
+- a safe Workspace Session directory (`alice-workspace peer sessions`) whose
+  only conversation handle is `resumeId`; it is an audit/addressing surface,
+  not permission to choose an arbitrary old Session when provenance is absent;
 - the standard `SessionOrigin` envelope;
 - immutable artifact occurrence edges and their forward/reverse indexes;
 - reliable propagation of `resumeId`, Workspace, runtime kind, and optional

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -155,7 +155,11 @@ alice-workspace inbox push --doc <path> --comments "<summary>"
 
 The launcher binds the run/issue origin; the agent does not pass its own
 identity. A no-change check should exit silently rather than generating Inbox
-noise.
+noise. `alice-workspace inbox read` returns this safe provenance to internal
+agents as `origin` (`runId` / `sessionId`, `resumeId`, `issueId`, and `agent`
+when available). For append-only entries created before `resumeId` was stamped,
+the read path joins the stored run/session handle against the live registries;
+native runtime session ids remain backend-only.
 
 When a user opens an Inbox result, the frontend supplies its OpenAlice-owned
 `resumeId`. The backend `ResumeRegistry` resolves that identity to the native

--- a/src/core/provenance-store.spec.ts
+++ b/src/core/provenance-store.spec.ts
@@ -1,0 +1,87 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ArtifactProvenanceStore, sessionOriginFromInboxOrigin } from './provenance-store.js'
+
+const dirs: string[] = []
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function store() {
+  const dir = await mkdtemp(join(tmpdir(), 'provenance-store-'))
+  dirs.push(dir)
+  const path = join(dir, 'artifact-provenance.json')
+  const logger = { warn: vi.fn() }
+  return { path, logger, value: await ArtifactProvenanceStore.load(path, logger) }
+}
+
+describe('ArtifactProvenanceStore', () => {
+  it('persists immutable occurrences and queries a report across revisions', async () => {
+    const { path, logger, value } = await store()
+    const origin = {
+      kind: 'session' as const,
+      workspaceId: 'ws-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+      execution: { kind: 'headless' as const, taskId: 'task-1' },
+    }
+    await value.append({
+      artifact: { kind: 'report', workspaceId: 'ws-1', path: 'research/a.md', revision: 'abc' },
+      action: 'updated',
+      origin,
+      at: 10,
+    })
+    await value.append({
+      artifact: { kind: 'report', workspaceId: 'ws-1', path: 'research/a.md', revision: 'def' },
+      action: 'sent',
+      origin,
+      at: 20,
+    })
+
+    expect(value.list({ artifact: { kind: 'report', workspaceId: 'ws-1', path: 'research/a.md' } }))
+      .toHaveLength(2)
+    expect(value.latest({ resumeId: origin.resumeId })?.action).toBe('sent')
+
+    const reloaded = await ArtifactProvenanceStore.load(path, logger)
+    expect(reloaded.list({ resumeId: origin.resumeId }).map((record) => record.action))
+      .toEqual(['sent', 'updated'])
+    expect(JSON.parse(await readFile(path, 'utf8'))).toMatchObject({ version: 1 })
+  })
+
+  it('deduplicates a stable occurrence fingerprint', async () => {
+    const { value } = await store()
+    const input = {
+      artifact: { kind: 'inbox' as const, inboxEntryId: 'entry-1' },
+      action: 'sent' as const,
+      origin: { kind: 'human' as const },
+      at: 1,
+      fingerprint: 'inbox:entry-1:sent',
+    }
+    const first = await value.append(input)
+    const second = await value.append({ ...input, at: 2 })
+    expect(second.id).toBe(first.id)
+    expect(value.list()).toHaveLength(1)
+  })
+
+  it('derives a safe Session origin without exposing native ids', () => {
+    expect(sessionOriginFromInboxOrigin('ws-1', {
+      kind: 'headless',
+      runId: 'task-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+    })).toEqual({
+      kind: 'session',
+      workspaceId: 'ws-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+      execution: { kind: 'headless', taskId: 'task-1' },
+    })
+    expect(sessionOriginFromInboxOrigin('ws-1', {
+      kind: 'headless', runId: 'task-1', agent: 'pi',
+    })).toBeNull()
+  })
+})

--- a/src/core/provenance-store.ts
+++ b/src/core/provenance-store.ts
@@ -1,0 +1,191 @@
+/**
+ * Durable Session -> artifact provenance.
+ *
+ * `resumeId` is the product Session identity. Native runtime session ids never
+ * enter this store. Records are immutable attribution occurrences; mutable
+ * artifacts accumulate edges instead of overwriting one "author" field.
+ */
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+import { z } from 'zod'
+
+import type { InboxOrigin } from './inbox-store.js'
+
+const executionSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('headless'), taskId: z.string().min(1) }),
+  z.object({ kind: z.literal('interactive'), sessionRecordId: z.string().min(1) }),
+])
+
+export const sessionOriginSchema = z.object({
+  kind: z.literal('session'),
+  workspaceId: z.string().min(1),
+  resumeId: z.string().min(1),
+  agent: z.string().min(1),
+  execution: executionSchema.optional(),
+})
+export type SessionOrigin = z.infer<typeof sessionOriginSchema>
+
+export const artifactRefSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('inbox'), inboxEntryId: z.string().min(1) }),
+  z.object({ kind: z.literal('issue'), workspaceId: z.string().min(1), issueId: z.string().min(1) }),
+  z.object({
+    kind: z.literal('report'),
+    workspaceId: z.string().min(1),
+    path: z.string().min(1),
+    revision: z.string().min(1).optional(),
+  }),
+  z.object({
+    kind: z.literal('trade-decision'),
+    accountId: z.string().min(1),
+    decisionId: z.string().min(1),
+  }),
+])
+export type ArtifactRef = z.infer<typeof artifactRefSchema>
+
+export const provenanceActions = ['created', 'updated', 'commented', 'sent', 'decided'] as const
+export type ProvenanceAction = (typeof provenanceActions)[number]
+
+const originSchema = z.union([
+  sessionOriginSchema,
+  z.object({ kind: z.literal('human') }),
+  z.object({ kind: z.literal('external'), system: z.string().min(1) }),
+  z.object({ kind: z.literal('unknown'), reason: z.string().min(1) }),
+])
+export type ArtifactOrigin = z.infer<typeof originSchema>
+
+const recordSchema = z.object({
+  id: z.string().min(1),
+  artifact: artifactRefSchema,
+  action: z.enum(provenanceActions),
+  origin: originSchema,
+  at: z.number().finite(),
+  fingerprint: z.string().min(1).optional(),
+})
+export type ProvenanceRecord = z.infer<typeof recordSchema>
+
+export interface ProvenanceQuery {
+  artifact?: ArtifactRef
+  action?: ProvenanceAction
+  resumeId?: string
+  limit?: number
+}
+
+export interface IProvenanceStore {
+  append(input: Omit<ProvenanceRecord, 'id'> & { id?: string }): Promise<ProvenanceRecord>
+  list(query?: ProvenanceQuery): ProvenanceRecord[]
+  latest(query: ProvenanceQuery): ProvenanceRecord | null
+}
+
+interface LoggerLike {
+  warn(message: string, meta?: Record<string, unknown>): void
+}
+
+export class ArtifactProvenanceStore implements IProvenanceStore {
+  private records: ProvenanceRecord[] = []
+  private flushChain: Promise<void> = Promise.resolve()
+
+  private constructor(
+    private readonly path: string,
+    private readonly logger: LoggerLike,
+  ) {}
+
+  static async load(path: string, logger: LoggerLike): Promise<ArtifactProvenanceStore> {
+    const store = new ArtifactProvenanceStore(path, logger)
+    await store.read()
+    return store
+  }
+
+  private async read(): Promise<void> {
+    try {
+      const parsed = JSON.parse(await readFile(this.path, 'utf8')) as { records?: unknown[] }
+      this.records = (Array.isArray(parsed.records) ? parsed.records : [])
+        .map((value) => recordSchema.safeParse(value))
+        .filter((result): result is z.ZodSafeParseSuccess<ProvenanceRecord> => result.success)
+        .map((result) => result.data)
+    } catch {
+      this.records = []
+    }
+  }
+
+  async append(input: Omit<ProvenanceRecord, 'id'> & { id?: string }): Promise<ProvenanceRecord> {
+    const candidate = recordSchema.parse({ ...input, id: input.id ?? randomUUID() })
+    if (candidate.fingerprint) {
+      const existing = this.records.find((record) => record.fingerprint === candidate.fingerprint)
+      if (existing) return existing
+    }
+    this.records.push(candidate)
+    await this.flush()
+    return candidate
+  }
+
+  list(query: ProvenanceQuery = {}): ProvenanceRecord[] {
+    let records = this.records.filter((record) =>
+      (!query.artifact || artifactMatches(record.artifact, query.artifact)) &&
+      (!query.action || record.action === query.action) &&
+      (!query.resumeId || (record.origin.kind === 'session' && record.origin.resumeId === query.resumeId)),
+    )
+    records = [...records].sort((a, b) => b.at - a.at)
+    return query.limit && query.limit > 0 ? records.slice(0, query.limit) : records
+  }
+
+  latest(query: ProvenanceQuery): ProvenanceRecord | null {
+    return this.list({ ...query, limit: 1 })[0] ?? null
+  }
+
+  private async flush(): Promise<void> {
+    const next = this.flushChain.then(() => this.flushNow())
+    this.flushChain = next.catch(() => undefined)
+    await next
+  }
+
+  private async flushNow(): Promise<void> {
+    try {
+      await mkdir(dirname(this.path), { recursive: true })
+      const tmp = `${this.path}.tmp`
+      await writeFile(tmp, JSON.stringify({ version: 1, records: this.records }, null, 2) + '\n', {
+        mode: 0o600,
+      })
+      await rename(tmp, this.path)
+    } catch (err) {
+      this.logger.warn('provenance_store.flush_failed', { err })
+    }
+  }
+}
+
+/** Undefined revision in a query means "all revisions of this report path". */
+function artifactMatches(record: ArtifactRef, query: ArtifactRef): boolean {
+  if (record.kind !== query.kind) return false
+  if (record.kind === 'inbox' && query.kind === 'inbox') return record.inboxEntryId === query.inboxEntryId
+  if (record.kind === 'issue' && query.kind === 'issue') {
+    return record.workspaceId === query.workspaceId && record.issueId === query.issueId
+  }
+  if (record.kind === 'report' && query.kind === 'report') {
+    return record.workspaceId === query.workspaceId && record.path === query.path &&
+      (query.revision === undefined || record.revision === query.revision)
+  }
+  if (record.kind === 'trade-decision' && query.kind === 'trade-decision') {
+    return record.accountId === query.accountId && record.decisionId === query.decisionId
+  }
+  return false
+}
+
+/** Convert the already-authoritative request origin into the common envelope. */
+export function sessionOriginFromInboxOrigin(
+  workspaceId: string,
+  origin: InboxOrigin | undefined,
+): SessionOrigin | null {
+  if (!origin?.resumeId || !origin.agent) return null
+  return {
+    kind: 'session',
+    workspaceId,
+    resumeId: origin.resumeId,
+    agent: origin.agent,
+    ...(origin.kind === 'headless' && origin.runId
+      ? { execution: { kind: 'headless' as const, taskId: origin.runId } }
+      : origin.kind === 'interactive' && origin.sessionId
+        ? { execution: { kind: 'interactive' as const, sessionRecordId: origin.sessionId } }
+        : {}),
+  }
+}

--- a/src/core/workspace-tool-center.spec.ts
+++ b/src/core/workspace-tool-center.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { makeWorkspaceResolver } from './workspace-tool-center.js'
+import type { InboxEntry } from './inbox-store.js'
+import {
+  makeInboxEntryOriginResolver,
+  makeWorkspaceResolver,
+  toSafeInboxOrigin,
+} from './workspace-tool-center.js'
 
 type Meta = { id: string; dir: string; tag: string }
 
@@ -31,5 +36,77 @@ describe('makeWorkspaceResolver', () => {
     expect(resolve('ws9')).toBeNull()
     map['ws9'] = { id: 'ws9', dir: '/wsroot/ws9', tag: 'Late' }
     expect(resolve('ws9')).toEqual({ id: 'ws9', dir: '/wsroot/ws9', tag: 'Late' })
+  })
+})
+
+describe('makeInboxEntryOriginResolver', () => {
+  const entry = (origin: InboxEntry['origin']): InboxEntry => ({
+    id: 'inbox-1',
+    ts: 1,
+    workspaceId: 'ws2',
+    comments: 'hello',
+    ...(origin ? { origin } : {}),
+  })
+
+  it('backfills a headless resumeId from the durable run registry', () => {
+    const resolve = makeInboxEntryOriginResolver(() => ({
+      headlessTasks: {
+        get: (id) => id === 'run-1' ? { resumeId: 'resume-run-1' } : null,
+      },
+      sessionRegistry: { get: () => undefined },
+    }))
+
+    expect(resolve(entry({ kind: 'headless', runId: 'run-1', agent: 'pi' })))
+      .toEqual({
+        kind: 'headless',
+        runId: 'run-1',
+        resumeId: 'resume-run-1',
+        agent: 'pi',
+      })
+  })
+
+  it('backfills an interactive resumeId from the workspace session registry', () => {
+    const resolve = makeInboxEntryOriginResolver(() => ({
+      headlessTasks: { get: () => null },
+      sessionRegistry: {
+        get: (wsId, id) => wsId === 'ws2' && id === 'session-1'
+          ? { resumeId: 'resume-session-1' }
+          : undefined,
+      },
+    }))
+
+    expect(resolve(entry({ kind: 'interactive', sessionId: 'session-1' })))
+      .toEqual({
+        kind: 'interactive',
+        sessionId: 'session-1',
+        resumeId: 'resume-session-1',
+      })
+  })
+
+  it('preserves stored provenance when it is already complete or unresolvable', () => {
+    const resolve = makeInboxEntryOriginResolver(() => null)
+    const complete = { kind: 'headless' as const, runId: 'run-1', resumeId: 'resume-1' }
+
+    expect(resolve(entry(complete))).toEqual(complete)
+    expect(resolve(entry({ kind: 'manual' }))).toEqual({ kind: 'manual' })
+    expect(resolve(entry(undefined))).toBeUndefined()
+  })
+
+  it('whitelists public fields from legacy append-only origin objects', () => {
+    const dirty = {
+      kind: 'headless' as const,
+      runId: 'run-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+      agentSessionId: 'native-secret',
+      arbitrary: true,
+    } as InboxEntry['origin']
+
+    expect(toSafeInboxOrigin(dirty)).toEqual({
+      kind: 'headless',
+      runId: 'run-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+    })
   })
 })

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -32,6 +32,7 @@ import type { IProvenanceStore } from './provenance-store.js'
 // core/ free of any runtime dependency on the workspaces/ module (no
 // core→workspaces coupling), while letting the board reader below be typed.
 import type { IssuesSnapshot, IssueDetail, WikilinkIssueRef } from '../workspaces/issues/board.js'
+import type { WorkspaceSessionDirectory } from '../workspaces/session-directory.js'
 
 // ==================== Context handed to factories ====================
 
@@ -65,6 +66,9 @@ export interface WorkspaceToolContext {
    * without rewriting their stored history.
    */
   resolveInboxOrigin?: (entry: InboxEntry) => InboxOrigin | undefined
+  /** Safe per-workspace conversation directory. It exposes product resumeIds,
+   * never adapter-native session ids or launcher record ids. */
+  sessionDirectory?: (workspaceId: string, limit?: number) => Promise<WorkspaceSessionDirectory | null>
   /** Agent-INVISIBLE run provenance, resolved server-side from the
    *  `x-openalice-run` header by the MCP / CLI route (never supplied by the
    *  agent). Factories pass it through to call sites (e.g. inbox_push →

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -25,7 +25,7 @@
  */
 
 import type { Tool } from 'ai'
-import type { IInboxStore, InboxOrigin } from './inbox-store.js'
+import type { IInboxStore, InboxEntry, InboxOrigin } from './inbox-store.js'
 import type { IEntityStore } from './entity-store.js'
 import type { IProvenanceStore } from './provenance-store.js'
 // TYPE-ONLY: the global-issue-board shapes. Importing them as types keeps
@@ -59,6 +59,12 @@ export interface WorkspaceToolContext {
    *  it needs the live WorkspaceService (created after this center); the two
    *  build sites (cli.ts, mcp.ts) inject a lazy closure, tests may omit it. */
   resolveWorkspace?: (id: string) => { id: string; dir: string; tag: string } | null
+  /**
+   * Return safe provenance an agent may use to follow up on an Inbox entry.
+   * Older append-only entries can be enriched from live run/session registries
+   * without rewriting their stored history.
+   */
+  resolveInboxOrigin?: (entry: InboxEntry) => InboxOrigin | undefined
   /** Agent-INVISIBLE run provenance, resolved server-side from the
    *  `x-openalice-run` header by the MCP / CLI route (never supplied by the
    *  agent). Factories pass it through to call sites (e.g. inbox_push →
@@ -126,6 +132,13 @@ interface WorkspaceRegistryLike {
   registry: { get(id: string): { id: string; dir: string; tag: string } | undefined }
 }
 
+interface InboxOriginRegistryLike {
+  headlessTasks: { get(id: string): { resumeId: string } | null }
+  sessionRegistry: {
+    get(wsId: string, id: string): { resumeId: string } | undefined
+  }
+}
+
 /**
  * Build the `resolveWorkspace` closure both tool-context build sites
  * (cli.ts, mcp.ts) inject. Single source so the two never drift. Lazy over
@@ -140,5 +153,46 @@ export function makeWorkspaceResolver(
   return (id) => {
     const meta = getService()?.registry.get(id)
     return meta ? { id: meta.id, dir: meta.dir, tag: meta.tag } : null
+  }
+}
+
+/**
+ * Resolve agent-visible Inbox provenance without exposing native runtime ids.
+ * New entries already carry resumeId; older ones are joined at read time.
+ */
+export function makeInboxEntryOriginResolver(
+  getService: () => InboxOriginRegistryLike | null,
+): NonNullable<WorkspaceToolContext['resolveInboxOrigin']> {
+  return (entry) => {
+    const origin = toSafeInboxOrigin(entry.origin)
+    if (!origin || origin.resumeId) return origin
+
+    if (origin.kind === 'headless' && origin.runId) {
+      const resumeId = getService()?.headlessTasks.get(origin.runId)?.resumeId
+      return resumeId ? { ...origin, resumeId } : origin
+    }
+
+    if (origin.kind === 'interactive' && origin.sessionId) {
+      const resumeId = getService()?.sessionRegistry.get(
+        entry.workspaceId,
+        origin.sessionId,
+      )?.resumeId
+      return resumeId ? { ...origin, resumeId } : origin
+    }
+
+    return origin
+  }
+}
+
+/** Runtime whitelist for append-only entries that may contain legacy fields. */
+export function toSafeInboxOrigin(origin: InboxOrigin | undefined): InboxOrigin | undefined {
+  if (!origin || !['headless', 'interactive', 'manual'].includes(origin.kind)) return undefined
+  return {
+    kind: origin.kind,
+    ...(typeof origin.runId === 'string' ? { runId: origin.runId } : {}),
+    ...(typeof origin.issueId === 'string' ? { issueId: origin.issueId } : {}),
+    ...(typeof origin.sessionId === 'string' ? { sessionId: origin.sessionId } : {}),
+    ...(typeof origin.resumeId === 'string' ? { resumeId: origin.resumeId } : {}),
+    ...(typeof origin.agent === 'string' ? { agent: origin.agent } : {}),
   }
 }

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -27,6 +27,7 @@
 import type { Tool } from 'ai'
 import type { IInboxStore, InboxOrigin } from './inbox-store.js'
 import type { IEntityStore } from './entity-store.js'
+import type { IProvenanceStore } from './provenance-store.js'
 // TYPE-ONLY: the global-issue-board shapes. Importing them as types keeps
 // core/ free of any runtime dependency on the workspaces/ module (no
 // core→workspaces coupling), while letting the board reader below be typed.
@@ -49,6 +50,8 @@ export interface WorkspaceToolContext {
    *  entity_upsert / entity_search read and write. Same injection rationale
    *  as inboxStore. */
   entityStore: IEntityStore
+  /** Durable Session -> artifact occurrence trail. Optional for older/tests. */
+  provenanceStore?: IProvenanceStore
   /** Resolve ANY workspace's location by id (not just this one) — the backing
    *  for cross-workspace collaboration: an inbox entry from a peer carries its
    *  workspaceId, and `workspace_path` turns that into the peer's absolute dir

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ import { WorkspaceToolCenter } from './core/workspace-tool-center.js'
 import { inboxPushFactory } from './tool/inbox-push.js'
 import { inboxReadFactory } from './tool/inbox-read.js'
 import { workspacePathFactory } from './tool/workspace-path.js'
+import { workspaceSessionsFactory } from './tool/workspace-sessions.js'
 import { createEntityStore } from './core/entity-store.js'
 import { entityUpsertFactory } from './tool/entity-upsert.js'
 import { entitySearchFactory } from './tool/entity-search.js'
@@ -109,6 +110,7 @@ async function main() {
   workspaceToolCenter.register(inboxPushFactory)
   workspaceToolCenter.register(inboxReadFactory)
   workspaceToolCenter.register(workspacePathFactory)
+  workspaceToolCenter.register(workspaceSessionsFactory)
   workspaceToolCenter.register(entityUpsertFactory)
   workspaceToolCenter.register(entitySearchFactory)
   for (const f of issueToolFactories) workspaceToolCenter.register(f)

--- a/src/migrations/0016_artifact_provenance_store.spec.ts
+++ b/src/migrations/0016_artifact_provenance_store.spec.ts
@@ -1,0 +1,33 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ensureArtifactProvenanceStore } from './0016_artifact_provenance_store/index.js'
+
+const dirs: string[] = []
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('0016_artifact_provenance_store', () => {
+  it('creates an empty v1 store once', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'migration-provenance-'))
+    dirs.push(root)
+    await expect(ensureArtifactProvenanceStore(root)).resolves.toEqual({ created: true })
+    await expect(ensureArtifactProvenanceStore(root)).resolves.toEqual({ created: false })
+    expect(JSON.parse(await readFile(join(root, 'state', 'artifact-provenance.json'), 'utf8')))
+      .toEqual({ version: 1, records: [] })
+  })
+
+  it('does not overwrite an unexpected existing file', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'migration-provenance-corrupt-'))
+    dirs.push(root)
+    const path = join(root, 'state', 'artifact-provenance.json')
+    await mkdir(join(root, 'state'), { recursive: true })
+    await writeFile(path, '{"unexpected":true}\n')
+    await expect(ensureArtifactProvenanceStore(root)).resolves.toEqual({ created: false })
+    expect(await readFile(path, 'utf8')).toBe('{"unexpected":true}\n')
+  })
+})

--- a/src/migrations/0016_artifact_provenance_store/index.ts
+++ b/src/migrations/0016_artifact_provenance_store/index.ts
@@ -1,0 +1,41 @@
+/** 0016_artifact_provenance_store — create the durable Session -> artifact trail. */
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import type { Migration } from '../types.js'
+
+function defaultLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+export async function ensureArtifactProvenanceStore(
+  launcherRoot: string = defaultLauncherRoot(),
+): Promise<{ created: boolean }> {
+  const path = join(launcherRoot, 'state', 'artifact-provenance.json')
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf8')) as { version?: unknown; records?: unknown }
+    if (parsed.version === 1 && Array.isArray(parsed.records)) return { created: false }
+    // Preserve an unexpected/corrupt file for operator inspection. Runtime load
+    // treats it as empty; the migration must not destroy unknown user state.
+    return { created: false }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') return { created: false }
+  }
+
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp`
+  await writeFile(tmp, JSON.stringify({ version: 1, records: [] }, null, 2) + '\n', { mode: 0o600 })
+  await rename(tmp, path)
+  return { created: true }
+}
+
+export const migration: Migration = {
+  id: '0016_artifact_provenance_store',
+  appVersion: '0.75.0-beta',
+  introducedAt: '2026-07-11',
+  affects: ['workspaces/state/artifact-provenance.json'],
+  summary: 'Create the durable product Session to artifact provenance store.',
+  rationale: 'Reports, Inbox messages, Issues, and trade decisions need one safe resumeId-based attribution index before cross-Session collaboration.',
+  up: async () => { await ensureArtifactProvenanceStore() },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -15,3 +15,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0013_session_run_source` | 0.74.0-beta | 2026-07-11 | workspaces/state/sessions/*.json | Version Session records for durable headless-run provenance and idempotent return-to-session navigation. |
 | `0014_headless_resume_identity` | 0.75.0-beta | 2026-07-11 | workspaces/state/headless-tasks.json | Assign durable resumeId values to historical headless runs so execution identity and resumable conversation identity remain distinct. |
 | `0015_resume_identity_registry` | 0.75.0-beta | 2026-07-11 | workspaces/state/resume-identities.json, workspaces/state/sessions/*.json | Create the backend resumeId to native runtime session-id registry. |
+| `0016_artifact_provenance_store` | 0.75.0-beta | 2026-07-11 | workspaces/state/artifact-provenance.json | Create the durable product Session to artifact provenance store. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -27,6 +27,7 @@ import { migration as migration_0012_recent_chat_workspace_preference } from './
 import { migration as migration_0013_session_run_source } from './0013_session_run_source/index.js'
 import { migration as migration_0014_headless_resume_identity } from './0014_headless_resume_identity/index.js'
 import { migration as migration_0015_resume_identity_registry } from './0015_resume_identity_registry/index.js'
+import { migration as migration_0016_artifact_provenance_store } from './0016_artifact_provenance_store/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -37,4 +38,5 @@ export const REGISTRY: Migration[] = [
   migration_0013_session_run_source,
   migration_0014_headless_resume_identity,
   migration_0015_resume_identity_registry,
+  migration_0016_artifact_provenance_store,
 ]

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -19,6 +19,7 @@ import { createThinkingTools } from '../tool/thinking.js'
 import { inboxPushFactory } from '../tool/inbox-push.js'
 import { inboxReadFactory } from '../tool/inbox-read.js'
 import { workspacePathFactory } from '../tool/workspace-path.js'
+import { workspaceSessionsFactory } from '../tool/workspace-sessions.js'
 import { entityUpsertFactory } from '../tool/entity-upsert.js'
 import { entitySearchFactory } from '../tool/entity-search.js'
 import { issueToolFactories } from '../tool/issue-tools.js'
@@ -84,6 +85,7 @@ describe('CLI_EXPORTS — workspace export (scoped collaboration tools)', () => 
   wtc.register(inboxPushFactory)
   wtc.register(inboxReadFactory)
   wtc.register(workspacePathFactory)
+  wtc.register(workspaceSessionsFactory)
   wtc.register(entityUpsertFactory)
   wtc.register(entitySearchFactory)
   for (const f of issueToolFactories) wtc.register(f)

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -163,6 +163,7 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       // that peer's files with native tools — cross-workspace collaboration.
       peer: {
         path: 'workspace_path',
+        sessions: 'workspace_sessions',
       },
       // track: the durable cross-workspace tracked-entity index ([[name]]).
       track: {

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -91,6 +91,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
         // mcp.ts build site so the two never drift.
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),
         resolveInboxOrigin: makeInboxEntryOriginResolver(getWorkspaceService),
+        ...(svc ? { sessionDirectory: (id: string, limit?: number) => svc.sessionDirectory(id, limit) } : {}),
         ...(svc
           ? {
               board: {

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -27,7 +27,11 @@ import type { Hono } from 'hono'
 import { z } from 'zod'
 import type { Tool } from 'ai'
 import type { ToolCenter } from '../core/tool-center.js'
-import { type WorkspaceToolCenter, makeWorkspaceResolver } from '../core/workspace-tool-center.js'
+import {
+  type WorkspaceToolCenter,
+  makeInboxEntryOriginResolver,
+  makeWorkspaceResolver,
+} from '../core/workspace-tool-center.js'
 import type { IInboxStore, InboxOrigin } from '../core/inbox-store.js'
 import type { IEntityStore } from '../core/entity-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
@@ -86,6 +90,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
         // the in-workspace cross-workspace addressing path. Shared with the
         // mcp.ts build site so the two never drift.
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),
+        resolveInboxOrigin: makeInboxEntryOriginResolver(getWorkspaceService),
         ...(svc
           ? {
               board: {

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -81,6 +81,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
         workspaceLabel: ws.tag,
         inboxStore,
         entityStore,
+        ...(svc ? { provenanceStore: svc.provenanceStore } : {}),
         // Lets workspace_path resolve ANY peer's dir (not just the caller) —
         // the in-workspace cross-workspace addressing path. Shared with the
         // mcp.ts build site so the two never drift.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -5,7 +5,11 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import type { Plugin, EngineContext } from '../core/types.js'
 import type { ToolCenter } from '../core/tool-center.js'
-import { type WorkspaceToolCenter, makeWorkspaceResolver } from '../core/workspace-tool-center.js'
+import {
+  type WorkspaceToolCenter,
+  makeInboxEntryOriginResolver,
+  makeWorkspaceResolver,
+} from '../core/workspace-tool-center.js'
 import type { IInboxStore } from '../core/inbox-store.js'
 import type { IEntityStore } from '../core/entity-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
@@ -102,6 +106,7 @@ export class McpPlugin implements Plugin {
         // Parity with the CLI gateway so external MCP consumers get the same
         // workspace_path resolution — shared helper, so the two can't drift.
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),
+        resolveInboxOrigin: makeInboxEntryOriginResolver(getWorkspaceService),
         ...(svc
           ? {
               board: {

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -98,6 +98,7 @@ export class McpPlugin implements Plugin {
         workspaceLabel: wsLabel,
         inboxStore,
         entityStore,
+        ...(svc ? { provenanceStore: svc.provenanceStore } : {}),
         // Parity with the CLI gateway so external MCP consumers get the same
         // workspace_path resolution — shared helper, so the two can't drift.
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -107,6 +107,7 @@ export class McpPlugin implements Plugin {
         // workspace_path resolution — shared helper, so the two can't drift.
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),
         resolveInboxOrigin: makeInboxEntryOriginResolver(getWorkspaceService),
+        ...(svc ? { sessionDirectory: (id: string, limit?: number) => svc.sessionDirectory(id, limit) } : {}),
         ...(svc
           ? {
               board: {

--- a/src/tool/inbox-push.spec.ts
+++ b/src/tool/inbox-push.spec.ts
@@ -1,0 +1,69 @@
+import type { Tool } from 'ai'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import { inboxPushFactory } from './inbox-push.js'
+
+async function run(tool: Tool, args: Record<string, unknown>) {
+  return tool.execute!(args, { toolCallId: 'test', messages: [] })
+}
+
+function context(over: Partial<WorkspaceToolContext> = {}): WorkspaceToolContext {
+  return {
+    workspaceId: 'ws-1',
+    workspaceLabel: 'desk',
+    inboxStore: {
+      append: vi.fn(async (input) => ({ ...input, id: 'entry-1', ts: 123 })),
+    } as never,
+    entityStore: {} as never,
+    ...over,
+  }
+}
+
+describe('inbox_push provenance', () => {
+  it('records the notification and published report against the caller Session', async () => {
+    const append = vi.fn(async (input) => ({ id: `p-${input.action}`, ...input }))
+    const ctx = context({
+      provenanceStore: { append, list: vi.fn(), latest: vi.fn() },
+      origin: {
+        kind: 'headless',
+        runId: 'task-1',
+        resumeId: 'resume-1',
+        issueId: 'issue-1',
+        agent: 'pi',
+      },
+    })
+
+    await expect(run(inboxPushFactory.build(ctx), {
+      comments: 'done',
+      docs: [{ path: 'research/a.md' }],
+    })).resolves.toMatchObject({ ok: true, entryId: 'entry-1' })
+
+    const origin = {
+      kind: 'session',
+      workspaceId: 'ws-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+      execution: { kind: 'headless', taskId: 'task-1' },
+    }
+    expect(append).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      artifact: { kind: 'inbox', inboxEntryId: 'entry-1' },
+      action: 'sent',
+      origin,
+    }))
+    expect(append).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      artifact: { kind: 'report', workspaceId: 'ws-1', path: 'research/a.md' },
+      action: 'sent',
+      origin,
+    }))
+  })
+
+  it('records an honest unknown origin when no Session context is available', async () => {
+    const append = vi.fn(async (input) => ({ id: 'p-1', ...input }))
+    const ctx = context({ provenanceStore: { append, list: vi.fn(), latest: vi.fn() } })
+    await run(inboxPushFactory.build(ctx), { comments: 'manual' })
+    expect(append).toHaveBeenCalledWith(expect.objectContaining({
+      origin: { kind: 'unknown', reason: 'missing-session-origin' },
+    }))
+  })
+})

--- a/src/tool/inbox-push.ts
+++ b/src/tool/inbox-push.ts
@@ -18,6 +18,7 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import { sessionOriginFromInboxOrigin } from '../core/provenance-store.js'
 
 export const inboxPushFactory: WorkspaceToolFactory = {
   name: 'inbox_push',
@@ -79,6 +80,26 @@ export const inboxPushFactory: WorkspaceToolFactory = {
             // when absent (interactive / no run header) so the JSONL stays clean.
             ...(ctx.origin ? { origin: ctx.origin } : {}),
           })
+          if (ctx.provenanceStore) {
+            const sessionOrigin = sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)
+            const origin = sessionOrigin ?? { kind: 'unknown' as const, reason: 'missing-session-origin' }
+            await ctx.provenanceStore.append({
+              artifact: { kind: 'inbox', inboxEntryId: entry.id },
+              action: 'sent',
+              origin,
+              at: entry.ts,
+              fingerprint: `inbox:${entry.id}:sent`,
+            })
+            for (const doc of entry.docs ?? []) {
+              await ctx.provenanceStore.append({
+                artifact: { kind: 'report', workspaceId: ctx.workspaceId, path: doc.path },
+                action: 'sent',
+                origin,
+                at: entry.ts,
+                fingerprint: `report:${ctx.workspaceId}:${doc.path}:sent:${entry.id}`,
+              })
+            }
+          }
           return {
             ok: true as const,
             entryId: entry.id,

--- a/src/tool/inbox-read.spec.ts
+++ b/src/tool/inbox-read.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { Tool } from 'ai'
 import { inboxReadFactory } from './inbox-read.js'
-import { createMemoryInboxStore } from '../core/inbox-store.js'
+import { createMemoryInboxStore, type InboxOrigin } from '../core/inbox-store.js'
 import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
 
 const WS = 'ws-self'
@@ -20,6 +20,7 @@ async function run(tool: Tool, args: Record<string, unknown>) {
       workspace: string
       comments?: string
       docs: string[]
+      origin?: InboxOrigin
     }>
   }
 }
@@ -27,9 +28,27 @@ async function run(tool: Tool, args: Record<string, unknown>) {
 async function seeded(): Promise<WorkspaceToolContext> {
   const inboxStore = createMemoryInboxStore()
   await inboxStore.append({ workspaceId: WS, workspaceLabel: 'Mine', docs: [{ path: 'a.md' }], comments: 'first' })
-  await inboxStore.append({ workspaceId: OTHER, workspaceLabel: 'Theirs', comments: 'from elsewhere' })
+  await inboxStore.append({
+    workspaceId: OTHER,
+    workspaceLabel: 'Theirs',
+    comments: 'from elsewhere',
+    origin: {
+      kind: 'headless',
+      runId: 'run-peer',
+      issueId: 'daily-scan',
+      agent: 'pi',
+    },
+  })
   await inboxStore.append({ workspaceId: WS, workspaceLabel: 'Mine', docs: [{ path: 'b.md' }, { path: 'c.md' }] })
-  return { workspaceId: WS, workspaceLabel: 'Mine', inboxStore, entityStore: {} as never }
+  return {
+    workspaceId: WS,
+    workspaceLabel: 'Mine',
+    inboxStore,
+    entityStore: {} as never,
+    resolveInboxOrigin: (entry) => entry.origin?.runId === 'run-peer'
+      ? { ...entry.origin, resumeId: 'resume-peer' }
+      : entry.origin,
+  }
 }
 
 describe('inbox_read', () => {
@@ -61,6 +80,20 @@ describe('inbox_read', () => {
     expect(foreign?.workspaceId).toBe(OTHER)
     // self entries carry this workspace's own id
     expect(res.entries.filter((e) => e.mine).every((e) => e.workspaceId === WS)).toBe(true)
+  })
+
+  it('surfaces safe, enriched provenance for following up with the originating agent', async () => {
+    const tool = inboxReadFactory.build(await seeded())
+    const res = await run(tool, {})
+    const foreign = res.entries.find((entry) => !entry.mine)
+
+    expect(foreign?.origin).toEqual({
+      kind: 'headless',
+      runId: 'run-peer',
+      resumeId: 'resume-peer',
+      issueId: 'daily-scan',
+      agent: 'pi',
+    })
   })
 
   it('`limit` caps the newest-first window and reports hasMore', async () => {

--- a/src/tool/inbox-read.ts
+++ b/src/tool/inbox-read.ts
@@ -21,7 +21,11 @@
 
 import { tool } from 'ai'
 import { z } from 'zod'
-import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import {
+  toSafeInboxOrigin,
+  type WorkspaceToolFactory,
+  type WorkspaceToolContext,
+} from '../core/workspace-tool-center.js'
 
 const DEFAULT_LIMIT = 20
 
@@ -37,6 +41,8 @@ export const inboxReadFactory: WorkspaceToolFactory = {
         "Pass `self` to limit the list to entries THIS workspace pushed; their `docs` paths are relative to your own workspace root, so you can open them directly with your shell (cat / read the path).",
         '',
         'Entries from other workspaces each carry a `workspaceId` — resolve it with `workspace_path` (CLI: `alice-workspace peer path`) to locate and read that peer\'s files.',
+        '',
+        'When an entry came from an agent run/session, `origin` carries its safe OpenAlice provenance (`runId` / `sessionId`, `resumeId`, `issueId`, `agent`). Native runtime session ids are never exposed.',
         '',
         `\`limit\` caps how many most-recent entries come back (newest first; default ${DEFAULT_LIMIT}).`,
       ].join('\n'),
@@ -64,19 +70,23 @@ export const inboxReadFactory: WorkspaceToolFactory = {
             ok: true as const,
             count: entries.length,
             hasMore,
-            entries: entries.map((e) => ({
-              id: e.id,
-              ts: new Date(e.ts).toISOString(),
-              // mine === true → the doc paths below are relative to your own
-              // workspace root and you can open them with shell tools.
-              mine: e.workspaceId === ctx.workspaceId,
-              // The dir-resolvable id (vs the human `workspace` label). For a
-              // peer entry, feed this to `workspace_path` to locate its files.
-              workspaceId: e.workspaceId,
-              workspace: e.workspaceLabel ?? e.workspaceId,
-              comments: e.comments,
-              docs: (e.docs ?? []).map((d) => d.path),
-            })),
+            entries: entries.map((e) => {
+              const origin = toSafeInboxOrigin(ctx.resolveInboxOrigin?.(e) ?? e.origin)
+              return {
+                id: e.id,
+                ts: new Date(e.ts).toISOString(),
+                // mine === true → the doc paths below are relative to your own
+                // workspace root and you can open them with shell tools.
+                mine: e.workspaceId === ctx.workspaceId,
+                // The dir-resolvable id (vs the human `workspace` label). For a
+                // peer entry, feed this to `workspace_path` to locate its files.
+                workspaceId: e.workspaceId,
+                workspace: e.workspaceLabel ?? e.workspaceId,
+                comments: e.comments,
+                docs: (e.docs ?? []).map((d) => d.path),
+                ...(origin ? { origin } : {}),
+              }
+            }),
           }
         } catch (err) {
           return {

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -318,10 +318,36 @@ describe('global board (ctx.board present)', () => {
   it('issue_show returns full detail for a unique name', async () => {
     const show = await run(issueShowFactory.build(boardCtx()), { id: 'Alpha' })
     expect(show.ok).toBe(true)
+    expect(show.mode).toBe('summary')
     expect(show.issue).toMatchObject({ id: 'alpha', body: 'the alpha body' })
     expect(show.runs).toEqual([])
     expect(show.inboxReports).toEqual([])
     expect(show.ambiguous).toBeUndefined()
+  })
+
+  it('issue_show keeps repeated prompts out of summary mode but includes them on request', async () => {
+    const detail: IssueDetail = {
+      issue: {
+        id: 'alpha', title: 'Alpha', body: 'one canonical body', status: 'todo',
+        priority: 'high', assignee: 'human', what: 'one canonical prompt',
+      },
+      runs: [{
+        taskId: 'task-1', resumeId: 'resume-kind-owl-abc123', wsId: 'ws-a', issueId: 'alpha',
+        agent: 'codex', prompt: 'large repeated execution prompt', status: 'done', startedAt: 1,
+        resumable: true,
+      }],
+      inboxReports: [],
+    }
+    const context = boardCtx({ detail: async () => detail })
+
+    const summary = await run(issueShowFactory.build(context), { id: 'Alpha' })
+    expect(JSON.stringify(summary)).not.toContain('large repeated execution prompt')
+    expect(summary.runs).toEqual([expect.objectContaining({
+      taskId: 'task-1', resumeId: 'resume-kind-owl-abc123', resumable: true,
+    })])
+
+    const detailed = await run(issueShowFactory.build(context), { id: 'Alpha', mode: 'detailed' })
+    expect(JSON.stringify(detailed)).toContain('large repeated execution prompt')
   })
 
   it('issue_show returns an ambiguous candidate list for a colliding name', async () => {

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import type { Tool } from 'ai'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
 import { readWorkspaceIssues } from '../workspaces/issues/declaration.js'
@@ -63,6 +63,31 @@ describe('issue_create', () => {
     expect(issue?.title).toBe('Fix the thing')
   })
 
+  it('records the creating product Session without accepting identity args', async () => {
+    const append = vi.fn(async (input) => ({ id: 'p-1', ...input }))
+    const context = ctx({
+      provenanceStore: { append, list: vi.fn(), latest: vi.fn() },
+      origin: {
+        kind: 'interactive',
+        sessionId: 'surface-1',
+        resumeId: 'resume-1',
+        agent: 'codex',
+      },
+    })
+    await run(issueCreateFactory.build(context), { id: 'owned', title: 'Owned issue' })
+    expect(append).toHaveBeenCalledWith(expect.objectContaining({
+      artifact: { kind: 'issue', workspaceId: 'ws-self', issueId: 'owned' },
+      action: 'created',
+      origin: {
+        kind: 'session',
+        workspaceId: 'ws-self',
+        resumeId: 'resume-1',
+        agent: 'codex',
+        execution: { kind: 'interactive', sessionRecordId: 'surface-1' },
+      },
+    }))
+  })
+
   it('refuses to overwrite an existing id (conflict → clean error)', async () => {
     await run(issueCreateFactory.build(ctx()), { id: 'dup', title: 'one' })
     const res = await run(issueCreateFactory.build(ctx()), { id: 'dup', title: 'two' })
@@ -85,6 +110,17 @@ describe('issue_update', () => {
     expect(issue).toMatchObject({ status: 'in_progress', priority: 'high', body: 'keep me' })
     // scheduling frontmatter survives a board-field patch
     expect(issue?.when).toEqual({ kind: 'every', every: '30m' })
+  })
+
+  it('records successful mutations but not rejected ones', async () => {
+    const append = vi.fn(async (input) => ({ id: 'p-1', ...input }))
+    const context = ctx({ provenanceStore: { append, list: vi.fn(), latest: vi.fn() } })
+    await run(issueCreateFactory.build(context), { id: 'trail', title: 'trail' })
+    append.mockClear()
+    await run(issueUpdateFactory.build(context), { id: 'trail', status: 'in_progress' })
+    await run(issueUpdateFactory.build(context), { id: 'missing', status: 'done' })
+    expect(append).toHaveBeenCalledTimes(1)
+    expect(append).toHaveBeenCalledWith(expect.objectContaining({ action: 'updated' }))
   })
 
   it('errors with no fields to update', async () => {

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -405,16 +405,18 @@ export const issueShowFactory: WorkspaceToolFactory = {
         'Show one issue from the global board in full — resolved by its NAME',
         '(case-insensitive id OR title), across every workspace.',
         '',
-        'Returns the full detail: frontmatter + markdown body (incl. any',
-        '`## Comments`), the run history, and the inbox reports the issue produced.',
+        'Summary mode (default) returns the issue once plus compact execution and',
+        'report references. Detailed mode includes each run prompt and full report.',
         'If the name matches issues in MORE THAN ONE workspace, returns',
         '`ambiguous` (candidate { wsId, wsTag, id, title } list) — pick one by',
         'workspace and call again. Use this before updating or commenting.',
       ].join('\n'),
       inputSchema: z.object({
         id: z.string().min(1).describe("The issue's name to show — its id OR title (case-insensitive)."),
+        mode: z.enum(['summary', 'detailed']).optional().default('summary'),
       }),
-      execute: async ({ id }) => {
+      execute: async ({ id, mode }) => {
+        const outputMode = mode ?? 'summary'
         // GLOBAL by-name resolution when the service-backed reader is wired.
         // Handle-addressed: the agent never supplies a wsId UUID up front; a
         // collision returns candidates so it can disambiguate by workspace.
@@ -422,7 +424,36 @@ export const issueShowFactory: WorkspaceToolFactory = {
           const refs = await ctx.board.resolveByName(id)
           if (refs.length === 1) {
             const detail = await ctx.board.detail(refs[0].wsId, refs[0].id)
-            if (detail) return { ok: true as const, ...detail }
+            if (detail) {
+              if (outputMode === 'detailed') return { ok: true as const, mode: outputMode, ...detail }
+              return {
+                ok: true as const,
+                mode: outputMode,
+                issue: detail.issue,
+                runs: detail.runs.map((run) => ({
+                  taskId: run.taskId,
+                  resumeId: run.resumeId,
+                  ...(run.parentTaskId ? { parentTaskId: run.parentTaskId } : {}),
+                  agent: run.agent,
+                  status: run.status,
+                  startedAt: run.startedAt,
+                  ...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
+                  ...(run.error ? { error: run.error } : {}),
+                  ...(run.output ? { output: run.output } : {}),
+                  resumable: run.resumable,
+                })),
+                inboxReports: detail.inboxReports.map((entry) => ({
+                  id: entry.id,
+                  workspaceId: entry.workspaceId,
+                  workspaceLabel: entry.workspaceLabel,
+                  ts: entry.ts,
+                  ...(entry.docs ? { docs: entry.docs.map((doc) => ({ path: doc.path })) } : {}),
+                  ...(entry.comments ? { comments: entry.comments } : {}),
+                  ...(entry.origin ? { origin: entry.origin } : {}),
+                })),
+                hint: 'Use --mode detailed only when you need every execution prompt and full report metadata.',
+              }
+            }
             // detail vanished between resolve and read → fall through to self.
           } else if (refs.length > 1) {
             return {

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -26,6 +26,7 @@ import { tool } from 'ai'
 import { z } from 'zod'
 
 import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import { sessionOriginFromInboxOrigin, type ProvenanceAction } from '../core/provenance-store.js'
 import { readWorkspaceFile } from '../workspaces/file-service.js'
 import {
   ISSUES_DIR_REL,
@@ -59,6 +60,25 @@ function selfDir(ctx: WorkspaceToolContext): { ok: true; dir: string } | { ok: f
 
 /** The comment / create author for this workspace's writes. */
 const author = (ctx: WorkspaceToolContext): string => `ws:${ctx.workspaceLabel}`
+
+async function recordIssueProvenance(
+  ctx: WorkspaceToolContext,
+  issueId: string,
+  action: Extract<ProvenanceAction, 'created' | 'updated' | 'commented'>,
+): Promise<void> {
+  if (!ctx.provenanceStore) return
+  const origin = sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin) ?? {
+    kind: 'unknown' as const,
+    reason: 'missing-session-origin',
+  }
+  await ctx.provenanceStore.append({
+    artifact: { kind: 'issue', workspaceId: ctx.workspaceId, issueId },
+    action,
+    origin,
+    at: Date.now(),
+    ...(action === 'created' ? { fingerprint: `issue:${ctx.workspaceId}:${issueId}:created` } : {}),
+  })
+}
 
 /** Project a full IssueRecord into the compact row the tools return. */
 function rowOf(issue: IssueRecord, workspaceLabel?: string) {
@@ -185,7 +205,10 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
           return { ok: false as const, error: 'no fields to update (pass at least one of status/priority/assignee)' }
         }
         const res = await updateIssueFields(dir.dir, id, { status, priority, assignee })
-        if (res.ok) return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+        if (res.ok) {
+          await recordIssueProvenance(ctx, res.issue.id, 'updated')
+          return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+        }
         if (res.reason === 'not_found') return { ok: false as const, error: `no such issue: ${id}` }
         return { ok: false as const, error: res.error }
       },
@@ -215,7 +238,10 @@ export const issueCommentFactory: WorkspaceToolFactory = {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
         const res = await appendIssueComment(dir.dir, id, author(ctx), text)
-        if (res.ok) return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+        if (res.ok) {
+          await recordIssueProvenance(ctx, res.issue.id, 'commented')
+          return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+        }
         if (res.reason === 'not_found') return { ok: false as const, error: `no such issue: ${id}` }
         return { ok: false as const, error: res.error }
       },
@@ -275,7 +301,10 @@ export const issueCreateFactory: WorkspaceToolFactory = {
           agent,
           body,
         })
-        if (res.ok) return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+        if (res.ok) {
+          await recordIssueProvenance(ctx, res.issue.id, 'created')
+          return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+        }
         if (res.reason === 'conflict') return { ok: false as const, error: `issue already exists: ${res.id}` }
         return { ok: false as const, error: res.error }
       },

--- a/src/tool/workspace-sessions.spec.ts
+++ b/src/tool/workspace-sessions.spec.ts
@@ -1,0 +1,30 @@
+import type { Tool } from 'ai'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import { workspaceSessionsFactory } from './workspace-sessions.js'
+
+async function run(tool: Tool, args: Record<string, unknown>) {
+  return tool.execute!(args, { toolCallId: 't', messages: [] })
+}
+
+describe('workspace_sessions', () => {
+  it('returns the safe directory for a known workspace', async () => {
+    const sessionDirectory = vi.fn(async () => ({
+      workspace: { id: 'peer', tag: 'research' },
+      sessions: [{ resumeId: 'resume-kind-owl-abc123', agent: 'pi', createdAt: 1, updatedAt: 2, resumable: true, active: false }],
+    }))
+    const ctx = {
+      workspaceId: 'self',
+      workspaceLabel: 'self',
+      inboxStore: {} as never,
+      entityStore: {} as never,
+      resolveWorkspace: (id: string) => id === 'peer' ? { id, tag: 'research', dir: '/peer' } : null,
+      sessionDirectory,
+    } satisfies WorkspaceToolContext
+
+    const result = await run(workspaceSessionsFactory.build(ctx), { id: 'peer' })
+    expect(result).toMatchObject({ ok: true, workspace: { id: 'peer' } })
+    expect(sessionDirectory).toHaveBeenCalledWith('peer', undefined)
+  })
+})

--- a/src/tool/workspace-sessions.ts
+++ b/src/tool/workspace-sessions.ts
@@ -1,0 +1,42 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import type { WorkspaceToolFactory } from '../core/workspace-tool-center.js'
+
+export const workspaceSessionsFactory: WorkspaceToolFactory = {
+  name: 'workspace_sessions',
+  build(ctx) {
+    return tool({
+      description: [
+        "List a workspace's known Sessions using OpenAlice-owned resumeId handles.",
+        '',
+        'Use this to audit who has worked at a workspace or to resolve a known artifact owner.',
+        'Do not choose an arbitrary old Session when an artifact has no exact owner: that means',
+        'the future collaboration flow should recruit a fresh Session at that workspace.',
+        '',
+        'Adapter-native session ids are intentionally hidden. Pass only resumeId to OpenAlice',
+        'resume/collaboration commands; the backend owns the runtime-specific mapping.',
+      ].join('\n'),
+      inputSchema: z.object({
+        id: z.string().min(1).describe('Workspace id to inspect.'),
+        limit: z.number().int().min(1).max(100).optional().describe('Newest Sessions to return (default 50).'),
+      }),
+      execute: async ({ id, limit }) => {
+        try {
+          if (!ctx.resolveWorkspace?.(id)) {
+            return { ok: false as const, error: `unknown workspace: ${id}` }
+          }
+          if (!ctx.sessionDirectory) {
+            return { ok: false as const, error: 'workspace Session directory is unavailable in this context' }
+          }
+          const directory = await ctx.sessionDirectory(id, limit)
+          return directory
+            ? { ok: true as const, ...directory }
+            : { ok: false as const, error: `unknown workspace: ${id}` }
+        } catch (err) {
+          return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
+        }
+      },
+    })
+  },
+}

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -9,7 +9,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createIssuesRoutes } from './issues.js'
 import type { InboxEntry } from '../../core/inbox-store.js'
@@ -32,6 +32,7 @@ afterEach(async () => {
 // `inboxReportsForIssue` test. Here the route is a thin pass-through, so the stub
 // just echoes whatever inboxReports it's handed.
 function build(inboxReports: InboxEntry[] = []) {
+  const appendProvenance = vi.fn(async (input) => ({ id: 'p-1', ...input }))
   const svc = {
     registry: {
       get: (id: string) => (
@@ -54,8 +55,9 @@ function build(inboxReports: InboxEntry[] = []) {
       const issue = r.issues.find((i) => i.id === id)
       return issue ? { issue: detailIssue(issue, null), runs: [], inboxReports } : null
     },
+    provenanceStore: { append: appendProvenance, list: vi.fn(), latest: vi.fn() },
   } as unknown as WorkspaceService
-  return createIssuesRoutes(svc)
+  return { app: createIssuesRoutes(svc), appendProvenance }
 }
 
 async function req(app: any, method: string, path: string, body?: unknown) {
@@ -70,18 +72,18 @@ async function req(app: any, method: string, path: string, body?: unknown) {
 
 describe('PATCH /api/issues/:wsId/:id', () => {
   it('404 on a malformed id', async () => {
-    const app = build()
+    const { app } = build()
     expect((await req(app, 'PATCH', '/ws-1/bad.id', { status: 'done' })).status).toBe(404)
   })
 
   it('404 for an unknown workspace', async () => {
-    const app = build()
+    const { app } = build()
     const r = await req(app, 'PATCH', '/ws-nope/x', { status: 'done' })
     expect(r.status).toBe(404)
   })
 
   it('404 for a missing issue in a real workspace', async () => {
-    const app = build()
+    const { app } = build()
     const r = await req(app, 'PATCH', '/ws-1/ghost', { status: 'done' })
     expect(r.status).toBe(404)
     expect(r.body.error).toBe('not_found')
@@ -89,7 +91,7 @@ describe('PATCH /api/issues/:wsId/:id', () => {
 
   it('400 invalid_status for an unknown status', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T' })
-    const app = build()
+    const { app } = build()
     const r = await req(app, 'PATCH', '/ws-1/i1', { status: 'nope' })
     expect(r.status).toBe(400)
     expect(r.body.error).toBe('invalid_status')
@@ -97,14 +99,14 @@ describe('PATCH /api/issues/:wsId/:id', () => {
 
   it('400 invalid_agent for an unknown or utility runtime', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T' })
-    const app = build()
+    const { app } = build()
     expect((await req(app, 'PATCH', '/ws-1/i1', { agent: 'nope' })).body.error).toBe('invalid_agent')
     expect((await req(app, 'PATCH', '/ws-1/i1', { agent: 'shell' })).body.error).toBe('invalid_agent')
   })
 
   it('400 no_fields when the body has none of the patchable fields', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T' })
-    const app = build()
+    const { app } = build()
     const r = await req(app, 'PATCH', '/ws-1/i1', { foo: 'bar' })
     expect(r.status).toBe(400)
     expect(r.body.error).toBe('no_fields')
@@ -112,7 +114,7 @@ describe('PATCH /api/issues/:wsId/:id', () => {
 
   it('updates fields including the scheduled agent runtime and returns the detail shape', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', body: 'keep me' })
-    const app = build()
+    const { app, appendProvenance } = build()
     const r = await req(app, 'PATCH', '/ws-1/i1', { status: 'in_progress', priority: 'high', assignee: 'human', agent: 'pi' })
     expect(r.status).toBe(200)
     expect(r.body.issue).toMatchObject({
@@ -128,11 +130,16 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     const re = await readWorkspaceIssues(wsDir)
     expect(re.ok && re.issues[0].status).toBe('in_progress')
     expect(re.ok && re.issues[0].agent).toBe('pi')
+    expect(appendProvenance).toHaveBeenCalledWith(expect.objectContaining({
+      artifact: { kind: 'issue', workspaceId: 'ws-1', issueId: 'i1' },
+      action: 'updated',
+      origin: { kind: 'human' },
+    }))
   })
 
   it('clears the scheduled agent runtime with null', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', agent: 'claude' })
-    const app = build()
+    const { app } = build()
     const r = await req(app, 'PATCH', '/ws-1/i1', { agent: null })
     expect(r.status).toBe(200)
     expect(r.body.issue.agent).toBeUndefined()
@@ -148,14 +155,14 @@ describe('GET /api/issues/:wsId/:id — inboxReports pass-through', () => {
       { id: 'e2', ts: 2, workspaceId: 'ws-1', comments: 'r2', origin: { kind: 'headless', runId: 'c', issueId: 'i1' } },
       { id: 'e1', ts: 1, workspaceId: 'ws-1', comments: 'r1', origin: { kind: 'headless', runId: 'a', issueId: 'i1' } },
     ] as unknown as InboxEntry[]
-    const r = await req(build(reports), 'GET', '/ws-1/i1')
+    const r = await req(build(reports).app, 'GET', '/ws-1/i1')
     expect(r.status).toBe(200)
     expect(r.body.inboxReports.map((e: any) => e.comments)).toEqual(['r2', 'r1'])
   })
 
   it('inboxReports defaults to [] when the issue produced none', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T' })
-    const r = await req(build(), 'GET', '/ws-1/i1')
+    const r = await req(build().app, 'GET', '/ws-1/i1')
     expect(r.status).toBe(200)
     expect(r.body.inboxReports).toEqual([])
   })
@@ -164,24 +171,28 @@ describe('GET /api/issues/:wsId/:id — inboxReports pass-through', () => {
 describe('POST /api/issues/:wsId/:id/comments', () => {
   it('400 text_required for a blank comment', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T' })
-    const app = build()
+    const { app } = build()
     expect((await req(app, 'POST', '/ws-1/i1/comments', { text: '   ' })).body.error).toBe('text_required')
   })
 
   it('404 for a missing issue', async () => {
-    const app = build()
+    const { app } = build()
     const r = await req(app, 'POST', '/ws-1/ghost/comments', { text: 'hi' })
     expect(r.status).toBe(404)
   })
 
   it('appends a human comment and returns the detail shape', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', body: 'desc' })
-    const app = build()
+    const { app, appendProvenance } = build()
     const r = await req(app, 'POST', '/ws-1/i1/comments', { text: 'looks good' })
     expect(r.status).toBe(200)
     expect(r.body.issue.body).toContain('## Comments')
     expect(r.body.issue.body).toContain('**human**')
     expect(r.body.issue.body).toContain('looks good')
     expect(r.body.issue.body).toContain('desc')
+    expect(appendProvenance).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'commented',
+      origin: { kind: 'human' },
+    }))
   })
 })

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -124,6 +124,12 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
         if (res.reason === 'not_found') return c.json({ error: 'not_found' }, 404)
         return c.json({ error: 'invalid_issue', message: res.error }, 422)
       }
+      await svc.provenanceStore.append({
+        artifact: { kind: 'issue', workspaceId: wsId, issueId: id },
+        action: 'updated',
+        origin: { kind: 'human' },
+        at: Date.now(),
+      })
       launcherLogger.info('issue.updated', { wsId, id, fields: Object.keys(patch) })
       const detail = await svc.issueDetail(wsId, id)
       return c.json(detail ?? { issue: res.issue, runs: [], inboxReports: [] })
@@ -159,6 +165,12 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
         if (res.reason === 'not_found') return c.json({ error: 'not_found' }, 404)
         return c.json({ error: 'invalid_issue', message: res.error }, 422)
       }
+      await svc.provenanceStore.append({
+        artifact: { kind: 'issue', workspaceId: wsId, issueId: id },
+        action: 'commented',
+        origin: { kind: 'human' },
+        at: Date.now(),
+      })
       launcherLogger.info('issue.comment_added', { wsId, id, author: 'human' })
       const detail = await svc.issueDetail(wsId, id)
       return c.json(detail ?? { issue: res.issue, runs: [], inboxReports: [] })

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -6,10 +6,34 @@ import {
   detailIssue,
   flattenBoardRows,
   inboxReportsForIssue,
+  issueRunRecord,
   snapshotBoardIssue,
   type IssuesSnapshot,
   type IssuesSnapshotWorkspace,
 } from './board.js'
+
+describe('issueRunRecord', () => {
+  it('projects a resumable run without leaking its native runtime session id', () => {
+    const projected = issueRunRecord({
+      taskId: 'task-1',
+      resumeId: 'resume-gentle-otter-abc123',
+      wsId: 'ws-1',
+      issueId: 'audit',
+      agent: 'codex',
+      prompt: 'inspect it',
+      status: 'done',
+      startedAt: 1,
+      agentSessionId: 'native-secret-id',
+    }, true)
+
+    expect(projected).toMatchObject({
+      taskId: 'task-1',
+      resumeId: 'resume-gentle-otter-abc123',
+      resumable: true,
+    })
+    expect(projected).not.toHaveProperty('agentSessionId')
+  })
+})
 
 function ws(wsId: string, titles: string[]): IssuesSnapshotWorkspace {
   return {

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -13,7 +13,11 @@
 
 import type { InboxEntry } from '../../core/inbox-store.js'
 import type { Schedule } from '../../core/schedule-expr.js'
-import type { HeadlessTaskRecord } from '../headless-task-registry.js'
+import type {
+  HeadlessTaskOutputSummary,
+  HeadlessTaskRecord,
+  HeadlessTaskStatus,
+} from '../headless-task-registry.js'
 import type { IssuePriority, IssueRecord, IssueStatus } from './declaration.js'
 
 /** One board row: the issue's display fields, plus — iff it self-schedules — its
@@ -218,12 +222,60 @@ export interface IssueDetailIssue {
  *  the inbox reports it produced. */
 export interface IssueDetail {
   issue: IssueDetailIssue
-  /** This issue's headless runs (wsId + issueId match), newest first. */
-  runs: HeadlessTaskRecord[]
+  /** This issue's headless runs (wsId + issueId match), newest first.
+   *  Runtime-native session ids are deliberately not part of this projection. */
+  runs: IssueRunRecord[]
   /** Inbox reports this issue produced — entries whose server-stamped
    *  `origin.issueId` is this issue, newest-first. The issue→inbox direction of
    *  the cross-link (`runs` is the run→issue one). */
   inboxReports: InboxEntry[]
+}
+
+/** Agent/UI-safe projection of one execution. `resumeId` is the only public
+ * conversation handle; adapter-native session ids stay in ResumeRegistry. */
+export interface IssueRunRecord {
+  taskId: string
+  resumeId: string
+  parentTaskId?: string
+  wsId: string
+  issueId?: string
+  agent: string
+  prompt: string
+  status: HeadlessTaskStatus
+  startedAt: number
+  finishedAt?: number
+  durationMs?: number
+  exitCode?: number | null
+  signal?: string | null
+  killed?: boolean
+  error?: string
+  output?: HeadlessTaskOutputSummary
+  /** Whether OpenAlice currently has a native runtime mapping for resumeId. */
+  resumable: boolean
+}
+
+/** Explicit whitelist: do not spread HeadlessTaskRecord here. Old registry
+ * records may contain adapter-specific compatibility fields. */
+export function issueRunRecord(task: HeadlessTaskRecord, resumable: boolean): IssueRunRecord {
+  return {
+    taskId: task.taskId,
+    resumeId: task.resumeId,
+    ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
+    wsId: task.wsId,
+    ...(task.issueId ? { issueId: task.issueId } : {}),
+    agent: task.agent,
+    prompt: task.prompt,
+    status: task.status,
+    startedAt: task.startedAt,
+    ...(task.finishedAt !== undefined ? { finishedAt: task.finishedAt } : {}),
+    ...(task.durationMs !== undefined ? { durationMs: task.durationMs } : {}),
+    ...(task.exitCode !== undefined ? { exitCode: task.exitCode } : {}),
+    ...(task.signal !== undefined ? { signal: task.signal } : {}),
+    ...(task.killed !== undefined ? { killed: task.killed } : {}),
+    ...(task.error !== undefined ? { error: task.error } : {}),
+    ...(task.output !== undefined ? { output: task.output } : {}),
+    resumable,
+  }
 }
 
 /** Filter a workspace's inbox entries to the ones a given issue produced

--- a/src/workspaces/resume-registry.spec.ts
+++ b/src/workspaces/resume-registry.spec.ts
@@ -51,4 +51,14 @@ describe('ResumeRegistry', () => {
     expect(record.resumeId).toBe(legacyId)
     expect((await ResumeRegistry.load(path, noopLogger)).get(legacyId)?.resumeId).toBe(legacyId)
   })
+
+  it('lists one workspace newest-first for directory projection', async () => {
+    const registry = await ResumeRegistry.load(path, noopLogger)
+    await registry.ensure({ resumeId: 'resume-old', wsId: 'ws-1', agent: 'pi', now: 1 })
+    await registry.ensure({ resumeId: 'resume-other', wsId: 'ws-2', agent: 'codex', now: 3 })
+    await registry.ensure({ resumeId: 'resume-new', wsId: 'ws-1', agent: 'claude', now: 2 })
+
+    expect(registry.list({ wsId: 'ws-1' }).map((record) => record.resumeId))
+      .toEqual(['resume-new', 'resume-old'])
+  })
 })

--- a/src/workspaces/resume-registry.ts
+++ b/src/workspaces/resume-registry.ts
@@ -73,6 +73,15 @@ export class ResumeRegistry {
     return this.records.get(resumeId) ?? null
   }
 
+  /** Backend records newest-first. Callers must project them before crossing an
+   * API/tool boundary because records also carry the native runtime mapping. */
+  list(opts: { wsId?: string; limit?: number } = {}): ResumeIdentityRecord[] {
+    const records = [...this.records.values()]
+      .filter((record) => !opts.wsId || record.wsId === opts.wsId)
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+    return opts.limit && opts.limit > 0 ? records.slice(0, opts.limit) : records
+  }
+
   async ensure(input: {
     resumeId?: string
     wsId: string

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -60,14 +60,20 @@ import {
   inboxReportsForIssue,
   snapshotBoardIssue,
   type IssueDetail,
+  issueRunRecord,
   type IssueFiringMarkers,
   type IssuesSnapshot,
   type IssuesSnapshotIssue,
   type IssuesSnapshotWorkspace,
   type WikilinkIssueRef,
 } from './issues/board.js';
+import {
+  buildWorkspaceSessionDirectory,
+  type WorkspaceSessionDirectory,
+} from './session-directory.js';
 import { completeOneShotIssueAfterRun } from './issues/auto-complete.js';
 import type { IInboxStore } from '@/core/inbox-store.js';
+import { toSafeInboxOrigin } from '@/core/workspace-tool-center.js';
 import {
   HeadlessTaskRegistry,
   headlessLogPaths,
@@ -240,6 +246,8 @@ export interface WorkspaceService {
    *  headless run history, newest first). `null` when the workspace or the issue
    *  id is absent. Powers GET /api/issues/:wsId/:id. */
   issueDetail(wsId: string, id: string): Promise<IssueDetail | null>;
+  /** Safe Workspace Session index. resumeId is the only public conversation handle. */
+  sessionDirectory(wsId: string, limit?: number): Promise<WorkspaceSessionDirectory | null>;
   /** Resolve a `[[name]]` token to the issues across ALL workspaces that claim it.
    *  Matches case-insensitively against an issue's `id` OR its `title` (either is a
    *  valid name handle). Returns every match — 0, 1, or many (a collision the UI
@@ -1250,16 +1258,45 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       markers = { lastFiredAtMs: fired.lastFiredAtMs, nextDueAtMs: fired.nextDueAtMs };
     }
     // Newest-first already (registry.list reverses); filter to this issue's runs.
-    const runs = headlessTasks.list({ wsId: ws.id, issueId: issue.id });
+    const runs = headlessTasks.list({ wsId: ws.id, issueId: issue.id }).map((task) =>
+      issueRunRecord(task, Boolean(resumeRegistry.get(task.resumeId)?.agentSessionId)),
+    );
     // The issue→inbox cross-link: the reports this issue produced (entries this
     // workspace pushed whose server-stamped origin.issueId is this issue).
     // Joined here in the domain so CLI / MCP get it too, not just the HTTP route.
     let inboxReports: IssueDetail['inboxReports'] = [];
     if (inboxStore) {
       const { entries } = await inboxStore.read({ workspaceId: ws.id, limit: 1000 });
-      inboxReports = inboxReportsForIssue(entries, issue.id);
+      inboxReports = inboxReportsForIssue(entries, issue.id).map((entry) => {
+        let origin = toSafeInboxOrigin(entry.origin);
+        if (origin && !origin.resumeId && origin.kind === 'headless' && origin.runId) {
+          const resumeId = headlessTasks.get(origin.runId)?.resumeId;
+          if (resumeId) origin = { ...origin, resumeId };
+        }
+        if (origin && !origin.resumeId && origin.kind === 'interactive' && origin.sessionId) {
+          const resumeId = sessionRegistry.get(ws.id, origin.sessionId)?.resumeId;
+          if (resumeId) origin = { ...origin, resumeId };
+        }
+        return { ...entry, ...(origin ? { origin } : { origin: undefined }) };
+      });
     }
     return { issue: detailIssue(issue, markers, ws.tag), runs, inboxReports };
+  };
+
+  const sessionDirectory = async (
+    wsId: string,
+    limit = 50,
+  ): Promise<WorkspaceSessionDirectory | null> => {
+    const ws = registry.get(wsId);
+    if (!ws) return null;
+    await sessionRegistry.ensureLoaded(wsId);
+    return buildWorkspaceSessionDirectory({
+      workspace: { id: ws.id, tag: ws.tag },
+      identities: resumeRegistry.list({ wsId, limit }),
+      interactiveFor: (resumeId) => sessionRegistry.findByResumeId(wsId, resumeId),
+      latestExecutionFor: (resumeId) => headlessTasks.latestForResumeId(resumeId),
+      isActive: (resumeId) => activeResumeIds.has(resumeId),
+    });
   };
 
   // Resolve a `[[name]]` token to the issues (across ALL workspaces) that claim
@@ -1502,6 +1539,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     scheduleSnapshot,
     issuesSnapshot,
     issueDetail,
+    sessionDirectory,
     resolveIssuesByName,
     headlessTasks,
     resumeRegistry,

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -14,6 +14,7 @@ import { basename, join } from 'node:path';
 
 import { cliBinPath } from '@/core/paths.js';
 import { readCredentials, readIssueDefaultAgent, readWorkspaceDefaultAgent } from '@/core/config.js';
+import { ArtifactProvenanceStore } from '@/core/provenance-store.js';
 import {
   readQuickChatPreferences,
   rememberRecentChatWorkspace,
@@ -248,6 +249,8 @@ export interface WorkspaceService {
   headlessTasks: HeadlessTaskRegistry;
   /** Backend-only product resumeId → native runtime session-id mapping. */
   resumeRegistry: ResumeRegistry;
+  /** Durable product Session -> business artifact attribution index. */
+  provenanceStore: ArtifactProvenanceStore;
   /** True while a headless turn owns this conversation transcript. */
   isResumeActive(resumeId: string): boolean;
   /** Atomically reserve a conversation before crossing an async spawn boundary. */
@@ -319,6 +322,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   const resumeRegistry = await ResumeRegistry.load(
     join(config.launcherRoot, 'state', 'resume-identities.json'),
     launcherLogger.child({ scope: 'resume-registry' }),
+  );
+  const provenanceStore = await ArtifactProvenanceStore.load(
+    join(config.launcherRoot, 'state', 'artifact-provenance.json'),
+    launcherLogger.child({ scope: 'provenance-store' }),
   );
   const activeResumeIds = new Set<string>();
   const claimResume = (resumeId: string): boolean => {
@@ -1498,6 +1505,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     resolveIssuesByName,
     headlessTasks,
     resumeRegistry,
+    provenanceStore,
     isResumeActive: (resumeId) => activeResumeIds.has(resumeId),
     claimResume,
     releaseResume: (resumeId) => activeResumeIds.delete(resumeId),

--- a/src/workspaces/session-directory.spec.ts
+++ b/src/workspaces/session-directory.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildWorkspaceSessionDirectory } from './session-directory.js'
+
+describe('buildWorkspaceSessionDirectory', () => {
+  it('joins useful state while hiding native and launcher ids', () => {
+    const result = buildWorkspaceSessionDirectory({
+      workspace: { id: 'ws-1', tag: 'research' },
+      identities: [{
+        resumeId: 'resume-kind-owl-abc123',
+        wsId: 'ws-1',
+        agent: 'codex',
+        agentSessionId: 'native-secret',
+        latestTaskId: 'task-1',
+        createdAt: 1,
+        updatedAt: 2,
+      }],
+      interactiveFor: () => ({
+        id: 'launcher-secret',
+        resumeId: 'resume-kind-owl-abc123',
+        wsId: 'ws-1',
+        agent: 'codex',
+        name: 'c1',
+        title: 'Investigate provenance',
+        createdAt: '2026-07-11T00:00:00Z',
+        lastActiveAt: '2026-07-11T00:01:00Z',
+        state: 'paused',
+      }),
+      latestExecutionFor: () => ({
+        taskId: 'task-1',
+        resumeId: 'resume-kind-owl-abc123',
+        wsId: 'ws-1',
+        agent: 'codex',
+        prompt: 'private repeated prompt',
+        status: 'done',
+        startedAt: 1,
+        agentSessionId: 'native-secret',
+        output: { hasAssistantReply: true, assistantPreview: 'done', blockCount: 1, toolCalls: 0, toolFailures: 0 },
+      }),
+      isActive: () => false,
+    })
+
+    expect(result.sessions[0]).toMatchObject({
+      resumeId: 'resume-kind-owl-abc123',
+      resumable: true,
+      interactive: { name: 'c1', title: 'Investigate provenance' },
+      latestExecution: { taskId: 'task-1', assistantPreview: 'done' },
+    })
+    expect(JSON.stringify(result)).not.toContain('native-secret')
+    expect(JSON.stringify(result)).not.toContain('launcher-secret')
+    expect(JSON.stringify(result)).not.toContain('private repeated prompt')
+  })
+})

--- a/src/workspaces/session-directory.ts
+++ b/src/workspaces/session-directory.ts
@@ -1,0 +1,84 @@
+import type { HeadlessTaskRecord, HeadlessTaskStatus } from './headless-task-registry.js'
+import type { ResumeIdentityRecord } from './resume-registry.js'
+import type { SessionRecord } from './session-registry.js'
+
+export interface WorkspaceSessionDirectoryEntry {
+  resumeId: string
+  agent: string
+  createdAt: number
+  updatedAt: number
+  resumable: boolean
+  active: boolean
+  latestExecution?: {
+    taskId: string
+    status: HeadlessTaskStatus
+    startedAt: number
+    finishedAt?: number
+    durationMs?: number
+    issueId?: string
+    assistantPreview?: string
+  }
+  interactive?: {
+    name: string
+    title?: string
+    state: SessionRecord['state']
+    lastActiveAt: string
+  }
+}
+
+export interface WorkspaceSessionDirectory {
+  workspace: { id: string; tag: string }
+  sessions: WorkspaceSessionDirectoryEntry[]
+}
+
+/** Build the public Session directory by joining backend registries while
+ * deliberately whitelisting fields. Native runtime ids and launcher record ids
+ * never cross this boundary; resumeId is the sole conversation handle. */
+export function buildWorkspaceSessionDirectory(input: {
+  workspace: { id: string; tag: string }
+  identities: readonly ResumeIdentityRecord[]
+  interactiveFor(resumeId: string): SessionRecord | undefined
+  latestExecutionFor(resumeId: string): HeadlessTaskRecord | null
+  isActive(resumeId: string): boolean
+}): WorkspaceSessionDirectory {
+  return {
+    workspace: input.workspace,
+    sessions: input.identities.map((identity) => {
+      const execution = input.latestExecutionFor(identity.resumeId)
+      const interactive = input.interactiveFor(identity.resumeId)
+      return {
+        resumeId: identity.resumeId,
+        agent: identity.agent,
+        createdAt: identity.createdAt,
+        updatedAt: identity.updatedAt,
+        resumable: Boolean(identity.agentSessionId),
+        active: input.isActive(identity.resumeId),
+        ...(execution
+          ? {
+              latestExecution: {
+                taskId: execution.taskId,
+                status: execution.status,
+                startedAt: execution.startedAt,
+                ...(execution.finishedAt !== undefined ? { finishedAt: execution.finishedAt } : {}),
+                ...(execution.durationMs !== undefined ? { durationMs: execution.durationMs } : {}),
+                ...(execution.issueId ? { issueId: execution.issueId } : {}),
+                ...(execution.output?.assistantPreview
+                  ? { assistantPreview: execution.output.assistantPreview }
+                  : {}),
+              },
+            }
+          : {}),
+        ...(interactive
+          ? {
+              interactive: {
+                name: interactive.name,
+                ...(interactive.title ? { title: interactive.title } : {}),
+                state: interactive.state,
+                lastActiveAt: interactive.lastActiveAt,
+              },
+            }
+          : {}),
+      }
+    }),
+  }
+}

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -28,7 +28,7 @@ Discover any command live with `<cli> --help` and `<cli> <group> <verb> --help`
 |---|---|---|
 | `alice` | **Research & data** — collected-RSS archive, symbol search (barIds), quant analysis | `alice` |
 | `alice-uta` | **Trading** — accounts, portfolio, orders, positions, trading-as-git approval (MUTATES real broker state) | `alice-uta` |
-| `alice-workspace` | **Collaboration** — push/read the user's Inbox, locate a peer workspace's files (`peer path`), track entities, the shared issue board | `alice-workspace` |
+| `alice-workspace` | **Collaboration** — push/read Inbox, locate peer files (`peer path`) and product Sessions (`peer sessions`), track entities, the shared issue board | `alice-workspace` |
 | `traderhub` | **Low-frequency market data** — fundamentals, macro series, calendars, ETF, boards, shipping, Fed | `traderhub` |
 
 ```bash
@@ -89,6 +89,12 @@ always fine. Collaboration runs on git, so:
   workspace. If you do edit a peer (with approval), commit it in that repo with a
   clear message so the owner can review or revert it — never edit-and-walk-away.
 
+When an artifact already identifies a `resumeId`, inspect that workspace with
+`alice-workspace peer sessions --id <workspaceId>`. This directory exposes only
+OpenAlice's product Session handle, never a runtime-native session id. If the
+artifact has no exact owner, do not pick an arbitrary old Session; the later
+collaboration flow must recruit a fresh Session at that Workspace.
+
 ## Issues — your standing work list
 
 An issue board spans every workspace and persists intent across sessions. In
@@ -107,6 +113,7 @@ issue in full (body + run history + inbox reports). You pass the issue's
 ```bash
 alice-workspace issue list                 # scan every workspace's issue titles
 alice-workspace issue show --id ai-power-rotation   # then read one in full, by name
+alice-workspace issue show --id ai-power-rotation --mode detailed  # only when every run prompt is needed
 alice-workspace issue create --title "Watch AI power names" --priority high
 ```
 


### PR DESCRIPTION
## What changed

- add a versioned, append-only artifact provenance store and migration
- record authoritative Inbox and Issue create/update/comment attribution
- expose safe Inbox origins with legacy resumeId backfill
- project Issue runs through an explicit whitelist and keep native runtime session ids backend-only
- make `issue show` compact by default, with `--mode detailed` for full prompts
- add `alice-workspace peer sessions` as a safe Workspace Session directory keyed by product `resumeId`
- document the Phase 1 trail/index contract and agent-facing usage

## Why

Cross-Session follow-up needs a durable answer to “which product Session produced this?” before collaboration can safely resume or recruit an agent. Existing Issue and Inbox views either omitted this identity or exposed backend-native fields, and Issue CLI output repeated large prompts per run.

## Impact

Agents and UI consumers can now trace Inbox/Issue activity to OpenAlice-owned `resumeId` handles without learning Codex/Pi/Claude native session ids. Missing provenance remains explicit; the Session directory is an audit/addressing surface and does not guess an owner.

## Validation

- `pnpm test` — 217 files passed, 2548 tests passed, 6 skipped
- `pnpm build`
- `npx tsc --noEmit`
- live `/cli` verification against the dev service: `peer sessions` returned real Codex/Claude/Pi histories with no native ids
- live Issue verification: default output dropped from about 21 KB to 7 KB, retained every `resumeId`, omitted repeated prompts, and contained no `agentSessionId`