### PR TITLE
feat(reports): support static HTML attachments

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -24,7 +24,7 @@ categories.
   slash-command control plane; ordinary DM text is not ingested.
 - Each adapter serves one owner account/private chat. Group and channel
   broadcasting are out of scope.
-- Inbox `docs` that are Markdown are sent as file attachments, not flattened
+- Inbox `docs` that are Markdown or static HTML reports are sent as file attachments, not flattened
   into the message body. Alice reads the live Workspace file before crossing
   the process boundary; Connector Service never reaches into a Workspace
   itself. The Workspace artifact is never rewritten or given an agent-facing
@@ -32,12 +32,20 @@ categories.
   source encoding and creates a UTF-8-with-BOM delivery copy so locale-sensitive
   mobile viewers do not guess GBK, Big5, Shift-JIS, or a Western legacy charset.
   Source and delivery byte evidence remain separate. One notification carries
-  at most five files of at most 1 MiB each. Missing, oversized, non-Markdown,
+  at most five files of at most 1 MiB each. Missing, oversized, unsupported,
   or path-escaping files remain visible as Inbox/report paths and never block
   the text notification. When an encoding cannot be identified safely, Alice
   sends the original bytes instead of guessing. A skipped or ambiguous
   eligible attachment is logged and leaves bridge health degraded so partial
   or unnormalized delivery is visible to operators.
+- HTML is a presentation asset, not a Connector message format. Adapters send
+  the `.html`/`.htm` file with a `text/html` media type and never inline,
+  translate, or render its contents into the external chat message. OpenAlice
+  previews static HTML in an origin-less sandbox with scripts, forms,
+  navigation, and network disabled; inline CSS, SVG, and data images remain
+  available for self-contained human-facing reports. Markdown remains the
+  default agent-readable work product, while Inbox comments carry the concise
+  summary for both the user and other agents.
 - Session provenance is rendered as a visible `@resumeId` signature. The
   runtime label may accompany it (`pi · @resume-…`) but must never replace it.
 

--- a/services/connector/src/adapters/shared.spec.ts
+++ b/services/connector/src/adapters/shared.spec.ts
@@ -51,21 +51,24 @@ describe('recorded Inbox payload formatting', () => {
     })).toContain('From: pi · @resume-calm-river-12ab')
   })
 
