### PR TITLE
feat(remote): make private-host setup self-managing

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -249,9 +249,13 @@ Before a release becomes visible, the installer:
    install files with SHA-256 and uses the first 16 hex characters as its
    content identity.
 
-That metadata is also returned by `openalice version --json`. Managed
-`openalice remote` uses it to invoke the same ordinary installer source and
-selector on a remote host. `remote` has no independent branch/version option.
+That metadata is returned by `openalice version --json` together with the
+16-character identity derived from the immutable installed release directory.
+Managed `openalice remote` compares both provenance and content identity before
+deciding that a remote CLI matches, then invokes the same ordinary installer
+source and selector when it does not. This catches changed payload bytes even
+when the CLI semantic version and branch name are unchanged. `remote` has no
+independent branch/version option.
 
 The resulting directory is:
 
@@ -302,13 +306,15 @@ With the default installer and Runtime roots:
 │   ├── dev-<content-id>/   # only after an explicit --branch dev install
 │   └── <older-ref-or-content>/
 ├── .cli-install.lock/       # present only while an installer owns it
+├── sources/                 # selector-specific managed remote checkouts
 ├── data/                    # application state, not installer debris
 ├── workspaces/              # user work, not installer debris
 ├── provider-keys.json       # sensitive user state
 └── sealing.key              # sensitive machine-bound key
 ```
 
-The installer root and Runtime `OPENALICE_HOME` independently default to
+`sources/` is created by approved managed-remote orchestration, not by the
+installer itself. The installer root and Runtime `OPENALICE_HOME` independently default to
 `~/.openalice`. The installer does not read an `OPENALICE_HOME` override, and
 `openalice start` does not infer Runtime home from the CLI's install location.
 Either override may therefore diverge intentionally. Their default co-location
@@ -383,12 +389,16 @@ Environment inputs:
 | `OPENALICE_PI_RELEASE_BASE_URL` | Override the pinned Pi release-asset base for installer tests |
 | `OPENALICE_PI_SOURCE_DIR` | Read the exact Pi manifest/lock assets from a local fixture |
 | `OPENALICE_NPM_BIN` | Use a single alternate npm executable in installer tests |
+| `OPENALICE_INSTALL_CONTEXT` | Internal managed-remote context; returns control without local checkout/start guidance |
 | `NO_COLOR` | Disable installer color output |
 | `HOME`, `SHELL`, `PATH`, `TERM` | Standard environment used for paths, profile detection, conflicts, and color |
 
-The three Pi overrides, `OPENALICE_INSTALL_URL`, and
-`OPENALICE_INSTALL_BASE_URL` are distributor/test seams, not user-facing
-branch selectors. The same pinned SHA-256 checks still apply to local Pi
+The Pi overrides, `OPENALICE_INSTALL_URL`, and `OPENALICE_INSTALL_BASE_URL`
+are distributor/test seams, not user-facing branch selectors. Managed remote
+sets `OPENALICE_INSTALL_CONTEXT=remote` only after the user approves its outer
+plan; the installer still owns its normal transaction and prints a
+remote-appropriate heading, then returns instead of suggesting a second manual
+clone or local start. The same pinned SHA-256 checks still apply to local Pi
 assets. A real mirror design must define equivalent authenticity and version
 semantics before becoming public API.
 
@@ -468,6 +478,8 @@ It verifies:
   the resulting commands;
 - installed `server status --json` execution and inclusion of every reachable
   Server/remote module;
+- installed content identity in `openalice version --json`, so same-version
+  remote payload drift is detectable;
 - runnable OpenAlice/Pi shell and CMD launchers plus managed-Pi env injection;
 - idempotent managed PATH configuration;
 - identical-release reuse;
@@ -555,6 +567,7 @@ Docker installer smoke remains a required manual gate under
 | Pi asset SHA-256 check fails | Stop. The pinned release metadata and downloaded asset disagree; do not bypass the check |
 | A `.damaged.<pid>` directory appears | A content-addressed release no longer matched its identity; preserve it for diagnosis while the validated replacement becomes active |
 | CLI installs but localhost startup fails | Installation succeeded; continue with [[docs/local-runtime.md]] and Guardian/runtime diagnostics |
+| Remote install succeeds and then prints no clone command | Managed remote set the installer context and is continuing with its already-approved source plan |
 | Native PowerShell/CMD bootstrap is unavailable | Use the complete Electron installer, WSL, or Git Bash until a reviewed native bootstrap exists |
 
 ## Design Decisions and Next Steps

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -6,7 +6,10 @@ remote-host safety boundary, and container smoke requirements. It complements
 External notification setup is owned by [[docs/connector-service.md]].
 For private source-backed browser access over SSH, start with
 [[docs/remote-quickstart.md]]; its authoritative lifecycle and transport
-contract is owned by [[docs/remote-access.md]].
+contract is owned by [[docs/remote-access.md]]. Docker and managed remote are
+parallel first-class deployment surfaces: Docker owns an image, volume,
+healthcheck, and container lifecycle, while managed remote prepares an existing
+SSH host without requiring it to adopt Docker.
 
 ## Topology
 

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -50,7 +50,9 @@ When explicitly selected,
 it can also install missing Linux Git/Python/make/C++ tools needed to build the
 source Runtime. It does not clone OpenAlice, write application state, install
 Electron, configure a provider credential, or start a service without separate
-consent. The curl entry targets macOS, Linux, WSL, and Git Bash; native Windows
+consent. Managed `openalice remote` can separately plan and clone a private
+remote checkout after installation; that orchestration belongs to
+[[docs/remote-access.md]]. The curl entry targets macOS, Linux, WSL, and Git Bash; native Windows
 desktop distribution remains the signed Electron installer. The complete
 consent, update, filesystem, PATH, authenticity, and test contract lives in
 [[docs/cli-installer.md]].
@@ -142,9 +144,10 @@ It refuses to guess at an unreachable PID or silently stop an Electron-owned
 Runtime. Exact status classes, control fields, recovery rules, and the managed
 SSH composition live in [[docs/remote-access.md]].
 
-The detached path is still source-backed: the checkout supplies the built
-Runtime while the installed CLI supplies lifecycle and transport control. A
-future standalone bundle changes preparation, not these ownership semantics.
+The detached path is still source-backed: a user-owned or remote-managed
+checkout supplies the built Runtime while the installed CLI supplies lifecycle
+and transport control. A future standalone bundle changes preparation, not
+these ownership semantics.
 
 ## Dependency Bootstrap Direction
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -23,13 +23,13 @@ The repository now contains the source-backed Stage 0 through Stage 2 path:
 - `openalice server run|start|status|stop` provides a browserless foreground or
   detached Runtime lifecycle backed by Guardian's local control endpoint;
 - `openalice remote <target>` probes, plans, installs the ordinary CLI when
-  approved, installs missing Linux source-build tools when the checkout needs
-  preparation, starts or reuses the remote Server, and opens the same loopback
-  tunnel;
+  approved, installs missing Linux source-build tools, atomically creates or
+  fast-forwards a managed checkout when needed, starts or reuses the remote
+  Server, and opens the same loopback tunnel;
 - Electron remains a complete local desktop distribution.
 
-These commands are still source-backed preview behavior on the `dev` lane, not
-a standalone headless release. The clean Docker SSH acceptance covers the
+These commands are source-backed behavior distributed by the selected CLI
+lane, not a standalone headless release. The clean Docker SSH acceptance covers the
 management and tunnel loop; real long-latency Agent TUI measurements remain a
 separate release observation rather than a reason to invent a new terminal
 protocol preemptively.
@@ -94,8 +94,9 @@ protocol is deferred until the local/server boundary is stable.
 8. `--takeover` remains the only command-line authority to replace another
    recorded Guardian owner.
 9. Remote bootstrap reuses the invoking local CLI's recorded ordinary
-   installer source and selector. It does not carry a second SSH-only installer
-   or upload the full OpenAlice Runtime through SSH.
+   installer source, selector, and installed content identity. It does not
+   carry a second SSH-only installer or upload the full OpenAlice Runtime
+   through SSH. A missing managed checkout clones directly on the remote host.
 10. Shared Runtime facts use presentation-neutral names and versioned schemas.
     Browser layout, Electron chrome, modal state, and other client UI state do
     not become server truth.
@@ -184,25 +185,30 @@ explicit takeover decision.
 ### Managed remote command
 
 ```bash
-openalice remote <target> --app-dir <remote-checkout>
+openalice remote <target>
 ```
 
 `openalice remote` is orchestration around the same Server and SSH contracts:
 
 1. verify ordinary SSH connectivity and host-key policy;
-2. detect remote platform and an installed `openalice` CLI;
-3. probe `openalice server status --json` and protocol compatibility;
-4. compare the remote CLI version and recorded installer source/selector with
-   the invoking local CLI;
-5. if CLI install or update is required, show the exact matching plan and ask
+2. detect remote platform, home, and an installed `openalice` CLI;
+3. select the explicit `--app-dir` or a selector-specific managed checkout
+   beneath remote `OPENALICE_HOME`;
+4. probe `openalice server status --json`, source state, and protocol
+   compatibility;
+5. compare the remote CLI version, installer source/selector, and immutable
+   installed content identity with the invoking local CLI;
+6. if CLI install or update is required, show the exact matching plan and ask
    separately before calling the normal installer on the remote host;
-6. re-probe and re-plan after installation so a newly visible owner can block
+7. re-probe and re-plan after installation so a newly visible owner can block
    or require a second explicit takeover decision;
-7. run `openalice server start --app-dir ...` remotely and wait for readiness;
-8. create the same loopback tunnel used by `openalice ssh`;
-9. reuse the last successful local port for this target and remote home when it
+8. clone a missing managed checkout atomically, or fast-forward a clean managed
+   branch checkout and rebuild after the plan names that update;
+9. run `openalice server start --app-dir ...` remotely and wait for readiness;
+10. create the same loopback tunnel used by `openalice ssh`;
+11. reuse the last successful local port for this target and remote home when it
    is available, so an existing browser tab can reconnect to the same origin;
-10. open or print the local URL and stay in the foreground to own only the
+12. open or print the local URL and stay in the foreground to own only the
     tunnel.
 
 When reusing a healthy Server, `remote` takes the loopback web port from the
@@ -210,21 +216,25 @@ versioned status response. An explicitly supplied `--remote-port` must match
 that owner; a mismatch is reported before opening a misleading tunnel.
 
 Closing `openalice remote` closes the tunnel but leaves the detached remote
-Server running. Stop is explicit:
+Server running. Status and stop remain explicit but do not require users to
+compose raw SSH commands:
 
 ```bash
-ssh <target> '"$HOME/.openalice/bin/openalice" server stop'
+openalice remote <target> --status
+openalice remote <target> --stop
 ```
 
-A later convenience subcommand may issue that same remote command, but it must
-not conflate “disconnect” with “stop my remote work.”
+Neither command conflates “disconnect” with “stop my remote work.”
 
-The source-backed phase requires `--app-dir` unless the remote CLI already has
-a previously validated Runtime source or standalone bundle recorded for that
-home. It must not scan arbitrary remote directories or clone a repository
-without a separate visible plan. A future headless release bundle can remove
-the source-checkout requirement without changing the command or lifecycle
-contract.
+When `--app-dir` is absent, the source-backed phase selects a private managed
+checkout beneath the remote home. A missing checkout is cloned only after the
+visible plan is approved. A clean managed branch checkout is compared with its
+selected upstream; an available fast-forward is planned together with a Server
+restart and rebuild. Tracked changes block that update. An explicit
+`--app-dir` is user-owned: it may be cloned when wholly absent, but existing
+source is never fetched, switched, reset, or overwritten. A future headless
+release bundle can remove the source-checkout requirement without changing the
+command or lifecycle contract.
 
 `--yes` may approve the displayed install/update/start plan for automation, but
 it never implies `--takeover`. Non-interactive execution without a sufficient
@@ -382,6 +392,8 @@ protocol is required.
   verification;
 - preserve interactive SSH authentication when a terminal is available;
 - use keepalives without overriding stronger user config;
+- buffer transient command stderr while retrying, so provider control-plane
+  noise is shown only if the connection ultimately fails;
 - exit clearly when the local port cannot bind or the remote forward fails;
 - for managed `openalice remote`, prefer the last successful per-target local
   port so the old browser origin can recover after a tunnel reconnect, and
@@ -520,11 +532,13 @@ Managed bootstrap uses a plan/apply split.
 The read-only plan reports:
 
 - SSH target and resolved remote platform/architecture;
-- detected OpenAlice CLI path, version, and whether its version/install source
-  match the invoking local CLI;
+- detected OpenAlice CLI path, version, and whether its install source and
+  content identity match the invoking local CLI;
 - control protocol compatibility;
 - Server state and source/bundle root;
 - whether the selected source checkout already has complete Runtime artifacts;
+- whether source will be cloned, is user-owned, or has a safe managed
+  fast-forward available;
 - missing Git, Python 3, make, or C++ tools and the package-manager action that
   would provide them;
 - proposed install/update/start actions;
@@ -548,18 +562,25 @@ Apply rules:
    effect-specific confirmation;
 8. owner conflict: fail unless the user separately passed `--takeover`;
 9. non-interactive mode: require flags that cover every proposed mutation.
+10. missing managed source: clone to a temporary sibling and rename only after
+    a complete checkout succeeds;
+11. managed branch advanced: refuse tracked changes, stop a self-owned Server,
+    fast-forward only, rebuild, and restart; never reset user work;
+12. explicit `--app-dir`: preserve existing Git state and never manage updates.
 
 Remote SSH commands retry a small allowlist of transport failures (connection
 reset/timeout/close, key-verifier service interruption, and SSH identification
-exchange failures). Arbitrary remote command failures are never retried. After
+exchange failures). Stderr from retryable attempts remains buffered; users see
+one neutral retry line, and raw diagnostics appear only after a final failure.
+Arbitrary remote command failures are never retried. After
 an approved installer or Server-start action loses its SSH transport, managed
 remote re-probes the versioned state: it continues only when the intended CLI
 or Server is already present and compatible, otherwise it returns the original
 failure. Source preparation uses compact phase output and suppresses successful
 package/build chatter; a failed phase still includes a bounded diagnostic tail.
 
-The local orchestrator compares protocol ranges, CLI version, and install
-source; human version strings alone are insufficient. It may tolerate a newer
+The local orchestrator compares protocol ranges, CLI version, install source,
+and immutable content identity; human version strings alone are insufficient. It may tolerate a newer
 compatible Runtime, but its remote control CLI must match the invoking local
 CLI. The managed command exposes no independent branch/version selector. Test
 fixtures may replace the installer URL and payload base through test-only
@@ -613,6 +634,8 @@ Runtime model.
 - `openalice remote` plan/apply orchestration;
 - probe and bootstrap the existing CLI plus pinned managed Pi with explicit
   consent;
+- choose, atomically clone, and safely fast-forward selector-specific managed
+  source without requiring manual SSH setup;
 - when an older healthy CLI Server lacks managed Pi, infer its recorded source
   root, install Pi, stop that self-owned Server through `runtime.stop`, and
   restart it so the Guardian tree inherits the managed runtime;
@@ -690,6 +713,17 @@ correctly dropping the container-local CLI and Pi, which managed remote then
 reinstalled from `https://openalice.ai/install` without rebuilding the source
 Runtime.
 
