### PR TITLE
feat(cli): add guided installer experience

### DIFF
--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -40,9 +40,19 @@ curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install |
 The preview requires Node.js 20 or newer. It installs versioned CLI files under
 `~/.openalice/cli-versions/`, writes stable `openalice` and `openalice.cmd`
 launchers under `~/.openalice/bin/`, and offers to add that bin directory to the
-current shell profile. It does not clone OpenAlice, write application state, or
+current shell profile. Before changing files, the interactive installer shows
+its source, version, paths, and shell changes, explains what it will not do, and
+asks for confirmation. It does not clone OpenAlice, write application state, or
 install Electron. The curl entry targets macOS, Linux, WSL, and Git Bash;
 native Windows desktop distribution remains the signed Electron installer.
+
+Unattended environments have no implicit consent. After reviewing the same
+install plan, pass `--yes` explicitly:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install \
+  | bash -s -- --yes
+```
 
 For a pinned tag or commit:
 
@@ -55,6 +65,13 @@ For local installer development:
 
 ```bash
 ./install --source . --version dev --no-modify-path
+```
+
+To experience the real prompt in a clean, offline container and remain in its
+shell afterward for inspection:
+
+```bash
+pnpm test:install:docker --interactive
 ```
 
 `OPENALICE_INSTALL_BASE_URL` may point the download branch at a local fixture

--- a/install
+++ b/install
@@ -5,7 +5,37 @@ REPOSITORY="TraderAlice/OpenAlice"
 VERSION="${OPENALICE_VERSION:-dev}"
 SOURCE_DIR=""
 MODIFY_PATH=1
+ASSUME_YES=0
 INSTALL_ROOT="${OPENALICE_INSTALL_DIR:-${HOME}/.openalice}"
+
+BOLD=""
+DIM=""
+CYAN=""
+GREEN=""
+RED=""
+RESET=""
+
+if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
+  BOLD=$'\033[1m'
+  DIM=$'\033[2m'
+  CYAN=$'\033[36m'
+  GREEN=$'\033[32m'
+  RED=$'\033[31m'
+  RESET=$'\033[0m'
+fi
+
+die() {
+  printf '\n%bError:%b %s\n' "${RED}${BOLD}" "$RESET" "$*" >&2
+  exit 1
+}
+
+step() {
+  printf '\n%b[%s/4]%b %s\n' "$CYAN" "$1" "$RESET" "$2"
+}
+
+ok() {
+  printf '      %b✓%b %s\n' "$GREEN" "$RESET" "$1"
+}
 
 usage() {
   cat <<'EOF'
@@ -13,13 +43,14 @@ OpenAlice CLI installer
 
 Usage:
   curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
-  ./install [--version <git-ref>] [--install-dir <path>] [--no-modify-path]
+  ./install [--version <git-ref>] [--install-dir <path>] [--no-modify-path] [--yes]
 
 Options:
   --version <git-ref>   Git tag, branch, or commit to install (default: dev)
   --install-dir <path>  OpenAlice user root (default: ~/.openalice)
   --source <path>       Install CLI files from a local checkout (development)
   --no-modify-path      Do not update the shell profile
+  -y, --yes             Accept the install plan without an interactive prompt
   -h, --help            Show this help
 EOF
 }
@@ -45,6 +76,10 @@ while [[ $# -gt 0 ]]; do
       MODIFY_PATH=0
       shift
       ;;
+    -y|--yes)
+      ASSUME_YES=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -58,25 +93,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$VERSION" == *".."* || ! "$VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-  echo "openalice install: unsupported version/ref: $VERSION" >&2
-  exit 1
-fi
-
-if ! command -v node >/dev/null 2>&1; then
-  echo "openalice install: Node.js 20 or newer is required for the preview CLI." >&2
-  echo "Install Node.js, then run this installer again." >&2
-  exit 1
-fi
-
-NODE_MAJOR="$(node -p 'Number(process.versions.node.split(".")[0])')"
-if [[ "$NODE_MAJOR" -lt 20 ]]; then
-  echo "openalice install: Node.js 20 or newer is required (found $(node --version))." >&2
-  exit 1
-fi
-
-if [[ -z "$SOURCE_DIR" ]] && ! command -v curl >/dev/null 2>&1; then
-  echo "openalice install: curl is required." >&2
-  exit 1
+  die "Unsupported version/ref: $VERSION"
 fi
 
 INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
@@ -84,10 +101,122 @@ BIN_DIR="$INSTALL_ROOT/bin"
 VERSIONS_DIR="$INSTALL_ROOT/cli-versions"
 SAFE_VERSION="${VERSION//\//_}"
 DESTINATION="$VERSIONS_DIR/$SAFE_VERSION"
-STAGING="$(mktemp -d "${TMPDIR:-/tmp}/openalice-cli.XXXXXX")"
-trap 'rm -rf "$STAGING"' EXIT
 
-mkdir -p "$STAGING/bin" "$STAGING/src" "$BIN_DIR" "$VERSIONS_DIR"
+if [[ -n "$SOURCE_DIR" ]]; then
+  source_argument="$SOURCE_DIR"
+  if ! SOURCE_DIR="$(cd "$SOURCE_DIR" 2>/dev/null && pwd)"; then
+    die "Local source checkout not found: $source_argument"
+  fi
+fi
+
+path_present=0
+case ":$PATH:" in
+  *":$BIN_DIR:"*) path_present=1 ;;
+esac
+
+profile=""
+path_line=""
+printf -v quoted_bin '%q' "$BIN_DIR"
+current_path_command="export PATH=$quoted_bin:\$PATH"
+if [[ "$MODIFY_PATH" -eq 0 ]]; then
+  shell_setup="Skip (--no-modify-path)"
+elif [[ "$path_present" -eq 1 ]]; then
+  shell_setup="Already available on PATH"
+else
+  case "${SHELL:-}" in
+    */zsh)
+      profile="$HOME/.zshrc"
+      path_line="export PATH=$quoted_bin:\$PATH"
+      ;;
+    */bash)
+      if [[ "$(uname -s)" == "Darwin" ]]; then profile="$HOME/.bash_profile"; else profile="$HOME/.bashrc"; fi
+      path_line="export PATH=$quoted_bin:\$PATH"
+      ;;
+    */fish)
+      profile="$HOME/.config/fish/config.fish"
+      path_line="fish_add_path $quoted_bin"
+      current_path_command="fish_add_path $quoted_bin"
+      ;;
+  esac
+  if [[ -n "$profile" ]]; then
+    shell_setup="Add OpenAlice to $profile"
+  else
+    shell_setup="Manual PATH setup (shell profile not detected)"
+  fi
+fi
+
+printf '\n%bOpenAlice%b\n' "${BOLD}${CYAN}" "$RESET"
+printf '%bLocal Runtime CLI installer%b\n\n' "$BOLD" "$RESET"
+printf 'This installs the small %bopenalice%b command used to launch a local\n' "$BOLD" "$RESET"
+printf 'OpenAlice checkout in your browser. Nothing will start yet.\n'
+printf '%bIt will not clone a repository, install Electron, start services, or configure credentials.%b\n' "$DIM" "$RESET"
+
+step 1 "Checking your system"
+if ! command -v node >/dev/null 2>&1; then
+  die "Node.js 20 or newer is required. Install Node.js, then run this installer again."
+fi
+
+NODE_MAJOR="$(node -p 'Number(process.versions.node.split(".")[0])')"
+if [[ "$NODE_MAJOR" -lt 20 ]]; then
+  die "Node.js 20 or newer is required (found $(node --version))."
+fi
+ok "Node.js $(node --version)"
+
+if [[ -z "$SOURCE_DIR" ]] && ! command -v curl >/dev/null 2>&1; then
+  die "curl is required to download the CLI files."
+fi
+if [[ -n "$SOURCE_DIR" ]]; then
+  [[ -f "$SOURCE_DIR/packages/cli/package.json" ]] || die "OpenAlice CLI sources are missing under $SOURCE_DIR"
+  ok "Local checkout is readable"
+  install_source="Local checkout: $SOURCE_DIR"
+else
+  ok "curl is available"
+  BASE_URL="${OPENALICE_INSTALL_BASE_URL:-https://raw.githubusercontent.com/$REPOSITORY/$VERSION/packages/cli}"
+  BASE_URL="${BASE_URL%/}"
+  if [[ -n "${OPENALICE_INSTALL_BASE_URL:-}" ]]; then
+    install_source="Download URL: $BASE_URL"
+  else
+    install_source="GitHub ref: $REPOSITORY@$VERSION"
+  fi
+fi
+
+printf '\n%bInstall plan%b\n' "$BOLD" "$RESET"
+printf '  %-14s %s\n' "Source" "$install_source"
+printf '  %-14s %s\n' "Version" "$VERSION"
+printf '  %-14s %s\n' "Install root" "$INSTALL_ROOT"
+printf '  %-14s %s\n' "Command" "$BIN_DIR/openalice"
+printf '  %-14s %s\n' "Shell setup" "$shell_setup"
+if [[ -d "$DESTINATION" ]]; then
+  printf '  %-14s %s\n' "Existing CLI" "Replace the installed $VERSION CLI files"
+fi
+
+if [[ "$ASSUME_YES" -eq 0 ]]; then
+  if ! { exec 3<>/dev/tty; } 2>/dev/null; then
+    printf '\n%bNo interactive terminal is available.%b\n' "${RED}${BOLD}" "$RESET" >&2
+    printf 'Review the install plan above, then re-run with %b--yes%b to approve it.\n' "$BOLD" "$RESET" >&2
+    exit 2
+  fi
+  while true; do
+    printf '\n%bContinue with this install?%b [Y/n] ' "$BOLD" "$RESET" >&3
+    if ! IFS= read -r reply <&3; then
+      reply="n"
+    fi
+    case "$reply" in
+      ""|y|Y|yes|YES|Yes)
+        break
+        ;;
+      n|N|no|NO|No)
+        exec 3>&-
+        printf '\nNo changes made. You can run the installer again whenever you are ready.\n'
+        exit 0
+        ;;
+      *)
+        printf 'Please answer y or n.\n' >&3
+        ;;
+    esac
+  done
+  exec 3>&-
+fi
 
 FILES=(
   "package.json"
@@ -97,25 +226,32 @@ FILES=(
   "src/ssh-connect.mjs"
 )
 
+step 2 "Preparing CLI files"
+STAGING="$(mktemp -d "${TMPDIR:-/tmp}/openalice-cli.XXXXXX")"
+trap 'rm -rf "$STAGING"' EXIT
+mkdir -p "$STAGING/bin" "$STAGING/src"
+
 if [[ -n "$SOURCE_DIR" ]]; then
-  SOURCE_DIR="$(cd "$SOURCE_DIR" && pwd)"
   for file in "${FILES[@]}"; do
     cp "$SOURCE_DIR/packages/cli/$file" "$STAGING/$file"
   done
 else
-  BASE_URL="${OPENALICE_INSTALL_BASE_URL:-https://raw.githubusercontent.com/$REPOSITORY/$VERSION/packages/cli}"
-  BASE_URL="${BASE_URL%/}"
   for file in "${FILES[@]}"; do
     curl --fail --silent --show-error --location "$BASE_URL/$file" --output "$STAGING/$file"
   done
 fi
+ok "CLI files are ready"
 
+step 3 "Verifying the download"
 chmod +x "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/src/local-start.mjs"
 node --check "$STAGING/src/runtime-client.mjs"
 node --check "$STAGING/src/ssh-connect.mjs"
+ok "JavaScript entry points passed validation"
 
+step 4 "Installing the command"
+mkdir -p "$BIN_DIR" "$VERSIONS_DIR"
 rm -rf "$DESTINATION"
 mv "$STAGING" "$DESTINATION"
 trap - EXIT
@@ -132,29 +268,7 @@ fi
 WINDOWS_CLI_ENTRY="${WINDOWS_CLI_ENTRY//%/%%}"
 printf '@echo off\r\nnode "%s" %%*\r\n' "$WINDOWS_CLI_ENTRY" > "$BIN_DIR/openalice.cmd"
 
-path_present=0
-case ":$PATH:" in
-  *":$BIN_DIR:"*) path_present=1 ;;
-esac
-
-profile=""
-path_line=""
 if [[ "$MODIFY_PATH" -eq 1 && "$path_present" -eq 0 ]]; then
-  printf -v quoted_bin '%q' "$BIN_DIR"
-  case "${SHELL:-}" in
-    */zsh)
-      profile="$HOME/.zshrc"
-      path_line="export PATH=$quoted_bin:\$PATH"
-      ;;
-    */bash)
-      if [[ "$(uname -s)" == "Darwin" ]]; then profile="$HOME/.bash_profile"; else profile="$HOME/.bashrc"; fi
-      path_line="export PATH=$quoted_bin:\$PATH"
-      ;;
-    */fish)
-      profile="$HOME/.config/fish/config.fish"
-      path_line="fish_add_path $quoted_bin"
-      ;;
-  esac
   if [[ -n "$profile" ]]; then
     mkdir -p "$(dirname "$profile")"
     touch "$profile"
@@ -163,12 +277,17 @@ if [[ "$MODIFY_PATH" -eq 1 && "$path_present" -eq 0 ]]; then
     fi
   fi
 fi
+ok "Installed $BIN_DIR/openalice"
 
-echo "OpenAlice CLI installed: $BIN_DIR/openalice"
-echo "Version: $VERSION"
-if [[ "$path_present" -eq 0 ]]; then
-  echo "For this shell, run:"
-  printf '  export PATH=%q:$PATH\n' "$BIN_DIR"
-  [[ -z "$profile" ]] || echo "Future shells will load it from $profile."
+printf '\n%bOpenAlice CLI is ready.%b\n' "${GREEN}${BOLD}" "$RESET"
+printf '  %-12s %s\n' "Command" "$BIN_DIR/openalice"
+printf '  %-12s %s\n' "Version" "$VERSION"
+if [[ -n "$profile" && "$path_present" -eq 0 ]]; then
+  printf '  %-12s %s\n' "Shell" "Future terminals will load $profile"
 fi
-echo "Then enter an OpenAlice checkout and run: openalice"
+if [[ "$path_present" -eq 0 ]]; then
+  printf '\nFor this terminal, run:\n  %s\n' "$current_path_command"
+fi
+printf '\nThen launch from an OpenAlice checkout:\n'
+printf '  cd /path/to/OpenAlice\n'
+printf '  openalice\n\n'

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -26,13 +26,36 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
       '--version', 'test/ref',
       '--install-dir', installRoot,
       '--no-modify-path',
+      '--yes',
     ], { env: { ...process.env, HOME: home } })
 
-    expect(installed.stdout).toContain('OpenAlice CLI installed')
+    expect(installed.stdout).toContain('Local Runtime CLI installer')
+    expect(installed.stdout).toContain('Nothing will start yet')
+    expect(installed.stdout).toContain('Install plan')
+    expect(installed.stdout).toContain('OpenAlice CLI is ready')
     await expect(access(join(installRoot, 'cli-versions', 'test_ref', 'bin', 'openalice.mjs'))).resolves.toBeUndefined()
     await expect(access(join(installRoot, 'bin', 'openalice.cmd'))).resolves.toBeUndefined()
 
     const result = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['--version'])
     expect(result.stdout.trim()).toBe('0.2.0')
+  })
+
+  it('requires explicit approval when no interactive terminal is available', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-unattended-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const installer = join(repositoryRoot, 'install')
+
+    await expect(execFileAsync('bash', [installer,
+      '--source', repositoryRoot,
+      '--version', 'unattended',
+      '--install-dir', installRoot,
+      '--no-modify-path',
+    ], { env: { ...process.env, HOME: home } })).rejects.toMatchObject({
+      code: 2,
+      stderr: expect.stringContaining('--yes'),
+    })
+
+    await expect(access(installRoot)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })

--- a/scripts/install-docker-smoke.mjs
+++ b/scripts/install-docker-smoke.mjs
@@ -7,25 +7,32 @@ const suffix = `${process.pid}-${Date.now().toString(36)}`
 const image = `openalice-install-smoke:${suffix}`
 const args = process.argv.slice(2)
 const keepImage = args.includes('--keep-image')
+const interactive = args.includes('--interactive')
 let imageBuilt = false
 
 if (args.includes('--help') || args.includes('-h')) {
-  console.log(`Usage: pnpm test:install:docker [--keep-image]
+  console.log(`Usage: pnpm test:install:docker [--interactive] [--keep-image]
 
 Build a clean local container and execute the OpenAlice curl installer through
 its real HTTP download path. The smoke is a manual pre-release gate and is not
 wired into PR CI.
 
 Options:
+  --interactive Keep a TTY open to experience and inspect the installer manually
   --keep-image  Preserve the temporary image for investigation
   -h, --help    Show this help
 `)
   process.exit(0)
 }
 
