### PR TITLE
Give scheduled Issues explicit Session ownership

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -89,6 +89,7 @@ alice-workspace issue list --mode detailed  # full global board, including low-p
 alice-workspace issue show --id <name>      # compact issue + resumeId run/report references
 alice-workspace issue show --id <name> --mode detailed  # every execution prompt + full reports
 alice-workspace issue create --title "…"    # a new issue on THIS workspace's board
+alice-workspace issue create --title "…" --when '{"kind":"every","every":"1h"}' --execution '{"mode":"resume"}'
 alice-workspace issue update --id <id> --status in_progress
 alice-workspace issue comment --id <id> --text "progress note / finding"
 ```
@@ -101,4 +102,5 @@ the whole board (all workspaces); `create` / `update` / `comment` write **this**
 workspace's own `.alice/issues/` files (changing a peer's board is the
 human-approved peer-edit path). The full on-disk file model + self-scheduling
 (an issue with a `when` fires a headless run) lives in the **`self-scheduling`**
-skill.
+skill. New scheduled Issues must explicitly choose `execution: fresh` (a new
+Session each fire) or `execution: resume` (one accountable product Session).

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -88,6 +88,7 @@ as `--when`:
 ```bash
 alice-workspace issue create --title "Pre-market brief" --priority high \
   --when '{"kind":"cron","cron":"30 8 * * 1-5"}' \
+  --execution '{"mode":"resume"}' \
   --what "Pull pre-market movers and overnight news for my watchlist, write a short brief to research/premarket.md, then run: alice-workspace inbox push --doc research/premarket.md --comments 'Pre-market brief'." \
   --agent claude
 ```
@@ -115,6 +116,7 @@ what: >
   brief to research/premarket.md, then run:
   alice-workspace inbox push --doc research/premarket.md --comments "Pre-market brief".
 agent: claude
+execution: { mode: resume, resumeId: resume-calm-amber-river-a1b2c3 }
 ---
 
 Every trading morning at 08:30, assemble the pre-market picture for the
@@ -138,7 +140,8 @@ can be unit-tested without the network. No rush — picking this up next time we
 touch fetching.
 ```
 
-The first self-schedules (it has `when`); the second is a pure work item the
+The first self-schedules (it has `when`) and keeps one accountable product
+Session; the second is a pure work item the
 scanner ignores. Drop the `when`/`what`/`agent` lines and any issue becomes a
 plain tracked item; add a `when` and it starts firing.
 
@@ -169,7 +172,15 @@ plain tracked item; add a `when` and it starts firing.
   below). If omitted, the fire prompt falls back to the title plus the markdown
   body. Only meaningful when `when` is present.
 - **`agent`** *(optional)* — which CLI runs the scheduled job; defaults to this
-  workspace's default agent. Only meaningful when `when` is present.
+  workspace's default agent. It selects the worker kind for `fresh`; a `resume`
+  owner already has an immutable runtime, so that Session's runtime wins.
+- **`execution`** *(required for newly created scheduled issues)* — choose who
+  receives each fire:
+  - `{ mode: fresh }` recruits a new product Session each time;
+  - `{ mode: resume, resumeId: <id> }` continues that exact accountable Session.
+    With `alice-workspace issue create`, pass `--execution '{"mode":"resume"}'`
+    to bind the current Session without guessing its id. Existing legacy Issues
+    that omit this field keep the historical `fresh` behavior.
 
 The markdown **body** below the closing `---` is the issue's description: free
 prose for you and the user. For an unscheduled item it's the whole point; for a

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -237,27 +237,29 @@ execution:
 
 - Every scheduled fire continues that exact `resumeId`.
 - The responsible Session must belong to the Issue's owning Workspace.
+- The Session's bound runtime is authoritative; the Issue's top-level `agent`
+  cannot override it.
 - Run `taskId`s change; the product Session does not.
 - Per-`resumeId` serialization prevents overlapping turns.
 - If the Session becomes unresumable, the Issue becomes blocked/unavailable;
   it must not silently recruit a replacement and pretend continuity.
 
-For agent-facing `issue_create`, the author should express an intent such as
-`executionMode: "self"`; OpenAlice resolves and stamps the caller's authoritative
-`resumeId`. A human UI may select an existing Session explicitly.
+For agent-facing `issue_create`, `execution: { mode: "resume" }` without a
+`resumeId` binds the caller's authoritative product Session; OpenAlice resolves
+and stamps the id server-side. A human UI may select an existing Session.
 
 #### Mode B: a fresh worker per fire
 
 ```yaml
 execution:
   mode: fresh
-  agent: pi # optional runtime selection, not identity
 ```
 
 - Every scheduled fire creates a new headless product Session and `resumeId`.
 - The Issue and Workspace files provide shared continuity; conversational
   memory does not.
-- `agent` may constrain the runtime kind, but does not name a unique worker.
+- The Issue's top-level `agent` may constrain the runtime kind, but does not name
+  a unique worker.
 - Each run keeps its own origin so a user can still ask that specific worker.
 
 The Issue's creator provenance is stamped separately in both modes. Choosing

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -39,6 +39,7 @@ what: >
   Pull pre-market movers and overnight news, write research/premarket.md,
   then push the report to Inbox.
 agent: pi
+execution: { mode: fresh }
 ---
 
 Prepare a concise brief before the trading day.
@@ -56,7 +57,12 @@ The filename stem is the stable issue id. Frontmatter:
   - `{ kind: cron, cron: <5-field expression> }`
 - `what` — optional standalone headless prompt; falls back to title + body.
 - `agent` — optional CLI adapter id; otherwise Workspace/default resolution is
-  used.
+  used. It selects the runtime for `fresh`; `resume` uses the declared Session's
+  immutable runtime.
+- `execution` — scheduled ownership: `{ mode: fresh }` creates a new product
+  Session per fire; `{ mode: resume, resumeId: <id> }` continues one exact
+  accountable Session. Existing files without it remain fresh for compatibility;
+  new agent-created schedules must choose explicitly.
 
 `done` and `canceled` are terminal and stop scheduled firing. There is no
 separate `enabled` flag. A successful one-shot `at` issue is automatically
@@ -69,14 +75,14 @@ Agents normally use:
 ```bash
 alice-workspace issue list
 alice-workspace issue show --id <id-or-title>
-alice-workspace issue create --title "..."
+alice-workspace issue create --title "..." --when '{"kind":"every","every":"1h"}' --execution '{"mode":"fresh"}'
 alice-workspace issue update --id <id> --status done
 alice-workspace issue comment --id <id> --text "..."
 ```
 
 The CLI and MCP tools use the same implementation and write the same markdown
 files. Direct file editing is also valid and is the clearest way to author the
-body plus `when` / `what` / `agent` fields.
+body plus `when` / `what` / `agent` / `execution` fields.
 
 Reads such as list/show aggregate all workspaces. Writes from an autonomous or
 headless run stay inside its own Workspace. Editing a peer Workspace requires
@@ -88,6 +94,7 @@ an attended, human-approved path and a commit in the peer repository.
 .alice/issues/<id>.md
   -> ScheduleScanner (~60s)
   -> due calculation from `when` + last-fired marker
