### PR TITLE
Make theme palettes universal preference assets

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="auto" data-palette="paper" data-light-palette="paper" data-dark-palette="graphite">
+<html lang="en" data-theme="auto" data-palette="paper" data-day-palette="paper" data-night-palette="graphite">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -7,28 +7,34 @@
     <title>OpenAlice</title>
     <meta name="color-scheme" content="light dark" />
     <script>
-      // No-flash theme: resolve the persisted mode + day/night palette pair
+      // No-flash theme: resolve the persisted preference + universal palette slots
       // before first paint. ui/src/theme re-applies and self-heals on boot.
       (function () {
         try {
           var raw = localStorage.getItem('openalice.theme.v1');
           var state = raw ? (JSON.parse(raw).state || {}) : {};
-          var t = state.theme === 'light' || state.theme === 'dark' ? state.theme : 'auto';
-          var light = state.lightPalette === 'porcelain' ? 'porcelain' : 'paper';
-          var dark = state.darkPalette === 'midnight' ? 'midnight' : 'graphite';
+          var storedTheme = state.theme;
+          var t = storedTheme === 'day' || storedTheme === 'night' || storedTheme === 'auto'
+            ? storedTheme
+            : storedTheme === 'light' ? 'day' : storedTheme === 'dark' ? 'night' : 'auto';
+          var palettes = ['paper', 'porcelain', 'graphite', 'midnight'];
+          var storedDay = palettes.indexOf(state.dayPalette) >= 0 ? state.dayPalette : state.lightPalette;
+          var storedNight = palettes.indexOf(state.nightPalette) >= 0 ? state.nightPalette : state.darkPalette;
+          var day = palettes.indexOf(storedDay) >= 0 ? storedDay : 'paper';
+          var night = palettes.indexOf(storedNight) >= 0 ? storedNight : 'graphite';
           var effective = t === 'auto'
-            ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'night' : 'day')
             : t;
           var root = document.documentElement;
           root.dataset.theme = t;
-          root.dataset.lightPalette = light;
-          root.dataset.darkPalette = dark;
-          root.dataset.palette = effective === 'dark' ? dark : light;
+          root.dataset.dayPalette = day;
+          root.dataset.nightPalette = night;
+          root.dataset.palette = effective === 'night' ? night : day;
         } catch (e) {
           var root = document.documentElement;
           root.dataset.theme = 'auto';
-          root.dataset.lightPalette = 'paper';
-          root.dataset.darkPalette = 'graphite';
+          root.dataset.dayPalette = 'paper';
+          root.dataset.nightPalette = 'graphite';
           root.dataset.palette = 'paper';
         }
       })();

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -1,8 +1,8 @@
 /**
  * The color-theme toggle that lives in the ActivityBar footer. One icon
- * button cycles auto → light → dark → auto. The icon reflects the concrete
- * effective mode (sun / moon); auto adds a tiny badge instead of using an
- * abstract monitor icon.
+ * button cycles auto → day → night → auto. The icon reflects the active
+ * palette's intrinsic appearance (sun / moon); auto adds a tiny badge instead
+ * of using an abstract monitor icon.
  *
  * State is the theme store (ui/src/theme/store); the side-effect module
  * resolves the configured day/night card onto `<html data-palette>`. No prop
@@ -15,11 +15,11 @@ import { useTranslation } from 'react-i18next'
 import { useThemeStore, type AppTheme } from '../theme/store'
 import { useEffectiveTheme } from '../theme/useEffectiveTheme'
 
-/** What the NEXT click switches to (auto → light → dark → auto). */
+/** What the NEXT click switches to (auto → day → night → auto). */
 const NEXT: Record<AppTheme, AppTheme> = {
-  auto: 'light',
-  light: 'dark',
-  dark: 'auto',
+  auto: 'day',
+  day: 'night',
+  night: 'auto',
 }
 
 export function ThemeToggle({ compact = false }: { compact?: boolean }) {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -55,11 +55,11 @@ export const en = {
       title: 'Appearance',
       description: 'Color and layout preferences. Stored locally on this device.',
       colorMode: 'Color mode',
-      colorModeDescription: 'Auto follows the system; Day and Night pin one side of the configured palette pair.',
+      colorModeDescription: 'Auto follows the system between Day and Night slots; Day and Night pin one slot.',
       dayPalette: 'Day palette',
-      dayPaletteDescription: 'Used in Day mode and while Auto resolves to a light appearance.',
+      dayPaletteDescription: 'Used for Day and when Auto follows a light system preference. Choose any palette.',
       nightPalette: 'Night palette',
-      nightPaletteDescription: 'Used in Night mode and while Auto resolves to a dark appearance.',
+      nightPaletteDescription: 'Used for Night and when Auto follows a dark system preference. Choose any palette.',
       showEditorTabs: 'Show editor tabs',
       showEditorTabsOn: 'The tab strip above the editor is shown — click to switch, × or middle-click to close.',
       showEditorTabsOff: 'The tab strip is hidden. Navigate from the sidebar; turn this on for VS Code-style tabs.',
@@ -642,7 +642,7 @@ export const en = {
     },
   },
   theme: {
-    mode: { auto: 'Auto', light: 'Light', dark: 'Dark' },
+    mode: { auto: 'Auto', day: 'Day', night: 'Night' },
     switchTo: 'Switch to {{mode}}',
     palette: { paper: 'Paper', porcelain: 'Porcelain', graphite: 'Graphite', midnight: 'Midnight' },
     paletteDescription: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -44,11 +44,11 @@ export const ja: Resources = {
       title: '外観',
       description: '色とレイアウトの設定。この端末にのみ保存されます。',
       colorMode: 'カラーモード',
-      colorModeDescription: '自動はシステムに追従し、ライトとダークは設定したパレットの片側に固定します。',
+      colorModeDescription: '自動はシステムに追従して昼と夜のスロットを切り替え、昼と夜は対応するスロットに固定します。',
       dayPalette: '昼用パレット',
-      dayPaletteDescription: 'ライトモードと、自動がライト表示になる場合に使います。',
+      dayPaletteDescription: '昼モードと、自動が明るいシステム設定に追従する場合に使います。どのパレットでも選べます。',
       nightPalette: '夜用パレット',
-      nightPaletteDescription: 'ダークモードと、自動がダーク表示になる場合に使います。',
+      nightPaletteDescription: '夜モードと、自動が暗いシステム設定に追従する場合に使います。どのパレットでも選べます。',
       showEditorTabs: 'エディタタブを表示',
       showEditorTabsOn: 'エディタ上部にタブバーを表示 —— クリックで切替、× または中クリックで閉じる。',
       showEditorTabsOff: 'タブバーは非表示。サイドバーから移動します。VS Code 風のタブが欲しい場合はオンに。',
@@ -631,7 +631,7 @@ export const ja: Resources = {
     },
   },
   theme: {
-    mode: { auto: '自動', light: 'ライト', dark: 'ダーク' },
+    mode: { auto: '自動', day: '昼', night: '夜' },
     switchTo: '{{mode}}に切り替え',
     palette: { paper: 'ペーパー', porcelain: 'ポーセリン', graphite: 'グラファイト', midnight: 'ミッドナイト' },
     paletteDescription: {

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -52,11 +52,11 @@ export const zhHant: Resources = {
       title: '外觀',
       description: '色彩與版面偏好，僅儲存在本機。',
       colorMode: '色彩模式',
-      colorModeDescription: '自動模式跟隨系統；日間與暗夜模式會固定使用所設定色卡的一側。',
+      colorModeDescription: '自動模式跟隨系統在日間與暗夜槽位間切換；日間與暗夜模式會固定對應槽位。',
       dayPalette: '日間色卡',
-      dayPaletteDescription: '用於日間模式，以及自動模式切換到淺色外觀時。',
+      dayPaletteDescription: '用於日間模式，以及自動模式跟隨淺色系統偏好時；可選擇任意色卡。',
       nightPalette: '暗夜色卡',
-      nightPaletteDescription: '用於暗夜模式，以及自動模式切換到深色外觀時。',
+      nightPaletteDescription: '用於暗夜模式，以及自動模式跟隨深色系統偏好時；可選擇任意色卡。',
       showEditorTabs: '顯示編輯器分頁',
       showEditorTabsOn: '編輯器上方顯示分頁列 —— 點擊切換，× 或中鍵關閉。',
       showEditorTabsOff: '分頁列已隱藏。從側欄導覽；想要 VS Code 式分頁就開啟它。',
@@ -639,7 +639,7 @@ export const zhHant: Resources = {
     },
   },
   theme: {
-    mode: { auto: '自動', light: '淺色', dark: '深色' },
+    mode: { auto: '自動', day: '日間', night: '暗夜' },
     switchTo: '切換到{{mode}}',
     palette: { paper: '紙張', porcelain: '白瓷', graphite: '石墨', midnight: '午夜' },
     paletteDescription: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -44,11 +44,11 @@ export const zh: Resources = {
       title: '外观',
       description: '色彩与布局偏好，仅保存在本设备。',
       colorMode: '色彩模式',
-      colorModeDescription: '自动模式跟随系统；日间和暗夜模式会固定使用所配置色卡的一侧。',
+      colorModeDescription: '自动模式跟随系统在日间和暗夜槽位间切换；日间和暗夜模式会固定对应槽位。',
       dayPalette: '日间色卡',
-      dayPaletteDescription: '用于日间模式，以及自动模式切换到浅色外观时。',
+      dayPaletteDescription: '用于日间模式，以及自动模式跟随浅色系统偏好时；可选择任意色卡。',
       nightPalette: '暗夜色卡',
-      nightPaletteDescription: '用于暗夜模式，以及自动模式切换到深色外观时。',
+      nightPaletteDescription: '用于暗夜模式，以及自动模式跟随深色系统偏好时；可选择任意色卡。',
       showEditorTabs: '显示编辑器标签页',
       showEditorTabsOn: '编辑器上方显示标签栏 —— 点击切换，× 或中键关闭。',
       showEditorTabsOff: '标签栏已隐藏。从侧栏导航；想要 VS Code 式标签页就打开它。',
@@ -631,7 +631,7 @@ export const zh: Resources = {
     },
   },
   theme: {
-    mode: { auto: '自动', light: '浅色', dark: '深色' },
+    mode: { auto: '自动', day: '日间', night: '暗夜' },
     switchTo: '切换到{{mode}}',
     palette: { paper: '纸张', porcelain: '白瓷', graphite: '石墨', midnight: '午夜' },
     paletteDescription: {

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocale, useSetLocale, LOCALE_LABELS } from '../i18n/useLocale'
 import { useEditorTabsPref } from '../live/editor-tabs-pref'
 import { preferencesApi, type WorkspaceShellStatus } from '../api/preferences'
-import { DARK_PALETTES, LIGHT_PALETTES, type ThemePaletteDefinition, type ThemePaletteId } from '../theme/palettes'
+import { THEME_PALETTES, type ThemePaletteDefinition, type ThemePaletteId } from '../theme/palettes'
 import { useThemeStore, type AppTheme } from '../theme/store'
 
 // ==================== Appearance ====================
@@ -21,12 +21,12 @@ function AppearanceSection() {
   const showEditorTabs = useEditorTabsPref((s) => s.showEditorTabs)
   const setShowEditorTabs = useEditorTabsPref((s) => s.setShowEditorTabs)
   const theme = useThemeStore((s) => s.theme)
-  const lightPalette = useThemeStore((s) => s.lightPalette)
-  const darkPalette = useThemeStore((s) => s.darkPalette)
+  const dayPalette = useThemeStore((s) => s.dayPalette)
+  const nightPalette = useThemeStore((s) => s.nightPalette)
   const setTheme = useThemeStore((s) => s.setTheme)
-  const setLightPalette = useThemeStore((s) => s.setLightPalette)
-  const setDarkPalette = useThemeStore((s) => s.setDarkPalette)
-  const modes: readonly AppTheme[] = ['auto', 'light', 'dark']
+  const setDayPalette = useThemeStore((s) => s.setDayPalette)
+  const setNightPalette = useThemeStore((s) => s.setNightPalette)
+  const modes: readonly AppTheme[] = ['auto', 'day', 'night']
   return (
     <ConfigSection title={t('settings.appearance.title')} description={t('settings.appearance.description')}>
       <div className="border-b border-border/60 pb-5">
@@ -61,16 +61,16 @@ function AppearanceSection() {
         <PalettePicker
           title={t('settings.appearance.dayPalette')}
           description={t('settings.appearance.dayPaletteDescription')}
-          palettes={LIGHT_PALETTES}
-          selected={lightPalette}
-          onSelect={setLightPalette}
+          palettes={THEME_PALETTES}
+          selected={dayPalette}
+          onSelect={setDayPalette}
         />
         <PalettePicker
           title={t('settings.appearance.nightPalette')}
           description={t('settings.appearance.nightPaletteDescription')}
-          palettes={DARK_PALETTES}
-          selected={darkPalette}
-          onSelect={setDarkPalette}
+          palettes={THEME_PALETTES}
+          selected={nightPalette}
+          onSelect={setNightPalette}
         />
       </div>
 
@@ -91,7 +91,7 @@ function AppearanceSection() {
   )
 }
 
-function PalettePicker<T extends ThemePaletteId>({
+function PalettePicker({
   title,
   description,
   palettes,
@@ -100,9 +100,9 @@ function PalettePicker<T extends ThemePaletteId>({
 }: {
   title: string
   description: string
-  palettes: readonly ThemePaletteDefinition<T>[]
-  selected: T
-  onSelect: (palette: T) => void
+  palettes: readonly ThemePaletteDefinition[]
+  selected: ThemePaletteId
+  onSelect: (palette: ThemePaletteId) => void
 }) {
   const { t } = useTranslation()
   return (

--- a/ui/src/theme/index.ts
+++ b/ui/src/theme/index.ts
@@ -3,8 +3,8 @@
  * BEFORE first render, so `<html>` has the persisted mode and resolved card.
  *
  * Wiring is one-directional, mirroring i18n/index.ts: the theme store is the
- * source of truth; here we resolve auto/light/dark onto the configured day or
- * night palette and publish the result as data attributes. CSS only defines
+ * source of truth; here we resolve auto/day/night onto the configured slot
+ * and publish its universal palette as data attributes. CSS only defines
  * complete semantic cards; it does not contain a second mode-selection path.
  *
  * A near-identical apply already ran from index.html's inline script to avoid
@@ -20,13 +20,13 @@ const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
 function applyTheme(state: ReturnType<typeof readInitialThemePreferences>): void {
   const root = document.documentElement
   root.dataset.theme = state.theme
-  root.dataset.lightPalette = state.lightPalette
-  root.dataset.darkPalette = state.darkPalette
+  root.dataset.dayPalette = state.dayPalette
+  root.dataset.nightPalette = state.nightPalette
   root.dataset.palette = resolveEffectivePalette(
     state.theme,
     systemTheme.matches,
-    state.lightPalette,
-    state.darkPalette,
+    state.dayPalette,
+    state.nightPalette,
   )
 }
 
@@ -35,8 +35,8 @@ applyTheme(readInitialThemePreferences())
 useThemeStore.subscribe((state, prev) => {
   if (
     state.theme !== prev.theme
-    || state.lightPalette !== prev.lightPalette
-    || state.darkPalette !== prev.darkPalette
+    || state.dayPalette !== prev.dayPalette
+    || state.nightPalette !== prev.nightPalette
   ) applyTheme(state)
 })
 

--- a/ui/src/theme/noFlashTheme.spec.ts
+++ b/ui/src/theme/noFlashTheme.spec.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+import { runInNewContext } from 'node:vm'
+
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = basename(process.cwd()) === 'ui' ? resolve(process.cwd(), '..') : process.cwd()
+const html = readFileSync(resolve(repoRoot, 'ui/index.html'), 'utf8')
+const script = html.match(/<script>\s*(\/\/ No-flash theme[\s\S]*?)<\/script>/)?.[1]
+
+function applyNoFlashTheme(state: Record<string, unknown>, systemDark: boolean): Record<string, string> {
+  expect(script).toBeDefined()
+  const dataset: Record<string, string> = {}
+  runInNewContext(script!, {
+    document: { documentElement: { dataset } },
+    localStorage: { getItem: () => JSON.stringify({ state }) },
+    matchMedia: () => ({ matches: systemDark }),
+  })
+  return dataset
+}
+
+describe('no-flash theme bootstrap', () => {
+  it('migrates legacy fields before first paint', () => {
+    expect(applyNoFlashTheme({
+      theme: 'dark',
+      lightPalette: 'porcelain',
+      darkPalette: 'midnight',
+    }, false)).toEqual({
+      theme: 'night',
+      dayPalette: 'porcelain',
+      nightPalette: 'midnight',
+      palette: 'midnight',
+    })
+  })
+
+  it('allows a dark card in Day and a light card in Night', () => {
+    expect(applyNoFlashTheme({
+      theme: 'day',
+      dayPalette: 'midnight',
+      nightPalette: 'paper',
+    }, true)).toEqual({
+      theme: 'day',
+      dayPalette: 'midnight',
+      nightPalette: 'paper',
+      palette: 'midnight',
+    })
+
+    expect(applyNoFlashTheme({
+      theme: 'night',
+      dayPalette: 'midnight',
+      nightPalette: 'paper',
+    }, false).palette).toBe('paper')
+  })
+
+  it('uses the system only to select a slot in Auto', () => {
+    const state = { theme: 'auto', dayPalette: 'midnight', nightPalette: 'paper' }
+    expect(applyNoFlashTheme(state, false).palette).toBe('midnight')
+    expect(applyNoFlashTheme(state, true).palette).toBe('paper')
+  })
+})

--- a/ui/src/theme/palettes.ts
+++ b/ui/src/theme/palettes.ts
@@ -1,52 +1,63 @@
-export type LightPaletteId = 'paper' | 'porcelain'
-export type DarkPaletteId = 'graphite' | 'midnight'
-export type ThemePaletteId = LightPaletteId | DarkPaletteId
-export type ThemePaletteMode = 'light' | 'dark'
-export type ThemeColorMode = ThemePaletteMode | 'auto'
+export type ThemePaletteId = 'paper' | 'porcelain' | 'graphite' | 'midnight'
+export type ThemePaletteAppearance = 'light' | 'dark'
+export type ThemePreferenceMode = 'auto' | 'day' | 'night'
+export type ThemePreferenceSlot = Exclude<ThemePreferenceMode, 'auto'>
 
-export interface ThemePaletteDefinition<T extends ThemePaletteId = ThemePaletteId> {
-  readonly id: T
-  readonly mode: ThemePaletteMode
-  readonly labelKey: `theme.palette.${T}`
-  readonly descriptionKey: `theme.paletteDescription.${T}`
+export interface ThemePaletteDefinition {
+  readonly id: ThemePaletteId
+  /** Intrinsic appearance used by native controls and terminal color reporting. */
+  readonly appearance: ThemePaletteAppearance
+  readonly labelKey: `theme.palette.${ThemePaletteId}`
+  readonly descriptionKey: `theme.paletteDescription.${ThemePaletteId}`
 }
 
-export const DEFAULT_LIGHT_PALETTE: LightPaletteId = 'paper'
-export const DEFAULT_DARK_PALETTE: DarkPaletteId = 'graphite'
+export const DEFAULT_DAY_PALETTE: ThemePaletteId = 'paper'
+export const DEFAULT_NIGHT_PALETTE: ThemePaletteId = 'graphite'
 
-export const LIGHT_PALETTES = [
-  { id: 'paper', mode: 'light', labelKey: 'theme.palette.paper', descriptionKey: 'theme.paletteDescription.paper' },
-  { id: 'porcelain', mode: 'light', labelKey: 'theme.palette.porcelain', descriptionKey: 'theme.paletteDescription.porcelain' },
-] as const satisfies readonly ThemePaletteDefinition<LightPaletteId>[]
+/**
+ * One universal palette library. `appearance` describes a card; it does not
+ * restrict which preference slot can select it.
+ */
+export const THEME_PALETTES = [
+  { id: 'paper', appearance: 'light', labelKey: 'theme.palette.paper', descriptionKey: 'theme.paletteDescription.paper' },
+  { id: 'porcelain', appearance: 'light', labelKey: 'theme.palette.porcelain', descriptionKey: 'theme.paletteDescription.porcelain' },
+  { id: 'graphite', appearance: 'dark', labelKey: 'theme.palette.graphite', descriptionKey: 'theme.paletteDescription.graphite' },
+  { id: 'midnight', appearance: 'dark', labelKey: 'theme.palette.midnight', descriptionKey: 'theme.paletteDescription.midnight' },
+] as const satisfies readonly ThemePaletteDefinition[]
 
-export const DARK_PALETTES = [
-  { id: 'graphite', mode: 'dark', labelKey: 'theme.palette.graphite', descriptionKey: 'theme.paletteDescription.graphite' },
-  { id: 'midnight', mode: 'dark', labelKey: 'theme.palette.midnight', descriptionKey: 'theme.paletteDescription.midnight' },
-] as const satisfies readonly ThemePaletteDefinition<DarkPaletteId>[]
-
-export const THEME_PALETTES: readonly ThemePaletteDefinition[] = [
-  ...LIGHT_PALETTES,
-  ...DARK_PALETTES,
-]
-
-export function isLightPaletteId(value: unknown): value is LightPaletteId {
-  return value === 'paper' || value === 'porcelain'
+export function isThemePaletteId(value: unknown): value is ThemePaletteId {
+  return value === 'paper' || value === 'porcelain' || value === 'graphite' || value === 'midnight'
 }
 
-export function isDarkPaletteId(value: unknown): value is DarkPaletteId {
-  return value === 'graphite' || value === 'midnight'
+export function isThemePreferenceMode(value: unknown): value is ThemePreferenceMode {
+  return value === 'auto' || value === 'day' || value === 'night'
 }
 
-export function isThemeColorMode(value: unknown): value is ThemeColorMode {
-  return value === 'auto' || value === 'light' || value === 'dark'
+/** Accept the v1 `light` / `dark` preference values without keeping them live. */
+export function normalizeThemePreferenceMode(value: unknown): ThemePreferenceMode | null {
+  if (isThemePreferenceMode(value)) return value
+  if (value === 'light') return 'day'
+  if (value === 'dark') return 'night'
+  return null
+}
+
+export function paletteAppearance(palette: ThemePaletteId): ThemePaletteAppearance {
+  return THEME_PALETTES.find(({ id }) => id === palette)!.appearance
+}
+
+export function resolveEffectiveSlot(
+  preference: ThemePreferenceMode,
+  systemDark: boolean,
+): ThemePreferenceSlot {
+  if (preference === 'auto') return systemDark ? 'night' : 'day'
+  return preference
 }
 
 export function resolveEffectivePalette(
-  theme: ThemeColorMode,
+  preference: ThemePreferenceMode,
   systemDark: boolean,
-  lightPalette: LightPaletteId,
-  darkPalette: DarkPaletteId,
+  dayPalette: ThemePaletteId,
+  nightPalette: ThemePaletteId,
 ): ThemePaletteId {
-  const mode = theme === 'auto' ? (systemDark ? 'dark' : 'light') : theme
-  return mode === 'dark' ? darkPalette : lightPalette
+  return resolveEffectiveSlot(preference, systemDark) === 'night' ? nightPalette : dayPalette
 }

--- a/ui/src/theme/semanticColors.spec.ts
+++ b/ui/src/theme/semanticColors.spec.ts
@@ -4,10 +4,10 @@ import { basename, extname, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import {
-  DARK_PALETTES,
-  LIGHT_PALETTES,
   THEME_PALETTES,
+  paletteAppearance,
   resolveEffectivePalette,
+  resolveEffectiveSlot,
   type ThemePaletteId,
 } from './palettes'
 
@@ -83,10 +83,9 @@ function paletteToken(id: ThemePaletteId, token: string): string {
 }
 
 describe('semantic color contract', () => {
-  it('ships two complete light cards and two complete dark cards', () => {
-    expect(LIGHT_PALETTES.map(({ id }) => id)).toEqual(['paper', 'porcelain'])
-    expect(DARK_PALETTES.map(({ id }) => id)).toEqual(['graphite', 'midnight'])
+  it('ships one universal library with four complete semantic cards', () => {
     expect(THEME_PALETTES.map(({ id }) => id)).toEqual(PALETTE_IDS)
+    expect(THEME_PALETTES.map(({ appearance }) => appearance)).toEqual(['light', 'light', 'dark', 'dark'])
     expect(new Set(PALETTE_IDS).size).toBe(4)
 
     for (const id of PALETTE_IDS) {
@@ -131,11 +130,17 @@ describe('semantic color contract', () => {
     expect(palette).toContain('.oa-palette-preview-terminal')
   })
 
-  it('resolves auto, day, and night modes through one palette selector', () => {
+  it('assigns any palette to either preference slot', () => {
+    expect(resolveEffectiveSlot('auto', false)).toBe('day')
+    expect(resolveEffectiveSlot('auto', true)).toBe('night')
+    expect(resolveEffectiveSlot('day', true)).toBe('day')
+    expect(resolveEffectiveSlot('night', false)).toBe('night')
     expect(resolveEffectivePalette('auto', false, 'porcelain', 'midnight')).toBe('porcelain')
     expect(resolveEffectivePalette('auto', true, 'porcelain', 'midnight')).toBe('midnight')
-    expect(resolveEffectivePalette('light', true, 'paper', 'graphite')).toBe('paper')
-    expect(resolveEffectivePalette('dark', false, 'paper', 'graphite')).toBe('graphite')
+    expect(resolveEffectivePalette('day', true, 'midnight', 'paper')).toBe('midnight')
+    expect(resolveEffectivePalette('night', false, 'midnight', 'paper')).toBe('paper')
+    expect(paletteAppearance('midnight')).toBe('dark')
+    expect(paletteAppearance('paper')).toBe('light')
     expect(palette).not.toMatch(/data-theme|prefers-color-scheme/)
   })
 

--- a/ui/src/theme/store.spec.ts
+++ b/ui/src/theme/store.spec.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+
+import { normalizeThemePreferences } from './store'
+
+describe('theme preference persistence', () => {
+  it('migrates the legacy light/dark shape into day/night slots', () => {
+    expect(normalizeThemePreferences({
+      theme: 'dark',
+      lightPalette: 'porcelain',
+      darkPalette: 'midnight',
+    })).toEqual({
+      theme: 'night',
+      dayPalette: 'porcelain',
+      nightPalette: 'midnight',
+    })
+  })
+
+  it('allows either slot to select any palette', () => {
+    expect(normalizeThemePreferences({
+      theme: 'day',
+      dayPalette: 'midnight',
+      nightPalette: 'paper',
+    })).toEqual({
+      theme: 'day',
+      dayPalette: 'midnight',
+      nightPalette: 'paper',
+    })
+  })
+
+  it('repairs malformed fields independently', () => {
+    expect(normalizeThemePreferences({
+      theme: 'sepia',
+      dayPalette: 'unknown',
+      nightPalette: 'graphite',
+    }, {
+      theme: 'auto',
+      dayPalette: 'porcelain',
+      nightPalette: 'midnight',
+    })).toEqual({
+      theme: 'auto',
+      dayPalette: 'porcelain',
+      nightPalette: 'graphite',
+    })
+  })
+})

--- a/ui/src/theme/store.ts
+++ b/ui/src/theme/store.ts
@@ -2,57 +2,86 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
 import {
-  DEFAULT_DARK_PALETTE,
-  DEFAULT_LIGHT_PALETTE,
-  isDarkPaletteId,
-  isLightPaletteId,
-  isThemeColorMode,
-  type DarkPaletteId,
-  type LightPaletteId,
-  type ThemeColorMode,
+  DEFAULT_DAY_PALETTE,
+  DEFAULT_NIGHT_PALETTE,
+  isThemePaletteId,
+  normalizeThemePreferenceMode,
+  type ThemePaletteId,
+  type ThemePreferenceMode,
 } from './palettes'
 
 /**
  * Color-mode and palette-pairing store.
  *
- * `'auto'` follows the OS (`prefers-color-scheme`); `'light'` / `'dark'` pin
- * it. Default is `'auto'` — unlike the locale store (which deliberately does
+ * `'auto'` follows the OS (`prefers-color-scheme`); `'day'` / `'night'` pin a
+ * preference slot. Default is `'auto'` — unlike the locale store (which deliberately does
  * NOT auto-detect), a color theme SHOULD honor the user's system setting out
  * of the box; that's the whole point of the mode.
  *
- * Persistence mirrors the locale store's loud-fail contract (i18n/store.ts):
- * a `version` bump clears stored state, NO migrate function.
+ * The storage key remains v1 so existing device preferences survive. The
+ * defensive merge below explicitly translates legacy light/dark field names;
+ * malformed values still fall back independently.
  *
- * Mode decides whether the day or night side is active; the two palette slots
- * independently choose which complete semantic card backs that side. Stays
+ * Preference decides whether the day or night slot is active; both slots may
+ * independently choose any complete semantic card. A palette's intrinsic
+ * light/dark appearance is metadata, not a slot restriction. Stays
  * pure (no DOM imports) so ui/src/theme owns all document mutations.
  */
 
-export type AppTheme = ThemeColorMode
+export type AppTheme = ThemePreferenceMode
 
-/** Cycle order for the single toggle button: auto → light → dark → auto. */
-const CYCLE: readonly AppTheme[] = ['auto', 'light', 'dark']
+/** Cycle order for the single toggle button: auto → day → night → auto. */
+const CYCLE: readonly AppTheme[] = ['auto', 'day', 'night']
+
+export interface ThemePreferences {
+  theme: AppTheme
+  dayPalette: ThemePaletteId
+  nightPalette: ThemePaletteId
+}
 
 interface ThemeStore {
   theme: AppTheme
-  lightPalette: LightPaletteId
-  darkPalette: DarkPaletteId
+  dayPalette: ThemePaletteId
+  nightPalette: ThemePaletteId
   setTheme: (theme: AppTheme) => void
-  setLightPalette: (palette: LightPaletteId) => void
-  setDarkPalette: (palette: DarkPaletteId) => void
+  setDayPalette: (palette: ThemePaletteId) => void
+  setNightPalette: (palette: ThemePaletteId) => void
   /** Advance to the next mode (drives the ActivityBar toggle). */
   cycleTheme: () => void
+}
+
+const DEFAULT_PREFERENCES: ThemePreferences = {
+  theme: 'auto',
+  dayPalette: DEFAULT_DAY_PALETTE,
+  nightPalette: DEFAULT_NIGHT_PALETTE,
+}
+
+/** Normalize both the universal-slot shape and the legacy v1 light/dark shape. */
+export function normalizeThemePreferences(
+  persisted: unknown,
+  fallback: ThemePreferences = DEFAULT_PREFERENCES,
+): ThemePreferences {
+  const stored = persisted && typeof persisted === 'object'
+    ? persisted as Record<string, unknown>
+    : {}
+  const dayPalette = isThemePaletteId(stored.dayPalette) ? stored.dayPalette : stored.lightPalette
+  const nightPalette = isThemePaletteId(stored.nightPalette) ? stored.nightPalette : stored.darkPalette
+  return {
+    theme: normalizeThemePreferenceMode(stored.theme) ?? fallback.theme,
+    dayPalette: isThemePaletteId(dayPalette) ? dayPalette : fallback.dayPalette,
+    nightPalette: isThemePaletteId(nightPalette) ? nightPalette : fallback.nightPalette,
+  }
 }
 
 export const useThemeStore = create<ThemeStore>()(
   persist(
     (set, get) => ({
       theme: 'auto',
-      lightPalette: DEFAULT_LIGHT_PALETTE,
-      darkPalette: DEFAULT_DARK_PALETTE,
+      dayPalette: DEFAULT_DAY_PALETTE,
+      nightPalette: DEFAULT_NIGHT_PALETTE,
       setTheme: (theme) => set({ theme }),
-      setLightPalette: (lightPalette) => set({ lightPalette }),
-      setDarkPalette: (darkPalette) => set({ darkPalette }),
+      setDayPalette: (dayPalette) => set({ dayPalette }),
+      setNightPalette: (nightPalette) => set({ nightPalette }),
       cycleTheme: () => {
         const i = CYCLE.indexOf(get().theme)
         set({ theme: CYCLE[(i + 1) % CYCLE.length]! })
@@ -62,16 +91,14 @@ export const useThemeStore = create<ThemeStore>()(
       // Keep this key in sync with the no-flash script in index.html.
       name: 'openalice.theme.v1',
       version: 1,
-      // The inline no-flash path validates the same three values. Keep the
-      // hydrated store equally defensive so malformed or stale local data
-      // cannot overwrite the card that was correct on first paint.
+      // The inline no-flash path performs the same migration. Keep hydration
+      // equally defensive so malformed or legacy local data cannot overwrite
+      // the card that was correct on first paint.
       merge: (persisted, current) => {
-        const stored = (persisted ?? {}) as Partial<ThemeStore>
+        const preferences = normalizeThemePreferences(persisted, current)
         return {
           ...current,
-          theme: isThemeColorMode(stored.theme) ? stored.theme : current.theme,
-          lightPalette: isLightPaletteId(stored.lightPalette) ? stored.lightPalette : current.lightPalette,
-          darkPalette: isDarkPaletteId(stored.darkPalette) ? stored.darkPalette : current.darkPalette,
+          ...preferences,
         }
       },
     },
@@ -79,7 +106,7 @@ export const useThemeStore = create<ThemeStore>()(
 )
 
 /** Persisted preferences at boot (zustand persist rehydrates localStorage sync). */
-export function readInitialThemePreferences(): Pick<ThemeStore, 'theme' | 'lightPalette' | 'darkPalette'> {
-  const { theme, lightPalette, darkPalette } = useThemeStore.getState()
-  return { theme, lightPalette, darkPalette }
+export function readInitialThemePreferences(): ThemePreferences {
+  const { theme, dayPalette, nightPalette } = useThemeStore.getState()
+  return { theme, dayPalette, nightPalette }
 }

--- a/ui/src/theme/useEffectiveTheme.ts
+++ b/ui/src/theme/useEffectiveTheme.ts
@@ -1,7 +1,12 @@
 import { useSyncExternalStore } from 'react'
 
 import { useThemeStore } from './store'
-import type { ThemePaletteId } from './palettes'
+import {
+  paletteAppearance,
+  resolveEffectiveSlot,
+  type ThemePaletteId,
+  type ThemePreferenceSlot,
+} from './palettes'
 
 const mq = window.matchMedia('(prefers-color-scheme: dark)')
 
@@ -11,28 +16,32 @@ function subscribeSystem(cb: () => void): () => void {
 }
 
 /**
- * Resolve the preference (`light | dark | auto`) to a concrete `'light' | 'dark'`
- * — `auto` follows the OS. Use this for the rare surfaces that need the actual
- * value in JS rather than via CSS: notably the xterm terminal, whose palette is
- * a JS object, not a CSS variable. CSS-driven surfaces should just read the
- * `--color-*` tokens (which resolve through the active `data-palette` card).
+ * Resolve which preference slot is active. Auto follows the OS; a palette's
+ * own light/dark appearance does not influence slot selection.
  */
-export function useEffectiveTheme(): 'light' | 'dark' {
+export function useEffectivePreferenceSlot(): ThemePreferenceSlot {
   const theme = useThemeStore((s) => s.theme)
   const systemDark = useSyncExternalStore(
     subscribeSystem,
     () => mq.matches,
     () => true,
   )
-  if (theme === 'light') return 'light'
-  if (theme === 'dark') return 'dark'
-  return systemDark ? 'dark' : 'light'
+  return resolveEffectiveSlot(theme, systemDark)
 }
 
-/** The concrete semantic card selected for the currently effective mode. */
+/** The concrete semantic card selected for the currently active slot. */
 export function useEffectivePalette(): ThemePaletteId {
-  const mode = useEffectiveTheme()
-  const lightPalette = useThemeStore((s) => s.lightPalette)
-  const darkPalette = useThemeStore((s) => s.darkPalette)
-  return mode === 'dark' ? darkPalette : lightPalette
+  const slot = useEffectivePreferenceSlot()
+  const dayPalette = useThemeStore((s) => s.dayPalette)
+  const nightPalette = useThemeStore((s) => s.nightPalette)
+  return slot === 'night' ? nightPalette : dayPalette
+}
+
+/**
+ * Resolve the active card's intrinsic appearance. Use this for JS surfaces
+ * such as xterm and chart redraws; assigning Midnight to Day must still report
+ * a dark color scheme to the shell.
+ */
+export function useEffectiveTheme(): 'light' | 'dark' {
+  return paletteAppearance(useEffectivePalette())
 }


### PR DESCRIPTION
## What changed

- replaced the light-only/dark-only palette buckets with one universal palette library
- changed the persisted mode model to Auto / Day / Night preference slots
- lets either Day or Night select any of Paper, Porcelain, Graphite, or Midnight
- keeps each palette's intrinsic light/dark appearance for CSS `color-scheme`, xterm reporting, native controls, and chart redraws
- migrates existing `lightPalette` / `darkPalette` and `light` / `dark` preferences before first paint
- updated Settings, the Activity Bar toggle, and all four locales

## Why

The previous model conflated the system preference slot with a palette's visual appearance. That made palettes subordinate to light/dark mode and prevented valid combinations such as Day → Midnight or Night → Paper. It also split color state across two concepts that were harder to test end to end.

The new model treats palettes as universal semantic assets. Auto only chooses between the configured Day and Night slots; the selected palette then owns its actual appearance semantics.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 336 files passed, 3268 tests passed
- targeted theme persistence, no-flash bootstrap, semantic color, and terminal appearance tests
- browser: verified all four cards in both slots, cross-appearance assignments, persistence after reload, no horizontal overflow, and Activity Bar Auto → Day → Night cycling
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
