### PR TITLE
fix(market): restore source-aware chart navigation

### DIFF
--- a/src/domain/market-data/aggregate-search.spec.ts
+++ b/src/domain/market-data/aggregate-search.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { aggregateSymbolSearch, type MarketSearchDeps } from './aggregate-search.js'
+
+function deps(): MarketSearchDeps {
+  return {
+    symbolIndex: {
+      search: vi.fn(() => [
+        { symbol: 'UNRELATED1', name: 'Unrelated One', source: 'sec' },
+        { symbol: 'UNRELATED2', name: 'Unrelated Two', source: 'sec' },
+        { symbol: 'UNRELATED3', name: 'Unrelated Three', source: 'sec' },
+      ]),
+    } as never,
+    equityVendors: ['yfinance'],
+    equityClient: { search: vi.fn(async () => []) } as never,
+    cryptoClient: { search: vi.fn(async () => []) } as never,
+    currencyClient: {
+      search: vi.fn(async () => [
+        { symbol: 'EURUSD', name: 'Euro / U.S. Dollar' },
+        { symbol: 'EURUSDX', name: 'Euro Index' },
+      ]),
+    } as never,
+    commodityCatalog: { search: vi.fn(() => []) } as never,
+  }
+}
+
+describe('aggregateSymbolSearch limits', () => {
+  it('ranks the full union, then enforces one global result limit', async () => {
+    const searchDeps = deps()
+    const results = await aggregateSymbolSearch(searchDeps, 'EURUSD', 2)
+
+    expect(results).toHaveLength(2)
+    expect(results[0]).toMatchObject({ symbol: 'EURUSD', assetClass: 'currency' })
+    expect(searchDeps.symbolIndex.search).toHaveBeenCalledWith('EURUSD', 2)
+    expect(searchDeps.commodityCatalog.search).toHaveBeenCalledWith('EURUSD', 2)
+  })
+})

