### PR TITLE
Harden optional Broker Pack lifecycle

### DIFF
--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -40,9 +40,11 @@ configSchema: ZodType
 createBroker(config): IBroker
 ```
 
-The wrapper workspaces live under `packages/uta-broker-*`. They bundle only
-OpenAlice's engine adapter code; third-party packages remain external within
-each deployed Pack. `services/uta/src/domain/trading/brokers/registry.ts`
+The wrapper workspaces live under `packages/uta-broker-*`. They bundle the
+OpenAlice-owned adapter/protocol code needed at runtime; third-party broker SDKs
+remain external within each deployed Pack. Release assembly removes workspace
+links, pnpm lock/workspace metadata, and build-machine paths before archiving.
+`services/uta/src/domain/trading/brokers/registry.ts`
 statically imports only Mock, then loads one active Pack by file URL when an
 account actually needs that engine.
 
@@ -84,8 +86,12 @@ which performs this transaction:
 
 Failure before pointer replacement leaves the previous active release intact.
 An installation lock rejects concurrent mutation of the same engine. Pack
-directories are replaceable machine/runtime state: backup `data/`, credentials,
-and Workspaces, then reinstall Packs after moving to an incompatible machine.
+reinstallation reuses a matching content-addressed release. If that release is
+corrupt, Alice installs a separate immutable `-repair-...` release and switches
+the pointer; it does not overwrite files that a Windows UTA process may still
+have open. Pack directories are replaceable machine/runtime state: backup
+`data/`, credentials, and Workspaces, then reinstall Packs after moving to an
+incompatible machine.
 
 Linux catalogs may declare a minimum glibc version. The current Longbridge GNU
 artifact requires glibc 2.39, so older Ubuntu/WSL systems are rejected before
@@ -106,9 +112,10 @@ Linux x64; publishes the files with the desktop release; mirrors them to the
 download CDN; and verifies every catalog and referenced archive.
 
 The build command also extracts every generated archive, verifies its catalog
-membership, size, SHA-256, package identity, and entry containment, then imports
-the entry in a clean Node process. `pnpm broker-packs:verify` repeats that
-acceptance check against an existing `dist/broker-packs/` directory.
+membership, size, SHA-256, package identity, entry containment, and absence of
+workspace/deployment metadata, then imports the entry in a clean Node process.
+`pnpm broker-packs:verify` repeats that acceptance check against an existing
+`dist/broker-packs/` directory.
 
 Desktop package acceptance rejects `ccxt`, `longbridge`, its native binding,
 and `@alpacahq/alpaca-trade-api` if they reappear under packaged

--- a/packages/uta-broker-alpaca/tsup.config.ts
+++ b/packages/uta-broker-alpaca/tsup.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: { index: 'src/index.ts' }, format: ['esm'], outDir: 'dist', target: 'node20',
   clean: true, sourcemap: true, splitting: false, skipNodeModulesBundle: true,
+  noExternal: [/^@traderalice\//, /^@bufbuild\/protobuf(?:\/|$)/],
   esbuildOptions: (options) => { options.conditions = ['openalice-source', ...(options.conditions ?? [])] },
 })

--- a/packages/uta-broker-ccxt/tsup.config.ts
+++ b/packages/uta-broker-ccxt/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   sourcemap: true,
   splitting: false,
   skipNodeModulesBundle: true,
+  noExternal: [/^@traderalice\//, /^@bufbuild\/protobuf(?:\/|$)/],
   esbuildOptions: (options) => {
     options.conditions = ['openalice-source', ...(options.conditions ?? [])]
   },

--- a/packages/uta-broker-ibkr/tsup.config.ts
+++ b/packages/uta-broker-ibkr/tsup.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: { index: 'src/index.ts' }, format: ['esm'], outDir: 'dist', target: 'node20',
   clean: true, sourcemap: true, splitting: false, skipNodeModulesBundle: true,
+  noExternal: [/^@traderalice\//, /^@bufbuild\/protobuf(?:\/|$)/],
   esbuildOptions: (options) => { options.conditions = ['openalice-source', ...(options.conditions ?? [])] },
 })

--- a/packages/uta-broker-leverup/tsup.config.ts
+++ b/packages/uta-broker-leverup/tsup.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: { index: 'src/index.ts' }, format: ['esm'], outDir: 'dist', target: 'node20',
   clean: true, sourcemap: true, splitting: false, skipNodeModulesBundle: true,
+  noExternal: [/^@traderalice\//, /^@bufbuild\/protobuf(?:\/|$)/],
   esbuildOptions: (options) => { options.conditions = ['openalice-source', ...(options.conditions ?? [])] },
 })

--- a/packages/uta-broker-longbridge/tsup.config.ts
+++ b/packages/uta-broker-longbridge/tsup.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: { index: 'src/index.ts' }, format: ['esm'], outDir: 'dist', target: 'node20',
   clean: true, sourcemap: true, splitting: false, skipNodeModulesBundle: true,
+  noExternal: [/^@traderalice\//, /^@bufbuild\/protobuf(?:\/|$)/],
   esbuildOptions: (options) => { options.conditions = ['openalice-source', ...(options.conditions ?? [])] },
 })

--- a/scripts/build-broker-packs.ts
+++ b/scripts/build-broker-packs.ts
@@ -2,7 +2,7 @@
 
 import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -42,11 +42,7 @@ try {
   for (const engine of INSTALLABLE_BROKER_ENGINES) {
     const deployRoot = resolve(tempRoot, engine)
     deployPackage(packageNames[engine], deployRoot)
-
-    const deployedPackagePath = resolve(deployRoot, 'package.json')
-    const deployedPackage = JSON.parse(await readFile(deployedPackagePath, 'utf8')) as Record<string, unknown>
-    deployedPackage.version = packageJson.version
-    await writeFile(deployedPackagePath, JSON.stringify(deployedPackage, null, 2) + '\n')
+    await sanitizeDeployment(engine, deployRoot)
 
     const file = brokerPackArchiveFileName(packageJson.version, engine)
     const archivePath = resolve(outDir, file)
@@ -89,6 +85,46 @@ function deployPackage(packageName: string, target: string): void {
   ], { cwd: repoRoot, stdio: 'inherit', env: process.env })
   if (result.error) throw result.error
   if (result.status !== 0) throw new Error(`pnpm deploy failed for ${packageName} (${result.status})`)
+}
+
+async function sanitizeDeployment(engine: InstallableBrokerEngine, deployRoot: string): Promise<void> {
+  const deployedPackagePath = resolve(deployRoot, 'package.json')
+  const deployedPackage = JSON.parse(await readFile(deployedPackagePath, 'utf8')) as {
+    dependencies?: Record<string, string>
+    optionalDependencies?: Record<string, string>
+  }
+  const releasePackage = {
+    name: packageNames[engine],
+    version: packageJson.version,
+    type: 'module',
+    main: './dist/index.js',
+    exports: { '.': './dist/index.js' },
+    dependencies: externalDependencies(deployedPackage.dependencies),
+    optionalDependencies: externalDependencies(deployedPackage.optionalDependencies),
+  }
+
+  await Promise.all([
+    rm(resolve(deployRoot, 'pnpm-lock.yaml'), { force: true }),
+    rm(resolve(deployRoot, 'pnpm-workspace.yaml'), { force: true }),
+    rm(resolve(deployRoot, 'node_modules', '.modules.yaml'), { force: true }),
+    rm(resolve(deployRoot, 'node_modules', '.pnpm-workspace-state-v1.json'), { force: true }),
+    rm(resolve(deployRoot, 'node_modules', '.pnpm', 'lock.yaml'), { force: true }),
+    rm(resolve(deployRoot, 'node_modules', '@traderalice'), { recursive: true, force: true }),
+    rm(resolve(deployRoot, 'node_modules', '.pnpm', 'node_modules', '@traderalice'), { recursive: true, force: true }),
+  ])
+  const virtualStore = resolve(deployRoot, 'node_modules', '.pnpm')
+  for (const entry of await readdir(virtualStore, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name.startsWith('@traderalice+')) {
+      await rm(resolve(virtualStore, entry.name), { recursive: true, force: true })
+    }
+  }
+  await writeFile(deployedPackagePath, JSON.stringify(releasePackage, null, 2) + '\n')
+}
+
+function externalDependencies(dependencies: Record<string, string> | undefined): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(dependencies ?? {}).filter(([name]) => !name.startsWith('@traderalice/')),
+  )
 }
 
 function requirementsFor(engine: InstallableBrokerEngine): { requirements?: BrokerPackRequirement } {

--- a/scripts/verify-broker-packs.ts
+++ b/scripts/verify-broker-packs.ts
@@ -3,7 +3,7 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { mkdir, mkdtemp, readFile, realpath, rm, stat } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -80,10 +80,16 @@ async function verifyAsset(asset: BrokerPackReleaseAsset, root: string): Promise
   const packageRoot = resolve(root, asset.engine)
   await mkdir(packageRoot)
   await tar.x({ file: archive, cwd: packageRoot, strict: true, preservePaths: false })
-  const pkg = JSON.parse(await readFile(resolve(packageRoot, 'package.json'), 'utf8')) as { name?: unknown; version?: unknown }
+  const pkg = JSON.parse(await readFile(resolve(packageRoot, 'package.json'), 'utf8')) as {
+    name?: unknown
+    version?: unknown
+    dependencies?: Record<string, unknown>
+    optionalDependencies?: Record<string, unknown>
+  }
   if (pkg.name !== `@traderalice/uta-broker-${asset.engine}` || pkg.version !== packageJson.version) {
     throw new Error(`${asset.engine} archive package identity mismatch`)
   }
+  await verifyPortableDeployment(asset.engine, packageRoot, pkg)
 
   const [realRoot, realEntry] = await Promise.all([
     realpath(packageRoot),
@@ -96,6 +102,49 @@ async function verifyAsset(asset: BrokerPackReleaseAsset, root: string): Promise
   verifyModuleInCleanProcess(asset.engine, realEntry, packageRoot)
   await rm(packageRoot, { recursive: true, force: true })
   console.log(`[broker-packs] verified ${asset.engine} (${formatBytes(asset.size)})`)
+}
+
+async function verifyPortableDeployment(
+  engine: InstallableBrokerEngine,
+  packageRoot: string,
+  pkg: { dependencies?: Record<string, unknown>; optionalDependencies?: Record<string, unknown> },
+): Promise<void> {
+  for (const [name, spec] of Object.entries({ ...pkg.dependencies, ...pkg.optionalDependencies })) {
+    if (name.startsWith('@traderalice/')) throw new Error(`${engine} archive contains an unbundled workspace dependency: ${name}`)
+    if (typeof spec !== 'string' || /^(?:file|link|workspace):/.test(spec) || spec.includes('file://')) {
+      throw new Error(`${engine} archive contains a non-portable dependency spec: ${name}@${String(spec)}`)
+    }
+  }
+
+  const forbiddenMetadata = [
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'node_modules/.modules.yaml',
+    'node_modules/.pnpm-workspace-state-v1.json',
+    'node_modules/.pnpm/lock.yaml',
+    'node_modules/@traderalice',
+    'node_modules/.pnpm/node_modules/@traderalice',
+  ]
+  for (const relativePath of forbiddenMetadata) {
+    if (await pathExists(resolve(packageRoot, relativePath))) {
+      throw new Error(`${engine} archive contains workspace/deployment metadata: ${relativePath}`)
+    }
+  }
+  const virtualStore = resolve(packageRoot, 'node_modules', '.pnpm')
+  const workspaceEntries = (await readdir(virtualStore)).filter((name) => name.startsWith('@traderalice+'))
+  if (workspaceEntries.length > 0) {
+    throw new Error(`${engine} archive contains workspace package paths: ${workspaceEntries.join(', ')}`)
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
 }
 
 function verifyModuleInCleanProcess(engine: InstallableBrokerEngine, entry: string, cwd: string): void {

--- a/services/uta/src/domain/trading/brokers/registry.spec.ts
+++ b/services/uta/src/domain/trading/brokers/registry.spec.ts
@@ -33,6 +33,11 @@ async function activateCcxtModule(release: string, source: string) {
   const releaseRoot = resolve(engineRoot, 'releases', release)
   await mkdir(resolve(releaseRoot, 'dist'), { recursive: true })
   await writeFile(resolve(releaseRoot, 'dist/index.js'), source)
+  await writeFile(resolve(releaseRoot, 'package.json'), JSON.stringify({
+    name: '@traderalice/uta-broker-ccxt',
+    version: getCurrentVersion(),
+    type: 'module',
+  }))
   await writeFile(resolve(releaseRoot, 'broker-pack.json'), JSON.stringify({
     schemaVersion: 1,
     apiVersion: 1,
@@ -111,6 +116,20 @@ describe('broker engine registry', () => {
     await expect(loadBrokerEngine('ccxt')).resolves.toMatchObject({
       configSchema: expect.any(Object),
       createBroker: expect.any(Function),
+    })
+  })
+
+  it('wraps a corrupt active pointer as an actionable unavailable-pack error', async () => {
+    const engineRoot = resolve(home, 'runtime/broker-packs/ccxt')
+    await mkdir(engineRoot, { recursive: true })
+    await writeFile(resolve(engineRoot, 'active.json'), '{not-json')
+    const { loadBrokerEngine } = await import('./registry.js')
+
+    await expect(loadBrokerEngine('ccxt')).rejects.toMatchObject({
+      name: 'BrokerPackUnavailableError',
+      code: 'BROKER_PACK_UNAVAILABLE',
+      engine: 'ccxt',
+      message: expect.stringMatching(/is invalid/i),
     })
   })
 })

--- a/services/uta/src/domain/trading/brokers/registry.ts
+++ b/services/uta/src/domain/trading/brokers/registry.ts
@@ -15,6 +15,7 @@ import {
   BROKER_PACK_API_VERSION,
   isInstallableBrokerEngine,
   resolveActiveBrokerPack,
+  type ResolvedBrokerPack,
   type InstallableBrokerEngine,
 } from '@/core/broker-packs.js'
 import { appResourcesHome } from '@/core/paths.js'
@@ -74,7 +75,15 @@ async function loadBrokerEngineUncached(engine: BrokerEngine): Promise<BrokerEng
   }
   if (!isInstallableBrokerEngine(engine)) throw new Error(`Unknown broker engine "${engine}"`)
 
-  const installed = await resolveActiveBrokerPack(engine)
+  let installed: ResolvedBrokerPack | null
+  try {
+    installed = await resolveActiveBrokerPack(engine)
+  } catch (err) {
+    throw new BrokerPackUnavailableError(
+      engine,
+      `Installed broker pack "${engine}" is invalid: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
   if (installed) {
     try {
       return validateModule(engine, await import(pathToFileURL(installed.entry).href))

--- a/src/core/broker-packs.spec.ts
+++ b/src/core/broker-packs.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 
@@ -28,6 +28,9 @@ async function writeActivePack(options: {
   version?: string
   apiVersion?: number
   entry?: string
+  packageName?: string
+  packageVersion?: string
+  writeEntry?: boolean
 } = {}) {
   const { getCurrentVersion } = await import('./version.js')
   const release = options.release ?? '0.80.0-testcontent'
@@ -49,7 +52,14 @@ async function writeActivePack(options: {
     contentId: 'testcontent',
     installedAt: '2026-07-15T00:00:00.000Z',
   }))
-  await writeFile(resolve(releaseRoot, 'dist/index.js'), 'export const ok = true\n')
+  await writeFile(resolve(releaseRoot, 'package.json'), JSON.stringify({
+    name: options.packageName ?? '@traderalice/uta-broker-ccxt',
+    version: options.packageVersion ?? options.version ?? getCurrentVersion(),
+    type: 'module',
+  }))
+  if (options.writeEntry !== false) {
+    await writeFile(resolve(releaseRoot, 'dist/index.js'), 'export const ok = true\n')
+  }
   return { engineRoot, releaseRoot }
 }
 
@@ -115,4 +125,35 @@ describe('resolveActiveBrokerPack', () => {
 
     await expect(resolveActiveBrokerPack('ccxt')).rejects.toThrow(/entry escapes/i)
   })
+
+  it('rejects a missing entry or mismatched package identity as a broken release', async () => {
+    await writeActivePack({ writeEntry: false })
+    const { resolveActiveBrokerPack } = await import('./broker-packs.js')
+    await expect(resolveActiveBrokerPack('ccxt')).rejects.toThrow(/ENOENT/i)
+
+    await writeActivePack({ packageName: '@traderalice/uta-broker-alpaca' })
+    await expect(resolveActiveBrokerPack('ccxt')).rejects.toThrow(/invalid package identity/i)
+  })
+
+  if (process.platform !== 'win32') {
+    it('rejects an entry symlink that resolves outside the immutable release', async () => {
+      const { releaseRoot } = await writeActivePack({ writeEntry: false })
+      const outside = resolve(home, 'outside.js')
+      await writeFile(outside, 'export const escaped = true\n')
+      await symlink(outside, resolve(releaseRoot, 'dist/index.js'))
+      const { resolveActiveBrokerPack } = await import('./broker-packs.js')
+
+      await expect(resolveActiveBrokerPack('ccxt')).rejects.toThrow(/entry escapes/i)
+    })
+
+    it('rejects a release directory symlink that escapes the engine release root', async () => {
+      const { releaseRoot } = await writeActivePack()
+      const outside = resolve(home, 'outside-release')
+      await rename(releaseRoot, outside)
+      await symlink(outside, releaseRoot, 'dir')
+      const { resolveActiveBrokerPack } = await import('./broker-packs.js')
+
+      await expect(resolveActiveBrokerPack('ccxt')).rejects.toThrow(/release escapes/i)
+    })
+  }
 })

