### PR TITLE
Send Inbox reports through connectors

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -13,6 +13,9 @@ truth. Telegram and Discord are the first adapters, not hard-coded product
 categories.
 
 - Local Inbox append completes before any external request begins.
+- Agent-originated pushes enter through the Workspace CLI and inherit the
+  CLI's server-validated Session origin; Connector delivery has no MCP identity
+  dependency.
 - A failed connector never changes `inbox_push` success and never marks an
   Inbox item read.
 - The service is optional in every trading mode, including lite.
@@ -21,12 +24,22 @@ categories.
   slash-command control plane; ordinary DM text is not ingested.
 - Each adapter serves one owner account/private chat. Group and channel
   broadcasting are out of scope.
+- Inbox `docs` that are Markdown are sent as original file attachments, not
+  flattened into the message body. Alice reads the live Workspace file before
+  crossing the process boundary; Connector Service never reaches into a
+  Workspace itself. One notification carries at most five files of at most
+  1 MiB each. Missing, oversized, non-Markdown, or path-escaping files remain
+  visible as Inbox/report paths and never block the text notification. A
+  skipped eligible attachment is logged and leaves bridge health degraded so
+  partial delivery is visible to operators.
+- Session provenance is rendered as a visible `@resumeId` signature. The
+  runtime label may accompany it (`pi · @resume-…`) but must never replace it.
 
 ## Topology
 
 ```text
 Workspace agent
-  -> inbox_push
+  -> alice-workspace inbox push (CLI)
   -> InboxStore durable JSONL append
   -> non-blocking Alice bridge
   -> Connector Service on loopback
@@ -161,7 +174,9 @@ two explicit layers.
 Connector Service writes a bounded, private JSONL journal to
 `data/logs/connector-io.jsonl` (one rotated generation at `.1`). It records:
 
-- complete normalized Inbox notifications at service ingress;
+- normalized Inbox notification text at service ingress;
+- attachment evidence (`filename`, media type, byte size, and SHA-256) without
+  repeating base64 file bodies into every ingress/adapter journal event;
 - per-adapter delivery attempt, success, or failure tied to one correlation ID;
 - inbound slash-command name and pseudonymized user/chat IDs;
 - command replies and command failures.
@@ -170,7 +185,9 @@ Bot tokens are never journaled. Platform user and chat IDs are stable SHA-256
 pseudonyms so authorization/equality cases remain replayable without retaining
 raw external identifiers. Notification text is retained because it is the
 payload under test; the journal is mode `0600`, bounded to 5 MiB, and remains
-local to the OpenAlice data home.
+local to the OpenAlice data home. Adapter tests own byte-level attachment
+decoding/upload contracts; replay owns the durable text and attachment-evidence
+contract without growing the journal into a report archive.
 
 `services/connector/test-fixtures/io-smoke.jsonl` is a safe fixture. The replay
 harness consumes only `notification.received` events and runs them through a

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -252,7 +252,10 @@ Inbox entry -> sender resumeId -> exact product Session
 
 This answers “who sent this message?” independently from who last edited any
 live document linked by the notification. Legacy/manual entries may have only a
-Workspace; those resolve through the explicit reconstruction path.
+Workspace; those resolve through the explicit reconstruction path. Product and
+external-notification surfaces display the sender as `@resumeId` (optionally
+preceded by its runtime label); a generic label such as `pi` must not hide the
+unique Session signature already present in the origin envelope.
 
 ### Issues: creation provenance versus execution responsibility
 

--- a/packages/connector-protocol/package.json
+++ b/packages/connector-protocol/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
-    "test": "vitest run",
+    "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/connector-protocol/src",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/connector-protocol/src/types.spec.ts
+++ b/packages/connector-protocol/src/types.spec.ts
@@ -1,0 +1,43 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_CONNECTOR_ATTACHMENT_BYTES,
+  inboxNotificationSchema,
+} from './types.js'
+
+const baseNotification = {
+  id: 'inbox-1',
+  createdAt: '2026-07-13T00:00:00.000Z',
+  workspaceId: 'ws-1',
+  title: 'Report ready',
+  body: '',
+}
+
+describe('Inbox notification attachments', () => {
+  it('accepts a bounded Markdown file payload', () => {
+    const content = Buffer.from('# Report\n')
+    expect(inboxNotificationSchema.parse({
+      ...baseNotification,
+      attachments: [{
+        filename: 'report.md',
+        mediaType: 'text/markdown; charset=utf-8',
+        sizeBytes: content.byteLength,
+        contentSha256: createHash('sha256').update(content).digest('hex'),
+        contentBase64: content.toString('base64'),
+      }],
+    }).attachments).toHaveLength(1)
+  })
+
+  it('rejects attachment metadata above the one-file limit', () => {
+    expect(() => inboxNotificationSchema.parse({
+      ...baseNotification,
+      attachments: [{
+        filename: 'too-large.md',
+        mediaType: 'text/markdown; charset=utf-8',
+        sizeBytes: MAX_CONNECTOR_ATTACHMENT_BYTES + 1,
+        contentSha256: '0'.repeat(64),
+        contentBase64: '',
+      }],
+    })).toThrow()
+  })
+})

--- a/packages/connector-protocol/src/types.ts
+++ b/packages/connector-protocol/src/types.ts
@@ -53,6 +53,23 @@ export const publicConnectorConfigSchema = z.object({
 })
 export type PublicConnectorConfig = z.infer<typeof publicConnectorConfigSchema>
 
+/** Keep inline delivery bounded below both Discord's ordinary upload limit and
+ * Telegram's document limit. Alice reads only the small Markdown reports that
+ * Inbox already exposes; Connector Service never reaches back into a Workspace. */
+export const MAX_CONNECTOR_ATTACHMENT_BYTES = 1024 * 1024
+export const MAX_CONNECTOR_ATTACHMENTS = 5
+
+export const connectorAttachmentSchema = z.object({
+  filename: z.string().min(1).max(255),
+  mediaType: z.string().min(1).max(128),
+  sizeBytes: z.number().int().min(0).max(MAX_CONNECTOR_ATTACHMENT_BYTES),
+  contentSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  // One MiB is at most 1,398,104 base64 characters. The small allowance keeps
+  // schema evolution from rejecting equivalent padded encodings.
+  contentBase64: z.string().max(1_400_000),
+})
+export type ConnectorAttachment = z.infer<typeof connectorAttachmentSchema>
+
 export const inboxNotificationSchema = z.object({
   id: z.string().min(1),
   createdAt: z.string().datetime(),
@@ -60,6 +77,7 @@ export const inboxNotificationSchema = z.object({
   workspaceLabel: z.string().optional(),
   title: z.string().min(1),
   body: z.string().default(''),
+  attachments: z.array(connectorAttachmentSchema).max(MAX_CONNECTOR_ATTACHMENTS).optional(),
   href: z.string().optional(),
   provenance: z.object({
     resumeId: z.string().optional(),

--- a/services/connector/package.json
+++ b/services/connector/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/main.ts",
     "start": "node dist/connector.cjs",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --config ../../vitest.config.ts --project node services/connector"
+    "test": "vitest run --root ../.. --config vitest.config.ts --project node services/connector/src"
   },
   "dependencies": {
     "@grammyjs/auto-retry": "^2.0.2",

--- a/services/connector/src/adapters/discord.ts
+++ b/services/connector/src/adapters/discord.ts
@@ -10,7 +10,11 @@ import type {
   ConnectorAdapterContext,
   ConnectorAdapterRegistration,
 } from '../core/adapter.js'
-import { AdapterHealthTracker, formatInboxNotification } from './shared.js'
+import {
+  AdapterHealthTracker,
+  decodeInboxAttachments,
+  formatInboxNotification,
+} from './shared.js'
 
 export class DiscordConnectorAdapter implements ConnectorAdapter {
   readonly id = 'discord'
@@ -84,7 +88,16 @@ export class DiscordConnectorAdapter implements ConnectorAdapter {
     this.tracker.attempt()
     try {
       const user = await this.client.users.fetch(this.ownerUserId)
-      await user.send(formatInboxNotification(notification))
+      const attachments = decodeInboxAttachments(notification)
+      await user.send({
+        content: formatInboxNotification(notification),
+        ...(attachments.length > 0 ? {
+          files: attachments.map((attachment) => ({
+            attachment: attachment.content,
+            name: attachment.filename,
+          })),
+        } : {}),
+      })
       this.tracker.success(this.ownerUserId)
     } catch (error) {
       this.tracker.degraded(error)

--- a/services/connector/src/adapters/shared.spec.ts
+++ b/services/connector/src/adapters/shared.spec.ts
@@ -1,6 +1,12 @@
+import { createHash } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
 import type { InboxNotification } from '@traderalice/connector-protocol'
-import { AdapterHealthTracker, formatInboxNotification, formatPlainInboxNotification } from './shared.js'
+import {
+  AdapterHealthTracker,
+  decodeInboxAttachments,
+  formatInboxNotification,
+  formatPlainInboxNotification,
+} from './shared.js'
 
 const notification: InboxNotification = {
   id: 'fixture-1',
@@ -18,7 +24,7 @@ describe('recorded Inbox payload formatting', () => {
     expect(formatInboxNotification(notification)).toBe([
       '**Close \\[scan\\]**',
       'Workspace: Research \\*desk\\*',
-      'From: resume\\-calm\\-river\\-12ab',
+      'From: @resume\\-calm\\-river\\-12ab',
       '',
       'Three findings.',
       '',
@@ -30,12 +36,51 @@ describe('recorded Inbox payload formatting', () => {
     expect(formatPlainInboxNotification(notification)).toBe([
       'Close [scan]',
       'Workspace: Research *desk*',
-      'From: resume-calm-river-12ab',
+      'From: @resume-calm-river-12ab',
       '',
       'Three findings.',
       '',
       'https://openalice.example/inbox',
     ].join('\n'))
+  })
+
+  it('keeps the runtime label and visible Session signature together', () => {
+    expect(formatPlainInboxNotification({
+      ...notification,
+      provenance: { actorLabel: 'pi', resumeId: 'resume-calm-river-12ab' },
+    })).toContain('From: pi · @resume-calm-river-12ab')
+  })
+
+  it('decodes and verifies Markdown attachments', () => {
+    const content = Buffer.from('# Close scan\n')
+    const decoded = decodeInboxAttachments({
+      ...notification,
+      attachments: [{
+        filename: 'close.md',
+        mediaType: 'text/markdown; charset=utf-8',
+        sizeBytes: content.byteLength,
+        contentSha256: createHash('sha256').update(content).digest('hex'),
+        contentBase64: content.toString('base64'),
+      }],
+    })
+    expect(decoded).toEqual([{
+      filename: 'close.md',
+      mediaType: 'text/markdown; charset=utf-8',
+      content,
+    }])
+  })
+
+  it('rejects attachment bytes that do not match their digest', () => {
+    expect(() => decodeInboxAttachments({
+      ...notification,
+      attachments: [{
+        filename: 'close.md',
+        mediaType: 'text/markdown; charset=utf-8',
+        sizeBytes: 1,
+        contentSha256: '0'.repeat(64),
+        contentBase64: Buffer.from('x').toString('base64'),
+      }],
+    })).toThrow('digest mismatch')
   })
 })
 

--- a/services/connector/src/adapters/shared.ts
+++ b/services/connector/src/adapters/shared.ts
@@ -1,4 +1,8 @@
-import type { ConnectorAdapterHealth, InboxNotification } from '@traderalice/connector-protocol'
+import { createHash } from 'node:crypto'
+import type {
+  ConnectorAdapterHealth,
+  InboxNotification,
+} from '@traderalice/connector-protocol'
 
 export class AdapterHealthTracker {
   private value: ConnectorAdapterHealth
@@ -58,7 +62,7 @@ export class AdapterHealthTracker {
 
 export function formatInboxNotification(notification: InboxNotification): string {
   const workspace = notification.workspaceLabel ?? notification.workspaceId
-  const provenance = notification.provenance?.actorLabel ?? notification.provenance?.resumeId
+  const provenance = formatProvenance(notification)
   const parts = [
     `**${escapeMarkdown(notification.title)}**`,
     `Workspace: ${escapeMarkdown(workspace)}`,
@@ -71,12 +75,54 @@ export function formatInboxNotification(notification: InboxNotification): string
 
 export function formatPlainInboxNotification(notification: InboxNotification): string {
   const workspace = notification.workspaceLabel ?? notification.workspaceId
-  const provenance = notification.provenance?.actorLabel ?? notification.provenance?.resumeId
+  const provenance = formatProvenance(notification)
   const parts = [notification.title, `Workspace: ${workspace}`]
   if (provenance) parts.push(`From: ${provenance}`)
   if (notification.body.trim()) parts.push('', truncate(notification.body.trim(), 1_600))
   if (notification.href) parts.push('', notification.href)
   return parts.join('\n')
+}
+
+export interface DecodedConnectorAttachment {
+  filename: string
+  mediaType: string
+  content: Buffer
+}
+
+/** Decode and verify the Alice-produced attachment before handing bytes to a
+ * platform SDK. Size and digest checks keep malformed loopback payloads from
+ * becoming opaque Discord/Telegram upload failures. */
+export function decodeInboxAttachments(notification: InboxNotification): DecodedConnectorAttachment[] {
+  return (notification.attachments ?? []).map((attachment) => {
+    if (!isCanonicalBase64(attachment.contentBase64)) {
+      throw new Error(`Connector attachment is not valid base64: ${attachment.filename}`)
+    }
+    const content = Buffer.from(attachment.contentBase64, 'base64')
+    if (content.byteLength !== attachment.sizeBytes) {
+      throw new Error(`Connector attachment size mismatch: ${attachment.filename}`)
+    }
+    const digest = createHash('sha256').update(content).digest('hex')
+    if (digest !== attachment.contentSha256) {
+      throw new Error(`Connector attachment digest mismatch: ${attachment.filename}`)
+    }
+    return {
+      filename: attachment.filename,
+      mediaType: attachment.mediaType,
+      content,
+    }
+  })
+}
+
+function formatProvenance(notification: InboxNotification): string | undefined {
+  const actor = notification.provenance?.actorLabel?.trim()
+  const resumeId = notification.provenance?.resumeId?.trim()
+  const signature = resumeId ? `@${resumeId}` : undefined
+  return actor && signature ? `${actor} · ${signature}` : actor ?? signature
+}
+
+function isCanonicalBase64(value: string): boolean {
+  if (value === '') return true
+  return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
 }
 
 function truncate(value: string, max: number): string {

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -1,4 +1,4 @@
-import { Bot } from 'grammy'
+import { Bot, InputFile } from 'grammy'
 import { autoRetry } from '@grammyjs/auto-retry'
 import type {
   ConnectorAdapterConfig,
@@ -11,7 +11,11 @@ import type {
   ConnectorAdapterContext,
   ConnectorAdapterRegistration,
 } from '../core/adapter.js'
-import { AdapterHealthTracker, formatPlainInboxNotification } from './shared.js'
+import {
+  AdapterHealthTracker,
+  decodeInboxAttachments,
+  formatPlainInboxNotification,
+} from './shared.js'
 
 export class TelegramConnectorAdapter implements ConnectorAdapter {
   readonly id = 'telegram'
@@ -71,6 +75,12 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
     this.tracker.attempt()
     try {
       await this.bot.api.sendMessage(this.chatId, formatPlainInboxNotification(notification))
+      for (const attachment of decodeInboxAttachments(notification)) {
+        await this.bot.api.sendDocument(
+          this.chatId,
+          new InputFile(attachment.content, attachment.filename),
+        )
+      }
       this.tracker.success(this.ownerUserId)
     } catch (error) {
       this.tracker.degraded(error)

--- a/services/connector/src/core/delivery-manager.spec.ts
+++ b/services/connector/src/core/delivery-manager.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import type {
   ConnectorAdapterConfig,
@@ -141,12 +142,20 @@ describe('DeliveryManager connector registry', () => {
       updateAdapterSettings: vi.fn(),
     })
     await manager.start()
+    const content = Buffer.from('# Report\n')
     const receipt = manager.enqueue({
       id: 'inbox-recorded',
       createdAt: new Date().toISOString(),
       workspaceId: 'ws-1',
       title: 'Replay me',
       body: 'Recorded payload',
+      attachments: [{
+        filename: 'report.md',
+        mediaType: 'text/markdown; charset=utf-8',
+        sizeBytes: content.byteLength,
+        contentSha256: createHash('sha256').update(content).digest('hex'),
+        contentBase64: content.toString('base64'),
+      }],
     })
 
     await vi.waitFor(() => expect(adapter.delivered).toHaveLength(1))
@@ -157,6 +166,11 @@ describe('DeliveryManager connector registry', () => {
     ])
     expect(recorder.events.every((event) => event.correlationId === receipt.deliveryId)).toBe(true)
     expect(recorder.events[0]?.payload).toMatchObject({ notification: { id: 'inbox-recorded' } })
+    expect(adapter.delivered[0]?.attachments?.[0]?.contentBase64).toBe(content.toString('base64'))
+    expect(recorder.events[0]?.payload).toMatchObject({
+      attachmentEvidence: [{ filename: 'report.md', sizeBytes: content.byteLength }],
+    })
+    expect(JSON.stringify(recorder.events)).not.toContain(content.toString('base64'))
   })
 
   it('does not let a broken recorder block external delivery', async () => {

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -59,7 +59,7 @@ export class DeliveryManager {
         correlationId: deliveryId,
         direction: 'inbound',
         stage: 'notification.received',
-        payload: { notification },
+        payload: journalNotificationPayload(notification),
       }).then(() => this.deliver(notification, deliveryId))
     })
     return { accepted: true, deliveryId }
@@ -72,7 +72,7 @@ export class DeliveryManager {
         direction: 'outbound',
         stage: 'delivery.attempted',
         connectorId: adapter.id,
-        payload: { notification },
+        payload: journalNotificationPayload(notification),
       })
       try {
         await adapter.deliver(notification)
@@ -168,7 +168,7 @@ export class DeliveryManager {
       direction: 'outbound',
       stage: 'delivery.attempted',
       connectorId: adapter.id,
-      payload: { notification },
+      payload: journalNotificationPayload(notification),
     })
     try {
       await adapter.deliver(notification)
@@ -195,5 +195,23 @@ export class DeliveryManager {
     await this.recorder.record(event).catch((error) => {
       console.warn('[connector] I/O delivery event could not be recorded:', error instanceof Error ? error.message : error)
     })
+  }
+}
+
+/** The replay journal proves which file revision was offered without copying
+ * base64 file bodies into connector-io.jsonl once per adapter and stage. The
+ * live adapter still receives the complete notification. */
+function journalNotificationPayload(notification: InboxNotification): Record<string, unknown> {
+  const { attachments, ...safeNotification } = notification
+  return {
+    notification: safeNotification,
+    ...(attachments && attachments.length > 0 ? {
+      attachmentEvidence: attachments.map((attachment) => ({
+        filename: attachment.filename,
+        mediaType: attachment.mediaType,
+        sizeBytes: attachment.sizeBytes,
+        contentSha256: attachment.contentSha256,
+      })),
+    } : {}),
   }
 }

--- a/services/connector/src/core/io-journal.spec.ts
+++ b/services/connector/src/core/io-journal.spec.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { access, mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -27,6 +28,13 @@ describe('ConnectorIOJournal', () => {
 
     expect(await readFile(`${path}.1`, 'utf8')).toContain('"correlationId":"second"')
     expect(await readFile(path, 'utf8')).toContain('"correlationId":"third"')
-    expect((await stat(path)).mode & 0o777).toBe(0o600)
+    if (process.platform === 'win32') {
+      // Windows does not expose POSIX permission bits: a file created with
+      // mode 0600 is reported as 0666. Keep the rotation/content contract
+      // above and prove the journal remains usable on the native filesystem.
+      await expect(access(path, constants.R_OK | constants.W_OK)).resolves.toBeUndefined()
+    } else {
+      expect((await stat(path)).mode & 0o777).toBe(0o600)
+    }
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,7 +292,6 @@ async function main() {
   // ==================== Inbox store ====================
 
   const inboxStore = createInboxStore()
-  startInboxConnectorBridge(inboxStore)
 
   // ==================== Entity store (durable cross-workspace tracked-index) ====================
 
@@ -305,6 +304,7 @@ async function main() {
   // `ref.current` is null until the plugin boots; an early cron fire is a loud
   // skip (see cron listener). Created here so cron dispatch can hold it.
   const workspaceServiceRef = createWorkspaceServiceRef()
+  startInboxConnectorBridge(inboxStore, () => workspaceServiceRef.current)
 
   // Snapshot scheduler lives in UTA after Step 6 — Alice no longer
   // drives the periodic equity-curve writes. The UTA service starts

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -266,7 +266,7 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
       sessionRegistry: {
         get: (wsId: string, id: string) =>
           wsId === 'ws1' && id === 'sess-1'
-            ? { id: 'sess-1', wsId: 'ws1', agent: 'claude' }
+            ? { id: 'sess-1', resumeId: 'resume-1', wsId: 'ws1', agent: 'claude' }
             : undefined,
       },
     }
@@ -324,7 +324,12 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
     const res = await pushWith(app, { 'x-openalice-session': 'sess-1' })
     expect(res.status).toBe(200)
     const { entries } = await inboxStore.read({ workspaceId: 'ws1' })
-    expect(entries[0].origin).toEqual({ kind: 'interactive', sessionId: 'sess-1', agent: 'claude' })
+    expect(entries[0].origin).toEqual({
+      kind: 'interactive',
+      sessionId: 'sess-1',
+      resumeId: 'resume-1',
+      agent: 'claude',
+    })
   })
 
   it('a forged session id resolves to no origin (registry is the authority)', async () => {

--- a/src/server/inbox-origin.spec.ts
+++ b/src/server/inbox-origin.spec.ts
@@ -6,7 +6,7 @@ import { resolveInboxOrigin } from './inbox-origin.js'
 /** Build a structural fake service with both authorities. */
 function svc(opts: {
   headless?: Record<string, { taskId: string; resumeId: string; trigger?: { kind: 'issue'; workspaceId: string; issueId: string }; agent: string }>
-  sessions?: Record<string, Record<string, { id: string; wsId: string; agent: string }>>
+  sessions?: Record<string, Record<string, { id: string; resumeId: string; wsId: string; agent: string }>>
 } = {}) {
   return {
     headlessTasks: { get: (id: string) => opts.headless?.[id] ?? null },
@@ -60,15 +60,15 @@ describe('resolveInboxOrigin — headless (Phase 1)', () => {
 describe('resolveInboxOrigin — interactive (Phase 2)', () => {
   it('builds an interactive origin from a valid session header (validated against the registry)', () => {
     const origin = resolveInboxOrigin({ session: 'sess-1', wsId: 'ws1' }, () =>
-      svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+      svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', resumeId: 'resume-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
     )
-    expect(origin).toEqual({ kind: 'interactive', sessionId: 'sess-1', agent: 'codex' })
+    expect(origin).toEqual({ kind: 'interactive', sessionId: 'sess-1', resumeId: 'resume-1', agent: 'codex' })
   })
 
   it('undefined for an unknown/forged session id (no fabricated link)', () => {
     expect(
       resolveInboxOrigin({ session: 'forged', wsId: 'ws1' }, () =>
-        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', resumeId: 'resume-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
       ),
     ).toBeUndefined()
   })
@@ -77,7 +77,7 @@ describe('resolveInboxOrigin — interactive (Phase 2)', () => {
     // The id exists, but not under the route's wsId — the authority is scoped.
     expect(
       resolveInboxOrigin({ session: 'sess-1', wsId: 'ws2' }, () =>
-        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', resumeId: 'resume-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
       ),
     ).toBeUndefined()
   })
@@ -85,7 +85,7 @@ describe('resolveInboxOrigin — interactive (Phase 2)', () => {
   it('undefined when the session header is present but wsId is missing', () => {
     expect(
       resolveInboxOrigin({ session: 'sess-1' }, () =>
-        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+        svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', resumeId: 'resume-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
       ),
     ).toBeUndefined()
   })
@@ -107,7 +107,7 @@ describe('resolveInboxOrigin — precedence + both-absent', () => {
             agent: 'claude',
           },
         },
-        sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } },
+        sessions: { ws1: { 'sess-1': { id: 'sess-1', resumeId: 'resume-1', wsId: 'ws1', agent: 'codex' } } },
       }) as any,
     )
     expect(origin).toEqual({
@@ -122,9 +122,9 @@ describe('resolveInboxOrigin — precedence + both-absent', () => {
 
   it('falls through to the session header when the run id is unknown', () => {
     const origin = resolveInboxOrigin({ run: 'ghost', session: 'sess-1', wsId: 'ws1' }, () =>
-      svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
+      svc({ sessions: { ws1: { 'sess-1': { id: 'sess-1', resumeId: 'resume-1', wsId: 'ws1', agent: 'codex' } } } }) as any,
     )
-    expect(origin).toEqual({ kind: 'interactive', sessionId: 'sess-1', agent: 'codex' })
+    expect(origin).toEqual({ kind: 'interactive', sessionId: 'sess-1', resumeId: 'resume-1', agent: 'codex' })
   })
 
   it('undefined when both headers are absent (manual case)', () => {

--- a/src/services/connector-client/index.spec.ts
+++ b/src/services/connector-client/index.spec.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { InboxNotification } from '@traderalice/connector-protocol'
 import { createMemoryInboxStore } from '../../core/inbox-store.js'
-import { attachInboxConnectorBridge, toNotification } from './index.js'
+import {
+  attachInboxConnectorBridge,
+  projectInboxAttachments,
+  toNotification,
+} from './index.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
 
 describe('Inbox Connector bridge', () => {
   it('does not make a durable Inbox append wait for external delivery', async () => {
@@ -38,5 +52,56 @@ describe('Inbox Connector bridge', () => {
       body: 'Read the report.\n\nReports:\n- research/close.md',
       provenance: { resumeId: 'resume-calm-river-12ab', actorLabel: 'pi' },
     })
+  })
+
+  it('delivers Markdown docs as bounded file attachments', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-connector-attachment-'))
+    tempDirs.push(root)
+    await mkdir(join(root, 'research'))
+    await writeFile(join(root, 'research', 'close.md'), '# Close scan\n')
+    const push = vi.fn(async (_notification: InboxNotification) => undefined)
+    const store = createMemoryInboxStore()
+    attachInboxConnectorBridge(store, {
+      isEnabled: async () => true,
+      push,
+      warn: vi.fn(),
+      resolveWorkspace: () => ({ dir: root }),
+    })
+
+    await store.append({
+      workspaceId: 'ws-1',
+      docs: [{ path: 'research/close.md' }],
+      comments: 'Attached without flattening the report.',
+    })
+
+    await vi.waitFor(() => expect(push).toHaveBeenCalledOnce())
+    const notification = push.mock.calls[0]?.[0]
+    expect(notification?.attachments).toHaveLength(1)
+    expect(notification?.attachments?.[0]).toMatchObject({
+      filename: 'close.md',
+      mediaType: 'text/markdown; charset=utf-8',
+      sizeBytes: Buffer.byteLength('# Close scan\n'),
+    })
+    expect(Buffer.from(notification!.attachments![0]!.contentBase64, 'base64').toString('utf8'))
+      .toBe('# Close scan\n')
+  })
+
+  it('refuses to attach a Markdown symlink that escapes the Workspace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-connector-workspace-'))
+    const outside = await mkdtemp(join(tmpdir(), 'openalice-connector-outside-'))
+    tempDirs.push(root, outside)
+    await writeFile(join(outside, 'secret.md'), '# outside\n')
+    await symlink(join(outside, 'secret.md'), join(root, 'leak.md'))
+    const warn = vi.fn()
+
+    const attachments = await projectInboxAttachments({
+      id: 'entry-escape',
+      ts: Date.now(),
+      workspaceId: 'ws-1',
+      docs: [{ path: 'leak.md' }],
+    }, () => ({ dir: root }), warn)
+
+    expect(attachments).toEqual([])
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('symlink target escapes Workspace'))
   })
 })

--- a/src/services/connector-client/index.ts
+++ b/src/services/connector-client/index.ts
@@ -1,6 +1,12 @@
+import { createHash } from 'node:crypto'
+import { readFile, realpath, stat } from 'node:fs/promises'
+import { basename, extname, isAbsolute, normalize, resolve, sep } from 'node:path'
 import {
   ConnectorClient,
+  MAX_CONNECTOR_ATTACHMENT_BYTES,
+  MAX_CONNECTOR_ATTACHMENTS,
   connectorServiceHealthSchema,
+  type ConnectorAttachment,
   type ConnectorServiceHealth,
   type InboxNotification,
 } from '@traderalice/connector-protocol'
@@ -30,6 +36,16 @@ export interface InboxConnectorBridgeDeps {
   isEnabled(): Promise<boolean>
   push(notification: InboxNotification): Promise<void>
   warn(message: string): void
+  resolveWorkspace?(id: string): { dir: string } | null
+}
+
+interface WorkspaceServiceLike {
+  registry: { get(id: string): { dir: string } | undefined }
+}
+
+export interface InboxAttachmentProjection {
+  sourcePath: string
+  attachment: ConnectorAttachment
 }
 
 export function resolveConnectorUrl(): string {
@@ -37,7 +53,10 @@ export function resolveConnectorUrl(): string {
     || `http://127.0.0.1:${process.env['OPENALICE_CONNECTOR_PORT'] ?? '47334'}`
 }
 
