### PR TITLE
Add UI motion foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,8 @@ Read the relevant guide before editing its subsystem:
   remote-host safety, persistence, health, and container acceptance.
 - [[docs/connector-service.md]] — [Connector Service](docs/connector-service.md): optional external Inbox
   notification adapters, sealed credentials, health, and Guardian lifecycle.
+- [[docs/ui-interaction-and-motion.md]] — [UI interaction and motion](docs/ui-interaction-and-motion.md):
+  clickable affordances, shared motion primitives, and reduced-motion policy.
 - [[docs/workspace-agent-guidance.md]] — [Workspace agent guidance](docs/workspace-agent-guidance.md): prompt
   layers, skill ownership, live CLI authority, and guidance versioning.
 - [[docs/workspace-lifecycle.md]] — [Workspace and Session lifecycle](docs/workspace-lifecycle.md): offboarding,

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ GitHub navigation.
 | [[docs/managed-workspace-runtime.md]] | [Managed Workspace runtime](managed-workspace-runtime.md) | Electron packaging, managed Pi, PortableGit/Bash, runtime profile, Workspace PATH |
 | [[docs/docker-deployment.md]] | [Docker deployment](docker-deployment.md) | Server image topology, remote-host safety, persistence, health, and container acceptance |
 | [[docs/connector-service.md]] | [Connector Service](connector-service.md) | Optional Discord/Telegram Inbox projection, adapters, secrets, health, Guardian lifecycle |
+| [[docs/ui-interaction-and-motion.md]] | [UI interaction and motion](ui-interaction-and-motion.md) | Clickable affordances, shared motion tokens, entrances/disclosures, reduced-motion policy |
 | [[docs/workspace-agent-guidance.md]] | [Workspace agent guidance](workspace-agent-guidance.md) | Always-loaded prompt contract, skill ownership, live CLI authority, guidance versioning |
 | [[docs/workspace-lifecycle.md]] | [Workspace and Session lifecycle](workspace-lifecycle.md) | Offboarding, departed directories, handoff, restore/purge, Session retirement |
 | [[docs/workspace-issues-and-scheduling.md]] | [Workspace issues and scheduling](workspace-issues-and-scheduling.md) | Markdown issue contract, global board, schedule scanner, headless execution, Inbox delivery |

--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -98,6 +98,37 @@ not ordinary operator-entered configuration.
 Both adapters reject commands from any account other than the linked owner.
 Use `/status` for adapter health and `/test` for an explicit delivery check.
 
