### PR TITLE
Document unsigned development package policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,21 @@ needed. A package passed through `--skip-pack` is externally owned and must
 never be deleted by the smoke runner; use `--keep-package` to preserve a
 temporary smoke package for investigation.
 
+Code signing and notarization are release gates, not routine development
+checks. Serial/parallel `dev` work, ordinary PR package smokes, and local
+packaged-runtime debugging must build unsigned (`CSC_IDENTITY_AUTO_DISCOVERY=false`)
+and must not read release signing secrets. Run a real signed/notarized build
+only for a versioned release candidate, an explicit release rehearsal, or a
+change whose subject is the signing/notarization/update chain. State that
+release-only residual risk instead of making every development iteration pay
+the signing cost.
+
+When optimizing CI/CD, preserve the lane boundaries above. First remove
+duplicate jobs, cancel superseded runs, narrow path triggers, reuse caches and
+unsigned build artifacts, and measure the slow step before considering larger
+runners. Do not trade away the full `master` promotion/release gates merely to
+make routine `dev` feedback look faster.
+
 ## Deferred Work and Issues
 
 Use GitHub issues for concrete deferred findings. Do not create repo TODO files

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -150,6 +150,46 @@ must still produce Windows and macOS evidence. In serial `dev` work that
 evidence may arrive after merge, but a known failure stops the next increment;
 it must be green before promotion to `master` or release.
 
+### Package signing boundary
+
+Packaging evidence and release-signing evidence are different gates:
+
+- Routine local work and PR package smoke build unpacked/unsigned artifacts
+  with `CSC_IDENTITY_AUTO_DISCOVERY=false`. They verify resource layout,
+  Guardian startup, managed runtimes, Workspace CLI acceptance, and
+  platform-specific behavior without touching signing identities or
+  notarization services.
+- Signed/notarized builds run only for a versioned release candidate, an
+  explicit release rehearsal, or a change directly concerning signing,
+  notarization, auto-update metadata, or release publication.
+- A development agent must not run a signed package merely because Electron or
+  packaging code changed. Report signing as release-only residual risk and use
+  the unsigned package smoke that matches the affected surface.
+- Temporary expanded apps are disposable test artifacts. Prefer the smoke
+  runner's isolated auto-clean path; preserve one only when investigation or a
+  human tester actually needs it.
+
+This boundary keeps expensive, credentialed, externally rate-limited release
+work out of the interactive development loop while retaining the same runtime
+and resource-layout coverage.
+
+### CI/CD optimization order
+
+Optimize measured waiting time without collapsing the confidence lanes:
+
+1. cancel superseded work and avoid repeating the PR matrix on `dev` push;
+2. use narrow path classification to skip irrelevant host/package jobs;
+3. cache dependency, build, and safe unsigned-package inputs across jobs;
+4. split fast contract/type gates from slower host/runtime acceptance so the
+   first actionable failure arrives early;
+5. measure queue time versus install/build/test time before buying larger
+   runners;
+6. keep complete promotion/release acceptance, signing, and publication gated
+   even when routine `dev` feedback is deliberately asynchronous.
+
+Any CI optimization PR should include before/after timing evidence and name the
+confidence gate it preserves, moves, or removes.
+
 ## Merge and Cleanup
 
 The normal merge method is a merge commit:


### PR DESCRIPTION
## What changed

- define signing and notarization as release-only gates in `AGENTS.md`
- require routine local and PR package verification to build unsigned
- forbid development agents from reading release signing secrets for ordinary work
- document CI/CD optimization order: deduplicate, narrow path triggers, cache, split fast/slow gates, measure, then consider larger runners
- preserve complete `master` promotion and release acceptance

## Why

Routine Electron development needs packaged runtime and resource-layout evidence, but a signed/notarized build adds credentialed external work and substantial latency without improving ordinary development feedback.

## Validation

- documentation diff and whitespace check
- previous serial increment #571 checked: no completed CI failures at publication time
