### PR TITLE
feat(chat): teach awaited peer collaboration

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -5,13 +5,15 @@ description: >
   finished work to the user's Inbox (`inbox push`, with repeatable `--doc`
   file attachments), read the inbox back (`inbox read`, `--self` for your own
   pushes), locate a peer workspace's files (`peer path`) and product Sessions
-  (`peer sessions`),
+  (`peer sessions`), ask attributable peer Sessions and await their replies
+  (`conversation ask` / `conversation await`),
   track entities across workspaces (`track`), and read & manage the
   cross-workspace issue board (`issue list`/`show`/`create`/`update`/`comment`).
   Use for: "push my findings to the inbox", "surface this report to the user",
   "what did I already report?", "read the file another workspace sent", "track
   this ticker", "what's on the issue board?", "what was I working on?", "add or
-  update an issue". Workspaces collaborate through git — commit before you push,
+  update an issue", "ask the agent who produced this Inbox result", "why was
+  this Issue created?". Workspaces collaborate through git — commit before you push,
   and commit after you edit a peer's files. Discover flags with
   `alice-workspace --help` — do NOT guess.
 ---
@@ -85,12 +87,13 @@ headless follow-up without leaving the embedded Workspace CLI:
 ```bash
 alice-workspace conversation ask \
   --issue-id <id> --ws-id <ws> \
-  --prompt 'Why did you create this issue?'
+  --prompt 'Why did you create this issue?' --await
 alice-workspace conversation ask \
   --resume-id <resumeId> \
-  --prompt 'Why did you send this result?'
-alice-workspace conversation ask \
-  --ws-id <ws> --prompt 'Reconstruct why this artifact was produced.'
+  --prompt 'Why did you send this result?' --await
+alice-workspace conversation ask --ws-id <ws> \
+  --prompt 'Reconstruct why this artifact was produced.' --await
+alice-workspace conversation await --task-id <taskId>
 alice-workspace conversation read --task-id <taskId>
 ```
 
@@ -98,6 +101,13 @@ Address with one flat form: `--resume-id` continues an exact known Session;
 `--issue-id` resolves Issue provenance (`--ws-id` scopes a peer Issue and
 defaults to this Workspace); `--ws-id` by itself recruits a fresh worker. Never
 construct or pass an internal target JSON object.
+
+For one question, start with `ask --await`: OpenAlice waits server-side and
+returns the final reply without making you guess a sleep duration. For several
+independent peers, issue every `ask` first without `--await` so all tasks run
+concurrently, then collect each short task id with `conversation await`. If an
+await returns `status: running`, do other useful work and await again later or
+use one-shot `conversation read`; never build a shell `sleep` polling loop.
 
 Inspect `resolution.mode` on the ask result:
 
@@ -108,7 +118,8 @@ Inspect `resolution.mode` on the ask result:
 - `unavailable` means an attributed Session cannot resume, or no safe
   Workspace target exists. Do not work around it by picking another old
 Session. Poll `conversation read` until `status` leaves `running`; its default
-output keeps the final `assistantText` and a compact error when needed. Use
+output keeps the final `assistantText` and a compact error when needed. Prefer
+the server-side await flow above; use `read` as the fallback snapshot. Use
 `--mode detailed` only for diagnostics that genuinely need tool/message blocks.
 
 > **Editing a peer is interactive-only.** Reading another workspace is always OK.

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -435,6 +435,7 @@ The embedded generic entry point is:
 alice-workspace conversation ask --resume-id <resumeId> --prompt '<question>'
 alice-workspace conversation ask --issue-id <issueId> [--ws-id <workspaceId>] --prompt '<question>'
 alice-workspace conversation ask --ws-id <workspaceId> --prompt '<question>'
