### PR TITLE
feat(webpi): collapse tool activity into conversational turns

### DIFF
--- a/ui/src/components/workspace/WebPiView.tsx
+++ b/ui/src/components/workspace/WebPiView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react'
-import { LoaderCircle, Send, Square } from 'lucide-react'
+import { Check, ChevronRight, CircleAlert, CircleDashed, LoaderCircle, Send, Square } from 'lucide-react'
 
 import { MarkdownContent } from '../MarkdownContent'
 import {
@@ -8,6 +8,15 @@ import {
   promptWebPiSession,
   type WebPiSnapshot,
 } from './api'
+import {
+  activityToolLabel,
+  contentText,
+  groupWebPiTranscript,
+  summarizeToolInput,
+  type WebPiActivity,
+  type WebPiToolStep,
+  type WebPiTranscriptItem,
+} from './webpi-transcript'
 
 interface Props {
   readonly wsId: string
@@ -66,10 +75,11 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
       ? [...snapshot.messages, snapshot.streamingMessage]
       : [...snapshot.messages]
   }, [snapshot])
+  const transcript = useMemo(() => groupWebPiTranscript(messages), [messages])
 
   useEffect(() => {
     scrollerRef.current?.scrollTo({ top: scrollerRef.current.scrollHeight, behavior: 'smooth' })
-  }, [messages.length, snapshot?.revision])
+  }, [snapshot?.revision, transcript.length])
 
   const working = snapshot?.phase === 'working' || snapshot?.phase === 'compacting' || snapshot?.phase === 'retrying'
 
@@ -111,8 +121,12 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
         {messages.length === 0 && !error && (
           <div className="webpi-empty">This Pi conversation is ready in the browser.</div>
         )}
