### PR TITLE
Harden the guided CLI installer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,8 @@ guides.
 
 Reference notes under `docs/reference/` are non-authoritative research
 material. The [installer script note](reference/install-script/README.md)
-records upstream links and design lessons without vendoring third-party code.
+records Claude Code and Codex upstream links and design lessons without
+vendoring third-party code.
 
 ## Maintenance Rule
 

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -37,15 +37,18 @@ The current installer distributes the small JavaScript CLI from the `dev` ref:
 curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
 ```
 
-The preview requires Node.js 20 or newer. It installs versioned CLI files under
-`~/.openalice/cli-versions/`, writes stable `openalice` and `openalice.cmd`
-launchers under `~/.openalice/bin/`, and offers to add that bin directory to the
-current shell profile. Before changing files, the interactive installer shows
-its source, version, paths, and shell changes, explains what it will not do, and
-requires an explicit `y` confirmation; blank input cancels without writing. It
-does not clone OpenAlice, write application state, or install Electron. The curl
-entry targets macOS, Linux, WSL, and Git Bash;
-native Windows desktop distribution remains the signed Electron installer.
+The preview requires Node.js 20 or newer. It installs immutable,
+content-addressed CLI releases under `~/.openalice/cli-versions/`, atomically
+switches stable `openalice` and `openalice.cmd` launchers under
+`~/.openalice/bin/`, and offers to manage that bin directory in the current
+shell profile. Before changing files, the interactive installer shows its
+source, action, version, paths, shell changes, and PATH conflicts, explains what
+it will not do, and requires an explicit `y` confirmation; blank input cancels
+without writing. Concurrent installs are locked, stale locks are recovered, and
+the downloaded package and staged launcher must execute successfully before
+the visible command changes. It does not clone OpenAlice, write application
+state, or install Electron. The curl entry targets macOS, Linux, WSL, and Git
+Bash; native Windows desktop distribution remains the signed Electron installer.
 
 Unattended environments have no implicit consent. After reviewing the same
 install plan, pass `--yes` explicitly:
@@ -66,6 +69,12 @@ For local installer development:
 
 ```bash
 ./install --source . --version dev --no-modify-path
