### PR TITLE
feat(remote): add SSH tunnel connector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,8 @@ Read the relevant guide before editing its subsystem:
   packaging, managed Pi, PortableGit/Bash, runtime profiles, and Workspace PATH.
 - [[docs/docker-deployment.md]] — [Docker deployment](docs/docker-deployment.md): server image topology,
   remote-host safety, persistence, health, and container acceptance.
+- [[docs/remote-access.md]] — [Remote access](docs/remote-access.md): SSH tunnel experiment,
+  local/remote ownership, and staged remote-control boundaries.
 - [[docs/connector-service.md]] — [Connector Service](docs/connector-service.md): optional external Inbox
   notification adapters, sealed credentials, health, and Guardian lifecycle.
 - [[docs/ui-interaction-and-motion.md]] — [UI interaction and motion](docs/ui-interaction-and-motion.md):

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN corepack enable && corepack prepare pnpm@11.7.0 --activate
 # of `pnpm install` and must already exist on disk.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY scripts/fix-pty-perms.mjs ./scripts/fix-pty-perms.mjs
+COPY packages/cli/package.json packages/cli/
 COPY packages/guardian-runtime/package.json packages/guardian-runtime/
 COPY packages/connector-protocol/package.json packages/connector-protocol/
 COPY packages/ibkr/package.json packages/ibkr/

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ GitHub navigation.
 | [[docs/development-workflow.md]] | [Development workflow](development-workflow.md) | Branches, delivery modes, PRs, promotions, external review, risk gates |
 | [[docs/managed-workspace-runtime.md]] | [Managed Workspace runtime](managed-workspace-runtime.md) | Electron packaging, managed Pi, PortableGit/Bash, runtime profile, Workspace PATH |
 | [[docs/docker-deployment.md]] | [Docker deployment](docker-deployment.md) | Server image topology, remote-host safety, persistence, health, and container acceptance |
+| [[docs/remote-access.md]] | [Remote access](remote-access.md) | SSH tunnel experiment, local/remote ownership, and staged remote-control boundaries |
 | [[docs/connector-service.md]] | [Connector Service](connector-service.md) | Optional Discord/Telegram Inbox projection, adapters, secrets, health, Guardian lifecycle |
 | [[docs/ui-interaction-and-motion.md]] | [UI interaction and motion](ui-interaction-and-motion.md) | Clickable affordances, shared motion tokens, entrances/disclosures, reduced-motion policy |
 | [[docs/workspace-agent-guidance.md]] | [Workspace agent guidance](workspace-agent-guidance.md) | Always-loaded prompt contract, skill ownership, live CLI authority, guidance versioning |

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -4,6 +4,7 @@ This guide owns the OpenAlice server-image contract, Docker Compose lifecycle,
 remote-host safety boundary, and container smoke requirements. It complements
 [[docs/project-structure.md]] and [[docs/managed-workspace-runtime.md]].
 External notification setup is owned by [[docs/connector-service.md]].
+Private browser access over SSH is owned by [[docs/remote-access.md]].
 
 ## Topology
 
@@ -59,6 +60,10 @@ example Caddy, nginx, Tailscale, or a private tunnel) rather than publishing an
 unencrypted public endpoint. Configure `OPENALICE_TRUSTED_PROXIES` only with
 the actual proxy peer addresses; an overly broad trusted-proxy range weakens
 the localhost/auth boundary.
+
+For the Stage 1 SSH path, keep `47331` private on the host and use
+`openalice ssh <host>` as described in [[docs/remote-access.md]]. The tunnel
+targets host loopback; it does not expose the internal CLI/MCP or UTA ports.
 
 ## Health and Lifecycle
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -73,6 +73,7 @@ services/uta/                  UTA process
 └── src/domain/trading/        all broker and trading-domain implementation
 
 packages/
