### PR TITLE
Add sticky Issue ownership and field-level Activity

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -179,8 +179,10 @@ the whole board (all workspaces); `create` / `update` / `comment` write **this**
 workspace's own `.alice/issues/` files (changing a peer's board is the
 human-approved peer-edit path). The full on-disk file model + self-scheduling
 (an issue with a `when` fires a headless run) lives in the **`self-scheduling`**
-skill. `assignee` is the single ownership and dispatch contract: `@workspace`
-recruits a new Session each fire, `@me` resolves to the caller, and an exact
-`@resumeId` keeps one accountable product Session. Issue/Inbox CLI actions are
-signed automatically. End standalone reports with `Signed-by: @resumeId`
+skill. `assignee` is the single ownership and dispatch contract: `@new`
+recruits once and then keeps that first Session, `@workspace` recruits a new
+Session each fire, `@me` resolves to the caller, and an exact `@resumeId` keeps
+one accountable product Session. Commit intentional Issue-file changes as a
+focused Git change; Activity remains an audit fallback, while Git is the exact
+rollback history. Issue/Inbox CLI actions are signed automatically. End standalone reports with `Signed-by: @resumeId`
 (copy it from `signature show`) so another Agent can return to the author.

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -151,12 +151,16 @@ plain tracked item; add a `when` and it starts firing.
 - **`assignee`** *(optional)* — the single owner and
   scheduled-dispatch policy:
   - `@workspace` recruits a new product Session for each scheduled fire;
+  - `@new` asks the Workspace to recruit once; the first successful dispatch
+    rewrites the Issue to that concrete `@resumeId`, so every later fire returns
+    to the same accountable coworker;
   - an exact `@resumeId` continues that accountable Session, even when its
     signed Workspace differs from the Issue's Workspace;
   - `@human` and `@unassigned` are valid only for unscheduled work.
   CLI `issue create` defaults to `@me` when called by an attributable Session
   (who creates it owns it); `@me` is resolved to a concrete `@resumeId` before
-  writing. Use `@workspace` explicitly when every fire should recruit a newcomer.
+  writing. Use `@new` when the job needs a new long-lived owner, and
+  `@workspace` explicitly only when every fire should recruit a newcomer.
 - **`when`** *(OPTIONAL — present iff the issue self-schedules)* — one of:
   - `{ kind: every, every: "30m" }` — repeat on an interval (`30m`, `2h`,
     `1h30m`). Runs on the next scan, then on the interval.
@@ -169,9 +173,10 @@ plain tracked item; add a `when` and it starts firing.
     only for compatibility with old files; new Issues should write it explicitly.
   - `{ kind: at, at: "2026-03-01T13:30:00Z" }` — run ONCE at an ISO timestamp,
     then never again.
-- **`agent`** *(optional)* — runtime override for `workspace`-owned scheduled
-  work; defaults to this Workspace's runtime resolution. A Session assignee
-  already has an immutable runtime, so Session-owned Issues cannot set this.
+- **`agent`** *(optional)* — runtime override for `@new` / `@workspace`
+  scheduled work; defaults to this Workspace's runtime resolution. An exact
+  Session assignee already has an immutable runtime, so Session-owned Issues
+  cannot set this.
 
 The old parallel `execution` field is retired and rejected after migration;
 never write it into a new Issue.
@@ -180,6 +185,12 @@ The markdown **What** below the closing `---` is the Issue's canonical work
 definition. It is useful for every Issue; when scheduled, this exact visible
 markdown becomes the headless prompt. Comments are separate structured markdown
 records in `.alice/issues/<id>.comments.json`, written through `issue comment`.
+
+Issue files are part of the Workspace's Git history. After intentionally
+creating or modifying `.alice/issues/<id>.md`, make a focused Git commit for
+that work-definition change; never sweep unrelated working-tree changes into
+it. OpenAlice Activity is the readable audit fallback (including edits made
+without a commit), while Git is the exact-content history and rollback layer.
 
 ## Link entities and issues with `[[name]]`
 

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -286,6 +286,13 @@ richer version of that same event. Scheduled/headless executions remain in the
 independent `runs[]` operational ledger; high-volume runtime history must not
 swallow the human-facing Activity timeline.
 
+Updated activities carry compact field-level before/after values. The large
+markdown What document is recorded only as “edited What”; its exact contents
+belong in the Workspace Git history. A launcher-owned snapshot detects direct
+Issue-file edits that bypass UI/CLI mutation routes. Such edits are attributed
+to a Session only when exactly one Session could have made them; concurrent
+edits remain explicitly unknown rather than crediting the wrong coworker.
+
 When an Issue has a fixed `@resumeId` owner, a comment from somebody else is
 delivered to that exact Session. The final assistant response is recorded as a
 reply comment, linked by `replyTo`; delivery state stays on the source comment.
@@ -313,7 +320,19 @@ authoritative product Session; OpenAlice resolves and persists the concrete
 `@resumeId` server-side. `@me` is never stored. A human UI may select an
 existing resumable Workspace Session.
 
