### PR TITLE
Document the CLI installer contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ Add checks according to the touched surface:
 | Workspace issues, schedules, headless dispatch | Follow [Workspace issues and scheduling](docs/workspace-issues-and-scheduling.md) |
 | Guardian locks, process ownership, takeover | `pnpm test:guardian-recovery`; exercise the real launcher path |
 | Desktop, IPC, PTY, managed Pi, shell, packaging | Follow [Managed Workspace runtime](docs/managed-workspace-runtime.md) and run the matching Electron/package smoke |
+| Root installer or distributed CLI payload | Follow [CLI installer](docs/cli-installer.md) and run `pnpm test:install:docker`; manually walk the interactive playground before release |
 | Docker/server image, Compose, remote deployment | Follow [Docker deployment](docs/docker-deployment.md) and run `pnpm docker:smoke`; before release, opt into the credentialed agent/CLI check documented there |
 | Persisted data shape | Add an idempotent migration + spec, register it, then run `pnpm build:migration-index` |
 | Onboarding/first run/auth | Use isolated data; exercise dev and packaged onboarding paths where relevant |
@@ -164,8 +165,10 @@ Read the relevant guide before editing its subsystem:
   delivery modes, promotions, external contributions, and risk gates.
 - [[docs/managed-workspace-runtime.md]] — [Managed Workspace runtime](docs/managed-workspace-runtime.md): Electron
   packaging, managed Pi, PortableGit/Bash, runtime profiles, and Workspace PATH.
-- [[docs/local-runtime.md]] — [Local Runtime and CLI bootstrap](docs/local-runtime.md): curl-installed
-  CLI, source-backed localhost startup, dependency bootstrap, and the headless bundle boundary.
+- [[docs/cli-installer.md]] — [CLI installer](docs/cli-installer.md): consent, installed layout,
+  atomic updates, PATH integration, installer tests, and release checks.
+- [[docs/local-runtime.md]] — [Local Runtime and CLI bootstrap](docs/local-runtime.md): source-backed
+  localhost startup, dependency bootstrap, Runtime ownership, and the headless bundle boundary.
 - [[docs/docker-deployment.md]] — [Docker deployment](docs/docker-deployment.md): server image topology,
   remote-host safety, persistence, health, and container acceptance.
 - [[docs/remote-access.md]] — [Remote access](docs/remote-access.md): SSH tunnel experiment,

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@ GitHub navigation.
 | [[docs/project-structure.md]] | [Project structure](project-structure.md) | Process boundaries, source ownership, state roots, architectural entry points |
 | [[docs/development-workflow.md]] | [Development workflow](development-workflow.md) | Branches, delivery modes, PRs, promotions, external review, risk gates |
 | [[docs/managed-workspace-runtime.md]] | [Managed Workspace runtime](managed-workspace-runtime.md) | Electron packaging, managed Pi, PortableGit/Bash, runtime profile, Workspace PATH |