+├── cli/                       installable OpenAlice connection/control CLI
 ├── guardian-runtime/          process ownership and recovery primitives
 ├── uta-protocol/              schemas and wire types shared by Alice + UTA
 ├── ibkr/                      IBKR TWS protocol package, owned by UTA

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -1,0 +1,83 @@
+# Remote Access
+
+This guide owns OpenAlice's SSH access experiment and the boundary between a
+remote Runtime and local presentation. It complements
+[[docs/docker-deployment.md]] and [[docs/managed-workspace-runtime.md]].
+
+## Stage 1: Measure the Existing TUI
+
+The first remote path deliberately keeps the existing product architecture:
+
+```text
+local browser
+  └── 127.0.0.1:<random port>
+        └── SSH local forward
+              └── remote 127.0.0.1:47331
+                    └── Alice HTTP + Workspace PTY WebSocket
+```
+
+Alice, the Workspace, agent CLI, shell, model requests, and tool execution all
+run on the SSH host. The browser loads the normal OpenAlice bundle through the
+tunnel, so HTTP, authentication, and the PTY WebSocket remain same-origin. No
+hosted Studio, relay, or second frontend protocol is involved.
+
+This stage exists to measure the real TUI experience before designing around a
+latency problem that may not matter on normal developer links. WebPi remains an
+optional structured Pi surface; it is not a prerequisite or replacement for
+Shell, Claude Code, Codex, opencode, or Pi TUI sessions.
+
+## Prerequisites
+
+1. OpenAlice is already running on the remote machine.
+2. Its web listener is reachable as `127.0.0.1:47331` from that machine.
+3. The local machine has `ssh` and working key, agent, or interactive SSH auth.
+
+For a source checkout, start the normal Guardian on the remote host. For a
+server deployment, follow [[docs/docker-deployment.md]]. Do not expose the
+internal CLI/MCP, UTA, or Connector ports.
+
+From this repository:
+
+```bash
+pnpm remote:ssh -- user@example.com
+```
+
+From an installed CLI package:
+
+```bash
+openalice ssh user@example.com
+```
+
+The command chooses a free local port, opens the local URL, and remains in the
+foreground to own the tunnel. Use `--no-open` to print the URL only, or
+`--remote-port` when the remote Alice web port differs from `47331`.
+
+The forward binds only local `127.0.0.1` and targets only remote `127.0.0.1`.
+Closing the CLI closes the tunnel. The command does not install, update, start,
+or stop the remote Runtime in Stage 1.
+
+## Security Boundary
+
+SSH authenticates the transport, but the remote HTTP server sees forwarded
+requests as loopback. Alice therefore grants its loginless localhost behavior
+only to requests with no browser `Origin` (CLI/server callers), a loopback
+browser Origin, or the exact packaged `app://openalice` origin. A public
+website cannot inherit localhost trust merely because the user currently has
+an OpenAlice tunnel open.
+
+Keep the remote web listener private or protected by the deployment's normal
+HTTPS/auth boundary. Never use `OPENALICE_DISABLE_AUTH=1` for remote access.
+
+## Deferred Stages
+
+Stage 1 intentionally leaves these separate:
+
+- managed Runtime installation and daemon lifecycle;
+- a hosted standalone Studio and pairing/capability protocol;
+- cloud relay or device enrollment;
+- cursor-based structured Session streaming for Pi, Codex, or other agents;
+- remote control from the packaged Electron app.
+
+Evidence from the raw TUI experiment should decide which of these is worth
+building next. Electron's existing local `app://` + preload/IPC distribution
+remains unchanged.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx scripts/guardian/dev.ts",
     "dev:onboarding": "tsx scripts/onboarding-test-dev.ts",
