### PR TITLE
Add Linen, Moss, and Iris terminal-aware palettes

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -17,7 +17,7 @@
           var t = storedTheme === 'day' || storedTheme === 'night' || storedTheme === 'auto'
             ? storedTheme
             : storedTheme === 'light' ? 'day' : storedTheme === 'dark' ? 'night' : 'auto';
-          var palettes = ['paper', 'porcelain', 'graphite', 'midnight'];
+          var palettes = ['paper', 'porcelain', 'linen', 'graphite', 'midnight', 'moss', 'iris'];
           var storedDay = palettes.indexOf(state.dayPalette) >= 0 ? state.dayPalette : state.lightPalette;
           var storedNight = palettes.indexOf(state.nightPalette) >= 0 ? state.nightPalette : state.darkPalette;
           var day = palettes.indexOf(storedDay) >= 0 ? storedDay : 'paper';

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -644,12 +644,18 @@ export const en = {
   theme: {
     mode: { auto: 'Auto', day: 'Day', night: 'Night' },
     switchTo: 'Switch to {{mode}}',
-    palette: { paper: 'Paper', porcelain: 'Porcelain', graphite: 'Graphite', midnight: 'Midnight' },
+    palette: {
+      paper: 'Paper', porcelain: 'Porcelain', linen: 'Linen',
+      graphite: 'Graphite', midnight: 'Midnight', moss: 'Moss', iris: 'Iris',
+    },
     paletteDescription: {
       paper: 'Warm, editorial neutrals',
       porcelain: 'Cool, crisp workspace',
+      linen: 'Oat, ink, and terracotta',
       graphite: 'Neutral low-glare dark',
       midnight: 'Deep blue night palette',
+      moss: 'Forest ink with soft amber',
+      iris: 'Violet dusk with cool cyan',
     },
   },
   dev: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -633,12 +633,18 @@ export const ja: Resources = {
   theme: {
     mode: { auto: '自動', day: '昼', night: '夜' },
     switchTo: '{{mode}}に切り替え',
-    palette: { paper: 'ペーパー', porcelain: 'ポーセリン', graphite: 'グラファイト', midnight: 'ミッドナイト' },
+    palette: {
+      paper: 'ペーパー', porcelain: 'ポーセリン', linen: 'リネン',
+      graphite: 'グラファイト', midnight: 'ミッドナイト', moss: 'モス', iris: 'アイリス',
+    },
     paletteDescription: {
       paper: '温かみのある編集向け中間色',
       porcelain: '涼しく鮮明なワークスペース',
+      linen: 'オート麦色、墨色、テラコッタ',
       graphite: '低反射のニュートラルダーク',
       midnight: '深いブルーの夜間パレット',
+      moss: '森の墨色と柔らかな琥珀色',
+      iris: '紫の夕暮れと涼やかなシアン',
     },
   },
   dev: {

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -641,12 +641,18 @@ export const zhHant: Resources = {
   theme: {
     mode: { auto: '自動', day: '日間', night: '暗夜' },
     switchTo: '切換到{{mode}}',
-    palette: { paper: '紙張', porcelain: '白瓷', graphite: '石墨', midnight: '午夜' },
+    palette: {
+      paper: '紙張', porcelain: '白瓷', linen: '亞麻',
+      graphite: '石墨', midnight: '午夜', moss: '苔色', iris: '鳶尾',
+    },
     paletteDescription: {
       paper: '溫暖的編輯風中性色',
       porcelain: '清爽的冷調工作區',
+      linen: '燕麥紙、墨棕與陶土色',
       graphite: '低眩光的中性深色',
       midnight: '深藍調暗夜色卡',
+      moss: '墨綠底色與柔和琥珀',
+      iris: '紫藍暮色與冷青點色',
     },
   },
   dev: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -633,12 +633,18 @@ export const zh: Resources = {
   theme: {
     mode: { auto: '自动', day: '日间', night: '暗夜' },
     switchTo: '切换到{{mode}}',
-    palette: { paper: '纸张', porcelain: '白瓷', graphite: '石墨', midnight: '午夜' },
+    palette: {
+      paper: '纸张', porcelain: '白瓷', linen: '亚麻',
+      graphite: '石墨', midnight: '午夜', moss: '苔色', iris: '鸢尾',
+    },
     paletteDescription: {
       paper: '温暖的编辑风中性色',
       porcelain: '清爽的冷调工作区',
+      linen: '燕麦纸、墨棕与陶土色',
       graphite: '低眩光的中性深色',
       midnight: '深蓝调暗夜色卡',
+      moss: '墨绿底色与柔和琥珀',
+      iris: '紫蓝暮色与冷青点色',
     },
   },
   dev: {

--- a/ui/src/theme/noFlashTheme.spec.ts
+++ b/ui/src/theme/noFlashTheme.spec.ts
@@ -53,8 +53,8 @@ describe('no-flash theme bootstrap', () => {
   })
 
   it('uses the system only to select a slot in Auto', () => {
-    const state = { theme: 'auto', dayPalette: 'midnight', nightPalette: 'paper' }
-    expect(applyNoFlashTheme(state, false).palette).toBe('midnight')
-    expect(applyNoFlashTheme(state, true).palette).toBe('paper')
+    const state = { theme: 'auto', dayPalette: 'linen', nightPalette: 'iris' }
+    expect(applyNoFlashTheme(state, false).palette).toBe('linen')
+    expect(applyNoFlashTheme(state, true).palette).toBe('iris')
   })
 })

--- a/ui/src/theme/palette.css
+++ b/ui/src/theme/palette.css
@@ -192,6 +192,98 @@
   );
 }
 
+:root[data-palette="linen"],
+[data-palette-preview="linen"] {
+  color-scheme: light;
+
+  --background: #f6f0e6;
+  --foreground: #342c27;
+  --card: #fffaf1;
+  --card-foreground: #342c27;
+  --popover: #fffaf1;
+  --popover-foreground: #342c27;
+  --primary: #9a4f3d;
+  --primary-foreground: #fffaf1;
+  --secondary: #ece2d3;
+  --secondary-foreground: #342c27;
+  --muted: #ddd0bd;
+  --muted-foreground: #73675d;
+  --accent: rgba(154, 79, 61, 0.07);
+  --accent-foreground: #342c27;
+  --destructive: #b83c38;
+  --destructive-foreground: #fffaf1;
+  --border: #d2c2ad;
+  --input: #d2c2ad;
+  --ring: #9a4f3d;
+
+  --accent-strong: rgba(154, 79, 61, 0.12);
+  --primary-muted: rgba(154, 79, 61, 0.15);
+  --success: #427354;
+  --success-foreground: #fffaf1;
+  --warning: #956118;
+  --warning-foreground: #fffaf1;
+  --warning-background: #f5e6c5;
+  --warning-border: #bd8b36;
+  --info: #4f6f8f;
+  --info-foreground: #fffaf1;
+  --ai-action: #7c5e8f;
+  --ai-action-foreground: #fffaf1;
+  --backdrop: rgba(35, 26, 22, 0.5);
+  --code-background: rgba(52, 44, 39, 0.075);
+  --report-canvas: #ffffff;
+  --shadow-color: #342c27;
+
+  --terminal-background: #f8f1e6;
+  --terminal-foreground: #352d28;
+  --terminal-cursor: #9a4f3d;
+  --terminal-cursor-accent: #fffaf1;
+  --terminal-selection-background: rgba(154, 79, 61, 0.24);
+  --terminal-selection-foreground: #342c27;
+  --terminal-black: #342c27;
+  --terminal-red: #b83c38;
+  --terminal-green: #427354;
+  --terminal-yellow: #956118;
+  --terminal-blue: #4f6f8f;
+  --terminal-magenta: #7c5e8f;
+  --terminal-cyan: #3e7772;
+  --terminal-white: #786b60;
+  --terminal-bright-black: #5f554d;
+  --terminal-bright-red: #9d302f;
+  --terminal-bright-green: #32684a;
+  --terminal-bright-yellow: #784b0d;
+  --terminal-bright-blue: #365a79;
+  --terminal-bright-magenta: #674b7b;
+  --terminal-bright-cyan: #286762;
+  --terminal-bright-white: #221d1a;
+
+  --chart-1: #9a4f3d;
+  --chart-2: #427354;
+  --chart-3: #956118;
+  --chart-4: #7c5e8f;
+  --chart-5: #3e7772;
+  --chart-positive: #427354;
+  --chart-negative: #b83c38;
+  --chart-positive-muted: rgba(66, 115, 84, 0.3);
+  --chart-negative-muted: rgba(184, 60, 56, 0.3);
+  --chart-axis: #73675d;
+  --chart-grid: #d2c2ad;
+
+  --sidebar: #ece2d3;
+  --sidebar-foreground: #342c27;
+  --sidebar-primary: #9a4f3d;
+  --sidebar-primary-foreground: #fffaf1;
+  --sidebar-accent: #ddd0bd;
+  --sidebar-accent-foreground: #342c27;
+  --sidebar-border: #d2c2ad;
+  --sidebar-ring: #9a4f3d;
+
+  --app-background-wash: radial-gradient(
+    circle at 50% 22%,
+    rgba(154, 79, 61, 0.055),
+    transparent 38rem
+  );
+}
+
 :root[data-palette="graphite"],
 [data-palette-preview="graphite"] {
   color-scheme: dark;
@@ -372,6 +464,190 @@
   --app-background-wash: radial-gradient(
     circle at 50% 24%,
     rgba(90, 162, 255, 0.065),
+    transparent 38rem
+  );
+}
+
+:root[data-palette="moss"],
+[data-palette-preview="moss"] {
+  color-scheme: dark;
+
+  --background: #0e1512;
+  --foreground: #d8e2d8;
+  --card: #151e19;
+  --card-foreground: #d8e2d8;
+  --popover: #151e19;
+  --popover-foreground: #d8e2d8;
+  --primary: #8fbe78;
+  --primary-foreground: #0c140f;
+  --secondary: #111a16;
+  --secondary-foreground: #d8e2d8;
+  --muted: #1d2922;
+  --muted-foreground: #91a093;
+  --accent: rgba(143, 190, 120, 0.075);
+  --accent-foreground: #d8e2d8;
+  --destructive: #e07a6f;
+  --destructive-foreground: #1c0b09;
+  --border: #2a3930;
+  --input: #2a3930;
+  --ring: #8fbe78;
+
+  --accent-strong: rgba(143, 190, 120, 0.13);
+  --primary-muted: rgba(143, 190, 120, 0.17);
+  --success: #7fc59a;
+  --success-foreground: #09150e;
+  --warning: #d6ad62;
+  --warning-foreground: #1d1609;
+  --warning-background: #211b0f;
+  --warning-border: #806633;
+  --info: #81b4c4;
+  --info-foreground: #071417;
+  --ai-action: #b49ad1;
+  --ai-action-foreground: #160f20;
+  --backdrop: rgba(3, 8, 5, 0.62);
+  --code-background: rgba(2, 7, 4, 0.4);
+  --report-canvas: #ffffff;
+  --shadow-color: #020604;
+
+  --terminal-background: #0b120f;
+  --terminal-foreground: #dce7dc;
+  --terminal-cursor: #8fbe78;
+  --terminal-cursor-accent: #0b120f;
+  --terminal-selection-background: rgba(143, 190, 120, 0.3);
+  --terminal-selection-foreground: #f2f7f1;
+  --terminal-black: #33433a;
+  --terminal-red: #e07a6f;
+  --terminal-green: #8ccf9f;
+  --terminal-yellow: #d6ad62;
+  --terminal-blue: #81b4c4;
+  --terminal-magenta: #b49ad1;
+  --terminal-cyan: #75c3b2;
+  --terminal-white: #dce7dc;
+  --terminal-bright-black: #607166;
+  --terminal-bright-red: #ef9a90;
+  --terminal-bright-green: #a9dfb8;
+  --terminal-bright-yellow: #e6c681;
+  --terminal-bright-blue: #a3cad5;
+  --terminal-bright-magenta: #cbb7df;
+  --terminal-bright-cyan: #98d7ca;
+  --terminal-bright-white: #f3f7f2;
+
+  --chart-1: #8fbe78;
+  --chart-2: #7fc59a;
+  --chart-3: #d6ad62;
+  --chart-4: #b49ad1;
+  --chart-5: #81b4c4;
+  --chart-positive: #7fc59a;
+  --chart-negative: #e07a6f;
+  --chart-positive-muted: rgba(127, 197, 154, 0.33);
+  --chart-negative-muted: rgba(224, 122, 111, 0.33);
+  --chart-axis: #91a093;
+  --chart-grid: #2a3930;
+
+  --sidebar: #111a16;
+  --sidebar-foreground: #d8e2d8;
+  --sidebar-primary: #8fbe78;
+  --sidebar-primary-foreground: #0c140f;
+  --sidebar-accent: #1d2922;
+  --sidebar-accent-foreground: #d8e2d8;
+  --sidebar-border: #2a3930;
+  --sidebar-ring: #8fbe78;
+
+  --app-background-wash: radial-gradient(
+    circle at 50% 26%,
+    rgba(143, 190, 120, 0.055),
+    transparent 38rem
+  );
+}
+
+:root[data-palette="iris"],
+[data-palette-preview="iris"] {
+  color-scheme: dark;
+
+  --background: #11101a;
+  --foreground: #e7e2f2;
+  --card: #191724;
+  --card-foreground: #e7e2f2;
+  --popover: #191724;
+  --popover-foreground: #e7e2f2;
+  --primary: #9b8cff;
+  --primary-foreground: #120f22;
+  --secondary: #15131f;
+  --secondary-foreground: #e7e2f2;
+  --muted: #242136;
+  --muted-foreground: #9b96ad;
+  --accent: rgba(155, 140, 255, 0.08);
+  --accent-foreground: #e7e2f2;
+  --destructive: #f1768e;
+  --destructive-foreground: #210b12;
+  --border: #322e46;
+  --input: #322e46;
+  --ring: #9b8cff;
+
+  --accent-strong: rgba(155, 140, 255, 0.14);
+  --primary-muted: rgba(155, 140, 255, 0.18);
+  --success: #64c7a4;
+  --success-foreground: #081510;
+  --warning: #e0b76d;
+  --warning-foreground: #201607;
+  --warning-background: #221a0d;
+  --warning-border: #84652e;
+  --info: #82b8ff;
+  --info-foreground: #081426;
+  --ai-action: #d28cff;
+  --ai-action-foreground: #1c0c27;
+  --backdrop: rgba(5, 3, 12, 0.64);
+  --code-background: rgba(4, 3, 10, 0.42);
+  --report-canvas: #ffffff;
+  --shadow-color: #05030c;
+
+  --terminal-background: #0d0c15;
+  --terminal-foreground: #e8e4f3;
+  --terminal-cursor: #9b8cff;
+  --terminal-cursor-accent: #0d0c15;
+  --terminal-selection-background: rgba(155, 140, 255, 0.32);
+  --terminal-selection-foreground: #ffffff;
+  --terminal-black: #353147;
+  --terminal-red: #f1768e;
+  --terminal-green: #6fd2ad;
+  --terminal-yellow: #e0b76d;
+  --terminal-blue: #82b8ff;
+  --terminal-magenta: #d49aff;
+  --terminal-cyan: #69c8d7;
+  --terminal-white: #e8e4f3;
+  --terminal-bright-black: #68627c;
+  --terminal-bright-red: #ff9aab;
+  --terminal-bright-green: #91e0c1;
+  --terminal-bright-yellow: #edcc8f;
+  --terminal-bright-blue: #a8cdff;
+  --terminal-bright-magenta: #e3b8ff;
+  --terminal-bright-cyan: #90dbe6;
+  --terminal-bright-white: #faf8ff;
+
+  --chart-1: #9b8cff;
+  --chart-2: #64c7a4;
+  --chart-3: #e0b76d;
+  --chart-4: #d28cff;
+  --chart-5: #69c8d7;
+  --chart-positive: #64c7a4;
+  --chart-negative: #f1768e;
+  --chart-positive-muted: rgba(100, 199, 164, 0.34);
+  --chart-negative-muted: rgba(241, 118, 142, 0.34);
+  --chart-axis: #9b96ad;
+  --chart-grid: #322e46;
+
+  --sidebar: #15131f;
+  --sidebar-foreground: #e7e2f2;
+  --sidebar-primary: #9b8cff;
+  --sidebar-primary-foreground: #120f22;
+  --sidebar-accent: #242136;
+  --sidebar-accent-foreground: #e7e2f2;
+  --sidebar-border: #322e46;
+  --sidebar-ring: #9b8cff;
+
+  --app-background-wash: radial-gradient(
+    circle at 50% 24%,
+    rgba(155, 140, 255, 0.065),
     transparent 38rem
   );
 }

--- a/ui/src/theme/palettes.ts
+++ b/ui/src/theme/palettes.ts
@@ -1,4 +1,11 @@
-export type ThemePaletteId = 'paper' | 'porcelain' | 'graphite' | 'midnight'
+export type ThemePaletteId =
+  | 'paper'
+  | 'porcelain'
+  | 'linen'
+  | 'graphite'
+  | 'midnight'
+  | 'moss'
+  | 'iris'
 export type ThemePaletteAppearance = 'light' | 'dark'
 export type ThemePreferenceMode = 'auto' | 'day' | 'night'
 export type ThemePreferenceSlot = Exclude<ThemePreferenceMode, 'auto'>
@@ -21,12 +28,15 @@ export const DEFAULT_NIGHT_PALETTE: ThemePaletteId = 'graphite'
 export const THEME_PALETTES = [
   { id: 'paper', appearance: 'light', labelKey: 'theme.palette.paper', descriptionKey: 'theme.paletteDescription.paper' },
   { id: 'porcelain', appearance: 'light', labelKey: 'theme.palette.porcelain', descriptionKey: 'theme.paletteDescription.porcelain' },
+  { id: 'linen', appearance: 'light', labelKey: 'theme.palette.linen', descriptionKey: 'theme.paletteDescription.linen' },
   { id: 'graphite', appearance: 'dark', labelKey: 'theme.palette.graphite', descriptionKey: 'theme.paletteDescription.graphite' },
   { id: 'midnight', appearance: 'dark', labelKey: 'theme.palette.midnight', descriptionKey: 'theme.paletteDescription.midnight' },
+  { id: 'moss', appearance: 'dark', labelKey: 'theme.palette.moss', descriptionKey: 'theme.paletteDescription.moss' },
+  { id: 'iris', appearance: 'dark', labelKey: 'theme.palette.iris', descriptionKey: 'theme.paletteDescription.iris' },
 ] as const satisfies readonly ThemePaletteDefinition[]
 
 export function isThemePaletteId(value: unknown): value is ThemePaletteId {
-  return value === 'paper' || value === 'porcelain' || value === 'graphite' || value === 'midnight'
+  return THEME_PALETTES.some(({ id }) => id === value)
 }
 
 export function isThemePreferenceMode(value: unknown): value is ThemePreferenceMode {

--- a/ui/src/theme/semanticColors.spec.ts
+++ b/ui/src/theme/semanticColors.spec.ts
@@ -38,7 +38,9 @@ const CORE_TOKENS = [
   'ring',
 ] as const
 
-const PALETTE_IDS: readonly ThemePaletteId[] = ['paper', 'porcelain', 'graphite', 'midnight']
+const PALETTE_IDS: readonly ThemePaletteId[] = [
+  'paper', 'porcelain', 'linen', 'graphite', 'midnight', 'moss', 'iris',
+]
 
 const ALLOWED_LITERAL_COLOR_FILES = new Set([
   // Single product color authority.
@@ -82,11 +84,26 @@ function paletteToken(id: ThemePaletteId, token: string): string {
   return value!
 }
 
+function hexContrast(a: string, b: string): number {
+  const luminance = (hex: string): number => {
+    expect(hex).toMatch(/^#[\da-f]{6}$/i)
+    const channels = [1, 3, 5].map((start) => {
+      const value = Number.parseInt(hex.slice(start, start + 2), 16) / 255
+      return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+    })
+    return channels[0]! * 0.2126 + channels[1]! * 0.7152 + channels[2]! * 0.0722
+  }
+  const [lighter, darker] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (lighter! + 0.05) / (darker! + 0.05)
+}
+
 describe('semantic color contract', () => {
-  it('ships one universal library with four complete semantic cards', () => {
+  it('ships one universal library with seven complete semantic cards', () => {
     expect(THEME_PALETTES.map(({ id }) => id)).toEqual(PALETTE_IDS)
-    expect(THEME_PALETTES.map(({ appearance }) => appearance)).toEqual(['light', 'light', 'dark', 'dark'])
-    expect(new Set(PALETTE_IDS).size).toBe(4)
+    expect(THEME_PALETTES.map(({ appearance }) => appearance)).toEqual([
+      'light', 'light', 'light', 'dark', 'dark', 'dark', 'dark',
+    ])
+    expect(new Set(PALETTE_IDS).size).toBe(7)
 
     for (const id of PALETTE_IDS) {
       const block = paletteBlock(id)
@@ -97,7 +114,7 @@ describe('semantic color contract', () => {
     }
   })
 
-  it('keeps every semantic token symmetric across all four cards', () => {
+  it('keeps every semantic token symmetric across all seven cards', () => {
     const tokens = [...paletteBlock('paper').matchAll(/^\s*(--[\w-]+):/gm)].map((match) => match[1])
     expect(tokens.length).toBeGreaterThan(CORE_TOKENS.length)
 
@@ -107,7 +124,7 @@ describe('semantic color contract', () => {
     }
   })
 
-  it('keeps the four visible palette preview signatures distinct', () => {
+  it('keeps all visible palette preview signatures distinct', () => {
     const previewTokens = [
       'background',
       'secondary',
@@ -130,6 +147,22 @@ describe('semantic color contract', () => {
     expect(palette).toContain('.oa-palette-preview-terminal')
   })
 
+  it('keeps the new product and ANSI text roles at normal-text contrast', () => {
+    const ansiTokens = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'] as const
+    for (const id of ['linen', 'moss', 'iris'] as const) {
+      expect(hexContrast(paletteToken(id, 'foreground'), paletteToken(id, 'background')), id).toBeGreaterThanOrEqual(4.5)
+      expect(hexContrast(paletteToken(id, 'muted-foreground'), paletteToken(id, 'background')), id).toBeGreaterThanOrEqual(4.5)
+      expect(hexContrast(paletteToken(id, 'primary-foreground'), paletteToken(id, 'primary')), id).toBeGreaterThanOrEqual(4.5)
+      expect(hexContrast(paletteToken(id, 'terminal-foreground'), paletteToken(id, 'terminal-background')), id).toBeGreaterThanOrEqual(4.5)
+      for (const token of ansiTokens) {
+        expect(
+          hexContrast(paletteToken(id, `terminal-${token}`), paletteToken(id, 'terminal-background')),
+          `${id}: terminal-${token}`,
+        ).toBeGreaterThanOrEqual(4.5)
+      }
+    }
+  })
+
   it('assigns any palette to either preference slot', () => {
     expect(resolveEffectiveSlot('auto', false)).toBe('day')
     expect(resolveEffectiveSlot('auto', true)).toBe('night')
@@ -139,8 +172,13 @@ describe('semantic color contract', () => {
     expect(resolveEffectivePalette('auto', true, 'porcelain', 'midnight')).toBe('midnight')
     expect(resolveEffectivePalette('day', true, 'midnight', 'paper')).toBe('midnight')
     expect(resolveEffectivePalette('night', false, 'midnight', 'paper')).toBe('paper')
+    expect(resolveEffectivePalette('day', false, 'moss', 'linen')).toBe('moss')
+    expect(resolveEffectivePalette('night', true, 'iris', 'linen')).toBe('linen')
     expect(paletteAppearance('midnight')).toBe('dark')
     expect(paletteAppearance('paper')).toBe('light')
+    expect(paletteAppearance('linen')).toBe('light')
+    expect(paletteAppearance('moss')).toBe('dark')
+    expect(paletteAppearance('iris')).toBe('dark')
     expect(palette).not.toMatch(/data-theme|prefers-color-scheme/)
   })
 

--- a/ui/src/theme/store.spec.ts
+++ b/ui/src/theme/store.spec.ts
@@ -20,12 +20,12 @@ describe('theme preference persistence', () => {
   it('allows either slot to select any palette', () => {
     expect(normalizeThemePreferences({
       theme: 'day',
-      dayPalette: 'midnight',
-      nightPalette: 'paper',
+      dayPalette: 'moss',
+      nightPalette: 'linen',
     })).toEqual({
       theme: 'day',
-      dayPalette: 'midnight',
-      nightPalette: 'paper',
+      dayPalette: 'moss',
+      nightPalette: 'linen',
     })
   })
 


### PR DESCRIPTION
## What changed

- added three complete universal semantic palettes:
  - **Linen** — warm oat, ink, and terracotta light palette
  - **Moss** — low-glare forest ink with soft amber
  - **Iris** — violet dusk with cool cyan
- defined the full product, chart, sidebar, terminal, selection, cursor, and ANSI 16-color vocabulary for each palette
- added the palettes to the no-flash bootstrap allowlist and all four locales
- extended persistence and semantic-card contracts to cover the new palette IDs
- added normal-text contrast assertions for product text, muted text, primary buttons, terminal text, and ANSI red/green/yellow/blue/magenta/cyan

## Why

The universal palette model needed visually distinct choices that exercise more than the existing neutral and blue families. These cards are intentionally designed from the terminal outward so the product shell and xterm remain one coherent surface.

## Browser and TUI validation

- reviewed all seven cards in both Day and Night selectors
- entered the demo xterm replay with Linen, Moss, and Iris
- verified ANSI emphasis colors, terminal background/foreground, selection roles, shell chrome, and sidebar colors
- hot-switched an already mounted TUI from Day/Linen to Night/Iris and confirmed the active xterm recolored
- audited contrast; all new normal-text and ANSI pairs are at least 4.5:1

## Checks

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 336 files passed, 3269 tests passed
- targeted semantic color, persistence, no-flash bootstrap, and terminal appearance tests
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
