### PR TITLE
refactor(reports): standardize on html extension

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -39,7 +39,7 @@ categories.
   eligible attachment is logged and leaves bridge health degraded so partial
   or unnormalized delivery is visible to operators.
 - HTML is a presentation asset, not a Connector message format. Adapters send
-  the `.html`/`.htm` file with a `text/html` media type and never inline,
+  the `.html` file with a `text/html` media type and never inline,
   translate, or render its contents into the external chat message. OpenAlice
   previews static HTML in an origin-less sandbox with scripts, forms,
   navigation, and network disabled; inline CSS, SVG, and data images remain

--- a/src/services/connector-client/index.spec.ts
+++ b/src/services/connector-client/index.spec.ts
@@ -131,6 +131,21 @@ describe('Inbox Connector bridge', () => {
       .toBe(html)
   })
 
+  it('does not treat the legacy .htm extension as an HTML report', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-connector-legacy-htm-'))
+    tempDirs.push(root)
+    await writeFile(join(root, 'legacy.htm'), '<!doctype html><h1>Legacy</h1>')
+
+    const attachments = await projectInboxAttachments({
+      id: 'entry-legacy-htm',
+      ts: Date.now(),
+      workspaceId: 'ws-1',
+      docs: [{ path: 'legacy.htm' }],
+    }, () => ({ dir: root }))
+
+    expect(attachments).toEqual([])
+  })
+
   it('warns and preserves source bytes when encoding cannot be normalized safely', async () => {
     const root = await mkdtemp(join(tmpdir(), 'openalice-connector-ambiguous-'))
     tempDirs.push(root)

--- a/src/services/connector-client/index.ts
+++ b/src/services/connector-client/index.ts
@@ -199,7 +199,7 @@ export async function projectInboxAttachments(
     const extension = extname(doc.path).toLowerCase()
     if (extension === '.md' || extension === '.markdown') {
       reportDocs.push({ doc, mediaType: 'text/markdown' })
-    } else if (extension === '.html' || extension === '.htm') {
+    } else if (extension === '.html') {
       reportDocs.push({ doc, mediaType: 'text/html' })
     }
   }

--- a/ui/src/components/FileContentView.spec.tsx
+++ b/ui/src/components/FileContentView.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { FileContentView } from './FileContentView'
+
+describe('FileContentView', () => {
+  it('renders .html reports in the isolated report viewer', () => {
+    render(<FileContentView path="research/close.html" result={{ kind: 'ok', content: '<h1>Close</h1>' }} />)
+
+    expect(screen.getByTitle('HTML report: research/close.html')).toBeTruthy()
+  })
+
+  it('does not treat the legacy .htm extension as an HTML report', () => {
+    render(<FileContentView path="research/legacy.htm" result={{ kind: 'ok', content: '<h1>Legacy</h1>' }} />)
+
+    expect(screen.queryByTitle('HTML report: research/legacy.htm')).toBeNull()
+    expect(screen.getByText('<h1>Legacy</h1>')).toBeTruthy()
+  })
+})

--- a/ui/src/components/FileContentView.tsx
+++ b/ui/src/components/FileContentView.tsx
@@ -33,7 +33,7 @@ function DocBody({ path, content }: { path: string; content: string }): ReactEle
   if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
     return <MarkdownContent text={content} />
   }
-  if (lower.endsWith('.html') || lower.endsWith('.htm')) {
+  if (lower.endsWith('.html')) {
     return <HtmlReportView path={path} content={content} />
   }
   // Plain-text fallback (.txt, .log, no extension, code files…)


### PR DESCRIPTION
## Summary
- remove legacy `.htm` recognition from OpenAlice report preview
- stop projecting `.htm` Inbox docs as Connector HTML attachments
- document `.html` as the sole HTML report extension
- add regression tests that keep `.htm` outside the report asset contract

## Verification
- `pnpm exec vitest run ui/src/components/FileContentView.spec.tsx src/services/connector-client/index.spec.ts`
- `pnpm exec tsc --noEmit`
- `cd ui && pnpm exec tsc -b`
- `git diff --check`

Previous PR #591 CI was also fully green before this follow-up was published.