### PR TITLE
Clarify Workspace agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,8 @@ Read the relevant guide before editing its subsystem:
   delivery modes, promotions, external contributions, and risk gates.
 - [[docs/managed-workspace-runtime.md]] — [Managed Workspace runtime](docs/managed-workspace-runtime.md): Electron
   packaging, managed Pi, PortableGit/Bash, runtime profiles, and Workspace PATH.
+- [[docs/workspace-agent-guidance.md]] — [Workspace agent guidance](docs/workspace-agent-guidance.md): prompt
+  layers, skill ownership, live CLI authority, and guidance versioning.
 - [[docs/workspace-lifecycle.md]] — [Workspace and Session lifecycle](docs/workspace-lifecycle.md): offboarding,
   departed desks, handoff, restore/purge, and resumeId retirement.
 - [[docs/uta-live-testing.md]] — [UTA live testing](docs/uta-live-testing.md): broker/trading acceptance loops.

--- a/default/persona.default.md
+++ b/default/persona.default.md
@@ -4,4 +4,7 @@ You are Alice, an autonomous agent from the OpenAlice project. You are a AI assi
 You are Trading savvy.
 Your speaking style sometimes has a young girl's feel to it, with a human-like tone.
 
-Your workspace launcher puts OpenAlice's tools on your PATH as CLIs — `alice` (research & data), `alice-analysis` (quant), `alice-uta` (trading), `alice-workspace` (inbox push/read, peer-workspace files, entity tracking), `traderhub` (low-frequency market data); each has a skill, and `--help` is live. To act on the market — place an order, manage a position — that's `alice-uta`. Tools are just tools — there is no internal/external distinction; reach for whatever fits the job, including anything else your environment offers.
+Tools are just tools — there is no internal/external distinction. Reach for
+whatever fits the job, including anything else your environment offers. The
+Workspace instructions define OpenAlice-specific operating rules and route you
+to the current CLI skills; do not rely on a remembered command shape.

--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -1,24 +1,30 @@
 ---
 name: alice-workspace
 description: >
-  Agent collaboration on your shell PATH via the `alice-workspace` CLI: push
-  finished work to the user's Inbox (`inbox push`, with repeatable `--doc`
-  file attachments), read the inbox back (`inbox read`, `--self` for your own
-  pushes), locate a peer workspace's files (`peer path`) and product Sessions
-  (`peer sessions`), ask attributable peer Sessions and await their replies
-  (`conversation ask` / `conversation await`),
-  track entities across workspaces (`track`), and read & manage the
-  cross-workspace issue board (`issue list`/`show`/`create`/`update`/`comment`).
-  Use for: "push my findings to the inbox", "surface this report to the user",
-  "what did I already report?", "read the file another workspace sent", "track
-  this ticker", "what's on the issue board?", "what was I working on?", "add or
-  update an issue", "ask the agent who produced this Inbox result", "why was
-  this Issue created?". Workspaces collaborate through git — commit before you push,
-  and commit after you edit a peer's files. Discover flags with
-  `alice-workspace --help` — do NOT guess.
+  Use the `alice-workspace` CLI for collaboration and provenance: Inbox
+  delivery, the global Issue board, tracked entities, peer files, and asking an
+  attributable product Session. Use it when work must be surfaced, remembered,
+  assigned, or followed back to the Agent that produced it. Read live help;
+  never guess flags or use `issue comment` as a substitute for `issue ask`.
 ---
 
 # Collaboration — `alice-workspace`
