### PR TITLE
fix WebPi compaction feedback

### DIFF
--- a/src/workspaces/webpi-session-host.spec.ts
+++ b/src/workspaces/webpi-session-host.spec.ts
@@ -12,9 +12,16 @@ class FakeRpcProcess extends EventEmitter {
   readonly stdout = new PassThrough()
   readonly stderr = new PassThrough()
   private messages: unknown[] = []
+  private state: Record<string, unknown>
 
-  constructor() {
+  constructor(state: Record<string, unknown> = {}) {
     super()
+    this.state = {
+      sessionId: 'native-pi', thinkingLevel: 'medium', isStreaming: false,
+      isCompacting: false, steeringMode: 'all', followUpMode: 'one-at-a-time',
+      autoCompactionEnabled: true, messageCount: 0, pendingMessageCount: 0,
+      ...state,
+    }
     this.stdin.setEncoding('utf8')
     let buffer = ''
     this.stdin.on('data', (chunk: string) => {
@@ -35,15 +42,18 @@ class FakeRpcProcess extends EventEmitter {
     return true
   }
 
+  event(value: Record<string, unknown>): void {
+    this.line(value)
+  }
+
   private command(command: Record<string, unknown>): void {
     const id = command['id']
     const type = command['type']
     if (type === 'get_state') {
-      this.line({ type: 'response', id, command: type, success: true, data: {
-        sessionId: 'native-pi', thinkingLevel: 'medium', isStreaming: false,
-        isCompacting: false, steeringMode: 'all', followUpMode: 'one-at-a-time',
-        autoCompactionEnabled: true, messageCount: this.messages.length, pendingMessageCount: 0,
-      } })
+      this.line({
+        type: 'response', id, command: type, success: true,
+        data: { ...this.state, messageCount: this.messages.length },
+      })
       return
     }
     if (type === 'get_messages') {
@@ -122,5 +132,26 @@ describe('WebPiSessionHost', () => {
     expect(host.has(input.recordId)).toBe(false)
     expect(onExit).toHaveBeenCalledWith(input.recordId, expect.objectContaining({ intentional: true }))
   })
-})
 
+  it('restores Pi compaction state reported at startup', async () => {
+    const rpc = new FakeRpcProcess({ isCompacting: true })
+    const host = new WebPiSessionHost(logger, {}, () => rpc as never)
+
+    expect((await host.start(input)).phase).toBe('compacting')
+  })
+
+  it('follows Pi compaction events until the agent settles', async () => {
+    const rpc = new FakeRpcProcess()
+    const host = new WebPiSessionHost(logger, {}, () => rpc as never)
+    await host.start(input)
+
+    rpc.event({ type: 'compaction_start', reason: 'threshold' })
+    expect(host.get(input.recordId)?.phase).toBe('compacting')
+
+    rpc.event({ type: 'compaction_end', reason: 'threshold', willRetry: false })
+    expect(host.get(input.recordId)?.phase).toBe('working')
+
+    rpc.event({ type: 'agent_settled' })
+    expect(host.get(input.recordId)?.phase).toBe('idle')
+  })
+})

--- a/src/workspaces/webpi-session-host.ts
+++ b/src/workspaces/webpi-session-host.ts
@@ -175,7 +175,7 @@ class LiveWebPiSession {
     })
     this.logger.info('webpi.started', { pid: this.child.pid ?? null, command: this.input.command })
     await this.refresh()
-    this.phase = this.state?.['isStreaming'] === true ? 'working' : 'idle'
+    this.phase = phaseFromRpcState(this.state)
     this.bump()
   }
 
@@ -391,6 +391,11 @@ function defaultSpawnProcess(input: StartWebPiInput): RpcProcess {
     stdio: ['pipe', 'pipe', 'pipe'],
     windowsHide: true,
   })
