### PR TITLE
Bundle four Docker runtimes and verify real agent work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ Add checks according to the touched surface:
 | Workspace issues, schedules, headless dispatch | Follow [Workspace issues and scheduling](docs/workspace-issues-and-scheduling.md) |
 | Guardian locks, process ownership, takeover | `pnpm test:guardian-recovery`; exercise the real launcher path |
 | Desktop, IPC, PTY, managed Pi, shell, packaging | Follow [Managed Workspace runtime](docs/managed-workspace-runtime.md) and run the matching Electron/package smoke |
-| Docker/server image, Compose, remote deployment | Follow [Docker deployment](docs/docker-deployment.md) and run `pnpm docker:smoke` |
+| Docker/server image, Compose, remote deployment | Follow [Docker deployment](docs/docker-deployment.md) and run `pnpm docker:smoke`; before release, opt into the credentialed agent/CLI check documented there |
 | Persisted data shape | Add an idempotent migration + spec, register it, then run `pnpm build:migration-index` |
 | Onboarding/first run/auth | Use isolated data; exercise dev and packaged onboarding paths where relevant |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,18 +64,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         tini \
     && rm -rf /var/lib/apt/lists/*
 
-# Two agent CLIs installed globally so they're on PATH for the PTY
-# sessions OpenAlice spawns. Both come from npm (codex's npm package is
-# a thin wrapper that pulls down the Rust binary on install).
+# The four supported agent CLIs are installed globally so every Docker
+# Workspace gets the same runtime surface as OpenAlice. They all come from npm
+# (Codex/opencode packages resolve their platform binary during install).
 # Keep these explicit: an unchanged Dockerfile layer must resolve to the same
 # runtime instead of silently changing when an upstream `latest` tag moves.
 ARG CLAUDE_CODE_VERSION=2.1.202
 ARG CODEX_VERSION=0.144.1
+ARG OPENCODE_VERSION=1.17.18
+ARG PI_VERSION=0.80.6
 RUN npm install -g \
         "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
         "@openai/codex@${CODEX_VERSION}" \
+        "opencode-ai@${OPENCODE_VERSION}" \
+        "@earendil-works/pi-coding-agent@${PI_VERSION}" \
     && claude --version \
     && codex --version \
+    && opencode --version \
+    && pi --version \
     && npm cache clean --force
 
 # Production artifacts. The Guardian script (`scripts/guardian/prod.mjs`)

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -23,10 +23,14 @@ container loopback. Workspace agents reach Alice through the injected
 `alice`, `alice-workspace`, `alice-uta`, and `traderhub` CLI launchers; remote
 clients must not expose the internal tool gateway as a replacement API.
 
-The server image installs pinned Claude Code and Codex runtimes. Unlike the
-desktop package, it does not currently bundle managed Pi, and it does not
-install opencode. Version changes are deliberate Dockerfile changes so a
-cached/rebuilt image cannot silently acquire a different native runtime.
+The server image installs pinned Claude Code, Codex, opencode, and Pi runtimes.
+Docker has no portable way to borrow host CLIs (a macOS binary cannot run in a
+Linux container, and remote hosts may have none), so the image owns the full
+four-runtime contract. Version changes are deliberate Dockerfile changes and
+the build executes every runtime's `--version`, preventing a cached/rebuilt
+image from silently acquiring a different or broken runtime. Pi headless runs
+auto-approve project resources because the image owns its pinned Pi version;
+interactive Pi still leaves that trust decision visible to the user.
 
 ## Start and Authenticate
 
@@ -99,15 +103,41 @@ Workspace history.
 1. builds an isolated, uniquely tagged image;
 2. starts it in lite mode with a temporary Docker volume and random host port;
 3. waits for Alice HTTP readiness;
-4. creates a real Chat Workspace with the shell adapter;
-5. opens the real Workspace PTY WebSocket;
-6. runs `alice` inside that PTY and requires a live CLI manifest response;
-7. offboards the Workspace and removes its container, volume, and owned image.
+4. requires Claude Code, Codex, opencode, and Pi to appear as installed;
+5. creates a real Chat Workspace with the shell adapter;
+6. opens the real Workspace PTY WebSocket;
+7. runs `alice` inside that PTY and requires a live CLI manifest response;
+8. offboards the Workspace and removes its container, volume, and owned image.
 
 The smoke uses no AI credential and no broker. It deliberately checks an
 observable CLI round trip rather than only asserting that files exist. Docker
 build cache is shared infrastructure and is retained; only resources owned by
 the smoke are deleted. Use `--keep` or `--keep-image` for investigation.
+
+Before a release, an operator can add a real multi-turn agent check with a
+credential already stored in the local Alice vault:
+
+```bash
+pnpm docker:smoke -- --ai-credential <slug>
+```
+
+This opt-in mode uses `claude` by default; `--ai-agent` can select any of the
+four installed runtimes when the credential exposes a compatible wire (Codex
+specifically requires `openai-responses`). It writes only the selected
+credential into the temporary runtime volume over stdin, asks the agent to
+remember a generated codeword, resumes the same OpenAlice `resumeId`, and
+requires the second turn to recall it. A final turn requires the agent to use
+`alice-workspace` to create and read back marker-bearing Issue data; the smoke
+requires both a normalized tool block containing the marker and the agent's
+confirmation. The credential check then requires a completed
+`traderhub board get --board macro` call and a metric summary from its live,
+keyless market-data output. The credential never enters the image or build
+context; credentialed runs reject `--keep`, redact the key from failure
+diagnostics, and fail loudly if Docker cannot remove their temporary volume. Set
+`OPENALICE_DOCKER_AI_CONFIG_FILE` only when testing against a non-default Alice
+vault path. This mode intentionally stays out of ordinary PR CI because it
+uses a paid external model and a repository secret would broaden the trust
+boundary.
 
 CI builds with BuildKit's GitHub cache, reuses that caller-owned image with
 `--skip-build --image openalice:ci`, and uploads redacted container diagnostics

--- a/scripts/docker-runtime-smoke-lib.mjs
+++ b/scripts/docker-runtime-smoke-lib.mjs
@@ -5,15 +5,19 @@ export function buildDockerRuntimeSmokePlan(argv, opts = {}) {
   const warnings = []
   const flags = new Set()
   let image = null
+  let aiCredentialSlug = null
+  let aiAgent = 'claude'
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
     if (arg === '--') continue
-    if (arg === '--image') {
+    if (arg === '--image' || arg === '--ai-credential' || arg === '--ai-agent') {
       const value = argv[index + 1]
-      if (!value || value.startsWith('--')) errors.push('[docker-smoke] --image requires a tag')
+      if (!value || value.startsWith('--')) errors.push(`[docker-smoke] ${arg} requires a value`)
       else {
-        image = value
+        if (arg === '--image') image = value
+        else if (arg === '--ai-credential') aiCredentialSlug = value
+        else aiAgent = value
         index += 1
       }
       continue
@@ -24,6 +28,15 @@ export function buildDockerRuntimeSmokePlan(argv, opts = {}) {
 
   const skipBuild = flags.has('--skip-build')
   if (skipBuild && !image) errors.push('[docker-smoke] --skip-build requires --image <tag>')
+  if (aiCredentialSlug && flags.has('--keep')) {
+    errors.push('[docker-smoke] --keep is disabled for credentialed smoke runs so the secret volume is always removed')
+  }
+  if (aiCredentialSlug && !['claude', 'codex', 'opencode', 'pi'].includes(aiAgent)) {
+    errors.push('[docker-smoke] --ai-agent must be claude, codex, opencode, or pi')
+  }
+  if (!aiCredentialSlug && aiAgent !== 'claude') {
+    errors.push('[docker-smoke] --ai-agent requires --ai-credential <slug>')
+  }
 
   const suffix = (opts.randomUUID?.() ?? randomUUID()).replaceAll('-', '').slice(0, 12).toLowerCase()
   const ownsImage = image === null
@@ -37,6 +50,8 @@ export function buildDockerRuntimeSmokePlan(argv, opts = {}) {
     warnings,
     options: {
       help: flags.has('--help') || flags.has('-h'),
+      aiAgent,
+      aiCredentialSlug,
       image: resolvedImage,
       keep: flags.has('--keep'),
       keepImage: flags.has('--keep-image'),
@@ -67,10 +82,10 @@ export function stripTerminalControl(text) {
     .replace(/\r/g, '')
 }
 
-export function redactDockerLogs(text) {
+export function redactDockerLogs(text, secrets = []) {
   const lines = text.split(/\r?\n/)
   let redactNextToken = false
-  return lines.map((line) => {
+  const tokenRedacted = lines.map((line) => {
     if (line.includes('First-run admin token')) {
       redactNextToken = true
       return line
@@ -81,4 +96,8 @@ export function redactDockerLogs(text) {
     }
     return line
   }).join('\n')
+  return secrets.reduce(
+    (result, secret) => secret ? result.replaceAll(secret, '[runtime credential redacted]') : result,
+    tokenRedacted,
+  )
 }

--- a/scripts/docker-runtime-smoke-lib.spec.ts
+++ b/scripts/docker-runtime-smoke-lib.spec.ts
@@ -31,6 +31,22 @@ describe('Docker runtime smoke plan', () => {
     expect(plan.options).toMatchObject({ image: 'openalice:ci', ownsImage: false, skipBuild: true })
   })
 
+  it('makes real AI conversation opt-in and never keeps its secret volume', () => {
+    const plan = buildDockerRuntimeSmokePlan(['--ai-credential', 'custom-1'])
+    expect(plan.errors).toEqual([])
+    expect(plan.options).toMatchObject({ aiCredentialSlug: 'custom-1', aiAgent: 'claude' })
+
+    expect(buildDockerRuntimeSmokePlan(['--ai-credential', 'custom-1', '--keep']).errors).toContain(
+      '[docker-smoke] --keep is disabled for credentialed smoke runs so the secret volume is always removed',
+    )
+    expect(buildDockerRuntimeSmokePlan(['--ai-agent', 'codex']).errors).toContain(
+      '[docker-smoke] --ai-agent requires --ai-credential <slug>',
+    )
+    expect(buildDockerRuntimeSmokePlan(['--ai-credential', 'custom-1', '--ai-agent', 'ghost']).errors).toContain(
+      '[docker-smoke] --ai-agent must be claude, codex, opencode, or pi',
+    )
+  })
+
   it('parses Docker port output and terminal output deterministically', () => {
     expect(parsePublishedPort('127.0.0.1:49173\n')).toBe(49173)
     expect(parsePublishedPort('[::1]:49174')).toBe(49174)
@@ -38,15 +54,19 @@ describe('Docker runtime smoke plan', () => {
     expect(stripTerminalControl('\u001b[32mOpenAlice\u001b[0m\r\n')).toBe('OpenAlice\n')
   })
 
-  it('redacts the ephemeral first-run token from failure logs', () => {
+  it('redacts the ephemeral first-run token and runtime credentials from failure logs', () => {
     const logs = [
       'First-run admin token (save this):',
       '',
       '      abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG',
       'engine started',
     ].join('\n')
-    expect(redactDockerLogs(logs)).not.toContain('abcdefghijklmnopqrstuvwxyz')
-    expect(redactDockerLogs(logs)).toContain('[ephemeral admin token redacted]')
+    const apiKey = 'secret-runtime-key'
+    const redacted = redactDockerLogs(`${logs}\nprovider rejected ${apiKey}`, [apiKey])
+    expect(redacted).not.toContain('abcdefghijklmnopqrstuvwxyz')
+    expect(redacted).not.toContain(apiKey)
+    expect(redacted).toContain('[ephemeral admin token redacted]')
+    expect(redacted).toContain('[runtime credential redacted]')
   })
 })
 
@@ -72,9 +92,13 @@ describe('Dockerfile runtime contract', () => {
     expect(dockerfile).not.toMatch(/ln -s[^\n]*\/usr\/local\/bin\/(alice|traderhub)/)
   })
 
-  it('pins native agent runtime versions and exposes a healthcheck', () => {
-    expect(dockerfile).toMatch(/ARG CLAUDE_CODE_VERSION=\d+\.\d+\.\d+/)
-    expect(dockerfile).toMatch(/ARG CODEX_VERSION=\d+\.\d+\.\d+/)
+  it('pins and verifies all four agent runtimes and exposes a healthcheck', () => {
+    for (const name of ['CLAUDE_CODE', 'CODEX', 'OPENCODE', 'PI']) {
+      expect(dockerfile).toMatch(new RegExp(`ARG ${name}_VERSION=\\d+\\.\\d+\\.\\d+`))
+    }
+    for (const command of ['claude', 'codex', 'opencode', 'pi']) {
+      expect(dockerfile).toContain(`&& ${command} --version`)
+    }
     expect(dockerfile).toContain('HEALTHCHECK ')
     expect(dockerfile).toContain('/api/version')
   })

--- a/scripts/docker-runtime-smoke.mjs
+++ b/scripts/docker-runtime-smoke.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
-import { mkdirSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -14,6 +15,8 @@ import {
 const repoRoot = fileURLToPath(new URL('..', import.meta.url))
 const plan = buildDockerRuntimeSmokePlan(process.argv.slice(2))
 const {
+  aiAgent,
+  aiCredentialSlug,
   containerName,
   image,
   keep,
@@ -24,17 +27,22 @@ const {
   volumeName,
 } = plan.options
 const logFile = process.env['OPENALICE_DOCKER_SMOKE_LOG_FILE']?.trim()
+const runtimeSecrets = []
 
 function printHelp() {
   console.log(`Usage: pnpm docker:smoke [options]
 
 Build and run an isolated OpenAlice server image, create a real Chat Workspace,
 open a shell PTY, and execute the injected alice CLI through its live gateway.
-No external AI credential or broker account is used.
+Default mode uses no external AI credential or broker account.
 
 Options:
   --skip-build        Reuse a caller-owned image (requires --image)
   --image <tag>       Build/reuse this caller-owned image tag
+  --ai-credential <slug>
+                      Run a real, two-turn conversation using one credential
+                      from Alice's local vault (never copied into the image)
+  --ai-agent <id>     claude (default), codex, opencode, or pi
   --keep              Keep the container, volume, and owned image for debugging
   --keep-image        Keep only the temporary image built by this run
   -h, --help          Show this help
@@ -46,6 +54,7 @@ function docker(args, options = {}) {
     cwd: repoRoot,
     encoding: options.inherit ? undefined : 'utf8',
     stdio: options.inherit ? 'inherit' : 'pipe',
+    ...(options.input !== undefined ? { input: options.input } : {}),
     env: process.env,
   })
   if (result.error) throw result.error
@@ -58,6 +67,56 @@ function docker(args, options = {}) {
     stdout: typeof result.stdout === 'string' ? result.stdout : '',
     stderr: typeof result.stderr === 'string' ? result.stderr : '',
   }
+}
+
+function loadAiCredentialConfig(slug, agent) {
+  const source = process.env['OPENALICE_DOCKER_AI_CONFIG_FILE']?.trim()
+    || resolve(homedir(), '.openalice', 'data', 'config', 'ai-provider-manager.json')
+  const parsed = JSON.parse(readFileSync(source, 'utf8'))
+  const credential = parsed?.credentials?.[slug]
+  if (!credential || typeof credential !== 'object') throw new Error(`AI credential not found in local vault: ${slug}`)
+  if (typeof credential.apiKey !== 'string' || credential.apiKey.length === 0) {
+    throw new Error(`AI credential has no API key: ${slug}`)
+  }
+  if (typeof credential.lastModel !== 'string' || credential.lastModel.length === 0) {
+    throw new Error(`AI credential has no remembered model: ${slug}`)
+  }
+  const wires = credential.wires && typeof credential.wires === 'object'
+    ? credential.wires
+    : credential.wireShape
+      ? { [credential.wireShape]: credential.baseUrl ?? '' }
+      : {}
+  const compatibleWires = agent === 'codex'
+    ? ['openai-responses']
+    : agent === 'claude'
+      ? ['anthropic']
+      : ['openai-chat', 'anthropic', 'openai-responses']
+  if (!compatibleWires.some((wire) => wire in wires)) {
+    throw new Error(`AI credential ${slug} cannot drive ${agent}; missing a compatible wire`)
+  }
+  runtimeSecrets.push(credential.apiKey)
+  return {
+    model: credential.lastModel,
+    config: {
+      credentials: { [slug]: credential },
+      workspaceCredentialDefaults: {
+        [agent]: { credentialSlug: slug, model: credential.lastModel },
+      },
+    },
+  }
+}
+
+function writeAiCredentialConfigToContainer(config) {
+  const writer = [
+    "const fs=require('node:fs')",
+    "let input=''",
+    "process.stdin.setEncoding('utf8')",
+    "process.stdin.on('data',(chunk)=>{input+=chunk})",
+    "process.stdin.on('end',()=>{fs.mkdirSync('/data/data/config',{recursive:true});fs.writeFileSync('/data/data/config/ai-provider-manager.json',input,{mode:0o600})})",
+  ].join(';')
+  docker(['exec', '--interactive', containerName, 'node', '-e', writer], {
+    input: `${JSON.stringify(config)}\n`,
+  })
 }
 
 function sleep(ms) {
@@ -98,6 +157,117 @@ async function waitForHttp(baseUrl, timeoutMs = 90_000) {
     }
   }
   throw new Error(`Alice HTTP surface did not become ready: ${lastError instanceof Error ? lastError.message : String(lastError)}`)
+}
+
+async function dispatchHeadlessTurn(baseUrl, workspaceId, { agent, prompt, resumeId }, timeoutMs = 180_000) {
+  const dispatched = await fetchJson(baseUrl, `/api/workspaces/${workspaceId}/headless`, {
+    method: 'POST',
+    body: JSON.stringify({
+      agent,
+      prompt,
+      timeoutMs,
+      ...(resumeId ? { resumeId } : {}),
+    }),
+  }, 202)
+  if (typeof dispatched?.taskId !== 'string' || typeof dispatched?.resumeId !== 'string') {
+    throw new Error('headless dispatch omitted taskId or resumeId')
+  }
+
+  const deadline = Date.now() + timeoutMs + 15_000
+  let task = null
+  while (Date.now() < deadline) {
+    task = await fetchJson(baseUrl, `/api/headless/${dispatched.taskId}`)
+    if (task?.status !== 'running') break
+    await sleep(500)
+  }
+  const output = await fetchJson(baseUrl, `/api/headless/${dispatched.taskId}/output`)
+  if (task?.status !== 'done') {
+    throw new Error(
+      `AI turn ${dispatched.taskId} ended as ${task?.status ?? 'unknown'}: ${output?.structured?.assistantText ?? output?.stderr?.text ?? 'no diagnostics'}`,
+    )
+  }
+  return {
+    taskId: dispatched.taskId,
+    resumeId: dispatched.resumeId,
+    assistantText: output?.structured?.assistantText,
+    structured: output?.structured,
+  }
+}
+
+async function runCredentialedConversation(baseUrl, workspaceId, agent, model) {
+  const codeword = `docker-${suffix.slice(0, 8)}`
+  const first = await dispatchHeadlessTurn(baseUrl, workspaceId, {
+    agent,
+    prompt: `Remember the codeword ${codeword}. Reply with exactly: ACK ${codeword}. Do not use tools.`,
+  })
+  if (typeof first.assistantText !== 'string' || !first.assistantText.includes(codeword)) {
+    throw new Error(`AI turn 1 did not return the codeword: ${first.assistantText ?? 'no assistant text'}`)
+  }
+  console.log(`[docker-smoke] AI turn 1 (${agent}/${model}): ${first.assistantText.trim()}`)
+
+  const second = await dispatchHeadlessTurn(baseUrl, workspaceId, {
+    agent,
+    resumeId: first.resumeId,
+    prompt: 'What codeword did I ask you to remember in the previous turn? Reply with only that codeword. Do not use tools.',
+  })
+  if (second.resumeId !== first.resumeId) throw new Error('AI turn 2 changed the OpenAlice resume identity')
+  if (typeof second.assistantText !== 'string' || !second.assistantText.includes(codeword)) {
+    throw new Error(`AI turn 2 did not remember the codeword: ${second.assistantText ?? 'no assistant text'}`)
+  }
+  console.log(`[docker-smoke] AI turn 2 resumed ${first.resumeId}: ${second.assistantText.trim()}`)
+
+  const issueId = `docker-cli-${suffix.slice(0, 8)}`
+  const dataMarker = `CLI_DATA_${suffix.slice(0, 8).toUpperCase()}`
+  const third = await dispatchHeadlessTurn(baseUrl, workspaceId, {
+    agent,
+    resumeId: first.resumeId,
+    prompt: [
+      'Use the Bash tool to run these commands in order:',
+      `alice-workspace issue create --title "${issueId}" --what "Docker CLI marker ${dataMarker}"`,
+      `alice-workspace issue show --id "${issueId}"`,
+      `Only if the second command output contains ${dataMarker}, reply exactly: CLI_DATA_OK ${dataMarker}`,
+    ].join('\n'),
+  })
+  const completedToolOutput = JSON.stringify(
+    (third.structured?.blocks ?? [])
+      .filter((block) => block?.type === 'tool' && block.status === 'completed')
+      .map((block) => block.output),
+  )
+  if ((third.structured?.metrics?.toolCalls ?? 0) < 1) {
+    throw new Error('AI CLI-data turn completed without a recorded tool call')
+  }
+  if (!completedToolOutput.includes(dataMarker)) {
+    throw new Error('AI CLI-data tool output did not contain the seeded Workspace marker')
+  }
+  if (third.assistantText?.trim() !== `CLI_DATA_OK ${dataMarker}`) {
+    throw new Error(`AI did not confirm the CLI data round trip: ${third.assistantText ?? 'no assistant text'}`)
+  }
+  console.log(`[docker-smoke] AI Workspace CLI data (${third.structured.metrics.toolCalls} tool calls): ${third.assistantText.trim()}`)
+
+  const market = await dispatchHeadlessTurn(baseUrl, workspaceId, {
+    agent,
+    resumeId: first.resumeId,
+    prompt: [
+      'Use the Bash tool to run exactly: traderhub board get --board macro',
+      'Read the actual command output. Reply on one line starting with MARKET_DATA_OK followed by one metric label and value from that output.',
+      'If the command fails or returns no macro data, reply exactly: MARKET_DATA_FAILED',
+    ].join('\n'),
+  })
+  const marketToolOutput = JSON.stringify(
+    (market.structured?.blocks ?? [])
+      .filter((block) => block?.type === 'tool' && block.status === 'completed')
+      .map((block) => block.output),
+  )
+  if ((market.structured?.metrics?.toolCalls ?? 0) < 1) {
+    throw new Error('AI market-data turn completed without a recorded tool call')
+  }
+  if (!/(CPI|Fed|Treasury|Unemployment|Oil|M2|GDP|Rates)/i.test(marketToolOutput)) {
+    throw new Error(`traderhub macro output was missing expected market fields: ${marketToolOutput.slice(-2000)}`)
+  }
+  if (!market.assistantText?.trim().startsWith('MARKET_DATA_OK ')) {
+    throw new Error(`AI did not confirm the market-data round trip: ${market.assistantText ?? 'no assistant text'}`)
+  }
+  console.log(`[docker-smoke] AI traderhub market data: ${market.assistantText.trim()}`)
 }
 
 function decodeWsData(data) {
@@ -192,7 +362,7 @@ function collectFailureLogs() {
     '=== docker logs ===',
     logs.stdout,
     logs.stderr,
-  ].filter(Boolean).join('\n')).trim()
+  ].filter(Boolean).join('\n'), runtimeSecrets).trim()
   if (logFile && report) {
     const target = resolve(repoRoot, logFile)
     mkdirSync(dirname(target), { recursive: true })
@@ -217,8 +387,10 @@ let containerCreated = false
 let volumeCreated = false
 let passed = false
 let finalCode = 0
+let aiCredential = null
 
 try {
+  if (aiCredentialSlug) aiCredential = loadAiCredentialConfig(aiCredentialSlug, aiAgent)
   docker(['info'])
   if (!skipBuild) {
     console.log(`[docker-smoke] building ${image}`)
@@ -246,10 +418,27 @@ try {
   const baseUrl = `http://127.0.0.1:${port}`
   const version = await waitForHttp(baseUrl)
   console.log(`[docker-smoke] HTTP ready: ${baseUrl} (${version?.version ?? 'version route OK'})`)
+  const agentInventory = await fetchJson(baseUrl, '/api/workspaces/agents')
+  const inventoryById = new Map((agentInventory?.agents ?? []).map((agent) => [agent.id, agent]))
+  const missingRuntimes = ['claude', 'codex', 'opencode', 'pi'].filter(
+    (id) => inventoryById.get(id)?.installed !== true,
+  )
+  if (missingRuntimes.length > 0) {
+    throw new Error(`Docker image did not detect all agent runtimes: ${missingRuntimes.join(', ')}`)
+  }
+  console.log('[docker-smoke] agent runtimes detected: claude, codex, opencode, pi')
+  if (aiCredential) {
+    writeAiCredentialConfigToContainer(aiCredential.config)
+    console.log(`[docker-smoke] staged isolated ${aiAgent} credential config (${aiCredential.model})`)
+  }
 
   const created = await fetchJson(baseUrl, '/api/workspaces', {
     method: 'POST',
-    body: JSON.stringify({ tag: `docker-smoke-${suffix}`, template: 'chat', agents: ['shell'] }),
+    body: JSON.stringify({
+      tag: `docker-smoke-${suffix}`,
+      template: 'chat',
+      agents: ['shell', ...(aiCredential ? [aiAgent] : [])],
+    }),
   }, 201)
   const workspaceId = created?.workspace?.id
   if (typeof workspaceId !== 'string' || !workspaceId) throw new Error('workspace create response omitted workspace.id')
@@ -267,6 +456,10 @@ try {
   const terminalOutput = await runWorkspaceCliThroughPty(baseUrl, session.sessionId)
   console.log('[docker-smoke] Workspace PTY + alice manifest round-trip: OK')
   if (process.env['OPENALICE_DOCKER_SMOKE_VERBOSE'] === '1') console.log(terminalOutput)
+  if (aiCredential) {
+    await runCredentialedConversation(baseUrl, workspaceId, aiAgent, aiCredential.model)
+    console.log('[docker-smoke] credentialed multi-turn conversation + Workspace CLI data: OK')
+  }
 
   await fetchJson(baseUrl, `/api/workspaces/${workspaceId}/offboard`, {
     method: 'POST',
@@ -276,7 +469,8 @@ try {
   passed = true
 } catch (error) {
   finalCode = 1
-  console.error(`[docker-smoke] ${error instanceof Error ? error.message : String(error)}`)
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`[docker-smoke] ${redactDockerLogs(message, runtimeSecrets)}`)
   if (containerCreated) {
     const report = collectFailureLogs()
     if (report) console.error(report.split('\n').slice(-160).join('\n'))

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -300,6 +300,8 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
       'claude',
       '--settings',
       '{"enableAllProjectMcpServers":true}',
+      '--allowedTools',
+      'Bash(alice:*),Bash(alice-workspace:*),Bash(alice-uta:*),Bash(traderhub:*)',
       '-p',
       '--output-format',
       'stream-json',
@@ -343,6 +345,12 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
       '--mode',
       'json',
       'do x',
+    ]);
+  });
+
+  it('pi: Docker headless explicitly approves the image-pinned runtime', () => {
+    expect(piAdapter.composeHeadlessCommand!(['pi'], ctx({ OPENALICE_LAUNCHER: 'docker' }), 'do x')).toEqual([
+      'pi', '--approve', '-p', '--mode', 'json', 'do x',
     ]);
   });
 

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -24,6 +24,18 @@ const CLAUDE_SETTINGS_PATH = '.claude/settings.local.json';
  */
 const AUTOTRUST_SETTINGS = '{"enableAllProjectMcpServers":true}';
 
