### PR TITLE
Guide AI credential setup by provider

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -33,6 +33,32 @@ and injects `OPENALICE_MANAGED_PI_*` when it starts a source-backed Runtime. It
 still relies on host Node/npm and does not inherit Electron's managed
 Git/Bash/search-tool payload.
 
+### AI credential setup contract
+
+**Settings → AI Provider** is an account-to-runtime setup flow, not a generic
+bag of provider fields. The form must make these decisions explicit before a
+key can be saved:
+
+1. which provider account issued the API key (subscription logins remain in the
+   native Claude Code or Codex CLI);
+2. which region or endpoint owns that key;
+3. which Workspace Agent runtimes can consume the endpoint's declared API
+   protocol;
+4. which exact model ID to test and remember as the credential default; and
+5. whether that exact key + endpoint + protocol + model combination passes a
+   live connection probe.
+
+Provider presets own provider-specific key, region, and model guidance. Runtime
+compatibility is derived from the preset's wire map rather than duplicated as
+editorial copy. Protocol names and raw endpoints belong behind an advanced
+detail unless the user chose **Custom**, where protocol and base URL are
+required inputs. The managed credential path is key-bearing; keyless local
+servers and subscription auth stay in the native CLI's own configuration.
+
+Editing must round-trip the stored `lastModel` and any endpoint that no longer
+matches a current preset. A catalog refresh must never silently replace either
+value merely because the user opened and saved the form.
+
 ### Desktop data-location selection
 
 The desktop resolves the complete `OPENALICE_HOME` before acquiring runtime

--- a/src/ai-providers/preset-catalog.spec.ts
+++ b/src/ai-providers/preset-catalog.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { LONGCAT } from './preset-catalog.js';
+import { DEFAULT_MODEL_BY_VENDOR, LONGCAT } from './preset-catalog.js';
+import { BUILTIN_PRESETS } from './presets.js';
 
 describe('LONGCAT preset', () => {
   it('uses the versioned OpenAI base URL required by the OpenAI SDK', () => {
@@ -11,5 +12,54 @@ describe('LONGCAT preset', () => {
       apiKey: 'test-key',
     }) as { baseUrl?: string };
     expect(parsed.baseUrl).toBe('https://api.longcat.chat/openai/v1');
+  });
+});
+
+describe('credential form catalog', () => {
+  it('serializes provider-aware setup guidance for every API-key preset', () => {
+    const apiKeyPresets = BUILTIN_PRESETS.filter((preset) => {
+      const properties = preset.schema['properties'] as Record<string, unknown> | undefined;
+      return !!properties?.['apiKey'];
+    });
+
+    expect(apiKeyPresets.length).toBeGreaterThan(0);
+    for (const preset of apiKeyPresets) {
+      expect(preset.setup, preset.id).toMatchObject({
+        apiKeyLabel: expect.any(String),
+        apiKeyHelp: expect.any(String),
+        modelHelp: expect.any(String),
+      });
+    }
+  });
+
+  it('keeps each declared model default inside its suggestion catalog', () => {
+    for (const preset of BUILTIN_PRESETS) {
+      const properties = preset.schema['properties'] as Record<string, Record<string, unknown>> | undefined;
+      const model = properties?.['model'];
+      const defaultModel = model?.['default'];
+      const suggestions = model?.['oneOf'] as Array<{ const: string }> | undefined;
+      if (typeof defaultModel === 'string' && suggestions?.length) {
+        expect(suggestions.map((option) => option.const), preset.id).toContain(defaultModel);
+      }
+    }
+  });
+
+  it('keeps injection fallbacks aligned with the model shown by the form', () => {
+    const vendorByPreset: Record<string, string> = {
+      'claude-api': 'anthropic',
+      'codex-api': 'openai',
+      gemini: 'google',
+      minimax: 'minimax',
+      glm: 'glm',
+      kimi: 'kimi',
+      deepseek: 'deepseek',
+      longcat: 'longcat',
+    };
+
+    for (const [presetId, vendor] of Object.entries(vendorByPreset)) {
+      const preset = BUILTIN_PRESETS.find((item) => item.id === presetId)!;
+      const properties = preset.schema['properties'] as Record<string, Record<string, unknown>>;
+      expect(DEFAULT_MODEL_BY_VENDOR[vendor], presetId).toBe(properties['model']?.['default']);
+    }
   });
 });

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -38,6 +38,20 @@ export interface RegionOption {
   wires: Partial<Record<WireShape, string>>
 }
 