+  -> execution policy selects a fresh Session or exact resumeId
   -> headless run of the owning Workspace
   -> native agent CLI
   -> normalized reply + message/tool blocks

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -69,6 +69,12 @@ export interface WorkspaceToolContext {
   /** Safe per-workspace conversation directory. It exposes product resumeIds,
    * never adapter-native session ids or launcher record ids. */
   sessionDirectory?: (workspaceId: string, limit?: number) => Promise<WorkspaceSessionDirectory | null>
+  /** Safe point lookup used to validate declared Issue ownership. */
+  resolveSessionIdentity?: (resumeId: string) => {
+    workspaceId: string
+    agent: string
+    resumable: boolean
+  } | null
   /** Agent-INVISIBLE run provenance, resolved server-side from the
    *  `x-openalice-run` header by the MCP / CLI route (never supplied by the
    *  agent). Factories pass it through to call sites (e.g. inbox_push →

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -92,6 +92,14 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),
         resolveInboxOrigin: makeInboxEntryOriginResolver(getWorkspaceService),
         ...(svc ? { sessionDirectory: (id: string, limit?: number) => svc.sessionDirectory(id, limit) } : {}),
+        ...(svc ? {
+          resolveSessionIdentity: (resumeId: string) => {
+            const identity = svc.resumeRegistry.get(resumeId)
+            return identity
+              ? { workspaceId: identity.wsId, agent: identity.agent, resumable: Boolean(identity.agentSessionId) }
+              : null
+          },
+        } : {}),
         ...(svc
           ? {
               board: {

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -108,6 +108,14 @@ export class McpPlugin implements Plugin {
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),
         resolveInboxOrigin: makeInboxEntryOriginResolver(getWorkspaceService),
         ...(svc ? { sessionDirectory: (id: string, limit?: number) => svc.sessionDirectory(id, limit) } : {}),
+        ...(svc ? {
+          resolveSessionIdentity: (resumeId: string) => {
+            const identity = svc.resumeRegistry.get(resumeId)
+            return identity
+              ? { workspaceId: identity.wsId, agent: identity.agent, resumable: Boolean(identity.agentSessionId) }
+              : null
+          },
+        } : {}),
         ...(svc
           ? {
               board: {

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -94,6 +94,59 @@ describe('issue_create', () => {
     expect(res.ok).toBe(false)
     expect(res.error).toMatch(/already exists/)
   })
+
+  it('requires scheduled creators to choose fresh or resume ownership', async () => {
+    const rejected = await run(issueCreateFactory.build(ctx()), {
+      id: 'ambiguous-owner',
+      title: 'Ambiguous owner',
+      when: { kind: 'every', every: '30m' },
+    })
+    expect(rejected.ok).toBe(false)
+    expect(rejected.error).toMatch(/explicitly choose/)
+
+    const created = await run(issueCreateFactory.build(ctx()), {
+      id: 'fresh-owner',
+      title: 'Fresh owner',
+      when: { kind: 'every', every: '30m' },
+      execution: { mode: 'fresh' },
+    })
+    expect(created.ok).toBe(true)
+    expect((await readBack('fresh-owner'))?.execution).toEqual({ mode: 'fresh' })
+  })
+
+  it('binds resume ownership to the server-attributed current Session', async () => {
+    const context = ctx({
+      origin: {
+        kind: 'interactive',
+        sessionId: 'surface-1',
+        resumeId: 'resume-kind-owl-abc123',
+        agent: 'codex',
+      },
+    })
+    const created = await run(issueCreateFactory.build(context), {
+      id: 'owned-schedule',
+      title: 'Owned schedule',
+      when: { kind: 'every', every: '30m' },
+      execution: { mode: 'resume' },
+    })
+    expect(created.ok).toBe(true)
+    expect((await readBack('owned-schedule'))?.execution)
+      .toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
+  })
+
+  it('refuses to assign a Session from another workspace', async () => {
+    const context = ctx({
+      resolveSessionIdentity: () => ({ workspaceId: 'ws-peer', agent: 'pi', resumable: true }),
+    })
+    const result = await run(issueCreateFactory.build(context), {
+      id: 'foreign-owner',
+      title: 'Foreign owner',
+      when: { kind: 'every', every: '30m' },
+      execution: { mode: 'resume', resumeId: 'resume-peer' },
+    })
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/another workspace/)
+  })
 })
 
 describe('issue_update', () => {
@@ -102,6 +155,7 @@ describe('issue_update', () => {
       id: 'sched',
       title: 'scheduled work',
       when: { kind: 'every', every: '30m' },
+      execution: { mode: 'fresh' },
       body: 'keep me',
     })
     const res = await run(issueUpdateFactory.build(ctx()), { id: 'sched', status: 'in_progress', priority: 'high' })
@@ -192,13 +246,14 @@ describe('global board (ctx.board present)', () => {
         tag: 'auto-quant',
         status: 'ok',
         issues: [
-          { id: 'alpha', title: 'Alpha', status: 'todo', priority: 'high', assignee: 'human' },
+          { id: 'alpha', title: 'Alpha', status: 'todo', priority: 'high', assignee: 'human', execution: { mode: 'fresh' } },
           {
             id: 'shared-a',
             title: 'Shared',
             status: 'in_progress',
             priority: 'none',
             assignee: 'ws:auto-quant',
+            execution: { mode: 'fresh' },
             when: { kind: 'every', every: '30m' },
             nameCollision: true,
           },
@@ -215,6 +270,7 @@ describe('global board (ctx.board present)', () => {
             status: 'todo',
             priority: 'low',
             assignee: 'unassigned',
+            execution: { mode: 'fresh' },
             nameCollision: true,
           },
         ],
@@ -233,6 +289,7 @@ describe('global board (ctx.board present)', () => {
         status: 'todo',
         priority: 'high',
         assignee: 'human',
+        execution: { mode: 'fresh' },
       },
       runs: [],
       inboxReports: [],
@@ -329,7 +386,7 @@ describe('global board (ctx.board present)', () => {
     const detail: IssueDetail = {
       issue: {
         id: 'alpha', title: 'Alpha', body: 'one canonical body', status: 'todo',
-        priority: 'high', assignee: 'human', what: 'one canonical prompt',
+        priority: 'high', assignee: 'human', what: 'one canonical prompt', execution: { mode: 'fresh' },
       },
       runs: [{
         taskId: 'task-1', resumeId: 'resume-kind-owl-abc123', wsId: 'ws-a', issueId: 'alpha',

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -32,10 +32,13 @@ import {
   ISSUES_DIR_REL,
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
+  issueExecution as effectiveIssueExecution,
+  issueExecutionSchema,
   issueWhenSchema,
   parseIssueContent,
   readWorkspaceIssues,
   type IssueRecord,
+  type IssueExecution,
 } from '../workspaces/issues/declaration.js'
 import {
   appendIssueComment,
@@ -56,6 +59,39 @@ function selfDir(ctx: WorkspaceToolContext): { ok: true; dir: string } | { ok: f
   const meta = resolve(ctx.workspaceId)
   if (!meta) return { ok: false, error: `cannot locate this workspace (${ctx.workspaceId})` }
   return { ok: true, dir: meta.dir }
+}
+
+const issueExecutionInputSchema = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('fresh') }),
+  z.object({
+    mode: z.literal('resume'),
+    resumeId: z.string().min(1).optional().describe('Omit to bind the current product Session.'),
+  }),
+])
+
+function resolveIssueExecution(
+  ctx: WorkspaceToolContext,
+  execution: z.infer<typeof issueExecutionInputSchema> | undefined,
+): { ok: true; execution?: IssueExecution } | { ok: false; error: string } {
+  if (!execution) return { ok: true }
+  if (execution.mode === 'fresh') return { ok: true, execution: { mode: 'fresh' } }
+  const resumeId = execution.resumeId ?? sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)?.resumeId
+  if (!resumeId) {
+    return {
+      ok: false,
+      error: 'execution.mode "resume" needs resumeId outside an attributable product Session',
+    }
+  }
+  const parsed = issueExecutionSchema.safeParse({ mode: 'resume', resumeId })
+  if (!parsed.success) return { ok: false, error: 'invalid resume execution policy' }
+  const identity = ctx.resolveSessionIdentity?.(resumeId)
+  if (ctx.resolveSessionIdentity && !identity) {
+    return { ok: false, error: `unknown product Session: ${resumeId}` }
+  }
+  if (identity && identity.workspaceId !== ctx.workspaceId) {
+    return { ok: false, error: `product Session ${resumeId} belongs to another workspace` }
+  }
+  return { ok: true, execution: parsed.data }
 }
 
 /** The comment / create author for this workspace's writes. */
@@ -89,6 +125,7 @@ function rowOf(issue: IssueRecord, workspaceLabel?: string) {
     priority: issue.priority,
     assignee: issueAssigneeForWorkspace(issue, workspaceLabel),
     ...(issue.agent ? { agent: issue.agent } : {}),
+    ...(issue.when ? { execution: effectiveIssueExecution(issue) } : {}),
     scheduled: issue.when !== undefined,
   }
 }