+alice-workspace conversation await --task-id <taskId>
 alice-workspace conversation read --task-id <taskId>
 ```
 
@@ -445,6 +446,10 @@ inside the resolver and future business-specific convenience commands; agents
 never serialize them into `conversation ask`. The ask result reports a compact
 `resolution.mode`; read returns runtime status and the latest assistant text by
 default. Full tool/message blocks are diagnostic data behind `--mode detailed`.
+For one peer, `ask --await` is the preferred path. For multiple peers, dispatch
+all asks first so their runs overlap, then server-side await each task before
+synthesizing. A timed-out await preserves the task and returns its id; callers
+fall back to later await/read snapshots instead of scripting arbitrary sleeps.
 
 The first fresh reconstruction appends a `reconstructed` occurrence to the
 artifact. Later questions about that same otherwise-unattributed artifact

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -193,6 +193,12 @@ assistant reply by default; diagnostic tool/message blocks require
 `--mode detailed`. New task ids are short `run-xxxxxxxx` codes; existing UUID
 task ids remain readable.
 
+Prefer `conversation ask ... --await` for a single follow-up. To question
+several independent Sessions, dispatch every ask first, then collect each task
+with `conversation await --task-id <id>` so the runs overlap. If server-side
+await reaches its budget while a task still runs, use a later await or one-shot
+read; agents should not manufacture shell sleep loops.
+
 Scheduling never bypasses trading approval. A headless agent may research or
 stage a trade, but execution remains behind UTA/Trading-as-Git permission and
 human approval boundaries.

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -187,6 +187,7 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       },
       conversation: {
         ask: 'conversation_ask',
+        await: 'conversation_await',
         read: 'conversation_read',
       },
     },

--- a/src/tool/conversation.spec.ts
+++ b/src/tool/conversation.spec.ts
@@ -2,7 +2,11 @@ import type { Tool } from 'ai'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
-import { conversationAskFactory, conversationReadFactory } from './conversation.js'
+import {
+  conversationAskFactory,
+  conversationAwaitFactory,
+  conversationReadFactory,
+} from './conversation.js'
 
 async function run(tool: Tool, args: Record<string, unknown>) {
   return tool.execute!(args, { toolCallId: 'test', messages: [] })
@@ -16,6 +20,21 @@ function context(over: Partial<WorkspaceToolContext> = {}): WorkspaceToolContext
     entityStore: {} as never,
     ...over,
   }
+}
+
+const completedTask = {
+  taskId: 'task-1', resumeId: 'resume-1', workspaceId: 'ws-peer', agent: 'pi',
+  status: 'done' as const, startedAt: 1, durationMs: 2,
+  structured: {
+    schemaVersion: 1 as const,
+    assistantText: 'The report followed the issue rule.',
+    blocks: [
+      { type: 'tool' as const, id: 'tool-1', name: 'Read', status: 'completed' as const, input: 'a.md', output: 'ok' },
+      { type: 'text' as const, text: 'The report followed the issue rule.' },
+    ],
+    metrics: { textBlocks: 1, toolCalls: 1, toolFailures: 0 },
+    truncated: false,
+  },
 }
 
 describe('conversation_ask', () => {
@@ -73,29 +92,79 @@ describe('conversation_ask', () => {
       ok: false, error: expect.stringContaining('choose one target'),
     })
   })
+
+  it('awaits a recorded task server-side and returns its final reply', async () => {
+    const ask = vi.fn(async () => ({
+      status: 'dispatched' as const,
+      taskId: completedTask.taskId,
+      resumeId: completedTask.resumeId,
+      workspaceId: completedTask.workspaceId,
+      workspace: 'peer',
+      agent: completedTask.agent,
+      resolution: {
+        mode: 'exact' as const,
+        origin: { kind: 'session' as const, workspaceId: 'ws-peer', resumeId: 'resume-1', agent: 'pi' },
+      },
+    }))
+    const read = vi.fn(async () => completedTask)
+    const tool = conversationAskFactory.build(context({ conversation: { ask, read } }))
+
+    await expect(run(tool, {
+      prompt: 'why?', resumeId: 'resume-1', await: true,
+    })).resolves.toMatchObject({
+      ok: true,
+      awaited: true,
+      status: 'done',
+      taskId: 'task-1',
+      assistantText: 'The report followed the issue rule.',
+    })
+    expect(read).toHaveBeenCalledWith('task-1')
+  })
+})
+
+describe('conversation_await', () => {
+  it('collects an already-running peer task without exposing diagnostic blocks', async () => {
+    const tool = conversationAwaitFactory.build(context({
+      conversation: { ask: vi.fn(), read: vi.fn(async () => completedTask) },
+    }))
+    const result = await run(tool, { taskId: completedTask.taskId })
+    expect(result).toMatchObject({
+      ok: true,
+      awaited: true,
+      status: 'done',
+      assistantText: 'The report followed the issue rule.',
+    })
+    expect(result).not.toHaveProperty('blocks')
+    expect(result).not.toHaveProperty('tools')
+  })
+
+  it('returns a running task for later polling when the wait budget expires', async () => {
+    const runningTask = {
+      ...completedTask,
+      status: 'running' as const,
+      durationMs: undefined,
+      structured: null,
+    }
+    const tool = conversationAwaitFactory.build(context({
+      conversation: { ask: vi.fn(), read: vi.fn(async () => runningTask) },
+    }))
+    await expect(run(tool, { taskId: runningTask.taskId, timeoutMs: 1 }))
+      .resolves.toMatchObject({
+        ok: true,
+        awaited: false,
+        status: 'running',
+        next: 'alice-workspace conversation read --task-id task-1',
+      })
+  })
 })
 
 describe('conversation_read', () => {
-  const task = {
-    taskId: 'task-1', resumeId: 'resume-1', workspaceId: 'ws-peer', agent: 'pi',
-    status: 'done' as const, startedAt: 1, durationMs: 2,
-    structured: {
-      schemaVersion: 1 as const,
-      assistantText: 'The report followed the issue rule.',
-      blocks: [
-        { type: 'tool' as const, id: 'tool-1', name: 'Read', status: 'completed' as const, input: 'a.md', output: 'ok' },
-        { type: 'text' as const, text: 'The report followed the issue rule.' },
-      ],
-      metrics: { textBlocks: 1, toolCalls: 1, toolFailures: 0 },
-      truncated: false,
-    },
-  }
 
   it('keeps default output decision-oriented', async () => {
     const tool = conversationReadFactory.build(context({
-      conversation: { ask: vi.fn(), read: vi.fn(async () => task) },
+      conversation: { ask: vi.fn(), read: vi.fn(async () => completedTask) },
     }))
-    const result = await run(tool, { taskId: task.taskId })
+    const result = await run(tool, { taskId: completedTask.taskId })
     expect(result).toMatchObject({
       ok: true,
       assistantText: 'The report followed the issue rule.',
@@ -107,12 +176,12 @@ describe('conversation_read', () => {
 
   it('returns normalized blocks only in detailed mode', async () => {
     const tool = conversationReadFactory.build(context({
-      conversation: { ask: vi.fn(), read: vi.fn(async () => task) },
+      conversation: { ask: vi.fn(), read: vi.fn(async () => completedTask) },
     }))
-    await expect(run(tool, { taskId: task.taskId, mode: 'detailed' }))
+    await expect(run(tool, { taskId: completedTask.taskId, mode: 'detailed' }))
       .resolves.toMatchObject({
         tools: [{ name: 'Read', status: 'completed' }],
-        blocks: task.structured.blocks,
+        blocks: completedTask.structured.blocks,
       })
   })
 })

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -1,12 +1,60 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 
-import type { WorkspaceToolFactory } from '../core/workspace-tool-center.js'
+import type {
+  WorkspaceConversationControl,
+  WorkspaceConversationTask,
+  WorkspaceToolFactory,
+} from '../core/workspace-tool-center.js'
 import type { HeadlessMessageBlock } from '../workspaces/headless-output.js'
 
 const DEFAULT_TIMEOUT_MS = 300_000
 const MAX_TIMEOUT_MS = 1_800_000
 const MAX_PROMPT_CHARS = 16_000
+const AWAIT_POLL_MS = 250
+
+function taskProjection(task: WorkspaceConversationTask, mode: 'summary' | 'detailed') {
+  const structured = task.structured
+  const tools = structured?.blocks
+    .filter((block): block is Extract<HeadlessMessageBlock, { type: 'tool' }> => block.type === 'tool')
+    .map((block) => ({ name: block.name, status: block.status })) ?? []
+  const errors = structured?.blocks
+    .filter((block): block is Extract<HeadlessMessageBlock, { type: 'error' }> => block.type === 'error')
+    .map((block) => block.message) ?? []
+  const compactError = task.error ?? errors.at(-1)
+  return {
+    taskId: task.taskId,
+    resumeId: task.resumeId,
+    workspaceId: task.workspaceId,
+    agent: task.agent,
+    status: task.status,
+    assistantText: structured?.assistantText ?? null,
+    ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
+    ...(task.durationMs !== undefined ? { durationMs: task.durationMs } : {}),
+    ...(compactError ? { error: compactError } : {}),
+    ...(mode === 'detailed' ? {
+      tools,
+      errors,
+      blocks: structured?.blocks ?? [],
+    } : {}),
+  }
+}
+
+async function awaitConversationTask(
+  conversation: WorkspaceConversationControl,
+  taskId: string,
+  timeoutMs: number,
+): Promise<WorkspaceConversationTask | null> {
+  const deadline = Date.now() + timeoutMs
+  let task = await conversation.read(taskId)
+  while (task?.status === 'running') {
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) return task
+    await new Promise((resolve) => setTimeout(resolve, Math.min(AWAIT_POLL_MS, remaining)))
+    task = await conversation.read(taskId)
+  }
+  return task
+}
 
 export const conversationAskFactory: WorkspaceToolFactory = {
   name: 'conversation_ask',
@@ -20,7 +68,9 @@ export const conversationAskFactory: WorkspaceToolFactory = {
         'The CLI exposes these as --resume-id, --issue-id, and --ws-id. It never requires',
         'callers to construct an internal target object.',
         '',
-        'The call is asynchronous and returns a short taskId. Poll with conversation_read.',
+        'Prefer --await for one question: the server waits without shell sleep loops.',
+        'Without --await the call returns a short taskId immediately, which lets several',
+        'questions run concurrently before conversation_await collects their replies.',
       ].join('\n'),
       inputSchema: z.object({
         prompt: z.string().trim().min(1).max(MAX_PROMPT_CHARS)
@@ -35,8 +85,10 @@ export const conversationAskFactory: WorkspaceToolFactory = {
           .describe('Optional runtime for reconstructed/fresh work only; exact Session runtime cannot be overridden.'),
         timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
           .describe(`Headless watchdog in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