-const unknownArgs = args.filter((arg) => arg !== '--keep-image')
+const unknownArgs = args.filter((arg) => !['--interactive', '--keep-image'].includes(arg))
 if (unknownArgs.length > 0) {
   console.error(`install docker smoke: unknown option: ${unknownArgs[0]}`)
+  process.exit(1)
+}
+
+if (interactive && (!process.stdin.isTTY || !process.stdout.isTTY)) {
+  console.error('install docker smoke: --interactive requires an interactive terminal')
   process.exit(1)
 }
 
@@ -51,8 +58,16 @@ try {
     '.',
   ])
   imageBuilt = true
-  console.log('[install-docker-smoke] running clean installer acceptance')
-  docker(['run', '--rm', '--network', 'none', image])
+  if (interactive) {
+    console.log('[install-docker-smoke] opening manual installer playground')
+    docker([
+      'run', '--rm', '--interactive', '--tty', '--network', 'none',
+      '--entrypoint', 'bash', image, '/fixture/interactive.sh',
+    ])
+  } else {
+    console.log('[install-docker-smoke] running clean installer acceptance')
+    docker(['run', '--rm', '--network', 'none', image])
+  }
 } catch (error) {
   console.error(`[install-docker-smoke] failed: ${error instanceof Error ? error.message : String(error)}`)
   process.exitCode = 1

--- a/scripts/install-smoke/Dockerfile
+++ b/scripts/install-smoke/Dockerfile
@@ -11,6 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 WORKDIR /fixture
 COPY --chown=smoke:smoke install /fixture/install
 COPY --chown=smoke:smoke packages/cli /fixture/packages/cli
+COPY --chown=smoke:smoke scripts/install-smoke/interactive.sh /fixture/interactive.sh
 COPY --chown=smoke:smoke scripts/install-smoke/run.sh /fixture/run.sh
 COPY --chown=smoke:smoke scripts/install-smoke/static-server.mjs /fixture/static-server.mjs
 

--- a/scripts/install-smoke/interactive.sh
+++ b/scripts/install-smoke/interactive.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -t 0 || ! -t 1 ]]; then
+  echo "[install-playground] an interactive terminal is required" >&2
+  exit 1
+fi
+
+server_log="$(mktemp)"
+node /fixture/static-server.mjs >"$server_log" 2>&1 &
+server_pid=$!
+cleanup() {
+  kill "$server_pid" >/dev/null 2>&1 || true
+  wait "$server_pid" >/dev/null 2>&1 || true
+  rm -f "$server_log"
+}
+trap cleanup EXIT
+
+export OPENALICE_INSTALL_URL="http://127.0.0.1:18080/install"
+export OPENALICE_INSTALL_BASE_URL="http://127.0.0.1:18080/packages/cli/"
+
+for _ in $(seq 1 100); do
+  if curl --fail --silent --output /dev/null "$OPENALICE_INSTALL_URL"; then
+    break
+  fi
+  sleep 0.1
+done
+curl --fail --silent --output /dev/null "$OPENALICE_INSTALL_URL" || {
+  cat "$server_log" >&2
+  exit 1
+}
+
+printf '\n[install-playground] Clean container ready: non-root, empty HOME, no pnpm, no external network.\n'
+printf '[install-playground] Starting the same curl installer a user will see.\n\n'
+curl -fsSL "$OPENALICE_INSTALL_URL" | bash
+
+if [[ -x "$HOME/.openalice/bin/openalice" ]]; then
+  export PATH="$HOME/.openalice/bin:$PATH"
+fi
+
+printf '\n[install-playground] You are now in the container after the installer.\n'
+printf 'Try: command -v openalice; openalice --version; cat ~/.bashrc\n'
+printf 'Re-run: curl -fsSL "$OPENALICE_INSTALL_URL" | bash\n'
+printf 'Leave: exit\n\n'
+export PS1='openalice-install> '
+bash --noprofile --norc -i

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -13,12 +13,13 @@ if command -v pnpm >/dev/null 2>&1; then
 fi
 
 server_log="$(mktemp)"