--- a/src/core/broker-packs.ts
+++ b/src/core/broker-packs.ts
@@ -3,7 +3,7 @@
  * Alice installs and activates immutable releases; UTA only resolves them.
  */
 
-import { readFile } from 'node:fs/promises'
+import { readFile, realpath } from 'node:fs/promises'
 import { resolve, sep } from 'node:path'
 import { runtimePath } from './paths.js'
 import { getCurrentVersion } from './version.js'
@@ -46,6 +46,12 @@ export interface ResolvedBrokerPack {
   manifest: InstalledBrokerPackManifest
 }
 
+export interface ResolvedBrokerPackRelease {
+  root: string
+  entry: string
+  manifest: InstalledBrokerPackManifest
+}
+
 export function isInstallableBrokerEngine(value: string): value is InstallableBrokerEngine {
   return (INSTALLABLE_BROKER_ENGINES as readonly string[]).includes(value)
 }
@@ -72,12 +78,35 @@ export async function resolveActiveBrokerPack(engine: InstallableBrokerEngine): 
   }
 
   const pointer = parseActivePointer(pointerRaw, engine)
+  const release = await resolveBrokerPackRelease(engine, pointer.release)
+  return { ...release, pointer }
+}
+
+export async function resolveBrokerPackRelease(
+  engine: InstallableBrokerEngine,
+  release: string,
+): Promise<ResolvedBrokerPackRelease> {
+  if (!/^[A-Za-z0-9._-]+$/.test(release)) {
+    throw new Error(`Invalid broker-pack release id for ${engine}`)
+  }
   const releasesRoot = brokerPackReleasesRoot(engine)
-  const root = resolve(releasesRoot, pointer.release)
+  const root = resolve(releasesRoot, release)
   assertChild(releasesRoot, root, 'release')
 
+  const manifestPath = resolve(root, 'broker-pack.json')
+  const packagePath = resolve(root, 'package.json')
+  const [realReleasesRoot, realRoot, realManifest, realPackage] = await Promise.all([
+    realpath(releasesRoot),
+    realpath(root),
+    realpath(manifestPath),
+    realpath(packagePath),
+  ])
+  assertChild(realReleasesRoot, realRoot, 'release')
+  assertChild(realRoot, realManifest, 'manifest')
+  assertChild(realRoot, realPackage, 'package')
+
   const manifest = parseInstalledManifest(
-    JSON.parse(await readFile(resolve(root, 'broker-pack.json'), 'utf8')),
+    JSON.parse(await readFile(manifestPath, 'utf8')),
     engine,
   )
   const currentVersion = getCurrentVersion()
@@ -86,9 +115,15 @@ export async function resolveActiveBrokerPack(engine: InstallableBrokerEngine): 
       `Installed broker pack ${engine} targets OpenAlice ${manifest.version}; ${currentVersion} is running`,
     )
   }
