### PR TITLE
feat(cli): add local Runtime bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,8 @@ Read the relevant guide before editing its subsystem:
   delivery modes, promotions, external contributions, and risk gates.
 - [[docs/managed-workspace-runtime.md]] — [Managed Workspace runtime](docs/managed-workspace-runtime.md): Electron
   packaging, managed Pi, PortableGit/Bash, runtime profiles, and Workspace PATH.
+- [[docs/local-runtime.md]] — [Local Runtime and CLI bootstrap](docs/local-runtime.md): curl-installed
+  CLI, source-backed localhost startup, dependency bootstrap, and the headless bundle boundary.
 - [[docs/docker-deployment.md]] — [Docker deployment](docs/docker-deployment.md): server image topology,
   remote-host safety, persistence, health, and container acceptance.
 - [[docs/remote-access.md]] — [Remote access](docs/remote-access.md): SSH tunnel experiment,

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ GitHub navigation.
 | [[docs/project-structure.md]] | [Project structure](project-structure.md) | Process boundaries, source ownership, state roots, architectural entry points |
 | [[docs/development-workflow.md]] | [Development workflow](development-workflow.md) | Branches, delivery modes, PRs, promotions, external review, risk gates |
 | [[docs/managed-workspace-runtime.md]] | [Managed Workspace runtime](managed-workspace-runtime.md) | Electron packaging, managed Pi, PortableGit/Bash, runtime profile, Workspace PATH |
+| [[docs/local-runtime.md]] | [Local Runtime and CLI bootstrap](local-runtime.md) | Curl-installed CLI, source-backed localhost startup, dependency bootstrap, and headless bundle boundary |
 | [[docs/docker-deployment.md]] | [Docker deployment](docker-deployment.md) | Server image topology, remote-host safety, persistence, health, and container acceptance |
 | [[docs/remote-access.md]] | [Remote access](remote-access.md) | SSH tunnel experiment, local/remote ownership, and staged remote-control boundaries |
 | [[docs/connector-service.md]] | [Connector Service](connector-service.md) | Optional Discord/Telegram Inbox projection, adapters, secrets, health, Guardian lifecycle |

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -1,0 +1,134 @@
+# Local Runtime and CLI Bootstrap
+
+This guide owns the browser-local OpenAlice entry, the small installable CLI,
+and the boundary between dependency bootstrap, source-backed Runtime startup,
+Electron distribution, and later downloadable Runtime bundles.
+
+Related guides: [[docs/managed-workspace-runtime.md]],
+[[docs/docker-deployment.md]], and [[docs/remote-access.md]].
+
+## Product Boundary
+
+The local browser path is a first-class OpenAlice distribution surface:
+
+```text
+installed openalice CLI
+  └── local OpenAlice source checkout
+        └── built-runtime Guardian
+              ├── Alice + normal Web UI on 127.0.0.1:47331
+              ├── optional UTA on local internal ports
+              └── optional Connector Service on local internal ports
+```
+
+The browser, API, authentication, Workspace WebSocket, and terminal all share
+one loopback origin. This path does not require a public domain, cross-domain
+cookies, a hosted Studio protocol, or an SSH transport.
+
+Electron remains a separate, complete distribution. The CLI excludes the
+desktop package when preparing a source checkout; it does not replace or
+modify Electron packaging, app protocol, preload, IPC, PTY, signing, or update
+behavior.
+
+## Preview Install
+
+The current installer distributes the small JavaScript CLI from the `dev` ref:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
+```
+
+The preview requires Node.js 20 or newer. It installs versioned CLI files under
+`~/.openalice/cli-versions/`, writes stable `openalice` and `openalice.cmd`
+launchers under `~/.openalice/bin/`, and offers to add that bin directory to the
+current shell profile. It does not clone OpenAlice, write application state, or
+install Electron. The curl entry targets macOS, Linux, WSL, and Git Bash;
+native Windows desktop distribution remains the signed Electron installer.
+
+For a pinned tag or commit:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install \
+  | bash -s -- --version <git-ref>
+```
+
+For local installer development:
+
+```bash
+./install --source . --version dev --no-modify-path
+```
+
+Until release assets include a standalone headless Runtime, users keep an
+OpenAlice source checkout and run the CLI from inside it:
+
+```bash
+git clone https://github.com/TraderAlice/OpenAlice.git
+cd OpenAlice
+openalice
+```
+
+`openalice` finds the checkout, installs the locked workspace dependencies
+without `@traderalice/desktop`, runs `pnpm build:server`, starts
+`scripts/guardian/prod.mjs` on `127.0.0.1`, and opens the normal UI. If `pnpm`
+is absent but Corepack is available, preparation uses Corepack with the pnpm
+version pinned by the repository.
+
+The CLI stays in the foreground and owns the Guardian lifetime. `Ctrl+C` stops
+the local Runtime. A normal second launch reuses an already healthy local URL;
+it does not kill the existing owner. `openalice start --takeover` explicitly
+requests the existing Guardian recovery flow.
+
+Useful controls:
+
+```bash
+openalice start --no-open
+openalice start --rebuild
+openalice start --home /tmp/openalice-test-home --port 41000
+openalice start /path/to/OpenAlice
+```
+
+Use `--rebuild` after pulling source changes when existing build artifacts may
+be stale. Never use a real user-state root for launcher or recovery tests.
+
+## Dependency Bootstrap Direction
+
+Keep bootstrap observable and layered:
+
+1. The shell installer validates Node and makes only the `openalice` command available.
+2. Local start validates the source and built artifacts, using pnpm or Corepack
+   when preparation is required.
+3. A guided setup layer should validate Git and present optional native agent
+   CLIs, installing only
+   the user's selections, with explicit commands, versions, and retry status.
+4. A future release asset can replace the source/build requirement with a
+   downloadable headless Runtime while retaining the same CLI and localhost
+   contract.
+
+Do not silently place every optional agent runtime into Electron or the curl
+installer. The same dependency plan must remain inspectable and independently
+retryable, and Electron's managed-runtime policy continues to belong to
+[[docs/managed-workspace-runtime.md]].
+
+## Security and Network Invariants
+
+- The CLI always sets `OPENALICE_BIND_HOST=127.0.0.1` for local startup.
+- Internal MCP/CLI, UTA, and Connector ports remain local-only.
+- The normal Guardian and Alice runtime locks remain the final single-writer
+  boundary for `OPENALICE_HOME`.
+- `--takeover` is the only CLI path authorized to replace a recorded owner.
+- Do not turn the local CLI into a public listener to make remote access work.
+  Remote access composes an authenticated transport around the same loopback
+  Runtime; see [[docs/remote-access.md]].
+
+## Verification
+
+When this surface changes:
+
+1. Run the CLI unit and installer tests.
+2. Install from `--source` into a temporary install root and execute the
+   installed symlink.
+3. Run `pnpm build:server` and start with an isolated `--home` and test port.
+4. Open the real localhost route and verify the auth contract and Workspace UI.
+5. Run Guardian recovery checks when launcher ownership changes.
+6. Run Docker smoke when `scripts/guardian/prod.mjs` changes.
+7. Run Electron PTY/package smoke when dependency topology or shared Runtime
+   behavior changes, even though the CLI itself does not package Electron.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -5,6 +5,7 @@ and persistent-state layout. Update it when a top-level subsystem moves or a
 new long-lived process, package, or state root is introduced.
 
 Related guides: [[docs/managed-workspace-runtime.md]],