-export function startInboxConnectorBridge(inboxStore: IInboxStore): () => void {
+export function startInboxConnectorBridge(
+  inboxStore: IInboxStore,
+  getWorkspaceService?: () => WorkspaceServiceLike | null,
+): () => void {
   const client = new ConnectorClient(resolveConnectorUrl())
   return attachInboxConnectorBridge(inboxStore, {
     isEnabled: readConnectorServiceEnabled,
@@ -45,6 +64,12 @@ export function startInboxConnectorBridge(inboxStore: IInboxStore): () => void {
       await client.pushInbox(notification, AbortSignal.timeout(5_000))
     },
     warn: (message) => console.warn('[connector] Inbox notification delivery unavailable:', message),
+    ...(getWorkspaceService ? {
+      resolveWorkspace: (id) => {
+        const workspace = getWorkspaceService()?.registry.get(id)
+        return workspace ? { dir: workspace.dir } : null
+      },
+    } : {}),
   })
 }
 
@@ -104,12 +129,23 @@ async function deliverEntry(entry: InboxEntry, deps: InboxConnectorBridgeDeps): 
   if (!await deps.isEnabled()) return
   state.enabled = true
   state.lastAttemptAt = new Date().toISOString()
-  const notification = toNotification(entry)
+  const attachmentWarnings: string[] = []
+  const warnAttachment = (warning: string) => {
+    attachmentWarnings.push(warning)
+    deps.warn(warning)
+  }
+  const attachments = await projectInboxAttachments(entry, deps.resolveWorkspace, warnAttachment)
+  const notification = toNotification(entry, attachments)
   try {
     await deps.push(notification)
-    state.status = 'healthy'
     state.lastSuccessAt = new Date().toISOString()
-    delete state.lastError
+    if (attachmentWarnings.length > 0) {
+      state.status = 'degraded'
+      state.lastError = attachmentWarnings.join('; ')
+    } else {
+      state.status = 'healthy'
+      delete state.lastError
+    }
   } catch (error) {
     state.status = 'degraded'
     state.lastError = message(error)
@@ -117,7 +153,10 @@ async function deliverEntry(entry: InboxEntry, deps: InboxConnectorBridgeDeps): 
   }
 }
 
