### PR TITLE
Add durable Session signatures

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -156,9 +156,10 @@ alice-workspace issue list --mode detailed  # full global board, including low-p
 alice-workspace issue show --id <name>      # compact issue + provenance/resumeId run/report references
 alice-workspace issue show --id <name> --mode detailed  # every execution prompt + full reports
 alice-workspace issue create --title "…"    # a new issue on THIS workspace's board
-alice-workspace issue create --title "…" --when '{"kind":"every","every":"1h"}' --assignee session:self
+alice-workspace issue create --title "…" --when '{"kind":"every","every":"1h"}' --assignee @me
 alice-workspace issue update --id <id> --status in_progress
 alice-workspace issue comment --id <id> --text "progress note / finding"
+alice-workspace signature show               # your @resumeId for standalone Markdown
 ```
 
 Work it like a human board: start with plain `list`, decide which focus rows
@@ -169,6 +170,8 @@ the whole board (all workspaces); `create` / `update` / `comment` write **this**
 workspace's own `.alice/issues/` files (changing a peer's board is the
 human-approved peer-edit path). The full on-disk file model + self-scheduling
 (an issue with a `when` fires a headless run) lives in the **`self-scheduling`**
-skill. `assignee` is the single ownership and dispatch contract: `workspace`
-recruits a new Session each fire, while `session:self` or
-`session:<resumeId>` keeps one accountable product Session.
+skill. `assignee` is the single ownership and dispatch contract: `@workspace`
+recruits a new Session each fire, `@me` resolves to the caller, and an exact
+`@resumeId` keeps one accountable product Session. Issue/Inbox CLI actions are
+signed automatically. End standalone reports with `Signed-by: @resumeId`
+(copy it from `signature show`) so another Agent can return to the author.

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -88,7 +88,7 @@ as `--when`:
 ```bash
 alice-workspace issue create --title "Pre-market brief" --priority high \
   --when '{"kind":"cron","cron":"30 8 * * 1-5"}' \
-  --assignee session:self \
+  --assignee @me \
   --what "Pull pre-market movers and overnight news for my watchlist, write a short brief to research/premarket.md, then run: alice-workspace inbox push --doc research/premarket.md --comments 'Pre-market brief'." \
   --agent claude
 ```
@@ -109,7 +109,7 @@ on-disk file shape the CLI and your direct edits both produce.
 title: Pre-market brief
 status: todo
 priority: high
-assignee: session:resume-calm-amber-river-a1b2c3
+assignee: "@resume-calm-amber-river-a1b2c3"
 when: { kind: cron, cron: "30 8 * * 1-5" }
 ---
 
@@ -153,13 +153,15 @@ plain tracked item; add a `when` and it starts firing.
   (There is no `enabled` field — terminal status is how you pause a timer.)
 - **`priority`** *(optional, default `none`)* — `urgent`, `high`, `medium`,
   `low`, `none`. Display/sort only.
-- **`assignee`** *(optional, default `workspace`)* — the single owner and
+- **`assignee`** *(optional)* — the single owner and
   scheduled-dispatch policy:
-  - `workspace` recruits a new product Session for each scheduled fire;
-  - `session:<resumeId>` continues that exact accountable Session;
-  - `human` and `unassigned` are valid only for unscheduled work.
-  The CLI convenience value `session:self` resolves to the caller's concrete
-  `session:<resumeId>` before writing the file.
+  - `@workspace` recruits a new product Session for each scheduled fire;
+  - an exact `@resumeId` continues that accountable Session, even when its
+    signed Workspace differs from the Issue's Workspace;
+  - `@human` and `@unassigned` are valid only for unscheduled work.
+  CLI `issue create` defaults to `@me` when called by an attributable Session
+  (who creates it owns it); `@me` is resolved to a concrete `@resumeId` before
+  writing. Use `@workspace` explicitly when every fire should recruit a newcomer.
 - **`when`** *(OPTIONAL — present iff the issue self-schedules)* — one of:
   - `{ kind: every, every: "30m" }` — repeat on an interval (`30m`, `2h`,
     `1h30m`). Runs on the next scan, then on the interval.

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -5,6 +5,27 @@ Sessions and everything they create: reports, Inbox notifications, Issues, and
 trade decisions. It is the design spine for features such as “ask the sender,”
 “ask the Issue owner,” and “why did this agent initiate this trade?”
 
+## Session signature
+
+`resumeId` is OpenAlice's unique Session identity; `@resumeId` is its visible
+signature. Every live interactive/headless Agent receives
+`OPENALICE_RESUME_ID` and `OPENALICE_SIGNATURE`, while
+`alice-workspace signature show` resolves the same identity through the
+authoritative request origin. Environment values help the Agent remember its
+name; server-side origin resolution remains the authority for structured
+Inbox, Issue, and trade actions.
+
+Standalone Markdown stays self-contained and should end with:
+
+```md
+---
+
+Signed-by: @resume-calm-amber-river-a1b2c3
+```
+
+The UI renders that signature as a link back to the exact product Session.
+Reports do not need a parallel metadata sidecar merely to carry authorship.
+
 Related guides: [[docs/project-structure.md]] and
 [[docs/workspace-issues-and-scheduling.md]]. This is a provenance/indexing
 contract, not a revival of the retired event-bus scheduler described in
@@ -257,11 +278,12 @@ instead of creating another parallel timeline.
 #### Mode A: one responsible Session
 
 ```yaml
-assignee: session:resume-calm-amber-river-a1b2c3
+assignee: "@resume-calm-amber-river-a1b2c3"
 ```
 
 - Every scheduled fire continues that exact `resumeId`.
-- The responsible Session must belong to the Issue's owning Workspace.
+- The responsible Session may be in another Workspace when the exact signature
+  was deliberately carried in from a signed artifact.
 - The Session's bound runtime is authoritative; the Issue's top-level `agent`
   cannot override it.
 - Run `taskId`s change; the product Session does not.
@@ -269,15 +291,15 @@ assignee: session:resume-calm-amber-river-a1b2c3
 - If the Session becomes unresumable, the Issue becomes blocked/unavailable;
   it must not silently recruit a replacement and pretend continuity.
 
-For agent-facing `issue_create`, `assignee: session:self` binds the caller's
+For agent-facing `issue_create`, omitted assignee or `@me` binds the caller's
 authoritative product Session; OpenAlice resolves and persists the concrete
-`session:<resumeId>` value server-side. A human UI may select an existing
-resumable Workspace Session.
+`@resumeId` server-side. `@me` is never stored. A human UI may select an
+existing resumable Workspace Session.
 
 #### Mode B: a fresh worker per fire
 
 ```yaml
-assignee: workspace
+assignee: "@workspace"
 ```
 
 - Every scheduled fire creates a new headless product Session and `resumeId`.
@@ -300,7 +322,7 @@ Typical questions then resolve without ambiguity:
 |---|---|
 | Why does this Issue exist? | Issue `created` provenance |
 | Why was its priority changed? | Matching `updated` provenance |
-| Ask the responsible owner | Declared `session:<resumeId>` assignee |
+| Ask the responsible owner | Declared `@resumeId` assignee |
 | Why did yesterday's report say this? | That run's `resumeId` |
 | What does the latest Workspace worker think? | Explicit latest-run selection |
 
@@ -361,7 +383,7 @@ the scan?”, “who wrote the 10 July report?”, and “who ran it most recent
 three different provenance queries.
 
 If the user instead wants one analyst to accumulate memory across days, the
-Issue must declare `assignee: session:<resumeId>` and keep one responsible
+Issue must declare `assignee: "@resumeId"` and keep one responsible
 product Session.
 
 ### Legacy Inbox with no sender Session
@@ -390,8 +412,8 @@ approval state, routing, fills, and slippage.
 9. Mutable artifacts retain occurrence-level provenance instead of one mutable
    “author” field.
 10. Issue creation provenance and future execution responsibility are separate.
-11. Issue assignee is the only ownership/dispatch contract: `workspace` or an
-    exact `session:<resumeId>` for scheduled work.
+11. Issue assignee is the only ownership/dispatch contract: `@workspace` or an
+    exact `@resumeId` for scheduled work.
 12. Trade decision attribution and trade execution authority remain separate.
 13. Provenance is stamped from authoritative context, not asserted by an agent.
 14. Existing UUID `resumeId`s remain valid; readable ids apply only to new

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -33,7 +33,7 @@ workspaces.
 title: Pre-market brief
 status: todo
 priority: high
-assignee: workspace
+assignee: "@workspace"
 when: { kind: cron, cron: "30 8 * * 1-5" }
 agent: pi
 ---
@@ -48,21 +48,23 @@ The filename stem is the stable issue id. Frontmatter:
 - `status` — `backlog | todo | in_progress | done | canceled`; default `todo`.
 - `priority` — `urgent | high | medium | low | none`; default `none`.
 - `assignee` — the single ownership and dispatch contract:
-  - `workspace` means the owning Workspace recruits a new product Session for
+  - `@workspace` means the owning Workspace recruits a new product Session for
     every scheduled fire;
-  - `session:<resumeId>` continues one exact accountable product Session;
-  - `human` or `unassigned` is valid only for unscheduled work.
+  - an exact `@resumeId` continues one accountable product Session;
+  - `@human` or `@unassigned` is valid only for unscheduled work.
 - `when` — optional schedule:
   - `{ kind: at, at: <ISO timestamp> }`
   - `{ kind: every, every: <duration> }`
   - `{ kind: cron, cron: <5-field expression> }`
-- `agent` — optional CLI adapter id for `workspace`-owned scheduled work;
+- `agent` — optional CLI adapter id for `@workspace`-owned scheduled work;
   otherwise Workspace/default resolution is used. A Session assignee already
   owns its runtime and cannot be overridden here.
 
 Migration `0018_issue_assignee_ownership` removes the retired parallel
-`execution` field. It maps `resume` to `session:<resumeId>` and fresh/omitted
-scheduled ownership to `workspace`; the reader only accepts the new contract.
+`execution` field. It maps `resume` to the former `session:<resumeId>` shape and
+fresh/omitted scheduled ownership to the former `workspace` shape.
+Migration `0019_issue_session_signatures` then writes those owners as
+`@resumeId` / `@workspace`, the same visible signature language used in reports.
 
 The markdown below frontmatter is the Issue's canonical **What**: the work
 definition humans inspect and edit. For scheduled Issues, Alice sends this exact
@@ -212,8 +214,8 @@ use a later collect or one-shot read; agents should not manufacture shell sleep
 loops.
 
 The Issue detail UI treats scheduling as an intrinsic Work item capability.
-`assignee: workspace` recruits a new Session on every fire;
-`assignee: session:<resumeId>` keeps one responsible Session. Only the latter
+`assignee: "@workspace"` recruits a new Session on every fire;
+`assignee: "@resumeId"` keeps one responsible Session. Only the latter
 has a stable owner to ask; Workspace-owned execution exposes the creator and
 each concrete run as separate follow-up targets.
 

--- a/src/core/inbox-store.ts
+++ b/src/core/inbox-store.ts
@@ -73,6 +73,8 @@ export interface InboxOrigin {
   runId?: string
   /** The scheduled issue that fired the run, when applicable. */
   issueId?: string
+  /** The Issue's home Workspace; may differ from the executing Session's Workspace. */
+  issueWorkspaceId?: string
   /** The interactive session's pre-allocated SessionRegistry record id. */
   sessionId?: string
   /** Stable product conversation identity. Native runtime ids stay server-side. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,7 @@ import { createEntityStore } from './core/entity-store.js'
 import { entityUpsertFactory } from './tool/entity-upsert.js'
 import { entitySearchFactory } from './tool/entity-search.js'
 import { issueToolFactories } from './tool/issue-tools.js'
+import { sessionSignatureFactory } from './tool/session-signature.js'
 import { provenanceShowFactory } from './tool/provenance-show.js'
 import { conversationToolFactories } from './tool/conversation.js'
 import { artifactConversationToolFactories } from './tool/conversation-artifacts.js'
@@ -117,6 +118,7 @@ async function main() {
   workspaceToolCenter.register(entityUpsertFactory)
   workspaceToolCenter.register(entitySearchFactory)
   for (const f of issueToolFactories) workspaceToolCenter.register(f)
+  workspaceToolCenter.register(sessionSignatureFactory)
   workspaceToolCenter.register(provenanceShowFactory)
   for (const f of conversationToolFactories) workspaceToolCenter.register(f)
   for (const f of artifactConversationToolFactories) workspaceToolCenter.register(f)

--- a/src/migrations/0010_workspace_issues_to_markdown.spec.ts
+++ b/src/migrations/0010_workspace_issues_to_markdown.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { migrateWorkspaceIssues } from './0010_workspace_issues_to_markdown/index.js'
+import { migrateIssueSessionSignatures } from './0019_issue_session_signatures/index.js'
 // Round-trip through the REAL reader — the strongest guarantee that what the
 // migration writes is exactly what the running launcher will read back.
 import { readWorkspaceIssues } from '@/workspaces/issues/declaration.js'
@@ -49,7 +50,8 @@ describe('0010 workspace issues → markdown', () => {
     // legacy file removed
     await expect(stat(join(wsDir['ws1'], '.alice', 'issue.json'))).rejects.toThrow()
 
-    // round-trip through the real reader
+    await migrateIssueSessionSignatures(root)
+    // round-trip through the current real reader after the ownership migrations
     const read = await readWorkspaceIssues(wsDir['ws1'])
     expect(read.ok).toBe(true)
     if (!read.ok) return
@@ -61,7 +63,7 @@ describe('0010 workspace issues → markdown', () => {
     expect(byId['morning-scan'].agent).toBe('codex')
     expect(byId['morning-scan'].status).toBe('todo') // board default
     expect(byId['morning-scan'].priority).toBe('none')
-    expect(byId['morning-scan'].assignee).toBe('workspace')
+    expect(byId['morning-scan'].assignee).toBe('@workspace')
 
     // enabled:false → terminal status so the schedule stops firing
     expect(byId['paused-one'].status).toBe('canceled')

--- a/src/migrations/0011_workspace_issue_assignee_defaults.spec.ts
+++ b/src/migrations/0011_workspace_issue_assignee_defaults.spec.ts
@@ -7,6 +7,7 @@ import { readWorkspaceIssues } from '@/workspaces/issues/declaration.js'
 import { snapshotBoardIssue } from '@/workspaces/issues/board.js'
 
 import { migrateWorkspaceIssueAssigneeDefaults } from './0011_workspace_issue_assignee_defaults/index.js'
+import { migrateIssueSessionSignatures } from './0019_issue_session_signatures/index.js'
 
 let root: string
 const wsDir: Record<string, string> = {}
@@ -48,11 +49,13 @@ describe('0011 workspace issue assignee defaults', () => {
     const raw = await readFile(join(wsDir['chat-jul3'], '.alice', 'issues', 'scan.md'), 'utf-8')
     expect(raw).not.toContain('assignee:')
 
+    await migrateIssueSessionSignatures(root)
+
     const read = await readWorkspaceIssues(wsDir['chat-jul3'])
     expect(read.ok).toBe(true)
     if (!read.ok) return
-    expect(read.issues[0].assignee).toBe('workspace')
-    expect(snapshotBoardIssue(read.issues[0], null).assignee).toBe('workspace')
+    expect(read.issues[0].assignee).toBe('@workspace')
+    expect(snapshotBoardIssue(read.issues[0], null).assignee).toBe('@workspace')
   })
 
   it('leaves explicit non-default assignees untouched and is idempotent', async () => {
@@ -63,10 +66,12 @@ describe('0011 workspace issue assignee defaults', () => {
     expect(await migrateWorkspaceIssueAssigneeDefaults(root)).toEqual({ updated: 0, workspaces: 0 })
     expect(await migrateWorkspaceIssueAssigneeDefaults(root)).toEqual({ updated: 0, workspaces: 0 })
 
+    await migrateIssueSessionSignatures(root)
+
     const read = await readWorkspaceIssues(wsDir['chat-jul4'])
     expect(read.ok).toBe(true)
     if (!read.ok) return
-    expect(read.issues.find((issue) => issue.id === 'human')?.assignee).toBe('human')
+    expect(read.issues.find((issue) => issue.id === 'human')?.assignee).toBe('@human')
   })
 
   it('skips malformed issue files without blocking other files', async () => {

--- a/src/migrations/0018_issue_assignee_ownership.spec.ts
+++ b/src/migrations/0018_issue_assignee_ownership.spec.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { readWorkspaceIssues } from '@/workspaces/issues/declaration.js'
 
 import { migrateIssueAssigneeOwnership } from './0018_issue_assignee_ownership/index.js'
+import { migrateIssueSessionSignatures } from './0019_issue_session_signatures/index.js'
 
 let root: string
 let wsDir: string
@@ -57,15 +58,16 @@ Do fresh work.
     expect(fresh).toContain('assignee: workspace')
     expect(fresh).not.toMatch(/^execution:/m)
 
+    expect(await migrateIssueAssigneeOwnership(root)).toEqual({ updated: 0, workspaces: 0 })
+    await migrateIssueSessionSignatures(root)
+
     const issues = await readWorkspaceIssues(wsDir)
     expect(issues.ok).toBe(true)
     if (!issues.ok) return
     expect(issues.issues.map((issue) => [issue.id, issue.assignee])).toEqual([
-      ['fresh', 'workspace'],
-      ['owned', 'session:resume-calm-cedar-a1b2c3'],
+      ['fresh', '@workspace'],
+      ['owned', '@resume-calm-cedar-a1b2c3'],
     ])
-
-    expect(await migrateIssueAssigneeOwnership(root)).toEqual({ updated: 0, workspaces: 0 })
   })
 
   it('normalizes old workspace labels while preserving unscheduled human ownership', async () => {
@@ -85,12 +87,13 @@ Human-owned.
 `, 'utf8')
 
     await migrateIssueAssigneeOwnership(root)
