### PR TITLE
feat(issues): unify and coalesce activity log

### DIFF
--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -133,9 +133,13 @@ interface ProvenanceEdge {
 }
 ```
 
-Mutable artifacts retain multiple edges. Creation, later edits, publication,
-and repeated execution are different occurrences and may belong to different
-Sessions or a human.
+Mutable artifacts retain multiple meaningful edges. Creation, later editing
+sessions, publication, and repeated execution are different occurrences and may
+belong to different Sessions or a human. High-frequency `updated` writes from
+the same origin to the same artifact are one editing activity: OpenAlice
+coalesces adjacent updates within fifteen minutes instead of treating autosave or
+several small agent patches as distinct user-facing events. Intervening actions
+such as comments or a different origin always start a new activity.
 
 ## Universal Follow-up Rule
 
@@ -232,12 +236,22 @@ An Issue has two independent identity questions:
 
 Creating an Issue must explicitly choose one execution mode.
 
-Issue detail and `alice-workspace issue show` expose the immutable
-`created` / `updated` / `commented` occurrences newest-first. Session origins
-carry a product `resumeId`, so a human or agent can continue that exact author
-without learning a runtime-native session id. Missing history remains visibly
-unattributed for legacy or manual files; it is never inferred from the current
-assignee, scheduled owner, or Workspace default runtime.
+Issue detail and `alice-workspace issue show` expose `created` / `updated` /
+`commented` activity newest-first. Adjacent updates from the same origin are
+projected as one editing activity, including historical autosave records written
+before store-side coalescing existed. Session origins carry a product
+`resumeId`, so a human or agent can continue that exact author without learning
+a runtime-native session id. Missing history remains visibly unattributed for
+legacy or manual files; it is never inferred from the current assignee,
+scheduled owner, or Workspace default runtime.
+
+The Issue detail API also exposes a unified chronological `activity[]` log.
+Change activities come from the provenance store; scheduled execution
+activities come from the headless run registry. They remain authoritative in
+their own persistence systems, while the projection gives UI, CLI, and future
+automation one extensible contract for “what happened to this Issue.” New kinds
+such as Inbox delivery or schedule skips should extend this activity union
+instead of creating another parallel timeline.
 
 #### Mode A: one responsible Session
 

--- a/src/core/provenance-store.spec.ts
+++ b/src/core/provenance-store.spec.ts
@@ -67,6 +67,39 @@ describe('ArtifactProvenanceStore', () => {
     expect(value.list()).toHaveLength(1)
   })
 
+  it('coalesces adjacent activity from the same artifact, action, and origin', async () => {
+    const { path, logger, value } = await store()
+    const input = {
+      artifact: { kind: 'issue' as const, workspaceId: 'ws-1', issueId: 'i1' },
+      action: 'updated' as const,
+      origin: { kind: 'human' as const },
+    }
+    const first = await value.append({ ...input, at: 100 }, { coalesceWithinMs: 300 })
+    const second = await value.append({ ...input, at: 250 }, { coalesceWithinMs: 300 })
+
+    expect(second.id).toBe(first.id)
+    expect(value.list()).toEqual([expect.objectContaining({ id: first.id, at: 250 })])
+
+    const reloaded = await ArtifactProvenanceStore.load(path, logger)
+    expect(reloaded.list()).toEqual([expect.objectContaining({ id: first.id, at: 250 })])
+  })
+
+  it('starts a new activity after an intervening event or a different origin', async () => {
+    const { value } = await store()
+    const artifact = { kind: 'issue' as const, workspaceId: 'ws-1', issueId: 'i1' }
+    await value.append({ artifact, action: 'updated', origin: { kind: 'human' }, at: 100 }, { coalesceWithinMs: 300 })
+    await value.append({ artifact, action: 'commented', origin: { kind: 'human' }, at: 150 })
+    await value.append({ artifact, action: 'updated', origin: { kind: 'human' }, at: 200 }, { coalesceWithinMs: 300 })
+    await value.append({
+      artifact,
+      action: 'updated',
+      origin: { kind: 'external', system: 'importer' },
+      at: 250,
+    }, { coalesceWithinMs: 300 })
+
+    expect(value.list()).toHaveLength(4)
+  })
+
   it('persists a reconstruction Session without changing historical authorship', async () => {
     const { value } = await store()
     await value.append({

--- a/src/core/provenance-store.ts
+++ b/src/core/provenance-store.ts
@@ -2,8 +2,9 @@
  * Durable Session -> artifact provenance.
  *
  * `resumeId` is the product Session identity. Native runtime session ids never
- * enter this store. Records are immutable attribution occurrences; mutable
+ * enter this store. Records are durable attribution activities; mutable
  * artifacts accumulate edges instead of overwriting one "author" field.
+ * High-frequency updates may advance one activity window's timestamp.
  */
 import { randomUUID } from 'node:crypto'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
@@ -65,6 +66,14 @@ const recordSchema = z.object({
 })
 export type ProvenanceRecord = z.infer<typeof recordSchema>
 
+/** Consecutive low-level updates inside one editing session are one product
+ * activity, not one timeline row per autosave / agent patch. */
+export const ACTIVITY_UPDATE_COALESCE_MS = 15 * 60 * 1000
+
+export interface ProvenanceAppendOptions {
+  coalesceWithinMs?: number
+}
+
 export interface ProvenanceQuery {
   artifact?: ArtifactRef
   action?: ProvenanceAction
@@ -73,7 +82,10 @@ export interface ProvenanceQuery {
 }
 
 export interface IProvenanceStore {
-  append(input: Omit<ProvenanceRecord, 'id'> & { id?: string }): Promise<ProvenanceRecord>
+  append(
+    input: Omit<ProvenanceRecord, 'id'> & { id?: string },
+    options?: ProvenanceAppendOptions,
+  ): Promise<ProvenanceRecord>
   list(query?: ProvenanceQuery): ProvenanceRecord[]
   latest(query: ProvenanceQuery): ProvenanceRecord | null
 }
@@ -109,12 +121,35 @@ export class ArtifactProvenanceStore implements IProvenanceStore {
     }
   }
 
-  async append(input: Omit<ProvenanceRecord, 'id'> & { id?: string }): Promise<ProvenanceRecord> {
+  async append(
+    input: Omit<ProvenanceRecord, 'id'> & { id?: string },
+    options: ProvenanceAppendOptions = {},
+  ): Promise<ProvenanceRecord> {
     const candidate = recordSchema.parse({ ...input, id: input.id ?? randomUUID() })
     if (candidate.fingerprint) {
       const existing = this.records.find((record) => record.fingerprint === candidate.fingerprint)
       if (existing) return existing
     }
+
+    const coalesceWithinMs = options.coalesceWithinMs ?? 0
+    if (coalesceWithinMs > 0) {
+      // Coalesce only with the latest activity for this artifact. An intervening
+      // create/comment/send/etc. starts a new activity window even if an older
+      // update has the same origin.
+      const previous = this.latest({ artifact: candidate.artifact })
+      const elapsed = previous ? candidate.at - previous.at : -1
+      if (
+        previous &&
+        previous.action === candidate.action &&
+        artifactOriginsMatch(previous.origin, candidate.origin) &&
+        elapsed >= 0 && elapsed <= coalesceWithinMs
+      ) {
+        previous.at = candidate.at
+        await this.flush()
+        return previous
+      }
+    }
+
     this.records.push(candidate)
     await this.flush()
     return candidate
@@ -152,6 +187,26 @@ export class ArtifactProvenanceStore implements IProvenanceStore {
       this.logger.warn('provenance_store.flush_failed', { err })
     }
   }
+}
+
+/** Product identity equality for grouping activity without exposing runtime
+ * native ids. Session execution identifies the concrete occurrence when set. */
+export function artifactOriginsMatch(a: ArtifactOrigin, b: ArtifactOrigin): boolean {
+  if (a.kind !== b.kind) return false
+  if (a.kind === 'human' && b.kind === 'human') return true
+  if (a.kind === 'external' && b.kind === 'external') return a.system === b.system
+  if (a.kind === 'unknown' && b.kind === 'unknown') return a.reason === b.reason
+  if (a.kind === 'session' && b.kind === 'session') {
+    if (a.workspaceId !== b.workspaceId || a.resumeId !== b.resumeId || a.agent !== b.agent) return false
+    if (!a.execution || !b.execution) return a.execution === b.execution
+    if (a.execution.kind !== b.execution.kind) return false
+    return a.execution.kind === 'headless' && b.execution.kind === 'headless'
+      ? a.execution.taskId === b.execution.taskId
+      : a.execution.kind === 'interactive' && b.execution.kind === 'interactive'
+        ? a.execution.sessionRecordId === b.execution.sessionRecordId
+        : false
+  }
+  return false
 }
 
 /** Undefined revision in a query means "all revisions of this report path". */

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -191,7 +191,10 @@ describe('issue_update', () => {
     await run(issueUpdateFactory.build(context), { id: 'trail', status: 'in_progress' })
     await run(issueUpdateFactory.build(context), { id: 'missing', status: 'done' })
     expect(append).toHaveBeenCalledTimes(1)
-    expect(append).toHaveBeenCalledWith(expect.objectContaining({ action: 'updated' }))
+    expect(append).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'updated' }),
+      { coalesceWithinMs: 900000 },
+    )
   })
 
   it('errors with no fields to update', async () => {
@@ -310,6 +313,7 @@ describe('global board (ctx.board present)', () => {
       runs: [],
       inboxReports: [],
       provenance: [],
+      activity: [],
     },
   }
 
@@ -416,6 +420,7 @@ describe('global board (ctx.board present)', () => {
         id: 'p-1', action: 'created', at: 1,
         origin: { kind: 'session', workspaceId: 'ws-a', resumeId: 'resume-kind-owl-abc123', agent: 'codex' },
       }],
+      activity: [],
     }
     const context = boardCtx({ detail: async () => detail })
 

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -26,7 +26,11 @@ import { tool } from 'ai'
 import { z } from 'zod'
 
 import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
-import { sessionOriginFromInboxOrigin, type ProvenanceAction } from '../core/provenance-store.js'
+import {
+  ACTIVITY_UPDATE_COALESCE_MS,
+  sessionOriginFromInboxOrigin,
+  type ProvenanceAction,
+} from '../core/provenance-store.js'
 import { readWorkspaceFile } from '../workspaces/file-service.js'
 import {
   ISSUES_DIR_REL,
@@ -114,13 +118,18 @@ async function recordIssueProvenance(
     kind: 'unknown' as const,
     reason: 'missing-session-origin',
   }
-  await ctx.provenanceStore.append({
-    artifact: { kind: 'issue', workspaceId: ctx.workspaceId, issueId },
+  const input = {
+    artifact: { kind: 'issue' as const, workspaceId: ctx.workspaceId, issueId },
     action,
     origin,
     at: Date.now(),
     ...(action === 'created' ? { fingerprint: `issue:${ctx.workspaceId}:${issueId}:created` } : {}),
-  })
+  }
+  if (action === 'updated') {
+    await ctx.provenanceStore.append(input, { coalesceWithinMs: ACTIVITY_UPDATE_COALESCE_MS })
+  } else {
+    await ctx.provenanceStore.append(input)
+  }
 }
 
 /** Project a full IssueRecord into the compact row the tools return. */

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -63,7 +63,7 @@ function build(inboxReports: InboxEntry[] = []) {
       const issue = r.issues.find((i) => i.id === id)
       if (!issue) return null
       const comments = await readIssueComments(wsDir, id)
-      return { issue: detailIssue(issue, null), comments: comments.ok ? comments.comments : [], runs: [], inboxReports, provenance: [] }
+      return { issue: detailIssue(issue, null), comments: comments.ok ? comments.comments : [], runs: [], inboxReports, provenance: [], activity: [] }
     },
     provenanceStore: { append: appendProvenance, list: vi.fn(), latest: vi.fn() },
   } as unknown as WorkspaceService
@@ -171,7 +171,7 @@ describe('PATCH /api/issues/:wsId/:id', () => {
       artifact: { kind: 'issue', workspaceId: 'ws-1', issueId: 'i1' },
       action: 'updated',
       origin: { kind: 'human' },
-    }))
+    }), { coalesceWithinMs: 900000 })
   })
 
   it('clears the scheduled agent runtime with null', async () => {

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -24,6 +24,7 @@
  */
 import { Hono } from 'hono'
 
+import { ACTIVITY_UPDATE_COALESCE_MS } from '../../core/provenance-store.js'
 import {
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
@@ -172,10 +173,10 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
         action: 'updated',
         origin: { kind: 'human' },
         at: Date.now(),
-      })
+      }, { coalesceWithinMs: ACTIVITY_UPDATE_COALESCE_MS })
       launcherLogger.info('issue.updated', { wsId, id, fields: Object.keys(patch) })
       const detail = await svc.issueDetail(wsId, id)
-      return c.json(detail ?? { issue: res.issue, comments: [], runs: [], inboxReports: [], provenance: [] })
+      return c.json(detail ?? { issue: res.issue, comments: [], runs: [], inboxReports: [], provenance: [], activity: [] })
     } catch (err) {
       launcherLogger.warn('issue.update_failed', { wsId, id, err })
       return c.json({ error: 'write_failed', message: (err as Error).message }, 500)
@@ -216,7 +217,7 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
       })
       launcherLogger.info('issue.comment_added', { wsId, id, author: 'human' })
       const detail = await svc.issueDetail(wsId, id)
-      return c.json(detail ?? { issue: res.issue, comments: [res.comment], runs: [], inboxReports: [], provenance: [] })
+      return c.json(detail ?? { issue: res.issue, comments: [res.comment], runs: [], inboxReports: [], provenance: [], activity: [] })
     } catch (err) {
       launcherLogger.warn('issue.comment_failed', { wsId, id, err })
       return c.json({ error: 'write_failed', message: (err as Error).message }, 500)

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -6,6 +6,7 @@ import {
   detailIssue,
   flattenBoardRows,
   inboxReportsForIssue,
+  issueActivityRecords,
   issueProvenanceRecords,
   issueRunRecord,
   snapshotBoardIssue,
@@ -44,6 +45,45 @@ describe('issueProvenanceRecords', () => {
     }])
     expect(projected[0]).not.toHaveProperty('artifact')
     expect(projected[0]).not.toHaveProperty('fingerprint')
+  })
+
+  it('folds legacy autosave spam into one user-facing update activity', () => {
+    const artifact = { kind: 'issue' as const, workspaceId: 'ws-1', issueId: 'audit' }
+    const origin = { kind: 'human' as const }
+    const projected = issueProvenanceRecords([
+      { id: 'newest', artifact, action: 'updated', origin, at: 250 },
+      { id: 'middle', artifact, action: 'updated', origin, at: 200 },
+      { id: 'oldest', artifact, action: 'updated', origin, at: 100 },
+    ])
+
+    expect(projected).toEqual([{ id: 'newest', action: 'updated', origin, at: 250 }])
+  })
+
+  it('keeps separate update activities across comments', () => {
+    const artifact = { kind: 'issue' as const, workspaceId: 'ws-1', issueId: 'audit' }
+    const origin = { kind: 'human' as const }
+    const projected = issueProvenanceRecords([
+      { id: 'after', artifact, action: 'updated', origin, at: 250 },
+      { id: 'comment', artifact, action: 'commented', origin, at: 225 },
+      { id: 'before', artifact, action: 'updated', origin, at: 200 },
+    ])
+
+    expect(projected.map((record) => record.id)).toEqual(['after', 'comment', 'before'])
+  })
+})
+
+describe('issueActivityRecords', () => {
+  it('projects changes and runs into one newest-first Issue log', () => {
+    const change = { id: 'p-1', action: 'updated' as const, origin: { kind: 'human' as const }, at: 100 }
+    const run = {
+      taskId: 'run-1', resumeId: 'resume-1', wsId: 'ws-1', issueId: 'audit', agent: 'codex',
+      prompt: 'scan', status: 'done' as const, startedAt: 200, resumable: true,
+    }
+
+    expect(issueActivityRecords([change], [run])).toEqual([
+      { kind: 'run', id: 'run-1', at: 200, run },
+      { kind: 'change', ...change },
+    ])
   })
 })
 

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -12,10 +12,12 @@
  */
 
 import type { InboxEntry } from '../../core/inbox-store.js'
-import type {
-  ArtifactOrigin,
-  ProvenanceAction,
-  ProvenanceRecord,
+import {
+  ACTIVITY_UPDATE_COALESCE_MS,
+  artifactOriginsMatch,
+  type ArtifactOrigin,
+  type ProvenanceAction,
+  type ProvenanceRecord,
 } from '../../core/provenance-store.js'
 import type { Schedule } from '../../core/schedule-expr.js'
 import type {
@@ -242,9 +244,13 @@ export interface IssueDetail {
    *  `origin.issueId` is this issue, newest-first. The issue→inbox direction of
    *  the cross-link (`runs` is the run→issue one). */
   inboxReports: InboxEntry[]
-  /** Immutable attribution events for this Issue, newest first. The product
+  /** Human-readable attribution activity for this Issue, newest first. Nearby
+   *  updates from one origin are one editing activity rather than autosave spam.
    *  `resumeId` is the only conversation handle exposed for Session origins. */
   provenance: IssueProvenanceRecord[]
+  /** Unified Issue log: human/Session changes and scheduled executions share
+   * one chronological contract while retaining their authoritative stores. */
+  activity: IssueActivityRecord[]
 }
 
 export interface IssueProvenanceRecord {
@@ -254,11 +260,28 @@ export interface IssueProvenanceRecord {
   at: number
 }
 
+export type IssueActivityRecord =
+  | ({ kind: 'change' } & IssueProvenanceRecord)
+  | { kind: 'run'; id: string; at: number; run: IssueRunRecord }
+
 /** Strip persistence-only artifact/fingerprint fields from Issue detail. */
 export function issueProvenanceRecords(
   records: readonly ProvenanceRecord[],
 ): IssueProvenanceRecord[] {
-  return records.map(({ id, action, origin, at }) => ({ id, action, origin, at }))
+  const sorted = [...records].sort((a, b) => b.at - a.at)
+  const compacted: ProvenanceRecord[] = []
+  for (const record of sorted) {
+    const newer = compacted.at(-1)
+    const elapsed = newer ? newer.at - record.at : -1
+    if (
+      newer &&
+      newer.action === 'updated' && record.action === 'updated' &&
+      artifactOriginsMatch(newer.origin, record.origin) &&
+      elapsed >= 0 && elapsed <= ACTIVITY_UPDATE_COALESCE_MS
+    ) continue
+    compacted.push(record)
+  }
+  return compacted.map(({ id, action, origin, at }) => ({ id, action, origin, at }))
 }
 
 /** Agent/UI-safe projection of one execution. `resumeId` is the only public
@@ -306,6 +329,19 @@ export function issueRunRecord(task: HeadlessTaskRecord, resumable: boolean): Is
     ...(task.output !== undefined ? { output: task.output } : {}),
     resumable,
   }
+}
+
+/** One chronological Issue log assembled from durable attribution edges and
+ * the headless run registry. New activity kinds can join this projection
+ * without forcing unrelated persistence systems into one file. */
+export function issueActivityRecords(
+  changes: readonly IssueProvenanceRecord[],
+  runs: readonly IssueRunRecord[],
+): IssueActivityRecord[] {
+  return [
+    ...changes.map((change) => ({ ...change, kind: 'change' as const })),
+    ...runs.map((run) => ({ kind: 'run' as const, id: run.taskId, at: run.startedAt, run })),
+  ].sort((a, b) => b.at - a.at)
 }
 
 /** Filter a workspace's inbox entries to the ones a given issue produced

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -58,6 +58,7 @@ import {
   annotateNameCollisions,
   detailIssue,
   inboxReportsForIssue,
+  issueActivityRecords,
   issueProvenanceRecords,
   snapshotBoardIssue,
   type IssueDetail,
@@ -1306,7 +1307,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     const provenance = issueProvenanceRecords(provenanceStore.list({
       artifact: { kind: 'issue', workspaceId: ws.id, issueId: issue.id },
     }));
-    return { issue: detailIssue(issue, markers, ws.tag), comments, runs, inboxReports, provenance };
+    const activity = issueActivityRecords(provenance, runs);
+    return { issue: detailIssue(issue, markers, ws.tag), comments, runs, inboxReports, provenance, activity };
   };
 
   const sessionDirectory = async (

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -48,6 +48,12 @@ export interface IssueProvenanceRecord {
   at: number
 }
 
+/** Unified Issue log. Persistence stays domain-owned; the API supplies one
+ * chronological projection for UI, CLI, and future activity consumers. */
+export type IssueActivityRecord =
+  | ({ kind: 'change' } & IssueProvenanceRecord)
+  | { kind: 'run'; id: string; at: number; run: HeadlessTaskRecord }
+
 export interface IssueComment {
   id: string
   author: string
@@ -178,9 +184,13 @@ export interface IssueDetail {
    * issue with no reports yields an empty array.
    */
   inboxReports?: InboxEntry[]
-  /** Immutable creation/update/comment attribution, newest first. Optional for
-   * legacy/demo payloads written before provenance projection existed. */
+  /** Creation/update/comment activity, newest first. Nearby updates from one
+   * origin are coalesced into an editing activity. Optional for legacy/demo
+   * payloads written before provenance projection existed. */
   provenance?: IssueProvenanceRecord[]
+  /** Unified change + scheduled execution log. Optional for older/demo servers;
+   * the client can derive it from provenance/runs during rollout. */
+  activity?: IssueActivityRecord[]
 }
 
 export const issuesApi = {

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -7,6 +7,7 @@ import type { InboxEntry } from '../api/inbox'
 import type {
   IssueDetail as IssueDetailData,
   IssueDetailIssue,
+  IssueActivityRecord,
   IssueExecution,
   IssuePriority,
   IssueProvenanceRecord,
@@ -626,27 +627,19 @@ function RunRow({ run, onAsk }: { run: HeadlessTaskRecord; onAsk: (run: Headless
           {run.prompt}
         </p>
       )}
+      {run.output?.assistantPreview && (
+        <p className="mt-1.5 line-clamp-2 border-l-2 border-accent/25 pl-2 text-[12px] leading-snug text-muted" title={run.output.assistantPreview}>
+          {run.output.assistantPreview}
+        </p>
+      )}
+      {run.output && (run.output.toolCalls > 0 || run.output.toolFailures > 0) && (
+        <p className={`mt-1 text-[11px] ${run.output.toolFailures > 0 ? 'text-red-400' : 'text-muted/60'}`}>
+          {run.output.toolCalls} tool {run.output.toolCalls === 1 ? 'call' : 'calls'}
+          {run.output.toolFailures > 0 ? ` · ${run.output.toolFailures} failed` : ''}
+        </p>
+      )}
       {run.error && <p className="mt-1 text-[12px] text-red-400">{run.error}</p>}
     </li>
-  )
-}
-
-function ActivityFeed({ runs, onAskRun }: { runs: HeadlessTaskRecord[]; onAskRun: (run: HeadlessTaskRecord) => void }) {
-  return (
-    <section className="mt-8">
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted/70">Activity</h3>
-      {runs.length === 0 ? (
-        <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-xs text-muted">
-          No headless runs for this issue yet.
-        </p>
-      ) : (
-        <ul className="space-y-2">
-          {runs.map((run) => (
-            <RunRow key={run.taskId} run={run} onAsk={onAskRun} />
-          ))}
-        </ul>
-      )}
-    </section>
   )
 }
 
@@ -655,7 +648,7 @@ function ActivityFeed({ runs, onAskRun }: { runs: HeadlessTaskRecord[]; onAskRun
 /**
  * The inbox reports this issue produced — the issue→inbox direction of the
  * cross-link (each entry's server-stamped `origin.issueId` is this issue). The
- * run→issue direction is the Activity feed above. Each row jumps to the Inbox,
+ * run→issue direction is the unified Activity feed. Each row jumps to the Inbox,
  * selecting + marking-read that entry. Rendered only when there are reports
  * (the Activity feed already establishes the run history; an empty inbox list
  * would just be noise).
@@ -698,7 +691,7 @@ function InboxReportsSection({
   )
 }
 
-// ==================== Provenance timeline (Issue → Session) ====================
+// ==================== Issue activity (attribution + runs) ====================
 
 const PROVENANCE_ACTION_LABEL: Record<IssueProvenanceRecord['action'], string> = {
   created: 'Created',
@@ -709,12 +702,14 @@ const PROVENANCE_ACTION_LABEL: Record<IssueProvenanceRecord['action'], string> =
   reconstructed: 'Reconstructed',
 }
 
-function ProvenanceTimeline({
-  records,
+function IssueActivity({
+  activity,
   onContinue,
+  onAskRun,
 }: {
-  records: IssueProvenanceRecord[]
+  activity: IssueActivityRecord[]
   onContinue: (record: IssueProvenanceRecord) => Promise<void>
+  onAskRun: (run: HeadlessTaskRecord) => void
 }) {
   const [continuingId, setContinuingId] = useState<string | null>(null)
   const [continueError, setContinueError] = useState<string | null>(null)
@@ -733,14 +728,18 @@ function ProvenanceTimeline({
 
   return (
     <section className="mt-8">
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted/70">Provenance</h3>
-      {records.length === 0 ? (
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted/70">Activity</h3>
+      {activity.length === 0 ? (
         <p className="rounded-lg border border-dashed border-border px-4 py-4 text-center text-xs text-muted">
-          No attribution was recorded for this legacy or manually-created issue.
+          No activity has been recorded for this issue yet.
         </p>
       ) : (
         <ul className="space-y-2">
-          {records.map((record) => {
+          {activity.map((item) => {
+            if (item.kind === 'run') {
+              return <RunRow key={`run:${item.run.taskId}`} run={item.run} onAsk={onAskRun} />
+            }
+            const record = item
             const origin = record.origin
             const isSession = origin.kind === 'session'
             const originLabel = isSession
@@ -751,7 +750,7 @@ function ProvenanceTimeline({
                   ? `External · ${origin.system}`
                   : `Unknown · ${origin.reason}`
             return (
-              <li key={record.id} className="flex items-center gap-2.5 rounded-lg border border-border bg-bg-secondary px-3 py-2.5">
+              <li key={`provenance:${record.id}`} className="flex items-center gap-2.5 rounded-lg border border-border bg-bg-secondary px-3 py-2.5">
                 <History size={14} className="shrink-0 text-muted/70" aria-hidden />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
@@ -1107,6 +1106,10 @@ export function IssueDetail({
   const comments = data.comments ?? []
   const inboxReports = data.inboxReports ?? []
   const provenance = data.provenance ?? []
+  const activity = data.activity ?? [
+    ...provenance.map((record) => ({ ...record, kind: 'change' as const })),
+    ...runs.map((run) => ({ kind: 'run' as const, id: run.taskId, at: run.startedAt, run })),
+  ].sort((a, b) => b.at - a.at)
   const inquiryDescription = inquiryTarget.relation === 'owner'
     ? 'Continue the one responsible Session declared by this Issue’s execution policy.'
     : inquiryTarget.relation === 'run'
@@ -1164,9 +1167,9 @@ export function IssueDetail({
           />
           <IssueComments comments={comments} />
           <CommentComposer wsId={wsId} id={id} onPosted={mutate} />
-          <ProvenanceTimeline records={provenance} onContinue={continueProvenanceSession} />
-          <ActivityFeed
-            runs={runs}
+          <IssueActivity
+            activity={activity}
+            onContinue={continueProvenanceSession}
             onAskRun={(run) => {
               setInquiryTarget({ relation: 'run', runId: run.taskId })
               window.requestAnimationFrame(() => document.getElementById('inquiries')?.scrollIntoView({ behavior: 'smooth', block: 'center' }))

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -221,6 +221,13 @@ const demoIssueExtras: Record<string, IssueDetailExtras> = {
         finishedAt: now - HOUR + 84_000,
         durationMs: 84_000,
         exitCode: 0,
+        output: {
+          hasAssistantReply: true,
+          assistantPreview: 'Morning scan complete: three actionable gaps, led by the semiconductor cluster.',
+          blockCount: 7,
+          toolCalls: 3,
+          toolFailures: 0,
+        },
       },
       {
         taskId: 'demo-run-morning-2',
@@ -235,6 +242,12 @@ const demoIssueExtras: Record<string, IssueDetailExtras> = {
         durationMs: 12_000,
         exitCode: 1,
         error: 'market-data provider timed out (OpenBB upstream 504)',
+        output: {
+          hasAssistantReply: false,
+          blockCount: 2,
+          toolCalls: 1,
+          toolFailures: 1,
+        },
       },
       {
         taskId: 'demo-run-morning-3',
@@ -426,6 +439,7 @@ export function demoIssueDetail(wsId: string, id: string): IssueDetail | null {
   const what = explicitWhat && legacyBody && explicitWhat !== legacyBody
     ? `${explicitWhat}\n\n## Context\n\n${legacyBody}`
     : explicitWhat || legacyBody || boardIssue.title
