### PR TITLE
feat: add WebPi beta surface for Pi sessions

### DIFF
--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -608,3 +608,85 @@ describe('POST /:id/sessions/:sid/resume — concurrent coalescing (ANG-120)', (
     expect([a.body, b.body].filter((x) => x.alreadyRunning)).toHaveLength(1);
   });
 });
+
+describe('WebPi surface routes', () => {
+  const TOKEN = 'pi-calm-amber-river';
+
+  function buildWebPi() {
+    const order: string[] = [];
+    const record = {
+      id: TOKEN,
+      resumeId: 'resume-webpi',
+      wsId: 'ws-1',
+      agent: 'pi',
+      name: 'p1',
+      createdAt: '2026-07-12T00:00:00.000Z',
+      lastActiveAt: '2026-07-12T00:00:00.000Z',
+      state: 'running',
+      surface: 'terminal',
+    };
+    const snapshot = {
+      recordId: TOKEN,
+      wsId: 'ws-1',
+      resumeId: 'resume-webpi',
+      pid: 9001,
+      startedAt: 1,
+      phase: 'idle',
+      state: {},
+      messages: [],
+      streamingMessage: null,
+      error: null,
+      stderrTail: '',
+      revision: 1,
+    };
+    const adapter = {
+      id: 'pi',
+      capabilities: { resumeById: true },
+      readAiConfig: vi.fn(async () => ({ baseUrl: 'https://example.test', apiKey: 'test', model: 'model' })),
+      writeAiConfig: vi.fn(async () => undefined),
+      bootstrap: vi.fn(async () => order.push('bootstrap')),
+    };
+    const webPi = {
+      get: vi.fn(() => null),
+      has: vi.fn(() => false),
+      stop: vi.fn(async () => false),
+      prompt: vi.fn(async () => ({ ...snapshot, phase: 'working' })),
+      abort: vi.fn(async () => snapshot),
+    };
+    const svc = {
+      registry: { get: () => ({ id: 'ws-1', dir: '/w', agents: ['pi'] }) },
+      sessionRegistry: {
+        get: () => record,
+        update: vi.fn(async (_wsId: string, _id: string, patch: any) => Object.assign(record, patch)),
+      },
+      resumeRegistry: { get: () => ({ agentSessionId: 'native-pi' }) },
+      adapters: { get: () => adapter },
+      pool: {
+        get: vi.fn(() => ({ pid: 123, startedAt: 1 })),
+        disposeToken: vi.fn(() => { order.push('terminal-stopped'); return true; }),
+      },
+      webPi,
+      startWebPiSession: vi.fn(async () => { order.push('webpi-started'); return snapshot; }),
+      isResumeActive: vi.fn(() => false),
+      config: { launcherRepoRoot: '/repo' },
+    } as unknown as WorkspaceService;
+    return { app: createWorkspaceRoutes(svc), order, svc, webPi };
+  }
+
+  it('hands an existing Pi Session from its PTY to WebPi', async () => {
+    const { app, order, svc } = buildWebPi();
+    const result = await post(app, `/ws-1/sessions/${TOKEN}/webpi/open`);
+    expect(result.status).toBe(200);
+    expect(result.body.snapshot).toMatchObject({ resumeId: 'resume-webpi', phase: 'idle' });
+    expect(order).toEqual(['bootstrap', 'terminal-stopped', 'webpi-started']);
+    expect(svc.startWebPiSession).toHaveBeenCalledOnce();
+  });
+
+  it('passes browser prompts straight to the live Pi RPC host', async () => {
+    const { app, webPi } = buildWebPi();
+    const result = await post(app, `/ws-1/sessions/${TOKEN}/webpi/prompt`, { message: 'hello Pi' });
+    expect(result.status).toBe(200);
+    expect(webPi.prompt).toHaveBeenCalledWith(TOKEN, 'hello Pi');
+    expect(result.body.snapshot.phase).toBe('working');
+  });
+});

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -647,7 +647,7 @@ describe('WebPi surface routes', () => {
       bootstrap: vi.fn(async () => order.push('bootstrap')),
     };
     const webPi = {
-      get: vi.fn(() => null),
+      get: vi.fn(() => snapshot),
       has: vi.fn(() => false),
       stop: vi.fn(async () => false),
       prompt: vi.fn(async () => ({ ...snapshot, phase: 'working' })),
@@ -688,5 +688,12 @@ describe('WebPi surface routes', () => {
     expect(result.status).toBe(200);
     expect(webPi.prompt).toHaveBeenCalledWith(TOKEN, 'hello Pi');
     expect(result.body.snapshot.phase).toBe('working');
+  });
+
+  it('returns a tiny unchanged response when the browser already has the revision', async () => {
+    const { app } = buildWebPi();
+    const result = await get(app, `/ws-1/sessions/${TOKEN}/webpi?revision=1`);
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ unchanged: true, revision: 1 });
   });
 });

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -125,6 +125,7 @@ interface PublicSessionBody {
   readonly createdAt: string;
   readonly lastActiveAt: string;
   readonly state: 'running' | 'paused';
+  readonly surface: 'terminal' | 'webpi';
   readonly resumeId: string;
   readonly pid: number | null;
   readonly startedAt: number | null;
@@ -285,6 +286,7 @@ export function createWorkspaceRoutes(
       createdAt: nowIso,
       lastActiveAt: nowIso,
       state: 'running',
+      surface: 'terminal',
       ...(title !== undefined ? { title } : {}),
       ...(opts.sourceRunId ? { sourceRunId: opts.sourceRunId } : {}),
       ...(resume && resume !== 'last'
@@ -340,7 +342,8 @@ export function createWorkspaceRoutes(
   }
 
   const publicSession = (record: SessionRecord): PublicSessionBody => {
-    const live = svc.pool.get(record.id);
+    const terminal = svc.pool.get(record.id);
+    const browser = svc.webPi?.get(record.id) ?? null;
     return {
       id: record.id,
       wsId: record.wsId,
@@ -348,10 +351,11 @@ export function createWorkspaceRoutes(
       name: record.name,
       createdAt: record.createdAt,
       lastActiveAt: record.lastActiveAt,
-      state: record.state === 'running' && live ? 'running' : 'paused',
+      state: record.state === 'running' && (terminal || browser) ? 'running' : 'paused',
+      surface: browser ? 'webpi' : (record.surface ?? 'terminal'),
       resumeId: record.resumeId,
-      pid: live?.pid ?? null,
-      startedAt: live?.startedAt ?? null,
+      pid: terminal?.pid ?? browser?.pid ?? null,
+      startedAt: terminal?.startedAt ?? browser?.startedAt ?? null,
       title: record.title ?? null,
       sourceRunId: record.sourceRunId ?? null,
     };
@@ -1021,7 +1025,9 @@ export function createWorkspaceRoutes(
           launcherLogger.warn('scrollback.dump_failed', { id, token, err });
         }
       }
-      const wasRunning = svc.pool.disposeToken(token, action === 'pause' ? 'paused' : 'tab stop');
+      const wasTerminalRunning = svc.pool.disposeToken(token, action === 'pause' ? 'paused' : 'tab stop');
+      const wasWebPiRunning = await svc.webPi?.stop(token, action === 'pause' ? 'paused' : 'tab stop') ?? false;
+      const wasRunning = wasTerminalRunning || wasWebPiRunning;
       if (record) {
         const patch: Partial<SessionRecord> = {
           state: 'paused',
@@ -1091,6 +1097,9 @@ export function createWorkspaceRoutes(
       if (svc.pool.get(token)) {
         return c.json({ ok: true, alreadyRunning: true });
       }
+      // Choosing the terminal surface is an explicit handoff. Never leave Pi's
+      // RPC host and PTY alive against the same native session file.
+      if (svc.webPi?.has(token)) await svc.webPi.stop(token, 'switch to terminal');
       const meta = svc.registry.get(id);
       if (!meta) return c.json({ error: 'workspace_not_found' }, 404);
       const adapter = svc.adapters.get(record.agent);
@@ -1196,7 +1205,7 @@ export function createWorkspaceRoutes(
           delete (record as { scrollbackFile?: string }).scrollbackFile;
         }
         await svc.sessionRegistry
-          .update(id, token, { state: 'running', lastActiveAt: new Date().toISOString() })
+          .update(id, token, { state: 'running', surface: 'terminal', lastActiveAt: new Date().toISOString() })
           .catch((err) =>
             launcherLogger.warn('session_registry.resume_update_failed', { id, token, err }),
           );
@@ -1226,6 +1235,88 @@ export function createWorkspaceRoutes(
       } finally {
         if (claimedResume) svc.releaseResume?.(record.resumeId);
       }
+    }
+  });
+
+  // WebPi is a presentation of an existing Pi Session, not another runtime.
+  // The four routes below expose Pi's own RPC state/messages without adapting
+  // them into OpenAlice message blocks.
+  app.post('/:id/sessions/:sid/webpi/open', async (c) => {
+    const id = c.req.param('id');
+    const token = c.req.param('sid');
+    if (!validId(id) || !validId(token)) return c.json({ error: 'not_found' }, 404);
+    const meta = svc.registry.get(id);
+    const record = svc.sessionRegistry.get(id, token);
+    if (!meta || !record) return c.json({ error: 'not_found' }, 404);
+    if (record.agent !== 'pi') {
+      return c.json({ error: 'unsupported_surface', message: 'WebPi is available only for Pi Sessions' }, 409);
+    }
+    if (svc.isResumeActive(record.resumeId)) {
+      return c.json({ error: 'resume_busy', message: 'this conversation has a running headless turn' }, 409);
+    }
+    const adapter = svc.adapters.get('pi');
+    if (!adapter) return c.json({ error: 'unknown_agent' }, 500);
+    try {
+      await ensureAgentCredentialReady({ meta, agentId: 'pi', adapter, logger: launcherLogger });
+      if (adapter.bootstrap) {
+        await adapter.bootstrap({ wsId: id, cwd: meta.dir, launcherRepoRoot: svc.config.launcherRepoRoot });
+      }
+      if (svc.pool.get(token)) svc.pool.disposeToken(token, 'switch to WebPi');
+      const snapshot = await svc.startWebPiSession(meta, record);
+      return c.json({ ok: true, snapshot, session: publicSession(record) });
+    } catch (err) {
+      await svc.sessionRegistry.update(id, token, {
+        state: 'paused',
+        surface: 'webpi',
+        lastActiveAt: new Date().toISOString(),
+      }).catch(() => undefined);
+      if (err instanceof AgentCredentialError) return c.json(err.toBody(), 400);
+      launcherLogger.error('webpi.open_failed', { id, token, err });
+      return c.json({ error: 'webpi_open_failed', message: (err as Error).message }, 500);
+    }
+  });
+
+  app.get('/:id/sessions/:sid/webpi', (c) => {
+    const id = c.req.param('id');
+    const token = c.req.param('sid');
+    if (!validId(id) || !validId(token)) return c.json({ error: 'not_found' }, 404);
+    const record = svc.sessionRegistry.get(id, token);
+    if (!record) return c.json({ error: 'not_found' }, 404);
+    const snapshot = svc.webPi.get(token);
+    if (!snapshot) return c.json({ error: 'webpi_not_running' }, 409);
+    return c.json({ snapshot });
+  });
+
+  app.post('/:id/sessions/:sid/webpi/prompt', async (c) => {
+    const id = c.req.param('id');
+    const token = c.req.param('sid');
+    if (!validId(id) || !validId(token)) return c.json({ error: 'not_found' }, 404);
+    const record = svc.sessionRegistry.get(id, token);
+    if (!record || record.agent !== 'pi') return c.json({ error: 'not_found' }, 404);
+    const body = await safeJson(c).catch(() => null);
+    const message = body && typeof body === 'object' ? (body as Record<string, unknown>)['message'] : null;
+    if (typeof message !== 'string' || !message.trim()) {
+      return c.json({ error: 'bad_request', message: 'message is required' }, 400);
+    }
+    try {
+      const snapshot = await svc.webPi.prompt(token, message);
+      await svc.sessionRegistry.update(id, token, { lastActiveAt: new Date().toISOString() });
+      return c.json({ ok: true, snapshot });
+    } catch (err) {
+      return c.json({ error: 'webpi_prompt_failed', message: (err as Error).message }, 409);
+    }
+  });
+
+  app.post('/:id/sessions/:sid/webpi/abort', async (c) => {
+    const id = c.req.param('id');
+    const token = c.req.param('sid');
+    if (!validId(id) || !validId(token)) return c.json({ error: 'not_found' }, 404);
+    const record = svc.sessionRegistry.get(id, token);
+    if (!record || record.agent !== 'pi') return c.json({ error: 'not_found' }, 404);
+    try {
+      return c.json({ ok: true, snapshot: await svc.webPi.abort(token) });
+    } catch (err) {
+      return c.json({ error: 'webpi_abort_failed', message: (err as Error).message }, 409);
     }
   });
 
@@ -1548,7 +1639,9 @@ export function createWorkspaceRoutes(
     }
     const record = svc.sessionRegistry.get(id, token);
     if (!record) return c.json({ error: 'not_found' }, 404);
-    const wasRunning = svc.pool.disposeToken(token, 'session deleted');
+    const wasTerminalRunning = svc.pool.disposeToken(token, 'session deleted');
+    const wasWebPiRunning = await svc.webPi?.stop(token, 'session deleted') ?? false;
+    const wasRunning = wasTerminalRunning || wasWebPiRunning;
     if (record.scrollbackFile) {
       await svc.scrollbackStore.remove(record.scrollbackFile);
     }

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -1284,6 +1284,10 @@ export function createWorkspaceRoutes(
     if (!record) return c.json({ error: 'not_found' }, 404);
     const snapshot = svc.webPi.get(token);
     if (!snapshot) return c.json({ error: 'webpi_not_running' }, 409);
+    const knownRevision = Number.parseInt(c.req.query('revision') ?? '', 10);
+    if (Number.isSafeInteger(knownRevision) && knownRevision === snapshot.revision) {
+      return c.json({ unchanged: true, revision: snapshot.revision });
+    }
     return c.json({ snapshot });
   });
 

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -387,6 +387,25 @@ describe('piAdapter AI-config', () => {
       .toEqual(['pi', '--session-id', 'sess-1']);
   });
 
+  it('composeWebCommand is opt-in RPC and does not alter the TUI command', () => {
+    const spawn = { cwd: dir, env: mcpEnv, resume: { sessionId: 'sess-web' } } as const;
+    expect(piAdapter.composeCommand([], spawn)).toEqual(['pi', '--session-id', 'sess-web']);
+    expect(piAdapter.composeWebCommand?.([], spawn)).toEqual([
+      'pi', '--session-id', 'sess-web', '--mode', 'rpc',
+    ]);
+  });
+
+  it('composeWebCommand uses the packaged managed Pi trust flag only on the RPC surface', () => {
+    const env = { ...mcpEnv, OPENALICE_MANAGED_PI_PATH: '/app/vendor/pi/pi' };
+    const spawn = { cwd: dir, env, resume: { sessionId: 'sess-web' } } as const;
+    expect(piAdapter.composeCommand([], spawn)).toEqual([
+      '/app/vendor/pi/pi', '--session-id', 'sess-web',
+    ]);
+    expect(piAdapter.composeWebCommand?.([], spawn)).toEqual([
+      '/app/vendor/pi/pi', '--approve', '--session-id', 'sess-web', '--mode', 'rpc',
+    ]);
+  });
+
   it('composeCommand uses managed Pi binary path when the spawn env provides one', () => {
     const env = { ...mcpEnv, OPENALICE_MANAGED_PI_PATH: '/app/vendor/pi/pi' };
     expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env })).toEqual(['/app/vendor/pi/pi']);

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -153,6 +153,25 @@ export const piAdapter: CliAdapter = {
     return [...head, '--session-id', ctx.resume.sessionId, ...seed];
   },
 
+  // WebPi is a second VIEW over the same Pi session, not another runtime.
+  // RPC stays completely separate from the TUI argv above: selecting WebPi
+  // cannot change ordinary Pi startup, trust prompts, input handling, or PTY
+  // behavior. It is always by-id so switching surfaces reopens the exact
+  // conversation that the OpenAlice resume registry already owns.
+  composeWebCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
+    if (!ctx.resume || ctx.resume === 'last') {
+      throw new Error('WebPi requires a concrete Pi session id');
+    }
+    return [
+      ...piCommandHead(ctx.env),
+      ...piHeadlessApproveArgs(ctx.env),
+      '--session-id',
+      ctx.resume.sessionId,
+      '--mode',
+      'rpc',
+    ];
+  },
+
   // Headless: `pi -p <prompt>` is non-interactive and exits at the turn
   // boundary, so there is nobody to answer Pi 0.79+'s project-trust prompt.
   // The packaged app explicitly approves its pinned managed Pi; contributor

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -167,6 +167,16 @@ export interface CliAdapter {
   composeCommand(base: readonly string[], ctx: SpawnContext): readonly string[];
 
   /**
+   * Optional long-lived structured interactive surface. Unlike headless mode,
+   * this process remains alive and accepts multiple prompts over stdin/stdout.
+   * WebPi is the first consumer: it opens the SAME native Pi session through
+   * Pi's documented RPC mode while the ordinary terminal keeps using
+   * `composeCommand`. Keeping this opt-in prevents any other runtime's launch
+   * path from changing merely because WebPi exists.
+   */
+  composeWebCommand?(base: readonly string[], ctx: SpawnContext): readonly string[];
+
+  /**
    * One-shot HEADLESS argv for an automation task — like `composeCommand`, but
    * the process consumes `prompt` and EXITS at the turn boundary (vs the
    * interactive TUI that waits for input). The adapter places `prompt` at the

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -144,6 +144,7 @@ import { resolveLaunchCommand } from './win-command.js';
 import { WorkspaceCreator } from './workspace-creator.js';
 import { WorkspaceCatalog } from './workspace-catalog.js';
 import { WorkspaceLifecycleManager } from './workspace-lifecycle.js';
+import { WebPiSessionHost, type WebPiSnapshot } from './webpi-session-host.js';
 import { WorkspaceRegistry, type WorkspaceMeta } from './workspace-registry.js';
 
 /**
@@ -175,12 +176,15 @@ export interface WorkspaceService {
   readonly adapters: AdapterRegistry;
   readonly creator: WorkspaceCreator;
   readonly pool: SessionPool;
+  readonly webPi: WebPiSessionHost;
   readonly transcriptWatcher: TranscriptWatcher;
   /** Resolve the preferred/recent durable Chat Workspace, creating one starter when absent. */
   resolveOrCreateChatWorkspace(preferredWorkspaceId?: string | null): Promise<ChatWorkspaceResolution>;
   /** Resolve the configured Workspace runtime, then fall back to its first enabled runtime. */
   resolveDefaultAgentId(meta: WorkspaceMeta): Promise<string | undefined>;
   resolveAdapter(meta: WorkspaceMeta, agentId?: string): CliAdapter;
+  /** Open the same persisted Pi Session through Pi RPC instead of its PTY. */
+  startWebPiSession(meta: WorkspaceMeta, record: SessionRecord): Promise<WebPiSnapshot>;
   publicMeta(w: WorkspaceMeta): Promise<unknown>;
   /**
    * Probe the host PATH for each registered adapter's CLI binary. Keyed by
@@ -1540,6 +1544,66 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     transcriptWatcher,
   );
 
+  const webPi = new WebPiSessionHost(
+    launcherLogger.child({ scope: 'webpi-host' }),
+    {
+      onExit: (recordId, reason) => {
+        // Intentional handoffs are followed by an explicit caller-owned state
+        // update (paused, terminal-running, or deleted). Letting this async
+        // callback also write `paused` would race a WebPi -> TUI switch.
+        if (reason.intentional) return;
+        const record = sessionRegistry.findById(recordId);
+        if (!record) return;
+        void sessionRegistry.update(record.wsId, record.id, {
+          state: 'paused',
+          lastActiveAt: new Date().toISOString(),
+        }).catch((err) => launcherLogger.warn('webpi.pause_update_failed', { recordId, err }));
+      },
+    },
+  );
+
+  const startWebPiSession = async (
+    meta: WorkspaceMeta,
+    record: SessionRecord,
+  ): Promise<WebPiSnapshot> => {
+    if (record.agent !== 'pi') throw new Error('WebPi is available only for Pi Sessions');
+    const adapter = adapters.get('pi');
+    if (!adapter?.composeWebCommand) throw new Error('installed Pi adapter has no WebPi surface');
+    const nativeSessionId = resumeRegistry.get(record.resumeId)?.agentSessionId
+      ?? record.resumeHint?.value;
+    if (!nativeSessionId) throw new Error('Pi Session has no resumable native session id');
+    const resume = { sessionId: nativeSessionId } as const;
+    const { cwd, env } = composeSpawnInputs(meta, adapter, resume, undefined, {
+      AQ_SESSION_ID: record.id,
+      OPENALICE_RESUME_ID: record.resumeId,
+      OPENALICE_SIGNATURE: `@${record.resumeId}`,
+    });
+    const command = adapter.composeWebCommand(config.command, { cwd, env, resume });
+    launcherLogger.event('path.trace', {
+      where: 'webpi.spawn',
+      wsId: meta.id,
+      recordId: record.id,
+      resumeId: record.resumeId,
+      nativeSessionId,
+      spawnCwd: cwd,
+      composedCommand: command,
+    });
+    const snapshot = await webPi.start({
+      recordId: record.id,
+      wsId: record.wsId,
+      resumeId: record.resumeId,
+      command,
+      cwd,
+      env,
+    });
+    await sessionRegistry.update(record.wsId, record.id, {
+      state: 'running',
+      surface: 'webpi',
+      lastActiveAt: new Date().toISOString(),
+    });
+    return snapshot;
+  };
+
   const lifecycle = new WorkspaceLifecycleManager({
     launcherRoot: config.launcherRoot,
     registry,
@@ -1549,6 +1613,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     scrollbackStore,
     headlessTasks,
     pool,
+    webPi,
     isWorkspaceHeadlessActive: (id) => (activeHeadlessByWorkspace.get(id) ?? 0) > 0,
     logger: launcherLogger.child({ scope: 'workspace-lifecycle' }),
   });
@@ -1576,11 +1641,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
 
   const publicMeta = async (w: WorkspaceMeta): Promise<unknown> => {
     const metadata = await readWorkspaceMetadata(w.dir);
-    const live = pool.liveSessionsFor(w.id);
     await sessionRegistry.ensureLoaded(w.id).catch(() => undefined);
-    const liveById = new Map(live.map((l) => [l.id, l]));
     const sessions = sessionRegistry.listFor(w.id).map((r) => {
-      const liveEntry = liveById.get(r.id);
+      const terminal = pool.get(r.id);
+      const browser = webPi.get(r.id);
       return {
         id: r.id,
         wsId: r.wsId,
@@ -1588,10 +1652,11 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         name: r.name,
         createdAt: r.createdAt,
         lastActiveAt: r.lastActiveAt,
-        state: r.state === 'running' && liveEntry ? 'running' : 'paused',
+        state: r.state === 'running' && (terminal || browser) ? 'running' : 'paused',
+        surface: browser ? 'webpi' : (r.surface ?? 'terminal'),
         resumeId: r.resumeId,
-        pid: liveEntry?.pid ?? null,
-        startedAt: liveEntry?.startedAt ?? null,
+        pid: terminal?.pid ?? browser?.pid ?? null,
+        startedAt: terminal?.startedAt ?? browser?.startedAt ?? null,
         title: r.title ?? null,
         sourceRunId: r.sourceRunId ?? null,
       };
@@ -1646,6 +1711,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     launcherLogger.info('workspaces.dispose', { reason, activeSessions: pool.size() });
     scheduleScanner.stop();
     pool.disposeAll('plugin shutdown');
+    await webPi.stopAll('plugin shutdown');
     transcriptWatcher.disposeAll();
   };
 
@@ -1660,10 +1726,12 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     adapters,
     creator,
     pool,
+    webPi,
     transcriptWatcher,
     resolveOrCreateChatWorkspace: resolveOrCreateChatWorkspaceMethod,
     resolveDefaultAgentId,
     resolveAdapter,
+    startWebPiSession,
     publicMeta,
     detectAgents,
     getAgentRuntimeReadiness: getAgentRuntimeReadinessMethod,

--- a/src/workspaces/session-registry.ts
+++ b/src/workspaces/session-registry.ts
@@ -33,6 +33,8 @@ export interface SessionRecord {
   readonly createdAt: string;
   lastActiveAt: string;
   state: 'running' | 'paused';
+  /** Preferred/live presentation for this Session. The runtime remains Pi. */
+  surface?: 'terminal' | 'webpi';
   resumeHint?: { kind: 'agent-session-id'; value: string };
   scrollbackFile?: string;
   /**
@@ -324,6 +326,9 @@ function validateFile(value: unknown): SessionRecord[] {
       createdAt: r['createdAt'],
       lastActiveAt: r['lastActiveAt'],
       state: r['state'],
+      ...(r['surface'] === 'terminal' || r['surface'] === 'webpi'
+        ? { surface: r['surface'] }
+        : {}),
       // Carry the session title (the captured first message) across reloads —
       // it's written to disk by `flush`, so it must be read back here too, or
       // every server restart / registry reload reverts the row to the `c1` name.

--- a/src/workspaces/webpi-session-host.spec.ts
+++ b/src/workspaces/webpi-session-host.spec.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Logger } from './logger.js'
+import { WebPiSessionHost, type StartWebPiInput } from './webpi-session-host.js'
+
+class FakeRpcProcess extends EventEmitter {
+  readonly pid = 4242
+  readonly stdin = new PassThrough()
+  readonly stdout = new PassThrough()
+  readonly stderr = new PassThrough()
+  private messages: unknown[] = []
+
+  constructor() {
+    super()
+    this.stdin.setEncoding('utf8')
+    let buffer = ''
+    this.stdin.on('data', (chunk: string) => {
+      buffer += chunk
+      let nl = buffer.indexOf('\n')
+      while (nl >= 0) {
+        const line = buffer.slice(0, nl)
+        buffer = buffer.slice(nl + 1)
+        if (line) this.command(JSON.parse(line) as Record<string, unknown>)
+        nl = buffer.indexOf('\n')
+      }
+    })
+    queueMicrotask(() => this.emit('spawn'))
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    queueMicrotask(() => this.emit('exit', 0, signal))
+    return true
+  }
+
+  private command(command: Record<string, unknown>): void {
+    const id = command['id']
+    const type = command['type']
+    if (type === 'get_state') {
+      this.line({ type: 'response', id, command: type, success: true, data: {
+        sessionId: 'native-pi', thinkingLevel: 'medium', isStreaming: false,
+        isCompacting: false, steeringMode: 'all', followUpMode: 'one-at-a-time',
+        autoCompactionEnabled: true, messageCount: this.messages.length, pendingMessageCount: 0,
+      } })
+      return
+    }
+    if (type === 'get_messages') {
+      this.line({ type: 'response', id, command: type, success: true, data: { messages: this.messages } })
+      return
+    }
+    if (type === 'prompt') {
+      const user = { role: 'user', content: command['message'] }
+      const partialA = { role: 'assistant', content: [{ type: 'text', text: 'hel' }] }
+      const partialB = { role: 'assistant', content: [{ type: 'text', text: 'hello' }] }
+      const assistant = partialB
+      this.messages = [...this.messages, user, assistant]
+      this.line({ type: 'response', id, command: type, success: true })
+      this.line({ type: 'agent_start' })
+      this.line({ type: 'message_update', message: partialA })
+      this.line({ type: 'message_update', message: partialB })
+      this.line({ type: 'message_end', message: assistant })
+      this.line({ type: 'agent_settled' })
+      return
+    }
+    if (type === 'abort') {
+      this.line({ type: 'response', id, command: type, success: true })
+    }
+  }
+
+  private line(value: unknown): void {
+    this.stdout.write(`${JSON.stringify(value)}\n`)
+  }
+}
+
+const logger = {
+  child: () => logger,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger
+
+const input: StartWebPiInput = {
+  recordId: 'pi-record',
+  wsId: 'chat-ws',
+  resumeId: 'resume-pi',
+  command: ['pi', '--session-id', 'native-pi', '--mode', 'rpc'],
+  cwd: '/tmp/workspace',
+  env: {},
+}
+
+describe('WebPiSessionHost', () => {
+  it('opens one RPC view and exposes Pi messages without accumulating update frames', async () => {
+    const host = new WebPiSessionHost(logger, {}, () => new FakeRpcProcess() as never)
+    const started = await host.start(input)
+    expect(started.phase).toBe('idle')
+    expect(started.messages).toEqual([])
+
+    await host.prompt(input.recordId, 'hi')
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    const snapshot = host.get(input.recordId)
+    expect(snapshot?.phase).toBe('idle')
+    expect(snapshot?.messages).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    ])
+    expect(snapshot?.streamingMessage).toBeNull()
+  })
+
+  it('deduplicates repeated opens and stops intentionally', async () => {
+    let spawns = 0
+    const onExit = vi.fn()
+    const host = new WebPiSessionHost(logger, { onExit }, () => {
+      spawns += 1
+      return new FakeRpcProcess() as never
+    })
+    await host.start(input)
+    await host.start(input)
+    expect(spawns).toBe(1)
+    expect(await host.stop(input.recordId, 'switch to TUI')).toBe(true)
+    expect(host.has(input.recordId)).toBe(false)
+    expect(onExit).toHaveBeenCalledWith(input.recordId, expect.objectContaining({ intentional: true }))
+  })
+})
+

--- a/src/workspaces/webpi-session-host.ts
+++ b/src/workspaces/webpi-session-host.ts
@@ -1,0 +1,398 @@
+/**
+ * WebPi — Pi's documented RPC mode supervised as a second interactive surface.
+ *
+ * This deliberately does NOT translate Pi messages into an OpenAlice message
+ * model. The browser receives Pi's own AgentMessage objects plus the current
+ * cumulative streaming message. Pi's JSONL session remains the only durable
+ * conversation store; this host owns only one live RPC process per record.
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { StringDecoder } from 'node:string_decoder'
+
+import type { Logger } from './logger.js'
+import { resolveLaunchCommand } from './win-command.js'
+
+const REQUEST_TIMEOUT_MS = 15_000
+const STDERR_MAX_CHARS = 64 * 1024
+
+type JsonObject = Record<string, unknown>
+
+interface RpcProcess {
+  readonly pid?: number
+  readonly stdin: ChildProcessWithoutNullStreams['stdin']
+  readonly stdout: ChildProcessWithoutNullStreams['stdout']
+  readonly stderr: ChildProcessWithoutNullStreams['stderr']
+  once(event: 'spawn', listener: () => void): this
+  once(event: 'error', listener: (error: Error) => void): this
+  once(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this
+  on(event: 'error', listener: (error: Error) => void): this
+  kill(signal?: NodeJS.Signals): boolean
+}
+
+export interface WebPiSnapshot {
+  readonly recordId: string
+  readonly wsId: string
+  readonly resumeId: string
+  readonly pid: number | null
+  readonly startedAt: number
+  readonly phase: 'starting' | 'idle' | 'working' | 'compacting' | 'retrying' | 'stopped' | 'failed'
+  readonly state: JsonObject | null
+  readonly messages: readonly unknown[]
+  /** Pi's current cumulative assistant message; replaced, never accumulated. */
+  readonly streamingMessage: unknown | null
+  readonly error: string | null
+  readonly stderrTail: string
+  readonly revision: number
+}
+
+export interface StartWebPiInput {
+  readonly recordId: string
+  readonly wsId: string
+  readonly resumeId: string
+  readonly command: readonly string[]
+  readonly cwd: string
+  readonly env: Readonly<Record<string, string>>
+}
+
+interface PendingRequest {
+  readonly command: string
+  readonly resolve: (response: JsonObject) => void
+  readonly reject: (error: Error) => void
+  readonly timer: ReturnType<typeof setTimeout>
+}
+
+interface HostCallbacks {
+  readonly onExit?: (recordId: string, reason: { code: number | null; signal: NodeJS.Signals | null; intentional: boolean }) => void
+}
+
+type SpawnProcess = (input: StartWebPiInput) => RpcProcess
+
+export class WebPiSessionHost {
+  private readonly sessions = new Map<string, LiveWebPiSession>()
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly callbacks: HostCallbacks = {},
+    private readonly spawnProcess: SpawnProcess = defaultSpawnProcess,
+  ) {}
+
+  has(recordId: string): boolean {
+    return this.sessions.has(recordId)
+  }
+
+  get(recordId: string): WebPiSnapshot | null {
+    return this.sessions.get(recordId)?.snapshot() ?? null
+  }
+
+  async start(input: StartWebPiInput): Promise<WebPiSnapshot> {
+    const existing = this.sessions.get(input.recordId)
+    if (existing) return existing.snapshot()
+    const session = new LiveWebPiSession(
+      input,
+      this.spawnProcess(input),
+      this.logger.child({ scope: 'webpi', wsId: input.wsId, recordId: input.recordId }),
+      (reason) => {
+        if (this.sessions.get(input.recordId) === session) this.sessions.delete(input.recordId)
+        this.callbacks.onExit?.(input.recordId, reason)
+      },
+    )
+    this.sessions.set(input.recordId, session)
+    try {
+      await session.start()
+      return session.snapshot()
+    } catch (error) {
+      this.sessions.delete(input.recordId)
+      await session.stop('startup failed').catch(() => undefined)
+      throw error
+    }
+  }
+
+  async prompt(recordId: string, message: string): Promise<WebPiSnapshot> {
+    const session = this.require(recordId)
+    await session.prompt(message)
+    return session.snapshot()
+  }
+
+  async abort(recordId: string): Promise<WebPiSnapshot> {
+    const session = this.require(recordId)
+    await session.abort()
+    return session.snapshot()
+  }
+
+  async stop(recordId: string, reason = 'stopped'): Promise<boolean> {
+    const session = this.sessions.get(recordId)
+    if (!session) return false
+    this.sessions.delete(recordId)
+    await session.stop(reason)
+    return true
+  }
+
+  async stopAll(reason = 'host disposed'): Promise<void> {
+    const sessions = Array.from(this.sessions.values())
+    this.sessions.clear()
+    await Promise.allSettled(sessions.map((session) => session.stop(reason)))
+  }
+
+  private require(recordId: string): LiveWebPiSession {
+    const session = this.sessions.get(recordId)
+    if (!session) throw new Error(`WebPi session is not running: ${recordId}`)
+    return session
+  }
+}
+
+class LiveWebPiSession {
+  private readonly pending = new Map<string, PendingRequest>()
+  private requestSeq = 0
+  private decoder = new StringDecoder('utf8')
+  private stdoutBuffer = ''
+  private stderrTail = ''
+  private phase: WebPiSnapshot['phase'] = 'starting'
+  private state: JsonObject | null = null
+  private messages: readonly unknown[] = []
+  private streamingMessage: unknown | null = null
+  private error: string | null = null
+  private revision = 0
+  private intentionalStop = false
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null
+  private exited = false
+  private readonly startedAt = Date.now()
+
+  constructor(
+    private readonly input: StartWebPiInput,
+    private readonly child: RpcProcess,
+    private readonly logger: Logger,
+    private readonly onExit: (reason: { code: number | null; signal: NodeJS.Signals | null; intentional: boolean }) => void,
+  ) {}
+
+  async start(): Promise<void> {
+    this.child.stdout.on('data', (chunk: Buffer) => this.onStdout(chunk))
+    this.child.stderr.on('data', (chunk: Buffer) => this.onStderr(chunk))
+    this.child.on('error', (error) => this.fail(error))
+    this.child.once('exit', (code, signal) => this.handleExit(code, signal))
+    await new Promise<void>((resolve, reject) => {
+      this.child.once('spawn', resolve)
+      this.child.once('error', reject)
+    })
+    this.logger.info('webpi.started', { pid: this.child.pid ?? null, command: this.input.command })
+    await this.refresh()
+    this.phase = this.state?.['isStreaming'] === true ? 'working' : 'idle'
+    this.bump()
+  }
+
+  snapshot(): WebPiSnapshot {
+    return {
+      recordId: this.input.recordId,
+      wsId: this.input.wsId,
+      resumeId: this.input.resumeId,
+      pid: this.exited ? null : this.child.pid ?? null,
+      startedAt: this.startedAt,
+      phase: this.phase,
+      state: this.state,
+      messages: this.messages,
+      streamingMessage: this.streamingMessage,
+      error: this.error,
+      stderrTail: this.stderrTail,
+      revision: this.revision,
+    }
+  }
+
+  async prompt(message: string): Promise<void> {
+    const trimmed = message.trim()
+    if (!trimmed) throw new Error('WebPi prompt cannot be empty')
+    if (trimmed.length > 16_000) throw new Error('WebPi prompt exceeds 16000 characters')
+    this.phase = 'working'
+    this.error = null
+    this.bump()
+    await this.request('prompt', { message: trimmed })
+    this.scheduleRefresh(50)
+  }
+
+  async abort(): Promise<void> {
+    await this.request('abort')
+    this.scheduleRefresh(0)
+  }
+
+  async stop(reason: string): Promise<void> {
+    if (this.exited) return
+    this.intentionalStop = true
+    this.logger.info('webpi.stopping', { reason })
+    this.child.stdin.end()
+    this.child.kill('SIGTERM')
+    await Promise.race([
+      new Promise<void>((resolve) => this.child.once('exit', () => resolve())),
+      new Promise<void>((resolve) => setTimeout(resolve, 2_000)),
+    ])
+    if (!this.exited) this.child.kill('SIGKILL')
+  }
+
+  private async refresh(): Promise<void> {
+    const [stateResponse, messageResponse] = await Promise.all([
+      this.request('get_state'),
+      this.request('get_messages'),
+    ])
+    const nextState = stateResponse['data']
+    if (isObject(nextState)) this.state = nextState
+    const data = messageResponse['data']
+    if (isObject(data) && Array.isArray(data['messages'])) this.messages = data['messages']
+    this.bump()
+  }
+
+  private scheduleRefresh(delayMs: number): void {
+    if (this.refreshTimer) clearTimeout(this.refreshTimer)
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = null
+      void this.refresh().catch((error) => this.fail(error))
+    }, delayMs)
+  }
+
+  private request(command: string, payload: JsonObject = {}): Promise<JsonObject> {
+    if (this.exited) return Promise.reject(new Error('WebPi process exited'))
+    const id = `webpi-${++this.requestSeq}`
+    return new Promise<JsonObject>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`WebPi RPC ${command} timed out`))
+      }, REQUEST_TIMEOUT_MS)
+      this.pending.set(id, { command, resolve, reject, timer })
+      const line = `${JSON.stringify({ id, type: command, ...payload })}\n`
+      this.child.stdin.write(line, (error) => {
+        if (!error) return
+        const pending = this.pending.get(id)
+        if (!pending) return
+        clearTimeout(pending.timer)
+        this.pending.delete(id)
+        pending.reject(error)
+      })
+    })
+  }
+
+  private onStdout(chunk: Buffer): void {
+    this.stdoutBuffer += this.decoder.write(chunk)
+    let newline = this.stdoutBuffer.indexOf('\n')
+    while (newline >= 0) {
+      const line = this.stdoutBuffer.slice(0, newline)
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1)
+      this.handleLine(line)
+      newline = this.stdoutBuffer.indexOf('\n')
+    }
+  }
+
+  private handleLine(raw: string): void {
+    const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw
+    if (!line) return
+    let event: JsonObject
+    try {
+      const parsed: unknown = JSON.parse(line)
+      if (!isObject(parsed)) return
+      event = parsed
+    } catch (error) {
+      this.logger.warn('webpi.invalid_json', { error, line: line.slice(0, 500) })
+      return
+    }
+    if (event['type'] === 'response' && typeof event['id'] === 'string') {
+      const pending = this.pending.get(event['id'])
+      if (!pending) return
+      clearTimeout(pending.timer)
+      this.pending.delete(event['id'])
+      if (event['success'] === false) {
+        pending.reject(new Error(typeof event['error'] === 'string' ? event['error'] : `WebPi RPC ${pending.command} failed`))
+      } else {
+        pending.resolve(event)
+      }
+      return
+    }
+    this.handleEvent(event)
+  }
+
+  private handleEvent(event: JsonObject): void {
+    switch (event['type']) {
+      case 'agent_start':
+      case 'turn_start':
+        this.phase = 'working'
+        break
+      case 'message_update':
+        this.streamingMessage = event['message'] ?? null
+        break
+      case 'message_end':
+      case 'tool_execution_end':
+      case 'queue_update':
+        this.scheduleRefresh(30)
+        break
+      case 'agent_settled':
+        this.phase = 'idle'
+        this.streamingMessage = null
+        this.scheduleRefresh(0)
+        break
+      case 'compaction_start':
+        this.phase = 'compacting'
+        break
+      case 'compaction_end':
+        this.phase = 'working'
+        this.scheduleRefresh(0)
+        break
+      case 'auto_retry_start':
+        this.phase = 'retrying'
+        break
+      case 'auto_retry_end':
+        this.phase = 'working'
+        break
+      case 'extension_error':
+        this.error = typeof event['error'] === 'string' ? event['error'] : 'Pi extension failed'
+        break
+      default:
+        break
+    }
+    this.bump()
+  }
+
+  private onStderr(chunk: Buffer): void {
+    this.stderrTail = `${this.stderrTail}${chunk.toString('utf8')}`.slice(-STDERR_MAX_CHARS)
+    this.bump()
+  }
+
+  private fail(error: Error): void {
+    this.error = error.message
+    this.phase = 'failed'
+    this.bump()
+    this.logger.error('webpi.failed', { error })
+  }
+
+  private handleExit(code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.exited) return
+    this.exited = true
+    if (this.refreshTimer) clearTimeout(this.refreshTimer)
+    this.refreshTimer = null
+    this.phase = this.intentionalStop ? 'stopped' : 'failed'
+    if (!this.intentionalStop && !this.error) {
+      this.error = `Pi RPC exited (code=${String(code)}, signal=${String(signal)})`
+    }
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error(this.error ?? 'WebPi stopped'))
+    }
+    this.pending.clear()
+    this.bump()
+    this.logger.info('webpi.exited', { code, signal, intentional: this.intentionalStop })
+    this.onExit({ code, signal, intentional: this.intentionalStop })
+  }
+
+  private bump(): void {
+    this.revision += 1
+  }
+}
+
+function defaultSpawnProcess(input: StartWebPiInput): RpcProcess {
+  const resolved = resolveLaunchCommand(input.command, { env: input.env })
+  const [file, ...args] = resolved.argv
+  if (!file) throw new Error('WebPi command is empty')
+  return spawn(file, args, {
+    cwd: input.cwd,
+    env: { ...input.env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/workspaces/workspace-lifecycle.ts
+++ b/src/workspaces/workspace-lifecycle.ts
@@ -9,6 +9,7 @@ import type { Logger } from './logger.js'
 import type { ResumeRegistry } from './resume-registry.js'
 import type { ScrollbackStore } from './scrollback-store.js'
 import type { SessionPool } from './session-pool.js'
+import type { WebPiSessionHost } from './webpi-session-host.js'
 import type { SessionRecord, SessionRegistry } from './session-registry.js'
 import {
   catalogRecordToMeta,
@@ -45,6 +46,7 @@ export interface WorkspaceLifecycleManagerDeps {
   scrollbackStore: ScrollbackStore
   headlessTasks: HeadlessTaskRegistry
   pool: SessionPool
+  webPi?: WebPiSessionHost
   /** Includes synchronous wait:true/probe-style runs not yet in HeadlessTaskRegistry. */
   isWorkspaceHeadlessActive?: (workspaceId: string) => boolean
   logger: Logger
@@ -350,6 +352,7 @@ export class WorkspaceLifecycleManager {
         if (dump.length > 0) scrollbackFile = await this.deps.scrollbackStore.dump(wsId, record.id, dump)
       }
       this.deps.pool.disposeToken(record.id, 'workspace offboarded')
+      await this.deps.webPi?.stop(record.id, 'workspace offboarded')
       if (record.state === 'running' || scrollbackFile) {
         await this.deps.sessionRegistry.update(wsId, record.id, {
           state: 'paused',

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -52,6 +52,7 @@ function workspaceContext(workspaces: readonly Workspace[]): WorkspacesContextVa
     quickChat: vi.fn(async () => 'session-1'),
     pauseSession: vi.fn(async () => undefined),
     resumeSession: vi.fn(async () => undefined),
+    openWebPiSession: vi.fn(async () => undefined),
     requestDeleteSession: vi.fn(),
     openAgentConfig: vi.fn(),
     saveWorkspaceMetadata: vi.fn(async () => undefined),

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -82,6 +82,7 @@ describe('ChatWorkspaceSection actions', () => {
     const newChat = screen.getByRole('button', { name: 'New chat' })
     const newWorkspace = screen.getByRole('button', { name: 'New workspace' })
     const workspaceHeading = screen.getByText('Workspaces', { selector: 'span' })
+    const workspaceButton = screen.getByRole('button', { name: chatWorkspace.tag })
     const newSession = screen.getByRole('button', { name: 'New conversation in this workspace' })
 
     expect(newChat.className).toContain('w-full')
@@ -96,8 +97,14 @@ describe('ChatWorkspaceSection actions', () => {
     fireEvent.click(newChat)
     expect(openOrFocus).toHaveBeenCalledWith({ kind: 'chat-landing', params: {} })
 
+    fireEvent.click(workspaceButton)
+    expect(openOrFocus).toHaveBeenLastCalledWith({
+      kind: 'chat-landing',
+      params: { targetWsId: chatWorkspace.id },
+    })
+
     fireEvent.click(newSession)
-    expect(openOrFocus).toHaveBeenCalledWith({
+    expect(openOrFocus).toHaveBeenLastCalledWith({
       kind: 'chat-landing',
       params: { targetWsId: chatWorkspace.id },
     })

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -168,13 +168,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
             selection={selection}
             onOpen={() => {
               rememberChatWorkspace(w.id)
-              const preferred = orderSessionsForSidebar(w.sessions)[0]
-              openOrFocus({
-                kind: 'workspace',
-                params: preferred
-                  ? { wsId: w.id, sessionId: preferred.id, source: 'chat' }
-                  : { wsId: w.id, source: 'chat' },
-              })
+              openOrFocus({ kind: 'chat-landing', params: { targetWsId: w.id } })
             }}
             onOpenSession={(sid) => {
               rememberChatWorkspace(w.id)

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -56,9 +56,8 @@ export function ChatWorkspaceSection(): ReactElement | null {
   const chatWorkspaces = useMemo(
     () => orderWorkspacesForSidebar(
       ctx.workspaces.filter((workspace) => workspace.template === CHAT_TEMPLATE),
-      selection,
     ),
-    [ctx.workspaces, selection],
+    [ctx.workspaces],
   )
   const workspaceListRef = useReorderMotion<HTMLUListElement>(
     chatWorkspaces.map((workspace) => workspace.id),
@@ -169,7 +168,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
             selection={selection}
             onOpen={() => {
               rememberChatWorkspace(w.id)
-              const preferred = orderSessionsForSidebar(w.sessions, null)[0]
+              const preferred = orderSessionsForSidebar(w.sessions)[0]
               openOrFocus({
                 kind: 'workspace',
                 params: preferred
@@ -232,11 +231,8 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
   const displayName = w.displayName?.trim()
   const subtitle = displayName && displayName !== props.label ? displayName : null
   const orderedSessions = useMemo(
-    () => orderSessionsForSidebar(
-      w.sessions,
-      props.selection?.wsId === w.id ? props.selection.sessionId : null,
-    ),
-    [w.sessions, w.id, props.selection],
+    () => orderSessionsForSidebar(w.sessions),
+    [w.sessions],
   )
   const sessionListRef = useReorderMotion<HTMLDivElement>(
     orderedSessions.map((session) => session.id),

--- a/ui/src/components/workspace/ResumeCta.tsx
+++ b/ui/src/components/workspace/ResumeCta.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
 import { formatRelativeTime } from '../../lib/intl';
 import type { ReactElement } from 'react';
-import { MessageSquare } from 'lucide-react';
+import { Bot, MessageSquare } from 'lucide-react';
 
 import type { SessionRecord } from './api';
 
 export interface ResumeCtaProps {
   readonly record: SessionRecord;
   readonly onResume: () => void;
+  readonly onOpenWebPi?: () => void;
 }
 
 /**
@@ -32,12 +33,12 @@ export interface ResumeCtaProps {
  *      `resume --last`; shell fresh + scrollback restore).
  */
 export function ResumeCta(props: ResumeCtaProps): ReactElement {
-  const [resuming, setResuming] = useState(false);
+  const [resuming, setResuming] = useState<'terminal' | 'webpi' | null>(null);
   const r = props.record;
 
   const onClick = (): void => {
     if (resuming) return;
-    setResuming(true);
+    setResuming('terminal');
     props.onResume();
     // No setResuming(false) — the parent re-renders once state flips to
     // 'running' which unmounts this component entirely.
@@ -58,16 +59,33 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
             </div>
           </div>
 
-          <button
-            type="button"
-            className="resume-cta-btn"
-            onClick={onClick}
-            disabled={resuming}
-            aria-label={resuming ? 'Resuming conversation…' : 'Continue conversation'}
-          >
-            <MessageSquare size={14} strokeWidth={2.25} aria-hidden="true" />
-            <span>{resuming ? 'Resuming…' : 'Continue conversation'}</span>
-          </button>
+          <div className="resume-cta-actions">
+            <button
+              type="button"
+              className="resume-cta-btn"
+              onClick={onClick}
+              disabled={resuming !== null}
+              aria-label={resuming ? 'Resuming conversation…' : 'Continue in terminal'}
+            >
+              <MessageSquare size={14} strokeWidth={2.25} aria-hidden="true" />
+              <span>{resuming === 'terminal' ? 'Opening…' : 'Open TUI'}</span>
+            </button>
+            {r.agent === 'pi' && props.onOpenWebPi && (
+              <button
+                type="button"
+                className="resume-cta-btn is-webpi"
+                onClick={() => {
+                  if (resuming) return
+                  setResuming('webpi')
+                  props.onOpenWebPi?.()
+                }}
+                disabled={resuming !== null}
+              >
+                <Bot size={14} strokeWidth={2.25} aria-hidden="true" />
+                <span>{resuming === 'webpi' ? 'Opening…' : 'Open WebPi · Beta'}</span>
+              </button>
+            )}
+          </div>
 
           <dl className="resume-cta-meta">
             <dt>Agent</dt>

--- a/ui/src/components/workspace/ResumeCta.tsx
+++ b/ui/src/components/workspace/ResumeCta.tsx
@@ -82,7 +82,8 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
                 disabled={resuming !== null}
               >
                 <Bot size={14} strokeWidth={2.25} aria-hidden="true" />
-                <span>{resuming === 'webpi' ? 'Opening…' : 'Open WebPi · Beta'}</span>
+                <span>{resuming === 'webpi' ? 'Opening…' : 'Open WebPi'}</span>
+                {resuming !== 'webpi' && <span className="resume-cta-beta">Beta</span>}
               </button>
             )}
           </div>

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -85,8 +85,8 @@ export function Sidebar(props: SidebarProps): ReactElement {
   const [pendingOffboard, setPendingOffboard] = useState<Workspace | null>(null);
   const showListError = Boolean(props.listError && props.workspaces.length === 0);
   const orderedWorkspaces = useMemo(
-    () => orderWorkspacesForSidebar(props.workspaces, props.selection),
-    [props.workspaces, props.selection],
+    () => orderWorkspacesForSidebar(props.workspaces),
+    [props.workspaces],
   );
   const workspaceListRef = useReorderMotion<HTMLDivElement>(
     orderedWorkspaces.map((workspace) => workspace.id),
@@ -325,11 +325,8 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   const hasRunning = w.sessions.some((s) => s.state === 'running');
   const runningCount = w.sessions.filter((s) => s.state === 'running').length;
   const orderedSessions = useMemo(
-    () => orderSessionsForSidebar(
-      w.sessions,
-      props.selection?.wsId === w.id ? props.selection.sessionId : null,
-    ),
-    [w.sessions, w.id, props.selection],
+    () => orderSessionsForSidebar(w.sessions),
+    [w.sessions],
   );
   const sessionListRef = useReorderMotion<HTMLDivElement>(
     orderedSessions.map((session) => session.id),

--- a/ui/src/components/workspace/WebPiView.tsx
+++ b/ui/src/components/workspace/WebPiView.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
+import { Bot, LoaderCircle, Send, Square, User } from 'lucide-react'
+
+import { MarkdownContent } from '../MarkdownContent'
+import {
+  abortWebPiSession,
+  getWebPiSession,
+  promptWebPiSession,
+  type WebPiSnapshot,
+} from './api'
+
+interface Props {
+  readonly wsId: string
+  readonly sessionId: string
+  readonly label?: string
+  readonly onSessionLost: () => void
+}
+
+/** A thin browser renderer over Pi's own RPC messages. Pi remains responsible
+ * for the conversation schema and JSONL persistence; this component does not
+ * introduce an OpenAlice message model. */
+export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): ReactElement {
+  const [snapshot, setSnapshot] = useState<WebPiSnapshot | null>(null)
+  const [draft, setDraft] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+
+  const refresh = useCallback(async (): Promise<void> => {
+    try {
+      const next = await getWebPiSession(wsId, sessionId)
+      setSnapshot(next)
+      setError(next.error)
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }, [sessionId, wsId])
+
+  useEffect(() => {
+    void refresh()
+    const timer = window.setInterval(() => void refresh(), 500)
+    return () => window.clearInterval(timer)
+  }, [refresh])
+
+  const messages = useMemo(() => {
+    if (!snapshot) return []
+    return snapshot.streamingMessage
+      ? [...snapshot.messages, snapshot.streamingMessage]
+      : [...snapshot.messages]
+  }, [snapshot])
+
+  useEffect(() => {
+    scrollerRef.current?.scrollTo({ top: scrollerRef.current.scrollHeight, behavior: 'smooth' })
+  }, [messages.length, snapshot?.revision])
+
+  const working = snapshot?.phase === 'working' || snapshot?.phase === 'compacting' || snapshot?.phase === 'retrying'
+
+  const submit = async (): Promise<void> => {
+    const message = draft.trim()
+    if (!message || working) return
+    setDraft('')
+    setError(null)
+    try {
+      setSnapshot(await promptWebPiSession(wsId, sessionId, message))
+    } catch (err) {
+      setDraft(message)
+      setError((err as Error).message)
+    }
+  }
+
+  const abort = async (): Promise<void> => {
+    try {
+      setSnapshot(await abortWebPiSession(wsId, sessionId))
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
+  return (
+    <div className="webpi-shell">
+      <header className="webpi-header">
+        <div>
+          <div className="webpi-title">{label ?? 'Pi'} <span>WebPi · Beta</span></div>
+          <div className="webpi-subtitle">Same Pi session · browser surface</div>
+        </div>
+        <div className={`webpi-phase is-${snapshot?.phase ?? 'starting'}`}>
+          {(working || !snapshot) && <LoaderCircle size={12} className="animate-spin" aria-hidden="true" />}
+          {snapshot?.phase ?? 'starting'}
+        </div>
+      </header>
+
+      <div ref={scrollerRef} className="webpi-messages">
+        {messages.length === 0 && !error && (
+          <div className="webpi-empty">This Pi conversation is ready in the browser.</div>
+        )}
+        {messages.map((message, index) => (
+          <PiMessage key={`${index}-${snapshot?.revision ?? 0}`} value={message} />
+        ))}
+        {error && (
+          <div className="webpi-error">
+            <strong>WebPi could not continue.</strong>
+            <span>{error}</span>
+            <button type="button" onClick={() => { setError(null); void refresh() }}>Retry</button>
+            <button type="button" onClick={onSessionLost}>Refresh session</button>
+          </div>
+        )}
+      </div>
+
+      <div className="webpi-composer-wrap">
+        <div className="webpi-composer">
+          <textarea
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault()
+                void submit()
+              }
+            }}
+            placeholder="Message Pi…"
+            rows={1}
+            disabled={!snapshot || snapshot.phase === 'failed'}
+          />
+          {working ? (
+            <button type="button" className="webpi-send" onClick={() => void abort()} aria-label="Stop Pi">
+              <Square size={14} fill="currentColor" aria-hidden="true" />
+            </button>
+          ) : (
+            <button type="button" className="webpi-send" onClick={() => void submit()} disabled={!draft.trim()} aria-label="Send message">
+              <Send size={15} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+        <div className="webpi-composer-hint">Enter to send · Shift+Enter for a new line</div>
+      </div>
+    </div>
+  )
+}
+
+function PiMessage({ value }: { readonly value: unknown }): ReactElement {
+  const record = asRecord(value)
+  const role = typeof record?.['role'] === 'string' ? record['role'] : 'assistant'
+  const user = role === 'user'
+  const tool = role === 'toolResult' || role === 'tool'
+  const content = record?.['content']
+  return (
+    <article className={`webpi-message is-${user ? 'user' : tool ? 'tool' : 'assistant'}`}>
+      <div className="webpi-avatar">{user ? <User size={14} /> : <Bot size={14} />}</div>
+      <div className="webpi-message-body">
+        <div className="webpi-role">{user ? 'You' : tool ? String(record?.['toolName'] ?? 'Tool') : 'Pi'}</div>
+        <PiContent value={content ?? value} />
+      </div>
+    </article>
+  )
+}
+
+function PiContent({ value }: { readonly value: unknown }): ReactElement {
+  if (typeof value === 'string') return <MarkdownContent text={value} />
+  if (!Array.isArray(value)) {
+    const record = asRecord(value)
+    const text = typeof record?.['text'] === 'string' ? record['text'] : JSON.stringify(value, null, 2)
+    return <MarkdownContent text={text ?? ''} />
+  }
+  return (
+    <div className="webpi-content-parts">
+      {value.map((part, index) => {
+        const item = asRecord(part)
+        const type = typeof item?.['type'] === 'string' ? item['type'] : 'unknown'
+        if (type === 'text' && typeof item?.['text'] === 'string') {
+          return <MarkdownContent key={index} text={item['text']} />
+        }
+        if (type === 'thinking') {
+          const thinking = typeof item?.['thinking'] === 'string' ? item['thinking'] : String(item?.['text'] ?? '')
+          return <details key={index} className="webpi-detail"><summary>Thinking</summary><MarkdownContent text={thinking} /></details>
+        }
+        if (type === 'toolCall') {
+          return (
+            <details key={index} className="webpi-detail is-tool">
+              <summary>Used {String(item?.['name'] ?? 'tool')}</summary>
+              <pre>{JSON.stringify(item?.['arguments'] ?? {}, null, 2)}</pre>
+            </details>
+          )
+        }
+        return <pre key={index} className="webpi-unknown">{JSON.stringify(part, null, 2)}</pre>
+      })}
+    </div>
+  )
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}

--- a/ui/src/components/workspace/WebPiView.tsx
+++ b/ui/src/components/workspace/WebPiView.tsx
@@ -24,21 +24,40 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
   const [draft, setDraft] = useState('')
   const [error, setError] = useState<string | null>(null)
   const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const snapshotRef = useRef<WebPiSnapshot | null>(null)
+
+  const acceptSnapshot = useCallback((next: WebPiSnapshot): void => {
+    snapshotRef.current = next
+    setSnapshot(next)
+  }, [])
 
   const refresh = useCallback(async (): Promise<void> => {
     try {
-      const next = await getWebPiSession(wsId, sessionId)
-      setSnapshot(next)
-      setError(next.error)
+      const next = await getWebPiSession(wsId, sessionId, snapshotRef.current?.revision)
+      if (next) acceptSnapshot(next)
+      setError(next?.error ?? null)
     } catch (err) {
       setError((err as Error).message)
     }
-  }, [sessionId, wsId])
+  }, [acceptSnapshot, sessionId, wsId])
 
   useEffect(() => {
-    void refresh()
-    const timer = window.setInterval(() => void refresh(), 500)
-    return () => window.clearInterval(timer)
+    let cancelled = false
+    let timer: number | null = null
+    const loop = async (): Promise<void> => {
+      await refresh()
+      if (cancelled) return
+      const phase = snapshotRef.current?.phase
+      const delay = phase === 'working' || phase === 'compacting' || phase === 'retrying'
+        ? 350
+        : 1_500
+      timer = window.setTimeout(() => void loop(), delay)
+    }
+    void loop()
+    return () => {
+      cancelled = true
+      if (timer !== null) window.clearTimeout(timer)
+    }
   }, [refresh])
 
   const messages = useMemo(() => {
@@ -60,7 +79,7 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
     setDraft('')
     setError(null)
     try {
-      setSnapshot(await promptWebPiSession(wsId, sessionId, message))
+      acceptSnapshot(await promptWebPiSession(wsId, sessionId, message))
     } catch (err) {
       setDraft(message)
       setError((err as Error).message)
@@ -69,7 +88,7 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
 
   const abort = async (): Promise<void> => {
     try {
-      setSnapshot(await abortWebPiSession(wsId, sessionId))
+      acceptSnapshot(await abortWebPiSession(wsId, sessionId))
     } catch (err) {
       setError((err as Error).message)
     }
@@ -93,7 +112,7 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
           <div className="webpi-empty">This Pi conversation is ready in the browser.</div>
         )}
         {messages.map((message, index) => (
-          <PiMessage key={`${index}-${snapshot?.revision ?? 0}`} value={message} />
+          <PiMessage key={messageKey(message, index)} value={message} />
         ))}
         {error && (
           <div className="webpi-error">
@@ -147,9 +166,31 @@ function PiMessage({ value }: { readonly value: unknown }): ReactElement {
       <div className="webpi-avatar">{user ? <User size={14} /> : <Bot size={14} />}</div>
       <div className="webpi-message-body">
         <div className="webpi-role">{user ? 'You' : tool ? String(record?.['toolName'] ?? 'Tool') : 'Pi'}</div>
-        <PiContent value={content ?? value} />
+        {tool && record
+          ? <PiToolResult record={record} />
+          : <PiContent value={content ?? value} />}
       </div>
     </article>
+  )
+}
+
+function PiToolResult({ record }: { readonly record: Record<string, unknown> }): ReactElement {
+  const failed = record['isError'] === true
+  const [open, setOpen] = useState(failed)
+  const content = record['content']
+  const chars = contentText(content).length
+  return (
+    <details
+      className={`webpi-tool-result${failed ? ' is-error' : ''}`}
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary>
+        <span>{failed ? 'Failed' : 'Result'} from {String(record['toolName'] ?? 'tool')}</span>
+        <span>{formatChars(chars)}</span>
+      </summary>
+      {open && <PiContent value={content} />}
+    </details>
   )
 }
 
@@ -190,4 +231,24 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null
+}
+
+function contentText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (!Array.isArray(value)) return ''
+  return value.flatMap((part) => {
+    const item = asRecord(part)
+    return typeof item?.['text'] === 'string' ? [item['text']] : []
+  }).join('\n')
+}
+
+function formatChars(chars: number): string {
+  if (chars < 1_000) return `${chars} chars`
+  return `${(chars / 1_000).toFixed(chars < 10_000 ? 1 : 0)}k chars`
+}
+
+function messageKey(value: unknown, index: number): string {
+  const record = asRecord(value)
+  const stable = record?.['id'] ?? record?.['toolCallId'] ?? record?.['timestamp'] ?? record?.['role'] ?? 'message'
+  return `${index}-${String(stable)}`
 }

--- a/ui/src/components/workspace/WebPiView.tsx
+++ b/ui/src/components/workspace/WebPiView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
-import { Bot, LoaderCircle, Send, Square, User } from 'lucide-react'
+import { LoaderCircle, Send, Square } from 'lucide-react'
 
 import { MarkdownContent } from '../MarkdownContent'
 import {
@@ -163,9 +163,7 @@ function PiMessage({ value }: { readonly value: unknown }): ReactElement {
   const content = record?.['content']
   return (
     <article className={`webpi-message is-${user ? 'user' : tool ? 'tool' : 'assistant'}`}>
-      <div className="webpi-avatar">{user ? <User size={14} /> : <Bot size={14} />}</div>
       <div className="webpi-message-body">
-        <div className="webpi-role">{user ? 'You' : tool ? String(record?.['toolName'] ?? 'Tool') : 'Pi'}</div>
         {tool && record
           ? <PiToolResult record={record} />
           : <PiContent value={content ?? value} />}

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -8,6 +8,7 @@ import { FilesPanel } from './FilesPanel';
 import { ResumeCta, prefixOf } from './ResumeCta';
 import { formatRelativeTime } from '../../lib/intl';
 import { TerminalView, type KeyMap } from './Terminal';
+import { WebPiView } from './WebPiView';
 import { useIsDesktop } from '../../live/use-is-desktop';
 import { useWorkspaceSidePanels } from '../../live/workspace-side-panels';
 
@@ -29,6 +30,7 @@ export interface WorkspaceViewProps {
   readonly keyMap?: KeyMap;
   readonly onSpawnFresh: () => void;
   readonly onResume: (sessionId: string) => void;
+  readonly onOpenWebPi: (sessionId: string) => void;
   /** Navigate to an already-running session without re-spawning it. The
    *  empty-state cards call this for running entries; resume-spawn for
    *  paused entries goes through `onResume`. */
@@ -93,6 +95,7 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
           <ResumeCta
             record={props.activeRecord}
             onResume={() => props.onResume(props.activeRecord!.id)}
+            onOpenWebPi={() => props.onOpenWebPi(props.activeRecord!.id)}
           />
         )}
         {!showPausedCta &&
@@ -103,13 +106,22 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
                 key={s.id}
                 className={`workspace-terminal-slot ${isActive ? 'is-active' : 'is-hidden'}`}
               >
-                <TerminalView
-                  wsId={props.wsId}
-                  sessionId={s.id}
-                  {...(props.label !== undefined ? { label: `${props.label} · ${s.name}` } : {})}
-                  {...(props.keyMap !== undefined ? { keyMap: props.keyMap } : {})}
-                  onSessionLost={props.onSessionLost}
-                />
+                {(s.surface ?? 'terminal') === 'webpi' && s.agent === 'pi' ? (
+                  <WebPiView
+                    wsId={props.wsId}
+                    sessionId={s.id}
+                    {...(props.label !== undefined ? { label: `${props.label} · ${s.name}` } : {})}
+                    onSessionLost={props.onSessionLost}
+                  />
+                ) : (
+                  <TerminalView
+                    wsId={props.wsId}
+                    sessionId={s.id}
+                    {...(props.label !== undefined ? { label: `${props.label} · ${s.name}` } : {})}
+                    {...(props.keyMap !== undefined ? { keyMap: props.keyMap } : {})}
+                    onSessionLost={props.onSessionLost}
+                  />
+                )}
               </div>
             );
           })}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -337,6 +337,8 @@ export interface SessionRecord {
   readonly createdAt: string;
   readonly lastActiveAt: string;
   readonly state: 'running' | 'paused';
+  /** UI surface only; `agent` remains `pi` for WebPi. */
+  readonly surface?: 'terminal' | 'webpi';
   readonly pid: number | null;
   readonly startedAt: number | null;
   /** First message (seeded sessions) — the sidebar title; null → fall back to `name`. */
@@ -354,6 +356,21 @@ export interface SpawnedSession {
   readonly agent: string;
   readonly resumeId: string;
   readonly title: string | null;
+}
+
+export interface WebPiSnapshot {
+  readonly recordId: string;
+  readonly wsId: string;
+  readonly resumeId: string;
+  readonly pid: number | null;
+  readonly startedAt: number;
+  readonly phase: 'starting' | 'idle' | 'working' | 'compacting' | 'retrying' | 'stopped' | 'failed';
+  readonly state: Record<string, unknown> | null;
+  readonly messages: readonly unknown[];
+  readonly streamingMessage: unknown | null;
+  readonly error: string | null;
+  readonly stderrTail: string;
+  readonly revision: number;
 }
 
 export interface SpawnOptions {
@@ -553,6 +570,53 @@ export async function resumeSession(
   );
   if (!res.ok) return null;
   return (await res.json()) as SpawnedSession;
+}
+
+export async function openWebPiSession(wsId: string, sessionId: string): Promise<WebPiSnapshot> {
+  const res = await fetch(
+    `/api/workspaces/${encodeURIComponent(wsId)}/sessions/${encodeURIComponent(sessionId)}/webpi/open`,
+    { method: 'POST' },
+  );
+  const body = (await res.json().catch(() => null)) as { snapshot?: WebPiSnapshot; message?: string } | null;
+  if (!res.ok || !body?.snapshot) throw new Error(body?.message ?? `WebPi open failed: ${res.status}`);
+  return body.snapshot;
+}
+
+export async function getWebPiSession(wsId: string, sessionId: string): Promise<WebPiSnapshot> {
+  const res = await fetch(
+    `/api/workspaces/${encodeURIComponent(wsId)}/sessions/${encodeURIComponent(sessionId)}/webpi`,
+  );
+  const body = (await res.json().catch(() => null)) as { snapshot?: WebPiSnapshot; message?: string } | null;
+  if (!res.ok || !body?.snapshot) throw new Error(body?.message ?? `WebPi read failed: ${res.status}`);
+  return body.snapshot;
+}
+
+export async function promptWebPiSession(
+  wsId: string,
+  sessionId: string,
+  message: string,
+): Promise<WebPiSnapshot> {
+  const res = await fetch(
+    `/api/workspaces/${encodeURIComponent(wsId)}/sessions/${encodeURIComponent(sessionId)}/webpi/prompt`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message }),
+    },
+  );
+  const body = (await res.json().catch(() => null)) as { snapshot?: WebPiSnapshot; message?: string } | null;
+  if (!res.ok || !body?.snapshot) throw new Error(body?.message ?? `WebPi prompt failed: ${res.status}`);
+  return body.snapshot;
+}
+
+export async function abortWebPiSession(wsId: string, sessionId: string): Promise<WebPiSnapshot> {
+  const res = await fetch(
+    `/api/workspaces/${encodeURIComponent(wsId)}/sessions/${encodeURIComponent(sessionId)}/webpi/abort`,
+    { method: 'POST' },
+  );
+  const body = (await res.json().catch(() => null)) as { snapshot?: WebPiSnapshot; message?: string } | null;
+  if (!res.ok || !body?.snapshot) throw new Error(body?.message ?? `WebPi abort failed: ${res.status}`);
+  return body.snapshot;
 }
 
 /** Permanently remove a session record (kills PTY first if running). */

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -582,12 +582,23 @@ export async function openWebPiSession(wsId: string, sessionId: string): Promise
   return body.snapshot;
 }
 
-export async function getWebPiSession(wsId: string, sessionId: string): Promise<WebPiSnapshot> {
+export async function getWebPiSession(
+  wsId: string,
+  sessionId: string,
+  revision?: number,
+): Promise<WebPiSnapshot | null> {
+  const query = revision === undefined ? '' : `?revision=${encodeURIComponent(String(revision))}`;
   const res = await fetch(
-    `/api/workspaces/${encodeURIComponent(wsId)}/sessions/${encodeURIComponent(sessionId)}/webpi`,
+    `/api/workspaces/${encodeURIComponent(wsId)}/sessions/${encodeURIComponent(sessionId)}/webpi${query}`,
   );
-  const body = (await res.json().catch(() => null)) as { snapshot?: WebPiSnapshot; message?: string } | null;
-  if (!res.ok || !body?.snapshot) throw new Error(body?.message ?? `WebPi read failed: ${res.status}`);
+  const body = (await res.json().catch(() => null)) as {
+    snapshot?: WebPiSnapshot;
+    unchanged?: boolean;
+    message?: string;
+  } | null;
+  if (!res.ok) throw new Error(body?.message ?? `WebPi read failed: ${res.status}`);
+  if (body?.unchanged) return null;
+  if (!body?.snapshot) throw new Error('WebPi response has no snapshot');
   return body.snapshot;
 }
 

--- a/ui/src/components/workspace/sidebar-order.spec.ts
+++ b/ui/src/components/workspace/sidebar-order.spec.ts
@@ -40,9 +40,9 @@ function workspace(
 }
 
 describe('sidebar attention order', () => {
-  it('lifts the selected workspace, then running workspaces, then recent activity', () => {
-    const selectedOld = workspace('selected-old', '2026-01-01T00:00:00Z', [
-      session('selected-session', 'paused', '2026-01-01T00:00:00Z'),
+  it('lifts running workspaces, then recent activity', () => {
+    const oldestPaused = workspace('oldest-paused', '2026-01-01T00:00:00Z', [
+      session('oldest-session', 'paused', '2026-01-01T00:00:00Z'),
     ])
     const runningOld = workspace('running-old', '2026-02-01T00:00:00Z', [
       session('running-session', 'running', '2026-02-01T00:00:00Z'),
@@ -55,13 +55,12 @@ describe('sidebar attention order', () => {
     ])
 
     expect(orderWorkspacesForSidebar(
-      [olderPaused, recentPaused, runningOld, selectedOld],
-      { wsId: selectedOld.id, sessionId: 'selected-session' },
+      [olderPaused, recentPaused, runningOld, oldestPaused],
     ).map((candidate) => candidate.id)).toEqual([
-      'selected-old',
       'running-old',
       'recent-paused',
       'older-paused',
+      'oldest-paused',
     ])
   })
 
@@ -69,24 +68,23 @@ describe('sidebar attention order', () => {
     const older = workspace('older', '2026-07-01T00:00:00Z', [])
     const newer = workspace('newer', '2026-07-10T00:00:00Z', [])
 
-    expect(orderWorkspacesForSidebar([older, newer], null).map((candidate) => candidate.id))
+    expect(orderWorkspacesForSidebar([older, newer]).map((candidate) => candidate.id))
       .toEqual(['newer', 'older'])
   })
 
-  it('lifts the selected session, then running sessions, then recent activity', () => {
-    const selectedOld = session('selected-old', 'paused', '2026-01-01T00:00:00Z')
+  it('lifts running sessions, then recent activity', () => {
+    const oldestPaused = session('oldest-paused', 'paused', '2026-01-01T00:00:00Z')
     const runningOld = session('running-old', 'running', '2026-02-01T00:00:00Z')
     const recentPaused = session('recent-paused', 'paused', '2026-07-10T00:00:00Z')
     const olderPaused = session('older-paused', 'paused', '2026-07-09T00:00:00Z')
 
     expect(orderSessionsForSidebar(
-      [olderPaused, recentPaused, runningOld, selectedOld],
-      selectedOld.id,
+      [olderPaused, recentPaused, runningOld, oldestPaused],
     ).map((candidate) => candidate.id)).toEqual([
-      'selected-old',
       'running-old',
       'recent-paused',
       'older-paused',
+      'oldest-paused',
     ])
   })
 })

--- a/ui/src/components/workspace/sidebar-order.ts
+++ b/ui/src/components/workspace/sidebar-order.ts
@@ -1,10 +1,5 @@
 import type { SessionRecord, Workspace } from './api'
 
-export interface SidebarSelection {
-  readonly wsId: string
-  readonly sessionId: string | null
-}
-
 function timestamp(value: string): number {
   const parsed = Date.parse(value)
   return Number.isFinite(parsed) ? parsed : 0
@@ -18,18 +13,15 @@ function workspaceActivityMs(workspace: Workspace): number {
 }
 
 /**
- * Rank the workspace tree by current attention, then by recency. Selection is
- * deliberately UI-local: opening an old Inbox-linked session should lift its
- * whole workspace immediately without rewriting durable session timestamps.
+ * Rank the workspace tree by active work, then by recency. Selection is
+ * deliberately presentation-only: inspecting a paused session must not move
+ * its workspace. A workspace is lifted only when one of its sessions is
+ * actually running.
  */
 export function orderWorkspacesForSidebar(
   workspaces: readonly Workspace[],
-  selection: SidebarSelection | null,
 ): Workspace[] {
   return [...workspaces].sort((a, b) => {
-    const selected = Number(b.id === selection?.wsId) - Number(a.id === selection?.wsId)
-    if (selected !== 0) return selected
-
     const running = Number(b.sessions.some((session) => session.state === 'running'))
       - Number(a.sessions.some((session) => session.state === 'running'))
     if (running !== 0) return running
@@ -43,16 +35,12 @@ export function orderWorkspacesForSidebar(
   })
 }
 
-/** Selected and running sessions are the ones most likely to need attention;
- * within the same state, the latest activity wins. */
+/** Running sessions need immediate attention; within the same state, the
+ * latest activity wins. Merely selecting a paused session never reorders it. */
 export function orderSessionsForSidebar(
   sessions: readonly SessionRecord[],
-  selectedSessionId: string | null,
 ): SessionRecord[] {
   return [...sessions].sort((a, b) => {
-    const selected = Number(b.id === selectedSessionId) - Number(a.id === selectedSessionId)
-    if (selected !== 0) return selected
-
     const running = Number(b.state === 'running') - Number(a.state === 'running')
     if (running !== 0) return running
 

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -998,12 +998,13 @@
 
 .webpi-empty { padding: 12vh 16px; text-align: center; color: var(--color-text-muted); font-size: 13px; }
 .webpi-message { display: flex; align-items: flex-start; gap: 10px; margin: 0 0 24px; }
-.webpi-message.is-user { margin-left: 12%; }
+.webpi-message.is-user { flex-direction: row-reverse; margin-left: 12%; }
 .webpi-message.is-tool { margin: -12px 0 16px 36px; }
 .webpi-avatar { width: 26px; height: 26px; flex: 0 0 26px; display: grid; place-items: center; border: 1px solid var(--color-border); border-radius: 8px; color: var(--color-text-muted); background: var(--color-bg-secondary); }
 .webpi-message.is-user .webpi-avatar { color: var(--color-accent); border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border)); }
 .webpi-message-body { flex: 1; min-width: 0; font-size: 13px; line-height: 1.65; }
-.webpi-message.is-user .webpi-message-body { padding: 10px 13px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-bg-secondary); }
+.webpi-message.is-user .webpi-message-body { flex: 0 1 auto; max-width: min(88%, 760px); padding: 10px 13px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-bg-secondary); }
+.webpi-message.is-user .webpi-role { text-align: right; }
 .webpi-role { margin-bottom: 4px; color: var(--color-text-muted); font-size: 10px; font-weight: 650; text-transform: uppercase; letter-spacing: .07em; }
 .webpi-content-parts > * + * { margin-top: 9px; }
 .webpi-detail { padding: 6px 9px; border-left: 2px solid var(--color-border); color: var(--color-text-muted); font-size: 11px; }

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -260,8 +260,19 @@
   border-radius: 6px;
   font-size: 13px;
   font-weight: 600;
+  white-space: nowrap;
   cursor: pointer;
   transition: filter 0.12s;
+}
+.resume-cta-beta {
+  padding: 1px 4px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-size: 8px;
+  line-height: 1.2;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  opacity: 0.58;
 }
 .resume-cta-btn:hover:not(:disabled) {
   filter: brightness(1.1);
@@ -949,6 +960,8 @@
 
 .resume-cta-actions .resume-cta-btn {
   flex: 1;
+  min-width: 0;
+  padding-inline: 14px;
 }
 
 .resume-cta-btn.is-webpi {

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -942,3 +942,85 @@
 .terminal-host .xterm-viewport {
   background-color: transparent !important;
 }
+.resume-cta-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.resume-cta-actions .resume-cta-btn {
+  flex: 1;
+}
+
+.resume-cta-btn.is-webpi {
+  background: color-mix(in srgb, var(--color-accent) 13%, var(--color-bg-secondary));
+  color: var(--color-text);
+}
+
+/* WebPi is deliberately a surface inside the existing terminal slot. */
+.webpi-shell {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: var(--color-text);
+  background:
+    radial-gradient(circle at 50% -20%, color-mix(in srgb, var(--color-accent) 8%, transparent), transparent 38%),
+    var(--color-bg);
+}
+
+.webpi-header {
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-bg-secondary) 72%, transparent);
+}
+
+.webpi-title { font-size: 13px; font-weight: 650; }
+.webpi-title span { margin-left: 7px; color: var(--color-text-muted); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; }
+.webpi-subtitle { margin-top: 2px; color: var(--color-text-muted); font-size: 10px; }
+.webpi-phase { display: inline-flex; align-items: center; gap: 5px; padding: 4px 8px; border: 1px solid var(--color-border); border-radius: 999px; color: var(--color-text-muted); font-size: 10px; text-transform: capitalize; }
+.webpi-phase.is-working, .webpi-phase.is-retrying, .webpi-phase.is-compacting { color: var(--color-accent); }
+.webpi-phase.is-failed { color: var(--color-danger, #d65c5c); }
+
+.webpi-messages {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 26px max(18px, calc((100% - 760px) / 2));
+  scrollbar-gutter: stable;
+}
+
+.webpi-empty { padding: 12vh 16px; text-align: center; color: var(--color-text-muted); font-size: 13px; }
+.webpi-message { display: flex; align-items: flex-start; gap: 10px; margin: 0 0 24px; }
+.webpi-message.is-user { margin-left: 12%; }
+.webpi-avatar { width: 26px; height: 26px; flex: 0 0 26px; display: grid; place-items: center; border: 1px solid var(--color-border); border-radius: 8px; color: var(--color-text-muted); background: var(--color-bg-secondary); }
+.webpi-message.is-user .webpi-avatar { color: var(--color-accent); border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border)); }
+.webpi-message-body { flex: 1; min-width: 0; font-size: 13px; line-height: 1.65; }
+.webpi-message.is-user .webpi-message-body { padding: 10px 13px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-bg-secondary); }
+.webpi-role { margin-bottom: 4px; color: var(--color-text-muted); font-size: 10px; font-weight: 650; text-transform: uppercase; letter-spacing: .07em; }
+.webpi-content-parts > * + * { margin-top: 9px; }
+.webpi-detail { padding: 6px 9px; border-left: 2px solid var(--color-border); color: var(--color-text-muted); font-size: 11px; }
+.webpi-detail summary { cursor: pointer; user-select: none; font-weight: 600; }
+.webpi-detail pre, .webpi-unknown { margin-top: 6px; max-height: 220px; overflow: auto; white-space: pre-wrap; font: 10px/1.5 var(--font-mono, monospace); }
+
+.webpi-error { display: grid; gap: 7px; margin: 20px 0; padding: 13px; border: 1px solid color-mix(in srgb, #d65c5c 50%, var(--color-border)); border-radius: 10px; color: #d65c5c; font-size: 12px; }
+.webpi-error button { width: fit-content; color: var(--color-text); text-decoration: underline; }
+.webpi-composer-wrap { padding: 10px max(18px, calc((100% - 760px) / 2)) 14px; border-top: 1px solid var(--color-border); background: color-mix(in srgb, var(--color-bg) 88%, transparent); }
+.webpi-composer { display: flex; align-items: flex-end; gap: 8px; padding: 9px 10px 9px 13px; border: 1px solid var(--color-border); border-radius: 14px; background: var(--color-bg-secondary); box-shadow: 0 6px 24px color-mix(in srgb, #000 9%, transparent); }
+.webpi-composer:focus-within { border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border)); }
+.webpi-composer textarea { flex: 1; min-height: 25px; max-height: 150px; resize: none; border: 0; outline: 0; color: var(--color-text); background: transparent; font: inherit; font-size: 13px; line-height: 1.6; }
+.webpi-send { width: 30px; height: 30px; flex: 0 0 30px; display: grid; place-items: center; border-radius: 9px; color: white; background: var(--color-accent); }
+.webpi-send:disabled { opacity: .35; }
+.webpi-composer-hint { padding: 5px 3px 0; text-align: right; color: var(--color-text-muted); font-size: 9px; }
+
+@media (max-width: 720px) {
+  .webpi-messages, .webpi-composer-wrap { padding-left: 12px; padding-right: 12px; }
+  .webpi-message.is-user { margin-left: 0; }
+  .resume-cta-actions { flex-direction: column; }
+}

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -999,6 +999,7 @@
 .webpi-empty { padding: 12vh 16px; text-align: center; color: var(--color-text-muted); font-size: 13px; }
 .webpi-message { display: flex; align-items: flex-start; gap: 10px; margin: 0 0 24px; }
 .webpi-message.is-user { margin-left: 12%; }
+.webpi-message.is-tool { margin: -12px 0 16px 36px; }
 .webpi-avatar { width: 26px; height: 26px; flex: 0 0 26px; display: grid; place-items: center; border: 1px solid var(--color-border); border-radius: 8px; color: var(--color-text-muted); background: var(--color-bg-secondary); }
 .webpi-message.is-user .webpi-avatar { color: var(--color-accent); border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border)); }
 .webpi-message-body { flex: 1; min-width: 0; font-size: 13px; line-height: 1.65; }
@@ -1008,6 +1009,12 @@
 .webpi-detail { padding: 6px 9px; border-left: 2px solid var(--color-border); color: var(--color-text-muted); font-size: 11px; }
 .webpi-detail summary { cursor: pointer; user-select: none; font-weight: 600; }
 .webpi-detail pre, .webpi-unknown { margin-top: 6px; max-height: 220px; overflow: auto; white-space: pre-wrap; font: 10px/1.5 var(--font-mono, monospace); }
+.webpi-tool-result { border: 1px solid var(--color-border); border-radius: 8px; background: color-mix(in srgb, var(--color-bg-secondary) 72%, transparent); }
+.webpi-tool-result > summary { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 6px 9px; cursor: pointer; color: var(--color-text-muted); font: 10px/1.4 var(--font-mono, monospace); user-select: none; }
+.webpi-tool-result > summary::marker { color: var(--color-text-muted); }
+.webpi-tool-result[open] > summary { border-bottom: 1px solid var(--color-border); }
+.webpi-tool-result > :not(summary) { max-height: 360px; overflow: auto; padding: 9px 11px; }
+.webpi-tool-result.is-error { border-color: color-mix(in srgb, #d65c5c 55%, var(--color-border)); }
 
 .webpi-error { display: grid; gap: 7px; margin: 20px 0; padding: 13px; border: 1px solid color-mix(in srgb, #d65c5c 50%, var(--color-border)); border-radius: 10px; color: #d65c5c; font-size: 12px; }
 .webpi-error button { width: fit-content; color: var(--color-text); text-decoration: underline; }

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -997,15 +997,11 @@
 }
 
 .webpi-empty { padding: 12vh 16px; text-align: center; color: var(--color-text-muted); font-size: 13px; }
-.webpi-message { display: flex; align-items: flex-start; gap: 10px; margin: 0 0 24px; }
-.webpi-message.is-user { flex-direction: row-reverse; margin-left: 12%; }
-.webpi-message.is-tool { margin: -12px 0 16px 36px; }
-.webpi-avatar { width: 26px; height: 26px; flex: 0 0 26px; display: grid; place-items: center; border: 1px solid var(--color-border); border-radius: 8px; color: var(--color-text-muted); background: var(--color-bg-secondary); }
-.webpi-message.is-user .webpi-avatar { color: var(--color-accent); border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border)); }
+.webpi-message { display: flex; align-items: flex-start; margin: 0 0 24px; }
+.webpi-message.is-user { justify-content: flex-end; margin-left: 12%; }
+.webpi-message.is-tool { margin: -12px 0 16px; }
 .webpi-message-body { flex: 1; min-width: 0; font-size: 13px; line-height: 1.65; }
 .webpi-message.is-user .webpi-message-body { flex: 0 1 auto; max-width: min(88%, 760px); padding: 10px 13px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-bg-secondary); }
-.webpi-message.is-user .webpi-role { text-align: right; }
-.webpi-role { margin-bottom: 4px; color: var(--color-text-muted); font-size: 10px; font-weight: 650; text-transform: uppercase; letter-spacing: .07em; }
 .webpi-content-parts > * + * { margin-top: 9px; }
 .webpi-detail { padding: 6px 9px; border-left: 2px solid var(--color-border); color: var(--color-text-muted); font-size: 11px; }
 .webpi-detail summary { cursor: pointer; user-select: none; font-weight: 600; }

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -38,6 +38,7 @@ import {
   listAgents,
   listTemplates,
   listWorkspaces,
+  openWebPiSession as apiOpenWebPiSession,
   openResumeSession,
   pauseSession as apiPauseSession,
   quickChat as apiQuickChat,
@@ -149,6 +150,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
           createdAt: nowIso,
           lastActiveAt: nowIso,
           state: 'running',
+          surface: 'terminal',
           resumeId: sess.resumeId,
           pid: sess.pid,
           startedAt: sess.startedAt,
@@ -194,6 +196,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
           nextSession = {
             ...session,
             state: 'running',
+            surface: 'terminal',
             pid: resumed.pid,
             startedAt: resumed.startedAt,
             resumeId: resumed.resumeId ?? session.resumeId,
@@ -238,6 +241,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         createdAt: nowIso,
         lastActiveAt: nowIso,
         state: 'running',
+        surface: 'terminal',
         resumeId: session.resumeId,
         pid: session.pid,
         startedAt: session.startedAt,
@@ -293,6 +297,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         setWorkspaces((prev) =>
           patchSession(prev, wsId, sessionId, {
             state: 'running',
+            surface: 'terminal',
             pid: resp.pid,
             startedAt: resp.startedAt,
             lastActiveAt: new Date().toISOString(),
@@ -310,6 +315,27 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
       void refresh()
     },
     [refresh, openOrFocus, terminalTheme],
+  )
+
+  const openWebPiSession = useCallback(
+    async (wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void> => {
+      const snapshot = await apiOpenWebPiSession(wsId, sessionId)
+      setWorkspaces((prev) =>
+        patchSession(prev, wsId, sessionId, {
+          state: 'running',
+          surface: 'webpi',
+          pid: snapshot.pid,
+          startedAt: snapshot.startedAt,
+          lastActiveAt: new Date().toISOString(),
+        }),
+      )
+      openOrFocus({
+        kind: 'workspace',
+        params: { wsId, sessionId, ...(source ? { source } : {}) },
+      })
+      void refresh()
+    },
+    [openOrFocus, refresh],
   )
 
   const saveWorkspaceMetadata = useCallback(
@@ -386,6 +412,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         quickChat,
         pauseSession,
         resumeSession,
+        openWebPiSession,
         requestDeleteSession,
         openAgentConfig: (wsId: string, agent?: AgentId) =>
           setConfiguringAgentTarget({ wsId, ...(agent ? { agent } : {}) }),

--- a/ui/src/contexts/workspaces-context.ts
+++ b/ui/src/contexts/workspaces-context.ts
@@ -33,6 +33,7 @@ export interface WorkspacesContextValue {
   quickChat(prompt: string, agent?: string, credentialSlug?: string, targetWsId?: string): Promise<string>
   pauseSession(wsId: string, sessionId: string): Promise<void>
   resumeSession(wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void>
+  openWebPiSession(wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void>
   requestDeleteSession(wsId: string, sessionId: string): void
   openAgentConfig(wsId: string, agent?: AgentId): void
   saveWorkspaceMetadata(

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -142,10 +142,10 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   const { quickChat, agents, workspaces, defaultAgent, setDefaultAgent } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
 
-  // Targeted launch: the chat sidebar's per-workspace "+" routes here with a
-  // targetWsId — "Ask Alice, but spawn the session in THIS workspace" rather
-  // than the recent Chat workspace. Same composer; the send just
-  // carries the target.
+  // Targeted launch: the chat sidebar's Workspace row and per-workspace "+"
+  // route here with a targetWsId — "Ask Alice, but spawn the session in THIS
+  // workspace" rather than the recent Chat workspace. Same composer; the send
+  // just carries the target.
   const targetWsId = spec.params.targetWsId
   const targetWs = targetWsId ? workspaces.find((w) => w.id === targetWsId) : undefined
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null)

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Plus } from 'lucide-react'
+import { Bot, Monitor, Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import '@xterm/xterm/css/xterm.css'
 
@@ -136,6 +136,25 @@ export function WorkspacePage({ spec, visible }: Props) {
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-bg-secondary/30 shrink-0">
         <span className="text-[12px] text-text-muted font-medium">{workspace.tag}</span>
         <div className="flex items-center gap-1">
+          {activeRecord?.agent === 'pi' && activeRecord.state === 'running' && (
+            <button
+              type="button"
+              onClick={() => {
+                if ((activeRecord.surface ?? 'terminal') === 'webpi') {
+                  void ctx.resumeSession(wsId, activeRecord.id, source)
+                } else {
+                  void ctx.openWebPiSession(wsId, activeRecord.id, source)
+                }
+              }}
+              className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
+              title={(activeRecord.surface ?? 'terminal') === 'webpi' ? 'Open this Pi Session in the terminal' : 'Open this Pi Session in WebPi'}
+            >
+              {(activeRecord.surface ?? 'terminal') === 'webpi'
+                ? <Monitor size={13} strokeWidth={2.25} aria-hidden="true" />
+                : <Bot size={13} strokeWidth={2.25} aria-hidden="true" />}
+              {(activeRecord.surface ?? 'terminal') === 'webpi' ? 'Open TUI' : 'WebPi · Beta'}
+            </button>
+          )}
           <div ref={spawnMenuRef} className="relative">
             <button
               type="button"
@@ -200,6 +219,7 @@ export function WorkspacePage({ spec, visible }: Props) {
           keyMap={keyMap}
           onSpawnFresh={spawnDefault}
           onResume={(id) => void ctx.resumeSession(wsId, id, source)}
+          onOpenWebPi={(id) => void ctx.openWebPiSession(wsId, id, source)}
           onSelectSession={(id) => {
             // Running session — already alive on the server, just
             // navigate. Mirrors the sidebar's onSelectSession path.


### PR DESCRIPTION
## What this changes

WebPi is a second presentation of an existing Pi Session, not a new agent runtime.

- opens the same OpenAlice resumeId and native Pi session in Pi RPC mode
- renders Pi messages directly in a normal browser chat view
- keeps TUI and WebPi mutually exclusive for one Session
- supports switching TUI -> WebPi -> TUI without losing history
- persists only the selected surface; Pi remains the conversation store
- closes WebPi on pause, delete, Workspace offboarding, and app shutdown
- leaves every non-Pi adapter untouched through an optional adapter hook

## Deliberate boundaries

- no OpenAlice MessageBlock translation layer
- no new approval subsystem
- no sixth runtime named WebPi
- no merge: this is an experimental review and dogfood PR

## Verification

- real chat-jul10 Pi p3 session opened with the Meituan LongCat workspace credential
- two-turn continuity marker survived in WebPi
- marker survived WebPi -> TUI -> WebPi switching
- TUI resumed with the unchanged pi --session-id command
- backend reload safely returned WebPi to paused state without a residual process
- 2,659 tests passed, 6 skipped
- UI production build and root TypeScript check passed
- Electron build and signed arm64 directory package passed
- desktop package resource assertion passed with managed Pi 0.80.6
- Electron IPC PTY and Workspace CLI socket smoke passed