### PR TITLE
feat(collaboration): ask Inbox and Issue agents

### DIFF
--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -468,6 +468,15 @@ continue the reconstruction Session instead of recruiting another worker, but
 the resolution mode remains `reconstructed`: continuity does not turn that
 worker into the historical author.
 
+The human UI uses the same resolver through asynchronous `/api/inquiries`
+business routes. Each dispatched headless task persists a safe inquiry subject
+(Inbox entry, or Issue + creator/owner/run relation), the original question,
+and exact/reconstructed resolution. This reverse link lets Inbox and Issue
+pages restore follow-up history after navigation or restart without parsing
+prompts or exposing adapter-native session ids. UI requests return immediately
+after dispatch; the page polls durable task state instead of holding an
+Electron IPC request open for the model turn.
+
 ## Phase 2 Feature Design Skeleton
 
 Business convenience wrappers delegate to the same shipped resolver:
@@ -512,6 +521,7 @@ shapes should point back here rather than restating the rules differently.
 | `src/workspaces/service.ts` | Dispatch, resume, and per-Session concurrency |
 | `src/workspaces/conversation-control.ts` | Provenance resolution plus exact/reconstructed headless dispatch |
 | `src/tool/conversation.ts` | Embedded business-target ask/read CLI tools |
+| `src/webui/routes/inquiries.ts` | Human Inbox/Issue ask dispatch and durable inquiry projections |
 | `src/core/inbox-store.ts` | Immutable notification records and sender provenance |
 | `src/server/inbox-origin.ts` | Server-side run/session attribution |
 | `src/workspaces/issues/declaration.ts` | Workspace-local Issue declaration |

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -202,6 +202,13 @@ overlap. If server-side collection reaches its budget while a task still runs,
 use a later collect or one-shot read; agents should not manufacture shell sleep
 loops.
 
+The Issue detail UI separates human tracking properties from scheduled
+execution responsibility. Status, priority, and assignee do not select an
+agent. A scheduled Issue instead presents two explicit policies: recruit a new
+Session on every fire (`fresh`), or keep one responsible Session (`resume`).
+Only the second policy has a stable owner to ask; fresh execution exposes the
+creator and each concrete run as separate follow-up targets.
+
 Scheduling never bypasses trading approval. A headless agent may research or
 stage a trade, but execution remains behind UTA/Trading-as-Git permission and
 human approval boundaries.
@@ -223,6 +230,7 @@ human approval boundaries.
 | `src/workspaces/headless-output.ts` | Vendor-neutral reply/tool block contract and accumulator |
 | `src/workspaces/adapters/{claude,codex,opencode,pi}.ts` | Runtime-specific JSON event translation |
 | `src/webui/routes/headless.ts` | Cross-workspace capacity, task, normalized output, and diagnostic-tail API |
+| `src/webui/routes/inquiries.ts` | Inbox/Issue follow-up dispatch and durable business-object history |
 | `ui/src/pages/AutomationRunsSection.tsx` | Run list, final reply, tool activity, and diagnostics UI |
 | `src/tool/issue-tools.ts` | Workspace-scoped issue CLI/MCP tools |
 | `src/tool/inbox-push.ts` | Headless/interactive delivery to Inbox |

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -35,7 +35,7 @@ import type { ArtifactRef, SessionOrigin } from './provenance-store.js'
 import type { IssuesSnapshot, IssueDetail, WikilinkIssueRef } from '../workspaces/issues/board.js'
 import type { WorkspaceSessionDirectory } from '../workspaces/session-directory.js'
 import type { HeadlessStructuredOutput } from '../workspaces/headless-output.js'
-import type { HeadlessTaskStatus } from '../workspaces/headless-task-registry.js'
+import type { HeadlessInquirySubject, HeadlessTaskStatus } from '../workspaces/headless-task-registry.js'
 
 export type WorkspaceConversationTarget =
   | { kind: 'resume'; resumeId: string }
@@ -118,6 +118,8 @@ export interface WorkspaceConversationControl {
     readonly timeoutMs: number
     readonly target: WorkspaceConversationTarget
     readonly agent?: string
+    /** Optional business reverse link persisted with the dispatched task. */
+    readonly subject?: HeadlessInquirySubject
   }): Promise<WorkspaceConversationAskResult>
   read(taskId: string): Promise<WorkspaceConversationTask | null>
 }

--- a/src/tool/conversation-artifacts.spec.ts
+++ b/src/tool/conversation-artifacts.spec.ts
@@ -64,6 +64,7 @@ describe('inbox_ask', () => {
     expect(ask).toHaveBeenCalledWith({
       prompt: 'why?',
       target: { kind: 'resume', resumeId: 'resume-peer' },
+      subject: { kind: 'inbox', entryId: entry.id },
       timeoutMs: 300_000,
     })
   })

