### PR TITLE
Installer: default to master and align remote CLI source

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -56,16 +56,18 @@ weaken or silently replace the Electron lane.
 The preview installer is served directly from the `dev` branch:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
+curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash -s -- --branch dev
 ```
 
 It requires Node.js 22.19.0 or newer, matching the pinned Pi runtime's engine
-floor. The default source ref is `dev`, the default install root is
-`~/.openalice`, and the downloaded OpenAlice payload is the file set declared
-by `FILES` in the root `install` script. The installer also downloads Pi's
-release-owned install manifest and lockfile for version `0.80.6`, verifies both
-against pinned SHA-256 values, and runs `npm ci --omit=dev --ignore-scripts` in
-the staged release.
+floor. With no selector, the installer targets the stable `master` branch;
+development dogfooding must opt into `--branch dev`. `--version` is reserved
+for a tag or commit, and the two selectors are mutually exclusive. The default
+install root is `~/.openalice`, and the downloaded OpenAlice payload is the file
+set declared by `FILES` in the root `install` script. The installer also
+downloads Pi's release-owned install manifest and lockfile for version `0.80.6`,
+verifies both against pinned SHA-256 values, and runs
+`npm ci --omit=dev --ignore-scripts` in the staged release.
 
 The preview URL is not yet a stable release channel. Do not present a mutable
 `dev` ref as a signed or immutable release. A stable installer needs release
@@ -78,6 +80,8 @@ assets and a release-owned authenticity chain; see
 - `packages/cli/package.json` — CLI version, engine requirement, bin entry, and
   published file list.
 - `packages/cli/bin/openalice.mjs` — installed command entry point.
+- `packages/cli/src/install-source.mjs` — validated installation-source
+  metadata used when managed remote reproduces the invoking CLI.
 - `packages/cli/src/server{,-control}.mjs` — detached lifecycle and the
   Guardian control client.
 - `packages/cli/src/remote.mjs` — consent-first managed SSH orchestration.
@@ -121,6 +125,7 @@ preflight
   -> SHA-256 verification of pinned Pi manifest and lockfile
   -> npm ci for managed Pi inside staging
   -> syntax, manifest, Pi version, and executable validation
+  -> record branch/tag/commit installer provenance
   -> content identity
   -> immutable release directory
   -> validate temporary launchers
@@ -141,7 +146,7 @@ but it cannot publish a partial OpenAlice CLI release.
 
 Preflight validates:
 
-- the requested Git ref syntax and length;
+- the requested branch/tag/commit selector syntax and length;
 - Node.js availability and the exact `>=22.19.0` floor;
 - npm availability for the staged managed-Pi install;
 - `curl` for remote installs, or CLI sources for `--source` installs;
@@ -151,11 +156,11 @@ Preflight validates:
   available when Runtime-tool installation is selected;
 - whether another `openalice` currently resolves earlier on `PATH`.
 
-The visible plan includes action, source, ref, install root, both command paths,
-the pinned Pi version and source, the exact Pi npm command, shell change,
-Runtime-tool action, exact system package-manager command when selected, and
-any PATH conflict. A check that only reads the system may happen before consent;
-no installer-owned filesystem mutation may happen there.
+The visible plan includes action, source, branch or version, install root, both
+command paths, the pinned Pi version and source, the exact Pi npm command,
+shell change, Runtime-tool action, exact system package-manager command when
+selected, and any PATH conflict. A check that only reads the system may happen
+before consent; no installer-owned filesystem mutation may happen there.
 
 ### Consent contract
 
@@ -232,8 +237,15 @@ Before a release becomes visible, the installer:
    package manifest;
 4. verifies the Pi install manifest and lockfile against the SHA-256 values
    pinned in the installer, then requires the staged Pi CLI to report `0.80.6`;
-5. hashes the ordered OpenAlice payload plus both Pi install files with SHA-256 and uses the
-   first 16 hex characters as its content identity.
+5. writes `install-source.json` with the CLI version, selected branch/tag/commit,
+   and installer URL that produced this CLI;
+6. hashes the ordered OpenAlice payload, install-source metadata, and both Pi
+   install files with SHA-256 and uses the first 16 hex characters as its
+   content identity.
+
+That metadata is also returned by `openalice version --json`. Managed
+`openalice remote` uses it to invoke the same ordinary installer source and
+selector on a remote host. `remote` has no independent branch/version option.
 
 The resulting directory is:
 
@@ -278,8 +290,10 @@ With the default installer and Runtime roots:
 │   ├── pi
 │   └── pi.cmd
 ├── cli-versions/
-│   ├── dev-<content-id>/
+│   ├── master-<content-id>/
+│   │   ├── install-source.json
 │   │   └── managed/pi/     # pinned npm runtime inside the immutable release
+│   ├── dev-<content-id>/   # only after an explicit --branch dev install
 │   └── <older-ref-or-content>/
 ├── .cli-install.lock/       # present only while an installer owns it
 ├── data/                    # application state, not installer debris
@@ -338,7 +352,8 @@ Public options:
 
 | Option | Meaning |
 |---|---|
-| `--version <git-ref>` | Select a tag, branch, or commit for remote payloads and the installed source-ref label |
+| `--branch <name>` | Select a named Git branch (default: `master`) |
+| `--version <git-ref>` | Select a Git tag or commit; mutually exclusive with `--branch` |
 | `--install-dir <path>` | Override the OpenAlice install/user root |
 | `--with-runtime-deps` | Include missing Linux Git/Python/make/C++ source-build tools in the approved plan |
 | `--no-modify-path` | Install launchers without editing a shell profile |
@@ -356,8 +371,8 @@ Environment inputs:
 
 | Variable | Meaning |
 |---|---|
-| `OPENALICE_VERSION` | Default source ref when `--version` is absent |
 | `OPENALICE_INSTALL_DIR` | Default install root when `--install-dir` is absent |
+| `OPENALICE_INSTALL_URL` | Record the distributor-owned installer URL in installed provenance; used by fixtures and future CDN entry points |
 | `OPENALICE_INSTALL_BASE_URL` | Override payload base URL for local fixtures and installer tests |
 | `OPENALICE_PI_RELEASE_BASE_URL` | Override the pinned Pi release-asset base for installer tests |
 | `OPENALICE_PI_SOURCE_DIR` | Read the exact Pi manifest/lock assets from a local fixture |
@@ -365,19 +380,21 @@ Environment inputs:
 | `NO_COLOR` | Disable installer color output |
 | `HOME`, `SHELL`, `PATH`, `TERM` | Standard environment used for paths, profile detection, conflicts, and color |
 
-The three Pi overrides and `OPENALICE_INSTALL_BASE_URL` are test/development
-seams, not user-facing mirror or package-manager selectors. The same pinned
-SHA-256 checks still apply to local Pi assets. A real mirror design must define
-equivalent authenticity and version semantics before becoming public API.
+The three Pi overrides, `OPENALICE_INSTALL_URL`, and
+`OPENALICE_INSTALL_BASE_URL` are distributor/test seams, not user-facing
+branch selectors. The same pinned SHA-256 checks still apply to local Pi
+assets. A real mirror design must define equivalent authenticity and version
+semantics before becoming public API.
 
 ## Authenticity Boundary
 
 The current content identity protects update layout and detects accidental or
 local modification. It does not prove who supplied the downloaded files. The
-script is normally fetched from the mutable `dev` URL and then chooses payload
-files from the requested raw GitHub ref. Even when that payload ref is an
-immutable commit, a hash computed by the same downloaded installer is not an
-independent trust anchor.
+current preview script is fetched from the mutable `dev` URL with an explicit
+`--branch dev`, while the selector-free release contract targets `master`.
+Both paths choose payload files from the selected raw GitHub ref. Even when
+that payload ref is an immutable commit, a hash computed by the same downloaded
+installer is not an independent trust anchor.
 
 Do not describe the preview as cryptographically verified. A stable release
 path should establish this chain:
@@ -406,6 +423,8 @@ pnpm -F @traderalice/openalice-cli test
 
 The unit suite covers:
 
+- default-`master`, explicit-branch, tag/commit, and selector-conflict behavior;
+- persisted install provenance and `openalice version --json`;
 - installed layout and a runnable launcher;
 - pinned managed Pi layout, version, direct launcher, and OpenAlice env
   injection;
@@ -428,6 +447,7 @@ exercises the same OpenAlice remote-download branch as `curl | bash`; exact
 release Pi assets plus a strict fake npm exercise the offline install contract.
 It verifies:
 
+- default `master`, explicit `dev`, and mutually exclusive selectors;
 - unattended refusal before the install root exists;
 - stale-lock recovery and lock cleanup;
 - downloaded payload equality;
@@ -461,10 +481,12 @@ with an explicit `y`, and run at least:
 ```bash
 command -v openalice
 openalice --version
