### PR TITLE
Prepare the 0.81.0 beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.80.0-beta",
+  "version": "0.81.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -19,7 +19,7 @@ afterEach(async () => {
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
 })
 
-describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', () => {
+describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeout: 15_000 }, () => {
   it('keeps the CLI and desktop managed-Pi pins aligned', async () => {
     const installer = await readFile(join(repositoryRoot, 'install'), 'utf8')
     const desktopVendor = await readFile(join(repositoryRoot, 'scripts/vendor-managed-runtime.mjs'), 'utf8')

--- a/packages/guardian-runtime/src/process-control.spec.ts
+++ b/packages/guardian-runtime/src/process-control.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeProcessExitCode } from './process-control.js'
+
+describe('normalizeProcessExitCode', () => {
+  it('preserves valid integer exit codes', () => {
+    expect(normalizeProcessExitCode(0)).toBe(0)
+    expect(normalizeProcessExitCode(1)).toBe(1)
+    expect(normalizeProcessExitCode(137)).toBe(137)
+  })
+
+  it('maps signal callback payloads and invalid numbers to success', () => {
+    expect(normalizeProcessExitCode('SIGINT')).toBe(0)
+    expect(normalizeProcessExitCode('SIGTERM')).toBe(0)
+    expect(normalizeProcessExitCode(Number.NaN)).toBe(0)
+    expect(normalizeProcessExitCode(-1)).toBe(0)
+  })
+})

--- a/packages/guardian-runtime/src/process-control.ts
+++ b/packages/guardian-runtime/src/process-control.ts
@@ -41,6 +41,18 @@ export function currentProcessStartedAt(): number {
   return Math.floor((Date.now() - process.uptime() * 1_000) / 1_000) * 1_000
 }
 
+/**
+ * Keep process shutdown codes safe when a callback is also used as a Node
+ * signal handler. Signal listeners receive the signal name as their first
+ * argument, which must never flow into `process.exit()` as though it were a
+ * numeric child-process exit code.
+ */
+export function normalizeProcessExitCode(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+    ? value
+    : 0
+}
+
 export async function isSameProcess(
   pid: number,
   expectedStartedAt: string | undefined,

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -34,6 +34,7 @@ import { setTimeout as sleep } from 'node:timers/promises'
 import {
   acquireGuardianRuntime,
   currentProcessStartedAt,
+  normalizeProcessExitCode,
   takeoverRequested,
 } from '@traderalice/guardian-runtime'
 import { startGuardianControlServer } from './control-server.mjs'
@@ -452,7 +453,7 @@ async function restartUTA() {
 }
 
 function shutdown(exitCode = 0) {
-  shutdownExitCode = Math.max(shutdownExitCode, exitCode)
+  shutdownExitCode = Math.max(shutdownExitCode, normalizeProcessExitCode(exitCode))
   if (stopping) return
   stopping = true
   if (aliceChild) aliceStatus = 'stopping'
@@ -482,9 +483,9 @@ function shutdown(exitCode = 0) {
   }, 5_000)
 }
 
-process.on('SIGINT', shutdown)
-process.on('SIGTERM', shutdown)
-process.on('SIGHUP', shutdown)
+process.on('SIGINT', () => shutdown())
+process.on('SIGTERM', () => shutdown())
+process.on('SIGHUP', () => shutdown())
 
 async function startFlagWatcher() {
   await mkdir(dirname(FLAG_PATH), { recursive: true })

--- a/src/domain/market-data/__test__/e2e/market-data.e2e.spec.ts
+++ b/src/domain/market-data/__test__/e2e/market-data.e2e.spec.ts
@@ -49,11 +49,11 @@ describe('market-data e2e — FRED via webui routes', () => {
   })
 
   it('fred_series multi-symbol returns rows with both columns populated', async () => {
-    // Catches the same asc bug indirectly — with old asc default, GDP (from 1947)
-    // and UNRATE (from 1948) latest-N timestamps had near-zero overlap, so
-    // merged rows were almost always single-column. With desc default,
-    // both series share the same recent dates.
-    const rows = await getJson(t.app, '/api/market-data-v1/economy/fred_series?provider=federal_reserve&symbol=GDP,UNRATE&limit=5')
+    // Exercise the date merge over an explicit recent window. Using `limit=5`
+    // independently for quarterly GDP and monthly UNRATE is time-dependent:
+    // once the monthly series advances far enough beyond the latest GDP
+    // publication, neither set is required to contain the same date.
+    const rows = await getJson(t.app, '/api/market-data-v1/economy/fred_series?provider=federal_reserve&symbol=GDP,UNRATE&start_date=2024-01-01')
     expect(rows.length).toBeGreaterThan(0)
     const hasBoth = rows.some(r => r.GDP != null && r.UNRATE != null)
     expect(hasBoth).toBe(true)


### PR DESCRIPTION
## Summary
- bump the release candidate to `0.81.0-beta`
- make built-runtime Guardian signal shutdown use a valid numeric exit code, with regression coverage
- give installer acceptance tests a suite-level budget consistent with their own PTY timeout
- make the live FRED multi-frequency merge test use an explicit shared date window

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm test` (3063 passed, 8 skipped)
- `pnpm -F @traderalice/guardian-runtime test`
- `pnpm -F @traderalice/guardian-runtime typecheck`
- `pnpm test:guardian-recovery`
- `pnpm test:install:docker`
- manual `pnpm test:install:docker --interactive` walkthrough
- source-installed CLI localhost handoff and clean Ctrl+C shutdown
- `pnpm broker-packs:build` (five 0.81.0-beta darwin-arm64 packs verified)
- main-home UI walkthrough: missing packs, install, 0.80-to-0.81 Repair, hot restart, and 8 UTA recovery without deleting credentials
- `pnpm test:remote:docker`
- `pnpm docker:smoke`
- credentialed Docker Pi/Google two-turn + CLI acceptance
- Docker volume persistence and healthcheck acceptance
- `pnpm electron:smoke:workspace`
- non-BLS E2E matrix: 30 passed, 6 skipped; the direct BLS live call remains locally unavailable because this machine's network resets TLS to api.bls.gov

## Boundary touch
- runtime/Guardian shutdown
- release metadata and Broker Pack version compatibility
- packaging and installer acceptance tests
- no trading writes, credential changes, or persisted-data migrations
