### PR TITLE
fix(ibkr): canonicalize conId contracts before routing

### DIFF
--- a/docs/ibkr-contract-resolution.md
+++ b/docs/ibkr-contract-resolution.md
@@ -1,0 +1,197 @@
+# IBKR conId Contract Resolution
+
+Status: completed
+
+Started: 2026-07-17
+
+Related contribution: [PR #345](https://github.com/TraderAlice/OpenAlice/pull/345)
+
+## Why this work exists
+
+UTA uses an IBKR `conId` as the broker-native identity for a tradeable leaf.
+That is the correct uniqueness primitive for answering "which instrument is
+this?", but it is not by itself a complete contract for every TWS request.
+Quotation and order-routing requests may also require the instrument's
+canonical `secType`, `exchange`, `currency`, `localSymbol`, or related fields.
+
+Two earlier changes combined into a latent bug:
+
+1. IBKR native-key resolution was simplified so a numeric Alice ID rebuilds a
+   `Contract` containing only its `conId`. The assumption was that TWS could
+   resolve the remaining contract fields from that identity.
+2. The order path added `SMART` and `USD` as unconditional defaults for thin
+   contracts. Those defaults are useful for hand-written US stock symbols but
+   are not valid cross-asset defaults.
+
+The combination did not send a bare conId to TWS. It sent a conId plus routing
+metadata that could contradict the instrument identified by that conId.
+
+The issue became user-visible after IBKR FX families were made discoverable as
+conId-addressed leaves. The quote path had already gained a one-off
+`reqContractDetails` enrichment, but the order path had not, so quote and order
+behavior diverged.
+
+## Live evidence
+
+The failure was reproduced against IBKR paper TWS with the USD.CHF cash
+contract (`conId=12087820`) using read-only contract-details probes:
+
+| Request shape | TWS result |
+| --- | --- |
+| `{ conId: 12087820 }` | Resolves to `USD.CHF / CASH / IDEALPRO / CHF` |
+| `{ conId, symbol: "USDCHF" }` | Resolves successfully |
+| `{ conId, exchange: "SMART", currency: "USD" }` | Error 200: no security definition |
+| Full canonical contract | Resolves successfully |
+
+This shows that the display symbol is not the direct cause. The decisive fault
+is attaching stock-routing defaults to a conId whose canonical contract is an
+FX instrument on IDEALPRO.
+
+No order was staged or submitted while establishing this evidence.
+
+## Design invariant
+
+The repair establishes this boundary inside `IbkrBroker`:
+
+- `conId` identifies the instrument.
+- A canonical IBKR `Contract` addresses that instrument for quotation or
+  execution.
+- When a conId is present, TWS contract details are authoritative. Resolution
+  must query with a clean `{ conId }`; caller-supplied symbol, exchange,
+  currency, and secType must not narrow or poison that lookup.
+- `STK / SMART / USD` remains a convenience default only for a symbol-form
+  stock request without a conId.
+- Missing routing fields for other no-conId asset classes must not be guessed.
+
+The resolver should cache canonical contracts by conId, deduplicate concurrent
+lookups, discard failed cache entries so they can be retried, and return clones
+so downstream code cannot mutate the cached canonical value.
+
+## Implementation boundary
+
+The same canonical resolver will be used by every IBKR path that sends a
+contract to a TWS operation where routing fields matter:
+
+- `placeOrder`
+- `modifyOrder`
+- `getQuote`
+- `closePosition` through `placeOrder`
+
+`closePosition` must stop overwriting the position contract's exchange with
+`SMART`. A venue-returned position contract is already stronger evidence than
+a generic stock default.
+
+UTA may continue carrying the optional tool `symbol` for display in staged
+operations during this repair. The IBKR boundary must treat it as
+non-authoritative whenever a conId is present. Separating display metadata from
+execution contracts across every broker is a larger model change and is not
+required to close this defect safely.
+
+## Non-goals
+
+- Do not replace or broadly redesign the UTA abstraction in this change.
+- Do not change Alice ID grammar or remove conId as IBKR's canonical leaf key.
+- Do not add general pricing or market-selection policy to UTA.
+- Do not merge or cherry-pick PR #345 as-is; it contains an unrelated
+  Dockerfile commit and does not cover close-position or contradictory typed
+  contracts.
+- Do not use a real-money account for validation.
+
+The architecture may deserve a separate review, but the current priority is to
+restore a correct broker boundary and protect it with reproducible evidence.
+
+## Regression and acceptance matrix
+
+### Unit tests
+
+- conId-only FX resolves to its canonical CASH contract before quote/order.
+- conId plus display symbol follows the same path.
+- contradictory SMART/USD fields are discarded before the clean conId lookup.
+- symbol-form AAPL retains the STK/SMART/USD convenience path.
+- quote and order share the conId cache; concurrent lookups are deduplicated.
+- resolver inputs and cached canonical contracts are not mutated.
+- a failed lookup is actionable and can be retried.
+- FX close preserves IDEALPRO rather than forcing SMART.
+
+### Non-trading E2E
+
+The ordinary UTA lifecycle suite must continue to cover staging, commit, push,
+ledger, and cleanup without configured broker accounts or external orders.
+
+### IBKR paper E2E
+
+The explicit live-paper lane will cover both layers that previously diverged:
+
+1. Broker-level contract resolution and order validation, preferring an IBKR
+   what-if order where it gives the same contract validation without
+   transmission.
+2. The real UTA identity path from FX search leaf through Alice ID, stage, and
+   commit, followed by reject before push. Existing AAPL live-paper coverage
+   owns the generic UTA push dispatcher; the broker what-if call proves that
+   the FX contract accepted at the write boundary is canonical without
+   transmitting an FX order.
+
+The live run must record the pre-run position and open-order baseline, clean up
+in `finally`, and prove the post-run state returned to that baseline. A failure
+to prove cleanup stops the delivery lane.
+
+## Smoke evidence and reusable fixtures
+
+Live-paper smoke output is split into two forms:
+
+1. An untracked per-run JSONL record under
+   `data/uta-live-paper-runs/`, containing the Git commit, scenario, safe input
+   fields, canonical contract fields, venue result/error, and cleanup result.
+2. A reviewed tracked fixture containing only stable, non-account data for
+   offline regression tests.
+
+The reviewed fixture contains a US SMART/USD stock control, USD.CHF CASH on
+IDEALPRO, and a SEHK/HKD equity. Volatile prices, timestamps, account
+identifiers, balances, positions, credentials, and expiring derivative
+identities do not enter tracked fixtures.
+
+## Validation safety finding
+
+An initial attempt to select only the new live-paper scenarios passed its file
+arguments through the package script incorrectly and started the broader
+live-paper catalog. It was interrupted before continuing across venues. The
+existing broker-level IBKR fill tests had already exposed a separate safety
+bug: two tests added shares independently and a later test called an
+unqualified full-position close, so the suite could close a position that
+existed before the run.
+
+TWS execution records made the test-created quantity and the pre-run baseline
+distinguishable. The paper account was restored to its exact pre-run positions
+and zero open orders. The broker-level fill coverage is now one self-contained
+scenario: it records the starting quantity and open-order ids, cancels any
+introduced hanger in `finally`, closes only the positive quantity delta created
+by the test, and asserts the exact baseline afterward.
+
+Targeted live runs must invoke Vitest directly when selecting files or test
+names; do not put an extra `--` between the live-paper config and the filters.
+
+## Verification completed
+
+- Canonical resolver unit suite: 20 passing tests, including the three recorded
+  TWS contract fixtures.
+- Full repository unit suite: 3,114 passing tests and 8 intentional skips.
+- Non-trading UTA lifecycle E2E: 15 passing tests.
+- IBKR paper USD.CHF polluted-contract what-if: accepted as canonical
+  `CASH / IDEALPRO / CHF`, with exact position and open-order baseline restored.
+- IBKR paper FX search/Alice ID/stage/commit/reject path: passed without push.
+- IBKR paper AAPL write lifecycle: bought and closed only the test-created
+  quantity, with the exact starting position and open-order set restored.
+- Full non-trading E2E reached 32 passing tests; its only failure was an
+  unrelated TLS `ECONNRESET` reaching `api.bls.gov`, explicitly classified by
+  the provider layer as external network unreachability.
+
+## Completion criteria
+
+- The targeted regression tests fail before the repair and pass afterward.
+- `npx tsc --noEmit`, `pnpm test`, and `pnpm test:e2e` pass.
+- Targeted IBKR paper broker and UTA scenarios pass against a verified paper
+  account.
+- The live-paper run leaves no new open orders or position delta.
+- The smoke record is written and a stable sanitized fixture is reviewed.
+- The change is delivered to `dev` as a focused internal repair with the
+  contribution in PR #345 credited in the final history or PR discussion.

--- a/docs/uta-live-testing.md
+++ b/docs/uta-live-testing.md
@@ -50,8 +50,10 @@ The commands are intentionally asymmetric:
 # Ordinary product E2E: safe for routine local development and CI.
 pnpm test:e2e
 
-# One explicitly selected account-trading spec.
-OPENALICE_UTA_LIVE_PAPER=1 pnpm test:uta:live-paper -- \
+# One explicitly selected account-trading spec. Invoke Vitest directly so
+# pnpm does not forward a literal `--` that defeats Vitest's file filter.
+OPENALICE_UTA_LIVE_PAPER=1 pnpm exec vitest run \
+  --config vitest.uta-live.config.ts \
   services/uta/src/domain/trading/__test__/e2e/uta-bybit.e2e.spec.ts
 
 # Full configured demo/paper account suite. Use only for a deliberate sweep.
@@ -82,6 +84,24 @@ query the venue again, cancel new open orders, close only positions created by
 the test, reject leftover Alice staging, and confirm the account returned to
 its baseline. If that cannot be proven, stop the development lane and report
 the account as requiring manual cleanup.
+
+IBKR routing smoke uses
+`services/uta/src/domain/trading/__test__/e2e/live-paper-evidence.ts` to append
+a small JSONL run record under ignored `data/uta-live-paper-runs/` by default.
+Set `OPENALICE_UTA_LIVE_RECORD_DIR` to choose another local destination. The
+record format deliberately excludes account ids, balances, credentials, and
+position payloads. When live contract data should become an offline regression
+input, manually review and copy only stable canonical contract fields into a
+tracked fixture; never make a test overwrite tracked fixtures directly.
+
+When selecting a test by name, keep the same direct invocation pattern:
+
+```bash
+OPENALICE_UTA_LIVE_PAPER=1 pnpm exec vitest run \
+  --config vitest.uta-live.config.ts \
+  services/uta/src/domain/trading/__test__/e2e/ibkr-paper.e2e.spec.ts \
+  -t 'canonical conId routing'
+```
 
 ## Ground rules
 

--- a/services/uta/src/domain/trading/__test__/e2e/ibkr-paper.e2e.spec.ts
+++ b/services/uta/src/domain/trading/__test__/e2e/ibkr-paper.e2e.spec.ts
@@ -15,6 +15,7 @@ import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
 import Decimal from 'decimal.js'
 import { Contract, Order } from '@traderalice/ibkr'
 import { getTestAccounts, filterByProvider } from './setup.js'
+import { contractEvidence, recordLivePaperEvidence } from './live-paper-evidence.js'
 import type { IBroker } from '../../brokers/types.js'
 import '../../contract-ext.js'
 
@@ -115,6 +116,97 @@ describe('IbkrBroker — currency tracking', () => {
   })
 })
 