-#### Mode B: a fresh worker per fire
+#### Mode B: recruit once, then keep that worker
+
+```yaml
+assignee: "@new"
+```
+
+- The first scheduled fire creates a new headless product Session.
+- OpenAlice immediately rewrites `@new` to that Session's exact `@resumeId`.
+- Later fires and Issue comments continue the same accountable coworker.
+- The Issue may specify `agent` before the first claim; after the claim, the
+  concrete Session owns its runtime.
+
+#### Mode C: a fresh worker per fire
 
 ```yaml
 assignee: "@workspace"
@@ -326,7 +345,7 @@ assignee: "@workspace"
   a unique worker.
 - Each run keeps its own origin so a user can still ask that specific worker.
 
-The Issue's creator provenance is stamped separately in both modes. Workspace
+The Issue's creator provenance is stamped separately in all modes. Workspace
 ownership does not erase who designed the Issue.
 
 Migration `0018_issue_assignee_ownership` removes the former `execution` field
@@ -429,8 +448,9 @@ approval state, routing, fills, and slippage.
 9. Mutable artifacts retain occurrence-level provenance instead of one mutable
    “author” field.
 10. Issue creation provenance and future execution responsibility are separate.
-11. Issue assignee is the only ownership/dispatch contract: `@workspace` or an
-    exact `@resumeId` for scheduled work.
+11. Issue assignee is the only ownership/dispatch contract: `@new` recruits
+    once and becomes an exact owner, `@workspace` recruits on every fire, and
+    an exact `@resumeId` continues one known Session.
 12. Trade decision attribution and trade execution authority remain separate.
 13. Provenance is stamped from authoritative context, not asserted by an agent.
 14. Existing UUID `resumeId`s remain valid; readable ids apply only to new

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -48,6 +48,8 @@ The filename stem is the stable issue id. Frontmatter:
 - `status` — `backlog | todo | in_progress | done | canceled`; default `todo`.
 - `priority` — `urgent | high | medium | low | none`; default `none`.
 - `assignee` — the single ownership and dispatch contract:
+  - `@new` means the owning Workspace recruits one new product Session on the
+    first fire, then persists that concrete Session as the future owner;
   - `@workspace` means the owning Workspace recruits a new product Session for
     every scheduled fire;
   - an exact `@resumeId` continues one accountable product Session;
@@ -56,7 +58,7 @@ The filename stem is the stable issue id. Frontmatter:
   - `{ kind: at, at: <ISO timestamp> }`
   - `{ kind: every, every: <duration> }`
   - `{ kind: cron, cron: <5-field expression>, timezone: local | <IANA zone> }`
-- `agent` — optional CLI adapter id for `@workspace`-owned scheduled work;
+- `agent` — optional CLI adapter id for `@new` / `@workspace` scheduled work;
   otherwise Workspace/default resolution is used. A Session assignee already
   owns its runtime and cannot be overridden here.
 
@@ -289,10 +291,19 @@ use a later collect or one-shot read; agents should not manufacture shell sleep
 loops.
 
 The Issue detail UI treats scheduling as an intrinsic Work item capability.
-`assignee: "@workspace"` recruits a new Session on every fire;
-`assignee: "@resumeId"` keeps one responsible Session. Only the latter
-has a stable owner to ask; Workspace-owned execution exposes the creator and
-each concrete run as separate follow-up targets.
+`assignee: "@new"` recruits one fresh Session on the first fire and then
+rewrites itself to that concrete `@resumeId`; `assignee: "@workspace"`
+recruits a new Session on every fire; `assignee: "@resumeId"` keeps one already
+known responsible Session. The first and third modes produce a stable owner to
+ask; `@workspace` execution exposes the creator and each concrete run as
+separate follow-up targets.
+
+Issue mutation has two complementary histories. Activity records attributable
+field-level changes (and marks the canonical What document as edited without
+copying its body into launcher state), including direct file edits detected by
+the live scanner. The Workspace Git log remains the exact-content rollback
+layer, so agents should make a focused commit after intentionally changing an
+Issue file. Activity stays useful even if that commit is forgotten.
 
 Scheduling never bypasses trading approval. A headless agent may research or
 stage a trade, but execution remains behind UTA/Trading-as-Git permission and

--- a/src/core/provenance-store.spec.ts
+++ b/src/core/provenance-store.spec.ts
@@ -84,6 +84,35 @@ describe('ArtifactProvenanceStore', () => {
     expect(reloaded.list()).toEqual([expect.objectContaining({ id: first.id, at: 250 })])
   })
 
+  it('merges field changes across one editing activity and drops net-zero fields', async () => {
+    const { value } = await store()
+    const input = {
+      artifact: { kind: 'issue' as const, workspaceId: 'ws-1', issueId: 'i1' },
+      action: 'updated' as const,
+      origin: { kind: 'human' as const },
+    }
+    await value.append({
+      ...input,
+      at: 100,
+      mutation: { fields: [{ field: 'status', before: 'todo', after: 'in_progress' }] },
+    }, { coalesceWithinMs: 300 })
+    await value.append({
+      ...input,
+      at: 200,
+      mutation: { fields: [
+        { field: 'status', before: 'in_progress', after: 'todo' },
+        { field: 'priority', before: 'none', after: 'high' },
+      ] },
+    }, { coalesceWithinMs: 300 })
+
+    expect(value.list()).toEqual([
+      expect.objectContaining({
+        at: 200,
+        mutation: { fields: [{ field: 'priority', before: 'none', after: 'high' }] },
+      }),
+    ])
+  })
+
   it('starts a new activity after an intervening event or a different origin', async () => {
     const { value } = await store()
     const artifact = { kind: 'issue' as const, workspaceId: 'ws-1', issueId: 'i1' }

--- a/src/core/provenance-store.ts
+++ b/src/core/provenance-store.ts
@@ -56,6 +56,20 @@ const originSchema = z.union([
 ])
 export type ArtifactOrigin = z.infer<typeof originSchema>
 
+/** Compact field-level audit payload. Large documents such as Issue What are
+ * represented by a field-only entry; Git remains the content rollback layer. */
+const provenanceFieldChangeSchema = z.object({
+  field: z.string().min(1).max(64),
+  before: z.string().max(1000).optional(),
+  after: z.string().max(1000).optional(),
+})
+export type ProvenanceFieldChange = z.infer<typeof provenanceFieldChangeSchema>
+
+const provenanceMutationSchema = z.object({
+  fields: z.array(provenanceFieldChangeSchema).min(1).max(24),
+})
+export type ProvenanceMutation = z.infer<typeof provenanceMutationSchema>
+
 const recordSchema = z.object({
   id: z.string().min(1),
   artifact: artifactRefSchema,
@@ -63,6 +77,7 @@ const recordSchema = z.object({
   origin: originSchema,
   at: z.number().finite(),
   fingerprint: z.string().min(1).optional(),
+  mutation: provenanceMutationSchema.optional(),
 })
 export type ProvenanceRecord = z.infer<typeof recordSchema>
 
@@ -144,6 +159,11 @@ export class ArtifactProvenanceStore implements IProvenanceStore {
         artifactOriginsMatch(previous.origin, candidate.origin) &&
         elapsed >= 0 && elapsed <= coalesceWithinMs
       ) {
+        if (candidate.mutation) {
+          const merged = mergeProvenanceMutation(previous.mutation, candidate.mutation)
+          if (merged.fields.length > 0) previous.mutation = merged
+          else delete previous.mutation
+        }
         previous.at = candidate.at
         await this.flush()
         return previous
@@ -187,6 +207,34 @@ export class ArtifactProvenanceStore implements IProvenanceStore {
       this.logger.warn('provenance_store.flush_failed', { err })
     }
   }
+}
+
+/** Keep the first observed value and the latest value inside one autosave/edit
+ * window. A field that returns to its original value disappears from the net
+ * activity; content-only fields remain as one compact "edited" entry. */
+export function mergeProvenanceMutation(
+  previous: ProvenanceMutation | undefined,
+  next: ProvenanceMutation,
+): ProvenanceMutation {
+  const fields = new Map<string, ProvenanceFieldChange>()
+  for (const change of previous?.fields ?? []) fields.set(change.field, { ...change })
+  for (const change of next.fields) {
+    const earlier = fields.get(change.field)
+    const merged: ProvenanceFieldChange = earlier
+      ? {
+          field: change.field,
+          ...(earlier.before !== undefined ? { before: earlier.before } : {}),
+          ...(change.after !== undefined ? { after: change.after } : {}),
+        }
+      : { ...change }
+    if (
+      merged.before !== undefined &&
+      merged.after !== undefined &&
+      merged.before === merged.after
+    ) fields.delete(change.field)
+    else fields.set(change.field, merged)
+  }
+  return { fields: [...fields.values()] }
 }
 
 /** Product identity equality for grouping activity without exposing runtime

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -106,6 +106,18 @@ describe('issue_create', () => {
     expect((await readBack('fresh-owner'))?.assignee).toBe('@workspace')
   })
 
+  it('accepts @new as an explicit recruit-once ownership policy', async () => {
+    const created = await run(issueCreateFactory.build(ctx()), {
+      id: 'sticky-owner',
+      title: 'Sticky owner',
+      when: { kind: 'every', every: '30m' },
+      assignee: '@new',
+      agent: 'pi',
+    })
+    expect(created.ok).toBe(true)
+    expect(await readBack('sticky-owner')).toMatchObject({ assignee: '@new', agent: 'pi' })
+  })
+
   it('defaults creation to the server-attributed current Session', async () => {
     const context = ctx({
       origin: {

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -55,6 +55,7 @@ import {
   type IssueComment,
 } from '../workspaces/issues/comments.js'
 import { dispatchIssueCommentReply } from '../workspaces/issues/comment-delivery.js'
+import { issueMutation, issueMutationFingerprint } from '../workspaces/issues/change-tracker.js'
 import {
   WORKSPACE_ASSIGNEE,
   normalizeIssueAssigneeAlias,
@@ -102,7 +103,7 @@ async function remoteIssueWriteHint(ctx: WorkspaceToolContext, id: string): Prom
 
 const issueAssigneeInputSchema = z.string().min(1).refine(
   (value) => value.toLowerCase() === '@me' || issueAssigneeSchema.safeParse(normalizeIssueAssigneeAlias(value)).success,
-  'assignee must be @me, @workspace, @human, @unassigned, or an exact @resumeId',
+  'assignee must be @me, @new, @workspace, @human, @unassigned, or an exact @resumeId',
 )
 
 function resolveIssueAssignee(
@@ -165,18 +166,26 @@ async function recordIssueProvenance(
   ctx: WorkspaceToolContext,
   issueId: string,
   action: Extract<ProvenanceAction, 'created' | 'updated' | 'commented'>,
+  mutationInput?: { before: IssueRecord; after: IssueRecord },
 ): Promise<void> {
   if (!ctx.provenanceStore) return
   const origin = sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin) ?? {
     kind: 'unknown' as const,
     reason: 'missing-session-origin',
   }
+  const mutation = mutationInput
+    ? issueMutation(mutationInput.before, mutationInput.after)
+    : null
   const input = {
     artifact: { kind: 'issue' as const, workspaceId: ctx.workspaceId, issueId },
     action,
     origin,
     at: Date.now(),
     ...(action === 'created' ? { fingerprint: `issue:${ctx.workspaceId}:${issueId}:created` } : {}),
+    ...(mutationInput && mutation ? {
+      mutation,
+      fingerprint: issueMutationFingerprint(ctx.workspaceId, issueId, mutationInput.after),
+    } : {}),
   }
   if (action === 'updated') {
     await ctx.provenanceStore.append(input, { coalesceWithinMs: ACTIVITY_UPDATE_COALESCE_MS })
@@ -287,7 +296,8 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
         '',
         'Patch any subset of `status`, `priority`, `assignee`, `what`; omitted fields are',
         'left untouched. `assignee:"@me"` binds this current product',
-        'Session; pass an exact `@resumeId` to assign another known Session. What is the',
+        'Session; `@new` recruits once and assigns that first Session permanently;',
+        'pass an exact `@resumeId` to assign another known Session. What is the',
         'canonical markdown work definition and exact scheduled prompt. Other scheduling',
         'frontmatter (`when`/`agent`) is preserved — edit it by writing the file directly',
         '(`.alice/issues/<id>.md`).',
@@ -301,7 +311,7 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
         priority: z.enum(ISSUE_PRIORITIES).optional().describe('New priority.'),
         assignee: issueAssigneeInputSchema
           .optional()
-          .describe('@workspace, @human, @unassigned, @me, or an exact @resumeId.'),
+          .describe('@new, @workspace, @human, @unassigned, @me, or an exact @resumeId.'),
         what: z.string().min(1).optional().describe('Canonical markdown work definition; exact scheduled prompt.'),
       }),
       execute: async ({ id, status, priority, assignee, what }) => {
@@ -319,7 +329,10 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
           what,
         })
         if (res.ok) {
-          await recordIssueProvenance(ctx, res.issue.id, 'updated')
+          await recordIssueProvenance(ctx, res.issue.id, 'updated', {
+            before: res.previous,
+            after: res.issue,
+          })
           return { ok: true as const, issue: rowOf(res.issue) }
         }
         if (res.reason === 'not_found') {
@@ -418,7 +431,8 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         'the scanner sends that exact visible What to the Agent Runtime; without',
         '`when` the same What remains a pure board work item. Assignee is the',
         'only ownership field:',
-        '`@workspace` recruits a new Session each fire. `@me` resolves to this',
+        '`@new` recruits once and keeps that first Session as owner. `@workspace`',
+        'recruits a new Session each fire. `@me` resolves to this',
         'calling Session, while an exact `@resumeId` keeps one accountable',
         'Session (including a deliberately signed Session from another Workspace).',
         'A scheduled run is unattended: if its result is meant for the human,',
@@ -435,12 +449,12 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         priority: z.enum(ISSUE_PRIORITIES).optional().describe('Initial priority (default "none").'),
         assignee: issueAssigneeInputSchema
           .optional()
-          .describe('Initial owner. Omit or use @me for the current Session; use @workspace to recruit a fresh Session each fire.'),
+          .describe('Initial owner. Omit or use @me for the current Session; @new recruits once and keeps that Session; @workspace recruits a fresh Session each fire.'),
         when: issueWhenSchema
           .optional()
           .describe('Schedule shape — { kind:"at", at } | { kind:"every", every } | { kind:"cron", cron, timezone?:"local"|IANA }. Present iff the issue self-schedules.'),
         what: z.string().min(1).optional().describe('Markdown work definition; exact scheduled prompt. Defaults to title.'),
-        agent: z.string().min(1).optional().describe('Adapter id when assignee is @workspace; Session assignees own their runtime.'),
+        agent: z.string().min(1).optional().describe('Adapter id when assignee is @new or @workspace; an exact Session owns its runtime.'),
       }),
       execute: async ({ title, id, status, priority, assignee, when, what, agent }) => {
         const dir = selfDir(ctx)

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -197,6 +197,15 @@ describe('PATCH /api/issues/:wsId/:id', () => {
       artifact: { kind: 'issue', workspaceId: 'ws-1', issueId: 'i1' },
       action: 'updated',
       origin: { kind: 'human' },
+      mutation: {
+        fields: expect.arrayContaining([
+          { field: 'status', before: 'todo', after: 'in_progress' },
+          { field: 'priority', before: 'none', after: 'high' },
+          { field: 'assignee', before: '@workspace', after: '@human' },
+          { field: 'runtime', after: 'pi' },
+          { field: 'what' },
+        ]),
+      },
     }), { coalesceWithinMs: 900000 })
   })
 

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -30,6 +30,7 @@ import type { WorkspaceConversationControl } from '../../core/workspace-tool-cen
 import { ACTIVITY_UPDATE_COALESCE_MS } from '../../core/provenance-store.js'
 import { createWorkspaceConversationControl } from '../../workspaces/conversation-control.js'
 import { dispatchIssueCommentReply } from '../../workspaces/issues/comment-delivery.js'
+import { issueMutation, issueMutationFingerprint } from '../../workspaces/issues/change-tracker.js'
 import { updateIssueCommentDelivery } from '../../workspaces/issues/comments.js'
 import {
   ISSUE_PRIORITIES,
@@ -152,7 +153,7 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
       const a = fields['assignee']
       const assignee = typeof a === 'string' ? issueAssigneeSchema.safeParse(a.trim()) : null
       if (!assignee?.success) {
-        return c.json({ error: 'invalid_assignee', message: 'assignee must be @workspace, @human, @unassigned, or an exact @resumeId' }, 400)
+        return c.json({ error: 'invalid_assignee', message: 'assignee must be @workspace, @new, @human, @unassigned, or an exact @resumeId' }, 400)
       }
       const resumeId = issueAssigneeResumeId(assignee.data)
       if (resumeId) {
@@ -213,11 +214,16 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
         if (res.reason === 'not_found') return c.json({ error: 'not_found' }, 404)
         return c.json({ error: 'invalid_issue', message: res.error }, 422)
       }
+      const mutation = issueMutation(res.previous, res.issue)
       await svc.provenanceStore.append({
         artifact: { kind: 'issue', workspaceId: wsId, issueId: id },
         action: 'updated',
         origin: { kind: 'human' },
         at: Date.now(),
+        ...(mutation ? {
+          mutation,
+          fingerprint: issueMutationFingerprint(wsId, id, res.issue),
+        } : {}),
       }, { coalesceWithinMs: ACTIVITY_UPDATE_COALESCE_MS })
       launcherLogger.info('issue.updated', { wsId, id, fields: Object.keys(patch) })
       const detail = await svc.issueDetail(wsId, id)

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -15,6 +15,7 @@ import type { InboxEntry } from '../../core/inbox-store.js'
 import {
   ACTIVITY_UPDATE_COALESCE_MS,
   artifactOriginsMatch,
+  type ProvenanceMutation,
   type ArtifactOrigin,
   type ProvenanceAction,
   type ProvenanceRecord,
@@ -261,6 +262,7 @@ export interface IssueProvenanceRecord {
   action: ProvenanceAction
   origin: ArtifactOrigin
   at: number
+  mutation?: ProvenanceMutation
 }
 
 export type IssueActivityRecord =
@@ -284,7 +286,13 @@ export function issueProvenanceRecords(
     ) continue
     compacted.push(record)
   }
-  return compacted.map(({ id, action, origin, at }) => ({ id, action, origin, at }))
+  return compacted.map(({ id, action, origin, at, mutation }) => ({
+    id,
+    action,
+    origin,
+    at,
+    ...(mutation ? { mutation } : {}),
+  }))
 }
 
 /** Agent/UI-safe projection of one execution. `resumeId` is the only public

--- a/src/workspaces/issues/change-tracker.spec.ts
+++ b/src/workspaces/issues/change-tracker.spec.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ArtifactProvenanceStore } from '../../core/provenance-store.js'
+import type { Logger } from '../logger.js'
+import type { IssueRecord } from './declaration.js'
+import {
+  IssueChangeTracker,
+  issueMutationFingerprint,
+} from './change-tracker.js'
+
+const dirs: string[] = []
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+const logger = { warn: vi.fn() } as unknown as Logger
+const human = { kind: 'human' as const }
+
+function issue(overrides: Partial<IssueRecord> = {}): IssueRecord {
+  return {
+    id: 'market-scan',
+    title: 'Market scan',
+    status: 'todo',
+    priority: 'none',
+    assignee: '@workspace',
+    what: 'Read the market.',
+    ...overrides,
+  }
+}
+
+async function harness() {
+  const dir = await mkdtemp(join(tmpdir(), 'issue-change-tracker-'))
+  dirs.push(dir)
+  const provenance = await ArtifactProvenanceStore.load(join(dir, 'provenance.json'), logger)
+  const path = join(dir, 'issue-audit-snapshots.json')
+  return {
+    path,
+    provenance,
+    tracker: await IssueChangeTracker.load(path, provenance, logger),
+  }
+}
+
+describe('IssueChangeTracker', () => {
+  it('persists a baseline and detects direct file changes after restart', async () => {
+    const { path, provenance, tracker } = await harness()
+    await tracker.observeWorkspace({ workspaceId: 'ws-1', issues: [issue()], origin: human, now: 10 })
+    expect(provenance.list()).toHaveLength(0)
+
+    const restarted = await IssueChangeTracker.load(path, provenance, logger)
+    await restarted.observeWorkspace({
+      workspaceId: 'ws-1',
+      issues: [issue({ status: 'in_progress', priority: 'high', what: 'Scan breadth and tape.' })],
+      origin: { kind: 'unknown', reason: 'direct-file-edit' },
+      now: 20,
+    })
+
+    expect(provenance.list()).toEqual([
+      expect.objectContaining({
+        action: 'updated',
+        origin: { kind: 'unknown', reason: 'direct-file-edit' },
+        mutation: {
+          fields: [
+            { field: 'status', before: 'todo', after: 'in_progress' },
+            { field: 'priority', before: 'none', after: 'high' },
+            { field: 'what' },
+          ],
+        },
+      }),
+    ])
+  })
+
+  it('deduplicates a known UI or CLI mutation by final-state fingerprint', async () => {
+    const { provenance, tracker } = await harness()
+    const before = issue()
+    const after = issue({ assignee: '@new' })
+    await tracker.observeWorkspace({ workspaceId: 'ws-1', issues: [before], origin: human, now: 10 })
+    await provenance.append({
+      artifact: { kind: 'issue', workspaceId: 'ws-1', issueId: after.id },
+      action: 'updated',
+      origin: human,
+      at: 20,
+      mutation: { fields: [{ field: 'assignee', before: '@workspace', after: '@new' }] },
+      fingerprint: issueMutationFingerprint('ws-1', after.id, after),
+    })
+
+    await tracker.observeWorkspace({ workspaceId: 'ws-1', issues: [after], origin: human, now: 21 })
+
+    expect(provenance.list()).toHaveLength(1)
+  })
+})

--- a/src/workspaces/issues/change-tracker.ts
+++ b/src/workspaces/issues/change-tracker.ts
@@ -1,0 +1,235 @@
+/**
+ * Issue change observation and field-level audit details.
+ *
+ * Issue markdown is intentionally editable outside OpenAlice's mutation APIs.
+ * The tracker therefore keeps a compact launcher-owned snapshot and compares
+ * every later scan. Known UI/CLI mutations use the same diff + fingerprint, so
+ * an observer pass cannot duplicate a mutation that was already attributed.
+ * Git remains the content/version rollback layer; this file stores only small
+ * field values and a hash for the markdown What document.
+ */
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+import type {
+  ArtifactOrigin,
+  IProvenanceStore,
+  ProvenanceMutation,
+} from '../../core/provenance-store.js'
+import { ACTIVITY_UPDATE_COALESCE_MS } from '../../core/provenance-store.js'
+import type { Logger } from '../logger.js'
+import type { IssueRecord } from './declaration.js'
+
+export interface IssueAuditSnapshot {
+  title: string
+  status: string
+  priority: string
+  assignee: string
+  schedule?: string
+  agent?: string
+  whatHash: string
+}
+
+interface TrackerFile {
+  version: 1
+  workspaces: Record<string, Record<string, IssueAuditSnapshot>>
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function compactAuditValue(value: string): string {
+  return value.length <= 1000 ? value : `${value.slice(0, 999)}…`
+}
+
+export function issueAuditSnapshot(issue: IssueRecord): IssueAuditSnapshot {
+  return {
+    title: issue.title,
+    status: issue.status,
+    priority: issue.priority,
+    assignee: issue.assignee,
+    ...(issue.when ? { schedule: JSON.stringify(issue.when) } : {}),
+    ...(issue.agent ? { agent: issue.agent } : {}),
+    whatHash: digest(issue.what),
+  }
+}
+
+export function issueMutation(
+  before: IssueRecord | IssueAuditSnapshot,
+  after: IssueRecord | IssueAuditSnapshot,
+): ProvenanceMutation | null {
+  const left = 'what' in before ? issueAuditSnapshot(before) : before
+  const right = 'what' in after ? issueAuditSnapshot(after) : after
+  const fields: ProvenanceMutation['fields'] = []
+  const valueField = (
+    field: string,
+    previous: string | undefined,
+    next: string | undefined,
+  ) => {
+    if (previous === next) return
+    fields.push({
+      field,
+      ...(previous !== undefined ? { before: compactAuditValue(previous) } : {}),
+      ...(next !== undefined ? { after: compactAuditValue(next) } : {}),
+    })
+  }
+  valueField('title', left.title, right.title)
+  valueField('status', left.status, right.status)
+  valueField('priority', left.priority, right.priority)
+  valueField('assignee', left.assignee, right.assignee)
+  valueField('schedule', left.schedule, right.schedule)
+  valueField('runtime', left.agent, right.agent)
+  if (left.whatHash !== right.whatHash) fields.push({ field: 'what' })
+  return fields.length > 0 ? { fields } : null
+}
+
+export function issueMutationFingerprint(
+  workspaceId: string,
+  issueId: string,
+  issue: IssueRecord | IssueAuditSnapshot,
+): string {
+  const snapshot = 'what' in issue ? issueAuditSnapshot(issue) : issue
+  return `issue-state:${workspaceId}:${issueId}:${digest(JSON.stringify(snapshot))}`
+}
+
+function validSnapshot(value: unknown): value is IssueAuditSnapshot {
+  if (!value || typeof value !== 'object') return false
+  const row = value as Record<string, unknown>
+  return (
+    typeof row['title'] === 'string' &&
+    typeof row['status'] === 'string' &&
+    typeof row['priority'] === 'string' &&
+    typeof row['assignee'] === 'string' &&
+    typeof row['whatHash'] === 'string' &&
+    (row['schedule'] === undefined || typeof row['schedule'] === 'string') &&
+    (row['agent'] === undefined || typeof row['agent'] === 'string')
+  )
+}
+
+/** Persistent observer for edits that bypass the UI/CLI mutation seam. */
+export class IssueChangeTracker {
+  private readonly workspaces = new Map<string, Map<string, IssueAuditSnapshot>>()
+  private queue: Promise<void> = Promise.resolve()
+
+  private constructor(
+    private readonly path: string,
+    private readonly provenance: IProvenanceStore,
+    private readonly logger: Logger,
+  ) {}
+
+  static async load(
+    path: string,
+    provenance: IProvenanceStore,
+    logger: Logger,
+  ): Promise<IssueChangeTracker> {
+    const tracker = new IssueChangeTracker(path, provenance, logger)
+    await tracker.read()
+    return tracker
+  }
+
+  observeWorkspace(input: {
+    workspaceId: string
+    issues: readonly IssueRecord[]
+    origin: ArtifactOrigin
+    now?: number
+  }): Promise<void> {
+    const next = this.queue.then(() => this.observeNow(input))
+    this.queue = next.catch(() => undefined)
+    return next
+  }
+
+  private async observeNow(input: {
+    workspaceId: string
+    issues: readonly IssueRecord[]
+    origin: ArtifactOrigin
+    now?: number
+  }): Promise<void> {
+    const previous = this.workspaces.get(input.workspaceId)
+    const current = new Map(
+      input.issues.map((issue) => [issue.id, issueAuditSnapshot(issue)] as const),
+    )
+    // The first sight of a Workspace establishes a baseline. Persisting it
+    // means edits made while OpenAlice is offline are visible on next startup.
+    if (!previous) {
+      this.workspaces.set(input.workspaceId, current)
+      await this.flush()
+      return
+    }
+
+    const at = input.now ?? Date.now()
+    let dirty = previous.size !== current.size
+    for (const issue of input.issues) {
+      const before = previous.get(issue.id)
+      const after = current.get(issue.id)!
+      const artifact = {
+        kind: 'issue' as const,
+        workspaceId: input.workspaceId,
+        issueId: issue.id,
+      }
+      if (!before) {
+        dirty = true
+        if (!this.provenance.latest({ artifact, action: 'created' })) {
+          await this.provenance.append({
+            artifact,
+            action: 'created',
+            origin: input.origin,
+            at,
+            fingerprint: `issue:${input.workspaceId}:${issue.id}:created`,
+          })
+        }
+        continue
+      }
+      const mutation = issueMutation(before, after)
+      if (!mutation) continue
+      dirty = true
+      await this.provenance.append({
+        artifact,
+        action: 'updated',
+        origin: input.origin,
+        at,
+        mutation,
+        fingerprint: issueMutationFingerprint(input.workspaceId, issue.id, after),
+      }, { coalesceWithinMs: ACTIVITY_UPDATE_COALESCE_MS })
+    }
+
+    if (!dirty) return
+    this.workspaces.set(input.workspaceId, current)
+    await this.flush()
+  }
+
+  private async read(): Promise<void> {
+    try {
+      const parsed = JSON.parse(await readFile(this.path, 'utf8')) as Partial<TrackerFile>
+      if (parsed.version !== 1 || !parsed.workspaces || typeof parsed.workspaces !== 'object') {
+        throw new Error('unsupported Issue audit snapshot shape')
+      }
+      for (const [workspaceId, rows] of Object.entries(parsed.workspaces)) {
+        if (!rows || typeof rows !== 'object') continue
+        const issues = new Map<string, IssueAuditSnapshot>()
+        for (const [issueId, snapshot] of Object.entries(rows)) {
+          if (validSnapshot(snapshot)) issues.set(issueId, snapshot)
+        }
+        this.workspaces.set(workspaceId, issues)
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+      this.logger.warn('issue_change_tracker.read_failed', { err })
+      this.workspaces.clear()
+    }
+  }
+
+  private async flush(): Promise<void> {
+    const workspaces: TrackerFile['workspaces'] = {}
+    for (const [workspaceId, issues] of this.workspaces) {
+      workspaces[workspaceId] = Object.fromEntries(issues)
+    }
+    await mkdir(dirname(this.path), { recursive: true })
+    const tmp = `${this.path}.tmp`
+    await writeFile(tmp, JSON.stringify({ version: 1, workspaces }, null, 2) + '\n', {
+      mode: 0o600,
+    })
+    await rename(tmp, this.path)
+  }
+}

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -20,7 +20,7 @@
  *   title: <required, short human title>
  *   status: backlog | todo | in_progress | done | canceled   (optional → 'todo')
  *   priority: urgent | high | medium | low | none             (optional → 'none')
- *   assignee: "@workspace" | "@human" | "@unassigned" | "@<resumeId>"  (optional → '@workspace')
+ *   assignee: "@workspace" | "@new" | "@human" | "@unassigned" | "@<resumeId>"  (optional → '@workspace')
  *   when: { kind: at, at } | { kind: every, every } |
  *         { kind: cron, cron, timezone?: local | IANA zone }  (OPTIONAL — present iff scheduled)
  *   what: <legacy fire prompt; migrated into the markdown What body>
@@ -41,6 +41,7 @@ import { z } from 'zod'
 import { isValidScheduleTimezone, type Schedule } from '../../core/schedule-expr.js'
 import {
   HUMAN_ASSIGNEE,
+  NEW_ASSIGNEE,
   UNASSIGNED_ASSIGNEE,
   WORKSPACE_ASSIGNEE,
   resumeIdFromSignature,
@@ -85,9 +86,11 @@ export const issueWhenSchema = z.discriminatedUnion('kind', [
 ])
 
 /** Who owns the Issue. Workspace ownership recruits a fresh Session for each
- * scheduled fire; Session ownership resumes exactly one product Session. */
+ * scheduled fire; `@new` recruits once and is replaced by the allocated
+ * `@resumeId`; Session ownership resumes exactly one product Session. */
 export const issueAssigneeSchema = z.union([
   z.literal(WORKSPACE_ASSIGNEE),
+  z.literal(NEW_ASSIGNEE),
   z.literal(HUMAN_ASSIGNEE),
   z.literal(UNASSIGNED_ASSIGNEE),
   z.string().regex(/^@resume-[^\s]+$/, 'Session assignee must be @<resumeId>'),
@@ -96,6 +99,11 @@ export const issueAssigneeSchema = z.union([
 /** Exact product Session owner encoded by the single assignee contract. */
 export function issueAssigneeResumeId(assignee: string): string | null {
   return resumeIdFromSignature(assignee)
+}
+
+/** Transitional ownership: the first dispatch claims one durable Session. */
+export function issueAssigneeClaimsFirstSession(assignee: string): boolean {
+  return assignee === NEW_ASSIGNEE
 }
 
 /**
@@ -126,7 +134,14 @@ export const issueFrontmatterSchema = z.object({
     ctx.addIssue({
       code: 'custom',
       path: ['assignee'],
-      message: 'scheduled issues must be assigned to @workspace or an exact @resumeId',
+      message: 'scheduled issues must be assigned to @workspace, @new, or an exact @resumeId',
+    })
+  }
+  if (!value.when && value.assignee === NEW_ASSIGNEE) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['assignee'],
+      message: '@new needs a schedule so its first run can claim a Session',
     })
   }
   if (issueAssigneeResumeId(value.assignee) && value.agent) {

--- a/src/workspaces/issues/mutate.spec.ts
+++ b/src/workspaces/issues/mutate.spec.ts
@@ -64,6 +64,28 @@ describe('createIssue', () => {
     expect(issue?.what).toBe('run the research routine')
   })
 
+  it('accepts @new only for scheduled work that will choose its first owner', async () => {
+    const scheduled = await createIssue(dir, {
+      id: 'choose-owner',
+      title: 'Choose one owner',
+      assignee: '@new',
+      when: { kind: 'every', every: '30m' },
+      agent: 'pi',
+    })
+    expect(scheduled.ok && scheduled.issue.assignee).toBe('@new')
+
+    const unscheduled = await createIssue(dir, {
+      id: 'no-trigger',
+      title: 'No trigger',
+      assignee: '@new',
+    })
+    expect(unscheduled.ok).toBe(false)
+    if (!unscheduled.ok) {
+      expect(unscheduled.reason).toBe('invalid')
+      if (unscheduled.reason === 'invalid') expect(unscheduled.error).toContain('@new needs a schedule')
+    }
+  })
+
   it('refuses to overwrite an existing issue (conflict)', async () => {
     await createIssue(dir, { id: 'dup', title: 'first' })
     const res = await createIssue(dir, { id: 'dup', title: 'second' })

--- a/src/workspaces/issues/mutate.ts
+++ b/src/workspaces/issues/mutate.ts
@@ -71,7 +71,7 @@ export interface CreateIssueInput {
 
 /** Result of an edit that targets an existing issue. */
 export type MutateResult =
-  | { ok: true; issue: IssueRecord }
+  | { ok: true; issue: IssueRecord; previous: IssueRecord }
   | { ok: false; reason: 'not_found' }
   | { ok: false; reason: 'invalid'; error: string }
 
@@ -153,7 +153,7 @@ export async function updateIssueFields(
     const a = patch.assignee.trim()
     const assignee = issueAssigneeSchema.safeParse(a)
     if (!assignee.success) {
-      return { ok: false, reason: 'invalid', error: 'assignee must be @workspace, @human, @unassigned, or an exact @resumeId' }
+      return { ok: false, reason: 'invalid', error: 'assignee must be @workspace, @new, @human, @unassigned, or an exact @resumeId' }
     }
     data.assignee = assignee.data
     if (issueAssigneeResumeId(assignee.data)) delete data.agent
@@ -183,7 +183,7 @@ export async function updateIssueFields(
   const reparsed = parseIssueContent(id, content)
   if (!reparsed.ok) return { ok: false, reason: 'invalid', error: reparsed.error }
   await writeWorkspaceFile(wsDir, relFor(id), content)
-  return { ok: true, issue: reparsed.issue }
+  return { ok: true, issue: reparsed.issue, previous: current.issue }
 }
 
 /**

--- a/src/workspaces/schedule/declaration.ts
+++ b/src/workspaces/schedule/declaration.ts
@@ -44,7 +44,8 @@ export interface ScheduleSnapshotTask {
   when: Schedule
   /** The prompt this fire hands to the headless run (resolved `what`/title+body). */
   what: string
-  /** Unified owner. `@workspace` recruits a fresh Session; exact `@resumeId` resumes one. */
+  /** Unified owner. `@new` recruits once, `@workspace` recruits every fire,
+   * and an exact `@resumeId` resumes one accountable Session. */
   assignee: string
   agent?: string
   /** False once the owning issue reaches a terminal status (done/canceled). */

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -114,15 +114,17 @@ function scannerFor(
       t: number,
       trigger?: import('../headless-task-registry.js').HeadlessTaskTrigger,
       resumeId?: string,
-    ) => Promise<{ taskId: string }>
+    ) => Promise<{ taskId: string; resumeId: string }>
     markers?: MarkerStore
     now?: number
     adapter?: CliAdapter
     resolveAdapter?: ScheduleScannerDeps['resolveAdapter']
     resolveResumeWorkspace?: ScheduleScannerDeps['resolveResumeWorkspace']
+    claimFreshSession?: ScheduleScannerDeps['claimFreshSession']
+    observeIssues?: ScheduleScannerDeps['observeIssues']
   } = {},
 ) {
-  const dispatch = opts.dispatch ?? vi.fn(async () => ({ taskId: 'run-1' }))
+  const dispatch = opts.dispatch ?? vi.fn(async () => ({ taskId: 'run-1', resumeId: 'resume-new-worker-a1b2c3' }))
   const markers = opts.markers ?? new FakeMarkers()
   const scanner = new ScheduleScanner({
     registry: {
@@ -132,6 +134,8 @@ function scannerFor(
     resolveResumeWorkspace: opts.resolveResumeWorkspace ?? (() => workspaces[0]),
     resolveAdapter: opts.resolveAdapter ?? (() => opts.adapter ?? headlessAdapter),
     dispatch,
+    claimFreshSession: opts.claimFreshSession,
+    observeIssues: opts.observeIssues,
     markers,
     logger: noopLogger,
     now: () => opts.now ?? NOW,
@@ -206,6 +210,51 @@ describe('ScheduleScanner', () => {
     )
     expect(scanner.snapshot()!.workspaces[0].tasks[0].assignee)
       .toBe('@resume-kind-owl-abc123')
+  })
+
+  it('assigns @new to the first fresh Session before advancing the marker', async () => {
+    const ws = await makeWs('w1', [{
+      id: 'sticky',
+      title: 'sticky worker',
+      when: { kind: 'every', every: '30m' },
+      what: 'own this work from now on',
+      assignee: '@new',
+    }])
+    const claimFreshSession = vi.fn(async () => undefined)
+    const { scanner, dispatch, markers } = scannerFor([ws], { claimFreshSession })
+
+    await scanner.scan()
+
+    expect(dispatch).toHaveBeenCalledWith(
+      ws,
+      headlessAdapter,
+      'own this work from now on',
+      expect.any(Number),
+      { kind: 'issue', workspaceId: 'w1', issueId: 'sticky' },
+    )
+    expect(claimFreshSession).toHaveBeenCalledWith({
+      issueWorkspace: ws,
+      issueId: 'sticky',
+      taskId: 'run-1',
+      resumeId: 'resume-new-worker-a1b2c3',
+      agent: 'claude',
+    })
+    expect(markers.get('w1', 'sticky')).toBe(NOW)
+  })
+
+  it('advances the dispatched occurrence when the Session claim write fails', async () => {
+    const ws = await makeWs('w1', [{
+      id: 'sticky', title: 'sticky worker', when: { kind: 'every', every: '30m' },
+      what: 'own this work', assignee: '@new',
+    }])
+    const claimFreshSession = vi.fn(async () => { throw new Error('claim write failed') })
+    const { scanner, markers } = scannerFor([ws], { claimFreshSession })
+
+    await scanner.scan()
+
+    // The worker already started; retrying the due occurrence would recruit a
+    // second worker immediately. The claim failure is logged independently.
+    expect(markers.get('w1', 'sticky')).toBe(NOW)
   })
 
   it('executes an exact cross-Workspace signature while retaining the home Issue trigger', async () => {

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -31,7 +31,14 @@ import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
 import type { HeadlessTaskTrigger } from '../headless-task-registry.js'
 
-import { isFireable, issueAssigneeResumeId, issueFirePrompt, readWorkspaceIssues } from '../issues/declaration.js'
+import {
+  isFireable,
+  issueAssigneeClaimsFirstSession,
+  issueAssigneeResumeId,
+  issueFirePrompt,
+  readWorkspaceIssues,
+  type IssueRecord,
+} from '../issues/declaration.js'
 import { SCHEDULED_ISSUE_RUN_TIMEOUT_MS } from '../issues/run-failure.js'
 
 import {
@@ -84,7 +91,17 @@ export interface ScheduleScannerDeps {
     trigger?: HeadlessTaskTrigger,
     /** Product Session to continue. Omitted means allocate a fresh Session. */
     resumeId?: string,
-  ) => Promise<{ taskId: string }>
+  ) => Promise<{ taskId: string; resumeId: string }>
+  /** Persist @new -> exact @resumeId after the first fresh dispatch. */
+  claimFreshSession?: (input: {
+    issueWorkspace: WorkspaceMeta
+    issueId: string
+    taskId: string
+    resumeId: string
+    agent: string
+  }) => Promise<void>
+  /** Observe direct Issue file edits during the scanner's normal live read. */
+  observeIssues?: (workspace: WorkspaceMeta, issues: readonly IssueRecord[]) => Promise<void>
   markers: MarkerStore
   logger: Logger
   /** Injectable clock for tests. */
@@ -160,6 +177,7 @@ export class ScheduleScanner {
       issueFirePrompt(issue),
       issue.agent,
       issueAssigneeResumeId(issue.assignee) ?? undefined,
+      issueAssigneeClaimsFirstSession(issue.assignee),
       true,
     )
   }
@@ -233,6 +251,7 @@ export class ScheduleScanner {
         invalid: res.invalid.map((i) => i.id),
       })
     }
+    await this.deps.observeIssues?.(ws, res.issues)
 
     const tasks: ScheduleSnapshotTask[] = []
     for (const issue of res.issues) {
@@ -247,6 +266,7 @@ export class ScheduleScanner {
           issueFirePrompt(issue),
           issue.agent,
           issueAssigneeResumeId(issue.assignee) ?? undefined,
+          issueAssigneeClaimsFirstSession(issue.assignee),
           nowMs,
         )
       }
@@ -269,6 +289,7 @@ export class ScheduleScanner {
     what: string,
     agentId: string | undefined,
     resumeId: string | undefined,
+    claimFreshSession: boolean,
     nowMs: number,
   ): Promise<void> {
     try {
@@ -278,6 +299,7 @@ export class ScheduleScanner {
         what,
         agentId,
         resumeId,
+        claimFreshSession,
       )
       await this.deps.markers.set(issueWorkspace.id, taskId, nowMs)
       this.deps.logger.info('schedule.fired', {
@@ -304,6 +326,7 @@ export class ScheduleScanner {
     what: string,
     agentId?: string,
     resumeId?: string,
+    claimFreshSession = false,
     manual = false,
   ): Promise<{ taskId: string }> {
     const dispatchKey = `${issueWorkspace.id}:${issueId}`
@@ -349,6 +372,31 @@ export class ScheduleScanner {
             SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
             trigger,
           )
+      if (claimFreshSession) {
+        if (!this.deps.claimFreshSession) {
+          throw new Error('Issue @new ownership cannot be persisted in this runtime')
+        }
+        try {
+          await this.deps.claimFreshSession({
+            issueWorkspace,
+            issueId,
+            taskId: result.taskId,
+            resumeId: result.resumeId,
+            agent: adapter.id,
+          })
+        } catch (err) {
+          // The worker is already running. Treat a claim-write failure as a
+          // separate control-plane fault so the due loop cannot immediately
+          // recruit a second worker for the same occurrence.
+          this.deps.logger.warn('schedule.first_session_claim_failed', {
+            wsId: issueWorkspace.id,
+            issueId,
+            taskId: result.taskId,
+            resumeId: result.resumeId,
+            err,
+          })
+        }
+      }
       this.deps.logger.info('schedule.issue_dispatched', {
         wsId: issueWorkspace.id,
         executionWsId: executionWorkspace.id,
@@ -357,7 +405,7 @@ export class ScheduleScanner {
         runId: result.taskId,
         manual,
       })
-      return result
+      return { taskId: result.taskId }
     } finally {
       this.dispatchingIssues.delete(dispatchKey)
     }

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -14,7 +14,11 @@ import { basename, join } from 'node:path';
 
 import { cliBinPath } from '@/core/paths.js';
 import { readCredentials, readIssueDefaultAgent, readWorkspaceDefaultAgent } from '@/core/config.js';
-import { ArtifactProvenanceStore } from '@/core/provenance-store.js';
+import {
+  ACTIVITY_UPDATE_COALESCE_MS,
+  ArtifactProvenanceStore,
+  type ArtifactOrigin,
+} from '@/core/provenance-store.js';
 import {
   readQuickChatPreferences,
   rememberRecentChatWorkspace,
@@ -81,10 +85,21 @@ import { completeOneShotIssueAfterRun } from './issues/auto-complete.js';
 import { readIssueComments } from './issues/comments.js';
 import { recordIssueCommentReply } from './issues/comment-delivery.js';
 import {
+  IssueChangeTracker,
+  issueMutation,
+  issueMutationFingerprint,
+} from './issues/change-tracker.js';
+import { updateIssueFields } from './issues/mutate.js';
+import {
   issueAutomationHealth,
   type IssueAutomationOwnerState,
 } from './issues/automation-health.js';
-import { issueAssigneeResumeId } from './issues/declaration.js';
+import {
+  issueAssigneeClaimsFirstSession,
+  issueAssigneeResumeId,
+  type IssueRecord,
+} from './issues/declaration.js';
+import { sessionSignature } from './session-signature.js';
 import { issueRunFailure } from './issues/run-failure.js';
 import type { IInboxStore } from '@/core/inbox-store.js';
 import { toSafeInboxOrigin } from '@/core/workspace-tool-center.js';
@@ -419,11 +434,88 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     join(config.launcherRoot, 'state', 'artifact-provenance.json'),
     launcherLogger.child({ scope: 'provenance-store' }),
   );
+  const issueChangeTracker = await IssueChangeTracker.load(
+    join(config.launcherRoot, 'state', 'issue-audit-snapshots.json'),
+    provenanceStore,
+    launcherLogger.child({ scope: 'issue-change-tracker' }),
+  );
   const activeResumeIds = new Set<string>();
   const claimResume = (resumeId: string): boolean => {
     if (activeResumeIds.has(resumeId)) return false;
     activeResumeIds.add(resumeId);
     return true;
+  };
+
+  /** Attribute a direct file edit only when exactly one product Session could
+   * have made it. Ambiguous concurrency is logged honestly instead of assigning
+   * another coworker's work to the wrong resumeId. */
+  const inferIssueMutationOrigin = async (wsId: string): Promise<ArtifactOrigin> => {
+    await sessionRegistry.ensureLoaded(wsId);
+    const candidates = new Map<string, ArtifactOrigin>();
+    for (const task of headlessTasks.list({ wsId }).filter((row) => row.status === 'running')) {
+      candidates.set(task.resumeId, {
+        kind: 'session',
+        workspaceId: wsId,
+        resumeId: task.resumeId,
+        agent: task.agent,
+        execution: { kind: 'headless', taskId: task.taskId },
+      });
+    }
+    for (const session of sessionRegistry.listFor(wsId).filter((row) => row.state === 'running')) {
+      if (session.agent === 'shell') continue;
+      candidates.set(session.resumeId, {
+        kind: 'session',
+        workspaceId: wsId,
+        resumeId: session.resumeId,
+        agent: session.agent,
+        execution: { kind: 'interactive', sessionRecordId: session.id },
+      });
+    }
+    if (candidates.size === 1) return [...candidates.values()][0]!;
+    return {
+      kind: 'unknown',
+      reason: candidates.size > 1 ? 'concurrent-workspace-edit' : 'direct-file-edit',
+    };
+  };
+
+  const observeIssueRecords = async (
+    ws: WorkspaceMeta,
+    issues: readonly IssueRecord[],
+    origin?: ArtifactOrigin,
+  ): Promise<void> => {
+    await issueChangeTracker.observeWorkspace({
+      workspaceId: ws.id,
+      issues,
+      origin: origin ?? await inferIssueMutationOrigin(ws.id),
+    });
+  };
+
+  /** Capture Issue-file work performed by one completed headless turn. The
+   * finished task is no longer in the running registry, so it is attributable
+   * only when no other product Session is still able to edit that Workspace. */
+  const observeHeadlessIssueChanges = async (
+    task: HeadlessTaskRecord,
+    executionWorkspace: WorkspaceMeta,
+  ): Promise<void> => {
+    const targets = new Map<string, WorkspaceMeta>([[executionWorkspace.id, executionWorkspace]]);
+    if (task.trigger?.kind === 'issue') {
+      const source = registry.get(task.trigger.workspaceId);
+      if (source) targets.set(source.id, source);
+    }
+    for (const target of targets.values()) {
+      const competing = await inferIssueMutationOrigin(target.id);
+      const origin: ArtifactOrigin = competing.kind === 'unknown' && competing.reason === 'direct-file-edit'
+        ? {
+            kind: 'session',
+            workspaceId: executionWorkspace.id,
+            resumeId: task.resumeId,
+            agent: task.agent,
+            execution: { kind: 'headless', taskId: task.taskId },
+          }
+        : { kind: 'unknown', reason: 'concurrent-workspace-edit' };
+      const result = await readWorkspaceIssues(target.dir);
+      if (result.ok) await observeIssueRecords(target, result.issues, origin);
+    }
   };
 
   /**
@@ -1319,6 +1411,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
             err,
           });
         }
+        await observeHeadlessIssueChanges(rec, ws).catch((err) =>
+          launcherLogger.warn('issue.headless_change_observation_failed', {
+            wsId: ws.id,
+            taskId: rec.taskId,
+            err,
+          }),
+        );
       })
       .catch(async (err) => {
         const message = err instanceof Error ? err.message : String(err);
@@ -1332,6 +1431,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           status: 'failed',
           error: message,
         });
+        await observeHeadlessIssueChanges(rec, ws).catch((observeErr) =>
+          launcherLogger.warn('issue.headless_change_observation_failed', {
+            wsId: ws.id,
+            taskId: rec.taskId,
+            err: observeErr,
+          }),
+        );
       })
       .finally(() => activeResumeIds.delete(rec.resumeId));
     return { taskId: rec.taskId, resumeId: rec.resumeId };
@@ -1365,6 +1471,56 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       return resolveAdapter(ws, await resolveIssueDefaultAgentId(ws));
     },
     dispatch: dispatchHeadlessTaskMethod,
+    claimFreshSession: async ({ issueWorkspace, issueId, taskId, resumeId, agent }) => {
+      const live = await readWorkspaceIssues(issueWorkspace.dir);
+      const candidate = live.ok ? live.issues.find((issue) => issue.id === issueId) : undefined;
+      if (!candidate || !issueAssigneeClaimsFirstSession(candidate.assignee)) {
+        launcherLogger.info('issue.first_session_claim_skipped', {
+          wsId: issueWorkspace.id,
+          issueId,
+          taskId,
+          resumeId,
+          reason: candidate ? 'assignee_changed' : 'issue_unavailable',
+        });
+        return;
+      }
+      const claimed = await updateIssueFields(issueWorkspace.dir, issueId, {
+        assignee: sessionSignature(resumeId),
+      });
+      if (!claimed.ok) {
+        throw new Error(
+          claimed.reason === 'invalid'
+            ? claimed.error
+            : `Issue disappeared before its first Session could claim it: ${issueId}`,
+        );
+      }
+      const mutation = issueMutation(claimed.previous, claimed.issue);
+      const origin: ArtifactOrigin = {
+        kind: 'session',
+        workspaceId: issueWorkspace.id,
+        resumeId,
+        agent,
+        execution: { kind: 'headless', taskId },
+      };
+      await provenanceStore.append({
+        artifact: { kind: 'issue', workspaceId: issueWorkspace.id, issueId },
+        action: 'updated',
+        origin,
+        at: Date.now(),
+        ...(mutation ? { mutation } : {}),
+        fingerprint: issueMutationFingerprint(issueWorkspace.id, issueId, claimed.issue),
+      }, { coalesceWithinMs: ACTIVITY_UPDATE_COALESCE_MS });
+      const reread = await readWorkspaceIssues(issueWorkspace.dir);
+      if (reread.ok) await observeIssueRecords(issueWorkspace, reread.issues, origin);
+      launcherLogger.info('issue.first_session_claimed', {
+        wsId: issueWorkspace.id,
+        issueId,
+        taskId,
+        resumeId,
+        agent,
+      });
+    },
+    observeIssues: (workspace, issues) => observeIssueRecords(workspace, issues),
     markers: scheduleMarkers,
     logger: launcherLogger.child({ scope: 'schedule' }),
   });
@@ -1431,6 +1587,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           }
           return { wsId: ws.id, tag: ws.tag, status: 'invalid', error: res.error, issues: [] };
         }
+        await observeIssueRecords(ws, res.issues);
         const issues: IssuesSnapshotIssue[] = res.issues.map((issue) => {
           // Unscheduled ⇒ pure board work item, no firing markers.
           if (!issue.when) return snapshotBoardIssue(issue, null);
@@ -1479,6 +1636,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     if (!ws) return null;
     const res = await readWorkspaceIssues(ws.dir);
     if (!res.ok) return null; // absent or unreadable issues dir ⇒ no such issue
+    await observeIssueRecords(ws, res.issues);
     const issue = res.issues.find((i) => i.id === id);
     if (!issue) return null;
     const commentsResult = await readIssueComments(ws.dir, issue.id);

--- a/src/workspaces/session-signature.ts
+++ b/src/workspaces/session-signature.ts
@@ -8,6 +8,8 @@
  */
 
 export const WORKSPACE_ASSIGNEE = '@workspace' as const
+/** Recruit one fresh Session on the next run, then persist that Session as owner. */
+export const NEW_ASSIGNEE = '@new' as const
 export const HUMAN_ASSIGNEE = '@human' as const
 export const UNASSIGNED_ASSIGNEE = '@unassigned' as const
 
@@ -25,8 +27,8 @@ export function normalizeIssueAssigneeAlias(value: string): string {
   const trimmed = value.trim()
   const lower = trimmed.toLowerCase()
   if (lower === '@workspace' || lower === 'workspace') return WORKSPACE_ASSIGNEE
+  if (lower === '@new' || lower === 'new') return NEW_ASSIGNEE
   if (lower === '@human' || lower === 'human') return HUMAN_ASSIGNEE
   if (lower === '@unassigned' || lower === 'unassigned') return UNASSIGNED_ASSIGNEE
   return trimmed
 }
-

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -57,6 +57,9 @@ export interface IssueProvenanceRecord {
   action: IssueProvenanceAction
   origin: IssueProvenanceOrigin
   at: number
+  mutation?: {
+    fields: Array<{ field: string; before?: string; after?: string }>
+  }
 }
 
 /** Human-facing Issue timeline. Runtime executions stay in `runs`. */
@@ -106,7 +109,7 @@ export interface IssueListItem {
   title: string
   status: IssueStatus
   priority: IssuePriority
-  /** @workspace | @human | @unassigned | exact @resumeId Session signature. */
+  /** @workspace | @new | @human | @unassigned | exact @resumeId Session signature. */
   assignee: string
   /** Adapter id for the scheduled fire override, if set. */
   agent?: string
@@ -194,7 +197,7 @@ export interface IssueDetailIssue {
   what: string
   status: IssueStatus
   priority: IssuePriority
-  /** @workspace | @human | @unassigned | exact @resumeId Session signature. */
+  /** @workspace | @new | @human | @unassigned | exact @resumeId Session signature. */
   assignee: string
   /** Present iff the issue self-schedules. */
   when?: ScheduleWhen

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -126,6 +126,7 @@ function AssigneeEditor({
       aria-label="Assignee"
       onChange={(event) => onChange(event.target.value)}
     >
+      {scheduled && <option value="@new">New Session · assign after first run</option>}
       <option value="@workspace">{scheduled ? '@Workspace · new Session each run' : '@Workspace'}</option>
       {!scheduled && <option value="@human">Human</option>}
       {!scheduled && <option value="@unassigned">Unassigned</option>}
@@ -389,11 +390,13 @@ function CommentComposer({
   wsId,
   id,
   ownerResumeId,
+  assignee,
   onPosted,
 }: {
   wsId: string
   id: string
   ownerResumeId: string | null
+  assignee: string
   onPosted: (next: IssueDetailData) => void
 }) {
   const [text, setText] = useState('')
@@ -437,7 +440,9 @@ function CommentComposer({
         <p className="min-w-0 flex-1 basis-full break-words text-[11px] leading-snug text-muted sm:basis-auto">
           {ownerResumeId
             ? <>The assigned Session <span className="font-mono text-text/75">@{ownerResumeId}</span> will reply here.</>
-            : 'No fixed Session owner — this comment is recorded as a timeline note.'}
+            : assignee === '@new'
+              ? 'The first scheduled run will assign a Session; until then this is a timeline note.'
+              : 'No fixed Session owner — this comment is recorded as a timeline note.'}
         </p>
         <button
           type="button"
@@ -600,12 +605,58 @@ const PROVENANCE_ACTION_LABEL: Record<IssueProvenanceRecord['action'], string> =
   reconstructed: 'reconstructed the Issue context',
 }
 
+const MUTATION_FIELD_LABEL: Record<string, string> = {
+  title: 'Title',
+  status: 'Status',
+  priority: 'Priority',
+  assignee: 'Assignee',
+  schedule: 'Schedule',
+  runtime: 'Runtime',
+  what: 'What',
+}
+
+function unknownOriginLabel(reason: string): string {
+  if (reason === 'direct-file-edit') return 'Direct file edit'
+  if (reason === 'concurrent-workspace-edit') return 'Concurrent Workspace edit · author unknown'
+  return `Unknown · ${reason.replaceAll('-', ' ')}`
+}
+
+function mutationValue(field: string, value: string): string {
+  if (field === 'assignee') {
+    if (value === '@new') return 'New Session, then keep owner'
+    if (value === '@workspace') return 'New Session each run'
+    if (value === '@human') return 'Human'
+    if (value === '@unassigned') return 'Unassigned'
+  }
+  if (field === 'status' || field === 'priority') return value.replaceAll('_', ' ')
+  if (field === 'schedule') {
+    try {
+      const schedule = JSON.parse(value) as { kind?: string; at?: string; every?: string; cron?: string; timezone?: string }
+      if (schedule.kind === 'at') return `Once · ${schedule.at}`
+      if (schedule.kind === 'every') return `Every ${schedule.every}`
+      if (schedule.kind === 'cron') return `${schedule.cron}${schedule.timezone ? ` · ${schedule.timezone}` : ''}`
+    } catch {
+      // Older audit rows can still carry a hand-written value; show it safely.
+    }
+  }
+  return value
+}
+
+function mutationSummary(change: { field: string; before?: string; after?: string }): string {
+  const label = MUTATION_FIELD_LABEL[change.field] ?? change.field
+  if (change.before === undefined && change.after === undefined) return `edited ${label}`
+  if (change.before === undefined) return `set ${label} to ${mutationValue(change.field, change.after!)}`
+  if (change.after === undefined) return `cleared ${label}`
+  return `changed ${label} from ${mutationValue(change.field, change.before)} to ${mutationValue(change.field, change.after)}`
+}
+
 function IssueActivity({
   activity,
   onContinue,
   wsId,
   issueId,
   ownerResumeId,
+  assignee,
   onPosted,
 }: {
   activity: IssueActivityRecord[]
@@ -613,6 +664,7 @@ function IssueActivity({
   wsId: string
   issueId: string
   ownerResumeId: string | null
+  assignee: string
   onPosted: (next: IssueDetailData) => void
 }) {
   const [continuingId, setContinuingId] = useState<string | null>(null)
@@ -683,17 +735,26 @@ function IssueActivity({
                 ? 'Human'
                 : origin.kind === 'external'
                   ? `External · ${origin.system}`
-                  : `Unknown · ${origin.reason}`
+                  : unknownOriginLabel(origin.reason)
             return (
-              <li key={`provenance:${record.id}`} className="relative flex min-w-0 items-center gap-2.5 py-1 pl-8">
+              <li key={`provenance:${record.id}`} className="relative flex min-w-0 items-start gap-2.5 py-1 pl-8">
                 <span className="absolute left-[3px] top-2 z-10 grid h-[18px] w-[18px] place-items-center rounded-full border border-border bg-bg text-muted">
                   <History size={10} aria-hidden />
                 </span>
-                <p className="min-w-0 flex-1 text-[12px] text-muted">
-                  <span className="font-medium text-text/80">{originLabel}</span>{' '}
-                  {PROVENANCE_ACTION_LABEL[record.action]} ·{' '}
-                  <span title={new Date(record.at).toLocaleString()}>{formatRelativeTime(record.at)}</span>
-                </p>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[12px] text-muted">
+                    <span className="font-medium text-text/80">{originLabel}</span>{' '}
+                    {PROVENANCE_ACTION_LABEL[record.action]} ·{' '}
+                    <span title={new Date(record.at).toLocaleString()}>{formatRelativeTime(record.at)}</span>
+                  </p>
+                  {record.mutation && (
+                    <ul className="mt-1 space-y-0.5 text-[11px] leading-relaxed text-muted/80">
+                      {record.mutation.fields.map((change) => (
+                        <li key={change.field}>{mutationSummary(change)}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
                 {isSession && (
                   <button
                     type="button"
@@ -714,6 +775,7 @@ function IssueActivity({
         wsId={wsId}
         id={issueId}
         ownerResumeId={ownerResumeId}
+        assignee={assignee}
         onPosted={onPosted}
       />
     </section>
@@ -1101,6 +1163,7 @@ export function IssueDetail({
             wsId={wsId}
             issueId={id}
             ownerResumeId={stableOwnerResumeId}
+            assignee={issue.assignee}
             onPosted={mutate}
           />
         </main>

--- a/ui/src/components/IssuesBoard.spec.tsx
+++ b/ui/src/components/IssuesBoard.spec.tsx
@@ -127,4 +127,24 @@ describe('IssuesBoard', () => {
     expect(screen.getByText('@resume-calm-market-desk-a1b2c3')).toBeTruthy()
     expect(screen.getByText('claude override')).toBeTruthy()
   })
+
+  it('explains transitional ownership without exposing the raw @new token', () => {
+    mocks.useIssues.mockReturnValue({
+      data: snapshot([
+        issue({
+          id: 'first-owner',
+          title: 'Assign one durable owner',
+          assignee: '@new',
+          when: { kind: 'every', every: '1h' },
+        }),
+      ]),
+      error: null,
+      loading: false,
+    })
+
+    render(<IssuesBoard />)
+
+    expect(screen.getByText('Assign on first run')).toBeTruthy()
+    expect(screen.queryByText('@new')).toBeNull()
+  })
 })

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -372,6 +372,7 @@ function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: Board
   const titleMatchesId = issue.title.trim().toLowerCase() === issue.id.trim().toLowerCase()
   const explicitAssignee = issue.assignee !== '@workspace'
   const explicitAgent = agentRuntime?.source === 'override' && agentRuntime.distinctOverride !== false
+  const assigneeLabel = issue.assignee === '@new' ? 'Assign on first run' : issue.assignee
   return (
     <li>
       <button
@@ -417,7 +418,7 @@ function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: Board
             )}
             {explicitAssignee && (
               <span className="max-w-[14rem] truncate text-muted/70" title={`Assignee: ${issue.assignee}`}>
-                {issue.assignee}
+                {assigneeLabel}
               </span>
             )}
             {explicitAgent && agentRuntime && (


### PR DESCRIPTION
## What changed

- add `@new` as an Issue assignee mode: the first scheduled run recruits a fresh Session, then persists its exact `@resumeId` for later runs
- record field-level Issue mutations in Activity, including UI, CLI, and direct markdown-file edits
- keep full Issue content and rollback history in Git; agent guidance now asks for focused commits after intentional Issue edits
- humanize the new ownership mode in the Issue detail and board UI

## Why

Repeatedly recruiting a new Session loses ownership continuity, while defaulting every Issue to its creator is also incorrect. Issues also need a Linear-style audit trail even when agents edit their markdown files directly.

## Validation

- `pnpm test` (2922 passed, 6 skipped)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm electron:build`
- browser-verified the Assignee dropdown on the live Issue detail page
- `git diff --check`