+[[docs/local-runtime.md]],
 [[docs/docker-deployment.md]],
 [[docs/workspace-lifecycle.md]],
 [[docs/workspace-issues-and-scheduling.md]],
@@ -33,7 +34,9 @@ Launchers share the same ownership model:
 - `scripts/guardian/dev.ts` runs UTA, Alice, and Vite for `pnpm dev`.
 - `apps/desktop/src/main.ts` is the packaged Electron Guardian and renderer
   host. It starts Alice/UTA through Electron's Node mode.
-- `scripts/guardian/prod.mjs` supervises the Docker/production process pair.
+- `scripts/guardian/prod.mjs` supervises built Runtime services for Docker and
+  the source-backed local CLI. Docker defaults to the `docker` launcher;
+  `openalice` supplies the distinct `cli` launcher and a loopback bind.
 - `packages/guardian-runtime/` owns cross-launcher single-writer locks,
   heartbeat metadata, process identity, and controlled takeover.
 
@@ -73,7 +76,7 @@ services/uta/                  UTA process
 └── src/domain/trading/        all broker and trading-domain implementation
 
 packages/
-├── cli/                       installable OpenAlice connection/control CLI
+├── cli/                       installable local Runtime/connection CLI
 ├── guardian-runtime/          process ownership and recovery primitives
 ├── uta-protocol/              schemas and wire types shared by Alice + UTA
 ├── ibkr/                      IBKR TWS protocol package, owned by UTA

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -2,9 +2,18 @@
 
 This guide owns OpenAlice's SSH access experiment and the boundary between a
 remote Runtime and local presentation. It complements
-[[docs/docker-deployment.md]] and [[docs/managed-workspace-runtime.md]].
+[[docs/local-runtime.md]], [[docs/docker-deployment.md]], and
+[[docs/managed-workspace-runtime.md]].
 
-## Stage 1: Measure the Existing TUI
+## Local Runtime First
+
+Remote access builds on the local Runtime contract in
+[[docs/local-runtime.md]]. Prove `openalice` can prepare a source checkout,
+start Guardian on `127.0.0.1`, and serve the normal browser UI before adding a
+transport. This keeps the first distribution loop independent of domains,
+cross-domain cookies, hosted Studio state, and SSH lifecycle.
+
+## SSH Experiment: Measure the Existing TUI
 
 The first remote path deliberately keeps the existing product architecture:
 
@@ -21,14 +30,15 @@ run on the SSH host. The browser loads the normal OpenAlice bundle through the
 tunnel, so HTTP, authentication, and the PTY WebSocket remain same-origin. No
 hosted Studio, relay, or second frontend protocol is involved.
 
-This stage exists to measure the real TUI experience before designing around a
+This experiment exists to measure the real TUI experience before designing around a
 latency problem that may not matter on normal developer links. WebPi remains an
 optional structured Pi surface; it is not a prerequisite or replacement for
 Shell, Claude Code, Codex, opencode, or Pi TUI sessions.
 
 ## Prerequisites
 
-1. OpenAlice is already running on the remote machine.
+1. OpenAlice is already running on the remote machine, for example with the
+   source-backed `openalice start --no-open` path.
 2. Its web listener is reachable as `127.0.0.1:47331` from that machine.
 3. The local machine has `ssh` and working key, agent, or interactive SSH auth.
 
@@ -54,7 +64,9 @@ foreground to own the tunnel. Use `--no-open` to print the URL only, or
 
 The forward binds only local `127.0.0.1` and targets only remote `127.0.0.1`.
 Closing the CLI closes the tunnel. The command does not install, update, start,
-or stop the remote Runtime in Stage 1.
+or stop the remote Runtime. A later remote lifecycle command should reuse the
+local bootstrap contract rather than embedding a second installation system in
+the SSH connector.
 
 ## Security Boundary
 
@@ -68,11 +80,11 @@ an OpenAlice tunnel open.
 Keep the remote web listener private or protected by the deployment's normal
 HTTPS/auth boundary. Never use `OPENALICE_DISABLE_AUTH=1` for remote access.
 
-## Deferred Stages
+## Deferred Remote Stages
 
-Stage 1 intentionally leaves these separate:
+The SSH experiment intentionally leaves these separate:
 
-- managed Runtime installation and daemon lifecycle;
+- managed remote Runtime installation and daemon lifecycle;
 - a hosted standalone Studio and pairing/capability protocol;
 - cloud relay or device enrollment;
 - cursor-based structured Session streaming for Pi, Codex, or other agents;

