### PR TITLE
Test the live dev installer channel before release

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -1,0 +1,84 @@
+name: CLI Installer Smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [dev, master]
+    paths:
+      - ".github/workflows/cli-installer-smoke.yml"
+      - ".github/workflows/release.yml"
+      - "install"
+      - "package.json"
+      - "packages/cli/**"
+      - "scripts/install-docker-smoke.mjs"
+      - "scripts/install-channel-smoke.mjs"
+      - "scripts/install-channel-smoke/**"
+      - "scripts/install-smoke/**"
+      - "scripts/remote-ssh-smoke.mjs"
+      - "scripts/remote-smoke/**"
+  push:
+    branches: [dev]
+    paths:
+      - ".github/workflows/cli-installer-smoke.yml"
+      - ".github/workflows/release.yml"
+      - "install"
+      - "package.json"
+      - "packages/cli/**"
+      - "scripts/install-channel-smoke.mjs"
+      - "scripts/install-channel-smoke/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-installer-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checkout-install:
+    if: github.event_name != 'push'
+    name: Current checkout install
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+
+      - name: Exercise clean HTTP installer fixture
+        run: node scripts/install-docker-smoke.mjs
+
+  checkout-remote:
+    if: github.event_name != 'push'
+    name: Current checkout managed remote
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+
+      - name: Exercise clean SSH host fixture
+        run: node scripts/remote-ssh-smoke.mjs
+
+  dev-channel-install:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    name: Live raw dev channel install
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+
+      - name: Install raw dev script and dev payload in a clean host
+        run: node scripts/install-channel-smoke.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,28 @@ jobs:
           compression-level: 0
           retention-days: 1
 
+  cli-installer-acceptance:
+    name: Accept CLI installer candidate
+    needs: release
+    if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+
+      - name: Exercise candidate installer in a clean HTTP fixture
+        run: node scripts/install-docker-smoke.mjs
+
+      - name: Exercise candidate installer through managed SSH remote
+        run: node scripts/remote-ssh-smoke.mjs
+
   build-linux-broker-packs:
     name: Build Linux Broker Packs
     needs: release
@@ -255,8 +277,8 @@ jobs:
 
   publish-release:
     name: Publish accepted release
-    needs: [release, build-desktop, build-linux-broker-packs]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.build-linux-broker-packs.result == 'success'
+    needs: [release, build-desktop, build-linux-broker-packs, cli-installer-acceptance]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.build-linux-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -308,6 +330,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # A manual mirror is an idempotent repair of an existing release.
+          # Always derive the installer from that tag, never from whichever
+          # commit happens to be at master when the workflow is dispatched.
+          ref: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
 
       - uses: actions/setup-node@v4
         with:
@@ -326,6 +353,9 @@ jobs:
           TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
         run: |
           VERSION="${TAG#v}"
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          test "$PACKAGE_VERSION" = "$VERSION"
+          bash -n install
           cp install "dist/r2-upload/OpenAlice-${VERSION}-install"
 
       - name: Prepare CDN download aliases
@@ -447,6 +477,7 @@ jobs:
       - name: Verify CDN metadata
         env:
           DOWNLOAD_BASE_URL: ${{ secrets.DOWNLOAD_BASE_URL }}
+          PUBLIC_INSTALL_URL: https://openalice.ai/install
           TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
         run: |
           BASE_URL="${DOWNLOAD_BASE_URL%/}"
@@ -484,8 +515,13 @@ jobs:
           curl -fsSI "${BASE_URL}/manifest.json"
           curl -fsSI "${BASE_URL}/OpenAlice-${VERSION}-install"
           curl -fsSI "${BASE_URL}/install"
+          curl -fsSL "${BASE_URL}/OpenAlice-${VERSION}-install" -o /tmp/openalice-versioned-install
           curl -fsSL "${BASE_URL}/install" -o /tmp/openalice-install
+          curl -fsSL "$PUBLIC_INSTALL_URL" -o /tmp/openalice-site-install
+          cmp /tmp/openalice-versioned-install "dist/r2-upload/OpenAlice-${VERSION}-install"
           cmp /tmp/openalice-install dist/r2-upload/install
