### PR TITLE
Add Workspace template upgrade CLI

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -21,6 +21,7 @@ Choose the verb from the intent, not from whichever object you happen to have:
 | Ask an Issue's creator or selected historical run | `issue ask` |
 | Discuss this Workspace's own Issue; notify its fixed owner | `issue comment` |
 | Ask by a known product Session/Workspace only when no business object exists | `conversation ask` |
+| Bring this desk's managed instructions and skills up to date | `template upgrade` |
 
 `issue comment` is the durable conversation entry for this Workspace's own
 Issue. If the Issue has an exact `@resumeId` assignee, a comment from somebody
@@ -186,3 +187,36 @@ one accountable product Session. Commit intentional Issue-file changes as a
 focused Git change; Activity remains an audit fallback, while Git is the exact
 rollback history. Issue/Inbox CLI actions are signed automatically. End standalone reports with `Signed-by: @resumeId`
 (copy it from `signature show`) so another Agent can return to the author.
+
+**Upgrade this Workspace's managed template assets** — preview first, then
+apply explicitly:
+
+```bash
+alice-workspace template upgrade
+alice-workspace template upgrade --apply
+alice-workspace template upgrade --id <workspaceId>       # manage a paused peer
+alice-workspace template upgrade --id <workspaceId> --apply
+```
+
+The default call is read-only. It compares this Workspace with the current
+template and lists ready changes, protected local customizations, blockers, and
+conflicts. `--apply` re-plans and runs the launcher's transactional upgrade;
+there is no HTTP endpoint or plan digest to copy by hand. Omit `--id` for this
+Workspace, or pass a peer Workspace id when interactively managing another
+desk. Applying to the current Workspace from one of its own live Sessions will
+correctly remain blocked; pause it or use a separate manager Workspace. A
+headless run may preview a peer but cannot apply a cross-Workspace upgrade.
+
+If a managed file changed both locally and in the template, resolve every
+conflict explicitly before applying:
+
+```bash
+alice-workspace template upgrade --mode detailed
+alice-workspace template upgrade --id <workspaceId> --apply \
+  --keep-workspace AGENTS.md \
+  --use-template .agents/skills/alice-workspace/SKILL.md
+```
+
+Both resolution flags are repeatable. Upgrade never adopts research, reports,
+Issues, credentials, runtime state, or other user files. It also refuses to run
+while Sessions/headless work are active or unrelated changes are staged.

--- a/docs/workspace-template-upgrade.md
+++ b/docs/workspace-template-upgrade.md
@@ -110,6 +110,28 @@ Apply remains disabled until every conflict has a decision. The operation ends
 with the Git commit id, making the change inspectable and reversible through
 normal Workspace history.
 
+The same transaction is available from inside the current Workspace without
+hand-authoring API calls:
+
+```bash
+alice-workspace template upgrade          # read-only preview
+alice-workspace template upgrade --apply  # re-plan and apply the exact current plan
+alice-workspace template upgrade --id <workspaceId>          # preview a peer
+alice-workspace template upgrade --id <workspaceId> --apply  # upgrade a paused peer
+```
+
+Conflicts require one repeatable `--keep-workspace <path>` or
+`--use-template <path>` decision per path. The caller's Workspace is the
+default target; an interactive manager can pass `--id` to reconcile a paused
+peer without entering its Session. The launcher still owns the plan digest
+internally. This keeps the shell surface aligned with the UI's safety contract
+while avoiding HTTP and transaction plumbing in agent prompts. A live Session
+cannot upgrade its own instructions underneath itself; pause it or apply from a
+separate manager Workspace.
+
+Cross-Workspace apply is an interactive management action. A headless run may
+preview another desk but the tool rejects applying that peer's upgrade.
+
 ## Shared Foundation, Different Workflows
 
 Template Upgrade and a future Workspace Merge/Absorb are not the same product

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -36,6 +36,11 @@ import type { IssuesSnapshot, IssueDetail, WikilinkIssueRef } from '../workspace
 import type { WorkspaceSessionDirectory } from '../workspaces/session-directory.js'
 import type { HeadlessStructuredOutput } from '../workspaces/headless-output.js'
 import type { HeadlessInquirySubject, HeadlessTaskStatus } from '../workspaces/headless-task-registry.js'