+
+Choose the verb from the intent, not from whichever object you happen to have:
+
+| Intent | Command family |
+|---|---|
+| Tell the human about finished/asynchronous work | `inbox push` |
+| Read what desks already surfaced | `inbox read` |
+| Ask why one Inbox entry was produced | `inbox ask` |
+| Inspect the shared work board | `issue list` / `issue show` |
+| Ask an Issue's creator, owner, or selected run | `issue ask` |
+| Record a note on this Workspace's own Issue | `issue comment` |
+| Ask by a known product Session/Workspace only when no business object exists | `conversation ask` |
+
+`issue comment` is a structured note for the human-visible board. It is a
+local write and **does not message or resume another agent**. When the goal is
+to obtain an answer, use `inbox ask` or `issue ask`, normally with `--await`.
 
 **Hand finished work back to the user** — this is the outbound channel. It posts
 to the user's Inbox tab:

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -1,19 +1,12 @@
 ---
 name: self-scheduling
 description: >
-  Track and self-schedule work for THIS workspace by writing one markdown file
-  per issue under `.alice/issues/<id>.md` at the workspace root. Each file is
-  YAML frontmatter + one canonical markdown What. An issue WITHOUT a `when` field is
-  just a tracked work item (it shows on the Issue board, the scanner ignores
-  it). An issue WITH a `when` field self-schedules: the launcher scans the dir
-  and, when it's due, dispatches the Workspace or assigned product Session with
-  your prompt; the run reports back to the user's Inbox. Use for: "track this",
-  "add an issue/todo", "run this every 30 minutes", "every morning before the
-  open do X", "check Y each hour and ping me only if Z", "do this once at 4pm",
-  "self-schedule", "set up a recurring job". Manage issues either by editing
-  the files directly or with the `alice-workspace issue …` CLI (list / show /
-  create / update / comment); the same tools are also exposed over MCP (one
-  adapter).
+  Define durable work and scheduled/headless execution with
+  `.alice/issues/<id>.md`: structured ownership and optional `when` frontmatter
+  plus one canonical markdown What. Use for creating or editing an Issue,
+  choosing its assignee, schedule, prompt, delivery behavior, or health state.
+  Use the `alice-workspace` skill instead when the goal is to ask another
+  Session for an answer.
 ---
 
 # Issues & self-scheduling — `.alice/issues/<id>.md`
@@ -77,7 +70,8 @@ alice-workspace issue create --title "Split the data fetcher" \
 alice-workspace issue update --id morning-scan --status done
 
 # comment — append markdown to the structured `<id>.comments.json` sidecar, authored as
-# ws:<this workspace>. Use it for a progress note, finding, or a question.
+# ws:<this workspace>. Use it for a human-visible progress note or finding. It
+# does not contact an Agent; use `issue ask` when you need a reply.
 alice-workspace issue comment --id morning-scan --text "Brief pushed; SPY gapped +0.4%."
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ GitHub navigation.
 | [[docs/project-structure.md]] | [Project structure](project-structure.md) | Process boundaries, source ownership, state roots, architectural entry points |
 | [[docs/development-workflow.md]] | [Development workflow](development-workflow.md) | Branches, delivery modes, PRs, promotions, external review, risk gates |
 | [[docs/managed-workspace-runtime.md]] | [Managed Workspace runtime](managed-workspace-runtime.md) | Electron packaging, managed Pi, PortableGit/Bash, runtime profile, Workspace PATH |
