### PR TITLE
Fix chat polling flicker and session routing

### DIFF
--- a/ui/src/components/ActivityBar.spec.ts
+++ b/ui/src/components/ActivityBar.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { NAV_SECTIONS } from './activity-navigation'
+
+describe('ActivityBar navigation hierarchy', () => {
+  it('keeps Workspaces out of primary navigation and under System', () => {
+    const primary = NAV_SECTIONS.find((section) => section.sectionLabel === '')
+    const system = NAV_SECTIONS.find((section) => section.sectionLabel === 'System')
+
+    expect(primary?.items.map((item) => item.page)).not.toContain('workspaces')
+    expect(system?.items.map((item) => item.page)).toContain('workspaces')
+  })
+})

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,13 +1,14 @@
-import { type LucideIcon, MessageSquare, Inbox, Telescope, LineChart, GitBranch, BarChart3, Newspaper, Zap, Settings, Code2, TerminalSquare, ChevronDown, Info, ListChecks, PanelLeftClose, PanelLeftOpen, Plug } from 'lucide-react'
+import { ChevronDown, Info, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
-import type { ActivitySection, ViewSpec } from '../tabs/types'
+import type { ActivitySection } from '../tabs/types'
 import { useUnreadInboxCount } from '../live/inbox-read'
 import { usePendingPushCount } from '../live/trading-push'
 import { useActivityBarCollapse } from '../live/activity-bar-collapse'
 import { useTranslation } from 'react-i18next'
 import { ThemeToggle } from './ThemeToggle'
+import { NAV_SECTIONS } from './activity-navigation'
 
 /**
  * Map ActivityBar page enum (visual layout grouping) to the ActivitySection
@@ -42,98 +43,6 @@ interface ActivityBarProps {
   compactRailForced?: boolean
 }
 
-// ==================== Nav item definitions ====================
-
-type NavItemKey =
-  | 'nav.item.inbox' | 'nav.item.tracked' | 'nav.item.chat' | 'nav.item.workspaces'
-  | 'nav.item.market' | 'nav.item.news' | 'nav.item.tradingAsGit' | 'nav.item.issue'
-  | 'nav.item.portfolio' | 'nav.item.connectors' | 'nav.item.automation' | 'nav.item.settings' | 'nav.item.dev'
-
-interface NavLeaf {
-  page: Page
-  labelKey: NavItemKey
-  icon: LucideIcon
-  /**
-   * What page opens when this ActivityBar item is clicked. Local navigators
-   * are page-owned now, so every rail item has a concrete landing surface.
-   */
-  defaultTab: ViewSpec
-}
-
-interface NavSection {
-  /** Stable identity — the collapse-state storage key and the labeled-vs-
-   *  pinned check. '' = the unlabeled top section. Display comes from
-   *  `labelKey`, not this. */
-  sectionLabel: string
-  /** i18n key for the displayed section header (labeled sections only). */
-  labelKey?: 'nav.section.beta' | 'nav.section.system'
-  items: NavLeaf[]
-  /** When true, the section starts collapsed on a user's first visit
-   *  (or after they clear localStorage). User-toggled collapse state
-   *  still wins — `defaultCollapsed` only fills in the absence-of-key
-   *  default. Useful for "this section exists but isn't the recommended
-   *  path" framing (Legacy). */
-  defaultCollapsed?: boolean
-  /** i18n key for the muted-text paragraph rendered between the section
-   *  header and its items (visible only when expanded) — e.g. Beta's
-   *  lifecycle hint. */
-  descriptionKey?: 'nav.betaDescription'
-}
-
-const NAV_SECTIONS: NavSection[] = [
-  // Top — primary nav, always visible (no header, not collapsible).
-  // Mental model: Chat (Ask Alice) is THE entry — for an AI product the
-  // chat surface is the front door (how you use the thing), so it sits at
-  // the very top, above Inbox (which is task sync, not the core loop).
-  // Workspaces (the all-templates index) is the power-user surface for
-  // hands-on session management; the two aren't redundant (Workspaces =
-  // whole set, Chat = chat-shape subset shortcut), but because day-to-day
-  // work rarely leaves Ask Alice, Workspaces sits at the bottom of this
-  // group rather than alongside Chat.
-  //
-  // Market / News are operational tools that work but aren't load-
-  // bearing — they live here because they don't need lifecycle
-  // labelling.
-  {
-    sectionLabel: '',
-    items: [
-      { page: 'chat',       labelKey: 'nav.item.chat',       icon: MessageSquare, defaultTab: { kind: 'chat-landing', params: {} } },
-      { page: 'inbox',      labelKey: 'nav.item.inbox',      icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
-      { page: 'issue',      labelKey: 'nav.item.issue',      icon: ListChecks, defaultTab: { kind: 'issue', params: {} } },
-      { page: 'tracked',    labelKey: 'nav.item.tracked',    icon: Telescope, defaultTab: { kind: 'tracked', params: {} } },
-      { page: 'market',     labelKey: 'nav.item.market',     icon: BarChart3, defaultTab: { kind: 'market-list', params: {} } },
-      { page: 'news',       labelKey: 'nav.item.news',       icon: Newspaper, defaultTab: { kind: 'news', params: {} } },
-      { page: 'workspaces', labelKey: 'nav.item.workspaces', icon: TerminalSquare, defaultTab: { kind: 'workspace-list', params: {} } },
-    ],
-  },
-  // Beta — useful product surfaces whose state model and UX are still
-  // settling. Configuration remains in Settings; these entries show the
-  // operational product state rather than editing credentials.
-  {
-    sectionLabel: 'Beta',
-    labelKey: 'nav.section.beta',
-    descriptionKey: 'nav.betaDescription',
-    items: [
-      { page: 'trading-as-git', labelKey: 'nav.item.tradingAsGit', icon: GitBranch, defaultTab: { kind: 'trading-as-git', params: {} } },
-      { page: 'portfolio',      labelKey: 'nav.item.portfolio',    icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
-      { page: 'connectors',     labelKey: 'nav.item.connectors',   icon: Plug, defaultTab: { kind: 'connectors', params: {} } },
-    ],
-  },
-  {
-    sectionLabel: 'System',
-    labelKey: 'nav.section.system',
-    items: [
-      // Automation lives here now: Issues (the board) is the primary
-      // management surface, and scheduled issues fire from there. Automation
-      // is the operations/plumbing side (headless runs, API, event bus) —
-      // System chrome, not a daily-driver nav target.
-      { page: 'automation', labelKey: 'nav.item.automation', icon: Zap, defaultTab: { kind: 'automation', params: { section: 'runs' } } },
-      { page: 'settings', labelKey: 'nav.item.settings', icon: Settings, defaultTab: { kind: 'settings', params: { category: 'general' } } },
-      { page: 'dev',      labelKey: 'nav.item.dev',      icon: Code2, defaultTab: { kind: 'dev', params: { tab: 'tools' } } },
-    ],
-  },
-]
-
 function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState(() =>
     typeof window !== 'undefined' ? window.matchMedia(query).matches : false,
@@ -155,8 +64,8 @@ function useMediaQuery(query: string): boolean {
  * text rail. The recessed-rail look comes from bg-tertiary
  * (one elevation step up from the secondary Sidebar and the base main
  * pane) — rail → sidebar → main read as three distinct tiers. Top
- * section (no header) is the pinned-nav block — Chat, Inbox,
- * Workspaces, etc. — always visible. Labeled sections (Agent, System)
+ * section (no header) is the pinned product-navigation block — Chat, Inbox,
+ * Issues, etc. — always visible. Labeled sections (Beta, System)
  * get collapsible chevron headers; collapse state persists to
  * localStorage.
  *

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1005,7 +1005,7 @@ export function IssueDetail({
   const continueProvenanceSession = useCallback(
     async (record: IssueProvenanceRecord) => {
       if (record.origin.kind !== 'session') return
-      setSidebar('workspaces')
+      setSidebar('chat')
       await openHeadlessRun(record.origin.workspaceId, record.origin.resumeId, {
         title: `${data?.issue.title ?? id} · ${record.action}`,
       })
@@ -1186,7 +1186,7 @@ export function IssueDetail({
           <RunsSection
             runs={runs}
             onOpen={(run) => {
-              setSidebar('workspaces')
+              setSidebar('chat')
               void openHeadlessRun(run.wsId, run.resumeId, {
                 title: `${issue.title} · ${run.agent}`,
               })

--- a/ui/src/components/activity-navigation.ts
+++ b/ui/src/components/activity-navigation.ts
@@ -1,0 +1,79 @@
+import {
+  BarChart3,
+  Code2,
+  GitBranch,
+  Inbox,
+  LineChart,
+  ListChecks,
+  MessageSquare,
+  Newspaper,
+  Plug,
+  Settings,
+  Telescope,
+  TerminalSquare,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react'
+
+import type { Page } from '../App'
+import type { ViewSpec } from '../tabs/types'
+
+type NavItemKey =
+  | 'nav.item.inbox' | 'nav.item.tracked' | 'nav.item.chat' | 'nav.item.workspaces'
+  | 'nav.item.market' | 'nav.item.news' | 'nav.item.tradingAsGit' | 'nav.item.issue'
+  | 'nav.item.portfolio' | 'nav.item.connectors' | 'nav.item.automation' | 'nav.item.settings' | 'nav.item.dev'
+
+interface NavLeaf {
+  page: Page
+  labelKey: NavItemKey
+  icon: LucideIcon
+  /** Concrete landing surface opened by this Activity Bar item. */
+  defaultTab: ViewSpec
+}
+
+export interface NavSection {
+  /** Empty string identifies the unlabeled, always-visible primary section. */
+  sectionLabel: string
+  labelKey?: 'nav.section.beta' | 'nav.section.system'
+  items: NavLeaf[]
+  defaultCollapsed?: boolean
+  descriptionKey?: 'nav.betaDescription'
+}
+
+export const NAV_SECTIONS: NavSection[] = [
+  // Ask Alice is the product front door. Workspaces is deliberately absent:
+  // it is the engineering container/debug surface beneath conversations.
+  {
+    sectionLabel: '',
+    items: [
+      { page: 'chat',       labelKey: 'nav.item.chat',       icon: MessageSquare, defaultTab: { kind: 'chat-landing', params: {} } },
+      { page: 'inbox',      labelKey: 'nav.item.inbox',      icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
+      { page: 'issue',      labelKey: 'nav.item.issue',      icon: ListChecks, defaultTab: { kind: 'issue', params: {} } },
+      { page: 'tracked',    labelKey: 'nav.item.tracked',    icon: Telescope, defaultTab: { kind: 'tracked', params: {} } },
+      { page: 'market',     labelKey: 'nav.item.market',     icon: BarChart3, defaultTab: { kind: 'market-list', params: {} } },
+      { page: 'news',       labelKey: 'nav.item.news',       icon: Newspaper, defaultTab: { kind: 'news', params: {} } },
+    ],
+  },
+  {
+    sectionLabel: 'Beta',
+    labelKey: 'nav.section.beta',
+    descriptionKey: 'nav.betaDescription',
+    items: [
+      { page: 'trading-as-git', labelKey: 'nav.item.tradingAsGit', icon: GitBranch, defaultTab: { kind: 'trading-as-git', params: {} } },
+      { page: 'portfolio',      labelKey: 'nav.item.portfolio',    icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
+      { page: 'connectors',     labelKey: 'nav.item.connectors',   icon: Plug, defaultTab: { kind: 'connectors', params: {} } },
+    ],
+  },
+  {
+    sectionLabel: 'System',
+    labelKey: 'nav.section.system',
+    items: [
+      // Workspace management remains available for project/container control
+      // and provenance debugging; conversation continuation belongs to Chat.
+      { page: 'workspaces', labelKey: 'nav.item.workspaces', icon: TerminalSquare, defaultTab: { kind: 'workspace-list', params: {} } },
+      { page: 'automation', labelKey: 'nav.item.automation', icon: Zap, defaultTab: { kind: 'automation', params: { section: 'runs' } } },
+      { page: 'settings',   labelKey: 'nav.item.settings',   icon: Settings, defaultTab: { kind: 'settings', params: { category: 'general' } } },
+      { page: 'dev',        labelKey: 'nav.item.dev',        icon: Code2, defaultTab: { kind: 'dev', params: { tab: 'tools' } } },
+    ],
+  },
+]

--- a/ui/src/contexts/WorkspacesContext.spec.tsx
+++ b/ui/src/contexts/WorkspacesContext.spec.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionRecord, Workspace } from '../components/workspace/api'
+import { useWorkspaces } from './workspaces-context'
+import { WorkspacesProvider } from './WorkspacesContext'
+
+const mocks = vi.hoisted(() => ({
+  openOrFocus: vi.fn(),
+  closeTab: vi.fn(),
+  setSidebar: vi.fn(),
+  listWorkspaces: vi.fn(),
+  listTemplates: vi.fn(),
+  listAgents: vi.fn(),
+  getWorkspaceDefaultAgent: vi.fn(),
+  getIssueDefaultAgent: vi.fn(),
+  openResumeSession: vi.fn(),
+  resumeSession: vi.fn(),
+}))
+
+vi.mock('../tabs/store', () => {
+  const useWorkspace = Object.assign(
+    (selector: (state: unknown) => unknown) => selector({
+      openOrFocus: mocks.openOrFocus,
+      closeTab: mocks.closeTab,
+      setSidebar: mocks.setSidebar,
+    }),
+    { getState: () => ({ tabs: {} }) },
+  )
+  return { useWorkspace }
+})
+
+vi.mock('../components/workspace/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/workspace/api')>()
+  return {
+    ...actual,
+    listWorkspaces: mocks.listWorkspaces,
+    listTemplates: mocks.listTemplates,
+    listAgents: mocks.listAgents,
+    getWorkspaceDefaultAgent: mocks.getWorkspaceDefaultAgent,
+    getIssueDefaultAgent: mocks.getIssueDefaultAgent,
+    openResumeSession: mocks.openResumeSession,
+    resumeSession: mocks.resumeSession,
+  }
+})
+
+vi.mock('../components/workspace/terminalTheme', () => ({
+  useResolvedTerminalThemeVariant: () => 'dark',
+}))
+
+vi.mock('../components/workspace/WorkspaceAIConfigModal', () => ({
+  WorkspaceAIConfigModal: () => null,
+}))
+
+function workspace(): Workspace {
+  return {
+    id: 'research-desk',
+    tag: 'research-desk',
+    dir: '/tmp/research-desk',
+    createdAt: '2026-07-16T00:00:00.000Z',
+    template: 'auto-quant',
+    agents: ['pi'],
+    sessions: [],
+  }
+}
+
+function materializedSession(): SessionRecord {
+  return {
+    id: 'pi-headless-follow-up',
+    resumeId: 'resume-headless',
+    wsId: 'research-desk',
+    agent: 'pi',
+    name: 'follow-up',
+    createdAt: '2026-07-16T00:00:00.000Z',
+    lastActiveAt: '2026-07-16T00:00:00.000Z',
+    state: 'paused',
+    surface: 'webpi',
+    pid: null,
+    startedAt: null,
+    title: 'Headless research follow-up',
+  }
+}
+
+function Probe() {
+  const { openHeadlessRun } = useWorkspaces()
+  return (
+    <button type="button" onClick={() => void openHeadlessRun('research-desk', 'resume-headless')}>
+      Continue
+    </button>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.listWorkspaces.mockResolvedValue([workspace()])
+  mocks.listTemplates.mockResolvedValue([])
+  mocks.listAgents.mockResolvedValue([])
+  mocks.getWorkspaceDefaultAgent.mockResolvedValue(null)
+  mocks.getIssueDefaultAgent.mockResolvedValue(null)
+  mocks.openResumeSession.mockResolvedValue({ session: materializedSession() })
+  mocks.resumeSession.mockResolvedValue(null)
+})
+
+afterEach(cleanup)
+
+describe('WorkspacesProvider conversation routing', () => {
+  it('opens a materialized headless Session on the Ask Alice surface', async () => {
+    render(
+      <WorkspacesProvider>
+        <Probe />
+      </WorkspacesProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'workspace',
+      params: {
+        wsId: 'research-desk',
+        sessionId: 'pi-headless-follow-up',
+        source: 'chat',
+      },
+    }))
+    expect(mocks.setSidebar).toHaveBeenCalledWith('chat')
+  })
+})

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -55,6 +55,7 @@ import {
 import { useWorkspace } from '../tabs/store'
 import type { WorkspaceSource } from '../tabs/types'
 import { WorkspacesContext, type SpawnOpts } from './workspaces-context'
+import { reconcileWorkspaceList } from './workspace-list-reconcile'
 
 const LIST_POLL_MS = 3000
 
@@ -86,11 +87,12 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
 
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const closeTab = useWorkspace((s) => s.closeTab)
+  const setSidebar = useWorkspace((s) => s.setSidebar)
 
   const refresh = useCallback(async (): Promise<void> => {
     try {
       const list = await listWorkspaces()
-      setWorkspaces(list)
+      setWorkspaces((current) => reconcileWorkspaceList(current, list))
       setHasLoaded(true)
       setListError(null)
     } catch (err) {
@@ -222,10 +224,16 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
             : workspace,
         ),
       )
-      openOrFocus({ kind: 'workspace', params: { wsId, sessionId: nextSession.id } })
+      // A resumed headless conversation is user-facing Chat, even though its
+      // durable Session still belongs to a Workspace underneath.
+      setSidebar('chat')
+      openOrFocus({
+        kind: 'workspace',
+        params: { wsId, sessionId: nextSession.id, source: 'chat' },
+      })
       void refresh()
     },
-    [openOrFocus, refresh, terminalTheme],
+    [openOrFocus, refresh, setSidebar, terminalTheme],
   )
 
   const setIssueDefaultAgent = useCallback(async (agent: string | null): Promise<void> => {

--- a/ui/src/contexts/workspace-list-reconcile.spec.ts
+++ b/ui/src/contexts/workspace-list-reconcile.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Workspace } from '../components/workspace/api'
+import { reconcileWorkspaceList } from './workspace-list-reconcile'
+
+function workspace(id: string, title: string): Workspace {
+  return {
+    id,
+    tag: id,
+    dir: `/tmp/${id}`,
+    createdAt: '2026-07-16T00:00:00.000Z',
+    template: 'chat',
+    agents: ['pi'],
+    sessions: [{
+      id: `${id}-session`,
+      resumeId: `${id}-resume`,
+      wsId: id,
+      agent: 'pi',
+      name: 'p1',
+      createdAt: '2026-07-16T00:00:00.000Z',
+      lastActiveAt: '2026-07-16T00:00:00.000Z',
+      state: 'paused',
+      pid: null,
+      startedAt: null,
+      title,
+    }],
+  }
+}
+
+describe('reconcileWorkspaceList', () => {
+  it('keeps the existing array and rows for an identical polling response', () => {
+    const current = [workspace('chat-1', 'Hello'), workspace('chat-2', 'Review')]
+    const incoming = structuredClone(current)
+
+    const reconciled = reconcileWorkspaceList(current, incoming)
+
+    expect(reconciled).toBe(current)
+    expect(reconciled[0]).toBe(current[0])
+    expect(reconciled[1]).toBe(current[1])
+  })
+
+  it('updates only changed rows and preserves stable neighbors', () => {
+    const current = [workspace('chat-1', 'Hello'), workspace('chat-2', 'Review')]
+    const incoming = structuredClone(current)
+    incoming[1] = workspace('chat-2', 'Updated review')
+
+    const reconciled = reconcileWorkspaceList(current, incoming)
+
+    expect(reconciled).not.toBe(current)
+    expect(reconciled[0]).toBe(current[0])
+    expect(reconciled[1]).toBe(incoming[1])
+  })
+
+  it('publishes order changes while reusing the unchanged Workspace objects', () => {
+    const current = [workspace('chat-1', 'Hello'), workspace('chat-2', 'Review')]
+    const incoming = [structuredClone(current[1]), structuredClone(current[0])]
+
+    const reconciled = reconcileWorkspaceList(current, incoming)
+
+    expect(reconciled).not.toBe(current)
+    expect(reconciled).toEqual([current[1], current[0]])
+    expect(reconciled[0]).toBe(current[1])
+    expect(reconciled[1]).toBe(current[0])
+  })
+})

--- a/ui/src/contexts/workspace-list-reconcile.ts
+++ b/ui/src/contexts/workspace-list-reconcile.ts
@@ -1,0 +1,33 @@
+import type { Workspace } from '../components/workspace/api'
+
+function sameSnapshot(a: Workspace, b: Workspace): boolean {
+  // Workspace DTOs are JSON-only and arrive from the same endpoint. Comparing
+  // their serialized snapshots lets a polling refresh preserve object identity
+  // without maintaining a second, inevitably incomplete field checklist.
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+/**
+ * Preserve stable Workspace identities across the three-second list poll.
+ * React consumers should only observe a new array/object when the server
+ * snapshot actually changed; an identical HTTP response is not UI state.
+ */
+export function reconcileWorkspaceList(
+  current: Workspace[],
+  incoming: Workspace[],
+): Workspace[] {
+  const currentById = new Map(current.map((workspace) => [workspace.id, workspace]))
+  let changed = current.length !== incoming.length
+
+  const next = incoming.map((workspace, index) => {
+    const previous = currentById.get(workspace.id)
+    if (!previous || !sameSnapshot(previous, workspace)) {
+      changed = true
+      return workspace
+    }
+    if (current[index] !== previous) changed = true
+    return previous
+  })
+
+  return changed ? next : current
+}

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { WorkspacesContextValue } from '../contexts/workspaces-context'
+import { i18n } from '../i18n'
+import type { AgentInfo, Workspace } from '../components/workspace/api'
+import { ChatLandingPage } from './ChatLandingPage'
+
+const mocks = vi.hoisted(() => ({
+  useWorkspaces: vi.fn(),
+  openOrFocus: vi.fn(),
+  listAgentCredentials: vi.fn(),
+  detectWorkspaceCredential: vi.fn(),
+  getAgentReadiness: vi.fn(),
+  getAgentRuntimeReadiness: vi.fn(),
+  probeAgentRuntimeReadiness: vi.fn(),
+  getWorkspaceCredentialDefaults: vi.fn(),
+  getQuickChat: vi.fn(),
+  rememberRecentChatWorkspace: vi.fn(),
+  rememberQuickChatCredential: vi.fn(),
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => mocks.useWorkspaces(),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: typeof mocks.openOrFocus }) => unknown) =>
+    selector({ openOrFocus: mocks.openOrFocus }),
+}))
+
+vi.mock('../components/workspace/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/workspace/api')>()
+  return {
+    ...actual,
+    listAgentCredentials: mocks.listAgentCredentials,
+    detectWorkspaceCredential: mocks.detectWorkspaceCredential,
+    getAgentReadiness: mocks.getAgentReadiness,
+    getAgentRuntimeReadiness: mocks.getAgentRuntimeReadiness,
+    probeAgentRuntimeReadiness: mocks.probeAgentRuntimeReadiness,
+  }
+})
+
+vi.mock('../api/config', () => ({
+  configApi: {
+    getWorkspaceCredentialDefaults: mocks.getWorkspaceCredentialDefaults,
+  },
+}))
+
+vi.mock('../api/preferences', () => ({
+  preferencesApi: {
+    getQuickChat: mocks.getQuickChat,
+    rememberRecentChatWorkspace: mocks.rememberRecentChatWorkspace,
+    rememberQuickChatCredential: mocks.rememberQuickChatCredential,
+  },
+}))
+
+const piAgent: AgentInfo = {
+  id: 'pi',
+  displayName: 'Pi',
+  kind: 'agent',
+  installed: true,
+  capabilities: {
+    parallelPerCwd: false,
+    resumeLast: true,
+    resumeById: true,
+    transcriptDiscovery: 'fs-watch',
+  },
+}
+
+function chatWorkspace(): Workspace {
+  return {
+    id: 'chat-1',
+    tag: 'chat-jul16',
+    dir: '/tmp/chat-jul16',
+    createdAt: '2026-07-16T00:00:00.000Z',
+    template: 'chat',
+    agents: ['pi'],
+    sessions: [],
+  }
+}
+
+function context(workspaces: readonly Workspace[]): WorkspacesContextValue {
+  return {
+    workspaces,
+    templates: [],
+    agents: [piAgent],
+    defaultAgent: 'pi',
+    issueDefaultAgent: null,
+    listError: null,
+    hasLoaded: true,
+    templatesLoaded: true,
+    refresh: vi.fn(),
+    spawn: vi.fn(async () => undefined),
+    openHeadlessRun: vi.fn(async () => undefined),
+    setDefaultAgent: vi.fn(async () => undefined),
+    setIssueDefaultAgent: vi.fn(async () => undefined),
+    quickChat: vi.fn(async () => 'chat-1'),
+    pauseSession: vi.fn(async () => undefined),
+    resumeSession: vi.fn(async () => undefined),
+    openWebPiSession: vi.fn(async () => undefined),
+    requestDeleteSession: vi.fn(),
+    openAgentConfig: vi.fn(),
+    saveWorkspaceMetadata: vi.fn(async () => undefined),
+    renameWorkspace: vi.fn(async () => undefined),
+  }
+}
+
+let workspaces: Workspace[]
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+  workspaces = [chatWorkspace()]
+  mocks.useWorkspaces.mockImplementation(() => context(workspaces))
+  mocks.listAgentCredentials.mockResolvedValue([{
+    slug: 'google-1',
+    vendor: 'google',
+    authType: 'api-key',
+    wires: { 'google-generative-ai': 'https://generativelanguage.googleapis.com/v1beta' },
+    resolvedModel: 'gemini-3.1-flash-lite',
+  }])
+  mocks.detectWorkspaceCredential.mockResolvedValue({
+    slug: 'google-1',
+    model: 'gemini-3.1-flash-lite',
+    contextWindow: 256_000,
+    wireShape: 'google-generative-ai',
+  })
+  mocks.getAgentReadiness.mockResolvedValue({
+    agents: {
+      pi: {
+        agent: 'pi',
+        ready: true,
+        requiresCredential: true,
+        source: 'workspace-config',
+        hasWorkspaceConfig: true,
+        hasUsableWorkspaceConfig: true,
+        detectedCredentialSlug: 'google-1',
+        compatibleCredentialSlugs: ['google-1'],
+        injectableCredentialSlugs: ['google-1'],
+      },
+    },
+  })
+  mocks.getAgentRuntimeReadiness.mockResolvedValue({
+    agents: {
+      pi: {
+        agent: 'pi',
+        displayName: 'Pi',
+        installed: true,
+        binPath: '/tmp/pi',
+        status: 'ready',
+        ready: true,
+        source: 'workspace-override',
+        checkedAt: '2026-07-16T00:00:00.000Z',
+        durationMs: 1,
+      },
+    },
+    overallReady: true,
+    checkedAt: '2026-07-16T00:00:00.000Z',
+  })
+  mocks.probeAgentRuntimeReadiness.mockImplementation(() => mocks.getAgentRuntimeReadiness())
+  mocks.getWorkspaceCredentialDefaults.mockResolvedValue({
+    defaults: {},
+    compatibleByAgent: { pi: ['google-1'] },
+    contextWindow: 256_000,
+  })
+  mocks.getQuickChat.mockResolvedValue({
+    lastCredentialByAgent: {},
+    recentChatWorkspaceId: 'chat-1',
+  })
+  mocks.rememberRecentChatWorkspace.mockResolvedValue(undefined)
+  mocks.rememberQuickChatCredential.mockResolvedValue(undefined)
+})
+
+afterEach(cleanup)
+
+describe('ChatLandingPage polling stability', () => {
+  it('does not re-run credential detection when a poll replaces the Workspace object with the same id', async () => {
+    const view = render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+
+    await waitFor(() => expect(mocks.detectWorkspaceCredential).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      workspaces = structuredClone(workspaces)
+      view.rerender(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+    })
+
+    expect(mocks.detectWorkspaceCredential).toHaveBeenCalledTimes(1)
+    expect(mocks.getAgentReadiness).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -308,6 +308,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   // With no Chat workspace yet this remains null; the backend creates one
   // stable starter workspace on the first successful send.
   const credentialWorkspace = workspaceTarget
+  const credentialWorkspaceId = credentialWorkspace?.id ?? null
 
   // Preload the loginless credential set ONCE on mount — NOT gated on the
   // selected agent. Previously this fired only after the agents list resolved
@@ -371,7 +372,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     const onWorkspaceAgentConfigChanged = (event: Event) => {
       const detail = (event as CustomEvent<{ wsId?: string; agent?: string }>).detail
       if (!detail || (
-        detail.wsId === credentialWorkspace?.id &&
+        detail.wsId === credentialWorkspaceId &&
         detail.agent === effectiveAgent
       )) {
         setAgentConfigRevision((revision) => revision + 1)
@@ -379,7 +380,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     }
     window.addEventListener('openalice:workspace-agent-config-changed', onWorkspaceAgentConfigChanged)
     return () => window.removeEventListener('openalice:workspace-agent-config-changed', onWorkspaceAgentConfigChanged)
-  }, [credentialWorkspace?.id, effectiveAgent])
+  }, [credentialWorkspaceId, effectiveAgent])
 
   useEffect(() => {
     let live = true
@@ -392,7 +393,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   // Detect the target workspace's current cred/readiness for this runtime (for the default
   // selection + the overwrite notice). Only when the workspace already exists.
   useEffect(() => {
-    if (!needsCred || effectiveAgent === null || credentialWorkspace === null || credentialWorkspace === undefined) {
+    if (!needsCred || effectiveAgent === null || credentialWorkspaceId === null) {
       setDetectedCred(null)
       setDetectedCredentialConfig(null)
       setAgentReadiness(null)
@@ -402,8 +403,8 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     let live = true
     setCredentialWorkspaceResolved(false)
     void Promise.allSettled([
-      detectWorkspaceCredential(credentialWorkspace.id, effectiveAgent),
-      getAgentReadiness(credentialWorkspace.id),
+      detectWorkspaceCredential(credentialWorkspaceId, effectiveAgent),
+      getAgentReadiness(credentialWorkspaceId),
     ]).then(([detected, readiness]) => {
       if (!live) return
       const detectedValue = detected.status === 'fulfilled' ? detected.value : null
@@ -417,7 +418,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
       setCredentialWorkspaceResolved(true)
     })
     return () => { live = false }
-  }, [needsCred, effectiveAgent, credentialWorkspace, agentConfigRevision])
+  }, [needsCred, effectiveAgent, credentialWorkspaceId, agentConfigRevision])
 
   const workspaceCredReady =
     needsCred &&

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -227,7 +227,6 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
     if (!wsAlive) return
     setContinueError(null)
     setContinuing(true)
-    setSidebar('workspaces')
     try {
       if (origin?.kind === 'headless' && (origin.resumeId || origin.runId)) {
         // Legacy Inbox JSONL stored only taskId. Runs are retained, so one
@@ -238,10 +237,14 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
           ...(entry.comments ? { title: entry.comments.slice(0, 200) } : {}),
         })
       } else if (sessionId && sessionRecord) {
+        setSidebar('chat')
         if (sessionRecord.state === 'paused') {
-          await workspacesCtx.resumeSession(entry.workspaceId, sessionId)
+          await workspacesCtx.resumeSession(entry.workspaceId, sessionId, 'chat')
         } else {
-          openOrFocus({ kind: 'workspace', params: { wsId: entry.workspaceId, sessionId } })
+          openOrFocus({
+            kind: 'workspace',
+            params: { wsId: entry.workspaceId, sessionId, source: 'chat' },
+          })
         }
       } else {
         openWorkspace()


### PR DESCRIPTION
Summary
- preserve Workspace object identity when the polling snapshot is unchanged, and key Quick Chat credential detection by Workspace ID
- move Workspaces from primary navigation into System
- open materialized headless and Inbox-origin Sessions on the Ask Alice surface while retaining Workspace ownership underneath
- add regression coverage for polling stability, navigation hierarchy, and headless Session routing

Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (302 passed, 1 skipped; 3071 tests passed, 8 skipped)
- real http://localhost:5173/chat browser walk: Workspaces under System, /workspaces to /chat navigation, 28 stability samples across two polling intervals, no console warnings/errors
- pnpm electron:smoke:workspace