### PR TITLE
Fix native agent AI launch disclosure

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -91,13 +91,27 @@ model id so it cannot leak across a later model change. Follow
 [[docs/model-semantics-and-runtime-injection.md]] for the full contract.
 
 Quick Chat must summarize the launch configuration behind its credential pill:
-the effective model ID and context limit are visible before Send. For an
-existing Workspace these values come from its CLI-native config; selecting a
-different credential previews the model that credential will inject and the
-global context default. The adjacent adjustment action opens that Workspace's
-AI injector when a target exists, and falls back to AI Provider settings before
-the first Workspace has been created. Saving the Workspace modal refreshes this
-summary without requiring a page reload.
+the effective model ID and every context limit actually declared by the native
+project config are visible before Send. For an existing Workspace these values
+come from its CLI-native config; selecting a different Pi/opencode credential
+previews the model that credential will inject and the global context default.
+Claude Code and Codex Workspace overrides show their model but omit context
+because those native project files do not declare one. The adjacent adjustment
+action opens that Workspace's AI injector for all four runtimes, and falls back
+to AI Provider settings before the first Workspace has been created. Saving the
+Workspace modal refreshes this summary without requiring a page reload.
+Their default remains the CLI's own global login and configuration: Alice never
+chooses the first compatible vault credential simply because one exists. Only
+an explicit Workspace binding or creation default opts into injection.
+
+Claude Code can place global onboarding and per-project trust screens before an
+interactive seeded prompt even after the same Workspace passes a headless
+provider probe. Its current CLI exposes authentication status but no supported
+status/accept command for these two gates. OpenAlice therefore reads only the
+existing completion booleans in Claude's native state and displays an advisory
+before launch. It never writes those booleans, substitutes a private config
+directory, or treats the advisory as a provider-readiness failure. An unknown
+or changed native state shape fails open and leaves Claude in control.
 
 Provider model catalogs are curated suggestions, not allowlists. Keep the
 free-text model field so a newly released or project-specific model remains

--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -120,6 +120,21 @@ resolved launch value as if it were already on disk. A launch surface
 distinguishes a Workspace-local binding from a credential that will be written
 only when the next session starts. Creation defaults are also explicitly
 creation-time policy: changing one never rewrites an existing Workspace.
