### PR TITLE
fix: include workspace CLI binaries in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,8 @@ RUN chmod +x /app/src/workspaces/cli/bin/alice \
  && ln -sf /app/src/workspaces/cli/bin/alice          /usr/local/bin/alice \
  && ln -sf /app/src/workspaces/cli/bin/alice-uta      /usr/local/bin/alice-uta \
  && ln -sf /app/src/workspaces/cli/bin/alice-workspace /usr/local/bin/alice-workspace \
- && ln -sf /app/src/workspaces/cli/bin/traderhub      /usr/local/bin/traderhub
+ && ln -sf /app/src/workspaces/cli/bin/traderhub      /usr/local/bin/traderhub \
+ && cp /app/src/workspaces/cli/bin/openalice-cli.cjs  /usr/local/bin/openalice-cli.cjs
 # tsup bundles backend deps into the entry files where possible, but
 # native modules (node-pty, longbridge, etc.) stay as runtime requires.
 COPY --from=build /src/node_modules               ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,19 @@ COPY --from=build /src/services/uta/dist          ./services/uta/dist
 COPY --from=build /src/ui/dist                    ./ui/dist
 COPY --from=build /src/default                    ./default
 COPY --from=build /src/src/workspaces/templates   ./src/workspaces/templates
+# Workspace CLIs (alice, alice-uta, alice-workspace, traderhub) — the launcher
+# injects these as the agent's ONLY path to OpenAlice's tools (no MCP in
+# workspaces). Without them on PATH, spawned agent sessions (claude, codex)
+# start but cannot reach any of the 72 registered tool-center tools.
+COPY --from=build /src/src/workspaces/cli/bin      ./src/workspaces/cli/bin
+RUN chmod +x /app/src/workspaces/cli/bin/alice \
+             /app/src/workspaces/cli/bin/alice-uta \
+             /app/src/workspaces/cli/bin/alice-workspace \
+             /app/src/workspaces/cli/bin/traderhub \
+ && ln -sf /app/src/workspaces/cli/bin/alice          /usr/local/bin/alice \
+ && ln -sf /app/src/workspaces/cli/bin/alice-uta      /usr/local/bin/alice-uta \
+ && ln -sf /app/src/workspaces/cli/bin/alice-workspace /usr/local/bin/alice-workspace \
+ && ln -sf /app/src/workspaces/cli/bin/traderhub      /usr/local/bin/traderhub
 # tsup bundles backend deps into the entry files where possible, but
 # native modules (node-pty, longbridge, etc.) stay as runtime requires.
 COPY --from=build /src/node_modules               ./node_modules


### PR DESCRIPTION
## Problem

The Dockerfile copies `src/workspaces/templates` into the runtime image but not `src/workspaces/cli/bin/`. This means the four workspace CLIs (`alice`, `alice-uta`, `alice-workspace`, `traderhub`) are missing from the container.

Per `src/workspaces/context-injector.ts`, the launcher injects NO MCP into workspaces — these CLIs are the agent's ONLY path to OpenAlice's 72 tool-center tools:

```ts
const CLI_TOOLS_SKILLS = ['alice', 'alice-analysis', 'alice-uta', 'alice-workspace', 'traderhub'];
```

Without them on PATH, spawned agent sessions (Claude Code, Codex) start successfully and appear healthy in the logs, but cannot reach any market data, trading, analysis, or inbox tools. The agent runs but is effectively blind.

## Symptom

On the web UI, agents show as installed and sessions spawn without error, but the agent cannot access any OpenAlice tools — `which alice` returns nothing inside the container.

## Fix

`COPY` the `src/workspaces/cli/bin/` directory into the image and symlink the four CLIs to `/usr/local/bin/` so they are on PATH for PTY sessions.