### PR TITLE
Record exact revisions for published reports

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -26,13 +26,14 @@ alice-workspace inbox push --doc research/tsla.md --comments "Done — TSLA look
 ```
 
 (Attach files with repeatable `--doc <path>` — workspace-relative; each renders
-live in the inbox UI, not snapshotted. `--comments` is your markdown note. At
+live in the inbox UI. OpenAlice records the exact published content hash even
+though later edits remain visible. `--comments` is your markdown note. At
 least one of `--doc` / `--comments` must be present.)
 
 > **Commit before you push.** The inbox renders your files live, not a snapshot —
 > a `git commit` is the only durable record of what you actually sent. Skip it and
-> a later edit (yours or a collaborator's) silently rewrites what the entry shows,
-> with nothing to recover.
+> a later edit changes what the entry shows. The publication hash proves which
+> revision was sent, while the commit preserves content you can recover.
 
 **Look back at the inbox** — recall what's been surfaced, newest first:
 

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -186,6 +186,11 @@ Reports are currently Markdown files. Their durable identity is at least
 `{ workspaceId, path }`; asking about mutable contents additionally needs a
 revision (git commit, content hash, or another immutable version handle).
 
+`inbox_push` stamps a `sha256:<hex>` revision from the report bytes it publishes
+and uses that same revision in both the Inbox attachment and report provenance
+edge. Rendering remains live; the hash identifies what was sent rather than
+freezing a second copy of the file.
+
 A report can have separate provenance for:
 
 - initial creation;

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -161,8 +161,10 @@ alice-workspace inbox push --doc <path> --comments "<summary>"
 ```
 
 The launcher binds the run/issue origin; the agent does not pass its own
-identity. A no-change check should exit silently rather than generating Inbox
-noise. `alice-workspace inbox read` returns this safe provenance to internal
+identity. Attached reports also receive a publication-time SHA-256 revision;
+the Inbox still renders the live file, but provenance can distinguish the sent
+revision from later edits. A no-change check should exit silently rather than
+generating Inbox noise. `alice-workspace inbox read` returns this safe provenance to internal
 agents as `origin` (`runId` / `sessionId`, `resumeId`, `issueId`, and `agent`
 when available). For append-only entries created before `resumeId` was stamped,
 the read path joins the stored run/session handle against the live registries;

--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -45,6 +45,8 @@ import { EventEmitter } from 'node:events'
 export interface InboxDoc {
   /** Path relative to the workspace root. */
   path: string
+  /** Content identity at publication time. The file is still rendered live. */
+  revision?: string
 }
 
 /**

--- a/src/tool/inbox-push.spec.ts
+++ b/src/tool/inbox-push.spec.ts
@@ -1,8 +1,11 @@
 import type { Tool } from 'ai'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
-import { inboxPushFactory } from './inbox-push.js'
+import { inboxPushFactory, reportContentRevision } from './inbox-push.js'
 
 async function run(tool: Tool, args: Record<string, unknown>) {
   return tool.execute!(args, { toolCallId: 'test', messages: [] })
@@ -21,6 +24,32 @@ function context(over: Partial<WorkspaceToolContext> = {}): WorkspaceToolContext
 }
 
 describe('inbox_push provenance', () => {
+  it('stamps the exact published report revision onto Inbox and provenance', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'inbox-report-revision-'))
+    try {
+      await mkdir(join(dir, 'research'), { recursive: true })
+      await writeFile(join(dir, 'research', 'a.md'), '# Published\n', 'utf8')
+      const appendInbox = vi.fn(async (input) => ({ ...input, id: 'entry-1', ts: 123 }))
+      const appendProvenance = vi.fn(async (input) => ({ id: 'p-1', ...input }))
+      const ctx = context({
+        inboxStore: { append: appendInbox } as never,
+        provenanceStore: { append: appendProvenance, list: vi.fn(), latest: vi.fn() },
+        resolveWorkspace: () => ({ id: 'ws-1', tag: 'desk', dir }),
+      })
+
+      await run(inboxPushFactory.build(ctx), { docs: [{ path: 'research/a.md' }] })
+      const revision = reportContentRevision('# Published\n')
+      expect(appendInbox).toHaveBeenCalledWith(expect.objectContaining({
+        docs: [{ path: 'research/a.md', revision }],
+      }))
+      expect(appendProvenance).toHaveBeenCalledWith(expect.objectContaining({
+        artifact: { kind: 'report', workspaceId: 'ws-1', path: 'research/a.md', revision },
+      }))
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it('records the notification and published report against the caller Session', async () => {
     const append = vi.fn(async (input) => ({ id: `p-${input.action}`, ...input }))
     const ctx = context({

--- a/src/tool/inbox-push.ts
+++ b/src/tool/inbox-push.ts
@@ -15,10 +15,17 @@
  * they can't sensibly use.
  */
 
