### PR TITLE
Explain interrupted Issue runs and guide safe retries

### DIFF
--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -148,7 +148,11 @@ the latest scheduled run, and the assignee's resume availability. It is not
 persisted in markdown and does not create another Issue workflow status:
 
 - `not_started`, `due`, `running`, and `healthy` describe normal progress;
-- `failed` retains the latest failed/interrupted run until a later success;
+- `interrupted` means the work was cut off by launcher restart, or its 30-minute
+  watchdog itself woke substantially late (usually computer sleep / launcher
+  suspension); this is operational interruption, not an agent-work failure;
+- `failed` retains a real timeout, launch error, runtime error, or non-zero
+  process exit until a later success;
 - `blocked` means the schedule has no future fire, or an exact Session owner is
   missing, retired, or not resumable;
 - `inactive` means Issue status `done`/`canceled` has stopped the schedule.
@@ -157,10 +161,25 @@ Health measures scheduler fulfillment, not human attention. A successful run
 may correctly exit silently when its condition is false, so Inbox delivery is
 not a health prerequisite.
 
+Failure explanations are read-side projections from the durable run record.
+Old runs therefore gain structured `failure.kind/title/message/retryable`
+diagnostics without migration. A killed run close to 30 minutes is a timeout;
+a killed run whose watchdog closes much later is described conservatively as a
+paused computer/launcher rather than falsely blaming the agent.
+
+The Issue detail offers **Retry now** only for the latest failed or interrupted
+scheduled run. Retry re-reads the live Issue and uses the same markdown What,
+assignee, runtime, resume mapping, and 30-minute budget as a scheduled fire. It
+does not write the last-fired marker, so a recovery attempt never shifts the
+Issue's cadence. The backend rejects duplicate/racing retries and returns the
+authoritative running detail immediately; there is no automatic retry storm.
+
 Headless runs may overlap with interactive sessions or other runs in the same
 checkout. Agents must tolerate concurrent edits. The launcher currently admits
 at most eight headless processes globally and serializes registry persistence,
-but there is no per-Workspace exclusive lock.
+but there is no per-Workspace exclusive lock. One small dispatch-start guard
+prevents a manual retry and a schedule tick from launching the same Issue at the
+same instant; it is released as soon as the run is registered.
 
 Offboarding is the lifecycle exception: a Workspace with a live headless run
 cannot depart. Once its Catalog row enters `offboarding`, new dispatch is
@@ -276,6 +295,7 @@ provenance store.
 | `src/workspaces/issues/board.ts` | Global board/detail projections |
 | `src/workspaces/issues/auto-complete.ts` | Successful one-shot → `done` transition |
 | `src/workspaces/issues/automation-health.ts` | Live schedule/run/owner health projection |
+| `src/workspaces/issues/run-failure.ts` | Read-side scheduled-run termination explanation |
 | `src/workspaces/schedule/scanner.ts` | Workspace scan, due calculation, dispatch |
 | `src/workspaces/schedule/marker-store.ts` | Atomic last-fired persistence |
 | `src/workspaces/service.ts` | Scanner composition, agent resolution, headless registry |

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -17,7 +17,7 @@ import { detailIssue } from '../../workspaces/issues/board.js'
 import { readWorkspaceIssues } from '../../workspaces/issues/declaration.js'
 import { createIssue } from '../../workspaces/issues/mutate.js'
 import { readIssueComments } from '../../workspaces/issues/comments.js'