+// ==================== Canonical conId routing (any time) ====================
+
+describe('IbkrBroker — canonical conId routing', () => {
+  beforeEach(({ skip }) => { if (!broker) skip('no IBKR paper account') })
+
+  it('validates a polluted USD.CHF conId as a what-if order and leaves no state delta', async () => {
+    expect(broker!.getOpenOrders).toBeDefined()
+
+    const clean = new Contract()
+    clean.conId = 12087820
+    const details = await broker!.getContractDetails(clean)
+    expect(details?.contract).toBeDefined()
+    expect(details!.contract.secType).toBe('CASH')
+    expect(details!.contract.exchange).toBe('IDEALPRO')
+    expect(details!.contract.currency).toBe('CHF')
+
+    const positionsBefore = await broker!.getPositions()
+    const ordersBefore = await broker!.getOpenOrders!()
+    const baselineOrderIds = new Set(ordersBefore.map(order => order.orderId))
+    const baselinePositions = positionsBefore
+      .map(position => `${position.contract.conId}|${position.contract.localSymbol}|${position.side}|${position.quantity}`)
+      .sort()
+    const evidencePath = await recordLivePaperEvidence({
+      scenario: 'ibkr-usd-chf-canonical-routing',
+      phase: 'baseline',
+      contract: contractEvidence(details!.contract),
+      baseline: { positions: positionsBefore.length, openOrders: ordersBefore.length },
+    })
+
+    // Recreate the historical UTA failure shape. conId is the identity; the
+    // other fields are deliberately wrong and must not reach TWS.
+    const polluted = new Contract()
+    polluted.conId = 12087820
+    polluted.symbol = 'USDCHF'
+    polluted.secType = 'STK'
+    polluted.exchange = 'SMART'
+    polluted.currency = 'USD'
+
+    const order = new Order()
+    order.action = 'BUY'
+    order.orderType = 'MKT'
+    order.totalQuantity = new Decimal('25000')
+    order.tif = 'DAY'
+    order.whatIf = true
+
+    let result: Awaited<ReturnType<IBroker['placeOrder']>> | undefined
+    try {
+      result = await broker!.placeOrder(polluted, order)
+      await recordLivePaperEvidence({
+        scenario: 'ibkr-usd-chf-canonical-routing',
+        phase: 'what-if-result',
+        contract: contractEvidence(details!.contract),
+        request: contractEvidence(polluted),
+        result: {
+          success: result.success,
+          status: result.orderState?.status,
+          error: result.error,
+        },
+      })
+      expect(result.success, result.error).toBe(true)
+    } finally {
+      // whatIf should never become an open order. If venue behavior changes,
+      // cancel any order introduced by this test before asserting the baseline.
+      const afterAttempt = await broker!.getOpenOrders!()
+      const introduced = afterAttempt.filter(order => !baselineOrderIds.has(order.orderId))
+      for (const open of introduced) await broker!.cancelOrder(open.orderId)
+
+      const positionsAfter = await broker!.getPositions()
+      const ordersAfter = await broker!.getOpenOrders!()
+      const finalPositions = positionsAfter
+        .map(position => `${position.contract.conId}|${position.contract.localSymbol}|${position.side}|${position.quantity}`)
+        .sort()
+      const finalOrderIds = ordersAfter.map(order => order.orderId).sort()
+      const matchesBaseline =
+        JSON.stringify(finalPositions) === JSON.stringify(baselinePositions) &&
+        JSON.stringify(finalOrderIds) === JSON.stringify([...baselineOrderIds].sort())
+      await recordLivePaperEvidence({
+        scenario: 'ibkr-usd-chf-canonical-routing',
+        phase: 'cleanup',
+        cleanup: {
+          positions: positionsAfter.length,
+          openOrders: ordersAfter.length,
+          matchesBaseline,
+        },
+      })
+      console.log(`  live-paper evidence: ${evidencePath}`)
+      expect(matchesBaseline).toBe(true)
+    }
+  }, 30_000)
+})
+
 // ==================== Order lifecycle (any time — limit orders accepted outside market hours) ====================
 
 describe('IbkrBroker — order lifecycle', () => {
@@ -135,26 +227,34 @@ describe('IbkrBroker — order lifecycle', () => {
     order.totalQuantity = new Decimal('1')
     order.tif = 'GTC'
 
-    const placed = await broker!.placeOrder(contract, order)
-    console.log(`  placeOrder LMT: success=${placed.success}, orderId=${placed.orderId}, status=${placed.orderState?.status}`)
-    expect(placed.success).toBe(true)
-    expect(placed.orderId).toBeDefined()
+    let orderId: string | undefined
+    try {
+      const placed = await broker!.placeOrder(contract, order)
+      orderId = placed.orderId
+      console.log(`  placeOrder LMT: success=${placed.success}, orderId=${placed.orderId}, status=${placed.orderState?.status}`)
+      expect(placed.success).toBe(true)
+      expect(orderId).toBeDefined()
 
-    // Query order
-    await new Promise(r => setTimeout(r, 1000))
-    const detail = await broker!.getOrder(placed.orderId!)
-    console.log(`  getOrder: status=${detail?.orderState.status}`)
-    expect(detail).not.toBeNull()
+      // Query order
+      await new Promise(r => setTimeout(r, 1000))
+      const detail = await broker!.getOrder(orderId!)
+      console.log(`  getOrder: status=${detail?.orderState.status}`)
+      expect(detail).not.toBeNull()
 
-    // Batch query
-    const orders = await broker!.getOrders([placed.orderId!])
-    console.log(`  getOrders: ${orders.length} results`)
-    expect(orders.length).toBe(1)
+      // Batch query
+      const orders = await broker!.getOrders([orderId!])
+      console.log(`  getOrders: ${orders.length} results`)
+      expect(orders.length).toBe(1)
 
-    // Cancel
-    const cancelled = await broker!.cancelOrder(placed.orderId!)
-    console.log(`  cancelOrder: success=${cancelled.success}, status=${cancelled.orderState?.status}`)
-    expect(cancelled.success).toBe(true)
+      const cancelled = await broker!.cancelOrder(orderId!)
+      console.log(`  cancelOrder: success=${cancelled.success}, status=${cancelled.orderState?.status}`)
+      expect(cancelled.success).toBe(true)
+    } finally {
+      if (orderId) {
+        const stillOpen = (await broker!.getOpenOrders!()).some(open => open.orderId === orderId)
+        if (stillOpen) await broker!.cancelOrder(orderId)
+      }
+    }
   }, 30_000)
 })
 