--- a/install
+++ b/install
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY="TraderAlice/OpenAlice"
+VERSION="${OPENALICE_VERSION:-dev}"
+SOURCE_DIR=""
+MODIFY_PATH=1
+INSTALL_ROOT="${OPENALICE_INSTALL_DIR:-${HOME}/.openalice}"
+
+usage() {
+  cat <<'EOF'
+OpenAlice CLI installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
+  ./install [--version <git-ref>] [--install-dir <path>] [--no-modify-path]
+
+Options:
+  --version <git-ref>   Git tag, branch, or commit to install (default: dev)
+  --install-dir <path>  OpenAlice user root (default: ~/.openalice)
+  --source <path>       Install CLI files from a local checkout (development)
+  --no-modify-path      Do not update the shell profile
+  -h, --help            Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { echo "openalice install: --version requires a value" >&2; exit 1; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --install-dir)
+      [[ $# -ge 2 ]] || { echo "openalice install: --install-dir requires a value" >&2; exit 1; }
+      INSTALL_ROOT="$2"
+      shift 2
+      ;;
+    --source)
+      [[ $# -ge 2 ]] || { echo "openalice install: --source requires a value" >&2; exit 1; }
+      SOURCE_DIR="$2"
+      shift 2
+      ;;
+    --no-modify-path)
+      MODIFY_PATH=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "openalice install: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$VERSION" == *".."* || ! "$VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  echo "openalice install: unsupported version/ref: $VERSION" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "openalice install: Node.js 20 or newer is required for the preview CLI." >&2
+  echo "Install Node.js, then run this installer again." >&2
+  exit 1
+fi
+
+NODE_MAJOR="$(node -p 'Number(process.versions.node.split(".")[0])')"
+if [[ "$NODE_MAJOR" -lt 20 ]]; then
+  echo "openalice install: Node.js 20 or newer is required (found $(node --version))." >&2
+  exit 1
+fi
+
+if [[ -z "$SOURCE_DIR" ]] && ! command -v curl >/dev/null 2>&1; then
+  echo "openalice install: curl is required." >&2
+  exit 1
+fi
+
+INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
+BIN_DIR="$INSTALL_ROOT/bin"
+VERSIONS_DIR="$INSTALL_ROOT/cli-versions"
+SAFE_VERSION="${VERSION//\//_}"
+DESTINATION="$VERSIONS_DIR/$SAFE_VERSION"
+STAGING="$(mktemp -d "${TMPDIR:-/tmp}/openalice-cli.XXXXXX")"
+trap 'rm -rf "$STAGING"' EXIT
+
+mkdir -p "$STAGING/bin" "$STAGING/src" "$BIN_DIR" "$VERSIONS_DIR"
+
+FILES=(
+  "package.json"
+  "bin/openalice.mjs"
+  "src/local-start.mjs"
+  "src/runtime-client.mjs"
+  "src/ssh-connect.mjs"
+)
+
+if [[ -n "$SOURCE_DIR" ]]; then
+  SOURCE_DIR="$(cd "$SOURCE_DIR" && pwd)"
+  for file in "${FILES[@]}"; do
+    cp "$SOURCE_DIR/packages/cli/$file" "$STAGING/$file"
+  done
+else
+  BASE_URL="https://raw.githubusercontent.com/$REPOSITORY/$VERSION/packages/cli"
+  for file in "${FILES[@]}"; do
+    curl --fail --silent --show-error --location "$BASE_URL/$file" --output "$STAGING/$file"
+  done
+fi
+
+chmod +x "$STAGING/bin/openalice.mjs"
+node --check "$STAGING/bin/openalice.mjs"
+node --check "$STAGING/src/local-start.mjs"
+node --check "$STAGING/src/runtime-client.mjs"
+node --check "$STAGING/src/ssh-connect.mjs"
+
+rm -rf "$DESTINATION"
+mv "$STAGING" "$DESTINATION"
+trap - EXIT
+
+CLI_ENTRY="$DESTINATION/bin/openalice.mjs"
+printf -v quoted_cli_entry '%q' "$CLI_ENTRY"
+printf '#!/usr/bin/env bash\nexec node %s "$@"\n' "$quoted_cli_entry" > "$BIN_DIR/openalice"
+chmod +x "$BIN_DIR/openalice"
+
+WINDOWS_CLI_ENTRY="$CLI_ENTRY"
+if command -v cygpath >/dev/null 2>&1; then
+  WINDOWS_CLI_ENTRY="$(cygpath -w "$CLI_ENTRY")"
+fi
+WINDOWS_CLI_ENTRY="${WINDOWS_CLI_ENTRY//%/%%}"
+printf '@echo off\r\nnode "%s" %%*\r\n' "$WINDOWS_CLI_ENTRY" > "$BIN_DIR/openalice.cmd"
+
+path_present=0
+case ":$PATH:" in
+  *":$BIN_DIR:"*) path_present=1 ;;
+esac
+
+profile=""
+path_line=""
+if [[ "$MODIFY_PATH" -eq 1 && "$path_present" -eq 0 ]]; then
+  printf -v quoted_bin '%q' "$BIN_DIR"
+  case "${SHELL:-}" in
+    */zsh)
+      profile="$HOME/.zshrc"
+      path_line="export PATH=$quoted_bin:\$PATH"
+      ;;
+    */bash)
+      if [[ "$(uname -s)" == "Darwin" ]]; then profile="$HOME/.bash_profile"; else profile="$HOME/.bashrc"; fi
+      path_line="export PATH=$quoted_bin:\$PATH"
+      ;;
+    */fish)
+      profile="$HOME/.config/fish/config.fish"
+      path_line="fish_add_path $quoted_bin"
+      ;;
+  esac
+  if [[ -n "$profile" ]]; then
+    mkdir -p "$(dirname "$profile")"
+    touch "$profile"
+    if ! grep -Fqx "$path_line" "$profile"; then
+      printf '\n%s\n' "$path_line" >> "$profile"
+    fi
+  fi
+fi
+
+echo "OpenAlice CLI installed: $BIN_DIR/openalice"
+echo "Version: $VERSION"
+if [[ "$path_present" -eq 0 ]]; then
+  echo "For this shell, run:"
+  printf '  export PATH=%q:$PATH\n' "$BIN_DIR"
+  [[ -z "$profile" ]] || echo "Future shells will load it from $profile."
+fi
+echo "Then enter an OpenAlice checkout and run: openalice"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "docker:smoke": "node scripts/docker-runtime-smoke.mjs",
     "prebuild": "tsx scripts/build-migration-index.ts",
     "build": "turbo run build && tsup src/main.ts --format esm --dts",