-import type { WorkspaceService } from '../../workspaces/service.js'
+import { IssueRetryError, type WorkspaceService } from '../../workspaces/service.js'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -34,6 +34,20 @@ afterEach(async () => {
 // just echoes whatever inboxReports it's handed.
 function build(inboxReports: InboxEntry[] = []) {
   const appendProvenance = vi.fn(async (input) => ({ id: 'p-1', ...input }))
+  const readDetail = async (wsId: string, id: string) => {
+    if (wsId !== 'ws-1') return null
+    const r = await readWorkspaceIssues(wsDir)
+    if (!r.ok) return null
+    const issue = r.issues.find((i) => i.id === id)
+    if (!issue) return null
+    const comments = await readIssueComments(wsDir, id)
+    return { issue: detailIssue(issue, null), comments: comments.ok ? comments.comments : [], runs: [], inboxReports, provenance: [], activity: [] }
+  }
+  const retryIssue = vi.fn(async (wsId: string, id: string) => {
+    const detail = await readDetail(wsId, id)
+    if (!detail) throw new IssueRetryError('not_found', 'Issue not found.')
+    return detail
+  })
   const svc = {
     registry: {
       get: (id: string) => (
@@ -56,18 +70,11 @@ function build(inboxReports: InboxEntry[] = []) {
           ? { resumeId, wsId: 'ws-1', agent: 'codex', createdAt: 1, updatedAt: 1 }
         : null,
     },
-    issueDetail: async (wsId: string, id: string) => {
-      if (wsId !== 'ws-1') return null
-      const r = await readWorkspaceIssues(wsDir)
-      if (!r.ok) return null
-      const issue = r.issues.find((i) => i.id === id)
-      if (!issue) return null
-      const comments = await readIssueComments(wsDir, id)
-      return { issue: detailIssue(issue, null), comments: comments.ok ? comments.comments : [], runs: [], inboxReports, provenance: [], activity: [] }
-    },
+    issueDetail: readDetail,
+    retryIssue,
     provenanceStore: { append: appendProvenance, list: vi.fn(), latest: vi.fn() },
   } as unknown as WorkspaceService
-  return { app: createIssuesRoutes(svc), appendProvenance }
+  return { app: createIssuesRoutes(svc), appendProvenance, retryIssue }
 }
 
 async function req(app: any, method: string, path: string, body?: unknown) {
@@ -202,6 +209,29 @@ describe('GET /api/issues/:wsId/:id — inboxReports pass-through', () => {
     const r = await req(build().app, 'GET', '/ws-1/i1')
     expect(r.status).toBe(200)
     expect(r.body.inboxReports).toEqual([])
+  })
+})
+
+describe('POST /api/issues/:wsId/:id/retry', () => {
+  it('returns the authoritative detail with 202', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
+    const { app, retryIssue } = build()
+    const r = await req(app, 'POST', '/ws-1/i1/retry')
+    expect(r.status).toBe(202)
+    expect(r.body.issue.id).toBe('i1')
+    expect(retryIssue).toHaveBeenCalledWith('ws-1', 'i1')
+  })
+
+  it('maps retry conflicts to an actionable response', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
+    const { app, retryIssue } = build()
+    retryIssue.mockRejectedValueOnce(new IssueRetryError('already_running', 'This Issue already has a run in progress.'))
+    const r = await req(app, 'POST', '/ws-1/i1/retry')
+    expect(r.status).toBe(409)
+    expect(r.body).toEqual({
+      error: 'already_running',
+      message: 'This Issue already has a run in progress.',
+    })
   })
 })
 

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -10,6 +10,7 @@
  * Read endpoints:
  *   GET  /api/issues               → list across all workspaces
  *   GET  /api/issues/:wsId/:id      → one issue's detail { issue, runs, inboxReports }
+ *   POST /api/issues/:wsId/:id/retry → rerun the latest failed/interrupted schedule now
  *
  * Phase 2b adds the human/UI WRITE path (the agent edits the files directly /
  * via its own tools). Both writes go through the shared mutation helper
@@ -36,7 +37,12 @@ import {
 import { appendIssueComment, updateIssueFields } from '../../workspaces/issues/mutate.js'
 import { isAgentRuntime } from '../../workspaces/cli-adapter.js'
 import { logger as launcherLogger } from '../../workspaces/logger.js'
-import type { WorkspaceService } from '../../workspaces/service.js'
+import {
+  HeadlessCapacityError,
+  HeadlessResumeError,
+  IssueRetryError,
+  type WorkspaceService,
+} from '../../workspaces/service.js'
 
 /** Upper bound on a single comment's text (matches the headless seed cap). */
 const MAX_COMMENT = 16000
@@ -70,6 +76,36 @@ export function createIssuesRoutes(svc: WorkspaceService): Hono {
     const detail = await svc.issueDetail(c.req.param('wsId'), c.req.param('id'))
     if (!detail) return c.json({ error: 'not_found' }, 404)
     return c.json(detail)
+  })
+
+  // POST /api/issues/:wsId/:id/retry — the UI never supplies a prompt, runtime,
+  // owner, or timeout. The service re-reads the live Issue and reuses the same
+  // dispatch path as the scheduler without advancing its next-fire marker.
+  app.post('/:wsId/:id/retry', async (c) => {
+    const wsId = c.req.param('wsId')
+    const id = c.req.param('id')
+    if (!validId(wsId) || !validId(id)) return c.json({ error: 'not_found' }, 404)
+    try {
+      return c.json(await svc.retryIssue(wsId, id), 202)
+    } catch (err) {
+      if (err instanceof IssueRetryError) {
+        const status = err.code === 'not_found' ? 404
+          : err.code === 'not_scheduled' ? 422
+          : 409
+        return c.json({ error: err.code, message: err.message }, status)
+      }
+      if (err instanceof HeadlessCapacityError) {
+        return c.json({ error: 'capacity_reached', message: err.message }, 429)
+      }
+      if (err instanceof HeadlessResumeError) {
+        return c.json({ error: err.code, message: err.message }, 409)
+      }
+      launcherLogger.warn('issue.retry_failed', { wsId, id, err })
+      return c.json({
+        error: 'retry_failed',
+        message: err instanceof Error ? err.message : String(err),
+      }, 500)
+    }
   })
 
   // PATCH /api/issues/:wsId/:id — patch board fields { status?, priority?,

--- a/src/workspaces/issues/automation-health.spec.ts
+++ b/src/workspaces/issues/automation-health.spec.ts
@@ -30,8 +30,21 @@ describe('issueAutomationHealth', () => {
       state: 'healthy', latestTaskId: 'run-b',
     })
     expect(issueAutomationHealth({ ...base, latestRun: { taskId: 'run-c', status: 'interrupted' } })).toMatchObject({
-      state: 'failed', latestTaskId: 'run-c',
+      state: 'interrupted', latestTaskId: 'run-c',
     })
+    expect(issueAutomationHealth({
+      ...base,
+      latestRun: {
+        taskId: 'run-sleep',
+        status: 'failed',
+        failure: {
+          kind: 'system_paused',
+          title: 'Computer or launcher was paused',
+          message: 'watchdog ran late',
+          retryable: true,
+        },
+      },
+    })).toMatchObject({ state: 'interrupted', message: 'watchdog ran late' })
   })
 
   it('blocks a future dispatch when an exact Session cannot resume', () => {

--- a/src/workspaces/issues/automation-health.ts
+++ b/src/workspaces/issues/automation-health.ts
@@ -1,5 +1,6 @@
 import type { HeadlessTaskStatus } from '../headless-task-registry.js'
 import type { IssueStatus } from './declaration.js'
+import type { IssueRunFailure } from './run-failure.js'
 
 /** Operational state of a scheduled Issue. This is a live projection, never a
  * field persisted into the agent-editable markdown file: workflow status says
@@ -11,6 +12,7 @@ export type IssueAutomationHealthState =
   | 'due'
   | 'running'
   | 'healthy'
+  | 'interrupted'
   | 'failed'
   | 'blocked'
 
@@ -29,7 +31,7 @@ export interface IssueAutomationHealthInput {
   nowMs: number
   nextDueAtMs: number | null
   ownerState: IssueAutomationOwnerState
-  latestRun?: { taskId: string; status: HeadlessTaskStatus }
+  latestRun?: { taskId: string; status: HeadlessTaskStatus; failure?: IssueRunFailure }
 }
 
 /** Derive one scheduler-health answer from authoritative stores. Ordering is
@@ -56,8 +58,19 @@ export function issueAutomationHealth(input: IssueAutomationHealthInput): IssueA
   if (input.ownerState === 'unbound') {
     return withLatest({ state: 'blocked', message: 'Assigned Session has no resumable runtime conversation yet.' })
   }
-  if (latest?.status === 'failed' || latest?.status === 'interrupted') {
-    return { state: 'failed', message: `Latest scheduled run ${latest.status}.`, latestTaskId: latest.taskId }
+  if (latest?.status === 'interrupted' || latest?.failure?.kind === 'system_paused') {
+    return {
+      state: 'interrupted',
+      message: latest.failure?.message ?? 'OpenAlice stopped while the latest scheduled run was active. It was not automatically retried.',
+      latestTaskId: latest.taskId,
+    }
+  }
+  if (latest?.status === 'failed') {
+    return {
+      state: 'failed',
+      message: latest.failure?.message ?? 'Latest scheduled run failed. Inspect its Activity entry, then retry when ready.',
+      latestTaskId: latest.taskId,
+    }
   }
   if (input.nextDueAtMs === null) {
     return withLatest({ state: 'blocked', message: 'Schedule has no future fire. Check its expression and timestamp.' })

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -108,6 +108,24 @@ describe('issueRunRecord', () => {
     })
     expect(projected).not.toHaveProperty('agentSessionId')
   })
+
+  it('derives an actionable failure explanation for legacy killed runs', () => {
+    const projected = issueRunRecord({
+      taskId: 'task-sleep',
+      resumeId: 'resume-sleep',
+      wsId: 'ws-1',
+      trigger: { kind: 'issue', workspaceId: 'ws-1', issueId: 'scan' },
+      agent: 'pi',
+      prompt: 'scan',
+      status: 'failed',
+      startedAt: 1,
+      durationMs: 44 * 60_000,
+      killed: true,
+      signal: 'SIGKILL',
+    }, false)
+
+    expect(projected.failure).toMatchObject({ kind: 'system_paused', retryable: true })
+  })
 })
 
 function ws(wsId: string, titles: string[]): IssuesSnapshotWorkspace {

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -28,6 +28,7 @@ import type {
 import type { IssuePriority, IssueRecord, IssueStatus } from './declaration.js'
 import type { IssueComment } from './comments.js'
 import type { IssueAutomationHealth } from './automation-health.js'
+import { issueRunFailure, type IssueRunFailure } from './run-failure.js'
 
 /** One board row: the issue's display fields, plus — iff it self-schedules — its
  *  `when` and the scanner's firing markers. No markdown What (Phase 2 loads it). */
@@ -305,6 +306,9 @@ export interface IssueRunRecord {
   killed?: boolean
   error?: string
   output?: HeadlessTaskOutputSummary
+  /** Read-side explanation for non-successful scheduled execution. Derived
+   * from durable fields so old registry entries need no migration. */
+  failure?: IssueRunFailure
   /** Whether OpenAlice currently has a native runtime mapping for resumeId. */
   resumable: boolean
 }
@@ -312,6 +316,7 @@ export interface IssueRunRecord {
 /** Explicit whitelist: do not spread HeadlessTaskRecord here. Old registry
  * records may contain adapter-specific compatibility fields. */
 export function issueRunRecord(task: HeadlessTaskRecord, resumable: boolean): IssueRunRecord {
+  const failure = issueRunFailure(task)
   return {
     taskId: task.taskId,
     resumeId: task.resumeId,
@@ -329,6 +334,7 @@ export function issueRunRecord(task: HeadlessTaskRecord, resumable: boolean): Is
     ...(task.killed !== undefined ? { killed: task.killed } : {}),
     ...(task.error !== undefined ? { error: task.error } : {}),
     ...(task.output !== undefined ? { output: task.output } : {}),
+    ...(failure ? { failure } : {}),
     resumable,
   }
 }

--- a/src/workspaces/issues/run-failure.spec.ts
+++ b/src/workspaces/issues/run-failure.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  issueRunFailure,
+  SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+} from './run-failure.js'
+
+describe('issueRunFailure', () => {
+  it('distinguishes a late watchdog after system pause from a normal timeout', () => {
+    expect(issueRunFailure({
+      status: 'failed',
+      killed: true,
+      durationMs: SCHEDULED_ISSUE_RUN_TIMEOUT_MS + 14 * 60_000,
+    })).toMatchObject({ kind: 'system_paused', retryable: true })
+
+    expect(issueRunFailure({
+      status: 'failed',
+      killed: true,
+      durationMs: SCHEDULED_ISSUE_RUN_TIMEOUT_MS + 5_000,
+    })).toMatchObject({ kind: 'timeout', retryable: true })
+  })
+
+  it('explains restart reconciliation, launch errors, and process exits', () => {
+    expect(issueRunFailure({ status: 'interrupted' })).toMatchObject({ kind: 'launcher_restarted' })
+    expect(issueRunFailure({ status: 'failed', error: 'spawn ENOENT' })).toMatchObject({
+      kind: 'launch_error', message: 'spawn ENOENT',
+    })
+    expect(issueRunFailure({ status: 'failed', exitCode: 2 })).toMatchObject({ kind: 'process_exit' })
+  })
+
+  it('does not manufacture failures for running or completed runs', () => {
+    expect(issueRunFailure({ status: 'running' })).toBeUndefined()
+    expect(issueRunFailure({ status: 'done' })).toBeUndefined()
+  })
+})

--- a/src/workspaces/issues/run-failure.ts
+++ b/src/workspaces/issues/run-failure.ts
@@ -1,0 +1,103 @@
+import type { HeadlessTaskRecord } from '../headless-task-registry.js'
+
+/** Scheduled Issue runs share one watchdog budget. Keeping the value here lets
+ * dispatch and the read-side failure projection explain the same deadline. */
+export const SCHEDULED_ISSUE_RUN_TIMEOUT_MS = 30 * 60_000
+
+/** A watchdog that fires this far after its own deadline did not merely time
+ * out: the launcher's event loop was paused (most commonly system sleep). */
+export const SCHEDULED_ISSUE_WATCHDOG_LATE_GRACE_MS = 60_000
+
+export type IssueRunFailureKind =
+  | 'system_paused'
+  | 'launcher_restarted'
+  | 'timeout'
+  | 'launch_error'
+  | 'process_exit'
+  | 'runtime_error'
+
+/** Read-side explanation derived from the durable execution record. It is not
+ * persisted, so old runs immediately gain better diagnostics without a data
+ * migration and the inference can evolve independently of registry format. */
+export interface IssueRunFailure {
+  kind: IssueRunFailureKind
+  title: string
+  message: string
+  retryable: boolean
+}
+
+function compactDuration(ms: number): string {
+  const minutes = Math.floor(ms / 60_000)
+  const seconds = Math.round((ms % 60_000) / 1000)
+  if (minutes === 0) return `${seconds}s`
+  return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`
+}
+
+/** Explain why a scheduled Issue run did not complete. The classification is
+ * deliberately conservative: an overdue watchdog says the system/launcher was
+ * paused, not that sleep is proven; SIGKILL near the deadline is a real timeout. */
+export function issueRunFailure(
+  task: Pick<
+    HeadlessTaskRecord,
+    'status' | 'durationMs' | 'exitCode' | 'signal' | 'killed' | 'error'
+  >,
+  timeoutMs = SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+): IssueRunFailure | undefined {
+  if (task.status === 'running' || task.status === 'done') return undefined
+
+  if (task.status === 'interrupted') {
+    return {
+      kind: 'launcher_restarted',
+      title: 'Launcher restarted',
+      message: 'OpenAlice stopped while this run was active. It was not automatically retried.',
+      retryable: true,
+    }
+  }
+
+  if (task.killed) {
+    const durationMs = task.durationMs ?? timeoutMs
+    const lateByMs = durationMs - timeoutMs
+    if (lateByMs >= SCHEDULED_ISSUE_WATCHDOG_LATE_GRACE_MS) {
+      return {
+        kind: 'system_paused',
+        title: 'Computer or launcher was paused',
+        message: `The ${compactDuration(timeoutMs)} watchdog ran ${compactDuration(lateByMs)} late. The computer likely slept or OpenAlice was paused; this run was not automatically retried.`,
+        retryable: true,
+      }
+    }
+    return {
+      kind: 'timeout',
+      title: 'Run timed out',
+      message: `The agent did not finish within the ${compactDuration(timeoutMs)} execution limit.`,
+      retryable: true,
+    }
+  }
+
+  if (task.error) {
+    return {
+      kind: 'launch_error',
+      title: 'Agent could not start',
+      message: task.error,
+      retryable: true,
+    }
+  }
+
+  if (task.signal || (task.exitCode !== undefined && task.exitCode !== null && task.exitCode !== 0)) {
+    const detail = task.signal
+      ? `signal ${task.signal}`
+      : `exit code ${task.exitCode}`
+    return {
+      kind: 'process_exit',
+      title: 'Agent process exited',
+      message: `The agent process ended with ${detail} before completing the work.`,
+      retryable: true,
+    }
+  }
+
+  return {
+    kind: 'runtime_error',
+    title: 'Agent reported an error',
+    message: 'The agent runtime ended without a successful final response. Inspect the run output, then retry when ready.',
+    retryable: true,
+  }
+}

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -125,7 +125,10 @@ function scannerFor(
   const dispatch = opts.dispatch ?? vi.fn(async () => ({ taskId: 'run-1' }))
   const markers = opts.markers ?? new FakeMarkers()
   const scanner = new ScheduleScanner({
-    registry: { list: () => workspaces } as unknown as WorkspaceRegistry,
+    registry: {
+      list: () => workspaces,
+      get: (id: string) => workspaces.find((workspace) => workspace.id === id),
+    } as unknown as WorkspaceRegistry,
     resolveResumeWorkspace: opts.resolveResumeWorkspace ?? (() => workspaces[0]),
     resolveAdapter: opts.resolveAdapter ?? (() => opts.adapter ?? headlessAdapter),
     dispatch,
@@ -137,6 +140,37 @@ function scannerFor(
 }
 
 describe('ScheduleScanner', () => {
+  it('manually retries with live Issue semantics without moving the schedule marker', async () => {
+    const ws = await makeWs('w1', [{
+      id: 'retry-me',
+      title: 'Retry me',
+      when: { kind: 'every', every: '30m' },
+      what: 'same exact prompt',
+      agent: 'claude',
+    }])
+    const { scanner, dispatch, markers } = scannerFor([ws])
+
+    await expect(scanner.runIssueNow('w1', 'retry-me')).resolves.toEqual({ taskId: 'run-1' })
+    expect(dispatch).toHaveBeenCalledWith(
+      ws,
+      headlessAdapter,
+      'same exact prompt',
+      30 * 60_000,
+      { kind: 'issue', workspaceId: 'w1', issueId: 'retry-me' },
+    )
+    expect(markers.get('w1', 'retry-me')).toBeUndefined()
+  })
+
+  it('refuses manual retry for an unscheduled or terminal Issue', async () => {
+    const ws = await makeWs('w1', [
+      { id: 'plain', title: 'Plain work' },
+      { id: 'closed', title: 'Closed', status: 'done', when: { kind: 'every', every: '30m' } },
+    ])
+    const { scanner } = scannerFor([ws])
+    await expect(scanner.runIssueNow('w1', 'plain')).rejects.toMatchObject({ code: 'not_scheduled' })
+    await expect(scanner.runIssueNow('w1', 'closed')).rejects.toMatchObject({ code: 'not_fireable' })
+  })
+
   it('fires a scheduled (every) issue on first sight and records the marker after dispatch', async () => {
     const ws = await makeWs('w1', [{ id: 't1', title: 'i1', when: { kind: 'every', every: '30m' }, what: 'go' }])
     const { scanner, dispatch, markers } = scannerFor([ws])

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -32,6 +32,7 @@ import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
 import type { HeadlessTaskTrigger } from '../headless-task-registry.js'
 
 import { isFireable, issueAssigneeResumeId, issueFirePrompt, readWorkspaceIssues } from '../issues/declaration.js'
+import { SCHEDULED_ISSUE_RUN_TIMEOUT_MS } from '../issues/run-failure.js'
 
 import {
   fireBase,
@@ -42,8 +43,24 @@ import {
 } from './declaration.js'
 
 export const DEFAULT_INTERVAL_MS = 60_000
-/** Matches the legacy cron-router's headless dispatch timeout. */
-const RUN_TIMEOUT_MS = 30 * 60_000
+
+export type ScheduledIssueRunNowErrorCode =
+  | 'not_found'
+  | 'not_scheduled'
+  | 'not_fireable'
+  | 'already_running'
+
+/** Stable domain error for the manual retry path. The scheduler's automatic
+ * path still catches and logs dispatch failures without advancing its marker. */
+export class ScheduledIssueRunNowError extends Error {
+  constructor(
+    public readonly code: ScheduledIssueRunNowErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ScheduledIssueRunNowError'
+  }
+}
 
 /** The slice of ScheduleMarkerStore the scanner needs (structural, for testing). */
 export interface MarkerStore {
@@ -80,6 +97,9 @@ export class ScheduleScanner {
   private timer: ReturnType<typeof setTimeout> | null = null
   private stopped = false
   private scanning = false
+  /** Close the tiny manual-retry vs schedule-tick race for one Issue. This is
+   * only a dispatch-start lock, not a per-Workspace execution lock. */
+  private readonly dispatchingIssues = new Set<string>()
   /** Snapshot built as a side-effect of each scan; null until the first scan. */
   private lastSnapshot: ScheduleSnapshot | null = null
   private readonly now: () => number
@@ -110,6 +130,38 @@ export class ScheduleScanner {
    *  tick, so this is free — the route serves it instead of re-walking disk. */
   snapshot(): ScheduleSnapshot | null {
     return this.lastSnapshot
+  }
+
+  /** Dispatch one scheduled Issue immediately without touching its firing
+   * marker. This is the authoritative manual-retry path: it re-reads the live
+   * Issue and reuses the exact prompt, owner, runtime, and timeout used by the
+   * scanner, while preserving the next scheduled occurrence. */
+  async runIssueNow(wsId: string, issueId: string): Promise<{ taskId: string }> {
+    const ws = this.deps.registry.get(wsId)
+    if (!ws) throw new ScheduledIssueRunNowError('not_found', 'Workspace not found.')
+
+    const res = await readWorkspaceIssues(ws.dir)
+    if (!res.ok) throw new ScheduledIssueRunNowError('not_found', 'Issue not found.')
+    const issue = res.issues.find((candidate) => candidate.id === issueId)
+    if (!issue) throw new ScheduledIssueRunNowError('not_found', 'Issue not found.')
+    if (!issue.when) {
+      throw new ScheduledIssueRunNowError('not_scheduled', 'Only scheduled Issues can be retried.')
+    }
+    if (!isFireable(issue)) {
+      throw new ScheduledIssueRunNowError(
+        'not_fireable',
+        `This Issue is ${issue.status}; reopen it before retrying.`,
+      )
+    }
+
+    return this.dispatchIssue(
+      ws,
+      issue.id,
+      issueFirePrompt(issue),
+      issue.agent,
+      issueAssigneeResumeId(issue.assignee) ?? undefined,
+      true,
+    )
   }
 
   private arm(): void {
@@ -220,34 +272,17 @@ export class ScheduleScanner {
     nowMs: number,
   ): Promise<void> {
     try {
-      const executionWorkspace = resumeId
-        ? this.resolveResumeWorkspace(resumeId)
-        : issueWorkspace
-      if (!executionWorkspace) {
-        this.deps.logger.warn('schedule.resume_workspace_missing', {
-          wsId: issueWorkspace.id, taskId, resumeId,
-        })
-        return
-      }
-      const adapter = await this.deps.resolveAdapter(executionWorkspace, agentId, resumeId)
-      if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
-        this.deps.logger.warn('schedule.adapter_not_headless', { wsId: executionWorkspace.id, taskId, agent: adapter.id })
-        return
-      }
-      const trigger: HeadlessTaskTrigger = {
-        kind: 'issue',
-        workspaceId: issueWorkspace.id,
-        issueId: taskId,
-      }
-      const { taskId: runId } = resumeId
-        ? await this.deps.dispatch(executionWorkspace, adapter, what, RUN_TIMEOUT_MS, trigger, resumeId)
-        : await this.deps.dispatch(executionWorkspace, adapter, what, RUN_TIMEOUT_MS, trigger)
+      const { taskId: runId } = await this.dispatchIssue(
+        issueWorkspace,
+        taskId,
+        what,
+        agentId,
+        resumeId,
+      )
       await this.deps.markers.set(issueWorkspace.id, taskId, nowMs)
       this.deps.logger.info('schedule.fired', {
         wsId: issueWorkspace.id,
-        executionWsId: executionWorkspace.id,
         taskId,
-        agent: adapter.id,
         runId,
         owner: resumeId ? 'session' : 'workspace',
         ...(resumeId ? { resumeId } : {}),
@@ -260,6 +295,71 @@ export class ScheduleScanner {
         taskId,
         reason: err instanceof Error ? err.message : String(err),
       })
+    }
+  }
+
+  private async dispatchIssue(
+    issueWorkspace: WorkspaceMeta,
+    issueId: string,
+    what: string,
+    agentId?: string,
+    resumeId?: string,
+    manual = false,
+  ): Promise<{ taskId: string }> {
+    const dispatchKey = `${issueWorkspace.id}:${issueId}`
+    if (this.dispatchingIssues.has(dispatchKey)) {
+      if (manual) {
+        throw new ScheduledIssueRunNowError(
+          'already_running',
+          'This Issue is already being dispatched.',
+        )
+      }
+      throw new Error(`Issue dispatch already in progress: ${dispatchKey}`)
+    }
+    this.dispatchingIssues.add(dispatchKey)
+    try {
+      const executionWorkspace = resumeId
+        ? this.resolveResumeWorkspace(resumeId)
+        : issueWorkspace
+      if (!executionWorkspace) {
+        throw new Error(`assigned Session Workspace is unavailable: ${resumeId}`)
+      }
+      const adapter = await this.deps.resolveAdapter(executionWorkspace, agentId, resumeId)
+      if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
+        throw new Error(`agent runtime does not support headless work: ${adapter.id}`)
+      }
+      const trigger: HeadlessTaskTrigger = {
+        kind: 'issue',
+        workspaceId: issueWorkspace.id,
+        issueId,
+      }
+      const result = resumeId
+        ? await this.deps.dispatch(
+            executionWorkspace,
+            adapter,
+            what,
+            SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+            trigger,
+            resumeId,
+          )
+        : await this.deps.dispatch(
+            executionWorkspace,
+            adapter,
+            what,
+            SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+            trigger,
+          )
+      this.deps.logger.info('schedule.issue_dispatched', {
+        wsId: issueWorkspace.id,
+        executionWsId: executionWorkspace.id,
+        issueId,
+        agent: adapter.id,
+        runId: result.taskId,
+        manual,
+      })
+      return result
+    } finally {
+      this.dispatchingIssues.delete(dispatchKey)
     }
   }
 

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -46,7 +46,11 @@ import {
   type AgentRuntimeReadinessSource,
 } from './agent-runtime-readiness.js';
 import { ScheduleMarkerStore } from './schedule/marker-store.js';
-import { ScheduleScanner, DEFAULT_INTERVAL_MS } from './schedule/scanner.js';
+import {
+  ScheduleScanner,
+  ScheduledIssueRunNowError,
+  DEFAULT_INTERVAL_MS,
+} from './schedule/scanner.js';
 import {
   readWorkspaceIssues,
   snapshotScheduledIssue,
@@ -80,6 +84,7 @@ import {
   type IssueAutomationOwnerState,
 } from './issues/automation-health.js';
 import { issueAssigneeResumeId } from './issues/declaration.js';
+import { issueRunFailure } from './issues/run-failure.js';
 import type { IInboxStore } from '@/core/inbox-store.js';
 import { toSafeInboxOrigin } from '@/core/workspace-tool-center.js';
 import {
@@ -111,6 +116,15 @@ function automationOwnerState(assignee: string, resumes: ResumeRegistry): IssueA
   return identity.agentSessionId ? 'ready' : 'unbound';
 }
 
+function automationLatestRun(task: HeadlessTaskRecord) {
+  const failure = issueRunFailure(task);
+  return {
+    taskId: task.taskId,
+    status: task.status,
+    ...(failure ? { failure } : {}),
+  };
+}
+
 /** Max concurrent in-flight headless tasks — backstop against unbounded spawn. */
 const MAX_CONCURRENT_HEADLESS = 8;
 
@@ -129,6 +143,21 @@ export class HeadlessResumeError extends Error {
   ) {
     super(message);
     this.name = 'HeadlessResumeError';
+  }
+}
+
+export class IssueRetryError extends Error {
+  constructor(
+    public readonly code:
+      | 'not_found'
+      | 'not_scheduled'
+      | 'not_fireable'
+      | 'not_retryable'
+      | 'already_running',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'IssueRetryError';
   }
 }
 import { ScrollbackStore } from './scrollback-store.js';
@@ -291,6 +320,9 @@ export interface WorkspaceService {
    *  headless run history, newest first). `null` when the workspace or the issue
    *  id is absent. Powers GET /api/issues/:wsId/:id. */
   issueDetail(wsId: string, id: string): Promise<IssueDetail | null>;
+  /** Retry the latest unsuccessful scheduled execution now. Reuses the live
+   * Issue prompt/owner/runtime and never advances its schedule marker. */
+  retryIssue(wsId: string, id: string): Promise<IssueDetail>;
   /** Safe Workspace Session index. resumeId is the only public conversation handle. */
   sessionDirectory(wsId: string, limit?: number): Promise<WorkspaceSessionDirectory | null>;
   /** Resolve a `[[name]]` token to the issues across ALL workspaces that claim it.
@@ -1362,7 +1394,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
                 nowMs,
                 nextDueAtMs: fired.nextDueAtMs,
                 ownerState: automationOwnerState(issue.assignee, resumeRegistry),
-                ...(latestRun ? { latestRun: { taskId: latestRun.taskId, status: latestRun.status } } : {}),
+                ...(latestRun ? { latestRun: automationLatestRun(latestRun) } : {}),
               }),
             },
           );
@@ -1418,7 +1450,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         nowMs: Date.now(),
         nextDueAtMs: scheduledSnapshot.nextDueAtMs,
         ownerState: automationOwnerState(issue.assignee, resumeRegistry),
-        ...(runs[0] ? { latestRun: { taskId: runs[0].taskId, status: runs[0].status } } : {}),
+        ...(runs[0] ? {
+          latestRun: {
+            taskId: runs[0].taskId,
+            status: runs[0].status,
+            ...(runs[0].failure ? { failure: runs[0].failure } : {}),
+          },
+        } : {}),
       }),
     } : null;
     // The issue→inbox cross-link: the reports this issue produced (entries this
@@ -1445,6 +1483,59 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     }));
     const activity = issueActivityRecords(provenance, runs);
     return { issue: detailIssue(issue, markers), comments, runs, inboxReports, provenance, activity };
+  };
+
+  const retryingIssueKeys = new Set<string>();
+  const retryIssue = async (wsId: string, id: string): Promise<IssueDetail> => {
+    const key = `${wsId}:${id}`;
+    const ws = registry.get(wsId);
+    if (!ws) throw new IssueRetryError('not_found', 'Workspace not found.');
+    const issueResult = await readWorkspaceIssues(ws.dir);
+    const issue = issueResult.ok
+      ? issueResult.issues.find((candidate) => candidate.id === id)
+      : undefined;
+    if (!issue) throw new IssueRetryError('not_found', 'Issue not found.');
+    if (!issue.when) {
+      throw new IssueRetryError('not_scheduled', 'Only scheduled Issues can be retried.');
+    }
+    if (issue.status === 'done' || issue.status === 'canceled') {
+      throw new IssueRetryError(
+        'not_fireable',
+        `This Issue is ${issue.status}; reopen it before retrying.`,
+      );
+    }
+    const latest = headlessTasks.list({ issue: { workspaceId: wsId, issueId: id } })[0];
+    if (latest?.status === 'running' || retryingIssueKeys.has(key)) {
+      throw new IssueRetryError('already_running', 'This Issue already has a run in progress.');
+    }
+    if (!latest || (latest.status !== 'failed' && latest.status !== 'interrupted')) {
+      throw new IssueRetryError(
+        'not_retryable',
+        'Only the latest failed or interrupted scheduled run can be retried.',
+      );
+    }
+
+    retryingIssueKeys.add(key);
+    try {
+      const { taskId } = await scheduleScanner.runIssueNow(wsId, id);
+      launcherLogger.info('issue.retry_dispatched', {
+        wsId,
+        issueId: id,
+        previousTaskId: latest.taskId,
+        taskId,
+      });
+    } catch (err) {
+      if (err instanceof ScheduledIssueRunNowError) {
+        throw new IssueRetryError(err.code, err.message);
+      }
+      throw err;
+    } finally {
+      retryingIssueKeys.delete(key);
+    }
+
+    const detail = await issueDetail(wsId, id);
+    if (!detail) throw new IssueRetryError('not_found', 'Issue not found.');
+    return detail;
   };
 
   const sessionDirectory = async (
@@ -1835,6 +1926,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     scheduleSnapshot,
     issuesSnapshot,
     issueDetail,
+    retryIssue,
     sessionDirectory,
     resolveIssuesByName,
     headlessTasks,

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -13,7 +13,7 @@ export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> 
   }
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }))
-    throw new Error(err.error || res.statusText)
+    throw new Error(err.message || err.error || res.statusText)
   }
   return res.json()
 }

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -28,6 +28,7 @@ export type IssueAutomationHealthState =
   | 'due'
   | 'running'
   | 'healthy'
+  | 'interrupted'
   | 'failed'
   | 'blocked'
 
@@ -62,7 +63,7 @@ export interface IssueProvenanceRecord {
  * chronological projection for UI, CLI, and future activity consumers. */
 export type IssueActivityRecord =
   | ({ kind: 'change' } & IssueProvenanceRecord)
-  | { kind: 'run'; id: string; at: number; run: HeadlessTaskRecord }
+  | { kind: 'run'; id: string; at: number; run: IssueRunRecord }
 
 export interface IssueComment {
   id: string
@@ -70,6 +71,28 @@ export interface IssueComment {
   at: string
   /** Full markdown payload. Comments deliberately do not share the agent-editable What file. */
   markdown: string
+}
+
+export type IssueRunFailureKind =
+  | 'system_paused'
+  | 'launcher_restarted'
+  | 'timeout'
+  | 'launch_error'
+  | 'process_exit'
+  | 'runtime_error'
+
+export interface IssueRunFailure {
+  kind: IssueRunFailureKind
+  title: string
+  message: string
+  retryable: boolean
+}
+
+/** Issue-safe headless projection. Native runtime session ids remain hidden;
+ * failure is a read-side explanation derived by the backend. */
+export interface IssueRunRecord extends HeadlessTaskRecord {
+  issueId?: string
+  failure?: IssueRunFailure
 }
 
 export interface IssueListItem {
@@ -185,7 +208,7 @@ export interface IssueDetail {
   /** Structured markdown comments from `<id>.comments.json`. */
   comments?: IssueComment[]
   /** This issue's headless runs (wsId + issueId match), newest first. */
-  runs: HeadlessTaskRecord[]
+  runs: IssueRunRecord[]
   /**
    * The inbox reports this issue produced — every inbox entry from this
    * workspace whose server-stamped `origin.issueId` is this issue, newest-first.
@@ -253,6 +276,15 @@ export const issuesApi = {
     return fetchJson<IssueDetail>(
       `/api/issues/${encodeURIComponent(wsId)}/${encodeURIComponent(id)}/comments`,
       { method: 'POST', headers, body: JSON.stringify({ text }) },
+    )
+  },
+
+  /** Retry the latest failed/interrupted scheduled run with its live Issue
+   * prompt, owner, and runtime. The backend preserves the cadence marker. */
+  async retry(wsId: string, id: string): Promise<IssueDetail> {
+    return fetchJson<IssueDetail>(
+      `/api/issues/${encodeURIComponent(wsId)}/${encodeURIComponent(id)}/retry`,
+      { method: 'POST', headers },
     )
   },
 }

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import { ArrowLeft, Hash, History, Inbox, ListChecks, Settings, TrendingUp, X } from 'lucide-react'
+import { ArrowLeft, Hash, History, Inbox, ListChecks, RotateCcw, Settings, TrendingUp, X } from 'lucide-react'
 
-import type { HeadlessTaskRecord, HeadlessTaskStatus } from '../api/headless'
+import type { HeadlessTaskStatus } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
 import type {
   IssueDetail as IssueDetailData,
@@ -10,6 +10,7 @@ import type {
   IssueActivityRecord,
   IssuePriority,
   IssueProvenanceRecord,
+  IssueRunRecord,
   IssueStatus,
   WikilinkIssueRef,
   WikilinkResolution,
@@ -244,8 +245,11 @@ function PropertiesRail({
   agentReadiness,
   sessions,
   saving,
+  retrying,
   error,
+  canRetry,
   onPatch,
+  onRetry,
   onConfigureAgent,
 }: {
   issue: IssueDetailIssue
@@ -255,8 +259,11 @@ function PropertiesRail({
   agentReadiness: Readonly<Record<string, AgentCredentialReadiness>>
   sessions: readonly WorkspaceSessionDirectoryEntry[]
   saving: boolean
+  retrying: boolean
   error: string | null
+  canRetry: boolean
   onPatch: (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string }) => void
+  onRetry: () => void
   onConfigureAgent: (agent: AgentId) => void
 }) {
   const meta = STATUS_META[issue.status]
@@ -346,6 +353,17 @@ function PropertiesRail({
                 <span className="max-w-44 text-[11px] leading-snug text-muted">
                   {issue.automationHealth.message}
                 </span>
+                {canRetry && (
+                  <button
+                    type="button"
+                    disabled={retrying}
+                    onClick={onRetry}
+                    className="oa-pressable mt-1 inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-[11px] font-medium text-amber-400 transition-colors hover:border-amber-500/60 hover:bg-amber-500/15 disabled:cursor-wait disabled:opacity-50"
+                  >
+                    <RotateCcw size={12} aria-hidden />
+                    {retrying ? 'Retrying…' : 'Retry now'}
+                  </button>
+                )}
               </div>
             </PropRow>
           )}
@@ -476,14 +494,17 @@ function IssueComments({ comments }: { comments: NonNullable<IssueDetailData['co
 
 // ==================== Activity feed (headless runs) ====================
 
-function RunRow({ run, onAsk }: { run: HeadlessTaskRecord; onAsk: (run: HeadlessTaskRecord) => void }) {
+function RunRow({ run, onAsk }: { run: IssueRunRecord; onAsk: (run: IssueRunRecord) => void }) {
+  const displayStatus = run.failure?.kind === 'system_paused' || run.failure?.kind === 'launcher_restarted'
+    ? 'interrupted'
+    : run.status
   return (
     <li className="rounded-lg border border-border bg-bg-secondary px-3 py-2.5">
       <div className="flex items-center gap-2">
         <span
-          className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${RUN_STATUS_STYLE[run.status]}`}
+          className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${RUN_STATUS_STYLE[displayStatus]}`}
         >
-          {run.status}
+          {displayStatus}
         </span>
         <span className="text-xs text-muted">{run.agent}</span>
         <span className="ml-auto text-xs text-muted" title={new Date(run.startedAt).toLocaleString()}>
@@ -515,6 +536,22 @@ function RunRow({ run, onAsk }: { run: HeadlessTaskRecord; onAsk: (run: Headless
           {run.output.toolCalls} tool {run.output.toolCalls === 1 ? 'call' : 'calls'}
           {run.output.toolFailures > 0 ? ` · ${run.output.toolFailures} failed` : ''}
         </p>
+      )}
+      {run.failure && (
+        <div className={`mt-2 rounded-md border px-2.5 py-2 ${
+          run.failure.kind === 'system_paused' || run.failure.kind === 'launcher_restarted'
+            ? 'border-amber-500/25 bg-amber-500/10'
+            : 'border-red-500/25 bg-red-500/10'
+        }`}>
+          <p className={`text-[12px] font-medium ${
+            run.failure.kind === 'system_paused' || run.failure.kind === 'launcher_restarted'
+              ? 'text-amber-400'
+              : 'text-red-400'
+          }`}>
+            {run.failure.title}
+          </p>
+          <p className="mt-0.5 text-[11px] leading-snug text-muted">{run.failure.message}</p>
+        </div>
       )}
       {run.error && <p className="mt-1 text-[12px] text-red-400">{run.error}</p>}
     </li>
@@ -587,7 +624,7 @@ function IssueActivity({
 }: {
   activity: IssueActivityRecord[]
   onContinue: (record: IssueProvenanceRecord) => Promise<void>
-  onAskRun: (run: HeadlessTaskRecord) => void
+  onAskRun: (run: IssueRunRecord) => void
 }) {
   const [continuingId, setContinuingId] = useState<string | null>(null)
   const [continueError, setContinueError] = useState<string | null>(null)
@@ -795,6 +832,7 @@ export function IssueDetail({
   const gotoEntity = useWikilinkHandler()
 
   const [saving, setSaving] = useState(false)
+  const [retrying, setRetrying] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
   const [agentReadiness, setAgentReadiness] = useState<Record<string, AgentCredentialReadiness>>({})
   const [sessionDirectory, setSessionDirectory] = useState<readonly WorkspaceSessionDirectoryEntry[]>([])
@@ -919,6 +957,19 @@ export function IssueDetail({
     [wsId, id, mutate],
   )
 
+  const onRetry = useCallback(async () => {
+    if (retrying) return
+    setRetrying(true)
+    setActionError(null)
+    try {
+      mutate(await issuesApi.retry(wsId, id))
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setRetrying(false)
+    }
+  }, [retrying, wsId, id, mutate])
+
   const loadInquiries = useCallback(
     () => inquiriesApi.forIssue(wsId, id),
     [wsId, id],
@@ -980,6 +1031,12 @@ export function IssueDetail({
   }
 
   const { issue, runs } = data
+  const latestRun = runs[0]
+  const canRetry = Boolean(
+    issue.when
+    && latestRun?.failure?.retryable
+    && (latestRun.status === 'failed' || latestRun.status === 'interrupted'),
+  )
   const comments = data.comments ?? []
   const inboxReports = data.inboxReports ?? []
   const provenance = data.provenance ?? []
@@ -1053,8 +1110,11 @@ export function IssueDetail({
           agentReadiness={agentReadiness}
           sessions={sessionDirectory}
           saving={saving}
+          retrying={retrying}
           error={actionError}
+          canRetry={canRetry}
           onPatch={onPatch}
+          onRetry={() => void onRetry()}
           onConfigureAgent={(agent) => openAgentConfig(wsId, agent)}
         />
         <div className="min-w-0 lg:col-start-1 lg:row-start-2">

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -150,6 +150,7 @@ const AUTOMATION_HEALTH_META: Record<IssueAutomationHealthState, { label: string
   due: { label: 'Due', className: 'bg-amber-500/15 text-amber-400' },
   running: { label: 'Running', className: 'bg-blue-500/15 text-blue-400' },
   healthy: { label: 'Healthy', className: 'bg-emerald-500/15 text-emerald-400' },
+  interrupted: { label: 'Interrupted', className: 'bg-amber-500/15 text-amber-400' },
   failed: { label: 'Failed', className: 'bg-red-500/15 text-red-400' },
   blocked: { label: 'Blocked', className: 'bg-red-500/15 text-red-400' },
 }
@@ -160,6 +161,7 @@ const BOARD_HEALTH_CLASS: Record<IssueAutomationHealthState, string> = {
   due: 'text-amber-400',
   running: 'text-blue-400',
   healthy: 'text-emerald-500/85',
+  interrupted: 'rounded-md bg-amber-500/15 px-2 py-1 text-amber-400',
   failed: 'rounded-md bg-red-500/15 px-2 py-1 text-red-400',
   blocked: 'rounded-md bg-red-500/15 px-2 py-1 text-red-400',
 }
@@ -291,11 +293,12 @@ function resolveAgentRuntime(
 const ATTENTION_ORDER: Record<IssueAutomationHealthState, number> = {
   blocked: 0,
   failed: 1,
-  running: 2,
-  due: 3,
-  not_started: 4,
-  healthy: 5,
-  inactive: 6,
+  interrupted: 2,
+  running: 3,
+  due: 4,
+  not_started: 5,
+  healthy: 6,
+  inactive: 7,
 }
 
 const PRIORITY_ORDER: Record<IssuePriority, number> = {

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -1,5 +1,4 @@
-import type { HeadlessTaskRecord } from '../../api/headless'
-import type { IssueComment, IssueDetail, IssuePriority, IssueSnapshot, IssueStatus } from '../../api/issues'
+import type { IssueComment, IssueDetail, IssuePriority, IssueRunRecord, IssueSnapshot, IssueStatus } from '../../api/issues'
 import { demoInboxEntries } from './inbox'
 
 // GET /api/issues aggregates every workspace's declared issues by SCANNING
@@ -57,7 +56,11 @@ export const demoIssuesSnapshot: IssueSnapshot = {
           when: { kind: 'every', every: '1h' },
           lastFiredAtMs: now - HOUR / 2,
           nextDueAtMs: now + HOUR / 2,
-          automationHealth: { state: 'failed', message: 'Latest scheduled run failed.', latestTaskId: 'demo-run-thesis-failed' },
+          automationHealth: {
+            state: 'interrupted',
+            message: 'The 30m watchdog ran 14m late. The computer likely slept or OpenAlice was paused; this run was not automatically retried.',
+            latestTaskId: 'demo-run-thesis-1',
+          },
         },
         // Pure work item — no `when`, scanner ignores it, board still shows it.
         {
@@ -174,7 +177,7 @@ interface IssueDetailExtras {
   /** Scheduling frontmatter `agent` (adapter id), if set. */
   agent?: string
   /** This issue's headless runs, newest-first (Activity feed). */
-  runs: HeadlessTaskRecord[]
+  runs: IssueRunRecord[]
 }
 
 // Keyed by `${wsId}/${id}`. Issues absent here fall back to a generic body + no
@@ -280,8 +283,18 @@ const demoIssueExtras: Record<string, IssueDetailExtras> = {
         wsId: 'demo-ws-auto-quant',
         agent: 'claude',
         prompt: 'Re-check every active thesis against the latest quotes; flag invalidations.',
-        status: 'running',
-        startedAt: now - 2 * 60_000,
+        startedAt: now - 44 * 60_000,
+        finishedAt: now,
+        durationMs: 44 * 60_000,
+        killed: true,
+        signal: 'SIGKILL',
+        status: 'failed',
+        failure: {
+          kind: 'system_paused',
+          title: 'Computer or launcher was paused',
+          message: 'The 30m watchdog ran 14m late. The computer likely slept or OpenAlice was paused; this run was not automatically retried.',
+          retryable: true,
+        },
       },
       {
         taskId: 'demo-run-thesis-2',
@@ -520,5 +533,33 @@ export function demoIssueAddComment(
   const comments = demoIssueComments[key] ?? []
   comments.push({ id: `demo-comment-${comments.length + 1}`, author, at: new Date().toISOString(), markdown: text })
   demoIssueComments[key] = comments
+  return demoIssueDetail(wsId, id)
+}
+
+/** POST-retry backing: add a fresh running execution without changing cadence. */
+export function demoIssueRetry(wsId: string, id: string): IssueDetail | null {
+  const boardIssue = findBoardIssue(wsId, id)
+  const extras = demoIssueExtras[`${wsId}/${id}`]
+  const latest = extras?.runs[0]
+  if (!boardIssue?.when || !extras || !latest || (latest.status !== 'failed' && latest.status !== 'interrupted')) {
+    return null
+  }
+  const run: IssueRunRecord = {
+    taskId: `demo-retry-${Date.now()}`,
+    resumeId: `demo-resume-retry-${Date.now()}`,
+    resumable: false,
+    wsId,
+    issueId: id,
+    agent: boardIssue.agent ?? extras.agent ?? latest.agent,
+    prompt: latest.prompt,
+    status: 'running',
+    startedAt: Date.now(),
+  }
+  extras.runs.unshift(run)
+  boardIssue.automationHealth = {
+    state: 'running',
+    message: 'A scheduled run is in progress.',
+    latestTaskId: run.taskId,
+  }
   return demoIssueDetail(wsId, id)
 }

--- a/ui/src/demo/handlers/issues.ts
+++ b/ui/src/demo/handlers/issues.ts
@@ -3,6 +3,7 @@ import type { IssuePriority, IssueStatus } from '../../api/issues'
 import {
   demoIssueAddComment,
   demoIssueDetail,
+  demoIssueRetry,
   demoIssueUpdate,
   demoIssuesSnapshot,
 } from '../fixtures/issues'
@@ -135,5 +136,15 @@ export const issuesHandlers = [
     return detail
       ? HttpResponse.json(detail)
       : HttpResponse.json({ error: 'not_found' }, { status: 404 })
+  }),
+
+  http.post('/api/issues/:wsId/:id/retry', ({ params }) => {
+    const detail = demoIssueRetry(String(params.wsId), String(params.id))
+    return detail
+      ? HttpResponse.json(detail, { status: 202 })
+      : HttpResponse.json({
+          error: 'not_retryable',
+          message: 'Only the latest failed or interrupted scheduled run can be retried.',
+        }, { status: 409 })
   }),
 ]


### PR DESCRIPTION
## What changed

- classify legacy and new scheduled runs that were killed after a suspended watchdog as **Interrupted**, with a concrete explanation instead of a generic failure
- add a guarded `Retry now` action that reuses the live Issue prompt, runtime, assignee, and timeout without moving the recurring schedule marker
- expose the structured failure reason in the Issue board, detail properties, activity log, and demo fixtures
- document the interrupted-versus-failed semantics and retry contract

## Why

A sleeping or powered-off computer pauses the JavaScript watchdog. On wake, overdue timers can kill otherwise healthy scheduled runs and the old UI reports only `Failed`, leaving users with neither a diagnosis nor a safe recovery path.

## Validation

- targeted Issue/scanner/route tests: 61 passed
- `pnpm test`: 2,852 passed, 6 skipped
- `pnpm build`
- backend and UI TypeScript checks
- browser verification against the existing failed runs on `/issues`
- packaged Electron smoke reached Guardian, renderer bridge, and Electron IPC readiness using temporary data
