### PR TITLE
fix(ui): make settings responsive and scrollable

### DIFF
--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -92,4 +92,29 @@ describe('PageSidebarLayout', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Select message' }))
     expect(drawer.getAttribute('data-state')).toBe('closed')
   })
+
+  it('keeps a page navigator in the drawer below its custom desktop breakpoint', () => {
+    render(
+      <PageSidebarLayout
+        storageKey="settings"
+        title="Settings"
+        desktopMinWidth={960}
+        sidebar={({ closeMobileDrawer }) => (
+          <button type="button" onClick={closeMobileDrawer}>Select General</button>
+        )}
+      >
+        <div>Settings content</div>
+      </PageSidebarLayout>,
+    )
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(min-width: 960px)')
+    const drawer = screen.getByTestId('page-sidebar-drawer')
+    expect(drawer.getAttribute('data-state')).toBe('closed')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Settings' }))
+    expect(drawer.getAttribute('data-state')).toBe('open')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select General' }))
+    expect(drawer.getAttribute('data-state')).toBe('closed')
+  })
 })

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -44,8 +44,8 @@ function responsiveMaxWidth(containerWidth: number): number {
   return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, proportional, reserveMain))
 }
 
-function useIsDesktop(): boolean {
-  const query = '(min-width: 768px)'
+function useIsDesktop(minWidth: number): boolean {
+  const query = `(min-width: ${minWidth}px)`
   const [matches, setMatches] = useState(() =>
     typeof window !== 'undefined' ? window.matchMedia(query).matches : true,
   )
@@ -56,7 +56,7 @@ function useIsDesktop(): boolean {
     setMatches(mq.matches)
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
-  }, [])
+  }, [query])
 
   return matches
 }
