### PR TITLE
feat(trading): attribute UTA decisions to Sessions

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -65,6 +65,20 @@ alice-workspace peer sessions --id 550e8400-e29b-41d4-a716-446655440000
 (Reading a peer's files is fine. For your OWN entries you don't need this at all;
 their doc paths are already relative to your cwd.)
 
+**Trace an artifact back to a Session** — query the immutable attribution trail
+without exposing a runtime-native session id:
+
+```bash
+alice-workspace provenance show --kind issue --issue-id <id>
+alice-workspace provenance show --kind report --path research/report.md --revision <sha256:...>
+alice-workspace provenance show --kind trade-decision --account-id <account> --decision-id <uta-commit-hash>
+alice-workspace provenance show --resume-id <resumeId>  # reverse lookup: artifacts attributed to one Session
+```
+
+For Issue/report keys, `--workspace-id` defaults to your current Workspace.
+`resumeId` is the follow-up handle; `taskId` is only execution evidence. A
+missing origin is not permission to pick an arbitrary old Session.
+
 > **Editing a peer is interactive-only.** Reading another workspace is always OK.
 > *Editing* one means reaching outside your own workspace — only do that in an
 > interactive session where a person is present to approve it. An autonomous /

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -299,19 +299,34 @@ A trade has a causal chain, not one undifferentiated author:
 Session decision/request -> human or policy approval -> UTA operation -> broker fills
 ```
 
-The trade request sent from Alice to UTA should carry non-authoritative
-correlation metadata:
+The UTA Git commit is the durable decision artifact. Its identity is scoped by
+the account and uses the real commit hash:
 
 ```ts
