### PR TITLE
fix(ibkr): close liveness and option-mark gaps

### DIFF
--- a/docs/uta-live-testing.md
+++ b/docs/uta-live-testing.md
@@ -155,6 +155,45 @@ files under `data/` (gitignored), run with
 importing `readUTAsConfig` + `createBroker` by absolute/relative path.
 Delete after use.
 
+## IBKR half-open and option-mark acceptance
+
+These two read-only checks cover the failure modes from issues #294 and #314.
+They do not authorize an order submission and are safe to run with the UTA and
+Gateway both configured read-only.
+
+### Silent half-open recovery
+
+Freeze the Gateway process/container without closing its TCP socket (for a
+Docker Gateway, `docker pause <container>` is deterministic). Always install a
+shell trap or otherwise guarantee `docker unpause <container>` on exit.
+
+Acceptance:
+
+1. Before the drop, `/api/trading/uta` reports `healthy/readable` and account
+   reads succeed.
+2. Within the heartbeat interval plus timeout (currently at most about 50s),
+   UTA moves directly to `offline/down`; it must not require six caller-driven
+   cache-read failures.
+3. While dead, account/position reads refuse rather than serving stale cache.
+4. After unpause, recovery reconnects and passes a private account read before
+   returning to `healthy/readable`.
+5. The unit-level write boundary separately proves place/modify/cancel performs
+   `reqCurrentTime` before the client send and never calls the send method when
+   that probe times out. Do not submit a live order merely to test this gate.
+
+### Option position mark overlay
+
+With an `OPT` or `FOP` paper position and an entitled or delayed quote:
+
+1. Positive snapshot bid+ask produces midpoint `(bid + ask) / 2`.
+2. `marketValue` and `unrealizedPnL` are recomputed through
+   `derivePositionMath`, including quantity, side, and contract multiplier.
+3. The broker-owned `updatePortfolio()` cache is not mutated.
+4. Missing entitlement, incomplete bid/ask, or timeout returns the cached row;
+   it must not fail the whole portfolio read.
+5. Requests use `regulatorySnapshot=false`; this acceptance must never opt the
+   account into paid per-request regulatory snapshots.
+
 ## Scenario catalog
 
 Run the relevant S1–S14 scenarios for a trading-path change; run the full

--- a/packages/uta-protocol/src/types/broker.ts
+++ b/packages/uta-protocol/src/types/broker.ts
@@ -411,6 +411,19 @@ export interface BrokerHealthInfo {
   disabled: boolean
 }
 
+/**
+ * Optional transport signal from a broker adapter to its owning UTA.
+ *
+ * `dead` is authoritative and must take health offline immediately. `restored`
+ * is only a hint to retry now (IBKR 1101/1102); it is not proof that private
+ * account reads work again. `alive` is emitted only after the adapter has
+ * completed its own reconnect/readiness handshake.
+ */
+export interface BrokerConnectionStateEvent {
+  state: 'alive' | 'dead' | 'restored'
+  error?: string
+}
+
 // ==================== Account capabilities ====================
 
 /**
@@ -477,6 +490,11 @@ export interface IBroker<TMeta = unknown> {
 
   init(): Promise<void>
   close(): Promise<void>
+
+  /** Optional push signal for transports with an active heartbeat. */
+  setConnectionStateListener?(
+    listener: ((event: BrokerConnectionStateEvent) => void) | null,
+  ): void
 
   // ---- Contract search (IBKR: reqMatchingSymbols + reqContractDetails) ----
 

--- a/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
@@ -1108,6 +1108,38 @@ describe('UTA — health tracking', () => {
     expect(uta.getHealthInfo().recovering).toBe(false)
   })
 