+  const runs = extras?.runs ?? []
   return {
     issue: {
       ...boardIssue,
@@ -433,7 +447,8 @@ export function demoIssueDetail(wsId: string, id: string): IssueDetail | null {
       ...(extras?.agent ? { agent: extras.agent } : {}),
     },
     comments: demoIssueComments[`${wsId}/${id}`] ?? [],
-    runs: extras?.runs ?? [],
+    runs,
+    activity: runs.map((run) => ({ kind: 'run' as const, id: run.taskId, at: run.startedAt, run })),
     // issue→inbox direction of the cross-link: every inbox report this issue
     // produced (server-stamped origin.issueId === id, this workspace), newest
     // first. Mirrors the real route's `inboxReportsFor` (webui/routes/issues.ts).


### PR DESCRIPTION
## Summary
- replace the separate Provenance and run timelines with one chronological Issue Activity log
- expose a backend `activity[]` union whose change events come from provenance and run events come from the headless registry
- coalesce adjacent Issue updates from the same origin into a 15-minute editing activity, and compact historical autosave spam at projection time
- show scheduled run result previews plus tool-call/failure counts in Activity
- document Activity as the extensible Issue logging contract for future delivery/skip event kinds

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (225 files passed, 1 skipped; 2618 tests passed, 6 skipped)
- `cd ui && pnpm build`
- browser: real Issue now has exactly one Activity heading, zero Provenance headings, and historical updates collapsed from nine rows to two editing sessions
- browser demo: run cards show assistant preview, tool call count, tool failure count, status, duration, error, and Ask run

## Boundary touch
- Issue provenance persistence and read projection; no trading, auth, credentials, migrations, runtime process, or packaging behavior changed.