@@ -159,6 +196,7 @@ function summarizeIssueRows(
       priority: row.priority,
       assignee: row.assignee,
       scheduled: row.scheduled,
+      ...(row.scheduled ? { execution: row.execution } : {}),
       workspace: row.workspace.tag,
       ...(row.nameCollision ? { nameCollision: true as const } : {}),
     })),
@@ -180,8 +218,10 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
       description: [
         "Update one of THIS workspace's issues — its board fields.",
         '',
-        'Patch any subset of `status`, `priority`, `assignee`; omitted fields are',
-        'left untouched. Scheduling frontmatter (`when`/`what`/`agent`) and the',
+        'Patch any subset of `status`, `priority`, `assignee`, `execution`; omitted fields are',
+        'left untouched. `execution:{mode:"resume"}` binds this current product',
+        'Session; pass a resumeId to assign another known Session. Other scheduling',
+        'frontmatter (`when`/`what`/`agent`) and the',
         'markdown body are preserved — edit those by writing the file directly',
         '(`.alice/issues/<id>.md`).',
         '',
@@ -197,14 +237,22 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
           .min(1)
           .optional()
           .describe('New assignee, e.g. "human", "ws:<tag>", or "unassigned".'),
+        execution: issueExecutionInputSchema.optional().describe('Scheduled ownership: fresh each fire, or resume one exact product Session.'),
       }),