+openalice version --json
 command -v pi
 pi --version
 cat ~/.bashrc
 curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan
+curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan --branch dev
 curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan --with-runtime-deps
 cat "$OPENALICE_RUNTIME_DEPS_LOG"
 ```

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -38,12 +38,14 @@ behavior.
 The current installer distributes the small JavaScript CLI from the `dev` ref:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
+curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash -s -- --branch dev
 ```
 
-The preview requires Node.js 22.19.0 or newer. It always installs the small CLI
-plus OpenAlice's pinned Pi runtime inside the same immutable install release;
-the two visible commands are `openalice` and `pi`. When explicitly selected,
+The installer defaults to the stable `master` branch; this preview command
+opts into `dev` explicitly. It requires Node.js 22.19.0 or newer and always
+installs the small CLI plus OpenAlice's pinned Pi runtime inside the same
+immutable install release; the two visible commands are `openalice` and `pi`.
+When explicitly selected,
 it can also install missing Linux Git/Python/make/C++ tools needed to build the
 source Runtime. It does not clone OpenAlice, write application state, install
 Electron, configure a provider credential, or start a service without separate

--- a/docs/reference/herdr-remote-architecture.md
+++ b/docs/reference/herdr-remote-architecture.md
@@ -320,6 +320,13 @@ OpenAlice should reuse its own installer/update trust chain for remote hosts.
 It should not copy Herdr's binary transfer implementation or grow a second
 remote-only installer inside `openalice remote`.
 
+Concretely, OpenAlice SSH carries the approved installer command, not the full
+Runtime artifact. The remote host pulls the small control CLI from the same
+installer source recorded by the invoking local CLI. The current large Runtime
+comes from the remote source checkout; a future standalone headless bundle
+should be pulled from a versioned CDN asset with release verification rather
+than streamed from the laptop.
+
 ## Stable API Versus Private Presentation Protocol
 
 Herdr currently exposes two materially different interfaces:

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -93,8 +93,9 @@ protocol is deferred until the local/server boundary is stable.
    completion. It does not signal a guessed PID or delete a live lock.
 8. `--takeover` remains the only command-line authority to replace another
    recorded Guardian owner.
-9. Remote bootstrap reuses the ordinary OpenAlice CLI installer and release
-   trust chain. It does not carry a second SSH-only installer.
+9. Remote bootstrap reuses the invoking local CLI's recorded ordinary
+   installer source and selector. It does not carry a second SSH-only installer
+   or upload the full OpenAlice Runtime through SSH.
 10. Shared Runtime facts use presentation-neutral names and versioned schemas.
     Browser layout, Electron chrome, modal state, and other client UI state do
     not become server truth.
@@ -191,9 +192,10 @@ openalice remote <target> --app-dir <remote-checkout>
 1. verify ordinary SSH connectivity and host-key policy;
 2. detect remote platform and an installed `openalice` CLI;
 3. probe `openalice server status --json` and protocol compatibility;
-4. if CLI install or update is required, show the exact plan and ask separately
-   before changing the remote host;
-5. call the normal remote installer non-interactively only after that consent;
+4. compare the remote CLI version and recorded installer source/selector with
+   the invoking local CLI;
+5. if CLI install or update is required, show the exact matching plan and ask
+   separately before calling the normal installer on the remote host;
 6. re-probe and re-plan after installation so a newly visible owner can block
    or require a second explicit takeover decision;
 7. run `openalice server start --app-dir ...` remotely and wait for readiness;
@@ -518,7 +520,8 @@ Managed bootstrap uses a plan/apply split.
 The read-only plan reports:
 
 - SSH target and resolved remote platform/architecture;
-- detected OpenAlice CLI path and version;
+- detected OpenAlice CLI path, version, and whether its version/install source
+  match the invoking local CLI;
 - control protocol compatibility;
 - Server state and source/bundle root;
 - whether the selected source checkout already has complete Runtime artifacts;
@@ -531,7 +534,8 @@ The read-only plan reports:
 
 Apply rules:
 
-1. no compatible CLI: ask before invoking the normal installer;
+1. no matching compatible CLI: ask before invoking the normal installer with
+   the local CLI's recorded branch/tag/commit selector;
 2. source artifacts absent and Linux build tools missing: include
    `--with-runtime-deps` in that same normal installer invocation after plan
    consent;
@@ -554,11 +558,12 @@ or Server is already present and compatible, otherwise it returns the original
 failure. Source preparation uses compact phase output and suppresses successful
 package/build chatter; a failed phase still includes a bounded diagnostic tail.
 
-The local orchestrator must compare protocol ranges, not only human version
-strings. It may tolerate a newer compatible Runtime, but it must fail clearly
-when a method or schema is unsupported. Development overrides for a local CLI
-payload or checkout are allowed only behind explicit flags and are not the
-release path.
+The local orchestrator compares protocol ranges, CLI version, and install
+source; human version strings alone are insufficient. It may tolerate a newer
+compatible Runtime, but its remote control CLI must match the invoking local
+CLI. The managed command exposes no independent branch/version selector. Test
+fixtures may replace the installer URL and payload base through test-only
+environment seams; those are not a release path.
 
 ## Future Independent Studio Protocol
 
@@ -721,7 +726,8 @@ shaping remains a separate latency observation.
 
 | Scenario | Required result |
 |---|---|
-| compatible remote CLI/Server | reuses both without mutation |
+| matching compatible remote CLI/Server | reuses both without mutation |
+| protocol-compatible CLI from a different branch/tag/commit | plan names a matching CLI update before connection |
 | compatible CLI Server but managed Pi missing | plan names Pi install and self-owned Server restart; refreshed Server reports pinned Pi |
 | missing remote CLI, interactive | shows plan; default no leaves host unchanged |
 | missing remote CLI, non-interactive | fails unless explicit approval is present |

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -117,7 +117,7 @@ The examples below use `/home/alice/OpenAlice`; replace it with that output.
 The preview installer shows its complete plan before asking for consent:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
+curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash -s -- --branch dev
 ```
 
 Open a new terminal so the managed PATH block is active, then verify both
@@ -125,12 +125,17 @@ commands:
 
 ```bash
 openalice --version