+### Setup lifecycle and UI ownership
+
+Connector setup is a lifecycle, not a single `enabled` checkbox. Keep these
+states explicit because collapsing them recreates the dead end where a token is
+saved but no bot process exists to receive `/link`.
+
+| Product state | Durable facts | Runtime fact | Primary action |
+|---|---|---|---|
+| Credentials needed | required secret/fields missing | adapter stopped | create the platform bot and save credentials |
+| Ready to link | credentials sealed, owner absent | adapter stopped | start the bot for linking |
+| Starting | adapter enabled, owner absent | Guardian/service reconciling | wait; Settings polls health without replacing form drafts |
+| Awaiting link | credentials sealed, owner absent | bot online with `awaiting_link` | open the private bot chat and send `/link` |
+| Linked | owner identity learned | adapter `healthy` | send tests or receive Inbox delivery |
+| Linked offline | owner identity retained | adapter/service intentionally stopped | start the connector when external delivery is wanted |
+| Error | durable config retained | adapter `degraded` or service unavailable | inspect credentials and Connector logs |
+
+The surfaces deliberately have different jobs:
+
+- **Settings → Connectors** owns credentials, the setup sequence, enable/stop,
+  linking instructions, and explicit test sends.
+- **Beta → Connectors** is a read-only operations view: service health, adapter
+  status, linked owner, and last delivery evidence.
+- **Dev Panel** may expose logs and replay tooling, but it is not a product
+  configuration surface.
+
+The Connector Service switch is a global kill switch. Starting an adapter from
+the setup flow may enable the service and adapter together; stopping the global
+service never deletes sealed credentials or the learned owner. Health polling
+during linking updates runtime health only. It must not replace the current
+Settings draft, reveal secrets, or create an auto-save/restart loop.
+
 ## Health Contract and Tests
 
 UTA and Connector Service are both optional external services. Alice probes

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -1,0 +1,82 @@
+# UI Interaction and Motion
+
+This guide owns OpenAlice interaction feedback: clickable affordances, motion
+tokens, entrance/disclosure behavior, and reduced-motion policy. It complements
+the component conventions in `ui/src/index.css` and the shared shell components
+under `ui/src/components/`.
+
+## Product Intent
+
+OpenAlice is a working console, not a static report. Motion should make the
+interface feel responsive and help the eye retain context without turning live
+trading surfaces into ambient animation.
+
+Use motion for four jobs:
+
+1. **Affordance** — buttons and clickable rows visibly respond to hover/press.
+2. **Continuity** — a newly focused view or expanded hierarchy arrives from the
+   direction implied by the interaction.
+3. **State change** — health/setup surfaces blend between states instead of
+   flashing to unrelated colors.
+4. **Activity** — looping motion is reserved for genuine loading, live data, or
+   work in progress.
+
+Do not animate merely to decorate empty space. Avoid long transitions on dense
+tables, competing loops, scroll hijacking, and transforms that move controls
+away from the pointer.
+
+## Shared Vocabulary
+
+Motion tokens and primitives live in `ui/src/index.css`:
+
+| Primitive | Intended use |
+|---|---|
+| `--motion-fast` | direct press/icon feedback |
+| `--motion-standard` | page, disclosure, hover, and most state transitions |
+| `--motion-slow` | dialogs and visually larger state changes |
+| `.oa-pressable` | primary or bordered buttons that lift one pixel on hover |
+| `.oa-icon-action` | compact icon/add/collapse controls |
+| `.oa-nav-item` / `.oa-nav-row` | rail and secondary-sidebar navigation |
+| `.oa-view-enter` | focused view entrance, owned by `TabHost` |
+| `.oa-dialog-*` | shared dialog surface and backdrop entrance |
+| `.oa-disclosure-enter` | newly expanded hierarchical content |
+| `.oa-popover-enter` | menus and compact floating choices |
+| `.oa-status-surface` | smooth health/setup card state changes |
+
+Prefer these primitives over copying arbitrary `duration-*`, easing curves, or
+keyframes into individual pages. A local animation is justified when it conveys
+domain-specific state that the shared vocabulary cannot express.
+
+Clickable native and ARIA controls receive a pointer cursor globally. Disabled
+controls keep the default cursor and must remain visually disabled. Hover-only
+transforms are gated to fine pointers, so touch devices do not inherit a fake
+hover state.
+
+## Accessibility and Performance
+
+Every shared entrance, loop, and transform honors
+`prefers-reduced-motion: reduce`. Reduced motion removes animation and transform
+movement while preserving color, focus, and state information.
+
+Keep entrance distances small (roughly 4–8 px) and durations below 300 ms.
+Animate `transform` and `opacity` for movement; use short color/border/box-shadow
+transitions for feedback. Do not add permanent `will-change` to large lists or
+page containers.
+
+Keyboard focus is not a motion effect. Interactive controls still require a
+clear `focus-visible` treatment, meaningful labels, and sensible tab order.
+
+## Verification
+
+For motion changes:
+
+1. exercise the real route with a mouse/trackpad and keyboard;
+2. verify light and dark themes where elevation or shadows changed;
+3. verify a narrow layout so transforms do not cause clipping;
+4. enable reduced motion at the OS/browser level and confirm state remains
+   legible without animation;
+5. check that repeated navigation does not restart expensive background work or
+   remount a surface that intentionally stays alive.
+
+Motion should be judged in the running UI. A class name or screenshot alone
+cannot prove timing, continuity, or pointer feedback.

