### PR TITLE
feat(cli): ask Inbox and Issue authors

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -85,22 +85,29 @@ missing origin is not permission to pick an arbitrary old Session.
 headless follow-up without leaving the embedded Workspace CLI:
 
 ```bash
-alice-workspace conversation ask \
-  --issue-id <id> --ws-id <ws> \
-  --prompt 'Why did you create this issue?' --await
-alice-workspace conversation ask \
-  --resume-id <resumeId> \
+alice-workspace inbox ask --id <entryId> \
   --prompt 'Why did you send this result?' --await
+alice-workspace issue ask --id <issueName> --creator \
+  --prompt 'Why did you create this Issue?' --await
+alice-workspace issue ask --id <issueName> --owner \
+  --prompt 'What is the current state and next decision?' --await
+alice-workspace issue ask --id <issueName> --run-id <taskId> \
+  --prompt 'What happened in this run?' --await
+
+# Lower-level escape hatches when there is no Inbox/Issue business object:
+alice-workspace conversation ask --resume-id <resumeId> \
+  --prompt 'Explain the missing context.' --await
 alice-workspace conversation ask --ws-id <ws> \
   --prompt 'Reconstruct why this artifact was produced.' --await
 alice-workspace conversation await --task-id <taskId>
 alice-workspace conversation read --task-id <taskId>
 ```
 
-Address with one flat form: `--resume-id` continues an exact known Session;
-`--issue-id` resolves Issue provenance (`--ws-id` scopes a peer Issue and
-defaults to this Workspace); `--ws-id` by itself recruits a fresh worker. Never
-construct or pass an internal target JSON object.
+Prefer the Inbox/Issue commands: they resolve provenance without making you
+extract `resumeId` or `wsId`. `issue ask` defaults to `--creator`; `--owner`
+requires a stable resume owner, while `--run-id` selects one exact run Session.
+Use the lower-level conversation command only when no business object already
+identifies whom to ask. Never construct or pass an internal target JSON object.
 
 For one question, start with `ask --await`: OpenAlice waits server-side and
 returns the final reply without making you guess a sleep duration. For several

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -439,6 +439,15 @@ alice-workspace conversation await --task-id <taskId>
 alice-workspace conversation read --task-id <taskId>
 ```
 
+Inbox and Issue callers normally use the business-level wrappers instead:
+
+```bash
+alice-workspace inbox ask --id <entryId> --prompt '<question>' --await
+alice-workspace issue ask --id <issueName> --creator --prompt '<question>' --await
+alice-workspace issue ask --id <issueName> --owner --prompt '<question>' --await
+alice-workspace issue ask --id <issueName> --run-id <taskId> --prompt '<question>' --await
+```
+
 The public CLI accepts only flat identity flags. `resumeId` addresses one exact
 Session, `issueId` consults the Phase 1 index, and `wsId` recruits a fresh worker
 when there is no known owner. Rich Inbox/report/trade target structures stay
@@ -459,13 +468,13 @@ worker into the historical author.
 
 ## Phase 2 Feature Design Skeleton
 
-All future convenience wrappers should delegate to the same shipped resolver:
+Business convenience wrappers delegate to the same shipped resolver:
 
 ```text
-inbox ask <entry>             -> sender Session or reconstructed Workspace Session
-issue ask <issue> --creator   -> creation provenance
-issue ask <issue> --owner     -> declared resume owner, or explain fresh mode
-issue ask <issue> --run <id>  -> that run's Session
+inbox ask <entry>             -> sender Session or reconstructed Workspace Session (shipped)
+issue ask <issue> --creator   -> creation provenance (shipped)
+issue ask <issue> --owner     -> declared resume owner, or explain fresh mode (shipped)
+issue ask <issue> --run-id    -> that run's Session (shipped)
 report ask <path> [revision]  -> matching writer/update occurrence
 trade ask <order> --decision  -> initiating Session
 trade ask <order> --execution -> UTA/broker evidence, not an AI conversation

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -183,9 +183,9 @@ remain valid and are never renamed. `taskId` remains one execution, while
 rather than silently pruned.
 
 Internal agents use the same product handle through the embedded collaboration