+import { createHash } from 'node:crypto'
+
 import { tool } from 'ai'
 import { z } from 'zod'
 import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
 import { sessionOriginFromInboxOrigin } from '../core/provenance-store.js'
+import { readWorkspaceFile } from '../workspaces/file-service.js'
+
+export function reportContentRevision(content: string): string {
+  return `sha256:${createHash('sha256').update(content, 'utf8').digest('hex')}`
+}
 
 export const inboxPushFactory: WorkspaceToolFactory = {
   name: 'inbox_push',
@@ -33,8 +40,9 @@ export const inboxPushFactory: WorkspaceToolFactory = {
         '',
         '`docs` are paths relative to this workspace root. Each one',
         'is rendered live in the inbox UI when the user opens the',
-        'entry — no snapshot is taken, so later edits to the file',
-        'will be reflected on subsequent reads.',
+        'entry — later edits remain visible. OpenAlice also records a content',
+        'hash for the exact revision published, so later readers can distinguish',
+        '“what was sent then” from the current live file.',
         '',
         '`comments` is markdown — your voice to the user about what',
         'you did or want to ask. Keep it short and direct; if more',
@@ -70,10 +78,18 @@ export const inboxPushFactory: WorkspaceToolFactory = {
       }),
       execute: async ({ docs, comments }) => {
         try {
+          const workspace = ctx.resolveWorkspace?.(ctx.workspaceId)
+          const publishedDocs = await Promise.all((docs ?? []).map(async (doc) => {
+            if (!workspace) return doc
+            const content = await readWorkspaceFile(workspace.dir, doc.path)
+            return content === null
+              ? doc
+              : { ...doc, revision: reportContentRevision(content) }
+          }))
           const entry = await ctx.inboxStore.append({
             workspaceId: ctx.workspaceId,
             workspaceLabel: ctx.workspaceLabel,
-            docs,
+            ...(docs ? { docs: publishedDocs } : {}),
             comments,
             // Agent-invisible: stamped from the server-resolved run origin, NOT
             // from anything in the tool's input schema. Omit the key entirely
@@ -92,11 +108,16 @@ export const inboxPushFactory: WorkspaceToolFactory = {
             })
             for (const doc of entry.docs ?? []) {
               await ctx.provenanceStore.append({
-                artifact: { kind: 'report', workspaceId: ctx.workspaceId, path: doc.path },
+                artifact: {
+                  kind: 'report',
+                  workspaceId: ctx.workspaceId,
+                  path: doc.path,
+                  ...(doc.revision ? { revision: doc.revision } : {}),
+                },
                 action: 'sent',
                 origin,
                 at: entry.ts,
-                fingerprint: `report:${ctx.workspaceId}:${doc.path}:sent:${entry.id}`,
+                fingerprint: `report:${ctx.workspaceId}:${doc.path}:${doc.revision ?? 'unversioned'}:sent:${entry.id}`,
               })
             }
           }

--- a/src/tool/inbox-read.spec.ts
+++ b/src/tool/inbox-read.spec.ts
@@ -20,6 +20,7 @@ async function run(tool: Tool, args: Record<string, unknown>) {
       workspace: string
       comments?: string
       docs: string[]
+      docRevisions?: Record<string, string>
       origin?: InboxOrigin
     }>
   }
@@ -39,7 +40,11 @@ async function seeded(): Promise<WorkspaceToolContext> {
       agent: 'pi',
     },
   })
