### PR TITLE
docs: preserve Claude installer reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,11 @@ GitHub navigation.
 Other files under `docs/images/` are README/product assets rather than owner
 guides.
 
+Reference snapshots under `docs/reference/` are non-authoritative research
+material rather than owner guides. The [installer script reference](reference/install-script/README.md)
+preserves dated Claude Code bootstrap snapshots and the OpenAlice distribution
+decisions derived from them.
+
 ## Maintenance Rule
 
 - Every owner guide states what it owns and points to the current load-bearing

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -130,6 +130,12 @@ installer. The same dependency plan must remain inspectable and independently
 retryable, and Electron's managed-runtime policy continues to belong to
 [[docs/managed-workspace-runtime.md]].
 
+The [installer script reference](reference/install-script/README.md) preserves
+a dated snapshot of Claude Code's macOS/Linux, PowerShell, and CMD bootstraps.
+Use it to inform release-channel, manifest, platform-detection, and CLI-owned
+installation design. It is third-party reference material, not an OpenAlice
+installer implementation or a substitute for current runtime verification.
+
 ## Security and Network Invariants
 
 - The CLI always sets `OPENALICE_BIND_HOST=127.0.0.1` for local startup.

--- a/docs/reference/install-script/.gitattributes
+++ b/docs/reference/install-script/.gitattributes
@@ -1,0 +1,1 @@
+claude-code-bootstrap.* -text -whitespace

