### PR TITLE
feat(cli): collect peer replies together

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -100,6 +100,7 @@ alice-workspace conversation ask --resume-id <resumeId> \
 alice-workspace conversation ask --ws-id <ws> \
   --prompt 'Reconstruct why this artifact was produced.' --await
 alice-workspace conversation await --task-id <taskId>
+alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
 alice-workspace conversation read --task-id <taskId>
 ```
 
@@ -112,9 +113,10 @@ identifies whom to ask. Never construct or pass an internal target JSON object.
 For one question, start with `ask --await`: OpenAlice waits server-side and
 returns the final reply without making you guess a sleep duration. For several
 independent peers, issue every `ask` first without `--await` so all tasks run
-concurrently, then collect each short task id with `conversation await`. If an
-await returns `status: running`, do other useful work and await again later or
-use one-shot `conversation read`; never build a shell `sleep` polling loop.
+concurrently, then pass every short task id to one `conversation collect` call.
+If collect reports a task still `running`, do other useful work and collect
+again later or use one-shot `conversation read`; never build a shell `sleep`
+polling loop.
 
 Inspect `resolution.mode` on the ask result:
 

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -436,6 +436,7 @@ alice-workspace conversation ask --resume-id <resumeId> --prompt '<question>'
 alice-workspace conversation ask --issue-id <issueId> [--ws-id <workspaceId>] --prompt '<question>'
 alice-workspace conversation ask --ws-id <workspaceId> --prompt '<question>'
 alice-workspace conversation await --task-id <taskId>
+alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
 alice-workspace conversation read --task-id <taskId>
 ```
 
@@ -456,9 +457,10 @@ never serialize them into `conversation ask`. The ask result reports a compact
 `resolution.mode`; read returns runtime status and the latest assistant text by
 default. Full tool/message blocks are diagnostic data behind `--mode detailed`.
 For one peer, `ask --await` is the preferred path. For multiple peers, dispatch
-all asks first so their runs overlap, then server-side await each task before
-synthesizing. A timed-out await preserves the task and returns its id; callers
-fall back to later await/read snapshots instead of scripting arbitrary sleeps.
+all asks first so their runs overlap, then server-side collect their task ids in
+one ordered result before synthesizing. A timed-out collect preserves every task;
+callers fall back to a later collect/read snapshot instead of scripting arbitrary
+sleeps.
 
 The first fresh reconstruction appends a `reconstructed` occurrence to the
 artifact. Later questions about that same otherwise-unattributed artifact

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -194,10 +194,11 @@ assistant reply by default; diagnostic tool/message blocks require
 task ids remain readable.
 
 Prefer `conversation ask ... --await` for a single follow-up. To question
-several independent Sessions, dispatch every ask first, then collect each task
-with `conversation await --task-id <id>` so the runs overlap. If server-side
-await reaches its budget while a task still runs, use a later await or one-shot
-read; agents should not manufacture shell sleep loops.
+several independent Sessions, dispatch every ask first, then collect the tasks
+in one `conversation collect --task-id <a> --task-id <b>` call so the runs
+overlap. If server-side collection reaches its budget while a task still runs,
+use a later collect or one-shot read; agents should not manufacture shell sleep
+loops.
 
 Scheduling never bypasses trading approval. A headless agent may research or
 stage a trade, but execution remains behind UTA/Trading-as-Git permission and

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -190,6 +190,7 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       conversation: {
         ask: 'conversation_ask',
         await: 'conversation_await',
+        collect: 'conversation_collect',
         read: 'conversation_read',
       },
     },

--- a/src/tool/conversation.spec.ts
+++ b/src/tool/conversation.spec.ts
@@ -5,6 +5,7 @@ import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
 import {
   conversationAskFactory,
   conversationAwaitFactory,
+  conversationCollectFactory,
   conversationReadFactory,
 } from './conversation.js'
 
@@ -155,6 +156,53 @@ describe('conversation_await', () => {
         status: 'running',
         next: 'alice-workspace conversation read --task-id task-1',
       })
