### PR TITLE
Refresh OpenAI and Claude model catalogs

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -96,6 +96,13 @@ usable before OpenAlice updates its catalog. Gemini suggestions should contain
 general-purpose text/tool models only; image, Live, TTS, embedding, and managed
 agent model IDs are different product surfaces and do not belong in Quick Chat.
 
+Keep subscription-backed CLI profiles distinct from API-key credentials.
+Claude Code subscription profiles should prefer its native aliases (`default`,
+`best`, `opus`, `sonnet`, `haiku`, and `opusplan`) so the CLI and account tier
+resolve current availability; Anthropic API credentials should suggest exact
+API model IDs. Codex subscription and OpenAI API catalogs may share a model
+family only when official documentation confirms both surfaces support it.
+
 Editing must round-trip the stored `lastModel` and any endpoint that no longer
 matches a current preset. A catalog refresh must never silently replace either
 value merely because the user opened and saved the form.

--- a/src/ai-providers/preset-catalog.spec.ts
+++ b/src/ai-providers/preset-catalog.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_MODEL_BY_VENDOR, GEMINI, LONGCAT } from './preset-catalog.js';
+import {
+  CLAUDE_API,
+  CLAUDE_OAUTH,
+  CODEX_API,
+  CODEX_OAUTH,
+  DEFAULT_MODEL_BY_VENDOR,
+  GEMINI,
+  LONGCAT,
+} from './preset-catalog.js';
 import { BUILTIN_PRESETS } from './presets.js';
 
 describe('LONGCAT preset', () => {
@@ -16,6 +24,39 @@ describe('LONGCAT preset', () => {
 });
 
 describe('credential form catalog', () => {
+  it('uses native Claude Code aliases for subscription profiles', () => {
+    expect(CLAUDE_OAUTH.models?.map((model) => model.id)).toEqual([
+      'default',
+      'best',
+      'opus',
+      'sonnet',
+      'haiku',
+      'opusplan',
+    ]);
+    expect(CLAUDE_OAUTH.zodSchema.parse({
+      backend: 'agent-sdk',
+      loginMethod: 'claudeai',
+    })).toMatchObject({ model: 'default' });
+  });
+
+  it('offers current Anthropic API tiers while keeping Opus as the complex-agent default', () => {
+    expect(CLAUDE_API.models?.map((model) => model.id)).toEqual([
+      'claude-fable-5',
+      'claude-opus-4-8',
+      'claude-sonnet-5',
+      'claude-haiku-4-5',
+      'claude-sonnet-4-6',
+    ]);
+    expect(DEFAULT_MODEL_BY_VENDOR['anthropic']).toBe('claude-opus-4-8');
+  });
+
+  it('offers the GPT 5.6 family to Codex subscriptions and OpenAI API keys', () => {
+    const expected = ['gpt-5.6', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4'];
+    expect(CODEX_OAUTH.models?.map((model) => model.id)).toEqual(expected);
+    expect(CODEX_API.models?.map((model) => model.id)).toEqual(expected);
+    expect(DEFAULT_MODEL_BY_VENDOR['openai']).toBe('gpt-5.6');
+  });
+
   it('offers current general-purpose Gemini tiers without mixing in media-only models', () => {
     expect(GEMINI.models?.map((model) => model.id)).toEqual([
       'gemini-3.5-flash',

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -81,15 +81,19 @@ export const CLAUDE_OAUTH: PresetDef = {
   description: 'Use your Claude Pro/Max subscription',
   category: 'official',
   defaultName: 'Claude (Pro/Max)',
-  hint: 'Requires Claude Code CLI login — run `claude login` in your terminal first. Model is switchable here or from the profile list anytime; Opus is most capable but burns subscription quota faster, so consider Sonnet for routine work.',
+  hint: 'Requires Claude Code CLI login — run `claude login` in your terminal first. Native aliases follow the models available to that account: keep Default for the plan recommendation, use Best/Opus for difficult work, or Sonnet for routine work.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('claudeai'),
-    model: z.string().default('claude-opus-4-8').describe('Model'),
+    model: z.string().default('default').describe('Model'),
   }),
   models: [
-    { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
-    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+    { id: 'default', label: 'Default (Recommended for your account)' },
+    { id: 'best', label: 'Best (Most capable available)' },
+    { id: 'opus', label: 'Opus (Latest available)' },
+    { id: 'sonnet', label: 'Sonnet (Latest available)' },
+    { id: 'haiku', label: 'Haiku (Fastest available)' },
+    { id: 'opusplan', label: 'Opus planning → Sonnet execution' },
   ],
 }
 
@@ -99,7 +103,7 @@ export const CLAUDE_API: PresetDef = {
   description: 'Pay per token via Anthropic API',
   category: 'official',
   defaultName: 'Claude (API Key)',
-  hint: 'Model is switchable here or from the profile list anytime. Opus is ~5× the cost of Sonnet.',
+  hint: 'Model is switchable here or from the profile list anytime. Opus is the recommended complex-agent default; Sonnet balances capability and cost, while Fable is the highest-capability premium tier.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
@@ -107,15 +111,18 @@ export const CLAUDE_API: PresetDef = {
     apiKey: z.string().min(1).describe('Anthropic API key'),
   }),
   models: [
-    { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
-    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+    { id: 'claude-fable-5', label: 'Claude Fable 5 (Highest capability)' },
+    { id: 'claude-opus-4-8', label: 'Claude Opus 4.8 (Complex agents)' },
+    { id: 'claude-sonnet-5', label: 'Claude Sonnet 5 (Balanced)' },
+    { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5 (Fastest)' },
+    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (Previous generation)' },
   ],
   regions: [{ id: 'official', label: 'Official (api.anthropic.com)', wires: { anthropic: '' } }],
   setup: {
     apiKeyLabel: 'Anthropic API key',
     apiKeyPlaceholder: 'sk-ant-...',
     apiKeyHelp: 'Use a key from Anthropic Console. Claude Pro/Max is a separate Claude Code login and does not belong in this field.',
-    modelHelp: 'Choose an Anthropic API model ID. OpenAlice tests this exact model and remembers it as the default for this credential.',
+    modelHelp: 'Choose an Anthropic API model ID, or paste another exact ID. Opus 4.8 stays the complex-agent default; Fable 5 is the premium capability tier and Sonnet 5 is the balanced tier.',
   },
   writeOnlyFields: ['apiKey'],
 }
@@ -132,11 +139,14 @@ export const CODEX_OAUTH: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('codex'),
     loginMethod: z.literal('codex-oauth'),
-    model: z.string().default('gpt-5.5').describe('Model'),
+    model: z.string().default('gpt-5.6').describe('Model'),
   }),
   models: [
-    { id: 'gpt-5.5', label: 'GPT 5.5' },
-    { id: 'gpt-5.4', label: 'GPT 5.4' },
+    { id: 'gpt-5.6', label: 'GPT 5.6 (Power · Sol)' },
+    { id: 'gpt-5.6-terra', label: 'GPT 5.6 Terra (Balanced)' },
+    { id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna (Fastest)' },
+    { id: 'gpt-5.5', label: 'GPT 5.5 (Previous generation)' },
+    { id: 'gpt-5.4', label: 'GPT 5.4 (Previous generation)' },
   ],
 }
 
@@ -149,12 +159,15 @@ export const CODEX_API: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('codex'),
     loginMethod: z.literal('api-key'),
-    model: z.string().default('gpt-5.5').describe('Model'),
+    model: z.string().default('gpt-5.6').describe('Model'),
     apiKey: z.string().min(1).describe('OpenAI API key'),
   }),
   models: [
-    { id: 'gpt-5.5', label: 'GPT 5.5' },
-    { id: 'gpt-5.4', label: 'GPT 5.4' },
+    { id: 'gpt-5.6', label: 'GPT 5.6 (Sol alias)' },
+    { id: 'gpt-5.6-terra', label: 'GPT 5.6 Terra (Balanced)' },
+    { id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna (Cost-efficient)' },
+    { id: 'gpt-5.5', label: 'GPT 5.5 (Previous generation)' },
+    { id: 'gpt-5.4', label: 'GPT 5.4 (Previous generation)' },
   ],
   // Same key + base; the shape is how you call it. Responses is OpenAI's
   // current API (what codex speaks); Chat Completions is the legacy shape
@@ -164,7 +177,7 @@ export const CODEX_API: PresetDef = {
     apiKeyLabel: 'OpenAI API key',
     apiKeyPlaceholder: 'sk-...',
     apiKeyHelp: 'Use an OpenAI Platform API key. A ChatGPT subscription is a separate Codex CLI login and does not belong in this field.',
-    modelHelp: 'Choose a model enabled for this API project. The saved model becomes this credential’s default in new Workspace injections.',
+    modelHelp: 'Choose a model enabled for this API project, or paste another exact ID. GPT 5.6 is the current Sol alias; Terra balances capability and cost, while Luna favors efficient high-volume work.',
   },
   writeOnlyFields: ['apiKey'],
 }
@@ -435,17 +448,17 @@ export const PRESET_CATALOG: PresetDef[] = [
 ]
 
 /**
- * The capable-flagship model to seed a fresh injection with when a credential
- * has no remembered `lastModel` yet (keyed by `CredentialVendor`). This is only
- * the very-first-run default — once a model is run it's remembered on the cred —
- * so it favors the most capable tier (a trading agent wants the flagship, not a
- * fast/cheap variant), mirroring the preset model lists. `custom` has no
- * canonical model (free-form), so it's absent and the caller falls back to
- * "let the runtime decide".
+ * The recommended model to seed a fresh injection with when a credential has
+ * no remembered `lastModel` yet (keyed by `CredentialVendor`). This is only the
+ * very-first-run default — once a model is run it's remembered on the cred — so
+ * each provider can balance agent capability, availability, and cost rather
+ * than inheriting whichever discovery suggestion happens to be listed first.
+ * `custom` has no canonical model (free-form), so it's absent and the caller
+ * falls back to "let the runtime decide".
  */
 export const DEFAULT_MODEL_BY_VENDOR: Record<string, string> = {
   anthropic: 'claude-opus-4-8',
-  openai: 'gpt-5.5',
+  openai: 'gpt-5.6',
   google: 'gemini-3.1-flash-lite',
   minimax: 'MiniMax-M3',
   glm: 'glm-5.2',

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -241,7 +241,7 @@ describe('POST /quick-chat — loginless credential injection', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it('opencode + compatible cred → injects it (flagship model) then spawns', async () => {
+  it('opencode + compatible cred → injects the current vendor recommendation then spawns', async () => {
     vi.mocked(readCredentials).mockResolvedValue({ 'openai-1': openaiKey });
     const { app, opencode, spawn } = build();
     const r = await quickChat(app, { prompt: 'hi', agent: 'opencode' });
@@ -250,10 +250,10 @@ describe('POST /quick-chat — loginless credential injection', () => {
     const cred = (opencode.writeAiConfig.mock.calls[0] as any[])[1];
     expect(cred.apiKey).toBe('sk-oa');
     expect(cred.wireShape).toBe('openai-chat');
-    expect(cred.model).toBe('gpt-5.5'); // vendor flagship — no lastModel yet
+    expect(cred.model).toBe('gpt-5.6'); // current vendor recommendation — no lastModel yet
     expect(cred.contextWindow).toBe(256_000);
     // model remembered on the cred for next time
-    expect(vi.mocked(setCredentialLastModel)).toHaveBeenCalledWith('openai-1', 'gpt-5.5');
+    expect(vi.mocked(setCredentialLastModel)).toHaveBeenCalledWith('openai-1', 'gpt-5.6');
     expect(spawn).toHaveBeenCalledOnce();
   });
 

--- a/src/workspaces/agent-credential-readiness.spec.ts
+++ b/src/workspaces/agent-credential-readiness.spec.ts
@@ -127,11 +127,11 @@ describe('agent credential readiness', () => {
     expect(a.writeAiConfig).toHaveBeenCalledOnce();
     expect(a.writeAiConfig).toHaveBeenCalledWith('/tmp/ws-1', expect.objectContaining({
       apiKey: 'sk-oa',
-      model: 'gpt-5.5',
+      model: 'gpt-5.6',
       wireShape: 'openai-chat',
       contextWindow: 256_000,
     }));
-    expect(vi.mocked(setCredentialLastModel)).toHaveBeenCalledWith('openai-1', 'gpt-5.5');
+    expect(vi.mocked(setCredentialLastModel)).toHaveBeenCalledWith('openai-1', 'gpt-5.6');
   });
 
   it('does not treat a custom credential without a remembered model as injectable', async () => {

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -291,10 +291,12 @@ describe('matchCredentialByApiKey', () => {
 describe('resolveInjectionModel', () => {
   it('prefers the credential\'s remembered lastModel', () => {
     expect(resolveInjectionModel({ vendor: 'openai', lastModel: 'gpt-5.5-custom' })).toBe('gpt-5.5-custom')
+    expect(resolveInjectionModel({ vendor: 'openai', lastModel: 'gpt-5.5' })).toBe('gpt-5.5')
   })
 
-  it('falls back to the vendor flagship when no lastModel', () => {
+  it('falls back to the vendor recommendation when no lastModel', () => {
     expect(resolveInjectionModel({ vendor: 'anthropic' })).toBe('claude-opus-4-8')
+    expect(resolveInjectionModel({ vendor: 'openai' })).toBe('gpt-5.6')
     expect(resolveInjectionModel({ vendor: 'glm' })).toBe('glm-5.2')
     expect(resolveInjectionModel({ vendor: 'longcat' })).toBe('LongCat-2.0')
   })

--- a/ui/src/demo/handlers/configKeys.spec.ts
+++ b/ui/src/demo/handlers/configKeys.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { demoCredentialPresets } from './configKeys'
+
+function modelIds(presetId: string): string[] {
+  const preset = demoCredentialPresets.find((candidate) => candidate.id === presetId)
+  const model = preset?.schema.properties.model as {
+    default?: string
+    oneOf?: Array<{ const: string }>
+  } | undefined
+  return model?.oneOf?.map((option) => option.const) ?? []
+}
+
+describe('demo credential catalog', () => {
+  it('covers the current OpenAI and Anthropic forms instead of falling back to Custom', () => {
+    expect(modelIds('codex-api')).toEqual([
+      'gpt-5.6',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+      'gpt-5.4',
+    ])
+    expect(modelIds('claude-api')).toEqual([
+      'claude-fable-5',
+      'claude-opus-4-8',
+      'claude-sonnet-5',
+      'claude-haiku-4-5',
+      'claude-sonnet-4-6',
+    ])
+  })
+})

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -1,6 +1,38 @@
 import { http, HttpResponse } from 'msw'
 
-const demoCredentialPresets = [
+export const demoCredentialPresets = [
+  {
+    id: 'claude-api',
+    label: 'Claude (API Key)',
+    description: 'Pay per token via Anthropic API',
+    category: 'official',
+    defaultName: 'Claude (API Key)',
+    hint: 'Opus is the recommended complex-agent default; Sonnet balances capability and cost, while Fable is the highest-capability premium tier.',
+    setup: {
+      apiKeyLabel: 'Anthropic API key',
+      apiKeyPlaceholder: 'sk-ant-...',
+      apiKeyHelp: 'Use a key from Anthropic Console. Claude Pro/Max is a separate Claude Code login.',
+      modelHelp: 'Choose an Anthropic API model ID, or paste another exact ID.',
+    },
+    schema: {
+      type: 'object',
+      properties: {
+        apiKey: { type: 'string' },
+        model: {
+          type: 'string',
+          default: 'claude-opus-4-8',
+          oneOf: [
+            { const: 'claude-fable-5', title: 'Claude Fable 5 (Highest capability)' },
+            { const: 'claude-opus-4-8', title: 'Claude Opus 4.8 (Complex agents)' },
+            { const: 'claude-sonnet-5', title: 'Claude Sonnet 5 (Balanced)' },
+            { const: 'claude-haiku-4-5', title: 'Claude Haiku 4.5 (Fastest)' },
+            { const: 'claude-sonnet-4-6', title: 'Claude Sonnet 4.6 (Previous generation)' },
+          ],
+        },
+      },
+    },
+    regions: [{ id: 'official', label: 'Official (api.anthropic.com)', wires: { anthropic: '' } }],
+  },
   {
     id: 'codex-api',
     label: 'OpenAI (API Key)',
@@ -11,13 +43,23 @@ const demoCredentialPresets = [
       apiKeyLabel: 'OpenAI API key',
       apiKeyPlaceholder: 'sk-...',
       apiKeyHelp: 'Use an OpenAI Platform API key. A ChatGPT subscription is a separate Codex CLI login.',
-      modelHelp: 'Choose a model enabled for this API project.',
+      modelHelp: 'Choose a model enabled for this API project, or paste another exact ID.',
     },
     schema: {
       type: 'object',
       properties: {
         apiKey: { type: 'string' },
-        model: { type: 'string', default: 'gpt-5.5', oneOf: [{ const: 'gpt-5.5', title: 'GPT 5.5' }] },
+        model: {
+          type: 'string',
+          default: 'gpt-5.6',
+          oneOf: [
+            { const: 'gpt-5.6', title: 'GPT 5.6 (Sol alias)' },
+            { const: 'gpt-5.6-terra', title: 'GPT 5.6 Terra (Balanced)' },
+            { const: 'gpt-5.6-luna', title: 'GPT 5.6 Luna (Cost-efficient)' },
+            { const: 'gpt-5.5', title: 'GPT 5.5 (Previous generation)' },
+            { const: 'gpt-5.4', title: 'GPT 5.4 (Previous generation)' },
+          ],
+        },
       },
     },
     regions: [{ id: 'official', label: 'OpenAI (api.openai.com)', wires: { 'openai-responses': '', 'openai-chat': '' } }],
@@ -107,7 +149,7 @@ export const configKeysHandlers = [
     HttpResponse.json({
       credentials: [
         { slug: 'anthropic-1', vendor: 'anthropic', label: 'Anthropic', authType: 'api-key', wires: { anthropic: '' }, apiKey: null, hasApiKey: true, lastModel: 'claude-opus-4-8' },
-        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true, lastModel: 'gpt-5.5' },
+        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true, lastModel: 'gpt-5.6' },
       ],
     }),
   ),

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -453,7 +453,7 @@ export const workspacesHandlers = [
   http.get('/api/workspaces/credentials', () =>
     HttpResponse.json({
       credentials: [
-        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-chat': '' }, lastModel: 'gpt-5.5', resolvedModel: 'gpt-5.5', apiKey: null },
+        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-chat': '' }, lastModel: 'gpt-5.6', resolvedModel: 'gpt-5.6', apiKey: null },
         { slug: 'minimax-1', vendor: 'minimax', label: 'MiniMax', authType: 'api-key', wires: { 'openai-chat': '' }, lastModel: 'MiniMax-M2.1', resolvedModel: 'MiniMax-M2.1', apiKey: null },
       ],
     }),


### PR DESCRIPTION
## Summary

- refresh OpenAI/Codex presets to the GPT-5.6 Sol, Terra, and Luna family
- keep Claude API on an explicit Opus 4.8 default while adding Fable 5, Sonnet 5, and Haiku 4.5
- use Claude Code's native subscription aliases instead of pinning OAuth users to an API snapshot
- keep remembered models unchanged for existing credentials and Workspaces
- align demo handlers, docs, and regression coverage with the runtime catalog

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (297 files passed, 1 skipped; 3061 tests passed, 8 skipped)
- targeted CLI installer spec rerun passed
- real settings route verified for OpenAI and Claude add forms
- demo settings route verified for OpenAI and Claude edit forms
- isolated first-run onboarding walk completed with no browser console warnings or errors
