### PR TITLE
feat: bootstrap source runtime build tools

### DIFF
--- a/apps/desktop/src/data-home.spec.ts
+++ b/apps/desktop/src/data-home.spec.ts
@@ -42,7 +42,7 @@ describe('desktop data-home preferences', () => {
   it('normalizes, bounds, and de-duplicates recent locations', () => {
     const homes = Array.from({ length: 10 }, (_, index) => resolve(root, String(index)))
     expect(dedupeRecentDataHomes([homes[0], homes[0], ...homes])).toEqual(homes.slice(0, 8))
-    expect(dedupeRecentDataHomes(['/Alice', '/alice'], 'win32')).toEqual(['/Alice'])
+    expect(dedupeRecentDataHomes(['/Alice', '/alice'], 'win32')).toEqual([resolve('/Alice')])
   })
 
   it('ignores relative and invalid persisted paths', () => {

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -14,7 +14,10 @@ non-authoritative and lives in
 
 ## Product Boundary
 
-The installer makes one small `openalice` command available. It does not:
+The installer always makes one small `openalice` command available. On Linux,
+it can also install the source Runtime's native build tools, but only after the
+user selects that option and approves the exact system command. By default it
+does not:
 
 - clone the OpenAlice repository;
 - install or modify Electron;
@@ -22,6 +25,11 @@ The installer makes one small `openalice` command available. It does not:
 - configure credentials or native agent CLIs;
 - expose a public listener;
 - remove user data during an update.
+
+`--with-runtime-deps` is deliberately narrower than a general machine setup
+mode. It covers Git, Python 3, make, and a C++ compiler because pnpm may need to
+compile native Node modules such as `node-pty`. It does not install Node,
+optional Agent CLIs, broker SDKs, credentials, Docker, or Electron.
 
 The current browser-local distribution remains source-backed:
 
@@ -63,6 +71,8 @@ assets and a release-owned authenticity chain; see
 - `packages/cli/src/server{,-control}.mjs` — detached lifecycle and the
   Guardian control client.
 - `packages/cli/src/remote.mjs` — consent-first managed SSH orchestration.
+- `packages/cli/src/runtime-deps.mjs` — source-build tool probe and actionable
+  local-start failure.
 - `packages/cli/src/install.spec.mjs` — plan, consent, PTY, layout, and live-lock
   contract tests.
 - `scripts/install-docker-smoke.mjs` — local Docker acceptance runner.
@@ -92,8 +102,10 @@ The durable sequence is:
 
 ```text
 preflight
+  -> optional source-build-tool selection
   -> visible install plan
   -> explicit consent
+  -> optional system package command
   -> installer lock
   -> download or local copy into staging
   -> syntax, manifest, and executable validation
@@ -107,8 +119,11 @@ preflight
   -> optional, separate localhost start prompt
 ```
 
-Nothing under the install root is created before the install plan is approved.
-The `--plan` path exits immediately after preflight and the plan.
+Nothing under the install root is created and no package manager is invoked
+before the install plan is approved. The `--plan` path exits immediately after
+preflight and the plan. System package managers are not transactional with the
+CLI install: a package-manager failure can leave packages partially updated,
+but it cannot publish a partial OpenAlice CLI release.
 
 ### Preflight and plan
 
@@ -118,26 +133,57 @@ Preflight validates:
 - Node.js availability and major version;
 - `curl` for remote installs, or CLI sources for `--source` installs;
 - target paths and shell-profile choice;
+- whether Git, Python 3, make, and a C++ compiler are already available;
+- on Linux, the supported package manager and whether root or `sudo` is
+  available when Runtime-tool installation is selected;
 - whether another `openalice` currently resolves earlier on `PATH`.
 
 The visible plan includes action, source, ref, install root, command path, shell
-change, and any PATH conflict. A check that only reads the system may happen
-before consent; no installer-owned filesystem mutation may happen there.
+change, Runtime-tool action, exact package-manager command when selected, and
+any PATH conflict. A check that only reads the system may happen before consent;
+no installer-owned filesystem mutation may happen there.
 
 ### Consent contract
 
 | Invocation | Required behavior |
 |---|---|
-| Interactive default | Ask `Continue with this install? [y/N]`; only an explicit `y` proceeds |
+| Interactive default with missing build tools | First ask whether to include the tools, then print one complete plan and ask `Continue with this install? [y/N]` |
+| Interactive default with tools ready | Print the plan and ask `Continue with this install? [y/N]`; only an explicit `y` proceeds |
 | Blank or `n` | Exit successfully without changing files |
 | No TTY and no `--yes` | Exit with code 2 before creating the install root |
-| `--yes` | Approve installation only; never start the Runtime |
+| `--yes` | Approve only the actions already selected by flags; never implies Runtime tools and never starts the Runtime |
+| `--with-runtime-deps` | Select missing Linux build tools; does not bypass the final confirmation |
 | `--plan` | Print the same plan and exit without opening a prompt or changing files |
 | Interactive install inside a checkout | After success, separately ask `Start OpenAlice now? [y/N]` |
 
-The installer reads prompts from `/dev/tty`, not the curl pipe. Both prompts are
-default-no. Installation consent and service-start consent are intentionally
-different decisions.
+The installer reads prompts from `/dev/tty`, not the curl pipe. The
+Runtime-tool selection, final plan approval, and optional service start are all
+default-no. They are intentionally different decisions. For automation,
+`--yes --with-runtime-deps` is the explicit pair that approves the displayed
+Linux package command as well as the CLI transaction.
+
+### Source Runtime build tools
+
+The Linux package mapping is:
+
+| Manager | Packages |
+|---|---|
+| `apt-get` | `git python3 make g++` |
+| `dnf`, `yum` | `git python3 make gcc-c++` |
+| `apk` | `git python3 make g++` |
+| `pacman` | `git python make gcc` |
+
+The installer uses the package manager directly as root and prefixes it with
+`sudo` otherwise. It refuses the selected action if neither authority is
+available or if the host has no supported manager. It re-probes every tool
+after the package command and fails before downloading the CLI if the machine
+is still incomplete.
+
+On macOS, the installer detects the same tool groups but does not try to launch
+the GUI-backed Command Line Tools flow over a curl pipe or SSH session. A
+selected but incomplete setup stops with the local-session instruction
+`xcode-select --install`. Native Windows remains the Electron lane; WSL follows
+the Linux contract.
 
 ### Lock and staging
 
@@ -264,6 +310,7 @@ Public options:
 |---|---|
 | `--version <git-ref>` | Select a tag, branch, or commit for remote payloads and the installed source-ref label |
 | `--install-dir <path>` | Override the OpenAlice install/user root |
+| `--with-runtime-deps` | Include missing Linux Git/Python/make/C++ source-build tools in the approved plan |
 | `--no-modify-path` | Install launchers without editing a shell profile |
 | `--plan` | Show the exact plan and make no changes |
 | `-y`, `--yes` | Explicit non-interactive installation consent |
@@ -330,6 +377,7 @@ The unit suite covers:
 - refusal without TTY or `--yes`;
 - blank-input cancellation;
 - explicit interactive approval and separate start refusal;
+- source-build-tool preflight before pnpm;
 - live installer lock rejection.
 
 ### Clean Docker acceptance
@@ -345,6 +393,11 @@ exercises the same remote-download branch as `curl | bash`. It verifies:
 - unattended refusal before the install root exists;
 - stale-lock recovery and lock cleanup;
 - downloaded payload equality;
+- default install does not invoke a package manager;
+- `--with-runtime-deps --plan` shows the exact elevated command without
+  running it;
+- approved Runtime-tool setup invokes the expected package list and re-probes
+  the resulting commands;
 - installed `server status --json` execution and inclusion of every reachable
   Server/remote module;
 - runnable shell and CMD launchers;
@@ -360,15 +413,19 @@ This is a local pre-release gate. It is intentionally not delegated to PR CI.
 pnpm test:install:docker --interactive
 ```
 
-The playground stops at the real plan and prompt, then leaves the tester in the
-clean container. Review the copy and spacing, approve with an explicit `y`, and
-run at least:
+The playground first offers the Runtime-tool choice, stops again at the real
+combined plan, and then leaves the tester in the clean container. Its fake
+offline package manager records the exact command while still exercising the
+non-root plus `sudo` branch. Review both choices, copy, and spacing, approve
+with an explicit `y`, and run at least:
 
 ```bash
 command -v openalice
 openalice --version
 cat ~/.bashrc
 curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan
+curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan --with-runtime-deps
+cat "$OPENALICE_RUNTIME_DEPS_LOG"
 ```
 
 Manual review is required when prompt text, color, progress, profile behavior,

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -41,12 +41,14 @@ The current installer distributes the small JavaScript CLI from the `dev` ref:
 curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
 ```
 
-The preview requires Node.js 20 or newer. It installs only the small CLI; it
-does not clone OpenAlice, write application state, install Electron, or start a
-service without separate consent. The curl entry targets macOS, Linux, WSL,
-and Git Bash; native Windows desktop distribution remains the signed Electron
-installer. The complete consent, update, filesystem, PATH, authenticity, and
-test contract lives in [[docs/cli-installer.md]].
+The preview requires Node.js 20 or newer. It always installs the small CLI and,
+when explicitly selected, can install missing Linux Git/Python/make/C++ tools
+needed to build the source Runtime. It does not clone OpenAlice, write
+application state, install Electron, or start a service without separate
+consent. The curl entry targets macOS, Linux, WSL, and Git Bash; native Windows
+desktop distribution remains the signed Electron installer. The complete
+consent, update, filesystem, PATH, authenticity, and test contract lives in
+[[docs/cli-installer.md]].
 
 Installer flags, non-interactive consent, development seams, the clean Docker
 fixture, and the manual prompt playground are documented only in
@@ -140,12 +142,16 @@ future standalone bundle changes preparation, not these ownership semantics.
 
 Keep bootstrap observable and layered:
 
-1. The shell installer validates Node and makes only the `openalice` command available.
-2. Local start validates the source and built artifacts, using pnpm or Corepack
-   when preparation is required.
-3. A guided setup layer should validate Git and present optional native agent
-   CLIs, installing only
-   the user's selections, with explicit commands, versions, and retry status.
+1. The shell installer validates Node and makes the `openalice` command
+   available. Its optional, explicit Linux Runtime plan installs only Git,
+   Python 3, make, and a C++ compiler.
+2. Local start validates the source and built artifacts. Before pnpm or
+   Corepack preparation, it rechecks those native build tools and points Linux
+   users back to `--with-runtime-deps` instead of exposing a late `node-gyp`
+   failure.
+3. A later guided setup layer may present optional native Agent CLIs,
+   installing only the user's selections with explicit commands, versions,
+   and retry status.
 4. A future release asset can replace the source/build requirement with a
    downloadable headless Runtime while retaining the same CLI and localhost
    contract.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -22,7 +22,8 @@ The repository now contains the source-backed Stage 0 through Stage 2 path:
 - `openalice server run|start|status|stop` provides a browserless foreground or
   detached Runtime lifecycle backed by Guardian's local control endpoint;
 - `openalice remote <target>` probes, plans, installs the ordinary CLI when
-  approved, starts or reuses the remote Server, and opens the same loopback
+  approved, installs missing Linux source-build tools when the checkout needs
+  preparation, starts or reuses the remote Server, and opens the same loopback
   tunnel;
 - Electron remains a complete local desktop distribution.
 
@@ -509,6 +510,9 @@ The read-only plan reports:
 - detected OpenAlice CLI path and version;
 - control protocol compatibility;
 - Server state and source/bundle root;
+- whether the selected source checkout already has complete Runtime artifacts;
+- missing Git, Python 3, make, or C++ tools and the package-manager action that
+  would provide them;
 - proposed install/update/start actions;
 - destination paths and whether PATH changes are required;
 - whether a running owner would be affected;
@@ -517,13 +521,18 @@ The read-only plan reports:
 Apply rules:
 
 1. no compatible CLI: ask before invoking the normal installer;
-2. compatible CLI, absent Server: start after explicit plan consent;
-3. compatible healthy Server: reuse without mutation;
-4. incompatible stopped CLI: ask before update;
-5. incompatible running Server: stop/restart or update only after a second
+2. source artifacts absent and Linux build tools missing: include
+   `--with-runtime-deps` in that same normal installer invocation after plan
+   consent;
+3. complete source artifacts: do not modify system packages merely because a
+   compiler is absent;
+4. compatible CLI, absent Server: start after explicit plan consent;
+5. compatible healthy Server: reuse without mutation;
+6. incompatible stopped CLI: ask before update;
+7. incompatible running Server: stop/restart or update only after a second
    effect-specific confirmation;
-6. owner conflict: fail unless the user separately passed `--takeover`;
-7. non-interactive mode: require flags that cover every proposed mutation.
+8. owner conflict: fail unless the user separately passed `--takeover`;
+9. non-interactive mode: require flags that cover every proposed mutation.
 
 The local orchestrator must compare protocol ranges, not only human version
 strings. It may tolerate a newer compatible Runtime, but it must fail clearly
@@ -584,6 +593,43 @@ Runtime model.
 - remaining release observation: validate ordinary Agent TUI interaction under
   representative network shaping before deciding whether Stage 3 is useful.
 
+#### Railway cold-host observation — 2026-07-15
+
+A disposable Railway Sandbox provided the first real clean-host acceptance for
+Stage 2. The host was Debian 13 x86_64 with Node 24, pnpm 11, curl, and Git. A
+fresh `dev` checkout did not have Python 3; `node-pty` had no matching bundled
+Linux x64 prebuild for that Node version, fell back to `node-gyp`, and made the
+old bootstrap fail during `pnpm install`. Installing Python 3, make, and g++
+allowed the same source preparation and detached Server start to complete.
+This failure is the reason the ordinary installer now owns the explicit Linux
+source-build-tool plan.
+
+The subsequent macOS-to-Railway loop verified:
+
+- real SSH plan, default-no confirmation boundary, CLI install, source build,
+  detached Server readiness, and local loopback tunnel;
+- a Shell Workspace Session accepted `printf 'REMOTE_PTY_OK\\n'`; the result and
+  next prompt were visible in the first observation within 500 ms;
+- closing the tunnel left the Server and Shell Session alive;
+- reconnecting on a new local port replayed the existing terminal scrollback;
+- structured `openalice server stop` returned the isolated home to `absent`.
+
+Claude Code, Codex, opencode, and Pi executables were present on that host, but
+only Shell completed an end-to-end PTY interaction. A harmless Codex prompt
+reached the remote process and failed with missing provider authentication, so
+this observation does not claim an authenticated model turn or the full Agent
+TUI matrix. No provider credentials were copied into the disposable host.
+Representative 20/80/150 ms network shaping also remains unmeasured.
+
+After the bootstrap fix, a second fresh Sandbox repeated the same cold-host
+shape with Python 3 absent. The managed plan reported only that missing tool,
+one outer confirmation authorized the normal installer, and the installer
+installed the declared Linux package set without a manual `apt` command.
+Python 3.13.5 was then available; source preparation, detached readiness, the
+real `/chat` route, tunnel disconnect, and reconnection on a new local port all
+passed. The Server was stopped through its control endpoint before the Sandbox
+was destroyed.
+
 ### Stage 3 — terminal transport optimization
 
 - build only if Stage 2 measurements justify it;
@@ -634,6 +680,8 @@ Runtime model.
 | missing remote CLI, non-interactive | fails unless explicit approval is present |
 | incompatible running Server | explains process impact before update/restart |
 | remote source missing | fails with actionable `--app-dir` guidance; no surprise clone |
+| source artifacts missing, build tools missing | plan names the tools and normal installer command; default no leaves packages untouched |
+| source artifacts complete, compiler missing | reuse artifacts without an unnecessary package-manager mutation |
 | tunnel disconnect | local command exits; remote Server and work continue |
 | reconnect | same Runtime and live terminal are reachable |
 | host-key failure | fails without disabling verification |

--- a/install
+++ b/install
@@ -7,6 +7,7 @@ SOURCE_DIR=""
 MODIFY_PATH=1
 ASSUME_YES=0
 PLAN_ONLY=0
+WITH_RUNTIME_DEPS=0
 INSTALL_ROOT="${OPENALICE_INSTALL_DIR:-${HOME}/.openalice}"
 
 BOLD=""
@@ -23,6 +24,11 @@ LOCK_HELD=0
 TTY_OPEN=0
 SHELL_LAUNCHER_TEMP=""
 CMD_LAUNCHER_TEMP=""
+RUNTIME_DEPS_MANAGER=""
+RUNTIME_DEPS_COMMAND=""
+RUNTIME_DEPS_BLOCKER=""
+RUNTIME_MISSING=()
+ELEVATE=()
 
 if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
   BOLD=$'\033[1m'
@@ -57,7 +63,7 @@ die() {
 }
 
 step() {
-  printf '\n%b[%s/4]%b %s\n' "$CYAN" "$1" "$RESET" "$2"
+  printf '\n%b[%s/5]%b %s\n' "$CYAN" "$1" "$RESET" "$2"
 }
 
 ok() {
@@ -74,12 +80,13 @@ OpenAlice CLI installer
 
 Usage:
   curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
-  ./install [--version <git-ref>] [--install-dir <path>] [--no-modify-path] [--yes]
+  ./install [--version <git-ref>] [--install-dir <path>] [--with-runtime-deps] [--no-modify-path] [--yes]
 
 Options:
   --version <git-ref>   Git tag, branch, or commit to install (default: dev)
   --install-dir <path>  OpenAlice user root (default: ~/.openalice)
   --source <path>       Install CLI files from a local checkout (development)
+  --with-runtime-deps   Install missing Linux source-build tools after consent
   --no-modify-path      Do not update the shell profile
   --plan                Show the install plan and exit without changing files
   -y, --yes             Accept the install plan without an interactive prompt
@@ -218,6 +225,92 @@ while (true) {
 NODE
 }
 
+probe_runtime_deps() {
+  RUNTIME_MISSING=()
+  command -v git >/dev/null 2>&1 || RUNTIME_MISSING+=("git")
+  command -v python3 >/dev/null 2>&1 || RUNTIME_MISSING+=("python3")
+  command -v make >/dev/null 2>&1 || RUNTIME_MISSING+=("make")
+  if ! command -v c++ >/dev/null 2>&1 \
+    && ! command -v g++ >/dev/null 2>&1 \
+    && ! command -v clang++ >/dev/null 2>&1; then
+    RUNTIME_MISSING+=("cxx")
+  fi
+}
+
+runtime_missing_text() {
+  local dependency
+  local label
+  local output=""
+  for dependency in "${RUNTIME_MISSING[@]}"; do
+    case "$dependency" in
+      git) label="Git" ;;
+      python3) label="Python 3" ;;
+      make) label="make" ;;
+      cxx) label="a C++ compiler" ;;
+    esac
+    [[ -z "$output" ]] || output+=", "
+    output+="$label"
+  done
+  printf '%s' "$output"
+}
+
+resolve_runtime_deps_plan() {
+  RUNTIME_DEPS_MANAGER=""
+  RUNTIME_DEPS_COMMAND=""
+  RUNTIME_DEPS_BLOCKER=""
+  ELEVATE=()
+  [[ ${#RUNTIME_MISSING[@]} -gt 0 ]] || return 0
+
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    RUNTIME_DEPS_BLOCKER='Automatic source Runtime prerequisite setup is currently supported on Linux. On macOS, run "xcode-select --install" in a local session, then retry.'
+    return 1
+  fi
+  if [[ "$EUID" -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      ELEVATE=(sudo)
+    else
+      RUNTIME_DEPS_BLOCKER="Installing source Runtime prerequisites requires root or sudo on this Linux host."
+      return 1
+    fi
+  fi
+
+  local prefix=""
+  [[ ${#ELEVATE[@]} -eq 0 ]] || prefix="sudo "
+  if command -v apt-get >/dev/null 2>&1; then
+    RUNTIME_DEPS_MANAGER="apt-get"
+    RUNTIME_DEPS_COMMAND="${prefix}apt-get update && ${prefix}apt-get install -y git python3 make g++"
+  elif command -v dnf >/dev/null 2>&1; then
+    RUNTIME_DEPS_MANAGER="dnf"
+    RUNTIME_DEPS_COMMAND="${prefix}dnf install -y git python3 make gcc-c++"
+  elif command -v yum >/dev/null 2>&1; then
+    RUNTIME_DEPS_MANAGER="yum"
+    RUNTIME_DEPS_COMMAND="${prefix}yum install -y git python3 make gcc-c++"
+  elif command -v apk >/dev/null 2>&1; then
+    RUNTIME_DEPS_MANAGER="apk"
+    RUNTIME_DEPS_COMMAND="${prefix}apk add --no-cache git python3 make g++"
+  elif command -v pacman >/dev/null 2>&1; then
+    RUNTIME_DEPS_MANAGER="pacman"
+    RUNTIME_DEPS_COMMAND="${prefix}pacman -Sy --needed --noconfirm git python make gcc"
+  else
+    RUNTIME_DEPS_BLOCKER="No supported Linux package manager was found (apt-get, dnf, yum, apk, or pacman)."
+    return 1
+  fi
+}
+
+install_runtime_deps() {
+  case "$RUNTIME_DEPS_MANAGER" in
+    apt-get)
+      "${ELEVATE[@]}" apt-get update
+      "${ELEVATE[@]}" apt-get install -y git python3 make g++
+      ;;
+    dnf) "${ELEVATE[@]}" dnf install -y git python3 make gcc-c++ ;;
+    yum) "${ELEVATE[@]}" yum install -y git python3 make gcc-c++ ;;
+    apk) "${ELEVATE[@]}" apk add --no-cache git python3 make g++ ;;
+    pacman) "${ELEVATE[@]}" pacman -Sy --needed --noconfirm git python make gcc ;;
+    *) die "No source Runtime prerequisite install command is available." ;;
+  esac
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --version)
@@ -237,6 +330,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-modify-path)
       MODIFY_PATH=0
+      shift
+      ;;
+    --with-runtime-deps)
+      WITH_RUNTIME_DEPS=1
       shift
       ;;
     --plan)