+| [[docs/workspace-agent-guidance.md]] | [Workspace agent guidance](workspace-agent-guidance.md) | Always-loaded prompt contract, skill ownership, live CLI authority, guidance versioning |
 | [[docs/workspace-lifecycle.md]] | [Workspace and Session lifecycle](workspace-lifecycle.md) | Offboarding, departed directories, handoff, restore/purge, Session retirement |
 | [[docs/workspace-issues-and-scheduling.md]] | [Workspace issues and scheduling](workspace-issues-and-scheduling.md) | Markdown issue contract, global board, schedule scanner, headless execution, Inbox delivery |
 | [[docs/conversation-provenance.md]] | [Workspace Session and artifact provenance](conversation-provenance.md) | `resumeId` identity, artifact trails, Issue execution responsibility, and provenance-before-collaboration sequencing |

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -1,0 +1,78 @@
+# Workspace Agent Guidance
+
+This guide owns the instruction architecture injected into OpenAlice
+Workspaces. It covers the boundary between the always-loaded Workspace
+contract, discoverable skills, and the live CLI surface.
+
+## The three layers
+
+### 1. Always-loaded contract
+
+`src/workspaces/templates/<template>/files/instruction.md` is composed with the
+Alice persona and written to both `CLAUDE.md` and `AGENTS.md` by
+`src/workspaces/context-injector.ts`.
+
+This layer may define only durable behavior:
+
+- how to distinguish chat, durable work, Inbox delivery, and trading;
+- evidence and freshness requirements;
+- when to ask an attributable Session instead of guessing;
+- which skill owns a domain.
+
+It must not duplicate flag manuals, Issue schemas, long examples, or provider
+inventories. Those details change too often and crowd out the actual request.
+
+### 2. Discoverable skills
+
+`default/skills/*/SKILL.md` owns domain procedures and command examples. A skill
+description should answer only “when should I load this?”; the body teaches the
+workflow after it is selected.
+
+One concept has one primary owner:
+
+| Concept | Owner |
+|---|---|
+| Inbox, Issue collaboration, provenance, peer questions | `alice-workspace` |
+| Issue file shape, ownership, schedules, headless delivery | `self-scheduling` |
+| Low-frequency market/fundamental/macro data | `traderhub` |
+| Quantitative K-line panels and source choice | `alice-analysis` |
+| Broker state and trading writes | `alice-uta` |
+
+Other instructions may route to that owner but should not copy its manual.
+
+### 3. Live CLI contract
+
+The CLI manifest and tool results are the final authority for verbs, flags, and
+validation. Durable Workspaces can carry old skill snapshots, so errors should
+be self-correcting: say what boundary was crossed and name the next appropriate
+command. A bare validation failure that forces the agent to guess is a product
+bug.
+
+Use the real shim in the verification loop; direct tool calls do not exercise
+argv parsing or manifest help.
+
+## Snapshot and upgrade semantics
+
+Guidance is copied into a Workspace at creation and committed as part of its
+initial desk state. It is not silently replaced later: agents and users may have
+edited those files, and an automatic overwrite would mutate a durable work log.
+
+The template README version records guidance changes. Bump it when the injected
+contract or bundled skill set changes materially. Existing Workspaces then show
+an upgrade-available signal; applying that upgrade must remain an explicit,
+diff-visible operation. Until an upgrade workflow exists, live CLI help and
+self-correcting errors are the compatibility layer for older desks.
+
+## Review checklist
+
+- Is the rule durable enough to be always loaded, or does it belong in a skill?
+- Does another skill already own the concept?
+- Does the skill description route clearly without becoming a mini-manual?
+- Can every market fact the prompt asks for be traced to a tool result or named
+  artifact, with its `asOf` meaning preserved?
+- If a stale agent chooses the wrong verb, does the live error lead it to the
+  correct one?
+- Was the template version bumped for a material injected-guidance change?
+- Were context injection, the affected tool, the CLI gateway, and the real shim
+  tested together?
+

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -382,6 +382,17 @@ describe('global board (ctx.board present)', () => {
     expect(list.invalid).toEqual([{ wsId: 'ws-c', tag: 'broken', error: 'retired .alice/issue.json' }])
   })
 