+/**
+ * Provider-aware copy for the credential form. The storage shape stays
+ * vendor-neutral, but users should not have to infer whether a subscription
+ * login belongs here, whether a key is region-bound, or what the model field
+ * will be used for.
+ */
+export interface CredentialSetupGuide {
+  apiKeyLabel: string
+  apiKeyPlaceholder?: string
+  apiKeyHelp: string
+  modelHelp: string
+  regionHelp?: string
+}
+
 export interface PresetDef {
   id: string
   label: string
@@ -54,6 +68,8 @@ export interface PresetDef {
    * (free-form).
    */
   regions?: RegionOption[]
+  /** User-facing guidance for the API-key credential form. */
+  setup?: CredentialSetupGuide
   writeOnlyFields?: string[]
 }
 
@@ -95,6 +111,12 @@ export const CLAUDE_API: PresetDef = {
     { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
   ],
   regions: [{ id: 'official', label: 'Official (api.anthropic.com)', wires: { anthropic: '' } }],
+  setup: {
+    apiKeyLabel: 'Anthropic API key',
+    apiKeyPlaceholder: 'sk-ant-...',
+    apiKeyHelp: 'Use a key from Anthropic Console. Claude Pro/Max is a separate Claude Code login and does not belong in this field.',
+    modelHelp: 'Choose an Anthropic API model ID. OpenAlice tests this exact model and remembers it as the default for this credential.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -138,6 +160,12 @@ export const CODEX_API: PresetDef = {
   // current API (what codex speaks); Chat Completions is the legacy shape
   // opencode/pi use.
   regions: [{ id: 'official', label: 'OpenAI (api.openai.com)', wires: { 'openai-responses': '', 'openai-chat': '' } }],
+  setup: {
+    apiKeyLabel: 'OpenAI API key',
+    apiKeyPlaceholder: 'sk-...',
+    apiKeyHelp: 'Use an OpenAI Platform API key. A ChatGPT subscription is a separate Codex CLI login and does not belong in this field.',
+    modelHelp: 'Choose a model enabled for this API project. The saved model becomes this credential’s default in new Workspace injections.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -149,6 +177,7 @@ export const GEMINI: PresetDef = {
   description: 'Google AI via API key',
   category: 'third-party',
   defaultName: 'Google Gemini',
+  hint: 'OpenAlice uses Google’s official OpenAI-compatible endpoint for this credential. It can drive Pi and opencode; it is not a native Gemini wire for Claude Code or Codex.',
   zodSchema: z.object({
     backend: z.literal('vercel-ai-sdk'),
     provider: z.literal('google'),
@@ -163,6 +192,12 @@ export const GEMINI: PresetDef = {
   // Google's OpenAI-compatibility layer (the native google-generative-ai wire
   // isn't a supported shape yet). Reachable by opencode/pi.
   regions: [{ id: 'default', label: 'Google', wires: { 'openai-chat': 'https://generativelanguage.googleapis.com/v1beta/openai/' } }],
+  setup: {
+    apiKeyLabel: 'Google AI API key',
+    apiKeyPlaceholder: 'AIza...',
+    apiKeyHelp: 'Use a Gemini API key from Google AI Studio. OpenAlice sends it to Google’s OpenAI-compatible API endpoint.',
+    modelHelp: 'Choose a Gemini model exposed by that compatibility endpoint, or paste another exact model ID available to your key.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -199,6 +234,12 @@ export const MINIMAX: PresetDef = {
     { id: 'MiniMax-M3', label: 'MiniMax M3' },
     { id: 'MiniMax-M2.7', label: 'MiniMax M2.7' },
   ],
+  setup: {
+    apiKeyLabel: 'MiniMax API key',
+    apiKeyHelp: 'Use the API key issued by the MiniMax platform selected above. China and International keys are not interchangeable.',
+    modelHelp: 'MiniMax model IDs are case-sensitive. Pick a suggestion or paste the exact model ID shown by the selected platform.',
+    regionHelp: 'Choose the platform that issued this key. OpenAlice will store both supported API protocols for that region.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -229,6 +270,12 @@ export const GLM: PresetDef = {
   models: [
     { id: 'glm-5.2', label: 'GLM 5.2' },
   ],
+  setup: {
+    apiKeyLabel: 'GLM API key',
+    apiKeyHelp: 'Use the API key issued by the Zhipu platform selected above. China and International keys are region-bound.',
+    modelHelp: 'Use the exact GLM model ID available to this account. OpenAlice remembers it as this credential’s default.',
+    regionHelp: 'Choose the platform that issued this key; it determines the endpoints OpenAlice injects.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -265,6 +312,12 @@ export const KIMI: PresetDef = {
     { id: 'kimi-k2.7-code', label: 'Kimi K2.7 Code' },
     { id: 'kimi-k2.6', label: 'Kimi K2.6' },
   ],
+  setup: {
+    apiKeyLabel: 'Moonshot API key',
+    apiKeyHelp: 'Use the API key issued by the Moonshot platform selected above. China and International keys are region-bound.',
+    modelHelp: 'Use the exact Moonshot model ID available on the selected platform; model IDs can differ by region and rollout.',
+    regionHelp: 'Choose the platform that issued this key; OpenAlice cannot use a China key against the International endpoint or vice versa.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -292,6 +345,11 @@ export const DEEPSEEK: PresetDef = {
   models: [
     { id: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro (flagship)' },
   ],
+  setup: {
+    apiKeyLabel: 'DeepSeek API key',
+    apiKeyHelp: 'Use a key from the DeepSeek API platform. This is separate from a consumer chat account.',
+    modelHelp: 'Choose a DeepSeek API model ID or paste another exact model ID enabled for the key.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -322,6 +380,11 @@ export const LONGCAT: PresetDef = {
   models: [
     { id: 'LongCat-2.0', label: 'LongCat 2.0' },
   ],
+  setup: {
+    apiKeyLabel: 'LongCat API key',
+    apiKeyHelp: 'Use a key accepted by api.longcat.chat. OpenAlice stores both LongCat-compatible protocol endpoints with this credential.',
+    modelHelp: 'Use the exact LongCat API model ID. The saved value is tested now and reused as the credential default.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -343,6 +406,11 @@ export const CUSTOM: PresetDef = {
   }),
   // No `regions` — Custom is free-form: the form lets the user pick any wire
   // shape and type the endpoint URL by hand.
+  setup: {
+    apiKeyLabel: 'Endpoint API key',
+    apiKeyHelp: 'Use a key accepted by this endpoint. Subscription logins and keyless local servers are configured in the agent CLI instead of this managed credential path.',
+    modelHelp: 'Enter the exact, case-sensitive model ID exposed by the endpoint. OpenAlice cannot discover custom model names automatically.',
+  },
   writeOnlyFields: ['apiKey'],
 }
 
@@ -374,7 +442,7 @@ export const PRESET_CATALOG: PresetDef[] = [
 export const DEFAULT_MODEL_BY_VENDOR: Record<string, string> = {
   anthropic: 'claude-opus-4-8',
   openai: 'gpt-5.5',
-  google: 'gemini-2.5-pro',
+  google: 'gemini-3.5-flash',
   minimax: 'MiniMax-M3',
   glm: 'glm-5.2',
   kimi: 'kimi-k2.7-code',

--- a/src/ai-providers/presets.ts
+++ b/src/ai-providers/presets.ts
@@ -10,7 +10,12 @@
  */
 
 import { z } from 'zod'
-import { PRESET_CATALOG, type PresetDef, type WireShape } from './preset-catalog.js'
+import {
+  PRESET_CATALOG,
+  type CredentialSetupGuide,
+  type PresetDef,
+  type WireShape,
+} from './preset-catalog.js'
 
 // ==================== Serialized Preset (sent to frontend) ====================
 
@@ -32,6 +37,8 @@ export interface SerializedPreset {
   /** Regions × their per-shape endpoints — the form's region picker + the wire
    *  capabilities a credential created here will declare. */
   regions?: SerializedRegion[]
+  /** Provider-specific copy that explains the account, key, and model fields. */
+  setup?: CredentialSetupGuide
 }
 
 // ==================== Schema post-processing ====================
@@ -68,4 +75,5 @@ export const BUILTIN_PRESETS: SerializedPreset[] = PRESET_CATALOG.map(def => ({
   defaultName: def.defaultName,
   schema: buildJsonSchema(def),
   ...(def.regions ? { regions: def.regions } : {}),
+  ...(def.setup ? { setup: def.setup } : {}),
 }))

--- a/src/webui/routes/config-workspace-defaults.spec.ts
+++ b/src/webui/routes/config-workspace-defaults.spec.ts
@@ -126,6 +126,24 @@ describe('POST /credentials', () => {
   })
 })
 
+describe('GET /credentials', () => {
+  it('returns the remembered model so editing does not replace it with the catalog default', async () => {
+    const routes = createConfigRoutes()
+    credStore['openai-1'] = {
+      ...credStore['openai-1']!,
+      lastModel: 'gpt-account-specific',
+    }
+
+    const { status, body } = await req(routes, 'GET', '/credentials')
+
+    expect(status).toBe(200)
+    const credentials = body!.credentials as Array<Record<string, unknown>>
+    expect(credentials.find((credential) => credential.slug === 'openai-1')).toMatchObject({
+      lastModel: 'gpt-account-specific',
+    })
+  })
+})
+
 describe('POST /credentials/test', () => {
   const mockBody = {
     wireShape: 'openai-chat',

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -114,6 +114,7 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
         wires: credentialWires(cred), // derives from legacy {baseUrl,wireShape} too
         apiKey: cred.apiKey ?? null,
         hasApiKey: !!cred.apiKey,
+        ...(cred.lastModel ? { lastModel: cred.lastModel } : {}),
       }))
       return c.json({ credentials: list })
     } catch (err) {

--- a/src/workspaces/credential-injection.ts
+++ b/src/workspaces/credential-injection.ts
@@ -7,7 +7,8 @@
  * adapter instead consumes a `WorkspaceAiCred` (`cli-adapter.ts`) and renders it
  * into its own file format. A credential carries no model — model is always a
  * per-use choice — so the caller supplies it (plus the adapter-specific
- * `authMode` / `wireApi` knobs) via `overrides`.
+ * `authMode` / `wireApi` knobs) via `overrides`. The vault's `lastModel` is a
+ * remembered default, not a lock; callers may still supply a per-use model.
  *
  * This is the one place that maps Credential → WorkspaceAiCred, used by
  * template-driven injection at workspace-create time and reusable by any future
@@ -76,9 +77,9 @@ export function matchCredentialByApiKey(
 
 /**
  * The model to inject for a credential: its remembered `lastModel`, else the
- * vendor's catalog flagship, else null (custom creds with no history — let the
- * runtime decide). A credential never carries its own model, so this is the
- * single resolution point shared by quick-chat injection.
+ * vendor's catalog default, else null (custom creds with no history — let the
+ * runtime decide). This is the single resolution point shared by quick-chat
+ * injection; a Workspace may still override it for one use.
  */
 export function resolveInjectionModel(cred: Pick<Credential, 'vendor' | 'lastModel'>): string | null {
   return cred.lastModel ?? DEFAULT_MODEL_BY_VENDOR[cred.vendor] ?? null

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -77,6 +77,14 @@ export interface SerializedRegion {
   wires: Partial<Record<WireShape, string>>
 }
 
+export interface CredentialSetupGuide {
+  apiKeyLabel: string
+  apiKeyPlaceholder?: string
+  apiKeyHelp: string
+  modelHelp: string
+  regionHelp?: string
+}
+
 export interface Preset {
   id: string
   label: string
@@ -88,6 +96,8 @@ export interface Preset {
   /** Regions × their per-shape endpoints — the form picks a region; the
    *  credential captures that region's whole wires map (its capabilities). */
   regions?: SerializedRegion[]
+  /** Provider-aware guidance for the API-key credential form. */
+  setup?: CredentialSetupGuide
 }
 
 /** Subset of JSON Schema types we use for form rendering. */

--- a/ui/src/components/FirstRunGuide.tsx
+++ b/ui/src/components/FirstRunGuide.tsx
@@ -58,6 +58,12 @@ const ONBOARDING_TEST_PRESET: Preset = {
   category: 'custom',
   defaultName: 'OpenAlice Test Provider',
   hint: 'Development-only. This provider exists only in onboarding test mode and never calls an external AI service.',
+  setup: {
+    apiKeyLabel: 'Onboarding test API key',
+    apiKeyPlaceholder: 'oa_test_ok',
+    apiKeyHelp: 'This development-only key is prefilled and talks only to the local onboarding mock.',
+    modelHelp: 'The local mock exposes one fixed model so the full test-and-save flow can run offline.',
+  },
   schema: {
     type: 'object',
     properties: {
@@ -65,6 +71,7 @@ const ONBOARDING_TEST_PRESET: Preset = {
       model: {
         type: 'string',
         title: 'Model',
+        default: 'openalice-onboarding-test',
         oneOf: [{ const: 'openalice-onboarding-test', title: 'Onboarding Mock' }],
       },
     },

--- a/ui/src/components/credentials/CredentialModal.spec.tsx
+++ b/ui/src/components/credentials/CredentialModal.spec.tsx
@@ -65,6 +65,62 @@ const onboardingTestPreset: Preset = {
   ],
 }
 
+const geminiPreset: Preset = {
+  id: 'gemini',
+  label: 'Google Gemini',
+  description: 'Google AI via API key',
+  category: 'third-party',
+  defaultName: 'Google Gemini',
+  hint: 'OpenAlice uses Google’s official OpenAI-compatible endpoint.',
+  setup: {
+    apiKeyLabel: 'Google AI API key',
+    apiKeyPlaceholder: 'AIza...',
+    apiKeyHelp: 'Use a Gemini API key from Google AI Studio.',
+    modelHelp: 'Choose a Gemini model exposed by the compatibility endpoint.',
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      apiKey: { type: 'string' },
+      model: {
+        type: 'string',
+        default: 'gemini-default',
+        oneOf: [
+          { const: 'gemini-list-first', title: 'First suggestion' },
+          { const: 'gemini-default', title: 'Catalog default' },
+        ],
+      },
+    },
+  },
+  regions: [
+    {
+      id: 'google',
+      label: 'Google',
+      wires: { 'openai-chat': 'https://generativelanguage.googleapis.com/v1beta/openai/' },
+    },
+  ],
+}
+
+const customPreset: Preset = {
+  id: 'custom',
+  label: 'Custom',
+  description: 'Custom compatible endpoint',
+  category: 'custom',
+  defaultName: '',
+  setup: {
+    apiKeyLabel: 'Endpoint API key',
+    apiKeyHelp: 'Use a key accepted by this endpoint.',
+    modelHelp: 'Enter the exact model ID.',
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      apiKey: { type: 'string' },
+      model: { type: 'string' },
+    },
+  },
+}
+
 function setup() {
   const onClose = vi.fn()
   const onSaved = vi.fn().mockResolvedValue(undefined)
@@ -87,6 +143,48 @@ afterEach(() => {
 })
 
 describe('CredentialModal', () => {
+  it('explains provider-specific key, runtime, and model behavior before testing', () => {
+    render(
+      <CredentialModal
+        mode="add"
+        presets={[geminiPreset]}
+        initialPresetId={geminiPreset.id}
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Use a Gemini API key from Google AI Studio.')).toBeTruthy()
+    expect(screen.getByText('Choose a Gemini model exposed by the compatibility endpoint.')).toBeTruthy()
+    expect(screen.getByText('Pi')).toBeTruthy()
+    expect(screen.getByText('opencode')).toBeTruthy()
+    expect(screen.queryByText('Claude Code')).toBeNull()
+    expect(screen.queryByText('Codex')).toBeNull()
+    expect(screen.getByPlaceholderText('AIza...')).toBeTruthy()
+    expect(screen.getByDisplayValue('gemini-default')).toBeTruthy()
+  })
+
+  it('requires a concrete URL for custom providers and explains mode compatibility', () => {
+    render(
+      <CredentialModal
+        mode="add"
+        presets={[customPreset]}
+        initialPresetId={customPreset.id}
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. OpenRouter work key'), { target: { value: 'Gateway' } })
+    fireEvent.change(screen.getByPlaceholderText('Enter API key'), { target: { value: 'sk-gateway' } })
+    fireEvent.change(screen.getByPlaceholderText('Exact provider model ID'), { target: { value: 'gateway-model' } })
+
+    expect(screen.getByRole('option', { name: /OpenAI Chat Completions — opencode, Pi/ })).toBeTruthy()
+    const testButton = screen.getByRole('button', { name: 'Test connection' }) as HTMLButtonElement
+    expect(testButton.disabled).toBe(true)
+    expect(testButton.title).toBe('Enter the custom API base URL.')
+  })
+
   it('can open directly on a provided onboarding test preset', async () => {
     render(
       <CredentialModal
@@ -159,6 +257,43 @@ describe('CredentialModal', () => {
       label: 'OpenAlice Test Provider',
       apiKey: 'oa_test_ok',
       lastModel: 'openalice-onboarding-test',
+    }))
+    expect(onSaved).toHaveBeenCalled()
+  })
+
+  it('preserves a remembered model and unmatched stored endpoint while editing', async () => {
+    vi.mocked(api.config.testCredential).mockResolvedValue({ ok: true, response: 'ready' })
+    vi.mocked(api.config.updateCredential).mockResolvedValue(undefined)
+    const onSaved = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <CredentialModal
+        mode="edit"
+        cred={{
+          slug: 'openai-1',
+          vendor: 'openai',
+          authType: 'api-key',
+          wires: { 'openai-responses': 'https://gateway.example/responses' },
+          apiKey: 'sk-existing',
+          hasApiKey: true,
+          lastModel: 'gpt-account-specific',
+        }}
+        presets={[openAiPreset]}
+        onClose={vi.fn()}
+        onSaved={onSaved}
+      />,
+    )
+
+    expect(screen.getByDisplayValue('gpt-account-specific')).toBeTruthy()
+    expect(screen.getByDisplayValue('Saved custom endpoint (keep unchanged)')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Test connection' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(api.config.updateCredential).toHaveBeenCalled())
+    expect(api.config.updateCredential).toHaveBeenCalledWith('openai-1', expect.objectContaining({
+      wires: { 'openai-responses': 'https://gateway.example/responses' },
+      lastModel: 'gpt-account-specific',
     }))
     expect(onSaved).toHaveBeenCalled()
   })

--- a/ui/src/components/credentials/CredentialModal.tsx
+++ b/ui/src/components/credentials/CredentialModal.tsx
@@ -1,11 +1,15 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { api, type Preset, type WireShape } from '../../api'
 import type { CredentialSummary } from '../../api/config'
 import { Field, inputClass } from '../form'
 import {
   VENDOR_BY_PRESET,
-  WIRE_SHAPE_SHORT,
+  AGENT_LABELS,
+  WIRE_SHAPE_GUIDANCE,
+  compatibleAgentIds,
+  presetCompatibleAgentIds,
+  presetDefaultModel,
   presetModels,
   presetRegions,
   regionById,
@@ -16,12 +20,29 @@ import { useTestGate } from '../../lib/useTestGate'
 import { ModelCombobox } from './PresetFields'
 
 const SHAPE_ORDER: WireShape[] = ['anthropic', 'openai-chat', 'openai-responses']
+const STORED_REGION_ID = '__stored__'
 
 /** Find the region whose wires match a stored credential (for edit mode). */
 function matchRegionId(preset: Preset | null, wires: Partial<Record<WireShape, string>>): string | undefined {
   const shapes = Object.keys(wires) as WireShape[]
   if (shapes.length === 0) return undefined
-  return presetRegions(preset).find((region) => shapes.every((shape) => region.wires[shape] === wires[shape]))?.id
+  return presetRegions(preset).find((region) => {
+    const regionShapes = Object.keys(region.wires) as WireShape[]
+    return regionShapes.length === shapes.length && shapes.every((shape) => region.wires[shape] === wires[shape])
+  })?.id
+}
+
+function validEndpoint(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function agentNames(ids: readonly string[]): string {
+  return ids.map((id) => AGENT_LABELS[id] ?? id).join(', ')
 }
 
 export function CredentialModal({ mode, cred, presets, initialPresetId, initialApiKey, onClose, onSaved }: {
@@ -37,9 +58,16 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
   const initialPreset = mode === 'edit' && cred
     ? vendorPreset(cred.vendor, presets) ?? null
     : presets.find((item) => item.id === initialPresetId) ?? null
+  const storedWires = cred?.wires ?? {}
+  const matchedInitialRegion = matchRegionId(initialPreset, storedWires)
+  const initialRegions = presetRegions(initialPreset)
   const [preset, setPreset] = useState<Preset | null>(initialPreset)
   const [regionId, setRegionId] = useState<string>(
-    () => matchRegionId(initialPreset, cred?.wires ?? {}) ?? presetRegions(initialPreset)[0]?.id ?? '',
+    () => matchedInitialRegion ?? (
+      mode === 'edit' && Object.keys(storedWires).length > 0 && initialRegions.length > 0
+        ? STORED_REGION_ID
+        : initialRegions[0]?.id ?? ''
+    ),
   )
   const customInit = cred ? (SHAPE_ORDER.find((shape) => shape in (cred.wires ?? {})) ?? 'openai-chat') : 'openai-chat'
   const [customName, setCustomName] = useState<string>(cred?.label ?? '')
@@ -48,32 +76,36 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
   const [apiKey, setApiKey] = useState(cred?.apiKey ?? initialApiKey ?? '')
   const [presetQuery, setPresetQuery] = useState('')
   const [showKey, setShowKey] = useState(false)
-  const [model, setModel] = useState(cred?.lastModel ?? '')
+  const [model, setModel] = useState(cred?.lastModel ?? presetDefaultModel(initialPreset))
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const gate = useTestGate()
 
-  useEffect(() => {
-    if (initialPreset && !model) setModel(presetModels(initialPreset)[0]?.id ?? '')
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   const regions = presetRegions(preset)
   const isCustom = !!preset && regions.length === 0
-  const region = regionById(preset, regionId)
+  const usingStoredRegion = !isCustom && regionId === STORED_REGION_ID
+  const region = usingStoredRegion ? undefined : regionById(preset, regionId)
   const models = preset ? presetModels(preset) : []
 
   const wires: Partial<Record<WireShape, string>> = isCustom
     ? (customUrl.trim() ? { [customShape]: customUrl.trim() } : {})
-    : (region?.wires ?? {})
-  const shapes = isCustom ? [customShape] : regionShapes(region)
+    : usingStoredRegion
+      ? storedWires
+      : (region?.wires ?? {})
+  const shapes = isCustom
+    ? [customShape]
+    : usingStoredRegion
+      ? SHAPE_ORDER.filter((shape) => shape in wires)
+      : regionShapes(region)
   const primaryShape = shapes[0]
   const primaryUrl = primaryShape ? (wires[primaryShape] ?? '') : ''
+  const compatibilityWires = isCustom ? { [customShape]: customUrl.trim() } : wires
+  const compatibleAgents = compatibleAgentIds(compatibilityWires)
 
   const pickPreset = (next: Preset) => {
     setPreset(next)
     setRegionId(presetRegions(next)[0]?.id ?? '')
-    setModel(presetModels(next)[0]?.id ?? '')
+    setModel(presetDefaultModel(next))
     setError('')
     gate.reset()
   }
@@ -89,13 +121,29 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
 
   // The fields the test covers. Editing any of them re-locks Save.
   const testKey = `${JSON.stringify(wires)}|${apiKey.trim()}|${model.trim()}`
-  const canTest = !!apiKey.trim() && !!model.trim() && !!primaryShape
+  const customLabel = customName.trim()
+  const formProblem = !preset
+    ? 'Choose a provider first.'
+    : isCustom && !customLabel
+      ? 'Enter a provider name.'
+      : isCustom && !customUrl.trim()
+        ? 'Enter the custom API base URL.'
+        : isCustom && !validEndpoint(customUrl.trim())
+          ? 'Enter a valid http:// or https:// API base URL.'
+          : Object.keys(wires).length === 0 || !primaryShape
+            ? 'Choose an API endpoint.'
+            : !apiKey.trim()
+              ? `Enter the ${preset.setup?.apiKeyLabel?.toLowerCase() ?? 'API key'}.`
+              : !model.trim()
+                ? 'Enter the exact model ID to test and remember.'
+                : ''
+  const canTest = formProblem.length === 0
   const needsTest = mode === 'add' || !!apiKey.trim()
   const canSave = !saving && (!needsTest || gate.passedFor(testKey))
 
   const handleTest = () => {
     if (!canTest || !primaryShape) {
-      setError('Fill the API key + model first')
+      setError(formProblem || 'Complete the required fields first.')
       return
     }
     setError('')
@@ -111,13 +159,8 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
 
   const handleSave = async () => {
     if (!preset) return
-    if (Object.keys(wires).length === 0) {
-      setError('Pick a region / endpoint first')
-      return
-    }
-    const customLabel = customName.trim()
-    if (isCustom && !customLabel) {
-      setError('Provider name is required')
+    if (formProblem) {
+      setError(formProblem)
       return
     }
     const vendor = VENDOR_BY_PRESET[preset.id] ?? 'custom'
@@ -138,11 +181,6 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
           ...(model.trim() ? { lastModel: model.trim() } : {}),
         })
       } else {
-        if (!apiKey.trim()) {
-          setError('API key is required')
-          setSaving(false)
-          return
-        }
         await api.config.addCredential({
           vendor,
           wires,
@@ -177,10 +215,13 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
 
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={onClose}>
-      <div className="bg-bg border border-border rounded-xl shadow-2xl w-full max-w-lg max-h-[85vh] flex flex-col" onClick={(event) => event.stopPropagation()}>
+      <div className="bg-bg border border-border rounded-xl shadow-2xl w-[calc(100vw-24px)] max-w-xl max-h-[88vh] flex flex-col" onClick={(event) => event.stopPropagation()}>
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-          <h2 className="text-[15px] font-semibold text-text">{title}</h2>
-          <button onClick={onClose} className="text-text-muted hover:text-text transition-colors">
+          <div>
+            <h2 className="text-[15px] font-semibold text-text">{title}</h2>
+            <p className="mt-0.5 text-[11px] text-text-muted">Connect a provider account to the agent runtimes that can use it.</p>
+          </div>
+          <button onClick={onClose} aria-label="Close credential dialog" className="text-text-muted hover:text-text transition-colors">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
           </button>
         </div>
@@ -205,6 +246,11 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                     <span className="min-w-0 flex-1">
                       <span className="block truncate text-[12.5px] font-medium text-text">{item.label}</span>
                       <span className="block truncate text-[10.5px] text-text-muted">{item.description}</span>
+                      <span className="mt-0.5 block truncate text-[10px] text-text-muted/75">
+                        {item.category === 'custom'
+                          ? 'Choose an API mode to determine compatible agents'
+                          : `Works with ${agentNames(presetCompatibleAgentIds(item))}`}
+                      </span>
                     </span>
                     {item.category === 'custom' && (
                       <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted">
@@ -247,17 +293,21 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                       maxLength={80}
                     />
                   </Field>
-                  <Field label="API mode" description="Which wire protocol your endpoint speaks.">
+                  <Field label="API compatibility mode" description="Match the API protocol implemented by the endpoint. This choice determines which agent runtimes can use the credential.">
                     <select className={inputClass} value={customShape} onChange={(event) => { setCustomShape(event.target.value as WireShape); gate.reset() }}>
-                      {SHAPE_ORDER.map((shape) => <option key={shape} value={shape}>{WIRE_SHAPE_SHORT[shape]}</option>)}
+                      {SHAPE_ORDER.map((shape) => (
+                        <option key={shape} value={shape}>
+                          {WIRE_SHAPE_GUIDANCE[shape]} — {agentNames(compatibleAgentIds({ [shape]: '' }))}
+                        </option>
+                      ))}
                     </select>
                   </Field>
-                  <Field label="Base URL">
+                  <Field label="API base URL" description="Required for a custom provider. Include any path prefix the provider documents, such as /v1.">
                     <input
                       className={inputClass + ' font-mono text-[12px]'}
                       value={customUrl}
                       onChange={(event) => { setCustomUrl(event.target.value); gate.reset() }}
-                      placeholder="https://... (leave empty for the official endpoint)"
+                      placeholder="https://provider.example/v1"
                       spellCheck={false}
                       autoCapitalize="off"
                       autoCorrect="off"
@@ -266,36 +316,48 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                 </>
               ) : (
                 <>
-                  {regions.length > 1 && (
-                    <Field label="Endpoint / region" description="Region picks the endpoints; this key authenticates against one region.">
+                  {(regions.length > 1 || usingStoredRegion) && (
+                    <Field
+                      label="Account region"
+                      description={preset.setup?.regionHelp ?? 'Choose the provider region that issued this API key.'}
+                    >
                       <select className={inputClass} value={regionId} onChange={(event) => { setRegionId(event.target.value); gate.reset() }}>
+                        {usingStoredRegion && <option value={STORED_REGION_ID}>Saved custom endpoint (keep unchanged)</option>}
                         {regions.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}
                       </select>
                     </Field>
                   )}
-
-                  <Field label="Wire capabilities" description="One key, every shape this region speaks.">
-                    <div className="space-y-1.5 rounded-lg border border-border bg-bg-secondary/30 px-3 py-2.5">
-                      {shapes.length === 0 && <p className="text-[11px] text-text-muted">No endpoints for this provider.</p>}
-                      {shapes.map((shape) => (
-                        <div key={shape} className="flex items-baseline gap-2 text-[11px]">
-                          <span className="text-text-muted w-28 shrink-0">{WIRE_SHAPE_SHORT[shape]}</span>
-                          <span className="font-mono text-text-muted/80 break-all">{wires[shape] || 'official endpoint'}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </Field>
                 </>
               )}
 
-              <Field label="API key">
+              <div className="rounded-lg border border-accent/20 bg-accent/5 px-3 py-2.5">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="mr-1 text-[11px] font-medium text-text">Compatible agent runtimes</span>
+                  {compatibleAgents.map((agentId) => (
+                    <span key={agentId} className="rounded border border-accent/25 bg-bg px-1.5 py-0.5 text-[10px] text-text-muted">
+                      {AGENT_LABELS[agentId] ?? agentId}
+                    </span>
+                  ))}
+                  {compatibleAgents.length === 0 && (
+                    <span className="text-[10.5px] text-text-muted">Choose a supported API mode.</span>
+                  )}
+                </div>
+                <p className="mt-1.5 text-[10.5px] leading-relaxed text-text-muted">
+                  OpenAlice injects the key, endpoint, protocol, and model into one of these Workspace runtimes. Other runtimes will not offer this credential.
+                </p>
+              </div>
+
+              <Field
+                label={preset.setup?.apiKeyLabel ?? 'API key'}
+                description={preset.setup?.apiKeyHelp ?? 'Use the API key issued by this provider. Subscription logins stay in the agent CLI.'}
+              >
                 <div className="flex gap-2">
                   <input
                     className={inputClass + ' flex-1'}
                     type={showKey ? 'text' : 'password'}
                     value={apiKey}
                     onChange={(event) => setApiKey(event.target.value)}
-                    placeholder="Enter API key"
+                    placeholder={preset.setup?.apiKeyPlaceholder ?? 'Enter API key'}
                     spellCheck={false}
                     autoCapitalize="off"
                     autoCorrect="off"
@@ -310,9 +372,31 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                 </div>
               </Field>
 
-              <Field label="Test model" description="Used to verify the key and remembered as the default for quick-chat injection. Workspaces can still choose a different model.">
-                <ModelCombobox value={model} suggestions={models} onChange={setModel} />
+              <Field
+                label="Default model"
+                description={preset.setup?.modelHelp ?? 'OpenAlice tests this exact model ID and remembers it as the default for this credential. A Workspace can override it later.'}
+              >
+                <ModelCombobox value={model} suggestions={models} onChange={setModel} placeholder="Exact provider model ID" />
               </Field>
+
+              <details className="rounded-lg border border-border bg-bg-secondary/20 px-3 py-2">
+                <summary className="cursor-pointer select-none text-[11px] text-text-muted hover:text-text">
+                  Protocol and endpoint details
+                </summary>
+                <div className="mt-2 space-y-1.5 border-t border-border/60 pt-2">
+                  {shapes.length === 0 && <p className="text-[11px] text-text-muted">No endpoint is configured yet.</p>}
+                  {shapes.map((shape) => (
+                    <div key={shape} className="grid grid-cols-[125px_minmax(0,1fr)] gap-2 text-[10.5px]">
+                      <span className="text-text-muted">{WIRE_SHAPE_GUIDANCE[shape]}</span>
+                      <span className="break-all font-mono text-text-muted/80">{wires[shape] || 'Provider official endpoint'}</span>
+                    </div>
+                  ))}
+                </div>
+              </details>
+
+              <p className="rounded-lg bg-bg-tertiary px-3 py-2 text-[10.5px] leading-relaxed text-text-muted">
+                Test connection sends a small request to <span className="font-mono text-text">{model.trim() || 'the selected model'}</span>. Saving unlocks only after this exact key, endpoint, protocol, and model pass together.
+              </p>
 
               {error && (
                 <p className="min-w-0 max-w-full whitespace-pre-wrap break-words text-[12px] text-red">{error}</p>
@@ -376,7 +460,7 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                 data-testid="credential-modal-primary"
                 onClick={handlePrimaryAction}
                 disabled={primaryDisabled}
-                title={needsConnectionTest && !canTest ? 'Fill the API key + model first' : undefined}
+                title={needsConnectionTest && !canTest ? formProblem : undefined}
                 className="btn-primary disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {gate.testing ? 'Testing...' : needsConnectionTest ? 'Test connection' : saving ? 'Saving...' : 'Save'}

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -1,5 +1,64 @@
 import { http, HttpResponse } from 'msw'
 
+const demoCredentialPresets = [
+  {
+    id: 'codex-api',
+    label: 'OpenAI (API Key)',
+    description: 'Pay per token via OpenAI API',
+    category: 'official',
+    defaultName: 'OpenAI (API Key)',
+    setup: {
+      apiKeyLabel: 'OpenAI API key',
+      apiKeyPlaceholder: 'sk-...',
+      apiKeyHelp: 'Use an OpenAI Platform API key. A ChatGPT subscription is a separate Codex CLI login.',
+      modelHelp: 'Choose a model enabled for this API project.',
+    },
+    schema: {
+      type: 'object',
+      properties: {
+        apiKey: { type: 'string' },
+        model: { type: 'string', default: 'gpt-5.5', oneOf: [{ const: 'gpt-5.5', title: 'GPT 5.5' }] },
+      },
+    },
+    regions: [{ id: 'official', label: 'OpenAI (api.openai.com)', wires: { 'openai-responses': '', 'openai-chat': '' } }],
+  },
+  {
+    id: 'gemini',
+    label: 'Google Gemini',
+    description: 'Google AI via API key',
+    category: 'third-party',
+    defaultName: 'Google Gemini',
+    hint: 'OpenAlice uses Google’s official OpenAI-compatible endpoint. This credential works with Pi and opencode.',
+    setup: {
+      apiKeyLabel: 'Google AI API key',
+      apiKeyPlaceholder: 'AIza...',
+      apiKeyHelp: 'Use a Gemini API key from Google AI Studio.',
+      modelHelp: 'Choose a Gemini model exposed by Google’s compatibility endpoint.',
+    },
+    schema: {
+      type: 'object',
+      properties: {
+        apiKey: { type: 'string' },
+        model: { type: 'string', default: 'gemini-3.5-flash', oneOf: [{ const: 'gemini-3.5-flash', title: 'Gemini 3.5 Flash' }] },
+      },
+    },
+    regions: [{ id: 'default', label: 'Google', wires: { 'openai-chat': 'https://generativelanguage.googleapis.com/v1beta/openai/' } }],
+  },
+  {
+    id: 'custom',
+    label: 'Custom',
+    description: 'Full control — any compatible provider, model, and endpoint',
+    category: 'custom',
+    defaultName: '',
+    setup: {
+      apiKeyLabel: 'Endpoint API key',
+      apiKeyHelp: 'Use a key accepted by this endpoint.',
+      modelHelp: 'Enter the exact model ID exposed by the endpoint.',
+    },
+    schema: { type: 'object', properties: { apiKey: { type: 'string' }, model: { type: 'string' } } },
+  },
+]
+
 export const configKeysHandlers = [
   http.get('/api/config/api-keys/status', () => HttpResponse.json({})),
   http.put('/api/config/apiKeys', () => new HttpResponse(null, { status: 204 })),
@@ -29,15 +88,15 @@ export const configKeysHandlers = [
     }),
   ),
 
-  http.get('/api/config/presets', () => HttpResponse.json({ presets: [] })),
+  http.get('/api/config/presets', () => HttpResponse.json({ presets: demoCredentialPresets })),
 
   // Credential vault (AI Provider page) — a small representative set so the
   // page (and the per-agent default pickers) render with content in the demo.
   http.get('/api/config/credentials', () =>
     HttpResponse.json({
       credentials: [
-        { slug: 'anthropic-1', vendor: 'anthropic', label: 'Anthropic', authType: 'api-key', wires: { anthropic: '' }, apiKey: null, hasApiKey: true },
-        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true },
+        { slug: 'anthropic-1', vendor: 'anthropic', label: 'Anthropic', authType: 'api-key', wires: { anthropic: '' }, apiKey: null, hasApiKey: true, lastModel: 'claude-opus-4-8' },
+        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true, lastModel: 'gpt-5.5' },
       ],
     }),
   ),

--- a/ui/src/lib/presetHelpers.ts
+++ b/ui/src/lib/presetHelpers.ts
@@ -25,6 +25,20 @@ export const WIRE_SHAPE_SHORT: Record<WireShape, string> = {
   'openai-responses': 'OpenAI Responses',
 }
 
+/** Plain-language labels for the custom endpoint mode picker. */
+export const WIRE_SHAPE_GUIDANCE: Record<WireShape, string> = {
+  anthropic: 'Anthropic Messages',
+  'openai-chat': 'OpenAI Chat Completions',
+  'openai-responses': 'OpenAI Responses',
+}
+
+export const AGENT_LABELS: Record<string, string> = {
+  claude: 'Claude Code',
+  codex: 'Codex',
+  opencode: 'opencode',
+  pi: 'Pi',
+}
+
 /** The regions a preset offers (each carrying its per-shape endpoint map). */
 export function presetRegions(p: Preset | null | undefined): SerializedRegion[] {
   return p?.regions ?? []
@@ -68,6 +82,18 @@ export function pickAgentWire(
   return null
 }
 
+/** Agent runtimes that can consume at least one declared wire shape. */
+export function compatibleAgentIds(wires: Partial<Record<WireShape, string>>): string[] {
+  return Object.keys(AGENT_WIRE_PREFERENCE).filter((agentId) => pickAgentWire(wires, agentId) !== null)
+}
+
+/** Compatibility summary for a preset before a region has been selected. */
+export function presetCompatibleAgentIds(preset: Preset): string[] {
+  const wires: Partial<Record<WireShape, string>> = {}
+  for (const region of presetRegions(preset)) Object.assign(wires, region.wires)
+  return compatibleAgentIds(wires)
+}
+
 function schemaProps(schema: Preset['schema']): Record<string, Record<string, unknown>> {
   return (schema?.properties as Record<string, Record<string, unknown>>) ?? {}
 }
@@ -80,6 +106,13 @@ function oneOf(schema: Preset['schema'], field: string): LabeledOption[] {
 /** Enumerated models for a preset (empty for custom / un-enumerated presets). */
 export function presetModels(p: Preset): LabeledOption[] {
   return oneOf(p.schema, 'model')
+}
+
+/** Use the catalog's actual field default instead of assuming list order. */
+export function presetDefaultModel(p: Preset | null | undefined): string {
+  if (!p) return ''
+  const value = schemaProps(p.schema)['model']?.default
+  return typeof value === 'string' ? value : presetModels(p)[0]?.id ?? ''
 }
 
 /** Only api-key presets belong in the credential vault — oauth ones log in via the CLI. */

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -15,15 +15,13 @@
  */
 
 import { useState, useEffect, useMemo } from 'react'
-import { api, type Preset, type WireShape } from '../api'
+import { api, type Preset } from '../api'
 import type { CredentialSummary, WorkspaceCredentialDefaultsResponse } from '../api/config'
 import { PageHeader } from '../components/PageHeader'
 import { PageLoading, Skeleton } from '../components/StateViews'
 import { inputClass } from '../components/form'
 import { CredentialModal } from '../components/credentials/CredentialModal'
-import { WIRE_SHAPE_SHORT, isApiKeyPreset } from '../lib/presetHelpers'
-
-const SHAPE_ORDER: WireShape[] = ['anthropic', 'openai-chat', 'openai-responses']
+import { AGENT_LABELS, compatibleAgentIds, isApiKeyPreset } from '../lib/presetHelpers'
 
 function credentialLabel(cred: Pick<CredentialSummary, 'slug' | 'vendor' | 'label'>): string {
   return cred.label?.trim() || cred.slug
@@ -109,7 +107,7 @@ export function AIProviderPage() {
   if (!credentials) {
     return (
       <div className="flex flex-col flex-1 min-h-0">
-        <PageHeader title="AI Provider" description="Credentials Alice holds and injects into workspaces." />
+        <PageHeader title="AI Provider" description="Provider accounts and model defaults Alice can inject into workspaces." />
         <PageLoading />
       </div>
     )
@@ -117,7 +115,7 @@ export function AIProviderPage() {
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <PageHeader title="AI Provider" description="Credentials Alice holds and injects into workspaces." />
+      <PageHeader title="AI Provider" description="Provider accounts and model defaults Alice can inject into workspaces." />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6">
         <div className="max-w-[1100px] mx-auto grid gap-6 lg:grid-cols-2">
           {/* ============== Credentials ============== */}
@@ -143,40 +141,45 @@ export function AIProviderPage() {
             </div>
 
             <div className="space-y-2.5">
-              {credentials.map((cred) => (
-                <div key={cred.slug} className="flex items-center gap-3 rounded-lg border border-border bg-bg px-4 py-3">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-[13px] font-medium text-text">{credentialLabel(cred)}</span>
-                      {cred.label && (
-                        <span className="text-[11px] text-text-muted">{cred.vendor}</span>
-                      )}
-                      <span className="text-[11px] text-text-muted font-mono">{cred.slug}</span>
-                      {(SHAPE_ORDER.filter((s) => s in cred.wires)).map((s) => (
-                        <span key={s} className="text-[10px] text-text-muted border border-border rounded px-1">{WIRE_SHAPE_SHORT[s]}</span>
-                      ))}
-                      {cred.hasApiKey && (
-                        <span className="text-[10px] text-green border border-green/40 rounded px-1">key set</span>
-                      )}
+              {credentials.map((cred) => {
+                const compatibleAgents = compatibleAgentIds(cred.wires)
+                return (
+                  <div key={cred.slug} className="flex items-center gap-3 rounded-lg border border-border bg-bg px-4 py-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-[13px] font-medium text-text">{credentialLabel(cred)}</span>
+                        {cred.label && (
+                          <span className="text-[11px] text-text-muted">{cred.vendor}</span>
+                        )}
+                        <span className="text-[11px] text-text-muted font-mono">{cred.slug}</span>
+                        {compatibleAgents.map((agentId) => (
+                          <span key={agentId} className="text-[10px] text-text-muted border border-border rounded px-1">{AGENT_LABELS[agentId] ?? agentId}</span>
+                        ))}
+                        {cred.hasApiKey && (
+                          <span className="text-[10px] text-green border border-green/40 rounded px-1">key set</span>
+                        )}
+                      </div>
+                      <div className="mt-0.5 truncate text-[11px] text-text-muted">
+                        Default model: <span className="font-mono">{cred.lastModel || 'not set'}</span>
+                        <span className="px-1.5 text-text-muted/50">·</span>
+                        <span className="font-mono">{Object.values(cred.wires)[0] || 'provider official endpoint'}</span>
+                      </div>
                     </div>
-                    <div className="text-[11px] text-text-muted mt-0.5 font-mono truncate">
-                      {Object.values(cred.wires)[0] || 'default endpoint'}
-                    </div>
+                    <button
+                      onClick={() => setModal({ mode: 'edit', cred })}
+                      className="text-[11px] px-2 py-1 rounded-md border border-border text-text-muted hover:text-text transition-colors"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(cred.slug)}
+                      className="text-[11px] px-2 py-1 rounded-md border border-border text-text-muted hover:text-red transition-colors"
+                    >
+                      Delete
+                    </button>
                   </div>
-                  <button
-                    onClick={() => setModal({ mode: 'edit', cred })}
-                    className="text-[11px] px-2 py-1 rounded-md border border-border text-text-muted hover:text-text transition-colors"
-                  >
-                    Edit
-                  </button>
-                  <button
-                    onClick={() => handleDelete(cred.slug)}
-                    className="text-[11px] px-2 py-1 rounded-md border border-border text-text-muted hover:text-red transition-colors"
-                  >
-                    Delete
-                  </button>
-                </div>
-              ))}
+                )
+              })}
 
               {credentials.length === 0 && (
                 <button
@@ -197,7 +200,8 @@ export function AIProviderPage() {
                 one a workspace (or cron job) runs. Pick by the models/provider you want; every
                 runtime reaches the full OpenAlice tool surface either way (native MCP where
                 supported, the <code className="font-mono text-[11.5px]">alice</code> CLI on PATH
-                otherwise). The model is chosen per workspace, not here.
+                otherwise). Each credential remembers a tested default model; a workspace can
+                override that model when needed.
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
- make the credential form provider-aware with key, model, endpoint, and runtime guidance
- surface which native agent runtimes can actually consume each credential, including the Gemini Pi/opencode boundary
- preserve the tested default model and unmatched custom endpoints when editing saved credentials
- validate custom API base URLs and align preset defaults with credential injection
- document the credential setup contract and provide representative demo handlers

## Verification
- `npx tsc --noEmit`
- `pnpm test` (289 files passed, 1 skipped; 3019 tests passed, 6 skipped before the latest dev rebase)
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build:demo`
- targeted credential/preset/config suite after rebase: 25/25 passed
- isolated `pnpm dev:onboarding` browser walk: add, test, save, readiness, provider picker, settings card
- demo `/settings/ai-provider` browser walk with OpenAI, Gemini, and Custom presets

## Boundary touch
- Alice continues to own credential storage and native CLI injection
- UTA and broker/vendor architecture are unchanged
- Gemini is described only through its supported OpenAI-compatible Pi/opencode path; no unsupported native Claude/Codex claim is introduced
- no packaged Electron smoke was required because this changes the shared settings/onboarding UI and API metadata rather than Electron-only IPC or packaging