### PR TITLE
Recover Workspace creation from disk exhaustion

### DIFF
--- a/docs/data-locations.md
+++ b/docs/data-locations.md
@@ -108,6 +108,12 @@ to the same physical location. A missing saved location is not silently
 re-created as an empty folder. The user must reconnect it, choose another
 location, or explicitly use the default.
 
+Workspace creation keeps a small free-space safety margin before bootstrap.
+An `ENOSPC` during bootstrap, context injection, git initialization, or
+registry persistence returns `insufficient_storage` without registering the
+Workspace. Partial directories are removed with bounded retries or renamed as
+failed bootstrap quarantine directories when Windows still holds a handle.
+
 ## Load-Bearing Code and Verification
 
 - `apps/desktop/src/data-home.ts` — preference parsing, canonicalization,

--- a/src/webui/routes/workspaces-storage.spec.ts
+++ b/src/webui/routes/workspaces-storage.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WorkspaceService } from '../../workspaces/service.js'
+import { createWorkspaceRoutes } from './workspaces.js'
+
+describe('Workspace creation storage response', () => {
+  it('returns an actionable 507 without exposing a partial Workspace', async () => {
+    const app = createWorkspaceRoutes({
+      config: { launcherRepoRoot: '/repo' },
+      templates: { defaultName: () => 'chat' },
+      creator: {
+        create: async () => ({
+          ok: false,
+          code: 'insufficient_storage',
+          message: 'Not enough free space to create this Workspace. Free disk space and retry.',
+        }),
+      },
+    } as unknown as WorkspaceService)
+
+    const response = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tag: 'diskfull', template: 'chat' }),
+    })
+
+    expect(response.status).toBe(507)
+    await expect(response.json()).resolves.toEqual(expect.objectContaining({
+      error: 'insufficient_storage',
+      message: expect.stringContaining('Free disk space'),
+    }))
+  })
+})

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -716,6 +716,7 @@ export function createWorkspaceRoutes(
         : result.code === 'unknown_template' ? 400
         : result.code === 'unknown_agent' ? 400
         : result.code === 'tag_in_use' ? 409
+        : result.code === 'insufficient_storage' ? 507
         : 500;
       return c.json({
         error: result.code,

--- a/src/workspaces/workspace-creator-storage.spec.ts
+++ b/src/workspaces/workspace-creator-storage.spec.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, mkdir, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { AdapterRegistry } from './cli-adapter.js'
+import type { Logger } from './logger.js'
+import type { TemplateRegistry } from './template-registry.js'
+import {
+  WorkspaceCreator,
+  inspectWorkspaceStorage,
+} from './workspace-creator.js'
+import type { WorkspaceRegistry } from './workspace-registry.js'
+
+const temporaryPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+  )))
+})
+
+describe('Workspace creation storage failures', () => {
+  it('rejects a volume below the creation safety margin', async () => {
+    await expect(inspectWorkspaceStorage('/unused', {
+      mkdirImpl: vi.fn(async () => undefined) as unknown as typeof mkdir,
+      statfsImpl: vi.fn(async () => ({ bavail: 0, bsize: 4096 })) as unknown as typeof import('node:fs/promises').statfs,
+    })).resolves.toEqual({ ok: false, availableBytes: 0 })
+  })
+
+  it('cleans a post-git-init ENOSPC bootstrap and never registers it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-enospc-create-'))
+    temporaryPaths.push(root)
+    const workspacesRoot = join(root, 'workspaces')
+    const templateRoot = join(root, 'template')
+    const bootstrapScript = join(templateRoot, 'bootstrap.mjs')
+    await mkdir(templateRoot, { recursive: true })
+    await writeFile(bootstrapScript, `
+      import { mkdir, writeFile } from 'node:fs/promises'
+      import { join } from 'node:path'
+      const dir = process.argv[3]
+      await mkdir(join(dir, '.git'), { recursive: true })
+      await writeFile(join(dir, 'README.md'), '# partial\\n')
+      process.stderr.write('Error: ENOSPC: no space left on device, write\\n')
+      process.exitCode = 1
+    `)
+
+    const registry = {
+      hasTag: vi.fn(() => false),
+      hasId: vi.fn(() => false),
+      add: vi.fn(async () => undefined),
+      remove: vi.fn(async () => undefined),
+    } as unknown as WorkspaceRegistry
+    const log = testLogger()
+    const creator = new WorkspaceCreator({
+      workspacesRoot,
+      templateRegistry: {
+        get: () => ({
+          name: 'fault',
+          bootstrapScript,
+          filesDir: templateRoot,
+          templateDir: templateRoot,
+          version: '1.0.0',
+          defaultAgents: [],
+          injectTools: false,
+          injectPersona: false,
+          bundledSkills: [],
+        }),
+      } as unknown as TemplateRegistry,
+      adapterRegistry: {
+        list: () => [],
+        get: () => undefined,
+      } as unknown as AdapterRegistry,
+      bootstrapEnv: { templateDir: '', launcherRepoRoot: root },
+      bootstrapTimeoutMs: 10_000,
+      registry,
+      logger: log.logger,
+    })
+
+    await expect(creator.create('diskfull', 'fault')).resolves.toMatchObject({
+      ok: false,
+      code: 'insufficient_storage',
+      message: expect.stringContaining('Free disk space'),
+    })
+    expect(await readdir(workspacesRoot)).toEqual([])
+    expect(registry.add).not.toHaveBeenCalled()
+    expect(log.warn).toHaveBeenCalledWith('bootstrap.failed', expect.objectContaining({ exitCode: 1 }))
+  })
+})
+
+function testLogger() {
+  const info = vi.fn()
+  const warn = vi.fn()
+  const error = vi.fn()
+  const logger = {
+    info,
+    warn,
+    error,
+    debug: vi.fn(),
+    child: () => logger,
+  } as unknown as Logger
+  return { logger, info, warn, error }
+}

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { resolveBashPath } from '@/core/shell-resolver.js';
 import { existsSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { mkdir, rename, rm, statfs } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { exec as gitExec } from 'dugite';
@@ -49,6 +49,7 @@ export type CreateResult =
       readonly code:
         | 'invalid_tag'
         | 'tag_in_use'
+        | 'insufficient_storage'
         | 'bootstrap_failed'
         | 'injection_failed'
         | 'unknown_template'
@@ -59,6 +60,7 @@ export type CreateResult =
     };
 
 const TAG_RE = /^[a-z0-9][a-z0-9_-]{0,32}$/;