+```
+
+To inspect exactly what would change without opening a prompt or writing files:
+
+```bash
+./install --source . --version dev --plan
 ```
 
 To experience the real prompt in a clean, offline container and remain in its
@@ -93,6 +102,11 @@ without `@traderalice/desktop`, runs `pnpm build:server`, starts
 `scripts/guardian/prod.mjs` on `127.0.0.1`, and opens the normal UI. If `pnpm`
 is absent but Corepack is available, preparation uses Corepack with the pnpm
 version pinned by the repository.
+
+When an interactive install is run from inside an OpenAlice checkout, the
+installer presents a separate, default-no `Start OpenAlice now?` prompt after
+the CLI is complete. Installation consent never implies service-start consent,
+and `--yes` remains installation-only for automation.
 
 The CLI stays in the foreground and owns the Guardian lifetime. `Ctrl+C` stops
 the local Runtime. A normal second launch reuses an already healthy local URL;
@@ -131,8 +145,9 @@ retryable, and Electron's managed-runtime policy continues to belong to
 [[docs/managed-workspace-runtime.md]].
 
 The [installer script note](reference/install-script/README.md) records the
-external Claude Code bootstrap sources and the distribution boundaries worth
-studying. Upstream scripts remain untracked local reference material.
+Claude Code bootstrap entry points, the open-source Codex installer sources,
+and the distribution boundaries worth studying. Unlicensed upstream snapshots
+remain untracked local reference material.
 
 ## Security and Network Invariants
 
@@ -152,11 +167,12 @@ When this surface changes:
 1. Run the CLI unit and installer tests.
 2. Run `pnpm test:install:docker` locally. It executes the real `curl | bash`
    download path as a non-root user with an empty home and no global pnpm,
-   then verifies repeat installation, version switching, shell PATH changes,
-   and both launchers while the run container has no external network. This is
-   a manual pre-release gate and intentionally does not run in PR CI.
+   then verifies stale-lock recovery, repeat installation, content-addressed
+   version switching, managed shell PATH changes, and both launchers while the
+   run container has no external network. This is a manual pre-release gate and
+   intentionally does not run in PR CI.
 3. Install from `--source` into a temporary install root and execute the
-   installed symlink.
+   installed launcher.
 4. Run `pnpm build:server` and start with an isolated `--home` and test port.
 5. Open the real localhost route and verify the auth contract and Workspace UI.
 6. Run Guardian recovery checks when launcher ownership changes.

--- a/docs/reference/install-script/README.md
+++ b/docs/reference/install-script/README.md
@@ -1,10 +1,11 @@
 # Installer Script Reference
 
 This note keeps the context behind OpenAlice installer design work without
-vendoring Claude Code source. Local script snapshots in this directory are
-ignored by Git and must not be committed or distributed with OpenAlice.
+vendoring third-party installer source. Local unlicensed script snapshots in
+this directory are ignored by Git and must not be committed or distributed
+with OpenAlice.
 
-Official upstream entry points, inspected on 2026-07-13:
+Claude Code upstream entry points, inspected on 2026-07-13:
 
 - Shell: <https://downloads.claude.ai/claude-code-releases/bootstrap.sh>
 - PowerShell: <https://downloads.claude.ai/claude-code-releases/bootstrap.ps1>
@@ -12,6 +13,21 @@ Official upstream entry points, inspected on 2026-07-13:
 - Installation documentation: <https://code.claude.com/docs/en/installation>
 
 At inspection time, `latest` was `2.1.207` and `stable` was `2.1.197`.
+
+Codex is the licensed, inspectable comparison. Its repository is Apache-2.0,
+and the complete installers and their test harness are public:
+
+- Repository and license: <https://github.com/openai/codex>
+- Shell installer: <https://github.com/openai/codex/blob/main/scripts/install/install.sh>
+- PowerShell installer: <https://github.com/openai/codex/blob/main/scripts/install/install.ps1>
+- Shell installer tests: <https://github.com/openai/codex/blob/main/scripts/install/test_install_sh.py>
+
+The useful Codex patterns are immutable release directories, a validated
+staging area, atomic visible-command switching, install locks, stale recovery,
+manager/PATH conflict detection, executable post-install verification, and
+default-no prompts only at meaningful decision points. OpenAlice applies those
+patterns independently to its smaller JavaScript CLI while keeping its more
+explicit pre-install plan and separate start consent.
 
 The useful design boundary is a thin platform-native bootstrap that detects the
 platform, resolves a release, verifies its checksum, and delegates durable
@@ -21,5 +37,6 @@ CLI rather than growing inside curl/PowerShell/CMD scripts.
 
 OpenAlice should independently implement that architecture while preserving
 its visible install plan and explicit consent. Electron remains a separate,
-complete distribution, and release authenticity needs an explicit trust chain
-beyond copying a manifest checksum pattern.
+complete distribution, and release authenticity still needs a signed or
+release-owned checksum trust chain when the preview graduates from raw GitHub
+files to standalone release assets.

--- a/install
+++ b/install
@@ -6,23 +6,50 @@ VERSION="${OPENALICE_VERSION:-dev}"
 SOURCE_DIR=""
 MODIFY_PATH=1
 ASSUME_YES=0
+PLAN_ONLY=0
 INSTALL_ROOT="${OPENALICE_INSTALL_DIR:-${HOME}/.openalice}"
 
 BOLD=""
 DIM=""
 CYAN=""
 GREEN=""
+YELLOW=""
 RED=""
 RESET=""
+
+STAGING=""
+LOCK_DIR=""
+LOCK_HELD=0
+TTY_OPEN=0
+SHELL_LAUNCHER_TEMP=""
+CMD_LAUNCHER_TEMP=""
 
 if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
   BOLD=$'\033[1m'
   DIM=$'\033[2m'
   CYAN=$'\033[36m'
   GREEN=$'\033[32m'
+  YELLOW=$'\033[33m'
   RED=$'\033[31m'
   RESET=$'\033[0m'
 fi
+
+cleanup() {
+  local status=$?
+  [[ -z "$STAGING" ]] || rm -rf "$STAGING"
+  [[ -z "$SHELL_LAUNCHER_TEMP" ]] || rm -f "$SHELL_LAUNCHER_TEMP"
+  [[ -z "$CMD_LAUNCHER_TEMP" ]] || rm -f "$CMD_LAUNCHER_TEMP"
+  if [[ "$LOCK_HELD" -eq 1 && -n "$LOCK_DIR" ]]; then
+    rm -rf "$LOCK_DIR"
+  fi
+  if [[ "$TTY_OPEN" -eq 1 ]]; then
+    exec 3>&- 3<&-
+  fi
+  return "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
 
 die() {
   printf '\n%bError:%b %s\n' "${RED}${BOLD}" "$RESET" "$*" >&2
@@ -35,6 +62,10 @@ step() {
 
 ok() {
   printf '      %b✓%b %s\n' "$GREEN" "$RESET" "$1"
+}
+
+warn() {
+  printf '      %b!%b %s\n' "$YELLOW" "$RESET" "$1"
 }
 
 usage() {
@@ -50,9 +81,141 @@ Options:
   --install-dir <path>  OpenAlice user root (default: ~/.openalice)
   --source <path>       Install CLI files from a local checkout (development)
   --no-modify-path      Do not update the shell profile
+  --plan                Show the install plan and exit without changing files
   -y, --yes             Accept the install plan without an interactive prompt
   -h, --help            Show this help
 EOF
+}
+
+open_tty() {
+  if { exec 3<>/dev/tty; } 2>/dev/null; then
+    TTY_OPEN=1
+    return 0
+  fi
+  return 1
+}
+
+prompt_yes_no() {
+  local message="$1"
+  local reply=""
+
+  while true; do
+    printf '\n%b%s%b [y/N] ' "$BOLD" "$message" "$RESET" >&3
+    if ! IFS= read -r reply <&3; then
+      return 2
+    fi
+    case "$reply" in
+      y|Y|yes|YES|Yes)
+        return 0
+        ;;
+      ""|n|N|no|NO|No)
+        return 1
+        ;;
+      *)
+        printf 'Please answer y or n. Press Enter to choose no.\n' >&3
+        ;;
+    esac
+  done
+}
+
+acquire_install_lock() {
+  local owner=""
+
+  mkdir -p "$INSTALL_ROOT"
+  LOCK_DIR="$INSTALL_ROOT/.cli-install.lock"
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    printf '%s\n' "$$" > "$LOCK_DIR/pid"
+    LOCK_HELD=1
+    return
+  fi
+
+  if [[ -r "$LOCK_DIR/pid" ]]; then
+    IFS= read -r owner < "$LOCK_DIR/pid" || owner=""
+  fi
+  if [[ "$owner" =~ ^[0-9]+$ ]] && kill -0 "$owner" 2>/dev/null; then
+    die "Another OpenAlice CLI installer is running (pid $owner)."
+  fi
+
+  warn "Removing a stale CLI installer lock"
+  rm -rf "$LOCK_DIR"
+  mkdir "$LOCK_DIR" || die "Could not acquire the CLI installer lock at $LOCK_DIR"
+  printf '%s\n' "$$" > "$LOCK_DIR/pid"
+  LOCK_HELD=1
+}
+
+release_install_lock() {
+  if [[ "$LOCK_HELD" -eq 1 ]]; then
+    rm -rf "$LOCK_DIR"
+    LOCK_HELD=0
+  fi
+}
+
+content_id() {
+  local root="$1"
+  shift
+  node - "$root" "$@" <<'NODE'
+const { createHash } = require('node:crypto')
+const { readFileSync } = require('node:fs')
+const { join } = require('node:path')
+
+const [, , root, ...files] = process.argv
+const hash = createHash('sha256')
+for (const file of files) {
+  hash.update(file)
+  hash.update('\0')
+  hash.update(readFileSync(join(root, file)))
+  hash.update('\0')
+}
+process.stdout.write(hash.digest('hex').slice(0, 16))
+NODE
+}
+
+update_path_profile() {
+  local begin_marker="# >>> OpenAlice CLI >>>"
+  local end_marker="# <<< OpenAlice CLI <<<"
+  local temporary="${profile}.openalice.$$"
+
+  mkdir -p "$(dirname "$profile")" || return 1
+  touch "$profile" || return 1
+  awk -v begin="$begin_marker" -v end="$end_marker" -v legacy="$path_line" '
+    $0 == begin { skipping = 1; next }
+    $0 == end { skipping = 0; next }
+    !skipping && $0 != legacy { print }
+  ' "$profile" > "$temporary" || return 1
+  if [[ -s "$temporary" ]]; then
+    printf '\n' >> "$temporary" || return 1
+  fi
+  printf '%s\n%s\n%s\n' "$begin_marker" "$path_line" "$end_marker" >> "$temporary" || return 1
+
+  if [[ -L "$profile" ]]; then
+    command cat "$temporary" > "$profile" || return 1
+    rm -f "$temporary" || return 1
+  else
+    mv -f "$temporary" "$profile" || return 1
+  fi
+}
+
+find_openalice_checkout() {
+  node - "$PWD" <<'NODE'
+const { readFileSync } = require('node:fs')
+const { dirname, join, resolve } = require('node:path')
+
+let current = resolve(process.argv[2])
+while (true) {
+  try {
+    const manifest = JSON.parse(readFileSync(join(current, 'package.json'), 'utf8'))
+    if (manifest?.name === 'open-alice' && manifest?.scripts?.['build:server']) {
+      process.stdout.write(current)
+      process.exit(0)
+    }
+  } catch {
+    // Walking up from an arbitrary install directory normally encounters no manifest.
+  }
+  const parent = dirname(current)
+  if (parent === current) process.exit(1)
+  current = parent
+}
+NODE
 }
 
 while [[ $# -gt 0 ]]; do
@@ -76,6 +239,10 @@ while [[ $# -gt 0 ]]; do
       MODIFY_PATH=0
       shift
       ;;
+    --plan)
+      PLAN_ONLY=1
+      shift
+      ;;
     -y|--yes)
       ASSUME_YES=1
       shift
@@ -92,7 +259,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "$VERSION" == *".."* || ! "$VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+if [[ ${#VERSION} -gt 128 || "$VERSION" == *".."* || ! "$VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
   die "Unsupported version/ref: $VERSION"
 fi
 
@@ -100,7 +267,6 @@ INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
 BIN_DIR="$INSTALL_ROOT/bin"
 VERSIONS_DIR="$INSTALL_ROOT/cli-versions"
 SAFE_VERSION="${VERSION//\//_}"
-DESTINATION="$VERSIONS_DIR/$SAFE_VERSION"
 
 if [[ -n "$SOURCE_DIR" ]]; then
   source_argument="$SOURCE_DIR"
@@ -125,7 +291,7 @@ elif [[ "$path_present" -eq 1 ]]; then
 else
   case "${SHELL:-}" in
     */zsh)
-      profile="$HOME/.zshrc"
+      if [[ "$(uname -s)" == "Darwin" ]]; then profile="$HOME/.zprofile"; else profile="$HOME/.zshrc"; fi
       path_line="export PATH=$quoted_bin:\$PATH"
       ;;
     */bash)
@@ -139,17 +305,22 @@ else
       ;;
   esac
   if [[ -n "$profile" ]]; then
-    shell_setup="Add OpenAlice to $profile"
+    shell_setup="Manage OpenAlice PATH in $profile"
   else
     shell_setup="Manual PATH setup (shell profile not detected)"
   fi
 fi
 
+existing_command="$(command -v openalice 2>/dev/null || true)"
+install_action="Install a new command"
+if [[ -e "$BIN_DIR/openalice" || -e "$BIN_DIR/openalice.cmd" ]]; then
+  install_action="Update the installed command"
+fi
+
 printf '\n%bOpenAlice%b\n' "${BOLD}${CYAN}" "$RESET"
 printf '%bLocal Runtime CLI installer%b\n\n' "$BOLD" "$RESET"
-printf 'This installs the small %bopenalice%b command used to launch a local\n' "$BOLD" "$RESET"
-printf 'OpenAlice checkout in your browser. Nothing will start yet.\n'
-printf '%bIt will not clone a repository, install Electron, start services, or configure credentials.%b\n' "$DIM" "$RESET"
+printf 'Install one small command, then run OpenAlice locally in your browser.\n'
+printf '%bYour checkout, Electron app, credentials, and services stay untouched until you start them yourself.%b\n' "$DIM" "$RESET"
 
 step 1 "Checking your system"
 if ! command -v node >/dev/null 2>&1; then
@@ -181,43 +352,40 @@ else
 fi
 
 printf '\n%bInstall plan%b\n' "$BOLD" "$RESET"
+printf '  %-14s %s\n' "Action" "$install_action"
 printf '  %-14s %s\n' "Source" "$install_source"
 printf '  %-14s %s\n' "Version" "$VERSION"
 printf '  %-14s %s\n' "Install root" "$INSTALL_ROOT"
 printf '  %-14s %s\n' "Command" "$BIN_DIR/openalice"
 printf '  %-14s %s\n' "Shell setup" "$shell_setup"
-if [[ -d "$DESTINATION" ]]; then
-  printf '  %-14s %s\n' "Existing CLI" "Replace the installed $VERSION CLI files"
+if [[ -n "$existing_command" && "$existing_command" != "$BIN_DIR/openalice" ]]; then
+  printf '  %-14s %s\n' "PATH warning" "$existing_command currently resolves first"
+fi
+
+if [[ "$PLAN_ONLY" -eq 1 ]]; then
+  printf '\n%bPlan complete.%b No files were changed.\n\n' "$BOLD" "$RESET"
+  exit 0
 fi
 
 if [[ "$ASSUME_YES" -eq 0 ]]; then
-  if ! { exec 3<>/dev/tty; } 2>/dev/null; then
+  if ! open_tty; then
     printf '\n%bNo interactive terminal is available.%b\n' "${RED}${BOLD}" "$RESET" >&2
     printf 'Review the install plan above, then re-run with %b--yes%b to approve it.\n' "$BOLD" "$RESET" >&2
     exit 2
   fi
-  while true; do
-    printf '\n%bContinue with this install?%b [y/N] ' "$BOLD" "$RESET"
-    if ! IFS= read -r reply <&3; then
-      exec 3>&-
+  confirmation_status=0
+  prompt_yes_no "Continue with this install?" || confirmation_status=$?
+  case "$confirmation_status" in
+    0) ;;
+    1)
+      printf '\nNo changes made. You can run the installer again whenever you are ready.\n'
+      exit 0
+      ;;
+    *)
       printf '\nNo confirmation received. No changes made.\n' >&2
       exit 2
-    fi
-    case "$reply" in
-      y|Y|yes|YES|Yes)
-        break
-        ;;
-      ""|n|N|no|NO|No)
-        exec 3>&-
-        printf '\nNo changes made. You can run the installer again whenever you are ready.\n'
-        exit 0
-        ;;
-      *)
-        printf 'Please answer y or n. Press Enter to cancel.\n'
-        ;;
-    esac
-  done
-  exec 3>&-
+      ;;
+  esac
 fi
 
 FILES=(
@@ -228,9 +396,9 @@ FILES=(
   "src/ssh-connect.mjs"
 )
 
-step 2 "Preparing CLI files"
+step 2 "Downloading the CLI"
+acquire_install_lock
 STAGING="$(mktemp -d "${TMPDIR:-/tmp}/openalice-cli.XXXXXX")"
-trap 'rm -rf "$STAGING"' EXIT
 mkdir -p "$STAGING/bin" "$STAGING/src"
 
 if [[ -n "$SOURCE_DIR" ]]; then
@@ -239,57 +407,125 @@ if [[ -n "$SOURCE_DIR" ]]; then
   done
 else
   for file in "${FILES[@]}"; do
-    curl --fail --silent --show-error --location "$BASE_URL/$file" --output "$STAGING/$file"
+    curl --fail --silent --show-error --location --retry 3 --connect-timeout 15 \
+      "$BASE_URL/$file" --output "$STAGING/$file"
   done
 fi
 ok "CLI files are ready"
 
-step 3 "Verifying the download"
+step 3 "Verifying the CLI"
 chmod +x "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/src/local-start.mjs"
 node --check "$STAGING/src/runtime-client.mjs"
 node --check "$STAGING/src/ssh-connect.mjs"
-ok "JavaScript entry points passed validation"
+
+CLI_VERSION="$(node -e '
+  const manifest = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+  if (manifest.name !== "@traderalice/openalice-cli" || typeof manifest.version !== "string") process.exit(1);
+  process.stdout.write(manifest.version);
+' "$STAGING/package.json")" || die "The downloaded package manifest is not an OpenAlice CLI package"
+STAGED_VERSION="$(node "$STAGING/bin/openalice.mjs" --version)"
+[[ "$STAGED_VERSION" == "$CLI_VERSION" ]] || die "The downloaded CLI did not report its package version"
+CONTENT_ID="$(content_id "$STAGING" "${FILES[@]}")"
+ok "OpenAlice CLI $CLI_VERSION passed validation ($CONTENT_ID)"
 
 step 4 "Installing the command"
 mkdir -p "$BIN_DIR" "$VERSIONS_DIR"
-rm -rf "$DESTINATION"
-mv "$STAGING" "$DESTINATION"
-trap - EXIT
+DESTINATION="$VERSIONS_DIR/${SAFE_VERSION}-${CONTENT_ID}"
+if [[ -e "$DESTINATION" ]]; then
+  if [[ -d "$DESTINATION" && "$(content_id "$DESTINATION" "${FILES[@]}" 2>/dev/null || true)" == "$CONTENT_ID" ]]; then
+    rm -rf "$STAGING"
+    STAGING=""
+    ok "Reusing the already-verified CLI release"
+  else
+    damaged_destination="${DESTINATION}.damaged.$$"
+    warn "Preserving a damaged prior release at $damaged_destination"
+    mv "$DESTINATION" "$damaged_destination"
+    mv "$STAGING" "$DESTINATION"
+    STAGING=""
+  fi
+else
+  mv "$STAGING" "$DESTINATION"
+  STAGING=""
+fi
 
 CLI_ENTRY="$DESTINATION/bin/openalice.mjs"
 printf -v quoted_cli_entry '%q' "$CLI_ENTRY"
-printf '#!/usr/bin/env bash\nexec node %s "$@"\n' "$quoted_cli_entry" > "$BIN_DIR/openalice"
-chmod +x "$BIN_DIR/openalice"
+SHELL_LAUNCHER_TEMP="$BIN_DIR/.openalice.$$.tmp"
+CMD_LAUNCHER_TEMP="$BIN_DIR/.openalice.$$.cmd.tmp"
+printf '#!/usr/bin/env bash\n# OpenAlice CLI launcher\nexec node %s "$@"\n' "$quoted_cli_entry" > "$SHELL_LAUNCHER_TEMP"
+chmod +x "$SHELL_LAUNCHER_TEMP"
 
 WINDOWS_CLI_ENTRY="$CLI_ENTRY"
 if command -v cygpath >/dev/null 2>&1; then
   WINDOWS_CLI_ENTRY="$(cygpath -w "$CLI_ENTRY")"
 fi
 WINDOWS_CLI_ENTRY="${WINDOWS_CLI_ENTRY//%/%%}"
-printf '@echo off\r\nnode "%s" %%*\r\n' "$WINDOWS_CLI_ENTRY" > "$BIN_DIR/openalice.cmd"
+printf '@echo off\r\nrem OpenAlice CLI launcher\r\nnode "%s" %%*\r\n' "$WINDOWS_CLI_ENTRY" > "$CMD_LAUNCHER_TEMP"
 
-if [[ "$MODIFY_PATH" -eq 1 && "$path_present" -eq 0 ]]; then
-  if [[ -n "$profile" ]]; then
-    mkdir -p "$(dirname "$profile")"
-    touch "$profile"
-    if ! grep -Fqx "$path_line" "$profile"; then
-      printf '\n%s\n' "$path_line" >> "$profile"
-    fi
+LAUNCHER_VERSION="$("$SHELL_LAUNCHER_TEMP" --version)"
+[[ "$LAUNCHER_VERSION" == "$CLI_VERSION" ]] || die "The staged OpenAlice launcher is not runnable"
+
+# Both launchers point to an immutable, validated release before either visible
+# command is replaced. A failed update therefore leaves every visible launcher
+# pointing to a complete old or new release rather than a half-written tree.
+mv -f "$CMD_LAUNCHER_TEMP" "$BIN_DIR/openalice.cmd"
+CMD_LAUNCHER_TEMP=""
+mv -f "$SHELL_LAUNCHER_TEMP" "$BIN_DIR/openalice"
+SHELL_LAUNCHER_TEMP=""
+
+path_updated=0
+if [[ "$MODIFY_PATH" -eq 1 && "$path_present" -eq 0 && -n "$profile" ]]; then
+  if update_path_profile; then
+    path_updated=1
+  else
+    rm -f "${profile}.openalice.$$"
+    warn "Could not update $profile; the command is installed and can be added to PATH manually"
   fi
 fi
-ok "Installed $BIN_DIR/openalice"
+
+INSTALLED_VERSION="$("$BIN_DIR/openalice" --version)"
+[[ "$INSTALLED_VERSION" == "$CLI_VERSION" ]] || die "The installed OpenAlice command failed its version check"
+ok "Installed and verified $BIN_DIR/openalice"
+release_install_lock
 
 printf '\n%bOpenAlice CLI is ready.%b\n' "${GREEN}${BOLD}" "$RESET"
 printf '  %-12s %s\n' "Command" "$BIN_DIR/openalice"
-printf '  %-12s %s\n' "Version" "$VERSION"
-if [[ -n "$profile" && "$path_present" -eq 0 ]]; then
-  printf '  %-12s %s\n' "Shell" "Future terminals will load $profile"
+printf '  %-12s %s\n' "CLI version" "$CLI_VERSION"
+printf '  %-12s %s\n' "Source ref" "$VERSION"
+if [[ "$path_updated" -eq 1 ]]; then
+  printf '  %-12s %s\n' "Shell" "Future terminals will load the managed block in $profile"
 fi
 if [[ "$path_present" -eq 0 ]]; then
   printf '\nFor this terminal, run:\n  %s\n' "$current_path_command"
 fi
-printf '\nThen launch from an OpenAlice checkout:\n'
-printf '  cd /path/to/OpenAlice\n'
-printf '  openalice\n\n'
+if [[ -n "$existing_command" && "$existing_command" != "$BIN_DIR/openalice" ]]; then
+  printf '\n%bPATH note:%b this terminal still resolves %s first.\n' "$YELLOW" "$RESET" "$existing_command"
+  printf 'Use %s now, or apply the PATH command above.\n' "$BIN_DIR/openalice"
+fi
+
+checkout=""
+checkout="$(find_openalice_checkout 2>/dev/null || true)"
+if [[ -n "$checkout" ]]; then
+  printf '\n%bReady to launch%b\n' "$BOLD" "$RESET"
+  printf '  Checkout     %s\n' "$checkout"
+  printf '  Local UI     http://127.0.0.1:47331\n'
+  printf '  Runtime      Stays attached to this terminal; Ctrl+C stops it\n'
+  if [[ "$TTY_OPEN" -eq 1 ]]; then
+    start_status=0
+    prompt_yes_no "Start OpenAlice now? Dependency preparation may take a few minutes." || start_status=$?
+    if [[ "$start_status" -eq 0 ]]; then
+      exec 3>&- 3<&-
+      TTY_OPEN=0
+      printf '\nStarting OpenAlice...\n\n'
+      exec "$BIN_DIR/openalice" start "$checkout"
+    fi
+  fi
+  printf '\nStart it when you are ready:\n  cd %q\n  %s\n\n' "$checkout" "$BIN_DIR/openalice"
+else
+  printf '\n%bNext: launch from an OpenAlice checkout%b\n' "$BOLD" "$RESET"
+  printf '  git clone https://github.com/TraderAlice/OpenAlice.git\n'
+  printf '  cd OpenAlice\n'
+  printf '  %s\n\n' "$BIN_DIR/openalice"
+fi

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { access, mkdtemp, rm } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -31,14 +31,35 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
     ], { env: { ...process.env, HOME: home } })
 
     expect(installed.stdout).toContain('Local Runtime CLI installer')
-    expect(installed.stdout).toContain('Nothing will start yet')
+    expect(installed.stdout).toContain('services stay untouched until you start them yourself')
     expect(installed.stdout).toContain('Install plan')
     expect(installed.stdout).toContain('OpenAlice CLI is ready')
-    await expect(access(join(installRoot, 'cli-versions', 'test_ref', 'bin', 'openalice.mjs'))).resolves.toBeUndefined()
+    const releases = await readdir(join(installRoot, 'cli-versions'))
+    expect(releases).toHaveLength(1)
+    expect(releases[0]).toMatch(/^test_ref-[a-f0-9]{16}$/)
+    await expect(access(join(installRoot, 'cli-versions', releases[0], 'bin', 'openalice.mjs'))).resolves.toBeUndefined()
     await expect(access(join(installRoot, 'bin', 'openalice.cmd'))).resolves.toBeUndefined()
 
     const result = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['--version'])
     expect(result.stdout.trim()).toBe('0.2.0')
+  })
+
+  it('can show the complete plan without creating the install root', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-plan-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const installer = join(repositoryRoot, 'install')
+    const result = await execFileAsync('bash', [installer,
+      '--source', repositoryRoot,
+      '--version', 'plan-only',
+      '--install-dir', installRoot,
+      '--no-modify-path',
+      '--plan',
+    ], { env: { ...process.env, HOME: home } })
+
+    expect(result.stdout).toContain('Install plan')
+    expect(result.stdout).toContain('Plan complete')
+    await expect(access(installRoot)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('requires explicit approval when no interactive terminal is available', async () => {
@@ -92,7 +113,31 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
     expect(result.exitCode).toBe(0)
     expect(result.output).toContain('Continue with this install?')
     expect(result.output).toContain('OpenAlice CLI is ready')
+    expect(result.output).toContain('Start OpenAlice now?')
+    expect(result.output).toContain('Start it when you are ready')
     await expect(access(join(installRoot, 'bin', 'openalice'))).resolves.toBeUndefined()
+  })
+
+  it('refuses to race another live installer', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-lock-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const lockDir = join(installRoot, '.cli-install.lock')
+    const installer = join(repositoryRoot, 'install')
+    await mkdir(lockDir, { recursive: true })
+    await writeFile(join(lockDir, 'pid'), `${process.pid}\n`)
+
+    await expect(execFileAsync('bash', [installer,
+      '--source', repositoryRoot,
+      '--version', 'locked',
+      '--install-dir', installRoot,
+      '--no-modify-path',
+      '--yes',
+    ], { env: { ...process.env, HOME: home } })).rejects.toMatchObject({
+      stderr: expect.stringContaining('Another OpenAlice CLI installer is running'),
+    })
+
+    await expect(access(join(installRoot, 'bin', 'openalice'))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })
 
@@ -111,6 +156,7 @@ function runInstallerInPty(args, { home, reply }) {
     })
     let output = ''
     let replied = false
+    let declinedStart = false
     const timeout = setTimeout(() => {
       terminal.kill()
       rejectPromise(new Error(`installer PTY timed out:\n${output}`))
@@ -121,6 +167,10 @@ function runInstallerInPty(args, { home, reply }) {
       if (!replied && output.includes('Continue with this install?')) {
         replied = true
         terminal.write(reply)
+      }
+      if (!declinedStart && output.includes('Start OpenAlice now?')) {
+        declinedStart = true
+        terminal.write('n\r')
       }
     })
     terminal.onExit(({ exitCode, signal }) => {

--- a/scripts/install-smoke/interactive.sh
+++ b/scripts/install-smoke/interactive.sh
@@ -42,6 +42,7 @@ fi
 printf '\n[install-playground] You are now in the container after the installer.\n'
 printf 'Try: command -v openalice; openalice --version; cat ~/.bashrc\n'
 printf 'Re-run: curl -fsSL "$OPENALICE_INSTALL_URL" | bash\n'
+printf 'Preview only: curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan\n'
 printf 'After a successful re-run: source ~/.bashrc\n'
 printf 'Leave: exit\n\n'
 export PS1='openalice-install> '

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -52,6 +52,8 @@ install_version() {
   curl -fsSL "$installer_url" | bash -s -- --yes --version "$version"
 }
 
+mkdir -p "$HOME/.openalice/.cli-install.lock"
+printf '99999999\n' > "$HOME/.openalice/.cli-install.lock/pid"
 install_version smoke-v1
 
 bin_dir="$HOME/.openalice/bin"
@@ -59,24 +61,31 @@ versions_dir="$HOME/.openalice/cli-versions"
 [[ "$($bin_dir/openalice --version)" == "0.2.0" ]] || fail "installed CLI version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"
 [[ -f "$bin_dir/openalice.cmd" ]] || fail "Windows launcher was not installed"
-[[ -f "$versions_dir/smoke-v1/bin/openalice.mjs" ]] || fail "versioned CLI entry was not installed"
-cmp /fixture/packages/cli/src/local-start.mjs "$versions_dir/smoke-v1/src/local-start.mjs" \
+[[ ! -e "$HOME/.openalice/.cli-install.lock" ]] || fail "installer lock was not released"
+v1_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v1-*' -print -quit)"
+[[ -n "$v1_release" && -f "$v1_release/bin/openalice.mjs" ]] || fail "content-addressed CLI release was not installed"
+cmp /fixture/packages/cli/src/local-start.mjs "$v1_release/src/local-start.mjs" \
   || fail "downloaded CLI file differs from the fixture"
 
 expected_path_line="export PATH=$HOME/.openalice/bin:\$PATH"
 path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
 [[ "$path_count" == "1" ]] || fail "installer did not add exactly one shell PATH entry"
+[[ "$(grep -Fxc '# >>> OpenAlice CLI >>>' "$HOME/.bashrc" || true)" == "1" ]] \
+  || fail "installer did not add its managed PATH block"
 
 install_version smoke-v1
 path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
 [[ "$path_count" == "1" ]] || fail "repeat install duplicated the shell PATH entry"
+v1_count="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v1-*' | wc -l | tr -d ' ')"
+[[ "$v1_count" == "1" ]] || fail "repeat install duplicated an identical CLI release"
 
 install_version smoke-v2
-[[ -d "$versions_dir/smoke-v1" ]] || fail "version switch removed the previous CLI"
-[[ -d "$versions_dir/smoke-v2" ]] || fail "version switch did not install the new CLI"
+v2_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v2-*' -print -quit)"
+[[ -d "$v1_release" ]] || fail "version switch removed the previous CLI"
+[[ -n "$v2_release" && -d "$v2_release" ]] || fail "version switch did not install the new CLI"
 version_count="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
 [[ "$version_count" == "2" ]] || fail "unexpected number of installed CLI versions: $version_count"
-grep -Fq "$versions_dir/smoke-v2/bin/openalice.mjs" "$bin_dir/openalice" \
+grep -Fq "$v2_release/bin/openalice.mjs" "$bin_dir/openalice" \
   || fail "stable launcher did not switch to the latest install"
 [[ "$($bin_dir/openalice --version)" == "0.2.0" ]] || fail "switched CLI is not runnable"
 


### PR DESCRIPTION
## Summary
- keep the explicit install plan and default-no consent while adding a separate optional localhost start prompt
- install validated content-addressed CLI releases behind atomically replaced launchers with lock and stale-lock recovery
- manage PATH through an idempotent marked block, surface conflicts, and add plan-only/manual smoke coverage
- record the open-source Codex installer reference without vendoring third-party code

## Verification
- `bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh`
- `git diff --check`
- `npx tsc --noEmit`
- `pnpm test` (2783 passed, 6 skipped)
- `pnpm -F @traderalice/openalice-cli test` (19 passed)
- `pnpm test:install:docker`
- `pnpm test:install:docker --interactive` with install approval, command/version checks, and PATH block inspection
- `pnpm build:server`
- installed from `--source`, started an isolated Runtime on `127.0.0.1:41937`, checked `/api/auth/status` and the real root page, then stopped it cleanly

## Boundary touch
- local CLI installer and localhost bootstrap only
- no Electron packaging, signing, credentials, trading, migrations, or public listener changes