+    "prebuild:server": "tsx scripts/build-migration-index.ts",
+    "build:server": "turbo run build --filter=!@traderalice/desktop && tsup src/main.ts --format esm --dts",
     "build:migration-index": "tsx scripts/build-migration-index.ts",
     "start": "node dist/main.js",
     "electron:tsc": "pnpm -F @traderalice/desktop build",

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs'
-import { pathToFileURL } from 'node:url'
+import { readFileSync, realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
+import { formatLocalStartHelp, parseLocalStartArgs, startLocal } from '../src/local-start.mjs'
 import { connectSsh, formatSshHelp, parseSshConnectArgs } from '../src/ssh-connect.mjs'
 
 export async function main(argv = process.argv.slice(2)) {
   const [command, ...args] = argv
-  if (!command || command === '--help' || command === '-h' || command === 'help') {
+  if (command === '--help' || command === '-h' || command === 'help') {
     process.stdout.write(formatHelp())
     return 0
   }
@@ -15,26 +16,37 @@ export async function main(argv = process.argv.slice(2)) {
     process.stdout.write(`${readVersion()}\n`)
     return 0
   }
-  if (command !== 'ssh') {
-    throw new Error(`Unknown command: ${command}\n\n${formatHelp()}`)
+  if (!command || command === 'start' || command.startsWith('-')) {
+    const startArgs = command === 'start' ? args : argv
+    if (startArgs.includes('--help') || startArgs.includes('-h')) {
+      process.stdout.write(formatLocalStartHelp())
+      return 0
+    }
+    return startLocal(parseLocalStartArgs(startArgs))
   }
-  if (args.includes('--help') || args.includes('-h')) {
-    process.stdout.write(formatSshHelp())
-    return 0
+  if (command === 'ssh') {
+    if (args.includes('--help') || args.includes('-h')) {
+      process.stdout.write(formatSshHelp())
+      return 0
+    }
+    return connectSsh(parseSshConnectArgs(args))
   }
-  return connectSsh(parseSshConnectArgs(args))
+  throw new Error(`Unknown command: ${command}\n\n${formatHelp()}`)
 }
 
 function formatHelp() {
   return `OpenAlice CLI
 
 Usage:
+  openalice
+  openalice start [path] [options]
   openalice ssh <user@host> [options]
 
 Commands:
+  start     Start OpenAlice from a source checkout on local loopback (default)
   ssh       Open a loopback-only SSH tunnel to an already-running OpenAlice
 
-Run "openalice ssh --help" for connection options.
+Run "openalice start --help" or "openalice ssh --help" for details.
 `
 }
 
@@ -43,7 +55,7 @@ function readVersion() {
   return JSON.parse(readFileSync(packageUrl, 'utf8')).version
 }
 
-if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+if (process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main().then(
     (code) => { process.exitCode = code },
     (error) => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,17 +1,19 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.1.0",
-  "description": "OpenAlice runtime connection CLI",
+  "version": "0.2.0",
+  "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {
     "openalice": "./bin/openalice.mjs"
   },
   "files": [
     "bin/openalice.mjs",
+    "src/local-start.mjs",
+    "src/runtime-client.mjs",
     "src/ssh-connect.mjs"
   ],
   "scripts": {
-    "build": "node --check bin/openalice.mjs && node --check src/ssh-connect.mjs",
+    "build": "node --check bin/openalice.mjs && node --check src/local-start.mjs && node --check src/runtime-client.mjs && node --check src/ssh-connect.mjs",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },
   "engines": {

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -1,0 +1,38 @@
+import { execFile } from 'node:child_process'
+import { access, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..')
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
+  it('installs a runnable, versioned CLI without touching the shell profile', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-test-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const installer = join(repositoryRoot, 'install')
+    const installed = await execFileAsync('bash', [installer,
+      '--source', repositoryRoot,
+      '--version', 'test/ref',
+      '--install-dir', installRoot,
+      '--no-modify-path',
+    ], { env: { ...process.env, HOME: home } })
+
+    expect(installed.stdout).toContain('OpenAlice CLI installed')
+    await expect(access(join(installRoot, 'cli-versions', 'test_ref', 'bin', 'openalice.mjs'))).resolves.toBeUndefined()
+    await expect(access(join(installRoot, 'bin', 'openalice.cmd'))).resolves.toBeUndefined()
+
+    const result = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['--version'])
+    expect(result.stdout.trim()).toBe('0.2.0')
+  })
+})

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -1,0 +1,315 @@
+import { spawn } from 'node:child_process'
+import { access, readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import {
+  LOOPBACK,
+  openBrowser,
+  probeOpenAlice,
+  waitForOpenAlice,
+} from './runtime-client.mjs'
+
+const RUNTIME_ARTIFACTS = [
+  'dist/main.js',
+  'ui/dist/index.html',
+  'services/uta/dist/uta.js',
+  'services/connector/dist/connector.cjs',
+  'packages/guardian-runtime/dist/index.js',
+  'node_modules',
+]
+
+export function parseLocalStartArgs(argv) {
+  const options = {
+    appDir: null,
+    homeRoot: null,
+    port: 47331,
+    openBrowser: true,
+    prepare: true,
+    rebuild: false,
+    takeover: false,
+    waitMs: 120_000,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') continue
+    if (arg === '--no-open') {
+      options.openBrowser = false
+      continue
+    }
+    if (arg === '--skip-prepare') {
+      options.prepare = false
+      continue
+    }
+    if (arg === '--rebuild') {
+      options.rebuild = true
+      continue
+    }
+    if (arg === '--takeover') {
+      options.takeover = true
+      continue
+    }
+    if (arg === '--app-dir') {
+      options.appDir = requireValue(argv, ++index, arg)
+      continue
+    }
+    if (arg === '--home') {
+      options.homeRoot = requireValue(argv, ++index, arg)
+      continue
+    }
+    if (arg === '--port') {
+      options.port = parsePort(requireValue(argv, ++index, arg), arg)
+      continue
+    }
+    if (arg === '--wait') {
+      const seconds = Number(requireValue(argv, ++index, arg))
+      if (!Number.isFinite(seconds) || seconds < 1 || seconds > 600) {
+        throw new Error('--wait must be a number of seconds between 1 and 600')
+      }
+      options.waitMs = Math.round(seconds * 1_000)
+      continue
+    }
+    if (arg?.startsWith('-')) throw new Error(`Unknown option: ${arg}`)
+    if (options.appDir) throw new Error(`Unexpected argument: ${arg}`)
+    options.appDir = arg ?? null
+  }
+
+  return options
+}
+
+export async function startLocal(options, dependencies = {}) {
+  const stdout = dependencies.stdout ?? process.stdout
+  const env = dependencies.env ?? process.env
+  const localUrl = `http://${LOOPBACK}:${options.port}`
+  const probeRuntime = dependencies.probeRuntime ?? probeOpenAlice
+  const launchBrowser = dependencies.launchBrowser ?? openBrowser
+
+  if (await probeRuntime(localUrl)) {
+    stdout.write(`OpenAlice is already running at ${localUrl}\n`)
+    if (options.openBrowser) await launchBrowser(localUrl)
+    return 0
+  }
+
+  const resolveRoot = dependencies.resolveRoot ?? findOpenAliceRoot
+  const appDir = await resolveRoot(options.appDir ?? dependencies.cwd ?? process.cwd())
+  const prepareSource = dependencies.prepareSource ?? prepareSourceCheckout
+  await prepareSource(appDir, options, { stdout, env })
+
+  const spawnProcess = dependencies.spawnProcess ?? spawn
+  const waitForRuntime = dependencies.waitForRuntime ?? waitForOpenAlice
+  const homeDir = dependencies.homeDir ?? homedir()
+  const nodeBinary = dependencies.nodeBinary ?? process.execPath
+  const homeRoot = resolve(options.homeRoot ?? env['OPENALICE_HOME'] ?? join(homeDir, '.openalice'))
+  const runtimeEnv = buildLocalRuntimeEnv(env, {
+    appDir,
+    homeRoot,
+    nodeBinary,
+    port: options.port,
+    takeover: options.takeover,
+  })
+  const runtime = spawnProcess(nodeBinary, ['scripts/guardian/prod.mjs'], {
+    cwd: appDir,
+    env: runtimeEnv,
+    stdio: 'inherit',
+    windowsHide: true,
+  })
+
+  let ready = false
+  const earlyFailure = new Promise((_, reject) => {
+    runtime.once('error', reject)
+    runtime.once('exit', (code, signal) => {
+      if (!ready) {
+        reject(new Error(`Local OpenAlice exited before it was ready (code=${String(code)}, signal=${String(signal)})`))
+      }
+    })
+  })
+
+  try {
+    await Promise.race([
+      waitForRuntime(localUrl, { timeoutMs: options.waitMs }),
+      earlyFailure,
+    ])
+    ready = true
+    stdout.write(`OpenAlice source: ${appDir}\n`)
+    stdout.write(`OpenAlice home: ${homeRoot}\n`)
+    stdout.write(`Local OpenAlice UI: ${localUrl}\n`)
+    stdout.write('The local Runtime stays active until this command exits. Press Ctrl+C to stop it.\n')
+    if (options.openBrowser) await launchBrowser(localUrl)
+    return await holdRuntime(runtime)
+  } catch (error) {
+    runtime.kill('SIGTERM')
+    throw error
+  }
+}
+
+export function buildLocalRuntimeEnv(env, options) {
+  const runtimeEnv = {
+    ...env,
+    OPENALICE_HOME: options.homeRoot,
+    OPENALICE_APP_HOME: options.appDir,
+    OPENALICE_BIND_HOST: LOOPBACK,
+    OPENALICE_WEB_PORT: String(options.port),
+    OPENALICE_WEB_TRANSPORT: 'http',
+    OPENALICE_LAUNCHER: 'cli',
+    OPENALICE_NODE_BINARY: options.nodeBinary,
+  }
+  delete runtimeEnv.OPENALICE_DISABLE_AUTH
+  delete runtimeEnv.OPENALICE_TAKEOVER
+  if (options.takeover) runtimeEnv.OPENALICE_TAKEOVER = '1'
+  return runtimeEnv
+}
+
+export async function findOpenAliceRoot(startPath, options = {}) {
+  const readFileImpl = options.readFileImpl ?? readFile
+  let current = resolve(startPath)
+
+  while (true) {
+    try {
+      const manifest = JSON.parse(await readFileImpl(join(current, 'package.json'), 'utf8'))
+      if (manifest?.name === 'open-alice' && manifest?.scripts?.['build:server']) return current
+    } catch {
+      // Keep walking. A non-repository directory commonly has no package.json.
+    }
+    const parent = dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+
+  throw new Error(`Could not find an OpenAlice source checkout from ${resolve(startPath)}. Run this command inside the checkout or pass --app-dir <path>.`)
+}
+
+export async function prepareSourceCheckout(appDir, options, dependencies = {}) {
+  const stdout = dependencies.stdout ?? process.stdout
+  const env = dependencies.env ?? process.env
+  const artifactsReady = dependencies.artifactsReady ?? hasRuntimeArtifacts
+  if (!options.rebuild && await artifactsReady(appDir)) return { prepared: false }
+  if (!options.prepare) {
+    throw new Error('OpenAlice server artifacts are missing. Re-run without --skip-prepare, or run pnpm build:server in the checkout.')
+  }
+
+  const configuredPnpm = dependencies.pnpmBin ?? env['OPENALICE_PNPM_BIN']
+  const platform = dependencies.platform ?? process.platform
+  const pnpmBin = configuredPnpm ?? (platform === 'win32' ? 'pnpm.cmd' : 'pnpm')
+  const runCommand = dependencies.runCommand ?? runChecked
+
+  stdout.write('Preparing the local OpenAlice Runtime (Electron is excluded)...\n')
+  const installArgs = [
+    'install',
+    '--frozen-lockfile',
+    '--filter=!@traderalice/desktop',
+  ]
+  const buildArgs = ['build:server']
+  try {
+    await runCommand(pnpmBin, installArgs, { cwd: appDir, env, platform })
+    await runCommand(pnpmBin, buildArgs, { cwd: appDir, env, platform })
+  } catch (error) {
+    if (configuredPnpm || error?.code !== 'ENOENT') throw error
+    const corepackBin = platform === 'win32' ? 'corepack.cmd' : 'corepack'
+    stdout.write('pnpm is not on PATH; using Corepack with the repository-pinned pnpm version.\n')
+    try {
+      await runCommand(corepackBin, ['pnpm', ...installArgs], { cwd: appDir, env, platform })
+      await runCommand(corepackBin, ['pnpm', ...buildArgs], { cwd: appDir, env, platform })
+    } catch (corepackError) {
+      if (corepackError?.code === 'ENOENT') {
+        throw new Error('Could not find pnpm or Corepack. Install pnpm 11, then retry.')
+      }
+      throw corepackError
+    }
+  }
+
+  if (!await artifactsReady(appDir)) {
+    throw new Error('OpenAlice server preparation completed without the expected runtime artifacts')
+  }
+  return { prepared: true }
+}
+
+export async function hasRuntimeArtifacts(appDir, options = {}) {
+  const accessImpl = options.accessImpl ?? access
+  try {
+    await Promise.all(RUNTIME_ARTIFACTS.map((path) => accessImpl(join(appDir, path))))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function formatLocalStartHelp() {
+  return `Usage:
+  openalice [options]
+  openalice start [path] [options]
+
+Prepares an OpenAlice source checkout without Electron, starts the built-runtime
+Guardian on local loopback, and opens the normal OpenAlice browser UI.
+
+Options:
+  --app-dir <path>   OpenAlice checkout (default: current directory or parent)
+  --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
+  --port <port>      Local web port (default: 47331)
+  --rebuild          Reinstall dependencies and rebuild server artifacts
+  --skip-prepare     Fail instead of installing/building missing artifacts
+  --takeover         Replace the recorded local Guardian owner tree
+  --wait <seconds>   Readiness timeout, 1-600 (default: 120)
+  --no-open          Print the URL without opening a browser
+  -h, --help         Show this help
+`
+}
+
+function holdRuntime(runtime) {
+  if (runtime.exitCode !== undefined && (runtime.exitCode !== null || runtime.signalCode !== null)) {
+    return Promise.resolve(runtime.exitCode ?? 0)
+  }
+  return new Promise((resolvePromise) => {
+    let requestedStop = false
+    const stop = () => {
+      requestedStop = true
+      runtime.kill('SIGTERM')
+    }
+    process.once('SIGINT', stop)
+    process.once('SIGTERM', stop)
+    runtime.once('exit', (code) => {
+      process.off('SIGINT', stop)
+      process.off('SIGTERM', stop)
+      resolvePromise(requestedStop ? 0 : code ?? 0)
+    })
+  })
+}
+
+function runChecked(command, args, options) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      shell: options.platform === 'win32',
+      stdio: 'inherit',
+      windowsHide: true,
+    })
+    child.once('error', (error) => {
+      if (error?.code === 'ENOENT') {
+        const missing = new Error(`Could not find ${command}`)
+        missing.code = 'ENOENT'
+        rejectPromise(missing)
+      } else {
+        rejectPromise(error)
+      }
+    })
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolvePromise()
+      else rejectPromise(new Error(`${command} ${args.join(' ')} failed (code=${String(code)}, signal=${String(signal)})`))
+    })
+  })
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index]
+  if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function parsePort(raw, flag) {
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new Error(`${flag} must be an integer between 1 and 65535`)
+  }
+  return value
+}

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -1,0 +1,183 @@
+import { EventEmitter } from 'node:events'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildLocalRuntimeEnv,
+  findOpenAliceRoot,
+  parseLocalStartArgs,
+  prepareSourceCheckout,
+  startLocal,
+} from './local-start.mjs'
+
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('OpenAlice local Runtime launcher', () => {
+  it('parses the source path and explicit local-runtime controls', () => {
+    expect(parseLocalStartArgs([
+      '/tmp/OpenAlice',
+      '--home', '/tmp/alice-home',
+      '--port', '41000',
+      '--wait', '15',
+      '--rebuild',
+      '--takeover',
+      '--no-open',
+    ])).toEqual({
+      appDir: '/tmp/OpenAlice',
+      homeRoot: '/tmp/alice-home',
+      port: 41000,
+      openBrowser: false,
+      prepare: true,
+      rebuild: true,
+      takeover: true,
+      waitMs: 15_000,
+    })
+  })
+
+  it('finds the repository from a nested working directory', async () => {
+    const root = await makeTempDir()
+    const nested = join(root, 'packages', 'example')
+    await mkdir(nested, { recursive: true })
+    await writeFile(join(root, 'package.json'), JSON.stringify({
+      name: 'open-alice',
+      scripts: { 'build:server': 'example' },
+    }))
+
+    await expect(findOpenAliceRoot(nested)).resolves.toBe(root)
+  })
+
+  it('reuses an already-running local Runtime without spawning a second owner', async () => {
+    const resolveRoot = vi.fn()
+    const launchBrowser = vi.fn(async () => undefined)
+    const stdout = { write: vi.fn() }
+
+    await expect(startLocal(parseLocalStartArgs([]), {
+      probeRuntime: async () => true,
+      resolveRoot,
+      launchBrowser,
+      stdout,
+    })).resolves.toBe(0)
+
+    expect(resolveRoot).not.toHaveBeenCalled()
+    expect(launchBrowser).toHaveBeenCalledWith('http://127.0.0.1:47331')
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('already running'))
+  })
+
+  it('does not inherit auth bypass or takeover into an ordinary local launch', () => {
+    const runtimeEnv = buildLocalRuntimeEnv({
+      OPENALICE_DISABLE_AUTH: '1',
+      OPENALICE_TAKEOVER: '1',
+      PATH: '/bin',
+    }, {
+      appDir: '/tmp/OpenAlice',
+      homeRoot: '/tmp/alice-home',
+      nodeBinary: '/test/node',
+      port: 41000,
+      takeover: false,
+    })
+
+    expect(runtimeEnv).toEqual(expect.objectContaining({
+      PATH: '/bin',
+      OPENALICE_BIND_HOST: '127.0.0.1',
+      OPENALICE_LAUNCHER: 'cli',
+    }))
+    expect(runtimeEnv).not.toHaveProperty('OPENALICE_DISABLE_AUTH')
+    expect(runtimeEnv).not.toHaveProperty('OPENALICE_TAKEOVER')
+  })
+
+  it('starts the built Guardian on loopback and preserves explicit takeover', async () => {
+    const child = new FakeChild()
+    const spawnProcess = vi.fn(() => child)
+    const launchBrowser = vi.fn(async () => {
+      setTimeout(() => child.finish(0), 0)
+    })
+    const prepareSource = vi.fn(async () => ({ prepared: false }))
+    const options = parseLocalStartArgs([
+      '--app-dir', '/tmp/OpenAlice',
+      '--home', '/tmp/alice-home',
+      '--port', '41000',
+      '--takeover',
+    ])
+
+    await expect(startLocal(options, {
+      env: { PATH: '/bin' },
+      nodeBinary: '/test/node',
+      probeRuntime: async () => false,
+      resolveRoot: async (path) => path,
+      prepareSource,
+      spawnProcess,
+      waitForRuntime: async () => ({ authed: true, tokenConfigured: false }),
+      launchBrowser,
+      stdout: { write: vi.fn() },
+    })).resolves.toBe(0)
+
+    expect(prepareSource).toHaveBeenCalledWith('/tmp/OpenAlice', options, expect.objectContaining({
+      env: { PATH: '/bin' },
+    }))
+    expect(spawnProcess).toHaveBeenCalledWith('/test/node', ['scripts/guardian/prod.mjs'], expect.objectContaining({
+      cwd: '/tmp/OpenAlice',
+      env: expect.objectContaining({
+        OPENALICE_HOME: '/tmp/alice-home',
+        OPENALICE_APP_HOME: '/tmp/OpenAlice',
+        OPENALICE_BIND_HOST: '127.0.0.1',
+        OPENALICE_WEB_PORT: '41000',
+        OPENALICE_LAUNCHER: 'cli',
+        OPENALICE_TAKEOVER: '1',
+      }),
+    }))
+    expect(launchBrowser).toHaveBeenCalledWith('http://127.0.0.1:41000')
+  })
+
+  it('uses Corepack when pnpm is not installed', async () => {
+    const commands = []
+    let artifactsReady = false
+    const missing = new Error('missing')
+    missing.code = 'ENOENT'
+    const runCommand = vi.fn(async (command, args) => {
+      commands.push([command, args])
+      if (command === 'pnpm') throw missing
+      if (args.at(-1) === 'build:server') artifactsReady = true
+    })
+
+    await expect(prepareSourceCheckout('/tmp/OpenAlice', {
+      prepare: true,
+      rebuild: false,
+    }, {
+      artifactsReady: async () => artifactsReady,
+      platform: 'linux',
+      runCommand,
+      stdout: { write: vi.fn() },
+      env: {},
+    })).resolves.toEqual({ prepared: true })
+
+    expect(commands).toEqual([
+      ['pnpm', ['install', '--frozen-lockfile', '--filter=!@traderalice/desktop']],
+      ['corepack', ['pnpm', 'install', '--frozen-lockfile', '--filter=!@traderalice/desktop']],
+      ['corepack', ['pnpm', 'build:server']],
+    ])
+  })
+})
+
+async function makeTempDir() {
+  const path = await mkdtemp(join(tmpdir(), 'openalice-cli-test-'))
+  temporaryPaths.push(path)
+  return path
+}
+
+class FakeChild extends EventEmitter {
+  exitCode = null
+  signalCode = null
+  kill = vi.fn()
+
+  finish(code) {
+    this.exitCode = code
+    this.emit('exit', code, null)
+  }
+}