+        await: z.boolean().optional().default(false)
+          .describe('Wait server-side for the final reply; on timeout, return the taskId for later await/read.'),
       }),
-      execute: async ({ prompt, resumeId, wsId, issueId, agent, timeoutMs }) => {
+      execute: async ({ prompt, resumeId, wsId, issueId, agent, timeoutMs, await: shouldAwait = false }) => {
         if (!ctx.conversation) {
           return { ok: false as const, error: 'workspace conversation control is unavailable' }
         }
@@ -58,10 +110,11 @@ export const conversationAskFactory: WorkspaceToolFactory = {
             ? { kind: 'issue' as const, workspaceId: wsId ?? ctx.workspaceId, issueId }
             : { kind: 'workspace' as const, workspaceId: wsId! }
         try {
+          const effectiveTimeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS
           const result = await ctx.conversation.ask({
             prompt,
             target,
-            timeoutMs: timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            timeoutMs: effectiveTimeoutMs,
             ...(agent ? { agent } : {}),
           })
           if (result.status === 'unavailable') {
@@ -71,7 +124,7 @@ export const conversationAskFactory: WorkspaceToolFactory = {
               resolution: { mode: result.resolution.mode, reason: result.resolution.reason },
             }
           }
-          return {
+          const dispatched = {
             ok: true as const,
             status: 'running' as const,
             taskId: result.taskId,
@@ -82,6 +135,66 @@ export const conversationAskFactory: WorkspaceToolFactory = {
             resolution: result.resolution.mode === 'reconstructed'
               ? { mode: result.resolution.mode, reason: result.resolution.reason }
               : { mode: result.resolution.mode },
+          }
+          if (!shouldAwait) return dispatched
+          const task = await awaitConversationTask(ctx.conversation, result.taskId, effectiveTimeoutMs)
+          if (!task) {
+            return {
+              ok: false as const,
+              taskId: result.taskId,
+              error: `conversation task disappeared while awaiting: ${result.taskId}`,
+            }
+          }
+          return {
+            ...dispatched,
+            ...taskProjection(task, 'summary'),
+            awaited: task.status !== 'running',
+            ...(task.status === 'running'
+              ? { next: `alice-workspace conversation await --task-id ${task.taskId}` }
+              : {}),
+          }
+        } catch (err) {
+          return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
+        }
+      },
+    })
+  },
+}
+
+export const conversationAwaitFactory: WorkspaceToolFactory = {
+  name: 'conversation_await',
+  build(ctx) {
+    return tool({
+      description: [
+        'Wait server-side for one conversation task to finish.',
+        '',
+        'Use after dispatching several conversation_ask calls so their headless runs execute',
+        'concurrently. This replaces hand-written sleep loops. If the wait budget expires,',
+        'the task remains running and can be awaited again or inspected with conversation_read.',
+      ].join('\n'),
+      inputSchema: z.object({
+        taskId: z.string().min(1).describe('Short taskId returned by conversation_ask.'),
+        timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
+          .describe(`Server-side wait budget in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
+      }),
+      execute: async ({ taskId, timeoutMs }) => {
+        if (!ctx.conversation) {
+          return { ok: false as const, error: 'workspace conversation control is unavailable' }
+        }
+        try {
+          const task = await awaitConversationTask(
+            ctx.conversation,
+            taskId,
+            timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          )
+          if (!task) return { ok: false as const, error: `conversation task not found: ${taskId}` }
+          return {
+            ok: true as const,
+            ...taskProjection(task, 'summary'),
+            awaited: task.status !== 'running',
+            ...(task.status === 'running'
+              ? { next: `alice-workspace conversation read --task-id ${task.taskId}` }
+              : {}),
           }
         } catch (err) {
           return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
@@ -113,30 +226,9 @@ export const conversationReadFactory: WorkspaceToolFactory = {
         try {
           const task = await ctx.conversation.read(taskId)
           if (!task) return { ok: false as const, error: `conversation task not found: ${taskId}` }
-          const structured = task.structured
-          const tools = structured?.blocks
-            .filter((block): block is Extract<HeadlessMessageBlock, { type: 'tool' }> => block.type === 'tool')
-            .map((block) => ({ name: block.name, status: block.status })) ?? []
-          const errors = structured?.blocks
-            .filter((block): block is Extract<HeadlessMessageBlock, { type: 'error' }> => block.type === 'error')
-            .map((block) => block.message) ?? []
-          const compactError = task.error ?? errors.at(-1)
           return {
             ok: true as const,
-            taskId: task.taskId,
-            resumeId: task.resumeId,
-            workspaceId: task.workspaceId,
-            agent: task.agent,
-            status: task.status,
-            assistantText: structured?.assistantText ?? null,
-            ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
-            ...(task.durationMs !== undefined ? { durationMs: task.durationMs } : {}),
-            ...(compactError ? { error: compactError } : {}),
-            ...(mode === 'detailed' ? {
-              tools,
-              errors,
-              blocks: structured?.blocks ?? [],
-            } : {}),
+            ...taskProjection(task, mode),
           }
         } catch (err) {
           return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
@@ -148,5 +240,6 @@ export const conversationReadFactory: WorkspaceToolFactory = {
 
 export const conversationToolFactories: WorkspaceToolFactory[] = [
   conversationAskFactory,
+  conversationAwaitFactory,
   conversationReadFactory,
 ]

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -225,6 +225,11 @@ function parseFlags(tokens, schema) {
       : Object.prototype.hasOwnProperty.call(properties, camelKey)
         ? camelKey
         : key
+    const propertySchema = properties[schemaKey]
+    if (propertySchema && propertySchema.type === 'boolean' && typeof val === 'string') {
+      if (val === 'true') val = true
+      else if (val === 'false') val = false
+    }
     if (schemaKey === 'meta') {
       // repeatable: --meta key=value -> metadataFilter
       const e = val.indexOf('=')
@@ -282,7 +287,8 @@ function printVerbHelp(group, verb, cmd) {
     const type = p.type || (p.enum ? 'enum' : '')
     const req = required.has(n) ? ' (required)' : ''
     const flag = n.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
-    out(`  --${flag}${type ? ' <' + type + '>' : ''}${req}   ${firstLine(p.description || '')}`)
+    const valueHint = type && type !== 'boolean' ? ' <' + type + '>' : ''
+    out(`  --${flag}${valueHint}${req}   ${firstLine(p.description || '')}`)
   }
 }
 

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -154,6 +154,7 @@ describe('CLI launchers and payload', () => {
               properties: {
                 issueId: { type: 'string' },
                 accountId: { type: 'string' },
+                await: { type: 'boolean' },
               },
             },
           },
@@ -187,14 +188,16 @@ describe('CLI launchers and payload', () => {
     try {
       const help = await runCli('alice-workspace', ['provenance', 'show', '--help'], env)
       expect(help.stdout).toContain('--issue-id')
+      expect(help.stdout).toContain('--await')
+      expect(help.stdout).not.toContain('--await <boolean>')
       expect(help.stdout).not.toContain('--issueId')
 
       await runCli('alice-workspace', [
-        'provenance', 'show', '--issue-id', 'audit', '--account-id', 'alpaca-paper',
+        'provenance', 'show', '--issue-id', 'audit', '--account-id', 'alpaca-paper', '--await',
       ], env)
       expect(invocation).toEqual({
         tool: 'provenance_show',
-        args: { issueId: 'audit', accountId: 'alpaca-paper' },
+        args: { issueId: 'audit', accountId: 'alpaca-paper', await: true },
       })
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()))

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2.0
+version: 1.3.0
 ---
 
 # Chat
@@ -18,6 +18,11 @@ and turn follow-up into `.alice/issues/<id>.md` work items. The bundled
 `opencli-reader` skill additionally teaches it to reach long-tail sources
 (social sentiment, options flow, global news frontpages) through the optional
 community `opencli` CLI — it will ask before assuming you have it.
+
+When an Inbox result or Issue is hard to interpret, the workspace can ask its
+attributable product Session directly. It can also dispatch several peer
+questions concurrently, await them server-side, and synthesize the replies
+without hand-written sleep loops or leaking runtime-native session ids.
 
 Trading runs through the `alice-uta` CLI against your UTA accounts — orders go
 through the trading-as-git approval flow. Recurring/headless work runs through

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -17,6 +17,11 @@ Default working habit:
 - If a ticker, topic, thesis, or issue should accumulate memory across time,
   register/reuse a tracked entity and link it with `[[name]]` in notes and issue
   bodies.
+- If an Issue or Inbox result lacks enough context, do not reconstruct the
+  author's reasoning alone. Follow its `resumeId` or Issue/Workspace provenance,
+  ask the responsible Session, and separate its answer from your own judgment.
+  When several peers may know different parts, ask them concurrently and
+  synthesize only after their replies arrive.
 
 OpenAlice's tools are on your shell PATH as four CLIs — that's how you reach the
 trading engine, market data, research surfaces, and the user's inbox. They're
@@ -28,7 +33,7 @@ Discover any command live with `<cli> --help` and `<cli> <group> <verb> --help`
 |---|---|---|
 | `alice` | **Research & data** — collected-RSS archive, symbol search (barIds), quant analysis | `alice` |
 | `alice-uta` | **Trading** — accounts, portfolio, orders, positions, trading-as-git approval (MUTATES real broker state) | `alice-uta` |
-| `alice-workspace` | **Collaboration** — push/read Inbox, locate peer files (`peer path`) and product Sessions (`peer sessions`), track entities, the shared issue board | `alice-workspace` |
+| `alice-workspace` | **Collaboration** — push/read Inbox, locate and ask peer Sessions, await replies, track entities, the shared issue board | `alice-workspace` |
 | `traderhub` | **Low-frequency market data** — fundamentals, macro series, calendars, ETF, boards, shipping, Fed | `traderhub` |
 
 ```bash
@@ -96,6 +101,30 @@ When an artifact already identifies a `resumeId`, inspect that workspace with
 OpenAlice's product Session handle, never a runtime-native session id. If the
 artifact has no exact owner, do not pick an arbitrary old Session; the later
 collaboration flow must recruit a fresh Session at that Workspace.
+
+## Ask peers instead of guessing their context
+
+Issue and Inbox entries are starting points, not always complete explanations.
+When the reason behind one is unclear, ask the attributable Session directly:
+
+```bash
+# One known author: server-side wait is the default recommendation.
+alice-workspace conversation ask --resume-id <resumeId> \
+  --prompt 'What evidence and tradeoffs led to this result?' --await
+
+# Issue provenance: scope a peer Issue with its Workspace when needed.
+alice-workspace conversation ask --issue-id <issueId> --ws-id <workspaceId> \
+  --prompt 'Why was this Issue created, and what would invalidate it?' --await
+```
+
+For several independent peers, dispatch every question first without `--await`;
+each call returns a short task id and all runs proceed concurrently. Then collect
+them with `alice-workspace conversation await --task-id <taskId>` and compare the
+answers before reporting a conclusion. Do not write shell `sleep` loops. If an
+await call exhausts its wait budget and still reports `running`, continue useful
+work and later use `conversation await` again or a one-shot `conversation read`.
+`read --mode detailed` is diagnostic-only; normal collaboration needs the final
+reply, not the peer's complete tool trace.
 
 ## Issues — your standing work list
 


### PR DESCRIPTION
## Summary
- teach new Chat workspaces to question attributable Sessions when Issue or Inbox context is incomplete
- recommend server-side await for one peer and concurrent dispatch plus await collection for several peers
- add `conversation ask --await` and `conversation await --task-id` without bypassing recorded task/resume lineage
- parse bare boolean CLI flags correctly and keep diagnostic tool traces out of normal replies

## Verification
- `npx tsc --noEmit`
- `pnpm test` (221 passed, 1 skipped; 2590 tests passed)
- targeted conversation, CLI, context injection, and workspace creation tests (58 passed)
- real CLI manifest/help: `conversation` exposes ask/await/read and renders bare `--await`
- real await against an existing completed UUID task returns the final reply without tools/blocks

## Boundary touch
- Chat workspace instruction template, Workspace collaboration CLI, and server-side headless result waiting