### PR TITLE
fix(cli): require explicit installer confirmation

### DIFF
--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -42,8 +42,9 @@ The preview requires Node.js 20 or newer. It installs versioned CLI files under
 launchers under `~/.openalice/bin/`, and offers to add that bin directory to the
 current shell profile. Before changing files, the interactive installer shows
 its source, version, paths, and shell changes, explains what it will not do, and
-asks for confirmation. It does not clone OpenAlice, write application state, or
-install Electron. The curl entry targets macOS, Linux, WSL, and Git Bash;
+requires an explicit `y` confirmation; blank input cancels without writing. It
+does not clone OpenAlice, write application state, or install Electron. The curl
+entry targets macOS, Linux, WSL, and Git Bash;
 native Windows desktop distribution remains the signed Electron installer.
 
 Unattended environments have no implicit consent. After reviewing the same

--- a/install
+++ b/install
@@ -197,21 +197,23 @@ if [[ "$ASSUME_YES" -eq 0 ]]; then
     exit 2
   fi
   while true; do
-    printf '\n%bContinue with this install?%b [Y/n] ' "$BOLD" "$RESET" >&3
+    printf '\n%bContinue with this install?%b [y/N] ' "$BOLD" "$RESET"
     if ! IFS= read -r reply <&3; then
-      reply="n"
+      exec 3>&-
+      printf '\nNo confirmation received. No changes made.\n' >&2
+      exit 2
     fi
     case "$reply" in
-      ""|y|Y|yes|YES|Yes)
+      y|Y|yes|YES|Yes)
         break
         ;;
-      n|N|no|NO|No)
+      ""|n|N|no|NO|No)
         exec 3>&-
         printf '\nNo changes made. You can run the installer again whenever you are ready.\n'
         exit 0
         ;;
       *)
-        printf 'Please answer y or n.\n' >&3
+        printf 'Please answer y or n. Press Enter to cancel.\n'
         ;;
     esac
   done

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 
+import * as pty from 'node-pty'
 import { afterEach, describe, expect, it } from 'vitest'
 
 const execFileAsync = promisify(execFile)
@@ -58,4 +59,73 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
 
     await expect(access(installRoot)).rejects.toMatchObject({ code: 'ENOENT' })
   })
+
+  it('treats blank interactive confirmation as cancellation', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-cancel-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const result = await runInstallerInPty([
+      '--source', repositoryRoot,
+      '--version', 'interactive-cancel',
+      '--install-dir', installRoot,
+      '--no-modify-path',
+    ], { home, reply: '\r' })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('Continue with this install?')
+    expect(result.output).toContain('[y/N]')
+    expect(result.output).toContain('No changes made')
+    await expect(access(installRoot)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('installs after an explicit interactive y confirmation', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-confirm-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const result = await runInstallerInPty([
+      '--source', repositoryRoot,
+      '--version', 'interactive-confirm',
+      '--install-dir', installRoot,
+      '--no-modify-path',
+    ], { home, reply: 'y\r' })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.output).toContain('Continue with this install?')
+    expect(result.output).toContain('OpenAlice CLI is ready')
+    await expect(access(join(installRoot, 'bin', 'openalice'))).resolves.toBeUndefined()
+  })
 })
+
+function runInstallerInPty(args, { home, reply }) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const terminal = pty.spawn('bash', [join(repositoryRoot, 'install'), ...args], {
+      cwd: repositoryRoot,
+      cols: 120,
+      rows: 32,
+      env: {
+        ...process.env,
+        HOME: home,
+        SHELL: '/bin/bash',
+        TERM: 'xterm-256color',
+      },
+    })
+    let output = ''
+    let replied = false
+    const timeout = setTimeout(() => {
+      terminal.kill()
+      rejectPromise(new Error(`installer PTY timed out:\n${output}`))
+    }, 10_000)
+
+    terminal.onData((data) => {
+      output += data
+      if (!replied && output.includes('Continue with this install?')) {
+        replied = true
+        terminal.write(reply)
+      }
+    })
+    terminal.onExit(({ exitCode, signal }) => {
+      clearTimeout(timeout)
+      resolvePromise({ exitCode, signal, output })
+    })
+  })
+}

--- a/scripts/install-smoke/interactive.sh
+++ b/scripts/install-smoke/interactive.sh
@@ -32,6 +32,7 @@ curl --fail --silent --output /dev/null "$OPENALICE_INSTALL_URL" || {
 
 printf '\n[install-playground] Clean container ready: non-root, empty HOME, no pnpm, no external network.\n'
 printf '[install-playground] Starting the same curl installer a user will see.\n\n'
+printf '[install-playground] The installer will pause at its plan. Type y and press Enter to approve it.\n\n'
 curl -fsSL "$OPENALICE_INSTALL_URL" | bash
 
 if [[ -x "$HOME/.openalice/bin/openalice" ]]; then
@@ -41,6 +42,7 @@ fi
 printf '\n[install-playground] You are now in the container after the installer.\n'
 printf 'Try: command -v openalice; openalice --version; cat ~/.bashrc\n'
 printf 'Re-run: curl -fsSL "$OPENALICE_INSTALL_URL" | bash\n'
+printf 'After a successful re-run: source ~/.bashrc\n'
 printf 'Leave: exit\n\n'
 export PS1='openalice-install> '
 bash --noprofile --norc -i


### PR DESCRIPTION
## Summary

- render the installer confirmation prompt on standard output so it remains visible through pnpm, Docker, and OrbStack PTY forwarding
- change the default from `[Y/n]` to fail-closed `[y/N]`; blank input cancels and unreadable input exits without writing
- tell the manual Docker playground that an explicit `y` is required
- add real node-pty regression tests for blank cancellation and explicit-y installation

## Root cause

The prompt text and input were both attached directly to the container `/dev/tty`, while blank input was treated as approval. In the reported OrbStack/pnpm path the plan was visible but the decision prompt was not reliably visible, leaving an empty terminal input able to approve installation without a meaningful user choice.

## Validation

- reproduced the exact `pnpm test:install:docker --interactive` flow
- pressed Enter at `[y/N]`, verified `No changes made` and confirmed `~/.openalice` did not exist
- re-ran inside the same clean container, typed `y`, and verified CLI version `0.2.0`
- `bash -n install scripts/install-smoke/interactive.sh`
- `pnpm exec vitest run packages/cli/src/install.spec.mjs` (4 passed)
- `pnpm test:install:docker`
- `npx tsc --noEmit`
- `pnpm test` (254 files passed, 2781 tests passed)

No Electron/runtime code or GitHub Actions workflow changed.