+    "remote:ssh": "node packages/cli/bin/openalice.mjs ssh",
     "docker:build": "docker build --tag openalice:local .",
     "docker:smoke": "node scripts/docker-runtime-smoke.mjs",
     "prebuild": "tsx scripts/build-migration-index.ts",

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+import { connectSsh, formatSshHelp, parseSshConnectArgs } from '../src/ssh-connect.mjs'
+
+export async function main(argv = process.argv.slice(2)) {
+  const [command, ...args] = argv
+  if (!command || command === '--help' || command === '-h' || command === 'help') {
+    process.stdout.write(formatHelp())
+    return 0
+  }
+  if (command === '--version' || command === '-v' || command === 'version') {
+    process.stdout.write(`${readVersion()}\n`)
+    return 0
+  }
+  if (command !== 'ssh') {
+    throw new Error(`Unknown command: ${command}\n\n${formatHelp()}`)
+  }
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(formatSshHelp())
+    return 0
+  }
+  return connectSsh(parseSshConnectArgs(args))
+}
+
+function formatHelp() {
+  return `OpenAlice CLI
+
+Usage:
+  openalice ssh <user@host> [options]
+
+Commands:
+  ssh       Open a loopback-only SSH tunnel to an already-running OpenAlice
+
+Run "openalice ssh --help" for connection options.
+`
+}
+
+function readVersion() {
+  const packageUrl = new URL('../package.json', import.meta.url)
+  return JSON.parse(readFileSync(packageUrl, 'utf8')).version
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().then(
+    (code) => { process.exitCode = code },
+    (error) => {
+      process.stderr.write(`openalice: ${error instanceof Error ? error.message : String(error)}\n`)
+      process.exitCode = 1
+    },
+  )
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@traderalice/openalice-cli",
+  "version": "0.1.0",
+  "description": "OpenAlice runtime connection CLI",
+  "type": "module",
+  "bin": {
+    "openalice": "./bin/openalice.mjs"
+  },
+  "files": [
+    "bin/openalice.mjs",
+    "src/ssh-connect.mjs"
+  ],
+  "scripts": {
+    "build": "node --check bin/openalice.mjs && node --check src/ssh-connect.mjs",
+    "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "license": "AGPL-3.0-only",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TraderAlice/OpenAlice.git",
+    "directory": "packages/cli"
+  }
+}