+          cmp /tmp/openalice-versioned-install /tmp/openalice-install
+          cmp /tmp/openalice-install /tmp/openalice-site-install
           bash -n /tmp/openalice-install
           bash /tmp/openalice-install --plan | tee /tmp/openalice-install-plan
           grep -Eq '^  Branch[[:space:]]+master$' /tmp/openalice-install-plan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,13 @@ for current ownership and entry points.
 ## Delivery and Branch Policy
 
 - `dev` is the integration lane. Routine PRs target `dev`.
+- `dev` is also the active preview channel: installer work must pass against
+  both the checked-out tree and the matching `raw/.../dev/install` +
+  `--branch dev` network path before promotion.
 - `master` is the stable/user-facing lane. Only human-directed promotions from
   `dev` and explicit emergency hotfixes target `master`.
+- A merge to `master` is a versioned release event, not a post-release staging
+  step. Stable CDN aliases are updated only from the resulting tag.
 - Do not commit directly to `master`. Avoid direct commits to `dev` unless the
   maintainer explicitly requests integration work.
 - Never force-push or delete `master` or `dev`.

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -67,11 +67,20 @@ upstream content.
 
 The script requires Node.js 22.19.0 or newer, matching the pinned Pi runtime's
 engine floor. With no selector, it targets the stable `master` branch.
-Development dogfooding must opt into `--branch dev` explicitly:
+
+The independently active development channel deliberately uses GitHub's raw
+branch endpoint rather than the release CDN. Both layers must select `dev`:
 
 ```bash
-curl -fsSL https://openalice.ai/install | bash -s -- --branch dev
+curl -fsSL https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install \
+  | bash -s -- --branch dev
 ```
+
+That command tests the current dev installer script and the current dev CLI
+payload together. Running the stable `https://openalice.ai/install` script with
+`--branch dev` can be useful as a compatibility probe, but it does not prove
+that changes to `dev/install` work. The raw endpoint is mutable preview
+infrastructure for maintainers, not a user-facing release mirror.
 
 `--version` selects a tag or commit, and the two selectors are mutually
 exclusive. The default install root is `~/.openalice`, and the downloaded
@@ -96,10 +105,14 @@ runs `npm ci --omit=dev --ignore-scripts` in the staged release.
 - `packages/cli/src/install.spec.mjs` — plan, consent, PTY, layout, and live-lock
   contract tests.
 - `scripts/install-docker-smoke.mjs` — local Docker acceptance runner.
+- `scripts/install-channel-smoke.mjs` — clean-host acceptance for the live raw
+  dev installer and matching dev payload.
 - `scripts/remote-ssh-smoke.mjs` — local clean-host Server/SSH acceptance
   runner; its product contract belongs to [[docs/remote-access.md]].
 - `scripts/install-smoke/` — clean user, local HTTP fixture, automated smoke,
   manual playground, exact Pi release assets, and an offline npm fixture.
+- `.github/workflows/cli-installer-smoke.yml` — checkout acceptance on relevant
+  PRs and live raw-channel acceptance after installer changes merge to `dev`.
 - `docs/local-runtime.md` — behavior after the installed command starts a
   source-backed localhost Runtime.
 - `docs/reference/install-script/README.md` — Claude Code and Codex research;
@@ -436,7 +449,8 @@ after that trust chain is added.
 ### Fast local feedback
 
 ```bash
-bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh
+bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh \
+  scripts/install-channel-smoke/run.sh
 pnpm -F @traderalice/openalice-cli test
 ```
 
@@ -485,7 +499,34 @@ It verifies:
 - identical-release reuse;
 - ref switching without deleting the prior release.
 