+  })
+})
+
+describe('conversation_collect', () => {
+  it('awaits several tasks concurrently and preserves input order', async () => {
+    const read = vi.fn(async (taskId: string) => ({
+      ...completedTask,
+      taskId,
+      resumeId: `resume-${taskId}`,
+      structured: {
+        ...completedTask.structured,
+        assistantText: `reply ${taskId}`,
+      },
+    }))
+    const tool = conversationCollectFactory.build(context({
+      conversation: { ask: vi.fn(), read },
+    }))
+    await expect(run(tool, { taskId: ['run-a', 'run-b'] })).resolves.toMatchObject({
+      ok: true,
+      complete: true,
+      count: 2,
+      running: 0,
+      results: [
+        { taskId: 'run-a', assistantText: 'reply run-a' },
+        { taskId: 'run-b', assistantText: 'reply run-b' },
+      ],
+    })
+    expect(read).toHaveBeenCalledWith('run-a')
+    expect(read).toHaveBeenCalledWith('run-b')
+  })
+
+  it('reports missing tasks without hiding completed replies', async () => {
+    const tool = conversationCollectFactory.build(context({
+      conversation: {
+        ask: vi.fn(),
+        read: vi.fn(async (taskId: string) => taskId === 'missing' ? null : completedTask),
+      },
+    }))
+    await expect(run(tool, { taskId: ['task-1', 'missing'] })).resolves.toMatchObject({
+      ok: false,
+      complete: false,
+      missing: 1,
+      results: [
+        { ok: true, assistantText: 'The report followed the issue rule.' },
+        { ok: false, taskId: 'missing' },
+      ],
+    })
   })
 })
 

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -232,6 +232,67 @@ export const conversationAwaitFactory: WorkspaceToolFactory = {
   },
 }
 
