### PR TITLE
refactor(ui): adopt Orca-aligned semantic colors

### DIFF
--- a/packages/uta-protocol/src/brokers/preset-catalog.ts
+++ b/packages/uta-protocol/src/brokers/preset-catalog.ts
@@ -128,7 +128,7 @@ export const BINANCE_PRESET: BrokerPresetDef = {
   hint: '**Demo Trading** is Binance\'s risk-free simulator — virtual funds, spot + futures in one place. It runs on isolated demo servers, so prices and fills are simulated and can differ from live. Generate a dedicated Demo API key at demo.binance.com → API Management; your live keys are rejected here (and demo keys are rejected on live).\n\n**Live** places real orders on real money — grant trade-only permissions and never enable withdrawals.',
   defaultName: 'binance-main',
   badge: 'BN',
-  badgeColor: 'text-yellow-400',
+  badgeColor: 'text-warning',
   engine: 'ccxt',
   guardCategory: 'crypto',
   modes: [
@@ -161,7 +161,7 @@ export const OKX_PRESET: BrokerPresetDef = {
   hint: 'Demo Trading uses the same domain as live but routes orders to a simulated matching engine. **You must generate a separate set of API keys from OKX\'s demo trading mode** — your live API keys will be rejected in demo. Live keys give the bot real money access; double-check trade-only permissions and never enable withdrawals.',
   defaultName: 'okx-main',
   badge: 'OKX',
-  badgeColor: 'text-accent',
+  badgeColor: 'text-primary',
   engine: 'ccxt',
   guardCategory: 'crypto',
   modes: [
@@ -196,7 +196,7 @@ export const BYBIT_PRESET: BrokerPresetDef = {
   hint: 'Bybit ships **two** non-live environments: Testnet (separate domain api-testnet.bybit.com, fake market data, fake matching) and Demo Trading (production domain, **real** market data, simulated matching). Each requires its own API keys generated in the matching environment.',
   defaultName: 'bybit-main',
   badge: 'BY',
-  badgeColor: 'text-accent',
+  badgeColor: 'text-primary',
   engine: 'ccxt',
   guardCategory: 'crypto',
   modes: [
@@ -231,7 +231,7 @@ export const HYPERLIQUID_PRESET: BrokerPresetDef = {
   hint: 'Hyperliquid authenticates via wallet signatures. Generate a **dedicated API wallet** at app.hyperliquid.xyz/API and use its private key here — never paste your main wallet\'s key. The wallet address can be either the main wallet (vault owner) or the API wallet itself.',
   defaultName: 'hyperliquid-main',
   badge: 'HL',
-  badgeColor: 'text-accent',
+  badgeColor: 'text-primary',
   engine: 'ccxt',
   guardCategory: 'crypto',
   modes: [
@@ -264,7 +264,7 @@ export const BITGET_PRESET: BrokerPresetDef = {
   hint: 'Bitget requires API key + secret + passphrase (set when creating the key). Demo Trading routes orders to a simulated environment using the production domain.',
   defaultName: 'bitget-main',
   badge: 'BG',
-  badgeColor: 'text-accent',
+  badgeColor: 'text-primary',
   engine: 'ccxt',
   guardCategory: 'crypto',
   modes: [
@@ -299,7 +299,7 @@ export const CCXT_CUSTOM_PRESET: BrokerPresetDef = {
   hint: 'This preset exposes every CCXT credential field. Use it only for exchanges without a dedicated preset. Read the exchange\'s CCXT page (docs.ccxt.com) to know which fields it actually requires — sandbox/demoTrading semantics vary per exchange.',
   defaultName: 'ccxt-custom',
   badge: 'CC',
-  badgeColor: 'text-text-muted',
+  badgeColor: 'text-muted-foreground',
   engine: 'ccxt',
   guardCategory: 'crypto',
   zodSchema: z.object({
@@ -342,7 +342,7 @@ export const ALPACA_PRESET: BrokerPresetDef = {
   hint: 'Paper and Live use **separate** API keys — generate from the matching dashboard at alpaca.markets. Paper is free and unlimited; Live places real orders on real money.',
   defaultName: 'alpaca-paper',
   badge: 'AL',
-  badgeColor: 'text-green',
+  badgeColor: 'text-success',
   engine: 'alpaca',
   guardCategory: 'securities',
   modes: [
@@ -374,7 +374,7 @@ export const IBKR_PRESET: BrokerPresetDef = {
   hint: 'IBKR auth happens via your TWS/Gateway login — no API keys here. Make sure TWS is running and "Enable ActiveX and Socket Clients" is on (File → Global Configuration → API → Settings). Default ports: 7496 (live) / 7497 (paper). For IB Gateway: 4001 (live) / 4002 (paper).',
   defaultName: 'ibkr',
   badge: 'IB',
-  badgeColor: 'text-orange-400',
+  badgeColor: 'text-warning',
   engine: 'ibkr',
   guardCategory: 'securities',
   zodSchema: z.object({
@@ -405,7 +405,7 @@ export const LONGBRIDGE_PRESET: BrokerPresetDef = {
   hint: 'Longbridge uses **appKey + appSecret + accessToken** from open.longbridge.com. The access token is long-lived (~90 days) but **does not auto-refresh** — when it expires you must regenerate it in the LB dashboard and update this config. Paper and live use separate credentials; generate from the matching environment.',
   defaultName: 'longbridge-main',
   badge: 'LB',
-  badgeColor: 'text-accent',
+  badgeColor: 'text-primary',
   engine: 'longbridge',
   guardCategory: 'securities',
   modes: [
@@ -447,7 +447,7 @@ export const LEVERUP_PRESET: BrokerPresetDef = {
 Paste the **private key of the authorized wallet** below. LeverUp's team confirmed a main wallet works directly here — anything pasted below has full control over its funds. Use a wallet whose balance you're comfortable with this app touching.`,
   defaultName: 'leverup-main',
   badge: 'LU',
-  badgeColor: 'text-accent',
+  badgeColor: 'text-primary',
   engine: 'leverup',
   guardCategory: 'crypto',
   modes: [
@@ -477,7 +477,7 @@ export const SIMULATOR_PRESET: BrokerPresetDef = {
   hint: 'For UI/AI repro testing only. Positions and orders live in process memory; **everything is wiped on dev server restart**. Connect via the Dev → Simulator panel to inject prices, manually撮合 limit orders, and simulate external transfers / off-platform trades.',
   defaultName: 'simulator',
   badge: 'SM',
-  badgeColor: 'text-text-muted',
+  badgeColor: 'text-muted-foreground',
   engine: 'mock',
   guardCategory: 'crypto',
   zodSchema: z.object({

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -91,19 +91,19 @@ function AppShell() {
   }, [sidebarOpen])
 
   const mainContent = (
-    <main className="flex flex-col min-w-0 min-h-0 bg-bg h-full">
+    <main className="flex flex-col min-w-0 min-h-0 bg-background h-full">
       {/* Mobile header — visible only below md */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-border/80 bg-bg-secondary shrink-0 md:hidden">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border/80 bg-secondary shrink-0 md:hidden">
         <button
           onClick={() => setSidebarOpen(true)}
-          className="text-text-muted hover:text-text p-1 -ml-1"
+          className="text-muted-foreground hover:text-foreground p-1 -ml-1"
           aria-label="Open menu"
         >
           <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
             <path d="M3 5h14M3 10h14M3 15h14" />
           </svg>
         </button>
-        <span className="text-sm font-semibold text-text">OpenAlice</span>
+        <span className="text-sm font-semibold text-foreground">OpenAlice</span>
       </div>
 
       <TabHost />

--- a/ui/src/auth/AuthGate.tsx
+++ b/ui/src/auth/AuthGate.tsx
@@ -20,7 +20,7 @@ function ReconnectNotice() {
     <div
       role="status"
       aria-live="polite"
-      className="fixed left-1/2 top-4 z-[80] flex -translate-x-1/2 items-center gap-2 rounded-lg border border-border bg-bg-secondary/95 px-3 py-2 text-[12px] text-text-muted shadow-lg backdrop-blur-sm"
+      className="fixed left-1/2 top-4 z-[80] flex -translate-x-1/2 items-center gap-2 rounded-lg border border-border bg-secondary/95 px-3 py-2 text-[12px] text-muted-foreground shadow-lg backdrop-blur-sm"
     >
       <Spinner size="sm" />
       <span>{t('auth.reconnecting')}</span>
@@ -34,7 +34,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
 
   if (state === 'loading') {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-3 bg-bg text-[12px] text-text-muted">
+      <div className="min-h-screen flex flex-col items-center justify-center gap-3 bg-background text-[12px] text-muted-foreground">
         <Spinner />
         {backendUnavailable && <span role="status">{t('auth.reconnecting')}</span>}
       </div>

--- a/ui/src/auth/LoginPage.tsx
+++ b/ui/src/auth/LoginPage.tsx
@@ -40,13 +40,13 @@ export function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-bg px-4">
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
       <div className="w-full max-w-[400px] rounded-lg border border-border bg-surface px-6 py-7 shadow-sm">
-        <h1 className="text-[18px] font-semibold text-text mb-1">{t('auth.heading')}</h1>
-        <p className="text-[12px] text-text-muted leading-relaxed mb-5">
+        <h1 className="text-[18px] font-semibold text-foreground mb-1">{t('auth.heading')}</h1>
+        <p className="text-[12px] text-muted-foreground leading-relaxed mb-5">
           {t('auth.instruction')}
           {' '}
-          <span className="text-text-faint">
+          <span className="text-foreground-faint">
             Find it in the backend logs after <code className="font-mono">pnpm dev</code> /
             {' '}<code className="font-mono">docker run</code>, or rotate via
             {' '}<code className="font-mono">rm data/config/auth.json</code> and restart.
@@ -55,7 +55,7 @@ export function LoginPage() {
 
         <form onSubmit={onSubmit} className="space-y-3">
           <div>
-            <label className="block text-[11px] uppercase tracking-wide text-text-muted mb-1">
+            <label className="block text-[11px] uppercase tracking-wide text-muted-foreground mb-1">
               {t('auth.adminTokenLabel')}
             </label>
             <input
@@ -65,7 +65,7 @@ export function LoginPage() {
               value={token}
               onChange={(e) => setToken(e.target.value)}
               disabled={busy}
-              className="w-full rounded border border-border bg-bg px-2.5 py-1.5 text-[13px] font-mono text-text focus:outline-none focus:border-accent disabled:opacity-60"
+              className="w-full rounded border border-border bg-background px-2.5 py-1.5 text-[13px] font-mono text-foreground focus:outline-none focus:border-primary disabled:opacity-60"
               placeholder="xKUT78dNUcRVDwoyDsUUROqffPJV8-..."
             />
           </div>
@@ -92,15 +92,15 @@ export function LoginPage() {
 export function NoTokenPage() {
   const { t } = useTranslation()
   return (
-    <div className="min-h-screen flex items-center justify-center bg-bg px-4">
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
       <div className="w-full max-w-[460px] rounded-lg border border-border bg-surface px-6 py-7">
-        <h1 className="text-[18px] font-semibold text-text mb-2">{t('auth.noTokenHeading')}</h1>
-        <p className="text-[13px] text-text leading-relaxed mb-3">
+        <h1 className="text-[18px] font-semibold text-foreground mb-2">{t('auth.noTokenHeading')}</h1>
+        <p className="text-[13px] text-foreground leading-relaxed mb-3">
           The backend did not generate <code className="font-mono">data/config/auth.json</code>.
           This usually means bootstrap was skipped via <code className="font-mono">OPENALICE_DISABLE_AUTH=1</code>,
           or the file was created empty.
         </p>
-        <p className="text-[12px] text-text-muted leading-relaxed">
+        <p className="text-[12px] text-muted-foreground leading-relaxed">
           Stop the backend, delete <code className="font-mono">data/config/auth.json</code> if it exists,
           unset <code className="font-mono">OPENALICE_DISABLE_AUTH</code>, and restart. The first-run
           token will be printed to stdout.

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -103,7 +103,7 @@ export function ActivityBar({
     <>
       {/* Backdrop — mobile only */}
       <div
-        className={`fixed inset-0 bg-black/50 z-40 md:hidden transition-opacity duration-200 ${
+        className={`fixed inset-0 bg-backdrop z-40 md:hidden transition-opacity duration-200 ${
           open ? 'opacity-100' : 'opacity-0 pointer-events-none'
         }`}
         onClick={onClose}
@@ -114,7 +114,7 @@ export function ActivityBar({
       <aside
         className={`
           w-[280px] ${compactRail ? 'md:w-[60px]' : narrowRail ? 'md:w-[152px]' : 'md:w-[188px]'} h-full flex flex-col shrink-0
-          bg-bg-tertiary
+          bg-muted
           border-r border-border/80
           fixed z-50 top-0 left-0 transition-[transform,width] duration-200
           ${open ? 'translate-x-0' : '-translate-x-full'}
@@ -127,10 +127,10 @@ export function ActivityBar({
           <img
             src="/alice.ico"
             alt="Alice"
-            className={`${denseRail ? 'h-6 w-6 md:h-5 md:w-5' : 'h-6 w-6'} shrink-0 rounded-full ring-1 ring-border shadow-[0_0_14px_var(--color-accent-dim)]`}
+            className={`${denseRail ? 'h-6 w-6 md:h-5 md:w-5' : 'h-6 w-6'} shrink-0 rounded-full ring-1 ring-border shadow-[0_0_14px_var(--primary-muted)]`}
             draggable={false}
           />
-          <h1 className={`min-w-0 flex-1 truncate text-[15px] font-semibold text-text ${compactRail ? 'md:hidden' : ''}`}>OpenAlice</h1>
+          <h1 className={`min-w-0 flex-1 truncate text-[15px] font-semibold text-foreground ${compactRail ? 'md:hidden' : ''}`}>OpenAlice</h1>
         </div>
 
         {/* Navigation */}
@@ -200,13 +200,13 @@ export function ActivityBar({
                                 : `min-h-[34px] ${narrowRail ? 'gap-2 px-2.5' : 'gap-3 px-3'} py-1.5 text-[13px]`
                           } ${
                             isActive
-                              ? 'bg-accent-dim text-text'
-                              : 'text-text-muted hover:text-text hover:bg-overlay'
+                              ? 'bg-primary-muted text-foreground'
+                              : 'text-muted-foreground hover:text-foreground hover:bg-accent'
                           }`}
                         >
                           {/* Active indicator — left vertical bar */}
                           <span
-                            className={`absolute left-0 ${denseRail ? 'top-1.5 bottom-1.5 md:top-0.5 md:bottom-0.5' : 'top-1.5 bottom-1.5'} w-[2px] rounded-r-full bg-accent transition-opacity duration-150 ${
+                            className={`absolute left-0 ${denseRail ? 'top-1.5 bottom-1.5 md:top-0.5 md:bottom-0.5' : 'top-1.5 bottom-1.5'} w-[2px] rounded-r-full bg-primary transition-opacity duration-150 ${
                               isActive ? 'opacity-100' : 'opacity-0'
                             }`}
                             aria-hidden
@@ -218,7 +218,7 @@ export function ActivityBar({
                           {item.page === 'inbox' && unreadInbox > 0 && (
                             <span
                               aria-label={t('nav.unread', { count: unreadInbox })}
-                              className={`shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center ${
+                              className={`shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-destructive text-[10px] font-semibold text-destructive-foreground tabular-nums flex items-center justify-center ${
                                 compactRail ? 'md:absolute md:-right-1 md:-top-1 md:h-4 md:min-w-4 md:px-1 md:text-[9px]' : ''
                               }`}
                             >
@@ -228,7 +228,7 @@ export function ActivityBar({
                           {item.page === 'trading-as-git' && pendingPush > 0 && (
                             <span
                               aria-label={t('nav.pendingPush', { count: pendingPush })}
-                              className={`shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-red text-[10px] font-semibold text-white tabular-nums flex items-center justify-center ${
+                              className={`shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-destructive text-[10px] font-semibold text-destructive-foreground tabular-nums flex items-center justify-center ${
                                 compactRail ? 'md:absolute md:-right-1 md:-top-1 md:h-4 md:min-w-4 md:px-1 md:text-[9px]' : ''
                               }`}
                             >
@@ -254,7 +254,7 @@ export function ActivityBar({
               onClick={() => setRailCollapsed(!railCollapsed)}
               title={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
               aria-label={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
-              className={`oa-icon-action hidden ${denseRail ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text md:flex`}
+              className={`oa-icon-action hidden ${denseRail ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground md:flex`}
             >
               {railCollapsed
                 ? <PanelLeftOpen size={denseRail ? 14 : 17} strokeWidth={1.75} aria-hidden />
@@ -306,7 +306,7 @@ function SectionHeader({
         <button
           type="button"
           onClick={onToggleCollapse}
-          className="flex min-h-7 flex-1 items-center gap-1.5 py-1 text-left text-[12px] font-semibold text-text-muted transition-colors hover:text-text"
+          className="flex min-h-7 flex-1 items-center gap-1.5 py-1 text-left text-[12px] font-semibold text-muted-foreground transition-colors hover:text-foreground"
           aria-expanded={!isCollapsed}
           aria-controls={controlsId}
           title={label}
@@ -326,7 +326,7 @@ function SectionHeader({
             type="button"
             onClick={() => setHintOpen((o) => !o)}
             className={`flex min-h-7 min-w-7 items-center justify-center p-0.5 transition-colors ${
-              hintOpen ? 'text-text-muted' : 'text-text-muted/50 hover:text-text-muted'
+              hintOpen ? 'text-muted-foreground' : 'text-muted-foreground/50 hover:text-muted-foreground'
             }`}
             aria-label={t('nav.about', { label })}
             aria-expanded={hintOpen}
@@ -336,7 +336,7 @@ function SectionHeader({
         )}
       </div>
       {showItems && description && hintOpen && (
-        <p className="oa-disclosure-enter mb-2 px-3 text-[11px] leading-relaxed text-text-muted">
+        <p className="oa-disclosure-enter mb-2 px-3 text-[11px] leading-relaxed text-muted-foreground">
           {description}
         </p>
       )}

--- a/ui/src/components/AutomationSidebar.tsx
+++ b/ui/src/components/AutomationSidebar.tsx
@@ -31,7 +31,7 @@ export function AutomationSidebar() {
       key={item.section}
       label={t(item.labelKey)}
       active={activeSection === item.section}
-      icon={<item.Icon size={14} strokeWidth={2} className="text-text-muted/70" aria-hidden />}
+      icon={<item.Icon size={14} strokeWidth={2} className="text-muted-foreground/70" aria-hidden />}
       onClick={() => openOrFocus({ kind: 'automation', params: { section: item.section } })}
     />
   )

--- a/ui/src/components/ConfirmDialog.tsx
+++ b/ui/src/components/ConfirmDialog.tsx
@@ -51,9 +51,9 @@ export function ConfirmDialog({
   return (
     <Dialog onClose={busy ? () => {} : onClose} width="w-[440px]">
       <div className="px-5 py-4 border-b border-border">
-        <h2 className="text-[15px] font-semibold text-text">{title}</h2>
+        <h2 className="text-[15px] font-semibold text-foreground">{title}</h2>
       </div>
-      <div className="px-5 py-4 text-[13px] text-text leading-relaxed">
+      <div className="px-5 py-4 text-[13px] text-foreground leading-relaxed">
         {message}
       </div>
       <div className="px-5 py-3 border-t border-border flex justify-end gap-2">

--- a/ui/src/components/ContextMenu.tsx
+++ b/ui/src/components/ContextMenu.tsx
@@ -78,7 +78,7 @@ export function ContextMenu({ anchor, items, onClose }: ContextMenuProps) {
         top: pos.y,
         zIndex: 60,
       }}
-      className="oa-popover-enter min-w-[180px] py-1 bg-bg-secondary border border-border rounded-md shadow-xl"
+      className="oa-popover-enter min-w-[180px] py-1 bg-secondary border border-border rounded-md shadow-xl"
     >
       {items.map((item, i) => {
         if (item.kind === 'separator') {
@@ -86,8 +86,8 @@ export function ContextMenu({ anchor, items, onClose }: ContextMenuProps) {
         }
         const disabled = item.disabled === true
         const colorClass = item.danger
-          ? 'text-red hover:bg-red/10'
-          : 'text-text hover:bg-bg-tertiary'
+          ? 'text-destructive hover:bg-destructive/10'
+          : 'text-foreground hover:bg-muted'
         return (
           <button
             key={`item-${i}`}

--- a/ui/src/components/DesktopUpdatePrompt.tsx
+++ b/ui/src/components/DesktopUpdatePrompt.tsx
@@ -72,18 +72,18 @@ export function DesktopUpdatePrompt() {
   return (
     <Dialog onClose={busy ? () => {} : () => setStatus(null)} width="w-[480px]">
       <div className="px-5 py-4 border-b border-border flex items-center gap-3">
-        <div className="h-9 w-9 rounded-lg border border-accent/30 bg-accent-dim/30 text-accent flex items-center justify-center shrink-0">
+        <div className="h-9 w-9 rounded-lg border border-primary/30 bg-primary-muted/30 text-primary flex items-center justify-center shrink-0">
           <Download size={18} strokeWidth={1.8} />
         </div>
         <div className="min-w-0 flex-1">
-          <h2 className="text-[15px] font-semibold text-text leading-snug">Update ready</h2>
-          <p className="text-[12px] text-text-muted truncate">OpenAlice v{status.version}</p>
+          <h2 className="text-[15px] font-semibold text-foreground leading-snug">Update ready</h2>
+          <p className="text-[12px] text-muted-foreground truncate">OpenAlice v{status.version}</p>
         </div>
         <button
           type="button"
           onClick={() => setStatus(null)}
           disabled={busy}
-          className="h-8 w-8 rounded-md text-text-muted hover:text-text hover:bg-bg-tertiary disabled:opacity-40 flex items-center justify-center transition-colors"
+          className="h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-40 flex items-center justify-center transition-colors"
           aria-label="Close update prompt"
         >
           <X size={16} />
@@ -91,14 +91,14 @@ export function DesktopUpdatePrompt() {
       </div>
 
       <div className="px-5 py-4 space-y-3">
-        <p className="text-[13px] leading-relaxed text-text">
+        <p className="text-[13px] leading-relaxed text-foreground">
           The update has been downloaded and is ready to install.
         </p>
-        <p className="text-[12px] leading-relaxed text-text-muted">
+        <p className="text-[12px] leading-relaxed text-muted-foreground">
           Restarting will stop Alice and UTA gracefully, then reopen OpenAlice on the new version.
         </p>
         {error && (
-          <div className="rounded-lg border border-red/30 bg-red/10 px-3 py-2 text-[12px] leading-relaxed text-red">
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-[12px] leading-relaxed text-destructive">
             {error}
           </div>
         )}

--- a/ui/src/components/DevCategoryList.tsx
+++ b/ui/src/components/DevCategoryList.tsx
@@ -30,7 +30,7 @@ export function DevCategoryList() {
             key={item.tab}
             label={'label' in item ? item.label : t(item.labelKey)}
             active={active}
-            icon={<item.Icon size={14} strokeWidth={1.75} className="text-text-muted/70" aria-hidden />}
+            icon={<item.Icon size={14} strokeWidth={1.75} className="text-muted-foreground/70" aria-hidden />}
             onClick={() => openOrFocus({ kind: 'dev', params: { tab: item.tab } })}
           />
         )

--- a/ui/src/components/EmptyEditor.tsx
+++ b/ui/src/components/EmptyEditor.tsx
@@ -10,16 +10,16 @@ export function EmptyEditor() {
       <img
         src="/alice.ico"
         alt="OpenAlice"
-        className="w-16 h-16 rounded-2xl ring-1 ring-accent/25 shadow-[0_0_18px_var(--color-accent-dim)]"
+        className="w-16 h-16 rounded-2xl ring-1 ring-primary/25 shadow-[0_0_18px_var(--primary-muted)]"
         draggable={false}
       />
       <div className="space-y-2 max-w-md">
-        <h2 className="text-base font-semibold text-text">OpenAlice</h2>
-        <p className="text-[13px] text-text-muted leading-relaxed">
+        <h2 className="text-base font-semibold text-foreground">OpenAlice</h2>
+        <p className="text-[13px] text-muted-foreground leading-relaxed">
           Click an icon on the activity bar to open its sidebar, then pick something from the sidebar to open it as a tab.
         </p>
-        <p className="text-[12px] text-text-muted/70 leading-relaxed">
-          First time here? Open <span className="text-text">Settings → AI Provider</span> to configure a model, then jump back to <span className="text-text">Chat</span>.
+        <p className="text-[12px] text-muted-foreground/70 leading-relaxed">
+          First time here? Open <span className="text-foreground">Settings → AI Provider</span> to configure a model, then jump back to <span className="text-foreground">Chat</span>.
         </p>
       </div>
     </div>

--- a/ui/src/components/EquityCurve.tsx
+++ b/ui/src/components/EquityCurve.tsx
@@ -85,10 +85,10 @@ export function EquityCurve({
   const isAllView = selectedAccountId === 'all'
 
   return (
-    <div className="border border-border rounded-lg bg-bg-secondary p-4">
+    <div className="border border-border rounded-lg bg-secondary p-4">
       {/* Header */}
       <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wide">
+        <h3 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wide">
           Equity Curve
         </h3>
         <SegmentedControl
@@ -103,7 +103,7 @@ export function EquityCurve({
       {/* Account switcher */}
       {accounts.length > 1 && (
         <div className="mb-3 flex max-w-full items-center gap-2">
-          <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Account</span>
+          <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Account</span>
           <SegmentedControl
             value={selectedAccountId}
             options={[
@@ -132,8 +132,8 @@ export function EquityCurve({
           >
           <defs>
             <linearGradient id="equityGradient" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="var(--color-accent)" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="var(--color-accent)" stopOpacity={0} />
+              <stop offset="5%" stopColor="var(--primary)" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="var(--primary)" stopOpacity={0} />
             </linearGradient>
           </defs>
           <XAxis
@@ -142,14 +142,14 @@ export function EquityCurve({
             domain={['dataMin', 'dataMax']}
             ticks={xTicks}
             tickFormatter={formatTime}
-            tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
-            axisLine={{ stroke: 'var(--color-border)' }}
+            tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+            axisLine={{ stroke: 'var(--border)' }}
             tickLine={false}
             minTickGap={40}
           />
           <YAxis
             tickFormatter={yAxis?.formatter ?? formatCurrency}
-            tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }}
+            tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
             axisLine={false}
             tickLine={false}
             width={70}
@@ -160,16 +160,16 @@ export function EquityCurve({
           <Area
             type="monotone"
             dataKey="equityNum"
-            stroke="var(--color-accent)"
+            stroke="var(--primary)"
             strokeWidth={1.5}
             fill="url(#equityGradient)"
             dot={false}
-            activeDot={{ r: 4, fill: 'var(--color-accent)', stroke: 'var(--color-bg-secondary)', strokeWidth: 2 }}
+            activeDot={{ r: 4, fill: 'var(--primary)', stroke: 'var(--secondary)', strokeWidth: 2 }}
           />
           {selectedTimestamp && (
             <ReferenceLine
               x={new Date(selectedTimestamp).getTime()}
-              stroke="var(--color-accent)"
+              stroke="var(--primary)"
               strokeDasharray="3 3"
               strokeOpacity={0.6}
             />
@@ -189,19 +189,19 @@ function CustomTooltip({ active, payload, isAllView, accounts }: any) {
   const accountMap = new Map((accounts as Array<{ id: string; label: string }>).map(a => [a.id, a.label]))
 
   return (
-    <div className="bg-bg-secondary border border-border rounded-md px-3 py-2 shadow-lg text-[12px]">
-      <p className="text-text-muted mb-1">
+    <div className="bg-secondary border border-border rounded-md px-3 py-2 shadow-lg text-[12px]">
+      <p className="text-muted-foreground mb-1">
         {new Date(data.time).toLocaleString()}
       </p>
-      <p className="text-text font-semibold tabular-nums">
+      <p className="text-foreground font-semibold tabular-nums">
         ${Number(data.equity).toLocaleString(getIntlLocale(), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
       </p>
       {isAllView && data.accounts && Object.keys(data.accounts).length > 1 && (
         <div className="mt-1.5 pt-1.5 border-t border-border space-y-0.5">
           {Object.entries(data.accounts).map(([id, val]) => (
             <div key={id} className="flex justify-between gap-4">
-              <span className="text-text-muted">{accountMap.get(id) ?? id}</span>
-              <span className="text-text tabular-nums">
+              <span className="text-muted-foreground">{accountMap.get(id) ?? id}</span>
+              <span className="text-foreground tabular-nums">
                 ${Number(val).toLocaleString(getIntlLocale(), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
               </span>
             </div>

--- a/ui/src/components/FileContentView.tsx
+++ b/ui/src/components/FileContentView.tsx
@@ -38,7 +38,7 @@ function DocBody({ path, content }: { path: string; content: string }): ReactEle
   }
   // Plain-text fallback (.txt, .log, no extension, code files…)
   return (
-    <pre className="text-[12px] text-text whitespace-pre-wrap font-mono leading-relaxed">
+    <pre className="text-[12px] text-foreground whitespace-pre-wrap font-mono leading-relaxed">
       {content}
     </pre>
   )
@@ -61,5 +61,5 @@ function DocTombstone({ result }: { result: ReadFileResult }): ReactElement {
         return ''
     }
   })()
-  return <div className="text-[12px] text-text-muted italic">{message}</div>
+  return <div className="text-[12px] text-muted-foreground italic">{message}</div>
 }

--- a/ui/src/components/FirstRunGuide.tsx
+++ b/ui/src/components/FirstRunGuide.tsx
@@ -580,15 +580,15 @@ export function FirstRunGuide() {
   }
 
   return (
-    <div className="fixed inset-0 z-[70] overflow-hidden bg-bg text-text" data-testid="first-run-guide">
+    <div className="fixed inset-0 z-[70] overflow-hidden bg-background text-foreground" data-testid="first-run-guide">
       <div className="flex h-full min-h-0 flex-col px-4 py-4 sm:px-6 lg:px-8">
         <div className="mx-auto flex h-full min-h-0 w-full max-w-[980px] flex-col">
           <header className="relative shrink-0 border-b border-border pb-4 pr-12">
             <div className="min-w-0">
-              <div className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                 {t('firstRunGuide.header.setup')}
               </div>
-              <div className="mt-1 text-[15px] font-semibold leading-snug text-text sm:text-[16px]">
+              <div className="mt-1 text-[15px] font-semibold leading-snug text-foreground sm:text-[16px]">
                 {t('firstRunGuide.header.subtitle')}
               </div>
             </div>
@@ -597,7 +597,7 @@ export function FirstRunGuide() {
                 type="button"
                 onClick={() => close()}
                 aria-label={t('firstRunGuide.header.close')}
-                className="absolute right-0 top-0 flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
+                className="absolute right-0 top-0 flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               >
                 <X className="h-4 w-4" />
               </button>
@@ -616,23 +616,23 @@ export function FirstRunGuide() {
                 {activeStep.key === 'finish' && (
                   <CompletionMark />
                 )}
-                <div className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                   {activeStep.eyebrow}
                 </div>
-                <h1 className="oa-onboarding-title mt-3 max-w-[660px] text-[28px] font-semibold leading-tight text-text sm:mt-4 sm:text-[38px] lg:text-[44px]">
+                <h1 className="oa-onboarding-title mt-3 max-w-[660px] text-[28px] font-semibold leading-tight text-foreground sm:mt-4 sm:text-[38px] lg:text-[44px]">
                   {activeStep.title}
                 </h1>
-                <p className="mt-3 max-w-[610px] text-[14px] leading-6 text-text-muted sm:mt-4 sm:text-[15px]">
+                <p className="mt-3 max-w-[610px] text-[14px] leading-6 text-muted-foreground sm:mt-4 sm:text-[15px]">
                   {activeStep.body}
                 </p>
               </div>
 
               <aside className="min-w-0 border-t border-border pt-4 md:border-l md:border-t-0 md:pl-5 md:pt-0 lg:pl-6">
-                <div className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                   {activeStep.panelTitle}
                 </div>
                 {activeStep.panelBody && (
-                  <p className="mt-2 text-[13px] leading-relaxed text-text-muted">
+                  <p className="mt-2 text-[13px] leading-relaxed text-muted-foreground">
                     {activeStep.panelBody}
                   </p>
                 )}
@@ -680,10 +680,10 @@ export function FirstRunGuide() {
                         disabled={locked}
                         className={`h-2.5 rounded-full transition-all ${
                           index === activeStepIndex
-                            ? 'w-8 bg-accent'
+                            ? 'w-8 bg-primary'
                             : locked
-                              ? 'w-2.5 cursor-default bg-bg-tertiary/50 opacity-60'
-                              : 'w-2.5 bg-bg-tertiary hover:bg-text-muted/50'
+                              ? 'w-2.5 cursor-default bg-muted/50 opacity-60'
+                              : 'w-2.5 bg-muted hover:bg-muted-foreground/50'
                         }`}
                         aria-label={`Go to ${step.navLabel}`}
                         aria-current={index === activeStepIndex ? 'step' : undefined}
@@ -691,7 +691,7 @@ export function FirstRunGuide() {
                     )
                   })}
                 </div>
-                <div className="min-w-0 text-[11px] font-medium uppercase tracking-wide text-text-muted">
+                <div className="min-w-0 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                   {t('firstRunGuide.common.step', {
                     current: activeStepIndex + 1,
                     total: steps.length,
@@ -705,7 +705,7 @@ export function FirstRunGuide() {
                   type="button"
                   onClick={() => goToStep(activeStepIndex - 1)}
                   disabled={activeStepIndex === 0}
-                  className="rounded-md border border-border bg-bg px-3 py-2 text-[13px] font-medium text-text-muted transition-colors hover:border-accent/50 hover:text-accent disabled:cursor-default disabled:opacity-40 disabled:hover:border-border disabled:hover:text-text-muted"
+                  className="rounded-md border border-border bg-background px-3 py-2 text-[13px] font-medium text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary disabled:cursor-default disabled:opacity-40 disabled:hover:border-border disabled:hover:text-muted-foreground"
                 >
                   {t('firstRunGuide.common.back')}
                 </button>
@@ -715,7 +715,7 @@ export function FirstRunGuide() {
                   disabled={primaryDisabled}
                   data-testid="first-run-guide-primary"
                   data-onboarding-action={primaryAction}
-                  className="flex min-w-0 items-center justify-center gap-2 rounded-md bg-accent px-4 py-2 text-[13px] font-semibold text-white transition-colors hover:bg-accent/90 disabled:cursor-default disabled:opacity-60 disabled:hover:bg-accent"
+                  className="flex min-w-0 items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-default disabled:opacity-60 disabled:hover:bg-primary"
                 >
                   <span className="min-w-0 truncate">{activeStep.primary}</span>
                   <ArrowRight className="h-4 w-4 shrink-0" />
@@ -725,7 +725,7 @@ export function FirstRunGuide() {
                     type="button"
                     onClick={runSecondary}
                     data-testid="first-run-guide-secondary"
-                    className="col-span-2 rounded-md px-3 py-2 text-[12px] font-medium text-text-muted transition-colors hover:bg-overlay hover:text-text sm:col-span-1"
+                    className="col-span-2 rounded-md px-3 py-2 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:col-span-1"
                   >
                     {activeStep.secondary}
                   </button>
@@ -820,30 +820,30 @@ function LanguageChoices({
             onClick={() => onSelect(option)}
             className={`grid min-w-0 w-full grid-cols-[auto_minmax(0,1fr)_auto] gap-3 rounded-md border px-3 py-3 text-left transition-[border-color,background-color,color,transform] ${
               active
-                ? 'border-accent/55 bg-accent/10 text-text'
-                : 'border-border bg-bg text-text-muted hover:border-accent/35 hover:bg-bg-tertiary hover:text-text'
+                ? 'border-primary/55 bg-primary/10 text-foreground'
+                : 'border-border bg-background text-muted-foreground hover:border-primary/35 hover:bg-muted hover:text-foreground'
             } active:scale-[0.99]`}
           >
             <span className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md ${
-              active ? 'bg-accent/15 text-accent' : 'bg-bg-tertiary text-text-muted'
+              active ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
             }`}>
               <Languages className="h-4 w-4" />
             </span>
             <span className="min-w-0">
-              <span className="block text-[13px] font-semibold text-text">{LOCALE_LABELS[option]}</span>
-              <span className="mt-0.5 block text-[12px] leading-relaxed text-text-muted">
+              <span className="block text-[13px] font-semibold text-foreground">{LOCALE_LABELS[option]}</span>
+              <span className="mt-0.5 block text-[12px] leading-relaxed text-muted-foreground">
                 {description}
               </span>
               <span className={`mt-1.5 inline-flex text-[11px] font-medium ${
-                active ? 'text-accent' : 'text-text-muted/70'
+                active ? 'text-primary' : 'text-muted-foreground/70'
               }`}>
                 {active ? t('firstRunGuide.language.current') : t('firstRunGuide.language.choose')}
               </span>
             </span>
             {active ? (
-              <CheckCircle2 className="mt-1.5 h-4 w-4 shrink-0 text-green" />
+              <CheckCircle2 className="mt-1.5 h-4 w-4 shrink-0 text-success" />
             ) : (
-              <Circle className="mt-1.5 h-4 w-4 shrink-0 text-text-muted" />
+              <Circle className="mt-1.5 h-4 w-4 shrink-0 text-muted-foreground" />
             )}
           </button>
         )
@@ -865,18 +865,18 @@ function StatusRow({
 }) {
   const ToneIcon = tone === 'attention' ? AlertTriangle : CheckCircle2
   const toneClass = tone === 'ready'
-    ? 'text-green'
+    ? 'text-success'
     : tone === 'attention'
-      ? 'text-red'
-      : 'text-text-muted'
+      ? 'text-destructive'
+      : 'text-muted-foreground'
   return (
     <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] gap-3 py-2.5 sm:py-3">
-      <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-bg-tertiary text-text-muted">
+      <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
         {icon}
       </div>
       <div className="min-w-0">
-        <div className="text-[12px] font-medium text-text">{label}</div>
-        <div className="mt-0.5 text-[12px] leading-relaxed text-text-muted">{value}</div>
+        <div className="text-[12px] font-medium text-foreground">{label}</div>
+        <div className="mt-0.5 text-[12px] leading-relaxed text-muted-foreground">{value}</div>
       </div>
       <ToneIcon className={`mt-1 h-4 w-4 shrink-0 ${toneClass}`} />
     </div>
@@ -890,7 +890,7 @@ function CompletionMark() {
       <span className="oa-onboarding-completion-line oa-onboarding-completion-line-b" />
       <span className="oa-onboarding-completion-line oa-onboarding-completion-line-c" />
       <div className="oa-onboarding-completion-ring">
-        <CheckCircle2 className="h-9 w-9 text-green" strokeWidth={1.8} />
+        <CheckCircle2 className="h-9 w-9 text-success" strokeWidth={1.8} />
       </div>
     </div>
   )
@@ -938,7 +938,7 @@ function TradingModeChoices({
   const disabled = envLocked || saving !== null
   return (
     <div className="mt-4 sm:mt-5">
-      <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-accent/25 bg-accent/10 px-2.5 py-1.5 text-[11px] font-medium text-accent">
+      <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-primary/10 px-2.5 py-1.5 text-[11px] font-medium text-primary">
         <MousePointerClick className="h-3.5 w-3.5" />
         {t('firstRunGuide.tradingChoices.badge')}
       </div>
@@ -955,53 +955,53 @@ function TradingModeChoices({
               onClick={() => onSelect(choice.mode)}
               className={`grid min-w-0 w-full grid-cols-[auto_minmax(0,1fr)_auto] gap-3 rounded-md border px-3 py-3 text-left transition-[border-color,background-color,color,transform] ${
                 active
-                  ? 'border-accent/55 bg-accent/10 text-text'
-                  : 'border-border bg-bg text-text-muted hover:border-accent/35 hover:bg-bg-tertiary hover:text-text'
+                  ? 'border-primary/55 bg-primary/10 text-foreground'
+                  : 'border-border bg-background text-muted-foreground hover:border-primary/35 hover:bg-muted hover:text-foreground'
               } ${disabled ? 'cursor-default opacity-75' : 'cursor-pointer active:scale-[0.99]'}`}
             >
               <span className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md ${
-                active ? 'bg-accent/15 text-accent' : 'bg-bg-tertiary text-text-muted'
+                active ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
               }`}>
                 {choice.icon}
               </span>
               <span className="min-w-0">
                 <span className="block text-[12px] font-medium">{choice.label}</span>
-                <span className="mt-0.5 block text-[12px] leading-relaxed text-text-muted">
+                <span className="mt-0.5 block text-[12px] leading-relaxed text-muted-foreground">
                   {choice.description}
                 </span>
                 {isSaving && (
-                  <span className="mt-1.5 inline-flex items-center gap-1.5 text-[11px] text-accent">
-                    <span className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" aria-hidden />
+                  <span className="mt-1.5 inline-flex items-center gap-1.5 text-[11px] text-primary">
+                    <span className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" aria-hidden />
                     {t('firstRunGuide.common.saving')}
                   </span>
                 )}
                 {!isSaving && (
                   <span className={`mt-1.5 inline-flex text-[11px] font-medium ${
-                    active ? 'text-accent' : 'text-text-muted/70'
+                    active ? 'text-primary' : 'text-muted-foreground/70'
                   }`}>
                     {active ? t('firstRunGuide.common.selected') : t('firstRunGuide.common.chooseThisOption')}
                   </span>
                 )}
               </span>
               {active ? (
-                <CheckCircle2 className="mt-1.5 h-4 w-4 shrink-0 text-green" />
+                <CheckCircle2 className="mt-1.5 h-4 w-4 shrink-0 text-success" />
               ) : (
-                <Circle className="mt-1.5 h-4 w-4 shrink-0 text-text-muted" />
+                <Circle className="mt-1.5 h-4 w-4 shrink-0 text-muted-foreground" />
               )}
             </button>
           )
         })}
       </div>
       {envLocked && (
-        <div className="mt-3 text-[11px] leading-relaxed text-text-muted/70">
+        <div className="mt-3 text-[11px] leading-relaxed text-muted-foreground/70">
           <span className="inline-flex items-center gap-1.5">
-            <AlertTriangle className="h-3.5 w-3.5 text-yellow-500" />
+            <AlertTriangle className="h-3.5 w-3.5 text-warning" />
             {t('firstRunGuide.tradingChoices.envLocked')}
           </span>
         </div>
       )}
       {error && (
-        <div className="mt-2 rounded-md border border-red/30 bg-red/5 px-3 py-2 text-[12px] leading-relaxed text-red">
+        <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] leading-relaxed text-destructive">
           {error}
         </div>
       )}
@@ -1032,12 +1032,12 @@ function RuntimeScanTable({
   return (
     <div className="mt-4 sm:mt-5">
       {error && (
-        <div className="mb-3 break-words rounded-md border border-red/25 bg-red/5 px-3 py-2 text-[12px] leading-relaxed text-red">
+        <div className="mb-3 break-words rounded-md border border-destructive/25 bg-destructive/5 px-3 py-2 text-[12px] leading-relaxed text-destructive">
           {error}
         </div>
       )}
       <div className="overflow-hidden border-y border-border">
-      <div className="hidden border-b border-border py-2 text-[10px] font-medium uppercase tracking-wide text-text-muted sm:grid sm:grid-cols-[minmax(0,1fr)_72px_minmax(112px,140px)] sm:gap-3">
+      <div className="hidden border-b border-border py-2 text-[10px] font-medium uppercase tracking-wide text-muted-foreground sm:grid sm:grid-cols-[minmax(0,1fr)_72px_minmax(112px,140px)] sm:gap-3">
           <span>{t('firstRunGuide.ai.runtime')}</span>
           <span>{t('firstRunGuide.ai.cli')}</span>
           <span>{t('firstRunGuide.ai.readyProbe')}</span>
@@ -1045,10 +1045,10 @@ function RuntimeScanTable({
       {rows.map((row) => {
         const tone: RowTone = row.chainReady ? 'ready' : row.installed ? 'attention' : 'muted'
         const toneClass = tone === 'ready'
-          ? 'text-green'
+          ? 'text-success'
           : tone === 'attention'
-            ? 'text-red'
-            : 'text-text-muted'
+            ? 'text-destructive'
+            : 'text-muted-foreground'
         const cliText = row.installed ? t('firstRunGuide.ai.installed') : t('firstRunGuide.ai.missing')
         const accessText = row.chainReady
           ? t('firstRunGuide.ai.ready')
@@ -1072,16 +1072,16 @@ function RuntimeScanTable({
             data-testid="runtime-scan-row"
           >
             <div className="min-w-0">
-              <div className="font-medium text-text">{row.displayName}</div>
-              <div className="mt-0.5 text-[10.5px] text-text-muted">
+              <div className="font-medium text-foreground">{row.displayName}</div>
+              <div className="mt-0.5 text-[10.5px] text-muted-foreground">
                 {row.loginRuntime ? t('firstRunGuide.ai.loginOrKey') : t('firstRunGuide.ai.aiKey')}
               </div>
               <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 sm:hidden">
-                <span className={row.installed ? 'text-green' : 'text-text-muted'}>{cliText}</span>
+                <span className={row.installed ? 'text-success' : 'text-muted-foreground'}>{cliText}</span>
                 <span className={toneClass}>{accessText}</span>
               </div>
             </div>
-            <div className={`hidden sm:block ${row.installed ? 'text-green' : 'text-text-muted'}`}>
+            <div className={`hidden sm:block ${row.installed ? 'text-success' : 'text-muted-foreground'}`}>
               {cliText}
             </div>
             <div className={`hidden sm:block ${toneClass}`}>

--- a/ui/src/components/HtmlReportView.tsx
+++ b/ui/src/components/HtmlReportView.tsx
@@ -104,13 +104,13 @@ export function HtmlReportView({ path, content }: { path: string; content: strin
   const srcDoc = useMemo(() => createSandboxedHtmlReportDocument(content), [content])
 
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-white shadow-sm">
+    <div className="overflow-hidden rounded-lg border border-border bg-report-canvas shadow-sm">
       <iframe
         title={`HTML report: ${path}`}
         sandbox=""
         referrerPolicy="no-referrer"
         srcDoc={srcDoc}
-        className="block h-[min(70vh,720px)] min-h-[420px] w-full border-0 bg-white"
+        className="block h-[min(70vh,720px)] min-h-[420px] w-full border-0 bg-report-canvas"
       />
     </div>
   )

--- a/ui/src/components/InboxReplyThread.tsx
+++ b/ui/src/components/InboxReplyThread.tsx
@@ -26,19 +26,19 @@ export function InboxReplyThread({
   return (
     <section id="inquiries" className="mt-8 border-t border-border/70 pt-6">
       <div className="flex min-w-0 items-baseline gap-2">
-        <h3 className="text-[13px] font-semibold text-text">{t('inbox.repliesTitle')}</h3>
+        <h3 className="text-[13px] font-semibold text-foreground">{t('inbox.repliesTitle')}</h3>
         {records.length > 0 && (
-          <span className="text-[11px] tabular-nums text-text-muted/45">{records.length}</span>
+          <span className="text-[11px] tabular-nums text-muted-foreground/45">{records.length}</span>
         )}
       </div>
-      <p className="mt-1 text-[12px] leading-relaxed text-text-muted/65">
+      <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground/65">
         {hasExactSender
           ? t('inbox.repliesDescription', { sender })
           : t('inbox.repliesWorkspaceDescription', { workspace: sender })}
       </p>
 
       {thread.loading && records.length === 0 ? (
-        <div className="mt-5 flex items-center gap-2 text-[12px] text-text-muted/60">
+        <div className="mt-5 flex items-center gap-2 text-[12px] text-muted-foreground/60">
           <LoaderCircle size={13} className="animate-spin" aria-hidden />
           {t('inbox.repliesLoading')}
         </div>
@@ -48,7 +48,7 @@ export function InboxReplyThread({
         </div>
       ) : null}
 
-      <div className="mt-5 overflow-hidden rounded-xl border border-border bg-bg transition-colors focus-within:border-accent/55 focus-within:ring-2 focus-within:ring-accent/10">
+      <div className="mt-5 overflow-hidden rounded-xl border border-border bg-background transition-colors focus-within:border-primary/55 focus-within:ring-2 focus-within:ring-primary/10">
         <textarea
           rows={2}
           value={thread.prompt}
@@ -62,17 +62,17 @@ export function InboxReplyThread({
               void thread.submit()
             }
           }}
-          className="min-h-[76px] w-full resize-y bg-transparent px-3.5 pb-2 pt-3 text-[13px] leading-relaxed text-text outline-none placeholder:text-text-muted/45 disabled:opacity-50 sm:min-h-[84px] sm:px-4"
+          className="min-h-[76px] w-full resize-y bg-transparent px-3.5 pb-2 pt-3 text-[13px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/45 disabled:opacity-50 sm:min-h-[84px] sm:px-4"
         />
-        <div className="flex min-h-11 items-center gap-3 border-t border-border/55 bg-bg-secondary/25 px-2.5 py-1.5 sm:px-3">
-          <span className="min-w-0 flex-1 text-[10px] leading-relaxed text-text-muted/50 sm:text-[11px]">
+        <div className="flex min-h-11 items-center gap-3 border-t border-border/55 bg-secondary/25 px-2.5 py-1.5 sm:px-3">
+          <span className="min-w-0 flex-1 text-[10px] leading-relaxed text-muted-foreground/50 sm:text-[11px]">
             {hasExactSender ? t('inbox.replyDeliveryHint') : t('inbox.replyWorkspaceHint')}
           </span>
           <button
             type="button"
             onClick={() => void thread.submit()}
             disabled={thread.sending || thread.prompt.trim().length === 0}
-            className="oa-pressable inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-accent px-2.5 text-[11px] font-medium text-bg hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-35 sm:px-3"
+            className="oa-pressable inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-primary px-2.5 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-35 sm:px-3"
             aria-label={thread.sending ? t('inbox.replySending') : t('inbox.replyAction')}
           >
             {thread.sending
@@ -84,7 +84,7 @@ export function InboxReplyThread({
           </button>
         </div>
       </div>
-      {thread.error && <p className="mt-2 text-[12px] text-red">{thread.error}</p>}
+      {thread.error && <p className="mt-2 text-[12px] text-destructive">{thread.error}</p>}
     </section>
   )
 }
@@ -97,45 +97,45 @@ function InboxReplyRecord({ record }: { record: InquiryRecord }) {
 
   return (
     <article className="relative pl-7 sm:pl-8">
-      <span className="absolute left-0 top-0 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-bg-secondary text-text-muted/70 sm:h-6 sm:w-6">
+      <span className="absolute left-0 top-0 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-secondary text-muted-foreground/70 sm:h-6 sm:w-6">
         <UserRound size={12} strokeWidth={1.75} aria-hidden />
       </span>
       <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-        <span className="text-[12px] font-medium text-text">{t('inbox.replyYou')}</span>
-        <span className="text-[10px] tabular-nums text-text-muted/45" title={new Date(record.startedAt).toLocaleString()}>
+        <span className="text-[12px] font-medium text-foreground">{t('inbox.replyYou')}</span>
+        <span className="text-[10px] tabular-nums text-muted-foreground/45" title={new Date(record.startedAt).toLocaleString()}>
           {formatRelativeTime(record.startedAt)}
         </span>
       </div>
-      <p className="mt-1 whitespace-pre-wrap text-[13px] leading-relaxed text-text/85">
+      <p className="mt-1 whitespace-pre-wrap text-[13px] leading-relaxed text-foreground/85">
         {record.inquiry.question}
       </p>
 
       <div className="relative mt-3 border-l border-border/70 pl-4">
-        <span className="absolute -left-[10px] top-0 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-bg text-text-muted/70">
+        <span className="absolute -left-[10px] top-0 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground/70">
           {running
-            ? <LoaderCircle size={11} className="animate-spin text-accent" aria-hidden />
-            : <Bot size={11} className={failed ? 'text-red' : 'text-accent'} aria-hidden />}
+            ? <LoaderCircle size={11} className="animate-spin text-primary" aria-hidden />
+            : <Bot size={11} className={failed ? 'text-destructive' : 'text-primary'} aria-hidden />}
         </span>
         <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
-          <span className="font-medium text-text/80">
+          <span className="font-medium text-foreground/80">
             {running
               ? t('inbox.replyAgentWorking', { agent: record.agent })
               : t('inbox.replyAgent', { agent: record.agent })}
           </span>
           {reconstructed && (
-            <span className="rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-medium text-amber-500">
+            <span className="rounded-full bg-warning/10 px-1.5 py-0.5 text-[9px] font-medium text-warning">
               {t('inbox.replyReconstructed')}
             </span>
           )}
         </div>
         {running ? (
-          <p className="mt-1.5 text-[12px] text-text-muted/60">{t('inbox.replyWaiting')}</p>
+          <p className="mt-1.5 text-[12px] text-muted-foreground/60">{t('inbox.replyWaiting')}</p>
         ) : record.assistantText ? (
-          <div className="mt-2 text-[13px] leading-relaxed text-text/85">
+          <div className="mt-2 text-[13px] leading-relaxed text-foreground/85">
             <MarkdownContent text={record.assistantText} strikethrough={false} />
           </div>
         ) : (
-          <p className={`mt-1.5 text-[12px] ${failed ? 'text-red' : 'text-text-muted/60'}`}>
+          <p className={`mt-1.5 text-[12px] ${failed ? 'text-destructive' : 'text-muted-foreground/60'}`}>
             {record.error || (failed ? t('inbox.replyFailed') : t('inbox.replyNoAnswer'))}
           </p>
         )}

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -96,9 +96,9 @@ export function InboxSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
 
   if (entries.length === 0) {
     return (
-      <div className="px-3 py-4 text-[12px] text-text-muted/70 leading-relaxed">
+      <div className="px-3 py-4 text-[12px] text-muted-foreground/70 leading-relaxed">
         {t('inbox.noMessages')}
-        <div className="mt-1 text-text-muted/50">
+        <div className="mt-1 text-muted-foreground/50">
           {t('inbox.emptyHint')}
         </div>
       </div>
@@ -169,7 +169,7 @@ function ToggleBtn({
       aria-label={title}
       aria-pressed={active}
       className={`flex items-center justify-center w-8 h-8 transition-colors ${
-        active ? 'bg-bg-tertiary text-text' : 'text-text-muted/60 hover:text-text hover:bg-bg-tertiary/50'
+        active ? 'bg-muted text-foreground' : 'text-muted-foreground/60 hover:text-foreground hover:bg-muted/50'
       }`}
     >
       {children}
@@ -195,15 +195,15 @@ function WorkspaceView({
           <div key={thread.workspaceId} className="mb-1.5">
             {/* Cluster header: label · unread badge · latest time */}
             <div className="flex items-center gap-1.5 px-3 mt-1.5 mb-0.5">
-              <span className="flex-1 truncate text-[12px] font-medium text-text/90">
+              <span className="flex-1 truncate text-[12px] font-medium text-foreground/90">
                 {thread.workspaceLabel ?? thread.workspaceId}
               </span>
               {unread > 0 && (
-                <span className="shrink-0 min-w-[15px] h-[15px] px-1 rounded-full bg-accent text-bg text-[9px] font-semibold tabular-nums flex items-center justify-center">
+                <span className="shrink-0 min-w-[15px] h-[15px] px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-semibold tabular-nums flex items-center justify-center">
                   {unread}
                 </span>
               )}
-              <span className="shrink-0 text-[10px] text-text-muted/50 tabular-nums">
+              <span className="shrink-0 text-[10px] text-muted-foreground/50 tabular-nums">
                 {formatRelativeTime(thread.latestTs)}
               </span>
             </div>
@@ -248,21 +248,21 @@ function ClusterRow({
           onClick()
         }
       }}
-      className={`group relative grid min-h-11 grid-cols-[auto_minmax(0,1fr)] gap-x-1.5 gap-y-0.5 pl-3 pr-3 py-1.5 cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
-        active ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary/50'
+      className={`group relative grid min-h-11 grid-cols-[auto_minmax(0,1fr)] gap-x-1.5 gap-y-0.5 pl-3 pr-3 py-1.5 cursor-pointer transition-colors outline-none focus-visible:bg-muted/70 ${
+        active ? 'bg-muted' : 'hover:bg-muted/50'
       }`}
     >
       {active && (
-        <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />
+        <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />
       )}
       <span
         aria-hidden
-        className={`mt-[7px] shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-accent' : 'bg-transparent'}`}
+        className={`mt-[7px] shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-primary' : 'bg-transparent'}`}
       />
-      <span className={`min-w-0 truncate text-[11px] leading-5 ${unread ? 'text-text-muted' : 'text-text-muted/70'}`}>
+      <span className={`min-w-0 truncate text-[11px] leading-5 ${unread ? 'text-muted-foreground' : 'text-muted-foreground/70'}`}>
         {previewForEntry(entry)}
       </span>
-      <span className="col-start-2 text-[10px] text-text-muted/50 tabular-nums">
+      <span className="col-start-2 text-[10px] text-muted-foreground/50 tabular-nums">
         {formatRelativeTime(entry.ts)}
       </span>
     </div>
@@ -286,7 +286,7 @@ function TimeView({
     <>
       {groups.map(([bucket, items]) => (
         <div key={bucket} className="mb-1">
-          <div className="px-3 mt-2 mb-1 text-[10px] font-medium text-text-muted/60 uppercase tracking-wider">
+          <div className="px-3 mt-2 mb-1 text-[10px] font-medium text-muted-foreground/60 uppercase tracking-wider">
             {t(BUCKET_KEYS[bucket])}
           </div>
           <div className="flex flex-col">
@@ -327,30 +327,30 @@ function TimeRow({
           onClick()
         }
       }}
-      className={`group relative flex min-h-14 flex-col gap-0.5 px-3 py-2 cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary/70 ${
-        active ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary/50'
+      className={`group relative flex min-h-14 flex-col gap-0.5 px-3 py-2 cursor-pointer transition-colors outline-none focus-visible:bg-muted/70 ${
+        active ? 'bg-muted' : 'hover:bg-muted/50'
       }`}
     >
       {active && (
-        <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />
+        <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />
       )}
 
       {/* Line 1: unread dot · workspace · time */}
       <div className="flex items-center gap-1.5">
         <span
           aria-hidden
-          className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-accent' : 'bg-transparent'}`}
+          className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-primary' : 'bg-transparent'}`}
         />
-        <span className={`flex-1 truncate text-[12px] ${unread ? 'font-medium text-text' : 'text-text'}`}>
+        <span className={`flex-1 truncate text-[12px] ${unread ? 'font-medium text-foreground' : 'text-foreground'}`}>
           {entry.workspaceLabel ?? entry.workspaceId}
         </span>
-        <span className="shrink-0 text-[10px] text-text-muted/60 tabular-nums">
+        <span className="shrink-0 text-[10px] text-muted-foreground/60 tabular-nums">
           {formatRelativeTime(entry.ts)}
         </span>
       </div>
 
       {/* Line 2: preview */}
-      <div className={`pl-3 text-[11px] truncate ${unread ? 'text-text-muted' : 'text-text-muted/70'}`}>
+      <div className={`pl-3 text-[11px] truncate ${unread ? 'text-muted-foreground' : 'text-muted-foreground/70'}`}>
         {previewForEntry(entry)}
       </div>
     </div>

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -40,10 +40,10 @@ import { CenteredLoading } from './StateViews'
 // Run-status pill tints — mirrors AutomationRunsSection's STATUS_STYLE so the
 // Issue's independent operational history stays consistent with Automation.
 const RUN_STATUS_STYLE: Record<HeadlessTaskStatus, string> = {
-  running: 'bg-blue-500/15 text-blue-400',
-  done: 'bg-emerald-500/15 text-emerald-400',
-  failed: 'bg-red-500/15 text-red-400',
-  interrupted: 'bg-amber-500/15 text-amber-400',
+  running: 'bg-info/15 text-info',
+  done: 'bg-success/15 text-success',
+  failed: 'bg-destructive/15 text-destructive',
+  interrupted: 'bg-warning/15 text-warning',
 }
 
 // Dropdown ordering for the editable Properties rail. Mirrors the board's
@@ -54,7 +54,7 @@ const PRIORITY_OPTIONS: IssuePriority[] = ['urgent', 'high', 'medium', 'low', 'n
 // Shared compact control styling for the rail's selects / inline input — the
 // settings `inputClass`, trimmed for the narrow rail.
 const railControl =
-  'min-w-0 flex-1 rounded-md border border-border bg-bg px-2 py-1 text-[13px] text-text outline-none transition-colors focus:border-accent/60 focus:shadow-[0_0_0_1px_var(--color-accent-dim)] disabled:cursor-not-allowed disabled:opacity-50'
+  'min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 text-[13px] text-foreground outline-none transition-colors focus:border-primary/60 focus:shadow-[0_0_0_1px_var(--primary-muted)] disabled:cursor-not-allowed disabled:opacity-50'
 
 const CONFIGURABLE_AGENTS: readonly AgentId[] = ['claude', 'codex', 'opencode', 'pi']
 
@@ -75,8 +75,8 @@ function fmtDuration(ms?: number): string {
 function PropRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex items-start justify-between gap-3 py-2">
-      <span className="shrink-0 text-xs text-muted">{label}</span>
-      <div className="min-w-0 text-right text-[13px] text-text">{children}</div>
+      <span className="shrink-0 text-xs text-muted-foreground">{label}</span>
+      <div className="min-w-0 text-right text-[13px] text-foreground">{children}</div>
     </div>
   )
 }
@@ -85,7 +85,7 @@ function PropRow({ label, children }: { label: string; children: ReactNode }) {
 function EditRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex items-center justify-between gap-3 py-2">
-      <span className="shrink-0 text-xs text-muted">{label}</span>
+      <span className="shrink-0 text-xs text-muted-foreground">{label}</span>
       <div className="flex min-w-0 flex-1 items-center justify-end gap-1.5">{children}</div>
     </div>
   )
@@ -210,7 +210,7 @@ function AgentEditor({
         }}
         title={canConfigure ? `Configure ${effectiveAgent}` : 'No configurable runtime selected'}
         aria-label={canConfigure ? `Configure ${effectiveAgent}` : 'No configurable runtime selected'}
-        className="shrink-0 rounded-md border border-border bg-bg px-2 py-1 text-muted transition-colors hover:border-accent/50 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+        className="shrink-0 rounded-md border border-border bg-background px-2 py-1 text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
       >
         <Settings size={14} aria-hidden />
       </button>
@@ -228,9 +228,9 @@ function PropertySection({
   children: ReactNode
 }) {
   return (
-    <section className="rounded-lg border border-border bg-bg p-3">
-      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted/70">{title}</h3>
-      {description && <p className="mt-1 text-[11px] leading-snug text-muted">{description}</p>}
+    <section className="rounded-lg border border-border bg-background p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/70">{title}</h3>
+      {description && <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{description}</p>}
       <div className="mt-2 divide-y divide-border/60">{children}</div>
     </section>
   )
@@ -343,13 +343,13 @@ function PropertiesRail({
             </EditRow>
           )}
           {agentNeedsCredential && (
-            <p className="py-2 text-right text-[11px] leading-snug text-amber-400">AI credential missing.</p>
+            <p className="py-2 text-right text-[11px] leading-snug text-warning">AI credential missing.</p>
           )}
           {issue.automationHealth && (
             <PropRow label="Health">
               <div className="flex flex-col items-end gap-1">
                 <AutomationHealthPill health={issue.automationHealth} />
-                <span className="max-w-44 text-[11px] leading-snug text-muted">
+                <span className="max-w-44 text-[11px] leading-snug text-muted-foreground">
                   {issue.automationHealth.message}
                 </span>
                 {canRetry && (
@@ -357,7 +357,7 @@ function PropertiesRail({
                     type="button"
                     disabled={retrying}
                     onClick={onRetry}
-                    className="oa-pressable mt-1 inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-[11px] font-medium text-amber-400 transition-colors hover:border-amber-500/60 hover:bg-amber-500/15 disabled:cursor-wait disabled:opacity-50"
+                    className="oa-pressable mt-1 inline-flex items-center gap-1.5 rounded-md border border-warning/30 bg-warning/10 px-2.5 py-1.5 text-[11px] font-medium text-warning transition-colors hover:border-warning/60 hover:bg-warning/15 disabled:cursor-wait disabled:opacity-50"
                   >
                     <RotateCcw size={12} aria-hidden />
                     {retrying ? 'Retrying…' : 'Retry now'}
@@ -367,15 +367,15 @@ function PropertiesRail({
             </PropRow>
           )}
           <PropRow label="Last run">
-            {issue.lastFiredAtMs ? formatRelativeTime(issue.lastFiredAtMs) : <span className="text-muted">never</span>}
+            {issue.lastFiredAtMs ? formatRelativeTime(issue.lastFiredAtMs) : <span className="text-muted-foreground">never</span>}
           </PropRow>
           <PropRow label="Next run">
-            {issue.nextDueAtMs ? formatRelativeTime(issue.nextDueAtMs) : <span className="text-muted">—</span>}
+            {issue.nextDueAtMs ? formatRelativeTime(issue.nextDueAtMs) : <span className="text-muted-foreground">—</span>}
           </PropRow>
           </>
         )}
       </PropertySection>
-      {error && <p className="mt-2 text-[11px] leading-snug text-red-400">{error}</p>}
+      {error && <p className="mt-2 text-[11px] leading-snug text-destructive">{error}</p>}
     </aside>
   )
 }
@@ -420,7 +420,7 @@ function CommentComposer({
   }, [text, sending, wsId, id, onPosted])
 
   return (
-    <div className="rounded-xl border border-border bg-bg px-3 py-3 shadow-sm transition-colors focus-within:border-accent/45">
+    <div className="rounded-xl border border-border bg-background px-3 py-3 shadow-sm transition-colors focus-within:border-primary/45">
       <textarea
         rows={3}
         value={text}
@@ -433,13 +433,13 @@ function CommentComposer({
             void submit()
           }
         }}
-        className="min-h-20 w-full resize-y bg-transparent px-1 py-1 text-[13px] leading-relaxed text-text outline-none placeholder:text-muted/60 disabled:opacity-50"
+        className="min-h-20 w-full resize-y bg-transparent px-1 py-1 text-[13px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/60 disabled:opacity-50"
       />
-      {error && <p className="mt-1.5 text-xs text-red-400">{error}</p>}
+      {error && <p className="mt-1.5 text-xs text-destructive">{error}</p>}
       <div className="mt-2 flex flex-wrap items-center justify-between gap-2 border-t border-border/60 pt-2">
-        <p className="min-w-0 flex-1 basis-full break-words text-[11px] leading-snug text-muted sm:basis-auto">
+        <p className="min-w-0 flex-1 basis-full break-words text-[11px] leading-snug text-muted-foreground sm:basis-auto">
           {ownerResumeId
-            ? <>The assigned Session <span className="font-mono text-text/75">@{ownerResumeId}</span> will reply here.</>
+            ? <>The assigned Session <span className="font-mono text-foreground/75">@{ownerResumeId}</span> will reply here.</>
             : assignee === '@new'
               ? 'The first scheduled run will assign a Session; until then this is a timeline note.'
               : 'No fixed Session owner — this comment is recorded as a timeline note.'}
@@ -448,7 +448,7 @@ function CommentComposer({
           type="button"
           onClick={() => void submit()}
           disabled={sending || text.trim().length === 0}
-          className="oa-pressable rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-bg transition-colors hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-40"
+          className="oa-pressable rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-40"
         >
           {sending ? 'Sending…' : ownerResumeId ? 'Comment & notify' : 'Comment'}
         </button>
@@ -471,8 +471,8 @@ function WhatEditor({
   return (
     <section className="mt-4 border-t border-border/60 pt-4">
       <div className="mb-2">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted/80">What</h2>
-        <p className="mt-1 text-[11px] leading-snug text-muted/65">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">What</h2>
+        <p className="mt-1 text-[11px] leading-snug text-muted-foreground/65">
           {scheduled ? 'This exact markdown is sent to the agent on every scheduled run.' : 'The canonical markdown definition of this work item.'}
         </p>
       </div>
@@ -488,40 +488,40 @@ function RunRow({ run, onOpen }: { run: IssueRunRecord; onOpen: (run: IssueRunRe
     ? 'interrupted'
     : run.status
   return (
-    <li className="min-w-0 overflow-hidden rounded-lg border border-border bg-bg-secondary px-3 py-2.5">
+    <li className="min-w-0 overflow-hidden rounded-lg border border-border bg-secondary px-3 py-2.5">
       <div className="flex flex-wrap items-center gap-2">
         <span
           className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium ${RUN_STATUS_STYLE[displayStatus]}`}
         >
           {displayStatus}
         </span>
-        <span className="text-xs text-muted">{run.agent}</span>
-        <span className="ml-auto text-xs text-muted" title={new Date(run.startedAt).toLocaleString()}>
+        <span className="text-xs text-muted-foreground">{run.agent}</span>
+        <span className="ml-auto text-xs text-muted-foreground" title={new Date(run.startedAt).toLocaleString()}>
           {formatRelativeTime(run.startedAt)}
         </span>
-        <span className="text-xs text-muted/70">· {fmtDuration(run.durationMs)}</span>
+        <span className="text-xs text-muted-foreground/70">· {fmtDuration(run.durationMs)}</span>
         <button
           type="button"
           onClick={() => onOpen(run)}
           disabled={!run.resumable || run.status === 'running'}
           title={run.resumable ? 'Open the Session behind this run' : 'This run did not capture a resumable Session'}
-          className="rounded-md border border-border px-2 py-1 text-[11px] text-muted transition-colors hover:border-accent/50 hover:text-text disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
         >
           Open conversation
         </button>
       </div>
       {run.prompt && (
-        <p className="mt-1.5 line-clamp-2 text-[12px] leading-snug text-text/80" title={run.prompt}>
+        <p className="mt-1.5 line-clamp-2 text-[12px] leading-snug text-foreground/80" title={run.prompt}>
           {run.prompt}
         </p>
       )}
       {run.output?.assistantPreview && (
-        <p className="mt-1.5 line-clamp-2 border-l-2 border-accent/25 pl-2 text-[12px] leading-snug text-muted" title={run.output.assistantPreview}>
+        <p className="mt-1.5 line-clamp-2 border-l-2 border-primary/25 pl-2 text-[12px] leading-snug text-muted-foreground" title={run.output.assistantPreview}>
           {run.output.assistantPreview}
         </p>
       )}
       {run.output && (run.output.toolCalls > 0 || run.output.toolFailures > 0) && (
-        <p className={`mt-1 text-[11px] ${run.output.toolFailures > 0 ? 'text-red-400' : 'text-muted/60'}`}>
+        <p className={`mt-1 text-[11px] ${run.output.toolFailures > 0 ? 'text-destructive' : 'text-muted-foreground/60'}`}>
           {run.output.toolCalls} tool {run.output.toolCalls === 1 ? 'call' : 'calls'}
           {run.output.toolFailures > 0 ? ` · ${run.output.toolFailures} failed` : ''}
         </p>
@@ -529,20 +529,20 @@ function RunRow({ run, onOpen }: { run: IssueRunRecord; onOpen: (run: IssueRunRe
       {run.failure && (
         <div className={`mt-2 rounded-md border px-2.5 py-2 ${
           run.failure.kind === 'system_paused' || run.failure.kind === 'launcher_restarted'
-            ? 'border-amber-500/25 bg-amber-500/10'
-            : 'border-red-500/25 bg-red-500/10'
+            ? 'border-warning/25 bg-warning/10'
+            : 'border-destructive/25 bg-destructive/10'
         }`}>
           <p className={`text-[12px] font-medium ${
             run.failure.kind === 'system_paused' || run.failure.kind === 'launcher_restarted'
-              ? 'text-amber-400'
-              : 'text-red-400'
+              ? 'text-warning'
+              : 'text-destructive'
           }`}>
             {run.failure.title}
           </p>
-          <p className="mt-0.5 text-[11px] leading-snug text-muted">{run.failure.message}</p>
+          <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{run.failure.message}</p>
         </div>
       )}
-      {run.error && <p className="mt-1 text-[12px] text-red-400">{run.error}</p>}
+      {run.error && <p className="mt-1 text-[12px] text-destructive">{run.error}</p>}
     </li>
   )
 }
@@ -566,7 +566,7 @@ function InboxReportsSection({
   if (reports.length === 0) return null
   return (
     <section className="mt-8">
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted/70">Inbox reports</h3>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground/70">Inbox reports</h3>
       <ul className="space-y-2">
         {reports.map((entry) => (
           <li key={entry.id}>
@@ -574,14 +574,14 @@ function InboxReportsSection({
               type="button"
               onClick={() => onOpen(entry.id)}
               title="Open in Inbox"
-              className="group flex w-full items-center gap-2.5 rounded-lg border border-border bg-bg-secondary px-3 py-2.5 text-left transition-colors hover:border-accent/40 hover:bg-bg-tertiary"
+              className="group flex w-full items-center gap-2.5 rounded-lg border border-border bg-secondary px-3 py-2.5 text-left transition-colors hover:border-primary/40 hover:bg-muted"
             >
-              <Inbox size={14} className="shrink-0 text-muted/70 transition-colors group-hover:text-accent" aria-hidden />
-              <span className="min-w-0 flex-1 truncate text-[12px] text-text/80">
+              <Inbox size={14} className="shrink-0 text-muted-foreground/70 transition-colors group-hover:text-primary" aria-hidden />
+              <span className="min-w-0 flex-1 truncate text-[12px] text-foreground/80">
                 {previewForEntry(entry) || '(empty push)'}
               </span>
               <span
-                className="ml-auto shrink-0 text-xs text-muted"
+                className="ml-auto shrink-0 text-xs text-muted-foreground"
                 title={new Date(entry.ts).toLocaleString()}
               >
                 {formatRelativeTime(entry.ts)}
@@ -685,11 +685,11 @@ function IssueActivity({
   return (
     <section className="mt-8">
       <div className="mb-3 flex items-baseline justify-between gap-3 border-t border-border/60 pt-5">
-        <h2 className="text-sm font-semibold text-text">Activity</h2>
-        <span className="hidden text-[11px] text-muted sm:inline">Changes and conversation</span>
+        <h2 className="text-sm font-semibold text-foreground">Activity</h2>
+        <span className="hidden text-[11px] text-muted-foreground sm:inline">Changes and conversation</span>
       </div>
       {activity.length === 0 ? (
-        <p className="mb-3 rounded-lg border border-dashed border-border px-4 py-4 text-center text-xs text-muted">
+        <p className="mb-3 rounded-lg border border-dashed border-border px-4 py-4 text-center text-xs text-muted-foreground">
           No changes or comments have been recorded yet.
         </p>
       ) : (
@@ -700,25 +700,25 @@ function IssueActivity({
               const delivery = comment.delivery
               return (
                 <li key={`comment:${comment.id}`} className="relative pl-8">
-                  <span className="absolute left-[3px] top-3 z-10 grid h-[18px] w-[18px] place-items-center rounded-full border border-border bg-bg text-accent">
+                  <span className="absolute left-[3px] top-3 z-10 grid h-[18px] w-[18px] place-items-center rounded-full border border-border bg-background text-primary">
                     <MessageSquare size={10} aria-hidden />
                   </span>
-                  <article className={`rounded-xl border bg-bg-secondary px-4 py-3 ${comment.replyTo ? 'ml-3 border-accent/25' : 'border-border'}`}>
-                    <div className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted">
-                      <span className="font-medium text-text/85">{comment.author}</span>
-                      {comment.replyTo && <span className="rounded bg-bg-tertiary px-1.5 py-0.5">reply</span>}
+                  <article className={`rounded-xl border bg-secondary px-4 py-3 ${comment.replyTo ? 'ml-3 border-primary/25' : 'border-border'}`}>
+                    <div className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+                      <span className="font-medium text-foreground/85">{comment.author}</span>
+                      {comment.replyTo && <span className="rounded bg-muted px-1.5 py-0.5">reply</span>}
                       <time className="ml-auto" dateTime={comment.at} title={new Date(comment.at).toLocaleString()}>
                         {formatRelativeTime(item.at)}
                       </time>
                     </div>
                     <MarkdownContent text={comment.markdown} />
                     {delivery?.state === 'pending' && (
-                      <p className="mt-3 border-t border-border/60 pt-2 text-[11px] text-muted">
-                        Waiting for <span className="font-mono text-text/75">@{delivery.targetResumeId}</span> to reply…
+                      <p className="mt-3 border-t border-border/60 pt-2 text-[11px] text-muted-foreground">
+                        Waiting for <span className="font-mono text-foreground/75">@{delivery.targetResumeId}</span> to reply…
                       </p>
                     )}
                     {delivery?.state === 'failed' && (
-                      <p className="mt-3 rounded-md border border-amber-500/25 bg-amber-500/10 px-2.5 py-2 text-[11px] leading-snug text-amber-400">
+                      <p className="mt-3 rounded-md border border-warning/25 bg-warning/10 px-2.5 py-2 text-[11px] leading-snug text-warning">
                         The comment is saved, but the owner could not be reached: {delivery.error}
                       </p>
                     )}
@@ -738,17 +738,17 @@ function IssueActivity({
                   : unknownOriginLabel(origin.reason)
             return (
               <li key={`provenance:${record.id}`} className="relative flex min-w-0 items-start gap-2.5 py-1 pl-8">
-                <span className="absolute left-[3px] top-2 z-10 grid h-[18px] w-[18px] place-items-center rounded-full border border-border bg-bg text-muted">
+                <span className="absolute left-[3px] top-2 z-10 grid h-[18px] w-[18px] place-items-center rounded-full border border-border bg-background text-muted-foreground">
                   <History size={10} aria-hidden />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <p className="text-[12px] text-muted">
-                    <span className="font-medium text-text/80">{originLabel}</span>{' '}
+                  <p className="text-[12px] text-muted-foreground">
+                    <span className="font-medium text-foreground/80">{originLabel}</span>{' '}
                     {PROVENANCE_ACTION_LABEL[record.action]} ·{' '}
                     <span title={new Date(record.at).toLocaleString()}>{formatRelativeTime(record.at)}</span>
                   </p>
                   {record.mutation && (
-                    <ul className="mt-1 space-y-0.5 text-[11px] leading-relaxed text-muted/80">
+                    <ul className="mt-1 space-y-0.5 text-[11px] leading-relaxed text-muted-foreground/80">
                       {record.mutation.fields.map((change) => (
                         <li key={change.field}>{mutationSummary(change)}</li>
                       ))}
@@ -760,7 +760,7 @@ function IssueActivity({
                     type="button"
                     onClick={() => void continueSession(record)}
                     disabled={continuingId !== null}
-                    className="oa-pressable shrink-0 rounded-md border border-border px-2 py-1 text-[11px] text-muted transition-colors hover:border-accent/50 hover:text-text disabled:cursor-wait disabled:opacity-50"
+                    className="oa-pressable shrink-0 rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:cursor-wait disabled:opacity-50"
                   >
                     {continuingId === record.id ? 'Opening…' : 'Continue'}
                   </button>
@@ -770,7 +770,7 @@ function IssueActivity({
           })}
         </ul>
       )}
-      {continueError && <p className="mt-2 text-xs text-red-400">Could not continue Session: {continueError}</p>}
+      {continueError && <p className="mt-2 text-xs text-destructive">Could not continue Session: {continueError}</p>}
       <CommentComposer
         wsId={wsId}
         id={issueId}
@@ -793,13 +793,13 @@ function RunsSection({
   if (runs.length === 0) return null
   const visible = expanded ? runs : runs.slice(0, 4)
   return (
-    <section className="mt-8 rounded-xl border border-border bg-bg-secondary/45 px-3 py-3 sm:px-4">
+    <section className="mt-8 rounded-xl border border-border bg-secondary/45 px-3 py-3 sm:px-4">
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
-          <h2 className="text-sm font-semibold text-text">Runs</h2>
-          <p className="mt-0.5 text-[11px] text-muted">Operational execution history</p>
+          <h2 className="text-sm font-semibold text-foreground">Runs</h2>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">Operational execution history</p>
         </div>
-        <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-[11px] text-muted">{runs.length}</span>
+        <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">{runs.length}</span>
       </div>
       <ul className="space-y-2">
         {visible.map((run) => <RunRow key={run.taskId} run={run} onOpen={onOpen} />)}
@@ -808,7 +808,7 @@ function RunsSection({
         <button
           type="button"
           onClick={() => setExpanded((value) => !value)}
-          className="oa-pressable mt-3 w-full rounded-md px-3 py-2 text-xs text-muted transition-colors hover:bg-bg-tertiary hover:text-text"
+          className="oa-pressable mt-3 w-full rounded-md px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         >
           {expanded ? 'Show recent runs' : `Show ${runs.length - 4} more runs`}
         </button>
@@ -842,26 +842,26 @@ function WikilinkPicker({
     <div
       role="presentation"
       onClick={onClose}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-backdrop p-4"
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-sm rounded-lg border border-border bg-bg-secondary p-4 shadow-xl"
+        className="w-full max-w-sm rounded-lg border border-border bg-secondary p-4 shadow-xl"
       >
         <div className="mb-1 flex items-start justify-between gap-2">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted/70">
-            <span className="font-mono normal-case text-text">[[{resolution.name}]]</span> matches several
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/70">
+            <span className="font-mono normal-case text-foreground">[[{resolution.name}]]</span> matches several
           </h3>
           <button
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="-mr-1 -mt-0.5 shrink-0 rounded p-0.5 text-muted transition-colors hover:text-text"
+            className="-mr-1 -mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
           >
             <X size={14} />
           </button>
         </div>
-        <p className="mb-3 text-[12px] leading-snug text-muted">
+        <p className="mb-3 text-[12px] leading-snug text-muted-foreground">
           This name is a global handle pointing at more than one thing — pick the one you meant.
         </p>
         <ul className="space-y-1.5">
@@ -871,13 +871,13 @@ function WikilinkPicker({
                 type="button"
                 onClick={() => onEntity(resolution.entity!.name)}
                 title={`Open tracked entity ${resolution.entity.name}`}
-                className="group flex w-full items-center gap-2.5 rounded-lg border border-border bg-bg-tertiary/30 px-3 py-2 text-left transition-colors hover:border-accent/40 hover:bg-bg-tertiary"
+                className="group flex w-full items-center gap-2.5 rounded-lg border border-border bg-muted/30 px-3 py-2 text-left transition-colors hover:border-primary/40 hover:bg-muted"
               >
-                <EntityIcon size={14} className="shrink-0 text-muted/70 transition-colors group-hover:text-accent" aria-hidden />
-                <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-text">
+                <EntityIcon size={14} className="shrink-0 text-muted-foreground/70 transition-colors group-hover:text-primary" aria-hidden />
+                <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground">
                   {resolution.entity.name}
                 </span>
-                <span className="shrink-0 rounded-full bg-bg-tertiary px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted">
+                <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
                   {resolution.entity.type}
                 </span>
               </button>
@@ -889,12 +889,12 @@ function WikilinkPicker({
                 type="button"
                 onClick={() => onIssue(iss)}
                 title={`Open ${iss.id} in ${iss.wsTag}`}
-                className="group flex w-full items-center gap-2.5 rounded-lg border border-border bg-bg-tertiary/30 px-3 py-2 text-left transition-colors hover:border-accent/40 hover:bg-bg-tertiary"
+                className="group flex w-full items-center gap-2.5 rounded-lg border border-border bg-muted/30 px-3 py-2 text-left transition-colors hover:border-primary/40 hover:bg-muted"
               >
-                <ListChecks size={14} className="shrink-0 text-muted/70 transition-colors group-hover:text-accent" aria-hidden />
-                <span className="min-w-0 flex-1 truncate text-[12px] text-text">{iss.title}</span>
+                <ListChecks size={14} className="shrink-0 text-muted-foreground/70 transition-colors group-hover:text-primary" aria-hidden />
+                <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">{iss.title}</span>
                 <span
-                  className="shrink-0 rounded-full bg-bg-tertiary px-2 py-0.5 text-[11px] text-muted"
+                  className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground"
                   title={`Workspace: ${iss.wsTag} (${iss.wsId.slice(0, 8)})`}
                 >
                   {iss.wsTag}
@@ -1091,7 +1091,7 @@ export function IssueDetail({
         setSidebar('issue')
         openOrFocus({ kind: 'issue', params: {} })
       }}
-      className="mb-4 inline-flex items-center gap-1.5 text-xs text-muted transition-colors hover:text-text"
+      className="mb-4 inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
     >
       <ArrowLeft size={13} /> {backLabel}
     </button>
@@ -1108,10 +1108,10 @@ export function IssueDetail({
         {loading ? (
           <CenteredLoading />
         ) : (
-          <div className="rounded-lg border border-border bg-bg-secondary px-6 py-12 text-center">
-            <ListChecks size={24} className="mx-auto text-muted/50" />
-            <p className="mt-3 text-sm text-red-400">Failed to load issue: {error}</p>
-            <p className="mt-1 font-mono text-xs text-muted/70">
+          <div className="rounded-lg border border-border bg-secondary px-6 py-12 text-center">
+            <ListChecks size={24} className="mx-auto text-muted-foreground/50" />
+            <p className="mt-3 text-sm text-destructive">Failed to load issue: {error}</p>
+            <p className="mt-1 font-mono text-xs text-muted-foreground/70">
               {wsId.slice(0, 8)} / {id}
             </p>
           </div>
@@ -1147,10 +1147,10 @@ export function IssueDetail({
       <div className="grid min-w-0 gap-6 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
         <main className="min-w-0 lg:col-start-1 lg:row-start-1">
           <div className="mb-1 flex items-center gap-2">
-            <span className="font-mono text-[11px] text-muted/70">{id}</span>
+            <span className="font-mono text-[11px] text-muted-foreground/70">{id}</span>
             {issue.when && <CadencePill when={issue.when} />}
           </div>
-          <h1 className="text-xl font-semibold text-text">{issue.title}</h1>
+          <h1 className="text-xl font-semibold text-foreground">{issue.title}</h1>
           <WhatEditor
             key={`${wsId}:${id}`}
             value={issue.what}

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -133,37 +133,37 @@ export function CadencePill({ when }: { when: ScheduleWhen }) {
   return (
     <span
       title={cadenceTitle(when)}
-      className="inline-flex shrink-0 items-center gap-1 rounded-full bg-bg-tertiary px-2 py-0.5 text-[11px] font-medium text-muted"
+      className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
     >
-      <Clock size={10} className="text-muted/70" />
+      <Clock size={10} className="text-muted-foreground/70" />
       {cadenceLabel(when)}
       {when.kind === 'cron' && (
-        <span className="text-muted/70">· {when.timezone ?? 'local'}</span>
+        <span className="text-muted-foreground/70">· {when.timezone ?? 'local'}</span>
       )}
     </span>
   )
 }
 
 const AUTOMATION_HEALTH_META: Record<IssueAutomationHealthState, { label: string; className: string }> = {
-  inactive: { label: 'Inactive', className: 'bg-bg-tertiary text-muted' },
-  not_started: { label: 'Not started', className: 'bg-bg-tertiary text-muted' },
-  due: { label: 'Due', className: 'bg-amber-500/15 text-amber-400' },
-  running: { label: 'Running', className: 'bg-blue-500/15 text-blue-400' },
-  healthy: { label: 'Healthy', className: 'bg-emerald-500/15 text-emerald-400' },
-  interrupted: { label: 'Interrupted', className: 'bg-amber-500/15 text-amber-400' },
-  failed: { label: 'Failed', className: 'bg-red-500/15 text-red-400' },
-  blocked: { label: 'Blocked', className: 'bg-red-500/15 text-red-400' },
+  inactive: { label: 'Inactive', className: 'bg-muted text-muted-foreground' },
+  not_started: { label: 'Not started', className: 'bg-muted text-muted-foreground' },
+  due: { label: 'Due', className: 'bg-warning/15 text-warning' },
+  running: { label: 'Running', className: 'bg-info/15 text-info' },
+  healthy: { label: 'Healthy', className: 'bg-success/15 text-success' },
+  interrupted: { label: 'Interrupted', className: 'bg-warning/15 text-warning' },
+  failed: { label: 'Failed', className: 'bg-destructive/15 text-destructive' },
+  blocked: { label: 'Blocked', className: 'bg-destructive/15 text-destructive' },
 }
 
 const BOARD_HEALTH_CLASS: Record<IssueAutomationHealthState, string> = {
-  inactive: 'text-muted/70',
-  not_started: 'text-muted/70',
-  due: 'text-amber-400',
-  running: 'text-blue-400',
-  healthy: 'text-emerald-500/85',
-  interrupted: 'rounded-md bg-amber-500/15 px-2 py-1 text-amber-400',
-  failed: 'rounded-md bg-red-500/15 px-2 py-1 text-red-400',
-  blocked: 'rounded-md bg-red-500/15 px-2 py-1 text-red-400',
+  inactive: 'text-muted-foreground/70',
+  not_started: 'text-muted-foreground/70',
+  due: 'text-warning',
+  running: 'text-info',
+  healthy: 'text-success/85',
+  interrupted: 'rounded-md bg-warning/15 px-2 py-1 text-warning',
+  failed: 'rounded-md bg-destructive/15 px-2 py-1 text-destructive',
+  blocked: 'rounded-md bg-destructive/15 px-2 py-1 text-destructive',
 }
 
 export function AutomationHealthPill({ health }: { health: IssueAutomationHealth }) {
@@ -192,7 +192,7 @@ export function PriorityIndicator({ priority }: { priority: IssuePriority }) {
       <span
         title="Urgent"
         aria-label="Urgent priority"
-        className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] bg-amber-500 text-[10px] font-bold leading-none text-black"
+        className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] bg-warning text-[10px] font-bold leading-none text-warning-foreground"
       >
         !
       </span>
@@ -337,7 +337,7 @@ function BoardHealth({ issue }: { issue: IssueListItem }) {
     >
       <span className={`h-1.5 w-1.5 rounded-full bg-current ${active ? 'animate-pulse' : ''}`} aria-hidden />
       {meta.label}
-      {lastRun && <span className="font-normal text-muted/55">· {lastRun}</span>}
+      {lastRun && <span className="font-normal text-muted-foreground/55">· {lastRun}</span>}
     </span>
   )
 }
@@ -348,11 +348,11 @@ function BoardCadence({ issue }: { issue: IssueListItem }) {
   return (
     <span
       title={cadenceTitle(issue.when)}
-      className="inline-flex min-w-0 items-center gap-1.5 text-[11px] text-muted/75"
+      className="inline-flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground/75"
     >
-      <Clock size={11} className="shrink-0 text-muted/55" aria-hidden />
+      <Clock size={11} className="shrink-0 text-muted-foreground/55" aria-hidden />
       <span className="truncate">{cadenceLabel(issue.when)}</span>
-      {nextRun && <span className="shrink-0 text-muted/50">· {nextRun}</span>}
+      {nextRun && <span className="shrink-0 text-muted-foreground/50">· {nextRun}</span>}
     </span>
   )
 }
@@ -379,7 +379,7 @@ function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: Board
         type="button"
         onClick={onOpen}
         title={`Open ${issue.id}`}
-        className={`oa-pressable flex w-full items-start gap-3 px-3.5 py-3 text-left transition-colors hover:bg-bg-tertiary/35 sm:px-4 ${
+        className={`oa-pressable flex w-full items-start gap-3 px-3.5 py-3 text-left transition-colors hover:bg-muted/35 sm:px-4 ${
           terminal ? 'opacity-60' : ''
         }`}
       >
@@ -389,7 +389,7 @@ function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: Board
 
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-2">
-            <span title={issue.title} className="min-w-0 truncate text-[13px] font-medium text-text sm:text-[13.5px]">
+            <span title={issue.title} className="min-w-0 truncate text-[13px] font-medium text-foreground sm:text-[13.5px]">
               {issue.title}
             </span>
             {issue.nameCollision && (
@@ -398,7 +398,7 @@ function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: Board
                   (dupOthers ?? 1) === 1 ? '' : 's'
                 }. A [[name]] is a global handle; resolve manually.`}
                 aria-label="Duplicate issue name across workspaces"
-                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-medium text-amber-400"
+                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-warning/10 px-1.5 py-0.5 text-[9px] font-medium text-warning"
               >
                 <Copy size={9} aria-hidden /> dup
               </span>
@@ -407,22 +407,22 @@ function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: Board
 
           <BoardAutomationSummary issue={issue} className="mt-2 lg:hidden" />
 
-          <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1 text-[10.5px] text-muted/60">
+          <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1 text-[10.5px] text-muted-foreground/60">
             <span className="truncate" title={`Workspace: ${wsTag} (${wsId.slice(0, 8)})`}>
               {wsTag}
             </span>
             {!titleMatchesId && (
-              <span className="hidden max-w-[14rem] truncate font-mono text-muted/45 sm:inline" title={`Issue ID: ${issue.id}`}>
+              <span className="hidden max-w-[14rem] truncate font-mono text-muted-foreground/45 sm:inline" title={`Issue ID: ${issue.id}`}>
                 #{issue.id}
               </span>
             )}
             {explicitAssignee && (
-              <span className="max-w-[14rem] truncate text-muted/70" title={`Assignee: ${issue.assignee}`}>
+              <span className="max-w-[14rem] truncate text-muted-foreground/70" title={`Assignee: ${issue.assignee}`}>
                 {assigneeLabel}
               </span>
             )}
             {explicitAgent && agentRuntime && (
-              <span className="inline-flex items-center gap-1 text-muted/70" title={`Agent runtime override: ${agentRuntime.displayName}`}>
+              <span className="inline-flex items-center gap-1 text-muted-foreground/70" title={`Agent runtime override: ${agentRuntime.displayName}`}>
                 <Bot size={10} aria-hidden /> {agentRuntime.id} override
               </span>
             )}
@@ -453,21 +453,21 @@ function StatusGroup({
 }) {
   const meta = STATUS_META[status]
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-bg-secondary">
+    <div className="overflow-hidden rounded-lg border border-border bg-secondary">
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={!collapsed}
-        className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-bg-tertiary/40"
+        className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-muted/40"
       >
         {collapsed ? (
-          <ChevronRight size={14} className="shrink-0 text-muted/70" />
+          <ChevronRight size={14} className="shrink-0 text-muted-foreground/70" />
         ) : (
-          <ChevronDown size={14} className="shrink-0 text-muted/70" />
+          <ChevronDown size={14} className="shrink-0 text-muted-foreground/70" />
         )}
         <meta.Icon size={14} className={`shrink-0 ${meta.className}`} />
-        <span className="text-[13px] font-semibold text-text">{meta.label}</span>
-        <span className="text-xs text-muted">{rows.length}</span>
+        <span className="text-[13px] font-semibold text-foreground">{meta.label}</span>
+        <span className="text-xs text-muted-foreground">{rows.length}</span>
       </button>
       {!collapsed && (
         <ul className="divide-y divide-border/60 border-t border-border">
@@ -493,10 +493,10 @@ function InvalidWorkspaces({ workspaces }: { workspaces: IssueWorkspace[] }) {
       {workspaces.map((ws) => (
         <div
           key={ws.wsId}
-          className="rounded-lg border border-red-500/30 bg-red-500/[0.06] px-4 py-2.5 text-xs text-red-400"
+          className="rounded-lg border border-destructive/30 bg-destructive/[0.06] px-4 py-2.5 text-xs text-destructive"
         >
-          <span className="font-medium text-red-300">{ws.tag}</span>{' '}
-          <span className="font-mono text-red-400/70">{ws.wsId.slice(0, 8)}</span>
+          <span className="font-medium text-destructive">{ws.tag}</span>{' '}
+          <span className="font-mono text-destructive/70">{ws.wsId.slice(0, 8)}</span>
           <p className="mt-1 leading-relaxed">{ws.error ?? 'issues are unreadable for this workspace'}</p>
         </div>
       ))}
@@ -538,7 +538,7 @@ export function IssuesBoard() {
   // flipping to a loading/error screen on a transient refresh failure.
   if (!data) {
     if (loading) return <CenteredLoading />
-    return <div className="text-sm text-red-400">Failed to load issues: {error}</div>
+    return <div className="text-sm text-destructive">Failed to load issues: {error}</div>
   }
 
   // Defensive: tolerate a malformed/empty payload (e.g. the demo catchAll's
@@ -589,7 +589,7 @@ export function IssuesBoard() {
   })).filter((g) => g.rows.length > 0)
 
   const staleBanner = error ? (
-    <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-xs text-amber-400">
+    <div className="rounded-lg border border-warning/30 bg-warning/10 px-3 py-1.5 text-xs text-warning">
       Live refresh failing — showing the last known issues.
     </div>
   ) : null
@@ -599,14 +599,14 @@ export function IssuesBoard() {
       <div className="space-y-3">
         {staleBanner}
         <div className="rounded-lg border border-dashed border-border px-6 py-12 text-center">
-          <ListChecks size={24} className="mx-auto text-muted/50" />
-          <p className="mt-3 text-sm text-muted">No workspace has any issues yet.</p>
-          <p className="mt-1 text-xs text-muted/80">
+          <ListChecks size={24} className="mx-auto text-muted-foreground/50" />
+          <p className="mt-3 text-sm text-muted-foreground">No workspace has any issues yet.</p>
+          <p className="mt-1 text-xs text-muted-foreground/80">
             A workspace tracks an issue by writing{' '}
-            <code className="rounded bg-bg-tertiary px-1 py-0.5 font-mono text-[11px] text-text/80">
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground/80">
               .alice/issues/&lt;id&gt;.md
             </code>
-            . Add a <span className="text-text">when</span> field and it self-schedules.
+            . Add a <span className="text-foreground">when</span> field and it self-schedules.
           </p>
         </div>
       </div>

--- a/ui/src/components/LiveIndicator.tsx
+++ b/ui/src/components/LiveIndicator.tsx
@@ -30,9 +30,9 @@ export function LiveIndicator({ lastUpdated, hideDot, className }: LiveIndicator
   const ago = lastUpdated ? formatRelativeTime(lastUpdated) : '—'
 
   return (
-    <span className={`inline-flex items-center gap-1.5 text-[11px] text-text-muted ${className ?? ''}`}>
+    <span className={`inline-flex items-center gap-1.5 text-[11px] text-muted-foreground ${className ?? ''}`}>
       {!hideDot && (
-        <span className="relative inline-block w-1.5 h-1.5 rounded-full bg-green live-pulse" aria-hidden />
+        <span className="relative inline-block w-1.5 h-1.5 rounded-full bg-success live-pulse" aria-hidden />
       )}
       <span className="tabular-nums">updated {ago}</span>
     </span>

--- a/ui/src/components/MarkdownWhatEditor.tsx
+++ b/ui/src/components/MarkdownWhatEditor.tsx
@@ -160,10 +160,10 @@ export function MarkdownWhatEditor({ value, onSave }: MarkdownWhatEditorProps) {
 
   return (
     <div>
-      <div className="what-editor-shell rounded-lg border border-transparent transition-colors hover:border-border/40 focus-within:border-border/70 focus-within:bg-bg-secondary/20">
+      <div className="what-editor-shell rounded-lg border border-transparent transition-colors hover:border-border/40 focus-within:border-border/70 focus-within:bg-secondary/20">
         <EditorContent editor={editor} className="markdown-content what-editor-content" />
       </div>
-      <div aria-live="polite" className={`mt-1 min-h-4 text-right text-[11px] transition-opacity ${saveState === 'error' ? 'text-red-400' : 'text-muted/60'} ${status ? 'opacity-100' : 'opacity-0'}`}>
+      <div aria-live="polite" className={`mt-1 min-h-4 text-right text-[11px] transition-opacity ${saveState === 'error' ? 'text-destructive' : 'text-muted-foreground/60'} ${status ? 'opacity-100' : 'opacity-0'}`}>
         {status || '\u00a0'}
       </div>
     </div>

--- a/ui/src/components/MarketSidebar.tsx
+++ b/ui/src/components/MarketSidebar.tsx
@@ -10,16 +10,16 @@ import { SidebarSectionHeader } from './SidebarSectionHeader'
 import { Spinner } from './StateViews'
 
 const ASSET_CLASS_COLORS: Record<string, string> = {
-  equity: 'bg-accent/15 text-accent',
-  crypto: 'bg-amber-500/15 text-amber-400',
-  currency: 'bg-green/15 text-green',
-  commodity: 'bg-purple-500/15 text-purple-400',
-  unknown: 'bg-bg-tertiary text-text-muted',
+  equity: 'bg-primary/15 text-primary',
+  crypto: 'bg-warning/15 text-warning',
+  currency: 'bg-success/15 text-success',
+  commodity: 'bg-ai-action/15 text-ai-action',
+  unknown: 'bg-muted text-muted-foreground',
 }
 
 const CAPABILITY_COLOR: Record<string, string> = {
-  realtime: 'text-green', iex: 'text-accent', delayed: 'text-text-muted',
-  subscription: 'text-amber-700 dark:text-amber-300', free: 'text-text-muted',
+  realtime: 'text-success', iex: 'text-primary', delayed: 'text-muted-foreground',
+  subscription: 'text-warning', free: 'text-muted-foreground',
 }
 
 /** A crypto venue's "AAPL" is synthetic — the route segment still needs a valid
@@ -70,7 +70,7 @@ export function MarketSidebar() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t('market.searchPlaceholder')}
-          className="w-full px-2.5 py-1.5 bg-bg text-text border border-border/70 rounded-md text-[13px] outline-none focus:border-accent"
+          className="w-full px-2.5 py-1.5 bg-background text-foreground border border-border/70 rounded-md text-[13px] outline-none focus:border-primary"
         />
       </div>
 
@@ -134,13 +134,13 @@ export function MarketSidebar() {
               {t('market.searchResults')}{loading ? ` (${t('common.searching')})` : results.length ? ` (${results.length})` : ''}
             </SidebarSectionHeader>
             {loading && (
-              <div className="flex items-center gap-2 px-3 py-2 text-[12px] text-text-muted">
+              <div className="flex items-center gap-2 px-3 py-2 text-[12px] text-muted-foreground">
                 <Spinner size="sm" />
                 <span>{t('common.searching')}</span>
               </div>
             )}
             {!loading && results.length === 0 && (
-              <p className="px-3 py-2 text-[12px] leading-relaxed text-text-muted">{t('market.noMatches')}</p>
+              <p className="px-3 py-2 text-[12px] leading-relaxed text-muted-foreground">{t('market.noMatches')}</p>
             )}
             {results.map((c) => (
               <SidebarRow
@@ -148,7 +148,7 @@ export function MarketSidebar() {
                 label={
                   <span className="flex items-center gap-1.5 min-w-0">
                     <span className="font-mono font-semibold shrink-0">{c.symbol}</span>
-                    {c.name && <span className="text-text-muted truncate">{c.name}</span>}
+                    {c.name && <span className="text-muted-foreground truncate">{c.name}</span>}
                   </span>
                 }
                 active={isFocusedDetail(routeAssetClass(c.assetClass), c.symbol, c.barId)}
@@ -162,7 +162,7 @@ export function MarketSidebar() {
         {/* Watchlist */}
         <SidebarSectionHeader>{t('market.watchlist')}{watchlist.length ? ` (${watchlist.length})` : ''}</SidebarSectionHeader>
         {watchlist.length === 0 ? (
-          <p className="px-3 py-2 text-[12px] leading-relaxed text-text-muted">
+          <p className="px-3 py-2 text-[12px] leading-relaxed text-muted-foreground">
             {t('market.emptyWatchlistHint')}
           </p>
         ) : (
@@ -186,7 +186,7 @@ export function MarketSidebar() {
                       e.stopPropagation()
                       removeFromWatchlist(entry.assetClass, entry.symbol)
                     }}
-                    className="flex h-4 w-4 items-center justify-center rounded text-text-muted opacity-0 hover:bg-bg-tertiary hover:text-text group-hover:opacity-100"
+                    className="flex h-4 w-4 items-center justify-center rounded text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground group-hover:opacity-100"
                     aria-label={t('market.removeFromWatchlist', { symbol: entry.symbol })}
                   >
                     <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
@@ -218,9 +218,9 @@ function SourceTrail({ c }: { c: BarSourceCandidate }) {
   // crushed. (Asset class is shown in the wider main search box, not here.)
   return (
     <span className="flex items-center gap-1 shrink-0" title={`${c.barId}${c.barCapability ? ` · ${c.barCapability}` : ''}`}>
-      <span className="text-[10px] text-text/75 font-medium truncate max-w-[96px]">{c.sourceId}</span>
+      <span className="text-[10px] text-foreground/75 font-medium truncate max-w-[96px]">{c.sourceId}</span>
       {c.barCapability && (
-        <span className={`text-[9px] ${CAPABILITY_COLOR[c.barCapability] ?? 'text-text-muted'}`}>{c.barCapability}</span>
+        <span className={`text-[9px] ${CAPABILITY_COLOR[c.barCapability] ?? 'text-muted-foreground'}`}>{c.barCapability}</span>
       )}
     </span>
   )

--- a/ui/src/components/Metric.tsx
+++ b/ui/src/components/Metric.tsx
@@ -43,7 +43,7 @@ export function Metric({ label, value, delta, valueSign, size = 'md', className 
 
   return (
     <div className={className}>
-      <p className="text-[11px] text-text-muted uppercase tracking-wide">{label}</p>
+      <p className="text-[11px] text-muted-foreground uppercase tracking-wide">{label}</p>
       <p className={valueClass}>{value}</p>
       {delta && (
         <p className={`text-[12px] tabular-nums mt-0.5 ${signColor(delta.sign)}`}>
@@ -55,9 +55,9 @@ export function Metric({ label, value, delta, valueSign, size = 'md', className 
 }
 
 function signColor(sign?: MetricSign): string {
-  if (sign === 'up') return 'text-green'
-  if (sign === 'down') return 'text-red'
-  return 'text-text'
+  if (sign === 'up') return 'text-success'
+  if (sign === 'down') return 'text-destructive'
+  return 'text-foreground'
 }
 
 function arrowFor(sign: MetricSign): string {

--- a/ui/src/components/PageHeader.tsx
+++ b/ui/src/components/PageHeader.tsx
@@ -18,20 +18,20 @@ export function PageHeader({ title, description, right, live }: PageHeaderProps)
       <div className="px-4 md:px-6 py-5 flex items-center justify-between gap-4">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <h2 className="text-title font-bold text-text truncate">{title}</h2>
+            <h2 className="text-title font-bold text-foreground truncate">{title}</h2>
             {live && (
               <span
-                className="relative inline-block w-1.5 h-1.5 rounded-full bg-green live-pulse shrink-0"
+                className="relative inline-block w-1.5 h-1.5 rounded-full bg-success live-pulse shrink-0"
                 aria-label="Live"
               />
             )}
           </div>
           {(description || live) && (
-            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[12px] text-text-muted">
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[12px] text-muted-foreground">
               {description && <span className="min-w-0">{description}</span>}
               {live && (
                 <>
-                  {description && <span className="text-text-muted/40">·</span>}
+                  {description && <span className="text-muted-foreground/40">·</span>}
                   <LiveIndicator lastUpdated={live.lastUpdated} hideDot />
                 </>
               )}

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -174,7 +174,7 @@ export function PageSidebarLayout({
       <button
         type="button"
         onClick={() => updateCollapsed(true)}
-        className="oa-icon-action flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
+        className="oa-icon-action flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         aria-label={t('common.collapsePanel', { title })}
         title={t('common.focusContent')}
       >
@@ -194,13 +194,13 @@ export function PageSidebarLayout({
       <div ref={rootRef} className="flex h-full min-h-0 w-full overflow-hidden">
         {collapsed ? (
           <aside
-            className="flex h-full shrink-0 flex-col items-center border-r border-border/80 bg-bg-secondary py-1.5"
+            className="flex h-full shrink-0 flex-col items-center border-r border-border/80 bg-secondary py-1.5"
             style={{ width: COLLAPSED_WIDTH }}
           >
             <button
               type="button"
               onClick={() => updateCollapsed(false)}
-              className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
+              className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               aria-label={t('common.openPanel', { title })}
               title={t('common.openPanel', { title })}
             >
@@ -208,7 +208,7 @@ export function PageSidebarLayout({
             </button>
             <span
               aria-hidden
-              className="mt-3 select-none text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted [writing-mode:vertical-rl] rotate-180"
+              className="mt-3 select-none text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground [writing-mode:vertical-rl] rotate-180"
             >
               {title}
             </span>
@@ -232,23 +232,23 @@ export function PageSidebarLayout({
   }
 
   return (
-    <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-bg">
-      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border/70 bg-bg-secondary/40 px-3">
+    <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-background">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border/70 bg-secondary/40 px-3">
         <button
           type="button"
           onClick={() => setDrawerOpen(true)}
-          className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text"
+          className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           aria-label={t('common.openPanel', { title })}
           title={title}
         >
           <PanelLeftOpen size={17} strokeWidth={1.75} aria-hidden />
         </button>
-        <span className="min-w-0 truncate text-[13px] font-semibold text-text">{title}</span>
+        <span className="min-w-0 truncate text-[13px] font-semibold text-foreground">{title}</span>
       </div>
       <div className="flex min-h-0 flex-1 flex-col">{children}</div>
 
       <div
-        className={`absolute inset-0 z-30 bg-black/40 transition-opacity duration-200 ${
+        className={`absolute inset-0 z-30 bg-backdrop transition-opacity duration-200 ${
           drawerOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
         }`}
         onClick={() => setDrawerOpen(false)}
@@ -267,7 +267,7 @@ export function PageSidebarLayout({
             <button
               type="button"
               onClick={() => setDrawerOpen(false)}
-              className="text-text-muted hover:text-text p-1 -ml-1"
+              className="text-muted-foreground hover:text-foreground p-1 -ml-1"
               aria-label={t('common.closePanel', { title })}
             >
               <X size={15} strokeWidth={1.75} aria-hidden />
@@ -303,7 +303,7 @@ function ResizeHandle({
     >
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/80 transition-colors group-hover:bg-accent/50 group-active:bg-accent/70"
+        className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/80 transition-colors group-hover:bg-primary/50 group-active:bg-primary/70"
       />
     </div>
   )

--- a/ui/src/components/PortfolioSidebar.tsx
+++ b/ui/src/components/PortfolioSidebar.tsx
@@ -47,13 +47,13 @@ export function PortfolioSidebar() {
         </SidebarSectionHeader>
 
         {lite ? (
-          <p className="px-3 py-2 text-[12px] leading-relaxed text-text-muted">
+          <p className="px-3 py-2 text-[12px] leading-relaxed text-muted-foreground">
             Account drill-down is unavailable in Lite mode.
           </p>
         ) : loading ? (
           <SidebarRowsSkeleton rows={3} />
         ) : utas.length === 0 ? (
-          <p className="px-3 py-2 text-[12px] leading-relaxed text-text-muted">
+          <p className="px-3 py-2 text-[12px] leading-relaxed text-muted-foreground">
             {t('portfolio.noAccountsYet')}
           </p>
         ) : (
@@ -71,7 +71,7 @@ export function PortfolioSidebar() {
                 }
                 trail={
                   !uta.enabled ? (
-                    <span className="text-[10px] uppercase tracking-wide text-text-muted">{t('common.off')}</span>
+                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground">{t('common.off')}</span>
                   ) : undefined
                 }
               />

--- a/ui/src/components/PushApprovalPanel.tsx
+++ b/ui/src/components/PushApprovalPanel.tsx
@@ -170,22 +170,22 @@ function historyOperationDisplay(op: WalletCommitLog['operations'][number]): Ope
 
 function toneClass(tone: OperationDisplay['tone']): string {
   switch (tone) {
-    case 'buy': return 'border-green/30 bg-green/5 text-green'
-    case 'sell': return 'border-red/30 bg-red/5 text-red'
-    case 'danger': return 'border-red/35 bg-red/10 text-red'
-    case 'modify': return 'border-yellow-400/30 bg-yellow-400/5 text-yellow-300'
-    default: return 'border-border bg-bg-tertiary text-text-muted'
+    case 'buy': return 'border-success/30 bg-success/5 text-success'
+    case 'sell': return 'border-destructive/30 bg-destructive/5 text-destructive'
+    case 'danger': return 'border-destructive/35 bg-destructive/10 text-destructive'
+    case 'modify': return 'border-warning/30 bg-warning/5 text-warning'
+    default: return 'border-border bg-muted text-muted-foreground'
   }
 }
 
 function statusClass(status: string | undefined): string {
   switch (status) {
-    case 'submitted': return 'text-blue-400'
-    case 'filled': return 'text-green'
-    case 'rejected': return 'text-red'
-    case 'user-rejected': return 'text-orange-400'
-    case 'cancelled': return 'text-text-muted'
-    default: return 'text-text-muted'
+    case 'submitted': return 'text-info'
+    case 'filled': return 'text-success'
+    case 'rejected': return 'text-destructive'
+    case 'user-rejected': return 'text-warning'
+    case 'cancelled': return 'text-muted-foreground'
+    default: return 'text-muted-foreground'
   }
 }
 
@@ -371,7 +371,7 @@ export function PushApprovalPanel() {
 
   if (accounts.length === 0) {
     return (
-      <div className="h-full rounded-lg border border-border bg-bg-secondary/30">
+      <div className="h-full rounded-lg border border-border bg-secondary/30">
         <EmptyState
           title="No trading accounts"
           description="Connect a broker account in Settings -> Trading before approving staged broker writes."
@@ -381,14 +381,14 @@ export function PushApprovalPanel() {
   }
 
   return (
-    <div className="grid h-full min-h-0 min-w-0 overflow-hidden rounded-lg border border-border bg-bg-secondary/30 md:grid-cols-[250px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)]">
-      <div className="flex min-h-0 min-w-0 flex-col border-b border-border bg-bg-secondary md:border-b-0 md:border-r">
+    <div className="grid h-full min-h-0 min-w-0 overflow-hidden rounded-lg border border-border bg-secondary/30 md:grid-cols-[250px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)]">
+      <div className="flex min-h-0 min-w-0 flex-col border-b border-border bg-secondary md:border-b-0 md:border-r">
         <div className="shrink-0 border-b border-border/70 px-4 py-3">
-          <div className="flex items-center gap-2 text-[12px] font-medium text-text">
+          <div className="flex items-center gap-2 text-[12px] font-medium text-foreground">
             {waitingCount > 0 ? (
-              <AlertTriangle size={15} className="text-yellow-300" aria-hidden />
+              <AlertTriangle size={15} className="text-warning" aria-hidden />
             ) : (
-              <CheckCircle2 size={15} className="text-green" aria-hidden />
+              <CheckCircle2 size={15} className="text-success" aria-hidden />
             )}
             <span className="truncate">{statusLabel}</span>
           </div>
@@ -401,15 +401,15 @@ export function PushApprovalPanel() {
 
         {historyAccounts.length > 1 && (
           <div className="shrink-0 border-b border-border/60 px-4 py-2">
-            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-text-muted/60">Account filter</div>
+            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">Account filter</div>
             <div className="flex flex-wrap gap-1">
               <button
                 type="button"
                 onClick={() => setHistoryFilter(null)}
                 className={`rounded-full border px-2 py-0.5 text-[10px] transition-colors ${
                   effectiveFilter === null
-                    ? 'border-border bg-bg-tertiary text-text'
-                    : 'border-border/50 text-text-muted hover:border-border hover:text-text'
+                    ? 'border-border bg-muted text-foreground'
+                    : 'border-border/50 text-muted-foreground hover:border-border hover:text-foreground'
                 }`}
               >
                 All
@@ -422,8 +422,8 @@ export function PushApprovalPanel() {
                   title={account.label}
                   className={`max-w-[120px] truncate rounded-full border px-2 py-0.5 text-[10px] transition-colors ${
                     effectiveFilter === account.id
-                      ? 'border-border bg-bg-tertiary text-text'
-                      : 'border-border/50 text-text-muted hover:border-border hover:text-text'
+                      ? 'border-border bg-muted text-foreground'
+                      : 'border-border/50 text-muted-foreground hover:border-border hover:text-foreground'
                   }`}
                 >
                   {account.label}
@@ -472,7 +472,7 @@ export function PushApprovalPanel() {
 
 function TradingReviewSkeleton() {
   return (
-    <div className="grid h-full min-h-0 min-w-0 overflow-hidden rounded-lg border border-border bg-bg-secondary/30 md:grid-cols-[250px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)]">
+    <div className="grid h-full min-h-0 min-w-0 overflow-hidden rounded-lg border border-border bg-secondary/30 md:grid-cols-[250px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)]">
       <div className="border-b border-border p-4 md:border-b-0 md:border-r">
         <Skeleton className="h-4 w-40" />
         <div className="mt-4 space-y-2">
@@ -492,9 +492,9 @@ function TradingReviewSkeleton() {
 
 function QueueStat({ label, value, tone }: { label: string; value: number; tone: 'warn' | 'muted' }) {
   return (
-    <div className={`rounded-md border px-2 py-1.5 ${tone === 'warn' ? 'border-yellow-400/30 bg-yellow-400/5' : 'border-border/60 bg-bg/35'}`}>
-      <div className={`text-sm font-semibold tabular-nums ${tone === 'warn' ? 'text-yellow-300' : 'text-text'}`}>{value}</div>
-      <div className="text-[9px] uppercase tracking-wider text-text-muted/55">{label}</div>
+    <div className={`rounded-md border px-2 py-1.5 ${tone === 'warn' ? 'border-warning/30 bg-warning/5' : 'border-border/60 bg-background/35'}`}>
+      <div className={`text-sm font-semibold tabular-nums ${tone === 'warn' ? 'text-warning' : 'text-foreground'}`}>{value}</div>
+      <div className="text-[9px] uppercase tracking-wider text-muted-foreground/55">{label}</div>
     </div>
   )
 }
@@ -517,22 +517,22 @@ function QueueRow({ item, active, onClick }: { item: ReviewItem; active: boolean
       onClick={onClick}
       className={`w-full rounded-md border px-3 py-2 text-left transition-colors ${
         active
-          ? 'border-accent/50 bg-accent-dim text-text'
-          : 'border-transparent text-text-muted hover:border-border/70 hover:bg-overlay hover:text-text'
+          ? 'border-primary/50 bg-primary-muted text-foreground'
+          : 'border-transparent text-muted-foreground hover:border-border/70 hover:bg-accent hover:text-foreground'
       }`}
     >
       <div className="flex items-center gap-2">
-        <span className={active ? 'text-accent' : 'text-text-muted/70'}>{icon}</span>
+        <span className={active ? 'text-primary' : 'text-muted-foreground/70'}>{icon}</span>
         <span className="min-w-0 flex-1 truncate text-[12px] font-medium">{itemTitle(item)}</span>
       </div>
-      <div className="mt-1 flex min-w-0 items-center gap-2 text-[10px] text-text-muted/65">
+      <div className="mt-1 flex min-w-0 items-center gap-2 text-[10px] text-muted-foreground/65">
         <span className="truncate">{itemAccountLabel(item)}</span>
-        <span className="text-text-muted/35">/</span>
+        <span className="text-muted-foreground/35">/</span>
         <span>{ops.length} op{ops.length === 1 ? '' : 's'}</span>
-        <span className="ml-auto rounded border border-border/60 px-1.5 py-0.5 font-mono text-[9px] text-text-muted/60">{badge}</span>
+        <span className="ml-auto rounded border border-border/60 px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground/60">{badge}</span>
       </div>
       {timestamp && (
-        <div className="mt-1 text-[10px] text-text-muted/45">{formatRelativeTime(timestamp)}</div>
+        <div className="mt-1 text-[10px] text-muted-foreground/45">{formatRelativeTime(timestamp)}</div>
       )}
     </button>
   )
@@ -541,9 +541,9 @@ function QueueRow({ item, active, onClick }: { item: ReviewItem; active: boolean
 function CleanQueue() {
   return (
     <div className="flex h-full min-h-[220px] flex-col items-center justify-center px-4 text-center">
-      <CheckCircle2 size={26} className="text-green/80" aria-hidden />
-      <div className="mt-3 text-[13px] font-medium text-text">Working tree clean</div>
-      <div className="mt-1 max-w-[190px] text-[12px] leading-relaxed text-text-muted/60">
+      <CheckCircle2 size={26} className="text-success/80" aria-hidden />
+      <div className="mt-3 text-[13px] font-medium text-foreground">Working tree clean</div>
+      <div className="mt-1 max-w-[190px] text-[12px] leading-relaxed text-muted-foreground/60">
         No broker writes are waiting for approval.
       </div>
     </div>
@@ -600,26 +600,26 @@ function ReviewDetail({
           <ResultBanner result={lastResult.data} onDismiss={onDismissResult} />
         )}
         {error && (
-          <div className="flex items-start gap-2 rounded-md border border-red/30 bg-red/5 px-3 py-2 text-[12px] text-red">
+          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] text-destructive">
             <XCircle size={15} className="mt-0.5 shrink-0" aria-hidden />
             <span className="min-w-0 flex-1">{error}</span>
-            <button type="button" onClick={onDismissError} className="text-text-muted hover:text-text">Dismiss</button>
+            <button type="button" onClick={onDismissError} className="text-muted-foreground hover:text-foreground">Dismiss</button>
           </div>
         )}
 
-        <div className="rounded-lg border border-border bg-bg">
+        <div className="rounded-lg border border-border bg-background">
           <div className="border-b border-border px-4 py-4">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
                 <div className="mb-1 flex flex-wrap items-center gap-2">
                   <StatusPill item={item} />
-                  <span className="text-[11px] text-text-muted">{itemAccountLabel(item)}</span>
+                  <span className="text-[11px] text-muted-foreground">{itemAccountLabel(item)}</span>
                   {item.kind === 'history' && (
-                    <span className="font-mono text-[11px] text-text-muted/60">{shortHash(item.commit.hash)}</span>
+                    <span className="font-mono text-[11px] text-muted-foreground/60">{shortHash(item.commit.hash)}</span>
                   )}
                 </div>
-                <h3 className="text-lg font-semibold text-text">{title}</h3>
-                <div className="mt-1 text-[12px] text-text-muted">
+                <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+                <div className="mt-1 text-[12px] text-muted-foreground">
                   {item.kind === 'history'
                     ? `Pushed ${formatRelativeTime(item.commit.timestamp)}`
                     : `${ops.length} proposed broker operation${ops.length === 1 ? '' : 's'} on head ${shortHash(item.status.head)}`}
@@ -640,7 +640,7 @@ function ReviewDetail({
                       <button
                         type="button"
                         onClick={() => onConfirmPush(null)}
-                        className="rounded-md px-2.5 py-1.5 text-[12px] text-text-muted transition-colors hover:bg-overlay hover:text-text"
+                        className="rounded-md px-2.5 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                       >
                         Cancel
                       </button>
@@ -659,7 +659,7 @@ function ReviewDetail({
                         type="button"
                         onClick={() => onReject(accountId)}
                         disabled={pushing !== null || rejecting !== null}
-                        className="rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-text-muted transition-colors hover:border-red/50 hover:text-red disabled:cursor-not-allowed disabled:opacity-50"
+                        className="rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:border-destructive/50 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         {rejecting === accountId ? 'Rejecting...' : 'Reject'}
                       </button>
@@ -672,7 +672,7 @@ function ReviewDetail({
 
           <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_260px]">
             <section className="min-w-0 space-y-3">
-              <div className="flex items-center gap-2 text-[12px] font-semibold uppercase tracking-wider text-text-muted/70">
+              <div className="flex items-center gap-2 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground/70">
                 <GitCommitHorizontal size={14} aria-hidden />
                 Operation diff
               </div>
@@ -686,12 +686,12 @@ function ReviewDetail({
             <section className="space-y-3">
               <ReviewSummary item={item} operations={ops} />
               {isStaged && (
-                <div className="rounded-md border border-yellow-400/25 bg-yellow-400/5 px-3 py-2 text-[12px] leading-relaxed text-yellow-100/80">
+                <div className="rounded-md border border-warning/25 bg-warning/5 px-3 py-2 text-[12px] leading-relaxed text-warning/80">
                   These operations are staged but do not have a commit message yet. The agent still needs to commit before this can be pushed.
                 </div>
               )}
               {isPending && (
-                <div className="rounded-md border border-red/25 bg-red/5 px-3 py-2 text-[12px] leading-relaxed text-red/90">
+                <div className="rounded-md border border-destructive/25 bg-destructive/5 px-3 py-2 text-[12px] leading-relaxed text-destructive/90">
                   Approval pushes these operations to the broker account. Check account, side, quantity, and order type before confirming.
                 </div>
               )}
@@ -706,7 +706,7 @@ function ReviewDetail({
 function StatusPill({ item }: { item: ReviewItem }) {
   if (item.kind === 'pending') {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full border border-yellow-400/30 bg-yellow-400/10 px-2 py-0.5 text-[11px] font-medium text-yellow-200">
+      <span className="inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-[11px] font-medium text-warning">
         <AlertTriangle size={12} aria-hidden />
         Needs approval
       </span>
@@ -714,14 +714,14 @@ function StatusPill({ item }: { item: ReviewItem }) {
   }
   if (item.kind === 'staged') {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full border border-blue-400/25 bg-blue-400/10 px-2 py-0.5 text-[11px] font-medium text-blue-200">
+      <span className="inline-flex items-center gap-1 rounded-full border border-info/25 bg-info/10 px-2 py-0.5 text-[11px] font-medium text-info">
         <Clock3 size={12} aria-hidden />
         Staged
       </span>
     )
   }
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-green/25 bg-green/10 px-2 py-0.5 text-[11px] font-medium text-green">
+    <span className="inline-flex items-center gap-1 rounded-full border border-success/25 bg-success/10 px-2 py-0.5 text-[11px] font-medium text-success">
       <CheckCircle2 size={12} aria-hidden />
       Pushed
     </span>
@@ -730,19 +730,19 @@ function StatusPill({ item }: { item: ReviewItem }) {
 
 function OperationRow({ op }: { op: OperationDisplay }) {
   return (
-    <div className="grid min-w-0 grid-cols-[28px_minmax(0,1fr)] overflow-hidden rounded-md border border-border bg-bg-secondary/50">
+    <div className="grid min-w-0 grid-cols-[28px_minmax(0,1fr)] overflow-hidden rounded-md border border-border bg-secondary/50">
       <div className={`flex items-center justify-center border-r font-mono text-sm font-semibold ${toneClass(op.tone)}`}>
         {op.marker}
       </div>
       <div className="min-w-0 px-3 py-2">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="min-w-0 break-all font-mono text-[13px] font-medium text-text">{op.title}</span>
+          <span className="min-w-0 break-all font-mono text-[13px] font-medium text-foreground">{op.title}</span>
           {op.status && (
             <span className={`text-[11px] ${statusClass(op.status)}`}>{op.status}</span>
           )}
         </div>
         {op.detail && (
-          <div className="mt-0.5 break-words text-[12px] text-text-muted">{op.detail}</div>
+          <div className="mt-0.5 break-words text-[12px] text-muted-foreground">{op.detail}</div>
         )}
       </div>
     </div>
@@ -756,8 +756,8 @@ function ReviewSummary({ item, operations }: { item: ReviewItem; operations: Ope
   const modifyCount = operations.length - buyCount - sellCount
 
   return (
-    <div className="rounded-md border border-border bg-bg-secondary/60 p-3">
-      <div className="text-[12px] font-semibold uppercase tracking-wider text-text-muted/70">Review summary</div>
+    <div className="rounded-md border border-border bg-secondary/60 p-3">
+      <div className="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground/70">Review summary</div>
       <dl className="mt-3 space-y-2 text-[12px]">
         <SummaryRow label="Account" value={itemAccountLabel(item)} />
         <SummaryRow label="Operations" value={String(operations.length)} />
@@ -774,8 +774,8 @@ function ReviewSummary({ item, operations }: { item: ReviewItem; operations: Ope
 function SummaryRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-start justify-between gap-3">
-      <dt className="text-text-muted">{label}</dt>
-      <dd className="min-w-0 truncate text-right font-medium text-text" title={value}>{value}</dd>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 truncate text-right font-medium text-foreground" title={value}>{value}</dd>
     </div>
   )
 }
@@ -784,7 +784,7 @@ function ResultBanner({ result, onDismiss }: { result: WalletPushResult; onDismi
   const hasRejected = result.rejected.length > 0
   return (
     <div className={`flex items-start gap-2 rounded-md border px-3 py-2 text-[12px] ${
-      hasRejected ? 'border-red/30 bg-red/5 text-red' : 'border-green/25 bg-green/5 text-green'
+      hasRejected ? 'border-destructive/30 bg-destructive/5 text-destructive' : 'border-success/25 bg-success/5 text-success'
     }`}>
       {hasRejected ? <AlertTriangle size={15} className="mt-0.5 shrink-0" aria-hidden /> : <CheckCircle2 size={15} className="mt-0.5 shrink-0" aria-hidden />}
       <div className="min-w-0 flex-1">
@@ -792,10 +792,10 @@ function ResultBanner({ result, onDismiss }: { result: WalletPushResult; onDismi
           {result.submitted.length} submitted, {result.rejected.length} rejected
         </div>
         {result.rejected.map((entry, index) => (
-          <div key={`${entry.action}:${index}`} className="mt-0.5 text-red/80">{entry.error || entry.action}</div>
+          <div key={`${entry.action}:${index}`} className="mt-0.5 text-destructive/80">{entry.error || entry.action}</div>
         ))}
       </div>
-      <button type="button" onClick={onDismiss} className="text-text-muted hover:text-text">Dismiss</button>
+      <button type="button" onClick={onDismiss} className="text-muted-foreground hover:text-foreground">Dismiss</button>
     </div>
   )
 }

--- a/ui/src/components/ReconnectButton.tsx
+++ b/ui/src/components/ReconnectButton.tsx
@@ -39,8 +39,8 @@ export function ReconnectButton({ accountId }: { accountId: string }) {
       >
         {status === 'loading' ? 'Connecting...' : 'Reconnect'}
       </button>
-      {status === 'success' && <span className="text-[12px] text-green">{message}</span>}
-      {status === 'error' && <span className="text-[12px] text-red">{message}</span>}
+      {status === 'success' && <span className="text-[12px] text-success">{message}</span>}
+      {status === 'error' && <span className="text-[12px] text-destructive">{message}</span>}
     </div>
   )
 }

--- a/ui/src/components/Resizer.tsx
+++ b/ui/src/components/Resizer.tsx
@@ -91,7 +91,7 @@ export function Resizer({ direction, onResize, onReset, className = '' }: Resize
     <div
       role="separator"
       aria-orientation={direction === 'horizontal' ? 'vertical' : 'horizontal'}
-      className={`${cursorClass} hover:bg-accent/40 active:bg-accent/60 transition-colors ${className}`}
+      className={`${cursorClass} hover:bg-primary/40 active:bg-primary/60 transition-colors ${className}`}
       onPointerDown={handleDown}
       onPointerMove={handleMove}
       onPointerUp={handleUp}

--- a/ui/src/components/SDKSelector.tsx
+++ b/ui/src/components/SDKSelector.tsx
@@ -60,24 +60,24 @@ export function SDKSelector(props: SDKSelectorProps) {
             className={`
               relative text-left rounded-lg border px-4 py-3.5 transition-all
               ${isSelected
-                ? 'border-accent bg-accent/5 ring-1 ring-accent/30'
+                ? 'border-primary bg-primary/5 ring-1 ring-primary/30'
                 : isDisabled
                   ? 'border-border/50 opacity-50 cursor-not-allowed'
-                  : 'border-border hover:border-text-muted/40 hover:bg-bg-tertiary/30 cursor-pointer'
+                  : 'border-border hover:border-muted-foreground/40 hover:bg-muted/30 cursor-pointer'
               }
               ${isLocked ? 'cursor-default' : ''}
             `}
           >
             {/* Coming Soon badge */}
             {isDisabled && (
-              <span className="absolute top-2.5 right-2.5 text-[10px] font-medium text-text-muted/60 bg-bg-tertiary px-1.5 py-0.5 rounded">
+              <span className="absolute top-2.5 right-2.5 text-[10px] font-medium text-muted-foreground/60 bg-muted px-1.5 py-0.5 rounded">
                 Coming Soon
               </span>
             )}
 
             {/* Locked badge (always active) */}
             {isLocked && !isDisabled && (
-              <span className="absolute top-2.5 right-2.5 text-[10px] font-medium text-accent/70 bg-accent/10 px-1.5 py-0.5 rounded">
+              <span className="absolute top-2.5 right-2.5 text-[10px] font-medium text-primary/70 bg-primary/10 px-1.5 py-0.5 rounded">
                 Always On
               </span>
             )}
@@ -86,7 +86,7 @@ export function SDKSelector(props: SDKSelectorProps) {
             {isSelected && !isLocked && !isDisabled && (
               <span className="absolute top-2.5 right-2.5">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                  <circle cx="8" cy="8" r="8" className="fill-accent" />
+                  <circle cx="8" cy="8" r="8" className="fill-primary" />
                   <path d="M5 8l2 2 4-4" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               </span>
@@ -97,17 +97,17 @@ export function SDKSelector(props: SDKSelectorProps) {
               <div className={`
                 w-9 h-9 rounded-lg flex items-center justify-center shrink-0 mt-0.5
                 text-[11px] font-bold tracking-wide
-                ${isSelected ? 'bg-accent/15' : 'bg-bg-tertiary'}
-                ${isSelected ? 'text-accent' : opt.badgeColor}
+                ${isSelected ? 'bg-primary/15' : 'bg-muted'}
+                ${isSelected ? 'text-primary' : opt.badgeColor}
               `}>
                 {opt.badge}
               </div>
 
               <div className="min-w-0 pr-5">
-                <p className={`text-[13px] font-medium ${isSelected ? 'text-text' : isDisabled ? 'text-text-muted' : 'text-text'}`}>
+                <p className={`text-[13px] font-medium ${isSelected ? 'text-foreground' : isDisabled ? 'text-muted-foreground' : 'text-foreground'}`}>
                   {opt.name}
                 </p>
-                <p className="text-[11px] text-text-muted/70 mt-0.5 leading-relaxed">
+                <p className="text-[11px] text-muted-foreground/70 mt-0.5 leading-relaxed">
                   {opt.description}
                 </p>
               </div>
@@ -127,14 +127,14 @@ export const CRYPTO_SDK_OPTIONS: SDKOption[] = [
     name: 'CCXT',
     description: 'Unified API for 100+ crypto exchanges. Supports Binance, Bybit, OKX, Coinbase, and more.',
     badge: 'CC',
-    badgeColor: 'text-accent',
+    badgeColor: 'text-primary',
   },
   {
     id: 'binance-native',
     name: 'Binance Native SDK',
     description: 'Direct Binance API integration with WebSocket streams and advanced order types.',
     badge: 'BN',
-    badgeColor: 'text-yellow',
+    badgeColor: 'text-warning',
     comingSoon: true,
   },
   {
@@ -142,7 +142,7 @@ export const CRYPTO_SDK_OPTIONS: SDKOption[] = [
     name: 'Bybit Native SDK',
     description: 'Native Bybit V5 API with unified trading account support.',
     badge: 'BY',
-    badgeColor: 'text-text-muted',
+    badgeColor: 'text-muted-foreground',
     comingSoon: true,
   },
   {
@@ -150,7 +150,7 @@ export const CRYPTO_SDK_OPTIONS: SDKOption[] = [
     name: 'OKX Native SDK',
     description: 'Direct OKX API with portfolio margin and copy trading support.',
     badge: 'OK',
-    badgeColor: 'text-text-muted',
+    badgeColor: 'text-muted-foreground',
     comingSoon: true,
   },
 ]
@@ -161,14 +161,14 @@ export const SECURITIES_SDK_OPTIONS: SDKOption[] = [
     name: 'Alpaca',
     description: 'Commission-free US equities and ETFs with fractional share support.',
     badge: 'AL',
-    badgeColor: 'text-green',
+    badgeColor: 'text-success',
   },
   {
     id: 'ibkr',
     name: 'Interactive Brokers',
     description: 'Global multi-asset broker with access to 150+ markets in 33 countries.',
     badge: 'IB',
-    badgeColor: 'text-text-muted',
+    badgeColor: 'text-muted-foreground',
     comingSoon: true,
   },
   {
@@ -176,7 +176,7 @@ export const SECURITIES_SDK_OPTIONS: SDKOption[] = [
     name: 'Charles Schwab',
     description: 'Full-service US broker with comprehensive research and zero-commission trades.',
     badge: 'CS',
-    badgeColor: 'text-text-muted',
+    badgeColor: 'text-muted-foreground',
     comingSoon: true,
   },
   {
@@ -184,7 +184,7 @@ export const SECURITIES_SDK_OPTIONS: SDKOption[] = [
     name: 'Tradier',
     description: 'Developer-friendly brokerage API with equity and options trading.',
     badge: 'TR',
-    badgeColor: 'text-text-muted',
+    badgeColor: 'text-muted-foreground',
     comingSoon: true,
   },
 ]
@@ -195,21 +195,21 @@ export const PLATFORM_TYPE_OPTIONS: SDKOption[] = [
     name: 'CCXT (Crypto)',
     description: 'Unified API for 100+ crypto exchanges. Supports Binance, Bybit, OKX, Coinbase, and more.',
     badge: 'CC',
-    badgeColor: 'text-accent',
+    badgeColor: 'text-primary',
   },
   {
     id: 'alpaca',
     name: 'Alpaca (Securities)',
     description: 'Commission-free US equities and ETFs with fractional share support.',
     badge: 'AL',
-    badgeColor: 'text-green',
+    badgeColor: 'text-success',
   },
   {
     id: 'ibkr',
     name: 'IBKR (Interactive Brokers)',
     description: 'Professional-grade trading via TWS or IB Gateway. Stocks, options, futures, bonds.',
     badge: 'IB',
-    badgeColor: 'text-orange-400',
+    badgeColor: 'text-warning',
   },
 ]
 
@@ -219,13 +219,13 @@ export const DATASOURCE_OPTIONS: SDKOption[] = [
     name: 'Market Data',
     description: 'Structured financial data — prices, fundamentals, macro indicators.',
     badge: 'MD',
-    badgeColor: 'text-green',
+    badgeColor: 'text-success',
   },
   {
     id: 'news',
     name: 'News',
     description: 'RSS/Atom feed aggregation and news archive search.',
     badge: 'NW',
-    badgeColor: 'text-purple',
+    badgeColor: 'text-ai-action',
   },
 ]

--- a/ui/src/components/SaveIndicator.tsx
+++ b/ui/src/components/SaveIndicator.tsx
@@ -7,24 +7,24 @@ export function SaveIndicator({ status, onRetry }: { status: SaveStatus; onRetry
     <span className="inline-flex items-center gap-1.5 text-[11px] shrink-0">
       {status === 'saving' && (
         <>
-          <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse" />
-          <span className="text-text-muted">Saving…</span>
+          <span className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
+          <span className="text-muted-foreground">Saving…</span>
         </>
       )}
       {status === 'saved' && (
         <>
-          <span className="w-1.5 h-1.5 rounded-full bg-green" />
-          <span className="text-text-muted">Saved</span>
+          <span className="w-1.5 h-1.5 rounded-full bg-success" />
+          <span className="text-muted-foreground">Saved</span>
         </>
       )}
       {status === 'error' && (
         <>
-          <span className="w-1.5 h-1.5 rounded-full bg-red" />
-          <span className="text-red">Save failed</span>
+          <span className="w-1.5 h-1.5 rounded-full bg-destructive" />
+          <span className="text-destructive">Save failed</span>
           {onRetry && (
             <button
               onClick={onRetry}
-              className="text-red underline underline-offset-2 hover:text-text ml-0.5"
+              className="text-destructive underline underline-offset-2 hover:text-foreground ml-0.5"
             >
               Retry
             </button>

--- a/ui/src/components/SegmentedControl.tsx
+++ b/ui/src/components/SegmentedControl.tsx
@@ -32,7 +32,7 @@ export function SegmentedControl<T extends string>({
     <div
       role="group"
       aria-label={ariaLabel}
-      className={`scrollbar-hide flex w-fit max-w-full items-center gap-0.5 overflow-x-auto rounded-lg border border-border/70 bg-bg-tertiary/60 p-0.5 ${className}`}
+      className={`scrollbar-hide flex w-fit max-w-full items-center gap-0.5 overflow-x-auto rounded-lg border border-border/70 bg-muted/60 p-0.5 ${className}`}
     >
       {options.map((option) => {
         const active = option.value === value
@@ -47,8 +47,8 @@ export function SegmentedControl<T extends string>({
               compact ? 'min-h-6 px-2 text-[10px]' : 'min-h-7 px-2.5 text-[11px]'
             } ${
               active
-                ? 'bg-bg text-accent shadow-sm ring-1 ring-border/60'
-                : 'text-text-muted hover:bg-overlay hover:text-text'
+                ? 'bg-background text-primary shadow-sm ring-1 ring-border/60'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground'
             }`}
           >
             {option.label}

--- a/ui/src/components/SettingsCategoryList.tsx
+++ b/ui/src/components/SettingsCategoryList.tsx
@@ -36,7 +36,7 @@ export function SettingsCategoryList() {
             key={item.category}
             label={t(item.labelKey)}
             active={active}
-            icon={<item.Icon size={14} strokeWidth={1.75} className="text-text-muted/70" aria-hidden />}
+            icon={<item.Icon size={14} strokeWidth={1.75} className="text-muted-foreground/70" aria-hidden />}
             onClick={() => openOrFocus({ kind: 'settings', params: { category: item.category } })}
           />
         )

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -17,11 +17,11 @@ interface SidebarProps {
  */
 export function Sidebar({ title, actions, children, leading }: SidebarProps) {
   return (
-    <aside className="flex h-full w-full flex-col bg-bg-secondary">
+    <aside className="flex h-full w-full flex-col bg-secondary">
       <div className="flex items-center justify-between px-4 h-10 shrink-0 gap-2 border-b border-border/60">
         <div className="flex items-center gap-1.5 min-w-0">
           {leading}
-          <h2 className="text-[13px] font-semibold text-text truncate">{title}</h2>
+          <h2 className="text-[13px] font-semibold text-foreground truncate">{title}</h2>
         </div>
         {actions && <div className="flex items-center gap-0.5 shrink-0">{actions}</div>}
       </div>

--- a/ui/src/components/SidebarRow.tsx
+++ b/ui/src/components/SidebarRow.tsx
@@ -10,7 +10,7 @@ interface SidebarRowProps {
   /**
    * Optional leading glyph (shrink-0), e.g. an entity-type icon. Pass the
    * fully-styled node — the row doesn't impose a size or colour so callers
-   * keep control (e.g. `<TrendingUp size={13} className="text-text-muted/70" />`).
+   * keep control (e.g. `<TrendingUp size={13} className="text-muted-foreground/70" />`).
    */
   icon?: ReactNode
   /**
@@ -53,16 +53,16 @@ export function SidebarRow({ label, active = false, onClick, icon, trail, title,
           onClick()
         }
       }}
-      className={`oa-nav-row group relative flex min-h-10 items-center gap-1.5 px-3 py-2 text-[13px] cursor-pointer outline-none focus-visible:bg-bg-tertiary/70 ${
+      className={`oa-nav-row group relative flex min-h-10 items-center gap-1.5 px-3 py-2 text-[13px] cursor-pointer outline-none focus-visible:bg-muted/70 ${
         active
-          ? 'bg-bg-tertiary text-text'
-          : 'text-text hover:bg-bg-tertiary/50'
+          ? 'bg-muted text-foreground'
+          : 'text-foreground hover:bg-muted/50'
       } ${dim ? 'opacity-60' : ''}`}
     >
       {active && (
         <span
           aria-hidden="true"
-          className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent"
+          className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary"
         />
       )}
       {icon && <span className="shrink-0 flex items-center">{icon}</span>}

--- a/ui/src/components/SidebarSectionHeader.tsx
+++ b/ui/src/components/SidebarSectionHeader.tsx
@@ -21,7 +21,7 @@ export function SidebarSectionHeader({
 }) {
   return (
     <div className="flex items-center gap-1.5 px-3 mt-2 mb-1 select-none">
-      <h3 className="flex-1 truncate text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+      <h3 className="flex-1 truncate text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
         {children}
       </h3>
       {trailing}

--- a/ui/src/components/SnapshotDetail.tsx
+++ b/ui/src/components/SnapshotDetail.tsx
@@ -14,20 +14,20 @@ export function SnapshotDetail({ snapshot, onClose }: SnapshotDetailProps) {
   const a = snapshot.account
 
   return (
-    <div className="border border-accent/30 rounded-lg bg-bg-secondary overflow-hidden">
+    <div className="border border-primary/30 rounded-lg bg-secondary overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2.5 bg-accent/5 border-b border-border">
+      <div className="flex items-center justify-between px-4 py-2.5 bg-primary/5 border-b border-border">
         <div className="flex items-center gap-2">
           <HealthDot health={snapshot.health} />
-          <span className="text-[13px] text-text font-medium">
+          <span className="text-[13px] text-foreground font-medium">
             {new Date(snapshot.timestamp).toLocaleString()}
           </span>
           <TriggerBadge trigger={snapshot.trigger} />
-          <span className="text-[11px] text-text-muted">{snapshot.accountId}</span>
+          <span className="text-[11px] text-muted-foreground">{snapshot.accountId}</span>
         </div>
         <button
           onClick={onClose}
-          className="text-text-muted hover:text-text text-[13px] px-1.5 transition-colors"
+          className="text-muted-foreground hover:text-foreground text-[13px] px-1.5 transition-colors"
         >
           &times;
         </button>
@@ -44,13 +44,13 @@ export function SnapshotDetail({ snapshot, onClose }: SnapshotDetailProps) {
       {/* Positions */}
       {snapshot.positions.length > 0 && (
         <div className="px-4 pb-3">
-          <p className="text-[11px] text-text-muted uppercase tracking-wide mb-1.5">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide mb-1.5">
             Positions ({snapshot.positions.length})
           </p>
           <div className="border border-border rounded overflow-x-auto">
             <table className="w-full text-[12px]">
               <thead>
-                <tr className="bg-bg text-text-muted text-left">
+                <tr className="bg-background text-muted-foreground text-left">
                   <th className="px-2.5 py-1.5 font-medium">Symbol</th>
                   <th className="px-2.5 py-1.5 font-medium text-center">Ccy</th>
                   <th className="px-2.5 py-1.5 font-medium text-right">Qty</th>
@@ -66,17 +66,17 @@ export function SnapshotDetail({ snapshot, onClose }: SnapshotDetailProps) {
                   return (
                     <tr key={i} className="border-t border-border">
                       <td className="px-2.5 py-1.5">
-                        <span className="font-medium text-text">{symbolFromAliceId(p.aliceId)}</span>
-                        <span className={`ml-1.5 text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
+                        <span className="font-medium text-foreground">{symbolFromAliceId(p.aliceId)}</span>
+                        <span className={`ml-1.5 text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-success/15 text-success' : 'bg-destructive/15 text-destructive'}`}>
                           {p.side}
                         </span>
                       </td>
-                      <td className="px-2.5 py-1.5 text-right text-text tabular-nums">{p.quantity}</td>
-                      <td className="px-2.5 py-1.5 text-center text-text-muted text-[10px] tabular-nums">{p.currency}</td>
-                      <td className="px-2.5 py-1.5 text-right text-text-muted tabular-nums">{fmtStr(p.avgCost, p.currency)}</td>
-                      <td className="px-2.5 py-1.5 text-right text-text tabular-nums">{fmtStr(p.marketPrice, p.currency)}</td>
-                      <td className="px-2.5 py-1.5 text-right text-text tabular-nums">{fmtStr(p.marketValue, p.currency)}</td>
-                      <td className={`px-2.5 py-1.5 text-right font-medium tabular-nums ${pnl >= 0 ? 'text-green' : 'text-red'}`}>
+                      <td className="px-2.5 py-1.5 text-right text-foreground tabular-nums">{p.quantity}</td>
+                      <td className="px-2.5 py-1.5 text-center text-muted-foreground text-[10px] tabular-nums">{p.currency}</td>
+                      <td className="px-2.5 py-1.5 text-right text-muted-foreground tabular-nums">{fmtStr(p.avgCost, p.currency)}</td>
+                      <td className="px-2.5 py-1.5 text-right text-foreground tabular-nums">{fmtStr(p.marketPrice, p.currency)}</td>
+                      <td className="px-2.5 py-1.5 text-right text-foreground tabular-nums">{fmtStr(p.marketValue, p.currency)}</td>
+                      <td className={`px-2.5 py-1.5 text-right font-medium tabular-nums ${pnl >= 0 ? 'text-success' : 'text-destructive'}`}>
                         {fmtPnlStr(p.unrealizedPnL, p.currency)}
                       </td>
                     </tr>
@@ -91,16 +91,16 @@ export function SnapshotDetail({ snapshot, onClose }: SnapshotDetailProps) {
       {/* Open Orders */}
       {snapshot.openOrders.length > 0 && (
         <div className="px-4 pb-3">
-          <p className="text-[11px] text-text-muted uppercase tracking-wide mb-1.5">
+          <p className="text-[11px] text-muted-foreground uppercase tracking-wide mb-1.5">
             Open Orders ({snapshot.openOrders.length})
           </p>
           <div className="space-y-1">
             {snapshot.openOrders.map((o, i) => (
-              <div key={i} className="flex items-center gap-2 text-[12px] px-2.5 py-1.5 border border-border rounded bg-bg">
-                <span className={`font-medium ${o.action === 'BUY' ? 'text-green' : 'text-red'}`}>{o.action}</span>
-                <span className="text-text">{symbolFromAliceId(o.aliceId)}</span>
-                <span className="text-text-muted">{o.totalQuantity} @ {o.orderType}</span>
-                <span className="text-accent text-[10px]">{o.status}</span>
+              <div key={i} className="flex items-center gap-2 text-[12px] px-2.5 py-1.5 border border-border rounded bg-background">
+                <span className={`font-medium ${o.action === 'BUY' ? 'text-success' : 'text-destructive'}`}>{o.action}</span>
+                <span className="text-foreground">{symbolFromAliceId(o.aliceId)}</span>
+                <span className="text-muted-foreground">{o.totalQuantity} @ {o.orderType}</span>
+                <span className="text-primary text-[10px]">{o.status}</span>
               </div>
             ))}
           </div>
@@ -110,7 +110,7 @@ export function SnapshotDetail({ snapshot, onClose }: SnapshotDetailProps) {
       {/* Empty state */}
       {snapshot.positions.length === 0 && snapshot.openOrders.length === 0 && (
         <div className="px-4 pb-3">
-          <p className="text-[12px] text-text-muted">No positions or orders at this time.</p>
+          <p className="text-[12px] text-muted-foreground">No positions or orders at this time.</p>
         </div>
       )}
     </div>
@@ -120,10 +120,10 @@ export function SnapshotDetail({ snapshot, onClose }: SnapshotDetailProps) {
 // ==================== Sub-components ====================
 
 function HealthDot({ health }: { health: string }) {
-  const color = health === 'healthy' ? 'bg-green'
-    : health === 'degraded' ? 'bg-yellow-400'
-    : health === 'disabled' ? 'bg-text-muted/40'
-    : 'bg-red'
+  const color = health === 'healthy' ? 'bg-success'
+    : health === 'degraded' ? 'bg-warning'
+    : health === 'disabled' ? 'bg-muted-foreground/40'
+    : 'bg-destructive'
   return <div className={`w-1.5 h-1.5 rounded-full ${color}`} />
 }
 
@@ -132,17 +132,17 @@ function TriggerBadge({ trigger }: { trigger: string }) {
     : trigger === 'post-reject' ? 'reject'
     : trigger
   return (
-    <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted">
+    <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
       {label}
     </span>
   )
 }
 
 function MetricItem({ label, value, pnl }: { label: string; value: string; pnl?: number }) {
-  const color = pnl == null ? 'text-text' : pnl >= 0 ? 'text-green' : 'text-red'
+  const color = pnl == null ? 'text-foreground' : pnl >= 0 ? 'text-success' : 'text-destructive'
   return (
     <div>
-      <p className="text-[10px] text-text-muted uppercase tracking-wide">{label}</p>
+      <p className="text-[10px] text-muted-foreground uppercase tracking-wide">{label}</p>
       <p className={`text-[16px] font-bold tabular-nums ${color}`}>{value}</p>
     </div>
   )

--- a/ui/src/components/Sparkline.tsx
+++ b/ui/src/components/Sparkline.tsx
@@ -34,13 +34,13 @@ export function Sparkline({
   const data = useMemo(() => values.map((v, i) => ({ i, v })), [values])
 
   const stroke = useMemo(() => {
-    if (color === 'green') return 'var(--color-green)'
-    if (color === 'red') return 'var(--color-red)'
-    if (color === 'accent') return 'var(--color-accent)'
-    if (values.length < 2) return 'var(--color-accent)'
+    if (color === 'green') return 'var(--success)'
+    if (color === 'red') return 'var(--destructive)'
+    if (color === 'accent') return 'var(--primary)'
+    if (values.length < 2) return 'var(--primary)'
     return values[values.length - 1] >= values[0]
-      ? 'var(--color-green)'
-      : 'var(--color-red)'
+      ? 'var(--success)'
+      : 'var(--destructive)'
   }, [color, values])
 
   if (values.length < 2) return null

--- a/ui/src/components/StateViews.tsx
+++ b/ui/src/components/StateViews.tsx
@@ -10,7 +10,7 @@ export function Spinner({ size = 'md' }: SpinnerProps) {
   const dim = size === 'sm' ? 'w-4 h-4' : 'w-6 h-6'
   return (
     <div
-      className={`${dim} border-2 border-accent/20 border-t-accent rounded-full animate-spin`}
+      className={`${dim} border-2 border-primary/20 border-t-accent rounded-full animate-spin`}
     />
   )
 }
@@ -33,7 +33,7 @@ export function PageLoading() {
  *  expand. */
 export function CenteredLoading({ label }: { label?: string }) {
   return (
-    <div className="flex items-center justify-center gap-2.5 py-20 text-[13px] text-text-muted">
+    <div className="flex items-center justify-center gap-2.5 py-20 text-[13px] text-muted-foreground">
       <Spinner size="sm" />
       {label && <span>{label}</span>}
     </div>
@@ -93,7 +93,7 @@ interface EmptyStateProps {
 export function EmptyState({ icon, title, description }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
-      <div className="w-12 h-12 rounded-xl bg-bg-secondary border border-border/60 flex items-center justify-center text-text-muted/30 mb-4">
+      <div className="w-12 h-12 rounded-xl bg-secondary border border-border/60 flex items-center justify-center text-muted-foreground/30 mb-4">
         {icon ?? (
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2" />
@@ -101,9 +101,9 @@ export function EmptyState({ icon, title, description }: EmptyStateProps) {
           </svg>
         )}
       </div>
-      <p className="text-sm font-medium text-text-muted">{title}</p>
+      <p className="text-sm font-medium text-muted-foreground">{title}</p>
       {description && (
-        <p className="text-[12px] text-text-muted/60 mt-1.5 max-w-[280px]">{description}</p>
+        <p className="text-[12px] text-muted-foreground/60 mt-1.5 max-w-[280px]">{description}</p>
       )}
     </div>
   )

--- a/ui/src/components/TabStrip.tsx
+++ b/ui/src/components/TabStrip.tsx
@@ -100,7 +100,7 @@ export function TabStrip() {
     <>
       <div
         onWheel={handleWheel}
-        className="scrollbar-hide hidden md:flex shrink-0 h-10 bg-bg-secondary/95 border-b border-border/80 overflow-x-auto"
+        className="scrollbar-hide hidden md:flex shrink-0 h-10 bg-secondary/95 border-b border-border/80 overflow-x-auto"
       >
         {tabIds.map((id) => {
           const tab = tabsMap[id]
@@ -157,8 +157,8 @@ function TabButton({ title, active, onSelect, onClose, onContextMenu }: TabButto
       onContextMenu={onContextMenu}
       className={`group flex items-center gap-2 pl-3 pr-2 h-full text-[13px] cursor-pointer border-r border-border/80 transition-colors ${
         active
-          ? 'bg-bg-tertiary text-text'
-          : 'text-text-muted hover:text-text hover:bg-overlay'
+          ? 'bg-muted text-foreground'
+          : 'text-muted-foreground hover:text-foreground hover:bg-accent'
       }`}
     >
       <span className="truncate max-w-[200px]">{title}</span>
@@ -168,7 +168,7 @@ function TabButton({ title, active, onSelect, onClose, onContextMenu }: TabButto
           e.stopPropagation()
           onClose()
         }}
-        className="w-4 h-4 rounded flex items-center justify-center text-text-muted/60 hover:text-text hover:bg-overlay-strong"
+        className="w-4 h-4 rounded flex items-center justify-center text-muted-foreground/60 hover:text-foreground hover:bg-accent-strong"
         aria-label={`Close ${title}`}
       >
         <X size={11} strokeWidth={2.5} />

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -34,12 +34,12 @@ export function ThemeToggle({ compact = false }: { compact?: boolean }) {
       onClick={cycle}
       title={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
       aria-label={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
-      className={`relative flex ${compact ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-overlay hover:text-text`}
+      className={`relative flex ${compact ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground`}
     >
       <Icon size={compact ? 14 : 17} strokeWidth={1.75} aria-hidden />
       {theme === 'auto' && (
         <span
-          className={`absolute right-0 top-0 rounded-[3px] border border-border bg-bg-tertiary px-[2px] py-px text-[7px] ${compact ? 'md:text-[6px]' : ''} font-semibold leading-none text-text-muted shadow-sm`}
+          className={`absolute right-0 top-0 rounded-[3px] border border-border bg-muted px-[2px] py-px text-[7px] ${compact ? 'md:text-[6px]' : ''} font-semibold leading-none text-muted-foreground shadow-sm`}
           aria-hidden
         >
           Auto

--- a/ui/src/components/Toast.tsx
+++ b/ui/src/components/Toast.tsx
@@ -96,7 +96,7 @@ function ToastNotification({ toast, onDismiss }: { toast: ToastItem; onDismiss: 
       className={`
         pointer-events-auto flex items-center gap-2 px-4 py-2.5 rounded-lg shadow-lg border text-sm
         transition-all duration-200
-        ${isSuccess ? 'bg-green/10 border-green/30 text-green' : 'bg-red/10 border-red/30 text-red'}
+        ${isSuccess ? 'bg-success/10 border-success/30 text-success' : 'bg-destructive/10 border-destructive/30 text-destructive'}
         ${mounted && !toast.removing ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-4'}
       `}
       role="alert"

--- a/ui/src/components/Toggle.tsx
+++ b/ui/src/components/Toggle.tsx
@@ -19,12 +19,12 @@ export function Toggle({ checked, onChange, size = 'md', ariaLabel, disabled = f
       disabled={disabled}
       onClick={() => onChange(!checked)}
       className={`relative rounded-full transition-colors ${track} ${disabled ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'} ${
-        checked ? 'bg-accent' : 'bg-bg-tertiary'
+        checked ? 'bg-primary' : 'bg-muted'
       }`}
     >
       <span
         className={`absolute rounded-full transition-all ${thumb} ${
-          checked ? `${translate} bg-white` : 'bg-text-muted'
+          checked ? `${translate} bg-primary-foreground` : 'bg-muted-foreground'
         }`}
       />
     </button>

--- a/ui/src/components/TrackedSidebar.tsx
+++ b/ui/src/components/TrackedSidebar.tsx
@@ -50,9 +50,9 @@ export function TrackedSidebar() {
 
   if (entities.length === 0) {
     return (
-      <div className="px-3 py-4 text-[12px] text-text-muted/70 leading-relaxed">
+      <div className="px-3 py-4 text-[12px] text-muted-foreground/70 leading-relaxed">
         {t('tracked.nothingTrackedYet')}
-        <div className="mt-1 text-text-muted/50">
+        <div className="mt-1 text-muted-foreground/50">
           Agents register assets &amp; topics with the{' '}
           <code className="text-[11px]">entity_upsert</code> tool, then link to them with{' '}
           <code className="text-[11px]">[[name]]</code> in their notes.
@@ -107,7 +107,7 @@ export function TrackedSidebar() {
 
 function SectionCount({ count }: { count: number }) {
   return (
-    <span className="rounded-full bg-bg-tertiary px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-text-muted/65">
+    <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground/65">
       {count}
     </span>
   )
@@ -140,13 +140,13 @@ function TrackedEntityRow({
       }}
       className={`group relative mb-0.5 grid min-h-[38px] grid-cols-[24px_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2.5 py-1.5 outline-none transition-colors ${
         active
-          ? 'bg-accent-dim text-text shadow-[inset_2px_0_0_var(--color-accent)]'
-          : 'text-text-muted hover:bg-overlay hover:text-text focus-visible:bg-overlay'
+          ? 'bg-primary-muted text-foreground shadow-[inset_2px_0_0_var(--primary)]'
+          : 'text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:bg-accent'
       }`}
     >
       <span
         className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${
-          active ? 'bg-bg/60 text-accent' : 'bg-bg-tertiary/55 text-text-muted/70 group-hover:text-text-muted'
+          active ? 'bg-background/60 text-primary' : 'bg-muted/55 text-muted-foreground/70 group-hover:text-muted-foreground'
         }`}
         aria-hidden
       >
@@ -156,15 +156,15 @@ function TrackedEntityRow({
       <span className="min-w-0">
         {display.prefix ? (
           <span className="flex min-w-0 items-baseline gap-1.5">
-            <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-text-muted/55">
+            <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/55">
               {display.prefix}
             </span>
-            <span className={`truncate text-[12.5px] ${active ? 'font-semibold text-text' : 'font-medium'}`}>
+            <span className={`truncate text-[12.5px] ${active ? 'font-semibold text-foreground' : 'font-medium'}`}>
               {display.rest}
             </span>
           </span>
         ) : (
-          <span className={`block truncate text-[12.5px] ${active ? 'font-semibold text-text' : 'font-medium'}`}>
+          <span className={`block truncate text-[12.5px] ${active ? 'font-semibold text-foreground' : 'font-medium'}`}>
             {display.rest}
           </span>
         )}
@@ -173,7 +173,7 @@ function TrackedEntityRow({
       {entity.backlinkCount > 0 && (
         <span
           className={`min-w-[20px] rounded-full px-1.5 py-0.5 text-center text-[10px] font-medium tabular-nums ${
-            active ? 'bg-bg/75 text-text-muted' : 'bg-bg-tertiary/70 text-text-muted/65'
+            active ? 'bg-background/75 text-muted-foreground' : 'bg-muted/70 text-muted-foreground/65'
           }`}
           title={t('tracked.backlinksTooltip', { count: entity.backlinkCount })}
         >

--- a/ui/src/components/TradingModeGate.tsx
+++ b/ui/src/components/TradingModeGate.tsx
@@ -11,22 +11,22 @@ export function TradingModeGate({ title, description }: TradingModeGateProps) {
 
   return (
     <div className="flex min-h-[420px] items-center justify-center px-0 py-8 sm:px-4 sm:py-10">
-      <div className="w-full max-w-[560px] rounded-lg border border-border bg-bg-secondary px-4 py-5 sm:px-5">
+      <div className="w-full max-w-[560px] rounded-lg border border-border bg-secondary px-4 py-5 sm:px-5">
         <div className="flex flex-col items-start gap-3 sm:flex-row">
-          <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-bg-tertiary text-text-muted">
+          <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-muted text-muted-foreground">
             <Gauge size={18} strokeWidth={1.8} aria-hidden />
           </span>
           <div className="min-w-0">
-            <div className="text-[11px] font-semibold uppercase tracking-wide text-text-muted">Lite mode</div>
-            <h2 className="mt-1 text-[17px] font-semibold text-text">{title}</h2>
-            <p className="mt-1.5 text-[12px] leading-relaxed text-text-muted">{description}</p>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Lite mode</div>
+            <h2 className="mt-1 text-[17px] font-semibold text-foreground">{title}</h2>
+            <p className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">{description}</p>
           </div>
         </div>
 
         <button
           type="button"
           onClick={() => openOrFocus({ kind: 'settings', params: { category: 'agent-permissions' } })}
-          className="mt-4 inline-flex min-h-9 items-center gap-2 rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-text transition-colors hover:border-accent/50 hover:bg-bg-tertiary"
+          className="mt-4 inline-flex min-h-9 items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-[12px] font-medium text-foreground transition-colors hover:border-primary/50 hover:bg-muted"
         >
           <Settings size={14} strokeWidth={1.8} aria-hidden />
           Open Agent Permissions

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -48,9 +48,9 @@ export function UpdateBanner() {
   }
 
   return (
-    <div className="flex items-center gap-3 px-4 py-2 bg-accent-dim/30 border-b border-accent/40 text-[12px] text-text">
+    <div className="flex items-center gap-3 px-4 py-2 bg-primary-muted/30 border-b border-primary/40 text-[12px] text-foreground">
       <span className="shrink-0">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-accent">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-primary">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
           <polyline points="7 10 12 15 17 10" />
           <line x1="12" y1="15" x2="12" y2="3" />
@@ -58,18 +58,18 @@ export function UpdateBanner() {
       </span>
       <span className="flex-1 min-w-0 truncate">
         <span className="font-semibold">v{info.latest}</span> available
-        {' '}<span className="text-text-muted hidden sm:inline">(you have v{info.current})</span>
+        {' '}<span className="text-muted-foreground hidden sm:inline">(you have v{info.current})</span>
         {info.publishedAt && (
-          <span className="text-text-muted hidden lg:inline"> · released {info.publishedAt.slice(0, 10)}</span>
+          <span className="text-muted-foreground hidden lg:inline"> · released {info.publishedAt.slice(0, 10)}</span>
         )}
       </span>
       {runtimeMode === 'electron-packaged' ? (
-        <span className="text-text-muted shrink-0 hidden md:inline">
+        <span className="text-muted-foreground shrink-0 hidden md:inline">
           Desktop updater will prompt when the download is ready
         </span>
       ) : (
-        <span className="text-text-muted shrink-0 hidden md:inline">
-          Run <code className="text-accent bg-bg-tertiary px-1 rounded">git pull &amp;&amp; pnpm build</code> to update
+        <span className="text-muted-foreground shrink-0 hidden md:inline">
+          Run <code className="text-primary bg-muted px-1 rounded">git pull &amp;&amp; pnpm build</code> to update
         </span>
       )}
       {info.releaseUrl && (
@@ -77,7 +77,7 @@ export function UpdateBanner() {
           href={info.releaseUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-accent hover:underline shrink-0"
+          className="text-primary hover:underline shrink-0"
         >
           <span className="hidden sm:inline">Release notes</span>
           <span className="sm:hidden">Notes</span>
@@ -86,7 +86,7 @@ export function UpdateBanner() {
       )}
       <button
         onClick={handleSkip}
-        className="text-text-muted hover:text-text shrink-0 text-[11px]"
+        className="text-muted-foreground hover:text-foreground shrink-0 text-[11px]"
         title="Don't show this update again"
       >
         <span className="hidden sm:inline">Skip this version</span>
@@ -94,7 +94,7 @@ export function UpdateBanner() {
       </button>
       <button
         onClick={handleDismiss}
-        className="text-text-muted hover:text-text shrink-0"
+        className="text-muted-foreground hover:text-foreground shrink-0"
         title="Dismiss until next reload"
         aria-label="Dismiss"
       >

--- a/ui/src/components/credentials/CredentialModal.tsx
+++ b/ui/src/components/credentials/CredentialModal.tsx
@@ -214,14 +214,14 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
   }
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={onClose}>
-      <div className="bg-bg border border-border rounded-xl shadow-2xl w-[calc(100vw-24px)] max-w-xl max-h-[88vh] flex flex-col" onClick={(event) => event.stopPropagation()}>
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-backdrop backdrop-blur-sm" onClick={onClose}>
+      <div className="bg-background border border-border rounded-xl shadow-2xl w-[calc(100vw-24px)] max-w-xl max-h-[88vh] flex flex-col" onClick={(event) => event.stopPropagation()}>
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <div>
-            <h2 className="text-[15px] font-semibold text-text">{title}</h2>
-            <p className="mt-0.5 text-[11px] text-text-muted">Connect a provider account to the agent runtimes that can use it.</p>
+            <h2 className="text-[15px] font-semibold text-foreground">{title}</h2>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">Connect a provider account to the agent runtimes that can use it.</p>
           </div>
-          <button onClick={onClose} aria-label="Close credential dialog" className="text-text-muted hover:text-text transition-colors">
+          <button onClick={onClose} aria-label="Close credential dialog" className="text-muted-foreground hover:text-foreground transition-colors">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
           </button>
         </div>
@@ -236,31 +236,31 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                 placeholder="Search providers..."
                 autoFocus
               />
-              <div className="overflow-hidden rounded-lg border border-border bg-bg">
+              <div className="overflow-hidden rounded-lg border border-border bg-background">
                 {visiblePresets.map((item) => (
                   <button
                     key={item.id}
                     onClick={() => pickPreset(item)}
-                    className="flex min-h-[46px] w-full items-center gap-3 border-b border-border/60 px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-bg-tertiary/60"
+                    className="flex min-h-[46px] w-full items-center gap-3 border-b border-border/60 px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-muted/60"
                   >
                     <span className="min-w-0 flex-1">
-                      <span className="block truncate text-[12.5px] font-medium text-text">{item.label}</span>
-                      <span className="block truncate text-[10.5px] text-text-muted">{item.description}</span>
-                      <span className="mt-0.5 block truncate text-[10px] text-text-muted/75">
+                      <span className="block truncate text-[12.5px] font-medium text-foreground">{item.label}</span>
+                      <span className="block truncate text-[10.5px] text-muted-foreground">{item.description}</span>
+                      <span className="mt-0.5 block truncate text-[10px] text-muted-foreground/75">
                         {item.category === 'custom'
                           ? 'Choose an API mode to determine compatible agents'
                           : `Works with ${agentNames(presetCompatibleAgentIds(item))}`}
                       </span>
                     </span>
                     {item.category === 'custom' && (
-                      <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-text-muted">
+                      <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground">
                         free-form
                       </span>
                     )}
                   </button>
                 ))}
                 {visiblePresets.length === 0 && (
-                  <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-[12px] text-text-muted">
+                  <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-[12px] text-muted-foreground">
                     No providers match "{presetQuery}".
                   </p>
                 )}
@@ -270,16 +270,16 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
             <>
               <div className="flex items-center justify-between">
                 <div className="flex items-baseline gap-2">
-                  <span className="text-[13px] font-semibold text-text">{preset.label}</span>
-                  <span className="text-[11px] text-text-muted">{preset.description}</span>
+                  <span className="text-[13px] font-semibold text-foreground">{preset.label}</span>
+                  <span className="text-[11px] text-muted-foreground">{preset.description}</span>
                 </div>
                 {mode === 'add' && (
-                  <button onClick={() => { setPreset(null); gate.reset() }} className="text-[11px] text-accent hover:underline">change</button>
+                  <button onClick={() => { setPreset(null); gate.reset() }} className="text-[11px] text-primary hover:underline">change</button>
                 )}
               </div>
 
               {preset.hint && (
-                <p className="text-[11px] text-text-muted bg-bg-tertiary rounded-lg px-3 py-2.5 leading-relaxed">{preset.hint}</p>
+                <p className="text-[11px] text-muted-foreground bg-muted rounded-lg px-3 py-2.5 leading-relaxed">{preset.hint}</p>
               )}
 
               {isCustom ? (
@@ -330,19 +330,19 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                 </>
               )}
 
-              <div className="rounded-lg border border-accent/20 bg-accent/5 px-3 py-2.5">
+              <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2.5">
                 <div className="flex flex-wrap items-center gap-1.5">
-                  <span className="mr-1 text-[11px] font-medium text-text">Compatible agent runtimes</span>
+                  <span className="mr-1 text-[11px] font-medium text-foreground">Compatible agent runtimes</span>
                   {compatibleAgents.map((agentId) => (
-                    <span key={agentId} className="rounded border border-accent/25 bg-bg px-1.5 py-0.5 text-[10px] text-text-muted">
+                    <span key={agentId} className="rounded border border-primary/25 bg-background px-1.5 py-0.5 text-[10px] text-muted-foreground">
                       {AGENT_LABELS[agentId] ?? agentId}
                     </span>
                   ))}
                   {compatibleAgents.length === 0 && (
-                    <span className="text-[10.5px] text-text-muted">Choose a supported API mode.</span>
+                    <span className="text-[10.5px] text-muted-foreground">Choose a supported API mode.</span>
                   )}
                 </div>
-                <p className="mt-1.5 text-[10.5px] leading-relaxed text-text-muted">
+                <p className="mt-1.5 text-[10.5px] leading-relaxed text-muted-foreground">
                   OpenAlice injects the key, endpoint, protocol, and model into one of these Workspace runtimes. Other runtimes will not offer this credential.
                 </p>
               </div>
@@ -365,7 +365,7 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                   <button
                     type="button"
                     onClick={() => setShowKey(!showKey)}
-                    className="px-3 rounded-md border border-border text-text-muted hover:text-text text-[12px]"
+                    className="px-3 rounded-md border border-border text-muted-foreground hover:text-foreground text-[12px]"
                   >
                     {showKey ? 'Hide' : 'Show'}
                   </button>
@@ -379,36 +379,36 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                 <ModelCombobox value={model} suggestions={models} onChange={setModel} placeholder="Exact provider model ID" />
               </Field>
 
-              <details className="rounded-lg border border-border bg-bg-secondary/20 px-3 py-2">
-                <summary className="cursor-pointer select-none text-[11px] text-text-muted hover:text-text">
+              <details className="rounded-lg border border-border bg-secondary/20 px-3 py-2">
+                <summary className="cursor-pointer select-none text-[11px] text-muted-foreground hover:text-foreground">
                   Protocol and endpoint details
                 </summary>
                 <div className="mt-2 space-y-1.5 border-t border-border/60 pt-2">
-                  {shapes.length === 0 && <p className="text-[11px] text-text-muted">No endpoint is configured yet.</p>}
+                  {shapes.length === 0 && <p className="text-[11px] text-muted-foreground">No endpoint is configured yet.</p>}
                   {shapes.map((shape) => (
                     <div key={shape} className="grid grid-cols-[125px_minmax(0,1fr)] gap-2 text-[10.5px]">
-                      <span className="text-text-muted">{WIRE_SHAPE_GUIDANCE[shape]}</span>
-                      <span className="break-all font-mono text-text-muted/80">{wires[shape] || 'Provider official endpoint'}</span>
+                      <span className="text-muted-foreground">{WIRE_SHAPE_GUIDANCE[shape]}</span>
+                      <span className="break-all font-mono text-muted-foreground/80">{wires[shape] || 'Provider official endpoint'}</span>
                     </div>
                   ))}
                 </div>
               </details>
 
-              <p className="rounded-lg bg-bg-tertiary px-3 py-2 text-[10.5px] leading-relaxed text-text-muted">
-                Test connection sends a small request to <span className="font-mono text-text">{model.trim() || 'the selected model'}</span>. Saving unlocks only after this exact key, endpoint, protocol, and model pass together.
+              <p className="rounded-lg bg-muted px-3 py-2 text-[10.5px] leading-relaxed text-muted-foreground">
+                Test connection sends a small request to <span className="font-mono text-foreground">{model.trim() || 'the selected model'}</span>. Saving unlocks only after this exact key, endpoint, protocol, and model pass together.
               </p>
 
               {error && (
-                <p className="min-w-0 max-w-full whitespace-pre-wrap break-words text-[12px] text-red">{error}</p>
+                <p className="min-w-0 max-w-full whitespace-pre-wrap break-words text-[12px] text-destructive">{error}</p>
               )}
-              {gate.testing && <p className="text-[12px] text-text-muted">Testing connection...</p>}
+              {gate.testing && <p className="text-[12px] text-muted-foreground">Testing connection...</p>}
               {gate.result && !staleResult && (
-                <div className={`min-w-0 max-w-full overflow-hidden rounded-lg px-3 py-2.5 text-[12px] ${gate.result.ok ? 'bg-green/10 text-green' : 'bg-red/10 text-red'}`}>
+                <div className={`min-w-0 max-w-full overflow-hidden rounded-lg px-3 py-2.5 text-[12px] ${gate.result.ok ? 'bg-success/10 text-success' : 'bg-destructive/10 text-destructive'}`}>
                   {gate.result.ok ? (
                     gate.result.response?.trim() ? (
                       <>
                         <div className="font-medium mb-0.5">Connection verified.</div>
-                        <div className="whitespace-pre-wrap break-words font-mono text-[11.5px] text-text">
+                        <div className="whitespace-pre-wrap break-words font-mono text-[11.5px] text-foreground">
                           {gate.result.response.trim().slice(0, 240)}
                         </div>
                       </>
@@ -426,28 +426,28 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                 </div>
               )}
               {staleResult && (
-                <p className="text-[11px] text-yellow-400/90">Form changed since the last test - re-test before saving.</p>
+                <p className="text-[11px] text-warning/90">Form changed since the last test - re-test before saving.</p>
               )}
             </>
           )}
         </div>
 
         {preset && (
-          <div className="flex flex-col gap-3 px-5 py-3 border-t border-border bg-bg-secondary/30 sm:flex-row sm:items-center sm:justify-between">
-            <div className="min-w-0 text-[12px] text-text-muted">
+          <div className="flex flex-col gap-3 px-5 py-3 border-t border-border bg-secondary/30 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0 text-[12px] text-muted-foreground">
               {tested ? (
-                <span className="inline-flex items-center gap-2 text-green">
-                  <span className="h-2 w-2 rounded-full bg-green" />
+                <span className="inline-flex items-center gap-2 text-success">
+                  <span className="h-2 w-2 rounded-full bg-success" />
                   Connection verified
                 </span>
               ) : staleResult ? (
-                <span className="inline-flex items-center gap-2 text-yellow-400/90">
-                  <span className="h-2 w-2 rounded-full bg-yellow-400/80" />
+                <span className="inline-flex items-center gap-2 text-warning/90">
+                  <span className="h-2 w-2 rounded-full bg-warning/80" />
                   Form changed - test again
                 </span>
               ) : gate.result && !gate.result.ok ? (
-                <span className="inline-flex items-center gap-2 text-red">
-                  <span className="h-2 w-2 rounded-full bg-red" />
+                <span className="inline-flex items-center gap-2 text-destructive">
+                  <span className="h-2 w-2 rounded-full bg-destructive" />
                   Fix the fields and test again
                 </span>
               ) : (
@@ -455,7 +455,7 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
               )}
             </div>
             <div className="flex items-center gap-2">
-              <button onClick={onClose} className="text-[12px] px-3 py-1.5 rounded-md text-text-muted hover:text-text">Cancel</button>
+              <button onClick={onClose} className="text-[12px] px-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground">Cancel</button>
               <button
                 data-testid="credential-modal-primary"
                 onClick={handlePrimaryAction}

--- a/ui/src/components/form.tsx
+++ b/ui/src/components/form.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 // ==================== Shared class constants ====================
 
 export const inputClass =
-  'w-full px-3 py-2 bg-bg text-text border border-border rounded-lg font-sans text-sm outline-none transition-all duration-200 focus:border-accent/60 focus:shadow-[0_0_0_1px_var(--color-accent-dim)]'
+  'w-full px-3 py-2 bg-background text-foreground border border-border rounded-lg font-sans text-sm outline-none transition-all duration-200 focus:border-primary/60 focus:shadow-[0_0_0_1px_var(--primary-muted)]'
 
 // ==================== Card ====================
 
@@ -14,7 +14,7 @@ interface CardProps {
 
 export function Card({ children, className = '' }: CardProps) {
   return (
-    <div className={`bg-bg-secondary/50 border border-border/60 rounded-xl p-5 transition-colors hover:border-accent/20 ${className}`}>
+    <div className={`bg-secondary/50 border border-border/60 rounded-xl p-5 transition-colors hover:border-primary/20 ${className}`}>
       {children}
     </div>
   )
@@ -33,11 +33,11 @@ export function Section({ id, title, description, children }: SectionProps) {
   return (
     <Card>
       <div id={id}>
-        <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wider mb-1">
+        <h3 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wider mb-1">
           {title}
         </h3>
         {description && (
-          <p className="text-[13px] text-text-muted/70 mb-4 leading-relaxed">{description}</p>
+          <p className="text-[13px] text-muted-foreground/70 mb-4 leading-relaxed">{description}</p>
         )}
         {children}
       </div>
@@ -58,9 +58,9 @@ export function ConfigSection({ title, description, children }: ConfigSectionPro
   return (
     <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-1 md:gap-10 py-6 border-b border-border/60 last:border-b-0">
       <div className="mb-3 md:mb-0 md:pt-0.5">
-        <h3 className="text-[14px] font-semibold text-text">{title}</h3>
+        <h3 className="text-[14px] font-semibold text-foreground">{title}</h3>
         {description && (
-          <p className="text-[13px] text-text-muted/70 mt-1.5 leading-relaxed">{description}</p>
+          <p className="text-[13px] text-muted-foreground/70 mt-1.5 leading-relaxed">{description}</p>
         )}
       </div>
       <div>{children}</div>
@@ -79,10 +79,10 @@ interface FieldProps {
 export function Field({ label, description, children }: FieldProps) {
   return (
     <div className="mb-3.5 last:mb-0">
-      <label className="block text-[13px] text-text mb-1.5 font-medium">{label}</label>
+      <label className="block text-[13px] text-foreground mb-1.5 font-medium">{label}</label>
       {children}
       {description && (
-        <p className="text-[12px] text-text-muted/60 mt-1">{description}</p>
+        <p className="text-[12px] text-muted-foreground/60 mt-1">{description}</p>
       )}
     </div>
   )

--- a/ui/src/components/guards.tsx
+++ b/ui/src/components/guards.tsx
@@ -110,7 +110,7 @@ export function GuardsSection({ guards, guardTypes, description, onChange, onCha
         description={description}
       >
         {guards.length === 0 && (
-          <p className="text-[12px] text-text-muted/60 mb-3">
+          <p className="text-[12px] text-muted-foreground/60 mb-3">
             No guards configured. All trades will pass through unchecked.
           </p>
         )}
@@ -120,18 +120,18 @@ export function GuardsSection({ guards, guardTypes, description, onChange, onCha
             const meta = guardTypes.find((t) => t.type === guard.type)
             const isEditing = editingIdx === idx
             return (
-              <div key={idx} className="border border-border rounded-lg bg-bg-secondary">
+              <div key={idx} className="border border-border rounded-lg bg-secondary">
                 {/* Header row */}
                 <div className="flex items-center gap-2 px-3 py-2">
                   <button
                     onClick={() => setEditingIdx(isEditing ? null : idx)}
-                    className="text-[10px] text-text-muted w-4"
+                    className="text-[10px] text-muted-foreground w-4"
                   >
                     {isEditing ? '▼' : '▶'}
                   </button>
-                  <span className="text-[13px] font-medium text-text flex-1">
+                  <span className="text-[13px] font-medium text-foreground flex-1">
                     {meta?.label || guard.type}
-                    <span className="text-text-muted font-normal ml-2 text-[12px]">
+                    <span className="text-muted-foreground font-normal ml-2 text-[12px]">
                       {guardSummary(guard)}
                     </span>
                   </span>
@@ -139,7 +139,7 @@ export function GuardsSection({ guards, guardTypes, description, onChange, onCha
                     <button
                       onClick={() => moveGuard(idx, -1)}
                       disabled={idx === 0}
-                      className="text-text-muted hover:text-text disabled:opacity-25 p-1 text-[11px]"
+                      className="text-muted-foreground hover:text-foreground disabled:opacity-25 p-1 text-[11px]"
                       title="Move up"
                     >
                       ▲
@@ -147,14 +147,14 @@ export function GuardsSection({ guards, guardTypes, description, onChange, onCha
                     <button
                       onClick={() => moveGuard(idx, 1)}
                       disabled={idx === guards.length - 1}
-                      className="text-text-muted hover:text-text disabled:opacity-25 p-1 text-[11px]"
+                      className="text-muted-foreground hover:text-foreground disabled:opacity-25 p-1 text-[11px]"
                       title="Move down"
                     >
                       ▼
                     </button>
                     <button
                       onClick={() => removeGuard(idx)}
-                      className="text-text-muted hover:text-red p-1 ml-1 text-[13px]"
+                      className="text-muted-foreground hover:text-destructive p-1 ml-1 text-[13px]"
                       title="Remove"
                     >
                       ×
@@ -165,7 +165,7 @@ export function GuardsSection({ guards, guardTypes, description, onChange, onCha
                 {/* Editor */}
                 {isEditing && (
                   <div className="px-3 pb-3 pt-1 border-t border-border">
-                    {meta && <p className="text-[11px] text-text-muted/60 mb-2">{meta.desc}</p>}
+                    {meta && <p className="text-[11px] text-muted-foreground/60 mb-2">{meta.desc}</p>}
                     <GuardOptionsEditor
                       type={guard.type}
                       options={guard.options}
@@ -204,7 +204,7 @@ function AddGuardButton({
     return (
       <button
         onClick={() => setOpen(true)}
-        className="border border-dashed border-border rounded-lg px-3 py-2 text-[12px] text-text-muted hover:text-text hover:border-text-muted transition-colors w-full text-left"
+        className="border border-dashed border-border rounded-lg px-3 py-2 text-[12px] text-muted-foreground hover:text-foreground hover:border-muted-foreground transition-colors w-full text-left"
       >
         + Add Guard
       </button>
@@ -212,19 +212,19 @@ function AddGuardButton({
   }
 
   return (
-    <div className="border border-border rounded-lg bg-bg-secondary p-3 space-y-1.5">
-      <p className="text-[11px] text-text-muted mb-1.5">Select a guard type:</p>
+    <div className="border border-border rounded-lg bg-secondary p-3 space-y-1.5">
+      <p className="text-[11px] text-muted-foreground mb-1.5">Select a guard type:</p>
       {types.map(({ type, label, desc }) => (
         <button
           key={type}
           onClick={() => { onAdd(type); setOpen(false) }}
-          className="block w-full text-left px-2.5 py-2 rounded-md hover:bg-bg-tertiary transition-colors"
+          className="block w-full text-left px-2.5 py-2 rounded-md hover:bg-muted transition-colors"
         >
-          <span className="text-[13px] text-text font-medium">{label}</span>
-          <span className="block text-[11px] text-text-muted/60">{desc}</span>
+          <span className="text-[13px] text-foreground font-medium">{label}</span>
+          <span className="block text-[11px] text-muted-foreground/60">{desc}</span>
         </button>
       ))}
-      <button onClick={() => setOpen(false)} className="text-[11px] text-text-muted hover:text-text mt-1">
+      <button onClick={() => setOpen(false)} className="text-[11px] text-muted-foreground hover:text-foreground mt-1">
         Cancel
       </button>
     </div>
@@ -273,7 +273,7 @@ function MaxPositionSizeEditor({ options, onChange }: EditorProps) {
         value={pct}
         onChange={(e) => onChange({ ...options, maxPercentOfEquity: Number(e.target.value) })}
       />
-      <p className="text-[10px] text-text-muted/60 mt-1">
+      <p className="text-[10px] text-muted-foreground/60 mt-1">
         Rejects orders where estimated position value exceeds this % of account equity.
       </p>
     </Field>
@@ -292,7 +292,7 @@ function MaxLeverageEditor({ options, onChange }: EditorProps) {
         value={lev}
         onChange={(e) => onChange({ ...options, maxLeverage: Number(e.target.value) })}
       />
-      <p className="text-[10px] text-text-muted/60 mt-1">
+      <p className="text-[10px] text-muted-foreground/60 mt-1">
         Rejects orders and leverage adjustments exceeding this limit.
       </p>
     </Field>
@@ -311,7 +311,7 @@ function CooldownEditor({ options, onChange }: EditorProps) {
         value={seconds}
         onChange={(e) => onChange({ ...options, minIntervalMs: Number(e.target.value) * 1000 })}
       />
-      <p className="text-[10px] text-text-muted/60 mt-1">
+      <p className="text-[10px] text-muted-foreground/60 mt-1">
         Minimum seconds between trades on the same symbol.
       </p>
     </Field>
@@ -334,7 +334,7 @@ function SymbolWhitelistEditor({ options, onChange }: EditorProps) {
           onChange({ ...options, symbols: parsed })
         }}
       />
-      <p className="text-[10px] text-text-muted/60 mt-1">
+      <p className="text-[10px] text-muted-foreground/60 mt-1">
         Comma-separated list of symbols allowed for trading.
       </p>
     </Field>
@@ -358,12 +358,12 @@ function GenericEditor({ options, onChange }: EditorProps) {
   return (
     <Field label="Options (JSON)">
       <textarea
-        className={`${inputClass} min-h-[80px] font-mono text-[12px] ${parseError ? 'border-red' : ''}`}
+        className={`${inputClass} min-h-[80px] font-mono text-[12px] ${parseError ? 'border-destructive' : ''}`}
         value={raw}
         onChange={(e) => setRaw(e.target.value)}
         onBlur={handleBlur}
       />
-      {parseError && <p className="text-[10px] text-red mt-1">Invalid JSON</p>}
+      {parseError && <p className="text-[10px] text-destructive mt-1">Invalid JSON</p>}
     </Field>
   )
 }

--- a/ui/src/components/issue-status-meta.ts
+++ b/ui/src/components/issue-status-meta.ts
@@ -16,9 +16,9 @@ export interface StatusMeta {
 }
 
 export const STATUS_META: Record<IssueStatus, StatusMeta> = {
-  in_progress: { label: 'In Progress', Icon: CircleDot, className: 'text-amber-400' },
-  todo: { label: 'Todo', Icon: Circle, className: 'text-muted' },
-  backlog: { label: 'Backlog', Icon: CircleDashed, className: 'text-muted/60' },
-  done: { label: 'Done', Icon: CheckCircle2, className: 'text-emerald-400' },
-  canceled: { label: 'Canceled', Icon: XCircle, className: 'text-muted/50' },
+  in_progress: { label: 'In Progress', Icon: CircleDot, className: 'text-warning' },
+  todo: { label: 'Todo', Icon: Circle, className: 'text-muted-foreground' },
+  backlog: { label: 'Backlog', Icon: CircleDashed, className: 'text-muted-foreground/60' },
+  done: { label: 'Done', Icon: CheckCircle2, className: 'text-success' },
+  canceled: { label: 'Canceled', Icon: XCircle, className: 'text-muted-foreground/50' },
 }

--- a/ui/src/components/market/BoardMeta.tsx
+++ b/ui/src/components/market/BoardMeta.tsx
@@ -20,11 +20,11 @@ export function BoardMeta({ meta, extra }: { meta: ReferenceMeta; extra?: string
     meta.cachedAt ? `cached: ${meta.cachedAt}` : null,
   ].filter(Boolean).join(' · ')
   return (
-    <span className="text-text-muted" title={detail}>
+    <span className="text-muted-foreground" title={detail}>
       {extra && <> · {extra}</>}
       {' · '}{sourceWord}
       {meta.stale && (
-        <span className="ml-1.5 rounded bg-amber-500/15 px-1 py-px text-[9px] uppercase tracking-wide text-amber-700 dark:text-amber-300">stale</span>
+        <span className="ml-1.5 rounded bg-warning/15 px-1 py-px text-[9px] uppercase tracking-wide text-warning">stale</span>
       )}
     </span>
   )

--- a/ui/src/components/market/Card.tsx
+++ b/ui/src/components/market/Card.tsx
@@ -23,10 +23,10 @@ interface Props {
  */
 export function Card({ title, info, right, className, contentClassName, children }: Props) {
   return (
-    <section className={`flex flex-col border border-border rounded bg-bg-secondary/30 ${className ?? ''}`}>
+    <section className={`flex flex-col border border-border rounded bg-secondary/30 ${className ?? ''}`}>
       <header className="flex items-center justify-between gap-3 px-3 py-2 border-b border-border/60">
         <div className="flex items-center gap-1.5 min-w-0">
-          <h3 className="text-[13px] font-medium text-text truncate">{title}</h3>
+          <h3 className="text-[13px] font-medium text-foreground truncate">{title}</h3>
           {info && (
             // Custom CSS-only tooltip via Tailwind's group/group-hover.
             // Native `title=` was the first instinct but the browser-level
@@ -34,14 +34,14 @@ export function Card({ title, info, right, className, contentClassName, children
             // instantly and lets us style / wrap freely.
             <span className="relative group inline-flex items-center">
               <span
-                className="inline-flex items-center justify-center w-[14px] h-[14px] rounded-full bg-text-muted/30 text-bg text-[10px] font-bold leading-none cursor-help select-none shrink-0"
+                className="inline-flex items-center justify-center w-[14px] h-[14px] rounded-full bg-muted-foreground/30 text-background text-[10px] font-bold leading-none cursor-help select-none shrink-0"
                 aria-label={info}
               >
                 i
               </span>
               <span
                 role="tooltip"
-                className="absolute left-0 top-full mt-1.5 z-50 hidden group-hover:block w-max max-w-sm whitespace-pre-line px-2.5 py-1.5 bg-bg-tertiary border border-border rounded shadow-lg text-[11px] text-text leading-relaxed pointer-events-none"
+                className="absolute left-0 top-full mt-1.5 z-50 hidden group-hover:block w-max max-w-sm whitespace-pre-line px-2.5 py-1.5 bg-muted border border-border rounded shadow-lg text-[11px] text-foreground leading-relaxed pointer-events-none"
               >
                 {info}
               </span>

--- a/ui/src/components/market/FinancialStatementsPanel.tsx
+++ b/ui/src/components/market/FinancialStatementsPanel.tsx
@@ -123,7 +123,7 @@ export function FinancialStatementsPanel({ symbol }: Props) {
               onClick={() => setTab(t.key)}
               className={`px-2.5 py-1 text-[12px] transition-colors cursor-pointer ${
                 i > 0 ? 'border-l border-border' : ''
-              } ${tab === t.key ? 'bg-bg-tertiary text-text' : 'text-text-muted hover:text-text'}`}
+              } ${tab === t.key ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
             >
               {t.label}
             </button>
@@ -135,7 +135,7 @@ export function FinancialStatementsPanel({ symbol }: Props) {
         <table aria-hidden="true" className="w-full text-[12px] border-collapse">
           <thead>
             <tr className="border-b border-border/60">
-              <th className="text-left px-3 py-2 sticky left-0 bg-bg-secondary/30">
+              <th className="text-left px-3 py-2 sticky left-0 bg-secondary/30">
                 <Skeleton className="h-3 w-10 rounded" />
               </th>
               {Array.from({ length: 4 }).map((_, i) => (
@@ -161,18 +161,18 @@ export function FinancialStatementsPanel({ symbol }: Props) {
           </tbody>
         </table>
       )}
-      {entry?.error && <div className="p-3 text-[12px] text-red">{entry.error}</div>}
+      {entry?.error && <div className="p-3 text-[12px] text-destructive">{entry.error}</div>}
       {!entry?.error && rows.length === 0 && !loading && (
-        <div className="p-3 text-[12px] text-text-muted">No data.</div>
+        <div className="p-3 text-[12px] text-muted-foreground">No data.</div>
       )}
       {rows.length > 0 && (
         <table className="w-full text-[12px] border-collapse">
           <thead>
             <tr className="border-b border-border/60">
-              <th className="text-left font-medium text-text-muted/70 px-3 py-2 sticky left-0 bg-bg-secondary/30">Item</th>
+              <th className="text-left font-medium text-muted-foreground/70 px-3 py-2 sticky left-0 bg-secondary/30">Item</th>
               {rows.map((row) => (
                 <th key={String(row.period_ending ?? row.filing_date)}
-                    className="text-right font-medium text-text-muted/70 px-3 py-2 whitespace-nowrap">
+                    className="text-right font-medium text-muted-foreground/70 px-3 py-2 whitespace-nowrap">
                   {periodLabel(row)}
                 </th>
               ))}
@@ -181,7 +181,7 @@ export function FinancialStatementsPanel({ symbol }: Props) {
           <tbody>
             {rowDefs.map((r) => (
               <tr key={r.key} className="border-b border-border/30 last:border-b-0">
-                <td className={`px-3 py-1.5 ${r.indent ? 'pl-6 text-text-muted' : 'text-text'}`}>
+                <td className={`px-3 py-1.5 ${r.indent ? 'pl-6 text-muted-foreground' : 'text-foreground'}`}>
                   {r.label}
                 </td>
                 {rows.map((row) => (

--- a/ui/src/components/market/KeyMetricsPanel.tsx
+++ b/ui/src/components/market/KeyMetricsPanel.tsx
@@ -103,13 +103,13 @@ export function KeyMetricsPanel({ symbol }: Props) {
           ))}
         </dl>
       )}
-      {error && !loading && <div className="text-[12px] text-red">{error}</div>}
+      {error && !loading && <div className="text-[12px] text-destructive">{error}</div>}
       {!loading && !error && data && (
         <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-[12px]">
           {rows.map(([k, v]) => (
             <div key={k} className="flex items-baseline justify-between border-b border-border/30 py-1 last:border-b-0">
-              <dt className="text-text-muted/70">{k}</dt>
-              <dd className="font-mono text-text tabular-nums">{v}</dd>
+              <dt className="text-muted-foreground/70">{k}</dt>
+              <dd className="font-mono text-foreground tabular-nums">{v}</dd>
             </div>
           ))}
         </dl>

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -11,6 +11,8 @@ import {
   type HistogramData,
 } from 'lightweight-charts'
 import { barsApi, type AssetClass, type HistoricalBar, type BarSourceCandidate, type BarMeta } from '../../api/market'
+import { readSemanticColor } from '../../theme/semanticColors'
+import { useEffectiveTheme } from '../../theme/useEffectiveTheme'
 import { Skeleton } from '../StateViews'
 
 type Interval = '1m' | '5m' | '1h' | '1d'
@@ -60,6 +62,7 @@ interface Props {
 }
 
 export function KlinePanel({ selection }: Props) {
+  const effectiveTheme = useEffectiveTheme()
   const [searchParams, setSearchParams] = useSearchParams()
   const interval = parseInterval(searchParams.get('interval'))
   const tf = parseTimeframe(searchParams.get('range'))
@@ -99,31 +102,33 @@ export function KlinePanel({ selection }: Props) {
   const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
   const volumeRef = useRef<ISeriesApi<'Histogram'> | null>(null)
 
-  // Build chart once.
+  // Canvas renderers cannot resolve CSS variables themselves. Rebuild on a
+  // concrete theme change and read the same semantic card used by DOM/SVG UI.
   useEffect(() => {
     if (!containerRef.current) return
+    const colors = readKlineChartColors()
     const chart = createChart(containerRef.current, {
       layout: {
         background: { color: 'transparent' },
-        textColor: '#c9d1d9',
-        panes: { separatorColor: '#30363d', separatorHoverColor: '#58a6ff33' },
+        textColor: colors.text,
+        panes: { separatorColor: colors.grid, separatorHoverColor: colors.primaryMuted },
       },
       grid: {
-        vertLines: { color: '#21262d' },
-        horzLines: { color: '#21262d' },
+        vertLines: { color: colors.grid },
+        horzLines: { color: colors.grid },
       },
-      rightPriceScale: { borderColor: '#30363d' },
-      timeScale: { borderColor: '#30363d', timeVisible: false, secondsVisible: false },
+      rightPriceScale: { borderColor: colors.grid },
+      timeScale: { borderColor: colors.grid, timeVisible: false, secondsVisible: false },
       autoSize: true,
     })
 
     const candle = chart.addSeries(CandlestickSeries, {
-      upColor: '#3fb950',
-      downColor: '#f85149',
-      borderUpColor: '#3fb950',
-      borderDownColor: '#f85149',
-      wickUpColor: '#3fb950',
-      wickDownColor: '#f85149',
+      upColor: colors.positive,
+      downColor: colors.negative,
+      borderUpColor: colors.positive,
+      borderDownColor: colors.negative,
+      wickUpColor: colors.positive,
+      wickDownColor: colors.negative,
     })
 
     const volume = chart.addSeries(HistogramSeries, {
@@ -142,12 +147,12 @@ export function KlinePanel({ selection }: Props) {
       candleRef.current = null
       volumeRef.current = null
     }
-  }, [])
+  }, [effectiveTheme])
 
   // Toggle time-axis detail when interval flips between intraday and daily.
   useEffect(() => {
     chartRef.current?.timeScale().applyOptions({ timeVisible: INTRADAY.has(interval) })
-  }, [interval])
+  }, [interval, effectiveTheme])
 
   // Discover the available bar sources for this symbol (populates the picker).
   // Seed the picked source from the URL (?source=barId, set at search time);
@@ -224,16 +229,17 @@ export function KlinePanel({ selection }: Props) {
       low: b.low,
       close: b.close,
     }))
+    const colors = readKlineChartColors()
     const volumeData: HistogramData[] = bars.map((b) => ({
       time: toUTCTimestamp(b.date),
       value: b.volume ?? 0,
-      color: b.close >= b.open ? '#3fb95055' : '#f8514955',
+      color: b.close >= b.open ? colors.positiveMuted : colors.negativeMuted,
     }))
 
     candleRef.current.setData(candleData)
     volumeRef.current.setData(volumeData)
     chartRef.current.timeScale().fitContent()
-  }, [bars])
+  }, [bars, effectiveTheme])
 
   const title = useMemo(() => {
     if (!selection) return 'Select a symbol'
@@ -254,17 +260,17 @@ export function KlinePanel({ selection }: Props) {
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between py-2 px-1 gap-3 flex-wrap">
         <div className="flex items-center gap-2 min-w-0">
-          <span className="text-[13px] font-medium text-text truncate">{title}</span>
+          <span className="text-[13px] font-medium text-foreground truncate">{title}</span>
           {meta && (
             <span
-              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium"
+              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium"
               title={`Provider: ${meta.barId}${meta.barCapability ? ` (${meta.barCapability})` : ''}`}
             >
               {meta.sourceId}{meta.barCapability ? ` · ${meta.barCapability}` : ''}
             </span>
           )}
           {bars && bars.length > 0 && (
-            <span className="text-[11px] text-text-muted/60 truncate">
+            <span className="text-[11px] text-muted-foreground/60 truncate">
               {bars.length} bars · {bars[0].date} → {bars[bars.length - 1].date}
             </span>
           )}
@@ -272,11 +278,11 @@ export function KlinePanel({ selection }: Props) {
         <div className="flex items-center gap-5 flex-wrap">
           {sourceOptions.length > 1 && (
             <label className="flex items-center gap-2">
-              <span className="text-[11px] uppercase tracking-wide text-text-muted/70">Source</span>
+              <span className="text-[11px] uppercase tracking-wide text-muted-foreground/70">Source</span>
               <select
                 value={selectedBarId ?? meta?.barId ?? ''}
                 onChange={(e) => setSelectedBarId(e.target.value || null)}
-                className="bg-bg-tertiary border border-border rounded px-2 py-1 text-[12px] text-text cursor-pointer max-w-[240px]"
+                className="bg-muted border border-border rounded px-2 py-1 text-[12px] text-foreground cursor-pointer max-w-[240px]"
                 title="Which provider's K-line to show — sources are never merged; you pick"
               >
                 {sourceOptions.map((c) => (
@@ -288,7 +294,7 @@ export function KlinePanel({ selection }: Props) {
             </label>
           )}
           <label className="flex items-center gap-2">
-            <span className="text-[11px] uppercase tracking-wide text-text-muted/70">Interval</span>
+            <span className="text-[11px] uppercase tracking-wide text-muted-foreground/70">Interval</span>
             <div className="flex border border-border rounded overflow-hidden" title="Candle width (how much time each bar covers)">
               {INTERVALS.map((iv, i) => (
                 <button
@@ -296,7 +302,7 @@ export function KlinePanel({ selection }: Props) {
                   onClick={() => selectInterval(iv)}
                   className={`px-2 py-1 text-[12px] transition-colors cursor-pointer ${
                     i > 0 ? 'border-l border-border' : ''
-                  } ${interval === iv ? 'bg-bg-tertiary text-text' : 'text-text-muted hover:text-text'}`}
+                  } ${interval === iv ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
                 >
                   {iv}
                 </button>
@@ -304,7 +310,7 @@ export function KlinePanel({ selection }: Props) {
             </div>
           </label>
           <label className="flex items-center gap-2">
-            <span className="text-[11px] uppercase tracking-wide text-text-muted/70">Range</span>
+            <span className="text-[11px] uppercase tracking-wide text-muted-foreground/70">Range</span>
             <div className="flex border border-border rounded overflow-hidden" title="How far back to load history">
               {TIMEFRAMES.map((t, i) => (
                 <button
@@ -312,7 +318,7 @@ export function KlinePanel({ selection }: Props) {
                   onClick={() => setTf(t)}
                   className={`px-2 py-1 text-[12px] transition-colors cursor-pointer ${
                     i > 0 ? 'border-l border-border' : ''
-                  } ${tf === t ? 'bg-bg-tertiary text-text' : 'text-text-muted hover:text-text'}`}
+                  } ${tf === t ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
                 >
                   {t}
                 </button>
@@ -322,10 +328,10 @@ export function KlinePanel({ selection }: Props) {
         </div>
       </div>
 
-      <div className="relative flex-1 min-h-0 border border-border rounded bg-bg-secondary/30">
+      <div className="relative flex-1 min-h-0 border border-border rounded bg-secondary/30">
         <div ref={containerRef} className="absolute inset-0" />
         {!selection && (
-          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-text-muted">
+          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-muted-foreground">
             Pick an asset to see the K-line.
           </div>
         )}
@@ -335,14 +341,26 @@ export function KlinePanel({ selection }: Props) {
           </div>
         )}
         {selection && loading && (
-          <div className="absolute top-2 right-2 text-[11px] text-text-muted">Loading…</div>
+          <div className="absolute top-2 right-2 text-[11px] text-muted-foreground">Loading…</div>
         )}
         {selection && error && !loading && (
-          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-text-muted px-8 text-center">
+          <div className="absolute inset-0 flex items-center justify-center text-[13px] text-muted-foreground px-8 text-center">
             {error}
           </div>
         )}
       </div>
     </div>
   )
+}
+
+function readKlineChartColors() {
+  return {
+    text: readSemanticColor('chart-axis'),
+    grid: readSemanticColor('chart-grid'),
+    primaryMuted: readSemanticColor('primary-muted'),
+    positive: readSemanticColor('chart-positive'),
+    negative: readSemanticColor('chart-negative'),
+    positiveMuted: readSemanticColor('chart-positive-muted'),
+    negativeMuted: readSemanticColor('chart-negative-muted'),
+  }
 }

--- a/ui/src/components/market/ProfilePanel.tsx
+++ b/ui/src/components/market/ProfilePanel.tsx
@@ -57,7 +57,7 @@ export function ProfilePanel({ symbol }: Props) {
           <Skeleton className="h-3 w-44 rounded" />
         </div>
       )}
-      {error && !loading && <div className="text-[12px] text-red">{error}</div>}
+      {error && !loading && <div className="text-[12px] text-destructive">{error}</div>}
       {!loading && !error && profile && (
         <div className="flex flex-col gap-3 text-[12px]">
           <dl className="grid grid-cols-[90px_1fr] gap-y-1 gap-x-3">
@@ -68,16 +68,16 @@ export function ProfilePanel({ symbol }: Props) {
             <KV label="HQ"        value={hq} />
             <KV
               label="Website"
-              value={website ? <a className="text-accent hover:underline break-all" href={website} target="_blank" rel="noreferrer">{website.replace(/^https?:\/\//, '')}</a> : undefined}
+              value={website ? <a className="text-primary hover:underline break-all" href={website} target="_blank" rel="noreferrer">{website.replace(/^https?:\/\//, '')}</a> : undefined}
             />
           </dl>
           {desc && (
-            <p className="text-text-muted/80 leading-[1.55] line-clamp-[8]">{desc}</p>
+            <p className="text-muted-foreground/80 leading-[1.55] line-clamp-[8]">{desc}</p>
           )}
         </div>
       )}
       {!loading && !error && !profile && (
-        <div className="text-[12px] text-text-muted">No profile data.</div>
+        <div className="text-[12px] text-muted-foreground">No profile data.</div>
       )}
     </Card>
   )
@@ -86,8 +86,8 @@ export function ProfilePanel({ symbol }: Props) {
 function KV({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <>
-      <dt className="text-text-muted/60">{label}</dt>
-      <dd className="text-text truncate">{value ?? <span className="text-text-muted/50">—</span>}</dd>
+      <dt className="text-muted-foreground/60">{label}</dt>
+      <dd className="text-foreground truncate">{value ?? <span className="text-muted-foreground/50">—</span>}</dd>
     </>
   )
 }

--- a/ui/src/components/market/QuoteHeader.tsx
+++ b/ui/src/components/market/QuoteHeader.tsx
@@ -42,22 +42,22 @@ export function QuoteHeader({ symbol }: Props) {
   const loading = !quote && !error
 
   return (
-    <div className="flex flex-wrap items-end gap-x-6 gap-y-2 px-4 py-3 border border-border rounded bg-bg-secondary/30">
+    <div className="flex flex-wrap items-end gap-x-6 gap-y-2 px-4 py-3 border border-border rounded bg-secondary/30">
       <div className="flex flex-col min-w-0">
         <div className="flex items-baseline gap-2 min-w-0">
-          <span className="text-[20px] font-semibold text-text tracking-tight">{symbol}</span>
+          <span className="text-[20px] font-semibold text-foreground tracking-tight">{symbol}</span>
           {loading ? (
             <Skeleton className="h-3.5 w-28 rounded" />
           ) : (
             <>
-              {name && <span className="text-[13px] text-text-muted truncate">{name}</span>}
+              {name && <span className="text-[13px] text-muted-foreground truncate">{name}</span>}
               {exchange && (
-                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
+                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
                   {exchange}
                 </span>
               )}
               {provider && (
-                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
+                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
                   {provider}
                 </span>
               )}
@@ -65,7 +65,7 @@ export function QuoteHeader({ symbol }: Props) {
           )}
         </div>
         <div className="flex items-baseline gap-3 mt-1">
-          <span className="text-[22px] font-mono font-semibold text-text">
+          <span className="text-[22px] font-mono font-semibold text-foreground">
             {loading ? (
               <Skeleton className="inline-block h-6 w-28 rounded align-baseline" />
             ) : (
@@ -77,7 +77,7 @@ export function QuoteHeader({ symbol }: Props) {
           ) : (
             change != null &&
             changePct != null && (
-              <span className={`text-[13px] font-medium ${up ? 'text-green' : 'text-red'}`}>
+              <span className={`text-[13px] font-medium ${up ? 'text-success' : 'text-destructive'}`}>
                 {up ? '+' : ''}{fmtNumber(change)} ({up ? '+' : ''}{fmtPercent(changePct)})
               </span>
             )
@@ -100,7 +100,7 @@ export function QuoteHeader({ symbol }: Props) {
         <Field label="MA200"     value={fmtNumber(quote?.ma200)}       loading={loading} />
       </dl>
 
-      {error && <div className="w-full text-[11px] text-red">{error}</div>}
+      {error && <div className="w-full text-[11px] text-destructive">{error}</div>}
     </div>
   )
 }
@@ -108,8 +108,8 @@ export function QuoteHeader({ symbol }: Props) {
 function Field({ label, value, loading }: { label: string; value: string; loading?: boolean }) {
   return (
     <div className="flex flex-col min-w-0">
-      <dt className="text-text-muted/60 uppercase tracking-wide">{label}</dt>
-      <dd className="font-mono text-text truncate">
+      <dt className="text-muted-foreground/60 uppercase tracking-wide">{label}</dt>
+      <dd className="font-mono text-foreground truncate">
         {loading ? <Skeleton className="h-3 w-12 rounded mt-0.5" /> : value}
       </dd>
     </div>

--- a/ui/src/components/market/SearchBox.tsx
+++ b/ui/src/components/market/SearchBox.tsx
@@ -4,19 +4,19 @@ import { type BarSourceCandidate, type AssetClass } from '../../api/market'
 import { useAssetSearch } from './useAssetSearch'
 
 const ASSET_CLASS_COLORS: Record<string, string> = {
-  equity: 'bg-accent/15 text-accent',
-  crypto: 'bg-amber-500/15 text-amber-400',
-  currency: 'bg-green/15 text-green',
-  commodity: 'bg-purple-500/15 text-purple-400',
-  unknown: 'bg-bg-tertiary text-text-muted',
+  equity: 'bg-primary/15 text-primary',
+  crypto: 'bg-warning/15 text-warning',
+  currency: 'bg-success/15 text-success',
+  commodity: 'bg-ai-action/15 text-ai-action',
+  unknown: 'bg-muted text-muted-foreground',
 }
 
 const CAPABILITY_COLOR: Record<string, string> = {
-  realtime: 'text-green',
-  iex: 'text-accent',
-  delayed: 'text-text-muted',
-  subscription: 'text-amber-400',
-  free: 'text-text-muted',
+  realtime: 'text-success',
+  iex: 'text-primary',
+  delayed: 'text-muted-foreground',
+  subscription: 'text-warning',
+  free: 'text-muted-foreground',
 }
 
 export function SearchBox() {
@@ -75,7 +75,7 @@ export function SearchBox() {
   return (
     <div ref={containerRef} className="relative">
       <input
-        className="w-full px-3 py-2 text-[14px] bg-bg-secondary border border-border rounded-md focus:outline-none focus:border-accent placeholder:text-text-muted/50"
+        className="w-full px-3 py-2 text-[14px] bg-secondary border border-border rounded-md focus:outline-none focus:border-primary placeholder:text-muted-foreground/50"
         placeholder="Search assets — AAPL, bitcoin, EUR, gold…"
         value={query}
         onChange={(e) => { setQuery(e.target.value); setOpen(true) }}
@@ -83,12 +83,12 @@ export function SearchBox() {
         onKeyDown={onKey}
       />
       {open && query.trim() && (
-        <div className="absolute z-20 mt-1 w-full bg-bg-secondary border border-border rounded-md shadow-lg max-h-[360px] overflow-y-auto">
+        <div className="absolute z-20 mt-1 w-full bg-secondary border border-border rounded-md shadow-lg max-h-[360px] overflow-y-auto">
           {loading && results.length === 0 && (
-            <div className="px-3 py-2 text-[13px] text-text-muted">Searching…</div>
+            <div className="px-3 py-2 text-[13px] text-muted-foreground">Searching…</div>
           )}
           {!loading && results.length === 0 && (
-            <div className="px-3 py-2 text-[13px] text-text-muted">No matches</div>
+            <div className="px-3 py-2 text-[13px] text-muted-foreground">No matches</div>
           )}
           {results.map((r, i) => (
             <button
@@ -96,18 +96,18 @@ export function SearchBox() {
               onClick={() => handleSelect(r)}
               onMouseEnter={() => setHighlight(i)}
               className={`w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] cursor-pointer transition-colors ${
-                i === highlight ? 'bg-bg-tertiary' : ''
+                i === highlight ? 'bg-muted' : ''
               }`}
             >
-              <span className="font-mono font-semibold text-text shrink-0">{r.symbol}</span>
+              <span className="font-mono font-semibold text-foreground shrink-0">{r.symbol}</span>
               {r.name && (
-                <span className="text-text-muted truncate flex-1 min-w-0">— {r.name}</span>
+                <span className="text-muted-foreground truncate flex-1 min-w-0">— {r.name}</span>
               )}
               {/* Explicit provider — this is how same-symbol sources are disambiguated. */}
-              <span className="ml-auto flex items-center gap-1 shrink-0 text-[11px] text-text-muted">
-                <span className="font-medium text-text/80">{r.sourceId}</span>
+              <span className="ml-auto flex items-center gap-1 shrink-0 text-[11px] text-muted-foreground">
+                <span className="font-medium text-foreground/80">{r.sourceId}</span>
                 {r.barCapability && (
-                  <span className={CAPABILITY_COLOR[r.barCapability] ?? 'text-text-muted'}>· {r.barCapability}</span>
+                  <span className={CAPABILITY_COLOR[r.barCapability] ?? 'text-muted-foreground'}>· {r.barCapability}</span>
                 )}
               </span>
               <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded font-medium shrink-0 ${ASSET_CLASS_COLORS[r.assetClass] ?? ASSET_CLASS_COLORS.unknown}`}>

--- a/ui/src/components/market/SeriesCard.tsx
+++ b/ui/src/components/market/SeriesCard.tsx
@@ -9,16 +9,16 @@ import type { MacroSeriesCard } from '../../api/reference'
 export function SeriesCard({ card, label, emptyText }: { card: MacroSeriesCard; label: string; emptyText: string }) {
   const empty = card.points.length === 0
   return (
-    <div className="min-w-0 border border-border rounded-md bg-bg-secondary/40 px-3 py-2.5 flex flex-col gap-1.5">
+    <div className="min-w-0 border border-border rounded-md bg-secondary/40 px-3 py-2.5 flex flex-col gap-1.5">
       <div className="flex items-baseline justify-between gap-2">
-        <span className="text-[12px] text-text-muted truncate" title={card.id}>{label}</span>
-        <span className="shrink-0 text-[10px] text-text-muted">{card.latestDate ?? ''}</span>
+        <span className="text-[12px] text-muted-foreground truncate" title={card.id}>{label}</span>
+        <span className="shrink-0 text-[10px] text-muted-foreground">{card.latestDate ?? ''}</span>
       </div>
       <div className="flex min-w-0 items-end justify-between gap-2">
         <div className="flex min-w-0 items-baseline gap-2">
-          <span className="shrink-0 text-[20px] font-semibold text-text font-mono">{fmtSeriesValue(card, card.latest)}</span>
+          <span className="shrink-0 text-[20px] font-semibold text-foreground font-mono">{fmtSeriesValue(card, card.latest)}</span>
           {card.change != null && card.change !== 0 && (
-            <span className={`text-[11px] font-mono ${card.change > 0 ? 'text-green' : 'text-red'}`}>
+            <span className={`text-[11px] font-mono ${card.change > 0 ? 'text-success' : 'text-destructive'}`}>
               {card.change > 0 ? '+' : ''}{card.unit === 'count' ? fmtCompactNum(card.change) : card.change.toFixed(2)}
             </span>
           )}
@@ -27,12 +27,12 @@ export function SeriesCard({ card, label, emptyText }: { card: MacroSeriesCard; 
           {!empty && (
             <LineChart width={96} height={36} data={card.points} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
               <YAxis hide domain={['dataMin', 'dataMax']} />
-              <Line type="monotone" dataKey="value" stroke="var(--color-accent)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
+              <Line type="monotone" dataKey="value" stroke="var(--primary)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
             </LineChart>
           )}
         </div>
       </div>
-      {empty && <span className="text-[11px] text-text-muted">{emptyText}</span>}
+      {empty && <span className="text-[11px] text-muted-foreground">{emptyText}</span>}
     </div>
   )
 }

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -52,13 +52,13 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
 
   return (
     <Card title="Tradeable on configured brokers" info={info}>
-      {loading && <div className="text-[12px] text-text-muted">Searching brokers…</div>}
-      {error && !loading && <div className="text-[12px] text-red">{error}</div>}
+      {loading && <div className="text-[12px] text-muted-foreground">Searching brokers…</div>}
+      {error && !loading && <div className="text-[12px] text-destructive">{error}</div>}
 
       {!loading && !error && utasConfigured === 0 && (
-        <div className="text-[12px] text-text-muted">
+        <div className="text-[12px] text-muted-foreground">
           No trading accounts configured.{' '}
-          <Link to="/trading" className="text-accent hover:underline">
+          <Link to="/trading" className="text-primary hover:underline">
             Add one in Trading
           </Link>
           {' '}to see matching contracts here.
@@ -66,7 +66,7 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
       )}
 
       {!loading && !error && utasConfigured !== 0 && hits && hits.length === 0 && (
-        <div className="text-[12px] text-text-muted">
+        <div className="text-[12px] text-muted-foreground">
           No tradeable contracts matching <span className="font-mono">{symbol}</span> on your configured brokers.
         </div>
       )}
@@ -86,7 +86,7 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
             {overflow && (
               <button
                 onClick={() => setExpanded((v) => !v)}
-                className="mt-2 text-[11px] text-text-muted/70 hover:text-accent transition-colors cursor-pointer"
+                className="mt-2 text-[11px] text-muted-foreground/70 hover:text-primary transition-colors cursor-pointer"
               >
                 {expanded ? `Show fewer` : `Show ${hidden} more (${sorted.length} total)`}
               </button>
@@ -134,22 +134,22 @@ function ContractRow({ hit }: { hit: ContractSearchHit }) {
     ? `/uta/${encodeURIComponent(hit.source)}?aliceId=${encodeURIComponent(aliceId)}`
     : null
   return (
-    <li className="px-3 py-2 flex items-baseline gap-3 text-[12px] hover:bg-bg-tertiary/40 transition-colors">
-      <span className="font-mono font-semibold text-text">{c.symbol ?? '—'}</span>
+    <li className="px-3 py-2 flex items-baseline gap-3 text-[12px] hover:bg-muted/40 transition-colors">
+      <span className="font-mono font-semibold text-foreground">{c.symbol ?? '—'}</span>
       {c.secType && (
-        <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
+        <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
           {c.secType}
         </span>
       )}
-      <span className="text-text-muted/70 truncate flex-1">
+      <span className="text-muted-foreground/70 truncate flex-1">
         {[c.description || c.localSymbol, c.primaryExchange ?? c.exchange, c.currency]
           .filter(Boolean)
           .join(' · ')}
       </span>
-      <span className="text-[10px] text-text-muted/60 shrink-0">{hit.source}</span>
+      <span className="text-[10px] text-muted-foreground/60 shrink-0">{hit.source}</span>
       {aliceId && (
         <code
-          className="text-[10px] font-mono text-text-muted truncate max-w-[260px]"
+          className="text-[10px] font-mono text-muted-foreground truncate max-w-[260px]"
           title={aliceId}
         >
           {aliceId}
@@ -158,7 +158,7 @@ function ContractRow({ hit }: { hit: ContractSearchHit }) {
       {orderHref && (
         <Link
           to={orderHref}
-          className="text-[11px] text-accent hover:underline shrink-0"
+          className="text-[11px] text-primary hover:underline shrink-0"
           title="Open order entry on the UTA"
         >
           Order →

--- a/ui/src/components/uta/CreateUTADialog.spec.tsx
+++ b/ui/src/components/uta/CreateUTADialog.spec.tsx
@@ -27,7 +27,7 @@ const brokerPreset: BrokerPreset = {
   category: 'recommended',
   defaultName: 'OKX',
   badge: 'OK',
-  badgeColor: 'text-text-muted',
+  badgeColor: 'text-muted-foreground',
   engine: 'ccxt',
   guardCategory: 'crypto',
   subtitleFields: [],

--- a/ui/src/components/uta/CreateUTADialog.tsx
+++ b/ui/src/components/uta/CreateUTADialog.tsx
@@ -197,7 +197,7 @@ export function CreateUTADialog({
       type="button"
       onClick={() => { void escapeAction.onClick() }}
       disabled={escapeAction.disabled}
-      className="rounded-md px-3 py-2 text-[12px] font-medium text-text-muted transition-colors hover:bg-overlay hover:text-text disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-muted"
+      className="rounded-md px-3 py-2 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
     >
       {escapeAction.label}
     </button>
@@ -207,10 +207,10 @@ export function CreateUTADialog({
     <Dialog onClose={onClose}>
       <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
-          <h3 className="text-[14px] font-semibold text-text truncate">{headerLabel}</h3>
+          <h3 className="text-[14px] font-semibold text-foreground truncate">{headerLabel}</h3>
           <StepDots current={step} />
         </div>
-        <button onClick={onClose} className="text-text-muted hover:text-text p-1 transition-colors" aria-label="Close broker setup">
+        <button onClick={onClose} className="text-muted-foreground hover:text-foreground p-1 transition-colors" aria-label="Close broker setup">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
             <path d="M18 6L6 18M6 6l12 12" />
           </svg>
@@ -244,8 +244,8 @@ export function CreateUTADialog({
               </Field>
               <div className="flex items-center justify-between gap-4 rounded-lg border border-border px-3 py-2.5">
                 <div className="min-w-0">
-                  <div className="text-[12px] font-medium text-text">Read-only account</div>
-                  <div className="text-[11px] text-text-muted leading-relaxed">
+                  <div className="text-[12px] font-medium text-foreground">Read-only account</div>
+                  <div className="text-[11px] text-muted-foreground leading-relaxed">
                     Allow analysis reads; block broker-side order changes.
                   </div>
                 </div>
@@ -253,8 +253,8 @@ export function CreateUTADialog({
               </div>
               <div className="flex items-center justify-between gap-4 rounded-lg border border-border px-3 py-2.5">
                 <div className="min-w-0">
-                  <div className="text-[12px] font-medium text-text">Use as data source</div>
-                  <div className="text-[11px] text-text-muted leading-relaxed">
+                  <div className="text-[12px] font-medium text-foreground">Use as data source</div>
+                  <div className="text-[11px] text-muted-foreground leading-relaxed">
                     Include this connector in K-line and contract discovery.
                   </div>
                 </div>
@@ -269,12 +269,12 @@ export function CreateUTADialog({
               {hasSensitive && (
                 <button
                   onClick={() => setShowSecrets(!showSecrets)}
-                  className="text-[11px] text-text-muted hover:text-text transition-colors"
+                  className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
                 >
                   {showSecrets ? 'Hide secrets' : 'Show secrets'}
                 </button>
               )}
-              {error && <p className="text-[12px] text-red">{error}</p>}
+              {error && <p className="text-[12px] text-destructive">{error}</p>}
             </div>
           </div>
         )}
@@ -305,10 +305,10 @@ export function CreateUTADialog({
           {escapeButton}
         </div>
         <div className="flex shrink-0 items-center justify-end">
-          {step === 'pick' && <span className="text-[11px] text-text-muted">Pick a platform to continue</span>}
+          {step === 'pick' && <span className="text-[11px] text-muted-foreground">Pick a platform to continue</span>}
           {step === 'install' && (
             packStatuses === null ? (
-              <span className="text-[11px] text-text-muted">Checking installed support…</span>
+              <span className="text-[11px] text-muted-foreground">Checking installed support…</span>
             ) : (
               <button onClick={() => { void handleInstallPack() }} disabled={installingPack} className="btn-primary">
                 {installingPack ? 'Installing…' : packStatus?.source === 'broken' ? 'Repair support' : `Install ${preset?.label ?? 'broker'} support`}
@@ -330,7 +330,7 @@ export function CreateUTADialog({
                 {saving ? 'Saving...' : 'Save connector'}
               </button>
             ) : (
-              <span className="text-[11px] text-text-muted">Fix the config and try again</span>
+              <span className="text-[11px] text-muted-foreground">Fix the config and try again</span>
             )
           )}
         </div>
@@ -341,7 +341,7 @@ export function CreateUTADialog({
 
 function PickerSectionHeader({ title }: { title: string }) {
   return (
-    <p className="text-[11px] font-medium text-text-muted uppercase tracking-wide">
+    <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
       {title}
     </p>
   )
@@ -355,7 +355,7 @@ function StepDots({ current }: { current: WizardStep }) {
         <span
           key={s}
           className={`w-1.5 h-1.5 rounded-full transition-colors ${
-            s === current ? 'bg-accent' : 'bg-border'
+            s === current ? 'bg-primary' : 'bg-border'
           }`}
         />
       ))}
@@ -370,36 +370,36 @@ function BrokerPackInstallPanel({ preset, status, error }: {
 }) {
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-border bg-bg-secondary/40 px-4 py-4">
+      <div className="rounded-lg border border-border bg-secondary/40 px-4 py-4">
         <div className="flex items-start gap-3">
           <span className={`mt-0.5 flex h-8 w-8 items-center justify-center rounded-md text-[11px] font-semibold ${preset.badgeColor} ${preset.badgeColor.replace('text-', 'bg-')}/10`}>
             {preset.badge}
           </span>
           <div className="min-w-0">
-            <div className="text-[13px] font-medium text-text">Install {preset.label} support</div>
-            <p className="mt-1 text-[12px] leading-relaxed text-text-muted">
+            <div className="text-[13px] font-medium text-foreground">Install {preset.label} support</div>
+            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
               OpenAlice installs broker integrations separately so the desktop app stays small and unused SDKs never load at startup.
             </p>
           </div>
         </div>
       </div>
-      <div className="rounded-md border border-border px-3 py-2.5 text-[11px] leading-relaxed text-text-muted">
+      <div className="rounded-md border border-border px-3 py-2.5 text-[11px] leading-relaxed text-muted-foreground">
         The downloaded pack is matched to this OpenAlice version and operating system, checksum-verified, then activated atomically. Your account credentials are requested only after installation.
       </div>
-      {status?.reason && <p className="text-[12px] text-yellow-400">{status.reason}</p>}
-      {error && <p className="text-[12px] text-red">{error}</p>}
+      {status?.reason && <p className="text-[12px] text-warning">{status.reason}</p>}
+      {error && <p className="text-[12px] text-destructive">{error}</p>}
     </div>
   )
 }
 
 function HintBlock({ text }: { text: string }) {
   return (
-    <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-2">
+    <div className="rounded-md border border-border bg-secondary/50 px-3 py-2.5 space-y-2">
       {text.trim().split('\n\n').map((para, i) => (
-        <p key={i} className="text-[12px] text-text-muted leading-relaxed">
+        <p key={i} className="text-[12px] text-muted-foreground leading-relaxed">
           {para.split(/(\*\*[^*]+\*\*)/).map((seg, j) =>
             seg.startsWith('**') && seg.endsWith('**')
-              ? <strong key={j} className="text-text">{seg.slice(2, -2)}</strong>
+              ? <strong key={j} className="text-foreground">{seg.slice(2, -2)}</strong>
               : <span key={j}>{seg}</span>
           )}
         </p>
@@ -415,21 +415,21 @@ function BrokerConflictPanel({ existing, onOpenExisting }: {
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2">
-        <span className="w-2 h-2 rounded-full bg-yellow-400 shrink-0" />
-        <span className="text-[13px] font-medium text-text">Broker already configured</span>
+        <span className="w-2 h-2 rounded-full bg-warning shrink-0" />
+        <span className="text-[13px] font-medium text-foreground">Broker already configured</span>
       </div>
-      <div className="rounded-md border border-yellow-400/30 bg-yellow-400/5 px-3 py-2.5">
-        <p className="text-[12px] text-text leading-relaxed">
+      <div className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2.5">
+        <p className="text-[12px] text-foreground leading-relaxed">
           Another broker connector already exists for this broker (same identity-defining credentials).
           Re-using the same key from a separate account would double-count its positions in
           aggregate views.
         </p>
-        <p className="text-[12px] text-text-muted leading-relaxed mt-2">
-          Existing: <strong className="text-text">{existing.label}</strong> <span className="font-mono text-text-muted/70">({existing.id})</span>
+        <p className="text-[12px] text-muted-foreground leading-relaxed mt-2">
+          Existing: <strong className="text-foreground">{existing.label}</strong> <span className="font-mono text-muted-foreground/70">({existing.id})</span>
         </p>
       </div>
-      <p className="text-[11px] text-text-muted">
-        Click <strong className="text-text">Open existing</strong> to use it, or <strong className="text-text">← Back</strong> to point this connector at a different account.
+      <p className="text-[11px] text-muted-foreground">
+        Click <strong className="text-foreground">Open existing</strong> to use it, or <strong className="text-foreground">← Back</strong> to point this connector at a different account.
       </p>
       <button onClick={onOpenExisting} className="btn-secondary w-full">Open existing connector</button>
     </div>
@@ -441,14 +441,14 @@ function TestResultPanel({ result, utaId }: { result: TestConnectionResult; utaI
     return (
       <div className="space-y-3">
         <div className="flex items-center gap-2">
-          <span className="w-2 h-2 rounded-full bg-red shrink-0" />
-          <span className="text-[13px] font-medium text-red">Connection failed</span>
+          <span className="w-2 h-2 rounded-full bg-destructive shrink-0" />
+          <span className="text-[13px] font-medium text-destructive">Connection failed</span>
         </div>
-        <div className="rounded-md border border-red/30 bg-red/5 px-3 py-2.5">
-          <p className="text-[12px] text-text leading-relaxed whitespace-pre-wrap">{result.error ?? 'Unknown error'}</p>
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5">
+          <p className="text-[12px] text-foreground leading-relaxed whitespace-pre-wrap">{result.error ?? 'Unknown error'}</p>
         </div>
-        <p className="text-[11px] text-text-muted">
-          Click <strong className="text-text">← Back</strong> to fix the configuration and try again.
+        <p className="text-[11px] text-muted-foreground">
+          Click <strong className="text-foreground">← Back</strong> to fix the configuration and try again.
         </p>
       </div>
     )
@@ -462,40 +462,40 @@ function TestResultPanel({ result, utaId }: { result: TestConnectionResult; utaI
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
-        <span className="w-2 h-2 rounded-full bg-green shrink-0" />
-        <span className="text-[13px] font-medium text-green">Connected as {utaId}</span>
+        <span className="w-2 h-2 rounded-full bg-success shrink-0" />
+        <span className="text-[13px] font-medium text-success">Connected as {utaId}</span>
       </div>
 
       {acct && (
-        <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-1">
+        <div className="rounded-md border border-border bg-secondary/50 px-3 py-2.5 space-y-1">
           <div className="flex justify-between text-[12px]">
-            <span className="text-text-muted">Net Liquidation</span>
-            <span className="text-text font-medium">{acct.baseCurrency} {acct.netLiquidation}</span>
+            <span className="text-muted-foreground">Net Liquidation</span>
+            <span className="text-foreground font-medium">{acct.baseCurrency} {acct.netLiquidation}</span>
           </div>
           <div className="flex justify-between text-[12px]">
-            <span className="text-text-muted">Cash</span>
-            <span className="text-text">{acct.baseCurrency} {acct.totalCashValue}</span>
+            <span className="text-muted-foreground">Cash</span>
+            <span className="text-foreground">{acct.baseCurrency} {acct.totalCashValue}</span>
           </div>
           {acct.unrealizedPnL !== '0' && (
             <div className="flex justify-between text-[12px]">
-              <span className="text-text-muted">Unrealized P&L</span>
-              <span className="text-text">{acct.baseCurrency} {acct.unrealizedPnL}</span>
+              <span className="text-muted-foreground">Unrealized P&L</span>
+              <span className="text-foreground">{acct.baseCurrency} {acct.unrealizedPnL}</span>
             </div>
           )}
         </div>
       )}
 
       <div>
-        <p className="text-[12px] font-medium text-text-muted uppercase tracking-wide mb-2">
+        <p className="text-[12px] font-medium text-muted-foreground uppercase tracking-wide mb-2">
           Positions ({positions.length})
         </p>
         {positions.length === 0 ? (
-          <p className="text-[12px] text-text-muted">No open positions — connection works, account is empty.</p>
+          <p className="text-[12px] text-muted-foreground">No open positions — connection works, account is empty.</p>
         ) : (
           <div className="rounded-md border border-border overflow-hidden">
             <table className="w-full text-[11px]">
               <thead>
-                <tr className="bg-bg-tertiary/30 text-text-muted">
+                <tr className="bg-muted/30 text-muted-foreground">
                   <th className="text-left px-2.5 py-1.5 font-medium">Contract</th>
                   <th className="text-left px-2.5 py-1.5 font-medium">Side</th>
                   <th className="text-right px-2.5 py-1.5 font-medium">Qty</th>
@@ -505,16 +505,16 @@ function TestResultPanel({ result, utaId }: { result: TestConnectionResult; utaI
               <tbody>
                 {visiblePositions.map((p, i) => (
                   <tr key={i} className="border-t border-border">
-                    <td className="px-2.5 py-1.5 text-text font-mono" title={p.contract.aliceId}>{p.contract.symbol ?? p.contract.localSymbol ?? p.contract.aliceId ?? '?'}</td>
-                    <td className="px-2.5 py-1.5 text-text-muted">{p.side}</td>
-                    <td className="px-2.5 py-1.5 text-right text-text">{p.quantity}</td>
-                    <td className="px-2.5 py-1.5 text-right text-text">{p.currency} {p.marketValue}</td>
+                    <td className="px-2.5 py-1.5 text-foreground font-mono" title={p.contract.aliceId}>{p.contract.symbol ?? p.contract.localSymbol ?? p.contract.aliceId ?? '?'}</td>
+                    <td className="px-2.5 py-1.5 text-muted-foreground">{p.side}</td>
+                    <td className="px-2.5 py-1.5 text-right text-foreground">{p.quantity}</td>
+                    <td className="px-2.5 py-1.5 text-right text-foreground">{p.currency} {p.marketValue}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
             {moreCount > 0 && (
-              <div className="px-2.5 py-1.5 border-t border-border text-[11px] text-text-muted bg-bg-tertiary/20">
+              <div className="px-2.5 py-1.5 border-t border-border text-[11px] text-muted-foreground bg-muted/20">
                 +{moreCount} more
               </div>
             )}

--- a/ui/src/components/uta/Dialog.tsx
+++ b/ui/src/components/uta/Dialog.tsx
@@ -18,8 +18,8 @@ export function Dialog({ onClose, width, children }: {
   return (
     // z-[60] keeps dialogs above the mobile nav drawers (z-50).
     <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
-      <div className="oa-dialog-backdrop absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className={`oa-dialog-surface relative ${width || 'w-full sm:w-[560px]'} max-w-[95vw] max-h-[85vh] bg-bg rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden`}>
+      <div className="oa-dialog-backdrop absolute inset-0 bg-backdrop" onClick={onClose} />
+      <div className={`oa-dialog-surface relative ${width || 'w-full sm:w-[560px]'} max-w-[95vw] max-h-[85vh] bg-background rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden`}>
         {children}
       </div>
     </div>

--- a/ui/src/components/uta/EditUTADialog.tsx
+++ b/ui/src/components/uta/EditUTADialog.tsx
@@ -77,14 +77,14 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
       {/* Header */}
       <div className="shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
         <div className="flex items-center gap-3 min-w-0">
-          <h3 className="text-[14px] font-semibold text-text truncate">{uta.id}</h3>
+          <h3 className="text-[14px] font-semibold text-foreground truncate">{uta.id}</h3>
           <HealthBadge health={health} size="md" />
         </div>
         <div className="flex items-center gap-3 shrink-0">
           {onViewInPortfolio && (
             <button
               onClick={onViewInPortfolio}
-              className="text-[11px] text-text-muted hover:text-text inline-flex items-center gap-1 transition-colors"
+              className="text-[11px] text-muted-foreground hover:text-foreground inline-flex items-center gap-1 transition-colors"
               title="See this account's positions and equity in Portfolio"
             >
               View in Portfolio
@@ -93,7 +93,7 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
               </svg>
             </button>
           )}
-          <button onClick={onClose} className="text-text-muted hover:text-text p-1 transition-colors">
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground p-1 transition-colors">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <path d="M18 6L6 18M6 6l12 12" />
             </svg>
@@ -105,13 +105,13 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
       <div className="flex-1 overflow-y-auto px-6 py-6 space-y-5">
         <Section title="Configuration">
           <div className="mb-3">
-            <span className="text-[12px] text-text-muted">Type</span>
-            <span className="ml-2 text-[12px] font-medium text-text">{preset?.label ?? uta.presetId}</span>
+            <span className="text-[12px] text-muted-foreground">Type</span>
+            <span className="ml-2 text-[12px] font-medium text-foreground">{preset?.label ?? uta.presetId}</span>
           </div>
           <div className="mb-3 flex items-center justify-between gap-4 rounded-lg border border-border px-3 py-2.5">
             <div className="min-w-0">
-              <div className="text-[12px] font-medium text-text">Read-only account</div>
-              <div className="text-[11px] text-text-muted leading-relaxed">
+              <div className="text-[12px] font-medium text-foreground">Read-only account</div>
+              <div className="text-[11px] text-muted-foreground leading-relaxed">
                 Allow analysis reads; block broker-side order changes.
               </div>
             </div>
@@ -119,8 +119,8 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
           </div>
           <div className="mb-3 flex items-center justify-between gap-4 rounded-lg border border-border px-3 py-2.5">
             <div className="min-w-0">
-              <div className="text-[12px] font-medium text-text">Use as data source</div>
-              <div className="text-[11px] text-text-muted leading-relaxed">
+              <div className="text-[12px] font-medium text-foreground">Use as data source</div>
+              <div className="text-[11px] text-muted-foreground leading-relaxed">
                 Include this UTA in K-line and contract discovery.
               </div>
             </div>
@@ -135,7 +135,7 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
           {hasSensitive && (
             <button
               onClick={() => setShowKeys(!showKeys)}
-              className="text-[11px] text-text-muted hover:text-text transition-colors mt-2"
+              className="text-[11px] text-muted-foreground hover:text-foreground transition-colors mt-2"
             >
               {showKeys ? 'Hide secrets' : 'Show secrets'}
             </button>
@@ -146,7 +146,7 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
         <div>
           <button
             onClick={() => setGuardsOpen(!guardsOpen)}
-            className="flex items-center gap-1.5 text-[13px] font-semibold text-text-muted uppercase tracking-wide"
+            className="flex items-center gap-1.5 text-[13px] font-semibold text-muted-foreground uppercase tracking-wide"
           >
             <svg
               width="12" height="12" viewBox="0 0 24 24"
@@ -186,9 +186,9 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
               setDraft(updated)
               await onSave(updated)
             }} />
-            <span className="text-[12px] text-text-muted">{draft.enabled !== false ? 'Enabled' : 'Disabled'}</span>
+            <span className="text-[12px] text-muted-foreground">{draft.enabled !== false ? 'Enabled' : 'Disabled'}</span>
           </label>
-          {msg && <span className="text-[12px] text-text-muted">{msg}</span>}
+          {msg && <span className="text-[12px] text-muted-foreground">{msg}</span>}
         </div>
         <div className="flex-1" />
         <DeleteButton label="Delete UTA" onConfirm={onDelete} />

--- a/ui/src/components/uta/HealthBadge.tsx
+++ b/ui/src/components/uta/HealthBadge.tsx
@@ -8,7 +8,7 @@ export function HealthBadge({ health, size = 'sm' }: { health?: BrokerHealthInfo
   const textSize = size === 'md' ? 'text-[12px]' : 'text-[11px]'
   const dotSize = size === 'md' ? 'w-2 h-2' : 'w-1.5 h-1.5'
 
-  if (!health) return <span className="text-text-muted/40">—</span>
+  if (!health) return <span className="text-muted-foreground/40">—</span>
 
   const pill = (color: string, dot: string, label: string, title?: string, pulse = false) => (
     <span className={`inline-flex items-center gap-1.5 ${textSize} ${color}`} title={title}>
@@ -17,31 +17,31 @@ export function HealthBadge({ health, size = 'sm' }: { health?: BrokerHealthInfo
     </span>
   )
 
-  if (health.disabled) return pill('text-text-muted', 'bg-text-muted/40', 'Disabled', health.lastError)
+  if (health.disabled) return pill('text-muted-foreground', 'bg-muted-foreground/40', 'Disabled', health.lastError)
 
   // Initial broker connect still in flight. `status` is optimistically 'healthy'
   // during this window, so this must be checked BEFORE the switch — otherwise a
   // cold-starting account misleadingly reads "Connected" while its data is still
   // loading. Pulses to signal work-in-progress, not a steady state.
-  if (health.connecting) return pill('text-accent', 'bg-accent', 'Connecting...', health.lastError, true)
+  if (health.connecting) return pill('text-primary', 'bg-primary', 'Connecting...', health.lastError, true)
 
   switch (health.status) {
     case 'healthy':
       // At target reach. The label tells the user the account's role.
       return pill(
-        'text-green',
-        'bg-green',
+        'text-success',
+        'bg-success',
         health.tier === 'data' ? 'Data source' : health.tier === 'account' ? 'Connected · read-only' : 'Connected',
       )
     case 'degraded':
       // Reachable but below target — e.g. transport up but account-read failing.
       return pill(
-        'text-yellow-400',
-        'bg-yellow-400',
+        'text-warning',
+        'bg-warning',
         health.reach === 'connected' ? 'No account access' : 'Unstable',
         health.lastError,
       )
     case 'offline':
-      return pill('text-red', 'bg-red', health.recovering ? 'Reconnecting...' : 'Offline', health.lastError, true)
+      return pill('text-destructive', 'bg-destructive', health.recovering ? 'Reconnecting...' : 'Offline', health.lastError, true)
   }
 }

--- a/ui/src/components/uta/OrderEntryDialog.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.tsx
@@ -78,8 +78,8 @@ function Header({ mode, onClose }: { mode: OrderEntryMode; onClose: () => void }
   const title = mode.kind === 'place' ? 'Place Order' : 'Close Position'
   return (
     <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
-      <h3 className="text-[14px] font-semibold text-text">{title}</h3>
-      <button onClick={onClose} className="text-text-muted hover:text-text p-1 transition-colors">
+      <h3 className="text-[14px] font-semibold text-foreground">{title}</h3>
+      <button onClick={onClose} className="text-muted-foreground hover:text-foreground p-1 transition-colors">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
           <path d="M18 6L6 18M6 6l12 12" />
         </svg>
@@ -116,7 +116,7 @@ function WalletPicker({ subAccounts, value, onChange }: {
       <select className={inputClass} value={value} onChange={(e) => onChange(e.target.value)}>
         {subAccounts.map(s => <option key={s.id} value={s.id}>{s.label}</option>)}
       </select>
-      <p className="text-[11px] text-text-muted/60 mt-1">This venue has separate wallets; the order routes to the one you pick.</p>
+      <p className="text-[11px] text-muted-foreground/60 mt-1">This venue has separate wallets; the order routes to the one you pick.</p>
     </Field>
   )
 }
@@ -209,7 +209,7 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
           placeholder="0.001"
           inputMode="decimal"
         />
-        <p className="text-[11px] text-text-muted/60 mt-1">Numeric string — preserved at full precision through to the broker (no float roundtrip).</p>
+        <p className="text-[11px] text-muted-foreground/60 mt-1">Numeric string — preserved at full precision through to the broker (no float roundtrip).</p>
       </Field>
 
       {orderType === 'LMT' && (
@@ -226,7 +226,7 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
 
       <button
         onClick={() => setShowAdvanced(!showAdvanced)}
-        className="text-[11px] text-text-muted hover:text-text transition-colors"
+        className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
       >
         {showAdvanced ? '▾ Hide advanced' : '▸ Show advanced (cash qty, TIF)'}
       </button>
@@ -240,7 +240,7 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
               placeholder="50"
               inputMode="decimal"
             />
-            <p className="text-[11px] text-text-muted/60 mt-1">USDT-equivalent notional. Overrides Quantity if both are set.</p>
+            <p className="text-[11px] text-muted-foreground/60 mt-1">USDT-equivalent notional. Overrides Quantity if both are set.</p>
           </Field>
           <Field label="Time in Force">
             <select className={inputClass} value={tif} onChange={(e) => setTif(e.target.value)}>
@@ -260,7 +260,7 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
             placeholder="Why are you placing this order?"
             autoFocus
           />
-          <p className="text-[11px] text-text-muted/60 mt-1">Goes into the trading-as-git commit log alongside the order. Required, even for manual entries.</p>
+          <p className="text-[11px] text-muted-foreground/60 mt-1">Goes into the trading-as-git commit log alongside the order. Required, even for manual entries.</p>
         </Field>
       </div>
 
@@ -316,9 +316,9 @@ function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { al
 
   return (
     <div className="space-y-4">
-      <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-1">
-        <div className="text-[11px] text-text-muted uppercase tracking-wide">Closing</div>
-        <div className="font-mono text-[13px] text-text">{aliceId}</div>
+      <div className="rounded-md border border-border bg-secondary/50 px-3 py-2.5 space-y-1">
+        <div className="text-[11px] text-muted-foreground uppercase tracking-wide">Closing</div>
+        <div className="font-mono text-[13px] text-foreground">{aliceId}</div>
       </div>
 
       <WalletPicker subAccounts={p.subAccounts} value={subAccountId} onChange={setSubAccountId} />
@@ -331,7 +331,7 @@ function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { al
           placeholder="(empty = full position)"
           inputMode="decimal"
         />
-        <p className="text-[11px] text-text-muted/60 mt-1">Defaults to current position size. Override for partial close. Empty = close entire position.</p>
+        <p className="text-[11px] text-muted-foreground/60 mt-1">Defaults to current position size. Override for partial close. Empty = close entire position.</p>
       </Field>
 
       <Field label="Commit Message — required">
@@ -369,22 +369,22 @@ function PushResultPanel({ result }: { result: WalletPushResult }) {
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
-        <span className={`w-2 h-2 rounded-full shrink-0 ${fullySubmitted ? 'bg-green' : 'bg-yellow-400'}`} />
-        <span className={`text-[13px] font-medium ${fullySubmitted ? 'text-green' : 'text-yellow-400'}`}>
+        <span className={`w-2 h-2 rounded-full shrink-0 ${fullySubmitted ? 'bg-success' : 'bg-warning'}`} />
+        <span className={`text-[13px] font-medium ${fullySubmitted ? 'text-success' : 'text-warning'}`}>
           {fullySubmitted
             ? `${totalSubmitted} operation${totalSubmitted > 1 ? 's' : ''} submitted to broker`
             : `${totalSubmitted} submitted, ${totalRejected} rejected`}
         </span>
       </div>
 
-      <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-1.5">
+      <div className="rounded-md border border-border bg-secondary/50 px-3 py-2.5 space-y-1.5">
         <div className="flex justify-between text-[12px]">
-          <span className="text-text-muted">Commit hash</span>
-          <span className="font-mono text-text">{result.hash}</span>
+          <span className="text-muted-foreground">Commit hash</span>
+          <span className="font-mono text-foreground">{result.hash}</span>
         </div>
         <div className="text-[12px]">
-          <span className="text-text-muted">Message:</span>
-          <span className="ml-2 text-text">{result.message}</span>
+          <span className="text-muted-foreground">Message:</span>
+          <span className="ml-2 text-foreground">{result.message}</span>
         </div>
       </div>
 
@@ -395,9 +395,9 @@ function PushResultPanel({ result }: { result: WalletPushResult }) {
         <OpTable title="Rejected" rows={result.rejected} kind="rejected" />
       )}
 
-      <p className="text-[11px] text-text-muted leading-relaxed">
-        Status <strong className="text-text">Submitted</strong> means the broker accepted the order — fills happen async.
-        Refresh the positions / orders panels in a moment to see the order transition to <strong className="text-text">Filled</strong>.
+      <p className="text-[11px] text-muted-foreground leading-relaxed">
+        Status <strong className="text-foreground">Submitted</strong> means the broker accepted the order — fills happen async.
+        Refresh the positions / orders panels in a moment to see the order transition to <strong className="text-foreground">Filled</strong>.
       </p>
     </div>
   )
@@ -414,11 +414,11 @@ interface OpRow {
 function OpTable({ title, rows, kind }: { title: string; rows: OpRow[]; kind: 'submitted' | 'rejected' }) {
   return (
     <div>
-      <p className="text-[11px] font-medium text-text-muted uppercase tracking-wide mb-1.5">{title} ({rows.length})</p>
+      <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide mb-1.5">{title} ({rows.length})</p>
       <div className="rounded-md border border-border overflow-hidden">
         <table className="w-full text-[12px]">
           <thead>
-            <tr className="bg-bg-tertiary/30 text-text-muted">
+            <tr className="bg-muted/30 text-muted-foreground">
               <th className="text-left px-2.5 py-1.5 font-medium">Action</th>
               <th className="text-left px-2.5 py-1.5 font-medium">Order ID</th>
               <th className="text-left px-2.5 py-1.5 font-medium">Status / Error</th>
@@ -427,9 +427,9 @@ function OpTable({ title, rows, kind }: { title: string; rows: OpRow[]; kind: 's
           <tbody>
             {rows.map((r, i) => (
               <tr key={i} className="border-t border-border">
-                <td className="px-2.5 py-1.5 text-text">{r.action}</td>
-                <td className="px-2.5 py-1.5 font-mono text-text-muted text-[11px]">{r.orderId ?? '—'}</td>
-                <td className={`px-2.5 py-1.5 ${kind === 'rejected' ? 'text-red' : 'text-text'}`}>
+                <td className="px-2.5 py-1.5 text-foreground">{r.action}</td>
+                <td className="px-2.5 py-1.5 font-mono text-muted-foreground text-[11px]">{r.orderId ?? '—'}</td>
+                <td className={`px-2.5 py-1.5 ${kind === 'rejected' ? 'text-destructive' : 'text-foreground'}`}>
                   {kind === 'rejected' ? (r.error ?? r.status) : r.status}
                 </td>
               </tr>
@@ -445,14 +445,14 @@ function OpTable({ title, rows, kind }: { title: string; rows: OpRow[]; kind: 's
 
 function ErrorPanel({ message, phase }: { message: string; phase?: string }) {
   return (
-    <div className="rounded-md border border-red/30 bg-red/5 px-3 py-2.5">
+    <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5">
       <div className="flex items-center gap-2 mb-1">
-        <span className="w-2 h-2 rounded-full bg-red shrink-0" />
-        <span className="text-[12px] font-medium text-red">
+        <span className="w-2 h-2 rounded-full bg-destructive shrink-0" />
+        <span className="text-[12px] font-medium text-destructive">
           {phase ? `Failed at ${phase} step` : 'Failed'}
         </span>
       </div>
-      <p className="text-[12px] text-text whitespace-pre-wrap">{message}</p>
+      <p className="text-[12px] text-foreground whitespace-pre-wrap">{message}</p>
     </div>
   )
 }
@@ -472,8 +472,8 @@ function Segmented({ value, options, onChange }: {
           onClick={() => onChange(o.id)}
           className={`px-3 py-1.5 text-[12px] font-medium transition-colors ${
             value === o.id
-              ? 'bg-accent/15 text-accent'
-              : 'text-text-muted hover:text-text hover:bg-bg-tertiary/30'
+              ? 'bg-primary/15 text-primary'
+              : 'text-muted-foreground hover:text-foreground hover:bg-muted/30'
           }`}
         >
           {o.label ?? o.id}

--- a/ui/src/components/uta/SchemaFormFields.tsx
+++ b/ui/src/components/uta/SchemaFormFields.tsx
@@ -22,8 +22,8 @@ export function SchemaFormFields({ fields, formData, setField, showSecrets }: {
               <label key={f.key} className="flex items-start gap-2 cursor-pointer select-none">
                 <Toggle size="sm" checked={value === 'true'} onChange={(v) => setField(f.key, v ? 'true' : 'false')} />
                 <span>
-                  <span className="text-[13px] text-text">{f.title}</span>
-                  {f.description && <p className="text-[11px] text-text-muted/60 mt-0.5">{f.description}</p>}
+                  <span className="text-[13px] text-foreground">{f.title}</span>
+                  {f.description && <p className="text-[11px] text-muted-foreground/60 mt-0.5">{f.description}</p>}
                 </span>
               </label>
             )
@@ -33,7 +33,7 @@ export function SchemaFormFields({ fields, formData, setField, showSecrets }: {
                 <select className={inputClass} value={value} onChange={(e) => setField(f.key, e.target.value)}>
                   {f.options?.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
                 </select>
-                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
+                {f.description && <p className="text-[11px] text-muted-foreground/60 mt-1">{f.description}</p>}
               </Field>
             )
           case 'password':
@@ -46,7 +46,7 @@ export function SchemaFormFields({ fields, formData, setField, showSecrets }: {
                   onChange={(e) => setField(f.key, e.target.value)}
                   placeholder={f.required ? 'Required' : ''}
                 />
-                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
+                {f.description && <p className="text-[11px] text-muted-foreground/60 mt-1">{f.description}</p>}
               </Field>
             )
           case 'text':
@@ -60,7 +60,7 @@ export function SchemaFormFields({ fields, formData, setField, showSecrets }: {
                   onChange={(e) => setField(f.key, e.target.value)}
                   placeholder={f.required ? 'Required' : ''}
                 />
-                {f.description && <p className="text-[11px] text-text-muted/60 mt-1">{f.description}</p>}
+                {f.description && <p className="text-[11px] text-muted-foreground/60 mt-1">{f.description}</p>}
               </Field>
             )
         }

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -79,7 +79,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
           aria-haspopup="menu"
           aria-expanded={agentMenuOpen}
           aria-label={t('chatLanding.selectAgent')}
-          className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 text-[11px] text-text-muted hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+          className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-[11px] text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
         >
           {SelectedIcon ? <SelectedIcon className="h-3 w-3 shrink-0" /> : <Bot className="h-3 w-3 shrink-0" />}
           <span className="truncate">{config.selectedAgent?.displayName ?? t('chatLanding.selectAgent')}</span>
@@ -88,7 +88,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
         {agentMenuOpen && config.agents.length > 0 && (
           <div
             role="menu"
-            className="oa-popover-enter absolute bottom-full left-0 z-20 mb-1 min-w-[180px] rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg"
+            className="oa-popover-enter absolute bottom-full left-0 z-20 mb-1 min-w-[180px] rounded-lg border border-border/70 bg-secondary py-1 shadow-lg"
           >
             {config.agents.map((agent) => {
               const Icon = AGENT_ICONS[agent.id]
@@ -103,11 +103,11 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
                     config.selectAgent(agent.id)
                     setAgentMenuOpen(false)
                   }}
-                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : missing ? 'text-text-muted' : 'text-text'}`}
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-muted ${active ? 'text-primary' : missing ? 'text-muted-foreground' : 'text-foreground'}`}
                 >
                   {Icon ? <Icon className="h-3.5 w-3.5 shrink-0" /> : <span className="w-3.5 shrink-0" />}
                   <span className="min-w-0 flex-1 truncate">{agent.displayName}</span>
-                  {missing && <span className="shrink-0 text-[10px] text-text-muted">{t('chatLanding.agentNotInstalled')}</span>}
+                  {missing && <span className="shrink-0 text-[10px] text-muted-foreground">{t('chatLanding.agentNotInstalled')}</span>}
                   {active && <Check className="h-3.5 w-3.5 shrink-0" />}
                 </button>
               )
@@ -120,7 +120,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
         <button
           type="button"
           onClick={onConfigureProvider}
-          className="oa-pressable inline-flex min-h-8 items-center gap-1.5 rounded-md bg-amber-500/10 px-2.5 py-1 text-[11px] text-amber-600 hover:bg-amber-500/20 dark:text-amber-400"
+          className="oa-pressable inline-flex min-h-8 items-center gap-1.5 rounded-md bg-warning/10 px-2.5 py-1 text-[11px] text-warning hover:bg-warning/20"
         >
           <KeyRound className="h-3 w-3" />
           {t('chatLanding.configureProvider')}
@@ -138,7 +138,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
             aria-haspopup="menu"
             aria-expanded={credentialMenuOpen}
             aria-label={t('chatLanding.selectCredential')}
-            className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 text-[11px] text-text-muted hover:text-text"
+            className="oa-pressable inline-flex min-h-8 max-w-[190px] items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-[11px] text-muted-foreground hover:text-foreground"
           >
             <KeyRound className="h-3 w-3 shrink-0" />
             <span className="truncate">
@@ -149,7 +149,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
           {credentialMenuOpen && (
             <div
               role="menu"
-              className="oa-popover-enter absolute bottom-full left-0 z-20 mb-1 min-w-[200px] rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg"
+              className="oa-popover-enter absolute bottom-full left-0 z-20 mb-1 min-w-[200px] rounded-lg border border-border/70 bg-secondary py-1 shadow-lg"
             >
               {config.credentials.map((credential) => {
                 const active = credential.slug === config.effectiveCredential
@@ -162,15 +162,15 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
                       config.selectCredential(credential.slug)
                       setCredentialMenuOpen(false)
                     }}
-                    className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : 'text-text'}`}
+                    className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-muted ${active ? 'text-primary' : 'text-foreground'}`}
                   >
                     <span className="min-w-0 flex-1">
                       <span className="block truncate">{credential.label?.trim() || credential.slug}</span>
                       {credential.resolvedModel && (
-                        <span className="block truncate text-[10px] text-text-muted">{credential.resolvedModel}</span>
+                        <span className="block truncate text-[10px] text-muted-foreground">{credential.resolvedModel}</span>
                       )}
                     </span>
-                    <span className="shrink-0 text-[10px] text-text-muted">{credential.vendor}</span>
+                    <span className="shrink-0 text-[10px] text-muted-foreground">{credential.vendor}</span>
                     {active && <Check className="h-3.5 w-3.5 shrink-0" />}
                   </button>
                 )
@@ -204,16 +204,16 @@ export function AgentLaunchDetails({
     const model = config.aiDetails.model ?? t('chatLanding.runtimeDefaultModel')
     const context = formatContextWindow(config.aiDetails.contextWindow)
     return (
-      <div className={`flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[10.5px] text-text-muted ${className}`}>
+      <div className={`flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[10.5px] text-muted-foreground ${className}`}>
         <span
           className="inline-flex min-w-0 max-w-full items-center gap-1"
           aria-label={t('chatLanding.modelSummary', { model })}
           title={model}
         >
           <Cpu className="h-3 w-3 shrink-0" />
-          <span className="truncate font-mono text-text/80">{model}</span>
+          <span className="truncate font-mono text-foreground/80">{model}</span>
         </span>
-        <span aria-hidden className="text-text-muted/40">·</span>
+        <span aria-hidden className="text-muted-foreground/40">·</span>
         <span
           className="inline-flex shrink-0 items-center gap-1"
           aria-label={t('chatLanding.contextSummary', { limit: context })}
@@ -224,7 +224,7 @@ export function AgentLaunchDetails({
         <button
           type="button"
           onClick={onAdjustAi}
-          className="oa-pressable inline-flex min-h-7 items-center gap-1 rounded-md px-2 py-1 text-accent hover:bg-accent/10 sm:ml-auto"
+          className="oa-pressable inline-flex min-h-7 items-center gap-1 rounded-md px-2 py-1 text-primary hover:bg-primary/10 sm:ml-auto"
           aria-label={hasWorkspaceTarget ? t('chatLanding.adjustWorkspaceAi') : t('chatLanding.providerSettings')}
           title={hasWorkspaceTarget ? t('chatLanding.adjustWorkspaceAi') : t('chatLanding.providerSettings')}
         >
@@ -237,7 +237,7 @@ export function AgentLaunchDetails({
 
   if (config.selectedAgent && (!config.needsCredential || config.selectedRuntimeUsesGlobalConfig)) {
     return (
-      <div className={`flex min-w-0 items-center gap-1.5 text-[10.5px] text-text-muted ${className}`}>
+      <div className={`flex min-w-0 items-center gap-1.5 text-[10.5px] text-muted-foreground ${className}`}>
         <Bot className="h-3 w-3 shrink-0" />
         <span>{t('chatLanding.runtimeManagedAi', { runtime: config.selectedAgent.displayName })}</span>
       </div>

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -94,9 +94,9 @@ export function ChatWorkspaceSection(): ReactElement | null {
         <button
           type="button"
           onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
-          className="oa-pressable flex w-full items-center gap-2 rounded-lg border border-accent/25 bg-accent/10 px-3 py-2.5 text-left text-[13px] font-medium text-text hover:border-accent/45 hover:bg-accent/15"
+          className="oa-pressable flex w-full items-center gap-2 rounded-lg border border-primary/25 bg-primary/10 px-3 py-2.5 text-left text-[13px] font-medium text-foreground hover:border-primary/45 hover:bg-primary/15"
         >
-          <MessageSquarePlus size={15} strokeWidth={2.15} className="shrink-0 text-accent" />
+          <MessageSquarePlus size={15} strokeWidth={2.15} className="shrink-0 text-primary" />
           <span>{t('chat.newChat')}</span>
         </button>
       </div>
@@ -123,7 +123,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
       />
 
       <div className="px-3 pb-1 pt-1.5">
-        <span className="min-w-0 truncate text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted/60">
+        <span className="min-w-0 truncate text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
           {t('nav.item.workspaces')}
         </span>
       </div>
@@ -131,7 +131,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
         <button
           type="button"
           onClick={() => setShowCreate(true)}
-          className="oa-pressable flex w-full items-center gap-2 rounded-lg border border-border/70 bg-bg-secondary/45 px-3 py-2 text-left text-[12px] font-medium text-text-muted hover:border-border hover:bg-bg-tertiary hover:text-text"
+          className="oa-pressable flex w-full items-center gap-2 rounded-lg border border-border/70 bg-secondary/45 px-3 py-2 text-left text-[12px] font-medium text-muted-foreground hover:border-border hover:bg-muted hover:text-foreground"
           title={t('chat.newWorkspace')}
           aria-label={t('chat.newWorkspace')}
         >
@@ -176,18 +176,18 @@ export function ChatWorkspaceSection(): ReactElement | null {
         )}
         {ctx.hasLoaded && chatWorkspaces.length === 0 && !showListError && (
           <li className="px-3 py-2.5">
-            <p className="text-[12px] text-text-muted/60">{t('chat.noChatWorkspacesYet')}</p>
+            <p className="text-[12px] text-muted-foreground/60">{t('chat.noChatWorkspacesYet')}</p>
             <button
               type="button"
               onClick={() => setShowCreate(true)}
-              className="mt-2 inline-flex items-center gap-1.5 text-[12px] font-medium text-text-muted transition-colors hover:text-text"
+              className="mt-2 inline-flex items-center gap-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               <PanelsTopLeft size={13} strokeWidth={2} />
               <span>{t('chat.newWorkspace')}</span>
             </button>
           </li>
         )}
-        {showListError && <li className="px-3 py-1 text-[11px] text-red">{ctx.listError}</li>}
+        {showListError && <li className="px-3 py-1 text-[11px] text-destructive">{ctx.listError}</li>}
         {chatWorkspaces.map((w) => (
           <ChatWorkspaceRow
             key={w.id}
@@ -260,8 +260,8 @@ function ManagerWorkspaceRow(props: ManagerWorkspaceRowProps): ReactElement {
       <div
         className={`group relative flex w-full items-center overflow-hidden rounded-lg border transition-colors ${
           props.isFocused
-            ? 'border-accent/35 bg-accent/10 text-text'
-            : 'border-border/70 bg-bg-secondary/45 text-text hover:border-accent/25 hover:bg-bg-tertiary'
+            ? 'border-primary/35 bg-primary/10 text-foreground'
+            : 'border-border/70 bg-secondary/45 text-foreground hover:border-primary/25 hover:bg-muted'
         }`}
       >
         <span className="pointer-events-none absolute inset-y-0 right-0 w-20 bg-gradient-to-l from-accent/[0.07] to-transparent" />
@@ -269,7 +269,7 @@ function ManagerWorkspaceRow(props: ManagerWorkspaceRowProps): ReactElement {
           type="button"
           onClick={() => setExpanded((current) => !current)}
           disabled={sessions.length === 0}
-          className="oa-icon-action relative ml-1 flex h-8 w-6 shrink-0 items-center justify-center rounded text-text-muted/55 hover:text-text disabled:cursor-default disabled:opacity-30"
+          className="oa-icon-action relative ml-1 flex h-8 w-6 shrink-0 items-center justify-center rounded text-muted-foreground/55 hover:text-foreground disabled:cursor-default disabled:opacity-30"
           aria-label={expanded ? t('chat.collapseSessions') : t('chat.expandSessions')}
           title={expanded ? t('chat.collapseSessions') : t('chat.expandSessions')}
         >
@@ -283,18 +283,18 @@ function ManagerWorkspaceRow(props: ManagerWorkspaceRowProps): ReactElement {
           aria-label={t('workspaceManager.title')}
           className="oa-pressable relative flex min-w-0 flex-1 items-center gap-2.5 py-2.5 pl-1 pr-3 text-left"
         >
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-accent/10 text-accent transition-transform group-hover:scale-105">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-transform group-hover:scale-105">
             <Network size={14} strokeWidth={2.1} />
           </span>
           <span className="min-w-0 flex-1">
             <span className="block truncate text-[12px] font-semibold">{t('workspaceManager.title')}</span>
-            <span className="mt-0.5 block truncate text-[10px] text-text-muted">{t('workspaceManager.sidebarDescription')}</span>
+            <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">{t('workspaceManager.sidebarDescription')}</span>
           </span>
           {!props.loaded ? (
-            <span aria-hidden className="h-2.5 w-4 animate-pulse rounded bg-text-muted/15" />
+            <span aria-hidden className="h-2.5 w-4 animate-pulse rounded bg-muted-foreground/15" />
           ) : sessions.length > 0 ? (
-            <span className="inline-flex shrink-0 items-center gap-1.5 text-[10px] tabular-nums text-text-muted/55">
-              <span className={`h-1.5 w-1.5 rounded-full ${hasRunning ? 'bg-green' : 'bg-text-muted/35'}`} />
+            <span className="inline-flex shrink-0 items-center gap-1.5 text-[10px] tabular-nums text-muted-foreground/55">
+              <span className={`h-1.5 w-1.5 rounded-full ${hasRunning ? 'bg-success' : 'bg-muted-foreground/35'}`} />
               {sessions.length}
             </span>
           ) : null}
@@ -353,20 +353,20 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
   )
 
   const statusClass = hasRunning
-    ? 'bg-green'
+    ? 'bg-success'
     : w.sessions.length > 0
-      ? 'bg-text-muted/40'
+      ? 'bg-muted-foreground/40'
       : 'border border-border'
 
   return (
     <li className="group relative" data-reorder-id={w.id}>
       <div
         className={`flex items-center gap-1 pl-2 pr-2 py-1 text-[13px] cursor-pointer transition-colors ${
-          isSelected ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
+          isSelected ? 'bg-muted text-foreground' : 'text-foreground hover:bg-muted/50'
         }`}
       >
         {isSelected && (
-          <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />
+          <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />
         )}
         <button
           type="button"
@@ -374,7 +374,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
             e.stopPropagation()
             setExpanded((v) => !v)
           }}
-          className="w-4 h-5 flex items-center justify-center text-text-muted/50 hover:text-text shrink-0"
+          className="w-4 h-5 flex items-center justify-center text-muted-foreground/50 hover:text-foreground shrink-0"
           aria-label={expanded ? t('chat.collapseSessions') : t('chat.expandSessions')}
           title={expanded ? t('chat.collapseSessions') : t('chat.expandSessions')}
         >
@@ -395,13 +395,13 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               {props.label}
             </span>
             {subtitle && (
-              <span className="block truncate text-[11px] leading-3 text-text-muted/65" title={subtitle}>
+              <span className="block truncate text-[11px] leading-3 text-muted-foreground/65" title={subtitle}>
                 {subtitle}
               </span>
             )}
           </span>
           {w.sessions.length > 0 && (
-            <span className="text-[11px] text-text-muted/45 tabular-nums shrink-0">
+            <span className="text-[11px] text-muted-foreground/45 tabular-nums shrink-0">
               {w.sessions.length}
             </span>
           )}
@@ -415,7 +415,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
             e.stopPropagation()
             props.onSpawn()
           }}
-          className="oa-icon-action shrink-0 w-5 h-5 rounded flex items-center justify-center text-text-muted/50 hover:text-text hover:bg-bg-secondary transition-colors"
+          className="oa-icon-action shrink-0 w-5 h-5 rounded flex items-center justify-center text-muted-foreground/50 hover:text-foreground hover:bg-secondary transition-colors"
           title={t('chat.newSession')}
           aria-label={t('chat.newSession')}
         >
@@ -428,7 +428,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               e.stopPropagation()
               props.onConfigure()
             }}
-            className="oa-icon-action w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-secondary"
+            className="oa-icon-action w-5 h-5 rounded flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary"
             title={t('workspace.configure')}
             aria-label={t('workspace.configure')}
           >
@@ -440,7 +440,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               e.stopPropagation()
               props.onDelete()
             }}
-            className="oa-icon-action w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-red hover:bg-red/10"
+            className="oa-icon-action w-5 h-5 rounded flex items-center justify-center text-muted-foreground hover:text-destructive hover:bg-destructive/10"
             title={t('chat.deleteWorkspace')}
             aria-label={t('chat.deleteWorkspace')}
           >

--- a/ui/src/components/workspace/CreateWorkspaceDialog.tsx
+++ b/ui/src/components/workspace/CreateWorkspaceDialog.tsx
@@ -29,8 +29,8 @@ export function CreateWorkspaceDialog(props: CreateWorkspaceDialogProps): ReactE
   return (
     <Dialog onClose={props.onClose} width="w-[460px]">
       <div className="px-5 py-4 border-b border-border">
-        <h2 className="text-[15px] font-semibold text-text">{t('createWorkspace.dialogTitle')}</h2>
-        <p className="text-[12px] text-text-muted mt-0.5">
+        <h2 className="text-[15px] font-semibold text-foreground">{t('createWorkspace.dialogTitle')}</h2>
+        <p className="text-[12px] text-muted-foreground mt-0.5">
           {t('createWorkspace.dialogSubtitle')}
         </p>
       </div>

--- a/ui/src/components/workspace/CreateWorkspaceForm.tsx
+++ b/ui/src/components/workspace/CreateWorkspaceForm.tsx
@@ -43,9 +43,9 @@ export interface CreateWorkspaceFormProps {
 }
 
 const FIELD =
-  'w-full px-3 py-2 text-[13px] bg-bg border border-border rounded text-text focus:outline-none focus:border-accent'
-const LABEL = 'block text-[11px] uppercase tracking-wider text-text-muted/70'
-const HINT = 'text-[11px] text-text-muted/70'
+  'w-full px-3 py-2 text-[13px] bg-background border border-border rounded text-foreground focus:outline-none focus:border-primary'
+const LABEL = 'block text-[11px] uppercase tracking-wider text-muted-foreground/70'
+const HINT = 'text-[11px] text-muted-foreground/70'
 
 export function CreateWorkspaceForm(props: CreateWorkspaceFormProps): ReactElement {
   const { t } = useTranslation()
@@ -149,12 +149,12 @@ export function CreateWorkspaceForm(props: CreateWorkspaceFormProps): ReactEleme
           spellCheck={false}
           autoCorrect="off"
           autoCapitalize="off"
-          className={`${FIELD} font-mono placeholder:text-text-muted/50`}
+          className={`${FIELD} font-mono placeholder:text-muted-foreground/50`}
         />
         <p className={HINT}>{TAG_HINT}</p>
       </div>
 
-      {create.error && <div className="text-[12px] text-red">{create.error}</div>}
+      {create.error && <div className="text-[12px] text-destructive">{create.error}</div>}
 
       <div className="flex items-center justify-end gap-2 pt-1">
         {onCancel && (
@@ -162,7 +162,7 @@ export function CreateWorkspaceForm(props: CreateWorkspaceFormProps): ReactEleme
             type="button"
             onClick={onCancel}
             disabled={create.creating}
-            className="px-3 py-2 text-[13px] rounded text-text-muted hover:text-text hover:bg-bg-secondary"
+            className="px-3 py-2 text-[13px] rounded text-muted-foreground hover:text-foreground hover:bg-secondary"
           >
             {t('createWorkspace.cancel')}
           </button>

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -64,9 +64,9 @@ export function OverviewCard({
   }, [w.sessions, w.createdAt])
 
   const dotClass = hasRunning
-    ? 'bg-green'
+    ? 'bg-success'
     : w.sessions.length > 0
-      ? 'bg-text-muted/40'
+      ? 'bg-muted-foreground/40'
       : 'border border-border'
 
   const overrideAgents: string[] = []
@@ -78,7 +78,7 @@ export function OverviewCard({
   return (
     <div
       onClick={onOpen}
-      className="group rounded-lg border border-border bg-bg-secondary hover:bg-bg-tertiary/40 hover:border-border/80 transition-colors cursor-pointer p-4 flex flex-col gap-3"
+      className="group rounded-lg border border-border bg-secondary hover:bg-muted/40 hover:border-border/80 transition-colors cursor-pointer p-4 flex flex-col gap-3"
     >
       {/* Header */}
       <div className="flex items-start gap-2.5">
@@ -87,10 +87,10 @@ export function OverviewCard({
           aria-hidden="true"
         />
         <div className="flex-1 min-w-0">
-          <h3 className="text-[14px] font-semibold text-text truncate" title={workspaceDisplayTitle(w)}>
+          <h3 className="text-[14px] font-semibold text-foreground truncate" title={workspaceDisplayTitle(w)}>
             {label}
           </h3>
-          <p className="text-[11px] text-text-muted truncate" title={w.description}>
+          <p className="text-[11px] text-muted-foreground truncate" title={w.description}>
             {w.description?.trim() || t('workspace.activeAgo', { time: formatRelativeTime(lastActivityMs) })}
           </p>
         </div>
@@ -106,7 +106,7 @@ export function OverviewCard({
               from: w.upgradeAvailable.from,
               to: w.upgradeAvailable.to,
             })}
-            className="oa-pressable shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/40 hover:border-accent/80 hover:bg-accent/10 transition-colors disabled:cursor-default disabled:hover:border-accent/40 disabled:hover:bg-transparent"
+            className="oa-pressable shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-primary border border-primary/40 hover:border-primary/80 hover:bg-primary/10 transition-colors disabled:cursor-default disabled:hover:border-primary/40 disabled:hover:bg-transparent"
           >
             <ArrowUpCircle size={10} strokeWidth={2.25} />
             <span>v{w.upgradeAvailable.to}</span>
@@ -116,11 +116,11 @@ export function OverviewCard({
 
       {/* Sessions */}
       <div className="border-t border-border pt-3">
-        <div className="text-[10px] uppercase tracking-wider text-text-muted/70 mb-1.5">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-1.5">
           {t('workspace.sessions')}
         </div>
         {w.sessions.length === 0 ? (
-          <p className="text-[12px] text-text-muted/80 italic">{t('workspace.noSessions')}</p>
+          <p className="text-[12px] text-muted-foreground/80 italic">{t('workspace.noSessions')}</p>
         ) : (
           <ul className="space-y-0.5 -mx-2">
             {w.sessions.map((s) => (
@@ -130,22 +130,22 @@ export function OverviewCard({
                   e.stopPropagation()
                   onOpenSession(s.id)
                 }}
-                className="flex items-center gap-2 text-[12px] text-text hover:bg-bg-tertiary/40 px-2 py-1 rounded transition-colors cursor-pointer"
+                className="flex items-center gap-2 text-[12px] text-foreground hover:bg-muted/40 px-2 py-1 rounded transition-colors cursor-pointer"
               >
-                <span className="w-3 flex justify-center text-text-muted">
+                <span className="w-3 flex justify-center text-muted-foreground">
                   <AgentGlyph agent={s.agent} />
                 </span>
                 <span className="font-mono text-[11px] tabular-nums">{s.name}</span>
                 <span
                   className={`text-[11px] ${
-                    s.state === 'running' ? 'text-green' : 'text-text-muted'
+                    s.state === 'running' ? 'text-success' : 'text-muted-foreground'
                   }`}
                 >
                   {t(s.state === 'running' ? 'workspace.running' : 'workspace.paused')}
                 </span>
                 <ChevronRight
                   size={10}
-                  className="ml-auto text-text-muted opacity-0 group-hover:opacity-60 transition-opacity"
+                  className="ml-auto text-muted-foreground opacity-0 group-hover:opacity-60 transition-opacity"
                 />
               </li>
             ))}
@@ -157,7 +157,7 @@ export function OverviewCard({
       {(overrideAgents.length > 0 || lastCommit || (w.template && w.spawnedFromVersion)) && (
         <div className="border-t border-border pt-3 space-y-1.5">
           {w.template && w.spawnedFromVersion && (
-            <div className="flex items-center gap-2 text-[11px] text-text-muted">
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
               <GitBranch size={11} strokeWidth={2.25} className="shrink-0" />
               <span className="truncate">
                 {t('workspace.fromTemplate', {
@@ -174,20 +174,20 @@ export function OverviewCard({
                 e.stopPropagation()
                 onConfigure()
               }}
-              className="flex items-center gap-2 text-[11px] text-text-muted hover:text-text transition-colors w-full text-left"
+              className="flex items-center gap-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
             >
               <Settings size={11} strokeWidth={2.25} className="shrink-0" />
               <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
             </button>
           )}
           {overrideAgents.length > 0 && !onConfigure && (
-            <div className="flex items-center gap-2 text-[11px] text-text-muted">
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
               <Settings size={11} strokeWidth={2.25} className="shrink-0" />
               <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
             </div>
           )}
           {lastCommit && (
-            <div className="flex items-center gap-2 text-[11px] text-text-muted">
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
               <ScrollText size={11} strokeWidth={2.25} className="shrink-0" />
               <span className="truncate" title={lastCommit.subject}>
                 {lastCommit.subject}

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -136,7 +136,7 @@ export function Sidebar(props: SidebarProps): ReactElement {
         <button
           type="button"
           onClick={() => setShowCreate(true)}
-          className="oa-pressable w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-border/60 bg-bg-tertiary/30 text-[13px] font-medium text-text-muted hover:text-text hover:border-accent/50 hover:bg-bg-tertiary/60"
+          className="oa-pressable w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-border/60 bg-muted/30 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:border-primary/50 hover:bg-muted/60"
         >
           <Plus size={15} strokeWidth={2.25} className="shrink-0" />
           <span className="truncate">{t('workspace.newWorkspace')}</span>
@@ -197,9 +197,9 @@ export function Sidebar(props: SidebarProps): ReactElement {
         </div>
       )}
       {props.hasLoaded && props.workspaces.length === 0 && !showListError && (
-        <div className="px-3 py-2 text-[12px] text-text-muted/60">{t('workspace.emptySidebar')}</div>
+        <div className="px-3 py-2 text-[12px] text-muted-foreground/60">{t('workspace.emptySidebar')}</div>
       )}
-      {showListError && <div className="px-3 py-2 text-[12px] text-red">{props.listError}</div>}
+      {showListError && <div className="px-3 py-2 text-[12px] text-destructive">{props.listError}</div>}
 
       <div ref={workspaceListRef} className="flex flex-col mt-0.5">
         {orderedWorkspaces.map((w) => (
@@ -246,11 +246,11 @@ function NavRow({
       onClick={onClick}
       title={title}
       className={`oa-nav-row relative flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-left ${
-        active ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
+        active ? 'bg-muted text-foreground' : 'text-foreground hover:bg-muted/50'
       }`}
     >
-      {active && <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />}
-      <Icon size={14} strokeWidth={2} className="shrink-0 text-text-muted/70" aria-hidden="true" />
+      {active && <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />}
+      <Icon size={14} strokeWidth={2} className="shrink-0 text-muted-foreground/70" aria-hidden="true" />
       <span className="truncate">{label}</span>
     </button>
   );
@@ -312,8 +312,8 @@ function AgentBadgeGlyph({ agentId }: { agentId: string }): ReactElement {
 
 /** Hover-revealed square action button used for the per-row controls. */
 function rowAction(danger = false): string {
-  return `oa-icon-action shrink-0 w-5 h-5 rounded flex items-center justify-center text-text-muted/70 transition-colors ${
-    danger ? 'hover:text-red hover:bg-red/10' : 'hover:text-text hover:bg-bg-secondary'
+  return `oa-icon-action shrink-0 w-5 h-5 rounded flex items-center justify-center text-muted-foreground/70 transition-colors ${
+    danger ? 'hover:text-destructive hover:bg-destructive/10' : 'hover:text-foreground hover:bg-secondary'
   }`;
 }
 
@@ -386,19 +386,19 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   const chooserTitle = t('workspace.chooseAgent');
 
   const statusClass = hasRunning
-    ? 'bg-green'
+    ? 'bg-success'
     : w.sessions.length > 0
-      ? 'bg-text-muted/40'
+      ? 'bg-muted-foreground/40'
       : 'border border-border';
 
   return (
     <div data-reorder-id={props.reorderId}>
       <div
         className={`group relative flex items-center gap-1 pl-3 pr-2 py-1.5 text-[12px] transition-colors ${
-          isSelected ? 'bg-bg-tertiary text-text' : 'text-text hover:bg-bg-tertiary/50'
+          isSelected ? 'bg-muted text-foreground' : 'text-foreground hover:bg-muted/50'
         }`}
       >
-        {isSelected && <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />}
+        {isSelected && <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />}
         <button
           type="button"
           onClick={() => props.onSelectWorkspace(w.id)}
@@ -410,7 +410,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
             title={hasRunning ? t('workspace.runningCount', { count: runningCount }) : t('workspace.idle')}
           />
           <span className="truncate font-medium">{label}</span>
-          <span className="text-[10px] text-text-muted/50 tabular-nums shrink-0">{formatRelativeTime(w.createdAt)}</span>
+          <span className="text-[10px] text-muted-foreground/50 tabular-nums shrink-0">{formatRelativeTime(w.createdAt)}</span>
         </button>
         {props.onRenameWorkspace && (
           <button
@@ -458,7 +458,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
               <ul
                 ref={menuRef}
                 role="menu"
-                className="oa-popover-enter absolute right-0 top-full mt-1 min-w-[170px] py-1 bg-bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
+                className="oa-popover-enter absolute right-0 top-full mt-1 min-w-[170px] py-1 bg-secondary border border-border/70 rounded-lg shadow-lg z-10"
               >
                 {runtimeAgents.map((agent) => (
                   <li key={agent.id}>
@@ -466,12 +466,12 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
                       type="button"
                       role="menuitem"
                       aria-label={`${agent.displayName} (${agentPrefix(agent.id)})`}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-text transition-colors hover:bg-bg-tertiary"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-foreground transition-colors hover:bg-muted"
                       onClick={() => onMenuPick(agent.id)}
                     >
-                      <Plus size={12} strokeWidth={2.25} className="shrink-0 text-text-muted" />
+                      <Plus size={12} strokeWidth={2.25} className="shrink-0 text-muted-foreground" />
                       <span className="flex-1 truncate">{agent.displayName}</span>
-                      <span className="text-[10px] font-mono text-text-muted/60">{agentPrefix(agent.id)}</span>
+                      <span className="text-[10px] font-mono text-muted-foreground/60">{agentPrefix(agent.id)}</span>
                     </button>
                   </li>
                 ))}
@@ -484,12 +484,12 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
                       type="button"
                       role="menuitem"
                       aria-label={`${agent.displayName} (${agentPrefix(agent.id)})`}
-                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text"
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                       onClick={() => onMenuPick(agent.id)}
                     >
-                      <Terminal size={12} strokeWidth={2.25} className="shrink-0 text-text-muted" />
+                      <Terminal size={12} strokeWidth={2.25} className="shrink-0 text-muted-foreground" />
                       <span className="flex-1 truncate">{agent.displayName}</span>
-                      <span className="text-[10px] font-mono text-text-muted/60">{agentPrefix(agent.id)}</span>
+                      <span className="text-[10px] font-mono text-muted-foreground/60">{agentPrefix(agent.id)}</span>
                     </button>
                   </li>
                 ))}
@@ -550,10 +550,10 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
 
 /** status → token-driven dot colour. */
 const HEADLESS_DOT_CLASS: Record<HeadlessTaskRecord['status'], string> = {
-  running: 'bg-accent',
-  done: 'bg-text-muted/40',
-  failed: 'bg-red',
-  interrupted: 'bg-yellow',
+  running: 'bg-primary',
+  done: 'bg-muted-foreground/40',
+  failed: 'bg-destructive',
+  interrupted: 'bg-warning',
 };
 
 /**
@@ -585,12 +585,12 @@ function HeadlessGroup(props: {
             ? t('workspace.headlessRunning', { count: runningCount })
             : t('workspace.headlessAutomation')
         }
-        className="group flex items-center gap-1 w-full pl-3 pr-2 py-1 text-[10px] font-medium uppercase tracking-wider text-text-muted/60 hover:text-text-muted transition-colors select-none"
+        className="group flex items-center gap-1 w-full pl-3 pr-2 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 hover:text-muted-foreground transition-colors select-none"
       >
         {open ? <ChevronDown size={11} strokeWidth={2.25} aria-hidden="true" /> : <ChevronRight size={11} strokeWidth={2.25} aria-hidden="true" />}
         <span>{t('workspace.headless')}</span>
-        <span className="text-text-muted/45 tabular-nums">{props.tasks.length}</span>
-        {runningCount > 0 && <span className="ml-0.5 w-1.5 h-1.5 rounded-full bg-accent" />}
+        <span className="text-muted-foreground/45 tabular-nums">{props.tasks.length}</span>
+        {runningCount > 0 && <span className="ml-0.5 w-1.5 h-1.5 rounded-full bg-primary" />}
       </button>
       {open && (
         <div className="oa-disclosure-enter ml-[7px] border-l border-border/50">
@@ -617,10 +617,10 @@ function HeadlessTaskRow(props: {
   return (
     <div className="group flex items-center gap-1.5 pl-3 pr-2 py-1 text-[11px]" title={titleParts.join('\n')}>
       <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${HEADLESS_DOT_CLASS[task.status]}`} aria-label={task.status} />
-      <span className="shrink-0 flex items-center justify-center w-3.5 text-text-muted/50">
+      <span className="shrink-0 flex items-center justify-center w-3.5 text-muted-foreground/50">
         <AgentBadgeGlyph agentId={task.agent} />
       </span>
-      <span className="flex-1 truncate text-text-muted">{task.prompt}</span>
+      <span className="flex-1 truncate text-muted-foreground">{task.prompt}</span>
       {openable && (
         <button
           type="button"
@@ -666,20 +666,20 @@ export function SessionRow(props: SessionRowProps): ReactElement {
     <div
       data-reorder-id={props.reorderId}
       className={`group relative flex items-center gap-1.5 pl-3 pr-2 py-1.5 text-[12px] transition-colors ${
-        props.isActive ? 'bg-bg-tertiary' : 'hover:bg-bg-tertiary/50'
+        props.isActive ? 'bg-muted' : 'hover:bg-muted/50'
       }`}
     >
-      {props.isActive && <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent" />}
+      {props.isActive && <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />}
       <button
         type="button"
         className="flex-1 min-w-0 flex items-center gap-1.5 text-left"
         onClick={props.onSelect}
         title={tooltip}
       >
-        <span className={`shrink-0 flex items-center justify-center w-3.5 ${isPaused ? 'text-text-muted/40' : 'text-text-muted/70'}`}>
+        <span className={`shrink-0 flex items-center justify-center w-3.5 ${isPaused ? 'text-muted-foreground/40' : 'text-muted-foreground/70'}`}>
           <AgentBadgeGlyph agentId={s.agent} />
         </span>
-        <span className={`truncate ${isPaused ? 'text-text-muted' : 'text-text'}`}>{display}</span>
+        <span className={`truncate ${isPaused ? 'text-muted-foreground' : 'text-foreground'}`}>{display}</span>
       </button>
       {/* Right-aligned, always-visible state-as-action: a running session shows
           STOP (■, click to pause it); a paused one shows PLAY (▶, click to

--- a/ui/src/components/workspace/TemplateCard.tsx
+++ b/ui/src/components/workspace/TemplateCard.tsx
@@ -5,7 +5,7 @@ import type { AgentInfo, TemplateInfo } from './api'
 
 /**
  * Catalog card for a workspace template. Mirrors the visual idiom of
- * OverviewCard (border + rounded-lg + bg-bg-secondary + hover) so the
+ * OverviewCard (border + rounded-lg + bg-secondary + hover) so the
  * Workspaces activity feels like one design system. Click → opens the
  * detail tab where the README and spawn form live.
  */
@@ -49,25 +49,25 @@ export function TemplateCard({ template: t, agents, onOpen }: Props) {
     <button
       type="button"
       onClick={onOpen}
-      className="group rounded-lg border border-border bg-bg-secondary hover:bg-bg-tertiary/40 hover:border-border/80 transition-colors cursor-pointer p-4 flex flex-col gap-3 text-left"
+      className="group rounded-lg border border-border bg-secondary hover:bg-muted/40 hover:border-border/80 transition-colors cursor-pointer p-4 flex flex-col gap-3 text-left"
     >
       <div className="flex items-start gap-2.5">
         <div className="flex-1 min-w-0">
           <div className="flex items-baseline gap-2">
-            <h3 className="text-[14px] font-semibold text-text truncate" title={t.name}>
+            <h3 className="text-[14px] font-semibold text-foreground truncate" title={t.name}>
               {title}
             </h3>
-            <span className="text-[11px] font-mono text-text-muted tabular-nums">
+            <span className="text-[11px] font-mono text-muted-foreground tabular-nums">
               v{t.version}
             </span>
             {t.community && (
-              <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-border text-text-muted">
+              <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-border text-muted-foreground">
                 {tr('templates.communityBadge')}
               </span>
             )}
           </div>
           {t.description && (
-            <p className="text-[12px] text-text-muted line-clamp-3 mt-1">
+            <p className="text-[12px] text-muted-foreground line-clamp-3 mt-1">
               {t.description}
             </p>
           )}
@@ -75,10 +75,10 @@ export function TemplateCard({ template: t, agents, onOpen }: Props) {
       </div>
 
       <div className="border-t border-border pt-3 flex items-center gap-3 flex-wrap">
-        <div className="text-[10px] uppercase tracking-wider text-text-muted/70">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
           {tr('templates.agentsLabel')}
         </div>
-        <div className="flex items-center gap-2 text-text-muted flex-wrap">
+        <div className="flex items-center gap-2 text-muted-foreground flex-wrap">
           {agents.map((a) => {
             // Backend PATH-probes each runtime; dim the ones not installed on
             // this host so the catalog hints at what needs setting up.

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -658,13 +658,13 @@ function TerminalThemeControl(): ReactElement {
 
 function StatusDot({ status }: { status: Status }): ReactElement {
   const colors: Record<Status, string> = {
-    connecting: '#d29922',
-    reconnecting: '#d29922',
-    connected: '#7ee787',
-    closed: '#6e7681',
-    error: '#ff7b72',
-    kicked: '#d2a8ff',
-    locked: '#d2a8ff',
+    connecting: 'var(--warning)',
+    reconnecting: 'var(--warning)',
+    connected: 'var(--success)',
+    closed: 'var(--muted-foreground)',
+    error: 'var(--destructive)',
+    kicked: 'var(--ai-action)',
+    locked: 'var(--ai-action)',
   };
   return (
     <span

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -61,7 +61,7 @@ interface Props {
 }
 
 const inputClass =
-  'w-full bg-bg-secondary border border-border rounded-md px-3 py-2 text-[13px] text-text placeholder:text-text-muted/60 focus:outline-none focus:border-accent'
+  'w-full bg-secondary border border-border rounded-md px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:border-primary'
 
 const TAB_LABEL: Record<Tab, string> = { claude: 'Claude Code', codex: 'Codex', opencode: 'opencode', pi: 'Pi' }
 const DEFAULT_CONTEXT_WINDOW = 256_000
@@ -414,23 +414,23 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-backdrop backdrop-blur-sm"
       onMouseDown={handleBackdropMouseDown}
     >
       <div
-        className="bg-bg border border-border rounded-xl shadow-2xl w-[calc(100vw-24px)] max-w-3xl max-h-[85vh] flex flex-col"
+        className="bg-background border border-border rounded-xl shadow-2xl w-[calc(100vw-24px)] max-w-3xl max-h-[85vh] flex flex-col"
         onMouseDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
           <div className="min-w-0">
-            <h2 className="text-[15px] font-semibold text-text">Workspace Settings</h2>
-            <p className="mt-0.5 truncate text-[11px] text-text-muted">{workspaceLabel}</p>
+            <h2 className="text-[15px] font-semibold text-foreground">Workspace Settings</h2>
+            <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{workspaceLabel}</p>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md p-1 text-text-muted hover:bg-bg-tertiary hover:text-text transition-colors"
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
             aria-label="Close workspace settings"
             title="Close"
           >
@@ -439,14 +439,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
-          <aside className="flex w-full shrink-0 gap-1 border-b border-border bg-bg-secondary/25 p-2 sm:block sm:w-40 sm:border-b-0 sm:border-r">
+          <aside className="flex w-full shrink-0 gap-1 border-b border-border bg-secondary/25 p-2 sm:block sm:w-40 sm:border-b-0 sm:border-r">
             <button
               type="button"
               onClick={() => setSection('general')}
               className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:w-full ${
                 section === 'general'
-                  ? 'bg-accent/10 text-accent'
-                  : 'text-text-muted hover:bg-bg-tertiary hover:text-text'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
               }`}
             >
               <Settings size={15} />
@@ -457,8 +457,8 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
               onClick={() => setSection('ai')}
               className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:mt-1 sm:w-full ${
                 section === 'ai'
-                  ? 'bg-accent/10 text-accent'
-                  : 'text-text-muted hover:bg-bg-tertiary hover:text-text'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
               }`}
             >
               <Bot size={15} />
@@ -469,14 +469,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
               onClick={() => setSection('template')}
               className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:mt-1 sm:w-full ${
                 section === 'template'
-                  ? 'bg-accent/10 text-accent'
-                  : 'text-text-muted hover:bg-bg-tertiary hover:text-text'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
               }`}
             >
               <Layers3 size={15} />
               <span>Template</span>
               {workspace?.upgradeAvailable && (
-                <span className="ml-auto h-1.5 w-1.5 rounded-full bg-accent" aria-label="Update available" />
+                <span className="ml-auto h-1.5 w-1.5 rounded-full bg-primary" aria-label="Update available" />
               )}
             </button>
             <button
@@ -484,8 +484,8 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
               onClick={() => setSection('absorb')}
               className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:mt-1 sm:w-full ${
                 section === 'absorb'
-                  ? 'bg-accent/10 text-accent'
-                  : 'text-text-muted hover:bg-bg-tertiary hover:text-text'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
               }`}
             >
               <GitMerge size={15} />
@@ -499,7 +499,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                 <div className="flex-1 overflow-y-auto p-4">
                   <div className="max-w-xl space-y-4">
                   <div>
-                    <label className="block text-xs font-medium text-text-muted mb-1">Display name</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1">Display name</label>
                     <input
                       value={displayName}
                       onChange={(e) => setDisplayName(e.target.value)}
@@ -507,14 +507,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                       placeholder={stableTag}
                       className={inputClass}
                     />
-                    <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-text-muted/70">
+                    <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-muted-foreground/70">
                       <span>Shown in the workspace list and tab titles.</span>
                       <span>{displayName.length}/80</span>
                     </div>
                   </div>
 
                   <div>
-                    <label className="block text-xs font-medium text-text-muted mb-1">Description</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1">Description</label>
                     <textarea
                       value={description}
                       onChange={(e) => setDescription(e.target.value)}
@@ -523,19 +523,19 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                       placeholder="Short note for recognizing this workspace."
                       className={`${inputClass} min-h-28 resize-y leading-relaxed`}
                     />
-                    <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-text-muted/70">
+                    <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-muted-foreground/70">
                       <span>Shown on workspace overview cards.</span>
                       <span>{description.length}/240</span>
                     </div>
                   </div>
 
-                  <div className="rounded-lg border border-border bg-bg-secondary/30 p-3">
+                  <div className="rounded-lg border border-border bg-secondary/30 p-3">
                     <div className="flex items-start gap-2">
-                      <Info size={14} className="mt-0.5 shrink-0 text-text-muted" />
+                      <Info size={14} className="mt-0.5 shrink-0 text-muted-foreground" />
                       <div className="min-w-0">
-                        <div className="text-[11px] font-medium uppercase tracking-wide text-text-muted">Stable tag</div>
-                        <div className="mt-1 truncate font-mono text-[12px] text-text">{stableTag}</div>
-                        <p className="mt-1 text-[11px] leading-snug text-text-muted/75">
+                        <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Stable tag</div>
+                        <div className="mt-1 truncate font-mono text-[12px] text-foreground">{stableTag}</div>
+                        <p className="mt-1 text-[11px] leading-snug text-muted-foreground/75">
                           The tag stays stable for paths and launcher bookkeeping; the display name is the human-facing label.
                         </p>
                       </div>
@@ -543,19 +543,19 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                   </div>
 
                   {error && (
-                    <div className="rounded-md border border-red/40 bg-red/10 text-red text-[12px] px-3 py-2">
+                    <div className="rounded-md border border-destructive/40 bg-destructive/10 text-destructive text-[12px] px-3 py-2">
                       {error}
                     </div>
                   )}
                   {metadataSavedFlash && (
-                    <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
+                    <div className="rounded-md border border-success/40 bg-success/10 text-success text-[12px] px-3 py-2">
                       Saved to <code className="font-mono text-[11.5px]">.alice/workspace.json</code>.
                     </div>
                   )}
                   </div>
                 </div>
-                <div className="flex flex-col gap-2 border-t border-border bg-bg-secondary/30 p-3 sm:flex-row sm:items-center sm:justify-between">
-                  <p className="text-[11px] text-text-muted/75">
+                <div className="flex flex-col gap-2 border-t border-border bg-secondary/30 p-3 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-[11px] text-muted-foreground/75">
                     Stored in <code className="font-mono text-[11.5px]">.alice/workspace.json</code>.
                   </p>
                   <div className="flex justify-end gap-2">
@@ -563,7 +563,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                       type="button"
                       onClick={onClose}
                       disabled={metadataSaving}
-                      className="px-3 py-2 rounded-md text-text-muted hover:text-text text-[13px] disabled:opacity-40"
+                      className="px-3 py-2 rounded-md text-muted-foreground hover:text-foreground text-[13px] disabled:opacity-40"
                     >
                       Cancel
                     </button>
@@ -571,7 +571,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                       type="button"
                       onClick={handleSaveMetadata}
                       disabled={metadataSaving || !metadataDirty}
-                      className="px-4 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
+                      className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-primary/90 transition-colors"
                     >
                       {metadataSaving ? 'Saving…' : 'Save'}
                     </button>
@@ -583,7 +583,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
             {section === 'ai' && (
               <>
         {/* Tabs */}
-        <div className="flex border-b border-border bg-bg-secondary/50">
+        <div className="flex border-b border-border bg-secondary/50">
           {(['claude', 'codex', 'opencode', 'pi'] as const).map((id) => (
             <button
               key={id}
@@ -594,8 +594,8 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
               }}
               className={`flex-1 px-4 py-2.5 text-[13px] font-medium transition-colors ${
                 tab === id
-                  ? 'text-accent border-b-2 border-accent -mb-px'
-                  : 'text-text-muted hover:text-text'
+                  ? 'text-primary border-b-2 border-primary -mb-px'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               {TAB_LABEL[id]}
@@ -606,8 +606,8 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
         {/* Body */}
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
           {/* Quick pick — load a saved credential into the form */}
-          <div className="rounded-lg border border-border bg-bg-secondary/30 p-3">
-            <label className="block text-xs font-medium text-text-muted mb-2">
+          <div className="rounded-lg border border-border bg-secondary/30 p-3">
+            <label className="block text-xs font-medium text-muted-foreground mb-2">
               Load from saved credential
             </label>
             {(() => {
@@ -661,12 +661,12 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                     <button
                       onClick={applyCredential}
                       disabled={!pickedCredential}
-                      className="px-3 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
+                      className="px-3 py-2 rounded-md bg-primary text-primary-foreground text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-primary/90 transition-colors"
                     >
                       Load
                     </button>
                   </div>
-                  <p className="text-[11px] text-text-muted/80 leading-snug mt-1.5">
+                  <p className="text-[11px] text-muted-foreground/80 leading-snug mt-1.5">
                     {compatible.length === 0 && credentials.length > 0
                       ? `None of your saved credentials speak a wire ${TAB_LABEL[tab]} supports — add one for this provider, or use a runtime that matches (pi / opencode).`
                       : 'Fills base URL + key from a credential Alice already holds. When it exposes several compatible protocols, choose the one this Workspace should use. Pick a model below, or type a new one.'}
@@ -679,7 +679,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
           {/* Manual fields */}
           {(tab === 'opencode' || tab === 'pi') && (
             <div>
-              <label className="block text-xs font-medium text-text-muted mb-1">API protocol</label>
+              <label className="block text-xs font-medium text-muted-foreground mb-1">API protocol</label>
               <select
                 aria-label={`${TAB_LABEL[tab]} API protocol`}
                 value={form.wireShape}
@@ -703,14 +703,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                   <option key={shape} value={shape}>{WIRE_SHAPE_GUIDANCE[shape]}</option>
                 ))}
               </select>
-              <p className="text-[11px] text-text-muted/80 leading-snug mt-1">
+              <p className="text-[11px] text-muted-foreground/80 leading-snug mt-1">
                 This chooses the agent SDK/provider adapter. The Base URL must expose the matching protocol.
               </p>
             </div>
           )}
 
           {tab === 'pi' && (
-            <label className="flex items-start gap-2.5 rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5">
+            <label className="flex items-start gap-2.5 rounded-md border border-border bg-secondary/50 px-3 py-2.5">
               <input
                 type="checkbox"
                 aria-label="Pi model supports reasoning"
@@ -718,8 +718,8 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                 onChange={(e) => setForm({ ...form, reasoning: e.target.checked })}
                 className="mt-0.5"
               />
-              <span className="text-[12px] leading-relaxed text-text-muted">
-                <strong className="text-text">Model supports reasoning.</strong>{' '}
+              <span className="text-[12px] leading-relaxed text-muted-foreground">
+                <strong className="text-foreground">Model supports reasoning.</strong>{' '}
                 Enables Pi's native thinking controls for this custom model. Leave this off for
                 models that do not expose reasoning tokens.
               </span>
@@ -727,7 +727,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
           )}
 
           <div>
-            <label className="block text-xs font-medium text-text-muted mb-1">Base URL</label>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">Base URL</label>
             <input
               value={form.baseUrl}
               onChange={(e) => setForm({ ...form, baseUrl: e.target.value })}
@@ -748,7 +748,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-muted mb-1">API Key</label>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">API Key</label>
             <div className="flex gap-2">
               <input
                 type={showKey ? 'text' : 'password'}
@@ -762,7 +762,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
               />
               <button
                 onClick={() => setShowKey(!showKey)}
-                className="px-3 rounded-md border border-border text-text-muted hover:text-text text-[12px]"
+                className="px-3 rounded-md border border-border text-muted-foreground hover:text-foreground text-[12px]"
                 type="button"
               >
                 {showKey ? 'Hide' : 'Show'}
@@ -772,7 +772,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
 
           {form.wireShape === 'anthropic' && (
             <div>
-              <label className="block text-xs font-medium text-text-muted mb-1">Auth header</label>
+              <label className="block text-xs font-medium text-muted-foreground mb-1">Auth header</label>
               <select
                 aria-label={`${TAB_LABEL[tab]} auth header`}
                 value={form.authMode}
@@ -782,7 +782,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                 <option value="x-api-key">x-api-key — Anthropic default</option>
                 <option value="bearer">Authorization: Bearer — gateways (MiniMax, LongCat, proxies)</option>
               </select>
-              <p className="text-[11px] text-text-muted/80 leading-snug mt-1">
+              <p className="text-[11px] text-muted-foreground/80 leading-snug mt-1">
                 Anthropic first-party uses <code className="font-mono text-[10.5px]">x-api-key</code>.
                 Switch to <code className="font-mono text-[10.5px]">Bearer</code> for
                 anthropic-compatible gateways that authenticate via{' '}
@@ -793,7 +793,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
           )}
 
           <div>
-            <label className="block text-xs font-medium text-text-muted mb-1">Model</label>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">Model</label>
             <ModelCombobox
               value={form.model}
               suggestions={modelSuggestions}
@@ -801,14 +801,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
               placeholder={tab === 'claude' ? 'claude-opus-4-8' : tab === 'opencode' || tab === 'pi' ? 'deepseek-chat' : 'gpt-5.5'}
             />
             {modelSuggestions.length > 0 && (
-              <p className="text-[11px] text-text-muted/70 mt-1">Suggestions from the matched provider — or type any model id.</p>
+              <p className="text-[11px] text-muted-foreground/70 mt-1">Suggestions from the matched provider — or type any model id.</p>
             )}
 
           </div>
 
           {(tab === 'opencode' || tab === 'pi') && (
             <div>
-              <label className="block text-xs font-medium text-text-muted mb-1">Context window</label>
+              <label className="block text-xs font-medium text-muted-foreground mb-1">Context window</label>
               <select
                 aria-label={`${TAB_LABEL[tab]} context window`}
                 value={form.contextWindow}
@@ -823,40 +823,40 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
           )}
 
           {tab === 'codex' && (
-            <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5 space-y-2">
-              <p className="text-[12px] text-text-muted leading-relaxed">
-                <strong className="text-text">Wire format is locked to <code className="font-mono text-[11.5px]">responses</code>.</strong>{' '}
+            <div className="rounded-md border border-border bg-secondary/50 px-3 py-2.5 space-y-2">
+              <p className="text-[12px] text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Wire format is locked to <code className="font-mono text-[11.5px]">responses</code>.</strong>{' '}
                 Codex 0.130+ hard-rejects <code className="font-mono text-[11.5px]">wire_api = "chat"</code> and only speaks the OpenAI Responses API.
               </p>
-              <p className="text-[12px] text-text-muted leading-relaxed">
-                <strong className="text-text">Chat-only providers</strong> (DeepSeek, Qwen, Moonshot, GLM, LM Studio, vLLM, llama.cpp, etc.) don't expose a Responses endpoint and won't work here directly.
+              <p className="text-[12px] text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Chat-only providers</strong> (DeepSeek, Qwen, Moonshot, GLM, LM Studio, vLLM, llama.cpp, etc.) don't expose a Responses endpoint and won't work here directly.
                 Run a translation proxy and point Base URL at it — e.g.{' '}
-                <strong className="text-text">OpenRouter</strong> (hosted, BYOK) or{' '}
-                <strong className="text-text">VibeAround</strong> (local) both speak Responses on the wire and forward to Chat Completions backends.
+                <strong className="text-foreground">OpenRouter</strong> (hosted, BYOK) or{' '}
+                <strong className="text-foreground">VibeAround</strong> (local) both speak Responses on the wire and forward to Chat Completions backends.
               </p>
             </div>
           )}
 
           {tab === 'opencode' && (
-            <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5">
-              <p className="text-[12px] text-text-muted leading-relaxed">
+            <div className="rounded-md border border-border bg-secondary/50 px-3 py-2.5">
+              <p className="text-[12px] text-muted-foreground leading-relaxed">
                 {form.wireShape === 'google-generative-ai' ? (
-                  <><strong className="text-text">Native Google Generative AI wire</strong> (via{' '}
+                  <><strong className="text-foreground">Native Google Generative AI wire</strong> (via{' '}
                   <code className="font-mono text-[11.5px]">@ai-sdk/google</code>) — supports current{' '}
                   <code className="font-mono text-[11.5px]">AQ.</code> authorization keys and legacy{' '}
                   <code className="font-mono text-[11.5px]">AIza</code> keys without a translation proxy.</>
                 ) : form.wireShape === 'anthropic' ? (
-                  <><strong className="text-text">Anthropic Messages wire</strong> (via{' '}
+                  <><strong className="text-foreground">Anthropic Messages wire</strong> (via{' '}
                   <code className="font-mono text-[11.5px]">@ai-sdk/anthropic</code>) — use the
                   provider's Anthropic-compatible endpoint and choose its required auth header.</>
                 ) : form.wireShape === 'openai-responses' ? (
-                  <><strong className="text-text">OpenAI Responses wire</strong> (via{' '}
+                  <><strong className="text-foreground">OpenAI Responses wire</strong> (via{' '}
                   <code className="font-mono text-[11.5px]">@ai-sdk/openai</code>) — use an endpoint
                   that implements Responses, not a Chat-only compatibility URL.</>
                 ) : (
-                  <><strong className="text-text">Speaks OpenAI Chat Completions</strong> (via{' '}
+                  <><strong className="text-foreground">Speaks OpenAI Chat Completions</strong> (via{' '}
                   <code className="font-mono text-[11.5px]">@ai-sdk/openai-compatible</code>), so it
-                  connects <strong className="text-text">directly</strong> to Chat-only providers —
+                  connects <strong className="text-foreground">directly</strong> to Chat-only providers —
                   DeepSeek, Qwen, Moonshot/Kimi, GLM, MiniMax — and local runtimes (Ollama, vLLM,
                   LM Studio). No translation proxy needed. Base URL is the provider's
                   OpenAI-compatible endpoint; Model is the bare model id.</>
@@ -866,21 +866,21 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
           )}
 
           {tab === 'pi' && (
-            <div className="rounded-md border border-border bg-bg-secondary/50 px-3 py-2.5">
-              <p className="text-[12px] text-text-muted leading-relaxed">
+            <div className="rounded-md border border-border bg-secondary/50 px-3 py-2.5">
+              <p className="text-[12px] text-muted-foreground leading-relaxed">
                 {form.wireShape === 'google-generative-ai' ? (
-                  <><strong className="text-text">Native Google Generative AI wire</strong> — sends current{' '}
+                  <><strong className="text-foreground">Native Google Generative AI wire</strong> — sends current{' '}
                   <code className="font-mono text-[11.5px]">AQ.</code> authorization keys and legacy{' '}
                   <code className="font-mono text-[11.5px]">AIza</code> keys as{' '}
                   <code className="font-mono text-[11.5px]">x-goog-api-key</code>.</>
                 ) : form.wireShape === 'anthropic' ? (
-                  <><strong className="text-text">Anthropic Messages wire</strong> — use the
+                  <><strong className="text-foreground">Anthropic Messages wire</strong> — use the
                   provider's Anthropic-compatible endpoint and choose its required auth header.</>
                 ) : form.wireShape === 'openai-responses' ? (
-                  <><strong className="text-text">OpenAI Responses wire</strong> — use an endpoint
+                  <><strong className="text-foreground">OpenAI Responses wire</strong> — use an endpoint
                   that implements Responses rather than Chat Completions only.</>
                 ) : (
-                  <><strong className="text-text">OpenAI Chat Completions wire</strong> — connects
+                  <><strong className="text-foreground">OpenAI Chat Completions wire</strong> — connects
                   directly to DeepSeek, Qwen, Kimi, GLM, MiniMax and local runtimes; Base URL is the
                   provider's OpenAI-compatible endpoint, Model is the bare model id.</>
                 )}{' '}OpenAlice registers the custom provider in Pi's normal user model registry,
@@ -895,17 +895,17 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
           )}
 
           {error && (
-            <div className="rounded-md border border-red/40 bg-red/10 text-red text-[12px] px-3 py-2">
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 text-destructive text-[12px] px-3 py-2">
               {error}
             </div>
           )}
           {savedFlash && (
-            <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
+            <div className="rounded-md border border-success/40 bg-success/10 text-success text-[12px] px-3 py-2">
               Saved. Pause + resume any open session to reload.
             </div>
           )}
           {offerSaveCred && (
-            <div className="rounded-md border border-accent/40 bg-accent/10 text-text text-[12px] px-3 py-2.5 flex items-center justify-between gap-3">
+            <div className="rounded-md border border-primary/40 bg-primary/10 text-foreground text-[12px] px-3 py-2.5 flex items-center justify-between gap-3">
               <span className="leading-snug">
                 Save this provider to Alice so other workspaces can reuse it?
               </span>
@@ -913,14 +913,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                 <button
                   onClick={() => setOfferSaveCred(false)}
                   disabled={savingCred}
-                  className="px-2.5 py-1 rounded-md border border-border text-text-muted hover:text-text text-[12px] disabled:opacity-40"
+                  className="px-2.5 py-1 rounded-md border border-border text-muted-foreground hover:text-foreground text-[12px] disabled:opacity-40"
                 >
                   Not now
                 </button>
                 <button
                   onClick={handleSaveCredential}
                   disabled={savingCred}
-                  className="px-2.5 py-1 rounded-md bg-accent text-bg text-[12px] font-medium disabled:opacity-40 hover:bg-accent/90"
+                  className="px-2.5 py-1 rounded-md bg-primary text-primary-foreground text-[12px] font-medium disabled:opacity-40 hover:bg-primary/90"
                 >
                   {savingCred ? 'Saving…' : 'Save to Alice'}
                 </button>
@@ -928,23 +928,23 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
             </div>
           )}
           {credFlash && (
-            <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
+            <div className="rounded-md border border-success/40 bg-success/10 text-success text-[12px] px-3 py-2">
               {credFlash}
             </div>
           )}
           {testing && (
-            <div className="rounded-md border border-border bg-bg-secondary text-text-muted text-[12px] px-3 py-2">
+            <div className="rounded-md border border-border bg-secondary text-muted-foreground text-[12px] px-3 py-2">
               Testing…
             </div>
           )}
           {!testing && result?.ok && resultMatchesCurrent && (
-            <div className="rounded-md border border-green/40 bg-green/10 text-green text-[12px] px-3 py-2">
+            <div className="rounded-md border border-success/40 bg-success/10 text-success text-[12px] px-3 py-2">
               {result.response?.trim() ? (
                 <>
                   <div className="font-medium mb-0.5">
                     Test passed — {tab === 'claude' ? 'Anthropic' : tab === 'opencode' || tab === 'pi' ? 'the provider' : 'OpenAI'} replied:
                   </div>
-                  <div className="text-text whitespace-pre-wrap break-words font-mono text-[11.5px]">
+                  <div className="text-foreground whitespace-pre-wrap break-words font-mono text-[11.5px]">
                     {result.response.trim()}
                   </div>
                 </>
@@ -954,7 +954,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
             </div>
           )}
           {!testing && result && !result.ok && resultMatchesCurrent && (
-            <div className="rounded-md border border-red/40 bg-red/10 text-red text-[12px] px-3 py-2">
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 text-destructive text-[12px] px-3 py-2">
               <div className="font-medium mb-0.5">Test failed:</div>
               <div className="whitespace-pre-wrap break-words font-mono text-[11.5px]">
                 {result.error}
@@ -962,14 +962,14 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
             </div>
           )}
           {!testing && result && !resultMatchesCurrent && (
-            <div className="rounded-md border border-yellow-400/30 bg-yellow-400/5 text-yellow-400/90 text-[12px] px-3 py-2">
+            <div className="rounded-md border border-warning/30 bg-warning/5 text-warning/90 text-[12px] px-3 py-2">
               Form changed since last test — re-test before saving.
             </div>
           )}
 
-          <p className="text-[11px] text-text-muted/80 leading-snug pt-1">
+          <p className="text-[11px] text-muted-foreground/80 leading-snug pt-1">
             Empty fields fall back to the CLI's global default. Changes apply to
-            <strong className="text-text"> new sessions</strong>; pause and resume
+            <strong className="text-foreground"> new sessions</strong>; pause and resume
             any open session to re-load.
             {tab === 'claude' && ' Claude reads `.claude/settings.local.json` from the workspace cwd.'}
             {tab === 'codex' && ' Codex reads `.codex/config.toml` + `.codex/env.json` (via CODEX_HOME).'}
@@ -979,12 +979,12 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
         </div>
 
         {/* Footer */}
-        <div className="flex flex-col gap-2 p-3 border-t border-border bg-bg-secondary/30 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-2 p-3 border-t border-border bg-secondary/30 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex gap-2">
             <button
               onClick={handleReset}
               disabled={saving}
-              className="px-3 py-2 rounded-md border border-border text-text-muted hover:text-text text-[12px] disabled:opacity-40"
+              className="px-3 py-2 rounded-md border border-border text-muted-foreground hover:text-foreground text-[12px] disabled:opacity-40"
             >
               Reset to global default
             </button>
@@ -993,7 +993,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
             <button
               onClick={onClose}
               disabled={saving}
-              className="px-3 py-2 rounded-md text-text-muted hover:text-text text-[13px]"
+              className="px-3 py-2 rounded-md text-muted-foreground hover:text-foreground text-[13px]"
             >
               Cancel
             </button>
@@ -1006,7 +1006,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
                 onClick={handleTest}
                 disabled={!canTest || testing || saving}
                 title={!canTest ? 'Fill base URL, API key, and model first' : undefined}
-                className="px-4 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
+                className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-primary/90 transition-colors"
               >
                 {testing ? 'Testing…' : 'Test'}
               </button>
@@ -1014,7 +1014,7 @@ export function WorkspaceAIConfigModal({ wsId, onClose, initialAgent = 'claude',
               <button
                 onClick={handleSave}
                 disabled={saving || !dirty}
-                className="px-4 py-2 rounded-md bg-accent text-bg text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent/90 transition-colors"
+                className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-[13px] font-medium disabled:opacity-40 disabled:cursor-not-allowed hover:bg-primary/90 transition-colors"
               >
                 {saving ? 'Saving…' : 'Save'}
               </button>

--- a/ui/src/components/workspace/WorkspaceAbsorbPanel.tsx
+++ b/ui/src/components/workspace/WorkspaceAbsorbPanel.tsx
@@ -118,20 +118,20 @@ export function WorkspaceAbsorbPanel({
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="flex flex-1 items-center justify-center overflow-y-auto p-6 text-center">
           <div className="max-w-md">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green/10 text-green">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-success/10 text-success">
               <Check size={24} />
             </div>
-            <h3 className="mt-4 text-[16px] font-semibold text-text">Workspace absorbed</h3>
-            <p className="mt-2 text-[12px] leading-relaxed text-text-muted">
+            <h3 className="mt-4 text-[16px] font-semibold text-foreground">Workspace absorbed</h3>
+            <p className="mt-2 text-[12px] leading-relaxed text-muted-foreground">
               The source desk is archived intact. {result.changedPaths.length} reviewed file{result.changedPaths.length === 1 ? '' : 's'} landed in this Workspace.
             </p>
-            <div className="mt-4 rounded-lg border border-border bg-bg-secondary/35 px-3 py-2 text-left">
-              <div className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Audit commit</div>
-              <code className="mt-1 block font-mono text-[12px] text-text">{result.commit}</code>
+            <div className="mt-4 rounded-lg border border-border bg-secondary/35 px-3 py-2 text-left">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Audit commit</div>
+              <code className="mt-1 block font-mono text-[12px] text-foreground">{result.commit}</code>
             </div>
           </div>
         </div>
-        <div className="flex justify-end border-t border-border bg-bg-secondary/30 p-3">
+        <div className="flex justify-end border-t border-border bg-secondary/30 p-3">
           <button type="button" onClick={onClose} className="btn-primary">Done</button>
         </div>
       </div>
@@ -141,20 +141,20 @@ export function WorkspaceAbsorbPanel({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex-1 space-y-4 overflow-y-auto p-4 sm:p-5">
-        <section className="overflow-hidden rounded-xl border border-border bg-bg-secondary/25">
+        <section className="overflow-hidden rounded-xl border border-border bg-secondary/25">
           <div className="p-4">
-            <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted/75">
+            <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/75">
               <FileInput size={14} />
               Absorb another Workspace
             </div>
-            <p className="mt-1 text-[12px] leading-relaxed text-text-muted">
+            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
               Bring reviewed working files into this desk, then archive the source intact. Sessions, credentials, schedules, and authorship never move.
             </p>
             <div className="mt-4 grid items-stretch gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-center">
               <DirectionCard label="Keep this Workspace" workspace={target} tone="target" />
-              <ArrowRight size={16} className="mx-auto rotate-90 text-text-muted sm:rotate-0" />
-              <label className="flex min-w-0 flex-col justify-center rounded-lg border border-dashed border-border bg-bg px-3 py-2.5">
-                <span className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Archive after absorb</span>
+              <ArrowRight size={16} className="mx-auto rotate-90 text-muted-foreground sm:rotate-0" />
+              <label className="flex min-w-0 flex-col justify-center rounded-lg border border-dashed border-border bg-background px-3 py-2.5">
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Archive after absorb</span>
                 <select
                   value={sourceId}
                   onChange={(event) => {
@@ -163,7 +163,7 @@ export function WorkspaceAbsorbPanel({
                     setResult(null)
                     setError(null)
                   }}
-                  className="mt-1 min-w-0 bg-transparent text-[13px] font-semibold text-text outline-none"
+                  className="mt-1 min-w-0 bg-transparent text-[13px] font-semibold text-foreground outline-none"
                   aria-label="Workspace to absorb"
                 >
                   <option value="">Choose a Workspace…</option>
@@ -179,13 +179,13 @@ export function WorkspaceAbsorbPanel({
         </section>
 
         {!sourceId && candidates.length === 0 && (
-          <div className="rounded-lg border border-border bg-bg-secondary/25 px-3 py-3 text-[12px] text-text-muted">
+          <div className="rounded-lg border border-border bg-secondary/25 px-3 py-3 text-[12px] text-muted-foreground">
             There is no other active Workspace to absorb.
           </div>
         )}
 
         {loading && !plan && (
-          <div className="flex min-h-40 items-center justify-center gap-2 text-[12px] text-text-muted">
+          <div className="flex min-h-40 items-center justify-center gap-2 text-[12px] text-muted-foreground">
             <LoaderCircle size={15} className="animate-spin" />
             Reviewing both Workspaces…
           </div>
@@ -193,23 +193,23 @@ export function WorkspaceAbsorbPanel({
 
         {plan && (
           <>
-            <section className="overflow-hidden rounded-xl border border-border bg-bg-secondary/25">
+            <section className="overflow-hidden rounded-xl border border-border bg-secondary/25">
               <div className="flex items-center justify-between gap-3 p-3.5">
                 <div>
-                  <div className="text-[12px] font-semibold text-text">What comes over</div>
-                  <p className="mt-0.5 text-[11px] text-text-muted">Git-tracked and non-ignored working files only.</p>
+                  <div className="text-[12px] font-semibold text-foreground">What comes over</div>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">Git-tracked and non-ignored working files only.</p>
                 </div>
                 <button
                   type="button"
                   onClick={() => void load()}
                   disabled={loading || applying}
-                  className="oa-pressable inline-flex min-h-8 items-center gap-1.5 rounded-lg border border-border bg-bg px-2.5 text-[11px] text-text-muted hover:text-text disabled:opacity-50"
+                  className="oa-pressable inline-flex min-h-8 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 text-[11px] text-muted-foreground hover:text-foreground disabled:opacity-50"
                 >
                   <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
                   Refresh
                 </button>
               </div>
-              <div className="grid grid-cols-4 border-t border-border bg-bg/45">
+              <div className="grid grid-cols-4 border-t border-border bg-background/45">
                 <Metric value={plan.summary.ready} label="New" tone="accent" />
                 <Metric value={plan.summary.duplicates} label="Same" tone="neutral" />
                 <Metric value={plan.summary.conflicts} label="Decide" tone="warning" />
@@ -220,7 +220,7 @@ export function WorkspaceAbsorbPanel({
             <RetirementImpact plan={plan} />
 
             {plan.summary.ready === 0 && plan.summary.conflicts === 0 && (
-              <div className="rounded-lg border border-border bg-bg-secondary/25 px-3 py-2.5 text-[11px] leading-relaxed text-text-muted">
+              <div className="rounded-lg border border-border bg-secondary/25 px-3 py-2.5 text-[11px] leading-relaxed text-muted-foreground">
                 No source working files need copying. Continuing will only archive the source desk and preserve its history.
               </div>
             )}
@@ -247,14 +247,14 @@ export function WorkspaceAbsorbPanel({
             )}
 
             {conflicts.length > 0 && (
-              <section className="overflow-hidden rounded-xl border border-amber-500/35 bg-bg-secondary/20">
+              <section className="overflow-hidden rounded-xl border border-warning/35 bg-secondary/20">
                 <div className="border-b border-border px-4 py-3">
-                  <div className="flex items-center gap-2 text-[13px] font-semibold text-text">
-                    <AlertTriangle size={15} className="text-amber-600 dark:text-amber-400" />
+                  <div className="flex items-center gap-2 text-[13px] font-semibold text-foreground">
+                    <AlertTriangle size={15} className="text-warning" />
                     Paths that need a decision
-                    <span className="rounded-full bg-amber-500/12 px-2 py-0.5 text-[10px] text-amber-700 dark:text-amber-300">{conflicts.length}</span>
+                    <span className="rounded-full bg-warning/12 px-2 py-0.5 text-[10px] text-warning">{conflicts.length}</span>
                   </div>
-                  <p className="mt-1 text-[11px] leading-relaxed text-text-muted">
+                  <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
                     Keep both is selected by default and places the source copy below <code className="font-mono">{plan.importRoot}</code>.
                   </p>
                 </div>
@@ -274,14 +274,14 @@ export function WorkspaceAbsorbPanel({
         )}
 
         {error && (
-          <div className="rounded-lg border border-red/35 bg-red/8 px-3 py-2.5 text-[12px] text-red" role="alert">
+          <div className="rounded-lg border border-destructive/35 bg-destructive/8 px-3 py-2.5 text-[12px] text-destructive" role="alert">
             {error}
           </div>
         )}
       </div>
 
-      <div className="flex flex-col gap-2 border-t border-border bg-bg-secondary/30 p-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="min-h-5 text-[11px] text-text-muted">
+      <div className="flex flex-col gap-2 border-t border-border bg-secondary/30 p-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-h-5 text-[11px] text-muted-foreground">
           {plan && !plan.blocked && unresolved === 0 && (
             <>The source will leave the active Workspace list but remain restorable.</>
           )}
@@ -293,7 +293,7 @@ export function WorkspaceAbsorbPanel({
             type="button"
             onClick={() => void apply()}
             disabled={!canApply}
-            className="oa-pressable inline-flex min-h-9 items-center gap-2 whitespace-nowrap rounded-lg bg-accent px-4 text-[12px] font-semibold text-white hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-40"
+            className="oa-pressable inline-flex min-h-9 items-center gap-2 whitespace-nowrap rounded-lg bg-primary px-4 text-[12px] font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-40"
           >
             {applying ? <LoaderCircle size={14} className="animate-spin" /> : <Archive size={14} />}
             {applying ? 'Absorbing…' : plan ? 'Absorb and archive source' : 'Choose a Workspace'}
@@ -310,10 +310,10 @@ function DirectionCard({ label, workspace, tone }: {
   tone: 'target'
 }): ReactElement {
   return (
-    <div className={`min-w-0 rounded-lg border px-3 py-2.5 ${tone === 'target' ? 'border-accent/35 bg-accent/6' : 'border-border bg-bg'}`}>
-      <div className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">{label}</div>
-      <div className="mt-1 truncate text-[13px] font-semibold text-text">{workspace.displayName?.trim() || workspace.tag}</div>
-      <code className="mt-0.5 block truncate font-mono text-[10px] text-text-muted">{workspace.tag}</code>
+    <div className={`min-w-0 rounded-lg border px-3 py-2.5 ${tone === 'target' ? 'border-primary/35 bg-primary/6' : 'border-border bg-background'}`}>
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-1 truncate text-[13px] font-semibold text-foreground">{workspace.displayName?.trim() || workspace.tag}</div>
+      <code className="mt-0.5 block truncate font-mono text-[10px] text-muted-foreground">{workspace.tag}</code>
     </div>
   )
 }
@@ -323,11 +323,11 @@ function Metric({ value, label, tone }: {
   label: string
   tone: 'accent' | 'neutral' | 'warning'
 }): ReactElement {
-  const color = tone === 'accent' ? 'text-accent' : tone === 'warning' ? 'text-amber-700 dark:text-amber-300' : 'text-text'
+  const color = tone === 'accent' ? 'text-primary' : tone === 'warning' ? 'text-warning' : 'text-foreground'
   return (
     <div className="border-r border-border px-2 py-2.5 text-center last:border-r-0">
       <div className={`text-[16px] font-semibold tabular-nums ${color}`}>{value}</div>
-      <div className="mt-0.5 truncate text-[10px] text-text-muted">{label}</div>
+      <div className="mt-0.5 truncate text-[10px] text-muted-foreground">{label}</div>
     </div>
   )
 }
@@ -341,12 +341,12 @@ function RetirementImpact({ plan }: { plan: WorkspaceAbsorbPlan }): ReactElement
     `${inventory.scheduledIssues.length} schedule${inventory.scheduledIssues.length === 1 ? '' : 's'} stopped`,
   ]
   return (
-    <section className="rounded-xl border border-border bg-bg-secondary/20 px-4 py-3">
+    <section className="rounded-xl border border-border bg-secondary/20 px-4 py-3">
       <div className="flex items-start gap-3">
-        <Users size={16} className="mt-0.5 shrink-0 text-text-muted" />
+        <Users size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
         <div className="min-w-0">
-          <div className="text-[12px] font-semibold text-text">What retires with {plan.source.tag}</div>
-          <p className="mt-1 text-[11px] leading-relaxed text-text-muted">
+          <div className="text-[12px] font-semibold text-foreground">What retires with {plan.source.tag}</div>
+          <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
             {facts.join(' · ')}. They remain in the archived desk for audit and restore; they do not become target identities.
           </p>
         </div>
@@ -363,12 +363,12 @@ function ActivityBlockers({ plan }: { plan: WorkspaceAbsorbPlan }): ReactElement
     ...plan.activity.target.headless.map((item) => `${plan.target.tag}: ${item.taskId ?? 'synchronous run'} (${item.agent})`),
   ]
   return (
-    <div className="rounded-lg border border-amber-500/35 bg-amber-500/8 px-3 py-3 text-[12px] text-text">
-      <div className="flex items-center gap-2 font-semibold text-amber-700 dark:text-amber-300">
+    <div className="rounded-lg border border-warning/35 bg-warning/8 px-3 py-3 text-[12px] text-foreground">
+      <div className="flex items-center gap-2 font-semibold text-warning">
         <AlertTriangle size={15} />
         Finish the real work listed below before absorbing
       </div>
-      <ul className="mt-2 space-y-1.5 pl-5 text-text-muted">
+      <ul className="mt-2 space-y-1.5 pl-5 text-muted-foreground">
         {activities.map((item) => <li key={item}>{item}</li>)}
         {plan.blockers.includes('target_staged_changes') && <li>The target has staged Git changes. Commit or unstage them first.</li>}
       </ul>
@@ -385,24 +385,24 @@ function FileGroup({ title, description, files, icon, defaultOpen = false }: {
 }): ReactElement {
   const [open, setOpen] = useState(defaultOpen)
   return (
-    <section className="rounded-xl border border-border bg-bg-secondary/20">
+    <section className="rounded-xl border border-border bg-secondary/20">
       <button type="button" onClick={() => setOpen((value) => !value)} className="oa-pressable flex w-full items-start gap-3 rounded-xl px-4 py-3 text-left" aria-expanded={open}>
-        {open ? <ChevronDown size={15} className="mt-0.5 text-text-muted" /> : <ChevronRight size={15} className="mt-0.5 text-text-muted" />}
+        {open ? <ChevronDown size={15} className="mt-0.5 text-muted-foreground" /> : <ChevronRight size={15} className="mt-0.5 text-muted-foreground" />}
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 text-[13px] font-semibold text-text">
+          <div className="flex items-center gap-2 text-[13px] font-semibold text-foreground">
             {title}
-            <span className="rounded-full bg-bg-tertiary px-2 py-0.5 text-[10px] text-text-muted">{files.length}</span>
+            <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">{files.length}</span>
           </div>
-          <p className="mt-0.5 text-[11px] text-text-muted">{description}</p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">{description}</p>
         </div>
       </button>
       {open && (
         <div className="oa-disclosure-enter border-t border-border px-4 py-2">
           {files.map((file) => (
             <div key={file.path} className="flex items-center gap-2 border-b border-border/60 py-2 last:border-b-0">
-              {icon === 'ready' ? <Check size={13} className="text-accent" /> : <ShieldCheck size={13} className="text-text-muted" />}
-              <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-text" title={file.path}>{file.path}</code>
-              <span className="text-[10px] text-text-muted">{formatBytes(file.sourceSize)}</span>
+              {icon === 'ready' ? <Check size={13} className="text-primary" /> : <ShieldCheck size={13} className="text-muted-foreground" />}
+              <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-foreground" title={file.path}>{file.path}</code>
+              <span className="text-[10px] text-muted-foreground">{formatBytes(file.sourceSize)}</span>
             </div>
           ))}
         </div>
@@ -421,16 +421,16 @@ function ConflictFile({ file, value, onChange }: {
     <div className="px-4 py-3">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
-          <code className="block truncate font-mono text-[11px] font-semibold text-text" title={file.path}>{file.path}</code>
-          <p className="mt-1 text-[10px] text-text-muted">Source {formatBytes(file.sourceSize)} · Target {file.targetSize === null ? 'non-file path' : formatBytes(file.targetSize)}</p>
+          <code className="block truncate font-mono text-[11px] font-semibold text-foreground" title={file.path}>{file.path}</code>
+          <p className="mt-1 text-[10px] text-muted-foreground">Source {formatBytes(file.sourceSize)} · Target {file.targetSize === null ? 'non-file path' : formatBytes(file.targetSize)}</p>
         </div>
-        <div className="flex shrink-0 flex-wrap rounded-lg border border-border bg-bg p-0.5" role="radiogroup" aria-label={file.path}>
+        <div className="flex shrink-0 flex-wrap rounded-lg border border-border bg-background p-0.5" role="radiogroup" aria-label={file.path}>
           <Choice active={value === 'target'} onClick={() => onChange('target')}>Keep target</Choice>
           <Choice active={value === 'source'} disabled={!file.canUseSource} onClick={() => onChange('source')}>Use source</Choice>
           <Choice active={value === 'both'} onClick={() => onChange('both')}>Keep both</Choice>
         </div>
       </div>
-      <button type="button" onClick={() => setPreviewOpen((open) => !open)} className="oa-pressable mt-2 inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-[11px] text-text-muted hover:text-text" aria-expanded={previewOpen}>
+      <button type="button" onClick={() => setPreviewOpen((open) => !open)} className="oa-pressable mt-2 inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-[11px] text-muted-foreground hover:text-foreground" aria-expanded={previewOpen}>
         {previewOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         Compare
       </button>
@@ -451,7 +451,7 @@ function Choice({ active, disabled = false, onClick, children }: {
   children: React.ReactNode
 }): ReactElement {
   return (
-    <button type="button" role="radio" aria-checked={active} disabled={disabled} onClick={onClick} className={`oa-pressable rounded-md px-2.5 py-1.5 text-[10px] font-medium disabled:cursor-not-allowed disabled:opacity-35 ${active ? 'bg-accent text-white shadow-sm' : 'text-text-muted hover:text-text'}`}>
+    <button type="button" role="radio" aria-checked={active} disabled={disabled} onClick={onClick} className={`oa-pressable rounded-md px-2.5 py-1.5 text-[10px] font-medium disabled:cursor-not-allowed disabled:opacity-35 ${active ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}>
       {children}
     </button>
   )
@@ -459,12 +459,12 @@ function Choice({ active, disabled = false, onClick, children }: {
 
 function Preview({ title, value, truncated }: { title: string; value: string | null; truncated: boolean }): ReactElement {
   return (
-    <div className="min-w-0 overflow-hidden rounded-lg border border-border bg-bg">
-      <div className="flex items-center justify-between border-b border-border px-2.5 py-1.5 text-[10px] font-semibold text-text-muted">
+    <div className="min-w-0 overflow-hidden rounded-lg border border-border bg-background">
+      <div className="flex items-center justify-between border-b border-border px-2.5 py-1.5 text-[10px] font-semibold text-muted-foreground">
         <span>{title}</span>
         {truncated && <span>Preview truncated</span>}
       </div>
-      <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words px-2.5 py-2 font-mono text-[10px] leading-relaxed text-text">
+      <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words px-2.5 py-2 font-mono text-[10px] leading-relaxed text-foreground">
         {value ?? 'Binary file or non-file path'}
       </pre>
     </div>

--- a/ui/src/components/workspace/WorkspaceFilesToggle.tsx
+++ b/ui/src/components/workspace/WorkspaceFilesToggle.tsx
@@ -25,8 +25,8 @@ export function WorkspaceFilesToggle(): ReactElement {
       title={files ? t('workspace.hideFilesTitle') : t('workspace.showFilesTitle')}
       className={`workspace-files-toggle flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] transition-colors ${
         files
-          ? 'text-text bg-bg-tertiary'
-          : 'text-text-muted hover:text-text hover:bg-bg-tertiary'
+          ? 'text-foreground bg-muted'
+          : 'text-muted-foreground hover:text-foreground hover:bg-muted'
       }`}
     >
       <PanelRight size={13} strokeWidth={1.8} aria-hidden />

--- a/ui/src/components/workspace/WorkspaceOffboardingDialog.tsx
+++ b/ui/src/components/workspace/WorkspaceOffboardingDialog.tsx
@@ -65,26 +65,26 @@ export function WorkspaceOffboardingDialog({
   return (
     <Dialog onClose={busy ? () => {} : onClose} width="w-[560px]">
       <div className="border-b border-border px-5 py-4">
-        <h2 className="text-[15px] font-semibold text-text">{t('workspace.offboardTitle')}</h2>
-        <p className="mt-1 text-[12px] text-text-muted">
+        <h2 className="text-[15px] font-semibold text-foreground">{t('workspace.offboardTitle')}</h2>
+        <p className="mt-1 text-[12px] text-muted-foreground">
           {t('workspace.offboardDescription', { workspace: workspaceDisplayTitle(workspace) })}
         </p>
       </div>
 
       <div className="max-h-[65vh] space-y-4 overflow-y-auto px-5 py-4">
-        {!assessment && !error && <p className="text-[13px] text-text-muted">{t('workspace.offboardLoading')}</p>}
+        {!assessment && !error && <p className="text-[13px] text-muted-foreground">{t('workspace.offboardLoading')}</p>}
 
         {assessment && (
           <>
             {assessment.blockers.length > 0 && (
-              <div className="rounded-lg border border-red/30 bg-red/5 px-3 py-2.5 text-[12px] text-red">
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-[12px] text-destructive">
                 <div className="font-semibold">{t('workspace.offboardBlocked')}</div>
                 {assessment.blockers.map((blocker) => <div key={blocker} className="mt-1">{blocker}</div>)}
               </div>
             )}
 
             <div>
-              <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted/70">
+              <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/70">
                 {t('workspace.offboardHandoffSnapshot')}
               </div>
               <div className="grid grid-cols-2 gap-2 text-[12px] sm:grid-cols-3">
@@ -100,29 +100,29 @@ export function WorkspaceOffboardingDialog({
         )}
 
         <label className="block">
-          <span className="mb-1.5 block text-[12px] font-medium text-text">{t('workspace.offboardReason')}</span>
+          <span className="mb-1.5 block text-[12px] font-medium text-foreground">{t('workspace.offboardReason')}</span>
           <input
             value={reason}
             onChange={(event) => setReason(event.target.value)}
             disabled={busy}
-            className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-[13px] text-text outline-none transition-colors placeholder:text-text-muted/50 focus:border-accent"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-primary"
             placeholder={t('workspace.offboardReasonPlaceholder')}
           />
         </label>
 
         <label className="block">
-          <span className="mb-1.5 block text-[12px] font-medium text-text">{t('workspace.offboardNotes')}</span>
+          <span className="mb-1.5 block text-[12px] font-medium text-foreground">{t('workspace.offboardNotes')}</span>
           <textarea
             value={notes}
             onChange={(event) => setNotes(event.target.value)}
             disabled={busy}
             rows={4}
-            className="w-full resize-y rounded-lg border border-border bg-bg px-3 py-2 text-[13px] text-text outline-none transition-colors placeholder:text-text-muted/50 focus:border-accent"
+            className="w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-primary"
             placeholder={t('workspace.offboardNotesPlaceholder')}
           />
         </label>
 
-        {error && <p className="text-[12px] text-red">{error}</p>}
+        {error && <p className="text-[12px] text-destructive">{error}</p>}
       </div>
 
       <div className="flex justify-end gap-2 border-t border-border px-5 py-3">
@@ -144,9 +144,9 @@ export function WorkspaceOffboardingDialog({
 
 function Snapshot({ label, value }: { label: string; value: number }): ReactElement {
   return (
-    <div className="rounded-lg border border-border/70 bg-bg-secondary/45 px-3 py-2">
-      <div className="text-[16px] font-semibold text-text">{value}</div>
-      <div className="mt-0.5 truncate text-[10px] text-text-muted">{label}</div>
+    <div className="rounded-lg border border-border/70 bg-secondary/45 px-3 py-2">
+      <div className="text-[16px] font-semibold text-foreground">{value}</div>
+      <div className="mt-0.5 truncate text-[10px] text-muted-foreground">{label}</div>
     </div>
   )
 }

--- a/ui/src/components/workspace/WorkspaceTemplateUpgradePanel.tsx
+++ b/ui/src/components/workspace/WorkspaceTemplateUpgradePanel.tsx
@@ -98,7 +98,7 @@ export function WorkspaceTemplateUpgradePanel({
 
   if (loading && !plan) {
     return (
-      <div className="flex min-h-[360px] items-center justify-center gap-2 text-[13px] text-text-muted">
+      <div className="flex min-h-[360px] items-center justify-center gap-2 text-[13px] text-muted-foreground">
         <LoaderCircle size={16} className="animate-spin" />
         {t('workspace.upgradeLoading')}
       </div>
@@ -108,9 +108,9 @@ export function WorkspaceTemplateUpgradePanel({
   if (unsupported) {
     return (
       <div className="flex min-h-[360px] flex-col items-center justify-center px-6 text-center">
-        <ShieldCheck size={28} className="mb-3 text-text-muted/60" />
-        <h3 className="text-[14px] font-semibold text-text">{t('workspace.upgradeUnavailableTitle')}</h3>
-        <p className="mt-1 max-w-md text-[12px] leading-relaxed text-text-muted">{error}</p>
+        <ShieldCheck size={28} className="mb-3 text-muted-foreground/60" />
+        <h3 className="text-[14px] font-semibold text-foreground">{t('workspace.upgradeUnavailableTitle')}</h3>
+        <p className="mt-1 max-w-md text-[12px] leading-relaxed text-muted-foreground">{error}</p>
       </div>
     )
   }
@@ -120,19 +120,19 @@ export function WorkspaceTemplateUpgradePanel({
       <div className="flex-1 space-y-4 overflow-y-auto p-4 sm:p-5">
         {plan && (
           <>
-            <section className="oa-status-surface overflow-hidden rounded-xl border border-border bg-bg-secondary/35">
+            <section className="oa-status-surface overflow-hidden rounded-xl border border-border bg-secondary/35">
               <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="min-w-0">
-                  <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted/75">
+                  <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/75">
                     <FileDiff size={14} />
                     {t('workspace.upgradeManagedAssets')}
                   </div>
-                  <div className="mt-2 flex flex-wrap items-center gap-2 text-[18px] font-semibold text-text">
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-[18px] font-semibold text-foreground">
                     <span>v{plan.fromVersion}</span>
-                    <ArrowRight size={17} className="text-text-muted" />
-                    <span className={current ? '' : 'text-accent'}>v{plan.toVersion}</span>
+                    <ArrowRight size={17} className="text-muted-foreground" />
+                    <span className={current ? '' : 'text-primary'}>v{plan.toVersion}</span>
                   </div>
-                  <p className="mt-1 max-w-xl text-[12px] leading-relaxed text-text-muted">
+                  <p className="mt-1 max-w-xl text-[12px] leading-relaxed text-muted-foreground">
                     {current
                       ? t('workspace.upgradeCurrentDescription')
                       : t('workspace.upgradeDescription')}
@@ -142,14 +142,14 @@ export function WorkspaceTemplateUpgradePanel({
                   type="button"
                   onClick={() => void load()}
                   disabled={loading || applying}
-                  className="oa-pressable inline-flex min-h-9 shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-bg px-3 text-[12px] text-text-muted hover:border-accent/40 hover:text-text disabled:opacity-50"
+                  className="oa-pressable inline-flex min-h-9 shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[12px] text-muted-foreground hover:border-primary/40 hover:text-foreground disabled:opacity-50"
                 >
                   <RefreshCw size={13} className={loading ? 'animate-spin' : ''} />
                   {t('workspace.upgradeRefresh')}
                 </button>
               </div>
               {!current && (
-                <div className="grid grid-cols-3 border-t border-border bg-bg/45">
+                <div className="grid grid-cols-3 border-t border-border bg-background/45">
                   <Metric value={plan.summary.ready} label={t('workspace.upgradeReadyShort')} tone="accent" />
                   <Metric value={plan.summary.preserved} label={t('workspace.upgradePreservedShort')} tone="neutral" />
                   <Metric value={plan.summary.conflicts} label={t('workspace.upgradeConflictsShort')} tone="warning" />
@@ -158,18 +158,18 @@ export function WorkspaceTemplateUpgradePanel({
             </section>
 
             {plan.source === 'legacy-root-commit' && !current && (
-              <div className="rounded-lg border border-border/70 bg-bg-secondary/25 px-3 py-2.5 text-[11px] leading-relaxed text-text-muted">
+              <div className="rounded-lg border border-border/70 bg-secondary/25 px-3 py-2.5 text-[11px] leading-relaxed text-muted-foreground">
                 {t('workspace.upgradeLegacyBaseline')}
               </div>
             )}
 
             {plan.blockers.length > 0 && (
-              <div className="rounded-lg border border-amber-500/35 bg-amber-500/8 px-3 py-3 text-[12px] text-text">
-                <div className="flex items-center gap-2 font-semibold text-amber-700 dark:text-amber-300">
+              <div className="rounded-lg border border-warning/35 bg-warning/8 px-3 py-3 text-[12px] text-foreground">
+                <div className="flex items-center gap-2 font-semibold text-warning">
                   <AlertTriangle size={15} />
                   {t('workspace.upgradeBlockedTitle')}
                 </div>
-                <ul className="mt-2 space-y-1.5 pl-5 text-text-muted">
+                <ul className="mt-2 space-y-1.5 pl-5 text-muted-foreground">
                   {plan.blockers.includes('active_sessions') && plan.activity.sessions.length === 0 && plan.activity.headless.length === 0 && (
                     <li>{t('workspace.upgradeBlockedSessions')}</li>
                   )}
@@ -215,16 +215,16 @@ export function WorkspaceTemplateUpgradePanel({
             )}
 
             {!current && conflicts.length > 0 && (
-              <section className="rounded-xl border border-amber-500/35 bg-bg-secondary/20">
+              <section className="rounded-xl border border-warning/35 bg-secondary/20">
                 <div className="border-b border-border px-4 py-3">
-                  <div className="flex items-center gap-2 text-[13px] font-semibold text-text">
-                    <AlertTriangle size={15} className="text-amber-600 dark:text-amber-400" />
+                  <div className="flex items-center gap-2 text-[13px] font-semibold text-foreground">
+                    <AlertTriangle size={15} className="text-warning" />
                     {t('workspace.upgradeConflictTitle')}
-                    <span className="rounded-full bg-amber-500/12 px-2 py-0.5 text-[10px] text-amber-700 dark:text-amber-300">
+                    <span className="rounded-full bg-warning/12 px-2 py-0.5 text-[10px] text-warning">
                       {conflicts.length}
                     </span>
                   </div>
-                  <p className="mt-1 text-[11px] leading-relaxed text-text-muted">
+                  <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
                     {t('workspace.upgradeConflictDescription')}
                   </p>
                 </div>
@@ -245,12 +245,12 @@ export function WorkspaceTemplateUpgradePanel({
             )}
 
             {result && current && (
-              <div className="oa-disclosure-enter rounded-xl border border-green/35 bg-green/8 px-4 py-3">
-                <div className="flex items-center gap-2 text-[13px] font-semibold text-green">
+              <div className="oa-disclosure-enter rounded-xl border border-success/35 bg-success/8 px-4 py-3">
+                <div className="flex items-center gap-2 text-[13px] font-semibold text-success">
                   <Check size={16} />
                   {t('workspace.upgradeCompleteTitle')}
                 </div>
-                <p className="mt-1 text-[11px] text-text-muted">
+                <p className="mt-1 text-[11px] text-muted-foreground">
                   {t('workspace.upgradeCompleteDescription', {
                     count: result.changedPaths.length,
                     commit: result.commit.slice(0, 8),
@@ -262,14 +262,14 @@ export function WorkspaceTemplateUpgradePanel({
         )}
 
         {error && !unsupported && (
-          <div className="rounded-lg border border-red/35 bg-red/8 px-3 py-2.5 text-[12px] text-red" role="alert">
+          <div className="rounded-lg border border-destructive/35 bg-destructive/8 px-3 py-2.5 text-[12px] text-destructive" role="alert">
             {error}
           </div>
         )}
       </div>
 
-      <div className="flex flex-col gap-2 border-t border-border bg-bg-secondary/30 p-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="min-h-5 text-[11px] text-text-muted">
+      <div className="flex flex-col gap-2 border-t border-border bg-secondary/30 p-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-h-5 text-[11px] text-muted-foreground">
           {plan && !current && conflicts.length > 0 && (
             unresolved > 0
               ? t('workspace.upgradeUnresolved', { count: unresolved })
@@ -286,7 +286,7 @@ export function WorkspaceTemplateUpgradePanel({
               type="button"
               onClick={() => void apply()}
               disabled={!canApply}
-              className="oa-pressable inline-flex min-h-9 items-center gap-2 rounded-lg bg-accent px-4 text-[12px] font-semibold text-white hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-40"
+              className="oa-pressable inline-flex min-h-9 items-center gap-2 rounded-lg bg-primary px-4 text-[12px] font-semibold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-40"
             >
               {applying ? <LoaderCircle size={14} className="animate-spin" /> : <GitCommitHorizontal size={14} />}
               {applying ? t('workspace.upgradeApplying') : t('workspace.upgradeApply')}
@@ -303,14 +303,14 @@ function Metric({ value, label, tone }: {
   tone: 'accent' | 'neutral' | 'warning'
 }): ReactElement {
   const valueClass = tone === 'accent'
-    ? 'text-accent'
+    ? 'text-primary'
     : tone === 'warning'
-      ? 'text-amber-700 dark:text-amber-300'
-      : 'text-text'
+      ? 'text-warning'
+      : 'text-foreground'
   return (
     <div className="border-r border-border px-3 py-2.5 text-center last:border-r-0">
       <div className={`text-[16px] font-semibold tabular-nums ${valueClass}`}>{value}</div>
-      <div className="mt-0.5 truncate text-[10px] text-text-muted">{label}</div>
+      <div className="mt-0.5 truncate text-[10px] text-muted-foreground">{label}</div>
     </div>
   )
 }
@@ -324,22 +324,22 @@ function FileGroup({ title, description, files, defaultOpen = false, tone }: {
 }): ReactElement {
   const [open, setOpen] = useState(defaultOpen)
   return (
-    <section className="rounded-xl border border-border bg-bg-secondary/20">
+    <section className="rounded-xl border border-border bg-secondary/20">
       <button
         type="button"
         onClick={() => setOpen((value) => !value)}
         aria-expanded={open}
         className="oa-pressable flex w-full items-start gap-3 rounded-xl px-4 py-3 text-left"
       >
-        {open ? <ChevronDown size={15} className="mt-0.5 text-text-muted" /> : <ChevronRight size={15} className="mt-0.5 text-text-muted" />}
+        {open ? <ChevronDown size={15} className="mt-0.5 text-muted-foreground" /> : <ChevronRight size={15} className="mt-0.5 text-muted-foreground" />}
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 text-[13px] font-semibold text-text">
+          <div className="flex items-center gap-2 text-[13px] font-semibold text-foreground">
             {title}
-            <span className={`rounded-full px-2 py-0.5 text-[10px] ${tone === 'accent' ? 'bg-accent/10 text-accent' : 'bg-bg-tertiary text-text-muted'}`}>
+            <span className={`rounded-full px-2 py-0.5 text-[10px] ${tone === 'accent' ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'}`}>
               {files.length}
             </span>
           </div>
-          <p className="mt-0.5 text-[11px] leading-relaxed text-text-muted">{description}</p>
+          <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">{description}</p>
         </div>
       </button>
       {open && (
@@ -347,10 +347,10 @@ function FileGroup({ title, description, files, defaultOpen = false, tone }: {
           {files.map((file) => (
             <div key={file.path} className="flex items-center gap-2 border-b border-border/60 py-2 last:border-b-0">
               {file.status === 'ready'
-                ? <Check size={13} className="shrink-0 text-accent" />
-                : <ShieldCheck size={13} className="shrink-0 text-text-muted" />}
-              <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-text" title={file.path}>{file.path}</code>
-              <span className="shrink-0 text-[10px] capitalize text-text-muted">{file.operation}</span>
+                ? <Check size={13} className="shrink-0 text-primary" />
+                : <ShieldCheck size={13} className="shrink-0 text-muted-foreground" />}
+              <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-foreground" title={file.path}>{file.path}</code>
+              <span className="shrink-0 text-[10px] capitalize text-muted-foreground">{file.operation}</span>
             </div>
           ))}
         </div>
@@ -370,10 +370,10 @@ function ConflictFile({ file, value, onChange }: {
     <div className="px-4 py-3">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <code className="block truncate font-mono text-[11px] font-semibold text-text" title={file.path}>{file.path}</code>
-          <p className="mt-1 text-[11px] leading-relaxed text-text-muted">{file.note}</p>
+          <code className="block truncate font-mono text-[11px] font-semibold text-foreground" title={file.path}>{file.path}</code>
+          <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">{file.note}</p>
         </div>
-        <div className="flex shrink-0 rounded-lg border border-border bg-bg p-0.5" role="radiogroup" aria-label={file.path}>
+        <div className="flex shrink-0 rounded-lg border border-border bg-background p-0.5" role="radiogroup" aria-label={file.path}>
           <Choice active={value === 'workspace'} onClick={() => onChange('workspace')}>
             {t('workspace.upgradeKeepWorkspace')}
           </Choice>
@@ -389,7 +389,7 @@ function ConflictFile({ file, value, onChange }: {
       <button
         type="button"
         onClick={() => setPreviewOpen((open) => !open)}
-        className="oa-pressable mt-2 inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-[11px] text-text-muted hover:text-text"
+        className="oa-pressable mt-2 inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-[11px] text-muted-foreground hover:text-foreground"
         aria-expanded={previewOpen}
       >
         {previewOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
@@ -419,7 +419,7 @@ function Choice({ active, disabled = false, onClick, children }: {
       disabled={disabled}
       onClick={onClick}
       className={`oa-pressable rounded-md px-2.5 py-1.5 text-[10px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-35 ${
-        active ? 'bg-accent text-white shadow-sm' : 'text-text-muted hover:text-text'
+        active ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
       }`}
     >
       {children}
@@ -434,12 +434,12 @@ function Preview({ title, value, truncated }: {
 }): ReactElement {
   const { t } = useTranslation()
   return (
-    <div className="min-w-0 overflow-hidden rounded-lg border border-border bg-bg">
-      <div className="flex items-center justify-between border-b border-border px-2.5 py-1.5 text-[10px] font-semibold text-text-muted">
+    <div className="min-w-0 overflow-hidden rounded-lg border border-border bg-background">
+      <div className="flex items-center justify-between border-b border-border px-2.5 py-1.5 text-[10px] font-semibold text-muted-foreground">
         <span>{title}</span>
         {truncated && <span>{t('workspace.upgradePreviewTruncated')}</span>}
       </div>
-      <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words px-2.5 py-2 font-mono text-[10px] leading-relaxed text-text">
+      <pre className="max-h-52 overflow-auto whitespace-pre-wrap break-words px-2.5 py-2 font-mono text-[10px] leading-relaxed text-foreground">
         {value ?? t('workspace.upgradeFileMissing')}
       </pre>
     </div>

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -228,7 +228,7 @@ function SessionCard(props: {
   const isPaused = r.state === 'paused';
   return (
     <li className="workspace-empty-card">
-      <span className="inline-flex items-center justify-center shrink-0 min-w-[18px] h-4 px-1 rounded text-[10px] font-mono text-text-muted bg-bg-tertiary">
+      <span className="inline-flex items-center justify-center shrink-0 min-w-[18px] h-4 px-1 rounded text-[10px] font-mono text-muted-foreground bg-muted">
         {prefixOf(r.agent)}
       </span>
       <div className="workspace-empty-card-meta">

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -1,18 +1,8 @@
 .workspaces-root {
-  /* Alias the local palette to the global theme tokens so the whole
-     Workspaces surface (session view + sidebar) follows light / dark.
-     `color-scheme` is inherited from :root (per-theme), not pinned dark.
-     The terminal itself is themed separately (xterm ITheme in Terminal.tsx).
-     Remaining hardcoded semantic chips (agent badges, status pills) are
-     tracked in ANG-110. */
-  --bg: var(--color-bg);
-  --panel: var(--color-bg-secondary);
-  --sidebar: var(--color-bg-secondary);
-  --border: var(--color-border);
-  --fg-dim: var(--color-text-muted);
-  --fg: var(--color-text);
-  --accent: var(--color-accent);
-  --danger: var(--color-red);
+  /* Workspaces consumes the same semantic palette as the rest of the app.
+     The terminal canvas remains separately themed through xterm ITheme. */
+  color: var(--foreground);
+  background: var(--background);
 }
 
 .app {
@@ -37,7 +27,7 @@
   overflow: hidden;
   border: 1px dashed var(--border);
   border-radius: 8px;
-  background: var(--panel);
+  background: var(--secondary);
 }
 
 /* Faux-TUI backdrop ------------------------------------------------------- */
@@ -51,8 +41,8 @@
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 13px;
   line-height: 1.6;
-  color: var(--fg);
-  background: var(--panel);
+  color: var(--foreground);
+  background: var(--secondary);
   /* Blur softens individual characters into "text-shaped bands"; the
    * brightness drop pushes it visually to the back layer so the Resume
    * card pops. opacity helps tune presence without crushing color. */
@@ -74,14 +64,14 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #28c840;
+  background: var(--success);
 }
 .resume-tui-titlebar-title {
   flex: 1 1 auto;
   font-weight: 600;
 }
 .resume-tui-titlebar-pid {
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-size: 12px;
 }
 
@@ -90,29 +80,29 @@
   margin: 0 0 14px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: var(--color-overlay);
+  background: var(--accent);
 }
 .resume-tui-meta-strong {
   font-weight: 600;
 }
 .resume-tui-meta-dim {
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
 }
 
 .resume-tui-prompt {
   display: flex;
   gap: 10px;
-  background: var(--color-overlay);
+  background: var(--accent);
   padding: 8px 14px;
   margin: 6px 0;
   border-radius: 4px;
 }
 .resume-tui-chev {
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   flex-shrink: 0;
 }
 .resume-tui-prompt-text {
-  color: var(--fg);
+  color: var(--foreground);
 }
 
 .resume-tui-response {
@@ -122,7 +112,7 @@
   margin: 4px 0;
 }
 .resume-tui-bullet {
-  color: var(--fg);
+  color: var(--foreground);
   flex-shrink: 0;
 }
 .resume-tui-response-body {
@@ -130,7 +120,7 @@
 }
 
 .resume-tui-status {
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-style: italic;
   padding-left: 14px;
   margin: 2px 0 12px;
@@ -149,7 +139,7 @@
   display: inline-block;
   width: 8px;
   height: 14px;
-  background: var(--fg);
+  background: var(--foreground);
   opacity: 0.7;
 }
 
@@ -158,7 +148,7 @@
   justify-content: space-between;
   padding: 6px 14px 0;
   font-size: 12px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
 }
 
 /* Foreground Resume card ------------------------------------------------- */
@@ -172,9 +162,9 @@
   /* Subtle vignette pushes the eye to center, where the card lives. */
   background: radial-gradient(
     ellipse at center,
-    rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 0.35) 60%,
-    rgba(0, 0, 0, 0.55) 100%
+    transparent 0%,
+    color-mix(in srgb, var(--shadow-color) 35%, transparent) 60%,
+    color-mix(in srgb, var(--shadow-color) 55%, transparent) 100%
   );
 }
 
@@ -186,10 +176,10 @@
   padding: 24px 28px;
   min-width: 320px;
   max-width: 420px;
-  background: var(--bg);
+  background: var(--background);
   border: 1px solid var(--border);
   border-radius: 10px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 8px 32px color-mix(in srgb, var(--shadow-color) 40%, transparent);
 }
 
 .resume-cta-card-header {
@@ -214,12 +204,12 @@
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 16px;
   font-weight: 600;
-  color: var(--fg);
+  color: var(--foreground);
 }
 
 .resume-cta-state {
   font-size: 11px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -235,11 +225,11 @@
   font-size: 12px;
 }
 .resume-cta-meta dt {
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   margin: 0;
 }
 .resume-cta-meta dd {
-  color: var(--fg);
+  color: var(--foreground);
   margin: 0;
   font-variant-numeric: tabular-nums;
 }
@@ -253,8 +243,8 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  background: var(--accent);
-  color: var(--bg);
+  background: var(--primary);
+  color: var(--primary-foreground);
   border: 0;
   padding: 10px 20px;
   border-radius: 6px;
@@ -284,7 +274,7 @@
 
 .resume-cta-hint {
   margin: 0;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-size: 11px;
   font-style: italic;
   text-align: center;
@@ -302,12 +292,12 @@
 .empty-pane {
   margin: auto;
   text-align: center;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
 }
 .empty-pane h2 {
   font-weight: 500;
   margin-bottom: 4px;
-  color: var(--fg);
+  color: var(--foreground);
 }
 
 /* ── Workspace view (terminal + side panels) ──────────────────────────────── */
@@ -344,8 +334,8 @@
     inset: 0 0 0 auto;
     width: min(360px, 100%);
     z-index: 10;
-    background: var(--color-bg);
-    box-shadow: -18px 0 36px -28px rgba(0, 0, 0, 0.65);
+    background: var(--background);
+    box-shadow: -18px 0 36px -28px color-mix(in srgb, var(--shadow-color) 65%, transparent);
   }
 }
 
@@ -392,19 +382,19 @@
   gap: 14px;
   border: 1px dashed var(--border);
   border-radius: 8px;
-  background: var(--panel);
+  background: var(--secondary);
   padding: 24px;
 }
 
 .workspace-cta-text {
   margin: 0;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-size: 13px;
 }
 
 .workspace-cta-btn {
-  background: var(--accent);
-  color: var(--bg);
+  background: var(--primary);
+  color: var(--primary-foreground);
   border: 0;
   padding: 8px 18px;
   border-radius: 6px;
@@ -419,12 +409,12 @@
 
 .workspace-cta-hint {
   margin: 0;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-size: 11px;
 }
 .workspace-cta-hint kbd {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  background: var(--color-overlay-strong);
+  background: var(--accent-strong);
   border: 1px solid var(--border);
   border-radius: 3px;
   padding: 0 4px;
@@ -449,7 +439,7 @@
   margin: 0 0 6px;
   font-size: 14px;
   font-weight: 600;
-  color: var(--fg);
+  color: var(--foreground);
   letter-spacing: 0.2px;
 }
 .workspace-empty-list {
@@ -467,14 +457,14 @@
   align-items: center;
   gap: 12px;
   padding: 12px 14px;
-  background: var(--bg);
+  background: var(--background);
   border: 1px solid var(--border);
   border-radius: 8px;
   transition: border-color 0.12s, background 0.12s;
 }
 .workspace-empty-card:hover {
-  border-color: var(--accent);
-  background: var(--panel);
+  border-color: var(--primary);
+  background: var(--secondary);
 }
 .workspace-empty-card-meta {
   display: flex;
@@ -486,11 +476,11 @@
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 13px;
   font-weight: 600;
-  color: var(--fg);
+  color: var(--foreground);
 }
 .workspace-empty-card-state {
   font-size: 10px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -498,8 +488,8 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: var(--accent);
-  color: var(--bg);
+  background: var(--primary);
+  color: var(--primary-foreground);
   border: 0;
   padding: 6px 12px;
   border-radius: 5px;
@@ -519,7 +509,7 @@
   width: 100%;
   max-width: 520px;
   margin: 6px 0 2px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-size: 11px;
 }
 .workspace-empty-divider::before,
@@ -531,7 +521,7 @@
 }
 .workspace-empty-secondary-btn {
   background: transparent;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   border: 1px dashed var(--border);
   padding: 6px 14px;
   border-radius: 6px;
@@ -540,8 +530,8 @@
   transition: color 0.12s, border-color 0.12s;
 }
 .workspace-empty-secondary-btn:hover {
-  color: var(--fg);
-  border-color: var(--fg-dim);
+  color: var(--foreground);
+  border-color: var(--muted-foreground);
 }
 
 .workspace-side {
@@ -566,7 +556,7 @@
 .panel {
   display: flex;
   flex-direction: column;
-  background: var(--panel);
+  background: var(--secondary);
   border: 1px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
@@ -578,10 +568,10 @@
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  background: linear-gradient(180deg, var(--color-bg-tertiary), var(--color-bg-secondary));
+  background: linear-gradient(180deg, var(--muted), var(--secondary));
   border-bottom: 1px solid var(--border);
   font-size: 11px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   user-select: none;
   flex: 0 0 auto;
 }
@@ -602,14 +592,14 @@
   background: none;
   border: 0;
   border-radius: 3px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   cursor: pointer;
   flex: 0 0 auto;
   transition: background 0.12s, color 0.12s;
 }
 .panel-collapse:hover {
-  background: var(--color-overlay-strong);
-  color: var(--fg);
+  background: var(--accent-strong);
+  color: var(--foreground);
 }
 
 .panel-collapse-chev {
@@ -623,25 +613,25 @@
   text-transform: uppercase;
   letter-spacing: 0.6px;
   font-weight: 600;
-  color: var(--fg);
+  color: var(--foreground);
 }
 
 .panel-pill {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 11px;
-  background: rgba(121, 192, 255, 0.12);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--info) 12%, transparent);
+  color: var(--info);
   padding: 2px 8px;
   border-radius: 10px;
 }
 .panel-pill-dirty {
-  background: rgba(210, 153, 34, 0.16);
-  color: #d29922;
+  background: color-mix(in srgb, var(--warning) 16%, transparent);
+  color: var(--warning);
 }
 
 .panel-error {
   padding: 8px 12px;
-  color: var(--danger);
+  color: var(--destructive);
   font-size: 12px;
   border-bottom: 1px solid var(--border);
 }
@@ -649,7 +639,7 @@
 .panel-empty {
   padding: 12px;
   text-align: center;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-size: 12px;
 }
 
@@ -688,48 +678,48 @@
   border: 1px solid transparent;
 }
 .git-status-badge.is-untracked {
-  background: rgba(110, 118, 129, 0.18);
-  color: var(--fg-dim);
-  border-color: rgba(110, 118, 129, 0.25);
+  background: color-mix(in srgb, var(--muted-foreground) 18%, transparent);
+  color: var(--muted-foreground);
+  border-color: color-mix(in srgb, var(--muted-foreground) 25%, transparent);
 }
 .git-status-badge.is-modified {
-  background: rgba(210, 153, 34, 0.16);
-  color: #d29922;
-  border-color: rgba(210, 153, 34, 0.25);
+  background: color-mix(in srgb, var(--warning) 16%, transparent);
+  color: var(--warning);
+  border-color: color-mix(in srgb, var(--warning) 25%, transparent);
 }
 .git-status-badge.is-staged {
-  background: rgba(126, 231, 135, 0.16);
-  color: #7ee787;
-  border-color: rgba(126, 231, 135, 0.25);
+  background: color-mix(in srgb, var(--success) 16%, transparent);
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 25%, transparent);
 }
 .git-status-badge.is-deleted {
-  background: rgba(255, 123, 114, 0.16);
-  color: var(--danger);
-  border-color: rgba(255, 123, 114, 0.28);
+  background: color-mix(in srgb, var(--destructive) 16%, transparent);
+  color: var(--destructive);
+  border-color: color-mix(in srgb, var(--destructive) 28%, transparent);
 }
 .git-status-badge.is-renamed {
-  background: rgba(121, 192, 255, 0.16);
-  color: var(--accent);
-  border-color: rgba(121, 192, 255, 0.25);
+  background: color-mix(in srgb, var(--info) 16%, transparent);
+  color: var(--info);
+  border-color: color-mix(in srgb, var(--info) 25%, transparent);
 }
 .git-status-badge.is-conflict {
-  background: rgba(255, 123, 114, 0.22);
-  color: #ff7b72;
-  border-color: rgba(255, 123, 114, 0.4);
+  background: color-mix(in srgb, var(--destructive) 22%, transparent);
+  color: var(--destructive);
+  border-color: color-mix(in srgb, var(--destructive) 40%, transparent);
   font-weight: 600;
 }
 .git-status-badge.is-ignored {
-  background: rgba(110, 118, 129, 0.10);
-  color: var(--fg-dim);
+  background: color-mix(in srgb, var(--muted-foreground) 10%, transparent);
+  color: var(--muted-foreground);
   opacity: 0.7;
 }
 .git-status-badge.is-unknown {
-  background: rgba(110, 118, 129, 0.10);
-  color: var(--fg-dim);
+  background: color-mix(in srgb, var(--muted-foreground) 10%, transparent);
+  color: var(--muted-foreground);
 }
 
 .git-status-path {
-  color: var(--fg);
+  color: var(--foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -755,19 +745,19 @@
   align-items: baseline;
 }
 .git-log-row:hover {
-  background: var(--color-overlay);
+  background: var(--accent);
 }
 
 .git-log-hash {
-  color: var(--accent);
+  color: var(--primary);
 }
 .git-log-time {
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
 .git-log-subject {
-  color: var(--fg);
+  color: var(--foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -788,17 +778,17 @@
 .files-crumb {
   background: none;
   border: 0;
-  color: var(--accent);
+  color: var(--primary);
   padding: 2px 4px;
   cursor: pointer;
   font: inherit;
 }
 .files-crumb:disabled {
-  color: var(--fg);
+  color: var(--foreground);
   cursor: default;
 }
 .files-crumb-sep {
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
 }
 
 .files-list {
@@ -825,26 +815,26 @@
 }
 .files-row.files-dir:hover,
 .files-row.files-symlink:hover {
-  background: var(--color-overlay);
+  background: var(--accent);
 }
 
 .files-icon {
   text-align: center;
   font-size: 11px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
 }
 .files-name {
-  color: var(--fg);
+  color: var(--foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .files-row.files-dir .files-name,
 .files-row.files-symlink .files-name {
-  color: var(--accent);
+  color: var(--primary);
 }
 .files-meta {
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   font-variant-numeric: tabular-nums;
   font-size: 11px;
 }
@@ -862,8 +852,8 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
-  background: var(--panel);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  background: var(--secondary);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--shadow-color) 35%, transparent);
 }
 
 .terminal-header {
@@ -873,10 +863,10 @@
   overflow: hidden;
   gap: 10px;
   padding: 8px 12px;
-  background: linear-gradient(180deg, var(--color-bg-tertiary), var(--color-bg-secondary));
+  background: linear-gradient(180deg, var(--muted), var(--secondary));
   border-bottom: 1px solid var(--border);
   font-size: 12px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   user-select: none;
 }
 
@@ -885,7 +875,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--fg);
+  color: var(--foreground);
   font-weight: 600;
   letter-spacing: 0.2px;
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
@@ -905,15 +895,15 @@
   padding: 0 8px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: var(--color-bg-secondary);
-  color: var(--fg);
+  background: var(--secondary);
+  color: var(--foreground);
   font-size: 11px;
   line-height: 22px;
 }
 
 .terminal-header-action:hover {
-  border-color: var(--accent);
-  color: var(--accent);
+  border-color: var(--primary);
+  color: var(--primary);
 }
 
 .terminal-theme-switch {
@@ -925,7 +915,7 @@
   gap: 1px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: var(--color-bg-secondary);
+  background: var(--secondary);
 }
 
 .terminal-theme-option {
@@ -936,19 +926,19 @@
   justify-content: center;
   border: 0;
   border-radius: 4px;
-  color: var(--fg-dim);
+  color: var(--muted-foreground);
   background: transparent;
   cursor: pointer;
 }
 
 .terminal-theme-option:hover {
-  color: var(--fg);
-  background: var(--color-overlay);
+  color: var(--foreground);
+  background: var(--accent);
 }
 
 .terminal-theme-option.active {
-  color: var(--accent);
-  background: var(--color-overlay-strong);
+  color: var(--primary);
+  background: var(--accent-strong);
 }
 
 .status-dot {
@@ -964,7 +954,7 @@
   min-height: 0;
   padding: 8px 8px 4px;
   overflow: hidden;
-  background: var(--bg);
+  background: var(--background);
 }
 
 .terminal-host {
@@ -1001,8 +991,8 @@
 }
 
 .resume-cta-btn.is-webpi {
-  background: color-mix(in srgb, var(--color-accent) 13%, var(--color-bg-secondary));
-  color: var(--color-text);
+  background: color-mix(in srgb, var(--primary) 13%, var(--secondary));
+  color: var(--foreground);
 }
 
 /* WebPi is deliberately a surface inside the existing terminal slot. */
@@ -1013,10 +1003,10 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  color: var(--color-text);
+  color: var(--foreground);
   background:
-    radial-gradient(circle at 50% -20%, color-mix(in srgb, var(--color-accent) 8%, transparent), transparent 38%),
-    var(--color-bg);
+    radial-gradient(circle at 50% -20%, color-mix(in srgb, var(--primary) 8%, transparent), transparent 38%),
+    var(--background);
 }
 
 .webpi-header {
@@ -1026,16 +1016,16 @@
   justify-content: space-between;
   gap: 16px;
   padding: 10px 18px;
-  border-bottom: 1px solid var(--color-border);
-  background: color-mix(in srgb, var(--color-bg-secondary) 72%, transparent);
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--secondary) 72%, transparent);
 }
 
 .webpi-title { font-size: 13px; font-weight: 650; }
-.webpi-title span { margin-left: 7px; color: var(--color-text-muted); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; }
-.webpi-subtitle { margin-top: 2px; color: var(--color-text-muted); font-size: 10px; }
-.webpi-phase { display: inline-flex; align-items: center; gap: 5px; padding: 4px 8px; border: 1px solid var(--color-border); border-radius: 999px; color: var(--color-text-muted); font-size: 10px; text-transform: capitalize; }
-.webpi-phase.is-working, .webpi-phase.is-retrying, .webpi-phase.is-compacting { color: var(--color-accent); }
-.webpi-phase.is-failed { color: var(--color-danger, #d65c5c); }
+.webpi-title span { margin-left: 7px; color: var(--muted-foreground); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; }
+.webpi-subtitle { margin-top: 2px; color: var(--muted-foreground); font-size: 10px; }
+.webpi-phase { display: inline-flex; align-items: center; gap: 5px; padding: 4px 8px; border: 1px solid var(--border); border-radius: 999px; color: var(--muted-foreground); font-size: 10px; text-transform: capitalize; }
+.webpi-phase.is-working, .webpi-phase.is-retrying, .webpi-phase.is-compacting { color: var(--primary); }
+.webpi-phase.is-failed { color: var(--destructive); }
 
 .webpi-messages {
   flex: 1;
@@ -1045,29 +1035,29 @@
   scrollbar-gutter: stable;
 }
 
-.webpi-empty { padding: 12vh 16px; text-align: center; color: var(--color-text-muted); font-size: 13px; }
+.webpi-empty { padding: 12vh 16px; text-align: center; color: var(--muted-foreground); font-size: 13px; }
 .webpi-message { display: flex; align-items: flex-start; margin: 0 0 26px; }
 .webpi-message.is-user { justify-content: flex-end; margin-left: 12%; }
 .webpi-message-body { flex: 1; min-width: 0; font-size: 13px; line-height: 1.65; }
-.webpi-message.is-user .webpi-message-body { flex: 0 1 auto; max-width: min(88%, 760px); padding: 10px 13px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-bg-secondary); }
+.webpi-message.is-user .webpi-message-body { flex: 0 1 auto; max-width: min(88%, 760px); padding: 10px 13px; border: 1px solid var(--border); border-radius: 12px; background: var(--secondary); }
 .webpi-message.is-turn .webpi-message-body { display: grid; gap: 12px; }
-.webpi-progress-text { color: color-mix(in srgb, var(--color-text) 88%, var(--color-text-muted)); }
-.webpi-final-text { color: var(--color-text); }
+.webpi-progress-text { color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground)); }
+.webpi-final-text { color: var(--foreground); }
 .webpi-content-parts > * + * { margin-top: 9px; }
-.webpi-detail { padding: 6px 9px; border-left: 2px solid var(--color-border); color: var(--color-text-muted); font-size: 11px; }
+.webpi-detail { padding: 6px 9px; border-left: 2px solid var(--border); color: var(--muted-foreground); font-size: 11px; }
 .webpi-detail summary { cursor: pointer; user-select: none; font-weight: 600; }
 .webpi-detail pre, .webpi-unknown { margin-top: 6px; max-height: 220px; overflow: auto; white-space: pre-wrap; font: 10px/1.5 var(--font-mono, monospace); }
 
 .webpi-activity {
   overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--color-border) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   border-radius: 10px;
-  background: color-mix(in srgb, var(--color-bg-secondary) 54%, transparent);
+  background: color-mix(in srgb, var(--secondary) 54%, transparent);
   transition: border-color 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
 }
-.webpi-activity:hover { border-color: color-mix(in srgb, var(--color-accent) 24%, var(--color-border)); }
-.webpi-activity[open] { background: color-mix(in srgb, var(--color-bg-secondary) 72%, transparent); box-shadow: 0 8px 24px color-mix(in srgb, #000 5%, transparent); }
-.webpi-activity.is-error { border-color: color-mix(in srgb, #d65c5c 48%, var(--color-border)); }
+.webpi-activity:hover { border-color: color-mix(in srgb, var(--primary) 24%, var(--border)); }
+.webpi-activity[open] { background: color-mix(in srgb, var(--secondary) 72%, transparent); box-shadow: 0 8px 24px color-mix(in srgb, var(--shadow-color) 5%, transparent); }
+.webpi-activity.is-error { border-color: color-mix(in srgb, var(--destructive) 48%, var(--border)); }
 .webpi-activity > summary,
 .webpi-tool-step > summary,
 .webpi-reasoning > summary {
@@ -1084,58 +1074,58 @@
   align-items: center;
   gap: 8px;
   padding: 7px 10px;
-  color: var(--color-text-muted);
+  color: var(--muted-foreground);
   font-size: 11px;
 }
-.webpi-activity-status { width: 18px; height: 18px; flex: 0 0 18px; display: grid; place-items: center; border-radius: 6px; color: color-mix(in srgb, var(--color-text-muted) 82%, transparent); background: color-mix(in srgb, var(--color-border) 42%, transparent); }
-.webpi-activity.is-running .webpi-activity-status { color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
-.webpi-activity.is-error .webpi-activity-status { color: #d65c5c; background: color-mix(in srgb, #d65c5c 10%, transparent); }
-.webpi-activity-title { flex: 0 0 auto; color: color-mix(in srgb, var(--color-text) 88%, var(--color-text-muted)); font-weight: 650; }
+.webpi-activity-status { width: 18px; height: 18px; flex: 0 0 18px; display: grid; place-items: center; border-radius: 6px; color: color-mix(in srgb, var(--muted-foreground) 82%, transparent); background: color-mix(in srgb, var(--border) 42%, transparent); }
+.webpi-activity.is-running .webpi-activity-status { color: var(--primary); background: color-mix(in srgb, var(--primary) 10%, transparent); }
+.webpi-activity.is-error .webpi-activity-status { color: var(--destructive); background: color-mix(in srgb, var(--destructive) 10%, transparent); }
+.webpi-activity-title { flex: 0 0 auto; color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground)); font-weight: 650; }
 .webpi-activity-meta { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 10px/1.4 var(--font-mono, monospace); }
 .webpi-disclosure { flex: 0 0 auto; margin-left: auto; transition: transform 150ms ease; }
 .webpi-activity[open] > summary .webpi-disclosure,
 .webpi-tool-step[open] > summary .webpi-disclosure { transform: rotate(90deg); }
-.webpi-activity-body { border-top: 1px solid color-mix(in srgb, var(--color-border) 84%, transparent); padding: 3px 10px 7px; }
+.webpi-activity-body { border-top: 1px solid color-mix(in srgb, var(--border) 84%, transparent); padding: 3px 10px 7px; }
 .webpi-activity[open] > .webpi-activity-body,
 .webpi-tool-step[open] > .webpi-step-detail { animation: webpi-detail-reveal 150ms ease-out both; }
 
-.webpi-tool-step { border-bottom: 1px solid color-mix(in srgb, var(--color-border) 68%, transparent); }
+.webpi-tool-step { border-bottom: 1px solid color-mix(in srgb, var(--border) 68%, transparent); }
 .webpi-tool-step:last-of-type { border-bottom: 0; }
-.webpi-tool-step > summary { min-height: 38px; display: grid; grid-template-columns: 18px minmax(58px, auto) minmax(0, 1fr) auto 14px; align-items: center; gap: 8px; padding: 6px 1px; color: var(--color-text-muted); }
-.webpi-tool-step > summary:hover { color: var(--color-text); }
-.webpi-step-status { width: 18px; height: 18px; display: grid; place-items: center; color: color-mix(in srgb, var(--color-text-muted) 70%, transparent); }
-.webpi-tool-step.is-running .webpi-step-status { color: var(--color-accent); }
-.webpi-tool-step.is-failed .webpi-step-status { color: #d65c5c; }
-.webpi-tool-step > summary code { overflow: hidden; color: color-mix(in srgb, var(--color-text) 90%, var(--color-text-muted)); font: 600 10px/1.4 var(--font-mono, monospace); text-overflow: ellipsis; }
+.webpi-tool-step > summary { min-height: 38px; display: grid; grid-template-columns: 18px minmax(58px, auto) minmax(0, 1fr) auto 14px; align-items: center; gap: 8px; padding: 6px 1px; color: var(--muted-foreground); }
+.webpi-tool-step > summary:hover { color: var(--foreground); }
+.webpi-step-status { width: 18px; height: 18px; display: grid; place-items: center; color: color-mix(in srgb, var(--muted-foreground) 70%, transparent); }
+.webpi-tool-step.is-running .webpi-step-status { color: var(--primary); }
+.webpi-tool-step.is-failed .webpi-step-status { color: var(--destructive); }
+.webpi-tool-step > summary code { overflow: hidden; color: color-mix(in srgb, var(--foreground) 90%, var(--muted-foreground)); font: 600 10px/1.4 var(--font-mono, monospace); text-overflow: ellipsis; }
 .webpi-step-summary { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 10px; }
-.webpi-step-size { white-space: nowrap; color: color-mix(in srgb, var(--color-text-muted) 72%, transparent); font: 9px/1.4 var(--font-mono, monospace); }
+.webpi-step-size { white-space: nowrap; color: color-mix(in srgb, var(--muted-foreground) 72%, transparent); font: 9px/1.4 var(--font-mono, monospace); }
 .webpi-tool-step > summary .webpi-disclosure { margin-left: 0; }
-.webpi-step-detail { display: grid; gap: 9px; margin: 0 0 8px 26px; padding: 9px 10px; border: 1px solid color-mix(in srgb, var(--color-border) 76%, transparent); border-radius: 8px; background: color-mix(in srgb, var(--color-bg) 64%, transparent); }
+.webpi-step-detail { display: grid; gap: 9px; margin: 0 0 8px 26px; padding: 9px 10px; border: 1px solid color-mix(in srgb, var(--border) 76%, transparent); border-radius: 8px; background: color-mix(in srgb, var(--background) 64%, transparent); }
 .webpi-step-detail section { min-width: 0; }
-.webpi-step-detail h4 { margin: 0 0 5px; color: var(--color-text-muted); font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-.webpi-step-detail pre { max-height: 230px; margin: 0; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; color: color-mix(in srgb, var(--color-text) 88%, var(--color-text-muted)); font: 10px/1.5 var(--font-mono, monospace); }
+.webpi-step-detail h4 { margin: 0 0 5px; color: var(--muted-foreground); font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.webpi-step-detail pre { max-height: 230px; margin: 0; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground)); font: 10px/1.5 var(--font-mono, monospace); }
 .webpi-step-result { max-height: 320px; overflow: auto; font-size: 11px; }
 
-.webpi-reasoning { color: var(--color-text-muted); }
+.webpi-reasoning { color: var(--muted-foreground); }
 .webpi-reasoning > summary { width: fit-content; padding: 7px 1px; font-size: 10px; font-weight: 600; }
-.webpi-reasoning > summary:hover { color: var(--color-text); }
-.webpi-reasoning-notes { display: grid; gap: 8px; margin: 0 0 7px; padding: 8px 10px; border-left: 2px solid color-mix(in srgb, var(--color-accent) 24%, var(--color-border)); color: color-mix(in srgb, var(--color-text) 82%, var(--color-text-muted)); font-size: 10px; }
+.webpi-reasoning > summary:hover { color: var(--foreground); }
+.webpi-reasoning-notes { display: grid; gap: 8px; margin: 0 0 7px; padding: 8px 10px; border-left: 2px solid color-mix(in srgb, var(--primary) 24%, var(--border)); color: color-mix(in srgb, var(--foreground) 82%, var(--muted-foreground)); font-size: 10px; }
 .webpi-reasoning pre { max-height: 220px; margin: 0 0 7px; overflow: auto; white-space: pre-wrap; font: 10px/1.5 var(--font-mono, monospace); }
 
-.webpi-error { display: grid; gap: 7px; margin: 20px 0; padding: 13px; border: 1px solid color-mix(in srgb, #d65c5c 50%, var(--color-border)); border-radius: 10px; color: #d65c5c; font-size: 12px; }
-.webpi-error button { width: fit-content; color: var(--color-text); text-decoration: underline; }
-.webpi-compaction-status { display: flex; align-items: flex-start; gap: 9px; margin: 0 max(18px, calc((100% - 760px) / 2)) 10px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--color-accent) 34%, var(--color-border)); border-radius: 10px; color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 7%, var(--color-bg-secondary)); }
+.webpi-error { display: grid; gap: 7px; margin: 20px 0; padding: 13px; border: 1px solid color-mix(in srgb, var(--destructive) 50%, var(--border)); border-radius: 10px; color: var(--destructive); font-size: 12px; }
+.webpi-error button { width: fit-content; color: var(--foreground); text-decoration: underline; }
+.webpi-compaction-status { display: flex; align-items: flex-start; gap: 9px; margin: 0 max(18px, calc((100% - 760px) / 2)) 10px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--primary) 34%, var(--border)); border-radius: 10px; color: var(--primary); background: color-mix(in srgb, var(--primary) 7%, var(--secondary)); }
 .webpi-compaction-status > svg { flex: 0 0 auto; margin-top: 2px; }
 .webpi-compaction-status > div { display: grid; gap: 2px; min-width: 0; }
-.webpi-compaction-status strong { color: var(--color-text); font-size: 11px; font-weight: 650; }
-.webpi-compaction-status span { color: var(--color-text-muted); font-size: 10px; line-height: 1.45; }
-.webpi-composer-wrap { padding: 10px max(18px, calc((100% - 760px) / 2)) 14px; border-top: 1px solid var(--color-border); background: color-mix(in srgb, var(--color-bg) 88%, transparent); }
-.webpi-composer { display: flex; align-items: flex-end; gap: 8px; padding: 9px 10px 9px 13px; border: 1px solid var(--color-border); border-radius: 14px; background: var(--color-bg-secondary); box-shadow: 0 6px 24px color-mix(in srgb, #000 9%, transparent); }
-.webpi-composer:focus-within { border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border)); }
-.webpi-composer textarea { flex: 1; min-height: 25px; max-height: 150px; resize: none; border: 0; outline: 0; color: var(--color-text); background: transparent; font: inherit; font-size: 13px; line-height: 1.6; }
-.webpi-send { width: 30px; height: 30px; flex: 0 0 30px; display: grid; place-items: center; border-radius: 9px; color: white; background: var(--color-accent); }
+.webpi-compaction-status strong { color: var(--foreground); font-size: 11px; font-weight: 650; }
+.webpi-compaction-status span { color: var(--muted-foreground); font-size: 10px; line-height: 1.45; }
+.webpi-composer-wrap { padding: 10px max(18px, calc((100% - 760px) / 2)) 14px; border-top: 1px solid var(--border); background: color-mix(in srgb, var(--background) 88%, transparent); }
+.webpi-composer { display: flex; align-items: flex-end; gap: 8px; padding: 9px 10px 9px 13px; border: 1px solid var(--border); border-radius: 14px; background: var(--secondary); box-shadow: 0 6px 24px color-mix(in srgb, var(--shadow-color) 9%, transparent); }
+.webpi-composer:focus-within { border-color: color-mix(in srgb, var(--primary) 60%, var(--border)); }
+.webpi-composer textarea { flex: 1; min-height: 25px; max-height: 150px; resize: none; border: 0; outline: 0; color: var(--foreground); background: transparent; font: inherit; font-size: 13px; line-height: 1.6; }
+.webpi-send { width: 30px; height: 30px; flex: 0 0 30px; display: grid; place-items: center; border-radius: 9px; color: var(--primary-foreground); background: var(--primary); }
 .webpi-send:disabled { opacity: .35; }
-.webpi-composer-hint { padding: 5px 3px 0; text-align: right; color: var(--color-text-muted); font-size: 9px; }
+.webpi-composer-hint { padding: 5px 3px 0; text-align: right; color: var(--muted-foreground); font-size: 9px; }
 
 @keyframes webpi-detail-reveal {
   from { opacity: 0; transform: translateY(-3px); }

--- a/ui/src/demo/DemoBanner.tsx
+++ b/ui/src/demo/DemoBanner.tsx
@@ -2,22 +2,22 @@ import type { ReactElement } from 'react'
 
 export function DemoBanner(): ReactElement {
   return (
-    <div className="flex min-h-8 items-center gap-2 border-b border-amber-500/40 bg-amber-500/10 px-3 text-[12px] text-text sm:gap-3 sm:px-4">
-      <span className="inline-flex shrink-0 items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-amber-700 dark:text-amber-300">
-        <span className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+    <div className="flex min-h-8 items-center gap-2 border-b border-warning/40 bg-warning/10 px-3 text-[12px] text-foreground sm:gap-3 sm:px-4">
+      <span className="inline-flex shrink-0 items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-warning">
+        <span className="h-1.5 w-1.5 rounded-full bg-warning animate-pulse" />
         Demo
       </span>
-      <span className="min-w-0 flex-1 truncate font-medium text-text-muted sm:hidden">
+      <span className="min-w-0 flex-1 truncate font-medium text-muted-foreground sm:hidden">
         Snapshot data · Read-only
       </span>
-      <span className="hidden min-w-0 flex-1 truncate text-text-muted sm:block">
+      <span className="hidden min-w-0 flex-1 truncate text-muted-foreground sm:block">
         You&apos;re looking at a snapshot of OpenAlice with recorded data. Mutations don&apos;t persist; the agent terminal is replayed.
       </span>
       <a
         href="https://github.com/TraderAlice/OpenAlice"
         target="_blank"
         rel="noopener noreferrer"
-        className="shrink-0 font-medium text-amber-700 hover:underline dark:text-amber-300"
+        className="shrink-0 font-medium text-warning hover:underline"
       >
         Install →
       </a>

--- a/ui/src/demo/DemoTerminalReplay.tsx
+++ b/ui/src/demo/DemoTerminalReplay.tsx
@@ -119,17 +119,17 @@ function ReplayPane({ label, transcript }: { label: string; transcript: Transcri
   return (
     <div className="terminal-shell">
       <header className="terminal-header">
-        <span className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-amber-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+        <span className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-warning">
+          <span className="w-1.5 h-1.5 rounded-full bg-warning animate-pulse" />
           Replay
         </span>
-        <span className="text-[11px] text-text-muted truncate">{label}</span>
+        <span className="text-[11px] text-muted-foreground truncate">{label}</span>
         <span className="flex-1" />
         {done && (
           <button
             type="button"
             onClick={() => setReplayKey((k) => k + 1)}
-            className="text-[11px] text-amber-400 hover:underline"
+            className="text-[11px] text-warning hover:underline"
           >
             ↻ Replay again
           </button>

--- a/ui/src/demo/DemoTerminalStub.tsx
+++ b/ui/src/demo/DemoTerminalStub.tsx
@@ -6,21 +6,21 @@ interface DemoTerminalStubProps {
 
 export function DemoTerminalStub({ label }: DemoTerminalStubProps): ReactElement {
   return (
-    <div className="flex h-full w-full items-center justify-center bg-zinc-950 p-8 text-zinc-400">
+    <div className="flex h-full w-full items-center justify-center bg-background p-8 text-muted-foreground">
       <div className="max-w-md text-left space-y-3">
-        <div className="font-mono text-[11px] uppercase tracking-wider text-zinc-500">
+        <div className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground/70">
           {label}
         </div>
-        <div className="text-base font-semibold text-zinc-200">
+        <div className="text-base font-semibold text-foreground">
           Agent terminal
         </div>
-        <div className="text-sm leading-relaxed text-zinc-400">
+        <div className="text-sm leading-relaxed text-muted-foreground">
           In a real OpenAlice install, this pane is a live PTY running{' '}
-          <span className="text-zinc-300">Claude Code</span>,{' '}
-          <span className="text-zinc-300">Codex</span>, or{' '}
-          <span className="text-zinc-300">shell</span> — the AI agent drives it directly: reads files, runs commands, reports back.
+          <span className="text-foreground">Claude Code</span>,{' '}
+          <span className="text-foreground">Codex</span>, or{' '}
+          <span className="text-foreground">shell</span> — the AI agent drives it directly: reads files, runs commands, reports back.
         </div>
-        <div className="text-xs text-zinc-500">
+        <div className="text-xs text-muted-foreground/70">
           Demo mode shows the workspace structure without a live process.
         </div>
         <div className="pt-2">
@@ -28,7 +28,7 @@ export function DemoTerminalStub({ label }: DemoTerminalStubProps): ReactElement
             href="https://github.com/TraderAlice/OpenAlice"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-xs font-medium text-amber-400 hover:underline"
+            className="inline-flex items-center gap-1 text-xs font-medium text-warning hover:underline"
           >
             Install OpenAlice locally →
           </a>

--- a/ui/src/demo/handlers/trading.ts
+++ b/ui/src/demo/handlers/trading.ts
@@ -46,7 +46,7 @@ function utaId(params: { id?: string | readonly string[] }): string {
 const demoBrokerPresets = [
   {
     id: 'alpaca', label: 'Alpaca', description: 'US equities with paper-trading support.',
-    category: 'recommended', defaultName: 'Alpaca', badge: 'AP', badgeColor: 'text-emerald-400',
+    category: 'recommended', defaultName: 'Alpaca', badge: 'AP', badgeColor: 'text-success',
     engine: 'alpaca', guardCategory: 'securities', subtitleFields: [],
     schema: {
       type: 'object',
@@ -60,7 +60,7 @@ const demoBrokerPresets = [
   },
   {
     id: 'okx', label: 'OKX', description: 'OKX Unified Trading Account.',
-    category: 'crypto', defaultName: 'OKX', badge: 'OK', badgeColor: 'text-sky-400',
+    category: 'crypto', defaultName: 'OKX', badge: 'OK', badgeColor: 'text-info',
     engine: 'ccxt', guardCategory: 'crypto', subtitleFields: [],
     schema: {
       type: 'object',

--- a/ui/src/design/projects.ts
+++ b/ui/src/design/projects.ts
@@ -3,6 +3,7 @@ export type DesignVariantLayout =
   | 'mode-ladder'
   | 'goal-picker'
   | 'quiet-checklist'
+  | 'semantic-colors'
 
 export interface DesignVariant {
   id: string
@@ -29,6 +30,41 @@ export interface DesignProject {
 }
 
 export const designProjects: DesignProject[] = [
+  {
+    slug: 'semantic-colors',
+    title: 'Semantic color system',
+    eyebrow: 'Living color card',
+    status: 'Current implementation',
+    updatedAt: '2026-07-18',
+    context: {
+      why: 'OpenAlice used separate physical color names, Tailwind palette shades, chart literals, and Workspace aliases. This project renders the shared semantic contract that now drives the product UI without requiring a component library.',
+      goals: [
+        'Keep the core CSS vocabulary aligned with Orca and shadcn.',
+        'Make light and dark palette changes visible on one real product route.',
+        'Keep trading, status, AI, and chart extensions explicit and small.',
+        'Give reviewers a fast contrast and hierarchy smoke test.',
+      ],
+      constraints: [
+        'The route consumes the real CSS variables; it must not duplicate palette values.',
+        'Terminal ANSI colors remain separately projected until the later unified appearance work.',
+        'Product components must not select Tailwind palette shades directly.',
+      ],
+      openQuestions: [
+        'Which product extensions can collapse into the terminal-compatible subset later?',
+        'Should imported terminal themes optionally seed the neutral product surfaces?',
+      ],
+    },
+    variants: [
+      {
+        id: 'A',
+        name: 'Current semantic palette',
+        summary: 'The live core, product extensions, and representative component states.',
+        intent: 'Use this route while adjusting palette.css so both themes and common semantic pairings can be judged together.',
+        risk: 'A color card cannot replace route-level visual review for dense trading and Workspace surfaces.',
+        layout: 'semantic-colors',
+      },
+    ],
+  },
   {
     slug: 'first-run-onboarding',
     title: 'First-run onboarding',

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,39 +1,58 @@
 @import "tailwindcss";
+@import "./theme/palette.css";
 
-/* ============================================================
-   Theme tokens — two palettes, one identity. Alice-blue (her dress)
-   is the brand accent in BOTH modes. @theme below is Daybreak (light)
-   and the DEFAULT; the [data-theme="dark"] block + the prefers-color-
-   scheme block flip the same token names, so every `bg-bg`/`text-accent`/
-   `border-border` utility follows the active theme with zero component
-   changes. Living color card: ui/design/theme-study.html. The toggle lives in the
-   ActivityBar footer (light / dark / auto), persisted by the theme store
-   (ui/src/theme) and mirrored pre-paint by the inline script in index.html.
-   ============================================================ */
-@theme {
-  /* Daybreak — light (default). Warm paper · engraved navy · alice-blue. */
-  --color-bg: #fbfaf6;
-  --color-bg-secondary: #f1ede4;
-  --color-bg-tertiary: #e4dccb;
-  --color-border: #d8d2c4;
-  --color-text: #1c2a41;
-  --color-text-muted: #5e6573;
-  --color-accent: #2f62b0;
-  --color-accent-dim: rgba(47, 98, 176, 0.14);
-  --color-user-bubble: #2f62b0;
-  --color-assistant-bubble: #fffdf8;
-  --color-notification-bg: #fbf1d6;
-  --color-notification-border: #c99a2e;
-  --color-green: #2e8b6f;
-  --color-red: #be4138;
-  --color-purple: #6b5bc2;
-  --color-purple-dim: rgba(107, 91, 194, 0.14);
+/* Tailwind aliases for the semantic color card. The core names intentionally
+   mirror Orca/shadcn; this does not import or require the shadcn component
+   library. `inline` keeps utilities connected to the active runtime palette. */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
 
-  /* Elevation overlays — theme-aware "subtle wash on hover / active".
-     Light darkens with navy ink; dark lightens with white. Components use
-     `bg-overlay` / `bg-overlay-strong`; raw CSS uses `var(--color-overlay)`. */
-  --color-overlay: rgba(28, 42, 65, 0.045);
-  --color-overlay-strong: rgba(28, 42, 65, 0.075);
+  --color-accent-strong: var(--accent-strong);
+  --color-primary-muted: var(--primary-muted);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning-background: var(--warning-background);
+  --color-warning-border: var(--warning-border);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-ai-action: var(--ai-action);
+  --color-ai-action-foreground: var(--ai-action-foreground);
+  --color-backdrop: var(--backdrop);
+  --color-code-background: var(--code-background);
+  --color-report-canvas: var(--report-canvas);
 
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
     "Microsoft YaHei", "Hiragino Sans GB", "Noto Sans CJK SC", sans-serif;
@@ -43,68 +62,11 @@
 
 /* Base resolution (no attribute / explicit light). */
 :root {
-  color-scheme: light;
-  --app-bg-wash: radial-gradient(circle at 50% 24%, rgba(47, 98, 176, 0.045), transparent 38rem);
   --motion-fast: 120ms;
   --motion-standard: 180ms;
   --motion-slow: 260ms;
   --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
   --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
-}
-
-/* ---- Midnight — dark (neutral charcoal-black) ----
-   Reverted to the #353 neutral-black palette: a navy-tinted dark read as
-   "too blue" once the full shell (rail + sidebar + tabs) was on screen — a
-   large neutral surface is calmer. Alice-blue survives ONLY as small brand
-   highlights (accent + the user's own bubble), so the large-area blue tint
-   is gone while the brand stays consistent with Daybreak.
-   Forced via data-theme="dark", AND the resolution for data-theme="auto"
-   when the OS is in dark mode (media block below). KEEP THE TWO IN SYNC. */
-:root[data-theme="dark"] {
-  --color-bg: #0b0c0e;
-  --color-bg-secondary: #0e0f12;
-  --color-bg-tertiary: #1a1b21;
-  --color-border: #24262c;
-  --color-text: #dfe1e6;
-  --color-text-muted: #8f929b;
-  --color-accent: #3b82f6;
-  --color-accent-dim: rgba(59, 130, 246, 0.16);
-  --color-user-bubble: #2f62b0;
-  --color-assistant-bubble: #141519;
-  --color-notification-bg: #1d1610;
-  --color-notification-border: #8a5b2f;
-  --color-green: #23b99a;
-  --color-red: #e5484d;
-  --color-purple: #8f72ff;
-  --color-purple-dim: rgba(143, 114, 255, 0.16);
-  --color-overlay: rgba(255, 255, 255, 0.04);
-  --color-overlay-strong: rgba(255, 255, 255, 0.07);
-  color-scheme: dark;
-  --app-bg-wash: radial-gradient(circle at 50% 28%, rgba(255, 255, 255, 0.02), transparent 34rem);
-}
-@media (prefers-color-scheme: dark) {
-  :root[data-theme="auto"] {
-    --color-bg: #0b0c0e;
-    --color-bg-secondary: #0e0f12;
-    --color-bg-tertiary: #1a1b21;
-    --color-border: #24262c;
-    --color-text: #dfe1e6;
-    --color-text-muted: #8f929b;
-    --color-accent: #3b82f6;
-    --color-accent-dim: rgba(59, 130, 246, 0.16);
-    --color-user-bubble: #2f62b0;
-    --color-assistant-bubble: #141519;
-    --color-notification-bg: #1d1610;
-    --color-notification-border: #8a5b2f;
-    --color-green: #23b99a;
-    --color-red: #e5484d;
-    --color-purple: #8f72ff;
-    --color-purple-dim: rgba(143, 114, 255, 0.16);
-    --color-overlay: rgba(255, 255, 255, 0.04);
-    --color-overlay-strong: rgba(255, 255, 255, 0.07);
-    color-scheme: dark;
-    --app-bg-wash: radial-gradient(circle at 50% 28%, rgba(255, 255, 255, 0.02), transparent 34rem);
-  }
 }
 
 /* Japanese gets a JP-first sans stack so shared Han characters render in
@@ -134,15 +96,15 @@ body,
 }
 
 body {
-  background: var(--app-bg-wash), var(--color-bg);
-  color: var(--color-text);
+  background: var(--app-background-wash), var(--background);
+  color: var(--foreground);
   overflow: hidden;
   transition: background-color 0.4s ease, color 0.4s ease;
 }
 
 ::selection {
-  background: color-mix(in srgb, var(--color-accent) 28%, transparent);
-  color: var(--color-text);
+  background: color-mix(in srgb, var(--primary) 28%, transparent);
+  color: var(--foreground);
 }
 
 /* ==================== Interaction + motion foundation ====================
@@ -196,7 +158,7 @@ body {
 @media (hover: hover) and (pointer: fine) {
   .oa-pressable:hover:not(:disabled):not([aria-disabled="true"]) {
     transform: translateY(-1px);
-    box-shadow: 0 5px 14px color-mix(in srgb, var(--color-text) 9%, transparent);
+    box-shadow: 0 5px 14px color-mix(in srgb, var(--foreground) 9%, transparent);
   }
 
   .oa-pressable:active:not(:disabled):not([aria-disabled="true"]) {
@@ -346,7 +308,7 @@ body {
   position: absolute;
   inset: -3px;
   border-radius: 9999px;
-  background: var(--color-green);
+  background: var(--success);
   opacity: 0.3;
   animation: live-pulse 2.4s ease-in-out infinite;
   animation-delay: 0.3s;
@@ -461,10 +423,10 @@ html[lang="ja"] .oa-onboarding-title {
   width: 4.5rem;
   height: 4.5rem;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--color-green) 38%, var(--color-border));
+  border: 1px solid color-mix(in srgb, var(--success) 38%, var(--border));
   border-radius: 999px;
-  background: color-mix(in srgb, var(--color-green) 12%, var(--color-bg));
-  box-shadow: inset 0 0 0 0.5rem color-mix(in srgb, var(--color-green) 7%, transparent);
+  background: color-mix(in srgb, var(--success) 12%, var(--background));
+  box-shadow: inset 0 0 0 0.5rem color-mix(in srgb, var(--success) 7%, transparent);
   animation: onboarding-completion-pop 0.58s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
@@ -472,7 +434,7 @@ html[lang="ja"] .oa-onboarding-title {
   position: absolute;
   inset: -0.5rem;
   content: "";
-  border: 1px solid var(--color-green);
+  border: 1px solid var(--success);
   border-radius: inherit;
   animation: onboarding-completion-ring 0.72s 0.12s ease-out both;
 }
@@ -482,7 +444,7 @@ html[lang="ja"] .oa-onboarding-title {
   width: 1.25rem;
   height: 1px;
   border-radius: 999px;
-  background: var(--color-green);
+  background: var(--success);
   opacity: 0;
   transform-origin: center;
   animation: onboarding-completion-line 0.62s ease-out both;
@@ -541,11 +503,11 @@ html[lang="ja"] .oa-onboarding-title {
   100% { background-position: -200% 0; }
 }
 .skeleton {
-  background-color: var(--color-bg-tertiary);
+  background-color: var(--muted);
   background-image: linear-gradient(
     90deg,
     transparent 0%,
-    var(--color-overlay-strong) 50%,
+    var(--accent-strong) 50%,
     transparent 100%
   );
   background-size: 200% 100%;
@@ -600,39 +562,39 @@ html[lang="ja"] .oa-onboarding-title {
 
 .btn-primary {
   @apply px-4 py-2 text-[13px] font-medium rounded-lg
-    bg-bg-tertiary border border-border text-text
-    hover:border-accent/40 hover:bg-bg-tertiary/80 transition-all active:scale-[0.98]
+    bg-primary border border-primary text-primary-foreground
+    hover:bg-primary/90 transition-all active:scale-[0.98]
     disabled:opacity-40 disabled:cursor-default cursor-pointer
-    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
+    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background;
 }
 
 .btn-secondary {
-  @apply px-4 py-2 text-[13px] font-medium rounded-lg border border-border text-text-muted
-    hover:bg-bg-tertiary hover:text-text transition-all active:scale-[0.98]
+  @apply px-4 py-2 text-[13px] font-medium rounded-lg border border-border text-muted-foreground
+    hover:bg-muted hover:text-foreground transition-all active:scale-[0.98]
     disabled:opacity-40 disabled:cursor-default cursor-pointer
-    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
+    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background;
 }
 
 .btn-danger {
-  @apply px-4 py-2 text-[13px] font-medium rounded-lg border border-red/30 text-red
-    hover:bg-red/10 transition-all active:scale-[0.98]
+  @apply px-4 py-2 text-[13px] font-medium rounded-lg border border-destructive/30 text-destructive
+    hover:bg-destructive/10 transition-all active:scale-[0.98]
     disabled:opacity-40 disabled:cursor-default cursor-pointer
-    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg;
+    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background;
 }
 
 .btn-primary-sm {
   @apply px-3 py-1.5 text-xs font-medium rounded-md
-    bg-bg-tertiary border border-border text-text
-    hover:border-accent/40 hover:bg-bg-tertiary/80 transition-all active:scale-[0.98]
+    bg-primary border border-primary text-primary-foreground
+    hover:bg-primary/90 transition-all active:scale-[0.98]
     disabled:opacity-40 disabled:cursor-default cursor-pointer
-    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-1 focus-visible:ring-offset-bg;
+    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background;
 }
 
 .btn-secondary-sm {
-  @apply px-3 py-1.5 text-xs font-medium rounded-md border border-border text-text-muted
-    hover:bg-bg-tertiary hover:text-text transition-all active:scale-[0.98]
+  @apply px-3 py-1.5 text-xs font-medium rounded-md border border-border text-muted-foreground
+    hover:bg-muted hover:text-foreground transition-all active:scale-[0.98]
     disabled:opacity-40 disabled:cursor-default cursor-pointer
-    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-1 focus-visible:ring-offset-bg;
+    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background;
 }
 
 /* Scrollbar styling */
@@ -643,7 +605,7 @@ html[lang="ja"] .oa-onboarding-title {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: var(--color-border);
+  background: var(--border);
   border-radius: 3px;
 }
 
@@ -679,8 +641,8 @@ html[lang="ja"] .oa-onboarding-title {
   margin-bottom: 0;
 }
 .markdown-content pre {
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
+  background: var(--background);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 12px;
   overflow-x: auto;
@@ -692,7 +654,7 @@ html[lang="ja"] .oa-onboarding-title {
   font-size: 13px;
 }
 .markdown-content :not(pre) > code {
-  background: var(--color-bg-tertiary);
+  background: var(--muted);
   padding: 2px 6px;
   border-radius: 4px;
   overflow-wrap: anywhere;
@@ -716,25 +678,25 @@ html[lang="ja"] .oa-onboarding-title {
   text-wrap: pretty;
 }
 .markdown-content li::marker {
-  color: var(--color-text-muted);
+  color: var(--muted-foreground);
 }
 /* Obsidian-style [[name]] wikilinks → clickable entity references. */
 .markdown-content a.wikilink {
   display: inline-block;
   max-width: 100%;
-  color: var(--color-accent);
+  color: var(--primary);
   cursor: pointer;
   text-decoration: none;
   vertical-align: baseline;
   overflow-wrap: anywhere;
-  border-bottom: 1px dashed color-mix(in srgb, var(--color-accent) 45%, transparent);
+  border-bottom: 1px dashed color-mix(in srgb, var(--primary) 45%, transparent);
 }
 .markdown-content a.wikilink:hover {
   border-bottom-style: solid;
 }
 
 .markdown-content a.session-signature {
-  color: var(--color-accent, #3b82f6);
+  color: var(--primary);
   cursor: pointer;
   font-weight: 600;
   text-decoration: none;
@@ -747,9 +709,9 @@ html[lang="ja"] .oa-onboarding-title {
   text-decoration: underline;
 }
 .markdown-content blockquote {
-  border-left: 3px solid var(--color-accent);
+  border-left: 3px solid var(--primary);
   padding-left: 12px;
-  color: var(--color-text-muted);
+  color: var(--muted-foreground);
   margin: 0.5em 0;
 }
 .markdown-content table {
@@ -759,12 +721,12 @@ html[lang="ja"] .oa-onboarding-title {
 }
 .markdown-content th,
 .markdown-content td {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border);
   padding: 6px 12px;
   text-align: left;
 }
 .markdown-content th {
-  background: var(--color-bg-tertiary);
+  background: var(--muted);
 }
 .markdown-content img {
   max-width: 100%;
@@ -772,7 +734,7 @@ html[lang="ja"] .oa-onboarding-title {
   margin: 8px 0;
 }
 .markdown-content a {
-  color: var(--color-accent);
+  color: var(--primary);
   text-decoration: none;
   overflow-wrap: anywhere;
 }
@@ -819,11 +781,11 @@ html[lang="ja"] .oa-onboarding-title {
   background: transparent;
 }
 .what-editor-content .ProseMirror-selectednode {
-  outline: 2px solid color-mix(in srgb, var(--color-accent) 45%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--primary) 45%, transparent);
   border-radius: 4px;
 }
 .what-editor-content .ProseMirror p.is-editor-empty:first-child::before {
-  color: var(--color-text-muted);
+  color: var(--muted-foreground);
   content: 'Describe what this Issue should accomplish…';
   float: left;
   height: 0;
@@ -892,13 +854,13 @@ html[lang="ja"] .oa-onboarding-title {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: var(--color-bg-tertiary);
-  border: 1px solid var(--color-border);
+  background: var(--muted);
+  border: 1px solid var(--border);
   border-bottom: none;
   border-radius: 6px 6px 0 0;
   padding: 4px 8px 4px 12px;
   font-size: 12px;
-  color: var(--color-text-muted);
+  color: var(--muted-foreground);
   font-family: var(--font-mono);
 }
 .code-block-wrapper .code-copy-btn {
@@ -907,7 +869,7 @@ html[lang="ja"] .oa-onboarding-title {
   gap: 4px;
   background: none;
   border: none;
-  color: var(--color-text-muted);
+  color: var(--muted-foreground);
   cursor: pointer;
   font-size: 12px;
   padding: 2px 6px;
@@ -916,13 +878,13 @@ html[lang="ja"] .oa-onboarding-title {
   font-family: var(--font-sans);
 }
 .code-block-wrapper .code-copy-btn:hover {
-  color: var(--color-text);
+  color: var(--foreground);
   /* Theme-aware wash — navy in Daybreak, white in Midnight. The old
      hardcoded rgba(255,255,255,…) was invisible in light mode. */
-  background: var(--color-overlay-strong);
+  background: var(--accent-strong);
 }
 .code-block-wrapper .code-copy-btn.copied {
-  color: var(--color-green);
+  color: var(--success);
 }
 .code-block-wrapper pre {
   margin-top: 0 !important;

--- a/ui/src/lib/contract-display.tsx
+++ b/ui/src/lib/contract-display.tsx
@@ -178,12 +178,12 @@ export function ContractCell({ contract }: { contract: ContractLike }) {
   const { name, meta } = contractSecondaryParts(contract)
   return (
     <div className="min-w-0">
-      <div className="text-[13px] text-text font-medium leading-tight">{contractPrimary(contract)}</div>
+      <div className="text-[13px] text-foreground font-medium leading-tight">{contractPrimary(contract)}</div>
       {(name || meta) && (
         <div className="text-[11px] leading-tight mt-0.5">
-          {name && <span className="text-text-muted">{name}</span>}
-          {name && meta && <span className="text-text-muted opacity-40"> · </span>}
-          {meta && <span className="text-text-muted opacity-60">{meta}</span>}
+          {name && <span className="text-muted-foreground">{name}</span>}
+          {name && meta && <span className="text-muted-foreground opacity-40"> · </span>}
+          {meta && <span className="text-muted-foreground opacity-60">{meta}</span>}
         </div>
       )}
     </div>

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -132,8 +132,8 @@ export function AIProviderPage() {
         <div className="max-w-[1100px] min-w-0 mx-auto grid gap-6 lg:grid-cols-2">
           {/* ============== Credentials ============== */}
           <section className="min-w-0">
-            <div className="rounded-lg border border-border/50 bg-bg-secondary/50 px-4 py-3 mb-4">
-              <p className="text-[13px] text-text-muted leading-relaxed">
+            <div className="rounded-lg border border-border/50 bg-secondary/50 px-4 py-3 mb-4">
+              <p className="text-[13px] text-muted-foreground leading-relaxed">
                 The API keys Alice keeps centrally. Templates inject them into new
                 workspaces, and a workspace's AI config can load any of them. Subscription
                 logins (Claude Pro/Max, ChatGPT) aren't stored here — they live in the agent
@@ -143,10 +143,10 @@ export function AIProviderPage() {
             </div>
 
             <div className="flex items-center justify-between mb-3">
-              <h2 className="text-[13px] font-semibold text-text uppercase tracking-wide">Credentials</h2>
+              <h2 className="text-[13px] font-semibold text-foreground uppercase tracking-wide">Credentials</h2>
               <button
                 onClick={() => setModal({ mode: 'add' })}
-                className="text-[11px] px-2 py-1 rounded-md border border-border text-text-muted hover:text-accent hover:border-accent transition-colors"
+                className="text-[11px] px-2 py-1 rounded-md border border-border text-muted-foreground hover:text-primary hover:border-primary transition-colors"
               >
                 + Add
               </button>
@@ -156,37 +156,37 @@ export function AIProviderPage() {
               {credentials.map((cred) => {
                 const compatibleAgents = compatibleAgentIds(cred.wires)
                 return (
-                  <div key={cred.slug} className="flex min-w-0 flex-col gap-3 rounded-lg border border-border bg-bg px-4 py-3 sm:flex-row sm:items-center">
+                  <div key={cred.slug} className="flex min-w-0 flex-col gap-3 rounded-lg border border-border bg-background px-4 py-3 sm:flex-row sm:items-center">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-[13px] font-medium text-text">{credentialLabel(cred)}</span>
+                        <span className="text-[13px] font-medium text-foreground">{credentialLabel(cred)}</span>
                         {cred.label && (
-                          <span className="text-[11px] text-text-muted">{cred.vendor}</span>
+                          <span className="text-[11px] text-muted-foreground">{cred.vendor}</span>
                         )}
-                        <span className="text-[11px] text-text-muted font-mono">{cred.slug}</span>
+                        <span className="text-[11px] text-muted-foreground font-mono">{cred.slug}</span>
                         {compatibleAgents.map((agentId) => (
-                          <span key={agentId} className="text-[10px] text-text-muted border border-border rounded px-1">{AGENT_LABELS[agentId] ?? agentId}</span>
+                          <span key={agentId} className="text-[10px] text-muted-foreground border border-border rounded px-1">{AGENT_LABELS[agentId] ?? agentId}</span>
                         ))}
                         {cred.hasApiKey && (
-                          <span className="text-[10px] text-green border border-green/40 rounded px-1">key set</span>
+                          <span className="text-[10px] text-success border border-success/40 rounded px-1">key set</span>
                         )}
                       </div>
-                      <div className="mt-0.5 truncate text-[11px] text-text-muted">
+                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
                         Default model: <span className="font-mono">{cred.lastModel || 'not set'}</span>
-                        <span className="px-1.5 text-text-muted/50">·</span>
+                        <span className="px-1.5 text-muted-foreground/50">·</span>
                         <span className="font-mono">{Object.values(cred.wires)[0] || 'provider official endpoint'}</span>
                       </div>
                     </div>
                     <div className="flex shrink-0 gap-2 self-end sm:self-auto">
                       <button
                         onClick={() => setModal({ mode: 'edit', cred })}
-                        className="text-[11px] px-2 py-1 rounded-md border border-border text-text-muted hover:text-text transition-colors"
+                        className="text-[11px] px-2 py-1 rounded-md border border-border text-muted-foreground hover:text-foreground transition-colors"
                       >
                         Edit
                       </button>
                       <button
                         onClick={() => handleDelete(cred.slug)}
-                        className="text-[11px] px-2 py-1 rounded-md border border-border text-text-muted hover:text-red transition-colors"
+                        className="text-[11px] px-2 py-1 rounded-md border border-border text-muted-foreground hover:text-destructive transition-colors"
                       >
                         Delete
                       </button>
@@ -198,7 +198,7 @@ export function AIProviderPage() {
               {credentials.length === 0 && (
                 <button
                   onClick={() => setModal({ mode: 'add' })}
-                  className="w-full p-4 rounded-xl border-2 border-dashed border-border text-text-muted hover:border-accent/50 hover:text-accent transition-all text-[13px] font-medium"
+                  className="w-full p-4 rounded-xl border-2 border-dashed border-border text-muted-foreground hover:border-primary/50 hover:text-primary transition-all text-[13px] font-medium"
                 >
                   + Add your first credential
                 </button>
@@ -208,8 +208,8 @@ export function AIProviderPage() {
 
           {/* ============== Agent runtimes ============== */}
           <section className="min-w-0">
-            <div className="rounded-lg border border-border/50 bg-bg-secondary/50 px-4 py-3 mb-4">
-              <p className="text-[13px] text-text-muted leading-relaxed">
+            <div className="rounded-lg border border-border/50 bg-secondary/50 px-4 py-3 mb-4">
+              <p className="text-[13px] text-muted-foreground leading-relaxed">
                 The agent runtimes a workspace can launch — a credential above feeds whichever
                 one a workspace (or cron job) runs. Pick by the models/provider you want; every
                 runtime reaches the full OpenAlice tool surface either way (native MCP where
@@ -219,21 +219,21 @@ export function AIProviderPage() {
               </p>
             </div>
 
-            <h2 className="text-[13px] font-semibold text-text uppercase tracking-wide mb-3">Agent runtimes</h2>
+            <h2 className="text-[13px] font-semibold text-foreground uppercase tracking-wide mb-3">Agent runtimes</h2>
 
             <div className="space-y-2.5">
               {AGENT_RUNTIMES.map((rt) => (
-                <div key={rt.id} className="rounded-lg border border-border bg-bg px-4 py-3">
+                <div key={rt.id} className="rounded-lg border border-border bg-background px-4 py-3">
                   <div className="flex items-baseline gap-2">
-                    <span className="text-[13px] font-medium text-text">{rt.name}</span>
-                    <span className="text-[11px] text-text-muted font-mono">{rt.id}</span>
+                    <span className="text-[13px] font-medium text-foreground">{rt.name}</span>
+                    <span className="text-[11px] text-muted-foreground font-mono">{rt.id}</span>
                   </div>
-                  <p className="text-[12px] text-text-muted mt-0.5 leading-snug">{rt.blurb}</p>
+                  <p className="text-[12px] text-muted-foreground mt-0.5 leading-snug">{rt.blurb}</p>
                   <dl className="mt-2 space-y-1">
                     {rt.facts.map(([label, value]) => (
                       <div key={label} className="flex gap-2 text-[11px] leading-snug">
-                        <dt className="text-text-muted/70 shrink-0 w-[58px]">{label}</dt>
-                        <dd className="text-text-muted">{value}</dd>
+                        <dt className="text-muted-foreground/70 shrink-0 w-[58px]">{label}</dt>
+                        <dd className="text-muted-foreground">{value}</dd>
                       </div>
                     ))}
                   </dl>
@@ -366,15 +366,15 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
       ? configuredWire
       : wireShapes[0] ?? ''
     return (
-      <div key={agent.id} className="flex flex-col gap-3 rounded-lg border border-border bg-bg px-4 py-3 sm:flex-row sm:items-center">
+      <div key={agent.id} className="flex flex-col gap-3 rounded-lg border border-border bg-background px-4 py-3 sm:flex-row sm:items-center">
         <div className="flex-1 min-w-0">
           <div className="flex items-baseline gap-2">
-            <span className="text-[13px] font-medium text-text">{agent.name}</span>
-            <span className="text-[11px] text-text-muted font-mono">{agent.id}</span>
+            <span className="text-[13px] font-medium text-foreground">{agent.name}</span>
+            <span className="text-[11px] text-muted-foreground font-mono">{agent.id}</span>
           </div>
-          {note && <p className="text-[11px] text-text-muted mt-0.5 leading-snug">{note}</p>}
+          {note && <p className="text-[11px] text-muted-foreground mt-0.5 leading-snug">{note}</p>}
           {options.length === 0 && (
-            <p className="text-[11px] text-text-muted/70 mt-0.5 leading-snug">No compatible credential in the vault yet.</p>
+            <p className="text-[11px] text-muted-foreground/70 mt-0.5 leading-snug">No compatible credential in the vault yet.</p>
           )}
         </div>
         <div className="flex w-full flex-col gap-2 sm:w-auto sm:min-w-[260px]">
@@ -402,12 +402,12 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
             </select>
           )}
           {current && wireShapes.length === 1 && (
-            <p className="px-1 text-[10.5px] text-text-muted">
+            <p className="px-1 text-[10.5px] text-muted-foreground">
               Protocol: {WIRE_SHAPE_GUIDANCE[wireShapes[0]!]}
             </p>
           )}
           {agent.id === 'pi' && current && (
-            <label className="flex items-center gap-2 px-1 text-[10.5px] text-text-muted">
+            <label className="flex items-center gap-2 px-1 text-[10.5px] text-muted-foreground">
               <input
                 type="checkbox"
                 aria-label="Default Pi model supports reasoning"
@@ -425,8 +425,8 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
 
   return (
     <section className="max-w-[1100px] mx-auto mt-6">
-      <div className="rounded-lg border border-border/50 bg-bg-secondary/50 px-4 py-3 mb-4">
-        <p className="text-[13px] text-text-muted leading-relaxed">
+      <div className="rounded-lg border border-border/50 bg-secondary/50 px-4 py-3 mb-4">
+        <p className="text-[13px] text-muted-foreground leading-relaxed">
           Seed a default credential into every <em>new</em> workspace, so you don’t open the
           per-workspace AI config each time. Choose the credential, protocol, and default context
           limit that should be written into the workspace’s own agent config
@@ -437,12 +437,12 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
         </p>
       </div>
 
-      <h2 className="text-[13px] font-semibold text-text uppercase tracking-wide mb-3">Default workspace credentials</h2>
+      <h2 className="text-[13px] font-semibold text-foreground uppercase tracking-wide mb-3">Default workspace credentials</h2>
 
       {!data ? (
         <div className="space-y-2.5" aria-hidden="true">
           {PRIMARY_DEFAULT_AGENTS.map((a) => (
-            <div key={a.id} className="flex items-center gap-3 rounded-lg border border-border bg-bg px-4 py-3">
+            <div key={a.id} className="flex items-center gap-3 rounded-lg border border-border bg-background px-4 py-3">
               <div className="flex-1 min-w-0 space-y-1.5">
                 <Skeleton className="h-3.5 w-28 rounded" />
                 <Skeleton className="h-2.5 w-44 rounded" />
@@ -453,10 +453,10 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
         </div>
       ) : (
         <div className="space-y-2.5">
-          <div className="flex flex-col gap-3 rounded-lg border border-border bg-bg px-4 py-3 sm:flex-row sm:items-center">
+          <div className="flex flex-col gap-3 rounded-lg border border-border bg-background px-4 py-3 sm:flex-row sm:items-center">
             <div className="min-w-0 flex-1">
-              <div className="text-[13px] font-medium text-text">Default context window</div>
-              <p className="mt-0.5 text-[11px] leading-snug text-text-muted">
+              <div className="text-[13px] font-medium text-foreground">Default context window</div>
+              <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
                 Applied to new opencode and Pi model entries. 256K avoids common higher-price tiers; existing workspaces stay unchanged.
               </p>
             </div>
@@ -478,14 +478,14 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
 
           <button
             onClick={() => setShowAdvanced((v) => !v)}
-            className="text-[11px] text-text-muted hover:text-text transition-colors pt-1"
+            className="text-[11px] text-muted-foreground hover:text-foreground transition-colors pt-1"
           >
             {showAdvanced ? '▾' : '▸'} Advanced — Claude Code / Codex (unofficial API)
           </button>
 
           {showAdvanced && (
             <>
-              <p className="text-[11px] text-text-muted/80 leading-snug px-1">
+              <p className="text-[11px] text-muted-foreground/80 leading-snug px-1">
                 Only set these if you drive Claude Code / Codex through an unofficial API key
                 instead of their built-in login. A default here overwrites the CLI login in each
                 new workspace.
@@ -494,7 +494,7 @@ function WorkspaceDefaultsSection({ credentials }: { credentials: CredentialSumm
             </>
           )}
 
-          {error && <p className="text-[12px] text-red">{error}</p>}
+          {error && <p className="text-[12px] text-destructive">{error}</p>}
         </div>
       )}
     </section>

--- a/ui/src/pages/AgentPermissionsPage.tsx
+++ b/ui/src/pages/AgentPermissionsPage.tsx
@@ -75,9 +75,9 @@ function PermissionSection({
   return (
     <div className="grid min-w-0 grid-cols-1 gap-4 border-b border-border/60 py-6 last:border-b-0 xl:grid-cols-[260px_minmax(0,1fr)] xl:gap-10">
       <div className="min-w-0 xl:pt-0.5">
-        <h3 className="text-[14px] font-semibold text-text">{title}</h3>
+        <h3 className="text-[14px] font-semibold text-foreground">{title}</h3>
         {description && (
-          <p className="mt-1.5 max-w-[42rem] text-[13px] leading-relaxed text-text-muted/70">{description}</p>
+          <p className="mt-1.5 max-w-[42rem] text-[13px] leading-relaxed text-muted-foreground/70">{description}</p>
         )}
       </div>
       <div className="min-w-0">{children}</div>
@@ -115,19 +115,19 @@ function TradingModeSection() {
               }}
               className={`flex min-h-[82px] items-start gap-3 rounded-lg border px-3.5 py-3 text-left transition-[border-color,background-color] ${
                 active
-                  ? 'border-accent/50 bg-accent/10 text-text'
-                  : 'border-border bg-bg text-text-muted hover:border-accent/40 hover:bg-bg-tertiary hover:text-text'
+                  ? 'border-primary/50 bg-primary/10 text-foreground'
+                  : 'border-border bg-background text-muted-foreground hover:border-primary/40 hover:bg-muted hover:text-foreground'
               } ${disabled ? 'cursor-default opacity-70' : ''}`}
             >
-              <span className={`grid h-8 w-8 shrink-0 place-items-center rounded-md ${active ? 'bg-accent/15 text-accent' : 'bg-bg-tertiary text-text-muted'}`}>
+              <span className={`grid h-8 w-8 shrink-0 place-items-center rounded-md ${active ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'}`}>
                 <meta.Icon size={16} strokeWidth={1.8} aria-hidden />
               </span>
               <span className="min-w-0">
                 <span className="block text-[13px] font-semibold">{t(meta.labelKey)}</span>
-                <span className="mt-1 block text-[12px] leading-relaxed text-text-muted">{t(meta.descriptionKey)}</span>
+                <span className="mt-1 block text-[12px] leading-relaxed text-muted-foreground">{t(meta.descriptionKey)}</span>
                 {saving === mode && (
-                  <span className="mt-2 inline-flex items-center gap-1.5 text-[11px] text-accent">
-                    <span className="h-1.5 w-1.5 rounded-full bg-accent animate-pulse" aria-hidden />
+                  <span className="mt-2 inline-flex items-center gap-1.5 text-[11px] text-primary">
+                    <span className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" aria-hidden />
                     {t('settings.agentPermissions.mode.saving')}
                   </span>
                 )}
@@ -136,13 +136,13 @@ function TradingModeSection() {
           )
         })}
       </div>
-      <div className="mt-3 text-[11px] leading-relaxed text-text-muted/70">
+      <div className="mt-3 text-[11px] leading-relaxed text-muted-foreground/70">
         {status.envLocked
           ? t('settings.agentPermissions.mode.envLocked')
           : t('settings.agentPermissions.mode.source', { source: status.modeSource })}
       </div>
       {error && (
-        <div className="mt-2 rounded-md border border-red/30 bg-red/5 px-3 py-2 text-[12px] text-red leading-relaxed">
+        <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] text-destructive leading-relaxed">
           {error}
         </div>
       )}
@@ -184,20 +184,20 @@ function AiTradingToggle({
     <>
       <div className="flex items-center justify-between gap-4 py-1">
         <div className="min-w-0 flex-1">
-          <span className="text-sm font-medium text-text">{t('settings.agent.allowAiTrading')}</span>
-          <p className="text-[12px] text-text-muted mt-0.5 leading-relaxed">
+          <span className="text-sm font-medium text-foreground">{t('settings.agent.allowAiTrading')}</span>
+          <p className="text-[12px] text-muted-foreground mt-0.5 leading-relaxed">
             {enabled ? t('settings.agent.allowAiTradingOn') : t('settings.agent.allowAiTradingOff')}
           </p>
         </div>
         <Toggle checked={enabled} onChange={onToggle} />
       </div>
       {enabled && (
-        <div className="mt-2 rounded-md border border-red/30 bg-red/5 px-3 py-2 text-[12px] text-red leading-relaxed">
+        <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] text-destructive leading-relaxed">
           {t('settings.agent.allowAiTradingWarning')}
         </div>
       )}
       {enabled && mode !== 'pro' && (
-        <div className="mt-2 rounded-md border border-yellow-400/30 bg-yellow-400/5 px-3 py-2 text-[12px] text-text-muted leading-relaxed">
+        <div className="mt-2 rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-[12px] text-muted-foreground leading-relaxed">
           {t('settings.agentPermissions.aiPush.proOnly')}
         </div>
       )}

--- a/ui/src/pages/AutomationApiSection.tsx
+++ b/ui/src/pages/AutomationApiSection.tsx
@@ -6,11 +6,11 @@
  * the retired event-bus webhook route is not part of the architecture.
  */
 
-const CODE = 'rounded bg-black/30 px-1 py-0.5 font-mono text-[12px] text-text/90'
+const CODE = 'rounded bg-code-background px-1 py-0.5 font-mono text-[12px] text-foreground/90'
 
 function Block({ children }: { children: string }) {
   return (
-    <pre className="overflow-auto rounded bg-black/30 p-3 text-[12px] leading-snug text-muted whitespace-pre-wrap">
+    <pre className="overflow-auto rounded bg-code-background p-3 text-[12px] leading-snug text-muted-foreground whitespace-pre-wrap">
       {children}
     </pre>
   )
@@ -20,19 +20,19 @@ export function AutomationApiSection() {
   return (
     <div className="max-w-prose mx-auto space-y-6 text-sm leading-relaxed">
       <section className="space-y-2">
-        <h2 className="text-base font-semibold text-text">Workspace automation</h2>
-        <p className="text-muted">
+        <h2 className="text-base font-semibold text-foreground">Workspace automation</h2>
+        <p className="text-muted-foreground">
           Automation is just a workspace run with no human attached: the same
           workspace, the same tools, spawned <em>headless</em> on a trigger. A run
-          reaches you through the <span className="text-text">Inbox</span> — there
+          reaches you through the <span className="text-foreground">Inbox</span> — there
           is no other output channel. There are two ways a run starts.
         </p>
       </section>
 
       <section className="space-y-2">
-        <h3 className="font-semibold text-text">1 · Self-scheduled (the workspace declares it)</h3>
-        <p className="text-muted">
-          A workspace declares its work as <strong className="text-text">one
+        <h3 className="font-semibold text-foreground">1 · Self-scheduled (the workspace declares it)</h3>
+        <p className="text-muted-foreground">
+          A workspace declares its work as <strong className="text-foreground">one
           markdown file per issue</strong> under{' '}
           <code className={CODE}>.alice/issues/&lt;id&gt;.md</code> in its own
           checkout (the filename stem is the issue id). Each file is YAML
@@ -58,7 +58,7 @@ Every trading morning before the open, assemble the pre-market picture for
 the watchlist — movers, gaps, and overnight headlines that move the thesis.
 Write research/premarket.md, then run alice-workspace inbox push --doc
 research/premarket.md --comments "Pre-market brief".`}</Block>
-        <ul className="ml-4 list-disc space-y-1 text-muted">
+        <ul className="ml-4 list-disc space-y-1 text-muted-foreground">
           <li>
             <code className={CODE}>title</code>: a short human title for the issue — required, surfaced
             on the Issue board and the Inbox.
@@ -90,8 +90,8 @@ research/premarket.md --comments "Pre-market brief".`}</Block>
       </section>
 
       <section className="space-y-2">
-        <h3 className="font-semibold text-text">2 · External trigger (POST a run)</h3>
-        <p className="text-muted">Trigger a one-off headless run in a specific workspace over HTTP:</p>
+        <h3 className="font-semibold text-foreground">2 · External trigger (POST a run)</h3>
+        <p className="text-muted-foreground">Trigger a one-off headless run in a specific workspace over HTTP:</p>
         <Block>{`POST /api/workspaces/:id/headless
 {
   "prompt": "<the instruction for the run>",
@@ -102,16 +102,16 @@ research/premarket.md --comments "Pre-market brief".`}</Block>
 
   202  { "taskId": "..." }     // accepted, runs in the background (default)
   429                          // headless concurrency cap reached, retry later`}</Block>
-        <p className="text-muted">
+        <p className="text-muted-foreground">
           This is the seam for an external system (a webhook bridge, a cron on
           another host) to drive a workspace. Every run is recorded under{' '}
-          <span className="text-text">Runs</span>.
+          <span className="text-foreground">Runs</span>.
         </p>
       </section>
 
       <section className="space-y-2">
-        <h3 className="font-semibold text-text">Reporting back</h3>
-        <p className="text-muted">
+        <h3 className="font-semibold text-foreground">Reporting back</h3>
+        <p className="text-muted-foreground">
           A headless run has no UI. It surfaces results by pushing to the Inbox
           (the <code className={CODE}>alice-workspace inbox push</code> CLI, on every
           workspace's PATH). A run that produces a deliverable but never pushes

--- a/ui/src/pages/AutomationRunsSection.tsx
+++ b/ui/src/pages/AutomationRunsSection.tsx
@@ -24,10 +24,10 @@ import { useWorkspaces } from '../contexts/workspaces-context'
 import { formatRelativeTime } from '../lib/intl'
 
 const STATUS_STYLE: Record<HeadlessTaskStatus, string> = {
-  running: 'bg-blue-500/15 text-blue-400',
-  done: 'bg-emerald-500/15 text-emerald-400',
-  failed: 'bg-red-500/15 text-red-400',
-  interrupted: 'bg-amber-500/15 text-amber-400',
+  running: 'bg-info/15 text-info',
+  done: 'bg-success/15 text-success',
+  failed: 'bg-destructive/15 text-destructive',
+  interrupted: 'bg-warning/15 text-warning',
 }
 
 const RUNS_PAGE_SIZE = 25
@@ -52,15 +52,15 @@ function formatValue(value: unknown): string {
 function ToolBlock({ block }: { block: Extract<HeadlessMessageBlock, { type: 'tool' }> }) {
   const hasDetails = block.input !== undefined || block.output !== undefined
   const statusClass = block.status === 'failed'
-    ? 'text-red-400'
+    ? 'text-destructive'
     : block.status === 'completed'
-      ? 'text-emerald-400'
-      : 'text-blue-400'
+      ? 'text-success'
+      : 'text-info'
   return (
-    <details className="group/tool rounded-lg border border-border/60 bg-bg-secondary/35" open={block.status === 'failed'}>
+    <details className="group/tool rounded-lg border border-border/60 bg-secondary/35" open={block.status === 'failed'}>
       <summary className={`flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs ${statusClass}`}>
         <Wrench size={13} className="shrink-0" />
-        <span className="min-w-0 flex-1 truncate font-medium text-text">{block.name}</span>
+        <span className="min-w-0 flex-1 truncate font-medium text-foreground">{block.name}</span>
         <span className="shrink-0 uppercase tracking-wide">{block.status}</span>
         {hasDetails && <ChevronRight size={12} className="shrink-0 transition-transform group-open/tool:rotate-90" />}
       </summary>
@@ -68,16 +68,16 @@ function ToolBlock({ block }: { block: Extract<HeadlessMessageBlock, { type: 'to
         <div className="space-y-2 border-t border-border/50 px-3 py-2">
           {block.input !== undefined && (
             <div>
-              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-text-muted/70">Input</div>
-              <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-text-muted">
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">Input</div>
+              <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-muted-foreground">
                 {formatValue(block.input)}
               </pre>
             </div>
           )}
           {block.output !== undefined && (
             <div>
-              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-text-muted/70">Output</div>
-              <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-text-muted">
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">Output</div>
+              <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-muted-foreground">
                 {formatValue(block.output)}
               </pre>
             </div>
@@ -116,8 +116,8 @@ function RunOutput({ task }: { task: HeadlessTaskRecord }) {
     }
   }, [task.taskId, running])
 
-  if (error) return <div className="text-xs text-red-400">Output unavailable: {error}</div>
-  if (!output) return <div className="text-xs text-text-muted">Loading structured output…</div>
+  if (error) return <div className="text-xs text-destructive">Output unavailable: {error}</div>
+  if (!output) return <div className="text-xs text-muted-foreground">Loading structured output…</div>
 
   const tools = output.structured.blocks.filter(
     (block): block is Extract<HeadlessMessageBlock, { type: 'tool' }> => block.type === 'tool',
@@ -128,15 +128,15 @@ function RunOutput({ task }: { task: HeadlessTaskRecord }) {
 
   return (
     <div className="space-y-3">
-      <section className="rounded-lg border border-border/70 bg-bg-secondary/25 p-3">
-        <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-text-muted">
+      <section className="rounded-lg border border-border/70 bg-secondary/25 p-3">
+        <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
           <MessageSquareText size={14} />
           Reply
         </div>
         {output.structured.assistantText ? (
           <MarkdownContent text={output.structured.assistantText} className="text-[13px] leading-relaxed" />
         ) : (
-          <p className="text-xs text-text-muted">
+          <p className="text-xs text-muted-foreground">
             {running ? 'Waiting for an assistant reply…' : 'This run produced no assistant reply.'}
           </p>
         )}
@@ -144,44 +144,44 @@ function RunOutput({ task }: { task: HeadlessTaskRecord }) {
 
       {(tools.length > 0 || errors.length > 0) && (
         <section>
-          <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-text-muted">
+          <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
             <Wrench size={13} />
             Activity · {tools.length} tool{tools.length === 1 ? '' : 's'}
           </div>
           <div className="space-y-1.5">
             {tools.map((block) => <ToolBlock key={block.id} block={block} />)}
             {errors.map((block, index) => (
-              <div key={`${block.message}-${index}`} className="flex gap-2 rounded-lg border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+              <div key={`${block.message}-${index}`} className="flex gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
                 <CircleAlert size={13} className="mt-0.5 shrink-0" />
                 <span className="whitespace-pre-wrap break-words">{block.message}</span>
               </div>
             ))}
           </div>
           {output.structured.truncated && (
-            <p className="mt-2 text-[11px] text-amber-400">Earlier activity was truncated; runtime diagnostics remain available below.</p>
+            <p className="mt-2 text-[11px] text-warning">Earlier activity was truncated; runtime diagnostics remain available below.</p>
           )}
         </section>
       )}
 
       <details className="rounded-lg border border-border/60">
-        <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs text-text-muted hover:text-text">
+        <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground">
           <TerminalSquare size={13} />
           Runtime diagnostics
         </summary>
         <div className="space-y-2 border-t border-border/50 p-2">
           {output.stdout && (
-            <pre className="max-h-64 overflow-auto rounded bg-black/30 p-2 text-[11px] leading-snug text-text-muted whitespace-pre-wrap break-all">
+            <pre className="max-h-64 overflow-auto rounded bg-code-background p-2 text-[11px] leading-snug text-muted-foreground whitespace-pre-wrap break-all">
               {output.stdout.truncated ? '… (tail)\n' : ''}
               {output.stdout.text || '(empty)'}
             </pre>
           )}
           {output.stderr && output.stderr.text.length > 0 && (
-            <pre className="max-h-32 overflow-auto rounded bg-red-950/20 p-2 text-[11px] leading-snug text-red-300/80 whitespace-pre-wrap break-all">
+            <pre className="max-h-32 overflow-auto rounded bg-destructive/20 p-2 text-[11px] leading-snug text-destructive/80 whitespace-pre-wrap break-all">
               {output.stderr.truncated ? '… (tail)\n' : ''}
               {output.stderr.text}
             </pre>
           )}
-          {!output.stdout && !output.stderr && <div className="text-xs text-text-muted">No runtime diagnostics for this run.</div>}
+          {!output.stdout && !output.stderr && <div className="text-xs text-muted-foreground">No runtime diagnostics for this run.</div>}
         </div>
       </details>
     </div>
@@ -190,10 +190,10 @@ function RunOutput({ task }: { task: HeadlessTaskRecord }) {
 
 function SummaryCard({ label, value, detail }: { label: string; value: string; detail: string }) {
   return (
-    <div className="rounded-lg border border-border/60 bg-bg-secondary/25 px-3 py-2">
-      <div className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-muted/70">{label}</div>
-      <div className="mt-0.5 text-lg font-semibold text-text">{value}</div>
-      <div className="text-[11px] text-text-muted">{detail}</div>
+    <div className="rounded-lg border border-border/60 bg-secondary/25 px-3 py-2">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/70">{label}</div>
+      <div className="mt-0.5 text-lg font-semibold text-foreground">{value}</div>
+      <div className="text-[11px] text-muted-foreground">{detail}</div>
     </div>
   )
 }
@@ -280,7 +280,7 @@ export function AutomationRunsSection() {
     }
   }
 
-  if (error && !snapshot) return <div className="text-sm text-red-400">Failed to load runs: {error}</div>
+  if (error && !snapshot) return <div className="text-sm text-destructive">Failed to load runs: {error}</div>
   if (!snapshot) {
     return (
       <div className="space-y-3" aria-hidden="true">
@@ -309,13 +309,13 @@ export function AutomationRunsSection() {
       </div>
 
       {snapshot.tasks.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-border p-5 text-sm text-text-muted">
+        <div className="rounded-lg border border-dashed border-border p-5 text-sm text-muted-foreground">
           No headless runs yet. Dispatch one with <code className="text-xs">POST /api/workspaces/:id/headless</code>.
         </div>
       ) : (
         <div className="space-y-2">
           {error && (
-            <div className="rounded-lg border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
               Refresh failed: {error}
             </div>
           )}
@@ -331,23 +331,23 @@ export function AutomationRunsSection() {
               <article
                 key={task.taskId}
                 data-task-id={task.taskId}
-                className="overflow-hidden rounded-xl border border-border/70 bg-bg-secondary/15"
+                className="overflow-hidden rounded-xl border border-border/70 bg-secondary/15"
               >
                 <button
                   type="button"
                   onClick={() => toggle(task.taskId)}
-                  className="flex w-full items-start gap-3 px-3 py-3 text-left hover:bg-bg-tertiary/35"
+                  className="flex w-full items-start gap-3 px-3 py-3 text-left hover:bg-muted/35"
                   aria-expanded={isExpanded}
                 >
                   <span className={`mt-0.5 inline-flex rounded px-1.5 py-0.5 text-[11px] font-medium ${STATUS_STYLE[task.status]}`}>
                     {task.status}
                   </span>
-                  <Bot size={15} className="mt-0.5 shrink-0 text-text-muted" />
+                  <Bot size={15} className="mt-0.5 shrink-0 text-muted-foreground" />
                   <span className="min-w-0 flex-1">
-                    <span className="block max-h-10 overflow-hidden text-[13px] leading-5 text-text">
+                    <span className="block max-h-10 overflow-hidden text-[13px] leading-5 text-foreground">
                       {task.prompt}
                     </span>
-                    <span className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-text-muted">
+                    <span className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
                       <span>{task.agent}</span>
                       <span className="font-mono">{task.wsId.slice(0, 8)}</span>
                       <span>{formatRelativeTime(task.startedAt)}</span>
@@ -355,21 +355,21 @@ export function AutomationRunsSection() {
                       <span>{toolSummary}</span>
                     </span>
                   </span>
-                  {isExpanded ? <ChevronDown size={15} className="mt-0.5 shrink-0 text-text-muted" /> : <ChevronRight size={15} className="mt-0.5 shrink-0 text-text-muted" />}
+                  {isExpanded ? <ChevronDown size={15} className="mt-0.5 shrink-0 text-muted-foreground" /> : <ChevronRight size={15} className="mt-0.5 shrink-0 text-muted-foreground" />}
                 </button>
 
                 {isExpanded && (
                   <div className="space-y-3 border-t border-border/60 px-3 py-3">
-                    <details className="rounded-lg border border-border/60 bg-bg-secondary/25">
-                      <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-text-muted hover:text-text">
+                    <details className="rounded-lg border border-border/60 bg-secondary/25">
+                      <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground">
                         Task instructions
                       </summary>
-                      <pre className="max-h-64 overflow-auto border-t border-border/50 px-3 py-2 whitespace-pre-wrap break-words text-[11px] leading-relaxed text-text-muted">
+                      <pre className="max-h-64 overflow-auto border-t border-border/50 px-3 py-2 whitespace-pre-wrap break-words text-[11px] leading-relaxed text-muted-foreground">
                         {task.prompt}
                       </pre>
                     </details>
                     {task.error && (
-                      <div className="flex gap-2 rounded-lg border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+                      <div className="flex gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
                         <CircleAlert size={13} className="mt-0.5 shrink-0" />
                         {task.error}
                       </div>
@@ -377,7 +377,7 @@ export function AutomationRunsSection() {
                     {openable && (
                       <button
                         type="button"
-                        className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-emerald-400 hover:bg-emerald-500/10"
+                        className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-success hover:bg-success/10"
                         title="Resume this run's conversation in an interactive session"
                         onClick={() => {
                           void openHeadlessRun(task.wsId, task.resumeId, {
@@ -402,11 +402,11 @@ export function AutomationRunsSection() {
                 data-testid="runs-load-more"
                 disabled={loadingMore}
                 onClick={() => void loadMore()}
-                className="rounded-lg border border-border bg-bg-secondary/35 px-4 py-2 text-xs font-medium text-text hover:bg-bg-tertiary disabled:cursor-wait disabled:opacity-60"
+                className="rounded-lg border border-border bg-secondary/35 px-4 py-2 text-xs font-medium text-foreground hover:bg-muted disabled:cursor-wait disabled:opacity-60"
               >
                 {loadingMore ? 'Loading older runs…' : `Load ${Math.min(RUNS_PAGE_SIZE, snapshot.page.total - snapshot.tasks.length)} older runs`}
               </button>
-              <span className="text-[11px] text-text-muted">
+              <span className="text-[11px] text-muted-foreground">
                 {snapshot.tasks.length} of {snapshot.page.total} loaded
               </span>
             </div>

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -235,26 +235,26 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   }
 
   return (
-    <div className="relative h-full w-full overflow-auto bg-bg flex flex-col items-center justify-center px-4 py-6 md:px-6 md:py-10">
+    <div className="relative h-full w-full overflow-auto bg-background flex flex-col items-center justify-center px-4 py-6 md:px-6 md:py-10">
       {/* Ask-Alice backdrop — full-bleed, responsive-only layers (gradient wash
           + faint grid). The #302 mock's %-positioned circle / diagonal bars were
           dropped: they drift on portrait and read as pixel-placed art, not a
           responsive surface. pointer-events-none so it never intercepts clicks. */}
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-overlay to-transparent" />
-        <div className="absolute inset-x-0 bottom-0 h-[38%] bg-gradient-to-t from-overlay-strong to-transparent" />
-        <div className="absolute inset-0 opacity-[0.06] [background-image:linear-gradient(to_right,var(--color-text)_1px,transparent_1px),linear-gradient(to_bottom,var(--color-text)_1px,transparent_1px)] [background-size:96px_96px]" />
+        <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-accent to-transparent" />
+        <div className="absolute inset-x-0 bottom-0 h-[38%] bg-gradient-to-t from-accent-strong to-transparent" />
+        <div className="absolute inset-0 opacity-[0.06] [background-image:linear-gradient(to_right,var(--foreground)_1px,transparent_1px),linear-gradient(to_bottom,var(--foreground)_1px,transparent_1px)] [background-size:96px_96px]" />
       </div>
 
       <div className="relative z-10 w-full max-w-2xl flex flex-col gap-4 md:gap-5">
         <div className="text-center space-y-1.5">
           {targetWs ? (
             <>
-              <h1 className="text-xl md:text-2xl font-semibold text-text">
+              <h1 className="text-xl md:text-2xl font-semibold text-foreground">
                 {t('chatLanding.targetHeading')}
               </h1>
               <div className="flex items-center justify-center gap-2 pt-1">
-                <span className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-accent/10 pl-2.5 pr-1.5 py-1 text-[12.5px] font-medium text-accent">
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/40 bg-primary/10 pl-2.5 pr-1.5 py-1 text-[12.5px] font-medium text-primary">
                   <LayoutGrid className="w-3.5 h-3.5 shrink-0" />
                   {targetWs.tag}
                   <button
@@ -262,7 +262,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                     onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
                     aria-label={t('chatLanding.clearTarget')}
                     title={t('chatLanding.clearTarget')}
-                    className="oa-icon-action ml-0.5 rounded-full p-0.5 text-accent/70 hover:text-accent hover:bg-accent/20 transition-colors"
+                    className="oa-icon-action ml-0.5 rounded-full p-0.5 text-primary/70 hover:text-primary hover:bg-primary/20 transition-colors"
                   >
                     <X className="w-3 h-3" />
                   </button>
@@ -271,17 +271,17 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
             </>
           ) : (
             <>
-              <h1 className="text-[19px] md:text-2xl font-semibold text-text leading-tight">{t('chatLanding.heading')}</h1>
-              <p className="text-[13px] md:text-sm text-text-muted leading-relaxed">{t('chatLanding.subheading')}</p>
+              <h1 className="text-[19px] md:text-2xl font-semibold text-foreground leading-tight">{t('chatLanding.heading')}</h1>
+              <p className="text-[13px] md:text-sm text-muted-foreground leading-relaxed">{t('chatLanding.subheading')}</p>
             </>
           )}
         </div>
 
         <div
-          className={`rounded-xl px-3 pb-2 pt-3 shadow-[0_18px_50px_-40px_var(--color-text)] transition-[border-color,box-shadow] md:rounded-2xl ${
+          className={`rounded-xl px-3 pb-2 pt-3 shadow-[0_18px_50px_-40px_var(--foreground)] transition-[border-color,box-shadow] md:rounded-2xl ${
             targetWs
-              ? 'bg-accent/[0.04] border border-accent/45 ring-1 ring-accent/15 focus-within:border-accent/70'
-              : 'border border-border/80 bg-bg-secondary/70 focus-within:border-accent/60 focus-within:shadow-[0_20px_55px_-38px_var(--color-accent)]'
+              ? 'bg-primary/[0.04] border border-primary/45 ring-1 ring-primary/15 focus-within:border-primary/70'
+              : 'border border-border/80 bg-secondary/70 focus-within:border-primary/60 focus-within:shadow-[0_20px_55px_-38px_var(--primary)]'
           }`}
         >
           <textarea
@@ -292,7 +292,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
             placeholder={t('chatLanding.placeholder')}
             rows={3}
             autoFocus
-            className="w-full max-h-[40vh] min-h-[92px] resize-none bg-transparent px-2 py-1.5 text-[15px] text-text outline-none placeholder:text-text-muted/70 md:min-h-[72px]"
+            className="w-full max-h-[40vh] min-h-[92px] resize-none bg-transparent px-2 py-1.5 text-[15px] text-foreground outline-none placeholder:text-muted-foreground/70 md:min-h-[72px]"
           />
           <div className="flex flex-col gap-2 px-1 pt-1 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -307,7 +307,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                   aria-haspopup="menu"
                   aria-expanded={workspaceMenuOpen}
                   aria-label={t('chatLanding.selectWorkspace')}
-                  className="oa-pressable inline-flex min-h-8 max-w-[220px] items-center gap-1.5 rounded-md bg-bg-tertiary px-2.5 py-1 text-[11px] text-text-muted hover:text-text disabled:cursor-default"
+                  className="oa-pressable inline-flex min-h-8 max-w-[220px] items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-[11px] text-muted-foreground hover:text-foreground disabled:cursor-default"
                 >
                   <MessageSquare className="w-3 h-3 shrink-0" />
                   <span className="truncate">
@@ -322,7 +322,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 {workspaceMenuOpen && targetWs === undefined && chatWorkspaceOptions.length > 0 && (
                   <div
                     role="menu"
-                    className="oa-popover-enter absolute bottom-full left-0 z-10 mb-1 max-h-[min(24rem,calc(100vh-8rem))] min-w-[220px] max-w-[320px] overflow-y-auto overscroll-contain rounded-lg border border-border/70 bg-bg-secondary py-1 shadow-lg [scrollbar-gutter:stable]"
+                    className="oa-popover-enter absolute bottom-full left-0 z-10 mb-1 max-h-[min(24rem,calc(100vh-8rem))] min-w-[220px] max-w-[320px] overflow-y-auto overscroll-contain rounded-lg border border-border/70 bg-secondary py-1 shadow-lg [scrollbar-gutter:stable]"
                   >
                     {chatWorkspaceOptions.map((workspace) => {
                       const active = workspace.id === workspaceTarget?.id
@@ -337,7 +337,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                             launchConfig.resetCredentialSelection()
                             setWorkspaceMenuOpen(false)
                           }}
-                          className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-bg-tertiary ${active ? 'text-accent' : 'text-text'}`}
+                          className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-muted ${active ? 'text-primary' : 'text-foreground'}`}
                         >
                           <LayoutGrid className="w-3.5 h-3.5 shrink-0" />
                           <span className="min-w-0 flex-1 truncate">{workspaceDisplayTitle(workspace)}</span>
@@ -361,7 +361,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 disabled
                 title={t('chatLanding.attachSoon')}
                 aria-label={t('chatLanding.attach')}
-                className="w-10 h-10 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center text-text-muted/50 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="w-10 h-10 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center text-muted-foreground/50 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 <Paperclip className="w-4 h-4" />
               </button>
@@ -371,7 +371,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 disabled={!canSend}
                 title={t('chatLanding.send')}
                 aria-label={t('chatLanding.send')}
-                className="oa-icon-action w-10 h-10 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center bg-accent text-white transition-colors hover:bg-accent/90 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="oa-icon-action w-10 h-10 sm:w-8 sm:h-8 rounded-lg flex items-center justify-center bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {launching ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowUp className="w-4 h-4" />}
               </button>
@@ -385,25 +385,25 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
           />
         </div>
 
-        {error !== null && <div className="text-[12px] text-red px-1">{error}</div>}
+        {error !== null && <div className="text-[12px] text-destructive px-1">{error}</div>}
 
         {/* Runtime guidance. A normal packaged build should expose managed Pi;
             no-runtime is now an abnormal setup/debug state, not a prompt to
             make a fresh user install a CLI. */}
         {launchConfig.agentsKnown && !launchConfig.anyInstalled ? (
-          <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-[12px] space-y-1.5">
-            <div className="font-medium text-text">{t('chatLanding.noAgentsTitle')}</div>
-            <p className="text-text-muted">{t('chatLanding.noAgentsBody')}</p>
+          <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2.5 text-[12px] space-y-1.5">
+            <div className="font-medium text-foreground">{t('chatLanding.noAgentsTitle')}</div>
+            <p className="text-muted-foreground">{t('chatLanding.noAgentsBody')}</p>
           </div>
         ) : launchConfig.selectedMissing && selectedInfo ? (
-          <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-[12px] space-y-1.5">
-            <p className="text-text-muted">
+          <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2.5 text-[12px] space-y-1.5">
+            <p className="text-muted-foreground">
               {t('chatLanding.agentMissing', { name: selectedInfo.displayName })}
             </p>
             {installHint?.cmd && (
               <div className="flex items-center gap-2">
-                <span className="text-text-muted">{t('chatLanding.installLabel')}</span>
-                <code className="font-mono text-[11px] text-text bg-bg-tertiary rounded px-2 py-1 select-all">
+                <span className="text-muted-foreground">{t('chatLanding.installLabel')}</span>
+                <code className="font-mono text-[11px] text-foreground bg-muted rounded px-2 py-1 select-all">
                   {installHint.cmd}
                 </code>
               </div>
@@ -413,7 +413,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
                 href={installHint.url}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-block text-accent hover:underline"
+                className="inline-block text-primary hover:underline"
               >
                 {t('chatLanding.installDocs')} ↗
               </a>
@@ -424,14 +424,14 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
         {/* Loginless runtime has no provider configured — the conversion
             dead-end. Guide the user to set one up instead of a silent failure. */}
         {launchConfig.noCredentials && selectedInfo && (
-          <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-[12px] space-y-1.5">
-            <p className="text-text-muted">
+          <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2.5 text-[12px] space-y-1.5">
+            <p className="text-muted-foreground">
               {t('chatLanding.noCredBody', { name: selectedInfo.displayName })}
             </p>
             <button
               type="button"
               onClick={goConfigureProvider}
-              className="inline-flex items-center gap-1.5 text-accent hover:underline"
+              className="inline-flex items-center gap-1.5 text-primary hover:underline"
             >
               <KeyRound className="w-3 h-3" />
               {t('chatLanding.configureProvider')} ↗
@@ -442,7 +442,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
         {/* The selected cred differs from the one today's workspace already uses
             — sending switches it. A notice, not a block (the user chose it). */}
         {launchConfig.willOverwriteCredential && launchConfig.credential && (
-          <div className="rounded-lg border border-border/60 bg-bg-secondary/60 px-3 py-2 text-[12px] text-text-muted">
+          <div className="rounded-lg border border-border/60 bg-secondary/60 px-3 py-2 text-[12px] text-muted-foreground">
             {t('chatLanding.credOverwrite', {
               from: launchConfig.detectedCredential?.slug ?? '',
               to: launchConfig.credential.slug,
@@ -452,14 +452,14 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
 
         <div className="relative -mx-4 md:mx-0">
           <div className="scrollbar-hide flex items-center gap-2 overflow-x-auto px-4 pb-1 pr-14 md:flex-wrap md:overflow-visible md:px-1 md:pr-1 md:pb-0">
-            <span className="shrink-0 text-[11px] font-medium text-text-muted">{t('chatLanding.examplesLabel')}</span>
+            <span className="shrink-0 text-[11px] font-medium text-muted-foreground">{t('chatLanding.examplesLabel')}</span>
             {[t('chatLanding.ex1'), t('chatLanding.ex2'), t('chatLanding.ex3')].map((ex) => (
               <button
                 key={ex}
                 type="button"
                 onClick={() => useExample(ex)}
                 disabled={launching}
-                className="min-h-8 shrink-0 rounded-full border border-border/70 bg-bg-secondary/75 px-3 py-1 text-[12px] text-text-muted transition-colors hover:border-accent/50 hover:bg-bg-secondary hover:text-text disabled:opacity-40"
+                className="min-h-8 shrink-0 rounded-full border border-border/70 bg-secondary/75 px-3 py-1 text-[12px] text-muted-foreground transition-colors hover:border-primary/50 hover:bg-secondary hover:text-foreground disabled:opacity-40"
               >
                 {ex}
               </button>

--- a/ui/src/pages/ConnectorStatusPage.tsx
+++ b/ui/src/pages/ConnectorStatusPage.tsx
@@ -47,13 +47,13 @@ export function ConnectorStatusPage() {
         right={(
           <div className="flex items-center gap-2">
             {lastUpdated && (
-              <span className="hidden text-[11px] text-text-muted/60 sm:inline">
+              <span className="hidden text-[11px] text-muted-foreground/60 sm:inline">
                 Updated {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
               </span>
             )}
             <button
               type="button"
-              className="oa-pressable inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[13px] text-text-muted hover:text-text hover:border-accent/50 disabled:opacity-50"
+              className="oa-pressable inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[13px] text-muted-foreground hover:text-foreground hover:border-primary/50 disabled:opacity-50"
               disabled={refreshing}
               onClick={() => void load(true)}
             >
@@ -62,7 +62,7 @@ export function ConnectorStatusPage() {
             </button>
             <button
               type="button"
-              className="oa-pressable inline-flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-[13px] font-medium text-white hover:bg-accent/90"
+              className="oa-pressable inline-flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-[13px] font-medium text-primary-foreground hover:bg-primary/90"
               onClick={configure}
             >
               <Settings2 size={14} />
@@ -81,11 +81,11 @@ export function ConnectorStatusPage() {
           ) : null}
 
           {error && (
-            <div className="flex gap-3 rounded-xl border border-red/30 bg-red/5 px-4 py-3 text-[13px] text-red" role="alert">
+            <div className="flex gap-3 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-[13px] text-destructive" role="alert">
               <CircleAlert size={17} className="mt-0.5 shrink-0" />
               <div>
                 <p className="font-medium">Could not read Connector status.</p>
-                <p className="mt-0.5 text-text-muted">{error}</p>
+                <p className="mt-0.5 text-muted-foreground">{error}</p>
               </div>
             </div>
           )}
@@ -110,29 +110,29 @@ function ConnectorOverview({
 
   return (
     <>
-      <section className="oa-status-surface rounded-2xl border border-border bg-bg-secondary/35 p-5 md:p-6">
+      <section className="oa-status-surface rounded-2xl border border-border bg-secondary/35 p-5 md:p-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="flex min-w-0 gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border bg-bg text-text-muted">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border bg-background text-muted-foreground">
               <Plug size={19} />
             </div>
             <div>
               <div className="flex flex-wrap items-center gap-2">
-                <h3 className="text-[15px] font-semibold text-text">Connector Service</h3>
+                <h3 className="text-[15px] font-semibold text-foreground">Connector Service</h3>
                 <StatusBadge tone={service.tone}>{service.label}</StatusBadge>
               </div>
-              <p className="mt-1 max-w-[660px] text-[13px] leading-5 text-text-muted">
+              <p className="mt-1 max-w-[660px] text-[13px] leading-5 text-muted-foreground">
                 {service.description}
               </p>
             </div>
           </div>
-          <div className="text-right text-[11px] text-text-muted/70">
+          <div className="text-right text-[11px] text-muted-foreground/70">
             {snapshot.health.checkedAt && <p>Checked {formatDate(snapshot.health.checkedAt)}</p>}
             {snapshot.health.latencyMs !== undefined && <p className="mt-0.5">{snapshot.health.latencyMs} ms</p>}
           </div>
         </div>
         {snapshot.health.lastError && (
-          <div className="mt-4 rounded-lg border border-red/20 bg-red/5 px-3 py-2 text-[12px] text-red">
+          <div className="mt-4 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2 text-[12px] text-destructive">
             {snapshot.health.lastError}
           </div>
         )}
@@ -141,8 +141,8 @@ function ConnectorOverview({
       <section>
         <div className="mb-3 flex items-end justify-between gap-3">
           <div>
-            <h3 className="text-[13px] font-semibold uppercase tracking-[0.08em] text-text">Delivery connectors</h3>
-            <p className="mt-1 text-[12px] text-text-muted">Each connector delivers to one private owner chat.</p>
+            <h3 className="text-[13px] font-semibold uppercase tracking-[0.08em] text-foreground">Delivery connectors</h3>
+            <p className="mt-1 text-[12px] text-muted-foreground">Each connector delivers to one private owner chat.</p>
           </div>
         </div>
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
@@ -166,31 +166,31 @@ function ConnectorOverview({
             })
 
             return (
-              <article key={definition.id} className="oa-status-surface rounded-2xl border border-border bg-bg-secondary/25 p-5">
+              <article key={definition.id} className="oa-status-surface rounded-2xl border border-border bg-secondary/25 p-5">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h4 className="text-[15px] font-semibold text-text">{definition.label}</h4>
+                      <h4 className="text-[15px] font-semibold text-foreground">{definition.label}</h4>
                       <StatusBadge tone={presentation.tone}>{presentation.label}</StatusBadge>
                     </div>
-                    <p className="mt-1 text-[12px] leading-5 text-text-muted">{definition.description}</p>
+                    <p className="mt-1 text-[12px] leading-5 text-muted-foreground">{definition.description}</p>
                   </div>
                   <span className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${presentation.dot}`} aria-hidden />
                 </div>
 
                 <dl className="mt-5 grid grid-cols-[112px_1fr] gap-x-3 gap-y-2 border-t border-border/70 pt-4 text-[12px]">
-                  <dt className="text-text-muted">Configuration</dt>
-                  <dd className="text-text">{configured ? 'Ready' : 'Needs setup'}</dd>
-                  <dt className="text-text-muted">Delivery</dt>
-                  <dd className="text-text">{config.enabled ? 'Enabled' : 'Disabled'}</dd>
-                  <dt className="text-text-muted">Owner</dt>
-                  <dd className="truncate text-text" title={runtime?.owner}>{runtime?.owner ?? 'Not linked'}</dd>
-                  <dt className="text-text-muted">Last success</dt>
-                  <dd className="text-text">{runtime?.lastSuccessAt ? formatDate(runtime.lastSuccessAt) : 'No delivery yet'}</dd>
+                  <dt className="text-muted-foreground">Configuration</dt>
+                  <dd className="text-foreground">{configured ? 'Ready' : 'Needs setup'}</dd>
+                  <dt className="text-muted-foreground">Delivery</dt>
+                  <dd className="text-foreground">{config.enabled ? 'Enabled' : 'Disabled'}</dd>
+                  <dt className="text-muted-foreground">Owner</dt>
+                  <dd className="truncate text-foreground" title={runtime?.owner}>{runtime?.owner ?? 'Not linked'}</dd>
+                  <dt className="text-muted-foreground">Last success</dt>
+                  <dd className="text-foreground">{runtime?.lastSuccessAt ? formatDate(runtime.lastSuccessAt) : 'No delivery yet'}</dd>
                 </dl>
 
                 {(runtime?.detail || runtime?.lastError) && (
-                  <p className={`mt-4 rounded-lg px-3 py-2 text-[12px] ${runtime.lastError ? 'bg-red/5 text-red' : 'bg-bg-tertiary/55 text-text-muted'}`}>
+                  <p className={`mt-4 rounded-lg px-3 py-2 text-[12px] ${runtime.lastError ? 'bg-destructive/5 text-destructive' : 'bg-muted/55 text-muted-foreground'}`}>
                     {runtime.lastError ?? runtime.detail}
                   </p>
                 )}
@@ -198,7 +198,7 @@ function ConnectorOverview({
                 {!configured && (
                   <button
                     type="button"
-                    className="mt-4 inline-flex items-center gap-1.5 text-[12px] font-medium text-accent hover:underline"
+                    className="mt-4 inline-flex items-center gap-1.5 text-[12px] font-medium text-primary hover:underline"
                     onClick={onConfigure}
                   >
                     Configure {definition.label}
@@ -249,29 +249,29 @@ function adapterPresentation(input: {
   runtimeStatus?: AdapterStatus
 }): { label: string; tone: StatusTone; dot: string } {
   if (!input.serviceEnabled || !input.adapterEnabled) {
-    return { label: 'Off', tone: 'neutral', dot: 'bg-text-muted/30' }
+    return { label: 'Off', tone: 'neutral', dot: 'bg-muted-foreground/30' }
   }
   if (!input.configured) {
-    return { label: 'Needs setup', tone: 'warning', dot: 'bg-yellow-400' }
+    return { label: 'Needs setup', tone: 'warning', dot: 'bg-warning' }
   }
   if (input.runtimeStatus === 'healthy') {
-    return { label: 'Connected', tone: 'healthy', dot: 'bg-green' }
+    return { label: 'Connected', tone: 'healthy', dot: 'bg-success' }
   }
   if (input.runtimeStatus === 'awaiting_link') {
-    return { label: 'Waiting for /link', tone: 'warning', dot: 'bg-yellow-400' }
+    return { label: 'Waiting for /link', tone: 'warning', dot: 'bg-warning' }
   }
   if (input.runtimeStatus === 'degraded' || input.runtimeStatus === 'stopped') {
-    return { label: 'Needs attention', tone: 'danger', dot: 'bg-red' }
+    return { label: 'Needs attention', tone: 'danger', dot: 'bg-destructive' }
   }
-  return { label: 'Starting', tone: 'warning', dot: 'bg-yellow-400' }
+  return { label: 'Starting', tone: 'warning', dot: 'bg-warning' }
 }
 
 function StatusBadge({ tone, children }: { tone: StatusTone; children: string }) {
   const styles: Record<StatusTone, string> = {
-    healthy: 'border-green/20 bg-green/10 text-green',
-    warning: 'border-yellow-400/25 bg-yellow-400/10 text-yellow-600 dark:text-yellow-300',
-    danger: 'border-red/25 bg-red/10 text-red',
-    neutral: 'border-border bg-bg-tertiary text-text-muted',
+    healthy: 'border-success/20 bg-success/10 text-success',
+    warning: 'border-warning/25 bg-warning/10 text-warning',
+    danger: 'border-destructive/25 bg-destructive/10 text-destructive',
+    neutral: 'border-border bg-muted text-muted-foreground',
   }
   return (
     <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${styles[tone]}`}>

--- a/ui/src/pages/ConnectorsPage.tsx
+++ b/ui/src/pages/ConnectorsPage.tsx
@@ -158,7 +158,7 @@ export function ConnectorsPage() {
                 title="Connector Service"
                 description="Independent, Guardian-managed process. Starting a bot below turns this on automatically; this switch is the global kill switch."
               >
-                <label className="flex items-start gap-3 rounded-xl border border-border/70 bg-bg-secondary/35 px-4 py-3">
+                <label className="flex items-start gap-3 rounded-xl border border-border/70 bg-secondary/35 px-4 py-3">
                   <input
                     className="mt-1"
                     type="checkbox"
@@ -166,8 +166,8 @@ export function ConnectorsPage() {
                     onChange={(event) => setConfig({ ...config, serviceEnabled: event.target.checked })}
                   />
                   <span>
-                    <span className="block text-[13px] font-medium text-text">Run external notification connectors</span>
-                    <span className="block mt-0.5 text-[12px] text-text-muted/70">Turning this off stops every bot. Local Inbox remains the source of truth.</span>
+                    <span className="block text-[13px] font-medium text-foreground">Run external notification connectors</span>
+                    <span className="block mt-0.5 text-[12px] text-muted-foreground/70">Turning this off stops every bot. Local Inbox remains the source of truth.</span>
                   </span>
                 </label>
                 <HealthLine health={health} />
@@ -222,7 +222,7 @@ export function ConnectorsPage() {
                                 {field.kind === 'secret' && configured && (
                                   <button
                                     type="button"
-                                    className="shrink-0 rounded-lg border border-border px-3 text-[12px] text-text-muted hover:text-red"
+                                    className="shrink-0 rounded-lg border border-border px-3 text-[12px] text-muted-foreground hover:text-destructive"
                                     onClick={() => setConfig((current) => {
                                       if (!current) return current
                                       const currentAdapter = current.adapters[definition.id]!
@@ -251,7 +251,7 @@ export function ConnectorsPage() {
                       <div className="flex flex-wrap items-center gap-3 border-t border-border/70 pt-4">
                         <button
                           type="button"
-                          className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[13px] text-text hover:border-accent/50 disabled:opacity-50"
+                          className="inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[13px] text-foreground hover:border-primary/50 disabled:opacity-50"
                           disabled={setup.stage !== 'linked' || runtime?.status !== 'healthy' || testing !== null}
                           onClick={() => void test(definition.id)}
                         >
@@ -259,14 +259,14 @@ export function ConnectorsPage() {
                           {testing === definition.id ? 'Sending…' : 'Send test'}
                         </button>
                         {runtime && (
-                          <span className={`text-[12px] ${runtime.status === 'healthy' ? 'text-green' : runtime.status === 'degraded' ? 'text-red' : 'text-text-muted'}`}>
+                          <span className={`text-[12px] ${runtime.status === 'healthy' ? 'text-success' : runtime.status === 'degraded' ? 'text-destructive' : 'text-muted-foreground'}`}>
                             {runtime.status.replace('_', ' ')}{runtime.owner ? ` · owner ${runtime.owner}` : ''}
                           </span>
                         )}
                       </div>
-                      {runtime?.lastError && <p className="text-[12px] text-red">{runtime.lastError}</p>}
+                      {runtime?.lastError && <p className="text-[12px] text-destructive">{runtime.lastError}</p>}
                       {lastProbe?.connectorId === definition.id && (
-                        <p className="text-[12px] text-green">Sent probe <code>{lastProbe.probeId}</code>. Confirm this ID in the private chat.</p>
+                        <p className="text-[12px] text-success">Sent probe <code>{lastProbe.probeId}</code>. Confirm this ID in the private chat.</p>
                       )}
                     </div>
                   </ConfigSection>
@@ -274,8 +274,8 @@ export function ConnectorsPage() {
               })}
             </>
           )}
-          {testError && <p className="mt-4 text-[13px] text-red">{testError}</p>}
-          {loadError && <p className="text-[13px] text-red">Failed to load connector settings.</p>}
+          {testError && <p className="mt-4 text-[13px] text-destructive">{testError}</p>}
+          {loadError && <p className="text-[13px] text-destructive">Failed to load connector settings.</p>}
         </div>
       </div>
     </div>
@@ -309,16 +309,16 @@ function SetupStatePanel({
           <Icon size={18} className={`mt-0.5 shrink-0 ${presentation.iconClass}`} />
           <div>
             <div className="flex flex-wrap items-center gap-2">
-              <p className="text-[13px] font-semibold text-text">{presentation.title}</p>
+              <p className="text-[13px] font-semibold text-foreground">{presentation.title}</p>
               <span className="rounded-full border border-current/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide">
                 {presentation.badge}
               </span>
             </div>
-            <p className="mt-1 max-w-[620px] text-[12px] leading-5 text-text-muted">{presentation.description}</p>
+            <p className="mt-1 max-w-[620px] text-[12px] leading-5 text-muted-foreground">{presentation.description}</p>
             {setup.stage === 'awaiting_link' && (
-              <ol className="mt-3 space-y-1 text-[12px] text-text">
+              <ol className="mt-3 space-y-1 text-[12px] text-foreground">
                 <li>1. Open your private chat with the {definition.label} bot.</li>
-                <li>2. Send <code className="rounded bg-bg px-1.5 py-0.5 font-mono text-accent">{command}</code>.</li>
+                <li>2. Send <code className="rounded bg-background px-1.5 py-0.5 font-mono text-primary">{command}</code>.</li>
                 <li>3. Keep this page open; it will detect the linked owner automatically.</li>
               </ol>
             )}
@@ -328,7 +328,7 @@ function SetupStatePanel({
           {(setup.stage === 'ready_to_link' || setup.stage === 'linked_offline') && (
             <button
               type="button"
-              className="oa-pressable inline-flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-[12px] font-medium text-white hover:bg-accent/90 disabled:opacity-50"
+              className="oa-pressable inline-flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-[12px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
               disabled={saving}
               onClick={onStart}
             >
@@ -339,7 +339,7 @@ function SetupStatePanel({
           {running && (
             <button
               type="button"
-              className="oa-pressable inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[12px] text-text-muted hover:text-text disabled:opacity-50"
+              className="oa-pressable inline-flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-[12px] text-muted-foreground hover:text-foreground disabled:opacity-50"
               disabled={saving}
               onClick={onStop}
             >
@@ -372,8 +372,8 @@ function setupPresentation(
         badge: 'Step 1 · credentials',
         description: 'Add the required bot credentials below. OpenAlice seals secrets locally and never returns them to the browser.',
         icon: Bot,
-        iconClass: 'text-text-muted',
-        container: 'border-border bg-bg-secondary/35',
+        iconClass: 'text-muted-foreground',
+        container: 'border-border bg-secondary/35',
       }
     case 'ready_to_link':
       return {
@@ -381,8 +381,8 @@ function setupPresentation(
         badge: 'Step 2 · not linked',
         description: `Credentials are saved. Start the bot so it can receive ${command} from your private ${label} chat.`,
         icon: Link2,
-        iconClass: 'text-accent',
-        container: 'border-accent/25 bg-accent/5',
+        iconClass: 'text-primary',
+        container: 'border-primary/25 bg-primary/5',
       }
     case 'starting':
       return {
@@ -390,8 +390,8 @@ function setupPresentation(
         badge: 'Starting',
         description: `OpenAlice is starting the ${label} adapter. The ${command} instructions will appear as soon as it is online.`,
         icon: Power,
-        iconClass: 'text-yellow-500',
-        container: 'border-yellow-400/25 bg-yellow-400/5',
+        iconClass: 'text-warning',
+        container: 'border-warning/25 bg-warning/5',
       }
     case 'awaiting_link':
       return {
@@ -399,8 +399,8 @@ function setupPresentation(
         badge: 'Waiting for /link',
         description: `The ${label} bot is running, but no owner is linked yet. Complete the three steps below.`,
         icon: Link2,
-        iconClass: 'text-yellow-500',
-        container: 'border-yellow-400/30 bg-yellow-400/5',
+        iconClass: 'text-warning',
+        container: 'border-warning/30 bg-warning/5',
       }
     case 'linked':
       return {
@@ -408,8 +408,8 @@ function setupPresentation(
         badge: 'Ready',
         description: `The ${label} bot is online${runtime?.owner ? ` for owner ${runtime.owner}` : ''} and can deliver Inbox notifications.`,
         icon: CheckCircle2,
-        iconClass: 'text-green',
-        container: 'border-green/25 bg-green/5',
+        iconClass: 'text-success',
+        container: 'border-success/25 bg-success/5',
       }
     case 'linked_offline':
       return {
@@ -417,8 +417,8 @@ function setupPresentation(
         badge: 'Offline',
         description: `The saved ${label} owner remains linked. Start the connector when you want external Inbox delivery.`,
         icon: Power,
-        iconClass: 'text-text-muted',
-        container: 'border-border bg-bg-secondary/35',
+        iconClass: 'text-muted-foreground',
+        container: 'border-border bg-secondary/35',
       }
     case 'error':
       return {
@@ -426,25 +426,25 @@ function setupPresentation(
         badge: 'Unavailable',
         description: runtime?.lastError ?? runtime?.detail ?? `The ${label} adapter could not start. Check the credentials and Connector logs.`,
         icon: CircleAlert,
-        iconClass: 'text-red',
-        container: 'border-red/30 bg-red/5',
+        iconClass: 'text-destructive',
+        container: 'border-destructive/30 bg-destructive/5',
       }
   }
 }
 
 function HealthLine({ health }: { health: ConnectorHealth | null }) {
   if (!health || health.status === 'disabled') {
-    return <p className="mt-3 flex items-center gap-2 text-[12px] text-text-muted"><ShieldCheck size={14} /> Service stopped</p>
+    return <p className="mt-3 flex items-center gap-2 text-[12px] text-muted-foreground"><ShieldCheck size={14} /> Service stopped</p>
   }
   if (health.status === 'healthy') {
-    return <p className="mt-3 flex items-center gap-2 text-[12px] text-green"><ShieldCheck size={14} /> Service online</p>
+    return <p className="mt-3 flex items-center gap-2 text-[12px] text-success"><ShieldCheck size={14} /> Service online</p>
   }
   return (
-    <div className="mt-3 text-[12px] text-red">
+    <div className="mt-3 text-[12px] text-destructive">
       <p className="flex items-center gap-2">
         <CircleAlert size={14} /> Connector Service unavailable. Alice and Inbox remain online.
       </p>
-      {health.lastError && <p className="ml-[22px] mt-1 text-text-muted/70">{health.lastError}</p>}
+      {health.lastError && <p className="ml-[22px] mt-1 text-muted-foreground/70">{health.lastError}</p>}
     </div>
   )
 }

--- a/ui/src/pages/DesignProjectPage.tsx
+++ b/ui/src/pages/DesignProjectPage.tsx
@@ -9,6 +9,7 @@ import {
   KeyRound,
   LockKeyhole,
   Monitor,
+  Palette,
   ShieldCheck,
   Sparkles,
   TerminalSquare,
@@ -18,6 +19,8 @@ import {
 import type { ReactNode } from 'react'
 
 import { designProjects, getDesignProject, type DesignProject, type DesignVariant } from '../design/projects'
+import { readSemanticColor } from '../theme/semanticColors'
+import { useEffectiveTheme } from '../theme/useEffectiveTheme'
 import type { ViewSpec } from '../tabs/types'
 
 interface DesignProjectPageProps {
@@ -29,6 +32,7 @@ const variantIcons: Record<DesignVariant['layout'], LucideIcon> = {
   'mode-ladder': Gauge,
   'goal-picker': Compass,
   'quiet-checklist': ClipboardList,
+  'semantic-colors': Palette,
 }
 
 export function DesignProjectPage({ spec }: DesignProjectPageProps) {
@@ -39,24 +43,24 @@ export function DesignProjectPage({ spec }: DesignProjectPageProps) {
   }
 
   return (
-    <div className="min-h-full overflow-y-auto bg-bg">
+    <div className="min-h-full overflow-y-auto bg-background">
       <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 px-4 py-5 sm:px-6 lg:px-8">
         <header className="border-b border-border pb-5">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div className="min-w-0">
-              <div className="text-[11px] font-semibold uppercase tracking-wide text-text-muted">
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
                 Hidden design project
               </div>
-              <h1 className="mt-2 text-[28px] font-semibold leading-tight text-text sm:text-[34px]">
+              <h1 className="mt-2 text-[28px] font-semibold leading-tight text-foreground sm:text-[34px]">
                 {project.title}
               </h1>
-              <div className="mt-3 flex flex-wrap items-center gap-2 text-[12px] text-text-muted">
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[12px] text-muted-foreground">
                 <InfoPill>{project.eyebrow}</InfoPill>
                 <InfoPill>{project.status}</InfoPill>
                 <InfoPill>Updated {project.updatedAt}</InfoPill>
               </div>
             </div>
-            <code className="w-fit max-w-full overflow-x-auto rounded-md border border-border bg-bg-secondary px-3 py-2 font-mono text-[12px] text-text-muted">
+            <code className="w-fit max-w-full overflow-x-auto rounded-md border border-border bg-secondary px-3 py-2 font-mono text-[12px] text-muted-foreground">
               /design/{project.slug}
             </code>
           </div>
@@ -68,12 +72,12 @@ export function DesignProjectPage({ spec }: DesignProjectPageProps) {
           <main className="min-w-0">
             <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <h2 className="text-[20px] font-semibold text-text">Versions</h2>
-                <p className="mt-1 max-w-[720px] text-[13px] leading-relaxed text-text-muted">
+                <h2 className="text-[20px] font-semibold text-foreground">Versions</h2>
+                <p className="mt-1 max-w-[720px] text-[13px] leading-relaxed text-muted-foreground">
                   Side-by-side sketches for the same project brief. These are internal drafts, not routes users discover from the app shell.
                 </p>
               </div>
-              <div className="text-[12px] text-text-muted">
+              <div className="text-[12px] text-muted-foreground">
                 {project.variants.length} drafts
               </div>
             </div>
@@ -92,23 +96,23 @@ export function DesignProjectPage({ spec }: DesignProjectPageProps) {
 
 function UnknownDesignProject({ slug }: { slug: string }) {
   return (
-    <div className="flex min-h-full items-center justify-center bg-bg px-4 py-10">
-      <div className="w-full max-w-[620px] rounded-lg border border-border bg-bg-secondary px-5 py-5">
+    <div className="flex min-h-full items-center justify-center bg-background px-4 py-10">
+      <div className="w-full max-w-[620px] rounded-lg border border-border bg-secondary px-5 py-5">
         <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-bg-tertiary text-text-muted">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
             <Monitor className="h-5 w-5" />
           </div>
           <div className="min-w-0">
-            <h1 className="text-[20px] font-semibold text-text">Design project not found</h1>
-            <p className="mt-2 text-[13px] leading-relaxed text-text-muted">
-              No project is registered for <code className="font-mono text-text">{slug}</code>. Add it to the design project registry before opening the route.
+            <h1 className="text-[20px] font-semibold text-foreground">Design project not found</h1>
+            <p className="mt-2 text-[13px] leading-relaxed text-muted-foreground">
+              No project is registered for <code className="font-mono text-foreground">{slug}</code>. Add it to the design project registry before opening the route.
             </p>
             <div className="mt-4 grid gap-2">
               {designProjects.map((project) => (
                 <a
                   key={project.slug}
                   href={`/design/${project.slug}`}
-                  className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border bg-bg px-3 py-2 text-[13px] text-text-muted transition-colors hover:border-accent/50 hover:text-accent"
+                  className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2 text-[13px] text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
                 >
                   <span className="min-w-0 truncate">{project.title}</span>
                   <ChevronRight className="h-4 w-4 shrink-0" />
@@ -124,10 +128,10 @@ function UnknownDesignProject({ slug }: { slug: string }) {
 
 function ProjectBrief({ project }: { project: DesignProject }) {
   return (
-    <aside className="min-w-0 rounded-lg border border-border bg-bg-secondary/55 p-4 md:sticky md:top-5 md:self-start">
+    <aside className="min-w-0 rounded-lg border border-border bg-secondary/55 p-4 md:sticky md:top-5 md:self-start">
       <div>
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-text-muted">Context</div>
-        <p className="mt-3 text-[13px] leading-relaxed text-text-muted">{project.context.why}</p>
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Context</div>
+        <p className="mt-3 text-[13px] leading-relaxed text-muted-foreground">{project.context.why}</p>
       </div>
 
       <BriefList title="Goals" icon={CheckCircle2} items={project.context.goals} />
@@ -141,15 +145,15 @@ function BriefList({ title, icon: Icon, items }: { title: string; icon: LucideIc
   return (
     <section className="mt-4 border-t border-border pt-4">
       <div className="flex items-center gap-2">
-        <div className="flex h-7 w-7 items-center justify-center rounded-md bg-bg-tertiary text-text-muted">
+        <div className="flex h-7 w-7 items-center justify-center rounded-md bg-muted text-muted-foreground">
           <Icon className="h-3.5 w-3.5" />
         </div>
-        <h2 className="text-[14px] font-semibold text-text">{title}</h2>
+        <h2 className="text-[14px] font-semibold text-foreground">{title}</h2>
       </div>
       <ul className="mt-3 space-y-2">
         {items.map((item) => (
-          <li key={item} className="grid grid-cols-[auto_minmax(0,1fr)] gap-2 text-[12px] leading-relaxed text-text-muted">
-            <span className="mt-[7px] h-1 w-1 rounded-full bg-text-muted" aria-hidden />
+          <li key={item} className="grid grid-cols-[auto_minmax(0,1fr)] gap-2 text-[12px] leading-relaxed text-muted-foreground">
+            <span className="mt-[7px] h-1 w-1 rounded-full bg-muted-foreground" aria-hidden />
             <span>{item}</span>
           </li>
         ))}
@@ -161,23 +165,23 @@ function BriefList({ title, icon: Icon, items }: { title: string; icon: LucideIc
 function VersionPreview({ variant }: { variant: DesignVariant }) {
   const Icon = variantIcons[variant.layout]
   return (
-    <section className="min-w-0 overflow-hidden rounded-lg border border-border bg-bg-secondary/45">
+    <section className="min-w-0 overflow-hidden rounded-lg border border-border bg-secondary/45">
       <div className="border-b border-border px-4 py-3">
         <div className="flex min-w-0 items-start gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent-dim text-accent">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary-muted text-primary">
             <Icon className="h-4 w-4" />
           </div>
           <div className="min-w-0">
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-              <span className="text-[11px] font-semibold uppercase tracking-wide text-accent">Draft {variant.id}</span>
-              <h3 className="text-[16px] font-semibold text-text">{variant.name}</h3>
+              <span className="text-[11px] font-semibold uppercase tracking-wide text-primary">Draft {variant.id}</span>
+              <h3 className="text-[16px] font-semibold text-foreground">{variant.name}</h3>
             </div>
-            <p className="mt-1 text-[12px] leading-relaxed text-text-muted">{variant.summary}</p>
+            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">{variant.summary}</p>
           </div>
         </div>
       </div>
 
-      <div className="bg-bg px-3 py-3 sm:px-4">
+      <div className="bg-background px-3 py-3 sm:px-4">
         <DesignCanvas variant={variant} />
       </div>
 
@@ -192,31 +196,160 @@ function VersionPreview({ variant }: { variant: DesignVariant }) {
 function VersionNote({ label, text }: { label: string; text: string }) {
   return (
     <div className="min-w-0">
-      <div className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">{label}</div>
-      <p className="mt-1 text-[12px] leading-relaxed text-text-muted">{text}</p>
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</div>
+      <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">{text}</p>
     </div>
   )
 }
 
 function DesignCanvas({ variant }: { variant: DesignVariant }) {
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-bg-secondary">
-      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border bg-bg-tertiary/55 px-3 py-2">
+    <div className="overflow-hidden rounded-lg border border-border bg-secondary">
+      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border bg-muted/55 px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="h-2.5 w-2.5 rounded-full bg-red/70" aria-hidden />
-          <span className="h-2.5 w-2.5 rounded-full bg-yellow-400/70" aria-hidden />
-          <span className="h-2.5 w-2.5 rounded-full bg-green/70" aria-hidden />
-          <span className="ml-1 truncate font-mono text-[10px] text-text-muted">first-run-guide/{variant.id.toLowerCase()}</span>
+          <span className="h-2.5 w-2.5 rounded-full bg-destructive/70" aria-hidden />
+          <span className="h-2.5 w-2.5 rounded-full bg-warning/70" aria-hidden />
+          <span className="h-2.5 w-2.5 rounded-full bg-success/70" aria-hidden />
+          <span className="ml-1 truncate font-mono text-[10px] text-muted-foreground">{variant.layout}/{variant.id.toLowerCase()}</span>
         </div>
-        <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-text-muted">Desktop sketch</span>
+        <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {variant.layout === 'semantic-colors' ? 'Live palette' : 'Desktop sketch'}
+        </span>
       </div>
       <div className="min-h-[330px] p-4">
         {variant.layout === 'safe-launch' ? <SafeLaunchMock /> : null}
         {variant.layout === 'mode-ladder' ? <ModeLadderMock /> : null}
         {variant.layout === 'goal-picker' ? <GoalPickerMock /> : null}
         {variant.layout === 'quiet-checklist' ? <QuietChecklistMock /> : null}
+        {variant.layout === 'semantic-colors' ? <SemanticColorCard /> : null}
       </div>
     </div>
+  )
+}
+
+const CORE_COLOR_TOKENS = [
+  'background',
+  'foreground',
+  'card',
+  'card-foreground',
+  'popover',
+  'popover-foreground',
+  'primary',
+  'primary-foreground',
+  'secondary',
+  'secondary-foreground',
+  'muted',
+  'muted-foreground',
+  'accent',
+  'accent-foreground',
+  'destructive',
+  'destructive-foreground',
+  'border',
+  'input',
+  'ring',
+] as const
+
+const PRODUCT_COLOR_TOKENS = [
+  'success',
+  'success-foreground',
+  'warning',
+  'warning-foreground',
+  'info',
+  'info-foreground',
+  'ai-action',
+  'ai-action-foreground',
+  'primary-muted',
+  'accent-strong',
+  'warning-background',
+  'warning-border',
+  'backdrop',
+  'code-background',
+  'report-canvas',
+  'shadow-color',
+  'app-background-wash',
+] as const
+
+const SIDEBAR_COLOR_TOKENS = [
+  'sidebar',
+  'sidebar-foreground',
+  'sidebar-primary',
+  'sidebar-primary-foreground',
+  'sidebar-accent',
+  'sidebar-accent-foreground',
+  'sidebar-border',
+  'sidebar-ring',
+] as const
+
+const CHART_COLOR_TOKENS = [
+  'chart-1',
+  'chart-2',
+  'chart-3',
+  'chart-4',
+  'chart-5',
+  'chart-positive',
+  'chart-negative',
+  'chart-positive-muted',
+  'chart-negative-muted',
+  'chart-axis',
+  'chart-grid',
+] as const
+
+function SemanticColorCard() {
+  const effectiveTheme = useEffectiveTheme()
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <div className="text-[13px] font-semibold text-foreground">Resolved semantic tokens</div>
+          <div className="mt-1 text-[11px] text-muted-foreground">Reading the live {effectiveTheme} palette from palette.css</div>
+        </div>
+        <span className="rounded-full border border-border bg-secondary px-2 py-1 text-[10px] font-medium text-muted-foreground">
+          {effectiveTheme}
+        </span>
+      </div>
+
+      <ColorTokenGroup title="Orca / shadcn core" tokens={CORE_COLOR_TOKENS} />
+      <ColorTokenGroup title="OpenAlice extensions" tokens={PRODUCT_COLOR_TOKENS} />
+      <ColorTokenGroup title="Sidebar projection" tokens={SIDEBAR_COLOR_TOKENS} />
+      <ColorTokenGroup title="Data visualization" tokens={CHART_COLOR_TOKENS} />
+
+      <section>
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Pairing smoke test</div>
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+          <button type="button" className="rounded-md bg-primary px-3 py-2 text-[11px] font-medium text-primary-foreground">Primary action</button>
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-[11px] text-destructive">Destructive state</div>
+          <div className="rounded-md border border-success/30 bg-success/10 px-3 py-2 text-[11px] text-success">Successful state</div>
+          <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning">Warning state</div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function ColorTokenGroup({ title, tokens }: { title: string; tokens: readonly string[] }) {
+  return (
+    <section>
+      <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</div>
+      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+        {tokens.map((token) => {
+          const value = readSemanticColor(token)
+          return (
+            <div key={token} className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-background p-2">
+              <span
+                className="h-8 w-8 shrink-0 rounded border border-border shadow-sm"
+                style={{ background: `var(--${token})` }}
+                aria-hidden
+              />
+              <span className="min-w-0">
+                <code className="block truncate text-[10px] font-medium text-foreground">--{token}</code>
+                <code className="mt-0.5 block truncate text-[9px] text-muted-foreground" title={value}>{value}</code>
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </section>
   )
 }
 
@@ -224,14 +357,14 @@ function SafeLaunchMock() {
   return (
     <div className="grid h-full min-h-[300px] min-w-0 gap-5 lg:grid-cols-[minmax(0,1fr)_230px] lg:items-center">
       <div className="min-w-0">
-        <div className="inline-flex items-center gap-2 rounded-md border border-green/30 bg-green/10 px-2.5 py-1 text-[11px] font-semibold text-green">
+        <div className="inline-flex items-center gap-2 rounded-md border border-success/30 bg-success/10 px-2.5 py-1 text-[11px] font-semibold text-success">
           <ShieldCheck className="h-3.5 w-3.5" />
           Safe start
         </div>
-        <h4 className="mt-5 max-w-[520px] text-[34px] font-semibold leading-[1.05] text-text">
+        <h4 className="mt-5 max-w-[520px] text-[34px] font-semibold leading-[1.05] text-foreground">
           Start in Lite. Add brokers when you need them.
         </h4>
-        <p className="mt-4 max-w-[560px] text-[14px] leading-relaxed text-text-muted">
+        <p className="mt-4 max-w-[560px] text-[14px] leading-relaxed text-muted-foreground">
           Alice can research, explain, and help you build workspaces before any trading system is connected.
         </p>
         <div className="mt-6 flex flex-wrap gap-2">
@@ -239,7 +372,7 @@ function SafeLaunchMock() {
           <MockButton>Continue setup</MockButton>
         </div>
       </div>
-      <div className="min-w-0 rounded-lg border border-border bg-bg px-3 py-3">
+      <div className="min-w-0 rounded-lg border border-border bg-background px-3 py-3">
         <MockStatusRow icon={Bot} label="Alice" value="Ready" state="ok" />
         <MockStatusRow icon={WalletCards} label="UTA" value="Off" />
         <MockStatusRow icon={LockKeyhole} label="Broker writes" value="Blocked" state="ok" />
@@ -257,8 +390,8 @@ function ModeLadderMock() {
   return (
     <div className="flex min-h-[300px] min-w-0 flex-col justify-center gap-5">
       <div>
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-text-muted">Choose the level of access</div>
-        <h4 className="mt-2 text-[28px] font-semibold leading-tight text-text">OpenAlice starts with brokers disconnected.</h4>
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Choose the level of access</div>
+        <h4 className="mt-2 text-[28px] font-semibold leading-tight text-foreground">OpenAlice starts with brokers disconnected.</h4>
       </div>
       <div className="grid gap-2 md:grid-cols-3">
         {modes.map((mode) => (
@@ -266,24 +399,24 @@ function ModeLadderMock() {
             key={mode.name}
             className={`min-w-0 rounded-lg border px-3 py-3 ${
               mode.active
-                ? 'border-accent bg-accent-dim text-text'
-                : 'border-border bg-bg text-text-muted'
+                ? 'border-primary bg-primary-muted text-foreground'
+                : 'border-border bg-background text-muted-foreground'
             }`}
           >
             <div className="flex items-center justify-between gap-2">
               <span className="text-[15px] font-semibold">{mode.name}</span>
-              {mode.active ? <CheckCircle2 className="h-4 w-4 text-accent" /> : null}
+              {mode.active ? <CheckCircle2 className="h-4 w-4 text-primary" /> : null}
             </div>
             <p className="mt-2 text-[12px] leading-relaxed">{mode.text}</p>
           </div>
         ))}
       </div>
-      <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-border bg-bg px-3 py-3">
+      <div className="flex min-w-0 items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-3">
         <div className="min-w-0">
-          <div className="text-[13px] font-semibold text-text">Next useful step</div>
-          <p className="mt-1 text-[12px] text-text-muted">Connect an AI provider, then decide whether UTA should stay off.</p>
+          <div className="text-[13px] font-semibold text-foreground">Next useful step</div>
+          <p className="mt-1 text-[12px] text-muted-foreground">Connect an AI provider, then decide whether UTA should stay off.</p>
         </div>
-        <ArrowRight className="h-4 w-4 shrink-0 text-accent" />
+        <ArrowRight className="h-4 w-4 shrink-0 text-primary" />
       </div>
     </div>
   )
@@ -298,8 +431,8 @@ function GoalPickerMock() {
   return (
     <div className="flex min-h-[300px] min-w-0 flex-col justify-center gap-5">
       <div className="max-w-[620px]">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-text-muted">What do you want first?</div>
-        <h4 className="mt-2 text-[30px] font-semibold leading-tight text-text">Pick a starting point. Alice will only ask for what that path needs.</h4>
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">What do you want first?</div>
+        <h4 className="mt-2 text-[30px] font-semibold leading-tight text-foreground">Pick a starting point. Alice will only ask for what that path needs.</h4>
       </div>
       <div className="grid gap-2 md:grid-cols-3">
         {goals.map((goal, index) => {
@@ -308,17 +441,17 @@ function GoalPickerMock() {
             <div
               key={goal.title}
               className={`min-w-0 rounded-lg border px-3 py-3 ${
-                index === 0 ? 'border-accent bg-accent-dim' : 'border-border bg-bg'
+                index === 0 ? 'border-primary bg-primary-muted' : 'border-border bg-background'
               }`}
             >
               <div className="flex items-center justify-between gap-2">
-                <Icon className={index === 0 ? 'h-4 w-4 text-accent' : 'h-4 w-4 text-text-muted'} />
-                <span className="rounded-md border border-border bg-bg-secondary px-2 py-0.5 text-[10px] font-semibold text-text-muted">
+                <Icon className={index === 0 ? 'h-4 w-4 text-primary' : 'h-4 w-4 text-muted-foreground'} />
+                <span className="rounded-md border border-border bg-secondary px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
                   {goal.badge}
                 </span>
               </div>
-              <div className="mt-4 text-[15px] font-semibold text-text">{goal.title}</div>
-              <p className="mt-2 text-[12px] leading-relaxed text-text-muted">{goal.body}</p>
+              <div className="mt-4 text-[15px] font-semibold text-foreground">{goal.title}</div>
+              <p className="mt-2 text-[12px] leading-relaxed text-muted-foreground">{goal.body}</p>
             </div>
           )
         })}
@@ -336,9 +469,9 @@ function QuietChecklistMock() {
   return (
     <div className="grid min-h-[300px] min-w-0 gap-5 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-center">
       <div className="min-w-0">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-text-muted">Welcome</div>
-        <h4 className="mt-2 text-[30px] font-semibold leading-tight text-text">Alice is open. Finish setup at your own pace.</h4>
-        <p className="mt-4 max-w-[560px] text-[13px] leading-relaxed text-text-muted">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Welcome</div>
+        <h4 className="mt-2 text-[30px] font-semibold leading-tight text-foreground">Alice is open. Finish setup at your own pace.</h4>
+        <p className="mt-4 max-w-[560px] text-[13px] leading-relaxed text-muted-foreground">
           The opening guide stays short, then hands durable tasks to the setup checklist.
         </p>
         <div className="mt-6 flex flex-wrap gap-2">
@@ -346,19 +479,19 @@ function QuietChecklistMock() {
           <MockButton>Open checklist</MockButton>
         </div>
       </div>
-      <div className="min-w-0 rounded-lg border border-border bg-bg px-3 py-3">
+      <div className="min-w-0 rounded-lg border border-border bg-background px-3 py-3">
         {tasks.map((task) => {
           const Icon = task.icon
           return (
             <div key={task.title} className="grid grid-cols-[auto_minmax(0,1fr)_auto] gap-3 border-b border-border py-3 last:border-b-0">
-              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-bg-tertiary text-text-muted">
+              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-muted-foreground">
                 <Icon className="h-4 w-4" />
               </div>
               <div className="min-w-0">
-                <div className="text-[13px] font-semibold text-text">{task.title}</div>
-                <div className="mt-0.5 text-[12px] text-text-muted">{task.body}</div>
+                <div className="text-[13px] font-semibold text-foreground">{task.title}</div>
+                <div className="mt-0.5 text-[12px] text-muted-foreground">{task.body}</div>
               </div>
-              <CheckCircle2 className={`mt-1 h-4 w-4 ${task.done ? 'text-green' : 'text-text-muted'}`} />
+              <CheckCircle2 className={`mt-1 h-4 w-4 ${task.done ? 'text-success' : 'text-muted-foreground'}`} />
             </div>
           )
         })}
@@ -370,11 +503,11 @@ function QuietChecklistMock() {
 function MockStatusRow({ icon: Icon, label, value, state }: { icon: LucideIcon; label: string; value: string; state?: 'ok' }) {
   return (
     <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border-b border-border py-3 last:border-b-0">
-      <div className="flex h-8 w-8 items-center justify-center rounded-md bg-bg-tertiary text-text-muted">
+      <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-muted-foreground">
         <Icon className="h-4 w-4" />
       </div>
-      <div className="min-w-0 text-[13px] font-semibold text-text">{label}</div>
-      <div className={state === 'ok' ? 'text-[12px] font-semibold text-green' : 'text-[12px] font-semibold text-text-muted'}>
+      <div className="min-w-0 text-[13px] font-semibold text-foreground">{label}</div>
+      <div className={state === 'ok' ? 'text-[12px] font-semibold text-success' : 'text-[12px] font-semibold text-muted-foreground'}>
         {value}
       </div>
     </div>
@@ -387,8 +520,8 @@ function MockButton({ children, primary = false }: { children: string; primary?:
       type="button"
       className={`inline-flex min-h-9 items-center justify-center gap-2 rounded-md px-3.5 py-2 text-[13px] font-semibold ${
         primary
-          ? 'bg-accent text-white'
-          : 'border border-border bg-bg text-text-muted'
+          ? 'bg-primary text-primary-foreground'
+          : 'border border-border bg-background text-muted-foreground'
       }`}
     >
       {children}
@@ -399,7 +532,7 @@ function MockButton({ children, primary = false }: { children: string; primary?:
 
 function InfoPill({ children }: { children: ReactNode }) {
   return (
-    <span className="inline-flex min-h-6 items-center rounded-md border border-border bg-bg-secondary px-2 text-[11px] font-medium text-text-muted">
+    <span className="inline-flex min-h-6 items-center rounded-md border border-border bg-secondary px-2 text-[11px] font-medium text-muted-foreground">
       {children}
     </span>
   )

--- a/ui/src/pages/DevPage.tsx
+++ b/ui/src/pages/DevPage.tsx
@@ -105,11 +105,11 @@ function SnapshotsTab() {
       <div className="max-w-[900px] space-y-4">
         {/* Account selector */}
         <div className="flex items-center gap-3">
-          <label className="text-[13px] text-text-muted">Account:</label>
+          <label className="text-[13px] text-muted-foreground">Account:</label>
           <select
             value={selectedAccount}
             onChange={e => setSelectedAccount(e.target.value)}
-            className="text-[13px] px-2 py-1.5 rounded-md border border-border bg-bg text-text"
+            className="text-[13px] px-2 py-1.5 rounded-md border border-border bg-background text-foreground"
           >
             {accounts.map(a => (
               <option key={a.id} value={a.id}>{a.label} ({a.id})</option>
@@ -117,11 +117,11 @@ function SnapshotsTab() {
           </select>
           <button
             onClick={loadSnapshots}
-            className="text-[13px] px-2.5 py-1.5 rounded-md border border-border hover:bg-bg-tertiary transition-colors text-text-muted"
+            className="text-[13px] px-2.5 py-1.5 rounded-md border border-border hover:bg-muted transition-colors text-muted-foreground"
           >
             Refresh
           </button>
-          <span className="text-[11px] text-text-muted/50">{snapshots.length} snapshots</span>
+          <span className="text-[11px] text-muted-foreground/50">{snapshots.length} snapshots</span>
         </div>
 
         {/* Snapshots table */}
@@ -133,7 +133,7 @@ function SnapshotsTab() {
           <div className="border border-border rounded-lg overflow-hidden">
             <table className="w-full text-[13px]">
               <thead>
-                <tr className="bg-bg-secondary text-text-muted text-left text-[11px] uppercase tracking-wide">
+                <tr className="bg-secondary text-muted-foreground text-left text-[11px] uppercase tracking-wide">
                   <th className="px-3 py-2 font-medium">Timestamp</th>
                   <th className="px-3 py-2 font-medium">Trigger</th>
                   <th className="px-3 py-2 font-medium text-center">Health</th>
@@ -168,41 +168,41 @@ function SnapshotRow({ snapshot: s, expanded, onToggle, onDelete }: {
   onDelete: () => void
 }) {
   const [confirming, setConfirming] = useState(false)
-  const healthColor = s.health === 'healthy' ? 'bg-green' : s.health === 'degraded' ? 'bg-yellow-400' : 'bg-red'
+  const healthColor = s.health === 'healthy' ? 'bg-success' : s.health === 'degraded' ? 'bg-warning' : 'bg-destructive'
 
   return (
     <>
       <tr
-        className="border-t border-border hover:bg-bg-tertiary/30 transition-colors cursor-pointer"
+        className="border-t border-border hover:bg-muted/30 transition-colors cursor-pointer"
         onClick={onToggle}
       >
-        <td className="px-3 py-2 font-mono text-[11px] text-text">
+        <td className="px-3 py-2 font-mono text-[11px] text-foreground">
           {new Date(s.timestamp).toLocaleString()}
         </td>
         <td className="px-3 py-2">
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted">{s.trigger}</span>
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{s.trigger}</span>
         </td>
         <td className="px-3 py-2 text-center">
           <div className={`w-2 h-2 rounded-full ${healthColor} mx-auto`} />
         </td>
-        <td className="px-3 py-2 text-right text-text">{s.positions.length}</td>
-        <td className="px-3 py-2 text-right text-text tabular-nums">
+        <td className="px-3 py-2 text-right text-foreground">{s.positions.length}</td>
+        <td className="px-3 py-2 text-right text-foreground tabular-nums">
           ${Number(s.account.netLiquidation).toLocaleString(getIntlLocale(), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
         </td>
         <td className="px-3 py-2 text-right" onClick={e => e.stopPropagation()}>
           {confirming ? (
             <div className="flex gap-1 justify-end">
-              <button onClick={onDelete} className="text-[11px] px-2 py-0.5 rounded bg-red/15 text-red hover:bg-red/25 transition-colors">
+              <button onClick={onDelete} className="text-[11px] px-2 py-0.5 rounded bg-destructive/15 text-destructive hover:bg-destructive/25 transition-colors">
                 Confirm
               </button>
-              <button onClick={() => setConfirming(false)} className="text-[11px] px-2 py-0.5 rounded bg-bg-tertiary text-text-muted hover:bg-bg-tertiary/80 transition-colors">
+              <button onClick={() => setConfirming(false)} className="text-[11px] px-2 py-0.5 rounded bg-muted text-muted-foreground hover:bg-muted/80 transition-colors">
                 Cancel
               </button>
             </div>
           ) : (
             <button
               onClick={() => setConfirming(true)}
-              className="text-[11px] px-2 py-0.5 rounded text-text-muted hover:text-red hover:bg-red/10 transition-colors"
+              className="text-[11px] px-2 py-0.5 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
             >
               Delete
             </button>
@@ -211,19 +211,19 @@ function SnapshotRow({ snapshot: s, expanded, onToggle, onDelete }: {
       </tr>
       {expanded && (
         <tr className="border-t border-border/50">
-          <td colSpan={6} className="px-3 py-3 bg-bg-secondary/50">
+          <td colSpan={6} className="px-3 py-3 bg-secondary/50">
             <div className="space-y-2">
               {/* Account metrics */}
               <div className="flex gap-4 text-[11px]">
-                <span className="text-text-muted">Cash: <span className="text-text">${Number(s.account.totalCashValue).toLocaleString(getIntlLocale(), { minimumFractionDigits: 2 })}</span></span>
-                <span className="text-text-muted">Unrealized PnL: <span className={Number(s.account.unrealizedPnL) >= 0 ? 'text-green' : 'text-red'}>{Number(s.account.unrealizedPnL) >= 0 ? '+' : ''}${Number(s.account.unrealizedPnL).toLocaleString(getIntlLocale(), { minimumFractionDigits: 2 })}</span></span>
-                {s.account.baseCurrency && <span className="text-text-muted">Base: <span className="text-text">{s.account.baseCurrency}</span></span>}
+                <span className="text-muted-foreground">Cash: <span className="text-foreground">${Number(s.account.totalCashValue).toLocaleString(getIntlLocale(), { minimumFractionDigits: 2 })}</span></span>
+                <span className="text-muted-foreground">Unrealized PnL: <span className={Number(s.account.unrealizedPnL) >= 0 ? 'text-success' : 'text-destructive'}>{Number(s.account.unrealizedPnL) >= 0 ? '+' : ''}${Number(s.account.unrealizedPnL).toLocaleString(getIntlLocale(), { minimumFractionDigits: 2 })}</span></span>
+                {s.account.baseCurrency && <span className="text-muted-foreground">Base: <span className="text-foreground">{s.account.baseCurrency}</span></span>}
               </div>
               {/* Positions detail */}
               {s.positions.length > 0 && (
                 <table className="w-full text-[11px]">
                   <thead>
-                    <tr className="text-text-muted text-left">
+                    <tr className="text-muted-foreground text-left">
                       <th className="pr-3 pb-1 font-medium">Symbol</th>
                       <th className="pr-3 pb-1 font-medium text-center">Ccy</th>
                       <th className="pr-3 pb-1 font-medium text-right">Qty</th>
@@ -238,14 +238,14 @@ function SnapshotRow({ snapshot: s, expanded, onToggle, onDelete }: {
                       const sym = p.aliceId.split('|').pop() ?? p.aliceId
                       const pnl = Number(p.unrealizedPnL)
                       return (
-                        <tr key={j} className="text-text">
+                        <tr key={j} className="text-foreground">
                           <td className="pr-3 py-0.5 font-medium">{sym}</td>
-                          <td className="pr-3 py-0.5 text-center text-text-muted">{p.currency}</td>
+                          <td className="pr-3 py-0.5 text-center text-muted-foreground">{p.currency}</td>
                           <td className="pr-3 py-0.5 text-right tabular-nums">{p.quantity}</td>
-                          <td className="pr-3 py-0.5 text-right tabular-nums text-text-muted">{Number(p.avgCost).toFixed(2)}</td>
+                          <td className="pr-3 py-0.5 text-right tabular-nums text-muted-foreground">{Number(p.avgCost).toFixed(2)}</td>
                           <td className="pr-3 py-0.5 text-right tabular-nums">{Number(p.marketPrice).toFixed(2)}</td>
                           <td className="pr-3 py-0.5 text-right tabular-nums">{Number(p.marketValue).toFixed(2)}</td>
-                          <td className={`pr-3 py-0.5 text-right tabular-nums font-medium ${pnl >= 0 ? 'text-green' : 'text-red'}`}>
+                          <td className={`pr-3 py-0.5 text-right tabular-nums font-medium ${pnl >= 0 ? 'text-success' : 'text-destructive'}`}>
                             {pnl >= 0 ? '+' : ''}{pnl.toFixed(2)}
                           </td>
                         </tr>
@@ -255,7 +255,7 @@ function SnapshotRow({ snapshot: s, expanded, onToggle, onDelete }: {
                 </table>
               )}
               {s.positions.length === 0 && (
-                <p className="text-[11px] text-text-muted">No positions in this snapshot.</p>
+                <p className="text-[11px] text-muted-foreground">No positions in this snapshot.</p>
               )}
             </div>
           </td>
@@ -331,7 +331,7 @@ function ToolsTab() {
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             placeholder="Filter tools..."
-            className="w-full px-2.5 py-1.5 bg-bg text-text border border-border rounded-md text-xs outline-none focus:border-accent"
+            className="w-full px-2.5 py-1.5 bg-background text-foreground border border-border rounded-md text-xs outline-none focus:border-primary"
           />
         </div>
         <div className="flex-1 overflow-y-auto px-1 pb-3">
@@ -339,11 +339,11 @@ function ToolsTab() {
             <div key={group} className="mb-1">
               <button
                 onClick={() => toggleGroup(group)}
-                className="w-full flex items-center gap-1.5 px-2 py-1 text-xs text-text-muted hover:text-text transition-colors"
+                className="w-full flex items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
                 <span className="text-[10px]">{expandedGroups.has(group) ? '\u25BC' : '\u25B6'}</span>
                 <span className="font-semibold uppercase tracking-wider">{group}</span>
-                <span className="text-text-muted/50">({tools.length})</span>
+                <span className="text-muted-foreground/50">({tools.length})</span>
               </button>
               {expandedGroups.has(group) && (
                 <div className="ml-2">
@@ -353,8 +353,8 @@ function ToolsTab() {
                       onClick={() => selectTool(t.name)}
                       className={`w-full text-left px-2 py-1 text-xs rounded transition-colors ${
                         selected === t.name
-                          ? 'bg-accent/10 text-accent'
-                          : 'text-text hover:bg-bg-tertiary/50'
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-foreground hover:bg-muted/50'
                       }`}
                     >
                       {t.name}
@@ -370,7 +370,7 @@ function ToolsTab() {
       {/* Right: Detail + Execute + Result (independent scroll) */}
       <div className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
         {!selected ? (
-          <div className="flex items-center justify-center h-full text-text-muted text-sm">
+          <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
             Select a tool from the left panel.
           </div>
         ) : loadingDetail ? (
@@ -378,7 +378,7 @@ function ToolsTab() {
         ) : detail ? (
           <ToolExecutePanel detail={detail} result={result} onResult={setResult} />
         ) : (
-          <p className="text-sm text-text-muted">Failed to load tool details.</p>
+          <p className="text-sm text-muted-foreground">Failed to load tool details.</p>
         )}
       </div>
     </div>
@@ -472,27 +472,27 @@ function ToolExecutePanel({ detail, result, onResult }: ToolExecutePanelProps) {
     <div className="space-y-5">
       {/* Header */}
       <div>
-        <h2 className="text-base font-semibold text-text">{detail.name}</h2>
-        {detail.group && <span className="text-xs text-text-muted uppercase tracking-wider">{detail.group}</span>}
-        <p className="text-sm text-text-muted mt-1">{detail.description}</p>
+        <h2 className="text-base font-semibold text-foreground">{detail.name}</h2>
+        {detail.group && <span className="text-xs text-muted-foreground uppercase tracking-wider">{detail.group}</span>}
+        <p className="text-sm text-muted-foreground mt-1">{detail.description}</p>
       </div>
 
       {/* Input form */}
       {properties.length > 0 && (
         <div className="space-y-3">
-          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">Input</h3>
+          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Input</h3>
           {properties.map((prop) => (
             <div key={prop.key}>
-              <label className="flex items-center gap-1.5 text-[13px] text-text mb-1">
+              <label className="flex items-center gap-1.5 text-[13px] text-foreground mb-1">
                 <span className="font-mono">{prop.key}</span>
-                <span className="text-[10px] text-text-muted/60">{prop.type}</span>
-                {prop.required && <span className="text-[10px] text-accent/70">required</span>}
+                <span className="text-[10px] text-muted-foreground/60">{prop.type}</span>
+                {prop.required && <span className="text-[10px] text-primary/70">required</span>}
               </label>
               {prop.type === 'boolean' ? (
                 <select
                   value={inputs[prop.key] ?? ''}
                   onChange={(e) => setInputs((prev) => ({ ...prev, [prop.key]: e.target.value }))}
-                  className="px-2.5 py-1.5 bg-bg text-text border border-border rounded-md text-xs outline-none focus:border-accent"
+                  className="px-2.5 py-1.5 bg-background text-foreground border border-border rounded-md text-xs outline-none focus:border-primary"
                 >
                   <option value="">-</option>
                   <option value="true">true</option>
@@ -504,11 +504,11 @@ function ToolExecutePanel({ detail, result, onResult }: ToolExecutePanelProps) {
                   value={inputs[prop.key] ?? ''}
                   onChange={(e) => setInputs((prev) => ({ ...prev, [prop.key]: e.target.value }))}
                   placeholder={prop.description || prop.key}
-                  className="w-full px-2.5 py-1.5 bg-bg text-text border border-border rounded-md text-xs font-mono outline-none focus:border-accent"
+                  className="w-full px-2.5 py-1.5 bg-background text-foreground border border-border rounded-md text-xs font-mono outline-none focus:border-primary"
                 />
               )}
               {prop.description && (
-                <p className="text-[11px] text-text-muted/60 mt-0.5">{prop.description}</p>
+                <p className="text-[11px] text-muted-foreground/60 mt-0.5">{prop.description}</p>
               )}
             </div>
           ))}
@@ -528,12 +528,12 @@ function ToolExecutePanel({ detail, result, onResult }: ToolExecutePanelProps) {
       {result && result.name === detail.name && (
         <div className="mt-4">
           <div className="flex items-center gap-2 mb-2">
-            <span className={`text-xs font-semibold ${result.data.isError ? 'text-red' : 'text-green'}`}>
+            <span className={`text-xs font-semibold ${result.data.isError ? 'text-destructive' : 'text-success'}`}>
               {result.data.isError ? 'ERROR' : 'OK'}
             </span>
-            <span className="text-xs text-text-muted">{result.durationMs}ms</span>
+            <span className="text-xs text-muted-foreground">{result.durationMs}ms</span>
           </div>
-          <pre className="bg-bg border border-border/60 rounded-lg p-3 text-xs font-mono text-text overflow-x-auto max-h-[400px] overflow-y-auto whitespace-pre-wrap">
+          <pre className="bg-background border border-border/60 rounded-lg p-3 text-xs font-mono text-foreground overflow-x-auto max-h-[400px] overflow-y-auto whitespace-pre-wrap">
             {result.data.content.map((c) => c.text ?? JSON.stringify(c)).join('\n')}
           </pre>
         </div>

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -49,21 +49,21 @@ export function FileViewerPage({ spec }: Props) {
 
   return (
     <div className="h-full flex flex-col min-h-0">
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-bg-secondary/30 shrink-0">
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-secondary/30 shrink-0">
         <button
           type="button"
           onClick={openWorkspace}
-          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2 text-[12px] font-medium text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text"
+          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           title={`Back to ${tag}`}
         >
           <ArrowLeft size={14} strokeWidth={1.8} aria-hidden />
           <span className="hidden sm:inline">Back</span>
         </button>
-        <FileText size={13} strokeWidth={1.75} className="shrink-0 text-text-muted/70" aria-hidden />
-        <span className="font-mono text-[12px] text-text truncate" title={path}>
+        <FileText size={13} strokeWidth={1.75} className="shrink-0 text-muted-foreground/70" aria-hidden />
+        <span className="font-mono text-[12px] text-foreground truncate" title={path}>
           {path}
         </span>
-        <span className="ml-auto shrink-0 text-[11px] text-text-muted/60">{tag}</span>
+        <span className="ml-auto shrink-0 text-[11px] text-muted-foreground/60">{tag}</span>
       </div>
       <div className="flex-1 overflow-y-auto min-h-0">
         <div className="max-w-[820px] mx-auto px-6 py-6">

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -116,7 +116,7 @@ export function InboxPage({ visible }: InboxPageProps) {
         ) : entries.length === 0 ? (
           <EmptyState />
         ) : !selected ? (
-          <div className="px-6 py-8 text-text-muted text-sm">
+          <div className="px-6 py-8 text-muted-foreground text-sm">
             {t('inbox.selectFromSidebar')}
           </div>
         ) : (
@@ -148,12 +148,12 @@ function EmptyState() {
   const { t } = useTranslation()
   return (
     <div className="px-6 py-16 text-center max-w-[520px] mx-auto">
-      <div className="text-[15px] text-text mb-2">{t('inbox.noMessages')}</div>
-      <p className="text-[13px] text-text-muted leading-relaxed">
+      <div className="text-[15px] text-foreground mb-2">{t('inbox.noMessages')}</div>
+      <p className="text-[13px] text-muted-foreground leading-relaxed">
         Workspaces push updates here as they work — finished analysis,
         blocked tasks, questions back to you. An agent surfaces one by
         calling the
-        <code className="mx-1 px-1 py-0.5 rounded bg-bg-tertiary text-[11px]">inbox_push</code>
+        <code className="mx-1 px-1 py-0.5 rounded bg-muted text-[11px]">inbox_push</code>
         tool from inside its workspace. Nothing to read yet.
       </p>
     </div>
@@ -275,7 +275,7 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
             <div className="flex min-w-0 flex-wrap items-center gap-2">
               <span
                 className={`text-[14px] font-semibold ${
-                  wsAlive ? 'text-text' : 'text-text-muted/70 line-through'
+                  wsAlive ? 'text-foreground' : 'text-muted-foreground/70 line-through'
                 }`}
                 title={wsAlive ? undefined : t('inbox.workspaceNotExists')}
               >
@@ -283,10 +283,10 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
               </span>
               {senderLabel && (
                 <span
-                  className="inline-flex min-w-0 items-center gap-1.5 text-[11px] text-text-muted/75"
+                  className="inline-flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground/75"
                   title={t('inbox.senderIdentityTitle', { sender: senderLabel })}
                 >
-                  <ChevronRight size={11} className="shrink-0 text-text-muted/35" aria-hidden />
+                  <ChevronRight size={11} className="shrink-0 text-muted-foreground/35" aria-hidden />
                   {origin?.kind === 'interactive'
                     ? <Terminal size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />
                     : <Bot size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />}
@@ -298,16 +298,16 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
                   type="button"
                   onClick={openIssue}
                   title={t('inbox.fromIssueTitle', { issue: issueId })}
-                  className="oa-pressable inline-flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-text-muted/75 hover:bg-accent/10 hover:text-accent"
+                  className="oa-pressable inline-flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground/75 hover:bg-primary/10 hover:text-primary"
                 >
                   <ListChecks size={12} strokeWidth={1.75} className="shrink-0" />
                   <span className="max-w-[220px] truncate">{t('inbox.fromIssue', { issue: issueTitle ?? issueId })}</span>
                 </button>
               )}
             </div>
-            <div className="mt-1.5 text-[11px] tabular-nums text-text-muted/55">
+            <div className="mt-1.5 text-[11px] tabular-nums text-muted-foreground/55">
               {formatAbsolute(entry.ts)}
-              <span className="mx-1.5 text-text-muted/30">·</span>
+              <span className="mx-1.5 text-muted-foreground/30">·</span>
               {formatRelativeTime(entry.ts)}
             </div>
           </div>
@@ -317,7 +317,7 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
                 type="button"
                 onClick={() => void continueOrigin()}
                 disabled={continuing}
-                className="oa-pressable inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-bg px-2 text-[11px] font-medium text-text-muted hover:border-accent/35 hover:text-accent disabled:cursor-not-allowed disabled:opacity-45 sm:px-2.5"
+                className="oa-pressable inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-background px-2 text-[11px] font-medium text-muted-foreground hover:border-primary/35 hover:text-primary disabled:cursor-not-allowed disabled:opacity-45 sm:px-2.5"
                 title={canContinueOrigin ? t('inbox.openConversation') : t('inbox.openWorkspace')}
                 aria-label={canContinueOrigin ? t('inbox.openConversation') : t('inbox.openWorkspace')}
               >
@@ -339,7 +339,7 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
             <button
               type="button"
               onClick={onDelete}
-              className="oa-pressable inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-muted/45 hover:bg-red/10 hover:text-red"
+              className="oa-pressable inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground/45 hover:bg-destructive/10 hover:text-destructive"
               title={t('inbox.deleteEntryTitle')}
               aria-label={t('inbox.deleteEntryAriaLabel')}
             >
@@ -348,26 +348,26 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
           </div>
         </div>
       </header>
-      {continueError && <div className="-mt-3 mb-5 text-[12px] text-red">{continueError}</div>}
+      {continueError && <div className="-mt-3 mb-5 text-[12px] text-destructive">{continueError}</div>}
 
       {/* The sender's message is the Inbox asset's primary content. */}
       {hasComments && (
-        <div className="text-[15px] leading-relaxed text-text/90">
+        <div className="text-[15px] leading-relaxed text-foreground/90">
           <MarkdownContent
             text={entry.comments!}
             strikethrough={false}
             codeSpanWikilinks
-            className="leading-relaxed text-text/90"
+            className="leading-relaxed text-foreground/90"
           />
         </div>
       )}
 
       {hasDocs && (
         <section className={hasComments ? 'mt-7' : ''}>
-          <div className="mb-2.5 flex items-center gap-2 text-[11px] font-medium uppercase tracking-wider text-text-muted/55">
+          <div className="mb-2.5 flex items-center gap-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/55">
             <Paperclip size={12} aria-hidden />
             {t('inbox.documentsSection')}
-            <span className="font-normal tabular-nums text-text-muted/40">{entry.docs!.length}</span>
+            <span className="font-normal tabular-nums text-muted-foreground/40">{entry.docs!.length}</span>
           </div>
           <div className="space-y-2">
             {entry.docs!.map((doc) => (
@@ -390,7 +390,7 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
           ask={askInbox}
         />
       ) : (
-        <div className="mt-8 border-t border-border/50 pt-4 text-[12px] italic text-text-muted/60">
+        <div className="mt-8 border-t border-border/50 pt-4 text-[12px] italic text-muted-foreground/60">
           {t('inbox.cannotReplyWorkspaceGone')}
         </div>
       )}
@@ -466,7 +466,7 @@ export function InboxAttachment({
 
   return (
     <div
-      className={`group overflow-hidden rounded-xl border bg-bg/55 transition-colors ${expanded ? 'border-accent/25' : 'border-border hover:border-text-muted/35'}`}
+      className={`group overflow-hidden rounded-xl border bg-background/55 transition-colors ${expanded ? 'border-primary/25' : 'border-border hover:border-muted-foreground/35'}`}
       title={doc.revision ? t('inbox.docRevisionTitle', { revision: doc.revision }) : undefined}
     >
       <div className="flex min-w-0 items-center gap-1">
@@ -477,26 +477,26 @@ export function InboxAttachment({
           aria-label={t(expanded ? 'inbox.docCollapseAria' : 'inbox.docExpandAria', { name })}
           className="oa-pressable flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5 text-left"
         >
-          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-bg-tertiary/70 text-text-muted/70">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/70 text-muted-foreground/70">
             {isHtml
               ? <FileCode2 size={15} strokeWidth={1.75} aria-hidden />
               : <FileText size={15} strokeWidth={1.75} aria-hidden />}
           </span>
           <span className="min-w-0 flex-1">
-            <span className="block truncate text-[12px] font-medium text-text/90">{name}</span>
-            <span className="mt-0.5 block truncate font-mono text-[10px] text-text-muted/50">
+            <span className="block truncate text-[12px] font-medium text-foreground/90">{name}</span>
+            <span className="mt-0.5 block truncate font-mono text-[10px] text-muted-foreground/50">
               {directory || t('inbox.workspaceRoot')}
             </span>
           </span>
-          <span className="hidden shrink-0 items-center gap-1.5 text-[10px] text-text-muted/50 sm:flex">
+          <span className="hidden shrink-0 items-center gap-1.5 text-[10px] text-muted-foreground/50 sm:flex">
             <span>{fileKind}</span>
-            {size && <><span className="text-text-muted/25">·</span><span>{size}</span></>}
+            {size && <><span className="text-muted-foreground/25">·</span><span>{size}</span></>}
           </span>
           <ChevronDown
             size={14}
             strokeWidth={1.75}
             aria-hidden
-            className={`shrink-0 text-text-muted/50 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+            className={`shrink-0 text-muted-foreground/50 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
           />
         </button>
         {isMarkdownPath(doc.path) && (
@@ -507,7 +507,7 @@ export function InboxAttachment({
               disabled={!markdownActionsAvailable}
               title={copied ? t('inbox.docCopiedMarkdown') : t('inbox.docCopyMarkdown')}
               aria-label={copied ? t('inbox.docCopiedMarkdown') : t('inbox.docCopyMarkdown')}
-              className="oa-pressable inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted/55 hover:bg-bg-tertiary hover:text-accent disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-text-muted/55"
+              className="oa-pressable inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/55 hover:bg-muted hover:text-primary disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/55"
             >
               {copied ? <Check size={14} strokeWidth={2} /> : <Copy size={14} strokeWidth={1.75} />}
             </button>
@@ -517,7 +517,7 @@ export function InboxAttachment({
               disabled={!markdownActionsAvailable}
               title={t('inbox.docDownloadMarkdown')}
               aria-label={t('inbox.docDownloadMarkdown')}
-              className="oa-pressable inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted/55 hover:bg-bg-tertiary hover:text-accent disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-text-muted/55"
+              className="oa-pressable inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/55 hover:bg-muted hover:text-primary disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/55"
             >
               <Download size={14} strokeWidth={1.75} />
             </button>
@@ -525,9 +525,9 @@ export function InboxAttachment({
         )}
       </div>
       {expanded && (
-        <div className="oa-disclosure-enter border-t border-border/60 bg-bg px-3 py-3 sm:px-4">
+        <div className="oa-disclosure-enter border-t border-border/60 bg-background px-3 py-3 sm:px-4">
           {result === null ? (
-            <div className="py-3 text-center text-[12px] text-text-muted">{t('common.loading')}</div>
+            <div className="py-3 text-center text-[12px] text-muted-foreground">{t('common.loading')}</div>
           ) : (
             <FileContentView path={doc.path} result={result} />
           )}

--- a/ui/src/pages/IssuePage.tsx
+++ b/ui/src/pages/IssuePage.tsx
@@ -24,7 +24,7 @@ export function IssuePage() {
             onClick={() => openOrFocus({ kind: 'settings', params: { category: 'issues' } })}
             title="Issue settings"
             aria-label="Issue settings"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-bg-secondary text-muted transition-colors hover:border-accent/50 hover:text-text"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-secondary text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
           >
             <Settings size={15} aria-hidden />
           </button>

--- a/ui/src/pages/IssueSettingsPage.tsx
+++ b/ui/src/pages/IssueSettingsPage.tsx
@@ -54,7 +54,7 @@ export function IssueSettingsPage() {
                   <Bot
                     size={14}
                     aria-hidden
-                    className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-text-muted/60"
+                    className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
                   />
                   <select
                     value={issueDefaultAgent ?? ''}

--- a/ui/src/pages/LogsPage.tsx
+++ b/ui/src/pages/LogsPage.tsx
@@ -33,7 +33,7 @@ function formatDuration(ms: number): string {
 }
 
 function statusColor(status: string): string {
-  return status === 'error' ? 'text-red' : 'text-green'
+  return status === 'error' ? 'text-destructive' : 'text-success'
 }
 
 /** Try to pretty-print JSON output, fall back to raw string. */
@@ -119,7 +119,7 @@ function ToolCallLogSection() {
         <select
           value={nameFilter}
           onChange={(e) => handleNameChange(e.target.value)}
-          className="bg-bg-tertiary text-text text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-accent"
+          className="bg-muted text-foreground text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-primary"
         >
           <option value="">All tools</option>
           {toolNames.map((n) => (
@@ -131,14 +131,14 @@ function ToolCallLogSection() {
           onClick={() => setPaused(!paused)}
           className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
             paused
-              ? 'border-notification-border text-notification-border hover:bg-notification-bg'
-              : 'border-border text-text-muted hover:bg-bg-tertiary'
+              ? 'border-warning-border text-warning hover:bg-warning-background'
+              : 'border-border text-muted-foreground hover:bg-muted'
           }`}
         >
           {paused ? 'Resume' : 'Pause'}
         </button>
 
-        <span className="text-xs text-text-muted ml-auto">
+        <span className="text-xs text-muted-foreground ml-auto">
           {total > 0
             ? `Page ${page} of ${totalPages} \u00b7 ${total} calls`
             : '0 calls'
@@ -150,16 +150,16 @@ function ToolCallLogSection() {
       {/* Table */}
       <div
         ref={containerRef}
-        className="flex-1 min-h-0 bg-bg rounded-lg border border-border overflow-y-auto font-mono text-xs"
+        className="flex-1 min-h-0 bg-background rounded-lg border border-border overflow-y-auto font-mono text-xs"
       >
         {loading && entries.length === 0 ? (
           <LogRowsSkeleton />
         ) : entries.length === 0 ? (
-          <div className="px-4 py-8 text-center text-text-muted">No tool calls yet</div>
+          <div className="px-4 py-8 text-center text-muted-foreground">No tool calls yet</div>
         ) : (
           <table className="w-full">
-            <thead className="sticky top-0 bg-bg-secondary">
-              <tr className="text-text-muted text-left">
+            <thead className="sticky top-0 bg-secondary">
+              <tr className="text-muted-foreground text-left">
                 <th className="px-3 py-2 w-12">#</th>
                 <th className="px-3 py-2 w-36">Time</th>
                 <th className="px-3 py-2 w-48">Tool</th>
@@ -183,31 +183,31 @@ function ToolCallLogSection() {
           <button
             onClick={() => goToPage(1)}
             disabled={page <= 1 || loading}
-            className="text-xs px-2 py-1 rounded border border-border text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           >
             &laquo;&laquo;
           </button>
           <button
             onClick={() => goToPage(page - 1)}
             disabled={page <= 1 || loading}
-            className="text-xs px-2 py-1 rounded border border-border text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           >
             &laquo;
           </button>
-          <span className="text-xs text-text-muted px-2">
+          <span className="text-xs text-muted-foreground px-2">
             {page} / {totalPages}
           </span>
           <button
             onClick={() => goToPage(page + 1)}
             disabled={page >= totalPages || loading}
-            className="text-xs px-2 py-1 rounded border border-border text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           >
             &raquo;
           </button>
           <button
             onClick={() => goToPage(totalPages)}
             disabled={page >= totalPages || loading}
-            className="text-xs px-2 py-1 rounded border border-border text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           >
             &raquo;&raquo;
           </button>
@@ -225,31 +225,31 @@ function ToolCallRow({ record }: { record: ToolCallRecord }) {
   return (
     <>
       <tr
-        className="border-t border-border/50 hover:bg-bg-tertiary/30 transition-colors cursor-pointer"
+        className="border-t border-border/50 hover:bg-muted/30 transition-colors cursor-pointer"
         onClick={() => setExpanded(!expanded)}
       >
-        <td className="px-3 py-1.5 text-text-muted">{record.seq}</td>
-        <td className="px-3 py-1.5 text-text-muted whitespace-nowrap">{formatDateTime(record.timestamp)}</td>
-        <td className="px-3 py-1.5 text-accent">{record.name}</td>
-        <td className="px-3 py-1.5 text-right text-text-muted">{formatDuration(record.durationMs)}</td>
+        <td className="px-3 py-1.5 text-muted-foreground">{record.seq}</td>
+        <td className="px-3 py-1.5 text-muted-foreground whitespace-nowrap">{formatDateTime(record.timestamp)}</td>
+        <td className="px-3 py-1.5 text-primary">{record.name}</td>
+        <td className="px-3 py-1.5 text-right text-muted-foreground">{formatDuration(record.durationMs)}</td>
         <td className={`px-3 py-1.5 text-center ${statusColor(record.status)}`}>{record.status}</td>
-        <td className="px-3 py-1.5 text-text-muted truncate max-w-0">
+        <td className="px-3 py-1.5 text-muted-foreground truncate max-w-0">
           {inputPreview}
-          <span className="ml-1 text-accent">{expanded ? '\u25be' : '\u25b8'}</span>
+          <span className="ml-1 text-primary">{expanded ? '\u25be' : '\u25b8'}</span>
         </td>
       </tr>
       {expanded && (
         <tr className="border-t border-border/30">
           <td colSpan={6} className="px-3 py-2 space-y-2">
             <div>
-              <span className="text-text-muted text-[11px] uppercase tracking-wide">Input</span>
-              <pre className="text-text-muted whitespace-pre-wrap break-all bg-bg-tertiary rounded p-2 text-[11px] mt-1">
+              <span className="text-muted-foreground text-[11px] uppercase tracking-wide">Input</span>
+              <pre className="text-muted-foreground whitespace-pre-wrap break-all bg-muted rounded p-2 text-[11px] mt-1">
                 {JSON.stringify(record.input, null, 2)}
               </pre>
             </div>
             <div>
-              <span className="text-text-muted text-[11px] uppercase tracking-wide">Output</span>
-              <pre className="text-text-muted whitespace-pre-wrap break-all bg-bg-tertiary rounded p-2 text-[11px] mt-1 max-h-64 overflow-y-auto">
+              <span className="text-muted-foreground text-[11px] uppercase tracking-wide">Output</span>
+              <pre className="text-muted-foreground whitespace-pre-wrap break-all bg-muted rounded p-2 text-[11px] mt-1 max-h-64 overflow-y-auto">
                 {formatOutput(record.output)}
               </pre>
             </div>

--- a/ui/src/pages/MCPPage.tsx
+++ b/ui/src/pages/MCPPage.tsx
@@ -35,7 +35,7 @@ export function MCPPage() {
               description="Disabled by default. Enable only when you intentionally want another local MCP client to call OpenAlice."
             >
               <Field label="Enabled">
-                <label className="inline-flex items-center gap-2 text-[13px] text-text">
+                <label className="inline-flex items-center gap-2 text-[13px] text-foreground">
                   <input
                     type="checkbox"
                     checked={config.enabled}
@@ -56,7 +56,7 @@ export function MCPPage() {
             </ConfigSection>
           </div>
         )}
-        {loadError && <p className="text-[13px] text-red">Failed to load configuration.</p>}
+        {loadError && <p className="text-[13px] text-destructive">Failed to load configuration.</p>}
       </div>
     </div>
   )

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -75,8 +75,8 @@ function MoversBoardView() {
               onClick={() => setList(k)}
               className={`px-3 py-1 rounded-md text-[12px] font-medium transition-colors ${
                 list === k
-                  ? 'bg-bg-tertiary text-text'
-                  : 'text-text-muted hover:text-text hover:bg-bg-secondary'
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-secondary'
               }`}
             >
               {listLabel(k, t)}
@@ -86,10 +86,10 @@ function MoversBoardView() {
 
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{error}</div>
+          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
         )}
         {data && rows.length === 0 && !loading && (
-          <div className="text-[13px] text-text-muted">{t('market.noMatches')}</div>
+          <div className="text-[13px] text-muted-foreground">{t('market.noMatches')}</div>
         )}
         {rows.length > 0 && <MoversTable rows={rows} />}
       </div>
@@ -116,7 +116,7 @@ function MoversTable({ rows }: { rows: MoverRow[] }) {
     <div className="overflow-x-auto">
       <table className="w-full text-[12px] border-collapse">
         <thead>
-          <tr className="text-text-muted/70 text-left border-b border-border">
+          <tr className="text-muted-foreground/70 text-left border-b border-border">
             <th className="py-1.5 pr-3 font-medium">{t('market.colSymbol')}</th>
             <th className="py-1.5 px-3 font-medium text-right">{t('market.colPrice')}</th>
             <th className="py-1.5 px-3 font-medium text-right">{t('market.colChangePct')}</th>
@@ -129,18 +129,18 @@ function MoversTable({ rows }: { rows: MoverRow[] }) {
           {rows.map((r) => (
             <tr
               key={r.symbol}
-              className="border-b border-border/50 hover:bg-bg-secondary/40 cursor-pointer"
+              className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer"
               onClick={() => openOrFocus({ kind: 'market-detail', params: { assetClass: 'equity', symbol: r.symbol } })}
             >
               <td className="py-1.5 pr-3">
-                <span className="font-mono font-semibold text-text">{r.symbol}</span>
-                {r.name && <span className="ml-2 text-text-muted">{r.name}</span>}
+                <span className="font-mono font-semibold text-foreground">{r.symbol}</span>
+                {r.name && <span className="ml-2 text-muted-foreground">{r.name}</span>}
               </td>
-              <td className="py-1.5 px-3 text-right font-mono text-text">{fmtPrice(r.price)}</td>
+              <td className="py-1.5 px-3 text-right font-mono text-foreground">{fmtPrice(r.price)}</td>
               <td className={`py-1.5 px-3 text-right font-mono ${signColor(r.percent_change)}`}>{fmtPct(r.percent_change)}</td>
-              <td className="py-1.5 px-3 text-right text-text">{fmtCompact(r.volume)}</td>
+              <td className="py-1.5 px-3 text-right text-foreground">{fmtCompact(r.volume)}</td>
               <td className={`py-1.5 px-3 text-right ${rvolColor(r.relative_volume)}`}>{r.relative_volume?.toFixed(2) ?? '—'}</td>
-              <td className="py-1.5 pl-3 text-right text-text">{fmtCompact(r.dollar_volume, '$')}</td>
+              <td className="py-1.5 pl-3 text-right text-foreground">{fmtCompact(r.dollar_volume, '$')}</td>
             </tr>
           ))}
         </tbody>
@@ -179,8 +179,8 @@ function CalendarBoardView() {
               onClick={() => setList(k)}
               className={`px-3 py-1 rounded-md text-[12px] font-medium transition-colors ${
                 list === k
-                  ? 'bg-bg-tertiary text-text'
-                  : 'text-text-muted hover:text-text hover:bg-bg-secondary'
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-secondary'
               }`}
             >
               {calendarLabel(k, t)} ({data?.[k].length ?? 0})
@@ -192,12 +192,12 @@ function CalendarBoardView() {
           <CenteredLoading label={slow ? t('market.calendarSlowLoading') : t('common.loading')} />
         )}
         {error && (
-          <div className="flex items-center justify-between gap-3 text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">
+          <div className="flex items-center justify-between gap-3 text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">
             <span className="min-w-0 break-words">{error}</span>
             <button
               type="button"
               onClick={retry}
-              className="shrink-0 text-[12px] font-medium text-red hover:text-red/80"
+              className="shrink-0 text-[12px] font-medium text-destructive hover:text-destructive/80"
             >
               {t('common.retry')}
             </button>
@@ -205,10 +205,10 @@ function CalendarBoardView() {
         )}
         {/* Per-list upstream failure — loud, with the provider's own message. */}
         {data?.errors?.[list] && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{data.errors[list]}</div>
+          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{data.errors[list]}</div>
         )}
         {data && data[list].length === 0 && !loading && !data.errors?.[list] && (
-          <div className="text-[13px] text-text-muted">{t('market.noMatches')}</div>
+          <div className="text-[13px] text-muted-foreground">{t('market.noMatches')}</div>
         )}
         {data && list === 'earnings' && data.earnings.length > 0 && <EarningsTable board={data} />}
         {data && list === 'ipos' && data.ipos.length > 0 && <IpoTable board={data} />}
@@ -242,14 +242,14 @@ function EarningsTable({ board }: { board: CalendarBoard }) {
   return (
     <CalTable head={[t('market.colDate'), t('market.colSymbol'), t('market.colEpsPrev'), t('market.colEpsEst')]} rightCols={[2, 3]}>
       {rows.map((r, i) => (
-        <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
-          <td className="py-1.5 pr-3 text-text-muted whitespace-nowrap">{r.report_date}</td>
+        <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
+          <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">{r.report_date}</td>
           <td className="py-1.5 px-3">
-            <span className="font-mono font-semibold text-text">{r.symbol}</span>
-            {r.name && <span className="ml-2 text-text-muted">{r.name}</span>}
+            <span className="font-mono font-semibold text-foreground">{r.symbol}</span>
+            {r.name && <span className="ml-2 text-muted-foreground">{r.name}</span>}
           </td>
-          <td className="py-1.5 px-3 text-right font-mono text-text">{r.eps_previous ?? '—'}</td>
-          <td className="py-1.5 pl-3 text-right font-mono text-text">{r.eps_consensus ?? '—'}</td>
+          <td className="py-1.5 px-3 text-right font-mono text-foreground">{r.eps_previous ?? '—'}</td>
+          <td className="py-1.5 pl-3 text-right font-mono text-foreground">{r.eps_consensus ?? '—'}</td>
         </tr>
       ))}
     </CalTable>
@@ -263,13 +263,13 @@ function IpoTable({ board }: { board: CalendarBoard }) {
   return (
     <CalTable head={[t('market.colDate'), t('market.colSymbol'), t('market.colExchange')]}>
       {rows.map((r, i) => (
-        <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
-          <td className="py-1.5 pr-3 text-text-muted whitespace-nowrap">{r.ipo_date ?? '—'}</td>
+        <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
+          <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">{r.ipo_date ?? '—'}</td>
           <td className="py-1.5 px-3">
-            <span className="font-mono font-semibold text-text">{r.symbol ?? '—'}</span>
-            {typeof r.name === 'string' && r.name && <span className="ml-2 text-text-muted">{r.name}</span>}
+            <span className="font-mono font-semibold text-foreground">{r.symbol ?? '—'}</span>
+            {typeof r.name === 'string' && r.name && <span className="ml-2 text-muted-foreground">{r.name}</span>}
           </td>
-          <td className="py-1.5 pl-3 text-text-muted">{typeof r.exchange === 'string' ? r.exchange : '—'}</td>
+          <td className="py-1.5 pl-3 text-muted-foreground">{typeof r.exchange === 'string' ? r.exchange : '—'}</td>
         </tr>
       ))}
     </CalTable>
@@ -283,14 +283,14 @@ function DividendTable({ board }: { board: CalendarBoard }) {
   return (
     <CalTable head={[t('market.colExDate'), t('market.colSymbol'), t('market.colDivAmount'), t('market.colPayDate')]} rightCols={[2]}>
       {rows.map((r, i) => (
-        <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
-          <td className="py-1.5 pr-3 text-text-muted whitespace-nowrap">{r.ex_dividend_date}</td>
+        <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
+          <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">{r.ex_dividend_date}</td>
           <td className="py-1.5 px-3">
-            <span className="font-mono font-semibold text-text">{r.symbol}</span>
-            {r.name && <span className="ml-2 text-text-muted">{r.name}</span>}
+            <span className="font-mono font-semibold text-foreground">{r.symbol}</span>
+            {r.name && <span className="ml-2 text-muted-foreground">{r.name}</span>}
           </td>
-          <td className="py-1.5 px-3 text-right font-mono text-text">{r.amount ?? '—'}</td>
-          <td className="py-1.5 pl-3 text-text-muted whitespace-nowrap">{r.payment_date ?? '—'}</td>
+          <td className="py-1.5 px-3 text-right font-mono text-foreground">{r.amount ?? '—'}</td>
+          <td className="py-1.5 pl-3 text-muted-foreground whitespace-nowrap">{r.payment_date ?? '—'}</td>
         </tr>
       ))}
     </CalTable>
@@ -302,7 +302,7 @@ function CalTable({ head, rightCols = [], children }: { head: string[]; rightCol
     <div className="overflow-x-auto">
       <table className="w-full text-[12px] border-collapse">
         <thead>
-          <tr className="text-text-muted/70 text-left border-b border-border">
+          <tr className="text-muted-foreground/70 text-left border-b border-border">
             {head.map((h, i) => (
               <th key={h} className={`py-1.5 font-medium ${i === 0 ? 'pr-3' : i === head.length - 1 ? 'pl-3' : 'px-3'} ${rightCols.includes(i) ? 'text-right' : ''}`}>{h}</th>
             ))}
@@ -335,7 +335,7 @@ function MacroBoardView() {
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{error}</div>
+          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
         )}
         {data && (
           <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
@@ -392,10 +392,10 @@ function TermStructureBoardView() {
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-6 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{error}</div>
+          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
         )}
         {data?.errors && Object.entries(data.errors).map(([sym, msg]) => (
-          <div key={sym} className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{sym}: {msg}</div>
+          <div key={sym} className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{sym}: {msg}</div>
         ))}
         {data?.curves.map((curve) => <TermCurveCard key={curve.symbol} curve={curve} />)}
       </div>
@@ -414,40 +414,40 @@ function TermCurveCard({ curve }: { curve: TermCurve }) {
     .filter((p) => p.price != null)
     .map((p) => ({ ...p, label: p.expiration.slice(2) }))
   return (
-    <div className="border border-border rounded-md bg-bg-secondary/40 px-4 py-3 flex flex-col gap-2">
+    <div className="border border-border rounded-md bg-secondary/40 px-4 py-3 flex flex-col gap-2">
       <div className="flex items-baseline gap-3">
-        <span className="text-[15px] font-semibold font-mono text-text">{curve.symbol}</span>
+        <span className="text-[15px] font-semibold font-mono text-foreground">{curve.symbol}</span>
         {curve.spot != null && (
-          <span className="text-[12px] text-text-muted">{t('market.termSpotPerp')} <span className="font-mono text-text">{curve.spot.toLocaleString('en-US')}</span></span>
+          <span className="text-[12px] text-muted-foreground">{t('market.termSpotPerp')} <span className="font-mono text-foreground">{curve.spot.toLocaleString('en-US')}</span></span>
         )}
-        {regime && <span className="text-[11px] uppercase tracking-wide text-text-muted/70">{regime}</span>}
+        {regime && <span className="text-[11px] uppercase tracking-wide text-muted-foreground/70">{regime}</span>}
       </div>
       <MeasuredChartFrame className="h-40">
         {({ width, height }) => (
           <LineChart width={width} height={height} data={chartData} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
-            <XAxis dataKey="label" tick={{ fontSize: 10, fill: '#7d8590' }} stroke="#7d8590" />
-            <YAxis domain={['dataMin', 'dataMax']} tick={{ fontSize: 10, fill: '#7d8590' }} stroke="#7d8590" width={70}
+            <XAxis dataKey="label" tick={{ fontSize: 10, fill: 'var(--chart-axis)' }} stroke="var(--chart-axis)" />
+            <YAxis domain={['dataMin', 'dataMax']} tick={{ fontSize: 10, fill: 'var(--chart-axis)' }} stroke="var(--chart-axis)" width={70}
               tickFormatter={(v: number) => v.toLocaleString('en-US')} />
             <Tooltip
               formatter={(v) => [Number(v).toLocaleString('en-US'), '']}
               labelFormatter={(l) => `20${l}`}
-              contentStyle={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)', fontSize: 11 }}
+              contentStyle={{ background: 'var(--popover)', border: '1px solid var(--border)', fontSize: 11 }}
             />
-            <Line type="monotone" dataKey="price" stroke="var(--color-accent)" strokeWidth={1.5} dot={{ r: 2.5 }} isAnimationActive={false} />
+            <Line type="monotone" dataKey="price" stroke="var(--primary)" strokeWidth={1.5} dot={{ r: 2.5 }} isAnimationActive={false} />
           </LineChart>
         )}
       </MeasuredChartFrame>
       <div className="flex flex-wrap gap-1.5">
         {curve.points.map((p) => (
-          <span key={p.expiration} className="text-[11px] px-1.5 py-0.5 rounded bg-bg-tertiary/60 font-mono" title={`${p.daysToExpiry ?? '—'}d`}>
+          <span key={p.expiration} className="text-[11px] px-1.5 py-0.5 rounded bg-muted/60 font-mono" title={`${p.daysToExpiry ?? '—'}d`}>
             {p.expiration.slice(2)}{' '}
-            <span className={p.annualizedBasis == null ? 'text-text-muted' : p.annualizedBasis >= 0 ? 'text-green' : 'text-red'}>
+            <span className={p.annualizedBasis == null ? 'text-muted-foreground' : p.annualizedBasis >= 0 ? 'text-success' : 'text-destructive'}>
               {p.annualizedBasis == null ? '—' : `${p.annualizedBasis >= 0 ? '+' : ''}${p.annualizedBasis.toFixed(1)}%`}
             </span>
           </span>
         ))}
         {curve.points.length > 0 && (
-          <span className="text-[10px] text-text-muted/60 self-center ml-1">{t('market.termBasisNote')}</span>
+          <span className="text-[10px] text-muted-foreground/60 self-center ml-1">{t('market.termBasisNote')}</span>
         )}
       </div>
     </div>
@@ -475,13 +475,13 @@ function GlobalMacroBoardView() {
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{error}</div>
+          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
         )}
         {data && (
           <div className="overflow-x-auto">
             <table className="w-full text-[12px] border-collapse">
               <thead>
-                <tr className="text-text-muted/70 text-left border-b border-border">
+                <tr className="text-muted-foreground/70 text-left border-b border-border">
                   <th className="py-1.5 pr-3 font-medium">{t('market.colCountry')}</th>
                   <th className="py-1.5 px-3 font-medium text-right">{t('market.colCpiYoy')}</th>
                   <th className="py-1.5 px-3 font-medium text-right">{t('market.colShortRate')}</th>
@@ -492,8 +492,8 @@ function GlobalMacroBoardView() {
               </thead>
               <tbody>
                 {data.rows.map((r) => (
-                  <tr key={r.country} className="border-b border-border/50 hover:bg-bg-secondary/40">
-                    <td className="py-1.5 pr-3 text-text font-medium">{r.label}</td>
+                  <tr key={r.country} className="border-b border-border/50 hover:bg-secondary/40">
+                    <td className="py-1.5 pr-3 text-foreground font-medium">{r.label}</td>
                     <GlobalCell cell={r.cpiYoy} fmt={(v) => `${v.toFixed(2)}%`} colorBy="cpi" />
                     <GlobalCell cell={r.shortRate} fmt={(v) => `${v.toFixed(2)}%`} />
                     <GlobalCell cell={r.cli} fmt={(v) => v.toFixed(1)} colorBy="cli" />
@@ -503,7 +503,7 @@ function GlobalMacroBoardView() {
                 ))}
               </tbody>
             </table>
-            <p className="mt-2 text-[10px] text-text-muted/60">{t('market.globalMacroNote')}</p>
+            <p className="mt-2 text-[10px] text-muted-foreground/60">{t('market.globalMacroNote')}</p>
           </div>
         )}
       </div>
@@ -513,11 +513,11 @@ function GlobalMacroBoardView() {
 
 function GlobalCell({ cell, fmt, colorBy }: { cell: GlobalMacroCell; fmt: (v: number) => string; colorBy?: 'cpi' | 'cli' }) {
   if (cell.value == null) {
-    return <td className="py-1.5 px-3 text-right text-text-muted/50" title={cell.error ?? 'no data'}>—</td>
+    return <td className="py-1.5 px-3 text-right text-muted-foreground/50" title={cell.error ?? 'no data'}>—</td>
   }
-  let color = 'text-text'
-  if (colorBy === 'cpi') color = cell.value >= 4 ? 'text-red' : cell.value <= 1 ? 'text-text-muted' : 'text-text'
-  if (colorBy === 'cli') color = cell.value >= 100 ? 'text-green' : 'text-red'
+  let color = 'text-foreground'
+  if (colorBy === 'cpi') color = cell.value >= 4 ? 'text-destructive' : cell.value <= 1 ? 'text-muted-foreground' : 'text-foreground'
+  if (colorBy === 'cli') color = cell.value >= 100 ? 'text-success' : 'text-destructive'
   return (
     <td className={`py-1.5 px-3 text-right font-mono ${color}`} title={cell.date ?? ''}>{fmt(cell.value)}</td>
   )
@@ -544,10 +544,10 @@ function ShippingBoardView() {
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{error}</div>
+          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
         )}
         {data?.errors && Object.entries(data.errors).map(([key, msg]) => (
-          <div key={key} className="mb-3 text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{key}: {msg}</div>
+          <div key={key} className="mb-3 text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{key}: {msg}</div>
         ))}
         {data && (
           <div className="grid gap-3 grid-cols-1 lg:grid-cols-2">
@@ -565,11 +565,11 @@ function ChokepointCard({ curve }: { curve: ShippingCurve }) {
     .filter((p) => p.tons != null)
     .map((p) => ({ ...p, mt: (p.tons as number) / 1e6, label: p.date.slice(5) }))
   return (
-    <div className="border border-border rounded-md bg-bg-secondary/40 px-4 py-3 flex flex-col gap-1.5">
+    <div className="border border-border rounded-md bg-secondary/40 px-4 py-3 flex flex-col gap-1.5">
       <div className="flex items-baseline justify-between gap-2">
-        <span className="text-[13px] font-semibold text-text">{curve.name}</span>
+        <span className="text-[13px] font-semibold text-foreground">{curve.name}</span>
         {curve.latest && (
-          <span className="text-[11px] text-text-muted">
+          <span className="text-[11px] text-muted-foreground">
             {curve.latest.date} · {curve.latest.vessels ?? '—'} {t('market.shippingVessels')} · {curve.latest.tons != null ? (curve.latest.tons / 1e6).toFixed(2) + 'M t' : '—'}
           </span>
         )}
@@ -577,14 +577,14 @@ function ChokepointCard({ curve }: { curve: ShippingCurve }) {
       <MeasuredChartFrame className="h-28">
         {({ width, height }) => (
           <LineChart width={width} height={height} data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
-            <XAxis dataKey="label" tick={{ fontSize: 9, fill: '#7d8590' }} stroke="#7d8590" minTickGap={28} />
-            <YAxis tick={{ fontSize: 9, fill: '#7d8590' }} stroke="#7d8590" width={36}
+            <XAxis dataKey="label" tick={{ fontSize: 9, fill: 'var(--chart-axis)' }} stroke="var(--chart-axis)" minTickGap={28} />
+            <YAxis tick={{ fontSize: 9, fill: 'var(--chart-axis)' }} stroke="var(--chart-axis)" width={36}
               tickFormatter={(v: number) => v.toFixed(1)} domain={['auto', 'auto']} />
             <Tooltip
               formatter={(v) => [`${Number(v).toFixed(2)}M t`, '']}
-              contentStyle={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)', fontSize: 11 }}
+              contentStyle={{ background: 'var(--popover)', border: '1px solid var(--border)', fontSize: 11 }}
             />
-            <Line type="monotone" dataKey="mt" stroke="var(--color-accent)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
+            <Line type="monotone" dataKey="mt" stroke="var(--primary)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
           </LineChart>
         )}
       </MeasuredChartFrame>
@@ -613,10 +613,10 @@ function FedBoardView() {
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-5 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{error}</div>
+          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
         )}
         {data?.errors && Object.entries(data.errors).map(([k, msg]) => (
-          <div key={k} className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{k}: {msg}</div>
+          <div key={k} className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{k}: {msg}</div>
         ))}
         {data && data.cards.length > 0 && (
           <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
@@ -627,22 +627,22 @@ function FedBoardView() {
         )}
         {data && data.documents.length > 0 && (
           <div className="flex flex-col gap-1.5">
-            <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-muted/60">{t('market.fedDocuments')}</h3>
+            <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/60">{t('market.fedDocuments')}</h3>
             {data.documents.map((d) => (
               <a
                 key={`${d.type}-${d.date}`}
                 href={d.url}
                 target="_blank"
                 rel="noreferrer"
-                className="flex items-center gap-3 px-3 py-1.5 rounded-md border border-border/60 bg-bg-secondary/30 hover:bg-bg-secondary text-[12px]"
+                className="flex items-center gap-3 px-3 py-1.5 rounded-md border border-border/60 bg-secondary/30 hover:bg-secondary text-[12px]"
               >
-                <span className="font-mono text-text-muted shrink-0">{d.date}</span>
+                <span className="font-mono text-muted-foreground shrink-0">{d.date}</span>
                 <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded shrink-0 ${
-                  d.type === 'statement' ? 'bg-accent/15 text-accent'
-                  : d.type === 'minutes' ? 'bg-green/15 text-green'
-                  : 'bg-bg-tertiary text-text-muted'
+                  d.type === 'statement' ? 'bg-primary/15 text-primary'
+                  : d.type === 'minutes' ? 'bg-success/15 text-success'
+                  : 'bg-muted text-muted-foreground'
                 }`}>{d.type}</span>
-                <span className="text-text truncate">{d.title}</span>
+                <span className="text-foreground truncate">{d.title}</span>
               </a>
             ))}
           </div>
@@ -680,10 +680,10 @@ function fmtCompact(x: number | null, prefix = ''): string {
   return `${prefix}${x.toFixed(0)}`
 }
 function signColor(x: number | null): string {
-  if (x == null) return 'text-text-muted'
-  return x > 0 ? 'text-green' : x < 0 ? 'text-red' : 'text-text-muted'
+  if (x == null) return 'text-muted-foreground'
+  return x > 0 ? 'text-success' : x < 0 ? 'text-destructive' : 'text-muted-foreground'
 }
 function rvolColor(x: number | null): string {
-  if (x == null) return 'text-text-muted'
-  return x >= 2 ? 'text-amber-400 font-semibold' : 'text-text'
+  if (x == null) return 'text-muted-foreground'
+  return x >= 2 ? 'text-warning font-semibold' : 'text-foreground'
 }

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -271,7 +271,7 @@ export function MarketDataPage() {
             highlightFmp={highlightFmp}
           />
         </div>
-        {loadError && <p className="text-[13px] text-red mt-4 max-w-[880px] mx-auto">Failed to load configuration.</p>}
+        {loadError && <p className="text-[13px] text-destructive mt-4 max-w-[880px] mx-auto">Failed to load configuration.</p>}
       </div>
     </div>
   )
@@ -291,17 +291,17 @@ function HubCard({
   const host = hub.baseUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '')
 
   return (
-    <section className="mb-6 border border-border/60 rounded-xl bg-bg-secondary/50 p-5">
+    <section className="mb-6 border border-border/60 rounded-xl bg-secondary/50 p-5">
       <div className="flex items-center justify-between mb-1.5">
         <h2 className="text-[14px] font-semibold">Data Hub</h2>
         <Toggle size="sm" checked={hub.enabled} onChange={onToggle} />
       </div>
       {hub.enabled ? (
         <div className="flex items-center gap-2 mb-1.5">
-          {ping === 'checking' && <span className="w-2 h-2 rounded-full bg-text-muted/40 animate-pulse shrink-0" />}
-          {ping === 'ok' && <span className="w-2 h-2 rounded-full bg-green shrink-0" />}
-          {ping === 'down' && <span className="w-2 h-2 rounded-full bg-red shrink-0" />}
-          <span className="text-[13px] text-text">
+          {ping === 'checking' && <span className="w-2 h-2 rounded-full bg-muted-foreground/40 animate-pulse shrink-0" />}
+          {ping === 'ok' && <span className="w-2 h-2 rounded-full bg-success shrink-0" />}
+          {ping === 'down' && <span className="w-2 h-2 rounded-full bg-destructive shrink-0" />}
+          <span className="text-[13px] text-foreground">
             {ping === 'checking' && 'Checking…'}
             {ping === 'ok' && <>Connected · <span className="font-mono text-[12px]">{host}</span></>}
             {ping === 'down' && 'Unreachable — using local sources'}
@@ -309,11 +309,11 @@ function HubCard({
         </div>
       ) : (
         <div className="flex items-center gap-2 mb-1.5">
-          <span className="w-2 h-2 rounded-full border border-text-muted/40 shrink-0" />
-          <span className="text-[13px] text-text-muted">Off — boards and series use your own keys and vendors.</span>
+          <span className="w-2 h-2 rounded-full border border-muted-foreground/40 shrink-0" />
+          <span className="text-[13px] text-muted-foreground">Off — boards and series use your own keys and vendors.</span>
         </div>
       )}
-      <p className="text-[12px] text-text-muted">
+      <p className="text-[12px] text-muted-foreground">
         Low-frequency data is served from the hosted hub — no API keys needed.
         Anonymous reads of public data; your own keys always take precedence.
       </p>
@@ -326,24 +326,24 @@ function HubCard({
 function SourcesCard({ rows, onAddFmp }: { rows: SourceRow[]; onAddFmp: () => void }) {
   return (
     <section className="mb-6">
-      <h2 className="text-[13px] font-semibold text-text-muted uppercase tracking-wider mb-2">Data Sources</h2>
-      <div className="border border-border/60 rounded-xl bg-bg-secondary/50 divide-y divide-border/40">
+      <h2 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">Data Sources</h2>
+      <div className="border border-border/60 rounded-xl bg-secondary/50 divide-y divide-border/40">
         {rows.map((row) => (
           <div key={row.name} className="flex items-center gap-3 px-4 py-3">
             <span
-              className={`w-2 h-2 rounded-full shrink-0 ${row.state === 'ok' ? 'bg-green' : 'border border-text-muted/50'}`}
+              className={`w-2 h-2 rounded-full shrink-0 ${row.state === 'ok' ? 'bg-success' : 'border border-muted-foreground/50'}`}
             />
             <div className="flex-1 min-w-0">
-              <span className="text-[13px] text-text font-medium">{row.name}</span>
-              {row.detail && <span className="text-[12px] text-text-muted/60 ml-2">{row.detail}</span>}
+              <span className="text-[13px] text-foreground font-medium">{row.name}</span>
+              {row.detail && <span className="text-[12px] text-muted-foreground/60 ml-2">{row.detail}</span>}
             </div>
-            <span className={`text-[12px] ${row.state === 'ok' ? 'text-text-muted' : 'text-text-muted/60'}`}>
+            <span className={`text-[12px] ${row.state === 'ok' ? 'text-muted-foreground' : 'text-muted-foreground/60'}`}>
               {row.source}
             </span>
             {row.cta && (
               <button
                 onClick={onAddFmp}
-                className="shrink-0 border border-accent/40 text-accent rounded-md px-2.5 py-1 text-[12px] font-medium cursor-pointer hover:bg-accent/10 transition-colors"
+                className="shrink-0 border border-primary/40 text-primary rounded-md px-2.5 py-1 text-[12px] font-medium cursor-pointer hover:bg-primary/10 transition-colors"
               >
                 Add key
               </button>
@@ -366,8 +366,8 @@ function ChartVendorsSection({
 }) {
   return (
     <section className="mb-6">
-      <h2 className="text-[13px] font-semibold text-text-muted uppercase tracking-wider mb-2">Chart Vendors</h2>
-      <p className="text-[12px] text-text-muted/70 mb-2.5 max-w-[640px]">
+      <h2 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">Chart Vendors</h2>
+      <p className="text-[12px] text-muted-foreground/70 mb-2.5 max-w-[640px]">
         Live K-line &amp; quote sources — queried per symbol, never via the hub. Switch one on and it
         joins the search pool; what it covers is found by searching, not configured here. yfinance is
         the always-on global default.
@@ -376,19 +376,19 @@ function ChartVendorsSection({
         {CHART_VENDORS.map((v) => {
           const on = v.alwaysOn || extraVendors.includes(v.id)
           return (
-            <div key={v.id} className="border border-border/60 rounded-xl bg-bg-secondary/50 px-4 py-3.5">
+            <div key={v.id} className="border border-border/60 rounded-xl bg-secondary/50 px-4 py-3.5">
               <div className="flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2 min-w-0">
-                  <span className={`w-2 h-2 rounded-full shrink-0 ${on ? 'bg-green' : 'border border-text-muted/50'}`} />
-                  <span className="text-[13px] font-semibold text-text truncate">{v.name}</span>
+                  <span className={`w-2 h-2 rounded-full shrink-0 ${on ? 'bg-success' : 'border border-muted-foreground/50'}`} />
+                  <span className="text-[13px] font-semibold text-foreground truncate">{v.name}</span>
                 </div>
                 {v.alwaysOn ? (
-                  <span className="text-[11px] text-text-muted/60 uppercase tracking-wider shrink-0">always on</span>
+                  <span className="text-[11px] text-muted-foreground/60 uppercase tracking-wider shrink-0">always on</span>
                 ) : (
                   <Toggle size="sm" checked={on} onChange={(val) => onToggle(v.id, val)} />
                 )}
               </div>
-              <p className="text-[12px] text-text-muted/70 mt-1.5 leading-relaxed">{v.desc}</p>
+              <p className="text-[12px] text-muted-foreground/70 mt-1.5 leading-relaxed">{v.desc}</p>
             </div>
           )
         })}
@@ -422,14 +422,14 @@ function AdvancedSection({
     <section className="mb-8">
       <button
         onClick={onToggle}
-        className="flex items-center gap-1.5 text-[13px] font-semibold text-text-muted hover:text-text cursor-pointer transition-colors py-1"
+        className="flex items-center gap-1.5 text-[13px] font-semibold text-muted-foreground hover:text-foreground cursor-pointer transition-colors py-1"
       >
         <span className={`inline-block transition-transform text-[10px] ${open ? 'rotate-90' : ''}`}>▶</span>
         Advanced
       </button>
 
       {open && (
-        <div className="mt-2 border border-border/60 rounded-xl bg-bg-secondary/30 px-5">
+        <div className="mt-2 border border-border/60 rounded-xl bg-secondary/30 px-5">
           <KeyProvidersSection
             providerKeys={providerKeys}
             onKeyChange={onKeyChange}
@@ -446,7 +446,7 @@ function AdvancedSection({
               value={hub.baseUrl}
               onChange={(e) => onHubChange({ ...hub, baseUrl: e.target.value })}
               placeholder="https://traderhub.openalice.ai"
-              className="w-full max-w-[420px] px-2.5 py-1.5 bg-bg text-text border border-border rounded-md text-[12px] font-mono outline-none focus:border-accent"
+              className="w-full max-w-[420px] px-2.5 py-1.5 bg-background text-foreground border border-border rounded-md text-[12px] font-mono outline-none focus:border-primary"
             />
           </ConfigSection>
         </div>
@@ -472,10 +472,10 @@ function TestButton({
       disabled={disabled}
       className={`shrink-0 border rounded-md px-3 py-2 text-[13px] font-medium cursor-pointer transition-colors disabled:opacity-40 disabled:cursor-default ${
         status === 'ok'
-          ? 'border-green text-green'
+          ? 'border-success text-success'
           : status === 'error'
-            ? 'border-red text-red'
-            : 'border-border text-text-muted hover:bg-bg-tertiary hover:text-text'
+            ? 'border-destructive text-destructive'
+            : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
       }`}
     >
       {status === 'testing' ? '...' : status === 'ok' ? 'OK' : status === 'error' ? 'Fail' : 'Test'}
@@ -530,7 +530,7 @@ function KeyProvidersSection({
         {KEY_GROUPS.map((group, gi) => (
           <div key={gi}>
             {group.label && (
-              <p className="text-[11px] text-text-muted/60 uppercase tracking-wider border-t border-border/40 pt-3 mb-3">
+              <p className="text-[11px] text-muted-foreground/60 uppercase tracking-wider border-t border-border/40 pt-3 mb-3">
                 {group.label}
               </p>
             )}
@@ -542,10 +542,10 @@ function KeyProvidersSection({
                   <div
                     key={key}
                     ref={isFmp ? fmpRef : undefined}
-                    className={`rounded-lg transition-shadow ${isFmp && highlightFmp ? 'ring-2 ring-accent/60' : ''}`}
+                    className={`rounded-lg transition-shadow ${isFmp && highlightFmp ? 'ring-2 ring-primary/60' : ''}`}
                   >
                     <Field label={name} description={hint}>
-                      <p className="text-[12px] text-text-muted/70 mb-2">{desc}</p>
+                      <p className="text-[12px] text-muted-foreground/70 mb-2">{desc}</p>
                       <div className="flex items-center gap-2">
                         <input
                           className={inputClass}

--- a/ui/src/pages/MarketDetailPage.tsx
+++ b/ui/src/pages/MarketDetailPage.tsx
@@ -48,8 +48,8 @@ function PinButton({ assetClass, symbol }: PinButtonProps) {
       title={pinned ? 'Remove from watchlist' : 'Add to watchlist'}
       className={`flex items-center gap-1.5 px-2.5 py-1 text-[12px] rounded-md border transition-colors ${
         pinned
-          ? 'border-amber-500/40 text-amber-400 bg-amber-500/10 hover:bg-amber-500/15'
-          : 'border-border text-text-muted hover:text-text hover:bg-bg-tertiary'
+          ? 'border-warning/40 text-warning bg-warning/10 hover:bg-warning/15'
+          : 'border-border text-muted-foreground hover:text-foreground hover:bg-muted'
       }`}
     >
       <svg width="13" height="13" viewBox="0 0 24 24" fill={pinned ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/ui/src/pages/MarketPage.tsx
+++ b/ui/src/pages/MarketPage.tsx
@@ -31,17 +31,17 @@ export function MarketPage() {
 
         {/* S&P 500 valuation strip — the market-level regime read. */}
         <div className="flex flex-col gap-2">
-          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
             {t('market.valuationTitle')}
             {strip && <span className="ml-2 normal-case font-normal tracking-normal"><BoardMeta meta={strip.meta} /></span>}
           </h3>
           {stripError && (
-            <div className="rounded-md border border-border px-3 py-2 text-[12px] text-text-muted">{stripError}</div>
+            <div className="rounded-md border border-border px-3 py-2 text-[12px] text-muted-foreground">{stripError}</div>
           )}
           {!strip && !stripError && (
             <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(210px,1fr))]" aria-hidden="true">
               {Array.from({ length: 4 }).map((_, i) => (
-                <div key={i} className="border border-border rounded-md bg-bg-secondary/40 px-3 py-2.5 flex flex-col gap-1.5">
+                <div key={i} className="border border-border rounded-md bg-secondary/40 px-3 py-2.5 flex flex-col gap-1.5">
                   <Skeleton className="h-3 w-20 rounded" />
                   <Skeleton className="h-6 w-24 rounded" />
                 </div>
@@ -57,18 +57,18 @@ export function MarketPage() {
           )}
         </div>
 
-        <section className="relative overflow-hidden rounded-xl border border-border/80 bg-bg-secondary/55 p-4 md:p-5">
+        <section className="relative overflow-hidden rounded-xl border border-border/80 bg-secondary/55 p-4 md:p-5">
           <div
             aria-hidden
-            className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--color-accent-dim),transparent_52%)]"
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--primary-muted),transparent_52%)]"
           />
           <div className="relative">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-accent">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-primary">
               {t('market.overviewEyebrow')}
             </p>
             <div className="mt-1 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
-              <h2 className="text-[17px] font-semibold text-text">{t('market.overviewTitle')}</h2>
-              <p className="max-w-xl text-[12px] leading-relaxed text-text-muted">{t('market.overviewHint')}</p>
+              <h2 className="text-[17px] font-semibold text-foreground">{t('market.overviewTitle')}</h2>
+              <p className="max-w-xl text-[12px] leading-relaxed text-muted-foreground">{t('market.overviewHint')}</p>
             </div>
 
             <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
@@ -119,13 +119,13 @@ function MarketLaunchCard({
     <button
       type="button"
       onClick={onClick}
-      className="group flex min-h-[92px] flex-col rounded-lg border border-border/70 bg-bg/75 p-3 text-left transition-[border-color,background-color,transform] hover:-translate-y-0.5 hover:border-accent/45 hover:bg-bg"
+      className="group flex min-h-[92px] flex-col rounded-lg border border-border/70 bg-background/75 p-3 text-left transition-[border-color,background-color,transform] hover:-translate-y-0.5 hover:border-primary/45 hover:bg-background"
     >
-      <span className="flex h-7 w-7 items-center justify-center rounded-md bg-accent/10 text-accent transition-colors group-hover:bg-accent/15">
+      <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
         {icon}
       </span>
-      <span className="mt-2 text-[13px] font-semibold text-text">{title}</span>
-      <span className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-text-muted">{description}</span>
+      <span className="mt-2 text-[13px] font-semibold text-foreground">{title}</span>
+      <span className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">{description}</span>
     </button>
   )
 }

--- a/ui/src/pages/MarketRotationPage.tsx
+++ b/ui/src/pages/MarketRotationPage.tsx
@@ -11,17 +11,17 @@ import { PageHeader } from '../components/PageHeader'
 import { CenteredLoading } from '../components/StateViews'
 import { marketApi, type SectorRotationResult, type SectorRotationRow } from '../api/market'
 
-const GREEN = 'var(--color-green)'
-const RED = 'var(--color-red)'
-const MUTED = '#7d8590'
+const GREEN = 'var(--success)'
+const RED = 'var(--destructive)'
+const MUTED = 'var(--chart-axis)'
 const REFRESH_MS = 5 * 60 * 1000
 
 function pct(x: number | null | undefined, places = 1): string {
   return x == null ? '—' : `${(x * 100).toFixed(places)}%`
 }
 function signColor(x: number | null | undefined): string {
-  if (x == null) return 'text-text-muted'
-  return x > 0 ? 'text-green' : x < 0 ? 'text-red' : 'text-text-muted'
+  if (x == null) return 'text-muted-foreground'
+  return x > 0 ? 'text-success' : x < 0 ? 'text-destructive' : 'text-muted-foreground'
 }
 function dotColor(score: number | null): string {
   if (score == null) return MUTED
@@ -84,7 +84,7 @@ export function MarketRotationPage() {
         description={
           <>
             {t('market.rotationSubtitle')}
-            {data && <><span className="text-text-muted/50"> · {t('market.asOf')} {data.asOf}</span>{data.meta && <BoardMeta meta={data.meta} />}</>}
+            {data && <><span className="text-muted-foreground/50"> · {t('market.asOf')} {data.asOf}</span>{data.meta && <BoardMeta meta={data.meta} />}</>}
           </>
         }
         live={{ lastUpdated: updatedAt }}
@@ -92,15 +92,15 @@ export function MarketRotationPage() {
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-6 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-red border border-red/30 rounded-md px-3 py-2 bg-red/5">{error}</div>
+          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
         )}
 
         {data && (
           <>
             <QuadrantChart points={points} t={t} />
             <RotationTable rows={data.sectors} benchmarkSymbol={data.benchmark.symbol} t={t} />
-            <p className="max-w-3xl break-words text-[11px] leading-relaxed text-text-muted/70">
-              <span className="font-semibold text-text-muted">{t('market.rotationMethodology')}: </span>
+            <p className="max-w-3xl break-words text-[11px] leading-relaxed text-muted-foreground/70">
+              <span className="font-semibold text-muted-foreground">{t('market.rotationMethodology')}: </span>
               {data.methodology}
             </p>
           </>
@@ -115,10 +115,10 @@ function QuadrantChart({ points, t }: { points: Point[]; t: TFunction }) {
     <div className="relative">
       {/* Quadrant corner labels */}
       <div className="pointer-events-none absolute inset-0 z-10">
-        <CornerLabel className="top-1 right-2 text-green/70" text={t('market.quadRotatingIn')} />
-        <CornerLabel className="top-1 left-12 text-text-muted/60" text={t('market.quadImproving')} />
-        <CornerLabel className="bottom-7 right-2 text-text-muted/60" text={t('market.quadWeakening')} />
-        <CornerLabel className="bottom-7 left-12 text-red/70" text={t('market.quadRotatingOut')} />
+        <CornerLabel className="top-1 right-2 text-success/70" text={t('market.quadRotatingIn')} />
+        <CornerLabel className="top-1 left-12 text-muted-foreground/60" text={t('market.quadImproving')} />
+        <CornerLabel className="bottom-7 right-2 text-muted-foreground/60" text={t('market.quadWeakening')} />
+        <CornerLabel className="bottom-7 left-12 text-destructive/70" text={t('market.quadRotatingOut')} />
       </div>
       <MeasuredChartFrame className="h-[420px] w-full">
         {({ width, height }) => (
@@ -146,7 +146,7 @@ function QuadrantChart({ points, t }: { points: Point[]; t: TFunction }) {
           </ScatterChart>
         )}
       </MeasuredChartFrame>
-      <div className="flex justify-between px-8 -mt-1 text-[10px] text-text-muted/50">
+      <div className="flex justify-between px-8 -mt-1 text-[10px] text-muted-foreground/50">
         <span>{t('market.axisRelStrength')} →</span>
         <span>↑ {t('market.axisVolumeShare')}</span>
       </div>
@@ -162,13 +162,13 @@ function PointTooltip({ active, payload, t }: { active?: boolean; payload?: Arra
   if (!active || !payload?.length) return null
   const p = payload[0].payload
   return (
-    <div className="rounded-md border border-border bg-bg-secondary px-2.5 py-1.5 text-[11px] shadow-lg">
-      <div className="font-mono font-semibold text-text">{p.symbol} <span className="text-text-muted font-sans font-normal">{p.sector}</span></div>
+    <div className="rounded-md border border-border bg-secondary px-2.5 py-1.5 text-[11px] shadow-lg">
+      <div className="font-mono font-semibold text-foreground">{p.symbol} <span className="text-muted-foreground font-sans font-normal">{p.sector}</span></div>
       <div className="mt-0.5 grid grid-cols-[auto_auto] gap-x-3 gap-y-0.5">
-        <span className="text-text-muted">{t('market.colScore')}</span><span className={signColor(p.score)}>{p.score ?? '—'}</span>
-        <span className="text-text-muted">{t('market.axisRelStrength')}</span><span className={signColor(p.x)}>{p.x.toFixed(1)}%</span>
-        <span className="text-text-muted">{t('market.axisVolumeShare')}</span><span className={signColor(p.y)}>{p.y.toFixed(2)}%</span>
-        <span className="text-text-muted">{t('market.colRvol')}</span><span className="text-text">{p.rvol ?? '—'}</span>
+        <span className="text-muted-foreground">{t('market.colScore')}</span><span className={signColor(p.score)}>{p.score ?? '—'}</span>
+        <span className="text-muted-foreground">{t('market.axisRelStrength')}</span><span className={signColor(p.x)}>{p.x.toFixed(1)}%</span>
+        <span className="text-muted-foreground">{t('market.axisVolumeShare')}</span><span className={signColor(p.y)}>{p.y.toFixed(2)}%</span>
+        <span className="text-muted-foreground">{t('market.colRvol')}</span><span className="text-foreground">{p.rvol ?? '—'}</span>
       </div>
     </div>
   )
@@ -180,7 +180,7 @@ function RotationTable({ rows, benchmarkSymbol, t }: { rows: SectorRotationRow[]
       {/* Keep the market columns readable; narrow screens scroll instead of compressing headers together. */}
       <table className="w-full min-w-[820px] border-collapse text-[12px]" data-testid="sector-rotation-table">
         <thead>
-          <tr className="whitespace-nowrap border-b border-border text-left text-text-muted/70">
+          <tr className="whitespace-nowrap border-b border-border text-left text-muted-foreground/70">
             <th className="w-[220px] py-1.5 pr-3 font-medium">{t('market.colSector')}</th>
             <th className="w-[72px] py-1.5 px-3 font-medium text-right">{t('market.colScore')}</th>
             <th className="w-[64px] py-1.5 px-3 font-medium text-right">1W</th>
@@ -193,17 +193,17 @@ function RotationTable({ rows, benchmarkSymbol, t }: { rows: SectorRotationRow[]
         </thead>
         <tbody>
           {rows.map((r) => (
-            <tr key={r.symbol} className="whitespace-nowrap border-b border-border/50 hover:bg-bg-secondary/40">
+            <tr key={r.symbol} className="whitespace-nowrap border-b border-border/50 hover:bg-secondary/40">
               <td className="py-1.5 pr-3">
-                <span className="font-mono font-semibold text-text">{r.symbol}</span>
-                <span className="ml-2 text-text-muted">{r.sector}</span>
+                <span className="font-mono font-semibold text-foreground">{r.symbol}</span>
+                <span className="ml-2 text-muted-foreground">{r.sector}</span>
               </td>
               <td className={`py-1.5 px-3 text-right font-mono ${signColor(r.rotation_score)}`}>{r.rotation_score ?? '—'}</td>
               <td className={`py-1.5 px-3 text-right ${signColor(r.returns['1W'])}`}>{pct(r.returns['1W'])}</td>
               <td className={`py-1.5 px-3 text-right ${signColor(r.returns['1M'])}`}>{pct(r.returns['1M'])}</td>
               <td className={`py-1.5 px-3 text-right ${signColor(r.returns['3M'])}`}>{pct(r.returns['3M'])}</td>
               <td className={`py-1.5 px-3 text-right ${signColor(r.rel_strength['1M'])}`}>{pct(r.rel_strength['1M'])}</td>
-              <td className="py-1.5 px-3 text-right text-text">{r.rvol ?? '—'}</td>
+              <td className="py-1.5 px-3 text-right text-foreground">{r.rvol ?? '—'}</td>
               <td className={`py-1.5 pl-3 text-right ${signColor(r.dv_share_change)}`}>{pct(r.dv_share_change, 2)}</td>
             </tr>
           ))}

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -67,7 +67,7 @@ function CollectorSettings() {
             onChange={(feeds) => updateConfigImmediate({ feeds })}
           />
         </div>
-        {loadError && <p className="text-[13px] text-red mt-4">Failed to load configuration.</p>}
+        {loadError && <p className="text-[13px] text-destructive mt-4">Failed to load configuration.</p>}
       </div>
     </div>
   )
@@ -136,21 +136,21 @@ function FeedsSection({
                   onChange={(v) => setEnabled(i, v)}
                 />
                 <div className="flex-1 min-w-0">
-                  <p className="text-[13px] font-medium text-text truncate">{feed.name}</p>
+                  <p className="text-[13px] font-medium text-foreground truncate">{feed.name}</p>
                   {feed.description && (
-                    <p className="text-[12px] text-text-muted/80 truncate">{feed.description}</p>
+                    <p className="text-[12px] text-muted-foreground/80 truncate">{feed.description}</p>
                   )}
-                  <p className="text-[11px] text-text-muted/60 truncate mt-0.5">{feed.url}</p>
+                  <p className="text-[11px] text-muted-foreground/60 truncate mt-0.5">{feed.url}</p>
                   <div className="flex items-center gap-2 mt-0.5">
-                    <span className="text-[11px] text-text-muted/50">source: {feed.source}</span>
+                    <span className="text-[11px] text-muted-foreground/50">source: {feed.source}</span>
                     {feed.categories && feed.categories.length > 0 && (
-                      <span className="text-[11px] text-text-muted/50">• {feed.categories.join(', ')}</span>
+                      <span className="text-[11px] text-muted-foreground/50">• {feed.categories.join(', ')}</span>
                     )}
                   </div>
                 </div>
                 <button
                   onClick={() => removeFeed(i)}
-                  className="shrink-0 text-text-muted hover:text-red transition-colors p-1"
+                  className="shrink-0 text-muted-foreground hover:text-destructive transition-colors p-1"
                   title="Remove feed"
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -166,7 +166,7 @@ function FeedsSection({
 
       {/* Add feed form */}
       <div className="border border-border/40 rounded-lg p-4 space-y-3">
-        <p className="text-[13px] font-medium text-text-muted">Add Feed</p>
+        <p className="text-[13px] font-medium text-muted-foreground">Add Feed</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <Field label="Name">
             <input className={inputClass} value={newName} onChange={(e) => setNewName(e.target.value)} placeholder="e.g. CoinDesk" />

--- a/ui/src/pages/NewsPage.tsx
+++ b/ui/src/pages/NewsPage.tsx
@@ -26,39 +26,39 @@ function ArticleRow({ article }: { article: NewsArticle }) {
 
   return (
     <div
-      className="px-4 py-3 hover:bg-bg-tertiary/30 transition-colors cursor-pointer"
+      className="px-4 py-3 hover:bg-muted/30 transition-colors cursor-pointer"
       onClick={() => setExpanded(!expanded)}
     >
       {/* Header row */}
       <div className="flex items-start gap-2">
         <div className="flex-1 min-w-0">
-          <p className="text-[13px] font-medium text-text leading-snug">{article.title}</p>
+          <p className="text-[13px] font-medium text-foreground leading-snug">{article.title}</p>
           <div className="flex items-center gap-2 mt-1">
             {article.source && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/10 text-accent">
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-primary/10 text-primary">
                 {article.source}
               </span>
             )}
-            <span className="text-[11px] text-text-muted">{formatRelativeTime(article.time)}</span>
+            <span className="text-[11px] text-muted-foreground">{formatRelativeTime(article.time)}</span>
             {article.categories && (
-              <span className="text-[11px] text-text-muted/50 truncate">{article.categories}</span>
+              <span className="text-[11px] text-muted-foreground/50 truncate">{article.categories}</span>
             )}
           </div>
         </div>
-        <span className="text-text-muted text-xs shrink-0 mt-0.5">{expanded ? '▾' : '▸'}</span>
+        <span className="text-muted-foreground text-xs shrink-0 mt-0.5">{expanded ? '▾' : '▸'}</span>
       </div>
 
       {/* Preview / Expanded */}
       {expanded ? (
         <div className="mt-2 space-y-2">
-          <p className="text-[12px] text-text-muted/80 leading-relaxed whitespace-pre-wrap">{article.content}</p>
+          <p className="text-[12px] text-muted-foreground/80 leading-relaxed whitespace-pre-wrap">{article.content}</p>
           {article.link && (
             <a
               href={article.link}
               target="_blank"
               rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}
-              className="inline-flex items-center gap-1 text-[12px] text-accent hover:underline"
+              className="inline-flex items-center gap-1 text-[12px] text-primary hover:underline"
             >
               {t('news.openOriginal')}
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -71,7 +71,7 @@ function ArticleRow({ article }: { article: NewsArticle }) {
         </div>
       ) : (
         article.content && (
-          <p className="mt-1 text-[12px] text-text-muted/50 truncate">{contentPreview}</p>
+          <p className="mt-1 text-[12px] text-muted-foreground/50 truncate">{contentPreview}</p>
         )
       )}
     </div>
@@ -132,7 +132,7 @@ export function NewsPage() {
             <select
               value={lookback}
               onChange={(e) => setLookback(e.target.value)}
-              className="bg-bg-tertiary text-text text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-accent"
+              className="bg-muted text-foreground text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-primary"
             >
               {LOOKBACK_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{t(o.labelKey)}</option>
@@ -142,7 +142,7 @@ export function NewsPage() {
             <select
               value={sourceFilter}
               onChange={(e) => setSourceFilter(e.target.value)}
-              className="bg-bg-tertiary text-text text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-accent"
+              className="bg-muted text-foreground text-sm rounded-md border border-border px-2 py-1.5 outline-none focus:border-primary"
             >
               <option value="">{t('news.allSources')}</option>
               {sources.map((s) => (
@@ -150,13 +150,13 @@ export function NewsPage() {
               ))}
             </select>
 
-            <span className="text-xs text-text-muted ml-auto">
+            <span className="text-xs text-muted-foreground ml-auto">
               {t('news.articleCount', { count: articles.length })}
             </span>
           </div>
 
           {/* Article list */}
-          <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border border-border bg-bg">
+          <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border border-border bg-background">
             {loading && articles.length === 0 ? (
               <div className="divide-y divide-border/50">
                 {Array.from({ length: 6 }).map((_, i) => (

--- a/ui/src/pages/OnboardingDesignPage.tsx
+++ b/ui/src/pages/OnboardingDesignPage.tsx
@@ -69,10 +69,10 @@ const STATE_LABEL: Record<Readiness, string> = {
 }
 
 const STATE_STYLE: Record<Readiness, string> = {
-  ready: 'border-green/25 bg-green/10 text-green',
-  attention: 'border-red/25 bg-red/10 text-red',
-  optional: 'border-border bg-bg-tertiary/60 text-text-muted',
-  locked: 'border-border bg-bg-secondary text-text-muted',
+  ready: 'border-success/25 bg-success/10 text-success',
+  attention: 'border-destructive/25 bg-destructive/10 text-destructive',
+  optional: 'border-border bg-muted/60 text-muted-foreground',
+  locked: 'border-border bg-secondary text-muted-foreground',
 }
 
 export function OnboardingDesignPage() {
@@ -132,24 +132,24 @@ export function OnboardingDesignPage() {
         {loading ? (
           <CenteredLoading label="Loading setup state..." />
         ) : error ? (
-          <div className="rounded-lg border border-red/30 bg-red/10 px-4 py-3 text-[13px] text-red">
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-[13px] text-destructive">
             {error}
           </div>
         ) : (
           <>
             <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
               <div className="min-w-0">
-                <div className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                   Setup checklist
                 </div>
-                <h1 className="mt-1 text-[24px] font-semibold leading-tight text-text">
+                <h1 className="mt-1 text-[24px] font-semibold leading-tight text-foreground">
                   Bring Alice online one layer at a time.
                 </h1>
-                <p className="mt-2 max-w-[680px] text-[13px] leading-relaxed text-text-muted">
+                <p className="mt-2 max-w-[680px] text-[13px] leading-relaxed text-muted-foreground">
                   Start with an agent runtime and AI access. Add UTA only when you want broker-aware analysis or trading workflows.
                 </p>
               </div>
-              <div className="flex flex-wrap items-center gap-2 text-[11px] text-text-muted">
+              <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
                 <StatusChip>{model.tradingModeLabel}</StatusChip>
                 <StatusChip>{model.installedAgentCount}/{model.agentCount} runtimes</StatusChip>
                 <StatusChip>{model.utaCount} UTA</StatusChip>
@@ -159,15 +159,15 @@ export function OnboardingDesignPage() {
             <StatusBand model={model} />
 
             <div className="grid min-w-0 gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
-              <section className="min-w-0 rounded-lg border border-border bg-bg-secondary/50">
+              <section className="min-w-0 rounded-lg border border-border bg-secondary/50">
                 <div className="border-b border-border px-4 py-3">
                   <div className="flex items-start gap-3">
-                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent-dim text-accent">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary-muted text-primary">
                       <TerminalSquare className="h-4 w-4" />
                     </div>
                     <div className="min-w-0">
-                      <h2 className="text-[16px] font-semibold text-text">Setup path</h2>
-                      <p className="mt-1 text-[12px] leading-relaxed text-text-muted">
+                      <h2 className="text-[16px] font-semibold text-foreground">Setup path</h2>
+                      <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
                         The first incomplete item is the next useful action.
                       </p>
                     </div>
@@ -190,8 +190,8 @@ export function OnboardingDesignPage() {
 
               <aside className="min-w-0 space-y-5">
                 <CapabilityPanel model={model} />
-                <div className="rounded-lg border border-border bg-bg-secondary/50 px-4 py-4">
-                  <div className="text-[11px] font-medium uppercase tracking-wide text-text-muted">
+                <div className="rounded-lg border border-border bg-secondary/50 px-4 py-4">
+                  <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                     Shortcuts
                   </div>
                   <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
@@ -370,7 +370,7 @@ export function buildOnboardingModel(input: {
 
 function StatusBand({ model }: { model: ReturnType<typeof buildOnboardingModel> }) {
   return (
-    <div className="border-y border-border bg-bg-secondary/35">
+    <div className="border-y border-border bg-secondary/35">
       <div className="grid grid-cols-2 divide-x divide-y divide-border lg:grid-cols-4 lg:divide-y-0">
         <StatusMetric label="Setup" value={`${model.readyCount}/${model.steps.length}`} sub="ready checks" />
         <StatusMetric label="Mode" value={model.tradingModeLabel} sub="global trading capability" />
@@ -384,24 +384,24 @@ function StatusBand({ model }: { model: ReturnType<typeof buildOnboardingModel> 
 function StatusMetric({ label, value, sub }: { label: string; value: string; sub: string }) {
   return (
     <div className="min-w-0 px-3 py-3">
-      <div className="text-[10px] uppercase tracking-wide text-text-muted">{label}</div>
-      <div className="mt-1 truncate text-[14px] font-semibold text-text">{value}</div>
-      <div className="mt-0.5 truncate text-[11px] text-text-muted">{sub}</div>
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-1 truncate text-[14px] font-semibold text-foreground">{value}</div>
+      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{sub}</div>
     </div>
   )
 }
 
 function CapabilityPanel({ model }: { model: ReturnType<typeof buildOnboardingModel> }) {
   return (
-    <section className="min-w-0 rounded-lg border border-border bg-bg-secondary/50">
+    <section className="min-w-0 rounded-lg border border-border bg-secondary/50">
       <div className="border-b border-border px-4 py-3">
         <div className="flex items-start gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent-dim text-accent">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary-muted text-primary">
             <Compass className="h-4 w-4" />
           </div>
           <div className="min-w-0">
-            <h2 className="text-[16px] font-semibold text-text">Capability map</h2>
-            <p className="mt-1 text-[12px] leading-relaxed text-text-muted">
+            <h2 className="text-[16px] font-semibold text-foreground">Capability map</h2>
+            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
               Shows what is usable in the current mode.
             </p>
           </div>
@@ -412,12 +412,12 @@ function CapabilityPanel({ model }: { model: ReturnType<typeof buildOnboardingMo
           const Icon = capability.icon
           return (
             <div key={capability.id} className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] gap-3 py-3">
-              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-bg-tertiary text-text-muted">
+              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-muted-foreground">
                 <Icon className="h-4 w-4" />
               </div>
               <div className="min-w-0">
-                <div className="truncate text-[13px] font-semibold text-text">{capability.label}</div>
-                <div className="mt-0.5 text-[12px] leading-relaxed text-text-muted">{capability.detail}</div>
+                <div className="truncate text-[13px] font-semibold text-foreground">{capability.label}</div>
+                <div className="mt-0.5 text-[12px] leading-relaxed text-muted-foreground">{capability.detail}</div>
               </div>
               <StateDot state={capability.state} />
             </div>
@@ -441,21 +441,21 @@ function StepRow({
   return (
     <div className="min-w-0 border-b border-border/70 py-4 last:border-b-0">
       <div className="flex min-w-0 items-start gap-3">
-        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-bg-tertiary text-[12px] font-semibold text-text-muted">
+        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-[12px] font-semibold text-muted-foreground">
           {index}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <Icon className="h-3.5 w-3.5 shrink-0 text-text-muted" />
-            <div className="min-w-0 text-[14px] font-semibold text-text">{step.title}</div>
+            <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 text-[14px] font-semibold text-foreground">{step.title}</div>
             <StateBadge state={step.state} />
           </div>
-          <p className="mt-1 text-[12px] leading-relaxed text-text-muted">{step.body}</p>
+          <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">{step.body}</p>
         </div>
         <button
           type="button"
           onClick={() => onAction(step.target)}
-          className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-bg text-text-muted transition-colors hover:border-accent/50 hover:text-accent"
+          className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
           aria-label={step.action}
           title={step.action}
         >
@@ -478,7 +478,7 @@ function PrimaryAction({
     <button
       type="button"
       onClick={() => onAction(step.target)}
-      className="flex w-full items-center justify-between gap-3 rounded-lg bg-accent px-3 py-2.5 text-left text-white transition-colors hover:bg-accent/90"
+      className="flex w-full items-center justify-between gap-3 rounded-lg bg-primary px-3 py-2.5 text-left text-primary-foreground transition-colors hover:bg-primary/90"
     >
       <span className="min-w-0 truncate text-[13px] font-semibold">{step.action}</span>
       <ArrowRight className="h-4 w-4 shrink-0" />
@@ -491,7 +491,7 @@ function SmallAction({ icon, label, onClick }: { icon: ReactNode; label: string;
     <button
       type="button"
       onClick={onClick}
-      className="flex min-h-9 min-w-0 items-center justify-center gap-2 rounded-md border border-border bg-bg px-3 py-2 text-[12px] font-medium text-text-muted transition-colors hover:border-accent/50 hover:text-accent"
+      className="flex min-h-9 min-w-0 items-center justify-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-[12px] font-medium text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
     >
       {icon}
       <span className="truncate">{label}</span>
@@ -524,7 +524,7 @@ function StateDot({ state }: { state: Readiness }) {
 
 function StatusChip({ children }: { children: ReactNode }) {
   return (
-    <span className="rounded-md border border-border bg-bg-secondary px-2 py-1">
+    <span className="rounded-md border border-border bg-secondary px-2 py-1">
       {children}
     </span>
   )

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -375,8 +375,8 @@ function NoAccountsEmpty() {
   }
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
-      <p className="text-sm font-medium text-text-muted">No trading accounts connected.</p>
-      <p className="mt-1.5 max-w-[320px] text-[12px] text-text-muted">
+      <p className="text-sm font-medium text-muted-foreground">No trading accounts connected.</p>
+      <p className="mt-1.5 max-w-[320px] text-[12px] text-muted-foreground">
         Portfolio shows live equity, positions and PnL across all your brokers. Add a connection to get started.
       </p>
       <button
@@ -397,8 +397,8 @@ function HeroMetrics({ equity, curve }: {
 }) {
   if (!equity) {
     return (
-      <div className="border border-border rounded-lg bg-bg-secondary p-5 text-center">
-        <p className="text-[13px] text-text-muted">Unable to load portfolio data.</p>
+      <div className="border border-border rounded-lg bg-secondary p-5 text-center">
+        <p className="text-[13px] text-muted-foreground">Unable to load portfolio data.</p>
       </div>
     )
   }
@@ -420,7 +420,7 @@ function HeroMetrics({ equity, curve }: {
   }
 
   return (
-    <div className="border border-border rounded-lg bg-bg-secondary px-5 py-5 space-y-4">
+    <div className="border border-border rounded-lg bg-secondary px-5 py-5 space-y-4">
       <Metric
         size="lg"
         label="Total Equity · USD"
@@ -456,7 +456,7 @@ function PortfolioSkeleton() {
   return (
     <div className="space-y-5" aria-hidden="true">
       {/* Hero metrics */}
-      <div className="rounded-lg border border-border bg-bg-secondary p-5">
+      <div className="rounded-lg border border-border bg-secondary p-5">
         <Skeleton className="h-3 w-24" />
         <Skeleton className="h-9 w-48 mt-3" />
         <div className="flex flex-wrap gap-5 sm:gap-8 mt-5">
@@ -473,7 +473,7 @@ function PortfolioSkeleton() {
       {/* Account strip */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
         {Array.from({ length: 2 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-3 px-3.5 py-3 rounded-lg border border-border bg-bg-secondary">
+          <div key={i} className="flex items-center gap-3 px-3.5 py-3 rounded-lg border border-border bg-secondary">
             <Skeleton className="h-1.5 w-1.5 rounded-full" />
             <div className="flex-1 space-y-2">
               <Skeleton className="h-3 w-24" />
@@ -485,7 +485,7 @@ function PortfolioSkeleton() {
       </div>
       {/* Positions table */}
       <div className="rounded-lg border border-border overflow-hidden">
-        <div className="px-4 py-2.5 border-b border-border bg-bg-secondary">
+        <div className="px-4 py-2.5 border-b border-border bg-secondary">
           <Skeleton className="h-3 w-32" />
         </div>
         <div className="divide-y divide-border">
@@ -506,9 +506,9 @@ function PortfolioSkeleton() {
 // ==================== Account Strip ====================
 
 const HEALTH_DOT: Record<string, string> = {
-  healthy: 'bg-green',
-  degraded: 'bg-yellow-400',
-  offline: 'bg-red',
+  healthy: 'bg-success',
+  degraded: 'bg-warning',
+  offline: 'bg-destructive',
 }
 
 function AccountStrip({ sources, perAccountCurve }: {
@@ -524,49 +524,49 @@ function AccountStrip({ sources, perAccountCurve }: {
         const isConnecting = !!s.connecting && !isDisabled
         const isOffline = s.health === 'offline' && !isDisabled && !isConnecting
         const dotColor = isDisabled
-          ? 'bg-text-muted/40'
+          ? 'bg-muted-foreground/40'
           : isConnecting
-            ? 'bg-accent'
-            : (HEALTH_DOT[s.health ?? 'healthy'] ?? 'bg-text-muted')
+            ? 'bg-primary'
+            : (HEALTH_DOT[s.health ?? 'healthy'] ?? 'bg-muted-foreground')
 
         const curve = perAccountCurve[s.id]
         const todayDelta = computeTodayDelta(curve ?? null)
         const showSpark = !isDisabled && !isOffline && !isConnecting && curve && curve.values.length >= 2
 
         return (
-          <div key={s.id} className={`flex items-center gap-3 px-3.5 py-3 rounded-lg border border-border bg-bg-secondary ${isOffline || isDisabled ? 'opacity-60' : ''}`}>
+          <div key={s.id} className={`flex items-center gap-3 px-3.5 py-3 rounded-lg border border-border bg-secondary ${isOffline || isDisabled ? 'opacity-60' : ''}`}>
             <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor} ${isConnecting ? 'animate-pulse' : ''}`} />
             <div className="flex-1 min-w-0">
               <div className="flex items-baseline justify-between gap-2">
-                <span className="text-text font-medium text-[13px] truncate">{s.label}</span>
+                <span className="text-foreground font-medium text-[13px] truncate">{s.label}</span>
                 {!isDisabled && !isOffline && !isConnecting && (
-                  <span className="text-text-muted tabular-nums text-[13px]">{fmt(Number(s.equity))}</span>
+                  <span className="text-muted-foreground tabular-nums text-[13px]">{fmt(Number(s.equity))}</span>
                 )}
               </div>
               <div className="flex items-baseline justify-between gap-2 mt-0.5">
                 {isDisabled
-                  ? <span className="text-text-muted text-[11px]">Disabled</span>
+                  ? <span className="text-muted-foreground text-[11px]">Disabled</span>
                   : isConnecting
-                    ? <span className="text-accent text-[11px]">Connecting...</span>
+                    ? <span className="text-primary text-[11px]">Connecting...</span>
                   : isOffline
-                    ? <span className="text-red text-[11px]">Reconnecting…</span>
+                    ? <span className="text-destructive text-[11px]">Reconnecting…</span>
                     : (
                       <span className="text-[11px] tabular-nums">
                         {todayDelta ? (
-                          <span className={todayDelta.delta >= 0 ? 'text-green' : 'text-red'}>
+                          <span className={todayDelta.delta >= 0 ? 'text-success' : 'text-destructive'}>
                             {todayDelta.delta >= 0 ? '▲' : '▼'} {fmtPnl(todayDelta.delta)} today
                           </span>
                         ) : s.unrealizedPnL !== 0 ? (
-                          <span className={s.unrealizedPnL >= 0 ? 'text-green' : 'text-red'}>
+                          <span className={s.unrealizedPnL >= 0 ? 'text-success' : 'text-destructive'}>
                             {fmtPnl(s.unrealizedPnL)} unrealized
                           </span>
                         ) : (
-                          <span className="text-text-muted">—</span>
+                          <span className="text-muted-foreground">—</span>
                         )}
                       </span>
                     )
                 }
-                {s.error && !isOffline && !isDisabled && <span className="text-[11px] text-text-muted">{s.error}</span>}
+                {s.error && !isOffline && !isDisabled && <span className="text-[11px] text-muted-foreground">{s.error}</span>}
               </div>
             </div>
             {showSpark && (
@@ -610,13 +610,13 @@ function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount
 
   return (
     <div>
-      <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wide mb-3">
+      <h3 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wide mb-3">
         Positions
       </h3>
       <div className="border border-border rounded-lg overflow-x-auto">
         <table className="w-full text-[13px]">
           <thead>
-            <tr className="bg-bg-secondary text-text-muted text-left">
+            <tr className="bg-secondary text-muted-foreground text-left">
               <th className="px-3 py-2 font-medium">Symbol</th>
               <th className="px-3 py-2 font-medium text-center">Ccy</th>
               <th className="px-3 py-2 font-medium text-right">Qty</th>
@@ -637,31 +637,31 @@ function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount
               const isShort = p.side === 'short'
 
               return (
-                <tr key={i} className="border-t border-border hover:bg-bg-tertiary/30 transition-colors">
+                <tr key={i} className="border-t border-border hover:bg-muted/30 transition-colors">
                   <td className="px-3 py-2">
                     <div className="flex items-center gap-1.5 flex-wrap">
-                      <span className="font-medium text-text">{display.name}</span>
-                      <span className="text-[10px] px-1 py-0.5 rounded bg-bg-tertiary text-text-muted font-mono tracking-tight">{display.tag}</span>
+                      <span className="font-medium text-foreground">{display.name}</span>
+                      <span className="text-[10px] px-1 py-0.5 rounded bg-muted text-muted-foreground font-mono tracking-tight">{display.tag}</span>
                       {isShort && (
-                        <span className="text-[10px] px-1 py-0.5 rounded font-medium bg-red/15 text-red">SHORT</span>
+                        <span className="text-[10px] px-1 py-0.5 rounded font-medium bg-destructive/15 text-destructive">SHORT</span>
                       )}
-                      <span className="text-[10px] text-text-muted">{p.accountLabel}</span>
+                      <span className="text-[10px] text-muted-foreground">{p.accountLabel}</span>
                     </div>
                   </td>
-                  <td className="px-3 py-2 text-center text-text-muted text-[11px]">{ccy}</td>
-                  <td className="px-3 py-2 text-right text-text">{fmtNum(Number(p.quantity))}</td>
-                  <td className="px-3 py-2 text-right text-text-muted">{fmt(Number(p.avgCost), p.currency)}</td>
-                  <td className="px-3 py-2 text-right text-text">{fmt(Number(p.marketPrice), p.currency)}</td>
-                  <td className="px-3 py-2 text-right text-text">{fmt(Number(p.marketValue), p.currency)}</td>
+                  <td className="px-3 py-2 text-center text-muted-foreground text-[11px]">{ccy}</td>
+                  <td className="px-3 py-2 text-right text-foreground">{fmtNum(Number(p.quantity))}</td>
+                  <td className="px-3 py-2 text-right text-muted-foreground">{fmt(Number(p.avgCost), p.currency)}</td>
+                  <td className="px-3 py-2 text-right text-foreground">{fmt(Number(p.marketPrice), p.currency)}</td>
+                  <td className="px-3 py-2 text-right text-foreground">{fmt(Number(p.marketValue), p.currency)}</td>
                   {hasNonUsd && (
-                    <td className="px-3 py-2 text-right text-text-muted">
+                    <td className="px-3 py-2 text-right text-muted-foreground">
                       {ccy === 'USD' ? '—' : fmt(usdValue)}
                     </td>
                   )}
-                  <td className={`px-3 py-2 text-right font-medium ${Number(p.unrealizedPnL) >= 0 ? 'text-green' : 'text-red'}`}>
+                  <td className={`px-3 py-2 text-right font-medium ${Number(p.unrealizedPnL) >= 0 ? 'text-success' : 'text-destructive'}`}>
                     {fmtPnl(Number(p.unrealizedPnL), p.currency)}
                   </td>
-                  <td className={`px-3 py-2 text-right ${Number(p.unrealizedPnL) >= 0 ? 'text-green' : 'text-red'}`}>
+                  <td className={`px-3 py-2 text-right ${Number(p.unrealizedPnL) >= 0 ? 'text-success' : 'text-destructive'}`}>
                     {(() => {
                       const cost = Number(p.avgCost) * Number(p.quantity)
                       const pct = cost > 0 ? (Number(p.unrealizedPnL) / cost) * 100 : 0
@@ -683,7 +683,7 @@ function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount
 function FxRatesPanel({ rates }: { rates: FxRateInfo[] }) {
   return (
     <div>
-      <h3 className="text-[11px] font-semibold text-text-muted uppercase tracking-wide mb-2">
+      <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wide mb-2">
         FX Rates
       </h3>
       <div className="border border-border rounded-lg overflow-hidden">
@@ -693,17 +693,17 @@ function FxRatesPanel({ rates }: { rates: FxRateInfo[] }) {
               <tr key={r.currency} className="border-t border-border first:border-t-0">
                 <td className="px-2.5 py-1.5">
                   <div className="flex items-center gap-1.5">
-                    <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${r.source === 'live' ? 'bg-green' : r.source === 'cached' ? 'bg-yellow-400' : 'bg-text-muted/40'}`} />
-                    <span className="font-medium text-text">{r.currency}</span>
+                    <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${r.source === 'live' ? 'bg-success' : r.source === 'cached' ? 'bg-warning' : 'bg-muted-foreground/40'}`} />
+                    <span className="font-medium text-foreground">{r.currency}</span>
                   </div>
                 </td>
-                <td className="px-2.5 py-1.5 text-right text-text tabular-nums">{r.rate.toFixed(4)}</td>
+                <td className="px-2.5 py-1.5 text-right text-foreground tabular-nums">{r.rate.toFixed(4)}</td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-      <p className="mt-1.5 text-right text-[10px] text-text-muted">per 1 unit → USD</p>
+      <p className="mt-1.5 text-right text-[10px] text-muted-foreground">per 1 unit → USD</p>
     </div>
   )
 }
@@ -724,36 +724,36 @@ function TradeLog({ commits }: { commits: CommitWithAccount[] }) {
 
   return (
     <div>
-      <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wide mb-3">
+      <h3 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wide mb-3">
         Recent Trades
       </h3>
       <div className="space-y-2">
         {sorted.map((commit) => {
           const badgeColor = commit.accountProvider === 'ccxt'
-            ? 'bg-accent/15 text-accent'
+            ? 'bg-primary/15 text-primary'
             : commit.accountProvider === 'alpaca'
-              ? 'bg-green/15 text-green'
-              : 'bg-bg-tertiary text-text-muted'
+              ? 'bg-success/15 text-success'
+              : 'bg-muted text-muted-foreground'
           return (
-            <div key={commit.hash} className="border border-border rounded-lg bg-bg-secondary px-3 py-2.5">
+            <div key={commit.hash} className="border border-border rounded-lg bg-secondary px-3 py-2.5">
               <div className="flex items-start gap-2">
                 <span className={`text-[10px] font-mono px-1.5 py-0.5 rounded ${badgeColor}`}>
                   {commit.accountLabel}
                 </span>
                 <div className="flex-1 min-w-0">
-                  <p className="text-[13px] text-text truncate">{commit.message}</p>
+                  <p className="text-[13px] text-foreground truncate">{commit.message}</p>
                   <div className="flex items-center gap-3 mt-1">
-                    <span className="text-[11px] text-text-muted font-mono">{commit.hash}</span>
-                    <span className="text-[11px] text-text-muted">
+                    <span className="text-[11px] text-muted-foreground font-mono">{commit.hash}</span>
+                    <span className="text-[11px] text-muted-foreground">
                       {new Date(commit.timestamp).toLocaleString()}
                     </span>
                   </div>
                   {commit.operations.length > 0 && (
                     <div className="mt-1.5 flex flex-wrap gap-1.5">
                       {commit.operations.map((op, i) => (
-                        <span key={i} className="text-[11px] text-text-muted bg-bg px-1.5 py-0.5 rounded">
+                        <span key={i} className="text-[11px] text-muted-foreground bg-background px-1.5 py-0.5 rounded">
                           {op.symbol} {op.change}
-                          <span className={`ml-1 ${op.status === 'filled' ? 'text-green' : op.status === 'rejected' ? 'text-red' : op.status === 'submitted' ? 'text-accent' : 'text-text-muted'}`}>
+                          <span className={`ml-1 ${op.status === 'filled' ? 'text-success' : op.status === 'rejected' ? 'text-destructive' : op.status === 'submitted' ? 'text-primary' : 'text-muted-foreground'}`}>
                             {op.status}
                           </span>
                         </span>
@@ -791,15 +791,15 @@ function SnapshotSettings({ enabled, every, onEnabledChange, onEveryChange, save
   const [showCustom, setShowCustom] = useState(!isPreset)
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-border/70 bg-bg-secondary/45 px-3 py-2.5 text-[12px] text-text-muted sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-2 rounded-lg border border-border/70 bg-secondary/45 px-3 py-2.5 text-[12px] text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
       <div className="flex items-center gap-2">
         <span className="font-semibold uppercase tracking-wide">Snapshots</span>
         <Toggle checked={enabled} onChange={onEnabledChange} size="sm" ariaLabel="Enable portfolio snapshots" />
-        {saveStatus === 'saving' && <span className="text-[10px] text-accent">saving...</span>}
-        {saveStatus === 'error' && <span className="text-[10px] text-red">save failed</span>}
+        {saveStatus === 'saving' && <span className="text-[10px] text-primary">saving...</span>}
+        {saveStatus === 'error' && <span className="text-[10px] text-destructive">save failed</span>}
       </div>
       <div className="flex min-w-0 items-center gap-2">
-        <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Every</span>
+        <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Every</span>
         <SegmentedControl
           value={showCustom ? 'custom' : every}
           options={[
@@ -820,7 +820,7 @@ function SnapshotSettings({ enabled, every, onEnabledChange, onEveryChange, save
         {showCustom && (
           <input
             aria-label="Custom portfolio snapshot interval"
-            className="w-16 rounded-md border border-border bg-bg px-1.5 py-1 text-center text-[12px] text-text outline-none focus:border-accent"
+            className="w-16 rounded-md border border-border bg-background px-1.5 py-1 text-center text-[12px] text-foreground outline-none focus:border-primary"
             value={every}
             onChange={(e) => onEveryChange(e.target.value)}
             placeholder="e.g. 2h"

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -22,10 +22,10 @@ function AppearanceSection() {
     <ConfigSection title={t('settings.appearance.title')} description={t('settings.appearance.description')}>
       <div className="flex items-center justify-between gap-4 py-1">
         <div className="flex-1">
-          <span className="text-sm font-medium text-text">
+          <span className="text-sm font-medium text-foreground">
             {t('settings.appearance.showEditorTabs')}
           </span>
-          <p className="text-[12px] text-text-muted mt-0.5 leading-relaxed">
+          <p className="text-[12px] text-muted-foreground mt-0.5 leading-relaxed">
             {showEditorTabs
               ? t('settings.appearance.showEditorTabsOn')
               : t('settings.appearance.showEditorTabsOff')}
@@ -53,8 +53,8 @@ function LanguageSection() {
             onClick={() => setLocale(l)}
             className={`px-3 py-1.5 text-sm rounded border transition-colors ${
               locale === l
-                ? 'border-accent text-accent bg-accent/10'
-                : 'border-border text-text-muted hover:text-text'
+                ? 'border-primary text-primary bg-primary/10'
+                : 'border-border text-muted-foreground hover:text-foreground'
             }`}
           >
             {LOCALE_LABELS[l]}
@@ -88,12 +88,12 @@ export function DataHomeSection() {
         title={t('settings.dataHome.title')}
         description={t('settings.dataHome.description')}
       >
-        <div className="rounded-lg border border-border/60 bg-bg-secondary/50 px-3 py-3">
-          <p className="text-[13px] text-text">{t('settings.dataHome.browserOnly')}</p>
-          <p className="mt-2 break-all font-mono text-[12px] text-text-muted">
+        <div className="rounded-lg border border-border/60 bg-secondary/50 px-3 py-3">
+          <p className="text-[13px] text-foreground">{t('settings.dataHome.browserOnly')}</p>
+          <p className="mt-2 break-all font-mono text-[12px] text-muted-foreground">
             openalice start --home &lt;path&gt;
           </p>
-          <p className="mt-1 break-all font-mono text-[12px] text-text-muted">
+          <p className="mt-1 break-all font-mono text-[12px] text-muted-foreground">
             pnpm dev -- --home &lt;path&gt;
           </p>
         </div>
@@ -139,21 +139,21 @@ export function DataHomeSection() {
       title={t('settings.dataHome.title')}
       description={t('settings.dataHome.description')}
     >
-      <div className="rounded-lg border border-border/60 bg-bg-secondary/50 px-3 py-3">
+      <div className="rounded-lg border border-border/60 bg-secondary/50 px-3 py-3">
         <div className="flex items-center justify-between gap-3">
-          <p className="text-[11px] uppercase tracking-wide text-text-muted">
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
             {t('settings.dataHome.current')}
           </p>
           {status && (
-            <span className="rounded-full border border-border px-2 py-0.5 text-[10px] text-text-muted">
+            <span className="rounded-full border border-border px-2 py-0.5 text-[10px] text-muted-foreground">
               {t(`settings.dataHome.source.${status.source}`)}
             </span>
           )}
         </div>
-        <p data-testid="data-home-current" className="mt-1 break-all font-mono text-[12px] text-text">
+        <p data-testid="data-home-current" className="mt-1 break-all font-mono text-[12px] text-foreground">
           {status?.currentHome ?? t('settings.dataHome.loading')}
         </p>
-        <p className="mt-2 text-[11px] leading-relaxed text-text-muted">
+        <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
           {t('settings.dataHome.switchNote')}
         </p>
       </div>
@@ -182,8 +182,8 @@ export function DataHomeSection() {
 
       <div className="mt-4 flex items-center justify-between gap-4 rounded-lg border border-border/60 px-3 py-2.5">
         <div className="flex-1">
-          <p className="text-[13px] font-medium text-text">{t('settings.dataHome.askOnStartup')}</p>
-          <p className="mt-0.5 text-[11px] leading-relaxed text-text-muted">
+          <p className="text-[13px] font-medium text-foreground">{t('settings.dataHome.askOnStartup')}</p>
+          <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
             {t('settings.dataHome.askOnStartupDescription')}
           </p>
         </div>
@@ -197,13 +197,13 @@ export function DataHomeSection() {
 
       {recentHomes.length > 0 && (
         <div className="mt-4">
-          <p className="mb-2 text-[11px] uppercase tracking-wide text-text-muted">
+          <p className="mb-2 text-[11px] uppercase tracking-wide text-muted-foreground">
             {t('settings.dataHome.recent')}
           </p>
           <div className="space-y-2">
             {recentHomes.map((path) => (
               <div key={path} className="flex items-center gap-2 rounded-lg border border-border/60 px-3 py-2">
-                <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-text" title={path}>
+                <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground" title={path}>
                   {path}
                 </span>
                 <button
@@ -221,11 +221,11 @@ export function DataHomeSection() {
       )}
 
       {lockDescription && (
-        <p className="mt-3 rounded-lg border border-yellow/30 bg-yellow/5 px-3 py-2 text-[11px] leading-relaxed text-yellow">
+        <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] leading-relaxed text-warning">
           {lockDescription}
         </p>
       )}
-      {error && <p className="mt-3 text-[11px] text-red">{error}</p>}
+      {error && <p className="mt-3 text-[11px] text-destructive">{error}</p>}
     </ConfigSection>
   )
 }
@@ -303,14 +303,14 @@ function WorkspaceShellSection() {
           />
         </Field>
       )}
-      <div className="rounded-lg border border-border/60 bg-bg-secondary/50 px-3 py-2.5 mb-3">
-        <p className="text-[11px] uppercase tracking-wide text-text-muted">
+      <div className="rounded-lg border border-border/60 bg-secondary/50 px-3 py-2.5 mb-3">
+        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
           {t('settings.workspaceShell.resolved')}
         </p>
-        <p className="mt-1 break-all font-mono text-[12px] text-text">
+        <p className="mt-1 break-all font-mono text-[12px] text-foreground">
           {status.resolvedPath ?? t('settings.workspaceShell.notFound')}
         </p>
-        <p className={`mt-1 text-[11px] ${status.valid ? 'text-green' : 'text-red'}`}>
+        <p className={`mt-1 text-[11px] ${status.valid ? 'text-success' : 'text-destructive'}`}>
           {status.valid
             ? t('settings.workspaceShell.source', { source: status.source })
             : status.message ?? t('settings.workspaceShell.notFound')}
@@ -325,7 +325,7 @@ function WorkspaceShellSection() {
         >
           {saving ? t('settings.workspaceShell.saving') : t('settings.workspaceShell.save')}
         </button>
-        {error && <span className="text-[11px] text-red">{error}</span>}
+        {error && <span className="text-[11px] text-destructive">{error}</span>}
       </div>
     </ConfigSection>
   )
@@ -441,7 +441,7 @@ function PersonaEditor() {
     }
   }
 
-  if (loading) return <div className="text-sm text-text-muted">{t('settings.persona.loading')}</div>
+  if (loading) return <div className="text-sm text-muted-foreground">{t('settings.persona.loading')}</div>
 
   return (
     <>
@@ -460,21 +460,21 @@ function PersonaEditor() {
         </button>
         {saved && (
           <span className="inline-flex items-center gap-1.5 text-[11px]">
-            <span className="w-1.5 h-1.5 rounded-full bg-green" />
-            <span className="text-text-muted">{t('settings.persona.saved')}</span>
+            <span className="w-1.5 h-1.5 rounded-full bg-success" />
+            <span className="text-muted-foreground">{t('settings.persona.saved')}</span>
           </span>
         )}
         {error && (
           <span className="inline-flex items-center gap-1.5 text-[11px]">
-            <span className="w-1.5 h-1.5 rounded-full bg-red" />
-            <span className="text-red">{error}</span>
+            <span className="w-1.5 h-1.5 rounded-full bg-destructive" />
+            <span className="text-destructive">{error}</span>
           </span>
         )}
         {dirty && !saved && !error && (
-          <span className="text-[11px] text-text-muted">{t('settings.persona.unsaved')}</span>
+          <span className="text-[11px] text-muted-foreground">{t('settings.persona.unsaved')}</span>
         )}
       </div>
-      {filePath && <p className="text-[11px] text-text-muted mt-1">{filePath}</p>}
+      {filePath && <p className="text-[11px] text-muted-foreground mt-1">{filePath}</p>}
     </>
   )
 }
@@ -577,7 +577,7 @@ function ToolsSection() {
       ) : (
         <div className="max-w-[880px] mx-auto">
           <div className="flex items-center justify-between mb-4">
-            <p className="text-[13px] text-text-muted">
+            <p className="text-[13px] text-muted-foreground">
               {t('settings.tools.summary', { tools: inventory.length, groups: groups.length })}
             </p>
             <SaveIndicator status={status} onRetry={retry} />
@@ -629,7 +629,7 @@ function ToolGroupCard({
   return (
     <div className="border border-border rounded-lg overflow-hidden">
       {/* Group header */}
-      <div className="flex items-center gap-3 px-4 py-2.5 bg-bg-secondary">
+      <div className="flex items-center gap-3 px-4 py-2.5 bg-secondary">
         <button
           onClick={onToggleExpanded}
           className="flex items-center gap-2 flex-1 text-left min-w-0"
@@ -641,8 +641,8 @@ function ToolGroupCard({
           >
             <polyline points="9 18 15 12 9 6" />
           </svg>
-          <span className="text-sm font-medium text-text truncate">{label}</span>
-          <span className="text-[11px] text-text-muted shrink-0">
+          <span className="text-sm font-medium text-foreground truncate">{label}</span>
+          <span className="text-[11px] text-muted-foreground shrink-0">
             {enabledCount}/{group.tools.length}
           </span>
         </button>
@@ -670,9 +670,9 @@ function ToolGroupCard({
                 }`}
               >
                 <div className="flex-1 min-w-0">
-                  <span className="text-[13px] text-text font-mono">{t.name}</span>
+                  <span className="text-[13px] text-foreground font-mono">{t.name}</span>
                   {t.description && (
-                    <p className="text-[11px] text-text-muted mt-0.5 line-clamp-1">
+                    <p className="text-[11px] text-muted-foreground mt-0.5 line-clamp-1">
                       {t.description}
                     </p>
                   )}
@@ -715,12 +715,12 @@ export function SettingsPage() {
               key={item.key}
               onClick={() => setTab(item.key)}
               className={`px-3 py-2 text-sm font-medium transition-colors relative ${
-                tab === item.key ? 'text-accent' : 'text-text-muted hover:text-text'
+                tab === item.key ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               {t(item.labelKey)}
               {tab === item.key && (
-                <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-accent rounded-t" />
+                <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-primary rounded-t" />
               )}
             </button>
           ))}

--- a/ui/src/pages/SimulatorPage.tsx
+++ b/ui/src/pages/SimulatorPage.tsx
@@ -102,8 +102,8 @@ function TopBar({ utas, selectedId, onSelect, cash, onRefresh }: {
               title={u.id}
               className={`px-2.5 py-1 text-sm rounded transition-colors ${
                 active
-                  ? 'bg-accent/15 text-accent font-medium border border-accent/30'
-                  : 'text-text-muted hover:text-text border border-transparent hover:bg-bg-tertiary/50'
+                  ? 'bg-primary/15 text-primary font-medium border border-primary/30'
+                  : 'text-muted-foreground hover:text-foreground border border-transparent hover:bg-muted/50'
               }`}
             >
               {u.label}
@@ -114,14 +114,14 @@ function TopBar({ utas, selectedId, onSelect, cash, onRefresh }: {
 
       <button
         onClick={onRefresh}
-        className="px-2.5 py-1 text-xs bg-bg-tertiary text-text-muted rounded hover:text-text transition-colors"
+        className="px-2.5 py-1 text-xs bg-muted text-muted-foreground rounded hover:text-foreground transition-colors"
       >
         Refresh
       </button>
 
       {cash !== undefined && (
-        <span className="ml-auto text-[12px] text-text-muted uppercase tracking-wide">
-          Cash <span className="font-mono text-text text-sm normal-case ml-1.5">
+        <span className="ml-auto text-[12px] text-muted-foreground uppercase tracking-wide">
+          Cash <span className="font-mono text-foreground text-sm normal-case ml-1.5">
             ${Number(cash).toLocaleString(getIntlLocale(), { minimumFractionDigits: 2 })}
           </span>
         </span>

--- a/ui/src/pages/TemplateCatalogPage.tsx
+++ b/ui/src/pages/TemplateCatalogPage.tsx
@@ -45,8 +45,8 @@ export function TemplateCatalogPage() {
 
   if (official.length + community.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-text-muted px-6">
-        <h2 className="text-lg font-medium text-text mb-2">{t('templates.emptyTitle')}</h2>
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground px-6">
+        <h2 className="text-lg font-medium text-foreground mb-2">{t('templates.emptyTitle')}</h2>
         <p className="text-sm max-w-md text-center">
           {t('templates.emptyBody')}
         </p>
@@ -73,8 +73,8 @@ export function TemplateCatalogPage() {
     <div className="h-full overflow-y-auto">
       <div className="max-w-5xl mx-auto px-6 py-6">
         <div className="mb-6">
-          <h2 className="text-[18px] font-semibold text-text">{t('templates.catalogTitle')}</h2>
-          <p className="text-[12px] text-text-muted mt-1 max-w-2xl">
+          <h2 className="text-[18px] font-semibold text-foreground">{t('templates.catalogTitle')}</h2>
+          <p className="text-[12px] text-muted-foreground mt-1 max-w-2xl">
             {t('templates.catalogDescription')}
           </p>
         </div>
@@ -84,8 +84,8 @@ export function TemplateCatalogPage() {
         {community.length > 0 && (
           <div className="mt-8">
             <div className="mb-4">
-              <h3 className="text-[14px] font-semibold text-text">{t('templates.communityTitle')}</h3>
-              <p className="text-[12px] text-text-muted mt-1 max-w-2xl">
+              <h3 className="text-[14px] font-semibold text-foreground">{t('templates.communityTitle')}</h3>
+              <p className="text-[12px] text-muted-foreground mt-1 max-w-2xl">
                 {t('templates.communityDescription')}
               </p>
             </div>

--- a/ui/src/pages/TemplateDetailPage.tsx
+++ b/ui/src/pages/TemplateDetailPage.tsx
@@ -76,8 +76,8 @@ export function TemplateDetailPage({ spec }: Props) {
 
   if (!template) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-text-muted px-6">
-        <h2 className="text-lg font-medium text-text mb-2">{t('templates.notFoundTitle')}</h2>
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground px-6">
+        <h2 className="text-lg font-medium text-foreground mb-2">{t('templates.notFoundTitle')}</h2>
         <p className="text-sm">{t('templates.notFoundBody', { name: templateName })}</p>
       </div>
     )
@@ -97,36 +97,36 @@ export function TemplateDetailPage({ spec }: Props) {
         <div className="mb-5 flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-baseline gap-2.5 flex-wrap">
-              <h2 className="text-[20px] font-semibold text-text truncate">{title}</h2>
-              <span className="text-[12px] font-mono text-text-muted tabular-nums shrink-0">
+              <h2 className="text-[20px] font-semibold text-foreground truncate">{title}</h2>
+              <span className="text-[12px] font-mono text-muted-foreground tabular-nums shrink-0">
                 v{template.version}
               </span>
               {template.community && (
-                <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-border text-text-muted shrink-0">
+                <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-border text-muted-foreground shrink-0">
                   {t('templates.communityBadge')}
                 </span>
               )}
             </div>
             {template.description && (
-              <p className="text-[12px] text-text-muted mt-1.5 max-w-2xl leading-relaxed">
+              <p className="text-[12px] text-muted-foreground mt-1.5 max-w-2xl leading-relaxed">
                 {template.description}
               </p>
             )}
             <div className="flex items-center gap-3 mt-2.5 flex-wrap">
-              <span className="text-[10px] uppercase tracking-wider text-text-muted/70">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
                 {t('templates.agentsLabel')}
               </span>
               <div className="flex items-center gap-2 flex-wrap">
                 {agents.map((a) => (
                   <span
                     key={a.id}
-                    className="text-[11px] font-mono text-text-muted px-1.5 py-0.5 rounded bg-bg-tertiary"
+                    className="text-[11px] font-mono text-muted-foreground px-1.5 py-0.5 rounded bg-muted"
                   >
                     {a.id}
                   </span>
                 ))}
               </div>
-              <span className="text-[11px] font-mono text-text-muted/60">
+              <span className="text-[11px] font-mono text-muted-foreground/60">
                 {template.name}
               </span>
             </div>
@@ -141,18 +141,18 @@ export function TemplateDetailPage({ spec }: Props) {
         </div>
 
         {/* README body — the template's starting-shape doc */}
-        <div className="text-[10px] uppercase tracking-wider text-text-muted/70 mb-2">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-2">
           {t('templates.readmeLabel')}
         </div>
-        <div className="rounded-lg border border-border bg-bg-secondary px-6 py-5">
+        <div className="rounded-lg border border-border bg-secondary px-6 py-5">
           {readme === null && !readmeMissing && readmeError === null && (
-            <p className="text-[12px] text-text-muted italic">{t('templates.loadingReadme')}</p>
+            <p className="text-[12px] text-muted-foreground italic">{t('templates.loadingReadme')}</p>
           )}
           {readmeMissing && (
-            <p className="text-[12px] text-text-muted italic">{t('templates.noReadme')}</p>
+            <p className="text-[12px] text-muted-foreground italic">{t('templates.noReadme')}</p>
           )}
           {readmeError && (
-            <p className="text-[12px] text-text-muted italic">{readmeError}</p>
+            <p className="text-[12px] text-muted-foreground italic">{readmeError}</p>
           )}
           {readmeBody && (
             <MarkdownContent text={readmeBody} className="text-[13px] leading-relaxed" />

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -61,7 +61,7 @@ export function TrackedPage() {
         ) : entities.length === 0 ? (
           <EmptyState />
         ) : !selectedName ? (
-          <div className="px-6 py-8 text-text-muted text-sm">{t('tracked.selectFromSidebar')}</div>
+          <div className="px-6 py-8 text-muted-foreground text-sm">{t('tracked.selectFromSidebar')}</div>
         ) : detailLoading || !detail ? (
           <PageLoading />
         ) : (
@@ -81,7 +81,7 @@ function TrackedListSkeleton() {
       {widths.map((w, i) => (
         <div
           key={i}
-          className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-bg-tertiary/30"
+          className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-muted/30"
         >
           <Skeleton className="h-3.5 w-3.5 rounded shrink-0" />
           <Skeleton className={`h-3.5 ${w} rounded`} />
@@ -97,12 +97,12 @@ function EmptyState() {
   const { t } = useTranslation()
   return (
     <div className="px-6 py-16 text-center max-w-[520px] mx-auto">
-      <div className="text-[15px] text-text mb-2">{t('tracked.nothingTrackedYet')}</div>
-      <p className="text-[13px] text-text-muted leading-relaxed">
+      <div className="text-[15px] text-foreground mb-2">{t('tracked.nothingTrackedYet')}</div>
+      <p className="text-[13px] text-muted-foreground leading-relaxed">
         As an agent works, it registers the assets and topics worth following with the
-        <code className="mx-1 px-1 py-0.5 rounded bg-bg-tertiary text-[11px]">entity_upsert</code>
+        <code className="mx-1 px-1 py-0.5 rounded bg-muted text-[11px]">entity_upsert</code>
         tool, and links to them from its notes with
-        <code className="mx-1 px-1 py-0.5 rounded bg-bg-tertiary text-[11px]">[[name]]</code>. They
+        <code className="mx-1 px-1 py-0.5 rounded bg-muted text-[11px]">[[name]]</code>. They
         show up here as a running watchlist — each with the notes that reference it.
       </p>
     </div>
@@ -116,19 +116,19 @@ function Detail({ detail }: { detail: EntityDetail }) {
   return (
     <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
       <div className="flex items-center gap-2.5 mb-2">
-        <Icon size={20} strokeWidth={1.75} className="shrink-0 text-text-muted" aria-hidden />
-        <h2 className="text-[20px] font-semibold font-mono text-text">{entity.name}</h2>
-        <span className="text-[11px] px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted uppercase tracking-wide">
+        <Icon size={20} strokeWidth={1.75} className="shrink-0 text-muted-foreground" aria-hidden />
+        <h2 className="text-[20px] font-semibold font-mono text-foreground">{entity.name}</h2>
+        <span className="text-[11px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground uppercase tracking-wide">
           {entity.type}
         </span>
       </div>
-      <p className="text-[14px] text-text-muted leading-relaxed mb-6">{entity.description}</p>
+      <p className="text-[14px] text-muted-foreground leading-relaxed mb-6">{entity.description}</p>
 
-      <div className="text-[11px] font-medium text-text-muted/60 uppercase tracking-wider mb-3">
+      <div className="text-[11px] font-medium text-muted-foreground/60 uppercase tracking-wider mb-3">
         {t('tracked.referencedIn', { count: backlinks.length })}
       </div>
       {backlinks.length === 0 ? (
-        <div className="text-[13px] text-text-muted/70 italic">
+        <div className="text-[13px] text-muted-foreground/70 italic">
           No notes link <span className="font-mono">[[{entity.name}]]</span> yet.
         </div>
       ) : (
@@ -185,16 +185,16 @@ function BacklinkRow({ backlink }: { backlink: Backlink }) {
       type="button"
       onClick={open}
       title={issueId ? `Open issue ${issueId}` : `Open ${backlink.path}`}
-      className="group flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-bg-tertiary/30 hover:bg-bg-tertiary hover:border-accent/40 transition-colors text-left"
+      className="group flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-muted/30 hover:bg-muted hover:border-primary/40 transition-colors text-left"
     >
       <Icon
         size={14}
         strokeWidth={1.75}
-        className="shrink-0 text-text-muted/70 group-hover:text-accent transition-colors"
+        className="shrink-0 text-muted-foreground/70 group-hover:text-primary transition-colors"
         aria-hidden
       />
-      <span className="flex-1 min-w-0 truncate font-mono text-[12px] text-text">{label}</span>
-      <span className="shrink-0 text-[11px] text-text-muted/60">{backlink.workspaceTag}</span>
+      <span className="flex-1 min-w-0 truncate font-mono text-[12px] text-foreground">{label}</span>
+      <span className="shrink-0 text-[11px] text-muted-foreground/60">{backlink.workspaceTag}</span>
     </button>
   )
 }

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -107,14 +107,14 @@ function ExternalOrderMonitoringRow() {
   return (
     <div className="flex items-center justify-between gap-3 px-4 py-3 border border-border rounded-lg">
       <div className="min-w-0">
-        <div className="text-[12px] font-medium text-text">External order monitoring</div>
-        <div className="text-[11px] text-text-muted">
+        <div className="text-[12px] font-medium text-foreground">External order monitoring</div>
+        <div className="text-[11px] text-muted-foreground">
           How often to scan for orders placed outside Alice (exchange app, direct API).
           Known pending orders are tracked every 10s regardless.
         </div>
       </div>
       <div className="flex items-center gap-2 shrink-0">
-        {msg && <span className="text-[11px] text-text-muted">{msg}</span>}
+        {msg && <span className="text-[11px] text-muted-foreground">{msg}</span>}
         <select
           value={value}
           onChange={(e) => { void save(e.target.value) }}
@@ -189,13 +189,13 @@ export function KeylessDataSourcesRow({ ccxtPack, onPackInstalled }: {
     <div className="px-4 py-3 border border-border rounded-lg">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-[12px] font-medium text-text">Public crypto data sources</div>
-          <div className="text-[11px] text-text-muted leading-relaxed mt-0.5">
+          <div className="text-[12px] font-medium text-foreground">Public crypto data sources</div>
+          <div className="text-[11px] text-muted-foreground leading-relaxed mt-0.5">
             Optional keyless K-line feeds. Disabled by default; enabled sources appear as read-only broker-style bar IDs.
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {msg && <span className="text-[11px] text-text-muted">{msg}</span>}
+          {msg && <span className="text-[11px] text-muted-foreground">{msg}</span>}
           {ccxtPack && !ccxtPack.installed && (
             <button className="btn-secondary" disabled={installing} onClick={() => { void install() }}>
               {installing ? 'Installing…' : ccxtPack.source === 'broken' ? 'Repair data support' : 'Install data support'}
@@ -207,8 +207,8 @@ export function KeylessDataSourcesRow({ ccxtPack, onPackInstalled }: {
         {KEYLESS_DATA_SOURCE_OPTIONS.map((source) => {
           const checked = runtimeConfig.keylessDataSources.includes(source.id)
           return (
-            <div key={source.id} className="flex items-center justify-between gap-2 rounded-md border border-border bg-bg-secondary/40 px-3 py-2">
-              <span className="text-[12px] text-text">{source.label}</span>
+            <div key={source.id} className="flex items-center justify-between gap-2 rounded-md border border-border bg-secondary/40 px-3 py-2">
+              <span className="text-[12px] text-foreground">{source.label}</span>
               <Toggle
                 size="sm"
                 checked={checked}
@@ -263,21 +263,21 @@ export function MissingBrokerPacksNotice({ packs, onInstalled }: {
   }
 
   return (
-    <div className="rounded-lg border border-yellow-400/30 bg-yellow-400/5 px-4 py-3">
+    <div className="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3">
       <div className="flex items-start gap-2.5">
-        <AlertTriangle size={15} className="mt-0.5 shrink-0 text-yellow-400" />
+        <AlertTriangle size={15} className="mt-0.5 shrink-0 text-warning" />
         <div className="min-w-0 flex-1">
-          <div className="text-[12px] font-medium text-text">Optional broker support is missing</div>
-          <p className="mt-0.5 text-[11px] leading-relaxed text-text-muted">
+          <div className="text-[12px] font-medium text-foreground">Optional broker support is missing</div>
+          <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
             OpenAlice itself can keep running. Install only the integrations used by these accounts or K-line sources.
           </p>
           <div className="mt-3 space-y-2">
             {missing.map((pack) => (
               <div key={pack.engine} className="flex items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2">
                 <div className="min-w-0">
-                  <div className="text-[12px] font-medium uppercase text-text">{pack.engine}</div>
-                  <div className="truncate text-[11px] text-text-muted">Required by {pack.requiredBy.join(', ')}</div>
-                  {pack.reason && <div className="mt-0.5 text-[11px] text-yellow-400">{pack.reason}</div>}
+                  <div className="text-[12px] font-medium uppercase text-foreground">{pack.engine}</div>
+                  <div className="truncate text-[11px] text-muted-foreground">Required by {pack.requiredBy.join(', ')}</div>
+                  {pack.reason && <div className="mt-0.5 text-[11px] text-warning">{pack.reason}</div>}
                 </div>
                 <button
                   className="btn-secondary shrink-0"
@@ -289,7 +289,7 @@ export function MissingBrokerPacksNotice({ packs, onInstalled }: {
               </div>
             ))}
           </div>
-          {error && <p className="mt-2 text-[11px] text-red">{error}</p>}
+          {error && <p className="mt-2 text-[11px] text-destructive">{error}</p>}
         </div>
       </div>
     </div>
@@ -376,7 +376,7 @@ export function TradingPage() {
     <PageShell subtitle="Configure your UTAs (Unified Trading Accounts).">
       <div className="max-w-[820px] mx-auto space-y-2.5" aria-hidden="true">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-3 px-4 py-3.5 rounded-lg border border-border bg-bg-secondary">
+          <div key={i} className="flex items-center gap-3 px-4 py-3.5 rounded-lg border border-border bg-secondary">
             <Skeleton className="h-9 w-9 rounded-lg" />
             <div className="flex-1 space-y-2">
               <Skeleton className="h-3.5 w-32" />
@@ -391,7 +391,7 @@ export function TradingPage() {
   if (tc.error) {
     return (
       <PageShell subtitle="Failed to load trading configuration.">
-        <p className="text-[13px] text-red">{tc.error}</p>
+        <p className="text-[13px] text-destructive">{tc.error}</p>
         <button onClick={tc.refresh} className="mt-2 btn-secondary">Retry</button>
       </PageShell>
     )
@@ -428,7 +428,7 @@ export function TradingPage() {
               })}
               <button
                 onClick={() => setShowAdd(true)}
-                className="w-full py-2.5 text-[12px] text-text-muted hover:text-text border border-dashed border-border hover:border-text-muted/40 rounded-lg transition-colors"
+                className="w-full py-2.5 text-[12px] text-muted-foreground hover:text-foreground border border-dashed border-border hover:border-muted-foreground/40 rounded-lg transition-colors"
               >
                 + Add UTA
               </button>
@@ -500,13 +500,13 @@ function PageShell({ subtitle, children }: { subtitle: string; children?: React.
 
 function TradingServiceOfflineBanner({ status }: { status: TradingServiceStatus }) {
   return (
-    <div className="flex gap-3 rounded-lg border border-yellow-400/30 bg-yellow-400/5 px-4 py-3" role="status">
-      <AlertTriangle size={16} className="mt-0.5 shrink-0 text-yellow-400" aria-hidden />
+    <div className="flex gap-3 rounded-lg border border-warning/30 bg-warning/5 px-4 py-3" role="status">
+      <AlertTriangle size={16} className="mt-0.5 shrink-0 text-warning" aria-hidden />
       <div className="min-w-0">
-        <div className="text-[12px] font-medium text-text">Trading service offline</div>
-        <div className="mt-0.5 text-[11px] text-text-muted leading-relaxed">
+        <div className="text-[12px] font-medium text-foreground">Trading service offline</div>
+        <div className="mt-0.5 text-[11px] text-muted-foreground leading-relaxed">
           {status.hint ?? 'Alice is running in lite mode.'}
-          {status.reason ? <span className="ml-1 font-mono text-text-muted/70">{status.reason}</span> : null}
+          {status.reason ? <span className="ml-1 font-mono text-muted-foreground/70">{status.reason}</span> : null}
         </div>
       </div>
     </div>
@@ -518,8 +518,8 @@ function TradingServiceOfflineBanner({ status }: { status: TradingServiceStatus 
 function EmptyState({ onAdd }: { onAdd: () => void }) {
   return (
     <div className="rounded-xl border border-dashed border-border p-12 text-center">
-      <h3 className="text-[16px] font-semibold text-text mb-2">No UTAs configured</h3>
-      <p className="text-[13px] text-text-muted mb-6 max-w-[320px] mx-auto leading-relaxed">
+      <h3 className="text-[16px] font-semibold text-foreground mb-2">No UTAs configured</h3>
+      <p className="text-[13px] text-muted-foreground mb-6 max-w-[320px] mx-auto leading-relaxed">
         Connect a crypto exchange or brokerage to start automated trading.
       </p>
       <button onClick={onAdd} className="btn-primary">
@@ -566,7 +566,7 @@ function UTACard({ uta, preset, health, equity, onClick }: {
   const isDisabled = health?.disabled || uta.enabled === false
   const badge = preset
     ? { text: preset.badge, color: `${preset.badgeColor} ${preset.badgeColor.replace('text-', 'bg-')}/10` }
-    : { text: uta.presetId.slice(0, 2).toUpperCase(), color: 'text-text-muted bg-text-muted/10' }
+    : { text: uta.presetId.slice(0, 2).toUpperCase(), color: 'text-muted-foreground bg-muted-foreground/10' }
 
   // Per-card equity is a liveness signal, not a portfolio view —
   // proves the connection returned a real account balance, not just
@@ -580,27 +580,27 @@ function UTACard({ uta, preset, health, equity, onClick }: {
   return (
     <button
       onClick={onClick}
-      className={`w-full text-left rounded-lg border border-border bg-bg-secondary/30 px-4 py-3 transition-all hover:border-text-muted/40 hover:bg-bg-tertiary/20 ${isDisabled ? 'opacity-50' : ''}`}
+      className={`w-full text-left rounded-lg border border-border bg-secondary/30 px-4 py-3 transition-all hover:border-muted-foreground/40 hover:bg-muted/20 ${isDisabled ? 'opacity-50' : ''}`}
     >
       <div className="flex items-center gap-3">
         <span className={`text-[10px] font-bold px-2 py-1 rounded-md shrink-0 ${badge.color}`}>
           {badge.text}
         </span>
         <div className="flex-1 min-w-0">
-          <div className="text-[13px] font-medium text-text truncate">{uta.label || uta.id}</div>
-          <div className="text-[11px] text-text-muted truncate mt-0.5 font-mono">
+          <div className="text-[13px] font-medium text-foreground truncate">{uta.label || uta.id}</div>
+          <div className="text-[11px] text-muted-foreground truncate mt-0.5 font-mono">
             {uta.id}
-            <span className="mx-1.5 text-text-muted/40">·</span>
+            <span className="mx-1.5 text-muted-foreground/40">·</span>
             {buildSubtitle(uta, preset)}
-            {uta.guards.length > 0 && <span className="ml-1.5 text-text-muted/50">{uta.guards.length} guard{uta.guards.length > 1 ? 's' : ''}</span>}
+            {uta.guards.length > 0 && <span className="ml-1.5 text-muted-foreground/50">{uta.guards.length} guard{uta.guards.length > 1 ? 's' : ''}</span>}
           </div>
         </div>
         <div className="shrink-0 flex items-center gap-3">
           {equityNode && (
-            <span className="text-[11px] text-text-muted/80 hidden sm:inline">{equityNode}</span>
+            <span className="text-[11px] text-muted-foreground/80 hidden sm:inline">{equityNode}</span>
           )}
           {uta.enabled === false
-            ? <span className="text-[11px] text-text-muted">Disabled</span>
+            ? <span className="text-[11px] text-muted-foreground">Disabled</span>
             : <HealthBadge health={health} />
           }
         </div>

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -205,10 +205,10 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
         live={{ lastUpdated }}
         description={
           <>
-            <Link to="/trading" className="text-text-muted hover:text-text">← Trading</Link>
-            <span className="mx-2 text-text-muted/40">·</span>
-            <span className="font-mono text-text-muted">{uta.id}</span>
-            <span className="mx-2 text-text-muted/40">·</span>
+            <Link to="/trading" className="text-muted-foreground hover:text-foreground">← Trading</Link>
+            <span className="mx-2 text-muted-foreground/40">·</span>
+            <span className="font-mono text-muted-foreground">{uta.id}</span>
+            <span className="mx-2 text-muted-foreground/40">·</span>
             <HealthBadge health={health} size="sm" />
           </>
         }
@@ -232,7 +232,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
             <button
               onClick={() => setOrderMode({ kind: 'place' })}
               disabled={isDisabled}
-              className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent text-bg hover:bg-accent/90 disabled:opacity-40 transition-all active:scale-[0.98] cursor-pointer"
+              className="px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 transition-all active:scale-[0.98] cursor-pointer"
             >
               + Place Order
             </button>
@@ -243,7 +243,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
       <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">
         <div className="max-w-[1240px] mx-auto">
           {dataError && (
-            <div className="rounded-md border border-red/30 bg-red/5 px-3 py-2 text-[12px] text-red mb-4">
+            <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] text-destructive mb-4">
               Failed to load live data: {dataError}
             </div>
           )}
@@ -333,7 +333,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
 function Shell({ title, children }: { title: string; children?: React.ReactNode }) {
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <PageHeader title={title} description={<Link to="/trading" className="text-text-muted hover:text-text">← Trading</Link>} />
+      <PageHeader title={title} description={<Link to="/trading" className="text-muted-foreground hover:text-foreground">← Trading</Link>} />
       <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">
         <div className="max-w-[720px] mx-auto">{children}</div>
       </div>
@@ -353,7 +353,7 @@ function SubAccountSelector({ subAccounts, selected, onSelect }: {
 }) {
   const pill = (active: boolean) =>
     `px-2.5 py-1 rounded text-xs font-medium transition-colors ${
-      active ? 'bg-accent text-white' : 'text-text-muted hover:text-text hover:bg-surface-hover'
+      active ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-accent'
     }`
   return (
     <div className="flex items-center gap-1 p-1 rounded-lg bg-surface border border-border">
@@ -390,7 +390,7 @@ function UTADetailMainSkeleton() {
     <div className="space-y-5" aria-hidden="true">
       <Skeleton className="h-[220px] w-full rounded-lg" />
       <div className="rounded-lg border border-border overflow-hidden">
-        <div className="px-4 py-2.5 border-b border-border bg-bg-secondary">
+        <div className="px-4 py-2.5 border-b border-border bg-secondary">
           <Skeleton className="h-3 w-28" />
         </div>
         <div className="divide-y divide-border">
@@ -417,7 +417,7 @@ function AccountPanel({ account, positions, delta24h, clock, connecting }: {
 }) {
   if (!account) {
     return (
-      <div className="border border-border rounded-lg bg-bg-secondary p-4">
+      <div className="border border-border rounded-lg bg-secondary p-4">
         {clock != null && (
           <div className="text-[12px] mb-3"><MarketClockChip clock={clock} /></div>
         )}
@@ -425,7 +425,7 @@ function AccountPanel({ account, positions, delta24h, clock, connecting }: {
             reads as progress, where a bare "Loading…" that lingers 30s reads
             as a stall. Skeleton rows below stand in for the metric list so the
             panel has shape instead of a single line of text. */}
-        <p className={`text-[12px] mb-3.5 ${connecting ? 'text-accent' : 'text-text-muted'}`}>
+        <p className={`text-[12px] mb-3.5 ${connecting ? 'text-primary' : 'text-muted-foreground'}`}>
           {connecting ? 'Connecting to broker…' : 'Loading account info…'}
         </p>
         <div className="space-y-3.5" aria-hidden="true">
@@ -474,7 +474,7 @@ function AccountPanel({ account, positions, delta24h, clock, connecting }: {
     : null
 
   return (
-    <div className="border border-border rounded-lg bg-bg-secondary p-4">
+    <div className="border border-border rounded-lg bg-secondary p-4">
       {clock != null && (
         <div className="text-[12px] mb-3"><MarketClockChip clock={clock} /></div>
       )}
@@ -497,12 +497,12 @@ function AccountPanel({ account, positions, delta24h, clock, connecting }: {
         {utilizationPct != null && (
           <div className="py-2">
             <div className="flex items-baseline justify-between gap-3">
-              <span className="text-[11px] uppercase tracking-wide text-text-muted">Utilization</span>
-              <span className="text-[13px] font-medium tabular-nums text-text">{utilizationPct.toFixed(1)}%</span>
+              <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Utilization</span>
+              <span className="text-[13px] font-medium tabular-nums text-foreground">{utilizationPct.toFixed(1)}%</span>
             </div>
-            <div className="mt-1.5 h-[2px] rounded-full bg-bg-tertiary overflow-hidden">
+            <div className="mt-1.5 h-[2px] rounded-full bg-muted overflow-hidden">
               <div
-                className="h-full rounded-full bg-accent"
+                className="h-full rounded-full bg-primary"
                 style={{ width: `${Math.min(100, Math.max(0, utilizationPct))}%` }}
               />
             </div>
@@ -546,10 +546,10 @@ function AccountRow({ label, value, sign }: {
   value: React.ReactNode
   sign?: 'up' | 'down' | 'flat'
 }) {
-  const valueColor = sign === 'up' ? 'text-green' : sign === 'down' ? 'text-red' : 'text-text'
+  const valueColor = sign === 'up' ? 'text-success' : sign === 'down' ? 'text-destructive' : 'text-foreground'
   return (
     <div className="flex items-baseline justify-between gap-3 py-2">
-      <span className="text-[11px] uppercase tracking-wide text-text-muted">{label}</span>
+      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</span>
       <span className={`text-[13px] font-medium tabular-nums text-right ${valueColor}`}>{value}</span>
     </div>
   )
@@ -561,7 +561,7 @@ function Section({ title, action, children }: { title: string; action?: React.Re
   return (
     <section>
       <div className="flex items-center justify-between mb-2.5">
-        <h3 className="text-[13px] font-semibold text-text-muted uppercase tracking-wide">{title}</h3>
+        <h3 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wide">{title}</h3>
         {action}
       </div>
       {children}
@@ -592,7 +592,7 @@ function PositionsSection({ positions, onCloseClick }: {
   if (positions.length === 0) {
     return (
       <Section title="Positions (0)">
-        <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-text-muted">
+        <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-muted-foreground">
           No open positions.
         </div>
       </Section>
@@ -606,7 +606,7 @@ function PositionsSection({ positions, onCloseClick }: {
       <div className="border border-border rounded-lg overflow-x-auto">
         <table className="w-full text-[13px]">
           <thead>
-            <tr className="bg-bg-secondary text-text-muted text-left">
+            <tr className="bg-secondary text-muted-foreground text-left">
               <th className="px-3 py-2 font-medium">Contract</th>
               <th className="px-3 py-2 font-medium">Side</th>
               <th className="px-3 py-2 font-medium text-right">Qty</th>
@@ -625,20 +625,20 @@ function PositionsSection({ positions, onCloseClick }: {
 
               return (
                 <Fragment key={g.class}>
-                  <tr className="bg-bg-tertiary/40 border-t border-border">
+                  <tr className="bg-muted/40 border-t border-border">
                     <td colSpan={cols} className="px-3 py-1.5">
                       <div className="flex items-center justify-between text-[12px]">
                         <div className="flex items-center gap-2">
-                          <span className="font-semibold text-text">{assetClassLabel(g.class)}</span>
-                          <span className="text-text-muted/60">·</span>
-                          <span className="text-text-muted">{g.positions.length} position{g.positions.length > 1 ? 's' : ''}</span>
+                          <span className="font-semibold text-foreground">{assetClassLabel(g.class)}</span>
+                          <span className="text-muted-foreground/60">·</span>
+                          <span className="text-muted-foreground">{g.positions.length} position{g.positions.length > 1 ? 's' : ''}</span>
                           {!groupCcy && (
-                            <span className="text-text-muted/60 text-[11px]">mixed ccy</span>
+                            <span className="text-muted-foreground/60 text-[11px]">mixed ccy</span>
                           )}
                         </div>
                         <div className="flex items-center gap-3 tabular-nums">
-                          <span className="text-text">{groupCcy ? fmt(sumValue, groupCcy) : `$${sumValue.toLocaleString(getIntlLocale(), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}</span>
-                          <span className={sumPnl >= 0 ? 'text-green' : 'text-red'}>
+                          <span className="text-foreground">{groupCcy ? fmt(sumValue, groupCcy) : `$${sumValue.toLocaleString(getIntlLocale(), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}</span>
+                          <span className={sumPnl >= 0 ? 'text-success' : 'text-destructive'}>
                             {groupCcy ? fmtPnl(sumPnl, groupCcy) : `${sumPnl >= 0 ? '+' : ''}${sumPnl.toLocaleString(getIntlLocale(), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
                           </span>
                         </div>
@@ -665,28 +665,28 @@ function PositionRow({ position: p, onClose }: { position: Position; onClose: ()
   const pct = cost > 0 ? (pnl / cost) * 100 : 0
 
   return (
-    <tr className="border-t border-border hover:bg-bg-tertiary/30 transition-colors">
+    <tr className="border-t border-border hover:bg-muted/30 transition-colors">
       <td className="px-3 py-2">
         <ContractCell contract={p.contract} />
       </td>
       <td className="px-3 py-2">
-        <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
+        <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-success/15 text-success' : 'bg-destructive/15 text-destructive'}`}>
           {p.side}
         </span>
       </td>
-      <td className="px-3 py-2 text-right text-text tabular-nums">{fmtNum(p.quantity)}</td>
-      <td className="px-3 py-2 text-right text-text-muted tabular-nums">
-        {fmt(p.avgCost, ccy)} <span className="text-text-muted/40">→</span> <span className="text-text">{fmt(p.marketPrice, ccy)}</span>
+      <td className="px-3 py-2 text-right text-foreground tabular-nums">{fmtNum(p.quantity)}</td>
+      <td className="px-3 py-2 text-right text-muted-foreground tabular-nums">
+        {fmt(p.avgCost, ccy)} <span className="text-muted-foreground/40">→</span> <span className="text-foreground">{fmt(p.marketPrice, ccy)}</span>
       </td>
-      <td className="px-3 py-2 text-right text-text tabular-nums">{fmt(p.marketValue, ccy)}</td>
-      <td className={`px-3 py-2 text-right font-medium tabular-nums ${pnl >= 0 ? 'text-green' : 'text-red'}`}>
+      <td className="px-3 py-2 text-right text-foreground tabular-nums">{fmt(p.marketValue, ccy)}</td>
+      <td className={`px-3 py-2 text-right font-medium tabular-nums ${pnl >= 0 ? 'text-success' : 'text-destructive'}`}>
         <div>{fmtPnl(pnl, ccy)}</div>
         <div className="text-[11px] font-normal opacity-80">{fmtPctSigned(pct)}</div>
       </td>
       <td className="px-3 py-2 text-right">
         <button
           onClick={onClose}
-          className="text-[11px] text-text-muted hover:text-red transition-colors"
+          className="text-[11px] text-muted-foreground hover:text-destructive transition-colors"
         >
           Close
         </button>
@@ -700,7 +700,7 @@ function PositionRow({ position: p, onClose }: { position: Position; onClose: ()
 type MarketClockState = { isOpen: boolean; nextOpen?: string; nextClose?: string } | 'error' | null
 
 function MarketClockChip({ clock }: { clock: NonNullable<MarketClockState> }) {
-  let dotClass = 'bg-green'
+  let dotClass = 'bg-success'
   let label = '24/7'
 
   if (clock !== 'error') {
@@ -715,7 +715,7 @@ function MarketClockChip({ clock }: { clock: NonNullable<MarketClockState> }) {
         label = 'Market Open'
       }
     } else {
-      dotClass = 'bg-text-muted/50'
+      dotClass = 'bg-muted-foreground/50'
       const opens = clock.nextOpen ? new Date(clock.nextOpen) : null
       if (opens && !Number.isNaN(opens.getTime())) {
         const mins = Math.max(0, Math.round((opens.getTime() - Date.now()) / 60_000))
@@ -729,7 +729,7 @@ function MarketClockChip({ clock }: { clock: NonNullable<MarketClockState> }) {
   }
 
   return (
-    <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-text-muted">
+    <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-muted-foreground">
       <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotClass}`} aria-hidden />
       {label}
     </span>
@@ -793,8 +793,8 @@ function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[
               onClick={() => setTab(t.id)}
               className={`px-2 py-0.5 text-[11px] rounded transition-colors ${
                 tab === t.id
-                  ? 'bg-accent/15 text-accent font-medium'
-                  : 'text-text-muted hover:text-text hover:bg-bg-tertiary'
+                  ? 'bg-primary/15 text-primary font-medium'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted'
               }`}
             >
               {t.label}
@@ -814,7 +814,7 @@ function OpenOrdersTable({ orders }: { orders: unknown[] }) {
   const rows = orders as OpenOrderRow[]
   if (rows.length === 0) {
     return (
-      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-text-muted">
+      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-muted-foreground">
         No open orders.
       </div>
     )
@@ -823,7 +823,7 @@ function OpenOrdersTable({ orders }: { orders: unknown[] }) {
     <div className="border border-border rounded-lg overflow-x-auto">
       <table className="w-full text-[13px]">
         <thead>
-          <tr className="bg-bg-secondary text-text-muted text-left">
+          <tr className="bg-secondary text-muted-foreground text-left">
             <th className="px-3 py-2 font-medium">Order ID</th>
             <th className="px-3 py-2 font-medium">Contract</th>
             <th className="px-3 py-2 font-medium">Action</th>
@@ -836,16 +836,16 @@ function OpenOrdersTable({ orders }: { orders: unknown[] }) {
         <tbody>
           {rows.map((o, i) => (
             <tr key={i} className="border-t border-border">
-              <td className="px-3 py-2 font-mono text-text-muted text-[11px]">{String(o.orderId ?? '—')}</td>
-              <td className="px-3 py-2 font-mono text-text" title={o.contract?.aliceId}>
+              <td className="px-3 py-2 font-mono text-muted-foreground text-[11px]">{String(o.orderId ?? '—')}</td>
+              <td className="px-3 py-2 font-mono text-foreground" title={o.contract?.aliceId}>
                 {o.contract?.symbol ?? o.contract?.localSymbol ?? o.contract?.aliceId ?? '?'}
               </td>
-              <td className={`px-3 py-2 font-medium ${o.order?.action === 'BUY' ? 'text-green' : o.order?.action === 'SELL' ? 'text-red' : 'text-text'}`}>{o.order?.action ?? '—'}</td>
-              <td className="px-3 py-2 text-text-muted">{o.order?.orderType ?? '—'}</td>
-              <td className="px-3 py-2 text-right text-text tabular-nums">{String(o.order?.totalQuantity ?? '')}</td>
-              <td className="px-3 py-2 text-right text-text-muted tabular-nums">{o.order?.lmtPrice != null && !isUnsetDecimal(o.order.lmtPrice) ? String(o.order.lmtPrice) : '—'}</td>
+              <td className={`px-3 py-2 font-medium ${o.order?.action === 'BUY' ? 'text-success' : o.order?.action === 'SELL' ? 'text-destructive' : 'text-foreground'}`}>{o.order?.action ?? '—'}</td>
+              <td className="px-3 py-2 text-muted-foreground">{o.order?.orderType ?? '—'}</td>
+              <td className="px-3 py-2 text-right text-foreground tabular-nums">{String(o.order?.totalQuantity ?? '')}</td>
+              <td className="px-3 py-2 text-right text-muted-foreground tabular-nums">{o.order?.lmtPrice != null && !isUnsetDecimal(o.order.lmtPrice) ? String(o.order.lmtPrice) : '—'}</td>
               <td className="px-3 py-2">
-                <span className="text-[11px] text-text-muted">{o.orderState?.status ?? 'Unknown'}</span>
+                <span className="text-[11px] text-muted-foreground">{o.orderState?.status ?? 'Unknown'}</span>
               </td>
             </tr>
           ))}
@@ -858,16 +858,16 @@ function OpenOrdersTable({ orders }: { orders: unknown[] }) {
 // ==================== Order History tab ====================
 
 const ORDER_STATUS_STYLES: Record<OrderHistoryStatus, string> = {
-  filled: 'bg-green/15 text-green',
-  cancelled: 'bg-bg-tertiary text-text-muted',
-  rejected: 'bg-red/15 text-red',
-  'user-rejected': 'bg-red/15 text-red',
-  submitted: 'bg-accent/15 text-accent',
+  filled: 'bg-success/15 text-success',
+  cancelled: 'bg-muted text-muted-foreground',
+  rejected: 'bg-destructive/15 text-destructive',
+  'user-rejected': 'bg-destructive/15 text-destructive',
+  submitted: 'bg-primary/15 text-primary',
 }
 
 function OrderStatusBadge({ status }: { status: OrderHistoryStatus }) {
   return (
-    <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${ORDER_STATUS_STYLES[status] ?? 'bg-bg-tertiary text-text-muted'}`}>
+    <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${ORDER_STATUS_STYLES[status] ?? 'bg-muted text-muted-foreground'}`}>
       {status}
     </span>
   )
@@ -875,7 +875,7 @@ function OrderStatusBadge({ status }: { status: OrderHistoryStatus }) {
 
 function SideBadge({ side }: { side: 'BUY' | 'SELL' }) {
   return (
-    <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${side === 'BUY' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
+    <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${side === 'BUY' ? 'bg-success/15 text-success' : 'bg-destructive/15 text-destructive'}`}>
       {side}
     </span>
   )
@@ -883,7 +883,7 @@ function SideBadge({ side }: { side: 'BUY' | 'SELL' }) {
 
 function SourceChip({ label }: { label: string }) {
   return (
-    <span className="text-[10px] px-1.5 rounded bg-bg-tertiary text-text-muted">
+    <span className="text-[10px] px-1.5 rounded bg-muted text-muted-foreground">
       {label}
     </span>
   )
@@ -894,14 +894,14 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
 
   if (orders == null) {
     return (
-      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-text-muted">
+      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-muted-foreground">
         Loading order history…
       </div>
     )
   }
   if (orders.length === 0) {
     return (
-      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-text-muted">
+      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-muted-foreground">
         No order history yet.
       </div>
     )
@@ -910,7 +910,7 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
     <div className="border border-border rounded-lg overflow-x-auto">
       <table className="w-full text-[13px]">
         <thead>
-          <tr className="bg-bg-secondary text-text-muted text-left">
+          <tr className="bg-secondary text-muted-foreground text-left">
             <th className="px-3 py-2 font-medium">Time</th>
             <th className="px-3 py-2 font-medium">Contract</th>
             <th className="px-3 py-2 font-medium">Side</th>
@@ -925,16 +925,16 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
           {orders.map((o, i) => (
             <Fragment key={`${o.commitHash}-${i}`}>
               <tr
-                className="border-t border-border hover:bg-bg-tertiary/30 transition-colors cursor-pointer"
+                className="border-t border-border hover:bg-muted/30 transition-colors cursor-pointer"
                 onClick={() => setExpanded(prev => prev === i ? null : i)}
               >
-                <td className="px-3 py-2 text-text-muted tabular-nums whitespace-nowrap">{formatHistoryTime(o.timestamp)}</td>
+                <td className="px-3 py-2 text-muted-foreground tabular-nums whitespace-nowrap">{formatHistoryTime(o.timestamp)}</td>
                 <td className="px-3 py-2"><ContractCell contract={o.contract} /></td>
                 <td className="px-3 py-2"><SideBadge side={o.side} /></td>
-                <td className="px-3 py-2 text-text-muted">{o.orderType ?? '—'}</td>
-                <td className="px-3 py-2 text-right text-text tabular-nums">{o.quantity != null ? fmtNum(o.quantity) : '—'}</td>
-                <td className="px-3 py-2 text-right text-text-muted tabular-nums">{o.limitPrice ?? '—'}</td>
-                <td className="px-3 py-2 text-right text-text tabular-nums">
+                <td className="px-3 py-2 text-muted-foreground">{o.orderType ?? '—'}</td>
+                <td className="px-3 py-2 text-right text-foreground tabular-nums">{o.quantity != null ? fmtNum(o.quantity) : '—'}</td>
+                <td className="px-3 py-2 text-right text-muted-foreground tabular-nums">{o.limitPrice ?? '—'}</td>
+                <td className="px-3 py-2 text-right text-foreground tabular-nums">
                   {o.avgFillPrice ? `${o.avgFillPrice}${o.filledQty ? ` × ${o.filledQty}` : ''}` : '—'}
                 </td>
                 <td className="px-3 py-2">
@@ -945,12 +945,12 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
                 </td>
               </tr>
               {expanded === i && (
-                <tr className="border-t border-border bg-bg-tertiary/20">
-                  <td colSpan={8} className="px-3 py-2 text-[11px] text-text-muted">
+                <tr className="border-t border-border bg-muted/20">
+                  <td colSpan={8} className="px-3 py-2 text-[11px] text-muted-foreground">
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
                       <span className="font-mono">{o.commitHash}</span>
                       <span>{o.message}</span>
-                      {o.error && <span className="text-red">{o.error}</span>}
+                      {o.error && <span className="text-destructive">{o.error}</span>}
                       {o.resolvedAt && <span>resolved {formatHistoryTime(o.resolvedAt)}</span>}
                     </div>
                   </td>
@@ -969,14 +969,14 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
 function TradeHistoryTable({ trades }: { trades: TradeHistoryEntry[] | null }) {
   if (trades == null) {
     return (
-      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-text-muted">
+      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-muted-foreground">
         Loading trade history…
       </div>
     )
   }
   if (trades.length === 0) {
     return (
-      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-text-muted">
+      <div className="border border-border rounded-lg px-4 py-3 text-[12px] text-muted-foreground">
         No trades yet.
       </div>
     )
@@ -985,7 +985,7 @@ function TradeHistoryTable({ trades }: { trades: TradeHistoryEntry[] | null }) {
     <div className="border border-border rounded-lg overflow-x-auto">
       <table className="w-full text-[13px]">
         <thead>
-          <tr className="bg-bg-secondary text-text-muted text-left">
+          <tr className="bg-secondary text-muted-foreground text-left">
             <th className="px-3 py-2 font-medium">Time</th>
             <th className="px-3 py-2 font-medium">Contract</th>
             <th className="px-3 py-2 font-medium">Side</th>
@@ -997,13 +997,13 @@ function TradeHistoryTable({ trades }: { trades: TradeHistoryEntry[] | null }) {
         </thead>
         <tbody>
           {trades.map((t, i) => (
-            <tr key={`${t.commitHash}-${i}`} className="border-t border-border hover:bg-bg-tertiary/30 transition-colors">
-              <td className="px-3 py-2 text-text-muted tabular-nums whitespace-nowrap">{formatHistoryTime(t.timestamp)}</td>
+            <tr key={`${t.commitHash}-${i}`} className="border-t border-border hover:bg-muted/30 transition-colors">
+              <td className="px-3 py-2 text-muted-foreground tabular-nums whitespace-nowrap">{formatHistoryTime(t.timestamp)}</td>
               <td className="px-3 py-2"><ContractCell contract={t.contract} /></td>
               <td className="px-3 py-2"><SideBadge side={t.side} /></td>
-              <td className="px-3 py-2 text-right text-text tabular-nums">{fmtNum(t.quantity)}</td>
-              <td className="px-3 py-2 text-right text-text tabular-nums">{t.price}</td>
-              <td className="px-3 py-2 text-right text-text tabular-nums">{fmt(t.value, t.contract.currency)}</td>
+              <td className="px-3 py-2 text-right text-foreground tabular-nums">{fmtNum(t.quantity)}</td>
+              <td className="px-3 py-2 text-right text-foreground tabular-nums">{t.price}</td>
+              <td className="px-3 py-2 text-right text-foreground tabular-nums">{fmt(t.value, t.contract.currency)}</td>
               <td className="px-3 py-2 text-right">
                 {t.source !== 'order' && (
                   <SourceChip label={t.source === 'external' ? 'External' : 'Reconcile'} />

--- a/ui/src/pages/WorkspaceListPage.tsx
+++ b/ui/src/pages/WorkspaceListPage.tsx
@@ -157,8 +157,8 @@ export function WorkspaceListPage() {
 
   if (workspaces.length === 0 && departed.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-text-muted px-6">
-        <h2 className="text-lg font-medium text-text mb-2">{t('workspace.emptyTitle')}</h2>
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground px-6">
+        <h2 className="text-lg font-medium text-foreground mb-2">{t('workspace.emptyTitle')}</h2>
         <p className="text-sm max-w-md text-center">
           {t('workspace.emptyBody')}
         </p>
@@ -170,8 +170,8 @@ export function WorkspaceListPage() {
     <div className="h-full overflow-y-auto">
       <div className="max-w-5xl mx-auto px-6 py-6">
         <div className="mb-6 flex items-baseline justify-between gap-4">
-          <h2 className="text-[18px] font-semibold text-text">{t('workspace.overviewTitle')}</h2>
-          <span className="text-[12px] text-text-muted">
+          <h2 className="text-[18px] font-semibold text-foreground">{t('workspace.overviewTitle')}</h2>
+          <span className="text-[12px] text-muted-foreground">
             {t(workspaces.length === 1 ? 'workspace.workspaceSingular' : 'workspace.workspacePlural', {
               count: workspaces.length,
             })}
@@ -182,10 +182,10 @@ export function WorkspaceListPage() {
           {sections.map((sec) => (
             <section key={sec.key}>
               <div className="mb-3 flex items-baseline gap-2">
-                <h3 className="text-[12px] font-semibold text-text/85 uppercase tracking-wider">
+                <h3 className="text-[12px] font-semibold text-foreground/85 uppercase tracking-wider">
                   {sec.title}
                 </h3>
-                <span className="text-[11px] text-text-muted">· {sec.workspaces.length}</span>
+                <span className="text-[11px] text-muted-foreground">· {sec.workspaces.length}</span>
               </div>
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                 {sec.workspaces.map((w) => (
@@ -213,12 +213,12 @@ export function WorkspaceListPage() {
           {(departed.length > 0 || departedError) && (
             <section className="border-t border-border pt-6">
               <div className="mb-3 flex items-baseline gap-2">
-                <h3 className="text-[12px] font-semibold uppercase tracking-wider text-text/85">
+                <h3 className="text-[12px] font-semibold uppercase tracking-wider text-foreground/85">
                   Departed Workspaces
                 </h3>
-                <span className="text-[11px] text-text-muted">· {departed.length}</span>
+                <span className="text-[11px] text-muted-foreground">· {departed.length}</span>
               </div>
-              <p className="mb-3 max-w-2xl text-[12px] leading-relaxed text-text-muted">
+              <p className="mb-3 max-w-2xl text-[12px] leading-relaxed text-muted-foreground">
                 Offboarded desks are outside the active Workspace directory. Restore returns the exact checkout and Session signatures; purge removes files but keeps the historical tombstone.
               </p>
               {departedError && (
@@ -230,25 +230,25 @@ export function WorkspaceListPage() {
                 {departed.map((workspace) => {
                   const purged = workspace.lifecycle === 'purged' || workspace.lifecycle === 'purging'
                   return (
-                    <article key={workspace.id} className="rounded-lg border border-border bg-bg-secondary/35 p-4">
+                    <article key={workspace.id} className="rounded-lg border border-border bg-secondary/35 p-4">
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0">
-                          <div className="truncate text-[14px] font-medium text-text">{workspace.tag}</div>
-                          <div className="mt-0.5 font-mono text-[10px] text-text-muted">{workspace.id}</div>
+                          <div className="truncate text-[14px] font-medium text-foreground">{workspace.tag}</div>
+                          <div className="mt-0.5 font-mono text-[10px] text-muted-foreground">{workspace.id}</div>
                         </div>
-                        <span className="rounded-full border border-border px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-muted">
+                        <span className="rounded-full border border-border px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
                           {workspace.lifecycle}
                         </span>
                       </div>
-                      <p className="mt-3 line-clamp-2 text-[12px] leading-relaxed text-text-muted">
+                      <p className="mt-3 line-clamp-2 text-[12px] leading-relaxed text-muted-foreground">
                         {workspace.reason ?? 'No departure reason recorded.'}
                       </p>
                       {workspace.absorbedIntoWorkspaceId && (
-                        <div className="mt-3 flex items-center gap-2 rounded-md border border-accent/20 bg-accent/6 px-2.5 py-2 text-[11px] text-text-muted">
-                          <GitMerge size={13} className="shrink-0 text-accent" />
+                        <div className="mt-3 flex items-center gap-2 rounded-md border border-primary/20 bg-primary/6 px-2.5 py-2 text-[11px] text-muted-foreground">
+                          <GitMerge size={13} className="shrink-0 text-primary" />
                           <span>
                             Working files reviewed into{' '}
-                            <strong className="font-medium text-text">
+                            <strong className="font-medium text-foreground">
                               {workspaces.find((candidate) => candidate.id === workspace.absorbedIntoWorkspaceId)?.displayName
                                 ?? workspaces.find((candidate) => candidate.id === workspace.absorbedIntoWorkspaceId)?.tag
                                 ?? workspace.absorbedIntoWorkspaceId}
@@ -257,7 +257,7 @@ export function WorkspaceListPage() {
                           </span>
                         </div>
                       )}
-                      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-text-muted">
+                      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
                         <span>{workspace.handoff?.resumeIds.length ?? 0} Sessions</span>
                         <span>{workspace.handoff?.openIssueIds.length ?? 0} open Issues</span>
                         {workspace.legacyImported && <span>legacy import</span>}

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -136,27 +136,27 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
 
   if (sessionId && session) {
     return (
-      <div className="workspaces-root flex h-full min-h-0 flex-col bg-bg">
-        <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-bg-secondary/35 px-3 py-2 md:px-4">
+      <div className="workspaces-root flex h-full min-h-0 flex-col bg-background">
+        <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-secondary/35 px-3 py-2 md:px-4">
           <div className="flex min-w-0 items-center gap-2.5">
             <button
               type="button"
               onClick={() => openOrFocus({ kind: 'workspace-manager', params: {} })}
-              className="oa-icon-action rounded-md p-1.5 text-text-muted hover:bg-bg-tertiary hover:text-text"
+              className="oa-icon-action rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
               title={t('workspaceManager.back')}
               aria-label={t('workspaceManager.back')}
             >
               <ArrowLeft size={15} />
             </button>
-            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-accent/12 text-accent">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-primary/12 text-primary">
               <Network size={15} />
             </span>
             <div className="min-w-0">
-              <div className="truncate text-[12px] font-semibold text-text">{t('workspaceManager.title')}</div>
-              <div className="truncate text-[10px] text-text-muted">{session.title ?? session.name}</div>
+              <div className="truncate text-[12px] font-semibold text-foreground">{t('workspaceManager.title')}</div>
+              <div className="truncate text-[10px] text-muted-foreground">{session.title ?? session.name}</div>
             </div>
           </div>
-          <span className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-bg px-2 py-1 text-[10px] font-medium text-text-muted">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background px-2 py-1 text-[10px] font-medium text-muted-foreground">
             <Bot size={11} /> {runtimeLabel(session.agent, agents)} · {session.surface === 'webpi' ? 'WebPi' : 'TUI'}
           </span>
         </header>
@@ -189,23 +189,23 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
   }
 
   return (
-    <div className="relative h-full overflow-y-auto bg-bg">
+    <div className="relative h-full overflow-y-auto bg-background">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="absolute inset-x-0 top-0 h-56 bg-gradient-to-b from-accent/[0.07] to-transparent" />
-        <div className="absolute -right-24 top-12 h-72 w-72 rounded-full border border-accent/10" />
-        <div className="absolute -right-8 top-28 h-44 w-44 rounded-full border border-accent/10" />
+        <div className="absolute -right-24 top-12 h-72 w-72 rounded-full border border-primary/10" />
+        <div className="absolute -right-8 top-28 h-44 w-44 rounded-full border border-primary/10" />
       </div>
 
       <div className="workspace-manager-layout relative mx-auto flex min-h-full w-full max-w-5xl flex-col px-4 py-6 md:px-8 md:py-10">
         <div className="workspace-manager-hero mb-7 flex flex-col gap-5">
           <div className="max-w-2xl">
-            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-accent/20 bg-accent/[0.07] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.15em] text-accent">
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/[0.07] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.15em] text-primary">
               <Network size={12} /> {t('workspaceManager.eyebrow')}
             </div>
-            <h1 className="text-2xl font-semibold leading-tight text-text md:text-4xl">
+            <h1 className="text-2xl font-semibold leading-tight text-foreground md:text-4xl">
               {t('workspaceManager.heading')}
             </h1>
-            <p className="mt-3 max-w-xl text-[13px] leading-relaxed text-text-muted md:text-[15px]">
+            <p className="mt-3 max-w-xl text-[13px] leading-relaxed text-muted-foreground md:text-[15px]">
               {t('workspaceManager.subheading')}
             </p>
           </div>
@@ -214,14 +214,14 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
           </div>
         </div>
 
-        <section className="rounded-2xl border border-border/80 bg-bg-secondary/60 p-3 shadow-[0_24px_70px_-58px_var(--color-text)] md:p-4">
+        <section className="rounded-2xl border border-border/80 bg-secondary/60 p-3 shadow-[0_24px_70px_-58px_var(--foreground)] md:p-4">
           <textarea
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={onKeyDown}
             placeholder={t('workspaceManager.placeholder')}
             rows={4}
-            className="min-h-28 w-full resize-none bg-transparent px-1 py-1 text-[14px] leading-relaxed text-text outline-none placeholder:text-text-muted/55 md:text-[15px]"
+            className="min-h-28 w-full resize-none bg-transparent px-1 py-1 text-[14px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/55 md:text-[15px]"
           />
           <div className="workspace-manager-composer-footer mt-3 flex flex-col gap-2 border-t border-border/60 pt-3">
             <div className="workspace-manager-composer-actions flex min-w-0 flex-col gap-2">
@@ -236,7 +236,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
                 type="button"
                 onClick={() => void submit()}
                 disabled={!draft.trim() || launching || !launchConfig.credentialSelectionReady}
-                className="oa-pressable inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-accent px-4 text-[12px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-45"
+                className="oa-pressable inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-[12px] font-semibold text-primary-foreground disabled:cursor-not-allowed disabled:opacity-45"
               >
                 {launching ? <Loader2 size={14} className="animate-spin" /> : <ArrowUp size={14} />}
                 {launching ? t('workspaceManager.launching') : t('workspaceManager.send')}
@@ -252,13 +252,13 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
         </section>
 
         {(error ?? workspaceManagerError) && (
-          <div className="mt-3 rounded-lg border border-red/25 bg-red/10 px-3 py-2 text-[12px] text-red">
+          <div className="mt-3 rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
             {error ?? workspaceManagerError}
           </div>
         )}
 
         <section className="workspace-manager-suggestions-section mt-7 min-w-0">
-          <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-muted/70">
+          <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">
             {t('workspaceManager.suggestions')}
           </h2>
           <div className="workspace-manager-suggestions grid min-w-0 gap-2">
@@ -269,17 +269,17 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
                   key={suggestion}
                   type="button"
                   onClick={() => setDraft(suggestion)}
-                  className="oa-pressable group flex items-start gap-3 rounded-xl border border-border/70 bg-bg-secondary/45 p-3 text-left hover:border-accent/30 hover:bg-bg-secondary"
+                  className="oa-pressable group flex items-start gap-3 rounded-xl border border-border/70 bg-secondary/45 p-3 text-left hover:border-primary/30 hover:bg-secondary"
                 >
-                  <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-bg-tertiary text-text-muted group-hover:text-accent">
+                  <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground group-hover:text-primary">
                     <Icon size={14} />
                   </span>
-                  <span className="text-[12px] leading-relaxed text-text-muted group-hover:text-text">{suggestion}</span>
+                  <span className="text-[12px] leading-relaxed text-muted-foreground group-hover:text-foreground">{suggestion}</span>
                 </button>
               )
             })}
           </div>
-          <p className="mt-3 text-[11px] leading-relaxed text-text-muted/65">{t('workspaceManager.guardrail')}</p>
+          <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground/65">{t('workspaceManager.guardrail')}</p>
         </section>
       </div>
     </div>
@@ -292,11 +292,11 @@ function runtimeLabel(agentId: string, agents: readonly { id: string; displayNam
 
 function ManagerStat({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: string }) {
   return (
-    <div className="rounded-xl border border-border/70 bg-bg-secondary/55 px-3 py-2.5">
-      <div className="flex items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.11em] text-text-muted/60">
+    <div className="rounded-xl border border-border/70 bg-secondary/55 px-3 py-2.5">
+      <div className="flex items-center gap-1.5 text-[9px] font-semibold uppercase tracking-[0.11em] text-muted-foreground/60">
         <Icon size={11} /> {label}
       </div>
-      <div className="mt-1.5 truncate text-[13px] font-semibold text-text">{value}</div>
+      <div className="mt-1.5 truncate text-[13px] font-semibold text-foreground">{value}</div>
     </div>
   )
 }

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -82,7 +82,7 @@ export function WorkspacePage({ spec, visible }: Props) {
 
   if (!workspace) {
     return (
-      <div className="workspaces-root flex flex-col items-center justify-center h-full text-text-muted text-sm">
+      <div className="workspaces-root flex flex-col items-center justify-center h-full text-muted-foreground text-sm">
         {t('workspace.notFound')}
       </div>
     )
@@ -98,8 +98,8 @@ export function WorkspacePage({ spec, visible }: Props) {
       {/* OpenAlice-side header bar above the launcher's WorkspaceView. The
        *  launcher component itself is byte-faithful; we add the AI-provider
        *  affordance here. */}
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-bg-secondary/30 shrink-0">
-        <span className="text-[12px] text-text-muted font-medium">{workspace.tag}</span>
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-secondary/30 shrink-0">
+        <span className="text-[12px] text-muted-foreground font-medium">{workspace.tag}</span>
         <div className="flex items-center gap-1">
           {activeRecord?.agent === 'pi' && activeRecord.state === 'running' && (
             <button
@@ -111,7 +111,7 @@ export function WorkspacePage({ spec, visible }: Props) {
                   void ctx.openWebPiSession(wsId, activeRecord.id, source)
                 }
               }}
-              className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
+              className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
               title={(activeRecord.surface ?? 'terminal') === 'webpi' ? 'Open this Pi Session in the terminal' : 'Open this Pi Session in WebPi'}
             >
               {(activeRecord.surface ?? 'terminal') === 'webpi'
@@ -124,7 +124,7 @@ export function WorkspacePage({ spec, visible }: Props) {
           <button
             type="button"
             onClick={() => ctx.openAgentConfig(wsId)}
-            className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-text-muted hover:text-text hover:bg-bg-tertiary transition-colors"
+            className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
             title={t('workspace.configure')}
           >
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">

--- a/ui/src/pages/market/GenericDetail.tsx
+++ b/ui/src/pages/market/GenericDetail.tsx
@@ -16,11 +16,11 @@ export function GenericDetail({ symbol, assetClass }: Props) {
   return (
     <div className="flex flex-col gap-3 min-h-0 flex-1">
       <div className="flex items-end gap-2 px-1">
-        <span className="text-[20px] font-semibold text-text tracking-tight">{symbol}</span>
-        <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-bg-tertiary text-text-muted font-medium">
+        <span className="text-[20px] font-semibold text-foreground tracking-tight">{symbol}</span>
+        <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
           {assetClass}
         </span>
-        <span className="text-[11px] text-text-muted/70">
+        <span className="text-[11px] text-muted-foreground/70">
           Detail layout coming — for now, price history only.
         </span>
       </div>

--- a/ui/src/pages/simulator/ActionPanel.tsx
+++ b/ui/src/pages/simulator/ActionPanel.tsx
@@ -19,9 +19,9 @@ import { InstrumentInput } from './InstrumentInput'
 import { buildInstrument, type InstrumentDraft } from './instruments'
 
 const inputClass =
-  'px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent'
+  'px-2 py-1 bg-background text-foreground border border-border rounded text-sm outline-none transition-colors focus:border-primary'
 const inputClassMono =
-  'px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+  'px-2 py-1 bg-background text-foreground border border-border rounded font-mono text-xs outline-none transition-colors focus:border-primary'
 
 type TabId = 'tick' | 'deposit' | 'trade' | 'order'
 
@@ -47,7 +47,7 @@ export function ActionPanel({ utaId, state, run, loading }: {
   }, [state])
 
   return (
-    <div className="sticky bottom-0 -mx-4 md:-mx-6 px-4 md:px-6 py-3 bg-bg-secondary/95 backdrop-blur border-t border-border z-10">
+    <div className="sticky bottom-0 -mx-4 md:-mx-6 px-4 md:px-6 py-3 bg-secondary/95 backdrop-blur border-t border-border z-10">
       {/* Tab strip */}
       <div className="flex items-center gap-1 mb-3" role="tablist">
         {TABS.map((t, i) => (
@@ -59,11 +59,11 @@ export function ActionPanel({ utaId, state, run, loading }: {
             onClick={() => setTab(t.id)}
             className={`px-2.5 py-1 text-xs rounded transition-colors ${
               tab === t.id
-                ? 'bg-accent/20 text-accent font-medium'
-                : 'text-text-muted hover:text-text hover:bg-bg-tertiary/50'
+                ? 'bg-primary/20 text-primary font-medium'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
             }`}
           >
-            <span className="text-[10px] text-text-muted/60 mr-1.5">{i + 1}</span>
+            <span className="text-[10px] text-muted-foreground/60 mr-1.5">{i + 1}</span>
             {t.label}
           </button>
         ))}
@@ -111,12 +111,12 @@ function QuickTickTab({ utaId, knownKeys, run, loading }: {
   return (
     <div className="flex items-center gap-2 flex-wrap">
       <KeySelect value={key} onChange={setKey} options={knownKeys} placeholder="symbol" />
-      <span className="text-text-muted text-xs">Δ</span>
+      <span className="text-muted-foreground text-xs">Δ</span>
       <button disabled={loading || !key} onClick={() => tick(-5)} className="btn-secondary-sm">−5%</button>
       <button disabled={loading || !key} onClick={() => tick(-1)} className="btn-secondary-sm">−1%</button>
       <button disabled={loading || !key} onClick={() => tick(1)} className="btn-secondary-sm">+1%</button>
       <button disabled={loading || !key} onClick={() => tick(5)} className="btn-secondary-sm">+5%</button>
-      <span className="text-text-muted/60 text-xs px-1">|</span>
+      <span className="text-muted-foreground/60 text-xs px-1">|</span>
       <input
         className={`${inputClassMono} w-32`}
         placeholder="set exact"
@@ -179,11 +179,11 @@ function DepositTab({ utaId, knownKeys, run, loading }: {
         <div className="flex rounded overflow-hidden border border-border">
           <button
             onClick={() => setMode('in')}
-            className={`px-2 py-1 text-xs ${mode === 'in' ? 'bg-green/20 text-green' : 'text-text-muted hover:text-text'}`}
+            className={`px-2 py-1 text-xs ${mode === 'in' ? 'bg-success/20 text-success' : 'text-muted-foreground hover:text-foreground'}`}
           >Deposit</button>
           <button
             onClick={() => setMode('out')}
-            className={`px-2 py-1 text-xs ${mode === 'out' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}
+            className={`px-2 py-1 text-xs ${mode === 'out' ? 'bg-destructive/20 text-destructive' : 'text-muted-foreground hover:text-foreground'}`}
           >Withdraw</button>
         </div>
 
@@ -202,8 +202,8 @@ function DepositTab({ utaId, knownKeys, run, loading }: {
               onClick={submitDeposit}
               className="btn-primary-sm"
             >Deposit</button>
-            {draftOk && <span className="text-[11px] text-text-muted/70 font-mono">→ {draftOk.nativeKey}</span>}
-            {draftError && draft.symbol && <span className="text-[11px] text-yellow-400">{draftError}</span>}
+            {draftOk && <span className="text-[11px] text-muted-foreground/70 font-mono">→ {draftOk.nativeKey}</span>}
+            {draftError && draft.symbol && <span className="text-[11px] text-warning">{draftError}</span>}
           </>
         ) : (
           <>
@@ -223,7 +223,7 @@ function DepositTab({ utaId, knownKeys, run, loading }: {
           </>
         )}
 
-        <span className="text-[11px] text-text-muted ml-auto">Cash unchanged. Triggers UTA reconcile pipeline.</span>
+        <span className="text-[11px] text-muted-foreground ml-auto">Cash unchanged. Triggers UTA reconcile pipeline.</span>
       </div>
     </div>
   )
@@ -268,20 +268,20 @@ function TradeTab({ utaId, run, loading }: {
       <div className="flex rounded overflow-hidden border border-border">
         <button
           onClick={() => setSide('BUY')}
-          className={`px-2 py-1 text-xs ${side === 'BUY' ? 'bg-green/20 text-green' : 'text-text-muted hover:text-text'}`}
+          className={`px-2 py-1 text-xs ${side === 'BUY' ? 'bg-success/20 text-success' : 'text-muted-foreground hover:text-foreground'}`}
         >BUY</button>
         <button
           onClick={() => setSide('SELL')}
-          className={`px-2 py-1 text-xs ${side === 'SELL' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}
+          className={`px-2 py-1 text-xs ${side === 'SELL' ? 'bg-destructive/20 text-destructive' : 'text-muted-foreground hover:text-foreground'}`}
         >SELL</button>
       </div>
       <InstrumentInput draft={draft} onChange={setDraft} />
       <input className={`${inputClassMono} w-24`} placeholder="qty" value={qty} onChange={(e) => setQty(e.target.value)} />
       <input className={`${inputClassMono} w-24`} placeholder="price" value={price} onChange={(e) => setPrice(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') submit() }} />
       <button disabled={loading || !draftOk || !qty || !price} onClick={submit} className="btn-primary-sm">Submit</button>
-      {draftOk && <span className="text-[11px] text-text-muted/70 font-mono">→ {draftOk.nativeKey}</span>}
-      {draftError && draft.symbol && <span className="text-[11px] text-yellow-400">{draftError}</span>}
-      <span className="text-[11px] text-text-muted ml-auto">Cash {side === 'BUY' ? '−' : '+'} qty × price.</span>
+      {draftOk && <span className="text-[11px] text-muted-foreground/70 font-mono">→ {draftOk.nativeKey}</span>}
+      {draftError && draft.symbol && <span className="text-[11px] text-warning">{draftError}</span>}
+      <span className="text-[11px] text-muted-foreground ml-auto">Cash {side === 'BUY' ? '−' : '+'} qty × price.</span>
     </div>
   )
 }
@@ -327,8 +327,8 @@ function OrderTab({ utaId, knownKeys, run, loading }: {
   return (
     <div className="flex items-center gap-2 flex-wrap">
       <div className="flex rounded overflow-hidden border border-border">
-        <button onClick={() => setSide('BUY')} className={`px-2 py-1 text-xs ${side === 'BUY' ? 'bg-green/20 text-green' : 'text-text-muted hover:text-text'}`}>BUY</button>
-        <button onClick={() => setSide('SELL')} className={`px-2 py-1 text-xs ${side === 'SELL' ? 'bg-red/20 text-red' : 'text-text-muted hover:text-text'}`}>SELL</button>
+        <button onClick={() => setSide('BUY')} className={`px-2 py-1 text-xs ${side === 'BUY' ? 'bg-success/20 text-success' : 'text-muted-foreground hover:text-foreground'}`}>BUY</button>
+        <button onClick={() => setSide('SELL')} className={`px-2 py-1 text-xs ${side === 'SELL' ? 'bg-destructive/20 text-destructive' : 'text-muted-foreground hover:text-foreground'}`}>SELL</button>
       </div>
       <select value={orderType} onChange={(e) => setOrderType(e.target.value as 'MKT' | 'LMT')} className={`${inputClass} w-20`}>
         <option value="MKT">MKT</option>
@@ -340,7 +340,7 @@ function OrderTab({ utaId, knownKeys, run, loading }: {
         <input className={`${inputClassMono} w-28`} placeholder="limit price" value={lmtPrice} onChange={(e) => setLmtPrice(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') submit() }} />
       )}
       <button disabled={loading || !key || !qty || (orderType === 'LMT' && !lmtPrice)} onClick={submit} className="btn-primary-sm">Place</button>
-      <span className="text-[11px] text-text-muted">Stage → commit → push via Alice's trading pipeline.</span>
+      <span className="text-[11px] text-muted-foreground">Stage → commit → push via Alice's trading pipeline.</span>
     </div>
   )
 }

--- a/ui/src/pages/simulator/CreateSimulatorSection.tsx
+++ b/ui/src/pages/simulator/CreateSimulatorSection.tsx
@@ -67,13 +67,13 @@ export function CreateSimulatorSection({ onCreated }: {
     >
       <div className="flex items-center gap-2 flex-wrap">
         <input
-          className="px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent w-48"
+          className="px-2 py-1 bg-background text-foreground border border-border rounded text-sm outline-none transition-colors focus:border-primary w-48"
           placeholder="name (e.g. simulator)"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <input
-          className="px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent w-32"
+          className="px-2 py-1 bg-background text-foreground border border-border rounded font-mono text-xs outline-none transition-colors focus:border-primary w-32"
           placeholder="cash (USD)"
           value={cash}
           onChange={(e) => setCash(e.target.value)}

--- a/ui/src/pages/simulator/EventLog.tsx
+++ b/ui/src/pages/simulator/EventLog.tsx
@@ -28,19 +28,19 @@ export function EventLog({ events }: { events: SimulatorEvent[] }) {
       description="Every simulator action issued through this panel, newest first. Useful for retracing steps after a surprising state change."
     >
       {events.length === 0 ? (
-        <p className="text-xs text-text-muted">No actions yet.</p>
+        <p className="text-xs text-muted-foreground">No actions yet.</p>
       ) : (
         <>
           <table className="w-full text-sm">
             <tbody>
               {visible.map((ev) => (
-                <tr key={ev.id} className="text-text">
-                  <td className="py-0.5 pr-3 font-mono text-[11px] text-text-muted/80 w-20">{formatTime(ev.ts)}</td>
-                  <td className="py-0.5 pr-3 text-text-muted/60 text-[11px] w-20">{formatRelativeTime(ev.ts)}</td>
+                <tr key={ev.id} className="text-foreground">
+                  <td className="py-0.5 pr-3 font-mono text-[11px] text-muted-foreground/80 w-20">{formatTime(ev.ts)}</td>
+                  <td className="py-0.5 pr-3 text-muted-foreground/60 text-[11px] w-20">{formatRelativeTime(ev.ts)}</td>
                   <td className="py-0.5 pr-3">
-                    <span className={ev.status === 'err' ? 'text-red' : 'text-text'}>{ev.label}</span>
+                    <span className={ev.status === 'err' ? 'text-destructive' : 'text-foreground'}>{ev.label}</span>
                     {ev.detail && (
-                      <span className="ml-2 text-[11px] text-red/80" title={ev.detail}>
+                      <span className="ml-2 text-[11px] text-destructive/80" title={ev.detail}>
                         {ev.detail.slice(0, 60)}{ev.detail.length > 60 ? '…' : ''}
                       </span>
                     )}
@@ -53,7 +53,7 @@ export function EventLog({ events }: { events: SimulatorEvent[] }) {
           {events.length > COLLAPSED_COUNT && (
             <button
               onClick={() => setExpanded(!expanded)}
-              className="mt-2 text-[11px] text-text-muted hover:text-text transition-colors"
+              className="mt-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
             >
               {expanded ? `Collapse (${COLLAPSED_COUNT})` : `Show all (${events.length})`}
             </button>

--- a/ui/src/pages/simulator/InstrumentInput.tsx
+++ b/ui/src/pages/simulator/InstrumentInput.tsx
@@ -11,9 +11,9 @@ import type { InstrumentDraft, SecType } from './instruments'
 import { SEC_TYPES } from './instruments'
 
 const inputClass =
-  'px-2 py-1 bg-bg text-text border border-border rounded text-sm outline-none transition-colors focus:border-accent'
+  'px-2 py-1 bg-background text-foreground border border-border rounded text-sm outline-none transition-colors focus:border-primary'
 const inputClassMono =
-  'px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+  'px-2 py-1 bg-background text-foreground border border-border rounded font-mono text-xs outline-none transition-colors focus:border-primary'
 
 export function InstrumentInput({ draft, onChange, knownSymbols }: {
   draft: InstrumentDraft

--- a/ui/src/pages/simulator/MarkPrices.tsx
+++ b/ui/src/pages/simulator/MarkPrices.tsx
@@ -13,7 +13,7 @@ import { Section } from '../../components/form'
 import { simulatorApi, type SimulatorState } from '../../api/simulator'
 
 const inputClass =
-  'w-full px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+  'w-full px-2 py-1 bg-background text-foreground border border-border rounded font-mono text-xs outline-none transition-colors focus:border-primary'
 
 const FLASH_MS = 500
 
@@ -103,7 +103,7 @@ export function MarkPrices({ utaId, state, run, loading }: {
   const flashClass = (key: string): string => {
     const f = flashes[key]
     if (!f) return ''
-    return f === 'up' ? 'bg-green/10' : 'bg-red/10'
+    return f === 'up' ? 'bg-success/10' : 'bg-destructive/10'
   }
 
   return (
@@ -113,11 +113,11 @@ export function MarkPrices({ utaId, state, run, loading }: {
     >
       <div className="space-y-1">
         {state.markPrices.length === 0 ? (
-          <p className="text-xs text-text-muted">No prices set yet — add one below.</p>
+          <p className="text-xs text-muted-foreground">No prices set yet — add one below.</p>
         ) : (
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-left text-text-muted text-xs">
+              <tr className="text-left text-muted-foreground text-xs">
                 <th className="pb-1 pr-3">Symbol</th>
                 <th className="pb-1 pr-3 w-40">Price</th>
                 <th className="pb-1 text-right">Quick</th>
@@ -127,7 +127,7 @@ export function MarkPrices({ utaId, state, run, loading }: {
               {state.markPrices.map((m) => (
                 <tr
                   key={m.nativeKey}
-                  className={`text-text transition-colors duration-500 ${flashClass(m.nativeKey)}`}
+                  className={`text-foreground transition-colors duration-500 ${flashClass(m.nativeKey)}`}
                 >
                   <td className="py-1 pr-3 font-mono text-xs">{m.nativeKey}</td>
                   <td className="py-1 pr-3">

--- a/ui/src/pages/simulator/PendingOrders.tsx
+++ b/ui/src/pages/simulator/PendingOrders.tsx
@@ -9,7 +9,7 @@ import { Section } from '../../components/form'
 import { simulatorApi, type SimulatorState } from '../../api/simulator'
 
 const inputClass =
-  'w-full px-2 py-1 bg-bg text-text border border-border rounded font-mono text-xs outline-none transition-colors focus:border-accent'
+  'w-full px-2 py-1 bg-background text-foreground border border-border rounded font-mono text-xs outline-none transition-colors focus:border-primary'
 
 export function PendingOrders({ utaId, state, run, loading }: {
   utaId: string
@@ -34,11 +34,11 @@ export function PendingOrders({ utaId, state, run, loading }: {
       description="Submitted limit/stop orders waiting on a price trigger or manual fill."
     >
       {state.pendingOrders.length === 0 ? (
-        <p className="text-xs text-text-muted">No pending orders.</p>
+        <p className="text-xs text-muted-foreground">No pending orders.</p>
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-left text-text-muted text-xs">
+            <tr className="text-left text-muted-foreground text-xs">
               <th className="pb-1 pr-3">Order</th>
               <th className="pb-1 pr-3">Symbol</th>
               <th className="pb-1 pr-3">Side</th>
@@ -61,14 +61,14 @@ export function PendingOrders({ utaId, state, run, loading }: {
               const distancePct = distance != null && trigger ? Math.abs(distance) / Number(trigger) : null
               const closeToFire = distancePct != null && distancePct < 0.01
               return (
-                <tr key={o.orderId} className="text-text">
+                <tr key={o.orderId} className="text-foreground">
                   <td className="py-1 pr-3 font-mono text-[11px]">{o.orderId}</td>
                   <td className="py-1 pr-3">{o.symbol}</td>
                   <td className="py-1 pr-3">{o.action}</td>
                   <td className="py-1 pr-3">{o.orderType}</td>
                   <td className="py-1 pr-3 font-mono text-xs text-right">{o.totalQuantity}</td>
                   <td className="py-1 pr-3 font-mono text-xs text-right">{trigger ?? '—'}</td>
-                  <td className={`py-1 pr-3 font-mono text-xs text-right ${closeToFire ? 'text-yellow-400' : 'text-text-muted'}`}>
+                  <td className={`py-1 pr-3 font-mono text-xs text-right ${closeToFire ? 'text-warning' : 'text-muted-foreground'}`}>
                     {distance == null ? '—' : `${distance >= 0 ? '+' : ''}${distance.toFixed(2)}`}
                   </td>
                   <td className="py-1 pr-3">

--- a/ui/src/pages/simulator/Positions.tsx
+++ b/ui/src/pages/simulator/Positions.tsx
@@ -34,11 +34,11 @@ export function Positions({ state }: { state: SimulatorState }) {
       description="Read-only — mutate via mark price moves, order fills, or external events."
     >
       {state.positions.length === 0 ? (
-        <p className="text-xs text-text-muted">No positions.</p>
+        <p className="text-xs text-muted-foreground">No positions.</p>
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-left text-text-muted text-xs">
+            <tr className="text-left text-muted-foreground text-xs">
               <th className="pb-1 pr-3">Position</th>
               <th className="pb-1 pr-3 text-right">Qty</th>
               <th className="pb-1 pr-3 text-right">Avg Cost</th>
@@ -57,29 +57,29 @@ export function Positions({ state }: { state: SimulatorState }) {
               const pnl = mark && Number.isFinite(qty) && Number.isFinite(avg)
                 ? (Number(mark) - avg) * qty * mult * (p.side === 'long' ? 1 : -1)
                 : null
-              const pnlClass = pnl == null ? 'text-text-muted' : pnl > 0 ? 'text-green' : pnl < 0 ? 'text-red' : 'text-text'
+              const pnlClass = pnl == null ? 'text-muted-foreground' : pnl > 0 ? 'text-success' : pnl < 0 ? 'text-destructive' : 'text-foreground'
               return (
-                <tr key={p.nativeKey} className="text-text">
+                <tr key={p.nativeKey} className="text-foreground">
                   <td className="py-1 pr-3">
                     <div className="flex items-center gap-1.5 flex-wrap">
-                      <span className="font-medium text-text">{describePosition(p)}</span>
+                      <span className="font-medium text-foreground">{describePosition(p)}</span>
                       {p.secType && (
-                        <span className="text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-bg-tertiary text-text-muted/80">{p.secType}</span>
+                        <span className="text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-muted text-muted-foreground/80">{p.secType}</span>
                       )}
-                      <span className={`text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-green/15 text-green' : 'bg-red/15 text-red'}`}>
+                      <span className={`text-[10px] px-1 py-0.5 rounded font-medium ${p.side === 'long' ? 'bg-success/15 text-success' : 'bg-destructive/15 text-destructive'}`}>
                         {p.side}
                       </span>
                       {p.multiplier && p.multiplier !== '1' && (
-                        <span className="text-[9px] text-text-muted/60" title={`Each contract = ${p.multiplier} units`}>×{p.multiplier}</span>
+                        <span className="text-[9px] text-muted-foreground/60" title={`Each contract = ${p.multiplier} units`}>×{p.multiplier}</span>
                       )}
                       {p.avgCostSource === 'wallet' && (
-                        <span className="text-[9px] text-text-muted/60" title="Cost basis derived from UTA reconcile pipeline (wallet-source position)">wallet</span>
+                        <span className="text-[9px] text-muted-foreground/60" title="Cost basis derived from UTA reconcile pipeline (wallet-source position)">wallet</span>
                       )}
                     </div>
                   </td>
                   <td className="py-1 pr-3 font-mono text-xs text-right">{p.quantity}</td>
                   <td className="py-1 pr-3 font-mono text-xs text-right">{p.avgCost}</td>
-                  <td className="py-1 pr-3 font-mono text-xs text-right text-text-muted">{mark ?? '—'}</td>
+                  <td className="py-1 pr-3 font-mono text-xs text-right text-muted-foreground">{mark ?? '—'}</td>
                   <td className={`py-1 font-mono text-xs text-right transition-colors duration-300 ${pnlClass}`}>
                     {pnl == null ? '—' : `${pnl >= 0 ? '+' : ''}${pnl.toFixed(2)}`}
                   </td>

--- a/ui/src/theme/palette.css
+++ b/ui/src/theme/palette.css
@@ -1,0 +1,223 @@
+/*
+ * OpenAlice semantic color card.
+ *
+ * The core vocabulary mirrors Orca/shadcn so components, imported terminal
+ * themes, and future theme tooling can speak the same language without taking
+ * a dependency on a component library. OpenAlice-specific roles extend that
+ * vocabulary only where the product has a real additional meaning (trading
+ * state, AI actions, scoped sidebars, and charts).
+ *
+ * Keep literal product colors in this file. Components consume semantic
+ * variables or their Tailwind aliases from index.css; they must not select a
+ * palette shade directly.
+ */
+
+:root {
+  color-scheme: light;
+
+  /* Orca/shadcn-compatible core roles. */
+  --background: #fbfaf6;
+  --foreground: #1c2a41;
+  --card: #fffdf8;
+  --card-foreground: #1c2a41;
+  --popover: #fffdf8;
+  --popover-foreground: #1c2a41;
+  --primary: #2f62b0;
+  --primary-foreground: #fffdf8;
+  --secondary: #f1ede4;
+  --secondary-foreground: #1c2a41;
+  --muted: #e4dccb;
+  --muted-foreground: #5e6573;
+  --accent: rgba(28, 42, 65, 0.045);
+  --accent-foreground: #1c2a41;
+  --destructive: #be4138;
+  --destructive-foreground: #fffdf8;
+  --border: #d8d2c4;
+  --input: #d8d2c4;
+  --ring: #2f62b0;
+
+  /* Deliberate extensions to the core vocabulary. */
+  --accent-strong: rgba(28, 42, 65, 0.075);
+  --primary-muted: rgba(47, 98, 176, 0.14);
+  --success: #2e8b6f;
+  --success-foreground: #fffdf8;
+  --warning: #986700;
+  --warning-foreground: #fffdf8;
+  --warning-background: #fbf1d6;
+  --warning-border: #c99a2e;
+  --info: #2f62b0;
+  --info-foreground: #fffdf8;
+  --ai-action: #6b5bc2;
+  --ai-action-foreground: #fffdf8;
+  --backdrop: rgba(11, 12, 14, 0.5);
+  --code-background: rgba(28, 42, 65, 0.07);
+  --report-canvas: #ffffff;
+  --shadow-color: #1c2a41;
+
+  /* Data visualization roles. */
+  --chart-1: #2f62b0;
+  --chart-2: #2e8b6f;
+  --chart-3: #986700;
+  --chart-4: #6b5bc2;
+  --chart-5: #1b7c83;
+  --chart-positive: #2e8b6f;
+  --chart-negative: #be4138;
+  --chart-positive-muted: rgba(46, 139, 111, 0.33);
+  --chart-negative-muted: rgba(190, 65, 56, 0.33);
+  --chart-axis: #5e6573;
+  --chart-grid: #d8d2c4;
+
+  /* Sidebar is a scoped projection of the same core roles. */
+  --sidebar: #f1ede4;
+  --sidebar-foreground: #1c2a41;
+  --sidebar-primary: #2f62b0;
+  --sidebar-primary-foreground: #fffdf8;
+  --sidebar-accent: #e4dccb;
+  --sidebar-accent-foreground: #1c2a41;
+  --sidebar-border: #d8d2c4;
+  --sidebar-ring: #2f62b0;
+
+  --app-background-wash: radial-gradient(
+    circle at 50% 24%,
+    rgba(47, 98, 176, 0.045),
+    transparent 38rem
+  );
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --background: #0b0c0e;
+  --foreground: #dfe1e6;
+  --card: #141519;
+  --card-foreground: #dfe1e6;
+  --popover: #141519;
+  --popover-foreground: #dfe1e6;
+  --primary: #3b82f6;
+  --primary-foreground: #ffffff;
+  --secondary: #0e0f12;
+  --secondary-foreground: #dfe1e6;
+  --muted: #1a1b21;
+  --muted-foreground: #8f929b;
+  --accent: rgba(255, 255, 255, 0.04);
+  --accent-foreground: #dfe1e6;
+  --destructive: #e5484d;
+  --destructive-foreground: #ffffff;
+  --border: #24262c;
+  --input: #24262c;
+  --ring: #3b82f6;
+
+  --accent-strong: rgba(255, 255, 255, 0.07);
+  --primary-muted: rgba(59, 130, 246, 0.16);
+  --success: #23b99a;
+  --success-foreground: #07130f;
+  --warning: #f0b95b;
+  --warning-foreground: #1d1610;
+  --warning-background: #1d1610;
+  --warning-border: #8a5b2f;
+  --info: #79c0ff;
+  --info-foreground: #07111c;
+  --ai-action: #8f72ff;
+  --ai-action-foreground: #ffffff;
+  --backdrop: rgba(0, 0, 0, 0.5);
+  --code-background: rgba(0, 0, 0, 0.3);
+  --report-canvas: #ffffff;
+  --shadow-color: #000000;
+
+  --chart-1: #79c0ff;
+  --chart-2: #23b99a;
+  --chart-3: #f0b95b;
+  --chart-4: #8f72ff;
+  --chart-5: #a5d6ff;
+  --chart-positive: #23b99a;
+  --chart-negative: #e5484d;
+  --chart-positive-muted: rgba(35, 185, 154, 0.33);
+  --chart-negative-muted: rgba(229, 72, 77, 0.33);
+  --chart-axis: #8f929b;
+  --chart-grid: #24262c;
+
+  --sidebar: #0e0f12;
+  --sidebar-foreground: #dfe1e6;
+  --sidebar-primary: #3b82f6;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #1a1b21;
+  --sidebar-accent-foreground: #dfe1e6;
+  --sidebar-border: #24262c;
+  --sidebar-ring: #3b82f6;
+
+  --app-background-wash: radial-gradient(
+    circle at 50% 28%,
+    rgba(255, 255, 255, 0.02),
+    transparent 34rem
+  );
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="auto"] {
+    color-scheme: dark;
+
+    --background: #0b0c0e;
+    --foreground: #dfe1e6;
+    --card: #141519;
+    --card-foreground: #dfe1e6;
+    --popover: #141519;
+    --popover-foreground: #dfe1e6;
+    --primary: #3b82f6;
+    --primary-foreground: #ffffff;
+    --secondary: #0e0f12;
+    --secondary-foreground: #dfe1e6;
+    --muted: #1a1b21;
+    --muted-foreground: #8f929b;
+    --accent: rgba(255, 255, 255, 0.04);
+    --accent-foreground: #dfe1e6;
+    --destructive: #e5484d;
+    --destructive-foreground: #ffffff;
+    --border: #24262c;
+    --input: #24262c;
+    --ring: #3b82f6;
+
+    --accent-strong: rgba(255, 255, 255, 0.07);
+    --primary-muted: rgba(59, 130, 246, 0.16);
+    --success: #23b99a;
+    --success-foreground: #07130f;
+    --warning: #f0b95b;
+    --warning-foreground: #1d1610;
+    --warning-background: #1d1610;
+    --warning-border: #8a5b2f;
+    --info: #79c0ff;
+    --info-foreground: #07111c;
+    --ai-action: #8f72ff;
+    --ai-action-foreground: #ffffff;
+    --backdrop: rgba(0, 0, 0, 0.5);
+    --code-background: rgba(0, 0, 0, 0.3);
+    --report-canvas: #ffffff;
+    --shadow-color: #000000;
+
+    --chart-1: #79c0ff;
+    --chart-2: #23b99a;
+    --chart-3: #f0b95b;
+    --chart-4: #8f72ff;
+    --chart-5: #a5d6ff;
+    --chart-positive: #23b99a;
+    --chart-negative: #e5484d;
+    --chart-positive-muted: rgba(35, 185, 154, 0.33);
+    --chart-negative-muted: rgba(229, 72, 77, 0.33);
+    --chart-axis: #8f929b;
+    --chart-grid: #24262c;
+
+    --sidebar: #0e0f12;
+    --sidebar-foreground: #dfe1e6;
+    --sidebar-primary: #3b82f6;
+    --sidebar-primary-foreground: #ffffff;
+    --sidebar-accent: #1a1b21;
+    --sidebar-accent-foreground: #dfe1e6;
+    --sidebar-border: #24262c;
+    --sidebar-ring: #3b82f6;
+
+    --app-background-wash: radial-gradient(
+      circle at 50% 28%,
+      rgba(255, 255, 255, 0.02),
+      transparent 34rem
+    );
+  }
+}

--- a/ui/src/theme/semanticColors.spec.ts
+++ b/ui/src/theme/semanticColors.spec.ts
@@ -1,0 +1,121 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { basename, extname, resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = basename(process.cwd()) === 'ui' ? resolve(process.cwd(), '..') : process.cwd()
+const uiRoot = resolve(repoRoot, 'ui')
+const palette = readFileSync(resolve(uiRoot, 'src/theme/palette.css'), 'utf8')
+const indexCss = readFileSync(resolve(uiRoot, 'src/index.css'), 'utf8')
+
+const CORE_TOKENS = [
+  'background',
+  'foreground',
+  'card',
+  'card-foreground',
+  'popover',
+  'popover-foreground',
+  'primary',
+  'primary-foreground',
+  'secondary',
+  'secondary-foreground',
+  'muted',
+  'muted-foreground',
+  'accent',
+  'accent-foreground',
+  'destructive',
+  'destructive-foreground',
+  'border',
+  'input',
+  'ring',
+] as const
+
+const ALLOWED_LITERAL_COLOR_FILES = new Set([
+  // Single product color authority.
+  resolve(uiRoot, 'src/theme/palette.css'),
+  // xterm remains a separate terminal-palette projection in this increment.
+  resolve(uiRoot, 'src/components/workspace/terminalThemeProfile.ts'),
+  // An origin-less document has no access to parent CSS variables; these are
+  // safe fallback colors for unstyled agent-authored HTML, not app chrome.
+  resolve(uiRoot, 'src/components/HtmlReportView.tsx'),
+])
+
+function productionStyleFiles(directory: string): string[] {
+  const output: string[] = []
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue
+      output.push(...productionStyleFiles(path))
+      continue
+    }
+    if (!['.css', '.ts', '.tsx'].includes(extname(entry.name))) continue
+    if (/\.(?:spec|test)\./.test(entry.name)) continue
+    output.push(path)
+  }
+  return output
+}
+
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+}
+
+describe('semantic color contract', () => {
+  it('defines the Orca/shadcn core vocabulary for light, dark, and auto-dark', () => {
+    for (const token of CORE_TOKENS) {
+      expect(palette.match(new RegExp(`--${token}:`, 'g'))?.length, token).toBe(3)
+      expect(indexCss, token).toContain(`--color-${token}: var(--${token});`)
+    }
+  })
+
+  it('keeps every palette token symmetric across light, dark, and auto-dark', () => {
+    const lightBlock = palette.match(/:root\s*\{([\s\S]*?)\n\}/)?.[1]
+    expect(lightBlock).toBeDefined()
+
+    const tokens = [...lightBlock!.matchAll(/^\s*(--[\w-]+):/gm)].map((match) => match[1])
+    expect(tokens.length).toBeGreaterThan(CORE_TOKENS.length)
+
+    for (const token of tokens) {
+      expect(palette.match(new RegExp(`${token}:`, 'g'))?.length, token).toBe(3)
+    }
+  })
+
+  it('keeps literal product colors in the color card', () => {
+    const files = [
+      ...productionStyleFiles(resolve(uiRoot, 'src')),
+      resolve(repoRoot, 'packages/uta-protocol/src/brokers/preset-catalog.ts'),
+    ]
+    const violations: string[] = []
+    const literalColor = /#(?:[\da-f]{3}|[\da-f]{4}|[\da-f]{6}|[\da-f]{8})\b|\b(?:rgb|rgba|hsl|hsla|oklch)\(/i
+
+    for (const file of files) {
+      if (ALLOWED_LITERAL_COLOR_FILES.has(file)) continue
+      if (literalColor.test(withoutComments(readFileSync(file, 'utf8')))) {
+        violations.push(file.replace(`${repoRoot}/`, ''))
+      }
+    }
+
+    expect(violations).toEqual([])
+  })
+
+  it('rejects legacy OpenAlice names and palette-specific utility colors', () => {
+    const files = [
+      ...productionStyleFiles(resolve(uiRoot, 'src')),
+      resolve(repoRoot, 'packages/uta-protocol/src/brokers/preset-catalog.ts'),
+    ]
+    const violations: string[] = []
+    const legacyToken = /--color-(?:bg|text|green|red|purple|overlay|notification)(?:-|\b)/
+    const legacyUtility = /\b(?:bg-bg(?:-secondary|-tertiary)?|text-text(?:-muted)?|text-bg|(?:bg|text|border|ring|fill|stroke)-(?:red|rose|green|emerald|lime|yellow|amber|orange|blue|sky|cyan|purple|violet|fuchsia)(?:-\d{2,3})?)(?:\/[^\s'"`]+)?\b/
+
+    for (const file of files) {
+      const source = withoutComments(readFileSync(file, 'utf8'))
+      if (legacyToken.test(source) || legacyUtility.test(source)) {
+        violations.push(file.replace(`${repoRoot}/`, ''))
+      }
+    }
+
+    expect(violations).toEqual([])
+  })
+})

--- a/ui/src/theme/semanticColors.ts
+++ b/ui/src/theme/semanticColors.ts
@@ -1,0 +1,8 @@
+/** Read a resolved semantic color for canvas-based renderers that cannot
+ * consume CSS custom properties directly. DOM/SVG surfaces should keep using
+ * `var(--token)` so the browser owns theme updates. */
+export function readSemanticColor(token: string): string {
+  const value = getComputedStyle(document.documentElement).getPropertyValue(`--${token}`).trim()
+  if (!value) throw new Error(`Missing semantic color token: --${token}`)
+  return value
+}


### PR DESCRIPTION
## Summary

- establish a single light/dark semantic color palette using the Orca/shadcn core vocabulary without adding the shadcn component library
- migrate product UI, Workspace CSS, status states, broker badges, and chart renderers away from physical palette names and literal colors
- add a live hidden color-card route at /design/semantic-colors plus a static contract test that blocks legacy tokens, raw Tailwind color families, and product color literals outside approved palette boundaries

## Boundary

- terminal ANSI/xterm colors intentionally remain a separate projection in this increment; the shared product vocabulary is now ready for a later terminal-theme bridge
- origin-less agent HTML keeps its minimal hardcoded fallback because it cannot inherit parent CSS variables

## Verification

- npx tsc --noEmit
- pnpm test (326 files passed, 3205 tests passed, 1 file / 8 tests skipped)
- cd ui && npx tsc -b
- pnpm -F open-alice-ui build
- pnpm -F @traderalice/uta-protocol typecheck
- npx vitest run ui/src/theme/semanticColors.spec.ts (4 passed)
- browser: /design/semantic-colors in light/dark, 430px narrow viewport, Market and Workspaces demo routes
- CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace