### PR TITLE
fix(ibkr): align text decoder framing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Read the relevant guide before editing its subsystem:
 - [[docs/workspace-absorb.md]] — [Workspace Absorb](docs/workspace-absorb.md): directional
   Workspace consolidation, file collisions, archived source identity, and recovery.
 - [[docs/uta-live-testing.md]] — [UTA live testing](docs/uta-live-testing.md): broker/trading acceptance loops.
+- [[docs/ibkr-wire-protocol.md]] — [IBKR wire protocol](docs/ibkr-wire-protocol.md): TWS/Gateway inbound framing and decoder failure isolation.
 - [[docs/workspace-issues-and-scheduling.md]] — [Workspace issues and scheduling](docs/workspace-issues-and-scheduling.md): Issue board, schedules, headless runs, and Inbox delivery.
 - [[docs/conversation-provenance.md]] — [Workspace Session and artifact provenance](docs/conversation-provenance.md): `resumeId` identity, artifact trails, Issue responsibility, and the provenance-before-collaboration delivery order.
 - [[docs/event-system.md]] — [Event-system retirement note](docs/event-system.md): removed Alice event-bus scheduler; UTA journal utility only.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ GitHub navigation.
 | [[docs/conversation-provenance.md]] | [Workspace Session and artifact provenance](conversation-provenance.md) | `resumeId` identity, artifact trails, Issue execution responsibility, and provenance-before-collaboration sequencing |
 | [[docs/event-system.md]] | [Event-system retirement note](event-system.md) | Removed Alice event-bus scheduler and the remaining UTA journal boundary |
 | [[docs/uta-live-testing.md]] | [UTA live testing](uta-live-testing.md) | Real broker/demo acceptance scenarios and trading invariants |
+| [[docs/ibkr-wire-protocol.md]] | [IBKR wire protocol](ibkr-wire-protocol.md) | TWS/Gateway inbound framing, payload-only decoder contract, failure isolation, and verification |
 | [[docs/market-data-architecture.md]] | [Market data architecture](market-data-architecture.md) | TraderHub/reference data, BarService K-lines, and the private provider compatibility layer |
 
 Other files under `docs/images/` are README/product assets rather than owner

--- a/docs/ibkr-wire-protocol.md
+++ b/docs/ibkr-wire-protocol.md
@@ -1,0 +1,82 @@
+# IBKR wire protocol and decoder boundary
+
+This guide owns the inbound framing contract between `@traderalice/ibkr` and
+TWS/IB Gateway. Broker acceptance and account-safety procedure remain in
+[[docs/uta-live-testing.md]].
+
+## Why this guide exists
+
+Issues #132 and #162 reported `BadMessage: no more fields` while IB Gateway
+was sending initial account updates. The reports correctly identified one
+extra field read in every text handler. Earlier investigation then attributed
+the mismatch to a TWS-versus-Gateway payload divergence. That conclusion was
+misleading: the TWS callbacks observed at server version 222 were largely
+protobuf, so they did not exercise the broken text handlers.
+
+The bundled IB API v10.44.01 Python source gives the actual invariant:
+
+1. `client.py` removes the wire message id before calling `read_fields()` for
+   both legacy and server-version-201+ framing.
+2. `decoder.py` receives that message id out of band.
+3. A text handler therefore starts at its first payload field. Depending on
+   the message, that is a version, request id, or business value.
+
+The initial TypeScript port had added `decodeInt(fields) // msgId` ahead of the
+already-translated payload reads in 84 text handlers. Gateway account frames
+made the extra read visible; the decoder consumed one real payload field and
+eventually ran out of fields. This was a porting error, not an IB Gateway
+10.37 protocol change and not an EU-account-specific schema.
+
+## Required boundary
+
+`packages/ibkr/src/client/base.ts` owns the envelope:
+
+- before server version 201, consume the leading NUL-delimited text message id;
+- from server version 201, consume the leading four-byte big-endian message id;
+- when the wire id selects protobuf, pass the remaining bytes unchanged;
+- otherwise split only the remaining text payload into fields.
+
+`Decoder.interpret(msgId, fields)` consequently has a payload-only contract.
+Handlers must never consume or reconstruct an envelope message id. Do not add
+conditional prepending, account-pattern guessing, or fallback field shifting:
+those approaches can silently turn a framing bug into incorrect financial
+data.
+
+## Failure boundary
+
+A missing or invalid field is not recoverable within the same connection. Once
+alignment is uncertain, the reader must:
+
+1. report safe framing metadata (`msgId` and field count), without logging raw
+   account or broker payloads;
+2. discard all successor frames already buffered in that read;
+3. disconnect only the affected IBKR connection so UTA health and recovery can
+   reconnect it.
+
+Continuing with the next buffered frame risks accepting shifted values. Letting
+the exception escape the socket callback crashes the UTA process. Both are
+incorrect.
+
+## Verification ladder
+
+Work on this boundary must proceed from narrow to broad:
+
+1. framing specs for legacy text, raw-int text, and protobuf envelopes;
+2. payload fixtures for every decoder category: account, market data, orders,
+   contracts, executions, historical data, and miscellaneous callbacks;
+3. a malformed-field recovery spec that proves the buffered successor is not
+   decoded and no payload value reaches the error message;
+4. package typecheck and unit suite;
+5. read-only package E2E against an available TWS or Gateway;
+6. reporter validation against IB Gateway for region/version combinations not
+   locally available.
+
+Large variable-length text messages such as open/completed orders and full
+contract details should be exercised from a real Gateway capture before a
+fixture is promoted to tracked test data. Captures must be manually minimized
+and scrubbed; never record account ids, balances, credentials, positions, or
+orders in tracked fixtures.
+
+This repair intentionally preserves the current UTA abstraction. It corrects
+the broker SDK boundary first; any broader UTA identity or valuation redesign
+is separate work.

--- a/packages/ibkr/README.md
+++ b/packages/ibkr/README.md
@@ -42,7 +42,15 @@ EClient  ──send──►  TWS/IB Gateway  ──respond──►  Decoder  �
 
 ### Dual Protocol
 
-TWS v201+ uses protobuf for most messages. Older versions use a text protocol (`\0`-delimited fields). Both are fully implemented. The protocol is negotiated at handshake — you don't need to think about it.
+Current TWS/Gateway versions can mix protobuf messages with the text protocol
+(`\0`-delimited fields); older versions use text only. Both paths are
+implemented and selected from the negotiated server version and message id.
+
+The message id is a wire-envelope field and is removed by `EClient` before a
+text payload reaches `Decoder.interpret()`. Decoder handlers begin at the first
+payload field; they must not read or reconstruct the message id. See the
+[IBKR wire protocol owner guide](../../docs/ibkr-wire-protocol.md) before
+changing framing or text handlers.
 
 ## Project Structure
 
@@ -101,12 +109,17 @@ Java/C++ sources are in `.gitignore` (available locally after extracting the TWS
 ## Testing
 
 ```bash
-pnpm test          # Unit tests (56 tests, no external deps)
+pnpm test          # Unit tests (no external dependencies)
 pnpm test:e2e      # Integration tests (needs TWS/IB Gateway running)
 pnpm test:all      # Both
 ```
 
 E2e tests share a single TWS connection via `tests/e2e/setup.ts`. If TWS is not running, e2e tests skip automatically.
+
+Text-decoder changes must include payload-only fixtures for the touched handler
+category plus framing and malformed-message recovery coverage. Run the
+[owner-guide verification ladder](../../docs/ibkr-wire-protocol.md#verification-ladder)
+before live broker acceptance.
 
 ### TWS Ports
 
@@ -115,7 +128,8 @@ E2e tests share a single TWS connection via `tests/e2e/setup.ts`. If TWS is not 
 | Paper | 7497 | 4002 |
 | Live | 7496 | 4001 |
 
-Configure via env: `TWS_HOST=127.0.0.1 TWS_PORT=7497`
+Configure via env: `TWS_HOST=127.0.0.1 TWS_PORT=7497 TWS_CLIENT_ID=91`.
+Use a client id that does not collide with a running UTA connection.
 
 ## Protobuf Generation
 

--- a/packages/ibkr/src/client/base.ts
+++ b/packages/ibkr/src/client/base.ts
@@ -20,7 +20,49 @@ import {
 import { NO_VALID_ID } from '../const.js'
 import { PROTOBUF_MSG_IDS } from '../common.js'
 import * as errors from '../errors.js'
-import { ClientException, isAsciiPrintable, currentTimeMillis } from '../utils.js'
+import { BadMessage, ClientException, isAsciiPrintable, currentTimeMillis } from '../utils.js'
+
+export type InboundFrame =
+  | { kind: 'text'; msgId: number; payload: Buffer }
+  | { kind: 'protobuf'; msgId: number; payload: Buffer }
+
+const PROTOBUF_MSG_ID = 200
+
+/**
+ * Remove the wire envelope from one complete inbound message.
+ *
+ * The decoder always receives the message id out-of-band and text fields that
+ * begin at the payload's first field (normally a message version or request
+ * id). This mirrors ibapi/client.py's run loop for both legacy and v201+
+ * framing.
+ */
+export function decodeInboundFrame(serverVersion: number, msgBuf: Buffer): InboundFrame {
+  let wireMsgId: number
+  let payload: Buffer
+
+  if (serverVersion >= MIN_SERVER_VER_PROTOBUF) {
+    if (msgBuf.length < 4) {
+      throw new BadMessage('missing binary message id')
+    }
+    wireMsgId = msgBuf.readUInt32BE(0)
+    payload = msgBuf.subarray(4)
+  } else {
+    const nullIdx = msgBuf.indexOf(0)
+    if (nullIdx < 0) {
+      throw new BadMessage('missing text message id delimiter')
+    }
+    wireMsgId = Number.parseInt(msgBuf.subarray(0, nullIdx).toString('utf-8'), 10)
+    if (!Number.isFinite(wireMsgId)) {
+      throw new BadMessage('invalid text message id')
+    }
+    payload = msgBuf.subarray(nullIdx + 1)
+  }
+
+  if (wireMsgId > PROTOBUF_MSG_ID) {
+    return { kind: 'protobuf', msgId: wireMsgId - PROTOBUF_MSG_ID, payload }
+  }
+  return { kind: 'text', msgId: wireMsgId, payload }
+}
 
 export class EClient {
   static readonly DISCONNECTED = 0
@@ -46,6 +88,7 @@ export class EClient {
   }
 
   reset(): void {
+    this.decoder = null
     this.conn = null
     this.host = null
     this.port = null
@@ -161,6 +204,8 @@ export class EClient {
       // Start reader
       this.reader = new EReader(this.conn, (msgBuf: Buffer) => {
         this.onMessage(msgBuf)
+      }, (error: unknown) => {
+        this.handleReaderError(error)
       })
       this.reader.start()
 
@@ -240,31 +285,50 @@ export class EClient {
   private onMessage(msgBuf: Buffer): void {
     if (!this.decoder) return
 
-    const PROTOBUF_MSG_ID = 200
-    let msgId: number
-    let payload: Buffer
-
-    if (this.serverVersion() >= MIN_SERVER_VER_PROTOBUF) {
-      // v201+: first 4 bytes are binary msgId
-      msgId = msgBuf.readUInt32BE(0)
-      payload = msgBuf.subarray(4)
-    } else {
-      // Legacy: first \0-delimited field is the text msgId
-      const nullIdx = msgBuf.indexOf(0)
-      if (nullIdx < 0) return
-      msgId = parseInt(msgBuf.subarray(0, nullIdx).toString('utf-8'), 10)
-      payload = msgBuf.subarray(nullIdx + 1)
+    let frame: InboundFrame
+    try {
+      frame = decodeInboundFrame(this.serverVersion(), msgBuf)
+    } catch (error) {
+      if (error instanceof BadMessage) {
+        this.wrapper.error(
+          NO_VALID_ID,
+          currentTimeMillis(),
+          errors.BAD_MESSAGE.code(),
+          `${errors.BAD_MESSAGE.msg()} envelope`,
+          '',
+        )
+      }
+      throw error
     }
 
-    if (msgId > PROTOBUF_MSG_ID) {
-      // Protobuf message
-      msgId -= PROTOBUF_MSG_ID
-      this.decoder.processProtoBuf(payload, msgId)
+    if (frame.kind === 'protobuf') {
+      this.decoder.processProtoBuf(frame.payload, frame.msgId)
     } else {
-      // Text message — split into fields and dispatch
-      const fields = readFields(payload)
-      this.decoder.interpret(fields, msgId)
+      this.decoder.interpret(frame.msgId, readFields(frame.payload))
     }
+  }
+
+  /**
+   * Contain an inbound decoder failure to this broker connection.
+   *
+   * BadMessage is already reported by Decoder with safe framing metadata. Any
+   * other exception gets a generic error so arbitrary broker payloads or
+   * account fields are never copied into logs.
+   */
+  private handleReaderError(error: unknown): void {
+    if (!(error instanceof BadMessage)) {
+      this.wrapper.error(
+        NO_VALID_ID,
+        currentTimeMillis(),
+        errors.BAD_MESSAGE.code(),
+        `${errors.BAD_MESSAGE.msg()} reader failure`,
+        '',
+      )
+    }
+
+    const conn = this.conn
+    this.reset()
+    conn?.disconnect()
   }
 
   private waitForHandshake(): Promise<{ serverVersion: number; connTime: string }> {

--- a/packages/ibkr/src/decoder/account.ts
+++ b/packages/ibkr/src/decoder/account.ts
@@ -74,7 +74,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.ACCT_VALUE, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const key = decodeStr(fields)
     const val = decodeStr(fields)
@@ -97,7 +96,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.PORTFOLIO_VALUE, (d, fields) => {
-    decodeInt(fields) // msgId
     const version = decodeInt(fields)
 
     const contract = new Contract()
@@ -162,7 +160,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.ACCT_UPDATE_TIME, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const timeStamp = decodeStr(fields)
     d.wrapper.updateAccountTime(timeStamp)
@@ -179,7 +176,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.ACCT_DOWNLOAD_END, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const accountName = decodeStr(fields)
     d.wrapper.accountDownloadEnd(accountName)
@@ -196,7 +192,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.MANAGED_ACCTS, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const accountsList = decodeStr(fields)
     d.wrapper.managedAccounts(accountsList)
@@ -212,7 +207,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.POSITION_DATA, (d, fields) => {
-    decodeInt(fields) // msgId
     const version = decodeInt(fields)
 
     const account = decodeStr(fields)
@@ -260,7 +254,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.POSITION_END, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     d.wrapper.positionEnd()
   })
@@ -275,7 +268,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.ACCOUNT_SUMMARY, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const account = decodeStr(fields)
@@ -300,7 +292,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.ACCOUNT_SUMMARY_END, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     d.wrapper.accountSummaryEnd(reqId)
@@ -317,7 +308,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.POSITION_MULTI, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const account = decodeStr(fields)
@@ -362,7 +352,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.POSITION_MULTI_END, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     d.wrapper.positionMultiEnd(reqId)
@@ -379,7 +368,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.ACCOUNT_UPDATE_MULTI, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const account = decodeStr(fields)
@@ -406,7 +394,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.ACCOUNT_UPDATE_MULTI_END, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     d.wrapper.accountUpdateMultiEnd(reqId)
@@ -423,7 +410,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.PNL, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const dailyPnL = decodeFloat(fields)
     let unrealizedPnL: number | null = null
@@ -454,7 +440,6 @@ export function applyAccountHandlers(decoder: Decoder): void {
   // ===========================================================================
 
   decoder.registerText(IN.PNL_SINGLE, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const pos = decodeDecimal(fields)
     const dailyPnL = decodeFloat(fields)

--- a/packages/ibkr/src/decoder/base.ts
+++ b/packages/ibkr/src/decoder/base.ts
@@ -37,12 +37,13 @@ export class Decoder {
 
   /**
    * Dispatch a text-protocol message.
+   *
+   * `msgId` belongs to the wire envelope and has already been consumed by the
+   * client. `fields` must begin at the first payload field (usually a message
+   * version, request id, or business value), exactly as in the official API.
    * Mirrors: ibapi/decoder.py interpret()
    */
-  interpret(fields: string[], msgId?: number): void {
-    if (msgId === undefined) {
-      msgId = parseInt(fields[0] || '0', 10)
-    }
+  interpret(msgId: number, fields: readonly string[]): void {
     if (msgId === 0) return
 
     const handler = this.msgId2textHandler.get(msgId)
@@ -57,7 +58,9 @@ export class Decoder {
       if (e instanceof BadMessage) {
         this.wrapper.error(
           NO_VALID_ID, currentTimeMillis(),
-          BAD_MESSAGE.code(), BAD_MESSAGE.msg() + fields.join(','), '',
+          BAD_MESSAGE.code(),
+          `${BAD_MESSAGE.msg()} text msgId=${msgId}, fieldCount=${fields.length}`,
+          '',
         )
       }
       throw e

--- a/packages/ibkr/src/decoder/contract.ts
+++ b/packages/ibkr/src/decoder/contract.ts
@@ -281,7 +281,6 @@ function decodeContractDetailsFromProto(
 // ---------------------------------------------------------------------------
 
 function processContractDataMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   let version = 8
   if (d.serverVersion < MIN_SERVER_VER_SIZE_RULES) {
     version = decodeInt(fields)
@@ -432,7 +431,6 @@ function processContractDataMsg(d: Decoder, fields: Iterator<string>): void {
 }
 
 function processBondContractDataMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   let version = 6
   if (d.serverVersion < MIN_SERVER_VER_SIZE_RULES) {
     version = decodeInt(fields)
@@ -518,14 +516,12 @@ function processBondContractDataMsg(d: Decoder, fields: Iterator<string>): void 
 }
 
 function processContractDataEndMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   decodeInt(fields) // version
   const reqId = decodeInt(fields)
   d.wrapper.contractDetailsEnd(reqId)
 }
 
 function processSymbolSamplesMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const nContractDescriptions = decodeInt(fields)
   const contractDescriptions: ContractDescription[] = []
@@ -554,7 +550,6 @@ function processSymbolSamplesMsg(d: Decoder, fields: Iterator<string>): void {
 }
 
 function processDeltaNeutralValidationMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   decodeInt(fields) // version
   const reqId = decodeInt(fields)
 
@@ -567,7 +562,6 @@ function processDeltaNeutralValidationMsg(d: Decoder, fields: Iterator<string>):
 }
 
 function processMarketRuleMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const marketRuleId = decodeInt(fields)
 
   const nPriceIncrements = decodeInt(fields)

--- a/packages/ibkr/src/decoder/execution.ts
+++ b/packages/ibkr/src/decoder/execution.ts
@@ -123,7 +123,6 @@ export function applyExecutionHandlers(decoder: Decoder): void {
 
   // IN.EXECUTION_DATA (11)
   decoder.registerText(IN.EXECUTION_DATA, (d, fields) => {
-    decodeInt(fields) // msgId
     let version = d.serverVersion
 
     if (d.serverVersion < MIN_SERVER_VER_LAST_LIQUIDITY) {
@@ -198,7 +197,6 @@ export function applyExecutionHandlers(decoder: Decoder): void {
 
   // IN.EXECUTION_DATA_END (55)
   decoder.registerText(IN.EXECUTION_DATA_END, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     d.wrapper.execDetailsEnd(reqId)
@@ -206,7 +204,6 @@ export function applyExecutionHandlers(decoder: Decoder): void {
 
   // IN.COMMISSION_AND_FEES_REPORT (59)
   decoder.registerText(IN.COMMISSION_AND_FEES_REPORT, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
 
     const report = new CommissionAndFeesReport()

--- a/packages/ibkr/src/decoder/historical.ts
+++ b/packages/ibkr/src/decoder/historical.ts
@@ -121,7 +121,6 @@ function decodeHistoricalTickLastProto(proto: HistoricalTickLastProtoMsg): Histo
 // ----------------------------------------------------------------
 
 function processHistoricalDataMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   if (d.serverVersion < MIN_SERVER_VER_SYNT_REALTIME_BARS) {
     decodeInt(fields) // version
   }
@@ -162,7 +161,6 @@ function processHistoricalDataMsg(d: Decoder, fields: Iterator<string>): void {
 }
 
 function processHistoricalDataEndMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const startDateStr = decodeStr(fields)
   const endDateStr = decodeStr(fields)
@@ -171,7 +169,6 @@ function processHistoricalDataEndMsg(d: Decoder, fields: Iterator<string>): void
 }
 
 function processHistoricalDataUpdateMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const bar = new BarData()
   bar.barCount = decodeInt(fields)
@@ -186,7 +183,6 @@ function processHistoricalDataUpdateMsg(d: Decoder, fields: Iterator<string>): v
 }
 
 function processRealTimeBarMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   decodeInt(fields) // version
   const reqId = decodeInt(fields)
 
@@ -207,14 +203,12 @@ function processRealTimeBarMsg(d: Decoder, fields: Iterator<string>): void {
 }
 
 function processHeadTimestamp(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const headTimestamp = decodeStr(fields)
   d.wrapper.headTimestamp(reqId, headTimestamp)
 }
 
 function processHistogramData(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const numPoints = decodeInt(fields)
 
@@ -230,7 +224,6 @@ function processHistogramData(d: Decoder, fields: Iterator<string>): void {
 }
 
 function processHistoricalTicks(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const tickCount = decodeInt(fields)
 
@@ -251,7 +244,6 @@ function processHistoricalTicks(d: Decoder, fields: Iterator<string>): void {
 }
 
 function processHistoricalTicksBidAsk(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const tickCount = decodeInt(fields)
 
@@ -278,7 +270,6 @@ function processHistoricalTicksBidAsk(d: Decoder, fields: Iterator<string>): voi
 }
 
 function processHistoricalTicksLast(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const tickCount = decodeInt(fields)
 
@@ -305,7 +296,6 @@ function processHistoricalTicksLast(d: Decoder, fields: Iterator<string>): void 
 }
 
 function processTickByTickMsg(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const tickType = decodeInt(fields)
   const time = decodeInt(fields)
@@ -350,7 +340,6 @@ function processTickByTickMsg(d: Decoder, fields: Iterator<string>): void {
 }
 
 function processHistoricalSchedule(d: Decoder, fields: Iterator<string>): void {
-  decodeInt(fields) // msgId
   const reqId = decodeInt(fields)
   const startDateTime = decodeStr(fields)
   const endDateTime = decodeStr(fields)

--- a/packages/ibkr/src/decoder/market-data.ts
+++ b/packages/ibkr/src/decoder/market-data.ts
@@ -36,7 +36,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.TICK_PRICE (1)
   decoder.registerText(IN.TICK_PRICE, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
 
     const reqId = decodeInt(fields)
@@ -82,7 +81,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.TICK_SIZE (2)
   decoder.registerText(IN.TICK_SIZE, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
 
     const reqId = decodeInt(fields)
@@ -96,7 +94,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.TICK_OPTION_COMPUTATION (21)
   decoder.registerText(IN.TICK_OPTION_COMPUTATION, (d, fields) => {
-    decodeInt(fields) // msgId
     let version = d.serverVersion
     let tickAttrib = 0
     let optPrice: number | null = null
@@ -156,7 +153,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.TICK_GENERIC (45)
   decoder.registerText(IN.TICK_GENERIC, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const tickType = decodeInt(fields)
@@ -166,7 +162,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.TICK_STRING (46)
   decoder.registerText(IN.TICK_STRING, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const tickType = decodeInt(fields)
@@ -176,7 +171,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.TICK_EFP (47) — text only, no proto
   decoder.registerText(IN.TICK_EFP, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const tickType = decodeInt(fields)
@@ -196,7 +190,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.TICK_SNAPSHOT_END (57)
   decoder.registerText(IN.TICK_SNAPSHOT_END, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     d.wrapper.tickSnapshotEnd(reqId)
@@ -204,7 +197,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.MARKET_DATA_TYPE (58)
   decoder.registerText(IN.MARKET_DATA_TYPE, (d, fields) => {
-    decodeInt(fields) // msgId (version)
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const marketDataType = decodeInt(fields)
@@ -213,7 +205,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.TICK_REQ_PARAMS (81)
   decoder.registerText(IN.TICK_REQ_PARAMS, (d, fields) => {
-    decodeInt(fields) // msgId
     const tickerId = decodeInt(fields)
     const minTick = decodeFloat(fields)
     const bboExchange = decodeStr(fields)
@@ -223,7 +214,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.MARKET_DEPTH (12)
   decoder.registerText(IN.MARKET_DEPTH, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
 
@@ -238,7 +228,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.MARKET_DEPTH_L2 (13)
   decoder.registerText(IN.MARKET_DEPTH_L2, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
 
@@ -261,7 +250,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.REROUTE_MKT_DATA_REQ (91)
   decoder.registerText(IN.REROUTE_MKT_DATA_REQ, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const conId = decodeInt(fields)
     const exchange = decodeStr(fields)
@@ -270,7 +258,6 @@ export function applyMarketDataHandlers(decoder: Decoder): void {
 
   // IN.REROUTE_MKT_DEPTH_REQ (92)
   decoder.registerText(IN.REROUTE_MKT_DEPTH_REQ, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const conId = decodeInt(fields)
     const exchange = decodeStr(fields)

--- a/packages/ibkr/src/decoder/misc.ts
+++ b/packages/ibkr/src/decoder/misc.ts
@@ -160,7 +160,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.ERR_MSG (4) ---
   decoder.registerText(IN.ERR_MSG, (d, fields) => {
-    decodeInt(fields) // msgId
     if (d.serverVersion < MIN_SERVER_VER_ERROR_TIME) {
       decodeInt(fields) // version
     }
@@ -180,7 +179,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.CURRENT_TIME (49) ---
   decoder.registerText(IN.CURRENT_TIME, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const time = decodeInt(fields)
     d.wrapper.currentTime(time)
@@ -188,14 +186,12 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.CURRENT_TIME_IN_MILLIS (109) ---
   decoder.registerText(IN.CURRENT_TIME_IN_MILLIS, (d, fields) => {
-    decodeInt(fields) // msgId
     const timeInMillis = decodeInt(fields)
     d.wrapper.currentTimeInMillis(timeInMillis)
   })
 
   // --- IN.NEWS_BULLETINS (14) ---
   decoder.registerText(IN.NEWS_BULLETINS, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const msgId = decodeInt(fields)
     const msgType = decodeInt(fields)
@@ -206,7 +202,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.RECEIVE_FA (16) ---
   decoder.registerText(IN.RECEIVE_FA, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const faDataType = decodeInt(fields)
     const xml = decodeStr(fields)
@@ -215,7 +210,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.SCANNER_PARAMETERS (19) ---
   decoder.registerText(IN.SCANNER_PARAMETERS, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const xml = decodeStr(fields)
     d.wrapper.scannerParameters(xml)
@@ -223,7 +217,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.SCANNER_DATA (20) ---
   decoder.registerText(IN.SCANNER_DATA, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
 
@@ -261,7 +254,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.FUNDAMENTAL_DATA (51) ---
   decoder.registerText(IN.FUNDAMENTAL_DATA, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const data = decodeStr(fields)
@@ -270,7 +262,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.NEWS_PROVIDERS (85) ---
   decoder.registerText(IN.NEWS_PROVIDERS, (d, fields) => {
-    decodeInt(fields) // msgId
     const newsProviders: NewsProvider[] = []
     const nNewsProviders = decodeInt(fields)
     if (nNewsProviders > 0) {
@@ -286,7 +277,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.NEWS_ARTICLE (83) ---
   decoder.registerText(IN.NEWS_ARTICLE, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const articleType = decodeInt(fields)
     const articleText = decodeStr(fields)
@@ -295,7 +285,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.TICK_NEWS (84) ---
   decoder.registerText(IN.TICK_NEWS, (d, fields) => {
-    decodeInt(fields) // msgId
     const tickerId = decodeInt(fields)
     const timeStamp = decodeInt(fields)
     const providerCode = decodeStr(fields)
@@ -307,7 +296,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.HISTORICAL_NEWS (86) ---
   decoder.registerText(IN.HISTORICAL_NEWS, (d, fields) => {
-    decodeInt(fields) // msgId
     const requestId = decodeInt(fields)
     const time = decodeStr(fields)
     const providerCode = decodeStr(fields)
@@ -318,7 +306,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.HISTORICAL_NEWS_END (87) ---
   decoder.registerText(IN.HISTORICAL_NEWS_END, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const hasMore = decodeBool(fields)
     d.wrapper.historicalNewsEnd(reqId, hasMore)
@@ -326,7 +313,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.SECURITY_DEFINITION_OPTION_PARAMETER (75) ---
   decoder.registerText(IN.SECURITY_DEFINITION_OPTION_PARAMETER, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const exchange = decodeStr(fields)
     const underlyingConId = decodeInt(fields)
@@ -353,14 +339,12 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.SECURITY_DEFINITION_OPTION_PARAMETER_END (76) ---
   decoder.registerText(IN.SECURITY_DEFINITION_OPTION_PARAMETER_END, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     d.wrapper.securityDefinitionOptionParameterEnd(reqId)
   })
 
   // --- IN.SOFT_DOLLAR_TIERS (77) ---
   decoder.registerText(IN.SOFT_DOLLAR_TIERS, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const nTiers = decodeInt(fields)
 
@@ -378,7 +362,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.FAMILY_CODES (78) ---
   decoder.registerText(IN.FAMILY_CODES, (d, fields) => {
-    decodeInt(fields) // msgId
     const nFamilyCodes = decodeInt(fields)
     const familyCodes: FamilyCode[] = []
     for (let i = 0; i < nFamilyCodes; i++) {
@@ -392,7 +375,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.SMART_COMPONENTS (82) ---
   decoder.registerText(IN.SMART_COMPONENTS, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const n = decodeInt(fields)
 
@@ -410,7 +392,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.MKT_DEPTH_EXCHANGES (80) ---
   decoder.registerText(IN.MKT_DEPTH_EXCHANGES, (d, fields) => {
-    decodeInt(fields) // msgId
     const depthMktDataDescriptions: DepthMktDataDescription[] = []
     const nDepthMktDataDescriptions = decodeInt(fields)
 
@@ -435,7 +416,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.VERIFY_MESSAGE_API (65) ---
   decoder.registerText(IN.VERIFY_MESSAGE_API, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const apiData = decodeStr(fields)
     d.wrapper.verifyMessageAPI(apiData)
@@ -443,7 +423,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.VERIFY_COMPLETED (66) ---
   decoder.registerText(IN.VERIFY_COMPLETED, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const isSuccessful = decodeBool(fields)
     const errorText = decodeStr(fields)
@@ -452,7 +431,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.VERIFY_AND_AUTH_MESSAGE_API (69) ---
   decoder.registerText(IN.VERIFY_AND_AUTH_MESSAGE_API, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const apiData = decodeStr(fields)
     const xyzChallenge = decodeStr(fields)
@@ -461,7 +439,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.VERIFY_AND_AUTH_COMPLETED (70) ---
   decoder.registerText(IN.VERIFY_AND_AUTH_COMPLETED, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const isSuccessful = decodeBool(fields)
     const errorText = decodeStr(fields)
@@ -470,7 +447,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.DISPLAY_GROUP_LIST (67) ---
   decoder.registerText(IN.DISPLAY_GROUP_LIST, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const groups = decodeStr(fields)
@@ -479,7 +455,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.DISPLAY_GROUP_UPDATED (68) ---
   decoder.registerText(IN.DISPLAY_GROUP_UPDATED, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const reqId = decodeInt(fields)
     const contractInfo = decodeStr(fields)
@@ -488,7 +463,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.WSH_META_DATA (104) ---
   decoder.registerText(IN.WSH_META_DATA, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const dataJson = decodeStr(fields)
     d.wrapper.wshMetaData(reqId, dataJson)
@@ -496,7 +470,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.WSH_EVENT_DATA (105) ---
   decoder.registerText(IN.WSH_EVENT_DATA, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const dataJson = decodeStr(fields)
     d.wrapper.wshEventData(reqId, dataJson)
@@ -504,7 +477,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.USER_INFO (107) ---
   decoder.registerText(IN.USER_INFO, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const whiteBrandingId = decodeStr(fields)
     d.wrapper.userInfo(reqId, whiteBrandingId)
@@ -512,7 +484,6 @@ export function applyMiscHandlers(decoder: Decoder): void {
 
   // --- IN.REPLACE_FA_END (103) ---
   decoder.registerText(IN.REPLACE_FA_END, (d, fields) => {
-    decodeInt(fields) // msgId
     const reqId = decodeInt(fields)
     const text = decodeStr(fields)
     d.wrapper.replaceFAEnd(reqId, text)

--- a/packages/ibkr/src/decoder/orders.ts
+++ b/packages/ibkr/src/decoder/orders.ts
@@ -429,7 +429,6 @@ export function applyOrderHandlers(decoder: Decoder): void {
   // IN.ORDER_STATUS (3) — text
   // -----------------------------------------------------------------------
   decoder.registerText(IN.ORDER_STATUS, (d, fields) => {
-    decodeInt(fields) // msgId
     if (d.serverVersion < MIN_SERVER_VER_MARKET_CAP_PRICE) {
       decodeInt(fields) // version
     }
@@ -490,8 +489,6 @@ export function applyOrderHandlers(decoder: Decoder): void {
   // IN.OPEN_ORDER (5) — text
   // -----------------------------------------------------------------------
   decoder.registerText(IN.OPEN_ORDER, (d, fields) => {
-    decodeInt(fields) // msgId
-
     const order = new Order()
     const contract = new Contract()
     const orderState = new OrderState()
@@ -612,7 +609,6 @@ export function applyOrderHandlers(decoder: Decoder): void {
   // IN.OPEN_ORDER_END (53) — text
   // -----------------------------------------------------------------------
   decoder.registerText(IN.OPEN_ORDER_END, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     d.wrapper.openOrderEnd()
   })
@@ -629,7 +625,6 @@ export function applyOrderHandlers(decoder: Decoder): void {
   // IN.ORDER_BOUND (100) — text
   // -----------------------------------------------------------------------
   decoder.registerText(IN.ORDER_BOUND, (d, fields) => {
-    decodeInt(fields) // msgId
     const permId = decodeInt(fields)
     const clientId = decodeInt(fields)
     const orderId = decodeInt(fields)
@@ -654,8 +649,6 @@ export function applyOrderHandlers(decoder: Decoder): void {
   // IN.COMPLETED_ORDER (101) — text
   // -----------------------------------------------------------------------
   decoder.registerText(IN.COMPLETED_ORDER, (d, fields) => {
-    decodeInt(fields) // msgId
-
     const order = new Order()
     const contract = new Contract()
     const orderState = new OrderState()
@@ -756,7 +749,6 @@ export function applyOrderHandlers(decoder: Decoder): void {
   // IN.COMPLETED_ORDERS_END (102) — text
   // -----------------------------------------------------------------------
   decoder.registerText(IN.COMPLETED_ORDERS_END, (d, fields) => {
-    decodeInt(fields) // msgId
     d.wrapper.completedOrdersEnd()
   })
 
@@ -772,7 +764,6 @@ export function applyOrderHandlers(decoder: Decoder): void {
   // IN.NEXT_VALID_ID (9) — text
   // -----------------------------------------------------------------------
   decoder.registerText(IN.NEXT_VALID_ID, (d, fields) => {
-    decodeInt(fields) // msgId
     decodeInt(fields) // version
     const orderId = decodeInt(fields)
     d.wrapper.nextValidId(orderId)
@@ -786,4 +777,3 @@ export function applyOrderHandlers(decoder: Decoder): void {
     d.wrapper.nextValidId(proto.orderId ?? 0)
   })
 }
-

--- a/packages/ibkr/src/reader.ts
+++ b/packages/ibkr/src/reader.ts
@@ -14,10 +14,16 @@ export class EReader {
   private conn: Connection
   private buf: Buffer = Buffer.alloc(0)
   private onMessage: (msg: Buffer) => void
+  private onError?: (error: unknown) => void
 
-  constructor(conn: Connection, onMessage: (msg: Buffer) => void) {
+  constructor(
+    conn: Connection,
+    onMessage: (msg: Buffer) => void,
+    onError?: (error: unknown) => void,
+  ) {
     this.conn = conn
     this.onMessage = onMessage
+    this.onError = onError
   }
 
   /**
@@ -44,7 +50,17 @@ export class EReader {
       const [size, msg, rest] = readMsg(this.buf)
       if (msg.length > 0) {
         this.buf = rest
-        this.onMessage(msg)
+        try {
+          this.onMessage(msg)
+        } catch (error) {
+          // A decoder failure means field alignment is no longer trustworthy.
+          // Drop every buffered successor and let the client replace this
+          // connection instead of continuing from an uncertain boundary.
+          this.buf = Buffer.alloc(0)
+          if (!this.onError) throw error
+          this.onError(error)
+          break
+        }
       } else {
         // Incomplete message — wait for more data
         break

--- a/packages/ibkr/tests/e2e/setup.ts
+++ b/packages/ibkr/tests/e2e/setup.ts
@@ -12,6 +12,8 @@ import Decimal from 'decimal.js'
 import { EClient, DefaultEWrapper, type ContractDetails, type Contract, type Order, type OrderState } from '../../src/index.js'
 import { isTwsAvailable, TWS_HOST, TWS_PORT } from '../helpers/tws.js'
 
+const TWS_CLIENT_ID = Number.parseInt(process.env.TWS_CLIENT_ID ?? '0', 10)
+
 // --- Collected results from TWS callbacks ---
 export const results = {
   serverVersion: 0,
@@ -90,7 +92,7 @@ export const client = new EClient(new E2EWrapper())
 export const available = await isTwsAvailable()
 
 if (available) {
-  await client.connect(TWS_HOST, TWS_PORT, 0)
+  await client.connect(TWS_HOST, TWS_PORT, TWS_CLIENT_ID)
   // Wait for initial messages (nextValidId, managedAccounts, etc.)
   await sleep(2000)
 }

--- a/packages/ibkr/tests/inbound-framing.spec.ts
+++ b/packages/ibkr/tests/inbound-framing.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { decodeInboundFrame } from '../src/client/base.js'
+import { readFields } from '../src/comm.js'
+import { IN } from '../src/message.js'
+import { BadMessage } from '../src/utils.js'
+
+const textPayload = Buffer.from(['2', 'CashBalance', '1000000.00', 'USD', 'DU_TEST', ''].join('\0'))
+
+describe('decodeInboundFrame', () => {
+  it('removes the legacy text msgId before exposing payload fields', () => {
+    const frame = decodeInboundFrame(
+      200,
+      Buffer.concat([Buffer.from(`${IN.ACCT_VALUE}\0`), textPayload]),
+    )
+
+    expect(frame).toMatchObject({ kind: 'text', msgId: IN.ACCT_VALUE })
+    expect(readFields(frame.payload)).toEqual([
+      '2',
+      'CashBalance',
+      '1000000.00',
+      'USD',
+      'DU_TEST',
+    ])
+  })
+
+  it('removes the v201+ binary msgId before exposing the same payload fields', () => {
+    const msgId = Buffer.alloc(4)
+    msgId.writeUInt32BE(IN.ACCT_VALUE)
+
+    const frame = decodeInboundFrame(206, Buffer.concat([msgId, textPayload]))
+
+    expect(frame).toMatchObject({ kind: 'text', msgId: IN.ACCT_VALUE })
+    expect(readFields(frame.payload)).toEqual([
+      '2',
+      'CashBalance',
+      '1000000.00',
+      'USD',
+      'DU_TEST',
+    ])
+  })
+
+  it('classifies a v201+ protobuf envelope without touching its payload', () => {
+    const wireMsgId = Buffer.alloc(4)
+    wireMsgId.writeUInt32BE(IN.MANAGED_ACCTS + 200)
+    const protobufPayload = Buffer.from([0x0a, 0x07, 0x44, 0x55, 0x5f, 0x54, 0x45, 0x53, 0x54])
+
+    const frame = decodeInboundFrame(222, Buffer.concat([wireMsgId, protobufPayload]))
+
+    expect(frame).toEqual({
+      kind: 'protobuf',
+      msgId: IN.MANAGED_ACCTS,
+      payload: protobufPayload,
+    })
+  })
+
+  it('rejects incomplete or invalid envelopes instead of continuing', () => {
+    expect(() => decodeInboundFrame(206, Buffer.alloc(3))).toThrow(BadMessage)
+    expect(() => decodeInboundFrame(200, Buffer.from(`${IN.ACCT_VALUE}`))).toThrow(BadMessage)
+    expect(() => decodeInboundFrame(200, Buffer.from('not-a-number\0payload\0'))).toThrow(BadMessage)
+  })
+})

--- a/packages/ibkr/tests/reader-recovery.spec.ts
+++ b/packages/ibkr/tests/reader-recovery.spec.ts
@@ -1,0 +1,139 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import { EClient } from '../src/client/base.js'
+import { makeField, makeMsg } from '../src/comm.js'
+import { Decoder, applyAllHandlers } from '../src/decoder/index.js'
+import { EReader } from '../src/reader.js'
+import { IN } from '../src/message.js'
+import type { ConnectionWrapper } from '../src/connection.js'
+import { DefaultEWrapper } from '../src/wrapper.js'
+
+class FakeConnection extends EventEmitter {
+  wrapper: ConnectionWrapper | null = null
+  private incoming = Buffer.alloc(0)
+  private connected = true
+
+  push(data: Buffer): void {
+    this.incoming = Buffer.concat([this.incoming, data])
+    this.emit('data')
+  }
+
+  consumeBuffer(): Buffer {
+    const data = this.incoming
+    this.incoming = Buffer.alloc(0)
+    return data
+  }
+
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  disconnect(): void {
+    if (!this.connected) return
+    this.connected = false
+    this.wrapper?.connectionClosed()
+  }
+}
+
+describe('EReader decoder failure recovery', () => {
+  it('contains a malformed broker frame to the connection and drops buffered successors', () => {
+    const wrapper = new DefaultEWrapper()
+    const error = vi.spyOn(wrapper, 'error')
+    const connectionClosed = vi.spyOn(wrapper, 'connectionClosed')
+    const currentTime = vi.spyOn(wrapper, 'currentTime')
+    const client = new EClient(wrapper)
+    const connection = new FakeConnection()
+    connection.wrapper = wrapper
+
+    client.conn = connection as never
+    client.serverVersion_ = 206
+    client.decoder = new Decoder(wrapper, 206)
+    applyAllHandlers(client.decoder)
+    client.setConnState(EClient.CONNECTED)
+
+    const privateClient = client as unknown as {
+      onMessage(message: Buffer): void
+      handleReaderError(error: unknown): void
+    }
+    const reader = new EReader(
+      connection as never,
+      (message) => privateClient.onMessage(message),
+      (readerError) => privateClient.handleReaderError(readerError),
+    )
+    reader.start()
+
+    const malformedAccount = makeMsg(
+      IN.ACCT_VALUE,
+      true,
+      makeField(2) + makeField('CashBalance') + makeField('DU_TEST'),
+    )
+    const bufferedCurrentTime = makeMsg(
+      IN.CURRENT_TIME,
+      true,
+      makeField(1) + makeField(1784289600),
+    )
+
+    expect(() => connection.push(Buffer.concat([
+      malformedAccount,
+      bufferedCurrentTime,
+    ]))).not.toThrow()
+
+    expect(error).toHaveBeenCalledOnce()
+    expect(error.mock.calls[0][3]).toContain('text msgId=6, fieldCount=3')
+    expect(error.mock.calls[0][3]).not.toContain('CashBalance')
+    expect(error.mock.calls[0][3]).not.toContain('DU_TEST')
+    expect(connectionClosed).toHaveBeenCalledOnce()
+    expect(currentTime).not.toHaveBeenCalled()
+    expect(client.conn).toBeNull()
+    expect(client.connState).toBe(EClient.DISCONNECTED)
+  })
+
+  it('contains a truncated envelope without logging its bytes', () => {
+    const wrapper = new DefaultEWrapper()
+    const error = vi.spyOn(wrapper, 'error')
+    const connectionClosed = vi.spyOn(wrapper, 'connectionClosed')
+    const currentTime = vi.spyOn(wrapper, 'currentTime')
+    const client = new EClient(wrapper)
+    const connection = new FakeConnection()
+    connection.wrapper = wrapper
+
+    client.conn = connection as never
+    client.serverVersion_ = 206
+    client.decoder = new Decoder(wrapper, 206)
+    applyAllHandlers(client.decoder)
+    client.setConnState(EClient.CONNECTED)
+
+    const privateClient = client as unknown as {
+      onMessage(message: Buffer): void
+      handleReaderError(readerError: unknown): void
+    }
+    const reader = new EReader(
+      connection as never,
+      (message) => privateClient.onMessage(message),
+      (readerError) => privateClient.handleReaderError(readerError),
+    )
+    reader.start()
+
+    const truncatedEnvelope = Buffer.alloc(7)
+    truncatedEnvelope.writeUInt32BE(3, 0)
+    truncatedEnvelope.set([0xde, 0xad, 0xbe], 4)
+    const bufferedCurrentTime = makeMsg(
+      IN.CURRENT_TIME,
+      true,
+      makeField(1) + makeField(1784289600),
+    )
+
+    expect(() => connection.push(Buffer.concat([
+      truncatedEnvelope,
+      bufferedCurrentTime,
+    ]))).not.toThrow()
+
+    expect(error).toHaveBeenCalledOnce()
+    expect(error.mock.calls[0][3]).toBe('Bad message envelope')
+    expect(error.mock.calls[0][3]).not.toContain('deadbe')
+    expect(connectionClosed).toHaveBeenCalledOnce()
+    expect(currentTime).not.toHaveBeenCalled()
+    expect(client.conn).toBeNull()
+    expect(client.connState).toBe(EClient.DISCONNECTED)
+  })
+})

--- a/packages/ibkr/tests/text-account-decode.spec.ts
+++ b/packages/ibkr/tests/text-account-decode.spec.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from 'vitest'
+import Decimal from 'decimal.js'
+import { Decoder, applyAllHandlers } from '../src/decoder/index.js'
+import { IN } from '../src/message.js'
+import { DefaultEWrapper } from '../src/wrapper.js'
+
+const RAW_ID_TEXT_ACCOUNT_SERVER_VERSION = 206
+
+function createDecoder(): { decoder: Decoder; wrapper: DefaultEWrapper } {
+  const wrapper = new DefaultEWrapper()
+  const decoder = new Decoder(wrapper, RAW_ID_TEXT_ACCOUNT_SERVER_VERSION)
+  applyAllHandlers(decoder)
+  return { decoder, wrapper }
+}
+
+describe('Decoder text account payloads', () => {
+  it('decodes the Gateway account-value frame reported in #132/#162', () => {
+    const { decoder, wrapper } = createDecoder()
+    const updateAccountValue = vi.spyOn(wrapper, 'updateAccountValue')
+
+    decoder.interpret(
+      IN.ACCT_VALUE,
+      ['2', 'CashBalance', '1000000.00', 'USD', 'DU_TEST'],
+    )
+
+    expect(updateAccountValue).toHaveBeenCalledWith(
+      'CashBalance',
+      '1000000.00',
+      'USD',
+      'DU_TEST',
+    )
+  })
+
+  it('decodes the initial text-account handshake frames without a payload msgId', () => {
+    const { decoder, wrapper } = createDecoder()
+    const nextValidId = vi.spyOn(wrapper, 'nextValidId')
+    const managedAccounts = vi.spyOn(wrapper, 'managedAccounts')
+    const updateAccountTime = vi.spyOn(wrapper, 'updateAccountTime')
+    const accountDownloadEnd = vi.spyOn(wrapper, 'accountDownloadEnd')
+
+    decoder.interpret(IN.NEXT_VALID_ID, ['1', '42'])
+    decoder.interpret(IN.MANAGED_ACCTS, ['1', 'DU_TEST'])
+    decoder.interpret(IN.ACCT_UPDATE_TIME, ['1', '17:30'])
+    decoder.interpret(IN.ACCT_DOWNLOAD_END, ['1', 'DU_TEST'])
+
+    expect(nextValidId).toHaveBeenCalledWith(42)
+    expect(managedAccounts).toHaveBeenCalledWith('DU_TEST')
+    expect(updateAccountTime).toHaveBeenCalledWith('17:30')
+    expect(accountDownloadEnd).toHaveBeenCalledWith('DU_TEST')
+  })
+
+  it('decodes a complete text portfolio row from its version field', () => {
+    const { decoder, wrapper } = createDecoder()
+    const updatePortfolio = vi.spyOn(wrapper, 'updatePortfolio')
+
+    decoder.interpret(IN.PORTFOLIO_VALUE, [
+      '8',
+      '265598',
+      'AAPL',
+      'STK',
+      '',
+      '0',
+      '',
+      '1',
+      'NASDAQ',
+      'USD',
+      'AAPL',
+      'NMS',
+      '10',
+      '250',
+      '2500',
+      '200',
+      '500',
+      '0',
+      'DU_TEST',
+    ])
+
+    expect(updatePortfolio).toHaveBeenCalledOnce()
+    const [contract, position, marketPrice, marketValue, averageCost,
+      unrealizedPnl, realizedPnl, accountName] = updatePortfolio.mock.calls[0]
+    expect(contract).toMatchObject({
+      conId: 265598,
+      symbol: 'AAPL',
+      secType: 'STK',
+      multiplier: '1',
+      primaryExchange: 'NASDAQ',
+      currency: 'USD',
+      localSymbol: 'AAPL',
+      tradingClass: 'NMS',
+    })
+    expect(position).toEqual(new Decimal('10'))
+    expect(marketPrice).toBe('250')
+    expect(marketValue).toBe('2500')
+    expect(averageCost).toBe('200')
+    expect(unrealizedPnl).toBe('500')
+    expect(realizedPnl).toBe('0')
+    expect(accountName).toBe('DU_TEST')
+  })
+
+  it('decodes position and account-summary payloads from their version field', () => {
+    const { decoder, wrapper } = createDecoder()
+    const position = vi.spyOn(wrapper, 'position')
+    const positionEnd = vi.spyOn(wrapper, 'positionEnd')
+    const accountSummary = vi.spyOn(wrapper, 'accountSummary')
+    const accountSummaryEnd = vi.spyOn(wrapper, 'accountSummaryEnd')
+
+    decoder.interpret(IN.POSITION_DATA, [
+      '3',
+      'DU_TEST',
+      '265598',
+      'AAPL',
+      'STK',
+      '',
+      '0',
+      '',
+      '1',
+      'SMART',
+      'USD',
+      'AAPL',
+      'NMS',
+      '10',
+      '200',
+    ])
+    decoder.interpret(IN.POSITION_END, ['1'])
+    decoder.interpret(IN.ACCOUNT_SUMMARY, [
+      '1',
+      '7',
+      'DU_TEST',
+      'NetLiquidation',
+      '1000000.00',
+      'USD',
+    ])
+    decoder.interpret(IN.ACCOUNT_SUMMARY_END, ['1', '7'])
+
+    expect(position).toHaveBeenCalledOnce()
+    expect(position.mock.calls[0][0]).toBe('DU_TEST')
+    expect(position.mock.calls[0][1]).toMatchObject({
+      conId: 265598,
+      symbol: 'AAPL',
+      secType: 'STK',
+      tradingClass: 'NMS',
+    })
+    expect(position.mock.calls[0][2]).toEqual(new Decimal('10'))
+    expect(position.mock.calls[0][3]).toBe(200)
+    expect(positionEnd).toHaveBeenCalledOnce()
+    expect(accountSummary).toHaveBeenCalledWith(
+      7,
+      'DU_TEST',
+      'NetLiquidation',
+      '1000000.00',
+      'USD',
+    )
+    expect(accountSummaryEnd).toHaveBeenCalledWith(7)
+  })
+
+  it('decodes multi-account payloads from their version field', () => {
+    const { decoder, wrapper } = createDecoder()
+    const positionMulti = vi.spyOn(wrapper, 'positionMulti')
+    const positionMultiEnd = vi.spyOn(wrapper, 'positionMultiEnd')
+    const accountUpdateMulti = vi.spyOn(wrapper, 'accountUpdateMulti')
+    const accountUpdateMultiEnd = vi.spyOn(wrapper, 'accountUpdateMultiEnd')
+
+    decoder.interpret(IN.POSITION_MULTI, [
+      '1',
+      '11',
+      'DU_TEST',
+      '265598',
+      'AAPL',
+      'STK',
+      '',
+      '0',
+      '',
+      '1',
+      'SMART',
+      'USD',
+      'AAPL',
+      'NMS',
+      '10',
+      '200',
+      'MODEL',
+    ])
+    decoder.interpret(IN.POSITION_MULTI_END, ['1', '11'])
+    decoder.interpret(IN.ACCOUNT_UPDATE_MULTI, [
+      '1',
+      '12',
+      'DU_TEST',
+      'MODEL',
+      'CashBalance',
+      '1000000.00',
+      'USD',
+    ])
+    decoder.interpret(IN.ACCOUNT_UPDATE_MULTI_END, ['1', '12'])
+
+    expect(positionMulti).toHaveBeenCalledOnce()
+    expect(positionMulti.mock.calls[0][0]).toBe(11)
+    expect(positionMulti.mock.calls[0][1]).toBe('DU_TEST')
+    expect(positionMulti.mock.calls[0][2]).toBe('MODEL')
+    expect(positionMulti.mock.calls[0][3]).toMatchObject({ conId: 265598, symbol: 'AAPL' })
+    expect(positionMulti.mock.calls[0][4]).toEqual(new Decimal('10'))
+    expect(positionMulti.mock.calls[0][5]).toBe(200)
+    expect(positionMultiEnd).toHaveBeenCalledWith(11)
+    expect(accountUpdateMulti).toHaveBeenCalledWith(
+      12,
+      'DU_TEST',
+      'MODEL',
+      'CashBalance',
+      '1000000.00',
+      'USD',
+    )
+    expect(accountUpdateMultiEnd).toHaveBeenCalledWith(12)
+  })
+
+  it('decodes PnL payloads that begin directly with reqId', () => {
+    const { decoder, wrapper } = createDecoder()
+    const pnl = vi.spyOn(wrapper, 'pnl')
+    const pnlSingle = vi.spyOn(wrapper, 'pnlSingle')
+
+    decoder.interpret(IN.PNL, ['21', '10.5', '11.5', '12.5'])
+    decoder.interpret(IN.PNL_SINGLE, ['22', '3', '20.5', '21.5', '22.5', '500'])
+
+    expect(pnl).toHaveBeenCalledWith(21, 10.5, 11.5, 12.5)
+    expect(pnlSingle).toHaveBeenCalledWith(
+      22,
+      new Decimal('3'),
+      20.5,
+      21.5,
+      22.5,
+      500,
+    )
+  })
+})

--- a/packages/ibkr/tests/text-contract-decode.spec.ts
+++ b/packages/ibkr/tests/text-contract-decode.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Decoder, applyAllHandlers } from '../src/decoder/index.js'
+import { IN } from '../src/message.js'
+import { DefaultEWrapper } from '../src/wrapper.js'
+
+function createDecoder(): { decoder: Decoder; wrapper: DefaultEWrapper } {
+  const wrapper = new DefaultEWrapper()
+  const decoder = new Decoder(wrapper, 206)
+  applyAllHandlers(decoder)
+  return { decoder, wrapper }
+}
+
+describe('Decoder text contract payloads', () => {
+  it('decodes contract end and symbol samples without a payload msgId', () => {
+    const { decoder, wrapper } = createDecoder()
+    const contractDetailsEnd = vi.spyOn(wrapper, 'contractDetailsEnd')
+    const symbolSamples = vi.spyOn(wrapper, 'symbolSamples')
+
+    decoder.interpret(IN.CONTRACT_DATA_END, ['1', '91'])
+    decoder.interpret(IN.SYMBOL_SAMPLES, [
+      '92',
+      '1',
+      '265598',
+      'AAPL',
+      'STK',
+      'NASDAQ',
+      'USD',
+      '1',
+      'OPT',
+      'Apple Inc.',
+      'ISSUER',
+    ])
+
+    expect(contractDetailsEnd).toHaveBeenCalledWith(91)
+    expect(symbolSamples).toHaveBeenCalledOnce()
+    expect(symbolSamples.mock.calls[0][0]).toBe(92)
+    expect(symbolSamples.mock.calls[0][1]).toHaveLength(1)
+    expect(symbolSamples.mock.calls[0][1][0]).toMatchObject({
+      contract: {
+        conId: 265598,
+        symbol: 'AAPL',
+        secType: 'STK',
+        primaryExchange: 'NASDAQ',
+        currency: 'USD',
+        description: 'Apple Inc.',
+        issuerId: 'ISSUER',
+      },
+      derivativeSecTypes: ['OPT'],
+    })
+  })
+
+  it('decodes delta-neutral validation and market-rule payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const deltaNeutralValidation = vi.spyOn(wrapper, 'deltaNeutralValidation')
+    const marketRule = vi.spyOn(wrapper, 'marketRule')
+
+    decoder.interpret(IN.DELTA_NEUTRAL_VALIDATION, [
+      '1', '93', '265598', '0.5', '250.5',
+    ])
+    decoder.interpret(IN.MARKET_RULE, ['26', '2', '0', '0.01', '1', '0.05'])
+
+    expect(deltaNeutralValidation).toHaveBeenCalledOnce()
+    expect(deltaNeutralValidation.mock.calls[0][0]).toBe(93)
+    expect(deltaNeutralValidation.mock.calls[0][1]).toMatchObject({
+      conId: 265598,
+      delta: 0.5,
+      price: 250.5,
+    })
+    expect(marketRule).toHaveBeenCalledWith(26, [
+      expect.objectContaining({ lowEdge: 0, increment: 0.01 }),
+      expect.objectContaining({ lowEdge: 1, increment: 0.05 }),
+    ])
+  })
+})

--- a/packages/ibkr/tests/text-execution-decode.spec.ts
+++ b/packages/ibkr/tests/text-execution-decode.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+import Decimal from 'decimal.js'
+import { Decoder, applyAllHandlers } from '../src/decoder/index.js'
+import { IN } from '../src/message.js'
+import { DefaultEWrapper } from '../src/wrapper.js'
+
+function createDecoder(): { decoder: Decoder; wrapper: DefaultEWrapper } {
+  const wrapper = new DefaultEWrapper()
+  const decoder = new Decoder(wrapper, 206)
+  applyAllHandlers(decoder)
+  return { decoder, wrapper }
+}
+
+describe('Decoder text execution payloads', () => {
+  it('decodes execution details beginning directly with reqId', () => {
+    const { decoder, wrapper } = createDecoder()
+    const execDetails = vi.spyOn(wrapper, 'execDetails')
+
+    decoder.interpret(IN.EXECUTION_DATA, [
+      '101',
+      '81',
+      '265598',
+      'AAPL',
+      'STK',
+      '',
+      '0',
+      '',
+      '1',
+      'NASDAQ',
+      'USD',
+      'AAPL',
+      'NMS',
+      'EXEC-1',
+      '20260717 12:00:00',
+      'DU_TEST',
+      'NASDAQ',
+      'BOT',
+      '2',
+      '250.5',
+      '9001',
+      '7',
+      '0',
+      '2',
+      '250.5',
+      'ref',
+      '',
+      '0',
+      'MODEL',
+      '1',
+      '0',
+      'SUBMITTER',
+    ])
+
+    expect(execDetails).toHaveBeenCalledOnce()
+    expect(execDetails.mock.calls[0][0]).toBe(101)
+    expect(execDetails.mock.calls[0][1]).toMatchObject({
+      conId: 265598,
+      symbol: 'AAPL',
+      secType: 'STK',
+      tradingClass: 'NMS',
+    })
+    expect(execDetails.mock.calls[0][2]).toMatchObject({
+      orderId: 81,
+      execId: 'EXEC-1',
+      acctNumber: 'DU_TEST',
+      side: 'BOT',
+      shares: new Decimal('2'),
+      price: 250.5,
+      permId: 9001,
+      clientId: 7,
+      modelCode: 'MODEL',
+      lastLiquidity: 1,
+      pendingPriceRevision: false,
+      submitter: 'SUBMITTER',
+    })
+  })
+
+  it('decodes execution end and commission payloads from their version field', () => {
+    const { decoder, wrapper } = createDecoder()
+    const execDetailsEnd = vi.spyOn(wrapper, 'execDetailsEnd')
+    const commissionAndFeesReport = vi.spyOn(wrapper, 'commissionAndFeesReport')
+
+    decoder.interpret(IN.EXECUTION_DATA_END, ['1', '101'])
+    decoder.interpret(IN.COMMISSION_AND_FEES_REPORT, [
+      '1', 'EXEC-1', '1.25', 'USD', '25', '0', '0',
+    ])
+
+    expect(execDetailsEnd).toHaveBeenCalledWith(101)
+    expect(commissionAndFeesReport).toHaveBeenCalledOnce()
+    expect(commissionAndFeesReport.mock.calls[0][0]).toMatchObject({
+      execId: 'EXEC-1',
+      commissionAndFees: 1.25,
+      currency: 'USD',
+      realizedPNL: 25,
+      yield_: 0,
+      yieldRedemptionDate: 0,
+    })
+  })
+})

--- a/packages/ibkr/tests/text-historical-decode.spec.ts
+++ b/packages/ibkr/tests/text-historical-decode.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+import Decimal from 'decimal.js'
+import { Decoder, applyAllHandlers } from '../src/decoder/index.js'
+import { IN } from '../src/message.js'
+import { DefaultEWrapper } from '../src/wrapper.js'
+
+function createDecoder(): { decoder: Decoder; wrapper: DefaultEWrapper } {
+  const wrapper = new DefaultEWrapper()
+  const decoder = new Decoder(wrapper, 206)
+  applyAllHandlers(decoder)
+  return { decoder, wrapper }
+}
+
+describe('Decoder text historical payloads', () => {
+  it('decodes historical bars, updates, and end markers beginning with reqId', () => {
+    const { decoder, wrapper } = createDecoder()
+    const historicalData = vi.spyOn(wrapper, 'historicalData')
+    const historicalDataUpdate = vi.spyOn(wrapper, 'historicalDataUpdate')
+    const historicalDataEnd = vi.spyOn(wrapper, 'historicalDataEnd')
+
+    decoder.interpret(IN.HISTORICAL_DATA, [
+      '201', '1', '20260717', '10', '12', '9', '11', '100', '10.5', '7',
+    ])
+    decoder.interpret(IN.HISTORICAL_DATA_UPDATE, [
+      '202', '8', '20260718', '11', '12', '13', '10', '11.5', '101',
+    ])
+    decoder.interpret(IN.HISTORICAL_DATA_END, [
+      '203', '20260717', '20260718',
+    ])
+
+    expect(historicalData).toHaveBeenCalledOnce()
+    expect(historicalData.mock.calls[0][0]).toBe(201)
+    expect(historicalData.mock.calls[0][1]).toMatchObject({
+      date: '20260717',
+      open: 10,
+      high: 12,
+      low: 9,
+      close: 11,
+      volume: new Decimal('100'),
+      wap: new Decimal('10.5'),
+      barCount: 7,
+    })
+    expect(historicalDataUpdate).toHaveBeenCalledOnce()
+    expect(historicalDataUpdate.mock.calls[0][0]).toBe(202)
+    expect(historicalDataUpdate.mock.calls[0][1]).toMatchObject({
+      barCount: 8,
+      date: '20260718',
+      volume: new Decimal('101'),
+    })
+    expect(historicalDataEnd).toHaveBeenCalledWith(203, '20260717', '20260718')
+  })
+
+  it('decodes realtime bars, head timestamps, and histograms', () => {
+    const { decoder, wrapper } = createDecoder()
+    const realtimeBar = vi.spyOn(wrapper, 'realtimeBar')
+    const headTimestamp = vi.spyOn(wrapper, 'headTimestamp')
+    const histogramData = vi.spyOn(wrapper, 'histogramData')
+
+    decoder.interpret(IN.REAL_TIME_BARS, [
+      '1', '211', '1784289600', '10', '12', '9', '11', '100', '10.5', '7',
+    ])
+    decoder.interpret(IN.HEAD_TIMESTAMP, ['212', '20260717 12:00:00'])
+    decoder.interpret(IN.HISTOGRAM_DATA, ['213', '2', '10', '5', '11', '6'])
+
+    expect(realtimeBar).toHaveBeenCalledWith(
+      211,
+      1784289600,
+      10,
+      12,
+      9,
+      11,
+      new Decimal('100'),
+      new Decimal('10.5'),
+      7,
+    )
+    expect(headTimestamp).toHaveBeenCalledWith(212, '20260717 12:00:00')
+    expect(histogramData).toHaveBeenCalledWith(213, [
+      expect.objectContaining({ price: 10, size: new Decimal('5') }),
+      expect.objectContaining({ price: 11, size: new Decimal('6') }),
+    ])
+  })
+
+  it('decodes all three historical-tick payload shapes', () => {
+    const { decoder, wrapper } = createDecoder()
+    const historicalTicks = vi.spyOn(wrapper, 'historicalTicks')
+    const historicalTicksBidAsk = vi.spyOn(wrapper, 'historicalTicksBidAsk')
+    const historicalTicksLast = vi.spyOn(wrapper, 'historicalTicksLast')
+
+    decoder.interpret(IN.HISTORICAL_TICKS, [
+      '221', '1', '1784289600', '', '10', '5', '1',
+    ])
+    decoder.interpret(IN.HISTORICAL_TICKS_BID_ASK, [
+      '222', '1', '1784289601', '3', '10', '11', '5', '6', '1',
+    ])
+    decoder.interpret(IN.HISTORICAL_TICKS_LAST, [
+      '223', '1', '1784289602', '3', '11', '6', 'NASDAQ', 'COND', '1',
+    ])
+
+    expect(historicalTicks).toHaveBeenCalledOnce()
+    expect(historicalTicks.mock.calls[0][0]).toBe(221)
+    expect(historicalTicks.mock.calls[0][1][0]).toMatchObject({
+      time: 1784289600,
+      price: 10,
+      size: new Decimal('5'),
+    })
+    expect(historicalTicks.mock.calls[0][2]).toBe(true)
+    expect(historicalTicksBidAsk).toHaveBeenCalledOnce()
+    expect(historicalTicksBidAsk.mock.calls[0][1][0]).toMatchObject({
+      time: 1784289601,
+      priceBid: 10,
+      priceAsk: 11,
+      sizeBid: new Decimal('5'),
+      sizeAsk: new Decimal('6'),
+    })
+    expect(historicalTicksLast).toHaveBeenCalledOnce()
+    expect(historicalTicksLast.mock.calls[0][1][0]).toMatchObject({
+      time: 1784289602,
+      price: 11,
+      size: new Decimal('6'),
+      exchange: 'NASDAQ',
+      specialConditions: 'COND',
+    })
+  })
+
+  it('decodes tick-by-tick and historical-schedule payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const tickByTickAllLast = vi.spyOn(wrapper, 'tickByTickAllLast')
+    const historicalSchedule = vi.spyOn(wrapper, 'historicalSchedule')
+
+    decoder.interpret(IN.TICK_BY_TICK, [
+      '231', '1', '1784289600', '11', '6', '3', 'NASDAQ', 'COND',
+    ])
+    decoder.interpret(IN.HISTORICAL_SCHEDULE, [
+      '232',
+      '20260717 09:30:00',
+      '20260717 16:00:00',
+      'US/Eastern',
+      '1',
+      '20260717 09:30:00',
+      '20260717 16:00:00',
+      '20260717',
+    ])
+
+    expect(tickByTickAllLast).toHaveBeenCalledOnce()
+    expect(tickByTickAllLast.mock.calls[0].slice(0, 5)).toEqual([
+      231, 1, 1784289600, 11, new Decimal('6'),
+    ])
+    expect(tickByTickAllLast.mock.calls[0][5]).toMatchObject({
+      pastLimit: true,
+      unreported: true,
+    })
+    expect(tickByTickAllLast.mock.calls[0].slice(6)).toEqual(['NASDAQ', 'COND'])
+    expect(historicalSchedule).toHaveBeenCalledOnce()
+    expect(historicalSchedule.mock.calls[0][0]).toBe(232)
+    expect(historicalSchedule.mock.calls[0][1]).toBe('20260717 09:30:00')
+    expect(historicalSchedule.mock.calls[0][2]).toBe('20260717 16:00:00')
+    expect(historicalSchedule.mock.calls[0][3]).toBe('US/Eastern')
+    expect(historicalSchedule.mock.calls[0][4]).toEqual([
+      expect.objectContaining({
+        startDateTime: '20260717 09:30:00',
+        endDateTime: '20260717 16:00:00',
+        refDate: '20260717',
+      }),
+    ])
+  })
+})

--- a/packages/ibkr/tests/text-market-data-decode.spec.ts
+++ b/packages/ibkr/tests/text-market-data-decode.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import Decimal from 'decimal.js'
+import { Decoder, applyAllHandlers } from '../src/decoder/index.js'
+import { IN } from '../src/message.js'
+import { TickTypeEnum } from '../src/tick-type.js'
+import { DefaultEWrapper } from '../src/wrapper.js'
+
+function createDecoder(): { decoder: Decoder; wrapper: DefaultEWrapper } {
+  const wrapper = new DefaultEWrapper()
+  const decoder = new Decoder(wrapper, 206)
+  applyAllHandlers(decoder)
+  return { decoder, wrapper }
+}
+
+describe('Decoder text market-data payloads', () => {
+  it('decodes tick price and size payloads from their version field', () => {
+    const { decoder, wrapper } = createDecoder()
+    const tickPrice = vi.spyOn(wrapper, 'tickPrice')
+    const tickSize = vi.spyOn(wrapper, 'tickSize')
+
+    decoder.interpret(IN.TICK_PRICE, ['3', '41', '1', '250.5', '10', '7'])
+    decoder.interpret(IN.TICK_SIZE, ['1', '42', '0', '11'])
+
+    expect(tickPrice).toHaveBeenCalledOnce()
+    expect(tickPrice.mock.calls[0][0]).toBe(41)
+    expect(tickPrice.mock.calls[0][1]).toBe(TickTypeEnum.BID)
+    expect(tickPrice.mock.calls[0][2]).toBe(250.5)
+    expect(tickPrice.mock.calls[0][3]).toMatchObject({
+      canAutoExecute: true,
+      pastLimit: true,
+      preOpen: true,
+    })
+    expect(tickSize).toHaveBeenCalledWith(41, TickTypeEnum.BID_SIZE, new Decimal('10'))
+    expect(tickSize).toHaveBeenCalledWith(42, TickTypeEnum.BID_SIZE, new Decimal('11'))
+  })
+
+  it('decodes option, generic, string, and EFP tick payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const tickOptionComputation = vi.spyOn(wrapper, 'tickOptionComputation')
+    const tickGeneric = vi.spyOn(wrapper, 'tickGeneric')
+    const tickString = vi.spyOn(wrapper, 'tickString')
+    const tickEFP = vi.spyOn(wrapper, 'tickEFP')
+
+    decoder.interpret(IN.TICK_OPTION_COMPUTATION, [
+      '51', '13', '1', '0.25', '0.5', '1.2', '0.1', '0.02', '0.03', '-0.04', '250',
+    ])
+    decoder.interpret(IN.TICK_GENERIC, ['1', '52', '23', '1.5'])
+    decoder.interpret(IN.TICK_STRING, ['1', '53', '45', 'hello'])
+    decoder.interpret(IN.TICK_EFP, [
+      '1', '54', '38', '1.1', '1.1bp', '251', '3', '202612', '0.2', '0.3',
+    ])
+
+    expect(tickOptionComputation).toHaveBeenCalledWith(
+      51, 13, 1, 0.25, 0.5, 1.2, 0.1, 0.02, 0.03, -0.04, 250,
+    )
+    expect(tickGeneric).toHaveBeenCalledWith(52, 23, 1.5)
+    expect(tickString).toHaveBeenCalledWith(53, 45, 'hello')
+    expect(tickEFP).toHaveBeenCalledWith(
+      54, 38, 1.1, '1.1bp', 251, 3, '202612', 0.2, 0.3,
+    )
+  })
+
+  it('decodes snapshot, market-data type, and request-parameter payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const tickSnapshotEnd = vi.spyOn(wrapper, 'tickSnapshotEnd')
+    const marketDataType = vi.spyOn(wrapper, 'marketDataType')
+    const tickReqParams = vi.spyOn(wrapper, 'tickReqParams')
+
+    decoder.interpret(IN.TICK_SNAPSHOT_END, ['1', '61'])
+    decoder.interpret(IN.MARKET_DATA_TYPE, ['1', '62', '3'])
+    decoder.interpret(IN.TICK_REQ_PARAMS, ['63', '0.01', 'NASDAQ', '7'])
+
+    expect(tickSnapshotEnd).toHaveBeenCalledWith(61)
+    expect(marketDataType).toHaveBeenCalledWith(62, 3)
+    expect(tickReqParams).toHaveBeenCalledWith(63, 0.01, 'NASDAQ', 7)
+  })
+
+  it('decodes depth and reroute payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const updateMktDepth = vi.spyOn(wrapper, 'updateMktDepth')
+    const updateMktDepthL2 = vi.spyOn(wrapper, 'updateMktDepthL2')
+    const rerouteMktDataReq = vi.spyOn(wrapper, 'rerouteMktDataReq')
+    const rerouteMktDepthReq = vi.spyOn(wrapper, 'rerouteMktDepthReq')
+
+    decoder.interpret(IN.MARKET_DEPTH, ['1', '71', '2', '0', '1', '250.5', '10'])
+    decoder.interpret(IN.MARKET_DEPTH_L2, [
+      '1', '72', '3', 'MM', '1', '0', '251.5', '11', '1',
+    ])
+    decoder.interpret(IN.REROUTE_MKT_DATA_REQ, ['73', '265598', 'NASDAQ'])
+    decoder.interpret(IN.REROUTE_MKT_DEPTH_REQ, ['74', '265598', 'NASDAQ'])
+
+    expect(updateMktDepth).toHaveBeenCalledWith(
+      71, 2, 0, 1, 250.5, new Decimal('10'),
+    )
+    expect(updateMktDepthL2).toHaveBeenCalledWith(
+      72, 3, 'MM', 1, 0, 251.5, new Decimal('11'), true,
+    )
+    expect(rerouteMktDataReq).toHaveBeenCalledWith(73, 265598, 'NASDAQ')
+    expect(rerouteMktDepthReq).toHaveBeenCalledWith(74, 265598, 'NASDAQ')
+  })
+})

--- a/packages/ibkr/tests/text-misc-decode.spec.ts
+++ b/packages/ibkr/tests/text-misc-decode.spec.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Decoder, applyAllHandlers } from '../src/decoder/index.js'
+import { IN } from '../src/message.js'
+import { DefaultEWrapper } from '../src/wrapper.js'
+
+function createDecoder(): { decoder: Decoder; wrapper: DefaultEWrapper } {
+  const wrapper = new DefaultEWrapper()
+  const decoder = new Decoder(wrapper, 206)
+  applyAllHandlers(decoder)
+  return { decoder, wrapper }
+}
+
+describe('Decoder text miscellaneous payloads', () => {
+  it('decodes error and time payloads without a payload msgId', () => {
+    const { decoder, wrapper } = createDecoder()
+    const error = vi.spyOn(wrapper, 'error')
+    const currentTime = vi.spyOn(wrapper, 'currentTime')
+    const currentTimeInMillis = vi.spyOn(wrapper, 'currentTimeInMillis')
+
+    decoder.interpret(IN.ERR_MSG, [
+      '81', '321', 'bad contract', '{"reason":"test"}', '1784289600',
+    ])
+    decoder.interpret(IN.CURRENT_TIME, ['1', '1784289600'])
+    decoder.interpret(IN.CURRENT_TIME_IN_MILLIS, ['1784289600123'])
+
+    expect(error).toHaveBeenCalledWith(
+      81, 1784289600, 321, 'bad contract', '{"reason":"test"}',
+    )
+    expect(currentTime).toHaveBeenCalledWith(1784289600)
+    expect(currentTimeInMillis).toHaveBeenCalledWith(1784289600123)
+  })
+
+  it('decodes scanner parameter and scanner row payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const scannerParameters = vi.spyOn(wrapper, 'scannerParameters')
+    const scannerData = vi.spyOn(wrapper, 'scannerData')
+    const scannerDataEnd = vi.spyOn(wrapper, 'scannerDataEnd')
+
+    decoder.interpret(IN.SCANNER_PARAMETERS, ['1', '<scan/>'])
+    decoder.interpret(IN.SCANNER_DATA, [
+      '1',
+      '91',
+      '1',
+      '0',
+      '265598',
+      'AAPL',
+      'STK',
+      '',
+      '0',
+      '',
+      'SMART',
+      'USD',
+      'AAPL',
+      'NASDAQ.NMS',
+      'NMS',
+      '1.0',
+      'SPX',
+      'UP',
+      '',
+    ])
+
+    expect(scannerParameters).toHaveBeenCalledWith('<scan/>')
+    expect(scannerData).toHaveBeenCalledOnce()
+    expect(scannerData.mock.calls[0][0]).toBe(91)
+    expect(scannerData.mock.calls[0][1]).toBe(0)
+    expect(scannerData.mock.calls[0][2]).toMatchObject({
+      contract: { conId: 265598, symbol: 'AAPL', secType: 'STK' },
+      marketName: 'NASDAQ.NMS',
+    })
+    expect(scannerData.mock.calls[0].slice(3)).toEqual(['1.0', 'SPX', 'UP', ''])
+    expect(scannerDataEnd).toHaveBeenCalledWith(91)
+  })
+
+  it('decodes bulletin, FA, fundamental, and news payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const updateNewsBulletin = vi.spyOn(wrapper, 'updateNewsBulletin')
+    const receiveFA = vi.spyOn(wrapper, 'receiveFA')
+    const fundamentalData = vi.spyOn(wrapper, 'fundamentalData')
+    const newsProviders = vi.spyOn(wrapper, 'newsProviders')
+    const newsArticle = vi.spyOn(wrapper, 'newsArticle')
+    const tickNews = vi.spyOn(wrapper, 'tickNews')
+    const historicalNews = vi.spyOn(wrapper, 'historicalNews')
+    const historicalNewsEnd = vi.spyOn(wrapper, 'historicalNewsEnd')
+
+    decoder.interpret(IN.NEWS_BULLETINS, ['1', '7', '2', 'headline', 'NYSE'])
+    decoder.interpret(IN.RECEIVE_FA, ['1', '3', '<fa/>'])
+    decoder.interpret(IN.FUNDAMENTAL_DATA, ['1', '101', '<fund/>'])
+    decoder.interpret(IN.NEWS_PROVIDERS, ['1', 'BRFG', 'Briefing.com'])
+    decoder.interpret(IN.NEWS_ARTICLE, ['102', '0', 'article'])
+    decoder.interpret(IN.TICK_NEWS, [
+      '103', '1784289600', 'BRFG', 'A-1', 'headline', 'extra',
+    ])
+    decoder.interpret(IN.HISTORICAL_NEWS, [
+      '104', '20260717 12:00:00', 'BRFG', 'A-1', 'headline',
+    ])
+    decoder.interpret(IN.HISTORICAL_NEWS_END, ['104', '1'])
+
+    expect(updateNewsBulletin).toHaveBeenCalledWith(7, 2, 'headline', 'NYSE')
+    expect(receiveFA).toHaveBeenCalledWith(3, '<fa/>')
+    expect(fundamentalData).toHaveBeenCalledWith(101, '<fund/>')
+    expect(newsProviders).toHaveBeenCalledWith([
+      expect.objectContaining({ code: 'BRFG', name: 'Briefing.com' }),
+    ])
+    expect(newsArticle).toHaveBeenCalledWith(102, 0, 'article')
+    expect(tickNews).toHaveBeenCalledWith(
+      103, 1784289600, 'BRFG', 'A-1', 'headline', 'extra',
+    )
+    expect(historicalNews).toHaveBeenCalledWith(
+      104, '20260717 12:00:00', 'BRFG', 'A-1', 'headline',
+    )
+    expect(historicalNewsEnd).toHaveBeenCalledWith(104, true)
+  })
+
+  it('decodes option metadata and market-directory payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const securityDefinitionOptionParameter = vi.spyOn(wrapper, 'securityDefinitionOptionParameter')
+    const securityDefinitionOptionParameterEnd = vi.spyOn(wrapper, 'securityDefinitionOptionParameterEnd')
+    const softDollarTiers = vi.spyOn(wrapper, 'softDollarTiers')
+    const familyCodes = vi.spyOn(wrapper, 'familyCodes')
+    const smartComponents = vi.spyOn(wrapper, 'smartComponents')
+    const mktDepthExchanges = vi.spyOn(wrapper, 'mktDepthExchanges')
+
+    decoder.interpret(IN.SECURITY_DEFINITION_OPTION_PARAMETER, [
+      '111', 'SMART', '265598', 'AAPL', '100',
+      '2', '20260821', '20260918',
+      '2', '250', '260',
+    ])
+    decoder.interpret(IN.SECURITY_DEFINITION_OPTION_PARAMETER_END, ['111'])
+    decoder.interpret(IN.SOFT_DOLLAR_TIERS, ['112', '1', 'TIER', 'VALUE', 'Display'])
+    decoder.interpret(IN.FAMILY_CODES, ['1', 'DU_TEST', 'FAMILY'])
+    decoder.interpret(IN.SMART_COMPONENTS, ['113', '1', '1', 'NASDAQ', 'Q'])
+    decoder.interpret(IN.MKT_DEPTH_EXCHANGES, [
+      '1', 'NASDAQ', 'STK', 'NASDAQ', 'Deep2', '7',
+    ])
+
+    expect(securityDefinitionOptionParameter).toHaveBeenCalledWith(
+      111,
+      'SMART',
+      265598,
+      'AAPL',
+      '100',
+      new Set(['20260821', '20260918']),
+      new Set([250, 260]),
+    )
+    expect(securityDefinitionOptionParameterEnd).toHaveBeenCalledWith(111)
+    expect(softDollarTiers).toHaveBeenCalledWith(112, [
+      expect.objectContaining({ name: 'TIER', val: 'VALUE', displayName: 'Display' }),
+    ])
+    expect(familyCodes).toHaveBeenCalledWith([
+      expect.objectContaining({ accountID: 'DU_TEST', familyCodeStr: 'FAMILY' }),
+    ])
+    expect(smartComponents).toHaveBeenCalledWith(113, [
+      expect.objectContaining({ bitNumber: 1, exchange: 'NASDAQ', exchangeLetter: 'Q' }),
+    ])
+    expect(mktDepthExchanges).toHaveBeenCalledWith([
+      expect.objectContaining({
+        exchange: 'NASDAQ',
+        secType: 'STK',
+        listingExch: 'NASDAQ',
+        serviceDataType: 'Deep2',
+        aggGroup: 7,
+      }),
+    ])
+  })
+
+  it('decodes verification and display-group payloads from their version field', () => {
+    const { decoder, wrapper } = createDecoder()
+    const verifyMessageAPI = vi.spyOn(wrapper, 'verifyMessageAPI')
+    const verifyCompleted = vi.spyOn(wrapper, 'verifyCompleted')
+    const verifyAndAuthMessageAPI = vi.spyOn(wrapper, 'verifyAndAuthMessageAPI')
+    const verifyAndAuthCompleted = vi.spyOn(wrapper, 'verifyAndAuthCompleted')
+    const displayGroupList = vi.spyOn(wrapper, 'displayGroupList')
+    const displayGroupUpdated = vi.spyOn(wrapper, 'displayGroupUpdated')
+
+    decoder.interpret(IN.VERIFY_MESSAGE_API, ['1', 'api-data'])
+    decoder.interpret(IN.VERIFY_COMPLETED, ['1', '1', ''])
+    decoder.interpret(IN.VERIFY_AND_AUTH_MESSAGE_API, ['1', 'api-data', 'challenge'])
+    decoder.interpret(IN.VERIFY_AND_AUTH_COMPLETED, ['1', '0', 'denied'])
+    decoder.interpret(IN.DISPLAY_GROUP_LIST, ['1', '121', '1|Group'])
+    decoder.interpret(IN.DISPLAY_GROUP_UPDATED, ['1', '122', '265598@SMART'])
+
+    expect(verifyMessageAPI).toHaveBeenCalledWith('api-data')
+    expect(verifyCompleted).toHaveBeenCalledWith(true, '')
+    expect(verifyAndAuthMessageAPI).toHaveBeenCalledWith('api-data', 'challenge')
+    expect(verifyAndAuthCompleted).toHaveBeenCalledWith(false, 'denied')
+    expect(displayGroupList).toHaveBeenCalledWith(121, '1|Group')
+    expect(displayGroupUpdated).toHaveBeenCalledWith(122, '265598@SMART')
+  })
+
+  it('decodes WSH, user-info, and FA-replacement payloads', () => {
+    const { decoder, wrapper } = createDecoder()
+    const wshMetaData = vi.spyOn(wrapper, 'wshMetaData')
+    const wshEventData = vi.spyOn(wrapper, 'wshEventData')
+    const userInfo = vi.spyOn(wrapper, 'userInfo')
+    const replaceFAEnd = vi.spyOn(wrapper, 'replaceFAEnd')
+
+    decoder.interpret(IN.WSH_META_DATA, ['131', '{"meta":true}'])
+    decoder.interpret(IN.WSH_EVENT_DATA, ['132', '{"event":true}'])
+    decoder.interpret(IN.USER_INFO, ['133', 'brand'])
+    decoder.interpret(IN.REPLACE_FA_END, ['134', 'done'])
+
+    expect(wshMetaData).toHaveBeenCalledWith(131, '{"meta":true}')
+    expect(wshEventData).toHaveBeenCalledWith(132, '{"event":true}')
+    expect(userInfo).toHaveBeenCalledWith(133, 'brand')
+    expect(replaceFAEnd).toHaveBeenCalledWith(134, 'done')
+  })
+})

--- a/packages/ibkr/tests/text-order-decode.spec.ts
+++ b/packages/ibkr/tests/text-order-decode.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import Decimal from 'decimal.js'
+import { Decoder, applyAllHandlers } from '../src/decoder/index.js'
+import { IN } from '../src/message.js'
+import { DefaultEWrapper } from '../src/wrapper.js'
+
+function createDecoder(): { decoder: Decoder; wrapper: DefaultEWrapper } {
+  const wrapper = new DefaultEWrapper()
+  const decoder = new Decoder(wrapper, 206)
+  applyAllHandlers(decoder)
+  return { decoder, wrapper }
+}
+
+describe('Decoder text order payloads', () => {
+  it('decodes order status beginning directly with orderId', () => {
+    const { decoder, wrapper } = createDecoder()
+    const orderStatus = vi.spyOn(wrapper, 'orderStatus')
+
+    decoder.interpret(IN.ORDER_STATUS, [
+      '81', 'Submitted', '2', '3', '250.5', '9001', '0', '251', '7', '', '252',
+    ])
+
+    expect(orderStatus).toHaveBeenCalledWith(
+      81,
+      'Submitted',
+      new Decimal('2'),
+      new Decimal('3'),
+      250.5,
+      9001,
+      0,
+      251,
+      7,
+      '',
+      252,
+    )
+  })
+
+  it('decodes text order lifecycle markers without a payload msgId', () => {
+    const { decoder, wrapper } = createDecoder()
+    const openOrderEnd = vi.spyOn(wrapper, 'openOrderEnd')
+    const orderBound = vi.spyOn(wrapper, 'orderBound')
+    const completedOrdersEnd = vi.spyOn(wrapper, 'completedOrdersEnd')
+
+    decoder.interpret(IN.OPEN_ORDER_END, ['1'])
+    decoder.interpret(IN.ORDER_BOUND, ['9001', '7', '81'])
+    decoder.interpret(IN.COMPLETED_ORDERS_END, [])
+
+    expect(openOrderEnd).toHaveBeenCalledOnce()
+    expect(orderBound).toHaveBeenCalledWith(9001, 7, 81)
+    expect(completedOrdersEnd).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

- make the inbound envelope and payload boundary explicit for legacy text, raw-int text, and protobuf messages
- remove 84 phantom message-id reads from text handlers and add category-level payload fixtures
- contain malformed frames to the IBKR connection, drop buffered successors, and sanitize decoder errors
- document the protocol invariant and add a collision-safe TWS E2E client-id override

Fixes #132.
Relates to #162; EU Gateway validation is still requested from the reporter.

## Verification

- npx tsc --noEmit
- pnpm test: 3146 passed, 8 skipped
- IBKR package typecheck and unit suite
- UTA MockBroker lifecycle: 15 passed
- TWS paper read-only connect: 4 passed using an isolated client id
- TWS paper contract details: 5 passed using an isolated client id

The full non-trading E2E run had 32 passes and 3 skips; its only failure was the unrelated BLS provider test because this machine received ECONNRESET before TLS to api.bls.gov. No logged-in IB Gateway is available locally, so Gateway 10.32/10.37 acceptance remains an explicit reporter-validation step.