+openalice version --json
 pi --version
 ```
 
 The installer adds the small `openalice` CLI and a pinned, release-local Pi. It
 does not install Electron, clone OpenAlice, start a service, or configure an AI
-provider. See [[docs/cli-installer.md]] for the transaction and trust model.
+provider. The JSON version output records this local CLI's version, installer
+source, and selector. Managed remote uses that record when the remote control
+CLI is missing or different; `openalice remote` has no separate branch/version
+flag.
+See [[docs/cli-installer.md]] for the transaction and trust model.
 
 ### 3. Review the remote plan
 
@@ -163,6 +168,11 @@ After explicit consent, the command can:
 4. prepare the source Runtime;
 5. start or reuse a detached Guardian-owned Server;
 6. open a local SSH loopback tunnel and browser URL.
+
+The first step makes the remote host pull the small matching control CLI from
+its recorded installer URL. OpenAlice is not uploaded from the laptop through
+SSH. The large source Runtime remains the checkout named by `--app-dir` and is
+prepared on that host; `remote` never checks out or switches its Git branch.
 
 The first preparation can take several minutes. Successful build output is
 compact; a failed phase includes a bounded diagnostic tail.
@@ -289,6 +299,11 @@ state and PTYs from attached clients. Its remote mode keeps a thin client local,
 reaches the server through SSH, and leaves agents running after detach. The
 important lesson is ownership: the host with the files owns execution and
 durable Runtime facts; presentation can disconnect and return.
+
+Herdr can stream a matching compact binary to the host. OpenAlice deliberately
+does not copy that mechanism for its much larger Runtime: SSH carries control
+commands, the remote host pulls the small CLI itself, and a future standalone
+headless bundle must be a versioned CDN download rather than a laptop upload.
 
 OpenAlice starts with a simpler transport than Herdr's private framed TUI
 protocol: the existing HTTP and Workspace WebSocket cross an SSH loopback

--- a/install
+++ b/install
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 REPOSITORY="TraderAlice/OpenAlice"
-VERSION="${OPENALICE_VERSION:-dev}"
+DEFAULT_BRANCH="master"
+VERSION=""
+REF_KIND=""
+REF_OPTION=""
 MINIMUM_NODE_VERSION="22.19.0"
 PI_VERSION="0.80.6"
 PI_RELEASE_BASE="${OPENALICE_PI_RELEASE_BASE_URL:-https://github.com/earendil-works/pi/releases/download/v${PI_VERSION}}"
@@ -91,11 +94,14 @@ usage() {
 OpenAlice CLI installer
 
 Usage:
-  curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash
-  ./install [--version <git-ref>] [--install-dir <path>] [--with-runtime-deps] [--no-modify-path] [--yes]
+  ./install
+  ./install --branch dev
+  ./install --version <tag-or-commit>
+  curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash -s -- --branch dev
 
 Options:
-  --version <git-ref>   Git tag, branch, or commit to install (default: dev)
+  --branch <name>       Git branch to install (default: master)
+  --version <git-ref>   Git tag or commit to install
   --install-dir <path>  OpenAlice user root (default: ~/.openalice)
   --source <path>       Install CLI files from a local checkout (development)
   --with-runtime-deps   Install missing Linux source-build tools after consent
@@ -352,9 +358,20 @@ install_runtime_deps() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --branch)
+      [[ $# -ge 2 ]] || { echo "openalice install: --branch requires a value" >&2; exit 1; }
+      [[ -z "$REF_OPTION" ]] || die "Use only one of --branch or --version."
+      VERSION="$2"
+      REF_KIND="branch"
+      REF_OPTION="--branch"
+      shift 2
+      ;;
     --version)
       [[ $# -ge 2 ]] || { echo "openalice install: --version requires a value" >&2; exit 1; }
+      [[ -z "$REF_OPTION" ]] || die "Use only one of --branch or --version."
       VERSION="$2"
+      REF_KIND="version"
+      REF_OPTION="--version"
       shift 2
       ;;
     --install-dir)
@@ -395,9 +412,16 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$VERSION" ]]; then
+  VERSION="$DEFAULT_BRANCH"
+  REF_KIND="branch"
+fi
+
 if [[ ${#VERSION} -gt 128 || "$VERSION" == *".."* || ! "$VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
   die "Unsupported version/ref: $VERSION"
 fi
+
+INSTALLER_URL="${OPENALICE_INSTALL_URL:-https://raw.githubusercontent.com/$REPOSITORY/$VERSION/install}"
 
 INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
 BIN_DIR="$INSTALL_ROOT/bin"
@@ -468,6 +492,13 @@ if ! node_version_supported; then
 fi
 ok "Node.js $(node --version)"
 
+if ! node -e '
+  const url = new URL(process.argv[1]);
+  if (url.protocol !== "https:" && url.protocol !== "http:") process.exit(1);
+' "$INSTALLER_URL" >/dev/null 2>&1; then
+  die "OPENALICE_INSTALL_URL must be an HTTP(S) URL."
+fi
+
 if [[ "$NPM_BIN" == *[[:space:]]* ]]; then
   die "OPENALICE_NPM_BIN must name one executable without arguments."
 fi
@@ -491,6 +522,8 @@ else
   BASE_URL="${BASE_URL%/}"
   if [[ -n "${OPENALICE_INSTALL_BASE_URL:-}" ]]; then
     install_source="Download URL: $BASE_URL"
+  elif [[ "$REF_KIND" == "branch" ]]; then
+    install_source="GitHub branch: $REPOSITORY@$VERSION"
   else
     install_source="GitHub ref: $REPOSITORY@$VERSION"
   fi
@@ -543,7 +576,11 @@ fi
 printf '\n%bInstall plan%b\n' "$BOLD" "$RESET"
 printf '  %-14s %s\n' "Action" "$install_action"
 printf '  %-14s %s\n' "Source" "$install_source"
-printf '  %-14s %s\n' "Version" "$VERSION"
+if [[ "$REF_KIND" == "branch" ]]; then
+  printf '  %-14s %s\n' "Branch" "$VERSION"
+else
+  printf '  %-14s %s\n' "Version" "$VERSION"
+fi
 printf '  %-14s %s\n' "Install root" "$INSTALL_ROOT"
 printf '  %-14s %s\n' "Command" "$BIN_DIR/openalice"
 printf '  %-14s %s\n' "Managed agent" "Pi $PI_VERSION -> $BIN_DIR/pi"
@@ -610,6 +647,7 @@ fi
 FILES=(
   "package.json"
   "bin/openalice.mjs"
+  "src/install-source.mjs"
   "src/local-start.mjs"
   "src/remote.mjs"
   "src/runtime-deps.mjs"
@@ -672,6 +710,7 @@ ok "Managed Pi $PI_VERSION is ready"
 step 5 "Verifying the OpenAlice CLI"
 chmod +x "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/bin/openalice.mjs"
+node --check "$STAGING/src/install-source.mjs"
 node --check "$STAGING/src/local-start.mjs"
 node --check "$STAGING/src/remote.mjs"
 node --check "$STAGING/src/runtime-deps.mjs"
@@ -687,7 +726,33 @@ CLI_VERSION="$(node -e '
 ' "$STAGING/package.json")" || die "The downloaded package manifest is not an OpenAlice CLI package"
 STAGED_VERSION="$(node "$STAGING/bin/openalice.mjs" --version)"
 [[ "$STAGED_VERSION" == "$CLI_VERSION" ]] || die "The downloaded CLI did not report its package version"
-CONTENT_FILES=("${FILES[@]}" "managed/pi/package.json" "managed/pi/package-lock.json")
+node -e '
+  const { writeFileSync } = require("node:fs");
+  const [path, repository, cliVersion, kind, value, installerUrl] = process.argv.slice(1);
+  writeFileSync(path, `${JSON.stringify({
+    schemaVersion: 1,
+    repository,
+    cliVersion,
+    selector: { kind, value },
+    installerUrl,
+  }, null, 2)}\n`, { mode: 0o644 });
+' "$STAGING/install-source.json" "$REPOSITORY" "$CLI_VERSION" "$REF_KIND" "$VERSION" "$INSTALLER_URL"
+node "$STAGING/bin/openalice.mjs" version --json | node -e '
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => { input += chunk; });
+  process.stdin.on("end", () => {
+    const [kind, value, installerUrl, cliVersion] = process.argv.slice(1);
+    const info = JSON.parse(input);
+    if (info.version !== cliVersion
+      || info.installSource?.cliVersion !== cliVersion
+      || info.installSource?.selector?.kind !== kind
+      || info.installSource?.selector?.value !== value
+      || info.installSource?.installerUrl !== installerUrl) process.exit(1);
+  });
+' "$REF_KIND" "$VERSION" "$INSTALLER_URL" "$CLI_VERSION" \
+  || die "The downloaded CLI did not preserve its installation source"
+CONTENT_FILES=("${FILES[@]}" "install-source.json" "managed/pi/package.json" "managed/pi/package-lock.json")
 CONTENT_ID="$(content_id "$STAGING" "${CONTENT_FILES[@]}")"
 ok "OpenAlice CLI $CLI_VERSION passed validation ($CONTENT_ID)"
 
@@ -782,7 +847,11 @@ printf '  %-12s %s\n' "Command" "$BIN_DIR/openalice"
 printf '  %-12s %s\n' "CLI version" "$CLI_VERSION"
 printf '  %-12s %s\n' "Agent" "$BIN_DIR/pi"
 printf '  %-12s %s\n' "Pi version" "$PI_VERSION"
-printf '  %-12s %s\n' "Source ref" "$VERSION"
+if [[ "$REF_KIND" == "branch" ]]; then
+  printf '  %-12s %s\n' "Branch" "$VERSION"
+else
+  printf '  %-12s %s\n' "Source ref" "$VERSION"
+fi
 if [[ "$path_updated" -eq 1 ]]; then
   printf '  %-12s %s\n' "Shell" "Future terminals will load the managed block in $profile"
 fi

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -3,6 +3,7 @@
 import { readFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
+import { readInstallSource } from '../src/install-source.mjs'
 import { formatLocalStartHelp, parseLocalStartArgs, startLocal } from '../src/local-start.mjs'
 import { connectRemote, formatRemoteHelp, parseRemoteArgs } from '../src/remote.mjs'
 import { formatServerHelp, parseServerArgs, runServerCommand } from '../src/server.mjs'
@@ -12,6 +13,13 @@ export async function main(argv = process.argv.slice(2)) {
   const [command, ...args] = argv
   if (command === '--help' || command === '-h' || command === 'help') {
     process.stdout.write(formatHelp())
+    return 0
+  }
+  if (command === 'version' && args[0] === '--json') {
+    process.stdout.write(`${JSON.stringify({
+      version: readVersion(),
+      installSource: await readInstallSource(),
+    })}\n`)
     return 0
   }
   if (command === '--version' || command === '-v' || command === 'version') {
@@ -56,12 +64,14 @@ function formatHelp() {
 
 Usage:
   openalice
+  openalice version --json
   openalice start [path] [options]
   openalice server <run|start|status|stop> [options]
   openalice ssh <user@host> [options]
   openalice remote <user@host> [options]
 
 Commands:
+  version   Print the CLI version; --json also reports its recorded install source
   start     Start OpenAlice from a source checkout on local loopback (default)
   server    Run, detach, inspect, or stop a browserless local Runtime
   ssh       Open a loopback-only SSH tunnel to an already-running OpenAlice

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,7 @@
   },
   "files": [
     "bin/openalice.mjs",
+    "src/install-source.mjs",
     "src/local-start.mjs",
     "src/remote.mjs",
     "src/runtime-deps.mjs",
@@ -17,7 +18,7 @@
     "src/ssh-connect.mjs"
   ],
   "scripts": {
-    "build": "node --check bin/openalice.mjs && node --check src/local-start.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs",
+    "build": "node --check bin/openalice.mjs && node --check src/install-source.mjs && node --check src/local-start.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },
   "engines": {

--- a/packages/cli/src/install-source.mjs
+++ b/packages/cli/src/install-source.mjs
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+
+const CLI_VERSION = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
+
+export const DEFAULT_INSTALL_SOURCE = Object.freeze({
+  schemaVersion: 1,
+  repository: 'TraderAlice/OpenAlice',
+  cliVersion: CLI_VERSION,
+  selector: Object.freeze({ kind: 'branch', value: 'master' }),
+  installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/master/install',
+})
+
+export async function readInstallSource(options = {}) {
+  const metadataUrl = options.metadataUrl ?? new URL('../install-source.json', import.meta.url)
+  try {
+    return requireInstallSource(JSON.parse(await readFile(metadataUrl, 'utf8')))
+  } catch (error) {
+    if (error?.code === 'ENOENT') return cloneInstallSource(DEFAULT_INSTALL_SOURCE)
+    throw error
+  }
+}
+
+export function normalizeInstallSource(value, fallback = DEFAULT_INSTALL_SOURCE) {
+  return parseInstallSource(value) ?? cloneInstallSource(fallback)
+}
+
+export function parseInstallSource(value) {
+  if (!value || typeof value !== 'object') return null
+  const repository = typeof value.repository === 'string' ? value.repository : ''
+  const cliVersion = typeof value.cliVersion === 'string' ? value.cliVersion : ''
+  const selector = value.selector
+  const kind = selector?.kind
+  const ref = selector?.value
+  const installerUrl = typeof value.installerUrl === 'string' ? value.installerUrl : ''
+  if (
+    value.schemaVersion !== 1
+    || repository !== 'TraderAlice/OpenAlice'
+    || cliVersion.length < 1
+    || !['branch', 'version'].includes(kind)
+    || typeof ref !== 'string'
+    || ref.length < 1
+    || ref.length > 128
+    || ref.includes('..')
+    || !/^[A-Za-z0-9._/-]+$/.test(ref)
+    || !isHttpUrl(installerUrl)
+  ) {
+    return null
+  }
+  return {
+    schemaVersion: 1,
+    repository,
+    cliVersion,
+    selector: { kind, value: ref },
+    installerUrl,
+  }
+}
+
+export function requireInstallSource(value) {
+  const parsed = parseInstallSource(value)
+  if (!parsed) throw new Error('OpenAlice install-source metadata is invalid')
+  return parsed
+}
+
+export function installSourcesMatch(left, right) {
+  const normalizedLeft = parseInstallSource(left)
+  const normalizedRight = parseInstallSource(right)
+  if (!normalizedLeft || !normalizedRight) return false
+  return normalizedLeft.repository === normalizedRight.repository
+    && normalizedLeft.cliVersion === normalizedRight.cliVersion
+    && normalizedLeft.selector.kind === normalizedRight.selector.kind
+    && normalizedLeft.selector.value === normalizedRight.selector.value
+    && normalizedLeft.installerUrl === normalizedRight.installerUrl
+}
+
+export function formatInstallSelector(source) {
+  const normalized = normalizeInstallSource(source)
+  return `${normalized.selector.kind} ${normalized.selector.value}`
+}
+
+function cloneInstallSource(source) {
+  return {
+    schemaVersion: 1,
+    repository: source.repository,
+    cliVersion: source.cliVersion,
+    selector: { ...source.selector },
+    installerUrl: source.installerUrl,
+  }
+}
+
+function isHttpUrl(value) {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}

--- a/packages/cli/src/install-source.spec.mjs
+++ b/packages/cli/src/install-source.spec.mjs
@@ -1,0 +1,44 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_INSTALL_SOURCE,
+  installSourcesMatch,
+  readInstallSource,
+} from './install-source.mjs'
+
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('OpenAlice install source', () => {
+  it('uses master only when no installed metadata exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-install-source-'))
+    temporaryPaths.push(root)
+    await expect(readInstallSource({ metadataUrl: join(root, 'missing.json') }))
+      .resolves.toEqual(DEFAULT_INSTALL_SOURCE)
+  })
+
+  it('rejects malformed installed metadata instead of silently changing channels', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-install-source-invalid-'))
+    temporaryPaths.push(root)
+    const metadataPath = join(root, 'install-source.json')
+    await writeFile(metadataPath, '{"selector":{"kind":"branch","value":"dev"}}\n')
+    await expect(readInstallSource({ metadataUrl: metadataPath })).rejects.toThrow('install-source metadata is invalid')
+  })
+
+  it('compares the complete installer source, including selector and URL', () => {
+    const dev = {
+      ...DEFAULT_INSTALL_SOURCE,
+      selector: { kind: 'branch', value: 'dev' },
+      installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install',
+    }
+    expect(installSourcesMatch(DEFAULT_INSTALL_SOURCE, { ...DEFAULT_INSTALL_SOURCE })).toBe(true)
+    expect(installSourcesMatch(DEFAULT_INSTALL_SOURCE, dev)).toBe(false)
+  })
+})

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -29,6 +29,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
     const rootManifest = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8'))
     const cliManifest = JSON.parse(await readFile(join(repositoryRoot, 'packages/cli/package.json'), 'utf8'))
 
+    expect(installer).toContain('DEFAULT_BRANCH="master"')
     expect(installer).toContain('MINIMUM_NODE_VERSION="22.19.0"')
     expect(installer).toContain('PI_VERSION="0.80.6"')
     expect(desktopVendor).toContain("const PI_VERSION = '0.80.6'")
@@ -41,6 +42,32 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
     expect(cliManifest.engines.node).toBe('>=22.19.0')
     expect(sha256(packageBytes)).toBe('ee080db64c3732daea5547bd6d9809465ffa236ef6099051e64a16753e48b795')
     expect(sha256(lockBytes)).toBe('0f409bf498507f93bfbde3dc6f2b4c83bc58bdea2e2f5eabf3053cc2a81568d4')
+  })
+
+  it('defaults to master, accepts an explicit branch, and rejects multiple selectors', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-selectors-'))
+    temporaryPaths.push(home)
+    const installer = join(repositoryRoot, 'install')
+    const commonArgs = [
+      '--source', repositoryRoot,
+      '--install-dir', join(home, '.openalice'),
+      '--no-modify-path',
+      '--plan',
+    ]
+
+    const stable = await execFileAsync('bash', [installer, ...commonArgs], { env: installerEnv(home) })
+    expect(stable.stdout).toContain('Branch         master')
+
+    const preview = await execFileAsync('bash', [installer, ...commonArgs, '--branch', 'dev'], { env: installerEnv(home) })
+    expect(preview.stdout).toContain('Branch         dev')
+
+    await expect(execFileAsync('bash', [installer,
+      ...commonArgs,
+      '--branch', 'dev',
+      '--version', 'v0.2.0',
+    ], { env: installerEnv(home) })).rejects.toMatchObject({
+      stderr: expect.stringContaining('Use only one of --branch or --version'),
+    })
   })
 
   it('installs a runnable, versioned CLI without touching the shell profile', async () => {
@@ -72,6 +99,18 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
 
     const result = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['--version'])
     expect(result.stdout.trim()).toBe('0.2.0')
+    const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
+    expect(JSON.parse(versionInfo.stdout)).toEqual({
+      version: '0.2.0',
+      installSource: {
+        schemaVersion: 1,
+        repository: 'TraderAlice/OpenAlice',
+        cliVersion: '0.2.0',
+        selector: { kind: 'version', value: 'test/ref' },
+        installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/test/ref/install',
+      },
+    })
+    await expect(access(join(installRoot, 'cli-versions', releases[0], 'install-source.json'))).resolves.toBeUndefined()
     const pi = await execFileAsync(join(installRoot, 'bin', 'pi'), ['--version'])
     expect(pi.stdout.trim()).toBe('0.80.6')
     const launcher = await readFile(join(installRoot, 'bin', 'openalice'), 'utf8')

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -5,10 +5,17 @@ import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { createInterface } from 'node:readline/promises'
 
+import {
+  DEFAULT_INSTALL_SOURCE,
+  formatInstallSelector,
+  installSourcesMatch,
+  parseInstallSource,
+  readInstallSource,
+  requireInstallSource,
+} from './install-source.mjs'
 import { formatMissingRuntimeBuildTools } from './runtime-deps.mjs'
 import { connectSsh } from './ssh-connect.mjs'
 
-const DEFAULT_INSTALL_URL = 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install'
 const MINIMUM_NODE_VERSION = '22.19.0'
 const MANAGED_PI_VERSION = '0.80.6'
 const MAX_SSH_OUTPUT_BYTES = 1024 * 1024
@@ -103,6 +110,7 @@ export function parseRemoteArgs(argv) {
 export async function connectRemote(options, dependencies = {}) {
   const stdout = dependencies.stdout ?? process.stdout
   const env = dependencies.env ?? process.env
+  const localInstallSource = await resolveLocalInstallSource(dependencies, env)
   const rememberedLocalPort = options.localPort === 0
     ? await readRememberedRemotePort(options, { ...dependencies, env })
     : null
@@ -112,9 +120,8 @@ export async function connectRemote(options, dependencies = {}) {
   const probe = dependencies.probeRemote ?? probeRemoteHost
   let remote = await probe(connectionOptions, dependencies)
   let plan = createRemotePlan(connectionOptions, remote, {
-    installUrl: dependencies.installUrl ?? env['OPENALICE_REMOTE_INSTALL_URL'] ?? DEFAULT_INSTALL_URL,
-    installVersion: dependencies.installVersion ?? env['OPENALICE_REMOTE_VERSION'] ?? 'dev',
-    installBaseUrl: dependencies.installBaseUrl ?? env['OPENALICE_REMOTE_INSTALL_BASE_URL'] ?? '',
+    installSource: localInstallSource,
+    installBaseUrl: dependencies.installBaseUrl ?? env['OPENALICE_REMOTE_TEST_INSTALL_BASE_URL'] ?? '',
   })
   stdout.write(formatRemotePlan(plan))
 
@@ -141,8 +148,7 @@ export async function connectRemote(options, dependencies = {}) {
     let installerError = null
     try {
       const output = await runRemote(connectionOptions, buildRemoteInstallCommand(
-        plan.installUrl,
-        plan.installVersion,
+        plan.installSource,
         plan.installBaseUrl,
         plan.installRuntimeDeps,
       ), dependencies)
@@ -156,20 +162,21 @@ export async function connectRemote(options, dependencies = {}) {
     } catch (probeError) {
       throw installerError ?? probeError
     }
-    if (installerError && remote.cliCompatible && remote.piCompatible && (!plan.installRuntimeDeps || (remote.runtimeBuildToolsMissing ?? []).length === 0)) {
+    const matchingRemoteCli = remote.cliCompatible
+      && installSourcesMatch(remote.installSource, plan.installSource)
+    if (installerError && matchingRemoteCli && remote.piCompatible && (!plan.installRuntimeDeps || (remote.runtimeBuildToolsMissing ?? []).length === 0)) {
       stdout.write('The remote install completed before the disconnect; continuing from detected state.\n')
     } else if (installerError) {
       throw installerError
     }
-    if (!remote.cliPath || !remote.cliCompatible) {
-      throw new Error('The remote OpenAlice CLI install completed, but a compatible CLI was not detected')
+    if (!remote.cliPath || !matchingRemoteCli) {
+      throw new Error('The remote OpenAlice CLI install completed, but it does not match the invoking local CLI')
     }
     if (!remote.piCompatible) {
       throw new Error(`The remote install completed, but managed Pi ${MANAGED_PI_VERSION} was not detected`)
     }
     const refreshedPlan = createRemotePlan(options, remote, {
-      installUrl: plan.installUrl,
-      installVersion: plan.installVersion,
+      installSource: plan.installSource,
       installBaseUrl: plan.installBaseUrl,
       forceRestartForManagedPi: plan.restartServer,
     })
@@ -272,8 +279,7 @@ export async function connectRemote(options, dependencies = {}) {
 }
 
 export function createRemotePlan(options, remote, install = {}) {
-  const installUrl = install.installUrl ?? DEFAULT_INSTALL_URL
-  const installVersion = install.installVersion ?? 'dev'
+  const installSource = requireInstallSource(install.installSource ?? DEFAULT_INSTALL_SOURCE)
   const installBaseUrl = install.installBaseUrl ?? ''
   const forceRestartForManagedPi = install.forceRestartForManagedPi === true
   const mutations = []
@@ -296,7 +302,9 @@ export function createRemotePlan(options, remote, install = {}) {
     blocker = `No OpenAlice source checkout was found at ${options.appDir}. Clone it first or pass the correct --app-dir.`
   }
 
-  if (!remote.cliPath || !remote.cliCompatible) {
+  const cliMatchesLocal = remote.installSource != null
+    && installSourcesMatch(remote.installSource, installSource)
+  if (!remote.cliPath || !remote.cliCompatible || !cliMatchesLocal) {
     installCli = true
   }
   if (!remote.piCompatible) {
@@ -374,6 +382,7 @@ export function createRemotePlan(options, remote, install = {}) {
     cliPath: remote.cliPath ?? 'missing',
     cliVersion: remote.cliVersion ?? 'unknown',
     cliCompatible: remote.cliCompatible === true,
+    cliMatchesLocal,
     piPath: remote.piPath ?? 'missing',
     piVersion: remote.piVersion ?? 'unknown',
     piCompatible: remote.piCompatible === true,
@@ -393,8 +402,7 @@ export function createRemotePlan(options, remote, install = {}) {
     sourceCheckoutPresent: remote.sourceCheckoutPresent ?? null,
     sourceArtifactsReady: remote.sourceArtifactsReady ?? null,
     runtimeBuildToolsMissing,
-    installUrl,
-    installVersion,
+    installSource,
     installBaseUrl,
     mutations,
     blocker,
@@ -414,7 +422,32 @@ export function formatRemotePlan(plan) {
       : plan.appDir === 'not selected'
         ? 'Not inspected'
         : 'Ready'
-  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  Node.js        ${plan.nodeVersion}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${plan.cliCompatible ? ', compatible' : ', install/update required'})\n  Agent          ${plan.piPath} (Pi ${plan.piVersion}${plan.piCompatible ? ', compatible' : `, install ${MANAGED_PI_VERSION} required`})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n  Source         ${plan.appDir}\n  Build tools    ${buildTools}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.runInstaller ? `  Installer      ${plan.installUrl} (${plan.installVersion})\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
+  const cliState = plan.cliCompatible && plan.cliMatchesLocal
+    ? ', compatible and matches local CLI'
+    : ', install/update required'
+  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  Node.js        ${plan.nodeVersion}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${cliState})\n  Agent          ${plan.piPath} (Pi ${plan.piVersion}${plan.piCompatible ? ', compatible' : `, install ${MANAGED_PI_VERSION} required`})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n  Source         ${plan.appDir}\n  Build tools    ${buildTools}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.runInstaller ? `  Installer      ${plan.installSource.installerUrl} (CLI ${plan.installSource.cliVersion}, ${formatInstallSelector(plan.installSource)}, selected by local CLI)\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
+}
+
+async function resolveLocalInstallSource(dependencies, env) {
+  if (dependencies.installSource) return requireInstallSource(dependencies.installSource)
+  const testUrl = env['OPENALICE_REMOTE_TEST_INSTALL_URL'] ?? ''
+  const testKind = env['OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_KIND'] ?? ''
+  const testValue = env['OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_VALUE'] ?? ''
+  if (testUrl || testKind || testValue) {
+    if (!testUrl || !testKind || !testValue) {
+      throw new Error('The remote installer test override requires URL, selector kind, and selector value')
+    }
+    const testSource = parseInstallSource({
+      schemaVersion: 1,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: DEFAULT_INSTALL_SOURCE.cliVersion,
+      selector: { kind: testKind, value: testValue },
+      installerUrl: testUrl,
+    })
+    if (!testSource) throw new Error('The remote installer test override is invalid')
+    return testSource
+  }
+  return readInstallSource()
 }
 
 export async function probeRemoteHost(options, dependencies = {}) {
@@ -451,21 +484,28 @@ export async function probeRemoteHost(options, dependencies = {}) {
   }
   const cliPath = normalizeRemoteCliPath((await runRemote(options, 'command -v openalice 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/openalice" ] || printf "%s\\n" "$HOME/.openalice/bin/openalice"; }', dependencies)).trim())
   if (!cliPath) {
-    return { platform, nodeVersion, hasCurl, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath: null, cliVersion: null, cliCompatible: false, status: null }
+    return { platform, nodeVersion, hasCurl, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath: null, cliVersion: null, installSource: null, cliCompatible: false, status: null }
   }
 
   let cliVersion = null
+  let remoteInstallSource = null
   let status = null
   let cliCompatible = false
   try {
     cliVersion = (await runRemote(options, `${shellQuote(cliPath)} --version`, dependencies)).trim()
+    try {
+      const versionInfo = parseRemoteVersionInfo(await runRemote(options, `${shellQuote(cliPath)} version --json`, dependencies))
+      if (versionInfo.version === cliVersion) remoteInstallSource = versionInfo.installSource
+    } catch {
+      remoteInstallSource = null
+    }
     const statusOutput = await runRemote(options, buildRemoteStatusCommand(options, cliPath), dependencies)
     status = parseRemoteStatus(statusOutput)
     cliCompatible = status.protocol === 1
   } catch {
     cliCompatible = false
   }
-  return { platform, nodeVersion, hasCurl, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath, cliVersion, cliCompatible, status }
+  return { platform, nodeVersion, hasCurl, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath, cliVersion, installSource: remoteInstallSource, cliCompatible, status }
 }
 
 export function buildRemoteCheckoutProbeCommand(appDir) {
@@ -508,12 +548,17 @@ export function buildRemoteServerStopCommand(options, cliPath) {
   return args.join(' ')
 }
 
-export function buildRemoteInstallCommand(installUrl, installVersion, installBaseUrl = '', withRuntimeDeps = false) {
-  const url = shellQuote(installUrl)
-  const version = shellQuote(installVersion)
-  const installEnv = installBaseUrl ? `OPENALICE_INSTALL_BASE_URL=${shellQuote(installBaseUrl)} ` : ''
+export function buildRemoteInstallCommand(installSource, installBaseUrl = '', withRuntimeDeps = false) {
+  const source = requireInstallSource(installSource)
+  const url = shellQuote(source.installerUrl)
+  const selectorFlag = source.selector.kind === 'branch' ? '--branch' : '--version'
+  const selectorValue = shellQuote(source.selector.value)
+  const installEnv = [
+    `OPENALICE_INSTALL_URL=${url}`,
+    installBaseUrl ? `OPENALICE_INSTALL_BASE_URL=${shellQuote(installBaseUrl)}` : '',
+  ].filter(Boolean).join(' ')
   const runtimeDepsFlag = withRuntimeDeps ? ' --with-runtime-deps' : ''
-  return `set -eu\ntmp=$(mktemp "${'${TMPDIR:-/tmp}'}/openalice-install.XXXXXX")\ntrap 'rm -f "$tmp"' EXIT HUP INT TERM\ncurl -fsSL ${url} -o "$tmp"\n${installEnv}bash "$tmp" --yes --no-modify-path --version ${version}${runtimeDepsFlag}`
+  return `set -eu\ntmp=$(mktemp "${'${TMPDIR:-/tmp}'}/openalice-install.XXXXXX")\ntrap 'rm -f "$tmp"' EXIT HUP INT TERM\ncurl -fsSL ${url} -o "$tmp"\n${installEnv} bash "$tmp" --yes --no-modify-path ${selectorFlag} ${selectorValue}${runtimeDepsFlag}`
 }
 
 export function buildRemoteSshArgs(options, remoteCommand) {
@@ -671,7 +716,19 @@ Options:
   -h, --help              Show this help
 
 --yes never implies --takeover. Stage 2 supports Linux and macOS SSH hosts.
+Remote CLI installation always uses the invoking local CLI's recorded installer
+source; this command has no independent branch or version selector.
 `