-This is a local pre-release gate. It is intentionally not delegated to PR CI.
+Relevant PRs run this deterministic acceptance in CI against the exact checkout.
+The same workflow runs `pnpm test:remote:docker` in a separate clean SSH fixture
+so installer changes cannot pass while managed remote is broken.
+
+### Live dev-channel acceptance
+
+```bash
+pnpm test:install:dev-channel
+```
+
+This smoke builds an empty non-root container but copies no OpenAlice installer
+or CLI payload into it. It downloads
+`https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install`, installs
+the matching `--branch dev` payload through the real network path, and verifies:
+
+- the response is the Bash installer and passes syntax validation;
+- `--plan` selects dev without writing the install root;
+- the complete OpenAlice CLI and managed Pi transaction succeeds;
+- installed provenance records the raw dev URL and branch selector;
+- the CLI version, Pi version, and `server status --json` execute;
+- an identical second install reuses the same content identity and immutable
+  release directory.
+
+The workflow runs this job after relevant changes merge to `dev`. PR checks use
+the checkout fixtures instead, because the raw dev URL correctly continues to
+represent the previously merged branch until the PR lands. A network failure is
+reported separately from deterministic checkout acceptance rather than being
+hidden by a local fixture.
 
 ### Manual interaction review
 
@@ -542,18 +583,25 @@ Before publishing or promoting a change that affects the installer:
    asset hashes, lockfile engine floor, and root/CLI Node engines. Do not
    accidentally advertise mutable `dev` as a stable release.
 3. Run the fast installer tests and the full repository-required checks.
-4. Run `pnpm test:install:docker` locally.
-5. Walk `pnpm test:install:docker --interactive` as a human.
+4. Require checkout install and managed-remote CI acceptance to pass, then
+   require the post-merge `pnpm test:install:dev-channel` result for current
+   `dev` to be green.
+5. Walk `pnpm test:install:docker --interactive` as a human when prompts,
+   progress, PATH guidance, or next steps changed.
 6. Exercise the installed CLI from `--source`; include the localhost handoff if
    the payload or start boundary changed.
-7. Verify the versioned installer asset, R2 `install` alias, manifest checksum,
-   and main-site proxy. State the remaining archive/signature gap explicitly.
+7. Treat the `dev` to `master` merge as the release event. The release workflow
+   repeats checkout acceptance before publication, creates the installer from
+   the accepted tag, then verifies the versioned asset, R2 `install` alias,
+   manifest checksum, and main-site proxy. State the remaining
+   archive/signature gap explicitly.
 8. Keep Electron signing and notarization in the Electron release lane; the CLI
    preview must not read those secrets.
 
-For a `dev` to `master` promotion that publishes installer behavior, the local
-Docker installer smoke remains a required manual gate under
-[[docs/development-workflow.md]].
+Do not refresh the stable installer from an unreleased `master` commit. A
+manual release mirror may only reproduce the exact bytes owned by its requested
+tag; new installer behavior stays on the live dev channel until the next
+versioned promotion under [[docs/development-workflow.md]].
 
 ## Troubleshooting
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -9,9 +9,15 @@ Canonical startup rules: [[AGENTS.md]]. Guide index: [[docs/README.md]].
 
 ## Branch Lanes
 
-- `dev` is the integration lane for routine development.
-- `master` is the stable/user-facing lane and the default GitHub branch.
-- Release automation runs from `master`.
+- `dev` is the integration lane for routine development and an independently
+  testable preview environment. Merged installer changes are exercised through
+  the mutable `raw/.../dev/install` endpoint with a matching `--branch dev`
+  payload selector.
+- `master` is the stable/user-facing lane and the default GitHub branch. A
+  `dev` to `master` merge is a versioned release event, not another integration
+  step.
+- Release automation runs from `master` and derives public artifacts from the
+  accepted release tag. It is the only path that updates stable CDN aliases.
 - `archive/dev-pre-beta6` is a historical snapshot; do not modify or delete it.
 - `local` is a legacy shared-worktree branch. It is not the default workflow;
   audit its unmerged commits before deciding whether to retain or retire it.
@@ -139,6 +145,11 @@ delivery lane:
   informs review but does not grant merge authority.
 - A push to `dev` runs the focused Ubuntu Guardian/full-stack smoke instead of
   repeating the PR's complete build, test, and cross-platform jobs.