+import type {
+  ApplyTemplateUpgradeInput,
+  TemplateUpgradePlan,
+  TemplateUpgradeResult,
+} from '../workspaces/template-upgrade.js'
 
 export type WorkspaceConversationTarget =
   | { kind: 'resume'; resumeId: string }
@@ -131,6 +136,12 @@ export interface WorkspaceConversationControl {
   read(taskId: string): Promise<WorkspaceConversationTask | null>
 }
 
+/** Launcher-owned reconciliation for the caller's current Workspace. */
+export interface WorkspaceTemplateUpgradeControl {
+  plan(workspaceId: string): Promise<TemplateUpgradePlan>
+  apply(workspaceId: string, input: ApplyTemplateUpgradeInput): Promise<TemplateUpgradeResult>
+}
+
 // ==================== Context handed to factories ====================
 
 export interface WorkspaceToolContext {
@@ -193,6 +204,8 @@ export interface WorkspaceToolContext {
     detail(wsId: string, id: string): Promise<IssueDetail | null>
     resolveByName(name: string): Promise<WikilinkIssueRef[]>
   }
+  /** Safe current-Workspace template preview/apply surface. */
+  templateUpgrades?: WorkspaceTemplateUpgradeControl
 }
 
 // ==================== Factory shape ====================

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,7 @@ import { inboxPushFactory } from './tool/inbox-push.js'
 import { inboxReadFactory } from './tool/inbox-read.js'
 import { workspacePathFactory } from './tool/workspace-path.js'
 import { workspaceSessionsFactory } from './tool/workspace-sessions.js'
+import { workspaceTemplateUpgradeFactory } from './tool/workspace-template-upgrade.js'
 import { createEntityStore } from './core/entity-store.js'
 import { entityUpsertFactory } from './tool/entity-upsert.js'
 import { entitySearchFactory } from './tool/entity-search.js'