+The same persistent service later validated the no-path managed-source flow:
+the laptop supplied only the SSH target and a volume-backed `--home`.
+`openalice remote` selected and atomically cloned the stable `master`
+checkout beneath that home, built it, reached the real `/api/version` and
+`/api/auth/status` routes through the tunnel, and left the Server alive after
+disconnect. A naturally occurring Railway key-verifier interruption appeared
+only as the neutral retry line and the operation recovered. Bundling
+`--status` into one control probe reduced the same Railway status operation
+from roughly 24 seconds and many SSH sessions to roughly 2 seconds and one SSH
+session.
+
 The redeploy also confirmed the cross-machine safety boundary. The reattached
 volume still named the removed container as Guardian and Alice owner; ordinary
 start refused it, and explicit `--takeover` still refused to signal or reclaim
@@ -750,11 +784,14 @@ permission to reclaim a shared volume.
 | missing remote CLI, interactive | shows plan; default no leaves host unchanged |
 | missing remote CLI, non-interactive | fails unless explicit approval is present |
 | incompatible running Server | explains process impact before update/restart |
-| remote source missing | fails with actionable `--app-dir` guidance; no surprise clone |
+| managed remote source missing | plan names the exact clone destination and selector; default no leaves it absent |
+| explicit source path missing | plan may clone only that exact path; an occupied non-OpenAlice path is refused |
+| managed branch advanced | clean checkout fast-forwards, rebuilds, and restarts; tracked changes block without overwrite |
 | source artifacts missing, build tools missing | plan names the tools and normal installer command; default no leaves packages untouched |
 | source artifacts complete, compiler missing | reuse artifacts without an unnecessary package-manager mutation |
 | tunnel disconnect | local command exits; remote Server and work continue |
 | reconnect | same local port is preferred; same Runtime, browser origin, and live terminal are reachable; a busy port falls back visibly |
+| status and stop | user-facing commands require no raw SSH; status uses one bundled control probe and stop verifies structured shutdown |
 | transient SSH loss after apply | retry known transport faults; re-probe completed install/start state before deciding failure |
 | host-key failure | fails without disabling verification |
 | SSH agent/passphrase path | preserves normal OpenSSH interaction |
@@ -809,6 +846,8 @@ behavior.
 - simultaneous writable control from multiple clients;
 - replacing Electron with a browser wrapper;
 - replacing Shell or native Agent TUIs with Pi/WebPi;
-- silently cloning OpenAlice or installing optional additional Agent CLIs on a
-  remote host; pinned managed Pi is part of the visible baseline plan;
+- scanning arbitrary remote directories or silently cloning OpenAlice; managed
+  clone/update is restricted to the displayed destination and explicit plan;
+- installing optional additional Agent CLIs on a remote host; pinned managed
+  Pi is part of the visible baseline plan;
 - moving broker credentials, account state, or trading writes out of UTA.

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -1,80 +1,76 @@
 # Remote Quickstart
 
-This guide is the shortest supported path for running OpenAlice on a private
-Linux or macOS host while keeping the browser on your laptop. It explains the
-daily workflow, the security and lifetime model, and the product ideas behind
-the design.
+Use this path when OpenAlice should run on a private Linux or macOS machine
+that you can already reach with SSH, while the browser stays on your laptop.
+The remote host owns Workspaces, native Agent processes, credentials, and
+optional trading services; the laptop owns only the browser and SSH tunnel.
 
-The current remote path is a source-backed preview on the `dev` lane. It is
-suitable for personal dogfooding and private development hosts, but it is not
-yet a signed standalone headless release. The authoritative lifecycle,
-protocol, recovery, and compatibility contract remains
-[[docs/remote-access.md]]. For an HTTPS/container deployment, use
-[[docs/docker-deployment.md]] instead.
+The lifecycle and security contract lives in [[docs/remote-access.md]]. For an
+always-on container exposed through HTTPS, Tailscale, or a private proxy, use
+[[docs/docker-deployment.md]]. Remote and Docker are parallel deployment
+choices: neither is a compatibility fallback for the other.
 
-## Choose the Right Surface
+## Choose a Deployment
 
-| Need | Recommended surface |
+| What you want | Use |
 |---|---|
-| Complete local desktop installation | Electron |
-| Local source checkout in a browser | `openalice start` |
-| Private remote machine reached through SSH | `openalice remote` |
-| Already-running remote Server; tunnel only | `openalice ssh` |
-| Durable container behind HTTPS, Tailscale, or a private proxy | Docker deployment |
+| Complete packaged desktop app | Electron |
+| OpenAlice from a local source checkout | `openalice start` |
+| Existing private machine reached through SSH | `openalice remote` |
+| Existing compatible Server; tunnel only | `openalice ssh` |
+| Container lifecycle, volume, healthcheck, and HTTPS | Docker |
 
-Electron remains a complete distribution. The CLI and remote path add another
-way to use OpenAlice; they do not replace the packaged desktop app.
+`openalice remote` follows the Herdr-style ownership model: execution and
+durable state stay on the machine with the files, while a replaceable local
+client can disconnect and return. OpenAlice uses an ordinary loopback HTTP/WS
+tunnel rather than Herdr's TUI protocol, so the normal browser UI remains the
+client.
 
-## Mental Model
-
-```text
-laptop
-  openalice CLI
-    └── ssh -L 127.0.0.1:<local-port>:127.0.0.1:47331
-          └── remote host
-                Guardian-owned OpenAlice Server
-                  ├── Alice HTTP + WebSocket on 127.0.0.1:47331
-                  ├── Workspace files and persistent state
-                  ├── Shell and Agent PTYs
-                  ├── managed Pi and other native Agent CLIs
-                  └── optional UTA and Connector Service
-
-laptop browser
-  └── http://127.0.0.1:<local-port>
-        └── the SSH tunnel above
-```
-
-The browser renders locally. The source checkout, Workspace files, shell,
-Agent process, tools, provider request, and optional trading Runtime all run on
-the remote host. Normal page traffic and the Workspace PTY WebSocket share the
-same loopback tunnel.
-
-This differs from opening SSH and launching a TUI inside the remote shell. In
-that traditional path, the TUI itself runs remotely and its terminal byte
-stream crosses SSH. In the OpenAlice browser path, menus, layout, Markdown, and
-most application presentation remain local, while the embedded shell or Agent
-terminal still reflects a remote PTY and therefore still pays network latency.
-
-## Prerequisites
+## Before You Start
 
 On the laptop:
 
-- macOS, Linux, or WSL with `curl` and OpenSSH;
+- macOS, Linux, or WSL;
 - Node.js `22.19.0` or newer;
-- SSH access to the target host.
+- `curl` and OpenSSH;
+- SSH access to the target.
 
 On the remote host:
 
 - Linux or macOS;
 - Node.js `22.19.0` or newer;
-- `curl`, Git, and a clone of OpenAlice;
-- enough disk and memory to install dependencies and build the source Runtime.
+- `curl`;
+- enough disk and memory for the source Runtime.
 
-The managed remote flow can offer to install missing Linux source-build tools
-after showing the exact plan. It does not install Node.js, clone the repository,
-configure SSH, or copy provider credentials from the laptop.
+The remote plan can install missing Git, Python 3, make, and C++ tools on
+supported Linux hosts after showing the exact package-manager command. On
+macOS, install Command Line Tools locally with `xcode-select --install` when
+the plan asks for them. OpenAlice does not install Node.js or configure SSH
+keys for you.
 
-Prefer a concrete alias in `~/.ssh/config`:
+## 1. Install the CLI on Your Laptop
+
+```bash
+curl -fsSL https://openalice.ai/install | bash
+```
+
+Open a new terminal and verify the installed commands:
+
+```bash
+openalice --version
+openalice version --json
+pi --version
+```
+
+The installer records its branch, tag, or commit and an immutable payload
+identity. Managed remote reproduces that same CLI and Pi on the target; it has
+no separate hidden release channel.
+
+## 2. Give the Host a Useful SSH Name
+
+OpenAlice delegates keys, agents, host verification, ports, and `ProxyJump` to
+your normal OpenSSH configuration. A short alias keeps every later command
+simple:
 
 ```sshconfig
 Host openalice-box
@@ -83,277 +79,149 @@ Host openalice-box
   IdentityFile ~/.ssh/id_ed25519
 ```
 
-Verify ordinary SSH first:
+Verify the transport once:
 
 ```bash
 ssh openalice-box
 ```
 
-OpenAlice deliberately delegates keys, agents, host verification, ports,
-`ProxyJump`, and other transport policy to OpenSSH.
+Exit that shell after it connects. OpenAlice will use the same host-key and
+authentication policy.
 
-## One-Time Setup
-
-### 1. Prepare the remote checkout
-
-Clone the current preview lane on the remote host:
+## 3. Review the Plan
 
 ```bash
-ssh openalice-box \
-  'git clone --branch master https://github.com/TraderAlice/OpenAlice.git "$HOME/OpenAlice"'
+openalice remote openalice-box --plan
 ```
 
-Ask the remote shell for the absolute path. `openalice remote` intentionally
-rejects `~` in `--app-dir` so the plan always names one unambiguous checkout:
+The read-only plan reports the remote platform, Node.js, CLI and Pi, Runtime
+owner, source location, build tools, ports, and every proposed change. On a
+new host it normally includes:
+
+1. install the matching OpenAlice CLI and managed Pi;
+2. install missing Linux source-build tools, when needed;
+3. clone a matching managed source checkout;
+4. build and start the detached OpenAlice Server;
+5. open a local loopback tunnel.
+
+The managed checkout lives below the selected remote `OPENALICE_HOME`, under a
+selector-specific `sources/` directory. You do not need to SSH in, clone the
+repository, find its absolute path, or repeat `--app-dir` on later connections.
+Nothing changes until you approve the plan.
+
+## 4. Connect
 
 ```bash
-ssh openalice-box 'cd "$HOME/OpenAlice" && pwd'
+openalice remote openalice-box
 ```
 
-The examples below use `/home/alice/OpenAlice`; replace it with that output.
+Approve the displayed plan. First preparation can take several minutes;
+successful install and build phases stay compact, while failures include a
+bounded diagnostic tail. When ready, OpenAlice opens a URL such as
+`http://127.0.0.1:49891` in the local browser.
 
-### 2. Install the local CLI
-
-The stable installer shows its complete plan before asking for consent:
-
-```bash
-curl -fsSL https://openalice.ai/install | bash
-```
-
-Open a new terminal so the managed PATH block is active, then verify both
-commands:
-
-```bash
-openalice --version
-openalice version --json
-pi --version
-```
-
-The installer adds the small `openalice` CLI and a pinned, release-local Pi. It
-does not install Electron, clone OpenAlice, start a service, or configure an AI
-provider. The JSON version output records this local CLI's version, installer
-source, and selector. Managed remote uses that record when the remote control
-CLI is missing or different; `openalice remote` has no separate branch/version
-flag.
-See [[docs/cli-installer.md]] for the transaction and trust model.
-
-### 3. Review the remote plan
-
-Run a read-only probe first:
-
-```bash
-openalice remote openalice-box \
-  --app-dir /home/alice/OpenAlice \
-  --plan
-```
-
-The plan reports the target, platform, Node.js version, checkout, CLI and Pi
-versions, Server owner, build requirements, ports, and every proposed
-mutation. `--plan` never installs, starts, stops, or replaces anything.
-
-### 4. Connect
-
-Run the same command without `--plan`:
-
-```bash
-openalice remote openalice-box \
-  --app-dir /home/alice/OpenAlice
-```
-
-After explicit consent, the command can:
-
-1. install or update the ordinary OpenAlice CLI on the remote host;
-2. install the pinned managed Pi when it is missing or incompatible;
-3. install missing Linux source-build tools declared by the plan;
-4. prepare the source Runtime;
-5. start or reuse a detached Guardian-owned Server;
-6. open a local SSH loopback tunnel and browser URL.
-
-The first step makes the remote host pull the small matching control CLI from
-its recorded installer URL. OpenAlice is not uploaded from the laptop through
-SSH. The large source Runtime remains the checkout named by `--app-dir` and is
-prepared on that host; `remote` never checks out or switches its Git branch.
-
-The first preparation can take several minutes. Successful build output is
-compact; a failed phase includes a bounded diagnostic tail.
-
-### 5. Configure the remote Runtime in the browser
-
-Create or open a Workspace and complete AI Provider setup in OpenAlice. The
-credential, Workspace, Session history, and Agent state are stored under the
-remote `OPENALICE_HOME`, not copied back to the laptop. Pi is already available
-through the managed runtime installed with the remote CLI.
+The browser, page APIs, and Workspace PTY WebSocket all cross the same SSH
+tunnel. Alice itself remains bound to remote `127.0.0.1`.
 
 ## Everyday Use
 
