### PR TITLE
Unify agent launch configuration surfaces

### DIFF
--- a/docs/workspace-manager.md
+++ b/docs/workspace-manager.md
@@ -22,8 +22,20 @@ such as:
 
 It is not a normal Chat Workspace. The UI gives it a distinct entry and a
 management-specific quick start. Its runtime picker consumes the same registered
-Agent list, saved default, install state, and readiness contract as Quick Chat.
-Pi uses WebPi; Claude, Codex, and OpenCode retain their native TUI surfaces.
+Agent list, saved default, install state, readiness, credential, model, and
+context contract as Quick Chat. `useAgentLaunchConfig` owns that resolution and
+the shared `AgentLaunchControls` components render it on both surfaces. Pi uses
+WebPi; Claude, Codex, and OpenCode retain their native TUI surfaces.
+
+For OpenCode and Pi, the summary describes the exact credential, model, and
+context that the next launch will inject. An existing Manager config wins over
+the global default and remembered choice. A usable hand-edited config (or one
+whose original vault credential was later deleted) still reports its on-disk
+model and context. Claude and Codex own their provider
+state, so the UI says that model/context are CLI-managed instead of inventing a
+value. The Manager's reserved Workspace resolves through
+`resolveRuntimeWorkspace` for config/readiness reads and writes; it must not be
+added to the business Workspace registry just to support this UI.
 
 ## Identity and Cwd
 
@@ -110,8 +122,12 @@ apply remains preview-first.
 - `src/tool/workspace-list.ts` — active floor inventory.
 - `src/server/cli.ts` and `src/server/cli-commands.ts` — embedded CLI exposure.
 - `src/webui/routes/workspaces.ts` — manager status, quick start, and resume.
-- `ui/src/lib/agentRuntime.ts` — shared Quick Chat/Manager runtime resolution.
-- `ui/src/pages/WorkspaceManagerPage.tsx` — runtime picker and WebPi/TUI shell.
+- `ui/src/lib/agentRuntime.ts` — shared runtime-selection policy.
+- `ui/src/hooks/useAgentLaunchConfig.ts` — shared readiness, credential,
+  model, context, and launch-parameter resolution.
+- `ui/src/components/workspace/AgentLaunchControls.tsx` — shared selectors and
+  truthful launch summary.
+- `ui/src/pages/WorkspaceManagerPage.tsx` — manager composer and WebPi/TUI shell.
 - `ui/src/components/workspace/ChatWorkspaceSection.tsx` — Chat sidebar entry.
 
 ## Verification
@@ -128,11 +144,14 @@ pnpm vitest run src/tool/workspace-list.spec.ts \
 
 Then use the real `/chat/manager` route with at least two available runtimes:
 
-1. verify the runtime picker agrees with Quick Chat and preserves the saved default;
-2. start one Pi/WebPi and one native-TUI Manager Session, then reopen both;
-3. inventory the active floor and confirm real `peer list` tool use;
-4. compare a harmless `--ws-id` reconstruction with an exact `--resume-id`
+1. verify the runtime/provider picker agrees with Quick Chat and preserves the
+   saved default;
+2. on Pi or OpenCode, verify the visible model/context matches the Manager
+   Workspace config, switch provider, and confirm the launch uses the new one;
+3. start one Pi/WebPi and one native-TUI Manager Session, then reopen both;
+4. inventory the active floor and confirm real `peer list` tool use;
+5. compare a harmless `--ws-id` reconstruction with an exact `--resume-id`
    continuation and verify their resolution modes remain visible;