-  it('decodes and verifies Markdown attachments', () => {
-    const content = Buffer.from('# Close scan\n')
+  it.each([
+    ['Markdown', 'close.md', 'text/markdown; charset=utf-8', '# Close scan\n'],
+    ['HTML', 'close.html', 'text/html; charset=utf-8', '<!doctype html><h1>Close scan</h1>\n'],
+  ])('decodes and verifies %s attachments', (_label, filename, mediaType, body) => {
+    const content = Buffer.from(body)
     const decoded = decodeInboxAttachments({
       ...notification,
       attachments: [{
-        filename: 'close.md',
-        mediaType: 'text/markdown; charset=utf-8',
+        filename,
+        mediaType,
         sizeBytes: content.byteLength,
         contentSha256: createHash('sha256').update(content).digest('hex'),
         contentBase64: content.toString('base64'),
       }],
     })
     expect(decoded).toEqual([{
-      filename: 'close.md',
-      mediaType: 'text/markdown; charset=utf-8',
+      filename,
+      mediaType,
       content,
     }])
   })

--- a/src/services/connector-client/index.spec.ts
+++ b/src/services/connector-client/index.spec.ts
@@ -93,6 +93,44 @@ describe('Inbox Connector bridge', () => {
       .toBe('# Close scan\n')
   })
 
+  it('delivers HTML reports as files without flattening their contents into the message', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-connector-html-attachment-'))
+    tempDirs.push(root)
+    await mkdir(join(root, 'research'))
+    const html = '<!doctype html><html><body><h1>Close dashboard</h1></body></html>\n'
+    await writeFile(join(root, 'research', 'close.html'), html)
+    const push = vi.fn(async (_notification: InboxNotification) => undefined)
+    const store = createMemoryInboxStore()
+    attachInboxConnectorBridge(store, {
+      isEnabled: async () => true,
+      push,
+      warn: vi.fn(),
+      resolveWorkspace: () => ({ dir: root }),
+    })
+
+    await store.append({
+      workspaceId: 'ws-1',
+      docs: [{ path: 'research/close.html' }],
+      comments: 'Dashboard attached.',
+    })
+
+    await vi.waitFor(() => expect(push).toHaveBeenCalledOnce())
+    const notification = push.mock.calls[0]?.[0]
+    expect(notification?.body).toBe('Dashboard attached.\n\nReports:\n- research/close.html')
+    expect(notification?.body).not.toContain('Close dashboard')
+    expect(notification?.attachments?.[0]).toMatchObject({
+      filename: 'close.html',
+      mediaType: 'text/html; charset=utf-8',
+      source: {
+        sizeBytes: Buffer.byteLength(html),
+        detectedEncoding: 'UTF-8',
+        detectionConfidence: 100,
+      },
+    })
+    expect(Buffer.from(notification!.attachments![0]!.contentBase64, 'base64').subarray(3).toString('utf8'))
+      .toBe(html)
+  })
+
   it('warns and preserves source bytes when encoding cannot be normalized safely', async () => {
     const root = await mkdtemp(join(tmpdir(), 'openalice-connector-ambiguous-'))
     tempDirs.push(root)

--- a/src/services/connector-client/index.ts
+++ b/src/services/connector-client/index.ts
@@ -10,10 +10,13 @@ import {
   type ConnectorServiceHealth,
   type InboxNotification,
 } from '@traderalice/connector-protocol'
-import type { InboxEntry, IInboxStore } from '../../core/inbox-store.js'
+import type { InboxDoc, InboxEntry, IInboxStore } from '../../core/inbox-store.js'
 import { readConnectorServiceEnabled } from '../../core/connector-config.js'
 import { probeOptionalCarrier } from '../optional-carrier/health.js'
-import { normalizeConnectorMarkdownAttachment } from './text-attachment.js'
+import {
+  normalizeConnectorTextAttachment,
+  type ConnectorTextMediaType,
+} from './text-attachment.js'
 
 export interface ConnectorBridgeHealth {
   enabled: boolean
@@ -182,7 +185,7 @@ export function toNotification(
   }
 }
 
-/** Project Inbox's live Markdown document pointers into bounded, verified file
+/** Project Inbox's live text-report pointers into bounded, verified file
  * bytes before crossing the process boundary. Unsupported or unavailable files
  * remain listed in the text notification and never block the durable Inbox
  * append or the remaining external message. */
@@ -191,11 +194,16 @@ export async function projectInboxAttachments(
   resolveWorkspace: InboxConnectorBridgeDeps['resolveWorkspace'],
   warn: (message: string) => void = () => undefined,
 ): Promise<InboxAttachmentProjection[]> {
-  const markdownDocs = (entry.docs ?? []).filter((doc) => {
+  const reportDocs: Array<{ doc: InboxDoc; mediaType: ConnectorTextMediaType }> = []
+  for (const doc of entry.docs ?? []) {
     const extension = extname(doc.path).toLowerCase()
-    return extension === '.md' || extension === '.markdown'
-  })
-  if (markdownDocs.length === 0 || !resolveWorkspace) return []
+    if (extension === '.md' || extension === '.markdown') {
+      reportDocs.push({ doc, mediaType: 'text/markdown' })
+    } else if (extension === '.html' || extension === '.htm') {
+      reportDocs.push({ doc, mediaType: 'text/html' })
+    }
+  }
+  if (reportDocs.length === 0 || !resolveWorkspace) return []
 
   const workspace = resolveWorkspace(entry.workspaceId)
   if (!workspace) {
@@ -213,7 +221,7 @@ export async function projectInboxAttachments(
 
   const projections: InboxAttachmentProjection[] = []
   const usedNames = new Set<string>()
-  for (const doc of markdownDocs.slice(0, MAX_CONNECTOR_ATTACHMENTS)) {
+  for (const { doc, mediaType } of reportDocs.slice(0, MAX_CONNECTOR_ATTACHMENTS)) {
     try {
       const target = await resolveSafeWorkspaceFile(workspaceRoot, doc.path)
       const info = await stat(target)
@@ -223,7 +231,7 @@ export async function projectInboxAttachments(
       }
       const content = await readFile(target)
       const sourceDigest = createHash('sha256').update(content).digest('hex')
-      const delivery = normalizeConnectorMarkdownAttachment(content)
+      const delivery = normalizeConnectorTextAttachment(content, mediaType)
       if (delivery.warning) warn(`Inbox attachment encoding unchanged (${doc.path}): ${delivery.warning}`)
       if (delivery.content.byteLength > MAX_CONNECTOR_ATTACHMENT_BYTES) {
         throw new Error(`encoding-normalized file exceeds ${MAX_CONNECTOR_ATTACHMENT_BYTES} bytes`)
@@ -251,8 +259,8 @@ export async function projectInboxAttachments(
       warn(`Inbox attachment skipped (${doc.path}): ${message(error)}`)
     }
   }
-  if (markdownDocs.length > MAX_CONNECTOR_ATTACHMENTS) {
-    warn(`Inbox attachment limit reached; skipped ${markdownDocs.length - MAX_CONNECTOR_ATTACHMENTS} file(s)`)
+  if (reportDocs.length > MAX_CONNECTOR_ATTACHMENTS) {
+    warn(`Inbox attachment limit reached; skipped ${reportDocs.length - MAX_CONNECTOR_ATTACHMENTS} file(s)`)
   }
   return projections
 }

--- a/src/services/connector-client/text-attachment.spec.ts
+++ b/src/services/connector-client/text-attachment.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import iconv from 'iconv-lite'
-import { normalizeConnectorMarkdownAttachment } from './text-attachment.js'
+import { normalizeConnectorTextAttachment } from './text-attachment.js'
 
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf])
 
-describe('normalizeConnectorMarkdownAttachment', () => {
+describe('normalizeConnectorTextAttachment', () => {
   it('adds one language-neutral UTF-8 marker without changing Unicode text', () => {
     const markdown = '# 市场 / 市場 / 市場\n\n日本語 · 한국어 · العربية · Русский · Français\n'
-    const result = normalizeConnectorMarkdownAttachment(Buffer.from(markdown, 'utf8'))
+    const result = normalizeConnectorTextAttachment(Buffer.from(markdown, 'utf8'), 'text/markdown')
 
     expect(result).toMatchObject({
       mediaType: 'text/markdown; charset=utf-8',
@@ -20,13 +20,13 @@ describe('normalizeConnectorMarkdownAttachment', () => {
 
   it('keeps an existing UTF-8 BOM singular', () => {
     const source = Buffer.concat([UTF8_BOM, Buffer.from('# Report\n')])
-    const result = normalizeConnectorMarkdownAttachment(source)
+    const result = normalizeConnectorTextAttachment(source, 'text/markdown')
     expect(result.content).toEqual(source)
   })
 
   it('does not trust a UTF-8 BOM when the following bytes are invalid UTF-8', () => {
     const source = Buffer.concat([UTF8_BOM, Buffer.from([0xc3, 0x28])])
-    const result = normalizeConnectorMarkdownAttachment(source)
+    const result = normalizeConnectorTextAttachment(source, 'text/markdown')
 
     expect(result.content).toEqual(source)
     expect(result.warning).toContain('could not be decoded safely')
@@ -40,7 +40,7 @@ describe('normalizeConnectorMarkdownAttachment', () => {
   ] as const)('normalizes BOM-marked %s', (detectedEncoding, sourceEncoding) => {
     const markdown = '# Encoding report\n\nZażółć · 測試 · テスト\n'
     const source = iconv.encode(markdown, sourceEncoding, { addBOM: true })
-    const result = normalizeConnectorMarkdownAttachment(source)
+    const result = normalizeConnectorTextAttachment(source, 'text/markdown')
 
     expect(result.detectedEncoding).toBe(detectedEncoding)
     expect(result.content.subarray(3).toString('utf8')).toBe(markdown)
@@ -54,7 +54,7 @@ describe('normalizeConnectorMarkdownAttachment', () => {
     ['KOI8-R', '# Отчёт рынка\n\nСегодня рынок спокоен, кодировка определяется корректно.\n'],
   ] as const)('normalizes detected legacy %s without locale assumptions', (encoding, markdown) => {
     const source = iconv.encode(markdown, encoding)
-    const result = normalizeConnectorMarkdownAttachment(source)
+    const result = normalizeConnectorTextAttachment(source, 'text/markdown')
 
     expect(result.warning).toBeUndefined()
     expect(result.detectedEncoding).toBe(encoding)
@@ -64,10 +64,19 @@ describe('normalizeConnectorMarkdownAttachment', () => {
 
   it('keeps unrecognizable binary-like bytes intact and reports the ambiguity', () => {
     const source = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x80, 0x81, 0x82, 0x83])
-    const result = normalizeConnectorMarkdownAttachment(source)
+    const result = normalizeConnectorTextAttachment(source, 'text/markdown')
 
     expect(result.content).toEqual(source)
     expect(result.mediaType).toBe('text/markdown')
     expect(result.warning).toContain('could not be determined safely')
+  })
+
+  it('uses the HTML media type without changing the report body', () => {
+    const html = '<!doctype html><html><body><h1>市場</h1></body></html>\n'
+    const result = normalizeConnectorTextAttachment(Buffer.from(html, 'utf8'), 'text/html')
+
+    expect(result.mediaType).toBe('text/html; charset=utf-8')
+    expect(result.content.subarray(0, 3)).toEqual(UTF8_BOM)
+    expect(result.content.subarray(3).toString('utf8')).toBe(html)
   })
 })

--- a/src/services/connector-client/text-attachment.ts
+++ b/src/services/connector-client/text-attachment.ts
@@ -17,6 +17,8 @@ export interface NormalizedTextAttachment {
   warning?: string
 }
 
+export type ConnectorTextMediaType = 'text/markdown' | 'text/html'
+
 /**
  * Normalize an external text attachment without changing the Workspace file.
  *
@@ -27,7 +29,10 @@ export interface NormalizedTextAttachment {
  * are deterministic; legacy encodings use bounded statistical detection and
  * round-trip/text sanity checks before conversion.
  */
-export function normalizeConnectorMarkdownAttachment(source: Buffer): NormalizedTextAttachment {
+export function normalizeConnectorTextAttachment(
+  source: Buffer,
+  mediaType: ConnectorTextMediaType,
+): NormalizedTextAttachment {
   const bomEncoding = detectBomEncoding(source)
   if (bomEncoding) {
     const decoded = decodeWithEncoding(source, bomEncoding)
@@ -35,15 +40,15 @@ export function normalizeConnectorMarkdownAttachment(source: Buffer): Normalized
       ? iconv.encode(decoded, bomEncoding, { addBOM: true })
       : null
     if (decoded !== null && isTextLike(decoded) && roundTrip?.equals(source)) {
-      return normalized(decoded, canonicalEncodingName(bomEncoding), 100)
+      return normalized(decoded, mediaType, canonicalEncodingName(bomEncoding), 100)
     }
-    return unchanged(source, `BOM declared ${bomEncoding}, but the Markdown bytes could not be decoded safely`)
+    return unchanged(source, mediaType, `BOM declared ${bomEncoding}, but the report bytes could not be decoded safely`)
   }
 
   // A UTF-16/32 or binary file can contain only byte values that are legal
   // UTF-8. NUL bytes are therefore routed through the detector first.
   if (!source.includes(0) && isStrictUtf8(source)) {
-    return normalized(source.toString('utf8'), 'UTF-8', 100)
+    return normalized(source.toString('utf8'), mediaType, 'UTF-8', 100)
   }
 
   const candidates = chardet.analyse(source)
@@ -56,26 +61,35 @@ export function normalizeConnectorMarkdownAttachment(source: Buffer): Normalized
       const roundTrip = iconv.encode(decoded, candidate.name)
       if (!roundTrip.equals(source)) continue
     }
-    return normalized(decoded, candidate.name, candidate.confidence)
+    return normalized(decoded, mediaType, candidate.name, candidate.confidence)
   }
 
-  return unchanged(source, 'Markdown attachment encoding could not be determined safely')
+  return unchanged(source, mediaType, 'Report attachment encoding could not be determined safely')
 }
 
-function normalized(text: string, detectedEncoding: string, detectionConfidence: number): NormalizedTextAttachment {
+function normalized(
+  text: string,
+  mediaType: ConnectorTextMediaType,
+  detectedEncoding: string,
+  detectionConfidence: number,
+): NormalizedTextAttachment {
   const withoutBom = text.startsWith('\uFEFF') ? text.slice(1) : text
   return {
     content: Buffer.concat([UTF8_BOM, Buffer.from(withoutBom, 'utf8')]),
-    mediaType: 'text/markdown; charset=utf-8',
+    mediaType: `${mediaType}; charset=utf-8`,
     detectedEncoding,
     detectionConfidence,
   }
 }
 
-function unchanged(source: Buffer, warning: string): NormalizedTextAttachment {
+function unchanged(
+  source: Buffer,
+  mediaType: ConnectorTextMediaType,
+  warning: string,
+): NormalizedTextAttachment {
   return {
     content: source,
-    mediaType: 'text/markdown',
+    mediaType,
     warning,
   }
 }

--- a/ui/src/components/FileContentView.tsx
+++ b/ui/src/components/FileContentView.tsx
@@ -6,15 +6,14 @@
  * same tombstone copy for the `readWorkspaceFile` error variants
  * (missing workspace / missing file / too large / …).
  *
- * `.html` deliberately routes through MarkdownContent for now: marked
- * passes raw HTML through, then DOMPurify sanitises before insertion.
- * Good enough for HTML fragments; a faithful full-document HTML report
- * would want a sandboxed iframe renderer instead — deferred until agents
- * actually emit those.
+ * HTML is a human-facing presentation asset. It uses an isolated static-report
+ * iframe so page-level CSS and SVG render faithfully without joining the
+ * OpenAlice document or gaining script/network privileges.
  */
 
 import type { ReactElement } from 'react'
 
+import { HtmlReportView } from './HtmlReportView'
 import { MarkdownContent } from './MarkdownContent'
 import type { ReadFileResult } from './workspace/api'
 
@@ -35,10 +34,7 @@ function DocBody({ path, content }: { path: string; content: string }): ReactEle
     return <MarkdownContent text={content} />
   }
   if (lower.endsWith('.html') || lower.endsWith('.htm')) {
-    // DOMPurify sanitisation is inside MarkdownContent; for raw HTML we
-    // run it through the markdown renderer too — marked passes HTML
-    // through, then DOMPurify sanitises before insertion.
-    return <MarkdownContent text={content} />
+    return <HtmlReportView path={path} content={content} />
   }
   // Plain-text fallback (.txt, .log, no extension, code files…)
   return (

--- a/ui/src/components/HtmlReportView.spec.tsx
+++ b/ui/src/components/HtmlReportView.spec.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createSandboxedHtmlReportDocument, HtmlReportView } from './HtmlReportView'
+
+afterEach(cleanup)
+
+describe('HtmlReportView', () => {
+  it('keeps static presentation markup while removing active content', () => {
+    const document = createSandboxedHtmlReportDocument(`<!doctype html>
+      <html><head>
+        <style>.metric { color: rebeccapurple }</style>
+        <script>parent.postMessage('owned', '*')</script>
+      </head><body>
+        <h1 class="metric" onclick="alert(1)">Close report</h1>
+        <svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="4" /></svg>
+        <form action="https://example.com"><input name="secret"></form>
+      </body></html>`)
+
+    expect(document).toContain('.metric { color: rebeccapurple }')
+    expect(document).toContain('<svg')
+    expect(document).toContain('Content-Security-Policy')
+    expect(document).not.toContain('<script')
+    expect(document).not.toContain('onclick=')
+    expect(document).not.toContain('<form')
+    expect(document).not.toContain('<input')
+  })
+
+  it('removes external resource and navigation URLs but keeps embedded data', () => {
+    const document = createSandboxedHtmlReportDocument(`
+      <img id="remote" src="https://tracker.example/pixel.png">
+      <img id="embedded" src="data:image/svg+xml;base64,PHN2Zy8+">
+      <a id="external" href="https://example.com">external</a>
+      <a id="local" href="#details">details</a>
+    `)
+    const parsed = new DOMParser().parseFromString(document, 'text/html')
+
+    expect(parsed.querySelector('#remote')?.hasAttribute('src')).toBe(false)
+    expect(parsed.querySelector('#embedded')?.getAttribute('src')).toMatch(/^data:/)
+    expect(parsed.querySelector('#external')?.hasAttribute('href')).toBe(false)
+    expect(parsed.querySelector('#local')?.getAttribute('href')).toBe('#details')
+  })
+
+  it('renders through an origin-less iframe sandbox', () => {
+    render(<HtmlReportView path="research/close.html" content="<h1>Close</h1>" />)
+
+    const frame = screen.getByTitle('HTML report: research/close.html')
+    expect(frame.getAttribute('sandbox')).toBe('')
+    expect(frame.getAttribute('referrerpolicy')).toBe('no-referrer')
+    expect(frame.getAttribute('srcdoc')).toContain('<h1>Close</h1>')
+  })
+})

--- a/ui/src/components/HtmlReportView.tsx
+++ b/ui/src/components/HtmlReportView.tsx
@@ -1,0 +1,117 @@
+/**
+ * Isolated renderer for Agent-authored static HTML reports.
+ *
+ * HTML reports are presentation assets, not trusted application UI. They run
+ * in an origin-less sandbox with no scripts, forms, navigation, or network.
+ * Inline CSS, SVG, and data images remain available so a self-contained report
+ * can keep its intended visual hierarchy without reaching outside OpenAlice.
+ */
+
+import DOMPurify from 'dompurify'
+import { useMemo } from 'react'
+
+const REPORT_CSP = [
+  "default-src 'none'",
+  "base-uri 'none'",
+  "connect-src 'none'",
+  "font-src data:",
+  "form-action 'none'",
+  "frame-src 'none'",
+  "img-src data:",
+  "media-src data:",
+  "object-src 'none'",
+  "script-src 'none'",
+  "style-src 'unsafe-inline'",
+].join('; ')
+
+const REPORT_BASE_STYLE = `
+  html { background: #fff; color: #172033; }
+  body {
+    box-sizing: border-box;
+    margin: 0;
+    min-width: 0;
+    padding: 24px;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+      "Segoe UI", sans-serif;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+  }
+  *, *::before, *::after { box-sizing: inherit; }
+  img, svg, video, canvas { max-width: 100%; height: auto; }
+  table { max-width: 100%; }
+  pre { max-width: 100%; overflow: auto; }
+  @media (max-width: 640px) { body { padding: 16px; } }
+`
+
+const FORBIDDEN_TAGS = [
+  'script',
+  'iframe',
+  'frame',
+  'frameset',
+  'object',
+  'embed',
+  'form',
+  'input',
+  'button',
+  'textarea',
+  'select',
+  'option',
+  'link',
+  'base',
+  'meta',
+] as const
+
+/** Build the exact srcdoc handed to the sandboxed iframe. Exported so the
+ * security contract can be tested without relying on browser iframe loading. */
+export function createSandboxedHtmlReportDocument(source: string): string {
+  const sanitized = DOMPurify.sanitize(source, {
+    WHOLE_DOCUMENT: true,
+    ADD_TAGS: ['style'],
+    FORBID_TAGS: [...FORBIDDEN_TAGS],
+  })
+  const report = new DOMParser().parseFromString(sanitized, 'text/html')
+
+  // DOMPurify removes executable attributes. This second pass owns resource
+  // policy: self-contained reports may use data URLs and in-document anchors,
+  // but must never turn opening an Inbox item into an external request.
+  for (const element of report.querySelectorAll<HTMLElement>('[src], [srcset], [poster], [background]')) {
+    const sourceUrl = element.getAttribute('src')?.trim()
+    if (sourceUrl && !sourceUrl.toLowerCase().startsWith('data:')) element.removeAttribute('src')
+    element.removeAttribute('srcset')
+    element.removeAttribute('poster')
+    element.removeAttribute('background')
+  }
+  for (const element of report.querySelectorAll<HTMLElement>('[href], [xlink\\:href]')) {
+    const href = (element.getAttribute('href') ?? element.getAttribute('xlink:href') ?? '').trim()
+    if (!href.startsWith('#')) {
+      element.removeAttribute('href')
+      element.removeAttribute('xlink:href')
+    }
+  }
+
+  const csp = report.createElement('meta')
+  csp.httpEquiv = 'Content-Security-Policy'
+  csp.content = REPORT_CSP
+  const baseStyle = report.createElement('style')
+  baseStyle.textContent = REPORT_BASE_STYLE
+  report.head.prepend(baseStyle)
+  report.head.prepend(csp)
+
+  return `<!doctype html>\n${report.documentElement.outerHTML}`
+}
+
+export function HtmlReportView({ path, content }: { path: string; content: string }) {
+  const srcDoc = useMemo(() => createSandboxedHtmlReportDocument(content), [content])
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-white shadow-sm">
+      <iframe
+        title={`HTML report: ${path}`}
+        sandbox=""
+        referrerPolicy="no-referrer"
+        srcDoc={srcDoc}
+        className="block h-[min(70vh,720px)] min-h-[420px] w-full border-0 bg-white"
+      />
+    </div>
+  )
+}

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -3,9 +3,9 @@
  * VS Code's editor. Opened from the Tracked backlink list and the
  * workspace Files panel; renders one workspace file read-only.
  *
- * Markdown (`[[name]]` wikilinks included) and HTML route through
- * MarkdownContent; everything else falls back to monospace plain text.
- * Rendering + tombstones are shared with the Inbox doc pane via
+ * Markdown (`[[name]]` wikilinks included) uses MarkdownContent; static HTML
+ * uses the isolated report renderer; everything else falls back to monospace
+ * plain text. Rendering + tombstones are shared with the Inbox doc pane via
  * FileContentView.
  */
 


### PR DESCRIPTION
## Summary
- treat `.html` and `.htm` Inbox docs as report file attachments alongside Markdown
- render static HTML reports in an origin-less sandbox with scripts, network, forms, and navigation disabled
- keep Connector messages concise and send HTML only as a file
- generalize text-attachment encoding normalization and adapter tests

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (2790 passed, 6 skipped)
- `pnpm test:connector-replay`
- `pnpm build`
- `pnpm test:connector-service`
- real browser Inbox smoke at desktop and 390px
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`