@@ -175,9 +275,9 @@ describe('IbkrBroker — fill + position (market hours)', () => {
 
     try {
       const quote = await broker!.getQuote(contract)
-      expect(quote.last).toBeGreaterThan(0)
-      expect(quote.bid).toBeGreaterThan(0)
-      expect(quote.ask).toBeGreaterThan(0)
+      expect(Number(quote.last)).toBeGreaterThan(0)
+      expect(Number(quote.bid)).toBeGreaterThan(0)
+      expect(Number(quote.ask)).toBeGreaterThan(0)
       console.log(`  AAPL: last=$${quote.last}, bid=$${quote.bid}, ask=$${quote.ask}, vol=${quote.volume}`)
     } catch (err: any) {
       // TWS paper frequently times out on snapshot market data requests
@@ -189,62 +289,69 @@ describe('IbkrBroker — fill + position (market hours)', () => {
     }
   })
 
-  it('places market buy 1 AAPL → success with numeric orderId', async () => {
+  it('places, queries, and closes only the AAPL quantity created by this test', async () => {
     const contract = new Contract()
     contract.symbol = 'AAPL'
     contract.secType = 'STK'
     contract.exchange = 'SMART'
     contract.currency = 'USD'
 
-    const order = new Order()
-    order.action = 'BUY'
-    order.orderType = 'MKT'
-    order.totalQuantity = new Decimal('1')
-    order.tif = 'DAY'
+    const positionsBefore = await broker!.getPositions()
+    const initialQty = positionsBefore.find(position => position.contract.symbol === 'AAPL')?.quantity ?? new Decimal(0)
+    const ordersBefore = await broker!.getOpenOrders!()
+    const baselineOrderIds = new Set(ordersBefore.map(open => open.orderId))
+    let entryOrderId: string | undefined
 
-    const result = await broker!.placeOrder(contract, order)
-    console.log(`  placeOrder: success=${result.success}, orderId=${result.orderId}, status=${result.orderState?.status}`)
+    const currentAaplQty = async (): Promise<Decimal> => {
+      const positions = await broker!.getPositions()
+      return positions.find(position => position.contract.symbol === 'AAPL')?.quantity ?? new Decimal(0)
+    }
+    const waitForQty = async (expected: Decimal): Promise<Decimal> => {
+      let current = await currentAaplQty()
+      for (let i = 0; i < 15 && !current.equals(expected); i += 1) {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        current = await currentAaplQty()
+      }
+      return current
+    }
 
-    expect(result.success).toBe(true)
-    expect(result.orderId).toBeDefined()
-  }, 15_000)
+    try {
+      const order = new Order()
+      order.action = 'BUY'
+      order.orderType = 'MKT'
+      order.totalQuantity = new Decimal('1')
+      order.tif = 'DAY'
 
-  it('queries order by ID after place', async () => {
-    const contract = new Contract()
-    contract.symbol = 'AAPL'
-    contract.secType = 'STK'
-    contract.exchange = 'SMART'
-    contract.currency = 'USD'
+      const placed = await broker!.placeOrder(contract, order)
+      entryOrderId = placed.orderId
+      console.log(`  placeOrder: success=${placed.success}, orderId=${placed.orderId}, status=${placed.orderState?.status}`)
+      expect(placed.success, placed.error).toBe(true)
+      expect(entryOrderId).toBeDefined()
 
-    const order = new Order()
-    order.action = 'BUY'
-    order.orderType = 'MKT'
-    order.totalQuantity = new Decimal('1')
-    order.tif = 'DAY'
+      const filledQty = await waitForQty(initialQty.plus(1))
+      expect(filledQty.equals(initialQty.plus(1))).toBe(true)
+      const detail = await broker!.getOrder(entryOrderId!)
+      expect(detail).not.toBeNull()
+    } finally {
+      const openAfterAttempt = await broker!.getOpenOrders!()
+      for (const open of openAfterAttempt.filter(order => !baselineOrderIds.has(order.orderId))) {
+        await broker!.cancelOrder(open.orderId)
+      }
 
-    const placed = await broker!.placeOrder(contract, order)
-    expect(placed.orderId).toBeDefined()
+      // Cancel first, then close only the filled delta introduced by this test.
+      const afterEntry = await currentAaplQty()
+      const createdQty = afterEntry.minus(initialQty)
+      if (createdQty.greaterThan(0)) {
+        const closed = await broker!.closePosition(contract, createdQty)
+        expect(closed.success, closed.error).toBe(true)
+      } else if (createdQty.lessThan(0)) {
+        throw new Error(`AAPL position moved below its baseline during E2E: ${afterEntry} < ${initialQty}`)
+      }
 
-    await new Promise(r => setTimeout(r, 3000))
-
-    const detail = await broker!.getOrder(placed.orderId!)
-    console.log(`  getOrder: status=${detail?.orderState.status}`)
-
-    expect(detail).not.toBeNull()
-  }, 20_000)
-
-  it('closes AAPL position', async () => {
-    // Wait for TWS to update positions after preceding buy
-    await new Promise(r => setTimeout(r, 3000))
-
-    const contract = new Contract()
-    contract.symbol = 'AAPL'
-    contract.secType = 'STK'
-    contract.exchange = 'SMART'
-    contract.currency = 'USD'
-
-    const result = await broker!.closePosition(contract)
-    console.log(`  closePosition: success=${result.success}, error=${result.error}`)
-    expect(result.success).toBe(true)
-  }, 20_000)
+      const cleanedQty = await waitForQty(initialQty)
+      expect(cleanedQty.equals(initialQty)).toBe(true)
+      const finalOrderIds = (await broker!.getOpenOrders!()).map(open => open.orderId).sort()
+      expect(finalOrderIds).toEqual([...baselineOrderIds].sort())
+    }
+  }, 60_000)
 })