--- a/docs/reference/install-script/README.md
+++ b/docs/reference/install-script/README.md
@@ -1,0 +1,120 @@
+# Installer Script Reference
+
+This directory preserves a dated snapshot of the public Claude Code native
+installer bootstraps. It exists so OpenAlice installer work can study a mature
+cross-platform distribution design without relying on chat history or a live
+upstream response that may change.
+
+These files are reference material, not OpenAlice production code. Do not run
+them from this repository, publish them as OpenAlice installers, or copy them
+verbatim into the product. Reimplement accepted ideas within OpenAlice's own
+security, consent, licensing, and release boundaries.
+
+## Snapshot provenance
+
+Captured on 2026-07-13 from the final official download URLs reached by the
+documented `claude.ai` installer entry points. The files are byte-for-byte
+snapshots, including upstream whitespace and the CRLF line endings in the CMD
+script. The local `.gitattributes` prevents Git from normalizing those bytes or
+treating upstream whitespace as OpenAlice-authored formatting errors.
+
+| Snapshot | Official source | SHA-256 |
+|---|---|---|
+| [Shell](claude-code-bootstrap.sh) | <https://downloads.claude.ai/claude-code-releases/bootstrap.sh> | `b3f79015b54c751440a6488f07b1b64f9088742b9052bc1bd356d13108320d2a` |
+| [PowerShell](claude-code-bootstrap.ps1) | <https://downloads.claude.ai/claude-code-releases/bootstrap.ps1> | `cd17c6b555f761d60373659824bf805e1510538226e4c7028e19d7494937a333` |
+| [Windows CMD](claude-code-bootstrap.cmd) | <https://downloads.claude.ai/claude-code-releases/bootstrap.cmd> | `dff10083f59203dce263c3cae63632d7e1c37c3bee686e27f84bdf0d1ad59683` |
+
+At capture time, the official channel pointers returned:
+
+- `latest`: `2.1.207`
+- `stable`: `2.1.197`
+
+The public installation and integrity documentation is at
+<https://code.claude.com/docs/en/installation>. Anthropic owns the upstream
+material and its associated rights; retaining this snapshot does not license
+it as OpenAlice or AGPL code.
+
+## What the design does
+
+The three bootstraps implement the same narrow pipeline in platform-native
+shells:
+
+1. Validate an optional `stable`, `latest`, or exact-version target.
+2. Detect the operating system, CPU architecture, and relevant ABI details.
+3. Always resolve the current `latest` Claude Code binary so installation logic
+   comes from the newest installer implementation.
+4. Download the matching release manifest and platform binary.
+5. Verify the binary SHA-256 against the manifest.
+6. Run the downloaded binary's own `install <target>` command.
+7. Preserve its exit status and clean up the temporary binary.
+
+The outer script does not own final version placement, launcher creation, PATH
+integration, migration, or update policy. Those behaviors belong to the CLI
+binary. This keeps the public curl/PowerShell/CMD surface small while allowing
+the installer implementation to evolve with the application.
+
+Notable platform handling includes:
+
+- `curl` or `wget`, with optional `jq`, on macOS and Linux;
+- Rosetta detection and native Apple Silicon selection;
+- glibc versus musl selection on Linux;
+- x64 and ARM64 selection on Windows, with explicit 32-bit rejection;
+- native PowerShell and CMD paths rather than requiring Bash on Windows;
+- checksum failure cleanup and install-process exit-code preservation;
+- terminal recovery and a focused Linux out-of-memory explanation after a
+  signal-killed install.
+
+## OpenAlice decisions informed by this reference
+
+Ideas to adopt:
+
+- Keep bootstrap scripts thin and move durable install/update/doctor behavior
+  behind the `openalice` CLI.
+- Publish immutable release artifacts with a manifest, platform or runtime
+  metadata, sizes, and SHA-256 checksums.
+- Support explicit `stable`, `latest`, and exact-version channels instead of
+  making a mutable development branch the public production default.
+- Give PowerShell and CMD first-class entry points when native Windows CLI
+  installation becomes part of the supported surface.
+- Install versions side by side and switch a stable launcher only after the new
+  version has passed verification.
+- Clean temporary artifacts on every failure path and preserve useful native
+  exit codes.
+
+OpenAlice-specific behavior to preserve:
+
+- Show the complete install plan before mutation and require explicit consent;
+  blank input remains cancellation. The Claude Code bootstrap starts work
+  immediately, which is not the desired OpenAlice onboarding contract.
+- Keep Electron as a separate, complete distribution with its existing
+  packaging, signing, updater, IPC, PTY, and managed-runtime behavior.
+- Keep localhost startup and later SSH transport as CLI/runtime concerns, not
+  responsibilities of the download bootstrap.
+- Treat dependency selection as a visible, independently retryable plan rather
+  than silently bundling every optional agent runtime.
+
+Security caveat: the captured bootstraps verify a binary checksum supplied by
+the downloaded manifest, but do not themselves verify the manifest's detached
+GPG signature. Anthropic documents manual signature verification separately.
+OpenAlice should define its release trust chain explicitly instead of assuming
+that copying the checksum step alone provides artifact authenticity.
+
+## Refreshing the snapshot
+
+Refresh only as an intentional review change. Download the files without
+executing them, inspect the diff, update the capture date/channel values and
+hashes above, and explain any adopted design change in the PR.
+
+```bash
+curl -fsSL https://downloads.claude.ai/claude-code-releases/bootstrap.sh \
+  -o /tmp/claude-code-bootstrap.sh
+curl -fsSL https://downloads.claude.ai/claude-code-releases/bootstrap.ps1 \
+  -o /tmp/claude-code-bootstrap.ps1
+curl -fsSL https://downloads.claude.ai/claude-code-releases/bootstrap.cmd \
+  -o /tmp/claude-code-bootstrap.cmd
+shasum -a 256 /tmp/claude-code-bootstrap.*
+```
+
+Do not automate upstream refreshes. A silent snapshot update would erase the
+reason this reference exists: making distribution-design changes visible and
+reviewable.