+// `claude -p` has nobody available to answer a permission prompt. Keep its
+// autonomous Bash surface limited to the four launcher-owned CLI shims rather
+// than bypassing every Claude Code permission. The gateway still validates the
+// Workspace/run identity and each command's argument schema server-side.
+// Syntax follows Claude Code's documented command-prefix permission rules.
+const HEADLESS_ALLOWED_TOOLS = [
+  'Bash(alice:*)',
+  'Bash(alice-workspace:*)',
+  'Bash(alice-uta:*)',
+  'Bash(traderhub:*)',
+].join(',');
+
 /** dashed-cwd convention used by Claude Code's project store. */
 function projectKey(workspaceDir: string): string {
   const abs = resolve(workspaceDir);
@@ -99,6 +111,7 @@ export const claudeAdapter: CliAdapter = {
     return [
       ...base,
       '--settings', AUTOTRUST_SETTINGS,
+      '--allowedTools', HEADLESS_ALLOWED_TOOLS,
       ...(ctx.resume ? ['--resume', ctx.resume.sessionId] : []),
       '-p', '--output-format', 'stream-json', '--verbose',
       '--', prompt,

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -31,8 +31,9 @@ function positiveNumber(value: number | null | undefined): number | null {
  * surface and (b) reach the Chat-Completions ecosystem (CN + local models)
  * that codex's Responses-only lock can't touch.
  *
- * Contract VERIFIED against opencode 1.16.0 on macOS (`opencode --help` +
- * an `opencode debug config` provider-config smoke, 2026-06):
+ * Contract VERIFIED against opencode 1.16.0 on macOS and the Docker-pinned
+ * 1.17.18 (`opencode --help`, provider config, headless resume, CLI tool calls,
+ * and live traderhub data; 2026-07):
  *
  *   - Tool access: OpenAlice tools are exposed through the injected
  *     `alice*` / `traderhub` CLI shims, not opencode's native MCP config.

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -64,10 +64,11 @@ export async function syncPiWindowsShellPath(
 }
 
 function piHeadlessApproveArgs(env: Readonly<Record<string, string | undefined>>): readonly string[] {
-  // The packaged app always uses OpenAlice's pinned managed Pi. Contributor
+  // Packaged desktop and Docker both use an OpenAlice-pinned Pi. Contributor
   // dev intentionally uses whatever `pi` is on PATH; its install/version/trust
   // policy belongs to that developer, so do not attach version-specific flags.
-  return runtimeProfileFromEnv(env).managedPiPath ? ['--approve'] : [];
+  const profile = runtimeProfileFromEnv(env);
+  return profile.managedPiPath || profile.launcher === 'docker' ? ['--approve'] : [];
 }
 
 /**


### PR DESCRIPTION
## What changed

- pin and install Claude Code 2.1.202, Codex 0.144.1, opencode 1.17.18, and Pi 0.80.6 in the server image; fail the build unless every CLI reports its version
- make the default Docker smoke require all four runtimes to appear installed
- add an opt-in credentialed smoke that copies only one selected vault credential into the temporary volume over stdin, then verifies reply parsing, resume continuity, Workspace CLI tool calls, and live traderhub macro data
- allow Claude headless to execute only the four OpenAlice CLI command families instead of bypassing all permissions
- treat Docker Pi as image-managed so headless uses its pinned `--approve` contract; interactive trust remains user-visible
- document the full runtime and release-acceptance contract

## Why

A Docker deployment cannot portably borrow host CLIs: remote hosts may not have them, and macOS/Windows binaries cannot run in the Linux container. The image therefore needs to own the same four-runtime surface the product exposes. The earlier smoke proved HTTP and PTY wiring but did not prove a model could reply, resume, execute an OpenAlice CLI, or read real market data.

## Real Docker validation

Using the local `custom-1` Meituan Longmao credential (the secret was not staged or embedded):

- Claude: two-turn resume, completed `alice-workspace` create/show, and `traderhub board get --board macro` → `Fed Funds Rate 3.62`
- Pi: same full flow → `Fed Funds Rate 3.62`
- opencode: same full flow → `Fed Funds Rate 3.62%`
- Codex: pinned install, `--version`, and `/api/workspaces/agents` detection; no paid turn because the current vault has no `openai-responses` credential
- credentialed containers, volumes, and the owned test image were removed; staged credential scan was clean

## Other checks

- `pnpm test` (236 files passed, 1 skipped; 2685 tests passed, 6 skipped)
- `pnpm exec tsc --noEmit`
- focused adapter/smoke specs (61 passed)
- `docker build --check .`
- `docker compose config --quiet`
- `git diff --check`

The normal PR Docker CI remains credential-free. Real-model mode is explicit, rejects `--keep`, redacts the selected key from diagnostics, and fails if its secret-bearing volume cannot be removed.