### PR TITLE
Treat recovered headless retries as successful

### DIFF
--- a/src/workspaces/headless-task.spec.ts
+++ b/src/workspaces/headless-task.spec.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { runHeadlessTask } from './headless-task.js';
+import { headlessTaskStatus, runHeadlessTask } from './headless-task.js';
 import type { Logger } from './logger.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -274,5 +274,47 @@ describe('runHeadlessTask', () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('headlessTaskStatus', () => {
+  const structured = (blocks: Array<{ type: 'error'; message: string } | { type: 'text'; text: string }>) => ({
+    schemaVersion: 1 as const,
+    assistantText: blocks.findLast((block) => block.type === 'text')?.text ?? null,
+    blocks,
+    metrics: {
+      textBlocks: blocks.filter((block) => block.type === 'text').length,
+      toolCalls: 0,
+      toolFailures: 0,
+    },
+    truncated: false,
+  });
+
+  it('keeps a recovered runtime retry as done', () => {
+    expect(headlessTaskStatus({
+      exitCode: 0,
+      killed: false,
+      structured: structured([
+        { type: 'error', message: 'Reconnecting... 2/5' },
+        { type: 'text', text: 'Recovered reply' },
+      ]),
+    })).toBe('done');
+  });
+
+  it('fails a terminal runtime error even when earlier text was emitted', () => {
+    expect(headlessTaskStatus({
+      exitCode: 0,
+      killed: false,
+      structured: structured([
+        { type: 'text', text: 'Partial reply' },
+        { type: 'error', message: 'Provider unavailable' },
+      ]),
+    })).toBe('failed');
+  });
+
+  it('fails killed and non-zero-exit runs', () => {
+    const output = structured([{ type: 'text', text: 'Reply before exit' }]);
+    expect(headlessTaskStatus({ exitCode: 0, killed: true, structured: output })).toBe('failed');
+    expect(headlessTaskStatus({ exitCode: 1, killed: false, structured: output })).toBe('failed');
   });
 });

--- a/src/workspaces/headless-task.ts
+++ b/src/workspaces/headless-task.ts
@@ -102,6 +102,28 @@ export interface HeadlessTaskResult {
 }
 
 /**
+ * Turn process/runtime evidence into the durable task status shown to callers.
+ *
+ * Some runtimes (currently Codex) emit retryable `error` events while
+ * reconnecting, then continue to a normal assistant reply and exit 0. Keep
+ * those events in the activity stream, but only treat an in-band runtime error
+ * as terminal when no later assistant text recovered the turn.
+ */
+export function headlessTaskStatus(
+  result: Pick<HeadlessTaskResult, 'exitCode' | 'killed' | 'structured'>,
+): 'done' | 'failed' {
+  if (result.killed || result.exitCode !== 0) return 'failed';
+
+  let lastError = -1;
+  let lastText = -1;
+  result.structured.blocks.forEach((block, index) => {
+    if (block.type === 'error') lastError = index;
+    if (block.type === 'text') lastText = index;
+  });
+  return lastError > lastText ? 'failed' : 'done';
+}
+
+/**
  * Byte-accumulating tail sink. Buffers raw chunks and decodes UTF-8 ONCE at the
  * end — so a multi-byte sequence split across two `data` chunks isn't mangled
  * into U+FFFD at the seam (which per-chunk `.toString()` would do, corrupting

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -30,7 +30,7 @@ import { loadConfig, type ServerConfig } from './config.js';
 import { ensureAgentCredentialReady } from './agent-credential-readiness.js';
 import { logger as launcherLogger } from './logger.js';
 import { runHeadlessProbe, type HeadlessProbeResult } from './probe.js';
-import { runHeadlessTask, type HeadlessTaskResult } from './headless-task.js';
+import { headlessTaskStatus, runHeadlessTask, type HeadlessTaskResult } from './headless-task.js';
 import {
   checkingRuntimeReadinessRow,
   failedRuntimeReadinessRow,
@@ -1107,10 +1107,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       throw err;
     }
     if (!resumeId) activeResumeIds.add(rec.resumeId);
-    // Fire-and-forget: run to natural exit, then fill the record. NOTE: status
-    // is judged by exit code — pi can exit 0 on an in-band model error, so
-    // "done" means "process exited cleanly", not "the agent succeeded"; the
-    // operator confirms via the normalized output / Inbox.
+    // Fire-and-forget: run to natural exit, then fill the record. Process
+    // failures and terminal in-band runtime errors fail the task; retryable
+    // errors followed by a later assistant reply remain visible in Activity
+    // without turning a recovered run into a false failure.
     void runHeadlessTaskMethod(ws, adapter, prompt, timeoutMs, {
       taskId: rec.taskId,
       resumeId: rec.resumeId,
@@ -1127,8 +1127,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       },
     })
       .then(async (r) => {
-        const runtimeReportedError = r.structured.blocks.some((block) => block.type === 'error');
-        const status = r.killed || runtimeReportedError || r.exitCode !== 0 ? 'failed' : 'done';
+        const status = headlessTaskStatus(r);
         await headlessTasks.complete(rec.taskId, {
           status,
           finishedAt: Date.now(),


### PR DESCRIPTION
## What changed

- classify a headless runtime error as terminal only when no later assistant text recovered the turn
- keep retry/error blocks in normalized Activity output for diagnostics
- preserve failure for killed, non-zero-exit, and terminal in-band runtime errors
- add regression coverage for recovered and terminal error ordering

## Root cause

Codex can emit retryable `error` JSON events while reconnecting and then complete the tool call, produce a final answer, and exit 0. The service previously treated the presence of any historical error block as a failed task, so successful recovered turns were recorded as failed.

## Real validation

Using the local ChatGPT subscription in `chat-crisp-saffron-garden`:

- Codex headless called `alice-workspace issue list` through the injected CLI with no approval prompt
- the same OpenAlice `resumeId` resumed and called `traderhub board get --board macro`
- the same session then called `alice-workspace issue show --id provenance-visibility-smoke`
- tool calls completed with zero tool failures and the post-fix task status was `done`

## Checks

- `pnpm exec vitest run src/workspaces/headless-task.spec.ts src/workspaces/headless-output.spec.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test` (236 passed, 1 skipped; 2688 tests passed, 6 skipped)
- `git diff --check`