-export function toNotification(entry: InboxEntry): InboxNotification {
+export function toNotification(
+  entry: InboxEntry,
+  attachments: readonly InboxAttachmentProjection[] = [],
+): InboxNotification {
   const docs = entry.docs?.map((doc) => doc.path) ?? []
   const body = [
     entry.comments?.trim(),
@@ -131,6 +170,7 @@ export function toNotification(entry: InboxEntry): InboxNotification {
     ...(entry.workspaceLabel ? { workspaceLabel: entry.workspaceLabel } : {}),
     title: `Inbox update from ${entry.workspaceLabel ?? entry.workspaceId}`,
     body,
+    ...(attachments.length > 0 ? { attachments: attachments.map(({ attachment }) => attachment) } : {}),
     ...(baseUrl ? { href: `${baseUrl}/inbox` } : {}),
     ...(entry.origin?.resumeId || entry.origin?.agent ? {
       provenance: {
@@ -139,6 +179,94 @@ export function toNotification(entry: InboxEntry): InboxNotification {
       },
     } : {}),
   }
+}
+
+/** Project Inbox's live Markdown document pointers into bounded, verified file
+ * bytes before crossing the process boundary. Unsupported or unavailable files
+ * remain listed in the text notification and never block the durable Inbox
+ * append or the remaining external message. */
+export async function projectInboxAttachments(
+  entry: InboxEntry,
+  resolveWorkspace: InboxConnectorBridgeDeps['resolveWorkspace'],
+  warn: (message: string) => void = () => undefined,
+): Promise<InboxAttachmentProjection[]> {
+  const markdownDocs = (entry.docs ?? []).filter((doc) => {
+    const extension = extname(doc.path).toLowerCase()
+    return extension === '.md' || extension === '.markdown'
+  })
+  if (markdownDocs.length === 0 || !resolveWorkspace) return []
+
+  const workspace = resolveWorkspace(entry.workspaceId)
+  if (!workspace) {
+    warn(`Workspace unavailable for Inbox attachments: ${entry.workspaceId}`)
+    return []
+  }
+
+  let workspaceRoot: string
+  try {
+    workspaceRoot = await realpath(workspace.dir)
+  } catch (error) {
+    warn(`Workspace path unavailable for Inbox attachments: ${message(error)}`)
+    return []
+  }
+
+  const projections: InboxAttachmentProjection[] = []
+  const usedNames = new Set<string>()
+  for (const doc of markdownDocs.slice(0, MAX_CONNECTOR_ATTACHMENTS)) {
+    try {
+      const target = await resolveSafeWorkspaceFile(workspaceRoot, doc.path)
+      const info = await stat(target)
+      if (!info.isFile()) throw new Error('not a regular file')
+      if (info.size > MAX_CONNECTOR_ATTACHMENT_BYTES) {
+        throw new Error(`file exceeds ${MAX_CONNECTOR_ATTACHMENT_BYTES} bytes`)
+      }
+      const content = await readFile(target)
+      const filename = uniqueFilename(basename(doc.path), usedNames)
+      projections.push({
+        sourcePath: doc.path,
+        attachment: {
+          filename,
+          mediaType: 'text/markdown; charset=utf-8',
+          sizeBytes: content.byteLength,
+          contentSha256: createHash('sha256').update(content).digest('hex'),
+          contentBase64: content.toString('base64'),
+        },
+      })
+    } catch (error) {
+      warn(`Inbox attachment skipped (${doc.path}): ${message(error)}`)
+    }
+  }
+  if (markdownDocs.length > MAX_CONNECTOR_ATTACHMENTS) {
+    warn(`Inbox attachment limit reached; skipped ${markdownDocs.length - MAX_CONNECTOR_ATTACHMENTS} file(s)`)
+  }
+  return projections
+}
+
+async function resolveSafeWorkspaceFile(workspaceRoot: string, relativePath: string): Promise<string> {
+  const clean = normalize(relativePath)
+  if (!clean || clean === '.' || isAbsolute(clean) || clean === '..' || clean.startsWith(`..${sep}`)) {
+    throw new Error('path escapes Workspace')
+  }
+  const target = await realpath(resolve(workspaceRoot, clean))
+  if (target !== workspaceRoot && !target.startsWith(`${workspaceRoot}${sep}`)) {
+    throw new Error('symlink target escapes Workspace')
+  }
+  return target
+}
+
+function uniqueFilename(input: string, used: Set<string>): string {
+  const candidate = input.trim() || 'report.md'
+  if (!used.has(candidate)) {
+    used.add(candidate)
+    return candidate
+  }
+  const extension = extname(candidate)
+  const stem = candidate.slice(0, candidate.length - extension.length)
+  let index = 2
+  while (used.has(`${stem}-${index}${extension}`)) index += 1
+  const unique = `${stem}-${index}${extension}`
+  used.add(unique)
+  return unique
 }
 
 function message(error: unknown): string {

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -171,6 +171,8 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
   // (there's no per-run detail surface to open).
   const origin = entry.origin
   const issueId = origin?.issueId
+  const senderSignature = origin?.resumeId ? `@${origin.resumeId}` : null
+  const senderLabel = [origin?.agent, senderSignature].filter(Boolean).join(' · ') || null
   // Interactive provenance — the human-attended session this push came from
   // (server-stamped from AQ_SESSION_ID, validated against the session registry).
   // Navigable: opens/focuses that exact session tab.
@@ -293,11 +295,11 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
             type="button"
             onClick={openSession}
             disabled={!wsAlive || !sessionRecord}
-            title={`From session ${sessionId}`}
+            title={senderLabel ? `From ${senderLabel}` : `From session ${sessionId}`}
             className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-text-muted/80 hover:text-accent hover:bg-accent/10 transition-colors disabled:opacity-50 disabled:hover:text-text-muted/80 disabled:hover:bg-transparent disabled:cursor-default"
           >
             <Terminal size={12} strokeWidth={1.75} className="shrink-0" />
-            <span className="truncate max-w-[220px]">from session{origin?.agent ? ` · ${origin.agent}` : ''}</span>
+            <span className="truncate max-w-[360px]">from {senderLabel ?? 'session'}</span>
           </button>
         ) : hasHeadlessOrigin ? (
           <button
@@ -305,10 +307,10 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
             onClick={() => void continueOrigin()}
             disabled={!wsAlive || continuing}
             className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-text-muted/80 hover:text-accent hover:bg-accent/10 transition-colors disabled:opacity-50 disabled:hover:text-text-muted/80 disabled:hover:bg-transparent disabled:cursor-default"
-            title={`From headless run ${origin.runId}`}
+            title={senderLabel ? `From ${senderLabel}` : `From headless run ${origin.runId}`}
           >
             <Bot size={12} strokeWidth={1.75} className="shrink-0" />
-            <span>from run{origin.agent ? ` · ${origin.agent}` : ''}</span>
+            <span className="truncate max-w-[360px]">from {senderLabel ?? 'run'}</span>
           </button>
         ) : null}
 
@@ -406,8 +408,9 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
         )}
       </div>
 
