### PR TITLE
Add Connector page to beta features

### DIFF
--- a/ui/src/components/DevCategoryList.tsx
+++ b/ui/src/components/DevCategoryList.tsx
@@ -1,11 +1,12 @@
 import { useTranslation } from 'react-i18next'
-import { Wrench, Camera, ScrollText, FlaskConical, Compass } from 'lucide-react'
+import { Wrench, Camera, ScrollText, FlaskConical, Compass, Plug } from 'lucide-react'
 import { useWorkspace } from '../tabs/store'
 import { getFocusedTab } from '../tabs/types'
 import { SidebarRow } from './SidebarRow'
 
 const CATEGORIES = [
   { labelKey: 'common.tools', tab: 'tools', Icon: Wrench },
+  { labelKey: 'settings.category.connectors', tab: 'connectors', Icon: Plug },
   { label: 'Onboarding', tab: 'onboarding', Icon: Compass },
   { labelKey: 'dev.snapshots', tab: 'snapshots', Icon: Camera },
   { labelKey: 'common.logs', tab: 'logs', Icon: ScrollText },

--- a/ui/src/pages/DevPage.tsx
+++ b/ui/src/pages/DevPage.tsx
@@ -6,6 +6,7 @@ import { useToast } from '../components/Toast'
 import { LogsPage } from './LogsPage'
 import { SimulatorPage } from './SimulatorPage'
 import { OnboardingDesignPage } from './OnboardingDesignPage'
+import { ConnectorsPage } from './ConnectorsPage'
 import {
   toolsApi,
   type ToolInfo,
@@ -22,6 +23,7 @@ type Tab = Extract<ViewSpec, { kind: 'dev' }>['params']['tab']
 
 const TAB_TITLES: Record<Tab, string> = {
   tools: 'Tools',
+  connectors: 'Connectors',
   onboarding: 'Onboarding',
   snapshots: 'Snapshots',
   logs: 'Logs',
@@ -39,6 +41,12 @@ interface DevPageProps {
 
 export function DevPage({ spec }: DevPageProps) {
   const tab = spec.params.tab
+
+  // Settings and Dev are two navigation contexts over one Connector surface.
+  // Reuse the page wholesale so credentials, health, and probe behavior cannot
+  // drift into separate implementations. ConnectorsPage owns its own header
+  // and scrolling layout, unlike the older inline Dev tabs below.
+  if (tab === 'connectors') return <ConnectorsPage />
 
   return (
     <div className="flex flex-col flex-1 min-h-0">

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { Navigate, Route, Routes, useParams, useSearchParams } from 'react-router-dom'
 import { useWorkspace } from './store'
-import { specEquals, type ActivitySection, type ViewSpec } from './types'
+import { isDevTab, specEquals, type ActivitySection, type ViewSpec } from './types'
 import { getView } from './registry'
 
 /**
@@ -185,8 +185,7 @@ function AdoptUtaDetail() {
 
 function AdoptDev() {
   const { tab } = useParams<{ tab: string }>()
-  const valid: ReadonlyArray<string> = ['tools', 'onboarding', 'snapshots', 'logs', 'simulator']
-  if (!tab || !valid.includes(tab)) return <Navigate to="/dev/tools" replace />
+  if (!tab || !isDevTab(tab)) return <Navigate to="/dev/tools" replace />
   return (
     <AdoptStatic
       spec={{

--- a/ui/src/tabs/__tests__/store.spec.ts
+++ b/ui/src/tabs/__tests__/store.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useWorkspace } from '../store'
-import { specEquals, getFocusedGroup, getFocusedTab, type ViewSpec } from '../types'
+import { specEquals, getFocusedGroup, getFocusedTab, isDevTab, type ViewSpec } from '../types'
 
 // Reset zustand state + localStorage before each test so cases stay isolated.
 function resetStore() {
@@ -16,6 +16,13 @@ function resetStore() {
 }
 
 beforeEach(resetStore)
+
+describe('Dev URL tabs', () => {
+  it('accepts the Connector beta surface and rejects unknown tabs', () => {
+    expect(isDevTab('connectors')).toBe(true)
+    expect(isDevTab('connector')).toBe(false)
+  })
+})
 
 // A sample ViewSpec whose params vary by a single string, used to drive
 // tab-store mechanics (open/focus/close/dedup). market-detail fits: its

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -322,6 +322,7 @@ const designProjectModule: ViewModule<'design-project'> = {
 
 const devTabTitle: Record<Extract<ViewSpec, { kind: 'dev' }>['params']['tab'], string> = {
   tools: 'Tools',
+  connectors: 'Connectors',
   onboarding: 'Onboarding',
   snapshots: 'Snapshots',
   logs: 'Logs',

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -15,6 +15,14 @@
 
 export type WorkspaceSource = 'chat'
 
+/** One source of truth for the Dev sidebar and `/dev/:tab` URL contract. */
+export const DEV_TABS = ['tools', 'connectors', 'onboarding', 'snapshots', 'logs', 'simulator'] as const
+export type DevTab = typeof DEV_TABS[number]
+
+export function isDevTab(value: string): value is DevTab {
+  return (DEV_TABS as readonly string[]).includes(value)
+}
+
 export type ViewSpec =
   | { kind: 'workspace-list'; params: Record<string, never> }
   | { kind: 'workspace';      params: { wsId: string; sessionId?: string; source?: WorkspaceSource } }
@@ -35,7 +43,7 @@ export type ViewSpec =
   | { kind: 'uta-detail';     params: { id: string } }
   | { kind: 'onboarding';     params: Record<string, never> }
   | { kind: 'design-project'; params: { project: string } }
-  | { kind: 'dev';            params: { tab: 'tools' | 'onboarding' | 'snapshots' | 'logs' | 'simulator' } }
+  | { kind: 'dev';            params: { tab: DevTab } }
   | { kind: 'inbox';               params: Record<string, never> }
   | { kind: 'tracked';             params: Record<string, never> }
   | { kind: 'chat-landing';        params: { targetWsId?: string } }


### PR DESCRIPTION
## What changed

- add Connectors to the Beta/Dev sidebar
- expose the shared Connector settings and health surface at `/dev/connectors`
- keep Settings and Beta Features on one `ConnectorsPage` implementation
- centralize valid Dev URL tabs and cover the Connector route contract

## Why

Connector development currently requires navigating through product Settings. A Beta Features entry makes service enablement, adapter configuration, health, and probe testing directly accessible during development without creating a second configuration implementation.

## Validation

- `pnpm vitest run ui/src/tabs/__tests__/store.spec.ts` — 25 passed
- `cd ui && npx tsc -b`
- browser verification at `http://localhost:5173/dev/connectors`
- verified sidebar selection, page heading, Connector Service data, refresh recovery, and absence of load errors
