### PR TITLE
Fix package artifact spec on Windows

### DIFF
--- a/scripts/desktop-package-artifact.spec.ts
+++ b/scripts/desktop-package-artifact.spec.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
@@ -21,8 +21,9 @@ afterEach(async () => {
 describe('temporary desktop package ownership', () => {
   it('uses the persistent package root unless an explicit root is supplied', () => {
     expect(resolveDesktopPackageRootArg([])).toBe(DEFAULT_DESKTOP_PACKAGE_ROOT)
-    expect(resolveDesktopPackageRootArg(['--package-root', 'build/app'], '/repo')).toBe('/repo/build/app')
-    expect(resolveDesktopPackageRootArg(['--', '--package-root', 'build/app'], '/repo')).toBe('/repo/build/app')
+    const expected = resolve('/repo', 'build/app')
+    expect(resolveDesktopPackageRootArg(['--package-root', 'build/app'], '/repo')).toBe(expected)
+    expect(resolveDesktopPackageRootArg(['--', '--package-root', 'build/app'], '/repo')).toBe(expected)
     expect(() => resolveDesktopPackageRootArg(['--package-root'])).toThrow('usage: --package-root <path>')
   })
 


### PR DESCRIPTION
## What changed

Make the desktop package-root test derive its expected path with Node `path.resolve`, matching the platform-native behavior of the implementation.

## Root cause

PR #561 added a test that expected the hard-coded POSIX path `/repo/build/app`. On Windows the implementation correctly returns `D:\repo\build\app`, so #562’s unrelated Windows cross-platform job failed.

## Validation

- `pnpm exec vitest run scripts/desktop-package-artifact.spec.ts` (5 passed)
- `git diff --check`

This changes only the cross-platform assertion; package cleanup behavior is unchanged.