### PR TITLE
Fix Windows release command execution and CI coverage

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -16,9 +16,13 @@ on:
       - "scripts/desktop-package-artifact.mjs"
       - "scripts/desktop-packaged-smoke.mjs"
       - "scripts/desktop-packaged-smoke-plan.mjs"
+      - "scripts/build-broker-packs.ts"
       - "scripts/guardian/**"
+      - "scripts/pnpm-command.mjs"
+      - "scripts/pnpm-command.spec.ts"
       - "scripts/prepare-desktop-release-assets.mjs"
       - "scripts/smoke-packaged-toolchain.mjs"
+      - "scripts/verify-broker-packs.ts"
       - "scripts/workspace-acceptance-ai-mock.mjs"
       - "scripts/vendor-managed-runtime.mjs"
       - "default/**"
@@ -34,6 +38,7 @@ on:
       - "services/uta/**"
       - "services/connector/**"
       - "packages/connector-protocol/**"
+      - "packages/uta-broker-*/**"
   push:
     # Keep push package smoke master-only: PRs into dev get coverage, while
     # routine dev integration pushes do not burn the expensive desktop matrix.
@@ -50,9 +55,13 @@ on:
       - "scripts/desktop-package-artifact.mjs"
       - "scripts/desktop-packaged-smoke.mjs"
       - "scripts/desktop-packaged-smoke-plan.mjs"
+      - "scripts/build-broker-packs.ts"
       - "scripts/guardian/**"
+      - "scripts/pnpm-command.mjs"
+      - "scripts/pnpm-command.spec.ts"
       - "scripts/prepare-desktop-release-assets.mjs"
       - "scripts/smoke-packaged-toolchain.mjs"
+      - "scripts/verify-broker-packs.ts"
       - "scripts/workspace-acceptance-ai-mock.mjs"
       - "scripts/vendor-managed-runtime.mjs"
       - "default/**"
@@ -68,6 +77,7 @@ on:
       - "services/uta/**"
       - "services/connector/**"
       - "packages/connector-protocol/**"
+      - "packages/uta-broker-*/**"
 
 jobs:
   package:
@@ -97,6 +107,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build optional Broker Packs on Windows
+        if: runner.os == 'Windows'
+        run: pnpm broker-packs:build
+        timeout-minutes: 10
 
       # Keep this until the Windows managed Git runtime fully replaces dugite's
       # embedded payload. It catches a skipped dugite postinstall before a
@@ -137,8 +152,18 @@ jobs:
         run: pnpm electron:smoke-toolchain
 
       - name: Prove packaged Workspace CLI acceptance
+        if: runner.os != 'Windows'
         run: pnpm electron:smoke:workspace --skip-build --skip-pack
         timeout-minutes: 5
+        env:
+          OPENALICE_SMOKE_RECEIPT_PATH: ${{ runner.temp }}/openalice-workspace-acceptance.json
+
+      # Re-run the cached desktop build through the Node wrapper on Windows.
+      # This guards the pnpm.cmd quoting path used by local packaged smokes.
+      - name: Prove packaged Workspace CLI acceptance and Windows build wrapper
+        if: runner.os == 'Windows'
+        run: pnpm electron:smoke:workspace --skip-pack
+        timeout-minutes: 10
         env:
           OPENALICE_SMOKE_RECEIPT_PATH: ${{ runner.temp }}/openalice-workspace-acceptance.json
 

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -114,6 +114,9 @@ download CDN; and verifies every catalog and referenced archive.
 The build command also extracts every generated archive, verifies its catalog
 membership, size, SHA-256, package identity, entry containment, and absence of
 workspace/deployment metadata, then imports the entry in a clean Node process.