--- a/packages/cli/src/ssh-connect.mjs
+++ b/packages/cli/src/ssh-connect.mjs
@@ -1,0 +1,212 @@
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+
+const LOOPBACK = '127.0.0.1'
+
+export function parseSshConnectArgs(argv) {
+  const options = {
+    destination: '',
+    localPort: 0,
+    remotePort: 47331,
+    sshPort: null,
+    identityFile: null,
+    openBrowser: true,
+    waitMs: 60_000,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') continue
+    if (arg === '--no-open') {
+      options.openBrowser = false
+      continue
+    }
+    if (arg === '--local-port') {
+      options.localPort = parsePort(requireValue(argv, ++index, arg), arg, { allowAuto: true })
+      continue
+    }
+    if (arg === '--remote-port') {
+      options.remotePort = parsePort(requireValue(argv, ++index, arg), arg)
+      continue
+    }
+    if (arg === '--ssh-port') {
+      options.sshPort = parsePort(requireValue(argv, ++index, arg), arg)
+      continue
+    }
+    if (arg === '--identity') {
+      options.identityFile = requireValue(argv, ++index, arg)
+      continue
+    }
+    if (arg === '--wait') {
+      const seconds = Number(requireValue(argv, ++index, arg))
+      if (!Number.isFinite(seconds) || seconds < 1 || seconds > 600) {
+        throw new Error('--wait must be a number of seconds between 1 and 600')
+      }
+      options.waitMs = Math.round(seconds * 1_000)
+      continue
+    }
+    if (arg?.startsWith('-')) throw new Error(`Unknown option: ${arg}`)
+    if (options.destination) throw new Error(`Unexpected argument: ${arg}`)
+    options.destination = arg ?? ''
+  }
+
+  if (!options.destination) throw new Error('SSH destination is required (for example: user@example.com)')
+  if (/\s|[\u0000-\u001f\u007f]/.test(options.destination) || options.destination.startsWith('-')) {
+    throw new Error('SSH destination contains unsupported characters')
+  }
+  return options
+}
+
+export function buildSshArgs(options, localPort) {
+  const args = [
+    '-N',
+    '-T',
+    '-o', 'ExitOnForwardFailure=yes',
+    '-o', 'ServerAliveInterval=30',
+    '-o', 'ServerAliveCountMax=3',
+  ]
+  if (options.sshPort !== null) args.push('-p', String(options.sshPort))
+  if (options.identityFile !== null) args.push('-i', options.identityFile)
+  args.push(
+    '-L', `${LOOPBACK}:${localPort}:${LOOPBACK}:${options.remotePort}`,
+    options.destination,
+  )
+  return args
+}
+
+export async function connectSsh(options, dependencies = {}) {
+  const allocatePort = dependencies.allocatePort ?? allocateLoopbackPort
+  const spawnProcess = dependencies.spawnProcess ?? spawn
+  const waitForRuntime = dependencies.waitForRuntime ?? waitForOpenAlice
+  const launchBrowser = dependencies.launchBrowser ?? openBrowser
+  const stdout = dependencies.stdout ?? process.stdout
+  const localPort = options.localPort || await allocatePort()
+  const localUrl = `http://${LOOPBACK}:${localPort}`
+  const ssh = spawnProcess('ssh', buildSshArgs(options, localPort), {
+    stdio: ['inherit', 'ignore', 'inherit'],
+    windowsHide: true,
+  })
+
+  let ready = false
+  const earlyFailure = new Promise((_, reject) => {
+    ssh.once('error', (error) => reject(error))
+    ssh.once('exit', (code, signal) => {
+      if (!ready) reject(new Error(`SSH tunnel exited before OpenAlice was ready (code=${String(code)}, signal=${String(signal)})`))
+    })
+  })
+
+  try {
+    await Promise.race([
+      waitForRuntime(localUrl, { timeoutMs: options.waitMs }),
+      earlyFailure,
+    ])
+    ready = true
+    stdout.write(`OpenAlice remote runtime: ${options.destination}\n`)
+    stdout.write(`Local OpenAlice UI: ${localUrl}\n`)
+    stdout.write('The SSH tunnel stays active until this command exits. Press Ctrl+C to close it.\n')
+    if (options.openBrowser) await launchBrowser(localUrl)
+    return await holdTunnel(ssh)
+  } catch (error) {
+    ssh.kill('SIGTERM')
+    throw error
+  }
+}
+
+export async function allocateLoopbackPort() {
+  const server = createServer()
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen({ host: LOOPBACK, port: 0, exclusive: true }, resolve)
+  })
+  const address = server.address()
+  const port = address && typeof address === 'object' ? address.port : 0
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  if (!port) throw new Error('Could not reserve a local loopback port')
+  return port
+}
+
+export async function waitForOpenAlice(baseUrl, options = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const timeoutMs = options.timeoutMs ?? 60_000
+  const pollMs = options.pollMs ?? 250
+  const deadline = Date.now() + timeoutMs
+  let lastError = 'connection refused'
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchImpl(`${baseUrl}/api/auth/status`, {
+        signal: AbortSignal.timeout(Math.min(2_000, Math.max(250, deadline - Date.now()))),
+      })
+      if (response.ok) {
+        const body = await response.json()
+        if (typeof body?.authed === 'boolean' && typeof body?.tokenConfigured === 'boolean') return body
+        lastError = 'unexpected response from /api/auth/status'
+      } else {
+        lastError = `HTTP ${response.status}`
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs))
+  }
+  throw new Error(`OpenAlice did not become ready at ${baseUrl} within ${Math.ceil(timeoutMs / 1_000)}s (${lastError}). Start OpenAlice on the remote host first.`)
+}
+
+export async function openBrowser(url, options = {}) {
+  const platform = options.platform ?? process.platform
+  const spawnProcess = options.spawnProcess ?? spawn
+  const command = platform === 'darwin' ? 'open' : platform === 'win32' ? 'cmd.exe' : 'xdg-open'
+  const args = platform === 'win32' ? ['/d', '/s', '/c', 'start', '', url] : [url]
+  const child = spawnProcess(command, args, { detached: true, stdio: 'ignore', windowsHide: true })
+  child.once?.('error', () => undefined)
+  child.unref()
+}
+
+export function formatSshHelp() {
+  return `Usage:
+  openalice ssh <user@host> [options]
+
+Connects the local browser to an OpenAlice instance that is already running on
+the SSH host. The local listener and remote target are both fixed to 127.0.0.1.
+
+Options:
+  --local-port <port|auto>  Local tunnel port (default: auto)
+  --remote-port <port>      OpenAlice web port on the remote host (default: 47331)
+  --ssh-port <port>         SSH server port
+  --identity <path>         SSH identity file
+  --wait <seconds>          Readiness timeout, 1-600 (default: 60)
+  --no-open                 Print the URL without opening a browser
+  -h, --help                Show this help
+`
+}
+
+function holdTunnel(ssh) {
+  if (ssh.exitCode !== undefined && (ssh.exitCode !== null || ssh.signalCode !== null)) {
+    return Promise.resolve(ssh.exitCode ?? 0)
+  }
+  return new Promise((resolve) => {
+    const stop = () => ssh.kill('SIGTERM')
+    process.once('SIGINT', stop)
+    process.once('SIGTERM', stop)
+    ssh.once('exit', (code) => {
+      process.off('SIGINT', stop)
+      process.off('SIGTERM', stop)
+      resolve(code ?? 0)
+    })
+  })
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index]
+  if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function parsePort(raw, flag, options = {}) {
+  if (options.allowAuto && raw === 'auto') return 0
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new Error(`${flag} must be an integer between 1 and 65535${options.allowAuto ? ', or auto' : ''}`)
+  }
+  return value
+}