-        {messages.map((message, index) => (
-          <PiMessage key={messageKey(message, index)} value={message} />
+        {transcript.map((item, index) => (
+          <PiTranscriptItem
+            key={item.key}
+            item={item}
+            working={working && index === transcript.length - 1}
+          />
         ))}
         {error && (
           <div className="webpi-error">
@@ -155,39 +169,146 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
   )
 }
 
-function PiMessage({ value }: { readonly value: unknown }): ReactElement {
-  const record = asRecord(value)
-  const role = typeof record?.['role'] === 'string' ? record['role'] : 'assistant'
-  const user = role === 'user'
-  const tool = role === 'toolResult' || role === 'tool'
-  const content = record?.['content']
+function PiTranscriptItem({
+  item,
+  working,
+}: {
+  readonly item: WebPiTranscriptItem
+  readonly working: boolean
+}): ReactElement {
+  if (item.kind === 'user') {
+    return (
+      <article className="webpi-message is-user">
+        <div className="webpi-message-body"><PiContent value={item.content} /></div>
+      </article>
+    )
+  }
+  if (item.kind === 'unknown') {
+    return (
+      <article className="webpi-message is-assistant">
+        <div className="webpi-message-body"><PiContent value={item.value} /></div>
+      </article>
+    )
+  }
   return (
-    <article className={`webpi-message is-${user ? 'user' : tool ? 'tool' : 'assistant'}`}>
+    <article className="webpi-message is-assistant is-turn">
       <div className="webpi-message-body">
-        {tool && record
-          ? <PiToolResult record={record} />
-          : <PiContent value={content ?? value} />}
+        {item.progress.map((text, index) => (
+          <div key={index} className="webpi-progress-text"><MarkdownContent text={text} /></div>
+        ))}
+        {item.activity && <PiActivityGroup activity={item.activity} working={working} />}
+        {item.final && <div className="webpi-final-text"><MarkdownContent text={item.final} /></div>}
       </div>
     </article>
   )
 }
 
-function PiToolResult({ record }: { readonly record: Record<string, unknown> }): ReactElement {
-  const failed = record['isError'] === true
-  const [open, setOpen] = useState(failed)
-  const content = record['content']
-  const chars = contentText(content).length
+function PiActivityGroup({ activity, working }: { readonly activity: WebPiActivity; readonly working: boolean }): ReactElement {
+  const failedCount = activity.steps.filter((step) => step.status === 'failed').length
+  const running = activity.steps.some((step) => step.status === 'running')
+  const thinkingCount = activity.thinking.length
+    + activity.steps.reduce((count, step) => count + step.thinking.length, 0)
+  const [open, setOpen] = useState(failedCount > 0)
+
+  useEffect(() => {
+    if (failedCount > 0) setOpen(true)
+  }, [failedCount])
+
+  const title = failedCount > 0
+    ? `${failedCount} failed`
+    : running ? (working ? 'Working' : 'Incomplete')
+      : activity.steps.length > 0 ? `${activity.steps.length} action${activity.steps.length === 1 ? '' : 's'}`
+        : 'Reasoning'
+  const tools = activityToolLabel(activity.steps)
+  const detail = tools || (thinkingCount > 0 ? `${thinkingCount} note${thinkingCount === 1 ? '' : 's'}` : 'Details')
+
   return (
     <details
-      className={`webpi-tool-result${failed ? ' is-error' : ''}`}
+      className={`webpi-activity${failedCount > 0 ? ' is-error' : ''}${running ? ' is-running' : ''}`}
       open={open}
       onToggle={(event) => setOpen(event.currentTarget.open)}
     >
       <summary>
-        <span>{failed ? 'Failed' : 'Result'} from {String(record['toolName'] ?? 'tool')}</span>
-        <span>{formatChars(chars)}</span>
+        <span className="webpi-activity-status" aria-hidden="true">
+          {failedCount > 0
+            ? <CircleAlert size={14} />
+            : running
+              ? working ? <LoaderCircle size={14} className="animate-spin" /> : <CircleDashed size={14} />
+              : <Check size={14} />}
+        </span>
+        <span className="webpi-activity-title">{title}</span>
+        <span className="webpi-activity-meta">{detail}</span>
+        <ChevronRight size={14} className="webpi-disclosure" aria-hidden="true" />
       </summary>
-      {open && <PiContent value={content} />}
+      <div className="webpi-activity-body">
+        {activity.steps.map((step) => <PiToolStepView key={step.id} step={step} working={working} />)}
+        {activity.thinking.length > 0 && (
+          <PiReasoning notes={activity.thinking} label="Final reasoning" />
+        )}
+        {activity.unknownParts.length > 0 && (
+          <details className="webpi-reasoning">
+            <summary>Raw events · {activity.unknownParts.length}</summary>
+            <pre>{JSON.stringify(activity.unknownParts, null, 2)}</pre>
+          </details>
+        )}
+      </div>
+    </details>
+  )
+}
+
+function PiToolStepView({ step, working }: { readonly step: WebPiToolStep; readonly working: boolean }): ReactElement {
+  const failed = step.status === 'failed'
+  const [open, setOpen] = useState(failed)
+  const summary = summarizeToolInput(step.name, step.input)
+  const resultChars = step.result === undefined ? null : contentText(step.result).length
+
+  useEffect(() => {
+    if (failed) setOpen(true)
+  }, [failed])
+
+  return (
+    <details
+      className={`webpi-tool-step is-${step.status}`}
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary>
+        <span className="webpi-step-status" aria-hidden="true">
+          {failed
+            ? <CircleAlert size={13} />
+            : step.status === 'running'
+              ? working ? <LoaderCircle size={13} className="animate-spin" /> : <CircleDashed size={13} />
+              : <Check size={13} />}
+        </span>
+        <code>{step.name}</code>
+        <span className="webpi-step-summary">{summary ?? (step.status === 'running' ? 'Running…' : 'Completed')}</span>
+        {resultChars !== null && <span className="webpi-step-size">{formatChars(resultChars)}</span>}
+        <ChevronRight size={13} className="webpi-disclosure" aria-hidden="true" />
+      </summary>
+      <div className="webpi-step-detail">
+        {step.thinking.length > 0 && <PiReasoning notes={step.thinking} label="Reasoning" />}
+        <section>
+          <h4>Input</h4>
+          <pre>{JSON.stringify(step.input, null, 2)}</pre>
+        </section>
+        {step.result !== undefined && (
+          <section>
+            <h4>{failed ? 'Error' : 'Result'}</h4>
+            <div className="webpi-step-result"><PiContent value={step.result} /></div>
+          </section>
+        )}
+      </div>
+    </details>
+  )
+}
+
+function PiReasoning({ notes, label }: { readonly notes: readonly string[]; readonly label: string }): ReactElement {
+  return (
+    <details className="webpi-reasoning">
+      <summary>{label} · {notes.length}</summary>
+      <div className="webpi-reasoning-notes">
+        {notes.map((note, index) => <MarkdownContent key={index} text={note} />)}
+      </div>
     </details>
   )
 }
@@ -231,22 +352,7 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
-function contentText(value: unknown): string {
-  if (typeof value === 'string') return value
-  if (!Array.isArray(value)) return ''
-  return value.flatMap((part) => {
-    const item = asRecord(part)
-    return typeof item?.['text'] === 'string' ? [item['text']] : []
-  }).join('\n')
-}
-
 function formatChars(chars: number): string {
   if (chars < 1_000) return `${chars} chars`
   return `${(chars / 1_000).toFixed(chars < 10_000 ? 1 : 0)}k chars`
-}
-
-function messageKey(value: unknown, index: number): string {
-  const record = asRecord(value)
-  const stable = record?.['id'] ?? record?.['toolCallId'] ?? record?.['timestamp'] ?? record?.['role'] ?? 'message'
-  return `${index}-${String(stable)}`
 }

--- a/ui/src/components/workspace/webpi-transcript.spec.ts
+++ b/ui/src/components/workspace/webpi-transcript.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  activityToolLabel,
+  groupWebPiTranscript,
+  summarizeToolInput,
+} from './webpi-transcript'
+
+describe('groupWebPiTranscript', () => {
+  it('turns Pi assistant/tool hops into one auditable activity group', () => {
+    const transcript = groupWebPiTranscript([
+      { role: 'user', content: [{ type: 'text', text: 'Send the report.' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'Create the report first.' },
+          { type: 'text', text: 'I will write and send it.' },
+          { type: 'toolCall', id: 'call-write', name: 'write', arguments: { path: 'research/report.md', content: '# Report' } },
+        ],
+      },
+      { role: 'toolResult', toolCallId: 'call-write', toolName: 'write', content: [{ type: 'text', text: 'Wrote 8 bytes' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'Push the Inbox entry.' },
+          { type: 'toolCall', id: 'call-bash', name: 'bash', arguments: { command: 'alice-workspace inbox push --doc research/report.md' } },
+        ],
+      },
+      { role: 'toolResult', toolCallId: 'call-bash', toolName: 'bash', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'assistant', content: [{ type: 'thinking', thinking: 'Summarize.' }, { type: 'text', text: 'Done.' }] },
+    ])
+
+    expect(transcript).toHaveLength(2)
+    expect(transcript[1]).toMatchObject({
+      kind: 'assistant-turn',
+      key: 'assistant-1',
+      progress: ['I will write and send it.'],
+      final: 'Done.',
+      activity: {
+        steps: [
+          { id: 'call-write', name: 'write', status: 'succeeded', thinking: ['Create the report first.'] },
+          { id: 'call-bash', name: 'bash', status: 'succeeded', thinking: ['Push the Inbox entry.'] },
+        ],
+        thinking: ['Summarize.'],
+      },
+    })
+  })
+
+  it('keeps failures openable and preserves unmatched native tool results', () => {
+    const transcript = groupWebPiTranscript([
+      { role: 'assistant', content: [{ type: 'toolCall', id: 'pending', name: 'bash', arguments: {} }] },
+      { role: 'toolResult', toolCallId: 'orphan', toolName: 'read', isError: true, content: [{ type: 'text', text: 'missing' }] },
+    ])
+    expect(transcript[0]).toMatchObject({
+      kind: 'assistant-turn',
+      activity: {
+        steps: [
+          { id: 'pending', status: 'running' },
+          { id: 'orphan', name: 'read', status: 'failed' },
+        ],
+      },
+    })
+  })
+})
+
+describe('WebPi activity summaries', () => {
+  it('summarizes safe, useful arguments without exposing write contents', () => {
+    expect(summarizeToolInput('write', { path: 'research/report.md', content: 'secret body' }))
+      .toBe('research/report.md')
+    expect(summarizeToolInput('write', { content: 'secret body' })).toBeNull()
+    expect(summarizeToolInput('bash', { command: 'git status --short\nsecond line' }))
+      .toBe('git status --short second line')
+  })
+
+  it('counts repeated tools in first-seen order', () => {
+    expect(activityToolLabel([
+      { id: '1', name: 'write', input: {}, thinking: [], status: 'succeeded' },
+      { id: '2', name: 'bash', input: {}, thinking: [], status: 'succeeded' },
+      { id: '3', name: 'bash', input: {}, thinking: [], status: 'succeeded' },
+    ])).toBe('write · bash ×2')
+  })
+})

--- a/ui/src/components/workspace/webpi-transcript.ts
+++ b/ui/src/components/workspace/webpi-transcript.ts
@@ -1,0 +1,235 @@
+export interface WebPiToolStep {
+  readonly id: string
+  readonly name: string
+  readonly input: unknown
+  readonly result?: unknown
+  readonly thinking: readonly string[]
+  readonly status: 'running' | 'succeeded' | 'failed'
+}
+
+export interface WebPiActivity {
+  readonly steps: readonly WebPiToolStep[]
+  readonly thinking: readonly string[]
+  readonly unknownParts: readonly unknown[]
+}
+
+export type WebPiTranscriptItem =
+  | {
+      readonly kind: 'user'
+      readonly key: string
+      readonly content: unknown
+    }
+  | {
+      readonly kind: 'assistant-turn'
+      readonly key: string
+      readonly progress: readonly string[]
+      readonly final: string | null
+      readonly activity: WebPiActivity | null
+    }
+  | {
+      readonly kind: 'unknown'
+      readonly key: string
+      readonly value: unknown
+    }
+
+interface MutableTurn {
+  readonly startIndex: number
+  readonly messages: Array<{ value: unknown; index: number }>
+}
+
+interface ToolResultRecord {
+  readonly value: Record<string, unknown>
+}
+
+/**
+ * Pi persists each assistant/tool-result hop as a native message. The browser
+ * should present those records as one conversational turn without replacing
+ * Pi's schema or losing the raw audit trail.
+ */
+export function groupWebPiTranscript(messages: readonly unknown[]): WebPiTranscriptItem[] {
+  const items: WebPiTranscriptItem[] = []
+  let turn: MutableTurn | null = null
+
+  const flushTurn = (): void => {
+    if (!turn) return
+    items.push(buildAssistantTurn(turn))
+    turn = null
+  }
+
+  messages.forEach((value, index) => {
+    const record = asRecord(value)
+    const role = typeof record?.['role'] === 'string' ? record['role'] : null
+    if (role === 'user') {
+      flushTurn()
+      items.push({
+        kind: 'user',
+        key: messageKey(value, index),
+        content: record?.['content'] ?? value,
+      })
+      return
+    }
+    if (role === 'assistant' || role === 'toolResult' || role === 'tool') {
+      turn ??= { startIndex: index, messages: [] }
+      turn.messages.push({ value, index })
+      return
+    }
+    flushTurn()
+    items.push({ kind: 'unknown', key: messageKey(value, index), value })
+  })
+  flushTurn()
+  return items
+}
+
+export function summarizeToolInput(_name: string, input: unknown): string | null {
+  const record = asRecord(input)
+  if (!record) return primitiveSummary(input)
+  const path = firstString(record, ['path', 'file', 'filePath', 'target'])
+  if (path) return truncateLine(path, 84)
+  const command = firstString(record, ['command', 'cmd'])
+  if (command) return truncateLine(command, 84)
+  const query = firstString(record, ['query', 'q', 'pattern'])
+  if (query) return truncateLine(query, 84)
+  const fallback = Object.entries(record).find(([key, value]) => (
+    key !== 'content' && ['string', 'number', 'boolean'].includes(typeof value)
+  ))
+  return fallback ? truncateLine(String(fallback[1]), 84) : null
+}
+
+export function activityToolLabel(steps: readonly WebPiToolStep[]): string {
+  const counts = new Map<string, number>()
+  for (const step of steps) counts.set(step.name, (counts.get(step.name) ?? 0) + 1)
+  return [...counts].map(([name, count]) => count > 1 ? `${name} ×${count}` : name).join(' · ')
+}
+
+export function contentText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (!Array.isArray(value)) {
+    const record = asRecord(value)
+    return typeof record?.['text'] === 'string' ? record['text'] : ''
+  }
+  return value.flatMap((part) => {
+    const item = asRecord(part)
+    return typeof item?.['text'] === 'string' ? [item['text']] : []
+  }).join('\n')
+}
+
+function buildAssistantTurn(turn: MutableTurn): WebPiTranscriptItem {
+  const results = new Map<string, ToolResultRecord>()
+  for (const message of turn.messages) {
+    const record = asRecord(message.value)
+    const role = typeof record?.['role'] === 'string' ? record['role'] : null
+    const toolCallId = typeof record?.['toolCallId'] === 'string' ? record['toolCallId'] : null
+    if ((role === 'toolResult' || role === 'tool') && toolCallId) {
+      results.set(toolCallId, { value: record! })
+    }
+  }
+
+  const usedResults = new Set<string>()
+  const texts: string[] = []
+  const steps: WebPiToolStep[] = []
+  const detachedThinking: string[] = []
+  const unknownParts: unknown[] = []
+
+  for (const message of turn.messages) {
+    const record = asRecord(message.value)
+    if (record?.['role'] !== 'assistant') continue
+    const content = record['content']
+    if (!Array.isArray(content)) {
+      if (typeof content === 'string' && content.trim()) texts.push(content)
+      else if (content !== undefined) unknownParts.push(content)
+      continue
+    }
+
+    let pendingThinking: string[] = []
+    for (const part of content) {
+      const item = asRecord(part)
+      const type = typeof item?.['type'] === 'string' ? item['type'] : 'unknown'
+      if (type === 'thinking') {
+        const thinking = typeof item?.['thinking'] === 'string'
+          ? item['thinking']
+          : typeof item?.['text'] === 'string' ? item['text'] : ''
+        if (thinking.trim()) pendingThinking.push(thinking)
+        continue
+      }
+      if (type === 'text' && typeof item?.['text'] === 'string') {
+        if (item['text'].trim()) texts.push(item['text'])
+        continue
+      }
+      if (type === 'toolCall') {
+        const id = typeof item?.['id'] === 'string'
+          ? item['id']
+          : typeof item?.['toolCallId'] === 'string' ? item['toolCallId'] : `tool-${message.index}-${steps.length}`
+        const result = results.get(id)
+        if (result) usedResults.add(id)
+        steps.push({
+          id,
+          name: typeof item?.['name'] === 'string' ? item['name'] : 'tool',
+          input: item?.['arguments'] ?? {},
+          ...(result ? { result: result.value['content'] } : {}),
+          thinking: pendingThinking,
+          status: result?.value['isError'] === true ? 'failed' : result ? 'succeeded' : 'running',
+        })
+        pendingThinking = []
+        continue
+      }
+      unknownParts.push(part)
+    }
+    detachedThinking.push(...pendingThinking)
+  }
+
+  for (const [id, result] of results) {
+    if (usedResults.has(id)) continue
+    steps.push({
+      id,
+      name: typeof result.value['toolName'] === 'string' ? result.value['toolName'] : 'tool',
+      input: {},
+      result: result.value['content'],
+      thinking: [],
+      status: result.value['isError'] === true ? 'failed' : 'succeeded',
+    })
+  }
+
+  const final = texts.length > 0 ? texts[texts.length - 1]! : null
+  const activity = steps.length > 0 || detachedThinking.length > 0 || unknownParts.length > 0
+    ? { steps, thinking: detachedThinking, unknownParts }
+    : null
+  return {
+    kind: 'assistant-turn',
+    // Keep the key stable while Pi appends tool calls/results during polling.
+    // Otherwise every newly-arrived step remounts the disclosure and closes it.
+    key: `assistant-${turn.startIndex}`,
+    progress: texts.slice(0, -1),
+    final,
+    activity,
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function firstString(record: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    if (typeof record[key] === 'string' && record[key].trim()) return record[key]
+  }
+  return null
+}
+
+function primitiveSummary(value: unknown): string | null {
+  return ['string', 'number', 'boolean'].includes(typeof value)
+    ? truncateLine(String(value), 84)
+    : null
+}
+
+function truncateLine(value: string, max: number): string {
+  const line = value.replace(/\s+/g, ' ').trim()
+  return line.length <= max ? line : `${line.slice(0, max - 1)}…`
+}
+
+function messageKey(value: unknown, index: number): string {
+  const record = asRecord(value)
+  const stable = record?.['id'] ?? record?.['toolCallId'] ?? record?.['timestamp'] ?? record?.['role'] ?? 'message'
+  return `${index}-${String(stable)}`
+}

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -1018,21 +1018,81 @@
 }
 
 .webpi-empty { padding: 12vh 16px; text-align: center; color: var(--color-text-muted); font-size: 13px; }
-.webpi-message { display: flex; align-items: flex-start; margin: 0 0 24px; }
+.webpi-message { display: flex; align-items: flex-start; margin: 0 0 26px; }
 .webpi-message.is-user { justify-content: flex-end; margin-left: 12%; }
-.webpi-message.is-tool { margin: -12px 0 16px; }
 .webpi-message-body { flex: 1; min-width: 0; font-size: 13px; line-height: 1.65; }
 .webpi-message.is-user .webpi-message-body { flex: 0 1 auto; max-width: min(88%, 760px); padding: 10px 13px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-bg-secondary); }
+.webpi-message.is-turn .webpi-message-body { display: grid; gap: 12px; }
+.webpi-progress-text { color: color-mix(in srgb, var(--color-text) 88%, var(--color-text-muted)); }
+.webpi-final-text { color: var(--color-text); }
 .webpi-content-parts > * + * { margin-top: 9px; }
 .webpi-detail { padding: 6px 9px; border-left: 2px solid var(--color-border); color: var(--color-text-muted); font-size: 11px; }
 .webpi-detail summary { cursor: pointer; user-select: none; font-weight: 600; }
 .webpi-detail pre, .webpi-unknown { margin-top: 6px; max-height: 220px; overflow: auto; white-space: pre-wrap; font: 10px/1.5 var(--font-mono, monospace); }
-.webpi-tool-result { border: 1px solid var(--color-border); border-radius: 8px; background: color-mix(in srgb, var(--color-bg-secondary) 72%, transparent); }
-.webpi-tool-result > summary { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 6px 9px; cursor: pointer; color: var(--color-text-muted); font: 10px/1.4 var(--font-mono, monospace); user-select: none; }
-.webpi-tool-result > summary::marker { color: var(--color-text-muted); }
-.webpi-tool-result[open] > summary { border-bottom: 1px solid var(--color-border); }
-.webpi-tool-result > :not(summary) { max-height: 360px; overflow: auto; padding: 9px 11px; }
-.webpi-tool-result.is-error { border-color: color-mix(in srgb, #d65c5c 55%, var(--color-border)); }
+
+.webpi-activity {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--color-border) 88%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-bg-secondary) 54%, transparent);
+  transition: border-color 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
+}
+.webpi-activity:hover { border-color: color-mix(in srgb, var(--color-accent) 24%, var(--color-border)); }
+.webpi-activity[open] { background: color-mix(in srgb, var(--color-bg-secondary) 72%, transparent); box-shadow: 0 8px 24px color-mix(in srgb, #000 5%, transparent); }
+.webpi-activity.is-error { border-color: color-mix(in srgb, #d65c5c 48%, var(--color-border)); }
+.webpi-activity > summary,
+.webpi-tool-step > summary,
+.webpi-reasoning > summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+}
+.webpi-activity > summary::-webkit-details-marker,
+.webpi-tool-step > summary::-webkit-details-marker,
+.webpi-reasoning > summary::-webkit-details-marker { display: none; }
+.webpi-activity > summary {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+.webpi-activity-status { width: 18px; height: 18px; flex: 0 0 18px; display: grid; place-items: center; border-radius: 6px; color: color-mix(in srgb, var(--color-text-muted) 82%, transparent); background: color-mix(in srgb, var(--color-border) 42%, transparent); }
+.webpi-activity.is-running .webpi-activity-status { color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
+.webpi-activity.is-error .webpi-activity-status { color: #d65c5c; background: color-mix(in srgb, #d65c5c 10%, transparent); }
+.webpi-activity-title { flex: 0 0 auto; color: color-mix(in srgb, var(--color-text) 88%, var(--color-text-muted)); font-weight: 650; }
+.webpi-activity-meta { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 10px/1.4 var(--font-mono, monospace); }
+.webpi-disclosure { flex: 0 0 auto; margin-left: auto; transition: transform 150ms ease; }
+.webpi-activity[open] > summary .webpi-disclosure,
+.webpi-tool-step[open] > summary .webpi-disclosure { transform: rotate(90deg); }
+.webpi-activity-body { border-top: 1px solid color-mix(in srgb, var(--color-border) 84%, transparent); padding: 3px 10px 7px; }
+.webpi-activity[open] > .webpi-activity-body,
+.webpi-tool-step[open] > .webpi-step-detail { animation: webpi-detail-reveal 150ms ease-out both; }
+
+.webpi-tool-step { border-bottom: 1px solid color-mix(in srgb, var(--color-border) 68%, transparent); }
+.webpi-tool-step:last-of-type { border-bottom: 0; }
+.webpi-tool-step > summary { min-height: 38px; display: grid; grid-template-columns: 18px minmax(58px, auto) minmax(0, 1fr) auto 14px; align-items: center; gap: 8px; padding: 6px 1px; color: var(--color-text-muted); }
+.webpi-tool-step > summary:hover { color: var(--color-text); }
+.webpi-step-status { width: 18px; height: 18px; display: grid; place-items: center; color: color-mix(in srgb, var(--color-text-muted) 70%, transparent); }
+.webpi-tool-step.is-running .webpi-step-status { color: var(--color-accent); }
+.webpi-tool-step.is-failed .webpi-step-status { color: #d65c5c; }
+.webpi-tool-step > summary code { overflow: hidden; color: color-mix(in srgb, var(--color-text) 90%, var(--color-text-muted)); font: 600 10px/1.4 var(--font-mono, monospace); text-overflow: ellipsis; }
+.webpi-step-summary { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 10px; }
+.webpi-step-size { white-space: nowrap; color: color-mix(in srgb, var(--color-text-muted) 72%, transparent); font: 9px/1.4 var(--font-mono, monospace); }
+.webpi-tool-step > summary .webpi-disclosure { margin-left: 0; }
+.webpi-step-detail { display: grid; gap: 9px; margin: 0 0 8px 26px; padding: 9px 10px; border: 1px solid color-mix(in srgb, var(--color-border) 76%, transparent); border-radius: 8px; background: color-mix(in srgb, var(--color-bg) 64%, transparent); }
+.webpi-step-detail section { min-width: 0; }
+.webpi-step-detail h4 { margin: 0 0 5px; color: var(--color-text-muted); font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.webpi-step-detail pre { max-height: 230px; margin: 0; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; color: color-mix(in srgb, var(--color-text) 88%, var(--color-text-muted)); font: 10px/1.5 var(--font-mono, monospace); }
+.webpi-step-result { max-height: 320px; overflow: auto; font-size: 11px; }
+
+.webpi-reasoning { color: var(--color-text-muted); }
+.webpi-reasoning > summary { width: fit-content; padding: 7px 1px; font-size: 10px; font-weight: 600; }
+.webpi-reasoning > summary:hover { color: var(--color-text); }
+.webpi-reasoning-notes { display: grid; gap: 8px; margin: 0 0 7px; padding: 8px 10px; border-left: 2px solid color-mix(in srgb, var(--color-accent) 24%, var(--color-border)); color: color-mix(in srgb, var(--color-text) 82%, var(--color-text-muted)); font-size: 10px; }
+.webpi-reasoning pre { max-height: 220px; margin: 0 0 7px; overflow: auto; white-space: pre-wrap; font: 10px/1.5 var(--font-mono, monospace); }
 
 .webpi-error { display: grid; gap: 7px; margin: 20px 0; padding: 13px; border: 1px solid color-mix(in srgb, #d65c5c 50%, var(--color-border)); border-radius: 10px; color: #d65c5c; font-size: 12px; }
 .webpi-error button { width: fit-content; color: var(--color-text); text-decoration: underline; }
@@ -1044,8 +1104,21 @@
 .webpi-send:disabled { opacity: .35; }
 .webpi-composer-hint { padding: 5px 3px 0; text-align: right; color: var(--color-text-muted); font-size: 9px; }
 
+@keyframes webpi-detail-reveal {
+  from { opacity: 0; transform: translateY(-3px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .webpi-activity[open] > .webpi-activity-body,
+  .webpi-tool-step[open] > .webpi-step-detail { animation: none; }
+}
+
 @media (max-width: 720px) {
   .webpi-messages, .webpi-composer-wrap { padding-left: 12px; padding-right: 12px; }
   .webpi-message.is-user { margin-left: 0; }
+  .webpi-tool-step > summary { grid-template-columns: 18px minmax(52px, auto) minmax(0, 1fr) 14px; }
+  .webpi-step-size { display: none; }
+  .webpi-step-detail { margin-left: 0; }
   .resume-cta-actions { flex-direction: column; }
 }


### PR DESCRIPTION
## Summary
- group Pi assistant/tool-result hops into one conversational activity per user turn
- show a compact action summary by default, with step and raw audit details behind two disclosure levels
- preserve progress/final text, running and failure states, and stable disclosure state while polling

## Verification
- `pnpm exec vitest run ui/src/components/workspace/webpi-transcript.spec.ts`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (250 files passed, 2744 tests passed)
- browser-verified against an existing WebPi conversation at localhost:5173