### PR TITLE
Refocus the Issues board on work

### DIFF
--- a/ui/src/components/IssuesBoard.spec.tsx
+++ b/ui/src/components/IssuesBoard.spec.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { IssueListItem, IssueSnapshot } from '../api/issues'
+import { IssuesBoard } from './IssuesBoard'
+
+const mocks = vi.hoisted(() => ({
+  useIssues: vi.fn(),
+  openOrFocus: vi.fn(),
+  setSidebar: vi.fn(),
+}))
+
+vi.mock('../hooks/useIssues', () => ({
+  useIssues: () => mocks.useIssues(),
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    agents: [
+      { id: 'pi', displayName: 'Pi', kind: 'agent' },
+      { id: 'claude', displayName: 'Claude Code', kind: 'agent' },
+    ],
+    defaultAgent: 'pi',
+    issueDefaultAgent: null,
+    workspaces: [{ id: 'ws-1', agents: ['pi', 'claude'] }],
+  }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: unknown) => unknown) => selector({
+    openOrFocus: mocks.openOrFocus,
+    setSidebar: mocks.setSidebar,
+  }),
+}))
+
+function issue(overrides: Partial<IssueListItem>): IssueListItem {
+  return {
+    id: 'issue-id',
+    title: 'Issue title',
+    status: 'todo',
+    priority: 'none',
+    assignee: '@workspace',
+    ...overrides,
+  }
+}
+
+function snapshot(issues: IssueListItem[]): IssueSnapshot {
+  return {
+    workspaces: [{ wsId: 'ws-1', tag: 'market-desk', status: 'ok', issues }],
+  }
+}
+
+beforeEach(() => {
+  mocks.useIssues.mockReturnValue({
+    data: snapshot([]),
+    error: null,
+    loading: false,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('IssuesBoard', () => {
+  it('puts work identity first and hides default execution metadata', () => {
+    mocks.useIssues.mockReturnValue({
+      data: snapshot([
+        issue({
+          id: 'daily-close-scan',
+          title: '收盘扫描',
+          priority: 'medium',
+          agent: 'pi',
+          when: { kind: 'cron', cron: '0 5 * * 1-5' },
+          automationHealth: { state: 'healthy', message: 'Latest scheduled run completed.' },
+        }),
+      ]),
+      error: null,
+      loading: false,
+    })
+
+    render(<IssuesBoard />)
+
+    expect(screen.getByText('收盘扫描')).toBeTruthy()
+    expect(screen.getByText('#daily-close-scan')).toBeTruthy()
+    expect(screen.getByText('market-desk')).toBeTruthy()
+    expect(screen.queryByText('@workspace')).toBeNull()
+    expect(screen.queryByText('pi override')).toBeNull()
+
+    const rowText = screen.getByTitle('Open daily-close-scan').textContent ?? ''
+    expect(rowText.indexOf('收盘扫描')).toBeLessThan(rowText.indexOf('Healthy'))
+    expect(rowText.indexOf('Healthy')).toBeLessThan(rowText.indexOf('market-desk'))
+  })
+
+  it('orders operational failures first and exposes only meaningful exceptions', () => {
+    mocks.useIssues.mockReturnValue({
+      data: snapshot([
+        issue({
+          id: 'healthy-high',
+          title: 'Healthy high-priority work',
+          priority: 'high',
+          when: { kind: 'every', every: '1h' },
+          automationHealth: { state: 'healthy', message: 'Latest scheduled run completed.' },
+        }),
+        issue({
+          id: 'failed-low',
+          title: 'Failed scheduled work',
+          priority: 'low',
+          assignee: '@resume-calm-market-desk-a1b2c3',
+          agent: 'claude',
+          when: { kind: 'every', every: '1h' },
+          automationHealth: { state: 'failed', message: 'Latest scheduled run failed.' },
+        }),
+      ]),
+      error: null,
+      loading: false,
+    })
+
+    render(<IssuesBoard />)
+
+    const rows = screen.getAllByRole('listitem')
+    expect(rows).toHaveLength(2)
+    expect(rows[0]?.textContent).toContain('Failed scheduled work')
+    expect(screen.getByText('@resume-calm-market-desk-a1b2c3')).toBeTruthy()
+    expect(screen.getByText('claude override')).toBeTruthy()
+  })
+})

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -19,6 +19,7 @@ import type {
 import type { ScheduleWhen } from '../api/schedule'
 import { useIssues } from '../hooks/useIssues'
 import { useWorkspaces } from '../contexts/workspaces-context'
+import { formatRelativeTime } from '../lib/intl'
 import { useWorkspace } from '../tabs/store'
 import { CenteredLoading } from './StateViews'
 import { STATUS_META } from './issue-status-meta'
@@ -153,6 +154,16 @@ const AUTOMATION_HEALTH_META: Record<IssueAutomationHealthState, { label: string
   blocked: { label: 'Blocked', className: 'bg-red-500/15 text-red-400' },
 }
 
+const BOARD_HEALTH_CLASS: Record<IssueAutomationHealthState, string> = {
+  inactive: 'text-muted/70',
+  not_started: 'text-muted/70',
+  due: 'text-amber-400',
+  running: 'text-blue-400',
+  healthy: 'text-emerald-500/85',
+  failed: 'rounded-md bg-red-500/15 px-2 py-1 text-red-400',
+  blocked: 'rounded-md bg-red-500/15 px-2 py-1 text-red-400',
+}
+
 export function AutomationHealthPill({ health }: { health: IssueAutomationHealth }) {
   const meta = AUTOMATION_HEALTH_META[health.state]
   return (
@@ -224,6 +235,8 @@ interface AgentRuntime {
   id: string
   displayName: string
   source: 'override' | 'issue-default' | 'workspace-default' | 'workspace'
+  /** Explicit frontmatter only matters in the board when it differs from the effective default. */
+  distinctOverride?: boolean
 }
 
 /** Normalised collision key — title, trimmed + lowercased. Mirrors the server's
@@ -243,19 +256,29 @@ function resolveAgentRuntime(
   issueDefaultAgent: string | null,
   defaultAgent: string | null,
 ): AgentRuntime | undefined {
-  if (issue.agent) {
-    return { id: issue.agent, displayName: agentName(issue.agent, agents), source: 'override' }
+  if (!workspace) {
+    return issue.agent
+      ? { id: issue.agent, displayName: agentName(issue.agent, agents), source: 'override', distinctOverride: true }
+      : undefined
   }
-  if (!workspace) return undefined
   const runtimeIds = workspace.agents.filter((id) => {
     const agent = agents.find((a) => a.id === id)
     return agent ? agent.kind !== 'utility' : id !== 'shell'
   })
   const issueDefaultId = issueDefaultAgent && runtimeIds.includes(issueDefaultAgent) ? issueDefaultAgent : null
+  const workspaceDefaultId = defaultAgent && runtimeIds.includes(defaultAgent) ? defaultAgent : null
+  const effectiveDefaultId = issueDefaultId ?? workspaceDefaultId ?? runtimeIds[0] ?? null
+  if (issue.agent) {
+    return {
+      id: issue.agent,
+      displayName: agentName(issue.agent, agents),
+      source: 'override',
+      distinctOverride: issue.agent !== effectiveDefaultId,
+    }
+  }
   if (issueDefaultId) {
     return { id: issueDefaultId, displayName: agentName(issueDefaultId, agents), source: 'issue-default' }
   }
-  const workspaceDefaultId = defaultAgent && runtimeIds.includes(defaultAgent) ? defaultAgent : null
   if (workspaceDefaultId) {
     return { id: workspaceDefaultId, displayName: agentName(workspaceDefaultId, agents), source: 'workspace-default' }
   }
@@ -265,75 +288,147 @@ function resolveAgentRuntime(
     : undefined
 }
 
-function AgentRuntimePill({ runtime }: { runtime: AgentRuntime }) {
-  // Accent/ring means "this issue explicitly overrides the runtime"; credential
-  // readiness is a separate workspace concern and must not be inferred here.
-  const title =
-    runtime.source === 'override'
-      ? `Agent runtime override: ${runtime.displayName}`
-      : runtime.source === 'issue-default'
-        ? `Agent runtime: ${runtime.displayName} (issue default)`
-      : runtime.source === 'workspace-default'
-        ? `Agent runtime: ${runtime.displayName} (workspace default)`
-        : `Agent runtime: ${runtime.displayName} (workspace fallback)`
+const ATTENTION_ORDER: Record<IssueAutomationHealthState, number> = {
+  blocked: 0,
+  failed: 1,
+  running: 2,
+  due: 3,
+  not_started: 4,
+  healthy: 5,
+  inactive: 6,
+}
+
+const PRIORITY_ORDER: Record<IssuePriority, number> = {
+  urgent: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  none: 4,
+}
+
+function boardRowOrder(a: BoardRow, b: BoardRow): number {
+  const aAttention = a.issue.automationHealth ? ATTENTION_ORDER[a.issue.automationHealth.state] : 4
+  const bAttention = b.issue.automationHealth ? ATTENTION_ORDER[b.issue.automationHealth.state] : 4
+  if (aAttention !== bAttention) return aAttention - bAttention
+
+  const priority = PRIORITY_ORDER[a.issue.priority] - PRIORITY_ORDER[b.issue.priority]
+  if (priority !== 0) return priority
+
+  const aDue = a.issue.nextDueAtMs ?? Number.POSITIVE_INFINITY
+  const bDue = b.issue.nextDueAtMs ?? Number.POSITIVE_INFINITY
+  if (aDue !== bDue) return aDue - bDue
+  return a.issue.title.localeCompare(b.issue.title)
+}
+
+function BoardHealth({ issue }: { issue: IssueListItem }) {
+  const health = issue.automationHealth
+  if (!health) return null
+  const meta = AUTOMATION_HEALTH_META[health.state]
+  const active = health.state === 'running' || health.state === 'due'
+  const lastRun = issue.lastFiredAtMs ? formatRelativeTime(issue.lastFiredAtMs) : ''
+
   return (
     <span
-      title={title}
-      aria-label={title}
-      className={`hidden shrink-0 items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[11px] sm:inline-flex ${
-        runtime.source === 'override'
-          ? 'bg-bg-tertiary text-text ring-1 ring-accent/30'
-          : 'bg-bg-tertiary text-muted'
-      }`}
+      title={health.message}
+      className={`inline-flex shrink-0 items-center gap-1.5 text-[11px] font-medium ${BOARD_HEALTH_CLASS[health.state]}`}
     >
-      <Bot size={10} aria-hidden className="opacity-80" />
-      {runtime.id}
+      <span className={`h-1.5 w-1.5 rounded-full bg-current ${active ? 'animate-pulse' : ''}`} aria-hidden />
+      {meta.label}
+      {lastRun && <span className="font-normal text-muted/55">· {lastRun}</span>}
     </span>
+  )
+}
+
+function BoardCadence({ issue }: { issue: IssueListItem }) {
+  if (!issue.when) return null
+  const nextRun = issue.nextDueAtMs ? formatRelativeTime(issue.nextDueAtMs) : ''
+  return (
+    <span
+      title={cadenceTitle(issue.when)}
+      className="inline-flex min-w-0 items-center gap-1.5 text-[11px] text-muted/75"
+    >
+      <Clock size={11} className="shrink-0 text-muted/55" aria-hidden />
+      <span className="truncate">{cadenceLabel(issue.when)}</span>
+      {nextRun && <span className="shrink-0 text-muted/50">· {nextRun}</span>}
+    </span>
+  )
+}
+
+function BoardAutomationSummary({ issue, className = '' }: { issue: IssueListItem; className?: string }) {
+  if (!issue.when && !issue.automationHealth) return null
+  return (
+    <div className={`flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5 ${className}`}>
+      <BoardHealth issue={issue} />
+      <BoardCadence issue={issue} />
+    </div>
   )
 }
 
 function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: BoardRow & { onOpen: () => void }) {
   const terminal = issue.status === 'done' || issue.status === 'canceled'
+  const titleMatchesId = issue.title.trim().toLowerCase() === issue.id.trim().toLowerCase()
+  const explicitAssignee = issue.assignee !== '@workspace'
+  const explicitAgent = agentRuntime?.source === 'override' && agentRuntime.distinctOverride !== false
   return (
     <li>
       <button
         type="button"
         onClick={onOpen}
         title={`Open ${issue.id}`}
-        className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-bg-tertiary/40 ${
+        className={`oa-pressable flex w-full items-start gap-3 px-3.5 py-3 text-left transition-colors hover:bg-bg-tertiary/35 sm:px-4 ${
           terminal ? 'opacity-60' : ''
         }`}
       >
-        <PriorityIndicator priority={issue.priority} />
-        <span
-          title={issue.id}
-          className="hidden max-w-[8rem] shrink-0 truncate font-mono text-[11px] text-muted/70 sm:inline"
-        >
-          {issue.id}
+        <span className="mt-0.5 flex h-5 w-4 shrink-0 items-center justify-center">
+          <PriorityIndicator priority={issue.priority} />
         </span>
-        <span title={issue.title} className="min-w-0 flex-1 truncate text-[13px] text-text">
-          {issue.title}
-        </span>
-        {issue.nameCollision && (
-          <span
-            title={`Duplicate name — also used in ${dupOthers ?? 1} other workspace${
-              (dupOthers ?? 1) === 1 ? '' : 's'
-            }. A [[name]] is a global handle; resolve manually.`}
-            aria-label="Duplicate issue name across workspaces"
-            className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-400"
-          >
-            <Copy size={10} aria-hidden /> dup
-          </span>
-        )}
-        {issue.when && <CadencePill when={issue.when} />}
-        {issue.automationHealth && <AutomationHealthPill health={issue.automationHealth} />}
-        {(issue.when || issue.agent) && agentRuntime && <AgentRuntimePill runtime={agentRuntime} />}
-        <span className="hidden shrink-0 text-xs text-muted sm:inline" title={`Assignee: ${issue.assignee}`}>
-          {issue.assignee}
-        </span>
-        <span className="shrink-0 rounded-full bg-bg-tertiary px-2 py-0.5 text-[11px] text-muted" title={`Workspace: ${wsTag} (${wsId.slice(0, 8)})`}>
-          {wsTag}
-        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span title={issue.title} className="min-w-0 truncate text-[13px] font-medium text-text sm:text-[13.5px]">
+              {issue.title}
+            </span>
+            {issue.nameCollision && (
+              <span
+                title={`Duplicate name — also used in ${dupOthers ?? 1} other workspace${
+                  (dupOthers ?? 1) === 1 ? '' : 's'
+                }. A [[name]] is a global handle; resolve manually.`}
+                aria-label="Duplicate issue name across workspaces"
+                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-medium text-amber-400"
+              >
+                <Copy size={9} aria-hidden /> dup
+              </span>
+            )}
+          </div>
+
+          <BoardAutomationSummary issue={issue} className="mt-2 lg:hidden" />
+
+          <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1 text-[10.5px] text-muted/60">
+            <span className="truncate" title={`Workspace: ${wsTag} (${wsId.slice(0, 8)})`}>
+              {wsTag}
+            </span>
+            {!titleMatchesId && (
+              <span className="hidden max-w-[14rem] truncate font-mono text-muted/45 sm:inline" title={`Issue ID: ${issue.id}`}>
+                #{issue.id}
+              </span>
+            )}
+            {explicitAssignee && (
+              <span className="max-w-[14rem] truncate text-muted/70" title={`Assignee: ${issue.assignee}`}>
+                {issue.assignee}
+              </span>
+            )}
+            {explicitAgent && agentRuntime && (
+              <span className="inline-flex items-center gap-1 text-muted/70" title={`Agent runtime override: ${agentRuntime.displayName}`}>
+                <Bot size={10} aria-hidden /> {agentRuntime.id} override
+              </span>
+            )}
+          </div>
+        </div>
+
+        <BoardAutomationSummary
+          issue={issue}
+          className="hidden max-w-[48%] shrink-0 justify-end lg:flex"
+        />
       </button>
     </li>
   )
@@ -486,7 +581,7 @@ export function IssuesBoard() {
 
   const groups = STATUS_ORDER.map((status) => ({
     status,
-    rows: rows.filter((r) => r.issue.status === status),
+    rows: rows.filter((r) => r.issue.status === status).sort(boardRowOrder),
   })).filter((g) => g.rows.length > 0)
 
   const staleBanner = error ? (

--- a/ui/src/pages/IssuePage.tsx
+++ b/ui/src/pages/IssuePage.tsx
@@ -17,7 +17,7 @@ export function IssuePage() {
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader
         title="Issues"
-        description="Work tracked across every workspace — what each agent is doing, and what's scheduled to run."
+        description="Work tracked across every workspace."
         right={
           <button
             type="button"
@@ -30,7 +30,7 @@ export function IssuePage() {
           </button>
         }
       />
-      <div className="flex-1 min-h-0 overflow-y-auto px-4 md:px-6 py-5">
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 py-4 sm:px-4 md:px-6 md:py-5">
         <IssuesBoard />
       </div>
     </div>


### PR DESCRIPTION
## What changed

- make the Issue title the primary row identity and demote Workspace/ID provenance
- hide implicit `@workspace` assignments and Agent overrides that match the effective default
- combine scheduling and latest-run state into a compact automation summary
- sort failed, blocked, running, and due work ahead of healthy work within each status group
- adapt rows into title-first desktop, tablet, and phone layouts without sacrificing the work item to metadata
- shorten the page introduction and tighten phone padding
- add component coverage for hierarchy, default-metadata suppression, exception visibility, and attention ordering

## Why

The board rendered every Issue field with nearly equal visual weight. Long slug-like IDs, default assignment/runtime pills, schedule pills, health pills, and Workspace tags competed with the actual work title. On phones the title could disappear while metadata remained visible.

## Validation

- `pnpm --dir ui exec vitest run src/components/IssuesBoard.spec.tsx`
- `pnpm --dir ui exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir ui build`
- `npx tsc --noEmit`
- `pnpm test` (265 files passed, 2835 tests passed)
- browser verification at 1280px, 900px, and 390px widths
