### PR TITLE
fix: wait for Guardian takeover readiness

### DIFF
--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -681,6 +681,24 @@ browser, SSH tunnel, remote PTY, remote Pi process, and provider round trip.
 This validates the functional Pi path; representative 20/80/150 ms network
 shaping remains a separate latency observation.
 
+A 2026-07-16 persistent-volume Railway service then exercised the stable
+`master` installer through ordinary OpenSSH. Cold bootstrap, source build,
+detached readiness, tunnel HTTP/auth, disconnect persistence, idempotent plan,
+and same-container restart recovery all passed. A full Railway redeploy kept
+the checkout, build artifacts, and `OPENALICE_HOME` on the volume while
+correctly dropping the container-local CLI and Pi, which managed remote then
+reinstalled from `https://openalice.ai/install` without rebuilding the source
+Runtime.
+
+The redeploy also confirmed the cross-machine safety boundary. The reattached
+volume still named the removed container as Guardian and Alice owner; ordinary
+start refused it, and explicit `--takeover` still refused to signal or reclaim
+an owner from another machine. After Railway independently reported the old
+deployment as removed, the operator quarantined all three foreign lock records
+before starting the new owner. This is an operational recovery observation,
+not automatic cross-machine failover: heartbeat expiry alone must never grant
+permission to reclaim a shared volume.
+
 ### Stage 3 — terminal transport optimization
 
 - build only if Stage 2 measurements justify it;

--- a/packages/cli/src/server.mjs
+++ b/packages/cli/src/server.mjs
@@ -164,6 +164,7 @@ export async function startRuntimeServer(options, dependencies = {}) {
       waitForServerReady(homeRoot, options.waitMs, {
         ...dependencies,
         readStatus,
+        allowOwnerTransition: options.takeover,
         signal: readinessAbort.signal,
       }),
       earlyFailure,
@@ -254,7 +255,10 @@ async function waitForServerReady(homeRoot, timeoutMs, dependencies) {
     if (dependencies.signal?.aborted) return null
     lastStatus = await readStatus({ homeRoot, timeoutMs: Math.min(1_000, Math.max(100, deadline - Date.now())) }, dependencies)
     if (lastStatus.class === 'running' && lastStatus.owner?.surface === 'cli-server') return lastStatus
-    if (lastStatus.class === 'owned_elsewhere' || lastStatus.class === 'incompatible') {
+    if (
+      !dependencies.allowOwnerTransition
+      && (lastStatus.class === 'owned_elsewhere' || lastStatus.class === 'incompatible')
+    ) {
       throw new Error(formatOwnershipRefusal(lastStatus))
     }
     const aborted = await sleepOrAbort(

--- a/packages/cli/src/server.spec.mjs
+++ b/packages/cli/src/server.spec.mjs
@@ -105,6 +105,46 @@ describe('OpenAlice Server CLI', () => {
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('keep running'))
   })
 
+  it('waits for an explicit takeover to replace the previous owner', async () => {
+    const child = new FakeChild()
+    const spawnProcess = vi.fn(() => child)
+    const previousOwner = {
+      ...runningStatus(),
+      class: 'owned_elsewhere',
+      owner: { ...runningStatus().owner, surface: 'cli-server' },
+      endpoints: {},
+      capabilities: [],
+    }
+    const readStatus = vi.fn()
+      .mockResolvedValueOnce(previousOwner)
+      .mockResolvedValueOnce(previousOwner)
+      .mockResolvedValue(runningStatus())
+
+    await expect(startRuntimeServer(parseServerArgs('start', [
+      '--app-dir', '/tmp/OpenAlice',
+      '--home', '/tmp/alice-home',
+      '--takeover',
+    ]), {
+      detached: true,
+      env: { PATH: '/bin' },
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess,
+      openFile: async () => ({ fd: 9, close: async () => undefined }),
+      mkdirImpl: async () => undefined,
+      readStatus,
+      sleep: async () => undefined,
+      stdout: { write: vi.fn() },
+    })).resolves.toBe(0)
+
+    expect(readStatus).toHaveBeenCalledTimes(3)
+    expect(spawnProcess).toHaveBeenCalledWith('/test/node', ['scripts/guardian/prod.mjs'], expect.objectContaining({
+      env: expect.objectContaining({ OPENALICE_TAKEOVER: '1' }),
+    }))
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
   it('keeps server run in the foreground until its Guardian exits', async () => {
     const child = new FakeChild()
     const stdout = { write: vi.fn((text) => {


### PR DESCRIPTION
## Summary
- keep polling readiness while an explicitly authorized Guardian takeover replaces the previous owner
- preserve the existing fail-fast refusal for ordinary starts
- add the Railway persistent-volume/redeploy observation and cross-machine safety boundary

## Root cause
`server start --takeover` spawned the replacement Guardian, but its parent readiness loop could observe the old `owned_elsewhere` status first, abort immediately, and kill the replacement before Guardian completed the controlled takeover.

This change does not weaken runtime locks. Foreign-machine owners are still never signaled or reclaimed automatically; the Railway redeploy test confirmed that boundary.

## Validation
- Guardian recovery skill `fast` matrix
- `npx tsc --noEmit`
- `pnpm test` (3065 passed, 8 skipped)
- targeted Server/remote specs (32 passed)
- `pnpm test:guardian-recovery`
- `pnpm test:remote:docker`
- real Railway Node 22.19 cold bootstrap, source build, tunnel HTTP/auth, disconnect persistence, restart recovery, full redeploy, and foreign-owner quarantine/recovery