### PR TITLE
fix(ui): distinguish palette previews

### DIFF
--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -115,46 +115,52 @@ function PalettePicker<T extends ThemePaletteId>({
             key={palette.id}
             type="button"
             data-palette-preview={palette.id}
+            data-selected={selected === palette.id}
             onClick={() => onSelect(palette.id)}
             aria-pressed={selected === palette.id}
-            className={`min-w-0 rounded-lg border bg-background p-3 text-left text-foreground shadow-sm transition-all ${
-              selected === palette.id
-                ? 'border-primary ring-2 ring-primary/25'
-                : 'border-border hover:border-primary/60'
-            }`}
+            className="oa-palette-preview min-w-0 rounded-lg border p-3 text-left shadow-sm transition-all"
           >
             <span className="flex items-start justify-between gap-2">
               <span className="min-w-0">
                 <span className="block break-words text-[12px] font-semibold">{t(palette.labelKey)}</span>
-                <span className="mt-0.5 block text-[10px] leading-snug text-muted-foreground">
+                <span className="oa-palette-preview-muted mt-0.5 block text-[10px] leading-snug">
                   {t(palette.descriptionKey)}
                 </span>
               </span>
-              <span
-                className={`mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full border ${
-                  selected === palette.id ? 'border-primary bg-primary' : 'border-border bg-muted'
-                }`}
-                aria-hidden
-              />
+              <span className="oa-palette-preview-indicator mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full border" aria-hidden />
             </span>
-            <span className="mt-3 flex items-center gap-1.5" aria-hidden>
-              <span className="h-4 flex-1 rounded-sm bg-primary" />
-              <span className="h-4 flex-1 rounded-sm bg-success" />
-              <span className="h-4 flex-1 rounded-sm bg-warning" />
-              <span className="h-4 flex-1 rounded-sm bg-destructive" />
+
+            <span className="oa-palette-preview-shell mt-3 flex h-9 overflow-hidden rounded border" aria-hidden>
+              <span className="oa-palette-preview-sidebar flex w-5 shrink-0 items-center justify-center border-r">
+                <span className="oa-palette-preview-sidebar-dot h-1.5 w-1.5 rounded-full" />
+              </span>
+              <span className="oa-palette-preview-canvas flex min-w-0 flex-1 flex-col justify-center gap-1.5 px-2">
+                <span className="oa-palette-preview-primary-line h-1.5 w-1/2 rounded-full" />
+                <span className="flex gap-1">
+                  <span className="oa-palette-preview-muted-line h-1 flex-1 rounded-full" />
+                  <span className="oa-palette-preview-muted-line h-1 w-1/4 rounded-full" />
+                </span>
+              </span>
+            </span>
+
+            <span className="mt-2 flex items-center gap-1.5" aria-hidden>
+              <span className="h-3 flex-1 rounded-sm" style={{ background: 'var(--primary)' }} />
+              <span className="h-3 flex-1 rounded-sm" style={{ background: 'var(--success)' }} />
+              <span className="h-3 flex-1 rounded-sm" style={{ background: 'var(--warning)' }} />
+              <span className="h-3 flex-1 rounded-sm" style={{ background: 'var(--destructive)' }} />
+              <span className="h-3 flex-1 rounded-sm" style={{ background: 'var(--ai-action)' }} />
             </span>
             <span
-              className="mt-2 flex h-5 items-center gap-1 rounded border border-border px-1.5"
-              style={{ background: 'var(--terminal-background)', color: 'var(--terminal-foreground)' }}
+              className="oa-palette-preview-terminal mt-2 flex h-5 items-center gap-1 rounded border px-1.5"
               aria-hidden
             >
               <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--terminal-red)' }} />
               <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--terminal-yellow)' }} />
               <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--terminal-green)' }} />
-              <span
-                className="ml-1 h-px flex-1"
-                style={{ background: 'color-mix(in srgb, var(--terminal-foreground) 35%, transparent)' }}
-              />
+              <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--terminal-cyan)' }} />
+              <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--terminal-blue)' }} />
+              <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--terminal-magenta)' }} />
+              <span className="oa-palette-preview-terminal-line ml-1 h-px flex-1" />
             </span>
           </button>
         ))}

--- a/ui/src/theme/palette.css
+++ b/ui/src/theme/palette.css
@@ -375,3 +375,71 @@
     transparent 38rem
   );
 }