--- a/packages/cli/src/ssh-connect.spec.mjs
+++ b/packages/cli/src/ssh-connect.spec.mjs
@@ -1,0 +1,110 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  buildSshArgs,
+  connectSsh,
+  openBrowser,
+  parseSshConnectArgs,
+  waitForOpenAlice,
+} from './ssh-connect.mjs'
+
+describe('OpenAlice SSH connector', () => {
+  it('parses a small, explicit SSH surface', () => {
+    expect(parseSshConnectArgs([
+      '--',
+      'alice@example.com',
+      '--local-port', '41000',
+      '--remote-port', '48000',
+      '--ssh-port', '2222',
+      '--identity', '/tmp/id key',
+      '--wait', '15',
+      '--no-open',
+    ])).toEqual({
+      destination: 'alice@example.com',
+      localPort: 41000,
+      remotePort: 48000,
+      sshPort: 2222,
+      identityFile: '/tmp/id key',
+      openBrowser: false,
+      waitMs: 15_000,
+    })
+  })
+
+  it('accepts pnpm run argument separators', () => {
+    expect(parseSshConnectArgs(['--', 'host-alias']).destination).toBe('host-alias')
+  })
+
+  it('rejects option-shaped destinations and invalid ports', () => {
+    expect(() => parseSshConnectArgs(['-oProxyCommand=bad'])).toThrow('Unknown option')
+    expect(() => parseSshConnectArgs(['host', '--remote-port', '0'])).toThrow('between 1 and 65535')
+    expect(() => parseSshConnectArgs(['host name'])).toThrow('unsupported characters')
+  })
+
+  it('builds a loopback-only tunnel and keeps user paths as argv entries', () => {
+    const options = parseSshConnectArgs(['host-alias', '--identity', '/tmp/id key'])
+    expect(buildSshArgs(options, 40123)).toEqual([
+      '-N', '-T',
+      '-o', 'ExitOnForwardFailure=yes',
+      '-o', 'ServerAliveInterval=30',
+      '-o', 'ServerAliveCountMax=3',
+      '-i', '/tmp/id key',
+      '-L', '127.0.0.1:40123:127.0.0.1:47331',
+      'host-alias',
+    ])
+  })
+
+  it('waits for the OpenAlice auth contract rather than accepting arbitrary HTTP', async () => {
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new Error('refused'))
+      .mockResolvedValueOnce(new Response('<html>wrong service</html>'))
+      .mockResolvedValueOnce(Response.json({ authed: true, tokenConfigured: false }))
+    await expect(waitForOpenAlice('http://127.0.0.1:40000', {
+      fetchImpl,
+      timeoutMs: 1_000,
+      pollMs: 1,
+    })).resolves.toEqual({ authed: true, tokenConfigured: false })
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+  })
+
+  it('opens a tunnel, probes it, and keeps the browser on the local URL', async () => {
+    const child = new FakeChild()
+    const spawnProcess = vi.fn(() => child)
+    const waitForRuntime = vi.fn(async () => ({ authed: true }))
+    const launchBrowser = vi.fn(async () => undefined)
+    const stdout = { write: vi.fn() }
+    const result = connectSsh(parseSshConnectArgs(['host']), {
+      allocatePort: async () => 40123,
+      spawnProcess,
+      waitForRuntime,
+      launchBrowser,
+      stdout,
+    })
+    await vi.waitFor(() => expect(launchBrowser).toHaveBeenCalledWith('http://127.0.0.1:40123'))
+    child.emit('exit', 0, null)
+    await expect(result).resolves.toBe(0)
+    expect(spawnProcess).toHaveBeenCalledWith('ssh', expect.arrayContaining([
+      '-L', '127.0.0.1:40123:127.0.0.1:47331', 'host',
+    ]), expect.any(Object))
+  })
+
+  it('uses argv-based browser launchers on each desktop platform', async () => {
+    for (const [platform, command] of [['darwin', 'open'], ['linux', 'xdg-open'], ['win32', 'cmd.exe']]) {
+      const child = { unref: vi.fn() }
+      const spawnProcess = vi.fn(() => child)
+      await openBrowser('http://127.0.0.1:40123', { platform, spawnProcess })
+      expect(spawnProcess).toHaveBeenCalledWith(command, expect.any(Array), expect.objectContaining({
+        detached: true,
+        stdio: 'ignore',
+      }))
+      expect(child.unref).toHaveBeenCalledOnce()
+    }
+  })
+})
+
+class FakeChild extends EventEmitter {
+  exitCode = null
+  signalCode = null
+  kill = vi.fn()
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,8 @@ importers:
         specifier: ^6.8.9
         version: 6.8.9
 
+  packages/cli: {}
+
   packages/connector-protocol:
     dependencies:
       zod:

--- a/src/webui/middleware/auth.spec.ts
+++ b/src/webui/middleware/auth.spec.ts
@@ -15,6 +15,7 @@ import { Hono } from 'hono'
 import {
   createAuthMiddleware,
   isLoopbackIp,
+  isTrustedLocalOrigin,
   SESSION_COOKIE_NAME,
 } from './auth.js'
 import {
@@ -85,6 +86,20 @@ describe('isLoopbackIp', () => {
   })
 })
 