-path. For example, `alice-workspace conversation ask --issue-id <id>
---ws-id <ws> --prompt '<question>'`
-queries Issue provenance first: it resumes the exact attributable Session,
+path. `alice-workspace issue ask --id <name> --creator --prompt '<question>'`
+queries Issue provenance first without making the caller extract a Workspace or
+resume id: it resumes the exact attributable Session,
 reconstructs with a fresh worker only when the Workspace is known and no
 Session origin exists, or returns unavailable without substituting another
 agent. `alice-workspace conversation read --task-id <id>` returns the latest

--- a/src/core/inbox-store.spec.ts
+++ b/src/core/inbox-store.spec.ts
@@ -124,6 +124,12 @@ describe('InboxStore (in-memory)', () => {
     expect(entries.map((e) => e.id)).toEqual([e2.id, e1.id])
   })
 
+  it('gets one entry directly by its immutable id', async () => {
+    const entry = await store.append({ workspaceId: 'ws-1', comments: 'find me' })
+    expect(await store.get(entry.id)).toMatchObject({ id: entry.id, comments: 'find me' })
+    expect(await store.get('missing')).toBeNull()
+  })
+
   it('delete removes an entry and returns true; missing id returns false', async () => {
     const a = await store.append({ workspaceId: 'ws-1', comments: 'a' })
     await store.append({ workspaceId: 'ws-1', comments: 'b' })
@@ -200,6 +206,14 @@ describe('InboxStore (JSONL persistence)', () => {
     expect(entries).toHaveLength(1)
     expect(entries[0].docs).toEqual([{ path: 'report.md' }])
     expect(entries[0].comments).toBe('final draft')
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('gets a persisted entry directly by id', async () => {
+    const entry = await store.append({ workspaceId: 'ws-1', comments: 'find me' })
+    const fresh = createInboxStore({ filePath: path, readStatePath })
+    expect(await fresh.get(entry.id)).toMatchObject({ id: entry.id, comments: 'find me' })
+    expect(await fresh.get('missing')).toBeNull()
     await rm(dir, { recursive: true, force: true })
   })
 

--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -113,6 +113,8 @@ export interface InboxReadOpts {
 export interface IInboxStore {
   append(input: InboxInput): Promise<InboxEntry>
   read(opts?: InboxReadOpts): Promise<{ entries: InboxEntry[]; hasMore: boolean }>
+  /** Point lookup for business actions such as "ask this entry's sender". */
+  get(id: string): Promise<InboxEntry | null>
   /** Mark an entry read. Returns false when the entry id does not exist. */
   markRead(id: string, readAt?: number): Promise<boolean>
   /** Mark an entry unread. Returns false when the entry id does not exist. */
@@ -278,6 +280,28 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
     return { entries, hasMore }
   }
 
+  async function get(id: string): Promise<InboxEntry | null> {
+    let raw: string
+    try {
+      raw = await readFile(filePath, 'utf-8')
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null
+      }
+      throw err
+    }
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const entry = JSON.parse(line) as InboxEntry
+        if (entry.id === id) return entry
+      } catch {
+        // A malformed sibling entry must not hide a later valid id.
+      }
+    }
+    return null
+  }
+
   async function markRead(id: string, readAt = Date.now()): Promise<boolean> {
     if (!await entryExists(id)) return false
     await withReadStateLock(async () => {
@@ -358,7 +382,7 @@ export function createInboxStore(opts: InboxStoreOptions = {}): IInboxStore {
     }
   }
 
-  return { append, read, markRead, markUnread, delete: deleteEntry, onAppended, onRemoved }
+  return { append, read, get, markRead, markUnread, delete: deleteEntry, onAppended, onRemoved }
 }
 
 // ==================== In-memory store (tests) ====================
@@ -389,6 +413,10 @@ export function createMemoryInboxStore(): IInboxStore {
     const limit = opts.limit ?? 100
     const window = scoped.slice(-limit)
     return { entries: [...window].reverse(), hasMore: window.length < scoped.length }
+  }
+
+  async function get(id: string): Promise<InboxEntry | null> {
+    return entries.find((entry) => entry.id === id) ?? null
   }
 
   async function deleteEntry(id: string): Promise<boolean> {
@@ -427,5 +455,5 @@ export function createMemoryInboxStore(): IInboxStore {
     }
   }
 
-  return { append, read, markRead, markUnread, delete: deleteEntry, onAppended, onRemoved }
+  return { append, read, get, markRead, markUnread, delete: deleteEntry, onAppended, onRemoved }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,6 +63,7 @@ import { entitySearchFactory } from './tool/entity-search.js'
 import { issueToolFactories } from './tool/issue-tools.js'
 import { provenanceShowFactory } from './tool/provenance-show.js'
 import { conversationToolFactories } from './tool/conversation.js'
+import { artifactConversationToolFactories } from './tool/conversation-artifacts.js'
 import { createToolCallLog } from './core/tool-call-log.js'
 import { NewsCollectorStore, NewsCollector } from './domain/news/index.js'
 import { createNewsArchiveTools } from './tool/news.js'
@@ -118,6 +119,7 @@ async function main() {
   for (const f of issueToolFactories) workspaceToolCenter.register(f)
   workspaceToolCenter.register(provenanceShowFactory)
   for (const f of conversationToolFactories) workspaceToolCenter.register(f)
+  for (const f of artifactConversationToolFactories) workspaceToolCenter.register(f)
 
   // ==================== UTA SDK (HTTP boundary) ====================
   //

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -25,6 +25,7 @@ import { entitySearchFactory } from '../tool/entity-search.js'
 import { issueToolFactories } from '../tool/issue-tools.js'
 import { provenanceShowFactory } from '../tool/provenance-show.js'
 import { conversationToolFactories } from '../tool/conversation.js'
+import { artifactConversationToolFactories } from '../tool/conversation-artifacts.js'
 import { createTradingTools } from '../tool/trading.js'
 
 /**
@@ -93,6 +94,7 @@ describe('CLI_EXPORTS — workspace export (scoped collaboration tools)', () => 
   for (const f of issueToolFactories) wtc.register(f)
   wtc.register(provenanceShowFactory)
   for (const f of conversationToolFactories) wtc.register(f)
+  for (const f of artifactConversationToolFactories) wtc.register(f)
   const built = wtc.build({
     workspaceId: 'ws-test',
     workspaceLabel: 'test',

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -157,6 +157,7 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       inbox: {
         push: 'inbox_push',
         read: 'inbox_read',
+        ask: 'inbox_ask',
       },
       // peer path: resolve another workspace's absolute dir by id (the
       // `workspaceId` an inbox_read entry carries), so the agent can read/edit
@@ -181,6 +182,7 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
         create: 'issue_create',
         list: 'issue_list',
         show: 'issue_show',
+        ask: 'issue_ask',
       },
       provenance: {
         show: 'provenance_show',

--- a/src/tool/conversation-artifacts.spec.ts
+++ b/src/tool/conversation-artifacts.spec.ts
@@ -1,0 +1,172 @@
+import type { Tool } from 'ai'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMemoryInboxStore } from '../core/inbox-store.js'
+import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import { inboxAskFactory, issueAskFactory } from './conversation-artifacts.js'
+
+async function run(tool: Tool, args: Record<string, unknown>) {
+  return tool.execute!(args, { toolCallId: 'test', messages: [] })
+}
+
+function dispatchedAsk() {
+  return vi.fn(async () => ({
+    status: 'dispatched' as const,
+    taskId: 'run-short123',
+    resumeId: 'resume-peer',
+    workspaceId: 'ws-peer',
+    workspace: 'peer',
+    agent: 'pi',
+    resolution: {
+      mode: 'exact' as const,
+      origin: {
+        kind: 'session' as const,
+        workspaceId: 'ws-peer',
+        resumeId: 'resume-peer',
+        agent: 'pi',
+      },
+    },
+  }))
+}
+
+function baseContext(over: Partial<WorkspaceToolContext> = {}): WorkspaceToolContext {
+  return {
+    workspaceId: 'ws-caller',
+    workspaceLabel: 'caller',
+    inboxStore: createMemoryInboxStore(),
+    entityStore: {} as never,
+    ...over,
+  }
+}
+
+describe('inbox_ask', () => {
+  it('resolves one entry id to its authoritative Session origin', async () => {
+    const inboxStore = createMemoryInboxStore()
+    const entry = await inboxStore.append({
+      workspaceId: 'ws-peer',
+      comments: 'result',
+      origin: { kind: 'headless', runId: 'run-old', agent: 'pi' },
+    })
+    const ask = dispatchedAsk()
+    const tool = inboxAskFactory.build(baseContext({
+      inboxStore,
+      resolveInboxOrigin: () => ({
+        kind: 'headless', runId: 'run-old', resumeId: 'resume-peer', agent: 'pi',
+      }),
+      conversation: { ask, read: vi.fn() },
+    }))
+
+    await expect(run(tool, { id: entry.id, prompt: 'why?' })).resolves.toMatchObject({
+      ok: true,
+      subject: { kind: 'inbox', id: entry.id },
+      taskId: 'run-short123',
+    })
+    expect(ask).toHaveBeenCalledWith({
+      prompt: 'why?',
+      target: { kind: 'resume', resumeId: 'resume-peer' },
+      timeoutMs: 300_000,
+    })
+  })
+
+  it('uses the Inbox provenance resolver with a Workspace fallback for unattributed entries', async () => {
+    const inboxStore = createMemoryInboxStore()
+    const entry = await inboxStore.append({ workspaceId: 'ws-peer', comments: 'manual result' })
+    const ask = dispatchedAsk()
+    const tool = inboxAskFactory.build(baseContext({
+      inboxStore,
+      conversation: { ask, read: vi.fn() },
+    }))
+    await run(tool, { id: entry.id, prompt: 'reconstruct this' })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({
+      target: { kind: 'inbox', inboxEntryId: entry.id, workspaceId: 'ws-peer' },
+    }))
+  })
+})
+
+function issueContext(opts: {
+  execution?: { mode: 'fresh' } | { mode: 'resume'; resumeId: string }
+  runs?: Array<{ taskId: string; resumeId: string }>
+} = {}) {
+  const ask = dispatchedAsk()
+  const detail = {
+    issue: {
+      id: 'audit', title: 'Audit', body: '', status: 'todo', priority: 'none',
+      assignee: 'ws:peer', execution: opts.execution ?? { mode: 'fresh' },
+    },
+    runs: (opts.runs ?? []).map((run) => ({
+      ...run,
+      wsId: 'ws-peer', agent: 'pi', prompt: 'work', status: 'done',
+      startedAt: 1, resumable: true,
+    })),
+    inboxReports: [],
+    provenance: [],
+  }
+  const ctx = baseContext({
+    board: {
+      snapshot: vi.fn(),
+      resolveByName: vi.fn(async () => [{
+        wsId: 'ws-peer', wsTag: 'peer', id: 'audit', title: 'Audit',
+      }]),
+      detail: vi.fn(async () => detail as never),
+    },
+    conversation: { ask, read: vi.fn() },
+  })
+  return { ctx, ask }
+}
+
+describe('issue_ask', () => {
+  it('asks the creator by default through Issue provenance', async () => {
+    const { ctx, ask } = issueContext()
+    const result = await run(issueAskFactory.build(ctx), { id: 'audit', prompt: 'why?' })
+    expect(result).toMatchObject({
+      ok: true,
+      subject: { kind: 'issue', id: 'audit', workspaceId: 'ws-peer', relation: 'creator' },
+    })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({
+      target: { kind: 'issue', workspaceId: 'ws-peer', issueId: 'audit', action: 'created' },
+    }))
+  })
+
+  it('asks the declared stable owner by resumeId', async () => {
+    const { ctx, ask } = issueContext({
+      execution: { mode: 'resume', resumeId: 'resume-owner' },
+    })
+    await run(issueAskFactory.build(ctx), { id: 'audit', owner: true, prompt: 'status?' })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({
+      target: { kind: 'resume', resumeId: 'resume-owner' },
+    }))
+  })
+
+  it('requires an exact run when a fresh Issue has no stable owner', async () => {
+    const { ctx, ask } = issueContext()
+    await expect(run(issueAskFactory.build(ctx), {
+      id: 'audit', owner: true, prompt: 'status?',
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('has no stable owner'),
+    })
+    expect(ask).not.toHaveBeenCalled()
+  })
+
+  it('asks the product Session behind one selected run', async () => {
+    const { ctx, ask } = issueContext({
+      runs: [{ taskId: 'run-abc12345', resumeId: 'resume-run' }],
+    })
+    await run(issueAskFactory.build(ctx), {
+      id: 'audit', runId: 'run-abc12345', prompt: 'what happened?',
+    })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({
+      target: { kind: 'resume', resumeId: 'resume-run' },
+    }))
+  })
+
+  it('points callers to Issue show when a task is not one of the Issue runs', async () => {
+    const { ctx } = issueContext()
+    await expect(run(issueAskFactory.build(ctx), {
+      id: 'audit', runId: 'run-from-a-follow-up', prompt: 'what happened?',
+    })).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('alice-workspace issue show --id audit'),
+    })
+  })
+})

--- a/src/tool/conversation-artifacts.ts
+++ b/src/tool/conversation-artifacts.ts
@@ -1,0 +1,178 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import {
+  toSafeInboxOrigin,
+  type WorkspaceToolContext,
+  type WorkspaceToolFactory,
+} from '../core/workspace-tool-center.js'
+import {
+  askWorkspaceConversation,
+  conversationAskCommonShape,
+} from './conversation.js'
+
+function withSubject<T extends object>(subject: Record<string, unknown>, result: T) {
+  return { subject, ...result }
+}
+
+export const inboxAskFactory: WorkspaceToolFactory = {
+  name: 'inbox_ask',
+  build(ctx: WorkspaceToolContext) {
+    return tool({
+      description: [
+        'Ask the Session that produced one Inbox entry.',
+        '',
+        'The entry id is enough: OpenAlice resolves server-stamped provenance. A known',
+        'Session is resumed exactly. An entry without an attributable Session recruits a',
+        'fresh worker only in its source Workspace and labels the answer reconstructed.',
+        'Prefer --await for one entry; dispatch several without it before collecting them.',
+      ].join('\n'),
+      inputSchema: z.object({
+        id: z.string().min(1).describe('Inbox entry id returned by inbox read.'),
+        ...conversationAskCommonShape,
+      }),
+      execute: async ({ id, prompt, agent, timeoutMs, await: shouldAwait = false }) => {
+        try {
+          const entry = await ctx.inboxStore.get(id)
+          if (!entry) return { ok: false as const, error: `inbox entry not found: ${id}` }
+          const origin = toSafeInboxOrigin(ctx.resolveInboxOrigin?.(entry) ?? entry.origin)
+          const target = origin?.resumeId
+            ? { kind: 'resume' as const, resumeId: origin.resumeId }
+            : {
+                kind: 'inbox' as const,
+                inboxEntryId: entry.id,
+                workspaceId: entry.workspaceId,
+              }
+          const result = await askWorkspaceConversation(ctx, {
+            prompt,
+            target,
+            ...(agent ? { agent } : {}),
+            ...(timeoutMs ? { timeoutMs } : {}),
+            await: shouldAwait,
+          })
+          return withSubject({ kind: 'inbox', id: entry.id }, result)
+        } catch (err) {
+          return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
+        }
+      },
+    })
+  },
+}
+
+export const issueAskFactory: WorkspaceToolFactory = {
+  name: 'issue_ask',
+  build(ctx: WorkspaceToolContext) {
+    return tool({
+      description: [
+        'Ask the creator, declared owner, or one run of an Issue.',
+        '',
+        'The Issue name resolves across the global board. Omit selectors to ask its creator;',
+        'use --owner for a stable resume owner or --run-id for one exact execution Session.',
+        'A duplicate Issue name returns candidates; add --ws-id only to disambiguate.',
+      ].join('\n'),
+      inputSchema: z.object({
+        id: z.string().min(1).describe('Issue id or title, resolved across the global board.'),
+        wsId: z.string().min(1).optional().describe('Optional Workspace id only for disambiguating duplicate Issue names.'),
+        creator: z.boolean().optional().default(false).describe('Ask the Issue creator (the default when no selector is passed).'),
+        owner: z.boolean().optional().default(false).describe('Ask the declared stable resume owner.'),
+        runId: z.string().min(1).optional().describe('Ask the product Session behind one Issue run task id.'),
+        ...conversationAskCommonShape,
+      }),
+      execute: async ({
+        id,
+        wsId,
+        creator = false,
+        owner = false,
+        runId,
+        prompt,
+        agent,
+        timeoutMs,
+        await: shouldAwait = false,
+      }) => {
+        if (!ctx.board) return { ok: false as const, error: 'global issue board is unavailable' }
+        const selectorCount = Number(creator) + Number(owner) + Number(Boolean(runId))
+        if (selectorCount > 1) {
+          return { ok: false as const, error: 'choose only one of --creator, --owner, or --run-id' }
+        }
+        try {
+          const refs = (await ctx.board.resolveByName(id))
+            .filter((ref) => !wsId || ref.wsId === wsId)
+          if (refs.length === 0) {
+            return { ok: false as const, error: `issue not found: ${id}${wsId ? ` in ${wsId}` : ''}` }
+          }
+          if (refs.length > 1) {
+            return {
+              ok: false as const,
+              ambiguous: refs.map((ref) => ({
+                wsId: ref.wsId,
+                wsTag: ref.wsTag,
+                id: ref.id,
+                title: ref.title,
+              })),
+              error: 'issue name is ambiguous; retry with --ws-id',
+            }
+          }
+          const ref = refs[0]!
+          const detail = await ctx.board.detail(ref.wsId, ref.id)
+          if (!detail) return { ok: false as const, error: `issue disappeared: ${ref.id}` }
+
+          let target
+          let relation: 'creator' | 'owner' | 'run'
+          if (runId) {
+            const run = detail.runs.find((candidate) => candidate.taskId === runId)
+            if (!run) {
+              return {
+                ok: false as const,
+                error: `issue run not found: ${runId}; use alice-workspace issue show --id ${ref.id} to list this Issue's runs`,
+              }
+            }
+            target = { kind: 'resume' as const, resumeId: run.resumeId }
+            relation = 'run'
+          } else if (owner) {
+            if (detail.issue.execution.mode !== 'resume') {
+              return {
+                ok: false as const,
+                error: 'this Issue uses fresh execution and has no stable owner; ask --creator or choose --run-id',
+              }
+            }
+            target = {
+              kind: 'resume' as const,
+              resumeId: detail.issue.execution.resumeId,
+            }
+            relation = 'owner'
+          } else {
+            target = {
+              kind: 'issue' as const,
+              workspaceId: ref.wsId,
+              issueId: ref.id,
+              action: 'created' as const,
+            }
+            relation = 'creator'
+          }
+
+          const result = await askWorkspaceConversation(ctx, {
+            prompt,
+            target,
+            ...(agent ? { agent } : {}),
+            ...(timeoutMs ? { timeoutMs } : {}),
+            await: shouldAwait,
+          })
+          return withSubject({
+            kind: 'issue',
+            id: ref.id,
+            workspaceId: ref.wsId,
+            relation,
+            ...(runId ? { runId } : {}),
+          }, result)
+        } catch (err) {
+          return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
+        }
+      },
+    })
+  },
+}
+
+export const artifactConversationToolFactories: WorkspaceToolFactory[] = [
+  inboxAskFactory,
+  issueAskFactory,
+]

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -4,6 +4,8 @@ import { z } from 'zod'
 import type {
   WorkspaceConversationControl,
   WorkspaceConversationTask,
+  WorkspaceConversationTarget,
+  WorkspaceToolContext,
   WorkspaceToolFactory,
 } from '../core/workspace-tool-center.js'
 import type { HeadlessMessageBlock } from '../workspaces/headless-output.js'
@@ -12,6 +14,17 @@ const DEFAULT_TIMEOUT_MS = 300_000
 const MAX_TIMEOUT_MS = 1_800_000
 const MAX_PROMPT_CHARS = 16_000
 const AWAIT_POLL_MS = 250
+
+export const conversationAskCommonShape = {
+  prompt: z.string().trim().min(1).max(MAX_PROMPT_CHARS)
+    .describe('Question for the responsible Session or reconstructing worker.'),
+  agent: z.string().min(1).optional()
+    .describe('Optional runtime for reconstructed/fresh work only; exact Session runtime cannot be overridden.'),
+  timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
+    .describe(`Headless watchdog in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
+  await: z.boolean().optional().default(false)
+    .describe('Wait server-side for the final reply; on timeout, return the taskId for later await/read.'),
+}
 
 function taskProjection(task: WorkspaceConversationTask, mode: 'summary' | 'detailed') {
   const structured = task.structured
@@ -56,6 +69,68 @@ async function awaitConversationTask(
   return task
 }
 
+export async function askWorkspaceConversation(
+  ctx: WorkspaceToolContext,
+  input: {
+    prompt: string
+    target: WorkspaceConversationTarget
+    agent?: string
+    timeoutMs?: number
+    await?: boolean
+  },
+) {
+  if (!ctx.conversation) {
+    return { ok: false as const, error: 'workspace conversation control is unavailable' }
+  }
+  try {
+    const effectiveTimeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const result = await ctx.conversation.ask({
+      prompt: input.prompt,
+      target: input.target,
+      timeoutMs: effectiveTimeoutMs,
+      ...(input.agent ? { agent: input.agent } : {}),
+    })
+    if (result.status === 'unavailable') {
+      return {
+        ok: false as const,
+        status: result.status,
+        resolution: { mode: result.resolution.mode, reason: result.resolution.reason },
+      }
+    }
+    const dispatched = {
+      ok: true as const,
+      status: 'running' as const,
+      taskId: result.taskId,
+      resumeId: result.resumeId,
+      workspaceId: result.workspaceId,
+      workspace: result.workspace,
+      agent: result.agent,
+      resolution: result.resolution.mode === 'reconstructed'
+        ? { mode: result.resolution.mode, reason: result.resolution.reason }
+        : { mode: result.resolution.mode },
+    }
+    if (!input.await) return dispatched
+    const task = await awaitConversationTask(ctx.conversation, result.taskId, effectiveTimeoutMs)
+    if (!task) {
+      return {
+        ok: false as const,
+        taskId: result.taskId,
+        error: `conversation task disappeared while awaiting: ${result.taskId}`,
+      }
+    }
+    return {
+      ...dispatched,
+      ...taskProjection(task, 'summary'),
+      awaited: task.status !== 'running',
+      ...(task.status === 'running'
+        ? { next: `alice-workspace conversation await --task-id ${task.taskId}` }
+        : {}),
+    }
+  } catch (err) {
+    return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
 export const conversationAskFactory: WorkspaceToolFactory = {
   name: 'conversation_ask',
   build(ctx) {
@@ -73,20 +148,13 @@ export const conversationAskFactory: WorkspaceToolFactory = {
         'questions run concurrently before conversation_await collects their replies.',
       ].join('\n'),
       inputSchema: z.object({
-        prompt: z.string().trim().min(1).max(MAX_PROMPT_CHARS)
-          .describe('Question for the responsible Session or reconstructing worker.'),
+        ...conversationAskCommonShape,
         resumeId: z.string().min(1).optional()
           .describe('Exact product Session to continue. Cannot be combined with wsId or issueId.'),
         wsId: z.string().min(1).optional()
           .describe('Workspace for a fresh worker, or optional scope for issueId.'),
         issueId: z.string().min(1).optional()
           .describe('Issue whose attributable Session should answer. Defaults to the current Workspace.'),
-        agent: z.string().min(1).optional()
-          .describe('Optional runtime for reconstructed/fresh work only; exact Session runtime cannot be overridden.'),
-        timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
-          .describe(`Headless watchdog in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
-        await: z.boolean().optional().default(false)
-          .describe('Wait server-side for the final reply; on timeout, return the taskId for later await/read.'),
       }),
       execute: async ({ prompt, resumeId, wsId, issueId, agent, timeoutMs, await: shouldAwait = false }) => {
         if (!ctx.conversation) {
@@ -109,53 +177,13 @@ export const conversationAskFactory: WorkspaceToolFactory = {
           : issueId
             ? { kind: 'issue' as const, workspaceId: wsId ?? ctx.workspaceId, issueId }
             : { kind: 'workspace' as const, workspaceId: wsId! }
-        try {
-          const effectiveTimeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS
-          const result = await ctx.conversation.ask({
-            prompt,
-            target,
-            timeoutMs: effectiveTimeoutMs,
-            ...(agent ? { agent } : {}),
-          })
-          if (result.status === 'unavailable') {
-            return {
-              ok: false as const,
-              status: result.status,
-              resolution: { mode: result.resolution.mode, reason: result.resolution.reason },
-            }
-          }
-          const dispatched = {
-            ok: true as const,
-            status: 'running' as const,
-            taskId: result.taskId,
-            resumeId: result.resumeId,
-            workspaceId: result.workspaceId,
-            workspace: result.workspace,
-            agent: result.agent,
-            resolution: result.resolution.mode === 'reconstructed'
-              ? { mode: result.resolution.mode, reason: result.resolution.reason }
-              : { mode: result.resolution.mode },
-          }
-          if (!shouldAwait) return dispatched
-          const task = await awaitConversationTask(ctx.conversation, result.taskId, effectiveTimeoutMs)
-          if (!task) {
-            return {
-              ok: false as const,
-              taskId: result.taskId,
-              error: `conversation task disappeared while awaiting: ${result.taskId}`,
-            }
-          }
-          return {
-            ...dispatched,
-            ...taskProjection(task, 'summary'),
-            awaited: task.status !== 'running',
-            ...(task.status === 'running'
-              ? { next: `alice-workspace conversation await --task-id ${task.taskId}` }
-              : {}),
-          }
-        } catch (err) {
-          return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
-        }
+        return askWorkspaceConversation(ctx, {
+          prompt,
+          target,
+          ...(agent ? { agent } : {}),
+          ...(timeoutMs ? { timeoutMs } : {}),
+          await: shouldAwait,
+        })
       },
     })
   },

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.3.0
+version: 1.4.0
 ---
 
 # Chat

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -108,13 +108,15 @@ Issue and Inbox entries are starting points, not always complete explanations.
 When the reason behind one is unclear, ask the attributable Session directly:
 
 ```bash
-# One known author: server-side wait is the default recommendation.
-alice-workspace conversation ask --resume-id <resumeId> \
+# One Inbox result: it resolves the sender for you.
+alice-workspace inbox ask --id <entryId> \
   --prompt 'What evidence and tradeoffs led to this result?' --await
 
-# Issue provenance: scope a peer Issue with its Workspace when needed.
-alice-workspace conversation ask --issue-id <issueId> --ws-id <workspaceId> \
+# One Issue: ask its creator, stable owner, or a selected run.
+alice-workspace issue ask --id <issueName> --creator \
   --prompt 'Why was this Issue created, and what would invalidate it?' --await
+alice-workspace issue ask --id <issueName> --owner \
+  --prompt 'What is the current state and next decision?' --await
 ```
 
 For several independent peers, dispatch every question first without `--await`;


### PR DESCRIPTION
## Summary
- add `inbox ask --id` to resolve and question an Inbox sender without manual provenance extraction
- add `issue ask` for creator, stable owner, or one selected run Session
- keep business wrappers on the shared exact/reconstructed conversation resolver and server-side await path
- add immutable Inbox point lookup and update Chat/CLI guidance to prefer business-level addressing

## Verification
- `npx tsc --noEmit`
- `pnpm test` (222 passed, 1 skipped; 2599 tests passed)
- targeted artifact conversation, Inbox store, CLI export/gateway, and shim tests (83 passed before final additions)
- real CLI help for `inbox ask` and `issue ask`
- real `inbox ask --await`: exact sender Session resumed, compact final reply returned
- real `issue ask --run-id --await`: exact Issue run Session resumed, compact final reply returned

## Boundary touch
- Workspace collaboration CLI, Inbox point lookup, Issue provenance/run addressing, Chat template guidance