### PR TITLE
Fix Workspace Manager path assertion on Windows

### DIFF
--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -933,7 +933,7 @@ describe('Workspace manager surface routes', () => {
       expect.objectContaining({
         approveProject: true,
         appendSystemPrompt: expect.stringContaining('Workspace Manager'),
-        skills: ['/repo/default/skills/workspace-manager'],
+        skills: [join('/repo', 'default', 'skills', 'workspace-manager')],
       }),
     );
     expect(prompt).toHaveBeenCalledWith(createdRecord.id, 'Audit the floor.');


### PR DESCRIPTION
## Summary
- derive the expected Workspace Manager skill path with `node:path.join`
- keep the assertion aligned with the production cross-platform path contract

## Verification
- `npx tsc --noEmit`
- `pnpm test`
- `pnpm exec vitest run src/webui/routes/workspaces.spec.ts`

## Boundary touch
- test-only fix; no runtime or product behavior changes