### PR TITLE
Reuse active same-home CLI runtimes

### DIFF
--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -85,8 +85,11 @@ and `--yes` remains installation-only for automation.
 
 The CLI stays in the foreground and owns the Guardian lifetime. `Ctrl+C` stops
 the local Runtime. A normal second launch reuses an already healthy local URL;
-it does not kill the existing owner. `openalice start --takeover` explicitly
-requests the existing Guardian recovery flow.
+it does not kill the existing owner. Discovery first uses the selected home's
+Guardian control endpoint; for a source `pnpm dev` owner without control
+metadata, it verifies that owner's configured Web port before reuse. It never
+guesses that another home owns a reachable port. `openalice start --takeover`
+explicitly requests the existing Guardian recovery flow.
 
 Useful controls:
 

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -14,6 +14,7 @@ import {
   inspectRuntimeBuildTools,
   runtimeBuildToolsError,
 } from './runtime-deps.mjs'
+import { readRuntimeStatus as readGuardianRuntimeStatus } from './server-control.mjs'
 
 const RUNTIME_ARTIFACTS = [
   'dist/main.js',
@@ -87,6 +88,8 @@ export function parseLocalStartArgs(argv) {
 export async function startLocal(options, dependencies = {}) {
   const stdout = dependencies.stdout ?? process.stdout
   const env = dependencies.env ?? process.env
+  const homeDir = dependencies.homeDir ?? homedir()
+  const homeRoot = resolve(options.homeRoot ?? env['OPENALICE_HOME'] ?? join(homeDir, '.openalice'))
   const localUrl = `http://${LOOPBACK}:${options.port}`
   const probeRuntime = dependencies.probeRuntime ?? probeOpenAlice
   const launchBrowser = dependencies.launchBrowser ?? openBrowser
@@ -97,6 +100,19 @@ export async function startLocal(options, dependencies = {}) {
     return 0
   }
 
+  const readRuntimeStatus = dependencies.readRuntimeStatus ?? readGuardianRuntimeStatus
+  const readConfiguredWebPort = dependencies.readConfiguredWebPort ?? readHomeWebPort
+  const status = await readRuntimeStatus({ homeRoot, timeoutMs: 500 }, { env, homeDir })
+  const discoveredUrl = status.endpoints?.web
+    ?? (status.class === 'owned_elsewhere'
+      ? configuredLocalUrl(await readConfiguredWebPort(homeRoot))
+      : null)
+  if (discoveredUrl && discoveredUrl !== localUrl && await probeRuntime(discoveredUrl)) {
+    stdout.write(`OpenAlice is already running at ${discoveredUrl} for ${homeRoot}\n`)
+    if (options.openBrowser) await launchBrowser(discoveredUrl)
+    return 0
+  }
+
   const resolveRoot = dependencies.resolveRoot ?? findOpenAliceRoot
   const appDir = await resolveRoot(options.appDir ?? dependencies.cwd ?? process.cwd())
   const prepareSource = dependencies.prepareSource ?? prepareSourceCheckout
@@ -104,9 +120,7 @@ export async function startLocal(options, dependencies = {}) {
 
   const spawnProcess = dependencies.spawnProcess ?? spawn
   const waitForRuntime = dependencies.waitForRuntime ?? waitForOpenAlice
-  const homeDir = dependencies.homeDir ?? homedir()
   const nodeBinary = dependencies.nodeBinary ?? process.execPath
-  const homeRoot = resolve(options.homeRoot ?? env['OPENALICE_HOME'] ?? join(homeDir, '.openalice'))
   const runtimeEnv = buildLocalRuntimeEnv(env, {
     appDir,
     homeRoot,
@@ -154,6 +168,21 @@ export async function startLocal(options, dependencies = {}) {
     runtime.kill('SIGTERM')
     throw error
   }
+}
+
+export async function readHomeWebPort(homeRoot, options = {}) {
+  const readFileImpl = options.readFileImpl ?? readFile
+  try {
+    const parsed = JSON.parse(await readFileImpl(join(homeRoot, 'data', 'config', 'ports.json'), 'utf8'))
+    const port = Number(parsed?.web)
+    return Number.isInteger(port) && port >= 1 && port <= 65_535 ? port : null
+  } catch {
+    return null
+  }
+}
+
+function configuredLocalUrl(port) {
+  return port ? `http://${LOOPBACK}:${port}` : null
 }
 
 export function buildLocalRuntimeEnv(env, options) {

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -10,6 +10,7 @@ import {
   findOpenAliceRoot,
   parseLocalStartArgs,
   prepareSourceCheckout,
+  readHomeWebPort,
   startLocal,
 } from './local-start.mjs'
 
@@ -68,6 +69,62 @@ describe('OpenAlice local Runtime launcher', () => {
     expect(resolveRoot).not.toHaveBeenCalled()
     expect(launchBrowser).toHaveBeenCalledWith('http://127.0.0.1:47331')
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('already running'))
+  })
+
+  it('reuses a healthy same-home dev Runtime on its configured nonstandard port', async () => {
+    const resolveRoot = vi.fn()
+    const launchBrowser = vi.fn(async () => undefined)
+    const stdout = { write: vi.fn() }
+    const probeRuntime = vi.fn(async (url) => url === 'http://127.0.0.1:3002')
+
+    await expect(startLocal(parseLocalStartArgs([]), {
+      env: {},
+      homeDir: '/tmp/user',
+      probeRuntime,
+      readRuntimeStatus: async () => ({
+        class: 'owned_elsewhere',
+        owner: { surface: 'dev', pid: 123 },
+        endpoints: {},
+      }),
+      readConfiguredWebPort: async () => 3002,
+      resolveRoot,
+      launchBrowser,
+      stdout,
+    })).resolves.toBe(0)
+
+    expect(probeRuntime).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:47331')
+    expect(probeRuntime).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:3002')
+    expect(resolveRoot).not.toHaveBeenCalled()
+    expect(launchBrowser).toHaveBeenCalledWith('http://127.0.0.1:3002')
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('/tmp/user/.openalice'))
+  })
+
+  it('prefers an owner-advertised web endpoint over persisted port configuration', async () => {
+    const launchBrowser = vi.fn(async () => undefined)
+    const readConfiguredWebPort = vi.fn()
+
+    await expect(startLocal(parseLocalStartArgs([]), {
+      probeRuntime: async (url) => url === 'http://127.0.0.1:41000',
+      readRuntimeStatus: async () => ({
+        class: 'owned_elsewhere',
+        endpoints: { web: 'http://127.0.0.1:41000' },
+      }),
+      readConfiguredWebPort,
+      launchBrowser,
+      stdout: { write: vi.fn() },
+    })).resolves.toBe(0)
+
+    expect(readConfiguredWebPort).not.toHaveBeenCalled()
+    expect(launchBrowser).toHaveBeenCalledWith('http://127.0.0.1:41000')
+  })
+
+  it('reads only a valid web port from the selected home', async () => {
+    await expect(readHomeWebPort('/tmp/home', {
+      readFileImpl: async () => '{"web":3002}',
+    })).resolves.toBe(3002)
+    await expect(readHomeWebPort('/tmp/home', {
+      readFileImpl: async () => '{"web":70000}',
+    })).resolves.toBeNull()
   })
 
   it('does not inherit auth bypass or takeover into an ordinary local launch', () => {


### PR DESCRIPTION
## Summary
- resolve the selected OpenAlice home before attempting a local CLI start
- consult same-home Guardian status after the default URL probe misses
- reuse an owner-advertised endpoint, or a verified persisted dev Web port when the dev Guardian has no control endpoint
- never prepare or spawn a replacement when the discovered same-home runtime is healthy

## Verification
- `pnpm exec vitest run packages/cli/src/local-start.spec.mjs packages/cli/src/server-control.spec.mjs`: 16/16 passed
- `pnpm -F @traderalice/openalice-cli build`
- `npx tsc --noEmit`
- Guardian recovery fast matrix: package tests/typecheck plus healthy duplicate, takeover, crash, and stubborn-owner real-process smoke
- isolated installer rerun: 8/8 passed
- `pnpm test`: 3025 passed, 6 skipped

## Boundary touch
- discovery is read-only and scoped to the selected `OPENALICE_HOME`
- ordinary launch never signals, unlocks, or takes over an owner
- explicit `--takeover` semantics are unchanged

Closes #622