@@ -320,7 +417,7 @@ fi
 printf '\n%bOpenAlice%b\n' "${BOLD}${CYAN}" "$RESET"
 printf '%bLocal Runtime CLI installer%b\n\n' "$BOLD" "$RESET"
 printf 'Install one small command, then run OpenAlice locally in your browser.\n'
-printf '%bYour checkout, Electron app, credentials, and services stay untouched until you start them yourself.%b\n' "$DIM" "$RESET"
+printf '%bSystem build tools are optional and listed before consent. Your checkout, Electron app, credentials, and services otherwise stay untouched.%b\n' "$DIM" "$RESET"
 
 step 1 "Checking your system"
 if ! command -v node >/dev/null 2>&1; then
@@ -351,6 +448,38 @@ else
   fi
 fi
 
+probe_runtime_deps
+runtime_deps_ready=0
+[[ ${#RUNTIME_MISSING[@]} -gt 0 ]] || runtime_deps_ready=1
+resolve_runtime_deps_plan || true
+if [[ "$runtime_deps_ready" -eq 1 ]]; then
+  ok "Source Runtime build tools are available"
+else
+  warn "Source Runtime build tools are missing: $(runtime_missing_text)"
+fi
+
+if [[ "$WITH_RUNTIME_DEPS" -eq 0 && "$PLAN_ONLY" -eq 0 && "$ASSUME_YES" -eq 0 \
+  && "$runtime_deps_ready" -eq 0 && -z "$RUNTIME_DEPS_BLOCKER" ]]; then
+  if open_tty; then
+    printf '\nThe CLI can prepare a source checkout later, but native Node modules may need these tools.\n' >&3
+    runtime_choice=0
+    prompt_yes_no "Also install the missing source Runtime build tools?" || runtime_choice=$?
+    if [[ "$runtime_choice" -eq 0 ]]; then
+      WITH_RUNTIME_DEPS=1
+    fi
+  fi
+fi
+
+if [[ "$runtime_deps_ready" -eq 1 ]]; then
+  runtime_setup="Already ready"
+elif [[ "$WITH_RUNTIME_DEPS" -eq 1 && -z "$RUNTIME_DEPS_BLOCKER" ]]; then
+  runtime_setup="Install $(runtime_missing_text)"
+elif [[ -n "$RUNTIME_DEPS_BLOCKER" ]]; then
+  runtime_setup="Manual setup required"
+else
+  runtime_setup="Skip (use --with-runtime-deps)"
+fi
+
 printf '\n%bInstall plan%b\n' "$BOLD" "$RESET"
 printf '  %-14s %s\n' "Action" "$install_action"
 printf '  %-14s %s\n' "Source" "$install_source"
@@ -358,13 +487,27 @@ printf '  %-14s %s\n' "Version" "$VERSION"
 printf '  %-14s %s\n' "Install root" "$INSTALL_ROOT"
 printf '  %-14s %s\n' "Command" "$BIN_DIR/openalice"
 printf '  %-14s %s\n' "Shell setup" "$shell_setup"
+printf '  %-14s %s\n' "Runtime tools" "$runtime_setup"
+if [[ "$WITH_RUNTIME_DEPS" -eq 1 && "$runtime_deps_ready" -eq 0 && -n "$RUNTIME_DEPS_COMMAND" ]]; then
+  printf '  %-14s %s\n' "System command" "$RUNTIME_DEPS_COMMAND"
+elif [[ "$runtime_deps_ready" -eq 0 && -n "$RUNTIME_DEPS_BLOCKER" ]]; then
+  printf '  %-14s %s\n' "Runtime note" "$RUNTIME_DEPS_BLOCKER"
+fi
 if [[ -n "$existing_command" && "$existing_command" != "$BIN_DIR/openalice" ]]; then
   printf '  %-14s %s\n' "PATH warning" "$existing_command currently resolves first"
 fi
 
 if [[ "$PLAN_ONLY" -eq 1 ]]; then
+  if [[ "$WITH_RUNTIME_DEPS" -eq 1 && "$runtime_deps_ready" -eq 0 && -n "$RUNTIME_DEPS_BLOCKER" ]]; then
+    printf '\n%bBlocked:%b %s\n' "${RED}${BOLD}" "$RESET" "$RUNTIME_DEPS_BLOCKER" >&2
+    exit 1
+  fi
   printf '\n%bPlan complete.%b No files were changed.\n\n' "$BOLD" "$RESET"
   exit 0
+fi
+
+if [[ "$WITH_RUNTIME_DEPS" -eq 1 && "$runtime_deps_ready" -eq 0 && -n "$RUNTIME_DEPS_BLOCKER" ]]; then
+  die "$RUNTIME_DEPS_BLOCKER"
 fi
 
 if [[ "$ASSUME_YES" -eq 0 ]]; then
@@ -388,18 +531,32 @@ if [[ "$ASSUME_YES" -eq 0 ]]; then
   esac
 fi
 
+step 2 "Preparing source Runtime tools"
+if [[ "$WITH_RUNTIME_DEPS" -eq 1 && "$runtime_deps_ready" -eq 0 ]]; then
+  install_runtime_deps
+  probe_runtime_deps
+  if [[ ${#RUNTIME_MISSING[@]} -gt 0 ]]; then
+    die "The package manager finished, but source Runtime build tools are still missing: $(runtime_missing_text)"
+  fi
+  runtime_deps_ready=1
+  ok "Source Runtime build tools are ready"
+else
+  printf '      No system packages were changed.\n'
+fi
+
 FILES=(
   "package.json"
   "bin/openalice.mjs"
   "src/local-start.mjs"
   "src/remote.mjs"
+  "src/runtime-deps.mjs"
   "src/runtime-client.mjs"
   "src/server.mjs"
   "src/server-control.mjs"
   "src/ssh-connect.mjs"
 )
 
-step 2 "Downloading the CLI"
+step 3 "Downloading the CLI"
 acquire_install_lock
 STAGING="$(mktemp -d "${TMPDIR:-/tmp}/openalice-cli.XXXXXX")"
 mkdir -p "$STAGING/bin" "$STAGING/src"
@@ -416,11 +573,12 @@ else
 fi
 ok "CLI files are ready"
 
-step 3 "Verifying the CLI"
+step 4 "Verifying the CLI"
 chmod +x "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/src/local-start.mjs"
 node --check "$STAGING/src/remote.mjs"
+node --check "$STAGING/src/runtime-deps.mjs"
 node --check "$STAGING/src/runtime-client.mjs"
 node --check "$STAGING/src/server.mjs"
 node --check "$STAGING/src/server-control.mjs"
@@ -436,7 +594,7 @@ STAGED_VERSION="$(node "$STAGING/bin/openalice.mjs" --version)"
 CONTENT_ID="$(content_id "$STAGING" "${FILES[@]}")"
 ok "OpenAlice CLI $CLI_VERSION passed validation ($CONTENT_ID)"
 
-step 4 "Installing the command"
+step 5 "Installing the command"
 mkdir -p "$BIN_DIR" "$VERSIONS_DIR"
 DESTINATION="$VERSIONS_DIR/${SAFE_VERSION}-${CONTENT_ID}"
 if [[ -e "$DESTINATION" ]]; then

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,13 +10,14 @@
     "bin/openalice.mjs",
     "src/local-start.mjs",
     "src/remote.mjs",
+    "src/runtime-deps.mjs",
     "src/runtime-client.mjs",
     "src/server.mjs",
     "src/server-control.mjs",
     "src/ssh-connect.mjs"
   ],
   "scripts": {
-    "build": "node --check bin/openalice.mjs && node --check src/local-start.mjs && node --check src/remote.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs",
+    "build": "node --check bin/openalice.mjs && node --check src/local-start.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },
   "engines": {

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -31,7 +31,8 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
     ], { env: { ...process.env, HOME: home } })
 
     expect(installed.stdout).toContain('Local Runtime CLI installer')
-    expect(installed.stdout).toContain('services stay untouched until you start them yourself')
+    expect(installed.stdout).toContain('System build tools are optional and listed before consent')
+    expect(installed.stdout).toContain('No system packages were changed')
     expect(installed.stdout).toContain('Install plan')
     expect(installed.stdout).toContain('OpenAlice CLI is ready')
     const releases = await readdir(join(installRoot, 'cli-versions'))

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -10,6 +10,10 @@ import {
   probeOpenAlice,
   waitForOpenAlice,
 } from './runtime-client.mjs'
+import {
+  inspectRuntimeBuildTools,
+  runtimeBuildToolsError,
+} from './runtime-deps.mjs'
 
 const RUNTIME_ARTIFACTS = [
   'dist/main.js',
@@ -200,6 +204,12 @@ export async function prepareSourceCheckout(appDir, options, dependencies = {}) 
   const platform = dependencies.platform ?? process.platform
   const pnpmBin = configuredPnpm ?? (platform === 'win32' ? 'pnpm.cmd' : 'pnpm')
   const runCommand = dependencies.runCommand ?? runChecked
+
+  const inspectBuildTools = dependencies.inspectBuildTools ?? inspectRuntimeBuildTools
+  const buildTools = await inspectBuildTools({ platform, env })
+  if (buildTools.supported && buildTools.missing.length > 0) {
+    throw new Error(runtimeBuildToolsError(buildTools))
+  }
 
   stdout.write('Preparing the local OpenAlice Runtime (Electron is excluded)...\n')
   const installArgs = [

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -151,6 +151,7 @@ describe('OpenAlice local Runtime launcher', () => {
       rebuild: false,
     }, {
       artifactsReady: async () => artifactsReady,
+      inspectBuildTools: async () => ({ platform: 'linux', supported: true, missing: [] }),
       platform: 'linux',
       runCommand,
       stdout: { write: vi.fn() },
@@ -162,6 +163,26 @@ describe('OpenAlice local Runtime launcher', () => {
       ['corepack', ['pnpm', 'install', '--frozen-lockfile', '--filter=!@traderalice/desktop']],
       ['corepack', ['pnpm', 'build:server']],
     ])
+  })
+
+  it('fails before pnpm with an actionable native build-tool error', async () => {
+    const runCommand = vi.fn()
+    await expect(prepareSourceCheckout('/tmp/OpenAlice', {
+      prepare: true,
+      rebuild: false,
+    }, {
+      artifactsReady: async () => false,
+      inspectBuildTools: async () => ({
+        platform: 'linux',
+        supported: true,
+        missing: ['python3', 'cxx'],
+      }),
+      platform: 'linux',
+      runCommand,
+      stdout: { write: vi.fn() },
+      env: {},
+    })).rejects.toThrow('installer with --with-runtime-deps')
+    expect(runCommand).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { createInterface } from 'node:readline/promises'
 
+import { formatMissingRuntimeBuildTools } from './runtime-deps.mjs'
 import { connectSsh } from './ssh-connect.mjs'
 
 const DEFAULT_INSTALL_URL = 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install'
@@ -109,10 +110,18 @@ export async function connectRemote(options, dependencies = {}) {
   }
 
   const runRemote = dependencies.runRemote ?? runSshCommand
-  if (plan.installCli) {
+  if (plan.runInstaller) {
     const expectedRemainingMutations = remainingMutationsAfterInstall(plan)
-    stdout.write(`Installing the OpenAlice CLI on ${options.destination} with the normal installer...\n`)
-    await runRemote(options, buildRemoteInstallCommand(plan.installUrl, plan.installVersion, plan.installBaseUrl), dependencies)
+    const installerPurpose = plan.installRuntimeDeps
+      ? 'Preparing the OpenAlice CLI and source Runtime build tools'
+      : 'Installing the OpenAlice CLI'
+    stdout.write(`${installerPurpose} on ${options.destination} with the normal installer...\n`)
+    await runRemote(options, buildRemoteInstallCommand(
+      plan.installUrl,
+      plan.installVersion,
+      plan.installBaseUrl,
+      plan.installRuntimeDeps,
+    ), dependencies)
     remote = await probe(options, dependencies)
     if (!remote.cliPath || !remote.cliCompatible) {
       throw new Error('The remote OpenAlice CLI install completed, but a compatible CLI was not detected')
@@ -174,6 +183,7 @@ export function createRemotePlan(options, remote, install = {}) {
   const mutations = []
   let blocker = ''
   let installCli = false
+  let installRuntimeDeps = false
   let startServer = false
   let remotePort = options.remotePort
 
@@ -183,12 +193,12 @@ export function createRemotePlan(options, remote, install = {}) {
     blocker = 'The remote host does not have Node.js 20 or newer; install Node.js before applying this plan.'
   } else if (!nodeVersionSupported(remote.nodeVersion)) {
     blocker = `The remote host reports ${remote.nodeVersion}; OpenAlice requires Node.js 20 or newer.`
+  } else if (options.appDir && remote.sourceCheckoutPresent === false) {
+    blocker = `No OpenAlice source checkout was found at ${options.appDir}. Clone it first or pass the correct --app-dir.`
   }
 
   if (!remote.cliPath || !remote.cliCompatible) {
     installCli = true
-    mutations.push(remote.cliPath ? 'update remote OpenAlice CLI' : 'install remote OpenAlice CLI')
-    if (!remote.hasCurl && !blocker) blocker = 'The remote host does not have curl, which the normal OpenAlice installer requires.'
   }
 
   const status = remote.status
@@ -229,6 +239,21 @@ export function createRemotePlan(options, remote, install = {}) {
     }
   }
 
+  const runtimeBuildToolsMissing = remote.runtimeBuildToolsMissing ?? []
+  if (!blocker && startServer && remote.sourceArtifactsReady !== true && runtimeBuildToolsMissing.length > 0) {
+    if (remote.platform?.os === 'linux') {
+      installRuntimeDeps = true
+    } else {
+      blocker = `The remote source Runtime is missing ${formatMissingRuntimeBuildTools(runtimeBuildToolsMissing)}. Run "xcode-select --install" in a local macOS session before reconnecting.`
+    }
+  }
+  if (installRuntimeDeps) mutations.unshift('install source Runtime build tools')
+  if (installCli) mutations.unshift(remote.cliPath ? 'update remote OpenAlice CLI' : 'install remote OpenAlice CLI')
+  const runInstaller = installCli || installRuntimeDeps
+  if (runInstaller && !remote.hasCurl && !blocker) {
+    blocker = 'The remote host does not have curl, which the normal OpenAlice installer requires.'
+  }
+
   return {
     target: options.destination,
     platform: remote.platform?.label ?? 'unknown',
@@ -243,7 +268,12 @@ export function createRemotePlan(options, remote, install = {}) {
     remotePort,
     localPort: options.localPort || 'auto',
     installCli,
+    installRuntimeDeps,
+    runInstaller,
     startServer,
+    sourceCheckoutPresent: remote.sourceCheckoutPresent ?? null,
+    sourceArtifactsReady: remote.sourceArtifactsReady ?? null,
+    runtimeBuildToolsMissing,
     installUrl,
     installVersion,
     installBaseUrl,
@@ -256,7 +286,16 @@ export function formatRemotePlan(plan) {
   const actions = plan.mutations.length > 0
     ? [...plan.mutations, 'open local SSH tunnel']
     : ['reuse compatible remote CLI Server', 'open local SSH tunnel']
-  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  Node.js        ${plan.nodeVersion}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${plan.cliCompatible ? ', compatible' : ', install/update required'})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n  Source         ${plan.appDir}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.installCli ? `  Installer      ${plan.installUrl} (${plan.installVersion})\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
+  const buildTools = plan.sourceCheckoutPresent === false
+    ? 'Not inspected (source missing)'
+    : plan.sourceArtifactsReady === true
+    ? 'Not needed (built artifacts present)'
+    : plan.runtimeBuildToolsMissing.length > 0
+      ? `Missing: ${formatMissingRuntimeBuildTools(plan.runtimeBuildToolsMissing)}`
+      : plan.appDir === 'not selected'
+        ? 'Not inspected'
+        : 'Ready'
+  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  Node.js        ${plan.nodeVersion}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${plan.cliCompatible ? ', compatible' : ', install/update required'})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n  Source         ${plan.appDir}\n  Build tools    ${buildTools}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.runInstaller ? `  Installer      ${plan.installUrl} (${plan.installVersion})\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
 }
 
 export async function probeRemoteHost(options, dependencies = {}) {
@@ -266,9 +305,24 @@ export async function probeRemoteHost(options, dependencies = {}) {
   const platform = normalizeRemotePlatform(kernel, architecture)
   const nodeVersion = (await runRemote(options, 'command -v node >/dev/null 2>&1 && node --version || true', dependencies)).trim() || null
   const hasCurl = (await runRemote(options, 'command -v curl >/dev/null 2>&1 && printf yes || true', dependencies)).trim() === 'yes'
+  let sourceCheckoutPresent = null
+  let sourceArtifactsReady = null
+  let runtimeBuildToolsMissing = []
+  if (options.appDir) {
+    sourceCheckoutPresent = (await runRemote(options, buildRemoteCheckoutProbeCommand(options.appDir), dependencies)).trim() === 'present'
+    if (sourceCheckoutPresent) {
+      sourceArtifactsReady = (await runRemote(options, buildRemoteArtifactsProbeCommand(options.appDir), dependencies)).trim() === 'ready'
+    }
+    if (sourceCheckoutPresent && !sourceArtifactsReady) {
+      runtimeBuildToolsMissing = (await runRemote(options, buildRemoteBuildToolsProbeCommand(), dependencies))
+        .trim()
+        .split(/\r?\n/)
+        .filter((value) => ['git', 'python3', 'make', 'cxx'].includes(value))
+    }
+  }
   const cliPath = normalizeRemoteCliPath((await runRemote(options, 'command -v openalice 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/openalice" ] || printf "%s\\n" "$HOME/.openalice/bin/openalice"; }', dependencies)).trim())
   if (!cliPath) {
-    return { platform, nodeVersion, hasCurl, cliPath: null, cliVersion: null, cliCompatible: false, status: null }
+    return { platform, nodeVersion, hasCurl, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, cliPath: null, cliVersion: null, cliCompatible: false, status: null }
   }
 
   let cliVersion = null
@@ -282,7 +336,21 @@ export async function probeRemoteHost(options, dependencies = {}) {
   } catch {
     cliCompatible = false
   }
-  return { platform, nodeVersion, hasCurl, cliPath, cliVersion, cliCompatible, status }
+  return { platform, nodeVersion, hasCurl, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, cliPath, cliVersion, cliCompatible, status }
+}
+
+export function buildRemoteCheckoutProbeCommand(appDir) {
+  const manifest = shellQuote(`${appDir.replace(/\/$/, '')}/package.json`)
+  return `test -f ${manifest} && grep -Eq '"name"[[:space:]]*:[[:space:]]*"open-alice"' ${manifest} && printf present || true`
+}
+
+export function buildRemoteArtifactsProbeCommand(appDir) {
+  const root = shellQuote(appDir)
+  return `root=${root}\ntest -f "$root/dist/main.js" \\\n  && test -f "$root/ui/dist/index.html" \\\n  && test -f "$root/services/uta/dist/uta.js" \\\n  && test -f "$root/services/connector/dist/connector.cjs" \\\n  && test -f "$root/packages/guardian-runtime/dist/index.js" \\\n  && test -d "$root/node_modules" \\\n  && printf ready || true`
+}
+
+export function buildRemoteBuildToolsProbeCommand() {
+  return `command -v git >/dev/null 2>&1 || printf 'git\\n'\ncommand -v python3 >/dev/null 2>&1 || printf 'python3\\n'\ncommand -v make >/dev/null 2>&1 || printf 'make\\n'\n{ command -v c++ >/dev/null 2>&1 || command -v g++ >/dev/null 2>&1 || command -v clang++ >/dev/null 2>&1; } || printf 'cxx\\n'`
 }
 
 export function buildRemoteStatusCommand(options, cliPath) {
@@ -305,11 +373,12 @@ export function buildRemoteServerStartCommand(options, cliPath) {
   return args.join(' ')
 }
 
-export function buildRemoteInstallCommand(installUrl, installVersion, installBaseUrl = '') {
+export function buildRemoteInstallCommand(installUrl, installVersion, installBaseUrl = '', withRuntimeDeps = false) {
   const url = shellQuote(installUrl)
   const version = shellQuote(installVersion)
   const installEnv = installBaseUrl ? `OPENALICE_INSTALL_BASE_URL=${shellQuote(installBaseUrl)} ` : ''
-  return `set -eu\ntmp=$(mktemp "${'${TMPDIR:-/tmp}'}/openalice-install.XXXXXX")\ntrap 'rm -f "$tmp"' EXIT HUP INT TERM\ncurl -fsSL ${url} -o "$tmp"\n${installEnv}bash "$tmp" --yes --no-modify-path --version ${version}`
+  const runtimeDepsFlag = withRuntimeDeps ? ' --with-runtime-deps' : ''
+  return `set -eu\ntmp=$(mktemp "${'${TMPDIR:-/tmp}'}/openalice-install.XXXXXX")\ntrap 'rm -f "$tmp"' EXIT HUP INT TERM\ncurl -fsSL ${url} -o "$tmp"\n${installEnv}bash "$tmp" --yes --no-modify-path --version ${version}${runtimeDepsFlag}`
 }
 
 export function buildRemoteSshArgs(options, remoteCommand) {
@@ -436,7 +505,10 @@ function remoteRuntimePort(status) {
 }
 
 function remainingMutationsAfterInstall(plan) {
-  return plan.mutations.filter((mutation) => !/^(install|update) remote OpenAlice CLI$/.test(mutation))
+  return plan.mutations.filter((mutation) => (
+    !/^(install|update) remote OpenAlice CLI$/.test(mutation)
+    && mutation !== 'install source Runtime build tools'
+  ))
 }
 
 function validateSshDestination(destination) {

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  buildRemoteArtifactsProbeCommand,
+  buildRemoteBuildToolsProbeCommand,
+  buildRemoteCheckoutProbeCommand,
   buildRemoteInstallCommand,
   buildRemoteServerStartCommand,
   buildRemoteSshArgs,
@@ -53,14 +56,19 @@ describe('OpenAlice managed remote connector', () => {
       platform: { os: 'linux', label: 'Linux x86_64' },
       nodeVersion: 'v22.0.0',
       hasCurl: true,
+      sourceCheckoutPresent: true,
+      sourceArtifactsReady: false,
+      runtimeBuildToolsMissing: ['git', 'python3', 'make', 'cxx'],
       cliPath: null,
       cliCompatible: false,
       status: null,
     })
     expect(plan.installCli).toBe(true)
+    expect(plan.installRuntimeDeps).toBe(true)
     expect(plan.startServer).toBe(true)
     expect(plan.mutations).toEqual([
       'install remote OpenAlice CLI',
+      'install source Runtime build tools',
       'start remote OpenAlice Server',
     ])
     expect(plan.blocker).toBe('')
@@ -78,6 +86,38 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.installCli).toBe(false)
     expect(plan.startServer).toBe(false)
     expect(plan.blocker).toBe('')
+  })
+
+  it('does not install build tools when a source Runtime is already built', () => {
+    const plan = createRemotePlan(parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice']), {
+      ...missingRemote(),
+      sourceArtifactsReady: true,
+    })
+    expect(plan.installRuntimeDeps).toBe(false)
+    expect(plan.mutations).toEqual([
+      'install remote OpenAlice CLI',
+      'start remote OpenAlice Server',
+    ])
+  })
+
+  it('blocks remote macOS prerequisite installation with local-session guidance', () => {
+    const plan = createRemotePlan(parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice']), {
+      ...missingRemote(),
+      platform: { os: 'darwin', label: 'Darwin arm64' },
+    })
+    expect(plan.blocker).toContain('xcode-select --install')
+    expect(plan.installRuntimeDeps).toBe(false)
+  })
+
+  it('blocks a missing checkout before proposing system-package changes', () => {
+    const plan = createRemotePlan(parseRemoteArgs(['host', '--app-dir', '/srv/missing']), {
+      ...missingRemote(),
+      sourceCheckoutPresent: false,
+      runtimeBuildToolsMissing: ['python3'],
+    })
+    expect(plan.blocker).toContain('Clone it first')
+    expect(plan.installRuntimeDeps).toBe(false)
+    expect(plan.mutations).toEqual(['install remote OpenAlice CLI'])
   })
 
   it('uses the detected Server port and blocks an explicit mismatch', () => {
@@ -162,6 +202,7 @@ describe('OpenAlice managed remote connector', () => {
       'https://example.test/install',
       'dev-test',
       'https://example.test/packages/cli/',
+      true,
     ))
     expect(runRemote.mock.calls[1][1]).toContain('server start')
     expect(connectTunnel).toHaveBeenCalledWith(expect.objectContaining({
@@ -195,6 +236,15 @@ describe('OpenAlice managed remote connector', () => {
     expect(connectTunnel).not.toHaveBeenCalled()
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('refreshed plan'))
   })
+
+  it('builds read-only remote probes without interpolating source paths as shell code', () => {
+    const probe = buildRemoteArtifactsProbeCommand("/srv/Alice's source")
+    expect(probe).toContain("root='/srv/Alice'\\''s source'")
+    expect(probe).toContain('test -f "$root/dist/main.js"')
+    expect(buildRemoteCheckoutProbeCommand("/srv/Alice's source"))
+      .toContain("'/srv/Alice'\\''s source/package.json'")
+    expect(buildRemoteBuildToolsProbeCommand()).toContain("printf 'cxx\\n'")
+  })
 })
 
 function missingRemote() {
@@ -202,6 +252,9 @@ function missingRemote() {
     platform: { os: 'linux', label: 'Linux x86_64' },
     nodeVersion: 'v22.0.0',
     hasCurl: true,
+    sourceCheckoutPresent: true,
+    sourceArtifactsReady: false,
+    runtimeBuildToolsMissing: ['git', 'python3', 'make', 'cxx'],
     cliPath: null,
     cliVersion: null,
     cliCompatible: false,
@@ -214,6 +267,9 @@ function compatibleRemote(statusOverrides = {}) {
     platform: { os: 'linux', label: 'Linux x86_64' },
     nodeVersion: 'v22.0.0',
     hasCurl: true,
+    sourceCheckoutPresent: null,
+    sourceArtifactsReady: null,
+    runtimeBuildToolsMissing: [],
     cliPath: '/home/alice/.openalice/bin/openalice',
     cliVersion: '0.2.0',
     cliCompatible: true,

--- a/packages/cli/src/runtime-deps.mjs
+++ b/packages/cli/src/runtime-deps.mjs
@@ -1,0 +1,68 @@
+import { spawn } from 'node:child_process'
+
+export const RUNTIME_BUILD_TOOL_GROUPS = [
+  { id: 'git', label: 'Git', commands: ['git'] },
+  { id: 'python3', label: 'Python 3', commands: ['python3'] },
+  { id: 'make', label: 'make', commands: ['make'] },
+  { id: 'cxx', label: 'a C++ compiler', commands: ['c++', 'g++', 'clang++'] },
+]
+
+export async function inspectRuntimeBuildTools(dependencies = {}) {
+  const platform = dependencies.platform ?? process.platform
+  if (!['linux', 'darwin'].includes(platform)) {
+    return { platform, supported: false, missing: [] }
+  }
+
+  const commandAvailable = dependencies.commandAvailable ?? executableAvailable
+  const missing = []
+  for (const group of RUNTIME_BUILD_TOOL_GROUPS) {
+    let found = false
+    for (const command of group.commands) {
+      if (await commandAvailable(command, dependencies)) {
+        found = true
+        break
+      }
+    }
+    if (!found) missing.push(group.id)
+  }
+  return { platform, supported: true, missing }
+}
+
+export function formatMissingRuntimeBuildTools(missing) {
+  const labels = new Map(RUNTIME_BUILD_TOOL_GROUPS.map((group) => [group.id, group.label]))
+  return missing.map((id) => labels.get(id) ?? id).join(', ')
+}
+
+export function runtimeBuildToolsError(report) {
+  const missing = formatMissingRuntimeBuildTools(report.missing)
+  if (report.platform === 'linux') {
+    return `Source Runtime build tools are missing: ${missing}. Re-run the OpenAlice installer with --with-runtime-deps, or install them with your system package manager before retrying.`
+  }
+  if (report.platform === 'darwin') {
+    return `Source Runtime build tools are missing: ${missing}. Run "xcode-select --install" in a local macOS session, then retry.`
+  }
+  return `Source Runtime build tools are missing: ${missing}. Install them before retrying.`
+}
+
+function executableAvailable(command, dependencies = {}) {
+  const spawnProcess = dependencies.spawnProcess ?? spawn
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawnProcess(command, ['--version'], {
+      env: dependencies.env ?? process.env,
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+    let settled = false
+    child.once('error', (error) => {
+      if (settled) return
+      settled = true
+      if (error?.code === 'ENOENT') resolvePromise(false)
+      else rejectPromise(error)
+    })
+    child.once('exit', () => {
+      if (settled) return
+      settled = true
+      resolvePromise(true)
+    })
+  })
+}

--- a/packages/cli/src/runtime-deps.spec.mjs
+++ b/packages/cli/src/runtime-deps.spec.mjs
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  formatMissingRuntimeBuildTools,
+  inspectRuntimeBuildTools,
+  runtimeBuildToolsError,
+} from './runtime-deps.mjs'
+
+describe('OpenAlice source Runtime build tools', () => {
+  it('accepts alternative C++ compiler commands', async () => {
+    const available = new Set(['git', 'python3', 'make', 'clang++'])
+    const commandAvailable = vi.fn(async (command) => available.has(command))
+
+    await expect(inspectRuntimeBuildTools({
+      platform: 'linux',
+      commandAvailable,
+    })).resolves.toEqual({ platform: 'linux', supported: true, missing: [] })
+    expect(commandAvailable).toHaveBeenCalledWith('clang++', expect.any(Object))
+  })
+
+  it('reports stable user-facing labels and platform guidance', async () => {
+    const report = await inspectRuntimeBuildTools({
+      platform: 'linux',
+      commandAvailable: async (command) => command === 'git',
+    })
+    expect(report.missing).toEqual(['python3', 'make', 'cxx'])
+    expect(formatMissingRuntimeBuildTools(report.missing)).toBe('Python 3, make, a C++ compiler')
+    expect(runtimeBuildToolsError(report)).toContain('--with-runtime-deps')
+  })
+})

--- a/packages/cli/src/server.spec.mjs
+++ b/packages/cli/src/server.spec.mjs
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { resolve } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
 
@@ -92,7 +93,7 @@ describe('OpenAlice Server CLI', () => {
       detached: true,
       stdio: ['ignore', 9, 9],
       env: expect.objectContaining({
-        OPENALICE_HOME: '/tmp/alice-home',
+        OPENALICE_HOME: resolve('/tmp/alice-home'),
         OPENALICE_BIND_HOST: '127.0.0.1',
         OPENALICE_WEB_PORT: '41000',
         OPENALICE_LAUNCHER: 'cli-server',

--- a/scripts/guardian/dev-options.spec.ts
+++ b/scripts/guardian/dev-options.spec.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { parseDevGuardianOptions } from './dev-options.js'
@@ -5,17 +7,17 @@ import { parseDevGuardianOptions } from './dev-options.js'
 describe('parseDevGuardianOptions', () => {
   it('resolves a separate development home from the checkout directory', () => {
     expect(parseDevGuardianOptions(['--', '--home', '../openalice-homes/feature-a'], '/repo/OpenAlice'))
-      .toEqual({ home: '/repo/openalice-homes/feature-a' })
+      .toEqual({ home: resolve('/repo/OpenAlice', '../openalice-homes/feature-a') })
   })
 
   it('supports equals syntax and leaves other Guardian options alone', () => {
     expect(parseDevGuardianOptions(['--takeover', '--home=/tmp/openalice feature']))
-      .toEqual({ home: '/tmp/openalice feature' })
+      .toEqual({ home: resolve('/tmp/openalice feature') })
   })
 
   it('uses the final home when a wrapper supplied more than one', () => {
     expect(parseDevGuardianOptions(['--home', '/tmp/first', '--home=/tmp/second']))
-      .toEqual({ home: '/tmp/second' })
+      .toEqual({ home: resolve('/tmp/second') })
   })
 
   it('rejects a missing home path before any process starts', () => {

--- a/scripts/install-smoke/Dockerfile
+++ b/scripts/install-smoke/Dockerfile
@@ -13,6 +13,7 @@ COPY --chown=smoke:smoke install /fixture/install
 COPY --chown=smoke:smoke packages/cli /fixture/packages/cli
 COPY --chown=smoke:smoke scripts/install-smoke/interactive.sh /fixture/interactive.sh
 COPY --chown=smoke:smoke scripts/install-smoke/run.sh /fixture/run.sh
+COPY --chown=smoke:smoke scripts/install-smoke/fake-package-manager.sh /fixture/fake-package-manager.sh
 COPY --chown=smoke:smoke scripts/install-smoke/static-server.mjs /fixture/static-server.mjs
 
 USER smoke

--- a/scripts/install-smoke/fake-package-manager.sh
+++ b/scripts/install-smoke/fake-package-manager.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="$(basename "$0")"
+if [[ "$command_name" == "sudo" ]]; then
+  exec "$@"
+fi
+if [[ "$command_name" != "apt-get" ]]; then
+  echo "fake package manager: unsupported command $command_name" >&2
+  exit 1
+fi
+
+: "${OPENALICE_RUNTIME_DEPS_SHIM_DIR:?runtime dependency shim directory is required}"
+: "${OPENALICE_RUNTIME_DEPS_LOG:?runtime dependency log is required}"
+printf 'apt-get %s\n' "$*" >> "$OPENALICE_RUNTIME_DEPS_LOG"
+
+if [[ "${1:-}" == "update" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" != "install" ]]; then
+  echo "fake apt-get: unsupported arguments: $*" >&2
+  exit 1
+fi
+
+for tool in git python3 make g++ c++; do
+  printf '#!/usr/bin/env sh\nexit 0\n' > "$OPENALICE_RUNTIME_DEPS_SHIM_DIR/$tool"
+  chmod +x "$OPENALICE_RUNTIME_DEPS_SHIM_DIR/$tool"
+done

--- a/scripts/install-smoke/interactive.sh
+++ b/scripts/install-smoke/interactive.sh
@@ -12,12 +12,23 @@ server_pid=$!
 cleanup() {
   kill "$server_pid" >/dev/null 2>&1 || true
   wait "$server_pid" >/dev/null 2>&1 || true
+  [[ -z "${runtime_fixture_bin:-}" ]] || rm -rf "$runtime_fixture_bin"
+  [[ -z "${runtime_deps_log:-}" ]] || rm -f "$runtime_deps_log"
   rm -f "$server_log"
 }
 trap cleanup EXIT
 
 export OPENALICE_INSTALL_URL="http://127.0.0.1:18080/install"
 export OPENALICE_INSTALL_BASE_URL="http://127.0.0.1:18080/packages/cli/"
+runtime_fixture_bin="$(mktemp -d)"
+runtime_deps_log="$(mktemp)"
+cp /fixture/fake-package-manager.sh "$runtime_fixture_bin/fake-package-manager"
+chmod +x "$runtime_fixture_bin/fake-package-manager"
+ln -s fake-package-manager "$runtime_fixture_bin/apt-get"
+ln -s fake-package-manager "$runtime_fixture_bin/sudo"
+export OPENALICE_RUNTIME_DEPS_SHIM_DIR="$runtime_fixture_bin"
+export OPENALICE_RUNTIME_DEPS_LOG="$runtime_deps_log"
+export PATH="$runtime_fixture_bin:$PATH"
 
 for _ in $(seq 1 100); do
   if curl --fail --silent --output /dev/null "$OPENALICE_INSTALL_URL"; then
@@ -32,7 +43,8 @@ curl --fail --silent --output /dev/null "$OPENALICE_INSTALL_URL" || {
 
 printf '\n[install-playground] Clean container ready: non-root, empty HOME, no pnpm, no external network.\n'
 printf '[install-playground] Starting the same curl installer a user will see.\n\n'
-printf '[install-playground] The installer will pause at its plan. Type y and press Enter to approve it.\n\n'
+printf '[install-playground] The installer first asks about source build tools, then pauses at the complete plan.\n'
+printf '[install-playground] Choose either path and inspect every command before approving it.\n\n'
 curl -fsSL "$OPENALICE_INSTALL_URL" | bash
 
 if [[ -x "$HOME/.openalice/bin/openalice" ]]; then
@@ -43,6 +55,8 @@ printf '\n[install-playground] You are now in the container after the installer.
 printf 'Try: command -v openalice; openalice --version; cat ~/.bashrc\n'
 printf 'Re-run: curl -fsSL "$OPENALICE_INSTALL_URL" | bash\n'
 printf 'Preview only: curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan\n'
+printf 'Runtime plan: curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan --with-runtime-deps\n'
+printf 'Package log: cat "$OPENALICE_RUNTIME_DEPS_LOG"\n'
 printf 'After a successful re-run: source ~/.bashrc\n'
 printf 'Leave: exit\n\n'
 export PS1='openalice-install> '

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -14,12 +14,22 @@ fi
 
 server_log="$(mktemp)"
 refusal_log="$(mktemp)"
+runtime_deps_log="$(mktemp)"
+runtime_fixture_bin="$(mktemp -d)"
+cp /fixture/fake-package-manager.sh "$runtime_fixture_bin/fake-package-manager"
+chmod +x "$runtime_fixture_bin/fake-package-manager"
+ln -s fake-package-manager "$runtime_fixture_bin/apt-get"
+ln -s fake-package-manager "$runtime_fixture_bin/sudo"
+export OPENALICE_RUNTIME_DEPS_SHIM_DIR="$runtime_fixture_bin"
+export OPENALICE_RUNTIME_DEPS_LOG="$runtime_deps_log"
+export PATH="$runtime_fixture_bin:$PATH"
 node /fixture/static-server.mjs >"$server_log" 2>&1 &
 server_pid=$!
 cleanup() {
   kill "$server_pid" >/dev/null 2>&1 || true
   wait "$server_pid" >/dev/null 2>&1 || true
-  rm -f "$server_log" "$refusal_log"
+  rm -rf "$runtime_fixture_bin"
+  rm -f "$server_log" "$refusal_log" "$runtime_deps_log"
 }
 trap cleanup EXIT
 
@@ -52,6 +62,11 @@ install_version() {
   curl -fsSL "$installer_url" | bash -s -- --yes --version "$version"
 }
 
+install_version_with_runtime_deps() {
+  local version="$1"
+  curl -fsSL "$installer_url" | bash -s -- --yes --with-runtime-deps --version "$version"
+}
+
 mkdir -p "$HOME/.openalice/.cli-install.lock"
 printf '99999999\n' > "$HOME/.openalice/.cli-install.lock/pid"
 install_version smoke-v1
@@ -73,6 +88,8 @@ cmp /fixture/packages/cli/src/local-start.mjs "$v1_release/src/local-start.mjs" 
   || fail "downloaded CLI file differs from the fixture"
 cmp /fixture/packages/cli/src/remote.mjs "$v1_release/src/remote.mjs" \
   || fail "downloaded Remote CLI file differs from the fixture"
+cmp /fixture/packages/cli/src/runtime-deps.mjs "$v1_release/src/runtime-deps.mjs" \
+  || fail "downloaded Runtime dependency probe differs from the fixture"
 cmp /fixture/packages/cli/src/server.mjs "$v1_release/src/server.mjs" \
   || fail "downloaded Server CLI file differs from the fixture"
 cmp /fixture/packages/cli/src/server-control.mjs "$v1_release/src/server-control.mjs" \
@@ -83,6 +100,20 @@ path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
 [[ "$path_count" == "1" ]] || fail "installer did not add exactly one shell PATH entry"
 [[ "$(grep -Fxc '# >>> OpenAlice CLI >>>' "$HOME/.bashrc" || true)" == "1" ]] \
   || fail "installer did not add its managed PATH block"
+
+[[ ! -s "$runtime_deps_log" ]] || fail "default install changed system packages"
+runtime_plan="$(curl -fsSL "$installer_url" | bash -s -- --plan --with-runtime-deps --version smoke-v1)"
+grep -Fq "sudo apt-get update && sudo apt-get install -y git python3 make g++" <<<"$runtime_plan" \
+  || fail "runtime dependency plan did not show the exact package command"
+[[ ! -s "$runtime_deps_log" ]] || fail "runtime dependency plan changed system packages"
+
+install_version_with_runtime_deps smoke-v1
+grep -Fxq "apt-get update" "$runtime_deps_log" || fail "runtime dependency setup skipped apt-get update"
+grep -Fxq "apt-get install -y git python3 make g++" "$runtime_deps_log" \
+  || fail "runtime dependency setup used the wrong package list"
+for tool in git python3 make g++; do
+  command -v "$tool" >/dev/null 2>&1 || fail "runtime dependency setup did not provide $tool"
+done
 
 install_version smoke-v1
 path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"


### PR DESCRIPTION
## Summary

- add an explicit, consent-first `--with-runtime-deps` installer path for Linux Git, Python, make, and C++ tooling
- make local and managed-remote source preparation preflight native build tools, while reusing complete artifacts without system package changes
- extend automated/manual installer smokes, document the Railway cold-host acceptance, and fix host-specific Windows path assertions found by the prior PR checks

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (2985 passed, 6 skipped)
- `pnpm test:install:docker`
- `pnpm test:install:docker --interactive` (manual opt-in and command-log walk)
- `pnpm test:remote:docker`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- fresh Railway Sandbox: missing Python detected, installer supplied prerequisites, source build/server/browser/reconnect/structured stop passed

## Residual observation

- the real Railway Shell PTY and reconnect path passed; authenticated Claude/Codex/opencode/Pi turns and representative network shaping remain separate observations