--- a/src/tool/conversation-artifacts.ts
+++ b/src/tool/conversation-artifacts.ts
@@ -46,6 +46,7 @@ export const inboxAskFactory: WorkspaceToolFactory = {
           const result = await askWorkspaceConversation(ctx, {
             prompt,
             target,
+            subject: { kind: 'inbox', entryId: entry.id },
             ...(agent ? { agent } : {}),
             ...(timeoutMs ? { timeoutMs } : {}),
             await: shouldAwait,
@@ -153,6 +154,13 @@ export const issueAskFactory: WorkspaceToolFactory = {
           const result = await askWorkspaceConversation(ctx, {
             prompt,
             target,
+            subject: {
+              kind: 'issue',
+              workspaceId: ref.wsId,
+              issueId: ref.id,
+              relation,
+              ...(runId ? { runId } : {}),
+            },
             ...(agent ? { agent } : {}),
             ...(timeoutMs ? { timeoutMs } : {}),
             await: shouldAwait,

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -9,6 +9,7 @@ import type {
   WorkspaceToolFactory,
 } from '../core/workspace-tool-center.js'
 import type { HeadlessMessageBlock } from '../workspaces/headless-output.js'
+import type { HeadlessInquirySubject } from '../workspaces/headless-task-registry.js'
 
 const DEFAULT_TIMEOUT_MS = 300_000
 const MAX_TIMEOUT_MS = 1_800_000
@@ -74,6 +75,7 @@ export async function askWorkspaceConversation(
   input: {
     prompt: string
     target: WorkspaceConversationTarget
+    subject?: HeadlessInquirySubject
     agent?: string
     timeoutMs?: number
     await?: boolean
@@ -88,6 +90,7 @@ export async function askWorkspaceConversation(
       prompt: input.prompt,
       target: input.target,
       timeoutMs: effectiveTimeoutMs,
+      ...(input.subject ? { subject: input.subject } : {}),
       ...(input.agent ? { agent: input.agent } : {}),
     })
     if (result.status === 'unavailable') {

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -12,6 +12,7 @@ import { createChannelsRoutes, type SSEClient } from './routes/channels.js'
 import { createConfigRoutes, createMarketDataRoutes } from './routes/config.js'
 import { createScheduleRoutes } from './routes/schedule.js'
 import { createIssuesRoutes } from './routes/issues.js'
+import { createInquiryRoutes } from './routes/inquiries.js'
 import { createTradingProxyRoutes } from './routes/trading-proxy.js'
 import { createTradingConfigRoutes } from './routes/trading-config.js'
 import { createToolsRoutes } from './routes/tools.js'
@@ -256,6 +257,10 @@ export class WebPlugin implements Plugin {
     app.route('/api/headless', createHeadlessRoutes(this.workspaceService))
     app.route('/api/schedule', createScheduleRoutes(this.workspaceService))
     app.route('/api/issues', createIssuesRoutes(this.workspaceService))
+    app.route('/api/inquiries', createInquiryRoutes({
+      service: this.workspaceService,
+      inboxStore: ctx.inboxStore,
+    }))
     // Tracked entities — read surface for the Tracked tab. Mounted here (not
     // with the other /api/* routes above) because backlink scanning needs the
     // workspace registry, which only exists once workspaceService is created.

--- a/src/webui/routes/inquiries.spec.ts
+++ b/src/webui/routes/inquiries.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMemoryInboxStore } from '../../core/inbox-store.js'
+import type { HeadlessTaskInquiry, HeadlessTaskRecord } from '../../workspaces/headless-task-registry.js'
+import type { WorkspaceService } from '../../workspaces/service.js'
+import { createInquiryRoutes } from './inquiries.js'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function build(opts: { execution?: { mode: 'fresh' } | { mode: 'resume'; resumeId: string } } = {}) {
+  const inboxStore = createMemoryInboxStore()
+  const dispatchHeadlessTask = vi.fn(async (
+    _meta: unknown,
+    _adapter: unknown,
+    _prompt: string,
+    _timeout: number,
+    _issueId?: string,
+    _resumeId?: string,
+    _inquiry?: HeadlessTaskInquiry,
+  ) => ({ taskId: 'run-new', resumeId: _resumeId ?? 'resume-new' }))
+  const list = vi.fn((_filters: unknown) => [] as HeadlessTaskRecord[])
+  const svc = {
+    registry: { get: (id: string) => id === 'ws-1' ? { id, tag: 'Research', dir: '/tmp/ws-1', agents: ['pi'] } : undefined },
+    resumeRegistry: {
+      get: (id: string) => id === 'resume-author' || id === 'resume-owner' || id === 'resume-run'
+        ? { resumeId: id, wsId: 'ws-1', agent: 'pi', agentSessionId: `native-${id}` }
+        : null,
+    },
+    provenanceStore: { latest: vi.fn(), append: vi.fn() },
+    sessionRegistry: { get: vi.fn() },
+    adapters: {
+      get: (id: string) => id === 'pi'
+        ? { id: 'pi', displayName: 'Pi', capabilities: { headless: true }, composeHeadlessCommand: vi.fn() }
+        : undefined,
+    },
+    config: { launcherRepoRoot: '/tmp/repo' },
+    resolveDefaultAgentId: vi.fn(async () => 'pi'),
+    dispatchHeadlessTask,
+    headlessTasks: { list, get: vi.fn() },
+    headlessLogsDir: '/tmp/missing-inquiry-logs',
+    issueDetail: vi.fn(async () => ({
+      issue: {
+        id: 'issue-1', title: 'Issue', body: '', status: 'todo', priority: 'none', assignee: 'ws:Research',
+        execution: opts.execution ?? { mode: 'fresh' },
+      },
+      runs: [{ taskId: 'run-old', resumeId: 'resume-run', wsId: 'ws-1', agent: 'pi', status: 'done', startedAt: 1, resumable: true }],
+      inboxReports: [], provenance: [],
+    })),
+  } as unknown as WorkspaceService
+  return { app: createInquiryRoutes({ service: svc, inboxStore }), inboxStore, dispatchHeadlessTask, list }
+}
+
+async function json(response: Response) {
+  return await response.json() as any
+}
+
+describe('business inquiry routes', () => {
+  it('asks an Inbox sender by exact resumeId and persists its business subject', async () => {
+    const { app, inboxStore, dispatchHeadlessTask } = build()
+    const entry = await inboxStore.append({
+      workspaceId: 'ws-1', comments: 'report',
+      origin: { kind: 'headless', runId: 'run-source', resumeId: 'resume-author', agent: 'pi' },
+    })
+    const response = await app.request(`/inbox/${entry.id}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ prompt: 'Why?' }),
+    })
+    expect(response.status).toBe(202)
+    expect((await json(response)).resolution.mode).toBe('exact')
+    expect(dispatchHeadlessTask).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), 'Why?', 300_000, undefined, 'resume-author',
+      expect.objectContaining({
+        subject: { kind: 'inbox', entryId: entry.id },
+        question: 'Why?',
+        resolution: { mode: 'exact' },
+      }),
+    )
+  })
+
+  it('reconstructs an unattributed Inbox entry without impersonating a sender', async () => {
+    const { app, inboxStore, dispatchHeadlessTask } = build()
+    const entry = await inboxStore.append({ workspaceId: 'ws-1', comments: 'manual note' })
+    const response = await app.request(`/inbox/${entry.id}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ prompt: 'Recover context' }),
+    })
+    expect(response.status).toBe(202)
+    expect((await json(response)).resolution.mode).toBe('reconstructed')
+    expect(dispatchHeadlessTask.mock.calls[0]?.[5]).toBeUndefined()
+    expect(dispatchHeadlessTask.mock.calls[0]?.[6]?.resolution).toMatchObject({ mode: 'reconstructed' })
+  })
+
+  it('rejects Ask owner for a fresh-execution Issue', async () => {
+    const { app } = build({ execution: { mode: 'fresh' } })
+    const response = await app.request('/issues/ws-1/issue-1', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Status?', relation: 'owner' }),
+    })
+    expect(response.status).toBe(409)
+    expect((await json(response)).error).toBe('no_stable_owner')
+  })
+
+  it('asks the fixed Issue owner and one selected run by their resumeIds', async () => {
+    const { app, dispatchHeadlessTask } = build({ execution: { mode: 'resume', resumeId: 'resume-owner' } })
+    const owner = await app.request('/issues/ws-1/issue-1', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Owner?', relation: 'owner' }),
+    })
+    expect(owner.status).toBe(202)
+    const run = await app.request('/issues/ws-1/issue-1', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Run?', relation: 'run', runId: 'run-old' }),
+    })
+    expect(run.status).toBe(202)
+    expect(dispatchHeadlessTask.mock.calls[0]?.[5]).toBe('resume-owner')
+    expect(dispatchHeadlessTask.mock.calls[0]?.[6]?.subject).toMatchObject({ relation: 'owner' })
+    expect(dispatchHeadlessTask.mock.calls[1]?.[5]).toBe('resume-run')
+    expect(dispatchHeadlessTask.mock.calls[1]?.[6]?.subject).toMatchObject({ relation: 'run', runId: 'run-old' })
+  })
+
+  it('lists inquiry history by business object', async () => {
+    const { app, list } = build()
+    expect((await app.request('/inbox/entry-1')).status).toBe(200)
+    expect(list).toHaveBeenCalledWith({ inquiry: { kind: 'inbox', entryId: 'entry-1' }, limit: 50 })
+    expect((await app.request('/issues/ws-1/issue-1')).status).toBe(200)
+    expect(list).toHaveBeenCalledWith({
+      inquiry: { kind: 'issue', workspaceId: 'ws-1', issueId: 'issue-1' },
+      limit: 50,
+    })
+  })
+})

--- a/src/webui/routes/inquiries.ts
+++ b/src/webui/routes/inquiries.ts
@@ -1,0 +1,179 @@
+/**
+ * Business-object follow-ups for the human UI.
+ *
+ * The UI never constructs native runtime/session identifiers. It names an
+ * Inbox entry or Issue relation, this route resolves the same provenance used
+ * by the embedded CLI, and dispatches asynchronously through the shared
+ * WorkspaceConversationControl. HeadlessTaskRegistry keeps the reverse link so
+ * answers survive navigation, refresh, and process restart.
+ */
+import { Hono } from 'hono'
+
+import type { IInboxStore } from '../../core/inbox-store.js'
+import { makeInboxEntryOriginResolver } from '../../core/workspace-tool-center.js'
+import { createWorkspaceConversationControl } from '../../workspaces/conversation-control.js'
+import type { HeadlessInquiryScope, HeadlessInquirySubject, HeadlessTaskRecord } from '../../workspaces/headless-task-registry.js'
+import { HeadlessCapacityError, HeadlessResumeError, type WorkspaceService } from '../../workspaces/service.js'
+
+const DEFAULT_TIMEOUT_MS = 300_000
+const MAX_PROMPT_CHARS = 16_000
+const LIST_LIMIT = 50
+
+export interface InquiryRoutesDeps {
+  service: WorkspaceService
+  inboxStore: IInboxStore
+}
+
+function validId(id: string | undefined): id is string {
+  return typeof id === 'string' && /^[a-zA-Z0-9_-]+$/.test(id)
+}
+
+async function promptFromRequest(c: import('hono').Context): Promise<string | null> {
+  try {
+    const body = await c.req.json() as { prompt?: unknown }
+    if (typeof body.prompt !== 'string') return null
+    const prompt = body.prompt.trim()
+    return prompt.length > 0 && prompt.length <= MAX_PROMPT_CHARS ? prompt : null
+  } catch {
+    return null
+  }
+}
+
+function errorResponse(c: import('hono').Context, err: unknown) {
+  if (err instanceof HeadlessCapacityError) {
+    return c.json({ error: 'capacity', message: err.message }, 429)
+  }
+  if (err instanceof HeadlessResumeError) {
+    return c.json({ error: err.code, message: err.message }, 409)
+  }
+  return c.json({ error: 'dispatch_failed', message: err instanceof Error ? err.message : String(err) }, 500)
+}
+
+async function inquiryProjection(
+  conversation: ReturnType<typeof createWorkspaceConversationControl>,
+  task: HeadlessTaskRecord,
+) {
+  const current = await conversation.read(task.taskId)
+  return {
+    taskId: task.taskId,
+    resumeId: task.resumeId,
+    workspaceId: task.wsId,
+    agent: task.agent,
+    status: task.status,
+    startedAt: task.startedAt,
+    ...(task.finishedAt !== undefined ? { finishedAt: task.finishedAt } : {}),
+    ...(task.durationMs !== undefined ? { durationMs: task.durationMs } : {}),
+    ...(task.error ? { error: task.error } : {}),
+    inquiry: task.inquiry!,
+    assistantText: current?.structured?.assistantText ?? null,
+  }
+}
+
+export function createInquiryRoutes(deps: InquiryRoutesDeps): Hono {
+  const app = new Hono()
+  const conversation = createWorkspaceConversationControl(deps.service)
+  const resolveInboxOrigin = makeInboxEntryOriginResolver(() => deps.service)
+
+  const list = async (subject: HeadlessInquiryScope) => Promise.all(
+    deps.service.headlessTasks
+      .list({ inquiry: subject, limit: LIST_LIMIT })
+      .filter((task) => task.inquiry)
+      .map((task) => inquiryProjection(conversation, task)),
+  )
+
+  app.get('/inbox/:id', async (c) => {
+    const id = c.req.param('id')
+    return c.json({ inquiries: await list({ kind: 'inbox', entryId: id }) })
+  })
+
+  app.post('/inbox/:id', async (c) => {
+    const id = c.req.param('id')
+    const prompt = await promptFromRequest(c)
+    if (!prompt) return c.json({ error: 'invalid_prompt', message: 'prompt must be 1-16000 characters' }, 400)
+    const entry = await deps.inboxStore.get(id)
+    if (!entry) return c.json({ error: 'not_found' }, 404)
+    const origin = resolveInboxOrigin(entry)
+    const target = origin?.resumeId
+      ? { kind: 'resume' as const, resumeId: origin.resumeId }
+      : { kind: 'inbox' as const, inboxEntryId: entry.id, workspaceId: entry.workspaceId }
+    try {
+      const result = await conversation.ask({
+        prompt,
+        target,
+        timeoutMs: DEFAULT_TIMEOUT_MS,
+        subject: { kind: 'inbox', entryId: entry.id },
+      })
+      if (result.status === 'unavailable') {
+        return c.json({ error: 'unavailable', resolution: result.resolution }, 409)
+      }
+      return c.json(result, 202)
+    } catch (err) {
+      return errorResponse(c, err)
+    }
+  })
+
+  app.get('/issues/:wsId/:id', async (c) => {
+    const wsId = c.req.param('wsId')
+    const id = c.req.param('id')
+    return c.json({
+      inquiries: await list({ kind: 'issue', workspaceId: wsId, issueId: id }),
+    })
+  })
+
+  app.post('/issues/:wsId/:id', async (c) => {
+    const wsId = c.req.param('wsId')
+    const id = c.req.param('id')
+    if (!validId(wsId) || !validId(id)) return c.json({ error: 'not_found' }, 404)
+    let body: { prompt?: unknown; relation?: unknown; runId?: unknown }
+    try {
+      body = await c.req.json() as typeof body
+    } catch {
+      return c.json({ error: 'invalid_json' }, 400)
+    }
+    const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
+    if (!prompt || prompt.length > MAX_PROMPT_CHARS) {
+      return c.json({ error: 'invalid_prompt', message: 'prompt must be 1-16000 characters' }, 400)
+    }
+    const relation = body.relation
+    if (!['creator', 'owner', 'run'].includes(String(relation))) {
+      return c.json({ error: 'invalid_relation', message: 'relation must be creator, owner, or run' }, 400)
+    }
+    const detail = await deps.service.issueDetail(wsId, id)
+    if (!detail) return c.json({ error: 'not_found' }, 404)
+
+    let target
+    let runId: string | undefined
+    if (relation === 'owner') {
+      if (detail.issue.execution.mode !== 'resume') {
+        return c.json({ error: 'no_stable_owner', message: 'this Issue recruits a new Session for every run' }, 409)
+      }
+      target = { kind: 'resume' as const, resumeId: detail.issue.execution.resumeId }
+    } else if (relation === 'run') {
+      runId = typeof body.runId === 'string' ? body.runId : undefined
+      const run = runId ? detail.runs.find((candidate) => candidate.taskId === runId) : undefined
+      if (!run) return c.json({ error: 'run_not_found' }, 404)
+      target = { kind: 'resume' as const, resumeId: run.resumeId }
+    } else {
+      target = { kind: 'issue' as const, workspaceId: wsId, issueId: id, action: 'created' as const }
+    }
+
+    const subject: HeadlessInquirySubject = {
+      kind: 'issue',
+      workspaceId: wsId,
+      issueId: id,
+      relation: relation as 'creator' | 'owner' | 'run',
+      ...(runId ? { runId } : {}),
+    }
+    try {
+      const result = await conversation.ask({ prompt, target, timeoutMs: DEFAULT_TIMEOUT_MS, subject })
+      if (result.status === 'unavailable') {
+        return c.json({ error: 'unavailable', resolution: result.resolution }, 409)
+      }
+      return c.json(result, 202)
+    } catch (err) {
+      return errorResponse(c, err)
+    }
+  })
+
+  return app
+}

--- a/src/workspaces/conversation-control.ts
+++ b/src/workspaces/conversation-control.ts
@@ -231,14 +231,23 @@ export function createWorkspaceConversationControl(
       const prompt = resolution.mode === 'exact'
         ? input.prompt
         : reconstructionPrompt(input.target, input.prompt, Boolean(continuingOrigin))
-      const dispatched = await svc.dispatchHeadlessTask(
-        meta,
-        adapter,
-        prompt,
-        input.timeoutMs,
-        undefined,
-        continuingOrigin?.resumeId,
-      )
+      const inquiry = input.subject
+        ? {
+            subject: input.subject,
+            question: input.prompt,
+            resolution: {
+              mode: resolution.mode,
+              ...(resolution.mode === 'reconstructed' ? { reason: resolution.reason } : {}),
+            },
+          }
+        : undefined
+      const dispatched = inquiry
+        ? await svc.dispatchHeadlessTask(
+            meta, adapter, prompt, input.timeoutMs, undefined, continuingOrigin?.resumeId, inquiry,
+          )
+        : await svc.dispatchHeadlessTask(
+            meta, adapter, prompt, input.timeoutMs, undefined, continuingOrigin?.resumeId,
+          )
       let effectiveResolution = resolution
       if (resolution.mode === 'reconstructed' && resolution.artifact && !resolution.origin) {
         const origin: SessionOrigin = {

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -85,6 +85,41 @@ describe('HeadlessTaskRegistry', () => {
     expect(reg2.get(fired.taskId)?.issueId).toBe('daily-scan')
   })
 
+  it('persists and reverse-filters business inquiry subjects', async () => {
+    const reg = await HeadlessTaskRegistry.load(path, noopLogger)
+    const inbox = await createTask(reg, {
+      wsId: 'w1', agent: 'pi', prompt: 'why?', startedAt: 1,
+      inquiry: {
+        subject: { kind: 'inbox', entryId: 'entry-1' },
+        question: 'why?',
+        resolution: { mode: 'exact' },
+      },
+    })
+    const owner = await createTask(reg, {
+      wsId: 'w1', agent: 'codex', prompt: 'status?', startedAt: 2,
+      inquiry: {
+        subject: { kind: 'issue', workspaceId: 'w1', issueId: 'issue-1', relation: 'owner' },
+        question: 'status?',
+        resolution: { mode: 'exact' },
+      },
+    })
+    const run = await createTask(reg, {
+      wsId: 'w1', agent: 'codex', prompt: 'what happened?', startedAt: 3,
+      inquiry: {
+        subject: { kind: 'issue', workspaceId: 'w1', issueId: 'issue-1', relation: 'run', runId: 'run-old' },
+        question: 'what happened?',
+        resolution: { mode: 'reconstructed', reason: 'missing-origin' },
+      },
+    })
+
+    expect(reg.list({ inquiry: { kind: 'inbox', entryId: 'entry-1' } }).map((task) => task.taskId))
+      .toEqual([inbox.taskId])
+    expect(reg.list({ inquiry: { kind: 'issue', workspaceId: 'w1', issueId: 'issue-1' } }).map((task) => task.taskId))
+      .toEqual([run.taskId, owner.taskId])
+    const reloaded = await HeadlessTaskRegistry.load(path, noopLogger)
+    expect(reloaded.get(owner.taskId)?.inquiry?.subject).toMatchObject({ relation: 'owner' })
+  })
+
   it('list filters by issueId (the issue detail Activity feed join)', async () => {
     const reg = await HeadlessTaskRegistry.load(path, noopLogger)
     const a = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'x', startedAt: 1, issueId: 'iss-a' })

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -35,6 +35,33 @@ export interface HeadlessTaskOutputSummary {
   readonly toolFailures: number
 }
 
+/** Business object that requested a headless follow-up. Product provenance
+ * only: adapter-native session ids never cross into this record. */
+export type HeadlessInquirySubject =
+  | { readonly kind: 'inbox'; readonly entryId: string }
+  | {
+      readonly kind: 'issue'
+      readonly workspaceId: string
+      readonly issueId: string
+      readonly relation: 'creator' | 'owner' | 'run'
+      readonly runId?: string
+    }
+
+/** Reverse-index scope used to load every inquiry attached to one object. */
+export type HeadlessInquiryScope =
+  | { readonly kind: 'inbox'; readonly entryId: string }
+  | { readonly kind: 'issue'; readonly workspaceId: string; readonly issueId: string }
+
+export interface HeadlessTaskInquiry {
+  readonly subject: HeadlessInquirySubject
+  /** Original user-facing question, before reconstruction instructions wrap it. */
+  readonly question: string
+  readonly resolution: {
+    readonly mode: 'exact' | 'reconstructed'
+    readonly reason?: string
+  }
+}
+
 export interface HeadlessTaskRecord {
   readonly taskId: string
   /**
@@ -54,6 +81,8 @@ export interface HeadlessTaskRecord {
    * issue. This is the run↔issue link the issue detail's Activity feed joins on.
    */
   readonly issueId?: string
+  /** Durable reverse link for Inbox/Issue follow-up UI. */
+  readonly inquiry?: HeadlessTaskInquiry
   readonly agent: string
   /** The task prompt (the run's instruction) — shown collapsible in the panel. */
   readonly prompt: string
@@ -144,6 +173,8 @@ export class HeadlessTaskRegistry {
     parentTaskId?: string
     /** Set only when an issue fired this run (scheduled scan); omitted for manual/external runs. */
     issueId?: string
+    /** Business follow-up metadata; omitted for automation/manual runs. */
+    inquiry?: HeadlessTaskInquiry
   }): Promise<HeadlessTaskRecord> {
     let taskId = randomTaskId()
     while (this.tasks.some((task) => task.taskId === taskId)) taskId = randomTaskId()
@@ -158,6 +189,7 @@ export class HeadlessTaskRegistry {
       startedAt: input.startedAt,
       // Keep the field absent (not `undefined`) on manual runs so the JSON stays clean.
       ...(input.issueId ? { issueId: input.issueId } : {}),
+      ...(input.inquiry ? { inquiry: input.inquiry } : {}),
     }
     this.tasks.push(rec)
     await this.flush()
@@ -206,6 +238,7 @@ export class HeadlessTaskRegistry {
       wsId?: string
       issueId?: string
       status?: HeadlessTaskStatus
+      inquiry?: HeadlessInquiryScope
       /** Return records older than this task in the filtered newest-first view. */
       cursor?: string
       limit?: number
@@ -215,6 +248,7 @@ export class HeadlessTaskRegistry {
       (t) =>
         (!opts.wsId || t.wsId === opts.wsId) &&
         (!opts.issueId || t.issueId === opts.issueId) &&
+        (!opts.inquiry || inquirySubjectMatches(t.inquiry?.subject, opts.inquiry)) &&
         (!opts.status || t.status === opts.status),
     )
     out = out.slice().reverse() // newest-first
@@ -228,11 +262,12 @@ export class HeadlessTaskRegistry {
   }
 
   /** Count filtered records without materializing them over the HTTP boundary. */
-  count(opts: { wsId?: string; issueId?: string; status?: HeadlessTaskStatus } = {}): number {
+  count(opts: { wsId?: string; issueId?: string; status?: HeadlessTaskStatus; inquiry?: HeadlessInquiryScope } = {}): number {
     return this.tasks.reduce(
       (count, task) => count + (
         (!opts.wsId || task.wsId === opts.wsId) &&
         (!opts.issueId || task.issueId === opts.issueId) &&
+        (!opts.inquiry || inquirySubjectMatches(task.inquiry?.subject, opts.inquiry)) &&
         (!opts.status || task.status === opts.status)
           ? 1
           : 0
@@ -261,4 +296,18 @@ export class HeadlessTaskRegistry {
       this.logger.warn('headless_registry.flush_failed', { err })
     }
   }
+}
+
+function inquirySubjectMatches(
+  actual: HeadlessInquirySubject | undefined,
+  expected: HeadlessInquiryScope,
+): boolean {
+  if (!actual || actual.kind !== expected.kind) return false
+  if (actual.kind === 'inbox' && expected.kind === 'inbox') {
+    return actual.entryId === expected.entryId
+  }
+  if (actual.kind === 'issue' && expected.kind === 'issue') {
+    return actual.workspaceId === expected.workspaceId && actual.issueId === expected.issueId
+  }
+  return false
 }

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -78,6 +78,7 @@ import { toSafeInboxOrigin } from '@/core/workspace-tool-center.js';
 import {
   HeadlessTaskRegistry,
   headlessLogPaths,
+  type HeadlessTaskInquiry,
   type HeadlessTaskRecord,
 } from './headless-task-registry.js';
 import { ResumeRegistry } from './resume-registry.js';
@@ -236,6 +237,8 @@ export interface WorkspaceService {
     /** Continue this OpenAlice-owned conversation. Native runtime ids are
      * resolved only inside the service. */
     resumeId?: string,
+    /** Optional Inbox/Issue reverse link for a user-initiated inquiry. */
+    inquiry?: HeadlessTaskInquiry,
   ): Promise<{ taskId: string; resumeId: string }>;
   /** Read-only scheduling projection of every workspace's `.alice/issues/`
    *  directory (scheduled issues only) + each task's last-fired marker and
@@ -969,6 +972,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     // Manual/external runs (the workspace "run task" route) leave it undefined.
     issueId?: string,
     resumeId?: string,
+    inquiry?: HeadlessTaskInquiry,
   ): Promise<{ taskId: string; resumeId: string }> => {
     if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
       throw new Error(`adapter "${adapter.id}" has no headless mode`);
@@ -1026,6 +1030,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         resumeId: identity.resumeId,
         ...(parentTaskId ? { parentTaskId } : {}),
         ...(issueId ? { issueId } : {}),
+        ...(inquiry ? { inquiry } : {}),
       });
       await resumeRegistry.ensure({
         resumeId: identity.resumeId,

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -17,6 +17,7 @@ import { entitiesApi } from './entities'
 import { versionApi } from './version'
 import { headlessApi } from './headless'
 import { preferencesApi } from './preferences'
+import { inquiriesApi } from './inquiries'
 export const api = {
   config: configApi,
   schedule: scheduleApi,
@@ -33,6 +34,7 @@ export const api = {
   version: versionApi,
   headless: headlessApi,
   preferences: preferencesApi,
+  inquiries: inquiriesApi,
 }
 
 // Re-export all types for convenience

--- a/ui/src/api/inquiries.ts
+++ b/ui/src/api/inquiries.ts
@@ -1,0 +1,71 @@
+import { fetchJson, headers } from './client'
+import type { HeadlessTaskStatus } from './headless'
+
+export type InquirySubject =
+  | { kind: 'inbox'; entryId: string }
+  | {
+      kind: 'issue'
+      workspaceId: string
+      issueId: string
+      relation: 'creator' | 'owner' | 'run'
+      runId?: string
+    }
+
+export interface InquiryRecord {
+  taskId: string
+  resumeId: string
+  workspaceId: string
+  agent: string
+  status: HeadlessTaskStatus
+  startedAt: number
+  finishedAt?: number
+  durationMs?: number
+  error?: string
+  assistantText: string | null
+  inquiry: {
+    subject: InquirySubject
+    question: string
+    resolution: { mode: 'exact' | 'reconstructed'; reason?: string }
+  }
+}
+
+export interface InquiryDispatch {
+  status: 'dispatched'
+  taskId: string
+  resumeId: string
+  workspaceId: string
+  workspace: string
+  agent: string
+  resolution: { mode: 'exact' | 'reconstructed'; reason?: string }
+}
+
+export const inquiriesApi = {
+  async forInbox(entryId: string): Promise<InquiryRecord[]> {
+    return (await fetchJson<{ inquiries: InquiryRecord[] }>(
+      `/api/inquiries/inbox/${encodeURIComponent(entryId)}`,
+    )).inquiries
+  },
+
+  async askInbox(entryId: string, prompt: string): Promise<InquiryDispatch> {
+    return fetchJson(`/api/inquiries/inbox/${encodeURIComponent(entryId)}`, {
+      method: 'POST', headers, body: JSON.stringify({ prompt }),
+    })
+  },
+
+  async forIssue(workspaceId: string, issueId: string): Promise<InquiryRecord[]> {
+    return (await fetchJson<{ inquiries: InquiryRecord[] }>(
+      `/api/inquiries/issues/${encodeURIComponent(workspaceId)}/${encodeURIComponent(issueId)}`,
+    )).inquiries
+  },
+
+  async askIssue(
+    workspaceId: string,
+    issueId: string,
+    input: { prompt: string; relation: 'creator' | 'owner' | 'run'; runId?: string },
+  ): Promise<InquiryDispatch> {
+    return fetchJson(
+      `/api/inquiries/issues/${encodeURIComponent(workspaceId)}/${encodeURIComponent(issueId)}`,
+      { method: 'POST', headers, body: JSON.stringify(input) },
+    )
+  },
+}

--- a/ui/src/components/InquiryPanel.tsx
+++ b/ui/src/components/InquiryPanel.tsx
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { Bot, LoaderCircle, MessageSquareText, Send } from 'lucide-react'
+
+import type { InquiryRecord } from '../api/inquiries'
+import { formatRelativeTime } from '../lib/intl'
+import { MarkdownContent } from './MarkdownContent'
+
+function relationLabel(record: InquiryRecord): string {
+  const subject = record.inquiry.subject
+  if (record.inquiry.resolution.mode === 'reconstructed') return 'workspace'
+  if (subject.kind === 'inbox') {
+    return 'sender'
+  }
+  if (subject.relation === 'creator') return 'creator'
+  if (subject.relation === 'owner') return 'owner'
+  return 'run'
+}
+
+function InquiryCard({ record }: { record: InquiryRecord }) {
+  const running = record.status === 'running'
+  const failed = record.status === 'failed' || record.status === 'interrupted'
+  return (
+    <article className="rounded-lg border border-border bg-bg-secondary px-3 py-3">
+      <div className="flex items-center gap-2 text-[11px] text-muted">
+        {running
+          ? <LoaderCircle size={13} className="animate-spin text-accent" aria-hidden />
+          : <Bot size={13} className={failed ? 'text-red-400' : 'text-emerald-400'} aria-hidden />}
+        <span className="font-medium text-text/80">{record.agent} · {relationLabel(record)}</span>
+        <span className={`rounded-full px-1.5 py-0.5 ${
+          record.inquiry.resolution.mode === 'reconstructed'
+            ? 'bg-amber-500/10 text-amber-400'
+            : 'bg-bg-tertiary text-muted'
+        }`}>
+          {record.inquiry.resolution.mode}
+        </span>
+        <span className="ml-auto" title={new Date(record.startedAt).toLocaleString()}>
+          {formatRelativeTime(record.startedAt)}
+        </span>
+      </div>
+      <p className="mt-2 text-[12px] leading-relaxed text-muted">
+        <span className="text-text/70">You asked:</span> {record.inquiry.question}
+      </p>
+      {running ? (
+        <p className="mt-3 text-[12px] text-muted">Waiting for the agent’s final reply…</p>
+      ) : record.assistantText ? (
+        <div className="mt-3 max-h-[420px] overflow-y-auto border-t border-border/60 pt-3 text-[13px]">
+          <MarkdownContent text={record.assistantText} strikethrough={false} />
+        </div>
+      ) : (
+        <p className={`mt-3 text-[12px] ${failed ? 'text-red-400' : 'text-muted'}`}>
+          {record.error || 'The run finished without a final reply.'}
+        </p>
+      )}
+    </article>
+  )
+}
+
+export function InquiryPanel({
+  title,
+  description,
+  actionLabel,
+  placeholder,
+  controls,
+  load,
+  ask,
+}: {
+  title: string
+  description: string
+  actionLabel: string
+  placeholder: string
+  controls?: ReactNode
+  load: () => Promise<InquiryRecord[]>
+  ask: (prompt: string) => Promise<unknown>
+}) {
+  const [records, setRecords] = useState<InquiryRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [prompt, setPrompt] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await load()
+      setRecords(next)
+      setError(null)
+      return next
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      return []
+    } finally {
+      setLoading(false)
+    }
+  }, [load])
+
+  useEffect(() => {
+    let live = true
+    setLoading(true)
+    void load().then((next) => {
+      if (live) {
+        setRecords(next)
+        setError(null)
+      }
+    }).catch((err) => {
+      if (live) setError(err instanceof Error ? err.message : String(err))
+    }).finally(() => {
+      if (live) setLoading(false)
+    })
+    return () => { live = false }
+  }, [load])
+
+  useEffect(() => {
+    if (!records.some((record) => record.status === 'running')) return
+    const timer = window.setInterval(() => { void refresh() }, 1500)
+    return () => window.clearInterval(timer)
+  }, [records, refresh])
+
+  const submit = async () => {
+    const question = prompt.trim()
+    if (!question || sending) return
+    setSending(true)
+    setError(null)
+    try {
+      await ask(question)
+      setPrompt('')
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <section id="inquiries" className="mt-8 rounded-xl border border-border bg-bg-tertiary/20 p-4">
+      <div className="flex flex-wrap items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <h3 className="flex items-center gap-2 text-sm font-semibold text-text">
+            <MessageSquareText size={15} className="text-accent" aria-hidden />
+            {title}
+          </h3>
+          <p className="mt-1 text-[12px] leading-relaxed text-muted">{description}</p>
+        </div>
+        {controls}
+      </div>
+
+      <div className="mt-3 flex items-end gap-2">
+        <textarea
+          rows={2}
+          value={prompt}
+          disabled={sending}
+          placeholder={placeholder}
+          onChange={(event) => setPrompt(event.target.value)}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+              event.preventDefault()
+              void submit()
+            }
+          }}
+          className="min-h-[68px] min-w-0 flex-1 resize-y rounded-lg border border-border bg-bg px-3 py-2 text-[13px] text-text outline-none transition-colors focus:border-accent/60 disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={() => void submit()}
+          disabled={sending || prompt.trim().length === 0}
+          className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg bg-accent px-3 text-xs font-medium text-bg transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {sending ? <LoaderCircle size={13} className="animate-spin" /> : <Send size={13} />}
+          {sending ? 'Dispatching…' : actionLabel}
+        </button>
+      </div>
+      {error && <p className="mt-2 text-[12px] text-red-400">{error}</p>}
+
+      {loading && records.length === 0 ? (
+        <p className="mt-4 text-[12px] text-muted">Loading previous questions…</p>
+      ) : records.length > 0 ? (
+        <div className="mt-4 space-y-2">
+          {records.map((record) => <InquiryCard key={record.taskId} record={record} />)}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import { ArrowLeft, Hash, History, Inbox, ListChecks, Settings, TrendingUp, X } from 'lucide-react'
+import { ArrowLeft, Hash, History, Inbox, ListChecks, Settings, TrendingUp, UserRound, UsersRound, X } from 'lucide-react'
 
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
@@ -22,6 +22,7 @@ import {
   type WorkspaceSessionDirectoryEntry,
 } from './workspace/api'
 import { issuesApi } from '../api/issues'
+import { inquiriesApi } from '../api/inquiries'
 import { useIssueDetail } from '../hooks/useIssueDetail'
 import { useIssues } from '../hooks/useIssues'
 import { useWorkspaces } from '../contexts/workspaces-context'
@@ -35,6 +36,7 @@ import { CadencePill, PriorityIndicator } from './IssuesBoard'
 import { STATUS_META } from './issue-status-meta'
 import { MarkdownContent } from './MarkdownContent'
 import { CenteredLoading } from './StateViews'
+import { InquiryPanel } from './InquiryPanel'
 
 // Run-status pill tints — mirrors AutomationRunsSection's STATUS_STYLE so the
 // Activity feed reads the same as the headless-runs panel.
@@ -275,26 +277,81 @@ function ExecutionEditor({
   )
   const hasSelected = value?.mode !== 'resume' || choices.some((session) => session.resumeId === value.resumeId)
 
+  const mode = value?.mode ?? 'fresh'
   return (
-    <select
-      className={railControl}
-      value={selected}
-      disabled={disabled}
-      onChange={(event) => {
-        const resumeId = event.target.value
-        onChange(resumeId === '__fresh__' ? { mode: 'fresh' } : { mode: 'resume', resumeId })
-      }}
-    >
-      <option value="__fresh__">Fresh Session each fire</option>
-      {choices.map((session) => (
-        <option key={session.resumeId} value={session.resumeId}>
-          Continue {labelFor(session)} · {session.agent}
-        </option>
-      ))}
-      {!hasSelected && value?.mode === 'resume' && (
-        <option value={value.resumeId}>Unavailable owner · {value.resumeId}</option>
+    <div className="space-y-2">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => onChange({ mode: 'fresh' })}
+        className={`w-full rounded-lg border px-3 py-2 text-left transition-colors ${
+          mode === 'fresh' ? 'border-accent/60 bg-accent/10' : 'border-border bg-bg hover:border-accent/30'
+        } disabled:opacity-50`}
+      >
+        <span className="flex items-center gap-2 text-[12px] font-medium text-text">
+          <UsersRound size={14} aria-hidden /> New agent every run
+        </span>
+        <span className="mt-1 block text-[11px] leading-snug text-muted">
+          Each fire starts a separate Session. Ask a specific run when you need follow-up.
+        </span>
+      </button>
+      <button
+        type="button"
+        disabled={disabled || (choices.length === 0 && mode !== 'resume')}
+        onClick={() => {
+          if (mode !== 'resume' && choices[0]) onChange({ mode: 'resume', resumeId: choices[0].resumeId })
+        }}
+        className={`w-full rounded-lg border px-3 py-2 text-left transition-colors ${
+          mode === 'resume' ? 'border-accent/60 bg-accent/10' : 'border-border bg-bg hover:border-accent/30'
+        } disabled:cursor-not-allowed disabled:opacity-50`}
+      >
+        <span className="flex items-center gap-2 text-[12px] font-medium text-text">
+          <UserRound size={14} aria-hidden /> One responsible Session
+        </span>
+        <span className="mt-1 block text-[11px] leading-snug text-muted">
+          Every fire resumes the same accountable agent and conversational context.
+        </span>
+      </button>
+      {mode === 'resume' && (
+        <select
+          className={`${railControl} w-full`}
+          value={selected}
+          disabled={disabled}
+          aria-label="Responsible Session"
+          onChange={(event) => onChange({ mode: 'resume', resumeId: event.target.value })}
+        >
+          {choices.map((session) => (
+            <option key={session.resumeId} value={session.resumeId}>
+              {labelFor(session)} · {session.agent}
+            </option>
+          ))}
+          {!hasSelected && value?.mode === 'resume' && (
+            <option value={value.resumeId}>Unavailable owner · {value.resumeId}</option>
+          )}
+        </select>
       )}
-    </select>
+      {choices.length === 0 && mode !== 'resume' && (
+        <p className="text-[11px] leading-snug text-muted">No resumable Session is available in this Workspace yet.</p>
+      )}
+    </div>
+  )
+}
+
+function PropertySection({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description?: string
+  children: ReactNode
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-bg p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted/70">{title}</h3>
+      {description && <p className="mt-1 text-[11px] leading-snug text-muted">{description}</p>}
+      <div className="mt-2 divide-y divide-border/60">{children}</div>
+    </section>
   )
 }
 
@@ -334,9 +391,8 @@ function PropertiesRail({
   const selectedReadiness = effectiveAgent ? agentReadiness[effectiveAgent] : undefined
   const agentNeedsCredential = selectedReadiness?.requiresCredential === true && !selectedReadiness.ready
   return (
-    <aside className="w-full shrink-0 space-y-1 rounded-lg border border-border bg-bg-secondary p-4 lg:w-64">
-      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted/70">Properties</h3>
-      <div className="divide-y divide-border/60">
+    <aside className="w-full shrink-0 space-y-3 lg:w-72">
+      <PropertySection title="Work item" description="Human tracking fields. These do not decide which agent runs the schedule.">
         <EditRow label="Status">
           <meta.Icon size={14} className={`shrink-0 ${meta.className}`} />
           <select
@@ -375,63 +431,53 @@ function PropertiesRail({
             onChange={(assignee) => onPatch({ assignee })}
           />
         </EditRow>
-        <PropRow label="Cadence">
-          {issue.when ? <CadencePill when={issue.when} /> : <span className="text-muted">—</span>}
-        </PropRow>
-        {issue.when && (
-          <EditRow label="Ownership">
+      </PropertySection>
+
+      {issue.when && (
+        <PropertySection
+          title="Scheduled execution"
+          description="Choose whether each fire recruits a new worker or keeps one accountable Session."
+        >
+          <PropRow label="Cadence"><CadencePill when={issue.when} /></PropRow>
+          <div className="py-3">
             <ExecutionEditor
               value={issue.execution}
               sessions={sessions}
               disabled={saving}
               onChange={(execution) => onPatch({ execution })}
             />
-          </EditRow>
-        )}
-        {issue.execution?.mode === 'resume' ? (
-          <PropRow label="Agent">
-            <span title="The responsible Session determines its runtime">
-              {ownerSession?.agent ?? 'Session-owned'}
-            </span>
+          </div>
+          {issue.execution?.mode === 'resume' ? (
+            <PropRow label="Runtime">
+              <span title="The responsible Session determines its runtime">
+                {ownerSession?.agent ?? 'Session-owned'}
+              </span>
+            </PropRow>
+          ) : (
+            <EditRow label="Runtime">
+              <AgentEditor
+                value={issue.agent}
+                issueDefaultAgent={issueDefaultAgent}
+                defaultAgent={defaultAgent}
+                options={agentOptions}
+                readiness={agentReadiness}
+                disabled={saving}
+                onChange={(agent) => onPatch({ agent })}
+                onConfigure={onConfigureAgent}
+              />
+            </EditRow>
+          )}
+          {agentNeedsCredential && (
+            <p className="py-2 text-right text-[11px] leading-snug text-amber-400">AI credential missing.</p>
+          )}
+          <PropRow label="Last run">
+            {issue.lastFiredAtMs ? formatRelativeTime(issue.lastFiredAtMs) : <span className="text-muted">never</span>}
           </PropRow>
-        ) : (
-          <EditRow label="Agent">
-            <AgentEditor
-              value={issue.agent}
-              issueDefaultAgent={issueDefaultAgent}
-              defaultAgent={defaultAgent}
-              options={agentOptions}
-              readiness={agentReadiness}
-              disabled={saving}
-              onChange={(agent) => onPatch({ agent })}
-              onConfigure={onConfigureAgent}
-            />
-          </EditRow>
-        )}
-        {agentNeedsCredential && (
-          <p className="-mt-1 pb-2 text-right text-[11px] leading-snug text-amber-400">
-            AI credential missing.
-          </p>
-        )}
-        {issue.when && (
-          <>
-            <PropRow label="Last fired">
-              {issue.lastFiredAtMs ? (
-                formatRelativeTime(issue.lastFiredAtMs)
-              ) : (
-                <span className="text-muted">never</span>
-              )}
-            </PropRow>
-            <PropRow label="Next due">
-              {issue.nextDueAtMs ? (
-                formatRelativeTime(issue.nextDueAtMs)
-              ) : (
-                <span className="text-muted">—</span>
-              )}
-            </PropRow>
-          </>
-        )}
-      </div>
+          <PropRow label="Next run">
+            {issue.nextDueAtMs ? formatRelativeTime(issue.nextDueAtMs) : <span className="text-muted">—</span>}
+          </PropRow>
+        </PropertySection>
+      )}
       {error && <p className="mt-2 text-[11px] leading-snug text-red-400">{error}</p>}
     </aside>
   )
@@ -508,7 +554,7 @@ function CommentComposer({
 
 // ==================== Activity feed (headless runs) ====================
 
-function RunRow({ run }: { run: HeadlessTaskRecord }) {
+function RunRow({ run, onAsk }: { run: HeadlessTaskRecord; onAsk: (run: HeadlessTaskRecord) => void }) {
   return (
     <li className="rounded-lg border border-border bg-bg-secondary px-3 py-2.5">
       <div className="flex items-center gap-2">
@@ -522,6 +568,15 @@ function RunRow({ run }: { run: HeadlessTaskRecord }) {
           {formatRelativeTime(run.startedAt)}
         </span>
         <span className="text-xs text-muted/70">· {fmtDuration(run.durationMs)}</span>
+        <button
+          type="button"
+          onClick={() => onAsk(run)}
+          disabled={!run.resumable || run.status === 'running'}
+          title={run.resumable ? 'Ask the Session behind this run' : 'This run did not capture a resumable Session'}
+          className="rounded-md border border-border px-2 py-1 text-[11px] text-muted transition-colors hover:border-accent/50 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Ask run
+        </button>
       </div>
       {run.prompt && (
         <p className="mt-1.5 line-clamp-2 text-[12px] leading-snug text-text/80" title={run.prompt}>
@@ -533,7 +588,7 @@ function RunRow({ run }: { run: HeadlessTaskRecord }) {
   )
 }
 
-function ActivityFeed({ runs }: { runs: HeadlessTaskRecord[] }) {
+function ActivityFeed({ runs, onAskRun }: { runs: HeadlessTaskRecord[]; onAskRun: (run: HeadlessTaskRecord) => void }) {
   return (
     <section className="mt-8">
       <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted/70">Activity</h3>
@@ -544,7 +599,7 @@ function ActivityFeed({ runs }: { runs: HeadlessTaskRecord[] }) {
       ) : (
         <ul className="space-y-2">
           {runs.map((run) => (
-            <RunRow key={run.taskId} run={run} />
+            <RunRow key={run.taskId} run={run} onAsk={onAskRun} />
           ))}
         </ul>
       )}
@@ -796,6 +851,11 @@ interface IssueDetailProps {
   onOpenIssue?: (ref: WikilinkIssueRef) => void
 }
 
+type IssueInquiryTarget =
+  | { relation: 'creator' }
+  | { relation: 'owner' }
+  | { relation: 'run'; runId: string }
+
 export function IssueDetail({
   wsId,
   id,
@@ -819,6 +879,7 @@ export function IssueDetail({
   const [actionError, setActionError] = useState<string | null>(null)
   const [agentReadiness, setAgentReadiness] = useState<Record<string, AgentCredentialReadiness>>({})
   const [sessionDirectory, setSessionDirectory] = useState<readonly WorkspaceSessionDirectoryEntry[]>([])
+  const [inquiryTarget, setInquiryTarget] = useState<IssueInquiryTarget>({ relation: 'creator' })
   // Set when a clicked `[[name]]` resolves to >1 target — drives the picker.
   const [picker, setPicker] = useState<WikilinkResolution | null>(null)
 
@@ -835,10 +896,14 @@ export function IssueDetail({
   }, [wsId])
 
   useEffect(() => {
+    setInquiryTarget({ relation: 'creator' })
+  }, [wsId, id])
+
+  useEffect(() => {
     let live = true
     getWorkspaceSessionDirectory(wsId)
       .then((directory) => {
-        if (live) setSessionDirectory(directory.sessions)
+        if (live) setSessionDirectory(Array.isArray(directory.sessions) ? directory.sessions : [])
       })
       .catch(() => {
         if (live) setSessionDirectory([])
@@ -937,6 +1002,20 @@ export function IssueDetail({
     [wsId, id, mutate],
   )
 
+  const loadInquiries = useCallback(
+    () => inquiriesApi.forIssue(wsId, id),
+    [wsId, id],
+  )
+
+  const askIssue = useCallback(
+    (prompt: string) => inquiriesApi.askIssue(wsId, id, {
+      prompt,
+      relation: inquiryTarget.relation,
+      ...(inquiryTarget.relation === 'run' ? { runId: inquiryTarget.runId } : {}),
+    }),
+    [wsId, id, inquiryTarget],
+  )
+
   const backToBoard = (
     <button
       type="button"
@@ -953,6 +1032,12 @@ export function IssueDetail({
       <ArrowLeft size={13} /> {backLabel}
     </button>
   )
+
+  useEffect(() => {
+    if (inquiryTarget.relation === 'owner' && data?.issue.execution?.mode !== 'resume') {
+      setInquiryTarget({ relation: 'creator' })
+    }
+  }, [data?.issue.execution, inquiryTarget.relation])
 
   if (!data) {
     return (
@@ -976,6 +1061,11 @@ export function IssueDetail({
   const { issue, runs } = data
   const inboxReports = data.inboxReports ?? []
   const provenance = data.provenance ?? []
+  const inquiryDescription = inquiryTarget.relation === 'owner'
+    ? 'Continue the one responsible Session declared by this Issue’s execution policy.'
+    : inquiryTarget.relation === 'run'
+      ? `Continue the exact Session behind run ${inquiryTarget.runId}.`
+      : 'Ask the attributable creator why this Issue exists. Legacy human-created Issues may require Workspace reconstruction.'
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-5 md:px-6">
@@ -994,9 +1084,48 @@ export function IssueDetail({
               <p className="text-sm text-muted">No description.</p>
             )}
           </div>
+          <InquiryPanel
+            title="Ask about this Issue"
+            description={inquiryDescription}
+            actionLabel={inquiryTarget.relation === 'owner' ? 'Ask owner' : inquiryTarget.relation === 'run' ? 'Ask run' : 'Ask creator'}
+            placeholder="What do you want to clarify?"
+            load={loadInquiries}
+            ask={askIssue}
+            controls={(
+              <div className="inline-flex rounded-lg border border-border bg-bg p-1 text-[11px]">
+                <button
+                  type="button"
+                  onClick={() => setInquiryTarget({ relation: 'creator' })}
+                  className={`rounded-md px-2 py-1 transition-colors ${inquiryTarget.relation === 'creator' ? 'bg-bg-tertiary text-text' : 'text-muted hover:text-text'}`}
+                >
+                  Creator
+                </button>
+                {issue.execution?.mode === 'resume' && (
+                  <button
+                    type="button"
+                    onClick={() => setInquiryTarget({ relation: 'owner' })}
+                    className={`rounded-md px-2 py-1 transition-colors ${inquiryTarget.relation === 'owner' ? 'bg-bg-tertiary text-text' : 'text-muted hover:text-text'}`}
+                  >
+                    Owner
+                  </button>
+                )}
+                {inquiryTarget.relation === 'run' && (
+                  <button type="button" className="rounded-md bg-bg-tertiary px-2 py-1 text-text">
+                    Run {inquiryTarget.runId}
+                  </button>
+                )}
+              </div>
+            )}
+          />
           <CommentComposer wsId={wsId} id={id} onPosted={mutate} />
           <ProvenanceTimeline records={provenance} onContinue={continueProvenanceSession} />
-          <ActivityFeed runs={runs} />
+          <ActivityFeed
+            runs={runs}
+            onAskRun={(run) => {
+              setInquiryTarget({ relation: 'run', runId: run.taskId })
+              window.requestAnimationFrame(() => document.getElementById('inquiries')?.scrollIntoView({ behavior: 'smooth', block: 'center' }))
+            }}
+          />
           <InboxReportsSection reports={inboxReports} onOpen={gotoInbox} />
         </main>
         <PropertiesRail

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -1,5 +1,5 @@
 import type { HeadlessTaskRecord } from '../../api/headless'
-import type { IssueDetail, IssuePriority, IssueSnapshot, IssueStatus } from '../../api/issues'
+import type { IssueDetail, IssueExecution, IssuePriority, IssueSnapshot, IssueStatus } from '../../api/issues'
 import { demoInboxEntries } from './inbox'
 
 // GET /api/issues aggregates every workspace's declared issues by SCANNING
@@ -42,6 +42,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           priority: 'high',
           assignee: 'ws:auto-quant',
           agent: 'codex',
+          execution: { mode: 'fresh' },
           when: { kind: 'cron', cron: '30 8 * * 1-5' },
           lastFiredAtMs: now - HOUR,
           nextDueAtMs: now + 16 * HOUR,
@@ -54,6 +55,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           priority: 'urgent',
           assignee: 'ws:auto-quant',
           agent: 'claude',
+          execution: { mode: 'resume', resumeId: 'demo-resume-thesis-owner' },
           when: { kind: 'every', every: '1h' },
           lastFiredAtMs: now - HOUR / 2,
           nextDueAtMs: now + HOUR / 2,
@@ -465,13 +467,14 @@ function appendCommentToBody(body: string, author: string, text: string): string
 export function demoIssueUpdate(
   wsId: string,
   id: string,
-  patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null },
+  patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution },
 ): IssueDetail | null {
   const boardIssue = findBoardIssue(wsId, id)
   if (!boardIssue) return null
   if (patch.status !== undefined) boardIssue.status = patch.status
   if (patch.priority !== undefined) boardIssue.priority = patch.priority
   if (patch.assignee !== undefined) boardIssue.assignee = patch.assignee
+  if (patch.execution !== undefined) boardIssue.execution = patch.execution
   if (patch.agent !== undefined) {
     if (patch.agent === null) delete boardIssue.agent
     else boardIssue.agent = patch.agent

--- a/ui/src/demo/handlers/index.ts
+++ b/ui/src/demo/handlers/index.ts
@@ -15,6 +15,7 @@ import { newsListHandlers } from './newsList'
 import { devMiscHandlers } from './devMisc'
 import { headlessHandlers } from './headless'
 import { preferencesHandlers } from './preferences'
+import { inquiryHandlers } from './inquiries'
 import { catchAllHandlers } from './catchAll'
 
 // Order matters: catchAll must be LAST. MSW resolves handlers in registration
@@ -38,5 +39,6 @@ export const handlers = [
   ...devMiscHandlers,
   ...headlessHandlers,
   ...preferencesHandlers,
+  ...inquiryHandlers,
   ...catchAllHandlers,
 ]

--- a/ui/src/demo/handlers/inquiries.ts
+++ b/ui/src/demo/handlers/inquiries.ts
@@ -1,0 +1,72 @@
+import { http, HttpResponse } from 'msw'
+
+import type { InquiryRecord, InquirySubject } from '../../api/inquiries'
+
+const records: InquiryRecord[] = []
+
+function list(subject: InquirySubject) {
+  return records.filter((record) => {
+    const candidate = record.inquiry.subject
+    if (subject.kind === 'inbox' && candidate.kind === 'inbox') return candidate.entryId === subject.entryId
+    if (subject.kind === 'issue' && candidate.kind === 'issue') {
+      return candidate.workspaceId === subject.workspaceId && candidate.issueId === subject.issueId
+    }
+    return false
+  })
+}
+
+function completed(subject: InquirySubject, question: string): InquiryRecord {
+  return {
+    taskId: `demo-inquiry-${records.length + 1}`,
+    resumeId: `demo-inquiry-resume-${records.length + 1}`,
+    workspaceId: subject.kind === 'issue' ? subject.workspaceId : 'demo-ws',
+    agent: 'pi',
+    status: 'done',
+    startedAt: Date.now(),
+    finishedAt: Date.now(),
+    durationMs: 1200,
+    assistantText: 'Demo reply: I checked the original Workspace context and answered from the available evidence.',
+    inquiry: {
+      subject,
+      question,
+      resolution: { mode: 'exact' },
+    },
+  }
+}
+
+export const inquiryHandlers = [
+  http.get('/api/inquiries/inbox/:id', ({ params }) =>
+    HttpResponse.json({ inquiries: list({ kind: 'inbox', entryId: String(params.id) }) }),
+  ),
+  http.post('/api/inquiries/inbox/:id', async ({ params, request }) => {
+    const body = await request.json() as { prompt?: string }
+    const record = completed({ kind: 'inbox', entryId: String(params.id) }, body.prompt ?? '')
+    records.unshift(record)
+    return HttpResponse.json({
+      status: 'dispatched', taskId: record.taskId, resumeId: record.resumeId,
+      workspaceId: record.workspaceId, workspace: 'demo', agent: record.agent,
+      resolution: record.inquiry.resolution,
+    }, { status: 202 })
+  }),
+  http.get('/api/inquiries/issues/:wsId/:id', ({ params }) =>
+    HttpResponse.json({
+      inquiries: list({
+        kind: 'issue', workspaceId: String(params.wsId), issueId: String(params.id), relation: 'creator',
+      }),
+    }),
+  ),
+  http.post('/api/inquiries/issues/:wsId/:id', async ({ params, request }) => {
+    const body = await request.json() as { prompt?: string; relation?: 'creator' | 'owner' | 'run'; runId?: string }
+    const subject: InquirySubject = {
+      kind: 'issue', workspaceId: String(params.wsId), issueId: String(params.id),
+      relation: body.relation ?? 'creator', ...(body.runId ? { runId: body.runId } : {}),
+    }
+    const record = completed(subject, body.prompt ?? '')
+    records.unshift(record)
+    return HttpResponse.json({
+      status: 'dispatched', taskId: record.taskId, resumeId: record.resumeId,
+      workspaceId: record.workspaceId, workspace: 'demo', agent: record.agent,
+      resolution: record.inquiry.resolution,
+    }, { status: 202 })
+  }),
+]

--- a/ui/src/demo/handlers/issues.ts
+++ b/ui/src/demo/handlers/issues.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw'
-import type { IssuePriority, IssueStatus } from '../../api/issues'
+import type { IssueExecution, IssuePriority, IssueStatus } from '../../api/issues'
 import {
   demoIssueAddComment,
   demoIssueDetail,
@@ -60,12 +60,13 @@ export const issuesHandlers = [
       priority?: unknown
       assignee?: unknown
       agent?: unknown
+      execution?: unknown
     } | null
     if (!body || typeof body !== 'object') {
       return HttpResponse.json({ error: 'invalid_body' }, { status: 400 })
     }
 
-    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null } = {}
+    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution } = {}
     if (body.status !== undefined) {
       if (!ISSUE_STATUSES.includes(body.status as IssueStatus)) {
         return HttpResponse.json({ error: 'invalid_status' }, { status: 400 })
@@ -97,11 +98,21 @@ export const issuesHandlers = [
         patch.agent = agent
       }
     }
+    if (body.execution !== undefined) {
+      const execution = body.execution as Partial<IssueExecution>
+      if (execution.mode === 'fresh') patch.execution = { mode: 'fresh' }
+      else if (execution.mode === 'resume' && typeof execution.resumeId === 'string' && execution.resumeId) {
+        patch.execution = { mode: 'resume', resumeId: execution.resumeId }
+      } else {
+        return HttpResponse.json({ error: 'invalid_execution' }, { status: 400 })
+      }
+    }
     if (
       patch.status === undefined &&
       patch.priority === undefined &&
       patch.assignee === undefined &&
       patch.agent === undefined
+      && patch.execution === undefined
     ) {
       return HttpResponse.json({ error: 'no_fields' }, { status: 400 })
     }

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -167,6 +167,42 @@ export const workspacesHandlers = [
       title: null,
     }),
   ),
+  http.get('/api/workspaces/:id/resumes', ({ params }) => {
+    const wsId = String(params.id)
+    if (wsId === 'demo-ws-auto-quant') {
+      return HttpResponse.json({
+        workspace: { id: wsId, tag: 'auto-quant' },
+        sessions: [{
+          resumeId: 'demo-resume-thesis-owner', agent: 'claude',
+          createdAt: Date.now() - 86_400_000, updatedAt: Date.now() - 60_000,
+          resumable: true, active: false,
+          latestExecution: {
+            taskId: 'demo-thesis-owner-run', status: 'done',
+            startedAt: Date.now() - 60_000,
+            assistantPreview: 'Reviewed the active thesis invalidation rules.',
+          },
+        }],
+      })
+    }
+    const workspace = demoWorkspaces.find((candidate) => candidate.id === wsId)
+    return HttpResponse.json({
+      workspace: { id: wsId, tag: workspace?.tag ?? wsId },
+      sessions: (workspace?.sessions ?? []).map((session) => ({
+        resumeId: session.resumeId,
+        agent: session.agent,
+        createdAt: Date.parse(session.createdAt),
+        updatedAt: Date.parse(session.lastActiveAt),
+        resumable: session.agent !== 'shell',
+        active: session.state === 'running',
+        interactive: {
+          name: session.name,
+          ...(session.title ? { title: session.title } : {}),
+          state: session.state,
+          lastActiveAt: session.lastActiveAt,
+        },
+      })),
+    })
+  }),
   http.post('/api/workspaces/:id/resumes/:resumeId/session', ({ params }) => {
     const wsId = String(params.id)
     const resumeId = String(params.resumeId)

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from '../components/PageHeader'
 import { Skeleton } from '../components/StateViews'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { FileContentView } from '../components/FileContentView'
+import { InquiryPanel } from '../components/InquiryPanel'
 import { api } from '../api'
 import { inboxLive, refreshInbox, removeInboxOptimistically } from '../live/inbox'
 import { useInboxSelection } from '../live/inbox-selection'
@@ -252,6 +253,14 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
 
   const hasHeadlessOrigin = origin?.kind === 'headless' && !!origin.runId
   const canContinueOrigin = hasHeadlessOrigin || !!sessionRecord
+  const loadInquiries = useCallback(
+    () => api.inquiries.forInbox(entry.id),
+    [entry.id],
+  )
+  const askInbox = useCallback(
+    (prompt: string) => api.inquiries.askInbox(entry.id, prompt),
+    [entry.id],
+  )
 
   return (
     <div className="max-w-[1040px] mx-auto py-6 px-4 md:px-8">
@@ -348,6 +357,19 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
             className="leading-relaxed text-text/90"
           />
         </div>
+      )}
+
+      {wsAlive && (
+        <InquiryPanel
+          title={origin?.resumeId || origin?.runId || origin?.sessionId ? 'Ask the sender' : 'Ask this Workspace'}
+          description={origin?.resumeId || origin?.runId || origin?.sessionId
+            ? 'Send a background follow-up to the Session that produced this Inbox entry. You can leave while it works.'
+            : 'No sender Session was recorded. OpenAlice will recruit a fresh agent in the source Workspace and label the answer reconstructed.'}
+          actionLabel={origin?.resumeId || origin?.runId || origin?.sessionId ? 'Ask sender' : 'Ask workspace'}
+          placeholder="What do you want to ask about this message?"
+          load={loadInquiries}
+          ask={askInbox}
+        />
       )}
 
       {/* Follow-up bar — exact originating Session when available; Workspace


### PR DESCRIPTION
## What changed

- add asynchronous Inbox and Issue inquiry routes backed by the existing provenance-aware conversation resolver
- persist safe business-object inquiry subjects, original questions, and exact/reconstructed resolution on headless task records
- restore inquiry history after navigation or restart without exposing native runtime session ids
- add Inbox `Ask sender / Ask workspace` UI with final-reply cards
- add Issue creator, stable owner, and per-run ask entry points
- split Issue Properties into human `Work item` fields and explicit `Scheduled execution` responsibility
- replace the ambiguous ownership select with explained fresh-worker vs fixed-Session policies
- repair and exercise demo handlers for inquiries, execution edits, and Workspace Session directories
- document the human inquiry API and Issue execution semantics

## Why

Inbox and Issue provenance was queryable from the Workspace CLI, but the human UI still forced users to manually locate a Session. The previous Properties rail also mixed tracking fields with runtime responsibility, making `fresh` and `resume` Issues look deceptively similar.

The UI now names the business object and relation; the backend resolves the authoritative product Session or labels a reconstruction honestly. Dispatch is asynchronous so Electron IPC is never held open for a model turn.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build:demo`
- `pnpm test` (223 files passed, 1 skipped; 2609 tests passed, 6 skipped)
- real browser verification of unscheduled and scheduled Issue layouts
- real reconstructed Inbox smoke using Pi with Meituan Longmao / LongCat-2.0; final reply persisted and rendered after refresh
- demo browser verification of fixed-owner selection, ask dispatch, and rendered reply

## Compatibility

The inquiry field is optional and additive in the durable headless registry. Existing task records and Issues require no migration.