--- a/packages/cli/src/runtime-client.mjs
+++ b/packages/cli/src/runtime-client.mjs
@@ -1,0 +1,68 @@
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+
+export const LOOPBACK = '127.0.0.1'
+
+export async function allocateLoopbackPort() {
+  const server = createServer()
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen({ host: LOOPBACK, port: 0, exclusive: true }, resolve)
+  })
+  const address = server.address()
+  const port = address && typeof address === 'object' ? address.port : 0
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  if (!port) throw new Error('Could not reserve a local loopback port')
+  return port
+}
+
+export async function probeOpenAlice(baseUrl, options = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch
+  try {
+    const response = await fetchImpl(`${baseUrl}/api/auth/status`, {
+      signal: AbortSignal.timeout(options.timeoutMs ?? 750),
+    })
+    if (!response.ok) return false
+    const body = await response.json()
+    return typeof body?.authed === 'boolean' && typeof body?.tokenConfigured === 'boolean'
+  } catch {
+    return false
+  }
+}
+
+export async function waitForOpenAlice(baseUrl, options = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const timeoutMs = options.timeoutMs ?? 60_000
+  const pollMs = options.pollMs ?? 250
+  const deadline = Date.now() + timeoutMs
+  let lastError = 'connection refused'
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchImpl(`${baseUrl}/api/auth/status`, {
+        signal: AbortSignal.timeout(Math.min(2_000, Math.max(250, deadline - Date.now()))),
+      })
+      if (response.ok) {
+        const body = await response.json()
+        if (typeof body?.authed === 'boolean' && typeof body?.tokenConfigured === 'boolean') return body
+        lastError = 'unexpected response from /api/auth/status'
+      } else {
+        lastError = `HTTP ${response.status}`
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs))
+  }
+  throw new Error(`OpenAlice did not become ready at ${baseUrl} within ${Math.ceil(timeoutMs / 1_000)}s (${lastError})`)
+}
+
+export async function openBrowser(url, options = {}) {
+  const platform = options.platform ?? process.platform
+  const spawnProcess = options.spawnProcess ?? spawn
+  const command = platform === 'darwin' ? 'open' : platform === 'win32' ? 'cmd.exe' : 'xdg-open'
+  const args = platform === 'win32' ? ['/d', '/s', '/c', 'start', '', url] : [url]
+  const child = spawnProcess(command, args, { detached: true, stdio: 'ignore', windowsHide: true })
+  child.once?.('error', () => undefined)
+  child.unref()
+}