+- Installer or distributed-CLI PRs run deterministic clean-container install
+  and managed-SSH acceptance against the checked-out tree. After merge, the
+  `dev` push separately downloads `raw/.../dev/install` into a clean container,
+  installs `--branch dev`, and verifies the live preview channel's provenance,
+  commands, server control surface, and idempotent reuse.
 - A push to `master` always runs the complete matrix.
 - Once this workflow version reaches the default `master` branch, the scheduled
   validation checks out current `dev` and runs the complete matrix, providing a
@@ -223,7 +234,10 @@ ownership.
 
 ## Promotion: `dev` to `master`
 
-Promotion is a human-directed stability decision.
+Promotion is a human-directed, versioned release decision. Do not merge
+unreleased follow-up work to `master` merely to make a public alias catch up;
+finish and test it in the active `dev` environment, then include it in the next
+release.
 
 ```bash
 git fetch origin
@@ -236,11 +250,20 @@ Before merging a promotion:
 
 - run the normal build/test gates against the full promotion delta;
 - add entry-path, trading, runtime, or package smokes required by included work;
-- follow [[docs/cli-installer.md]] and run `pnpm test:install:docker` locally
-  when the release publishes the CLI bootstrap installer; this manual gate is
-  intentionally not a PR CI job;
-- confirm release metadata/version intent;
+- follow [[docs/cli-installer.md]]; require the checkout installer/remote jobs
+  and the post-merge live dev-channel job to be green, and walk the interactive
+  installer locally when its human-facing flow changed;
+- confirm the new release version, notes, and tag intent; the release workflow
+  must see a version whose tag does not already exist;
 - confirm CI and release workflow triggers still match the branch policy.
+
+The release workflow repeats the deterministic installer and managed-remote
+acceptance against the exact master candidate before it can create the tag and
+GitHub Release. It then creates the versioned installer from that tag, mirrors
+the same bytes to `download.openalice.ai/install`, writes the manifest checksum,
+and verifies both CDN objects. A manual `mirror_tag` run is recovery-only: it
+checks out that existing tag and may reproduce its bytes, but must never source
+an installer from current `master`.
 
 Do not delete `dev` after promotion. After a master hotfix, propagate the fix
 back to `dev` immediately so a later promotion cannot revert it.
@@ -257,8 +280,9 @@ git switch -c hotfix/<short-description>
 ```
 
 Keep the change minimal, run focused checks plus relevant smoke coverage, open
-a PR to `master`, and then merge or cherry-pick the resulting fix back into
-`dev`.
+a PR to `master`, give it a patch release version, and then merge or cherry-pick
+the resulting fix back into `dev`. An emergency path may be smaller, but it is
+still a release and must not silently mutate an existing versioned artifact.
 
 ## External Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "docker:build": "docker build --tag openalice:local .",
     "docker:smoke": "node scripts/docker-runtime-smoke.mjs",
     "test:install:docker": "node scripts/install-docker-smoke.mjs",
+    "test:install:dev-channel": "node scripts/install-channel-smoke.mjs",
     "test:remote:docker": "node scripts/remote-ssh-smoke.mjs",
     "prebuild": "tsx scripts/build-migration-index.ts",
     "build": "turbo run build && tsup src/main.ts --format esm --dts",