+    await migrateIssueSessionSignatures(root)
     const issues = await readWorkspaceIssues(wsDir)
     expect(issues.ok).toBe(true)
     if (!issues.ok) return
     expect(issues.issues.map((issue) => [issue.id, issue.assignee])).toEqual([
-      ['human', 'human'],
-      ['workspace', 'workspace'],
+      ['human', '@human'],
+      ['workspace', '@workspace'],
     ])
   })
 })

--- a/src/migrations/0019_issue_session_signatures.spec.ts
+++ b/src/migrations/0019_issue_session_signatures.spec.ts
@@ -1,0 +1,28 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { migrateIssueSessionSignatures } from './0019_issue_session_signatures/index.js'
+
+let root: string
+let wsDir: string
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'mig0019-'))
+  wsDir = join(root, 'ws')
+  await mkdir(join(wsDir, '.alice', 'issues'), { recursive: true })
+  await writeFile(join(root, 'workspaces.json'), JSON.stringify({ workspaces: [{ id: 'ws', tag: 'ws', dir: wsDir, agents: [] }] }))
+})
+afterEach(async () => { await rm(root, { recursive: true, force: true }) })
+
+describe('0019 Issue Session signatures', () => {
+  it('migrates legacy ownership once and preserves the markdown body', async () => {
+    await writeFile(join(wsDir, '.alice', 'issues', 'owned.md'), `---\ntitle: Owned\nassignee: session:resume-kind-owl-abc123\n---\n\nKeep **this**.\n`)
+    expect(await migrateIssueSessionSignatures(root)).toEqual({ updated: 1, workspaces: 1 })
+    const raw = await readFile(join(wsDir, '.alice', 'issues', 'owned.md'), 'utf8')
+    expect(raw).toContain('assignee: "@resume-kind-owl-abc123"')
+    expect(raw).toContain('Keep **this**.')
+    expect(await migrateIssueSessionSignatures(root)).toEqual({ updated: 0, workspaces: 0 })
+  })
+})
+

--- a/src/migrations/0019_issue_session_signatures/index.ts
+++ b/src/migrations/0019_issue_session_signatures/index.ts
@@ -1,0 +1,88 @@
+/** 0019_issue_session_signatures — make Issue ownership use the same
+ * human-readable `@resumeId` signature agents place in Markdown artifacts. */
+import { mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+
+import type { Migration } from '../types.js'
+
+interface WorkspaceMeta { dir: string }
+
+function defaultLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+function splitFrontmatter(raw: string): { frontmatter: string; body: string } | null {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---([\s\S]*)$/.exec(raw)
+  return match ? { frontmatter: match[1]!, body: match[2]! } : null
+}
+
+function signedAssignee(value: unknown): string {
+  if (typeof value !== 'string') return '@workspace'
+  if (value.startsWith('session:')) return `@${value.slice('session:'.length)}`
+  if (value === 'human') return '@human'
+  if (value === 'unassigned') return '@unassigned'
+  if (value === 'workspace') return '@workspace'
+  return value
+}
+
+async function writeAtomic(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp`
+  await writeFile(tmp, content, 'utf8')
+  await rename(tmp, path)
+}
+
+async function migrateOne(path: string): Promise<boolean> {
+  const raw = await readFile(path, 'utf8')
+  const split = splitFrontmatter(raw)
+  if (!split) return false
+  let parsed: unknown
+  try { parsed = parseYaml(split.frontmatter) } catch { return false }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false
+  const frontmatter = parsed as Record<string, unknown>
+  const next = signedAssignee(frontmatter.assignee)
+  if (frontmatter.assignee === next) return false
+  frontmatter.assignee = next
+  const body = split.body.startsWith('\n') ? split.body : `\n${split.body}`
+  await writeAtomic(path, `---\n${stringifyYaml(frontmatter).trimEnd()}\n---${body}`)
+  return true
+}
+
+export async function migrateIssueSessionSignatures(
+  launcherRoot: string = defaultLauncherRoot(),
+): Promise<{ updated: number; workspaces: number }> {
+  let registry: { workspaces?: WorkspaceMeta[] }
+  try { registry = JSON.parse(await readFile(join(launcherRoot, 'workspaces.json'), 'utf8')) as typeof registry }
+  catch { return { updated: 0, workspaces: 0 } }
+  let updated = 0
+  let workspaces = 0
+  for (const ws of registry.workspaces ?? []) {
+    const dir = join(ws.dir, '.alice', 'issues')
+    let files: string[]
+    try { files = (await readdir(dir)).filter((name) => name.toLowerCase().endsWith('.md')) }
+    catch { continue }
+    let touched = false
+    for (const file of files) {
+      try {
+        if (await migrateOne(join(dir, file))) { updated++; touched = true }
+      } catch (err) {
+        console.log(`[migration 0019] skipped ${join(dir, file)}: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+    if (touched) workspaces++
+  }
+  return { updated, workspaces }
+}
+
+export const migration: Migration = {
+  id: '0019_issue_session_signatures',
+  appVersion: '0.75.0-beta',
+  introducedAt: '2026-07-12',
+  affects: ['workspaces/<id>/.alice/issues/*.md'],
+  summary: 'Write Issue ownership as @workspace or an exact @resumeId Session signature.',
+  rationale: 'One visible signature syntax should identify accountable Sessions across Issue and Markdown artifacts.',
+  up: async () => { await migrateIssueSessionSignatures() },
+}

--- a/src/migrations/0020_headless_issue_trigger.spec.ts
+++ b/src/migrations/0020_headless_issue_trigger.spec.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { migrateHeadlessIssueTrigger } from './0020_headless_issue_trigger/index.js'
+
+let root: string
+beforeEach(async () => { root = await mkdtemp(join(tmpdir(), 'mig0020-')); await mkdir(join(root, 'state')) })
+afterEach(async () => { await rm(root, { recursive: true, force: true }) })
+
+describe('0020 headless Issue trigger', () => {
+  it('converts the implicit same-Workspace link to a composite trigger', async () => {
+    const path = join(root, 'state', 'headless-tasks.json')
+    await writeFile(path, JSON.stringify({ version: 2, tasks: [
+      { taskId: 'run-1', wsId: 'ws-home', issueId: 'daily-scan' },
+      { taskId: 'run-2', wsId: 'ws-manual' },
+    ] }))
+    expect(await migrateHeadlessIssueTrigger(root)).toEqual({ updated: 1 })
+    const saved = JSON.parse(await readFile(path, 'utf8'))
+    expect(saved.version).toBe(3)
+    expect(saved.tasks[0]).not.toHaveProperty('issueId')
+    expect(saved.tasks[0].trigger).toEqual({ kind: 'issue', workspaceId: 'ws-home', issueId: 'daily-scan' })
+  })
+})
+

