### PR TITLE
Prepare the 0.82.0 beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.81.0-beta",
+  "version": "0.82.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary

- bump the root release version from `0.81.0-beta` to `0.82.0-beta`
- keep the CLI package on its independent `0.2.0` version
- prepare the current `dev` snapshot for beta promotion to `master`

## Local release gates

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (3104 passed, 8 skipped)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- `pnpm docker:smoke`
- `pnpm electron:smoke:workspace`
- `git diff --check`

The packaged Electron acceptance covered workspace creation, Electron PTY, CLI manifests, managed Pi execution and side effects, diagnostic compaction, pause, and workspace offboarding.