### PR TITLE
Fix Quick Chat provider injection and workspace actions

### DIFF
--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -36,6 +36,7 @@ function build(opts: {
   sessionsByWorkspace?: Record<string, any[]>;
   recentChatWorkspaceId?: string | null;
   opencodeConfig?: WorkspaceAiCred | null;
+  opencodeRuntimeSource?: 'global-config' | 'global-login' | 'managed-runtime';
 } = {}) {
   const META = {
     id: 'ws-1',
@@ -104,7 +105,25 @@ function build(opts: {
     pool: { spawn, get: vi.fn(() => undefined) },
     publicMeta: vi.fn(async () => META),
     config: { launcherRepoRoot: '/repo' },
-    getAgentRuntimeReadiness: vi.fn(() => ({ agents: {}, overallReady: false, checkedAt: null })),
+    getAgentRuntimeReadiness: vi.fn(() => ({
+      agents: opts.opencodeRuntimeSource
+        ? {
+            opencode: {
+              agent: 'opencode',
+              displayName: 'opencode',
+              installed: true,
+              binPath: '/usr/local/bin/opencode',
+              status: 'ready',
+              ready: true,
+              source: opts.opencodeRuntimeSource,
+              checkedAt: '2026-07-12T00:00:00.000Z',
+              durationMs: 1,
+            },
+          }
+        : {},
+      overallReady: opts.opencodeRuntimeSource !== undefined,
+      checkedAt: opts.opencodeRuntimeSource ? '2026-07-12T00:00:00.000Z' : null,
+    })),
   } as unknown as WorkspaceService;
   const rememberRecentChatWorkspace = vi.fn(async (workspaceId: string | null) => ({
     lastCredentialByAgent: {},
@@ -198,6 +217,27 @@ describe('POST /quick-chat — loginless credential injection', () => {
     const cred = (opencode.writeAiConfig.mock.calls[0] as any[])[1];
     expect(cred.apiKey).toBe('sk-second');
     expect(cred.model).toBe('gpt-5.5-mini'); // remembered lastModel wins over flagship
+  });
+
+  it('explicit credential pick overrides a globally-ready opencode config', async () => {
+    vi.mocked(readCredentials).mockResolvedValue({
+      'openai-2': { ...openaiKey, apiKey: 'sk-second', lastModel: 'gpt-5.5-mini' },
+    });
+    const { app, opencode, spawn } = build({ opencodeRuntimeSource: 'global-config' });
+
+    const r = await quickChat(app, {
+      prompt: 'hi',
+      agent: 'opencode',
+      credentialSlug: 'openai-2',
+    });
+
+    expect(r.status).toBe(201);
+    expect(opencode.writeAiConfig).toHaveBeenCalledOnce();
+    expect((opencode.writeAiConfig.mock.calls[0] as any[])[1]).toMatchObject({
+      apiKey: 'sk-second',
+      model: 'gpt-5.5-mini',
+    });
+    expect(spawn).toHaveBeenCalledOnce();
   });
 
   it('claude is never injected (own CLI login) — vault is not even read', async () => {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -220,7 +220,10 @@ export function createWorkspaceRoutes(
         runtimeReadiness.source === 'global-login' ||
         runtimeReadiness.source === 'managed-runtime');
     try {
-      if (!runtimeIsGloballyReady) {
+      // Global login/config is a valid no-pick fallback, but it must never
+      // suppress an explicit Quick Chat credential choice. The selected vault
+      // credential belongs to this Workspace and must be written before spawn.
+      if (!runtimeIsGloballyReady || opts.credentialSlug !== undefined) {
         await ensureAgentCredentialReady({
           meta,
           agentId: adapter.id,

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -319,6 +319,7 @@
   flex: 1 1 auto;
   min-width: 0;
   min-height: 0;
+  position: relative;
 }
 
 /* Measure the space actually left for WorkspacePage after the global rail and
@@ -335,9 +336,16 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .workspace-page-shell .workspace-side,
-  .workspace-page-shell .workspace-files-toggle {
-    display: none;
+  /* Keep Files reachable in a narrow Workspace. A fixed second column would
+   * crush the terminal, so the same panel becomes a right-side overlay while
+   * its header toggle remains visible. */
+  .workspace-page-shell .workspace-side {
+    position: absolute;
+    inset: 0 0 0 auto;
+    width: min(360px, 100%);
+    z-index: 10;
+    background: var(--color-bg);
+    box-shadow: -18px 0 36px -28px rgba(0, 0, 0, 0.65);
   }
 }
 

--- a/ui/src/pages/ChatLandingPage.spec.ts
+++ b/ui/src/pages/ChatLandingPage.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveChatAgent, resolveChatCredential, resolveChatWorkspaceTarget } from './ChatLandingPage'
+import {
+  resolveChatAgent,
+  resolveChatCredential,
+  resolveChatWorkspaceTarget,
+  resolveQuickChatCredentialSlug,
+} from './ChatLandingPage'
 import type { AgentRuntimeReadinessSnapshot, Workspace } from '../components/workspace/api'
 
 const agents = [
@@ -178,5 +183,15 @@ describe('resolveChatCredential', () => {
   it('does not claim a deleted credential is available', () => {
     expect(resolveChatCredential(credentials, null, 'missing', true)).toBeNull()
     expect(resolveChatCredential(credentials, 'missing', null, false, null, 'saved-b')).toBe('saved-b')
+  })
+})
+
+describe('resolveQuickChatCredentialSlug', () => {
+  it('passes a resolved OpenCode/Pi credential even when runtime readiness came from global config', () => {
+    expect(resolveQuickChatCredentialSlug(true, 'meituan-longcat')).toBe('meituan-longcat')
+  })
+
+  it('does not send credentials to login-backed runtimes', () => {
+    expect(resolveQuickChatCredentialSlug(false, 'meituan-longcat')).toBeUndefined()
   })
 })

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -128,6 +128,16 @@ export function resolveChatCredential(
   return credentials?.[0]?.slug ?? null
 }
 
+/** The provider pill is a per-Workspace launch choice. Global runtime
+ * readiness may let a loginless runtime start without a vault credential, but
+ * it must not erase a credential the composer resolved for this launch. */
+export function resolveQuickChatCredentialSlug(
+  needsCredential: boolean,
+  effectiveCredential: string | null,
+): string | undefined {
+  return needsCredential ? (effectiveCredential ?? undefined) : undefined
+}
+
 /**
  * Quick-chat landing — the "type a message → you're in" front door for the
  * "Ask Alice" activity. A single composer: the user types a first message and
@@ -430,12 +440,11 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
         setError(runtimeRow?.message ?? t('chatLanding.runtimeNotReady'))
         return
       }
-      const runtimeUsesGlobalConfig =
-        runtimeRow.source === 'global-config' ||
-        runtimeRow.source === 'managed-runtime' ||
-        runtimeRow.source === 'global-login'
-      const credentialSlug =
-        needsCred && !runtimeUsesGlobalConfig ? (effectiveCred ?? undefined) : undefined
+      // A global OpenCode/Pi config is only a fallback when the user has not
+      // selected a vault credential for this launch. The provider pill is an
+      // explicit per-Workspace choice: always send it so the backend can write
+      // the selected provider/model before spawning the runtime.
+      const credentialSlug = resolveQuickChatCredentialSlug(needsCred, effectiveCred)
       // On success this focuses the new session's terminal tab; the landing tab
       // stays open in the background, so clear it for next time.
       const workspaceId = await quickChat(

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -16,8 +16,8 @@
  * keeps running on the server. Use the sidebar's × to actually delete.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { Bot, Monitor, Plus } from 'lucide-react'
+import { useEffect } from 'react'
+import { Bot, Monitor } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import '@xterm/xterm/css/xterm.css'
 
@@ -47,37 +47,22 @@ export function WorkspacePage({ spec, visible }: Props) {
     ? sessions.find((s) => s.id === sessionId) ?? null
     : null
   const keyMap = keyMapForAgent(activeRecord?.agent)
-  const [spawnMenuOpen, setSpawnMenuOpen] = useState(false)
-  const spawnMenuRef = useRef<HTMLDivElement | null>(null)
-  const runtimeAgents = useMemo(() => {
-    if (!workspace) return []
-    return workspace.agents
-      .map((id) => ctx.agents.find((a) => a.id === id))
-      .filter((a): a is NonNullable<typeof a> => !!a && a.kind !== 'utility')
-  }, [ctx.agents, workspace])
-  const utilityAgents = useMemo(() => {
-    if (!workspace) return []
-    return workspace.agents
-      .map((id) => ctx.agents.find((a) => a.id === id))
-      .filter((a): a is NonNullable<typeof a> => !!a && a.kind === 'utility')
-  }, [ctx.agents, workspace])
   const defaultAgentEnabled =
     ctx.defaultAgent !== null &&
     workspace?.agents.includes(ctx.defaultAgent) === true &&
-    runtimeAgents.some((a) => a.id === ctx.defaultAgent)
-
-  const spawnWithAgent = async (agentId: string, saveDefault: boolean): Promise<void> => {
-    setSpawnMenuOpen(false)
-    if (saveDefault) await ctx.setDefaultAgent(agentId)
-    await ctx.spawn(wsId, { agent: agentId }, source)
-  }
+    ctx.agents.some((a) => a.id === ctx.defaultAgent && a.kind !== 'utility')
 
   const spawnDefault = (): void => {
     if (defaultAgentEnabled && ctx.defaultAgent) {
       void ctx.spawn(wsId, { agent: ctx.defaultAgent }, source)
       return
     }
-    setSpawnMenuOpen((v) => !v)
+    // The old header dropdown duplicated the global New chat flow and left a
+    // second, stale session-creation surface in every Workspace. When no
+    // default runtime is configured, take the remaining empty-state/shortcut
+    // entry points to the targeted composer, which owns runtime + credential
+    // selection.
+    openOrFocus({ kind: 'chat-landing', params: { targetWsId: wsId } })
   }
 
   // Cmd+T / Ctrl+T: spawn fresh session in this workspace; only when this
@@ -96,24 +81,6 @@ export function WorkspacePage({ spec, visible }: Props) {
     document.addEventListener('keydown', handler, { capture: true })
     return () => document.removeEventListener('keydown', handler, { capture: true })
   }, [visible, ctx, wsId, defaultAgentEnabled])
-
-  useEffect(() => {
-    if (!spawnMenuOpen) return
-    const onDocClick = (e: MouseEvent): void => {
-      if (spawnMenuRef.current?.contains(e.target as Node)) return
-      setSpawnMenuOpen(false)
-    }
-    const onEsc = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setSpawnMenuOpen(false)
-    }
-    const tid = setTimeout(() => document.addEventListener('click', onDocClick), 0)
-    document.addEventListener('keydown', onEsc)
-    return () => {
-      clearTimeout(tid)
-      document.removeEventListener('click', onDocClick)
-      document.removeEventListener('keydown', onEsc)
-    }
-  }, [spawnMenuOpen])
 
   if (!workspace) {
     return (
@@ -155,44 +122,6 @@ export function WorkspacePage({ spec, visible }: Props) {
               {(activeRecord.surface ?? 'terminal') === 'webpi' ? 'Open TUI' : 'WebPi · Beta'}
             </button>
           )}
-          <div ref={spawnMenuRef} className="relative">
-            <button
-              type="button"
-              onClick={spawnDefault}
-              className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
-              title={t('workspace.newSessionTitle')}
-            >
-              <Plus size={13} strokeWidth={2.25} aria-hidden="true" />
-              {t('workspace.newSession')}
-            </button>
-            {spawnMenuOpen && (
-              <div className="absolute right-0 top-full mt-1 w-44 rounded-md border border-border bg-bg-secondary shadow-lg py-1 z-20">
-                {runtimeAgents.map((agent) => (
-                  <button
-                    key={agent.id}
-                    type="button"
-                    onClick={() => void spawnWithAgent(agent.id, true)}
-                    className="w-full px-3 py-1.5 text-left text-[12px] text-text-muted hover:text-text hover:bg-bg-tertiary"
-                  >
-                    {agent.displayName}
-                  </button>
-                ))}
-                {utilityAgents.length > 0 && runtimeAgents.length > 0 && (
-                  <div className="my-1 border-t border-border" />
-                )}
-                {utilityAgents.map((agent) => (
-                  <button
-                    key={agent.id}
-                    type="button"
-                    onClick={() => void spawnWithAgent(agent.id, false)}
-                    className="w-full px-3 py-1.5 text-left text-[12px] text-text-muted hover:text-text hover:bg-bg-tertiary"
-                  >
-                    {agent.displayName}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
           <WorkspaceFilesToggle />
           <button
             type="button"


### PR DESCRIPTION
## What changed

- always carry the resolved OpenCode/Pi credential from Quick Chat into the target Workspace, even when the runtime readiness probe reports a global config/login
- make an explicit credential pick override globally-ready runtime state before spawn
- remove the duplicate workspace-header New session menu
- keep the Files action available at narrow content widths and show the file tree as an overlay instead of crushing the terminal
- route the remaining empty-state/keyboard spawn fallback through the targeted Quick Chat composer when no default runtime exists

## Root cause

Quick Chat treated global runtime readiness as permission to omit `credentialSlug`, and the backend repeated that shortcut even for an explicit selection. Separately, the narrow workspace container query hid both the fixed file column and its toggle, leaving the obsolete New session action as the only visible header affordance.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (2695 passed, 6 skipped)
- live `/chat/workspaces/...` verification at narrow content width: Files visible, overlay opens, header New session absent
- `pnpm electron:smoke:workspace` (packaged workspace acceptance passed; temporary package auto-cleaned)