--- a/services/uta/src/domain/trading/__test__/e2e/live-paper-evidence.ts
+++ b/services/uta/src/domain/trading/__test__/e2e/live-paper-evidence.ts
@@ -1,0 +1,87 @@
+import { appendFile, mkdir } from 'node:fs/promises'
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import type { Contract } from '@traderalice/ibkr'
+
+export interface ContractEvidence {
+  conId: number
+  symbol: string
+  localSymbol: string
+  secType: string
+  exchange: string
+  primaryExchange: string
+  currency: string
+  tradingClass: string
+  multiplier: string
+}
+
+export interface LivePaperEvidence {
+  scenario: string
+  phase: string
+  contract?: ContractEvidence
+  request?: Partial<ContractEvidence>
+  result?: {
+    success?: boolean
+    status?: string
+    error?: string
+  }
+  baseline?: {
+    positions: number
+    openOrders: number
+  }
+  cleanup?: {
+    positions: number
+    openOrders: number
+    matchesBaseline: boolean
+  }
+  note?: string
+}
+
+const runStamp = new Date().toISOString().replaceAll(':', '-').replaceAll('.', '-')
+const runId = process.env.OPENALICE_UTA_LIVE_RUN_ID || `${runStamp}-${process.pid}`
+
+function currentCommit(): string {
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const gitCommit = currentCommit()
+
+export function contractEvidence(contract: Contract): ContractEvidence {
+  return {
+    conId: contract.conId,
+    symbol: contract.symbol,
+    localSymbol: contract.localSymbol,
+    secType: contract.secType,
+    exchange: contract.exchange,
+    primaryExchange: contract.primaryExchange,
+    currency: contract.currency,
+    tradingClass: contract.tradingClass,
+    multiplier: contract.multiplier,
+  }
+}
+
+/** Append a deliberately small, non-account live-paper record. The default
+ * destination is under ignored data/; callers must not pass balances,
+ * credentials, account ids, positions, or other private broker payloads. */
+export async function recordLivePaperEvidence(evidence: LivePaperEvidence): Promise<string> {
+  const outputDir = resolve(
+    process.env.OPENALICE_UTA_LIVE_RECORD_DIR ||
+      resolve(process.cwd(), 'data', 'uta-live-paper-runs'),
+  )
+  await mkdir(outputDir, { recursive: true })
+  const outputPath = resolve(outputDir, `${runId}.jsonl`)
+  await appendFile(outputPath, `${JSON.stringify({
+    schemaVersion: 1,
+    recordedAt: new Date().toISOString(),
+    gitCommit,
+    paper: true,
+    broker: 'ibkr',
+    ...evidence,
+  })}\n`, 'utf8')
+  return outputPath
+}

--- a/services/uta/src/domain/trading/__test__/e2e/uta-ibkr.e2e.spec.ts
+++ b/services/uta/src/domain/trading/__test__/e2e/uta-ibkr.e2e.spec.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
 import { getTestAccounts, filterByProvider } from './setup.js'
+import { contractEvidence, recordLivePaperEvidence } from './live-paper-evidence.js'
 import { UnifiedTradingAccount } from '../../UnifiedTradingAccount.js'
 import type { IBroker } from '../../brokers/types.js'
 import '../../contract-ext.js'
@@ -29,6 +30,63 @@ beforeAll(async () => {
   marketOpen = clock.isOpen
   console.log(`UTA IBKR: market ${marketOpen ? 'OPEN' : 'CLOSED'}`)
 }, 60_000)
+
+// ==================== FX identity → staging contract (any time) ====================
+
+describe('UTA — IBKR FX identity staging', () => {
+  beforeEach(({ skip }) => { if (!uta) skip('no IBKR paper account') })
+
+  it('round-trips an FX leaf as conId identity while keeping symbol display-only', async () => {
+    const results = await broker!.searchContracts('USD.CHF')
+    const leaf = results.find(result =>
+      result.contract.conId > 0 &&
+      result.contract.secType === 'CASH' &&
+      result.contract.currency === 'CHF',
+    )
+    expect(leaf, 'USD.CHF leaf not returned by IBKR search').toBeDefined()
+
+    const nativeKey = broker!.getNativeKey(leaf!.contract)
+    const aliceId = `${uta!.id}|${nativeKey}`
+    let committed = false
+    try {
+      const staged = uta!.stagePlaceOrder({
+        aliceId,
+        symbol: 'USDCHF',
+        action: 'BUY',
+        orderType: 'LMT',
+        lmtPrice: '0.1',
+        totalQuantity: '25000',
+        tif: 'DAY',
+      })
+      expect(staged.staged).toBe(true)
+
+      const operation = uta!.status().staged[0]
+      expect(operation.action).toBe('placeOrder')
+      if (operation.action !== 'placeOrder') throw new Error('expected staged placeOrder')
+      expect(operation.contract.conId).toBe(leaf!.contract.conId)
+      expect(operation.contract.symbol).toBe('USDCHF')
+      expect(operation.contract.exchange).toBe('')
+      expect(operation.contract.currency).toBe('')
+
+      const commit = uta!.commit('e2e: verify USD.CHF conId staging boundary')
+      expect(commit.prepared).toBe(true)
+      committed = true
+      await recordLivePaperEvidence({
+        scenario: 'uta-ibkr-usd-chf-identity-staging',
+        phase: 'prepared-not-pushed',
+        contract: contractEvidence(leaf!.contract),
+        request: contractEvidence(operation.contract),
+        note: 'UTA carries conId identity plus display symbol; IbkrBroker resolves canonical routing at push.',
+      })
+    } finally {
+      if (committed || uta!.status().staged.length > 0) {
+        await uta!.reject('e2e: staging-boundary smoke cleanup')
+      }
+      expect(uta!.status().staged).toHaveLength(0)
+      expect(uta!.status().pendingHash).toBeNull()
+    }
+  }, 30_000)
+})
 
 // ==================== Order lifecycle (any time) ====================
 

--- a/services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.spec.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import Decimal from 'decimal.js'
 import { Contract, Order } from '@traderalice/ibkr'
 import { IbkrBroker } from './IbkrBroker.js'
+import contractCorpus from './__fixtures__/contract-resolution.v1.json'
 
 /**
  * The gate must fire BEFORE any bridge/client access, so it is testable on
@@ -24,6 +25,233 @@ function stkOrder(): { contract: Contract; order: Order } {
   order.lmtPrice = new Decimal(100)
   return { contract, order }
 }
+
+function recordedContract(name: string): Contract {
+  const recorded = contractCorpus.cases.find(item => item.name === name)?.canonical
+  if (!recorded) throw new Error(`missing recorded IBKR contract fixture: ${name}`)
+  const contract = new Contract()
+  Object.assign(contract, recorded)
+  contract.secType = recorded.secType as Contract['secType']
+  return contract
+}
+
+function usdChfContract(): Contract {
+  return recordedContract('usd-chf-cash')
+}
+
+function brokerWithContractIo(resolvedContract = usdChfContract()): {
+  broker: IbkrBroker
+  bridge: {
+    requestCollector: ReturnType<typeof vi.fn>
+    requestSnapshot: ReturnType<typeof vi.fn>
+    requestOrder: ReturnType<typeof vi.fn>
+  }
+  client: {
+    reqContractDetails: ReturnType<typeof vi.fn>
+    reqMktData: ReturnType<typeof vi.fn>
+    placeOrder: ReturnType<typeof vi.fn>
+  }
+} {
+  const broker = new IbkrBroker({ id: 'ibkr-test', host: '127.0.0.1', port: 7497, clientId: 91 })
+  const bridge = {
+    connectionDead: false,
+    allocReqId: vi.fn(() => 17),
+    requestCollector: vi.fn(async () => [{ contract: Object.assign(new Contract(), resolvedContract) }]),
+    requestSnapshot: vi.fn(async () => ({ last: 0.8, bid: 0.79, ask: 0.81, volume: 1 })),
+    getNextOrderId: vi.fn(() => 42),
+    requestOrder: vi.fn(async () => ({ orderState: { status: 'Submitted' } })),
+  }
+  const client = {
+    reqContractDetails: vi.fn(),
+    reqMktData: vi.fn(),
+    placeOrder: vi.fn(),
+  }
+  ;(broker as unknown as { bridge: unknown }).bridge = bridge
+  ;(broker as unknown as { client: unknown }).client = client
+  return { broker, bridge, client }
+}
+
+function limitBuy(): Order {
+  const order = new Order()
+  order.action = 'BUY'
+  order.orderType = 'LMT'
+  order.totalQuantity = new Decimal(1)
+  order.lmtPrice = new Decimal('0.1')
+  return order
+}
+
+describe('IbkrBroker — canonical conId contract resolution', () => {
+  it.each(contractCorpus.cases)('replays the recorded $name canonical contract', async ({ canonical }) => {
+    const resolved = new Contract()
+    Object.assign(resolved, canonical)
+    resolved.secType = canonical.secType as Contract['secType']
+    const { broker, client } = brokerWithContractIo(resolved)
+    const identity = Object.assign(new Contract(), {
+      conId: canonical.conId,
+      symbol: 'DISPLAY-ONLY',
+      secType: 'STK' as const,
+      exchange: 'SMART',
+      currency: 'USD',
+    })
+
+    const result = await broker.placeOrder(identity, limitBuy())
+
+    expect(result.success).toBe(true)
+    const sent = client.placeOrder.mock.calls[0][1] as Contract
+    expect({
+      conId: sent.conId,
+      symbol: sent.symbol,
+      localSymbol: sent.localSymbol,
+      secType: sent.secType,
+      exchange: sent.exchange,
+      primaryExchange: sent.primaryExchange,
+      currency: sent.currency,
+      tradingClass: sent.tradingClass,
+      multiplier: sent.multiplier,
+    }).toEqual(canonical)
+  })
+
+  it('resolves a polluted conId through a clean lookup before placing an order', async () => {
+    const { broker, client } = brokerWithContractIo()
+    const input = new Contract()
+    input.conId = 12087820
+    input.symbol = 'USDCHF' // display-only value carried by UTA staging
+    input.secType = 'STK'
+    input.exchange = 'SMART'
+    input.currency = 'USD'
+
+    const result = await broker.placeOrder(input, limitBuy())
+
+    expect(result.success).toBe(true)
+    expect(client.reqContractDetails).toHaveBeenCalledOnce()
+    const lookup = client.reqContractDetails.mock.calls[0][1] as Contract
+    expect({
+      conId: lookup.conId,
+      symbol: lookup.symbol,
+      secType: lookup.secType,
+      exchange: lookup.exchange,
+      currency: lookup.currency,
+    }).toEqual({ conId: 12087820, symbol: '', secType: '', exchange: '', currency: '' })
+
+    const sent = client.placeOrder.mock.calls[0][1] as Contract
+    expect({
+      conId: sent.conId,
+      symbol: sent.symbol,
+      localSymbol: sent.localSymbol,
+      secType: sent.secType,
+      exchange: sent.exchange,
+      currency: sent.currency,
+    }).toEqual({
+      conId: 12087820,
+      symbol: 'USD',
+      localSymbol: 'USD.CHF',
+      secType: 'CASH',
+      exchange: 'IDEALPRO',
+      currency: 'CHF',
+    })
+  })
+
+  it('does not mutate a symbol-form stock while applying its convenience defaults', async () => {
+    const { broker, client } = brokerWithContractIo()
+    const input = new Contract()
+    input.symbol = 'AAPL'
+    input.secType = 'STK'
+
+    await broker.placeOrder(input, limitBuy())
+
+    expect(input.exchange).toBe('')
+    expect(input.currency).toBe('')
+    const sent = client.placeOrder.mock.calls[0][1] as Contract
+    expect(sent.symbol).toBe('AAPL')
+    expect(sent.secType).toBe('STK')
+    expect(sent.exchange).toBe('SMART')
+    expect(sent.currency).toBe('USD')
+    expect(client.reqContractDetails).not.toHaveBeenCalled()
+  })
+
+  it('refuses to guess routing fields for a non-stock contract without conId', async () => {
+    const { broker, client } = brokerWithContractIo()
+    const input = new Contract()
+    input.symbol = 'USD'
+    input.secType = 'CASH'
+    input.currency = 'CHF'
+
+    const result = await broker.placeOrder(input, limitBuy())
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/missing exchange.*search\/expand/i)
+    expect(client.placeOrder).not.toHaveBeenCalled()
+    expect(client.reqContractDetails).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates concurrent conId lookups and returns independent contracts', async () => {
+    const { broker, client } = brokerWithContractIo()
+    const left = Object.assign(new Contract(), { conId: 12087820 })
+    const right = Object.assign(new Contract(), { conId: 12087820 })
+
+    const [a, b] = await Promise.all([broker.getQuote(left), broker.getQuote(right)])
+
+    expect(client.reqContractDetails).toHaveBeenCalledOnce()
+    expect(a.contract).not.toBe(b.contract)
+    a.contract.exchange = 'MUTATED'
+    expect(b.contract.exchange).toBe('IDEALPRO')
+  })
+
+  it('drops a failed cached lookup so the conId can be retried', async () => {
+    const { broker, bridge, client } = brokerWithContractIo()
+    bridge.requestCollector
+      .mockRejectedValueOnce(new Error('temporary contract lookup failure'))
+      .mockResolvedValueOnce([{ contract: usdChfContract() }])
+    const input = Object.assign(new Contract(), { conId: 12087820 })
+
+    await expect(broker.getQuote(input)).rejects.toThrow(/temporary contract lookup failure/)
+    await expect(broker.getQuote(input)).resolves.toMatchObject({ contract: { exchange: 'IDEALPRO' } })
+    expect(client.reqContractDetails).toHaveBeenCalledTimes(2)
+  })
+
+  it('canonicalizes a conId contract before an order modification', async () => {
+    const { broker, client } = brokerWithContractIo()
+    const polluted = Object.assign(new Contract(), {
+      conId: 12087820,
+      symbol: 'USDCHF',
+      secType: 'STK',
+      exchange: 'SMART',
+      currency: 'USD',
+    })
+    ;(broker as unknown as { getOrder: unknown }).getOrder = vi.fn(async () => ({
+      contract: polluted,
+      order: limitBuy(),
+      orderState: { status: 'Submitted' },
+    }))
+
+    const result = await broker.modifyOrder('42', { lmtPrice: new Decimal('0.2') })
+
+    expect(result.success).toBe(true)
+    const sent = client.placeOrder.mock.calls[0][1] as Contract
+    expect(sent.secType).toBe('CASH')
+    expect(sent.exchange).toBe('IDEALPRO')
+    expect(sent.currency).toBe('CHF')
+  })
+
+  it('closes an FX position without overwriting its venue contract', async () => {
+    const broker = bareBroker()
+    const positionContract = usdChfContract()
+    ;(broker as unknown as { getPositions: unknown }).getPositions = vi.fn(async () => [{
+      contract: positionContract,
+      side: 'long',
+      quantity: new Decimal('1'),
+    }])
+    const placeOrder = vi.fn(async () => ({ success: true, orderId: '42' }))
+    ;(broker as unknown as { placeOrder: unknown }).placeOrder = placeOrder
+
+    const result = await broker.closePosition(Object.assign(new Contract(), { conId: 12087820 }))
+
+    expect(result.success).toBe(true)
+    const sent = placeOrder.mock.calls[0][0] as Contract
+    expect(sent.exchange).toBe('IDEALPRO')
+    expect(positionContract.exchange).toBe('IDEALPRO')
+  })
+})
 
 describe('IbkrBroker — attached TP/SL refusal gate', () => {
   // Guards the silent naked-entry failure: the tpsl param used to be

--- a/services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.ts
@@ -16,6 +16,8 @@ import Decimal from 'decimal.js'
 import {
   EClient,
   Contract,
+  ComboLeg,
+  DeltaNeutralContract,
   Order,
   OrderCancel,
   OrderState,
@@ -42,6 +44,19 @@ import { aggregateAccountFromPositions } from '../../position-math.js'
 import { RequestBridge } from './request-bridge.js'
 import { resolveSymbol } from './ibkr-contracts.js'
 import type { IbkrBrokerConfig } from './ibkr-types.js'
+
+/** IBKR models are mutable because the wire decoder fills them field by field.
+ * Broker routing must not let a caller mutate a cached canonical contract (or
+ * let routing defaults mutate a staged/ledger contract), so clone at the
+ * boundary where contracts change ownership. */
+function cloneContract(contract: Contract): Contract {
+  const clone = Object.assign(new Contract(), contract)
+  clone.comboLegs = (contract.comboLegs ?? []).map(leg => Object.assign(new ComboLeg(), leg))
+  clone.deltaNeutralContract = contract.deltaNeutralContract
+    ? Object.assign(new DeltaNeutralContract(), contract.deltaNeutralContract)
+    : null
+  return clone
+}
 
 export class IbkrBroker implements IBroker {
   // ---- Self-registration ----
@@ -84,6 +99,9 @@ export class IbkrBroker implements IBroker {
   private client: EClient
   private readonly config: IbkrBrokerConfig
   private accountId: string | null = null
+  /** A promise cache deduplicates simultaneous quote/order resolution for the
+   * same conId. Cached contracts are canonical TWS values; callers get clones. */
+  private readonly conIdContracts = new Map<number, Promise<Contract>>()
 
   constructor(config: IbkrBrokerConfig) {
     this.config = config
@@ -236,19 +254,91 @@ export class IbkrBroker implements IBroker {
   /** All matching contract details (a conId resolves to one; a family query
    *  like EUR/CASH or an issuerId resolves to many). */
   private async contractDetailsQuery(query: Contract): Promise<ContractDetails[]> {
+    const requestContract = cloneContract(query)
     // Routing defaults are for SYMBOL-form STK queries only. A conId (or
     // issuerId) resolves globally, and non-STK secTypes don't live on SMART
     // (EUR.USD is on IDEALPRO; conId+SMART → TWS error 200, found live).
     // Forcing USD would also narrow a CASH family query to one pair.
-    if (!query.conId && !query.issuerId && (!query.secType || query.secType === 'STK')) {
-      if (!query.exchange) query.exchange = 'SMART'
-      if (!query.currency) query.currency = 'USD'
+    if (!requestContract.conId && !requestContract.issuerId && (!requestContract.secType || requestContract.secType === 'STK')) {
+      if (!requestContract.exchange) requestContract.exchange = 'SMART'
+      if (!requestContract.currency) requestContract.currency = 'USD'
     }
 
     const reqId = this.bridge.allocReqId()
     const promise = this.bridge.requestCollector<ContractDetails>(reqId)
-    this.client.reqContractDetails(reqId, query)
-    return promise
+    this.client.reqContractDetails(reqId, requestContract)
+    const details = await promise
+    for (const detail of details) this.rememberCanonicalContract(detail.contract)
+    return details
+  }
+
+  /** Seed the cache from any authoritative ContractDetails response. Do not
+   * replace an in-flight lookup for the same conId. */
+  private rememberCanonicalContract(contract: Contract): void {
+    if (!contract.conId || this.conIdContracts.has(contract.conId)) return
+    this.conIdContracts.set(contract.conId, Promise.resolve(cloneContract(contract)))
+  }
+
+  /** Resolve a conId with a deliberately clean request. conId is authoritative
+   * identity; caller-provided routing fields must not narrow this lookup. */
+  private async resolveConIdContract(conId: number): Promise<Contract> {
+    let pending = this.conIdContracts.get(conId)
+    if (!pending) {
+      pending = (async () => {
+        const query = new Contract()
+        query.conId = conId
+        const details = await this.contractDetailsQuery(query)
+        const canonical = details.find(item => item.contract.conId === conId)?.contract
+        if (!canonical) {
+          throw new BrokerError('EXCHANGE', `IBKR conId ${conId} did not resolve to a canonical contract`)
+        }
+        return cloneContract(canonical)
+      })()
+      this.conIdContracts.set(conId, pending)
+    }
+
+    try {
+      return cloneContract(await pending)
+    } catch (err) {
+      // A transient TWS/network failure must not become a permanent rejected
+      // cache entry. Only delete the promise that this caller observed.
+      if (this.conIdContracts.get(conId) === pending) this.conIdContracts.delete(conId)
+      throw err
+    }
+  }
+
+  /** Convert an identity/display contract into a contract safe to send to a
+   * TWS quote or order request. */
+  private async resolveRoutableContract(contract: Contract): Promise<Contract> {
+    if (contract.conId) {
+      const canonical = await this.resolveConIdContract(contract.conId)
+      if (contract.aliceId) canonical.aliceId = contract.aliceId
+      return canonical
+    }
+
+    const routed = cloneContract(contract)
+    // Bare symbols are the one supported convenience form. They mean a US
+    // stock unless the caller supplied a different secType explicitly.
+    if (!routed.secType && routed.symbol) routed.secType = 'STK'
+    if (routed.secType === 'STK') {
+      if (!routed.exchange) routed.exchange = 'SMART'
+      if (!routed.currency) routed.currency = 'USD'
+      return routed
+    }
+
+    const missing: string[] = []
+    if (!routed.secType) missing.push('secType')
+    if (!routed.exchange) missing.push('exchange')
+    if (!routed.currency) missing.push('currency')
+    if (!routed.symbol && !routed.localSymbol) missing.push('symbol/localSymbol')
+    if (missing.length > 0) {
+      throw new BrokerError(
+        'EXCHANGE',
+        `IBKR contract without conId is missing ${missing.join(', ')}. ` +
+        'Resolve it through contract search/expand before requesting a quote or order.',
+      )
+    }
+    return routed
   }
 
   /**
@@ -358,19 +448,12 @@ export class IbkrBroker implements IBroker {
         error: 'IBKR attached TP/SL (bracket) is not implemented yet — refusing to place a naked entry. Place the entry first, then a standalone STP/LMT protective order.',
       }
     }
-    // TWS requires exchange and currency on the contract. Upstream layers
-    // (staging, AI tools) typically only populate symbol + secType.
-    // Default to SMART routing. Currency defaults to USD — non-USD markets
-    // (LSE/GBP, TSE/JPY) and forex (CASH secType) will need the caller
-    // to specify currency explicitly.
-    if (!contract.exchange) contract.exchange = 'SMART'
-    if (!contract.currency) contract.currency = 'USD'
-
     try {
       this._ensureAlive()
+      const routedContract = await this.resolveRoutableContract(contract)
       const orderId = this.bridge.getNextOrderId()
       const promise = this.bridge.requestOrder(orderId)
-      this.client.placeOrder(orderId, contract, order)
+      this.client.placeOrder(orderId, routedContract, order)
       const result = await promise
       return {
         success: true,
@@ -401,9 +484,10 @@ export class IbkrBroker implements IBroker {
       if (changes.trailingPercent != null) mergedOrder.trailingPercent = changes.trailingPercent
       if (changes.trailStopPrice != null) mergedOrder.trailStopPrice = changes.trailStopPrice
 
+      const routedContract = await this.resolveRoutableContract(original.contract)
       const numericId = parseInt(orderId, 10)
       const promise = this.bridge.requestOrder(numericId)
-      this.client.placeOrder(numericId, original.contract, mergedOrder)
+      this.client.placeOrder(numericId, routedContract, mergedOrder)
       const result = await promise
 
       return {
@@ -445,9 +529,10 @@ export class IbkrBroker implements IBroker {
       return { success: false, error: `No position for ${symbol ?? `conId=${contract.conId}`}` }
     }
 
-    // Use the position's contract (has conId etc.) but route via SMART
-    const closeContract = pos.contract
-    closeContract.exchange = 'SMART'
+    // The position contract came from TWS and may live somewhere other than
+    // SMART (for example CASH on IDEALPRO). Do not mutate or override it;
+    // placeOrder will canonicalize the conId again at the write boundary.
+    const closeContract = cloneContract(pos.contract)
     const order = new Order()
     order.action = pos.side === 'long' ? 'SELL' : 'BUY'
     order.orderType = 'MKT'
@@ -615,40 +700,17 @@ export class IbkrBroker implements IBroker {
    * Each call briefly occupies one TWS market data line (limit ~100),
    * auto-released after tickSnapshotEnd.
    */
-  /** conId → resolved full contract, so by-conId quotes pay reqContractDetails once. */
-  private readonly conIdContracts = new Map<number, Contract>()
-
   async getQuote(contract: Contract): Promise<Quote> {
-    // Enrichment must run BEFORE routing defaults: a premature SMART poisons
-    // the conId details lookup for anything not on SMART (EUR.USD@IDEALPRO).
-    // The enriched contract carries its real exchange/currency.
-
-    // TWS rejects reqMktData on a bare conId (error 321: symbol/localSymbol/
-    // secId required) even though the wire carries conId — resolution by
-    // conId is only honoured via reqContractDetails. Enrich once and cache.
-    if (contract.conId && !contract.symbol && !contract.localSymbol) {
-      let full = this.conIdContracts.get(contract.conId)
-      if (!full) {
-        const details = await this.getContractDetails(contract)
-        if (!details?.contract) {
-          throw new BrokerError('EXCHANGE', `conId ${contract.conId} did not resolve to a contract`)
-        }
-        full = details.contract
-        this.conIdContracts.set(contract.conId, full)
-      }
-      contract = full
-    }
-
-    if (!contract.exchange) contract.exchange = 'SMART'
-    if (!contract.currency) contract.currency = 'USD'
+    this._ensureAlive()
+    const routedContract = await this.resolveRoutableContract(contract)
 
     const reqId = this.bridge.allocReqId()
     const promise = this.bridge.requestSnapshot(reqId)
-    this.client.reqMktData(reqId, contract, '', true, false, [])
+    this.client.reqMktData(reqId, routedContract, '', true, false, [])
     const snap = await promise
 
     return {
-      contract,
+      contract: routedContract,
       last: String(snap.last ?? 0),
       bid: String(snap.bid ?? 0),
       ask: String(snap.ask ?? 0),

--- a/services/uta/src/domain/trading/brokers/ibkr/__fixtures__/contract-resolution.v1.json
+++ b/services/uta/src/domain/trading/brokers/ibkr/__fixtures__/contract-resolution.v1.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "capturedOn": "2026-07-17",
+  "source": "IBKR paper TWS reqContractDetails",
+  "cases": [
+    {
+      "name": "aapl-stock",
+      "canonical": {
+        "conId": 265598,
+        "symbol": "AAPL",
+        "localSymbol": "AAPL",
+        "secType": "STK",
+        "exchange": "SMART",
+        "primaryExchange": "NASDAQ",
+        "currency": "USD",
+        "tradingClass": "NMS",
+        "multiplier": ""
+      }
+    },
+    {
+      "name": "usd-chf-cash",
+      "canonical": {
+        "conId": 12087820,
+        "symbol": "USD",
+        "localSymbol": "USD.CHF",
+        "secType": "CASH",
+        "exchange": "IDEALPRO",
+        "primaryExchange": "",
+        "currency": "CHF",
+        "tradingClass": "USD.CHF",
+        "multiplier": ""
+      }
+    },
+    {
+      "name": "sehk-700-stock",
+      "canonical": {
+        "conId": 152791428,
+        "symbol": "700",
+        "localSymbol": "700",
+        "secType": "STK",
+        "exchange": "SEHK",
+        "primaryExchange": "SEHK",
+        "currency": "HKD",
+        "tradingClass": "700",
+        "multiplier": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- resolve every IBKR conId through a clean `reqContractDetails({ conId })` request before quote or order routing
- share the canonical resolver across place, modify, quote, and close paths; preserve venue contracts instead of forcing `SMART/USD`
- cache in-flight/resolved conId lookups while cloning mutable IBKR contracts at ownership boundaries
- add recorded AAPL, USD.CHF, and SEHK/HKD canonical fixtures plus unit and live-paper regression coverage
- record small local JSONL smoke evidence and harden IBKR E2E cleanup to restore exact position/open-order baselines

## Root cause

UTA correctly used IBKR conId as the tradeable leaf identity, but a later stock convenience path unconditionally filled missing routing fields with `SMART/USD`. A staged FX leaf therefore reached TWS as the USD.CHF conId paired with contradictory stock-routing metadata, producing TWS error 200.

PR #345 identified the missing place-order enrichment and provided the useful starting signal. This repair reimplements the fix on current `dev` and covers the related modify/close/cache/test-safety boundaries.

## Validation

- `npx tsc --noEmit`
- `pnpm test` — 3,114 passed, 8 skipped
- `pnpm exec vitest run --config vitest.e2e.config.ts services/uta/src/domain/trading/__test__/e2e/uta-lifecycle.e2e.spec.ts` — 15 passed
- targeted IBKR paper USD.CHF polluted-contract what-if — passed as `CASH / IDEALPRO / CHF`, exact baseline restored
- targeted IBKR paper FX search → Alice ID → stage → commit → reject — passed without push
- targeted IBKR paper AAPL write lifecycle — bought and closed only the test-created quantity, exact baseline restored

The full non-trading E2E run reached 32 passing tests; its only failure was an unrelated TLS `ECONNRESET` reaching `api.bls.gov`, classified by the provider layer as external network unreachability.

## Safety

All broker validation used the verified IBKR paper preset. Final IBKR state matched the pre-run position quantities and open-order set. No account identifiers, balances, credentials, or raw position payloads are tracked in fixtures or smoke records.