+  it('redirects a failed local write to the attributable cross-workspace ask flow', async () => {
+    const result = await run(issueCommentFactory.build(boardCtx()), {
+      id: 'shared-b',
+      text: 'why?',
+    })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('writes only this workspace')
+    expect(result.error).toContain('issue ask --id "shared-b" --owner')
+    expect(result.error).toContain('--await')
+  })
+
   it('issue_list summary hides low-priority global noise but keeps local issues', async () => {
     const list = await run(issueListFactory.build(boardCtx()), {})
     expect(list.ok).toBe(true)

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -69,6 +69,31 @@ function selfDir(ctx: WorkspaceToolContext): { ok: true; dir: string } | { ok: f
   return { ok: true, dir: meta.dir }
 }
 
+/**
+ * A durable Workspace can carry an older copy of the injected skill manual.
+ * Keep the live CLI error self-correcting: if a local write misses but the
+ * global board knows the Issue, explain the collaboration action instead of
+ * leaving the agent to guess that `comment` might message a peer.
+ */
+async function remoteIssueWriteHint(ctx: WorkspaceToolContext, id: string): Promise<string> {
+  if (!ctx.board) return ''
+  try {
+    const refs = await ctx.board.resolveByName(id)
+    const remote = refs.filter((ref) => ref.wsId !== ctx.workspaceId)
+    if (remote.length === 0) return ''
+    if (remote.length > 1) {
+      const labels = remote.map((ref) => `${ref.wsTag}/${ref.id}`).join(', ')
+      return `; global matches exist in other workspaces (${labels}). This command writes only this workspace. Inspect with issue show; to contact a responsible Session use issue ask with an unambiguous Issue name.`
+    }
+    const [ref] = remote
+    return `; a global match belongs to ${ref.wsTag}/${ref.id}. This command writes only this workspace. To get an answer from its responsible Session, use issue ask --id ${JSON.stringify(ref.id)} --owner --prompt <question> --await.`
+  } catch {
+    // The original local-write failure is still useful. Board lookup is an
+    // optional diagnostic and must never turn a clean tool error into a throw.
+    return ''
+  }
+}
+
 const issueAssigneeInputSchema = z.string().min(1).refine(
   (value) => value.toLowerCase() === '@me' || issueAssigneeSchema.safeParse(normalizeIssueAssigneeAlias(value)).success,
   'assignee must be @me, @workspace, @human, @unassigned, or an exact @resumeId',
@@ -288,7 +313,10 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
           await recordIssueProvenance(ctx, res.issue.id, 'updated')
           return { ok: true as const, issue: rowOf(res.issue) }
         }
-        if (res.reason === 'not_found') return { ok: false as const, error: `no such issue: ${id}` }
+        if (res.reason === 'not_found') {
+          const remoteHint = await remoteIssueWriteHint(ctx, id)
+          return { ok: false as const, error: `no such issue in this workspace: ${id}${remoteHint}` }
+        }
         return { ok: false as const, error: res.error }
       },
     })
@@ -321,7 +349,10 @@ export const issueCommentFactory: WorkspaceToolFactory = {
           await recordIssueProvenance(ctx, res.issue.id, 'commented')
           return { ok: true as const, issue: rowOf(res.issue) }
         }
-        if (res.reason === 'not_found') return { ok: false as const, error: `no such issue: ${id}` }
+        if (res.reason === 'not_found') {
+          const remoteHint = await remoteIssueWriteHint(ctx, id)
+          return { ok: false as const, error: `no such issue in this workspace: ${id}${remoteHint}` }
+        }
         return { ok: false as const, error: res.error }
       },
     })

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -86,6 +86,17 @@ describe('injectWorkspaceContext — persona', () => {
     expect(existsSync(join(dir, 'CLAUDE.md'))).toBe(false);
     expect(existsSync(join(dir, 'AGENTS.md'))).toBe(false);
   });
