### PR TITLE
feat(market): add FX analysis workbench

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,6 +530,9 @@ importers:
       '@xterm/xterm':
         specifier: 6.1.0-beta.287
         version: 6.1.0-beta.287(patch_hash=9c1de9931d86864923ff53bc9d64474a86478085ac81ea4e432648c7e23d702c)
+      decimal.js:
+        specifier: ^10.6.0
+        version: 10.6.0
       dompurify:
         specifier: ^3.4.0
         version: 3.4.1

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "@xterm/addon-web-links": "0.13.0-beta.287",
     "@xterm/addon-webgl": "0.20.0-beta.286",
     "@xterm/xterm": "6.1.0-beta.287",
+    "decimal.js": "^10.6.0",
     "dompurify": "^3.4.0",
     "highlight.js": "^11.11.1",
     "i18next": "^26.3.1",

--- a/ui/src/components/market/KlinePanel.spec.tsx
+++ b/ui/src/components/market/KlinePanel.spec.tsx
@@ -168,4 +168,39 @@ describe('KlinePanel source routing', () => {
     })
     expect(mocks.bars).not.toHaveBeenCalledWith(expect.objectContaining({ barId: 'yfinance|gold' }))
   })
+
+  it('publishes the displayed bars to a sibling analysis panel without another request', async () => {
+    const onSnapshot = vi.fn()
+    mocks.bars.mockResolvedValue(response('EURUSD', 'yfinance|EURUSD'))
+
+    const view = render(
+      <MemoryRouter initialEntries={['/market/currency/EURUSD']}>
+        <KlinePanel
+          selection={{ symbol: 'EURUSD', assetClass: 'currency' }}
+          source="yfinance|EURUSD"
+          onSnapshot={onSnapshot}
+        />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(onSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+        bars: expect.arrayContaining([expect.objectContaining({ close: 1.5 })]),
+        meta: expect.objectContaining({ barId: 'yfinance|EURUSD' }),
+      }))
+    })
+    // CurrencyDetail mirrors snapshots into parent state. That parent render
+    // recreates the selection object; primitive effect dependencies must keep
+    // it from becoming a request loop.
+    view.rerender(
+      <MemoryRouter initialEntries={['/market/currency/EURUSD']}>
+        <KlinePanel
+          selection={{ symbol: 'EURUSD', assetClass: 'currency' }}
+          source="yfinance|EURUSD"
+          onSnapshot={onSnapshot}
+        />
+      </MemoryRouter>,
+    )
+    expect(mocks.bars).toHaveBeenCalledTimes(1)
+  })
 })

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -15,25 +15,25 @@ import { readSemanticColor } from '../../theme/semanticColors'
 import { useEffectivePalette, useEffectiveTheme } from '../../theme/useEffectiveTheme'
 import { Skeleton } from '../StateViews'
 
-type Interval = '1m' | '5m' | '1h' | '1d'
-type Timeframe = '1D' | '5D' | '1M' | '3M' | '1Y' | '5Y' | 'All'
+export type KlineInterval = '1m' | '5m' | '1h' | '1d'
+export type KlineTimeframe = '1D' | '5D' | '1M' | '3M' | '1Y' | '5Y' | 'All'
 
-const INTERVALS: Interval[] = ['1m', '5m', '1h', '1d']
-const TIMEFRAMES: Timeframe[] = ['1D', '5D', '1M', '3M', '1Y', '5Y', 'All']
-const DEFAULT_INTERVAL: Interval = '1d'
-const DEFAULT_RANGE: Timeframe = '1Y'
+const INTERVALS: KlineInterval[] = ['1m', '5m', '1h', '1d']
+const TIMEFRAMES: KlineTimeframe[] = ['1D', '5D', '1M', '3M', '1Y', '5Y', 'All']
+const DEFAULT_INTERVAL: KlineInterval = '1d'
+const DEFAULT_RANGE: KlineTimeframe = '1Y'
 