--- a/packages/cli/src/ssh-connect.mjs
+++ b/packages/cli/src/ssh-connect.mjs
@@ -1,7 +1,12 @@
 import { spawn } from 'node:child_process'
-import { createServer } from 'node:net'
+import {
+  LOOPBACK,
+  allocateLoopbackPort,
+  openBrowser,
+  waitForOpenAlice,
+} from './runtime-client.mjs'
 
-const LOOPBACK = '127.0.0.1'
+export { allocateLoopbackPort, openBrowser, waitForOpenAlice } from './runtime-client.mjs'
 
 export function parseSshConnectArgs(argv) {
   const options = {
@@ -110,56 +115,6 @@ export async function connectSsh(options, dependencies = {}) {
     ssh.kill('SIGTERM')
     throw error
   }
-}
-
-export async function allocateLoopbackPort() {
-  const server = createServer()
-  await new Promise((resolve, reject) => {
-    server.once('error', reject)
-    server.listen({ host: LOOPBACK, port: 0, exclusive: true }, resolve)
-  })
-  const address = server.address()
-  const port = address && typeof address === 'object' ? address.port : 0
-  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
-  if (!port) throw new Error('Could not reserve a local loopback port')
-  return port
-}
-
-export async function waitForOpenAlice(baseUrl, options = {}) {
-  const fetchImpl = options.fetchImpl ?? fetch
-  const timeoutMs = options.timeoutMs ?? 60_000
-  const pollMs = options.pollMs ?? 250
-  const deadline = Date.now() + timeoutMs
-  let lastError = 'connection refused'
-
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetchImpl(`${baseUrl}/api/auth/status`, {
-        signal: AbortSignal.timeout(Math.min(2_000, Math.max(250, deadline - Date.now()))),
-      })
-      if (response.ok) {
-        const body = await response.json()
-        if (typeof body?.authed === 'boolean' && typeof body?.tokenConfigured === 'boolean') return body
-        lastError = 'unexpected response from /api/auth/status'
-      } else {
-        lastError = `HTTP ${response.status}`
-      }
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error)
-    }
-    await new Promise((resolve) => setTimeout(resolve, pollMs))
-  }
-  throw new Error(`OpenAlice did not become ready at ${baseUrl} within ${Math.ceil(timeoutMs / 1_000)}s (${lastError}). Start OpenAlice on the remote host first.`)
-}
-
-export async function openBrowser(url, options = {}) {
-  const platform = options.platform ?? process.platform
-  const spawnProcess = options.spawnProcess ?? spawn
-  const command = platform === 'darwin' ? 'open' : platform === 'win32' ? 'cmd.exe' : 'xdg-open'
-  const args = platform === 'win32' ? ['/d', '/s', '/c', 'start', '', url] : [url]
-  const child = spawnProcess(command, args, { detached: true, stdio: 'ignore', windowsHide: true })
-  child.once?.('error', () => undefined)
-  child.unref()
 }
 
 export function formatSshHelp() {

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 /**
- * Guardian — production entry, used as the Docker container CMD.
+ * Guardian — built-runtime entry, used by Docker and the local CLI.
  *
  * tini runs as PID 1 (signal forwarding + zombie reaping); this script is
- * the orchestrator tini supervises. It spawns the two long-lived Node
- * processes that make up a self-hosted OpenAlice deployment:
+ * the orchestrator tini supervises. It spawns the long-lived Node services
+ * that make up a built OpenAlice Runtime:
  *
  *   1. UTA service  (services/uta/dist/uta.js, bind 127.0.0.1:47333)
  *   2. Connector Service (optional, bind 127.0.0.1:47334)
- *   3. Alice main   (dist/main.js,             bind 0.0.0.0:47331)
+ *   3. Alice main   (dist/main.js, bind OPENALICE_BIND_HOST:47331)
  *
  * Lifecycle:
  *   - spawn UTA, poll /__uta/health for observability (Alice still boots if
@@ -41,6 +41,10 @@ const DATA_HOME = process.env.OPENALICE_HOME
   ?? process.env.OPENALICE_USER_DATA_HOME // deprecated alias, one-release courtesy
   ?? '/data'
 const LAUNCHER_ROOT = process.env.AQ_LAUNCHER_ROOT ?? resolve(DATA_HOME, 'workspaces')
+const LAUNCHER = process.env.OPENALICE_LAUNCHER?.trim() || 'docker'
+const GUARDIAN_LAUNCHER = LAUNCHER.startsWith('guardian-') ? LAUNCHER : `guardian-${LAUNCHER}`
+const NODE_BINARY = process.env.OPENALICE_NODE_BINARY?.trim() || process.execPath
+const BIND_HOST = process.env.OPENALICE_BIND_HOST?.trim() || '127.0.0.1'
 const GUARDIAN_STARTED_AT = currentProcessStartedAt()
 const TAKEOVER = takeoverRequested()
 if (!process.env.OPENALICE_HOME && process.env.OPENALICE_USER_DATA_HOME) {
@@ -179,7 +183,7 @@ console.log(`[guardian/prod] mode  → ${TRADING_MODE.mode} (${TRADING_MODE.sour
 console.log(`[guardian/prod] data  → ${DATA_HOME}`)
 console.log(`[guardian/prod] UTA   → ${LITE_MODE ? 'disabled (trading mode lite)' : UTA_URL}`)
 console.log(`[guardian/prod] Connector → ${CONNECTOR_URL} (optional)`)
-console.log(`[guardian/prod] Alice → http://0.0.0.0:${WEB_PORT}`)
+console.log(`[guardian/prod] Alice → http://${BIND_HOST}:${WEB_PORT}`)
 console.log(`[guardian/prod] Tools → http://127.0.0.1:${MCP_PORT}/cli`)
 console.log(`[guardian/prod] MCP   → optional on http://127.0.0.1:${MCP_PORT}/mcp`)
 console.log(`[guardian/prod] flags → ${FLAG_PATH}, ${CONNECTOR_FLAG_PATH}`)
@@ -195,14 +199,14 @@ async function readConnectorEnabled() {
 
 function makeUTASpec() {
   return {
-    cmd: 'node',
+    cmd: NODE_BINARY,
     args: ['services/uta/dist/uta.js'],
     env: {
       ...process.env,
       OPENALICE_UTA_PORT: String(UTA_PORT),
       OPENALICE_HOME: DATA_HOME,
       AQ_LAUNCHER_ROOT: LAUNCHER_ROOT,
-      OPENALICE_LAUNCHER: 'docker',
+      OPENALICE_LAUNCHER: LAUNCHER,
       OPENALICE_GUARDIAN_PID: String(process.pid),
       OPENALICE_GUARDIAN_STARTED_AT: String(GUARDIAN_STARTED_AT),
       ...(TAKEOVER ? { OPENALICE_TAKEOVER: '1' } : {}),
@@ -221,13 +225,13 @@ function spawnUTA() {
 }
 
 function spawnConnector() {
-  const child = spawn('node', ['services/connector/dist/connector.cjs'], {
+  const child = spawn(NODE_BINARY, ['services/connector/dist/connector.cjs'], {
     env: {
       ...process.env,
       OPENALICE_CONNECTOR_PORT: String(CONNECTOR_PORT),
       OPENALICE_HOME: DATA_HOME,
       AQ_LAUNCHER_ROOT: LAUNCHER_ROOT,
-      OPENALICE_LAUNCHER: 'docker',
+      OPENALICE_LAUNCHER: LAUNCHER,
       OPENALICE_GUARDIAN_PID: String(process.pid),
       OPENALICE_GUARDIAN_STARTED_AT: String(GUARDIAN_STARTED_AT),
       ...(TAKEOVER ? { OPENALICE_TAKEOVER: '1' } : {}),
@@ -242,7 +246,7 @@ function spawnConnector() {
 }
 
 function spawnAlice() {
-  const child = spawn('node', ['dist/main.js'], {
+  const child = spawn(NODE_BINARY, ['dist/main.js'], {
     env: {
       ...process.env,
       OPENALICE_WEB_PORT: String(WEB_PORT),
@@ -252,7 +256,7 @@ function spawnAlice() {
       OPENALICE_CONNECTOR_URL: CONNECTOR_URL,
       OPENALICE_HOME: DATA_HOME,
       AQ_LAUNCHER_ROOT: LAUNCHER_ROOT,
-      OPENALICE_LAUNCHER: 'docker',
+      OPENALICE_LAUNCHER: LAUNCHER,
       OPENALICE_GUARDIAN_PID: String(process.pid),
       OPENALICE_GUARDIAN_STARTED_AT: String(GUARDIAN_STARTED_AT),
       ...(TAKEOVER ? { OPENALICE_TAKEOVER: '1' } : {}),
@@ -435,7 +439,7 @@ async function main() {
   guardianRuntimeLock = await acquireGuardianRuntime({
     userDataHome: DATA_HOME,
     launcherRoot: LAUNCHER_ROOT,
-    launcher: 'guardian-docker',
+    launcher: GUARDIAN_LAUNCHER,
     takeover: TAKEOVER,
     processStartedAt: GUARDIAN_STARTED_AT,
     onOwnershipLost: (err) => {

--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -4,7 +4,7 @@
  * Guardian is OpenAlice's L2 authority (see memory:port-architecture-3-layers).
  * Three carriers, one set of L2 responsibilities:
  *   - dev:    `scripts/guardian/dev.ts`, spawned by `pnpm dev`
- *   - prod:   `scripts/guardian/prod.mjs`, container CMD (Step 7)
+ *   - built:  `scripts/guardian/prod.mjs`, Docker CMD or local CLI child
  *   - desktop: Electron `main` process (future)
  *
  * Responsibilities (this module):


### PR DESCRIPTION
## What changed

- add a curl-installable, versioned `openalice` CLI bootstrap with POSIX and Windows command wrappers
- make `openalice` default to a source-backed, loopback-only local Runtime that prepares server artifacts without Electron, starts Guardian, and opens the normal browser UI
- generalize the built-runtime Guardian for `cli` and `docker` launcher identities while preserving the existing single-writer/takeover boundary
- keep the SSH connector as a later transport over the same localhost contract
- document the local-first distribution boundary and future guided dependency setup

## Why

This establishes the smallest useful distribution loop before adding remote lifecycle or a hosted Studio: users can keep a normal OpenAlice checkout, install only a small global command, and reach the full product at `localhost` without public-domain or cross-domain cookie work. Electron remains a complete, independent `app://` + IPC distribution.

## Validation

- `npx tsc --noEmit`
- `pnpm test` (2,778 passed, 6 skipped)
- `pnpm build:server`
- CLI installer/unit tests (14 passed)
- installed-CLI real localhost boot with isolated `OPENALICE_HOME`; `/chat` rendered with no browser console errors
- loopback auth accepted; foreign browser Origin stayed unauthenticated
- Guardian recovery full check, including duplicate, takeover, crash, stubborn owner, dev boot, and orphan cleanup
- `pnpm docker:smoke`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:build`
- `pnpm electron:smoke:pty --skip-build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`