### PR TITLE
test(cli): add local installer Docker smoke

### DIFF
--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -236,6 +236,8 @@ Before merging a promotion:
 
 - run the normal build/test gates against the full promotion delta;
 - add entry-path, trading, runtime, or package smokes required by included work;
+- run `pnpm test:install:docker` locally when the release publishes the CLI
+  bootstrap installer; this manual gate is intentionally not a PR CI job;
 - confirm release metadata/version intent;
 - confirm CI and release workflow triggers still match the branch policy.
 
@@ -323,6 +325,7 @@ to `master` or release, every applicable gate must be complete and green.
 | Persisted data | Idempotent migration + spec + regenerated migration index + backup behavior |
 | Desktop, Guardian, PTY, IPC, managed runtimes | Matching dev/Electron/package smoke on affected platforms |
 | UI/API contracts | Strict UI types, real browser route, and matching demo handler |
+| CLI bootstrap installer | Local `pnpm test:install:docker` against the real download path before release |
 | Public contributor/release workflow | Cross-check `AGENTS.md`, `CONTRIBUTING.md`, and GitHub Actions triggers |
 
 If a required gate cannot run, document the exact residual risk in the PR and

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -57,6 +57,10 @@ For local installer development:
 ./install --source . --version dev --no-modify-path
 ```
 
+`OPENALICE_INSTALL_BASE_URL` may point the download branch at a local fixture
+server. It exists for installer development and the release smoke; normal user
+installs should leave it unset.
+
 Until release assets include a standalone headless Runtime, users keep an
 OpenAlice source checkout and run the CLI from inside it:
 
@@ -124,11 +128,16 @@ retryable, and Electron's managed-runtime policy continues to belong to
 When this surface changes:
 
 1. Run the CLI unit and installer tests.
-2. Install from `--source` into a temporary install root and execute the
+2. Run `pnpm test:install:docker` locally. It executes the real `curl | bash`
+   download path as a non-root user with an empty home and no global pnpm,
+   then verifies repeat installation, version switching, shell PATH changes,
+   and both launchers while the run container has no external network. This is
+   a manual pre-release gate and intentionally does not run in PR CI.
+3. Install from `--source` into a temporary install root and execute the
    installed symlink.
-3. Run `pnpm build:server` and start with an isolated `--home` and test port.
-4. Open the real localhost route and verify the auth contract and Workspace UI.
-5. Run Guardian recovery checks when launcher ownership changes.
-6. Run Docker smoke when `scripts/guardian/prod.mjs` changes.
-7. Run Electron PTY/package smoke when dependency topology or shared Runtime
+4. Run `pnpm build:server` and start with an isolated `--home` and test port.
+5. Open the real localhost route and verify the auth contract and Workspace UI.
+6. Run Guardian recovery checks when launcher ownership changes.
+7. Run Docker smoke when `scripts/guardian/prod.mjs` changes.
+8. Run Electron PTY/package smoke when dependency topology or shared Runtime
    behavior changes, even though the CLI itself does not package Electron.

--- a/install
+++ b/install
@@ -103,7 +103,8 @@ if [[ -n "$SOURCE_DIR" ]]; then
     cp "$SOURCE_DIR/packages/cli/$file" "$STAGING/$file"
   done
 else
-  BASE_URL="https://raw.githubusercontent.com/$REPOSITORY/$VERSION/packages/cli"
+  BASE_URL="${OPENALICE_INSTALL_BASE_URL:-https://raw.githubusercontent.com/$REPOSITORY/$VERSION/packages/cli}"
+  BASE_URL="${BASE_URL%/}"
   for file in "${FILES[@]}"; do
     curl --fail --silent --show-error --location "$BASE_URL/$file" --output "$STAGING/$file"
   done

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "remote:ssh": "node packages/cli/bin/openalice.mjs ssh",
     "docker:build": "docker build --tag openalice:local .",
     "docker:smoke": "node scripts/docker-runtime-smoke.mjs",
+    "test:install:docker": "node scripts/install-docker-smoke.mjs",
     "prebuild": "tsx scripts/build-migration-index.ts",
     "build": "turbo run build && tsup src/main.ts --format esm --dts",
     "prebuild:server": "tsx scripts/build-migration-index.ts",

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -124,7 +124,7 @@ describe('OpenAlice local Runtime launcher', () => {
     expect(spawnProcess).toHaveBeenCalledWith('/test/node', ['scripts/guardian/prod.mjs'], expect.objectContaining({
       cwd: '/tmp/OpenAlice',
       env: expect.objectContaining({
-        OPENALICE_HOME: '/tmp/alice-home',
+        OPENALICE_HOME: resolve('/tmp/alice-home'),
         OPENALICE_APP_HOME: '/tmp/OpenAlice',
         OPENALICE_BIND_HOST: '127.0.0.1',
         OPENALICE_WEB_PORT: '41000',

--- a/scripts/install-docker-smoke.mjs
+++ b/scripts/install-docker-smoke.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+const suffix = `${process.pid}-${Date.now().toString(36)}`
+const image = `openalice-install-smoke:${suffix}`
+const args = process.argv.slice(2)
+const keepImage = args.includes('--keep-image')
+let imageBuilt = false
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Usage: pnpm test:install:docker [--keep-image]
+
+Build a clean local container and execute the OpenAlice curl installer through
+its real HTTP download path. The smoke is a manual pre-release gate and is not
+wired into PR CI.
+
+Options:
+  --keep-image  Preserve the temporary image for investigation
+  -h, --help    Show this help
+`)
+  process.exit(0)
+}
+
+const unknownArgs = args.filter((arg) => arg !== '--keep-image')
+if (unknownArgs.length > 0) {
+  console.error(`install docker smoke: unknown option: ${unknownArgs[0]}`)
+  process.exit(1)
+}
+
+function docker(dockerArgs, { allowFailure = false } = {}) {
+  const result = spawnSync('docker', dockerArgs, {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0 && !allowFailure) {
+    throw new Error(`docker ${dockerArgs[0]} failed (${result.status ?? result.signal ?? 'unknown'})`)
+  }
+  return result.status === 0
+}
+
+try {
+  console.log(`[install-docker-smoke] building ${image}`)
+  docker([
+    'build',
+    '--file', 'scripts/install-smoke/Dockerfile',
+    '--tag', image,
+    '.',
+  ])
+  imageBuilt = true
+  console.log('[install-docker-smoke] running clean installer acceptance')
+  docker(['run', '--rm', '--network', 'none', image])
+} catch (error) {
+  console.error(`[install-docker-smoke] failed: ${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 1
+} finally {
+  if (keepImage && imageBuilt) {
+    console.log(`[install-docker-smoke] kept image ${image}`)
+  } else if (imageBuilt) {
+    docker(['image', 'rm', '--force', image], { allowFailure: true })
+  }
+}

--- a/scripts/install-smoke/Dockerfile
+++ b/scripts/install-smoke/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22-bookworm-slim
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f /usr/local/bin/pnpm /usr/local/bin/pnpx \
+  && useradd --home-dir /home/smoke --no-create-home --shell /bin/bash --uid 10001 smoke \
+  && mkdir -p /home/smoke \
+  && chown smoke:smoke /home/smoke
+
+WORKDIR /fixture
+COPY --chown=smoke:smoke install /fixture/install
+COPY --chown=smoke:smoke packages/cli /fixture/packages/cli
+COPY --chown=smoke:smoke scripts/install-smoke/run.sh /fixture/run.sh
+COPY --chown=smoke:smoke scripts/install-smoke/static-server.mjs /fixture/static-server.mjs
+
+USER smoke
+ENV HOME=/home/smoke
+ENV SHELL=/bin/bash
+
+ENTRYPOINT ["bash", "/fixture/run.sh"]

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "[install-docker-smoke] $*" >&2
+  exit 1
+}
+
+[[ "$(id -u)" -ne 0 ]] || fail "container must run as a non-root user"
+[[ -z "$(find "$HOME" -mindepth 1 -maxdepth 1 -print -quit)" ]] || fail "HOME is not empty"
+if command -v pnpm >/dev/null 2>&1; then
+  fail "pnpm must not be globally installed in the bootstrap fixture"
+fi
+
+server_log="$(mktemp)"
+node /fixture/static-server.mjs >"$server_log" 2>&1 &
+server_pid=$!
+cleanup() {
+  kill "$server_pid" >/dev/null 2>&1 || true
+  wait "$server_pid" >/dev/null 2>&1 || true
+  rm -f "$server_log"
+}
+trap cleanup EXIT
+
+installer_url="http://127.0.0.1:18080/install"
+for _ in $(seq 1 100); do
+  if curl --fail --silent --output /dev/null "$installer_url"; then
+    break
+  fi
+  if ! kill -0 "$server_pid" >/dev/null 2>&1; then
+    cat "$server_log" >&2
+    fail "fixture server exited before becoming ready"
+  fi
+  sleep 0.1
+done
+curl --fail --silent --output /dev/null "$installer_url" || {
+  cat "$server_log" >&2
+  fail "fixture server did not become ready"
+}
+
+export OPENALICE_INSTALL_BASE_URL="http://127.0.0.1:18080/packages/cli/"
+
+install_version() {
+  local version="$1"
+  curl -fsSL "$installer_url" | bash -s -- --version "$version"
+}
+
+install_version smoke-v1
+
+bin_dir="$HOME/.openalice/bin"
+versions_dir="$HOME/.openalice/cli-versions"
+[[ "$($bin_dir/openalice --version)" == "0.2.0" ]] || fail "installed CLI version check failed"
+"$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"
+[[ -f "$bin_dir/openalice.cmd" ]] || fail "Windows launcher was not installed"
+[[ -f "$versions_dir/smoke-v1/bin/openalice.mjs" ]] || fail "versioned CLI entry was not installed"
+cmp /fixture/packages/cli/src/local-start.mjs "$versions_dir/smoke-v1/src/local-start.mjs" \
+  || fail "downloaded CLI file differs from the fixture"
+
+expected_path_line="export PATH=$HOME/.openalice/bin:\$PATH"
+path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
+[[ "$path_count" == "1" ]] || fail "installer did not add exactly one shell PATH entry"
+
+install_version smoke-v1
+path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
+[[ "$path_count" == "1" ]] || fail "repeat install duplicated the shell PATH entry"
+
+install_version smoke-v2
+[[ -d "$versions_dir/smoke-v1" ]] || fail "version switch removed the previous CLI"
+[[ -d "$versions_dir/smoke-v2" ]] || fail "version switch did not install the new CLI"
+version_count="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+[[ "$version_count" == "2" ]] || fail "unexpected number of installed CLI versions: $version_count"
+grep -Fq "$versions_dir/smoke-v2/bin/openalice.mjs" "$bin_dir/openalice" \
+  || fail "stable launcher did not switch to the latest install"
+[[ "$($bin_dir/openalice --version)" == "0.2.0" ]] || fail "switched CLI is not runnable"
+
+grep -Fq "GET /packages/cli/package.json" "$server_log" \
+  || fail "installer did not exercise the HTTP download branch"
+
+echo "[install-docker-smoke] passed"

--- a/scripts/install-smoke/static-server.mjs
+++ b/scripts/install-smoke/static-server.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { resolve, sep } from 'node:path'
+
+const root = '/fixture'
+const host = '127.0.0.1'
+const port = 18080
+
+const server = createServer(async (request, response) => {
+  const method = request.method ?? 'GET'
+  const pathname = decodeURIComponent(new URL(request.url ?? '/', `http://${host}:${port}`).pathname)
+  console.log(`${method} ${pathname}`)
+
+  if (method !== 'GET') {
+    response.writeHead(405).end('method not allowed\n')
+    return
+  }
+
+  const candidate = resolve(root, `.${pathname}`)
+  if (candidate !== root && !candidate.startsWith(`${root}${sep}`)) {
+    response.writeHead(403).end('forbidden\n')
+    return
+  }
+
+  try {
+    const details = await stat(candidate)
+    if (!details.isFile()) throw new Error('not a file')
+    response.writeHead(200, { 'content-length': details.size })
+    createReadStream(candidate).pipe(response)
+  } catch {
+    response.writeHead(404).end('not found\n')
+  }
+})
+
+server.listen(port, host, () => {
+  console.log(`ready http://${host}:${port}`)
+})
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => server.close(() => process.exit(0)))
+}


### PR DESCRIPTION
## Summary

- add a local Docker acceptance test for the bootstrap installer download path
- run the fixture as a non-root user with an empty home, no pnpm, and no external network
- make the smoke a documented manual pre-release gate without adding a CI job
- fix the cross-platform CLI test assertion exposed by the previous Windows check

## Why

The bootstrap installer needs a repeatable clean-machine check before release without adding another expensive PR CI lane. A local HTTP fixture lets the container execute the real `curl | bash` and multi-file download branch before a tag exists.

## Validation

- `npx tsc --noEmit`
- `pnpm test` (254 files passed, 2778 tests passed)
- `pnpm exec vitest run packages/cli/src/install.spec.mjs packages/cli/src/local-start.spec.mjs`
- `pnpm test:install:docker` (passed with the run container on `--network none`)
- `bash -n install scripts/install-smoke/run.sh`
- `node --check scripts/install-docker-smoke.mjs`
- `node --check scripts/install-smoke/static-server.mjs`

No GitHub Actions workflow was changed.