+export const conversationCollectFactory: WorkspaceToolFactory = {
+  name: 'conversation_collect',
+  build(ctx) {
+    return tool({
+      description: [
+        'Collect several already-dispatched conversation tasks in one server-side wait.',
+        '',
+        'Repeat --task-id for every peer. Tasks keep running concurrently; this command',
+        'waits for all of them and returns compact final replies in the same order.',
+        'It does not ask another model to summarize or merge the answers.',
+      ].join('\n'),
+      inputSchema: z.object({
+        taskId: z.array(z.string().min(1)).min(1).max(32)
+          .describe('Task id to collect. Repeat --task-id for multiple concurrent peers.'),
+        timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
+          .describe(`Server-side wait budget per task in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
+      }),
+      execute: async ({ taskId, timeoutMs }) => {
+        if (!ctx.conversation) {
+          return { ok: false as const, error: 'workspace conversation control is unavailable' }
+        }
+        try {
+          const ids = [...new Set(taskId)]
+          const tasks = await Promise.all(ids.map((id) => awaitConversationTask(
+            ctx.conversation!,
+            id,
+            timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          )))
+          const results = tasks.map((task, index) => task
+            ? {
+                ok: true as const,
+                ...taskProjection(task, 'summary'),
+                awaited: task.status !== 'running',
+              }
+            : {
+                ok: false as const,
+                taskId: ids[index]!,
+                error: `conversation task not found: ${ids[index]}`,
+              })
+          const running = results.filter((result) => result.ok && result.status === 'running').length
+          const failed = results.filter((result) => result.ok && (
+            result.status === 'failed' || result.status === 'interrupted'
+          )).length
+          const missing = results.filter((result) => !result.ok).length
+          return {
+            ok: missing === 0,
+            complete: missing === 0 && running === 0,
+            count: results.length,
+            running,
+            failed,
+            missing,
+            results,
+          }
+        } catch (err) {
+          return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
+        }
+      },
+    })
+  },
+}
+
 export const conversationReadFactory: WorkspaceToolFactory = {
   name: 'conversation_read',
   build(ctx) {
@@ -269,5 +330,6 @@ export const conversationReadFactory: WorkspaceToolFactory = {
 export const conversationToolFactories: WorkspaceToolFactory[] = [
   conversationAskFactory,
   conversationAwaitFactory,
+  conversationCollectFactory,
   conversationReadFactory,
 ]

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -239,6 +239,9 @@ function parseFlags(tokens, schema) {
       // A JSON object value (--doc '{"path":"x"}') is kept as-is so future
       // per-doc fields keep working; a bare path is wrapped into { path }.
       docs.push(val && typeof val === 'object' ? val : { path: String(val) })
+    } else if (propertySchema && propertySchema.type === 'array') {
+      const current = Array.isArray(args[schemaKey]) ? args[schemaKey] : []
+      args[schemaKey] = current.concat(Array.isArray(val) ? val : [val])
     } else {
       args[schemaKey] = val
     }
@@ -287,8 +290,13 @@ function printVerbHelp(group, verb, cmd) {
     const type = p.type || (p.enum ? 'enum' : '')
     const req = required.has(n) ? ' (required)' : ''
     const flag = n.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
-    const valueHint = type && type !== 'boolean' ? ' <' + type + '>' : ''
-    out(`  --${flag}${valueHint}${req}   ${firstLine(p.description || '')}`)
+    const valueHint = type === 'array'
+      ? ' <value>'
+      : type && type !== 'boolean'
+        ? ' <' + type + '>'
+        : ''
+    const repeatable = type === 'array' ? ' (repeatable)' : ''
+    out(`  --${flag}${valueHint}${req}${repeatable}   ${firstLine(p.description || '')}`)
   }
 }
 

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -155,6 +155,7 @@ describe('CLI launchers and payload', () => {
                 issueId: { type: 'string' },
                 accountId: { type: 'string' },
                 await: { type: 'boolean' },
+                taskId: { type: 'array', items: { type: 'string' } },
               },
             },
           },
@@ -190,14 +191,22 @@ describe('CLI launchers and payload', () => {
       expect(help.stdout).toContain('--issue-id')
       expect(help.stdout).toContain('--await')
       expect(help.stdout).not.toContain('--await <boolean>')
+      expect(help.stdout).toContain('--task-id <value> (repeatable)')
+      expect(help.stdout).not.toContain('--task-id <array>')
       expect(help.stdout).not.toContain('--issueId')
 
       await runCli('alice-workspace', [
         'provenance', 'show', '--issue-id', 'audit', '--account-id', 'alpaca-paper', '--await',
+        '--task-id', 'run-a', '--task-id', 'run-b',
       ], env)
       expect(invocation).toEqual({
         tool: 'provenance_show',
-        args: { issueId: 'audit', accountId: 'alpaca-paper', await: true },
+        args: {
+          issueId: 'audit',
+          accountId: 'alpaca-paper',
+          await: true,
+          taskId: ['run-a', 'run-b'],
+        },
       })
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()))

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.4.0
+version: 1.5.0
 ---
 
 # Chat

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -121,10 +121,11 @@ alice-workspace issue ask --id <issueName> --owner \
 
 For several independent peers, dispatch every question first without `--await`;
 each call returns a short task id and all runs proceed concurrently. Then collect
-them with `alice-workspace conversation await --task-id <taskId>` and compare the
-answers before reporting a conclusion. Do not write shell `sleep` loops. If an
-await call exhausts its wait budget and still reports `running`, continue useful
-work and later use `conversation await` again or a one-shot `conversation read`.
+them in one call with `alice-workspace conversation collect --task-id <taskA>
+--task-id <taskB>` and compare the answers before reporting a conclusion. Do not
+write shell `sleep` loops. If collect exhausts its wait budget and still reports
+`running`, continue useful work and later collect again or use a one-shot
+`conversation read`.
 `read --mode detailed` is diagnostic-only; normal collaboration needs the final
 reply, not the peer's complete tool trace.
 


### PR DESCRIPTION
## Summary
- add `conversation collect` to await several already-dispatched peer tasks concurrently
- return ordered compact replies plus complete/running/failed/missing counts without hidden model synthesis
- teach the CLI shim repeatable array flags so agents use repeated `--task-id` values instead of JSON arrays
- update Chat and collaboration guidance to dispatch peers first, then collect once

## Verification
- `npx tsc --noEmit`
- `pnpm test` (222 passed, 1 skipped; 2601 tests passed)
- targeted conversation, CLI export/gateway, and shim tests (52 passed)
- real `conversation collect --task-id ... --task-id ...` over two completed LongCat follow-ups; ordered compact replies returned with no tool/message blocks
- real help renders `--task-id <value> (repeatable)`

## Boundary touch
- Workspace collaboration CLI, server-side task collection, generic repeatable CLI flags, Chat template guidance