-function parseInterval(s: string | null): Interval {
-  return (INTERVALS as string[]).includes(s ?? '') ? (s as Interval) : DEFAULT_INTERVAL
+function parseInterval(s: string | null): KlineInterval {
+  return (INTERVALS as string[]).includes(s ?? '') ? (s as KlineInterval) : DEFAULT_INTERVAL
 }
 
-function parseTimeframe(s: string | null): Timeframe {
-  return (TIMEFRAMES as string[]).includes(s ?? '') ? (s as Timeframe) : DEFAULT_RANGE
+function parseTimeframe(s: string | null): KlineTimeframe {
+  return (TIMEFRAMES as string[]).includes(s ?? '') ? (s as KlineTimeframe) : DEFAULT_RANGE
 }
 
-const INTRADAY: ReadonlySet<Interval> = new Set(['1m', '5m', '1h'])
+const INTRADAY: ReadonlySet<KlineInterval> = new Set(['1m', '5m', '1h'])
 
-function daysForTimeframe(tf: Timeframe): number | null {
+function daysForTimeframe(tf: KlineTimeframe): number | null {
   switch (tf) {
     case '1D': return 1
     case '5D': return 5
@@ -57,15 +57,27 @@ function toUTCTimestamp(s: string): UTCTimestamp {
   return Math.floor(new Date(iso).getTime() / 1000) as UTCTimestamp
 }
 
+export interface KlineSnapshot {
+  bars: HistoricalBar[] | null
+  meta: BarMeta | null
+  loading: boolean
+  error: string | null
+  interval: KlineInterval
+  timeframe: KlineTimeframe
+}
+
 interface Props {
   selection: { symbol: string; assetClass: AssetClass } | null
   /** Explicit provider identity from the focused market tab. This cannot rely
    * only on React Router state: tab switches project their URL with
    * history.replaceState, which intentionally does not notify the router. */
   source?: string
+  /** Read-only mirror of the displayed series for sibling analysis panels.
+   *  This avoids a second bar request on bespoke detail pages. */
+  onSnapshot?: (snapshot: KlineSnapshot) => void
 }
 
-export function KlinePanel({ selection, source }: Props) {
+export function KlinePanel({ selection, source, onSnapshot }: Props) {
   const effectiveTheme = useEffectiveTheme()
   const effectivePalette = useEffectivePalette()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -75,10 +87,12 @@ export function KlinePanel({ selection, source }: Props) {
   // it. Unlike interval/range, source comes from the focused tab spec. Router
   // search state can be stale after history.replaceState-based tab switches.
   const requestedBarId = source ?? null
+  const selectionSymbol = selection?.symbol ?? null
+  const selectionAssetClass = selection?.assetClass ?? null
 
   // Local setter named `selectInterval` rather than `setInterval` so it
   // doesn't shadow the global timer function we use for polling below.
-  const selectInterval = (iv: Interval) => {
+  const selectInterval = (iv: KlineInterval) => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev)
       if (iv === DEFAULT_INTERVAL) next.delete('interval')
@@ -86,7 +100,7 @@ export function KlinePanel({ selection, source }: Props) {
       return next
     }, { replace: true })
   }
-  const setTf = (t: Timeframe) => {
+  const setTf = (t: KlineTimeframe) => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev)
       if (t === DEFAULT_RANGE) next.delete('range')
@@ -104,10 +118,23 @@ export function KlinePanel({ selection, source }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  useEffect(() => {
+    onSnapshot?.({ bars, meta, loading, error, interval, timeframe: tf })
+  }, [bars, meta, loading, error, interval, tf, onSnapshot])
+
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
   const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
   const volumeRef = useRef<ISeriesApi<'Histogram'> | null>(null)
+
+  // A focused market tab can change identity without remounting this panel.
+  // Never let the previous pair's last close leak into sibling analytics while
+  // the new source is loading.
+  useEffect(() => {
+    setBars(null)
+    setMeta(null)
+    setError(null)
+  }, [selectionSymbol, selectionAssetClass, requestedBarId])
 
   // Canvas renderers cannot resolve CSS variables themselves. Rebuild on a
   // concrete theme change and read the same semantic card used by DOM/SVG UI.
@@ -166,29 +193,29 @@ export function KlinePanel({ selection, source }: Props) {
   useEffect(() => {
     setSelectedBarId(requestedBarId)
     setCandidates([])
-    if (!selection) return
+    if (!selectionSymbol || !selectionAssetClass) return
     let cancelled = false
-    barsApi.searchSources(selection.symbol, 12)
+    barsApi.searchSources(selectionSymbol, 12)
       .then((r) => {
         if (cancelled) return
-        const selectedSymbol = selection.symbol.trim().toLowerCase()
+        const selectedSymbol = selectionSymbol.trim().toLowerCase()
         // Federated search is intentionally fuzzy across asset classes. The
         // chart picker is not: it may switch providers for the current asset,
         // but must never offer similarly named instruments (e.g. GOLD stock
         // and gold-miner equities on the commodity/gold chart).
         setCandidates(r.candidates.filter((candidate) =>
           candidate.symbol.trim().toLowerCase() === selectedSymbol &&
-          (candidate.assetClass === selection.assetClass || candidate.assetClass === 'unknown'),
+          (candidate.assetClass === selectionAssetClass || candidate.assetClass === 'unknown'),
         ))
       })
       .catch(() => { if (!cancelled) setCandidates([]) })
     return () => { cancelled = true }
-  }, [selection, requestedBarId])
+  }, [selectionSymbol, selectionAssetClass, requestedBarId])
 
   // Fetch bars: an explicitly-picked source (barId) or the vendor default
   // (symbol+assetClass). Re-polls so a long-open tab doesn't show stale bars.
   useEffect(() => {
-    if (!selection) { setBars(null); setMeta(null); setError(null); return }
+    if (!selectionSymbol || !selectionAssetClass) { setBars(null); setMeta(null); setError(null); return }
     let cancelled = false
     const run = (isInitial: boolean) => {
       if (isInitial) setLoading(true)
@@ -201,9 +228,9 @@ export function KlinePanel({ selection, source }: Props) {
       // this extra routing hint.
       if (selectedBarId) {
         params.barId = selectedBarId
-        params.assetClass = selection.assetClass
+        params.assetClass = selectionAssetClass
       }
-      else { params.symbol = selection.symbol; params.assetClass = selection.assetClass }
+      else { params.symbol = selectionSymbol; params.assetClass = selectionAssetClass }
       if (days != null) params.start = startDateFromToday(days)
 
       barsApi.bars(params)
@@ -229,7 +256,7 @@ export function KlinePanel({ selection, source }: Props) {
     const pollMs = INTRADAY.has(interval) ? 60_000 : 300_000
     const timer = setInterval(() => run(false), pollMs)
     return () => { cancelled = true; clearInterval(timer) }
-  }, [selection, selectedBarId, interval, tf])
+  }, [selectionSymbol, selectionAssetClass, selectedBarId, interval, tf])
 
   // Push bars into chart and fit.
   useEffect(() => {
@@ -260,9 +287,9 @@ export function KlinePanel({ selection, source }: Props) {
   }, [bars, effectiveTheme, effectivePalette])
 
   const title = useMemo(() => {
-    if (!selection) return 'Select a symbol'
-    return `${selection.symbol} · ${selection.assetClass}`
-  }, [selection])
+    if (!selectionSymbol || !selectionAssetClass) return 'Select a symbol'
+    return `${selectionSymbol} · ${selectionAssetClass}`
+  }, [selectionSymbol, selectionAssetClass])
 
   // Source options for the picker — always include the currently-shown provider
   // (even if it wasn't in the search results), so the dropdown reflects reality.

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -9,6 +9,12 @@ import type { BarSourceCandidate, BarMeta } from '../../api/market'
 import type { MoversBoard, MoverRow, CalendarBoard, MacroBoard, MacroSeriesCard, TermStructureBoard, ValuationStrip, GlobalMacroBoard, ShippingBoard, FedBoard } from '../../api/reference'
 
 const AAPL = 'AAPL'
+const DEMO_FX: Record<string, { name: string; spot: number; aliases: string[] }> = {
+  EURUSD: { name: 'Euro / U.S. Dollar', spot: 1.0842, aliases: ['EUR', 'EURO'] },
+  USDJPY: { name: 'U.S. Dollar / Japanese Yen', spot: 157.35, aliases: ['JPY', 'YEN'] },
+  GBPUSD: { name: 'British Pound / U.S. Dollar', spot: 1.2915, aliases: ['GBP', 'POUND', 'STERLING'] },
+  USDCNH: { name: 'U.S. Dollar / Offshore Renminbi', spot: 7.185, aliases: ['CNH', 'RMB', 'RENMINBI', 'YUAN'] },
+}
 
 function symbolFromUrl(url: string): string {
   return (new URL(url).searchParams.get('symbol') ?? '').toUpperCase()
@@ -56,10 +62,19 @@ export const marketHandlers = [
         { barId: 'yfinance|AAPL', source: 'vendor', sourceId: 'yfinance', symbol: 'AAPL', name: 'Apple Inc.', assetClass: 'equity', label: 'AAPL', barCapability: 'delayed' },
         { barId: 'alpaca-paper|AAPL', source: 'uta', sourceId: 'alpaca-paper', symbol: 'AAPL', name: 'Apple Inc.', assetClass: 'equity', label: 'AAPL', barCapability: 'iex' },
       ]
-    } else if (q.includes('EUR') || q.includes('EURO')) {
-      candidates = [
-        { barId: 'yfinance|EURUSD', source: 'vendor', sourceId: 'yfinance', symbol: 'EURUSD', name: 'Euro / U.S. Dollar', assetClass: 'currency', label: 'EURUSD', barCapability: 'delayed' },
-      ]
+    } else if (Object.entries(DEMO_FX).some(([symbol, fx]) => q.includes(symbol) || fx.aliases.some((alias) => q.includes(alias)))) {
+      candidates = Object.entries(DEMO_FX)
+        .filter(([symbol, fx]) => q.includes(symbol) || fx.aliases.some((alias) => q.includes(alias)))
+        .map(([symbol, fx]) => ({
+          barId: `yfinance|${symbol}`,
+          source: 'vendor' as const,
+          sourceId: 'yfinance',
+          symbol,
+          name: fx.name,
+          assetClass: 'currency' as const,
+          label: symbol,
+          barCapability: 'delayed' as const,
+        }))
     } else if (q.includes('GOLD') || q.includes('XAU') || q.includes('黄金')) {
       candidates = [
         { barId: 'yfinance|gold', source: 'vendor', sourceId: 'yfinance', symbol: 'gold', name: 'Gold', assetClass: 'commodity', label: 'gold', barCapability: 'delayed' },
@@ -79,7 +94,7 @@ export const marketHandlers = [
     const knownSources: Record<string, { symbol: string; assetClass: string }> = {
       'yfinance|AAPL': { symbol: 'AAPL', assetClass: 'equity' },
       'alpaca-paper|AAPL': { symbol: 'AAPL', assetClass: 'equity' },
-      'yfinance|EURUSD': { symbol: 'EURUSD', assetClass: 'currency' },
+      ...Object.fromEntries(Object.keys(DEMO_FX).map((symbol) => [`yfinance|${symbol}`, { symbol, assetClass: 'currency' }])),
       'yfinance|gold': { symbol: 'gold', assetClass: 'commodity' },
       'eastmoney|1.600519': { symbol: '1.600519', assetClass: 'equity' },
     }
@@ -90,7 +105,32 @@ export const marketHandlers = [
     if (barId && !barId.startsWith('alpaca-paper|') && assetClass !== selected.assetClass) {
       return HttpResponse.json({ results: null, meta: null, error: `Vendor barId needs assetClass=${selected.assetClass}.` })
     }
-    const results = demoMarketAAPL.historical.results
+    const rawResults = demoMarketAAPL.historical.results ?? []
+    const targetSpot = DEMO_FX[selected.symbol]?.spot
+    const results = targetSpot == null
+      ? rawResults
+      : (() => {
+          const last = Math.max(1, rawResults.length - 1)
+          const factor = (index: number) => 1
+            + (index - last) * 0.00012
+            + Math.sin(index / 4) * 0.007
+            + Math.sin(index / 1.7) * 0.003
+          const anchor = factor(last)
+          const closeAt = (index: number) => targetSpot * factor(index) / anchor
+          return rawResults.map((bar, index) => {
+            const close = closeAt(index)
+            const open = index === 0 ? close * 0.9996 : closeAt(index - 1)
+            const band = close * 0.0012
+            return {
+              ...bar,
+              open,
+              high: Math.max(open, close) + band,
+              low: Math.min(open, close) - band,
+              close,
+              volume: null,
+            }
+          })
+        })()
     const sourceId = barId ? barId.split('|')[0] : 'yfinance'
     const meta: BarMeta = {
       symbol: selected.symbol, from: results[0]?.date ?? '', to: results[results.length - 1]?.date ?? '', bars: results.length,

--- a/ui/src/pages/MarketDetailPage.tsx
+++ b/ui/src/pages/MarketDetailPage.tsx
@@ -1,6 +1,7 @@
 import { PageHeader } from '../components/PageHeader'
 import { SearchBox } from '../components/market/SearchBox'
 import { EquityDetail } from './market/EquityDetail'
+import { CurrencyDetail } from './market/CurrencyDetail'
 import { GenericDetail } from './market/GenericDetail'
 import { useWatchlist } from '../tabs/watchlist-store'
 import type { ViewSpec } from '../tabs/types'
@@ -16,13 +17,17 @@ export function MarketDetailPage({ spec }: MarketDetailPageProps) {
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader
         title={symbol}
-        description={`${assetClass} · price history`}
+        description={assetClass === 'currency'
+          ? 'FX workbench · spot, carry, macro divergence and manual scenarios'
+          : `${assetClass} · price history`}
         right={<PinButton assetClass={assetClass} symbol={symbol} />}
       />
       <div className="flex-1 flex flex-col gap-3 px-4 md:px-8 py-4 min-h-0 overflow-y-auto">
         <SearchBox />
         {assetClass === 'equity' ? (
           <EquityDetail symbol={symbol} source={source} />
+        ) : assetClass === 'currency' ? (
+          <CurrencyDetail symbol={symbol} source={source} />
         ) : (
           <GenericDetail symbol={symbol} assetClass={assetClass} source={source} />
         )}

--- a/ui/src/pages/MarketPage.tsx
+++ b/ui/src/pages/MarketPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ArrowUpRight, CalendarDays, Globe2, TrendingUp } from 'lucide-react'
+import { Activity, ArrowRightLeft, ArrowUpRight, CalendarDays, Globe2, Landmark, TrendingUp } from 'lucide-react'
 import { BoardMeta } from '../components/market/BoardMeta'
 import { PageHeader } from '../components/PageHeader'
 import { SearchBox } from '../components/market/SearchBox'
@@ -28,6 +28,53 @@ export function MarketPage() {
       <PageHeader title="Market" description="Search assets and view price history." />
       <div className="flex-1 flex flex-col gap-6 px-4 md:px-8 py-4 min-h-0 overflow-y-auto">
         <SearchBox />
+
+        <section className="relative overflow-hidden rounded-xl border border-success/25 bg-success/5 p-4 md:p-5">
+          <div aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,var(--success-muted),transparent_56%)]" />
+          <div className="relative flex flex-col gap-4">
+            <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between lg:gap-8">
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-success">FX desk</p>
+                <h2 className="mt-1 text-[17px] font-semibold text-foreground">From spot to carry and macro — in one pair view.</h2>
+                <p className="mt-1 max-w-2xl text-[12px] leading-relaxed text-muted-foreground">
+                  Open a major pair for price risk, rate and inflation divergence, indicative forwards, and a manual exposure scenario. No broker or bank-account connection required.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {FX_MAJORS.map((pair) => (
+                  <button
+                    key={pair}
+                    type="button"
+                    onClick={() => openOrFocus({ kind: 'market-detail', params: { assetClass: 'currency', symbol: pair } })}
+                    className="min-h-8 rounded-md border border-success/25 bg-background/75 px-2.5 font-mono text-[11px] font-semibold text-foreground transition-[border-color,background-color,transform] hover:-translate-y-0.5 hover:border-success/55 hover:bg-background"
+                  >
+                    {pair.slice(0, 3)}/{pair.slice(3)}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+              <FxDeskEntry
+                icon={<Globe2 size={15} />}
+                title="Cross-country macro"
+                description="Rates, inflation and growth momentum by currency economy."
+                onClick={() => openOrFocus({ kind: 'market-board', params: { board: 'global-macro' } })}
+              />
+              <FxDeskEntry
+                icon={<Activity size={15} />}
+                title="US regime"
+                description="Dollar, Treasury curve, inflation and labor inputs."
+                onClick={() => openOrFocus({ kind: 'market-board', params: { board: 'macro' } })}
+              />
+              <FxDeskEntry
+                icon={<Landmark size={15} />}
+                title="Fed policy"
+                description="Balance sheet, dealer positioning and FOMC documents."
+                onClick={() => openOrFocus({ kind: 'market-board', params: { board: 'fed' } })}
+              />
+            </div>
+          </div>
+        </section>
 
         {/* S&P 500 valuation strip — the market-level regime read. */}
         <div className="flex flex-col gap-2">
@@ -101,6 +148,33 @@ export function MarketPage() {
         </section>
       </div>
     </div>
+  )
+}
+
+const FX_MAJORS = ['EURUSD', 'USDJPY', 'GBPUSD', 'USDCNH'] as const
+
+function FxDeskEntry({ icon, title, description, onClick }: {
+  icon: ReactNode
+  title: string
+  description: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex min-h-[58px] items-center gap-3 rounded-lg border border-border/70 bg-background/65 px-3 py-2 text-left transition-colors hover:border-success/35 hover:bg-background"
+    >
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-success/10 text-success">
+        {icon}
+      </span>
+      <span className="min-w-0">
+        <span className="flex items-center gap-1 text-[12px] font-semibold text-foreground">
+          {title}<ArrowRightLeft size={11} className="text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+        </span>
+        <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">{description}</span>
+      </span>
+    </button>
   )
 }
 

--- a/ui/src/pages/market/CurrencyDetail.tsx
+++ b/ui/src/pages/market/CurrencyDetail.tsx
@@ -1,0 +1,355 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { referenceApi, type GlobalMacroBoard, type GlobalMacroCell, type MacroBoard } from '../../api/reference'
+import { Card } from '../../components/market/Card'
+import { KlinePanel, type KlineSnapshot } from '../../components/market/KlinePanel'
+import { SegmentedControl } from '../../components/SegmentedControl'
+import { Skeleton } from '../../components/StateViews'
+import { fmtPctSigned, fmtPnl } from '../../lib/format'
+import { useWorkspace } from '../../tabs/store'
+import {
+  broadDollarChange,
+  buildIndicativeForwardCurve,
+  calculateFxScenario,
+  computeFxPriceStats,
+  macroRowForCurrency,
+  parseFxPair,
+  resolveFxCountry,
+} from './fx-analysis'
+
+interface Props {
+  symbol: string
+  source?: string
+}
+
+const EMPTY_SNAPSHOT: KlineSnapshot = {
+  bars: null,
+  meta: null,
+  loading: true,
+  error: null,
+  interval: '1d',
+  timeframe: '1Y',
+}
+const SHOCKS = [-100, -25, 25, 100]
+
+function fxDigits(value: number, pair: ReturnType<typeof parseFxPair>): number {
+  if (!pair) return 4
+  return pair.quote === 'JPY' || Math.abs(value) >= 100 ? 3 : 5
+}
+
+function fmtFx(value: number | null | undefined, pair: ReturnType<typeof parseFxPair>): string {
+  if (value == null || !Number.isFinite(value)) return '—'
+  return value.toLocaleString('en-US', {
+    minimumFractionDigits: fxDigits(value, pair),
+    maximumFractionDigits: fxDigits(value, pair),
+  })
+}
+
+function fmtFxRange(value: number, pair: ReturnType<typeof parseFxPair>): string {
+  const digits = pair?.quote === 'JPY' ? 2 : 4
+  return value.toLocaleString('en-US', { minimumFractionDigits: digits, maximumFractionDigits: digits })
+}
+
+function fmtCell(cell: GlobalMacroCell | undefined, suffix: string): string {
+  return cell?.value == null ? '—' : `${cell.value.toFixed(suffix === '%' ? 2 : 1)}${suffix}`
+}
+
+export function CurrencyDetail({ symbol, source }: Props) {
+  const pair = useMemo(() => parseFxPair(symbol), [symbol])
+  const [snapshot, setSnapshot] = useState<KlineSnapshot>(EMPTY_SNAPSHOT)
+  const [globalMacro, setGlobalMacro] = useState<GlobalMacroBoard | null>(null)
+  const [macro, setMacro] = useState<MacroBoard | null>(null)
+  const [macroError, setMacroError] = useState<string | null>(null)
+  const [side, setSide] = useState<'long' | 'short'>('long')
+  const [notional, setNotional] = useState('1000000')
+  const [movePips, setMovePips] = useState('25')
+  const handleSnapshot = useCallback((next: KlineSnapshot) => setSnapshot(next), [])
+  const openOrFocus = useWorkspace((state) => state.openOrFocus)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.allSettled([referenceApi.globalMacro(), referenceApi.macro()])
+      .then(([globalResult, macroResult]) => {
+        if (cancelled) return
+        if (globalResult.status === 'fulfilled') setGlobalMacro(globalResult.value)
+        if (macroResult.status === 'fulfilled') setMacro(macroResult.value)
+        setMacroError(globalResult.status === 'rejected'
+          ? (globalResult.reason instanceof Error ? globalResult.reason.message : String(globalResult.reason))
+          : null)
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  const stats = useMemo(() => computeFxPriceStats(snapshot.bars ?? []), [snapshot.bars])
+  const dailyRisk = snapshot.interval === '1d' ? stats : null
+  const baseRow = pair ? macroRowForCurrency(pair.base, globalMacro) : null
+  const quoteRow = pair ? macroRowForCurrency(pair.quote, globalMacro) : null
+  const baseCountry = pair ? resolveFxCountry(pair.base) : null
+  const quoteCountry = pair ? resolveFxCountry(pair.quote) : null
+  const baseRate = baseRow?.shortRate.value ?? null
+  const quoteRate = quoteRow?.shortRate.value ?? null
+  const rateDiff = baseRate != null && quoteRate != null ? baseRate - quoteRate : null
+  const cpiDiff = baseRow?.cpiYoy.value != null && quoteRow?.cpiYoy.value != null
+    ? baseRow.cpiYoy.value - quoteRow.cpiYoy.value
+    : null
+  const cliDiff = baseRow?.cli.value != null && quoteRow?.cli.value != null
+    ? baseRow.cli.value - quoteRow.cli.value
+    : null
+  const forwards = stats && pair && baseRate != null && quoteRate != null
+    ? buildIndicativeForwardCurve(stats.spot, baseRate, quoteRate, pair.pipSize)
+    : []
+  const scenario = pair && stats
+    ? calculateFxScenario({
+        pair,
+        spot: stats.spot,
+        notionalBase: Number(notional),
+        movePips: Number(movePips),
+        side,
+      })
+    : null
+  const dollar = broadDollarChange(macro)
+
+  if (!pair) {
+    return (
+      <div className="flex flex-col gap-3 min-h-0 flex-1">
+        <div className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-[12px] text-muted-foreground">
+          Open a six-letter currency pair such as EURUSD or USDJPY to use the FX workbench.
+        </div>
+        <div className="h-[420px] shrink-0">
+          <KlinePanel selection={{ symbol, assetClass: 'currency' }} source={source} />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <section className="rounded-lg border border-border bg-secondary/35 px-4 py-3.5">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div>
+            <div className="flex items-baseline gap-2">
+              <span className="font-mono text-[22px] font-semibold tracking-tight text-foreground">{pair.base}/{pair.quote}</span>
+              <span className="text-[11px] text-muted-foreground">spot research · no account required</span>
+            </div>
+            <div className="mt-1 flex items-baseline gap-2">
+              <span className="font-mono text-[26px] font-semibold text-foreground">{fmtFx(stats?.spot, pair)}</span>
+              <span className="text-[11px] text-muted-foreground">{stats?.asOf ?? (snapshot.loading ? 'loading price history…' : 'no price')}</span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-5">
+            <FxMetric label="1W" value={snapshot.interval === '1d' ? fmtPctSigned(dailyRisk?.oneWeekReturn) : '1d candles'} />
+            <FxMetric label="1M" value={snapshot.interval === '1d' ? fmtPctSigned(dailyRisk?.oneMonthReturn) : '1d candles'} />
+            <FxMetric label="3M" value={snapshot.interval === '1d' ? fmtPctSigned(dailyRisk?.threeMonthReturn) : '1d candles'} />
+            <FxMetric label="20D vol" value={dailyRisk?.realizedVol20 == null ? (snapshot.interval === '1d' ? '—' : '1d candles') : `${dailyRisk.realizedVol20.toFixed(1)}%`} />
+            <FxMetric
+              label={`${snapshot.timeframe} range`}
+              value={stats ? `${fmtFxRange(stats.rangeLow, pair)}–${fmtFxRange(stats.rangeHigh, pair)}` : '—'}
+              subvalue={stats?.rangePosition == null ? undefined : `${stats.rangePosition.toFixed(0)}% through range`}
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="h-[390px] shrink-0">
+        <KlinePanel
+          selection={{ symbol: pair.symbol, assetClass: 'currency' }}
+          source={source}
+          onSnapshot={handleSnapshot}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 2xl:grid-cols-2">
+        <Card
+          title="Macro divergence"
+          info="Country-level OECD proxies. EUR uses Germany and CNH uses onshore China; dates can differ by indicator. Read the dates before treating a spread as current."
+          right={
+            <button
+              type="button"
+              className="text-[11px] font-medium text-primary hover:text-primary/80"
+              onClick={() => openOrFocus({ kind: 'market-board', params: { board: 'global-macro' } })}
+            >
+              Open board
+            </button>
+          }
+          contentClassName="p-0"
+        >
+          {!globalMacro && !macroError ? (
+            <div className="space-y-3 p-3"><Skeleton className="h-10 w-full" /><Skeleton className="h-10 w-full" /><Skeleton className="h-10 w-full" /></div>
+          ) : macroError ? (
+            <p className="p-3 text-[12px] text-destructive">{macroError}</p>
+          ) : (
+            <div>
+              <div className="overflow-x-auto">
+                <div className="min-w-[430px]">
+                  <div className="grid grid-cols-[minmax(110px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_80px] border-b border-border/60 bg-muted/25 px-3 py-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+                    <span>Driver</span><span className="text-right">{pair.base}</span><span className="text-right">{pair.quote}</span><span className="text-right">Spread</span>
+                  </div>
+                  <MacroCompareRow label="Short rate" base={baseRow?.shortRate} quote={quoteRow?.shortRate} diff={rateDiff} cellSuffix="%" diffSuffix="pp" />
+                  <MacroCompareRow label="CPI YoY" base={baseRow?.cpiYoy} quote={quoteRow?.cpiYoy} diff={cpiDiff} cellSuffix="%" diffSuffix="pp" />
+                  <MacroCompareRow label="Growth CLI" base={baseRow?.cli} quote={quoteRow?.cli} diff={cliDiff} cellSuffix="" diffSuffix="" />
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border/60 px-3 py-2 text-[10px] text-muted-foreground">
+                <span>{baseCountry?.label}{baseCountry?.proxy ? ` · ${baseCountry.proxy}` : ''} vs {quoteCountry?.label}{quoteCountry?.proxy ? ` · ${quoteCountry.proxy}` : ''}</span>
+                {pair.symbol.includes('USD') && dollar && (
+                  <span>Broad USD {dollar.latest.toFixed(1)} · 20 obs {fmtPctSigned(dollar.changePct)}</span>
+                )}
+              </div>
+            </div>
+          )}
+        </Card>
+
+        <Card
+          title="Indicative carry curve"
+          info="Covered-interest-parity estimate from OECD short-rate proxies. It excludes cross-currency basis, bid/ask, holidays and exact tenor curves; it is not an executable forward quote."
+          right={rateDiff == null ? null : (
+            <span className={`text-[11px] font-medium ${rateDiff >= 0 ? 'text-success' : 'text-warning'}`}>
+              {pair.base}–{pair.quote} {rateDiff >= 0 ? '+' : ''}{rateDiff.toFixed(2)}pp
+            </span>
+          )}
+          contentClassName="p-0"
+        >
+          {forwards.length === 0 ? (
+            <p className="p-3 text-[12px] leading-relaxed text-muted-foreground">
+              Short-rate data is unavailable for one or both currencies. Price history remains usable; carry is left blank instead of guessed.
+            </p>
+          ) : (
+            <table className="w-full text-[12px]">
+              <thead><tr className="border-b border-border/60 bg-muted/25 text-[10px] uppercase tracking-wide text-muted-foreground">
+                <th className="px-3 py-2 text-left font-medium">Tenor</th><th className="px-3 py-2 text-right font-medium">Outright</th><th className="px-3 py-2 text-right font-medium">Forward points</th>
+              </tr></thead>
+              <tbody>{forwards.map((point) => (
+                <tr key={point.months} className="border-b border-border/50 last:border-0">
+                  <td className="px-3 py-2 font-medium text-foreground">{point.months}M</td>
+                  <td className="px-3 py-2 text-right font-mono text-foreground">{fmtFx(point.outright, pair)}</td>
+                  <td className={`px-3 py-2 text-right font-mono ${point.points >= 0 ? 'text-success' : 'text-destructive'}`}>{point.points >= 0 ? '+' : ''}{point.points.toFixed(1)}</td>
+                </tr>
+              ))}</tbody>
+            </table>
+          )}
+        </Card>
+      </div>
+
+      <Card
+        title="Exposure scenario"
+        info="Manual what-if calculator for exposure held in another system. P&L is linear spot delta and excludes options convexity, forward carry, funding, fees and basis. Inputs stay in this tab and are never sent to a broker."
+      >
+        <div className="grid grid-cols-1 gap-4 2xl:grid-cols-[auto_minmax(150px,220px)_minmax(180px,1fr)_minmax(210px,1fr)] 2xl:items-end">
+          <div>
+            <label className="mb-1.5 block text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Exposure side</label>
+            <SegmentedControl
+              value={side}
+              options={[
+                { value: 'long', label: `Long ${pair.base}` },
+                { value: 'short', label: `Short ${pair.base}` },
+              ]}
+              onChange={setSide}
+              ariaLabel="Exposure side"
+            />
+          </div>
+          <label className="block">
+            <span className="mb-1.5 block text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Notional · {pair.base}</span>
+            <input
+              type="number"
+              min="0"
+              step="100000"
+              value={notional}
+              onChange={(event) => setNotional(event.target.value)}
+              className="min-h-8 w-full rounded-md border border-border bg-background px-2.5 text-[12px] font-mono text-foreground focus:border-primary focus:outline-none"
+            />
+          </label>
+          <div>
+            <label className="mb-1.5 block text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Pair move · pips</label>
+            <div className="flex flex-wrap gap-1.5">
+              {SHOCKS.map((shock) => (
+                <button
+                  key={shock}
+                  type="button"
+                  aria-pressed={Number(movePips) === shock}
+                  onClick={() => setMovePips(String(shock))}
+                  className={`min-h-8 rounded-md border px-2 text-[11px] font-medium transition-colors ${Number(movePips) === shock ? 'border-primary/60 bg-primary/10 text-primary' : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'}`}
+                >
+                  {shock > 0 ? '+' : ''}{shock}
+                </button>
+              ))}
+              <input
+                aria-label="Custom pair move in pips"
+                type="number"
+                step="1"
+                value={movePips}
+                onChange={(event) => setMovePips(event.target.value)}
+                className="min-h-8 w-24 rounded-md border border-border bg-background px-2 text-right text-[11px] font-mono text-foreground focus:border-primary focus:outline-none"
+              />
+            </div>
+          </div>
+          <div className="rounded-md border border-border/70 bg-muted/25 px-3 py-2">
+            <div className="flex items-end justify-between gap-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Estimated P&amp;L · {pair.quote}</p>
+                <p className={`mt-0.5 font-mono text-[20px] font-semibold ${scenario && scenario.quotePnl >= 0 ? 'text-success' : 'text-destructive'}`}>
+                  {scenario ? fmtPnl(scenario.quotePnl, pair.quote) : '—'}
+                </p>
+              </div>
+              <div className="text-right text-[10px] text-muted-foreground">
+                <p>spot {scenario ? fmtFx(scenario.shockedSpot, pair) : '—'}</p>
+                <p>{scenario ? fmtPctSigned(scenario.movePercent) : '—'} · ≈ {scenario ? fmtPnl(scenario.basePnlApprox, pair.base) : '—'}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p className="mt-3 text-[10px] leading-relaxed text-muted-foreground">
+          Manual research only. OpenAlice does not need the bank account or position feed; enter a receivable, payable or hedge notional here and take the result back to the desk system.
+        </p>
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-2 pb-2">
+        <span className="mr-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Continue analysis</span>
+        <DeskLink label="Global Macro" onClick={() => openOrFocus({ kind: 'market-board', params: { board: 'global-macro' } })} />
+        <DeskLink label="US Macro" onClick={() => openOrFocus({ kind: 'market-board', params: { board: 'macro' } })} />
+        <DeskLink label="Fed" onClick={() => openOrFocus({ kind: 'market-board', params: { board: 'fed' } })} />
+      </div>
+    </div>
+  )
+}
+
+function FxMetric({ label, value, subvalue }: { label: string; value: string; subvalue?: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-0.5 truncate font-mono text-[12px] font-medium text-foreground">{value}</p>
+      {subvalue && <p className="truncate text-[9px] text-muted-foreground">{subvalue}</p>}
+    </div>
+  )
+}
+
+function MacroCompareRow({ label, base, quote, diff, cellSuffix, diffSuffix }: {
+  label: string
+  base?: GlobalMacroCell
+  quote?: GlobalMacroCell
+  diff: number | null
+  cellSuffix: string
+  diffSuffix: string
+}) {
+  return (
+    <div className="grid grid-cols-[minmax(110px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_80px] items-center border-b border-border/50 px-3 py-2.5 text-[12px] last:border-0">
+      <span className="font-medium text-foreground">{label}</span>
+      <span className="text-right font-mono text-foreground" title={base?.date ?? 'No data'}>{fmtCell(base, cellSuffix)}</span>
+      <span className="text-right font-mono text-foreground" title={quote?.date ?? 'No data'}>{fmtCell(quote, cellSuffix)}</span>
+      <span className={`text-right font-mono ${diff == null ? 'text-muted-foreground' : diff >= 0 ? 'text-success' : 'text-destructive'}`}>
+        {diff == null ? '—' : `${diff >= 0 ? '+' : ''}${diff.toFixed(2)}${diffSuffix}`}
+      </span>
+    </div>
+  )
+}
+
+function DeskLink({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-md border border-border bg-secondary/50 px-2.5 py-1.5 text-[11px] font-medium text-foreground transition-colors hover:border-primary/40 hover:bg-muted"
+    >
+      {label} →
+    </button>
+  )
+}

--- a/ui/src/pages/market/fx-analysis.spec.ts
+++ b/ui/src/pages/market/fx-analysis.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HistoricalBar } from '../../api/market'
+import {
+  buildIndicativeForwardCurve,
+  calculateFxScenario,
+  computeFxPriceStats,
+  parseFxPair,
+  resolveFxCountry,
+} from './fx-analysis'
+
+function dailyBars(days: number): HistoricalBar[] {
+  return Array.from({ length: days }, (_, index) => {
+    const close = 1 + index * 0.001
+    return {
+      date: new Date(Date.UTC(2026, 0, index + 1)).toISOString().slice(0, 10),
+      open: close - 0.0005,
+      high: close + 0.001,
+      low: close - 0.001,
+      close,
+      volume: null,
+    }
+  })
+}
+
+describe('FX market analysis', () => {
+  it('parses common FX vendor symbols and applies the JPY pip convention', () => {
+    expect(parseFxPair('EURUSD=X')).toEqual({ symbol: 'EURUSD', base: 'EUR', quote: 'USD', pipSize: 0.0001 })
+    expect(parseFxPair('USD/JPY')).toEqual({ symbol: 'USDJPY', base: 'USD', quote: 'JPY', pipSize: 0.01 })
+    expect(parseFxPair('USD.USD')).toBeNull()
+  })
+
+  it('marks the macro proxies that are not exact currency-area aggregates', () => {
+    expect(resolveFxCountry('EUR')?.proxy).toBe('Germany proxy')
+    expect(resolveFxCountry('CNH')?.proxy).toBe('onshore macro proxy')
+  })
+
+  it('derives horizon returns, realized volatility and range position from displayed bars', () => {
+    const stats = computeFxPriceStats(dailyBars(120))!
+    expect(stats.spot).toBeCloseTo(1.119)
+    expect(stats.oneWeekReturn).toBeGreaterThan(0)
+    expect(stats.oneMonthReturn).toBeGreaterThan(stats.oneWeekReturn!)
+    expect(stats.threeMonthReturn).toBeGreaterThan(stats.oneMonthReturn!)
+    expect(stats.realizedVol20).not.toBeNull()
+    expect(stats.rangePosition).toBeGreaterThan(90)
+  })
+
+  it('projects indicative forward points from the two short-rate proxies', () => {
+    const curve = buildIndicativeForwardCurve(1.08, 2, 4, 0.0001)
+    expect(curve).toHaveLength(4)
+    expect(curve[0].outright).toBeGreaterThan(1.08)
+    expect(curve[3].points).toBeGreaterThan(curve[0].points)
+  })
+
+  it('calculates manual long and short exposure P&L without an account connection', () => {
+    const pair = parseFxPair('EURUSD')!
+    const long = calculateFxScenario({ pair, spot: 1.08, notionalBase: 1_000_000, movePips: 25, side: 'long' })!
+    const short = calculateFxScenario({ pair, spot: 1.08, notionalBase: 1_000_000, movePips: 25, side: 'short' })!
+    expect(long.quotePnl).toBe(2_500)
+    expect(short.quotePnl).toBe(-2_500)
+    expect(long.shockedSpot).toBeCloseTo(1.0825)
+  })
+})

--- a/ui/src/pages/market/fx-analysis.ts
+++ b/ui/src/pages/market/fx-analysis.ts
@@ -1,0 +1,199 @@
+import Decimal from 'decimal.js'
+
+import type { HistoricalBar } from '../../api/market'
+import type { GlobalMacroBoard, GlobalMacroRow, MacroBoard } from '../../api/reference'
+
+export interface FxPair {
+  symbol: string
+  base: string
+  quote: string
+  pipSize: number
+}
+
+export interface FxCountry {
+  currency: string
+  country: string
+  label: string
+  proxy?: string
+}
+
+export interface FxPriceStats {
+  spot: number
+  asOf: string
+  oneWeekReturn: number | null
+  oneMonthReturn: number | null
+  threeMonthReturn: number | null
+  realizedVol20: number | null
+  rangeLow: number
+  rangeHigh: number
+  rangePosition: number | null
+}
+
+export interface FxForwardPoint {
+  months: number
+  outright: number
+  points: number
+}
+
+export interface FxScenario {
+  shockedSpot: number
+  movePercent: number
+  quotePnl: number
+  basePnlApprox: number
+}
+
+const COUNTRY_BY_CURRENCY: Record<string, FxCountry> = {
+  USD: { currency: 'USD', country: 'united_states', label: 'United States' },
+  EUR: { currency: 'EUR', country: 'germany', label: 'Euro area', proxy: 'Germany proxy' },
+  GBP: { currency: 'GBP', country: 'united_kingdom', label: 'United Kingdom' },
+  JPY: { currency: 'JPY', country: 'japan', label: 'Japan' },
+  CNY: { currency: 'CNY', country: 'china', label: 'China' },
+  CNH: { currency: 'CNH', country: 'china', label: 'China', proxy: 'onshore macro proxy' },
+  CAD: { currency: 'CAD', country: 'canada', label: 'Canada' },
+  AUD: { currency: 'AUD', country: 'australia', label: 'Australia' },
+  CHF: { currency: 'CHF', country: 'switzerland', label: 'Switzerland' },
+  NZD: { currency: 'NZD', country: 'new_zealand', label: 'New Zealand' },
+}
+
+/** Parse common vendor spellings: EURUSD, EUR/USD, USD.CHF and EURUSD=X. */
+export function parseFxPair(raw: string): FxPair | null {
+  const symbol = raw.toUpperCase().replace(/=X$/, '').replace(/[^A-Z]/g, '')
+  if (symbol.length !== 6) return null
+  const base = symbol.slice(0, 3)
+  const quote = symbol.slice(3)
+  if (base === quote) return null
+  return { symbol, base, quote, pipSize: quote === 'JPY' ? 0.01 : 0.0001 }
+}
+
+export function resolveFxCountry(currency: string): FxCountry | null {
+  return COUNTRY_BY_CURRENCY[currency.toUpperCase()] ?? null
+}
+
+export function macroRowForCurrency(
+  currency: string,
+  board: GlobalMacroBoard | null,
+): GlobalMacroRow | null {
+  const country = resolveFxCountry(currency)
+  if (!country || !board) return null
+  return board.rows.find((row) => row.country === country.country) ?? null
+}
+
+function sortedBars(input: HistoricalBar[]): HistoricalBar[] {
+  return input
+    .filter((bar) => Number.isFinite(bar.close) && Number.isFinite(bar.high) && Number.isFinite(bar.low))
+    .sort((a, b) => a.date.localeCompare(b.date))
+}
+
+function returnOverDays(bars: HistoricalBar[], days: number): number | null {
+  const latest = bars[bars.length - 1]
+  if (!latest) return null
+  const latestTime = new Date(latest.date).getTime()
+  if (!Number.isFinite(latestTime)) return null
+  const target = latestTime - days * 86_400_000
+  let baseline: HistoricalBar | null = null
+  for (const bar of bars) {
+    const time = new Date(bar.date).getTime()
+    if (Number.isFinite(time) && time <= target) baseline = bar
+    if (time > target) break
+  }
+  if (!baseline || baseline.close === 0) return null
+  return new Decimal(latest.close).div(baseline.close).minus(1).mul(100).toNumber()
+}
+
+function realizedVol20(bars: HistoricalBar[]): number | null {
+  const closes = bars.slice(-21).map((bar) => bar.close).filter((value) => value > 0)
+  if (closes.length < 6) return null
+  const returns: number[] = []
+  for (let i = 1; i < closes.length; i++) returns.push(Math.log(closes[i] / closes[i - 1]))
+  const mean = returns.reduce((sum, value) => sum + value, 0) / returns.length
+  const variance = returns.reduce((sum, value) => sum + (value - mean) ** 2, 0) / Math.max(1, returns.length - 1)
+  return Math.sqrt(variance) * Math.sqrt(252) * 100
+}
+
+export function computeFxPriceStats(input: HistoricalBar[]): FxPriceStats | null {
+  const bars = sortedBars(input)
+  const latest = bars[bars.length - 1]
+  if (!latest) return null
+  const range = bars.slice(-252)
+  const rangeLow = Math.min(...range.map((bar) => bar.low))
+  const rangeHigh = Math.max(...range.map((bar) => bar.high))
+  const rangeWidth = rangeHigh - rangeLow
+  return {
+    spot: latest.close,
+    asOf: latest.date,
+    oneWeekReturn: returnOverDays(bars, 7),
+    oneMonthReturn: returnOverDays(bars, 30),
+    threeMonthReturn: returnOverDays(bars, 90),
+    realizedVol20: realizedVol20(bars),
+    rangeLow,
+    rangeHigh,
+    rangePosition: rangeWidth > 0 ? ((latest.close - rangeLow) / rangeWidth) * 100 : null,
+  }
+}
+
+/**
+ * Covered-interest-parity indication using the board's short-rate proxies.
+ * This is a research estimate, not an executable forward quote.
+ */
+export function buildIndicativeForwardCurve(
+  spot: number,
+  baseRatePct: number,
+  quoteRatePct: number,
+  pipSize: number,
+  tenors = [1, 3, 6, 12],
+): FxForwardPoint[] {
+  const spotDec = new Decimal(spot)
+  const baseRate = new Decimal(baseRatePct).div(100)
+  const quoteRate = new Decimal(quoteRatePct).div(100)
+  const pip = new Decimal(pipSize)
+  return tenors.map((months) => {
+    const years = new Decimal(months).div(12)
+    const outright = spotDec
+      .mul(new Decimal(1).plus(quoteRate.mul(years)))
+      .div(new Decimal(1).plus(baseRate.mul(years)))
+    return {
+      months,
+      outright: outright.toNumber(),
+      points: outright.minus(spotDec).div(pip).toNumber(),
+    }
+  })
+}
+
+export function calculateFxScenario(input: {
+  pair: FxPair
+  spot: number
+  notionalBase: number
+  movePips: number
+  side: 'long' | 'short'
+}): FxScenario | null {
+  if (![input.spot, input.notionalBase, input.movePips].every(Number.isFinite) || input.spot <= 0 || input.notionalBase < 0) return null
+  const direction = input.side === 'long' ? 1 : -1
+  const move = new Decimal(input.movePips).mul(input.pair.pipSize)
+  const shocked = new Decimal(input.spot).plus(move)
+  if (shocked.lte(0)) return null
+  const quotePnl = new Decimal(input.notionalBase).mul(move).mul(direction)
+  return {
+    shockedSpot: shocked.toNumber(),
+    movePercent: move.div(input.spot).mul(100).toNumber(),
+    quotePnl: quotePnl.toNumber(),
+    basePnlApprox: quotePnl.div(input.spot).toNumber(),
+  }
+}
+
+export function broadDollarChange(macro: MacroBoard | null, observations = 20): {
+  latest: number
+  date: string | null
+  changePct: number | null
+} | null {
+  const card = macro?.cards.find((entry) => entry.id === 'DTWEXBGS')
+  if (!card || card.latest == null) return null
+  const points = card.points.filter((point) => Number.isFinite(point.value))
+  const baseline = points[Math.max(0, points.length - 1 - observations)]
+  return {
+    latest: card.latest,
+    date: card.latestDate,
+    changePct: baseline && baseline.value !== 0
+      ? new Decimal(card.latest).div(baseline.value).minus(1).mul(100).toNumber()
+      : null,
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated FX analysis workbench with spot risk, macro divergence, carry, and range context
- add indicative forwards and manual exposure scenarios without requiring a broker or bank account connection
- add a prominent FX desk entry on Market and expand the demo surface for EUR/USD, USD/JPY, GBP/USD, and USD/CNH
- reuse displayed K-line data safely and prevent rerender-driven request loops

## Why
The currency detail path stopped at a price chart. Bank FX users generally keep positions in internal systems; OpenAlice should serve as an analysis surface rather than depend on account aggregation.

## Validation
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (332 files passed, 3251 tests passed)
- `pnpm -F open-alice-ui build:demo`
- browser demo walk for EUR/USD and USD/JPY, daily/intraday semantics, and responsive layout
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
