### PR TITLE
Serialize config bootstrap across Alice and UTA

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       '@hono/node-server':
         specifier: ^2.0.0
         version: 2.0.0(hono@4.12.25)
+      '@traderalice/guardian-runtime':
+        specifier: workspace:*
+        version: link:../../packages/guardian-runtime
       '@traderalice/ibkr':
         specifier: workspace:*
         version: link:../../packages/ibkr

--- a/services/uta/package.json
+++ b/services/uta/package.json
@@ -15,6 +15,7 @@
     "@alpacahq/alpaca-trade-api": "^3.1.3",
     "@hono/node-server": "^2.0.0",
     "@traderalice/ibkr": "workspace:*",
+    "@traderalice/guardian-runtime": "workspace:*",
     "@traderalice/uta-protocol": "workspace:*",
     "ccxt": "^4.5.38",
     "decimal.js": "^10.6.0",

--- a/src/core/config-bootstrap-lock.spec.ts
+++ b/src/core/config-bootstrap-lock.spec.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { acquireRuntimeLock } from '@traderalice/guardian-runtime'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { withConfigBootstrapLock } from './config-bootstrap-lock.js'
+
+const roots: string[] = []
+
+async function lockPath(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-config-bootstrap-'))
+  roots.push(root)
+  return join(root, 'config-bootstrap.lock')
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('withConfigBootstrapLock', () => {
+  it('serializes concurrent config bootstraps', async () => {
+    const lockDir = await lockPath()
+    let active = 0
+    let maxActive = 0
+    const run = async () => withConfigBootstrapLock(async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 40))
+      active -= 1
+    }, { lockDir, waitMs: 5_000, pollMs: 5 })
+
+    await Promise.all([run(), run()])
+
+    expect(maxActive).toBe(1)
+  })
+
+  it('waits for a live owner without taking it over', async () => {
+    const lockDir = await lockPath()
+    const owner = await acquireRuntimeLock(lockDir, {
+      launcher: 'live-config-bootstrap-test',
+      heartbeatMs: 0,
+    })
+
+    await expect(withConfigBootstrapLock(async () => undefined, {
+      lockDir,
+      waitMs: 25,
+      pollMs: 5,
+    })).rejects.toThrow(new RegExp(`pid=${process.pid}`))
+
+    await owner.release()
+  })
+
+  it('reclaims a lock whose owner process is gone', async () => {
+    const lockDir = await lockPath()
+    const stale = await acquireRuntimeLock(lockDir, {
+      launcher: 'dead-config-bootstrap-test',
+      pid: 2_147_483_647,
+      processStartedAt: 0,
+      heartbeatMs: 0,
+    })
+    let ran = false
+
+    await withConfigBootstrapLock(async () => {
+      ran = true
+    }, { lockDir, waitMs: 5_000, pollMs: 5 })
+
+    expect(ran).toBe(true)
+    await stale.release()
+  })
+
+  it('releases ownership when config bootstrap throws', async () => {
+    const lockDir = await lockPath()
+
+    await expect(withConfigBootstrapLock(async () => {
+      throw new Error('bootstrap failed')
+    }, { lockDir, waitMs: 5_000, pollMs: 5 })).rejects.toThrow('bootstrap failed')
+
+    await expect(withConfigBootstrapLock(async () => 'recovered', {
+      lockDir,
+      waitMs: 5_000,
+      pollMs: 5,
+    })).resolves.toBe('recovered')
+  })
+})

