### PR TITLE
Contain IBKR handshake failures inside UTA account health

### DIFF
--- a/docs/ibkr-wire-protocol.md
+++ b/docs/ibkr-wire-protocol.md
@@ -57,6 +57,14 @@ Continuing with the next buffered frame risks accepting shifted values. Letting
 the exception escape the socket callback crashes the UTA process. Both are
 incorrect.
 
+The same containment rule applies before framing begins. A socket close during
+the API handshake is an ordinary account-level connection failure: the bridge
+must observe its `nextValidId` waiter from the instant the transport attempt
+starts, the client must stop waiting as soon as that socket closes, and the UTA
+must remain alive with that account reported as `offline/down`. A failed broker
+must never escape as a process-level unhandled rejection or take other accounts
+offline with it.
+
 ## Verification ladder
 
 Work on this boundary must proceed from narrow to broad:

--- a/packages/ibkr/src/client/base.ts
+++ b/packages/ibkr/src/client/base.ts
@@ -333,10 +333,29 @@ export class EClient {
 
   private waitForHandshake(): Promise<{ serverVersion: number; connTime: string }> {
     return new Promise((resolve, reject) => {
+      const conn = this.conn
+      const socket = conn?.socket
+      if (!conn || !socket) {
+        reject(new Error('Connection closed before handshake started'))
+        return
+      }
+
       let buf: Buffer = Buffer.alloc(0)
+      let timer: ReturnType<typeof setTimeout> | undefined
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer)
+        conn.removeListener('data', onData)
+        socket.removeListener('close', onClose)
+      }
+
+      const onClose = () => {
+        cleanup()
+        reject(new Error('Connection closed during handshake'))
+      }
 
       const onData = () => {
-        const incoming = this.conn!.consumeBuffer()
+        const incoming = conn.consumeBuffer()
         if (incoming.length === 0) return
 
         buf = Buffer.concat([buf, incoming])
@@ -345,8 +364,7 @@ export class EClient {
           buf = rest
           const fields = readFields(msg)
           if (fields.length >= 2) {
-            clearTimeout(timer)
-            this.conn!.removeListener('data', onData)
+            cleanup()
             resolve({
               serverVersion: parseInt(fields[0], 10),
               connTime: fields[1],
@@ -355,11 +373,12 @@ export class EClient {
         }
       }
 
-      this.conn!.on('data', onData)
+      conn.on('data', onData)
+      socket.once('close', onClose)
 
       // Timeout after 10 seconds
-      const timer = setTimeout(() => {
-        this.conn?.removeListener('data', onData)
+      timer = setTimeout(() => {
+        cleanup()
         reject(new Error('Handshake timeout'))
       }, 10000)
     })

--- a/services/uta/src/domain/trading/brokers/ibkr/request-bridge.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/request-bridge.spec.ts
@@ -1,6 +1,8 @@
+import { createServer, type Socket } from 'node:net'
+
 import { describe, it, expect, vi } from 'vitest'
 import Decimal from 'decimal.js'
-import { Contract, NO_VALID_ID, TickTypeEnum } from '@traderalice/ibkr'
+import { Contract, EClient, makeField, makeMsg, NO_VALID_ID, TickTypeEnum } from '@traderalice/ibkr'
 import { RequestBridge } from './request-bridge.js'
 
 function stk(conId: number, symbol: string): Contract {
@@ -15,6 +17,100 @@ function stk(conId: number, symbol: string): Contract {
 function pushUpdate(b: RequestBridge, contract: Contract, qty: number, avgCost = '100'): void {
   b.updatePortfolio(contract, new Decimal(qty), '101', String(qty * 101), avgCost, '1', '0', 'DU1')
 }
+
+describe('RequestBridge — connection handshake', () => {
+  it('still completes the normal serverVersion → nextValidId handshake', async () => {
+    const server = createServer((socket) => {
+      let stage: 'greeting' | 'start-api' | 'done' = 'greeting'
+      socket.on('data', () => {
+        if (stage === 'greeting') {
+          stage = 'start-api'
+          const payload = Buffer.from(`222\0${new Date(0).toISOString()}\0`, 'utf8')
+          const header = Buffer.alloc(4)
+          header.writeUInt32BE(payload.length)
+          socket.write(Buffer.concat([header, payload]))
+          return
+        }
+        if (stage === 'start-api') {
+          stage = 'done'
+          socket.write(makeMsg(9, true, makeField(1) + makeField(700)))
+        }
+      })
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    const bridge = new RequestBridge()
+    const client = new EClient(bridge)
+    try {
+      const address = server.address()
+      if (address === null || typeof address === 'string') throw new Error('test server has no TCP port')
+      await expect(bridge.waitForConnect(client, '127.0.0.1', address.port, 19, 1_000))
+        .resolves.toBeUndefined()
+      expect(client.isConnected()).toBe(true)
+      expect(bridge.getNextOrderId()).toBe(700)
+    } finally {
+      client.disconnect()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('contains a server-side handshake close as a normal rejected connect', async () => {
+    const server = createServer((socket) => {
+      socket.once('data', () => socket.destroy())
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    try {
+      const address = server.address()
+      if (address === null || typeof address === 'string') throw new Error('test server has no TCP port')
+      const bridge = new RequestBridge()
+      const client = new EClient(bridge)
+
+      const startedAt = Date.now()
+      await expect(bridge.waitForConnect(client, '127.0.0.1', address.port, 19, 1_000))
+        .rejects.toThrow('Connection to TWS/Gateway closed during handshake')
+      expect(Date.now() - startedAt).toBeLessThan(1_000)
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  }, 3_000)
+
+  it('tears down a silent handshake when the bridge timeout expires', async () => {
+    const sockets = new Set<Socket>()
+    const server = createServer((socket) => {
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+      socket.resume()
+      // Accept and consume the greeting, but deliberately never answer.
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    try {
+      const address = server.address()
+      if (address === null || typeof address === 'string') throw new Error('test server has no TCP port')
+      const bridge = new RequestBridge()
+      const client = new EClient(bridge)
+
+      const startedAt = Date.now()
+      await expect(bridge.waitForConnect(client, '127.0.0.1', address.port, 19, 50))
+        .rejects.toThrow('timed out after 50ms')
+      expect(Date.now() - startedAt).toBeLessThan(500)
+      expect(client.isConnected()).toBe(false)
+    } finally {
+      for (const socket of sockets) socket.destroy()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+})
 
 describe('RequestBridge — error routing', () => {
   it('routes 10xxx errors into the pending request (no silent timeout)', async () => {

--- a/services/uta/src/domain/trading/brokers/ibkr/request-bridge.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/request-bridge.ts
@@ -91,6 +91,7 @@ export class RequestBridge extends DefaultEWrapper {
   // ---- Connection handshake ----
   private connectResolve: (() => void) | null = null
   private connectReject: ((err: Error) => void) | null = null
+  private connectTimer: ReturnType<typeof setTimeout> | null = null
 
   // ---- Current time request ----
   private currentTimePending: PendingRequest<number> | null = null
@@ -136,18 +137,62 @@ export class RequestBridge extends DefaultEWrapper {
   ): Promise<void> {
     this.client_ = client
 
-    const promise = new Promise<void>((resolve, reject) => {
+    if (this.connectReject) {
+      this.rejectConnect(new BrokerError('NETWORK', 'Previous TWS/Gateway connection attempt was superseded'))
+    }
+
+    const handshake = new Promise<void>((resolve, reject) => {
       this.connectResolve = resolve
       this.connectReject = reject
-      setTimeout(() => {
-        this.connectResolve = null
-        this.connectReject = null
-        reject(new BrokerError('NETWORK', `Connection to TWS/Gateway timed out after ${timeoutMs}ms`))
+      this.connectTimer = setTimeout(() => {
+        this.rejectConnect(
+          new BrokerError('NETWORK', `Connection to TWS/Gateway timed out after ${timeoutMs}ms`),
+        )
       }, timeoutMs)
     })
 
-    await client.connect(host, port, clientId)
-    return promise
+    // Observe both promises from the moment the socket attempt starts. TWS can
+    // accept TCP and close before EClient.connect() finishes its own protocol
+    // handshake; leaving `handshake` unobserved during that window turns the
+    // normal rejection from connectionClosed() into a process-fatal unhandled
+    // rejection on Node 22.
+    const observedHandshake = handshake.catch((error: unknown) => {
+      // Also make the bridge timeout authoritative. Without this teardown, a
+      // custom short timeout could reject while EClient's independent 10s
+      // protocol timer kept the socket attempt alive in the background.
+      try { client.disconnect() } catch { /* best-effort teardown */ }
+      throw error
+    })
+    const [transportResult, handshakeResult] = await Promise.allSettled([
+      client.connect(host, port, clientId),
+      observedHandshake,
+    ])
+
+    const failure = handshakeResult.status === 'rejected'
+      ? handshakeResult.reason
+      : transportResult.status === 'rejected'
+        ? transportResult.reason
+        : null
+    if (failure !== null) {
+      this.clearConnectWaiter()
+      // A failed handshake must leave no half-connected EClient for the UTA
+      // recovery loop to mistake for a successful reconnect.
+      try { client.disconnect() } catch { /* best-effort teardown */ }
+      throw failure
+    }
+  }
+
+  private clearConnectWaiter(): void {
+    if (this.connectTimer) clearTimeout(this.connectTimer)
+    this.connectTimer = null
+    this.connectResolve = null
+    this.connectReject = null
+  }
+
+  private rejectConnect(error: Error): void {
+    const reject = this.connectReject
+    this.clearConnectWaiter()
+    reject?.(error)
   }
 
   // ---- Mode A: reqId-based requests ----
@@ -401,11 +446,9 @@ export class RequestBridge extends DefaultEWrapper {
   override nextValidId(orderId: number): void {
     this.nextOrderId_ = orderId
     // Resolve the connect promise (TWS is ready)
-    if (this.connectResolve) {
-      this.connectResolve()
-      this.connectResolve = null
-      this.connectReject = null
-    }
+    const resolve = this.connectResolve
+    this.clearConnectWaiter()
+    resolve?.()
   }
 
   override managedAccounts(accountsList: string): void {
@@ -436,9 +479,7 @@ export class RequestBridge extends DefaultEWrapper {
     this.rejectAll(new BrokerError('NETWORK', 'Connection to TWS/Gateway lost'))
 
     if (this.connectReject) {
-      this.connectReject(new BrokerError('NETWORK', 'Connection to TWS/Gateway closed during handshake'))
-      this.connectResolve = null
-      this.connectReject = null
+      this.rejectConnect(new BrokerError('NETWORK', 'Connection to TWS/Gateway closed during handshake'))
     }
   }
 

--- a/services/uta/src/uta-startup-resilience.spec.ts
+++ b/services/uta/src/uta-startup-resilience.spec.ts
@@ -1,0 +1,158 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer, type Server } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (address === null || typeof address === 'string') {
+        reject(new Error('test server has no TCP port'))
+        return
+      }
+      resolve(address.port)
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()))
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()))
+  child.kill('SIGTERM')
+  await Promise.race([exited, delay(3_000)])
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill('SIGKILL')
+    await exited
+  }
+}
+
+describe('UTA process startup resilience', () => {
+  it('keeps serving while an IBKR account fails during protocol handshake', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-uta-handshake-'))
+    const configDir = join(home, 'data', 'config')
+    const fakeTws = createServer((socket) => {
+      // Accept the TCP connection, consume the API greeting, then reproduce a
+      // TWS/Gateway close before serverVersion/nextValidId arrives.
+      socket.once('data', () => socket.destroy())
+    })
+    const fakeTwsPort = await listen(fakeTws)
+    const utaPortReservation = createServer()
+    const utaPort = await listen(utaPortReservation)
+    await closeServer(utaPortReservation)
+    await mkdir(configDir, { recursive: true })
+    await Promise.all([
+      writeFile(join(configDir, 'accounts.json'), JSON.stringify([{
+        id: 'ibkr-handshake-down',
+        label: 'IBKR handshake fixture',
+        presetId: 'ibkr-tws',
+        enabled: true,
+        guards: [],
+        presetConfig: { host: '127.0.0.1', port: fakeTwsPort, clientId: 19 },
+        readOnly: true,
+      }, {
+        id: 'simulator-healthy',
+        label: 'Unaffected simulator fixture',
+        presetId: 'mock-simulator',
+        enabled: true,
+        guards: [],
+        presetConfig: { cash: 100_000 },
+        readOnly: true,
+      }], null, 2)),
+      writeFile(join(configDir, 'snapshot.json'), JSON.stringify({ enabled: false, every: '15m' })),
+      writeFile(join(configDir, 'trading.json'), JSON.stringify({
+        mode: 'readonly',
+        observeExternalOrdersEvery: 'off',
+        keylessDataSources: [],
+      })),
+    ])
+
+    const child = spawn(process.execPath, ['--import', 'tsx', 'services/uta/src/main.ts'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `${process.env['NODE_OPTIONS'] ?? ''} --conditions=openalice-source`.trim(),
+        OPENALICE_HOME: home,
+        OPENALICE_APP_HOME: process.cwd(),
+        OPENALICE_UTA_PORT: String(utaPort),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let output = ''
+    child.stdout.on('data', (chunk: Buffer) => { output += chunk.toString('utf8') })
+    child.stderr.on('data', (chunk: Buffer) => { output += chunk.toString('utf8') })
+
+    try {
+      const deadline = Date.now() + 10_000
+      type ListedAccount = {
+        id?: string
+        health?: { status?: string; reach?: string; connecting?: boolean; recovering?: boolean; lastError?: string }
+      }
+      let account: ListedAccount | undefined
+      let unaffected: ListedAccount | undefined
+      while (Date.now() < deadline) {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          throw new Error(`UTA exited during one-account handshake failure:\n${output}`)
+        }
+        try {
+          const health = await fetch(`http://127.0.0.1:${utaPort}/__uta/health`)
+          const listing = await fetch(`http://127.0.0.1:${utaPort}/api/trading/uta`)
+          if (health.ok && listing.ok) {
+            const healthBody = await health.json() as { ok?: boolean; utas?: number }
+            const listingBody = await listing.json() as { utas?: ListedAccount[] }
+            const candidate = listingBody.utas?.find((uta) => (
+              uta.id === 'ibkr-handshake-down'
+            ))
+            const healthyCandidate = listingBody.utas?.find((uta) => uta.id === 'simulator-healthy')
+            if (
+              healthBody.ok === true &&
+              healthBody.utas === 2 &&
+              candidate?.health?.status === 'offline' &&
+              candidate.health.reach === 'down' &&
+              candidate.health.connecting === false &&
+              candidate.health.recovering === true &&
+              healthyCandidate?.health?.status === 'healthy' &&
+              healthyCandidate.health.reach === 'readable'
+            ) {
+              account = candidate
+              unaffected = healthyCandidate
+              break
+            }
+          }
+        } catch {
+          // Service is still binding or the account handshake has not settled.
+        }
+        await delay(50)
+      }
+
+      expect(account, output).toBeDefined()
+      expect(account?.health?.lastError).toContain('closed during handshake')
+      expect(unaffected?.health).toMatchObject({ status: 'healthy', reach: 'readable' })
+      expect(child.exitCode).toBeNull()
+
+      // Prove the service remains usable after the account failure, rather
+      // than merely winning a race against process termination.
+      await delay(100)
+      const stillHealthy = await fetch(`http://127.0.0.1:${utaPort}/__uta/health`)
+      await expect(stillHealthy.json()).resolves.toMatchObject({ ok: true, utas: 2 })
+      expect(child.exitCode).toBeNull()
+      expect(output).not.toContain('[uta] fatal:')
+    } finally {
+      await stopChild(child)
+      await closeServer(fakeTws)
+      await rm(home, { recursive: true, force: true })
+    }
+  }, 15_000)
+})


### PR DESCRIPTION
## Summary

- observe the IBKR nextValidId waiter throughout transport negotiation so an early TWS/Gateway close cannot become an unhandled rejection
- stop the low-level protocol handshake immediately on socket close and tear down timed-out attempts before recovery retries
- prove in a real isolated UTA child process that the failed IBKR account becomes offline/down while UTA HTTP and an unaffected simulator account remain healthy
- document the pre-framing containment contract

## Root cause

RequestBridge created the nextValidId promise before awaiting EClient.connect, but did not observe that promise until the transport handshake returned. A peer that accepted TCP and closed during the protocol handshake therefore rejected an unobserved nested promise. Node 22 treated it as fatal and terminated the UTA process before normal account health containment could handle the failure.

## Verification

- npx tsc --noEmit
- pnpm test
- pnpm test:e2e
- pnpm -F @traderalice/ibkr typecheck
- pnpm -F @traderalice/ibkr test
- pnpm vitest run services/uta/src/domain/trading/brokers/ibkr/request-bridge.spec.ts services/uta/src/uta-startup-resilience.spec.ts
- CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace

No live-paper order test was run: this change touches connection establishment only, and the regressions use a local fake TWS plus an isolated read-only UTA process.