-interface TradeDecisionOrigin extends SessionOrigin {
-  decisionId: string
+type TradeDecisionRef = {
+  kind: 'trade-decision'
+  accountId: string
+  decisionId: string // UTA Git commit hash
 }
 ```
 
 - `resumeId`, `workspaceId`, and `agent` identify who initiated the decision.
 - `taskId` identifies the exact headless turn when applicable.
+- staging without a commit is not yet a durable decision occurrence.
+- `tradingPush` and broker order/fill ids are execution evidence, not new
+  decision identities.
 - approval records identify the human/policy gate separately.
 - UTA operations and broker records remain the authority for execution/fills.
+
+When an internal agent creates a commit through the Workspace-owned
+`alice-uta` CLI, the gateway resolves the out-of-band run/session header and
+records a `decided` occurrence. A call without an authoritative Session header
+remains unattributed rather than being guessed. Query it with:
+
+```bash
+alice-workspace provenance show --kind trade-decision \
+  --account-id <account> --decision-id <uta-commit-hash>
+```
 
 “Why did you take this trade?” resumes the decision Session. “Why did it fill at
 this price?” reads UTA/broker execution evidence. Correlation must not move
@@ -390,6 +405,8 @@ responsible?” It owns:
   responsibility;
 - report revision/write attribution where observable;
 - trade-decision correlation across the Alice -> UTA boundary;
+- read-only artifact and reverse-Session queries through
+  `alice-workspace provenance show`;
 - honest `unknown`/`unavailable` records for legacy, human, or external changes;
 - read-only provenance queries and diagnostics.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,7 @@ import { createEntityStore } from './core/entity-store.js'
 import { entityUpsertFactory } from './tool/entity-upsert.js'
 import { entitySearchFactory } from './tool/entity-search.js'
 import { issueToolFactories } from './tool/issue-tools.js'
+import { provenanceShowFactory } from './tool/provenance-show.js'
 import { createToolCallLog } from './core/tool-call-log.js'
 import { NewsCollectorStore, NewsCollector } from './domain/news/index.js'
 import { createNewsArchiveTools } from './tool/news.js'
@@ -114,6 +115,7 @@ async function main() {
   workspaceToolCenter.register(entityUpsertFactory)
   workspaceToolCenter.register(entitySearchFactory)
   for (const f of issueToolFactories) workspaceToolCenter.register(f)
+  workspaceToolCenter.register(provenanceShowFactory)
 
   // ==================== UTA SDK (HTTP boundary) ====================
   //

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -23,6 +23,7 @@ import { workspaceSessionsFactory } from '../tool/workspace-sessions.js'
 import { entityUpsertFactory } from '../tool/entity-upsert.js'
 import { entitySearchFactory } from '../tool/entity-search.js'
 import { issueToolFactories } from '../tool/issue-tools.js'
+import { provenanceShowFactory } from '../tool/provenance-show.js'
 import { createTradingTools } from '../tool/trading.js'
 
 /**
@@ -89,6 +90,7 @@ describe('CLI_EXPORTS — workspace export (scoped collaboration tools)', () => 
   wtc.register(entityUpsertFactory)
   wtc.register(entitySearchFactory)
   for (const f of issueToolFactories) wtc.register(f)
+  wtc.register(provenanceShowFactory)
   const built = wtc.build({
     workspaceId: 'ws-test',
     workspaceLabel: 'test',

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -182,6 +182,9 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
         list: 'issue_list',
         show: 'issue_show',
       },
+      provenance: {
+        show: 'provenance_show',
+      },
     },
   },
   uta: {

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { Hono } from 'hono'
+import { tool } from 'ai'
+import { z } from 'zod'
 import { ToolCenter } from '../core/tool-center.js'
 import { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
 import { createThinkingTools } from '../tool/thinking.js'
@@ -122,6 +124,65 @@ describe('CLI gateway — export scope isolation', () => {
     const body = (await res.json()) as { export: string; groups: Record<string, unknown> }
     expect(body.export).toBe('workspace')
     expect(typeof body.groups).toBe('object')
+  })
+})
+
+describe('CLI gateway — UTA decision provenance', () => {
+  function makeTradeApp() {
+    const append = vi.fn(async (input) => ({ id: 'p-1', ...input }))
+    const toolCenter = new ToolCenter()
+    toolCenter.register({
+      tradingCommit: tool({
+        description: 'fake UTA commit',
+        inputSchema: z.object({ message: z.string() }),
+        execute: async () => ({ source: 'alpaca-paper', hash: 'commit-abc', message: 'thesis' }),
+      }),
+    }, 'trading')
+    const fakeSvc = {
+      registry: {
+        get: (id: string) => id === 'ws1' ? { id: 'ws1', tag: 'demo' } : undefined,
+      },
+      headlessTasks: {
+        get: (id: string) => id === 'run-1'
+          ? { taskId: 'run-1', resumeId: 'resume-1', agent: 'codex' }
+          : null,
+      },
+      sessionRegistry: { get: () => undefined },
+      provenanceStore: { append },
+    }
+    const app = new Hono()
+    registerCliRoutes(app, {
+      toolCenter,
+      workspaceToolCenter: new WorkspaceToolCenter(),
+      inboxStore: {} as never,
+      entityStore: {} as never,
+      getWorkspaceService: () => fakeSvc as never,
+    })
+    return { app, append }
+  }
+
+  const commit = (app: Hono, headers: Record<string, string> = {}) => app.request('/cli/ws1/uta/invoke', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify({ tool: 'tradingCommit', args: { message: 'thesis' } }),
+  })
+
+  it('attributes a successful UTA commit to the authoritative product Session', async () => {
+    const { app, append } = makeTradeApp()
+    expect((await commit(app, { 'x-openalice-run': 'run-1' })).status).toBe(200)
+    expect(append).toHaveBeenCalledWith(expect.objectContaining({
+      artifact: { kind: 'trade-decision', accountId: 'alpaca-paper', decisionId: 'commit-abc' },
+      action: 'decided',
+      origin: expect.objectContaining({
+        kind: 'session', workspaceId: 'ws1', resumeId: 'resume-1', agent: 'codex',
+      }),
+    }))
+  })
+
+  it('does not invent attribution for a commit without a valid Session header', async () => {
+    const { app, append } = makeTradeApp()
+    expect((await commit(app)).status).toBe(200)
+    expect(append).not.toHaveBeenCalled()
   })
 })
 

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -34,10 +34,13 @@ import {
 } from '../core/workspace-tool-center.js'
 import type { IInboxStore, InboxOrigin } from '../core/inbox-store.js'
 import type { IEntityStore } from '../core/entity-store.js'
+import { sessionOriginFromInboxOrigin } from '../core/provenance-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
+import { logger as launcherLogger } from '../workspaces/logger.js'
 import { extractMcpShape, wrapToolExecute } from '../core/mcp-export.js'
 import { type CliExport, getExport, mappedToolNames } from './cli-commands.js'
 import { resolveInboxOrigin } from './inbox-origin.js'
+import { extractTradeDecisionRefs } from './trade-provenance.js'
 
 export interface CliGatewayDeps {
   toolCenter: ToolCenter
@@ -233,6 +236,37 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
     if (result.isError) {
       const text = result.content.map((b) => (b.type === 'text' ? b.text : '')).join('\n')
       return c.json({ error: text || 'tool error' }, 500)
+    }
+    // A UTA Git commit is the durable business decision. Attribute only commits
+    // created through an authoritative Workspace Session header; a bare local
+    // API/CLI call remains unattributed rather than being guessed as an agent.
+    const provenanceOrigin = sessionOriginFromInboxOrigin(r.ws.id, origin)
+    const decisionRefs = provenanceOrigin
+      ? extractTradeDecisionRefs(toolName, result.content)
+      : []
+    if (provenanceOrigin && decisionRefs.length > 0) {
+      const svc = getWorkspaceService()
+      if (svc) {
+        try {
+          for (const ref of decisionRefs) {
+            await svc.provenanceStore.append({
+              artifact: {
+                kind: 'trade-decision',
+                accountId: ref.accountId,
+                decisionId: ref.decisionId,
+              },
+              action: 'decided',
+              origin: provenanceOrigin,
+              at: Date.now(),
+              fingerprint: `trade-decision:${ref.accountId}:${ref.decisionId}:decided`,
+            })
+          }
+        } catch (err) {
+          // Trading already committed successfully. A diagnostics write must
+          // never turn that success into a reported command failure.
+          launcherLogger.warn('trade_decision_provenance.append_failed', { err })
+        }
+      }
     }
     // Hand back the MCP content blocks; the client prints text blocks verbatim
     // (data tools return one text block that already holds the JSON payload).

--- a/src/server/trade-provenance.spec.ts
+++ b/src/server/trade-provenance.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractTradeDecisionRefs } from './trade-provenance.js'
+
+const content = (value: unknown) => [{ type: 'text', text: JSON.stringify(value) }]
+
+describe('extractTradeDecisionRefs', () => {
+  it('extracts one or many explicit trading commits', () => {
+    expect(extractTradeDecisionRefs('tradingCommit', content({ source: 'alpaca', hash: 'h1' })))
+      .toEqual([{ accountId: 'alpaca', decisionId: 'h1' }])
+    expect(extractTradeDecisionRefs('tradingCommit', content([
+      { source: 'alpaca', hash: 'h1' },
+      { source: 'ibkr', hash: 'h2' },
+    ]))).toEqual([
+      { accountId: 'alpaca', decisionId: 'h1' },
+      { accountId: 'ibkr', decisionId: 'h2' },
+    ])
+  })
+
+  it('extracts commits created inline while staging an operation', () => {
+    expect(extractTradeDecisionRefs('placeOrder', content({
+      source: 'alpaca-paper', staged: [{ action: 'placeOrder' }], committed: { hash: 'h3' },
+    }))).toEqual([{ accountId: 'alpaca-paper', decisionId: 'h3' }])
+  })
+
+  it('does not confuse staged operations, pushes, or broker order ids with decisions', () => {
+    expect(extractTradeDecisionRefs('placeOrder', content({
+      source: 'alpaca-paper', staged: [{ action: 'placeOrder', orderId: 'broker-1' }],
+    }))).toEqual([])
+    expect(extractTradeDecisionRefs('tradingPush', content({
+      results: [{ source: 'alpaca-paper', orderId: 'broker-1' }],
+    }))).toEqual([])
+  })
+
+  it('ignores malformed or non-JSON tool content', () => {
+    expect(extractTradeDecisionRefs('tradingCommit', [{ type: 'text', text: 'done' }])).toEqual([])
+    expect(extractTradeDecisionRefs('tradingCommit', [{ type: 'image', data: 'x' }])).toEqual([])
+  })
+})
+

--- a/src/server/trade-provenance.ts
+++ b/src/server/trade-provenance.ts
@@ -1,0 +1,64 @@
+export interface TradeDecisionRef {
+  accountId: string
+  decisionId: string
+}
+
+const inlineCommitTools = new Set([
+  'placeOrder',
+  'modifyOrder',
+  'closePosition',
+  'cancelOrder',
+])
+
+function textPayload(content: readonly unknown[]): unknown {
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue
+    const candidate = block as { type?: unknown; text?: unknown }
+    if (candidate.type !== 'text' || typeof candidate.text !== 'string') continue
+    try {
+      return JSON.parse(candidate.text)
+    } catch {
+      // Non-JSON text is not a structured trading result.
+    }
+  }
+  return undefined
+}
+
+function decisionFrom(value: unknown, hashKey: 'hash' | 'committed'): TradeDecisionRef | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const accountId = record['source']
+  const decisionId = hashKey === 'hash'
+    ? record['hash']
+    : record['committed'] && typeof record['committed'] === 'object'
+      ? (record['committed'] as Record<string, unknown>)['hash']
+      : undefined
+  return typeof accountId === 'string' && accountId && typeof decisionId === 'string' && decisionId
+    ? { accountId, decisionId }
+    : null
+}
+
+/**
+ * Extract only newly-created UTA commits from a successful Workspace CLI
+ * invocation. Broker order/fill ids are deliberately ignored: the Git commit
+ * hash is the durable trading-decision identity.
+ */
+export function extractTradeDecisionRefs(
+  toolName: string,
+  content: readonly unknown[],
+): TradeDecisionRef[] {
+  const payload = textPayload(content)
+  const refs: TradeDecisionRef[] = []
+  if (toolName === 'tradingCommit') {
+    for (const value of Array.isArray(payload) ? payload : [payload]) {
+      const ref = decisionFrom(value, 'hash')
+      if (ref) refs.push(ref)
+    }
+  } else if (inlineCommitTools.has(toolName)) {
+    const ref = decisionFrom(payload, 'committed')
+    if (ref) refs.push(ref)
+  }
+  const unique = new Map(refs.map((ref) => [`${ref.accountId}\0${ref.decisionId}`, ref]))
+  return [...unique.values()]
+}
+

--- a/src/tool/provenance-show.spec.ts
+++ b/src/tool/provenance-show.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ProvenanceQuery, ProvenanceRecord } from '../core/provenance-store.js'
+import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import { provenanceShowFactory } from './provenance-show.js'
+
+function run(tool: { execute?: unknown }, args: unknown): Promise<unknown> {
+  return (tool.execute as (a: unknown, o: unknown) => Promise<unknown>)(args, {})
+}
+
+function context(): WorkspaceToolContext {
+  return {
+    workspaceId: 'ws-self',
+    workspaceLabel: 'self',
+    inboxStore: {} as never,
+    entityStore: {} as never,
+    provenanceStore: {
+      append: vi.fn() as never,
+      latest: vi.fn() as never,
+      list: vi.fn((query: ProvenanceQuery = {}): ProvenanceRecord[] => [{
+        id: 'p-1',
+        artifact: query.artifact ?? { kind: 'inbox', inboxEntryId: 'i-1' },
+        action: query.action ?? 'decided',
+        origin: {
+          kind: 'session' as const, workspaceId: 'ws-self', resumeId: query.resumeId ?? 'resume-1', agent: 'codex',
+        },
+        at: 10,
+        fingerprint: 'private-dedupe-key',
+      }]),
+    },
+  }
+}
+
+describe('provenance_show', () => {
+  it('queries a trade decision by UTA commit hash and strips the fingerprint', async () => {
+    const result = await run(provenanceShowFactory.build(context()), {
+      kind: 'trade-decision', accountId: 'alpaca-paper', decisionId: 'abc123', limit: 10,
+    }) as { ok: boolean; records: Array<Record<string, unknown>> }
+
+    expect(result.ok).toBe(true)
+    expect(result.records[0]).toMatchObject({
+      artifact: { kind: 'trade-decision', accountId: 'alpaca-paper', decisionId: 'abc123' },
+      origin: { resumeId: 'resume-1' },
+    })
+    expect(result.records[0]).not.toHaveProperty('fingerprint')
+  })
+
+  it('defaults Issue/report workspace identity to the caller', async () => {
+    const result = await run(provenanceShowFactory.build(context()), {
+      kind: 'issue', issueId: 'audit', limit: 100,
+    }) as { records: Array<{ artifact: unknown }> }
+    expect(result.records[0].artifact).toEqual({ kind: 'issue', workspaceId: 'ws-self', issueId: 'audit' })
+  })
+
+  it('supports reverse lookup by product Session', async () => {
+    const result = await run(provenanceShowFactory.build(context()), {
+      resumeId: 'resume-exact', action: 'created', limit: 5,
+    }) as { records: Array<{ origin: { resumeId: string }; action: string }> }
+    expect(result.records[0]).toMatchObject({ action: 'created', origin: { resumeId: 'resume-exact' } })
+  })
+
+  it('rejects incomplete artifact keys without touching the store', async () => {
+    const ctx = context()
+    const result = await run(provenanceShowFactory.build(ctx), {
+      kind: 'trade-decision', accountId: 'alpaca-paper', limit: 100,
+    }) as { ok: boolean; error: string }
+    expect(result).toEqual({ ok: false, error: 'kind trade-decision requires accountId and decisionId' })
+    expect(ctx.provenanceStore?.list).not.toHaveBeenCalled()
+  })
+})

--- a/src/tool/provenance-show.ts
+++ b/src/tool/provenance-show.ts
@@ -1,0 +1,100 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import {
+  provenanceActions,
+  type ArtifactRef,
+  type ProvenanceRecord,
+} from '../core/provenance-store.js'
+import type { WorkspaceToolContext, WorkspaceToolFactory } from '../core/workspace-tool-center.js'
+
+const artifactKinds = ['inbox', 'issue', 'report', 'trade-decision'] as const
+
+/** Fingerprints are persistence-only dedupe keys, not part of the public trail. */
+export function publicProvenanceRecord(
+  record: ProvenanceRecord,
+): Omit<ProvenanceRecord, 'fingerprint'> {
+  const { fingerprint: _fingerprint, ...publicRecord } = record
+  return publicRecord
+}
+
+function artifactFromArgs(
+  ctx: WorkspaceToolContext,
+  args: {
+    kind?: (typeof artifactKinds)[number]
+    workspaceId?: string
+    inboxEntryId?: string
+    issueId?: string
+    path?: string
+    revision?: string
+    accountId?: string
+    decisionId?: string
+  },
+): ArtifactRef | { error: string } | undefined {
+  if (!args.kind) return undefined
+  const workspaceId = args.workspaceId ?? ctx.workspaceId
+  if (args.kind === 'inbox') {
+    return args.inboxEntryId
+      ? { kind: 'inbox', inboxEntryId: args.inboxEntryId }
+      : { error: 'kind inbox requires inboxEntryId' }
+  }
+  if (args.kind === 'issue') {
+    return args.issueId
+      ? { kind: 'issue', workspaceId, issueId: args.issueId }
+      : { error: 'kind issue requires issueId' }
+  }
+  if (args.kind === 'report') {
+    return args.path
+      ? { kind: 'report', workspaceId, path: args.path, ...(args.revision ? { revision: args.revision } : {}) }
+      : { error: 'kind report requires path' }
+  }
+  return args.accountId && args.decisionId
+    ? { kind: 'trade-decision', accountId: args.accountId, decisionId: args.decisionId }
+    : { error: 'kind trade-decision requires accountId and decisionId' }
+}
+
+export const provenanceShowFactory: WorkspaceToolFactory = {
+  name: 'provenance_show',
+  build(ctx) {
+    return tool({
+      description: [
+        'Read immutable Session attribution for one business artifact, or list',
+        'artifacts attributed to one product Session. This is a read-only audit',
+        'surface: resumeId is the follow-up handle; native runtime ids are never returned.',
+        '',
+        'Artifact keys: inboxEntryId; issueId (+ optional workspaceId); report path',
+        '(+ optional workspaceId/revision); or trade-decision accountId + decisionId.',
+        'Omit workspaceId for Issue/report artifacts owned by the current Workspace.',
+      ].join('\n'),
+      inputSchema: z.object({
+        kind: z.enum(artifactKinds).optional(),
+        workspaceId: z.string().min(1).optional(),
+        inboxEntryId: z.string().min(1).optional(),
+        issueId: z.string().min(1).optional(),
+        path: z.string().min(1).optional(),
+        revision: z.string().min(1).optional(),
+        accountId: z.string().min(1).optional(),
+        decisionId: z.string().min(1).optional(),
+        resumeId: z.string().min(1).optional(),
+        action: z.enum(provenanceActions).optional(),
+        limit: z.coerce.number().int().min(1).max(500).optional().default(100),
+      }),
+      execute: async (args) => {
+        if (!ctx.provenanceStore) return { ok: false as const, error: 'provenance unavailable' }
+        if (!args.kind && !args.resumeId) {
+          return { ok: false as const, error: 'provide an artifact kind or resumeId' }
+        }
+        const artifact = artifactFromArgs(ctx, args)
+        if (artifact && 'error' in artifact) return { ok: false as const, error: artifact.error }
+        const records = ctx.provenanceStore.list({
+          ...(artifact ? { artifact } : {}),
+          ...(args.resumeId ? { resumeId: args.resumeId } : {}),
+          ...(args.action ? { action: args.action } : {}),
+          limit: args.limit,
+        }).map(publicProvenanceRecord)
+        return { ok: true as const, count: records.length, records }
+      },
+    })
+  },
+}
+

--- a/src/tool/trading.spec.ts
+++ b/src/tool/trading.spec.ts
@@ -163,6 +163,34 @@ describe('trading tools — partial tolerance (#390)', () => {
   })
 })
 
+describe('inline trading commits', () => {
+  it('returns the resolved account id beside the UTA commit hash', async () => {
+    const uta = {
+      id: 'alpaca-paper',
+      stagePlaceOrder: async () => ({
+        staged: true,
+        index: 0,
+        operation: { action: 'placeOrder', contract: { symbol: 'AAPL' }, order: { action: 'BUY' } },
+      }),
+      commit: async (message: string) => ({ hash: 'commit-1', message }),
+    }
+    const tools = createTradingTools({ resolveOne: async () => uta } as never)
+    const result = await run(tools.placeOrder, {
+      aliceId: 'alpaca-paper|AAPL',
+      action: 'BUY',
+      orderType: 'MKT',
+      totalQuantity: '1',
+      tif: 'DAY',
+      commitMessage: 'Entry thesis',
+    }) as Record<string, unknown>
+
+    expect(result).toMatchObject({
+      source: 'alpaca-paper',
+      committed: { hash: 'commit-1', message: 'Entry thesis' },
+    })
+  })
+})
+
 describe('searchContracts — data-source participation', () => {
   it('defaults to accounts with UTA data-source participation enabled', async () => {
     const tools = createTradingTools(fakeManager([

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -672,7 +672,10 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
       }).meta({ examples: [{ aliceId: 'alpaca-paper|AAPL', action: 'BUY', orderType: 'MKT', totalQuantity: '1', commitMessage: 'Entry: momentum breakout' }] }),
       execute: async ({ source, commitMessage, ...params }) => {
         const uta = await manager.resolveOne(source ?? parseAliceId(params.aliceId)?.utaId ?? '')
-        return stageAndMaybeCommit({ stage: () => uta.stagePlaceOrder(params), commit: (m) => uta.commit(m) }, commitMessage)
+        return {
+          source: uta.id,
+          ...await stageAndMaybeCommit({ stage: () => uta.stagePlaceOrder(params), commit: (m) => uta.commit(m) }, commitMessage),
+        }
       },
     }),
 
@@ -693,7 +696,10 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
       }).meta({ examples: [{ source: 'alpaca-paper', orderId: '1', lmtPrice: '150' }] }),
       execute: async ({ source, commitMessage, ...params }) => {
         const uta = await manager.resolveOne(source)
-        return stageAndMaybeCommit({ stage: () => uta.stageModifyOrder(params), commit: (m) => uta.commit(m) }, commitMessage)
+        return {
+          source: uta.id,
+          ...await stageAndMaybeCommit({ stage: () => uta.stageModifyOrder(params), commit: (m) => uta.commit(m) }, commitMessage),
+        }
       },
     }),
 
@@ -709,7 +715,10 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
       }).meta({ examples: [{ aliceId: 'alpaca-paper|AAPL', commitMessage: 'Exit: thesis invalidated' }] }),
       execute: async ({ source, commitMessage, ...params }) => {
         const uta = await manager.resolveOne(source ?? parseAliceId(params.aliceId)?.utaId ?? '')
-        return stageAndMaybeCommit({ stage: () => uta.stageClosePosition(params), commit: (m) => uta.commit(m) }, commitMessage)
+        return {
+          source: uta.id,
+          ...await stageAndMaybeCommit({ stage: () => uta.stageClosePosition(params), commit: (m) => uta.commit(m) }, commitMessage),
+        }
       },
     }),
 
@@ -722,7 +731,10 @@ Optional: attach takeProfit and/or stopLoss for automatic exit orders.`,
       }).meta({ examples: [{ source: 'alpaca-paper', orderId: '1', commitMessage: 'Cancel: stale level' }] }),
       execute: async ({ source, orderId, commitMessage }) => {
         const uta = await manager.resolveOne(source)
-        return stageAndMaybeCommit({ stage: () => uta.stageCancelOrder({ orderId }), commit: (m) => uta.commit(m) }, commitMessage)
+        return {
+          source: uta.id,
+          ...await stageAndMaybeCommit({ stage: () => uta.stageCancelOrder({ orderId }), commit: (m) => uta.commit(m) }, commitMessage),
+        }
       },
     }),
 

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -77,7 +77,7 @@ async function main() {
   if (wantsHelp) return printVerbHelp(group, verb, cmd)
 
   // Run it.
-  const args = parseFlags(argv.slice(argv.indexOf(verb) + 1))
+  const args = parseFlags(argv.slice(argv.indexOf(verb) + 1), cmd.schema)
   const res = await invoke(base, cmd.tool, args)
   process.stdout.write(res.endsWith('\n') ? res : res + '\n')
 }
