### PR TITLE
feat(ui): autosave issue What inline

### DIFF
--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import { ArrowLeft, Hash, History, Inbox, ListChecks, Pencil, Settings, TrendingUp, UserRound, UsersRound, X } from 'lucide-react'
+import { ArrowLeft, Hash, History, Inbox, ListChecks, Settings, TrendingUp, UserRound, UsersRound, X } from 'lucide-react'
 
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
@@ -556,51 +556,21 @@ function CommentComposer({
 function WhatEditor({
   value,
   scheduled,
-  saving,
   onSave,
-  onWikilink,
 }: {
   value: string
   scheduled: boolean
-  saving: boolean
   onSave: (what: string) => Promise<boolean>
-  onWikilink: (key: string) => void
 }) {
-  const [editing, setEditing] = useState(false)
-
   return (
     <section className="mt-4 border-t border-border/60 pt-4">
-      <div className="mb-3 flex items-start justify-between gap-3">
-        <div>
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted/80">What</h2>
-          <p className="mt-1 text-[11px] leading-snug text-muted/65">
-            {scheduled ? 'This exact markdown is sent to the agent on every scheduled run.' : 'The canonical markdown definition of this work item.'}
-          </p>
-        </div>
-        {!editing && (
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs text-muted transition-colors hover:border-accent/40 hover:text-text"
-          >
-            <Pencil size={12} /> Edit
-          </button>
-        )}
+      <div className="mb-2">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted/80">What</h2>
+        <p className="mt-1 text-[11px] leading-snug text-muted/65">
+          {scheduled ? 'This exact markdown is sent to the agent on every scheduled run.' : 'The canonical markdown definition of this work item.'}
+        </p>
       </div>
-      {editing ? (
-        <MarkdownWhatEditor
-          value={value}
-          saving={saving}
-          onSave={async (what) => {
-            const saved = await onSave(what)
-            if (saved) setEditing(false)
-            return saved
-          }}
-          onCancel={() => setEditing(false)}
-        />
-      ) : (
-        <MarkdownContent text={value} onWikilink={onWikilink} />
-      )}
+      <MarkdownWhatEditor value={value} onSave={onSave} />
     </section>
   )
 }
@@ -1154,11 +1124,10 @@ export function IssueDetail({
           </div>
           <h1 className="text-xl font-semibold text-text">{issue.title}</h1>
           <WhatEditor
+            key={`${wsId}:${id}`}
             value={issue.what}
             scheduled={Boolean(issue.when)}
-            saving={saving}
             onSave={(what) => onPatch({ what })}
-            onWikilink={(key) => { void onWikilink(key) }}
           />
           <InquiryPanel
             title="Ask about this Issue"

--- a/ui/src/components/MarkdownWhatEditor.tsx
+++ b/ui/src/components/MarkdownWhatEditor.tsx
@@ -1,68 +1,39 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { EditorContent, useEditor, useEditorState } from '@tiptap/react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { Markdown } from '@tiptap/markdown'
-import {
-  Bold,
-  Braces,
-  Code2,
-  FileCode2,
-  Heading2,
-  Italic,
-  Link2,
-  List,
-  ListOrdered,
-  Quote,
-  Redo2,
-  Undo2,
-} from 'lucide-react'
 
-type Mode = 'rich' | 'source'
+type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error'
 
 interface MarkdownWhatEditorProps {
   value: string
-  saving: boolean
+  /** Returns true only after the server has accepted this exact Markdown. */
   onSave: (what: string) => Promise<boolean>
-  onCancel: () => void
 }
 
-interface ToolbarButtonProps {
-  label: string
-  active?: boolean
-  disabled?: boolean
-  onClick: () => void
-  children: React.ReactNode
-}
-
-function ToolbarButton({ label, active = false, disabled = false, onClick, children }: ToolbarButtonProps) {
-  return (
-    <button
-      type="button"
-      title={label}
-      aria-label={label}
-      aria-pressed={active}
-      disabled={disabled}
-      onMouseDown={(event) => event.preventDefault()}
-      onClick={onClick}
-      className={`inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-35 ${
-        active ? 'bg-accent/15 text-accent' : 'text-muted hover:bg-bg-tertiary hover:text-text'
-      }`}
-    >
-      {children}
-    </button>
-  )
-}
+const AUTOSAVE_DELAY_MS = 800
+const SAVED_LABEL_MS = 1_200
 
 /**
- * A real rich-text editing surface backed by Tiptap/ProseMirror while Markdown
- * remains the storage and API contract. Source mode is deliberately retained:
- * agents may author advanced Markdown that a visual editor cannot represent
- * perfectly, and opening the UI must never make that content inaccessible.
+ * Linear-style always-editable Issue body. Tiptap owns the visual surface while
+ * Markdown remains the persisted/API representation.
+ *
+ * Autosave is intentionally a small serial queue rather than one request per
+ * editor update. While one write is in flight, newer edits replace the queued
+ * candidate; the stale response can acknowledge its own snapshot but can never
+ * overwrite what the human is currently typing. Incoming poll/write snapshots
+ * are only applied when there are no local edits waiting to be saved.
  */
-export function MarkdownWhatEditor({ value, saving, onSave, onCancel }: MarkdownWhatEditorProps) {
-  const [mode, setMode] = useState<Mode>('rich')
-  const [source, setSource] = useState(value)
-  const [richDirty, setRichDirty] = useState(false)
+export function MarkdownWhatEditor({ value, onSave }: MarkdownWhatEditorProps) {
+  const [saveState, setSaveState] = useState<SaveState>('idle')
+  const mountedRef = useRef(true)
+  const latestRef = useRef(value)
+  const savedRef = useRef(value)
+  const saveInFlightRef = useRef(false)
+  const saveQueuedRef = useRef(false)
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const savedLabelTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const drainRef = useRef<() => Promise<void>>(async () => {})
 
   const extensions = useMemo(() => [
     StarterKit.configure({
@@ -71,122 +42,129 @@ export function MarkdownWhatEditor({ value, saving, onSave, onCancel }: Markdown
     Markdown.configure({ markedOptions: { breaks: true, gfm: true } }),
   ], [])
 
+  const clearDebounce = useCallback(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleSave = useCallback((delay = AUTOSAVE_DELAY_MS) => {
+    clearDebounce()
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null
+      void drainRef.current()
+    }, delay)
+  }, [clearDebounce])
+
   const editor = useEditor({
     extensions,
     content: value,
     contentType: 'markdown',
     immediatelyRender: false,
-    onUpdate: () => setRichDirty(true),
+    onUpdate: ({ editor: current }) => {
+      latestRef.current = current.getMarkdown()
+      saveQueuedRef.current = latestRef.current.trim() !== savedRef.current.trim()
+      setSaveState(saveQueuedRef.current ? 'dirty' : 'idle')
+      if (saveQueuedRef.current) scheduleSave()
+      else clearDebounce()
+    },
+    onBlur: () => {
+      if (!saveQueuedRef.current) return
+      clearDebounce()
+      void drainRef.current()
+    },
     editorProps: {
       attributes: {
-        'aria-label': 'Issue What rich text editor',
+        'aria-label': 'Issue What',
         spellcheck: 'true',
       },
     },
   })
 
+  const drainSave = useCallback(async () => {
+    if (saveInFlightRef.current) {
+      saveQueuedRef.current = true
+      return
+    }
+
+    const candidate = latestRef.current.trim()
+    if (!candidate || candidate === savedRef.current.trim()) {
+      saveQueuedRef.current = false
+      if (mountedRef.current) setSaveState('idle')
+      return
+    }
+
+    saveInFlightRef.current = true
+    saveQueuedRef.current = false
+    if (mountedRef.current) setSaveState('saving')
+
+    const saved = await onSave(candidate)
+    if (saved) savedRef.current = candidate
+
+    saveInFlightRef.current = false
+    const changedWhileSaving = latestRef.current.trim() !== candidate
+    const hasUnsavedEdits = latestRef.current.trim() !== savedRef.current.trim()
+    saveQueuedRef.current = hasUnsavedEdits
+
+    if (!mountedRef.current) return
+    if (changedWhileSaving) {
+      setSaveState(saved ? 'dirty' : 'error')
+      // If the debounce already fired during the request, the newest snapshot
+      // still needs a turn. A short delay also avoids hammering a failing API.
+      scheduleSave(saved ? 0 : AUTOSAVE_DELAY_MS)
+      return
+    }
+
+    if (!saved) {
+      setSaveState('error')
+      return
+    }
+
+    setSaveState('saved')
+    if (savedLabelTimerRef.current) clearTimeout(savedLabelTimerRef.current)
+    savedLabelTimerRef.current = setTimeout(() => {
+      if (mountedRef.current) setSaveState('idle')
+    }, SAVED_LABEL_MS)
+  }, [onSave, scheduleSave])
+
+  drainRef.current = drainSave
+
   useEffect(() => {
-    setSource(value)
-    setRichDirty(false)
-    editor?.commands.setContent(value, { contentType: 'markdown', emitUpdate: false })
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      clearDebounce()
+      if (savedLabelTimerRef.current) clearTimeout(savedLabelTimerRef.current)
+    }
+  }, [clearDebounce])
+
+  useEffect(() => {
+    if (!editor) return
+
+    const incoming = value.trim()
+    const hasLocalEdits = latestRef.current.trim() !== savedRef.current.trim()
+    if (saveInFlightRef.current || hasLocalEdits || incoming === savedRef.current.trim()) return
+
+    savedRef.current = value
+    latestRef.current = value
+    editor.commands.setContent(value, { contentType: 'markdown', emitUpdate: false })
+    setSaveState('idle')
   }, [editor, value])
 
-  const state = useEditorState({
-    editor,
-    selector: ({ editor: current }) => ({
-      bold: current?.isActive('bold') ?? false,
-      italic: current?.isActive('italic') ?? false,
-      code: current?.isActive('code') ?? false,
-      codeBlock: current?.isActive('codeBlock') ?? false,
-      heading: current?.isActive('heading', { level: 2 }) ?? false,
-      bulletList: current?.isActive('bulletList') ?? false,
-      orderedList: current?.isActive('orderedList') ?? false,
-      blockquote: current?.isActive('blockquote') ?? false,
-      link: current?.isActive('link') ?? false,
-      canUndo: current?.can().chain().focus().undo().run() ?? false,
-      canRedo: current?.can().chain().focus().redo().run() ?? false,
-    }),
-  })
-
-  const current = mode === 'source' ? source : editor?.getMarkdown() ?? value
-  const changed = mode === 'source' ? source.trim() !== value.trim() : richDirty
-
-  const switchMode = useCallback((next: Mode) => {
-    if (!editor || next === mode) return
-    if (next === 'source') {
-      // Do not turn harmless parser/serializer normalization into a fake edit.
-      // Until the user changes rich content, source mode shows their exact bytes.
-      setSource(richDirty ? editor.getMarkdown() : value)
-    } else {
-      editor.commands.setContent(source, { contentType: 'markdown', emitUpdate: false })
-      setRichDirty(source.trim() !== value.trim())
-      editor.commands.focus()
-    }
-    setMode(next)
-  }, [editor, mode, richDirty, source, value])
-
-  const save = useCallback(async () => {
-    const markdown = (mode === 'source' ? source : editor?.getMarkdown() ?? value).trim()
-    if (!markdown || saving) return
-    await onSave(markdown)
-  }, [editor, mode, onSave, saving, source, value])
-
-  const editLink = useCallback(() => {
-    if (!editor) return
-    const previous = editor.getAttributes('link').href as string | undefined
-    const href = window.prompt('Link URL', previous ?? 'https://')
-    if (href === null) return
-    if (!href.trim()) editor.chain().focus().extendMarkRange('link').unsetLink().run()
-    else editor.chain().focus().extendMarkRange('link').setLink({ href: href.trim() }).run()
-  }, [editor])
+  const status =
+    saveState === 'saving' ? 'Saving…'
+      : saveState === 'saved' ? 'Saved'
+        : saveState === 'error' ? 'Couldn’t save · will retry after the next edit'
+          : ''
 
   return (
-    <div className="overflow-hidden rounded-xl border border-accent/35 bg-bg shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-accent)_8%,transparent)]">
-      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border bg-bg-secondary/75 px-2 py-1.5">
-        <div className="flex flex-wrap items-center gap-0.5" aria-label="Formatting tools">
-          <ToolbarButton label="Bold" active={state?.bold} disabled={!editor || mode === 'source'} onClick={() => editor?.chain().focus().toggleBold().run()}><Bold size={15} /></ToolbarButton>
-          <ToolbarButton label="Italic" active={state?.italic} disabled={!editor || mode === 'source'} onClick={() => editor?.chain().focus().toggleItalic().run()}><Italic size={15} /></ToolbarButton>
-          <ToolbarButton label="Inline code" active={state?.code} disabled={!editor || mode === 'source'} onClick={() => editor?.chain().focus().toggleCode().run()}><Code2 size={15} /></ToolbarButton>
-          <span className="mx-1 h-5 w-px bg-border" />
-          <ToolbarButton label="Heading" active={state?.heading} disabled={!editor || mode === 'source'} onClick={() => editor?.chain().focus().toggleHeading({ level: 2 }).run()}><Heading2 size={15} /></ToolbarButton>
-          <ToolbarButton label="Bullet list" active={state?.bulletList} disabled={!editor || mode === 'source'} onClick={() => editor?.chain().focus().toggleBulletList().run()}><List size={15} /></ToolbarButton>
-          <ToolbarButton label="Ordered list" active={state?.orderedList} disabled={!editor || mode === 'source'} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><ListOrdered size={15} /></ToolbarButton>
-          <ToolbarButton label="Quote" active={state?.blockquote} disabled={!editor || mode === 'source'} onClick={() => editor?.chain().focus().toggleBlockquote().run()}><Quote size={15} /></ToolbarButton>
-          <ToolbarButton label="Code block" active={state?.codeBlock} disabled={!editor || mode === 'source'} onClick={() => editor?.chain().focus().toggleCodeBlock().run()}><FileCode2 size={15} /></ToolbarButton>
-          <ToolbarButton label="Link" active={state?.link} disabled={!editor || mode === 'source'} onClick={editLink}><Link2 size={15} /></ToolbarButton>
-          <span className="mx-1 h-5 w-px bg-border" />
-          <ToolbarButton label="Undo" disabled={!state?.canUndo || mode === 'source'} onClick={() => editor?.chain().focus().undo().run()}><Undo2 size={15} /></ToolbarButton>
-          <ToolbarButton label="Redo" disabled={!state?.canRedo || mode === 'source'} onClick={() => editor?.chain().focus().redo().run()}><Redo2 size={15} /></ToolbarButton>
-        </div>
-        <div className="inline-flex rounded-lg border border-border bg-bg p-0.5 text-[11px]">
-          <button type="button" onClick={() => switchMode('rich')} className={`rounded-md px-2 py-1 ${mode === 'rich' ? 'bg-bg-tertiary text-text' : 'text-muted hover:text-text'}`}>Visual</button>
-          <button type="button" onClick={() => switchMode('source')} className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'source' ? 'bg-bg-tertiary text-text' : 'text-muted hover:text-text'}`}><Braces size={11} /> Markdown</button>
-        </div>
-      </div>
-
-      {mode === 'rich' ? (
+    <div>
+      <div className="what-editor-shell rounded-lg border border-transparent transition-colors hover:border-border/40 focus-within:border-border/70 focus-within:bg-bg-secondary/20">
         <EditorContent editor={editor} className="markdown-content what-editor-content" />
-      ) : (
-        <textarea
-          autoFocus
-          value={source}
-          onChange={(event) => setSource(event.target.value)}
-          aria-label="Issue What Markdown source"
-          spellCheck={false}
-          className="min-h-80 w-full resize-y bg-bg px-5 py-4 font-mono text-[13px] leading-relaxed text-text outline-none"
-        />
-      )}
-
-      <div className="flex items-center justify-between gap-3 border-t border-border bg-bg-secondary/55 px-3 py-2">
-        <p className="text-[11px] text-muted/65">
-          {mode === 'rich' ? 'Formatting is saved as Markdown.' : 'Source mode preserves advanced Markdown exactly.'}
-        </p>
-        <div className="flex items-center gap-2">
-          <button type="button" onClick={onCancel} disabled={saving} className="rounded-md px-2.5 py-1.5 text-xs text-muted hover:text-text disabled:opacity-50">Cancel</button>
-          <button type="button" onClick={() => void save()} disabled={saving || !current.trim() || !changed} className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-bg transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-40">
-            {saving ? 'Saving…' : 'Save What'}
-          </button>
-        </div>
+      </div>
+      <div aria-live="polite" className={`mt-1 min-h-4 text-right text-[11px] transition-opacity ${saveState === 'error' ? 'text-red-400' : 'text-muted/60'} ${status ? 'opacity-100' : 'opacity-0'}`}>
+        {status || '\u00a0'}
       </div>
     </div>
   )

--- a/ui/src/hooks/useIssueDetail.spec.ts
+++ b/ui/src/hooks/useIssueDetail.spec.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '../api'
+import type { IssueDetail } from '../api/issues'
+import { useIssueDetail } from './useIssueDetail'
+
+vi.mock('../api', () => ({
+  api: {
+    issues: {
+      getDetail: vi.fn(),
+    },
+  },
+}))
+
+function detail(what: string): IssueDetail {
+  return {
+    issue: {
+      id: 'issue-a',
+      title: 'Issue A',
+      what,
+      status: 'todo',
+      priority: 'medium',
+      assignee: 'human',
+    },
+    runs: [],
+  }
+}
+
+describe('useIssueDetail', () => {
+  beforeEach(() => {
+    vi.mocked(api.issues.getDetail).mockReset()
+  })
+
+  it('does not let a GET started before a write replace the authoritative result', async () => {
+    let resolveStale: ((value: IssueDetail) => void) | undefined
+    vi.mocked(api.issues.getDetail).mockReturnValueOnce(new Promise((resolve) => {
+      resolveStale = resolve
+    }))
+
+    const { result, unmount } = renderHook(() => useIssueDetail('ws-a', 'issue-a'))
+
+    act(() => result.current.mutate(detail('locally saved')))
+    await act(async () => {
+      resolveStale?.(detail('stale poll'))
+      await Promise.resolve()
+    })
+
+    expect(result.current.data?.issue.what).toBe('locally saved')
+    unmount()
+  })
+})

--- a/ui/src/hooks/useIssueDetail.ts
+++ b/ui/src/hooks/useIssueDetail.ts
@@ -30,21 +30,31 @@ export function useIssueDetail(wsId: string, id: string): UseIssueDetail {
   const [data, setData] = useState<IssueDetail | null>(null)
   const [error, setError] = useState<string | null>(null)
   const mounted = useRef(true)
+  const requestKey = `${wsId}:${id}`
+  const activeKey = useRef(requestKey)
+  // A GET that started before a successful write must not land afterwards and
+  // restore its stale snapshot over the editor. Incremented by `mutate`; each
+  // poll only commits when no authoritative write has happened in between.
+  const mutationVersion = useRef(0)
 
   useEffect(() => {
     mounted.current = true
+    activeKey.current = requestKey
     // Reset so switching issues doesn't show the previous one's body.
     setData(null)
     setError(null)
     const load = async () => {
+      const startedAtMutation = mutationVersion.current
       try {
         const next = await api.issues.getDetail(wsId, id)
-        if (mounted.current) {
+        if (mounted.current && mutationVersion.current === startedAtMutation) {
           setData(next)
           setError(null)
         }
       } catch (e) {
-        if (mounted.current) setError(e instanceof Error ? e.message : String(e))
+        if (mounted.current && mutationVersion.current === startedAtMutation) {
+          setError(e instanceof Error ? e.message : String(e))
+        }
       }
     }
     void load()
@@ -53,14 +63,15 @@ export function useIssueDetail(wsId: string, id: string): UseIssueDetail {
       mounted.current = false
       clearInterval(timer)
     }
-  }, [wsId, id])
+  }, [wsId, id, requestKey])
 
   const mutate = useCallback((next: IssueDetail) => {
-    if (mounted.current) {
+    if (mounted.current && activeKey.current === requestKey) {
+      mutationVersion.current += 1
       setData(next)
       setError(null)
     }
-  }, [])
+  }, [requestKey])
 
   return { data, error, loading: data === null && error === null, mutate }
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -602,11 +602,11 @@ html[lang="ja"] .oa-onboarding-title {
 }
 
 /* Issue What visual editor. Tiptap owns the editable DOM, while these rules
-   deliberately reuse the same markdown typography as read mode so clicking
-   Edit does not feel like falling into a separate source-code application. */
+   deliberately reuse read-mode typography so the always-editable body still
+   feels like part of the Issue rather than a separate source application. */
 .what-editor-content .ProseMirror {
-  min-height: 20rem;
-  padding: 1rem 1.25rem;
+  min-height: 12rem;
+  padding: 0.75rem 1rem;
   outline: none;
   cursor: text;
 }
@@ -617,7 +617,7 @@ html[lang="ja"] .oa-onboarding-title {
   margin-bottom: 0;
 }
 .what-editor-content .ProseMirror-focused {
-  background: color-mix(in srgb, var(--color-accent) 2%, transparent);
+  background: transparent;
 }
 .what-editor-content .ProseMirror-selectednode {
   outline: 2px solid color-mix(in srgb, var(--color-accent) 45%, transparent);


### PR DESCRIPTION
## Summary
- make Issue What an always-editable visual Markdown surface with no Edit gate or formatting toolbar
- autosave after an 800ms pause and flush on blur, while serializing writes and retaining only the newest queued snapshot
- prevent stale detail polling and writes from replacing authoritative or locally pending content
- keep save feedback intentionally quiet: only Saving, Saved, or error state

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (225 files passed, 1 skipped; 2613 tests passed, 6 skipped)
- `cd ui && pnpm build`
- browser: verified the real Issue route layout and a non-persistent demo rapid-edit autosave ending on the newest snapshot
- regression test: stale GET response cannot replace a write result

## Boundary touch
- UI only; no trading, auth, credentials, migrations, runtime, or packaging behavior changed.