### PR TITLE
Fix narrow session terminals and Manager paused state

### DIFF
--- a/ui/src/components/TabHost.tsx
+++ b/ui/src/components/TabHost.tsx
@@ -27,9 +27,9 @@ export function TabHost() {
   const isDesktop = useIsDesktop()
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <TabStrip />
-      <div className="relative flex-1 min-h-0">
+      <div className="relative min-h-0 min-w-0 flex-1">
         {tabIds.length === 0 ? (
           <EmptyEditor />
         ) : (
@@ -60,7 +60,7 @@ function TabFrame({ tab, visible }: { tab: Tab; visible: boolean }) {
     <div
       data-view-frame={tab.spec.kind}
       data-view-visible={visible ? 'true' : 'false'}
-      className={`absolute inset-0 flex min-h-0 flex-col ${visible ? 'oa-view-enter' : ''}`}
+      className={`absolute inset-0 flex min-h-0 min-w-0 flex-col ${visible ? 'oa-view-enter' : ''}`}
       style={{
         visibility: visible ? 'visible' : 'hidden',
         pointerEvents: visible ? 'auto' : 'none',

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -183,6 +183,10 @@ describe('ChatWorkspaceSection actions', () => {
     const managerSection = managerButton.parentElement?.parentElement
     expect(managerSection).toBeTruthy()
     const managerUi = within(managerSection as HTMLElement)
+
+    expect(managerUi.queryByRole('button', { name: 'Inspect the floor' })).toBeNull()
+    fireEvent.click(managerUi.getByRole('button', { name: 'Expand sessions' }))
+
     const runningSession = managerUi.getByRole('button', { name: 'Inspect the floor' })
     const pausedSession = managerUi.getByRole('button', { name: 'Coordinate owners' })
 

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -245,7 +245,7 @@ interface ManagerWorkspaceRowProps {
  * but remain outside the business Workspace tree and registry. */
 function ManagerWorkspaceRow(props: ManagerWorkspaceRowProps): ReactElement {
   const { t } = useTranslation()
-  const [expanded, setExpanded] = useState(true)
+  const [expanded, setExpanded] = useState(false)
   const sessions = useMemo(
     () => orderSessionsForSidebar(props.manager?.sessions ?? []),
     [props.manager?.sessions],

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -632,7 +632,13 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
         )}
         <TerminalThemeControl />
       </header>
-      <div ref={containerRef} className="terminal-host" />
+      {/* FitAddon reads the computed size of xterm's direct parent. Keep that
+          parent padding-free: putting the visual inset on `.terminal-host`
+          makes FitAddon count the padding as usable columns, so the xterm
+          screen/canvas becomes wider than the pane at narrow widths. */}
+      <div className="terminal-body">
+        <div ref={containerRef} className="terminal-host" />
+      </div>
     </div>
   );
 }

--- a/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
+++ b/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const uiRoot = basename(process.cwd()) === 'ui' ? process.cwd() : resolve(process.cwd(), 'ui')
+const css = readFileSync(resolve(uiRoot, 'src/components/workspace/workspaces.css'), 'utf8')
+
+function declarationsFor(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))
+  if (!match?.[1]) throw new Error(`Missing CSS rule for ${selector}`)
+  return match[1]
+}
+
+describe('terminal responsive layout contract', () => {
+  it('keeps FitAddon parent dimensions free of visual padding', () => {
+    const body = declarationsFor('.terminal-body')
+    const host = declarationsFor('.terminal-host')
+
+    expect(body).toContain('padding: 8px 8px 4px')
+    expect(body).toContain('overflow: hidden')
+    expect(host).not.toContain('padding:')
+    expect(host).toContain('width: 100%')
+    expect(host).toContain('height: 100%')
+    expect(host).toContain('min-width: 0')
+  })
+
+  it('lets xterm own its viewport and screen dimensions', () => {
+    const root = declarationsFor('.terminal-host > .xterm')
+    const viewport = declarationsFor('.terminal-host .xterm-viewport')
+
+    expect(root).toContain('max-width: 100%')
+    expect(root).toContain('min-width: 0')
+    expect(viewport).not.toMatch(/(?:^|\s)(?:width|height)\s*:/)
+    expect(css).not.toMatch(/\.terminal-host\s+\.xterm-screen\s*\{/)
+  })
+
+  it('allows the terminal shell and header text to shrink', () => {
+    expect(declarationsFor('.terminal-shell')).toContain('min-width: 0')
+    expect(declarationsFor('.terminal-header')).toContain('overflow: hidden')
+    expect(declarationsFor('.terminal-title')).toContain('text-overflow: ellipsis')
+    expect(declarationsFor('.terminal-meta')).toContain('text-overflow: ellipsis')
+  })
+})

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -854,6 +854,9 @@
 .terminal-shell {
   display: grid;
   grid-template-rows: auto 1fr;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   min-height: 0;
   flex: 1 1 auto;
   border: 1px solid var(--border);
@@ -866,6 +869,8 @@
 .terminal-header {
   display: flex;
   align-items: center;
+  min-width: 0;
+  overflow: hidden;
   gap: 10px;
   padding: 8px 12px;
   background: linear-gradient(180deg, var(--color-bg-tertiary), var(--color-bg-secondary));
@@ -876,6 +881,10 @@
 }
 
 .terminal-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--fg);
   font-weight: 600;
   letter-spacing: 0.2px;
@@ -883,6 +892,10 @@
 }
 
 .terminal-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   margin-left: auto;
   font-variant-numeric: tabular-nums;
 }
@@ -905,6 +918,7 @@
 
 .terminal-theme-switch {
   display: inline-flex;
+  flex-shrink: 0;
   align-items: center;
   height: 24px;
   padding: 2px;
@@ -945,17 +959,31 @@
   display: inline-block;
 }
 
-.terminal-host {
+.terminal-body {
+  min-width: 0;
   min-height: 0;
   padding: 8px 8px 4px;
+  overflow: hidden;
   background: var(--bg);
 }
 
-.terminal-host .xterm,
-.terminal-host .xterm-viewport,
-.terminal-host .xterm-screen {
-  height: 100% !important;
-  width: 100% !important;
+.terminal-host {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* xterm owns the inline dimensions of its viewport, screen, and canvases.
+ * Overriding those descendants with `!important` desynchronizes the DOM box
+ * from the renderer's cell grid. Only size the xterm root; FitAddon will keep
+ * the managed descendants inside it. */
+.terminal-host > .xterm {
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  min-width: 0;
 }
 
 .terminal-host .xterm-viewport {

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -379,13 +379,14 @@ describe('WorkspaceManagerPage runtime selection', () => {
     const snapshot = managerSnapshot([session])
     mocks.useWorkspaces.mockImplementation(() => context('codex', snapshot))
 
-    render(<WorkspaceManagerPage spec={{
+    const { container } = render(<WorkspaceManagerPage spec={{
       kind: 'workspace-manager',
       params: { sessionId: session.id },
     }} />)
 
     expect(mocks.resumeSession).not.toHaveBeenCalled()
     expect(screen.queryByTestId('terminal-view')).toBeNull()
+    expect(container.firstElementChild?.classList.contains('workspaces-root')).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'Continue in terminal' }))
 

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -161,7 +161,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
             <Bot size={11} /> {runtimeLabel(session.agent, agents)} · {session.surface === 'webpi' ? 'WebPi' : 'TUI'}
           </span>
         </header>
-        <div className="min-h-0 flex-1 p-2 md:p-3">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-2 md:p-3">
           {session.state === 'paused' ? (
             <ResumeCta
               record={session}

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -137,7 +137,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
 
   if (sessionId && session) {
     return (
-      <div className="flex h-full min-h-0 flex-col bg-bg">
+      <div className="workspaces-root flex h-full min-h-0 flex-col bg-bg">
         <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-bg-secondary/35 px-3 py-2 md:px-4">
           <div className="flex min-w-0 items-center gap-2.5">
             <button

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -96,7 +96,7 @@ export function WorkspacePage({ spec, visible }: Props) {
   // holds for the active path); when sessionId is null, the empty
   // state needs the full list to render resume/continue cards.
   return (
-    <div className="workspaces-root workspace-page-shell flex-1 min-h-0 flex flex-col">
+    <div className="workspaces-root workspace-page-shell flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       {/* OpenAlice-side header bar above the launcher's WorkspaceView. The
        *  launcher component itself is byte-faithful; we add the AI-provider
        *  affordance here. */}
@@ -138,7 +138,7 @@ export function WorkspacePage({ spec, visible }: Props) {
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 flex flex-col p-3">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col p-3">
         <WorkspaceView
           wsId={wsId}
           sessionId={sessionId}


### PR DESCRIPTION
## Summary
- keep regular and Workspace Manager TUI surfaces inside narrow panes without xterm overflow
- make the Manager paused-session view inherit the same workspace theme tokens as ordinary sessions
- keep Manager session history collapsed by default
- add regression coverage for terminal layout and Manager disclosure/theme scope

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3104 passed, 8 skipped)
- `cd ui && npx tsc -b`
- browser walk at narrow width for regular Codex and Manager OpenCode sessions
- browser walk for paused Manager session styling and default-collapsed Manager history