### PR TITLE
Harden Windows release tooling

### DIFF
--- a/apps/desktop/src/data-home.spec.ts
+++ b/apps/desktop/src/data-home.spec.ts
@@ -144,11 +144,16 @@ describe('desktop data-home preferences', () => {
     await expect(prepareDataHome(missing)).rejects.toBeInstanceOf(DataHomeUnavailableError)
   })
 
-  it('resolves symlink aliases to one physical location', async () => {
+  it('resolves symlink aliases to one physical location', async ({ skip }) => {
     const actual = join(root, 'actual')
     const alias = join(root, 'alias')
     await mkdir(actual)
-    await symlink(actual, alias, 'dir')
+    try {
+      await symlink(actual, alias, 'dir')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') skip('symlinks unavailable on this runner')
+      throw error
+    }
 
     expect((await prepareDataHome(alias)).path).toBe((await prepareDataHome(actual)).path)
   })

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -115,7 +115,8 @@ The build command also extracts every generated archive, verifies its catalog
 membership, size, SHA-256, package identity, entry containment, and absence of
 workspace/deployment metadata, then imports the entry in a clean Node process.
 `pnpm broker-packs:verify` repeats that acceptance check against an existing
-`dist/broker-packs/` directory.
+`dist/broker-packs/` directory. Release scripts invoke Corepack's `pnpm.cmd`
+through `ComSpec` on Windows; package scripts must not rely on POSIX quoting.
 
 Desktop package acceptance rejects `ccxt`, `longbridge`, its native binding,
 and `@alpacahq/alpaca-trade-api` if they reappear under packaged

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prebuild:server": "tsx scripts/build-migration-index.ts",
     "build:server": "turbo run build --filter=!@traderalice/desktop --filter=!./packages/uta-broker-* && tsup src/main.ts --format esm --dts",
     "build:migration-index": "tsx scripts/build-migration-index.ts",
-    "broker-packs:build": "turbo run build --filter='./packages/uta-broker-*' && tsx scripts/build-broker-packs.ts && pnpm broker-packs:verify",
+    "broker-packs:build": "turbo run build --filter=./packages/uta-broker-* && tsx scripts/build-broker-packs.ts && pnpm broker-packs:verify",
     "broker-packs:verify": "tsx scripts/verify-broker-packs.ts",
     "start": "node dist/main.js",
     "electron:tsc": "pnpm -F @traderalice/desktop build",

--- a/packages/guardian-runtime/src/runtime-lock.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.spec.ts
@@ -60,7 +60,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await rm(home, { recursive: true, force: true })
+  await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
 })
 
 describe('runtime lock ownership', () => {

--- a/scripts/build-broker-packs.ts
+++ b/scripts/build-broker-packs.ts
@@ -19,6 +19,7 @@ import {
   type BrokerPackRequirement,
   type BrokerPackReleaseCatalog,
 } from '../src/core/broker-pack-catalog.js'
+import { composePnpmCommand } from './pnpm-command.mjs'
 
 const repoRoot = resolve(import.meta.dirname, '..')
 const packageJson = JSON.parse(await readFile(resolve(repoRoot, 'package.json'), 'utf8')) as { version: string }
@@ -77,12 +78,16 @@ try {
 }
 
 function deployPackage(packageName: string, target: string): void {
-  const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-  const result = spawnSync(pnpm, [
+  const command = composePnpmCommand([
     '--config.inject-workspace-packages=true',
     '--filter', packageName,
     'deploy', '--prod', target,
-  ], { cwd: repoRoot, stdio: 'inherit', env: process.env })
+  ])
+  const result = spawnSync(command.command, command.args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: process.env,
+  })
   if (result.error) throw result.error
   if (result.status !== 0) throw new Error(`pnpm deploy failed for ${packageName} (${result.status})`)
 }

--- a/scripts/desktop-packaged-smoke.mjs
+++ b/scripts/desktop-packaged-smoke.mjs
@@ -11,6 +11,7 @@ import {
   DEFAULT_DESKTOP_PACKAGE_ROOT,
 } from './desktop-package-artifact.mjs'
 import { buildDesktopPackagedSmokePlan } from './desktop-packaged-smoke-plan.mjs'
+import { composePnpmCommand } from './pnpm-command.mjs'
 import { packagedElectronExecutable } from './smoke-packaged-toolchain.mjs'
 import { startWorkspaceAcceptanceAiMock } from './workspace-acceptance-ai-mock.mjs'
 
@@ -58,7 +59,10 @@ Options:
 
 function run(label, command, commandArgs, extraEnv = {}) {
   console.log(`\n[desktop-smoke] ${label}`)
-  const result = spawnSync(command, commandArgs, {
+  const childCommand = command === 'pnpm'
+    ? composePnpmCommand(commandArgs, { env: process.env })
+    : { command, args: commandArgs }
+  const result = spawnSync(childCommand.command, childCommand.args, {
     cwd: repoRoot,
     stdio: 'inherit',
     env: { ...process.env, ...extraEnv },

--- a/scripts/pnpm-command.mjs
+++ b/scripts/pnpm-command.mjs
@@ -1,0 +1,24 @@
+/**
+ * Compose a shell-free pnpm child-process command on POSIX and the equivalent
+ * cmd.exe invocation required for Corepack's pnpm.cmd shim on Windows.
+ *
+ * Arguments are repository-owned release/build inputs. Quote every argument
+ * on Windows so paths with spaces and cmd metacharacters stay one argument.
+ */
+export function composePnpmCommand(commandArgs, options = {}) {
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+  if (platform !== 'win32') {
+    return { command: 'pnpm', args: [...commandArgs] }
+  }
+
+  const commandLine = ['pnpm.cmd', ...commandArgs.map(quoteCmdArgument)].join(' ')
+  return {
+    command: env.ComSpec ?? env.COMSPEC ?? 'cmd.exe',
+    args: ['/d', '/s', '/c', commandLine],
+  }
+}
+
+function quoteCmdArgument(value) {
+  return `"${String(value).replaceAll('"', '""')}"`
+}

--- a/scripts/pnpm-command.spec.ts
+++ b/scripts/pnpm-command.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { composePnpmCommand } from './pnpm-command.mjs'
+
+describe('composePnpmCommand', () => {
+  it('uses a direct shell-free pnpm invocation on POSIX', () => {
+    expect(composePnpmCommand(['electron:build'], { platform: 'darwin' })).toEqual({
+      command: 'pnpm',
+      args: ['electron:build'],
+    })
+  })
+
+  it('routes the Corepack pnpm.cmd shim through ComSpec on Windows', () => {
+    expect(composePnpmCommand(
+      ['-F', '@traderalice/desktop', 'exec', 'electron-builder'],
+      { platform: 'win32', env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' } },
+    )).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        'pnpm.cmd "-F" "@traderalice/desktop" "exec" "electron-builder"',
+      ],
+    })
+  })
+
+  it('keeps a Windows deploy target with spaces in one cmd argument', () => {
+    const spec = composePnpmCommand(
+      ['deploy', '--prod', 'C:\\Users\\Alice Dev\\broker pack'],
+      { platform: 'win32', env: {} },
+    )
+
+    expect(spec.command).toBe('cmd.exe')
+    expect(spec.args.at(-1)).toBe(
+      'pnpm.cmd "deploy" "--prod" "C:\\Users\\Alice Dev\\broker pack"',
+    )
+  })
+})

--- a/src/services/connector-client/index.spec.ts
+++ b/src/services/connector-client/index.spec.ts
@@ -166,12 +166,17 @@ describe('Inbox Connector bridge', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('encoding unchanged'))
   })
 
-  it('refuses to attach a Markdown symlink that escapes the Workspace', async () => {
+  it('refuses to attach a Markdown symlink that escapes the Workspace', async ({ skip }) => {
     const root = await mkdtemp(join(tmpdir(), 'openalice-connector-workspace-'))
     const outside = await mkdtemp(join(tmpdir(), 'openalice-connector-outside-'))
     tempDirs.push(root, outside)
     await writeFile(join(outside, 'secret.md'), '# outside\n')
-    await symlink(join(outside, 'secret.md'), join(root, 'leak.md'))
+    try {
+      await symlink(join(outside, 'secret.md'), join(root, 'leak.md'))
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') skip('symlinks unavailable on this runner')
+      throw error
+    }
     const warn = vi.fn()
 
     const attachments = await projectInboxAttachments({

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -214,7 +214,7 @@ describe('HeadlessTaskRegistry', () => {
     expect(existsSync(firstLogs.stdout)).toBe(true)
     expect(existsSync(firstLogs.stderr)).toBe(true)
     expect(existsSync(firstLogs.structured)).toBe(true)
-  })
+  }, 30_000)
 
   it('keeps one resumeId across executions and records direct lineage', async () => {
     const reg = await HeadlessTaskRegistry.load(path, noopLogger)


### PR DESCRIPTION
## Summary
- compose pnpm child processes through `ComSpec` on Windows while keeping shell-free POSIX execution
- remove POSIX-only quoting from the Broker Pack Turbo filter
- add deterministic Windows command-shape coverage, including paths with spaces
- keep symlink security tests active on capable Windows hosts and skip only `EPERM` fixture creation
- give the durable 200-run retention test a realistic timeout and retry Windows lock-fixture cleanup

## Verification
- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- focused Windows/release suite: 50/50 passed
- `pnpm test`: 3022 passed, 6 skipped
- `pnpm broker-packs:build`: built and verified all 5 darwin-arm64 artifacts
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`: packaged Workspace acceptance passed and temporary package was cleaned

## Boundary touch
- release/test tooling only; no Broker Pack runtime activation or UTA vendor-routing semantics change
- no symlink security assertion is disabled when the host supports fixture creation

Closes #619
Closes #620
Closes #621