### PR TITLE
feat(issues): make markdown What canonical

### DIFF
--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -3,7 +3,7 @@ name: self-scheduling
 description: >
   Track and self-schedule work for THIS workspace by writing one markdown file
   per issue under `.alice/issues/<id>.md` at the workspace root. Each file is
-  YAML frontmatter + a markdown description. An issue WITHOUT a `when` field is
+  YAML frontmatter + one canonical markdown What. An issue WITHOUT a `when` field is
   just a tracked work item (it shows on the Issue board, the scanner ignores
   it). An issue WITH a `when` field self-schedules: the launcher scans the dir
   and, when it's due, spawns a fresh headless run of this workspace with your
@@ -26,7 +26,7 @@ summon a headless agent run.
 
 This workspace owns its work as **one markdown file per issue** in `.alice/issues/`
 at its own root. Each file is YAML frontmatter (the structured fields) plus a
-markdown body (the human description).
+markdown What (the human-visible work definition and exact scheduled prompt).
 
 - An issue **without** `when` is a plain **tracked work item** — it appears on
   the Issue board for you and the user to see, but the scanner never fires it.
@@ -44,14 +44,14 @@ You have two equivalent paths, and both write the **same**
 1. **`alice-workspace issue …` — the convenient agent surface, and what you
    should reach for first.** A small set of verbs does the read-modify-write for
    you: id slug derivation, frontmatter validation against the allowed
-   status/priority enums, the stable `## Comments` section, and not clobbering an
+   status/priority enums, structured comment sidecars, and not clobbering an
    existing id. The same tools are also exposed over **MCP** — it is *one*
    registration behind both, so an MCP-speaking agent gets the identical surface
    with no separate path.
 2. **Editing the file directly** with your normal file tools. Reach for this when
-   you are writing the markdown **body** or the scheduling frontmatter
-   (`when` / `what` / `agent`) — the CLI verbs cover the board fields and
-   comments, but the body and the schedule shape read most clearly as text. The
+   you are writing rich markdown **What** or scheduling frontmatter
+   (`when` / `agent`) — the CLI verbs cover the board fields, What, and
+   comments, but the document and schedule shape read most clearly as text. The
    file is always the single source of truth either way.
 
 ### CLI verbs
@@ -60,7 +60,7 @@ You have two equivalent paths, and both write the **same**
 # list — scan the WHOLE board: every workspace's issues as compact title rows
 alice-workspace issue list
 
-# show — one issue in full, resolved by its (global) name: frontmatter + body +
+# show — one issue in full, resolved by its (global) name: frontmatter + What + comments +
 # run history + inbox reports. --id takes a name OR id and resolves across the
 # board; a name two workspaces share returns the candidates to pick from.
 alice-workspace issue show --id morning-scan
@@ -69,14 +69,14 @@ alice-workspace issue show --id morning-scan
 # from the title when omitted. Creating over an existing id is refused.
 alice-workspace issue create --title "Split the data fetcher" \
   --priority medium \
-  --body "src/fetch.ts mixes the HTTP call with the normalization step."
+  --what "src/fetch.ts mixes the HTTP call with the normalization step."
 
-# update — patch board fields only (status / priority / assignee); the body and
-# scheduling frontmatter are left untouched. Setting status done|canceled is how
+# update — patch board fields or canonical What; scheduling frontmatter is left
+# untouched. Setting status done|canceled is how
 # you silence a self-scheduled issue (there is no separate enabled flag).
 alice-workspace issue update --id morning-scan --status done
 
-# comment — append a note under the ## Comments section, authored as
+# comment — append markdown to the structured `<id>.comments.json` sidecar, authored as
 # ws:<this workspace>. Use it for a progress note, finding, or a question.
 alice-workspace issue comment --id morning-scan --text "Brief pushed; SPY gapped +0.4%."
 ```
@@ -111,17 +111,14 @@ status: todo
 priority: high
 assignee: ws:research
 when: { kind: cron, cron: "30 8 * * 1-5" }
-what: >
-  Pull pre-market movers and overnight news for my watchlist, write a short
-  brief to research/premarket.md, then run:
-  alice-workspace inbox push --doc research/premarket.md --comments "Pre-market brief".
 agent: claude
 execution: { mode: resume, resumeId: resume-calm-amber-river-a1b2c3 }
 ---
 
-Every trading morning at 08:30, assemble the pre-market picture for the
-watchlist so I have it before the open. Movers, gaps, and any overnight
-headlines that move the thesis.
+Pull pre-market movers and overnight news for my watchlist. Every trading
+morning at 08:30, assemble the pre-market picture before the open, write a short
+brief to `research/premarket.md`, then push it to Inbox. Cover movers, gaps, and
+overnight headlines that move the thesis.
 ```
 
 ## Example — an unscheduled work item (`.alice/issues/refactor-fetcher.md`)
@@ -142,7 +139,7 @@ touch fetching.
 
 The first self-schedules (it has `when`) and keeps one accountable product
 Session; the second is a pure work item the
-scanner ignores. Drop the `when`/`what`/`agent` lines and any issue becomes a
+scanner ignores. Drop the `when`/`agent` lines and any issue becomes a
 plain tracked item; add a `when` and it starts firing.
 
 ## Frontmatter fields
@@ -168,9 +165,6 @@ plain tracked item; add a `when` and it starts firing.
     lists `1,15`, steps `*/15`). Wall-clock; waits for the next match.
   - `{ kind: at, at: "2026-03-01T13:30:00Z" }` — run ONCE at an ISO timestamp,
     then never again.
-- **`what`** *(optional)* — the prompt for the scheduled headless run (see
-  below). If omitted, the fire prompt falls back to the title plus the markdown
-  body. Only meaningful when `when` is present.
 - **`agent`** *(optional)* — which CLI runs the scheduled job; defaults to this
   workspace's default agent. It selects the worker kind for `fresh`; a `resume`
   owner already has an immutable runtime, so that Session's runtime wins.
@@ -182,13 +176,14 @@ plain tracked item; add a `when` and it starts firing.
     to bind the current Session without guessing its id. Existing legacy Issues
     that omit this field keep the historical `fresh` behavior.
 
-The markdown **body** below the closing `---` is the issue's description: free
-prose for you and the user. For an unscheduled item it's the whole point; for a
-scheduled item with no `what`, the body becomes part of the fire prompt.
+The markdown **What** below the closing `---` is the Issue's canonical work
+definition. It is useful for every Issue; when scheduled, this exact visible
+markdown becomes the headless prompt. Comments are separate structured markdown
+records in `.alice/issues/<id>.comments.json`, written through `issue comment`.
 
 ## Link entities and issues with `[[name]]`
 
-An issue body can reference things in the `[[]]` knowledge graph, exactly like
+An Issue's What can reference things in the `[[]]` knowledge graph, exactly like
 any other note: write `[[name]]` to link a **tracked entity** (an asset ticker
 or topic, e.g. `[[vst]]`, `[[ai-data-center-power]]`) or **another issue** (by
 its id or title). The link shows up as a backlink on the target's page and is
@@ -208,7 +203,7 @@ avoids the collision flag in the first place.
 ## Write `what` for a headless run
 
 The scheduled run is **headless — nobody is watching, and it cannot see this
-conversation.** Write `what` (or, if you rely on the fallback, the body) as a
+conversation.** Write What as a
 **complete, standalone instruction**, as if handing the job to a fresh teammate
 who has only this workspace's files. Say exactly what to read, do, and produce.
 

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -35,14 +35,12 @@ status: todo
 priority: high
 assignee: ws:research
 when: { kind: cron, cron: "30 8 * * 1-5" }
-what: >
-  Pull pre-market movers and overnight news, write research/premarket.md,
-  then push the report to Inbox.
 agent: pi
 execution: { mode: fresh }
 ---
 
-Prepare a concise brief before the trading day.
+Pull pre-market movers and overnight news, write `research/premarket.md`,
+then push the report to Inbox. Prepare a concise brief before the trading day.
 ```
 
 The filename stem is the stable issue id. Frontmatter:
@@ -55,7 +53,6 @@ The filename stem is the stable issue id. Frontmatter:
   - `{ kind: at, at: <ISO timestamp> }`
   - `{ kind: every, every: <duration> }`
   - `{ kind: cron, cron: <5-field expression> }`
-- `what` — optional standalone headless prompt; falls back to title + body.
 - `agent` — optional CLI adapter id; otherwise Workspace/default resolution is
   used. It selects the runtime for `fresh`; `resume` uses the declared Session's
   immutable runtime.
@@ -65,6 +62,17 @@ The filename stem is the stable issue id. Frontmatter:
   runtime session id; provenance-only, not-yet-resumable Sessions are rejected
   at assignment time. Existing files without `execution` remain fresh for
   compatibility; new agent-created schedules must choose explicitly.
+
+The markdown below frontmatter is the Issue's canonical **What**: the work
+definition humans inspect and edit. For scheduled Issues, Alice sends this exact
+markdown to the Agent Runtime. There is no second prompt in frontmatter and no
+description/prompt fallback chain that can drift.
+
+Comments are markdown too, but they are not part of What. They persist in the
+adjacent `.alice/issues/<id>.comments.json` sidecar as structured records
+(`id`, `author`, `at`, `markdown`). The Issue document is intentionally editable
+by agents and has no reliable internal structure, so comments must not depend on
+a heading surviving an arbitrary rewrite.
 
 `done` and `canceled` are terminal and stop scheduled firing. There is no
 separate `enabled` flag. A successful one-shot `at` issue is automatically
@@ -77,14 +85,14 @@ Agents normally use:
 ```bash
 alice-workspace issue list
 alice-workspace issue show --id <id-or-title>
-alice-workspace issue create --title "..." --when '{"kind":"every","every":"1h"}' --execution '{"mode":"fresh"}'
+alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --execution '{"mode":"fresh"}'
 alice-workspace issue update --id <id> --status done
 alice-workspace issue comment --id <id> --text "..."
 ```
 
-The CLI and MCP tools use the same implementation and write the same markdown
-files. Direct file editing is also valid and is the clearest way to author the
-body plus `when` / `what` / `agent` / `execution` fields.
+The CLI and MCP tools use the same implementation and write the same files.
+Direct file editing is also valid and is the clearest way to author rich What
+markdown plus `when` / `agent` / `execution` frontmatter.
 
 Reads such as list/show aggregate all workspaces. Writes from an autonomous or
 headless run stay inside its own Workspace. Editing a peer Workspace requires
@@ -104,7 +112,7 @@ an attended, human-approved path and a commit in the peer repository.
   -> Inbox item linked to the run and issue
 ```
 
-The scanner interprets timing only. It hands `what` (or title + body) to the
+The scanner interprets timing only. It hands the visible markdown What to the
 agent unchanged. Conditions belong in that prompt: for “notify only if X,” the
 run checks X and exits silently when false.
 
@@ -217,7 +225,8 @@ human approval boundaries.
 
 | Path | Responsibility |
 |---|---|
-| `src/workspaces/issues/declaration.ts` | File schema, parsing, validation, prompt fallback |
+| `src/workspaces/issues/declaration.ts` | File schema, canonical What parsing, validation |
+| `src/workspaces/issues/comments.ts` | Structured per-Issue markdown comment sidecars |
 | `src/workspaces/issues/mutate.ts` | Safe read-modify-write operations |
 | `src/workspaces/issues/board.ts` | Global board/detail projections |
 | `src/workspaces/issues/auto-complete.ts` | Successful one-shot → `done` transition |