+describe('isTrustedLocalOrigin', () => {
+  it('accepts local browser origins on any port', () => {
+    expect(isTrustedLocalOrigin('http://127.0.0.1:47331')).toBe(true)
+    expect(isTrustedLocalOrigin('http://localhost:5173')).toBe(true)
+    expect(isTrustedLocalOrigin('https://[::1]:47331')).toBe(true)
+    expect(isTrustedLocalOrigin('app://openalice')).toBe(true)
+  })
+
+  it('rejects public and malformed origins', () => {
+    expect(isTrustedLocalOrigin('https://example.com')).toBe(false)
+    expect(isTrustedLocalOrigin('null')).toBe(false)
+  })
+})
+
 describe('auth middleware — playbook 01 (auth bypass)', () => {
   it('01.1: GET /api/trading/uta without cookie from non-localhost → 401', async () => {
     const app = makeApp({ trustedProxies: [], csrfTrustedOrigins: [] })
@@ -129,6 +144,22 @@ describe('auth middleware — playbook 01 (auth bypass)', () => {
     const app = makeApp({ trustedProxies: [], csrfTrustedOrigins: [] })
     const res = await app.request('/api/trading/uta', undefined, envWithIp('::1'))
     expect(res.status).toBe(200)
+  })
+
+  it('loopback browser origin keeps the localhost bypass', async () => {
+    const app = makeApp({ trustedProxies: [], csrfTrustedOrigins: [] })
+    const res = await app.request('/api/trading/uta', {
+      headers: { origin: 'http://127.0.0.1:40123' },
+    }, envWithIp('127.0.0.1'))
+    expect(res.status).toBe(200)
+  })
+
+  it('public browser origin cannot inherit the localhost bypass', async () => {
+    const app = makeApp({ trustedProxies: [], csrfTrustedOrigins: [] })
+    const res = await app.request('/api/trading/uta', {
+      headers: { origin: 'https://evil.example' },
+    }, envWithIp('127.0.0.1'))
+    expect(res.status).toBe(401)
   })
 
   it('public route /api/version is accessible without cookie or localhost', async () => {

--- a/src/webui/middleware/auth.ts
+++ b/src/webui/middleware/auth.ts
@@ -78,7 +78,8 @@ export function createAuthMiddleware(opts: AuthMiddlewareOptions): MiddlewareHan
     // public request through. See safe/playbooks/03-localhost-spoofing.md.
     if (trustedProxies.size === 0) {
       const clientIp = getSocketRemoteAddress(c)
-      if (clientIp && isLoopbackIp(clientIp)) {
+      const origin = c.req.header('origin')
+      if (clientIp && isLoopbackIp(clientIp) && (!origin || isTrustedLocalOrigin(origin))) {
         return next()
       }
     }
@@ -145,6 +146,24 @@ export function isLoopbackIp(ip: string): boolean {
   // IPv4 — accept the entire 127.0.0.0/8 range, not just 127.0.0.1
   if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(norm)) return true
   return false
+}
+
+/** Browser origins that are owned by a local OpenAlice surface. This keeps
+ * localhost, Vite, and the packaged Electron app frictionless without letting
+ * an arbitrary public page inherit the socket-level loopback bypass (including
+ * while an SSH tunnel is open). */
+export function isTrustedLocalOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin)
+    if (url.protocol === 'app:' && url.hostname === 'openalice') return true
+    return (url.protocol === 'http:' || url.protocol === 'https:') && (
+      url.hostname === 'localhost' ||
+      url.hostname === '127.0.0.1' ||
+      url.hostname === '[::1]'
+    )
+  } catch {
+    return false
+  }
 }
 
 function readSessionCookie(cookieHeader: string): string | null {

--- a/src/webui/routes/auth.spec.ts
+++ b/src/webui/routes/auth.spec.ts
@@ -120,3 +120,23 @@ describe('login cookie Secure flag — X-Forwarded-Proto trust gating', () => {
     expect(res.headers.get('set-cookie')).toBeNull()
   })
 })
+
+describe('auth status localhost boundary', () => {
+  it('accepts a local page through a loopback socket', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/auth/status', {
+      headers: { origin: 'http://127.0.0.1:40123' },
+    }, envWithIp('127.0.0.1'))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ authed: true, passthrough: 'localhost' })
+  })
+
+  it('does not report localhost auth to a public browser origin', async () => {
+    const app = makeApp()
+    const res = await app.request('/api/auth/status', {
+      headers: { origin: 'https://evil.example' },
+    }, envWithIp('127.0.0.1'))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ authed: false })
+  })
+})