-5. preview a peer template upgrade without `--apply`;
-6. confirm no business artifact appeared at the floor root;
-7. reload the manager conversation and confirm the same resume identity opens.
+6. preview a peer template upgrade without `--apply`;
+7. confirm no business artifact appeared at the floor root;
+8. reload the manager conversation and confirm the same resume identity opens.

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -44,6 +44,7 @@ function build(opts: {
   recentChatWorkspaceId?: string | null;
   opencodeConfig?: WorkspaceAiCred | null;
   opencodeRuntimeSource?: 'global-config' | 'global-login' | 'managed-runtime';
+  runtimeWorkspace?: any;
 } = {}) {
   const META = {
     id: 'ws-1',
@@ -102,6 +103,9 @@ function build(opts: {
     // Default []: today's tag never matches → creator.create path. Tests that
     // exercise targetWsId pass the workspace in so registry resolves it by id.
     registry,
+    resolveRuntimeWorkspace: (id: string) => (
+      opts.runtimeWorkspace?.id === id ? opts.runtimeWorkspace : registry.get(id)
+    ),
     creator,
     resolveOrCreateChatWorkspace: (preferredWorkspaceId?: string | null) =>
       chatWorkspaceResolver.resolveOrCreate(preferredWorkspaceId),
@@ -226,6 +230,82 @@ describe('GET /credentials — Quick Chat launch metadata', () => {
       contextWindow: 512_000,
       wireShape: 'google-generative-ai',
     });
+  });
+
+  it('reads launch metadata from the reserved Manager runtime workspace', async () => {
+    vi.mocked(readCredentials).mockResolvedValue({
+      'google-1': {
+        vendor: 'google',
+        authType: 'api-key',
+        apiKey: 'AQ.test',
+        wires: { 'google-generative-ai': 'https://generativelanguage.googleapis.com/v1beta' },
+      },
+    });
+    const { app } = build({
+      runtimeWorkspace: {
+        id: 'workspace-manager',
+        dir: '/manager',
+        agents: ['opencode'],
+        template: 'workspace-manager',
+        tag: 'Workspace Manager',
+        createdAt: '2026-07-16T00:00:00.000Z',
+      },
+      opencodeConfig: {
+        apiKey: 'AQ.test',
+        model: 'gemini-3.5-flash',
+        contextWindow: 512_000,
+        wireShape: 'google-generative-ai',
+      },
+    });
+
+    const credential = await get(app, '/workspace-manager/agent-config/opencode/credential');
+    const readiness = await get(app, '/workspace-manager/agent-readiness');
+
+    expect(credential).toEqual({
+      status: 200,
+      body: {
+        slug: 'google-1',
+        model: 'gemini-3.5-flash',
+        contextWindow: 512_000,
+        wireShape: 'google-generative-ai',
+      },
+    });
+    expect(readiness.status).toBe(200);
+    expect(readiness.body.agents.opencode).toMatchObject({
+      agent: 'opencode',
+      ready: true,
+      source: 'workspace-config',
+      detectedCredentialSlug: 'google-1',
+    });
+  });
+
+  it('writes AI adjustments to the reserved Manager runtime workspace', async () => {
+    vi.mocked(readCredentials).mockResolvedValue({});
+    const { app, opencode } = build({
+      runtimeWorkspace: {
+        id: 'workspace-manager',
+        dir: '/manager',
+        agents: ['opencode'],
+        template: 'workspace-manager',
+        tag: 'Workspace Manager',
+        createdAt: '2026-07-16T00:00:00.000Z',
+      },
+    });
+    const config = {
+      apiKey: 'AQ.test',
+      model: 'gemini-3.5-flash',
+      contextWindow: 512_000,
+      wireShape: 'google-generative-ai',
+    };
+
+    const response = await app.request('/workspace-manager/agent-config/opencode', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(config),
+    });
+
+    expect(response.status).toBe(200);
+    expect(opencode.writeAiConfig).toHaveBeenCalledWith('/manager', config);
   });
 });
 

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -1992,7 +1992,7 @@ export function createWorkspaceRoutes(
   app.get('/:id/agent-config', async (c) => {
     const id = c.req.param('id');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
-    const meta = svc.registry.get(id);
+    const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
     if (!meta) return c.json({ error: 'not_found' }, 404);
     try {
       const [claude, codex, opencode, pi] = await Promise.all([
@@ -2017,7 +2017,7 @@ export function createWorkspaceRoutes(
     const id = c.req.param('id');
     const agent = c.req.param('agent');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
-    const meta = svc.registry.get(id);
+    const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
     if (!meta) return c.json({ error: 'not_found' }, 404);
     try {
       const detected = await detectWorkspaceCred(meta, agent, await readCredentials());
@@ -2037,7 +2037,7 @@ export function createWorkspaceRoutes(
   app.get('/:id/agent-readiness', async (c) => {
     const id = c.req.param('id');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
-    const meta = svc.registry.get(id);
+    const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
     if (!meta) return c.json({ error: 'not_found' }, 404);
     try {
       const credentials = await readCredentials();
@@ -2061,7 +2061,7 @@ export function createWorkspaceRoutes(
     const id = c.req.param('id');
     const agent = c.req.param('agent');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
-    const meta = svc.registry.get(id);
+    const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
     if (!meta) return c.json({ error: 'not_found' }, 404);
     try {
       const row = await getAgentCredentialReadiness({
@@ -2084,7 +2084,7 @@ export function createWorkspaceRoutes(
     if (agent !== 'claude' && agent !== 'codex' && agent !== 'opencode' && agent !== 'pi') {
       return c.json({ error: 'unknown_agent' }, 400);
     }
-    const meta = svc.registry.get(id);
+    const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
     if (!meta) return c.json({ error: 'not_found' }, 404);
 
     const body = (await safeJson(c)) as WorkspaceAiCred | null;

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -1,0 +1,248 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Bot,
+  Check,
+  ChevronDown,
+  Code2,
+  Cpu,
+  Gauge,
+  KeyRound,
+  Settings2,
+  Sparkles,
+  type LucideIcon,
+} from 'lucide-react'
+
+import { formatContextWindow, type AgentLaunchConfigState } from '../../hooks/useAgentLaunchConfig'
+
+const AGENT_ICONS: Record<string, LucideIcon> = {
+  claude: Sparkles,
+  codex: Cpu,
+  opencode: Code2,
+  pi: Bot,
+}
+
+export interface AgentLaunchSelectorsProps {
+  readonly config: AgentLaunchConfigState
+  readonly onConfigureProvider: () => void
+}
+
+export interface AgentLaunchSelectorsHandle {
+  openAgentMenu(): void
+}
+
+/** The shared runtime + credential selector used by every chat-style launch
+ * surface. Selection behavior and presentation now evolve together. */
+export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, AgentLaunchSelectorsProps>(function AgentLaunchSelectors(
+  { config, onConfigureProvider },
+  ref,
+) {
+  const { t } = useTranslation()
+  const [agentMenuOpen, setAgentMenuOpen] = useState(false)
+  const [credentialMenuOpen, setCredentialMenuOpen] = useState(false)
+  const agentBoxRef = useRef<HTMLDivElement>(null)
+  const credentialBoxRef = useRef<HTMLDivElement>(null)
+  const SelectedIcon = config.selectedAgent ? AGENT_ICONS[config.selectedAgent.id] : undefined
+
+  useImperativeHandle(ref, () => ({
+    openAgentMenu() {
+      setCredentialMenuOpen(false)
+      setAgentMenuOpen(true)
+    },
+  }), [])
+
+  useEffect(() => {
+    if (!agentMenuOpen && !credentialMenuOpen) return
+    const onDown = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (agentMenuOpen && agentBoxRef.current && !agentBoxRef.current.contains(target)) {
+        setAgentMenuOpen(false)
+      }
+      if (credentialMenuOpen && credentialBoxRef.current && !credentialBoxRef.current.contains(target)) {
+        setCredentialMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [agentMenuOpen, credentialMenuOpen])
+
+  return (
+    <>
+      <div ref={agentBoxRef} className="relative">
+        <button
+          type="button"
+          onClick={() => {
+            setAgentMenuOpen((open) => !open)
+            setCredentialMenuOpen(false)
+          }}
+          disabled={config.agents.length === 0}
+          aria-haspopup="menu"
+          aria-expanded={agentMenuOpen}
+          aria-label={t('chatLanding.selectAgent')}
+          className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 text-[11px] text-text-muted hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {SelectedIcon ? <SelectedIcon className="h-3 w-3 shrink-0" /> : <Bot className="h-3 w-3 shrink-0" />}
+          <span className="truncate">{config.selectedAgent?.displayName ?? t('chatLanding.selectAgent')}</span>
+          <ChevronDown className="h-3 w-3 shrink-0 opacity-60" />
+        </button>
+        {agentMenuOpen && config.agents.length > 0 && (
+          <div
+            role="menu"
+            className="oa-popover-enter absolute bottom-full left-0 z-20 mb-1 min-w-[180px] rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg"
+          >
+            {config.agents.map((agent) => {
+              const Icon = AGENT_ICONS[agent.id]
+              const active = agent.id === config.effectiveAgent
+              const missing = agent.installed === false
+              return (
+                <button
+                  key={agent.id}
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    config.selectAgent(agent.id)
+                    setAgentMenuOpen(false)
+                  }}
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : missing ? 'text-text-muted' : 'text-text'}`}
+                >
+                  {Icon ? <Icon className="h-3.5 w-3.5 shrink-0" /> : <span className="w-3.5 shrink-0" />}
+                  <span className="min-w-0 flex-1 truncate">{agent.displayName}</span>
+                  {missing && <span className="shrink-0 text-[10px] text-text-muted">{t('chatLanding.agentNotInstalled')}</span>}
+                  {active && <Check className="h-3.5 w-3.5 shrink-0" />}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {config.needsCredential && config.noCredentials && (
+        <button
+          type="button"
+          onClick={onConfigureProvider}
+          className="oa-pressable inline-flex min-h-8 items-center gap-1.5 rounded-md bg-amber-500/10 px-2.5 py-1 text-[11px] text-amber-600 hover:bg-amber-500/20 dark:text-amber-400"
+        >
+          <KeyRound className="h-3 w-3" />
+          {t('chatLanding.configureProvider')}
+        </button>
+      )}
+
+      {config.needsCredential && !config.noCredentials && config.credentials && config.credentials.length > 0 && (
+        <div ref={credentialBoxRef} className="relative">
+          <button
+            type="button"
+            onClick={() => {
+              setCredentialMenuOpen((open) => !open)
+              setAgentMenuOpen(false)
+            }}
+            aria-haspopup="menu"
+            aria-expanded={credentialMenuOpen}
+            aria-label={t('chatLanding.selectCredential')}
+            className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 text-[11px] text-text-muted hover:text-text"
+          >
+            <KeyRound className="h-3 w-3 shrink-0" />
+            <span className="truncate">
+              {config.credential?.label?.trim() || config.credential?.slug || t('chatLanding.selectCredential')}
+            </span>
+            <ChevronDown className="h-3 w-3 shrink-0 opacity-60" />
+          </button>
+          {credentialMenuOpen && (
+            <div
+              role="menu"
+              className="oa-popover-enter absolute bottom-full left-0 z-20 mb-1 min-w-[200px] rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg"
+            >
+              {config.credentials.map((credential) => {
+                const active = credential.slug === config.effectiveCredential
+                return (
+                  <button
+                    key={credential.slug}
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      config.selectCredential(credential.slug)
+                      setCredentialMenuOpen(false)
+                    }}
+                    className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : 'text-text'}`}
+                  >
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate">{credential.label?.trim() || credential.slug}</span>
+                      {credential.resolvedModel && (
+                        <span className="block truncate text-[10px] text-text-muted">{credential.resolvedModel}</span>
+                      )}
+                    </span>
+                    <span className="shrink-0 text-[10px] text-text-muted">{credential.vendor}</span>
+                    {active && <Check className="h-3.5 w-3.5 shrink-0" />}
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  )
+})
+
+export interface AgentLaunchDetailsProps {
+  readonly config: AgentLaunchConfigState
+  readonly hasWorkspaceTarget: boolean
+  readonly onAdjustAi: () => void
+  readonly className?: string
+}
+
+/** Compact, truthful launch metadata. Loginless runtimes show the exact
+ * model/context that will be injected; native-login CLIs say who owns it. */
+export function AgentLaunchDetails({
+  config,
+  hasWorkspaceTarget,
+  onAdjustAi,
+  className = '',
+}: AgentLaunchDetailsProps) {
+  const { t } = useTranslation()
+
+  if (config.needsCredential && config.aiDetails) {
+    const model = config.aiDetails.model ?? t('chatLanding.runtimeDefaultModel')
+    const context = formatContextWindow(config.aiDetails.contextWindow)
+    return (
+      <div className={`flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[10.5px] text-text-muted ${className}`}>
+        <span
+          className="inline-flex min-w-0 max-w-full items-center gap-1"
+          aria-label={t('chatLanding.modelSummary', { model })}
+          title={model}
+        >
+          <Cpu className="h-3 w-3 shrink-0" />
+          <span className="truncate font-mono text-text/80">{model}</span>
+        </span>
+        <span aria-hidden className="text-text-muted/40">·</span>
+        <span
+          className="inline-flex shrink-0 items-center gap-1"
+          aria-label={t('chatLanding.contextSummary', { limit: context })}
+        >
+          <Gauge className="h-3 w-3" />
+          {t('chatLanding.contextSummary', { limit: context })}
+        </span>
+        <button
+          type="button"
+          onClick={onAdjustAi}
+          className="oa-pressable inline-flex min-h-7 items-center gap-1 rounded-md px-2 py-1 text-accent hover:bg-accent/10 sm:ml-auto"
+          aria-label={hasWorkspaceTarget ? t('chatLanding.adjustWorkspaceAi') : t('chatLanding.providerSettings')}
+          title={hasWorkspaceTarget ? t('chatLanding.adjustWorkspaceAi') : t('chatLanding.providerSettings')}
+        >
+          <Settings2 className="h-3 w-3" />
+          {hasWorkspaceTarget ? t('chatLanding.adjustWorkspaceAi') : t('chatLanding.providerSettings')}
+        </button>
+      </div>
+    )
+  }
+
+  if (config.selectedAgent && (!config.needsCredential || config.selectedRuntimeUsesGlobalConfig)) {
+    return (
+      <div className={`flex min-w-0 items-center gap-1.5 text-[10.5px] text-text-muted ${className}`}>
+        <Bot className="h-3 w-3 shrink-0" />
+        <span>{t('chatLanding.runtimeManagedAi', { runtime: config.selectedAgent.displayName })}</span>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/ui/src/hooks/useAgentLaunchConfig.ts
+++ b/ui/src/hooks/useAgentLaunchConfig.ts
@@ -1,0 +1,449 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { configApi, type WorkspaceContextWindow, type WorkspaceCredentialDefault } from '../api/config'
+import { preferencesApi, type QuickChatPreferences } from '../api/preferences'
+import {
+  detectWorkspaceCredential,
+  getAgentReadiness,
+  getAgentRuntimeReadiness,
+  listAgentCredentials,
+  probeAgentRuntimeReadiness,
+  type AgentCredentialReadiness,
+  type AgentInfo,
+  type AgentRuntimeReadinessRow,
+  type AgentRuntimeReadinessSnapshot,
+  type SavedCredential,
+  type WorkspaceCredentialDetection,
+} from '../components/workspace/api'
+import { isLoginlessAgent, resolveAgentRuntime, type LoginlessAgentId } from '../lib/agentRuntime'
+import { WORKSPACE_DEFAULTS_CHANGED_EVENT } from '../lib/workspaceAiEvents'
+
+const DEFAULT_CONTEXT_WINDOW: WorkspaceContextWindow = 256_000
+const AGENT_LAUNCH_PREFERENCES_CHANGED_EVENT = 'openalice:agent-launch-preferences-changed'
+
+export interface AgentLaunchAiDetails {
+  readonly model: string | null
+  readonly contextWindow: number
+  readonly source: 'workspace' | 'new-injection'
+}
+
+/** Resolve the visible credential without allowing global defaults to flash
+ * over a Workspace whose on-disk agent config is still being inspected. */
+export function resolveAgentCredential(
+  credentials: readonly Pick<SavedCredential, 'slug'>[] | null,
+  pickedCredential: string | null,
+  detectedCredential: string | null,
+  workspaceCredentialReady: boolean,
+  workspaceDefaultCredential: string | null = null,
+  lastCredential: string | null = null,
+  workspaceCredentialResolved = true,
+  preferencesResolved = true,
+): string | null {
+  const available = (slug: string | null): slug is string => (
+    slug !== null && credentials?.some((credential) => credential.slug === slug) === true
+  )
+  if (available(pickedCredential)) return pickedCredential
+  if (!workspaceCredentialResolved) return null
+  if (available(detectedCredential)) return detectedCredential
+  if (workspaceCredentialReady) return null
+  if (available(workspaceDefaultCredential)) return workspaceDefaultCredential
+  // Credentials and preferences load in parallel. Do not briefly expose (or
+  // launch with) the first vault entry before the remembered choice arrives.
+  if (!preferencesResolved) return null
+  if (available(lastCredential)) return lastCredential
+  return credentials?.[0]?.slug ?? null
+}
+
+/** Login-backed CLIs own their provider state. Loginless runtimes receive the
+ * exact credential shown by the shared selector, including global-config fallbacks. */
+export function resolveAgentLaunchCredentialSlug(
+  needsCredential: boolean,
+  effectiveCredential: string | null,
+): string | undefined {
+  return needsCredential ? (effectiveCredential ?? undefined) : undefined
+}
+
+/** Describe the exact model/context that the next launch will use. Existing
+ * Workspace config wins only when it belongs to the selected credential. */
+export function resolveAgentLaunchAiDetails(
+  effectiveCredential: string | null,
+  credential: Pick<SavedCredential, 'slug' | 'resolvedModel'> | null,
+  detected: WorkspaceCredentialDetection | null,
+  creationDefault: WorkspaceCredentialDefault | undefined,
+  defaultContextWindow: number,
+  hasWorkspace: boolean,
+): AgentLaunchAiDetails | null {
+  // A usable hand-edited Workspace config has no vault slug, and a formerly
+  // linked credential can later be deleted. The runtime can still use that
+  // on-disk config, so keep its real model/context visible instead of falling
+  // back to an empty summary.
+  if (hasWorkspace && !effectiveCredential && detected && (
+    detected.model !== null || detected.contextWindow !== null
+  )) {
+    return {
+      model: detected.model,
+      contextWindow: detected.contextWindow ?? defaultContextWindow,
+      source: 'workspace',
+    }
+  }
+  if (!effectiveCredential || credential?.slug !== effectiveCredential) return null
+  if (hasWorkspace && detected?.slug === effectiveCredential) {
+    return {
+      model: detected.model ?? credential.resolvedModel ?? null,
+      contextWindow: detected.contextWindow ?? defaultContextWindow,
+      source: 'workspace',
+    }
+  }
+  const creationModel = !hasWorkspace && creationDefault?.credentialSlug === effectiveCredential
+    ? creationDefault.model
+    : undefined
+  return {
+    model: creationModel ?? credential.resolvedModel ?? null,
+    contextWindow: defaultContextWindow,
+    source: 'new-injection',
+  }
+}
+
+export function formatContextWindow(value: number): string {
+  if (value >= 1_000_000 && value % 1_000_000 === 0) return `${value / 1_000_000}M`
+  if (value >= 1_000 && value % 1_000 === 0) return `${value / 1_000}K`
+  return String(value)
+}
+
+export interface AgentLaunchPreferencesState {
+  readonly lastCredentialByAgent: Readonly<Record<string, string>>
+  readonly recentChatWorkspaceId: string | null
+  readonly loaded: boolean
+  rememberCredential(agent: LoginlessAgentId, credentialSlug: string | null): Promise<void>
+  adoptRecentChatWorkspace(workspaceId: string | null): void
+}
+
+function fallbackPreferences(): QuickChatPreferences {
+  return { lastCredentialByAgent: {}, recentChatWorkspaceId: null }
+}
+
+/** Shared persistence boundary for every chat-style launcher. Keeping this
+ * separate lets Quick Chat resolve its recent Workspace before the launch
+ * config hook needs that Workspace id. */
+export function useAgentLaunchPreferences(): AgentLaunchPreferencesState {
+  const [preferences, setPreferences] = useState<QuickChatPreferences>(fallbackPreferences)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let live = true
+    void preferencesApi.getQuickChat()
+      .then((next) => {
+        if (!live) return
+        setPreferences(next)
+        setLoaded(true)
+      })
+      .catch(() => {
+        if (live) setLoaded(true)
+      })
+
+    const onChanged = (event: Event) => {
+      const detail = (event as CustomEvent<QuickChatPreferences>).detail
+      if (detail) setPreferences(detail)
+    }
+    window.addEventListener(AGENT_LAUNCH_PREFERENCES_CHANGED_EVENT, onChanged)
+    return () => {
+      live = false
+      window.removeEventListener(AGENT_LAUNCH_PREFERENCES_CHANGED_EVENT, onChanged)
+    }
+  }, [])
+
+  const rememberCredential = useCallback(async (
+    agent: LoginlessAgentId,
+    credentialSlug: string | null,
+  ): Promise<void> => {
+    setPreferences((current) => ({
+      ...current,
+      lastCredentialByAgent: credentialSlug === null
+        ? Object.fromEntries(Object.entries(current.lastCredentialByAgent).filter(([key]) => key !== agent))
+        : { ...current.lastCredentialByAgent, [agent]: credentialSlug },
+    }))
+    try {
+      const saved = await preferencesApi.rememberQuickChatCredential(agent, credentialSlug)
+      if (saved) {
+        setPreferences(saved)
+        window.dispatchEvent(new CustomEvent(AGENT_LAUNCH_PREFERENCES_CHANGED_EVENT, { detail: saved }))
+      }
+    } catch {
+      // The visible choice remains valid for this launch even when remembering
+      // it fails; the backend remains authoritative on the next page load.
+    }
+  }, [])
+
+  const adoptRecentChatWorkspace = useCallback((workspaceId: string | null) => {
+    setPreferences((current) => ({ ...current, recentChatWorkspaceId: workspaceId }))
+  }, [])
+
+  return {
+    lastCredentialByAgent: preferences.lastCredentialByAgent,
+    recentChatWorkspaceId: preferences.recentChatWorkspaceId,
+    loaded,
+    rememberCredential,
+    adoptRecentChatWorkspace,
+  }
+}
+
+export interface UseAgentLaunchConfigOptions {
+  readonly agents: readonly AgentInfo[]
+  readonly defaultAgent: string | null
+  readonly setDefaultAgent: (agent: string | null) => Promise<void>
+  readonly preferences: AgentLaunchPreferencesState
+  readonly workspaceId: string | null
+  readonly hasWorkspace: boolean
+}
+
+export interface AgentLaunchConfigState {
+  readonly agents: readonly AgentInfo[]
+  readonly effectiveAgent: string | null
+  readonly selectedAgent: AgentInfo | null
+  readonly runtimeReadiness: AgentRuntimeReadinessSnapshot | null
+  readonly selectedRuntimeReadiness: AgentRuntimeReadinessRow | null
+  readonly needsCredential: boolean
+  readonly credentials: readonly SavedCredential[] | null
+  readonly effectiveCredential: string | null
+  readonly credential: SavedCredential | null
+  readonly detectedCredential: WorkspaceCredentialDetection | null
+  readonly aiDetails: AgentLaunchAiDetails | null
+  readonly selectedRuntimeUsesGlobalConfig: boolean
+  readonly credentialSelectionReady: boolean
+  readonly noCredentials: boolean
+  readonly needsProviderSetup: boolean
+  readonly willOverwriteCredential: boolean
+  readonly selectedMissing: boolean
+  readonly anyInstalled: boolean
+  readonly agentsKnown: boolean
+  readonly launchCredentialSlug: string | undefined
+  selectAgent(agent: string): void
+  selectCredential(credentialSlug: string): void
+  resetCredentialSelection(): void
+  checkSelectedRuntime(): Promise<AgentRuntimeReadinessRow | null>
+}
+
+/** Canonical launch-state hook for Quick Chat, Workspace Manager, and future
+ * chat-style surfaces. It owns runtime selection/readiness plus the complete
+ * credential -> model -> context resolution chain. */
+export function useAgentLaunchConfig({
+  agents,
+  defaultAgent,
+  setDefaultAgent,
+  preferences,
+  workspaceId,
+  hasWorkspace,
+}: UseAgentLaunchConfigOptions): AgentLaunchConfigState {
+  const [runtimeReadiness, setRuntimeReadiness] = useState<AgentRuntimeReadinessSnapshot | null>(null)
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
+  const [credentials, setCredentials] = useState<SavedCredential[] | null>(null)
+  const [pickedCredential, setPickedCredential] = useState<{
+    agent: string
+    workspaceId: string | null
+    slug: string
+  } | null>(null)
+  const [detectedCredential, setDetectedCredential] = useState<WorkspaceCredentialDetection | null>(null)
+  const [agentReadiness, setAgentReadiness] = useState<AgentCredentialReadiness | null>(null)
+  const [credentialWorkspaceResolved, setCredentialWorkspaceResolved] = useState(false)
+  const [workspaceCredentialDefaults, setWorkspaceCredentialDefaults] = useState<Record<string, WorkspaceCredentialDefault>>({})
+  const [workspaceDefaultContextWindow, setWorkspaceDefaultContextWindow] = useState<WorkspaceContextWindow>(DEFAULT_CONTEXT_WINDOW)
+  const [agentConfigRevision, setAgentConfigRevision] = useState(0)
+
+  const effectiveAgent = resolveAgentRuntime(agents, selectedAgentId, defaultAgent, runtimeReadiness)
+  const selectedAgent = agents.find((agent) => agent.id === effectiveAgent) ?? null
+  const selectedRuntimeReadiness = effectiveAgent ? runtimeReadiness?.agents[effectiveAgent] ?? null : null
+  const selectedRuntimeUsesGlobalConfig = selectedRuntimeReadiness?.ready === true && (
+    selectedRuntimeReadiness.source === 'global-config' ||
+    selectedRuntimeReadiness.source === 'managed-runtime' ||
+    selectedRuntimeReadiness.source === 'global-login'
+  )
+  const needsCredential = isLoginlessAgent(effectiveAgent)
+
+  useEffect(() => {
+    let live = true
+    void getAgentRuntimeReadiness()
+      .then((snapshot) => { if (live) setRuntimeReadiness(snapshot) })
+      .catch(() => { if (live) setRuntimeReadiness(null) })
+    return () => { live = false }
+  }, [])
+
+  useEffect(() => {
+    let live = true
+    const refreshAll = () => {
+      void Promise.all([
+        listAgentCredentials('opencode').catch(() => []),
+        configApi.getWorkspaceCredentialDefaults().catch(() => null),
+      ]).then(([available, defaults]) => {
+        if (!live) return
+        setCredentials(available)
+        if (defaults) {
+          setWorkspaceCredentialDefaults(defaults.defaults)
+          setWorkspaceDefaultContextWindow(defaults.contextWindow)
+        }
+      })
+    }
+    const refreshDefaults = () => {
+      void configApi.getWorkspaceCredentialDefaults()
+        .then((defaults) => {
+          if (!live) return
+          setWorkspaceCredentialDefaults(defaults.defaults)
+          setWorkspaceDefaultContextWindow(defaults.contextWindow)
+        })
+        .catch(() => undefined)
+    }
+    refreshAll()
+    window.addEventListener('openalice:credentials-changed', refreshAll)
+    window.addEventListener(WORKSPACE_DEFAULTS_CHANGED_EVENT, refreshDefaults)
+    return () => {
+      live = false
+      window.removeEventListener('openalice:credentials-changed', refreshAll)
+      window.removeEventListener(WORKSPACE_DEFAULTS_CHANGED_EVENT, refreshDefaults)
+    }
+  }, [])
+
+  useEffect(() => {
+    const onWorkspaceAgentConfigChanged = (event: Event) => {
+      const detail = (event as CustomEvent<{ wsId?: string; agent?: string }>).detail
+      if (!detail || (detail.wsId === workspaceId && detail.agent === effectiveAgent)) {
+        setAgentConfigRevision((revision) => revision + 1)
+      }
+    }
+    window.addEventListener('openalice:workspace-agent-config-changed', onWorkspaceAgentConfigChanged)
+    return () => window.removeEventListener('openalice:workspace-agent-config-changed', onWorkspaceAgentConfigChanged)
+  }, [effectiveAgent, workspaceId])
+
+  useEffect(() => {
+    if (!needsCredential || effectiveAgent === null || workspaceId === null) {
+      setDetectedCredential(null)
+      setAgentReadiness(null)
+      setCredentialWorkspaceResolved(true)
+      return
+    }
+    let live = true
+    setCredentialWorkspaceResolved(false)
+    void Promise.allSettled([
+      detectWorkspaceCredential(workspaceId, effectiveAgent),
+      getAgentReadiness(workspaceId),
+    ]).then(([detected, readiness]) => {
+      if (!live) return
+      setDetectedCredential(detected.status === 'fulfilled' ? detected.value : null)
+      setAgentReadiness(
+        readiness.status === 'fulfilled'
+          ? readiness.value.agents[effectiveAgent] ?? null
+          : null,
+      )
+      setCredentialWorkspaceResolved(true)
+    })
+    return () => { live = false }
+  }, [agentConfigRevision, effectiveAgent, needsCredential, workspaceId])
+
+  const workspaceCredentialReady = needsCredential &&
+    agentReadiness?.ready === true &&
+    agentReadiness.requiresCredential === true &&
+    agentReadiness.source === 'workspace-config'
+  const scopedPickedCredential = pickedCredential?.agent === effectiveAgent &&
+    pickedCredential.workspaceId === workspaceId
+    ? pickedCredential.slug
+    : null
+  const effectiveCredential = resolveAgentCredential(
+    credentials,
+    scopedPickedCredential,
+    detectedCredential?.slug ?? null,
+    workspaceCredentialReady,
+    effectiveAgent ? workspaceCredentialDefaults[effectiveAgent]?.credentialSlug ?? null : null,
+    effectiveAgent ? preferences.lastCredentialByAgent[effectiveAgent] ?? null : null,
+    credentialWorkspaceResolved,
+    preferences.loaded,
+  )
+  const credential = credentials?.find((candidate) => candidate.slug === effectiveCredential) ?? null
+  const aiDetails = resolveAgentLaunchAiDetails(
+    effectiveCredential,
+    credential,
+    detectedCredential,
+    effectiveAgent ? workspaceCredentialDefaults[effectiveAgent] : undefined,
+    workspaceDefaultContextWindow,
+    hasWorkspace,
+  )
+  const noCredentials = needsCredential &&
+    credentialWorkspaceResolved &&
+    !workspaceCredentialReady &&
+    !selectedRuntimeUsesGlobalConfig &&
+    credentials !== null &&
+    credentials.length === 0
+  const credentialSelectionReady = !needsCredential || selectedRuntimeUsesGlobalConfig || (
+    credentials !== null && credentialWorkspaceResolved && preferences.loaded
+  )
+
+  const selectAgent = useCallback((agent: string) => {
+    setSelectedAgentId(agent)
+    setPickedCredential(null)
+    void setDefaultAgent(agent)
+  }, [setDefaultAgent])
+
+  const selectCredential = useCallback((credentialSlug: string) => {
+    if (!isLoginlessAgent(effectiveAgent)) return
+    setPickedCredential({ agent: effectiveAgent, workspaceId, slug: credentialSlug })
+    void preferences.rememberCredential(effectiveAgent, credentialSlug)
+  }, [effectiveAgent, preferences, workspaceId])
+
+  const resetCredentialSelection = useCallback(() => setPickedCredential(null), [])
+
+  const checkSelectedRuntime = useCallback(async (): Promise<AgentRuntimeReadinessRow | null> => {
+    if (!effectiveAgent) return null
+    const current = runtimeReadiness?.agents[effectiveAgent] ?? null
+    if (current?.ready === true) return current
+    const snapshot = await probeAgentRuntimeReadiness(effectiveAgent)
+    setRuntimeReadiness(snapshot)
+    return snapshot.agents[effectiveAgent] ?? null
+  }, [effectiveAgent, runtimeReadiness])
+
+  return useMemo(() => ({
+    agents,
+    effectiveAgent,
+    selectedAgent,
+    runtimeReadiness,
+    selectedRuntimeReadiness,
+    needsCredential,
+    credentials,
+    effectiveCredential,
+    credential,
+    detectedCredential,
+    aiDetails,
+    selectedRuntimeUsesGlobalConfig,
+    credentialSelectionReady,
+    noCredentials,
+    needsProviderSetup: noCredentials,
+    willOverwriteCredential: needsCredential &&
+      detectedCredential?.slug !== null &&
+      detectedCredential?.slug !== undefined &&
+      effectiveCredential !== null &&
+      effectiveCredential !== detectedCredential.slug,
+    selectedMissing: selectedAgent?.installed === false,
+    anyInstalled: agents.some((agent) => agent.installed !== false),
+    agentsKnown: agents.length > 0,
+    launchCredentialSlug: resolveAgentLaunchCredentialSlug(needsCredential, effectiveCredential),
+    selectAgent,
+    selectCredential,
+    resetCredentialSelection,
+    checkSelectedRuntime,
+  }), [
+    agents,
+    aiDetails,
+    checkSelectedRuntime,
+    credentials,
+    credential,
+    credentialSelectionReady,
+    detectedCredential,
+    effectiveAgent,
+    effectiveCredential,
+    needsCredential,
+    noCredentials,
+    runtimeReadiness,
+    selectAgent,
+    selectCredential,
+    selectedAgent,
+    selectedRuntimeReadiness,
+    selectedRuntimeUsesGlobalConfig,
+    resetCredentialSelection,
+  ])
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -259,6 +259,7 @@ export const en = {
     selectCredential: 'AI provider',
     configureProvider: 'Configure an AI provider',
     runtimeDefaultModel: 'Runtime default model',
+    runtimeManagedAi: 'Model and context are managed by {{runtime}}',
     modelSummary: 'Model {{model}}',
     contextSummary: '{{limit}} context',
     adjustWorkspaceAi: 'Adjust workspace AI',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -248,6 +248,7 @@ export const ja: Resources = {
     selectCredential: 'AI プロバイダー',
     configureProvider: 'AI プロバイダーを設定',
     runtimeDefaultModel: 'ランタイム既定モデル',
+    runtimeManagedAi: 'モデルとコンテキストは {{runtime}} が管理します',
     modelSummary: 'モデル {{model}}',
     contextSummary: '{{limit}} コンテキスト',
     adjustWorkspaceAi: 'ワークスペース AI を調整',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -256,6 +256,7 @@ export const zhHant: Resources = {
     selectCredential: 'AI 供應方',
     configureProvider: '設定一個 AI 供應方',
     runtimeDefaultModel: '執行環境預設模型',
+    runtimeManagedAi: '模型與上下文由 {{runtime}} 管理',
     modelSummary: '模型 {{model}}',
     contextSummary: '{{limit}} 上下文',
     adjustWorkspaceAi: '調整工作區 AI',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -248,6 +248,7 @@ export const zh: Resources = {
     selectCredential: 'AI 提供方',
     configureProvider: '配置一个 AI 提供方',
     runtimeDefaultModel: '运行时默认模型',
+    runtimeManagedAi: '模型和上下文由 {{runtime}} 管理',
     modelSummary: '模型 {{model}}',
     contextSummary: '{{limit}} 上下文',
     adjustWorkspaceAi: '调整工作区 AI',

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -948,7 +948,7 @@ html[lang="ja"] .oa-onboarding-title {
 }
 
 @container workspace-manager-layout (min-width: 34rem) {
-  .workspace-manager-composer-footer {
+  .workspace-manager-composer-actions {
     flex-direction: row;
     align-items: center;
     justify-content: space-between;

--- a/ui/src/pages/ChatLandingPage.spec.ts
+++ b/ui/src/pages/ChatLandingPage.spec.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import {
   formatContextWindow,
-  resolveChatAgent,
-  resolveChatCredential,
-  resolveChatWorkspaceTarget,
-  resolveQuickChatAiDetails,
-  resolveQuickChatCredentialSlug,
-} from './ChatLandingPage'
+  resolveAgentCredential,
+  resolveAgentLaunchAiDetails,
+  resolveAgentLaunchCredentialSlug,
+} from '../hooks/useAgentLaunchConfig'
+import { resolveAgentRuntime } from '../lib/agentRuntime'
+import { resolveChatWorkspaceTarget } from './ChatLandingPage'
 import type { AgentRuntimeReadinessSnapshot, Workspace } from '../components/workspace/api'
 
 const agents = [
@@ -92,15 +92,15 @@ describe('resolveChatWorkspaceTarget', () => {
 
 describe('resolveChatAgent', () => {
   it('keeps an explicit valid choice ahead of saved and detected defaults', () => {
-    expect(resolveChatAgent(agents, 'codex', 'claude', readiness('claude'))).toBe('codex')
+    expect(resolveAgentRuntime(agents, 'codex', 'claude', readiness('claude'))).toBe('codex')
   })
 
   it('uses the saved default when there is no explicit choice', () => {
-    expect(resolveChatAgent(agents, null, 'claude', readiness('codex'))).toBe('claude')
+    expect(resolveAgentRuntime(agents, null, 'claude', readiness('codex'))).toBe('claude')
   })
 
   it('uses a verified runtime when no preference exists', () => {
-    expect(resolveChatAgent(agents, null, null, readiness('codex'))).toBe('codex')
+    expect(resolveAgentRuntime(agents, null, null, readiness('codex'))).toBe('codex')
   })
 
   it('uses the only installed runtime while readiness is still stale', () => {
@@ -109,36 +109,36 @@ describe('resolveChatAgent', () => {
       { id: 'codex', installed: false },
       { id: 'pi', installed: true },
     ]
-    expect(resolveChatAgent(freshInstall, null, null, null)).toBe('pi')
+    expect(resolveAgentRuntime(freshInstall, null, null, null)).toBe('pi')
   })
 
   it('does not guess when several runtimes are installed and none is ready', () => {
-    expect(resolveChatAgent(agents, null, null, null)).toBeNull()
+    expect(resolveAgentRuntime(agents, null, null, null)).toBeNull()
   })
 
   it('ignores choices that are unavailable in the target workspace', () => {
-    expect(resolveChatAgent([{ id: 'pi', installed: true }], 'codex', 'claude', null)).toBe('pi')
+    expect(resolveAgentRuntime([{ id: 'pi', installed: true }], 'codex', 'claude', null)).toBe('pi')
   })
 })
 
-describe('resolveChatCredential', () => {
+describe('resolveAgentCredential', () => {
   const credentials = [{ slug: 'saved-a' }, { slug: 'saved-b' }]
 
   it('keeps an explicit provider choice', () => {
-    expect(resolveChatCredential(credentials, 'saved-b', 'saved-a', true)).toBe('saved-b')
+    expect(resolveAgentCredential(credentials, 'saved-b', 'saved-a', true)).toBe('saved-b')
   })
 
   it('shows the detected provider even when workspace config is already ready', () => {
-    expect(resolveChatCredential(credentials, null, 'saved-a', true)).toBe('saved-a')
+    expect(resolveAgentCredential(credentials, null, 'saved-a', true)).toBe('saved-a')
   })
 
   it('falls back to the first credential only when workspace config needs one', () => {
-    expect(resolveChatCredential(credentials, null, null, false)).toBe('saved-a')
-    expect(resolveChatCredential(credentials, null, null, true)).toBeNull()
+    expect(resolveAgentCredential(credentials, null, null, false)).toBe('saved-a')
+    expect(resolveAgentCredential(credentials, null, null, true)).toBeNull()
   })
 
   it('uses a configured workspace default before the remembered quick-chat choice', () => {
-    expect(resolveChatCredential(
+    expect(resolveAgentCredential(
       credentials,
       null,
       null,
@@ -149,7 +149,7 @@ describe('resolveChatCredential', () => {
   })
 
   it('uses the remembered quick-chat choice before the first credential', () => {
-    expect(resolveChatCredential(
+    expect(resolveAgentCredential(
       credentials,
       null,
       null,
@@ -160,7 +160,7 @@ describe('resolveChatCredential', () => {
   })
 
   it('keeps the workspace credential ahead of global defaults and history', () => {
-    expect(resolveChatCredential(
+    expect(resolveAgentCredential(
       credentials,
       null,
       'saved-b',
@@ -171,7 +171,7 @@ describe('resolveChatCredential', () => {
   })
 
   it('does not expose a global fallback while workspace detection is pending', () => {
-    expect(resolveChatCredential(
+    expect(resolveAgentCredential(
       credentials,
       null,
       null,
@@ -182,27 +182,40 @@ describe('resolveChatCredential', () => {
     )).toBeNull()
   })
 
+  it('does not expose the first vault credential while remembered preferences are pending', () => {
+    expect(resolveAgentCredential(
+      credentials,
+      null,
+      null,
+      false,
+      null,
+      null,
+      true,
+      false,
+    )).toBeNull()
+  })
+
   it('does not claim a deleted credential is available', () => {
-    expect(resolveChatCredential(credentials, null, 'missing', true)).toBeNull()
-    expect(resolveChatCredential(credentials, 'missing', null, false, null, 'saved-b')).toBe('saved-b')
+    expect(resolveAgentCredential(credentials, null, 'missing', true)).toBeNull()
+    expect(resolveAgentCredential(credentials, 'missing', null, false, null, 'saved-b')).toBe('saved-b')
   })
 })
 
-describe('resolveQuickChatCredentialSlug', () => {
+describe('resolveAgentLaunchCredentialSlug', () => {
   it('passes a resolved OpenCode/Pi credential even when runtime readiness came from global config', () => {
-    expect(resolveQuickChatCredentialSlug(true, 'meituan-longcat')).toBe('meituan-longcat')
+    expect(resolveAgentLaunchCredentialSlug(true, 'meituan-longcat')).toBe('meituan-longcat')
   })
 
   it('does not send credentials to login-backed runtimes', () => {
-    expect(resolveQuickChatCredentialSlug(false, 'meituan-longcat')).toBeUndefined()
+    expect(resolveAgentLaunchCredentialSlug(false, 'meituan-longcat')).toBeUndefined()
   })
 })
 
-describe('resolveQuickChatAiDetails', () => {
+describe('resolveAgentLaunchAiDetails', () => {
   const credential = { slug: 'google-1', resolvedModel: 'gemini-3.5-flash' }
 
   it('shows the effective model and context already written in the target workspace', () => {
-    expect(resolveQuickChatAiDetails(
+    expect(resolveAgentLaunchAiDetails(
       'google-1',
       credential,
       {
@@ -222,7 +235,7 @@ describe('resolveQuickChatAiDetails', () => {
   })
 
   it('shows the selected credential model and global context for a replacement injection', () => {
-    expect(resolveQuickChatAiDetails(
+    expect(resolveAgentLaunchAiDetails(
       'google-1',
       credential,
       {
@@ -242,7 +255,7 @@ describe('resolveQuickChatAiDetails', () => {
   })
 
   it('shows the configured creation model before the first workspace exists', () => {
-    expect(resolveQuickChatAiDetails(
+    expect(resolveAgentLaunchAiDetails(
       'google-1',
       credential,
       null,
@@ -253,6 +266,26 @@ describe('resolveQuickChatAiDetails', () => {
       model: 'gemini-3.1-pro-preview',
       contextWindow: 512_000,
       source: 'new-injection',
+    })
+  })
+
+  it('shows a usable hand-edited workspace config without a vault credential', () => {
+    expect(resolveAgentLaunchAiDetails(
+      null,
+      null,
+      {
+        slug: null,
+        model: 'local-manual-model',
+        contextWindow: 128_000,
+        wireShape: 'openai-chat',
+      },
+      undefined,
+      256_000,
+      true,
+    )).toEqual({
+      model: 'local-manual-model',
+      contextWindow: 128_000,
+      source: 'workspace',
     })
   })
 

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -2,51 +2,41 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   ArrowUp,
-  Bot,
   Check,
   ChevronDown,
-  Code2,
-  Cpu,
-  Gauge,
   KeyRound,
   LayoutGrid,
   Loader2,
   MessageSquare,
   Paperclip,
-  Settings2,
-  Sparkles,
   X,
-  type LucideIcon,
 } from 'lucide-react'
 
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { installHintFor } from '../components/workspace/agentInstall'
 import {
-  getAgentReadiness,
-  getAgentRuntimeReadiness,
-  listAgentCredentials,
-  detectWorkspaceCredential,
-  probeAgentRuntimeReadiness,
   QuickChatError,
-  type AgentInfo,
-  type AgentCredentialReadiness,
-  type AgentRuntimeReadinessSnapshot,
-  type SavedCredential,
-  type WorkspaceCredentialDetection,
   type Workspace,
 } from '../components/workspace/api'
+import {
+  AgentLaunchDetails,
+  AgentLaunchSelectors,
+  type AgentLaunchSelectorsHandle,
+} from '../components/workspace/AgentLaunchControls'
 import { workspaceDisplayTitle } from '../components/workspace/display'
 import { useWorkspace } from '../tabs/store'
 import {
-  configApi,
-  type WorkspaceContextWindow,
-  type WorkspaceCredentialDefault,
-} from '../api/config'
-import { preferencesApi } from '../api/preferences'
-import { WORKSPACE_DEFAULTS_CHANGED_EVENT } from '../lib/workspaceAiEvents'
-import { isLoginlessAgent, resolveAgentRuntime } from '../lib/agentRuntime'
+  useAgentLaunchConfig,
+  useAgentLaunchPreferences,
+} from '../hooks/useAgentLaunchConfig'
 
 export { resolveAgentRuntime as resolveChatAgent } from '../lib/agentRuntime'
+export {
+  formatContextWindow,
+  resolveAgentCredential as resolveChatCredential,
+  resolveAgentLaunchAiDetails as resolveQuickChatAiDetails,
+  resolveAgentLaunchCredentialSlug as resolveQuickChatCredentialSlug,
+} from '../hooks/useAgentLaunchConfig'
 
 function workspaceActivityMs(workspace: Pick<Workspace, 'createdAt' | 'sessions'>): number {
   const sessionActivity = workspace.sessions
@@ -76,92 +66,6 @@ export function resolveChatWorkspaceTarget(
   return [...chats].sort((a, b) => workspaceActivityMs(b) - workspaceActivityMs(a))[0] ?? null
 }
 
-/** Glyph per agent CLI, for the runtime picker (claude/codex/opencode/pi). */
-const AGENT_ICONS: Record<string, LucideIcon> = {
-  claude: Sparkles,
-  codex: Cpu,
-  opencode: Code2,
-  pi: Bot,
-}
-
-/** Keep the provider pill truthful for an existing workspace. A ready
- * workspace still has a detected credential; readiness controls whether we
- * need a fallback, not whether the current provider name should disappear. */
-export function resolveChatCredential(
-  credentials: readonly Pick<SavedCredential, 'slug'>[] | null,
-  pickedCredential: string | null,
-  detectedCredential: string | null,
-  workspaceCredentialReady: boolean,
-  workspaceDefaultCredential: string | null = null,
-  lastCredential: string | null = null,
-  workspaceCredentialResolved = true,
-): string | null {
-  const available = (slug: string | null): slug is string => (
-    slug !== null && credentials?.some((credential) => credential.slug === slug) === true
-  )
-  if (available(pickedCredential)) return pickedCredential
-  // An existing workspace owns its provider choice. Do not briefly expose (or
-  // submit) a global fallback while its on-disk config is still being detected.
-  if (!workspaceCredentialResolved) return null
-  if (available(detectedCredential)) return detectedCredential
-  if (workspaceCredentialReady) return null
-  if (available(workspaceDefaultCredential)) return workspaceDefaultCredential
-  if (available(lastCredential)) return lastCredential
-  return credentials?.[0]?.slug ?? null
-}
-
-/** The provider pill is a per-Workspace launch choice. Global runtime
- * readiness may let a loginless runtime start without a vault credential, but
- * it must not erase a credential the composer resolved for this launch. */
-export function resolveQuickChatCredentialSlug(
-  needsCredential: boolean,
-  effectiveCredential: string | null,
-): string | undefined {
-  return needsCredential ? (effectiveCredential ?? undefined) : undefined
-}
-
-export interface QuickChatAiDetails {
-  readonly model: string | null
-  readonly contextWindow: number
-  readonly source: 'workspace' | 'new-injection'
-}
-
-/** Resolve the exact model/context Quick Chat will launch with. Existing
- * Workspace config wins when the visible credential already matches it; a
- * different selection is a new injection and therefore uses that credential's
- * resolved model plus the global creation-time context default. */
-export function resolveQuickChatAiDetails(
-  effectiveCredential: string | null,
-  credential: Pick<SavedCredential, 'slug' | 'resolvedModel'> | null,
-  detected: WorkspaceCredentialDetection | null,
-  creationDefault: WorkspaceCredentialDefault | undefined,
-  defaultContextWindow: number,
-  hasWorkspace: boolean,
-): QuickChatAiDetails | null {
-  if (!effectiveCredential || credential?.slug !== effectiveCredential) return null
-  if (hasWorkspace && detected?.slug === effectiveCredential) {
-    return {
-      model: detected.model ?? credential.resolvedModel ?? null,
-      contextWindow: detected.contextWindow ?? defaultContextWindow,
-      source: 'workspace',
-    }
-  }
-  const creationModel = !hasWorkspace && creationDefault?.credentialSlug === effectiveCredential
-    ? creationDefault.model
-    : undefined
-  return {
-    model: creationModel ?? credential.resolvedModel ?? null,
-    contextWindow: defaultContextWindow,
-    source: 'new-injection',
-  }
-}
-
-export function formatContextWindow(value: number): string {
-  if (value >= 1_000_000 && value % 1_000_000 === 0) return `${value / 1_000_000}M`
-  if (value >= 1_000 && value % 1_000 === 0) return `${value / 1_000}K`
-  return String(value)
-}
-
 /**
  * Quick-chat landing — the "type a message → you're in" front door for the
  * "Ask Alice" activity. A single composer: the user types a first message and
@@ -183,7 +87,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   const targetWsId = spec.params.targetWsId
   const targetWs = targetWsId ? workspaces.find((w) => w.id === targetWsId) : undefined
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null)
-  const [recentChatWorkspaceId, setRecentChatWorkspaceId] = useState<string | null>(null)
+  const launchPreferences = useAgentLaunchPreferences()
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false)
   const workspaceBoxRef = useRef<HTMLDivElement>(null)
   const activeWorkspaceOptionRef = useRef<HTMLButtonElement>(null)
@@ -191,9 +95,9 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
     () => resolveChatWorkspaceTarget(
       workspaces,
       targetWsId ?? selectedWorkspaceId,
-      recentChatWorkspaceId,
+      launchPreferences.recentChatWorkspaceId,
     ),
-    [workspaces, targetWsId, selectedWorkspaceId, recentChatWorkspaceId],
+    [workspaces, targetWsId, selectedWorkspaceId, launchPreferences.recentChatWorkspaceId],
   )
   const workspaceTarget = targetWs ?? selectedChatWorkspace
   const chatWorkspaceOptions = useMemo(
@@ -213,237 +117,20 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   const [value, setValue] = useState('')
   const [launching, setLaunching] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [runtimeReadiness, setRuntimeReadiness] = useState<AgentRuntimeReadinessSnapshot | null>(null)
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
-  const [agentMenuOpen, setAgentMenuOpen] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const agentBoxRef = useRef<HTMLDivElement>(null)
-
-  // Backend probes the host PATH and reports `installed` per agent. Treat a
-  // missing value as installed (older backend / don't gate on a stale shape).
-  const isInstalled = (a: { installed?: boolean }) => a.installed !== false
-  const anyInstalled = targetCliAgents.some(isInstalled)
-  // Whether the `/agents` fetch has actually landed. Before it does, `agents`
-  // is `[]` and `anyInstalled` is falsely false — which would flash the
-  // "nothing installed, go install something" nudge on every page load until
-  // the request resolves. The backend registers claude/codex/opencode/pi/shell
-  // unconditionally, so a loaded list always has ≥1 CLI agent; an empty
-  // `targetCliAgents` means "still loading" (or the fetch failed) — in both cases we
-  // must NOT assert that the host is missing its runtimes.
-  const agentsKnown = targetCliAgents.length > 0
-
-  // Prefer explicit and persisted choices, then remove first-message friction
-  // when the host has one clear usable runtime. The picker remains available
-  // and persists any later user choice.
-  const effectiveAgent = resolveAgentRuntime(
-    targetCliAgents,
-    selectedAgent,
-    defaultAgent,
-    runtimeReadiness,
-  )
-  const selectedInfo = targetCliAgents.find((a) => a.id === effectiveAgent) ?? null
-  const SelectedIcon = selectedInfo ? AGENT_ICONS[selectedInfo.id] : undefined
-  // Surface install guidance when the chosen runtime isn't on PATH.
-  const selectedMissing = selectedInfo != null && !isInstalled(selectedInfo)
-  const installHint = selectedInfo ? installHintFor(selectedInfo.id) : undefined
-  const selectedRuntimeReadiness = effectiveAgent ? runtimeReadiness?.agents[effectiveAgent] ?? null : null
-  const selectedRuntimeReady = selectedRuntimeReadiness?.ready === true
-  const selectedRuntimeUsesGlobalConfig =
-    selectedRuntimeReady &&
-    (selectedRuntimeReadiness?.source === 'global-config' ||
-      selectedRuntimeReadiness?.source === 'managed-runtime' ||
-      selectedRuntimeReadiness?.source === 'global-login')
-
-  // ── Loginless-runtime credential picker (opencode/pi) ─────────────────────
-  // opencode/pi have no login of their own, so a quick-chat send must seed them
-  // with a vault credential. claude/codex skip all of this (own CLI login).
-  const needsCred = isLoginlessAgent(effectiveAgent)
-  // The loginless-runtime credential set (null = not yet loaded). opencode and
-  // pi are both provider-agnostic and share one compatibility set (any wire), so
-  // a single preloaded list serves both — see the mount-time fetch below.
-  const [creds, setCreds] = useState<SavedCredential[] | null>(null)
-  // The cred the user explicitly picked (null = use the default below).
-  const [pickedCred, setPickedCred] = useState<string | null>(null)
-  // The credential the visible target Workspace is configured with, if any.
-  const [detectedCred, setDetectedCred] = useState<string | null>(null)
-  const [detectedCredentialConfig, setDetectedCredentialConfig] = useState<WorkspaceCredentialDetection | null>(null)
-  const [agentReadiness, setAgentReadiness] = useState<AgentCredentialReadiness | null>(null)
-  const [credentialWorkspaceResolved, setCredentialWorkspaceResolved] = useState(false)
-  const [workspaceCredentialDefaults, setWorkspaceCredentialDefaults] = useState<
-    Record<string, WorkspaceCredentialDefault>
-  >({})
-  const [workspaceDefaultContextWindow, setWorkspaceDefaultContextWindow] = useState<WorkspaceContextWindow>(256_000)
-  const [lastCredentialByAgent, setLastCredentialByAgent] = useState<Record<string, string>>({})
-  const [credMenuOpen, setCredMenuOpen] = useState(false)
-  const [agentConfigRevision, setAgentConfigRevision] = useState(0)
-  const credBoxRef = useRef<HTMLDivElement>(null)
-
-  // Credential state belongs to the Workspace the composer visibly targets.
-  // With no Chat workspace yet this remains null; the backend creates one
-  // stable starter workspace on the first successful send.
+  const launchSelectorsRef = useRef<AgentLaunchSelectorsHandle>(null)
   const credentialWorkspace = workspaceTarget
-  const credentialWorkspaceId = credentialWorkspace?.id ?? null
-
-  // Preload the loginless credential set ONCE on mount — NOT gated on the
-  // selected agent. Previously this fired only after the agents list resolved
-  // and the user landed on opencode/pi, so the dropdown's data was a second,
-  // late-starting request that visibly lagged behind the agent button (a
-  // request waterfall). Fetching at mount runs it in parallel with the agents
-  // load, so the picker is ready the instant opencode/pi is chosen. opencode and
-  // pi share the same compatibility (any configured wire), so one fetch covers
-  // both; claude/codex never show the picker.
-  useEffect(() => {
-    let live = true
-    const refreshCredentials = () => {
-      void Promise.all([
-        listAgentCredentials('opencode').catch(() => []),
-        configApi.getWorkspaceCredentialDefaults().catch(() => null),
-      ]).then(([list, defaults]) => {
-        if (!live) return
-        setCreds(list)
-        if (defaults) {
-          setWorkspaceCredentialDefaults(defaults.defaults)
-          setWorkspaceDefaultContextWindow(defaults.contextWindow)
-        }
-      })
-    }
-    const refreshWorkspaceDefaults = () => {
-      void configApi.getWorkspaceCredentialDefaults()
-        .then((defaults) => {
-          if (!live) return
-          setWorkspaceCredentialDefaults(defaults.defaults)
-          setWorkspaceDefaultContextWindow(defaults.contextWindow)
-        })
-        .catch(() => undefined)
-    }
-    void Promise.all([
-      listAgentCredentials('opencode').catch(() => []),
-      preferencesApi.getQuickChat().catch(() => ({
-        lastCredentialByAgent: {},
-        recentChatWorkspaceId: null,
-      })),
-      configApi.getWorkspaceCredentialDefaults().catch(() => ({
-        defaults: {}, compatibleByAgent: {}, contextWindow: 256_000 as const,
-      })),
-    ]).then(([list, preferences, defaults]) => {
-      if (!live) return
-      setCreds(list)
-      setLastCredentialByAgent(preferences.lastCredentialByAgent)
-      setRecentChatWorkspaceId(preferences.recentChatWorkspaceId)
-      setWorkspaceCredentialDefaults(defaults.defaults)
-      setWorkspaceDefaultContextWindow(defaults.contextWindow)
-    })
-    window.addEventListener('openalice:credentials-changed', refreshCredentials)
-    window.addEventListener(WORKSPACE_DEFAULTS_CHANGED_EVENT, refreshWorkspaceDefaults)
-    return () => {
-      live = false
-      window.removeEventListener('openalice:credentials-changed', refreshCredentials)
-      window.removeEventListener(WORKSPACE_DEFAULTS_CHANGED_EVENT, refreshWorkspaceDefaults)
-    }
-  }, [])
-
-  useEffect(() => {
-    const onWorkspaceAgentConfigChanged = (event: Event) => {
-      const detail = (event as CustomEvent<{ wsId?: string; agent?: string }>).detail
-      if (!detail || (
-        detail.wsId === credentialWorkspaceId &&
-        detail.agent === effectiveAgent
-      )) {
-        setAgentConfigRevision((revision) => revision + 1)
-      }
-    }
-    window.addEventListener('openalice:workspace-agent-config-changed', onWorkspaceAgentConfigChanged)
-    return () => window.removeEventListener('openalice:workspace-agent-config-changed', onWorkspaceAgentConfigChanged)
-  }, [credentialWorkspaceId, effectiveAgent])
-
-  useEffect(() => {
-    let live = true
-    getAgentRuntimeReadiness()
-      .then((snapshot) => { if (live) setRuntimeReadiness(snapshot) })
-      .catch(() => { if (live) setRuntimeReadiness(null) })
-    return () => { live = false }
-  }, [])
-
-  // Detect the target workspace's current cred/readiness for this runtime (for the default
-  // selection + the overwrite notice). Only when the workspace already exists.
-  useEffect(() => {
-    if (!needsCred || effectiveAgent === null || credentialWorkspaceId === null) {
-      setDetectedCred(null)
-      setDetectedCredentialConfig(null)
-      setAgentReadiness(null)
-      setCredentialWorkspaceResolved(true)
-      return
-    }
-    let live = true
-    setCredentialWorkspaceResolved(false)
-    void Promise.allSettled([
-      detectWorkspaceCredential(credentialWorkspaceId, effectiveAgent),
-      getAgentReadiness(credentialWorkspaceId),
-    ]).then(([detected, readiness]) => {
-      if (!live) return
-      const detectedValue = detected.status === 'fulfilled' ? detected.value : null
-      setDetectedCred(detectedValue?.slug ?? null)
-      setDetectedCredentialConfig(detectedValue)
-      setAgentReadiness(
-        readiness.status === 'fulfilled'
-          ? readiness.value.agents[effectiveAgent] ?? null
-          : null,
-      )
-      setCredentialWorkspaceResolved(true)
-    })
-    return () => { live = false }
-  }, [needsCred, effectiveAgent, credentialWorkspaceId, agentConfigRevision])
-
-  const workspaceCredReady =
-    needsCred &&
-    agentReadiness?.ready === true &&
-    agentReadiness.requiresCredential === true &&
-    agentReadiness.source === 'workspace-config'
-  const noCreds =
-    needsCred &&
-    credentialWorkspaceResolved &&
-    !workspaceCredReady &&
-    !selectedRuntimeUsesGlobalConfig &&
-    creds !== null &&
-    creds.length === 0
-  // Effective cred = explicit pick, else what the workspace already uses, else
-  // the first compatible one. Mirrors the backend's resolution order.
-  const effectiveCred = resolveChatCredential(
-    creds,
-    pickedCred,
-    detectedCred,
-    workspaceCredReady,
-    effectiveAgent ? workspaceCredentialDefaults[effectiveAgent]?.credentialSlug ?? null : null,
-    effectiveAgent ? lastCredentialByAgent[effectiveAgent] ?? null : null,
-    credentialWorkspaceResolved,
-  )
-  const credInfo = creds?.find((c) => c.slug === effectiveCred) ?? null
-  const effectiveWorkspaceDefault = effectiveAgent
-    ? workspaceCredentialDefaults[effectiveAgent]
-    : undefined
-  const quickChatAiDetails = resolveQuickChatAiDetails(
-    effectiveCred,
-    credInfo,
-    detectedCredentialConfig,
-    effectiveWorkspaceDefault,
-    workspaceDefaultContextWindow,
-    credentialWorkspace !== null && credentialWorkspace !== undefined,
-  )
-  // Warn when sending will overwrite the workspace's existing cred with a
-  // different one (only meaningful once today's workspace exists).
-  const willOverwrite =
-    needsCred && detectedCred !== null && effectiveCred !== null && effectiveCred !== detectedCred
-
-  useEffect(() => {
-    if (!credMenuOpen) return
-    const onDown = (e: MouseEvent) => {
-      if (credBoxRef.current && !credBoxRef.current.contains(e.target as Node)) {
-        setCredMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', onDown)
-    return () => document.removeEventListener('mousedown', onDown)
-  }, [credMenuOpen])
+  const launchConfig = useAgentLaunchConfig({
+    agents: targetCliAgents,
+    defaultAgent,
+    setDefaultAgent,
+    preferences: launchPreferences,
+    workspaceId: credentialWorkspace?.id ?? null,
+    hasWorkspace: credentialWorkspace !== null && credentialWorkspace !== undefined,
+  })
+  const effectiveAgent = launchConfig.effectiveAgent
+  const selectedInfo = launchConfig.selectedAgent
+  const installHint = selectedInfo ? installHintFor(selectedInfo.id) : undefined
 
   const goConfigureProvider = () => {
     openOrFocus({ kind: 'settings', params: { category: 'ai-provider' } })
@@ -462,24 +149,8 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
 
   // A missing runtime choice should open the picker, not leave a mysteriously
   // disabled send button. submit() already handles that branch.
-  const credentialSelectionReady =
-    !needsCred ||
-    selectedRuntimeUsesGlobalConfig ||
-    (creds !== null && credentialWorkspaceResolved)
-  const canSend = value.trim().length > 0 && !launching && credentialSelectionReady
+  const canSend = value.trim().length > 0 && !launching && launchConfig.credentialSelectionReady
   const effectiveTargetWorkspaceId = targetWsId ?? workspaceTarget?.id
-
-  // Close the agent menu on an outside click.
-  useEffect(() => {
-    if (!agentMenuOpen) return
-    const onDown = (e: MouseEvent) => {
-      if (agentBoxRef.current && !agentBoxRef.current.contains(e.target as Node)) {
-        setAgentMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', onDown)
-    return () => document.removeEventListener('mousedown', onDown)
-  }, [agentMenuOpen])
 
   useEffect(() => {
     if (!workspaceMenuOpen) return
@@ -506,23 +177,17 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   const submit = async () => {
     const prompt = value.trim()
     if (!prompt || launching) return
-    if (!credentialSelectionReady) return
+    if (!launchConfig.credentialSelectionReady) return
     if (effectiveAgent === null) {
-      setAgentMenuOpen(true)
+      launchSelectorsRef.current?.openAgentMenu()
       return
     }
     setError(null)
     setLaunching(true)
     try {
-      let readiness = runtimeReadiness
-      let runtimeRow = readiness?.agents[effectiveAgent] ?? null
+      const runtimeRow = await launchConfig.checkSelectedRuntime()
       if (runtimeRow?.ready !== true) {
-        readiness = await probeAgentRuntimeReadiness(effectiveAgent)
-        setRuntimeReadiness(readiness)
-        runtimeRow = readiness.agents[effectiveAgent] ?? null
-      }
-      if (runtimeRow?.ready !== true) {
-        if (runtimeRow?.repairTarget === 'ai-provider' || noCreds) {
+        if (runtimeRow?.repairTarget === 'ai-provider' || launchConfig.needsProviderSetup) {
           goConfigureProvider()
           return
         }
@@ -533,16 +198,15 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
       // selected a vault credential for this launch. The provider pill is an
       // explicit per-Workspace choice: always send it so the backend can write
       // the selected provider/model before spawning the runtime.
-      const credentialSlug = resolveQuickChatCredentialSlug(needsCred, effectiveCred)
       // On success this focuses the new session's terminal tab; the landing tab
       // stays open in the background, so clear it for next time.
       const workspaceId = await quickChat(
         prompt,
         effectiveAgent,
-        credentialSlug,
+        launchConfig.launchCredentialSlug,
         effectiveTargetWorkspaceId,
       )
-      setRecentChatWorkspaceId(workspaceId)
+      launchPreferences.adoptRecentChatWorkspace(workspaceId)
       setValue('')
     } catch (err) {
       // Backend says no compatible credential — bounce to the provider settings.
@@ -670,7 +334,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                           role="menuitem"
                           onClick={() => {
                             setSelectedWorkspaceId(workspace.id)
-                            setPickedCred(null)
+                            launchConfig.resetCredentialSelection()
                             setWorkspaceMenuOpen(false)
                           }}
                           className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : 'text-text'}`}
@@ -685,129 +349,11 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 )}
               </div>
 
-              {/* Agent runtime picker — one of the installed CLIs. */}
-              <div ref={agentBoxRef} className="relative">
-                <button
-                  type="button"
-                  onClick={() => setAgentMenuOpen((o) => !o)}
-                  disabled={targetCliAgents.length === 0}
-                  aria-haspopup="menu"
-                  aria-expanded={agentMenuOpen}
-                  aria-label={t('chatLanding.selectAgent')}
-                  className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {SelectedIcon ? <SelectedIcon className="w-3 h-3" /> : null}
-                  <span className="truncate">{selectedInfo?.displayName ?? t('chatLanding.selectAgent')}</span>
-                  <ChevronDown className="w-3 h-3 opacity-60" />
-                </button>
-                {agentMenuOpen && targetCliAgents.length > 0 && (
-                  <div
-                    role="menu"
-                    className="oa-popover-enter absolute bottom-full left-0 mb-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
-                  >
-                    {targetCliAgents.map((a) => {
-                      const Icon = AGENT_ICONS[a.id]
-                      const active = a.id === effectiveAgent
-                      const missing = !isInstalled(a)
-                      return (
-                        <button
-                          key={a.id}
-                          type="button"
-                          role="menuitem"
-                          onClick={() => {
-                            setSelectedAgent(a.id)
-                            setPickedCred(null)
-                            void setDefaultAgent(a.id)
-                            setAgentMenuOpen(false)
-                          }}
-                          className={`w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : missing ? 'text-text-muted' : 'text-text'}`}
-                        >
-                          {Icon ? <Icon className="w-3.5 h-3.5 shrink-0" /> : <span className="w-3.5 shrink-0" />}
-                          <span className="flex-1">{a.displayName}</span>
-                          {missing && (
-                            <span className="text-[10px] text-text-muted shrink-0">
-                              {t('chatLanding.agentNotInstalled')}
-                            </span>
-                          )}
-                          {active && <Check className="w-3.5 h-3.5 shrink-0" />}
-                        </button>
-                      )
-                    })}
-                  </div>
-                )}
-              </div>
-
-              {/* Credential picker — only for loginless runtimes (opencode/pi),
-                  which can't start without an injected provider. When none is
-                  configured, the pill becomes a shortcut to set one up. */}
-              {needsCred && noCreds && (
-                <button
-                  type="button"
-                  onClick={goConfigureProvider}
-                  className="oa-pressable inline-flex min-h-8 items-center gap-1.5 text-[11px] text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2.5 py-1 rounded-md hover:bg-amber-500/20"
-                >
-                  <KeyRound className="w-3 h-3" />
-                  {t('chatLanding.configureProvider')}
-                </button>
-              )}
-              {needsCred && !noCreds && creds && creds.length > 0 && (
-                <div ref={credBoxRef} className="relative">
-                  <button
-                    type="button"
-                    onClick={() => setCredMenuOpen((o) => !o)}
-                    aria-haspopup="menu"
-                    aria-expanded={credMenuOpen}
-                    aria-label={t('chatLanding.selectCredential')}
-                    className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 text-[11px] text-text-muted bg-bg-tertiary px-2.5 py-1 rounded-md hover:text-text"
-                  >
-                    <KeyRound className="w-3 h-3" />
-                    <span className="truncate">{credInfo?.label?.trim() || credInfo?.slug || t('chatLanding.selectCredential')}</span>
-                    <ChevronDown className="w-3 h-3 opacity-60" />
-                  </button>
-                  {credMenuOpen && (
-                    <div
-                      role="menu"
-                      className="oa-popover-enter absolute bottom-full left-0 mb-1 min-w-[180px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
-                    >
-                      {creds.map((cr) => {
-                        const active = cr.slug === effectiveCred
-                        return (
-                          <button
-                            key={cr.slug}
-                            type="button"
-                            role="menuitem"
-                            onClick={() => {
-                              setPickedCred(cr.slug)
-                              if (effectiveAgent === 'opencode' || effectiveAgent === 'pi') {
-                                setLastCredentialByAgent((current) => ({
-                                  ...current,
-                                  [effectiveAgent]: cr.slug,
-                                }))
-                                void preferencesApi.rememberQuickChatCredential(effectiveAgent, cr.slug)
-                                  .then((preferences) => setLastCredentialByAgent(preferences.lastCredentialByAgent))
-                                  .catch(() => undefined)
-                              }
-                              setCredMenuOpen(false)
-                            }}
-                            className={`w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : 'text-text'}`}
-                          >
-                            <span className="min-w-0 flex-1">
-                              <span className="block truncate">{cr.label?.trim() || cr.slug}</span>
-                              {cr.resolvedModel && (
-                                <span className="block truncate text-[10px] text-text-muted">
-                                  {cr.resolvedModel}
-                                </span>
-                              )}
-                            </span>
-                            <span className="text-[10px] text-text-muted shrink-0">{cr.vendor}</span>
-                            {active && <Check className="w-3.5 h-3.5 shrink-0" />}
-                          </button>
-                        )
-                      })}
-                    </div>
-                  )}
-                </div>
-              )}
+              <AgentLaunchSelectors
+                ref={launchSelectorsRef}
+                config={launchConfig}
+                onConfigureProvider={goConfigureProvider}
+              />
             </div>
             <div className="flex items-center justify-end gap-1.5">
               <button
@@ -831,50 +377,12 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
               </button>
             </div>
           </div>
-          {needsCred && credInfo && quickChatAiDetails && (
-            <div className="mx-1 mt-2 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 border-t border-border/50 px-1 pt-2 text-[10.5px] text-text-muted">
-              <span
-                className="inline-flex min-w-0 max-w-full items-center gap-1"
-                aria-label={t('chatLanding.modelSummary', {
-                  model: quickChatAiDetails.model ?? t('chatLanding.runtimeDefaultModel'),
-                })}
-                title={quickChatAiDetails.model ?? t('chatLanding.runtimeDefaultModel')}
-              >
-                <Cpu className="h-3 w-3 shrink-0" />
-                <span className="truncate font-mono text-text/80">
-                  {quickChatAiDetails.model ?? t('chatLanding.runtimeDefaultModel')}
-                </span>
-              </span>
-              <span aria-hidden className="text-text-muted/40">·</span>
-              <span
-                className="inline-flex shrink-0 items-center gap-1"
-                aria-label={t('chatLanding.contextSummary', {
-                  limit: formatContextWindow(quickChatAiDetails.contextWindow),
-                })}
-              >
-                <Gauge className="h-3 w-3" />
-                {t('chatLanding.contextSummary', {
-                  limit: formatContextWindow(quickChatAiDetails.contextWindow),
-                })}
-              </span>
-              <button
-                type="button"
-                onClick={adjustQuickChatAi}
-                className="oa-pressable inline-flex min-h-7 items-center gap-1 rounded-md px-2 py-1 text-accent hover:bg-accent/10 sm:ml-auto"
-                aria-label={credentialWorkspace
-                  ? t('chatLanding.adjustWorkspaceAi')
-                  : t('chatLanding.providerSettings')}
-                title={credentialWorkspace
-                  ? t('chatLanding.adjustWorkspaceAi')
-                  : t('chatLanding.providerSettings')}
-              >
-                <Settings2 className="h-3 w-3" />
-                {credentialWorkspace
-                  ? t('chatLanding.adjustWorkspaceAi')
-                  : t('chatLanding.providerSettings')}
-              </button>
-            </div>
-          )}
+          <AgentLaunchDetails
+            config={launchConfig}
+            hasWorkspaceTarget={credentialWorkspace !== null && credentialWorkspace !== undefined}
+            onAdjustAi={adjustQuickChatAi}
+            className="mx-1 mt-2 border-t border-border/50 px-1 pt-2"
+          />
         </div>
 
         {error !== null && <div className="text-[12px] text-red px-1">{error}</div>}
@@ -882,12 +390,12 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
         {/* Runtime guidance. A normal packaged build should expose managed Pi;
             no-runtime is now an abnormal setup/debug state, not a prompt to
             make a fresh user install a CLI. */}
-        {agentsKnown && !anyInstalled ? (
+        {launchConfig.agentsKnown && !launchConfig.anyInstalled ? (
           <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-[12px] space-y-1.5">
             <div className="font-medium text-text">{t('chatLanding.noAgentsTitle')}</div>
             <p className="text-text-muted">{t('chatLanding.noAgentsBody')}</p>
           </div>
-        ) : selectedMissing && selectedInfo ? (
+        ) : launchConfig.selectedMissing && selectedInfo ? (
           <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-[12px] space-y-1.5">
             <p className="text-text-muted">
               {t('chatLanding.agentMissing', { name: selectedInfo.displayName })}
@@ -915,7 +423,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
 
         {/* Loginless runtime has no provider configured — the conversion
             dead-end. Guide the user to set one up instead of a silent failure. */}
-        {noCreds && selectedInfo && (
+        {launchConfig.noCredentials && selectedInfo && (
           <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-[12px] space-y-1.5">
             <p className="text-text-muted">
               {t('chatLanding.noCredBody', { name: selectedInfo.displayName })}
@@ -933,9 +441,12 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
 
         {/* The selected cred differs from the one today's workspace already uses
             — sending switches it. A notice, not a block (the user chose it). */}
-        {willOverwrite && credInfo && (
+        {launchConfig.willOverwriteCredential && launchConfig.credential && (
           <div className="rounded-lg border border-border/60 bg-bg-secondary/60 px-3 py-2 text-[12px] text-text-muted">
-            {t('chatLanding.credOverwrite', { from: detectedCred ?? '', to: credInfo.slug })}
+            {t('chatLanding.credOverwrite', {
+              from: launchConfig.detectedCredential?.slug ?? '',
+              to: launchConfig.credential.slug,
+            })}
           </div>
         )}
 

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorkspacesContextValue } from '../contexts/workspaces-context'
@@ -16,11 +16,15 @@ const mocks = vi.hoisted(() => ({
   getAgentRuntimeReadiness: vi.fn(),
   probeAgentRuntimeReadiness: vi.fn(),
   listAgentCredentials: vi.fn(),
+  detectWorkspaceCredential: vi.fn(),
+  getAgentReadiness: vi.fn(),
+  getWorkspaceCredentialDefaults: vi.fn(),
   quickStartWorkspaceManager: vi.fn(),
   openWebPiSession: vi.fn(),
   resumeSession: vi.fn(),
   getQuickChat: vi.fn(),
   rememberQuickChatCredential: vi.fn(),
+  openAgentConfig: vi.fn(),
 }))
 
 vi.mock('../contexts/workspaces-context', () => ({
@@ -40,6 +44,8 @@ vi.mock('../components/workspace/api', async (importOriginal) => {
     getAgentRuntimeReadiness: mocks.getAgentRuntimeReadiness,
     probeAgentRuntimeReadiness: mocks.probeAgentRuntimeReadiness,
     listAgentCredentials: mocks.listAgentCredentials,
+    detectWorkspaceCredential: mocks.detectWorkspaceCredential,
+    getAgentReadiness: mocks.getAgentReadiness,
     quickStartWorkspaceManager: mocks.quickStartWorkspaceManager,
     openWebPiSession: mocks.openWebPiSession,
     resumeSession: mocks.resumeSession,
@@ -50,6 +56,12 @@ vi.mock('../api/preferences', () => ({
   preferencesApi: {
     getQuickChat: mocks.getQuickChat,
     rememberQuickChatCredential: mocks.rememberQuickChatCredential,
+  },
+}))
+
+vi.mock('../api/config', () => ({
+  configApi: {
+    getWorkspaceCredentialDefaults: mocks.getWorkspaceCredentialDefaults,
   },
 }))
 
@@ -110,7 +122,7 @@ function context(defaultAgent: string): WorkspacesContextValue {
     resumeSession: vi.fn(async () => undefined),
     openWebPiSession: vi.fn(async () => undefined),
     requestDeleteSession: vi.fn(),
-    openAgentConfig: vi.fn(),
+    openAgentConfig: mocks.openAgentConfig,
     saveWorkspaceMetadata: vi.fn(async () => undefined),
     renameWorkspace: vi.fn(async () => undefined),
   }
@@ -142,6 +154,18 @@ beforeEach(async () => {
   mocks.getAgentRuntimeReadiness.mockResolvedValue(readiness())
   mocks.probeAgentRuntimeReadiness.mockResolvedValue(readiness())
   mocks.listAgentCredentials.mockResolvedValue([])
+  mocks.detectWorkspaceCredential.mockResolvedValue({
+    slug: null,
+    model: null,
+    contextWindow: null,
+    wireShape: null,
+  })
+  mocks.getAgentReadiness.mockResolvedValue({ agents: {} })
+  mocks.getWorkspaceCredentialDefaults.mockResolvedValue({
+    defaults: {},
+    compatibleByAgent: {},
+    contextWindow: 256_000,
+  })
   mocks.getQuickChat.mockResolvedValue({ lastCredentialByAgent: {}, recentChatWorkspaceId: null })
   mocks.rememberQuickChatCredential.mockResolvedValue(undefined)
   mocks.openWebPiSession.mockResolvedValue(undefined)
@@ -174,6 +198,7 @@ describe('WorkspaceManagerPage runtime selection', () => {
 
     const picker = await screen.findByRole('button', { name: 'Select agent' })
     expect(picker.textContent).toContain('Codex')
+    expect(screen.getByText('Model and context are managed by Codex')).toBeTruthy()
     fireEvent.click(picker)
 
     for (const name of ['Claude', 'Codex', 'OpenCode', 'Pi']) {
@@ -197,7 +222,76 @@ describe('WorkspaceManagerPage runtime selection', () => {
     })
   })
 
-  it('keeps the loginless provider selection in the shared per-runtime preferences', async () => {
+  it('shows and launches the Manager workspace model/context from the shared config', async () => {
+    mocks.useWorkspaces.mockImplementation(() => context('pi'))
+    mocks.listAgentCredentials.mockResolvedValue([
+      {
+        slug: 'google-1',
+        label: 'Gemini',
+        vendor: 'google',
+        authType: 'api-key',
+        wires: { 'google-generative-ai': 'https://generativelanguage.googleapis.com/v1beta' },
+        resolvedModel: 'gemini-3.1-flash-lite',
+      },
+      {
+        slug: 'deepseek-1',
+        label: 'DeepSeek',
+        vendor: 'deepseek',
+        authType: 'api-key',
+        wires: { 'openai-chat': 'https://api.deepseek.com' },
+        resolvedModel: 'deepseek-chat',
+      },
+    ])
+    mocks.getQuickChat.mockResolvedValue({
+      lastCredentialByAgent: { pi: 'deepseek-1' },
+      recentChatWorkspaceId: null,
+    })
+    mocks.detectWorkspaceCredential.mockResolvedValue({
+      slug: 'google-1',
+      model: 'gemini-3.1-flash-lite',
+      contextWindow: 256_000,
+      wireShape: 'google-generative-ai',
+    })
+    mocks.getAgentReadiness.mockResolvedValue({
+      agents: {
+        pi: {
+          agent: 'pi',
+          ready: true,
+          requiresCredential: true,
+          source: 'workspace-config',
+          hasWorkspaceConfig: true,
+          hasUsableWorkspaceConfig: true,
+          detectedCredentialSlug: 'google-1',
+          compatibleCredentialSlugs: ['google-1'],
+          injectableCredentialSlugs: ['google-1'],
+        },
+      },
+    })
+
+    render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
+
+    expect((await screen.findByRole('button', { name: 'AI provider' })).textContent).toContain('Gemini')
+    expect(screen.getByLabelText('Model gemini-3.1-flash-lite')).toBeTruthy()
+    expect(screen.getByLabelText('256K context')).toBeTruthy()
+    expect(screen.queryByText('Agent runtime')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Adjust workspace AI' }))
+    expect(mocks.openAgentConfig).toHaveBeenCalledWith('workspace-manager', 'pi', 'ai')
+
+    fireEvent.click(screen.getByRole('button', { name: 'AI provider' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /DeepSeek/ }))
+    expect(screen.getByLabelText('Model deepseek-chat')).toBeTruthy()
+    expect(mocks.rememberQuickChatCredential).toHaveBeenCalledWith('pi', 'deepseek-1')
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Audit issues.' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start manager' }))
+
+    await waitFor(() => expect(mocks.quickStartWorkspaceManager).toHaveBeenCalledWith(
+      'Audit issues.',
+      'pi',
+      'deepseek-1',
+    ))
+  })
+
+  it('does not flash a fallback credential before remembered preferences resolve', async () => {
     mocks.useWorkspaces.mockImplementation(() => context('pi'))
     mocks.listAgentCredentials.mockResolvedValue([{
       slug: 'google-1',
@@ -207,22 +301,56 @@ describe('WorkspaceManagerPage runtime selection', () => {
       wires: { 'google-generative-ai': 'https://generativelanguage.googleapis.com/v1beta' },
       resolvedModel: 'gemini-3.1-flash-lite',
     }])
-    mocks.getQuickChat.mockResolvedValue({
-      lastCredentialByAgent: { pi: 'google-1' },
-      recentChatWorkspaceId: null,
+    let resolvePreferences!: (value: {
+      lastCredentialByAgent: Record<string, string>
+      recentChatWorkspaceId: string | null
+    }) => void
+    mocks.getQuickChat.mockReturnValue(new Promise((resolve) => {
+      resolvePreferences = resolve
+    }))
+
+    render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
+
+    await waitFor(() => expect(mocks.listAgentCredentials).toHaveBeenCalled())
+    expect(screen.getByRole('button', { name: 'AI provider' }).textContent).toContain('AI provider')
+    expect(screen.queryByText('Gemini')).toBeNull()
+    expect(screen.queryByLabelText('Model gemini-3.1-flash-lite')).toBeNull()
+
+    await act(async () => {
+      resolvePreferences({ lastCredentialByAgent: { pi: 'google-1' }, recentChatWorkspaceId: null })
+    })
+    expect((await screen.findByRole('button', { name: 'AI provider' })).textContent).toContain('Gemini')
+  })
+
+  it('shows model/context for a usable hand-edited Manager config without a vault credential', async () => {
+    mocks.useWorkspaces.mockImplementation(() => context('pi'))
+    mocks.detectWorkspaceCredential.mockResolvedValue({
+      slug: null,
+      model: 'local-manual-model',
+      contextWindow: 128_000,
+      wireShape: 'openai-chat',
+    })
+    mocks.getAgentReadiness.mockResolvedValue({
+      agents: {
+        pi: {
+          agent: 'pi',
+          ready: true,
+          requiresCredential: true,
+          source: 'workspace-config',
+          hasWorkspaceConfig: true,
+          hasUsableWorkspaceConfig: true,
+          detectedCredentialSlug: null,
+          compatibleCredentialSlugs: [],
+          injectableCredentialSlugs: [],
+        },
+      },
     })
 
     render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
 
-    await screen.findByRole('combobox', { name: 'AI provider' })
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Audit issues.' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Start manager' }))
-
-    await waitFor(() => expect(mocks.quickStartWorkspaceManager).toHaveBeenCalledWith(
-      'Audit issues.',
-      'pi',
-      'google-1',
-    ))
+    expect(await screen.findByLabelText('Model local-manual-model')).toBeTruthy()
+    expect(screen.getByLabelText('128K context')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'AI provider' })).toBeNull()
   })
 
   it('resumes a paused non-Pi Manager Session through the native terminal path', async () => {

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -5,41 +5,34 @@ import {
   ArrowUp,
   Bot,
   Building2,
-  Check,
-  ChevronDown,
   ChevronRight,
   ClipboardCheck,
-  Code2,
-  Cpu,
   GitMerge,
-  KeyRound,
   Loader2,
   Network,
   RefreshCw,
-  Sparkles,
   UsersRound,
   type LucideIcon,
 } from 'lucide-react'
 import '@xterm/xterm/css/xterm.css'
 
-import { preferencesApi } from '../api/preferences'
-import type { QuickChatPreferences } from '../api/preferences'
 import {
-  getAgentRuntimeReadiness,
   getWorkspaceManager,
-  listAgentCredentials,
   MANAGER_WORKSPACE_ID,
   openWebPiSession,
-  probeAgentRuntimeReadiness,
   quickStartWorkspaceManager,
   resumeSession,
   type ManagerWorkspaceSnapshot,
-  type SavedCredential,
 } from '../components/workspace/api'
+import {
+  AgentLaunchDetails,
+  AgentLaunchSelectors,
+  type AgentLaunchSelectorsHandle,
+} from '../components/workspace/AgentLaunchControls'
 import { TerminalView } from '../components/workspace/Terminal'
 import { WebPiView } from '../components/workspace/WebPiView'
 import { useWorkspaces } from '../contexts/workspaces-context'
-import { isLoginlessAgent, resolveAgentRuntime } from '../lib/agentRuntime'
+import { useAgentLaunchConfig, useAgentLaunchPreferences } from '../hooks/useAgentLaunchConfig'
 import { useWorkspace } from '../tabs/store'
 import type { ViewSpec } from '../tabs/types'
 import { keyMapForAgent } from '../components/workspace/terminalInput'
@@ -47,45 +40,30 @@ import { keyMapForAgent } from '../components/workspace/terminalInput'
 type ManagerSpec = Extract<ViewSpec, { kind: 'workspace-manager' }>
 
 const SUGGESTION_ICONS = [ClipboardCheck, UsersRound, GitMerge, RefreshCw] as const
-const AGENT_ICONS: Record<string, LucideIcon> = {
-  claude: Sparkles,
-  codex: Cpu,
-  opencode: Code2,
-  pi: Bot,
-}
 
 export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
   const { t } = useTranslation()
-  const { agents, defaultAgent, setDefaultAgent } = useWorkspaces()
+  const { agents, defaultAgent, setDefaultAgent, openAgentConfig } = useWorkspaces()
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
   const [manager, setManager] = useState<ManagerWorkspaceSnapshot | null>(null)
-  const [credentials, setCredentials] = useState<SavedCredential[] | null>(null)
-  const [credentialSlug, setCredentialSlug] = useState<string | null>(null)
-  const [runtimeReadiness, setRuntimeReadiness] = useState<Awaited<ReturnType<typeof getAgentRuntimeReadiness>> | null>(null)
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
-  const [agentMenuOpen, setAgentMenuOpen] = useState(false)
   const [draft, setDraft] = useState('')
   const [loading, setLoading] = useState(true)
   const [launching, setLaunching] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const openingRef = useRef<string | null>(null)
-  const agentBoxRef = useRef<HTMLDivElement>(null)
+  const launchSelectorsRef = useRef<AgentLaunchSelectorsHandle>(null)
 
   const runtimeAgents = useMemo(() => agents.filter((agent) => agent.kind !== 'utility'), [agents])
-  const effectiveAgent = resolveAgentRuntime(runtimeAgents, selectedAgent, defaultAgent, runtimeReadiness)
-  const selectedRuntime = runtimeAgents.find((agent) => agent.id === effectiveAgent) ?? null
-  const SelectedRuntimeIcon = selectedRuntime ? AGENT_ICONS[selectedRuntime.id] : undefined
-  const needsCredential = isLoginlessAgent(effectiveAgent)
-  const selectedReadiness = effectiveAgent ? runtimeReadiness?.agents[effectiveAgent] ?? null : null
-  const selectedRuntimeUsesGlobalConfig = selectedReadiness?.ready === true && (
-    selectedReadiness.source === 'global-config' ||
-    selectedReadiness.source === 'global-login' ||
-    selectedReadiness.source === 'managed-runtime'
-  )
-  const needsProviderSetup = needsCredential && !selectedRuntimeUsesGlobalConfig && credentials?.length === 0
-  const credentialSelectionReady = !needsCredential || selectedRuntimeUsesGlobalConfig || (
-    credentials !== null && credentialSlug !== null
-  )
+  const launchPreferences = useAgentLaunchPreferences()
+  const launchConfig = useAgentLaunchConfig({
+    agents: runtimeAgents,
+    defaultAgent,
+    setDefaultAgent,
+    preferences: launchPreferences,
+    workspaceId: MANAGER_WORKSPACE_ID,
+    hasWorkspace: true,
+  })
+  const effectiveAgent = launchConfig.effectiveAgent
 
   const refresh = useCallback(async (): Promise<void> => {
     try {
@@ -100,45 +78,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
 
   useEffect(() => {
     void refresh()
-    void getAgentRuntimeReadiness()
-      .then(setRuntimeReadiness)
-      .catch(() => setRuntimeReadiness(null))
   }, [refresh])
-
-  useEffect(() => {
-    if (!effectiveAgent || !isLoginlessAgent(effectiveAgent)) {
-      setCredentials([])
-      setCredentialSlug(null)
-      return
-    }
-    let live = true
-    setCredentials(null)
-    void Promise.all([
-      listAgentCredentials(effectiveAgent).catch(() => []),
-      preferencesApi.getQuickChat().catch((): QuickChatPreferences => ({ lastCredentialByAgent: {}, recentChatWorkspaceId: null })),
-    ]).then(([available, preferences]) => {
-      if (!live) return
-      setCredentials(available)
-      const remembered = preferences.lastCredentialByAgent[effectiveAgent]
-      setCredentialSlug(
-        remembered && available.some((credential) => credential.slug === remembered)
-          ? remembered
-          : available[0]?.slug ?? null,
-      )
-    })
-    return () => { live = false }
-  }, [effectiveAgent])
-
-  useEffect(() => {
-    if (!agentMenuOpen) return
-    const onDown = (event: MouseEvent) => {
-      if (agentBoxRef.current && !agentBoxRef.current.contains(event.target as Node)) {
-        setAgentMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', onDown)
-    return () => document.removeEventListener('mousedown', onDown)
-  }, [agentMenuOpen])
 
   const sessionId = spec.params.sessionId
   const session = sessionId
@@ -174,23 +114,17 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
   const submit = async (): Promise<void> => {
     const prompt = draft.trim()
     if (!prompt || launching) return
-    if (!credentialSelectionReady) return
+    if (!launchConfig.credentialSelectionReady) return
     if (!effectiveAgent) {
-      setAgentMenuOpen(true)
+      launchSelectorsRef.current?.openAgentMenu()
       return
     }
     setLaunching(true)
     setError(null)
     try {
-      let readiness = runtimeReadiness
-      let runtimeRow = readiness?.agents[effectiveAgent] ?? null
+      const runtimeRow = await launchConfig.checkSelectedRuntime()
       if (runtimeRow?.ready !== true) {
-        readiness = await probeAgentRuntimeReadiness(effectiveAgent)
-        setRuntimeReadiness(readiness)
-        runtimeRow = readiness.agents[effectiveAgent] ?? null
-      }
-      if (runtimeRow?.ready !== true) {
-        if (runtimeRow?.repairTarget === 'ai-provider' || needsProviderSetup) {
+        if (runtimeRow?.repairTarget === 'ai-provider' || launchConfig.needsProviderSetup) {
           openOrFocus({ kind: 'settings', params: { category: 'ai-provider' } })
           return
         }
@@ -200,7 +134,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
       const result = await quickStartWorkspaceManager(
         prompt,
         effectiveAgent,
-        needsCredential ? credentialSlug ?? undefined : undefined,
+        launchConfig.launchCredentialSlug,
       )
       setManager(result.manager)
       setDraft('')
@@ -217,6 +151,18 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
       event.preventDefault()
       void submit()
     }
+  }
+
+  const goConfigureProvider = () => {
+    openOrFocus({ kind: 'settings', params: { category: 'ai-provider' } })
+  }
+
+  const adjustManagerAi = () => {
+    if (effectiveAgent === 'opencode' || effectiveAgent === 'pi') {
+      openAgentConfig(MANAGER_WORKSPACE_ID, effectiveAgent, 'ai')
+      return
+    }
+    goConfigureProvider()
   }
 
   if (sessionId && session) {
@@ -288,13 +234,8 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
               {t('workspaceManager.subheading')}
             </p>
           </div>
-          <div className="workspace-manager-stats grid grid-cols-2 gap-2">
+          <div className="workspace-manager-stats grid max-w-56 grid-cols-1 gap-2">
             <ManagerStat icon={Building2} label={t('workspaceManager.scope')} value={loading ? '—' : String(manager?.activeWorkspaceCount ?? 0)} />
-            <ManagerStat
-              icon={Bot}
-              label={t('workspaceManager.runtime')}
-              value={selectedRuntime?.displayName ?? t('chatLanding.selectAgent')}
-            />
           </div>
         </div>
 
@@ -308,93 +249,30 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
             className="min-h-28 w-full resize-none bg-transparent px-1 py-1 text-[14px] leading-relaxed text-text outline-none placeholder:text-text-muted/55 md:text-[15px]"
           />
           <div className="workspace-manager-composer-footer mt-3 flex flex-col gap-2 border-t border-border/60 pt-3">
-            <div className="flex min-w-0 items-center gap-2">
-              <div ref={agentBoxRef} className="relative">
-                <button
-                  type="button"
-                  onClick={() => setAgentMenuOpen((open) => !open)}
-                  disabled={runtimeAgents.length === 0}
-                  aria-haspopup="menu"
-                  aria-expanded={agentMenuOpen}
-                  aria-label={t('chatLanding.selectAgent')}
-                  className="oa-pressable inline-flex min-h-8 max-w-48 items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 text-[11px] text-text-muted hover:text-text disabled:opacity-50"
-                >
-                  {SelectedRuntimeIcon ? <SelectedRuntimeIcon size={12} /> : <Bot size={12} />}
-                  <span className="truncate">{selectedRuntime?.displayName ?? t('chatLanding.selectAgent')}</span>
-                  <ChevronDown size={12} className="opacity-60" />
-                </button>
-                {agentMenuOpen && runtimeAgents.length > 0 && (
-                  <div
-                    role="menu"
-                    className="oa-popover-enter absolute bottom-full left-0 z-10 mb-1 min-w-48 rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg"
-                  >
-                    {runtimeAgents.map((agent) => {
-                      const Icon = AGENT_ICONS[agent.id]
-                      const active = agent.id === effectiveAgent
-                      const missing = agent.installed === false
-                      return (
-                        <button
-                          key={agent.id}
-                          type="button"
-                          role="menuitem"
-                          onClick={() => {
-                            setSelectedAgent(agent.id)
-                            void setDefaultAgent(agent.id)
-                            setAgentMenuOpen(false)
-                          }}
-                          className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : missing ? 'text-text-muted' : 'text-text'}`}
-                        >
-                          {Icon ? <Icon size={14} className="shrink-0" /> : <span className="w-3.5 shrink-0" />}
-                          <span className="min-w-0 flex-1 truncate">{agent.displayName}</span>
-                          {missing && <span className="shrink-0 text-[10px] text-text-muted">{t('chatLanding.agentNotInstalled')}</span>}
-                          {active && <Check size={14} className="shrink-0" />}
-                        </button>
-                      )
-                    })}
-                  </div>
-                )}
+            <div className="workspace-manager-composer-actions flex min-w-0 flex-col gap-2">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <AgentLaunchSelectors
+                  ref={launchSelectorsRef}
+                  config={launchConfig}
+                  onConfigureProvider={goConfigureProvider}
+                />
               </div>
-              {needsCredential && credentials && credentials.length > 0 ? (
-                <label className="relative inline-flex min-w-0 items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1.5 text-[11px] text-text-muted">
-                  <KeyRound size={12} className="shrink-0" />
-                  <select
-                    aria-label={t('workspaceManager.credential')}
-                    value={credentialSlug ?? ''}
-                    onChange={(event) => {
-                      const next = event.target.value || null
-                      setCredentialSlug(next)
-                      if (isLoginlessAgent(effectiveAgent)) {
-                        void preferencesApi.rememberQuickChatCredential(effectiveAgent, next).catch(() => undefined)
-                      }
-                    }}
-                    className="max-w-44 appearance-none truncate bg-transparent pr-3 text-text outline-none"
-                  >
-                    {credentials.map((credential) => (
-                      <option key={credential.slug} value={credential.slug}>
-                        {credential.label?.trim() || credential.slug}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              ) : needsProviderSetup ? (
-                <button
-                  type="button"
-                  onClick={() => openOrFocus({ kind: 'settings', params: { category: 'ai-provider' } })}
-                  className="oa-pressable inline-flex items-center gap-1.5 rounded-md bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-600 dark:text-amber-400"
-                >
-                  <KeyRound size={12} /> {t('workspaceManager.configureCredential')}
-                </button>
-              ) : null}
+              <button
+                type="button"
+                onClick={() => void submit()}
+                disabled={!draft.trim() || launching || !launchConfig.credentialSelectionReady}
+                className="oa-pressable inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-accent px-4 text-[12px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-45"
+              >
+                {launching ? <Loader2 size={14} className="animate-spin" /> : <ArrowUp size={14} />}
+                {launching ? t('workspaceManager.launching') : t('workspaceManager.send')}
+              </button>
             </div>
-            <button
-              type="button"
-              onClick={() => void submit()}
-              disabled={!draft.trim() || launching || !credentialSelectionReady}
-              className="oa-pressable inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-accent px-4 text-[12px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-45"
-            >
-              {launching ? <Loader2 size={14} className="animate-spin" /> : <ArrowUp size={14} />}
-              {launching ? t('workspaceManager.launching') : t('workspaceManager.send')}
-            </button>
+            <AgentLaunchDetails
+              config={launchConfig}
+              hasWorkspaceTarget
+              onAdjustAi={adjustManagerAi}
+              className="border-t border-border/45 pt-2"
+            />
           </div>
         </section>
 


### PR DESCRIPTION
## What changed

- add a canonical `useAgentLaunchConfig` / `useAgentLaunchPreferences` boundary for runtime readiness, credential precedence, model, context, and launch parameters
- share the runtime/provider selectors and launch metadata between Quick Chat and Workspace Manager
- make the reserved Manager Workspace participate in agent config and readiness routes without registering it as a business Workspace
- remove the duplicate top-level Manager runtime stat and show truthful model/context metadata in the composer
- preserve native Claude/Codex ownership messaging and handle delayed preferences, hand-edited configs, deleted credentials, and responsive Manager layout
- document the shared ownership and manual acceptance path

## Why

Quick Chat and Workspace Manager had independently evolved launch controls. The Manager surface could select runtimes but omitted provider/model/context details and could not read or adjust the reserved Workspace configuration. Centralizing the state machine prevents the two launch surfaces from drifting and makes the actual next-launch configuration visible.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (3,085 passed, 8 skipped)
- targeted shared-launch and Manager route/UI tests (53 passed)
- `pnpm build` (15/15 packages)
- `pnpm electron:smoke:pty`
- real browser: switched Manager between OpenCode and Pi, confirmed exact model/context, opened the reserved Workspace AI editor, launched Pi/WebPi to an `OK` response, then launched Claude in the native TUI and restored the original OpenCode default
- `pnpm test:e2e`: 32 passed, 3 skipped; the only failure was the existing live BLS test because this machine's TLS connection to `api.bls.gov` was reset before establishment