--- a/docs/reference/install-script/claude-code-bootstrap.cmd
+++ b/docs/reference/install-script/claude-code-bootstrap.cmd
@@ -1,0 +1,230 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Claude Code Windows CMD Bootstrap Script
+REM Installs Claude Code for environments where PowerShell is not available
+
+REM Parse command line argument
+set "TARGET=%~1"
+if "!TARGET!"=="" set "TARGET=latest"
+
+REM Validate target parameter
+if /i "!TARGET!"=="stable" goto :target_valid
+if /i "!TARGET!"=="latest" goto :target_valid
+echo !TARGET! | findstr /r "^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*" >nul
+if !ERRORLEVEL! equ 0 goto :target_valid
+
+echo Usage: %0 [stable^|latest^|VERSION] >&2
+echo Example: %0 1.0.58 >&2
+exit /b 1
+
+:target_valid
+
+REM Check for 64-bit Windows
+if /i "%PROCESSOR_ARCHITECTURE%"=="AMD64" goto :arch_valid
+if /i "%PROCESSOR_ARCHITECTURE%"=="ARM64" goto :arch_valid
+if /i "%PROCESSOR_ARCHITEW6432%"=="AMD64" goto :arch_valid
+if /i "%PROCESSOR_ARCHITEW6432%"=="ARM64" goto :arch_valid
+
+echo Claude Code does not support 32-bit Windows. Please use a 64-bit version of Windows. >&2
+exit /b 1
+
+:arch_valid
+
+REM Set constants
+set "DOWNLOAD_BASE_URL=https://downloads.claude.ai/claude-code-releases"
+set "DOWNLOAD_DIR=%USERPROFILE%\.claude\downloads"
+REM Use native ARM64 binary on ARM64 Windows, x64 otherwise
+if /i "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+    set "PLATFORM=win32-arm64"
+) else (
+    set "PLATFORM=win32-x64"
+)
+
+REM Create download directory
+if not exist "!DOWNLOAD_DIR!" mkdir "!DOWNLOAD_DIR!"
+
+REM Check for curl availability
+curl --version >nul 2>&1
+if !ERRORLEVEL! neq 0 (
+    echo curl is required but not available. Please install curl or use PowerShell installer. >&2
+    exit /b 1
+)
+
+REM Always download latest version (which has the most up-to-date installer)
+call :download_file "!DOWNLOAD_BASE_URL!/latest" "!DOWNLOAD_DIR!\latest"
+if !ERRORLEVEL! neq 0 (
+    echo Failed to get latest version >&2
+    exit /b 1
+)
+
+REM Reject non-version content (e.g. an HTML error page) before it reaches the manifest URL
+findstr /r "^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*" "!DOWNLOAD_DIR!\latest" >nul
+if !ERRORLEVEL! neq 0 (
+    del "!DOWNLOAD_DIR!\latest"
+    echo Failed to get a valid version from downloads.claude.ai - got unexpected content. >&2
+    echo This can happen if the download service is unreachable or not available in your region - see https://www.anthropic.com/supported-countries >&2
+    exit /b 1
+)
+
+REM Read version from file
+set /p VERSION=<"!DOWNLOAD_DIR!\latest"
+del "!DOWNLOAD_DIR!\latest"
+
+REM Download manifest
+call :download_file "!DOWNLOAD_BASE_URL!/!VERSION!/manifest.json" "!DOWNLOAD_DIR!\manifest.json"
+if !ERRORLEVEL! neq 0 (
+    echo Failed to get manifest >&2
+    exit /b 1
+)
+
+REM Extract checksum from manifest
+call :parse_manifest "!DOWNLOAD_DIR!\manifest.json" "!PLATFORM!"
+if !ERRORLEVEL! neq 0 (
+    echo Platform !PLATFORM! not found in manifest >&2
+    del "!DOWNLOAD_DIR!\manifest.json" 2>nul
+    exit /b 1
+)
+del "!DOWNLOAD_DIR!\manifest.json"
+
+REM Download binary
+set "BINARY_PATH=!DOWNLOAD_DIR!\claude-!VERSION!-!PLATFORM!.exe"
+call :download_file "!DOWNLOAD_BASE_URL!/!VERSION!/!PLATFORM!/claude.exe" "!BINARY_PATH!"
+if !ERRORLEVEL! neq 0 (
+    echo Failed to download binary >&2
+    if exist "!BINARY_PATH!" del "!BINARY_PATH!"
+    exit /b 1
+)
+
+REM Verify checksum
+call :verify_checksum "!BINARY_PATH!" "!EXPECTED_CHECKSUM!"
+if !ERRORLEVEL! neq 0 (
+    echo Checksum verification failed >&2
+    del "!BINARY_PATH!"
+    exit /b 1
+)
+
+REM Run claude install to set up launcher and shell integration
+echo Setting up Claude Code...
+"!BINARY_PATH!" install "!TARGET!"
+set "INSTALL_RESULT=!ERRORLEVEL!"
+
+REM Clean up downloaded file
+REM Wait a moment for any file handles to be released
+timeout /t 1 /nobreak >nul 2>&1
+del /f "!BINARY_PATH!" >nul 2>&1
+if exist "!BINARY_PATH!" (
+    echo Warning: Could not remove temporary file: !BINARY_PATH!
+)
+
+if !INSTALL_RESULT! neq 0 (
+    echo Installation failed >&2
+    exit /b 1
+)
+
+echo.
+echo Installation complete^^!
+echo.
+exit /b 0
+
+REM ============================================================================
+REM SUBROUTINES
+REM ============================================================================
+
+:download_file
+REM Downloads a file using curl
+REM Args: %1=URL, %2=OutputPath
+set "URL=%~1"
+set "OUTPUT=%~2"
+
+curl -fsSL "!URL!" -o "!OUTPUT!"
+exit /b !ERRORLEVEL!
+
+:parse_manifest
+REM Parse JSON manifest to extract checksum for platform
+REM Args: %1=ManifestPath, %2=Platform
+set "MANIFEST_PATH=%~1"
+set "PLATFORM_NAME=%~2"
+set "EXPECTED_CHECKSUM="
+
+REM Use findstr to find platform section, then look for checksum
+set "FOUND_PLATFORM="
+set "IN_PLATFORM_SECTION="
+
+REM Read the manifest line by line
+for /f "usebackq tokens=*" %%i in ("!MANIFEST_PATH!") do (
+    set "LINE=%%i"
+    
+    REM Check if this line contains our platform
+    echo !LINE! | findstr /c:"\"%PLATFORM_NAME%\":" >nul
+    if !ERRORLEVEL! equ 0 (
+        set "IN_PLATFORM_SECTION=1"
+    )
+    
+    REM If we're in the platform section, look for checksum
+    if defined IN_PLATFORM_SECTION (
+        echo !LINE! | findstr /c:"\"checksum\":" >nul
+        if !ERRORLEVEL! equ 0 (
+            REM Extract checksum value
+            for /f "tokens=2 delims=:" %%j in ("!LINE!") do (
+                set "CHECKSUM_PART=%%j"
+                REM Remove quotes, whitespace, and comma
+                set "CHECKSUM_PART=!CHECKSUM_PART: =!"
+                set "CHECKSUM_PART=!CHECKSUM_PART:"=!"
+                set "CHECKSUM_PART=!CHECKSUM_PART:,=!"
+                
+                REM Check if it looks like a SHA256 (64 hex chars)
+                if not "!CHECKSUM_PART!"=="" (
+                    call :check_length "!CHECKSUM_PART!" 64
+                    if !ERRORLEVEL! equ 0 (
+                        set "EXPECTED_CHECKSUM=!CHECKSUM_PART!"
+                        exit /b 0
+                    )
+                )
+            )
+        )
+        
+        REM Check if we've left the platform section (closing brace)
+        echo !LINE! | findstr /c:"}" >nul
+        if !ERRORLEVEL! equ 0 set "IN_PLATFORM_SECTION="
+    )
+)
+
+if "!EXPECTED_CHECKSUM!"=="" exit /b 1
+exit /b 0
+
+:check_length
+REM Check if string length equals expected length
+REM Args: %1=String, %2=ExpectedLength
+set "STR=%~1"
+set "EXPECTED_LEN=%~2"
+set "LEN=0"
+:count_loop
+if "!STR:~%LEN%,1!"=="" goto :count_done
+set /a LEN+=1
+goto :count_loop
+:count_done
+if %LEN%==%EXPECTED_LEN% exit /b 0
+exit /b 1
+
+:verify_checksum
+REM Verify file checksum using certutil
+REM Args: %1=FilePath, %2=ExpectedChecksum
+set "FILE_PATH=%~1"
+set "EXPECTED=%~2"
+
+for /f "skip=1 tokens=*" %%i in ('certutil -hashfile "!FILE_PATH!" SHA256') do (
+    set "ACTUAL=%%i"
+    set "ACTUAL=!ACTUAL: =!"
+    if "!ACTUAL!"=="CertUtil:Thecommandcompletedsuccessfully." goto :verify_done
+    if "!ACTUAL!" neq "" (
+        if /i "!ACTUAL!"=="!EXPECTED!" (
+            exit /b 0
+        ) else (
+            exit /b 1
+        )
+    )
+)
+
+:verify_done
+exit /b 1