--- a/src/core/config-bootstrap-lock.ts
+++ b/src/core/config-bootstrap-lock.ts
@@ -1,0 +1,80 @@
+import {
+  RuntimeAlreadyRunningError,
+  acquireRuntimeLock,
+  type RuntimeProcessLock,
+} from '@traderalice/guardian-runtime'
+
+import { dataPath } from './paths.js'
+
+const DEFAULT_WAIT_MS = 120_000
+const DEFAULT_POLL_MS = 25
+const DEFAULT_LOCK_DIR = dataPath('state', 'config-bootstrap.lock')
+
+export interface ConfigBootstrapLockOptions {
+  /** Override only for isolated tests. Production always uses the user-data root. */
+  readonly lockDir?: string
+  readonly waitMs?: number
+  readonly pollMs?: number
+}
+
+function positiveEnvNumber(name: string): number | undefined {
+  const value = Number(process.env[name])
+  return Number.isSafeInteger(value) && value > 0 ? value : undefined
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Serialize config bootstrap across Alice and UTA processes sharing one home.
+ *
+ * Both children legitimately call `loadConfig()` during startup. That path is
+ * write-capable: it runs migrations and seeds missing defaults. A Guardian
+ * runtime lock prevents a second OpenAlice instance, but it intentionally does
+ * not prevent sibling Alice/UTA children from running together, so this
+ * shorter critical-section lock is still required.
+ *
+ * A live owner is waited on and never taken over. Dead owners are reclaimed by
+ * the Guardian lock primitive using PID/start-time/token identity, which keeps
+ * crash recovery safe without treating a stale heartbeat as permission to
+ * unlock a process that may still write.
+ */
+export async function withConfigBootstrapLock<T>(
+  run: () => Promise<T>,
+  opts: ConfigBootstrapLockOptions = {},
+): Promise<T> {
+  const lockDir = opts.lockDir ?? DEFAULT_LOCK_DIR
+  const waitMs = opts.waitMs ?? DEFAULT_WAIT_MS
+  const pollMs = opts.pollMs ?? DEFAULT_POLL_MS
+  const deadline = Date.now() + waitMs
+  let lock: RuntimeProcessLock | null = null
+
+  while (lock === null) {
+    try {
+      lock = await acquireRuntimeLock(lockDir, {
+        launcher: `${process.env['OPENALICE_LAUNCHER'] ?? 'standalone'}-config-bootstrap`,
+        guardianPid: positiveEnvNumber('OPENALICE_GUARDIAN_PID'),
+        guardianStartedAt: positiveEnvNumber('OPENALICE_GUARDIAN_STARTED_AT'),
+      })
+    } catch (err) {
+      if (!(err instanceof RuntimeAlreadyRunningError)) throw err
+      if (Date.now() >= deadline) {
+        const owner = err.inspection.owner
+        throw new Error(
+          owner
+            ? `Timed out waiting for config bootstrap owned by ${owner.launcher} pid=${owner.pid}`
+            : `Timed out waiting for config bootstrap lock at ${lockDir}: ${err.inspection.reason}`,
+          { cause: err },
+        )
+      }
+      await sleep(Math.min(pollMs, Math.max(1, deadline - Date.now())))
+    }
+  }
+
+  try {
+    return await run()
+  } finally {
+    await lock.release()
+  }
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -5,6 +5,7 @@ import { homedir } from 'os'
 import { newsCollectorSchema } from '../domain/news/config.js'
 import { runMigrations } from '../migrations/runner.js'
 import { dataPath } from '@/core/paths.js'
+import { withConfigBootstrapLock } from './config-bootstrap-lock.js'
 import { isSealedEnvelope, seal, unseal } from './sealing.js'
 
 const CONFIG_DIR = dataPath('config')
@@ -518,6 +519,10 @@ async function parseAndSeed<T>(filename: string, schema: z.ZodType<T>, raw: unkn
 }
 
 export async function loadConfig(): Promise<Config> {
+  return withConfigBootstrapLock(loadConfigUnlocked)
+}
+
+async function loadConfigUnlocked(): Promise<Config> {
   // Run pending migrations before reading any section. Each migration is
   // recorded in data/config/_meta.json; the runner is a no-op when nothing
   // is pending. See src/migrations/INDEX.md for the full list.

--- a/src/workspaces/workspace-creator.spec.ts
+++ b/src/workspaces/workspace-creator.spec.ts
@@ -16,7 +16,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveCreateAgents, runScript } from './workspace-creator.js';
 
-vi.mock('node:child_process', () => ({
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...await importOriginal<typeof import('node:child_process')>(),
   spawn: vi.fn(),
 }));
 


### PR DESCRIPTION
## What changed

- wrap the full `loadConfig()` bootstrap path in a cross-process `config-bootstrap.lock`
- serialize migrations, config reads, and missing-default writes across Alice and UTA
- reuse Guardian runtime PID/start-time/token ownership instead of inventing a second lock protocol
- wait for live owners without takeover, reclaim dead owners, and release on bootstrap failure
- declare Guardian runtime as a UTA runtime dependency so dev, Electron, and Docker layouts resolve it
- keep the workspace-creator child-process mock partial now that config imports the process identity helper

## Root cause

Guardian intentionally starts Alice and UTA as sibling processes. Both call `loadConfig()` against the same `OPENALICE_HOME`; on a fresh home both could run migrations and seed defaults concurrently. Windows intermittently rejected the competing `_meta.json` write with `EBUSY`, causing Alice startup to fail. Existing Guardian instance locks cover competing OpenAlice instances, not these two legitimate sibling children.

## Safety semantics

- heartbeat age alone never permits takeover of a live process
- dead owners are reclaimed using the existing PID/start-time/token checks
- a waiter times out after 120 seconds rather than killing the active bootstrap owner
- the critical section covers migration and default seeding, not the long-lived process

## Validation

- Guardian full checks: runtime package typecheck/tests/build, root and Desktop typechecks, crash/takeover recovery smoke, full test suite, real dev Guardian smoke
- `pnpm test`: 237 passed, 1 skipped; 2692 tests passed, 6 skipped
- `pnpm build`
- Electron Guardian recovery/PTy smoke
- packaged Electron smoke with disposable data
- Docker build/runtime smoke with Claude, Codex, opencode, and Pi detected; Workspace PTY/CLI round-trip and offboarding passed
- focused config-lock and workspace-creator tests
- `git diff --check`

## Existing unrelated check

`pnpm -F @traderalice/uta-service typecheck` still reports the pre-existing Alpaca SDK argument-shape error at `AlpacaBroker.ts:502`; this PR does not touch that code. The actual UTA tsup build passes in root, Electron, and Docker builds.