@@ -68,6 +68,8 @@ interface PageSidebarLayoutProps {
   sidebar: ReactNode | ((controls: PageSidebarControls) => ReactNode)
   children: ReactNode
   defaultWidth?: number
+  /** Keep a page-specific navigator in a drawer below this viewport width. */
+  desktopMinWidth?: number
 }
 
 export interface PageSidebarControls {
@@ -87,9 +89,10 @@ export function PageSidebarLayout({
   sidebar,
   children,
   defaultWidth = 260,
+  desktopMinWidth = 768,
 }: PageSidebarLayoutProps) {
   const { t } = useTranslation()
-  const isDesktop = useIsDesktop()
+  const isDesktop = useIsDesktop(desktopMinWidth)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [collapsed, setCollapsed] = useState(() => readStoredCollapsed(storageKey))

--- a/ui/src/components/SettingsCategoryList.tsx
+++ b/ui/src/components/SettingsCategoryList.tsx
@@ -21,7 +21,7 @@ const CATEGORIES = [
  * focuses) the corresponding tab. Active highlight is driven by the
  * currently-focused tab's spec, not by sidebar selection.
  */
-export function SettingsCategoryList() {
+export function SettingsCategoryList({ onSelect }: { onSelect?: () => void }) {
   const { t } = useTranslation()
   const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
@@ -37,7 +37,10 @@ export function SettingsCategoryList() {
             label={t(item.labelKey)}
             active={active}
             icon={<item.Icon size={14} strokeWidth={1.75} className="text-muted-foreground/70" aria-hidden />}
-            onClick={() => openOrFocus({ kind: 'settings', params: { category: item.category } })}
+            onClick={() => {
+              openOrFocus({ kind: 'settings', params: { category: item.category } })
+              onSelect?.()
+            }}
           />
         )
       })}

--- a/ui/src/components/form.tsx
+++ b/ui/src/components/form.tsx
@@ -3,7 +3,31 @@ import type { ReactNode } from 'react'
 // ==================== Shared class constants ====================
 
 export const inputClass =
-  'w-full px-3 py-2 bg-background text-foreground border border-border rounded-lg font-sans text-sm outline-none transition-all duration-200 focus:border-primary/60 focus:shadow-[0_0_0_1px_var(--primary-muted)]'
+  'w-full min-w-0 px-3 py-2 bg-background text-foreground border border-border rounded-lg font-sans text-sm outline-none transition-all duration-200 focus:border-primary/60 focus:shadow-[0_0_0_1px_var(--primary-muted)]'
+
+// ==================== Settings scroll area ====================
+
+interface SettingsScrollAreaProps {
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * The one vertical scroll owner for a Settings category. Settings pages live
+ * inside two nested flex shells (TabHost + PageSidebarLayout), so every level
+ * must carry `min-h-0` before overflow can work. Keeping the contract here
+ * prevents a long form from being clipped by the app-level `overflow-hidden`.
+ */
+export function SettingsScrollArea({ children, className = '' }: SettingsScrollAreaProps) {
+  return (
+    <div
+      data-settings-scroll-area
+      className={`min-h-0 flex-1 overflow-y-auto overscroll-contain [scrollbar-gutter:stable] ${className}`}
+    >
+      {children}
+    </div>
+  )
+}
 
 // ==================== Card ====================
 
@@ -47,7 +71,7 @@ export function Section({ id, title, description, children }: SectionProps) {
 
 // ==================== ConfigSection ====================
 
-/** Two-column settings layout: title + description on the left, controls on the right. */
+/** Two-column settings layout once the whole app shell has genuine room. */
 interface ConfigSectionProps {
   title: string
   description?: string
@@ -56,14 +80,14 @@ interface ConfigSectionProps {
 
 export function ConfigSection({ title, description, children }: ConfigSectionProps) {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-1 md:gap-10 py-6 border-b border-border/60 last:border-b-0">
-      <div className="mb-3 md:mb-0 md:pt-0.5">
+    <div className="grid min-w-0 grid-cols-1 gap-4 border-b border-border/60 py-6 last:border-b-0 xl:grid-cols-[240px_minmax(0,1fr)] xl:gap-10">
+      <div className="min-w-0 xl:pt-0.5">
         <h3 className="text-[14px] font-semibold text-foreground">{title}</h3>
         {description && (
           <p className="text-[13px] text-muted-foreground/70 mt-1.5 leading-relaxed">{description}</p>
         )}
       </div>
-      <div>{children}</div>
+      <div className="min-w-0">{children}</div>
     </div>
   )
 }

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -24,7 +24,7 @@ import type {
 } from '../api/config'
 import { PageHeader } from '../components/PageHeader'
 import { PageLoading, Skeleton } from '../components/StateViews'
-import { inputClass } from '../components/form'
+import { SettingsScrollArea, inputClass } from '../components/form'
 import { CredentialModal } from '../components/credentials/CredentialModal'
 import {
   AGENT_LABELS,
@@ -132,8 +132,8 @@ export function AIProviderPage() {
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader title="AI Provider" description="Provider accounts and model defaults Alice can inject into workspaces." />
-      <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6">
-        <div className="max-w-[1100px] min-w-0 mx-auto grid gap-6 lg:grid-cols-2">
+      <SettingsScrollArea className="px-4 py-6 md:px-8">
+        <div className="mx-auto grid min-w-0 max-w-[1100px] gap-6 2xl:grid-cols-2">
           {/* ============== Credentials ============== */}
           <section className="min-w-0">
             <div className="rounded-lg border border-border/50 bg-secondary/50 px-4 py-3 mb-4">
@@ -249,7 +249,7 @@ export function AIProviderPage() {
 
         {/* ============== Default workspace credentials ============== */}
         <WorkspaceDefaultsSection credentials={credentials} presets={presets} />
-      </div>
+      </SettingsScrollArea>
 
       {modal && (
         <CredentialModal

--- a/ui/src/pages/AgentPermissionsPage.tsx
+++ b/ui/src/pages/AgentPermissionsPage.tsx
@@ -8,6 +8,7 @@ import { ConfirmDialog } from '../components/ConfirmDialog'
 import { PageHeader } from '../components/PageHeader'
 import { PageLoading } from '../components/StateViews'
 import { Toggle } from '../components/Toggle'
+import { SettingsScrollArea } from '../components/form'
 import { ensureTradingModePolling, useTradingMode } from '../live/trading-mode'
 
 const MODE_META: Record<TradingMode, {
@@ -48,7 +49,7 @@ export function AgentPermissionsPage() {
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader title={t('settings.agentPermissions.title')} />
-      <div className="flex-1 overflow-y-auto">
+      <SettingsScrollArea>
         <div className="mx-auto w-full max-w-[980px] px-4 md:px-6">
           <TradingModeSection />
           <PermissionSection
@@ -58,7 +59,7 @@ export function AgentPermissionsPage() {
             <AiTradingToggle config={config} setConfig={setConfig} />
           </PermissionSection>
         </div>
-      </div>
+      </SettingsScrollArea>
     </div>
   )
 }

--- a/ui/src/pages/ConnectorsPage.tsx
+++ b/ui/src/pages/ConnectorsPage.tsx
@@ -3,7 +3,7 @@ import { Bot, CheckCircle2, CircleAlert, Link2, Power, Send, ShieldCheck } from 
 import { api, type ConnectorDefinition, type ConnectorHealth, type PublicConnectorConfig } from '../api'
 import { PageHeader } from '../components/PageHeader'
 import { SaveIndicator } from '../components/SaveIndicator'
-import { ConfigSection, Field, inputClass } from '../components/form'
+import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
 import { useAutoSave } from '../hooks/useAutoSave'
 import {
   getConnectorSetupState,
@@ -150,7 +150,7 @@ export function ConnectorsPage() {
         right={<SaveIndicator status={status} onRetry={retry} />}
       />
 
-      <div className="flex-1 overflow-y-auto px-4 md:px-8 py-5">
+      <SettingsScrollArea className="px-4 py-5 md:px-8">
         <div className="max-w-[920px] mx-auto">
           {config && (
             <>
@@ -206,7 +206,7 @@ export function ConnectorsPage() {
                                 onChange={(event) => updateSetting(definition.id, field.key, event.target.checked)}
                               />
                             ) : (
-                              <div className="flex gap-2">
+                              <div className="flex flex-col gap-2 sm:flex-row">
                                 <input
                                   className={inputClass}
                                   type={field.kind === 'secret' ? 'password' : field.kind}
@@ -277,7 +277,7 @@ export function ConnectorsPage() {
           {testError && <p className="mt-4 text-[13px] text-destructive">{testError}</p>}
           {loadError && <p className="text-[13px] text-destructive">Failed to load connector settings.</p>}
         </div>
-      </div>
+      </SettingsScrollArea>
     </div>
   )
 }

--- a/ui/src/pages/IssueSettingsPage.tsx
+++ b/ui/src/pages/IssueSettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { Bot } from 'lucide-react'
 
-import { ConfigSection, Field, inputClass } from '../components/form'
+import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
 import { PageHeader } from '../components/PageHeader'
 import { SaveIndicator } from '../components/SaveIndicator'
 import { useWorkspaces } from '../contexts/workspaces-context'
@@ -35,7 +35,7 @@ export function IssueSettingsPage() {
         title="Issue Settings"
         description="Defaults for scheduled issue runs and issue-owned headless work."
       />
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8">
+      <SettingsScrollArea className="px-4 py-6 md:px-8">
         <div className="mx-auto max-w-[880px]">
           <ConfigSection
             title="Default agent runtime"
@@ -75,7 +75,7 @@ export function IssueSettingsPage() {
             </Field>
           </ConfigSection>
         </div>
-      </div>
+      </SettingsScrollArea>
     </div>
   )
 }

--- a/ui/src/pages/MCPPage.tsx
+++ b/ui/src/pages/MCPPage.tsx
@@ -9,7 +9,7 @@
 
 import { useConfigPage } from '../hooks/useConfigPage'
 import { SaveIndicator } from '../components/SaveIndicator'
-import { ConfigSection, Field, inputClass } from '../components/form'
+import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
 import { PageHeader } from '../components/PageHeader'
 import type { AppConfig, McpConfig } from '../api'
 
@@ -27,7 +27,7 @@ export function MCPPage() {
         right={<SaveIndicator status={status} onRetry={retry} />}
       />
 
-      <div className="flex-1 overflow-y-auto px-4 md:px-8 py-5">
+      <SettingsScrollArea className="px-4 py-5 md:px-8">
         {config && (
           <div className="max-w-[880px] mx-auto">
             <ConfigSection
@@ -57,7 +57,7 @@ export function MCPPage() {
           </div>
         )}
         {loadError && <p className="text-[13px] text-destructive">Failed to load configuration.</p>}
-      </div>
+      </SettingsScrollArea>
     </div>
   )
 }

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { api, type AppConfig } from '../api'
 import { SaveIndicator } from '../components/SaveIndicator'
-import { ConfigSection, Field, inputClass } from '../components/form'
+import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
 import { Toggle } from '../components/Toggle'
 import { useConfigPage } from '../hooks/useConfigPage'
 import { PageHeader } from '../components/PageHeader'
@@ -248,7 +248,7 @@ export function MarketDataPage() {
         }
       />
 
-      <div className="flex-1 overflow-y-auto px-4 md:px-8 py-5">
+      <SettingsScrollArea className="px-4 py-5 md:px-8">
         <div className={`max-w-[880px] mx-auto ${!enabled ? 'opacity-40 pointer-events-none' : ''}`}>
           <HubCard
             hub={hub}
@@ -272,7 +272,7 @@ export function MarketDataPage() {
           />
         </div>
         {loadError && <p className="text-[13px] text-destructive mt-4 max-w-[880px] mx-auto">Failed to load configuration.</p>}
-      </div>
+      </SettingsScrollArea>
     </div>
   )
 }
@@ -546,7 +546,7 @@ function KeyProvidersSection({
                   >
                     <Field label={name} description={hint}>
                       <p className="text-[12px] text-muted-foreground/70 mb-2">{desc}</p>
-                      <div className="flex items-center gap-2">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                         <input
                           className={inputClass}
                           type="password"

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { type AppConfig, type NewsCollectorConfig, type NewsCollectorFeed } from '../api'
 import { SaveIndicator } from '../components/SaveIndicator'
-import { ConfigSection, Field, inputClass } from '../components/form'
+import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
 import { Toggle } from '../components/Toggle'
 import { useConfigPage } from '../hooks/useConfigPage'
 import { PageHeader } from '../components/PageHeader'
@@ -26,49 +26,47 @@ function CollectorSettings() {
   const enabled = cfg.enabled !== false
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-[880px] mx-auto">
-        <div className="flex items-center justify-end gap-3 mb-4">
-          <SaveIndicator status={status} onRetry={retry} />
-          <Toggle size="sm" checked={enabled} onChange={(v) => updateConfigImmediate({ enabled: v })} />
-        </div>
-
-        <div className={`${!enabled ? 'opacity-40 pointer-events-none' : ''}`}>
-          {/* Collection Settings */}
-          <ConfigSection
-            title="Collection Settings"
-            description="Control how often articles are fetched and how long they are retained in the archive."
-          >
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <Field label="Fetch interval (min)">
-                <input
-                  className={inputClass}
-                  type="number"
-                  min={1}
-                  value={cfg.intervalMinutes}
-                  onChange={(e) => updateConfig({ intervalMinutes: Number(e.target.value) || 10 })}
-                />
-              </Field>
-              <Field label="Retention (days)">
-                <input
-                  className={inputClass}
-                  type="number"
-                  min={1}
-                  value={cfg.retentionDays}
-                  onChange={(e) => updateConfig({ retentionDays: Number(e.target.value) || 7 })}
-                />
-              </Field>
-            </div>
-          </ConfigSection>
-
-          {/* RSS Feeds */}
-          <FeedsSection
-            feeds={cfg.feeds}
-            onChange={(feeds) => updateConfigImmediate({ feeds })}
-          />
-        </div>
-        {loadError && <p className="text-[13px] text-destructive mt-4">Failed to load configuration.</p>}
+    <div className="mx-auto w-full max-w-[880px]">
+      <div className="mb-4 flex items-center justify-end gap-3">
+        <SaveIndicator status={status} onRetry={retry} />
+        <Toggle size="sm" checked={enabled} onChange={(v) => updateConfigImmediate({ enabled: v })} />
       </div>
+
+      <div className={`${!enabled ? 'opacity-40 pointer-events-none' : ''}`}>
+        {/* Collection Settings */}
+        <ConfigSection
+          title="Collection Settings"
+          description="Control how often articles are fetched and how long they are retained in the archive."
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Field label="Fetch interval (min)">
+              <input
+                className={inputClass}
+                type="number"
+                min={1}
+                value={cfg.intervalMinutes}
+                onChange={(e) => updateConfig({ intervalMinutes: Number(e.target.value) || 10 })}
+              />
+            </Field>
+            <Field label="Retention (days)">
+              <input
+                className={inputClass}
+                type="number"
+                min={1}
+                value={cfg.retentionDays}
+                onChange={(e) => updateConfig({ retentionDays: Number(e.target.value) || 7 })}
+              />
+            </Field>
+          </div>
+        </ConfigSection>
+
+        {/* RSS Feeds */}
+        <FeedsSection
+          feeds={cfg.feeds}
+          onChange={(feeds) => updateConfigImmediate({ feeds })}
+        />
+      </div>
+      {loadError && <p className="mt-4 text-[13px] text-destructive">Failed to load configuration.</p>}
     </div>
   )
 }
@@ -203,9 +201,9 @@ export function NewsCollectorPage() {
         description="Configure RSS feeds and collection settings."
       />
 
-      <div className="flex-1 flex flex-col min-h-0 px-4 md:px-8 py-5">
+      <SettingsScrollArea className="px-4 py-5 md:px-8">
         <CollectorSettings />
-      </div>
+      </SettingsScrollArea>
     </div>
   )
 }

--- a/ui/src/pages/PageSidebarShell.tsx
+++ b/ui/src/pages/PageSidebarShell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { PageSidebarLayout } from '../components/PageSidebarLayout'
+import { PageSidebarLayout, type PageSidebarControls } from '../components/PageSidebarLayout'
 
 type NavTitleKey =
   | 'nav.item.tracked'
@@ -16,9 +16,10 @@ interface PageSidebarShellProps {
   storageKey: string
   titleKey: NavTitleKey
   defaultWidth: number
-  sidebar: ReactNode
+  sidebar: ReactNode | ((controls: PageSidebarControls) => ReactNode)
   actions?: ReactNode
   children: ReactNode
+  desktopMinWidth?: number
 }
 
 export function PageSidebarShell({
@@ -28,6 +29,7 @@ export function PageSidebarShell({
   sidebar,
   actions,
   children,
+  desktopMinWidth,
 }: PageSidebarShellProps) {
   const { t } = useTranslation()
   return (
@@ -37,6 +39,7 @@ export function PageSidebarShell({
       defaultWidth={defaultWidth}
       actions={actions}
       sidebar={sidebar}
+      desktopMinWidth={desktopMinWidth}
     >
       {children}
     </PageSidebarLayout>

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -3,7 +3,7 @@ import { api, type AppConfig } from '../api'
 import type { ToolInfo } from '../api/tools'
 import { Toggle } from '../components/Toggle'
 import { SaveIndicator } from '../components/SaveIndicator'
-import { ConfigSection, Field, inputClass } from '../components/form'
+import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
 import { useAutoSave } from '../hooks/useAutoSave'
 import { PageHeader } from '../components/PageHeader'
 import { PageLoading, EmptyState } from '../components/StateViews'
@@ -57,7 +57,7 @@ function AppearanceSection() {
         </div>
       </div>
 
-      <div className="grid gap-5 border-b border-border/60 py-5 lg:grid-cols-2">
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,20rem),1fr))] gap-5 border-b border-border/60 py-5">
         <PalettePicker
           title={t('settings.appearance.dayPalette')}
           description={t('settings.appearance.dayPaletteDescription')}
@@ -109,7 +109,7 @@ function PalettePicker<T extends ThemePaletteId>({
     <div>
       <span className="text-sm font-medium text-foreground">{title}</span>
       <p className="mt-0.5 text-[12px] leading-relaxed text-muted-foreground">{description}</p>
-      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+      <div className="mt-3 grid grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-2">
         {palettes.map((palette) => (
           <button
             key={palette.id}
@@ -125,7 +125,7 @@ function PalettePicker<T extends ThemePaletteId>({
           >
             <span className="flex items-start justify-between gap-2">
               <span className="min-w-0">
-                <span className="block truncate text-[12px] font-semibold">{t(palette.labelKey)}</span>
+                <span className="block break-words text-[12px] font-semibold">{t(palette.labelKey)}</span>
                 <span className="mt-0.5 block text-[10px] leading-snug text-muted-foreground">
                   {t(palette.descriptionKey)}
                 </span>
@@ -171,7 +171,7 @@ function LanguageSection() {
   const setLocale = useSetLocale()
   return (
     <ConfigSection title={t('settings.language.title')} description={t('settings.language.description')}>
-      <div className="flex gap-2 py-1">
+      <div className="flex flex-wrap gap-2 py-1">
         {(['en', 'zh', 'ja', 'zh-Hant'] as const).map((l) => (
           <button
             key={l}
@@ -470,30 +470,28 @@ function SettingsSection() {
   if (!config) return <PageLoading />
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-[880px] mx-auto">
-        {/* Appearance */}
-        <AppearanceSection />
+    <div className="mx-auto w-full max-w-[1100px]">
+      {/* Appearance */}
+      <AppearanceSection />
 
-        {/* Language */}
-        <LanguageSection />
+      {/* Language */}
+      <LanguageSection />
 
-        {/* Complete OpenAlice home + runtime lock boundary */}
-        <DataHomeSection />
+      {/* Complete OpenAlice home + runtime lock boundary */}
+      <DataHomeSection />
 
-        {/* Windows-only workspace shell */}
-        <WorkspaceShellSection />
+      {/* Windows-only workspace shell */}
+      <WorkspaceShellSection />
 
-        {/* Persona */}
-        <ConfigSection title={t('settings.persona.title')} description={t('settings.persona.description')}>
-          <PersonaEditor />
-        </ConfigSection>
+      {/* Persona */}
+      <ConfigSection title={t('settings.persona.title')} description={t('settings.persona.description')}>
+        <PersonaEditor />
+      </ConfigSection>
 
-        {/* Compaction */}
-        <ConfigSection title={t('settings.compaction.title')} description={t('settings.compaction.description')}>
-          <CompactionForm config={config} />
-        </ConfigSection>
-      </div>
+      {/* Compaction */}
+      <ConfigSection title={t('settings.compaction.title')} description={t('settings.compaction.description')}>
+        <CompactionForm config={config} />
+      </ConfigSection>
     </div>
   )
 }
@@ -695,13 +693,13 @@ function ToolsSection() {
   }, [])
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="mx-auto w-full max-w-[1100px]">
       {!loaded ? (
         <PageLoading />
       ) : groups.length === 0 ? (
         <EmptyState title={t('settings.tools.emptyTitle')} description={t('settings.tools.emptyDescription')} />
       ) : (
-        <div className="max-w-[880px] mx-auto">
+        <div>
           <div className="flex items-center justify-between mb-4">
             <p className="text-[13px] text-muted-foreground">
               {t('settings.tools.summary', { tools: inventory.length, groups: groups.length })}
@@ -853,11 +851,9 @@ export function SettingsPage() {
         </div>
       </div>
 
-      <div className="flex-1 flex flex-col min-h-0 px-4 md:px-8 py-6">
-        <div className="flex-1 min-h-0">
-          {tab === 'settings' ? <SettingsSection /> : <ToolsSection />}
-        </div>
-      </div>
+      <SettingsScrollArea className="px-4 py-6 md:px-8">
+        {tab === 'settings' ? <SettingsSection /> : <ToolsSection />}
+      </SettingsScrollArea>
     </div>
   )
 }

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { AlertTriangle } from 'lucide-react'
-import { inputClass } from '../components/form'
+import { SettingsScrollArea, inputClass } from '../components/form'
 import { Skeleton } from '../components/StateViews'
 import { Toggle } from '../components/Toggle'
 import { useTradingConfig } from '../hooks/useTradingConfig'
@@ -187,14 +187,14 @@ export function KeylessDataSourcesRow({ ccxtPack, onPackInstalled }: {
 
   return (
     <div className="px-4 py-3 border border-border rounded-lg">
-      <div className="flex items-start justify-between gap-3">
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-between">
         <div className="min-w-0">
           <div className="text-[12px] font-medium text-foreground">Public crypto data sources</div>
           <div className="text-[11px] text-muted-foreground leading-relaxed mt-0.5">
             Optional keyless K-line feeds. Disabled by default; enabled sources appear as read-only broker-style bar IDs.
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
           {msg && <span className="text-[11px] text-muted-foreground">{msg}</span>}
           {ccxtPack && !ccxtPack.installed && (
             <button className="btn-secondary" disabled={installing} onClick={() => { void install() }}>
@@ -203,7 +203,7 @@ export function KeylessDataSourcesRow({ ccxtPack, onPackInstalled }: {
           )}
         </div>
       </div>
-      <div className="mt-3 grid gap-2 sm:grid-cols-3">
+      <div className="mt-3 grid grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-2">
         {KEYLESS_DATA_SOURCE_OPTIONS.map((source) => {
           const checked = runtimeConfig.keylessDataSources.includes(source.id)
           return (
@@ -405,7 +405,7 @@ export function TradingPage() {
         live={tc.utas.length > 0 ? { lastUpdated } : undefined}
       />
 
-      <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">
+      <SettingsScrollArea className="px-4 py-5 md:px-6">
         <div className="max-w-[820px] mx-auto space-y-4">
           {serviceStatus?.available === false && <TradingServiceOfflineBanner status={serviceStatus} />}
           <MissingBrokerPacksNotice packs={brokerPacks} onInstalled={updateBrokerPack} />
@@ -441,7 +441,7 @@ export function TradingPage() {
           />
           {tc.utas.length > 0 && <ExternalOrderMonitoringRow />}
         </div>
-      </div>
+      </SettingsScrollArea>
 
       {showAdd && (
         <CreateUTADialog
@@ -493,7 +493,7 @@ function PageShell({ subtitle, children }: { subtitle: string; children?: React.
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader title="Trading" description={subtitle} />
-      <div className="flex-1 overflow-y-auto px-4 md:px-6 py-5">{children}</div>
+      <SettingsScrollArea className="px-4 py-5 md:px-6">{children}</SettingsScrollArea>
     </div>
   )
 }
@@ -517,7 +517,7 @@ function TradingServiceOfflineBanner({ status }: { status: TradingServiceStatus 
 
 function EmptyState({ onAdd }: { onAdd: () => void }) {
   return (
-    <div className="rounded-xl border border-dashed border-border p-12 text-center">
+    <div className="rounded-xl border border-dashed border-border p-6 text-center sm:p-12">
       <h3 className="text-[16px] font-semibold text-foreground mb-2">No UTAs configured</h3>
       <p className="text-[13px] text-muted-foreground mb-6 max-w-[320px] mx-auto leading-relaxed">
         Connect a crypto exchange or brokerage to start automated trading.

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -292,7 +292,8 @@ const settingsModule: ViewModule<'settings'> = {
       storageKey="settings"
       titleKey="nav.item.settings"
       defaultWidth={220}
-      sidebar={<SettingsCategoryList />}
+      desktopMinWidth={960}
+      sidebar={({ closeMobileDrawer }) => <SettingsCategoryList onSelect={closeMobileDrawer} />}
     >
       <SettingsRouter {...props} />
     </PageSidebarShell>


### PR DESCRIPTION
## What changed

- give every Settings category one height-constrained vertical scroll owner
- keep the Settings category navigator in a drawer below 960px and close it after navigation
- delay two-column configuration layouts until the content pane has enough room
- make palette cards, provider forms, connector inputs, trading sources, and market-data credentials adapt to narrow panes

## Root cause

The General page nested `overflow-y-auto` inside a non-flex wrapper, so the app-level `overflow-hidden` clipped the form instead of giving it a scrollable height. Responsive grids also keyed off the full viewport width even though the Activity Bar and Settings navigator had already consumed much of that width.

## User impact

Settings now scrolls to the final fields in browser and Electron. At tablet/narrow desktop widths the category navigator becomes a drawer and forms stack instead of squeezing controls into a small right column.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (331 files passed, 1 skipped; 3244 tests passed, 8 skipped)
- browser demo audit of all 9 Settings categories: one scroll owner per page, no horizontal overflow; General scrolled to `Max Output Tokens`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`