### PR TITLE
feat(issues): expose Session provenance

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -87,7 +87,7 @@ It's *what's on the plate* when you've lost the thread — scan it when you star
 ```bash
 alice-workspace issue list                  # startup-safe summary: local + active urgent/high/medium rows
 alice-workspace issue list --mode detailed  # full global board, including low-priority scheduled noise
-alice-workspace issue show --id <name>      # compact issue + resumeId run/report references
+alice-workspace issue show --id <name>      # compact issue + provenance/resumeId run/report references
 alice-workspace issue show --id <name> --mode detailed  # every execution prompt + full reports
 alice-workspace issue create --title "…"    # a new issue on THIS workspace's board
 alice-workspace issue create --title "…" --when '{"kind":"every","every":"1h"}' --execution '{"mode":"resume"}'

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -127,7 +127,7 @@ type ArtifactRef =
 
 interface ProvenanceEdge {
   artifact: ArtifactRef
-  action: 'created' | 'updated' | 'sent' | 'decided'
+  action: 'created' | 'updated' | 'commented' | 'sent' | 'decided'
   origin: SessionOrigin | { kind: 'human' } | { kind: 'external'; system: string }
   at: number
 }
@@ -231,6 +231,13 @@ An Issue has two independent identity questions:
    Session, or should the Workspace pull a fresh worker every time?
 
 Creating an Issue must explicitly choose one execution mode.
+
+Issue detail and `alice-workspace issue show` expose the immutable
+`created` / `updated` / `commented` occurrences newest-first. Session origins
+carry a product `resumeId`, so a human or agent can continue that exact author
+without learning a runtime-native session id. Missing history remains visibly
+unattributed for legacy or manual files; it is never inferred from the current
+assignee, scheduled owner, or Workspace default runtime.
 
 #### Mode A: one responsible Session
 

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -293,6 +293,7 @@ describe('global board (ctx.board present)', () => {
       },
       runs: [],
       inboxReports: [],
+      provenance: [],
     },
   }
 
@@ -394,6 +395,10 @@ describe('global board (ctx.board present)', () => {
         resumable: true,
       }],
       inboxReports: [],
+      provenance: [{
+        id: 'p-1', action: 'created', at: 1,
+        origin: { kind: 'session', workspaceId: 'ws-a', resumeId: 'resume-kind-owl-abc123', agent: 'codex' },
+      }],
     }
     const context = boardCtx({ detail: async () => detail })
 
@@ -401,6 +406,10 @@ describe('global board (ctx.board present)', () => {
     expect(JSON.stringify(summary)).not.toContain('large repeated execution prompt')
     expect(summary.runs).toEqual([expect.objectContaining({
       taskId: 'task-1', resumeId: 'resume-kind-owl-abc123', resumable: true,
+    })])
+    expect(summary.provenance).toEqual([expect.objectContaining({
+      action: 'created',
+      origin: expect.objectContaining({ resumeId: 'resume-kind-owl-abc123' }),
     })])
 
     const detailed = await run(issueShowFactory.build(context), { id: 'Alpha', mode: 'detailed' })

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -516,6 +516,7 @@ export const issueShowFactory: WorkspaceToolFactory = {
                   ...(entry.comments ? { comments: entry.comments } : {}),
                   ...(entry.origin ? { origin: entry.origin } : {}),
                 })),
+                provenance: detail.provenance,
                 hint: 'Use --mode detailed only when you need every execution prompt and full report metadata.',
               }
             }

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -58,7 +58,7 @@ function build(inboxReports: InboxEntry[] = []) {
       const r = await readWorkspaceIssues(wsDir)
       if (!r.ok) return null
       const issue = r.issues.find((i) => i.id === id)
-      return issue ? { issue: detailIssue(issue, null), runs: [], inboxReports } : null
+      return issue ? { issue: detailIssue(issue, null), runs: [], inboxReports, provenance: [] } : null
     },
     provenanceStore: { append: appendProvenance, list: vi.fn(), latest: vi.fn() },
   } as unknown as WorkspaceService

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -6,11 +6,46 @@ import {
   detailIssue,
   flattenBoardRows,
   inboxReportsForIssue,
+  issueProvenanceRecords,
   issueRunRecord,
   snapshotBoardIssue,
   type IssuesSnapshot,
   type IssuesSnapshotWorkspace,
 } from './board.js'
+
+describe('issueProvenanceRecords', () => {
+  it('keeps product Session attribution while stripping storage-only fields', () => {
+    const projected = issueProvenanceRecords([{
+      id: 'p-1',
+      artifact: { kind: 'issue', workspaceId: 'ws-1', issueId: 'audit' },
+      action: 'created',
+      origin: {
+        kind: 'session',
+        workspaceId: 'ws-1',
+        resumeId: 'resume-gentle-otter-abc123',
+        agent: 'codex',
+        execution: { kind: 'headless', taskId: 'task-1' },
+      },
+      at: 123,
+      fingerprint: 'internal-dedupe-key',
+    }])
+
+    expect(projected).toEqual([{
+      id: 'p-1',
+      action: 'created',
+      origin: {
+        kind: 'session',
+        workspaceId: 'ws-1',
+        resumeId: 'resume-gentle-otter-abc123',
+        agent: 'codex',
+        execution: { kind: 'headless', taskId: 'task-1' },
+      },
+      at: 123,
+    }])
+    expect(projected[0]).not.toHaveProperty('artifact')
+    expect(projected[0]).not.toHaveProperty('fingerprint')
+  })
+})
 
 describe('issueRunRecord', () => {
   it('projects a resumable run without leaking its native runtime session id', () => {

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -12,6 +12,11 @@
  */
 
 import type { InboxEntry } from '../../core/inbox-store.js'
+import type {
+  ArtifactOrigin,
+  ProvenanceAction,
+  ProvenanceRecord,
+} from '../../core/provenance-store.js'
 import type { Schedule } from '../../core/schedule-expr.js'
 import type {
   HeadlessTaskOutputSummary,
@@ -236,6 +241,23 @@ export interface IssueDetail {
    *  `origin.issueId` is this issue, newest-first. The issue→inbox direction of
    *  the cross-link (`runs` is the run→issue one). */
   inboxReports: InboxEntry[]
+  /** Immutable attribution events for this Issue, newest first. The product
+   *  `resumeId` is the only conversation handle exposed for Session origins. */
+  provenance: IssueProvenanceRecord[]
+}
+
+export interface IssueProvenanceRecord {
+  id: string
+  action: ProvenanceAction
+  origin: ArtifactOrigin
+  at: number
+}
+
+/** Strip persistence-only artifact/fingerprint fields from Issue detail. */
+export function issueProvenanceRecords(
+  records: readonly ProvenanceRecord[],
+): IssueProvenanceRecord[] {
+  return records.map(({ id, action, origin, at }) => ({ id, action, origin, at }))
 }
 
 /** Agent/UI-safe projection of one execution. `resumeId` is the only public

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -58,6 +58,7 @@ import {
   annotateNameCollisions,
   detailIssue,
   inboxReportsForIssue,
+  issueProvenanceRecords,
   snapshotBoardIssue,
   type IssueDetail,
   issueRunRecord,
@@ -1286,7 +1287,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         return { ...entry, ...(origin ? { origin } : { origin: undefined }) };
       });
     }
-    return { issue: detailIssue(issue, markers, ws.tag), runs, inboxReports };
+    const provenance = issueProvenanceRecords(provenanceStore.list({
+      artifact: { kind: 'issue', workspaceId: ws.id, issueId: issue.id },
+    }));
+    return { issue: detailIssue(issue, markers, ws.tag), runs, inboxReports, provenance };
   };
 
   const sessionDirectory = async (

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -26,6 +26,28 @@ export type IssueExecution =
   | { mode: 'fresh' }
   | { mode: 'resume'; resumeId: string }
 
+export type IssueProvenanceAction = 'created' | 'updated' | 'commented' | 'sent' | 'decided'
+export type IssueProvenanceOrigin =
+  | {
+      kind: 'session'
+      workspaceId: string
+      resumeId: string
+      agent: string
+      execution?:
+        | { kind: 'headless'; taskId: string }
+        | { kind: 'interactive'; sessionRecordId: string }
+    }
+  | { kind: 'human' }
+  | { kind: 'external'; system: string }
+  | { kind: 'unknown'; reason: string }
+
+export interface IssueProvenanceRecord {
+  id: string
+  action: IssueProvenanceAction
+  origin: IssueProvenanceOrigin
+  at: number
+}
+
 export interface IssueListItem {
   id: string
   title: string
@@ -149,6 +171,9 @@ export interface IssueDetail {
    * issue with no reports yields an empty array.
    */
   inboxReports?: InboxEntry[]
+  /** Immutable creation/update/comment attribution, newest first. Optional for
+   * legacy/demo payloads written before provenance projection existed. */
+  provenance?: IssueProvenanceRecord[]
 }
 
 export const issuesApi = {

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import { ArrowLeft, Hash, Inbox, ListChecks, Settings, TrendingUp, X } from 'lucide-react'
+import { ArrowLeft, Hash, History, Inbox, ListChecks, Settings, TrendingUp, X } from 'lucide-react'
 
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
@@ -9,6 +9,7 @@ import type {
   IssueDetailIssue,
   IssueExecution,
   IssuePriority,
+  IssueProvenanceRecord,
   IssueStatus,
   WikilinkIssueRef,
   WikilinkResolution,
@@ -594,6 +595,91 @@ function InboxReportsSection({
   )
 }
 
+// ==================== Provenance timeline (Issue → Session) ====================
+
+const PROVENANCE_ACTION_LABEL: Record<IssueProvenanceRecord['action'], string> = {
+  created: 'Created',
+  updated: 'Updated',
+  commented: 'Commented',
+  sent: 'Sent',
+  decided: 'Decided',
+}
+
+function ProvenanceTimeline({
+  records,
+  onContinue,
+}: {
+  records: IssueProvenanceRecord[]
+  onContinue: (record: IssueProvenanceRecord) => Promise<void>
+}) {
+  const [continuingId, setContinuingId] = useState<string | null>(null)
+  const [continueError, setContinueError] = useState<string | null>(null)
+
+  const continueSession = async (record: IssueProvenanceRecord) => {
+    setContinuingId(record.id)
+    setContinueError(null)
+    try {
+      await onContinue(record)
+    } catch (err) {
+      setContinueError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setContinuingId(null)
+    }
+  }
+
+  return (
+    <section className="mt-8">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted/70">Provenance</h3>
+      {records.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border px-4 py-4 text-center text-xs text-muted">
+          No attribution was recorded for this legacy or manually-created issue.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {records.map((record) => {
+            const origin = record.origin
+            const isSession = origin.kind === 'session'
+            const originLabel = isSession
+              ? `${origin.agent} · ${origin.resumeId}`
+              : origin.kind === 'human'
+                ? 'Human'
+                : origin.kind === 'external'
+                  ? `External · ${origin.system}`
+                  : `Unknown · ${origin.reason}`
+            return (
+              <li key={record.id} className="flex items-center gap-2.5 rounded-lg border border-border bg-bg-secondary px-3 py-2.5">
+                <History size={14} className="shrink-0 text-muted/70" aria-hidden />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-medium text-text">{PROVENANCE_ACTION_LABEL[record.action]}</span>
+                    <span className="text-xs text-muted" title={new Date(record.at).toLocaleString()}>
+                      {formatRelativeTime(record.at)}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 truncate font-mono text-[11px] text-muted" title={originLabel}>
+                    {originLabel}
+                  </p>
+                </div>
+                {isSession && (
+                  <button
+                    type="button"
+                    onClick={() => void continueSession(record)}
+                    disabled={continuingId !== null}
+                    className="shrink-0 rounded-md border border-border px-2 py-1 text-[11px] text-muted transition-colors hover:border-accent/50 hover:text-text disabled:cursor-wait disabled:opacity-50"
+                  >
+                    {continuingId === record.id ? 'Opening…' : 'Continue'}
+                  </button>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+      {continueError && <p className="mt-2 text-xs text-red-400">Could not continue Session: {continueError}</p>}
+    </section>
+  )
+}
+
 // ==================== Wikilink disambiguation picker ====================
 
 /**
@@ -713,7 +799,7 @@ export function IssueDetail({
 }: IssueDetailProps) {
   const { data, error, loading, mutate } = useIssueDetail(wsId, id)
   const { data: board } = useIssues()
-  const { agents, defaultAgent, issueDefaultAgent, openAgentConfig, workspaces } = useWorkspaces()
+  const { agents, defaultAgent, issueDefaultAgent, openAgentConfig, openHeadlessRun, workspaces } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
   const selectInboxEntry = useInboxSelection((s) => s.select)
@@ -776,6 +862,17 @@ export function IssueDetail({
       openOrFocus({ kind: 'inbox', params: {} })
     },
     [selectInboxEntry, markInboxRead, setSidebar, openOrFocus],
+  )
+
+  const continueProvenanceSession = useCallback(
+    async (record: IssueProvenanceRecord) => {
+      if (record.origin.kind !== 'session') return
+      setSidebar('workspaces')
+      await openHeadlessRun(record.origin.workspaceId, record.origin.resumeId, {
+        title: `${data?.issue.title ?? id} · ${record.action}`,
+      })
+    },
+    [data?.issue.title, id, openHeadlessRun, setSidebar],
   )
 
   // Clicking a `[[name]]` in the body resolves it across BOTH namespaces. A
@@ -872,6 +969,7 @@ export function IssueDetail({
 
   const { issue, runs } = data
   const inboxReports = data.inboxReports ?? []
+  const provenance = data.provenance ?? []
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-5 md:px-6">
@@ -891,6 +989,7 @@ export function IssueDetail({
             )}
           </div>
           <CommentComposer wsId={wsId} id={id} onPosted={mutate} />
+          <ProvenanceTimeline records={provenance} onContinue={continueProvenanceSession} />
           <ActivityFeed runs={runs} />
           <InboxReportsSection reports={inboxReports} onOpen={gotoInbox} />
         </main>


### PR DESCRIPTION
## Outcome

Issue detail now exposes immutable `created` / `updated` / `commented` attribution and lets users continue an exact originating product Session by `resumeId`.

## Changes

- query the durable provenance store by `{ workspaceId, issueId }`
- strip persistence-only artifact and fingerprint fields from the Issue projection
- include the safe provenance timeline in `alice-workspace issue show`
- render legacy/unattributed state honestly in Issue detail
- render Session origins with agent, `resumeId`, timestamp, and a working Continue action
- document the read contract without conflating creator provenance and execution ownership

## Verification

- root and UI strict TypeScript checks
- 48 focused Issue/route/tool tests
- full suite: 217 files passed, 1 skipped; 2559 tests passed, 6 skipped
- full `pnpm build`
- real Workspace CLI: created `provenance-visibility-smoke` from headless run `cfd5634b-3f08-4a28-8cbe-6d018c9b1fd2`; `issue show` resolved product Session `d13e11d5-2c84-4942-994a-c66e5e2c12eb`
- real browser: legacy Issue showed explicit unattributed state; attributed Issue showed the Session; Continue materialized and opened `/workspaces/chat-crisp-saffron-garden/s/codex-polished-juniper-studio`
- paused the materialized smoke PTY after validation