### PR TITLE
fix(codex): launch interactive sessions with full access

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -188,6 +188,22 @@ Do not add external-Pi version probing or upgrade UX to preserve flags used by
 the packaged runtime. Compatibility for the packaged app is maintained by
 pinning and upgrading the bundled Pi with the OpenAlice release.
 
+### Codex interactive permissions
+
+OpenAlice launches interactive Codex TUI sessions with explicit
+`--sandbox danger-full-access --ask-for-approval never` arguments. This applies
+to fresh sessions, Quick Chat prompts, and resumed sessions. Launch-time flags
+are intentional: otherwise Codex may inherit a restrictive global or project
+default, silently sandbox the session, and prevent the injected `alice`,
+`alice-workspace`, `alice-uta`, and `traderhub` CLIs from reaching their local
+OpenAlice transport.
+
+Headless Codex remains narrower: it uses `approval_policy=never`, a
+workspace-write sandbox, and explicit loopback network access. That is enough
+for unattended Workspace CLI work without granting an automation run unrelated
+host access. Neither policy bypasses OpenAlice's trading boundary; broker writes
+and their approval rules remain enforced by UTA.
+
 ## Workspace Bootstrap and Skills
 
 Built-in templates run `bootstrap.mjs` on Electron's Node using

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -103,6 +103,10 @@ describe('codexAdapter AI-config', () => {
       },
     })).toEqual([
       'codex',
+      '--sandbox',
+      'danger-full-access',
+      '--ask-for-approval',
+      'never',
       '-c',
       'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
       '-c',
@@ -117,6 +121,10 @@ describe('codexAdapter AI-config', () => {
     };
     expect(codexAdapter.composeCommand([], { cwd: dir, env, resume: 'last' })).toEqual([
       'codex',
+      '--sandbox',
+      'danger-full-access',
+      '--ask-for-approval',
+      'never',
       '-c',
       'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
       '-c',
@@ -126,12 +134,26 @@ describe('codexAdapter AI-config', () => {
     ]);
     expect(codexAdapter.composeCommand([], { cwd: dir, env, resume: { sessionId: 'rollout-id' } })).toEqual([
       'codex',
+      '--sandbox',
+      'danger-full-access',
+      '--ask-for-approval',
+      'never',
       '-c',
       'mcp_servers.openalice.url="http://127.0.0.1:47332/mcp"',
       '-c',
       'mcp_servers.openalice-workspace.url="http://127.0.0.1:47332/mcp/ws-abc"',
       'resume',
       'rollout-id',
+    ]);
+  });
+
+  it('keeps explicit full access when interactive Codex runs without MCP', () => {
+    expect(codexAdapter.composeCommand([], { cwd: dir, env: {} })).toEqual([
+      'codex',
+      '--sandbox',
+      'danger-full-access',
+      '--ask-for-approval',
+      'never',
     ]);
   });
 

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -12,6 +12,12 @@ const CODEX_CONFIG_PATH = '.codex/config.toml';
 const CODEX_ENV_PATH = '.codex/env.json';
 const CODEX_KEY_ENV_NAME = 'OPENALICE_WORKSPACE_KEY';
 const CODEX_PROVIDER_NAME = 'workspace';
+const CODEX_INTERACTIVE_PERMISSION_ARGS = [
+  '--sandbox',
+  'danger-full-access',
+  '--ask-for-approval',
+  'never',
+] as const;
 
 /**
  * OpenAI Codex CLI (Rust rewrite, `codex-cli`).
@@ -72,9 +78,14 @@ export const codexAdapter: CliAdapter = {
   },
 
   /**
-   * Prepends MCP server flags only when OpenAlice's optional MCP server is
-   * enabled. The default tool path is CLI-mode (`alice*` shell commands), so a
-   * workspace must still spawn even when no MCP URL is present.
+   * Every OpenAlice-owned interactive Codex launch explicitly selects full
+   * host access and disables command approvals. Without launch-time flags,
+   * Codex inherits its global/project defaults and can silently start in a
+   * sandbox that blocks the injected `alice*` CLIs from reaching Alice.
+   *
+   * MCP server flags remain optional. The default tool path is CLI-mode
+   * (`alice*` shell commands), so a workspace must still spawn when no MCP URL
+   * is present.
    */
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
     const head = codexMcpHead(ctx);
@@ -431,7 +442,7 @@ export const codexAdapter: CliAdapter = {
 function codexMcpHead(ctx: SpawnContext): string[] {
   const mcpUrl = ctx.env['OPENALICE_MCP_URL'];
   if (!mcpUrl) {
-    return ['codex'];
+    return ['codex', ...CODEX_INTERACTIVE_PERMISSION_ARGS];
   }
   const workspaceId = ctx.env['AQ_WS_ID'];
   if (!workspaceId) {
@@ -439,6 +450,7 @@ function codexMcpHead(ctx: SpawnContext): string[] {
   }
   return [
     'codex',
+    ...CODEX_INTERACTIVE_PERMISSION_ARGS,
     '-c',
     `mcp_servers.openalice.url="${mcpUrl}"`,
     '-c',

--- a/src/workspaces/adapters/interactive-seed.spec.ts
+++ b/src/workspaces/adapters/interactive-seed.spec.ts
@@ -53,6 +53,9 @@ describe('interactive seed — composeCommand initialPrompt', () => {
       const argv = codexAdapter.composeCommand([], ctx({ initialPrompt: PROMPT }));
       expect(argv.slice(-2)).toEqual(['--', PROMPT]);
       expect(argv[0]).toBe('codex');
+      expect(argv).toEqual(expect.arrayContaining([
+        '--sandbox', 'danger-full-access', '--ask-for-approval', 'never',
+      ]));
       expect(argv).not.toContain('exec'); // interactive, NOT headless
     });
 
@@ -94,6 +97,9 @@ describe('interactive seed — composeCommand initialPrompt', () => {
     it('codex resume ignores the prompt', () => {
       const argv = codexAdapter.composeCommand([], ctx({ resume: RESUME, initialPrompt: PROMPT }));
       expect(argv).toContain('resume');
+      expect(argv).toEqual(expect.arrayContaining([
+        '--sandbox', 'danger-full-access', '--ask-for-approval', 'never',
+      ]));
       expect(argv).not.toContain(PROMPT);
     });
     it('opencode resume ignores the prompt', () => {


### PR DESCRIPTION
## Summary
- explicitly launch interactive Codex sessions with `danger-full-access` and approval policy `never`
- cover fresh, Quick Chat, and resume argv paths
- document the separate interactive and headless permission contracts

## Verification
- `pnpm vitest run src/workspaces/adapters/ai-config.spec.ts src/workspaces/adapters/interactive-seed.spec.ts` (64 passed)
- `npx tsc --noEmit`
- `pnpm test` (2784 passed, 6 skipped)
- real Codex 0.144.1 TUI showed `permissions: YOLO mode`
- `pnpm electron:smoke:pty`

## Boundary touch
- Agent runtime / Workspace PTY
- Headless policy and UTA trading approval boundary remain unchanged
