### PR TITLE
Fix Shell-created Issue ownership

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "electron:tsc": "pnpm -F @traderalice/desktop build",
     "electron:build": "pnpm build && pnpm electron:tsc",
     "electron:dev": "pnpm electron:build && pnpm -F @traderalice/desktop dev",
-    "electron:pack": "pnpm electron:build && pnpm vendor:runtime && pnpm -F @traderalice/desktop pack",
+    "electron:pack": "pnpm electron:build && pnpm vendor:runtime && pnpm -F @traderalice/desktop run pack",
     "electron:assert-package": "node scripts/assert-desktop-package.mjs",
     "electron:smoke-toolchain": "node scripts/smoke-packaged-toolchain.mjs",
     "electron:smoke:packaged": "node scripts/desktop-packaged-smoke.mjs",

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -114,6 +114,7 @@ describe('issue_create', () => {
         resumeId: 'resume-kind-owl-abc123',
         agent: 'codex',
       },
+      resolveSessionIdentity: () => ({ workspaceId: 'ws-self', agent: 'codex', resumable: true }),
     })
     const created = await run(issueCreateFactory.build(context), {
       id: 'owned-schedule',
@@ -129,6 +130,30 @@ describe('issue_create', () => {
     })
     expect(explicit.ok).toBe(true)
     expect((await readBack('owned-explicit'))?.assignee).toBe('@resume-kind-owl-abc123')
+  })
+
+  it('does not make a non-resumable Shell PTY the implicit owner', async () => {
+    const context = ctx({
+      origin: {
+        kind: 'interactive',
+        sessionId: 'shell-surface',
+        resumeId: 'resume-shell-terminal',
+        agent: 'shell',
+      },
+      resolveSessionIdentity: () => ({ workspaceId: 'ws-self', agent: 'shell', resumable: false }),
+    })
+
+    const implicit = await run(issueCreateFactory.build(context), {
+      id: 'shell-created', title: 'Shell-created issue',
+    })
+    expect(implicit.ok).toBe(true)
+    expect((await readBack('shell-created'))?.assignee).toBe('@workspace')
+
+    const explicit = await run(issueCreateFactory.build(context), {
+      id: 'shell-owned', title: 'Invalid shell owner', assignee: '@me',
+    })
+    expect(explicit.ok).toBe(false)
+    expect(explicit.error).toMatch(/not resumable yet/)
   })
 
   it('allows assigning an exact signed Session from another workspace', async () => {

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -104,6 +104,26 @@ function resolveIssueAssignee(
   return { ok: true, assignee: parsed.data }
 }
 
+/**
+ * "Who creates it owns it" only applies when the caller is an actual product
+ * Session that Alice can resume. Shell PTYs also carry an interactive
+ * SessionRecord/resumeId for terminal bookkeeping, but they have no native
+ * Agent Runtime conversation to continue. Treating those as owners creates an
+ * Issue that cannot ever run; an omitted owner therefore falls back to the
+ * Workspace, while an explicit `@me` remains a strict validation error.
+ *
+ * Older/test contexts may not expose the identity resolver. Preserve their
+ * attributable-session behavior; production always supplies the resolver.
+ */
+function defaultIssueAssignee(ctx: WorkspaceToolContext): string {
+  const origin = sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)
+  if (!origin) return WORKSPACE_ASSIGNEE
+  if (!ctx.resolveSessionIdentity) return '@me'
+  return ctx.resolveSessionIdentity(origin.resumeId)?.resumable
+    ? '@me'
+    : WORKSPACE_ASSIGNEE
+}
+
 /** The comment / create author for this workspace's writes. */
 const author = (ctx: WorkspaceToolContext): string => `ws:${ctx.workspaceLabel}`
 
@@ -353,9 +373,7 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         // Structured creation is attributable: "who creates it owns it". A
         // human/unattributed caller has no Session to sign with, so its safe
         // fallback is the Issue's home Workspace recruiting a fresh worker.
-        const defaultAssignee = sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin)
-          ? '@me'
-          : WORKSPACE_ASSIGNEE
+        const defaultAssignee = defaultIssueAssignee(ctx)
         const resolvedAssignee = resolveIssueAssignee(ctx, assignee ?? defaultAssignee)
         if (!resolvedAssignee.ok) return { ok: false as const, error: resolvedAssignee.error }
         const res = await createIssue(dir.dir, {


### PR DESCRIPTION
## Summary
- make omitted Issue ownership fall back to `@workspace` for Shell and other non-resumable PTYs
- keep explicit `@me` strict and preserve automatic ownership for resumable Agent Sessions
- fix the root Electron packaging script so it invokes the desktop package script rather than pnpm's built-in tarball command

## Root cause
Shell PTYs receive a product-side resume id for terminal bookkeeping, but they do not own a resumable native Agent Runtime conversation. The Issue creator treated any attributed resume id as an assignable owner, so packaged CLI creation was rejected after the command had already entered the tool layer and the Issue never appeared on the board.

## Verification
- `pnpm vitest run src/tool/issue-tools.spec.ts src/server/cli.spec.ts`
- `pnpm build`
- unsigned Electron directory package through `pnpm --filter @traderalice/desktop run pack`
- `pnpm electron:smoke:workspace --skip-build --skip-pack` (all Shell, Pi, structured-output, side-effect, and cleanup checks passed)

## Boundary touch
- Workspace CLI ownership semantics
- Electron packaging command