+export const MIN_WORKSPACE_FREE_BYTES = 64 * 1024 * 1024;
 
 /**
  * Resolve the adapter set a new workspace is created with. This is the single
@@ -144,6 +146,9 @@ export class WorkspaceCreator {
       }
     }
 
+    const storage = await inspectWorkspaceStorage(this.opts.workspacesRoot);
+    if (!storage.ok) return insufficientStorageResult(storage.availableBytes);
+
     const id = generatePetnameId(templateName, {
       fallbackPrefix: 'workspace',
       isTaken: (candidate) =>
@@ -177,6 +182,8 @@ export class WorkspaceCreator {
         exitCode: result.exitCode,
         stderr: result.stderr.slice(0, 4000),
       });
+      await cleanupIncompleteWorkspace(dir, log);
+      if (isInsufficientStorageFailure(result)) return insufficientStorageResult();
       // Surface the actual reason in the message, not just the exit code —
       // a null exit code (spawn failure: bash-not-found on Windows, timeout)
       // rendered as "code unknown" tells the user nothing, while result.stderr
@@ -202,7 +209,8 @@ export class WorkspaceCreator {
       await injectWorkspaceContext({ template, wsId: id, dir });
     } catch (err) {
       log.warn('inject.failed', { err });
-      await rm(dir, { recursive: true, force: true });
+      await cleanupIncompleteWorkspace(dir, log);
+      if (isInsufficientStorageError(err)) return insufficientStorageResult();
       return {
         ok: false,
         code: 'injection_failed',
@@ -213,7 +221,8 @@ export class WorkspaceCreator {
       await commitInitial(dir, `${templateName}: ${tag}`);
     } catch (err) {
       log.warn('initial_commit.failed', { err });
-      await rm(dir, { recursive: true, force: true });
+      await cleanupIncompleteWorkspace(dir, log);
+      if (isInsufficientStorageError(err)) return insufficientStorageResult();
       return {
         ok: false,
         code: 'injection_failed',
@@ -285,20 +294,33 @@ export class WorkspaceCreator {
       await initializeWorkspaceTemplateState(workspace, template);
     } catch (err) {
       log.warn('template_state.initialize_failed', { err });
-      await rm(dir, { recursive: true, force: true });
+      await cleanupIncompleteWorkspace(dir, log);
+      if (isInsufficientStorageError(err)) return insufficientStorageResult();
       return {
         ok: false,
         code: 'injection_failed',
         message: `template baseline initialization failed: ${(err as Error).message}`,
       };
     }
-    await this.opts.registry.add(workspace);
+    try {
+      await this.opts.registry.add(workspace);
+    } catch (err) {
+      await cleanupIncompleteWorkspace(dir, log);
+      log.error('registry.register_failed', { err });
+      if (isInsufficientStorageError(err)) return insufficientStorageResult();
+      return {
+        ok: false,
+        code: 'injection_failed',
+        message: `workspace registry update failed: ${(err as Error).message}`,
+      };
+    }
     try {
       await this.opts.onWorkspaceCreated?.(workspace);
     } catch (err) {
       await this.opts.registry.remove(workspace.id).catch(() => undefined);
-      await rm(dir, { recursive: true, force: true });
+      await cleanupIncompleteWorkspace(dir, log);
       log.error('catalog.register_failed', { err });
+      if (isInsufficientStorageError(err)) return insufficientStorageResult();
       return {
         ok: false,
         code: 'injection_failed',
@@ -308,6 +330,68 @@ export class WorkspaceCreator {
     log.info('bootstrap.ok', { stdout: result.stdout.slice(-400) });
     return { ok: true, workspace };
   }
+}
+
+export async function inspectWorkspaceStorage(
+  workspacesRoot: string,
+  options: {
+    readonly minimumFreeBytes?: number;
+    readonly mkdirImpl?: typeof mkdir;
+    readonly statfsImpl?: typeof statfs;
+  } = {},
+): Promise<{ readonly ok: boolean; readonly availableBytes: number | null }> {
+  try {
+    await (options.mkdirImpl ?? mkdir)(workspacesRoot, { recursive: true });
+    const stats = await (options.statfsImpl ?? statfs)(workspacesRoot);
+    const availableBytes = Number(stats.bavail) * Number(stats.bsize);
+    return {
+      ok: !Number.isFinite(availableBytes)
+        || availableBytes >= (options.minimumFreeBytes ?? MIN_WORKSPACE_FREE_BYTES),
+      availableBytes: Number.isFinite(availableBytes) ? availableBytes : null,
+    };
+  } catch (error) {
+    if (isInsufficientStorageError(error)) return { ok: false, availableBytes: 0 };
+    // Some virtual/network filesystems do not implement statfs. Creation still
+    // has stage-specific ENOSPC handling below, so do not reject them blindly.
+    return { ok: true, availableBytes: null };
+  }
+}
+
+async function cleanupIncompleteWorkspace(dir: string, log: Logger): Promise<void> {
+  try {
+    await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    return;
+  } catch (cleanupError) {
+    const quarantine = `${dir}.bootstrap-failed-${Date.now()}`;
+    try {
+      await rename(dir, quarantine);
+      log.warn('bootstrap.quarantined', { dir, quarantine, cleanupError });
+      return;
+    } catch (quarantineError) {
+      log.error('bootstrap.cleanup_failed', { dir, cleanupError, quarantineError });
+    }
+  }
+}
+
+function isInsufficientStorageFailure(result: RunResult): boolean {
+  return result.errorCode === 'ENOSPC' || /\bENOSPC\b|no space left on device/i.test(result.stderr);
+}
+
+function isInsufficientStorageError(error: unknown): boolean {
+  const candidate = error as NodeJS.ErrnoException;
+  return candidate?.code === 'ENOSPC'
+    || /\bENOSPC\b|no space left on device/i.test(candidate?.message ?? String(error));
+}
+
+function insufficientStorageResult(availableBytes: number | null = null): CreateResult {
+  const available = availableBytes === null
+    ? ''
+    : ` (${Math.max(0, Math.floor(availableBytes / 1024 / 1024))} MiB available)`;
+  return {
+    ok: false,
+    code: 'insufficient_storage',
+    message: `Not enough free space to create this Workspace${available}. Free disk space or choose another OpenAlice data location, then retry.`,
+  };
 }
 
 /**
@@ -343,6 +427,7 @@ interface RunResult {
   readonly stdout: string;
   readonly stderr: string;
   readonly exitCode: number | null;
+  readonly errorCode?: string;
 }
 
 const WINDOWS_BASH_HINT =
@@ -424,6 +509,9 @@ export function runScript(
         stdout: Buffer.concat(stdoutChunks).toString('utf8'),
         stderr: `${hinted}\n${Buffer.concat(stderrChunks).toString('utf8')}`,
         exitCode: null,
+        ...((err as NodeJS.ErrnoException).code
+          ? { errorCode: (err as NodeJS.ErrnoException).code }
+          : {}),
       });
     });
 

--- a/src/workspaces/workspace-registry.spec.ts
+++ b/src/workspaces/workspace-registry.spec.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Logger } from './logger.js'
+import { WorkspaceRegistry } from './workspace-registry.js'
+
+const temporaryPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('WorkspaceRegistry persistence failures', () => {
+  it('rolls back the in-memory row when the registry file cannot be persisted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-registry-failure-'))
+    temporaryPaths.push(root)
+    const registry = await WorkspaceRegistry.load(join(root, 'workspaces.json'), logger())
+    const error = Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' })
+    vi.spyOn(registry as unknown as { flush(): Promise<void> }, 'flush').mockRejectedValueOnce(error)
+
+    await expect(registry.add({
+      id: 'chat-failed-row',
+      tag: 'diskfull',
+      dir: join(root, 'chat-failed-row'),
+      createdAt: '2026-07-15T00:00:00.000Z',
+      agents: ['pi'],
+    })).rejects.toMatchObject({ code: 'ENOSPC' })
+
+    expect(registry.hasId('chat-failed-row')).toBe(false)
+    expect(registry.hasTag('diskfull')).toBe(false)
+    expect(registry.list()).toEqual([])
+  })
+})
+
+function logger(): Logger {
+  const value = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => value,
+  }
+  return value as unknown as Logger
+}

--- a/src/workspaces/workspace-registry.ts
+++ b/src/workspaces/workspace-registry.ts
@@ -100,7 +100,13 @@ export class WorkspaceRegistry {
     }
     this.byId.set(ws.id, ws);
     this.tagsInUse.add(ws.tag);
-    await this.flush();
+    try {
+      await this.flush();
+    } catch (error) {
+      this.byId.delete(ws.id);
+      this.tagsInUse.delete(ws.tag);
+      throw error;
+    }
   }
 
   async remove(id: string): Promise<WorkspaceMeta | undefined> {

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -59,6 +59,7 @@ export interface CreateError {
     | 'invalid_tag'
     | 'tag_in_use'
     | 'tag_required'
+    | 'insufficient_storage'
     | 'bootstrap_failed'
     | 'unknown_template'
     | 'unknown_agent'


### PR DESCRIPTION
## Summary
- keep a 64 MiB creation safety margin before starting Workspace bootstrap
- classify ENOSPC across bootstrap, context injection, git commit, registry, and lifecycle catalog stages
- return actionable HTTP 507 `insufficient_storage` instead of a generic 500
- remove partial Workspace directories with bounded Windows retries, then quarantine when a handle still blocks deletion
- roll back the in-memory Workspace registry row when its atomic file write fails

## Verification
- storage/registry/API fault suite plus creator regression suite: 16/16 passed
- real fault injection creates `.git/README.md`, emits ENOSPC, verifies cleanup and zero registry writes
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test`: 3029 passed, 6 skipped
- Workspace creation E2E passed after building guardian-runtime; two unrelated live FRED/BLS network assertions failed (BLS ECONNRESET, FRED data alignment)
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`: packaged creation/CLI/Pi acceptance passed and temporary package was cleaned

## Boundary touch
- no Guardian ownership or UTA behavior changes
- no partial Workspace is registered after a persistence failure
- the free-space check tolerates filesystems without statfs and retains stage-level ENOSPC handling

Closes #623