--- a/docs/reference/install-script/claude-code-bootstrap.ps1
+++ b/docs/reference/install-script/claude-code-bootstrap.ps1
@@ -1,0 +1,110 @@
+param(
+    [Parameter(Position=0)]
+    [ValidatePattern('^(stable|latest|\d+\.\d+\.\d+(-[^\s]+)?)$')]
+    [string]$Target = "latest"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = 'SilentlyContinue'
+
+# Check for 32-bit Windows
+if (-not [Environment]::Is64BitProcess) {
+    Write-Error "Claude Code does not support 32-bit Windows. Please use a 64-bit version of Windows."
+    exit 1
+}
+
+$DOWNLOAD_BASE_URL = "https://downloads.claude.ai/claude-code-releases"
+$DOWNLOAD_DIR = "$env:USERPROFILE\.claude\downloads"
+
+# Use native ARM64 binary on ARM64 Windows, x64 otherwise
+if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+    $platform = "win32-arm64"
+} else {
+    $platform = "win32-x64"
+}
+New-Item -ItemType Directory -Force -Path $DOWNLOAD_DIR | Out-Null
+
+# Always download latest version (which has the most up-to-date installer)
+try {
+    $version = Invoke-RestMethod -Uri "$DOWNLOAD_BASE_URL/latest" -ErrorAction Stop
+}
+catch {
+    Write-Error "Failed to get latest version: $_"
+    exit 1
+}
+
+# Reject non-version content (e.g. an HTML error page) before it reaches the manifest URL
+if ($version -notmatch '^\d+\.\d+\.\d+') {
+    Write-Error "Failed to get a valid version from downloads.claude.ai (got unexpected content). This can happen if the download service is unreachable or not available in your region - see https://www.anthropic.com/supported-countries"
+    exit 1
+}
+
+try {
+    $manifest = Invoke-RestMethod -Uri "$DOWNLOAD_BASE_URL/$version/manifest.json" -ErrorAction Stop
+    $checksum = $manifest.platforms.$platform.checksum
+
+    if (-not $checksum) {
+        Write-Error "Platform $platform not found in manifest"
+        exit 1
+    }
+}
+catch {
+    Write-Error "Failed to get manifest: $_"
+    exit 1
+}
+
+# Download and verify
+$binaryPath = "$DOWNLOAD_DIR\claude-$version-$platform.exe"
+try {
+    Invoke-WebRequest -Uri "$DOWNLOAD_BASE_URL/$version/$platform/claude.exe" -OutFile $binaryPath -ErrorAction Stop
+}
+catch {
+    Write-Error "Failed to download binary: $_"
+    if (Test-Path $binaryPath) {
+        Remove-Item -Force $binaryPath
+    }
+    exit 1
+}
+
+# Calculate checksum
+$actualChecksum = (Get-FileHash -Path $binaryPath -Algorithm SHA256).Hash.ToLower()
+
+if ($actualChecksum -ne $checksum) {
+    Write-Error "Checksum verification failed"
+    Remove-Item -Force $binaryPath
+    exit 1
+}
+
+# Run claude install to set up launcher and shell integration
+Write-Output "Setting up Claude Code..."
+try {
+    if ($Target) {
+        & $binaryPath install $Target
+    }
+    else {
+        & $binaryPath install
+    }
+    # Native exit codes don't trigger $ErrorActionPreference - capture explicitly
+    $installExitCode = $LASTEXITCODE
+}
+finally {
+    try {
+        # Clean up downloaded file
+        # Wait a moment for any file handles to be released
+        Start-Sleep -Seconds 1
+        Remove-Item -Force $binaryPath
+    }
+    catch {
+        Write-Warning "Could not remove temporary file: $binaryPath"
+    }
+}
+
+if ($installExitCode -ne 0) {
+    Write-Error "Installation failed (exit code $installExitCode)"
+    exit $installExitCode
+}
+
+Write-Output ""
+Write-Output "$([char]0x2705) Installation complete!"
+Write-Output ""