-Reconnect with the same command:
+Reconnect with the short command:
+
+```bash
+openalice remote openalice-box
+```
+
+OpenAlice prefers the last successful local port, so an existing browser tab
+can recover on the same localhost origin. If that port is genuinely occupied,
+the command chooses another one and tells you.
+
+Inspect or stop the remote Server without writing raw SSH commands:
+
+```bash
+openalice remote openalice-box --status
+openalice remote openalice-box --stop
+```
+
+Status bundles the control lookup into one SSH round trip instead of repeating
+the full bootstrap prerequisite scan. Stop uses the same control-only probe
+before and after Guardian's structured shutdown.
+
+Closing the browser or pressing `Ctrl+C` closes only the local tunnel. The
+detached Server, Workspaces, PTYs, and Agent processes continue on the remote
+host until you run `--stop`, the host stops, or Guardian shuts them down.
+
+Known transient SSH transport interruptions are retried with a short,
+platform-neutral message. Raw platform diagnostics are shown only when the
+connection finally fails, so a provider's temporary SSH control-plane noise
+does not become the normal OpenAlice experience.
+
+## Managed and User-Owned Source
+
+The default managed checkout is maintained by OpenAlice:
+
+- a missing checkout is cloned atomically after consent;
+- a clean branch checkout is compared with its selected upstream on reconnect;
+- an available fast-forward is shown in the plan, then applied with a Server
+  restart and source rebuild;
+- tracked local changes block the managed update instead of being overwritten.
+
+For development or a deliberately pinned checkout, pass your own absolute
+path:
 
 ```bash
 openalice remote openalice-box \
-  --app-dir /home/alice/OpenAlice
+  --app-dir /srv/OpenAlice
 ```
 
-OpenAlice remembers the last successful local port for the target and remote
-home. If that port is free, an existing browser tab can recover on the same
-localhost origin. To reserve an explicit origin instead:
-
-```bash
-openalice remote openalice-box \
-  --app-dir /home/alice/OpenAlice \
-  --local-port 49891
-```
+If that path does not exist, the plan can clone the selected source there. If
+it already contains OpenAlice, it remains user-owned: managed remote prepares
+and starts it but does not fetch, switch, reset, or overwrite it. A path that
+exists but is not an OpenAlice checkout is refused.
 
 Useful variations:
 
 ```bash
-# Print the URL instead of opening the browser.
-openalice remote openalice-box \
-  --app-dir /home/alice/OpenAlice \
-  --no-open
+# Keep one explicit browser origin.
+openalice remote openalice-box --local-port 49891
 
-# Tunnel only when a compatible Server is already running.
-openalice ssh openalice-box
+# Print the URL without opening a browser.
+openalice remote openalice-box --no-open
 
-# Use an identity without adding an SSH config alias.
+# Use an identity without an SSH config alias.
 openalice remote alice@server.example.com \
-  --identity ~/.ssh/id_ed25519 \
-  --app-dir /home/alice/OpenAlice
+  --identity ~/.ssh/id_ed25519
+
+# Put durable state and the managed source on a mounted volume.
+openalice remote openalice-box \
+  --home /data/openalice-home
 ```
-
-Pressing `Ctrl+C` closes only the local tunnel. The detached remote Server,
-Workspace, PTYs, and Agent processes keep running. Reconnecting creates another
-tunnel to the same Runtime.
-
-## Status, Stop, and Ownership
-
-Inspect the remote Server without changing it:
-
-```bash
-ssh openalice-box \
-  '"$HOME/.openalice/bin/openalice" server status'
-```
-
-Stop it explicitly:
-
-```bash
-ssh openalice-box \
-  '"$HOME/.openalice/bin/openalice" server stop'
-```
-
-`server stop` asks the owning Guardian to shut down its own tree. It does not
-guess a PID or delete a live lock. A normal `remote` command also refuses to
-replace an Electron session, another launcher, an unhealthy Runtime, or an
-incompatible owner. `--takeover` is a separate explicit authority and should
-only be used after inspecting `server status`.
 
 ## Security and Persistence
 
-- Alice stays bound to remote `127.0.0.1`; SSH authenticates and encrypts the
-  transport.
-- Do not publish port `47331` directly and never use
-  `OPENALICE_DISABLE_AUTH=1` for remote access.
-- Use a least-privilege remote account and the same SSH host-key discipline as
-  any other development server.
-- Back up the remote source checkout and `OPENALICE_HOME` according to the
-  value of the data. The browser is a client, not a backup.
-- An SSH disconnect does not stop a detached Server. A destroyed VM, container,
-  or ephemeral sandbox can still destroy its local filesystem.
+- Never publish remote port `47331` directly for the SSH path.
+- Never set `OPENALICE_DISABLE_AUTH=1` for remote access.
+- Use a least-privilege remote account and normal SSH host-key discipline.
+- Provider credentials, Workspace history, files, and Agent state live under
+  the remote home; the browser is not a backup.
+- For an ephemeral VM or container, place `--home` on persistent storage. The
+  managed source then follows that home onto the same volume.
+- A platform replacement can reattach a volume whose Guardian lock names the
+  removed machine. OpenAlice refuses cross-machine takeover automatically;
+  confirm the previous instance is gone before following the operator recovery
+  guidance in [[docs/remote-access.md]].
 
-Railway Sandboxes were useful for clean-host acceptance, including a real Pi
-provider round trip, but Railway describes them as experimental and ephemeral.
-They are appropriate for temporary dogfooding, not the only copy of important
-Workspace state. For a durable host, use a persistent VM or the Docker path
-with a volume and private HTTPS/Tailscale access.
+## Docker Is a First-Class Alternative
 
-## Why This Architecture
+Choose Docker when the container image, volume, healthcheck, bundled Agent
+runtimes, and HTTPS/private-proxy lifecycle are benefits rather than overhead:
 
-OpenAlice did not start by inventing a hosted Studio protocol. The first goal
-was to make the existing local/server boundary real, measurable, and useful:
+```bash
+docker compose up -d --build
+docker compose ps
+```
 
