### PR TITLE
Bundle verified fd and ripgrep for managed Pi

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -34,15 +34,15 @@ import {
   type RuntimeProcessLock,
 } from '@traderalice/guardian-runtime'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
-import { existsSync, statSync } from 'node:fs'
 import { mkdir, readFile, watch, writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { homedir } from 'node:os'
-import { delimiter, dirname, join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { probeFreePort } from './probe-port.js'
 import { relocateLegacyData } from './relocate-data.js'
 import { configureAutoUpdate } from './auto-update.js'
 import { fetchAliceWebRequest, handleOpenAliceIpcMessage, registerOpenAliceIpc } from './ipc.js'
+import { resolveManagedRuntimeEnv } from './managed-runtime.js'
 import { proxyEnvFromRules } from './proxy-env.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -181,91 +181,6 @@ function truthyEnv(raw: string | undefined): boolean {
   if (raw === undefined || raw === '') return false
   const normalized = raw.toLowerCase()
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on'
-}
-
-function existingFile(path: string): string | null {
-  try {
-    return existsSync(path) && statSync(path).isFile() ? path : null
-  } catch {
-    return null
-  }
-}
-
-function existingDir(path: string): string | null {
-  try {
-    return existsSync(path) && statSync(path).isDirectory() ? path : null
-  } catch {
-    return null
-  }
-}
-
-function resolveManagedRuntimeEnv(opts: {
-  readonly appHome: string
-  readonly launcherMode: 'electron-dev' | 'electron-packaged'
-}): Record<string, string> {
-  const out: Record<string, string> = {
-    OPENALICE_RUNTIME_PROFILE: opts.launcherMode,
-  }
-  const platformArch = `${process.platform}-${process.arch}`
-
-  const managedPiCli = existingFile(join(
-    opts.appHome,
-    'vendor',
-    'pi',
-    'node_modules',
-    '@earendil-works',
-    'pi-coding-agent',
-    'dist',
-    'cli.js',
-  ))
-  const managedPiBinary = existingFile(join(
-    opts.appHome,
-    'vendor',
-    'pi',
-    platformArch,
-    process.platform === 'win32' ? 'pi.exe' : 'pi',
-  ))
-  if (managedPiCli) {
-    out.OPENALICE_MANAGED_PI_PATH = managedPiCli
-    out.OPENALICE_MANAGED_PI_NODE_PATH = process.execPath
-  } else if (managedPiBinary) {
-    out.OPENALICE_MANAGED_PI_PATH = managedPiBinary
-  }
-
-  const toolchainPaths: string[] = []
-  if (process.platform === 'win32') {
-    const gitDir = existingDir(join(opts.appHome, 'vendor', 'git', platformArch))
-    if (gitDir) {
-      out.OPENALICE_MANAGED_GIT_DIR = gitDir
-      out.LOCAL_GIT_DIRECTORY = gitDir
-
-      const gitBin =
-        existingFile(join(gitDir, 'cmd', 'git.exe')) ??
-        existingFile(join(gitDir, 'bin', 'git.exe')) ??
-        existingFile(join(gitDir, 'mingw64', 'bin', 'git.exe')) ??
-        existingFile(join(gitDir, 'clangarm64', 'bin', 'git.exe'))
-      if (gitBin) out.OPENALICE_MANAGED_GIT_BIN = gitBin
-
-      const shellPath =
-        existingFile(join(gitDir, 'bin', 'bash.exe')) ??
-        existingFile(join(gitDir, 'usr', 'bin', 'bash.exe'))
-      if (shellPath) out.OPENALICE_MANAGED_SHELL_PATH = shellPath
-
-      for (const rel of ['cmd', 'bin', 'usr/bin', 'mingw64/bin', 'clangarm64/bin']) {
-        const dir = existingDir(join(gitDir, ...rel.split('/')))
-        if (dir) toolchainPaths.push(dir)
-      }
-    }
-  } else if (opts.launcherMode === 'electron-packaged') {
-    const shellPath = existingFile('/bin/bash') ?? existingFile('/bin/sh')
-    if (shellPath) out.OPENALICE_MANAGED_SHELL_PATH = shellPath
-  }
-
-  if (toolchainPaths.length > 0) {
-    out.OPENALICE_MANAGED_TOOLCHAIN_PATH = toolchainPaths.join(delimiter)
-  }
-
-  return out
 }
 
 async function resolveChildProxyEnv(): Promise<Record<string, string>> {

--- a/apps/desktop/src/managed-runtime.spec.ts
+++ b/apps/desktop/src/managed-runtime.spec.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveManagedRuntimeEnv } from './managed-runtime.js'
+
+function touch(path: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, '')
+}
+
+describe('resolveManagedRuntimeEnv', () => {
+  it('publishes managed Pi and complete macOS search tools', () => {
+    const appHome = mkdtempSync(join(tmpdir(), 'openalice-managed-runtime-mac-'))
+    try {
+      const piCli = join(
+        appHome,
+        'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
+      )
+      const toolsBin = join(appHome, 'vendor/tools/darwin-arm64/bin')
+      touch(piCli)
+      touch(join(toolsBin, 'fd'))
+      touch(join(toolsBin, 'rg'))
+
+      const env = resolveManagedRuntimeEnv({
+        appHome,
+        launcherMode: 'electron-packaged',
+        platform: 'darwin',
+        arch: 'arm64',
+        execPath: '/Applications/OpenAlice.app/Contents/MacOS/OpenAlice',
+      })
+
+      expect(env.OPENALICE_MANAGED_PI_PATH).toBe(piCli)
+      expect(env.OPENALICE_MANAGED_PI_NODE_PATH).toContain('/Applications/OpenAlice.app')
+      expect(env.OPENALICE_MANAGED_TOOLCHAIN_PATH).toBe(toolsBin)
+    } finally {
+      rmSync(appHome, { recursive: true, force: true })
+    }
+  })
+
+  it('does not advertise a partial search tool payload', () => {
+    const appHome = mkdtempSync(join(tmpdir(), 'openalice-managed-runtime-partial-'))
+    try {
+      touch(join(appHome, 'vendor/tools/darwin-arm64/bin/fd'))
+
+      const env = resolveManagedRuntimeEnv({
+        appHome,
+        launcherMode: 'electron-dev',
+        platform: 'darwin',
+        arch: 'arm64',
+      })
+
+      expect(env.OPENALICE_MANAGED_TOOLCHAIN_PATH).toBeUndefined()
+    } finally {
+      rmSync(appHome, { recursive: true, force: true })
+    }
+  })
+
+  it('places Windows search tools before PortableGit directories', () => {
+    const appHome = mkdtempSync(join(tmpdir(), 'openalice-managed-runtime-win-'))
+    try {
+      const toolsBin = join(appHome, 'vendor/tools/win32-x64/bin')
+      const gitRoot = join(appHome, 'vendor/git/win32-x64')
+      touch(join(toolsBin, 'fd.exe'))
+      touch(join(toolsBin, 'rg.exe'))
+      touch(join(gitRoot, 'cmd/git.exe'))
+      touch(join(gitRoot, 'bin/bash.exe'))
+      mkdirSync(join(gitRoot, 'usr/bin'), { recursive: true })
+      mkdirSync(join(gitRoot, 'mingw64/bin'), { recursive: true })
+
+      const env = resolveManagedRuntimeEnv({
+        appHome,
+        launcherMode: 'electron-packaged',
+        platform: 'win32',
+        arch: 'x64',
+        execPath: 'C:\\OpenAlice\\OpenAlice.exe',
+      })
+
+      const toolchain = env.OPENALICE_MANAGED_TOOLCHAIN_PATH?.split(delimiter) ?? []
+      expect(toolchain[0]).toBe(toolsBin)
+      expect(toolchain).toContain(join(gitRoot, 'mingw64/bin'))
+      expect(env.OPENALICE_MANAGED_SHELL_PATH).toBe(join(gitRoot, 'bin/bash.exe'))
+    } finally {
+      rmSync(appHome, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/desktop/src/managed-runtime.ts
+++ b/apps/desktop/src/managed-runtime.ts
@@ -1,0 +1,115 @@
+import { existsSync, statSync } from 'node:fs'
+import { delimiter, join } from 'node:path'
+
+export interface ManagedRuntimeEnvOptions {
+  readonly appHome: string
+  readonly launcherMode: 'electron-dev' | 'electron-packaged'
+  readonly platform?: NodeJS.Platform
+  readonly arch?: NodeJS.Architecture
+  readonly execPath?: string
+}
+
+function existingFile(path: string): string | null {
+  try {
+    return existsSync(path) && statSync(path).isFile() ? path : null
+  } catch {
+    return null
+  }
+}
+
+function existingDir(path: string): string | null {
+  try {
+    return existsSync(path) && statSync(path).isDirectory() ? path : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Describe only the managed capabilities that are actually present in the
+ * application resource tree. The backend consumes these paths as one runtime
+ * profile and prepends the toolchain entries to every Workspace process.
+ */
+export function resolveManagedRuntimeEnv(opts: ManagedRuntimeEnvOptions): Record<string, string> {
+  const platform = opts.platform ?? process.platform
+  const arch = opts.arch ?? process.arch
+  const platformArch = `${platform}-${arch}`
+  const out: Record<string, string> = {
+    OPENALICE_RUNTIME_PROFILE: opts.launcherMode,
+  }
+
+  const managedPiCli = existingFile(join(
+    opts.appHome,
+    'vendor',
+    'pi',
+    'node_modules',
+    '@earendil-works',
+    'pi-coding-agent',
+    'dist',
+    'cli.js',
+  ))
+  const managedPiBinary = existingFile(join(
+    opts.appHome,
+    'vendor',
+    'pi',
+    platformArch,
+    platform === 'win32' ? 'pi.exe' : 'pi',
+  ))
+  if (managedPiCli) {
+    out.OPENALICE_MANAGED_PI_PATH = managedPiCli
+    out.OPENALICE_MANAGED_PI_NODE_PATH = opts.execPath ?? process.execPath
+  } else if (managedPiBinary) {
+    out.OPENALICE_MANAGED_PI_PATH = managedPiBinary
+  }
+
+  const toolchainPaths: string[] = []
+  const searchToolsBin = existingDir(join(
+    opts.appHome,
+    'vendor',
+    'tools',
+    platformArch,
+    'bin',
+  ))
+  const executableSuffix = platform === 'win32' ? '.exe' : ''
+  if (
+    searchToolsBin &&
+    existingFile(join(searchToolsBin, `fd${executableSuffix}`)) &&
+    existingFile(join(searchToolsBin, `rg${executableSuffix}`))
+  ) {
+    toolchainPaths.push(searchToolsBin)
+  }
+
+  if (platform === 'win32') {
+    const gitDir = existingDir(join(opts.appHome, 'vendor', 'git', platformArch))
+    if (gitDir) {
+      out.OPENALICE_MANAGED_GIT_DIR = gitDir
+      out.LOCAL_GIT_DIRECTORY = gitDir
+
+      const gitBin =
+        existingFile(join(gitDir, 'cmd', 'git.exe')) ??
+        existingFile(join(gitDir, 'bin', 'git.exe')) ??
+        existingFile(join(gitDir, 'mingw64', 'bin', 'git.exe')) ??
+        existingFile(join(gitDir, 'clangarm64', 'bin', 'git.exe'))
+      if (gitBin) out.OPENALICE_MANAGED_GIT_BIN = gitBin
+
+      const shellPath =
+        existingFile(join(gitDir, 'bin', 'bash.exe')) ??
+        existingFile(join(gitDir, 'usr', 'bin', 'bash.exe'))
+      if (shellPath) out.OPENALICE_MANAGED_SHELL_PATH = shellPath
+
+      for (const rel of ['cmd', 'bin', 'usr/bin', 'mingw64/bin', 'clangarm64/bin']) {
+        const dir = existingDir(join(gitDir, ...rel.split('/')))
+        if (dir) toolchainPaths.push(dir)
+      }
+    }
+  } else if (opts.launcherMode === 'electron-packaged') {
+    const shellPath = existingFile('/bin/bash') ?? existingFile('/bin/sh')
+    if (shellPath) out.OPENALICE_MANAGED_SHELL_PATH = shellPath
+  }
+
+  if (toolchainPaths.length > 0) {
+    out.OPENALICE_MANAGED_TOOLCHAIN_PATH = toolchainPaths.join(delimiter)
+  }
+
+  return out
+}

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -37,6 +37,7 @@ The app ships:
 
 - Electron's bundled Node runtime;
 - the pinned managed Pi npm runtime under `vendor/pi/`;
+- pinned `fd` and `ripgrep` binaries under `vendor/tools/darwin-<arch>/`;
 - the existing packaged Git path used by Workspace bootstrap.
 
 Pi uses `/bin/bash` when available and falls back to `/bin/sh`. The packaged
@@ -49,6 +50,7 @@ The app ships:
 
 - Electron's bundled Node runtime;
 - the same pinned managed Pi npm runtime;
+- pinned `fd` and `ripgrep` binaries under `vendor/tools/win32-<arch>/`;
 - a pinned PortableGit payload under `vendor/git/<platform>-<arch>/`, including
   `git.exe`, `bash.exe`, `sh.exe`, and the command-line tools Pi needs.
 
@@ -113,12 +115,19 @@ machine-local preference remains the source of truth.
 - downloads Pi's pinned install package and lockfile;
 - verifies their checksums;
 - runs an isolated `npm ci --omit=dev` under `vendor/pi/`;
+- downloads the platform's pinned `fd` and `ripgrep` archives, verifies their
+  release checksums, and retains their license files;
+- publishes both search binaries from one shared `vendor/tools/<platform>-<arch>/bin`
+  directory so Pi never needs a per-Workspace tool download;
 - downloads and verifies PortableGit on supported Windows targets;
 - extracts it into the deterministic `vendor/git/<platform>-<arch>/` path;
 - writes `vendor/manifest.json` with versions, paths, and toolchain entries.
 
 `pnpm electron:pack` runs this through `pnpm vendor:runtime`. The desktop
 builder keeps `asar` disabled and includes `vendor/**` in the packaged files.
+Contributors who run `pnpm vendor:runtime` also get the generated search-tool
+directory on `pnpm dev`'s managed PATH; dev startup never downloads or mutates
+that payload implicitly.
 
 ### 2. Resolve packaged capabilities
 
@@ -132,7 +141,7 @@ OPENALICE_MANAGED_PI_NODE_PATH=/.../OpenAlice(.exe)
 OPENALICE_MANAGED_GIT_DIR=/.../vendor/git/win32-x64
 OPENALICE_MANAGED_GIT_BIN=/.../vendor/git/win32-x64/cmd/git.exe
 OPENALICE_MANAGED_SHELL_PATH=/.../vendor/git/win32-x64/bin/bash.exe
-OPENALICE_MANAGED_TOOLCHAIN_PATH=/.../cmd:/.../bin:/.../usr/bin
+OPENALICE_MANAGED_TOOLCHAIN_PATH=/.../vendor/tools/win32-x64/bin:/.../cmd:/.../bin:/.../usr/bin
 LOCAL_GIT_DIRECTORY=/.../vendor/git/win32-x64
 ```
 
@@ -211,6 +220,11 @@ Keep these true together:
   incomplete package.
 - Pi and PortableGit versions, download URLs, and checksums remain pinned in
   `scripts/vendor-managed-runtime.mjs`.
+- Managed `fd` and `ripgrep` versions, release URLs, checksums, binaries, and
+  license files remain pinned together in `scripts/vendor-managed-runtime.mjs`.
+- Pi remains network-capable. The managed search tools prevent its normal
+  startup probe from downloading a separate copy into each redirected
+  `PI_CODING_AGENT_DIR`; they do not force `PI_OFFLINE` or patch Pi itself.
 - Every packaged Workspace CLI includes the shared `openalice-cli.cjs` payload,
   its POSIX launcher, and its Windows `.cmd` twin; packaged smoke must execute
   the payload through Electron Node.

--- a/scripts/assert-desktop-package.mjs
+++ b/scripts/assert-desktop-package.mjs
@@ -54,7 +54,7 @@ export function assertDesktopPackage(options = {}) {
 
   const platform = options.platform ?? platformFromAppRoot(appRoot)
   const arch = options.arch ?? process.arch
-  const platformArch = platform === 'win32' ? `win32-${arch}` : null
+  const platformArch = `${platform}-${arch}`
   const requiredFiles = [...BASE_REQUIRED_FILES, ...platformRequiredFiles(platform, platformArch)]
   const missing = requiredFiles.filter((file) => !existsSync(join(appRoot, file)))
   if (missing.length > 0) {
@@ -78,7 +78,30 @@ export function assertDesktopPackage(options = {}) {
     errors.push(`[desktop-package] unexpected manifest.pi.cli: ${JSON.stringify(manifest?.pi?.cli)}`)
   }
 
-  if (platform === 'win32' && platformArch) {
+  if (platform === 'win32' || platform === 'darwin') {
+    const searchTools = manifest?.searchTools?.[platformArch]
+    if (!searchTools) {
+      errors.push(`[desktop-package] expected manifest.searchTools.${platformArch} for managed fd/rg`)
+    } else {
+      if (searchTools.path !== `vendor/tools/${platformArch}`) {
+        errors.push(
+          `[desktop-package] unexpected manifest.searchTools.${platformArch}.path: ${JSON.stringify(searchTools.path)}`,
+        )
+      }
+      if (normalizeManifestPath(searchTools.fd?.binary) !== `bin/fd${platform === 'win32' ? '.exe' : ''}`) {
+        errors.push(
+          `[desktop-package] unexpected manifest.searchTools.${platformArch}.fd.binary: ${JSON.stringify(searchTools.fd?.binary)}`,
+        )
+      }
+      if (normalizeManifestPath(searchTools.rg?.binary) !== `bin/rg${platform === 'win32' ? '.exe' : ''}`) {
+        errors.push(
+          `[desktop-package] unexpected manifest.searchTools.${platformArch}.rg.binary: ${JSON.stringify(searchTools.rg?.binary)}`,
+        )
+      }
+    }
+  }
+
+  if (platform === 'win32') {
     const git = manifest?.git?.[platformArch]
     if (!git) {
       errors.push(`[desktop-package] expected manifest.git.${platformArch} for Windows managed Git Bash`)
@@ -110,12 +133,24 @@ export function platformFromAppRoot(appRoot) {
 }
 
 function platformRequiredFiles(platform, platformArch) {
-  if (platform !== 'win32' || !platformArch) return []
-  return [
-    `vendor/git/${platformArch}/cmd/git.exe`,
-    `vendor/git/${platformArch}/bin/bash.exe`,
-    `vendor/git/${platformArch}/bin/sh.exe`,
-  ]
+  const searchTools = platform === 'win32' || platform === 'darwin'
+    ? [
+        `vendor/tools/${platformArch}/bin/fd${platform === 'win32' ? '.exe' : ''}`,
+        `vendor/tools/${platformArch}/bin/rg${platform === 'win32' ? '.exe' : ''}`,
+        `vendor/tools/${platformArch}/licenses/fd/LICENSE-APACHE`,
+        `vendor/tools/${platformArch}/licenses/fd/LICENSE-MIT`,
+        `vendor/tools/${platformArch}/licenses/rg/LICENSE-MIT`,
+        `vendor/tools/${platformArch}/licenses/rg/UNLICENSE`,
+      ]
+    : []
+  const git = platform === 'win32'
+    ? [
+        `vendor/git/${platformArch}/cmd/git.exe`,
+        `vendor/git/${platformArch}/bin/bash.exe`,
+        `vendor/git/${platformArch}/bin/sh.exe`,
+      ]
+    : []
+  return [...searchTools, ...git]
 }
 
 function normalizeManifestPath(value) {
@@ -130,6 +165,12 @@ function main() {
   }
   console.log(`[desktop-package] app resources OK: ${relative(repoRoot, result.appRoot)}`)
   console.log(`[desktop-package] managed Pi: ${result.manifest.pi.version} (${result.manifest.pi.mode})`)
+  if (result.platform === 'win32' || result.platform === 'darwin') {
+    const tools = result.manifest.searchTools[result.platformArch]
+    console.log(
+      `[desktop-package] managed fd/rg: ${tools.fd.version}/${tools.rg.version} (${result.platformArch})`,
+    )
+  }
   if (result.platform === 'win32') {
     const git = result.manifest.git[result.platformArch]
     console.log(`[desktop-package] managed Git Bash: ${git.version} (${result.platformArch})`)

--- a/scripts/assert-desktop-package.spec.ts
+++ b/scripts/assert-desktop-package.spec.ts
@@ -32,12 +32,38 @@ function piManifest() {
   }
 }
 
+function searchToolsManifest(platformArch: string, windows = false) {
+  return {
+    searchTools: {
+      [platformArch]: {
+        path: `vendor/tools/${platformArch}`,
+        binPath: 'bin',
+        fd: {
+          version: windows || platformArch.endsWith('arm64') ? '10.4.2' : '10.3.0',
+          binary: `bin/fd${windows ? '.exe' : ''}`,
+        },
+        rg: { version: '15.1.0', binary: `bin/rg${windows ? '.exe' : ''}` },
+      },
+    },
+  }
+}
+
+function writeSearchToolFiles(appRoot: string, platformArch: string, windows = false) {
+  writePackageFile(appRoot, `vendor/tools/${platformArch}/bin/fd${windows ? '.exe' : ''}`)
+  writePackageFile(appRoot, `vendor/tools/${platformArch}/bin/rg${windows ? '.exe' : ''}`)
+  writePackageFile(appRoot, `vendor/tools/${platformArch}/licenses/fd/LICENSE-APACHE`)
+  writePackageFile(appRoot, `vendor/tools/${platformArch}/licenses/fd/LICENSE-MIT`)
+  writePackageFile(appRoot, `vendor/tools/${platformArch}/licenses/rg/LICENSE-MIT`)
+  writePackageFile(appRoot, `vendor/tools/${platformArch}/licenses/rg/UNLICENSE`)
+}
+
 describe('assertDesktopPackage', () => {
-  it('does not require vendor Git in macOS packages', () => {
+  it('requires managed search tools but not vendor Git in macOS packages', () => {
     const root = mkdtempSync(join(tmpdir(), 'openalice-package-mac-'))
     try {
       const appRoot = join(root, 'mac-arm64/OpenAlice.app/Contents/Resources/app')
-      writeBasePackage(appRoot, piManifest())
+      writeBasePackage(appRoot, { ...piManifest(), ...searchToolsManifest('darwin-arm64') })
+      writeSearchToolFiles(appRoot, 'darwin-arm64')
 
       const result = assertDesktopPackage({ packageRoot: root, repoRoot: root, arch: 'arm64' })
 
@@ -57,6 +83,8 @@ describe('assertDesktopPackage', () => {
       const result = assertDesktopPackage({ packageRoot: root, repoRoot: root, arch: 'x64' })
 
       expect(result.ok).toBe(false)
+      expect(result.errors.join('\n')).toContain('vendor/tools/win32-x64/bin/fd.exe')
+      expect(result.errors.join('\n')).toContain('expected manifest.searchTools.win32-x64')
       expect(result.errors.join('\n')).toContain('vendor/git/win32-x64/cmd/git.exe')
       expect(result.errors.join('\n')).toContain('vendor/git/win32-x64/bin/bash.exe')
       expect(result.errors.join('\n')).toContain('expected manifest.git.win32-x64')
@@ -71,6 +99,7 @@ describe('assertDesktopPackage', () => {
       const appRoot = join(root, 'win-unpacked/resources/app')
       writeBasePackage(appRoot, {
         ...piManifest(),
+        ...searchToolsManifest('win32-x64', true),
         git: {
           'win32-x64': {
             version: '2.55.0.2',
@@ -84,6 +113,7 @@ describe('assertDesktopPackage', () => {
       writePackageFile(appRoot, 'vendor/git/win32-x64/cmd/git.exe')
       writePackageFile(appRoot, 'vendor/git/win32-x64/bin/bash.exe')
       writePackageFile(appRoot, 'vendor/git/win32-x64/bin/sh.exe')
+      writeSearchToolFiles(appRoot, 'win32-x64', true)
 
       const result = assertDesktopPackage({ packageRoot: root, repoRoot: root, arch: 'x64' })
 

--- a/scripts/guardian/dev.ts
+++ b/scripts/guardian/dev.ts
@@ -14,7 +14,7 @@
  * Replaces the previous `scripts/dev.ts`. Same `pnpm dev` UX.
  */
 
-import { resolve } from 'node:path'
+import { delimiter, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { existsSync } from 'node:fs'
 import type { ChildProcess } from 'node:child_process'
@@ -113,6 +113,21 @@ async function main(): Promise<void> {
   const flagPath = resolve(dataHome, 'data/control/restart-uta.flag')
   const utaUrl = `http://127.0.0.1:${ports.utaPort}`
   const backendHotReload = isBackendHotReloadEnabled(process.env)
+  const managedSearchToolsBin = resolve(
+    process.cwd(),
+    'vendor',
+    'tools',
+    `${process.platform}-${process.arch}`,
+    'bin',
+  )
+  const searchToolSuffix = process.platform === 'win32' ? '.exe' : ''
+  const hasManagedSearchTools = ['fd', 'rg'].every((name) => (
+    existsSync(resolve(managedSearchToolsBin, `${name}${searchToolSuffix}`))
+  ))
+  const managedToolchainPath = [
+    ...(hasManagedSearchTools ? [managedSearchToolsBin] : []),
+    ...(process.env['OPENALICE_MANAGED_TOOLCHAIN_PATH'] ?? '').split(delimiter).filter(Boolean),
+  ].join(delimiter)
 
   console.log('')
   console.log(`[guardian] mode     →  ${initialMode.mode} (${initialMode.source}${initialMode.envLocked ? ', env-locked' : ''})`)
@@ -137,6 +152,7 @@ async function main(): Promise<void> {
     OPENALICE_LAUNCHER: 'dev',
     OPENALICE_GUARDIAN_PID: String(process.pid),
     OPENALICE_GUARDIAN_STARTED_AT: String(guardianStartedAt),
+    ...(managedToolchainPath ? { OPENALICE_MANAGED_TOOLCHAIN_PATH: managedToolchainPath } : {}),
     ...(takeover ? { OPENALICE_TAKEOVER: '1' } : {}),
   }
 

--- a/scripts/smoke-packaged-toolchain.mjs
+++ b/scripts/smoke-packaged-toolchain.mjs
@@ -36,6 +36,64 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
     expectStdout: /\b0\.80\.6\b/,
   })
 
+  const searchTools = packageResult.manifest.searchTools?.[packageResult.platformArch]
+  if ((packageResult.platform === 'win32' || packageResult.platform === 'darwin') && !searchTools) {
+    errors.push(`[packaged-toolchain] missing managed fd/rg manifest entry ${packageResult.platformArch}`)
+    return { ok: false, errors, commands }
+  }
+  let searchToolsBin = null
+  if (searchTools) {
+    const searchToolsRoot = join(packageResult.appRoot, searchTools.path)
+    searchToolsBin = join(searchToolsRoot, searchTools.binPath)
+    const searchToolsEnv = {
+      PATH: [searchToolsBin, process.env['PATH']].filter(Boolean).join(delimiter),
+    }
+    commands.push({
+      label: 'managed fd',
+      command: join(searchToolsRoot, searchTools.fd.binary),
+      args: ['--version'],
+      expectStdout: /^fd \d+\.\d+\.\d+/m,
+    })
+    commands.push({
+      label: 'managed ripgrep',
+      command: join(searchToolsRoot, searchTools.rg.binary),
+      args: ['--version'],
+      expectStdout: /^ripgrep \d+\.\d+\.\d+/m,
+    })
+
+    // Pi's interactive startup calls getToolPath("fd"/"rg") before rendering
+    // the TUI. Point its private agent dir at a missing location so this proves
+    // the packaged PATH satisfies both probes without touching a Workspace or
+    // entering Pi's download/cache path.
+    const piToolsManager = join(
+      packageResult.appRoot,
+      'vendor',
+      'pi',
+      'node_modules',
+      '@earendil-works',
+      'pi-coding-agent',
+      'dist',
+      'utils',
+      'tools-manager.js',
+    )
+    const piProbe = [
+      `import(${JSON.stringify(pathToFileURL(piToolsManager).href)})`,
+      '.then((m) => console.log("OPENALICE_PI_SEARCH_TOOLS_OK " + m.getToolPath("fd") + " " + m.getToolPath("rg")))',
+      '.catch((err) => { console.error(err); process.exit(1) })',
+    ].join('')
+    commands.push({
+      label: 'managed Pi resolves packaged fd/rg without download',
+      command: electron,
+      args: ['-e', piProbe],
+      env: {
+        ...searchToolsEnv,
+        ELECTRON_RUN_AS_NODE: '1',
+        PI_CODING_AGENT_DIR: join(packageResult.appRoot, '.missing-smoke-pi-agent'),
+      },
+      expectStdout: /OPENALICE_PI_SEARCH_TOOLS_OK fd rg/,
+    })
+  }
+
   commands.push({
     label: 'workspace CLI payload through packaged Electron Node',
     command: electron,
@@ -63,7 +121,9 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
       .map((entry) => join(gitRoot, entry))
       .join(delimiter)
     const winEnv = {
-      PATH: [workspaceCliDir, toolchainPath, process.env['PATH']].filter(Boolean).join(delimiter),
+      PATH: [workspaceCliDir, searchToolsBin, toolchainPath, process.env['PATH']]
+        .filter(Boolean)
+        .join(delimiter),
       CHERE_INVOKING: '1',
       MSYSTEM: packageResult.platformArch.endsWith('arm64') ? 'CLANGARM64' : 'MINGW64',
       OPENALICE_MANAGED_PI_NODE_PATH: electron,

--- a/scripts/smoke-packaged-toolchain.spec.ts
+++ b/scripts/smoke-packaged-toolchain.spec.ts
@@ -25,10 +25,18 @@ describe('buildPackagedToolchainSmokePlan', () => {
         errors: [],
         appRoot,
         platform: 'darwin',
-        platformArch: null,
+        platformArch: 'darwin-arm64',
         manifest: {
           pi: {
             cli: 'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
+          },
+          searchTools: {
+            'darwin-arm64': {
+              path: 'vendor/tools/darwin-arm64',
+              binPath: 'bin',
+              fd: { binary: 'bin/fd' },
+              rg: { binary: 'bin/rg' },
+            },
           },
         },
       })
@@ -37,6 +45,9 @@ describe('buildPackagedToolchainSmokePlan', () => {
       expect(plan.commands.map((command) => command.label)).toEqual([
         'packaged Electron Node mode',
         'managed Pi through packaged Electron Node',
+        'managed fd',
+        'managed ripgrep',
+        'managed Pi resolves packaged fd/rg without download',
         'workspace CLI payload through packaged Electron Node',
       ])
       expect(packagedElectronExecutable(appRoot, 'darwin')?.replaceAll('\\', '/'))
@@ -61,6 +72,14 @@ describe('buildPackagedToolchainSmokePlan', () => {
           pi: {
             cli: 'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
           },
+          searchTools: {
+            'win32-x64': {
+              path: 'vendor/tools/win32-x64',
+              binPath: 'bin',
+              fd: { binary: 'bin/fd.exe' },
+              rg: { binary: 'bin/rg.exe' },
+            },
+          },
           git: {
             'win32-x64': {
               path: 'vendor/git/win32-x64',
@@ -77,6 +96,9 @@ describe('buildPackagedToolchainSmokePlan', () => {
       expect(plan.commands.map((command) => command.label)).toEqual([
         'packaged Electron Node mode',
         'managed Pi through packaged Electron Node',
+        'managed fd',
+        'managed ripgrep',
+        'managed Pi resolves packaged fd/rg without download',
         'workspace CLI payload through packaged Electron Node',
         'managed git.exe',
         'managed bash.exe',
@@ -84,11 +106,13 @@ describe('buildPackagedToolchainSmokePlan', () => {
         'Workspace CLI launcher through managed Git Bash',
         'Workspace CLI transport env through managed Git Bash',
       ])
-      expect(plan.commands[3].command.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/cmd/git.exe')
-      expect(plan.commands[5].env?.PATH.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/mingw64/bin')
-      expect(plan.commands[6].env?.OPENALICE_MANAGED_PI_NODE_PATH.replaceAll('\\', '/'))
+      expect(plan.commands[2].command.replaceAll('\\', '/')).toContain('vendor/tools/win32-x64/bin/fd.exe')
+      expect(plan.commands[6].command.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/cmd/git.exe')
+      expect(plan.commands[8].env?.PATH.replaceAll('\\', '/')).toContain('vendor/git/win32-x64/mingw64/bin')
+      expect(plan.commands[8].env?.PATH.replaceAll('\\', '/')).toContain('vendor/tools/win32-x64/bin')
+      expect(plan.commands[9].env?.OPENALICE_MANAGED_PI_NODE_PATH.replaceAll('\\', '/'))
         .toContain('win-unpacked/OpenAlice.exe')
-      expect(plan.commands[7].env?.OPENALICE_TOOL_URL).toBe('/cli')
+      expect(plan.commands[10].env?.OPENALICE_TOOL_URL).toBe('/cli')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/scripts/vendor-managed-runtime.mjs
+++ b/scripts/vendor-managed-runtime.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { chmod, copyFile, mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, dirname, relative, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -55,13 +55,106 @@ const WINDOWS_GIT_RUNTIMES = {
   },
 }
 
+const MANAGED_SEARCH_TOOL_RUNTIMES = {
+  'darwin-arm64': searchToolRuntime('darwin', 'arm64', {
+    fd: releaseAsset({
+      id: 'fd',
+      version: '10.4.2',
+      binaryName: 'fd',
+      url: 'https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-aarch64-apple-darwin.tar.gz',
+      sha256: '623dc0afc81b92e4d4606b380d7bc91916ba7b97814263e554d50923a39e480a',
+      licenses: ['LICENSE-APACHE', 'LICENSE-MIT'],
+    }),
+    rg: releaseAsset({
+      id: 'rg',
+      version: '15.1.0',
+      binaryName: 'rg',
+      url: 'https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-aarch64-apple-darwin.tar.gz',
+      sha256: '378e973289176ca0c6054054ee7f631a065874a352bf43f0fa60ef079b6ba715',
+      licenses: ['LICENSE-MIT', 'UNLICENSE'],
+    }),
+  }),
+  'darwin-x64': searchToolRuntime('darwin', 'x64', {
+    // fd 10.4.x no longer publishes an Intel macOS asset.
+    fd: releaseAsset({
+      id: 'fd',
+      version: '10.3.0',
+      binaryName: 'fd',
+      url: 'https://github.com/sharkdp/fd/releases/download/v10.3.0/fd-v10.3.0-x86_64-apple-darwin.tar.gz',
+      sha256: '50d30f13fe3d5914b14c4fff5abcbd4d0cdab4b855970a6956f4f006c17117a3',
+      licenses: ['LICENSE-APACHE', 'LICENSE-MIT'],
+    }),
+    rg: releaseAsset({
+      id: 'rg',
+      version: '15.1.0',
+      binaryName: 'rg',
+      url: 'https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-apple-darwin.tar.gz',
+      sha256: '64811cb24e77cac3057d6c40b63ac9becf9082eedd54ca411b475b755d334882',
+      licenses: ['LICENSE-MIT', 'UNLICENSE'],
+    }),
+  }),
+  'win32-x64': searchToolRuntime('win32', 'x64', {
+    fd: releaseAsset({
+      id: 'fd',
+      version: '10.4.2',
+      binaryName: 'fd.exe',
+      url: 'https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-x86_64-pc-windows-msvc.zip',
+      sha256: 'b2816e506390a89941c63c9187d58a3cc10e9a55f2ef0685f9ea0eccaf7c98c8',
+      licenses: ['LICENSE-APACHE', 'LICENSE-MIT'],
+    }),
+    rg: releaseAsset({
+      id: 'rg',
+      version: '15.1.0',
+      binaryName: 'rg.exe',
+      url: 'https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-pc-windows-msvc.zip',
+      sha256: '124510b94b6baa3380d051fdf4650eaa80a302c876d611e9dba0b2e18d87493a',
+      licenses: ['LICENSE-MIT', 'UNLICENSE'],
+    }),
+  }),
+  'win32-arm64': searchToolRuntime('win32', 'arm64', {
+    fd: releaseAsset({
+      id: 'fd',
+      version: '10.4.2',
+      binaryName: 'fd.exe',
+      url: 'https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-aarch64-pc-windows-msvc.zip',
+      sha256: '4f9110c2d5b33a7f760bfa5510f4c113d828109f7277d421b1053a9943c0fc92',
+      licenses: ['LICENSE-APACHE', 'LICENSE-MIT'],
+    }),
+    rg: releaseAsset({
+      id: 'rg',
+      version: '15.1.0',
+      binaryName: 'rg.exe',
+      url: 'https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-aarch64-pc-windows-msvc.zip',
+      sha256: '00d931fb5237c9696ca49308818edb76d8eb6fc132761cb2a1bd616b2df02f8e',
+      licenses: ['LICENSE-MIT', 'UNLICENSE'],
+    }),
+  }),
+}
+
+function releaseAsset(spec) {
+  return spec
+}
+
+function searchToolRuntime(platform, arch, tools) {
+  const platformArch = `${platform}-${arch}`
+  return {
+    platform,
+    arch,
+    platformArch,
+    root: `vendor/tools/${platformArch}`,
+    binPath: 'bin',
+    licensesPath: 'licenses',
+    tools,
+  }
+}
+
 function printHelp() {
   console.log(`Usage: pnpm vendor:runtime [options]
 
 Prepare managed workspace runtimes under vendor/.
 
 Options:
-  --force    Remove and reinstall vendor/pi even if it already matches
+  --force    Reinstall managed runtimes even if they already match
   -h, --help Show this help
 `)
 }
@@ -70,8 +163,9 @@ async function main() {
   parseArgs(process.argv.slice(2))
   await mkdir(vendorRoot, { recursive: true })
   await vendorPi()
+  const searchToolsSpec = await vendorManagedSearchTools()
   const gitSpec = await vendorWindowsGit()
-  await writeManifest(gitSpec)
+  await writeManifest(gitSpec, searchToolsSpec)
 }
 
 function parseArgs(argv) {
@@ -167,11 +261,128 @@ async function vendorWindowsGit() {
   return spec
 }
 
-async function download(url) {
-  console.log(`[vendor-runtime] download ${url}`)
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`${url} returned HTTP ${res.status}`)
-  return Buffer.from(await res.arrayBuffer())
+async function vendorManagedSearchTools() {
+  const spec = resolveManagedSearchToolsSpec()
+  if (!spec) {
+    console.log(`[vendor-runtime] managed fd/rg skipped on unsupported ${process.platform}-${process.arch} host`)
+    return null
+  }
+
+  const existingManifest = readManifest()
+  const existing = existingManifest?.searchTools?.[spec.platformArch]
+  const isCurrent = Object.values(spec.tools).every((tool) => (
+    existing?.[tool.id]?.version === tool.version &&
+    existing?.[tool.id]?.sha256 === tool.sha256
+  ))
+  if (
+    !force &&
+    isCurrent &&
+    requiredManagedSearchToolFiles(spec).every((file) => existsSync(resolve(repoRoot, spec.root, file)))
+  ) {
+    console.log(`[vendor-runtime] managed fd/rg already present at ${spec.root}`)
+    return spec
+  }
+
+  const toolsParent = resolve(vendorRoot, 'tools')
+  const finalRoot = resolve(repoRoot, spec.root)
+  await mkdir(toolsParent, { recursive: true })
+  let stagingRoot = await mkdtemp(resolve(toolsParent, `.${spec.platformArch}-`))
+  try {
+    const binDir = resolve(stagingRoot, spec.binPath)
+    await mkdir(binDir, { recursive: true })
+
+    for (const tool of Object.values(spec.tools)) {
+      const bytes = await download(tool.url)
+      verifySha256(bytes, tool.sha256, tool.url)
+
+      const extractRoot = await mkdtemp(resolve(tmpdir(), `openalice-${tool.id}-`))
+      const archivePath = resolve(extractRoot, basename(tool.url))
+      try {
+        await writeFile(archivePath, bytes)
+        extractArchive(tool.id, archivePath, extractRoot)
+
+        const binary = findFileRecursively(extractRoot, tool.binaryName)
+        if (!binary) throw new Error(`${tool.binaryName} missing after extracting ${tool.url}`)
+        const destination = resolve(binDir, tool.binaryName)
+        await copyFile(binary, destination)
+        if (spec.platform !== 'win32') await chmod(destination, 0o755)
+
+        const licenseDir = resolve(stagingRoot, spec.licensesPath, tool.id)
+        await mkdir(licenseDir, { recursive: true })
+        for (const licenseName of tool.licenses) {
+          const license = findFileRecursively(extractRoot, licenseName)
+          if (!license) throw new Error(`${licenseName} missing after extracting ${tool.url}`)
+          await copyFile(license, resolve(licenseDir, licenseName))
+        }
+      } finally {
+        await rm(extractRoot, { recursive: true, force: true })
+      }
+    }
+
+    const missing = requiredManagedSearchToolFiles(spec)
+      .filter((file) => !existsSync(resolve(stagingRoot, file)))
+    if (missing.length > 0) {
+      throw new Error(`managed fd/rg staging missing required files: ${missing.join(', ')}`)
+    }
+
+    await rm(finalRoot, { recursive: true, force: true })
+    await rename(stagingRoot, finalRoot)
+    stagingRoot = null
+    console.log(`[vendor-runtime] managed fd/rg -> ${relativeForLog(resolve(finalRoot, spec.binPath))}`)
+    return spec
+  } finally {
+    if (stagingRoot) await rm(stagingRoot, { recursive: true, force: true })
+  }
+}
+
+function extractArchive(toolId, archivePath, destination) {
+  if (archivePath.endsWith('.tar.gz')) {
+    run(`extract ${toolId}`, windowsTarCommand(), ['-xzf', archivePath, '-C', destination])
+    return
+  }
+  if (archivePath.endsWith('.zip')) {
+    run(`extract ${toolId}`, windowsTarCommand(), ['-xf', archivePath, '-C', destination])
+    return
+  }
+  throw new Error(`unsupported managed tool archive: ${archivePath}`)
+}
+
+function windowsTarCommand() {
+  if (process.platform !== 'win32') return 'tar'
+  const systemRoot = process.env['SystemRoot'] ?? process.env['WINDIR']
+  const systemTar = systemRoot ? resolve(systemRoot, 'System32', 'tar.exe') : null
+  return systemTar && existsSync(systemTar) ? systemTar : 'tar.exe'
+}
+
+function findFileRecursively(root, fileName) {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = resolve(root, entry.name)
+    if (entry.isFile() && entry.name === fileName) return path
+    if (entry.isDirectory()) {
+      const nested = findFileRecursively(path, fileName)
+      if (nested) return nested
+    }
+  }
+  return null
+}
+
+async function download(url, attempts = 3) {
+  let lastError = null
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    console.log(`[vendor-runtime] download ${url}${attempt > 1 ? ` (attempt ${attempt}/${attempts})` : ''}`)
+    try {
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`${url} returned HTTP ${res.status}`)
+      return Buffer.from(await res.arrayBuffer())
+    } catch (err) {
+      lastError = err
+      if (attempt < attempts) await new Promise((resolveDelay) => setTimeout(resolveDelay, attempt * 1_000))
+    }
+  }
+  const detail = lastError instanceof Error
+    ? `${lastError.message}${lastError.cause instanceof Error ? `: ${lastError.cause.message}` : ''}`
+    : String(lastError)
+  throw new Error(`failed to download ${url} after ${attempts} attempts: ${detail}`)
 }
 
 function verifySha256(bytes, expected, label) {
@@ -190,9 +401,11 @@ function run(label, command, commandArgs, opts = {}) {
     shell: opts.shell ?? false,
   })
   if (result.error) {
-    console.error(`[vendor-runtime] failed to start ${command}: ${result.error.message}`)
+    throw new Error(`${label} failed to start ${command}: ${result.error.message}`)
   }
-  if (result.status !== 0 || result.error) process.exit(result.status ?? 1)
+  if (result.status !== 0) {
+    throw new Error(`${label} exited ${result.status ?? 'unknown'}${result.signal ? ` (${result.signal})` : ''}`)
+  }
 }
 
 function readManifest() {
@@ -203,7 +416,7 @@ function readManifest() {
   }
 }
 
-export function buildVendorRuntimeManifest(gitSpec = null) {
+export function buildVendorRuntimeManifest(gitSpec = null, searchToolsSpec = null) {
   const manifest = {
     pi: {
       version: PI_VERSION,
@@ -212,6 +425,25 @@ export function buildVendorRuntimeManifest(gitSpec = null) {
       cli: relativeForManifest(piCliPath),
       node: 'electron',
     },
+  }
+  if (searchToolsSpec) {
+    manifest.searchTools = {
+      [searchToolsSpec.platformArch]: {
+        path: searchToolsSpec.root,
+        binPath: searchToolsSpec.binPath,
+        ...Object.fromEntries(Object.values(searchToolsSpec.tools).map((tool) => [
+          tool.id,
+          {
+            version: tool.version,
+            binary: `${searchToolsSpec.binPath}/${tool.binaryName}`,
+            distribution: tool.id === 'fd' ? 'sharkdp/fd' : 'BurntSushi/ripgrep',
+            url: tool.url,
+            sha256: tool.sha256,
+            licenses: tool.licenses.map((name) => `${searchToolsSpec.licensesPath}/${tool.id}/${name}`),
+          },
+        ])),
+      },
+    }
   }
   if (gitSpec) {
     manifest.git = {
@@ -231,10 +463,23 @@ export function buildVendorRuntimeManifest(gitSpec = null) {
   return manifest
 }
 
-async function writeManifest(gitSpec) {
-  const manifest = buildVendorRuntimeManifest(gitSpec)
+async function writeManifest(gitSpec, searchToolsSpec) {
+  const manifest = buildVendorRuntimeManifest(gitSpec, searchToolsSpec)
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n')
   console.log(`[vendor-runtime] manifest -> ${relativeForLog(manifestPath)}`)
+}
+
+export function resolveManagedSearchToolsSpec(opts = {}) {
+  const platform = opts.platform ?? process.platform
+  const arch = opts.arch ?? process.arch
+  return MANAGED_SEARCH_TOOL_RUNTIMES[`${platform}-${arch}`] ?? null
+}
+
+export function requiredManagedSearchToolFiles(spec) {
+  return Object.values(spec.tools).flatMap((tool) => [
+    `${spec.binPath}/${tool.binaryName}`,
+    ...tool.licenses.map((name) => `${spec.licensesPath}/${tool.id}/${name}`),
+  ])
 }
 
 export function resolveWindowsGitRuntimeSpec(opts = {}) {

--- a/scripts/vendor-managed-runtime.spec.ts
+++ b/scripts/vendor-managed-runtime.spec.ts
@@ -2,13 +2,63 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildVendorRuntimeManifest,
+  requiredManagedSearchToolFiles,
   requiredWindowsGitFiles,
+  resolveManagedSearchToolsSpec,
   resolveWindowsGitRuntimeSpec,
 } from './vendor-managed-runtime.mjs'
 
 describe('vendor managed runtime helpers', () => {
   it('pins the managed Pi release', () => {
     expect(buildVendorRuntimeManifest(null).pi.version).toBe('0.80.6')
+  })
+
+  it('pins both Pi search tools for every supported desktop architecture', () => {
+    const windows = resolveManagedSearchToolsSpec({ platform: 'win32', arch: 'x64' })
+    expect(windows).toMatchObject({
+      platformArch: 'win32-x64',
+      root: 'vendor/tools/win32-x64',
+      binPath: 'bin',
+      tools: {
+        fd: { version: '10.4.2', binaryName: 'fd.exe' },
+        rg: { version: '15.1.0', binaryName: 'rg.exe' },
+      },
+    })
+    expect(requiredManagedSearchToolFiles(windows!)).toEqual([
+      'bin/fd.exe',
+      'licenses/fd/LICENSE-APACHE',
+      'licenses/fd/LICENSE-MIT',
+      'bin/rg.exe',
+      'licenses/rg/LICENSE-MIT',
+      'licenses/rg/UNLICENSE',
+    ])
+
+    const intelMac = resolveManagedSearchToolsSpec({ platform: 'darwin', arch: 'x64' })
+    expect(intelMac?.tools.fd.version).toBe('10.3.0')
+    expect(intelMac?.tools.rg.version).toBe('15.1.0')
+    expect(resolveManagedSearchToolsSpec({ platform: 'linux', arch: 'x64' })).toBeNull()
+  })
+
+  it('writes search tool provenance and license paths into the runtime manifest', () => {
+    const tools = resolveManagedSearchToolsSpec({ platform: 'darwin', arch: 'arm64' })
+    const manifest = buildVendorRuntimeManifest(null, tools)
+
+    expect(manifest.searchTools['darwin-arm64']).toMatchObject({
+      path: 'vendor/tools/darwin-arm64',
+      binPath: 'bin',
+      fd: {
+        version: '10.4.2',
+        binary: 'bin/fd',
+        distribution: 'sharkdp/fd',
+        licenses: ['licenses/fd/LICENSE-APACHE', 'licenses/fd/LICENSE-MIT'],
+      },
+      rg: {
+        version: '15.1.0',
+        binary: 'bin/rg',
+        distribution: 'BurntSushi/ripgrep',
+        licenses: ['licenses/rg/LICENSE-MIT', 'licenses/rg/UNLICENSE'],
+      },
+    })
   })
 
   it('does not select a managed Git runtime on non-Windows hosts', () => {


### PR DESCRIPTION
## Summary

- bundle pinned, SHA-256-verified `fd` and `ripgrep` assets for macOS arm64/x64 and Windows arm64/x64
- publish one shared managed search-tool directory through the existing Workspace PATH contract in packaged Electron and opt-in source/dev vendoring
- retain upstream license files and replace generated tool directories only after a complete staged download, verification, and extraction
- assert the binaries and licenses in desktop packages, execute both tools in packaged smoke, and prove Pi resolves them with an empty private agent directory

## Root cause

Pi 0.80.6 probes `fd` and `rg` during interactive startup. When OpenAlice injects a Workspace AI credential, `PI_CODING_AGENT_DIR` points into that Workspace. Missing tools can therefore send Pi into a fresh per-Workspace GitHub download/cache path. A clean desktop install should not depend on that network side effect.

This keeps Pi network-capable and does not patch Pi or force `PI_OFFLINE`; it simply makes both commands available on OpenAlice's existing managed toolchain PATH before Pi starts.

## Security and provenance

This is an independent implementation from current `dev`; it does not cherry-pick or merge PR #524. The pinned digests were re-read from the official GitHub release APIs and the downloaded macOS arm64 and Windows x64 archives were independently hashed and inspected.

The generated binaries remain ignored build artifacts under `vendor/`. No binary payload is committed to Git.

## Supported payloads

| Platform | fd | ripgrep |
| --- | --- | --- |
| macOS arm64 | 10.4.2 | 15.1.0 |
| macOS x64 | 10.3.0 | 15.1.0 |
| Windows x64/arm64 | 10.4.2 | 15.1.0 |

Intel macOS uses fd 10.3.0 because 10.4.x no longer publishes an x86_64 Apple asset.

## Verification

- `node --check scripts/vendor-managed-runtime.mjs`
- `node --check scripts/assert-desktop-package.mjs`
- `node --check scripts/smoke-packaged-toolchain.mjs`
- focused managed-runtime, package-assertion, packaged-toolchain, runtime-profile, and spawn-env tests: 29 passed
- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm test`: 2665 passed, 6 skipped
- `pnpm vendor:runtime --force`: official macOS arm64 archives downloaded, hashed, extracted, and reused
- direct Pi `getToolPath("fd"/"rg")` probe with a missing `PI_CODING_AGENT_DIR`: `OPENALICE_PI_SEARCH_TOOLS_OK fd rg`
- `pnpm electron:build`
- unsigned macOS arm64 `electron-builder --dir`
- `pnpm electron:assert-package`
- `pnpm electron:smoke-toolchain`
- `pnpm electron:smoke:workspace --skip-build --skip-pack`: complete packaged Workspace acceptance passed

Native Windows execution and Intel macOS packaging remain review gates for this draft PR's CI matrix.

Closes #498
Related: #524