@@ -116,6 +117,7 @@ async function main() {
   workspaceToolCenter.register(inboxReadFactory)
   workspaceToolCenter.register(workspacePathFactory)
   workspaceToolCenter.register(workspaceSessionsFactory)
+  workspaceToolCenter.register(workspaceTemplateUpgradeFactory)
   workspaceToolCenter.register(entityUpsertFactory)
   workspaceToolCenter.register(entitySearchFactory)
   for (const f of issueToolFactories) workspaceToolCenter.register(f)

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -20,6 +20,7 @@ import { inboxPushFactory } from '../tool/inbox-push.js'
 import { inboxReadFactory } from '../tool/inbox-read.js'
 import { workspacePathFactory } from '../tool/workspace-path.js'
 import { workspaceSessionsFactory } from '../tool/workspace-sessions.js'
+import { workspaceTemplateUpgradeFactory } from '../tool/workspace-template-upgrade.js'
 import { entityUpsertFactory } from '../tool/entity-upsert.js'
 import { entitySearchFactory } from '../tool/entity-search.js'
 import { issueToolFactories } from '../tool/issue-tools.js'
@@ -90,6 +91,7 @@ describe('CLI_EXPORTS — workspace export (scoped collaboration tools)', () => 
   wtc.register(inboxReadFactory)
   wtc.register(workspacePathFactory)
   wtc.register(workspaceSessionsFactory)
+  wtc.register(workspaceTemplateUpgradeFactory)
   wtc.register(entityUpsertFactory)
   wtc.register(entitySearchFactory)
   for (const f of issueToolFactories) wtc.register(f)

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -145,7 +145,7 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
   workspace: {
     binary: 'alice-workspace',
     scope: 'scoped',
-    description: 'Agent collaboration — push/read the user inbox, locate a peer workspace (peer path), track entities',
+    description: 'Workspace collaboration and management — Inbox, Issues, peers, provenance, and managed template upgrades',
     commands: {
       // inbox push: surface doc(s) + comment to the user's Inbox tab. Attach
       // files with repeatable `--doc <path>` (the shim folds them into the
@@ -195,6 +195,11 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
         await: 'conversation_await',
         collect: 'conversation_collect',
         read: 'conversation_read',
+      },
+      // Current-Workspace managed template reconciliation. Preview is the
+      // default; `--apply` explicitly performs the reviewed safe operation.
+      template: {
+        upgrade: 'workspace_template_upgrade',
       },
     },
   },

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -91,6 +91,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
         entityStore,
         ...(svc ? { provenanceStore: svc.provenanceStore } : {}),
         ...(svc ? { conversation: createWorkspaceConversationControl(svc) } : {}),
+        ...(svc ? { templateUpgrades: svc.templateUpgrades } : {}),
         // Lets workspace_path resolve ANY peer's dir (not just the caller) —
         // the in-workspace cross-workspace addressing path. Shared with the
         // mcp.ts build site so the two never drift.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -105,6 +105,7 @@ export class McpPlugin implements Plugin {
         entityStore,
         ...(svc ? { provenanceStore: svc.provenanceStore } : {}),
         ...(svc ? { conversation: createWorkspaceConversationControl(svc) } : {}),
+        ...(svc ? { templateUpgrades: svc.templateUpgrades } : {}),
         // Parity with the CLI gateway so external MCP consumers get the same
         // workspace_path resolution — shared helper, so the two can't drift.
         resolveWorkspace: makeWorkspaceResolver(getWorkspaceService),

--- a/src/tool/workspace-template-upgrade.spec.ts
+++ b/src/tool/workspace-template-upgrade.spec.ts
@@ -1,0 +1,184 @@
+import type { Tool } from 'ai'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
+import type { TemplateUpgradePlan } from '../workspaces/template-upgrade.js'
+import { workspaceTemplateUpgradeFactory } from './workspace-template-upgrade.js'
+
+async function run(tool: Tool, args: Record<string, unknown>) {
+  return await tool.execute!(args, { toolCallId: 'upgrade', messages: [] }) as Record<string, any>
+}
+
+function plan(overrides: Partial<TemplateUpgradePlan> = {}): TemplateUpgradePlan {
+  return {
+    workspaceId: 'ws-1',
+    template: 'chat',
+    fromVersion: '1.5.0',
+    toVersion: '1.6.1',
+    strategy: 'managed-context',
+    planDigest: 'digest-1',
+    source: 'recorded-baseline',
+    blocked: false,
+    blockers: [],
+    activity: { busy: false, sessions: [], headless: [] },
+    files: [{
+      path: 'AGENTS.md',
+      status: 'ready',
+      operation: 'update',
+      currentPreview: 'old',
+      templatePreview: 'new',
+      currentTruncated: false,
+      templateTruncated: false,
+      canUseTemplate: true,
+    }],
+    summary: { ready: 1, preserved: 0, conflicts: 0, unchanged: 0 },
+    ...overrides,
+  }
+}
+
+function setup(currentPlan = plan()) {
+  const templateUpgrades = {
+    plan: vi.fn(async () => currentPlan),
+    apply: vi.fn(async () => ({
+      workspaceId: 'ws-1',
+      fromVersion: currentPlan.fromVersion,
+      toVersion: currentPlan.toVersion,
+      commit: 'commit-1',
+      changedPaths: ['AGENTS.md'],
+      keptPaths: [],
+    })),
+  }
+  const ctx = {
+    workspaceId: 'ws-1',
+    workspaceLabel: 'desk',
+    inboxStore: {} as never,
+    entityStore: {} as never,
+    templateUpgrades,
+  } satisfies WorkspaceToolContext
+  return { tool: workspaceTemplateUpgradeFactory.build(ctx), templateUpgrades }
+}
+
+describe('workspace_template_upgrade', () => {
+  it('previews by default without dumping file bodies', async () => {
+    const { tool, templateUpgrades } = setup()
+    const result = await run(tool, { apply: false, mode: 'summary' })
+
+    expect(result).toMatchObject({
+      ok: true,
+      action: 'preview',
+      preview: {
+        status: 'ready',
+        fromVersion: '1.5.0',
+        toVersion: '1.6.1',
+        nextCommand: 'alice-workspace template upgrade --apply',
+      },
+    })
+    expect(result.preview.changes[0]).not.toHaveProperty('currentPreview')
+    expect(templateUpgrades.apply).not.toHaveBeenCalled()
+  })
+
+  it('re-plans and applies the exact current digest after --apply', async () => {
+    const { tool, templateUpgrades } = setup()
+    const result = await run(tool, { apply: true, mode: 'summary' })
+
+    expect(result).toMatchObject({ ok: true, action: 'applied', result: { commit: 'commit-1' } })
+    expect(templateUpgrades.apply).toHaveBeenCalledWith('ws-1', { planDigest: 'digest-1' })
+  })
+
+  it('can target a paused peer Workspace without changing the caller identity', async () => {
+    const { tool, templateUpgrades } = setup(plan({ workspaceId: 'ws-peer' }))
+    const result = await run(tool, { id: 'ws-peer', apply: true, mode: 'summary' })
+
+    expect(result.ok).toBe(true)
+    expect(templateUpgrades.plan).toHaveBeenCalledWith('ws-peer')
+    expect(templateUpgrades.apply).toHaveBeenCalledWith('ws-peer', { planDigest: 'digest-1' })
+  })
+
+  it('allows headless peer previews but refuses cross-Workspace apply', async () => {
+    const { tool, templateUpgrades } = setup(plan({ workspaceId: 'ws-peer' }))
+    const headlessTool = workspaceTemplateUpgradeFactory.build({
+      workspaceId: 'ws-1',
+      workspaceLabel: 'desk',
+      inboxStore: {} as never,
+      entityStore: {} as never,
+      templateUpgrades,
+      origin: { kind: 'headless', runId: 'run-1' },
+    })
+
+    expect(await run(headlessTool, { id: 'ws-peer', apply: false, mode: 'summary' }))
+      .toMatchObject({ ok: true, action: 'preview' })
+    expect(await run(headlessTool, { id: 'ws-peer', apply: true, mode: 'summary' }))
+      .toMatchObject({ ok: false, error: { code: 'interactive_required' } })
+    expect(templateUpgrades.apply).not.toHaveBeenCalled()
+  })
+
+  it('requires every conflict exactly once and forwards explicit resolutions', async () => {
+    const conflictPlan = plan({
+      files: [{
+        path: 'AGENTS.md',
+        status: 'conflict',
+        operation: 'update',
+        currentPreview: 'mine',
+        templatePreview: 'theirs',
+        currentTruncated: false,
+        templateTruncated: false,
+        canUseTemplate: true,
+      }],
+      summary: { ready: 0, preserved: 0, conflicts: 1, unchanged: 0 },
+    })
+    const { tool, templateUpgrades } = setup(conflictPlan)
+
+    const unresolved = await run(tool, { apply: true, mode: 'detailed' })
+    expect(unresolved).toMatchObject({
+      ok: false,
+      error: { code: 'invalid_resolutions', unresolved: ['AGENTS.md'] },
+      preview: { conflicts: [{ currentPreview: 'mine', templatePreview: 'theirs' }] },
+    })
+    expect(templateUpgrades.apply).not.toHaveBeenCalled()
+
+    const applied = await run(tool, {
+      apply: true,
+      keepWorkspace: ['AGENTS.md'],
+      useTemplate: [],
+      mode: 'summary',
+    })
+    expect(applied.ok).toBe(true)
+    expect(templateUpgrades.apply).toHaveBeenCalledWith('ws-1', {
+      planDigest: 'digest-1',
+      resolutions: { 'AGENTS.md': 'workspace' },
+    })
+  })
+
+  it('does not apply while the Workspace is busy', async () => {
+    const { tool, templateUpgrades } = setup(plan({
+      blocked: true,
+      blockers: ['active_sessions'],
+      activity: {
+        busy: true,
+        sessions: [{
+          sessionId: 'session-1',
+          resumeId: 'resume-1',
+          name: 'p1',
+          agent: 'pi',
+          surface: 'terminal',
+          startedAt: 1,
+        }],
+        headless: [],
+      },
+    }))
+    const result = await run(tool, { apply: true, mode: 'summary' })
+    expect(result).toMatchObject({ ok: false, error: { code: 'blocked' } })
+    expect(templateUpgrades.apply).not.toHaveBeenCalled()
+  })
+
+  it('surfaces changed template contents that forgot to advance the version', async () => {
+    const { tool, templateUpgrades } = setup(plan({ fromVersion: '1.6.1', toVersion: '1.6.1' }))
+    const result = await run(tool, { apply: true, mode: 'summary' })
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: 'template_version_not_bumped' },
+      preview: { status: 'template_version_not_bumped' },
+    })
+    expect(templateUpgrades.apply).not.toHaveBeenCalled()
+  })
+})