-1. one CLI can start the same product locally or manage it remotely;
-2. one detached Server owns files, processes, credentials, and lifecycle;
-3. SSH supplies an already-understood private transport;
-4. the existing browser UI remains a replaceable client;
-5. Electron remains complete while sharing the same Runtime concepts.
-
-That ordering lets us dogfood remote work before committing to a relay,
-pairing system, or application-specific remote protocol.
-
-### Drizzle Studio: a browser can be a distribution surface
-
-[`drizzle-kit studio`](https://orm.drizzle.team/docs/drizzle-kit-studio)
-starts a loopback server and opens a browser-based database UI. The useful
-lesson is the product shape: installing a small CLI can be enough to make a
-rich local tool available without asking every user to build a repository or
-install a desktop shell.
-
-OpenAlice borrows that low-friction entry shape, but initially serves its UI
-and APIs from one Runtime-owned localhost origin. This avoids making hosted
-domains, cross-domain cookies, and public network exposure prerequisites for
-the CLI path.
-
-### Herdr: durable Runtime, replaceable clients
-
-[`herdr`](https://github.com/ogulcancelik/herdr) separates persistent terminal
-state and PTYs from attached clients. Its remote mode keeps a thin client local,
-reaches the server through SSH, and leaves agents running after detach. The
-important lesson is ownership: the host with the files owns execution and
-durable Runtime facts; presentation can disconnect and return.
-
-Herdr can stream a matching compact binary to the host. OpenAlice deliberately
-does not copy that mechanism for its much larger Runtime: SSH carries control
-commands, the remote host pulls the small CLI itself, and a future standalone
-headless bundle must be a versioned CDN download rather than a laptop upload.
-
-OpenAlice starts with a simpler transport than Herdr's private framed TUI
-protocol: the existing HTTP and Workspace WebSocket cross an SSH loopback
-tunnel unchanged. We will add terminal snapshot/diff/backpressure semantics
-only if real latency measurements justify them. The pinned source comparison
-lives in [[docs/reference/herdr-remote-architecture.md]].
-
-### Codex: an Agent Runtime can power multiple rich clients
-
-Codex exposes an open-source
-[`app-server`](https://github.com/openai/codex/tree/main/codex-rs/app-server)
-behind rich interfaces. Its
-[documented SSH remote flow](https://learn.chatgpt.com/docs/remote-connections.md#connect-to-an-ssh-host)
-starts the Codex app-server on the remote host while the desktop client remains
-local. Its
-[remote TUI mode](https://learn.chatgpt.com/docs/app-server.md#connect-the-cli-terminal-ui)
-likewise separates a local terminal client from an app-server transport.
-
-That validates the longer-term direction: OpenAlice can eventually expose a
-versioned, presentation-neutral Runtime snapshot/event protocol for Electron,
-a local browser, or an independent Studio. We deliberately have not copied the
-Codex protocol. Stage 2 first proves our own ownership, lifecycle, security,
-and compatibility boundaries over the browser protocol we already operate.
-
-### Traditional Agent TUI over SSH: the compatibility baseline
-
-Running Claude Code, Codex, opencode, or Pi after `ssh host` remains the most
-compatible fallback. It is often perfectly usable, especially on a good
-connection. It also makes the remote terminal application responsible for
-every redraw sent through the outer SSH terminal stream.
-
-OpenAlice therefore keeps Shell and native Agent PTYs available, but does not
-make a remotely rendered heavyweight TUI the only product surface. The browser
-path lets us measure the remaining PTY latency independently from the rest of
-the UI before building a more specialized terminal transport.
-
-## Current Limits
-
-- The remote host must already contain an OpenAlice checkout; `remote` does not
-  clone or update source.
-- The bootstrap is a release-owned asset, but the installed CLI payload still
-  comes from the selected GitHub ref rather than a signed standalone archive.
-- Linux and macOS remote hosts are supported; the native Windows distribution
-  remains Electron.
-- One interactive browser per terminal is the conservative assumption until
-  controller/observer and resize authority are explicit.
-- Representative 20/80/150 ms Agent TUI measurements are still needed before
-  deciding whether to build a structured terminal transport.
-- A hosted independent Studio, device pairing, relay access, and a standalone
-  headless Runtime bundle are later stages, not hidden features of this path.
-
-For implementation details, failure classes, protocol versions, recovery, and
-the staged roadmap, continue with [[docs/remote-access.md]].
+The Docker image is not deprecated by managed remote, and remote users are not
+expected to wrap their SSH host in Docker. Both surfaces run the same
+Guardian/Alice product with different operational ownership. Continue with
+[[docs/docker-deployment.md]] for authentication, backups, upgrades, and the
+full container acceptance contract.

--- a/install
+++ b/install
@@ -21,6 +21,15 @@ ASSUME_YES=0
 PLAN_ONLY=0
 WITH_RUNTIME_DEPS=0
 INSTALL_ROOT="${OPENALICE_INSTALL_DIR:-${HOME}/.openalice}"
+INSTALL_CONTEXT="${OPENALICE_INSTALL_CONTEXT:-local}"
+
+case "$INSTALL_CONTEXT" in
+  local|remote) ;;
+  *)
+    printf 'Error: OPENALICE_INSTALL_CONTEXT must be local or remote.\n' >&2
+    exit 1
+    ;;
+esac
 
 BOLD=""
 DIM=""
@@ -483,8 +492,13 @@ if [[ -e "$BIN_DIR/openalice" || -e "$BIN_DIR/openalice.cmd" ]]; then
 fi
 
 printf '\n%bOpenAlice%b\n' "${BOLD}${CYAN}" "$RESET"
-printf '%bLocal Runtime CLI installer%b\n\n' "$BOLD" "$RESET"
-printf 'Install the OpenAlice command and its ready-to-use Pi agent, then run locally in your browser.\n'
+if [[ "$INSTALL_CONTEXT" == "remote" ]]; then
+  printf '%bRemote Runtime CLI installer%b\n\n' "$BOLD" "$RESET"
+  printf 'Install the matching OpenAlice command and ready-to-use Pi agent on this SSH host.\n'
+else
+  printf '%bLocal Runtime CLI installer%b\n\n' "$BOLD" "$RESET"
+  printf 'Install the OpenAlice command and its ready-to-use Pi agent, then run locally in your browser.\n'
+fi
 printf '%bPi stays inside the OpenAlice install root. System build tools are optional and listed before consent; your checkout, Electron app, credentials, and services otherwise stay untouched.%b\n' "$DIM" "$RESET"
 
 step 1 "Checking your system"
@@ -869,7 +883,11 @@ if [[ -n "$existing_command" && "$existing_command" != "$BIN_DIR/openalice" ]]; 
 fi
 
 checkout=""
-checkout="$(find_openalice_checkout 2>/dev/null || true)"
+if [[ "$INSTALL_CONTEXT" == "remote" ]]; then
+  printf '\nReturning to the approved remote setup plan.\n\n'
+else
+  checkout="$(find_openalice_checkout 2>/dev/null || true)"
+fi
 if [[ -n "$checkout" ]]; then
   printf '\n%bReady to launch%b\n' "$BOLD" "$RESET"
   printf '  Checkout     %s\n' "$checkout"
@@ -886,7 +904,7 @@ if [[ -n "$checkout" ]]; then
     fi
   fi
   printf '\nStart it when you are ready:\n  cd %q\n  %s\n\n' "$checkout" "$BIN_DIR/openalice"
-else
+elif [[ "$INSTALL_CONTEXT" != "remote" ]]; then
   printf '\n%bNext: launch from an OpenAlice checkout%b\n' "$BOLD" "$RESET"
   printf '  git clone https://github.com/TraderAlice/OpenAlice.git\n'
   printf '  cd OpenAlice\n'

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -3,7 +3,7 @@
 import { readFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
-import { readInstallSource } from '../src/install-source.mjs'
+import { installedContentIdentity, readInstallSource } from '../src/install-source.mjs'
 import { formatLocalStartHelp, parseLocalStartArgs, startLocal } from '../src/local-start.mjs'
 import { connectRemote, formatRemoteHelp, parseRemoteArgs } from '../src/remote.mjs'
 import { formatServerHelp, parseServerArgs, runServerCommand } from '../src/server.mjs'
@@ -19,6 +19,7 @@ export async function main(argv = process.argv.slice(2)) {
     process.stdout.write(`${JSON.stringify({
       version: readVersion(),
       installSource: await readInstallSource(),
+      contentIdentity: installedContentIdentity(),
     })}\n`)
     return 0
   }

--- a/packages/cli/src/install-source.mjs
+++ b/packages/cli/src/install-source.mjs
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
+import { basename, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const CLI_VERSION = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
 
@@ -19,6 +21,11 @@ export async function readInstallSource(options = {}) {
     if (error?.code === 'ENOENT') return cloneInstallSource(DEFAULT_INSTALL_SOURCE)
     throw error
   }
+}
+
+export function installedContentIdentity(moduleUrl = import.meta.url) {
+  const releaseDirectory = basename(dirname(dirname(fileURLToPath(moduleUrl))))
+  return /-([a-f0-9]{16})$/.exec(releaseDirectory)?.[1] ?? null
 }
 
 export function normalizeInstallSource(value, fallback = DEFAULT_INSTALL_SOURCE) {

--- a/packages/cli/src/install-source.spec.mjs
+++ b/packages/cli/src/install-source.spec.mjs
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   DEFAULT_INSTALL_SOURCE,
+  installedContentIdentity,
   installSourcesMatch,
   readInstallSource,
 } from './install-source.mjs'
@@ -44,5 +45,11 @@ describe('OpenAlice install source', () => {
     }
     expect(installSourcesMatch(DEFAULT_INSTALL_SOURCE, { ...DEFAULT_INSTALL_SOURCE })).toBe(true)
     expect(installSourcesMatch(DEFAULT_INSTALL_SOURCE, dev)).toBe(false)
+  })
+
+  it('derives installed content identity only from an immutable release directory', () => {
+    expect(installedContentIdentity('file:///tmp/.openalice/cli-versions/master-0123456789abcdef/src/install-source.mjs'))
+      .toBe('0123456789abcdef')
+    expect(installedContentIdentity('file:///tmp/OpenAlice/packages/cli/src/install-source.mjs')).toBeNull()
   })
 })

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -77,12 +77,22 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     const installRoot = join(home, '.openalice')
     const installer = join(repositoryRoot, 'install')
 
-    await execFileAsync('bash', [installer,
+    const installed = await execFileAsync('bash', [installer,
       '--source', repositoryRoot,
       '--install-dir', installRoot,
       '--no-modify-path',
       '--yes',
-    ], { env: installerEnv(home) })
+    ], {
+      env: {
+        ...installerEnv(home),
+        OPENALICE_INSTALL_CONTEXT: 'remote',
+      },
+    })
+
+    expect(installed.stdout).toContain('Remote Runtime CLI installer')
+    expect(installed.stdout).not.toContain('then run locally in your browser')
+    expect(installed.stdout).toContain('Returning to the approved remote setup plan')
+    expect(installed.stdout).not.toContain('Next: launch from an OpenAlice checkout')
 
     const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
     expect(JSON.parse(versionInfo.stdout).installSource).toMatchObject({
@@ -123,6 +133,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
     expect(JSON.parse(versionInfo.stdout)).toEqual({
       version: '0.2.0',
+      contentIdentity: releases[0].slice(-16),
       installSource: {
         schemaVersion: 1,
         repository: 'TraderAlice/OpenAlice',

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -2,12 +2,13 @@ import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, posix } from 'node:path'
 import { createInterface } from 'node:readline/promises'
 
 import {
   DEFAULT_INSTALL_SOURCE,
   formatInstallSelector,
+  installedContentIdentity,
   installSourcesMatch,
   parseInstallSource,
   readInstallSource,
@@ -21,6 +22,7 @@ const MANAGED_PI_VERSION = '0.80.6'
 const MAX_SSH_OUTPUT_BYTES = 1024 * 1024
 const REMOTE_STATE_VERSION = 1
 const MAX_REMEMBERED_TARGETS = 32
+const DEFAULT_REPOSITORY_URL = 'https://github.com/TraderAlice/OpenAlice.git'
 const TRANSIENT_SSH_PATTERNS = [
   /can't verify your ssh key right now/i,
   /temporary service issue/i,
@@ -45,6 +47,7 @@ export function parseRemoteArgs(argv) {
     assumeYes: false,
     planOnly: false,
     takeover: false,
+    mode: 'connect',
   }
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
@@ -98,30 +101,55 @@ export function parseRemoteArgs(argv) {
       options.takeover = true
       continue
     }
+    if (arg === '--status' || arg === '--stop') {
+      const mode = arg.slice(2)
+      if (options.mode !== 'connect' && options.mode !== mode) {
+        throw new Error('--status and --stop cannot be used together')
+      }
+      options.mode = mode
+      continue
+    }
     if (arg?.startsWith('-')) throw new Error(`Unknown option: ${arg}`)
     if (options.destination) throw new Error(`Unexpected argument: ${arg}`)
     validateSshDestination(arg)
     options.destination = arg
   }
   if (!options.destination) throw new Error('Remote SSH destination is required (for example: user@example.com)')
+  if (options.mode !== 'connect' && (options.planOnly || options.takeover)) {
+    throw new Error(`--${options.mode} cannot be combined with --plan or --takeover`)
+  }
   return options
 }
 
 export async function connectRemote(options, dependencies = {}) {
   const stdout = dependencies.stdout ?? process.stdout
   const env = dependencies.env ?? process.env
-  const localInstallSource = await resolveLocalInstallSource(dependencies, env)
+  const localInstall = await resolveLocalInstallIdentity(dependencies, env)
+  const repositoryUrl = dependencies.repositoryUrl ?? env['OPENALICE_REMOTE_TEST_REPOSITORY_URL'] ?? DEFAULT_REPOSITORY_URL
   const rememberedLocalPort = options.localPort === 0
     ? await readRememberedRemotePort(options, { ...dependencies, env })
     : null
-  const connectionOptions = rememberedLocalPort === null
-    ? options
-    : { ...options, preferredLocalPort: rememberedLocalPort }
+  const connectionOptions = {
+    ...options,
+    ...(rememberedLocalPort === null ? {} : { preferredLocalPort: rememberedLocalPort }),
+    managedSourceKey: managedSourceKey(localInstall.installSource),
+    managedInstallSource: localInstall.installSource,
+    repositoryUrl,
+  }
   const probe = dependencies.probeRemote ?? probeRemoteHost
   let remote = await probe(connectionOptions, dependencies)
+  if (options.mode === 'status') {
+    stdout.write(formatManagedRemoteStatus(options.destination, remote))
+    return remote.status?.class === 'running' ? 0 : 1
+  }
+  if (options.mode === 'stop') {
+    return stopManagedRemote(connectionOptions, remote, { ...dependencies, probe, stdout })
+  }
   let plan = createRemotePlan(connectionOptions, remote, {
-    installSource: localInstallSource,
+    installSource: localInstall.installSource,
+    contentIdentity: localInstall.contentIdentity,
     installBaseUrl: dependencies.installBaseUrl ?? env['OPENALICE_REMOTE_TEST_INSTALL_BASE_URL'] ?? '',
+    repositoryUrl,
   })
   stdout.write(formatRemotePlan(plan))
 
@@ -164,6 +192,7 @@ export async function connectRemote(options, dependencies = {}) {
     }
     const matchingRemoteCli = remote.cliCompatible
       && installSourcesMatch(remote.installSource, plan.installSource)
+      && contentIdentitiesMatch(plan.contentIdentity, remote.cliContentIdentity)
     if (installerError && matchingRemoteCli && remote.piCompatible && (!plan.installRuntimeDeps || (remote.runtimeBuildToolsMissing ?? []).length === 0)) {
       stdout.write('The remote install completed before the disconnect; continuing from detected state.\n')
     } else if (installerError) {
@@ -175,9 +204,11 @@ export async function connectRemote(options, dependencies = {}) {
     if (!remote.piCompatible) {
       throw new Error(`The remote install completed, but managed Pi ${MANAGED_PI_VERSION} was not detected`)
     }
-    const refreshedPlan = createRemotePlan(options, remote, {
+    const refreshedPlan = createRemotePlan(connectionOptions, remote, {
       installSource: plan.installSource,
+      contentIdentity: plan.contentIdentity,
       installBaseUrl: plan.installBaseUrl,
+      repositoryUrl: plan.repositoryUrl,
       forceRestartForManagedPi: plan.restartServer,
     })
     const planChanged = JSON.stringify(refreshedPlan.mutations) !== JSON.stringify(expectedRemainingMutations)
@@ -190,6 +221,57 @@ export async function connectRemote(options, dependencies = {}) {
       const confirm = dependencies.confirmPlan ?? confirmRemotePlan
       if (!await confirm('Apply the refreshed remote plan?', dependencies)) {
         stdout.write('The remote CLI is installed; no additional actions were applied.\n')
+        return 0
+      }
+    }
+    plan = refreshedPlan
+  }
+
+  if (plan.cloneSource) {
+    const expectedRemainingMutations = remainingMutationsAfterClone(plan)
+    stdout.write(`Preparing the managed OpenAlice source on ${options.destination}...\n`)
+    let cloneError = null
+    try {
+      const output = await runRemote(connectionOptions, buildRemoteCloneCommand(
+        plan.serverAppDir,
+        plan.installSource,
+        plan.repositoryUrl,
+      ), dependencies)
+      writeRemoteActionOutput(stdout, output)
+    } catch (error) {
+      cloneError = error
+      stdout.write('The SSH action ended unexpectedly; checking whether source preparation completed...\n')
+    }
+    try {
+      remote = await probe(connectionOptions, dependencies)
+    } catch (probeError) {
+      throw cloneError ?? probeError
+    }
+    if (cloneError && remote.sourceCheckoutState === 'present') {
+      stdout.write('The source checkout completed before the disconnect; continuing from detected state.\n')
+    } else if (cloneError) {
+      throw cloneError
+    }
+    if (remote.sourceCheckoutState !== 'present') {
+      throw new Error(`OpenAlice source preparation did not create a valid checkout at ${plan.serverAppDir}`)
+    }
+    const refreshedPlan = createRemotePlan(connectionOptions, remote, {
+      installSource: plan.installSource,
+      contentIdentity: plan.contentIdentity,
+      installBaseUrl: plan.installBaseUrl,
+      repositoryUrl: plan.repositoryUrl,
+      forceRestartForManagedPi: plan.restartServer,
+    })
+    const planChanged = JSON.stringify(refreshedPlan.mutations) !== JSON.stringify(expectedRemainingMutations)
+    if (refreshedPlan.blocker || planChanged) {
+      stdout.write('Remote facts changed after source preparation. Review the refreshed plan:\n')
+      stdout.write(formatRemotePlan(refreshedPlan))
+    }
+    if (refreshedPlan.blocker) throw new Error(refreshedPlan.blocker)
+    if (planChanged && refreshedPlan.mutations.length > 0 && !options.assumeYes) {
+      const confirm = dependencies.confirmPlan ?? confirmRemotePlan
+      if (!await confirm('Apply the refreshed remote plan?', dependencies)) {
+        stdout.write('The remote source is ready; no additional actions were applied.\n')
         return 0
       }
     }
@@ -217,7 +299,36 @@ export async function connectRemote(options, dependencies = {}) {
       throw stopError
     }
     if (remote.status?.class !== 'absent') {
-      throw new Error(`Remote OpenAlice Server did not stop cleanly before managed Pi restart (${remote.status?.class ?? 'no status'})`)
+      throw new Error(`Remote OpenAlice Server did not stop cleanly before restart (${remote.status?.class ?? 'no status'})`)
+    }
+  }
+
+  if (plan.updateSource) {
+    stdout.write(`Updating the managed OpenAlice source on ${options.destination}...\n`)
+    let updateError = null
+    try {
+      const output = await runRemote(connectionOptions, buildRemoteSourceUpdateCommand(
+        plan.serverAppDir,
+        plan.installSource,
+        plan.repositoryUrl,
+      ), dependencies)
+      writeRemoteActionOutput(stdout, output)
+    } catch (error) {
+      updateError = error
+      stdout.write('The connection ended unexpectedly; checking whether the source update completed...\n')
+    }
+    try {
+      remote = await probe(connectionOptions, dependencies)
+    } catch (probeError) {
+      throw updateError ?? probeError
+    }
+    if (updateError && remote.sourceUpdateAvailable === false) {
+      stdout.write('The managed source update completed before the disconnect; continuing from detected state.\n')
+    } else if (updateError) {
+      throw updateError
+    }
+    if (remote.sourceCheckoutState !== 'present' || remote.sourceUpdateAvailable === true) {
+      throw new Error(`Managed OpenAlice source did not update cleanly at ${plan.serverAppDir}`)
     }
   }
 
@@ -228,6 +339,7 @@ export async function connectRemote(options, dependencies = {}) {
       const output = await runRemote(connectionOptions, buildRemoteServerStartCommand({
         ...connectionOptions,
         appDir: plan.serverAppDir,
+        rebuild: plan.rebuildSource,
       }, remote.cliPath), dependencies)
       writeRemoteActionOutput(stdout, output)
     } catch (error) {
@@ -278,18 +390,75 @@ export async function connectRemote(options, dependencies = {}) {
   }, dependencies)
 }
 
+async function stopManagedRemote(options, initialRemote, dependencies) {
+  const stdout = dependencies.stdout
+  const runRemote = dependencies.runRemote ?? runSshCommand
+  const probe = dependencies.probe
+  if (!initialRemote.cliPath) {
+    throw new Error(`No managed OpenAlice CLI was found on ${options.destination}; there is no CLI Server to stop`)
+  }
+  if (initialRemote.status?.class === 'absent') {
+    stdout.write(`OpenAlice Server is already stopped on ${options.destination}.\n`)
+    return 0
+  }
+  if (initialRemote.status?.class !== 'running' || initialRemote.status?.owner?.surface !== 'cli-server') {
+    throw new Error(`Remote Runtime is ${initialRemote.status?.class ?? 'unknown'} and is not a controllable CLI Server`)
+  }
+
+  stdout.write(`Stopping OpenAlice Server on ${options.destination}...\n`)
+  let stopError = null
+  try {
+    const output = await runRemote(options, buildRemoteServerStopCommand(options, initialRemote.cliPath), dependencies)
+    writeRemoteActionOutput(stdout, output)
+  } catch (error) {
+    stopError = error
+    stdout.write('The connection ended unexpectedly; checking whether the remote Server stopped...\n')
+  }
+  let remote
+  try {
+    remote = await probe(options, dependencies)
+  } catch (probeError) {
+    throw stopError ?? probeError
+  }
+  if (remote.status?.class !== 'absent') throw stopError ?? new Error(`Remote OpenAlice Server did not stop cleanly (${remote.status?.class ?? 'unknown'})`)
+  if (stopError) stdout.write('The remote Server stopped before the disconnect; continuing from detected state.\n')
+  stdout.write(`OpenAlice Server is stopped on ${options.destination}.\n`)
+  return 0
+}
+
+function formatManagedRemoteStatus(destination, remote) {
+  const status = remote.status
+  const lines = [
+    '',
+    'OpenAlice Remote',
+    '',
+    `Target:  ${destination}`,
+    `CLI:     ${remote.cliPath ? `${remote.cliVersion ?? 'unknown'} at ${remote.cliPath}` : 'not installed'}`,
+    `Runtime: ${status?.class ?? 'unknown'}${status?.owner?.surface ? ` (${status.owner.surface})` : ''}`,
+  ]
+  if (status?.home) lines.push(`Home:    ${status.home}`)
+  if (status?.owner?.launchRoot) lines.push(`Source:  ${status.owner.launchRoot}`)
+  if (status?.endpoints?.web) lines.push(`Web:     ${status.endpoints.web}`)
+  return `${lines.join('\n')}\n\n`
+}
+
 export function createRemotePlan(options, remote, install = {}) {
   const installSource = requireInstallSource(install.installSource ?? DEFAULT_INSTALL_SOURCE)
+  const contentIdentity = normalizeContentIdentity(install.contentIdentity)
   const installBaseUrl = install.installBaseUrl ?? ''
+  const repositoryUrl = install.repositoryUrl ?? DEFAULT_REPOSITORY_URL
   const forceRestartForManagedPi = install.forceRestartForManagedPi === true
   const mutations = []
   let blocker = ''
   let installCli = false
   let installManagedPi = false
   let installRuntimeDeps = false
+  let cloneSource = false
+  let updateSource = false
+  let rebuildSource = false
   let startServer = false
   let restartServer = false
-  let serverAppDir = options.appDir
+  let serverAppDir = options.appDir || remote.managedAppDir || ''
   let remotePort = options.remotePort
 
   if (!['linux', 'darwin'].includes(remote.platform?.os)) {
@@ -298,12 +467,13 @@ export function createRemotePlan(options, remote, install = {}) {
     blocker = `The remote host does not have Node.js ${MINIMUM_NODE_VERSION} or newer; install Node.js 22 LTS before applying this plan.`
   } else if (!nodeVersionSupported(remote.nodeVersion)) {
     blocker = `The remote host reports ${remote.nodeVersion}; OpenAlice and managed Pi require Node.js ${MINIMUM_NODE_VERSION} or newer.`
-  } else if (options.appDir && remote.sourceCheckoutPresent === false) {
-    blocker = `No OpenAlice source checkout was found at ${options.appDir}. Clone it first or pass the correct --app-dir.`
+  } else if (options.appDir && remote.sourceCheckoutState === 'invalid') {
+    blocker = `${options.appDir} exists but is not an OpenAlice source checkout. Choose another --app-dir or move the existing path.`
   }
 
   const cliMatchesLocal = remote.installSource != null
     && installSourcesMatch(remote.installSource, installSource)
+    && contentIdentitiesMatch(contentIdentity, remote.cliContentIdentity)
   if (!remote.cliPath || !remote.cliCompatible || !cliMatchesLocal) {
     installCli = true
   }
@@ -321,9 +491,9 @@ export function createRemotePlan(options, remote, install = {}) {
     } else {
       remotePort = detectedRuntimePort
       if (installManagedPi || forceRestartForManagedPi) {
-        serverAppDir = options.appDir || status.owner?.launchRoot || ''
+        serverAppDir = options.appDir || status.owner?.launchRoot || serverAppDir
         if (!serverAppDir) {
-          blocker = `--app-dir <absolute-remote-path> is required to restart the current Server with managed Pi ${MANAGED_PI_VERSION}.`
+          blocker = `OpenAlice could not recover the running Server's source location for the managed Pi ${MANAGED_PI_VERSION} restart.`
         } else {
           restartServer = true
           startServer = true
@@ -334,7 +504,7 @@ export function createRemotePlan(options, remote, install = {}) {
   }
   if (!blocker && status?.class === 'owned_elsewhere') {
     if (options.takeover) {
-      if (!options.appDir) blocker = '--app-dir <absolute-remote-path> is required to replace the current owner.'
+      if (!serverAppDir) blocker = 'OpenAlice could not select a source checkout for takeover.'
       else {
         startServer = true
         mutations.push(`take over ${status.owner?.surface ?? 'existing'} Runtime and start CLI Server`)
@@ -345,17 +515,41 @@ export function createRemotePlan(options, remote, install = {}) {
   } else if (!blocker && ['incompatible', 'unhealthy', 'stopping'].includes(status?.class)) {
     if (!options.takeover) {
       blocker = `Remote Runtime is ${status.class}; inspect it or pass --takeover only if replacement is intentional.`
-    } else if (!options.appDir) {
-      blocker = '--app-dir <absolute-remote-path> is required for takeover.'
+    } else if (!serverAppDir) {
+      blocker = 'OpenAlice could not select a source checkout for takeover.'
     } else {
       startServer = true
       mutations.push('replace incompatible or unhealthy Runtime with CLI Server')
     }
   } else if (!blocker && status?.class !== 'running') {
-    if (!options.appDir) blocker = '--app-dir <absolute-remote-path> is required while the source-backed Server is absent.'
+    if (!serverAppDir) blocker = 'OpenAlice could not select a managed source checkout on the remote host.'
     else {
       startServer = true
       mutations.push('start remote OpenAlice Server')
+    }
+  }
+
+  if (!blocker && !options.appDir && remote.sourceCheckoutState === 'present' && remote.sourceUpdateAvailable === true) {
+    if (remote.sourceDirty) {
+      blocker = `${serverAppDir} has tracked local changes, so OpenAlice will not update the managed checkout. Preserve the changes with a separate checkout and pass --app-dir.`
+    } else {
+      updateSource = true
+      rebuildSource = true
+      mutations.unshift(`update managed OpenAlice source (${formatInstallSelector(installSource)})`)
+      if (status?.class === 'running' && status?.owner?.surface === 'cli-server' && !restartServer) {
+        restartServer = true
+        startServer = true
+        mutations.push('restart remote OpenAlice Server with updated source')
+      }
+    }
+  }
+
+  if (!blocker && startServer) {
+    if (remote.sourceCheckoutState === 'invalid') {
+      blocker = `${serverAppDir} exists but is not an OpenAlice source checkout. Choose another --app-dir or move the existing path.`
+    } else if (remote.sourceCheckoutState === 'absent') {
+      cloneSource = true
+      mutations.unshift(`clone OpenAlice source (${formatInstallSelector(installSource)})`)
     }
   }
 
@@ -382,6 +576,7 @@ export function createRemotePlan(options, remote, install = {}) {
     cliPath: remote.cliPath ?? 'missing',
     cliVersion: remote.cliVersion ?? 'unknown',
     cliCompatible: remote.cliCompatible === true,
+    cliContentIdentity: remote.cliContentIdentity ?? null,
     cliMatchesLocal,
     piPath: remote.piPath ?? 'missing',
     piVersion: remote.piVersion ?? 'unknown',
@@ -391,19 +586,28 @@ export function createRemotePlan(options, remote, install = {}) {
     appDir: serverAppDir || 'not selected',
     serverAppDir,
     remoteHome: options.remoteHome || '~/.openalice (remote default)',
+    sourceMode: options.appDir ? 'user-selected' : 'managed',
+    sourceCheckoutState: remote.sourceCheckoutState ?? null,
     remotePort,
     localPort: options.localPort || (options.preferredLocalPort ? `${options.preferredLocalPort} (remembered)` : 'auto'),
     installCli,
     installManagedPi,
     installRuntimeDeps,
+    cloneSource,
+    updateSource,
+    rebuildSource,
     runInstaller,
     startServer,
     restartServer,
     sourceCheckoutPresent: remote.sourceCheckoutPresent ?? null,
+    sourceUpdateAvailable: remote.sourceUpdateAvailable ?? null,
+    sourceDirty: remote.sourceDirty ?? null,
     sourceArtifactsReady: remote.sourceArtifactsReady ?? null,
     runtimeBuildToolsMissing,
     installSource,
+    contentIdentity,
     installBaseUrl,
+    repositoryUrl,
     mutations,
     blocker,
   }
@@ -413,9 +617,7 @@ export function formatRemotePlan(plan) {
   const actions = plan.mutations.length > 0
     ? [...plan.mutations, 'open local SSH tunnel']
     : ['reuse compatible remote CLI Server', 'open local SSH tunnel']
-  const buildTools = plan.sourceCheckoutPresent === false
-    ? 'Not inspected (source missing)'
-    : plan.sourceArtifactsReady === true
+  const buildTools = plan.sourceArtifactsReady === true
     ? 'Not needed (built artifacts present)'
     : plan.runtimeBuildToolsMissing.length > 0
       ? `Missing: ${formatMissingRuntimeBuildTools(plan.runtimeBuildToolsMissing)}`
@@ -425,11 +627,19 @@ export function formatRemotePlan(plan) {
   const cliState = plan.cliCompatible && plan.cliMatchesLocal
     ? ', compatible and matches local CLI'
     : ', install/update required'
-  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  Node.js        ${plan.nodeVersion}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${cliState})\n  Agent          ${plan.piPath} (Pi ${plan.piVersion}${plan.piCompatible ? ', compatible' : `, install ${MANAGED_PI_VERSION} required`})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n  Source         ${plan.appDir}\n  Build tools    ${buildTools}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.runInstaller ? `  Installer      ${plan.installSource.installerUrl} (CLI ${plan.installSource.cliVersion}, ${formatInstallSelector(plan.installSource)}, selected by local CLI)\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
+  const sourceState = plan.cloneSource
+    ? ', will clone'
+    : plan.updateSource
+      ? ', update available'
+      : plan.sourceCheckoutState === 'present' ? ', ready' : ''
+  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  Node.js        ${plan.nodeVersion}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${cliState})\n  Agent          ${plan.piPath} (Pi ${plan.piVersion}${plan.piCompatible ? ', compatible' : `, install ${MANAGED_PI_VERSION} required`})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n  Source         ${plan.appDir} (${plan.sourceMode}${sourceState})\n  Build tools    ${buildTools}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.runInstaller ? `  Installer      ${plan.installSource.installerUrl} (CLI ${plan.installSource.cliVersion}, ${formatInstallSelector(plan.installSource)}, selected by local CLI)\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
 }
 
-async function resolveLocalInstallSource(dependencies, env) {
-  if (dependencies.installSource) return requireInstallSource(dependencies.installSource)
+async function resolveLocalInstallIdentity(dependencies, env) {
+  const contentIdentity = normalizeContentIdentity(dependencies.contentIdentity ?? installedContentIdentity())
+  if (dependencies.installSource) {
+    return { installSource: requireInstallSource(dependencies.installSource), contentIdentity }
+  }
   const testUrl = env['OPENALICE_REMOTE_TEST_INSTALL_URL'] ?? ''
   const testKind = env['OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_KIND'] ?? ''
   const testValue = env['OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_VALUE'] ?? ''
@@ -445,16 +655,23 @@ async function resolveLocalInstallSource(dependencies, env) {
       installerUrl: testUrl,
     })
     if (!testSource) throw new Error('The remote installer test override is invalid')
-    return testSource
+    return { installSource: testSource, contentIdentity }
   }
-  return readInstallSource()
+  return { installSource: await readInstallSource(), contentIdentity }
 }
 
 export async function probeRemoteHost(options, dependencies = {}) {
   const runRemote = dependencies.runRemote ?? runSshCommand
+  if (options.mode === 'status' || options.mode === 'stop') {
+    return probeRemoteControl(options, { ...dependencies, runRemote })
+  }
   const platformRaw = await runRemote(options, 'uname -s; uname -m', dependencies)
   const [kernel = '', architecture = ''] = platformRaw.trim().split(/\r?\n/)
   const platform = normalizeRemotePlatform(kernel, architecture)
+  const shellHome = normalizeRemoteHome((await runRemote(options, 'printf "%s\\n" "$HOME"', dependencies)).trim())
+  const managedRoot = options.remoteHome || `${shellHome}/.openalice`
+  const managedAppDir = `${managedRoot}/sources/${options.managedSourceKey ?? 'branch-master'}/OpenAlice`
+  const sourceAppDir = options.appDir || managedAppDir
   const nodeVersion = (await runRemote(options, 'command -v node >/dev/null 2>&1 && node --version || true', dependencies)).trim() || null
   const hasCurl = (await runRemote(options, 'command -v curl >/dev/null 2>&1 && printf yes || true', dependencies)).trim() === 'yes'
   const piPath = normalizeRemoteExecutablePath((await runRemote(options, 'command -v pi 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/pi" ] || printf "%s\\n" "$HOME/.openalice/bin/pi"; }', dependencies)).trim(), 'pi')
@@ -467,35 +684,57 @@ export async function probeRemoteHost(options, dependencies = {}) {
     }
   }
   const piCompatible = piVersion === MANAGED_PI_VERSION
+  let sourceCheckoutState = null
   let sourceCheckoutPresent = null
   let sourceArtifactsReady = null
+  let sourceUpdateAvailable = null
+  let sourceDirty = null
   let runtimeBuildToolsMissing = []
-  if (options.appDir) {
-    sourceCheckoutPresent = (await runRemote(options, buildRemoteCheckoutProbeCommand(options.appDir), dependencies)).trim() === 'present'
+  if (sourceAppDir) {
+    sourceCheckoutState = (await runRemote(options, buildRemoteCheckoutProbeCommand(sourceAppDir), dependencies)).trim() || 'absent'
+    sourceCheckoutPresent = sourceCheckoutState === 'present'
     if (sourceCheckoutPresent) {
-      sourceArtifactsReady = (await runRemote(options, buildRemoteArtifactsProbeCommand(options.appDir), dependencies)).trim() === 'ready'
+      sourceArtifactsReady = (await runRemote(options, buildRemoteArtifactsProbeCommand(sourceAppDir), dependencies)).trim() === 'ready'
     }
-    if (sourceCheckoutPresent && !sourceArtifactsReady) {
+    if (sourceCheckoutState === 'absent' || (sourceCheckoutPresent && !sourceArtifactsReady)) {
       runtimeBuildToolsMissing = (await runRemote(options, buildRemoteBuildToolsProbeCommand(), dependencies))
         .trim()
         .split(/\r?\n/)
         .filter((value) => ['git', 'python3', 'make', 'cxx'].includes(value))
     }
+    if (
+      sourceCheckoutPresent
+      && !options.appDir
+      && options.managedInstallSource?.selector?.kind === 'branch'
+    ) {
+      const updateProbe = await runRemote(options, buildRemoteSourceUpdateProbeCommand(
+        sourceAppDir,
+        options.managedInstallSource,
+        options.repositoryUrl ?? DEFAULT_REPOSITORY_URL,
+      ), dependencies)
+      const updateFacts = parseSourceUpdateProbe(updateProbe)
+      sourceUpdateAvailable = updateFacts.updateAvailable
+      sourceDirty = updateFacts.dirty
+    }
   }
   const cliPath = normalizeRemoteCliPath((await runRemote(options, 'command -v openalice 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/openalice" ] || printf "%s\\n" "$HOME/.openalice/bin/openalice"; }', dependencies)).trim())
   if (!cliPath) {
-    return { platform, nodeVersion, hasCurl, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath: null, cliVersion: null, installSource: null, cliCompatible: false, status: null }
+    return { platform, shellHome, managedAppDir, nodeVersion, hasCurl, sourceCheckoutState, sourceCheckoutPresent, sourceArtifactsReady, sourceUpdateAvailable, sourceDirty, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath: null, cliVersion: null, cliContentIdentity: null, installSource: null, cliCompatible: false, status: null }
   }
 
   let cliVersion = null
   let remoteInstallSource = null
+  let cliContentIdentity = null
   let status = null
   let cliCompatible = false
   try {
     cliVersion = (await runRemote(options, `${shellQuote(cliPath)} --version`, dependencies)).trim()
     try {
       const versionInfo = parseRemoteVersionInfo(await runRemote(options, `${shellQuote(cliPath)} version --json`, dependencies))
-      if (versionInfo.version === cliVersion) remoteInstallSource = versionInfo.installSource
+      if (versionInfo.version === cliVersion) {
+        remoteInstallSource = versionInfo.installSource
+        cliContentIdentity = versionInfo.contentIdentity
+      }
     } catch {
       remoteInstallSource = null
     }
@@ -505,12 +744,96 @@ export async function probeRemoteHost(options, dependencies = {}) {
   } catch {
     cliCompatible = false
   }
-  return { platform, nodeVersion, hasCurl, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath, cliVersion, installSource: remoteInstallSource, cliCompatible, status }
+  return { platform, shellHome, managedAppDir, nodeVersion, hasCurl, sourceCheckoutState, sourceCheckoutPresent, sourceArtifactsReady, sourceUpdateAvailable, sourceDirty, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath, cliVersion, cliContentIdentity, installSource: remoteInstallSource, cliCompatible, status }
+}
+
+async function probeRemoteControl(options, dependencies) {
+  const output = await dependencies.runRemote(
+    options,
+    buildRemoteControlProbeCommand(options),
+    dependencies,
+  )
+  const fields = new Map(
+    output
+      .split(/\r?\n/)
+      .map((line) => {
+        const separator = line.indexOf('=')
+        return separator < 0 ? null : [line.slice(0, separator), line.slice(separator + 1)]
+      })
+      .filter(Boolean),
+  )
+  const cliPath = normalizeRemoteCliPath(fields.get('cli') ?? '')
+  if (!cliPath) {
+    return {
+      cliPath: null,
+      cliVersion: null,
+      cliContentIdentity: null,
+      installSource: null,
+      cliCompatible: false,
+      status: null,
+    }
+  }
+
+  const cliVersion = fields.get('version') ?? null
+  const versionInfo = parseRemoteVersionInfo(fields.get('identity') ?? '')
+  const status = parseRemoteStatus(fields.get('status') ?? '')
+  return {
+    cliPath,
+    cliVersion,
+    cliContentIdentity: versionInfo.version === cliVersion ? versionInfo.contentIdentity : null,
+    installSource: versionInfo.version === cliVersion ? versionInfo.installSource : null,
+    cliCompatible: status.protocol === 1,
+    status,
+  }
+}
+
+export function buildRemoteControlProbeCommand(options) {
+  const statusHome = options.remoteHome ? ` --home ${shellQuote(options.remoteHome)}` : ''
+  return `cli=$(command -v openalice 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/openalice" ] || printf '%s\\n' "$HOME/.openalice/bin/openalice"; })
+printf 'cli=%s\\n' "$cli"
+if test -n "$cli"; then
+  printf 'version='; "$cli" --version
+  printf 'identity='; "$cli" version --json
+  printf 'status='; "$cli" server status --json${statusHome}
+fi`
 }
 
 export function buildRemoteCheckoutProbeCommand(appDir) {
-  const manifest = shellQuote(`${appDir.replace(/\/$/, '')}/package.json`)
-  return `test -f ${manifest} && grep -Eq '"name"[[:space:]]*:[[:space:]]*"open-alice"' ${manifest} && printf present || true`
+  const root = shellQuote(appDir.replace(/\/$/, ''))
+  return `root=${root}\nif test ! -e "$root" && test ! -L "$root"; then\n  printf absent\nelif test -f "$root/package.json" && grep -Eq '"name"[[:space:]]*:[[:space:]]*"open-alice"' "$root/package.json"; then\n  printf present\nelse\n  printf invalid\nfi`
+}
+
+export function buildRemoteCloneCommand(appDir, installSource, repositoryUrl = DEFAULT_REPOSITORY_URL) {
+  const source = requireInstallSource(installSource)
+  const root = shellQuote(appDir)
+  const parent = shellQuote(posix.dirname(appDir))
+  const repository = shellQuote(repositoryUrl)
+  const ref = shellQuote(source.selector.value)
+  const cloneArgs = source.selector.kind === 'branch'
+    ? `--branch ${ref} --single-branch ${repository}`
+    : repository
+  const checkout = source.selector.kind === 'version'
+    ? `\ngit -C "$tmp" checkout --detach ${ref}`
+    : ''
+  return `set -eu\nroot=${root}\nparent=${parent}\ntest ! -e "$root" && test ! -L "$root" || { printf '%s\\n' "Source path already exists: $root" >&2; exit 1; }\nmkdir -p "$parent"\ntmp="$root.openalice-clone.$$"\ntrap 'rm -rf "$tmp"' EXIT HUP INT TERM\ngit clone ${cloneArgs} "$tmp"${checkout}\nmv "$tmp" "$root"\ntrap - EXIT HUP INT TERM\nprintf 'OpenAlice source is ready at %s\\n' "$root"`
+}
+
+export function buildRemoteSourceUpdateProbeCommand(appDir, installSource, repositoryUrl = DEFAULT_REPOSITORY_URL) {
+  const source = requireInstallSource(installSource)
+  if (source.selector.kind !== 'branch') throw new Error('Only managed branch checkouts can be updated')
+  const root = shellQuote(appDir)
+  const repository = shellQuote(repositoryUrl)
+  const remoteRef = shellQuote(`refs/heads/${source.selector.value}`)
+  return `root=${root}\nhead=$(git -C "$root" rev-parse HEAD 2>/dev/null || true)\nupstream=$(git ls-remote ${repository} ${remoteRef} 2>/dev/null | awk 'NR == 1 { print $1; exit }')\nif test -z "$head"; then dirty=unknown\nelif test -n "$(git -C "$root" status --porcelain --untracked-files=no 2>/dev/null)"; then dirty=yes\nelse dirty=no\nfi\nprintf 'head=%s\\nupstream=%s\\ndirty=%s\\n' "$head" "$upstream" "$dirty"`
+}
+
+export function buildRemoteSourceUpdateCommand(appDir, installSource, repositoryUrl = DEFAULT_REPOSITORY_URL) {
+  const source = requireInstallSource(installSource)
+  if (source.selector.kind !== 'branch') throw new Error('Only managed branch checkouts can be updated')
+  const root = shellQuote(appDir)
+  const repository = shellQuote(repositoryUrl)
+  const remoteRef = shellQuote(`refs/heads/${source.selector.value}`)
+  return `set -eu\nroot=${root}\ntest -z "$(git -C "$root" status --porcelain --untracked-files=no)" || { printf '%s\\n' 'Managed source has tracked local changes; refusing update.' >&2; exit 1; }\ngit -C "$root" fetch --prune ${repository} ${remoteRef}\ngit -C "$root" merge --ff-only FETCH_HEAD\nprintf 'Managed OpenAlice source is now at %s\\n' "$(git -C "$root" rev-parse --short HEAD)"`
 }
 
 export function buildRemoteArtifactsProbeCommand(appDir) {
@@ -538,6 +861,7 @@ export function buildRemoteServerStartCommand(options, cliPath) {
     '--wait', String(Math.ceil(options.waitMs / 1_000)),
   ]
   if (options.remoteHome) args.push('--home', shellQuote(options.remoteHome))
+  if (options.rebuild) args.push('--rebuild')
   if (options.takeover) args.push('--takeover')
   return `OPENALICE_PREPARE_OUTPUT=compact TURBO_TELEMETRY_DISABLED=1 DO_NOT_TRACK=1 ${args.join(' ')}`
 }
@@ -555,6 +879,7 @@ export function buildRemoteInstallCommand(installSource, installBaseUrl = '', wi
   const selectorValue = shellQuote(source.selector.value)
   const installEnv = [
     `OPENALICE_INSTALL_URL=${url}`,
+    'OPENALICE_INSTALL_CONTEXT=remote',
     installBaseUrl ? `OPENALICE_INSTALL_BASE_URL=${shellQuote(installBaseUrl)}` : '',
   ].filter(Boolean).join(' ')
   const runtimeDepsFlag = withRuntimeDeps ? ' --with-runtime-deps' : ''
@@ -576,15 +901,19 @@ export function buildRemoteSshArgs(options, remoteCommand) {
 export async function runSshCommand(options, remoteCommand, dependencies = {}) {
   const sleep = dependencies.sleep ?? ((ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
   const stdout = dependencies.stdout ?? process.stdout
+  const stderrOutput = dependencies.stderr ?? process.stderr
   let lastError
   for (let attempt = 1; attempt <= 3; attempt += 1) {
     try {
       return await runSshCommandOnce(options, remoteCommand, dependencies)
     } catch (error) {
       lastError = error
-      if (attempt >= 3 || !isTransientSshError(error)) throw error
+      if (attempt >= 3 || !isTransientSshError(error)) {
+        if (error?.stderr) stderrOutput.write(error.stderr)
+        throw error
+      }
       const delayMs = attempt * 750
-      stdout.write(`SSH transport was interrupted; retrying in ${delayMs}ms (${attempt}/2)...\n`)
+      stdout.write(`Connection interrupted; retrying (${attempt} of 2)...\n`)
       await sleep(delayMs)
     }
   }
@@ -593,7 +922,6 @@ export async function runSshCommand(options, remoteCommand, dependencies = {}) {
 
 function runSshCommandOnce(options, remoteCommand, dependencies = {}) {
   const spawnProcess = dependencies.spawnProcess ?? spawn
-  const stderrOutput = dependencies.stderr ?? process.stderr
   const child = spawnProcess('ssh', buildRemoteSshArgs(options, remoteCommand), {
     stdio: ['inherit', 'pipe', 'pipe'],
     windowsHide: true,
@@ -621,7 +949,6 @@ function runSshCommandOnce(options, remoteCommand, dependencies = {}) {
     child.stderr.on('data', (chunk) => {
       if (settled) return
       stderr += chunk
-      stderrOutput.write(chunk)
       if (Buffer.byteLength(stderr, 'utf8') > MAX_SSH_OUTPUT_BYTES) {
         child.kill('SIGTERM')
         finish(createSshCommandError('Remote SSH command produced too much error output', stdout, stderr))
@@ -701,14 +1028,20 @@ Plans and, after explicit consent, prepares a source-backed OpenAlice Server on
 the SSH host. It then opens the normal loopback browser tunnel. Disconnecting
 closes only the tunnel; the remote Server keeps running.
 
+When --app-dir is omitted, OpenAlice selects a private managed checkout under
+the remote OPENALICE_HOME and clones it when needed. Pass an absolute checkout
+path to keep source ownership manual.
+
 Options:
-  --app-dir <path>        Absolute OpenAlice checkout path on the remote host
+  --app-dir <path>        Existing or new checkout path (default: managed)
   --home <path>           Absolute remote OPENALICE_HOME (default: ~/.openalice)
   --local-port <port|auto> Local tunnel port (default: auto)
   --remote-port <port>    Remote OpenAlice web port (default: 47331)
   --ssh-port <port>       SSH server port
   --identity <path>       Local SSH identity file
   --wait <seconds>        Server/tunnel readiness timeout, 1-600 (default: 120)
+  --status                Inspect the managed remote Server and exit
+  --stop                  Gracefully stop the managed remote Server and exit
   --plan                  Print the read-only plan and exit
   -y, --yes               Approve install/update/start actions non-interactively
   --takeover              Explicitly replace the recorded remote Guardian owner
@@ -728,7 +1061,11 @@ function parseRemoteVersionInfo(output) {
   if (typeof value?.version !== 'string' || !installSource || value.version !== installSource.cliVersion) {
     throw new Error('Remote openalice version returned an invalid payload')
   }
-  return { version: value.version, installSource }
+  return {
+    version: value.version,
+    installSource,
+    contentIdentity: normalizeContentIdentity(value.contentIdentity),
+  }
 }
 
 function parseRemoteStatus(output) {
@@ -738,6 +1075,16 @@ function parseRemoteStatus(output) {
     throw new Error('Remote openalice server status returned an invalid payload')
   }
   return status
+}
+
+function parseSourceUpdateProbe(output) {
+  const head = /^head=([a-f0-9]{40,64})$/m.exec(output)?.[1] ?? null
+  const upstream = /^upstream=([a-f0-9]{40,64})$/m.exec(output)?.[1] ?? null
+  const dirtyValue = /^dirty=(yes|no|unknown)$/m.exec(output)?.[1] ?? 'unknown'
+  return {
+    updateAvailable: head && upstream ? head !== upstream : null,
+    dirty: dirtyValue === 'yes' ? true : dirtyValue === 'no' ? false : null,
+  }
 }
 
 function normalizeRemotePlatform(kernel, architecture) {
@@ -755,6 +1102,13 @@ function normalizeRemoteExecutablePath(path, command) {
     throw new Error(`Remote ${command} command resolved to an unsupported path`)
   }
   return path
+}
+
+function normalizeRemoteHome(path) {
+  if (!path || !path.startsWith('/') || /[\u0000-\u001f\u007f]/.test(path)) {
+    throw new Error('Remote HOME resolved to an unsupported path')
+  }
+  return path.replace(/\/$/, '')
 }
 
 function nodeVersionSupported(version) {
@@ -788,6 +1142,10 @@ function remainingMutationsAfterInstall(plan) {
   ))
 }
 
+function remainingMutationsAfterClone(plan) {
+  return plan.mutations.filter((mutation) => !mutation.startsWith('clone OpenAlice source ('))
+}
+
 function writeRemoteActionOutput(stdout, output) {
   const text = String(output ?? '').trim()
   if (text) stdout.write(`${text}\n`)
@@ -803,6 +1161,27 @@ function createSshCommandError(message, stdout, stderr) {
 function isTransientSshError(error) {
   const details = [error?.message, error?.stderr].filter(Boolean).join('\n')
   return TRANSIENT_SSH_PATTERNS.some((pattern) => pattern.test(details))
+}
+
+function contentIdentitiesMatch(localIdentity, remoteIdentity) {
+  return localIdentity === null || localIdentity === normalizeContentIdentity(remoteIdentity)
+}
+
+function normalizeContentIdentity(value) {
+  return typeof value === 'string' && /^[a-f0-9]{16}$/.test(value) ? value : null
+}
+
+function managedSourceKey(source) {
+  const normalized = requireInstallSource(source)
+  const readable = `${normalized.selector.kind}-${normalized.selector.value}`
+    .replaceAll(/[^A-Za-z0-9._-]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '')
+    .slice(0, 48) || 'source'
+  const digest = createHash('sha256')
+    .update(`${normalized.selector.kind}:${normalized.selector.value}`)
+    .digest('hex')
+    .slice(0, 8)
+  return `${readable}-${digest}`
 }
 
 function remoteStatePath(env, homeDir) {

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -8,13 +8,18 @@ import {
   buildRemoteArtifactsProbeCommand,
   buildRemoteBuildToolsProbeCommand,
   buildRemoteCheckoutProbeCommand,
+  buildRemoteCloneCommand,
+  buildRemoteControlProbeCommand,
   buildRemoteInstallCommand,
   buildRemoteServerStartCommand,
   buildRemoteServerStopCommand,
+  buildRemoteSourceUpdateCommand,
+  buildRemoteSourceUpdateProbeCommand,
   buildRemoteSshArgs,
   connectRemote,
   createRemotePlan,
   parseRemoteArgs,
+  probeRemoteHost,
   readRememberedRemotePort,
   runSshCommand,
 } from './remote.mjs'
@@ -56,6 +61,7 @@ describe('OpenAlice managed remote connector', () => {
       assumeYes: true,
       planOnly: true,
       takeover: true,
+      mode: 'connect',
     })
   })
 
@@ -64,11 +70,14 @@ describe('OpenAlice managed remote connector', () => {
     expect(() => parseRemoteArgs(['host name'])).toThrow('unsupported characters')
     expect(() => parseRemoteArgs(['host', '--app-dir', '~/OpenAlice'])).toThrow('absolute path')
     expect(() => parseRemoteArgs(['host', '--branch', 'dev'])).toThrow('Unknown option')
+    expect(() => parseRemoteArgs(['host', '--status', '--stop'])).toThrow('cannot be used together')
+    expect(() => parseRemoteArgs(['host', '--stop', '--takeover'])).toThrow('cannot be combined')
   })
 
   it('builds a remote installer command from local provenance, not remote flags', () => {
     const command = buildRemoteInstallCommand(masterInstallSource)
     expect(command).toContain('OPENALICE_INSTALL_URL=')
+    expect(command).toContain('OPENALICE_INSTALL_CONTEXT=remote')
     expect(command).toContain("--branch 'master'")
     expect(command).not.toContain('--version')
   })
@@ -180,18 +189,76 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.blocker).toContain('22.19.0')
   })
 
-  it('blocks a missing checkout before proposing system-package changes', () => {
+  it('plans a managed clone instead of making the user prepare a checkout over raw SSH', () => {
     const plan = createRemotePlan(parseRemoteArgs(['host', '--app-dir', '/srv/missing']), {
       ...missingRemote(),
+      sourceCheckoutState: 'absent',
       sourceCheckoutPresent: false,
       runtimeBuildToolsMissing: ['python3'],
     })
-    expect(plan.blocker).toContain('Clone it first')
-    expect(plan.installRuntimeDeps).toBe(false)
+    expect(plan.blocker).toBe('')
+    expect(plan.cloneSource).toBe(true)
+    expect(plan.installRuntimeDeps).toBe(true)
     expect(plan.mutations).toEqual([
       'install remote OpenAlice CLI',
       'install managed Pi 0.80.6',
+      'install source Runtime build tools',
+      'clone OpenAlice source (branch master)',
+      'start remote OpenAlice Server',
     ])
+  })
+
+  it('selects a private managed checkout when --app-dir is omitted', () => {
+    const remote = {
+      ...missingRemote(),
+      managedAppDir: '/home/alice/.openalice/sources/branch-master-12345678/OpenAlice',
+      sourceCheckoutState: 'absent',
+      sourceCheckoutPresent: false,
+    }
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+    expect(plan.sourceMode).toBe('managed')
+    expect(plan.serverAppDir).toBe(remote.managedAppDir)
+    expect(plan.cloneSource).toBe(true)
+    expect(plan.mutations).toContain('clone OpenAlice source (branch master)')
+  })
+
+  it('refuses to overwrite an occupied non-OpenAlice source path', () => {
+    const plan = createRemotePlan(parseRemoteArgs(['host', '--app-dir', '/srv/existing']), {
+      ...missingRemote(),
+      sourceCheckoutState: 'invalid',
+      sourceCheckoutPresent: false,
+    })
+    expect(plan.blocker).toContain('exists but is not an OpenAlice source checkout')
+    expect(plan.cloneSource).toBe(false)
+  })
+
+  it('updates a matching-version remote CLI when its installed payload differs', () => {
+    const remote = compatibleRemote()
+    remote.cliContentIdentity = '1111111111111111'
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote, {
+      contentIdentity: '2222222222222222',
+    })
+    expect(plan.cliMatchesLocal).toBe(false)
+    expect(plan.mutations).toEqual([
+      'update remote OpenAlice CLI',
+    ])
+  })
+
+  it('plans a safe rebuild when the managed branch checkout has advanced', () => {
+    const remote = managedUpdateRemote()
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+    expect(plan.updateSource).toBe(true)
+    expect(plan.rebuildSource).toBe(true)
+    expect(plan.restartServer).toBe(true)
+    expect(plan.mutations).toEqual([
+      'update managed OpenAlice source (branch master)',
+      'restart remote OpenAlice Server with updated source',
+    ])
+
+    remote.sourceDirty = true
+    const dirty = createRemotePlan(parseRemoteArgs(['host']), remote)
+    expect(dirty.blocker).toContain('tracked local changes')
+    expect(dirty.updateSource).toBe(false)
   })
 
   it('uses the detected Server port and blocks an explicit mismatch', () => {
@@ -237,6 +304,74 @@ describe('OpenAlice managed remote connector', () => {
     expect(runRemote).not.toHaveBeenCalled()
     expect(connectTunnel).not.toHaveBeenCalled()
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('No remote files or processes were changed'))
+  })
+
+  it('reports managed remote status without opening a tunnel or changing the host', async () => {
+    const runRemote = vi.fn()
+    const connectTunnel = vi.fn()
+    const stdout = { write: vi.fn() }
+    await expect(connectRemote(parseRemoteArgs(['host', '--status']), {
+      probeRemote: async () => compatibleRemote(),
+      runRemote,
+      connectTunnel,
+      stdout,
+    })).resolves.toBe(0)
+    expect(runRemote).not.toHaveBeenCalled()
+    expect(connectTunnel).not.toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Runtime: running (cli-server)'))
+  })
+
+  it('uses one lightweight SSH probe for status and stop control', async () => {
+    const runRemote = vi.fn(async (_options, command) => {
+      expect(command).toContain('server status --json')
+      expect(command).toContain("--home '/data/openalice'")
+      return [
+        'cli=/home/alice/.openalice/bin/openalice',
+        'version=0.2.0',
+        'identity=' + JSON.stringify({
+          version: '0.2.0',
+          installSource: masterInstallSource,
+          contentIdentity: '1234567890abcdef',
+        }),
+        'status=' + JSON.stringify(compatibleRemote().status),
+        '',
+      ].join('\n')
+    })
+    const remote = await probeRemoteHost(parseRemoteArgs([
+      'host',
+      '--home', '/data/openalice',
+      '--status',
+    ]), { runRemote })
+
+    expect(runRemote).toHaveBeenCalledOnce()
+    expect(remote).toEqual(expect.objectContaining({
+      cliPath: '/home/alice/.openalice/bin/openalice',
+      cliVersion: '0.2.0',
+      cliContentIdentity: '1234567890abcdef',
+      cliCompatible: true,
+      status: expect.objectContaining({ class: 'running' }),
+    }))
+    expect(buildRemoteControlProbeCommand(parseRemoteArgs(['host', '--stop'])))
+      .toContain('server status --json')
+  })
+
+  it('stops a managed remote Server without requiring a raw SSH command', async () => {
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(compatibleRemote())
+      .mockResolvedValueOnce(compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} }))
+    const runRemote = vi.fn(async () => 'OpenAlice Server stopped\n')
+    const connectTunnel = vi.fn()
+    const stdout = { write: vi.fn() }
+    await expect(connectRemote(parseRemoteArgs(['host', '--stop']), {
+      probeRemote,
+      runRemote,
+      connectTunnel,
+      stdout,
+    })).resolves.toBe(0)
+    expect(runRemote).toHaveBeenCalledOnce()
+    expect(runRemote.mock.calls[0][1]).toContain('server stop')
+    expect(connectTunnel).not.toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith('OpenAlice Server is stopped on host.\n')
   })
 
   it('default-no leaves a missing remote Runtime unchanged', async () => {
@@ -297,6 +432,54 @@ describe('OpenAlice managed remote connector', () => {
     }), expect.any(Object))
   })
 
+  it('installs, clones a managed checkout, starts, and connects without manual SSH setup', async () => {
+    const options = parseRemoteArgs(['host', '--yes', '--no-open'])
+    const appDir = '/home/alice/.openalice/sources/version-remote-smoke/OpenAlice'
+    const initial = { ...missingRemote(), managedAppDir: appDir, sourceCheckoutState: 'absent', sourceCheckoutPresent: false }
+    const installed = {
+      ...compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} }),
+      managedAppDir: appDir,
+      sourceCheckoutState: 'absent',
+      sourceCheckoutPresent: false,
+      sourceArtifactsReady: null,
+    }
+    const cloned = {
+      ...installed,
+      sourceCheckoutState: 'present',
+      sourceCheckoutPresent: true,
+      sourceArtifactsReady: true,
+    }
+    const running = {
+      ...compatibleRemote(),
+      managedAppDir: appDir,
+      sourceCheckoutState: 'present',
+      sourceCheckoutPresent: true,
+      sourceArtifactsReady: true,
+    }
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(initial)
+      .mockResolvedValueOnce(installed)
+      .mockResolvedValueOnce(cloned)
+      .mockResolvedValueOnce(running)
+    const runRemote = vi.fn(async () => '')
+    const connectTunnel = vi.fn(async () => 0)
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      connectTunnel,
+      installSource: masterInstallSource,
+      repositoryUrl: 'https://example.test/OpenAlice.git',
+      stdout: { write: vi.fn() },
+    })).resolves.toBe(0)
+
+    expect(runRemote).toHaveBeenCalledTimes(3)
+    expect(runRemote.mock.calls[0][1]).toContain('openalice-install')
+    expect(runRemote.mock.calls[1][1]).toContain("git clone --branch 'master' --single-branch 'https://example.test/OpenAlice.git'")
+    expect(runRemote.mock.calls[2][1]).toContain(`--app-dir '${appDir}'`)
+    expect(connectTunnel).toHaveBeenCalledOnce()
+  })
+
   it('continues when an interrupted installer or Server start actually completed remotely', async () => {
     const options = parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice', '--yes', '--no-open'])
     const probeRemote = vi.fn()
@@ -317,6 +500,33 @@ describe('OpenAlice managed remote connector', () => {
 
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('remote install completed before the disconnect'))
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('remote Server became ready before the disconnect'))
+  })
+
+  it('stops, fast-forwards, rebuilds, and reconnects when a managed branch advances', async () => {
+    const options = parseRemoteArgs(['host', '--yes', '--no-open'])
+    const absentBeforeUpdate = managedUpdateRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} })
+    const absentAfterUpdate = { ...absentBeforeUpdate, sourceUpdateAvailable: false }
+    const runningAfterUpdate = { ...managedUpdateRemote(), sourceUpdateAvailable: false }
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(managedUpdateRemote())
+      .mockResolvedValueOnce(absentBeforeUpdate)
+      .mockResolvedValueOnce(absentAfterUpdate)
+      .mockResolvedValueOnce(runningAfterUpdate)
+    const runRemote = vi.fn(async () => '')
+    const connectTunnel = vi.fn(async () => 0)
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      connectTunnel,
+      stdout: { write: vi.fn() },
+    })).resolves.toBe(0)
+
+    expect(runRemote).toHaveBeenCalledTimes(3)
+    expect(runRemote.mock.calls[0][1]).toContain('server stop')
+    expect(runRemote.mock.calls[1][1]).toContain('merge --ff-only FETCH_HEAD')
+    expect(runRemote.mock.calls[2][1]).toContain('--rebuild')
+    expect(connectTunnel).toHaveBeenCalledOnce()
   })
 
   it('installs Pi, gracefully restarts an existing CLI Server, and reconnects', async () => {
@@ -383,26 +593,33 @@ describe('OpenAlice managed remote connector', () => {
       .mockImplementationOnce(() => commandChild({ code: 0, stdout: 'ready\n' }))
     const sleep = vi.fn(async () => undefined)
 
+    const stdout = { write: vi.fn() }
+    const stderr = { write: vi.fn() }
     await expect(runSshCommand(parseRemoteArgs(['host']), 'printf ready', {
       spawnProcess,
       sleep,
-      stdout: { write: vi.fn() },
-      stderr: { write: vi.fn() },
+      stdout,
+      stderr,
     })).resolves.toBe('ready\n')
     expect(spawnProcess).toHaveBeenCalledTimes(3)
     expect(sleep).toHaveBeenNthCalledWith(1, 750)
     expect(sleep).toHaveBeenNthCalledWith(2, 1500)
+    expect(stdout.write).toHaveBeenCalledWith('Connection interrupted; retrying (1 of 2)...\n')
+    expect(stderr.write).not.toHaveBeenCalled()
   })
 
   it('does not retry an ordinary remote command failure', async () => {
     const spawnProcess = vi.fn(() => commandChild({ code: 1, stderr: 'remote command rejected\n' }))
+    const stderr = { write: vi.fn() }
     await expect(runSshCommand(parseRemoteArgs(['host']), 'exit 1', {
       spawnProcess,
       sleep: vi.fn(async () => undefined),
       stdout: { write: vi.fn() },
-      stderr: { write: vi.fn() },
+      stderr,
     })).rejects.toThrow('Remote SSH command failed')
     expect(spawnProcess).toHaveBeenCalledOnce()
+    expect(stderr.write).toHaveBeenCalledOnce()
+    expect(stderr.write).toHaveBeenCalledWith('remote command rejected\n')
   })
 
   it('re-plans after install and never replaces a newly discovered owner implicitly', async () => {
@@ -435,8 +652,16 @@ describe('OpenAlice managed remote connector', () => {
     expect(probe).toContain("root='/srv/Alice'\\''s source'")
     expect(probe).toContain('test -f "$root/dist/main.js"')
     expect(buildRemoteCheckoutProbeCommand("/srv/Alice's source"))
-      .toContain("'/srv/Alice'\\''s source/package.json'")
+      .toContain("root='/srv/Alice'\\''s source'")
     expect(buildRemoteBuildToolsProbeCommand()).toContain("printf 'cxx\\n'")
+    const clone = buildRemoteCloneCommand("/srv/Alice's source", masterInstallSource)
+    expect(clone).toContain("root='/srv/Alice'\\''s source'")
+    expect(clone).toContain("--branch 'master' --single-branch")
+    expect(clone).toContain('mv "$tmp" "$root"')
+    const updateProbe = buildRemoteSourceUpdateProbeCommand('/srv/OpenAlice', masterInstallSource)
+    expect(updateProbe).toContain("'refs/heads/master'")
+    const update = buildRemoteSourceUpdateCommand('/srv/OpenAlice', masterInstallSource)
+    expect(update).toContain('merge --ff-only FETCH_HEAD')
   })
 })
 
@@ -462,6 +687,7 @@ function missingRemote() {
     piVersion: null,
     piCompatible: false,
     sourceCheckoutPresent: true,
+    sourceCheckoutState: 'present',
     sourceArtifactsReady: false,
     runtimeBuildToolsMissing: ['git', 'python3', 'make', 'cxx'],
     cliPath: null,
@@ -481,6 +707,7 @@ function compatibleRemote(statusOverrides = {}) {
     piVersion: '0.80.6',
     piCompatible: true,
     sourceCheckoutPresent: null,
+    sourceCheckoutState: null,
     sourceArtifactsReady: null,
     runtimeBuildToolsMissing: [],
     cliPath: '/home/alice/.openalice/bin/openalice',
@@ -498,5 +725,17 @@ function compatibleRemote(statusOverrides = {}) {
       capabilities: ['runtime.stop'],
       ...statusOverrides,
     },
+  }
+}
+
+function managedUpdateRemote(statusOverrides = {}) {
+  return {
+    ...compatibleRemote(statusOverrides),
+    managedAppDir: '/home/alice/.openalice/sources/branch-master-12345678/OpenAlice',
+    sourceCheckoutState: 'present',
+    sourceCheckoutPresent: true,
+    sourceArtifactsReady: true,
+    sourceUpdateAvailable: true,
+    sourceDirty: false,
   }
 }

--- a/packages/cli/src/ssh-connect.mjs
+++ b/packages/cli/src/ssh-connect.mjs
@@ -102,6 +102,7 @@ export async function connectSsh(options, dependencies = {}) {
     stdio: ['inherit', 'ignore', 'inherit'],
     windowsHide: true,
   })
+  const tunnelLifetime = holdTunnel(ssh)
 
   let ready = false
   const earlyFailure = new Promise((_, reject) => {
@@ -122,7 +123,7 @@ export async function connectSsh(options, dependencies = {}) {
     stdout.write('The SSH tunnel stays active until this command exits. Press Ctrl+C to close it.\n')
     if (options.onReady) await options.onReady({ localPort, localUrl })
     if (options.openBrowser) await launchBrowser(localUrl)
-    return await holdTunnel(ssh)
+    return await tunnelLifetime
   } catch (error) {
     ssh.kill('SIGTERM')
     throw error

--- a/scripts/remote-smoke/Dockerfile
+++ b/scripts/remote-smoke/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-bookworm-slim
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-  && apt-get install -y --no-install-recommends bash ca-certificates curl openssh-server \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl git g++ make openssh-server python3 \
   && rm -rf /var/lib/apt/lists/* \
   && useradd --create-home --shell /bin/bash --uid 10001 smoke \
   && passwd --delete smoke \
@@ -33,6 +33,13 @@ RUN mkdir -p \
     /fixture/OpenAlice/services/uta/dist/uta.js \
     /fixture/OpenAlice/services/connector/dist/connector.cjs \
     /fixture/OpenAlice/packages/guardian-runtime/dist/index.js \
+    /fixture/OpenAlice/node_modules/.keep \
+  && git -C /fixture/OpenAlice init --initial-branch=main \
+  && git -C /fixture/OpenAlice config user.email smoke@openalice.local \
+  && git -C /fixture/OpenAlice config user.name 'OpenAlice Smoke' \
+  && git -C /fixture/OpenAlice add --force . \
+  && git -C /fixture/OpenAlice commit -m 'remote smoke fixture' \
+  && git -C /fixture/OpenAlice tag remote-smoke \
   && chmod +x /fixture/entrypoint.sh /fixture/fake-npm.sh \
   && chown -R smoke:smoke /fixture/OpenAlice /home/smoke
 

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -94,23 +94,23 @@ try {
     OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_KIND: 'version',
     OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_VALUE: 'remote-smoke',
     OPENALICE_REMOTE_TEST_INSTALL_BASE_URL: 'http://127.0.0.1:18080/packages/cli/',
+    OPENALICE_REMOTE_TEST_REPOSITORY_URL: 'file:///fixture/OpenAlice',
   }
   await waitForSsh(remoteTarget, smokeEnv)
 
   console.log('[remote-ssh-smoke] checking read-only missing-host plan')
   const initialPlan = run(process.execPath, [
     cliEntry, 'remote', remoteTarget,
-    '--app-dir', '/fixture/OpenAlice',
     '--plan', '--no-open',
   ], { cwd: repoRoot, env: smokeEnv })
   requireText(initialPlan, 'install remote OpenAlice CLI')
   requireText(initialPlan, 'install managed Pi 0.80.6')
+  requireText(initialPlan, 'clone OpenAlice source (version remote-smoke)')
   requireText(initialPlan, 'start remote OpenAlice Server')
   run('ssh', [remoteTarget, 'test ! -x "$HOME/.openalice/bin/openalice"'], { env: smokeEnv })
 
   console.log('[remote-ssh-smoke] applying install/start and opening first tunnel')
   const firstTunnelUrl = await attachAndProbe(remoteTarget, smokeEnv, [
-    '--app-dir', '/fixture/OpenAlice',
     '--yes', '--no-open', '--wait', '30',
   ])
   const running = remoteJson(remoteTarget, smokeEnv, '"$HOME/.openalice/bin/openalice" server status --json')
@@ -119,6 +119,11 @@ try {
   }
   const piVersion = run('ssh', [remoteTarget, '"$HOME/.openalice/bin/pi" --version'], { env: smokeEnv }).trim()
   if (piVersion !== '0.80.6') throw new Error(`Remote managed Pi version mismatch: ${piVersion}`)
+  const launchRoot = running.owner?.launchRoot
+  if (typeof launchRoot !== 'string' || !launchRoot.includes('/.openalice/sources/')) {
+    throw new Error(`Remote Server did not use a managed checkout: ${JSON.stringify(launchRoot)}`)
+  }
+  run('ssh', [remoteTarget, `test -d ${shellQuote(join(launchRoot, '.git'))}`], { env: smokeEnv })
 
   console.log('[remote-ssh-smoke] repairing a legacy CLI Server with its managed Pi launcher missing')
   run('ssh', [remoteTarget, 'rm -f "$HOME/.openalice/bin/pi" "$HOME/.openalice/bin/pi.cmd"'], { env: smokeEnv })
@@ -140,7 +145,10 @@ try {
   }
 
   console.log('[remote-ssh-smoke] stopping the remote Server through its control endpoint')
-  run('ssh', [remoteTarget, '"$HOME/.openalice/bin/openalice" server stop --wait 15'], { env: smokeEnv })
+  const statusOutput = run(process.execPath, [cliEntry, 'remote', remoteTarget, '--status'], { cwd: repoRoot, env: smokeEnv })
+  requireText(statusOutput, 'Runtime: running (cli-server)')
+  const stopOutput = run(process.execPath, [cliEntry, 'remote', remoteTarget, '--stop', '--wait', '15'], { cwd: repoRoot, env: smokeEnv })
+  requireText(stopOutput, 'OpenAlice Server is stopped')
   const absent = remoteJson(remoteTarget, smokeEnv, '"$HOME/.openalice/bin/openalice" server status --json')
   if (absent.class !== 'absent') throw new Error(`Remote Server did not stop cleanly: ${JSON.stringify(absent)}`)
 


### PR DESCRIPTION
## What changed

- make `openalice remote <target>` select, clone, update, build, and restart a private managed source checkout without a required `--app-dir`
- add structured `--status` and `--stop` flows, a single-round-trip control probe, buffered transient SSH diagnostics, and stable tunnel ownership
- compare immutable installed payload identity so same-version CLI drift still updates
- make the installer remote-aware and expand Docker/remote acceptance coverage
- rewrite the owner docs around first-run, persistence, upgrades, and Docker as a parallel first-class deployment surface

## Why

A normal private-host user should not need to SSH in, clone the repository, recover an absolute path, or translate provider-specific SSH noise. The remote path should own its replaceable source checkout while preserving explicit user-owned checkouts and Guardian's safety boundaries.

## Validation

- `pnpm -F @traderalice/openalice-cli test` (81 tests)
- `npx tsc --noEmit`
- `pnpm test` (3095 passed, 8 skipped)
- `pnpm test:install:docker` plus interactive installer review
- `pnpm test:remote:docker`
- `pnpm test:guardian-recovery`
- `pnpm docker:smoke`
- `pnpm electron:smoke:pty`
- `pnpm electron:smoke:packaged -- --onboarding`
- real Railway persistent-volume cold start, tunnel HTTP/auth, disconnect persistence, and one-round-trip status probe