+refusal_log="$(mktemp)"
 node /fixture/static-server.mjs >"$server_log" 2>&1 &
 server_pid=$!
 cleanup() {
   kill "$server_pid" >/dev/null 2>&1 || true
   wait "$server_pid" >/dev/null 2>&1 || true
-  rm -f "$server_log"
+  rm -f "$server_log" "$refusal_log"
 }
 trap cleanup EXIT
 
@@ -40,9 +41,15 @@ curl --fail --silent --output /dev/null "$installer_url" || {
 
 export OPENALICE_INSTALL_BASE_URL="http://127.0.0.1:18080/packages/cli/"
 
+if curl -fsSL "$installer_url" | bash -s -- --version smoke-unattended >"$refusal_log" 2>&1; then
+  fail "installer proceeded without interactive or explicit approval"
+fi
+grep -Fq -- "--yes" "$refusal_log" || fail "unattended refusal did not explain --yes"
+[[ ! -e "$HOME/.openalice" ]] || fail "unattended refusal changed the install root"
+
 install_version() {
   local version="$1"
-  curl -fsSL "$installer_url" | bash -s -- --version "$version"
+  curl -fsSL "$installer_url" | bash -s -- --yes --version "$version"
 }
 
 install_version smoke-v1


### PR DESCRIPTION
## Summary

- turn the bootstrap installer into a guided terminal experience with environment checks, a transparent install plan, confirmation, progress, and clear next steps
- require explicit `--yes` consent when no interactive terminal is available
- add `pnpm test:install:docker --interactive` for a clean offline manual playground
- extend unit and Docker acceptance coverage for unattended refusal, zero-write cancellation, repeat install, PATH idempotency, and version switching

## Why

The previous bootstrap started writing files immediately and only printed a terse result. Users should understand that this installs a small CLI, see exactly which paths and shell profile may change, and know that it will not clone OpenAlice, install Electron, start services, or configure credentials before approving it.

## Validation

- manually exercised accept and cancel paths in a real PTY with isolated HOME
- manually completed `pnpm test:install:docker --interactive`, verified `openalice --version` and `.bashrc`, then confirmed image cleanup
- `bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh`
- `node --check scripts/install-docker-smoke.mjs`
- `node --check scripts/install-smoke/static-server.mjs`
- `pnpm exec vitest run packages/cli/src/install.spec.mjs`
- `pnpm test:install:docker`
- `npx tsc --noEmit`
- `pnpm test` (254 files passed, 2779 tests passed)

No Electron/runtime code or GitHub Actions workflow changed.