+Archive files are written synchronously because Pack assembly is serial and
+the asynchronous tar file writer can leave an unresolved top-level await on
+Windows after `pnpm deploy` exits.
 `pnpm broker-packs:verify` repeats that acceptance check against an existing
 `dist/broker-packs/` directory. Release scripts invoke Corepack's `pnpm.cmd`
 through `ComSpec` on Windows; the shared runner supplies the already-quoted

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -100,7 +100,7 @@ the native module is loaded instead of crashing UTA with `ERR_DLOPEN_FAILED`.
 ## Release Assets
 
 `pnpm broker-packs:build` builds all wrapper packages, runs `pnpm deploy --prod`
-for each engine, and emits:
+with the hoisted node linker for each engine, and emits:
 
 ```text
 OpenAlice-Broker-Packs-<version>-<platform>-<arch>.json
@@ -117,6 +117,10 @@ workspace/deployment metadata, then imports the entry in a clean Node process.
 Archive files are written synchronously because Pack assembly is serial and
 the asynchronous tar file writer can leave an unresolved top-level await on
 Windows after `pnpm deploy` exits.
+The hoisted deployment is also part of the portability contract: every
+manifest dependency must be an actual directory in the archive, not a pnpm
+symlink or Windows junction. Verification rejects missing or linked dependency
+roots before attempting the clean-process import.
 `pnpm broker-packs:verify` repeats that acceptance check against an existing
 `dist/broker-packs/` directory. Release scripts invoke Corepack's `pnpm.cmd`
 through `ComSpec` on Windows; the shared runner supplies the already-quoted

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -116,7 +116,14 @@ membership, size, SHA-256, package identity, entry containment, and absence of
 workspace/deployment metadata, then imports the entry in a clean Node process.
 `pnpm broker-packs:verify` repeats that acceptance check against an existing
 `dist/broker-packs/` directory. Release scripts invoke Corepack's `pnpm.cmd`
-through `ComSpec` on Windows; package scripts must not rely on POSIX quoting.
+through `ComSpec` on Windows; the shared runner supplies the already-quoted
+command line verbatim so Node does not quote it a second time. Package scripts
+must not rely on POSIX quoting.
+
+The Desktop Package Smoke workflow builds every optional Broker Pack on its
+Windows runner before packaging. It also reruns the cached desktop build
+through the packaged-smoke wrapper, so both release-facing `pnpm.cmd` call
+sites fail during PR validation rather than after a release starts.
 
 Desktop package acceptance rejects `ccxt`, `longbridge`, its native binding,
 and `@alpacahq/alpaca-trade-api` if they reappear under packaged

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -96,7 +96,9 @@ describe('OpenAlice local Runtime launcher', () => {
     expect(probeRuntime).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:3002')
     expect(resolveRoot).not.toHaveBeenCalled()
     expect(launchBrowser).toHaveBeenCalledWith('http://127.0.0.1:3002')
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('/tmp/user/.openalice'))
+    expect(stdout.write).toHaveBeenCalledWith(
+      expect.stringContaining(resolve('/tmp/user', '.openalice')),
+    )
   })
 
   it('prefers an owner-advertised web endpoint over persisted port configuration', async () => {

--- a/scripts/build-broker-packs.ts
+++ b/scripts/build-broker-packs.ts
@@ -46,7 +46,16 @@ try {
 
     const file = brokerPackArchiveFileName(packageJson.version, engine)
     const archivePath = resolve(outDir, file)
-    await tar.c({ gzip: true, cwd: deployRoot, file: archivePath, portable: true }, ['.'])
+    // tar's async file writer can leave an unresolved top-level await on
+    // Windows after pnpm deploy exits. Pack assembly is intentionally serial,
+    // so use the documented synchronous file mode for a deterministic write.
+    tar.c({
+      gzip: true,
+      cwd: deployRoot,
+      file: archivePath,
+      portable: true,
+      sync: true,
+    }, ['.'])
     const archiveStat = await stat(archivePath)
     packs.push({
       engine,

--- a/scripts/build-broker-packs.ts
+++ b/scripts/build-broker-packs.ts
@@ -87,6 +87,7 @@ try {
 
 function deployPackage(packageName: string, target: string): void {
   const result = runPnpmSync([
+    '--config.node-linker=hoisted',
     '--config.inject-workspace-packages=true',
     '--filter', packageName,
     'deploy', '--prod', target,

--- a/scripts/build-broker-packs.ts
+++ b/scripts/build-broker-packs.ts
@@ -5,7 +5,6 @@ import { createReadStream } from 'node:fs'
 import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, resolve } from 'node:path'
-import { spawnSync } from 'node:child_process'
 import * as tar from 'tar'
 import {
   BROKER_PACK_API_VERSION,
@@ -19,7 +18,7 @@ import {
   type BrokerPackRequirement,
   type BrokerPackReleaseCatalog,
 } from '../src/core/broker-pack-catalog.js'
-import { composePnpmCommand } from './pnpm-command.mjs'
+import { runPnpmSync } from './pnpm-command.mjs'
 
 const repoRoot = resolve(import.meta.dirname, '..')
 const packageJson = JSON.parse(await readFile(resolve(repoRoot, 'package.json'), 'utf8')) as { version: string }
@@ -78,12 +77,11 @@ try {
 }
 
 function deployPackage(packageName: string, target: string): void {
-  const command = composePnpmCommand([
+  const result = runPnpmSync([
     '--config.inject-workspace-packages=true',
     '--filter', packageName,
     'deploy', '--prod', target,
-  ])
-  const result = spawnSync(command.command, command.args, {
+  ], {
     cwd: repoRoot,
     stdio: 'inherit',
     env: process.env,

--- a/scripts/desktop-packaged-smoke.mjs
+++ b/scripts/desktop-packaged-smoke.mjs
@@ -11,7 +11,7 @@ import {
   DEFAULT_DESKTOP_PACKAGE_ROOT,
 } from './desktop-package-artifact.mjs'
 import { buildDesktopPackagedSmokePlan } from './desktop-packaged-smoke-plan.mjs'
-import { composePnpmCommand } from './pnpm-command.mjs'
+import { runPnpmSync } from './pnpm-command.mjs'
 import { packagedElectronExecutable } from './smoke-packaged-toolchain.mjs'
 import { startWorkspaceAcceptanceAiMock } from './workspace-acceptance-ai-mock.mjs'
 
@@ -59,14 +59,14 @@ Options:
 
 function run(label, command, commandArgs, extraEnv = {}) {
   console.log(`\n[desktop-smoke] ${label}`)
-  const childCommand = command === 'pnpm'
-    ? composePnpmCommand(commandArgs, { env: process.env })
-    : { command, args: commandArgs }
-  const result = spawnSync(childCommand.command, childCommand.args, {
+  const options = {
     cwd: repoRoot,
     stdio: 'inherit',
     env: { ...process.env, ...extraEnv },
-  })
+  }
+  const result = command === 'pnpm'
+    ? runPnpmSync(commandArgs, options)
+    : spawnSync(command, commandArgs, options)
   if (result.error) throw result.error
   if (result.status !== 0) {
     throw new Error(`${label} exited ${result.status ?? 'unknown'}${result.signal ? ` (${result.signal})` : ''}`)

--- a/scripts/pnpm-command.mjs
+++ b/scripts/pnpm-command.mjs
@@ -1,3 +1,5 @@
+import { spawnSync } from 'node:child_process'
+
 /**
  * Compose a shell-free pnpm child-process command on POSIX and the equivalent
  * cmd.exe invocation required for Corepack's pnpm.cmd shim on Windows.
@@ -9,14 +11,38 @@ export function composePnpmCommand(commandArgs, options = {}) {
   const platform = options.platform ?? process.platform
   const env = options.env ?? process.env
   if (platform !== 'win32') {
-    return { command: 'pnpm', args: [...commandArgs] }
+    return {
+      command: 'pnpm',
+      args: [...commandArgs],
+      windowsVerbatimArguments: false,
+    }
   }
 
   const commandLine = ['pnpm.cmd', ...commandArgs.map(quoteCmdArgument)].join(' ')
   return {
     command: env.ComSpec ?? env.COMSPEC ?? 'cmd.exe',
     args: ['/d', '/s', '/c', commandLine],
+    // The command line is already quoted for cmd.exe. Letting Node quote it a
+    // second time makes the quotes around pnpm arguments literal on Windows.
+    windowsVerbatimArguments: true,
   }
+}
+
+/**
+ * Run pnpm synchronously with the platform-specific quoting contract above.
+ * Keep this wrapper as the shared release-script boundary so callers cannot
+ * accidentally omit windowsVerbatimArguments when invoking pnpm.cmd.
+ */
+export function runPnpmSync(commandArgs, options = {}) {
+  const { platform, ...spawnOptions } = options
+  const invocation = composePnpmCommand(commandArgs, {
+    platform,
+    env: spawnOptions.env,
+  })
+  return spawnSync(invocation.command, invocation.args, {
+    ...spawnOptions,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+  })
 }
 
 function quoteCmdArgument(value) {

--- a/scripts/pnpm-command.spec.ts
+++ b/scripts/pnpm-command.spec.ts
@@ -55,6 +55,7 @@ describe.runIf(process.platform === 'win32')('runPnpmSync on Windows', () => {
 
   it('preserves a leading config flag, spaces, and cmd metacharacters', () => {
     const result = runPnpmSync([
+      '--config.node-linker=hoisted',
       '--config.inject-workspace-packages=true',
       'exec',
       'node',

--- a/scripts/pnpm-command.spec.ts
+++ b/scripts/pnpm-command.spec.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { composePnpmCommand } from './pnpm-command.mjs'
+import { composePnpmCommand, runPnpmSync } from './pnpm-command.mjs'
 
 describe('composePnpmCommand', () => {
   it('uses a direct shell-free pnpm invocation on POSIX', () => {
     expect(composePnpmCommand(['electron:build'], { platform: 'darwin' })).toEqual({
       command: 'pnpm',
       args: ['electron:build'],
+      windowsVerbatimArguments: false,
     })
   })
 
@@ -22,6 +23,7 @@ describe('composePnpmCommand', () => {
         '/c',
         'pnpm.cmd "-F" "@traderalice/desktop" "exec" "electron-builder"',
       ],
+      windowsVerbatimArguments: true,
     })
   })
 
@@ -35,5 +37,41 @@ describe('composePnpmCommand', () => {
     expect(spec.args.at(-1)).toBe(
       'pnpm.cmd "deploy" "--prod" "C:\\Users\\Alice Dev\\broker pack"',
     )
+    expect(spec.windowsVerbatimArguments).toBe(true)
   })
+})
+
+describe.runIf(process.platform === 'win32')('runPnpmSync on Windows', () => {
+  it('runs a quoted pnpm command through the installed Corepack shim', () => {
+    const result = runPnpmSync(['--version'], {
+      encoding: 'utf8',
+      env: process.env,
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(0)
+    expect(result.stdout).toMatch(/^\d+\.\d+\.\d+/)
+  }, 15_000)
+
+  it('preserves a leading config flag, spaces, and cmd metacharacters', () => {
+    const result = runPnpmSync([
+      '--config.inject-workspace-packages=true',
+      'exec',
+      'node',
+      '-e',
+      'process.stdout.write(JSON.stringify(process.argv.slice(1)))',
+      'C:\\Alice Work\\broker pack',
+      'alpha&beta',
+    ], {
+      encoding: 'utf8',
+      env: process.env,
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual([
+      'C:\\Alice Work\\broker pack',
+      'alpha&beta',
+    ])
+  }, 15_000)
 })

--- a/scripts/verify-broker-packs.ts
+++ b/scripts/verify-broker-packs.ts
@@ -3,7 +3,7 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { access, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat } from 'node:fs/promises'
+import { access, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -113,6 +113,20 @@ async function verifyPortableDeployment(
     if (name.startsWith('@traderalice/')) throw new Error(`${engine} archive contains an unbundled workspace dependency: ${name}`)
     if (typeof spec !== 'string' || /^(?:file|link|workspace):/.test(spec) || spec.includes('file://')) {
       throw new Error(`${engine} archive contains a non-portable dependency spec: ${name}@${String(spec)}`)
+    }
+
+    const dependencyPath = resolve(packageRoot, 'node_modules', ...name.split('/'))
+    let dependencyStat
+    try {
+      dependencyStat = await lstat(dependencyPath)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`${engine} archive is missing declared dependency: ${name}`)
+      }
+      throw error
+    }
+    if (!dependencyStat.isDirectory() || dependencyStat.isSymbolicLink()) {
+      throw new Error(`${engine} archive dependency must be a portable directory: ${name}`)
     }
   }
 

--- a/src/workspaces/template-upgrade.spec.ts
+++ b/src/workspaces/template-upgrade.spec.ts
@@ -71,7 +71,12 @@ beforeEach(async () => {
   };
 });
 
-afterEach(async () => rm(root, { recursive: true, force: true }));
+afterEach(async () => rm(root, {
+  recursive: true,
+  force: true,
+  maxRetries: 5,
+  retryDelay: 100,
+}));
 
 describe('TemplateUpgradeManager', () => {
   it('classifies incoming updates, local customizations, dual edits, and additions', async () => {
@@ -232,7 +237,7 @@ describe('TemplateUpgradeManager', () => {
         .toContain('# Chat');
       expect(plan.files.some((entry) => entry.path.startsWith('.agents/skills/'))).toBe(true);
     }
-  });
+  }, 15_000);
 });
 
 describe('isManagedTemplatePath', () => {


### PR DESCRIPTION
## Summary

- centralize synchronous pnpm execution so pre-quoted `pnpm.cmd` commands use `windowsVerbatimArguments` through `ComSpec`
- route desktop packaged smoke and Broker Pack deployment through that shared runner
- build Broker Packs with deterministic synchronous tar writes and hoisted, real-directory dependencies that survive Windows archive extraction
- reject missing or linked Broker Pack dependency roots before clean-process import
- add Windows-native argument round-trip coverage for config flags, spaces, and cmd metacharacters
- make the local Runtime path assertion platform-aware and give concurrent Chat template materialization bounded Windows cleanup retries and a realistic timeout
- extend Desktop Package Smoke so Windows builds optional Broker Packs and exercises the packaged-smoke build wrapper instead of skipping it

## Root cause

Node's default Windows argument escaping wrapped an already-quoted `cmd.exe /c` command line again. Quotes around pnpm arguments then reached pnpm literally, so `electron:build` became `"electron:build"` and the leading Broker Pack config flag became a quoted command token. The existing package job built directly and later passed `--skip-build`, so it never exercised the failing wrapper.

Once that path was covered, Windows also exposed two latent Broker Pack portability problems: async tar file creation could leave an unsettled top-level await, and pnpm-linked dependency roots did not survive the Windows archive path as importable directories. Pack assembly is now synchronous and uses a hoisted deployment whose manifest dependencies are verified as real directories.

## Validation

Local:

- `pnpm exec vitest run scripts/pnpm-command.spec.ts packages/cli/src/local-start.spec.mjs src/workspaces/template-upgrade.spec.ts`
- `pnpm broker-packs:build`
- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm test` (293 files passed, 3029 tests passed)
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`

GitHub Actions:

- `cross-platform-test (windows-latest)` passed
- `package windows-latest` passed, including Broker Pack build/verification and the non-skipped desktop build wrapper
- all other PR checks passed

Closes #627
Closes #628