+This disclosure applies to all four supported Agent runtimes. Claude Code and
+Codex use their native global login and global runtime configuration by default.
+Merely storing a compatible credential in Alice never selects or injects it;
+only an explicit Workspace binding or explicit new-Workspace creation default
+overrides the native fallback. When a Workspace-local override exists its real
+model must be shown instead of a generic “runtime managed” label. Their native
+project files do not declare a context limit, so the UI omits that field rather
+than borrowing the Pi/opencode injection default.
+
+Headless provider readiness does not prove that an interactive TUI can consume
+its first queued prompt immediately. A native runtime may still own global
+onboarding or per-project trust gates. OpenAlice may expose those gates as
+read-only, best-effort launch guidance, but it must not mark private global
+state complete or accept trust on the user's behalf. Unknown native state is
+advisory and fail-open; it never becomes a fabricated ready/not-ready fact.
 
 The test-before-save gate follows the same boundary as the probe. Changes to
 the key, endpoint, wire shape, authentication mode, or model require a fresh

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -42,6 +42,8 @@ function build(opts: {
   workspaces?: any[];
   sessionsByWorkspace?: Record<string, any[]>;
   recentChatWorkspaceId?: string | null;
+  claudeConfig?: WorkspaceAiCred | null;
+  claudeInteractiveSetupStatus?: 'ready' | 'runtime-onboarding-required' | 'workspace-trust-required' | 'unknown';
   opencodeConfig?: WorkspaceAiCred | null;
   opencodeRuntimeSource?: 'global-config' | 'global-login' | 'managed-runtime';
   runtimeWorkspace?: any;
@@ -60,7 +62,12 @@ function build(opts: {
     writeAiConfig: vi.fn(async () => {}),
     readAiConfig: vi.fn(async () => opts.opencodeConfig ?? null),
   };
-  const claude = { id: 'claude', namePrefix: 'c' };
+  const claude = {
+    id: 'claude',
+    namePrefix: 'c',
+    readAiConfig: vi.fn(async () => opts.claudeConfig ?? null),
+    readInteractiveSetupStatus: vi.fn(async () => opts.claudeInteractiveSetupStatus ?? 'ready'),
+  };
   const shell = { id: 'shell', kind: 'utility', namePrefix: 'sh' };
   const adapters: Record<string, any> = { opencode, claude, shell };
   const spawn = vi.fn((_wsId: string, ctx: any) => ({
@@ -261,10 +268,69 @@ describe('GET /credentials — Quick Chat launch metadata', () => {
 
     expect(result.status).toBe(200);
     expect(result.body).toEqual({
+      configured: true,
       slug: 'google-1',
       model: 'gemini-3.5-flash',
       contextWindow: 512_000,
       wireShape: 'google-generative-ai',
+    });
+  });
+
+  it('keeps hand-edited Workspace config visible when no vault key matches', async () => {
+    vi.mocked(readCredentials).mockResolvedValue({});
+    const { app } = build({
+      opencodeConfig: {
+        apiKey: 'hand-edited-key',
+        model: 'local-manual-model',
+        contextWindow: 128_000,
+        wireShape: 'openai-chat',
+      },
+    });
+
+    const result = await get(app, '/ws-1/agent-config/opencode/credential');
+
+    expect(result).toEqual({
+      status: 200,
+      body: {
+        configured: true,
+        slug: null,
+        model: 'local-manual-model',
+        contextWindow: 128_000,
+        wireShape: 'openai-chat',
+      },
+    });
+  });
+
+  it('returns Claude project metadata and its native interactive setup gate', async () => {
+    vi.mocked(readCredentials).mockResolvedValue({
+      'minimax-1': {
+        vendor: 'minimax',
+        authType: 'api-key',
+        apiKey: 'minimax-test-key',
+        wires: { anthropic: 'https://api.example.test/anthropic' },
+      },
+    });
+    const { app } = build({
+      claudeConfig: {
+        apiKey: 'minimax-test-key',
+        model: 'MiniMax-M2.5',
+        wireShape: 'anthropic',
+      },
+      claudeInteractiveSetupStatus: 'workspace-trust-required',
+    });
+
+    const result = await get(app, '/ws-1/agent-config/claude/credential');
+
+    expect(result).toEqual({
+      status: 200,
+      body: {
+        configured: true,
+        slug: 'minimax-1',
+        model: 'MiniMax-M2.5',
+        contextWindow: null,
+        wireShape: 'anthropic',
+        interactiveSetupStatus: 'workspace-trust-required',
+      },
     });
   });
 
@@ -300,6 +366,7 @@ describe('GET /credentials — Quick Chat launch metadata', () => {
     expect(credential).toEqual({
       status: 200,
       body: {
+        configured: true,
         slug: 'google-1',
         model: 'gemini-3.5-flash',
         contextWindow: 512_000,

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -574,15 +574,16 @@ export function createWorkspaceRoutes(
     }
   });
 
-  // Detect which vault credential a workspace's loginless agent is currently
-  // configured with (null when none / hand-edited). The "which cred is this
-  // workspace using" probe the overwrite-notice and reuse-default both build on.
+  // Detect which vault credential a workspace agent is currently configured
+  // with. A null slug can still be a real hand-edited native config; returning
+  // that distinction is what lets launch surfaces describe Claude/Codex as
+  // truthfully as the loginless runtimes.
   const detectWorkspaceCred = async (
     meta: WorkspaceMeta,
     agentId: string,
     credentials: Record<string, Credential>,
   ): Promise<{
-    slug: string;
+    slug: string | null;
     model: string | null;
     contextWindow: number | null;
     wireShape: WireShape | null;
@@ -593,15 +594,13 @@ export function createWorkspaceRoutes(
     const cfg = await adapter.readAiConfig(meta.dir).catch(() => null);
     if (!cfg) return null;
     const slug = matchCredentialByApiKey(credentials, cfg.apiKey);
-    return slug
-      ? {
-          slug,
-          model: cfg.model ?? null,
-          contextWindow: cfg.contextWindow ?? null,
-          wireShape: cfg.wireShape ?? null,
-          reasoning: cfg.reasoning ?? null,
-        }
-      : null;
+    return {
+      slug,
+      model: cfg.model ?? null,
+      contextWindow: cfg.contextWindow ?? null,
+      wireShape: cfg.wireShape ?? null,
+      reasoning: cfg.reasoning ?? null,
+    };
   };
 
   // ── templates / agents ───────────────────────────────────────────────────
@@ -2005,8 +2004,8 @@ export function createWorkspaceRoutes(
   });
 
   // Which vault credential this workspace's agent is currently configured with
-  // (slug + effective model/protocol/context), or null. Feeds the quick-chat
-  // composer's overwrite notice and its compact launch-config summary.
+  // (slug + effective model/protocol/context), plus any native pre-prompt setup
+  // gate the adapter can inspect without changing runtime-owned state.
   // Ordinary detection does not overwrite config. The Pi adapter may perform
   // its one-time legacy `.pi-agent` layout migration before reading.
   app.get('/:id/agent-config/:agent/credential', async (c) => {
@@ -2016,18 +2015,24 @@ export function createWorkspaceRoutes(
     const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
     if (!meta) return c.json({ error: 'not_found' }, 404);
     try {
-      const detected = await detectWorkspaceCred(meta, agent, await readCredentials());
+      const adapter = svc.adapters.get(agent);
+      const [detected, interactiveSetupStatus] = await Promise.all([
+        detectWorkspaceCred(meta, agent, await readCredentials()),
+        adapter?.readInteractiveSetupStatus?.(meta.dir).catch(() => 'unknown' as const) ?? null,
+      ]);
       return c.json({
+        configured: detected !== null,
         slug: detected?.slug ?? null,
         model: detected?.model ?? null,
         contextWindow: detected?.contextWindow ?? null,
         wireShape: detected?.wireShape ?? null,
         ...(typeof detected?.reasoning === 'boolean' ? { reasoning: detected.reasoning } : {}),
+        ...(interactiveSetupStatus !== null ? { interactiveSetupStatus } : {}),
       });
     } catch (err) {
       if (err instanceof PathTraversal) return c.json({ error: 'invalid_path' }, 400);
       launcherLogger.warn('agent_config.detect_cred_failed', { id, agent, err });
-      return c.json({ slug: null, model: null, contextWindow: null, wireShape: null });
+      return c.json({ configured: false, slug: null, model: null, contextWindow: null, wireShape: null });
     }
   });
 

--- a/src/workspaces/adapters/claude-interactive-setup.spec.ts
+++ b/src/workspaces/adapters/claude-interactive-setup.spec.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { readClaudeInteractiveSetupStatus } from './claude.js';
+
+describe('Claude interactive setup status', () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (tempDir !== null) await rm(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
+  async function fixture(state?: unknown): Promise<{ home: string; cwd: string }> {
+    tempDir = await mkdtemp(join(tmpdir(), 'claude-interactive-setup-'));
+    const home = join(tempDir, 'home');
+    const cwd = join(tempDir, 'workspace');
+    await Promise.all([mkdir(home, { recursive: true }), mkdir(cwd, { recursive: true })]);
+    if (state !== undefined) {
+      await writeFile(join(home, '.claude.json'), JSON.stringify(state), 'utf8');
+    }
+    return { home, cwd };
+  }
+
+  it('reports native onboarding before Claude has created global state', async () => {
+    const { home, cwd } = await fixture();
+
+    await expect(readClaudeInteractiveSetupStatus(cwd, home))
+      .resolves.toBe('runtime-onboarding-required');
+  });
+
+  it('reports native onboarding when Claude explicitly marks it incomplete', async () => {
+    const { home, cwd } = await fixture({ hasCompletedOnboarding: false, projects: {} });
+
+    await expect(readClaudeInteractiveSetupStatus(cwd, home))
+      .resolves.toBe('runtime-onboarding-required');
+  });
+
+  it('reports per-project trust after global onboarding is complete', async () => {
+    const { home, cwd } = await fixture({ hasCompletedOnboarding: true, projects: {} });
+
+    await expect(readClaudeInteractiveSetupStatus(cwd, home))
+      .resolves.toBe('workspace-trust-required');
+  });
+
+  it('reports ready only for the exact trusted workspace', async () => {
+    const { home, cwd } = await fixture({
+      hasCompletedOnboarding: true,
+      projects: {
+        [resolve('/somewhere-else')]: { hasTrustDialogAccepted: true },
+      },
+    });
+    await expect(readClaudeInteractiveSetupStatus(cwd, home))
+      .resolves.toBe('workspace-trust-required');
+
+    await writeFile(join(home, '.claude.json'), JSON.stringify({
+      hasCompletedOnboarding: true,
+      projects: {
+        [resolve(cwd)]: { hasTrustDialogAccepted: true },
+      },
+    }), 'utf8');
+
+    await expect(readClaudeInteractiveSetupStatus(cwd, home)).resolves.toBe('ready');
+  });
+
+  it('fails open when Claude changes or corrupts its private state shape', async () => {
+    const { home, cwd } = await fixture('{not-json');
+    await writeFile(join(home, '.claude.json'), '{not-json', 'utf8');
+
+    await expect(readClaudeInteractiveSetupStatus(cwd, home)).resolves.toBe('unknown');
+  });
+
+  it('does not guess when a known private-state field changes type', async () => {
+    const { home, cwd } = await fixture({ hasCompletedOnboarding: 'yes', projects: {} });
+
+    await expect(readClaudeInteractiveSetupStatus(cwd, home)).resolves.toBe('unknown');
+  });
+});

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -1,7 +1,13 @@
+import { readFile, realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-import type { CliAdapter, SpawnContext, WorkspaceAiCred } from '../cli-adapter.js';
+import type {
+  AgentInteractiveSetupStatus,
+  CliAdapter,
+  SpawnContext,
+  WorkspaceAiCred,
+} from '../cli-adapter.js';
 import { readWorkspaceFile } from '../file-service.js';
 import type { HeadlessOutputEvent } from '../headless-output.js';
 import { resetOwnedJsonConfig, writeOwnedJsonConfig } from './owned-json-config.js';
@@ -43,6 +49,69 @@ const HEADLESS_ALLOWED_TOOLS = [
   'Bash(traderhub:*)',
 ].join(',');
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Claude Code has two native gates that can consume the first interactive
+ * screen before a seeded prompt: global onboarding and per-project trust.
+ * Current Claude Code exposes no status/accept command for either gate, so we
+ * read only the small booleans it already owns in `~/.claude.json`.
+ *
+ * This deliberately remains advisory and fail-open. The private file is never
+ * changed, and an unfamiliar/corrupt shape returns `unknown` rather than
+ * blocking launch or guessing that setup is complete.
+ */
+export async function readClaudeInteractiveSetupStatus(
+  cwd: string,
+  homeDir = homedir(),
+): Promise<AgentInteractiveSetupStatus> {
+  let parsed: unknown;
+  try {
+    const raw = await readFile(join(homeDir, '.claude.json'), 'utf8');
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: string }).code === 'ENOENT'
+    ) {
+      return 'runtime-onboarding-required';
+    }
+    return 'unknown';
+  }
+
+  if (!isRecord(parsed)) return 'unknown';
+  const onboarding = parsed['hasCompletedOnboarding'];
+  if (onboarding === false || onboarding === undefined) {
+    return 'runtime-onboarding-required';
+  }
+  if (onboarding !== true) return 'unknown';
+
+  const projects = parsed['projects'];
+  if (projects === undefined) return 'workspace-trust-required';
+  if (!isRecord(projects)) return 'unknown';
+  const resolvedCwd = resolve(cwd);
+  const physicalCwd = await realpath(resolvedCwd).catch(() => resolvedCwd);
+  let projectSeen = false;
+  const trusted = [resolvedCwd, physicalCwd].some((candidate) => {
+    const project = projects[candidate];
+    if (project !== undefined) projectSeen = true;
+    return isRecord(project) && project['hasTrustDialogAccepted'] === true;
+  });
+  if (!trusted && projectSeen) {
+    const project = projects[resolvedCwd] ?? projects[physicalCwd];
+    if (!isRecord(project)) return 'unknown';
+    const accepted = project['hasTrustDialogAccepted'];
+    if (accepted !== undefined && typeof accepted !== 'boolean') return 'unknown';
+  }
+  return trusted
+    ? 'ready'
+    : 'workspace-trust-required';
+}
+
 /** dashed-cwd convention used by Claude Code's project store. */
 function projectKey(workspaceDir: string): string {
   const abs = resolve(workspaceDir);
@@ -81,6 +150,8 @@ export const claudeAdapter: CliAdapter = {
     transcriptDiscovery: 'fs-watch',
     headless: true,
   },
+
+  readInteractiveSetupStatus: readClaudeInteractiveSetupStatus,
 
   composeCommand(base: readonly string[], ctx: SpawnContext): readonly string[] {
     const cmd = [...base, '--settings', AUTOTRUST_SETTINGS];

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -115,6 +115,17 @@ export interface EnvOverrides {
   readonly set?: Readonly<Record<string, string>>;
 }
 
+/**
+ * Best-effort status for native interactive gates that run before a queued
+ * prompt. This is advisory only: adapters must never satisfy a runtime's
+ * onboarding or project-trust prompt by mutating private global state.
+ */
+export type AgentInteractiveSetupStatus =
+  | 'ready'
+  | 'runtime-onboarding-required'
+  | 'workspace-trust-required'
+  | 'unknown';
+
 export interface CliAdapter {
   readonly id: string;                          // 'claude' | 'codex' | 'shell'
   readonly displayName: string;
@@ -163,6 +174,12 @@ export interface CliAdapter {
      */
     readonly headless?: boolean;
   };
+
+  /**
+   * Inspect native first-use state without changing it. Omit when the runtime
+   * has no known pre-prompt interactive gate or exposes no safe read seam.
+   */
+  readInteractiveSetupStatus?(cwd: string): Promise<AgentInteractiveSetupStatus>;
 
   /**
    * Translate the base command (from `WEB_TERMINAL_COMMAND` / template) +

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -1,6 +1,7 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
+  AlertTriangle,
   Bot,
   Check,
   ChevronDown,
@@ -190,8 +191,8 @@ export interface AgentLaunchDetailsProps {
   readonly className?: string
 }
 
-/** Compact, truthful launch metadata. Loginless runtimes show the exact
- * model/context that will be injected; native-login CLIs say who owns it. */
+/** Compact, truthful launch metadata. Workspace-local config always wins the
+ * disclosure, while absent native fields remain unknown rather than inferred. */
 export function AgentLaunchDetails({
   config,
   hasWorkspaceTarget,
@@ -200,9 +201,11 @@ export function AgentLaunchDetails({
 }: AgentLaunchDetailsProps) {
   const { t } = useTranslation()
 
-  if (config.needsCredential && config.aiDetails) {
+  if (hasWorkspaceTarget && !config.workspaceConfigResolved) return null
+
+  let summary: ReactNode = null
+  if (config.aiDetails) {
     const model = config.aiDetails.model ?? t('chatLanding.runtimeDefaultModel')
-    const context = formatContextWindow(config.aiDetails.contextWindow)
     const workspaceSaved = config.aiDetails.source === 'workspace'
     const sourceLabel = workspaceSaved
       ? t('chatLanding.workspaceAiSaved')
@@ -214,8 +217,8 @@ export function AgentLaunchDetails({
         ? t('chatLanding.adjustWorkspaceAi')
         : t('chatLanding.configureWorkspaceAi')
       : t('chatLanding.providerSettings')
-    return (
-      <div className={`flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[10.5px] text-muted-foreground ${className}`}>
+    summary = (
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[10.5px] text-muted-foreground">
         <span className={workspaceSaved ? 'text-success' : 'text-primary'}>
           {sourceLabel}
         </span>
@@ -228,14 +231,22 @@ export function AgentLaunchDetails({
           <Cpu className="h-3 w-3 shrink-0" />
           <span className="truncate font-mono text-foreground/80">{model}</span>
         </span>
-        <span aria-hidden className="text-muted-foreground/40">·</span>
-        <span
-          className="inline-flex shrink-0 items-center gap-1"
-          aria-label={t('chatLanding.contextSummary', { limit: context })}
-        >
-          <Gauge className="h-3 w-3" />
-          {t('chatLanding.contextSummary', { limit: context })}
-        </span>
+        {config.aiDetails.contextWindow !== null && (
+          <>
+            <span aria-hidden className="text-muted-foreground/40">·</span>
+            <span
+              className="inline-flex shrink-0 items-center gap-1"
+              aria-label={t('chatLanding.contextSummary', {
+                limit: formatContextWindow(config.aiDetails.contextWindow),
+              })}
+            >
+              <Gauge className="h-3 w-3" />
+              {t('chatLanding.contextSummary', {
+                limit: formatContextWindow(config.aiDetails.contextWindow),
+              })}
+            </span>
+          </>
+        )}
         <button
           type="button"
           onClick={onAdjustAi}
@@ -248,16 +259,49 @@ export function AgentLaunchDetails({
         </button>
       </div>
     )
-  }
-
-  if (config.selectedAgent && (!config.needsCredential || config.selectedRuntimeUsesGlobalConfig)) {
-    return (
-      <div className={`flex min-w-0 items-center gap-1.5 text-[10.5px] text-muted-foreground ${className}`}>
-        <Bot className="h-3 w-3 shrink-0" />
-        <span>{t('chatLanding.runtimeManagedAi', { runtime: config.selectedAgent.displayName })}</span>
+  } else if (config.selectedAgent && (!config.needsCredential || config.selectedRuntimeUsesGlobalConfig)) {
+    summary = (
+      <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-[10.5px] text-muted-foreground">
+        <span className="inline-flex min-w-0 items-center gap-1.5">
+          <Bot className="h-3 w-3 shrink-0" />
+          <span>{t('chatLanding.runtimeManagedAi', { runtime: config.selectedAgent.displayName })}</span>
+        </span>
+        {!config.needsCredential && hasWorkspaceTarget && (
+          <button
+            type="button"
+            onClick={onAdjustAi}
+            className="oa-pressable inline-flex min-h-7 items-center gap-1 rounded-md px-2 py-1 text-primary hover:bg-primary/10 sm:ml-auto"
+            aria-label={t('chatLanding.configureWorkspaceAi')}
+            title={t('chatLanding.configureWorkspaceAi')}
+          >
+            <Settings2 className="h-3 w-3" />
+            {t('chatLanding.configureWorkspaceAi')}
+          </button>
+        )}
       </div>
     )
   }
 
-  return null
+  const setupStatus = config.detectedCredential?.interactiveSetupStatus
+  const setupNotice = setupStatus === 'runtime-onboarding-required'
+    ? t('chatLanding.claudeOnboardingRequired')
+    : setupStatus === 'workspace-trust-required'
+      ? t('chatLanding.claudeWorkspaceTrustRequired')
+      : null
+
+  if (summary === null && setupNotice === null) return null
+  return (
+    <div className={`flex min-w-0 flex-col gap-1.5 ${className}`}>
+      {summary}
+      {setupNotice !== null && (
+        <div
+          role="status"
+          className="flex min-w-0 items-start gap-1.5 text-[10.5px] leading-relaxed text-warning"
+        >
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          <span>{setupNotice}</span>
+        </div>
+      )}
+    </div>
+  )
 }

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -1221,11 +1221,18 @@ export async function listAgentCredentials(agent: string): Promise<SavedCredenti
 
 /** Which vault credential a workspace's agent is currently configured with (null = none/hand-edited). */
 export interface WorkspaceCredentialDetection {
+  /** True when the runtime has any usable native Workspace config, even when its key is hand-edited. */
+  readonly configured: boolean;
   readonly slug: string | null;
   readonly model: string | null;
   readonly contextWindow: number | null;
   readonly wireShape: WireShape | null;
   readonly reasoning?: boolean | null;
+  readonly interactiveSetupStatus?:
+    | 'ready'
+    | 'runtime-onboarding-required'
+    | 'workspace-trust-required'
+    | 'unknown';
 }
 
 export async function detectWorkspaceCredential(
@@ -1235,7 +1242,14 @@ export async function detectWorkspaceCredential(
   const res = await fetch(
     `/api/workspaces/${encodeURIComponent(wsId)}/agent-config/${encodeURIComponent(agent)}/credential`,
   );
-  if (!res.ok) return { slug: null, model: null, contextWindow: null, wireShape: null, reasoning: null };
+  if (!res.ok) return {
+    configured: false,
+    slug: null,
+    model: null,
+    contextWindow: null,
+    wireShape: null,
+    reasoning: null,
+  };
   return (await res.json()) as WorkspaceCredentialDetection;
 }
 

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -673,7 +673,7 @@ export const workspacesHandlers = [
   // Credential detection — demo workspaces have no on-disk config, so report
   // none (no overwrite notice; the picker defaults to the first compatible).
   http.get('/api/workspaces/:id/agent-config/:agent/credential', () =>
-    HttpResponse.json({ slug: null, model: null, contextWindow: null, wireShape: null }),
+    HttpResponse.json({ configured: false, slug: null, model: null, contextWindow: null, wireShape: null }),
   ),
   http.put('/api/workspaces/:id/agent-config/:agent', () => HttpResponse.json({ ok: true })),
   http.post('/api/workspaces/:id/agent-config/:agent/test', () =>

--- a/ui/src/hooks/useAgentLaunchConfig.ts
+++ b/ui/src/hooks/useAgentLaunchConfig.ts
@@ -23,7 +23,8 @@ const AGENT_LAUNCH_PREFERENCES_CHANGED_EVENT = 'openalice:agent-launch-preferenc
 
 export interface AgentLaunchAiDetails {
   readonly model: string | null
-  readonly contextWindow: number
+  /** Null when the native runtime owns the limit and its project config does not declare one. */
+  readonly contextWindow: number | null
   readonly source: 'workspace' | 'new-injection'
 }
 
@@ -54,6 +55,19 @@ export function resolveAgentCredential(
   return credentials?.[0]?.slug ?? null
 }
 
+/** Match only a credential that the user has explicitly bound to Claude/Codex.
+ * Merely storing a compatible vault entry must not replace the runtime's native
+ * global login, provider, or model defaults. */
+export function resolveExplicitLoginBackedCredential(
+  credentials: readonly Pick<SavedCredential, 'slug'>[] | null,
+  explicitCredential: string | null,
+): string | null {
+  if (explicitCredential === null) return null
+  return credentials?.some((credential) => credential.slug === explicitCredential) === true
+    ? explicitCredential
+    : null
+}
+
 /** Login-backed CLIs own their provider state. Loginless runtimes receive the
  * exact credential shown by the shared selector, including global-config fallbacks. */
 export function resolveAgentLaunchCredentialSlug(
@@ -66,6 +80,7 @@ export function resolveAgentLaunchCredentialSlug(
 /** Describe the exact model/context that the next launch will use. Existing
  * Workspace config wins only when it belongs to the selected credential. */
 export function resolveAgentLaunchAiDetails(
+  needsCredential: boolean,
   effectiveCredential: string | null,
   credential: Pick<SavedCredential, 'slug' | 'resolvedModel'> | null,
   detected: WorkspaceCredentialDetection | null,
@@ -73,12 +88,43 @@ export function resolveAgentLaunchAiDetails(
   defaultContextWindow: number,
   hasWorkspace: boolean,
 ): AgentLaunchAiDetails | null {
+  // Claude/Codex retain native login fallback and never receive an ad-hoc
+  // credential on launch. Show only config that is already on disk, or a
+  // creation default that will actually be seeded into a brand-new Workspace.
+  // Their project files do not declare context limits, so keep that fact
+  // unknown instead of borrowing the Pi/opencode injection default.
+  if (!needsCredential) {
+    if (hasWorkspace && detected?.configured === true) {
+      return {
+        model: detected.model ?? (
+          detected.slug !== null && credential?.slug === detected.slug
+            ? credential.resolvedModel ?? null
+            : null
+        ),
+        contextWindow: detected.contextWindow,
+        source: 'workspace',
+      }
+    }
+    if (
+      !hasWorkspace &&
+      creationDefault !== undefined &&
+      credential?.slug === creationDefault.credentialSlug
+    ) {
+      return {
+        model: creationDefault.model ?? credential.resolvedModel ?? null,
+        contextWindow: null,
+        source: 'new-injection',
+      }
+    }
+    return null
+  }
+
   // A usable hand-edited Workspace config has no vault slug, and a formerly
   // linked credential can later be deleted. The runtime can still use that
   // on-disk config, so keep its real model/context visible instead of falling
   // back to an empty summary.
-  if (hasWorkspace && !effectiveCredential && detected && (
-    detected.model !== null || detected.contextWindow !== null
+  if (hasWorkspace && detected?.configured === true && (
+    !effectiveCredential || detected.slug === null || detected.slug === effectiveCredential
   )) {
     return {
       model: detected.model,
@@ -207,6 +253,7 @@ export interface AgentLaunchConfigState {
   readonly effectiveCredential: string | null
   readonly credential: SavedCredential | null
   readonly detectedCredential: WorkspaceCredentialDetection | null
+  readonly workspaceConfigResolved: boolean
   readonly aiDetails: AgentLaunchAiDetails | null
   readonly selectedRuntimeUsesGlobalConfig: boolean
   readonly credentialSelectionReady: boolean
@@ -236,15 +283,22 @@ export function useAgentLaunchConfig({
 }: UseAgentLaunchConfigOptions): AgentLaunchConfigState {
   const [runtimeReadiness, setRuntimeReadiness] = useState<AgentRuntimeReadinessSnapshot | null>(null)
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
-  const [credentials, setCredentials] = useState<SavedCredential[] | null>(null)
+  const [credentialList, setCredentialList] = useState<{
+    agent: string
+    credentials: SavedCredential[]
+  } | null>(null)
   const [pickedCredential, setPickedCredential] = useState<{
     agent: string
     workspaceId: string | null
     slug: string
   } | null>(null)
-  const [detectedCredential, setDetectedCredential] = useState<WorkspaceCredentialDetection | null>(null)
-  const [agentReadiness, setAgentReadiness] = useState<AgentCredentialReadiness | null>(null)
-  const [credentialWorkspaceResolved, setCredentialWorkspaceResolved] = useState(false)
+  const [workspaceConfigDetection, setWorkspaceConfigDetection] = useState<{
+    agent: string
+    workspaceId: string
+    revision: number
+    detectedCredential: WorkspaceCredentialDetection | null
+    agentReadiness: AgentCredentialReadiness | null
+  } | null>(null)
   const [workspaceCredentialDefaults, setWorkspaceCredentialDefaults] = useState<Record<string, WorkspaceCredentialDefault>>({})
   const [workspaceDefaultContextWindow, setWorkspaceDefaultContextWindow] = useState<WorkspaceContextWindow>(DEFAULT_CONTEXT_WINDOW)
   const [agentConfigRevision, setAgentConfigRevision] = useState(0)
@@ -258,6 +312,20 @@ export function useAgentLaunchConfig({
     selectedRuntimeReadiness.source === 'global-login'
   )
   const needsCredential = isLoginlessAgent(effectiveAgent)
+  const credentials = credentialList?.agent === effectiveAgent
+    ? credentialList.credentials
+    : null
+  const workspaceConfigResolved = effectiveAgent === null || workspaceId === null || (
+    workspaceConfigDetection?.agent === effectiveAgent &&
+    workspaceConfigDetection.workspaceId === workspaceId &&
+    workspaceConfigDetection.revision === agentConfigRevision
+  )
+  const detectedCredential = workspaceConfigResolved
+    ? workspaceConfigDetection?.detectedCredential ?? null
+    : null
+  const agentReadiness = workspaceConfigResolved
+    ? workspaceConfigDetection?.agentReadiness ?? null
+    : null
 
   useEffect(() => {
     let live = true
@@ -269,19 +337,29 @@ export function useAgentLaunchConfig({
 
   useEffect(() => {
     let live = true
-    const refreshAll = () => {
-      void Promise.all([
-        listAgentCredentials('opencode').catch(() => []),
-        configApi.getWorkspaceCredentialDefaults().catch(() => null),
-      ]).then(([available, defaults]) => {
-        if (!live) return
-        setCredentials(available)
-        if (defaults) {
-          setWorkspaceCredentialDefaults(defaults.defaults)
-          setWorkspaceDefaultContextWindow(defaults.contextWindow)
-        }
-      })
+    const refreshCredentials = () => {
+      if (effectiveAgent === null) {
+        setCredentialList(null)
+        return
+      }
+      void listAgentCredentials(effectiveAgent)
+        .then((available) => {
+          if (live) setCredentialList({ agent: effectiveAgent, credentials: available })
+        })
+        .catch(() => {
+          if (live) setCredentialList({ agent: effectiveAgent, credentials: [] })
+        })
     }
+    refreshCredentials()
+    window.addEventListener('openalice:credentials-changed', refreshCredentials)
+    return () => {
+      live = false
+      window.removeEventListener('openalice:credentials-changed', refreshCredentials)
+    }
+  }, [effectiveAgent])
+
+  useEffect(() => {
+    let live = true
     const refreshDefaults = () => {
       void configApi.getWorkspaceCredentialDefaults()
         .then((defaults) => {
@@ -291,12 +369,10 @@ export function useAgentLaunchConfig({
         })
         .catch(() => undefined)
     }
-    refreshAll()
-    window.addEventListener('openalice:credentials-changed', refreshAll)
+    refreshDefaults()
     window.addEventListener(WORKSPACE_DEFAULTS_CHANGED_EVENT, refreshDefaults)
     return () => {
       live = false
-      window.removeEventListener('openalice:credentials-changed', refreshAll)
       window.removeEventListener(WORKSPACE_DEFAULTS_CHANGED_EVENT, refreshDefaults)
     }
   }, [])
@@ -313,26 +389,21 @@ export function useAgentLaunchConfig({
   }, [effectiveAgent, workspaceId])
 
   useEffect(() => {
-    if (!needsCredential || effectiveAgent === null || workspaceId === null) {
-      setDetectedCredential(null)
-      setAgentReadiness(null)
-      setCredentialWorkspaceResolved(true)
-      return
-    }
+    if (effectiveAgent === null || workspaceId === null) return
     let live = true
-    setCredentialWorkspaceResolved(false)
     void Promise.allSettled([
       detectWorkspaceCredential(workspaceId, effectiveAgent),
-      getAgentReadiness(workspaceId),
+      needsCredential ? getAgentReadiness(workspaceId) : Promise.resolve(null),
     ]).then(([detected, readiness]) => {
       if (!live) return
-      setDetectedCredential(detected.status === 'fulfilled' ? detected.value : null)
-      setAgentReadiness(
-        readiness.status === 'fulfilled'
-          ? readiness.value.agents[effectiveAgent] ?? null
-          : null,
-      )
-      setCredentialWorkspaceResolved(true)
+      const readinessBundle = readiness.status === 'fulfilled' ? readiness.value : null
+      setWorkspaceConfigDetection({
+        agent: effectiveAgent,
+        workspaceId,
+        revision: agentConfigRevision,
+        detectedCredential: detected.status === 'fulfilled' ? detected.value : null,
+        agentReadiness: readinessBundle?.agents[effectiveAgent] ?? null,
+      })
     })
     return () => { live = false }
   }, [agentConfigRevision, effectiveAgent, needsCredential, workspaceId])
@@ -345,18 +416,27 @@ export function useAgentLaunchConfig({
     pickedCredential.workspaceId === workspaceId
     ? pickedCredential.slug
     : null
-  const effectiveCredential = resolveAgentCredential(
-    credentials,
-    scopedPickedCredential,
-    detectedCredential?.slug ?? null,
-    workspaceCredentialReady,
-    effectiveAgent ? workspaceCredentialDefaults[effectiveAgent]?.credentialSlug ?? null : null,
-    effectiveAgent ? preferences.lastCredentialByAgent[effectiveAgent] ?? null : null,
-    credentialWorkspaceResolved,
-    preferences.loaded,
-  )
+  const loginBackedCreationDefault = !hasWorkspace && effectiveAgent
+    ? workspaceCredentialDefaults[effectiveAgent]?.credentialSlug ?? null
+    : null
+  const explicitLoginBackedCredential = hasWorkspace
+    ? detectedCredential?.slug ?? null
+    : loginBackedCreationDefault
+  const effectiveCredential = needsCredential
+    ? resolveAgentCredential(
+        credentials,
+        scopedPickedCredential,
+        detectedCredential?.slug ?? null,
+        workspaceCredentialReady,
+        effectiveAgent ? workspaceCredentialDefaults[effectiveAgent]?.credentialSlug ?? null : null,
+        effectiveAgent ? preferences.lastCredentialByAgent[effectiveAgent] ?? null : null,
+        workspaceConfigResolved,
+        preferences.loaded,
+      )
+    : resolveExplicitLoginBackedCredential(credentials, explicitLoginBackedCredential)
   const credential = credentials?.find((candidate) => candidate.slug === effectiveCredential) ?? null
   const aiDetails = resolveAgentLaunchAiDetails(
+    needsCredential,
     effectiveCredential,
     credential,
     detectedCredential,
@@ -365,13 +445,13 @@ export function useAgentLaunchConfig({
     hasWorkspace,
   )
   const noCredentials = needsCredential &&
-    credentialWorkspaceResolved &&
+    workspaceConfigResolved &&
     !workspaceCredentialReady &&
     !selectedRuntimeUsesGlobalConfig &&
     credentials !== null &&
     credentials.length === 0
   const credentialSelectionReady = !needsCredential || selectedRuntimeUsesGlobalConfig || (
-    credentials !== null && credentialWorkspaceResolved && preferences.loaded
+    credentials !== null && workspaceConfigResolved && preferences.loaded
   )
 
   const selectAgent = useCallback((agent: string) => {
@@ -408,6 +488,7 @@ export function useAgentLaunchConfig({
     effectiveCredential,
     credential,
     detectedCredential,
+    workspaceConfigResolved,
     aiDetails,
     selectedRuntimeUsesGlobalConfig,
     credentialSelectionReady,
@@ -444,6 +525,7 @@ export function useAgentLaunchConfig({
     selectedAgent,
     selectedRuntimeReadiness,
     selectedRuntimeUsesGlobalConfig,
+    workspaceConfigResolved,
     resetCredentialSelection,
   ])
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -466,6 +466,8 @@ export const en = {
     adjustWorkspaceAi: 'Adjust workspace AI',
     configureWorkspaceAi: 'Configure workspace AI',
     providerSettings: 'Provider settings',
+    claudeOnboardingRequired: "Claude Code still needs its own first-run setup. Complete it in the TUI before continuing; OpenAlice leaves Claude's login state untouched.",
+    claudeWorkspaceTrustRequired: 'Claude Code will ask you to trust this workspace once before the queued prompt continues.',
     noCredBody: '{{name}} has no AI provider configured. Add one to start chatting.',
     credOverwrite: "Sending switches this workspace's provider from {{from}} to {{to}}.",
     send: 'Send',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -455,6 +455,8 @@ export const ja: Resources = {
     adjustWorkspaceAi: 'ワークスペース AI を調整',
     configureWorkspaceAi: 'ワークスペース AI を設定',
     providerSettings: 'プロバイダー設定',
+    claudeOnboardingRequired: 'Claude Code 側の初回セットアップが必要です。TUI で完了してから続行してください。OpenAlice は Claude のログイン状態を変更しません。',
+    claudeWorkspaceTrustRequired: 'Claude Code は、このワークスペースを初めて開くときに信頼確認を表示します。一度承認すると、待機中のプロンプトが続行されます。',
     noCredBody: '{{name}} には AI プロバイダーが設定されていません。追加するとチャットを開始できます。',
     credOverwrite: '送信すると、この workspace のプロバイダーが {{from}} から {{to}} に切り替わります。',
     send: '送信',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -463,6 +463,8 @@ export const zhHant: Resources = {
     adjustWorkspaceAi: '調整工作區 AI',
     configureWorkspaceAi: '設定工作區 AI',
     providerSettings: '供應方設定',
+    claudeOnboardingRequired: 'Claude Code 仍需完成它自己的首次設定。請在 TUI 中完成後繼續；OpenAlice 不會改動 Claude 的登入狀態。',
+    claudeWorkspaceTrustRequired: 'Claude Code 首次進入此工作區時會要求確認信任；確認一次後，已排隊的提示會繼續執行。',
     noCredBody: '{{name}} 尚未設定 AI 供應方，先新增一個才能開始對話。',
     credOverwrite: '傳送會把此 workspace 的供應方從 {{from}} 切換為 {{to}}。',
     send: '傳送',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -455,6 +455,8 @@ export const zh: Resources = {
     adjustWorkspaceAi: '调整工作区 AI',
     configureWorkspaceAi: '配置工作区 AI',
     providerSettings: '提供方设置',
+    claudeOnboardingRequired: 'Claude Code 仍需完成它自己的首次设置。请在 TUI 中完成后继续；OpenAlice 不会改动 Claude 的登录状态。',
+    claudeWorkspaceTrustRequired: 'Claude Code 首次进入此工作区时会要求确认信任；确认一次后，已排队的提示会继续执行。',
     noCredBody: '{{name}} 还没有配置 AI 提供方，先添加一个才能开始对话。',
     credOverwrite: '发送会把此 workspace 的提供方从 {{from}} 切换为 {{to}}。',
     send: '发送',

--- a/ui/src/lib/agentRuntime.ts
+++ b/ui/src/lib/agentRuntime.ts
@@ -1,4 +1,4 @@
-import type { AgentInfo, AgentRuntimeReadinessSnapshot } from '../components/workspace/api'
+import type { AgentId, AgentInfo, AgentRuntimeReadinessSnapshot } from '../components/workspace/api'
 
 /** Agent runtimes without a first-party login flow need an injected provider. */
 export type LoginlessAgentId = 'opencode' | 'pi'
@@ -7,6 +7,13 @@ export const LOGINLESS_AGENT_IDS = new Set<LoginlessAgentId>(['opencode', 'pi'])
 
 export function isLoginlessAgent(agentId: string | null): agentId is LoginlessAgentId {
   return agentId !== null && LOGINLESS_AGENT_IDS.has(agentId as LoginlessAgentId)
+}
+
+const WORKSPACE_AI_AGENT_IDS = new Set<AgentId>(['claude', 'codex', 'opencode', 'pi'])
+
+/** Native runtimes supported by the per-Workspace AI configuration modal. */
+export function isWorkspaceAiAgent(agentId: string | null): agentId is AgentId {
+  return agentId !== null && WORKSPACE_AI_AGENT_IDS.has(agentId as AgentId)
 }
 
 /**

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -128,6 +128,7 @@ beforeEach(async () => {
     resolvedModel: 'gemini-3.1-flash-lite',
   }])
   mocks.detectWorkspaceCredential.mockResolvedValue({
+    configured: true,
     slug: 'google-1',
     model: 'gemini-3.1-flash-lite',
     contextWindow: 256_000,
@@ -207,6 +208,7 @@ describe('ChatLandingPage AI source disclosure', () => {
 
   it('labels a vault fallback as a pending write instead of existing Workspace config', async () => {
     mocks.detectWorkspaceCredential.mockResolvedValue({
+      configured: false,
       slug: null,
       model: null,
       contextWindow: null,

--- a/ui/src/pages/ChatLandingPage.spec.ts
+++ b/ui/src/pages/ChatLandingPage.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   formatContextWindow,
   resolveAgentCredential,
+  resolveExplicitLoginBackedCredential,
   resolveAgentLaunchAiDetails,
   resolveAgentLaunchCredentialSlug,
 } from '../hooks/useAgentLaunchConfig'
@@ -211,14 +212,29 @@ describe('resolveAgentLaunchCredentialSlug', () => {
   })
 })
 
+describe('resolveExplicitLoginBackedCredential', () => {
+  const credentials = [{ slug: 'anthropic-1' }, { slug: 'openai-1' }]
+
+  it('keeps Claude/Codex on native global state when no Workspace override is explicit', () => {
+    expect(resolveExplicitLoginBackedCredential(credentials, null)).toBeNull()
+  })
+
+  it('resolves an explicit Workspace override without falling back to another vault entry', () => {
+    expect(resolveExplicitLoginBackedCredential(credentials, 'openai-1')).toBe('openai-1')
+    expect(resolveExplicitLoginBackedCredential(credentials, 'deleted-entry')).toBeNull()
+  })
+})
+
 describe('resolveAgentLaunchAiDetails', () => {
   const credential = { slug: 'google-1', resolvedModel: 'gemini-3.5-flash' }
 
   it('shows the effective model and context already written in the target workspace', () => {
     expect(resolveAgentLaunchAiDetails(
+      true,
       'google-1',
       credential,
       {
+        configured: true,
         slug: 'google-1',
         model: 'gemini-3.1-flash-lite',
         contextWindow: 256_000,
@@ -236,9 +252,11 @@ describe('resolveAgentLaunchAiDetails', () => {
 
   it('shows the selected credential model and global context for a replacement injection', () => {
     expect(resolveAgentLaunchAiDetails(
+      true,
       'google-1',
       credential,
       {
+        configured: true,
         slug: 'openai-1',
         model: 'gpt-5.5',
         contextWindow: 1_000_000,
@@ -256,6 +274,7 @@ describe('resolveAgentLaunchAiDetails', () => {
 
   it('shows the configured creation model before the first workspace exists', () => {
     expect(resolveAgentLaunchAiDetails(
+      true,
       'google-1',
       credential,
       null,
@@ -271,9 +290,11 @@ describe('resolveAgentLaunchAiDetails', () => {
 
   it('shows a usable hand-edited workspace config without a vault credential', () => {
     expect(resolveAgentLaunchAiDetails(
+      true,
       null,
       null,
       {
+        configured: true,
         slug: null,
         model: 'local-manual-model',
         contextWindow: 128_000,
@@ -286,6 +307,62 @@ describe('resolveAgentLaunchAiDetails', () => {
       model: 'local-manual-model',
       contextWindow: 128_000,
       source: 'workspace',
+    })
+  })
+
+  it('shows a login-backed Workspace override without fabricating a context limit', () => {
+    expect(resolveAgentLaunchAiDetails(
+      false,
+      'minimax-1',
+      { slug: 'minimax-1', resolvedModel: 'MiniMax-M2.5' },
+      {
+        configured: true,
+        slug: 'minimax-1',
+        model: 'MiniMax-M2.5',
+        contextWindow: null,
+        wireShape: 'anthropic',
+      },
+      { credentialSlug: 'minimax-1', model: 'MiniMax-M2.5' },
+      256_000,
+      true,
+    )).toEqual({
+      model: 'MiniMax-M2.5',
+      contextWindow: null,
+      source: 'workspace',
+    })
+  })
+
+  it('keeps native login fallback visible when no login-backed Workspace override exists', () => {
+    expect(resolveAgentLaunchAiDetails(
+      false,
+      'minimax-1',
+      { slug: 'minimax-1', resolvedModel: 'MiniMax-M2.5' },
+      {
+        configured: false,
+        slug: null,
+        model: null,
+        contextWindow: null,
+        wireShape: null,
+      },
+      undefined,
+      256_000,
+      true,
+    )).toBeNull()
+  })
+
+  it('previews a login-backed creation default without claiming a runtime context limit', () => {
+    expect(resolveAgentLaunchAiDetails(
+      false,
+      'minimax-1',
+      { slug: 'minimax-1', resolvedModel: 'MiniMax-M2.5' },
+      null,
+      { credentialSlug: 'minimax-1', model: 'MiniMax-M2.5' },
+      256_000,
+      false,
+    )).toEqual({
+      model: 'MiniMax-M2.5',
+      contextWindow: null,
+      source: 'new-injection',
     })
   })
 

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -29,6 +29,7 @@ import {
   useAgentLaunchConfig,
   useAgentLaunchPreferences,
 } from '../hooks/useAgentLaunchConfig'
+import { isWorkspaceAiAgent } from '../lib/agentRuntime'
 
 export { resolveAgentRuntime as resolveChatAgent } from '../lib/agentRuntime'
 export {
@@ -137,10 +138,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
   }
 
   const adjustQuickChatAi = () => {
-    if (
-      credentialWorkspace &&
-      (effectiveAgent === 'opencode' || effectiveAgent === 'pi')
-    ) {
+    if (credentialWorkspace && isWorkspaceAiAgent(effectiveAgent)) {
       openAgentConfig(credentialWorkspace.id, effectiveAgent, 'ai')
       return
     }

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -163,6 +163,7 @@ beforeEach(async () => {
   mocks.probeAgentRuntimeReadiness.mockResolvedValue(readiness())
   mocks.listAgentCredentials.mockResolvedValue([])
   mocks.detectWorkspaceCredential.mockResolvedValue({
+    configured: false,
     slug: null,
     model: null,
     contextWindow: null,
@@ -207,6 +208,8 @@ describe('WorkspaceManagerPage runtime selection', () => {
     const picker = await screen.findByRole('button', { name: 'Select agent' })
     expect(picker.textContent).toContain('Codex')
     expect(screen.getByText('Model and context are managed by Codex')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Configure workspace AI' }))
+    expect(mocks.openAgentConfig).toHaveBeenCalledWith('workspace-manager', 'codex', 'ai')
     fireEvent.click(picker)
 
     for (const name of ['Claude', 'Codex', 'OpenCode', 'Pi']) {
@@ -228,6 +231,38 @@ describe('WorkspaceManagerPage runtime selection', () => {
       kind: 'workspace-manager',
       params: { sessionId: 'manager-session' },
     })
+  })
+
+  it('discloses a Claude Workspace override and its native first-run gate', async () => {
+    mocks.useWorkspaces.mockImplementation(() => context('claude'))
+    mocks.listAgentCredentials.mockResolvedValue([{
+      slug: 'minimax-1',
+      label: 'MiniMax',
+      vendor: 'minimax',
+      authType: 'api-key',
+      wires: { anthropic: 'https://api.example.test/anthropic' },
+      resolvedModel: 'MiniMax-M2.5',
+    }])
+    mocks.detectWorkspaceCredential.mockResolvedValue({
+      configured: true,
+      slug: 'minimax-1',
+      model: 'MiniMax-M2.5',
+      contextWindow: null,
+      wireShape: 'anthropic',
+      interactiveSetupStatus: 'runtime-onboarding-required',
+    })
+
+    render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
+
+    expect(await screen.findByText('Saved in this workspace')).toBeTruthy()
+    expect(screen.getByLabelText('Model MiniMax-M2.5')).toBeTruthy()
+    expect(screen.queryByText(/context$/)).toBeNull()
+    expect(screen.getByRole('status').textContent).toContain('Claude Code still needs its own first-run setup')
+    expect(mocks.listAgentCredentials).toHaveBeenCalledWith('claude')
+    expect(mocks.getAgentReadiness).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Adjust workspace AI' }))
+    expect(mocks.openAgentConfig).toHaveBeenCalledWith('workspace-manager', 'claude', 'ai')
   })
 
   it('shows and launches the Manager workspace model/context from the shared config', async () => {
@@ -255,6 +290,7 @@ describe('WorkspaceManagerPage runtime selection', () => {
       recentChatWorkspaceId: null,
     })
     mocks.detectWorkspaceCredential.mockResolvedValue({
+      configured: true,
       slug: 'google-1',
       model: 'gemini-3.1-flash-lite',
       contextWindow: 256_000,
@@ -333,6 +369,7 @@ describe('WorkspaceManagerPage runtime selection', () => {
   it('shows model/context for a usable hand-edited Manager config without a vault credential', async () => {
     mocks.useWorkspaces.mockImplementation(() => context('pi'))
     mocks.detectWorkspaceCredential.mockResolvedValue({
+      configured: true,
       slug: null,
       model: 'local-manual-model',
       contextWindow: 128_000,

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -28,6 +28,7 @@ import { WebPiView } from '../components/workspace/WebPiView'
 import { ResumeCta } from '../components/workspace/ResumeCta'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { useAgentLaunchConfig, useAgentLaunchPreferences } from '../hooks/useAgentLaunchConfig'
+import { isWorkspaceAiAgent } from '../lib/agentRuntime'
 import { useWorkspace } from '../tabs/store'
 import type { ViewSpec } from '../tabs/types'
 
@@ -127,7 +128,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
   }
 
   const adjustManagerAi = () => {
-    if (effectiveAgent === 'opencode' || effectiveAgent === 'pi') {
+    if (isWorkspaceAiAgent(effectiveAgent)) {
       openAgentConfig(MANAGER_WORKSPACE_ID, effectiveAgent, 'ai')
       return
     }


### PR DESCRIPTION
## Summary
- keep Claude Code and Codex on their native global login and configuration unless a Workspace AI credential or creation default is explicitly configured
- disclose real Workspace-local model metadata for all four agent runtimes without inventing context limits
- surface Claude native onboarding and project-trust gates as read-only launch guidance
- preserve hand-edited native agent configs even when they do not match a vault credential

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test: 337 files passed, 3283 tests passed
- focused launch/config tests: 71 passed
- browser E2E against real Claude Code, Codex, OpenCode, and Pi CLIs
- CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace