### PR TITLE
fix(docker): copy pnpm patches before install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN corepack enable && corepack prepare pnpm@11.7.0 --activate
 # because the root postinstall hook (`fix-pty-perms.mjs`) runs at the end
 # of `pnpm install` and must already exist on disk.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY patches/ patches/
 COPY scripts/fix-pty-perms.mjs ./scripts/fix-pty-perms.mjs
 COPY packages/cli/package.json packages/cli/
 COPY packages/guardian-runtime/package.json packages/guardian-runtime/

--- a/scripts/docker-runtime-smoke-lib.spec.ts
+++ b/scripts/docker-runtime-smoke-lib.spec.ts
@@ -83,6 +83,14 @@ describe('Dockerfile runtime contract', () => {
     expect(dockerfile).toContain(`corepack prepare pnpm@${pnpmVersion} --activate`)
   })
 
+  it('copies pnpm patch files before the frozen dependency install', () => {
+    const patchCopy = dockerfile.indexOf('COPY patches/ patches/')
+    const install = dockerfile.indexOf('RUN pnpm install --frozen-lockfile')
+
+    expect(patchCopy).toBeGreaterThan(-1)
+    expect(install).toBeGreaterThan(patchCopy)
+  })
+
   it('installs the complete sibling-based Workspace CLI set for login shells', () => {
     expect(dockerfile).toContain('COPY --from=build /src/src/workspaces/cli/bin')
     expect(dockerfile).toContain('/usr/local/bin/openalice-cli.cjs')


### PR DESCRIPTION
## What changed

- copy the repository patch directory into Docker’s manifest-only dependency layer
- add a Dockerfile contract test that keeps the copy ahead of the frozen install

## Root cause

The xterm WebGL patch is registered in `pnpm-lock.yaml`, so `pnpm install --frozen-lockfile` resolves it before the later full-source `COPY . .`. The Docker dependency layer did not contain `patches/@xterm__addon-webgl@0.20.0-beta.286.patch`, causing Docker Smoke to fail with ENOENT.

## Impact

Docker builds can install patched dependencies while retaining the cache-friendly manifest layer.

## Verification

- `npx tsc --noEmit`
- `pnpm test` (3,163 passed; 8 skipped)
- `pnpm docker:smoke` (image build, runtime health, Workspace PTY/CLI round-trip, offboarding)