-| [[docs/local-runtime.md]] | [Local Runtime and CLI bootstrap](local-runtime.md) | Curl-installed CLI, source-backed localhost startup, dependency bootstrap, and headless bundle boundary |
+| [[docs/cli-installer.md]] | [CLI installer](cli-installer.md) | Bootstrap consent, installed layout, atomic updates, PATH integration, installer tests, and release checks |
+| [[docs/local-runtime.md]] | [Local Runtime and CLI bootstrap](local-runtime.md) | Source-backed localhost startup, dependency bootstrap, Runtime ownership, and headless bundle boundary |
 | [[docs/docker-deployment.md]] | [Docker deployment](docker-deployment.md) | Server image topology, remote-host safety, persistence, health, and container acceptance |
 | [[docs/remote-access.md]] | [Remote access](remote-access.md) | SSH tunnel experiment, local/remote ownership, and staged remote-control boundaries |
 | [[docs/connector-service.md]] | [Connector Service](connector-service.md) | Optional Discord/Telegram Inbox projection, adapters, secrets, health, Guardian lifecycle |

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -1,0 +1,447 @@
+# CLI Installer
+
+This guide owns the OpenAlice CLI installer contract: bootstrap behavior,
+interactive consent, installed layout, update safety, PATH integration,
+platform boundaries, verification, and release checks. Update it whenever the
+root `install` script, the distributed CLI file set, or installer smoke changes.
+
+Related guides: [[docs/local-runtime.md]],
+[[docs/managed-workspace-runtime.md]], and
+[[docs/development-workflow.md]]. External installer research is deliberately
+non-authoritative and lives in
+[[docs/reference/install-script/README.md]].
+
+## Product Boundary
+
+The installer makes one small `openalice` command available. It does not:
+
+- clone the OpenAlice repository;
+- install or modify Electron;
+- start Alice, UTA, Connector Service, or a browser before separate consent;
+- configure credentials or native agent CLIs;
+- expose a public listener;
+- remove user data during an update.
+
+The current browser-local distribution remains source-backed:
+
+```text
+curl installer
+  └── installed openalice CLI
+        └── user-owned OpenAlice checkout
+              └── localhost Runtime
+```
+
+The install script targets macOS, Linux, WSL, and Git Bash. Native Windows
+desktop distribution remains the complete Electron installer. A future native
+PowerShell bootstrap may reuse the same installer contract, but it must not
+weaken or silently replace the Electron lane.
+
+## Current Entry Point
+
+The preview installer is served directly from the `dev` branch:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
+```
+
+It requires Node.js 20 or newer. The default source ref is `dev`, the default
+install root is `~/.openalice`, and the downloaded payload is the file set
+declared by `FILES` in the root `install` script.
+
+The preview URL is not yet a stable release channel. Do not present a mutable
+`dev` ref as a signed or immutable release. A stable installer needs release
+assets and a release-owned authenticity chain; see
+[Authenticity boundary](#authenticity-boundary).
+
+## Load-Bearing Files
+
+- `install` — user-facing Bash bootstrap and durable install transaction.
+- `packages/cli/package.json` — CLI version, engine requirement, bin entry, and
+  published file list.
+- `packages/cli/bin/openalice.mjs` — installed command entry point.
+- `packages/cli/src/install.spec.mjs` — plan, consent, PTY, layout, and live-lock
+  contract tests.
+- `scripts/install-docker-smoke.mjs` — local Docker acceptance runner.
+- `scripts/install-smoke/` — clean user, local HTTP fixture, automated smoke,
+  and manual playground.
+- `docs/local-runtime.md` — behavior after the installed command starts a
+  source-backed localhost Runtime.
+- `docs/reference/install-script/README.md` — Claude Code and Codex research;
+  useful context, not OpenAlice truth.
+
+When a new runtime file is imported by the installed CLI, update all of the
+following together:
+
+1. `packages/cli/package.json` `files`;
+2. `FILES` in `install`;
+3. syntax or runtime validation in `install`;
+4. installer tests and Docker fixture assertions as needed.
+
+Leaving those lists out of sync produces an installer that validates locally
+but fails only after the downloaded command imports a missing file.
+
+## Installation Transaction
+
+The durable sequence is:
+
+```text
+preflight
+  -> visible install plan
+  -> explicit consent
+  -> installer lock
+  -> download or local copy into staging
+  -> syntax, manifest, and executable validation
+  -> content identity
+  -> immutable release directory
+  -> validate temporary launchers
+  -> atomically replace visible launchers
+  -> best-effort managed PATH update
+  -> verify installed command
+  -> release lock
+  -> optional, separate localhost start prompt
+```
+
+Nothing under the install root is created before the install plan is approved.
+The `--plan` path exits immediately after preflight and the plan.
+
+### Preflight and plan
+
+Preflight validates:
+
+- the requested Git ref syntax and length;
+- Node.js availability and major version;
+- `curl` for remote installs, or CLI sources for `--source` installs;
+- target paths and shell-profile choice;
+- whether another `openalice` currently resolves earlier on `PATH`.
+
+The visible plan includes action, source, ref, install root, command path, shell
+change, and any PATH conflict. A check that only reads the system may happen
+before consent; no installer-owned filesystem mutation may happen there.
+
+### Consent contract
+
+| Invocation | Required behavior |
+|---|---|
+| Interactive default | Ask `Continue with this install? [y/N]`; only an explicit `y` proceeds |
+| Blank or `n` | Exit successfully without changing files |
+| No TTY and no `--yes` | Exit with code 2 before creating the install root |
+| `--yes` | Approve installation only; never start the Runtime |
+| `--plan` | Print the same plan and exit without opening a prompt or changing files |
+| Interactive install inside a checkout | After success, separately ask `Start OpenAlice now? [y/N]` |
+
+The installer reads prompts from `/dev/tty`, not the curl pipe. Both prompts are
+default-no. Installation consent and service-start consent are intentionally
+different decisions.
+
+### Lock and staging
+
+After consent, the installer acquires:
+
+```text
+<install-root>/.cli-install.lock/pid
+```
+
+A live PID blocks a concurrent installer. A lock without a live owner is
+treated as stale and recovered. Cleanup releases a lock owned by the current
+installer and removes temporary staging or launcher files.
+
+Downloads first land in a temporary `openalice-cli.*` directory outside the
+visible command path. A failed or interrupted download therefore leaves the
+previous installed command untouched.
+
+### Validation and content identity
+
+Before a release becomes visible, the installer:
+
+1. runs `node --check` on every JavaScript entry;
+2. verifies that `package.json` names `@traderalice/openalice-cli` and carries a
+   string version;
+3. executes the staged CLI with `--version` and compares its result with the
+   package manifest;
+4. hashes the ordered payload filenames and bytes with SHA-256 and uses the
+   first 16 hex characters as its content identity.
+
+The resulting directory is:
+
+```text
+<install-root>/cli-versions/<safe-ref>-<content-id>/
+```
+
+Installing identical content for the same ref reuses the existing directory.
+If a directory claims that identity but its files no longer hash correctly, it
+is preserved as `<release>.damaged.<pid>` and replaced with the validated
+staging tree. The installer does not silently destroy the damaged evidence.
+
+### Atomic visible-command switch
+
+The installer writes temporary `openalice` and `openalice.cmd` launchers in the
+target bin directory. Both point to the complete immutable release. It executes
+the temporary shell launcher before replacing either visible command, then
+moves the launchers into place within the same directory.
+
+This gives updates a simple safety property: a visible launcher points to the
+complete old release or the complete new release, never to a half-written
+replacement tree. The final installed launcher is executed again with
+`--version` before success is reported.
+
+Old content-addressed releases are retained. There is currently no automatic
+garbage collection, rollback command, or CLI-only uninstall command.
+
+## Installed Layout
+
+With the default installer and Runtime roots:
+
+```text
+~/.openalice/
+├── bin/
+│   ├── openalice
+│   └── openalice.cmd
+├── cli-versions/
+│   ├── dev-<content-id>/
+│   └── <older-ref-or-content>/
+├── .cli-install.lock/       # present only while an installer owns it
+├── data/                    # application state, not installer debris
+├── workspaces/              # user work, not installer debris
+├── provider-keys.json       # sensitive user state
+└── sealing.key              # sensitive machine-bound key
+```
+
+The installer root and Runtime `OPENALICE_HOME` independently default to
+`~/.openalice`. The installer does not read an `OPENALICE_HOME` override, and
+`openalice start` does not infer Runtime home from the CLI's install location.
+Either override may therefore diverge intentionally. Their default co-location
+is convenient, but it makes the uninstall boundary critical: never implement
+uninstall as `rm -rf ~/.openalice`.
+
+A future uninstall operation must remove only installer-owned launchers,
+installer-owned CLI releases, its lock, and its marked PATH block. It must
+preserve application data, Workspaces, credentials, keys, backups, and any
+other user-owned state.
+
+## PATH Integration
+
+The installer prepends `<install-root>/bin` through a marked block:
+
+```text
+# >>> OpenAlice CLI >>>
+export PATH=.../bin:$PATH
+# <<< OpenAlice CLI <<<
+```
+
+Profile selection is:
+
+| Shell | Platform | Profile |
+|---|---|---|
+| zsh | macOS | `~/.zprofile` |
+| zsh | other | `~/.zshrc` |
+| bash | macOS | `~/.bash_profile` |
+| bash | other | `~/.bashrc` |
+| fish | all | `~/.config/fish/config.fish` |
+| unknown | all | no automatic change; print manual command |
+
+Repeated installs replace the managed block instead of appending duplicates.
+The migration also removes the exact unmarked PATH line written by the earlier
+preview installer. A symlinked profile is updated through the symlink instead
+of replacing the symlink itself.
+
+PATH integration is non-critical. If profile editing fails, the validated CLI
+remains installed and the user receives the command needed for the current
+shell. The installer never uninstalls a conflicting npm, Homebrew, or other
+`openalice` command automatically; it reports which command currently resolves
+first.
+
+## Options and Environment
+
+Public options:
+
+| Option | Meaning |
+|---|---|
+| `--version <git-ref>` | Select a tag, branch, or commit for remote payloads and the installed source-ref label |
+| `--install-dir <path>` | Override the OpenAlice install/user root |
+| `--no-modify-path` | Install launchers without editing a shell profile |
+| `--plan` | Show the exact plan and make no changes |
+| `-y`, `--yes` | Explicit non-interactive installation consent |
+| `-h`, `--help` | Print installer usage without making changes |
+
+Development-only option:
+
+| Option | Meaning |
+|---|---|
+| `--source <checkout>` | Copy CLI payload files from a local OpenAlice checkout |
+
+Environment inputs:
+
+| Variable | Meaning |
+|---|---|
+| `OPENALICE_VERSION` | Default source ref when `--version` is absent |
+| `OPENALICE_INSTALL_DIR` | Default install root when `--install-dir` is absent |
+| `OPENALICE_INSTALL_BASE_URL` | Override payload base URL for local fixtures and installer tests |
+| `NO_COLOR` | Disable installer color output |
+| `HOME`, `SHELL`, `PATH`, `TERM` | Standard environment used for paths, profile detection, conflicts, and color |
+
+`OPENALICE_INSTALL_BASE_URL` is a test/development seam, not a user-facing
+mirror selector. A real mirror design must define equivalent authenticity and
+version semantics before becoming public API.
+
+## Authenticity Boundary
+
+The current content identity protects update layout and detects accidental or
+local modification. It does not prove who supplied the downloaded files. The
+script is normally fetched from the mutable `dev` URL and then chooses payload
+files from the requested raw GitHub ref. Even when that payload ref is an
+immutable commit, a hash computed by the same downloaded installer is not an
+independent trust anchor.
+
+Do not describe the preview as cryptographically verified. A stable release
+path should establish this chain:
+
+```text
+trusted release metadata
+  -> expected checksum or signature
+  -> downloaded archive
+  -> validated package layout
+  -> installed executable version
+```
+
+The expected checksum must come from release-owned metadata or a signature,
+not from an unsigned manifest downloaded beside the archive. Preserve the
+existing staging, executable validation, immutable placement, and atomic switch
+after that trust chain is added.
+
+## Verification
+
+### Fast local feedback
+
+```bash
+bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh
+pnpm -F @traderalice/openalice-cli test
+```
+
+The unit suite covers:
+
+- installed layout and a runnable launcher;
+- `--plan` no-write behavior;
+- refusal without TTY or `--yes`;
+- blank-input cancellation;
+- explicit interactive approval and separate start refusal;
+- live installer lock rejection.
+
+### Clean Docker acceptance
+
+```bash
+pnpm test:install:docker
+```
+
+The smoke builds a non-root Debian fixture with an empty home, Node and curl,
+no global pnpm, and no external network during the run. A local HTTP server
+exercises the same remote-download branch as `curl | bash`. It verifies:
+
+- unattended refusal before the install root exists;
+- stale-lock recovery and lock cleanup;
+- downloaded payload equality;
+- runnable shell and CMD launchers;
+- idempotent managed PATH configuration;
+- identical-release reuse;
+- ref switching without deleting the prior release.
+
+This is a local pre-release gate. It is intentionally not delegated to PR CI.
+
+### Manual interaction review
+
+```bash
+pnpm test:install:docker --interactive
+```
+
+The playground stops at the real plan and prompt, then leaves the tester in the
+clean container. Review the copy and spacing, approve with an explicit `y`, and
+run at least:
+
+```bash
+command -v openalice
+openalice --version
+cat ~/.bashrc
+curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan
+```
+
+Manual review is required when prompt text, color, progress, profile behavior,
+or next-step guidance changes. A passing non-interactive smoke cannot judge
+whether the installer feels alarming or confusing.
+
+### End-to-end localhost handoff
+
+When installer behavior, the distributed payload, or the optional start handoff
+changes:
+
+1. run `pnpm build:server`;
+2. install from `--source` into a temporary install root;
+3. start the installed CLI with an isolated `--home`, unused port, and
+   `--no-open`;
+4. verify `/api/auth/status` and the real root page;
+5. stop with `Ctrl+C` and confirm the Runtime exits cleanly.
+
+Never use the normal user home or a live broker account for this acceptance.
+Electron smoke is required only when shared dependency topology, managed
+Runtime behavior, PTY behavior, or Electron files also change.
+
+## Release Checklist
+
+Before publishing or promoting a change that affects the installer:
+
+1. Confirm the CLI payload list in `install` and `packages/cli/package.json`
+   still match the imports reachable from `bin/openalice.mjs`.
+2. Confirm the intended source ref and CLI package version. Do not accidentally
+   advertise mutable `dev` as a stable release.
+3. Run the fast installer tests and the full repository-required checks.
+4. Run `pnpm test:install:docker` locally.
+5. Walk `pnpm test:install:docker --interactive` as a human.
+6. Exercise the installed CLI from `--source`; include the localhost handoff if
+   the payload or start boundary changed.
+7. State residual platform and authenticity gaps explicitly. Do not treat an
+   unsigned raw-file preview as release-signing evidence.
+8. Keep Electron signing and notarization in the Electron release lane; the CLI
+   preview must not read those secrets.
+
+For a `dev` to `master` promotion that publishes installer behavior, the local
+Docker installer smoke remains a required manual gate under
+[[docs/development-workflow.md]].
+
+## Troubleshooting
+
+| Symptom | Interpretation and next check |
+|---|---|
+| `No interactive terminal is available` | The installer correctly refused implicit consent; use `--plan`, or review the plan and pass `--yes` intentionally |
+| `Another OpenAlice CLI installer is running` | Check the recorded PID and wait for the live installer; do not delete a lock owned by a live process |
+| `Removing a stale CLI installer lock` | The prior owner no longer exists; the installer recovered before downloading |
+| `PATH warning` or the wrong command runs | Use the printed absolute command, inspect `command -v openalice`, and reload the managed profile block |
+| A `.damaged.<pid>` directory appears | A content-addressed release no longer matched its identity; preserve it for diagnosis while the validated replacement becomes active |
+| CLI installs but localhost startup fails | Installation succeeded; continue with [[docs/local-runtime.md]] and Guardian/runtime diagnostics |
+| Native PowerShell/CMD bootstrap is unavailable | Use the complete Electron installer, WSL, or Git Bash until a reviewed native bootstrap exists |
+
+## Design Decisions and Next Steps
+
+These decisions are intentional:
+
+- localhost-first browser use is the initial CLI distribution contract;
+- Electron remains a complete, independent desktop distribution;
+- installation and service start always require separate consent;
+- optional native agent CLIs and other dependencies are selected in a later,
+  inspectable setup layer, not silently installed by the curl bootstrap;
+- Claude Code installer source may be read as public behavior but is not
+  vendored; Codex's Apache-2.0 installer is the inspectable engineering
+  reference, while OpenAlice keeps an independent implementation;
+- release authenticity must be designed explicitly rather than implied by a
+  locally computed content hash.
+
+Likely follow-up stages, in dependency order:
+
+1. publish an immutable CLI archive with release-owned checksums or signatures;
+2. move durable install logic behind a shared cross-platform core before adding
+   a native PowerShell bootstrap;
+3. add explicit CLI rollback, garbage collection, and surgical uninstall;
+4. replace the source/build requirement with a standalone headless Runtime
+   asset while retaining the same localhost and consent contracts;
+5. layer remote transports around a loopback Runtime rather than opening the
+   Runtime itself to the network.
+
+Do not implement a later stage by weakening the current consent, data ownership,
+loopback, Electron, or authenticity boundaries.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -236,8 +236,9 @@ Before merging a promotion:
 
 - run the normal build/test gates against the full promotion delta;
 - add entry-path, trading, runtime, or package smokes required by included work;
-- run `pnpm test:install:docker` locally when the release publishes the CLI
-  bootstrap installer; this manual gate is intentionally not a PR CI job;
+- follow [[docs/cli-installer.md]] and run `pnpm test:install:docker` locally
+  when the release publishes the CLI bootstrap installer; this manual gate is
+  intentionally not a PR CI job;
 - confirm release metadata/version intent;
 - confirm CI and release workflow triggers still match the branch policy.
 
@@ -325,7 +326,7 @@ to `master` or release, every applicable gate must be complete and green.
 | Persisted data | Idempotent migration + spec + regenerated migration index + backup behavior |
 | Desktop, Guardian, PTY, IPC, managed runtimes | Matching dev/Electron/package smoke on affected platforms |
 | UI/API contracts | Strict UI types, real browser route, and matching demo handler |
-| CLI bootstrap installer | Local `pnpm test:install:docker` against the real download path before release |
+| CLI bootstrap installer | Follow [CLI installer](cli-installer.md); run local `pnpm test:install:docker` against the real download path before release |
 | Public contributor/release workflow | Cross-check `AGENTS.md`, `CONTRIBUTING.md`, and GitHub Actions triggers |
 
 If a required gate cannot run, document the exact residual risk in the PR and

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -1,10 +1,13 @@
 # Local Runtime and CLI Bootstrap
 
-This guide owns the browser-local OpenAlice entry, the small installable CLI,
-and the boundary between dependency bootstrap, source-backed Runtime startup,
-Electron distribution, and later downloadable Runtime bundles.
+This guide owns the browser-local OpenAlice entry after CLI installation and
+the boundary between dependency bootstrap, source-backed Runtime startup,
+Electron distribution, and later downloadable Runtime bundles. Installer
+consent, installed layout, PATH integration, updates, and installer release
+checks belong to [[docs/cli-installer.md]].
 
-Related guides: [[docs/managed-workspace-runtime.md]],
+Related guides: [[docs/cli-installer.md]],
+[[docs/managed-workspace-runtime.md]],
 [[docs/docker-deployment.md]], and [[docs/remote-access.md]].
 
 ## Product Boundary
@@ -37,56 +40,16 @@ The current installer distributes the small JavaScript CLI from the `dev` ref:
 curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
 ```
 