-      <div className="mt-4 text-[11px] text-text-muted/40 font-mono">
-        workspace: {entry.workspaceId}
+      <div className="mt-4 space-y-0.5 text-[11px] text-text-muted/40 font-mono">
+        <div>workspace: {entry.workspaceId}</div>
+        {senderSignature && <div>sender: {senderSignature}</div>}
       </div>
     </div>
   )


### PR DESCRIPTION
## What changed

- attach bounded Markdown files from Inbox `docs` to Telegram and Discord deliveries
- verify attachment size, base64, and SHA-256 before platform upload
- keep attachment bytes out of the replay journal while retaining filename/size/hash evidence
- show the CLI-stamped Session signature as `@resumeId` in Inbox and external messages
- keep text delivery non-blocking and mark partial attachment delivery degraded
- make the Connector journal permission test portable on Windows while retaining strict `0600` checks on POSIX
- document the CLI-only provenance and attachment contract

## Why

Inbox reports are normally Markdown files. External connectors previously sent only the path text, while the generic runtime label hid the unique Session signature that the CLI had already persisted.

The prior Windows CI failure was a test portability bug: Windows reports files created with mode `0600` as `0666` because it does not expose POSIX permission bits.

## Validation

- `pnpm test` — 249 files passed, 2740 tests passed
- root and UI TypeScript checks
- Connector protocol and service builds
- `pnpm test:connector-replay`
- `pnpm test:connector-service`
- targeted journal/attachment/provenance tests
- live Inbox browser verification of `pi · @resumeId`

Live Telegram/Discord account delivery was intentionally not triggered without an explicit external-message acceptance run.