### PR TITLE
fix: harden remote workspace startup

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -190,8 +190,15 @@ uses the normal `pi` command path.
 
 Pi project trust follows the runtime boundary:
 
-- interactive sessions never receive `--approve`; Pi shows its trust prompt
-  and the user makes the project-resource decision;
+- before TUI or WebPi startup, the Pi adapter records a genuinely undecided
+  OpenAlice-managed Workspace in the trust store used by that Pi process. This
+  prevents a fresh Quick Chat from stalling behind a terminal-only trust
+  selector that WebPi cannot render;
+- an explicit saved allow or deny decision on the Workspace or its nearest
+  parent remains authoritative. OpenAlice never flips that decision;
+- interactive argv does not receive the version-sensitive `--approve` flag.
+  External Pi 0.78.x therefore remains launch-compatible while Pi 0.79+ reads
+  its normal `trust.json` state;
 - packaged headless sessions pass `--approve` because no user is present and
   OpenAlice controls the pinned managed Pi and Workspace contents;
 - source/dev headless sessions do not receive version-specific approval flags.
@@ -201,6 +208,11 @@ Pi project trust follows the runtime boundary:
 Do not add external-Pi version probing or upgrade UX to preserve flags used by
 the packaged runtime. Compatibility for the packaged app is maintained by
 pinning and upgrading the bundled Pi with the OpenAlice release.
+
+When a Workspace has a `.pi-agent/` provider override, its trust file lives in
+that redirected agent directory. Otherwise OpenAlice updates Pi's normal agent
+directory; it must not create `.pi-agent/` solely for trust because doing so
+would hide the user's global Pi settings and extensions.
 
 ### Codex interactive permissions
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -197,8 +197,10 @@ openalice remote <target> --app-dir <remote-checkout>
    or require a second explicit takeover decision;
 7. run `openalice server start --app-dir ...` remotely and wait for readiness;
 8. create the same loopback tunnel used by `openalice ssh`;
-9. open or print the local URL and stay in the foreground to own only the
-   tunnel.
+9. reuse the last successful local port for this target and remote home when it
+   is available, so an existing browser tab can reconnect to the same origin;
+10. open or print the local URL and stay in the foreground to own only the
+    tunnel.
 
 When reusing a healthy Server, `remote` takes the loopback web port from the
 versioned status response. An explicitly supplied `--remote-port` must match
@@ -224,6 +226,11 @@ contract.
 `--yes` may approve the displayed install/update/start plan for automation, but
 it never implies `--takeover`. Non-interactive execution without a sufficient
 explicit approval fails without remote mutation.
+
+The remembered local port is user-local connection state, not remote Runtime
+state. An explicit `--local-port` wins. If an automatically remembered port is
+already occupied, `remote` reports the conflict, allocates a free loopback port,
+and remembers the replacement only after the tunnel passes OpenAlice readiness.
 
 ## Server Lifecycle
 
@@ -373,6 +380,9 @@ protocol is required.
 - preserve interactive SSH authentication when a terminal is available;
 - use keepalives without overriding stronger user config;
 - exit clearly when the local port cannot bind or the remote forward fails;
+- for managed `openalice remote`, prefer the last successful per-target local
+  port so the old browser origin can recover after a tunnel reconnect, and
+  visibly fall back when that port is occupied;
 - never disable host-key checking;
 - never expose the Guardian control endpoint.
 
@@ -534,6 +544,15 @@ Apply rules:
 8. owner conflict: fail unless the user separately passed `--takeover`;
 9. non-interactive mode: require flags that cover every proposed mutation.
 
+Remote SSH commands retry a small allowlist of transport failures (connection
+reset/timeout/close, key-verifier service interruption, and SSH identification
+exchange failures). Arbitrary remote command failures are never retried. After
+an approved installer or Server-start action loses its SSH transport, managed
+remote re-probes the versioned state: it continues only when the intended CLI
+or Server is already present and compatible, otherwise it returns the original
+failure. Source preparation uses compact phase output and suppresses successful
+package/build chatter; a failed phase still includes a bounded diagnostic tail.
+
 The local orchestrator must compare protocol ranges, not only human version
 strings. It may tolerate a newer compatible Runtime, but it must fail clearly
 when a method or schema is unsupported. Development overrides for a local CLI
@@ -611,7 +630,9 @@ The subsequent macOS-to-Railway loop verified:
 - a Shell Workspace Session accepted `printf 'REMOTE_PTY_OK\\n'`; the result and
   next prompt were visible in the first observation within 500 ms;
 - closing the tunnel left the Server and Shell Session alive;
-- reconnecting on a new local port replayed the existing terminal scrollback;
+- reconnecting replayed the existing terminal scrollback; current managed
+  remote also reuses the last successful local port when it remains available,
+  allowing the original browser tab and origin to recover;
 - structured `openalice server stop` returned the isolated home to `absent`.
 
 Claude Code, Codex, opencode, and Pi executables were present on that host, but
@@ -629,6 +650,16 @@ Python 3.13.5 was then available; source preparation, detached readiness, the
 real `/chat` route, tunnel disconnect, and reconnection on a new local port all
 passed. The Server was stopped through its control endpoint before the Sandbox
 was destroyed.
+
+A 2026-07-15 Railway regression run then exercised the hardened reconnect path
+against another fresh Sandbox. Successful source preparation printed only the
+install/build phases; two naturally occurring Railway SSH interruptions
+(`Connection closed` followed by the temporary key-verifier outage) were
+retried and recovered without repeating a completed mutation. Three tunnel
+connections all selected the same remembered local port. A browser tab left
+open across the final disconnect first showed its normal fetch failure, then
+recovered in place after the tunnel returned on the same origin. The Server was
+stopped through its control endpoint and the Sandbox was destroyed.
 
 ### Stage 3 — terminal transport optimization
 
@@ -683,7 +714,8 @@ was destroyed.
 | source artifacts missing, build tools missing | plan names the tools and normal installer command; default no leaves packages untouched |
 | source artifacts complete, compiler missing | reuse artifacts without an unnecessary package-manager mutation |
 | tunnel disconnect | local command exits; remote Server and work continue |
-| reconnect | same Runtime and live terminal are reachable |
+| reconnect | same local port is preferred; same Runtime, browser origin, and live terminal are reachable; a busy port falls back visibly |
+| transient SSH loss after apply | retry known transport faults; re-probe completed install/start state before deciding failure |
 | host-key failure | fails without disabling verification |
 | SSH agent/passphrase path | preserves normal OpenSSH interaction |
 | browser security | same-origin HTTP/WS works; public Origin remains rejected |

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -23,6 +23,7 @@ const RUNTIME_ARTIFACTS = [
   'packages/guardian-runtime/dist/index.js',
   'node_modules',
 ]