--- a/src/migrations/0017_issue_what_and_comment_sidecars.spec.ts
+++ b/src/migrations/0017_issue_what_and_comment_sidecars.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { readWorkspaceIssues } from '@/workspaces/issues/declaration.js'
+import { readIssueComments } from '@/workspaces/issues/comments.js'
+
+import { migrateIssueWhatAndCommentSidecars } from './0017_issue_what_and_comment_sidecars/index.js'
+
+let root: string
+let wsDir: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'mig0017-'))
+  wsDir = join(root, 'workspaces', 'research')
+  await mkdir(join(wsDir, '.alice', 'issues'), { recursive: true })
+  await writeFile(join(root, 'workspaces.json'), JSON.stringify({
+    version: 1,
+    workspaces: [{ id: 'research', tag: 'research', dir: wsDir, agents: [] }],
+  }), 'utf8')
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('0017 issue What and comment sidecars', () => {
+  it('moves YAML What into markdown and extracts legacy comments without prompt leakage', async () => {
+    await writeFile(join(wsDir, '.alice', 'issues', 'daily.md'), `---
+title: Daily scan
+when: { kind: every, every: 1h }
+what: Run the daily scan and publish it.
+---
+
+Use the latest market data.
+
+## Comments
+
+**human** · 2026-07-11T01:00:00.000Z
+
+Please include breadth.
+
+**ws:research** · 2026-07-11T02:00:00.000Z
+
+Breadth was added.
+`, 'utf8')
+
+    expect(await migrateIssueWhatAndCommentSidecars(root)).toEqual({
+      updated: 1,
+      commentsMoved: 2,
+      workspaces: 1,
+    })
+
+    const raw = await readFile(join(wsDir, '.alice', 'issues', 'daily.md'), 'utf8')
+    expect(raw).not.toMatch(/^what:/m)
+    expect(raw).not.toContain('## Comments')
+    expect(raw).toContain('Run the daily scan and publish it.\n\n## Context\n\nUse the latest market data.')
+
+    const issues = await readWorkspaceIssues(wsDir)
+    expect(issues.ok).toBe(true)
+    if (!issues.ok) return
+    expect(issues.issues[0].what).toBe('Run the daily scan and publish it.\n\n## Context\n\nUse the latest market data.')
+
+    const comments = await readIssueComments(wsDir, 'daily')
+    expect(comments.ok).toBe(true)
+    if (!comments.ok) return
+    expect(comments.comments.map((comment) => [comment.author, comment.markdown])).toEqual([
+      ['human', 'Please include breadth.'],
+      ['ws:research', 'Breadth was added.'],
+    ])
+
+    expect(await migrateIssueWhatAndCommentSidecars(root)).toEqual({
+      updated: 0,
+      commentsMoved: 0,
+      workspaces: 0,
+    })
+  })
+
+  it('preserves an unparseable legacy comment section as one markdown record', async () => {
+    await writeFile(join(wsDir, '.alice', 'issues', 'odd.md'), `---
+title: Odd comments
+---
+
+Do the work.
+
+## Comments
+
+An agent rewrote this section into arbitrary markdown.
+
+- keep every line
+`, 'utf8')
+
+    await migrateIssueWhatAndCommentSidecars(root)
+    const comments = await readIssueComments(wsDir, 'odd')
+    expect(comments.ok).toBe(true)
+    if (!comments.ok) return
+    expect(comments.comments).toEqual([
+      expect.objectContaining({
+        author: 'legacy',
+        markdown: 'An agent rewrote this section into arbitrary markdown.\n\n- keep every line',
+      }),
+    ])
+  })
+})