--- a/docs/reference/install-script/claude-code-bootstrap.sh
+++ b/docs/reference/install-script/claude-code-bootstrap.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -e
+
+# Parse command line arguments
+TARGET="$1"  # Optional target parameter
+
+# Validate target if provided
+if [[ -n "$TARGET" ]] && [[ ! "$TARGET" =~ ^(stable|latest|[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?)$ ]]; then
+    echo "Usage: $0 [stable|latest|VERSION]" >&2
+    exit 1
+fi
+
+DOWNLOAD_BASE_URL="https://downloads.claude.ai/claude-code-releases"
+DOWNLOAD_DIR="$HOME/.claude/downloads"
+
+# Check for required dependencies
+DOWNLOADER=""
+if command -v curl >/dev/null 2>&1; then
+    DOWNLOADER="curl"
+elif command -v wget >/dev/null 2>&1; then
+    DOWNLOADER="wget"
+else
+    echo "Either curl or wget is required but neither is installed" >&2
+    exit 1
+fi
+
+# Check if jq is available (optional)
+HAS_JQ=false
+if command -v jq >/dev/null 2>&1; then
+    HAS_JQ=true
+fi
+
+# Download function that works with both curl and wget
+download_file() {
+    local url="$1"
+    local output="$2"
+    
+    if [ "$DOWNLOADER" = "curl" ]; then
+        if [ -n "$output" ]; then
+            curl -fsSL -o "$output" "$url"
+        else
+            curl -fsSL "$url"
+        fi
+    elif [ "$DOWNLOADER" = "wget" ]; then
+        if [ -n "$output" ]; then
+            wget -q -O "$output" "$url"
+        else
+            wget -q -O - "$url"
+        fi
+    else
+        return 1
+    fi
+}
+
+# Simple JSON parser for extracting checksum when jq is not available
+get_checksum_from_manifest() {
+    local json="$1"
+    local platform="$2"
+    
+    # Normalize JSON to single line and extract checksum
+    json=$(echo "$json" | tr -d '\n\r\t' | sed 's/ \+/ /g')
+    
+    # Extract checksum for platform using bash regex
+    if [[ $json =~ \"$platform\"[^}]*\"checksum\"[[:space:]]*:[[:space:]]*\"([a-f0-9]{64})\" ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    
+    return 1
+}
+
+# Detect platform
+case "$(uname -s)" in
+    Darwin) os="darwin" ;;
+    Linux) os="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) echo "Windows is not supported by this script. See https://code.claude.com/docs for installation options." >&2; exit 1 ;;
+    *) echo "Unsupported operating system: $(uname -s). See https://code.claude.com/docs for supported platforms." >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Detect Rosetta 2 on macOS: if the shell is running as x64 under Rosetta on an ARM Mac,
+# download the native arm64 binary instead of the x64 one
+if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
+    if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+        arch="arm64"
+    fi
+fi
+
+# Check for musl on Linux and adjust platform accordingly
+if [ "$os" = "linux" ]; then
+    if [ -f /lib/libc.musl-x86_64.so.1 ] || [ -f /lib/libc.musl-aarch64.so.1 ] || ldd /bin/ls 2>&1 | grep -q musl; then
+        platform="linux-${arch}-musl"
+    else
+        platform="linux-${arch}"
+    fi
+else
+    platform="${os}-${arch}"
+fi
+mkdir -p "$DOWNLOAD_DIR"
+
+# Always download latest version (which has the most up-to-date installer)
+version=$(download_file "$DOWNLOAD_BASE_URL/latest")
+
+# Reject non-version content (e.g. an HTML error page) before it reaches the manifest URL
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Failed to get a valid version from downloads.claude.ai (got unexpected content)." >&2
+    echo "This can happen if the download service is unreachable or not available in your region - see https://www.anthropic.com/supported-countries" >&2
+    exit 1
+fi
+
+# Download manifest and extract checksum
+manifest_json=$(download_file "$DOWNLOAD_BASE_URL/$version/manifest.json")
+
+# Use jq if available, otherwise fall back to pure bash parsing
+if [ "$HAS_JQ" = true ]; then
+    checksum=$(echo "$manifest_json" | jq -r ".platforms[\"$platform\"].checksum // empty")
+else
+    checksum=$(get_checksum_from_manifest "$manifest_json" "$platform")
+fi
+
+# Validate checksum format (SHA256 = 64 hex characters)
+if [ -z "$checksum" ] || [[ ! "$checksum" =~ ^[a-f0-9]{64}$ ]]; then
+    echo "Platform $platform not found in manifest" >&2
+    exit 1
+fi
+
+# Download and verify
+binary_path="$DOWNLOAD_DIR/claude-$version-$platform"
+if ! download_file "$DOWNLOAD_BASE_URL/$version/$platform/claude" "$binary_path"; then
+    echo "Download failed" >&2
+    rm -f "$binary_path"
+    exit 1
+fi
+
+# Pick the right checksum tool
+if [ "$os" = "darwin" ]; then
+    actual=$(shasum -a 256 "$binary_path" | cut -d' ' -f1)
+else
+    actual=$(sha256sum "$binary_path" | cut -d' ' -f1)
+fi
+
+if [ "$actual" != "$checksum" ]; then
+    echo "Checksum verification failed" >&2
+    rm -f "$binary_path"
+    exit 1
+fi
+
+chmod +x "$binary_path"
+
+# Run claude install to set up launcher and shell integration
+echo "Setting up Claude Code..."
+install_code=0
+"$binary_path" install ${TARGET:+"$TARGET"} || install_code=$?
+
+# Clean up downloaded file
+rm -f "$binary_path"
+
+if [ "$install_code" -ne 0 ]; then
+    # A signal death mid-install kills the binary's TUI with no chance to
+    # restore the terminal, leaving the user's shell in raw mode (typed
+    # characters stop echoing). Restore it before printing anything.
+    if [ "$install_code" -ge 128 ] && [ -t 0 ]; then
+        stty sane 2>/dev/null || true
+    fi
+    # Red when stderr is a terminal, so the explanation stands out from the
+    # surrounding install output; plain when piped or captured
+    red="" reset=""
+    if [ -t 2 ]; then
+        red=$'\033[31m'
+        reset=$'\033[0m'
+    fi
+    # Signal deaths (exit code 128+N) print nothing of their own — bash shows
+    # only e.g. "Killed". 137 = SIGKILL, which on Linux is almost always the
+    # kernel OOM killer on small hosts; macOS has no equivalent OOM kill, so
+    # the out-of-memory explanation is Linux-only.
+    if [ "$install_code" -eq 137 ] && [ "$os" = "linux" ]; then
+        echo "${red}Installation was killed before it could finish (exit code 137). This usually means the system ran out of memory.${reset}" >&2
+        echo "${red}Claude Code needs roughly 512MB of free memory to install. Free up memory, then run this script again.${reset}" >&2
+    elif [ "$install_code" -ge 128 ]; then
+        echo "${red}Installation was killed before it could finish (exit code $install_code).${reset}" >&2
+    fi
+    exit "$install_code"
+fi
+
+echo ""
+echo "✅ Installation complete!"
+echo ""


### PR DESCRIPTION
## Summary

- preserve byte-for-byte snapshots of the official Claude Code shell, PowerShell, and CMD bootstrap scripts
- record source URLs, capture date, hashes, channel versions, and the distribution design OpenAlice should study
- link the reference from the docs index and local Runtime owner guide

## Verification

- compared all three files byte-for-byte with the official downloads captured on 2026-07-13
- verified the recorded SHA-256 hashes
- verified local documentation links
- ran `git diff --check`

Runtime tests were not run because this change only adds non-executable third-party reference snapshots and documentation.