+const MAX_PREPARE_ERROR_OUTPUT_BYTES = 64 * 1024
 
 export function parseLocalStartArgs(argv) {
   const options = {
@@ -204,6 +205,8 @@ export async function prepareSourceCheckout(appDir, options, dependencies = {}) 
   const platform = dependencies.platform ?? process.platform
   const pnpmBin = configuredPnpm ?? (platform === 'win32' ? 'pnpm.cmd' : 'pnpm')
   const runCommand = dependencies.runCommand ?? runChecked
+  const compactOutput = env['OPENALICE_PREPARE_OUTPUT'] === 'compact'
+  const commandOptions = { cwd: appDir, env, platform, output: compactOutput ? 'capture' : 'inherit' }
 
   const inspectBuildTools = dependencies.inspectBuildTools ?? inspectRuntimeBuildTools
   const buildTools = await inspectBuildTools({ platform, env })
@@ -211,7 +214,7 @@ export async function prepareSourceCheckout(appDir, options, dependencies = {}) 
     throw new Error(runtimeBuildToolsError(buildTools))
   }
 
-  stdout.write('Preparing the local OpenAlice Runtime (Electron is excluded)...\n')
+  stdout.write(`${compactOutput ? 'Preparing the OpenAlice Server' : 'Preparing the local OpenAlice Runtime (Electron is excluded)'}...\n`)
   const installArgs = [
     'install',
     '--frozen-lockfile',
@@ -219,15 +222,18 @@ export async function prepareSourceCheckout(appDir, options, dependencies = {}) 
   ]
   const buildArgs = ['build:server']
   try {
-    await runCommand(pnpmBin, installArgs, { cwd: appDir, env, platform })
-    await runCommand(pnpmBin, buildArgs, { cwd: appDir, env, platform })
+    if (compactOutput) stdout.write('  Installing source dependencies...\n')
+    await runCommand(pnpmBin, installArgs, commandOptions)
+    if (compactOutput) stdout.write('  Building source Runtime...\n')
+    await runCommand(pnpmBin, buildArgs, commandOptions)
   } catch (error) {
     if (configuredPnpm || error?.code !== 'ENOENT') throw error
     const corepackBin = platform === 'win32' ? 'corepack.cmd' : 'corepack'
     stdout.write('pnpm is not on PATH; using Corepack with the repository-pinned pnpm version.\n')
     try {
-      await runCommand(corepackBin, ['pnpm', ...installArgs], { cwd: appDir, env, platform })
-      await runCommand(corepackBin, ['pnpm', ...buildArgs], { cwd: appDir, env, platform })
+      await runCommand(corepackBin, ['pnpm', ...installArgs], commandOptions)
+      if (compactOutput) stdout.write('  Building source Runtime...\n')
+      await runCommand(corepackBin, ['pnpm', ...buildArgs], commandOptions)
     } catch (corepackError) {
       if (corepackError?.code === 'ENOENT') {
         throw new Error('Could not find pnpm or Corepack. Install pnpm 11, then retry.')
@@ -295,13 +301,22 @@ function holdRuntime(runtime) {
 
 function runChecked(command, args, options) {
   return new Promise((resolvePromise, rejectPromise) => {
+    const captureOutput = options.output === 'capture'
     const child = spawn(command, args, {
       cwd: options.cwd,
       env: options.env ?? process.env,
       shell: options.platform === 'win32',
-      stdio: 'inherit',
+      stdio: captureOutput ? ['inherit', 'pipe', 'pipe'] : 'inherit',
       windowsHide: true,
     })
+    let outputTail = ''
+    const rememberOutput = (chunk) => {
+      outputTail = `${outputTail}${chunk}`.slice(-MAX_PREPARE_ERROR_OUTPUT_BYTES)
+    }
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+    child.stdout?.on('data', rememberOutput)
+    child.stderr?.on('data', rememberOutput)
     child.once('error', (error) => {
       if (error?.code === 'ENOENT') {
         const missing = new Error(`Could not find ${command}`)
@@ -313,7 +328,10 @@ function runChecked(command, args, options) {
     })
     child.once('exit', (code, signal) => {
       if (code === 0) resolvePromise()
-      else rejectPromise(new Error(`${command} ${args.join(' ')} failed (code=${String(code)}, signal=${String(signal)})`))
+      else {
+        const details = outputTail.trim()
+        rejectPromise(new Error(`${command} ${args.join(' ')} failed (code=${String(code)}, signal=${String(signal)})${details ? `\n\n${details}` : ''}`))
+      }
     })
   })
 }

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -165,6 +165,32 @@ describe('OpenAlice local Runtime launcher', () => {
     ])
   })
 
+  it('uses compact phase output and captures successful remote build noise', async () => {
+    let artifactsReady = false
+    const runCommand = vi.fn(async (_command, args) => {
+      if (args.at(-1) === 'build:server') artifactsReady = true
+    })
+    const stdout = { write: vi.fn() }
+
+    await expect(prepareSourceCheckout('/tmp/OpenAlice', {
+      prepare: true,
+      rebuild: false,
+    }, {
+      artifactsReady: async () => artifactsReady,
+      inspectBuildTools: async () => ({ platform: 'linux', supported: true, missing: [] }),
+      platform: 'linux',
+      runCommand,
+      stdout,
+      env: { OPENALICE_PREPARE_OUTPUT: 'compact' },
+    })).resolves.toEqual({ prepared: true })
+
+    expect(runCommand).toHaveBeenCalledTimes(2)
+    expect(runCommand.mock.calls[0][2]).toEqual(expect.objectContaining({ output: 'capture' }))
+    expect(stdout.write).toHaveBeenCalledWith('Preparing the OpenAlice Server...\n')
+    expect(stdout.write).toHaveBeenCalledWith('  Installing source dependencies...\n')
+    expect(stdout.write).toHaveBeenCalledWith('  Building source Runtime...\n')
+  })
+
   it('fails before pnpm with an actionable native build-tool error', async () => {
     const runCommand = vi.fn()
     await expect(prepareSourceCheckout('/tmp/OpenAlice', {

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -1,4 +1,8 @@
 import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
 import { createInterface } from 'node:readline/promises'
 
 import { formatMissingRuntimeBuildTools } from './runtime-deps.mjs'
@@ -6,6 +10,16 @@ import { connectSsh } from './ssh-connect.mjs'
 
 const DEFAULT_INSTALL_URL = 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install'
 const MAX_SSH_OUTPUT_BYTES = 1024 * 1024
+const REMOTE_STATE_VERSION = 1
+const MAX_REMEMBERED_TARGETS = 32
+const TRANSIENT_SSH_PATTERNS = [
+  /can't verify your ssh key right now/i,
+  /temporary service issue/i,
+  /connection (?:reset|timed out|closed)/i,
+  /kex_exchange_identification/i,
+  /ssh_exchange_identification/i,
+  /operation timed out/i,
+]
 
 export function parseRemoteArgs(argv) {
   const options = {
@@ -87,9 +101,15 @@ export function parseRemoteArgs(argv) {
 export async function connectRemote(options, dependencies = {}) {
   const stdout = dependencies.stdout ?? process.stdout
   const env = dependencies.env ?? process.env
+  const rememberedLocalPort = options.localPort === 0
+    ? await readRememberedRemotePort(options, { ...dependencies, env })
+    : null
+  const connectionOptions = rememberedLocalPort === null
+    ? options
+    : { ...options, preferredLocalPort: rememberedLocalPort }
   const probe = dependencies.probeRemote ?? probeRemoteHost
-  let remote = await probe(options, dependencies)
-  let plan = createRemotePlan(options, remote, {
+  let remote = await probe(connectionOptions, dependencies)
+  let plan = createRemotePlan(connectionOptions, remote, {
     installUrl: dependencies.installUrl ?? env['OPENALICE_REMOTE_INSTALL_URL'] ?? DEFAULT_INSTALL_URL,
     installVersion: dependencies.installVersion ?? env['OPENALICE_REMOTE_VERSION'] ?? 'dev',
     installBaseUrl: dependencies.installBaseUrl ?? env['OPENALICE_REMOTE_INSTALL_BASE_URL'] ?? '',
@@ -116,13 +136,29 @@ export async function connectRemote(options, dependencies = {}) {
       ? 'Preparing the OpenAlice CLI and source Runtime build tools'
       : 'Installing the OpenAlice CLI'
     stdout.write(`${installerPurpose} on ${options.destination} with the normal installer...\n`)
-    await runRemote(options, buildRemoteInstallCommand(
-      plan.installUrl,
-      plan.installVersion,
-      plan.installBaseUrl,
-      plan.installRuntimeDeps,
-    ), dependencies)
-    remote = await probe(options, dependencies)
+    let installerError = null
+    try {
+      const output = await runRemote(connectionOptions, buildRemoteInstallCommand(
+        plan.installUrl,
+        plan.installVersion,
+        plan.installBaseUrl,
+        plan.installRuntimeDeps,
+      ), dependencies)
+      writeRemoteActionOutput(stdout, output)
+    } catch (error) {
+      installerError = error
+      stdout.write('The SSH action ended unexpectedly; checking whether the remote install completed...\n')
+    }
+    try {
+      remote = await probe(connectionOptions, dependencies)
+    } catch (probeError) {
+      throw installerError ?? probeError
+    }
+    if (installerError && remote.cliCompatible && (!plan.installRuntimeDeps || (remote.runtimeBuildToolsMissing ?? []).length === 0)) {
+      stdout.write('The remote install completed before the disconnect; continuing from detected state.\n')
+    } else if (installerError) {
+      throw installerError
+    }
     if (!remote.cliPath || !remote.cliCompatible) {
       throw new Error('The remote OpenAlice CLI install completed, but a compatible CLI was not detected')
     }
@@ -149,8 +185,24 @@ export async function connectRemote(options, dependencies = {}) {
 
   if (plan.startServer) {
     stdout.write(`${options.takeover ? 'Replacing' : 'Starting'} the OpenAlice Server on ${options.destination}...\n`)
-    await runRemote(options, buildRemoteServerStartCommand(options, remote.cliPath), dependencies)
-    remote = await probe(options, dependencies)
+    let startError = null
+    try {
+      const output = await runRemote(connectionOptions, buildRemoteServerStartCommand(connectionOptions, remote.cliPath), dependencies)
+      writeRemoteActionOutput(stdout, output)
+    } catch (error) {
+      startError = error
+      stdout.write('The SSH action ended unexpectedly; checking whether the remote Server became ready...\n')
+    }
+    try {
+      remote = await probe(connectionOptions, dependencies)
+    } catch (probeError) {
+      throw startError ?? probeError
+    }
+    if (startError && remote.status?.class === 'running' && remote.status?.owner?.surface === 'cli-server') {
+      stdout.write('The remote Server became ready before the disconnect; continuing from detected state.\n')
+    } else if (startError) {
+      throw startError
+    }
   }
   if (remote.status?.class !== 'running' || remote.status?.owner?.surface !== 'cli-server') {
     throw new Error(`Remote OpenAlice Server is not ready after apply (${remote.status?.class ?? 'no status'})`)
@@ -168,11 +220,20 @@ export async function connectRemote(options, dependencies = {}) {
   return openTunnel({
     destination: options.destination,
     localPort: options.localPort,
+    preferredLocalPort: rememberedLocalPort,
     remotePort: runtimePort,
     sshPort: options.sshPort,
     identityFile: options.identityFile,
     openBrowser: options.openBrowser,
     waitMs: options.waitMs,
+    onReady: async ({ localPort }) => {
+      try {
+        await rememberRemotePort(options, localPort, { ...dependencies, env })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        stdout.write(`OpenAlice could not remember this tunnel port (${message}).\n`)
+      }
+    },
   }, dependencies)
 }
 
@@ -266,7 +327,7 @@ export function createRemotePlan(options, remote, install = {}) {
     appDir: options.appDir || 'not selected',
     remoteHome: options.remoteHome || '~/.openalice (remote default)',
     remotePort,
-    localPort: options.localPort || 'auto',
+    localPort: options.localPort || (options.preferredLocalPort ? `${options.preferredLocalPort} (remembered)` : 'auto'),
     installCli,
     installRuntimeDeps,
     runInstaller,
@@ -370,7 +431,7 @@ export function buildRemoteServerStartCommand(options, cliPath) {
   ]
   if (options.remoteHome) args.push('--home', shellQuote(options.remoteHome))
   if (options.takeover) args.push('--takeover')
-  return args.join(' ')
+  return `OPENALICE_PREPARE_OUTPUT=compact TURBO_TELEMETRY_DISABLED=1 DO_NOT_TRACK=1 ${args.join(' ')}`
 }
 
 export function buildRemoteInstallCommand(installUrl, installVersion, installBaseUrl = '', withRuntimeDeps = false) {
@@ -393,14 +454,35 @@ export function buildRemoteSshArgs(options, remoteCommand) {
   return args
 }
 
-export function runSshCommand(options, remoteCommand, dependencies = {}) {
+export async function runSshCommand(options, remoteCommand, dependencies = {}) {
+  const sleep = dependencies.sleep ?? ((ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
+  const stdout = dependencies.stdout ?? process.stdout
+  let lastError
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return await runSshCommandOnce(options, remoteCommand, dependencies)
+    } catch (error) {
+      lastError = error
+      if (attempt >= 3 || !isTransientSshError(error)) throw error
+      const delayMs = attempt * 750
+      stdout.write(`SSH transport was interrupted; retrying in ${delayMs}ms (${attempt}/2)...\n`)
+      await sleep(delayMs)
+    }
+  }
+  throw lastError
+}
+
+function runSshCommandOnce(options, remoteCommand, dependencies = {}) {
   const spawnProcess = dependencies.spawnProcess ?? spawn
+  const stderrOutput = dependencies.stderr ?? process.stderr
   const child = spawnProcess('ssh', buildRemoteSshArgs(options, remoteCommand), {
-    stdio: ['inherit', 'pipe', 'inherit'],
+    stdio: ['inherit', 'pipe', 'pipe'],
     windowsHide: true,
   })
   child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
   let stdout = ''
+  let stderr = ''
   return new Promise((resolvePromise, rejectPromise) => {
     let settled = false
     const finish = (error, value) => {
@@ -417,12 +499,64 @@ export function runSshCommand(options, remoteCommand, dependencies = {}) {
         finish(new Error('Remote SSH command produced too much output'))
       }
     })
+    child.stderr.on('data', (chunk) => {
+      if (settled) return
+      stderr += chunk
+      stderrOutput.write(chunk)
+      if (Buffer.byteLength(stderr, 'utf8') > MAX_SSH_OUTPUT_BYTES) {
+        child.kill('SIGTERM')
+        finish(createSshCommandError('Remote SSH command produced too much error output', stdout, stderr))
+      }
+    })
     child.once('error', (error) => finish(error))
     child.once('exit', (code, signal) => {
       if (code === 0) finish(null, stdout)
-      else finish(new Error(`Remote SSH command failed (code=${String(code)}, signal=${String(signal)})`))
+      else finish(createSshCommandError(
+        `Remote SSH command failed (code=${String(code)}, signal=${String(signal)})`,
+        stdout,
+        stderr,
+      ))
     })
   })
+}
+
+export async function readRememberedRemotePort(options, dependencies = {}) {
+  const statePath = remoteStatePath(dependencies.env ?? process.env, dependencies.homeDir)
+  try {
+    const state = JSON.parse(await (dependencies.readFileImpl ?? readFile)(statePath, 'utf8'))
+    if (state?.version !== REMOTE_STATE_VERSION || !state.targets || typeof state.targets !== 'object') return null
+    const port = state.targets[remoteTargetKey(options)]?.localPort
+    return Number.isInteger(port) && port >= 1 && port <= 65_535 ? port : null
+  } catch {
+    return null
+  }
+}
+
+export async function rememberRemotePort(options, localPort, dependencies = {}) {
+  if (!Number.isInteger(localPort) || localPort < 1 || localPort > 65_535) return
+  const statePath = remoteStatePath(dependencies.env ?? process.env, dependencies.homeDir)
+  const readFileImpl = dependencies.readFileImpl ?? readFile
+  let state = { version: REMOTE_STATE_VERSION, targets: {} }
+  try {
+    const existing = JSON.parse(await readFileImpl(statePath, 'utf8'))
+    if (existing?.version === REMOTE_STATE_VERSION && existing.targets && typeof existing.targets === 'object') {
+      state = existing
+    }
+  } catch {
+    // Missing or malformed local state should never block a remote connection.
+  }
+  state.targets[remoteTargetKey(options)] = { localPort, updatedAt: new Date().toISOString() }
+  const entries = Object.entries(state.targets)
+    .sort(([, left], [, right]) => String(right?.updatedAt ?? '').localeCompare(String(left?.updatedAt ?? '')))
+    .slice(0, MAX_REMEMBERED_TARGETS)
+  state.targets = Object.fromEntries(entries)
+  const mkdirImpl = dependencies.mkdirImpl ?? mkdir
+  const writeFileImpl = dependencies.writeFileImpl ?? writeFile
+  const renameImpl = dependencies.renameImpl ?? rename
+  await mkdirImpl(dirname(statePath), { recursive: true })
+  const temporaryPath = `${statePath}.${process.pid}.${Date.now()}.tmp`
+  await writeFileImpl(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 })
+  await renameImpl(temporaryPath, statePath)
 }
 
 export async function confirmRemotePlan(message, dependencies = {}) {
@@ -509,6 +643,38 @@ function remainingMutationsAfterInstall(plan) {
     !/^(install|update) remote OpenAlice CLI$/.test(mutation)
     && mutation !== 'install source Runtime build tools'
   ))
+}
+
+function writeRemoteActionOutput(stdout, output) {
+  const text = String(output ?? '').trim()
+  if (text) stdout.write(`${text}\n`)
+}
+
+function createSshCommandError(message, stdout, stderr) {
+  const error = new Error(message)
+  error.stdout = stdout
+  error.stderr = stderr
+  return error
+}
+
+function isTransientSshError(error) {
+  const details = [error?.message, error?.stderr].filter(Boolean).join('\n')
+  return TRANSIENT_SSH_PATTERNS.some((pattern) => pattern.test(details))
+}
+
+function remoteStatePath(env, homeDir) {
+  return env['OPENALICE_REMOTE_STATE_FILE']
+    || join(homeDir ?? homedir(), '.openalice', 'state', 'remote-targets.json')
+}
+
+function remoteTargetKey(options) {
+  return createHash('sha256')
+    .update(JSON.stringify([
+      options.destination,
+      options.sshPort ?? 22,
+      options.remoteHome || '~/.openalice',
+    ]))
+    .digest('hex')
 }
 
 function validateSshDestination(destination) {

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -1,3 +1,7 @@
+import { EventEmitter } from 'node:events'
+import { rm } from 'node:fs/promises'
+import { PassThrough } from 'node:stream'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -10,6 +14,8 @@ import {
   connectRemote,
   createRemotePlan,
   parseRemoteArgs,
+  readRememberedRemotePort,
+  runSshCommand,
 } from './remote.mjs'
 
 describe('OpenAlice managed remote connector', () => {
@@ -141,6 +147,8 @@ describe('OpenAlice managed remote connector', () => {
     expect(command).toContain("'/opt/Alice'\\''s bin/openalice'")
     expect(command).toContain("'/srv/Alice'\\''s source'")
     expect(command).toContain("'/srv/Alice'\\''s home'")
+    expect(command).toContain('OPENALICE_PREPARE_OUTPUT=compact')
+    expect(command).toContain('TURBO_TELEMETRY_DISABLED=1')
     expect(buildRemoteSshArgs(options, command)).toEqual(expect.arrayContaining([
       '-i', '/tmp/id key', 'host', command,
     ]))
@@ -212,6 +220,85 @@ describe('OpenAlice managed remote connector', () => {
     }), expect.any(Object))
   })
 
+  it('continues when an interrupted installer or Server start actually completed remotely', async () => {
+    const options = parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice', '--yes', '--no-open'])
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(missingRemote())
+      .mockResolvedValueOnce(compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} }))
+      .mockResolvedValueOnce(compatibleRemote())
+    const runRemote = vi.fn()
+      .mockRejectedValueOnce(new Error('connection closed'))
+      .mockRejectedValueOnce(new Error('connection reset'))
+    const stdout = { write: vi.fn() }
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      connectTunnel: async () => 0,
+      stdout,
+    })).resolves.toBe(0)
+
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('remote install completed before the disconnect'))
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('remote Server became ready before the disconnect'))
+  })
+
+  it('remembers the successful local port per remote target and reuses it next time', async () => {
+    const stateFile = `/tmp/openalice-remote-state-${process.pid}-${Date.now()}.json`
+    const env = { OPENALICE_REMOTE_STATE_FILE: stateFile }
+    const options = parseRemoteArgs(['host', '--no-open'])
+    const connectTunnel = vi.fn(async (tunnelOptions) => {
+      await tunnelOptions.onReady({ localPort: 40126, localUrl: 'http://127.0.0.1:40126' })
+      return 0
+    })
+    await connectRemote(options, {
+      env,
+      probeRemote: async () => compatibleRemote(),
+      connectTunnel,
+      stdout: { write: vi.fn() },
+    })
+    expect(await readRememberedRemotePort(options, { env })).toBe(40126)
+
+    await connectRemote(options, {
+      env,
+      probeRemote: async () => compatibleRemote(),
+      connectTunnel,
+      stdout: { write: vi.fn() },
+    })
+    expect(connectTunnel.mock.calls[1][0]).toEqual(expect.objectContaining({
+      preferredLocalPort: 40126,
+    }))
+    await rm(stateFile, { force: true })
+  })
+
+  it('retries only transient SSH transport failures', async () => {
+    const spawnProcess = vi.fn()
+      .mockImplementationOnce(() => commandChild({ code: 255, stderr: "Railway can't verify your SSH key right now\n" }))
+      .mockImplementationOnce(() => commandChild({ code: 255, stderr: 'Connection reset by peer\n' }))
+      .mockImplementationOnce(() => commandChild({ code: 0, stdout: 'ready\n' }))
+    const sleep = vi.fn(async () => undefined)
+
+    await expect(runSshCommand(parseRemoteArgs(['host']), 'printf ready', {
+      spawnProcess,
+      sleep,
+      stdout: { write: vi.fn() },
+      stderr: { write: vi.fn() },
+    })).resolves.toBe('ready\n')
+    expect(spawnProcess).toHaveBeenCalledTimes(3)
+    expect(sleep).toHaveBeenNthCalledWith(1, 750)
+    expect(sleep).toHaveBeenNthCalledWith(2, 1500)
+  })
+
+  it('does not retry an ordinary remote command failure', async () => {
+    const spawnProcess = vi.fn(() => commandChild({ code: 1, stderr: 'remote command rejected\n' }))
+    await expect(runSshCommand(parseRemoteArgs(['host']), 'exit 1', {
+      spawnProcess,
+      sleep: vi.fn(async () => undefined),
+      stdout: { write: vi.fn() },
+      stderr: { write: vi.fn() },
+    })).rejects.toThrow('Remote SSH command failed')
+    expect(spawnProcess).toHaveBeenCalledOnce()
+  })
+
   it('re-plans after install and never replaces a newly discovered owner implicitly', async () => {
     const options = parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice', '--yes'])
     const probeRemote = vi.fn()
@@ -246,6 +333,19 @@ describe('OpenAlice managed remote connector', () => {
     expect(buildRemoteBuildToolsProbeCommand()).toContain("printf 'cxx\\n'")
   })
 })
+
+function commandChild({ code, stdout = '', stderr = '' }) {
+  const child = new EventEmitter()
+  child.stdout = new PassThrough()
+  child.stderr = new PassThrough()
+  child.kill = vi.fn()
+  queueMicrotask(() => {
+    if (stdout) child.stdout.write(stdout)
+    if (stderr) child.stderr.write(stderr)
+    child.emit('exit', code, null)
+  })
+  return child
+}
 
 function missingRemote() {
   return {

--- a/packages/cli/src/ssh-connect.mjs
+++ b/packages/cli/src/ssh-connect.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { createServer } from 'node:net'
 import {
   LOOPBACK,
   allocateLoopbackPort,
@@ -81,11 +82,21 @@ export function buildSshArgs(options, localPort) {
 
 export async function connectSsh(options, dependencies = {}) {
   const allocatePort = dependencies.allocatePort ?? allocateLoopbackPort
+  const portAvailable = dependencies.portAvailable ?? isLoopbackPortAvailable
   const spawnProcess = dependencies.spawnProcess ?? spawn
   const waitForRuntime = dependencies.waitForRuntime ?? waitForOpenAlice
   const launchBrowser = dependencies.launchBrowser ?? openBrowser
   const stdout = dependencies.stdout ?? process.stdout
-  const localPort = options.localPort || await allocatePort()
+  let localPort = options.localPort
+  if (!localPort && options.preferredLocalPort) {
+    if (await portAvailable(options.preferredLocalPort)) {
+      localPort = options.preferredLocalPort
+    } else {
+      localPort = await allocatePort()
+      stdout.write(`Remembered local port ${options.preferredLocalPort} is busy; using ${localPort} instead.\n`)
+    }
+  }
+  if (!localPort) localPort = await allocatePort()
   const localUrl = `http://${LOOPBACK}:${localPort}`
   const ssh = spawnProcess('ssh', buildSshArgs(options, localPort), {
     stdio: ['inherit', 'ignore', 'inherit'],
@@ -109,11 +120,30 @@ export async function connectSsh(options, dependencies = {}) {
     stdout.write(`OpenAlice remote runtime: ${options.destination}\n`)
     stdout.write(`Local OpenAlice UI: ${localUrl}\n`)
     stdout.write('The SSH tunnel stays active until this command exits. Press Ctrl+C to close it.\n')
+    if (options.onReady) await options.onReady({ localPort, localUrl })
     if (options.openBrowser) await launchBrowser(localUrl)
     return await holdTunnel(ssh)
   } catch (error) {
     ssh.kill('SIGTERM')
     throw error
+  }
+}
+
+export async function isLoopbackPortAvailable(port, dependencies = {}) {
+  const createServerImpl = dependencies.createServerImpl ?? createServer
+  const server = createServerImpl()
+  try {
+    await new Promise((resolvePromise, rejectPromise) => {
+      server.once('error', rejectPromise)
+      server.listen({ host: LOOPBACK, port, exclusive: true }, resolvePromise)
+    })
+    return true
+  } catch {
+    return false
+  } finally {
+    if (server.listening) {
+      await new Promise((resolvePromise) => server.close(() => resolvePromise()))
+    }
   }
 }
 

--- a/packages/cli/src/ssh-connect.spec.mjs
+++ b/packages/cli/src/ssh-connect.spec.mjs
@@ -89,6 +89,47 @@ describe('OpenAlice SSH connector', () => {
     ]), expect.any(Object))
   })
 
+  it('reuses a remembered port and reports the ready URL to its owner', async () => {
+    const child = new FakeChild()
+    const onReady = vi.fn(async () => undefined)
+    const result = connectSsh({
+      ...parseSshConnectArgs(['host', '--no-open']),
+      preferredLocalPort: 40124,
+      onReady,
+    }, {
+      portAvailable: async () => true,
+      spawnProcess: () => child,
+      waitForRuntime: async () => ({ authed: true }),
+      stdout: { write: vi.fn() },
+    })
+    await vi.waitFor(() => expect(onReady).toHaveBeenCalledWith({
+      localPort: 40124,
+      localUrl: 'http://127.0.0.1:40124',
+    }))
+    child.emit('exit', 0, null)
+    await expect(result).resolves.toBe(0)
+  })
+
+  it('falls back cleanly when a remembered port is occupied', async () => {
+    const child = new FakeChild()
+    const stdout = { write: vi.fn() }
+    const spawnProcess = vi.fn(() => child)
+    const result = connectSsh({
+      ...parseSshConnectArgs(['host', '--no-open']),
+      preferredLocalPort: 40124,
+    }, {
+      portAvailable: async () => false,
+      allocatePort: async () => 40125,
+      spawnProcess,
+      waitForRuntime: async () => ({ authed: true }),
+      stdout,
+    })
+    await vi.waitFor(() => expect(spawnProcess).toHaveBeenCalled())
+    child.emit('exit', 0, null)
+    await expect(result).resolves.toBe(0)
+    expect(stdout.write).toHaveBeenCalledWith('Remembered local port 40124 is busy; using 40125 instead.\n')
+  })
+
   it('uses argv-based browser launchers on each desktop platform', async () => {
     for (const [platform, command] of [['darwin', 'open'], ['linux', 'xdg-open'], ['win32', 'cmd.exe']]) {
       const child = { unref: vi.fn() }

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -107,7 +107,7 @@ try {
   run('ssh', [remoteTarget, 'test ! -x "$HOME/.openalice/bin/openalice"'], { env: smokeEnv })
 
   console.log('[remote-ssh-smoke] applying install/start and opening first tunnel')
-  await attachAndProbe(remoteTarget, smokeEnv, [
+  const firstTunnelUrl = await attachAndProbe(remoteTarget, smokeEnv, [
     '--app-dir', '/fixture/OpenAlice',
     '--yes', '--no-open', '--wait', '30',
   ])
@@ -121,7 +121,10 @@ try {
     cliEntry, 'remote', remoteTarget, '--plan', '--no-open',
   ], { cwd: repoRoot, env: smokeEnv })
   requireText(reusePlan, 'reuse compatible remote CLI Server')
-  await attachAndProbe(remoteTarget, smokeEnv, ['--no-open', '--wait', '30'])
+  const reconnectedTunnelUrl = await attachAndProbe(remoteTarget, smokeEnv, ['--no-open', '--wait', '30'])
+  if (reconnectedTunnelUrl !== firstTunnelUrl) {
+    throw new Error(`Reconnect changed the remembered browser origin (${firstTunnelUrl} -> ${reconnectedTunnelUrl})`)
+  }
 
   console.log('[remote-ssh-smoke] stopping the remote Server through its control endpoint')
   run('ssh', [remoteTarget, '"$HOME/.openalice/bin/openalice" server stop --wait 15'], { env: smokeEnv })
@@ -198,6 +201,7 @@ async function attachAndProbe(target, env, remoteArgs) {
   child.kill('SIGTERM')
   const exit = await waitForExit(child, 10_000)
   if (exit.code !== 0) throw new Error(`remote CLI did not close cleanly after tunnel disconnect (${JSON.stringify(exit)})`)
+  return url
 }
 
 function waitForExit(child, timeoutMs) {

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -6,16 +6,16 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { claudeAdapter } from './claude.js';
 import { codexAdapter } from './codex.js';
 import { opencodeAdapter } from './opencode.js';
-import { piAdapter, syncPiWindowsShellPath } from './pi.js';
+import { piAdapter, syncPiProjectTrust, syncPiWindowsShellPath } from './pi.js';
 
 let dir: string;
 
@@ -408,6 +408,45 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
 
 describe('piAdapter AI-config', () => {
   const mcpEnv = { OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp', AQ_WS_ID: 'ws-abc' };
+
+  it('records a new OpenAlice workspace in Pi global trust without forcing agent-dir redirection', async () => {
+    const home = join(dir, 'home');
+    await syncPiProjectTrust(dir, { HOME: home });
+    const canonicalDir = await realpath(dir);
+
+    expect(JSON.parse(await readFile(join(home, '.pi/agent/trust.json'), 'utf8'))).toEqual({
+      [canonicalDir]: true,
+    });
+    expect(piAdapter.composeEnv!({ cwd: dir, env: { HOME: home } })).toEqual({});
+  });
+
+  it('writes trust beside a workspace provider and preserves an explicit parent refusal', async () => {
+    await mkdir(join(dir, '.pi-agent'), { recursive: true });
+    await syncPiProjectTrust(dir, { HOME: join(dir, 'unused-home') });
+    const canonicalDir = await realpath(dir);
+    expect(JSON.parse(await read('.pi-agent/trust.json'))).toEqual({ [canonicalDir]: true });
+
+    const parent = dirname(canonicalDir);
+    const refused = join(dir, 'refused');
+    await mkdir(refused, { recursive: true });
+    const home = join(dir, 'refused-home');
+    await mkdir(join(home, '.pi/agent'), { recursive: true });
+    await writeFile(join(home, '.pi/agent/trust.json'), JSON.stringify({ [parent]: false }));
+    await syncPiProjectTrust(refused, { HOME: home });
+    expect(JSON.parse(await readFile(join(home, '.pi/agent/trust.json'), 'utf8'))).toEqual({
+      [parent]: false,
+    });
+  });
+
+  it('preserves a malformed Pi-owned trust store instead of blocking launch or overwriting it', async () => {
+    const home = join(dir, 'malformed-home');
+    const trustPath = join(home, '.pi/agent/trust.json');
+    await mkdir(dirname(trustPath), { recursive: true });
+    await writeFile(trustPath, '{ user is repairing this');
+
+    await expect(syncPiProjectTrust(dir, { HOME: home })).resolves.toBeUndefined();
+    expect(await readFile(trustPath, 'utf8')).toBe('{ user is repairing this');
+  });
 
   it('composeCommand leaves project trust to Pi and the user', () => {
     expect(piAdapter.composeCommand(['ignored'], { cwd: dir, env: mcpEnv })).toEqual(['pi']);

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { mkdir, readFile, realpath, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
 
 import { runtimeProfileFromEnv } from '@/core/runtime-profile.js';
 import { resolveBashPath } from '@/core/shell-resolver.js';
@@ -21,6 +22,9 @@ const PI_AGENT_DIR = '.pi-agent';
 const PI_MODELS_PATH = `${PI_AGENT_DIR}/models.json`;
 const PI_SETTINGS_PATH = `${PI_AGENT_DIR}/settings.json`;
 const PI_PROVIDER_NAME = 'workspace';
+const PI_TRUST_FILENAME = 'trust.json';
+
+let piTrustWriteQueue: Promise<void> = Promise.resolve();
 
 function positiveNumber(value: number | null | undefined): number | null {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
@@ -61,6 +65,104 @@ export async function syncPiWindowsShellPath(
     PI_SETTINGS_PATH,
     JSON.stringify({ ...settings, shellPath }, null, 2) + '\n',
   );
+}
+
+/**
+ * OpenAlice Workspaces are created, registered, and launched through the
+ * Workspace service. Pi 0.79+ otherwise stops its first interactive launch at
+ * a project-resource trust selector because OpenAlice injects `.agents/skills`.
+ * Record the managed Workspace as trusted before either the TUI or WebPi RPC
+ * process starts, while preserving any explicit trust/no-trust decision the
+ * user already saved for this directory or one of its parents.
+ *
+ * Pi uses the redirected `.pi-agent` directory whenever a Workspace credential
+ * is installed; without that override it uses the user's normal agent dir.
+ * Writing to the directory Pi will actually read avoids creating `.pi-agent`
+ * just for trust (which would accidentally hide the user's global Pi config).
+ */
+export async function syncPiProjectTrust(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const run = async (): Promise<void> => {
+    const workspaceAgentDir = join(cwd, PI_AGENT_DIR);
+    const configuredAgentDir = env['PI_CODING_AGENT_DIR']?.trim();
+    const agentDir = existsSync(workspaceAgentDir)
+      ? workspaceAgentDir
+      : configuredAgentDir
+        ? resolve(configuredAgentDir)
+        : join(resolve(env['HOME']?.trim() || homedir()), '.pi', 'agent');
+    const trustPath = join(agentDir, PI_TRUST_FILENAME);
+    const canonicalCwd = await realpath(cwd).catch(() => resolve(cwd));
+    const trust = await readPiTrustFile(trustPath);
+    if (trust === null) return;
+
+    // Pi applies the nearest saved parent decision. Respect an explicit yes or
+    // no; only fill the genuinely undecided first-run case.
+    if (nearestPiTrustDecision(trust, canonicalCwd) !== null) return;
+    trust[canonicalCwd] = true;
+
+    await mkdir(agentDir, { recursive: true });
+    const tempPath = `${trustPath}.openalice-${process.pid}`;
+    await writeFile(tempPath, `${JSON.stringify(sortPiTrust(trust), null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    await rename(tempPath, trustPath);
+  };
+
+  // Several Workspaces can bootstrap concurrently. Serialize read/merge/write
+  // inside this process so one Workspace never drops another's trust entry.
+  const queued = piTrustWriteQueue.then(run, run);
+  piTrustWriteQueue = queued.catch(() => undefined);
+  await queued;
+}
+
+async function readPiTrustFile(path: string): Promise<Record<string, boolean | null> | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    // Pi owns this file. Preserve malformed/user-edited contents and let Pi
+    // surface its own recovery path instead of replacing them during launch.
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const trust: Record<string, boolean | null> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (value !== true && value !== false && value !== null) {
+      return null;
+    }
+    trust[key] = value;
+  }
+  return trust;
+}
+
+function nearestPiTrustDecision(
+  trust: Readonly<Record<string, boolean | null>>,
+  cwd: string,
+): boolean | null {
+  let candidate = cwd;
+  while (true) {
+    const decision = trust[candidate];
+    if (decision === true || decision === false) return decision;
+    const parent = dirname(candidate);
+    if (parent === candidate) return null;
+    candidate = parent;
+  }
+}
+
+function sortPiTrust(trust: Readonly<Record<string, boolean | null>>): Record<string, boolean | null> {
+  return Object.fromEntries(Object.entries(trust).sort(([a], [b]) => a.localeCompare(b)));
 }
 
 function piHeadlessApproveArgs(env: Readonly<Record<string, string | undefined>>): readonly string[] {
@@ -127,16 +229,16 @@ export const piAdapter: CliAdapter = {
   // credential rewrite. The helper returns before I/O on every other OS.
   async bootstrap({ cwd }): Promise<void> {
     await syncPiWindowsShellPath(cwd);
+    await syncPiProjectTrust(cwd);
   },
 
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
     // Tools come from the CLI-injection path (alice on PATH + shared
     // .agents/skills), not flags — so the command head is just the binary + a
     // resume flag (if any).
-    // Pi 0.79+ asks the user to trust project-local resources on interactive
-    // startup. Do not answer that security decision for them: the prompt makes
-    // the `.agents/skills` boundary visible, and omitting the flag also keeps
-    // external Pi 0.78.x runtimes (which predate `--approve`) compatible.
+    // `bootstrap()` records trust for this OpenAlice-managed Workspace before
+    // every launch. Keeping argv free of `--approve` preserves compatibility
+    // with external Pi 0.78.x runtimes that predate the flag.
     const head = [...piCommandHead(ctx.env)];
     // Quick-chat seed: `pi [--session-id <id>] <messages…>` opens the
     // interactive TUI seeded with that first message. UNLIKE the other adapters,
@@ -175,9 +277,9 @@ export const piAdapter: CliAdapter = {
 
   // Headless: `pi -p <prompt>` is non-interactive and exits at the turn
   // boundary, so there is nobody to answer Pi 0.79+'s project-trust prompt.
-  // The packaged app explicitly approves its pinned managed Pi; contributor
-  // dev leaves its external Pi untouched. Interactive sessions above always
-  // leave the decision to the user. NOTE: pi
+  // Bootstrap records a missing trust decision for every OpenAlice-managed
+  // Workspace. The packaged app additionally approves its pinned managed Pi;
+  // contributor dev leaves its external Pi argv untouched. NOTE: pi
   // REJECTS a `--` end-of-options terminator ("Unknown option: --", verified
   // 0.78.1), so the prompt is a bare trailing positional — a prompt literally
   // starting with `-`/`--` is unprotected on pi (rare for task prompts).

--- a/ui/src/components/workspace/Sidebar.spec.tsx
+++ b/ui/src/components/workspace/Sidebar.spec.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../../i18n'
+import type { AgentInfo, Workspace } from './api'
+import { WorkspaceRow } from './Sidebar'
+
+const capabilities = {
+  parallelPerCwd: true,
+  resumeLast: true,
+  resumeById: true,
+  transcriptDiscovery: 'none' as const,
+}
+
+const agents: readonly AgentInfo[] = [
+  { id: 'pi', displayName: 'Pi', kind: 'agent', capabilities },
+  { id: 'shell', displayName: 'Shell', kind: 'utility', capabilities },
+]
+
+const workspace: Workspace = {
+  id: 'workspace-1',
+  tag: 'chat',
+  dir: '/tmp/chat',
+  createdAt: '2026-07-15T00:00:00.000Z',
+  agents: ['pi', 'shell'],
+  sessions: [],
+}
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('WorkspaceRow session launcher', () => {
+  it('keeps the default runtime one click away while the full runtime menu remains discoverable', () => {
+    const onSpawn = vi.fn()
+    const onSetDefaultAgent = vi.fn()
+    render(
+      <WorkspaceRow
+        workspace={workspace}
+        agents={agents}
+        defaultAgent="pi"
+        selection={null}
+        onSelectWorkspace={vi.fn()}
+        onSelectSession={vi.fn()}
+        onSpawn={onSpawn}
+        onOpenHeadlessRun={vi.fn()}
+        onSetDefaultAgent={onSetDefaultAgent}
+        onPauseSession={vi.fn()}
+        onResumeSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onDelete={vi.fn(async () => undefined)}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Spawn a new Pi session' }))
+    expect(onSpawn).toHaveBeenCalledWith(workspace.id, { agent: 'pi' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose runtime for new session' }))
+    expect(screen.getByRole('menuitem', { name: 'Shell (sh)' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Shell (sh)' }))
+
+    expect(onSpawn).toHaveBeenLastCalledWith(workspace.id, { agent: 'shell' })
+    expect(onSetDefaultAgent).not.toHaveBeenCalled()
+  })
+
+  it('uses the primary plus button as the chooser when no default runtime exists', () => {
+    render(
+      <WorkspaceRow
+        workspace={workspace}
+        agents={agents}
+        defaultAgent={null}
+        selection={null}
+        onSelectWorkspace={vi.fn()}
+        onSelectSession={vi.fn()}
+        onSpawn={vi.fn()}
+        onOpenHeadlessRun={vi.fn()}
+        onSetDefaultAgent={vi.fn()}
+        onPauseSession={vi.fn()}
+        onResumeSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onDelete={vi.fn(async () => undefined)}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Choose runtime for new session' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Spawn a new session…' }))
+    expect(screen.getByRole('menuitem', { name: 'Shell (sh)' })).toBeTruthy()
+  })
+})

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -333,7 +333,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   );
 
   const [spawnMenuOpen, setSpawnMenuOpen] = useState(false);
-  const plusBtnRef = useRef<HTMLButtonElement | null>(null);
+  const spawnControlsRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLUListElement | null>(null);
   const enabledAgents = w.agents
     .map((id) => props.agents.find((a) => a.id === id))
@@ -348,7 +348,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
     if (!spawnMenuOpen) return;
     const onDocClick = (e: MouseEvent): void => {
       const t = e.target as Node | null;
-      if (plusBtnRef.current?.contains(t)) return;
+      if (spawnControlsRef.current?.contains(t)) return;
       if (menuRef.current?.contains(t)) return;
       setSpawnMenuOpen(false);
     };
@@ -383,6 +383,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
     defaultAgentEnabled && props.defaultAgent
       ? t('workspace.spawnAgent', { agent: agentLabel(props.defaultAgent, props.agents) })
       : t('workspace.spawn');
+  const chooserTitle = t('workspace.chooseAgent');
 
   const statusClass = hasRunning
     ? 'bg-green'
@@ -428,18 +429,31 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
           </button>
         )}
         {enabledAgents.length > 0 && (
-          <div className="relative shrink-0">
+          <div ref={spawnControlsRef} className="relative flex shrink-0 items-center">
             <button
-              ref={plusBtnRef}
               type="button"
               className={rowAction()}
               title={plusTitle}
-              aria-haspopup="menu"
-              aria-expanded={spawnMenuOpen}
+              aria-label={plusTitle}
+              aria-haspopup={defaultAgentEnabled ? undefined : 'menu'}
+              aria-expanded={defaultAgentEnabled ? undefined : spawnMenuOpen}
               onClick={onPlusClick}
             >
               <Plus size={13} strokeWidth={2.25} />
             </button>
+            {defaultAgentEnabled && (
+              <button
+                type="button"
+                className={`${rowAction()} -ml-0.5 w-4`}
+                title={chooserTitle}
+                aria-label={chooserTitle}
+                aria-haspopup="menu"
+                aria-expanded={spawnMenuOpen}
+                onClick={() => setSpawnMenuOpen((open) => !open)}
+              >
+                <ChevronDown size={11} strokeWidth={2.25} />
+              </button>
+            )}
             {spawnMenuOpen && (
               <ul
                 ref={menuRef}
@@ -451,6 +465,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
                     <button
                       type="button"
                       role="menuitem"
+                      aria-label={`${agent.displayName} (${agentPrefix(agent.id)})`}
                       className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-text transition-colors hover:bg-bg-tertiary"
                       onClick={() => onMenuPick(agent.id)}
                     >
@@ -468,6 +483,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
                     <button
                       type="button"
                       role="menuitem"
+                      aria-label={`${agent.displayName} (${agentPrefix(agent.id)})`}
                       className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text"
                       onClick={() => onMenuPick(agent.id)}
                     >

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -666,6 +666,7 @@ export const en = {
     displayNamePrompt: 'Workspace display name',
     spawnAgent: 'Spawn a new {{agent}} session',
     spawn: 'Spawn a new session…',
+    chooseAgent: 'Choose runtime for new session',
     configure: 'Configure this workspace',
     deleteWorkspace: 'Offboard workspace',
     headless: 'headless',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -655,6 +655,7 @@ export const ja: Resources = {
     displayNamePrompt: 'ワークスペースの表示名',
     spawnAgent: '新しい {{agent}} セッションを開始',
     spawn: '新しいセッションを開始…',
+    chooseAgent: '新しいセッションのランタイムを選択',
     configure: 'このワークスペースを設定',
     deleteWorkspace: 'ワークスペースを退役',
     headless: '自動実行',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -663,6 +663,7 @@ export const zhHant: Resources = {
     displayNamePrompt: '工作區顯示名稱',
     spawnAgent: '新增 {{agent}} 工作階段',
     spawn: '新增工作階段…',
+    chooseAgent: '選擇新工作階段執行環境',
     configure: '設定此工作區',
     deleteWorkspace: '辦理工作區離職',
     headless: '自動任務',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -655,6 +655,7 @@ export const zh: Resources = {
     displayNamePrompt: '工作区显示名称',
     spawnAgent: '新建 {{agent}} 会话',
     spawn: '新建会话…',
+    chooseAgent: '选择新会话运行时',
     configure: '配置此工作区',
     deleteWorkspace: '办理工作区离职',
     headless: '自动任务',


### PR DESCRIPTION
## Summary

- initialize Pi project trust safely before both TUI and WebPi startup while preserving explicit denials and existing Pi config ownership
- keep the default agent as the one-click session action while exposing a separate runtime chooser for Shell and alternate agents
- remember successful remote tunnel ports, retry transient SSH transport failures, re-probe interrupted actions, and compact remote source-build output
- document the runtime contracts and strengthen installer/remote/UI regression coverage

## Verification

- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (287 files passed, 1 skipped; 2996 tests passed, 6 skipped)
- `pnpm -F @traderalice/openalice-cli test` (55 passed)
- focused Pi adapter and Sidebar component tests
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- isolated browser onboarding with real Pi TUI and WebPi
- dedicated Railway sandbox source build, repeated same-origin tunnel reconnect, and transient SSH retry exercise
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:onboarding`