-      execute: async ({ id, status, priority, assignee }) => {
+      execute: async ({ id, status, priority, assignee, execution }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
-        if (status === undefined && priority === undefined && assignee === undefined) {
-          return { ok: false as const, error: 'no fields to update (pass at least one of status/priority/assignee)' }
+        const resolvedExecution = resolveIssueExecution(ctx, execution)
+        if (!resolvedExecution.ok) return { ok: false as const, error: resolvedExecution.error }
+        if (status === undefined && priority === undefined && assignee === undefined && !resolvedExecution.execution) {
+          return { ok: false as const, error: 'no fields to update (pass status/priority/assignee/execution)' }
         }
-        const res = await updateIssueFields(dir.dir, id, { status, priority, assignee })
+        const res = await updateIssueFields(dir.dir, id, {
+          status,
+          priority,
+          assignee,
+          ...(resolvedExecution.execution ? { execution: resolvedExecution.execution } : {}),
+        })
         if (res.ok) {
           await recordIssueProvenance(ctx, res.issue.id, 'updated')
           return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
@@ -264,7 +312,9 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         '',
         'Add a `when` to make the issue self-schedule (the scanner fires `what`,',
         'or the title+body if `what` is absent, on the schedule) — otherwise it’s',
-        'a pure board work item. `body` is the markdown description.',
+        'a pure board work item. Every new scheduled issue must choose execution:',
+        '`fresh` recruits a new Session each fire; `resume` keeps one accountable',
+        'Session. Omit resumeId to bind the current Session. `body` is markdown.',
       ].join('\n'),
       inputSchema: z.object({
         title: z.string().min(1).describe('Short human title (required).'),
@@ -284,12 +334,21 @@ export const issueCreateFactory: WorkspaceToolFactory = {
           .optional()
           .describe('Schedule shape — { kind:"at", at } | { kind:"every", every } | { kind:"cron", cron }. Present iff the issue self-schedules.'),
         what: z.string().min(1).optional().describe('Prompt fired on schedule; falls back to title+body if absent.'),
-        agent: z.string().min(1).optional().describe('Adapter id to run the scheduled fire with.'),
+        agent: z.string().min(1).optional().describe('Adapter id for fresh execution; resume uses its Session-bound runtime.'),
+        execution: issueExecutionInputSchema.optional().describe('Required with `when`: fresh each fire, or resume an exact product Session.'),
         body: z.string().optional().describe('Markdown description body.'),
       }),
-      execute: async ({ title, id, status, priority, assignee, when, what, agent, body }) => {
+      execute: async ({ title, id, status, priority, assignee, when, what, agent, execution, body }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
+        if (when && !execution) {
+          return { ok: false as const, error: 'scheduled issues must explicitly choose execution.mode "fresh" or "resume"' }
+        }
+        if (!when && execution) {
+          return { ok: false as const, error: 'execution only applies to a scheduled issue with `when`' }
+        }
+        const resolvedExecution = resolveIssueExecution(ctx, execution)
+        if (!resolvedExecution.ok) return { ok: false as const, error: resolvedExecution.error }
         const res = await createIssue(dir.dir, {
           title,
           id,
@@ -299,6 +358,7 @@ export const issueCreateFactory: WorkspaceToolFactory = {
           when,
           what,
           agent,
+          ...(resolvedExecution.execution ? { execution: resolvedExecution.execution } : {}),
           body,
         })
         if (res.ok) {

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -48,6 +48,11 @@ function build(inboxReports: InboxEntry[] = []) {
         return undefined
       },
     },
+    resumeRegistry: {
+      get: (resumeId: string) => resumeId === 'resume-kind-owl-abc123'
+        ? { resumeId, wsId: 'ws-1', agent: 'codex', createdAt: 1, updatedAt: 1 }
+        : null,
+    },
     issueDetail: async (wsId: string, id: string) => {
       if (wsId !== 'ws-1') return null
       const r = await readWorkspaceIssues(wsDir)
@@ -102,6 +107,20 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     const { app } = build()
     expect((await req(app, 'PATCH', '/ws-1/i1', { agent: 'nope' })).body.error).toBe('invalid_agent')
     expect((await req(app, 'PATCH', '/ws-1/i1', { agent: 'shell' })).body.error).toBe('invalid_agent')
+  })
+
+  it('validates and persists explicit scheduled ownership', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
+    const { app } = build()
+    const invalid = await req(app, 'PATCH', '/ws-1/i1', { execution: { mode: 'resume' } })
+    expect(invalid.status).toBe(400)
+    expect(invalid.body.error).toBe('invalid_execution')
+
+    const updated = await req(app, 'PATCH', '/ws-1/i1', {
+      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
+    })
+    expect(updated.status).toBe(200)
+    expect(updated.body.issue.execution).toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
   })
 
   it('400 no_fields when the body has none of the patchable fields', async () => {

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -24,7 +24,14 @@
  */
 import { Hono } from 'hono'
 
-import { ISSUE_PRIORITIES, ISSUE_STATUSES, type IssuePriority, type IssueStatus } from '../../workspaces/issues/declaration.js'
+import {
+  ISSUE_PRIORITIES,
+  ISSUE_STATUSES,
+  issueExecutionSchema,
+  type IssueExecution,
+  type IssuePriority,
+  type IssueStatus,
+} from '../../workspaces/issues/declaration.js'
 import { appendIssueComment, updateIssueFields } from '../../workspaces/issues/mutate.js'
 import { isAgentRuntime } from '../../workspaces/cli-adapter.js'
 import { logger as launcherLogger } from '../../workspaces/logger.js'
@@ -77,7 +84,7 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
 
     const body = await safeJson(c)
     const fields = body && typeof body === 'object' ? (body as Record<string, unknown>) : {}
-    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null } = {}
+    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution } = {}
     if ('status' in fields) {
       const s = fields['status']
       if (typeof s !== 'string' || !ISSUE_STATUSES.includes(s as IssueStatus)) {
@@ -114,8 +121,27 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
         patch.agent = agent
       }
     }
+    if ('execution' in fields) {
+      const execution = issueExecutionSchema.safeParse(fields['execution'])
+      if (!execution.success) {
+        return c.json({
+          error: 'invalid_execution',
+          message: 'execution must be {mode:"fresh"} or {mode:"resume",resumeId}',
+        }, 400)
+      }
+      if (execution.data.mode === 'resume') {
+        const identity = svc.resumeRegistry.get(execution.data.resumeId)
+        if (!identity || identity.wsId !== wsId) {
+          return c.json({
+            error: 'invalid_execution_owner',
+            message: 'resumeId must identify a product Session in this Workspace',
+          }, 400)
+        }
+      }
+      patch.execution = execution.data
+    }
     if (Object.keys(patch).length === 0) {
-      return c.json({ error: 'no_fields', message: 'provide at least one of status, priority, assignee, agent' }, 400)
+      return c.json({ error: 'no_fields', message: 'provide at least one of status, priority, assignee, agent, execution' }, 400)
     }
 
     try {

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -33,6 +33,7 @@ function build(
     dispatch?: any;
     runtimeReadiness?: any;
     resumeIdentity?: any;
+    sessionDirectory?: any;
   } = {},
 ) {
   const claude = {
@@ -91,6 +92,12 @@ function build(
     },
     getAgentRuntimeReadiness,
     probeAgentRuntimeReadiness,
+    sessionDirectory: vi.fn(async (id: string) => id === 'ws-1'
+      ? (opts.sessionDirectory ?? {
+          workspace: { id: 'ws-1', tag: 'demo' },
+          sessions: [{ resumeId: 'resume-1', agent: 'claude', createdAt: 1, updatedAt: 2, resumable: true, active: false }],
+        })
+      : null),
     publicMeta: vi.fn(async (m: any) => {
       const res = await readWorkspaceMetadata(m.dir);
       return { ...m, ...(res.ok ? res.metadata : {}) };
@@ -104,6 +111,23 @@ function build(
     probeAgentRuntimeReadiness,
   };
 }
+
+async function get(app: any, path: string) {
+  const res = await app.request(path)
+  return { status: res.status, body: await res.json().catch(() => null) as any }
+}
+
+describe('GET /:id/resumes', () => {
+  it('returns the safe product Session directory', async () => {
+    const { app } = build()
+    const result = await get(app, '/ws-1/resumes')
+    expect(result.status).toBe(200)
+    expect(result.body.sessions).toEqual([
+      expect.objectContaining({ resumeId: 'resume-1', agent: 'claude', resumable: true }),
+    ])
+    expect(JSON.stringify(result.body)).not.toContain('agentSessionId')
+  })
+})
 
 async function post(app: any, path: string, body?: unknown) {
   const res = await app.request(path, {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -735,6 +735,16 @@ export function createWorkspaceRoutes(
 
   // ── sessions ─────────────────────────────────────────────────────────────
 
+  // Safe product Session directory for attribution/ownership pickers. Native
+  // runtime ids and launcher record ids stay inside WorkspaceService.
+  app.get('/:id/resumes', async (c) => {
+    const id = c.req.param('id');
+    if (!validId(id)) return c.json({ error: 'not_found' }, 404);
+    const directory = await svc.sessionDirectory(id, 100);
+    if (!directory) return c.json({ error: 'workspace_not_found' }, 404);
+    return c.json(directory);
+  });
+
   // Materialize one product-owned conversation as a stable interactive
   // Session. The frontend supplies only resumeId; native CLI ids stay in the
   // backend ResumeRegistry.

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -46,6 +46,7 @@ function ws(wsId: string, titles: string[]): IssuesSnapshotWorkspace {
       status: 'todo',
       priority: 'none',
       assignee: 'unassigned',
+      execution: { mode: 'fresh' },
     })),
   }
 }
@@ -85,13 +86,14 @@ describe('flattenBoardRows', () => {
           tag: 'auto-quant',
           status: 'ok',
           issues: [
-            { id: 'x', title: 'X', status: 'todo', priority: 'high', assignee: 'human' },
+            { id: 'x', title: 'X', status: 'todo', priority: 'high', assignee: 'human', execution: { mode: 'fresh' } },
             {
               id: 'y',
               title: 'Y',
               status: 'todo',
               priority: 'none',
               assignee: 'unassigned',
+              execution: { mode: 'fresh' },
               agent: 'pi',
               when: { kind: 'every', every: '1h' },
               nameCollision: true,
@@ -110,6 +112,7 @@ describe('flattenBoardRows', () => {
         status: 'todo',
         priority: 'high',
         assignee: 'human',
+        execution: { mode: 'fresh' },
         scheduled: false,
         workspace: { wsId: 'a', tag: 'auto-quant' },
       },
@@ -120,6 +123,7 @@ describe('flattenBoardRows', () => {
         priority: 'none',
         assignee: 'unassigned',
         agent: 'pi',
+        execution: { mode: 'fresh' },
         scheduled: true,
         workspace: { wsId: 'a', tag: 'auto-quant' },
         nameCollision: true,

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -18,7 +18,7 @@ import type {
   HeadlessTaskRecord,
   HeadlessTaskStatus,
 } from '../headless-task-registry.js'
-import type { IssuePriority, IssueRecord, IssueStatus } from './declaration.js'
+import { issueExecution, type IssueExecution, type IssuePriority, type IssueRecord, type IssueStatus } from './declaration.js'
 
 /** One board row: the issue's display fields, plus — iff it self-schedules — its
  *  `when` and the scanner's firing markers. No markdown body (Phase 2 loads it). */
@@ -30,6 +30,8 @@ export interface IssuesSnapshotIssue {
   assignee: string
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
+  /** Effective scheduled owner policy. */
+  execution: IssueExecution
   /** Present iff the issue self-schedules. */
   when?: Schedule
   /** When the scanner last fired this issue (epoch ms); only for scheduled issues. */
@@ -125,6 +127,8 @@ export interface BoardRow {
   assignee: string
   /** Adapter id for the scheduled fire override, if set. */
   agent?: string
+  /** Effective scheduled owner policy. */
+  execution?: IssueExecution
   /** True iff the issue self-schedules (snapshot `when` present). */
   scheduled: boolean
   workspace: { wsId: string; tag: string }
@@ -163,6 +167,7 @@ export function flattenBoardRows(snapshot: IssuesSnapshot): {
         priority: issue.priority,
         assignee: issue.assignee,
         ...(issue.agent ? { agent: issue.agent } : {}),
+        execution: issue.execution,
         scheduled: issue.when !== undefined,
         workspace: { wsId: ws.wsId, tag: ws.tag },
         ...(issue.nameCollision ? { nameCollision: true } : {}),
@@ -212,6 +217,8 @@ export interface IssueDetailIssue {
   what?: string
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
+  /** Effective policy; legacy files project as fresh. */
+  execution: IssueExecution
   /** When the scanner last fired this issue (epoch ms); only for scheduled issues. */
   lastFiredAtMs?: number | null
   /** When it is next due (epoch ms); only for scheduled issues. */
@@ -309,6 +316,7 @@ export function detailIssue(
     ...(issue.when ? { when: issue.when } : {}),
     ...(issue.what ? { what: issue.what } : {}),
     ...(issue.agent ? { agent: issue.agent } : {}),
+    execution: issueExecution(issue),
     ...(markers ? { lastFiredAtMs: markers.lastFiredAtMs, nextDueAtMs: markers.nextDueAtMs } : {}),
   }
 }
@@ -328,6 +336,7 @@ export function snapshotBoardIssue(
     priority: issue.priority,
     assignee: issueAssigneeForWorkspace(issue, workspaceTag),
     ...(issue.agent ? { agent: issue.agent } : {}),
+    execution: issueExecution(issue),
     ...(issue.when ? { when: issue.when } : {}),
     ...(markers ? { lastFiredAtMs: markers.lastFiredAtMs, nextDueAtMs: markers.nextDueAtMs } : {}),
   }

--- a/src/workspaces/issues/declaration.spec.ts
+++ b/src/workspaces/issues/declaration.spec.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { issueFirePrompt, isFireable, readWorkspaceIssues } from './declaration.js'
+import { issueExecution, issueFirePrompt, isFireable, readWorkspaceIssues } from './declaration.js'
 
 let dir: string
 beforeEach(async () => {
@@ -121,6 +121,21 @@ describe('readWorkspaceIssues', () => {
       expect(i.body).toBe('Scan overnight movers and summarize.')
       expect(isFireable(i)).toBe(true)
     }
+  })
+
+  it('parses resume ownership and treats legacy omission as fresh', async () => {
+    await writeIssue('owned', fm([
+      'title: Owned work',
+      'when: { kind: every, every: 30m }',
+      'execution: { mode: resume, resumeId: resume-kind-owl-abc123 }',
+    ].join('\n')))
+    await writeIssue('legacy', fm('title: Legacy\nwhen: { kind: every, every: 30m }'))
+    const result = await readWorkspaceIssues(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const byId = Object.fromEntries(result.issues.map((issue) => [issue.id, issue]))
+    expect(issueExecution(byId['owned'])).toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
+    expect(issueExecution(byId['legacy'])).toEqual({ mode: 'fresh' })
   })
 
   it('parses block-style and cron/at `when` shapes', async () => {

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -24,6 +24,7 @@
  *   when: { kind: at, at } | { kind: every, every } | { kind: cron, cron }  (OPTIONAL — present iff scheduled)
  *   what: <optional fire prompt; if absent, the fire prompt falls back to title+body>
  *   agent: <optional adapter id for the scheduled run>
+ *   execution: { mode: fresh } | { mode: resume, resumeId: <product Session id> }
  *   ---
  *   <markdown description body>
  *
@@ -71,6 +72,14 @@ export const issueWhenSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('cron'), cron: z.string().min(1) }),
 ])
 
+/** Who receives each scheduled fire. Legacy files omit this and retain the
+ * historical behavior (`fresh`); new agent-created schedules must choose. */
+export const issueExecutionSchema = z.discriminatedUnion('mode', [
+  z.object({ mode: z.literal('fresh') }),
+  z.object({ mode: z.literal('resume'), resumeId: z.string().min(1) }),
+])
+export type IssueExecution = z.infer<typeof issueExecutionSchema>
+
 /**
  * The validated frontmatter of one issue. `id` and `body` are NOT here — `id`
  * comes from the filename, `body` from below the frontmatter (see IssueRecord).
@@ -88,6 +97,17 @@ export const issueFrontmatterSchema = z.object({
   what: z.string().min(1).optional(),
   /** Which agent runtime to run the scheduled fire with; omitted uses the issue default / workspace default / first runtime. */
   agent: z.string().min(1).optional(),
+  /** `fresh`: create a new product Session each fire. `resume`: continue the
+   * exact OpenAlice-owned product Session named by resumeId. */
+  execution: issueExecutionSchema.optional(),
+}).superRefine((value, ctx) => {
+  if (value.execution && !value.when) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['execution'],
+      message: 'execution only applies to a scheduled issue with `when`',
+    })
+  }
 })
 export type IssueFrontmatter = z.infer<typeof issueFrontmatterSchema>
 
@@ -129,6 +149,11 @@ export function issueFirePrompt(issue: IssueRecord): string {
   if (what) return what
   const body = issue.body.trim()
   return body ? `${issue.title}\n\n${body}` : issue.title
+}
+
+/** Backward-compatible effective execution policy for the scanner/UI. */
+export function issueExecution(issue: IssueRecord): IssueExecution {
+  return issue.execution ?? { mode: 'fresh' }
 }
 
 /**

--- a/src/workspaces/issues/mutate.spec.ts
+++ b/src/workspaces/issues/mutate.spec.ts
@@ -49,6 +49,7 @@ describe('createIssue', () => {
       when: { kind: 'every', every: '30m' },
       what: 'run the research routine',
       agent: 'codex',
+      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
       body: 'Scan overnight movers.',
     })
     expect(res.ok).toBe(true)
@@ -61,6 +62,7 @@ describe('createIssue', () => {
       assignee: 'ws:auto-quant',
       what: 'run the research routine',
       agent: 'codex',
+      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
     })
     expect(issue?.when).toEqual({ kind: 'every', every: '30m' })
     expect(issue?.body).toBe('Scan overnight movers.')
@@ -130,6 +132,22 @@ describe('updateIssueFields', () => {
     expect(res.ok).toBe(true)
     const { issue } = await readBack('agent-clear')
     expect(issue?.agent).toBeUndefined()
+  })
+
+  it('changes scheduled ownership without disturbing the schedule', async () => {
+    await createIssue(dir, {
+      id: 'owned',
+      title: 'Owned',
+      when: { kind: 'every', every: '15m' },
+      execution: { mode: 'fresh' },
+    })
+    const res = await updateIssueFields(dir, 'owned', {
+      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
+    })
+    expect(res.ok).toBe(true)
+    const { issue } = await readBack('owned')
+    expect(issue?.execution).toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
+    expect(issue?.when).toEqual({ kind: 'every', every: '15m' })
   })
 
   it('supports a partial patch (only status)', async () => {

--- a/src/workspaces/issues/mutate.ts
+++ b/src/workspaces/issues/mutate.ts
@@ -29,9 +29,11 @@ import {
   ISSUE_STATUSES,
   ISSUES_DIR_REL,
   issueFrontmatterSchema,
+  issueExecutionSchema,
   parseIssueContent,
   splitFrontmatter,
   type IssuePriority,
+  type IssueExecution,
   type IssueRecord,
   type IssueStatus,
 } from './declaration.js'
@@ -48,6 +50,8 @@ export interface IssueFieldPatch {
   assignee?: string
   /** Runtime override for scheduled fires; null removes the override. */
   agent?: string | null
+  /** Scheduled execution owner. Use `{mode:'fresh'}` instead of deleting it. */
+  execution?: IssueExecution
 }
 
 /** Input to `createIssue`. `id` is optional — derived as a kebab slug from the
@@ -61,6 +65,7 @@ export interface CreateIssueInput {
   when?: unknown
   what?: string
   agent?: string
+  execution?: IssueExecution
   body?: string
 }
 
@@ -154,6 +159,16 @@ export async function updateIssueFields(
       data.agent = a
     }
   }
+  if (patch.execution !== undefined) {
+    if (!current.issue.when) {
+      return { ok: false, reason: 'invalid', error: 'execution only applies to a scheduled issue with `when`' }
+    }
+    const execution = issueExecutionSchema.safeParse(patch.execution)
+    if (!execution.success) {
+      return { ok: false, reason: 'invalid', error: 'execution must be {mode:"fresh"} or {mode:"resume",resumeId}' }
+    }
+    data.execution = execution.data
+  }
 
   const content = serializeIssue(data, split.body)
   // Final guard: never persist a file that wouldn't read back cleanly.
@@ -224,6 +239,9 @@ export async function createIssue(wsDir: string, input: CreateIssueInput): Promi
 
   const existing = await readWorkspaceFile(wsDir, relFor(id))
   if (existing !== null) return { ok: false, reason: 'conflict', id }
+  if (input.execution !== undefined && input.when === undefined) {
+    return { ok: false, reason: 'invalid', error: 'execution only applies to a scheduled issue with `when`' }
+  }
 
   // Assemble frontmatter from only the provided keys (so we don't write default
   // noise), then validate the whole thing against the issue schema.
@@ -234,6 +252,7 @@ export async function createIssue(wsDir: string, input: CreateIssueInput): Promi
   if (input.when !== undefined) data.when = input.when
   if (input.what !== undefined) data.what = input.what
   if (input.agent !== undefined) data.agent = input.agent
+  if (input.execution !== undefined) data.execution = input.execution
 
   const parsed = issueFrontmatterSchema.safeParse(data)
   if (!parsed.success) {

--- a/src/workspaces/schedule/declaration.ts
+++ b/src/workspaces/schedule/declaration.ts
@@ -19,8 +19,10 @@ import {
   isFireable,
   isTerminalStatus,
   issueFirePrompt,
+  issueExecution,
   readWorkspaceIssues,
   type IssueRecord,
+  type IssueExecution,
 } from '../issues/declaration.js'
 
 export {
@@ -45,6 +47,7 @@ export interface ScheduleSnapshotTask {
   /** The prompt this fire hands to the headless run (resolved `what`/title+body). */
   what: string
   agent?: string
+  execution: IssueExecution
   /** False once the owning issue reaches a terminal status (done/canceled). */
   enabled: boolean
   /** When the scanner last fired this issue (epoch ms), null if never. */
@@ -99,6 +102,7 @@ export function snapshotScheduledIssue(
     when,
     what: issueFirePrompt(issue),
     ...(issue.agent ? { agent: issue.agent } : {}),
+    execution: issueExecution(issue),
     enabled: !isTerminalStatus(issue.status),
     lastFiredAtMs,
     // An overdue computed time clamps to now: a due-now task reads "due now",

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -8,8 +8,9 @@ import type { Schedule } from '../../core/schedule-expr.js'
 import type { CliAdapter } from '../cli-adapter.js'
 import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
+import type { IssueExecution } from '../issues/declaration.js'
 
-import { ScheduleScanner, type MarkerStore } from './scanner.js'
+import { ScheduleScanner, type MarkerStore, type ScheduleScannerDeps } from './scanner.js'
 
 const NOW = 1_700_000_000_000 // realistic epoch ms — `every` is relative-from-0, so first-sight needs a large clock
 
@@ -69,6 +70,7 @@ interface IssueSpec {
   status?: string
   priority?: string
   agent?: string
+  execution?: IssueExecution
   body?: string
 }
 
@@ -79,6 +81,10 @@ function issueMd(spec: IssueSpec): string {
   if (spec.priority) lines.push(`priority: ${spec.priority}`)
   if (spec.what) lines.push(`what: ${spec.what}`)
   if (spec.agent) lines.push(`agent: ${spec.agent}`)
+  if (spec.execution?.mode === 'fresh') lines.push('execution: { mode: fresh }')
+  if (spec.execution?.mode === 'resume') {
+    lines.push(`execution: { mode: resume, resumeId: ${spec.execution.resumeId} }`)
+  }
   if (spec.when) {
     const w = spec.when
     const inner =
@@ -111,17 +117,19 @@ function scannerFor(
       p: string,
       t: number,
       issueId?: string,
+      resumeId?: string,
     ) => Promise<{ taskId: string }>
     markers?: MarkerStore
     now?: number
     adapter?: CliAdapter
+    resolveAdapter?: ScheduleScannerDeps['resolveAdapter']
   } = {},
 ) {
   const dispatch = opts.dispatch ?? vi.fn(async () => ({ taskId: 'run-1' }))
   const markers = opts.markers ?? new FakeMarkers()
   const scanner = new ScheduleScanner({
     registry: { list: () => workspaces } as unknown as WorkspaceRegistry,
-    resolveAdapter: () => opts.adapter ?? headlessAdapter,
+    resolveAdapter: opts.resolveAdapter ?? (() => opts.adapter ?? headlessAdapter),
     dispatch,
     markers,
     logger: noopLogger,
@@ -139,6 +147,31 @@ describe('ScheduleScanner', () => {
     // 5th arg = the firing issue's id, threaded so the run records its origin.
     expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'go', expect.any(Number), 't1')
     expect(markers.get('w1', 't1')).toBe(NOW)
+  })
+
+  it('passes one exact resumeId through adapter resolution and dispatch', async () => {
+    const ws = await makeWs('w1', [{
+      id: 'owned',
+      title: 'owned work',
+      when: { kind: 'every', every: '30m' },
+      what: 'continue',
+      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
+    }])
+    const resolveAdapter = vi.fn(async () => headlessAdapter)
+    const { scanner, dispatch } = scannerFor([ws], { resolveAdapter })
+    await scanner.scan()
+
+    expect(resolveAdapter).toHaveBeenCalledWith(ws, undefined, 'resume-kind-owl-abc123')
+    expect(dispatch).toHaveBeenCalledWith(
+      ws,
+      headlessAdapter,
+      'continue',
+      expect.any(Number),
+      'owned',
+      'resume-kind-owl-abc123',
+    )
+    expect(scanner.snapshot()!.workspaces[0].tasks[0].execution)
+      .toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
   })
 
   it('ignores an UNSCHEDULED issue (no when): never fires, never in the snapshot', async () => {

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -30,7 +30,7 @@ import type { CliAdapter } from '../cli-adapter.js'
 import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
 
-import { isFireable, issueFirePrompt, readWorkspaceIssues } from '../issues/declaration.js'
+import { isFireable, issueExecution, issueFirePrompt, readWorkspaceIssues, type IssueExecution } from '../issues/declaration.js'
 
 import {
   fireBase,
@@ -54,7 +54,7 @@ export interface MarkerStore {
 
 export interface ScheduleScannerDeps {
   registry: WorkspaceRegistry
-  resolveAdapter: (meta: WorkspaceMeta, agentId?: string) => CliAdapter | Promise<CliAdapter>
+  resolveAdapter: (meta: WorkspaceMeta, agentId?: string, resumeId?: string) => CliAdapter | Promise<CliAdapter>
   dispatch: (
     meta: WorkspaceMeta,
     adapter: CliAdapter,
@@ -64,6 +64,8 @@ export interface ScheduleScannerDeps {
      *  its real run history. The scanner ALWAYS passes it (it only fires from an
      *  issue); manual/external dispatch callers omit it. */
     issueId?: string,
+    /** Product Session to continue. Omitted means allocate a fresh Session. */
+    resumeId?: string,
   ) => Promise<{ taskId: string }>
   markers: MarkerStore
   logger: Logger
@@ -186,7 +188,7 @@ export class ScheduleScanner {
       if (!when) continue
       seen.add(this.deps.markers.key(ws.id, issue.id))
       if (isFireable(issue) && this.isDue(ws.id, issue.id, when, nowMs)) {
-        await this.fire(ws, issue.id, issueFirePrompt(issue), issue.agent, nowMs)
+        await this.fire(ws, issue.id, issueFirePrompt(issue), issue.agent, issueExecution(issue), nowMs)
       }
       // Read the marker AFTER any fire so last/next reflect a just-fired run.
       const last = this.deps.markers.get(ws.id, issue.id) ?? null
@@ -206,19 +208,30 @@ export class ScheduleScanner {
     taskId: string,
     what: string,
     agentId: string | undefined,
+    execution: IssueExecution,
     nowMs: number,
   ): Promise<void> {
-    const adapter = await this.deps.resolveAdapter(ws, agentId)
-    if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
-      this.deps.logger.warn('schedule.adapter_not_headless', { wsId: ws.id, taskId, agent: adapter.id })
-      return
-    }
     try {
+      const resumeId = execution.mode === 'resume' ? execution.resumeId : undefined
+      const adapter = await this.deps.resolveAdapter(ws, agentId, resumeId)
+      if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
+        this.deps.logger.warn('schedule.adapter_not_headless', { wsId: ws.id, taskId, agent: adapter.id })
+        return
+      }
       // `taskId` here is the firing ISSUE's id (keyed by filename stem) — thread
       // it so the run records which issue triggered it.
-      const { taskId: runId } = await this.deps.dispatch(ws, adapter, what, RUN_TIMEOUT_MS, taskId)
+      const { taskId: runId } = resumeId
+        ? await this.deps.dispatch(ws, adapter, what, RUN_TIMEOUT_MS, taskId, resumeId)
+        : await this.deps.dispatch(ws, adapter, what, RUN_TIMEOUT_MS, taskId)
       await this.deps.markers.set(ws.id, taskId, nowMs)
-      this.deps.logger.info('schedule.fired', { wsId: ws.id, taskId, agent: adapter.id, runId })
+      this.deps.logger.info('schedule.fired', {
+        wsId: ws.id,
+        taskId,
+        agent: adapter.id,
+        runId,
+        executionMode: execution.mode,
+        ...(resumeId ? { resumeId } : {}),
+      })
     } catch (err) {
       // Capacity full (or transient) - do NOT mark; the task stays due and
       // retries on the next tick once a headless slot frees.

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -1130,10 +1130,16 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   );
   const scheduleScanner = new ScheduleScanner({
     registry,
-    resolveAdapter: async (ws, agentId) => resolveAdapter(
-      ws,
-      agentId ?? await resolveIssueDefaultAgentId(ws),
-    ),
+    resolveAdapter: async (ws, agentId, resumeId) => {
+      if (resumeId) {
+        const identity = resumeRegistry.get(resumeId);
+        if (!identity) throw new Error(`unknown resume conversation: ${resumeId}`);
+        if (identity.wsId !== ws.id) throw new Error(`resume conversation belongs to another workspace`);
+        return resolveAdapter(ws, identity.agent);
+      }
+      if (agentId) return resolveAdapter(ws, agentId);
+      return resolveAdapter(ws, await resolveIssueDefaultAgentId(ws));
+    },
     dispatch: dispatchHeadlessTaskMethod,
     markers: scheduleMarkers,
     logger: launcherLogger.child({ scope: 'schedule' }),

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -43,7 +43,9 @@ Output is JSON on stdout; a non-zero exit means it failed (reason on stderr).
 **To place a trade, that's `alice-uta`** — resolve the contract first and report
 every result. Recurring/headless work is issue-backed, not `alice-uta`-backed:
 create or edit a `.alice/issues/<id>.md` issue with a `when` field (or use
-`alice-workspace issue create --when ...`) and write a complete `what` prompt.
+`alice-workspace issue create --when ... --execution '{"mode":"resume"}'`) and
+write a complete `what` prompt. Choose `resume` for one accountable Session or
+`fresh` to recruit a new Session each fire.
 
 ## Beyond Alice's data — `opencli` (optional, read-only)
 
@@ -122,6 +124,7 @@ For recurring work, create a scheduled issue instead of inventing a side channel
 ```bash
 alice-workspace issue create --title "Pre-market power brief" --priority high \
   --when '{"kind":"cron","cron":"30 8 * * 1-5"}' \
+  --execution '{"mode":"resume"}' \
   --what "Check AI power infrastructure names, write research/premarket-power.md, then push it to Inbox if there is a material update."
 ```
 

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -22,6 +22,9 @@ import type { ScheduleWhen } from './schedule'
 
 export type IssueStatus = 'backlog' | 'todo' | 'in_progress' | 'done' | 'canceled'
 export type IssuePriority = 'urgent' | 'high' | 'medium' | 'low' | 'none'
+export type IssueExecution =
+  | { mode: 'fresh' }
+  | { mode: 'resume'; resumeId: string }
 
 export interface IssueListItem {
   id: string
@@ -32,6 +35,8 @@ export interface IssueListItem {
   assignee: string
   /** Adapter id for the scheduled fire override, if set. */
   agent?: string
+  /** Effective scheduled owner policy; legacy server payloads may omit it. */
+  execution?: IssueExecution
   /** Present iff the issue is scheduled (shares the core Schedule union). */
   when?: ScheduleWhen
   /** Scanner last-fired marker (epoch ms) — scheduled issues only. */
@@ -123,6 +128,8 @@ export interface IssueDetailIssue {
   what?: string
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
+  /** Effective scheduled owner policy; legacy server payloads may omit it. */
+  execution?: IssueExecution
   /** Scanner last-fired marker (epoch ms) — scheduled issues only. */
   lastFiredAtMs?: number | null
   /** Computed next fire (epoch ms) — scheduled issues only. */
@@ -178,7 +185,7 @@ export const issuesApi = {
   async update(
     wsId: string,
     id: string,
-    patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null },
+    patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution },
   ): Promise<IssueDetail> {
     return fetchJson<IssueDetail>(
       `/api/issues/${encodeURIComponent(wsId)}/${encodeURIComponent(id)}`,

--- a/ui/src/api/schedule.ts
+++ b/ui/src/api/schedule.ts
@@ -1,4 +1,5 @@
 import { fetchJson } from './client'
+import type { IssueExecution } from './issues'
 
 export type ScheduleWhen =
   | { kind: 'at'; at: string }
@@ -12,6 +13,7 @@ export interface ScheduleTask {
   when: ScheduleWhen
   what: string
   agent?: string
+  execution?: IssueExecution
   enabled: boolean
   /** When the scanner last fired this task (epoch ms), null if never. */
   lastFiredAtMs: number | null

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -7,12 +7,19 @@ import type { InboxEntry } from '../api/inbox'
 import type {
   IssueDetail as IssueDetailData,
   IssueDetailIssue,
+  IssueExecution,
   IssuePriority,
   IssueStatus,
   WikilinkIssueRef,
   WikilinkResolution,
 } from '../api/issues'
-import { getAgentReadiness, type AgentCredentialReadiness, type AgentId } from './workspace/api'
+import {
+  getAgentReadiness,
+  getWorkspaceSessionDirectory,
+  type AgentCredentialReadiness,
+  type AgentId,
+  type WorkspaceSessionDirectoryEntry,
+} from './workspace/api'
 import { issuesApi } from '../api/issues'
 import { useIssueDetail } from '../hooks/useIssueDetail'
 import { useIssues } from '../hooks/useIssues'
@@ -240,6 +247,51 @@ function AgentEditor({
   )
 }
 
+function ExecutionEditor({
+  value,
+  sessions,
+  disabled,
+  onChange,
+}: {
+  value?: IssueExecution
+  sessions: readonly WorkspaceSessionDirectoryEntry[]
+  disabled?: boolean
+  onChange: (next: IssueExecution) => void
+}) {
+  const labelFor = (session: WorkspaceSessionDirectoryEntry) => {
+    const raw = session.interactive?.title
+      || session.interactive?.name
+      || session.latestExecution?.assistantPreview
+      || session.resumeId
+    return raw.length > 44 ? `${raw.slice(0, 43)}…` : raw
+  }
+  const selected = value?.mode === 'resume' ? value.resumeId : '__fresh__'
+  const choices = sessions.filter((session) => session.resumeId && session.agent !== 'shell')
+  const hasSelected = value?.mode !== 'resume' || choices.some((session) => session.resumeId === value.resumeId)
+
+  return (
+    <select
+      className={railControl}
+      value={selected}
+      disabled={disabled}
+      onChange={(event) => {
+        const resumeId = event.target.value
+        onChange(resumeId === '__fresh__' ? { mode: 'fresh' } : { mode: 'resume', resumeId })
+      }}
+    >
+      <option value="__fresh__">Fresh Session each fire</option>
+      {choices.map((session) => (
+        <option key={session.resumeId} value={session.resumeId}>
+          Continue {labelFor(session)} · {session.agent}
+        </option>
+      ))}
+      {!hasSelected && value?.mode === 'resume' && (
+        <option value={value.resumeId}>Continue {value.resumeId}</option>
+      )}
+    </select>
+  )
+}
+
 function PropertiesRail({
   issue,
   wsTag,
@@ -247,6 +299,7 @@ function PropertiesRail({
   issueDefaultAgent,
   defaultAgent,
   agentReadiness,
+  sessions,
   saving,
   error,
   onPatch,
@@ -258,15 +311,20 @@ function PropertiesRail({
   issueDefaultAgent: string | null
   defaultAgent: string | null
   agentReadiness: Readonly<Record<string, AgentCredentialReadiness>>
+  sessions: readonly WorkspaceSessionDirectoryEntry[]
   saving: boolean
   error: string | null
-  onPatch: (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null }) => void
+  onPatch: (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution }) => void
   onConfigureAgent: (agent: AgentId) => void
 }) {
   const meta = STATUS_META[issue.status]
   const issueDefaultInOptions = issueDefaultAgent && agentOptions.some((a) => a.id === issueDefaultAgent) ? issueDefaultAgent : null
   const defaultInOptions = defaultAgent && agentOptions.some((a) => a.id === defaultAgent) ? defaultAgent : null
-  const effectiveAgent = issue.agent || issueDefaultInOptions || defaultInOptions || agentOptions[0]?.id || null
+  const ownerResumeId = issue.execution?.mode === 'resume' ? issue.execution.resumeId : null
+  const ownerSession = ownerResumeId
+    ? sessions.find((session) => session.resumeId === ownerResumeId)
+    : undefined
+  const effectiveAgent = ownerSession?.agent || issue.agent || issueDefaultInOptions || defaultInOptions || agentOptions[0]?.id || null
   const selectedReadiness = effectiveAgent ? agentReadiness[effectiveAgent] : undefined
   const agentNeedsCredential = selectedReadiness?.requiresCredential === true && !selectedReadiness.ready
   return (
@@ -314,18 +372,36 @@ function PropertiesRail({
         <PropRow label="Cadence">
           {issue.when ? <CadencePill when={issue.when} /> : <span className="text-muted">—</span>}
         </PropRow>
-        <EditRow label="Agent">
-          <AgentEditor
-            value={issue.agent}
-            issueDefaultAgent={issueDefaultAgent}
-            defaultAgent={defaultAgent}
-            options={agentOptions}
-            readiness={agentReadiness}
-            disabled={saving}
-            onChange={(agent) => onPatch({ agent })}
-            onConfigure={onConfigureAgent}
-          />
-        </EditRow>
+        {issue.when && (
+          <EditRow label="Ownership">
+            <ExecutionEditor
+              value={issue.execution}
+              sessions={sessions}
+              disabled={saving}
+              onChange={(execution) => onPatch({ execution })}
+            />
+          </EditRow>
+        )}
+        {issue.execution?.mode === 'resume' ? (
+          <PropRow label="Agent">
+            <span title="The responsible Session determines its runtime">
+              {ownerSession?.agent ?? 'Session-owned'}
+            </span>
+          </PropRow>
+        ) : (
+          <EditRow label="Agent">
+            <AgentEditor
+              value={issue.agent}
+              issueDefaultAgent={issueDefaultAgent}
+              defaultAgent={defaultAgent}
+              options={agentOptions}
+              readiness={agentReadiness}
+              disabled={saving}
+              onChange={(agent) => onPatch({ agent })}
+              onConfigure={onConfigureAgent}
+            />
+          </EditRow>
+        )}
         {agentNeedsCredential && (
           <p className="-mt-1 pb-2 text-right text-[11px] leading-snug text-amber-400">
             AI credential missing.
@@ -650,6 +726,7 @@ export function IssueDetail({
   const [saving, setSaving] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
   const [agentReadiness, setAgentReadiness] = useState<Record<string, AgentCredentialReadiness>>({})
+  const [sessionDirectory, setSessionDirectory] = useState<readonly WorkspaceSessionDirectoryEntry[]>([])
   // Set when a clicked `[[name]]` resolves to >1 target — drives the picker.
   const [picker, setPicker] = useState<WikilinkResolution | null>(null)
 
@@ -661,6 +738,18 @@ export function IssueDetail({
       })
       .catch(() => {
         if (live) setAgentReadiness({})
+      })
+    return () => { live = false }
+  }, [wsId])
+
+  useEffect(() => {
+    let live = true
+    getWorkspaceSessionDirectory(wsId)
+      .then((directory) => {
+        if (live) setSessionDirectory(directory.sessions)
+      })
+      .catch(() => {
+        if (live) setSessionDirectory([])
       })
     return () => { live = false }
   }, [wsId])
@@ -728,7 +817,7 @@ export function IssueDetail({
   )
 
   const onPatch = useCallback(
-    async (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null }) => {
+    async (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution }) => {
       setSaving(true)
       setActionError(null)
       try {
@@ -812,6 +901,7 @@ export function IssueDetail({
           issueDefaultAgent={issueDefaultAgent}
           defaultAgent={defaultAgent}
           agentReadiness={agentReadiness}
+          sessions={sessionDirectory}
           saving={saving}
           error={actionError}
           onPatch={onPatch}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -371,6 +371,39 @@ export interface SpawnOptions {
   readonly terminalTheme?: TerminalThemeVariant;
 }
 
+export interface WorkspaceSessionDirectoryEntry {
+  readonly resumeId: string;
+  readonly agent: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly resumable: boolean;
+  readonly active: boolean;
+  readonly latestExecution?: {
+    readonly taskId: string;
+    readonly status: 'running' | 'done' | 'failed' | 'interrupted';
+    readonly startedAt: number;
+    readonly issueId?: string;
+    readonly assistantPreview?: string;
+  };
+  readonly interactive?: {
+    readonly name: string;
+    readonly title?: string;
+    readonly state: 'running' | 'paused';
+    readonly lastActiveAt: string;
+  };
+}
+
+export interface WorkspaceSessionDirectory {
+  readonly workspace: { readonly id: string; readonly tag: string };
+  readonly sessions: readonly WorkspaceSessionDirectoryEntry[];
+}
+
+export async function getWorkspaceSessionDirectory(id: string): Promise<WorkspaceSessionDirectory> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(id)}/resumes`);
+  if (!res.ok) throw new Error(`Failed to load Workspace Sessions (${res.status})`);
+  return res.json() as Promise<WorkspaceSessionDirectory>;
+}
+
 export async function spawnSession(
   id: string,
   opts: SpawnOptions = {},


### PR DESCRIPTION
## What changed

- add `execution: { mode: fresh } | { mode: resume, resumeId }` to Issue frontmatter
- keep legacy Issues without the field on the historical fresh-run behavior
- require new agent-created scheduled Issues to choose ownership explicitly
- bind `execution:{mode:"resume"}` to the server-attributed current Session when resumeId is omitted
- validate explicit owners against the Issue Workspace and keep runtime selection owned by the Session
- pass resumeId through ScheduleScanner into headless dispatch while fresh mode continues allocating a new Session
- expose the safe Workspace Session directory to the frontend
- add an Issue-detail Ownership picker covering interactive and headless-only Sessions
- update agent skills and architecture docs

## Why

An Issue creator and an Issue executor are different identities. Scheduled work previously always recruited a fresh headless Session, so the product could not express “this exact colleague remains responsible” or distinguish it from “pull a new analyst each time.”

## Impact

Users and agents can now deliberately choose conversational continuity. Resume mode keeps one accountable product Session across fires; fresh mode keeps stateless worker rotation. Runtime-native session ids remain backend-only, and a Session from another Workspace is rejected before the Issue file is written.

## Validation

- `pnpm test` — 217 files passed, 2556 tests passed, 6 skipped
- `pnpm build`
- `npx tsc --noEmit` and UI `tsc -b`
- live CLI manifest and rejection-path verification
- live same-Workspace vs foreign-Workspace resumeId validation without file mutation
- browser verification on a real scheduled Issue: Ownership picker rendered correctly and listed all 22 product Sessions, including headless-only histories