@@ -186,10 +186,11 @@ async function fetchSocketJson(socketPath, path, opts) {
 
 // ---- flag parsing ---------------------------------------------------------
 
-function parseFlags(tokens) {
+function parseFlags(tokens, schema) {
   const args = {}
   const meta = {}
   const docs = []
+  const properties = (schema && schema.properties) || {}
   for (let i = 0; i < tokens.length; i++) {
     let tok = tokens[i]
     if (!tok.startsWith('--')) continue
@@ -215,17 +216,26 @@ function parseFlags(tokens) {
     if (typeof val === 'string' && (val.startsWith('{') || val.startsWith('['))) {
       try { val = JSON.parse(val) } catch { /* keep the raw string */ }
     }
-    if (key === 'meta') {
+    // Shell-facing flags are kebab-case; tool schemas are commonly camelCase.
+    // Preserve an exact schema key first (some data tools intentionally use
+    // hyphenated keys), then normalize only when the camelCase key exists.
+    const camelKey = key.replace(/-([a-zA-Z0-9])/g, (_, ch) => ch.toUpperCase())
+    const schemaKey = Object.prototype.hasOwnProperty.call(properties, key)
+      ? key
+      : Object.prototype.hasOwnProperty.call(properties, camelKey)
+        ? camelKey
+        : key
+    if (schemaKey === 'meta') {
       // repeatable: --meta key=value -> metadataFilter
       const e = val.indexOf('=')
       if (e >= 0) meta[val.slice(0, e)] = val.slice(e + 1)
-    } else if (key === 'doc') {
+    } else if (schemaKey === 'doc') {
       // repeatable: --doc <path> -> docs: [{ path }] (inbox_push attachments).
       // A JSON object value (--doc '{"path":"x"}') is kept as-is so future
       // per-doc fields keep working; a bare path is wrapped into { path }.
       docs.push(val && typeof val === 'object' ? val : { path: String(val) })
     } else {
-      args[key] = val
+      args[schemaKey] = val
     }
   }
   if (Object.keys(meta).length) args.metadataFilter = meta
@@ -271,7 +281,8 @@ function printVerbHelp(group, verb, cmd) {
     const p = props[n] || {}
     const type = p.type || (p.enum ? 'enum' : '')
     const req = required.has(n) ? ' (required)' : ''
-    out(`  --${n}${type ? ' <' + type + '>' : ''}${req}   ${firstLine(p.description || '')}`)
+    const flag = n.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+    out(`  --${flag}${type ? ' <' + type + '>' : ''}${req}   ${firstLine(p.description || '')}`)
   }
 }
 

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -136,6 +136,72 @@ describe('CLI launchers and payload', () => {
     }
   })
 
+  it('accepts kebab-case shell flags for camelCase tool schema keys', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openalice-cli-shim-flags-'))
+    const socketPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\openalice-cli-shim-flags-${process.pid}-${Date.now()}`
+      : join(dir, 'tools.sock')
+    let invocation: { tool?: string; args?: Record<string, unknown> } | null = null
+    const manifest = {
+      description: 'test manifest',
+      groups: {
+        provenance: {
+          show: {
+            tool: 'provenance_show',
+            description: 'Show provenance',
+            schema: {
+              type: 'object',
+              properties: {
+                issueId: { type: 'string' },
+                accountId: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    }
+    const server = createServer((req, res) => {
+      if (req.method === 'POST') {
+        const chunks: Buffer[] = []
+        req.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+        req.on('end', () => {
+          invocation = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+          res.writeHead(200, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ content: [{ type: 'text', text: '{"ok":true}' }] }))
+        })
+        return
+      }
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify(manifest))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, resolve)
+    })
+    const env = {
+      ...process.env,
+      AQ_WS_ID: 'ws1',
+      OPENALICE_TOOL_SOCKET: socketPath,
+      OPENALICE_TOOL_URL: '/cli',
+    }
+    try {
+      const help = await runCli('alice-workspace', ['provenance', 'show', '--help'], env)
+      expect(help.stdout).toContain('--issue-id')
+      expect(help.stdout).not.toContain('--issueId')
+
+      await runCli('alice-workspace', [
+        'provenance', 'show', '--issue-id', 'audit', '--account-id', 'alpaca-paper',
+      ], env)
+      expect(invocation).toEqual({
+        tool: 'provenance_show',
+        args: { issueId: 'audit', accountId: 'alpaca-paper' },
+      })
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it('every Windows `.cmd` twin derives its export and selects the managed Node runtime', () => {
     const canonical = read('alice.cmd')
     for (const name of EXPORT_BINARIES) {


### PR DESCRIPTION
## Outcome

UTA Git commits created by internal Workspace agents now leave a durable `trade-decision` provenance edge to the exact product Session that made the decision. A generic read-only Workspace provenance command supports both artifact lookup and reverse `resumeId` lookup.

## Identity boundary

- decision identity is `{ accountId, decisionId }`, where `decisionId` is the real UTA commit hash
- staging without a commit creates no decision occurrence
- `tradingPush`, broker order ids, and fills remain execution evidence, not decision ids
- attribution requires an authoritative `AQ_RUN_ID` / `AQ_SESSION_ID` header resolved by OpenAlice
- a bare CLI/API commit remains unattributed instead of being guessed
- native runtime session ids and store fingerprints are never returned

## Changes

- include resolved UTA account `source` in inline stage-and-commit results
- extract explicit and inline commit refs from successful CLI tool content
- append best-effort `decided` provenance without turning a successful UTA commit into a command failure
- add `alice-workspace provenance show` for Inbox, Issue, report revision, trade decision, and reverse Session queries
- make CLI flags schema-aware so shell-facing kebab-case maps safely to camelCase tool fields while preserving exact hyphenated schemas
- update agent skill and provenance design guide

## Verification

- 68 focused gateway, extractor, trading, provenance tool, map, and cross-platform shim tests
- full suite: 219 files passed, 1 skipped; 2571 tests passed, 6 skipped
- strict root TypeScript check
- full `pnpm build`
- real Workspace CLI help renders kebab-case flags
- real `provenance show --kind issue --issue-id provenance-visibility-smoke` resolved the originating Codex Session
- real reverse query `--resume-id d13e11d5-2c84-4942-994a-c66e5e2c12eb` returned the same artifact
- no real UTA account was staged, committed, pushed, or contacted; trading tests use fake managers only