+}
+
+function phaseFromRpcState(state: JsonObject | null): WebPiSnapshot['phase'] {
+  if (state?.['isCompacting'] === true) return 'compacting'
+  return state?.['isStreaming'] === true ? 'working' : 'idle'
 }
 
 function isObject(value: unknown): value is JsonObject {

--- a/ui/src/components/workspace/WebPiView.spec.tsx
+++ b/ui/src/components/workspace/WebPiView.spec.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { WebPiSnapshot } from './api'
+import { WebPiView } from './WebPiView'
+
+const mocks = vi.hoisted(() => ({
+  abortWebPiSession: vi.fn(),
+  getWebPiSession: vi.fn(),
+  promptWebPiSession: vi.fn(),
+}))
+
+vi.mock('./api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./api')>()
+  return {
+    ...actual,
+    abortWebPiSession: mocks.abortWebPiSession,
+    getWebPiSession: mocks.getWebPiSession,
+    promptWebPiSession: mocks.promptWebPiSession,
+  }
+})
+
+function snapshot(phase: WebPiSnapshot['phase']): WebPiSnapshot {
+  return {
+    recordId: 'p1',
+    wsId: 'workspace-manager',
+    resumeId: 'resume-pi',
+    pid: 42,
+    startedAt: 1,
+    phase,
+    state: { isCompacting: phase === 'compacting', isStreaming: phase === 'working' },
+    messages: [],
+    streamingMessage: null,
+    error: null,
+    stderrTail: '',
+    revision: 1,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.defineProperty(HTMLElement.prototype, 'scrollTo', { configurable: true, value: vi.fn() })
+  mocks.getWebPiSession.mockResolvedValue(snapshot('compacting'))
+  mocks.abortWebPiSession.mockResolvedValue(snapshot('idle'))
+})
+
+afterEach(cleanup)
+
+describe('WebPiView compaction state', () => {
+  it('explains the pause and keeps the stop action available while Pi compacts', async () => {
+    render(
+      <WebPiView
+        wsId="workspace-manager"
+        sessionId="p1"
+        label="Workspace Manager"
+        onSessionLost={vi.fn()}
+      />,
+    )
+
+    const status = await screen.findByRole('status')
+    expect(status.textContent).toContain('Compacting conversation context')
+    expect(status.textContent).toContain('summarizing older history')
+    expect(screen.getByText('compacting')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Stop Pi' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Send message' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop Pi' }))
+    await waitFor(() => expect(mocks.abortWebPiSession).toHaveBeenCalledWith('workspace-manager', 'p1'))
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeTruthy()
+  })
+})

--- a/ui/src/components/workspace/WebPiView.tsx
+++ b/ui/src/components/workspace/WebPiView.tsx
@@ -138,6 +138,16 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
         )}
       </div>
 
+      {snapshot?.phase === 'compacting' && (
+        <div className="webpi-compaction-status" role="status" aria-live="polite">
+          <LoaderCircle size={14} className="animate-spin" aria-hidden="true" />
+          <div>
+            <strong>Compacting conversation context</strong>
+            <span>Pi is summarizing older history. Sending will resume when the compact finishes.</span>
+          </div>
+        </div>
+      )}
+
       <div className="webpi-composer-wrap">
         <div className="webpi-composer">
           <textarea

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -1096,6 +1096,11 @@
 
 .webpi-error { display: grid; gap: 7px; margin: 20px 0; padding: 13px; border: 1px solid color-mix(in srgb, #d65c5c 50%, var(--color-border)); border-radius: 10px; color: #d65c5c; font-size: 12px; }
 .webpi-error button { width: fit-content; color: var(--color-text); text-decoration: underline; }
+.webpi-compaction-status { display: flex; align-items: flex-start; gap: 9px; margin: 0 max(18px, calc((100% - 760px) / 2)) 10px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--color-accent) 34%, var(--color-border)); border-radius: 10px; color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 7%, var(--color-bg-secondary)); }
+.webpi-compaction-status > svg { flex: 0 0 auto; margin-top: 2px; }
+.webpi-compaction-status > div { display: grid; gap: 2px; min-width: 0; }
+.webpi-compaction-status strong { color: var(--color-text); font-size: 11px; font-weight: 650; }
+.webpi-compaction-status span { color: var(--color-text-muted); font-size: 10px; line-height: 1.45; }
 .webpi-composer-wrap { padding: 10px max(18px, calc((100% - 760px) / 2)) 14px; border-top: 1px solid var(--color-border); background: color-mix(in srgb, var(--color-bg) 88%, transparent); }
 .webpi-composer { display: flex; align-items: flex-end; gap: 8px; padding: 9px 10px 9px 13px; border: 1px solid var(--color-border); border-radius: 14px; background: var(--color-bg-secondary); box-shadow: 0 6px 24px color-mix(in srgb, #000 9%, transparent); }
 .webpi-composer:focus-within { border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border)); }
@@ -1116,6 +1121,7 @@
 
 @media (max-width: 720px) {
   .webpi-messages, .webpi-composer-wrap { padding-left: 12px; padding-right: 12px; }
+  .webpi-compaction-status { margin-left: 12px; margin-right: 12px; }
   .webpi-message.is-user { margin-left: 0; }
   .webpi-tool-step > summary { grid-template-columns: 18px minmax(52px, auto) minmax(0, 1fr) 14px; }
   .webpi-step-size { display: none; }


### PR DESCRIPTION
## What changed

- restore WebPi's initial phase from Pi RPC `isCompacting`, not only `isStreaming`
- show an explicit, accessible compaction status above the composer while keeping Stop available
- add host and UI regression coverage for startup state, live compaction events, and abort behavior

## Why

WebPi already observed Pi's compaction events, but the only visible feedback was a small phase badge and startup ignored `isCompacting`. Users could not tell why sending was paused, and a reopened surface could mislabel Pi's state.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 3079 passed, 8 skipped
- real `/chat/manager` Pi/WebPi session: manually compacted a ~46k-token conversation, observed the compacting state and Stop control, then continued the same session and confirmed the compacted context was retained