-The preview requires Node.js 20 or newer. It installs immutable,
-content-addressed CLI releases under `~/.openalice/cli-versions/`, atomically
-switches stable `openalice` and `openalice.cmd` launchers under
-`~/.openalice/bin/`, and offers to manage that bin directory in the current
-shell profile. Before changing files, the interactive installer shows its
-source, action, version, paths, shell changes, and PATH conflicts, explains what
-it will not do, and requires an explicit `y` confirmation; blank input cancels
-without writing. Concurrent installs are locked, stale locks are recovered, and
-the downloaded package and staged launcher must execute successfully before
-the visible command changes. It does not clone OpenAlice, write application
-state, or install Electron. The curl entry targets macOS, Linux, WSL, and Git
-Bash; native Windows desktop distribution remains the signed Electron installer.
+The preview requires Node.js 20 or newer. It installs only the small CLI; it
+does not clone OpenAlice, write application state, install Electron, or start a
+service without separate consent. The curl entry targets macOS, Linux, WSL,
+and Git Bash; native Windows desktop distribution remains the signed Electron
+installer. The complete consent, update, filesystem, PATH, authenticity, and
+test contract lives in [[docs/cli-installer.md]].
 
-Unattended environments have no implicit consent. After reviewing the same
-install plan, pass `--yes` explicitly:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install \
-  | bash -s -- --yes
-```
-
-For a pinned tag or commit:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install \
-  | bash -s -- --version <git-ref>
-```
-
-For local installer development:
-
-```bash
-./install --source . --version dev --no-modify-path
-```
-
-To inspect exactly what would change without opening a prompt or writing files:
-
-```bash
-./install --source . --version dev --plan
-```
-
-To experience the real prompt in a clean, offline container and remain in its
-shell afterward for inspection:
-
-```bash
-pnpm test:install:docker --interactive
-```
-
-`OPENALICE_INSTALL_BASE_URL` may point the download branch at a local fixture
-server. It exists for installer development and the release smoke; normal user
-installs should leave it unset.
+Installer flags, non-interactive consent, development seams, the clean Docker
+fixture, and the manual prompt playground are documented only in
+[[docs/cli-installer.md]].
 
 Until release assets include a standalone headless Runtime, users keep an
 OpenAlice source checkout and run the CLI from inside it:
@@ -144,11 +107,6 @@ installer. The same dependency plan must remain inspectable and independently
 retryable, and Electron's managed-runtime policy continues to belong to
 [[docs/managed-workspace-runtime.md]].
 
-The [installer script note](reference/install-script/README.md) records the
-Claude Code bootstrap entry points, the open-source Codex installer sources,
-and the distribution boundaries worth studying. Unlicensed upstream snapshots
-remain untracked local reference material.
-
 ## Security and Network Invariants
 
 - The CLI always sets `OPENALICE_BIND_HOST=127.0.0.1` for local startup.
@@ -164,18 +122,11 @@ remain untracked local reference material.
 
 When this surface changes:
 
-1. Run the CLI unit and installer tests.
-2. Run `pnpm test:install:docker` locally. It executes the real `curl | bash`
-   download path as a non-root user with an empty home and no global pnpm,
-   then verifies stale-lock recovery, repeat installation, content-addressed
-   version switching, managed shell PATH changes, and both launchers while the
-   run container has no external network. This is a manual pre-release gate and
-   intentionally does not run in PR CI.
-3. Install from `--source` into a temporary install root and execute the
-   installed launcher.
-4. Run `pnpm build:server` and start with an isolated `--home` and test port.
-5. Open the real localhost route and verify the auth contract and Workspace UI.
-6. Run Guardian recovery checks when launcher ownership changes.
-7. Run Docker smoke when `scripts/guardian/prod.mjs` changes.
-8. Run Electron PTY/package smoke when dependency topology or shared Runtime
+1. Follow [[docs/cli-installer.md]] when the root installer or distributed CLI
+   payload changes.
+2. Run `pnpm build:server` and start with an isolated `--home` and test port.
+3. Open the real localhost route and verify the auth contract and Workspace UI.
+4. Run Guardian recovery checks when launcher ownership changes.
+5. Run Docker smoke when `scripts/guardian/prod.mjs` changes.
+6. Run Electron PTY/package smoke when dependency topology or shared Runtime
    behavior changes, even though the CLI itself does not package Electron.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -5,7 +5,7 @@ and persistent-state layout. Update it when a top-level subsystem moves or a
 new long-lived process, package, or state root is introduced.
 
 Related guides: [[docs/managed-workspace-runtime.md]],
-[[docs/local-runtime.md]],
+[[docs/cli-installer.md]], [[docs/local-runtime.md]],
 [[docs/docker-deployment.md]],
 [[docs/workspace-lifecycle.md]],
 [[docs/workspace-issues-and-scheduling.md]],


### PR DESCRIPTION
## Summary
- add a dedicated CLI installer owner guide covering consent, transaction safety, installed layout, PATH management, authenticity, troubleshooting, and release gates
- separate installer ownership from the source-backed localhost Runtime guide
- route AGENTS, project structure, development workflow, and the owner-guide index to the new canonical document

## Verification
- installer payload list matches `packages/cli/package.json` and every payload file exists
- touched wikilinks and Markdown links resolve
- `install --help` exposes every documented flag
- `install --plan` leaves the requested install root absent
- `git diff --check`
- `pnpm -F @traderalice/openalice-cli test` (19 passed)

## Boundary touch
- documentation and maintainer guidance only
- no installer, Runtime, Electron, credentials, trading, or persisted-data behavior changes
