### PR TITLE
Clarify current template version state

### DIFF
--- a/ui/src/components/workspace/WorkspaceTemplateUpgradePanel.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceTemplateUpgradePanel.spec.tsx
@@ -119,6 +119,8 @@ describe('WorkspaceTemplateUpgradePanel', () => {
       { '.agents/skills/self-scheduling/SKILL.md': 'template' },
     ))
     await waitFor(() => expect(screen.getByText('Template upgrade complete')).toBeTruthy())
+    expect(screen.getByText('Latest version')).toBeTruthy()
+    expect(screen.getAllByText(`v${plan.toVersion}`)).toHaveLength(1)
     expect(onWorkspaceChanged).toHaveBeenCalled()
   })
 

--- a/ui/src/components/workspace/WorkspaceTemplateUpgradePanel.tsx
+++ b/ui/src/components/workspace/WorkspaceTemplateUpgradePanel.tsx
@@ -128,9 +128,20 @@ export function WorkspaceTemplateUpgradePanel({
                     {t('workspace.upgradeManagedAssets')}
                   </div>
                   <div className="mt-2 flex flex-wrap items-center gap-2 text-[18px] font-semibold text-text">
-                    <span>v{plan.fromVersion}</span>
-                    <ArrowRight size={17} className="text-text-muted" />
-                    <span className={current ? '' : 'text-accent'}>v{plan.toVersion}</span>
+                    {current ? (
+                      <>
+                        <span className="text-accent">v{plan.toVersion}</span>
+                        <span className="rounded-full border border-accent/25 bg-accent/10 px-2 py-0.5 text-[10px] font-semibold text-accent">
+                          {t('workspace.upgradeLatestVersion')}
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <span>v{plan.fromVersion}</span>
+                        <ArrowRight size={17} className="text-text-muted" />
+                        <span className="text-accent">v{plan.toVersion}</span>
+                      </>
+                    )}
                   </div>
                   <p className="mt-1 max-w-xl text-[12px] leading-relaxed text-text-muted">
                     {current

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -733,6 +733,7 @@ export const en = {
     upgradeLoading: 'Building a three-way upgrade preview…',
     upgradeUnavailableTitle: 'In-place upgrade is not available',
     upgradeManagedAssets: 'Managed template assets',
+    upgradeLatestVersion: 'Latest version',
     upgradeCurrentDescription: 'This Workspace is on the latest recorded template baseline. Its own customizations remain independent.',
     upgradeDescription: 'Only launcher-managed instructions and skills are compared. Research, reports, issues, credentials, and other work stay outside this upgrade.',
     upgradeRefresh: 'Refresh preview',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -721,6 +721,7 @@ export const ja: Resources = {
     upgradeLoading: '3-way アップグレードのプレビューを作成中…',
     upgradeUnavailableTitle: 'このテンプレートはインプレース更新に対応していません',
     upgradeManagedAssets: 'テンプレート管理資産',
+    upgradeLatestVersion: '最新バージョン',
     upgradeCurrentDescription: 'このワークスペースは最新のテンプレート基準を使用しています。独自のカスタマイズは引き続き独立して保持されます。',
     upgradeDescription: 'OpenAlice が管理する指示と Skill だけを比較します。調査、レポート、Issue、認証情報、その他の成果物は更新対象外です。',
     upgradeRefresh: 'プレビューを更新',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -729,6 +729,7 @@ export const zhHant: Resources = {
     upgradeLoading: '正在建立三方升級預覽…',
     upgradeUnavailableTitle: '此範本不支援原地升級',
     upgradeManagedAssets: '範本管理資產',
+    upgradeLatestVersion: '最新版本',
     upgradeCurrentDescription: '此工作區已使用最新的範本基線；自己的客製內容仍保持獨立。',
     upgradeDescription: '這裡只比較由 OpenAlice 管理的說明與 Skill。研究、報告、Issue、憑證及其他工作成果不會參與升級。',
     upgradeRefresh: '重新整理預覽',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -721,6 +721,7 @@ export const zh: Resources = {
     upgradeLoading: '正在生成三方升级预览…',
     upgradeUnavailableTitle: '此模板不支持原地升级',
     upgradeManagedAssets: '模板管理资产',
+    upgradeLatestVersion: '最新版本',
     upgradeCurrentDescription: '此工作区已使用最新的模板基线；它自己的定制内容仍保持独立。',
     upgradeDescription: '这里只比较由 OpenAlice 管理的说明和 Skill。研究、报告、Issue、凭据及其他工作产物不会参与升级。',
     upgradeRefresh: '刷新预览',


### PR DESCRIPTION
## What changed

- show a single highlighted template version when a Workspace is already current
- replace the misleading version-to-version arrow with a localized `Latest version` badge
- keep the existing version transition treatment when an upgrade is actually available
- add regression coverage for the current-version state

## Why

The current state rendered the same version on both sides of an arrow, which made a completed Workspace template upgrade look unfinished. The new state gives users a direct, affirmative signal that the Workspace is already on the latest template baseline.

## User impact

Workspace Settings → Template now shows one emphasized version and a clear latest-version badge after an upgrade is complete. Existing upgrade previews and apply behavior are unchanged.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (3071 passed, 8 skipped)
- `pnpm -F open-alice-ui test -- WorkspaceTemplateUpgradePanel.spec.tsx`
- verified the real `/chat` Workspace Settings → Template surface in Chinese