-  const entry = resolve(root, manifest.entry)
-  assertChild(root, entry, 'entry')
-  return { root, entry, pointer, manifest }
+  const pkg = JSON.parse(await readFile(packagePath, 'utf8')) as { name?: unknown; version?: unknown }
+  if (pkg.name !== `@traderalice/uta-broker-${engine}` || pkg.version !== manifest.version) {
+    throw new Error(`Installed broker pack ${engine} has an invalid package identity`)
+  }
+  const declaredEntry = resolve(root, manifest.entry)
+  assertChild(root, declaredEntry, 'entry')
+  const realEntry = await realpath(declaredEntry)
+  assertChild(realRoot, realEntry, 'entry')
+  return { root, entry: declaredEntry, manifest }
 }
 
 function parseActivePointer(raw: unknown, engine: InstallableBrokerEngine): BrokerPackActivePointer {

--- a/src/services/broker-packs/installer.spec.ts
+++ b/src/services/broker-packs/installer.spec.ts
@@ -48,6 +48,7 @@ interface PublishedPackOptions {
   catalogVersion?: string
   catalogPlatform?: NodeJS.Platform
   catalogArch?: string
+  assetVersion?: string
   apiVersion?: number
   includeAsset?: boolean
 }
@@ -72,7 +73,7 @@ async function publishCcxtPack(options: PublishedPackOptions = {}) {
   const catalogName = brokerPackCatalogFileName(version)
   const asset = {
     engine: 'ccxt',
-    version,
+    version: options.assetVersion ?? version,
     apiVersion: options.apiVersion ?? 1,
     file: archiveName,
     entry: 'dist/index.js',
@@ -185,6 +186,31 @@ describe('broker-pack installer', () => {
     await expect(getBrokerPackLocalStatus('ccxt')).resolves.toMatchObject({ installed: true, source: 'downloaded' })
   })
 
+  it('repairs a corrupt content-addressed release without mutating it in place', async () => {
+    const { version } = await publishCcxtPack()
+    const { installBrokerPack, getBrokerPackLocalStatus } = await loadInstaller()
+    await installBrokerPack('ccxt')
+    const { brokerPackEngineRoot, resolveActiveBrokerPack } = await import('../../core/broker-packs.js')
+    const before = await resolveActiveBrokerPack('ccxt')
+    await writeFile(resolve(before!.root, 'package.json'), JSON.stringify({
+      name: '@traderalice/uta-broker-alpaca', version, type: 'module',
+    }))
+
+    await expect(getBrokerPackLocalStatus('ccxt')).resolves.toMatchObject({
+      installed: false, source: 'broken', reason: expect.stringMatching(/package identity/i),
+    })
+    await expect(installBrokerPack('ccxt')).resolves.toMatchObject({ installed: true, source: 'downloaded' })
+
+    const after = await resolveActiveBrokerPack('ccxt')
+    expect(after?.pointer.release).not.toBe(before?.pointer.release)
+    expect(after?.pointer.release).toMatch(/-repair-/)
+    expect(await readdir(resolve(brokerPackEngineRoot('ccxt'), 'releases'))).toHaveLength(2)
+    await expect(getBrokerPackLocalStatus('ccxt')).resolves.toMatchObject({ installed: true, source: 'downloaded' })
+
+    await expect(installBrokerPack('ccxt')).resolves.toMatchObject({ installed: true })
+    expect(await readdir(resolve(brokerPackEngineRoot('ccxt'), 'releases'))).toHaveLength(2)
+  })
+
   it.each([
     ['OpenAlice version', { catalogVersion: '0.0.0-other' }],
     ['platform', { catalogPlatform: process.platform === 'win32' ? 'linux' : 'win32' }],
@@ -201,6 +227,13 @@ describe('broker-pack installer', () => {
     const { installBrokerPack } = await loadInstaller()
 
     await expect(installBrokerPack('ccxt')).rejects.toThrow(/API 2 is unsupported/i)
+  })
+
+  it('rejects an asset version that disagrees with its otherwise compatible catalog', async () => {
+    await publishCcxtPack({ assetVersion: '0.0.0-other' })
+    const { installBrokerPack } = await loadInstaller()
+
+    await expect(installBrokerPack('ccxt')).rejects.toThrow(/asset targets OpenAlice 0\.0\.0-other/i)
   })
 
   it('rejects an archive whose package identity does not match the engine', async () => {
@@ -235,6 +268,24 @@ describe('broker-pack installer', () => {
     const { installBrokerPack } = await loadInstaller()
 
     await expect(installBrokerPack('ccxt')).rejects.toThrow(/already running/i)
+  })
+
+  it('serializes simultaneous installs and leaves one valid active release', async () => {
+    await publishCcxtPack()
+    const { installBrokerPack } = await loadInstaller()
+
+    const results = await Promise.allSettled([
+      installBrokerPack('ccxt'),
+      installBrokerPack('ccxt'),
+    ])
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    expect(results.filter((result) => result.status === 'rejected')).toEqual([
+      expect.objectContaining({ reason: expect.objectContaining({ message: expect.stringMatching(/already running/i) }) }),
+    ])
+    const { brokerPackEngineRoot, resolveActiveBrokerPack } = await import('../../core/broker-packs.js')
+    await expect(resolveActiveBrokerPack('ccxt')).resolves.toMatchObject({ manifest: { engine: 'ccxt' } })
+    expect(await readdir(brokerPackEngineRoot('ccxt'))).not.toContain('.install.lock')
   })
 
   it('recovers an abandoned incomplete lock after its stale window', async () => {

--- a/src/services/broker-packs/installer.ts
+++ b/src/services/broker-packs/installer.ts
@@ -2,7 +2,7 @@
 
 import { createHash } from 'node:crypto'
 import { createReadStream, createWriteStream } from 'node:fs'
-import { access, mkdir, readFile, realpath, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, realpath, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { basename, resolve, sep } from 'node:path'
@@ -14,6 +14,7 @@ import {
   brokerPackEngineRoot,
   brokerPackReleasesRoot,
   resolveActiveBrokerPack,
+  resolveBrokerPackRelease,
   type BrokerPackActivePointer,
   type InstalledBrokerPackManifest,
   type InstallableBrokerEngine,
@@ -64,7 +65,7 @@ export async function installBrokerPack(engine: InstallableBrokerEngine): Promis
     const catalog = await fetchCatalog(catalogUrl)
     const asset = catalog.packs.find((row) => row.engine === engine)
     if (!asset) throw new Error(`No ${engine} broker pack is published for ${process.platform}-${process.arch}`)
-    validateAsset(asset)
+    validateAsset(asset, getCurrentVersion())
     assertBrokerPackRequirements(asset, {
       platform: process.platform,
       glibcVersion: runtimeGlibcVersion(),
@@ -85,8 +86,7 @@ export async function installBrokerPack(engine: InstallableBrokerEngine): Promis
     await validateExtractedPackage(extracted, engine, asset)
 
     const contentId = actualSha.slice(0, 16)
-    const release = `${safePart(asset.version)}-${contentId}`
-    const finalRoot = resolve(brokerPackReleasesRoot(engine), release)
+    const preferredRelease = `${safePart(asset.version)}-${contentId}`
     const installedAt = new Date().toISOString()
     const manifest: InstalledBrokerPackManifest = {
       schemaVersion: BROKER_PACK_SCHEMA_VERSION,
@@ -101,12 +101,7 @@ export async function installBrokerPack(engine: InstallableBrokerEngine): Promis
     await writeFile(resolve(extracted, 'broker-pack.json'), JSON.stringify(manifest, null, 2) + '\n')
 
     await mkdir(brokerPackReleasesRoot(engine), { recursive: true })
-    try {
-      await rename(extracted, finalRoot)
-    } catch (err) {
-      if (!isCode(err, 'EEXIST') && !isCode(err, 'ENOTEMPTY')) throw err
-      await access(resolve(finalRoot, asset.entry))
-    }
+    const release = await activateImmutableRelease(extracted, engine, preferredRelease, asset, contentId)
 
     const pointer: BrokerPackActivePointer = {
       schemaVersion: BROKER_PACK_SCHEMA_VERSION,
@@ -142,12 +137,88 @@ async function fetchCatalog(url: string): Promise<BrokerPackReleaseCatalog> {
   return raw as BrokerPackReleaseCatalog
 }
 
-function validateAsset(asset: BrokerPackReleaseAsset): void {
+function validateAsset(asset: BrokerPackReleaseAsset, currentVersion: string): void {
+  if (asset.version !== currentVersion) throw new Error(`Broker-pack asset targets OpenAlice ${asset.version}; expected ${currentVersion}`)
   if (asset.apiVersion !== BROKER_PACK_API_VERSION) throw new Error(`Broker-pack API ${asset.apiVersion} is unsupported`)
   if (!/^[A-Za-z0-9._-]+$/.test(asset.file) || basename(asset.file) !== asset.file) throw new Error('Invalid broker-pack asset name')
   if (!/^[a-f0-9]{64}$/.test(asset.sha256)) throw new Error('Invalid broker-pack checksum')
   if (!Number.isSafeInteger(asset.size) || asset.size <= 0 || asset.size > MAX_PACK_BYTES) throw new Error('Invalid broker-pack size')
   if (!asset.entry || asset.entry.startsWith('/') || asset.entry.includes('..')) throw new Error('Invalid broker-pack entry')
+}
+
+async function activateImmutableRelease(
+  extracted: string,
+  engine: InstallableBrokerEngine,
+  preferredRelease: string,
+  asset: BrokerPackReleaseAsset,
+  contentId: string,
+): Promise<string> {
+  const active = await resolveActiveBrokerPack(engine).catch(() => null)
+  if (
+    active
+    && active.manifest.contentId === contentId
+    && active.manifest.entry === asset.entry
+    && active.manifest.version === asset.version
+  ) {
+    return active.pointer.release
+  }
+
+  if (await releaseMatches(engine, preferredRelease, asset, contentId)) return preferredRelease
+
+  const preferredRoot = resolve(brokerPackReleasesRoot(engine), preferredRelease)
+  if (!await pathExists(preferredRoot)) {
+    try {
+      await rename(extracted, preferredRoot)
+      return preferredRelease
+    } catch (err) {
+      // A destination may appear between the existence check and rename. This
+      // is also how Windows reports a rename onto an existing directory.
+      if (await releaseMatches(engine, preferredRelease, asset, contentId)) return preferredRelease
+      if (!await pathExists(preferredRoot)) throw err
+    }
+  }
+
+  // Never mutate a corrupt immutable release in place: the running UTA may
+  // still have its native files open on Windows. Install a fresh repair release
+  // and switch active.json only after the replacement is complete.
+  const repairRelease = await nextRepairReleaseId(engine, preferredRelease)
+  await rename(extracted, resolve(brokerPackReleasesRoot(engine), repairRelease))
+  return repairRelease
+}
+
+async function releaseMatches(
+  engine: InstallableBrokerEngine,
+  release: string,
+  asset: BrokerPackReleaseAsset,
+  contentId: string,
+): Promise<boolean> {
+  try {
+    const existing = await resolveBrokerPackRelease(engine, release)
+    return existing.manifest.contentId === contentId
+      && existing.manifest.entry === asset.entry
+      && existing.manifest.version === asset.version
+  } catch {
+    return false
+  }
+}
+
+async function nextRepairReleaseId(engine: InstallableBrokerEngine, base: string): Promise<string> {
+  const stamp = `${Date.now()}-${process.pid}`
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const release = `${base}-repair-${stamp}-${attempt}`
+    if (!await pathExists(resolve(brokerPackReleasesRoot(engine), release))) return release
+  }
+  throw new Error(`Unable to allocate a repair release for ${engine}`)
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch (err) {
+    if (isCode(err, 'ENOENT')) return false
+    throw err
+  }
 }
 
 async function download(url: string, target: string, expectedSize: number): Promise<void> {
@@ -161,16 +232,21 @@ async function download(url: string, target: string, expectedSize: number): Prom
 }
 
 async function validateExtractedPackage(root: string, engine: InstallableBrokerEngine, asset: BrokerPackReleaseAsset): Promise<void> {
-  const pkg = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8')) as { name?: unknown; version?: unknown }
-  if (pkg.name !== `@traderalice/uta-broker-${engine}`) throw new Error(`Broker-pack package name mismatch for ${engine}`)
-  if (pkg.version !== asset.version) throw new Error(`Broker-pack package version mismatch for ${engine}`)
-  const [realRoot, realEntry] = await Promise.all([
+  const packagePath = resolve(root, 'package.json')
+  const [realRoot, realPackage, realEntry] = await Promise.all([
     realpath(root),
+    realpath(packagePath),
     realpath(resolve(root, asset.entry)),
   ])
+  if (realPackage === realRoot || !realPackage.startsWith(`${realRoot}${sep}`)) {
+    throw new Error(`Broker-pack package metadata escapes the extracted package for ${engine}`)
+  }
   if (realEntry === realRoot || !realEntry.startsWith(`${realRoot}${sep}`)) {
     throw new Error(`Broker-pack entry escapes the extracted package for ${engine}`)
   }
+  const pkg = JSON.parse(await readFile(packagePath, 'utf8')) as { name?: unknown; version?: unknown }
+  if (pkg.name !== `@traderalice/uta-broker-${engine}`) throw new Error(`Broker-pack package name mismatch for ${engine}`)
+  if (pkg.version !== asset.version) throw new Error(`Broker-pack package version mismatch for ${engine}`)
 }
 
 function resolveCatalogUrl(): string {

--- a/src/webui/routes/trading-config.spec.ts
+++ b/src/webui/routes/trading-config.spec.ts
@@ -123,6 +123,24 @@ describe('GET /broker-packs — optional engine requirements', () => {
       requiredBy: ['Main OKX'],
     }))
   })
+
+  it('keeps pack recovery UI available when a legacy account references a removed preset', async () => {
+    utaStore = [{
+      id: 'legacy-account', label: 'Legacy account', presetId: 'removed-preset', enabled: true,
+      presetConfig: {}, guards: [], asVendor: true,
+    }]
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { status, body } = await req(makeRoutes(), 'GET', '/broker-packs')
+
+    expect(status).toBe(200)
+    expect((body as { packs: unknown[] }).packs).toHaveLength(6)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('legacy-account'),
+      expect.stringMatching(/unknown broker preset/i),
+    )
+    warn.mockRestore()
+  })
 })
 
 describe('POST /broker-packs/:engine/install', () => {

--- a/src/webui/routes/trading-config.ts
+++ b/src/webui/routes/trading-config.ts
@@ -99,7 +99,16 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
       const requiredBy = new Map<string, string[]>()
       for (const account of accounts) {
         if (account.enabled === false) continue
-        const engine = getBrokerPreset(account.presetId).engine
+        let engine: string
+        try {
+          engine = getBrokerPreset(account.presetId).engine
+        } catch (err) {
+          console.warn(
+            `[trading-config] unable to map UTA ${account.id} to a Broker Pack:`,
+            err instanceof Error ? err.message : err,
+          )
+          continue
+        }
         const rows = requiredBy.get(engine) ?? []
         rows.push(account.label ?? account.id)
         requiredBy.set(engine, rows)


### PR DESCRIPTION
## What changed

- make Broker Pack activation idempotent across Windows/macOS/Linux, including Windows directory-rename `EPERM`
- repair corrupt content-addressed releases by installing a fresh immutable release instead of mutating loaded native files
- validate active release/package/entry containment and surface corrupt packs as actionable unavailable-pack errors
- bundle OpenAlice-owned runtime dependencies, strip workspace/pnpm build metadata and absolute build paths, and verify each archive in a clean Node process
- keep the Broker Pack recovery UI available when legacy UTA configs reference removed presets
- document the repair and portable-release contracts

## Root cause

The previous idempotent install path assumed directory rename collisions would report `EEXIST` or `ENOTEMPTY`. Windows reports `EPERM` when renaming the staged payload onto an existing release directory. Separately, `pnpm deploy` preserved workspace file URLs, lockfiles, and build-machine paths in release artifacts.

## User impact

Repeated installs and repairs now reuse valid releases or atomically switch to a new repair release. Installed Broker Packs no longer expose the build workspace, and UTA/keyless vendor activation remains separate from installation.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 274 files passed, 2904 tests passed
- `pnpm broker-packs:build` and `pnpm broker-packs:verify` — 5 platform artifacts imported in clean processes
- isolated live UI: CCXT install, corrupt-release repair/reinstall, Binance keyless source enable/disable, Alpaca install-before-credentials
- `pnpm electron:smoke:workspace` — temporary packaged Electron acceptance passed
