### PR TITLE
fix(issues): reject unresumable owners

### DIFF
--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -61,8 +61,10 @@ The filename stem is the stable issue id. Frontmatter:
   immutable runtime.
 - `execution` — scheduled ownership: `{ mode: fresh }` creates a new product
   Session per fire; `{ mode: resume, resumeId: <id> }` continues one exact
-  accountable Session. Existing files without it remain fresh for compatibility;
-  new agent-created schedules must choose explicitly.
+  accountable Session. A new resume owner must already have captured a native
+  runtime session id; provenance-only, not-yet-resumable Sessions are rejected
+  at assignment time. Existing files without `execution` remain fresh for
+  compatibility; new agent-created schedules must choose explicitly.
 
 `done` and `canceled` are terminal and stop scheduled firing. There is no
 separate `enabled` flag. A successful one-shot `at` issue is automatically

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -147,6 +147,20 @@ describe('issue_create', () => {
     expect(result.ok).toBe(false)
     expect(result.error).toMatch(/another workspace/)
   })
+
+  it('refuses to assign a Session that has no resumable runtime identity yet', async () => {
+    const context = ctx({
+      resolveSessionIdentity: () => ({ workspaceId: 'ws-self', agent: 'pi', resumable: false }),
+    })
+    const result = await run(issueCreateFactory.build(context), {
+      id: 'unready-owner',
+      title: 'Unready owner',
+      when: { kind: 'every', every: '30m' },
+      execution: { mode: 'resume', resumeId: 'resume-unready' },
+    })
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/not resumable yet/)
+  })
 })
 
 describe('issue_update', () => {

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -91,6 +91,12 @@ function resolveIssueExecution(
   if (identity && identity.workspaceId !== ctx.workspaceId) {
     return { ok: false, error: `product Session ${resumeId} belongs to another workspace` }
   }
+  if (identity && !identity.resumable) {
+    return {
+      ok: false,
+      error: `product Session ${resumeId} is not resumable yet; complete one agent turn before assigning it`,
+    }
+  }
   return { ok: true, execution: parsed.data }
 }
 

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -50,7 +50,9 @@ function build(inboxReports: InboxEntry[] = []) {
     },
     resumeRegistry: {
       get: (resumeId: string) => resumeId === 'resume-kind-owl-abc123'
-        ? { resumeId, wsId: 'ws-1', agent: 'codex', createdAt: 1, updatedAt: 1 }
+        ? { resumeId, wsId: 'ws-1', agent: 'codex', agentSessionId: 'native-1', createdAt: 1, updatedAt: 1 }
+        : resumeId === 'resume-unready'
+          ? { resumeId, wsId: 'ws-1', agent: 'codex', createdAt: 1, updatedAt: 1 }
         : null,
     },
     issueDetail: async (wsId: string, id: string) => {
@@ -121,6 +123,16 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     })
     expect(updated.status).toBe(200)
     expect(updated.body.issue.execution).toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
+  })
+
+  it('409 when the selected execution owner is not resumable yet', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
+    const { app } = build()
+    const unavailable = await req(app, 'PATCH', '/ws-1/i1', {
+      execution: { mode: 'resume', resumeId: 'resume-unready' },
+    })
+    expect(unavailable.status).toBe(409)
+    expect(unavailable.body.error).toBe('unavailable_execution_owner')
   })
 
   it('400 no_fields when the body has none of the patchable fields', async () => {

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -137,6 +137,12 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
             message: 'resumeId must identify a product Session in this Workspace',
           }, 400)
         }
+        if (!identity.agentSessionId) {
+          return c.json({
+            error: 'unavailable_execution_owner',
+            message: 'the selected Session is not resumable yet; complete one agent turn before assigning it',
+          }, 409)
+        }
       }
       patch.execution = execution.data
     }

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -267,7 +267,12 @@ function ExecutionEditor({
     return raw.length > 44 ? `${raw.slice(0, 43)}…` : raw
   }
   const selected = value?.mode === 'resume' ? value.resumeId : '__fresh__'
-  const choices = sessions.filter((session) => session.resumeId && session.agent !== 'shell')
+  // A product resumeId can exist before the native runtime has reported its
+  // own session id. Such an entry is useful provenance, but cannot own a
+  // scheduled resume yet: dispatch would fail with `not_ready` on every tick.
+  const choices = sessions.filter(
+    (session) => session.resumeId && session.agent !== 'shell' && session.resumable,
+  )
   const hasSelected = value?.mode !== 'resume' || choices.some((session) => session.resumeId === value.resumeId)
 
   return (
@@ -287,7 +292,7 @@ function ExecutionEditor({
         </option>
       ))}
       {!hasSelected && value?.mode === 'resume' && (
-        <option value={value.resumeId}>Continue {value.resumeId}</option>
+        <option value={value.resumeId}>Unavailable owner · {value.resumeId}</option>
       )}
     </select>
   )


### PR DESCRIPTION
## What changed

- reject fixed Issue owners that have not captured a resumable native runtime session yet
- hide unavailable Sessions from new Ownership choices while preserving existing unavailable bindings visibly
- keep CLI/MCP and HTTP validation aligned
- document the assignment requirement

## Why

A product resumeId can exist before its native runtime session id is known. Allowing that identity to own a scheduled Issue made configuration appear successful while every scheduled fire failed with `not_ready`.

## Validation

- `pnpm vitest run src/workspaces/schedule/scanner.spec.ts src/workspaces/issues/declaration.spec.ts src/workspaces/issues/mutate.spec.ts src/webui/routes/issues.spec.ts src/tool/issue-tools.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (222 files passed, 1 skipped; 2603 tests passed, 6 skipped)
- real `/issues` detail verification for scheduled and unscheduled Issues