--- a/packages/connector-protocol/tsconfig.json
+++ b/packages/connector-protocol/tsconfig.json
@@ -11,5 +11,6 @@
     "skipLibCheck": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -265,7 +265,7 @@ export function ActivityBar({
                   />
                 )}
                 {showItems && (
-                  <div className={`flex flex-col ${denseRail ? 'gap-1 md:gap-px' : 'gap-1'}`} id={`activity-section-${si}`}>
+                  <div className={`oa-disclosure-enter flex flex-col ${denseRail ? 'gap-1 md:gap-px' : 'gap-1'}`} id={`activity-section-${si}`}>
                     {section.items.map((item) => {
                       const sec = activitySectionFor(item.page)
                       const isActive = selectedSidebar === sec
@@ -281,7 +281,7 @@ export function ActivityBar({
                           type="button"
                           onClick={handleClick}
                           title={t(item.labelKey)}
-                          className={`relative flex items-center rounded-md transition-colors text-left ${
+                          className={`oa-nav-item relative flex items-center rounded-md text-left ${
                             compactRail
                               ? denseRail
                                 ? 'md:h-[26px] md:w-8 md:min-h-[26px] md:justify-center md:gap-0 md:px-0 md:py-0'
@@ -302,7 +302,7 @@ export function ActivityBar({
                             }`}
                             aria-hidden
                           />
-                          <span className={`relative flex items-center justify-center w-5 h-5 shrink-0 ${denseRail ? 'md:w-3.5 md:h-3.5' : ''}`}>
+                          <span className={`oa-nav-icon relative flex items-center justify-center w-5 h-5 shrink-0 ${denseRail ? 'md:w-3.5 md:h-3.5' : ''}`}>
                             <Icon size={denseRail ? 14 : 16} strokeWidth={1.75} />
                           </span>
                           <span className={`flex-1 truncate ${compactRail ? 'md:hidden' : ''}`}>{t(item.labelKey)}</span>
@@ -345,7 +345,7 @@ export function ActivityBar({
               onClick={() => setRailCollapsed(!railCollapsed)}
               title={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
               aria-label={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
-              className={`hidden ${denseRail ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text md:flex`}
+              className={`oa-icon-action hidden ${denseRail ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text md:flex`}
             >
               {railCollapsed
                 ? <PanelLeftOpen size={denseRail ? 14 : 17} strokeWidth={1.75} aria-hidden />
@@ -427,7 +427,7 @@ function SectionHeader({
         )}
       </div>
       {showItems && description && hintOpen && (
-        <p className="mb-2 px-3 text-[11px] leading-relaxed text-text-muted">
+        <p className="oa-disclosure-enter mb-2 px-3 text-[11px] leading-relaxed text-text-muted">
           {description}
         </p>
       )}

--- a/ui/src/components/ContextMenu.tsx
+++ b/ui/src/components/ContextMenu.tsx
@@ -78,7 +78,7 @@ export function ContextMenu({ anchor, items, onClose }: ContextMenuProps) {
         top: pos.y,
         zIndex: 60,
       }}
-      className="min-w-[180px] py-1 bg-bg-secondary border border-border rounded-md shadow-xl"
+      className="oa-popover-enter min-w-[180px] py-1 bg-bg-secondary border border-border rounded-md shadow-xl"
     >
       {items.map((item, i) => {
         if (item.kind === 'separator') {

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -165,7 +165,7 @@ export function PageSidebarLayout({
       <button
         type="button"
         onClick={() => updateCollapsed(true)}
-        className="flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
+        className="oa-icon-action flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
         aria-label={t('common.collapsePanel', { title })}
         title={t('common.focusContent')}
       >
@@ -191,7 +191,7 @@ export function PageSidebarLayout({
             <button
               type="button"
               onClick={() => updateCollapsed(false)}
-              className="flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
+              className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
               aria-label={t('common.openPanel', { title })}
               title={t('common.openPanel', { title })}
             >
@@ -228,7 +228,7 @@ export function PageSidebarLayout({
         <button
           type="button"
           onClick={() => setDrawerOpen(true)}
-          className="flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
+          className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
           aria-label={t('common.openPanel', { title })}
           title={title}
         >

--- a/ui/src/components/SidebarRow.tsx
+++ b/ui/src/components/SidebarRow.tsx
@@ -53,7 +53,7 @@ export function SidebarRow({ label, active = false, onClick, icon, trail, title,
           onClick()
         }
       }}
-      className={`group relative flex min-h-10 items-center gap-1.5 px-3 py-2 text-[13px] cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
+      className={`oa-nav-row group relative flex min-h-10 items-center gap-1.5 px-3 py-2 text-[13px] cursor-pointer outline-none focus-visible:bg-bg-tertiary/70 ${
         active
           ? 'bg-bg-tertiary text-text'
           : 'text-text hover:bg-bg-tertiary/50'

--- a/ui/src/components/TabHost.tsx
+++ b/ui/src/components/TabHost.tsx
@@ -60,7 +60,7 @@ function TabFrame({ tab, visible }: { tab: Tab; visible: boolean }) {
     <div
       data-view-frame={tab.spec.kind}
       data-view-visible={visible ? 'true' : 'false'}
-      className="absolute inset-0 flex flex-col min-h-0"
+      className={`absolute inset-0 flex min-h-0 flex-col ${visible ? 'oa-view-enter' : ''}`}
       style={{
         visibility: visible ? 'visible' : 'hidden',
         pointerEvents: visible ? 'auto' : 'none',

--- a/ui/src/components/uta/Dialog.tsx
+++ b/ui/src/components/uta/Dialog.tsx
@@ -18,8 +18,8 @@ export function Dialog({ onClose, width, children }: {
   return (
     // z-[60] keeps dialogs above the mobile nav drawers (z-50).
     <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className={`relative ${width || 'w-full sm:w-[560px]'} max-w-[95vw] max-h-[85vh] bg-bg rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden`}>
+      <div className="oa-dialog-backdrop absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className={`oa-dialog-surface relative ${width || 'w-full sm:w-[560px]'} max-w-[95vw] max-h-[85vh] bg-bg rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden`}>
         {children}
       </div>
     </div>

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -87,7 +87,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
         <button
           type="button"
           onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
-          className="flex w-full items-center gap-2 rounded-lg border border-accent/25 bg-accent/10 px-3 py-2.5 text-left text-[13px] font-medium text-text transition-colors hover:border-accent/45 hover:bg-accent/15"
+          className="oa-pressable flex w-full items-center gap-2 rounded-lg border border-accent/25 bg-accent/10 px-3 py-2.5 text-left text-[13px] font-medium text-text hover:border-accent/45 hover:bg-accent/15"
         >
           <MessageSquarePlus size={15} strokeWidth={2.15} className="shrink-0 text-accent" />
           <span>{t('chat.newChat')}</span>
@@ -103,7 +103,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
         <button
           type="button"
           onClick={() => setShowCreate(true)}
-          className="flex w-full items-center gap-2 rounded-lg border border-border/70 bg-bg-secondary/45 px-3 py-2 text-left text-[12px] font-medium text-text-muted transition-colors hover:border-border hover:bg-bg-tertiary hover:text-text"
+          className="oa-pressable flex w-full items-center gap-2 rounded-lg border border-border/70 bg-bg-secondary/45 px-3 py-2 text-left text-[12px] font-medium text-text-muted hover:border-border hover:bg-bg-tertiary hover:text-text"
           title={t('chat.newWorkspace')}
           aria-label={t('chat.newWorkspace')}
         >
@@ -295,7 +295,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
             e.stopPropagation()
             props.onSpawn()
           }}
-          className="shrink-0 w-5 h-5 rounded flex items-center justify-center text-text-muted/50 hover:text-text hover:bg-bg-secondary transition-colors"
+          className="oa-icon-action shrink-0 w-5 h-5 rounded flex items-center justify-center text-text-muted/50 hover:text-text hover:bg-bg-secondary transition-colors"
           title={t('chat.newSession')}
           aria-label={t('chat.newSession')}
         >
@@ -308,7 +308,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               e.stopPropagation()
               props.onConfigure()
             }}
-            className="w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-secondary"
+            className="oa-icon-action w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-secondary"
             title={t('workspace.configure')}
             aria-label={t('workspace.configure')}
           >
@@ -320,7 +320,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               e.stopPropagation()
               props.onDelete()
             }}
-            className="w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-red hover:bg-red/10"
+            className="oa-icon-action w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-red hover:bg-red/10"
             title={t('chat.deleteWorkspace')}
             aria-label={t('chat.deleteWorkspace')}
           >
@@ -329,7 +329,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
         </span>
       </div>
       {expanded && orderedSessions.length > 0 && (
-        <div ref={sessionListRef} className="ml-[18px] border-l border-border/50">
+        <div ref={sessionListRef} className="oa-disclosure-enter ml-[18px] border-l border-border/50">
           {orderedSessions.map((s) => (
             <SessionRow
               key={s.id}

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -136,7 +136,7 @@ export function Sidebar(props: SidebarProps): ReactElement {
         <button
           type="button"
           onClick={() => setShowCreate(true)}
-          className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-border/60 bg-bg-tertiary/30 text-[13px] font-medium text-text-muted transition-colors hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/60"
+          className="oa-pressable w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-border/60 bg-bg-tertiary/30 text-[13px] font-medium text-text-muted hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/60"
         >
           <Plus size={15} strokeWidth={2.25} className="shrink-0" />
           <span className="truncate">{t('workspace.newWorkspace')}</span>
@@ -245,7 +245,7 @@ function NavRow({
       type="button"
       onClick={onClick}
       title={title}
-      className={`relative flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-left transition-colors ${
+      className={`oa-nav-row relative flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-left ${
         active ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
       }`}
     >
@@ -312,7 +312,7 @@ function AgentBadgeGlyph({ agentId }: { agentId: string }): ReactElement {
 
 /** Hover-revealed square action button used for the per-row controls. */
 function rowAction(danger = false): string {
-  return `shrink-0 w-5 h-5 rounded flex items-center justify-center text-text-muted/70 transition-colors ${
+  return `oa-icon-action shrink-0 w-5 h-5 rounded flex items-center justify-center text-text-muted/70 transition-colors ${
     danger ? 'hover:text-red hover:bg-red/10' : 'hover:text-text hover:bg-bg-secondary'
   }`;
 }
@@ -444,7 +444,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
               <ul
                 ref={menuRef}
                 role="menu"
-                className="absolute right-0 top-full mt-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
+                className="oa-popover-enter absolute right-0 top-full mt-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
               >
                 {runtimeAgents.map((agent) => (
                   <li key={agent.id}>
@@ -577,7 +577,7 @@ function HeadlessGroup(props: {
         {runningCount > 0 && <span className="ml-0.5 w-1.5 h-1.5 rounded-full bg-accent" />}
       </button>
       {open && (
-        <div className="ml-[7px] border-l border-border/50">
+        <div className="oa-disclosure-enter ml-[7px] border-l border-border/50">
           {props.tasks.map((t) => (
             <HeadlessTaskRow key={t.taskId} task={t} onOpenAsSession={props.onOpenAsSession} />
           ))}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -45,6 +45,11 @@
 :root {
   color-scheme: light;
   --app-bg-wash: radial-gradient(circle at 50% 24%, rgba(47, 98, 176, 0.045), transparent 38rem);
+  --motion-fast: 120ms;
+  --motion-standard: 180ms;
+  --motion-slow: 260ms;
+  --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
 }
 
 /* ---- Midnight — dark (neutral charcoal-black) ----
@@ -138,6 +143,157 @@ body {
 ::selection {
   background: color-mix(in srgb, var(--color-accent) 28%, transparent);
   color: var(--color-text);
+}
+
+/* ==================== Interaction + motion foundation ====================
+   Motion explains hierarchy and confirms intent; it should not turn the shell
+   into a moving background. Keep transforms on explicitly marked controls and
+   reserve ambient loops for real live/loading state. Pointer cursors are global
+   because a clickable control should never make the user guess. */
+
+:where(button, [role="button"], summary, a[href], select):not(:disabled):not([aria-disabled="true"]) {
+  cursor: pointer;
+}
+
+:where(button:disabled, [role="button"][aria-disabled="true"]) {
+  cursor: default;
+}
+
+.oa-pressable {
+  transition:
+    transform var(--motion-fast) var(--motion-ease-standard),
+    border-color var(--motion-standard) var(--motion-ease-standard),
+    background-color var(--motion-standard) var(--motion-ease-standard),
+    color var(--motion-standard) var(--motion-ease-standard),
+    box-shadow var(--motion-standard) var(--motion-ease-standard);
+}
+
+.oa-icon-action,
+.oa-icon-action > svg,
+.oa-nav-icon {
+  transition:
+    transform var(--motion-fast) var(--motion-ease-out),
+    color var(--motion-standard) var(--motion-ease-standard),
+    background-color var(--motion-standard) var(--motion-ease-standard),
+    opacity var(--motion-standard) var(--motion-ease-standard);
+}
+
+.oa-nav-item,
+.oa-nav-row {
+  transition:
+    transform var(--motion-fast) var(--motion-ease-out),
+    color var(--motion-standard) var(--motion-ease-standard),
+    background-color var(--motion-standard) var(--motion-ease-standard);
+}
+
+.oa-status-surface {
+  transition:
+    border-color var(--motion-slow) var(--motion-ease-standard),
+    background-color var(--motion-slow) var(--motion-ease-standard),
+    box-shadow var(--motion-slow) var(--motion-ease-standard);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .oa-pressable:hover:not(:disabled):not([aria-disabled="true"]) {
+    transform: translateY(-1px);
+    box-shadow: 0 5px 14px color-mix(in srgb, var(--color-text) 9%, transparent);
+  }
+
+  .oa-pressable:active:not(:disabled):not([aria-disabled="true"]) {
+    transform: translateY(0) scale(0.98);
+    box-shadow: none;
+  }
+
+  .oa-icon-action:hover:not(:disabled):not([aria-disabled="true"]) {
+    transform: translateY(-1px);
+  }
+
+  .oa-icon-action:hover:not(:disabled):not([aria-disabled="true"]) > svg {
+    transform: scale(1.1);
+  }
+
+  .oa-icon-action:active:not(:disabled):not([aria-disabled="true"]) {
+    transform: translateY(0) scale(0.92);
+  }
+
+  .oa-nav-item:hover .oa-nav-icon {
+    transform: translateX(1px) scale(1.04);
+  }
+
+  .oa-nav-row:hover {
+    transform: translateX(1px);
+  }
+}
+
+@keyframes oa-view-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes oa-dialog-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes oa-backdrop-enter {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes oa-disclosure-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes oa-popover-enter {
+  from {
+    opacity: 0;
+    transform: translateY(3px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.oa-view-enter {
+  animation: oa-view-enter var(--motion-standard) var(--motion-ease-out) both;
+}
+
+.oa-dialog-surface {
+  animation: oa-dialog-enter var(--motion-slow) var(--motion-ease-out) both;
+}
+
+.oa-dialog-backdrop {
+  animation: oa-backdrop-enter var(--motion-standard) ease-out both;
+}
+
+.oa-disclosure-enter {
+  transform-origin: top;
+  animation: oa-disclosure-enter var(--motion-standard) var(--motion-ease-out) both;
+}
+
+.oa-popover-enter {
+  transform-origin: top;
+  animation: oa-popover-enter var(--motion-standard) var(--motion-ease-out) both;
 }
 
 /* ==================== Typography scale ====================
@@ -408,6 +564,35 @@ html[lang="ja"] .oa-onboarding-title {
     animation: none;
     background-image: none;
     opacity: 0.7;
+  }
+  .live-pulse,
+  .live-pulse::after,
+  .thinking-dot,
+  .message-enter,
+  .page-fade-in,
+  .oa-view-enter,
+  .oa-dialog-surface,
+  .oa-dialog-backdrop,
+  .oa-disclosure-enter,
+  .oa-popover-enter {
+    animation: none;
+  }
+  .oa-pressable,
+  .oa-icon-action,
+  .oa-icon-action > svg,
+  .oa-nav-item,
+  .oa-nav-row,
+  .oa-nav-icon,
+  .oa-status-surface {
+    transition-duration: 0.01ms;
+  }
+  .oa-pressable:hover,
+  .oa-pressable:active,
+  .oa-icon-action:hover,
+  .oa-icon-action:active,
+  .oa-nav-row:hover,
+  .oa-nav-item:hover .oa-nav-icon {
+    transform: none;
   }
 }
 
@@ -743,4 +928,17 @@ html[lang="ja"] .oa-onboarding-title {
   margin-top: 0 !important;
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
+}
+
+/* Final cascade-level safety net. Several domain animations are declared
+   below the first reduced-motion block, so this lives at EOF on purpose. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -509,7 +509,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                     onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
                     aria-label={t('chatLanding.clearTarget')}
                     title={t('chatLanding.clearTarget')}
-                    className="ml-0.5 rounded-full p-0.5 text-accent/70 hover:text-accent hover:bg-accent/20 transition-colors"
+                    className="oa-icon-action ml-0.5 rounded-full p-0.5 text-accent/70 hover:text-accent hover:bg-accent/20 transition-colors"
                   >
                     <X className="w-3 h-3" />
                   </button>
@@ -554,7 +554,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                   aria-haspopup="menu"
                   aria-expanded={workspaceMenuOpen}
                   aria-label={t('chatLanding.selectWorkspace')}
-                  className="inline-flex min-h-8 max-w-[220px] items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 text-[11px] text-text-muted transition-colors hover:text-text disabled:cursor-default"
+                  className="oa-pressable inline-flex min-h-8 max-w-[220px] items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 text-[11px] text-text-muted hover:text-text disabled:cursor-default"
                 >
                   <MessageSquare className="w-3 h-3 shrink-0" />
                   <span className="truncate">
@@ -569,7 +569,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 {workspaceMenuOpen && targetWs === undefined && chatWorkspaceOptions.length > 0 && (
                   <div
                     role="menu"
-                    className="absolute bottom-full left-0 z-10 mb-1 max-h-[min(24rem,calc(100vh-8rem))] min-w-[220px] max-w-[320px] overflow-y-auto overscroll-contain rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg [scrollbar-gutter:stable]"
+                    className="oa-popover-enter absolute bottom-full left-0 z-10 mb-1 max-h-[min(24rem,calc(100vh-8rem))] min-w-[220px] max-w-[320px] overflow-y-auto overscroll-contain rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg [scrollbar-gutter:stable]"
                   >
                     {chatWorkspaceOptions.map((workspace) => {
                       const active = workspace.id === workspaceTarget?.id
@@ -605,7 +605,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                   aria-haspopup="menu"
                   aria-expanded={agentMenuOpen}
                   aria-label={t('chatLanding.selectAgent')}
-                  className="inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md transition-colors hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {SelectedIcon ? <SelectedIcon className="w-3 h-3" /> : null}
                   <span className="truncate">{selectedInfo?.displayName ?? t('chatLanding.selectAgent')}</span>
@@ -614,7 +614,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 {agentMenuOpen && targetCliAgents.length > 0 && (
                   <div
                     role="menu"
-                    className="absolute bottom-full left-0 mb-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
+                    className="oa-popover-enter absolute bottom-full left-0 mb-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
                   >
                     {targetCliAgents.map((a) => {
                       const Icon = AGENT_ICONS[a.id]
@@ -655,7 +655,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 <button
                   type="button"
                   onClick={goConfigureProvider}
-                  className="inline-flex min-h-8 items-center gap-1.5 text-[11px] text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2.5 py-1 rounded-md transition-colors hover:bg-amber-500/20"
+                  className="oa-pressable inline-flex min-h-8 items-center gap-1.5 text-[11px] text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2.5 py-1 rounded-md hover:bg-amber-500/20"
                 >
                   <KeyRound className="w-3 h-3" />
                   {t('chatLanding.configureProvider')}
@@ -669,7 +669,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                     aria-haspopup="menu"
                     aria-expanded={credMenuOpen}
                     aria-label={t('chatLanding.selectCredential')}
-                    className="inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md transition-colors hover:text-text"
+                    className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md hover:text-text"
                   >
                     <KeyRound className="w-3 h-3" />
                     <span className="truncate">{credInfo?.label?.trim() || credInfo?.slug || t('chatLanding.selectCredential')}</span>
@@ -678,7 +678,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                   {credMenuOpen && (
                     <div
                       role="menu"
-                      className="absolute bottom-full left-0 mb-1 min-w-[180px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
+                      className="oa-popover-enter absolute bottom-full left-0 mb-1 min-w-[180px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
                     >
                       {creds.map((cr) => {
                         const active = cr.slug === effectiveCred
@@ -729,7 +729,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 disabled={!canSend}
                 title={t('chatLanding.send')}
                 aria-label={t('chatLanding.send')}
-                className="w-10 h-10 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center bg-accent text-white transition-colors hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="oa-icon-action w-10 h-10 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center bg-accent text-white transition-colors hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {launching ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowUp className="w-4 h-4" />}
               </button>

--- a/ui/src/pages/ConnectorStatusPage.tsx
+++ b/ui/src/pages/ConnectorStatusPage.tsx
@@ -53,7 +53,7 @@ export function ConnectorStatusPage() {
             )}
             <button
               type="button"
-              className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[13px] text-text-muted hover:text-text hover:border-accent/50 disabled:opacity-50"
+              className="oa-pressable inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[13px] text-text-muted hover:text-text hover:border-accent/50 disabled:opacity-50"
               disabled={refreshing}
               onClick={() => void load(true)}
             >
@@ -62,7 +62,7 @@ export function ConnectorStatusPage() {
             </button>
             <button
               type="button"
-              className="inline-flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-[13px] font-medium text-white hover:bg-accent/90"
+              className="oa-pressable inline-flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-[13px] font-medium text-white hover:bg-accent/90"
               onClick={configure}
             >
               <Settings2 size={14} />
@@ -110,7 +110,7 @@ function ConnectorOverview({
 
   return (
     <>
-      <section className="rounded-2xl border border-border bg-bg-secondary/35 p-5 md:p-6">
+      <section className="oa-status-surface rounded-2xl border border-border bg-bg-secondary/35 p-5 md:p-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex min-w-0 gap-3">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border bg-bg text-text-muted">
@@ -166,7 +166,7 @@ function ConnectorOverview({
             })
 
             return (
-              <article key={definition.id} className="rounded-2xl border border-border bg-bg-secondary/25 p-5">
+              <article key={definition.id} className="oa-status-surface rounded-2xl border border-border bg-bg-secondary/25 p-5">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">

--- a/ui/src/pages/ConnectorsPage.tsx
+++ b/ui/src/pages/ConnectorsPage.tsx
@@ -303,7 +303,7 @@ function SetupStatePanel({
   const running = setup.stage === 'starting' || setup.stage === 'awaiting_link' || setup.stage === 'linked' || setup.stage === 'error'
 
   return (
-    <div className={`rounded-xl border px-4 py-4 ${presentation.container}`}>
+    <div className={`oa-status-surface rounded-xl border px-4 py-4 ${presentation.container}`} aria-live="polite">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex min-w-0 gap-3">
           <Icon size={18} className={`mt-0.5 shrink-0 ${presentation.iconClass}`} />
@@ -328,7 +328,7 @@ function SetupStatePanel({
           {(setup.stage === 'ready_to_link' || setup.stage === 'linked_offline') && (
             <button
               type="button"
-              className="inline-flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-[12px] font-medium text-white hover:bg-accent/90 disabled:opacity-50"
+              className="oa-pressable inline-flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-[12px] font-medium text-white hover:bg-accent/90 disabled:opacity-50"
               disabled={saving}
               onClick={onStart}
             >
@@ -339,7 +339,7 @@ function SetupStatePanel({
           {running && (
             <button
               type="button"
-              className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[12px] text-text-muted hover:text-text disabled:opacity-50"
+              className="oa-pressable inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[12px] text-text-muted hover:text-text disabled:opacity-50"
               disabled={saving}
               onClick={onStop}
             >


### PR DESCRIPTION
## Summary

- document the Connector setup lifecycle and the ownership split between Settings, Beta status, and Dev Panel
- add a shared interaction and motion vocabulary for views, dialogs, disclosures, popovers, navigation, icon actions, and status surfaces
- apply the motion primitives to the shell, Chat, Workspace controls, and Connector surfaces with fine-pointer and reduced-motion safeguards
- stop connector-protocol builds from emitting spec artifacts that the post-build Vitest lane mistakes for test suites

## Why

The Connector linking flow now has several meaningful setup phases that need a durable product contract. The UI also lacked consistent clickable and transition feedback, which made a working console feel visually static and made compact add controls harder to discover.

The previous Connector PR additionally exposed a CI-order bug: building connector-protocol emitted catalog.spec JavaScript, declaration, and map files into dist, then the full test lane collected those generated artifacts.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` after building connector-protocol: 248 files passed, 1 skipped; 2733 tests passed, 6 skipped
- `pnpm -F @traderalice/connector-protocol typecheck`
- `pnpm -F @traderalice/connector-protocol build` and confirmed no spec artifacts in dist
- `pnpm -F open-alice-ui build`
- live browser verification at 1000x768 in auto, light, and dark themes: view, dialog, disclosure, popover, pointer, and status transitions
- `pnpm electron:smoke:workspace`: packaged Electron Workspace acceptance passed and temporary package was cleaned
