### PR TITLE
chore: promote stable CLI installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+
       - name: Download release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -316,6 +320,13 @@ jobs:
         run: |
           mkdir -p dist/r2-upload
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir dist/r2-upload --clobber
+
+      - name: Prepare release-owned CLI installer
+        env:
+          TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          cp install "dist/r2-upload/OpenAlice-${VERSION}-install"
 
       - name: Prepare CDN download aliases
         env:
@@ -328,13 +339,17 @@ jobs:
             --base-url "${DOWNLOAD_BASE_URL:-https://download.openalice.ai}" \
             --repository "$GITHUB_REPOSITORY"
 
-      - name: Publish architecture-specific macOS update metadata
+      - name: Publish generated release metadata and installer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
         run: |
           shopt -s nullglob
           files=(dist/r2-upload/*-mac-intel.yml dist/r2-upload/*-intel-mac.yml dist/r2-upload/latest-mac-arm64.yml)
+          installer="dist/r2-upload/OpenAlice-${TAG#v}-install"
+          if [ -f "$installer" ]; then
+            files+=("$installer")
+          fi
           if ((${#files[@]})); then
             gh release upload "$TAG" "${files[@]}" --repo "$GITHUB_REPOSITORY" --clobber
           fi
@@ -364,6 +379,8 @@ jobs:
             --exclude "mac-x64.dmg" \
             --exclude "mac-x64.zip" \
             --exclude "windows-x64.exe" \
+            --exclude "install" \
+            --exclude "OpenAlice-*-install" \
             --cache-control "public, max-age=31536000, immutable" \
             --endpoint-url "$ENDPOINT"
 
@@ -378,6 +395,18 @@ jobs:
           aws s3 cp dist/r2-upload/manifest.json "s3://${R2_BUCKET}/manifest.json" \
             --cache-control "no-cache" \
             --content-type "application/json" \
+            --endpoint-url "$ENDPOINT"
+
+          for installer in dist/r2-upload/OpenAlice-*-install; do
+            aws s3 cp "$installer" "s3://${R2_BUCKET}/$(basename "$installer")" \
+              --cache-control "public, max-age=31536000, immutable" \
+              --content-type "text/plain" \
+              --endpoint-url "$ENDPOINT"
+          done
+
+          aws s3 cp dist/r2-upload/install "s3://${R2_BUCKET}/install" \
+            --cache-control "no-cache" \
+            --content-type "text/plain" \
             --endpoint-url "$ENDPOINT"
 
           if [ -f dist/r2-upload/mac-arm64.dmg ]; then
@@ -453,6 +482,21 @@ jobs:
           fi
           curl -fsSI "${BASE_URL}/windows-x64.exe"
           curl -fsSI "${BASE_URL}/manifest.json"
+          curl -fsSI "${BASE_URL}/OpenAlice-${VERSION}-install"
+          curl -fsSI "${BASE_URL}/install"
+          curl -fsSL "${BASE_URL}/install" -o /tmp/openalice-install
+          cmp /tmp/openalice-install dist/r2-upload/install
+          bash -n /tmp/openalice-install
+          bash /tmp/openalice-install --plan | tee /tmp/openalice-install-plan
+          grep -Eq '^  Branch[[:space:]]+master$' /tmp/openalice-install-plan
+          INSTALLER_PATH=/tmp/openalice-install MANIFEST_URL="${BASE_URL}/manifest.json" node -e '
+            const { createHash } = require("node:crypto");
+            const { readFileSync } = require("node:fs");
+            const manifest = JSON.parse(require("node:child_process").execFileSync("curl", ["-fsSL", process.env.MANIFEST_URL], { encoding: "utf8" }));
+            const digest = createHash("sha256").update(readFileSync(process.env.INSTALLER_PATH)).digest("hex");
+            if (manifest.installer?.url !== process.env.MANIFEST_URL.replace(/manifest\.json$/, "install")) process.exit(1);
+            if (manifest.installer?.sha256 !== digest) process.exit(1);
+          '
 
           for catalog in dist/r2-upload/OpenAlice-Broker-Packs-${VERSION}-*.json; do
             curl -fsSI "${BASE_URL}/$(basename "$catalog")"

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ guides.
 ## User Quickstarts
 
 - [[docs/remote-quickstart.md]] — [Remote quickstart](remote-quickstart.md):
-  install the preview CLI, prepare a private SSH host, connect and reconnect,
+  install the stable CLI, prepare a private SSH host, connect and reconnect,
   understand Server lifetime and security, and see the design inspiration
   behind the remote path.
 

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -53,26 +53,32 @@ weaken or silently replace the Electron lane.
 
 ## Current Entry Point
 
-The preview installer is served directly from the `dev` branch:
+The stable installer is served from the OpenAlice site:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash -s -- --branch dev
+curl -fsSL https://openalice.ai/install | bash
 ```
 
-It requires Node.js 22.19.0 or newer, matching the pinned Pi runtime's engine
-floor. With no selector, the installer targets the stable `master` branch;
-development dogfooding must opt into `--branch dev`. `--version` is reserved
-for a tag or commit, and the two selectors are mutually exclusive. The default
-install root is `~/.openalice`, and the downloaded OpenAlice payload is the file
-set declared by `FILES` in the root `install` script. The installer also
-downloads Pi's release-owned install manifest and lockfile for version `0.80.6`,
-verifies both against pinned SHA-256 values, and runs
-`npm ci --omit=dev --ignore-scripts` in the staged release.
+The release workflow publishes the same bytes as a versioned GitHub Release
+asset, mirrors them to `download.openalice.ai`, records their SHA-256 in the
+download manifest, and updates the rolling `install` alias without caching it.
+The main-site route proxies that release-owned alias and refuses non-script
+upstream content.
 
-The preview URL is not yet a stable release channel. Do not present a mutable
-`dev` ref as a signed or immutable release. A stable installer needs release
-assets and a release-owned authenticity chain; see
-[Authenticity boundary](#authenticity-boundary).
+The script requires Node.js 22.19.0 or newer, matching the pinned Pi runtime's
+engine floor. With no selector, it targets the stable `master` branch.
+Development dogfooding must opt into `--branch dev` explicitly:
+
+```bash
+curl -fsSL https://openalice.ai/install | bash -s -- --branch dev
+```
+
+`--version` selects a tag or commit, and the two selectors are mutually
+exclusive. The default install root is `~/.openalice`, and the downloaded
+OpenAlice payload is the file set declared by `FILES` in the root `install`
+script. The installer also downloads Pi's release-owned install manifest and
+lockfile for version `0.80.6`, verifies both against pinned SHA-256 values, and
+runs `npm ci --omit=dev --ignore-scripts` in the staged release.
 
 ## Load-Bearing Files
 
@@ -372,7 +378,7 @@ Environment inputs:
 | Variable | Meaning |
 |---|---|
 | `OPENALICE_INSTALL_DIR` | Default install root when `--install-dir` is absent |
-| `OPENALICE_INSTALL_URL` | Record the distributor-owned installer URL in installed provenance; used by fixtures and future CDN entry points |
+| `OPENALICE_INSTALL_URL` | Override the public installer URL recorded in installed provenance; used by fixtures and private mirrors |
 | `OPENALICE_INSTALL_BASE_URL` | Override payload base URL for local fixtures and installer tests |
 | `OPENALICE_PI_RELEASE_BASE_URL` | Override the pinned Pi release-asset base for installer tests |
 | `OPENALICE_PI_SOURCE_DIR` | Read the exact Pi manifest/lock assets from a local fixture |
@@ -388,16 +394,19 @@ semantics before becoming public API.
 
 ## Authenticity Boundary
 
-The current content identity protects update layout and detects accidental or
-local modification. It does not prove who supplied the downloaded files. The
-current preview script is fetched from the mutable `dev` URL with an explicit
-`--branch dev`, while the selector-free release contract targets `master`.
-Both paths choose payload files from the selected raw GitHub ref. Even when
-that payload ref is an immutable commit, a hash computed by the same downloaded
-installer is not an independent trust anchor.
+The public bootstrap is release-owned: each accepted release carries a
+versioned installer asset, the R2 manifest records its SHA-256, and the rolling
+main-site entry resolves to the mirrored bytes. The installed content identity
+then protects update layout and detects accidental or local modification.
 
-Do not describe the preview as cryptographically verified. A stable release
-path should establish this chain:
+This is still not a cryptographic signature. The installer downloads the CLI
+payload as individual files from the selected raw GitHub ref, and the R2
+manifest belongs to the same release control plane as the mirrored script.
+Even when that payload ref is an immutable commit, a hash published beside the
+download is not an independent trust anchor.
+
+Do not describe the CLI path as signed. A future archive/signature path should
+establish this chain:
 
 ```text
 trusted release metadata
@@ -525,8 +534,8 @@ Before publishing or promoting a change that affects the installer:
 5. Walk `pnpm test:install:docker --interactive` as a human.
 6. Exercise the installed CLI from `--source`; include the localhost handoff if
    the payload or start boundary changed.
-7. State residual platform and authenticity gaps explicitly. Do not treat an
-   unsigned raw-file preview as release-signing evidence.
+7. Verify the versioned installer asset, R2 `install` alias, manifest checksum,
+   and main-site proxy. State the remaining archive/signature gap explicitly.
 8. Keep Electron signing and notarization in the Electron release lane; the CLI
    preview must not read those secrets.
 

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -33,18 +33,19 @@ desktop package when preparing a source checkout; it does not replace or
 modify Electron packaging, app protocol, preload, IPC, PTY, signing, or update
 behavior.
 
-## Preview Install
+## Stable Install
 
-The current installer distributes the small JavaScript CLI from the `dev` ref:
+The public installer distributes the small JavaScript CLI from the stable
+`master` lane:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash -s -- --branch dev
+curl -fsSL https://openalice.ai/install | bash
 ```
 
-The installer defaults to the stable `master` branch; this preview command
-opts into `dev` explicitly. It requires Node.js 22.19.0 or newer and always
-installs the small CLI plus OpenAlice's pinned Pi runtime inside the same
-immutable install release; the two visible commands are `openalice` and `pi`.
+Development dogfooding can opt into `dev` explicitly with `--branch dev`. The
+installer requires Node.js 22.19.0 or newer and always installs the small CLI
+plus OpenAlice's pinned Pi runtime inside the same immutable install release;
+the two visible commands are `openalice` and `pi`.
 When explicitly selected,
 it can also install missing Linux Git/Python/make/C++ tools needed to build the
 source Runtime. It does not clone OpenAlice, write application state, install

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -100,7 +100,7 @@ Clone the current preview lane on the remote host:
 
 ```bash
 ssh openalice-box \
-  'git clone --branch dev https://github.com/TraderAlice/OpenAlice.git "$HOME/OpenAlice"'
+  'git clone --branch master https://github.com/TraderAlice/OpenAlice.git "$HOME/OpenAlice"'
 ```
 
 Ask the remote shell for the absolute path. `openalice remote` intentionally
@@ -114,10 +114,10 @@ The examples below use `/home/alice/OpenAlice`; replace it with that output.
 
 ### 2. Install the local CLI
 
-The preview installer shows its complete plan before asking for consent:
+The stable installer shows its complete plan before asking for consent:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash -s -- --branch dev
+curl -fsSL https://openalice.ai/install | bash
 ```
 
 Open a new terminal so the managed PATH block is active, then verify both
@@ -344,8 +344,8 @@ the UI before building a more specialized terminal transport.
 
 - The remote host must already contain an OpenAlice checkout; `remote` does not
   clone or update source.
-- The preview installer follows mutable `dev` rather than signed immutable
-  release assets.
+- The bootstrap is a release-owned asset, but the installed CLI payload still
+  comes from the selected GitHub ref rather than a signed standalone archive.
 - Linux and macOS remote hosts are supported; the native Windows distribution
   remains Electron.
 - One interactive browser per terminal is the conservative assumption until

--- a/install
+++ b/install
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPOSITORY="TraderAlice/OpenAlice"
 DEFAULT_BRANCH="master"
+PUBLIC_INSTALLER_URL="https://openalice.ai/install"
 VERSION=""
 REF_KIND=""
 REF_OPTION=""
@@ -97,7 +98,7 @@ Usage:
   ./install
   ./install --branch dev
   ./install --version <tag-or-commit>
-  curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install | bash -s -- --branch dev
+  curl -fsSL https://openalice.ai/install | bash
 
 Options:
   --branch <name>       Git branch to install (default: master)
@@ -421,7 +422,11 @@ if [[ ${#VERSION} -gt 128 || "$VERSION" == *".."* || ! "$VERSION" =~ ^[A-Za-z0-9
   die "Unsupported version/ref: $VERSION"
 fi
 
-INSTALLER_URL="${OPENALICE_INSTALL_URL:-https://raw.githubusercontent.com/$REPOSITORY/$VERSION/install}"
+DEFAULT_INSTALLER_URL="https://raw.githubusercontent.com/$REPOSITORY/$VERSION/install"
+if [[ "$REF_KIND" == "branch" && "$VERSION" == "$DEFAULT_BRANCH" ]]; then
+  DEFAULT_INSTALLER_URL="$PUBLIC_INSTALLER_URL"
+fi
+INSTALLER_URL="${OPENALICE_INSTALL_URL:-$DEFAULT_INSTALLER_URL}"
 
 INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
 BIN_DIR="$INSTALL_ROOT/bin"

--- a/packages/cli/src/install-source.mjs
+++ b/packages/cli/src/install-source.mjs
@@ -8,7 +8,7 @@ export const DEFAULT_INSTALL_SOURCE = Object.freeze({
   repository: 'TraderAlice/OpenAlice',
   cliVersion: CLI_VERSION,
   selector: Object.freeze({ kind: 'branch', value: 'master' }),
-  installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/master/install',
+  installerUrl: 'https://openalice.ai/install',
 })
 
 export async function readInstallSource(options = {}) {

--- a/packages/cli/src/install-source.spec.mjs
+++ b/packages/cli/src/install-source.spec.mjs
@@ -17,11 +17,15 @@ afterEach(async () => {
 })
 
 describe('OpenAlice install source', () => {
-  it('uses master only when no installed metadata exists', async () => {
+  it('uses the public master installer when no installed metadata exists', async () => {
     const root = await mkdtemp(join(tmpdir(), 'openalice-install-source-'))
     temporaryPaths.push(root)
     await expect(readInstallSource({ metadataUrl: join(root, 'missing.json') }))
       .resolves.toEqual(DEFAULT_INSTALL_SOURCE)
+    expect(DEFAULT_INSTALL_SOURCE).toMatchObject({
+      selector: { kind: 'branch', value: 'master' },
+      installerUrl: 'https://openalice.ai/install',
+    })
   })
 
   it('rejects malformed installed metadata instead of silently changing channels', async () => {

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -30,6 +30,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     const cliManifest = JSON.parse(await readFile(join(repositoryRoot, 'packages/cli/package.json'), 'utf8'))
 
     expect(installer).toContain('DEFAULT_BRANCH="master"')
+    expect(installer).toContain('PUBLIC_INSTALLER_URL="https://openalice.ai/install"')
     expect(installer).toContain('MINIMUM_NODE_VERSION="22.19.0"')
     expect(installer).toContain('PI_VERSION="0.80.6"')
     expect(desktopVendor).toContain("const PI_VERSION = '0.80.6'")
@@ -67,6 +68,26 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
       '--version', 'v0.2.0',
     ], { env: installerEnv(home) })).rejects.toMatchObject({
       stderr: expect.stringContaining('Use only one of --branch or --version'),
+    })
+  })
+
+  it('records the public installer URL for the default master channel', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-public-source-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const installer = join(repositoryRoot, 'install')
+
+    await execFileAsync('bash', [installer,
+      '--source', repositoryRoot,
+      '--install-dir', installRoot,
+      '--no-modify-path',
+      '--yes',
+    ], { env: installerEnv(home) })
+
+    const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
+    expect(JSON.parse(versionInfo.stdout).installSource).toMatchObject({
+      selector: { kind: 'branch', value: 'master' },
+      installerUrl: 'https://openalice.ai/install',
     })
   })
 

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -24,7 +24,7 @@ const masterInstallSource = {
   repository: 'TraderAlice/OpenAlice',
   cliVersion: '0.2.0',
   selector: { kind: 'branch', value: 'master' },
-  installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/master/install',
+  installerUrl: 'https://openalice.ai/install',
 }
 
 describe('OpenAlice managed remote connector', () => {

--- a/scripts/prepare-desktop-release-assets.mjs
+++ b/scripts/prepare-desktop-release-assets.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto'
 import { copyFileSync, existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -75,6 +76,10 @@ function copyAlias(outDir, source, alias) {
   return alias
 }
 
+function sha256File(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex')
+}
+
 export function prepareMirrorAssets({ outDir, tag, baseUrl, repository }) {
   const version = tag.replace(/^v/, '')
   const channel = prereleaseChannel(version)
@@ -86,12 +91,14 @@ export function prepareMirrorAssets({ outDir, tag, baseUrl, repository }) {
   const macX64Zip = findFirst(names, [`OpenAlice-${version}-x64-mac.zip`, `OpenAlice-${version}-mac.zip`])
   const windowsX64Exe = findFirst(names, [`OpenAlice.Setup.${version}.exe`])
   const windowsX64Blockmap = findFirst(names, [`OpenAlice.Setup.${version}.exe.blockmap`])
+  const installerAsset = findFirst(names, [`OpenAlice-${version}-install`])
 
   copyAlias(outDir, macArm64Dmg, 'mac-arm64.dmg')
   copyAlias(outDir, macArm64Zip, 'mac-arm64.zip')
   copyAlias(outDir, macX64Dmg, 'mac-x64.dmg')
   copyAlias(outDir, macX64Zip, 'mac-x64.zip')
   copyAlias(outDir, windowsX64Exe, 'windows-x64.exe')
+  copyAlias(outDir, installerAsset, 'install')
 
   if (channel !== 'latest') {
     copyIfPresent(outDir, 'latest-mac.yml', [`${channel}-mac.yml`])
@@ -127,6 +134,11 @@ export function prepareMirrorAssets({ outDir, tag, baseUrl, repository }) {
     macX64Dmg: urlFor(macX64Dmg && 'mac-x64.dmg'),
     macX64Zip: urlFor(macX64Zip && 'mac-x64.zip'),
     windowsX64Exe: urlFor(windowsX64Exe && 'windows-x64.exe'),
+    installer: installerAsset ? {
+      url: urlFor('install'),
+      sha256: sha256File(join(outDir, 'install')),
+      versionedUrl: urlFor(installerAsset),
+    } : null,
     versioned: {
       macArm64Dmg: urlFor(macArm64Dmg),
       macArm64Zip: urlFor(macArm64Zip),

--- a/scripts/prepare-desktop-release-assets.spec.ts
+++ b/scripts/prepare-desktop-release-assets.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -49,6 +50,7 @@ describe('prepareMirrorAssets', () => {
         'OpenAlice-1.2.3-beta-mac.zip',
         'OpenAlice.Setup.1.2.3-beta.exe',
         'OpenAlice.Setup.1.2.3-beta.exe.blockmap',
+        'OpenAlice-1.2.3-beta-install',
       ]
       for (const file of files) writeFileSync(join(dir, file), file)
       writeFileSync(join(dir, 'latest-mac.yml'), 'version: 1.2.3-beta\n')
@@ -71,6 +73,12 @@ describe('prepareMirrorAssets', () => {
       expect(manifest.feeds.macIntel).toBe('https://download.openalice.ai/beta-mac-intel.yml')
       expect(manifest.macX64Dmg).toBe('https://download.openalice.ai/mac-x64.dmg')
       expect(manifest.versioned.macX64Zip).toBe('https://download.openalice.ai/OpenAlice-1.2.3-beta-mac.zip')
+      expect(readFileSync(join(dir, 'install'), 'utf8')).toBe('OpenAlice-1.2.3-beta-install')
+      expect(manifest.installer).toEqual({
+        url: 'https://download.openalice.ai/install',
+        sha256: createHash('sha256').update('OpenAlice-1.2.3-beta-install').digest('hex'),
+        versionedUrl: 'https://download.openalice.ai/OpenAlice-1.2.3-beta-install',
+      })
     })
   })
 
@@ -88,6 +96,7 @@ describe('prepareMirrorAssets', () => {
       })
 
       expect(manifest.feeds.macIntel).toBeNull()
+      expect(manifest.installer).toBeNull()
       expect(manifest.macX64Dmg).toBeNull()
       expect(manifest.macArm64Dmg).toBe('https://download.openalice.ai/mac-arm64.dmg')
     })


### PR DESCRIPTION
## Summary

Promote the post-release CLI installation stack from `dev` to `master` without changing the desktop version:

- release-owned, versioned installer asset and rolling R2 `/install` alias
- installer URL/SHA-256 in `manifest.json`
- stable `https://openalice.ai/install` provenance
- owner docs and validation coverage

After this promotion is green and merged, the existing `v0.81.0-beta` release will be mirrored again through the workflow’s `mirror_tag` path. This does not create a new version or rerun the package release lane.

## Local validation

- `npx tsc --noEmit`
- `pnpm test` (3064 passed, 8 skipped)
- CLI tests (70 passed)
- installer/release targeted tests (39 passed)
- automated and interactive Docker installer smoke
- isolated source install with managed Pi 0.80.6 and localhost Guardian/UI handoff