+
+  it('keeps the always-loaded Chat contract compact and routes manuals to skills', async () => {
+    const instruction = await readFile(join(CHAT_FILES, 'instruction.md'), 'utf8');
+    expect(instruction.split('\n').length).toBeLessThan(120);
+    expect(instruction).toContain('Every price, return, date, ratio');
+    expect(instruction).toContain('A comment is a board');
+    expect(instruction).toContain('The `alice-workspace` skill contains the exact commands');
+    expect(instruction).not.toContain('alice-workspace issue comment --text');
+    expect(instruction).not.toContain('alice-workspace inbox push --doc');
+    expect(instruction).not.toContain('--when');
+  });
 });
 
 describe('injectWorkspaceContext — skills', () => {

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.5.0
+version: 1.6.0
 ---
 
 # Chat

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -1,192 +1,82 @@
 # Chat workspace
 
-Chat is not a stateless Q&A box. Treat trading work as collaboration in a
-workspace: capture durable context in files, turn dynamic follow-up into Issues,
-link assets/topics/issues with `[[name]]`, and hand finished work back through
-the Inbox.
+This is a durable trading desk, not a stateless Q&A box. Help the user make
+better decisions by combining current evidence with the desk's accumulated
+files, Issues, Inbox reports, tracked entities, and attributable Sessions.
 
-Default working habit:
+## Operating contract
 
-- If the user asks a quick one-off question, answer it directly.
-- If the question creates follow-up work, monitoring, a rejected/active thesis,
-  or a recurring check, write or update an issue instead of leaving it only in
-  chat. Issues are the team's standing work items: status + priority tell human
-  and headless agents what deserves attention.
-- If you produce a result the user should see later, write it to a workspace
-  file, commit it, and push it to the Inbox.
-- If a ticker, topic, thesis, or issue should accumulate memory across time,
-  register/reuse a tracked entity and link it with `[[name]]` in notes and issue
-  bodies.
-- If an Issue or Inbox result lacks enough context, do not reconstruct the
-  author's reasoning alone. Follow its `resumeId` or Issue/Workspace provenance,
-  ask the responsible Session, and separate its answer from your own judgment.
-  When several peers may know different parts, ask them concurrently and
-  synthesize only after their replies arrive.
+1. **Answer the request before manufacturing workflow.** A quick question can
+   stay in chat. Create durable artifacts only when the work will matter later,
+   needs follow-up, or the user asks for them.
+2. **Read before repeating work.** Check the relevant files and, when history
+   matters, scan Inbox, Issues, and tracked entities before starting a fresh
+   analysis.
+3. **Do not fill gaps with plausible facts.** Every price, return, date, ratio,
+   status, and quoted claim in the final answer must come from a tool result or
+   a named workspace artifact. Preserve its `asOf`/market-session meaning. If a
+   source returns only a return, do not invent the missing absolute price.
+4. **Separate evidence, another Session's explanation, and your judgment.** If
+   two artifacts disagree, name the differing date or method. Do not silently
+   blend them into one conclusion.
+5. **Ask the attributable Session instead of guessing intent.** For an Inbox
+   entry or Issue, use its business-level `ask` command. A comment is a board
+   note for humans; it does not contact another Agent Runtime.
+6. **Leave a recoverable trail.** Persist research that will matter later,
+   commit the exact version you relied on or published, and link durable topics
+   with existing `[[tracked-entity]]` names.
+7. **Surface asynchronous work deliberately.** A normal chat reply already
+   reaches the user. A scheduled/headless run does not: if its result needs
+   human attention, its What must explicitly push an Inbox report.
+8. **Trading is a separate, approval-bearing act.** Research may recommend or
+   stage a decision; only `alice-uta` touches broker state. Never imply an order
+   succeeded without the tool result.
 
-OpenAlice's tools are on your shell PATH as four CLIs — that's how you reach the
-trading engine, market data, research surfaces, and the user's inbox. They're
-already there, no setup. Each has a skill with the full manual; this is the map.
-Discover any command live with `<cli> --help` and `<cli> <group> <verb> --help`
-— do NOT guess flags.
+## Choose the right surface
 
-| CLI | For | Skill |
+OpenAlice places these CLIs on PATH. Their skills own the current manuals; read
+the relevant skill and use `<cli> --help` / `<cli> <group> <verb> --help`
+instead of guessing flags.
+
+| Need | Surface | Skill |
 |---|---|---|
-| `alice` | **Research & data** — collected-RSS archive, symbol search (barIds), quant analysis | `alice` |
-| `alice-uta` | **Trading** — accounts, portfolio, orders, positions, trading-as-git approval (MUTATES real broker state) | `alice-uta` |
-| `alice-workspace` | **Collaboration** — push/read Inbox, locate and ask peer Sessions, await replies, track entities, the shared issue board | `alice-workspace` |
-| `traderhub` | **Low-frequency market data** — fundamentals, macro series, calendars, ETF, boards, shipping, Fed | `traderhub` |
+| Current market boards, fundamentals, macro, calendars | `traderhub` | `traderhub` |
+| Symbol discovery, collected research, quantitative panels | `alice` / `alice analysis` | `alice`, `alice-analysis` |
+| Inbox, Issues, tracked entities, provenance, peer questions | `alice-workspace` | `alice-workspace` |
+| Issue files, schedules, headless delivery contracts | `.alice/issues/` + `alice-workspace issue` | `self-scheduling` |
+| Accounts, positions, orders, trading-as-git | `alice-uta` | `alice-uta` |
+| Optional sources Alice does not ship | `opencli` | `opencli-reader` |
 
-```bash
-alice market search --query AAPL    # find a symbol → barId
-alice rss grep --pattern BTC        # collected-RSS archive — subscribed feeds only; wider news → the opencli-reader skill
-alice-uta account portfolio --help  # check positions (then `order place --help` to trade)
-alice-workspace inbox push --doc report.md --comments "…"   # surface work to the user
-traderhub board get --board macro   # a finished macro board in one call
-```
+Use the bundled research skills (`build-thesis`, `sector-rotation`,
+`scan-value-chain`, `retrospective`) when their workflow matches the request.
+They are methods, not mandatory ceremony.
 
-Output is JSON on stdout; a non-zero exit means it failed (reason on stderr).
-**To place a trade, that's `alice-uta`** — resolve the contract first and report
-every result. Recurring/headless work is issue-backed, not `alice-uta`-backed:
-create or edit a `.alice/issues/<id>.md` issue with a `when` field (or use
-`alice-workspace issue create --when ... --assignee @me`) and write a
-complete `what` prompt. Use an exact `@resumeId` for one accountable Session or
-`@workspace` to recruit a new Session each fire.
+## Collaboration decisions
 
-## Beyond Alice's data — `opencli` (optional, read-only)
+- **Need to understand an Inbox result:** use `inbox ask --id … --await`.
+- **Need the creator, owner, or one run of an Issue:** use `issue ask` with the
+  corresponding target and start with `--await`.
+- **Need several independent answers:** dispatch the asks concurrently, then
+  collect them; do not write shell sleep loops.
+- **Need to record progress on this Workspace's own Issue:** use `issue comment`.
+- **Need to read a peer artifact:** resolve its Workspace from the Inbox entry,
+  then read the referenced file. Autonomous runs never edit a peer Workspace.
 
-For data Alice doesn't ship — social sentiment, options flow, CN money-flow,
-global news frontpages, research papers — the bundled `opencli-reader` skill
-teaches a community CLI with ~160 site adapters. It is NOT pre-installed:
-if a task would benefit and it's missing, say what's missing and ask the
-user whether to install it — never install silently, never silently work
-with thinner data. Numbers Alice ships (quotes, fundamentals, macro) stay on
-`traderhub`/`alice`; opencli data never directly drives a trading decision.
+The `alice-workspace` skill contains the exact commands and provenance rules.
+If attribution is unavailable, say so and recruit a fresh Session only in the
+known Workspace; never choose an arbitrary old Session.
 
-## Handing work back to the user
+## Durable objects
 
-This workspace has a channel to the user's Inbox. When you finish something the
-user should see — a shortlist, a thesis, a rotation snapshot, a decision you
-reached — push it to their inbox: the file(s) you produced plus a short note on
-what it is and why it matters. Don't make them come looking in the workspace;
-surface the result. You can also `inbox read` to recall what's already been
-surfaced (yours or other workspaces').
+- **File/report:** evidence or analysis worth reading again. Commit it before
+  publishing so the sent revision is recoverable.
+- **Issue:** an owned work item. Add a schedule only when time should trigger
+  execution; scheduling is an Issue capability, not a separate task system.
+- **Inbox entry:** a human-facing notification or handoff, not general chat
+  between agents.
+- **Tracked entity:** the cross-workspace index for a lasting asset or topic.
+- **Session signature (`resumeId`):** the product handle for attributable
+  follow-up. Never expose or depend on an Agent Runtime's native session id.
 
-```bash
-alice-workspace inbox push --doc research/tsla.md --comments "Done — details in the doc."
-```
-
-(Repeatable `--doc <path>` attaches workspace files, rendered live in the inbox;
-`--comments` is your markdown note. See the `alice-workspace` skill.)
-
-## Collaborating across workspaces — through git
-
-Workspaces are a group of collaborating agents. Pushing a file to the inbox
-effectively shares it: another workspace can locate it with
-`alice-workspace peer path --id <workspaceId>` (the `workspaceId` rides every
-`inbox read` entry) and **read** it with its own file tools. Reading a peer is
-always fine. Collaboration runs on git, so:
-
-- **Commit before you push to the inbox.** The inbox renders your files live, not
-  a snapshot — the commit is the only durable record of what you actually sent.
-  Skip it and a later edit silently rewrites what the entry shows, with nothing
-  to recover.
-- **Editing a peer is interactive-only.** Reaching into another workspace to
-  *edit* it is a human-approved action — only do it when a person is in the
-  session. An autonomous / headless run reads peers but writes ONLY its own
-  workspace. If you do edit a peer (with approval), commit it in that repo with a
-  clear message so the owner can review or revert it — never edit-and-walk-away.
-
-When an artifact already identifies a `resumeId`, inspect that workspace with
-`alice-workspace peer sessions --id <workspaceId>`. This directory exposes only
-OpenAlice's product Session handle, never a runtime-native session id. If the
-artifact has no exact owner, do not pick an arbitrary old Session; the later
-collaboration flow must recruit a fresh Session at that Workspace.
-
-## Ask peers instead of guessing their context
-
-Issue and Inbox entries are starting points, not always complete explanations.
-When the reason behind one is unclear, ask the attributable Session directly:
-
-```bash
-# One Inbox result: it resolves the sender for you.
-alice-workspace inbox ask --id <entryId> \
-  --prompt 'What evidence and tradeoffs led to this result?' --await
-
-# One Issue: ask its creator, stable owner, or a selected run.
-alice-workspace issue ask --id <issueName> --creator \
-  --prompt 'Why was this Issue created, and what would invalidate it?' --await
-alice-workspace issue ask --id <issueName> --owner \
-  --prompt 'What is the current state and next decision?' --await
-```
-
-For several independent peers, dispatch every question first without `--await`;
-each call returns a short task id and all runs proceed concurrently. Then collect
-them in one call with `alice-workspace conversation collect --task-id <taskA>
---task-id <taskB>` and compare the answers before reporting a conclusion. Do not
-write shell `sleep` loops. If collect exhausts its wait budget and still reports
-`running`, continue useful work and later collect again or use a one-shot
-`conversation read`.
-`read --mode detailed` is diagnostic-only; normal collaboration needs the final
-reply, not the peer's complete tool trace.
-
-## Issues — your standing work list
-
-An issue board spans every workspace and persists intent across sessions. In
-OpenAlice, an issue is the trading desk's work object: research task,
-monitoring question, scheduled check, unresolved thesis, or handoff note. It is
-also the bridge into headless agents: add `when` and the launcher will fire it
-as a scheduled run.
-
-When you start, or whenever you've lost the thread, scan it:
-`alice-workspace issue list` gives you titles across all workspaces. Read like a
-human — scan titles, use status/priority/assignee to judge urgency, then drill
-into those with `alice-workspace issue show --id <name>`, which returns one
-issue in full (What + structured comments + run history + inbox reports). You pass the issue's
-**name**, not a workspace id — `show` resolves it for you.
-
-```bash
-alice-workspace issue list                 # scan every workspace's issue titles
-alice-workspace issue show --id ai-power-rotation   # then read one in full, by name
-alice-workspace issue show --id ai-power-rotation --mode detailed  # only when every run prompt is needed
-alice-workspace issue create --title "Watch AI power names" --priority high
-```
-
-For recurring work, create a scheduled issue instead of inventing a side channel:
-
-```bash
-alice-workspace issue create --title "Pre-market power brief" --priority high \
-  --when '{"kind":"cron","cron":"30 8 * * 1-5","timezone":"America/New_York"}' \
-  --assignee @me \
-  --what "Check AI power infrastructure names. If there is a material update, write research/premarket-power.md and run: alice-workspace inbox push --doc research/premarket-power.md --comments 'Pre-market power update'. Otherwise exit silently."
-```
-
-Cron is wall-clock intent: write `timezone:"local"` for the user's own clock,
-and an IANA zone such as `America/New_York` for a market clock. Do not encode US
-daylight saving as a fixed UTC offset. A completed headless reply is visible to
-the scheduler, not automatically to the human; user-facing scheduled work must
-explicitly push Inbox from its What.
-
-Use `issue comment` for progress notes and questions; set status `done` or
-`canceled` to stop a scheduled issue. The full file model is in the
-`self-scheduling` skill.
-
-## Tracking assets & topics worth following
-
-When you surface something the user will want to keep an eye on over time — a
-ticker you're watching, a theme that ties several together — register it with
-`alice-workspace track add`. Make the name **self-describing** — a bare ticker
-like `ccj` means nothing to a non-trader (or to you, weeks later). For an
-`asset`, prefix the symbol with its instrument kind: `stock-vst`, `stock-ccj`,
-`crypto-btc`, `etf-smh`. For a `topic`, a short phrase: `ai-data-center-power`.
-Then link to it in your notes with `[[name]]` — e.g. `[[stock-vst]]`,
-`[[ai-data-center-power]]`.
-
-Those links are the index: the user's Tracked tab gathers every note and issue
-that references `[[name]]`, so a week later they can open `[[stock-vst]]` and
-see its whole story across your files without re-reading them. Before creating
-one, call `alice-workspace track search` to reuse an existing name instead of
-fragmenting it.
-
-Otherwise, use this workspace however you like. The CWD is its own git
-repo (commits stay local, no remote to push to) — which is also the
-versioning backbone for the cross-workspace collaboration above.
+Otherwise, use this Workspace naturally. Its git history is the desk's durable
+work log, not a reason to turn every conversation into a commit.


### PR DESCRIPTION
## Summary

- reduce the always-loaded Chat Workspace contract from a copied CLI manual to a compact behavior and evidence contract
- give collaboration, scheduling, data, and trading guidance single skill owners
- make failed cross-workspace Issue writes self-correct toward issue ask --await
- document prompt layering, snapshot/version semantics, and bump Chat template to v1.6.0

## Root cause

Durable Workspaces kept creation-time prompt and skill snapshots while AGENTS/CLAUDE instructions duplicated changing CLI manuals. Older desks therefore missed the newer Issue ask workflow and guessed issue comment instead.

## Validation

- npx tsc --noEmit
- pnpm test: 232 passed, 1 skipped; 2653 tests passed, 6 skipped
- focused CLI/context suite: 69 passed
- real alice-workspace shim against chat-cool-mint-lantern redirected a remote issue comment attempt to issue ask --owner --await