--- a/src/migrations/0017_issue_what_and_comment_sidecars/index.ts
+++ b/src/migrations/0017_issue_what_and_comment_sidecars/index.ts
@@ -1,0 +1,173 @@
+/**
+ * 0017_issue_what_and_comment_sidecars
+ *
+ * Unify the human-visible Issue document and the scheduled prompt: YAML
+ * frontmatter `what` is moved into the markdown below frontmatter. Historical
+ * `## Comments` blocks leave the agent-editable markdown entirely and become a
+ * structured per-Issue JSON sidecar. The migration is deliberately
+ * self-contained rather than importing the evolving Issue parser.
+ */
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, readFile, readdir, rename, stat, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+
+import type { Migration } from '../types.js'
+
+interface WorkspaceMeta { dir?: unknown }
+interface CommentRecord { id: string; author: string; at: string; markdown: string }
+
+function defaultLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+function splitFrontmatter(raw: string): { frontmatter: string; body: string } | null {
+  const lines = raw.replace(/^\uFEFF/, '').split(/\r?\n/)
+  if (lines[0]?.trim() !== '---') return null
+  const end = lines.findIndex((line, index) => index > 0 && line.trim() === '---')
+  if (end < 0) return null
+  return { frontmatter: lines.slice(1, end).join('\n'), body: lines.slice(end + 1).join('\n').trim() }
+}
+
+function splitLegacyComments(body: string): { what: string; comments: string } {
+  const lines = body.split(/\r?\n/)
+  const index = lines.findIndex((line) => /^##\s+Comments\s*$/.test(line.trim()))
+  if (index < 0) return { what: body.trim(), comments: '' }
+  return { what: lines.slice(0, index).join('\n').trim(), comments: lines.slice(index + 1).join('\n').trim() }
+}
+
+function mergeWhat(legacyWhat: unknown, markdownWhat: string, title: unknown): string {
+  const explicit = typeof legacyWhat === 'string' ? legacyWhat.trim() : ''
+  const markdown = markdownWhat.trim()
+  const fallback = typeof title === 'string' ? title.trim() : ''
+  if (explicit && markdown && explicit !== markdown) return `${explicit}\n\n## Context\n\n${markdown}`
+  return explicit || markdown || fallback
+}
+
+function commentId(author: string, at: string, markdown: string): string {
+  return `comment-${createHash('sha256').update(`${author}\0${at}\0${markdown}`).digest('hex').slice(0, 24)}`
+}
+
+/** Parse the exact legacy format written by appendIssueComment. If an agent
+ * rewrote that supposedly-structured section, preserve the entire remainder as
+ * one legacy markdown comment rather than guessing and losing content. */
+function parseLegacyComments(markdown: string): CommentRecord[] {
+  const text = markdown.trim()
+  if (!text) return []
+  const marker = /^\*\*(.+?)\*\*\s+·\s+(\d{4}-\d{2}-\d{2}T[^\n]+)\s*$/gm
+  const matches = Array.from(text.matchAll(marker))
+  if (matches.length === 0) {
+    const at = '1970-01-01T00:00:00.000Z'
+    return [{ id: commentId('legacy', at, text), author: 'legacy', at, markdown: text }]
+  }
+  const comments: CommentRecord[] = []
+  for (let index = 0; index < matches.length; index++) {
+    const current = matches[index]
+    const start = (current.index ?? 0) + current[0].length
+    const end = matches[index + 1]?.index ?? text.length
+    const body = text.slice(start, end).trim()
+    const author = current[1].trim()
+    const at = current[2].trim()
+    if (!body) continue
+    comments.push({ id: commentId(author, at, body), author, at, markdown: body })
+  }
+  if (comments.length > 0) return comments
+  const at = '1970-01-01T00:00:00.000Z'
+  return [{ id: commentId('legacy', at, text), author: 'legacy', at, markdown: text }]
+}
+
+async function writeAtomic(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const temp = join(dirname(path), `.${randomUUID()}.tmp`)
+  await writeFile(temp, content, 'utf8')
+  await rename(temp, path)
+}
+
+async function exists(path: string): Promise<boolean> {
+  try { await stat(path); return true } catch { return false }
+}
+
+async function normalizeIssue(path: string, id: string): Promise<{ updated: boolean; commentsMoved: number }> {
+  const raw = await readFile(path, 'utf8')
+  const split = splitFrontmatter(raw)
+  if (!split) return { updated: false, commentsMoved: 0 }
+  let parsed: unknown
+  try { parsed = parseYaml(split.frontmatter) } catch { return { updated: false, commentsMoved: 0 } }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { updated: false, commentsMoved: 0 }
+  }
+  const frontmatter = parsed as Record<string, unknown>
+  const document = splitLegacyComments(split.body)
+  const comments = parseLegacyComments(document.comments)
+  const commentsPath = join(dirname(path), `${id}.comments.json`)
+
+  if (comments.length > 0) {
+    let existing: CommentRecord[] = []
+    if (await exists(commentsPath)) {
+      try {
+        const sidecar = JSON.parse(await readFile(commentsPath, 'utf8')) as { version?: unknown; issueId?: unknown; comments?: unknown }
+        if (sidecar.version !== 1 || sidecar.issueId !== id || !Array.isArray(sidecar.comments)) {
+          return { updated: false, commentsMoved: 0 }
+        }
+        existing = sidecar.comments as CommentRecord[]
+      } catch {
+        return { updated: false, commentsMoved: 0 }
+      }
+    }
+    const ids = new Set(existing.map((comment) => comment.id))
+    const merged = [...existing, ...comments.filter((comment) => !ids.has(comment.id))]
+    await writeAtomic(commentsPath, JSON.stringify({ version: 1, issueId: id, comments: merged }, null, 2) + '\n')
+  }
+
+  const what = mergeWhat(frontmatter.what, document.what, frontmatter.title)
+  delete frontmatter.what
+  const fm = stringifyYaml(frontmatter).trimEnd()
+  const content = what ? `---\n${fm}\n---\n\n${what}\n` : `---\n${fm}\n---\n`
+  const updated = content !== raw
+  if (updated) await writeAtomic(path, content)
+  return { updated, commentsMoved: comments.length }
+}
+
+export async function migrateIssueWhatAndCommentSidecars(
+  launcherRoot: string = defaultLauncherRoot(),
+): Promise<{ updated: number; commentsMoved: number; workspaces: number }> {
+  let registry: { workspaces?: WorkspaceMeta[] }
+  try { registry = JSON.parse(await readFile(join(launcherRoot, 'workspaces.json'), 'utf8')) as typeof registry }
+  catch { return { updated: 0, commentsMoved: 0, workspaces: 0 } }
+  const dirs = Array.isArray(registry.workspaces)
+    ? registry.workspaces.map((workspace) => typeof workspace.dir === 'string' ? workspace.dir : '').filter(Boolean)
+    : []
+  let updated = 0
+  let commentsMoved = 0
+  let workspaces = 0
+  for (const dir of dirs) {
+    const issuesDir = join(dir, '.alice', 'issues')
+    let files: string[]
+    try { files = (await readdir(issuesDir)).filter((name) => name.toLowerCase().endsWith('.md')) }
+    catch { continue }
+    let touched = false
+    for (const file of files) {
+      try {
+        const result = await normalizeIssue(join(issuesDir, file), file.slice(0, -3))
+        if (result.updated) { updated++; touched = true }
+        commentsMoved += result.commentsMoved
+      } catch (err) {
+        console.log(`[migration 0017] skipped ${join(issuesDir, file)}: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+    if (touched) workspaces++
+  }
+  return { updated, commentsMoved, workspaces }
+}
+
+export const migration: Migration = {
+  id: '0017_issue_what_and_comment_sidecars',
+  appVersion: '0.75.0-beta',
+  introducedAt: '2026-07-12',
+  affects: ['workspaces/<id>/.alice/issues/*.md', 'workspaces/<id>/.alice/issues/*.comments.json'],
+  summary: 'Make markdown What the sole Issue work definition and move comments into structured per-Issue JSON sidecars.',
+  rationale: 'Agents may freely rewrite Issue markdown, so comment structure cannot safely share that document; a visible work definition must also be the exact scheduled prompt.',
+  up: async () => { await migrateIssueWhatAndCommentSidecars() },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -16,3 +16,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0014_headless_resume_identity` | 0.75.0-beta | 2026-07-11 | workspaces/state/headless-tasks.json | Assign durable resumeId values to historical headless runs so execution identity and resumable conversation identity remain distinct. |
 | `0015_resume_identity_registry` | 0.75.0-beta | 2026-07-11 | workspaces/state/resume-identities.json, workspaces/state/sessions/*.json | Create the backend resumeId to native runtime session-id registry. |
 | `0016_artifact_provenance_store` | 0.75.0-beta | 2026-07-11 | workspaces/state/artifact-provenance.json | Create the durable product Session to artifact provenance store. |
+| `0017_issue_what_and_comment_sidecars` | 0.75.0-beta | 2026-07-12 | workspaces/<id>/.alice/issues/*.md, workspaces/<id>/.alice/issues/*.comments.json | Make markdown What the sole Issue work definition and move comments into structured per-Issue JSON sidecars. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -14,7 +14,7 @@
  * deletion + Workspace pivot turned the pre-0.40 data shapes over completely, so
  * pre-0.40 installs rebuild `data/` rather than migrate. The framework stays for
  * future upgrades. Numbering continues FORWARD from the highest id ever shipped
- * (next: 0013) — never reuse a retired id, since existing installs' journals
+ * (next: 0018) — never reuse a retired id, since existing installs' journals
  * recorded the old ones.
  */
 
@@ -28,6 +28,7 @@ import { migration as migration_0013_session_run_source } from './0013_session_r
 import { migration as migration_0014_headless_resume_identity } from './0014_headless_resume_identity/index.js'
 import { migration as migration_0015_resume_identity_registry } from './0015_resume_identity_registry/index.js'
 import { migration as migration_0016_artifact_provenance_store } from './0016_artifact_provenance_store/index.js'
+import { migration as migration_0017_issue_what_and_comment_sidecars } from './0017_issue_what_and_comment_sidecars/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -39,4 +40,5 @@ export const REGISTRY: Migration[] = [
   migration_0014_headless_resume_identity,
   migration_0015_resume_identity_registry,
   migration_0016_artifact_provenance_store,
+  migration_0017_issue_what_and_comment_sidecars,
 ]

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
 import { readWorkspaceIssues } from '../workspaces/issues/declaration.js'
+import { readIssueComments } from '../workspaces/issues/comments.js'
 import type {
   IssueDetail,
   IssuesSnapshot,
@@ -164,18 +165,20 @@ describe('issue_create', () => {
 })
 
 describe('issue_update', () => {
-  it('validates and writes patched fields, preserving body + scheduling', async () => {
+  it('updates canonical What while preserving scheduling', async () => {
     await run(issueCreateFactory.build(ctx()), {
       id: 'sched',
       title: 'scheduled work',
       when: { kind: 'every', every: '30m' },
       execution: { mode: 'fresh' },
-      body: 'keep me',
+      what: 'keep me',
     })
-    const res = await run(issueUpdateFactory.build(ctx()), { id: 'sched', status: 'in_progress', priority: 'high' })
+    const res = await run(issueUpdateFactory.build(ctx()), {
+      id: 'sched', status: 'in_progress', priority: 'high', what: 'new exact work',
+    })
     expect(res.ok).toBe(true)
     const issue = await readBack('sched')
-    expect(issue).toMatchObject({ status: 'in_progress', priority: 'high', body: 'keep me' })
+    expect(issue).toMatchObject({ status: 'in_progress', priority: 'high', what: 'new exact work' })
     // scheduling frontmatter survives a board-field patch
     expect(issue?.when).toEqual({ kind: 'every', every: '30m' })
   })
@@ -206,14 +209,12 @@ describe('issue_update', () => {
 })
 
 describe('issue_comment', () => {
-  it('appends a ws-authored comment into the issue body', async () => {
-    await run(issueCreateFactory.build(ctx()), { id: 'c1', title: 'commentable', body: 'desc' })
+  it('appends a ws-authored structured markdown comment', async () => {
+    await run(issueCreateFactory.build(ctx()), { id: 'c1', title: 'commentable', what: 'desc' })
     const res = await run(issueCommentFactory.build(ctx()), { id: 'c1', text: 'progress note' })
     expect(res.ok).toBe(true)
-    const issue = await readBack('c1')
-    expect(issue?.body).toMatch(/## Comments/)
-    expect(issue?.body).toMatch(/\*\*ws:auto-quant\*\*/)
-    expect(issue?.body).toMatch(/progress note/)
+    const comments = await readIssueComments(dir, 'c1')
+    expect(comments.ok && comments.comments[0]).toMatchObject({ author: 'ws:auto-quant', markdown: 'progress note' })
   })
 
   it('errors cleanly on a missing issue', async () => {
@@ -299,12 +300,13 @@ describe('global board (ctx.board present)', () => {
       issue: {
         id: 'alpha',
         title: 'Alpha',
-        body: 'the alpha body',
+        what: 'the alpha body',
         status: 'todo',
         priority: 'high',
         assignee: 'human',
         execution: { mode: 'fresh' },
       },
+      comments: [],
       runs: [],
       inboxReports: [],
       provenance: [],
@@ -391,7 +393,7 @@ describe('global board (ctx.board present)', () => {
     const show = await run(issueShowFactory.build(boardCtx()), { id: 'Alpha' })
     expect(show.ok).toBe(true)
     expect(show.mode).toBe('summary')
-    expect(show.issue).toMatchObject({ id: 'alpha', body: 'the alpha body' })
+    expect(show.issue).toMatchObject({ id: 'alpha', what: 'the alpha body' })
     expect(show.runs).toEqual([])
     expect(show.inboxReports).toEqual([])
     expect(show.ambiguous).toBeUndefined()
@@ -400,9 +402,10 @@ describe('global board (ctx.board present)', () => {
   it('issue_show keeps repeated prompts out of summary mode but includes them on request', async () => {
     const detail: IssueDetail = {
       issue: {
-        id: 'alpha', title: 'Alpha', body: 'one canonical body', status: 'todo',
-        priority: 'high', assignee: 'human', what: 'one canonical prompt', execution: { mode: 'fresh' },
+        id: 'alpha', title: 'Alpha', what: 'one canonical prompt', status: 'todo',
+        priority: 'high', assignee: 'human', execution: { mode: 'fresh' },
       },
+      comments: [],
       runs: [{
         taskId: 'task-1', resumeId: 'resume-kind-owl-abc123', wsId: 'ws-a', issueId: 'alpha',
         agent: 'codex', prompt: 'large repeated execution prompt', status: 'done', startedAt: 1,

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -13,7 +13,7 @@
  * and goes through the single read-modify-write seam in
  * `../workspaces/issues/mutate.ts` (shared with the human/UI HTTP routes) or the
  * live reader in `../workspaces/issues/declaration.ts`. The issue file
- * (`.alice/issues/<id>.md`, YAML frontmatter + markdown body) is the single
+ * (`.alice/issues/<id>.md`, YAML frontmatter + canonical markdown What) is the single
  * source of truth; writes are working-tree only (no auto-commit).
  *
  * Comments and created-issue authorship are tagged `ws:<workspaceLabel>` — the
@@ -45,6 +45,7 @@ import {
   createIssue,
   updateIssueFields,
 } from '../workspaces/issues/mutate.js'
+import { readIssueComments, type IssueComment } from '../workspaces/issues/comments.js'
 import {
   flattenBoardRows,
   issueAssigneeForWorkspace,
@@ -224,11 +225,11 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
       description: [
         "Update one of THIS workspace's issues — its board fields.",
         '',
-        'Patch any subset of `status`, `priority`, `assignee`, `execution`; omitted fields are',
+        'Patch any subset of `status`, `priority`, `assignee`, `execution`, `what`; omitted fields are',
         'left untouched. `execution:{mode:"resume"}` binds this current product',
-        'Session; pass a resumeId to assign another known Session. Other scheduling',
-        'frontmatter (`when`/`what`/`agent`) and the',
-        'markdown body are preserved — edit those by writing the file directly',
+        'Session; pass a resumeId to assign another known Session. What is the',
+        'canonical markdown work definition and exact scheduled prompt. Other scheduling',
+        'frontmatter (`when`/`agent`) is preserved — edit it by writing the file directly',
         '(`.alice/issues/<id>.md`).',
         '',
         'Marking an issue `done` or `canceled` is how a self-scheduled issue is',
@@ -244,19 +245,21 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
           .optional()
           .describe('New assignee, e.g. "human", "ws:<tag>", or "unassigned".'),
         execution: issueExecutionInputSchema.optional().describe('Scheduled ownership: fresh each fire, or resume one exact product Session.'),
+        what: z.string().min(1).optional().describe('Canonical markdown work definition; exact scheduled prompt.'),
       }),
-      execute: async ({ id, status, priority, assignee, execution }) => {
+      execute: async ({ id, status, priority, assignee, execution, what }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
         const resolvedExecution = resolveIssueExecution(ctx, execution)
         if (!resolvedExecution.ok) return { ok: false as const, error: resolvedExecution.error }
-        if (status === undefined && priority === undefined && assignee === undefined && !resolvedExecution.execution) {
-          return { ok: false as const, error: 'no fields to update (pass status/priority/assignee/execution)' }
+        if (status === undefined && priority === undefined && assignee === undefined && !resolvedExecution.execution && what === undefined) {
+          return { ok: false as const, error: 'no fields to update (pass status/priority/assignee/execution/what)' }
         }
         const res = await updateIssueFields(dir.dir, id, {
           status,
           priority,
           assignee,
+          what,
           ...(resolvedExecution.execution ? { execution: resolvedExecution.execution } : {}),
         })
         if (res.ok) {
@@ -279,9 +282,9 @@ export const issueCommentFactory: WorkspaceToolFactory = {
       description: [
         "Append a comment to one of THIS workspace's issues.",
         '',
-        'The comment lands under a stable `## Comments` section in the issue’s',
-        'markdown body (the file is the single source of truth — no separate',
-        'comment store), authored as `ws:<this workspace>`. Use it to leave a',
+        'The markdown comment is appended to the Issue’s structured JSON sidecar,',
+        'authored as `ws:<this workspace>`. It never mutates the canonical What',
+        'or silently changes the next scheduled prompt. Use it to leave a',
         'progress note, a finding, or a question for the human reading the board.',
       ].join('\n'),
       inputSchema: z.object({
@@ -316,11 +319,12 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         'title when omitted). Creating over an existing id is refused — pick a',
         'different id or update the existing one with issue_update.',
         '',
-        'Add a `when` to make the issue self-schedule (the scanner fires `what`,',
-        'or the title+body if `what` is absent, on the schedule) — otherwise it’s',
+        'The markdown `what` is the Issue’s work definition. Add a `when` and',
+        'the scanner sends that exact visible What to the Agent Runtime; without',
+        '`when` the same What remains a pure board work item. Otherwise it’s',
         'a pure board work item. Every new scheduled issue must choose execution:',
         '`fresh` recruits a new Session each fire; `resume` keeps one accountable',
-        'Session. Omit resumeId to bind the current Session. `body` is markdown.',
+        'Session. Omit resumeId to bind the current Session.',
       ].join('\n'),
       inputSchema: z.object({
         title: z.string().min(1).describe('Short human title (required).'),
@@ -339,12 +343,11 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         when: issueWhenSchema
           .optional()
           .describe('Schedule shape — { kind:"at", at } | { kind:"every", every } | { kind:"cron", cron }. Present iff the issue self-schedules.'),
-        what: z.string().min(1).optional().describe('Prompt fired on schedule; falls back to title+body if absent.'),
+        what: z.string().min(1).optional().describe('Markdown work definition; exact scheduled prompt. Defaults to title.'),
         agent: z.string().min(1).optional().describe('Adapter id for fresh execution; resume uses its Session-bound runtime.'),
         execution: issueExecutionInputSchema.optional().describe('Required with `when`: fresh each fire, or resume an exact product Session.'),
-        body: z.string().optional().describe('Markdown description body.'),
       }),
-      execute: async ({ title, id, status, priority, assignee, when, what, agent, execution, body }) => {
+      execute: async ({ title, id, status, priority, assignee, when, what, agent, execution }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
         if (when && !execution) {
@@ -365,7 +368,6 @@ export const issueCreateFactory: WorkspaceToolFactory = {
           what,
           agent,
           ...(resolvedExecution.execution ? { execution: resolvedExecution.execution } : {}),
-          body,
         })
         if (res.ok) {
           await recordIssueProvenance(ctx, res.issue.id, 'created')
@@ -547,14 +549,16 @@ export const issueShowFactory: WorkspaceToolFactory = {
 async function readSelfIssue(
   ctx: WorkspaceToolContext,
   id: string,
-): Promise<{ ok: true; issue: IssueRecord } | { ok: false; error: string }> {
+): Promise<{ ok: true; issue: IssueRecord; comments: IssueComment[] } | { ok: false; error: string }> {
   const dir = selfDir(ctx)
   if (!dir.ok) return { ok: false, error: dir.error }
   const raw = await readWorkspaceFile(dir.dir, join(ISSUES_DIR_REL, `${id}.md`))
   if (raw === null) return { ok: false, error: `no such issue: ${id}` }
   const parsed = parseIssueContent(id, raw)
   if (!parsed.ok) return { ok: false, error: parsed.error }
-  return { ok: true, issue: parsed.issue }
+  const comments = await readIssueComments(dir.dir, id)
+  if (!comments.ok) return { ok: false, error: comments.error }
+  return { ok: true, issue: parsed.issue, comments: comments.comments }
 }
 
 /** All issue tool factories, in registration order. */

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -16,6 +16,7 @@ import type { InboxEntry } from '../../core/inbox-store.js'
 import { detailIssue } from '../../workspaces/issues/board.js'
 import { readWorkspaceIssues } from '../../workspaces/issues/declaration.js'
 import { createIssue } from '../../workspaces/issues/mutate.js'
+import { readIssueComments } from '../../workspaces/issues/comments.js'
 import type { WorkspaceService } from '../../workspaces/service.js'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -60,7 +61,9 @@ function build(inboxReports: InboxEntry[] = []) {
       const r = await readWorkspaceIssues(wsDir)
       if (!r.ok) return null
       const issue = r.issues.find((i) => i.id === id)
-      return issue ? { issue: detailIssue(issue, null), runs: [], inboxReports, provenance: [] } : null
+      if (!issue) return null
+      const comments = await readIssueComments(wsDir, id)
+      return { issue: detailIssue(issue, null), comments: comments.ok ? comments.comments : [], runs: [], inboxReports, provenance: [] }
     },
     provenanceStore: { append: appendProvenance, list: vi.fn(), latest: vi.fn() },
   } as unknown as WorkspaceService
@@ -146,7 +149,9 @@ describe('PATCH /api/issues/:wsId/:id', () => {
   it('updates fields including the scheduled agent runtime and returns the detail shape', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', body: 'keep me' })
     const { app, appendProvenance } = build()
-    const r = await req(app, 'PATCH', '/ws-1/i1', { status: 'in_progress', priority: 'high', assignee: 'human', agent: 'pi' })
+    const r = await req(app, 'PATCH', '/ws-1/i1', {
+      status: 'in_progress', priority: 'high', assignee: 'human', agent: 'pi', what: 'new exact work',
+    })
     expect(r.status).toBe(200)
     expect(r.body.issue).toMatchObject({
       id: 'i1',
@@ -154,13 +159,14 @@ describe('PATCH /api/issues/:wsId/:id', () => {
       priority: 'high',
       assignee: 'human',
       agent: 'pi',
-      body: 'keep me',
+      what: 'new exact work',
     })
     expect(Array.isArray(r.body.runs)).toBe(true)
     // Persisted on disk.
     const re = await readWorkspaceIssues(wsDir)
     expect(re.ok && re.issues[0].status).toBe('in_progress')
     expect(re.ok && re.issues[0].agent).toBe('pi')
+    expect(re.ok && re.issues[0].what).toBe('new exact work')
     expect(appendProvenance).toHaveBeenCalledWith(expect.objectContaining({
       artifact: { kind: 'issue', workspaceId: 'ws-1', issueId: 'i1' },
       action: 'updated',
@@ -217,10 +223,10 @@ describe('POST /api/issues/:wsId/:id/comments', () => {
     const { app, appendProvenance } = build()
     const r = await req(app, 'POST', '/ws-1/i1/comments', { text: 'looks good' })
     expect(r.status).toBe(200)
-    expect(r.body.issue.body).toContain('## Comments')
-    expect(r.body.issue.body).toContain('**human**')
-    expect(r.body.issue.body).toContain('looks good')
-    expect(r.body.issue.body).toContain('desc')
+    expect(r.body.issue.what).toBe('desc')
+    expect(r.body.comments).toEqual([
+      expect.objectContaining({ author: 'human', markdown: 'looks good' }),
+    ])
     expect(appendProvenance).toHaveBeenCalledWith(expect.objectContaining({
       action: 'commented',
       origin: { kind: 'human' },

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -15,7 +15,7 @@
  * via its own tools). Both writes go through the shared mutation helper
  * (`workspaces/issues/mutate.ts`) so the human and agent surfaces can never
  * drift on file format or validation; writes are working-tree only (no commit):
- *   PATCH /api/issues/:wsId/:id           body { status?, priority?, assignee? }
+ *   PATCH /api/issues/:wsId/:id           body { status?, priority?, assignee?, what? }
  *   POST  /api/issues/:wsId/:id/comments  body { text }  (author = 'human')
  *
  * Both return the same detail shape GET /api/issues/:wsId/:id does, so the UI
@@ -39,6 +39,7 @@ import type { WorkspaceService } from '../../workspaces/service.js'
 
 /** Upper bound on a single comment's text (matches the headless seed cap). */
 const MAX_COMMENT = 16000
+const MAX_WHAT = 60000
 
 function validId(id: string | undefined): id is string {
   return typeof id === 'string' && /^[a-zA-Z0-9_-]+$/.test(id)
@@ -60,7 +61,7 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
     return c.json(await svc.issuesSnapshot())
   })
 
-  // GET /api/issues/:wsId/:id → { issue: {...incl. body + markers}, runs: [...],
+  // GET /api/issues/:wsId/:id → { issue: {...incl. What + markers}, comments, runs: [...],
   // inboxReports: [...] }. The issue→inbox join lives in svc.issueDetail (domain),
   // so this route is a thin pass-through. 404 when the workspace or the issue id
   // is absent (mirrors the workspaces route convention: `{ error: 'not_found' }`).
@@ -73,7 +74,7 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
   // PATCH /api/issues/:wsId/:id — patch board fields { status?, priority?,
   // assignee? } plus the scheduled runtime override { agent? } on one issue
   // (the human/UI path). `agent: null` removes the override so future fires use
-  // the workspace default runtime. Other scheduling frontmatter (when/what)
+  // the workspace default runtime. Other scheduling frontmatter (`when`)
   // stays file-owned. Returns the updated detail shape; 404 when missing.
   app.patch('/:wsId/:id', async (c) => {
     const wsId = c.req.param('wsId')
@@ -84,7 +85,7 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
 
     const body = await safeJson(c)
     const fields = body && typeof body === 'object' ? (body as Record<string, unknown>) : {}
-    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution } = {}
+    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string } = {}
     if ('status' in fields) {
       const s = fields['status']
       if (typeof s !== 'string' || !ISSUE_STATUSES.includes(s as IssueStatus)) {
@@ -146,8 +147,18 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
       }
       patch.execution = execution.data
     }
+    if ('what' in fields) {
+      const what = fields['what']
+      if (typeof what !== 'string' || what.trim().length === 0) {
+        return c.json({ error: 'invalid_what', message: 'what must be non-empty markdown' }, 400)
+      }
+      if (what.length > MAX_WHAT) {
+        return c.json({ error: 'what_too_long', message: `max ${MAX_WHAT} chars` }, 400)
+      }
+      patch.what = what.trim()
+    }
     if (Object.keys(patch).length === 0) {
-      return c.json({ error: 'no_fields', message: 'provide at least one of status, priority, assignee, agent, execution' }, 400)
+      return c.json({ error: 'no_fields', message: 'provide at least one of status, priority, assignee, agent, execution, what' }, 400)
     }
 
     try {
@@ -164,15 +175,15 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
       })
       launcherLogger.info('issue.updated', { wsId, id, fields: Object.keys(patch) })
       const detail = await svc.issueDetail(wsId, id)
-      return c.json(detail ?? { issue: res.issue, runs: [], inboxReports: [] })
+      return c.json(detail ?? { issue: res.issue, comments: [], runs: [], inboxReports: [], provenance: [] })
     } catch (err) {
       launcherLogger.warn('issue.update_failed', { wsId, id, err })
       return c.json({ error: 'write_failed', message: (err as Error).message }, 500)
     }
   })
 
-  // POST /api/issues/:wsId/:id/comments — append a comment to the issue body
-  // under the stable `## Comments` section. Author is fixed to 'human' here
+  // POST /api/issues/:wsId/:id/comments — append a structured markdown comment
+  // to `<id>.comments.json`. Author is fixed to 'human' here
   // (the agent path stamps 'ws:<label>'). Returns the updated detail shape.
   app.post('/:wsId/:id/comments', async (c) => {
     const wsId = c.req.param('wsId')
@@ -205,7 +216,7 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
       })
       launcherLogger.info('issue.comment_added', { wsId, id, author: 'human' })
       const detail = await svc.issueDetail(wsId, id)
-      return c.json(detail ?? { issue: res.issue, runs: [], inboxReports: [] })
+      return c.json(detail ?? { issue: res.issue, comments: [res.comment], runs: [], inboxReports: [], provenance: [] })
     } catch (err) {
       launcherLogger.warn('issue.comment_failed', { wsId, id, err })
       return c.json({ error: 'write_failed', message: (err as Error).message }, 500)

--- a/src/workspaces/issues/auto-complete.spec.ts
+++ b/src/workspaces/issues/auto-complete.spec.ts
@@ -49,7 +49,7 @@ describe('completeOneShotIssueAfterRun', () => {
       expect(issue).toMatchObject({
         status: 'done',
         agent: 'pi',
-        body: 'Make sure this keeps the body.',
+        what: 'Make sure this keeps the body.',
       })
       expect(issue?.when).toEqual({ kind: 'at', at: '2030-01-01T09:00:00Z' })
     }

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -175,7 +175,7 @@ describe('workspace default assignee projection', () => {
     status: 'todo',
     priority: 'none',
     assignee: 'unassigned',
-    body: '',
+    what: 'Issue',
   } as const
 
   it('projects a missing assignee to the owning workspace', () => {

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -7,7 +7,7 @@
  * shows ALL issues (scheduled or not); a scheduled issue additionally carries its
  * firing markers (`lastFiredAtMs` / `nextDueAtMs`) so the row matches real firing.
  *
- * Phase 1 is read-only and the list view does NOT include the markdown body — the
+ * Phase 1 is read-only and the list view does NOT include markdown What — the
  * Phase 2 detail view loads it. Keeping the body out keeps the poll payload small.
  */
 
@@ -24,9 +24,10 @@ import type {
   HeadlessTaskStatus,
 } from '../headless-task-registry.js'
 import { issueExecution, type IssueExecution, type IssuePriority, type IssueRecord, type IssueStatus } from './declaration.js'
+import type { IssueComment } from './comments.js'
 
 /** One board row: the issue's display fields, plus — iff it self-schedules — its
- *  `when` and the scanner's firing markers. No markdown body (Phase 2 loads it). */
+ *  `when` and the scanner's firing markers. No markdown What (Phase 2 loads it). */
 export interface IssuesSnapshotIssue {
   id: string
   title: string
@@ -202,24 +203,22 @@ export interface IssueFiringMarkers {
 
 // ==================== Detail (Phase 2a) ====================
 // The read-only shape GET /api/issues/:wsId/:id returns: one issue's full
-// fields INCLUDING the markdown body and (iff scheduled) its firing markers +
+// fields INCLUDING markdown What and (iff scheduled) its firing markers +
 // scheduling frontmatter, plus that issue's headless run history (its Activity
-// feed). Unlike the board list, the detail loads the body and the runs.
+// feed). Unlike the board list, the detail loads What and the runs.
 
-/** One issue's full detail fields: the board row's fields + the markdown body +
- *  the scheduling frontmatter (`what`/`agent`). Markers are present iff scheduled. */
+/** One issue's full detail fields: the board row's fields + the canonical
+ * markdown What. Markers are present iff scheduled. */
 export interface IssueDetailIssue {
   id: string
   title: string
-  /** Markdown description body (the list view omits this; the detail loads it). */
-  body: string
+  /** Canonical markdown work definition and exact scheduled prompt. */
+  what: string
   status: IssueStatus
   priority: IssuePriority
   assignee: string
   /** Present iff the issue self-schedules. */
   when?: Schedule
-  /** Scheduled fire prompt override (frontmatter `what`), if set. */
-  what?: string
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
   /** Effective policy; legacy files project as fresh. */
@@ -234,6 +233,8 @@ export interface IssueDetailIssue {
  *  the inbox reports it produced. */
 export interface IssueDetail {
   issue: IssueDetailIssue
+  /** Structured markdown comments loaded from the adjacent JSON sidecar. */
+  comments: IssueComment[]
   /** This issue's headless runs (wsId + issueId match), newest first.
    *  Runtime-native session ids are deliberately not part of this projection. */
   runs: IssueRunRecord[]
@@ -322,7 +323,7 @@ export function issueAssigneeForWorkspace(issue: IssueRecord, workspaceTag?: str
 }
 
 /** Map a validated issue (+ its firing markers, iff scheduled) to the detail
- *  issue shape. Keeps the body and the scheduling frontmatter the board drops. */
+ *  issue shape. Keeps What and scheduling frontmatter the board drops. */
 export function detailIssue(
   issue: IssueRecord,
   markers: IssueFiringMarkers | null,
@@ -331,12 +332,11 @@ export function detailIssue(
   return {
     id: issue.id,
     title: issue.title,
-    body: issue.body,
+    what: issue.what,
     status: issue.status,
     priority: issue.priority,
     assignee: issueAssigneeForWorkspace(issue, workspaceTag),
     ...(issue.when ? { when: issue.when } : {}),
-    ...(issue.what ? { what: issue.what } : {}),
     ...(issue.agent ? { agent: issue.agent } : {}),
     execution: issueExecution(issue),
     ...(markers ? { lastFiredAtMs: markers.lastFiredAtMs, nextDueAtMs: markers.nextDueAtMs } : {}),
@@ -345,7 +345,7 @@ export function detailIssue(
 
 /** Map one validated issue (+ its firing markers, iff scheduled) to a board row.
  *  Pure: the caller resolves `markers` for scheduled issues and passes `null` for
- *  pure board work items. The markdown body is intentionally dropped. */
+ *  pure board work items. Markdown What is intentionally dropped. */
 export function snapshotBoardIssue(
   issue: IssueRecord,
   markers: IssueFiringMarkers | null,

--- a/src/workspaces/issues/comments.ts
+++ b/src/workspaces/issues/comments.ts
@@ -1,0 +1,96 @@
+/**
+ * Structured Issue comments.
+ *
+ * The Issue markdown is intentionally agent-editable and has no enforceable
+ * internal structure, so comments must not depend on a heading or HTML marker
+ * surviving an arbitrary rewrite. Each Issue therefore owns one adjacent JSON
+ * sidecar: `.alice/issues/<id>.comments.json`. Per-Issue files also prevent two
+ * concurrent workers commenting on different Issues from contending on one
+ * workspace-wide blob. If comments later become prompt context, callers can
+ * project this stable structure into markdown deliberately.
+ */
+import { randomUUID } from 'node:crypto'
+
+import { z } from 'zod'
+
+import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js'
+import { ISSUES_DIR_REL, parseIssueContent, type IssueRecord } from './declaration.js'
+
+export interface IssueComment {
+  id: string
+  author: string
+  at: string
+  markdown: string
+}
+
+const issueCommentSchema = z.object({
+  id: z.string().min(1),
+  author: z.string().min(1),
+  at: z.string().min(1),
+  markdown: z.string().min(1),
+})
+
+const issueCommentsFileSchema = z.object({
+  version: z.literal(1),
+  issueId: z.string().min(1),
+  comments: z.array(issueCommentSchema),
+})
+
+function issueRel(id: string): string {
+  return `${ISSUES_DIR_REL}/${id}.md`
+}
+
+export function issueCommentsRel(id: string): string {
+  return `${ISSUES_DIR_REL}/${id}.comments.json`
+}
+
+export async function readIssueComments(
+  wsDir: string,
+  id: string,
+): Promise<{ ok: true; comments: IssueComment[] } | { ok: false; error: string }> {
+  const raw = await readWorkspaceFile(wsDir, issueCommentsRel(id))
+  if (raw === null) return { ok: true, comments: [] }
+  try {
+    const parsed = issueCommentsFileSchema.safeParse(JSON.parse(raw))
+    if (!parsed.success) return { ok: false, error: `invalid comments sidecar: ${parsed.error.message}` }
+    if (parsed.data.issueId !== id) return { ok: false, error: `comments sidecar belongs to ${parsed.data.issueId}` }
+    return { ok: true, comments: parsed.data.comments }
+  } catch (err) {
+    return { ok: false, error: `invalid comments JSON: ${err instanceof Error ? err.message : String(err)}` }
+  }
+}
+
+export type AppendIssueCommentResult =
+  | { ok: true; issue: IssueRecord; comment: IssueComment }
+  | { ok: false; reason: 'not_found' }
+  | { ok: false; reason: 'invalid'; error: string }
+
+export async function appendIssueComment(
+  wsDir: string,
+  id: string,
+  author: string,
+  text: string,
+): Promise<AppendIssueCommentResult> {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(id)) return { ok: false, reason: 'not_found' }
+  const issueRaw = await readWorkspaceFile(wsDir, issueRel(id))
+  if (issueRaw === null) return { ok: false, reason: 'not_found' }
+  const issue = parseIssueContent(id, issueRaw)
+  if (!issue.ok) return { ok: false, reason: 'invalid', error: issue.error }
+
+  const markdown = text.trim()
+  if (!author.trim() || !markdown) {
+    return { ok: false, reason: 'invalid', error: 'author and comment markdown must be non-empty' }
+  }
+  const existing = await readIssueComments(wsDir, id)
+  if (!existing.ok) return { ok: false, reason: 'invalid', error: existing.error }
+
+  const comment: IssueComment = {
+    id: `comment-${randomUUID()}`,
+    author: author.trim(),
+    at: new Date().toISOString(),
+    markdown,
+  }
+  const content = JSON.stringify({ version: 1, issueId: id, comments: [...existing.comments, comment] }, null, 2) + '\n'
+  await writeWorkspaceFile(wsDir, issueCommentsRel(id), content)
+  return { ok: true, issue: issue.issue, comment }
+}

--- a/src/workspaces/issues/declaration.spec.ts
+++ b/src/workspaces/issues/declaration.spec.ts
@@ -87,7 +87,7 @@ describe('readWorkspaceIssues', () => {
     }
   })
 
-  it('parses a SCHEDULED issue (with when) including its body', async () => {
+  it('merges a legacy frontmatter prompt and body into canonical What', async () => {
     await writeIssue(
       'morning-research',
       fm(
@@ -114,11 +114,11 @@ describe('readWorkspaceIssues', () => {
         status: 'in_progress',
         priority: 'high',
         assignee: 'ws:auto-quant',
-        what: 'run the research routine',
+        what: 'run the research routine\n\n## Context\n\nScan overnight movers and summarize.',
         agent: 'codex',
       })
       expect(i.when).toEqual({ kind: 'every', every: '30m' })
-      expect(i.body).toBe('Scan overnight movers and summarize.')
+      expect(i.what).toBe('run the research routine\n\n## Context\n\nScan overnight movers and summarize.')
       expect(isFireable(i)).toBe(true)
     }
   })
@@ -205,7 +205,7 @@ describe('isFireable / issueFirePrompt', () => {
     if (r.ok) for (const i of r.issues) expect(isFireable(i)).toBe(false)
   })
 
-  it('fire prompt prefers `what`, else falls back to title+body, else title', async () => {
+  it('fire prompt is exactly the canonical visible What', async () => {
     await writeIssue('with-what', fm('title: T\nwhat: explicit prompt', 'ignored body'))
     await writeIssue('no-what', fm('title: Do the thing', 'with detail'))
     await writeIssue('bare', fm('title: Just a title'))
@@ -213,9 +213,18 @@ describe('isFireable / issueFirePrompt', () => {
     expect(r.ok).toBe(true)
     if (r.ok) {
       const byId = Object.fromEntries(r.issues.map((i) => [i.id, i]))
-      expect(issueFirePrompt(byId['with-what'])).toBe('explicit prompt')
-      expect(issueFirePrompt(byId['no-what'])).toBe('Do the thing\n\nwith detail')
+      expect(issueFirePrompt(byId['with-what'])).toBe('explicit prompt\n\n## Context\n\nignored body')
+      expect(issueFirePrompt(byId['no-what'])).toBe('with detail')
       expect(issueFirePrompt(byId['bare'])).toBe('Just a title')
     }
+  })
+
+  it('keeps legacy inline comments out of canonical What', async () => {
+    await writeIssue('commented', fm('title: Commented', 'Do the work.\n\n## Comments\n\n**human** · 2026-07-12T00:00:00.000Z\n\nLooks good.'))
+    const result = await readWorkspaceIssues(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.issues[0].what).toBe('Do the work.')
+    expect(issueFirePrompt(result.issues[0])).toBe('Do the work.')
   })
 })

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -15,18 +15,18 @@
  * size-capped, and isolated — one bad file is reported (not propagated), and one
  * bad workspace can't break the whole scan. Nothing here ever throws.
  *
- * File shape — YAML frontmatter + markdown body:
+ * File shape — YAML frontmatter + canonical markdown What:
  *   ---
  *   title: <required, short human title>
  *   status: backlog | todo | in_progress | done | canceled   (optional → 'todo')
  *   priority: urgent | high | medium | low | none             (optional → 'none')
  *   assignee: "human" | "ws:<tag|id>" | "unassigned"          (optional → 'unassigned')
  *   when: { kind: at, at } | { kind: every, every } | { kind: cron, cron }  (OPTIONAL — present iff scheduled)
- *   what: <optional fire prompt; if absent, the fire prompt falls back to title+body>
+ *   what: <legacy fire prompt; migrated into the markdown What body>
  *   agent: <optional adapter id for the scheduled run>
  *   execution: { mode: fresh } | { mode: resume, resumeId: <product Session id> }
  *   ---
- *   <markdown description body>
+ *   <markdown What — the exact work definition and scheduled prompt>
  *
  * `id` is the filename stem (kebab-case slug), stable; it keys the scanner's
  * last-fired marker for scheduled issues.
@@ -81,8 +81,8 @@ export const issueExecutionSchema = z.discriminatedUnion('mode', [
 export type IssueExecution = z.infer<typeof issueExecutionSchema>
 
 /**
- * The validated frontmatter of one issue. `id` and `body` are NOT here — `id`
- * comes from the filename, `body` from below the frontmatter (see IssueRecord).
+ * The validated frontmatter of one issue. `id` and `what` are NOT here — `id`
+ * comes from the filename, What from below the frontmatter (see IssueRecord).
  * Optional fields carry their board defaults so every read yields a complete row.
  */
 export const issueFrontmatterSchema = z.object({
@@ -93,7 +93,9 @@ export const issueFrontmatterSchema = z.object({
   assignee: z.string().min(1).default('unassigned'),
   /** Present iff the issue self-schedules. Absent ⇒ pure board work item. */
   when: issueWhenSchema.optional(),
-  /** Prompt fired on schedule; if absent, the fire prompt falls back to title+body. */
+  /** Legacy compatibility only. New files keep What in the markdown document
+   * below frontmatter so the human-visible work definition and runtime prompt
+   * cannot drift. Migration 0017 removes this key from existing files. */
   what: z.string().min(1).optional(),
   /** Which agent runtime to run the scheduled fire with; omitted uses the issue default / workspace default / first runtime. */
   agent: z.string().min(1).optional(),
@@ -109,14 +111,16 @@ export const issueFrontmatterSchema = z.object({
     })
   }
 })
-export type IssueFrontmatter = z.infer<typeof issueFrontmatterSchema>
+type IssueFrontmatterFile = z.infer<typeof issueFrontmatterSchema>
+export type IssueFrontmatter = Omit<IssueFrontmatterFile, 'what'>
 
-/** A fully read issue: validated frontmatter + its filename id + markdown body. */
+/** A fully read issue: validated frontmatter + filename id + markdown What. */
 export interface IssueRecord extends IssueFrontmatter {
   /** Filename stem (kebab-case slug) — stable; keys the scanner's marker. */
   id: string
-  /** Markdown description below the frontmatter (trimmed). */
-  body: string
+  /** Markdown work definition below frontmatter. For a scheduled Issue this is
+   * the exact prompt sent to the Agent Runtime. */
+  what: string
   /**
    * True when `assignee` came from the schema default rather than frontmatter.
    * Board projections can then default it to `ws:<workspace>` while still
@@ -142,13 +146,11 @@ export function isFireable(issue: IssueRecord): issue is IssueRecord & { when: S
   return issue.when !== undefined && !isTerminalStatus(issue.status)
 }
 
-/** The prompt a scheduled fire hands to the headless run: explicit `what`, else
- *  title + body, else just the title. The launcher interprets none of it. */
+/** The prompt a scheduled fire hands to the headless run. `what` is already the
+ * canonical, human-visible markdown work definition; there is no second hidden
+ * prompt field for it to disagree with. */
 export function issueFirePrompt(issue: IssueRecord): string {
-  const what = issue.what?.trim()
-  if (what) return what
-  const body = issue.body.trim()
-  return body ? `${issue.title}\n\n${body}` : issue.title
+  return issue.what
 }
 
 /** Backward-compatible effective execution policy for the scanner/UI. */
@@ -216,7 +218,7 @@ async function readOneIssue(
 }
 
 /**
- * Pure parse of one issue's file content (frontmatter + body) into a validated
+ * Pure parse of one issue's file content (frontmatter + markdown What) into a validated
  * IssueRecord — no disk IO, no size cap. The shared validation seam: the reader
  * (`readOneIssue`) calls it after the file read + size check, and the mutation
  * helper (`./mutate.ts`) calls it to re-validate the content it just wrote so
@@ -245,15 +247,44 @@ export function parseIssueContent(
     return { ok: false, error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ') }
   }
 
+  const { what: legacyWhat, ...frontmatter } = parsed.data
+  const document = splitLegacyIssueDocument(split.body)
   return {
     ok: true,
     issue: {
       id,
-      ...parsed.data,
-      body: split.body,
+      ...frontmatter,
+      what: mergeLegacyWhat(legacyWhat, document.what, frontmatter.title),
       assigneeDefaulted: !Object.prototype.hasOwnProperty.call(rawFrontmatter, 'assignee'),
     },
   }
+}
+
+/**
+ * Before comments moved to `<id>.comments.json`, the mutation helper appended
+ * them under a reserved `## Comments` heading in the Issue markdown. Keep this
+ * small compatibility splitter until every live Workspace has crossed migration
+ * 0017: legacy comments must never leak into the scheduled prompt.
+ */
+export function splitLegacyIssueDocument(body: string): { what: string; legacyComments: string } {
+  const lines = body.split(/\r?\n/)
+  const index = lines.findIndex((line) => /^##\s+Comments\s*$/.test(line.trim()))
+  if (index < 0) return { what: body.trim(), legacyComments: '' }
+  return {
+    what: lines.slice(0, index).join('\n').trim(),
+    legacyComments: lines.slice(index + 1).join('\n').trim(),
+  }
+}
+
+/** Merge the two historical work-definition locations without dropping either.
+ * The old frontmatter `what` remains the primary instruction; a distinct body
+ * becomes explicit Context. Empty legacy Issues materialize their title so the
+ * UI and runtime still agree on the exact prompt. */
+export function mergeLegacyWhat(legacyWhat: string | undefined, markdownWhat: string, title: string): string {
+  const explicit = legacyWhat?.trim() ?? ''
+  const markdown = markdownWhat.trim()
+  if (explicit && markdown && explicit !== markdown) return `${explicit}\n\n## Context\n\n${markdown}`
+  return explicit || markdown || title.trim()
 }
 
 /** Split a `---\n<yaml>\n---\n<body>` document. Line-based so a `---` inside the

--- a/src/workspaces/issues/mutate.spec.ts
+++ b/src/workspaces/issues/mutate.spec.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { readWorkspaceIssues } from './declaration.js'
+import { readIssueComments } from './comments.js'
 import { appendIssueComment, createIssue, updateIssueFields } from './mutate.js'
 
 let dir: string
@@ -39,7 +40,7 @@ describe('createIssue', () => {
     expect(issue?.title).toBe('Fix the Login Bug!')
   })
 
-  it('honors an explicit id, frontmatter fields, and a body', async () => {
+  it('honors an explicit id, frontmatter fields, and canonical What', async () => {
     const res = await createIssue(dir, {
       id: 'morning-sweep',
       title: 'Morning research sweep',
@@ -50,7 +51,6 @@ describe('createIssue', () => {
       what: 'run the research routine',
       agent: 'codex',
       execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
-      body: 'Scan overnight movers.',
     })
     expect(res.ok).toBe(true)
     const { issue } = await readBack('morning-sweep')
@@ -65,7 +65,7 @@ describe('createIssue', () => {
       execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
     })
     expect(issue?.when).toEqual({ kind: 'every', every: '30m' })
-    expect(issue?.body).toBe('Scan overnight movers.')
+    expect(issue?.what).toBe('run the research routine')
   })
 
   it('refuses to overwrite an existing issue (conflict)', async () => {
@@ -92,14 +92,13 @@ describe('createIssue', () => {
 })
 
 describe('updateIssueFields', () => {
-  it('patches status/priority/assignee/agent and preserves body + other scheduling frontmatter', async () => {
+  it('patches properties and preserves canonical What + scheduling frontmatter', async () => {
     await createIssue(dir, {
       id: 'task-1',
       title: 'Do the thing',
       when: { kind: 'every', every: '15m' },
       what: 'keep the fire prompt',
       agent: 'claude',
-      body: 'Body text to preserve.',
     })
     const res = await updateIssueFields(dir, 'task-1', {
       status: 'in_progress',
@@ -123,7 +122,7 @@ describe('updateIssueFields', () => {
       agent: 'pi',
     })
     expect(issue?.when).toEqual({ kind: 'every', every: '15m' })
-    expect(issue?.body).toBe('Body text to preserve.')
+    expect(issue?.what).toBe('keep the fire prompt')
   })
 
   it('clears an issue agent override with null', async () => {
@@ -182,29 +181,27 @@ describe('updateIssueFields', () => {
 })
 
 describe('appendIssueComment', () => {
-  it('creates a ## Comments section then appends a stamped block under it', async () => {
-    await createIssue(dir, { id: 'c1', title: 'Talk', body: 'Original description.' })
+  it('writes a structured sidecar without changing What', async () => {
+    await createIssue(dir, { id: 'c1', title: 'Talk', what: 'Original description.' })
     const res = await appendIssueComment(dir, 'c1', 'human', 'first comment')
     expect(res.ok).toBe(true)
     const { issue } = await readBack('c1')
-    expect(issue?.body).toContain('Original description.')
-    expect(issue?.body).toContain('## Comments')
-    expect(issue?.body).toContain('**human**')
-    expect(issue?.body).toContain('first comment')
+    expect(issue?.what).toBe('Original description.')
+    const comments = await readIssueComments(dir, 'c1')
+    expect(comments.ok && comments.comments).toEqual([
+      expect.objectContaining({ author: 'human', markdown: 'first comment' }),
+    ])
   })
 
-  it('appends a second comment under the same section (one heading only)', async () => {
+  it('appends comments in order to one per-Issue sidecar', async () => {
     await createIssue(dir, { id: 'c2', title: 'Talk' })
     await appendIssueComment(dir, 'c2', 'human', 'one')
     await appendIssueComment(dir, 'c2', 'ws:auto-quant', 'two')
-    const { issue } = await readBack('c2')
-    const headingCount = (issue?.body.match(/^##\s+Comments\s*$/gm) ?? []).length
-    expect(headingCount).toBe(1)
-    expect(issue?.body).toContain('one')
-    expect(issue?.body).toContain('two')
-    expect(issue?.body).toContain('**ws:auto-quant**')
-    // First comment precedes the second.
-    expect(issue!.body.indexOf('one')).toBeLessThan(issue!.body.indexOf('two'))
+    const comments = await readIssueComments(dir, 'c2')
+    expect(comments.ok && comments.comments.map((comment) => [comment.author, comment.markdown])).toEqual([
+      ['human', 'one'],
+      ['ws:auto-quant', 'two'],
+    ])
   })
 
   it('returns not_found for a missing issue', async () => {
@@ -216,8 +213,8 @@ describe('appendIssueComment', () => {
 })
 
 describe('round-trip: create → update → comment → read back', () => {
-  it('reflects every mutation through readWorkspaceIssues', async () => {
-    await createIssue(dir, { id: 'rt', title: 'Round trip', body: 'desc' })
+  it('keeps work definition and comments independently readable', async () => {
+    await createIssue(dir, { id: 'rt', title: 'Round trip', what: 'desc' })
     await updateIssueFields(dir, 'rt', { status: 'in_progress', assignee: 'human' })
     await appendIssueComment(dir, 'rt', 'human', 'looks good')
     const { issue, invalid } = await readBack('rt')
@@ -228,8 +225,8 @@ describe('round-trip: create → update → comment → read back', () => {
       status: 'in_progress',
       assignee: 'human',
     })
-    expect(issue?.body).toContain('desc')
-    expect(issue?.body).toContain('## Comments')
-    expect(issue?.body).toContain('looks good')
+    expect(issue?.what).toBe('desc')
+    const comments = await readIssueComments(dir, 'rt')
+    expect(comments.ok && comments.comments[0]).toMatchObject({ author: 'human', markdown: 'looks good' })
   })
 })

--- a/src/workspaces/issues/mutate.ts
+++ b/src/workspaces/issues/mutate.ts
@@ -6,9 +6,9 @@
  * not-found / conflict contract.
  *
  * The issue file is the single source of truth (`<wsDir>/.alice/issues/<id>.md`,
- * YAML frontmatter + markdown body, git-versioned in the workspace's own
- * checkout). Comments live in the BODY under a stable `## Comments` section — no
- * separate comment store. All writes go through `writeWorkspaceFile`
+ * YAML frontmatter + markdown What, git-versioned in the workspace's own
+ * checkout). What lives in the markdown document below frontmatter; comments
+ * live in a JSON sidecar managed by `./comments.ts`. All writes go through `writeWorkspaceFile`
  * (path-traversal guarded, working-tree only, NO auto-commit).
  *
  * Every function NEVER throws on a missing / conflicting target: it returns a
@@ -31,15 +31,14 @@ import {
   issueFrontmatterSchema,
   issueExecutionSchema,
   parseIssueContent,
+  splitLegacyIssueDocument,
   splitFrontmatter,
   type IssuePriority,
   type IssueExecution,
   type IssueRecord,
   type IssueStatus,
 } from './declaration.js'
-
-/** The heading that anchors the comment thread inside an issue's markdown body. */
-const COMMENTS_HEADING = '## Comments'
+export { appendIssueComment } from './comments.js'
 
 /** Fields a human/agent may patch on an existing issue. Most scheduling
  *  frontmatter is preserved untouched; `agent` is intentionally editable from
@@ -52,6 +51,8 @@ export interface IssueFieldPatch {
   agent?: string | null
   /** Scheduled execution owner. Use `{mode:'fresh'}` instead of deleting it. */
   execution?: IssueExecution
+  /** Canonical markdown work definition; exact scheduled prompt. */
+  what?: string
 }
 
 /** Input to `createIssue`. `id` is optional — derived as a kebab slug from the
@@ -66,6 +67,8 @@ export interface CreateIssueInput {
   what?: string
   agent?: string
   execution?: IssueExecution
+  /** @deprecated Compatibility alias for callers written before What became the
+   * sole markdown document. New callers must use `what`. */
   body?: string
 }
 
@@ -96,18 +99,22 @@ function slugify(title: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
-/** Serialize a frontmatter object + body back into the `---\n…\n---\n\n<body>`
- *  document shape the reader expects. Body is preserved verbatim (trimmed). */
-function serializeIssue(frontmatter: Record<string, unknown>, body: string): string {
+/** Serialize frontmatter + canonical What back into the Issue document. */
+function serializeIssue(frontmatter: Record<string, unknown>, what: string, legacyComments = ''): string {
   const fm = stringifyYaml(frontmatter).trimEnd()
-  const trimmed = body.trim()
+  const canonical = what.trim()
+  // Startup migration normally removes this legacy block first. Preserve it on
+  // an opportunistic mutation anyway: a partially migrated/manual test setup
+  // must never lose comments merely because somebody changed priority.
+  const comments = legacyComments.trim()
+  const trimmed = comments ? `${canonical}\n\n## Comments\n\n${comments}` : canonical
   return trimmed ? `---\n${fm}\n---\n\n${trimmed}\n` : `---\n${fm}\n---\n`
 }
 
 /**
  * Patch one or more board fields on an existing issue. Reads the file, validates
  * each patched field against the enums (assignee = non-empty string), merges
- * into the existing frontmatter (preserving `when`/`what`/`agent` + any other
+ * into the existing frontmatter (preserving `when`/`agent` + any other
  * keys), re-serializes via the `yaml` lib, and writes. Returns the re-validated
  * IssueRecord, or `not_found` when the file is absent.
  */
@@ -169,53 +176,19 @@ export async function updateIssueFields(
     }
     data.execution = execution.data
   }
+  let what = current.issue.what
+  if (patch.what !== undefined) {
+    what = patch.what.trim()
+    if (!what) return { ok: false, reason: 'invalid', error: 'what must be non-empty markdown' }
+  }
 
-  const content = serializeIssue(data, split.body)
+  // Any mutation opportunistically upgrades a legacy file. The old YAML What
+  // must not survive beside the canonical markdown What and silently diverge.
+  delete data.what
+
+  const legacyComments = splitLegacyIssueDocument(split.body).legacyComments
+  const content = serializeIssue(data, what, legacyComments)
   // Final guard: never persist a file that wouldn't read back cleanly.
-  const reparsed = parseIssueContent(id, content)
-  if (!reparsed.ok) return { ok: false, reason: 'invalid', error: reparsed.error }
-  await writeWorkspaceFile(wsDir, relFor(id), content)
-  return { ok: true, issue: reparsed.issue }
-}
-
-/**
- * Append a comment to an issue's markdown body under a stable `## Comments`
- * section (created if absent). The frontmatter is preserved byte-for-byte (a
- * comment never touches it). Each comment is a block:
- *
- *   **<author>** · <ISO timestamp>
- *
- *   <text>
- *
- * `author` is `'human'` for the HTTP/UI path, `'ws:<label>'` for the agent path.
- * Returns the re-validated record, or `not_found` when the file is absent.
- */
-export async function appendIssueComment(
-  wsDir: string,
-  id: string,
-  author: string,
-  text: string,
-): Promise<MutateResult> {
-  if (!ID_RE.test(id)) return { ok: false, reason: 'not_found' }
-  const raw = await readWorkspaceFile(wsDir, relFor(id))
-  if (raw === null) return { ok: false, reason: 'not_found' }
-
-  const split = splitFrontmatter(raw)
-  if (!split) return { ok: false, reason: 'invalid', error: 'missing YAML frontmatter' }
-  // Validate the existing file so we don't grow a comment onto a broken issue.
-  const current = parseIssueContent(id, raw)
-  if (!current.ok) return { ok: false, reason: 'invalid', error: current.error }
-
-  const stamp = new Date().toISOString()
-  const block = `**${author}** · ${stamp}\n\n${text.trim()}`
-
-  const body = split.body
-  const hasSection = /^##\s+Comments\s*$/m.test(body)
-  const base = hasSection ? body : `${body}${body ? '\n\n' : ''}${COMMENTS_HEADING}`
-  const newBody = `${base}\n\n${block}`
-
-  // Preserve the frontmatter raw (no re-serialize) — a comment is body-only.
-  const content = `---\n${split.frontmatter}\n---\n\n${newBody}\n`
   const reparsed = parseIssueContent(id, content)
   if (!reparsed.ok) return { ok: false, reason: 'invalid', error: reparsed.error }
   await writeWorkspaceFile(wsDir, relFor(id), content)
@@ -250,7 +223,6 @@ export async function createIssue(wsDir: string, input: CreateIssueInput): Promi
   if (input.priority !== undefined) data.priority = input.priority
   if (input.assignee !== undefined) data.assignee = input.assignee
   if (input.when !== undefined) data.when = input.when
-  if (input.what !== undefined) data.what = input.what
   if (input.agent !== undefined) data.agent = input.agent
   if (input.execution !== undefined) data.execution = input.execution
 
@@ -263,7 +235,8 @@ export async function createIssue(wsDir: string, input: CreateIssueInput): Promi
     }
   }
 
-  const content = serializeIssue(data, input.body ?? '')
+  const what = input.what?.trim() || input.body?.trim() || title
+  const content = serializeIssue(data, what)
   const reparsed = parseIssueContent(id, content)
   if (!reparsed.ok) return { ok: false, reason: 'invalid', error: reparsed.error }
   await writeWorkspaceFile(wsDir, relFor(id), content)

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -196,13 +196,13 @@ describe('ScheduleScanner', () => {
     expect(scanner.snapshot()!.workspaces[0].tasks.map((t) => t.id)).toEqual(['sched'])
   })
 
-  it('falls back to title+body for the fire prompt when `what` is absent', async () => {
+  it('sends the canonical markdown What without prepending the display title', async () => {
     const ws = await makeWs('w1', [
       { id: 't1', title: 'Do research', when: { kind: 'every', every: '30m' }, body: 'scan movers' },
     ])
     const { scanner, dispatch } = scannerFor([ws])
     await scanner.scan()
-    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'Do research\n\nscan movers', expect.any(Number), 't1')
+    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'scan movers', expect.any(Number), 't1')
   })
 
   it('fires a never-fired cron issue whose occurrence is within the last tick (not never)', async () => {

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -73,6 +73,7 @@ import {
   type WorkspaceSessionDirectory,
 } from './session-directory.js';
 import { completeOneShotIssueAfterRun } from './issues/auto-complete.js';
+import { readIssueComments } from './issues/comments.js';
 import type { IInboxStore } from '@/core/inbox-store.js';
 import { toSafeInboxOrigin } from '@/core/workspace-tool-center.js';
 import {
@@ -1254,8 +1255,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   // workspace, live-reads its issues, finds the matching id, enriches a scheduled
   // issue with the SAME firing math as the board (so last/next agree), and joins
   // the headless registry on wsId+issueId for the issue's run history (Activity
-  // feed). Returns null when the workspace, its issues dir, or the id is absent —
-  // the route maps that to a 404. Includes the markdown body (the list omits it).
+    // feed). Returns null when the workspace, its issues dir, or the id is absent —
+    // the route maps that to a 404. Includes canonical What (the list omits it).
   const issueDetail = async (wsId: string, id: string): Promise<IssueDetail | null> => {
     const ws = registry.get(wsId);
     if (!ws) return null;
@@ -1263,6 +1264,11 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     if (!res.ok) return null; // absent or unreadable issues dir ⇒ no such issue
     const issue = res.issues.find((i) => i.id === id);
     if (!issue) return null;
+    const commentsResult = await readIssueComments(ws.dir, issue.id);
+    const comments = commentsResult.ok ? commentsResult.comments : [];
+    if (!commentsResult.ok) {
+      launcherLogger.warn('issue.comments_invalid', { wsId: ws.id, issueId: issue.id, error: commentsResult.error });
+    }
     let markers: IssueFiringMarkers | null = null;
     if (issue.when) {
       const fired = snapshotScheduledIssue(
@@ -1300,7 +1306,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     const provenance = issueProvenanceRecords(provenanceStore.list({
       artifact: { kind: 'issue', workspaceId: ws.id, issueId: issue.id },
     }));
-    return { issue: detailIssue(issue, markers, ws.tag), runs, inboxReports, provenance };
+    return { issue: detailIssue(issue, markers, ws.tag), comments, runs, inboxReports, provenance };
   };
 
   const sessionDirectory = async (

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -141,7 +141,7 @@ When you start, or whenever you've lost the thread, scan it:
 `alice-workspace issue list` gives you titles across all workspaces. Read like a
 human — scan titles, use status/priority/assignee to judge urgency, then drill
 into those with `alice-workspace issue show --id <name>`, which returns one
-issue in full (body + run history + inbox reports). You pass the issue's
+issue in full (What + structured comments + run history + inbox reports). You pass the issue's
 **name**, not a workspace id — `show` resolves it for you.
 
 ```bash

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -13,7 +13,7 @@ import type { ScheduleWhen } from './schedule'
  * store. An issue WITH a `when` is scheduled (the scanner fires it as a
  * headless run); an issue WITHOUT `when` is a pure tracked work item.
  *
- * Phase 1 is read-only and the list does NOT carry the markdown body — the
+ * Phase 1 is read-only and the list does NOT carry markdown What — the
  * Phase 2 detail view loads that on demand.
  *
  * Demo handlers MUST import these types (do not inline an ad-hoc shape):
@@ -46,6 +46,14 @@ export interface IssueProvenanceRecord {
   action: IssueProvenanceAction
   origin: IssueProvenanceOrigin
   at: number
+}
+
+export interface IssueComment {
+  id: string
+  author: string
+  at: string
+  /** Full markdown payload. Comments deliberately do not share the agent-editable What file. */
+  markdown: string
 }
 
 export interface IssueListItem {
@@ -128,26 +136,23 @@ export interface WikilinkResolution {
 
 // ==================== Detail (Phase 2a) ====================
 // GET /api/issues/:wsId/:id — the read-only DETAIL shape: one issue's full
-// fields INCLUDING the markdown body and (iff scheduled) its firing markers +
+// fields INCLUDING markdown What and (iff scheduled) its firing markers +
 // scheduling frontmatter, plus that issue's headless run history (its Activity
 // feed). Mirrors the server's `IssueDetail` / `IssueDetailIssue` in
 // `src/workspaces/issues/board.ts`. Demo handlers MUST import these types.
 
-/** One issue's full detail fields: the board row's fields + the markdown body +
- *  the scheduling frontmatter (`what`/`agent`). Markers present iff scheduled. */
+/** One issue's full detail fields plus canonical markdown What. */
 export interface IssueDetailIssue {
   id: string
   title: string
-  /** Markdown description body (the list omits this; the detail loads it). */
-  body: string
+  /** Human-visible work definition; exact scheduled prompt. */
+  what: string
   status: IssueStatus
   priority: IssuePriority
   /** "human" | "ws:<tag|id>" | "unassigned"; missing assignee defaults to the owning workspace. */
   assignee: string
   /** Present iff the issue self-schedules. */
   when?: ScheduleWhen
-  /** Scheduled fire prompt override (frontmatter `what`), if set. */
-  what?: string
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
   /** Effective scheduled owner policy; legacy server payloads may omit it. */
@@ -161,6 +166,8 @@ export interface IssueDetailIssue {
 /** GET /api/issues/:wsId/:id — one issue + its run history (Activity feed). */
 export interface IssueDetail {
   issue: IssueDetailIssue
+  /** Structured markdown comments from `<id>.comments.json`. */
+  comments?: IssueComment[]
   /** This issue's headless runs (wsId + issueId match), newest first. */
   runs: HeadlessTaskRecord[]
   /**
@@ -182,7 +189,7 @@ export const issuesApi = {
     return fetchJson<IssueSnapshot>('/api/issues')
   },
 
-  /** Read-only detail: one issue's full fields + markdown body + its run feed. */
+  /** Read-only detail: one issue's full fields + canonical What + its run feed. */
   async getDetail(wsId: string, id: string): Promise<IssueDetail> {
     return fetchJson<IssueDetail>(
       `/api/issues/${encodeURIComponent(wsId)}/${encodeURIComponent(id)}`,
@@ -202,7 +209,7 @@ export const issuesApi = {
 
   /**
    * Human write path: patch one issue's editable fields (any subset of
-   * status / priority / assignee / agent). `agent: null` clears the scheduled
+   * status / priority / assignee / agent / what). `agent: null` clears the scheduled
    * runtime override so the workspace default applies. Returns the SAME detail
    * shape as `getDetail` so the caller can apply it directly (refetch-free).
    * Working-tree write on the server, no commit.
@@ -210,7 +217,7 @@ export const issuesApi = {
   async update(
     wsId: string,
     id: string,
-    patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution },
+    patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string },
   ): Promise<IssueDetail> {
     return fetchJson<IssueDetail>(
       `/api/issues/${encodeURIComponent(wsId)}/${encodeURIComponent(id)}`,
@@ -219,10 +226,8 @@ export const issuesApi = {
   },
 
   /**
-   * Human write path: append a comment (author fixed to "human" server-side) to
-   * the issue body's `## Comments` section. Returns the updated detail — the
-   * returned `body` already carries the new comment, so the existing markdown
-   * renderer surfaces it with no client-side re-parsing.
+   * Human write path: append a structured markdown comment (author fixed to
+   * "human" server-side) to the Issue's JSON sidecar.
    */
   async addComment(wsId: string, id: string, text: string): Promise<IssueDetail> {
     return fetchJson<IssueDetail>(

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import { ArrowLeft, Hash, History, Inbox, ListChecks, Settings, TrendingUp, UserRound, UsersRound, X } from 'lucide-react'
+import { ArrowLeft, Hash, History, Inbox, ListChecks, Pencil, Settings, TrendingUp, UserRound, UsersRound, X } from 'lucide-react'
 
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
@@ -377,7 +377,7 @@ function PropertiesRail({
   sessions: readonly WorkspaceSessionDirectoryEntry[]
   saving: boolean
   error: string | null
-  onPatch: (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution }) => void
+  onPatch: (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string }) => void
   onConfigureAgent: (agent: AgentId) => void
 }) {
   const meta = STATUS_META[issue.status]
@@ -486,10 +486,8 @@ function PropertiesRail({
 // ==================== Comment composer ====================
 
 /**
- * Human comment composer. POSTs to the comments endpoint (author = "human");
- * the response carries the updated body (with the new `## Comments` block), so
- * we hand it straight to the detail hook's `mutate` — the existing markdown
- * renderer in the main column surfaces the comment. No client-side re-parsing.
+ * Human comment composer. Comments are markdown, but persist in the structured
+ * per-Issue JSON sidecar rather than the agent-editable What document.
  */
 function CommentComposer({
   wsId,
@@ -547,6 +545,111 @@ function CommentComposer({
         >
           {sending ? 'Sending…' : 'Comment'}
         </button>
+      </div>
+    </section>
+  )
+}
+
+// ==================== Canonical What editor ====================
+
+function WhatEditor({
+  value,
+  scheduled,
+  saving,
+  onSave,
+  onWikilink,
+}: {
+  value: string
+  scheduled: boolean
+  saving: boolean
+  onSave: (what: string) => Promise<boolean>
+  onWikilink: (key: string) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [preview, setPreview] = useState(false)
+
+  useEffect(() => {
+    if (!editing) setDraft(value)
+  }, [editing, value])
+
+  const save = useCallback(async () => {
+    const what = draft.trim()
+    if (!what || saving) return
+    if (await onSave(what)) {
+      setEditing(false)
+      setPreview(false)
+    }
+  }, [draft, onSave, saving])
+
+  return (
+    <section className="mt-4 border-t border-border/60 pt-4">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted/80">What</h2>
+          <p className="mt-1 text-[11px] leading-snug text-muted/65">
+            {scheduled ? 'This exact markdown is sent to the agent on every scheduled run.' : 'The canonical markdown definition of this work item.'}
+          </p>
+        </div>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs text-muted transition-colors hover:border-accent/40 hover:text-text"
+          >
+            <Pencil size={12} /> Edit
+          </button>
+        )}
+      </div>
+      {editing ? (
+        <div>
+          <textarea
+            autoFocus
+            rows={14}
+            value={draft}
+            disabled={saving}
+            onChange={(event) => setDraft(event.target.value)}
+            className="w-full resize-y rounded-lg border border-border bg-bg px-3 py-2.5 font-mono text-[13px] leading-relaxed text-text outline-none transition-colors focus:border-accent/60 focus:shadow-[0_0_0_1px_var(--color-accent-dim)] disabled:opacity-50"
+          />
+          {preview && (
+            <div className="mt-3 rounded-lg border border-border bg-bg-secondary p-4">
+              <MarkdownContent text={draft} onWikilink={onWikilink} />
+            </div>
+          )}
+          <div className="mt-2 flex items-center justify-end gap-2">
+            <button type="button" onClick={() => setPreview((value) => !value)} className="rounded-md px-2.5 py-1.5 text-xs text-muted hover:text-text">
+              {preview ? 'Hide preview' : 'Preview'}
+            </button>
+            <button type="button" onClick={() => { setEditing(false); setDraft(value); setPreview(false) }} disabled={saving} className="rounded-md px-2.5 py-1.5 text-xs text-muted hover:text-text disabled:opacity-50">
+              Cancel
+            </button>
+            <button type="button" onClick={() => void save()} disabled={saving || !draft.trim() || draft.trim() === value.trim()} className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-bg disabled:cursor-not-allowed disabled:opacity-40">
+              {saving ? 'Saving…' : 'Save What'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <MarkdownContent text={value} onWikilink={onWikilink} />
+      )}
+    </section>
+  )
+}
+
+function IssueComments({ comments }: { comments: NonNullable<IssueDetailData['comments']> }) {
+  if (comments.length === 0) return null
+  return (
+    <section className="mt-8">
+      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted/70">Comments</h2>
+      <div className="space-y-3">
+        {comments.map((comment) => (
+          <article key={comment.id} className="rounded-lg border border-border bg-bg-secondary px-4 py-3">
+            <div className="mb-2 flex items-center justify-between gap-3 text-[11px] text-muted">
+              <span className="font-medium text-text/80">{comment.author}</span>
+              <time dateTime={comment.at}>{new Date(comment.at).toLocaleString()}</time>
+            </div>
+            <MarkdownContent text={comment.markdown} />
+          </article>
+        ))}
       </div>
     </section>
   )
@@ -836,7 +939,7 @@ function WikilinkPicker({
 
 /**
  * Linear-style issue detail (Phase 2b — interactive). Main column = title +
- * rendered markdown body (which now carries the `## Comments` section) +
+ * editable canonical What + structured markdown comments +
  * Activity feed + a comment composer. Right rail = Properties, with status /
  * priority / assignee editable inline (each write PATCHes and applies the
  * server-returned detail — authoritative, refetch-free). The scheduled agent
@@ -985,16 +1088,18 @@ export function IssueDetail({
   )
 
   const onPatch = useCallback(
-    async (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution }) => {
+    async (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string }): Promise<boolean> => {
       setSaving(true)
       setActionError(null)
       try {
         const next = await issuesApi.update(wsId, id, patch)
         mutate(next)
+        return true
       } catch (e) {
         // The selects are bound to the (unchanged) server data, so they revert
         // on their own; we just surface why.
         setActionError(e instanceof Error ? e.message : String(e))
+        return false
       } finally {
         setSaving(false)
       }
@@ -1059,6 +1164,7 @@ export function IssueDetail({
   }
 
   const { issue, runs } = data
+  const comments = data.comments ?? []
   const inboxReports = data.inboxReports ?? []
   const provenance = data.provenance ?? []
   const inquiryDescription = inquiryTarget.relation === 'owner'
@@ -1077,13 +1183,13 @@ export function IssueDetail({
             {issue.when && <CadencePill when={issue.when} />}
           </div>
           <h1 className="text-xl font-semibold text-text">{issue.title}</h1>
-          <div className="mt-4 border-t border-border/60 pt-4">
-            {issue.body.trim() ? (
-              <MarkdownContent text={issue.body} onWikilink={onWikilink} />
-            ) : (
-              <p className="text-sm text-muted">No description.</p>
-            )}
-          </div>
+          <WhatEditor
+            value={issue.what}
+            scheduled={Boolean(issue.when)}
+            saving={saving}
+            onSave={(what) => onPatch({ what })}
+            onWikilink={(key) => { void onWikilink(key) }}
+          />
           <InquiryPanel
             title="Ask about this Issue"
             description={inquiryDescription}
@@ -1117,6 +1223,7 @@ export function IssueDetail({
               </div>
             )}
           />
+          <IssueComments comments={comments} />
           <CommentComposer wsId={wsId} id={id} onPosted={mutate} />
           <ProvenanceTimeline records={provenance} onContinue={continueProvenanceSession} />
           <ActivityFeed

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -1,5 +1,5 @@
 import type { HeadlessTaskRecord } from '../../api/headless'
-import type { IssueDetail, IssueExecution, IssuePriority, IssueSnapshot, IssueStatus } from '../../api/issues'
+import type { IssueComment, IssueDetail, IssueExecution, IssuePriority, IssueSnapshot, IssueStatus } from '../../api/issues'
 import { demoInboxEntries } from './inbox'
 
 // GET /api/issues aggregates every workspace's declared issues by SCANNING
@@ -421,14 +421,18 @@ export function demoIssueDetail(wsId: string, id: string): IssueDetail | null {
   const boardIssue = findBoardIssue(wsId, id)
   if (!boardIssue) return null
   const extras = demoIssueExtras[`${wsId}/${id}`]
-  const body = extras?.body ?? `${boardIssue.title}\n\n(No description.)`
+  const legacyBody = extras?.body?.trim() ?? ''
+  const explicitWhat = extras?.what?.trim() ?? ''
+  const what = explicitWhat && legacyBody && explicitWhat !== legacyBody
+    ? `${explicitWhat}\n\n## Context\n\n${legacyBody}`
+    : explicitWhat || legacyBody || boardIssue.title
   return {
     issue: {
       ...boardIssue,
-      body,
-      ...(extras?.what ? { what: extras.what } : {}),
+      what,
       ...(extras?.agent ? { agent: extras.agent } : {}),
     },
+    comments: demoIssueComments[`${wsId}/${id}`] ?? [],
     runs: extras?.runs ?? [],
     // issue→inbox direction of the cross-link: every inbox report this issue
     // produced (server-stamped origin.issueId === id, this workspace), newest
@@ -446,20 +450,9 @@ export function demoIssueDetail(wsId: string, id: string): IssueDetail | null {
 // UI reflects edits/comments just like the real working-tree-only writes do. The
 // board snapshot is the single source of truth for status/priority/assignee
 // (GET list + GET detail both read it live, so one mutation updates both); the
-// markdown body — which now carries the appended `## Comments` section — lives in
-// the extras map, materialized on demand for rows that had no extras entry.
-
-/** Append one comment block to a markdown body, under a stable `## Comments`
- *  heading (created if absent). Mirrors the server's appendIssueComment format:
- *  `**<author>** · <ISO timestamp>` then a blank line then the text. */
-function appendCommentToBody(body: string, author: string, text: string): string {
-  const block = `**${author}** · ${new Date().toISOString()}\n\n${text}`
-  const trimmed = body.replace(/\s+$/, '')
-  const hasSection = /(^|\n)## Comments\s*(\n|$)/.test(trimmed)
-  return hasSection
-    ? `${trimmed}\n\n${block}\n`
-    : `${trimmed}\n\n## Comments\n\n${block}\n`
-}
+// What stays in the markdown fixture; comments mirror the server's independent
+// per-Issue JSON sidecar so editing one cannot corrupt the other.
+const demoIssueComments: Record<string, IssueComment[]> = {}
 
 /** PATCH backing: mutate the board issue's status/priority/assignee in place,
  *  then return the fresh detail shape (same `{ issue, runs }` as GET). Returns
@@ -467,7 +460,7 @@ function appendCommentToBody(body: string, author: string, text: string): string
 export function demoIssueUpdate(
   wsId: string,
   id: string,
-  patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution },
+  patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string },
 ): IssueDetail | null {
   const boardIssue = findBoardIssue(wsId, id)
   if (!boardIssue) return null
@@ -475,6 +468,16 @@ export function demoIssueUpdate(
   if (patch.priority !== undefined) boardIssue.priority = patch.priority
   if (patch.assignee !== undefined) boardIssue.assignee = patch.assignee
   if (patch.execution !== undefined) boardIssue.execution = patch.execution
+  if (patch.what !== undefined) {
+    const key = `${wsId}/${id}`
+    const existing = demoIssueExtras[key]
+    if (existing) {
+      existing.what = patch.what
+      existing.body = ''
+    } else {
+      demoIssueExtras[key] = { body: '', what: patch.what, runs: [] }
+    }
+  }
   if (patch.agent !== undefined) {
     if (patch.agent === null) delete boardIssue.agent
     else boardIssue.agent = patch.agent
@@ -490,9 +493,7 @@ export function demoIssueUpdate(
   return demoIssueDetail(wsId, id)
 }
 
-/** POST-comment backing: append a comment to the issue's markdown body (creating
- *  an extras entry for rows that only had the generic fallback body), then return
- *  the fresh detail shape. Returns null when the issue doesn't exist (→ 404). */
+/** POST-comment backing: append to the structured sidecar fixture. */
 export function demoIssueAddComment(
   wsId: string,
   id: string,
@@ -502,10 +503,8 @@ export function demoIssueAddComment(
   const boardIssue = findBoardIssue(wsId, id)
   if (!boardIssue) return null
   const key = `${wsId}/${id}`
-  const existing = demoIssueExtras[key]
-  const currentBody = existing?.body ?? `${boardIssue.title}\n\n(No description.)`
-  const nextBody = appendCommentToBody(currentBody, author, text)
-  if (existing) existing.body = nextBody
-  else demoIssueExtras[key] = { body: nextBody, runs: [] }
+  const comments = demoIssueComments[key] ?? []
+  comments.push({ id: `demo-comment-${comments.length + 1}`, author, at: new Date().toISOString(), markdown: text })
+  demoIssueComments[key] = comments
   return demoIssueDetail(wsId, id)
 }

--- a/ui/src/demo/handlers/issues.ts
+++ b/ui/src/demo/handlers/issues.ts
@@ -61,12 +61,13 @@ export const issuesHandlers = [
       assignee?: unknown
       agent?: unknown
       execution?: unknown
+      what?: unknown
     } | null
     if (!body || typeof body !== 'object') {
       return HttpResponse.json({ error: 'invalid_body' }, { status: 400 })
     }
 
-    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution } = {}
+    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string } = {}
     if (body.status !== undefined) {
       if (!ISSUE_STATUSES.includes(body.status as IssueStatus)) {
         return HttpResponse.json({ error: 'invalid_status' }, { status: 400 })
@@ -107,12 +108,19 @@ export const issuesHandlers = [
         return HttpResponse.json({ error: 'invalid_execution' }, { status: 400 })
       }
     }
+    if (body.what !== undefined) {
+      if (typeof body.what !== 'string' || !body.what.trim()) {
+        return HttpResponse.json({ error: 'invalid_what' }, { status: 400 })
+      }
+      patch.what = body.what.trim()
+    }
     if (
       patch.status === undefined &&
       patch.priority === undefined &&
       patch.assignee === undefined &&
       patch.agent === undefined
       && patch.execution === undefined
+      && patch.what === undefined
     ) {
       return HttpResponse.json({ error: 'no_fields' }, { status: 400 })
     }


### PR DESCRIPTION
## Summary

- make the Markdown below Issue frontmatter the single canonical `What` and exact scheduled prompt
- move comments into per-Issue `<id>.comments.json` sidecars so agent rewrites cannot corrupt comment structure
- add migration `0017` for legacy frontmatter `what`, Markdown bodies, and inline `## Comments`
- expose What editing and preview in Issue detail, with API/CLI/demo support
- update Issue authoring guidance and runtime documentation

## Why

The former `what` frontmatter and Markdown body could disagree, and agents often wrote only one. Comments also depended on a heading inside agent-editable Markdown. The new contract gives humans and runtimes one visible work definition while keeping comments structured and independent.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (2612 passed, 6 skipped)
- targeted Issue/migration suite (105 passed)
- real browser: `/issues/.../daily-close-scan` What render, edit, preview, cancel
- `pnpm electron:build`
- `pnpm electron:smoke:pty`