--- a/src/domain/market-data/aggregate-search.ts
+++ b/src/domain/market-data/aggregate-search.ts
@@ -81,6 +81,7 @@ export async function aggregateSymbolSearch(
 ): Promise<MarketSearchResult[]> {
   const q = query.trim()
   if (!q) return []
+  const boundedLimit = Math.max(1, Math.min(100, Number.isFinite(limit) ? Math.floor(limit) : 20))
 
   const equityVendors = typeof deps.equityVendors === 'function'
     ? await deps.equityVendors()
@@ -90,11 +91,11 @@ export async function aggregateSymbolSearch(
   // Local SEC index — US-only, zero-latency, authoritative for US tickers.
   // Attributed to the primary equity vendor (its symbols feed that provider).
   const equityResults = deps.symbolIndex
-    .search(q, limit)
+    .search(q, boundedLimit)
     .map((r) => ({ ...r, assetClass: 'equity' as const, sourceId: primaryEquity }))
 
   const commodityResults = deps.commodityCatalog
-    .search(q, limit)
+    .search(q, boundedLimit)
     .map((r) => ({ ...r, assetClass: 'commodity' as const }))
 
   // Online searches, concurrent: crypto + currency on yfinance; equity fanned
@@ -161,4 +162,5 @@ export async function aggregateSymbolSearch(
     .map((r, i) => ({ r, i, s: matchScore(q, r) }))
     .sort((a, b) => b.s - a.s || a.i - b.i)
     .map((x) => x.r)
+    .slice(0, boundedLimit)
 }

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -54,6 +54,7 @@ describe('barId helpers', () => {
   it('rejects malformed', () => {
     expect(parseBarId('AAPL')).toBeNull()
     expect(parseBarId('|AAPL')).toBeNull()
+    expect(parseBarId('yfinance|')).toBeNull()
   })
 })
 
@@ -176,6 +177,21 @@ describe('getBars — UTA branch', () => {
     expect(meta.barCapability).toBe('realtime')
   })
 
+  it('rejects a UTA source that does not advertise historical-bar support', async () => {
+    const getHistorical = vi.fn(async () => WIRE)
+    const utaManager: UtaBarGateway = {
+      has: async (id) => id === 'ibkr',
+      get: async () => ({ getHistorical }),
+      searchContracts: async () => [],
+      getBarCapabilities: async () => ({}),
+    }
+    const svc = createBarService(makeDeps({ utaManager }))
+
+    await expect(svc.getBars({ barId: 'ibkr|AAPL' }, { interval: '1d' }))
+      .rejects.toThrow(/does not advertise historical-bar support/)
+    expect(getHistorical).not.toHaveBeenCalled()
+  })
+
   it('renders a daily broker bar date-only even when stamped at the session open (no 05:00 / DST noise)', async () => {
     // Alpaca stamps a daily bar at the premarket open (04:00/05:00 ET in UTC),
     // which also flips an hour across DST — render the calendar day, not an instant.
@@ -264,6 +280,52 @@ describe('searchBarSources — federated candidates', () => {
     const uta = out.filter((c) => c.source === 'uta')
     expect(uta[0]).toMatchObject({ sourceId: 'okx-readonly', assetClass: 'crypto' })
     expect(uta[1]).toMatchObject({ sourceId: 'ibkr', assetClass: 'commodity' })
+  })
+
+  it('filters capability-less, blank, invalid, and duplicate UTA bar candidates', async () => {
+    const utaManager = {
+      has: async () => true,
+      get: async () => undefined,
+      getBarCapabilities: async () => ({ 'alpaca-paper': 'iex' }),
+      searchContracts: async () => [
+        { source: 'ibkr', contract: { aliceId: 'ibkr|AAPL', symbol: 'AAPL', secType: 'STK' }, derivativeSecTypes: [] },
+        { source: 'alpaca-paper', contract: { aliceId: 'alpaca-paper|-1', symbol: 'AAPL', secType: 'STK' }, derivativeSecTypes: [] },
+        { source: 'alpaca-paper', contract: { aliceId: 'not-a-bar-id', symbol: 'AAPL', secType: 'STK' }, derivativeSecTypes: [] },
+        { source: 'alpaca-paper', contract: { aliceId: 'alpaca-paper|EMPTY', symbol: '', secType: 'STK' }, derivativeSecTypes: [] },
+        { source: 'alpaca-paper', contract: { aliceId: 'alpaca-paper|AAPL', symbol: 'AAPL', secType: 'STK' }, derivativeSecTypes: [] },
+        { source: 'alpaca-paper', contract: { aliceId: 'alpaca-paper|AAPL', symbol: 'AAPL duplicate', secType: 'STK' }, derivativeSecTypes: [] },
+      ],
+    } as never
+
+    const out = await createBarService(makeDeps({ utaManager })).searchBarSources('AAPL')
+    const uta = out.filter((candidate) => candidate.source === 'uta')
+
+    expect(uta).toEqual([
+      expect.objectContaining({
+        barId: 'alpaca-paper|AAPL',
+        sourceId: 'alpaca-paper',
+        symbol: 'AAPL',
+        barCapability: 'iex',
+      }),
+    ])
+  })
+
+  it('applies the requested limit after relevance and freshness sorting', async () => {
+    const utaManager = {
+      has: async () => true,
+      get: async () => undefined,
+      searchContracts: async () => [
+        { source: 'alpaca-paper', contract: { aliceId: 'alpaca-paper|AAPL', symbol: 'AAPL', secType: 'STK' }, derivativeSecTypes: [] },
+        { source: 'alpaca-paper', contract: { aliceId: 'alpaca-paper|AAPL-RELATED', symbol: 'AAPL-RELATED', secType: 'STK' }, derivativeSecTypes: [] },
+      ],
+      getBarCapabilities: async () => ({ 'alpaca-paper': 'iex' }),
+    } as never
+
+    const out = await createBarService(makeDeps({ utaManager })).searchBarSources('AAPL', { limit: 1 })
+
+    expect(out).toHaveLength(1)
+    expect(out[0].symbol).toBe('AAPL')
+    expect(out[0].barCapability).toBe('iex')
   })
 
   it('survives one side failing (vendor still returns if UTA throws)', async () => {

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -5,11 +5,9 @@
  * OHLCV, tagging the result with source metadata. `searchBarSources(query)`
  * surfaces candidate sources for an asset.
  *
- * Phase 0 scope: the vendor branch is fully wired; the UTA branch calls
- * `UTAAccountSDK.getHistorical` (404s until the Phase-1 server route + a
- * per-broker `getHistorical` land). `searchBarSources` is vendor-only here —
- * the UTA search side (and the `ContractSearchResult` wire-shape fix) lands in
- * Phase 1 alongside CCXT. No Phase-0 consumer calls `searchBarSources`.
+ * Vendor and UTA sources share one explicit identity namespace. Broker search
+ * hits are only exposed as K-line sources when their capability declaration
+ * says historical bars are supported.
  */
 
 import type { BarParams, BarInterval, Bar } from '@traderalice/uta-protocol'
@@ -56,6 +54,17 @@ function secTypeToAssetClass(secType: string | undefined): AssetClass | 'unknown
     case 'FUT': case 'FOP': case 'CMDTY': return 'commodity'
     default: return 'unknown'
   }
+}
+
+function candidateRelevance(query: string, candidate: BarSourceCandidate): number {
+  const q = query.trim().toLowerCase()
+  const symbol = candidate.symbol.toLowerCase()
+  const name = candidate.name?.toLowerCase() ?? ''
+  if (symbol === q || name === q) return 4
+  if (symbol.startsWith(q)) return 3
+  if (name.startsWith(q)) return 2
+  if (symbol.includes(q) || name.includes(q)) return 1
+  return 0
 }
 
 // ---- window heuristics (legacy behavior-preserving; lifted from tool/analysis.ts) ----
@@ -233,7 +242,11 @@ export function createBarService(deps: BarServiceDeps): BarService {
     // not a blanket 'realtime'. Falls back to 'realtime' when the gateway can't
     // surface it (mocks / brokers that declare no quality).
     const caps: Record<string, BarCapability> = (await deps.utaManager.getBarCapabilities?.()) ?? {}
-    const cap: BarCapability = caps[sourceId] ?? 'realtime'
+    const cap = caps[sourceId]
+    if (deps.utaManager.getBarCapabilities && !cap) {
+      throw new Error(`UTA source "${sourceId}" does not advertise historical-bar support.`)
+    }
+    const effectiveCap: BarCapability = cap ?? 'realtime'
     // Mirror the vendor branch: a count-only request becomes a START WINDOW we
     // over-fetch and then tail-slice (finalize keeps the most-recent `count`).
     // We deliberately do NOT forward `count` as the broker's `limit`. Alpaca's
@@ -258,7 +271,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
         source: 'uta',
         sourceId,
         barId,
-        barCapability: cap,
+        barCapability: effectiveCap,
         ...computeFreshness(bars[bars.length - 1]?.date ?? '', opts, () => new Date()),
       }),
     }
@@ -266,7 +279,9 @@ export function createBarService(deps: BarServiceDeps): BarService {
 
   return {
     async searchBarSources(query, opts) {
-      const limit = opts?.limit ?? 20
+      const requestedLimit = opts?.limit ?? 20
+      const limit = Math.max(1, Math.min(100, Number.isFinite(requestedLimit) ? Math.floor(requestedLimit) : 20))
+      const capabilityAware = typeof deps.utaManager.getBarCapabilities === 'function'
       // Federate embedded vendor + broker (UTA) search. allSettled so one
       // side failing (e.g. no UTA configured) doesn't kill the other. Flat
       // candidates, no cross-source dedup — redundancy is the feature.
@@ -277,6 +292,12 @@ export function createBarService(deps: BarServiceDeps): BarService {
       ])
       const caps: Record<string, BarCapability> = capsRes.status === 'fulfilled' ? capsRes.value : {}
       const out: BarSourceCandidate[] = []
+      const seenBarIds = new Set<string>()
+      const append = (candidate: BarSourceCandidate) => {
+        if (!candidate.symbol.trim() || !candidate.barId.trim() || seenBarIds.has(candidate.barId)) return
+        seenBarIds.add(candidate.barId)
+        out.push(candidate)
+      }
 
       if (vendorRes.status === 'fulfilled') {
         for (const r of vendorRes.value) {
@@ -286,7 +307,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
           const provider = r.sourceId ?? deps.vendorProviders[r.assetClass]
           const cap = VENDOR_CAPABILITY[provider]
           const base = r.name ? `${symbol} · ${r.name} (${provider})` : `${symbol} (${provider})`
-          out.push({
+          append({
             barId: formatBarId(provider, symbol),
             source: 'vendor',
             sourceId: provider,
@@ -306,9 +327,17 @@ export function createBarService(deps: BarServiceDeps): BarService {
         for (const hit of utaRes.value) {
           const barId = hit.contract.aliceId
           if (!barId) continue // need the operational identity to fetch later
-          const symbol = hit.contract.symbol || hit.contract.localSymbol || ''
-          const cap: BarCapability = caps[hit.source] ?? 'realtime'
-          out.push({
+          const parsed = parseBarId(barId)
+          const symbol = (hit.contract.symbol || hit.contract.localSymbol || '').trim()
+          const cap = caps[hit.source]
+          // Production gateways expose the capability map. Missing capability
+          // means this account can search/trade contracts but cannot supply
+          // historical bars (IBKR is a common example), so it is not a bar
+          // source. Gateways without capability discovery retain the legacy
+          // realtime fallback for tests/custom integrations.
+          if ((capabilityAware && (!cap || capsRes.status !== 'fulfilled')) || !parsed || parsed.nativeSymbol === '-1') continue
+          const effectiveCap: BarCapability = cap ?? 'realtime'
+          append({
             barId,
             source: 'uta',
             sourceId: hit.source,
@@ -318,26 +347,25 @@ export function createBarService(deps: BarServiceDeps): BarService {
             assetClass: hit.assetClass ?? secTypeToAssetClass(hit.contract.secType),
             // Honest entitlement in the label too (Alpaca free = 'iex'), not a
             // blanket 'realtime'.
-            label: (symbol ? `${symbol} (${hit.source})` : barId) + ` · ${cap}`,
-            barCapability: cap,
+            label: `${symbol} (${hit.source}) · ${effectiveCap}`,
+            barCapability: effectiveCap,
           })
         }
       }
 
-      // Order by freshness so the agent's default pick is the freshest source:
-      // broker bars (realtime) float above delayed vendors (yfinance/fmp). The
-      // list stays fully redundant — this is only the suggested ordering; every
-      // candidate is still returned. (Array.sort is stable → within-source order
-      // is preserved.)
+      // User intent first, freshness second: an exact delayed EURUSD result must
+      // not disappear below dozens of vaguely-related realtime contracts. Auto
+      // source resolution applies its own derivative/freshness policy later.
       const FRESHNESS_RANK: Record<BarCapability, number> = {
         realtime: 0, iex: 1, subscription: 2, delayed: 3, free: 4,
       }
       out.sort(
         (a, b) =>
+          candidateRelevance(query, b) - candidateRelevance(query, a) ||
           (a.barCapability ? FRESHNESS_RANK[a.barCapability] : 5) -
           (b.barCapability ? FRESHNESS_RANK[b.barCapability] : 5),
       )
-      return out
+      return out.slice(0, limit)
     },
 
     async getBars(ref, opts) {

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -36,7 +36,7 @@ export interface BarRef {
 /** Split a barId on the FIRST `|` (nativeKey may itself contain separators). */
 export function parseBarId(barId: string): BarRef | null {
   const idx = barId.indexOf('|')
-  if (idx <= 0) return null
+  if (idx <= 0 || idx === barId.length - 1) return null
   return { sourceId: barId.slice(0, idx), nativeSymbol: barId.slice(idx + 1) }
 }
 

--- a/src/services/uta-client/UTAManagerSDK.spec.ts
+++ b/src/services/uta-client/UTAManagerSDK.spec.ts
@@ -76,10 +76,19 @@ describe('UTAManagerSDK — data-source participation', () => {
           asVendor: false,
           capabilities: { supportedSecTypes: [], supportedOrderTypes: [], historicalBars: { supported: true, quality: 'realtime' } },
         }),
+        summary('custom-bars', 'trading', {
+          capabilities: { supportedSecTypes: [], supportedOrderTypes: [], historicalBars: { supported: true } },
+        }),
+        summary('disabled-bars', 'trading', {
+          capabilities: { supportedSecTypes: [], supportedOrderTypes: [], historicalBars: { supported: false, quality: 'delayed' } },
+        }),
       ]),
     })
 
-    await expect(m.getBarCapabilities()).resolves.toEqual({ 'alpaca-paper': 'iex' })
+    await expect(m.getBarCapabilities()).resolves.toEqual({
+      'alpaca-paper': 'iex',
+      'custom-bars': 'realtime',
+    })
   })
 })
 

--- a/src/services/uta-client/UTAManagerSDK.ts
+++ b/src/services/uta-client/UTAManagerSDK.ts
@@ -138,8 +138,9 @@ export class UTAManagerSDK {
     const out: Record<string, 'realtime' | 'iex' | 'delayed' | 'subscription'> = {}
     for (const u of all) {
       if (u.asVendor === false) continue
-      const q = u.capabilities.historicalBars?.quality
-      if (q) out[u.id] = q
+      const historical = u.capabilities.historicalBars
+      if (!historical?.supported) continue
+      out[u.id] = historical.quality ?? 'realtime'
     }
     return out
   }

--- a/src/tool/quant.ts
+++ b/src/tool/quant.ts
@@ -18,7 +18,7 @@ export function createQuantTools(deps: CalcDeps) {
       description: `Find K-line sources for a symbol — returns barIds to paste into calculateQuant's bars(...).
 
 Federates connected brokers, user-enabled keyless data sources (binance-readonly, …), AND vendors (fmp, yfinance).
-Candidates come back freshest-first. Each carries:
+Candidates come back relevance-first, then freshest within the same match quality. Each carries:
   - barId: use directly, e.g. bars("<barId>", "1d", count=250).
     · broker barIds ("accountId|symbol") need NO asset= in bars().
     · vendor barIds ("provider|symbol") need asset="equity|crypto|currency|commodity".

--- a/src/webui/routes/bars.spec.ts
+++ b/src/webui/routes/bars.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createBarsRoutes } from './bars.js'
 import type { EngineContext } from '../../core/types.js'
 
@@ -30,12 +30,26 @@ describe('bars routes', () => {
     expect((await res.json()).candidates).toEqual([])
   })
 
-  it('GET / by barId returns bars + meta (explicit provider)', async () => {
-    const res = await createBarsRoutes(mkCtx()).request('/?barId=yfinance|AAPL&interval=1d')
+  it('GET /search clamps the requested limit before service dispatch', async () => {
+    const searchBarSources = vi.fn(async () => [])
+    const res = await createBarsRoutes(mkCtx({ searchBarSources })).request('/search?query=AAPL&limit=999')
+
+    expect(res.status).toBe(200)
+    expect(searchBarSources).toHaveBeenCalledWith('AAPL', { limit: 100 })
+  })
+
+  it('GET / by vendor barId forwards the asset class required for routing', async () => {
+    const ctx = mkCtx()
+    const getBars = vi.spyOn(ctx.barService, 'getBars')
+    const res = await createBarsRoutes(ctx).request('/?barId=yfinance|AAPL&assetClass=equity&interval=1d')
     const body = await res.json()
     expect(body.results).toHaveLength(1)
     expect(body.meta.sourceId).toBe('yfinance')
     expect(body.meta.barId).toBe('yfinance|AAPL')
+    expect(getBars).toHaveBeenCalledWith(
+      { barId: 'yfinance|AAPL', assetClass: 'equity' },
+      { interval: '1d' },
+    )
   })
 
   it('GET / without barId or symbol → 400', async () => {

--- a/src/webui/routes/bars.ts
+++ b/src/webui/routes/bars.ts
@@ -21,7 +21,8 @@ export function createBarsRoutes(ctx: EngineContext): Hono {
   // each with source/sourceId/assetClass/label/barCapability for the picker.
   app.get('/search', async (c) => {
     const query = (c.req.query('query') ?? '').trim()
-    const limit = Number(c.req.query('limit') ?? 20)
+    const requestedLimit = Number(c.req.query('limit') ?? 20)
+    const limit = Math.max(1, Math.min(100, Number.isFinite(requestedLimit) ? Math.floor(requestedLimit) : 20))
     if (!query) return c.json({ candidates: [], count: 0 })
     const candidates = await ctx.barService.searchBarSources(query, { limit })
     return c.json({ candidates, count: candidates.length })

--- a/ui/src/components/market/KlinePanel.spec.tsx
+++ b/ui/src/components/market/KlinePanel.spec.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BarsResponse } from '../../api/market'
+import { KlinePanel } from './KlinePanel'
+
+const mocks = vi.hoisted(() => ({
+  bars: vi.fn(),
+  searchSources: vi.fn(),
+  candleSetData: vi.fn(),
+  volumeSetData: vi.fn(),
+  fitContent: vi.fn(),
+}))
+
+vi.mock('../../api/market', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/market')>()
+  return {
+    ...actual,
+    barsApi: {
+      ...actual.barsApi,
+      bars: mocks.bars,
+      searchSources: mocks.searchSources,
+    },
+  }
+})
+
+vi.mock('../../theme/useEffectiveTheme', () => ({
+  useEffectiveTheme: () => 'light',
+}))
+
+vi.mock('../../theme/semanticColors', () => ({
+  readSemanticColor: () => '#000000',
+}))
+
+vi.mock('lightweight-charts', () => ({
+  CandlestickSeries: 'CandlestickSeries',
+  HistogramSeries: 'HistogramSeries',
+  createChart: () => {
+    const timeScale = {
+      applyOptions: vi.fn(),
+      fitContent: mocks.fitContent,
+    }
+    return {
+      addSeries: (series: string) => ({
+        priceScale: () => ({ applyOptions: vi.fn() }),
+        setData: series === 'CandlestickSeries' ? mocks.candleSetData : mocks.volumeSetData,
+      }),
+      remove: vi.fn(),
+      timeScale: () => timeScale,
+    }
+  },
+}))
+
+function response(symbol: string, barId: string): BarsResponse {
+  return {
+    results: [{ date: '2026-07-17', open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 }],
+    meta: {
+      symbol,
+      from: '2026-07-17',
+      to: '2026-07-17',
+      bars: 1,
+      source: 'vendor',
+      sourceId: 'yfinance',
+      barId,
+      provider: 'yfinance',
+      barCapability: 'delayed',
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.searchSources.mockResolvedValue({ candidates: [], count: 0 })
+})
+
+afterEach(cleanup)
+
+describe('KlinePanel source routing', () => {
+  it.each([
+    { assetClass: 'currency' as const, symbol: 'EURUSD', barId: 'yfinance|EURUSD' },
+    { assetClass: 'equity' as const, symbol: '1.600519', barId: 'eastmoney|1.600519' },
+  ])('sends assetClass with an explicit vendor barId ($assetClass)', async ({ assetClass, symbol, barId }) => {
+    mocks.bars.mockResolvedValue(response(symbol, barId))
+
+    render(
+      <MemoryRouter initialEntries={[`/market/${assetClass}/${symbol}?source=${encodeURIComponent(barId)}`]}>
+        <KlinePanel selection={{ symbol, assetClass }} source={barId} />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(mocks.bars).toHaveBeenCalledWith(expect.objectContaining({
+        barId,
+        assetClass,
+        interval: '1d',
+      }))
+    })
+  })
+
+  it('loads commodity bars through the federated endpoint', async () => {
+    mocks.bars.mockResolvedValue(response('gold', 'yfinance|gold'))
+    mocks.searchSources.mockResolvedValue({
+      candidates: [
+        { barId: 'yfinance|GOLD', source: 'vendor', sourceId: 'yfinance', symbol: 'GOLD', name: 'Gold.com, Inc.', assetClass: 'equity', label: 'GOLD', barCapability: 'delayed' },
+        { barId: 'yfinance|gold', source: 'vendor', sourceId: 'yfinance', symbol: 'gold', name: 'Gold', assetClass: 'commodity', label: 'gold', barCapability: 'delayed' },
+        { barId: 'yfinance|GFI', source: 'vendor', sourceId: 'yfinance', symbol: 'GFI', name: 'Gold Fields', assetClass: 'equity', label: 'GFI', barCapability: 'delayed' },
+      ],
+      count: 3,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/market/commodity/gold?source=yfinance%7Cgold']}>
+        <KlinePanel selection={{ symbol: 'gold', assetClass: 'commodity' }} source="yfinance|gold" />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(mocks.searchSources).toHaveBeenCalledWith('gold', 12)
+      expect(mocks.bars).toHaveBeenCalledWith(expect.objectContaining({
+        barId: 'yfinance|gold',
+        assetClass: 'commodity',
+        interval: '1d',
+      }))
+      expect(mocks.candleSetData).toHaveBeenCalled()
+    })
+    expect(screen.queryByRole('combobox', { name: 'Source' })).toBeNull()
+  })
+
+  it('prefers the focused tab source when Router location still names the previous tab', async () => {
+    mocks.bars.mockResolvedValue(response('1.600519', 'eastmoney|1.600519'))
+
+    render(
+      <MemoryRouter initialEntries={['/market/commodity/gold?source=yfinance%7Cgold']}>
+        <KlinePanel
+          selection={{ symbol: '1.600519', assetClass: 'equity' }}
+          source="eastmoney|1.600519"
+        />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(mocks.bars).toHaveBeenCalledWith(expect.objectContaining({
+        barId: 'eastmoney|1.600519',
+        assetClass: 'equity',
+      }))
+    })
+    expect(mocks.bars).not.toHaveBeenCalledWith(expect.objectContaining({ barId: 'yfinance|gold' }))
+  })
+
+  it('does not inherit a stale Router source when the focused tab requests its default provider', async () => {
+    mocks.bars.mockResolvedValue(response('AAPL', 'yfinance|AAPL'))
+
+    render(
+      <MemoryRouter initialEntries={['/market/commodity/gold?source=yfinance%7Cgold']}>
+        <KlinePanel selection={{ symbol: 'AAPL', assetClass: 'equity' }} />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(mocks.bars).toHaveBeenCalledWith(expect.objectContaining({
+        symbol: 'AAPL',
+        assetClass: 'equity',
+      }))
+    })
+    expect(mocks.bars).not.toHaveBeenCalledWith(expect.objectContaining({ barId: 'yfinance|gold' }))
+  })
+})

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -59,15 +59,21 @@ function toUTCTimestamp(s: string): UTCTimestamp {
 
 interface Props {
   selection: { symbol: string; assetClass: AssetClass } | null
+  /** Explicit provider identity from the focused market tab. This cannot rely
+   * only on React Router state: tab switches project their URL with
+   * history.replaceState, which intentionally does not notify the router. */
+  source?: string
 }
 
-export function KlinePanel({ selection }: Props) {
+export function KlinePanel({ selection, source }: Props) {
   const effectiveTheme = useEffectiveTheme()
   const [searchParams, setSearchParams] = useSearchParams()
   const interval = parseInterval(searchParams.get('interval'))
   const tf = parseTimeframe(searchParams.get('range'))
-  // The provider picked at search time (a barId), if any — opens the chart on it.
-  const sourceParam = searchParams.get('source')
+  // The provider picked at search time (a barId), if any — opens the chart on
+  // it. Unlike interval/range, source comes from the focused tab spec. Router
+  // search state can be stale after history.replaceState-based tab switches.
+  const requestedBarId = source ?? null
 
   // Local setter named `selectInterval` rather than `setInterval` so it
   // doesn't shadow the global timer function we use for polling below.
@@ -92,8 +98,8 @@ export function KlinePanel({ selection }: Props) {
   const [meta, setMeta] = useState<BarMeta | null>(null)
   const [candidates, setCandidates] = useState<BarSourceCandidate[]>([])
   // null = vendor default for this symbol; a barId = an explicitly-picked source.
-  // Seed from the URL so the very first fetch is the right source (no vendor flicker).
-  const [selectedBarId, setSelectedBarId] = useState<string | null>(sourceParam)
+  // Seed from the focused tab so the first fetch is right (no vendor flicker).
+  const [selectedBarId, setSelectedBarId] = useState<string | null>(requestedBarId)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -155,36 +161,47 @@ export function KlinePanel({ selection }: Props) {
   }, [interval, effectiveTheme])
 
   // Discover the available bar sources for this symbol (populates the picker).
-  // Seed the picked source from the URL (?source=barId, set at search time);
-  // otherwise null → vendor default.
+  // Seed the picked source from the focused tab; otherwise null → vendor default.
   useEffect(() => {
-    setSelectedBarId(sourceParam)
+    setSelectedBarId(requestedBarId)
     setCandidates([])
-    if (!selection || selection.assetClass === 'commodity') return
+    if (!selection) return
     let cancelled = false
     barsApi.searchSources(selection.symbol, 12)
-      .then((r) => { if (!cancelled) setCandidates(r.candidates) })
+      .then((r) => {
+        if (cancelled) return
+        const selectedSymbol = selection.symbol.trim().toLowerCase()
+        // Federated search is intentionally fuzzy across asset classes. The
+        // chart picker is not: it may switch providers for the current asset,
+        // but must never offer similarly named instruments (e.g. GOLD stock
+        // and gold-miner equities on the commodity/gold chart).
+        setCandidates(r.candidates.filter((candidate) =>
+          candidate.symbol.trim().toLowerCase() === selectedSymbol &&
+          (candidate.assetClass === selection.assetClass || candidate.assetClass === 'unknown'),
+        ))
+      })
       .catch(() => { if (!cancelled) setCandidates([]) })
     return () => { cancelled = true }
-  }, [selection, sourceParam])
+  }, [selection, requestedBarId])
 
   // Fetch bars: an explicitly-picked source (barId) or the vendor default
   // (symbol+assetClass). Re-polls so a long-open tab doesn't show stale bars.
   useEffect(() => {
     if (!selection) { setBars(null); setMeta(null); setError(null); return }
-    if (selection.assetClass === 'commodity') {
-      setBars(null)
-      setMeta(null)
-      setError('Commodity K-line support is coming in the next step.')
-      return
-    }
     let cancelled = false
     const run = (isInitial: boolean) => {
       if (isInitial) setLoading(true)
       setError(null)
       const days = daysForTimeframe(tf)
       const params: Parameters<typeof barsApi.bars>[0] = { interval }
-      if (selectedBarId) params.barId = selectedBarId
+      // Vendor barIds share the same `{source}|{nativeSymbol}` shape as UTA
+      // aliceIds, so the server needs the selected asset class to distinguish
+      // which vendor client owns the native symbol. UTA sources safely ignore
+      // this extra routing hint.
+      if (selectedBarId) {
+        params.barId = selectedBarId
+        params.assetClass = selection.assetClass
+      }
       else { params.symbol = selection.symbol; params.assetClass = selection.assetClass }
       if (days != null) params.start = startDateFromToday(days)
 

--- a/ui/src/components/market/useAssetSearch.spec.ts
+++ b/ui/src/components/market/useAssetSearch.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import type { BarSourceCandidate } from '../../api/market'
+import { normalizeAssetSearchCandidates } from './useAssetSearch'
+
+function candidate(barId: string, symbol: string): BarSourceCandidate {
+  return {
+    barId,
+    source: barId.startsWith('yfinance|') ? 'vendor' : 'uta',
+    sourceId: barId.split('|')[0] ?? '',
+    symbol,
+    assetClass: 'equity',
+    label: symbol,
+  }
+}
+
+describe('normalizeAssetSearchCandidates', () => {
+  it('removes blank and duplicate operational identities before applying the limit', () => {
+    expect(normalizeAssetSearchCandidates([
+      candidate('ibkr|-1', ''),
+      candidate('yfinance|AAPL', 'AAPL'),
+      candidate('yfinance|AAPL', 'AAPL duplicate'),
+      candidate('', 'MSFT'),
+      candidate('yfinance|MSFT', 'MSFT'),
+      candidate('yfinance|TSLA', 'TSLA'),
+    ], 2).map((row) => row.barId)).toEqual([
+      'yfinance|AAPL',
+      'yfinance|MSFT',
+    ])
+  })
+})

--- a/ui/src/components/market/useAssetSearch.ts
+++ b/ui/src/components/market/useAssetSearch.ts
@@ -1,6 +1,24 @@
 import { useEffect, useState } from 'react'
 import { barsApi, type BarSourceCandidate } from '../../api/market'
 
+/** Defensive client boundary for older/custom backends: an unusable candidate
+ * must never render as a button that silently does nothing, and duplicate
+ * operational identities must never become duplicate React keys. */
+export function normalizeAssetSearchCandidates(
+  candidates: BarSourceCandidate[],
+  limit: number,
+): BarSourceCandidate[] {
+  const seen = new Set<string>()
+  const usable: BarSourceCandidate[] = []
+  for (const candidate of candidates) {
+    if (!candidate.symbol.trim() || !candidate.barId.trim() || seen.has(candidate.barId)) continue
+    seen.add(candidate.barId)
+    usable.push(candidate)
+    if (usable.length >= limit) break
+  }
+  return usable
+}
+
 /**
  * The single source of truth for asset search — used by BOTH the market sidebar
  * and the main search box, so their logic can't drift apart again. Debounced
@@ -20,7 +38,7 @@ export function useAssetSearch(query: string, limit = 24): { results: BarSourceC
     const timer = setTimeout(async () => {
       try {
         const res = await barsApi.searchSources(q, limit)
-        if (!cancelled) setResults(res.candidates)
+        if (!cancelled) setResults(normalizeAssetSearchCandidates(res.candidates, limit))
       } catch (e) {
         console.error('asset search failed', e)
         if (!cancelled) setResults([])

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -45,28 +45,56 @@ export const marketHandlers = [
   http.get('/api/reference/fed', () => HttpResponse.json(demoFed)),
 
   // ---- federated bars (multi-source K-lines) ----
-  // AAPL has two demo sources so the source picker is exercised.
+  // Cover the provider/asset-class combinations that have historically broken
+  // at the UI → bar-service boundary. AAPL has two sources so the picker is
+  // exercised; the other rows validate vendor-native namespaces.
   http.get('/api/bars/search', ({ request }) => {
     const q = (new URL(request.url).searchParams.get('query') ?? '').toUpperCase()
-    if (!q.includes('AAPL') && !q.includes('APPLE')) return HttpResponse.json({ candidates: [], count: 0 })
-    const candidates: BarSourceCandidate[] = [
-      { barId: 'yfinance|AAPL', source: 'vendor', sourceId: 'yfinance', symbol: 'AAPL', name: 'Apple Inc.', assetClass: 'equity', label: 'AAPL', barCapability: 'delayed' },
-      { barId: 'alpaca-paper|AAPL', source: 'uta', sourceId: 'alpaca-paper', symbol: 'AAPL', name: 'Apple Inc.', assetClass: 'equity', label: 'AAPL', barCapability: 'iex' },
-    ]
+    let candidates: BarSourceCandidate[] = []
+    if (q.includes('AAPL') || q.includes('APPLE')) {
+      candidates = [
+        { barId: 'yfinance|AAPL', source: 'vendor', sourceId: 'yfinance', symbol: 'AAPL', name: 'Apple Inc.', assetClass: 'equity', label: 'AAPL', barCapability: 'delayed' },
+        { barId: 'alpaca-paper|AAPL', source: 'uta', sourceId: 'alpaca-paper', symbol: 'AAPL', name: 'Apple Inc.', assetClass: 'equity', label: 'AAPL', barCapability: 'iex' },
+      ]
+    } else if (q.includes('EUR') || q.includes('EURO')) {
+      candidates = [
+        { barId: 'yfinance|EURUSD', source: 'vendor', sourceId: 'yfinance', symbol: 'EURUSD', name: 'Euro / U.S. Dollar', assetClass: 'currency', label: 'EURUSD', barCapability: 'delayed' },
+      ]
+    } else if (q.includes('GOLD') || q.includes('XAU') || q.includes('黄金')) {
+      candidates = [
+        { barId: 'yfinance|gold', source: 'vendor', sourceId: 'yfinance', symbol: 'gold', name: 'Gold', assetClass: 'commodity', label: 'gold', barCapability: 'delayed' },
+      ]
+    } else if (q.includes('600519') || q.includes('茅台')) {
+      candidates = [
+        { barId: 'eastmoney|1.600519', source: 'vendor', sourceId: 'eastmoney', symbol: '1.600519', name: '贵州茅台', assetClass: 'equity', label: '1.600519', barCapability: 'delayed' },
+      ]
+    }
     return HttpResponse.json({ candidates, count: candidates.length })
   }),
   http.get('/api/bars', ({ request }) => {
     const url = new URL(request.url)
     const barId = url.searchParams.get('barId')
-    const symbol = (url.searchParams.get('symbol') ?? '').toUpperCase()
-    if (!(barId?.includes('AAPL') || symbol === AAPL)) {
+    const assetClass = url.searchParams.get('assetClass')
+    const fallbackSymbol = url.searchParams.get('symbol') ?? ''
+    const knownSources: Record<string, { symbol: string; assetClass: string }> = {
+      'yfinance|AAPL': { symbol: 'AAPL', assetClass: 'equity' },
+      'alpaca-paper|AAPL': { symbol: 'AAPL', assetClass: 'equity' },
+      'yfinance|EURUSD': { symbol: 'EURUSD', assetClass: 'currency' },
+      'yfinance|gold': { symbol: 'gold', assetClass: 'commodity' },
+      'eastmoney|1.600519': { symbol: '1.600519', assetClass: 'equity' },
+    }
+    const selected = barId ? knownSources[barId] : Object.values(knownSources).find((row) => row.symbol === fallbackSymbol)
+    if (!selected) {
       return HttpResponse.json({ results: null, meta: null, error: 'No demo data for this symbol.' })
+    }
+    if (barId && !barId.startsWith('alpaca-paper|') && assetClass !== selected.assetClass) {
+      return HttpResponse.json({ results: null, meta: null, error: `Vendor barId needs assetClass=${selected.assetClass}.` })
     }
     const results = demoMarketAAPL.historical.results
     const sourceId = barId ? barId.split('|')[0] : 'yfinance'
     const meta: BarMeta = {
-      symbol: 'AAPL', from: results[0]?.date ?? '', to: results[results.length - 1]?.date ?? '', bars: results.length,
-      source: sourceId === 'alpaca-paper' ? 'uta' : 'vendor', sourceId, barId: barId ?? `${sourceId}|AAPL`,
+      symbol: selected.symbol, from: results[0]?.date ?? '', to: results[results.length - 1]?.date ?? '', bars: results.length,
+      source: sourceId === 'alpaca-paper' ? 'uta' : 'vendor', sourceId, barId: barId ?? `${sourceId}|${selected.symbol}`,
       provider: sourceId, barCapability: sourceId === 'alpaca-paper' ? 'iex' : 'delayed',
     }
     return HttpResponse.json({ results, meta })

--- a/ui/src/pages/MarketDetailPage.tsx
+++ b/ui/src/pages/MarketDetailPage.tsx
@@ -10,7 +10,7 @@ interface MarketDetailPageProps {
 }
 
 export function MarketDetailPage({ spec }: MarketDetailPageProps) {
-  const { assetClass, symbol } = spec.params
+  const { assetClass, symbol, source } = spec.params
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -22,9 +22,9 @@ export function MarketDetailPage({ spec }: MarketDetailPageProps) {
       <div className="flex-1 flex flex-col gap-3 px-4 md:px-8 py-4 min-h-0 overflow-y-auto">
         <SearchBox />
         {assetClass === 'equity' ? (
-          <EquityDetail symbol={symbol} />
+          <EquityDetail symbol={symbol} source={source} />
         ) : (
-          <GenericDetail symbol={symbol} assetClass={assetClass} />
+          <GenericDetail symbol={symbol} assetClass={assetClass} source={source} />
         )}
       </div>
     </div>

--- a/ui/src/pages/market/EquityDetail.spec.tsx
+++ b/ui/src/pages/market/EquityDetail.spec.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { EquityDetail } from './EquityDetail'
+
+vi.mock('../../components/market/QuoteHeader', () => ({ QuoteHeader: () => <div>quote-panel</div> }))
+vi.mock('../../components/market/ProfilePanel', () => ({ ProfilePanel: () => <div>profile-panel</div> }))
+vi.mock('../../components/market/KeyMetricsPanel', () => ({ KeyMetricsPanel: () => <div>metrics-panel</div> }))
+vi.mock('../../components/market/FinancialStatementsPanel', () => ({ FinancialStatementsPanel: () => <div>statements-panel</div> }))
+vi.mock('../../components/market/KlinePanel', () => ({ KlinePanel: () => <div>kline-panel</div> }))
+vi.mock('../../components/market/TradeableContractsPanel', () => ({ TradeableContractsPanel: () => <div>contracts-panel</div> }))
+
+afterEach(cleanup)
+
+describe('EquityDetail provider namespaces', () => {
+  it('keeps Eastmoney native secids on the supported K-line-only surface', () => {
+    render(<EquityDetail symbol="1.600519" source="eastmoney|1.600519" />)
+
+    expect(screen.getByText(/Eastmoney provides Chinese A-share discovery/)).toBeTruthy()
+    expect(screen.getByText('kline-panel')).toBeTruthy()
+    expect(screen.getByText('contracts-panel')).toBeTruthy()
+    expect(screen.queryByText('quote-panel')).toBeNull()
+    expect(screen.queryByText('profile-panel')).toBeNull()
+    expect(screen.queryByText('metrics-panel')).toBeNull()
+    expect(screen.queryByText('statements-panel')).toBeNull()
+  })
+
+  it('keeps quote and fundamental panels for shared ticker namespaces', () => {
+    render(<EquityDetail symbol="AAPL" source="yfinance|AAPL" />)
+
+    expect(screen.getByText('quote-panel')).toBeTruthy()
+    expect(screen.getByText('profile-panel')).toBeTruthy()
+    expect(screen.getByText('metrics-panel')).toBeTruthy()
+    expect(screen.getByText('statements-panel')).toBeTruthy()
+  })
+})

--- a/ui/src/pages/market/EquityDetail.tsx
+++ b/ui/src/pages/market/EquityDetail.tsx
@@ -7,25 +7,40 @@ import { TradeableContractsPanel } from '../../components/market/TradeableContra
 
 interface Props {
   symbol: string
+  source?: string
 }
 
-export function EquityDetail({ symbol }: Props) {
+export function EquityDetail({ symbol, source }: Props) {
+  // Eastmoney intentionally owns only Chinese-name discovery + forward-adjusted
+  // K-lines. Its native secid (`1.600519`) is not a Yahoo/FMP ticker, so feeding
+  // it into the default quote/fundamental panels produces misleading failures.
+  const klineOnly = source?.startsWith('eastmoney|') === true
+
   return (
     <div className="flex flex-col gap-3">
-      <QuoteHeader symbol={symbol} />
+      {klineOnly ? (
+        <div className="rounded-md border border-border bg-secondary/40 px-3 py-2 text-[12px] leading-relaxed text-muted-foreground">
+          Eastmoney provides Chinese A-share discovery and forward-adjusted price history for this source.
+          Quote and fundamental panels are not available in its native symbol namespace.
+        </div>
+      ) : (
+        <QuoteHeader symbol={symbol} />
+      )}
 
       <div className="h-[360px] shrink-0">
-        <KlinePanel selection={{ symbol, assetClass: 'equity' }} />
+        <KlinePanel selection={{ symbol, assetClass: 'equity' }} source={source} />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        <ProfilePanel symbol={symbol} />
-        <KeyMetricsPanel symbol={symbol} />
-      </div>
+      {!klineOnly && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <ProfilePanel symbol={symbol} />
+          <KeyMetricsPanel symbol={symbol} />
+        </div>
+      )}
 
       <TradeableContractsPanel symbol={symbol} assetClass="equity" />
 
-      <FinancialStatementsPanel symbol={symbol} />
+      {!klineOnly && <FinancialStatementsPanel symbol={symbol} />}
     </div>
   )
 }

--- a/ui/src/pages/market/GenericDetail.tsx
+++ b/ui/src/pages/market/GenericDetail.tsx
@@ -5,6 +5,7 @@ import type { AssetClass } from '../../api/market'
 interface Props {
   symbol: string
   assetClass: AssetClass
+  source?: string
 }
 
 /**
@@ -12,7 +13,7 @@ interface Props {
  * Shows just the K-line — quote/fundamentals panels are equity-shaped and
  * would be misleading if forced onto crypto/currency/commodity.
  */
-export function GenericDetail({ symbol, assetClass }: Props) {
+export function GenericDetail({ symbol, assetClass, source }: Props) {
   return (
     <div className="flex flex-col gap-3 min-h-0 flex-1">
       <div className="flex items-end gap-2 px-1">
@@ -25,7 +26,7 @@ export function GenericDetail({ symbol, assetClass }: Props) {
         </span>
       </div>
       <div className="flex-1 min-h-[420px]">
-        <KlinePanel selection={{ symbol, assetClass }} />
+        <KlinePanel selection={{ symbol, assetClass }} source={source} />
       </div>
 
       <TradeableContractsPanel symbol={symbol} assetClass={assetClass} />


### PR DESCRIPTION
## What changed

- Preserve the exact selected K-line source across Market tab switches and send `assetClass` with explicit vendor `barId` requests.
- Enable commodity K-lines through the federated bars endpoint.
- Keep the chart source picker scoped to the current symbol and asset class instead of fuzzy-search neighbors.
- Filter unusable broker candidates: no historical-bar capability, malformed/blank identities, sentinel `-1` contracts, and duplicate bar IDs.
- Apply relevance ordering and a real global search limit.
- Keep Eastmoney native A-share secids on their supported K-line-only detail surface.
- Expand demo coverage and add UI/backend regression tests for currency, commodity, A-share, tab-source, candidate, and limit behavior.

## Root cause

The Market UI carried only `barId` after a source was selected, while vendor bar routing also requires `assetClass`. Tab-to-URL synchronization uses `history.replaceState`, so reading the selected source back from React Router could also retain the previous tab's source. Separately, federated search treated every UTA contract hit as a bar source and did not enforce its requested limit.

## User impact

EURUSD, Eastmoney A-share results, and commodity results now open real price history. Invalid broker/search rows no longer render as dead controls, and native Eastmoney symbols no longer trigger unrelated yfinance quote/fundamental failures.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 331 files / 3238 tests passed
- `pnpm test:e2e` — 30 tests passed
- Real provider/API checks — EURUSD 142 bars, gold 135 bars, Eastmoney 1.600519 129 bars
- Real browser checks in isolated dev runtime — EURUSD 260 bars, gold 251 bars, Eastmoney 1.600519 242 bars; cross-tab and watchlist source transitions verified
- Demo browser walk for EURUSD, gold, and Eastmoney A-share
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