--- a/src/tool/workspace-template-upgrade.ts
+++ b/src/tool/workspace-template-upgrade.ts
@@ -1,0 +1,217 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import type { WorkspaceToolFactory } from '../core/workspace-tool-center.js'
+import type {
+  TemplateUpgradeFilePlan,
+  TemplateUpgradePlan,
+  TemplateUpgradeResolution,
+} from '../workspaces/template-upgrade.js'
+
+type OutputMode = 'summary' | 'detailed'
+
+function fileSummary(file: TemplateUpgradeFilePlan, mode: OutputMode) {
+  return {
+    path: file.path,
+    status: file.status,
+    operation: file.operation,
+    canUseTemplate: file.canUseTemplate,
+    ...(file.note ? { note: file.note } : {}),
+    ...(mode === 'detailed'
+      ? {
+          currentPreview: file.currentPreview,
+          templatePreview: file.templatePreview,
+          currentTruncated: file.currentTruncated,
+          templateTruncated: file.templateTruncated,
+        }
+      : {}),
+  }
+}
+
+function previewPayload(plan: TemplateUpgradePlan, mode: OutputMode, explicitTarget = false) {
+  const changes = plan.files.filter((file) => file.status === 'ready')
+  const preserved = plan.files.filter((file) => file.status === 'preserved')
+  const conflicts = plan.files.filter((file) => file.status === 'conflict')
+  const sameVersion = plan.fromVersion === plan.toVersion
+  const versionMismatch = sameVersion && (changes.length > 0 || conflicts.length > 0)
+  const current = sameVersion && !versionMismatch
+  const status = plan.blocked
+    ? 'blocked'
+    : versionMismatch
+      ? 'template_version_not_bumped'
+      : current
+      ? 'current'
+      : conflicts.length > 0
+        ? 'needs_resolution'
+        : 'ready'
+
+  return {
+    status,
+    workspaceId: plan.workspaceId,
+    template: plan.template,
+    fromVersion: plan.fromVersion,
+    toVersion: plan.toVersion,
+    source: plan.source,
+    summary: plan.summary,
+    blockers: plan.blockers,
+    activity: {
+      busy: plan.activity.busy,
+      activeSessions: plan.activity.sessions.length,
+      headlessRuns: plan.activity.headless.length,
+    },
+    changes: changes.map((file) => fileSummary(file, mode)),
+    preserved: preserved.map((file) => fileSummary(file, mode)),
+    conflicts: conflicts.map((file) => fileSummary(file, mode)),
+    nextCommand: plan.blocked || current || versionMismatch
+      ? null
+      : conflicts.length > 0
+        ? 'Resolve every conflict with repeatable --keep-workspace <path> or --use-template <path>, then add --apply.'
+        : `alice-workspace template upgrade${explicitTarget ? ` --id ${plan.workspaceId}` : ''} --apply`,
+  }
+}
+
+function errorPayload(err: unknown, mode: OutputMode, explicitTarget = false) {
+  const value = err && typeof err === 'object' ? err as Record<string, unknown> : null
+  const plan = value?.['plan'] as TemplateUpgradePlan | undefined
+  return {
+    ok: false as const,
+    error: {
+      code: typeof value?.['code'] === 'string' ? value['code'] : 'upgrade_failed',
+      message: err instanceof Error ? err.message : String(err),
+    },
+    ...(plan ? { preview: previewPayload(plan, mode, explicitTarget) } : {}),
+  }
+}
+
+/**
+ * Current-Workspace template reconciliation for the embedded CLI.
+ *
+ * The default call is deliberately read-only. `--apply` is the explicit user
+ * confirmation; the tool still obtains and submits the manager's plan digest
+ * internally, so agents never need to hand-roll the HTTP transaction.
+ */
+export const workspaceTemplateUpgradeFactory: WorkspaceToolFactory = {
+  name: 'workspace_template_upgrade',
+  build(ctx) {
+    return tool({
+      description: [
+        "Preview or safely apply the current Workspace's managed template upgrade.",
+        '',
+        'Without --apply this is read-only and returns the changed, preserved, and conflicting managed files.',
+        'With --apply it re-plans and submits the exact current plan through the launcher transaction.',
+        'Omit --id for this Workspace, or pass a peer Workspace id when acting as an interactive manager.',
+        'Research, reports, Issues, credentials, runtime state, and other user files are outside the managed set.',
+        'If conflicts exist, resolve every one with repeatable --keep-workspace <path> or --use-template <path>.',
+      ].join('\n'),
+      inputSchema: z.object({
+        id: z.string().min(1).optional()
+          .describe('Workspace id to upgrade. Defaults to the current Workspace.'),
+        apply: z.boolean().optional().default(false)
+          .describe('Apply the current plan. Omit for a read-only preview.'),
+        keepWorkspace: z.array(z.string().min(1)).optional()
+          .describe('Conflict path to keep from the Workspace (repeatable; requires --apply).'),
+        useTemplate: z.array(z.string().min(1)).optional()
+          .describe('Conflict path to replace with the template copy (repeatable; requires --apply).'),
+        mode: z.enum(['summary', 'detailed']).optional().default('summary')
+          .describe('Detailed includes conflict file previews; summary is the compact default.'),
+      }),
+      execute: async ({ id, apply, keepWorkspace = [], useTemplate = [], mode }) => {
+        const manager = ctx.templateUpgrades
+        const workspaceId = id ?? ctx.workspaceId
+        const explicitTarget = id !== undefined
+        const crossWorkspace = workspaceId !== ctx.workspaceId
+        if (!manager) {
+          return {
+            ok: false as const,
+            error: {
+              code: 'unavailable',
+              message: 'Workspace template upgrades are unavailable in this context.',
+            },
+          }
+        }
+        if (!apply && (keepWorkspace.length > 0 || useTemplate.length > 0)) {
+          return {
+            ok: false as const,
+            error: {
+              code: 'apply_required',
+              message: 'Conflict resolution flags require --apply. Omit them for a read-only preview.',
+            },
+          }
+        }
+        if (apply && crossWorkspace && ctx.origin?.kind === 'headless') {
+          return {
+            ok: false as const,
+            error: {
+              code: 'interactive_required',
+              message: 'A headless run may preview a peer upgrade but cannot apply one. Ask the user to apply it interactively.',
+            },
+          }
+        }
+
+        try {
+          const plan = await manager.plan(workspaceId)
+          const preview = previewPayload(plan, mode, explicitTarget)
+          if (!apply) return { ok: true as const, action: 'preview' as const, preview }
+          if (plan.blocked) {
+            return {
+              ok: false as const,
+              error: { code: 'blocked', message: 'Prepare this Workspace before applying the upgrade.' },
+              preview,
+            }
+          }
+          const changedAtSameVersion = plan.fromVersion === plan.toVersion
+            && plan.files.some((file) => file.status === 'ready' || file.status === 'conflict')
+          if (changedAtSameVersion) {
+            return {
+              ok: false as const,
+              error: {
+                code: 'template_version_not_bumped',
+                message: 'The template contents changed without a version bump. Update the template version before applying.',
+              },
+              preview,
+            }
+          }
+          if (plan.fromVersion === plan.toVersion) {
+            return { ok: true as const, action: 'noop' as const, preview }
+          }
+
+          const conflictPaths = new Set(
+            plan.files.filter((file) => file.status === 'conflict').map((file) => file.path),
+          )
+          const duplicate = keepWorkspace.filter((path) => useTemplate.includes(path))
+          const unknown = [...keepWorkspace, ...useTemplate].filter((path) => !conflictPaths.has(path))
+          const supplied = new Set([...keepWorkspace, ...useTemplate])
+          const unresolved = [...conflictPaths].filter((path) => !supplied.has(path))
+          if (duplicate.length > 0 || unknown.length > 0 || unresolved.length > 0) {
+            return {
+              ok: false as const,
+              error: {
+                code: 'invalid_resolutions',
+                message: 'Resolve each conflict exactly once before applying.',
+                duplicate,
+                unknown,
+                unresolved,
+              },
+              preview,
+            }
+          }
+
+          const resolutions: Record<string, TemplateUpgradeResolution> = {}
+          for (const path of keepWorkspace) resolutions[path] = 'workspace'
+          for (const path of useTemplate) resolutions[path] = 'template'
+          const result = await manager.apply(workspaceId, {
+            planDigest: plan.planDigest,
+            ...(Object.keys(resolutions).length > 0 ? { resolutions } : {}),
+          })
+          return {
+            ok: true as const,
+            action: 'applied' as const,
+            result,
+          }
+        } catch (err) {
+          return errorPayload(err, mode, explicitTarget)
+        }
+      },
+    })
+  },
+}

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.6.1
+version: 1.6.2
 ---
 
 # Chat


### PR DESCRIPTION
## What changed

- add `alice-workspace template upgrade` as a read-only preview by default
- add explicit `--apply` plus repeatable per-file conflict resolutions
- allow an interactive manager Workspace to target a paused peer with `--id`
- block headless cross-Workspace apply and preserve all existing runtime/Git safety gates
- bump the Chat template to 1.6.2 and document the CLI contract

## Why

Workspace managers previously had to hand-author preview/apply HTTP requests and traffic plan digests. The embedded CLI now owns that plumbing while continuing to use the same transactional template-upgrade manager as the UI.

## Validation

- `pnpm vitest run src/tool/workspace-template-upgrade.spec.ts src/server/cli-commands.spec.ts src/server/cli.spec.ts src/workspaces/cli/shim.spec.ts src/workspaces/template-upgrade.spec.ts`
- `npx tsc --noEmit`
- `pnpm test` (2956 passed, 6 skipped)
- real shim: previewed, applied, and re-verified a 1.6.1 -> 1.6.2 peer upgrade through `alice-workspace template upgrade --id ... --apply`