### PR TITLE
fix(cli): simplify conversation addressing

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -84,16 +84,20 @@ headless follow-up without leaving the embedded Workspace CLI:
 
 ```bash
 alice-workspace conversation ask \
-  --target '{"kind":"issue","workspaceId":"<ws>","issueId":"<id>"}' \
+  --issue-id <id> --ws-id <ws> \
   --prompt 'Why did you create this issue?'
 alice-workspace conversation ask \
-  --target '{"kind":"inbox","inboxEntryId":"<id>","workspaceId":"<ws>"}' \
-  --prompt 'Why did you send this?'
+  --resume-id <resumeId> \
+  --prompt 'Why did you send this result?'
 alice-workspace conversation ask \
-  --target '{"kind":"trade-decision","accountId":"<account>","decisionId":"<commit>"}' \
-  --prompt 'What thesis justified this decision?'
+  --ws-id <ws> --prompt 'Reconstruct why this artifact was produced.'
 alice-workspace conversation read --task-id <taskId>
 ```
+
+Address with one flat form: `--resume-id` continues an exact known Session;
+`--issue-id` resolves Issue provenance (`--ws-id` scopes a peer Issue and
+defaults to this Workspace); `--ws-id` by itself recruits a fresh worker. Never
+construct or pass an internal target JSON object.
 
 Inspect `resolution.mode` on the ask result:
 
@@ -103,9 +107,9 @@ Inspect `resolution.mode` on the ask result:
   letting it impersonate the original author;
 - `unavailable` means an attributed Session cannot resume, or no safe
   Workspace target exists. Do not work around it by picking another old
-  Session. Poll `conversation read` until `status` leaves `running`; a runtime
-  may still return usable `assistantText` alongside error blocks, so preserve
-  both the status and the answer.
+Session. Poll `conversation read` until `status` leaves `running`; its default
+output keeps the final `assistantText` and a compact error when needed. Use
+`--mode detailed` only for diagnostics that genuinely need tool/message blocks.
 
 > **Editing a peer is interactive-only.** Reading another workspace is always OK.
 > *Editing* one means reaching outside your own workspace — only do that in an

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -382,6 +382,8 @@ approval state, routing, fills, and slippage.
 13. Provenance is stamped from authoritative context, not asserted by an agent.
 14. Existing UUID `resumeId`s remain valid; readable ids apply only to new
     Sessions.
+15. New `taskId`s are short opaque run codes. Existing UUID task ids remain
+    valid, and no second alias id is introduced.
 
 ## Delivery Order: Leave the Trail, Then Collaborate
 
@@ -430,16 +432,19 @@ Phase 2 consumes Phase 1; it does not infer provenance independently. It owns:
 The embedded generic entry point is:
 
 ```bash
-alice-workspace conversation ask --target '<typed JSON target>' --prompt '<question>'
+alice-workspace conversation ask --resume-id <resumeId> --prompt '<question>'
+alice-workspace conversation ask --issue-id <issueId> [--ws-id <workspaceId>] --prompt '<question>'
+alice-workspace conversation ask --ws-id <workspaceId> --prompt '<question>'
 alice-workspace conversation read --task-id <taskId>
 ```
 
-`target.kind` supports `resume`, `workspace`, `inbox`, `issue`, `report`, and
-`trade-decision`. Artifact targets always consult the Phase 1 index. The ask
-result reports `resolution.mode`; read returns normalized assistant text,
-compact tool/error activity, and the real runtime status. A response may carry
-usable assistant text and runtime errors together; consumers preserve both
-rather than rewriting failure into success.
+The public CLI accepts only flat identity flags. `resumeId` addresses one exact
+Session, `issueId` consults the Phase 1 index, and `wsId` recruits a fresh worker
+when there is no known owner. Rich Inbox/report/trade target structures stay
+inside the resolver and future business-specific convenience commands; agents
+never serialize them into `conversation ask`. The ask result reports a compact
+`resolution.mode`; read returns runtime status and the latest assistant text by
+default. Full tool/message blocks are diagnostic data behind `--mode detailed`.
 
 The first fresh reconstruction appends a `reconstructed` occurrence to the
 artifact. Later questions about that same otherwise-unattributed artifact

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -183,13 +183,15 @@ remain valid and are never renamed. `taskId` remains one execution, while
 rather than silently pruned.
 
 Internal agents use the same product handle through the embedded collaboration
-path. For example, `alice-workspace conversation ask --target
-'{"kind":"issue","workspaceId":"<ws>","issueId":"<id>"}' --prompt '<question>'`
+path. For example, `alice-workspace conversation ask --issue-id <id>
+--ws-id <ws> --prompt '<question>'`
 queries Issue provenance first: it resumes the exact attributable Session,
 reconstructs with a fresh worker only when the Workspace is known and no
 Session origin exists, or returns unavailable without substituting another
