### PR TITLE
Add native Server lifecycle and managed SSH remote

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ GitHub navigation.
 | [[docs/local-runtime.md]] | [Local Runtime and CLI bootstrap](local-runtime.md) | Source-backed localhost startup, dependency bootstrap, Runtime ownership, and headless bundle boundary |
 | [[docs/data-locations.md]] | [Data locations](data-locations.md) | Complete-home selection, desktop launcher preferences, concurrent instances, and directory safety |
 | [[docs/docker-deployment.md]] | [Docker deployment](docker-deployment.md) | Server image topology, remote-host safety, persistence, health, and container acceptance |
-| [[docs/remote-access.md]] | [Remote access](remote-access.md) | SSH tunnel experiment, local/remote ownership, and staged remote-control boundaries |
+| [[docs/remote-access.md]] | [Remote Runtime and access](remote-access.md) | Server lifecycle, SSH transport, managed remote bootstrap, client authority, and staged Studio protocol |
 | [[docs/connector-service.md]] | [Connector Service](connector-service.md) | Optional Discord/Telegram Inbox projection, adapters, secrets, health, Guardian lifecycle |
 | [[docs/ui-interaction-and-motion.md]] | [UI interaction and motion](ui-interaction-and-motion.md) | Clickable affordances, shared motion tokens, entrances/disclosures, reduced-motion policy |
 | [[docs/workspace-agent-guidance.md]] | [Workspace agent guidance](workspace-agent-guidance.md) | Always-loaded prompt contract, skill ownership, live CLI authority, guidance versioning |
@@ -35,7 +35,10 @@ guides.
 Reference notes under `docs/reference/` are non-authoritative research
 material. The [installer script note](reference/install-script/README.md)
 records Claude Code and Codex upstream links and design lessons without
-vendoring third-party code.
+vendoring third-party code. The
+[Herdr remote Runtime note](reference/herdr-remote-architecture.md) records a
+pinned public-source architecture comparison behind the authoritative remote
+guide, also without vendoring third-party code.
 
 ## Maintenance Rule
 

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -60,9 +60,14 @@ assets and a release-owned authenticity chain; see
 - `packages/cli/package.json` — CLI version, engine requirement, bin entry, and
   published file list.
 - `packages/cli/bin/openalice.mjs` — installed command entry point.
+- `packages/cli/src/server{,-control}.mjs` — detached lifecycle and the
+  Guardian control client.
+- `packages/cli/src/remote.mjs` — consent-first managed SSH orchestration.
 - `packages/cli/src/install.spec.mjs` — plan, consent, PTY, layout, and live-lock
   contract tests.
 - `scripts/install-docker-smoke.mjs` — local Docker acceptance runner.
+- `scripts/remote-ssh-smoke.mjs` — local clean-host Server/SSH acceptance
+  runner; its product contract belongs to [[docs/remote-access.md]].
 - `scripts/install-smoke/` — clean user, local HTTP fixture, automated smoke,
   and manual playground.
 - `docs/local-runtime.md` — behavior after the installed command starts a
@@ -340,6 +345,8 @@ exercises the same remote-download branch as `curl | bash`. It verifies:
 - unattended refusal before the install root exists;
 - stale-lock recovery and lock cleanup;
 - downloaded payload equality;
+- installed `server status --json` execution and inclusion of every reachable
+  Server/remote module;
 - runnable shell and CMD launchers;
 - idempotent managed PATH configuration;
 - identical-release reuse;

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -106,6 +106,36 @@ Workspaces, runtime locks, credentials, and optional Broker Packs. See
 Use `--rebuild` after pulling source changes when existing build artifacts may
 be stale. Never use a real user-state root for launcher or recovery tests.
 
+## Server Lifecycle Direction
+
+The browser convenience command and a persistent Server are separate lifetime
+contracts. `openalice start` remains foreground and browser-oriented. The
+target Server surface is:
+
+```bash
+openalice server run [app-dir]     # foreground, no browser
+openalice server start [app-dir]   # detached, wait for real readiness
+openalice server status            # read-only, with stable --json output
+openalice server stop              # ask the owning Guardian to stop itself
+```
+
+These commands reuse the same checkout preparation, build artifacts,
+`OPENALICE_HOME`, loopback binding, Guardian lease, optional-component policy,
+and explicit `--takeover` rule as local start. They do not introduce a second
+launcher or a PID-file kill path. Detached start succeeds only after Guardian
+ownership, the local control endpoint, and Alice HTTP are ready.
+
+The control endpoint is local to the selected home and is not an Alice HTTP
+route. `server stop` sends a versioned structured request to a matching CLI
+Server, then waits for Guardian's normal child shutdown and ownership release.
+It refuses to guess at an unreachable PID or silently stop an Electron-owned
+Runtime. Exact status classes, control fields, recovery rules, and the managed
+SSH composition live in [[docs/remote-access.md]].
+
+Until this target surface is implemented and passes the acceptance matrix in
+that guide, the supported source-backed server operation remains the
+foreground `openalice start --no-open` path.
+
 ## Dependency Bootstrap Direction
 
 Keep bootstrap observable and layered:
@@ -119,6 +149,10 @@ Keep bootstrap observable and layered:
 4. A future release asset can replace the source/build requirement with a
    downloadable headless Runtime while retaining the same CLI and localhost
    contract.
+
+The same Server command contract survives that transition. Source-backed and
+standalone-bundle Runtime providers differ in preparation, not in ownership,
+status, stop, browser, or SSH behavior.
 
 Do not silently place every optional agent runtime into Electron or the curl
 installer. The same dependency plan must remain inspectable and independently

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -106,11 +106,11 @@ Workspaces, runtime locks, credentials, and optional Broker Packs. See
 Use `--rebuild` after pulling source changes when existing build artifacts may
 be stale. Never use a real user-state root for launcher or recovery tests.
 
-## Server Lifecycle Direction
+## Server Lifecycle
 
 The browser convenience command and a persistent Server are separate lifetime
 contracts. `openalice start` remains foreground and browser-oriented. The
-target Server surface is:
+installed Server surface is:
 
 ```bash
 openalice server run [app-dir]     # foreground, no browser
@@ -132,9 +132,9 @@ It refuses to guess at an unreachable PID or silently stop an Electron-owned
 Runtime. Exact status classes, control fields, recovery rules, and the managed
 SSH composition live in [[docs/remote-access.md]].
 
-Until this target surface is implemented and passes the acceptance matrix in
-that guide, the supported source-backed server operation remains the
-foreground `openalice start --no-open` path.
+The detached path is still source-backed: the checkout supplies the built
+Runtime while the installed CLI supplies lifecycle and transport control. A
+future standalone bundle changes preparation, not these ownership semantics.
 
 ## Dependency Bootstrap Direction
 
@@ -179,6 +179,7 @@ When this surface changes:
 2. Run `pnpm build:server` and start with an isolated `--home` and test port.
 3. Open the real localhost route and verify the auth contract and Workspace UI.
 4. Run Guardian recovery checks when launcher ownership changes.
-5. Run Docker smoke when `scripts/guardian/prod.mjs` changes.
-6. Run Electron PTY/package smoke when dependency topology or shared Runtime
+5. Run `pnpm test:remote:docker` when managed SSH or Server lifecycle changes.
+6. Run Docker smoke when `scripts/guardian/prod.mjs` changes.
+7. Run Electron PTY/package smoke when dependency topology or shared Runtime
    behavior changes, even though the CLI itself does not package Electron.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -15,20 +15,23 @@ Related guides: [[docs/managed-workspace-runtime.md]],
 
 ## Runtime Topology
 
-OpenAlice has two long-running service processes supervised by Guardian:
+OpenAlice has two principal long-running service processes plus an optional
+Connector Service supervised by Guardian:
 
 ```text
 Guardian
+├── built Runtime control    versioned status + self-owned Server stop
 ├── Alice                    Workspace runtime + product/API process
 │   ├── Web UI transport     HTTP/Vite in dev, app:// + IPC in Electron
 │   ├── Workspace PTYs       claude / codex / opencode / pi / shell
 │   ├── ToolCenter           market, news, analysis, Inbox, UTA bridges
 │   └── file-backed state    config, sessions, issues, schedules, tool-call log
-└── UTA                      broker carrier and trading authority
-    ├── broker connections
-    ├── account state
-    ├── staged/committed trading operations
-    └── snapshots, FX, and execution
+├── UTA                      broker carrier and trading authority
+│   ├── broker connections
+│   ├── account state
+│   ├── staged/committed trading operations
+│   └── snapshots, FX, and execution
+└── Connector Service        optional external Inbox notification adapters
 ```
 
 Launchers share the same ownership model:
@@ -38,7 +41,9 @@ Launchers share the same ownership model:
   host. It starts Alice/UTA through Electron's Node mode.
 - `scripts/guardian/prod.mjs` supervises built Runtime services for Docker and
   the source-backed local CLI. Docker defaults to the `docker` launcher;
-  `openalice` supplies the distinct `cli` launcher and a loopback bind.
+  `openalice start` supplies the `cli` launcher, while `openalice server`
+  supplies `cli-server` plus a versioned local status/stop capability. All CLI
+  browser and SSH paths keep Alice on loopback.
 - `packages/guardian-runtime/` owns cross-launcher single-writer locks,
   heartbeat metadata, process identity, and controlled takeover.
 
@@ -87,7 +92,7 @@ packages/
 
 ui/                            React/Vite renderer
 apps/desktop/                  Electron main/preload/IPC shell
-scripts/guardian/              dev and production supervisors + smoke tests
+scripts/guardian/              dev/prod supervisors, local control + recovery tests
 default/                       shipped skills and factory defaults
 docs/                          owner guides and contributor documentation
 ```

--- a/docs/reference/herdr-remote-architecture.md
+++ b/docs/reference/herdr-remote-architecture.md
@@ -1,0 +1,396 @@
+# Herdr Remote Runtime Reference
+
+This is a non-authoritative research note for OpenAlice's remote Runtime work.
+It records what Herdr actually does, which parts are worth learning from, and
+which parts OpenAlice should not copy. Product contracts belong to
+[[docs/remote-access.md]].
+
+## Source Snapshot and License Boundary
+
+The review used the public
+[`ogulcancelik/herdr`](https://github.com/ogulcancelik/herdr) repository at
+commit
+[`a0678a38b9426b011f66e1b88ff7aaa9bf877104`](https://github.com/ogulcancelik/herdr/tree/a0678a38b9426b011f66e1b88ff7aaa9bf877104),
+inspected on 2026-07-15. The repository declares AGPL-3.0-or-later with a
+commercial-license option. This note links to and paraphrases the public source;
+it does not vendor Herdr code or make Herdr an OpenAlice dependency.
+
+Line links below are pinned to that commit so this note remains reproducible
+when Herdr's main branch changes.
+
+## Executive Summary
+
+Herdr is not merely a TUI launched inside SSH. Its default architecture is a
+persistent terminal Runtime with one or more thin clients:
+
+```text
+client terminal
+  └── input + resize + client-local integrations
+        └── private client protocol
+              └── background Herdr server
+                    ├── session state and layout
+                    ├── PTY processes and VT state
+                    ├── agent detection and metadata
+                    ├── virtual TUI rendering
+                    └── JSON control API and event subscriptions
+```
+
+There are two distinct SSH experiences:
+
+1. SSH into the host and run `herdr`. Both server and TUI client are remote;
+   the outer terminal transports their byte stream in the traditional tmux
+   style.
+2. Run `herdr --remote <host>` locally. A local Herdr client reaches a remote
+   Herdr server through an SSH stdio bridge. The client renders locally and can
+   integrate with the local clipboard and desktop.
+
+The second path improves ownership of local presentation and avoids replaying a
+remote terminal application's own drawing decisions. It does not eliminate
+network round-trip time: every keystroke still has to reach the remote PTY
+before new terminal state can return.
+
+The most transferable lesson is broader than the SSH bridge: the remote host
+owns durable Runtime facts and execution, while client presentation is
+replaceable. Herdr's own contributor guidance says it is still migrating toward
+that boundary and warns against adding shared behavior only to its private TUI
+socket. OpenAlice should begin with that neutral boundary instead of first
+building a second server-rendered application protocol.
+
+## Process Topologies
+
+### Default local mode
+
+Running `herdr` checks for the session server, starts it as a detached daemon if
+needed, waits for its client socket, and attaches a thin client. A
+`--no-session` option preserves a single-process compatibility path. The
+behavior is documented in
+[`src/server/autodetect.rs`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/autodetect.rs#L1-L29).
+
+The headless server owns both a JSON API socket and a private binary client
+socket. It restores state, owns PTYs, runs the event loop, renders to an
+in-memory terminal buffer, streams frames, routes client input, and remains
+alive after clients disconnect. See
+[`src/server/headless.rs`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/headless.rs#L1-L15).
+
+### Traditional SSH mode
+
+```text
+local terminal emulator
+  └── ssh terminal byte stream
+        └── remote Herdr client
+              └── remote Herdr server
+                    └── remote PTYs and agents
+```
+
+This is the simplest and most compatible route. Herdr behaves like a persistent
+terminal multiplexer. It also means the local machine cannot directly provide
+desktop clipboard/image behavior because the Herdr client itself is remote.
+Herdr documents the distinction in
+[`how-to-work.mdx`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/docs/next/website/src/content/docs/how-to-work.mdx#L34-L45).
+
+### Local client with remote Runtime
+
+```text
+local Herdr client
+  └── private local Unix socket
+        └── local bridge process
+              └── ssh -T <host> <remote-client-bridge>
+                    └── remote private client socket
+                          └── remote Herdr server, PTYs, and agents
+```
+
+`herdr --remote` first prepares a compatible remote binary, ensures the remote
+server is ready, creates a user-only local bridge socket, and launches the
+ordinary client against that socket. The bridge starts a non-interactive SSH
+process for each local connection and copies framed protocol bytes through SSH
+stdin/stdout. It is not an SSH `-L` tunnel to an HTTP application.
+
+Relevant implementation points:
+
+- remote orchestration:
+  [`src/remote/unix.rs#L155-L192`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L155-L192);
+- remote stdio-to-socket bridge:
+  [`src/remote/unix.rs#L194-L218`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L194-L218);
+- private local listener:
+  [`src/remote/unix.rs#L1685-L1753`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L1685-L1753);
+- SSH stdio forwarding:
+  [`src/remote/unix.rs#L1851-L1903`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L1851-L1903).
+
+## Server Ownership
+
+Herdr's server owns four different categories of state:
+
+| Category | Examples | Lifetime |
+|---|---|---|
+| Durable session model | workspaces, tabs, pane layout, labels, launch metadata | snapshot across server restart |
+| Live terminal Runtime | PTY process, parser/VT state, scrollback, current screen | while server and process live |
+| Shared agent facts | process identity, agent/session metadata, detection state | server-owned, API-visible direction |
+| Client-specific presentation | size, theme, keybindings, render baseline, clipboard side effects | one attached client |
+
+The separation is intentional. Herdr's repository rules distinguish pure
+`AppState` from `PaneRuntime`, keep rendering conceptually pure, and make
+detectors read terminal snapshots rather than own parsers. See
+[`AGENTS.md#L24-L32`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/AGENTS.md#L24-L32).
+
+The headless server still contains substantial application-presentation
+responsibility: it performs virtual ratatui rendering and carries presentation
+through a private client protocol. That is useful, but it is also architectural
+debt Herdr explicitly acknowledges. Its stated direction is a server-owned
+Runtime API with the TUI as one client, with shared facts exposed through the
+JSON API/event path and TUI-only state kept client-side. See
+[`AGENTS.md#L36-L51`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/AGENTS.md#L36-L51).
+
+## Client Protocol
+
+### Handshake and compatibility
+
+The private protocol is length-prefixed and versioned. The inspected snapshot
+uses protocol version 16, caps ordinary frames at 2 MiB, and has separate larger
+limits for explicit graphics and clipboard payloads. A client starts with
+`Hello` containing protocol version, terminal dimensions, render encoding,
+keybinding profile, and launch mode. The server answers with `Welcome` or a
+compatibility error.
+
+Sources:
+
+- limits and encodings:
+  [`src/protocol/wire.rs#L12-L44`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/protocol/wire.rs#L12-L44);
+- client messages:
+  [`src/protocol/wire.rs#L306-L398`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/protocol/wire.rs#L306-L398);
+- server messages:
+  [`src/protocol/wire.rs#L597-L667`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/protocol/wire.rs#L597-L667);
+- handshake validation:
+  [`src/server/client_transport.rs#L420-L574`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/client_transport.rs#L420-L574).
+
+### Two render encodings
+
+`SemanticFrame` sends structured cell/frame data. `TerminalAnsi` sends a
+per-client sequence plus already-diffed ANSI bytes that the client can write to
+stdout. Remote attach explicitly selects `terminal-ansi`; see
+[`src/remote/unix.rs#L1923-L1942`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L1923-L1942).
+
+The choice is pragmatic. Semantic frames leave more presentation work in the
+client but serialize a richer cell model. ANSI frames let the server reuse its
+terminal diff knowledge and keep the remote client small. Both are still
+frames of Herdr's whole terminal UI; neither is a neutral agent/session API.
+
+### Backpressure and slow clients
+
+Control messages and rendered frames do not share the same reliability policy:
+
+- control messages are queued reliably and take priority;
+- each client has only one pending render slot;
+- if that slot is occupied, the server defers a fresh full render instead of
+  accumulating obsolete intermediate frames;
+- each client keeps its own render baseline and only commits the baseline after
+  a frame is accepted for sending;
+- identical semantic or ANSI frames are skipped.
+
+This is the right mental model for interactive remoting: control is ordered;
+presentation is latest-state delivery. The queue and priority behavior is in
+[`src/server/client_transport.rs#L45-L52`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/client_transport.rs#L45-L52) and
+[`src/server/client_transport.rs#L183-L266`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/client_transport.rs#L183-L266).
+Per-client frame comparison and ANSI diff state live in
+[`src/server/render_stream.rs#L12-L117`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/render_stream.rs#L12-L117).
+
+Herdr also has a retained PTY update fast path that patches an existing frame
+when one full-app client is attached and the UI is in a safe terminal-only
+state. Otherwise it falls back to a full virtual render. A full render does not
+necessarily imply a full network redraw because the per-client encoder can
+still emit a diff. The fast path and queue-full behavior are visible in
+[`src/server/headless.rs#L3338-L3547`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/headless.rs#L3338-L3547).
+
+### What the latency optimization does and does not solve
+
+An Agent TUI may emit many cursor movements, clears, style changes, and repeated
+draws while producing one logical screen update. Herdr's remote server parses
+the PTY into terminal state, renders from current state, diffs against each
+client's acknowledged baseline, and skips or defers intermediate presentation.
+That reduces bandwidth and prevents a slow client from replaying a backlog of
+stale TUI bytes.
+
+It cannot make the remote Agent process local. Input still crosses SSH, the
+remote process decides what to render, and the resulting state crosses back.
+Herdr even preserves the ANSI diff baseline across ordinary keypresses because
+resetting it would force full redraws and make remote interaction noticeably
+slower; see
+[`src/server/headless.rs#L2570-L2594`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/headless.rs#L2570-L2594).
+
+For OpenAlice, this means the existing browser PTY-over-WebSocket path is a
+valid first measurement. A structured terminal stream is justified only if
+measurements show bandwidth/backlog problems. It should optimize the terminal
+plane, not turn the whole Studio into a remotely rendered TUI.
+
+## Multi-Client Ownership
+
+Multiple clients create authority questions that a simple tunnel can hide:
+
+- the most recently interacting full-app client becomes foreground;
+- the foreground client's dimensions drive shared PTY sizing;
+- client-local effects such as clipboard, window title, and notifications
+  should go to the relevant foreground client;
+- only one writable direct-attach client owns input and resize for a terminal;
+- an explicit takeover can replace that writer;
+- multiple observers may receive terminal frames without input or resize
+  authority.
+
+The server fields for foreground and attach ownership are in
+[`src/server/headless.rs#L250-L280`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/server/headless.rs#L250-L280).
+The user-facing controller/observer contract is documented in
+[`persistence-remote.mdx#L105-L155`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/docs/next/website/src/content/docs/persistence-remote.mdx#L105-L155).
+
+OpenAlice should not silently let the last WebSocket resize every PTY. The
+first managed-remote implementation may remain single-interactive-client, but
+its protocol and docs must name writer, resize, observer, and takeover
+authority so later Electron and browser clients do not invent conflicting
+rules.
+
+## Persistence Is Not One Feature
+
+Herdr usefully distinguishes five survival mechanisms:
+
+| Mechanism | What survives |
+|---|---|
+| Client detach | original server, PTYs, processes, live terminal state |
+| Server restart | serialized layout and launch metadata, not original processes |
+| Optional screen history | recent ANSI history, with an explicit secret-retention tradeoff |
+| Native Agent resume | conversation continuity through the Agent CLI's own session reference |
+| Live handoff | best-effort transfer of live PTYs during a compatible server replacement |
+
+The matrix is documented in
+[`session-state.mdx#L8-L35`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/docs/next/website/src/content/docs/session-state.mdx#L8-L35).
+Herdr stores layout/session snapshots separately from optional terminal history;
+its snapshot model is visible in
+[`src/persist/snapshot.rs#L11-L122`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/persist/snapshot.rs#L11-L122),
+and writes are committed through a temporary file plus rename in
+[`src/persist/io.rs#L44-L75`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/persist/io.rs#L44-L75).
+
+This vocabulary prevents misleading claims. “The server persists” does not
+mean “every process survives a server crash,” and “the conversation resumes”
+does not mean “the original PTY is alive.” OpenAlice's remote contract should
+use the same distinctions.
+
+## Session Isolation and Local Control
+
+Herdr gives each named session its own state directory, API socket, client
+socket, panes, and Runtime while sharing global configuration. Session status
+is determined by reachability, and stop is a structured `server.stop` request
+followed by a bounded wait for both sockets to become unreachable. See
+[`src/session.rs#L157-L225`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/session.rs#L157-L225) and
+[`src/session.rs#L232-L297`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/session.rs#L232-L297).
+
+The API listener applies user-only socket permissions, refuses a busy socket,
+and only removes a socket it still owns. See
+[`src/api/server.rs#L74-L137`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/api/server.rs#L74-L137).
+
+The transferable pattern is self-termination through an authenticated local
+control endpoint. A CLI should ask the Runtime to stop and verify the endpoint
+has gone away; it should not guess a PID and kill it. OpenAlice already has a
+stronger Guardian lease/process-tree model, so the local control endpoint must
+compose with Guardian ownership rather than replace it.
+
+## Remote Bootstrap and Upgrade
+
+Herdr's remote attach does more than connect:
+
+1. detect remote OS and architecture;
+2. search normal `PATH` and common manager-specific locations;
+3. verify that a candidate binary reports the expected version;
+4. ask before installing or replacing a remote binary;
+5. fail without host mutation in non-interactive mode;
+6. stream a matching binary to a temporary path, make it executable, and
+   atomically move it into `~/.local/bin`;
+7. verify the installed version and warn if the directory is absent from PATH;
+8. ensure the remote server is compatible and ready before attaching.
+
+The product contract is summarized in
+[`persistence-remote.mdx#L38-L95`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/docs/next/website/src/content/docs/persistence-remote.mdx#L38-L95).
+The staged transfer is in
+[`src/remote/unix.rs#L522-L611`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L522-L611),
+and detection/confirmation/verification is in
+[`src/remote/unix.rs#L672-L735`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L672-L735).
+
+For connection stability, Herdr can generate a private temporary SSH config
+that includes the user's config and adds fallback keepalive and ControlMaster
+settings. The directory and bridge socket are user-only. See
+[`src/remote/unix.rs#L634-L648`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L634-L648) and
+[`src/remote/unix.rs#L1756-L1765`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/remote/unix.rs#L1756-L1765).
+
+OpenAlice should reuse its own installer/update trust chain for remote hosts.
+It should not copy Herdr's binary transfer implementation or grow a second
+remote-only installer inside `openalice remote`.
+
+## Stable API Versus Private Presentation Protocol
+
+Herdr currently exposes two materially different interfaces:
+
+| Interface | Purpose | Coupling |
+|---|---|---|
+| Private binary client socket | full TUI attach, raw input, resize, semantic/ANSI render frames, local presentation effects | tightly coupled to Herdr's TUI |
+| JSON socket API | version/capabilities, session snapshot, workspace/tab/pane/agent control, event subscription | intended as neutral Runtime control |
+
+The JSON API exposes version and protocol in `ping`, a complete
+`session.snapshot`, and event subscriptions. The snapshot contains focused
+identifiers plus workspace, tab, pane, layout, and agent records; see
+[`src/api/schema/session.rs#L8-L22`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/api/schema/session.rs#L8-L22).
+The public API method surface is dispatched independently of the private TUI
+client in
+[`src/api/server.rs#L307-L425`](https://github.com/ogulcancelik/herdr/blob/a0678a38b9426b011f66e1b88ff7aaa9bf877104/src/api/server.rs#L307-L425).
+
+The snapshot-plus-events shape is the better model for an independent
+OpenAlice Studio. On connect or reconnect, a client needs a coherent snapshot,
+a sequence/cursor boundary, and ordered events after that boundary. If the
+cursor cannot be resumed, the client must resnapshot instead of guessing. PTY
+bytes remain a specialized stream keyed by stable Runtime identities.
+
+## What OpenAlice Should Borrow
+
+| Herdr lesson | OpenAlice adaptation |
+|---|---|
+| Default client/server split | Make Guardian-supervised Runtime a named CLI surface without changing Electron ownership |
+| Two distinct SSH modes | Preserve ordinary SSH/manual startup and add a separate managed `remote` orchestration command |
+| Remote execution, local presentation | Keep browser/Electron local when useful; keep Workspace files, Agent processes, tools, and credentials on the remote host |
+| Versioned handshake | Version local control and future Studio protocols from the first release |
+| Reliable control, droppable frames | Never let a slow terminal viewer build an obsolete render backlog |
+| Explicit foreground/writer/observer ownership | Specify input and resize authority before supporting concurrent clients |
+| Snapshot plus events | Use presentation-neutral Runtime facts for a future independent Studio |
+| Structured local stop | Ask Guardian to stop its own tree, then verify shutdown; do not kill guessed PIDs |
+| Consentful bootstrap | Probe first, show a plan, default to no mutation, reuse the normal OpenAlice installer |
+| Precise persistence vocabulary | Distinguish detach, restart, scrollback, native Agent resume, and live handoff |
+
+## What OpenAlice Should Not Borrow
+
+- Do not replace the existing browser/Electron UI with a server-rendered TUI
+  framebuffer protocol. OpenAlice already has a presentation-neutral HTTP/WS
+  surface and a complete Electron client.
+- Do not make the server depend on a currently attached client. Guardian,
+  workspaces, schedules, and Agent processes must remain valid without one.
+- Do not let SSH mutate a host merely because a connection succeeded. Install,
+  update, start, takeover, and stop are separate consent and authority steps.
+- Do not create a second installation path for remote machines. The installed
+  CLI and release trust chain must be the same as local bootstrap.
+- Do not claim that daemon persistence implies PTY crash recovery or Agent
+  conversation recovery.
+- Do not expose a private control socket through SSH or HTTP by default.
+- Do not adopt Herdr's AGPL implementation. Learn from the public architecture,
+  keep source attribution, and implement OpenAlice's contract independently.
+
+## Decision for OpenAlice
+
+The first OpenAlice increment should establish a durable server lifecycle and
+then compose SSH around the existing same-origin localhost application:
+
+```text
+local browser or Electron client
+  └── local loopback endpoint
+        └── SSH transport
+              └── remote loopback Alice HTTP + PTY WebSocket
+                    └── Guardian-owned Runtime and native Agent CLIs
+```
+
+This gives users a useful remote product before inventing a new Studio
+protocol. In parallel, server status and future shared state must use neutral
+Runtime names and versioned schemas so a later independent frontend can consume
+`snapshot + events + terminal streams` without inheriting a server-rendered UI
+protocol. The authoritative commands, ownership rules, security boundary, and
+acceptance stages are specified in [[docs/remote-access.md]].

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -1,95 +1,678 @@
-# Remote Access
+# Remote Runtime and Access
 
-This guide owns OpenAlice's SSH access experiment and the boundary between a
-remote Runtime and local presentation. It complements
-[[docs/local-runtime.md]], [[docs/docker-deployment.md]], and
-[[docs/managed-workspace-runtime.md]].
+This guide owns OpenAlice's remote Runtime architecture: server lifecycle,
+local and remote client responsibilities, SSH transport, managed remote
+bootstrap, control/status contracts, multi-client authority, and the staged
+path toward an independent Studio frontend.
 
-## Local Runtime First
+It complements [[docs/local-runtime.md]], [[docs/docker-deployment.md]], and
+[[docs/managed-workspace-runtime.md]]. The Herdr comparison that informed this
+design is recorded in
+[[docs/reference/herdr-remote-architecture.md]]. That reference is research;
+this guide is the OpenAlice contract.
 
-Remote access builds on the local Runtime contract in
-[[docs/local-runtime.md]]. Prove `openalice` can prepare a source checkout,
-start Guardian on `127.0.0.1`, and serve the normal browser UI before adding a
-transport. This keeps the first distribution loop independent of domains,
-cross-domain cookies, hosted Studio state, and SSH lifecycle.
+## Status
 
-## SSH Experiment: Measure the Existing TUI
+The repository currently ships the Stage 0 path:
 
-The first remote path deliberately keeps the existing product architecture:
+- `openalice start` prepares a source checkout, runs Guardian in the
+  foreground, and optionally opens the local browser;
+- `openalice ssh <target>` creates a loopback SSH tunnel to an already-running
+  remote OpenAlice Runtime;
+- Electron remains a complete local desktop distribution.
+
+The `openalice server` lifecycle and `openalice remote` managed-host flow below
+are the next implementation stages. Commands described as target behavior must
+not be documented to users as already released until their acceptance rows are
+complete.
+
+## Product Decision
+
+OpenAlice has four first-class entry surfaces, not one replacement chain:
+
+| Surface | Presentation runs | Runtime runs | Purpose |
+|---|---|---|---|
+| Electron | local packaged app | local Electron-owned Runtime | complete desktop distribution |
+| Local browser | local browser | local Guardian-owned Runtime | low-friction CLI distribution and development |
+| SSH browser | local browser | remote Guardian-owned Runtime | same product over an authenticated transport |
+| Independent Studio | local or hosted web client | local, remote, or managed Runtime | later presentation-neutral client |
+
+Electron must remain complete. The CLI/server path is an additional
+distribution and remote-control surface; it does not replace Electron's
+`app://` protocol, preload/IPC, packaged PTY, signing, updater, or managed
+runtime behavior.
+
+The first remote product reuses the normal OpenAlice browser application over
+an SSH loopback tunnel. This already keeps the expensive and security-sensitive
+work on the remote host while rendering HTML locally. A new hosted Studio
+protocol is deferred until the local/server boundary is stable.
+
+## Vocabulary
+
+- **Runtime**: the Guardian-owned process tree and user state under one
+  `OPENALICE_HOME`. It includes Alice, optional UTA, optional Connector Service,
+  workspaces, PTYs, native Agent CLIs, schedules, and file-backed state.
+- **Server**: a Runtime deliberately started without owning a browser or
+  terminal client. It continues after the command that requested detached
+  startup exits.
+- **Client**: a presentation or control surface: browser, Electron renderer,
+  installed CLI, or future independent Studio.
+- **Transport**: how a client reaches a Runtime. The first remote transport is
+  OpenSSH; it is not part of Runtime state.
+- **Control endpoint**: a user-local, non-network endpoint owned by Guardian for
+  status and graceful shutdown. It is distinct from Alice HTTP, MCP/CLI, UTA,
+  Connector, and PTY WebSocket endpoints.
+- **Presentation protocol**: HTTP/WS for the current browser, Electron IPC for
+  the packaged app, and a future versioned snapshot/event protocol for an
+  independent Studio.
+
+## Architectural Invariants
+
+1. The machine that owns the files owns the Workspace, native Agent processes,
+   tool execution, provider requests, and trading boundary.
+2. Guardian remains the final single-writer and process-tree authority for an
+   `OPENALICE_HOME`; a new CLI command may not invent a parallel lock.
+3. UTA remains optional. Server, remote status, browser Chat, and non-trading
+   work must function in lite/read-only mode.
+4. Alice binds to `127.0.0.1` for local and SSH-backed server use. Internal
+   MCP/CLI, UTA, Connector, control, and PTY ports are never made public to
+   enable remote access.
+5. SSH authenticates and encrypts transport. It does not silently grant
+   install, update, start, takeover, or stop consent.
+6. Disconnecting a browser, Electron renderer, CLI, or SSH tunnel does not stop
+   a detached Server.
+7. `server stop` asks the owning Guardian to terminate its own tree and verifies
+   completion. It does not signal a guessed PID or delete a live lock.
+8. `--takeover` remains the only command-line authority to replace another
+   recorded Guardian owner.
+9. Remote bootstrap reuses the ordinary OpenAlice CLI installer and release
+   trust chain. It does not carry a second SSH-only installer.
+10. Shared Runtime facts use presentation-neutral names and versioned schemas.
+    Browser layout, Electron chrome, modal state, and other client UI state do
+    not become server truth.
+
+## Layered Topology
+
+```text
+presentation plane
+  browser | Electron | future Studio
+        │
+transport plane
+  loopback HTTP/WS | Electron IPC | SSH loopback | future capability channel
+        │
+runtime/control plane
+  Guardian lease + local control endpoint + Alice APIs
+        │
+execution plane
+  Workspace files + PTYs + native Agent CLIs + tools + optional UTA
+```
+
+The boundary matters when debugging latency. In an SSH-browser session, the
+browser is local but the shell/TUI and model loop are remote. Keystrokes cross
+the network to the remote PTY; remote screen changes return over the Workspace
+WebSocket. HTML layout, menus, lists, and most Studio interaction remain local
+browser work.
+
+## Command Contract
+
+### Existing local and transport commands
+
+```bash
+openalice start [app-dir]
+openalice ssh <target>
+```
+
+`openalice start` is an interactive foreground convenience command. It prepares
+the source checkout, starts Guardian, opens the browser unless `--no-open` is
+set, and stops its Runtime when the command receives a termination signal. If a
+healthy Runtime already owns the requested home and port, it reuses that URL
+instead of replacing the owner.
+
+`openalice ssh` is a pure transport command. It chooses a free local loopback
+port, forwards it to the remote Alice loopback port, optionally opens the
+browser, and stays in the foreground to own the tunnel. It never installs,
+updates, starts, stops, or takes over the remote Runtime.
+
+### Target server lifecycle
+
+```bash
+openalice server run [app-dir]
+openalice server start [app-dir]
+openalice server status
+openalice server stop
+```
+
+All server commands accept the same explicit `--home`, `--port`, and source
+checkout selection as local start. `run` and `start` also accept `--rebuild` and
+`--takeover` where the existing start contract does.
+
+| Command | Lifetime and side effects |
+|---|---|
+| `server run` | foreground Guardian; no browser; logs remain attached; signals cascade through Guardian |
+| `server start` | idempotent detached start; waits for control and HTTP readiness before succeeding; never opens a browser |
+| `server status` | read-only probe; human output by default and stable `--json` for orchestration |
+| `server stop` | structured local stop request to the matching CLI Server, followed by a bounded wait for tree and endpoint exit |
+
+`server start` has three valid outcomes:
+
+1. **started**: it prepared the Runtime, detached it, and observed readiness;
+2. **already running**: the requested CLI Server was already healthy and
+   compatible, so no process was replaced;
+3. **owned elsewhere**: another launcher or incompatible owner holds the
+   Guardian lease. The command reports the owner and exits without mutation.
+
+Only an explicit `--takeover` may turn the third result into replacement. A
+normal start must never interrupt an Electron session, another checkout, a
+Docker-owned home, or a healthy CLI foreground start.
+
+`server stop` is deliberately narrower than takeover. It stops a Runtime only
+when the reachable control endpoint proves that it is the requested CLI Server
+for the same canonical home. If Electron or another launcher owns the lease but
+does not advertise that control contract, status reports `owned_elsewhere` and
+stop refuses. The user may then close that surface normally or make a separate
+explicit takeover decision.
+
+### Target managed remote command
+
+```bash
+openalice remote <target> --app-dir <remote-checkout>
+```
+
+`openalice remote` is orchestration around the same Server and SSH contracts:
+
+1. verify ordinary SSH connectivity and host-key policy;
+2. detect remote platform and an installed `openalice` CLI;
+3. probe `openalice server status --json` and protocol compatibility;
+4. if CLI install or update is required, show the exact plan and ask separately
+   before changing the remote host;
+5. call the normal remote installer non-interactively only after that consent;
+6. run `openalice server start --app-dir ...` remotely and wait for readiness;
+7. create the same loopback tunnel used by `openalice ssh`;
+8. open or print the local URL and stay in the foreground to own only the
+   tunnel.
+
+Closing `openalice remote` closes the tunnel but leaves the detached remote
+Server running. Stop is explicit:
+
+```bash
+ssh <target> openalice server stop
+```
+
+A later convenience subcommand may issue that same remote command, but it must
+not conflate “disconnect” with “stop my remote work.”
+
+The source-backed phase requires `--app-dir` unless the remote CLI already has
+a previously validated Runtime source or standalone bundle recorded for that
+home. It must not scan arbitrary remote directories or clone a repository
+without a separate visible plan. A future headless release bundle can remove
+the source-checkout requirement without changing the command or lifecycle
+contract.
+
+`--yes` may approve the displayed install/update/start plan for automation, but
+it never implies `--takeover`. Non-interactive execution without a sufficient
+explicit approval fails without remote mutation.
+
+## Server Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Absent
+    Absent --> Starting: server start or run
+    Starting --> Running: control and HTTP ready
+    Starting --> Failed: timeout or child exit
+    Running --> Running: idempotent start or status
+    Running --> Stopping: structured stop or owner signal
+    Stopping --> Absent: process tree exited and lease released
+    Running --> Recovering: owner dies unexpectedly
+    Recovering --> Running: Guardian recovery or explicit takeover
+    Recovering --> Absent: bounded cleanup completes
+```
+
+The readiness barrier includes:
+
+- Guardian owns the canonical runtime lease;
+- the local control endpoint responds with a compatible protocol;
+- Alice reports healthy on its loopback HTTP endpoint;
+- optional components report their own state without making UTA a readiness
+  requirement for non-trading use.
+
+The detached parent returns success only after this barrier. On timeout it
+prints the isolated log path and current ownership evidence. It must not report
+success merely because a child PID was spawned.
+
+The Server writes structured logs beneath the selected `OPENALICE_HOME` and
+prints that path on start/status. Logs must not contain provider, broker, SSH,
+pairing, or sealing secrets.
+
+## Guardian Control Contract
+
+### Endpoint
+
+The initial Unix endpoint is a user-only local socket beneath the canonical
+`OPENALICE_HOME` Runtime state. The exact filesystem name is implementation
+owned, but it must be deterministic for that home, created with user-only
+permissions, and removed only by the process that still owns it. Native Windows
+uses an equivalent per-home named pipe when this CLI surface is supported
+there.
+
+The endpoint is never bound to TCP and is never forwarded by `openalice ssh`.
+Remote orchestration reaches it only by executing the remote CLI through SSH.
+
+Stale path handling follows reachability and ownership, not existence alone:
+
+1. connect and perform a versioned status request;
+2. if reachable, treat it as an owner regardless of a surprising PID file;
+3. if unreachable, consult the Guardian lease/recovery state;
+4. remove a stale endpoint only while acquiring ownership for a new Guardian;
+5. never unlink an endpoint merely because status timed out once.
+
+### Versioned messages
+
+The control protocol is newline-delimited JSON with a small, bounded request
+size. Every request and response carries `protocol` and `id`. Initial methods:
+
+- `runtime.status` — read-only readiness, ownership, version, endpoints, and
+  component health;
+- `runtime.stop` — acknowledge intent, begin the normal Guardian shutdown
+  cascade, and close the endpoint only after shutdown begins.
+
+The status result is presentation-neutral and includes at least:
+
+```json
+{
+  "protocol": 1,
+  "runtimeVersion": "<OpenAlice version or dev identity>",
+  "state": "running",
+  "home": "<canonical OPENALICE_HOME>",
+  "owner": {
+    "surface": "cli-server",
+    "pid": 1234,
+    "instanceId": "<Guardian instance id>",
+    "startedAt": "<ISO-8601>",
+    "launchRoot": "<source or bundle root>"
+  },
+  "endpoints": {
+    "web": "http://127.0.0.1:47331"
+  },
+  "components": {
+    "alice": "ready",
+    "uta": "disabled",
+    "connector": "disabled"
+  },
+  "capabilities": ["runtime.stop"]
+}
+```
+
+Human `server status` output may be friendly, but `--json` preserves this
+machine-readable meaning and stable exit classes:
+
+| Class | Meaning |
+|---|---|
+| `running` | compatible CLI Server is ready |
+| `starting` / `stopping` | matching owner is in a transitional state |
+| `absent` | no reachable control endpoint and no live Guardian owner |
+| `owned_elsewhere` | Guardian evidence exists, but it is not a matching controllable CLI Server |
+| `incompatible` | endpoint is reachable but protocol/runtime compatibility fails |
+| `unhealthy` | matching owner exists but readiness checks fail |
+
+Status must not return credentials, auth tokens, complete environment
+variables, arbitrary command lines, or private internal-port URLs.
+
+### Shutdown and recovery
+
+`runtime.stop` enters the existing Guardian shutdown path:
+
+1. stop accepting new control mutations;
+2. send the normal graceful signal to children;
+3. wait the existing grace period;
+4. escalate through Guardian's process-tree policy when required;
+5. wait for children and the recorded owner to exit;
+6. release only the lease and control endpoint owned by this instance.
+
+If the control endpoint is unreachable but a lease exists, `server stop` does
+not improvise cleanup. Recovery remains the existing explicit Guardian
+takeover path with its discover → TERM → grace → tree KILL → owner-exit order.
+
+## SSH Transport Contract
+
+The current transport remains intentionally boring:
 
 ```text
 local browser
-  └── 127.0.0.1:<random port>
-        └── SSH local forward
-              └── remote 127.0.0.1:47331
-                    └── Alice HTTP + Workspace PTY WebSocket
+  └── http://127.0.0.1:<random-local-port>
+        └── ssh -L 127.0.0.1:<local>:127.0.0.1:<remote>
+              └── remote Alice HTTP + Workspace PTY WebSocket
 ```
 
-Alice, the Workspace, agent CLI, shell, model requests, and tool execution all
-run on the SSH host. The browser loads the normal OpenAlice bundle through the
-tunnel, so HTTP, authentication, and the PTY WebSocket remain same-origin. No
-hosted Studio, relay, or second frontend protocol is involved.
+Alice, the Workspace, Agent CLI, shell, provider calls, and tools run on the SSH
+host. The browser loads the normal OpenAlice bundle through the tunnel, so
+HTTP, authentication, and Workspace WebSockets stay on one local loopback
+origin. No public domain, hosted-cookie bridge, relay, or second frontend
+protocol is required.
 
-This experiment exists to measure the real TUI experience before designing around a
-latency problem that may not matter on normal developer links. WebPi remains an
-optional structured Pi surface; it is not a prerequisite or replacement for
-Shell, Claude Code, Codex, opencode, or Pi TUI sessions.
+`openalice ssh` and the tunnel phase of `openalice remote`:
 
-## Prerequisites
+- bind only local `127.0.0.1`;
+- target only remote `127.0.0.1`;
+- use the user's ordinary OpenSSH config, agent, keys, ProxyJump, and host-key
+  verification;
+- preserve interactive SSH authentication when a terminal is available;
+- use keepalives without overriding stronger user config;
+- exit clearly when the local port cannot bind or the remote forward fails;
+- never disable host-key checking;
+- never expose the Guardian control endpoint.
 
-1. OpenAlice is already running on the remote machine, for example with the
-   source-backed `openalice start --no-open` path.
-2. Its web listener is reachable as `127.0.0.1:47331` from that machine.
-3. The local machine has `ssh` and working key, agent, or interactive SSH auth.
+Before diagnosing an OpenAlice error, users should be able to verify
+`ssh <target>` independently. Managed remote may reuse an SSH ControlMaster in
+a private user-only temporary directory, but it must clean up only the control
+socket it created.
 
-For a source checkout, start the normal Guardian on the remote host. For a
-server deployment, follow [[docs/docker-deployment.md]]. Do not expose the
-internal CLI/MCP, UTA, or Connector ports.
+## HTTP and Browser Security
 
-From this repository:
+SSH makes the remote HTTP request arrive from loopback, so network origin alone
+is not sufficient authorization. The browser contract remains:
 
-```bash
-pnpm remote:ssh -- user@example.com
-```
+- the UI, HTTP API, and PTY WebSocket share the tunnel's local loopback origin;
+- Alice accepts loginless local behavior only for no-`Origin` local CLI/server
+  callers, a validated loopback browser origin, or the exact packaged
+  `app://openalice` origin;
+- public web origins cannot inherit localhost trust merely because a tunnel is
+  open;
+- state-changing requests and WebSocket upgrades keep origin validation;
+- `OPENALICE_DISABLE_AUTH=1` is never a remote-access instruction;
+- a deployment intentionally exposed beyond loopback follows
+  [[docs/docker-deployment.md]] and its normal HTTPS/auth boundary.
 
-From an installed CLI package:
+The future independent Studio cannot reuse “it arrived from loopback” as its
+identity. It needs an explicit pairing/capability flow with revocation,
+least-privilege scopes, origin binding, and a user-visible device/session list.
+That is a later protocol, not a shortcut in the SSH phase.
 
-```bash
-openalice ssh user@example.com
-```
+## Terminal and Agent Streaming
 
-The command chooses a free local port, opens the local URL, and remains in the
-foreground to own the tunnel. Use `--no-open` to print the URL only, or
-`--remote-port` when the remote Alice web port differs from `47331`.
+### Stage-one behavior
 
-The forward binds only local `127.0.0.1` and targets only remote `127.0.0.1`.
-Closing the CLI closes the tunnel. The command does not install, update, start,
-or stop the remote Runtime. A later remote lifecycle command should reuse the
-local bootstrap contract rather than embedding a second installation system in
-the SSH connector.
+The existing Workspace PTY WebSocket crosses the SSH tunnel unchanged. The
+remote PTY and Agent TUI remain authoritative; the local xterm-compatible
+surface renders received terminal bytes. Shell, Claude Code, Codex, opencode,
+and Pi retain the same terminal semantics. WebPi remains an optional structured
+Pi surface, not a prerequisite or replacement for shell/TUI workflows.
 
-## Security Boundary
+This path should be measured before adding a second terminal protocol. Relevant
+tests use controlled network conditions such as 20 ms, 80 ms, and 150 ms RTT,
+low-bandwidth links, bursty Agent redraws, resize, reconnect, and long-running
+output. Record:
 
-SSH authenticates the transport, but the remote HTTP server sees forwarded
-requests as loopback. Alice therefore grants its loginless localhost behavior
-only to requests with no browser `Origin` (CLI/server callers), a loopback
-browser Origin, or the exact packaged `app://openalice` origin. A public
-website cannot inherit localhost trust merely because the user currently has
-an OpenAlice tunnel open.
+- input-to-first-visible-output latency;
+- bytes transferred during representative Agent interactions;
+- whether stale output accumulates after a burst;
+- reconnect and scrollback behavior;
+- CPU and memory on both ends;
+- behavior when the tunnel disappears mid-command.
 
-Keep the remote web listener private or protected by the deployment's normal
-HTTPS/auth boundary. Never use `OPENALICE_DISABLE_AUTH=1` for remote access.
+Round-trip latency cannot be removed while the Agent process is remote. The
+design goal is to avoid adding avoidable backlog, excessive redraw bandwidth,
+or remote presentation work on top of that RTT.
 
-## Deferred Remote Stages
+### Structured terminal optimization, if evidence requires it
 
-The SSH experiment intentionally leaves these separate:
+If raw PTY traffic creates meaningful backlog or bandwidth cost, add a
+terminal-specific stream behind stable Workspace/Session/terminal identities:
 
-- managed remote Runtime installation and daemon lifecycle;
-- a hosted standalone Studio and pairing/capability protocol;
-- cloud relay or device enrollment;
-- cursor-based structured Session streaming for Pi, Codex, or other agents;
-- remote control from the packaged Electron app.
+- server parses terminal bytes into current VT state;
+- clients negotiate full snapshot plus incremental updates;
+- each frame has a monotonic sequence and explicit dimensions;
+- control messages remain reliable and ordered;
+- render updates are bounded latest-state data, not an unbounded reliable
+  queue;
+- a gap or incompatible baseline triggers a fresh snapshot;
+- only an acknowledged or queued frame advances the per-client baseline;
+- observers cannot send input or resize;
+- one controller owns input and resize, with explicit takeover.
 
-Evidence from the raw TUI experiment should decide which of these is worth
-building next. Electron's existing local `app://` + preload/IPC distribution
-remains unchanged.
+This stream optimizes terminals only. Studio navigation, data tables, settings,
+Inbox, Workspace metadata, and trading UI continue to use presentation-neutral
+application APIs rather than a remote-rendered framebuffer.
+
+## Multi-Client Authority
+
+The first SSH-browser release may support one interactive browser per terminal,
+but the contract reserves explicit roles:
+
+| Role | Read output | Send input | Resize PTY | Take ownership |
+|---|---:|---:|---:|---:|
+| observer | yes | no | no | no |
+| controller | yes | yes | yes | no |
+| takeover requester | after grant | after grant | after grant | explicit only |
+
+For a given terminal there is at most one controller. A second browser,
+Electron client, or future Studio may observe without changing the PTY size.
+Control transfer is visible and deliberate; it is not awarded silently to the
+last socket that sends a resize.
+
+Client-local effects stay client-local:
+
+- clipboard reads/writes target the controlling local surface;
+- notifications name the Session and source client policy;
+- window size and focus are not durable Runtime facts;
+- reconnect does not imply takeover;
+- disconnect releases transient controller ownership after a bounded grace
+  period, but does not kill the PTY or Agent.
+
+Shared Runtime facts include Workspace and Session identity, terminal identity,
+Agent process/session metadata, execution status, artifacts, and file-backed
+state. They must not be named after a particular sidebar, card, tab strip, or
+Electron window.
+
+## Persistence Semantics
+
+Remote documentation must distinguish what survived:
+
+| Event | Guardian tree | PTY process | recent terminal state | Agent conversation |
+|---|---:|---:|---:|---:|
+| browser/tunnel disconnect | survives | survives | live in PTY Runtime | survives because process lives |
+| controller transfer | survives | survives | live in PTY Runtime | survives because process lives |
+| Alice child restart under Guardian | Guardian survives | depends on current PTY ownership path | implementation-dependent | native Agent process/session dependent |
+| full Guardian/server restart | stops and restarts | does not automatically survive | only persisted history, if explicitly supported | only through native Agent resume/provenance |
+| machine reboot | stops | stops | only persisted history | only through native Agent resume/provenance |
+
+OpenAlice must not market server detach as crash-proof terminal persistence.
+Conversation provenance and native CLI resume remain governed by
+[[docs/conversation-provenance.md]]. Persisting terminal scrollback is a
+separate privacy decision because screens can contain source, prompts, output,
+tokens, or account data.
+
+Live PTY handoff during Runtime upgrade is explicitly deferred. The first
+managed remote version may require a visible stop/restart when protocols are
+incompatible. It must describe the effect before acting.
+
+## Managed Remote Bootstrap and Compatibility
+
+Managed bootstrap uses a plan/apply split.
+
+The read-only plan reports:
+
+- SSH target and resolved remote platform/architecture;
+- detected OpenAlice CLI path and version;
+- control protocol compatibility;
+- Server state and source/bundle root;
+- proposed install/update/start actions;
+- destination paths and whether PATH changes are required;
+- whether a running owner would be affected;
+- the final local and remote loopback ports.
+
+Apply rules:
+
+1. no compatible CLI: ask before invoking the normal installer;
+2. compatible CLI, absent Server: start after explicit plan consent;
+3. compatible healthy Server: reuse without mutation;
+4. incompatible stopped CLI: ask before update;
+5. incompatible running Server: stop/restart or update only after a second
+   effect-specific confirmation;
+6. owner conflict: fail unless the user separately passed `--takeover`;
+7. non-interactive mode: require flags that cover every proposed mutation.
+
+The local orchestrator must compare protocol ranges, not only human version
+strings. It may tolerate a newer compatible Runtime, but it must fail clearly
+when a method or schema is unsupported. Development overrides for a local CLI
+payload or checkout are allowed only behind explicit flags and are not the
+release path.
+
+## Future Independent Studio Protocol
+
+The independent frontend is not “serve the current bundle from another domain
+and forward cookies.” It is a client of a versioned Runtime protocol.
+
+Its minimum reconnect model is:
+
+1. authenticate through an explicit local pairing or remote capability;
+2. negotiate protocol version and capabilities;
+3. fetch one coherent Runtime snapshot with a cursor;
+4. subscribe to ordered events after that cursor;
+5. attach specialized streams, such as terminal output, by stable identity;
+6. if the cursor is unavailable or a sequence gap appears, discard derived
+   state and resnapshot;
+7. issue mutations with request IDs and idempotency where retry is possible.
+
+The snapshot contains presentation-neutral data such as Runtime identity,
+Workspace/Session records, terminal and Agent identities, health, and
+capabilities. It does not contain browser component trees or Electron window
+state.
+
+This protocol can later travel through SSH stdio, a local socket, an
+authenticated WebSocket, or a relay. Transport choice does not redefine the
+Runtime model.
+
+## Delivery Stages
+
+### Stage 0 — pure SSH tunnel (current)
+
+- remote Runtime is started manually;
+- `openalice ssh` owns only the tunnel;
+- normal browser UI and PTY WebSocket traverse one local loopback origin;
+- no remote mutation.
+
+### Stage 1 — native Server lifecycle
+
+- add `server run/start/status/stop`;
+- add Guardian-owned local status/stop endpoint;
+- detached start waits for real readiness;
+- status distinguishes absent, compatible, unhealthy, and other owner;
+- stop is structured and self-owned;
+- Electron behavior remains unchanged.
+
+### Stage 2 — managed source-backed remote
+
+- add `openalice remote` plan/apply orchestration;
+- probe and bootstrap the existing CLI with explicit consent;
+- start/reuse the remote Server;
+- reuse the existing SSH loopback tunnel;
+- leave the Server alive after disconnect;
+- validate ordinary Agent TUI interaction under network shaping.
+
+### Stage 3 — terminal transport optimization
+
+- build only if Stage 2 measurements justify it;
+- add snapshot/diff/sequence/backpressure semantics for terminal state;
+- add controller/observer ownership and takeover tests;
+- keep the rest of Studio on application-level APIs.
+
+### Stage 4 — independent Studio and broader transports
+
+- add Runtime snapshot/events protocol;
+- add pairing/capability security;
+- support Electron remote selection and/or hosted Studio;
+- consider relay/device enrollment only after direct SSH is operationally
+  understood.
+
+### Stage 5 — standalone headless Runtime bundle
+
+- replace source checkout preparation with signed, content-addressed release
+  assets where supported;
+- retain the same `server` and `remote` commands, status schema, state root, and
+  consent model;
+- keep source-backed development as a supported diagnostic path.
+
+## Acceptance Matrix
+
+### Stage 1
+
+| Scenario | Required result |
+|---|---|
+| fresh isolated home | detached Server reaches control and HTTP readiness |
+| second normal start | reports already running; does not signal owner |
+| explicit takeover | follows Guardian recovery ordering and obtains one owner |
+| status JSON | stable schema and exit class for all lifecycle states |
+| graceful stop | Guardian stops children, releases owned lease/socket, exits in bound |
+| hung child | TERM precedes process-tree KILL; no orphan survives |
+| stale endpoint | recovered only with lease/ownership evidence |
+| cross-root or foreign owner | no normal-start kill; explicit takeover only |
+| optional UTA absent | Server and browser Chat remain ready |
+| Electron running | `server start/stop` do not silently replace or terminate it |
+| packaged Electron smoke | local app, PTY, IPC, and shutdown remain healthy |
+
+### Stage 2
+
+| Scenario | Required result |
+|---|---|
+| compatible remote CLI/Server | reuses both without mutation |
+| missing remote CLI, interactive | shows plan; default no leaves host unchanged |
+| missing remote CLI, non-interactive | fails unless explicit approval is present |
+| incompatible running Server | explains process impact before update/restart |
+| remote source missing | fails with actionable `--app-dir` guidance; no surprise clone |
+| tunnel disconnect | local command exits; remote Server and work continue |
+| reconnect | same Runtime and live terminal are reachable |
+| host-key failure | fails without disabling verification |
+| SSH agent/passphrase path | preserves normal OpenSSH interaction |
+| browser security | same-origin HTTP/WS works; public Origin remains rejected |
+| Agent TUI matrix | Shell, Claude Code, Codex, opencode, and Pi remain usable |
+| Docker SSH fixture | clean host exercises plan, consent, start, tunnel, reconnect, stop |
+
+### Later protocols
+
+| Scenario | Required result |
+|---|---|
+| slow observer | cannot accumulate unbounded obsolete terminal frames |
+| concurrent clients | exactly one controller owns input/resize |
+| dropped sequence | client resnapshots instead of rendering corrupted state |
+| reconnect after event gap | Runtime snapshot reestablishes coherent state |
+| capability revocation | independent Studio loses access without stopping Runtime |
+
+## Verification Route
+
+When this surface changes:
+
+1. use isolated `OPENALICE_HOME` roots; never exercise recovery against the
+   user's normal home;
+2. follow [[docs/cli-installer.md]] for distributed CLI payload changes and run
+   `pnpm test:install:docker`, plus the manual installer playground before a
+   release;
+3. run the Guardian recovery case matrix when lifecycle, ownership, signals,
+   locks, or the control endpoint changes;
+4. start the real localhost route and verify the Workspace terminal and
+   loginless loopback Origin contract;
+5. exercise pure `ssh` and managed `remote` against a disposable SSH/Docker
+   host, including default-no and reconnect behavior;
+6. follow [[docs/docker-deployment.md]] and run `pnpm docker:smoke` when
+   `scripts/guardian/prod.mjs` or the server image path changes;
+7. follow [[docs/managed-workspace-runtime.md]] and run the matching Electron
+   and package smoke whenever shared Guardian, PTY, startup, or dependency
+   behavior changes;
+8. run the repository-wide TypeScript and test gates required by `AGENTS.md`.
+
+Record any network-shaping gap explicitly. A localhost smoke does not verify
+remote TUI behavior, and an SSH tunnel smoke does not verify Electron package
+behavior.
+
+## Non-Goals for the First Implementation
+
+- public TCP binding of Alice or the Guardian control endpoint;
+- hosted-domain cookie forwarding;
+- cloud relay, NAT traversal, or device fleet management;
+- live migration of PTYs across Runtime upgrades;
+- persistent terminal screen history by default;
+- simultaneous writable control from multiple clients;
+- replacing Electron with a browser wrapper;
+- replacing Shell or native Agent TUIs with Pi/WebPi;
+- silently cloning OpenAlice or installing optional Agent CLIs on a remote host;
+- moving broker credentials, account state, or trading writes out of UTA.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -13,18 +13,24 @@ this guide is the OpenAlice contract.
 
 ## Status
 
-The repository currently ships the Stage 0 path:
+The repository now contains the source-backed Stage 0 through Stage 2 path:
 
 - `openalice start` prepares a source checkout, runs Guardian in the
   foreground, and optionally opens the local browser;
 - `openalice ssh <target>` creates a loopback SSH tunnel to an already-running
   remote OpenAlice Runtime;
+- `openalice server run|start|status|stop` provides a browserless foreground or
+  detached Runtime lifecycle backed by Guardian's local control endpoint;
+- `openalice remote <target>` probes, plans, installs the ordinary CLI when
+  approved, starts or reuses the remote Server, and opens the same loopback
+  tunnel;
 - Electron remains a complete local desktop distribution.
 
-The `openalice server` lifecycle and `openalice remote` managed-host flow below
-are the next implementation stages. Commands described as target behavior must
-not be documented to users as already released until their acceptance rows are
-complete.
+These commands are still source-backed preview behavior on the `dev` lane, not
+a standalone headless release. The clean Docker SSH acceptance covers the
+management and tunnel loop; real long-latency Agent TUI measurements remain a
+separate release observation rather than a reason to invent a new terminal
+protocol preemptively.
 
 ## Product Decision
 
@@ -133,7 +139,7 @@ port, forwards it to the remote Alice loopback port, optionally opens the
 browser, and stays in the foreground to own the tunnel. It never installs,
 updates, starts, stops, or takes over the remote Runtime.
 
-### Target server lifecycle
+### Server lifecycle
 
 ```bash
 openalice server run [app-dir]
@@ -172,7 +178,7 @@ does not advertise that control contract, status reports `owned_elsewhere` and
 stop refuses. The user may then close that surface normally or make a separate
 explicit takeover decision.
 
-### Target managed remote command
+### Managed remote command
 
 ```bash
 openalice remote <target> --app-dir <remote-checkout>
@@ -186,16 +192,22 @@ openalice remote <target> --app-dir <remote-checkout>
 4. if CLI install or update is required, show the exact plan and ask separately
    before changing the remote host;
 5. call the normal remote installer non-interactively only after that consent;
-6. run `openalice server start --app-dir ...` remotely and wait for readiness;
-7. create the same loopback tunnel used by `openalice ssh`;
-8. open or print the local URL and stay in the foreground to own only the
+6. re-probe and re-plan after installation so a newly visible owner can block
+   or require a second explicit takeover decision;
+7. run `openalice server start --app-dir ...` remotely and wait for readiness;
+8. create the same loopback tunnel used by `openalice ssh`;
+9. open or print the local URL and stay in the foreground to own only the
    tunnel.
+
+When reusing a healthy Server, `remote` takes the loopback web port from the
+versioned status response. An explicitly supplied `--remote-port` must match
+that owner; a mismatch is reported before opening a misleading tunnel.
 
 Closing `openalice remote` closes the tunnel but leaves the detached remote
 Server running. Stop is explicit:
 
 ```bash
-ssh <target> openalice server stop
+ssh <target> '"$HOME/.openalice/bin/openalice" server stop'
 ```
 
 A later convenience subcommand may issue that same remote command, but it must
@@ -240,20 +252,21 @@ The detached parent returns success only after this barrier. On timeout it
 prints the isolated log path and current ownership evidence. It must not report
 success merely because a child PID was spawned.
 
-The Server writes structured logs beneath the selected `OPENALICE_HOME` and
-prints that path on start/status. Logs must not contain provider, broker, SSH,
-pairing, or sealing secrets.
+The Server appends Guardian and child output beneath the selected
+`OPENALICE_HOME` and prints that path on start. Logs must not contain provider,
+broker, SSH, pairing, or sealing secrets.
 
 ## Guardian Control Contract
 
 ### Endpoint
 
-The initial Unix endpoint is a user-only local socket beneath the canonical
-`OPENALICE_HOME` Runtime state. The exact filesystem name is implementation
-owned, but it must be deterministic for that home, created with user-only
-permissions, and removed only by the process that still owns it. Native Windows
-uses an equivalent per-home named pipe when this CLI surface is supported
-there.
+The Unix endpoint is normally
+`<OPENALICE_HOME>/state/guardian-control.sock`, mode `0600`. If that path would
+exceed the conservative Unix-domain-socket byte limit, both Guardian and the
+CLI derive a per-home hashed filename beneath a UID-owned `0700` directory in
+the OS temporary root. Native Windows derives an equivalent per-home named
+pipe. Every form is deterministic for the canonical home and is removed only
+when the closing Guardian still sees the socket identity it created.
 
 The endpoint is never bound to TCP and is never forwarded by `openalice ssh`.
 Remote orchestration reaches it only by executing the remote CLI through SSH.
@@ -545,30 +558,31 @@ Runtime model.
 
 ## Delivery Stages
 
-### Stage 0 — pure SSH tunnel (current)
+### Stage 0 — pure SSH tunnel (implemented)
 
 - remote Runtime is started manually;
 - `openalice ssh` owns only the tunnel;
 - normal browser UI and PTY WebSocket traverse one local loopback origin;
 - no remote mutation.
 
-### Stage 1 — native Server lifecycle
+### Stage 1 — native Server lifecycle (implemented)
 
-- add `server run/start/status/stop`;
-- add Guardian-owned local status/stop endpoint;
+- `server run/start/status/stop`;
+- Guardian-owned local status/stop endpoint;
 - detached start waits for real readiness;
 - status distinguishes absent, compatible, unhealthy, and other owner;
 - stop is structured and self-owned;
 - Electron behavior remains unchanged.
 
-### Stage 2 — managed source-backed remote
+### Stage 2 — managed source-backed remote (implemented baseline)
 
-- add `openalice remote` plan/apply orchestration;
+- `openalice remote` plan/apply orchestration;
 - probe and bootstrap the existing CLI with explicit consent;
 - start/reuse the remote Server;
 - reuse the existing SSH loopback tunnel;
 - leave the Server alive after disconnect;
-- validate ordinary Agent TUI interaction under network shaping.
+- remaining release observation: validate ordinary Agent TUI interaction under
+  representative network shaping before deciding whether Stage 3 is useful.
 
 ### Stage 3 — terminal transport optimization
 
@@ -652,7 +666,8 @@ When this surface changes:
 4. start the real localhost route and verify the Workspace terminal and
    loginless loopback Origin contract;
 5. exercise pure `ssh` and managed `remote` against a disposable SSH/Docker
-   host, including default-no and reconnect behavior;
+   host with `pnpm test:remote:docker`, including default-no, installed payload
+   equality, detach persistence, reconnect, and structured stop;
 6. follow [[docs/docker-deployment.md]] and run `pnpm docker:smoke` when
    `scripts/guardian/prod.mjs` or the server image path changes;
 7. follow [[docs/managed-workspace-runtime.md]] and run the matching Electron

--- a/install
+++ b/install
@@ -392,7 +392,10 @@ FILES=(
   "package.json"
   "bin/openalice.mjs"
   "src/local-start.mjs"
+  "src/remote.mjs"
   "src/runtime-client.mjs"
+  "src/server.mjs"
+  "src/server-control.mjs"
   "src/ssh-connect.mjs"
 )
 
@@ -417,7 +420,10 @@ step 3 "Verifying the CLI"
 chmod +x "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/src/local-start.mjs"
+node --check "$STAGING/src/remote.mjs"
 node --check "$STAGING/src/runtime-client.mjs"
+node --check "$STAGING/src/server.mjs"
+node --check "$STAGING/src/server-control.mjs"
 node --check "$STAGING/src/ssh-connect.mjs"
 
 CLI_VERSION="$(node -e '

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "docker:build": "docker build --tag openalice:local .",
     "docker:smoke": "node scripts/docker-runtime-smoke.mjs",
     "test:install:docker": "node scripts/install-docker-smoke.mjs",
+    "test:remote:docker": "node scripts/remote-ssh-smoke.mjs",
     "prebuild": "tsx scripts/build-migration-index.ts",
     "build": "turbo run build && tsup src/main.ts --format esm --dts",
     "prebuild:server": "tsx scripts/build-migration-index.ts",

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -4,6 +4,8 @@ import { readFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 import { formatLocalStartHelp, parseLocalStartArgs, startLocal } from '../src/local-start.mjs'
+import { connectRemote, formatRemoteHelp, parseRemoteArgs } from '../src/remote.mjs'
+import { formatServerHelp, parseServerArgs, runServerCommand } from '../src/server.mjs'
 import { connectSsh, formatSshHelp, parseSshConnectArgs } from '../src/ssh-connect.mjs'
 
 export async function main(argv = process.argv.slice(2)) {
@@ -31,6 +33,21 @@ export async function main(argv = process.argv.slice(2)) {
     }
     return connectSsh(parseSshConnectArgs(args))
   }
+  if (command === 'server') {
+    const [action, ...serverArgs] = args
+    if (!action || action === 'help' || action === '--help' || action === '-h' || serverArgs.includes('--help') || serverArgs.includes('-h')) {
+      process.stdout.write(formatServerHelp())
+      return 0
+    }
+    return runServerCommand(action, parseServerArgs(action, serverArgs))
+  }
+  if (command === 'remote') {
+    if (args.includes('--help') || args.includes('-h')) {
+      process.stdout.write(formatRemoteHelp())
+      return 0
+    }
+    return connectRemote(parseRemoteArgs(args))
+  }
   throw new Error(`Unknown command: ${command}\n\n${formatHelp()}`)
 }
 
@@ -40,13 +57,18 @@ function formatHelp() {
 Usage:
   openalice
   openalice start [path] [options]
+  openalice server <run|start|status|stop> [options]
   openalice ssh <user@host> [options]
+  openalice remote <user@host> [options]
 
 Commands:
   start     Start OpenAlice from a source checkout on local loopback (default)
+  server    Run, detach, inspect, or stop a browserless local Runtime
   ssh       Open a loopback-only SSH tunnel to an already-running OpenAlice
+  remote    Plan, prepare, and connect to an OpenAlice Server over SSH
 
-Run "openalice start --help" or "openalice ssh --help" for details.
+Run "openalice start --help", "openalice server --help",
+"openalice ssh --help", or "openalice remote --help" for details.
 `
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,11 +9,14 @@
   "files": [
     "bin/openalice.mjs",
     "src/local-start.mjs",
+    "src/remote.mjs",
     "src/runtime-client.mjs",
+    "src/server.mjs",
+    "src/server-control.mjs",
     "src/ssh-connect.mjs"
   ],
   "scripts": {
-    "build": "node --check bin/openalice.mjs && node --check src/local-start.mjs && node --check src/runtime-client.mjs && node --check src/ssh-connect.mjs",
+    "build": "node --check bin/openalice.mjs && node --check src/local-start.mjs && node --check src/remote.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },
   "engines": {

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path'
 
 import {
   LOOPBACK,
+  createStartupSignalGuard,
   openBrowser,
   probeOpenAlice,
   waitForOpenAlice,
@@ -116,6 +117,8 @@ export async function startLocal(options, dependencies = {}) {
   })
 
   let ready = false
+  const readinessAbort = new AbortController()
+  const startupSignals = createStartupSignalGuard(runtime, 'Local OpenAlice start')
   const earlyFailure = new Promise((_, reject) => {
     runtime.once('error', reject)
     runtime.once('exit', (code, signal) => {
@@ -127,17 +130,22 @@ export async function startLocal(options, dependencies = {}) {
 
   try {
     await Promise.race([
-      waitForRuntime(localUrl, { timeoutMs: options.waitMs }),
+      waitForRuntime(localUrl, { timeoutMs: options.waitMs, signal: readinessAbort.signal }),
       earlyFailure,
+      startupSignals.promise,
     ])
     ready = true
+    const runtimeExit = holdRuntime(runtime)
+    startupSignals.release()
     stdout.write(`OpenAlice source: ${appDir}\n`)
     stdout.write(`OpenAlice home: ${homeRoot}\n`)
     stdout.write(`Local OpenAlice UI: ${localUrl}\n`)
     stdout.write('The local Runtime stays active until this command exits. Press Ctrl+C to stop it.\n')
     if (options.openBrowser) await launchBrowser(localUrl)
-    return await holdRuntime(runtime)
+    return await runtimeExit
   } catch (error) {
+    readinessAbort.abort()
+    startupSignals.release()
     runtime.kill('SIGTERM')
     throw error
   }

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -1,0 +1,472 @@
+import { spawn } from 'node:child_process'
+import { createInterface } from 'node:readline/promises'
+
+import { connectSsh } from './ssh-connect.mjs'
+
+const DEFAULT_INSTALL_URL = 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install'
+const MAX_SSH_OUTPUT_BYTES = 1024 * 1024
+
+export function parseRemoteArgs(argv) {
+  const options = {
+    destination: '',
+    appDir: '',
+    remoteHome: '',
+    localPort: 0,
+    remotePort: 47331,
+    remotePortExplicit: false,
+    sshPort: null,
+    identityFile: null,
+    openBrowser: true,
+    waitMs: 120_000,
+    assumeYes: false,
+    planOnly: false,
+    takeover: false,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') continue
+    if (arg === '--app-dir') {
+      options.appDir = requireAbsoluteRemotePath(requireValue(argv, ++index, arg), arg)
+      continue
+    }
+    if (arg === '--home') {
+      options.remoteHome = requireAbsoluteRemotePath(requireValue(argv, ++index, arg), arg)
+      continue
+    }
+    if (arg === '--local-port') {
+      options.localPort = parsePort(requireValue(argv, ++index, arg), arg, { allowAuto: true })
+      continue
+    }
+    if (arg === '--remote-port') {
+      options.remotePort = parsePort(requireValue(argv, ++index, arg), arg)
+      options.remotePortExplicit = true
+      continue
+    }
+    if (arg === '--ssh-port') {
+      options.sshPort = parsePort(requireValue(argv, ++index, arg), arg)
+      continue
+    }
+    if (arg === '--identity') {
+      options.identityFile = requireValue(argv, ++index, arg)
+      continue
+    }
+    if (arg === '--wait') {
+      const seconds = Number(requireValue(argv, ++index, arg))
+      if (!Number.isFinite(seconds) || seconds < 1 || seconds > 600) {
+        throw new Error('--wait must be a number of seconds between 1 and 600')
+      }
+      options.waitMs = Math.round(seconds * 1_000)
+      continue
+    }
+    if (arg === '--no-open') {
+      options.openBrowser = false
+      continue
+    }
+    if (arg === '--yes' || arg === '-y') {
+      options.assumeYes = true
+      continue
+    }
+    if (arg === '--plan') {
+      options.planOnly = true
+      continue
+    }
+    if (arg === '--takeover') {
+      options.takeover = true
+      continue
+    }
+    if (arg?.startsWith('-')) throw new Error(`Unknown option: ${arg}`)
+    if (options.destination) throw new Error(`Unexpected argument: ${arg}`)
+    validateSshDestination(arg)
+    options.destination = arg
+  }
+  if (!options.destination) throw new Error('Remote SSH destination is required (for example: user@example.com)')
+  return options
+}
+
+export async function connectRemote(options, dependencies = {}) {
+  const stdout = dependencies.stdout ?? process.stdout
+  const env = dependencies.env ?? process.env
+  const probe = dependencies.probeRemote ?? probeRemoteHost
+  let remote = await probe(options, dependencies)
+  let plan = createRemotePlan(options, remote, {
+    installUrl: dependencies.installUrl ?? env['OPENALICE_REMOTE_INSTALL_URL'] ?? DEFAULT_INSTALL_URL,
+    installVersion: dependencies.installVersion ?? env['OPENALICE_REMOTE_VERSION'] ?? 'dev',
+    installBaseUrl: dependencies.installBaseUrl ?? env['OPENALICE_REMOTE_INSTALL_BASE_URL'] ?? '',
+  })
+  stdout.write(formatRemotePlan(plan))
+
+  if (plan.blocker) throw new Error(plan.blocker)
+  if (options.planOnly) {
+    stdout.write('Plan complete. No remote files or processes were changed.\n')
+    return 0
+  }
+  if (plan.mutations.length > 0 && !options.assumeYes) {
+    const confirm = dependencies.confirmPlan ?? confirmRemotePlan
+    if (!await confirm('Apply this remote plan?', dependencies)) {
+      stdout.write('No changes made.\n')
+      return 0
+    }
+  }
+
+  const runRemote = dependencies.runRemote ?? runSshCommand
+  if (plan.installCli) {
+    const expectedRemainingMutations = remainingMutationsAfterInstall(plan)
+    stdout.write(`Installing the OpenAlice CLI on ${options.destination} with the normal installer...\n`)
+    await runRemote(options, buildRemoteInstallCommand(plan.installUrl, plan.installVersion, plan.installBaseUrl), dependencies)
+    remote = await probe(options, dependencies)
+    if (!remote.cliPath || !remote.cliCompatible) {
+      throw new Error('The remote OpenAlice CLI install completed, but a compatible CLI was not detected')
+    }
+    const refreshedPlan = createRemotePlan(options, remote, {
+      installUrl: plan.installUrl,
+      installVersion: plan.installVersion,
+      installBaseUrl: plan.installBaseUrl,
+    })
+    const planChanged = JSON.stringify(refreshedPlan.mutations) !== JSON.stringify(expectedRemainingMutations)
+    if (refreshedPlan.blocker || planChanged) {
+      stdout.write('Remote facts changed after the CLI install. Review the refreshed plan:\n')
+      stdout.write(formatRemotePlan(refreshedPlan))
+    }
+    if (refreshedPlan.blocker) throw new Error(refreshedPlan.blocker)
+    if (planChanged && refreshedPlan.mutations.length > 0 && !options.assumeYes) {
+      const confirm = dependencies.confirmPlan ?? confirmRemotePlan
+      if (!await confirm('Apply the refreshed remote plan?', dependencies)) {
+        stdout.write('The remote CLI is installed; no additional actions were applied.\n')
+        return 0
+      }
+    }
+    plan = refreshedPlan
+  }
+
+  if (plan.startServer) {
+    stdout.write(`${options.takeover ? 'Replacing' : 'Starting'} the OpenAlice Server on ${options.destination}...\n`)
+    await runRemote(options, buildRemoteServerStartCommand(options, remote.cliPath), dependencies)
+    remote = await probe(options, dependencies)
+  }
+  if (remote.status?.class !== 'running' || remote.status?.owner?.surface !== 'cli-server') {
+    throw new Error(`Remote OpenAlice Server is not ready after apply (${remote.status?.class ?? 'no status'})`)
+  }
+  const runtimePort = remoteRuntimePort(remote.status)
+  if (runtimePort === null) {
+    throw new Error('Remote OpenAlice Server reported an invalid non-loopback web endpoint')
+  }
+  if (options.remotePortExplicit && runtimePort !== options.remotePort) {
+    throw new Error(`Remote OpenAlice Server is listening on ${runtimePort}, not the requested --remote-port ${options.remotePort}`)
+  }
+
+  stdout.write(`Remote OpenAlice Server is ready at ${remote.status.endpoints.web}\n`)
+  const openTunnel = dependencies.connectTunnel ?? connectSsh
+  return openTunnel({
+    destination: options.destination,
+    localPort: options.localPort,
+    remotePort: runtimePort,
+    sshPort: options.sshPort,
+    identityFile: options.identityFile,
+    openBrowser: options.openBrowser,
+    waitMs: options.waitMs,
+  }, dependencies)
+}
+
+export function createRemotePlan(options, remote, install = {}) {
+  const installUrl = install.installUrl ?? DEFAULT_INSTALL_URL
+  const installVersion = install.installVersion ?? 'dev'
+  const installBaseUrl = install.installBaseUrl ?? ''
+  const mutations = []
+  let blocker = ''
+  let installCli = false
+  let startServer = false
+  let remotePort = options.remotePort
+
+  if (!['linux', 'darwin'].includes(remote.platform?.os)) {
+    blocker = `Unsupported remote platform: ${remote.platform?.label ?? 'unknown'}. Stage 2 supports Linux and macOS hosts.`
+  } else if (!remote.nodeVersion) {
+    blocker = 'The remote host does not have Node.js 20 or newer; install Node.js before applying this plan.'
+  } else if (!nodeVersionSupported(remote.nodeVersion)) {
+    blocker = `The remote host reports ${remote.nodeVersion}; OpenAlice requires Node.js 20 or newer.`
+  }
+
+  if (!remote.cliPath || !remote.cliCompatible) {
+    installCli = true
+    mutations.push(remote.cliPath ? 'update remote OpenAlice CLI' : 'install remote OpenAlice CLI')
+    if (!remote.hasCurl && !blocker) blocker = 'The remote host does not have curl, which the normal OpenAlice installer requires.'
+  }
+
+  const status = remote.status
+  const detectedRuntimePort = remoteRuntimePort(status)
+  if (!blocker && status?.class === 'running' && status?.owner?.surface === 'cli-server') {
+    if (detectedRuntimePort === null) {
+      blocker = 'The remote CLI Server reported an invalid non-loopback web endpoint.'
+    } else if (options.remotePortExplicit && detectedRuntimePort !== options.remotePort) {
+      blocker = `The remote CLI Server is listening on ${detectedRuntimePort}; omit --remote-port to reuse it or pass ${detectedRuntimePort}.`
+    } else {
+      remotePort = detectedRuntimePort
+    }
+  }
+  if (!blocker && status?.class === 'owned_elsewhere') {
+    if (options.takeover) {
+      if (!options.appDir) blocker = '--app-dir <absolute-remote-path> is required to replace the current owner.'
+      else {
+        startServer = true
+        mutations.push(`take over ${status.owner?.surface ?? 'existing'} Runtime and start CLI Server`)
+      }
+    } else {
+      blocker = `Remote ${status.owner?.surface ?? 'Runtime'} already owns ${status.home}. Re-run with --takeover only if replacement is intentional.`
+    }
+  } else if (!blocker && ['incompatible', 'unhealthy', 'stopping'].includes(status?.class)) {
+    if (!options.takeover) {
+      blocker = `Remote Runtime is ${status.class}; inspect it or pass --takeover only if replacement is intentional.`
+    } else if (!options.appDir) {
+      blocker = '--app-dir <absolute-remote-path> is required for takeover.'
+    } else {
+      startServer = true
+      mutations.push('replace incompatible or unhealthy Runtime with CLI Server')
+    }
+  } else if (!blocker && status?.class !== 'running') {
+    if (!options.appDir) blocker = '--app-dir <absolute-remote-path> is required while the source-backed Server is absent.'
+    else {
+      startServer = true
+      mutations.push('start remote OpenAlice Server')
+    }
+  }
+
+  return {
+    target: options.destination,
+    platform: remote.platform?.label ?? 'unknown',
+    nodeVersion: remote.nodeVersion ?? 'missing',
+    cliPath: remote.cliPath ?? 'missing',
+    cliVersion: remote.cliVersion ?? 'unknown',
+    cliCompatible: remote.cliCompatible === true,
+    runtimeClass: status?.class ?? 'unknown',
+    runtimeOwner: status?.owner?.surface ?? 'none',
+    appDir: options.appDir || 'not selected',
+    remoteHome: options.remoteHome || '~/.openalice (remote default)',
+    remotePort,
+    localPort: options.localPort || 'auto',
+    installCli,
+    startServer,
+    installUrl,
+    installVersion,
+    installBaseUrl,
+    mutations,
+    blocker,
+  }
+}
+
+export function formatRemotePlan(plan) {
+  const actions = plan.mutations.length > 0
+    ? [...plan.mutations, 'open local SSH tunnel']
+    : ['reuse compatible remote CLI Server', 'open local SSH tunnel']
+  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  Node.js        ${plan.nodeVersion}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${plan.cliCompatible ? ', compatible' : ', install/update required'})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n  Source         ${plan.appDir}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.installCli ? `  Installer      ${plan.installUrl} (${plan.installVersion})\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
+}
+
+export async function probeRemoteHost(options, dependencies = {}) {
+  const runRemote = dependencies.runRemote ?? runSshCommand
+  const platformRaw = await runRemote(options, 'uname -s; uname -m', dependencies)
+  const [kernel = '', architecture = ''] = platformRaw.trim().split(/\r?\n/)
+  const platform = normalizeRemotePlatform(kernel, architecture)
+  const nodeVersion = (await runRemote(options, 'command -v node >/dev/null 2>&1 && node --version || true', dependencies)).trim() || null
+  const hasCurl = (await runRemote(options, 'command -v curl >/dev/null 2>&1 && printf yes || true', dependencies)).trim() === 'yes'
+  const cliPath = normalizeRemoteCliPath((await runRemote(options, 'command -v openalice 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/openalice" ] || printf "%s\\n" "$HOME/.openalice/bin/openalice"; }', dependencies)).trim())
+  if (!cliPath) {
+    return { platform, nodeVersion, hasCurl, cliPath: null, cliVersion: null, cliCompatible: false, status: null }
+  }
+
+  let cliVersion = null
+  let status = null
+  let cliCompatible = false
+  try {
+    cliVersion = (await runRemote(options, `${shellQuote(cliPath)} --version`, dependencies)).trim()
+    const statusOutput = await runRemote(options, buildRemoteStatusCommand(options, cliPath), dependencies)
+    status = parseRemoteStatus(statusOutput)
+    cliCompatible = status.protocol === 1
+  } catch {
+    cliCompatible = false
+  }
+  return { platform, nodeVersion, hasCurl, cliPath, cliVersion, cliCompatible, status }
+}
+
+export function buildRemoteStatusCommand(options, cliPath) {
+  const args = [shellQuote(cliPath), 'server', 'status', '--json']
+  if (options.remoteHome) args.push('--home', shellQuote(options.remoteHome))
+  return args.join(' ')
+}
+
+export function buildRemoteServerStartCommand(options, cliPath) {
+  if (!options.appDir) throw new Error('--app-dir is required to start the remote Server')
+  const args = [
+    shellQuote(cliPath),
+    'server', 'start',
+    '--app-dir', shellQuote(options.appDir),
+    '--port', String(options.remotePort),
+    '--wait', String(Math.ceil(options.waitMs / 1_000)),
+  ]
+  if (options.remoteHome) args.push('--home', shellQuote(options.remoteHome))
+  if (options.takeover) args.push('--takeover')
+  return args.join(' ')
+}
+
+export function buildRemoteInstallCommand(installUrl, installVersion, installBaseUrl = '') {
+  const url = shellQuote(installUrl)
+  const version = shellQuote(installVersion)
+  const installEnv = installBaseUrl ? `OPENALICE_INSTALL_BASE_URL=${shellQuote(installBaseUrl)} ` : ''
+  return `set -eu\ntmp=$(mktemp "${'${TMPDIR:-/tmp}'}/openalice-install.XXXXXX")\ntrap 'rm -f "$tmp"' EXIT HUP INT TERM\ncurl -fsSL ${url} -o "$tmp"\n${installEnv}bash "$tmp" --yes --no-modify-path --version ${version}`
+}
+
+export function buildRemoteSshArgs(options, remoteCommand) {
+  const args = [
+    '-T',
+    '-o', 'ServerAliveInterval=30',
+    '-o', 'ServerAliveCountMax=3',
+  ]
+  if (options.sshPort !== null) args.push('-p', String(options.sshPort))
+  if (options.identityFile !== null) args.push('-i', options.identityFile)
+  args.push(options.destination, remoteCommand)
+  return args
+}
+
+export function runSshCommand(options, remoteCommand, dependencies = {}) {
+  const spawnProcess = dependencies.spawnProcess ?? spawn
+  const child = spawnProcess('ssh', buildRemoteSshArgs(options, remoteCommand), {
+    stdio: ['inherit', 'pipe', 'inherit'],
+    windowsHide: true,
+  })
+  child.stdout.setEncoding('utf8')
+  let stdout = ''
+  return new Promise((resolvePromise, rejectPromise) => {
+    let settled = false
+    const finish = (error, value) => {
+      if (settled) return
+      settled = true
+      if (error) rejectPromise(error)
+      else resolvePromise(value)
+    }
+    child.stdout.on('data', (chunk) => {
+      if (settled) return
+      stdout += chunk
+      if (Buffer.byteLength(stdout, 'utf8') > MAX_SSH_OUTPUT_BYTES) {
+        child.kill('SIGTERM')
+        finish(new Error('Remote SSH command produced too much output'))
+      }
+    })
+    child.once('error', (error) => finish(error))
+    child.once('exit', (code, signal) => {
+      if (code === 0) finish(null, stdout)
+      else finish(new Error(`Remote SSH command failed (code=${String(code)}, signal=${String(signal)})`))
+    })
+  })
+}
+
+export async function confirmRemotePlan(message, dependencies = {}) {
+  const input = dependencies.stdin ?? process.stdin
+  const output = dependencies.stdout ?? process.stdout
+  if (!input.isTTY || !output.isTTY) {
+    throw new Error('No interactive terminal is available. Review with --plan, then re-run with --yes to approve the remote plan.')
+  }
+  const readline = createInterface({ input, output })
+  try {
+    const answer = (await readline.question(`${message} [y/N] `)).trim().toLowerCase()
+    return answer === 'y' || answer === 'yes'
+  } finally {
+    readline.close()
+  }
+}
+
+export function formatRemoteHelp() {
+  return `Usage:
+  openalice remote <user@host> [options]
+
+Plans and, after explicit consent, prepares a source-backed OpenAlice Server on
+the SSH host. It then opens the normal loopback browser tunnel. Disconnecting
+closes only the tunnel; the remote Server keeps running.
+
+Options:
+  --app-dir <path>        Absolute OpenAlice checkout path on the remote host
+  --home <path>           Absolute remote OPENALICE_HOME (default: ~/.openalice)
+  --local-port <port|auto> Local tunnel port (default: auto)
+  --remote-port <port>    Remote OpenAlice web port (default: 47331)
+  --ssh-port <port>       SSH server port
+  --identity <path>       Local SSH identity file
+  --wait <seconds>        Server/tunnel readiness timeout, 1-600 (default: 120)
+  --plan                  Print the read-only plan and exit
+  -y, --yes               Approve install/update/start actions non-interactively
+  --takeover              Explicitly replace the recorded remote Guardian owner
+  --no-open               Print the local URL without opening a browser
+  -h, --help              Show this help
+
+--yes never implies --takeover. Stage 2 supports Linux and macOS SSH hosts.
+`
+}
+
+function parseRemoteStatus(output) {
+  const line = output.trim().split(/\r?\n/).filter(Boolean).at(-1)
+  const status = JSON.parse(line ?? '')
+  if (!status || typeof status !== 'object' || typeof status.class !== 'string') {
+    throw new Error('Remote openalice server status returned an invalid payload')
+  }
+  return status
+}
+
+function normalizeRemotePlatform(kernel, architecture) {
+  const os = kernel === 'Linux' ? 'linux' : kernel === 'Darwin' ? 'darwin' : 'unsupported'
+  return { os, architecture, label: `${kernel || 'unknown'} ${architecture || 'unknown'}` }
+}
+
+function normalizeRemoteCliPath(path) {
+  if (!path) return null
+  if (!path.startsWith('/') || /[\u0000-\u001f\u007f]/.test(path)) {
+    throw new Error('Remote openalice command resolved to an unsupported path')
+  }
+  return path
+}
+
+function nodeVersionSupported(version) {
+  const match = /^v?(\d+)(?:\.|$)/.exec(version)
+  return match !== null && Number(match[1]) >= 20
+}
+
+function remoteRuntimePort(status) {
+  if (status?.class !== 'running' || status?.owner?.surface !== 'cli-server') return null
+  try {
+    const endpoint = new URL(status.endpoints?.web)
+    if (endpoint.protocol !== 'http:' || endpoint.hostname !== '127.0.0.1' || !endpoint.port) return null
+    return parsePort(endpoint.port, 'remote Runtime web endpoint')
+  } catch {
+    return null
+  }
+}
+
+function remainingMutationsAfterInstall(plan) {
+  return plan.mutations.filter((mutation) => !/^(install|update) remote OpenAlice CLI$/.test(mutation))
+}
+
+function validateSshDestination(destination) {
+  if (!destination || /\s|[\u0000-\u001f\u007f]/.test(destination) || destination.startsWith('-')) {
+    throw new Error('SSH destination contains unsupported characters')
+  }
+}
+
+function requireAbsoluteRemotePath(path, flag) {
+  if (!path.startsWith('/') || /[\u0000-\u001f\u007f]/.test(path)) {
+    throw new Error(`${flag} must be an absolute path on the remote Linux or macOS host`)
+  }
+  return path
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index]
+  if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function parsePort(raw, flag, options = {}) {
+  if (options.allowAuto && raw === 'auto') return 0
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new Error(`${flag} must be an integer between 1 and 65535${options.allowAuto ? ', or auto' : ''}`)
+  }
+  return value
+}

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  buildRemoteInstallCommand,
+  buildRemoteServerStartCommand,
+  buildRemoteSshArgs,
+  connectRemote,
+  createRemotePlan,
+  parseRemoteArgs,
+} from './remote.mjs'
+
+describe('OpenAlice managed remote connector', () => {
+  it('parses an explicit SSH and remote Runtime surface', () => {
+    expect(parseRemoteArgs([
+      'alice@example.com',
+      '--app-dir', '/srv/OpenAlice source',
+      '--home', '/srv/openalice home',
+      '--local-port', 'auto',
+      '--remote-port', '41000',
+      '--ssh-port', '2222',
+      '--identity', '/tmp/id key',
+      '--wait', '30',
+      '--plan',
+      '--yes',
+      '--takeover',
+      '--no-open',
+    ])).toEqual({
+      destination: 'alice@example.com',
+      appDir: '/srv/OpenAlice source',
+      remoteHome: '/srv/openalice home',
+      localPort: 0,
+      remotePort: 41000,
+      remotePortExplicit: true,
+      sshPort: 2222,
+      identityFile: '/tmp/id key',
+      openBrowser: false,
+      waitMs: 30_000,
+      assumeYes: true,
+      planOnly: true,
+      takeover: true,
+    })
+  })
+
+  it('rejects shell-shaped destinations and relative remote paths', () => {
+    expect(() => parseRemoteArgs(['-oProxyCommand=bad'])).toThrow('Unknown option')
+    expect(() => parseRemoteArgs(['host name'])).toThrow('unsupported characters')
+    expect(() => parseRemoteArgs(['host', '--app-dir', '~/OpenAlice'])).toThrow('absolute path')
+  })
+
+  it('plans install and start separately, with no implicit takeover', () => {
+    const options = parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice'])
+    const plan = createRemotePlan(options, {
+      platform: { os: 'linux', label: 'Linux x86_64' },
+      nodeVersion: 'v22.0.0',
+      hasCurl: true,
+      cliPath: null,
+      cliCompatible: false,
+      status: null,
+    })
+    expect(plan.installCli).toBe(true)
+    expect(plan.startServer).toBe(true)
+    expect(plan.mutations).toEqual([
+      'install remote OpenAlice CLI',
+      'start remote OpenAlice Server',
+    ])
+    expect(plan.blocker).toBe('')
+
+    const conflict = createRemotePlan(options, compatibleRemote({
+      class: 'owned_elsewhere',
+      owner: { surface: 'electron', pid: 9 },
+    }))
+    expect(conflict.blocker).toContain('Re-run with --takeover')
+  })
+
+  it('reuses a healthy compatible CLI Server without mutation', () => {
+    const plan = createRemotePlan(parseRemoteArgs(['host']), compatibleRemote())
+    expect(plan.mutations).toEqual([])
+    expect(plan.installCli).toBe(false)
+    expect(plan.startServer).toBe(false)
+    expect(plan.blocker).toBe('')
+  })
+
+  it('uses the detected Server port and blocks an explicit mismatch', () => {
+    const detected = compatibleRemote({ endpoints: { web: 'http://127.0.0.1:41000' } })
+    const inferred = createRemotePlan(parseRemoteArgs(['host']), detected)
+    expect(inferred.remotePort).toBe(41000)
+    expect(inferred.blocker).toBe('')
+
+    const mismatch = createRemotePlan(parseRemoteArgs(['host', '--remote-port', '42000']), detected)
+    expect(mismatch.blocker).toContain('listening on 41000')
+  })
+
+  it('shell-quotes every remote path and keeps SSH identity as a local argv entry', () => {
+    const options = parseRemoteArgs([
+      'host',
+      '--app-dir', "/srv/Alice's source",
+      '--home', "/srv/Alice's home",
+      '--identity', '/tmp/id key',
+    ])
+    const command = buildRemoteServerStartCommand(options, "/opt/Alice's bin/openalice")
+    expect(command).toContain("'/opt/Alice'\\''s bin/openalice'")
+    expect(command).toContain("'/srv/Alice'\\''s source'")
+    expect(command).toContain("'/srv/Alice'\\''s home'")
+    expect(buildRemoteSshArgs(options, command)).toEqual(expect.arrayContaining([
+      '-i', '/tmp/id key', 'host', command,
+    ]))
+  })
+
+  it('prints a plan without applying or opening a tunnel', async () => {
+    const runRemote = vi.fn()
+    const connectTunnel = vi.fn()
+    const stdout = { write: vi.fn() }
+    await expect(connectRemote(parseRemoteArgs(['host', '--plan']), {
+      probeRemote: async () => compatibleRemote(),
+      runRemote,
+      connectTunnel,
+      stdout,
+    })).resolves.toBe(0)
+    expect(runRemote).not.toHaveBeenCalled()
+    expect(connectTunnel).not.toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('No remote files or processes were changed'))
+  })
+
+  it('default-no leaves a missing remote Runtime unchanged', async () => {
+    const runRemote = vi.fn()
+    const connectTunnel = vi.fn()
+    const stdout = { write: vi.fn() }
+    await expect(connectRemote(parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice']), {
+      probeRemote: async () => missingRemote(),
+      confirmPlan: async () => false,
+      runRemote,
+      connectTunnel,
+      stdout,
+    })).resolves.toBe(0)
+    expect(runRemote).not.toHaveBeenCalled()
+    expect(connectTunnel).not.toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith('No changes made.\n')
+  })
+
+  it('applies the normal installer, starts the Server, re-probes, then opens the tunnel', async () => {
+    const options = parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice', '--yes', '--no-open'])
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(missingRemote())
+      .mockResolvedValueOnce(compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} }))
+      .mockResolvedValueOnce(compatibleRemote())
+    const runRemote = vi.fn(async () => '')
+    const connectTunnel = vi.fn(async () => 0)
+    const stdout = { write: vi.fn() }
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      connectTunnel,
+      installUrl: 'https://example.test/install',
+      installVersion: 'dev-test',
+      installBaseUrl: 'https://example.test/packages/cli/',
+      stdout,
+    })).resolves.toBe(0)
+
+    expect(runRemote).toHaveBeenCalledTimes(2)
+    expect(runRemote.mock.calls[0][1]).toBe(buildRemoteInstallCommand(
+      'https://example.test/install',
+      'dev-test',
+      'https://example.test/packages/cli/',
+    ))
+    expect(runRemote.mock.calls[1][1]).toContain('server start')
+    expect(connectTunnel).toHaveBeenCalledWith(expect.objectContaining({
+      destination: 'host',
+      remotePort: 47331,
+      openBrowser: false,
+    }), expect.any(Object))
+  })
+
+  it('re-plans after install and never replaces a newly discovered owner implicitly', async () => {
+    const options = parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice', '--yes'])
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(missingRemote())
+      .mockResolvedValueOnce(compatibleRemote({
+        class: 'owned_elsewhere',
+        owner: { surface: 'electron', pid: 42 },
+      }))
+    const runRemote = vi.fn(async () => '')
+    const connectTunnel = vi.fn()
+    const stdout = { write: vi.fn() }
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      connectTunnel,
+      stdout,
+    })).rejects.toThrow('Re-run with --takeover')
+
+    expect(runRemote).toHaveBeenCalledOnce()
+    expect(runRemote.mock.calls[0][1]).toContain('openalice-install')
+    expect(connectTunnel).not.toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('refreshed plan'))
+  })
+})
+
+function missingRemote() {
+  return {
+    platform: { os: 'linux', label: 'Linux x86_64' },
+    nodeVersion: 'v22.0.0',
+    hasCurl: true,
+    cliPath: null,
+    cliVersion: null,
+    cliCompatible: false,
+    status: null,
+  }
+}
+
+function compatibleRemote(statusOverrides = {}) {
+  return {
+    platform: { os: 'linux', label: 'Linux x86_64' },
+    nodeVersion: 'v22.0.0',
+    hasCurl: true,
+    cliPath: '/home/alice/.openalice/bin/openalice',
+    cliVersion: '0.2.0',
+    cliCompatible: true,
+    status: {
+      protocol: 1,
+      class: 'running',
+      state: 'running',
+      home: '/home/alice/.openalice',
+      owner: { surface: 'cli-server', pid: 99 },
+      endpoints: { web: 'http://127.0.0.1:47331' },
+      components: { alice: 'ready', uta: 'disabled', connector: 'disabled' },
+      capabilities: ['runtime.stop'],
+      ...statusOverrides,
+    },
+  }
+}

--- a/packages/cli/src/runtime-client.mjs
+++ b/packages/cli/src/runtime-client.mjs
@@ -38,6 +38,7 @@ export async function waitForOpenAlice(baseUrl, options = {}) {
   let lastError = 'connection refused'
 
   while (Date.now() < deadline) {
+    if (options.signal?.aborted) throw new Error(`OpenAlice readiness wait was cancelled at ${baseUrl}`)
     try {
       const response = await fetchImpl(`${baseUrl}/api/auth/status`, {
         signal: AbortSignal.timeout(Math.min(2_000, Math.max(250, deadline - Date.now()))),
@@ -52,9 +53,36 @@ export async function waitForOpenAlice(baseUrl, options = {}) {
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error)
     }
-    await new Promise((resolve) => setTimeout(resolve, pollMs))
+    if (await sleepOrAbort(pollMs, options.signal)) {
+      throw new Error(`OpenAlice readiness wait was cancelled at ${baseUrl}`)
+    }
   }
   throw new Error(`OpenAlice did not become ready at ${baseUrl} within ${Math.ceil(timeoutMs / 1_000)}s (${lastError})`)
+}
+
+export function createStartupSignalGuard(runtime, label) {
+  let interrupted = false
+  let rejectSignal
+  const promise = new Promise((_, rejectPromise) => {
+    rejectSignal = rejectPromise
+  })
+  const interrupt = (signal) => {
+    if (interrupted) return
+    interrupted = true
+    runtime.kill('SIGTERM')
+    rejectSignal(new Error(`${label} was interrupted by ${signal} before readiness`))
+  }
+  const onSigint = () => interrupt('SIGINT')
+  const onSigterm = () => interrupt('SIGTERM')
+  process.once('SIGINT', onSigint)
+  process.once('SIGTERM', onSigterm)
+  return {
+    promise,
+    release() {
+      process.off('SIGINT', onSigint)
+      process.off('SIGTERM', onSigterm)
+    },
+  }
 }
 
 export async function openBrowser(url, options = {}) {
@@ -65,4 +93,20 @@ export async function openBrowser(url, options = {}) {
   const child = spawnProcess(command, args, { detached: true, stdio: 'ignore', windowsHide: true })
   child.once?.('error', () => undefined)
   child.unref()
+}
+
+function sleepOrAbort(ms, signal) {
+  if (!signal) return new Promise((resolvePromise) => setTimeout(() => resolvePromise(false), ms))
+  if (signal.aborted) return Promise.resolve(true)
+  return new Promise((resolvePromise) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolvePromise(false)
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolvePromise(true)
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
 }

--- a/packages/cli/src/server-control.mjs
+++ b/packages/cli/src/server-control.mjs
@@ -1,0 +1,297 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { homedir, hostname, tmpdir } from 'node:os'
+import { createConnection } from 'node:net'
+import { resolve } from 'node:path'
+
+export const GUARDIAN_CONTROL_PROTOCOL = 1
+const MAX_RESPONSE_BYTES = 1024 * 1024
+
+export function resolveOpenAliceHome(homeRoot, options = {}) {
+  const env = options.env ?? process.env
+  const homeDir = options.homeDir ?? homedir()
+  return resolve(homeRoot ?? env['OPENALICE_HOME'] ?? resolve(homeDir, '.openalice'))
+}
+
+export function guardianControlEndpoint(homeRoot, platform = process.platform) {
+  const canonicalHome = resolve(homeRoot)
+  const homeId = createHash('sha256').update(canonicalHome).digest('hex').slice(0, 20)
+  if (platform === 'win32') {
+    return `\\\\.\\pipe\\openalice-guardian-${homeId}`
+  }
+  const homeEndpoint = resolve(canonicalHome, 'state', 'guardian-control.sock')
+  if (Buffer.byteLength(homeEndpoint, 'utf8') <= 96) return homeEndpoint
+  const uid = typeof process.getuid === 'function' ? process.getuid() : 'user'
+  return resolve(tmpdir(), `openalice-guardian-${uid}`, `${homeId}.sock`)
+}
+
+export async function requestRuntimeControl(homeRoot, method, options = {}) {
+  const endpoint = options.endpoint ?? guardianControlEndpoint(homeRoot, options.platform)
+  const timeoutMs = options.timeoutMs ?? 2_000
+  const id = options.id ?? randomUUID()
+  const request = `${JSON.stringify({
+    protocol: GUARDIAN_CONTROL_PROTOCOL,
+    id,
+    method,
+    params: options.params ?? {},
+  })}\n`
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    const socket = (options.createConnectionImpl ?? createConnection)(endpoint)
+    let body = ''
+    let settled = false
+    const finish = (error, result) => {
+      if (settled) return
+      settled = true
+      socket.destroy()
+      if (error) rejectPromise(error)
+      else resolvePromise(result)
+    }
+    socket.setEncoding('utf8')
+    socket.setTimeout(timeoutMs, () => finish(controlError('ETIMEDOUT', `Timed out waiting for OpenAlice Guardian at ${endpoint}`)))
+    socket.once('error', (error) => finish(error))
+    socket.once('connect', () => socket.write(request))
+    socket.on('data', (chunk) => {
+      if (settled) return
+      body += chunk
+      if (Buffer.byteLength(body, 'utf8') > MAX_RESPONSE_BYTES) {
+        finish(controlError('ERESPONSETOOLARGE', 'OpenAlice Guardian control response is too large'))
+        return
+      }
+      const newline = body.indexOf('\n')
+      if (newline < 0) return
+      let response
+      try {
+        response = JSON.parse(body.slice(0, newline))
+      } catch {
+        finish(controlError('EINVALIDRESPONSE', 'OpenAlice Guardian returned invalid JSON'))
+        return
+      }
+      if (response?.protocol !== GUARDIAN_CONTROL_PROTOCOL || response?.id !== id) {
+        finish(controlError('EINCOMPATIBLE', 'OpenAlice Guardian control protocol is incompatible'))
+        return
+      }
+      if (response.ok !== true) {
+        finish(controlError(
+          typeof response?.error?.code === 'string' ? response.error.code : 'ECONTROL',
+          typeof response?.error?.message === 'string' ? response.error.message : 'OpenAlice Guardian control request failed',
+        ))
+        return
+      }
+      finish(null, response.result)
+    })
+    socket.once('end', () => {
+      if (!settled) finish(controlError('EUNEXPECTEDEND', 'OpenAlice Guardian closed the control connection without a response'))
+    })
+  })
+}
+
+export async function readRuntimeStatus(options = {}, dependencies = {}) {
+  const homeRoot = resolveOpenAliceHome(options.homeRoot, {
+    env: dependencies.env,
+    homeDir: dependencies.homeDir,
+  })
+  const requestControl = dependencies.requestControl ?? requestRuntimeControl
+  try {
+    const runtime = await requestControl(homeRoot, 'runtime.status', {
+      timeoutMs: options.timeoutMs,
+      platform: dependencies.platform,
+    })
+    return classifyControlStatus(homeRoot, runtime)
+  } catch (error) {
+    if (!isUnavailableControlError(error)) {
+      return {
+        protocol: GUARDIAN_CONTROL_PROTOCOL,
+        class: error?.code === 'EINCOMPATIBLE' || error?.code === 'incompatible_protocol'
+          ? 'incompatible'
+          : 'unhealthy',
+        state: 'unknown',
+        home: homeRoot,
+        owner: null,
+        endpoints: {},
+        components: {},
+        capabilities: [],
+        detail: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  const inspectOwner = dependencies.inspectOwner ?? inspectGuardianOwner
+  const owner = await inspectOwner(homeRoot, {
+    hostname: dependencies.hostname,
+    isProcessAlive: dependencies.isProcessAlive,
+  })
+  if (owner?.active) {
+    return {
+      protocol: GUARDIAN_CONTROL_PROTOCOL,
+      class: 'owned_elsewhere',
+      state: 'running',
+      home: homeRoot,
+      owner: owner.publicOwner,
+      endpoints: {},
+      components: {},
+      capabilities: [],
+      detail: 'Guardian ownership is active but no compatible CLI Server control endpoint is available',
+    }
+  }
+  return {
+    protocol: GUARDIAN_CONTROL_PROTOCOL,
+    class: 'absent',
+    state: 'absent',
+    home: homeRoot,
+    owner: null,
+    endpoints: {},
+    components: {},
+    capabilities: [],
+    ...(owner?.detail ? { detail: owner.detail } : {}),
+  }
+}
+
+export async function stopRuntimeServer(options = {}, dependencies = {}) {
+  const readStatus = dependencies.readStatus ?? readRuntimeStatus
+  const requestControl = dependencies.requestControl ?? requestRuntimeControl
+  const sleep = dependencies.sleep ?? ((ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
+  const timeoutMs = options.waitMs ?? 15_000
+  let status = await readStatus(options, dependencies)
+  if (status.class === 'absent') return { stopped: false, status }
+  if (status.owner?.surface !== 'cli-server') {
+    throw controlError('EOWNED', `OpenAlice is owned by ${status.owner?.surface ?? status.class}; refusing server stop`)
+  }
+  if (!status.capabilities?.includes('runtime.stop')) {
+    throw controlError('ESTOPUNSUPPORTED', 'This OpenAlice owner does not advertise runtime.stop')
+  }
+
+  if (status.state !== 'stopping') {
+    await requestControl(status.home, 'runtime.stop', {
+      timeoutMs: Math.min(timeoutMs, 5_000),
+      platform: dependencies.platform,
+    })
+  }
+
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    await sleep(Math.min(100, Math.max(1, deadline - Date.now())))
+    status = await readStatus({ ...options, homeRoot: status.home }, dependencies)
+    if (status.class === 'absent') return { stopped: true, status }
+  }
+  throw controlError('ETIMEDOUT', `OpenAlice Server did not stop within ${Math.ceil(timeoutMs / 1_000)}s`)
+}
+
+export function formatRuntimeStatus(status) {
+  const lines = [`OpenAlice Server: ${status.class}`]
+  lines.push(`Home: ${status.home}`)
+  if (status.owner) {
+    lines.push(`Owner: ${status.owner.surface} (pid ${status.owner.pid})`)
+  }
+  if (status.endpoints?.web) lines.push(`Web: ${status.endpoints.web}`)
+  if (status.owner?.launchRoot) lines.push(`Runtime source: ${status.owner.launchRoot}`)
+  if (status.detail) lines.push(`Detail: ${status.detail}`)
+  return `${lines.join('\n')}\n`
+}
+
+function classifyControlStatus(homeRoot, runtime) {
+  if (!runtime || typeof runtime !== 'object') {
+    return {
+      protocol: GUARDIAN_CONTROL_PROTOCOL,
+      class: 'unhealthy',
+      state: 'unknown',
+      home: homeRoot,
+      owner: null,
+      endpoints: {},
+      components: {},
+      capabilities: [],
+      detail: 'Guardian returned an invalid runtime.status result',
+    }
+  }
+  const owner = sanitizeControlOwner(runtime.owner)
+  const surface = owner?.surface
+  const state = typeof runtime.state === 'string' ? runtime.state : 'unknown'
+  let statusClass
+  if (surface !== 'cli-server') statusClass = 'owned_elsewhere'
+  else if (state === 'starting' || state === 'stopping') statusClass = state
+  else if (state === 'running' && runtime.components?.alice === 'ready') statusClass = 'running'
+  else statusClass = 'unhealthy'
+  return {
+    protocol: GUARDIAN_CONTROL_PROTOCOL,
+    class: statusClass,
+    runtimeVersion: typeof runtime.runtimeVersion === 'string' ? runtime.runtimeVersion : 'unknown',
+    state,
+    home: homeRoot,
+    owner,
+    endpoints: sanitizeEndpoints(runtime.endpoints),
+    components: sanitizeComponents(runtime.components),
+    capabilities: Array.isArray(runtime.capabilities)
+      ? runtime.capabilities.filter((item) => typeof item === 'string')
+      : [],
+  }
+}
+
+async function inspectGuardianOwner(homeRoot, options = {}) {
+  let owner
+  try {
+    owner = JSON.parse(await readFile(resolve(homeRoot, 'state', 'guardian.lock', 'owner.json'), 'utf8'))
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null
+    return { active: true, publicOwner: null, detail: 'Guardian owner metadata is unreadable' }
+  }
+  if (!Number.isInteger(owner?.pid) || typeof owner?.launcher !== 'string') {
+    return { active: true, publicOwner: null, detail: 'Guardian owner metadata is invalid' }
+  }
+  const localHostname = options.hostname ?? hostname()
+  const sameHost = typeof owner.hostname !== 'string' || owner.hostname === localHostname
+  const isAlive = options.isProcessAlive ?? isProcessAlive
+  const active = !sameHost || isAlive(owner.pid)
+  return {
+    active,
+    publicOwner: {
+      surface: owner.launcher.startsWith('guardian-') ? owner.launcher.slice('guardian-'.length) : owner.launcher,
+      pid: owner.pid,
+      startedAt: typeof owner.acquiredAt === 'string' ? owner.acquiredAt : null,
+    },
+    ...(!active ? { detail: 'A stale Guardian owner record is present; the next start may recover it' } : {}),
+  }
+}
+
+function sanitizeControlOwner(owner) {
+  if (!owner || typeof owner !== 'object' || !Number.isInteger(owner.pid)) return null
+  return {
+    surface: typeof owner.surface === 'string' ? owner.surface : 'unknown',
+    pid: owner.pid,
+    instanceId: typeof owner.instanceId === 'string' ? owner.instanceId : 'unknown',
+    startedAt: typeof owner.startedAt === 'string' ? owner.startedAt : null,
+    ...(typeof owner.launchRoot === 'string' ? { launchRoot: owner.launchRoot } : {}),
+    ...(typeof owner.mode === 'string' ? { mode: owner.mode } : {}),
+  }
+}
+
+function sanitizeEndpoints(endpoints) {
+  return typeof endpoints?.web === 'string' ? { web: endpoints.web } : {}
+}
+
+function sanitizeComponents(components) {
+  if (!components || typeof components !== 'object') return {}
+  const output = {}
+  for (const name of ['alice', 'uta', 'connector']) {
+    if (typeof components[name] === 'string') output[name] = components[name]
+  }
+  return output
+}
+
+function isUnavailableControlError(error) {
+  return ['ENOENT', 'ECONNREFUSED', 'ENOTSOCK', 'EPIPE'].includes(error?.code)
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return error?.code === 'EPERM'
+  }
+}
+
+function controlError(code, message) {
+  const error = new Error(message)
+  error.code = code
+  return error
+}

--- a/packages/cli/src/server-control.spec.mjs
+++ b/packages/cli/src/server-control.spec.mjs
@@ -1,0 +1,170 @@
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { startGuardianControlServer } from '../../../scripts/guardian/control-server.mjs'
+import {
+  guardianControlEndpoint,
+  readRuntimeStatus,
+  requestRuntimeControl,
+  stopRuntimeServer,
+} from './server-control.mjs'
+
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('OpenAlice Guardian control protocol', () => {
+  it('shares one endpoint and returns a sanitized CLI Server status', async () => {
+    const home = await makeTempDir()
+    const runtime = runtimeStatus(home)
+    const server = await startGuardianControlServer({
+      homeRoot: home,
+      allowStop: true,
+      getStatus: () => runtime,
+      onStop: vi.fn(),
+    })
+    try {
+      expect(server.endpoint).toBe(guardianControlEndpoint(home))
+      if (process.platform !== 'win32') {
+        expect((await stat(server.endpoint)).mode & 0o777).toBe(0o600)
+      }
+      const status = await readRuntimeStatus({ homeRoot: home })
+      expect(status).toEqual(expect.objectContaining({
+        protocol: 1,
+        class: 'running',
+        state: 'running',
+        home,
+        owner: expect.objectContaining({ surface: 'cli-server', pid: process.pid }),
+        capabilities: ['runtime.stop'],
+      }))
+      expect(JSON.stringify(status)).not.toContain('secret-lock-token')
+    } finally {
+      await server.close()
+    }
+    if (process.platform !== 'win32') await expect(stat(server.endpoint)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('asks a matching Server to stop and waits until its endpoint disappears', async () => {
+    const home = await makeTempDir()
+    let state = 'running'
+    let server
+    const onStop = vi.fn(() => {
+      state = 'stopping'
+      setTimeout(() => { void server.close() }, 5)
+    })
+    server = await startGuardianControlServer({
+      homeRoot: home,
+      allowStop: true,
+      getStatus: () => runtimeStatus(home, { state }),
+      onStop,
+    })
+
+    const result = await stopRuntimeServer({ homeRoot: home, waitMs: 2_000 })
+    expect(result.stopped).toBe(true)
+    expect(result.status.class).toBe('absent')
+    expect(onStop).toHaveBeenCalledOnce()
+  })
+
+  it('uses a private hashed fallback when the home socket path is too long', async () => {
+    if (process.platform === 'win32') return
+    const root = await makeTempDir()
+    const home = join(root, 'nested-home-with-a-long-name'.repeat(8))
+    await mkdir(home, { recursive: true })
+    const server = await startGuardianControlServer({
+      homeRoot: home,
+      allowStop: true,
+      getStatus: () => runtimeStatus(home),
+      onStop: vi.fn(),
+    })
+    try {
+      expect(server.endpoint.startsWith(home)).toBe(false)
+      expect(server.endpoint).toBe(guardianControlEndpoint(home))
+      expect((await stat(dirname(server.endpoint))).mode & 0o777).toBe(0o700)
+      expect((await readRuntimeStatus({ homeRoot: home })).class).toBe('running')
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('recognizes another launcher but refuses to stop it', async () => {
+    const home = await makeTempDir()
+    const server = await startGuardianControlServer({
+      homeRoot: home,
+      allowStop: false,
+      getStatus: () => runtimeStatus(home, {
+        surface: 'cli',
+        capabilities: [],
+      }),
+      onStop: vi.fn(),
+    })
+    try {
+      const status = await readRuntimeStatus({ homeRoot: home })
+      expect(status.class).toBe('owned_elsewhere')
+      await expect(stopRuntimeServer({ homeRoot: home, waitMs: 100 })).rejects.toThrow('refusing server stop')
+      await expect(requestRuntimeControl(home, 'runtime.stop')).rejects.toMatchObject({ code: 'stop_not_supported' })
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('uses Guardian owner evidence when no control endpoint is available', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(lock, { recursive: true })
+    await writeFile(join(lock, 'owner.json'), JSON.stringify({
+      pid: process.pid,
+      hostname: 'fixture-host',
+      launcher: 'guardian-electron',
+      acquiredAt: '2026-07-15T00:00:00.000Z',
+      token: 'do-not-expose',
+    }))
+
+    const active = await readRuntimeStatus({ homeRoot: home }, {
+      hostname: 'fixture-host',
+      isProcessAlive: () => true,
+    })
+    expect(active).toEqual(expect.objectContaining({
+      class: 'owned_elsewhere',
+      owner: expect.objectContaining({ surface: 'electron', pid: process.pid }),
+    }))
+    expect(JSON.stringify(active)).not.toContain('do-not-expose')
+
+    const stale = await readRuntimeStatus({ homeRoot: home }, {
+      hostname: 'fixture-host',
+      isProcessAlive: () => false,
+    })
+    expect(stale.class).toBe('absent')
+    expect(stale.detail).toContain('stale')
+  })
+})
+
+function runtimeStatus(home, overrides = {}) {
+  return {
+    protocol: 1,
+    runtimeVersion: '0.2.0-test',
+    state: overrides.state ?? 'running',
+    home,
+    owner: {
+      surface: overrides.surface ?? 'cli-server',
+      pid: process.pid,
+      instanceId: 'instance-test',
+      startedAt: '2026-07-15T00:00:00.000Z',
+      launchRoot: '/tmp/OpenAlice',
+      secret: 'secret-lock-token',
+    },
+    endpoints: { web: 'http://127.0.0.1:47331', private: 'http://127.0.0.1:47332' },
+    components: { alice: 'ready', uta: 'disabled', connector: 'disabled', secret: 'hidden' },
+    capabilities: overrides.capabilities ?? ['runtime.stop'],
+  }
+}
+
+async function makeTempDir() {
+  const path = await mkdtemp(join(tmpdir(), 'openalice-server-control-test-'))
+  temporaryPaths.push(path)
+  return path
+}

--- a/packages/cli/src/server.mjs
+++ b/packages/cli/src/server.mjs
@@ -1,0 +1,345 @@
+import { spawn } from 'node:child_process'
+import { mkdir, open } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+import {
+  buildLocalRuntimeEnv,
+  findOpenAliceRoot,
+  parseLocalStartArgs,
+  prepareSourceCheckout,
+} from './local-start.mjs'
+import {
+  createStartupSignalGuard,
+} from './runtime-client.mjs'
+import {
+  formatRuntimeStatus,
+  readRuntimeStatus,
+  resolveOpenAliceHome,
+  stopRuntimeServer,
+} from './server-control.mjs'
+
+export function parseServerArgs(action, argv) {
+  if (action === 'run' || action === 'start') {
+    const { argv: startArgv, value: logFile } = takeValueOption(argv, '--log')
+    const options = parseLocalStartArgs(startArgv)
+    return { ...options, openBrowser: false, logFile }
+  }
+  if (action !== 'status' && action !== 'stop') {
+    throw new Error(`Unknown server command: ${String(action)}`)
+  }
+
+  const options = {
+    homeRoot: null,
+    json: false,
+    port: 47331,
+    waitMs: action === 'stop' ? 15_000 : 2_000,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') continue
+    if (arg === '--json') {
+      options.json = true
+      continue
+    }
+    if (arg === '--home') {
+      options.homeRoot = requireValue(argv, ++index, arg)
+      continue
+    }
+    if (arg === '--port') {
+      options.port = parsePort(requireValue(argv, ++index, arg), arg)
+      continue
+    }
+    if (arg === '--wait') {
+      const seconds = Number(requireValue(argv, ++index, arg))
+      if (!Number.isFinite(seconds) || seconds < 1 || seconds > 600) {
+        throw new Error('--wait must be a number of seconds between 1 and 600')
+      }
+      options.waitMs = Math.round(seconds * 1_000)
+      continue
+    }
+    throw new Error(arg?.startsWith('-') ? `Unknown option: ${arg}` : `Unexpected argument: ${arg}`)
+  }
+  return options
+}
+
+export async function runServerCommand(action, options, dependencies = {}) {
+  if (action === 'run') return startRuntimeServer(options, { ...dependencies, detached: false })
+  if (action === 'start') return startRuntimeServer(options, { ...dependencies, detached: true })
+  if (action === 'status') return showServerStatus(options, dependencies)
+  if (action === 'stop') return stopServer(options, dependencies)
+  throw new Error(`Unknown server command: ${String(action)}`)
+}
+
+export async function startRuntimeServer(options, dependencies = {}) {
+  const stdout = dependencies.stdout ?? process.stdout
+  const env = dependencies.env ?? process.env
+  const detached = dependencies.detached === true
+  const homeRoot = resolveOpenAliceHome(options.homeRoot, {
+    env,
+    homeDir: dependencies.homeDir,
+  })
+  const readStatus = dependencies.readStatus ?? readRuntimeStatus
+  let status = await readStatus({ homeRoot, timeoutMs: 1_000 }, dependencies)
+
+  if (status.owner?.surface === 'cli-server' && status.class === 'running') {
+    stdout.write(`OpenAlice Server is already running at ${status.endpoints.web ?? `http://127.0.0.1:${options.port}`}\n`)
+    return 0
+  }
+  if (status.owner?.surface === 'cli-server' && status.class === 'starting' && !options.takeover) {
+    status = await waitForServerReady(homeRoot, options.waitMs, { ...dependencies, readStatus })
+    stdout.write(`OpenAlice Server is already running at ${status.endpoints.web}\n`)
+    return 0
+  }
+  if (status.class !== 'absent' && !options.takeover) {
+    throw new Error(formatOwnershipRefusal(status))
+  }
+
+  const resolveRoot = dependencies.resolveRoot ?? findOpenAliceRoot
+  const appDir = await resolveRoot(options.appDir ?? dependencies.cwd ?? process.cwd())
+  const prepareSource = dependencies.prepareSource ?? prepareSourceCheckout
+  await prepareSource(appDir, options, { stdout, env })
+
+  const nodeBinary = dependencies.nodeBinary ?? process.execPath
+  const runtimeEnv = buildLocalRuntimeEnv(env, {
+    appDir,
+    homeRoot,
+    nodeBinary,
+    port: options.port,
+    takeover: options.takeover,
+  })
+  runtimeEnv.OPENALICE_LAUNCHER = 'cli-server'
+  runtimeEnv.OPENALICE_SERVER_MODE = detached ? 'detached' : 'foreground'
+
+  const logPath = resolve(options.logFile ?? resolve(homeRoot, 'logs', 'server.log'))
+  runtimeEnv.OPENALICE_SERVER_LOG = logPath
+  const spawnProcess = dependencies.spawnProcess ?? spawn
+  let logHandle = null
+  let runtime
+  if (detached) {
+    const makeDir = dependencies.mkdirImpl ?? mkdir
+    const openFile = dependencies.openFile ?? open
+    await makeDir(dirname(logPath), { recursive: true })
+    logHandle = await openFile(logPath, 'a', 0o600)
+    try {
+      runtime = spawnProcess(nodeBinary, ['scripts/guardian/prod.mjs'], {
+        cwd: appDir,
+        env: runtimeEnv,
+        detached: true,
+        stdio: ['ignore', logHandle.fd, logHandle.fd],
+        windowsHide: true,
+      })
+      runtime.unref()
+    } finally {
+      await logHandle.close()
+    }
+  } else {
+    runtime = spawnProcess(nodeBinary, ['scripts/guardian/prod.mjs'], {
+      cwd: appDir,
+      env: runtimeEnv,
+      stdio: 'inherit',
+      windowsHide: true,
+    })
+  }
+
+  let ready = false
+  const readinessAbort = new AbortController()
+  const startupSignals = createStartupSignalGuard(runtime, 'OpenAlice Server start')
+  const earlyFailure = new Promise((_, reject) => {
+    runtime.once('error', reject)
+    const rejectExit = (code, signal) => {
+      if (!ready) {
+        reject(new Error(`OpenAlice Server exited before it was ready (code=${String(code)}, signal=${String(signal)})`))
+      }
+    }
+    runtime.once('exit', rejectExit)
+    if (runtime.exitCode !== undefined && (
+      runtime.exitCode !== null ||
+      (runtime.signalCode !== undefined && runtime.signalCode !== null)
+    )) {
+      rejectExit(runtime.exitCode, runtime.signalCode)
+    }
+  })
+  try {
+    status = await Promise.race([
+      waitForServerReady(homeRoot, options.waitMs, {
+        ...dependencies,
+        readStatus,
+        signal: readinessAbort.signal,
+      }),
+      earlyFailure,
+      startupSignals.promise,
+    ])
+    ready = true
+    const runtimeExit = detached ? null : holdRuntime(runtime)
+    startupSignals.release()
+    stdout.write(`OpenAlice source: ${appDir}\n`)
+    stdout.write(`OpenAlice home: ${homeRoot}\n`)
+    stdout.write(`OpenAlice Server: ${status.endpoints.web}\n`)
+    if (detached) {
+      stdout.write(`OpenAlice Server log: ${logPath}\n`)
+      stdout.write('The Server will keep running after this command exits. Use "openalice server stop" to stop it.\n')
+      return 0
+    }
+    stdout.write('The Server stays active until this command exits. Press Ctrl+C to stop it.\n')
+    return await runtimeExit
+  } catch (error) {
+    readinessAbort.abort()
+    startupSignals.release()
+    runtime.kill('SIGTERM')
+    if (detached) {
+      throw new Error(`${error instanceof Error ? error.message : String(error)}. See the Server log at ${logPath}`, { cause: error })
+    }
+    throw error
+  }
+}
+
+export async function showServerStatus(options, dependencies = {}) {
+  const stdout = dependencies.stdout ?? process.stdout
+  const status = await (dependencies.readStatus ?? readRuntimeStatus)({
+    homeRoot: options.homeRoot,
+    timeoutMs: options.waitMs,
+  }, dependencies)
+  stdout.write(options.json ? `${JSON.stringify(status)}\n` : formatRuntimeStatus(status))
+  return 0
+}
+
+export async function stopServer(options, dependencies = {}) {
+  const stdout = dependencies.stdout ?? process.stdout
+  const stop = dependencies.stopRuntime ?? stopRuntimeServer
+  const result = await stop({ homeRoot: options.homeRoot, waitMs: options.waitMs }, dependencies)
+  if (options.json) {
+    stdout.write(`${JSON.stringify({ stopped: result.stopped, status: result.status })}\n`)
+  } else if (result.stopped) {
+    stdout.write(`OpenAlice Server stopped (${result.status.home})\n`)
+  } else {
+    stdout.write(`OpenAlice Server is not running (${result.status.home})\n`)
+  }
+  return 0
+}
+
+export function formatServerHelp() {
+  return `Usage:
+  openalice server run [path] [options]
+  openalice server start [path] [options]
+  openalice server status [options]
+  openalice server stop [options]
+
+Runs OpenAlice on local loopback without opening a browser. "run" owns the
+Runtime in the foreground; "start" detaches after Guardian and Alice are ready.
+
+Run/start options:
+  --app-dir <path>   OpenAlice checkout (default: current directory or parent)
+  --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
+  --port <port>      Local web port (default: 47331)
+  --log <path>       Detached Server log (default: <home>/logs/server.log)
+  --rebuild          Reinstall dependencies and rebuild server artifacts
+  --skip-prepare     Fail instead of installing/building missing artifacts
+  --takeover         Replace the recorded Guardian owner tree
+  --wait <seconds>   Readiness timeout, 1-600 (default: 120)
+
+Status/stop options:
+  --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
+  --wait <seconds>   Control timeout (status: 2, stop: 15)
+  --json             Print stable machine-readable output
+  -h, --help         Show this help
+`
+}
+
+async function waitForServerReady(homeRoot, timeoutMs, dependencies) {
+  const readStatus = dependencies.readStatus ?? readRuntimeStatus
+  const sleep = dependencies.sleep ?? ((ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
+  const deadline = Date.now() + timeoutMs
+  let lastStatus = null
+  while (Date.now() < deadline) {
+    if (dependencies.signal?.aborted) return null
+    lastStatus = await readStatus({ homeRoot, timeoutMs: Math.min(1_000, Math.max(100, deadline - Date.now())) }, dependencies)
+    if (lastStatus.class === 'running' && lastStatus.owner?.surface === 'cli-server') return lastStatus
+    if (lastStatus.class === 'owned_elsewhere' || lastStatus.class === 'incompatible') {
+      throw new Error(formatOwnershipRefusal(lastStatus))
+    }
+    const aborted = await sleepOrAbort(
+      Math.min(100, Math.max(1, deadline - Date.now())),
+      sleep,
+      dependencies.signal,
+    )
+    if (aborted) return null
+  }
+  throw new Error(`OpenAlice Server did not become ready within ${Math.ceil(timeoutMs / 1_000)}s (${lastStatus?.class ?? 'no status'})`)
+}
+
+async function sleepOrAbort(ms, sleep, signal) {
+  if (!signal) {
+    await sleep(ms)
+    return false
+  }
+  if (signal.aborted) return true
+  let onAbort
+  const aborted = new Promise((resolvePromise) => {
+    onAbort = () => resolvePromise(true)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+  try {
+    return await Promise.race([
+      Promise.resolve(sleep(ms)).then(() => false),
+      aborted,
+    ])
+  } finally {
+    signal.removeEventListener('abort', onAbort)
+  }
+}
+
+function formatOwnershipRefusal(status) {
+  const owner = status.owner
+  if (owner) {
+    return `OpenAlice ${owner.surface} already owns ${status.home} as pid ${owner.pid}. Re-run with --takeover only if replacing it is intentional.`
+  }
+  return `OpenAlice Runtime at ${status.home} is ${status.class}. Re-run with --takeover only if replacing it is intentional.`
+}
+
+function holdRuntime(runtime) {
+  if (runtime.exitCode !== undefined && (runtime.exitCode !== null || runtime.signalCode !== null)) {
+    return Promise.resolve(runtime.exitCode ?? 0)
+  }
+  return new Promise((resolvePromise) => {
+    let requestedStop = false
+    const stop = () => {
+      requestedStop = true
+      runtime.kill('SIGTERM')
+    }
+    process.once('SIGINT', stop)
+    process.once('SIGTERM', stop)
+    runtime.once('exit', (code) => {
+      process.off('SIGINT', stop)
+      process.off('SIGTERM', stop)
+      resolvePromise(requestedStop ? 0 : code ?? 0)
+    })
+  })
+}
+
+function takeValueOption(argv, flag) {
+  const output = []
+  let value = null
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] !== flag) {
+      output.push(argv[index])
+      continue
+    }
+    if (value !== null) throw new Error(`${flag} may only be provided once`)
+    value = requireValue(argv, ++index, flag)
+  }
+  return { argv: output, value }
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index]
+  if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function parsePort(raw, flag) {
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new Error(`${flag} must be an integer between 1 and 65535`)
+  }
+  return value
+}

--- a/packages/cli/src/server.spec.mjs
+++ b/packages/cli/src/server.spec.mjs
@@ -1,0 +1,205 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  parseServerArgs,
+  runServerCommand,
+  startRuntimeServer,
+} from './server.mjs'
+
+describe('OpenAlice Server CLI', () => {
+  it('parses lifecycle-specific options', () => {
+    expect(parseServerArgs('start', [
+      '/tmp/OpenAlice',
+      '--home', '/tmp/alice-home',
+      '--port', '41000',
+      '--log', '/tmp/server log.txt',
+      '--takeover',
+      '--no-open',
+    ])).toEqual(expect.objectContaining({
+      appDir: '/tmp/OpenAlice',
+      homeRoot: '/tmp/alice-home',
+      port: 41000,
+      logFile: '/tmp/server log.txt',
+      openBrowser: false,
+      takeover: true,
+    }))
+    expect(parseServerArgs('status', ['--home', '/tmp/alice-home', '--json'])).toEqual({
+      homeRoot: '/tmp/alice-home',
+      json: true,
+      port: 47331,
+      waitMs: 2_000,
+    })
+  })
+
+  it('reuses a healthy matching Server without preparing or spawning', async () => {
+    const resolveRoot = vi.fn()
+    const stdout = { write: vi.fn() }
+    await expect(startRuntimeServer(parseServerArgs('start', []), {
+      detached: true,
+      readStatus: async () => runningStatus(),
+      resolveRoot,
+      stdout,
+    })).resolves.toBe(0)
+    expect(resolveRoot).not.toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('already running'))
+  })
+
+  it('refuses another launcher without explicit takeover', async () => {
+    await expect(startRuntimeServer(parseServerArgs('start', []), {
+      detached: true,
+      readStatus: async () => ({
+        ...runningStatus(),
+        class: 'owned_elsewhere',
+        owner: { ...runningStatus().owner, surface: 'electron' },
+      }),
+    })).rejects.toThrow('electron already owns')
+  })
+
+  it('detaches only after the Guardian control status is ready', async () => {
+    const child = new FakeChild()
+    const spawnProcess = vi.fn(() => child)
+    const prepareSource = vi.fn(async () => ({ prepared: false }))
+    const closeLog = vi.fn(async () => undefined)
+    const stdout = { write: vi.fn() }
+    const readStatus = vi.fn()
+      .mockResolvedValueOnce(absentStatus())
+      .mockResolvedValueOnce({ ...runningStatus(), class: 'starting', state: 'starting' })
+      .mockResolvedValue(runningStatus())
+
+    await expect(startRuntimeServer(parseServerArgs('start', [
+      '--app-dir', '/tmp/OpenAlice',
+      '--home', '/tmp/alice-home',
+      '--port', '41000',
+    ]), {
+      detached: true,
+      env: { PATH: '/bin' },
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource,
+      spawnProcess,
+      openFile: async () => ({ fd: 9, close: closeLog }),
+      mkdirImpl: vi.fn(async () => undefined),
+      readStatus,
+      sleep: async () => undefined,
+      stdout,
+    })).resolves.toBe(0)
+
+    expect(prepareSource).toHaveBeenCalledOnce()
+    expect(spawnProcess).toHaveBeenCalledWith('/test/node', ['scripts/guardian/prod.mjs'], expect.objectContaining({
+      cwd: '/tmp/OpenAlice',
+      detached: true,
+      stdio: ['ignore', 9, 9],
+      env: expect.objectContaining({
+        OPENALICE_HOME: '/tmp/alice-home',
+        OPENALICE_BIND_HOST: '127.0.0.1',
+        OPENALICE_WEB_PORT: '41000',
+        OPENALICE_LAUNCHER: 'cli-server',
+        OPENALICE_SERVER_MODE: 'detached',
+      }),
+    }))
+    expect(child.unref).toHaveBeenCalledOnce()
+    expect(closeLog).toHaveBeenCalledOnce()
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('keep running'))
+  })
+
+  it('keeps server run in the foreground until its Guardian exits', async () => {
+    const child = new FakeChild()
+    const stdout = { write: vi.fn((text) => {
+      if (String(text).includes('stays active')) setTimeout(() => child.finish(0), 0)
+    }) }
+    const readStatus = vi.fn()
+      .mockResolvedValueOnce(absentStatus())
+      .mockResolvedValue(runningStatus())
+    await expect(startRuntimeServer(parseServerArgs('run', ['--app-dir', '/tmp/OpenAlice']), {
+      detached: false,
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess: vi.fn(() => child),
+      readStatus,
+      stdout,
+    })).resolves.toBe(0)
+  })
+
+  it('cancels readiness polling when the detached Guardian exits early', async () => {
+    const child = new FakeChild()
+    const never = () => new Promise(() => undefined)
+    const startedAt = Date.now()
+
+    await expect(startRuntimeServer(parseServerArgs('start', [
+      '--app-dir', '/tmp/OpenAlice',
+      '--home', '/tmp/alice-home',
+    ]), {
+      detached: true,
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess: () => {
+        queueMicrotask(() => child.finish(1))
+        return child
+      },
+      openFile: async () => ({ fd: 9, close: async () => undefined }),
+      mkdirImpl: async () => undefined,
+      readStatus: async () => absentStatus(),
+      sleep: never,
+      stdout: { write: vi.fn() },
+    })).rejects.toThrow('exited before it was ready')
+
+    expect(Date.now() - startedAt).toBeLessThan(1_000)
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('prints stable JSON for status and stop', async () => {
+    const stdout = { write: vi.fn() }
+    await runServerCommand('status', parseServerArgs('status', ['--json']), {
+      readStatus: async () => runningStatus(),
+      stdout,
+    })
+    expect(JSON.parse(stdout.write.mock.calls[0][0])).toEqual(expect.objectContaining({ class: 'running' }))
+
+    stdout.write.mockClear()
+    await runServerCommand('stop', parseServerArgs('stop', ['--json']), {
+      stopRuntime: async () => ({ stopped: true, status: absentStatus() }),
+      stdout,
+    })
+    expect(JSON.parse(stdout.write.mock.calls[0][0])).toEqual(expect.objectContaining({ stopped: true }))
+  })
+})
+
+function runningStatus() {
+  return {
+    protocol: 1,
+    class: 'running',
+    state: 'running',
+    home: '/tmp/alice-home',
+    owner: { surface: 'cli-server', pid: 123, instanceId: 'test' },
+    endpoints: { web: 'http://127.0.0.1:41000' },
+    components: { alice: 'ready', uta: 'disabled', connector: 'disabled' },
+    capabilities: ['runtime.stop'],
+  }
+}
+
+function absentStatus() {
+  return {
+    protocol: 1,
+    class: 'absent',
+    state: 'absent',
+    home: '/tmp/alice-home',
+    owner: null,
+    endpoints: {},
+    components: {},
+    capabilities: [],
+  }
+}
+
+class FakeChild extends EventEmitter {
+  exitCode = null
+  signalCode = null
+  kill = vi.fn()
+  unref = vi.fn()
+
+  finish(code) {
+    this.exitCode = code
+    this.emit('exit', code, null)
+  }
+}

--- a/scripts/guardian/control-server.mjs
+++ b/scripts/guardian/control-server.mjs
@@ -1,0 +1,203 @@
+import { createHash } from 'node:crypto'
+import { chmod, lstat, mkdir, rm } from 'node:fs/promises'
+import { createConnection, createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+
+export const GUARDIAN_CONTROL_PROTOCOL = 1
+export const GUARDIAN_CONTROL_MAX_REQUEST_BYTES = 64 * 1024
+
+export function guardianControlEndpoint(homeRoot, platform = process.platform) {
+  const canonicalHome = resolve(homeRoot)
+  const homeId = createHash('sha256').update(canonicalHome).digest('hex').slice(0, 20)
+  if (platform === 'win32') {
+    return `\\\\.\\pipe\\openalice-guardian-${homeId}`
+  }
+  const homeEndpoint = resolve(canonicalHome, 'state', 'guardian-control.sock')
+  if (Buffer.byteLength(homeEndpoint, 'utf8') <= 96) return homeEndpoint
+  const uid = typeof process.getuid === 'function' ? process.getuid() : 'user'
+  return resolve(tmpdir(), `openalice-guardian-${uid}`, `${homeId}.sock`)
+}
+
+export async function startGuardianControlServer(options) {
+  const platform = options.platform ?? process.platform
+  const endpoint = options.endpoint ?? guardianControlEndpoint(options.homeRoot, platform)
+  if (platform !== 'win32') {
+    await mkdir(dirname(endpoint), { recursive: true })
+    const directEndpoint = resolve(options.homeRoot, 'state', 'guardian-control.sock')
+    if (endpoint !== directEndpoint) await secureFallbackDirectory(dirname(endpoint))
+    await prepareUnixEndpoint(endpoint)
+  }
+
+  const sockets = new Set()
+  let closed = false
+  let socketIdentity = null
+  const server = createServer((socket) => {
+    sockets.add(socket)
+    socket.setEncoding('utf8')
+    socket.setTimeout(options.requestTimeoutMs ?? 5_000)
+    let body = ''
+    let handled = false
+
+    const finish = (response, afterWrite) => {
+      if (handled) return
+      handled = true
+      socket.end(`${JSON.stringify(response)}\n`, afterWrite)
+    }
+    const fail = (id, code, message) => finish({
+      protocol: GUARDIAN_CONTROL_PROTOCOL,
+      id,
+      ok: false,
+      error: { code, message },
+    })
+
+    socket.on('data', (chunk) => {
+      if (handled) return
+      body += chunk
+      if (Buffer.byteLength(body, 'utf8') > GUARDIAN_CONTROL_MAX_REQUEST_BYTES) {
+        fail(null, 'request_too_large', 'Guardian control request is too large')
+        return
+      }
+      const newline = body.indexOf('\n')
+      if (newline < 0) return
+
+      let request
+      try {
+        request = JSON.parse(body.slice(0, newline))
+      } catch {
+        fail(null, 'invalid_json', 'Guardian control request must be one JSON line')
+        return
+      }
+      const id = typeof request?.id === 'string' ? request.id : null
+      if (request?.protocol !== GUARDIAN_CONTROL_PROTOCOL) {
+        fail(id, 'incompatible_protocol', `Guardian control protocol ${GUARDIAN_CONTROL_PROTOCOL} is required`)
+        return
+      }
+      if (!id) {
+        fail(null, 'invalid_request', 'Guardian control request id is required')
+        return
+      }
+      if (request.method === 'runtime.status') {
+        finish({
+          protocol: GUARDIAN_CONTROL_PROTOCOL,
+          id,
+          ok: true,
+          result: options.getStatus(),
+        })
+        return
+      }
+      if (request.method === 'runtime.stop') {
+        if (!options.allowStop) {
+          fail(id, 'stop_not_supported', 'This OpenAlice owner does not accept server stop requests')
+          return
+        }
+        finish({
+          protocol: GUARDIAN_CONTROL_PROTOCOL,
+          id,
+          ok: true,
+          result: { accepted: true, state: 'stopping' },
+        }, () => setImmediate(options.onStop))
+        return
+      }
+      fail(id, 'method_not_found', `Unknown Guardian control method: ${String(request.method)}`)
+    })
+    socket.on('timeout', () => socket.destroy())
+    socket.on('error', () => undefined)
+    socket.on('close', () => sockets.delete(socket))
+  })
+
+  await new Promise((resolvePromise, rejectPromise) => {
+    const onError = (error) => {
+      server.off('listening', onListening)
+      rejectPromise(error)
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      resolvePromise()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(endpoint)
+  })
+
+  if (platform !== 'win32') {
+    await waitForEndpointPath(endpoint)
+    await chmod(endpoint, 0o600)
+    socketIdentity = await endpointIdentity(endpoint)
+  }
+
+  return {
+    endpoint,
+    close: async () => {
+      if (closed) return
+      closed = true
+      const serverClosed = new Promise((resolvePromise) => server.close(() => resolvePromise()))
+      for (const socket of sockets) socket.destroy()
+      await serverClosed
+      if (platform !== 'win32' && socketIdentity !== null) {
+        const currentIdentity = await endpointIdentity(endpoint).catch(() => null)
+        if (currentIdentity === socketIdentity) await rm(endpoint, { force: true })
+      }
+    },
+  }
+}
+
+async function prepareUnixEndpoint(endpoint) {
+  try {
+    await probeEndpoint(endpoint, 250)
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error?.code === 'ECONNREFUSED') {
+      await rm(endpoint, { force: true })
+      return
+    }
+    throw error
+  }
+  throw new Error(`OpenAlice Guardian control endpoint is already active at ${endpoint}`)
+}
+
+function probeEndpoint(endpoint, timeoutMs) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const socket = createConnection(endpoint)
+    const done = (error) => {
+      socket.destroy()
+      if (error) rejectPromise(error)
+      else resolvePromise()
+    }
+    socket.setTimeout(timeoutMs, () => {
+      const error = new Error(`Timed out connecting to ${endpoint}`)
+      error.code = 'ETIMEDOUT'
+      done(error)
+    })
+    socket.once('connect', () => done())
+    socket.once('error', done)
+  })
+}
+
+async function endpointIdentity(endpoint) {
+  const stats = await lstat(endpoint)
+  return `${stats.dev}:${stats.ino}:${stats.birthtimeMs}`
+}
+
+async function secureFallbackDirectory(directory) {
+  const stats = await lstat(directory)
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(`OpenAlice Guardian control directory is not a private directory: ${directory}`)
+  }
+  if (typeof process.getuid === 'function' && stats.uid !== process.getuid()) {
+    throw new Error(`OpenAlice Guardian control directory is owned by another user: ${directory}`)
+  }
+  await chmod(directory, 0o700)
+}
+
+async function waitForEndpointPath(endpoint) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await lstat(endpoint)
+      return
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 10))
+  }
+  throw new Error(`OpenAlice Guardian control endpoint was not published at ${endpoint}`)
+}

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -27,7 +27,7 @@
  */
 
 import { spawn } from 'node:child_process'
-import { createDecipheriv } from 'node:crypto'
+import { createDecipheriv, randomUUID } from 'node:crypto'
 import { mkdir, readFile, watch } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -36,6 +36,7 @@ import {
   currentProcessStartedAt,
   takeoverRequested,
 } from '@traderalice/guardian-runtime'
+import { startGuardianControlServer } from './control-server.mjs'
 
 const DATA_HOME = process.env.OPENALICE_HOME
   ?? process.env.OPENALICE_USER_DATA_HOME // deprecated alias, one-release courtesy
@@ -47,6 +48,8 @@ const NODE_BINARY = process.env.OPENALICE_NODE_BINARY?.trim() || process.execPat
 const BIND_HOST = process.env.OPENALICE_BIND_HOST?.trim() || '127.0.0.1'
 const GUARDIAN_STARTED_AT = currentProcessStartedAt()
 const TAKEOVER = takeoverRequested()
+const SERVER_MODE = process.env.OPENALICE_SERVER_MODE?.trim() || 'foreground'
+const GUARDIAN_INSTANCE_ID = randomUUID()
 if (!process.env.OPENALICE_HOME && process.env.OPENALICE_USER_DATA_HOME) {
   console.warn('[guardian/prod] OPENALICE_USER_DATA_HOME is deprecated — set OPENALICE_HOME instead')
 }
@@ -171,12 +174,18 @@ let TRADING_MODE = await resolveTradingMode(process.env, DATA_HOME)
 const LITE_MODE = TRADING_MODE.mode === 'lite'
 
 let stopping = false
+let shutdownExitCode = 0
 let utaChild = null
 let connectorChild = null
 let aliceChild = null
 let restartingUTA = false
 let restartingConnector = false
 let guardianRuntimeLock = null
+let guardianControlServer = null
+let aliceStatus = 'starting'
+let utaStatus = LITE_MODE ? 'disabled' : 'starting'
+let connectorStatus = 'disabled'
+const RUNTIME_VERSION = await readRuntimeVersion()
 
 console.log('[guardian/prod] starting')
 console.log(`[guardian/prod] mode  → ${TRADING_MODE.mode} (${TRADING_MODE.source}${TRADING_MODE.envLocked ? ', env-locked' : ''})`)
@@ -187,6 +196,42 @@ console.log(`[guardian/prod] Alice → http://${BIND_HOST}:${WEB_PORT}`)
 console.log(`[guardian/prod] Tools → http://127.0.0.1:${MCP_PORT}/cli`)
 console.log(`[guardian/prod] MCP   → optional on http://127.0.0.1:${MCP_PORT}/mcp`)
 console.log(`[guardian/prod] flags → ${FLAG_PATH}, ${CONNECTOR_FLAG_PATH}`)
+
+async function readRuntimeVersion() {
+  try {
+    const manifest = JSON.parse(await readFile(resolve(process.cwd(), 'package.json'), 'utf8'))
+    return typeof manifest.version === 'string' ? manifest.version : 'dev'
+  } catch {
+    return 'dev'
+  }
+}
+
+function runtimeStatus() {
+  const owner = guardianRuntimeLock?.owner
+  return {
+    protocol: 1,
+    runtimeVersion: RUNTIME_VERSION,
+    state: stopping ? 'stopping' : aliceStatus === 'ready' ? 'running' : 'starting',
+    home: resolve(DATA_HOME),
+    owner: {
+      surface: LAUNCHER,
+      pid: process.pid,
+      instanceId: GUARDIAN_INSTANCE_ID,
+      startedAt: owner?.acquiredAt ?? new Date(GUARDIAN_STARTED_AT).toISOString(),
+      launchRoot: resolve(process.env.OPENALICE_APP_HOME ?? process.cwd()),
+      mode: SERVER_MODE,
+    },
+    endpoints: {
+      web: `http://${BIND_HOST}:${WEB_PORT}`,
+    },
+    components: {
+      alice: aliceStatus,
+      uta: utaStatus,
+      connector: connectorStatus,
+    },
+    capabilities: LAUNCHER === 'cli-server' ? ['runtime.stop'] : [],
+  }
+}
 
 async function readConnectorEnabled() {
   try {
@@ -219,6 +264,7 @@ function spawnUTA() {
   const child = spawn(spec.cmd, spec.args, { env: spec.env, stdio: 'inherit' })
   child.once('exit', (code, signal) => {
     if (stopping || restartingUTA) return
+    utaStatus = 'offline'
     console.error(`[guardian/prod] UTA exited unexpectedly (code=${code}, signal=${signal}) — trading offline, Alice stays up`)
   })
   return child
@@ -240,6 +286,7 @@ function spawnConnector() {
   })
   child.once('exit', (code, signal) => {
     if (stopping || restartingConnector) return
+    connectorStatus = 'offline'
     console.error(`[guardian/prod] Connector exited unexpectedly (code=${code}, signal=${signal}) — external notifications offline, Alice stays up`)
   })
   return child
@@ -265,8 +312,9 @@ function spawnAlice() {
   })
   child.once('exit', (code, signal) => {
     if (stopping) return
+    aliceStatus = 'offline'
     console.error(`[guardian/prod] Alice exited unexpectedly (code=${code}, signal=${signal})`)
-    shutdown()
+    shutdown(typeof code === 'number' && code !== 0 ? code : 1)
   })
   return child
 }
@@ -278,6 +326,22 @@ async function waitForUTA() {
     try {
       const res = await fetch(url)
       if (res.ok) return true
+    } catch { /* not ready */ }
+    await sleep(200)
+  }
+  return false
+}
+
+async function waitForAlice() {
+  const url = `http://127.0.0.1:${WEB_PORT}/api/auth/status`
+  const deadline = Date.now() + 60_000
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) {
+        const body = await res.json()
+        if (typeof body?.authed === 'boolean' && typeof body?.tokenConfigured === 'boolean') return true
+      }
     } catch { /* not ready */ }
     await sleep(200)
   }
@@ -307,10 +371,12 @@ async function restartConnector() {
       restartingConnector = false
       connectorChild = null
     }
+    connectorStatus = 'disabled'
     return
   }
   if (restartingConnector) return
   restartingConnector = true
+  connectorStatus = 'starting'
   try {
     const old = connectorChild
     if (old && old.exitCode === null) {
@@ -324,6 +390,7 @@ async function restartConnector() {
     }
     connectorChild = spawnConnector()
     const ready = await waitForConnector()
+    connectorStatus = ready ? 'ready' : 'offline'
     if (!ready) console.error('[guardian/prod] Connector did not become ready')
     else console.log('[guardian/prod] Connector ready')
   } finally {
@@ -344,15 +411,18 @@ async function restartUTA() {
     } else {
       console.warn('[guardian/prod] restart-uta.flag ignored — trading mode lite disables UTA')
     }
+    utaStatus = 'disabled'
     return
   }
   if (restartingUTA) return
   restartingUTA = true
+  utaStatus = 'starting'
   try {
     if (!utaChild) {
       console.log(`[guardian/prod] trading mode ${TRADING_MODE.mode} — starting UTA`)
       utaChild = spawnUTA()
       const ready = await waitForUTA()
+      utaStatus = ready ? 'ready' : 'offline'
       if (!ready) console.error('[guardian/prod] UTA did not come up')
       else console.log('[guardian/prod] UTA ready')
       return
@@ -370,6 +440,7 @@ async function restartUTA() {
     }
     utaChild = spawnUTA()
     const ready = await waitForUTA()
+    utaStatus = ready ? 'ready' : 'offline'
     if (!ready) {
       console.error('[guardian/prod] UTA did not come back up after restart')
     } else {
@@ -380,9 +451,13 @@ async function restartUTA() {
   }
 }
 
-function shutdown() {
+function shutdown(exitCode = 0) {
+  shutdownExitCode = Math.max(shutdownExitCode, exitCode)
   if (stopping) return
   stopping = true
+  if (aliceChild) aliceStatus = 'stopping'
+  if (utaChild) utaStatus = 'stopping'
+  if (connectorChild) connectorStatus = 'stopping'
   console.log('[guardian/prod] shutting down')
   for (const c of [utaChild, connectorChild, aliceChild]) {
     if (c && c.exitCode === null && !c.killed) {
@@ -391,16 +466,20 @@ function shutdown() {
   }
   setTimeout(() => {
     for (const c of [utaChild, connectorChild, aliceChild]) {
-      if (c && c.exitCode === null && !c.killed) {
+      if (c && c.exitCode === null) {
         try { c.kill('SIGKILL') } catch { /* noop */ }
       }
     }
+    const currentControl = guardianControlServer
+    guardianControlServer = null
     const current = guardianRuntimeLock
     guardianRuntimeLock = null
-    void Promise.resolve(current?.release())
+    void Promise.resolve(currentControl?.close())
+      .catch((err) => console.error('[guardian/prod] control endpoint close failed:', err))
+      .then(() => current?.release())
       .catch((err) => console.error('[guardian/prod] runtime lock release failed:', err))
-      .finally(() => process.exit(0))
-  }, 5_000).unref()
+      .finally(() => process.exit(shutdownExitCode))
+  }, 5_000)
 }
 
 process.on('SIGINT', shutdown)
@@ -449,23 +528,41 @@ async function main() {
   })
   if (TAKEOVER) console.log('[guardian/prod] takeover → previous OpenAlice runtime stopped')
 
+  guardianControlServer = await startGuardianControlServer({
+    homeRoot: DATA_HOME,
+    allowStop: LAUNCHER === 'cli-server',
+    getStatus: runtimeStatus,
+    onStop: () => shutdown(),
+  })
+  console.log(`[guardian/prod] Control → ${guardianControlServer.endpoint}`)
+
   if (TRADING_MODE.mode !== 'lite') {
+    utaStatus = 'starting'
     utaChild = spawnUTA()
     void waitForUTA().then((ready) => {
+      utaStatus = ready ? 'ready' : 'offline'
       if (ready) console.log('[guardian/prod] UTA ready')
       else console.warn('[guardian/prod] UTA did not become ready within 15s — continuing with trading offline')
     })
   }
 
   if (await readConnectorEnabled()) {
+    connectorStatus = 'starting'
     connectorChild = spawnConnector()
     void waitForConnector().then((ready) => {
+      connectorStatus = ready ? 'ready' : 'offline'
       if (ready) console.log('[guardian/prod] Connector ready')
       else console.warn('[guardian/prod] Connector did not become ready within 15s — external notifications offline')
     })
   }
 
+  aliceStatus = 'starting'
   aliceChild = spawnAlice()
+  void waitForAlice().then((ready) => {
+    aliceStatus = ready ? 'ready' : 'offline'
+    if (ready) console.log('[guardian/prod] Alice ready')
+    else console.error('[guardian/prod] Alice did not become ready within 60s')
+  })
   // Alice may create connector-service.json while applying the migration from
   // the retired Telegram config. Reconcile once after its startup path.
   void (async () => {
@@ -477,6 +574,5 @@ async function main() {
 
 main().catch((err) => {
   console.error('[guardian/prod] fatal:', err)
-  shutdown()
-  process.exit(1)
+  shutdown(1)
 })

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -60,12 +60,23 @@ bin_dir="$HOME/.openalice/bin"
 versions_dir="$HOME/.openalice/cli-versions"
 [[ "$($bin_dir/openalice --version)" == "0.2.0" ]] || fail "installed CLI version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"
+server_status="$($bin_dir/openalice server status --home "$HOME/openalice-server-smoke" --json)"
+node -e '
+const status = JSON.parse(process.argv[1]);
+if (status.class !== "absent" || status.state !== "absent") process.exit(1);
+' "$server_status" || fail "installed CLI server status check failed"
 [[ -f "$bin_dir/openalice.cmd" ]] || fail "Windows launcher was not installed"
 [[ ! -e "$HOME/.openalice/.cli-install.lock" ]] || fail "installer lock was not released"
 v1_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v1-*' -print -quit)"
 [[ -n "$v1_release" && -f "$v1_release/bin/openalice.mjs" ]] || fail "content-addressed CLI release was not installed"
 cmp /fixture/packages/cli/src/local-start.mjs "$v1_release/src/local-start.mjs" \
   || fail "downloaded CLI file differs from the fixture"
+cmp /fixture/packages/cli/src/remote.mjs "$v1_release/src/remote.mjs" \
+  || fail "downloaded Remote CLI file differs from the fixture"
+cmp /fixture/packages/cli/src/server.mjs "$v1_release/src/server.mjs" \
+  || fail "downloaded Server CLI file differs from the fixture"
+cmp /fixture/packages/cli/src/server-control.mjs "$v1_release/src/server-control.mjs" \
+  || fail "downloaded Server control file differs from the fixture"
 
 expected_path_line="export PATH=$HOME/.openalice/bin:\$PATH"
 path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"

--- a/scripts/remote-smoke/Dockerfile
+++ b/scripts/remote-smoke/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:22-bookworm-slim
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl openssh-server \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --create-home --shell /bin/bash --uid 10001 smoke \
+  && passwd --delete smoke \
+  && mkdir -p /run/sshd /fixture/OpenAlice/scripts/guardian \
+  && ssh-keygen -A
+
+COPY install /fixture/install
+COPY packages/cli /fixture/packages/cli
+COPY scripts/install-smoke/static-server.mjs /fixture/static-server.mjs
+COPY scripts/guardian/control-server.mjs /fixture/OpenAlice/scripts/guardian/control-server.mjs
+COPY scripts/remote-smoke/fixture-guardian.mjs /fixture/OpenAlice/scripts/guardian/prod.mjs
+COPY scripts/remote-smoke/fixture-package.json /fixture/OpenAlice/package.json
+COPY scripts/remote-smoke/entrypoint.sh /fixture/entrypoint.sh
+
+RUN mkdir -p \
+    /fixture/OpenAlice/dist \
+    /fixture/OpenAlice/ui/dist \
+    /fixture/OpenAlice/services/uta/dist \
+    /fixture/OpenAlice/services/connector/dist \
+    /fixture/OpenAlice/packages/guardian-runtime/dist \
+    /fixture/OpenAlice/node_modules \
+  && touch \
+    /fixture/OpenAlice/dist/main.js \
+    /fixture/OpenAlice/ui/dist/index.html \
+    /fixture/OpenAlice/services/uta/dist/uta.js \
+    /fixture/OpenAlice/services/connector/dist/connector.cjs \
+    /fixture/OpenAlice/packages/guardian-runtime/dist/index.js \
+  && chmod +x /fixture/entrypoint.sh \
+  && chown -R smoke:smoke /fixture/OpenAlice /home/smoke
+
+EXPOSE 22
+ENTRYPOINT ["/fixture/entrypoint.sh"]

--- a/scripts/remote-smoke/entrypoint.sh
+++ b/scripts/remote-smoke/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install -d -m 0700 -o smoke -g smoke /home/smoke/.ssh
+install -m 0600 -o smoke -g smoke /tmp/authorized_keys /home/smoke/.ssh/authorized_keys
+
+node /fixture/static-server.mjs >/tmp/openalice-installer-server.log 2>&1 &
+
+exec /usr/sbin/sshd -D -e \
+  -o PasswordAuthentication=no \
+  -o KbdInteractiveAuthentication=no \
+  -o PermitRootLogin=no \
+  -o PubkeyAuthentication=yes \
+  -o AllowUsers=smoke

--- a/scripts/remote-smoke/fixture-guardian.mjs
+++ b/scripts/remote-smoke/fixture-guardian.mjs
@@ -1,0 +1,61 @@
+import { randomUUID } from 'node:crypto'
+import { createServer } from 'node:http'
+
+import { startGuardianControlServer } from './control-server.mjs'
+
+const home = process.env.OPENALICE_HOME
+const port = Number(process.env.OPENALICE_WEB_PORT ?? 47331)
+const surface = process.env.OPENALICE_LAUNCHER ?? 'cli-server'
+const startedAt = new Date().toISOString()
+const instanceId = randomUUID()
+let stopping = false
+let control
+
+const http = createServer((request, response) => {
+  if (request.url === '/api/auth/status') {
+    response.setHeader('content-type', 'application/json')
+    response.end(JSON.stringify({ authed: true, tokenConfigured: false, fixture: 'remote-ssh-smoke' }))
+    return
+  }
+  response.statusCode = 404
+  response.end('not found\n')
+})
+
+await new Promise((resolvePromise, rejectPromise) => {
+  http.once('error', rejectPromise)
+  http.listen(port, '127.0.0.1', resolvePromise)
+})
+
+control = await startGuardianControlServer({
+  homeRoot: home,
+  allowStop: surface === 'cli-server',
+  getStatus: () => ({
+    protocol: 1,
+    runtimeVersion: '0.0.0-remote-smoke',
+    state: stopping ? 'stopping' : 'running',
+    home,
+    owner: {
+      surface,
+      pid: process.pid,
+      instanceId,
+      startedAt,
+      launchRoot: process.cwd(),
+      mode: process.env.OPENALICE_SERVER_MODE ?? 'detached',
+    },
+    endpoints: { web: `http://127.0.0.1:${port}` },
+    components: { alice: 'ready', uta: 'disabled', connector: 'disabled' },
+    capabilities: surface === 'cli-server' ? ['runtime.stop'] : [],
+  }),
+  onStop: () => { void shutdown() },
+})
+
+async function shutdown() {
+  if (stopping) return
+  stopping = true
+  await new Promise((resolvePromise) => http.close(resolvePromise))
+  await control.close()
+  process.exit(0)
+}
+
+process.on('SIGINT', () => { void shutdown() })
+process.on('SIGTERM', () => { void shutdown() })

--- a/scripts/remote-smoke/fixture-package.json
+++ b/scripts/remote-smoke/fixture-package.json
@@ -1,0 +1,8 @@
+{
+  "name": "open-alice",
+  "version": "0.0.0-remote-smoke",
+  "type": "module",
+  "scripts": {
+    "build:server": "node -e \"process.exit(0)\""
+  }
+}

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+const cliEntry = join(repoRoot, 'packages/cli/bin/openalice.mjs')
+const suffix = `${process.pid}-${Date.now().toString(36)}`
+const image = `openalice-remote-smoke:${suffix}`
+const args = process.argv.slice(2)
+const keepImage = args.includes('--keep-image')
+const keepContainer = args.includes('--keep-container')
+let imageBuilt = false
+let container = ''
+let scratch = ''
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Usage: pnpm test:remote:docker [--keep-image] [--keep-container]
+
+Builds a clean local SSH host, serves the real OpenAlice installer inside that
+host, and exercises plan, install, detached Server start, browser tunnel,
+disconnect persistence, reconnect, structured stop, and absent status. This is
+a local acceptance gate and is not wired into PR CI.
+
+Options:
+  --keep-image      Preserve the temporary Docker image
+  --keep-container  Preserve the running fixture container (also keeps image)
+  -h, --help        Show this help
+`)
+  process.exit(0)
+}
+
+const unknownArgs = args.filter((arg) => !['--keep-image', '--keep-container'].includes(arg))
+if (unknownArgs.length > 0) {
+  console.error(`remote docker smoke: unknown option: ${unknownArgs[0]}`)
+  process.exit(1)
+}
+
+try {
+  scratch = await mkdtemp(join(tmpdir(), 'openalice-remote-smoke-'))
+  const keyPath = join(scratch, 'id_ed25519')
+  run('ssh-keygen', ['-q', '-t', 'ed25519', '-N', '', '-f', keyPath])
+
+  console.log(`[remote-ssh-smoke] building ${image}`)
+  run('docker', [
+    'build',
+    '--file', 'scripts/remote-smoke/Dockerfile',
+    '--tag', image,
+    '.',
+  ], { cwd: repoRoot, inherit: true })
+  imageBuilt = true
+
+  container = run('docker', [
+    'run', '--detach', '--rm',
+    '--publish', '127.0.0.1::22',
+    '--mount', `type=bind,src=${keyPath}.pub,dst=/tmp/authorized_keys,readonly`,
+    image,
+  ]).trim()
+  const portOutput = run('docker', ['port', container, '22/tcp']).trim()
+  const sshPort = Number(portOutput.slice(portOutput.lastIndexOf(':') + 1))
+  if (!Number.isInteger(sshPort) || sshPort < 1) throw new Error(`Could not parse SSH port from ${portOutput}`)
+
+  const localHome = join(scratch, 'local-home')
+  const sshDir = join(localHome, '.ssh')
+  await mkdir(sshDir, { recursive: true })
+  await writeFile(join(sshDir, 'config'), `Host openalice-remote-smoke
+  HostName 127.0.0.1
+  User smoke
+  Port ${sshPort}
+  IdentityFile ${keyPath}
+  IdentitiesOnly yes
+  StrictHostKeyChecking no
+  UserKnownHostsFile ${join(sshDir, 'known_hosts')}
+  LogLevel ERROR
+`)
+  await chmod(sshDir, 0o700)
+  await chmod(join(sshDir, 'config'), 0o600)
+  const fixtureBin = join(scratch, 'bin')
+  await mkdir(fixtureBin, { recursive: true })
+  const sshWrapper = join(fixtureBin, 'ssh')
+  const systemSsh = run('which', ['ssh']).trim()
+  await writeFile(sshWrapper, `#!/bin/sh\nexec ${shellQuote(systemSsh)} -F "$OPENALICE_REMOTE_SMOKE_SSH_CONFIG" "$@"\n`)
+  await chmod(sshWrapper, 0o700)
+
+  const remoteTarget = 'openalice-remote-smoke'
+  const smokeEnv = {
+    ...process.env,
+    HOME: localHome,
+    PATH: `${fixtureBin}:${process.env.PATH ?? ''}`,
+    OPENALICE_REMOTE_SMOKE_SSH_CONFIG: join(sshDir, 'config'),
+    OPENALICE_REMOTE_INSTALL_URL: 'http://127.0.0.1:18080/install',
+    OPENALICE_REMOTE_INSTALL_BASE_URL: 'http://127.0.0.1:18080/packages/cli/',
+    OPENALICE_REMOTE_VERSION: 'remote-smoke',
+  }
+  await waitForSsh(remoteTarget, smokeEnv)
+
+  console.log('[remote-ssh-smoke] checking read-only missing-host plan')
+  const initialPlan = run(process.execPath, [
+    cliEntry, 'remote', remoteTarget,
+    '--app-dir', '/fixture/OpenAlice',
+    '--plan', '--no-open',
+  ], { cwd: repoRoot, env: smokeEnv })
+  requireText(initialPlan, 'install remote OpenAlice CLI')
+  requireText(initialPlan, 'start remote OpenAlice Server')
+  run('ssh', [remoteTarget, 'test ! -x "$HOME/.openalice/bin/openalice"'], { env: smokeEnv })
+
+  console.log('[remote-ssh-smoke] applying install/start and opening first tunnel')
+  await attachAndProbe(remoteTarget, smokeEnv, [
+    '--app-dir', '/fixture/OpenAlice',
+    '--yes', '--no-open', '--wait', '30',
+  ])
+  const running = remoteJson(remoteTarget, smokeEnv, '"$HOME/.openalice/bin/openalice" server status --json')
+  if (running.class !== 'running' || running.owner?.surface !== 'cli-server') {
+    throw new Error(`Remote Server did not survive tunnel disconnect: ${JSON.stringify(running)}`)
+  }
+
+  console.log('[remote-ssh-smoke] checking reuse plan and reconnecting')
+  const reusePlan = run(process.execPath, [
+    cliEntry, 'remote', remoteTarget, '--plan', '--no-open',
+  ], { cwd: repoRoot, env: smokeEnv })
+  requireText(reusePlan, 'reuse compatible remote CLI Server')
+  await attachAndProbe(remoteTarget, smokeEnv, ['--no-open', '--wait', '30'])
+
+  console.log('[remote-ssh-smoke] stopping the remote Server through its control endpoint')
+  run('ssh', [remoteTarget, '"$HOME/.openalice/bin/openalice" server stop --wait 15'], { env: smokeEnv })
+  const absent = remoteJson(remoteTarget, smokeEnv, '"$HOME/.openalice/bin/openalice" server status --json')
+  if (absent.class !== 'absent') throw new Error(`Remote Server did not stop cleanly: ${JSON.stringify(absent)}`)
+
+  console.log('[remote-ssh-smoke] passed')
+} catch (error) {
+  console.error(`[remote-ssh-smoke] failed: ${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 1
+} finally {
+  if (keepContainer && container) {
+    console.log(`[remote-ssh-smoke] kept container ${container}`)
+  } else if (container) {
+    run('docker', ['rm', '--force', container], { allowFailure: true, inherit: true })
+  }
+  if ((keepImage || keepContainer) && imageBuilt) {
+    console.log(`[remote-ssh-smoke] kept image ${image}`)
+  } else if (imageBuilt) {
+    run('docker', ['image', 'rm', '--force', image], { allowFailure: true, inherit: true })
+  }
+  if (scratch) await rm(scratch, { recursive: true, force: true })
+}
+
+async function waitForSsh(target, env) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const result = spawnSync('ssh', [target, 'true'], { env, stdio: 'ignore' })
+    if (result.status === 0) return
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100))
+  }
+  throw new Error('SSH fixture did not become ready')
+}
+
+async function attachAndProbe(target, env, remoteArgs) {
+  const child = spawn(process.execPath, [cliEntry, 'remote', target, ...remoteArgs], {
+    cwd: repoRoot,
+    env,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  })
+  child.stdout.setEncoding('utf8')
+  let output = ''
+  let resolveUrl
+  let rejectUrl
+  const urlReady = new Promise((resolvePromise, rejectPromise) => {
+    resolveUrl = resolvePromise
+    rejectUrl = rejectPromise
+  })
+  child.stdout.on('data', (chunk) => {
+    process.stdout.write(chunk)
+    output += chunk
+    const match = /Local OpenAlice UI: (http:\/\/127\.0\.0\.1:\d+)/.exec(output)
+    if (match) resolveUrl(match[1])
+  })
+  child.once('error', rejectUrl)
+  child.once('exit', (code, signal) => {
+    if (!/Local OpenAlice UI:/.test(output)) {
+      rejectUrl(new Error(`remote CLI exited before tunnel readiness (code=${String(code)}, signal=${String(signal)})`))
+    }
+  })
+
+  const timeout = setTimeout(() => rejectUrl(new Error('Timed out waiting for the local tunnel URL')), 60_000)
+  let url
+  try {
+    url = await urlReady
+  } finally {
+    clearTimeout(timeout)
+  }
+  const response = await fetch(`${url}/api/auth/status`, { signal: AbortSignal.timeout(5_000) })
+  const body = await response.json()
+  if (!response.ok || body.fixture !== 'remote-ssh-smoke') {
+    child.kill('SIGTERM')
+    throw new Error(`Tunnel returned the wrong Runtime response: ${JSON.stringify(body)}`)
+  }
+  child.kill('SIGTERM')
+  const exit = await waitForExit(child, 10_000)
+  if (exit.code !== 0) throw new Error(`remote CLI did not close cleanly after tunnel disconnect (${JSON.stringify(exit)})`)
+}
+
+function waitForExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode ?? 0, signal: child.signalCode })
+  }
+  return new Promise((resolvePromise, rejectPromise) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      rejectPromise(new Error('Timed out waiting for remote CLI to close'))
+    }, timeoutMs)
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout)
+      resolvePromise({ code: code ?? 0, signal })
+    })
+  })
+}
+
+function remoteJson(target, env, command) {
+  const output = run('ssh', [target, command], { env })
+  return JSON.parse(output.trim().split(/\r?\n/).filter(Boolean).at(-1))
+}
+
+function requireText(output, expected) {
+  if (!output.includes(expected)) throw new Error(`Expected output to contain ${JSON.stringify(expected)}\n${output}`)
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `'"'"'`)}'`
+}
+
+function run(command, commandArgs, options = {}) {
+  const result = spawnSync(command, commandArgs, {
+    cwd: options.cwd ?? repoRoot,
+    env: options.env ?? process.env,
+    encoding: 'utf8',
+    stdio: options.inherit ? 'inherit' : ['ignore', 'pipe', 'inherit'],
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new Error(`${command} ${commandArgs[0] ?? ''} failed (${result.status ?? result.signal ?? 'unknown'})`)
+  }
+  return typeof result.stdout === 'string' ? result.stdout : ''
+}


### PR DESCRIPTION
## Summary

- document the Herdr comparison and the staged OpenAlice remote Runtime architecture
- add openalice server run/start/status/stop with a versioned user-local Guardian control endpoint
- add consent-first openalice remote planning, normal CLI bootstrap, owner re-probe, Server reuse/start, and loopback SSH tunneling
- preserve Electron as the complete desktop lane and add clean local Docker SSH acceptance

## Why

OpenAlice needs a source-backed localhost and SSH distribution path that keeps files, Agent CLIs, PTYs, and model execution on the Runtime host without exposing Alice publicly or coupling disconnect to process lifetime. The new lifecycle reuses Guardian ownership and the existing browser/Workspace transport instead of introducing a parallel daemon or terminal protocol.

## Validation

- npx tsc --noEmit
- pnpm test: 2971 passed, 6 skipped after rebasing onto current dev
- pnpm -F @traderalice/openalice-cli test: 41 passed
- pnpm test:guardian-recovery and the full Guardian recovery skill checks
- pnpm build:server
- pnpm test:install:docker
- pnpm test:remote:docker
- pnpm docker:smoke
- unsigned pnpm electron:smoke:workspace
- real isolated source-backed Server start/status/auth/stop and foreign-owner refusal smokes

## Residual release observation

Representative WAN/network-shaping measurements for Shell and native Agent TUIs remain a release observation before deciding whether a later terminal snapshot/diff protocol is justified. The current implementation intentionally keeps the existing PTY WebSocket over the SSH loopback tunnel.