-  await inboxStore.append({ workspaceId: WS, workspaceLabel: 'Mine', docs: [{ path: 'b.md' }, { path: 'c.md' }] })
+  await inboxStore.append({
+    workspaceId: WS,
+    workspaceLabel: 'Mine',
+    docs: [{ path: 'b.md', revision: 'sha256:bbbb' }, { path: 'c.md' }],
+  })
   return {
     workspaceId: WS,
     workspaceLabel: 'Mine',
@@ -94,6 +99,12 @@ describe('inbox_read', () => {
       issueId: 'daily-scan',
       agent: 'pi',
     })
+  })
+
+  it('keeps path compatibility and adds published revision metadata', async () => {
+    const res = await run(inboxReadFactory.build(await seeded()), { self: true })
+    expect(res.entries[0].docs).toEqual(['b.md', 'c.md'])
+    expect(res.entries[0].docRevisions).toEqual({ 'b.md': 'sha256:bbbb' })
   })
 
   it('`limit` caps the newest-first window and reports hasMore', async () => {

--- a/src/tool/inbox-read.ts
+++ b/src/tool/inbox-read.ts
@@ -84,6 +84,15 @@ export const inboxReadFactory: WorkspaceToolFactory = {
                 workspace: e.workspaceLabel ?? e.workspaceId,
                 comments: e.comments,
                 docs: (e.docs ?? []).map((d) => d.path),
+                ...((e.docs ?? []).some((doc) => doc.revision)
+                  ? {
+                      docRevisions: Object.fromEntries(
+                        (e.docs ?? [])
+                          .filter((doc) => doc.revision)
+                          .map((doc) => [doc.path, doc.revision]),
+                      ),
+                    }
+                  : {}),
                 ...(origin ? { origin } : {}),
               }
             }),

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -507,7 +507,12 @@ export const issueShowFactory: WorkspaceToolFactory = {
                   workspaceId: entry.workspaceId,
                   workspaceLabel: entry.workspaceLabel,
                   ts: entry.ts,
-                  ...(entry.docs ? { docs: entry.docs.map((doc) => ({ path: doc.path })) } : {}),
+                  ...(entry.docs ? {
+                    docs: entry.docs.map((doc) => ({
+                      path: doc.path,
+                      ...(doc.revision ? { revision: doc.revision } : {}),
+                    })),
+                  } : {}),
                   ...(entry.comments ? { comments: entry.comments } : {}),
                   ...(entry.origin ? { origin: entry.origin } : {}),
                 })),

--- a/ui/src/api/inbox.ts
+++ b/ui/src/api/inbox.ts
@@ -2,6 +2,8 @@ import { fetchJson } from './client'
 
 export interface InboxDoc {
   path: string
+  /** Content hash captured when this doc was published; rendering stays live. */
+  revision?: string
 }
 
 /**

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -462,6 +462,14 @@ function DocBlock({
         />
         <span className="text-[12px]">📄</span>
         <span className="flex-1 truncate text-[12px] font-mono text-text-muted">{doc.path}</span>
+        {doc.revision && (
+          <span
+            className="shrink-0 rounded bg-bg-tertiary px-1.5 py-0.5 font-mono text-[9px] text-text-muted/60"
+            title={`Published revision ${doc.revision}`}
+          >
+            sent {doc.revision.replace(/^sha256:/, '').slice(0, 8)}
+          </span>
+        )}
         <span className="shrink-0 text-[10px] uppercase tracking-wider text-text-muted/45">
           {expanded ? t('inbox.docCollapse') : t('inbox.docExpand')}
         </span>


### PR DESCRIPTION
## What changed

- hash each readable Inbox attachment as `sha256:<hex>` at publication time
- store the same revision on the Inbox doc pointer and report provenance edge
- keep Inbox rendering live rather than snapshotting a second copy
- preserve the agent-facing `docs: string[]` contract and add `docRevisions` metadata
- retain revision metadata in compact Issue report projections
- show a short published-revision badge in the Inbox document header
- document the distinction between the sent revision and later live edits

## Why

A path alone cannot answer “which version did this Session publish?” because Workspace reports remain mutable and Inbox intentionally renders them live. The publication occurrence needs an immutable content identity without creating a stale parallel document store.

## Impact

Provenance can now attribute the exact report revision sent by a Session. Later edits remain visible to users, while the Inbox and provenance index retain one shared content hash for historical follow-up. Missing or legacy files remain honestly unversioned.

## Validation

- `pnpm test` — 217 files passed, 2558 tests passed, 6 skipped
- `pnpm build`
- root and UI TypeScript builds
- focused Inbox push/read/projection tests, including filesystem-backed hash verification