+}
+
+function parseRemoteVersionInfo(output) {
+  const line = output.trim().split(/\r?\n/).filter(Boolean).at(-1)
+  const value = JSON.parse(line ?? '')
+  const installSource = parseInstallSource(value?.installSource)
+  if (typeof value?.version !== 'string' || !installSource || value.version !== installSource.cliVersion) {
+    throw new Error('Remote openalice version returned an invalid payload')
+  }
+  return { version: value.version, installSource }
 }
 
 function parseRemoteStatus(output) {

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -19,6 +19,14 @@ import {
   runSshCommand,
 } from './remote.mjs'
 
+const masterInstallSource = {
+  schemaVersion: 1,
+  repository: 'TraderAlice/OpenAlice',
+  cliVersion: '0.2.0',
+  selector: { kind: 'branch', value: 'master' },
+  installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/master/install',
+}
+
 describe('OpenAlice managed remote connector', () => {
   it('parses an explicit SSH and remote Runtime surface', () => {
     expect(parseRemoteArgs([
@@ -55,6 +63,14 @@ describe('OpenAlice managed remote connector', () => {
     expect(() => parseRemoteArgs(['-oProxyCommand=bad'])).toThrow('Unknown option')
     expect(() => parseRemoteArgs(['host name'])).toThrow('unsupported characters')
     expect(() => parseRemoteArgs(['host', '--app-dir', '~/OpenAlice'])).toThrow('absolute path')
+    expect(() => parseRemoteArgs(['host', '--branch', 'dev'])).toThrow('Unknown option')
+  })
+
+  it('builds a remote installer command from local provenance, not remote flags', () => {
+    const command = buildRemoteInstallCommand(masterInstallSource)
+    expect(command).toContain('OPENALICE_INSTALL_URL=')
+    expect(command).toContain("--branch 'master'")
+    expect(command).not.toContain('--version')
   })
 
   it('plans install and start separately, with no implicit takeover', () => {
@@ -95,6 +111,28 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.installCli).toBe(false)
     expect(plan.startServer).toBe(false)
     expect(plan.blocker).toBe('')
+  })
+
+  it('updates a protocol-compatible remote CLI when its install source differs from local', () => {
+    const remote = compatibleRemote()
+    remote.installSource = {
+      ...masterInstallSource,
+      selector: { kind: 'branch', value: 'dev' },
+      installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install',
+    }
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+    expect(plan.installCli).toBe(true)
+    expect(plan.mutations).toEqual(['update remote OpenAlice CLI'])
+  })
+
+  it('updates a protocol-compatible remote CLI when only its CLI version differs', () => {
+    const remote = compatibleRemote()
+    remote.cliVersion = '0.1.0'
+    remote.installSource = { ...masterInstallSource, cliVersion: '0.1.0' }
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+    expect(plan.cliCompatible).toBe(true)
+    expect(plan.cliMatchesLocal).toBe(false)
+    expect(plan.mutations).toEqual(['update remote OpenAlice CLI'])
   })
 
   it('installs missing managed Pi and plans a self-owned Server restart from its recorded source', () => {
@@ -219,10 +257,19 @@ describe('OpenAlice managed remote connector', () => {
 
   it('applies the normal installer, starts the Server, re-probes, then opens the tunnel', async () => {
     const options = parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice', '--yes', '--no-open'])
+    const installSource = {
+      ...masterInstallSource,
+      selector: { kind: 'version', value: 'dev-test' },
+      installerUrl: 'https://example.test/install',
+    }
+    const installedRemote = compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} })
+    installedRemote.installSource = installSource
+    const runningRemote = compatibleRemote()
+    runningRemote.installSource = installSource
     const probeRemote = vi.fn()
       .mockResolvedValueOnce(missingRemote())
-      .mockResolvedValueOnce(compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} }))
-      .mockResolvedValueOnce(compatibleRemote())
+      .mockResolvedValueOnce(installedRemote)
+      .mockResolvedValueOnce(runningRemote)
     const runRemote = vi.fn(async () => '')
     const connectTunnel = vi.fn(async () => 0)
     const stdout = { write: vi.fn() }
@@ -231,16 +278,14 @@ describe('OpenAlice managed remote connector', () => {
       probeRemote,
       runRemote,
       connectTunnel,
-      installUrl: 'https://example.test/install',
-      installVersion: 'dev-test',
+      installSource,
       installBaseUrl: 'https://example.test/packages/cli/',
       stdout,
     })).resolves.toBe(0)
 
     expect(runRemote).toHaveBeenCalledTimes(2)
     expect(runRemote.mock.calls[0][1]).toBe(buildRemoteInstallCommand(
-      'https://example.test/install',
-      'dev-test',
+      installSource,
       'https://example.test/packages/cli/',
       true,
     ))
@@ -421,6 +466,7 @@ function missingRemote() {
     runtimeBuildToolsMissing: ['git', 'python3', 'make', 'cxx'],
     cliPath: null,
     cliVersion: null,
+    installSource: null,
     cliCompatible: false,
     status: null,
   }
@@ -439,6 +485,7 @@ function compatibleRemote(statusOverrides = {}) {
     runtimeBuildToolsMissing: [],
     cliPath: '/home/alice/.openalice/bin/openalice',
     cliVersion: '0.2.0',
+    installSource: masterInstallSource,
     cliCompatible: true,
     status: {
       protocol: 1,

--- a/scripts/install-smoke/interactive.sh
+++ b/scripts/install-smoke/interactive.sh
@@ -57,6 +57,7 @@ printf '\n[install-playground] You are now in the container after the installer.
 printf 'Try: command -v openalice; openalice --version; pi --version; cat ~/.bashrc\n'
 printf 'Re-run: curl -fsSL "$OPENALICE_INSTALL_URL" | bash\n'
 printf 'Preview only: curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan\n'
+printf 'Dev channel: curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan --branch dev\n'
 printf 'Runtime plan: curl -fsSL "$OPENALICE_INSTALL_URL" | bash -s -- --plan --with-runtime-deps\n'
 printf 'Package log: cat "$OPENALICE_RUNTIME_DEPS_LOG"\n'
 printf 'After a successful re-run: source ~/.bashrc\n'

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -36,6 +36,7 @@ cleanup() {
 trap cleanup EXIT
 
 installer_url="http://127.0.0.1:18080/install"
+export OPENALICE_INSTALL_URL="$installer_url"
 for _ in $(seq 1 100); do
   if curl --fail --silent --output /dev/null "$installer_url"; then
     break
@@ -53,29 +54,47 @@ curl --fail --silent --output /dev/null "$installer_url" || {
 
 export OPENALICE_INSTALL_BASE_URL="http://127.0.0.1:18080/packages/cli/"
 
-if curl -fsSL "$installer_url" | bash -s -- --version smoke-unattended >"$refusal_log" 2>&1; then
+default_plan="$(curl -fsSL "$installer_url" | bash -s -- --plan)"
+grep -Fq "Branch         master" <<<"$default_plan" || fail "installer did not default to master"
+dev_plan="$(curl -fsSL "$installer_url" | bash -s -- --plan --branch dev)"
+grep -Fq "Branch         dev" <<<"$dev_plan" || fail "installer did not accept an explicit dev branch"
+if curl -fsSL "$installer_url" | bash -s -- --plan --branch dev --version v0.2.0 >"$refusal_log" 2>&1; then
+  fail "installer accepted both --branch and --version"
+fi
+grep -Fq "Use only one of --branch or --version" "$refusal_log" \
+  || fail "installer selector conflict was not explained"
+
+if curl -fsSL "$installer_url" | bash -s -- --branch smoke-unattended >"$refusal_log" 2>&1; then
   fail "installer proceeded without interactive or explicit approval"
 fi
 grep -Fq -- "--yes" "$refusal_log" || fail "unattended refusal did not explain --yes"
 [[ ! -e "$HOME/.openalice" ]] || fail "unattended refusal changed the install root"
 
-install_version() {
-  local version="$1"
-  curl -fsSL "$installer_url" | bash -s -- --yes --version "$version"
+install_branch() {
+  local branch="$1"
+  curl -fsSL "$installer_url" | bash -s -- --yes --branch "$branch"
 }
 
-install_version_with_runtime_deps() {
-  local version="$1"
-  curl -fsSL "$installer_url" | bash -s -- --yes --with-runtime-deps --version "$version"
+install_branch_with_runtime_deps() {
+  local branch="$1"
+  curl -fsSL "$installer_url" | bash -s -- --yes --with-runtime-deps --branch "$branch"
 }
 
 mkdir -p "$HOME/.openalice/.cli-install.lock"
 printf '99999999\n' > "$HOME/.openalice/.cli-install.lock/pid"
-install_version smoke-v1
+install_branch smoke-v1
 
 bin_dir="$HOME/.openalice/bin"
 versions_dir="$HOME/.openalice/cli-versions"
 [[ "$($bin_dir/openalice --version)" == "0.2.0" ]] || fail "installed CLI version check failed"
+install_source="$($bin_dir/openalice version --json)"
+node -e '
+const value = JSON.parse(process.argv[1]);
+if (value.version !== "0.2.0") process.exit(1);
+if (value.installSource?.cliVersion !== "0.2.0") process.exit(1);
+if (value.installSource?.selector?.kind !== "branch" || value.installSource?.selector?.value !== "smoke-v1") process.exit(1);
+if (value.installSource?.installerUrl !== "http://127.0.0.1:18080/install") process.exit(1);
+' "$install_source" || fail "installed CLI did not preserve its install source"
 [[ "$($bin_dir/pi --version)" == "0.80.6" ]] || fail "installed managed Pi version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"
 server_status="$($bin_dir/openalice server status --home "$HOME/openalice-server-smoke" --json)"
@@ -88,12 +107,15 @@ if (status.class !== "absent" || status.state !== "absent") process.exit(1);
 [[ ! -e "$HOME/.openalice/.cli-install.lock" ]] || fail "installer lock was not released"
 v1_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v1-*' -print -quit)"
 [[ -n "$v1_release" && -f "$v1_release/bin/openalice.mjs" ]] || fail "content-addressed CLI release was not installed"
+[[ -f "$v1_release/install-source.json" ]] || fail "content-addressed CLI release omitted install source metadata"
 [[ -f "$v1_release/managed/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js" ]] \
   || fail "content-addressed managed Pi runtime was not installed"
 grep -Fq "OPENALICE_MANAGED_PI_PATH" "$bin_dir/openalice" \
   || fail "OpenAlice launcher does not inject the managed Pi path"
 cmp /fixture/packages/cli/src/local-start.mjs "$v1_release/src/local-start.mjs" \
   || fail "downloaded CLI file differs from the fixture"
+cmp /fixture/packages/cli/src/install-source.mjs "$v1_release/src/install-source.mjs" \
+  || fail "downloaded install-source module differs from the fixture"
 cmp /fixture/packages/cli/src/remote.mjs "$v1_release/src/remote.mjs" \
   || fail "downloaded Remote CLI file differs from the fixture"
 cmp /fixture/packages/cli/src/runtime-deps.mjs "$v1_release/src/runtime-deps.mjs" \
@@ -110,12 +132,12 @@ path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
   || fail "installer did not add its managed PATH block"
 
 [[ ! -s "$runtime_deps_log" ]] || fail "default install changed system packages"
-runtime_plan="$(curl -fsSL "$installer_url" | bash -s -- --plan --with-runtime-deps --version smoke-v1)"
+runtime_plan="$(curl -fsSL "$installer_url" | bash -s -- --plan --with-runtime-deps --branch smoke-v1)"
 grep -Fq "sudo apt-get update && sudo apt-get install -y git python3 make g++" <<<"$runtime_plan" \
   || fail "runtime dependency plan did not show the exact package command"
 [[ ! -s "$runtime_deps_log" ]] || fail "runtime dependency plan changed system packages"
 
-install_version_with_runtime_deps smoke-v1
+install_branch_with_runtime_deps smoke-v1
 grep -Fxq "apt-get update" "$runtime_deps_log" || fail "runtime dependency setup skipped apt-get update"
 grep -Fxq "apt-get install -y git python3 make g++" "$runtime_deps_log" \
   || fail "runtime dependency setup used the wrong package list"
@@ -123,13 +145,13 @@ for tool in git python3 make g++; do
   command -v "$tool" >/dev/null 2>&1 || fail "runtime dependency setup did not provide $tool"
 done
 
-install_version smoke-v1
+install_branch smoke-v1
 path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
 [[ "$path_count" == "1" ]] || fail "repeat install duplicated the shell PATH entry"
 v1_count="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v1-*' | wc -l | tr -d ' ')"
 [[ "$v1_count" == "1" ]] || fail "repeat install duplicated an identical CLI release"
 
-install_version smoke-v2
+curl -fsSL "$installer_url" | bash -s -- --yes --version smoke-v2
 v2_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v2-*' -print -quit)"
 [[ -d "$v1_release" ]] || fail "version switch removed the previous CLI"
 [[ -n "$v2_release" && -d "$v2_release" ]] || fail "version switch did not install the new CLI"

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -90,9 +90,10 @@ try {
     HOME: localHome,
     PATH: `${fixtureBin}:${process.env.PATH ?? ''}`,
     OPENALICE_REMOTE_SMOKE_SSH_CONFIG: join(sshDir, 'config'),
-    OPENALICE_REMOTE_INSTALL_URL: 'http://127.0.0.1:18080/install',
-    OPENALICE_REMOTE_INSTALL_BASE_URL: 'http://127.0.0.1:18080/packages/cli/',
-    OPENALICE_REMOTE_VERSION: 'remote-smoke',
+    OPENALICE_REMOTE_TEST_INSTALL_URL: 'http://127.0.0.1:18080/install',
+    OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_KIND: 'version',
+    OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_VALUE: 'remote-smoke',
+    OPENALICE_REMOTE_TEST_INSTALL_BASE_URL: 'http://127.0.0.1:18080/packages/cli/',
   }
   await waitForSsh(remoteTarget, smokeEnv)
 


### PR DESCRIPTION
## Summary
- default the bootstrap installer to `master`, with explicit `--branch dev` and mutually exclusive tag/commit selection
- persist CLI version and installer provenance, then make managed remote reproduce that identity without exposing its own branch/version flags
- document the Herdr-inspired managed bootstrap boundary: remote pull of the small control CLI, never full Runtime upload over SSH
- expand installer and SSH smoke coverage plus the manual playground

## Verification
- `pnpm -F @traderalice/openalice-cli build`
- `pnpm -F @traderalice/openalice-cli test` (66 tests)
- `npx tsc --noEmit`
- `pnpm test` (3012 passed, 6 skipped)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- manual `pnpm test:install:docker --interactive` walkthrough (default master, decline tools, approve install, version/provenance/help checks)