+  it('moves offline immediately on a broker transport-dead event and retries when transport is restored', async () => {
+    const broker = new MockBroker()
+    let connectionListener: (event: { state: 'alive' | 'dead' | 'restored'; error?: string }) => void = () => {
+      throw new Error('connection-state listener was not registered')
+    }
+    ;(broker as unknown as { setConnectionStateListener: unknown }).setConnectionStateListener = (
+      listener: typeof connectionListener | null,
+    ) => { if (listener) connectionListener = listener }
+    const { uta } = createUTA(broker)
+    await flush()
+    expect(broker.callCount('init')).toBe(1)
+
+    connectionListener({ state: 'dead', error: 'silent half-open detected' })
+    expect(uta.health).toBe('offline')
+    expect(uta.reach).toBe('down')
+    expect(uta.getHealthInfo()).toMatchObject({
+      consecutiveFailures: 6,
+      recovering: true,
+      lastError: 'silent half-open detected',
+    })
+
+    // 1101/1102 is only a nudge: the broker must still pass init+account read
+    // before health can become green again. The nudge bypasses recovery backoff.
+    connectionListener({ state: 'restored' })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(broker.callCount('init')).toBe(2)
+    expect(uta.health).toBe('healthy')
+    expect(uta.getHealthInfo().recovering).toBe(false)
+    await uta.close()
+  })
+
   it('transitions healthy → degraded after 3 consecutive failures', async () => {
     const broker = new MockBroker()
     const { uta } = createUTA(broker)

--- a/services/uta/src/domain/trading/UnifiedTradingAccount.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.ts
@@ -9,7 +9,7 @@
 
 import Decimal from 'decimal.js'
 import { Contract, Order, ContractDescription, ContractDetails, UNSET_DECIMAL, UNSET_INTEGER, UNSET_DOUBLE } from '@traderalice/ibkr'
-import { BrokerError, type IBroker, type AccountInfo, type Position, type OpenOrder, type PlaceOrderResult, type Quote, type MarketClock, type AccountCapabilities, type BrokerHealth, type BrokerHealthInfo, type UTAReach, type UTATier, type TpSlParams, type Bar, type BarParams, type ExpandContractFilters, type ContractExpansion, type SubAccountRef } from './brokers/types.js'
+import { BrokerError, type IBroker, type AccountInfo, type Position, type OpenOrder, type PlaceOrderResult, type Quote, type MarketClock, type AccountCapabilities, type BrokerHealth, type BrokerHealthInfo, type BrokerConnectionStateEvent, type UTAReach, type UTATier, type TpSlParams, type Bar, type BarParams, type ExpandContractFilters, type ContractExpansion, type SubAccountRef } from './brokers/types.js'
 
 const REACH_RANK: Record<UTAReach, number> = { down: 0, connected: 1, readable: 2 }
 import { TradingGit } from './git/TradingGit.js'
@@ -152,6 +152,7 @@ export class UnifiedTradingAccount {
     this._onHealthChange = options.onHealthChange
     this._onPostPush = options.onPostPush
     this._onPostReject = options.onPostReject
+    this.broker.setConnectionStateListener?.((event) => this._onBrokerConnectionState(event))
 
     // Wire internals
     this._getState = async (): Promise<GitState> => {
@@ -323,6 +324,30 @@ export class UnifiedTradingAccount {
     this._lastFailureAt = new Date()
   }
 
+  /** A broker heartbeat knows more than passive failure counting: once the
+   * transport is explicitly dead, serving a green health badge is unsafe.
+   * Recovery still has to pass the normal capability ladder before the UTA is
+   * marked healthy again. */
+  private _onBrokerConnectionState(event: BrokerConnectionStateEvent): void {
+    if (event.state === 'alive') return
+    if (event.state === 'restored') {
+      this.nudgeRecovery()
+      return
+    }
+    if (this._disabled) return
+
+    this._currentReach = 'down'
+    this._consecutiveFailures = UnifiedTradingAccount.OFFLINE_THRESHOLD
+    this._lastError = event.error ?? 'Broker transport reported a dead connection'
+    this._lastFailureAt = new Date()
+
+    // During the initial handshake, _connect owns the transition into recovery
+    // and will emit the first settled health snapshot.
+    if (this._connecting) return
+    if (!this._recovering) this._startRecovery()
+    else this._emitHealthChange()
+  }
+
   /** Initial broker connection — fire-and-forget from constructor. */
   private async _connect(): Promise<void> {
     // Timed + logged: the connect duration is the cold-start cost this whole
@@ -420,8 +445,8 @@ export class UnifiedTradingAccount {
     if (this._recoveryTimer) {
       clearTimeout(this._recoveryTimer)
       this._recoveryTimer = undefined
-      this._recovering = false
     }
+    this._recovering = false
     if (prev !== this.health) this._emitHealthChange()
   }
 
@@ -440,7 +465,7 @@ export class UnifiedTradingAccount {
   nudgeRecovery(): void {
     if (!this._recovering || this._disabled) return
     if (this._recoveryTimer) clearTimeout(this._recoveryTimer)
-    this._scheduleRecoveryAttempt(0)
+    this._scheduleRecoveryAttempt(0, 0)
   }
 
   private _startRecovery(): void {
@@ -451,12 +476,13 @@ export class UnifiedTradingAccount {
     this._scheduleRecoveryAttempt(0)
   }
 
-  private _scheduleRecoveryAttempt(attempt: number): void {
-    const delay = Math.min(
+  private _scheduleRecoveryAttempt(attempt: number, delayOverride?: number): void {
+    const delay = delayOverride ?? Math.min(
       UnifiedTradingAccount.RECOVERY_BASE_MS * 2 ** attempt,
       UnifiedTradingAccount.RECOVERY_MAX_MS,
     )
     this._recoveryTimer = setTimeout(async () => {
+      this._recoveryTimer = undefined
       this._currentReach = await this._attemptReach()
       if (this._disabled) {
         this._recovering = false
@@ -1178,6 +1204,7 @@ export class UnifiedTradingAccount {
   // ==================== Lifecycle ====================
 
   async close(): Promise<void> {
+    this.broker.setConnectionStateListener?.(null)
     if (this._recoveryTimer) {
       clearTimeout(this._recoveryTimer)
       this._recoveryTimer = undefined

--- a/services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.spec.ts
@@ -44,12 +44,15 @@ function brokerWithContractIo(resolvedContract = usdChfContract()): {
   bridge: {
     requestCollector: ReturnType<typeof vi.fn>
     requestSnapshot: ReturnType<typeof vi.fn>
+    requestCurrentTime: ReturnType<typeof vi.fn>
     requestOrder: ReturnType<typeof vi.fn>
+    markDead: ReturnType<typeof vi.fn>
   }
   client: {
     reqContractDetails: ReturnType<typeof vi.fn>
     reqMktData: ReturnType<typeof vi.fn>
     placeOrder: ReturnType<typeof vi.fn>
+    cancelOrder: ReturnType<typeof vi.fn>
   }
 } {
   const broker = new IbkrBroker({ id: 'ibkr-test', host: '127.0.0.1', port: 7497, clientId: 91 })
@@ -58,13 +61,16 @@ function brokerWithContractIo(resolvedContract = usdChfContract()): {
     allocReqId: vi.fn(() => 17),
     requestCollector: vi.fn(async () => [{ contract: Object.assign(new Contract(), resolvedContract) }]),
     requestSnapshot: vi.fn(async () => ({ last: 0.8, bid: 0.79, ask: 0.81, volume: 1 })),
+    requestCurrentTime: vi.fn(async () => 1_784_289_600),
     getNextOrderId: vi.fn(() => 42),
     requestOrder: vi.fn(async () => ({ orderState: { status: 'Submitted' } })),
+    markDead: vi.fn(),
   }
   const client = {
     reqContractDetails: vi.fn(),
     reqMktData: vi.fn(),
     placeOrder: vi.fn(),
+    cancelOrder: vi.fn(),
   }
   ;(broker as unknown as { bridge: unknown }).bridge = bridge
   ;(broker as unknown as { client: unknown }).client = client
@@ -241,7 +247,7 @@ describe('IbkrBroker — canonical conId contract resolution', () => {
       side: 'long',
       quantity: new Decimal('1'),
     }])
-    const placeOrder = vi.fn(async () => ({ success: true, orderId: '42' }))
+    const placeOrder = vi.fn(async (_contract: Contract, _order: Order) => ({ success: true, orderId: '42' }))
     ;(broker as unknown as { placeOrder: unknown }).placeOrder = placeOrder
 
     const result = await broker.closePosition(Object.assign(new Contract(), { conId: 12087820 }))
@@ -352,13 +358,117 @@ describe('IbkrBroker — getAccount mixed-currency math (ANG-101 / issues #295 #
     expect(a.netLiquidation).toBe('1046101.7')
   })
 
-  it('same-currency book keeps the reconstructed (fresher) netLiquidation', async () => {
+  it('prefers broker NetLiquidation for a same-currency book too', async () => {
     const b = brokerWithCache({
       TotalCashValue: '1000', NetLiquidation: '99999',
       RealizedPnL: '0', BuyingPower: '0', InitMarginReq: '0', MaintMarginReq: '0',
     }, [{ ...usdPos, multiplier: '1', quantity: '10' }])
     const a = await b.getAccount()
-    expect(a.netLiquidation).not.toBe('99999') // cash + Σ marketValue, not the cached tag
+    expect(a.netLiquidation).toBe('99999')
+  })
+
+  it('reconstructs NetLiquidation only when the broker value is unavailable', async () => {
+    const b = brokerWithCache({
+      TotalCashValue: '1000',
+      RealizedPnL: '0', BuyingPower: '0', InitMarginReq: '0', MaintMarginReq: '0',
+    }, [{ ...usdPos, multiplier: '1', quantity: '10', side: 'long' }])
+    const a = await b.getAccount()
+    expect(a.netLiquidation).toBe('3913.1')
+  })
+
+  it('reconstructs NetLiquidation when the broker value is non-finite', async () => {
+    const b = brokerWithCache({
+      TotalCashValue: '1000', NetLiquidation: 'NaN',
+      RealizedPnL: '0', BuyingPower: '0', InitMarginReq: '0', MaintMarginReq: '0',
+    }, [{ ...usdPos, multiplier: '1', quantity: '10', side: 'long' }])
+    const a = await b.getAccount()
+    expect(a.netLiquidation).toBe('3913.1')
+  })
+})
+
+describe('IbkrBroker — option position snapshot marks (issue #314)', () => {
+  function optionPosition() {
+    const contract = Object.assign(new Contract(), {
+      conId: 123456,
+      symbol: 'AAPL',
+      localSymbol: 'AAPL  260918C00250000',
+      secType: 'OPT' as const,
+      exchange: 'SMART',
+      currency: 'USD',
+      multiplier: '100',
+    })
+    return {
+      contract,
+      currency: 'USD',
+      side: 'long' as const,
+      quantity: new Decimal(2),
+      avgCost: '1.5',
+      marketPrice: '1',
+      marketValue: '200',
+      unrealizedPnL: '-100',
+      realizedPnL: '0',
+      multiplier: '100',
+    }
+  }
+
+  it('overlays an option midpoint and recomputes multiplier-aware value and PnL', async () => {
+    const position = optionPosition()
+    const { broker, bridge } = brokerWithContractIo(position.contract)
+    ;(bridge as unknown as { getAccountCache: unknown }).getAccountCache = () => ({
+      values: new Map(),
+      positions: [position],
+    })
+    bridge.requestSnapshot.mockResolvedValue({ bid: 2, ask: 4 })
+
+    const [refreshed] = await broker.getPositions()
+
+    expect(refreshed.marketPrice).toBe('3')
+    expect(refreshed.marketValue).toBe('600')
+    expect(refreshed.unrealizedPnL).toBe('300')
+    expect(bridge.requestSnapshot).toHaveBeenCalledOnce()
+    expect(bridge.requestSnapshot.mock.calls[0][2]).toEqual({ resolveOnBidAsk: true })
+    expect(position.marketPrice).toBe('1') // cache remains broker-owned
+  })
+
+  it('keeps cached option marks when snapshot data is unavailable', async () => {
+    const position = optionPosition()
+    const { broker, bridge } = brokerWithContractIo(position.contract)
+    ;(bridge as unknown as { getAccountCache: unknown }).getAccountCache = () => ({
+      values: new Map(),
+      positions: [position],
+    })
+    bridge.requestSnapshot.mockRejectedValue(new Error('market data subscription unavailable'))
+
+    await expect(broker.getPositions()).resolves.toEqual([position])
+    await expect(broker.getPositions()).resolves.toEqual([position])
+    expect(bridge.requestSnapshot).toHaveBeenCalledOnce() // short negative cache
+  })
+
+  it('coalesces concurrent refreshes for the same option conId', async () => {
+    const position = optionPosition()
+    const { broker, bridge } = brokerWithContractIo(position.contract)
+    ;(bridge as unknown as { getAccountCache: unknown }).getAccountCache = () => ({
+      values: new Map(),
+      positions: [position],
+    })
+
+    const [left, right] = await Promise.all([broker.getPositions(), broker.getPositions()])
+
+    expect(left[0].marketPrice).toBe('0.8')
+    expect(right[0].marketPrice).toBe('0.8')
+    expect(bridge.requestSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it('does not request snapshots for non-option positions', async () => {
+    const position = { ...optionPosition(), contract: recordedContract('aapl-stock'), multiplier: '1' }
+    const { broker, bridge } = brokerWithContractIo(position.contract)
+    ;(bridge as unknown as { getAccountCache: unknown }).getAccountCache = () => ({
+      values: new Map(),
+      positions: [position],
+    })
+
+    await expect(broker.getPositions()).resolves.toEqual([position])
+    expect(bridge.requestSnapshot).not.toHaveBeenCalled()
   })
 })
 
@@ -376,5 +486,50 @@ describe('IbkrBroker — dead-connection gate (issue #294)', () => {
     // still carry the dead-connection cause, not a generic failure.
     expect(r.success).toBe(false)
     expect(r.error).toMatch(/connection lost/i)
+  })
+
+  it('probes the socket immediately before an order write', async () => {
+    const { broker, bridge, client } = brokerWithContractIo(recordedContract('aapl-stock'))
+    const { contract, order } = stkOrder()
+
+    await expect(broker.placeOrder(contract, order)).resolves.toMatchObject({ success: true })
+
+    expect(bridge.requestCurrentTime).toHaveBeenCalledOnce()
+    expect(client.placeOrder).toHaveBeenCalledOnce()
+    expect(bridge.requestCurrentTime.mock.invocationCallOrder[0])
+      .toBeLessThan(client.placeOrder.mock.invocationCallOrder[0])
+  })
+
+  it('marks the connection dead and refuses without touching the order socket when the probe fails', async () => {
+    const { broker, bridge, client } = brokerWithContractIo(recordedContract('aapl-stock'))
+    bridge.requestCurrentTime.mockRejectedValue(new Error('silent half-open'))
+    const { contract, order } = stkOrder()
+
+    const result = await broker.placeOrder(contract, order)
+
+    expect(result).toMatchObject({ success: false })
+    expect(result.error).toMatch(/liveness|connection/i)
+    expect(bridge.markDead).toHaveBeenCalledOnce()
+    expect(client.placeOrder).not.toHaveBeenCalled()
+  })
+
+  it('uses the same write probe for modify and cancel', async () => {
+    const canonical = recordedContract('aapl-stock')
+    const { broker, bridge, client } = brokerWithContractIo(canonical)
+    const originalOrder = limitBuy()
+    originalOrder.orderId = 42
+    ;(broker as unknown as { getOrder: unknown }).getOrder = vi.fn(async () => ({
+      contract: canonical,
+      order: originalOrder,
+      orderState: { status: 'Submitted' },
+    }))
+
+    await expect(broker.modifyOrder('42', { lmtPrice: new Decimal('0.2') }))
+      .resolves.toMatchObject({ success: true })
+    await expect(broker.cancelOrder('42')).resolves.toMatchObject({ success: true })
+
+    expect(bridge.requestCurrentTime).toHaveBeenCalledTimes(2)
+    expect(client.placeOrder).toHaveBeenCalledOnce()
+    expect(client.cancelOrder).toHaveBeenCalledOnce()
   })
 })

--- a/services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.ts
@@ -35,15 +35,27 @@ import {
   type Quote,
   type MarketClock,
   type BrokerConfigField,
+  type BrokerConnectionStateEvent,
   type TpSlParams,
   type ExpandContractFilters,
   type ContractExpansion,
 } from '../types.js'
 import '../../contract-ext.js'
-import { aggregateAccountFromPositions } from '../../position-math.js'
+import { derivePositionMath } from '../../position-math.js'
 import { RequestBridge } from './request-bridge.js'
 import { resolveSymbol } from './ibkr-contracts.js'
 import type { IbkrBrokerConfig } from './ibkr-types.js'
+
+const WRITE_LIVENESS_TIMEOUT_MS = 3_000
+const OPTION_MARK_SUCCESS_TTL_MS = 15_000
+const OPTION_MARK_FAILURE_TTL_MS = 60_000
+const OPTION_MARK_CONCURRENCY = 8
+
+interface OptionMarkOverlay {
+  marketPrice: string
+  marketValue: string
+  unrealizedPnL: string
+}
 
 /** IBKR models are mutable because the wire decoder fills them field by field.
  * Broker routing must not let a caller mutate a cached canonical contract (or
@@ -102,6 +114,13 @@ export class IbkrBroker implements IBroker {
   /** A promise cache deduplicates simultaneous quote/order resolution for the
    * same conId. Cached contracts are canonical TWS values; callers get clones. */
   private readonly conIdContracts = new Map<number, Promise<Contract>>()
+  /** Briefly cache successful marks and failed-entitlement attempts so a UI
+   * poll cannot create an unbounded snapshot-request loop. */
+  private readonly optionMarkCache = new Map<number, {
+    expiresAt: number
+    overlay: OptionMarkOverlay | null
+  }>()
+  private readonly optionMarkRequests = new Map<number, Promise<OptionMarkOverlay | null>>()
 
   constructor(config: IbkrBrokerConfig) {
     this.config = config
@@ -126,13 +145,34 @@ export class IbkrBroker implements IBroker {
     }
   }
 
+  /** Confirm liveness on the same ordered socket immediately before a broker
+   * write. The 45s heartbeat is sufficient for stale-read containment but
+   * leaves a blind window that is unacceptable for place/modify/cancel. */
+  private async _ensureWriteAlive(): Promise<void> {
+    this._ensureAlive()
+    try {
+      await this.bridge.requestCurrentTime(WRITE_LIVENESS_TIMEOUT_MS)
+      this._ensureAlive()
+    } catch (err) {
+      this.bridge.markDead('Write-path liveness probe failed')
+      throw new BrokerError(
+        'NETWORK',
+        `TWS/Gateway write-path liveness check failed; order was not transmitted: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  }
+
+  setConnectionStateListener(listener: ((event: BrokerConnectionStateEvent) => void) | null): void {
+    this.bridge.setConnectionStateListener(listener)
+  }
+
   private startHeartbeat(): void {
     if (this.heartbeatTimer_) clearInterval(this.heartbeatTimer_)
     this.heartbeatTimer_ = setInterval(() => {
       if (this.bridge.connectionDead) return
       this.bridge.requestCurrentTime(5000).catch(() => {
         console.warn(`IbkrBroker[${this.id}]: heartbeat failed — marking connection dead`)
-        this.bridge.markDead()
+        this.bridge.markDead('TWS/Gateway heartbeat timed out')
       })
     }, 45_000)
     // Don't hold the process open for the probe
@@ -451,6 +491,7 @@ export class IbkrBroker implements IBroker {
     try {
       this._ensureAlive()
       const routedContract = await this.resolveRoutableContract(contract)
+      await this._ensureWriteAlive()
       const orderId = this.bridge.getNextOrderId()
       const promise = this.bridge.requestOrder(orderId)
       this.client.placeOrder(orderId, routedContract, order)
@@ -485,6 +526,7 @@ export class IbkrBroker implements IBroker {
       if (changes.trailStopPrice != null) mergedOrder.trailStopPrice = changes.trailStopPrice
 
       const routedContract = await this.resolveRoutableContract(original.contract)
+      await this._ensureWriteAlive()
       const numericId = parseInt(orderId, 10)
       const promise = this.bridge.requestOrder(numericId)
       this.client.placeOrder(numericId, routedContract, mergedOrder)
@@ -502,7 +544,7 @@ export class IbkrBroker implements IBroker {
 
   async cancelOrder(orderId: string, orderCancel?: OrderCancel): Promise<PlaceOrderResult> {
     try {
-      this._ensureAlive()
+      await this._ensureWriteAlive()
       const numericId = parseInt(orderId, 10)
       const promise = this.bridge.requestOrder(numericId)
       this.client.cancelOrder(numericId, orderCancel ?? new OrderCancel())
@@ -549,14 +591,9 @@ export class IbkrBroker implements IBroker {
    *
    * Data source: reqAccountUpdates → accountDownloadEnd callback.
    *
-   * netLiquidation is reconstructed from cash + Σ(position.marketValue)
-   * because TWS's account-level NetLiquidation tag is cached server-side
-   * and refreshes less frequently than position-level data.
-   *
-   * Note: position marketPrice comes from updatePortfolio() callbacks,
-   * which TWS stops pushing after ~20:00 ET (see README.md "TWS Market
-   * Data Channels"). During overnight hours, the reconstructed netLiq
-   * will be stale even though Blue Ocean ATS prices may be moving.
+   * NetLiquidation is the broker's account-level value whenever present.
+   * Position-derived reconstruction is fallback-only, so adding a foreign-
+   * currency holding cannot silently change the meaning of the field.
    */
   /** TWS-provided FX rate (currency → base) from the ExchangeRate account
    *  tags. Returns null when TWS didn't send one for this currency. */
@@ -574,14 +611,6 @@ export class IbkrBroker implements IBroker {
     const baseCurrency = download.values.get('BaseCurrency') ?? 'USD'
     const totalCashValue = new Decimal(download.values.get('TotalCashValue') ?? '0')
 
-    // Position-derived account math is only currency-safe when every line is
-    // in the base currency. Mixed books (HKD stock + USD stock) used to
-    // blind-sum different units (ANG-101: HKD -4767 + USD +369 reported as
-    // USD -4398). TWS hands us per-currency ExchangeRate tags — convert per
-    // position; if a rate is missing, fall back to TWS's own consolidated
-    // NetLiquidation tag (already FX-correct) rather than summing garbage.
-    const mixed = download.positions.some((pos) => (pos.currency || baseCurrency) !== baseCurrency)
-
     let positionUnrealizedPnL: Decimal | null = new Decimal(0)
     let positionMarketValue: Decimal | null = new Decimal(0)
     for (const pos of download.positions) {
@@ -595,17 +624,21 @@ export class IbkrBroker implements IBroker {
       positionMarketValue = positionMarketValue!.plus(sided.mul(rate))
     }
 
-    const brokerNetLiq = new Decimal(download.values.get('NetLiquidation') ?? '0')
-    // Freshness-vs-authority: same-currency books keep the reconstructed
-    // value (position marks refresh faster than the server-cached tag, see
-    // docstring above). Mixed books prefer the broker tag (issue #314) —
-    // reconstruction is rate-converted and only used when the tag is absent.
+    const brokerNetLiqRaw = download.values.get('NetLiquidation')
+    let brokerNetLiq: Decimal | null = null
+    if (brokerNetLiqRaw != null) {
+      try {
+        const parsed = new Decimal(brokerNetLiqRaw)
+        if (parsed.isFinite()) brokerNetLiq = parsed
+      } catch { /* fall back below */ }
+    }
+    // NetLiquidation is an account-level broker fact. Do not make the same
+    // field switch semantics based on whether the user happens to hold a
+    // foreign-currency position. Local reconstruction is fallback-only.
     const reconstructedNetLiq = positionMarketValue !== null
       ? totalCashValue.plus(positionMarketValue)
       : null
-    const netLiquidation = download.positions.length === 0 ? brokerNetLiq
-      : mixed ? (brokerNetLiq.isZero() ? (reconstructedNetLiq ?? brokerNetLiq) : brokerNetLiq)
-      : aggregateAccountFromPositions(totalCashValue, download.positions).netLiquidation
+    const netLiquidation = brokerNetLiq ?? reconstructedNetLiq ?? new Decimal(0)
 
     const unrealizedPnL = download.positions.length > 0 && positionUnrealizedPnL !== null
       ? positionUnrealizedPnL
@@ -645,7 +678,82 @@ export class IbkrBroker implements IBroker {
     this._ensureAlive()
     const download = this.bridge.getAccountCache()
     if (!download) throw new BrokerError('NETWORK', 'Account data not yet available')
-    return download.positions
+    const output = [...download.positions]
+    const optionIndexes = output
+      .map((position, index) => ({ position, index }))
+      .filter(({ position }) => position.contract.secType === 'OPT' || position.contract.secType === 'FOP')
+    if (optionIndexes.length === 0) return output
+
+    let cursor = 0
+    const worker = async (): Promise<void> => {
+      while (cursor < optionIndexes.length) {
+        const item = optionIndexes[cursor++]
+        output[item.index] = await this.refreshOptionPosition(item.position)
+      }
+    }
+    await Promise.all(Array.from(
+      { length: Math.min(OPTION_MARK_CONCURRENCY, optionIndexes.length) },
+      () => worker(),
+    ))
+    return output
+  }
+
+  private async refreshOptionPosition(position: Position): Promise<Position> {
+    const conId = position.contract.conId
+    if (!conId) return position
+
+    const now = Date.now()
+    const cached = this.optionMarkCache.get(conId)
+    if (cached && cached.expiresAt > now) {
+      return cached.overlay ? { ...position, ...cached.overlay } : position
+    }
+
+    let pending = this.optionMarkRequests.get(conId)
+    if (!pending) {
+      pending = this.fetchOptionMark(position)
+      this.optionMarkRequests.set(conId, pending)
+    }
+    try {
+      const overlay = await pending
+      return overlay ? { ...position, ...overlay } : position
+    } finally {
+      if (this.optionMarkRequests.get(conId) === pending) this.optionMarkRequests.delete(conId)
+    }
+  }
+
+  private async fetchOptionMark(position: Position): Promise<OptionMarkOverlay | null> {
+    const conId = position.contract.conId
+    try {
+      const { snap } = await this.requestSnapshot(position.contract, { resolveOnBidAsk: true })
+      const bid = new Decimal(snap.bid ?? 0)
+      const ask = new Decimal(snap.ask ?? 0)
+      if (!bid.isFinite() || !ask.isFinite() || bid.lte(0) || ask.lte(0)) {
+        throw new BrokerError('EXCHANGE', 'IBKR option snapshot did not include a positive bid and ask')
+      }
+      const marketPrice = bid.plus(ask).div(2).toString()
+      const derived = derivePositionMath({
+        quantity: position.quantity,
+        marketPrice,
+        avgCost: position.avgCost,
+        multiplier: position.multiplier,
+        side: position.side,
+      })
+      const overlay: OptionMarkOverlay = { marketPrice, ...derived }
+      this.optionMarkCache.set(conId, {
+        expiresAt: Date.now() + OPTION_MARK_SUCCESS_TTL_MS,
+        overlay,
+      })
+      return overlay
+    } catch {
+      // Missing market-data entitlement and closed-market snapshots are normal
+      // fallbacks. Preserve the broker's updatePortfolio values and suppress
+      // repeated requests briefly instead of turning a read into an outage.
+      this.optionMarkCache.set(conId, {
+        expiresAt: Date.now() + OPTION_MARK_FAILURE_TTL_MS,
+        overlay: null,
+      })
+      return null
+    }
   }
 
   async getOrders(orderIds: string[]): Promise<OpenOrder[]> {
@@ -702,12 +810,7 @@ export class IbkrBroker implements IBroker {
    */
   async getQuote(contract: Contract): Promise<Quote> {
     this._ensureAlive()
-    const routedContract = await this.resolveRoutableContract(contract)
-
-    const reqId = this.bridge.allocReqId()
-    const promise = this.bridge.requestSnapshot(reqId)
-    this.client.reqMktData(reqId, routedContract, '', true, false, [])
-    const snap = await promise
+    const { routedContract, snap } = await this.requestSnapshot(contract)
 
     return {
       contract: routedContract,
@@ -719,6 +822,20 @@ export class IbkrBroker implements IBroker {
       low: snap.low != null ? String(snap.low) : undefined,
       timestamp: snap.lastTimestamp ? new Date(snap.lastTimestamp * 1000) : new Date(),
     }
+  }
+
+  private async requestSnapshot(
+    contract: Contract,
+    options: { resolveOnBidAsk?: boolean } = {},
+  ): Promise<{ routedContract: Contract; snap: import('./ibkr-types.js').TickSnapshot }> {
+    const routedContract = await this.resolveRoutableContract(contract)
+    const reqId = this.bridge.allocReqId()
+    const promise = this.bridge.requestSnapshot(reqId, undefined, options)
+    // `regulatorySnapshot=false`: never opt the account into per-request paid
+    // US regulatory snapshots. Live entitlement or free delayed data may still
+    // satisfy the ordinary snapshot; otherwise callers retain cached marks.
+    this.client.reqMktData(reqId, routedContract, '', true, false, [])
+    return { routedContract, snap: await promise }
   }
 
   async getMarketClock(): Promise<MarketClock> {

--- a/services/uta/src/domain/trading/brokers/ibkr/README.md
+++ b/services/uta/src/domain/trading/brokers/ibkr/README.md
@@ -25,7 +25,7 @@ Understanding which channel we use (and don't use) is critical for debugging pri
 - **Callback**: `updatePortfolio(contract, position, marketPrice, marketValue, avgCost, unrealizedPnL, realizedPnL, accountName)`
 - **Behavior**: TWS internally decides when to push updates. During regular trading hours, updates come every few seconds. During after-hours and overnight, updates slow down or stop entirely.
 - **Coverage**: Only positions in the account. No quote data for contracts you don't hold.
-- **Current usage**: `getPositions()` and `getAccount()` both rely on this channel via `downloadAccount()`.
+- **Current usage**: This is the durable position cache. `getPositions()` overlays short-lived snapshot midpoints for `OPT`/`FOP` rows when bid+ask are available; all other rows and failed snapshots retain these broker values. `getAccount()` uses the account-level `NetLiquidation` tag whenever IBKR supplied it.
 
 ### `reqMktData` — snapshot mode (what `getQuote()` uses)
 
@@ -34,6 +34,8 @@ Understanding which channel we use (and don't use) is critical for debugging pri
 - **Behavior**: One-time batch of current market data. Auto-cancels after `tickSnapshotEnd`.
 - **Coverage**: Any contract, including ones you don't hold. Includes overnight session data from Blue Ocean ATS.
 - **Limitation**: Counts against TWS market data line limit (~100 concurrent). Snapshot mode is short-lived so typically not a problem.
+- **Entitlement boundary**: OpenAlice always sends `regulatorySnapshot=false`; it never opts the account into per-request paid US regulatory snapshots. Ordinary live snapshots still need the corresponding market-data entitlement. Free delayed data may be returned after `reqMarketDataType(3)`; otherwise the option overlay falls back to `updatePortfolio()` without failing the account read.
+- **Timing**: IBKR documents `tickSnapshotEnd()` at about 11 seconds. Ordinary quotes wait for that end marker with a 12.5 second timeout. Option mark refreshes may resolve earlier once both positive bid and ask ticks arrive.
 
 ### `reqMktData` — streaming mode (not currently used)
 
@@ -81,13 +83,18 @@ The `@traderalice/ibkr` Connection class is a Node port of Python's `Connection`
 
 The `close` event handler checks `if (this.socket === null) return` to avoid double-calling `connectionClosed()` when `disconnect()` already handled cleanup.
 
-Upper layers (UTA health system) detect the disconnect via `connectionClosed()` → health degrades → auto-recovery attempts reconnection.
+Known-dead transport state reaches UTA through an explicit connection-state listener:
+
+1. `connectionClosed()`, connectivity error 1100, or a failed 45-second heartbeat marks the bridge dead.
+2. UTA moves directly to `offline` and starts recovery instead of waiting for passive cached-read failures.
+3. Error 1101/1102 nudges recovery immediately but does not mark the account alive; reconnect plus a private account read must still pass.
+4. Place/modify/cancel performs a coalesced `reqCurrentTime` round-trip on the same socket immediately before transmission. A timeout marks the bridge dead and no order bytes are sent.
 
 ## Known Limitations
 
-1. **`getPositions()` price staleness**: Prices come from `updatePortfolio()` which TWS controls. During overnight hours, prices freeze even though the market has activity on Blue Ocean ATS. Future improvement: call `getQuote()` per position to refresh prices.
+1. **Non-option position price staleness**: Stocks, futures, FX, warrants, and bonds still use `updatePortfolio()` marks. Only `OPT`/`FOP` rows receive the bounded snapshot-midpoint overlay.
 
-2. **`getAccount()` netLiq reconstruction**: TWS's account-level `NetLiquidation` tag is cached server-side. We reconstruct it from `cash + Σ(position.marketValue)` for accuracy. But since position prices can be stale (see #1), the reconstructed netLiq inherits that staleness.
+2. **Option market-data entitlement**: Without a live or delayed quote permission, option positions deliberately keep the cached `updatePortfolio()` mark. A short negative cache prevents polling loops from repeatedly issuing a request that the account cannot satisfy.
 
 3. **Single account**: Current implementation assumes one account per TWS connection. Multi-account setups (Financial Advisor accounts) would need `reqAccountUpdatesMulti` instead.
 

--- a/services/uta/src/domain/trading/brokers/ibkr/request-bridge.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/request-bridge.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import Decimal from 'decimal.js'
-import { Contract } from '@traderalice/ibkr'
+import { Contract, NO_VALID_ID, TickTypeEnum } from '@traderalice/ibkr'
 import { RequestBridge } from './request-bridge.js'
 
 function stk(conId: number, symbol: string): Contract {
@@ -31,6 +31,84 @@ describe('RequestBridge — error routing', () => {
     const b = new RequestBridge()
     // no pending request — must simply not throw
     expect(() => b.error(-1, 0, 2104, 'Market data farm connection is OK')).not.toThrow()
+  })
+
+  it('marks 1100 dead immediately and treats 1102 as a recovery nudge, not proof of life', () => {
+    const b = new RequestBridge()
+    const events: Array<{ state: string; error?: string }> = []
+    b.setConnectionStateListener((event) => events.push(event))
+
+    b.error(NO_VALID_ID, 0, 1100, 'Connectivity between IBKR and TWS has been lost')
+    expect(b.connectionDead).toBe(true)
+    expect(events.at(-1)).toMatchObject({ state: 'dead' })
+
+    b.error(NO_VALID_ID, 0, 1102, 'Connectivity restored - data maintained')
+    expect(b.connectionDead).toBe(true)
+    expect(events.at(-1)).toEqual({ state: 'restored' })
+
+    b.markAlive()
+    expect(b.connectionDead).toBe(false)
+    expect(events.at(-1)).toEqual({ state: 'alive' })
+  })
+})
+
+describe('RequestBridge — socket probes and snapshots', () => {
+  it('coalesces concurrent current-time probes onto one wire request', async () => {
+    const b = new RequestBridge()
+    const reqCurrentTime = vi.fn()
+    b.setClient({ reqCurrentTime } as never)
+
+    const first = b.requestCurrentTime()
+    const second = b.requestCurrentTime()
+    expect(reqCurrentTime).toHaveBeenCalledOnce()
+
+    b.currentTime(1_784_289_600)
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      1_784_289_600,
+      1_784_289_600,
+    ])
+  })
+
+  it('clears a failed current-time probe so the next write can retry', async () => {
+    const b = new RequestBridge()
+    const reqCurrentTime = vi.fn()
+      .mockImplementationOnce(() => { throw new Error('socket write failed') })
+      .mockImplementationOnce(() => {})
+    b.setClient({ reqCurrentTime } as never)
+
+    await expect(b.requestCurrentTime()).rejects.toThrow(/socket write failed/)
+    const retry = b.requestCurrentTime()
+    b.currentTime(1_784_289_601)
+
+    await expect(retry).resolves.toBe(1_784_289_601)
+    expect(reqCurrentTime).toHaveBeenCalledTimes(2)
+  })
+
+  it('can resolve option-mark snapshots as soon as both bid and ask arrive', async () => {
+    const b = new RequestBridge()
+    const snapshot = b.requestSnapshot(71, 5_000, { resolveOnBidAsk: true })
+
+    b.tickPrice(71, TickTypeEnum.BID, 2, {} as never)
+    b.tickPrice(71, TickTypeEnum.ASK, 4, {} as never)
+
+    await expect(snapshot).resolves.toMatchObject({ bid: 2, ask: 4 })
+  })
+
+  it('keeps ordinary quote snapshots open until tickSnapshotEnd', async () => {
+    const b = new RequestBridge()
+    let settled = false
+    const snapshot = b.requestSnapshot(72, 5_000).then((value) => {
+      settled = true
+      return value
+    })
+
+    b.tickPrice(72, TickTypeEnum.BID, 2, {} as never)
+    b.tickPrice(72, TickTypeEnum.ASK, 4, {} as never)
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    b.tickSnapshotEnd(72)
+    await expect(snapshot).resolves.toMatchObject({ bid: 2, ask: 4 })
   })
 })
 

--- a/services/uta/src/domain/trading/brokers/ibkr/request-bridge.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/request-bridge.ts
@@ -26,7 +26,7 @@ import {
   type EClient,
   type TickAttrib,
 } from '@traderalice/ibkr'
-import { BrokerError } from '../types.js'
+import { BrokerError, type BrokerConnectionStateEvent } from '../types.js'
 import { classifyIbkrError } from './ibkr-contracts.js'
 import { buildPosition } from '../contract-builder.js'
 import type {
@@ -37,6 +37,7 @@ import type {
 } from './ibkr-types.js'
 
 const DEFAULT_TIMEOUT_MS = 10_000
+const SNAPSHOT_TIMEOUT_MS = 12_500
 const ACCOUNT_READY_TIMEOUT_MS = 20_000
 
 export class RequestBridge extends DefaultEWrapper {
@@ -52,6 +53,7 @@ export class RequestBridge extends DefaultEWrapper {
 
   // ---- Mode A: tick snapshot accumulators ----
   private snapshots = new Map<number, TickSnapshot>()
+  private snapshotResolveOnBidAsk = new Set<number>()
 
   // ---- Mode B: orderId-based pending requests ----
   private orderPending = new Map<number, PendingRequest<CollectedOpenOrder>>()
@@ -92,12 +94,19 @@ export class RequestBridge extends DefaultEWrapper {
 
   // ---- Current time request ----
   private currentTimePending: PendingRequest<number> | null = null
+  private currentTimePromise: Promise<number> | null = null
+
+  private connectionStateListener: ((event: BrokerConnectionStateEvent) => void) | null = null
 
   // ==================== Public API ====================
 
   /** Store reference to the EClient for unsubscribe calls. */
   setClient(client: EClient): void {
     this.client_ = client
+  }
+
+  setConnectionStateListener(listener: ((event: BrokerConnectionStateEvent) => void) | null): void {
+    this.connectionStateListener = listener
   }
 
   /** Allocate a unique reqId (starts at 10000 to avoid orderId range). */
@@ -148,6 +157,9 @@ export class RequestBridge extends DefaultEWrapper {
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(reqId)
+        this.collectors.delete(reqId)
+        this.snapshots.delete(reqId)
+        this.snapshotResolveOnBidAsk.delete(reqId)
         reject(new BrokerError('NETWORK', `Request ${reqId} timed out after ${timeoutMs}ms`))
       }, timeoutMs)
       this.pending.set(reqId, { resolve: resolve as (v: unknown) => void, reject, timer })
@@ -161,8 +173,13 @@ export class RequestBridge extends DefaultEWrapper {
   }
 
   /** Register a snapshot market data request. */
-  requestSnapshot(reqId: number, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<TickSnapshot> {
+  requestSnapshot(
+    reqId: number,
+    timeoutMs = SNAPSHOT_TIMEOUT_MS,
+    options: { resolveOnBidAsk?: boolean } = {},
+  ): Promise<TickSnapshot> {
     this.snapshots.set(reqId, {})
+    if (options.resolveOnBidAsk) this.snapshotResolveOnBidAsk.add(reqId)
     return this.request<TickSnapshot>(reqId, timeoutMs)
   }
 
@@ -214,15 +231,34 @@ export class RequestBridge extends DefaultEWrapper {
 
   /** Request current TWS server time. */
   requestCurrentTime(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<number> {
-    return new Promise<number>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.currentTimePending = null
-        reject(new BrokerError('NETWORK', `currentTime request timed out`))
-      }, timeoutMs)
+    if (this.currentTimePromise) return this.currentTimePromise
 
-      this.currentTimePending = { resolve: resolve as (v: unknown) => void, reject, timer }
-      this.client_!.reqCurrentTime()
+    let resolvePromise!: (value: number) => void
+    let rejectPromise!: (error: Error) => void
+    const promise = new Promise<number>((resolve, reject) => {
+      resolvePromise = resolve
+      rejectPromise = reject
     })
+    this.currentTimePromise = promise
+    const clear = (): void => {
+      if (this.currentTimePromise === promise) this.currentTimePromise = null
+      this.currentTimePending = null
+    }
+    const timer = setTimeout(() => {
+      clear()
+      rejectPromise(new BrokerError('NETWORK', `currentTime request timed out`))
+    }, timeoutMs)
+    this.currentTimePending = {
+      resolve: (value) => { clearTimeout(timer); clear(); resolvePromise(value as number) },
+      reject: (error) => { clearTimeout(timer); clear(); rejectPromise(error) },
+      timer,
+    }
+    try {
+      this.client_!.reqCurrentTime()
+    } catch (err) {
+      this.currentTimePending?.reject(BrokerError.from(err, 'NETWORK'))
+    }
+    return promise
   }
 
   // ---- Mode D: persistent account subscription ----
@@ -274,6 +310,7 @@ export class RequestBridge extends DefaultEWrapper {
     this.pending.delete(reqId)
     this.collectors.delete(reqId)
     this.snapshots.delete(reqId)
+    this.snapshotResolveOnBidAsk.delete(reqId)
     entry.resolve(value)
   }
 
@@ -284,6 +321,7 @@ export class RequestBridge extends DefaultEWrapper {
     this.pending.delete(reqId)
     this.collectors.delete(reqId)
     this.snapshots.delete(reqId)
+    this.snapshotResolveOnBidAsk.delete(reqId)
     entry.reject(error)
   }
 
@@ -319,6 +357,7 @@ export class RequestBridge extends DefaultEWrapper {
     this.pending.clear()
     this.collectors.clear()
     this.snapshots.clear()
+    this.snapshotResolveOnBidAsk.clear()
 
     for (const [, entry] of this.orderPending) {
       clearTimeout(entry.timer)
@@ -381,11 +420,19 @@ export class RequestBridge extends DefaultEWrapper {
    *  (issue #294). */
   private connectionDead_ = false
   get connectionDead(): boolean { return this.connectionDead_ }
-  markDead(): void { this.connectionDead_ = true }
-  markAlive(): void { this.connectionDead_ = false }
+  markDead(error = 'Connection to TWS/Gateway lost'): void {
+    if (this.connectionDead_) return
+    this.connectionDead_ = true
+    this.connectionStateListener?.({ state: 'dead', error })
+  }
+  markAlive(): void {
+    const wasDead = this.connectionDead_
+    this.connectionDead_ = false
+    if (wasDead) this.connectionStateListener?.({ state: 'alive' })
+  }
 
   override connectionClosed(): void {
-    this.connectionDead_ = true
+    this.markDead()
     this.rejectAll(new BrokerError('NETWORK', 'Connection to TWS/Gateway lost'))
 
     if (this.connectReject) {
@@ -408,7 +455,11 @@ export class RequestBridge extends DefaultEWrapper {
     // System-level errors (reqId === -1) — connectivity events
     if (reqId === NO_VALID_ID) {
       if (errorCode === 502 || errorCode === 504 || errorCode === 1100) {
-        // These will be followed by connectionClosed() which rejects all
+        this.markDead(`TWS/Gateway reported connectivity lost (${errorCode})`)
+      } else if (errorCode === 1101 || errorCode === 1102) {
+        // A restored farm/socket is a reason to retry immediately, not proof
+        // that account subscriptions and private reads are healthy again.
+        this.connectionStateListener?.({ state: 'restored' })
       }
       return
     }
@@ -606,6 +657,14 @@ export class RequestBridge extends DefaultEWrapper {
       case TickTypeEnum.LOW:
       case TickTypeEnum.DELAYED_LOW: snap.low = price; break
     }
+
+    if (
+      this.snapshotResolveOnBidAsk.has(reqId)
+      && snap.bid != null && snap.bid > 0
+      && snap.ask != null && snap.ask > 0
+    ) {
+      this.resolveRequest(reqId, { ...snap })
+    }
   }
 
   override tickSize(reqId: number, tickType: number, size: Decimal): void {
@@ -701,8 +760,6 @@ export class RequestBridge extends DefaultEWrapper {
 
   override currentTime(time: number): void {
     if (!this.currentTimePending) return
-    clearTimeout(this.currentTimePending.timer)
     this.currentTimePending.resolve(time)
-    this.currentTimePending = null
   }
 }


### PR DESCRIPTION
## Summary

Addresses the remaining verified gaps in #294 and #314.

- require a coalesced `reqCurrentTime` round-trip immediately before IBKR place/modify/cancel sends; a failed probe marks the transport dead and no order bytes are sent
- propagate authoritative broker `dead` state into UTA health immediately, use 1101/1102 only as recovery nudges, and require the normal reconnect + private-read ladder before health becomes green again
- make broker `NetLiquidation` authoritative for both same- and mixed-currency books, with finite-value validation and position reconstruction only as a last resort
- overlay bounded OPT/FOP snapshot midpoints onto returned position rows, recompute multiplier-aware value/PnL, keep the broker cache immutable, and fall back safely on missing entitlement
- extend snapshot timeout past IBKR's documented ~11 second `tickSnapshotEnd`, while allowing option marks to resolve early on positive bid+ask
- document the read-only half-open and option-mark acceptance loops

## Verification

- `npx tsc --noEmit`
- `pnpm -F @traderalice/uta-protocol typecheck`
- targeted UTA/IBKR specs: 151 passed
- `pnpm test`: 314 files / 3161 tests passed (plus existing skips)
- `pnpm test:e2e`: IBKR-unrelated BLS case failed because this machine's TLS connection to `api.bls.gov` was reset; the failing case was rerun alone and reproduced the same external-network error
- real IB Gateway 10.37.1r, serverVersion 203, paper + API read-only:
  - `docker pause` half-open: healthy/readable -> offline/down in 46s; account read refused with 503
  - unpause: healthy/readable and account/position reads recovered in 2s
  - no order endpoint called
  - UTA NetLiquidation matched a live `reqAccountSummary(NetLiquidation)` read
  - a real option contract resolved; without option market-data permission the mark path retained the cached row and did not mutate the source cache

## Boundary notes

- Option snapshots always use `regulatorySnapshot=false`; this change never opts an account into paid per-request regulatory snapshots.
- The local paper account has no option position or positive market-data entitlement, so successful live bid/ask overlay still needs external confirmation. The fallback path was verified live and the positive path is covered by deterministic specs.
- No trading write was submitted during live acceptance.

Refs #294
Refs #314