--- a/src/migrations/0020_headless_issue_trigger/index.ts
+++ b/src/migrations/0020_headless_issue_trigger/index.ts
@@ -1,0 +1,48 @@
+/** 0020_headless_issue_trigger — preserve the Issue's home Workspace separately
+ * from the Workspace where a signed Session executes. */
+import { readFile, rename, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import type { Migration } from '../types.js'
+
+function defaultLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+export async function migrateHeadlessIssueTrigger(
+  launcherRoot: string = defaultLauncherRoot(),
+): Promise<{ updated: number }> {
+  const path = join(launcherRoot, 'state', 'headless-tasks.json')
+  let parsed: { version?: number; tasks?: Array<Record<string, unknown>> }
+  try { parsed = JSON.parse(await readFile(path, 'utf8')) as typeof parsed }
+  catch { return { updated: 0 } }
+  if (!Array.isArray(parsed.tasks)) return { updated: 0 }
+  let updated = 0
+  for (const task of parsed.tasks) {
+    const issueId = typeof task['issueId'] === 'string' ? task['issueId'] : null
+    const wsId = typeof task['wsId'] === 'string' ? task['wsId'] : null
+    if (issueId && wsId) {
+      task['trigger'] = { kind: 'issue', workspaceId: wsId, issueId }
+      delete task['issueId']
+      updated++
+    }
+  }
+  if (updated === 0 && parsed.version === 3) return { updated: 0 }
+  parsed.version = 3
+  const tmp = `${path}.tmp`
+  await writeFile(tmp, JSON.stringify(parsed, null, 2), 'utf8')
+  await rename(tmp, path)
+  return { updated }
+}
+
+export const migration: Migration = {
+  id: '0020_headless_issue_trigger',
+  appVersion: '0.75.0-beta',
+  introducedAt: '2026-07-12',
+  affects: ['workspaces/state/headless-tasks.json'],
+  summary: 'Store the composite Issue trigger separately from a run execution Workspace.',
+  rationale: 'An exact signed Session may execute a scheduled Issue across Workspace boundaries without breaking Activity attribution.',
+  up: async () => { await migrateHeadlessIssueTrigger() },
+}
+

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -18,3 +18,5 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0016_artifact_provenance_store` | 0.75.0-beta | 2026-07-11 | workspaces/state/artifact-provenance.json | Create the durable product Session to artifact provenance store. |
 | `0017_issue_what_and_comment_sidecars` | 0.75.0-beta | 2026-07-12 | workspaces/<id>/.alice/issues/*.md, workspaces/<id>/.alice/issues/*.comments.json | Make markdown What the sole Issue work definition and move comments into structured per-Issue JSON sidecars. |
 | `0018_issue_assignee_ownership` | 0.75.0-beta | 2026-07-12 | workspaces/<id>/.alice/issues/*.md | Replace Issue execution ownership with one workspace, human, unassigned, or Session assignee. |
+| `0019_issue_session_signatures` | 0.75.0-beta | 2026-07-12 | workspaces/<id>/.alice/issues/*.md | Write Issue ownership as @workspace or an exact @resumeId Session signature. |
+| `0020_headless_issue_trigger` | 0.75.0-beta | 2026-07-12 | workspaces/state/headless-tasks.json | Store the composite Issue trigger separately from a run execution Workspace. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -14,7 +14,7 @@
  * deletion + Workspace pivot turned the pre-0.40 data shapes over completely, so
  * pre-0.40 installs rebuild `data/` rather than migrate. The framework stays for
  * future upgrades. Numbering continues FORWARD from the highest id ever shipped
- * (next: 0018) — never reuse a retired id, since existing installs' journals
+ * (next: 0021) — never reuse a retired id, since existing installs' journals
  * recorded the old ones.
  */
 
@@ -30,6 +30,8 @@ import { migration as migration_0015_resume_identity_registry } from './0015_res
 import { migration as migration_0016_artifact_provenance_store } from './0016_artifact_provenance_store/index.js'
 import { migration as migration_0017_issue_what_and_comment_sidecars } from './0017_issue_what_and_comment_sidecars/index.js'
 import { migration as migration_0018_issue_assignee_ownership } from './0018_issue_assignee_ownership/index.js'
+import { migration as migration_0019_issue_session_signatures } from './0019_issue_session_signatures/index.js'
+import { migration as migration_0020_headless_issue_trigger } from './0020_headless_issue_trigger/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -43,4 +45,6 @@ export const REGISTRY: Migration[] = [
   migration_0016_artifact_provenance_store,
   migration_0017_issue_what_and_comment_sidecars,
   migration_0018_issue_assignee_ownership,
+  migration_0019_issue_session_signatures,
+  migration_0020_headless_issue_trigger,
 ]

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -23,6 +23,7 @@ import { workspaceSessionsFactory } from '../tool/workspace-sessions.js'
 import { entityUpsertFactory } from '../tool/entity-upsert.js'
 import { entitySearchFactory } from '../tool/entity-search.js'
 import { issueToolFactories } from '../tool/issue-tools.js'
+import { sessionSignatureFactory } from '../tool/session-signature.js'
 import { provenanceShowFactory } from '../tool/provenance-show.js'
 import { conversationToolFactories } from '../tool/conversation.js'
 import { artifactConversationToolFactories } from '../tool/conversation-artifacts.js'
@@ -92,6 +93,7 @@ describe('CLI_EXPORTS — workspace export (scoped collaboration tools)', () => 
   wtc.register(entityUpsertFactory)
   wtc.register(entitySearchFactory)
   for (const f of issueToolFactories) wtc.register(f)
+  wtc.register(sessionSignatureFactory)
   wtc.register(provenanceShowFactory)
   for (const f of conversationToolFactories) wtc.register(f)
   for (const f of artifactConversationToolFactories) wtc.register(f)

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -187,6 +187,9 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       provenance: {
         show: 'provenance_show',
       },
+      signature: {
+        show: 'session_signature',
+      },
       conversation: {
         ask: 'conversation_ask',
         await: 'conversation_await',

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -257,7 +257,10 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
       headlessTasks: {
         get: (taskId: string) =>
           taskId === 'run-7'
-            ? { taskId: 'run-7', issueId: 'macro-scan', agent: 'opencode' }
+            ? {
+                taskId: 'run-7', resumeId: 'resume-7', agent: 'opencode',
+                trigger: { kind: 'issue', workspaceId: 'ws1', issueId: 'macro-scan' },
+              }
             : null,
       },
       sessionRegistry: {
@@ -295,7 +298,9 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
     expect(entries[0].origin).toEqual({
       kind: 'headless',
       runId: 'run-7',
+      resumeId: 'resume-7',
       issueId: 'macro-scan',
+      issueWorkspaceId: 'ws1',
       agent: 'opencode',
     })
   })
@@ -336,7 +341,9 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
     expect(entries[0].origin).toEqual({
       kind: 'headless',
       runId: 'run-7',
+      resumeId: 'resume-7',
       issueId: 'macro-scan',
+      issueWorkspaceId: 'ws1',
       agent: 'opencode',
     })
   })

--- a/src/server/inbox-origin.spec.ts
+++ b/src/server/inbox-origin.spec.ts
@@ -5,7 +5,7 @@ import { resolveInboxOrigin } from './inbox-origin.js'
 
 /** Build a structural fake service with both authorities. */
 function svc(opts: {
-  headless?: Record<string, { taskId: string; resumeId: string; issueId?: string; agent: string }>
+  headless?: Record<string, { taskId: string; resumeId: string; trigger?: { kind: 'issue'; workspaceId: string; issueId: string }; agent: string }>
   sessions?: Record<string, Record<string, { id: string; wsId: string; agent: string }>>
 } = {}) {
   return {
@@ -19,12 +19,13 @@ function svc(opts: {
 describe('resolveInboxOrigin — headless (Phase 1)', () => {
   it('builds a headless origin from the authoritative record', () => {
     const origin = resolveInboxOrigin({ run: 'run-7' }, () =>
-      svc({ headless: { 'run-7': { taskId: 'run-7', resumeId: 'resume-7', issueId: 'macro', agent: 'claude' } } }) as any,
+      svc({ headless: { 'run-7': { taskId: 'run-7', resumeId: 'resume-7', trigger: { kind: 'issue', workspaceId: 'research', issueId: 'macro' }, agent: 'claude' } } }) as any,
     )
     expect(origin).toEqual({
       kind: 'headless',
       runId: 'run-7',
       issueId: 'macro',
+      issueWorkspaceId: 'research',
       agent: 'claude',
       resumeId: 'resume-7',
     })
@@ -102,7 +103,7 @@ describe('resolveInboxOrigin — precedence + both-absent', () => {
           'run-7': {
             taskId: 'run-7',
             resumeId: 'resume-7',
-            issueId: 'macro',
+            trigger: { kind: 'issue', workspaceId: 'research', issueId: 'macro' },
             agent: 'claude',
           },
         },
@@ -114,6 +115,7 @@ describe('resolveInboxOrigin — precedence + both-absent', () => {
       runId: 'run-7',
       resumeId: 'resume-7',
       issueId: 'macro',
+      issueWorkspaceId: 'research',
       agent: 'claude',
     })
   })

--- a/src/server/inbox-origin.ts
+++ b/src/server/inbox-origin.ts
@@ -36,7 +36,7 @@ import type { InboxOrigin } from '../core/inbox-store.js'
 interface HeadlessRecordLike {
   readonly taskId: string
   readonly resumeId: string
-  readonly issueId?: string
+  readonly trigger?: { readonly kind: 'issue'; readonly workspaceId: string; readonly issueId: string }
   readonly agent: string
 }
 interface SessionRecordLike {
@@ -84,7 +84,10 @@ export function resolveInboxOrigin(
         kind: 'headless',
         runId: rec.taskId,
         resumeId: rec.resumeId,
-        ...(rec.issueId ? { issueId: rec.issueId } : {}),
+        ...(rec.trigger?.kind === 'issue' ? {
+          issueId: rec.trigger.issueId,
+          issueWorkspaceId: rec.trigger.workspaceId,
+        } : {}),
         ...(rec.agent ? { agent: rec.agent } : {}),
       }
     }

--- a/src/tool/conversation-artifacts.spec.ts
+++ b/src/tool/conversation-artifacts.spec.ts
@@ -130,7 +130,7 @@ describe('issue_ask', () => {
 
   it('asks the declared stable owner by resumeId', async () => {
     const { ctx, ask } = issueContext({
-      assignee: 'session:resume-owner',
+      assignee: '@resume-owner',
     })
     await run(issueAskFactory.build(ctx), { id: 'audit', owner: true, prompt: 'status?' })
     expect(ask).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -59,7 +59,7 @@ describe('issue_create', () => {
   it('creates an issue, stamps the workspace assignee, and is reachable via the reader', async () => {
     const res = await run(issueCreateFactory.build(ctx()), { title: 'Fix the thing' })
     expect(res.ok).toBe(true)
-    expect(res.issue).toMatchObject({ id: 'fix-the-thing', title: 'Fix the thing', assignee: 'workspace' })
+    expect(res.issue).toMatchObject({ id: 'fix-the-thing', title: 'Fix the thing', assignee: '@workspace' })
     const issue = await readBack('fix-the-thing')
     expect(issue?.title).toBe('Fix the thing')
   })
@@ -103,10 +103,10 @@ describe('issue_create', () => {
       when: { kind: 'every', every: '30m' },
     })
     expect(created.ok).toBe(true)
-    expect((await readBack('fresh-owner'))?.assignee).toBe('workspace')
+    expect((await readBack('fresh-owner'))?.assignee).toBe('@workspace')
   })
 
-  it('binds resume ownership to the server-attributed current Session', async () => {
+  it('defaults creation to the server-attributed current Session', async () => {
     const context = ctx({
       origin: {
         kind: 'interactive',
@@ -119,14 +119,19 @@ describe('issue_create', () => {
       id: 'owned-schedule',
       title: 'Owned schedule',
       when: { kind: 'every', every: '30m' },
-      assignee: 'session:self',
     })
     expect(created.ok).toBe(true)
     expect((await readBack('owned-schedule'))?.assignee)
-      .toBe('session:resume-kind-owl-abc123')
+      .toBe('@resume-kind-owl-abc123')
+
+    const explicit = await run(issueCreateFactory.build(context), {
+      id: 'owned-explicit', title: 'Owned explicit', assignee: '@me',
+    })
+    expect(explicit.ok).toBe(true)
+    expect((await readBack('owned-explicit'))?.assignee).toBe('@resume-kind-owl-abc123')
   })
 
-  it('refuses to assign a Session from another workspace', async () => {
+  it('allows assigning an exact signed Session from another workspace', async () => {
     const context = ctx({
       resolveSessionIdentity: () => ({ workspaceId: 'ws-peer', agent: 'pi', resumable: true }),
     })
@@ -134,10 +139,9 @@ describe('issue_create', () => {
       id: 'foreign-owner',
       title: 'Foreign owner',
       when: { kind: 'every', every: '30m' },
-      assignee: 'session:resume-peer',
+      assignee: '@resume-peer',
     })
-    expect(result.ok).toBe(false)
-    expect(result.error).toMatch(/another workspace/)
+    expect(result.ok).toBe(true)
   })
 
   it('refuses to assign a Session that has no resumable runtime identity yet', async () => {
@@ -148,7 +152,7 @@ describe('issue_create', () => {
       id: 'unready-owner',
       title: 'Unready owner',
       when: { kind: 'every', every: '30m' },
-      assignee: 'session:resume-unready',
+      assignee: '@resume-unready',
     })
     expect(result.ok).toBe(false)
     expect(result.error).toMatch(/not resumable yet/)
@@ -161,7 +165,7 @@ describe('issue_update', () => {
       id: 'sched',
       title: 'scheduled work',
       when: { kind: 'every', every: '30m' },
-      assignee: 'workspace',
+      assignee: '@workspace',
       what: 'keep me',
     })
     const res = await run(issueUpdateFactory.build(ctx()), {
@@ -255,13 +259,13 @@ describe('global board (ctx.board present)', () => {
         tag: 'auto-quant',
         status: 'ok',
         issues: [
-          { id: 'alpha', title: 'Alpha', status: 'todo', priority: 'high', assignee: 'human' },
+          { id: 'alpha', title: 'Alpha', status: 'todo', priority: 'high', assignee: '@human' },
           {
             id: 'shared-a',
             title: 'Shared',
             status: 'in_progress',
             priority: 'none',
-            assignee: 'workspace',
+            assignee: '@workspace',
             when: { kind: 'every', every: '30m' },
             nameCollision: true,
           },
@@ -277,7 +281,7 @@ describe('global board (ctx.board present)', () => {
             title: 'Shared',
             status: 'todo',
             priority: 'low',
-            assignee: 'unassigned',
+            assignee: '@unassigned',
             nameCollision: true,
           },
         ],
@@ -295,7 +299,7 @@ describe('global board (ctx.board present)', () => {
         what: 'the alpha body',
         status: 'todo',
         priority: 'high',
-        assignee: 'human',
+        assignee: '@human',
       },
       comments: [],
       runs: [],
@@ -395,7 +399,7 @@ describe('global board (ctx.board present)', () => {
     const detail: IssueDetail = {
       issue: {
         id: 'alpha', title: 'Alpha', what: 'one canonical prompt', status: 'todo',
-        priority: 'high', assignee: 'human',
+        priority: 'high', assignee: '@human',
       },
       comments: [],
       runs: [{

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -50,6 +50,11 @@ import {
 } from '../workspaces/issues/mutate.js'
 import { readIssueComments, type IssueComment } from '../workspaces/issues/comments.js'
 import {
+  WORKSPACE_ASSIGNEE,
+  normalizeIssueAssigneeAlias,
+  sessionSignature,
+} from '../workspaces/session-signature.js'
+import {
   flattenBoardRows,
   type BoardInvalidWorkspace,
   type BoardRow,
@@ -65,8 +70,8 @@ function selfDir(ctx: WorkspaceToolContext): { ok: true; dir: string } | { ok: f
 }
 
 const issueAssigneeInputSchema = z.string().min(1).refine(
-  (value) => value === 'session:self' || issueAssigneeSchema.safeParse(value).success,
-  'assignee must be workspace, human, unassigned, session:self, or session:<resumeId>',
+  (value) => value.toLowerCase() === '@me' || issueAssigneeSchema.safeParse(normalizeIssueAssigneeAlias(value)).success,
+  'assignee must be @me, @workspace, @human, @unassigned, or an exact @resumeId',
 )
 
 function resolveIssueAssignee(
@@ -74,15 +79,14 @@ function resolveIssueAssignee(
   requested: string | undefined,
 ): { ok: true; assignee?: string } | { ok: false; error: string } {
   if (!requested) return { ok: true }
-  const selfResumeId = requested === 'session:self'
+  const isMe = requested.toLowerCase() === '@me'
+  const selfResumeId = isMe
     ? sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)?.resumeId
     : undefined
-  if (requested === 'session:self' && !selfResumeId) {
-    return { ok: false, error: 'session:self needs an attributable product Session' }
+  if (isMe && !selfResumeId) {
+    return { ok: false, error: '@me needs an attributable product Session' }
   }
-  const assignee = requested === 'session:self'
-    ? `session:${selfResumeId}`
-    : requested
+  const assignee = isMe ? sessionSignature(selfResumeId!) : normalizeIssueAssigneeAlias(requested)
   const parsed = issueAssigneeSchema.safeParse(assignee)
   if (!parsed.success) return { ok: false, error: 'invalid assignee' }
   const resumeId = issueAssigneeResumeId(parsed.data)
@@ -90,9 +94,6 @@ function resolveIssueAssignee(
   const identity = ctx.resolveSessionIdentity?.(resumeId)
   if (ctx.resolveSessionIdentity && !identity) {
     return { ok: false, error: `unknown product Session: ${resumeId}` }
-  }
-  if (identity && identity.workspaceId !== ctx.workspaceId) {
-    return { ok: false, error: `product Session ${resumeId} belongs to another workspace` }
   }
   if (identity && !identity.resumable) {
     return {
@@ -231,8 +232,8 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
         "Update one of THIS workspace's issues — its board fields.",
         '',
         'Patch any subset of `status`, `priority`, `assignee`, `what`; omitted fields are',
-        'left untouched. `assignee:"session:self"` binds this current product',
-        'Session; pass `session:<resumeId>` to assign another known Session. What is the',
+        'left untouched. `assignee:"@me"` binds this current product',
+        'Session; pass an exact `@resumeId` to assign another known Session. What is the',
         'canonical markdown work definition and exact scheduled prompt. Other scheduling',
         'frontmatter (`when`/`agent`) is preserved — edit it by writing the file directly',
         '(`.alice/issues/<id>.md`).',
@@ -246,7 +247,7 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
         priority: z.enum(ISSUE_PRIORITIES).optional().describe('New priority.'),
         assignee: issueAssigneeInputSchema
           .optional()
-          .describe('workspace, human, unassigned, session:self, or session:<resumeId>.'),
+          .describe('@workspace, @human, @unassigned, @me, or an exact @resumeId.'),
         what: z.string().min(1).optional().describe('Canonical markdown work definition; exact scheduled prompt.'),
       }),
       execute: async ({ id, status, priority, assignee, what }) => {
@@ -324,8 +325,9 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         'the scanner sends that exact visible What to the Agent Runtime; without',
         '`when` the same What remains a pure board work item. Assignee is the',
         'only ownership field:',
-        '`workspace` (the default) recruits a new Session each fire, while',
-        '`session:self` or `session:<resumeId>` keeps one accountable Session.',
+        '`@workspace` recruits a new Session each fire. `@me` resolves to this',
+        'calling Session, while an exact `@resumeId` keeps one accountable',
+        'Session (including a deliberately signed Session from another Workspace).',
       ].join('\n'),
       inputSchema: z.object({
         title: z.string().min(1).describe('Short human title (required).'),
@@ -338,17 +340,23 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         priority: z.enum(ISSUE_PRIORITIES).optional().describe('Initial priority (default "none").'),
         assignee: issueAssigneeInputSchema
           .optional()
-          .describe('Initial owner (default workspace). Use session:self for the current Session.'),
+          .describe('Initial owner. Omit or use @me for the current Session; use @workspace to recruit a fresh Session each fire.'),
         when: issueWhenSchema
           .optional()
           .describe('Schedule shape — { kind:"at", at } | { kind:"every", every } | { kind:"cron", cron }. Present iff the issue self-schedules.'),
         what: z.string().min(1).optional().describe('Markdown work definition; exact scheduled prompt. Defaults to title.'),
-        agent: z.string().min(1).optional().describe('Adapter id when assignee is workspace; Session assignees own their runtime.'),
+        agent: z.string().min(1).optional().describe('Adapter id when assignee is @workspace; Session assignees own their runtime.'),
       }),
       execute: async ({ title, id, status, priority, assignee, when, what, agent }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
-        const resolvedAssignee = resolveIssueAssignee(ctx, assignee ?? 'workspace')
+        // Structured creation is attributable: "who creates it owns it". A
+        // human/unattributed caller has no Session to sign with, so its safe
+        // fallback is the Issue's home Workspace recruiting a fresh worker.
+        const defaultAssignee = sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)
+          ? '@me'
+          : WORKSPACE_ASSIGNEE
+        const resolvedAssignee = resolveIssueAssignee(ctx, assignee ?? defaultAssignee)
         if (!resolvedAssignee.ok) return { ok: false as const, error: resolvedAssignee.error }
         const res = await createIssue(dir.dir, {
           title,

--- a/src/tool/session-signature.spec.ts
+++ b/src/tool/session-signature.spec.ts
@@ -1,0 +1,41 @@
+import type { Tool } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import { sessionSignatureFactory } from './session-signature.js'
+
+async function run(tool: Tool) {
+  return await tool.execute!({}, { toolCallId: 'signature', messages: [] }) as Record<string, unknown>
+}
+
+const base = {
+  workspaceId: 'ws-research',
+  workspaceLabel: 'Research',
+  inboxStore: {} as never,
+  entityStore: {} as never,
+} satisfies WorkspaceToolContext
+
+describe('session_signature', () => {
+  it('returns the authoritative current product Session signature', async () => {
+    const result = await run(sessionSignatureFactory.build({
+      ...base,
+      origin: {
+        kind: 'interactive',
+        sessionId: 'launcher-record-hidden',
+        resumeId: 'resume-kind-owl-abc123',
+        agent: 'codex',
+      },
+    }))
+    expect(result).toMatchObject({
+      ok: true,
+      signature: '@resume-kind-owl-abc123',
+      resumeId: 'resume-kind-owl-abc123',
+      markdown: 'Signed-by: @resume-kind-owl-abc123',
+    })
+  })
+
+  it('does not fabricate a signature outside an attributable Session', async () => {
+    expect(await run(sessionSignatureFactory.build(base))).toMatchObject({ ok: false })
+  })
+})
+

--- a/src/tool/session-signature.ts
+++ b/src/tool/session-signature.ts
@@ -1,0 +1,42 @@
+/** Agent-facing self identity. Structured actions are signed server-side; this
+ * tool lets an Agent intentionally place the same signature in free-form files. */
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import { sessionOriginFromInboxOrigin } from '../core/provenance-store.js'
+import type { WorkspaceToolFactory } from '../core/workspace-tool-center.js'
+import { sessionSignature } from '../workspaces/session-signature.js'
+
+export const sessionSignatureFactory: WorkspaceToolFactory = {
+  name: 'session_signature',
+  build(ctx) {
+    return tool({
+      description: [
+        'Show this Agent Session’s OpenAlice signature.',
+        'Structured Inbox/Issue actions are signed automatically. Add the returned',
+        '`@resumeId` to standalone Markdown reports as `Signed-by: @resumeId` so',
+        'another Agent or the user can return to the exact accountable Session.',
+      ].join('\n'),
+      inputSchema: z.object({}),
+      execute: async () => {
+        const origin = sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)
+        if (!origin) {
+          return {
+            ok: false as const,
+            error: 'no attributable Session is attached to this CLI call',
+            hint: 'Run this inside an OpenAlice interactive or headless Session.',
+          }
+        }
+        return {
+          ok: true as const,
+          signature: sessionSignature(origin.resumeId),
+          resumeId: origin.resumeId,
+          workspaceId: origin.workspaceId,
+          agent: origin.agent,
+          markdown: `Signed-by: ${sessionSignature(origin.resumeId)}`,
+        }
+      },
+    })
+  },
+}
+

--- a/src/webui/routes/inquiries.spec.ts
+++ b/src/webui/routes/inquiries.spec.ts
@@ -89,7 +89,7 @@ describe('business inquiry routes', () => {
   })
 
   it('rejects Ask owner for a Workspace-owned Issue', async () => {
-    const { app } = build({ assignee: 'workspace' })
+    const { app } = build({ assignee: '@workspace' })
     const response = await app.request('/issues/ws-1/issue-1', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Status?', relation: 'owner' }),
@@ -99,7 +99,7 @@ describe('business inquiry routes', () => {
   })
 
   it('asks the fixed Issue owner and one selected run by their resumeIds', async () => {
-    const { app, dispatchHeadlessTask } = build({ assignee: 'session:resume-owner' })
+    const { app, dispatchHeadlessTask } = build({ assignee: '@resume-owner' })
     const owner = await app.request('/issues/ws-1/issue-1', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Owner?', relation: 'owner' }),

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -122,17 +122,17 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     expect(invalid.body.error).toBe('invalid_assignee')
 
     const updated = await req(app, 'PATCH', '/ws-1/i1', {
-      assignee: 'session:resume-kind-owl-abc123',
+      assignee: '@resume-kind-owl-abc123',
     })
     expect(updated.status).toBe(200)
-    expect(updated.body.issue.assignee).toBe('session:resume-kind-owl-abc123')
+    expect(updated.body.issue.assignee).toBe('@resume-kind-owl-abc123')
   })
 
   it('409 when the selected Session assignee is not resumable yet', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
     const { app } = build()
     const unavailable = await req(app, 'PATCH', '/ws-1/i1', {
-      assignee: 'session:resume-unready',
+      assignee: '@resume-unready',
     })
     expect(unavailable.status).toBe(409)
     expect(unavailable.body.error).toBe('unavailable_assignee_session')
@@ -150,14 +150,14 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', body: 'keep me' })
     const { app, appendProvenance } = build()
     const r = await req(app, 'PATCH', '/ws-1/i1', {
-      status: 'in_progress', priority: 'high', assignee: 'human', agent: 'pi', what: 'new exact work',
+      status: 'in_progress', priority: 'high', assignee: '@human', agent: 'pi', what: 'new exact work',
     })
     expect(r.status).toBe(200)
     expect(r.body.issue).toMatchObject({
       id: 'i1',
       status: 'in_progress',
       priority: 'high',
-      assignee: 'human',
+      assignee: '@human',
       agent: 'pi',
       what: 'new exact work',
     })

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -105,15 +105,15 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
       const a = fields['assignee']
       const assignee = typeof a === 'string' ? issueAssigneeSchema.safeParse(a.trim()) : null
       if (!assignee?.success) {
-        return c.json({ error: 'invalid_assignee', message: 'assignee must be workspace, human, unassigned, or session:<resumeId>' }, 400)
+        return c.json({ error: 'invalid_assignee', message: 'assignee must be @workspace, @human, @unassigned, or an exact @resumeId' }, 400)
       }
       const resumeId = issueAssigneeResumeId(assignee.data)
       if (resumeId) {
         const identity = svc.resumeRegistry.get(resumeId)
-        if (!identity || identity.wsId !== wsId) {
+        if (!identity) {
           return c.json({
             error: 'invalid_assignee_session',
-            message: 'session assignee must identify a product Session in this Workspace',
+            message: 'Session assignee must identify a known product Session',
           }, 400)
         }
         if (!identity.agentSessionId) {

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -129,6 +129,24 @@ describe('GET /:id/resumes', () => {
   })
 })
 
+describe('GET /signatures/:resumeId', () => {
+  it('resolves a globally signed Session without exposing its native runtime id', async () => {
+    const { app } = build({ resumeIdentity: {
+      resumeId: 'resume-kind-owl-abc123', wsId: 'ws-peer', agent: 'codex', agentSessionId: 'native-secret',
+    } })
+    const result = await get(app, '/signatures/resume-kind-owl-abc123')
+    expect(result.status).toBe(200)
+    expect(result.body).toEqual({
+      signature: '@resume-kind-owl-abc123',
+      resumeId: 'resume-kind-owl-abc123',
+      workspaceId: 'ws-peer',
+      agent: 'codex',
+      resumable: true,
+    })
+    expect(JSON.stringify(result.body)).not.toContain('native-secret')
+  })
+})
+
 async function post(app: any, path: string, body?: unknown) {
   const res = await app.request(path, {
     method: 'POST',

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -710,6 +710,20 @@ export function createWorkspaceRoutes(
    * use this to render tombstone states. Larger than 1 MiB returns 413
    * so the inbox can't be weaponised into a large-file viewer.
    */
+  app.get('/signatures/:resumeId', (c) => {
+    const resumeId = c.req.param('resumeId');
+    if (!validId(resumeId)) return c.json({ error: 'not_found' }, 404);
+    const identity = svc.resumeRegistry.get(resumeId);
+    if (!identity) return c.json({ error: 'not_found' }, 404);
+    return c.json({
+      signature: `@${identity.resumeId}`,
+      resumeId: identity.resumeId,
+      workspaceId: identity.wsId,
+      agent: identity.agent,
+      resumable: Boolean(identity.agentSessionId),
+    });
+  });
+
   app.get('/:id/file', async (c) => {
     const id = c.req.param('id');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);

--- a/src/workspaces/conversation-control.ts
+++ b/src/workspaces/conversation-control.ts
@@ -295,7 +295,7 @@ export function createWorkspaceConversationControl(
         startedAt: task.startedAt,
         structured,
         ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
-        ...(task.issueId ? { issueId: task.issueId } : {}),
+        ...(task.trigger?.kind === 'issue' ? { issueId: task.trigger.issueId } : {}),
         ...(task.finishedAt !== undefined ? { finishedAt: task.finishedAt } : {}),
         ...(task.durationMs !== undefined ? { durationMs: task.durationMs } : {}),
         ...(task.error ? { error: task.error } : {}),

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -73,16 +73,16 @@ describe('HeadlessTaskRegistry', () => {
     expect(reg.list({ limit: 1 }).length).toBe(1)
   })
 
-  it('records issueId when an issue fired the run; omits it for manual runs', async () => {
+  it('records a composite Issue trigger when an issue fired the run', async () => {
     const reg = await HeadlessTaskRegistry.load(path, noopLogger)
-    const fired = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'x', startedAt: 1, issueId: 'daily-scan' })
+    const fired = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'x', startedAt: 1, trigger: { kind: 'issue', workspaceId: 'home', issueId: 'daily-scan' } })
     const manual = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'y', startedAt: 2 })
-    expect(fired.issueId).toBe('daily-scan')
+    expect(fired.trigger).toEqual({ kind: 'issue', workspaceId: 'home', issueId: 'daily-scan' })
     // Manual runs leave the field absent (not undefined-valued) so the JSON stays clean.
-    expect('issueId' in manual).toBe(false)
+    expect('trigger' in manual).toBe(false)
     // Persists across reload.
     const reg2 = await HeadlessTaskRegistry.load(path, noopLogger)
-    expect(reg2.get(fired.taskId)?.issueId).toBe('daily-scan')
+    expect(reg2.get(fired.taskId)?.trigger?.issueId).toBe('daily-scan')
   })
 
   it('persists and reverse-filters business inquiry subjects', async () => {
@@ -122,12 +122,12 @@ describe('HeadlessTaskRegistry', () => {
 
   it('list filters by issueId (the issue detail Activity feed join)', async () => {
     const reg = await HeadlessTaskRegistry.load(path, noopLogger)
-    const a = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'x', startedAt: 1, issueId: 'iss-a' })
-    const b = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'y', startedAt: 2, issueId: 'iss-a' })
-    await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'z', startedAt: 3, issueId: 'iss-b' })
+    const a = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'x', startedAt: 1, trigger: { kind: 'issue', workspaceId: 'home', issueId: 'iss-a' } })
+    const b = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'y', startedAt: 2, trigger: { kind: 'issue', workspaceId: 'home', issueId: 'iss-a' } })
+    await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'z', startedAt: 3, trigger: { kind: 'issue', workspaceId: 'home', issueId: 'iss-b' } })
     await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'm', startedAt: 4 }) // manual, no issueId
     // newest-first, only iss-a's runs.
-    expect(reg.list({ wsId: 'w1', issueId: 'iss-a' }).map((t) => t.taskId)).toEqual([b.taskId, a.taskId])
+    expect(reg.list({ issue: { workspaceId: 'home', issueId: 'iss-a' } }).map((t) => t.taskId)).toEqual([b.taskId, a.taskId])
   })
 
   it('stores the full task prompt (not truncated — collapsible in the UI)', async () => {

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -35,6 +35,15 @@ export interface HeadlessTaskOutputSummary {
   readonly toolFailures: number
 }
 
+/** The business object that caused an execution. This is intentionally
+ * independent from `wsId`: an exact signed Session may execute in Workspace B
+ * while answering a scheduled Issue whose source of truth remains Workspace A. */
+export type HeadlessTaskTrigger = {
+  readonly kind: 'issue'
+  readonly workspaceId: string
+  readonly issueId: string
+}
+
 /** Business object that requested a headless follow-up. Product provenance
  * only: adapter-native session ids never cross into this record. */
 export type HeadlessInquirySubject =
@@ -80,7 +89,7 @@ export interface HeadlessTaskRecord {
    * "run task" route) and on runs that predate the field — those have no owning
    * issue. This is the run↔issue link the issue detail's Activity feed joins on.
    */
-  readonly issueId?: string
+  readonly trigger?: HeadlessTaskTrigger
   /** Durable reverse link for Inbox/Issue follow-up UI. */
   readonly inquiry?: HeadlessTaskInquiry
   readonly agent: string
@@ -171,8 +180,8 @@ export class HeadlessTaskRegistry {
     resumeId: string
     /** Previous execution in the same resume chain, when continuing. */
     parentTaskId?: string
-    /** Set only when an issue fired this run (scheduled scan); omitted for manual/external runs. */
-    issueId?: string
+    /** Set only when an Issue fired this run; omitted for manual/external runs. */
+    trigger?: HeadlessTaskTrigger
     /** Business follow-up metadata; omitted for automation/manual runs. */
     inquiry?: HeadlessTaskInquiry
   }): Promise<HeadlessTaskRecord> {
@@ -188,7 +197,7 @@ export class HeadlessTaskRegistry {
       status: 'running',
       startedAt: input.startedAt,
       // Keep the field absent (not `undefined`) on manual runs so the JSON stays clean.
-      ...(input.issueId ? { issueId: input.issueId } : {}),
+      ...(input.trigger ? { trigger: input.trigger } : {}),
       ...(input.inquiry ? { inquiry: input.inquiry } : {}),
     }
     this.tasks.push(rec)
@@ -236,7 +245,7 @@ export class HeadlessTaskRegistry {
   list(
     opts: {
       wsId?: string
-      issueId?: string
+      issue?: { workspaceId: string; issueId: string }
       status?: HeadlessTaskStatus
       inquiry?: HeadlessInquiryScope
       /** Return records older than this task in the filtered newest-first view. */
@@ -247,7 +256,11 @@ export class HeadlessTaskRegistry {
     let out = this.tasks.filter(
       (t) =>
         (!opts.wsId || t.wsId === opts.wsId) &&
-        (!opts.issueId || t.issueId === opts.issueId) &&
+        (!opts.issue || (
+          t.trigger?.kind === 'issue' &&
+          t.trigger.workspaceId === opts.issue.workspaceId &&
+          t.trigger.issueId === opts.issue.issueId
+        )) &&
         (!opts.inquiry || inquirySubjectMatches(t.inquiry?.subject, opts.inquiry)) &&
         (!opts.status || t.status === opts.status),
     )
@@ -262,11 +275,15 @@ export class HeadlessTaskRegistry {
   }
 
   /** Count filtered records without materializing them over the HTTP boundary. */
-  count(opts: { wsId?: string; issueId?: string; status?: HeadlessTaskStatus; inquiry?: HeadlessInquiryScope } = {}): number {
+  count(opts: { wsId?: string; issue?: { workspaceId: string; issueId: string }; status?: HeadlessTaskStatus; inquiry?: HeadlessInquiryScope } = {}): number {
     return this.tasks.reduce(
       (count, task) => count + (
         (!opts.wsId || task.wsId === opts.wsId) &&
-        (!opts.issueId || task.issueId === opts.issueId) &&
+        (!opts.issue || (
+          task.trigger?.kind === 'issue' &&
+          task.trigger.workspaceId === opts.issue.workspaceId &&
+          task.trigger.issueId === opts.issue.issueId
+        )) &&
         (!opts.inquiry || inquirySubjectMatches(task.inquiry?.subject, opts.inquiry)) &&
         (!opts.status || task.status === opts.status)
           ? 1
@@ -290,7 +307,7 @@ export class HeadlessTaskRegistry {
     try {
       await mkdir(dirname(this.path), { recursive: true })
       const tmp = `${this.path}.tmp`
-      await writeFile(tmp, JSON.stringify({ version: 2, tasks: this.tasks }, null, 2), 'utf8')
+      await writeFile(tmp, JSON.stringify({ version: 3, tasks: this.tasks }, null, 2), 'utf8')
       await rename(tmp, this.path)
     } catch (err) {
       this.logger.warn('headless_registry.flush_failed', { err })

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -93,7 +93,7 @@ describe('issueRunRecord', () => {
       taskId: 'task-1',
       resumeId: 'resume-gentle-otter-abc123',
       wsId: 'ws-1',
-      issueId: 'audit',
+      trigger: { kind: 'issue', workspaceId: 'ws-home', issueId: 'audit' },
       agent: 'codex',
       prompt: 'inspect it',
       status: 'done',
@@ -120,7 +120,7 @@ function ws(wsId: string, titles: string[]): IssuesSnapshotWorkspace {
       title,
       status: 'todo',
       priority: 'none',
-      assignee: 'unassigned',
+      assignee: '@unassigned',
     })),
   }
 }
@@ -160,13 +160,13 @@ describe('flattenBoardRows', () => {
           tag: 'auto-quant',
           status: 'ok',
           issues: [
-            { id: 'x', title: 'X', status: 'todo', priority: 'high', assignee: 'human' },
+            { id: 'x', title: 'X', status: 'todo', priority: 'high', assignee: '@human' },
             {
               id: 'y',
               title: 'Y',
               status: 'todo',
               priority: 'none',
-              assignee: 'workspace',
+              assignee: '@workspace',
               agent: 'pi',
               when: { kind: 'every', every: '1h' },
               nameCollision: true,
@@ -184,7 +184,7 @@ describe('flattenBoardRows', () => {
         title: 'X',
         status: 'todo',
         priority: 'high',
-        assignee: 'human',
+        assignee: '@human',
         scheduled: false,
         workspace: { wsId: 'a', tag: 'auto-quant' },
       },
@@ -193,7 +193,7 @@ describe('flattenBoardRows', () => {
         title: 'Y',
         status: 'todo',
         priority: 'none',
-        assignee: 'workspace',
+        assignee: '@workspace',
         agent: 'pi',
         scheduled: true,
         workspace: { wsId: 'a', tag: 'auto-quant' },
@@ -210,19 +210,19 @@ describe('assignee projection', () => {
     title: 'Issue',
     status: 'todo',
     priority: 'none',
-    assignee: 'workspace',
+    assignee: '@workspace',
     what: 'Issue',
   } as const
 
   it('projects Workspace ownership without needing a workspace-tag rewrite', () => {
-    expect(snapshotBoardIssue(baseIssue, null).assignee).toBe('workspace')
-    expect(detailIssue(baseIssue, null).assignee).toBe('workspace')
+    expect(snapshotBoardIssue(baseIssue, null).assignee).toBe('@workspace')
+    expect(detailIssue(baseIssue, null).assignee).toBe('@workspace')
   })
 
   it('respects an explicit unassigned assignee', () => {
-    const issue = { ...baseIssue, assignee: 'unassigned' as const }
-    expect(snapshotBoardIssue(issue, null).assignee).toBe('unassigned')
-    expect(detailIssue(issue, null).assignee).toBe('unassigned')
+    const issue = { ...baseIssue, assignee: '@unassigned' as const }
+    expect(snapshotBoardIssue(issue, null).assignee).toBe('@unassigned')
+    expect(detailIssue(issue, null).assignee).toBe('@unassigned')
   })
 })
 
@@ -236,10 +236,10 @@ describe('inboxReportsForIssue', () => {
   ] as unknown as InboxEntry[]
 
   it('keeps only entries whose origin.issueId matches, preserving order', () => {
-    expect(inboxReportsForIssue(entries, 'i1').map((e) => e.id)).toEqual(['e3', 'e1'])
+    expect(inboxReportsForIssue(entries, 'w', 'i1').map((e) => e.id)).toEqual(['e3', 'e1'])
   })
 
   it('returns [] for a non-matching issue and ignores origin-less entries', () => {
-    expect(inboxReportsForIssue(entries, 'nope')).toEqual([])
+    expect(inboxReportsForIssue(entries, 'w', 'nope')).toEqual([])
   })
 })

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -308,7 +308,7 @@ export function issueRunRecord(task: HeadlessTaskRecord, resumable: boolean): Is
     resumeId: task.resumeId,
     ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
     wsId: task.wsId,
-    ...(task.issueId ? { issueId: task.issueId } : {}),
+    ...(task.trigger?.kind === 'issue' ? { issueId: task.trigger.issueId } : {}),
     agent: task.agent,
     prompt: task.prompt,
     status: task.status,
@@ -341,8 +341,15 @@ export function issueActivityRecords(
  *  (`origin.issueId` match). Pure + order-preserving, so the caller's
  *  newest-first read order carries through. The issue→inbox join, kept in the
  *  domain (not the HTTP route) so every surface — CLI, MCP — gets it. */
-export function inboxReportsForIssue(entries: readonly InboxEntry[], issueId: string): InboxEntry[] {
-  return entries.filter((e) => e.origin?.issueId === issueId)
+export function inboxReportsForIssue(
+  entries: readonly InboxEntry[],
+  workspaceId: string,
+  issueId: string,
+): InboxEntry[] {
+  return entries.filter((entry) =>
+    entry.origin?.issueId === issueId &&
+    (entry.origin.issueWorkspaceId ?? entry.workspaceId) === workspaceId,
+  )
 }
 
 /** Map a validated issue (+ its firing markers, iff scheduled) to the detail

--- a/src/workspaces/issues/declaration.spec.ts
+++ b/src/workspaces/issues/declaration.spec.ts
@@ -69,7 +69,7 @@ describe('readWorkspaceIssues', () => {
         title: 'Fix the login bug',
         status: 'todo',
         priority: 'none',
-        assignee: 'workspace',
+        assignee: '@workspace',
       })
       expect(i.when).toBeUndefined()
       expect(isFireable(i)).toBe(false)
@@ -77,11 +77,11 @@ describe('readWorkspaceIssues', () => {
   })
 
   it('preserves an explicit unassigned owner for an unscheduled issue', async () => {
-    await writeIssue('explicit', fm('title: Explicit\nassignee: unassigned'))
+    await writeIssue('explicit', fm('title: Explicit\nassignee: "@unassigned"'))
     const r = await readWorkspaceIssues(dir)
     expect(r.ok).toBe(true)
     if (r.ok) {
-      expect(r.issues[0].assignee).toBe('unassigned')
+      expect(r.issues[0].assignee).toBe('@unassigned')
     }
   })
 
@@ -93,7 +93,7 @@ describe('readWorkspaceIssues', () => {
           'title: Morning research sweep',
           'status: in_progress',
           'priority: high',
-          'assignee: workspace',
+          'assignee: "@workspace"',
           'when: { kind: every, every: 30m }',
           'what: run the research routine',
           'agent: codex',
@@ -111,7 +111,7 @@ describe('readWorkspaceIssues', () => {
         title: 'Morning research sweep',
         status: 'in_progress',
         priority: 'high',
-        assignee: 'workspace',
+        assignee: '@workspace',
         what: 'run the research routine\n\n## Context\n\nScan overnight movers and summarize.',
         agent: 'codex',
       })
@@ -125,7 +125,7 @@ describe('readWorkspaceIssues', () => {
     await writeIssue('owned', fm([
       'title: Owned work',
       'when: { kind: every, every: 30m }',
-      'assignee: session:resume-kind-owl-abc123',
+      'assignee: "@resume-kind-owl-abc123"',
     ].join('\n')))
     await writeIssue('legacy', fm('title: Legacy\nwhen: { kind: every, every: 30m }'))
     const result = await readWorkspaceIssues(dir)
@@ -133,7 +133,7 @@ describe('readWorkspaceIssues', () => {
     if (!result.ok) return
     const byId = Object.fromEntries(result.issues.map((issue) => [issue.id, issue]))
     expect(issueAssigneeResumeId(byId['owned'].assignee)).toBe('resume-kind-owl-abc123')
-    expect(byId['legacy'].assignee).toBe('workspace')
+    expect(byId['legacy'].assignee).toBe('@workspace')
   })
 
   it('rejects retired execution declarations instead of silently keeping two owner models', async () => {

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -20,7 +20,7 @@
  *   title: <required, short human title>
  *   status: backlog | todo | in_progress | done | canceled   (optional → 'todo')
  *   priority: urgent | high | medium | low | none             (optional → 'none')
- *   assignee: "workspace" | "human" | "unassigned" | "session:<resumeId>"  (optional → 'workspace')
+ *   assignee: "@workspace" | "@human" | "@unassigned" | "@<resumeId>"  (optional → '@workspace')
  *   when: { kind: at, at } | { kind: every, every } | { kind: cron, cron }  (OPTIONAL — present iff scheduled)
  *   what: <legacy fire prompt; migrated into the markdown What body>
  *   agent: <optional adapter id for the scheduled run>
@@ -38,6 +38,12 @@ import { parse as parseYaml } from 'yaml'
 import { z } from 'zod'
 
 import type { Schedule } from '../../core/schedule-expr.js'
+import {
+  HUMAN_ASSIGNEE,
+  UNASSIGNED_ASSIGNEE,
+  WORKSPACE_ASSIGNEE,
+  resumeIdFromSignature,
+} from '../session-signature.js'
 
 /** Directory of per-issue markdown files, relative to a workspace's `dir`. */
 export const ISSUES_DIR_REL = join('.alice', 'issues')
@@ -74,15 +80,15 @@ export const issueWhenSchema = z.discriminatedUnion('kind', [
 /** Who owns the Issue. Workspace ownership recruits a fresh Session for each
  * scheduled fire; Session ownership resumes exactly one product Session. */
 export const issueAssigneeSchema = z.union([
-  z.literal('workspace'),
-  z.literal('human'),
-  z.literal('unassigned'),
-  z.string().regex(/^session:[^\s:][^\s]*$/, 'session assignee must be session:<resumeId>'),
+  z.literal(WORKSPACE_ASSIGNEE),
+  z.literal(HUMAN_ASSIGNEE),
+  z.literal(UNASSIGNED_ASSIGNEE),
+  z.string().regex(/^@resume-[^\s]+$/, 'Session assignee must be @<resumeId>'),
 ])
 
 /** Exact product Session owner encoded by the single assignee contract. */
 export function issueAssigneeResumeId(assignee: string): string | null {
-  return assignee.startsWith('session:') ? assignee.slice('session:'.length) || null : null
+  return resumeIdFromSignature(assignee)
 }
 
 /**
@@ -95,7 +101,7 @@ export const issueFrontmatterSchema = z.object({
   title: z.string().min(1),
   status: z.enum(ISSUE_STATUSES).default('todo'),
   priority: z.enum(ISSUE_PRIORITIES).default('none'),
-  assignee: issueAssigneeSchema.default('workspace'),
+  assignee: issueAssigneeSchema.default(WORKSPACE_ASSIGNEE),
   /** Present iff the issue self-schedules. Absent ⇒ pure board work item. */
   when: issueWhenSchema.optional(),
   /** Legacy compatibility only. New files keep What in the markdown document
@@ -109,11 +115,11 @@ export const issueFrontmatterSchema = z.object({
    * `never` key makes stale files fail loudly instead of being silently read. */
   execution: z.never().optional(),
 }).superRefine((value, ctx) => {
-  if (value.when && (value.assignee === 'human' || value.assignee === 'unassigned')) {
+  if (value.when && (value.assignee === HUMAN_ASSIGNEE || value.assignee === UNASSIGNED_ASSIGNEE)) {
     ctx.addIssue({
       code: 'custom',
       path: ['assignee'],
-      message: 'scheduled issues must be assigned to workspace or session:<resumeId>',
+      message: 'scheduled issues must be assigned to @workspace or an exact @resumeId',
     })
   }
   if (issueAssigneeResumeId(value.assignee) && value.agent) {

--- a/src/workspaces/issues/mutate.spec.ts
+++ b/src/workspaces/issues/mutate.spec.ts
@@ -34,7 +34,7 @@ describe('createIssue', () => {
       // Defaults applied on read-back.
       expect(res.issue.status).toBe('todo')
       expect(res.issue.priority).toBe('none')
-      expect(res.issue.assignee).toBe('workspace')
+      expect(res.issue.assignee).toBe('@workspace')
     }
     const { issue } = await readBack('fix-the-login-bug')
     expect(issue?.title).toBe('Fix the Login Bug!')
@@ -46,7 +46,7 @@ describe('createIssue', () => {
       title: 'Morning research sweep',
       status: 'in_progress',
       priority: 'high',
-      assignee: 'session:resume-kind-owl-abc123',
+      assignee: '@resume-kind-owl-abc123',
       when: { kind: 'every', every: '30m' },
       what: 'run the research routine',
     })
@@ -57,7 +57,7 @@ describe('createIssue', () => {
       title: 'Morning research sweep',
       status: 'in_progress',
       priority: 'high',
-      assignee: 'session:resume-kind-owl-abc123',
+      assignee: '@resume-kind-owl-abc123',
       what: 'run the research routine',
     })
     expect(issue?.when).toEqual({ kind: 'every', every: '30m' })
@@ -99,21 +99,21 @@ describe('updateIssueFields', () => {
     const res = await updateIssueFields(dir, 'task-1', {
       status: 'in_progress',
       priority: 'urgent',
-      assignee: 'workspace',
+      assignee: '@workspace',
       agent: 'pi',
     })
     expect(res.ok).toBe(true)
     if (res.ok) {
       expect(res.issue.status).toBe('in_progress')
       expect(res.issue.priority).toBe('urgent')
-      expect(res.issue.assignee).toBe('workspace')
+      expect(res.issue.assignee).toBe('@workspace')
       expect(res.issue.agent).toBe('pi')
     }
     const { issue } = await readBack('task-1')
     expect(issue).toMatchObject({
       status: 'in_progress',
       priority: 'urgent',
-      assignee: 'workspace',
+      assignee: '@workspace',
       what: 'keep the fire prompt',
       agent: 'pi',
     })
@@ -134,15 +134,15 @@ describe('updateIssueFields', () => {
       id: 'owned',
       title: 'Owned',
       when: { kind: 'every', every: '15m' },
-      assignee: 'workspace',
+      assignee: '@workspace',
       agent: 'codex',
     })
     const res = await updateIssueFields(dir, 'owned', {
-      assignee: 'session:resume-kind-owl-abc123',
+      assignee: '@resume-kind-owl-abc123',
     })
     expect(res.ok).toBe(true)
     const { issue } = await readBack('owned')
-    expect(issue?.assignee).toBe('session:resume-kind-owl-abc123')
+    expect(issue?.assignee).toBe('@resume-kind-owl-abc123')
     expect(issue?.agent).toBeUndefined()
     expect(issue?.when).toEqual({ kind: 'every', every: '15m' })
   })
@@ -213,7 +213,7 @@ describe('appendIssueComment', () => {
 describe('round-trip: create → update → comment → read back', () => {
   it('keeps work definition and comments independently readable', async () => {
     await createIssue(dir, { id: 'rt', title: 'Round trip', what: 'desc' })
-    await updateIssueFields(dir, 'rt', { status: 'in_progress', assignee: 'human' })
+    await updateIssueFields(dir, 'rt', { status: 'in_progress', assignee: '@human' })
     await appendIssueComment(dir, 'rt', 'human', 'looks good')
     const { issue, invalid } = await readBack('rt')
     expect(invalid).toHaveLength(0)
@@ -221,7 +221,7 @@ describe('round-trip: create → update → comment → read back', () => {
       id: 'rt',
       title: 'Round trip',
       status: 'in_progress',
-      assignee: 'human',
+      assignee: '@human',
     })
     expect(issue?.what).toBe('desc')
     const comments = await readIssueComments(dir, 'rt')

--- a/src/workspaces/issues/mutate.ts
+++ b/src/workspaces/issues/mutate.ts
@@ -153,7 +153,7 @@ export async function updateIssueFields(
     const a = patch.assignee.trim()
     const assignee = issueAssigneeSchema.safeParse(a)
     if (!assignee.success) {
-      return { ok: false, reason: 'invalid', error: 'assignee must be workspace, human, unassigned, or session:<resumeId>' }
+      return { ok: false, reason: 'invalid', error: 'assignee must be @workspace, @human, @unassigned, or an exact @resumeId' }
     }
     data.assignee = assignee.data
     if (issueAssigneeResumeId(assignee.data)) delete data.agent

--- a/src/workspaces/schedule/declaration.ts
+++ b/src/workspaces/schedule/declaration.ts
@@ -44,7 +44,7 @@ export interface ScheduleSnapshotTask {
   when: Schedule
   /** The prompt this fire hands to the headless run (resolved `what`/title+body). */
   what: string
-  /** Unified owner. `workspace` recruits a fresh Session; `session:<resumeId>` resumes one. */
+  /** Unified owner. `@workspace` recruits a fresh Session; exact `@resumeId` resumes one. */
   assignee: string
   agent?: string
   /** False once the owning issue reaches a terminal status (done/canceled). */

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -80,7 +80,7 @@ function issueMd(spec: IssueSpec): string {
   if (spec.priority) lines.push(`priority: ${spec.priority}`)
   if (spec.what) lines.push(`what: ${spec.what}`)
   if (spec.agent) lines.push(`agent: ${spec.agent}`)
-  if (spec.assignee) lines.push(`assignee: ${spec.assignee}`)
+  if (spec.assignee) lines.push(`assignee: ${JSON.stringify(spec.assignee)}`)
   if (spec.when) {
     const w = spec.when
     const inner =
@@ -112,19 +112,21 @@ function scannerFor(
       a: CliAdapter,
       p: string,
       t: number,
-      issueId?: string,
+      trigger?: import('../headless-task-registry.js').HeadlessTaskTrigger,
       resumeId?: string,
     ) => Promise<{ taskId: string }>
     markers?: MarkerStore
     now?: number
     adapter?: CliAdapter
     resolveAdapter?: ScheduleScannerDeps['resolveAdapter']
+    resolveResumeWorkspace?: ScheduleScannerDeps['resolveResumeWorkspace']
   } = {},
 ) {
   const dispatch = opts.dispatch ?? vi.fn(async () => ({ taskId: 'run-1' }))
   const markers = opts.markers ?? new FakeMarkers()
   const scanner = new ScheduleScanner({
     registry: { list: () => workspaces } as unknown as WorkspaceRegistry,
+    resolveResumeWorkspace: opts.resolveResumeWorkspace ?? (() => workspaces[0]),
     resolveAdapter: opts.resolveAdapter ?? (() => opts.adapter ?? headlessAdapter),
     dispatch,
     markers,
@@ -141,7 +143,9 @@ describe('ScheduleScanner', () => {
     await scanner.scan()
     expect(dispatch).toHaveBeenCalledTimes(1)
     // 5th arg = the firing issue's id, threaded so the run records its origin.
-    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'go', expect.any(Number), 't1')
+    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'go', expect.any(Number), {
+      kind: 'issue', workspaceId: 'w1', issueId: 't1',
+    })
     expect(markers.get('w1', 't1')).toBe(NOW)
   })
 
@@ -151,7 +155,7 @@ describe('ScheduleScanner', () => {
       title: 'owned work',
       when: { kind: 'every', every: '30m' },
       what: 'continue',
-      assignee: 'session:resume-kind-owl-abc123',
+      assignee: '@resume-kind-owl-abc123',
     }])
     const resolveAdapter = vi.fn(async () => headlessAdapter)
     const { scanner, dispatch } = scannerFor([ws], { resolveAdapter })
@@ -163,11 +167,34 @@ describe('ScheduleScanner', () => {
       headlessAdapter,
       'continue',
       expect.any(Number),
-      'owned',
+      { kind: 'issue', workspaceId: 'w1', issueId: 'owned' },
       'resume-kind-owl-abc123',
     )
     expect(scanner.snapshot()!.workspaces[0].tasks[0].assignee)
-      .toBe('session:resume-kind-owl-abc123')
+      .toBe('@resume-kind-owl-abc123')
+  })
+
+  it('executes an exact cross-Workspace signature while retaining the home Issue trigger', async () => {
+    const home = await makeWs('home', [{
+      id: 'review-report', title: 'Review report', when: { kind: 'every', every: '30m' },
+      what: 'revisit your report', assignee: '@resume-peer-author',
+    }])
+    const execution = await makeWs('peer', [])
+    const resolveAdapter = vi.fn(async () => headlessAdapter)
+    const { scanner, dispatch } = scannerFor([home, execution], {
+      resolveAdapter,
+      resolveResumeWorkspace: () => execution,
+    })
+    await scanner.scan()
+    expect(resolveAdapter).toHaveBeenCalledWith(execution, undefined, 'resume-peer-author')
+    expect(dispatch).toHaveBeenCalledWith(
+      execution,
+      headlessAdapter,
+      'revisit your report',
+      expect.any(Number),
+      { kind: 'issue', workspaceId: 'home', issueId: 'review-report' },
+      'resume-peer-author',
+    )
   })
 
   it('ignores an UNSCHEDULED issue (no when): never fires, never in the snapshot', async () => {
@@ -188,7 +215,9 @@ describe('ScheduleScanner', () => {
     const { scanner, dispatch } = scannerFor([ws])
     await scanner.scan()
     expect(dispatch).toHaveBeenCalledTimes(1)
-    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'go', expect.any(Number), 'sched')
+    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'go', expect.any(Number), {
+      kind: 'issue', workspaceId: 'w1', issueId: 'sched',
+    })
     expect(scanner.snapshot()!.workspaces[0].tasks.map((t) => t.id)).toEqual(['sched'])
   })
 
@@ -198,7 +227,9 @@ describe('ScheduleScanner', () => {
     ])
     const { scanner, dispatch } = scannerFor([ws])
     await scanner.scan()
-    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'scan movers', expect.any(Number), 't1')
+    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'scan movers', expect.any(Number), {
+      kind: 'issue', workspaceId: 'w1', issueId: 't1',
+    })
   })
 
   it('fires a never-fired cron issue whose occurrence is within the last tick (not never)', async () => {

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -29,6 +29,7 @@ import { computeNextRun, type Schedule } from '../../core/schedule-expr.js'
 import type { CliAdapter } from '../cli-adapter.js'
 import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
+import type { HeadlessTaskTrigger } from '../headless-task-registry.js'
 
 import { isFireable, issueAssigneeResumeId, issueFirePrompt, readWorkspaceIssues } from '../issues/declaration.js'
 
@@ -54,16 +55,16 @@ export interface MarkerStore {
 
 export interface ScheduleScannerDeps {
   registry: WorkspaceRegistry
+  /** Resolve the execution Workspace for an exact signed Session owner. */
+  resolveResumeWorkspace?: (resumeId: string) => WorkspaceMeta | undefined
   resolveAdapter: (meta: WorkspaceMeta, agentId?: string, resumeId?: string) => CliAdapter | Promise<CliAdapter>
   dispatch: (
     meta: WorkspaceMeta,
     adapter: CliAdapter,
     prompt: string,
     timeoutMs: number,
-    /** The firing issue's id — recorded on the run so the issue detail can show
-     *  its real run history. The scanner ALWAYS passes it (it only fires from an
-     *  issue); manual/external dispatch callers omit it. */
-    issueId?: string,
+    /** Composite source of the dispatch. Execution may happen elsewhere. */
+    trigger?: HeadlessTaskTrigger,
     /** Product Session to continue. Omitted means allocate a fresh Session. */
     resumeId?: string,
   ) => Promise<{ taskId: string }>
@@ -211,7 +212,7 @@ export class ScheduleScanner {
   }
 
   private async fire(
-    ws: WorkspaceMeta,
+    issueWorkspace: WorkspaceMeta,
     taskId: string,
     what: string,
     agentId: string | undefined,
@@ -219,19 +220,32 @@ export class ScheduleScanner {
     nowMs: number,
   ): Promise<void> {
     try {
-      const adapter = await this.deps.resolveAdapter(ws, agentId, resumeId)
-      if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
-        this.deps.logger.warn('schedule.adapter_not_headless', { wsId: ws.id, taskId, agent: adapter.id })
+      const executionWorkspace = resumeId
+        ? this.resolveResumeWorkspace(resumeId)
+        : issueWorkspace
+      if (!executionWorkspace) {
+        this.deps.logger.warn('schedule.resume_workspace_missing', {
+          wsId: issueWorkspace.id, taskId, resumeId,
+        })
         return
       }
-      // `taskId` here is the firing ISSUE's id (keyed by filename stem) — thread
-      // it so the run records which issue triggered it.
+      const adapter = await this.deps.resolveAdapter(executionWorkspace, agentId, resumeId)
+      if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
+        this.deps.logger.warn('schedule.adapter_not_headless', { wsId: executionWorkspace.id, taskId, agent: adapter.id })
+        return
+      }
+      const trigger: HeadlessTaskTrigger = {
+        kind: 'issue',
+        workspaceId: issueWorkspace.id,
+        issueId: taskId,
+      }
       const { taskId: runId } = resumeId
-        ? await this.deps.dispatch(ws, adapter, what, RUN_TIMEOUT_MS, taskId, resumeId)
-        : await this.deps.dispatch(ws, adapter, what, RUN_TIMEOUT_MS, taskId)
-      await this.deps.markers.set(ws.id, taskId, nowMs)
+        ? await this.deps.dispatch(executionWorkspace, adapter, what, RUN_TIMEOUT_MS, trigger, resumeId)
+        : await this.deps.dispatch(executionWorkspace, adapter, what, RUN_TIMEOUT_MS, trigger)
+      await this.deps.markers.set(issueWorkspace.id, taskId, nowMs)
       this.deps.logger.info('schedule.fired', {
-        wsId: ws.id,
+        wsId: issueWorkspace.id,
+        executionWsId: executionWorkspace.id,
         taskId,
         agent: adapter.id,
         runId,
@@ -242,10 +256,14 @@ export class ScheduleScanner {
       // Capacity full (or transient) - do NOT mark; the task stays due and
       // retries on the next tick once a headless slot frees.
       this.deps.logger.info('schedule.fire_skipped', {
-        wsId: ws.id,
+        wsId: issueWorkspace.id,
         taskId,
         reason: err instanceof Error ? err.message : String(err),
       })
     }
+  }
+
+  private resolveResumeWorkspace(resumeId: string): WorkspaceMeta | undefined {
+    return this.deps.resolveResumeWorkspace?.(resumeId)
   }
 }

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -82,6 +82,7 @@ import {
   headlessLogPaths,
   type HeadlessTaskInquiry,
   type HeadlessTaskRecord,
+  type HeadlessTaskTrigger,
 } from './headless-task-registry.js';
 import { ResumeRegistry } from './resume-registry.js';
 import {
@@ -232,10 +233,9 @@ export interface WorkspaceService {
     adapter: CliAdapter,
     prompt: string,
     timeoutMs: number,
-    /** The firing issue's id, when dispatched by the ScheduleScanner; recorded on
-     *  the run as `issueId` so the issue detail's Activity feed can join on it.
-     *  Manual/external runs omit it. */
-    issueId?: string,
+    /** Business source of the dispatch. Its Workspace may differ from `meta`
+     * when an Issue explicitly resumes a signed Session across Workspaces. */
+    trigger?: HeadlessTaskTrigger,
     /** Continue this OpenAlice-owned conversation. Native runtime ids are
      * resolved only inside the service. */
     resumeId?: string,
@@ -901,6 +901,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     // id (recorded WHILE running, so the panel can offer "open as session").
     opts: {
       taskId?: string;
+      resumeId?: string;
       resume?: SessionFactoryContext['resume'];
       onSessionId?: (id: string) => void;
     } = {},
@@ -925,7 +926,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       adapter,
       opts.resume,
       undefined,
-      opts.taskId ? { AQ_RUN_ID: opts.taskId } : undefined,
+      opts.taskId ? {
+        AQ_RUN_ID: opts.taskId,
+        ...(opts.resumeId ? {
+          OPENALICE_RESUME_ID: opts.resumeId,
+          OPENALICE_SIGNATURE: `@${opts.resumeId}`,
+        } : {}),
+      } : undefined,
     );
     const command = adapter.composeHeadlessCommand(
       config.command,
@@ -970,9 +977,9 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     adapter: CliAdapter,
     prompt: string,
     timeoutMs: number,
-    // The firing issue's id, when this dispatch came from the ScheduleScanner.
-    // Manual/external runs (the workspace "run task" route) leave it undefined.
-    issueId?: string,
+    // Composite Issue source when dispatched by ScheduleScanner. Manual and
+    // external runs leave it undefined.
+    trigger?: HeadlessTaskTrigger,
     resumeId?: string,
     inquiry?: HeadlessTaskInquiry,
   ): Promise<{ taskId: string; resumeId: string }> => {
@@ -1031,7 +1038,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         startedAt: Date.now(),
         resumeId: identity.resumeId,
         ...(parentTaskId ? { parentTaskId } : {}),
-        ...(issueId ? { issueId } : {}),
+        ...(trigger ? { trigger } : {}),
         ...(inquiry ? { inquiry } : {}),
       });
       await resumeRegistry.ensure({
@@ -1051,6 +1058,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     // operator confirms via the normalized output / Inbox.
     void runHeadlessTaskMethod(ws, adapter, prompt, timeoutMs, {
       taskId: rec.taskId,
+      resumeId: rec.resumeId,
       ...(nativeResume ? { resume: nativeResume } : {}),
       onSessionId: (id) => {
         void Promise.all([
@@ -1088,16 +1096,19 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         // issue open; failed one-shots stay open so the operator can inspect and
         // decide whether to rerun.
         try {
+          const issueWorkspace = trigger?.kind === 'issue'
+            ? registry.get(trigger.workspaceId)
+            : undefined;
           const issueCompletion = await completeOneShotIssueAfterRun({
-            wsDir: ws.dir,
-            issueId,
+            wsDir: issueWorkspace?.dir ?? ws.dir,
+            issueId: issueWorkspace && trigger?.kind === 'issue' ? trigger.issueId : undefined,
             status,
             exitCode: r.exitCode,
             killed: r.killed,
           });
           if (issueCompletion.updated) {
             launcherLogger.info('issue.oneshot_completed', {
-              wsId: ws.id,
+              wsId: trigger?.kind === 'issue' ? trigger.workspaceId : ws.id,
               issueId: issueCompletion.issueId,
               previousStatus: issueCompletion.previousStatus,
               taskId: rec.taskId,
@@ -1105,7 +1116,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           } else if (issueCompletion.reason === 'mutation_failed' || issueCompletion.reason === 'issues_unavailable') {
             launcherLogger.warn('issue.oneshot_complete_skipped', {
               wsId: ws.id,
-              issueId,
+              issueId: trigger?.kind === 'issue' ? trigger.issueId : undefined,
               taskId: rec.taskId,
               reason: issueCompletion.reason,
               error: issueCompletion.error,
@@ -1114,7 +1125,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         } catch (err) {
           launcherLogger.warn('issue.oneshot_complete_failed', {
             wsId: ws.id,
-            issueId,
+            issueId: trigger?.kind === 'issue' ? trigger.issueId : undefined,
             taskId: rec.taskId,
             err,
           });
@@ -1143,11 +1154,15 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   );
   const scheduleScanner = new ScheduleScanner({
     registry,
+    resolveResumeWorkspace: (resumeId) => {
+      const identity = resumeRegistry.get(resumeId);
+      return identity ? registry.get(identity.wsId) : undefined;
+    },
     resolveAdapter: async (ws, agentId, resumeId) => {
       if (resumeId) {
         const identity = resumeRegistry.get(resumeId);
         if (!identity) throw new Error(`unknown resume conversation: ${resumeId}`);
-        if (identity.wsId !== ws.id) throw new Error(`resume conversation belongs to another workspace`);
+        if (identity.wsId !== ws.id) throw new Error(`resume conversation workspace resolution drifted`);
         return resolveAdapter(ws, identity.agent);
       }
       if (agentId) return resolveAdapter(ws, agentId);
@@ -1281,7 +1296,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       markers = { lastFiredAtMs: fired.lastFiredAtMs, nextDueAtMs: fired.nextDueAtMs };
     }
     // Newest-first already (registry.list reverses); filter to this issue's runs.
-    const runs = headlessTasks.list({ wsId: ws.id, issueId: issue.id }).map((task) =>
+    const runs = headlessTasks.list({ issue: { workspaceId: ws.id, issueId: issue.id } }).map((task) =>
       issueRunRecord(task, Boolean(resumeRegistry.get(task.resumeId)?.agentSessionId)),
     );
     // The issue→inbox cross-link: the reports this issue produced (entries this
@@ -1289,8 +1304,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     // Joined here in the domain so CLI / MCP get it too, not just the HTTP route.
     let inboxReports: IssueDetail['inboxReports'] = [];
     if (inboxStore) {
-      const { entries } = await inboxStore.read({ workspaceId: ws.id, limit: 1000 });
-      inboxReports = inboxReportsForIssue(entries, issue.id).map((entry) => {
+      const { entries } = await inboxStore.read({ limit: 1000 });
+      inboxReports = inboxReportsForIssue(entries, ws.id, issue.id).map((entry) => {
         let origin = toSafeInboxOrigin(entry.origin);
         if (origin && !origin.resumeId && origin.kind === 'headless' && origin.runId) {
           const resumeId = headlessTasks.get(origin.runId)?.resumeId;
@@ -1384,6 +1399,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           );
         }
       }
+      const productSession = sessionRegistry.get(wsId, ctx.recordId);
       const { command: composedCommand, env, transcriptDir } = composeSpawnInputs(
         ws,
         adapter,
@@ -1402,6 +1418,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         {
           ...terminalThemeEnv(ctx.terminalTheme),
           AQ_SESSION_ID: ctx.recordId,
+          ...(productSession?.resumeId ? {
+            OPENALICE_RESUME_ID: productSession.resumeId,
+            OPENALICE_SIGNATURE: `@${productSession.resumeId}`,
+          } : {}),
         },
       );
 

--- a/src/workspaces/session-directory.ts
+++ b/src/workspaces/session-directory.ts
@@ -61,7 +61,7 @@ export function buildWorkspaceSessionDirectory(input: {
                 startedAt: execution.startedAt,
                 ...(execution.finishedAt !== undefined ? { finishedAt: execution.finishedAt } : {}),
                 ...(execution.durationMs !== undefined ? { durationMs: execution.durationMs } : {}),
-                ...(execution.issueId ? { issueId: execution.issueId } : {}),
+                ...(execution.trigger?.kind === 'issue' ? { issueId: execution.trigger.issueId } : {}),
                 ...(execution.output?.assistantPreview
                   ? { assistantPreview: execution.output.assistantPreview }
                   : {}),

--- a/src/workspaces/session-signature.ts
+++ b/src/workspaces/session-signature.ts
@@ -1,0 +1,32 @@
+/**
+ * OpenAlice Session signatures are human-readable, product-owned identities.
+ *
+ * A signature is written as `@<resumeId>` in self-contained artifacts. The
+ * leading `@` is presentation/authoring syntax; ResumeRegistry continues to
+ * store the bare resumeId. Convenience aliases (`@me`, `@workspace`) are never
+ * persisted as an exact Session identity: callers resolve `@me` at write time.
+ */
+
+export const WORKSPACE_ASSIGNEE = '@workspace' as const
+export const HUMAN_ASSIGNEE = '@human' as const
+export const UNASSIGNED_ASSIGNEE = '@unassigned' as const
+
+export function sessionSignature(resumeId: string): string {
+  return `@${resumeId}`
+}
+
+export function resumeIdFromSignature(value: string): string | null {
+  if (!value.startsWith('@resume-')) return null
+  const resumeId = value.slice(1)
+  return resumeId && !/\s/.test(resumeId) ? resumeId : null
+}
+
+export function normalizeIssueAssigneeAlias(value: string): string {
+  const trimmed = value.trim()
+  const lower = trimmed.toLowerCase()
+  if (lower === '@workspace' || lower === 'workspace') return WORKSPACE_ASSIGNEE
+  if (lower === '@human' || lower === 'human') return HUMAN_ASSIGNEE
+  if (lower === '@unassigned' || lower === 'unassigned') return UNASSIGNED_ASSIGNEE
+  return trimmed
+}
+

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -48,9 +48,9 @@ Output is JSON on stdout; a non-zero exit means it failed (reason on stderr).
 **To place a trade, that's `alice-uta`** — resolve the contract first and report
 every result. Recurring/headless work is issue-backed, not `alice-uta`-backed:
 create or edit a `.alice/issues/<id>.md` issue with a `when` field (or use
-`alice-workspace issue create --when ... --assignee session:self`) and write a
-complete `what` prompt. Use `session:<resumeId>` for one accountable Session or
-`workspace` to recruit a new Session each fire.
+`alice-workspace issue create --when ... --assignee @me`) and write a
+complete `what` prompt. Use an exact `@resumeId` for one accountable Session or
+`@workspace` to recruit a new Session each fire.
 
 ## Beyond Alice's data — `opencli` (optional, read-only)
 
@@ -156,7 +156,7 @@ For recurring work, create a scheduled issue instead of inventing a side channel
 ```bash
 alice-workspace issue create --title "Pre-market power brief" --priority high \
   --when '{"kind":"cron","cron":"30 8 * * 1-5"}' \
-  --assignee session:self \
+  --assignee @me \
   --what "Check AI power infrastructure names, write research/premarket-power.md, then push it to Inbox if there is a material update."
 ```
 

--- a/ui/src/api/headless.ts
+++ b/ui/src/api/headless.ts
@@ -9,11 +9,9 @@ export interface HeadlessTaskRecord {
   /** Direct execution lineage within this resumable conversation. */
   parentTaskId?: string
   wsId: string
-  /** The workspace ISSUE that fired this run (the issue filename stem), when it
-   *  was dispatched by the scheduler from a scheduled `.alice/issues/<id>.md`.
-   *  Absent on manual/external dispatches and on runs predating the field. This
-   *  is the run↔issue link the issue detail's Activity feed joins on. */
-  issueId?: string
+  /** Business source; independent from wsId when a cross-Workspace signed
+   * Session executes an Issue owned by another Workspace. */
+  trigger?: { kind: 'issue'; workspaceId: string; issueId: string }
   agent: string
   prompt: string
   status: HeadlessTaskStatus

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -63,7 +63,7 @@ export interface IssueListItem {
   title: string
   status: IssueStatus
   priority: IssuePriority
-  /** "human" | "ws:<tag|id>" | "unassigned"; missing assignee defaults to the owning workspace. */
+  /** @workspace | @human | @unassigned | exact @resumeId Session signature. */
   assignee: string
   /** Adapter id for the scheduled fire override, if set. */
   agent?: string
@@ -149,7 +149,7 @@ export interface IssueDetailIssue {
   what: string
   status: IssueStatus
   priority: IssuePriority
-  /** "human" | "ws:<tag|id>" | "unassigned"; missing assignee defaults to the owning workspace. */
+  /** @workspace | @human | @unassigned | exact @resumeId Session signature. */
   assignee: string
   /** Present iff the issue self-schedules. */
   when?: ScheduleWhen

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -108,7 +108,7 @@ function AssigneeEditor({
   const sessionChoices = sessions.filter(
     (session) => session.resumeId && session.agent !== 'shell' && session.resumable,
   )
-  const selectedResumeId = value.startsWith('session:') ? value.slice('session:'.length) : null
+  const selectedResumeId = value.startsWith('@resume-') ? value.slice(1) : null
   const hasSelected = !selectedResumeId || sessionChoices.some((session) => session.resumeId === selectedResumeId)
   const labelFor = (session: WorkspaceSessionDirectoryEntry) => {
     const raw = session.interactive?.title
@@ -127,17 +127,17 @@ function AssigneeEditor({
       aria-label="Assignee"
       onChange={(event) => onChange(event.target.value)}
     >
-      <option value="workspace">{scheduled ? 'Workspace · new Session each run' : 'Workspace'}</option>
-      {!scheduled && <option value="human">Human</option>}
-      {!scheduled && <option value="unassigned">Unassigned</option>}
+      <option value="@workspace">{scheduled ? '@Workspace · new Session each run' : '@Workspace'}</option>
+      {!scheduled && <option value="@human">Human</option>}
+      {!scheduled && <option value="@unassigned">Unassigned</option>}
       <optgroup label="Workspace Sessions">
         {sessionChoices.map((session) => (
-          <option key={session.resumeId} value={`session:${session.resumeId}`}>
+          <option key={session.resumeId} value={`@${session.resumeId}`}>
             {labelFor(session)}
           </option>
         ))}
         {!hasSelected && selectedResumeId && (
-          <option value={value}>Unavailable Session · {selectedResumeId}</option>
+          <option value={value}>Signed Session · {selectedResumeId}</option>
         )}
       </optgroup>
     </select>
@@ -262,8 +262,8 @@ function PropertiesRail({
   const meta = STATUS_META[issue.status]
   const issueDefaultInOptions = issueDefaultAgent && agentOptions.some((a) => a.id === issueDefaultAgent) ? issueDefaultAgent : null
   const defaultInOptions = defaultAgent && agentOptions.some((a) => a.id === defaultAgent) ? defaultAgent : null
-  const ownerResumeId = issue.assignee.startsWith('session:')
-    ? issue.assignee.slice('session:'.length)
+  const ownerResumeId = issue.assignee.startsWith('@resume-')
+    ? issue.assignee.slice(1)
     : null
   const ownerSession = ownerResumeId
     ? sessions.find((session) => session.resumeId === ownerResumeId)
@@ -940,8 +940,8 @@ export function IssueDetail({
     </button>
   )
 
-  const stableOwnerResumeId = data?.issue.assignee.startsWith('session:')
-    ? data.issue.assignee.slice('session:'.length)
+  const stableOwnerResumeId = data?.issue.assignee.startsWith('@resume-')
+    ? data.issue.assignee.slice(1)
     : null
 
   useEffect(() => {

--- a/ui/src/components/MarkdownContent.spec.ts
+++ b/ui/src/components/MarkdownContent.spec.ts
@@ -46,4 +46,11 @@ describe('renderMarkdownHtml', () => {
     expect(html).toContain('data-entity="stock-glw"')
     expect(html).toContain('data-entity="ai-data-center-power"')
   })
+
+  it('renders a Session signature as a resumable link but leaves code examples alone', () => {
+    const html = renderMarkdownHtml('Signed-by: @resume-kind-owl-abc123 and `@resume-example`')
+    expect(html).toContain('class="session-signature"')
+    expect(html).toContain('data-resume-id="resume-kind-owl-abc123"')
+    expect(html).toContain('<code>@resume-example</code>')
+  })
 })

--- a/ui/src/components/MarkdownContent.tsx
+++ b/ui/src/components/MarkdownContent.tsx
@@ -13,6 +13,8 @@ import DOMPurify from 'dompurify'
 import 'highlight.js/styles/github-dark.min.css'
 
 import { useWikilinkHandler } from '../live/wikilink'
+import { useWorkspaces } from '../contexts/workspaces-context'
+import { resolveSessionSignature } from './workspace/api'
 
 function escapeHtml(s: string): string {
   return s
@@ -60,6 +62,22 @@ function createWikilinkExtension(opts: { codeSpanWikilinks: boolean }): Tokenize
   }
 }
 
+/** `@resumeId` is the visible signature of an accountable product Session.
+ * Like wikilinks this is an inline tokenizer, so examples in code remain text. */
+const sessionSignatureExtension: TokenizerAndRendererExtension = {
+  name: 'sessionSignature',
+  level: 'inline',
+  start: (src) => src.indexOf('@resume-'),
+  tokenizer(src) {
+    const match = /^@(resume-[A-Za-z0-9_-]+)/.exec(src)
+    return match ? { type: 'sessionSignature', raw: match[0], text: match[1] } : undefined
+  },
+  renderer(token) {
+    const resumeId = token.text as string
+    return `<a class="session-signature" data-resume-id="${escapeHtml(resumeId)}">@${escapeHtml(resumeId)}</a>`
+  },
+}
+
 function createMarked(opts: { strikethrough: boolean; codeSpanWikilinks: boolean }): Marked {
   const instance = new Marked(
     markedHighlight({
@@ -73,7 +91,10 @@ function createMarked(opts: { strikethrough: boolean; codeSpanWikilinks: boolean
     }),
     { breaks: true },
   )
-  instance.use({ extensions: [createWikilinkExtension({ codeSpanWikilinks: opts.codeSpanWikilinks })] })
+  instance.use({ extensions: [
+    createWikilinkExtension({ codeSpanWikilinks: opts.codeSpanWikilinks }),
+    sessionSignatureExtension,
+  ] })
   if (!opts.strikethrough) {
     instance.use({
       tokenizer: {
@@ -152,6 +173,7 @@ export function MarkdownContent({
 }: MarkdownContentProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const defaultWikilink = useWikilinkHandler()
+  const { openHeadlessRun } = useWorkspaces()
   const wikilink = onWikilink ?? defaultWikilink
 
   const html = useMemo(() => {
@@ -168,6 +190,20 @@ export function MarkdownContent({
         if (key) wikilink(key)
         return
       }
+      const signature = target.closest('a.session-signature') as HTMLElement | null
+      if (signature) {
+        e.preventDefault()
+        const resumeId = signature.getAttribute('data-resume-id')
+        if (resumeId) {
+          void resolveSessionSignature(resumeId)
+            .then((identity) => {
+              if (!identity.resumable) throw new Error('This Session has not captured a resumable runtime conversation yet.')
+              return openHeadlessRun(identity.workspaceId, identity.resumeId)
+            })
+            .catch((err) => console.error('session_signature.open_failed', { resumeId, err }))
+        }
+        return
+      }
       const btn = target.closest('.code-copy-btn') as HTMLButtonElement | null
       if (!btn) return
       const wrapper = btn.closest('.code-block-wrapper')
@@ -181,7 +217,7 @@ export function MarkdownContent({
         }, 2000)
       })
     },
-    [wikilink],
+    [wikilink, openHeadlessRun],
   )
 
   useEffect(() => {

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -432,6 +432,20 @@ export interface OpenHeadlessSessionOptions {
   readonly title?: string;
 }
 
+export interface SessionSignatureIdentity {
+  readonly signature: string;
+  readonly resumeId: string;
+  readonly workspaceId: string;
+  readonly agent: string;
+  readonly resumable: boolean;
+}
+
+export async function resolveSessionSignature(resumeId: string): Promise<SessionSignatureIdentity> {
+  const res = await fetch(`/api/workspaces/signatures/${encodeURIComponent(resumeId)}`);
+  if (!res.ok) throw new Error(res.status === 404 ? 'Session signature not found' : `signature lookup failed: ${res.status}`);
+  return (await res.json()) as SessionSignatureIdentity;
+}
+
 export interface OpenHeadlessSessionResult {
   readonly session: SessionRecord;
   readonly created: boolean;

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -40,7 +40,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Morning movers scan',
           status: 'in_progress',
           priority: 'high',
-          assignee: 'workspace',
+          assignee: '@workspace',
           agent: 'codex',
           when: { kind: 'cron', cron: '30 8 * * 1-5' },
           lastFiredAtMs: now - HOUR,
@@ -52,7 +52,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Thesis invalidation watch',
           status: 'todo',
           priority: 'urgent',
-          assignee: 'session:demo-resume-thesis-owner',
+          assignee: '@resume-demo-thesis-owner',
           when: { kind: 'every', every: '1h' },
           lastFiredAtMs: now - HOUR / 2,
           nextDueAtMs: now + HOUR / 2,
@@ -63,7 +63,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Rebalance sizing logic needs a human review',
           status: 'todo',
           priority: 'medium',
-          assignee: 'human',
+          assignee: '@human',
         },
         // Backlog, unassigned, unscheduled.
         {
@@ -71,7 +71,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Prune stale signal cache entries',
           status: 'backlog',
           priority: 'low',
-          assignee: 'unassigned',
+          assignee: '@unassigned',
         },
         // Cross-workspace name collision (also declared in demo-ws-macro under
         // the same title). nameCollision flags the board warning; the two share a
@@ -81,7 +81,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Liquidity risk review',
           status: 'todo',
           priority: 'high',
-          assignee: 'workspace',
+          assignee: '@workspace',
           nameCollision: true,
         },
       ],
@@ -97,7 +97,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Weekly macro digest',
           status: 'in_progress',
           priority: 'medium',
-          assignee: 'workspace',
+          assignee: '@workspace',
           agent: 'codex',
           when: { kind: 'cron', cron: '0 16 * * 5' },
           lastFiredAtMs: now - 2 * DAY,
@@ -109,7 +109,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Write the CPI release reaction note',
           status: 'todo',
           priority: 'high',
-          assignee: 'human',
+          assignee: '@human',
           agent: 'claude',
           when: { kind: 'at', at: new Date(now + 3 * DAY).toISOString() },
           lastFiredAtMs: null,
@@ -121,7 +121,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Summarize the upcoming Fed speaker calendar',
           status: 'done',
           priority: 'none',
-          assignee: 'human',
+          assignee: '@human',
         },
         // Canceled work item.
         {
@@ -129,7 +129,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Cross-asset correlation study',
           status: 'canceled',
           priority: 'low',
-          assignee: 'unassigned',
+          assignee: '@unassigned',
         },
         // Cross-workspace name collision (the other half of the auto-quant
         // "Liquidity risk review"). Same title, different wsId / status / owner.
@@ -138,7 +138,7 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           title: 'Liquidity risk review',
           status: 'backlog',
           priority: 'medium',
-          assignee: 'human',
+          assignee: '@human',
           nameCollision: true,
         },
       ],

--- a/ui/src/demo/fixtures/schedule.ts
+++ b/ui/src/demo/fixtures/schedule.ts
@@ -12,7 +12,7 @@ export const demoScheduleSnapshot: ScheduleSnapshot = {
       tasks: [
         {
           id: 'morning-scan',
-          assignee: 'workspace',
+          assignee: '@workspace',
           issue: 'Morning movers scan',
           when: { kind: 'cron', cron: '30 8 * * 1-5' },
           what: 'Pull pre-market movers and overnight news for the watchlist, write a brief, then push it to the inbox.',
@@ -22,7 +22,7 @@ export const demoScheduleSnapshot: ScheduleSnapshot = {
         },
         {
           id: 'thesis-watch',
-          assignee: 'session:demo-resume-thesis-owner',
+          assignee: '@resume-demo-thesis-owner',
           issue: 'Thesis invalidation watch',
           when: { kind: 'every', every: '1h' },
           what: 'Re-check the thesis vs the latest quote; alert only if the invalidation level broke, otherwise exit.',
@@ -40,7 +40,7 @@ export const demoScheduleSnapshot: ScheduleSnapshot = {
       tasks: [
         {
           id: 'weekly-digest',
-          assignee: 'workspace',
+          assignee: '@workspace',
           issue: 'Weekly macro digest',
           when: { kind: 'cron', cron: '0 16 * * 5' },
           what: 'Summarize the week across tracked entities and push a digest to the inbox.',

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -167,13 +167,30 @@ export const workspacesHandlers = [
       title: null,
     }),
   ),
+  http.get('/api/workspaces/signatures/:resumeId', ({ params }) => {
+    const resumeId = String(params.resumeId)
+    const workspace = demoWorkspaces.find((candidate) =>
+      candidate.sessions.some((session) => session.resumeId === resumeId),
+    ) ?? (resumeId === 'resume-demo-thesis-owner'
+      ? demoWorkspaces.find((candidate) => candidate.id === 'demo-ws-auto-quant')
+      : undefined)
+    if (!workspace) return HttpResponse.json({ error: 'not_found' }, { status: 404 })
+    const session = workspace.sessions.find((candidate) => candidate.resumeId === resumeId)
+    return HttpResponse.json({
+      signature: `@${resumeId}`,
+      resumeId,
+      workspaceId: workspace.id,
+      agent: session?.agent ?? 'claude',
+      resumable: true,
+    })
+  }),
   http.get('/api/workspaces/:id/resumes', ({ params }) => {
     const wsId = String(params.id)
     if (wsId === 'demo-ws-auto-quant') {
       return HttpResponse.json({
         workspace: { id: wsId, tag: 'auto-quant' },
         sessions: [{
-          resumeId: 'demo-resume-thesis-owner', agent: 'claude',
+          resumeId: 'resume-demo-thesis-owner', agent: 'claude',
           createdAt: Date.now() - 86_400_000, updatedAt: Date.now() - 60_000,
           resumable: true, active: false,
           latestExecution: {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -547,6 +547,20 @@ html[lang="ja"] .oa-onboarding-title {
 .markdown-content a.wikilink:hover {
   border-bottom-style: solid;
 }
+
+.markdown-content a.session-signature {
+  color: var(--color-accent, #3b82f6);
+  cursor: pointer;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 4px;
+  padding: 0 2px;
+}
+
+.markdown-content a.session-signature:hover {
+  background: color-mix(in srgb, currentColor 10%, transparent);
+  text-decoration: underline;
+}
 .markdown-content blockquote {
   border-left: 3px solid var(--color-accent);
   padding-left: 12px;


### PR DESCRIPTION
## What changed

- Introduces visible product Session signatures (`@resumeId`) across Issue ownership and standalone Markdown.
- Makes agent-created Issues default to the current attributable Session; `@me` resolves at write time and `@workspace` explicitly recruits a fresh Session per fire.
- Supports exact signed Session ownership across Workspace boundaries while preserving the Issue home Workspace in run, Inbox, Activity, and one-shot completion provenance.
- Adds `alice-workspace signature show`, spawn-time `OPENALICE_RESUME_ID` / `OPENALICE_SIGNATURE`, clickable Markdown signatures, and safe backend signature resolution.
- Adds migrations for Issue assignee syntax and composite headless Issue triggers, plus updated agent guidance and docs.

## Why

OpenAlice needs artifacts to answer “who did this?” with a stable product identity and let another Agent or the user return to that exact conversation. Runtime-native session ids remain private implementation details.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 2628 passed, 6 skipped
- `pnpm build`
- Browser verification on the live Issue detail page; no console errors
- `pnpm electron:smoke:packaged --temp-data`
- `pnpm electron:assert-package`
