### PR TITLE
Fix Workspace Manager responsive layout

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -930,6 +930,53 @@ html[lang="ja"] .oa-onboarding-title {
   border-top-right-radius: 0 !important;
 }
 
+/* Workspace Manager lives beside both the activity rail and the Ask Alice
+   sidebar, so viewport breakpoints overestimate the width it can actually use.
+   Size the layout against the page container and keep every grid track
+   shrinkable so long conversation titles cannot force horizontal overflow. */
+.workspace-manager-layout {
+  container: workspace-manager-layout / inline-size;
+}
+
+.workspace-manager-support-grid,
+.workspace-manager-suggestions {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.workspace-manager-suggestions-section {
+  container: workspace-manager-suggestions / inline-size;
+}
+
+@container workspace-manager-layout (min-width: 34rem) {
+  .workspace-manager-composer-footer {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+@container workspace-manager-layout (min-width: 48rem) {
+  .workspace-manager-hero {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+
+  .workspace-manager-stats {
+    width: 18rem;
+  }
+
+  .workspace-manager-support-grid {
+    grid-template-columns: minmax(0, 1.25fr) minmax(0, 0.75fr);
+  }
+}
+
+@container workspace-manager-suggestions (min-width: 34rem) {
+  .workspace-manager-suggestions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 /* Final cascade-level safety net. Several domain animations are declared
    below the first reduced-motion block, so this lives at EOF on purpose. */
 @media (prefers-reduced-motion: reduce) {

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -170,8 +170,8 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
         <div className="absolute -right-8 top-28 h-44 w-44 rounded-full border border-accent/10" />
       </div>
 
-      <div className="relative mx-auto flex min-h-full w-full max-w-5xl flex-col px-4 py-6 md:px-8 md:py-10">
-        <div className="mb-7 flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+      <div className="workspace-manager-layout relative mx-auto flex min-h-full w-full max-w-5xl flex-col px-4 py-6 md:px-8 md:py-10">
+        <div className="workspace-manager-hero mb-7 flex flex-col gap-5">
           <div className="max-w-2xl">
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-accent/20 bg-accent/[0.07] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.15em] text-accent">
               <Network size={12} /> {t('workspaceManager.eyebrow')}
@@ -183,7 +183,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
               {t('workspaceManager.subheading')}
             </p>
           </div>
-          <div className="grid grid-cols-2 gap-2 md:w-72">
+          <div className="workspace-manager-stats grid grid-cols-2 gap-2">
             <ManagerStat icon={Building2} label={t('workspaceManager.scope')} value={loading ? '—' : String(manager?.activeWorkspaceCount ?? 0)} />
             <ManagerStat icon={Bot} label={t('workspaceManager.runtime')} value="Pi · WebPi" />
           </div>
@@ -198,7 +198,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
             rows={4}
             className="min-h-28 w-full resize-none bg-transparent px-1 py-1 text-[14px] leading-relaxed text-text outline-none placeholder:text-text-muted/55 md:text-[15px]"
           />
-          <div className="mt-3 flex flex-col gap-2 border-t border-border/60 pt-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="workspace-manager-composer-footer mt-3 flex flex-col gap-2 border-t border-border/60 pt-3">
             <div className="flex min-w-0 items-center gap-2">
               <span className="inline-flex items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1.5 text-[11px] text-text-muted">
                 <Bot size={12} /> Pi · WebPi
@@ -249,12 +249,12 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
           <div className="mt-3 rounded-lg border border-red/25 bg-red/10 px-3 py-2 text-[12px] text-red">{error}</div>
         )}
 
-        <div className="mt-7 grid gap-6 lg:grid-cols-[1.25fr_0.75fr]">
-          <section>
+        <div className="workspace-manager-support-grid mt-7 grid min-w-0 gap-6">
+          <section className="workspace-manager-suggestions-section min-w-0">
             <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-muted/70">
               {t('workspaceManager.suggestions')}
             </h2>
-            <div className="grid gap-2 sm:grid-cols-2">
+            <div className="workspace-manager-suggestions grid min-w-0 gap-2">
               {suggestions.map((suggestion, index) => {
                 const Icon = SUGGESTION_ICONS[index] ?? Network
                 return (
@@ -275,7 +275,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
             <p className="mt-3 text-[11px] leading-relaxed text-text-muted/65">{t('workspaceManager.guardrail')}</p>
           </section>
 
-          <section>
+          <section className="min-w-0">
             <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-muted/70">
               {t('workspaceManager.recent')}
             </h2>


### PR DESCRIPTION
## What changed

- size the Workspace Manager hero, composer footer, support grid, and suggestion grid from the page container instead of the browser viewport
- make support-grid tracks and sections explicitly shrinkable
- preserve the wide-screen two-column layout while stacking cleanly when the activity rail and Ask Alice sidebar leave less room

## Root cause

The page used Tailwind viewport breakpoints. At a 1069px viewport, `lg` was active even though the two surrounding sidebars left only 620px for the Manager content. A long recent-conversation title then contributed a 1017px min-content width, shrinking Quick starts to roughly 80px and overflowing the page.

## User impact

Workspace Manager no longer overlaps or creates horizontal overflow at constrained desktop/tablet widths, and it still restores the intended two-column layout when its own container is wide enough.

## Verification

- `npx tsc --noEmit`
- `cd ui && pnpm run build`
- `pnpm test` (3029 passed, 6 skipped)
- live `/chat/manager` checks at 800x768, 1069x768, and 1440x900; no horizontal overflow and expected one/two-column transitions
- browser console: no warnings or errors