--- a/src/webui/routes/auth.ts
+++ b/src/webui/routes/auth.ts
@@ -22,6 +22,7 @@ import {
 import {
   SESSION_COOKIE_NAME,
   isLoopbackIp,
+  isTrustedLocalOrigin,
   normalizeIp,
   getSocketRemoteAddress,
 } from '../middleware/auth.js'
@@ -63,7 +64,8 @@ export function createAuthRoutes(opts: AuthRouteOptions = {}) {
     // login page in single-user local mode.
     if (trustedProxies.size === 0) {
       const remote = getSocketRemoteAddress(c) ?? ''
-      if (isLoopbackIp(remote)) {
+      const origin = c.req.header('origin')
+      if (isLoopbackIp(remote) && (!origin || isTrustedLocalOrigin(origin))) {
         return c.json({ authed: true, tokenConfigured: tokenInfo.exists, passthrough: 'localhost' })
       }
     }

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,10 @@
     "open-alice-ui#build": {
       "dependsOn": [],
       "outputs": ["dist/**"]
+    },
+    "@traderalice/openalice-cli#build": {
+      "dependsOn": [],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a zero-dependency `openalice ssh` CLI that opens a loopback-only SSH forward to an already-running remote OpenAlice and launches the normal local browser UI
- preserve the existing Shell/TUI, Electron app, and same-origin PTY transport while tightening localhost auth so public browser origins cannot inherit loopback trust
- document the staged remote-access boundary and keep the new workspace package cache-friendly in local and Docker builds

## Verification
- `npx tsc --noEmit`
- `pnpm test` (252 files passed, 2771 tests passed)
- `pnpm -F @traderalice/openalice-cli build`
- `npm pack --dry-run --json`
- isolated real `sshd` + built OpenAlice + `openalice ssh` tunnel; auth boundary checked with local/public Origins
- in-app browser loaded the tunneled OpenAlice `/chat` route with no console errors
- `pnpm docker:smoke`
- `pnpm electron:build && pnpm electron:smoke:pty --skip-build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`

## Boundary touch
- auth: narrows loopback passthrough to CLI/server calls, local browser Origins, and exact `app://openalice`
- runtime/packaging: adds an installable CLI package and verifies Docker plus unsigned Electron package paths
- trading/credentials/migrations: no ownership or persisted-shape changes