### PR TITLE
feat(issues): unify assignee and schedule ownership

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -156,7 +156,7 @@ alice-workspace issue list --mode detailed  # full global board, including low-p
 alice-workspace issue show --id <name>      # compact issue + provenance/resumeId run/report references
 alice-workspace issue show --id <name> --mode detailed  # every execution prompt + full reports
 alice-workspace issue create --title "…"    # a new issue on THIS workspace's board
-alice-workspace issue create --title "…" --when '{"kind":"every","every":"1h"}' --execution '{"mode":"resume"}'
+alice-workspace issue create --title "…" --when '{"kind":"every","every":"1h"}' --assignee session:self
 alice-workspace issue update --id <id> --status in_progress
 alice-workspace issue comment --id <id> --text "progress note / finding"
 ```
@@ -169,5 +169,6 @@ the whole board (all workspaces); `create` / `update` / `comment` write **this**
 workspace's own `.alice/issues/` files (changing a peer's board is the
 human-approved peer-edit path). The full on-disk file model + self-scheduling
 (an issue with a `when` fires a headless run) lives in the **`self-scheduling`**
-skill. New scheduled Issues must explicitly choose `execution: fresh` (a new
-Session each fire) or `execution: resume` (one accountable product Session).
+skill. `assignee` is the single ownership and dispatch contract: `workspace`
+recruits a new Session each fire, while `session:self` or
+`session:<resumeId>` keeps one accountable product Session.

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -6,8 +6,8 @@ description: >
   YAML frontmatter + one canonical markdown What. An issue WITHOUT a `when` field is
   just a tracked work item (it shows on the Issue board, the scanner ignores
   it). An issue WITH a `when` field self-schedules: the launcher scans the dir
-  and, when it's due, spawns a fresh headless run of this workspace with your
-  prompt; the run reports back to the user's Inbox. Use for: "track this",
+  and, when it's due, dispatches the Workspace or assigned product Session with
+  your prompt; the run reports back to the user's Inbox. Use for: "track this",
   "add an issue/todo", "run this every 30 minutes", "every morning before the
   open do X", "check Y each hour and ping me only if Z", "do this once at 4pm",
   "self-schedule", "set up a recurring job". Manage issues either by editing
@@ -50,7 +50,7 @@ You have two equivalent paths, and both write the **same**
    with no separate path.
 2. **Editing the file directly** with your normal file tools. Reach for this when
    you are writing rich markdown **What** or scheduling frontmatter
-   (`when` / `agent`) — the CLI verbs cover the board fields, What, and
+   (`when` / `assignee` / `agent`) — the CLI verbs cover the board fields, What, and
    comments, but the document and schedule shape read most clearly as text. The
    file is always the single source of truth either way.
 
@@ -88,7 +88,7 @@ as `--when`:
 ```bash
 alice-workspace issue create --title "Pre-market brief" --priority high \
   --when '{"kind":"cron","cron":"30 8 * * 1-5"}' \
-  --execution '{"mode":"resume"}' \
+  --assignee session:self \
   --what "Pull pre-market movers and overnight news for my watchlist, write a short brief to research/premarket.md, then run: alice-workspace inbox push --doc research/premarket.md --comments 'Pre-market brief'." \
   --agent claude
 ```
@@ -109,10 +109,8 @@ on-disk file shape the CLI and your direct edits both produce.
 title: Pre-market brief
 status: todo
 priority: high
-assignee: ws:research
+assignee: session:resume-calm-amber-river-a1b2c3
 when: { kind: cron, cron: "30 8 * * 1-5" }
-agent: claude
-execution: { mode: resume, resumeId: resume-calm-amber-river-a1b2c3 }
 ---
 
 Pull pre-market movers and overnight news for my watchlist. Every trading
@@ -138,8 +136,8 @@ touch fetching.
 ```
 
 The first self-schedules (it has `when`) and keeps one accountable product
-Session; the second is a pure work item the
-scanner ignores. Drop the `when`/`agent` lines and any issue becomes a
+Session; the second is a pure work item the scanner ignores. Drop the `when`
+line and any issue becomes a
 plain tracked item; add a `when` and it starts firing.
 
 ## Frontmatter fields
@@ -155,8 +153,13 @@ plain tracked item; add a `when` and it starts firing.
   (There is no `enabled` field — terminal status is how you pause a timer.)
 - **`priority`** *(optional, default `none`)* — `urgent`, `high`, `medium`,
   `low`, `none`. Display/sort only.
-- **`assignee`** *(optional, default `unassigned`)* — `human`, `ws:<workspace
-  tag or id>`, or `unassigned`. Display only.
+- **`assignee`** *(optional, default `workspace`)* — the single owner and
+  scheduled-dispatch policy:
+  - `workspace` recruits a new product Session for each scheduled fire;
+  - `session:<resumeId>` continues that exact accountable Session;
+  - `human` and `unassigned` are valid only for unscheduled work.
+  The CLI convenience value `session:self` resolves to the caller's concrete
+  `session:<resumeId>` before writing the file.
 - **`when`** *(OPTIONAL — present iff the issue self-schedules)* — one of:
   - `{ kind: every, every: "30m" }` — repeat on an interval (`30m`, `2h`,
     `1h30m`). Runs on the next scan, then on the interval.
@@ -165,16 +168,12 @@ plain tracked item; add a `when` and it starts firing.
     lists `1,15`, steps `*/15`). Wall-clock; waits for the next match.
   - `{ kind: at, at: "2026-03-01T13:30:00Z" }` — run ONCE at an ISO timestamp,
     then never again.
-- **`agent`** *(optional)* — which CLI runs the scheduled job; defaults to this
-  workspace's default agent. It selects the worker kind for `fresh`; a `resume`
-  owner already has an immutable runtime, so that Session's runtime wins.
-- **`execution`** *(required for newly created scheduled issues)* — choose who
-  receives each fire:
-  - `{ mode: fresh }` recruits a new product Session each time;
-  - `{ mode: resume, resumeId: <id> }` continues that exact accountable Session.
-    With `alice-workspace issue create`, pass `--execution '{"mode":"resume"}'`
-    to bind the current Session without guessing its id. Existing legacy Issues
-    that omit this field keep the historical `fresh` behavior.
+- **`agent`** *(optional)* — runtime override for `workspace`-owned scheduled
+  work; defaults to this Workspace's runtime resolution. A Session assignee
+  already has an immutable runtime, so Session-owned Issues cannot set this.
+
+The old parallel `execution` field is retired and rejected after migration;
+never write it into a new Issue.
 
 The markdown **What** below the closing `---` is the Issue's canonical work
 definition. It is useful for every Issue; when scheduled, this exact visible

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -231,10 +231,11 @@ An Issue has two independent identity questions:
 
 1. **Creation/mutation provenance:** which Session or human created and edited
    the self-describing Issue?
-2. **Execution responsibility:** should scheduled fires keep using one product
-   Session, or should the Workspace pull a fresh worker every time?
+2. **Current ownership:** is the Work item owned by one product Session or by
+   the Workspace, which recruits a new worker for each scheduled fire?
 
-Creating an Issue must explicitly choose one execution mode.
+`assignee` is the single answer to the second question; schedule is an intrinsic
+capability of that Work item, not a second ownership object.
 
 Issue detail and `alice-workspace issue show` expose `created` / `updated` /
 `commented` activity newest-first. Adjacent updates from the same origin are
@@ -256,9 +257,7 @@ instead of creating another parallel timeline.
 #### Mode A: one responsible Session
 
 ```yaml
-execution:
-  mode: resume
-  resumeId: resume-calm-amber-river-a1b2c3
+assignee: session:resume-calm-amber-river-a1b2c3
 ```
 
 - Every scheduled fire continues that exact `resumeId`.
@@ -270,15 +269,15 @@ execution:
 - If the Session becomes unresumable, the Issue becomes blocked/unavailable;
   it must not silently recruit a replacement and pretend continuity.
 
-For agent-facing `issue_create`, `execution: { mode: "resume" }` without a
-`resumeId` binds the caller's authoritative product Session; OpenAlice resolves
-and stamps the id server-side. A human UI may select an existing Session.
+For agent-facing `issue_create`, `assignee: session:self` binds the caller's
+authoritative product Session; OpenAlice resolves and persists the concrete
+`session:<resumeId>` value server-side. A human UI may select an existing
+resumable Workspace Session.
 
 #### Mode B: a fresh worker per fire
 
 ```yaml
-execution:
-  mode: fresh
+assignee: workspace
 ```
 
 - Every scheduled fire creates a new headless product Session and `resumeId`.
@@ -288,12 +287,12 @@ execution:
   a unique worker.
 - Each run keeps its own origin so a user can still ask that specific worker.
 
-The Issue's creator provenance is stamped separately in both modes. Choosing
-`fresh` for execution does not erase who designed the Issue.
+The Issue's creator provenance is stamped separately in both modes. Workspace
+ownership does not erase who designed the Issue.
 
-Existing Issues without an execution declaration retain the current fresh-run
-behavior for compatibility. New agent/UI creation should require an explicit
-choice so ownership is never accidental.
+Migration `0018_issue_assignee_ownership` removes the former `execution` field
+and converts its meaning into `assignee`; the runtime does not maintain two
+ownership contracts.
 
 Typical questions then resolve without ambiguity:
 
@@ -301,9 +300,9 @@ Typical questions then resolve without ambiguity:
 |---|---|
 | Why does this Issue exist? | Issue `created` provenance |
 | Why was its priority changed? | Matching `updated` provenance |
-| Ask the responsible owner | Declared `execution.mode: resume` Session |
+| Ask the responsible owner | Declared `session:<resumeId>` assignee |
 | Why did yesterday's report say this? | That run's `resumeId` |
-| What does the latest fresh worker think? | Explicit latest-run selection |
+| What does the latest Workspace worker think? | Explicit latest-run selection |
 
 ### Trades
 
@@ -357,12 +356,13 @@ can explain the original trigger and falsifiers from its conversational context.
 ### One recurring Issue, multiple workers
 
 A financial/industrial scan has historical Codex runs and later Pi runs. If its
-execution mode is `fresh`, each report has a different `resumeId`. “Who created
+assignee is `workspace`, each report has a different `resumeId`. “Who created
 the scan?”, “who wrote the 10 July report?”, and “who ran it most recently?” are
 three different provenance queries.
 
 If the user instead wants one analyst to accumulate memory across days, the
-Issue must declare `mode: resume` and keep one responsible `resumeId`.
+Issue must declare `assignee: session:<resumeId>` and keep one responsible
+product Session.
 
 ### Legacy Inbox with no sender Session
 
@@ -390,8 +390,8 @@ approval state, routing, fills, and slippage.
 9. Mutable artifacts retain occurrence-level provenance instead of one mutable
    “author” field.
 10. Issue creation provenance and future execution responsibility are separate.
-11. New Issues explicitly choose `resume` or `fresh`; legacy omissions preserve
-    compatible fresh behavior.
+11. Issue assignee is the only ownership/dispatch contract: `workspace` or an
+    exact `session:<resumeId>` for scheduled work.
 12. Trade decision attribution and trade execution authority remain separate.
 13. Provenance is stamped from authoritative context, not asserted by an agent.
 14. Existing UUID `resumeId`s remain valid; readable ids apply only to new
@@ -417,8 +417,7 @@ responsible?” It owns:
 - reliable propagation of `resumeId`, Workspace, runtime kind, and optional
   execution id;
 - Inbox sender attribution;
-- Issue creator/mutation attribution and explicit `resume`/`fresh` execution
-  responsibility;
+- Issue creator/mutation attribution and explicit Workspace/Session ownership;
 - report revision/write attribution where observable;
 - trade-decision correlation across the Alice -> UTA boundary;
 - read-only artifact and reverse-Session queries through
@@ -498,7 +497,7 @@ Business convenience wrappers delegate to the same shipped resolver:
 ```text
 inbox ask <entry>             -> sender Session or reconstructed Workspace Session (shipped)
 issue ask <issue> --creator   -> creation provenance (shipped)
-issue ask <issue> --owner     -> declared resume owner, or explain fresh mode (shipped)
+issue ask <issue> --owner     -> declared Session assignee, or explain Workspace ownership (shipped)
 issue ask <issue> --run-id    -> that run's Session (shipped)
 report ask <path> [revision]  -> matching writer/update occurrence
 trade ask <order> --decision  -> initiating Session
@@ -516,7 +515,7 @@ No feature should invent its own meaning of “the agent who made this.”
 | Product Session | `ResumeRegistry`, headless `resumeId`, interactive materialization | Standard origin projection and read-only lookup | Continue exact or create reconstructed Session |
 | Execution | `HeadlessTaskRegistry`, `parentTaskId`, normalized output | Bind every attributable occurrence to the execution and `resumeId` | Poll/stream the peer reply and tool activity |
 | Inbox | Server-stamped run/session origin | Safe exposure and legacy/unknown classification | Ask sender or reconstruct at Workspace |
-| Issue | `{ workspaceId, issueId }`, run and Inbox activity | Creator/mutation edges plus explicit `resume`/`fresh` responsibility | Ask creator, owner, or one selected run |
+| Issue | `{ workspaceId, issueId }`, run and Inbox activity | Creator/mutation edges plus explicit Workspace/Session ownership | Ask creator, owner, or one selected run |
 | Report | Workspace path and git repository | Revision-level creation/update attribution | Ask writer of the selected revision |
 | Trade | UTA operation/order authority | Alice Session decision correlation across the UTA boundary | Ask initiator; route execution questions to UTA evidence |
 

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -33,10 +33,9 @@ workspaces.
 title: Pre-market brief
 status: todo
 priority: high
-assignee: ws:research
+assignee: workspace
 when: { kind: cron, cron: "30 8 * * 1-5" }
 agent: pi
-execution: { mode: fresh }
 ---
 
 Pull pre-market movers and overnight news, write `research/premarket.md`,
@@ -48,20 +47,22 @@ The filename stem is the stable issue id. Frontmatter:
 - `title` — required human title.
 - `status` — `backlog | todo | in_progress | done | canceled`; default `todo`.
 - `priority` — `urgent | high | medium | low | none`; default `none`.
-- `assignee` — human/workspace display ownership.
+- `assignee` — the single ownership and dispatch contract:
+  - `workspace` means the owning Workspace recruits a new product Session for
+    every scheduled fire;
+  - `session:<resumeId>` continues one exact accountable product Session;
+  - `human` or `unassigned` is valid only for unscheduled work.
 - `when` — optional schedule:
   - `{ kind: at, at: <ISO timestamp> }`
   - `{ kind: every, every: <duration> }`
   - `{ kind: cron, cron: <5-field expression> }`
-- `agent` — optional CLI adapter id; otherwise Workspace/default resolution is
-  used. It selects the runtime for `fresh`; `resume` uses the declared Session's
-  immutable runtime.
-- `execution` — scheduled ownership: `{ mode: fresh }` creates a new product
-  Session per fire; `{ mode: resume, resumeId: <id> }` continues one exact
-  accountable Session. A new resume owner must already have captured a native
-  runtime session id; provenance-only, not-yet-resumable Sessions are rejected
-  at assignment time. Existing files without `execution` remain fresh for
-  compatibility; new agent-created schedules must choose explicitly.
+- `agent` — optional CLI adapter id for `workspace`-owned scheduled work;
+  otherwise Workspace/default resolution is used. A Session assignee already
+  owns its runtime and cannot be overridden here.
+
+Migration `0018_issue_assignee_ownership` removes the retired parallel
+`execution` field. It maps `resume` to `session:<resumeId>` and fresh/omitted
+scheduled ownership to `workspace`; the reader only accepts the new contract.
 
 The markdown below frontmatter is the Issue's canonical **What**: the work
 definition humans inspect and edit. For scheduled Issues, Alice sends this exact
@@ -85,14 +86,14 @@ Agents normally use:
 ```bash
 alice-workspace issue list
 alice-workspace issue show --id <id-or-title>
-alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --execution '{"mode":"fresh"}'
+alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee workspace
 alice-workspace issue update --id <id> --status done
 alice-workspace issue comment --id <id> --text "..."
 ```
 
 The CLI and MCP tools use the same implementation and write the same files.
 Direct file editing is also valid and is the clearest way to author rich What
-markdown plus `when` / `agent` / `execution` frontmatter.
+markdown plus `when` / `assignee` / `agent` frontmatter.
 
 Reads such as list/show aggregate all workspaces. Writes from an autonomous or
 headless run stay inside its own Workspace. Editing a peer Workspace requires
@@ -104,7 +105,7 @@ an attended, human-approved path and a commit in the peer repository.
 .alice/issues/<id>.md
   -> ScheduleScanner (~60s)
   -> due calculation from `when` + last-fired marker
-  -> execution policy selects a fresh Session or exact resumeId
+  -> assignee selects a new Workspace Session or exact resumeId
   -> headless run of the owning Workspace
   -> native agent CLI
   -> normalized reply + message/tool blocks
@@ -210,12 +211,11 @@ overlap. If server-side collection reaches its budget while a task still runs,
 use a later collect or one-shot read; agents should not manufacture shell sleep
 loops.
 
-The Issue detail UI separates human tracking properties from scheduled
-execution responsibility. Status, priority, and assignee do not select an
-agent. A scheduled Issue instead presents two explicit policies: recruit a new
-Session on every fire (`fresh`), or keep one responsible Session (`resume`).
-Only the second policy has a stable owner to ask; fresh execution exposes the
-creator and each concrete run as separate follow-up targets.
+The Issue detail UI treats scheduling as an intrinsic Work item capability.
+`assignee: workspace` recruits a new Session on every fire;
+`assignee: session:<resumeId>` keeps one responsible Session. Only the latter
+has a stable owner to ask; Workspace-owned execution exposes the creator and
+each concrete run as separate follow-up targets.
 
 Scheduling never bypasses trading approval. A headless agent may research or
 stage a trade, but execution remains behind UTA/Trading-as-Git permission and

--- a/src/migrations/0010_workspace_issues_to_markdown.spec.ts
+++ b/src/migrations/0010_workspace_issues_to_markdown.spec.ts
@@ -61,7 +61,7 @@ describe('0010 workspace issues → markdown', () => {
     expect(byId['morning-scan'].agent).toBe('codex')
     expect(byId['morning-scan'].status).toBe('todo') // board default
     expect(byId['morning-scan'].priority).toBe('none')
-    expect(byId['morning-scan'].assignee).toBe('unassigned')
+    expect(byId['morning-scan'].assignee).toBe('workspace')
 
     // enabled:false → terminal status so the schedule stops firing
     expect(byId['paused-one'].status).toBe('canceled')

--- a/src/migrations/0011_workspace_issue_assignee_defaults.spec.ts
+++ b/src/migrations/0011_workspace_issue_assignee_defaults.spec.ts
@@ -51,8 +51,8 @@ describe('0011 workspace issue assignee defaults', () => {
     const read = await readWorkspaceIssues(wsDir['chat-jul3'])
     expect(read.ok).toBe(true)
     if (!read.ok) return
-    expect(read.issues[0].assigneeDefaulted).toBe(true)
-    expect(snapshotBoardIssue(read.issues[0], null, 'chat-jul3').assignee).toBe('ws:chat-jul3')
+    expect(read.issues[0].assignee).toBe('workspace')
+    expect(snapshotBoardIssue(read.issues[0], null).assignee).toBe('workspace')
   })
 
   it('leaves explicit non-default assignees untouched and is idempotent', async () => {
@@ -66,10 +66,7 @@ describe('0011 workspace issue assignee defaults', () => {
     const read = await readWorkspaceIssues(wsDir['chat-jul4'])
     expect(read.ok).toBe(true)
     if (!read.ok) return
-    expect(Object.fromEntries(read.issues.map((issue) => [issue.id, issue.assignee]))).toEqual({
-      human: 'human',
-      workspace: 'ws:chat-jul4',
-    })
+    expect(read.issues.find((issue) => issue.id === 'human')?.assignee).toBe('human')
   })
 
   it('skips malformed issue files without blocking other files', async () => {

--- a/src/migrations/0018_issue_assignee_ownership.spec.ts
+++ b/src/migrations/0018_issue_assignee_ownership.spec.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { readWorkspaceIssues } from '@/workspaces/issues/declaration.js'
+
+import { migrateIssueAssigneeOwnership } from './0018_issue_assignee_ownership/index.js'
+
+let root: string
+let wsDir: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'mig0018-'))
+  wsDir = join(root, 'workspaces', 'research')
+  await mkdir(join(wsDir, '.alice', 'issues'), { recursive: true })
+  await writeFile(join(root, 'workspaces.json'), JSON.stringify({
+    version: 1,
+    workspaces: [{ id: 'research', tag: 'research', dir: wsDir, agents: [] }],
+  }), 'utf8')
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('0018 Issue assignee ownership', () => {
+  it('folds resume/fresh execution into assignee and removes the parallel field', async () => {
+    await writeFile(join(wsDir, '.alice', 'issues', 'owned.md'), `---
+title: Owned
+assignee: ws:research
+when: { kind: every, every: 1h }
+agent: codex
+execution: { mode: resume, resumeId: resume-calm-cedar-a1b2c3 }
+---
+
+Do the work.
+`, 'utf8')
+    await writeFile(join(wsDir, '.alice', 'issues', 'fresh.md'), `---
+title: Fresh
+assignee: human
+when: { kind: cron, cron: "0 9 * * 1-5" }
+execution: { mode: fresh }
+---
+
+Do fresh work.
+`, 'utf8')
+
+    expect(await migrateIssueAssigneeOwnership(root)).toEqual({ updated: 2, workspaces: 1 })
+
+    const owned = await readFile(join(wsDir, '.alice', 'issues', 'owned.md'), 'utf8')
+    expect(owned).toContain('assignee: session:resume-calm-cedar-a1b2c3')
+    expect(owned).not.toMatch(/^execution:/m)
+    expect(owned).not.toMatch(/^agent:/m)
+
+    const fresh = await readFile(join(wsDir, '.alice', 'issues', 'fresh.md'), 'utf8')
+    expect(fresh).toContain('assignee: workspace')
+    expect(fresh).not.toMatch(/^execution:/m)
+
+    const issues = await readWorkspaceIssues(wsDir)
+    expect(issues.ok).toBe(true)
+    if (!issues.ok) return
+    expect(issues.issues.map((issue) => [issue.id, issue.assignee])).toEqual([
+      ['fresh', 'workspace'],
+      ['owned', 'session:resume-calm-cedar-a1b2c3'],
+    ])
+
+    expect(await migrateIssueAssigneeOwnership(root)).toEqual({ updated: 0, workspaces: 0 })
+  })
+
+  it('normalizes old workspace labels while preserving unscheduled human ownership', async () => {
+    await writeFile(join(wsDir, '.alice', 'issues', 'workspace.md'), `---
+title: Workspace
+assignee: ws:research
+---
+
+Workspace-owned.
+`, 'utf8')
+    await writeFile(join(wsDir, '.alice', 'issues', 'human.md'), `---
+title: Human
+assignee: human
+---
+
+Human-owned.
+`, 'utf8')
+
+    await migrateIssueAssigneeOwnership(root)
+    const issues = await readWorkspaceIssues(wsDir)
+    expect(issues.ok).toBe(true)
+    if (!issues.ok) return
+    expect(issues.issues.map((issue) => [issue.id, issue.assignee])).toEqual([
+      ['human', 'human'],
+      ['workspace', 'workspace'],
+    ])
+  })
+})

--- a/src/migrations/0018_issue_assignee_ownership/index.ts
+++ b/src/migrations/0018_issue_assignee_ownership/index.ts
@@ -1,0 +1,129 @@
+/**
+ * 0018_issue_assignee_ownership
+ *
+ * Replace the parallel `assignee` + `execution` Issue ownership model with one
+ * assignee contract:
+ *   workspace | human | unassigned | session:<resumeId>
+ *
+ * Scheduled Issues are always workspace- or Session-owned. A Session owns its
+ * runtime, so the old top-level agent override is removed in that case.
+ */
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+
+import type { Migration } from '../types.js'
+
+interface WorkspaceMeta { dir?: unknown }
+
+function defaultLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+function splitFrontmatter(raw: string): { frontmatter: string; body: string } | null {
+  const lines = raw.replace(/^\uFEFF/, '').split(/\r?\n/)
+  if (lines[0]?.trim() !== '---') return null
+  const end = lines.findIndex((line, index) => index > 0 && line.trim() === '---')
+  if (end < 0) return null
+  return { frontmatter: lines.slice(1, end).join('\n'), body: lines.slice(end + 1).join('\n') }
+}
+
+function sessionAssignee(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return /^session:[^\s:][^\s]*$/.test(trimmed) ? trimmed : null
+}
+
+function migratedAssignee(frontmatter: Record<string, unknown>): string {
+  const execution = frontmatter.execution
+  if (execution && typeof execution === 'object' && !Array.isArray(execution)) {
+    const record = execution as Record<string, unknown>
+    if (record.mode === 'resume' && typeof record.resumeId === 'string' && record.resumeId.trim()) {
+      return `session:${record.resumeId.trim()}`
+    }
+  }
+
+  const existingSession = sessionAssignee(frontmatter.assignee)
+  if (existingSession) return existingSession
+  if (frontmatter.when !== undefined) return 'workspace'
+  if (frontmatter.assignee === 'human' || frontmatter.assignee === 'unassigned') {
+    return frontmatter.assignee
+  }
+  return 'workspace'
+}
+
+async function writeAtomic(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const temp = join(dirname(path), `.${randomUUID()}.tmp`)
+  await writeFile(temp, content, 'utf8')
+  await rename(temp, path)
+}
+
+async function normalizeIssue(path: string): Promise<boolean> {
+  const raw = await readFile(path, 'utf8')
+  const split = splitFrontmatter(raw)
+  if (!split) return false
+
+  let parsed: unknown
+  try { parsed = parseYaml(split.frontmatter) } catch { return false }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return false
+
+  const frontmatter = parsed as Record<string, unknown>
+  const assignee = migratedAssignee(frontmatter)
+  frontmatter.assignee = assignee
+  delete frontmatter.execution
+  if (assignee.startsWith('session:')) delete frontmatter.agent
+
+  const fm = stringifyYaml(frontmatter).trimEnd()
+  const body = split.body.startsWith('\n') ? split.body : `\n${split.body}`
+  const content = `---\n${fm}\n---${body}`
+  if (content === raw) return false
+  await writeAtomic(path, content)
+  return true
+}
+
+export async function migrateIssueAssigneeOwnership(
+  launcherRoot: string = defaultLauncherRoot(),
+): Promise<{ updated: number; workspaces: number }> {
+  let registry: { workspaces?: WorkspaceMeta[] }
+  try { registry = JSON.parse(await readFile(join(launcherRoot, 'workspaces.json'), 'utf8')) as typeof registry }
+  catch { return { updated: 0, workspaces: 0 } }
+
+  const dirs = Array.isArray(registry.workspaces)
+    ? registry.workspaces.map((workspace) => typeof workspace.dir === 'string' ? workspace.dir : '').filter(Boolean)
+    : []
+  let updated = 0
+  let workspaces = 0
+  for (const dir of dirs) {
+    const issuesDir = join(dir, '.alice', 'issues')
+    let files: string[]
+    try { files = (await readdir(issuesDir)).filter((name) => name.toLowerCase().endsWith('.md')) }
+    catch { continue }
+    let touched = false
+    for (const file of files) {
+      try {
+        if (await normalizeIssue(join(issuesDir, file))) {
+          updated++
+          touched = true
+        }
+      } catch (err) {
+        console.log(`[migration 0018] skipped ${join(issuesDir, file)}: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+    if (touched) workspaces++
+  }
+  return { updated, workspaces }
+}
+
+export const migration: Migration = {
+  id: '0018_issue_assignee_ownership',
+  appVersion: '0.75.0-beta',
+  introducedAt: '2026-07-12',
+  affects: ['workspaces/<id>/.alice/issues/*.md'],
+  summary: 'Replace Issue execution ownership with one workspace, human, unassigned, or Session assignee.',
+  rationale: 'Schedule is an intrinsic Issue capability; assignee must be the single ownership and dispatch contract.',
+  up: async () => { await migrateIssueAssigneeOwnership() },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -17,3 +17,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0015_resume_identity_registry` | 0.75.0-beta | 2026-07-11 | workspaces/state/resume-identities.json, workspaces/state/sessions/*.json | Create the backend resumeId to native runtime session-id registry. |
 | `0016_artifact_provenance_store` | 0.75.0-beta | 2026-07-11 | workspaces/state/artifact-provenance.json | Create the durable product Session to artifact provenance store. |
 | `0017_issue_what_and_comment_sidecars` | 0.75.0-beta | 2026-07-12 | workspaces/<id>/.alice/issues/*.md, workspaces/<id>/.alice/issues/*.comments.json | Make markdown What the sole Issue work definition and move comments into structured per-Issue JSON sidecars. |
+| `0018_issue_assignee_ownership` | 0.75.0-beta | 2026-07-12 | workspaces/<id>/.alice/issues/*.md | Replace Issue execution ownership with one workspace, human, unassigned, or Session assignee. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -29,6 +29,7 @@ import { migration as migration_0014_headless_resume_identity } from './0014_hea
 import { migration as migration_0015_resume_identity_registry } from './0015_resume_identity_registry/index.js'
 import { migration as migration_0016_artifact_provenance_store } from './0016_artifact_provenance_store/index.js'
 import { migration as migration_0017_issue_what_and_comment_sidecars } from './0017_issue_what_and_comment_sidecars/index.js'
+import { migration as migration_0018_issue_assignee_ownership } from './0018_issue_assignee_ownership/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -41,4 +42,5 @@ export const REGISTRY: Migration[] = [
   migration_0015_resume_identity_registry,
   migration_0016_artifact_provenance_store,
   migration_0017_issue_what_and_comment_sidecars,
+  migration_0018_issue_assignee_ownership,
 ]

--- a/src/tool/conversation-artifacts.spec.ts
+++ b/src/tool/conversation-artifacts.spec.ts
@@ -85,14 +85,14 @@ describe('inbox_ask', () => {
 })
 
 function issueContext(opts: {
-  execution?: { mode: 'fresh' } | { mode: 'resume'; resumeId: string }
+  assignee?: string
   runs?: Array<{ taskId: string; resumeId: string }>
 } = {}) {
   const ask = dispatchedAsk()
   const detail = {
     issue: {
       id: 'audit', title: 'Audit', body: '', status: 'todo', priority: 'none',
-      assignee: 'ws:peer', execution: opts.execution ?? { mode: 'fresh' },
+      assignee: opts.assignee ?? 'workspace',
     },
     runs: (opts.runs ?? []).map((run) => ({
       ...run,
@@ -130,7 +130,7 @@ describe('issue_ask', () => {
 
   it('asks the declared stable owner by resumeId', async () => {
     const { ctx, ask } = issueContext({
-      execution: { mode: 'resume', resumeId: 'resume-owner' },
+      assignee: 'session:resume-owner',
     })
     await run(issueAskFactory.build(ctx), { id: 'audit', owner: true, prompt: 'status?' })
     expect(ask).toHaveBeenCalledWith(expect.objectContaining({
@@ -144,7 +144,7 @@ describe('issue_ask', () => {
       id: 'audit', owner: true, prompt: 'status?',
     })).resolves.toMatchObject({
       ok: false,
-      error: expect.stringContaining('has no stable owner'),
+      error: expect.stringContaining('has no stable Session owner'),
     })
     expect(ask).not.toHaveBeenCalled()
   })

--- a/src/tool/conversation-artifacts.ts
+++ b/src/tool/conversation-artifacts.ts
@@ -6,6 +6,7 @@ import {
   type WorkspaceToolContext,
   type WorkspaceToolFactory,
 } from '../core/workspace-tool-center.js'
+import { issueAssigneeResumeId } from '../workspaces/issues/declaration.js'
 import {
   askWorkspaceConversation,
   conversationAskCommonShape,
@@ -130,15 +131,16 @@ export const issueAskFactory: WorkspaceToolFactory = {
             target = { kind: 'resume' as const, resumeId: run.resumeId }
             relation = 'run'
           } else if (owner) {
-            if (detail.issue.execution.mode !== 'resume') {
+            const resumeId = issueAssigneeResumeId(detail.issue.assignee)
+            if (!resumeId) {
               return {
                 ok: false as const,
-                error: 'this Issue uses fresh execution and has no stable owner; ask --creator or choose --run-id',
+                error: 'this Issue is assigned to its Workspace and has no stable Session owner; ask --creator or choose --run-id',
               }
             }
             target = {
               kind: 'resume' as const,
-              resumeId: detail.issue.execution.resumeId,
+              resumeId,
             }
             relation = 'owner'
           } else {

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -59,7 +59,7 @@ describe('issue_create', () => {
   it('creates an issue, stamps the workspace assignee, and is reachable via the reader', async () => {
     const res = await run(issueCreateFactory.build(ctx()), { title: 'Fix the thing' })
     expect(res.ok).toBe(true)
-    expect(res.issue).toMatchObject({ id: 'fix-the-thing', title: 'Fix the thing', assignee: 'ws:auto-quant' })
+    expect(res.issue).toMatchObject({ id: 'fix-the-thing', title: 'Fix the thing', assignee: 'workspace' })
     const issue = await readBack('fix-the-thing')
     expect(issue?.title).toBe('Fix the thing')
   })
@@ -96,23 +96,14 @@ describe('issue_create', () => {
     expect(res.error).toMatch(/already exists/)
   })
 
-  it('requires scheduled creators to choose fresh or resume ownership', async () => {
-    const rejected = await run(issueCreateFactory.build(ctx()), {
-      id: 'ambiguous-owner',
-      title: 'Ambiguous owner',
-      when: { kind: 'every', every: '30m' },
-    })
-    expect(rejected.ok).toBe(false)
-    expect(rejected.error).toMatch(/explicitly choose/)
-
+  it('defaults scheduled work to Workspace ownership', async () => {
     const created = await run(issueCreateFactory.build(ctx()), {
       id: 'fresh-owner',
       title: 'Fresh owner',
       when: { kind: 'every', every: '30m' },
-      execution: { mode: 'fresh' },
     })
     expect(created.ok).toBe(true)
-    expect((await readBack('fresh-owner'))?.execution).toEqual({ mode: 'fresh' })
+    expect((await readBack('fresh-owner'))?.assignee).toBe('workspace')
   })
 
   it('binds resume ownership to the server-attributed current Session', async () => {
@@ -128,11 +119,11 @@ describe('issue_create', () => {
       id: 'owned-schedule',
       title: 'Owned schedule',
       when: { kind: 'every', every: '30m' },
-      execution: { mode: 'resume' },
+      assignee: 'session:self',
     })
     expect(created.ok).toBe(true)
-    expect((await readBack('owned-schedule'))?.execution)
-      .toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
+    expect((await readBack('owned-schedule'))?.assignee)
+      .toBe('session:resume-kind-owl-abc123')
   })
 
   it('refuses to assign a Session from another workspace', async () => {
@@ -143,7 +134,7 @@ describe('issue_create', () => {
       id: 'foreign-owner',
       title: 'Foreign owner',
       when: { kind: 'every', every: '30m' },
-      execution: { mode: 'resume', resumeId: 'resume-peer' },
+      assignee: 'session:resume-peer',
     })
     expect(result.ok).toBe(false)
     expect(result.error).toMatch(/another workspace/)
@@ -157,7 +148,7 @@ describe('issue_create', () => {
       id: 'unready-owner',
       title: 'Unready owner',
       when: { kind: 'every', every: '30m' },
-      execution: { mode: 'resume', resumeId: 'resume-unready' },
+      assignee: 'session:resume-unready',
     })
     expect(result.ok).toBe(false)
     expect(result.error).toMatch(/not resumable yet/)
@@ -170,7 +161,7 @@ describe('issue_update', () => {
       id: 'sched',
       title: 'scheduled work',
       when: { kind: 'every', every: '30m' },
-      execution: { mode: 'fresh' },
+      assignee: 'workspace',
       what: 'keep me',
     })
     const res = await run(issueUpdateFactory.build(ctx()), {
@@ -264,14 +255,13 @@ describe('global board (ctx.board present)', () => {
         tag: 'auto-quant',
         status: 'ok',
         issues: [
-          { id: 'alpha', title: 'Alpha', status: 'todo', priority: 'high', assignee: 'human', execution: { mode: 'fresh' } },
+          { id: 'alpha', title: 'Alpha', status: 'todo', priority: 'high', assignee: 'human' },
           {
             id: 'shared-a',
             title: 'Shared',
             status: 'in_progress',
             priority: 'none',
-            assignee: 'ws:auto-quant',
-            execution: { mode: 'fresh' },
+            assignee: 'workspace',
             when: { kind: 'every', every: '30m' },
             nameCollision: true,
           },
@@ -288,7 +278,6 @@ describe('global board (ctx.board present)', () => {
             status: 'todo',
             priority: 'low',
             assignee: 'unassigned',
-            execution: { mode: 'fresh' },
             nameCollision: true,
           },
         ],
@@ -307,7 +296,6 @@ describe('global board (ctx.board present)', () => {
         status: 'todo',
         priority: 'high',
         assignee: 'human',
-        execution: { mode: 'fresh' },
       },
       comments: [],
       runs: [],
@@ -407,7 +395,7 @@ describe('global board (ctx.board present)', () => {
     const detail: IssueDetail = {
       issue: {
         id: 'alpha', title: 'Alpha', what: 'one canonical prompt', status: 'todo',
-        priority: 'high', assignee: 'human', execution: { mode: 'fresh' },
+        priority: 'high', assignee: 'human',
       },
       comments: [],
       runs: [{

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -36,13 +36,12 @@ import {
   ISSUES_DIR_REL,
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
-  issueExecution as effectiveIssueExecution,
-  issueExecutionSchema,
+  issueAssigneeResumeId,
+  issueAssigneeSchema,
   issueWhenSchema,
   parseIssueContent,
   readWorkspaceIssues,
   type IssueRecord,
-  type IssueExecution,
 } from '../workspaces/issues/declaration.js'
 import {
   appendIssueComment,
@@ -52,7 +51,6 @@ import {
 import { readIssueComments, type IssueComment } from '../workspaces/issues/comments.js'
 import {
   flattenBoardRows,
-  issueAssigneeForWorkspace,
   type BoardInvalidWorkspace,
   type BoardRow,
 } from '../workspaces/issues/board.js'
@@ -66,29 +64,29 @@ function selfDir(ctx: WorkspaceToolContext): { ok: true; dir: string } | { ok: f
   return { ok: true, dir: meta.dir }
 }
 
-const issueExecutionInputSchema = z.discriminatedUnion('mode', [
-  z.object({ mode: z.literal('fresh') }),
-  z.object({
-    mode: z.literal('resume'),
-    resumeId: z.string().min(1).optional().describe('Omit to bind the current product Session.'),
-  }),
-])
+const issueAssigneeInputSchema = z.string().min(1).refine(
+  (value) => value === 'session:self' || issueAssigneeSchema.safeParse(value).success,
+  'assignee must be workspace, human, unassigned, session:self, or session:<resumeId>',
+)
 
-function resolveIssueExecution(
+function resolveIssueAssignee(
   ctx: WorkspaceToolContext,
-  execution: z.infer<typeof issueExecutionInputSchema> | undefined,
-): { ok: true; execution?: IssueExecution } | { ok: false; error: string } {
-  if (!execution) return { ok: true }
-  if (execution.mode === 'fresh') return { ok: true, execution: { mode: 'fresh' } }
-  const resumeId = execution.resumeId ?? sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)?.resumeId
-  if (!resumeId) {
-    return {
-      ok: false,
-      error: 'execution.mode "resume" needs resumeId outside an attributable product Session',
-    }
+  requested: string | undefined,
+): { ok: true; assignee?: string } | { ok: false; error: string } {
+  if (!requested) return { ok: true }
+  const selfResumeId = requested === 'session:self'
+    ? sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)?.resumeId
+    : undefined
+  if (requested === 'session:self' && !selfResumeId) {
+    return { ok: false, error: 'session:self needs an attributable product Session' }
   }
-  const parsed = issueExecutionSchema.safeParse({ mode: 'resume', resumeId })
-  if (!parsed.success) return { ok: false, error: 'invalid resume execution policy' }
+  const assignee = requested === 'session:self'
+    ? `session:${selfResumeId}`
+    : requested
+  const parsed = issueAssigneeSchema.safeParse(assignee)
+  if (!parsed.success) return { ok: false, error: 'invalid assignee' }
+  const resumeId = issueAssigneeResumeId(parsed.data)
+  if (!resumeId) return { ok: true, assignee: parsed.data }
   const identity = ctx.resolveSessionIdentity?.(resumeId)
   if (ctx.resolveSessionIdentity && !identity) {
     return { ok: false, error: `unknown product Session: ${resumeId}` }
@@ -102,7 +100,7 @@ function resolveIssueExecution(
       error: `product Session ${resumeId} is not resumable yet; complete one agent turn before assigning it`,
     }
   }
-  return { ok: true, execution: parsed.data }
+  return { ok: true, assignee: parsed.data }
 }
 
 /** The comment / create author for this workspace's writes. */
@@ -133,15 +131,14 @@ async function recordIssueProvenance(
 }
 
 /** Project a full IssueRecord into the compact row the tools return. */
-function rowOf(issue: IssueRecord, workspaceLabel?: string) {
+function rowOf(issue: IssueRecord) {
   return {
     id: issue.id,
     title: issue.title,
     status: issue.status,
     priority: issue.priority,
-    assignee: issueAssigneeForWorkspace(issue, workspaceLabel),
+    assignee: issue.assignee,
     ...(issue.agent ? { agent: issue.agent } : {}),
-    ...(issue.when ? { execution: effectiveIssueExecution(issue) } : {}),
     scheduled: issue.when !== undefined,
   }
 }
@@ -212,7 +209,6 @@ function summarizeIssueRows(
       priority: row.priority,
       assignee: row.assignee,
       scheduled: row.scheduled,
-      ...(row.scheduled ? { execution: row.execution } : {}),
       workspace: row.workspace.tag,
       ...(row.nameCollision ? { nameCollision: true as const } : {}),
     })),
@@ -234,9 +230,9 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
       description: [
         "Update one of THIS workspace's issues — its board fields.",
         '',
-        'Patch any subset of `status`, `priority`, `assignee`, `execution`, `what`; omitted fields are',
-        'left untouched. `execution:{mode:"resume"}` binds this current product',
-        'Session; pass a resumeId to assign another known Session. What is the',
+        'Patch any subset of `status`, `priority`, `assignee`, `what`; omitted fields are',
+        'left untouched. `assignee:"session:self"` binds this current product',
+        'Session; pass `session:<resumeId>` to assign another known Session. What is the',
         'canonical markdown work definition and exact scheduled prompt. Other scheduling',
         'frontmatter (`when`/`agent`) is preserved — edit it by writing the file directly',
         '(`.alice/issues/<id>.md`).',
@@ -248,32 +244,28 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
         id: z.string().min(1).describe('The issue id (the filename stem of `.alice/issues/<id>.md`).'),
         status: z.enum(ISSUE_STATUSES).optional().describe('New status.'),
         priority: z.enum(ISSUE_PRIORITIES).optional().describe('New priority.'),
-        assignee: z
-          .string()
-          .min(1)
+        assignee: issueAssigneeInputSchema
           .optional()
-          .describe('New assignee, e.g. "human", "ws:<tag>", or "unassigned".'),
-        execution: issueExecutionInputSchema.optional().describe('Scheduled ownership: fresh each fire, or resume one exact product Session.'),
+          .describe('workspace, human, unassigned, session:self, or session:<resumeId>.'),
         what: z.string().min(1).optional().describe('Canonical markdown work definition; exact scheduled prompt.'),
       }),
-      execute: async ({ id, status, priority, assignee, execution, what }) => {
+      execute: async ({ id, status, priority, assignee, what }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
-        const resolvedExecution = resolveIssueExecution(ctx, execution)
-        if (!resolvedExecution.ok) return { ok: false as const, error: resolvedExecution.error }
-        if (status === undefined && priority === undefined && assignee === undefined && !resolvedExecution.execution && what === undefined) {
-          return { ok: false as const, error: 'no fields to update (pass status/priority/assignee/execution/what)' }
+        const resolvedAssignee = resolveIssueAssignee(ctx, assignee)
+        if (!resolvedAssignee.ok) return { ok: false as const, error: resolvedAssignee.error }
+        if (status === undefined && priority === undefined && resolvedAssignee.assignee === undefined && what === undefined) {
+          return { ok: false as const, error: 'no fields to update (pass status/priority/assignee/what)' }
         }
         const res = await updateIssueFields(dir.dir, id, {
           status,
           priority,
-          assignee,
+          assignee: resolvedAssignee.assignee,
           what,
-          ...(resolvedExecution.execution ? { execution: resolvedExecution.execution } : {}),
         })
         if (res.ok) {
           await recordIssueProvenance(ctx, res.issue.id, 'updated')
-          return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+          return { ok: true as const, issue: rowOf(res.issue) }
         }
         if (res.reason === 'not_found') return { ok: false as const, error: `no such issue: ${id}` }
         return { ok: false as const, error: res.error }
@@ -306,7 +298,7 @@ export const issueCommentFactory: WorkspaceToolFactory = {
         const res = await appendIssueComment(dir.dir, id, author(ctx), text)
         if (res.ok) {
           await recordIssueProvenance(ctx, res.issue.id, 'commented')
-          return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+          return { ok: true as const, issue: rowOf(res.issue) }
         }
         if (res.reason === 'not_found') return { ok: false as const, error: `no such issue: ${id}` }
         return { ok: false as const, error: res.error }
@@ -330,10 +322,10 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         '',
         'The markdown `what` is the Issue’s work definition. Add a `when` and',
         'the scanner sends that exact visible What to the Agent Runtime; without',
-        '`when` the same What remains a pure board work item. Otherwise it’s',
-        'a pure board work item. Every new scheduled issue must choose execution:',
-        '`fresh` recruits a new Session each fire; `resume` keeps one accountable',
-        'Session. Omit resumeId to bind the current Session.',
+        '`when` the same What remains a pure board work item. Assignee is the',
+        'only ownership field:',
+        '`workspace` (the default) recruits a new Session each fire, while',
+        '`session:self` or `session:<resumeId>` keeps one accountable Session.',
       ].join('\n'),
       inputSchema: z.object({
         title: z.string().min(1).describe('Short human title (required).'),
@@ -344,43 +336,33 @@ export const issueCreateFactory: WorkspaceToolFactory = {
           .describe('Explicit id (filename stem). Omit to derive a kebab slug from the title.'),
         status: z.enum(ISSUE_STATUSES).optional().describe('Initial status (default "todo").'),
         priority: z.enum(ISSUE_PRIORITIES).optional().describe('Initial priority (default "none").'),
-        assignee: z
-          .string()
-          .min(1)
+        assignee: issueAssigneeInputSchema
           .optional()
-          .describe('Initial assignee (default `ws:<this workspace>`).'),
+          .describe('Initial owner (default workspace). Use session:self for the current Session.'),
         when: issueWhenSchema
           .optional()
           .describe('Schedule shape — { kind:"at", at } | { kind:"every", every } | { kind:"cron", cron }. Present iff the issue self-schedules.'),
         what: z.string().min(1).optional().describe('Markdown work definition; exact scheduled prompt. Defaults to title.'),
-        agent: z.string().min(1).optional().describe('Adapter id for fresh execution; resume uses its Session-bound runtime.'),
-        execution: issueExecutionInputSchema.optional().describe('Required with `when`: fresh each fire, or resume an exact product Session.'),
+        agent: z.string().min(1).optional().describe('Adapter id when assignee is workspace; Session assignees own their runtime.'),
       }),
-      execute: async ({ title, id, status, priority, assignee, when, what, agent, execution }) => {
+      execute: async ({ title, id, status, priority, assignee, when, what, agent }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
-        if (when && !execution) {
-          return { ok: false as const, error: 'scheduled issues must explicitly choose execution.mode "fresh" or "resume"' }
-        }
-        if (!when && execution) {
-          return { ok: false as const, error: 'execution only applies to a scheduled issue with `when`' }
-        }
-        const resolvedExecution = resolveIssueExecution(ctx, execution)
-        if (!resolvedExecution.ok) return { ok: false as const, error: resolvedExecution.error }
+        const resolvedAssignee = resolveIssueAssignee(ctx, assignee ?? 'workspace')
+        if (!resolvedAssignee.ok) return { ok: false as const, error: resolvedAssignee.error }
         const res = await createIssue(dir.dir, {
           title,
           id,
           status,
           priority,
-          assignee: assignee ?? author(ctx),
+          assignee: resolvedAssignee.assignee,
           when,
           what,
           agent,
-          ...(resolvedExecution.execution ? { execution: resolvedExecution.execution } : {}),
         })
         if (res.ok) {
           await recordIssueProvenance(ctx, res.issue.id, 'created')
-          return { ok: true as const, issue: rowOf(res.issue, ctx.workspaceLabel) }
+          return { ok: true as const, issue: rowOf(res.issue) }
         }
         if (res.reason === 'conflict') return { ok: false as const, error: `issue already exists: ${res.id}` }
         return { ok: false as const, error: res.error }
@@ -445,7 +427,7 @@ export const issueListFactory: WorkspaceToolFactory = {
         const res = await readWorkspaceIssues(dir.dir)
         if (res.ok) {
           const rows = res.issues.map((issue) => ({
-            ...rowOf(issue, ctx.workspaceLabel),
+            ...rowOf(issue),
             workspace: { wsId: ctx.workspaceId, tag: ctx.workspaceLabel },
             ...(issue.when !== undefined ? { scheduled: true } : { scheduled: false }),
           }))

--- a/src/webui/routes/inquiries.spec.ts
+++ b/src/webui/routes/inquiries.spec.ts
@@ -7,7 +7,7 @@ import { createInquiryRoutes } from './inquiries.js'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-function build(opts: { execution?: { mode: 'fresh' } | { mode: 'resume'; resumeId: string } } = {}) {
+function build(opts: { assignee?: string } = {}) {
   const inboxStore = createMemoryInboxStore()
   const dispatchHeadlessTask = vi.fn(async (
     _meta: unknown,
@@ -40,8 +40,8 @@ function build(opts: { execution?: { mode: 'fresh' } | { mode: 'resume'; resumeI
     headlessLogsDir: '/tmp/missing-inquiry-logs',
     issueDetail: vi.fn(async () => ({
       issue: {
-        id: 'issue-1', title: 'Issue', body: '', status: 'todo', priority: 'none', assignee: 'ws:Research',
-        execution: opts.execution ?? { mode: 'fresh' },
+        id: 'issue-1', title: 'Issue', body: '', status: 'todo', priority: 'none',
+        assignee: opts.assignee ?? 'workspace',
       },
       runs: [{ taskId: 'run-old', resumeId: 'resume-run', wsId: 'ws-1', agent: 'pi', status: 'done', startedAt: 1, resumable: true }],
       inboxReports: [], provenance: [],
@@ -88,8 +88,8 @@ describe('business inquiry routes', () => {
     expect(dispatchHeadlessTask.mock.calls[0]?.[6]?.resolution).toMatchObject({ mode: 'reconstructed' })
   })
 
-  it('rejects Ask owner for a fresh-execution Issue', async () => {
-    const { app } = build({ execution: { mode: 'fresh' } })
+  it('rejects Ask owner for a Workspace-owned Issue', async () => {
+    const { app } = build({ assignee: 'workspace' })
     const response = await app.request('/issues/ws-1/issue-1', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Status?', relation: 'owner' }),
@@ -99,7 +99,7 @@ describe('business inquiry routes', () => {
   })
 
   it('asks the fixed Issue owner and one selected run by their resumeIds', async () => {
-    const { app, dispatchHeadlessTask } = build({ execution: { mode: 'resume', resumeId: 'resume-owner' } })
+    const { app, dispatchHeadlessTask } = build({ assignee: 'session:resume-owner' })
     const owner = await app.request('/issues/ws-1/issue-1', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Owner?', relation: 'owner' }),

--- a/src/webui/routes/inquiries.ts
+++ b/src/webui/routes/inquiries.ts
@@ -13,6 +13,7 @@ import type { IInboxStore } from '../../core/inbox-store.js'
 import { makeInboxEntryOriginResolver } from '../../core/workspace-tool-center.js'
 import { createWorkspaceConversationControl } from '../../workspaces/conversation-control.js'
 import type { HeadlessInquiryScope, HeadlessInquirySubject, HeadlessTaskRecord } from '../../workspaces/headless-task-registry.js'
+import { issueAssigneeResumeId } from '../../workspaces/issues/declaration.js'
 import { HeadlessCapacityError, HeadlessResumeError, type WorkspaceService } from '../../workspaces/service.js'
 
 const DEFAULT_TIMEOUT_MS = 300_000
@@ -144,10 +145,11 @@ export function createInquiryRoutes(deps: InquiryRoutesDeps): Hono {
     let target
     let runId: string | undefined
     if (relation === 'owner') {
-      if (detail.issue.execution.mode !== 'resume') {
+      const resumeId = issueAssigneeResumeId(detail.issue.assignee)
+      if (!resumeId) {
         return c.json({ error: 'no_stable_owner', message: 'this Issue recruits a new Session for every run' }, 409)
       }
-      target = { kind: 'resume' as const, resumeId: detail.issue.execution.resumeId }
+      target = { kind: 'resume' as const, resumeId }
     } else if (relation === 'run') {
       runId = typeof body.runId === 'string' ? body.runId : undefined
       const run = runId ? detail.runs.find((candidate) => candidate.taskId === runId) : undefined

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -117,25 +117,25 @@ describe('PATCH /api/issues/:wsId/:id', () => {
   it('validates and persists explicit scheduled ownership', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
     const { app } = build()
-    const invalid = await req(app, 'PATCH', '/ws-1/i1', { execution: { mode: 'resume' } })
+    const invalid = await req(app, 'PATCH', '/ws-1/i1', { assignee: 'session:' })
     expect(invalid.status).toBe(400)
-    expect(invalid.body.error).toBe('invalid_execution')
+    expect(invalid.body.error).toBe('invalid_assignee')
 
     const updated = await req(app, 'PATCH', '/ws-1/i1', {
-      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
+      assignee: 'session:resume-kind-owl-abc123',
     })
     expect(updated.status).toBe(200)
-    expect(updated.body.issue.execution).toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
+    expect(updated.body.issue.assignee).toBe('session:resume-kind-owl-abc123')
   })
 
-  it('409 when the selected execution owner is not resumable yet', async () => {
+  it('409 when the selected Session assignee is not resumable yet', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
     const { app } = build()
     const unavailable = await req(app, 'PATCH', '/ws-1/i1', {
-      execution: { mode: 'resume', resumeId: 'resume-unready' },
+      assignee: 'session:resume-unready',
     })
     expect(unavailable.status).toBe(409)
-    expect(unavailable.body.error).toBe('unavailable_execution_owner')
+    expect(unavailable.body.error).toBe('unavailable_assignee_session')
   })
 
   it('400 no_fields when the body has none of the patchable fields', async () => {

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -28,8 +28,8 @@ import { ACTIVITY_UPDATE_COALESCE_MS } from '../../core/provenance-store.js'
 import {
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
-  issueExecutionSchema,
-  type IssueExecution,
+  issueAssigneeResumeId,
+  issueAssigneeSchema,
   type IssuePriority,
   type IssueStatus,
 } from '../../workspaces/issues/declaration.js'
@@ -86,7 +86,7 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
 
     const body = await safeJson(c)
     const fields = body && typeof body === 'object' ? (body as Record<string, unknown>) : {}
-    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string } = {}
+    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string } = {}
     if ('status' in fields) {
       const s = fields['status']
       if (typeof s !== 'string' || !ISSUE_STATUSES.includes(s as IssueStatus)) {
@@ -103,10 +103,27 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
     }
     if ('assignee' in fields) {
       const a = fields['assignee']
-      if (typeof a !== 'string' || a.trim().length === 0) {
-        return c.json({ error: 'invalid_assignee', message: 'assignee must be a non-empty string' }, 400)
+      const assignee = typeof a === 'string' ? issueAssigneeSchema.safeParse(a.trim()) : null
+      if (!assignee?.success) {
+        return c.json({ error: 'invalid_assignee', message: 'assignee must be workspace, human, unassigned, or session:<resumeId>' }, 400)
       }
-      patch.assignee = a.trim()
+      const resumeId = issueAssigneeResumeId(assignee.data)
+      if (resumeId) {
+        const identity = svc.resumeRegistry.get(resumeId)
+        if (!identity || identity.wsId !== wsId) {
+          return c.json({
+            error: 'invalid_assignee_session',
+            message: 'session assignee must identify a product Session in this Workspace',
+          }, 400)
+        }
+        if (!identity.agentSessionId) {
+          return c.json({
+            error: 'unavailable_assignee_session',
+            message: 'the selected Session is not resumable yet; complete one agent turn before assigning it',
+          }, 409)
+        }
+      }
+      patch.assignee = assignee.data
     }
     if ('agent' in fields) {
       const raw = fields['agent']
@@ -123,31 +140,6 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
         patch.agent = agent
       }
     }
-    if ('execution' in fields) {
-      const execution = issueExecutionSchema.safeParse(fields['execution'])
-      if (!execution.success) {
-        return c.json({
-          error: 'invalid_execution',
-          message: 'execution must be {mode:"fresh"} or {mode:"resume",resumeId}',
-        }, 400)
-      }
-      if (execution.data.mode === 'resume') {
-        const identity = svc.resumeRegistry.get(execution.data.resumeId)
-        if (!identity || identity.wsId !== wsId) {
-          return c.json({
-            error: 'invalid_execution_owner',
-            message: 'resumeId must identify a product Session in this Workspace',
-          }, 400)
-        }
-        if (!identity.agentSessionId) {
-          return c.json({
-            error: 'unavailable_execution_owner',
-            message: 'the selected Session is not resumable yet; complete one agent turn before assigning it',
-          }, 409)
-        }
-      }
-      patch.execution = execution.data
-    }
     if ('what' in fields) {
       const what = fields['what']
       if (typeof what !== 'string' || what.trim().length === 0) {
@@ -159,7 +151,7 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
       patch.what = what.trim()
     }
     if (Object.keys(patch).length === 0) {
-      return c.json({ error: 'no_fields', message: 'provide at least one of status, priority, assignee, agent, execution, what' }, 400)
+      return c.json({ error: 'no_fields', message: 'provide at least one of status, priority, assignee, agent, what' }, 400)
     }
 
     try {

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -121,7 +121,6 @@ function ws(wsId: string, titles: string[]): IssuesSnapshotWorkspace {
       status: 'todo',
       priority: 'none',
       assignee: 'unassigned',
-      execution: { mode: 'fresh' },
     })),
   }
 }
@@ -161,14 +160,13 @@ describe('flattenBoardRows', () => {
           tag: 'auto-quant',
           status: 'ok',
           issues: [
-            { id: 'x', title: 'X', status: 'todo', priority: 'high', assignee: 'human', execution: { mode: 'fresh' } },
+            { id: 'x', title: 'X', status: 'todo', priority: 'high', assignee: 'human' },
             {
               id: 'y',
               title: 'Y',
               status: 'todo',
               priority: 'none',
-              assignee: 'unassigned',
-              execution: { mode: 'fresh' },
+              assignee: 'workspace',
               agent: 'pi',
               when: { kind: 'every', every: '1h' },
               nameCollision: true,
@@ -187,7 +185,6 @@ describe('flattenBoardRows', () => {
         status: 'todo',
         priority: 'high',
         assignee: 'human',
-        execution: { mode: 'fresh' },
         scheduled: false,
         workspace: { wsId: 'a', tag: 'auto-quant' },
       },
@@ -196,9 +193,8 @@ describe('flattenBoardRows', () => {
         title: 'Y',
         status: 'todo',
         priority: 'none',
-        assignee: 'unassigned',
+        assignee: 'workspace',
         agent: 'pi',
-        execution: { mode: 'fresh' },
         scheduled: true,
         workspace: { wsId: 'a', tag: 'auto-quant' },
         nameCollision: true,
@@ -208,26 +204,25 @@ describe('flattenBoardRows', () => {
   })
 })
 
-describe('workspace default assignee projection', () => {
+describe('assignee projection', () => {
   const baseIssue = {
     id: 'i',
     title: 'Issue',
     status: 'todo',
     priority: 'none',
-    assignee: 'unassigned',
+    assignee: 'workspace',
     what: 'Issue',
   } as const
 
-  it('projects a missing assignee to the owning workspace', () => {
-    const issue = { ...baseIssue, assigneeDefaulted: true }
-    expect(snapshotBoardIssue(issue, null, 'chat-jul4').assignee).toBe('ws:chat-jul4')
-    expect(detailIssue(issue, null, 'chat-jul4').assignee).toBe('ws:chat-jul4')
+  it('projects Workspace ownership without needing a workspace-tag rewrite', () => {
+    expect(snapshotBoardIssue(baseIssue, null).assignee).toBe('workspace')
+    expect(detailIssue(baseIssue, null).assignee).toBe('workspace')
   })
 
   it('respects an explicit unassigned assignee', () => {
-    const issue = { ...baseIssue, assigneeDefaulted: false }
-    expect(snapshotBoardIssue(issue, null, 'chat-jul4').assignee).toBe('unassigned')
-    expect(detailIssue(issue, null, 'chat-jul4').assignee).toBe('unassigned')
+    const issue = { ...baseIssue, assignee: 'unassigned' as const }
+    expect(snapshotBoardIssue(issue, null).assignee).toBe('unassigned')
+    expect(detailIssue(issue, null).assignee).toBe('unassigned')
   })
 })
 

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -25,7 +25,7 @@ import type {
   HeadlessTaskRecord,
   HeadlessTaskStatus,
 } from '../headless-task-registry.js'
-import { issueExecution, type IssueExecution, type IssuePriority, type IssueRecord, type IssueStatus } from './declaration.js'
+import type { IssuePriority, IssueRecord, IssueStatus } from './declaration.js'
 import type { IssueComment } from './comments.js'
 
 /** One board row: the issue's display fields, plus — iff it self-schedules — its
@@ -38,8 +38,6 @@ export interface IssuesSnapshotIssue {
   assignee: string
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
-  /** Effective scheduled owner policy. */
-  execution: IssueExecution
   /** Present iff the issue self-schedules. */
   when?: Schedule
   /** When the scanner last fired this issue (epoch ms); only for scheduled issues. */
@@ -135,8 +133,6 @@ export interface BoardRow {
   assignee: string
   /** Adapter id for the scheduled fire override, if set. */
   agent?: string
-  /** Effective scheduled owner policy. */
-  execution?: IssueExecution
   /** True iff the issue self-schedules (snapshot `when` present). */
   scheduled: boolean
   workspace: { wsId: string; tag: string }
@@ -175,7 +171,6 @@ export function flattenBoardRows(snapshot: IssuesSnapshot): {
         priority: issue.priority,
         assignee: issue.assignee,
         ...(issue.agent ? { agent: issue.agent } : {}),
-        execution: issue.execution,
         scheduled: issue.when !== undefined,
         workspace: { wsId: ws.wsId, tag: ws.tag },
         ...(issue.nameCollision ? { nameCollision: true } : {}),
@@ -223,8 +218,6 @@ export interface IssueDetailIssue {
   when?: Schedule
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
-  /** Effective policy; legacy files project as fresh. */
-  execution: IssueExecution
   /** When the scanner last fired this issue (epoch ms); only for scheduled issues. */
   lastFiredAtMs?: number | null
   /** When it is next due (epoch ms); only for scheduled issues. */
@@ -352,18 +345,11 @@ export function inboxReportsForIssue(entries: readonly InboxEntry[], issueId: st
   return entries.filter((e) => e.origin?.issueId === issueId)
 }
 
-/** A missing assignee in a workspace-owned issue means "this workspace owns it".
- *  Keep an explicit `assignee: unassigned` as unassigned so human edits survive. */
-export function issueAssigneeForWorkspace(issue: IssueRecord, workspaceTag?: string): string {
-  return issue.assigneeDefaulted && workspaceTag ? `ws:${workspaceTag}` : issue.assignee
-}
-
 /** Map a validated issue (+ its firing markers, iff scheduled) to the detail
  *  issue shape. Keeps What and scheduling frontmatter the board drops. */
 export function detailIssue(
   issue: IssueRecord,
   markers: IssueFiringMarkers | null,
-  workspaceTag?: string,
 ): IssueDetailIssue {
   return {
     id: issue.id,
@@ -371,10 +357,9 @@ export function detailIssue(
     what: issue.what,
     status: issue.status,
     priority: issue.priority,
-    assignee: issueAssigneeForWorkspace(issue, workspaceTag),
+    assignee: issue.assignee,
     ...(issue.when ? { when: issue.when } : {}),
     ...(issue.agent ? { agent: issue.agent } : {}),
-    execution: issueExecution(issue),
     ...(markers ? { lastFiredAtMs: markers.lastFiredAtMs, nextDueAtMs: markers.nextDueAtMs } : {}),
   }
 }
@@ -385,16 +370,14 @@ export function detailIssue(
 export function snapshotBoardIssue(
   issue: IssueRecord,
   markers: IssueFiringMarkers | null,
-  workspaceTag?: string,
 ): IssuesSnapshotIssue {
   return {
     id: issue.id,
     title: issue.title,
     status: issue.status,
     priority: issue.priority,
-    assignee: issueAssigneeForWorkspace(issue, workspaceTag),
+    assignee: issue.assignee,
     ...(issue.agent ? { agent: issue.agent } : {}),
-    execution: issueExecution(issue),
     ...(issue.when ? { when: issue.when } : {}),
     ...(markers ? { lastFiredAtMs: markers.lastFiredAtMs, nextDueAtMs: markers.nextDueAtMs } : {}),
   }

--- a/src/workspaces/issues/declaration.spec.ts
+++ b/src/workspaces/issues/declaration.spec.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { issueExecution, issueFirePrompt, isFireable, readWorkspaceIssues } from './declaration.js'
+import { issueAssigneeResumeId, issueFirePrompt, isFireable, readWorkspaceIssues } from './declaration.js'
 
 let dir: string
 beforeEach(async () => {
@@ -69,21 +69,19 @@ describe('readWorkspaceIssues', () => {
         title: 'Fix the login bug',
         status: 'todo',
         priority: 'none',
-        assignee: 'unassigned',
+        assignee: 'workspace',
       })
-      expect(i.assigneeDefaulted).toBe(true)
       expect(i.when).toBeUndefined()
       expect(isFireable(i)).toBe(false)
     }
   })
 
-  it('distinguishes explicit unassigned from a defaulted assignee', async () => {
+  it('preserves an explicit unassigned owner for an unscheduled issue', async () => {
     await writeIssue('explicit', fm('title: Explicit\nassignee: unassigned'))
     const r = await readWorkspaceIssues(dir)
     expect(r.ok).toBe(true)
     if (r.ok) {
       expect(r.issues[0].assignee).toBe('unassigned')
-      expect(r.issues[0].assigneeDefaulted).toBe(false)
     }
   })
 
@@ -95,7 +93,7 @@ describe('readWorkspaceIssues', () => {
           'title: Morning research sweep',
           'status: in_progress',
           'priority: high',
-          'assignee: "ws:auto-quant"',
+          'assignee: workspace',
           'when: { kind: every, every: 30m }',
           'what: run the research routine',
           'agent: codex',
@@ -113,7 +111,7 @@ describe('readWorkspaceIssues', () => {
         title: 'Morning research sweep',
         status: 'in_progress',
         priority: 'high',
-        assignee: 'ws:auto-quant',
+        assignee: 'workspace',
         what: 'run the research routine\n\n## Context\n\nScan overnight movers and summarize.',
         agent: 'codex',
       })
@@ -123,19 +121,32 @@ describe('readWorkspaceIssues', () => {
     }
   })
 
-  it('parses resume ownership and treats legacy omission as fresh', async () => {
+  it('parses Session ownership and defaults scheduled work to the Workspace', async () => {
     await writeIssue('owned', fm([
       'title: Owned work',
       'when: { kind: every, every: 30m }',
-      'execution: { mode: resume, resumeId: resume-kind-owl-abc123 }',
+      'assignee: session:resume-kind-owl-abc123',
     ].join('\n')))
     await writeIssue('legacy', fm('title: Legacy\nwhen: { kind: every, every: 30m }'))
     const result = await readWorkspaceIssues(dir)
     expect(result.ok).toBe(true)
     if (!result.ok) return
     const byId = Object.fromEntries(result.issues.map((issue) => [issue.id, issue]))
-    expect(issueExecution(byId['owned'])).toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
-    expect(issueExecution(byId['legacy'])).toEqual({ mode: 'fresh' })
+    expect(issueAssigneeResumeId(byId['owned'].assignee)).toBe('resume-kind-owl-abc123')
+    expect(byId['legacy'].assignee).toBe('workspace')
+  })
+
+  it('rejects retired execution declarations instead of silently keeping two owner models', async () => {
+    await writeIssue('retired', fm([
+      'title: Retired owner field',
+      'when: { kind: every, every: 30m }',
+      'execution: { mode: fresh }',
+    ].join('\n')))
+    const result = await readWorkspaceIssues(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.issues).toEqual([])
+    expect(result.invalid[0]?.error).toMatch(/execution/)
   })
 
   it('parses block-style and cron/at `when` shapes', async () => {

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -20,11 +20,10 @@
  *   title: <required, short human title>
  *   status: backlog | todo | in_progress | done | canceled   (optional → 'todo')
  *   priority: urgent | high | medium | low | none             (optional → 'none')
- *   assignee: "human" | "ws:<tag|id>" | "unassigned"          (optional → 'unassigned')
+ *   assignee: "workspace" | "human" | "unassigned" | "session:<resumeId>"  (optional → 'workspace')
  *   when: { kind: at, at } | { kind: every, every } | { kind: cron, cron }  (OPTIONAL — present iff scheduled)
  *   what: <legacy fire prompt; migrated into the markdown What body>
  *   agent: <optional adapter id for the scheduled run>
- *   execution: { mode: fresh } | { mode: resume, resumeId: <product Session id> }
  *   ---
  *   <markdown What — the exact work definition and scheduled prompt>
  *
@@ -72,13 +71,19 @@ export const issueWhenSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('cron'), cron: z.string().min(1) }),
 ])
 
-/** Who receives each scheduled fire. Legacy files omit this and retain the
- * historical behavior (`fresh`); new agent-created schedules must choose. */
-export const issueExecutionSchema = z.discriminatedUnion('mode', [
-  z.object({ mode: z.literal('fresh') }),
-  z.object({ mode: z.literal('resume'), resumeId: z.string().min(1) }),
+/** Who owns the Issue. Workspace ownership recruits a fresh Session for each
+ * scheduled fire; Session ownership resumes exactly one product Session. */
+export const issueAssigneeSchema = z.union([
+  z.literal('workspace'),
+  z.literal('human'),
+  z.literal('unassigned'),
+  z.string().regex(/^session:[^\s:][^\s]*$/, 'session assignee must be session:<resumeId>'),
 ])
-export type IssueExecution = z.infer<typeof issueExecutionSchema>
+
+/** Exact product Session owner encoded by the single assignee contract. */
+export function issueAssigneeResumeId(assignee: string): string | null {
+  return assignee.startsWith('session:') ? assignee.slice('session:'.length) || null : null
+}
 
 /**
  * The validated frontmatter of one issue. `id` and `what` are NOT here — `id`
@@ -90,29 +95,37 @@ export const issueFrontmatterSchema = z.object({
   title: z.string().min(1),
   status: z.enum(ISSUE_STATUSES).default('todo'),
   priority: z.enum(ISSUE_PRIORITIES).default('none'),
-  assignee: z.string().min(1).default('unassigned'),
+  assignee: issueAssigneeSchema.default('workspace'),
   /** Present iff the issue self-schedules. Absent ⇒ pure board work item. */
   when: issueWhenSchema.optional(),
   /** Legacy compatibility only. New files keep What in the markdown document
    * below frontmatter so the human-visible work definition and runtime prompt
    * cannot drift. Migration 0017 removes this key from existing files. */
   what: z.string().min(1).optional(),
-  /** Which agent runtime to run the scheduled fire with; omitted uses the issue default / workspace default / first runtime. */
+  /** Runtime override for Workspace-owned scheduled work. A Session owner
+   * already carries its runtime identity and therefore cannot set this. */
   agent: z.string().min(1).optional(),
-  /** `fresh`: create a new product Session each fire. `resume`: continue the
-   * exact OpenAlice-owned product Session named by resumeId. */
-  execution: issueExecutionSchema.optional(),
+  /** Migration 0018 removes the former parallel ownership field. Keeping a
+   * `never` key makes stale files fail loudly instead of being silently read. */
+  execution: z.never().optional(),
 }).superRefine((value, ctx) => {
-  if (value.execution && !value.when) {
+  if (value.when && (value.assignee === 'human' || value.assignee === 'unassigned')) {
     ctx.addIssue({
       code: 'custom',
-      path: ['execution'],
-      message: 'execution only applies to a scheduled issue with `when`',
+      path: ['assignee'],
+      message: 'scheduled issues must be assigned to workspace or session:<resumeId>',
+    })
+  }
+  if (issueAssigneeResumeId(value.assignee) && value.agent) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['agent'],
+      message: 'session assignee owns its runtime; remove the agent override',
     })
   }
 })
 type IssueFrontmatterFile = z.infer<typeof issueFrontmatterSchema>
-export type IssueFrontmatter = Omit<IssueFrontmatterFile, 'what'>
+export type IssueFrontmatter = Omit<IssueFrontmatterFile, 'what' | 'execution'>
 
 /** A fully read issue: validated frontmatter + filename id + markdown What. */
 export interface IssueRecord extends IssueFrontmatter {
@@ -121,12 +134,6 @@ export interface IssueRecord extends IssueFrontmatter {
   /** Markdown work definition below frontmatter. For a scheduled Issue this is
    * the exact prompt sent to the Agent Runtime. */
   what: string
-  /**
-   * True when `assignee` came from the schema default rather than frontmatter.
-   * Board projections can then default it to `ws:<workspace>` while still
-   * respecting a human who explicitly wrote `assignee: unassigned`.
-   */
-  assigneeDefaulted: boolean
 }
 
 /** A file that could not be read/validated — reported, never propagated. */
@@ -151,11 +158,6 @@ export function isFireable(issue: IssueRecord): issue is IssueRecord & { when: S
  * prompt field for it to disagree with. */
 export function issueFirePrompt(issue: IssueRecord): string {
   return issue.what
-}
-
-/** Backward-compatible effective execution policy for the scanner/UI. */
-export function issueExecution(issue: IssueRecord): IssueExecution {
-  return issue.execution ?? { mode: 'fresh' }
 }
 
 /**
@@ -240,14 +242,12 @@ export function parseIssueContent(
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
     return { ok: false, error: 'frontmatter is not a mapping' }
   }
-  const rawFrontmatter = data as Record<string, unknown>
-
   const parsed = issueFrontmatterSchema.safeParse(data)
   if (!parsed.success) {
     return { ok: false, error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ') }
   }
 
-  const { what: legacyWhat, ...frontmatter } = parsed.data
+  const { what: legacyWhat, execution: _retiredExecution, ...frontmatter } = parsed.data
   const document = splitLegacyIssueDocument(split.body)
   return {
     ok: true,
@@ -255,7 +255,6 @@ export function parseIssueContent(
       id,
       ...frontmatter,
       what: mergeLegacyWhat(legacyWhat, document.what, frontmatter.title),
-      assigneeDefaulted: !Object.prototype.hasOwnProperty.call(rawFrontmatter, 'assignee'),
     },
   }
 }

--- a/src/workspaces/issues/mutate.spec.ts
+++ b/src/workspaces/issues/mutate.spec.ts
@@ -34,7 +34,7 @@ describe('createIssue', () => {
       // Defaults applied on read-back.
       expect(res.issue.status).toBe('todo')
       expect(res.issue.priority).toBe('none')
-      expect(res.issue.assignee).toBe('unassigned')
+      expect(res.issue.assignee).toBe('workspace')
     }
     const { issue } = await readBack('fix-the-login-bug')
     expect(issue?.title).toBe('Fix the Login Bug!')
@@ -46,11 +46,9 @@ describe('createIssue', () => {
       title: 'Morning research sweep',
       status: 'in_progress',
       priority: 'high',
-      assignee: 'ws:auto-quant',
+      assignee: 'session:resume-kind-owl-abc123',
       when: { kind: 'every', every: '30m' },
       what: 'run the research routine',
-      agent: 'codex',
-      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
     })
     expect(res.ok).toBe(true)
     const { issue } = await readBack('morning-sweep')
@@ -59,10 +57,8 @@ describe('createIssue', () => {
       title: 'Morning research sweep',
       status: 'in_progress',
       priority: 'high',
-      assignee: 'ws:auto-quant',
+      assignee: 'session:resume-kind-owl-abc123',
       what: 'run the research routine',
-      agent: 'codex',
-      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
     })
     expect(issue?.when).toEqual({ kind: 'every', every: '30m' })
     expect(issue?.what).toBe('run the research routine')
@@ -103,21 +99,21 @@ describe('updateIssueFields', () => {
     const res = await updateIssueFields(dir, 'task-1', {
       status: 'in_progress',
       priority: 'urgent',
-      assignee: 'human',
+      assignee: 'workspace',
       agent: 'pi',
     })
     expect(res.ok).toBe(true)
     if (res.ok) {
       expect(res.issue.status).toBe('in_progress')
       expect(res.issue.priority).toBe('urgent')
-      expect(res.issue.assignee).toBe('human')
+      expect(res.issue.assignee).toBe('workspace')
       expect(res.issue.agent).toBe('pi')
     }
     const { issue } = await readBack('task-1')
     expect(issue).toMatchObject({
       status: 'in_progress',
       priority: 'urgent',
-      assignee: 'human',
+      assignee: 'workspace',
       what: 'keep the fire prompt',
       agent: 'pi',
     })
@@ -138,14 +134,16 @@ describe('updateIssueFields', () => {
       id: 'owned',
       title: 'Owned',
       when: { kind: 'every', every: '15m' },
-      execution: { mode: 'fresh' },
+      assignee: 'workspace',
+      agent: 'codex',
     })
     const res = await updateIssueFields(dir, 'owned', {
-      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
+      assignee: 'session:resume-kind-owl-abc123',
     })
     expect(res.ok).toBe(true)
     const { issue } = await readBack('owned')
-    expect(issue?.execution).toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
+    expect(issue?.assignee).toBe('session:resume-kind-owl-abc123')
+    expect(issue?.agent).toBeUndefined()
     expect(issue?.when).toEqual({ kind: 'every', every: '15m' })
   })
 

--- a/src/workspaces/issues/mutate.ts
+++ b/src/workspaces/issues/mutate.ts
@@ -28,13 +28,13 @@ import {
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
   ISSUES_DIR_REL,
+  issueAssigneeResumeId,
+  issueAssigneeSchema,
   issueFrontmatterSchema,
-  issueExecutionSchema,
   parseIssueContent,
   splitLegacyIssueDocument,
   splitFrontmatter,
   type IssuePriority,
-  type IssueExecution,
   type IssueRecord,
   type IssueStatus,
 } from './declaration.js'
@@ -49,8 +49,6 @@ export interface IssueFieldPatch {
   assignee?: string
   /** Runtime override for scheduled fires; null removes the override. */
   agent?: string | null
-  /** Scheduled execution owner. Use `{mode:'fresh'}` instead of deleting it. */
-  execution?: IssueExecution
   /** Canonical markdown work definition; exact scheduled prompt. */
   what?: string
 }
@@ -66,7 +64,6 @@ export interface CreateIssueInput {
   when?: unknown
   what?: string
   agent?: string
-  execution?: IssueExecution
   /** @deprecated Compatibility alias for callers written before What became the
    * sole markdown document. New callers must use `what`. */
   body?: string
@@ -113,7 +110,7 @@ function serializeIssue(frontmatter: Record<string, unknown>, what: string, lega
 
 /**
  * Patch one or more board fields on an existing issue. Reads the file, validates
- * each patched field against the enums (assignee = non-empty string), merges
+ * each patched field against the Issue schema (including the owner contract), merges
  * into the existing frontmatter (preserving `when`/`agent` + any other
  * keys), re-serializes via the `yaml` lib, and writes. Returns the re-validated
  * IssueRecord, or `not_found` when the file is absent.
@@ -154,8 +151,12 @@ export async function updateIssueFields(
   }
   if (patch.assignee !== undefined) {
     const a = patch.assignee.trim()
-    if (a.length === 0) return { ok: false, reason: 'invalid', error: 'assignee must be a non-empty string' }
-    data.assignee = a
+    const assignee = issueAssigneeSchema.safeParse(a)
+    if (!assignee.success) {
+      return { ok: false, reason: 'invalid', error: 'assignee must be workspace, human, unassigned, or session:<resumeId>' }
+    }
+    data.assignee = assignee.data
+    if (issueAssigneeResumeId(assignee.data)) delete data.agent
   }
   if (patch.agent !== undefined) {
     if (patch.agent === null) {
@@ -165,16 +166,6 @@ export async function updateIssueFields(
       if (a.length === 0) return { ok: false, reason: 'invalid', error: 'agent must be a non-empty string or null' }
       data.agent = a
     }
-  }
-  if (patch.execution !== undefined) {
-    if (!current.issue.when) {
-      return { ok: false, reason: 'invalid', error: 'execution only applies to a scheduled issue with `when`' }
-    }
-    const execution = issueExecutionSchema.safeParse(patch.execution)
-    if (!execution.success) {
-      return { ok: false, reason: 'invalid', error: 'execution must be {mode:"fresh"} or {mode:"resume",resumeId}' }
-    }
-    data.execution = execution.data
   }
   let what = current.issue.what
   if (patch.what !== undefined) {
@@ -212,10 +203,6 @@ export async function createIssue(wsDir: string, input: CreateIssueInput): Promi
 
   const existing = await readWorkspaceFile(wsDir, relFor(id))
   if (existing !== null) return { ok: false, reason: 'conflict', id }
-  if (input.execution !== undefined && input.when === undefined) {
-    return { ok: false, reason: 'invalid', error: 'execution only applies to a scheduled issue with `when`' }
-  }
-
   // Assemble frontmatter from only the provided keys (so we don't write default
   // noise), then validate the whole thing against the issue schema.
   const data: Record<string, unknown> = { title }
@@ -224,7 +211,6 @@ export async function createIssue(wsDir: string, input: CreateIssueInput): Promi
   if (input.assignee !== undefined) data.assignee = input.assignee
   if (input.when !== undefined) data.when = input.when
   if (input.agent !== undefined) data.agent = input.agent
-  if (input.execution !== undefined) data.execution = input.execution
 
   const parsed = issueFrontmatterSchema.safeParse(data)
   if (!parsed.success) {

--- a/src/workspaces/schedule/declaration.ts
+++ b/src/workspaces/schedule/declaration.ts
@@ -19,10 +19,8 @@ import {
   isFireable,
   isTerminalStatus,
   issueFirePrompt,
-  issueExecution,
   readWorkspaceIssues,
   type IssueRecord,
-  type IssueExecution,
 } from '../issues/declaration.js'
 
 export {
@@ -46,8 +44,9 @@ export interface ScheduleSnapshotTask {
   when: Schedule
   /** The prompt this fire hands to the headless run (resolved `what`/title+body). */
   what: string
+  /** Unified owner. `workspace` recruits a fresh Session; `session:<resumeId>` resumes one. */
+  assignee: string
   agent?: string
-  execution: IssueExecution
   /** False once the owning issue reaches a terminal status (done/canceled). */
   enabled: boolean
   /** When the scanner last fired this issue (epoch ms), null if never. */
@@ -101,8 +100,8 @@ export function snapshotScheduledIssue(
     issue: issue.title,
     when,
     what: issueFirePrompt(issue),
+    assignee: issue.assignee,
     ...(issue.agent ? { agent: issue.agent } : {}),
-    execution: issueExecution(issue),
     enabled: !isTerminalStatus(issue.status),
     lastFiredAtMs,
     // An overdue computed time clamps to now: a due-now task reads "due now",

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -8,7 +8,6 @@ import type { Schedule } from '../../core/schedule-expr.js'
 import type { CliAdapter } from '../cli-adapter.js'
 import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
-import type { IssueExecution } from '../issues/declaration.js'
 
 import { ScheduleScanner, type MarkerStore, type ScheduleScannerDeps } from './scanner.js'
 
@@ -70,7 +69,7 @@ interface IssueSpec {
   status?: string
   priority?: string
   agent?: string
-  execution?: IssueExecution
+  assignee?: string
   body?: string
 }
 
@@ -81,10 +80,7 @@ function issueMd(spec: IssueSpec): string {
   if (spec.priority) lines.push(`priority: ${spec.priority}`)
   if (spec.what) lines.push(`what: ${spec.what}`)
   if (spec.agent) lines.push(`agent: ${spec.agent}`)
-  if (spec.execution?.mode === 'fresh') lines.push('execution: { mode: fresh }')
-  if (spec.execution?.mode === 'resume') {
-    lines.push(`execution: { mode: resume, resumeId: ${spec.execution.resumeId} }`)
-  }
+  if (spec.assignee) lines.push(`assignee: ${spec.assignee}`)
   if (spec.when) {
     const w = spec.when
     const inner =
@@ -155,7 +151,7 @@ describe('ScheduleScanner', () => {
       title: 'owned work',
       when: { kind: 'every', every: '30m' },
       what: 'continue',
-      execution: { mode: 'resume', resumeId: 'resume-kind-owl-abc123' },
+      assignee: 'session:resume-kind-owl-abc123',
     }])
     const resolveAdapter = vi.fn(async () => headlessAdapter)
     const { scanner, dispatch } = scannerFor([ws], { resolveAdapter })
@@ -170,8 +166,8 @@ describe('ScheduleScanner', () => {
       'owned',
       'resume-kind-owl-abc123',
     )
-    expect(scanner.snapshot()!.workspaces[0].tasks[0].execution)
-      .toEqual({ mode: 'resume', resumeId: 'resume-kind-owl-abc123' })
+    expect(scanner.snapshot()!.workspaces[0].tasks[0].assignee)
+      .toBe('session:resume-kind-owl-abc123')
   })
 
   it('ignores an UNSCHEDULED issue (no when): never fires, never in the snapshot', async () => {

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -30,7 +30,7 @@ import type { CliAdapter } from '../cli-adapter.js'
 import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
 
-import { isFireable, issueExecution, issueFirePrompt, readWorkspaceIssues, type IssueExecution } from '../issues/declaration.js'
+import { isFireable, issueAssigneeResumeId, issueFirePrompt, readWorkspaceIssues } from '../issues/declaration.js'
 
 import {
   fireBase,
@@ -188,7 +188,14 @@ export class ScheduleScanner {
       if (!when) continue
       seen.add(this.deps.markers.key(ws.id, issue.id))
       if (isFireable(issue) && this.isDue(ws.id, issue.id, when, nowMs)) {
-        await this.fire(ws, issue.id, issueFirePrompt(issue), issue.agent, issueExecution(issue), nowMs)
+        await this.fire(
+          ws,
+          issue.id,
+          issueFirePrompt(issue),
+          issue.agent,
+          issueAssigneeResumeId(issue.assignee) ?? undefined,
+          nowMs,
+        )
       }
       // Read the marker AFTER any fire so last/next reflect a just-fired run.
       const last = this.deps.markers.get(ws.id, issue.id) ?? null
@@ -208,11 +215,10 @@ export class ScheduleScanner {
     taskId: string,
     what: string,
     agentId: string | undefined,
-    execution: IssueExecution,
+    resumeId: string | undefined,
     nowMs: number,
   ): Promise<void> {
     try {
-      const resumeId = execution.mode === 'resume' ? execution.resumeId : undefined
       const adapter = await this.deps.resolveAdapter(ws, agentId, resumeId)
       if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
         this.deps.logger.warn('schedule.adapter_not_headless', { wsId: ws.id, taskId, agent: adapter.id })
@@ -229,7 +235,7 @@ export class ScheduleScanner {
         taskId,
         agent: adapter.id,
         runId,
-        executionMode: execution.mode,
+        owner: resumeId ? 'session' : 'workspace',
         ...(resumeId ? { resumeId } : {}),
       })
     } catch (err) {

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -1224,7 +1224,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         }
         const issues: IssuesSnapshotIssue[] = res.issues.map((issue) => {
           // Unscheduled ⇒ pure board work item, no firing markers.
-          if (!issue.when) return snapshotBoardIssue(issue, null, ws.tag);
+          if (!issue.when) return snapshotBoardIssue(issue, null);
           // Scheduled ⇒ reuse the schedule snapshot's math so the board's
           // last/next match the Schedules dashboard exactly.
           const fired = snapshotScheduledIssue(
@@ -1240,7 +1240,6 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
               lastFiredAtMs: fired.lastFiredAtMs,
               nextDueAtMs: fired.nextDueAtMs,
             },
-            ws.tag,
           );
         });
         return { wsId: ws.id, tag: ws.tag, status: 'ok', issues };
@@ -1308,7 +1307,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       artifact: { kind: 'issue', workspaceId: ws.id, issueId: issue.id },
     }));
     const activity = issueActivityRecords(provenance, runs);
-    return { issue: detailIssue(issue, markers, ws.tag), comments, runs, inboxReports, provenance, activity };
+    return { issue: detailIssue(issue, markers), comments, runs, inboxReports, provenance, activity };
   };
 
   const sessionDirectory = async (

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -48,9 +48,9 @@ Output is JSON on stdout; a non-zero exit means it failed (reason on stderr).
 **To place a trade, that's `alice-uta`** — resolve the contract first and report
 every result. Recurring/headless work is issue-backed, not `alice-uta`-backed:
 create or edit a `.alice/issues/<id>.md` issue with a `when` field (or use
-`alice-workspace issue create --when ... --execution '{"mode":"resume"}'`) and
-write a complete `what` prompt. Choose `resume` for one accountable Session or
-`fresh` to recruit a new Session each fire.
+`alice-workspace issue create --when ... --assignee session:self`) and write a
+complete `what` prompt. Use `session:<resumeId>` for one accountable Session or
+`workspace` to recruit a new Session each fire.
 
 ## Beyond Alice's data — `opencli` (optional, read-only)
 
@@ -156,7 +156,7 @@ For recurring work, create a scheduled issue instead of inventing a side channel
 ```bash
 alice-workspace issue create --title "Pre-market power brief" --priority high \
   --when '{"kind":"cron","cron":"30 8 * * 1-5"}' \
-  --execution '{"mode":"resume"}' \
+  --assignee session:self \
   --what "Check AI power infrastructure names, write research/premarket-power.md, then push it to Inbox if there is a material update."
 ```
 

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -22,10 +22,6 @@ import type { ScheduleWhen } from './schedule'
 
 export type IssueStatus = 'backlog' | 'todo' | 'in_progress' | 'done' | 'canceled'
 export type IssuePriority = 'urgent' | 'high' | 'medium' | 'low' | 'none'
-export type IssueExecution =
-  | { mode: 'fresh' }
-  | { mode: 'resume'; resumeId: string }
-
 export type IssueProvenanceAction = 'created' | 'updated' | 'commented' | 'sent' | 'decided' | 'reconstructed'
 export type IssueProvenanceOrigin =
   | {
@@ -71,8 +67,6 @@ export interface IssueListItem {
   assignee: string
   /** Adapter id for the scheduled fire override, if set. */
   agent?: string
-  /** Effective scheduled owner policy; legacy server payloads may omit it. */
-  execution?: IssueExecution
   /** Present iff the issue is scheduled (shares the core Schedule union). */
   when?: ScheduleWhen
   /** Scanner last-fired marker (epoch ms) — scheduled issues only. */
@@ -161,8 +155,6 @@ export interface IssueDetailIssue {
   when?: ScheduleWhen
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
-  /** Effective scheduled owner policy; legacy server payloads may omit it. */
-  execution?: IssueExecution
   /** Scanner last-fired marker (epoch ms) — scheduled issues only. */
   lastFiredAtMs?: number | null
   /** Computed next fire (epoch ms) — scheduled issues only. */
@@ -227,7 +219,7 @@ export const issuesApi = {
   async update(
     wsId: string,
     id: string,
-    patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string },
+    patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string },
   ): Promise<IssueDetail> {
     return fetchJson<IssueDetail>(
       `/api/issues/${encodeURIComponent(wsId)}/${encodeURIComponent(id)}`,

--- a/ui/src/api/schedule.ts
+++ b/ui/src/api/schedule.ts
@@ -1,5 +1,4 @@
 import { fetchJson } from './client'
-import type { IssueExecution } from './issues'
 
 export type ScheduleWhen =
   | { kind: 'at'; at: string }
@@ -13,7 +12,7 @@ export interface ScheduleTask {
   when: ScheduleWhen
   what: string
   agent?: string
-  execution?: IssueExecution
+  assignee: string
   enabled: boolean
   /** When the scanner last fired this task (epoch ms), null if never. */
   lastFiredAtMs: number | null

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import { ArrowLeft, Hash, History, Inbox, ListChecks, Settings, TrendingUp, UserRound, UsersRound, X } from 'lucide-react'
+import { ArrowLeft, Hash, History, Inbox, ListChecks, Settings, TrendingUp, X } from 'lucide-react'
 
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
@@ -8,7 +8,6 @@ import type {
   IssueDetail as IssueDetailData,
   IssueDetailIssue,
   IssueActivityRecord,
-  IssueExecution,
   IssuePriority,
   IssueProvenanceRecord,
   IssueStatus,
@@ -25,7 +24,6 @@ import {
 import { issuesApi } from '../api/issues'
 import { inquiriesApi } from '../api/inquiries'
 import { useIssueDetail } from '../hooks/useIssueDetail'
-import { useIssues } from '../hooks/useIssues'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { formatRelativeTime } from '../lib/intl'
 import { useInboxRead } from '../live/inbox-read'
@@ -58,9 +56,6 @@ const PRIORITY_OPTIONS: IssuePriority[] = ['urgent', 'high', 'medium', 'low', 'n
 // settings `inputClass`, trimmed for the narrow rail.
 const railControl =
   'min-w-0 flex-1 rounded-md border border-border bg-bg px-2 py-1 text-[13px] text-text outline-none transition-colors focus:border-accent/60 focus:shadow-[0_0_0_1px_var(--color-accent-dim)] disabled:cursor-not-allowed disabled:opacity-50'
-
-// Sentinel option that swaps the assignee select into a free-text input.
-const ASSIGNEE_CUSTOM = '__custom__'
 
 const CONFIGURABLE_AGENTS: readonly AgentId[] = ['claude', 'codex', 'opencode', 'pi']
 
@@ -97,60 +92,31 @@ function EditRow({ label, children }: { label: string; children: ReactNode }) {
   )
 }
 
-/**
- * Assignee editor: a small select over the common assignees (unassigned / human
- * / `ws:<this workspace's tag>`), with the current value preserved if it's
- * something else, plus a "Custom…" escape hatch that reveals a free-text input.
- */
 function AssigneeEditor({
   value,
-  wsTag,
+  scheduled,
+  sessions,
   disabled,
   onChange,
 }: {
   value: string
-  wsTag?: string
+  scheduled: boolean
+  sessions: readonly WorkspaceSessionDirectoryEntry[]
   disabled?: boolean
   onChange: (next: string) => void
 }) {
-  const [editing, setEditing] = useState(false)
-  const [draft, setDraft] = useState(value)
-
-  const presets = useMemo(() => {
-    const out = ['unassigned', 'human']
-    if (wsTag) out.push(`ws:${wsTag}`)
-    if (!out.includes(value)) out.push(value)
-    return out
-  }, [wsTag, value])
-
-  if (editing) {
-    const commit = () => {
-      const next = draft.trim()
-      setEditing(false)
-      if (next && next !== value) onChange(next)
-      else setDraft(value)
-    }
-    return (
-      <input
-        autoFocus
-        className={railControl}
-        value={draft}
-        disabled={disabled}
-        placeholder="ws:tag / human / …"
-        onChange={(e) => setDraft(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault()
-            commit()
-          } else if (e.key === 'Escape') {
-            e.preventDefault()
-            setEditing(false)
-            setDraft(value)
-          }
-        }}
-        onBlur={commit}
-      />
-    )
+  const sessionChoices = sessions.filter(
+    (session) => session.resumeId && session.agent !== 'shell' && session.resumable,
+  )
+  const selectedResumeId = value.startsWith('session:') ? value.slice('session:'.length) : null
+  const hasSelected = !selectedResumeId || sessionChoices.some((session) => session.resumeId === selectedResumeId)
+  const labelFor = (session: WorkspaceSessionDirectoryEntry) => {
+    const raw = session.interactive?.title
+      || session.interactive?.name
+      || session.latestExecution?.assistantPreview
+      || session.resumeId
+    const label = raw.length > 38 ? `${raw.slice(0, 37)}…` : raw
+    return `${label} · ${session.agent}`
   }
 
   return (
@@ -158,22 +124,22 @@ function AssigneeEditor({
       className={railControl}
       value={value}
       disabled={disabled}
-      onChange={(e) => {
-        const v = e.target.value
-        if (v === ASSIGNEE_CUSTOM) {
-          setDraft(value)
-          setEditing(true)
-          return
-        }
-        if (v !== value) onChange(v)
-      }}
+      aria-label="Assignee"
+      onChange={(event) => onChange(event.target.value)}
     >
-      {presets.map((p) => (
-        <option key={p} value={p}>
-          {p}
-        </option>
-      ))}
-      <option value={ASSIGNEE_CUSTOM}>Custom…</option>
+      <option value="workspace">{scheduled ? 'Workspace · new Session each run' : 'Workspace'}</option>
+      {!scheduled && <option value="human">Human</option>}
+      {!scheduled && <option value="unassigned">Unassigned</option>}
+      <optgroup label="Workspace Sessions">
+        {sessionChoices.map((session) => (
+          <option key={session.resumeId} value={`session:${session.resumeId}`}>
+            {labelFor(session)}
+          </option>
+        ))}
+        {!hasSelected && selectedResumeId && (
+          <option value={value}>Unavailable Session · {selectedResumeId}</option>
+        )}
+      </optgroup>
     </select>
   )
 }
@@ -252,93 +218,6 @@ function AgentEditor({
   )
 }
 
-function ExecutionEditor({
-  value,
-  sessions,
-  disabled,
-  onChange,
-}: {
-  value?: IssueExecution
-  sessions: readonly WorkspaceSessionDirectoryEntry[]
-  disabled?: boolean
-  onChange: (next: IssueExecution) => void
-}) {
-  const labelFor = (session: WorkspaceSessionDirectoryEntry) => {
-    const raw = session.interactive?.title
-      || session.interactive?.name
-      || session.latestExecution?.assistantPreview
-      || session.resumeId
-    return raw.length > 44 ? `${raw.slice(0, 43)}…` : raw
-  }
-  const selected = value?.mode === 'resume' ? value.resumeId : '__fresh__'
-  // A product resumeId can exist before the native runtime has reported its
-  // own session id. Such an entry is useful provenance, but cannot own a
-  // scheduled resume yet: dispatch would fail with `not_ready` on every tick.
-  const choices = sessions.filter(
-    (session) => session.resumeId && session.agent !== 'shell' && session.resumable,
-  )
-  const hasSelected = value?.mode !== 'resume' || choices.some((session) => session.resumeId === value.resumeId)
-
-  const mode = value?.mode ?? 'fresh'
-  return (
-    <div className="space-y-2">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => onChange({ mode: 'fresh' })}
-        className={`w-full rounded-lg border px-3 py-2 text-left transition-colors ${
-          mode === 'fresh' ? 'border-accent/60 bg-accent/10' : 'border-border bg-bg hover:border-accent/30'
-        } disabled:opacity-50`}
-      >
-        <span className="flex items-center gap-2 text-[12px] font-medium text-text">
-          <UsersRound size={14} aria-hidden /> New agent every run
-        </span>
-        <span className="mt-1 block text-[11px] leading-snug text-muted">
-          Each fire starts a separate Session. Ask a specific run when you need follow-up.
-        </span>
-      </button>
-      <button
-        type="button"
-        disabled={disabled || (choices.length === 0 && mode !== 'resume')}
-        onClick={() => {
-          if (mode !== 'resume' && choices[0]) onChange({ mode: 'resume', resumeId: choices[0].resumeId })
-        }}
-        className={`w-full rounded-lg border px-3 py-2 text-left transition-colors ${
-          mode === 'resume' ? 'border-accent/60 bg-accent/10' : 'border-border bg-bg hover:border-accent/30'
-        } disabled:cursor-not-allowed disabled:opacity-50`}
-      >
-        <span className="flex items-center gap-2 text-[12px] font-medium text-text">
-          <UserRound size={14} aria-hidden /> One responsible Session
-        </span>
-        <span className="mt-1 block text-[11px] leading-snug text-muted">
-          Every fire resumes the same accountable agent and conversational context.
-        </span>
-      </button>
-      {mode === 'resume' && (
-        <select
-          className={`${railControl} w-full`}
-          value={selected}
-          disabled={disabled}
-          aria-label="Responsible Session"
-          onChange={(event) => onChange({ mode: 'resume', resumeId: event.target.value })}
-        >
-          {choices.map((session) => (
-            <option key={session.resumeId} value={session.resumeId}>
-              {labelFor(session)} · {session.agent}
-            </option>
-          ))}
-          {!hasSelected && value?.mode === 'resume' && (
-            <option value={value.resumeId}>Unavailable owner · {value.resumeId}</option>
-          )}
-        </select>
-      )}
-      {choices.length === 0 && mode !== 'resume' && (
-        <p className="text-[11px] leading-snug text-muted">No resumable Session is available in this Workspace yet.</p>
-      )}
-    </div>
-  )
-}
-
 function PropertySection({
   title,
   description,
@@ -359,7 +238,6 @@ function PropertySection({
 
 function PropertiesRail({
   issue,
-  wsTag,
   agentOptions,
   issueDefaultAgent,
   defaultAgent,
@@ -371,7 +249,6 @@ function PropertiesRail({
   onConfigureAgent,
 }: {
   issue: IssueDetailIssue
-  wsTag?: string
   agentOptions: readonly { id: string; displayName: string; installed?: boolean }[]
   issueDefaultAgent: string | null
   defaultAgent: string | null
@@ -379,13 +256,15 @@ function PropertiesRail({
   sessions: readonly WorkspaceSessionDirectoryEntry[]
   saving: boolean
   error: string | null
-  onPatch: (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string }) => void
+  onPatch: (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string }) => void
   onConfigureAgent: (agent: AgentId) => void
 }) {
   const meta = STATUS_META[issue.status]
   const issueDefaultInOptions = issueDefaultAgent && agentOptions.some((a) => a.id === issueDefaultAgent) ? issueDefaultAgent : null
   const defaultInOptions = defaultAgent && agentOptions.some((a) => a.id === defaultAgent) ? defaultAgent : null
-  const ownerResumeId = issue.execution?.mode === 'resume' ? issue.execution.resumeId : null
+  const ownerResumeId = issue.assignee.startsWith('session:')
+    ? issue.assignee.slice('session:'.length)
+    : null
   const ownerSession = ownerResumeId
     ? sessions.find((session) => session.resumeId === ownerResumeId)
     : undefined
@@ -393,8 +272,8 @@ function PropertiesRail({
   const selectedReadiness = effectiveAgent ? agentReadiness[effectiveAgent] : undefined
   const agentNeedsCredential = selectedReadiness?.requiresCredential === true && !selectedReadiness.ready
   return (
-    <aside className="w-full shrink-0 space-y-3 lg:w-72">
-      <PropertySection title="Work item" description="Human tracking fields. These do not decide which agent runs the schedule.">
+    <aside className="w-full shrink-0 space-y-3 lg:col-start-2 lg:row-start-1 lg:row-span-2">
+      <PropertySection title="Work item" description="Ownership and schedule are part of this Issue.">
         <EditRow label="Status">
           <meta.Icon size={14} className={`shrink-0 ${meta.className}`} />
           <select
@@ -428,28 +307,16 @@ function PropertiesRail({
         <EditRow label="Assignee">
           <AssigneeEditor
             value={issue.assignee}
-            wsTag={wsTag}
+            scheduled={Boolean(issue.when)}
+            sessions={sessions}
             disabled={saving}
             onChange={(assignee) => onPatch({ assignee })}
           />
         </EditRow>
-      </PropertySection>
-
-      {issue.when && (
-        <PropertySection
-          title="Scheduled execution"
-          description="Choose whether each fire recruits a new worker or keeps one accountable Session."
-        >
+        {issue.when && (
+          <>
           <PropRow label="Cadence"><CadencePill when={issue.when} /></PropRow>
-          <div className="py-3">
-            <ExecutionEditor
-              value={issue.execution}
-              sessions={sessions}
-              disabled={saving}
-              onChange={(execution) => onPatch({ execution })}
-            />
-          </div>
-          {issue.execution?.mode === 'resume' ? (
+          {ownerResumeId ? (
             <PropRow label="Runtime">
               <span title="The responsible Session determines its runtime">
                 {ownerSession?.agent ?? 'Session-owned'}
@@ -478,8 +345,9 @@ function PropertiesRail({
           <PropRow label="Next run">
             {issue.nextDueAtMs ? formatRelativeTime(issue.nextDueAtMs) : <span className="text-muted">—</span>}
           </PropRow>
-        </PropertySection>
-      )}
+          </>
+        )}
+      </PropertySection>
       {error && <p className="mt-2 text-[11px] leading-snug text-red-400">{error}</p>}
     </aside>
   )
@@ -906,7 +774,6 @@ export function IssueDetail({
   onOpenIssue,
 }: IssueDetailProps) {
   const { data, error, loading, mutate } = useIssueDetail(wsId, id)
-  const { data: board } = useIssues()
   const { agents, defaultAgent, issueDefaultAgent, openAgentConfig, openHeadlessRun, workspaces } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
@@ -1015,10 +882,6 @@ export function IssueDetail({
     [gotoEntity, gotoIssue],
   )
 
-  // This workspace's tag — the `ws:<tag>` assignee option. Sourced from the
-  // board snapshot (the canonical wsId→tag map), which is process-cached and
-  // already warm when the detail is opened from a board row.
-  const wsTag = board?.workspaces.find((w) => w.wsId === wsId)?.tag
   const workspace = workspaces.find((w) => w.id === wsId) ?? null
   const agentOptions = agents.filter(
     (agent) =>
@@ -1027,7 +890,7 @@ export function IssueDetail({
   )
 
   const onPatch = useCallback(
-    async (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string }): Promise<boolean> => {
+    async (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string }): Promise<boolean> => {
       setSaving(true)
       setActionError(null)
       try {
@@ -1077,11 +940,15 @@ export function IssueDetail({
     </button>
   )
 
+  const stableOwnerResumeId = data?.issue.assignee.startsWith('session:')
+    ? data.issue.assignee.slice('session:'.length)
+    : null
+
   useEffect(() => {
-    if (inquiryTarget.relation === 'owner' && data?.issue.execution?.mode !== 'resume') {
+    if (inquiryTarget.relation === 'owner' && !stableOwnerResumeId) {
       setInquiryTarget({ relation: 'creator' })
     }
-  }, [data?.issue.execution, inquiryTarget.relation])
+  }, [stableOwnerResumeId, inquiryTarget.relation])
 
   if (!data) {
     return (
@@ -1111,7 +978,7 @@ export function IssueDetail({
     ...runs.map((run) => ({ kind: 'run' as const, id: run.taskId, at: run.startedAt, run })),
   ].sort((a, b) => b.at - a.at)
   const inquiryDescription = inquiryTarget.relation === 'owner'
-    ? 'Continue the one responsible Session declared by this Issue’s execution policy.'
+    ? 'Continue the Session assigned to this Issue.'
     : inquiryTarget.relation === 'run'
       ? `Continue the exact Session behind run ${inquiryTarget.runId}.`
       : 'Ask the attributable creator why this Issue exists. Legacy human-created Issues may require Workspace reconstruction.'
@@ -1119,8 +986,8 @@ export function IssueDetail({
   return (
     <div className="mx-auto max-w-4xl px-4 py-5 md:px-6">
       {backToBoard}
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <main className="min-w-0 flex-1">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
+        <main className="min-w-0 lg:col-start-1 lg:row-start-1">
           <div className="mb-1 flex items-center gap-2">
             <span className="font-mono text-[11px] text-muted/70">{id}</span>
             {issue.when && <CadencePill when={issue.when} />}
@@ -1148,7 +1015,7 @@ export function IssueDetail({
                 >
                   Creator
                 </button>
-                {issue.execution?.mode === 'resume' && (
+                {stableOwnerResumeId && (
                   <button
                     type="button"
                     onClick={() => setInquiryTarget({ relation: 'owner' })}
@@ -1167,19 +1034,9 @@ export function IssueDetail({
           />
           <IssueComments comments={comments} />
           <CommentComposer wsId={wsId} id={id} onPosted={mutate} />
-          <IssueActivity
-            activity={activity}
-            onContinue={continueProvenanceSession}
-            onAskRun={(run) => {
-              setInquiryTarget({ relation: 'run', runId: run.taskId })
-              window.requestAnimationFrame(() => document.getElementById('inquiries')?.scrollIntoView({ behavior: 'smooth', block: 'center' }))
-            }}
-          />
-          <InboxReportsSection reports={inboxReports} onOpen={gotoInbox} />
         </main>
         <PropertiesRail
           issue={issue}
-          wsTag={wsTag}
           agentOptions={agentOptions}
           issueDefaultAgent={issueDefaultAgent}
           defaultAgent={defaultAgent}
@@ -1190,6 +1047,17 @@ export function IssueDetail({
           onPatch={onPatch}
           onConfigureAgent={(agent) => openAgentConfig(wsId, agent)}
         />
+        <div className="min-w-0 lg:col-start-1 lg:row-start-2">
+          <IssueActivity
+            activity={activity}
+            onContinue={continueProvenanceSession}
+            onAskRun={(run) => {
+              setInquiryTarget({ relation: 'run', runId: run.taskId })
+              window.requestAnimationFrame(() => document.getElementById('inquiries')?.scrollIntoView({ behavior: 'smooth', block: 'center' }))
+            }}
+          />
+          <InboxReportsSection reports={inboxReports} onOpen={gotoInbox} />
+        </div>
       </div>
       {picker && (
         <WikilinkPicker

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -1,5 +1,5 @@
 import type { HeadlessTaskRecord } from '../../api/headless'
-import type { IssueComment, IssueDetail, IssueExecution, IssuePriority, IssueSnapshot, IssueStatus } from '../../api/issues'
+import type { IssueComment, IssueDetail, IssuePriority, IssueSnapshot, IssueStatus } from '../../api/issues'
 import { demoInboxEntries } from './inbox'
 
 // GET /api/issues aggregates every workspace's declared issues by SCANNING
@@ -11,8 +11,8 @@ import { demoInboxEntries } from './inbox'
 //
 // Coverage exercised by these fixtures: 2 workspaces; all five `status` values
 // (backlog/todo/in_progress/done/canceled); all five `priority` values
-// (urgent/high/medium/low/none); all three assignee shapes (human / ws:<tag> /
-// unassigned); all three `when` kinds (cron/every/at) plus unscheduled work
+// (urgent/high/medium/low/none); all four assignee shapes (workspace / session /
+// human / unassigned); all three `when` kinds (cron/every/at) plus unscheduled work
 // items (no `when`, no lastFired/nextDue).
 //
 // Also exercised: a CROSS-WORKSPACE NAME COLLISION. Both workspaces declare an
@@ -40,9 +40,8 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Morning movers scan',
           status: 'in_progress',
           priority: 'high',
-          assignee: 'ws:auto-quant',
+          assignee: 'workspace',
           agent: 'codex',
-          execution: { mode: 'fresh' },
           when: { kind: 'cron', cron: '30 8 * * 1-5' },
           lastFiredAtMs: now - HOUR,
           nextDueAtMs: now + 16 * HOUR,
@@ -53,9 +52,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Thesis invalidation watch',
           status: 'todo',
           priority: 'urgent',
-          assignee: 'ws:auto-quant',
-          agent: 'claude',
-          execution: { mode: 'resume', resumeId: 'demo-resume-thesis-owner' },
+          assignee: 'session:demo-resume-thesis-owner',
           when: { kind: 'every', every: '1h' },
           lastFiredAtMs: now - HOUR / 2,
           nextDueAtMs: now + HOUR / 2,
@@ -84,7 +81,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Liquidity risk review',
           status: 'todo',
           priority: 'high',
-          assignee: 'ws:auto-quant',
+          assignee: 'workspace',
           nameCollision: true,
         },
       ],
@@ -100,7 +97,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Weekly macro digest',
           status: 'in_progress',
           priority: 'medium',
-          assignee: 'ws:macro-research',
+          assignee: 'workspace',
           agent: 'codex',
           when: { kind: 'cron', cron: '0 16 * * 5' },
           lastFiredAtMs: now - 2 * DAY,
@@ -475,14 +472,13 @@ const demoIssueComments: Record<string, IssueComment[]> = {}
 export function demoIssueUpdate(
   wsId: string,
   id: string,
-  patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string },
+  patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string },
 ): IssueDetail | null {
   const boardIssue = findBoardIssue(wsId, id)
   if (!boardIssue) return null
   if (patch.status !== undefined) boardIssue.status = patch.status
   if (patch.priority !== undefined) boardIssue.priority = patch.priority
   if (patch.assignee !== undefined) boardIssue.assignee = patch.assignee
-  if (patch.execution !== undefined) boardIssue.execution = patch.execution
   if (patch.what !== undefined) {
     const key = `${wsId}/${id}`
     const existing = demoIssueExtras[key]

--- a/ui/src/demo/fixtures/schedule.ts
+++ b/ui/src/demo/fixtures/schedule.ts
@@ -12,6 +12,7 @@ export const demoScheduleSnapshot: ScheduleSnapshot = {
       tasks: [
         {
           id: 'morning-scan',
+          assignee: 'workspace',
           issue: 'Morning movers scan',
           when: { kind: 'cron', cron: '30 8 * * 1-5' },
           what: 'Pull pre-market movers and overnight news for the watchlist, write a brief, then push it to the inbox.',
@@ -21,6 +22,7 @@ export const demoScheduleSnapshot: ScheduleSnapshot = {
         },
         {
           id: 'thesis-watch',
+          assignee: 'session:demo-resume-thesis-owner',
           issue: 'Thesis invalidation watch',
           when: { kind: 'every', every: '1h' },
           what: 'Re-check the thesis vs the latest quote; alert only if the invalidation level broke, otherwise exit.',
@@ -38,6 +40,7 @@ export const demoScheduleSnapshot: ScheduleSnapshot = {
       tasks: [
         {
           id: 'weekly-digest',
+          assignee: 'workspace',
           issue: 'Weekly macro digest',
           when: { kind: 'cron', cron: '0 16 * * 5' },
           what: 'Summarize the week across tracked entities and push a digest to the inbox.',

--- a/ui/src/demo/handlers/issues.ts
+++ b/ui/src/demo/handlers/issues.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw'
-import type { IssueExecution, IssuePriority, IssueStatus } from '../../api/issues'
+import type { IssuePriority, IssueStatus } from '../../api/issues'
 import {
   demoIssueAddComment,
   demoIssueDetail,
@@ -60,14 +60,13 @@ export const issuesHandlers = [
       priority?: unknown
       assignee?: unknown
       agent?: unknown
-      execution?: unknown
       what?: unknown
     } | null
     if (!body || typeof body !== 'object') {
       return HttpResponse.json({ error: 'invalid_body' }, { status: 400 })
     }
 
-    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; execution?: IssueExecution; what?: string } = {}
+    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string } = {}
     if (body.status !== undefined) {
       if (!ISSUE_STATUSES.includes(body.status as IssueStatus)) {
         return HttpResponse.json({ error: 'invalid_status' }, { status: 400 })
@@ -99,15 +98,6 @@ export const issuesHandlers = [
         patch.agent = agent
       }
     }
-    if (body.execution !== undefined) {
-      const execution = body.execution as Partial<IssueExecution>
-      if (execution.mode === 'fresh') patch.execution = { mode: 'fresh' }
-      else if (execution.mode === 'resume' && typeof execution.resumeId === 'string' && execution.resumeId) {
-        patch.execution = { mode: 'resume', resumeId: execution.resumeId }
-      } else {
-        return HttpResponse.json({ error: 'invalid_execution' }, { status: 400 })
-      }
-    }
     if (body.what !== undefined) {
       if (typeof body.what !== 'string' || !body.what.trim()) {
         return HttpResponse.json({ error: 'invalid_what' }, { status: 400 })
@@ -119,7 +109,6 @@ export const issuesHandlers = [
       patch.priority === undefined &&
       patch.assignee === undefined &&
       patch.agent === undefined
-      && patch.execution === undefined
       && patch.what === undefined
     ) {
       return HttpResponse.json({ error: 'no_fields' }, { status: 400 })


### PR DESCRIPTION
## What changed

- replace the parallel Issue `assignee` and `execution` fields with one ownership contract: `workspace`, `session:<resumeId>`, `human`, or `unassigned`
- make schedule behavior intrinsic to the Work item: Workspace ownership recruits a new Session; Session ownership resumes that exact Session
- add migration 0018 to rewrite existing Issue files and remove the retired `execution` field
- let the Issue UI choose resumable Workspace Sessions from Assignee and keep Session runtime identity authoritative
- reorder narrow Issue detail so Work item/schedule appears before Activity and Inbox reports
- update agent tools, templates, skills, docs, demo fixtures, and inquiry owner resolution

## Why

Issue responsibility and scheduled execution described the same decision in two places. That made the UI confusing and allowed contradictory owner/runtime states. One assignee contract makes the Issue self-contained for humans, agents, and the scheduler.

## Validation

- `pnpm test` — 2621 passed, 6 skipped
- `pnpm build`
- `pnpm -C ui build`
- real browser verification on a Workspace Issue
- demo interaction: switch Workspace/Session ownership and verify Owner/runtime behavior
- 760px responsive verification: What → Work item → Activity
- packaged Electron smoke with isolated data; migrations through 0018 applied and renderer bridge became ready