+
+/* Palette cards are miniature, isolated product surfaces. Keep their chrome
+ * bound directly to the preview card's variables so the active app palette
+ * cannot make all four choices look alike. */
+[data-palette-preview] {
+  background: var(--background);
+  color: var(--foreground);
+  border-color: var(--border);
+}
+
+[data-palette-preview]:hover {
+  border-color: color-mix(in srgb, var(--primary) 60%, var(--border));
+}
+
+[data-palette-preview][data-selected="true"] {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 25%, transparent);
+}
+
+[data-palette-preview] .oa-palette-preview-muted {
+  color: var(--muted-foreground);
+}
+
+[data-palette-preview] .oa-palette-preview-indicator {
+  background: var(--muted);
+  border-color: var(--border);
+}
+
+[data-palette-preview][data-selected="true"] .oa-palette-preview-indicator {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+[data-palette-preview] .oa-palette-preview-shell,
+[data-palette-preview] .oa-palette-preview-terminal {
+  border-color: var(--border);
+}
+
+[data-palette-preview] .oa-palette-preview-shell {
+  background: var(--card);
+}
+
+[data-palette-preview] .oa-palette-preview-sidebar {
+  background: var(--sidebar);
+  border-color: var(--sidebar-border);
+}
+
+[data-palette-preview] .oa-palette-preview-sidebar-dot,
+[data-palette-preview] .oa-palette-preview-primary-line {
+  background: var(--primary);
+}
+
+[data-palette-preview] .oa-palette-preview-canvas {
+  background: var(--background);
+}
+
+[data-palette-preview] .oa-palette-preview-muted-line {
+  background: var(--muted);
+}
+
+[data-palette-preview] .oa-palette-preview-terminal {
+  background: var(--terminal-background);
+  color: var(--terminal-foreground);
+}
+
+[data-palette-preview] .oa-palette-preview-terminal-line {
+  background: color-mix(in srgb, var(--terminal-foreground) 35%, transparent);
+}

--- a/ui/src/theme/semanticColors.spec.ts
+++ b/ui/src/theme/semanticColors.spec.ts
@@ -76,6 +76,12 @@ function paletteBlock(id: ThemePaletteId): string {
   return block!
 }
 
+function paletteToken(id: ThemePaletteId, token: string): string {
+  const value = paletteBlock(id).match(new RegExp(`--${token}:\\s*([^;]+);`))?.[1]?.trim()
+  expect(value, `${id}: --${token}`).toBeDefined()
+  return value!
+}
+
 describe('semantic color contract', () => {
   it('ships two complete light cards and two complete dark cards', () => {
     expect(LIGHT_PALETTES.map(({ id }) => id)).toEqual(['paper', 'porcelain'])
@@ -100,6 +106,29 @@ describe('semantic color contract', () => {
       const cardTokens = [...paletteBlock(id).matchAll(/^\s*(--[\w-]+):/gm)].map((match) => match[1])
       expect(cardTokens.sort(), id).toEqual([...tokens].sort())
     }
+  })
+
+  it('keeps the four visible palette preview signatures distinct', () => {
+    const previewTokens = [
+      'background',
+      'secondary',
+      'primary',
+      'success',
+      'warning',
+      'destructive',
+      'ai-action',
+      'terminal-background',
+      'terminal-red',
+      'terminal-green',
+      'terminal-blue',
+      'terminal-magenta',
+      'terminal-cyan',
+    ]
+    const signatures = PALETTE_IDS.map((id) => previewTokens.map((token) => paletteToken(id, token)).join('|'))
+
+    expect(new Set(signatures).size).toBe(PALETTE_IDS.length)
+    expect(palette).toContain('[data-palette-preview][data-selected="true"]')
+    expect(palette).toContain('.oa-palette-preview-terminal')
   })
 
   it('resolves auto, day, and night modes through one palette selector', () => {


### PR DESCRIPTION
## What changed

- bind palette-card chrome directly to each preview card's semantic variables
- preview each palette as a miniature product surface with sidebar, canvas, primary/muted treatments, product-state colors, AI action color, and six terminal ANSI colors
- keep selected and hover states scoped to the previewed palette
- add a color-contract test that requires all four visible preview signatures to stay distinct

## Root cause

The old preview emphasized the same four semantic roles—primary, success, warning, and destructive—whose hue families intentionally remain consistent across palettes. In a stale/HMR state the card chrome could also visually inherit the active app palette, making all four choices appear identical.

## User impact

Paper now reads as warm light, Porcelain as cool light, Graphite as neutral black, and Midnight as deep blue-black regardless of the currently active color mode. The terminal palette differences are visible before selection.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (331 files passed, 1 skipped; 3245 tests passed, 8 skipped)
- browser verification in both Light and Dark modes: four isolated computed backgrounds/primary values and no horizontal overflow