--- a/scripts/install-channel-smoke.mjs
+++ b/scripts/install-channel-smoke.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+const suffix = `${process.pid}-${Date.now().toString(36)}`
+const image = `openalice-install-channel-smoke:${suffix}`
+const args = process.argv.slice(2)
+const keepImage = args.includes('--keep-image')
+const installerUrl = optionValue('--installer-url')
+  ?? 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install'
+const branch = optionValue('--branch') ?? 'dev'
+let imageBuilt = false
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Usage: pnpm test:install:dev-channel [--installer-url <url>] [--branch <name>] [--keep-image]
+
+Build a clean container, download the installer from the live dev channel, and
+install the matching branch through the real network path. The default pair is
+raw.githubusercontent.com/TraderAlice/OpenAlice/dev/install plus --branch dev.
+
+Options:
+  --installer-url <url>  Installer endpoint to exercise
+  --branch <name>        Matching payload branch (default: dev)
+  --keep-image           Preserve the temporary image for investigation
+  -h, --help             Show this help
+`)
+  process.exit(0)
+}
+
+const valuedOptions = new Set(['--installer-url', '--branch'])
+const flagOptions = new Set(['--keep-image'])
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index]
+  if (valuedOptions.has(arg)) {
+    if (!args[index + 1] || args[index + 1].startsWith('--')) {
+      console.error(`install channel smoke: ${arg} requires a value`)
+      process.exit(1)
+    }
+    index += 1
+    continue
+  }
+  if (!flagOptions.has(arg)) {
+    console.error(`install channel smoke: unknown option: ${arg}`)
+    process.exit(1)
+  }
+}
+
+if (!/^https:\/\//.test(installerUrl)) {
+  console.error('install channel smoke: --installer-url must use https://')
+  process.exit(1)
+}
+if (!/^[A-Za-z0-9._/-]+$/.test(branch) || branch.startsWith('/') || branch.endsWith('/')) {
+  console.error('install channel smoke: --branch is invalid')
+  process.exit(1)
+}
+
+function optionValue(option) {
+  const index = args.indexOf(option)
+  return index === -1 ? null : args[index + 1]
+}
+
+function docker(dockerArgs, { allowFailure = false } = {}) {
+  const result = spawnSync('docker', dockerArgs, {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0 && !allowFailure) {
+    throw new Error(`docker ${dockerArgs[0]} failed (${result.status ?? result.signal ?? 'unknown'})`)
+  }
+}
+
+try {
+  console.log(`[install-channel-smoke] building ${image}`)
+  docker([
+    'build',
+    '--file', 'scripts/install-channel-smoke/Dockerfile',
+    '--tag', image,
+    '.',
+  ])
+  imageBuilt = true
+
+  console.log(`[install-channel-smoke] exercising ${installerUrl} with branch ${branch}`)
+  docker([
+    'run', '--rm',
+    '--env', `OPENALICE_CHANNEL_INSTALLER_URL=${installerUrl}`,
+    '--env', `OPENALICE_CHANNEL_BRANCH=${branch}`,
+    image,
+  ])
+} catch (error) {
+  console.error(`[install-channel-smoke] failed: ${error instanceof Error ? error.message : String(error)}`)
+  process.exitCode = 1
+} finally {
+  if (keepImage && imageBuilt) {
+    console.log(`[install-channel-smoke] kept image ${image}`)
+  } else if (imageBuilt) {
+    docker(['image', 'rm', '--force', image], { allowFailure: true })
+  }
+}

--- a/scripts/install-channel-smoke/Dockerfile
+++ b/scripts/install-channel-smoke/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-bookworm-slim
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --home-dir /home/smoke --no-create-home --shell /bin/bash --uid 10001 smoke \
+  && mkdir -p /home/smoke \
+  && chown smoke:smoke /home/smoke
+
+COPY scripts/install-channel-smoke/run.sh /fixture/run.sh
+RUN chmod +x /fixture/run.sh
+
+USER smoke
+ENV HOME=/home/smoke
+ENV SHELL=/bin/bash
+
+ENTRYPOINT ["bash", "/fixture/run.sh"]

--- a/scripts/install-channel-smoke/run.sh
+++ b/scripts/install-channel-smoke/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "[install-channel-smoke] $*" >&2
+  exit 1
+}
+
+installer_url="${OPENALICE_CHANNEL_INSTALLER_URL:?OPENALICE_CHANNEL_INSTALLER_URL is required}"
+branch="${OPENALICE_CHANNEL_BRANCH:-dev}"
+install_root="$HOME/.openalice"
+installer_path="$(mktemp)"
+plan_path="$(mktemp)"
+
+cleanup() {
+  rm -f "$installer_path" "$plan_path"
+}
+trap cleanup EXIT
+
+[[ "$(id -u)" -ne 0 ]] || fail "container must run as a non-root user"
+[[ -z "$(find "$HOME" -mindepth 1 -maxdepth 1 -print -quit)" ]] || fail "HOME is not empty"
+
+for attempt in $(seq 1 10); do
+  if curl --fail --silent --show-error --location \
+    --output "$installer_path" "$installer_url"; then
+    break
+  fi
+  [[ "$attempt" -lt 10 ]] || fail "could not download $installer_url"
+  sleep "$attempt"
+done
+
+head -n 1 "$installer_path" | grep -Fq '#!/usr/bin/env bash' \
+  || fail "channel endpoint did not return the OpenAlice Bash installer"
+bash -n "$installer_path"
+
+OPENALICE_INSTALL_URL="$installer_url" \
+  bash "$installer_path" --plan --branch "$branch" --no-modify-path >"$plan_path"
+grep -Eq "^  Branch[[:space:]]+${branch}$" "$plan_path" \
+  || fail "plan did not select branch $branch"
+[[ ! -e "$install_root" ]] || fail "plan changed the install root"
+
+OPENALICE_INSTALL_URL="$installer_url" \
+  bash "$installer_path" --yes --branch "$branch" --no-modify-path \
+    --install-dir "$install_root"
+
+openalice="$install_root/bin/openalice"
+pi="$install_root/bin/pi"
+[[ -x "$openalice" ]] || fail "openalice launcher was not installed"
+[[ -x "$pi" ]] || fail "managed Pi launcher was not installed"
+
+version_json="$($openalice version --json)"
+first_content_identity="$(node -e '
+const value = JSON.parse(process.argv[1]);
+const expectedBranch = process.env.OPENALICE_CHANNEL_BRANCH || "dev";
+const expectedUrl = process.env.OPENALICE_CHANNEL_INSTALLER_URL;
+if (value.installSource?.selector?.kind !== "branch") process.exit(1);
+if (value.installSource?.selector?.value !== expectedBranch) process.exit(1);
+if (value.installSource?.installerUrl !== expectedUrl) process.exit(1);
+if (!/^[a-f0-9]{16}$/.test(value.contentIdentity || "")) process.exit(1);
+process.stdout.write(value.contentIdentity);
+' "$version_json")" || fail "installed CLI did not preserve dev-channel provenance"
+
+[[ -n "$($openalice --version)" ]] || fail "installed OpenAlice CLI did not report a version"
+[[ -n "$($pi --version)" ]] || fail "installed managed Pi did not report a version"
+
+server_status="$($openalice server status --home "$HOME/runtime-smoke" --json)"
+node -e '
+const value = JSON.parse(process.argv[1]);
+if (value.class !== "absent" || value.state !== "absent") process.exit(1);
+' "$server_status" || fail "installed CLI could not execute server status"
+
+OPENALICE_INSTALL_URL="$installer_url" \
+  bash "$installer_path" --yes --branch "$branch" --no-modify-path \
+    --install-dir "$install_root"
+
+second_content_identity="$($openalice version --json | node -e '
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => process.stdout.write(JSON.parse(input).contentIdentity || ""));
+')"
+[[ "$second_content_identity" == "$first_content_identity" ]] \
+  || fail "identical channel install did not reuse the same content identity"
+
+release_count="$(find "$install_root/cli-versions" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+[[ "$release_count" == "1" ]] || fail "identical channel install created $release_count releases"
+
+echo "[install-channel-smoke] passed $installer_url -> branch $branch ($first_content_identity)"


### PR DESCRIPTION
## Summary
- treat raw `dev/install` plus `--branch dev` as an independently testable preview channel
- run deterministic checkout install and managed-SSH acceptance for relevant PRs, then exercise the live raw dev channel after merge
- gate release publication on installer/remote candidate acceptance and make manual CDN mirrors source the exact requested tag
- document the dev → master → tag → CDN ownership contract

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3101 passed, 8 skipped)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- `pnpm test:install:dev-channel`
- Bash syntax checks for installer smoke scripts
- YAML parse for both changed workflows

## Boundary touch
- CLI installer, managed remote, release workflow, and maintainer documentation
- no trading, broker, credential, persisted-data, or public CDN mutation