-agent. `alice-workspace conversation read --task-id <id>` exposes normalized
-assistant text plus tool/error activity.
+agent. `alice-workspace conversation read --task-id <id>` returns the latest
+assistant reply by default; diagnostic tool/message blocks require
+`--mode detailed`. New task ids are short `run-xxxxxxxx` codes; existing UUID
+task ids remain readable.
 
 Scheduling never bypasses trading approval. A headless agent may research or
 stage a trade, but execution remains behind UTA/Trading-as-Git permission and

--- a/src/tool/conversation.spec.ts
+++ b/src/tool/conversation.spec.ts
@@ -19,7 +19,7 @@ function context(over: Partial<WorkspaceToolContext> = {}): WorkspaceToolContext
 }
 
 describe('conversation_ask', () => {
-  it('passes a typed business target to embedded conversation control', async () => {
+  it('turns flat Issue flags into the internal conversation target', async () => {
     const ask = vi.fn(async () => ({
       status: 'dispatched' as const,
       taskId: 'task-1', resumeId: 'resume-1', workspaceId: 'ws-peer',
@@ -35,7 +35,7 @@ describe('conversation_ask', () => {
     }))
     const target = { kind: 'issue' as const, workspaceId: 'ws-peer', issueId: 'audit' }
 
-    await expect(run(tool, { prompt: 'why?', target })).resolves.toMatchObject({
+    await expect(run(tool, { prompt: 'why?', wsId: 'ws-peer', issueId: 'audit' })).resolves.toMatchObject({
       ok: true, status: 'running', taskId: 'task-1', resolution: { mode: 'exact' },
     })
     expect(ask).toHaveBeenCalledWith({ prompt: 'why?', target, timeoutMs: 300_000 })
@@ -52,11 +52,25 @@ describe('conversation_ask', () => {
       },
     }))
     await expect(run(tool, {
-      prompt: 'why?', target: { kind: 'resume', resumeId: 'resume-old' },
+      prompt: 'why?', resumeId: 'resume-old',
     })).resolves.toEqual({
       ok: false,
       status: 'unavailable',
       resolution: { mode: 'unavailable', reason: 'missing-native-session' },
+    })
+  })
+
+  it('rejects ambiguous or missing addressing flags', async () => {
+    const tool = conversationAskFactory.build(context({
+      conversation: { ask: vi.fn(), read: vi.fn() },
+    }))
+    await expect(run(tool, { prompt: 'why?' })).resolves.toMatchObject({
+      ok: false, error: expect.stringContaining('provide --resume-id'),
+    })
+    await expect(run(tool, {
+      prompt: 'why?', resumeId: 'resume-1', wsId: 'ws-peer',
+    })).resolves.toMatchObject({
+      ok: false, error: expect.stringContaining('choose one target'),
     })
   })
 })
@@ -85,9 +99,10 @@ describe('conversation_read', () => {
     expect(result).toMatchObject({
       ok: true,
       assistantText: 'The report followed the issue rule.',
-      tools: [{ name: 'Read', status: 'completed' }],
     })
     expect(result).not.toHaveProperty('blocks')
+    expect(result).not.toHaveProperty('tools')
+    expect(result).not.toHaveProperty('errors')
   })
 
   it('returns normalized blocks only in detailed mode', async () => {
@@ -95,7 +110,9 @@ describe('conversation_read', () => {
       conversation: { ask: vi.fn(), read: vi.fn(async () => task) },
     }))
     await expect(run(tool, { taskId: task.taskId, mode: 'detailed' }))
-      .resolves.toMatchObject({ blocks: task.structured.blocks })
+      .resolves.toMatchObject({
+        tools: [{ name: 'Read', status: 'completed' }],
+        blocks: task.structured.blocks,
+      })
   })
 })
-

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -8,63 +8,55 @@ const DEFAULT_TIMEOUT_MS = 300_000
 const MAX_TIMEOUT_MS = 1_800_000
 const MAX_PROMPT_CHARS = 16_000
 
-const targetSchema = z.discriminatedUnion('kind', [
-  z.object({ kind: z.literal('resume'), resumeId: z.string().min(1) }),
-  z.object({ kind: z.literal('workspace'), workspaceId: z.string().min(1) }),
-  z.object({
-    kind: z.literal('inbox'),
-    inboxEntryId: z.string().min(1),
-    workspaceId: z.string().min(1).optional(),
-  }),
-  z.object({
-    kind: z.literal('issue'),
-    workspaceId: z.string().min(1),
-    issueId: z.string().min(1),
-    action: z.enum(['created', 'updated', 'commented']).optional(),
-  }),
-  z.object({
-    kind: z.literal('report'),
-    workspaceId: z.string().min(1),
-    path: z.string().min(1),
-    revision: z.string().min(1).optional(),
-    action: z.enum(['created', 'updated', 'sent']).optional(),
-  }),
-  z.object({
-    kind: z.literal('trade-decision'),
-    accountId: z.string().min(1),
-    decisionId: z.string().min(1),
-    workspaceId: z.string().min(1).optional(),
-  }),
-])
-
 export const conversationAskFactory: WorkspaceToolFactory = {
   name: 'conversation_ask',
   build(ctx) {
     return tool({
       description: [
-        'Ask the agent responsible for a business artifact through embedded headless dispatch.',
+        'Ask a known product Session, an Issue owner, or a fresh worker in one Workspace.',
         '',
-        'Pass a typed target object. Issue/Inbox/report/trade targets resolve immutable',
-        'provenance first. A known Session is resumed exactly. If no Session origin exists',
-        'but the target carries a live Workspace, a fresh worker reconstructs the answer and',
-        'the result says mode=reconstructed. An attributed but unavailable Session is never',
-        'silently replaced. Direct resume/workspace targets are the explicit low-level forms.',
+        'Use exactly one addressing form: resumeId for an exact Session; issueId (optionally',
+        'scoped by wsId) for Issue provenance; or wsId alone to recruit a fresh worker.',
+        'The CLI exposes these as --resume-id, --issue-id, and --ws-id. It never requires',
+        'callers to construct an internal target object.',
         '',
-        'The call is asynchronous and returns taskId. Poll with conversation_read.',
+        'The call is asynchronous and returns a short taskId. Poll with conversation_read.',
       ].join('\n'),
       inputSchema: z.object({
         prompt: z.string().trim().min(1).max(MAX_PROMPT_CHARS)
           .describe('Question for the responsible Session or reconstructing worker.'),
-        target: targetSchema.describe('Typed business target or explicit resume/workspace target.'),
+        resumeId: z.string().min(1).optional()
+          .describe('Exact product Session to continue. Cannot be combined with wsId or issueId.'),
+        wsId: z.string().min(1).optional()
+          .describe('Workspace for a fresh worker, or optional scope for issueId.'),
+        issueId: z.string().min(1).optional()
+          .describe('Issue whose attributable Session should answer. Defaults to the current Workspace.'),
         agent: z.string().min(1).optional()
           .describe('Optional runtime for reconstructed/fresh work only; exact Session runtime cannot be overridden.'),
         timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
           .describe(`Headless watchdog in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
       }),
-      execute: async ({ prompt, target, agent, timeoutMs }) => {
+      execute: async ({ prompt, resumeId, wsId, issueId, agent, timeoutMs }) => {
         if (!ctx.conversation) {
           return { ok: false as const, error: 'workspace conversation control is unavailable' }
         }
+        if (resumeId && (wsId || issueId)) {
+          return {
+            ok: false as const,
+            error: 'choose one target: --resume-id, --issue-id [--ws-id], or --ws-id',
+          }
+        }
+        if (!resumeId && !issueId && !wsId) {
+          return {
+            ok: false as const,
+            error: 'provide --resume-id, --issue-id [--ws-id], or --ws-id',
+          }
+        }
+        const target = resumeId
+          ? { kind: 'resume' as const, resumeId }
+          : issueId
+            ? { kind: 'issue' as const, workspaceId: wsId ?? ctx.workspaceId, issueId }
+            : { kind: 'workspace' as const, workspaceId: wsId! }
         try {
           const result = await ctx.conversation.ask({
             prompt,
@@ -73,7 +65,11 @@ export const conversationAskFactory: WorkspaceToolFactory = {
             ...(agent ? { agent } : {}),
           })
           if (result.status === 'unavailable') {
-            return { ok: false as const, status: result.status, resolution: result.resolution }
+            return {
+              ok: false as const,
+              status: result.status,
+              resolution: { mode: result.resolution.mode, reason: result.resolution.reason },
+            }
           }
           return {
             ok: true as const,
@@ -83,7 +79,9 @@ export const conversationAskFactory: WorkspaceToolFactory = {
             workspaceId: result.workspaceId,
             workspace: result.workspace,
             agent: result.agent,
-            resolution: result.resolution,
+            resolution: result.resolution.mode === 'reconstructed'
+              ? { mode: result.resolution.mode, reason: result.resolution.reason }
+              : { mode: result.resolution.mode },
           }
         } catch (err) {
           return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
@@ -100,8 +98,9 @@ export const conversationReadFactory: WorkspaceToolFactory = {
       description: [
         'Read one headless follow-up started by conversation_ask.',
         '',
-        'Summary returns the latest assistant reply plus compact tool/error activity.',
-        'Detailed mode includes normalized message blocks. Running tasks may have partial output.',
+        'Summary returns the latest assistant reply and one compact failure when present.',
+        'Tool activity and normalized message blocks are available only in detailed mode.',
+        'Running tasks may have partial output.',
       ].join('\n'),
       inputSchema: z.object({
         taskId: z.string().min(1).describe('taskId returned by conversation_ask.'),
@@ -121,6 +120,7 @@ export const conversationReadFactory: WorkspaceToolFactory = {
           const errors = structured?.blocks
             .filter((block): block is Extract<HeadlessMessageBlock, { type: 'error' }> => block.type === 'error')
             .map((block) => block.message) ?? []
+          const compactError = task.error ?? errors.at(-1)
           return {
             ok: true as const,
             taskId: task.taskId,
@@ -129,12 +129,14 @@ export const conversationReadFactory: WorkspaceToolFactory = {
             agent: task.agent,
             status: task.status,
             assistantText: structured?.assistantText ?? null,
-            tools,
-            errors,
             ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
             ...(task.durationMs !== undefined ? { durationMs: task.durationMs } : {}),
-            ...(task.error ? { error: task.error } : {}),
-            ...(mode === 'detailed' ? { blocks: structured?.blocks ?? [] } : {}),
+            ...(compactError ? { error: compactError } : {}),
+            ...(mode === 'detailed' ? {
+              tools,
+              errors,
+              blocks: structured?.blocks ?? [],
+            } : {}),
           }
         } catch (err) {
           return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
@@ -148,4 +150,3 @@ export const conversationToolFactories: WorkspaceToolFactory[] = [
   conversationAskFactory,
   conversationReadFactory,
 ]
-

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -48,6 +48,7 @@ describe('HeadlessTaskRegistry', () => {
     const a = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'do A', startedAt: 1 })
     const b = await createTask(reg, { wsId: 'w2', agent: 'pi', prompt: 'do B', startedAt: 2 })
     expect(a.status).toBe('running')
+    expect(a.taskId).toMatch(/^run-[A-Za-z0-9_-]{8}$/)
     expect(a.resumeId).toBe('resume-test-1')
     expect(reg.list().map((t) => t.taskId)).toEqual([b.taskId, a.taskId]) // newest-first
     expect(reg.runningCount()).toBe(2)

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -13,13 +13,19 @@
  * "running" from a previous Alice life. (Durable/detached runs are a later
  * upgrade; see project_workspace_automation_design.)
  */
-import { randomUUID } from 'node:crypto'
+import { randomBytes } from 'node:crypto'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 import type { Logger } from './logger.js'
 
 export type HeadlessTaskStatus = 'running' | 'done' | 'failed' | 'interrupted'
+
+const TASK_ID_BYTES = 6
+
+function randomTaskId(): string {
+  return `run-${randomBytes(TASK_ID_BYTES).toString('base64url')}`
+}
 
 export interface HeadlessTaskOutputSummary {
   readonly hasAssistantReply: boolean
@@ -139,8 +145,10 @@ export class HeadlessTaskRegistry {
     /** Set only when an issue fired this run (scheduled scan); omitted for manual/external runs. */
     issueId?: string
   }): Promise<HeadlessTaskRecord> {
+    let taskId = randomTaskId()
+    while (this.tasks.some((task) => task.taskId === taskId)) taskId = randomTaskId()
     const rec: HeadlessTaskRecord = {
-      taskId: randomUUID(),
+      taskId,
       resumeId: input.resumeId,
       ...(input.parentTaskId ? { parentTaskId: input.parentTaskId } : {}),
       wsId: input.wsId,


### PR DESCRIPTION
## Summary
- replace typed JSON conversation targets with flat `--resume-id`, `--issue-id`, and `--ws-id` flags
- keep default conversation reads focused on the latest assistant reply, with tool/message blocks behind detailed mode
- generate short collision-checked task ids for new headless runs while retaining legacy UUID compatibility

## Verification
- `npx tsc --noEmit`
- `pnpm test` (221 passed, 1 skipped; 2587 tests passed)
- targeted CLI/tool/registry tests (70 passed)
- real `alice-workspace conversation ask --help` against the live CLI manifest
- real summary read of an existing UUID task; final reply retained and tool/block/error arrays omitted

## Boundary touch
- Workspace CLI, embedded conversation control projection, and headless task identity