### PR TITLE
Prepare agent runtimes through shared lifecycle

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -289,9 +289,14 @@ remain at the OpenAlice/UTA boundary.
 - `src/workspaces/spawn-env.ts` places OpenAlice's CLI shims first, followed by
   managed toolchain directories and host fallbacks. On Windows it also
   canonicalizes `Path`/`PATH` so Pi's nested shell keeps the injected entries.
+- `CliAdapter.lifecycle.prepareWorkspace` is the common, idempotent runtime
+  preparation hook. Workspace creation and every real TUI, Web, headless,
+  readiness, or probe launch use the same hook instead of inventing
+  surface-specific adapter setup.
 - `src/workspaces/adapters/pi.ts` launches the npm runtime as
-  `[managedPiNodePath, managedPiPath, ...args]` and writes the managed shell
-  path into `.pi/settings.json` during Windows Workspace bootstrap.
+  `[managedPiNodePath, managedPiPath, ...args]`; its lifecycle implementation
+  reconciles trust, legacy config, the managed Windows shell, and the native Pi
+  automatic theme pair.
 
 The packaged Electron managed npm runtime is not added to `PATH` as a fake
 `pi` binary; the Pi adapter owns its explicit launch command. The curl
@@ -317,6 +322,16 @@ Pi project trust follows the runtime boundary:
   flags. The Pi executable on `PATH`, its version, and its upgrade policy
   belong to the contributor. A curl-installed CLI Runtime has an explicit
   managed Pi path and therefore follows the pinned managed approval contract.
+
+Pi terminal appearance follows the same boundary used by Orca:
+
+- when a Workspace has no explicit Pi project theme, runtime preparation writes
+  Pi's built-in `light/dark` automatic pair to `.pi/settings.json`;
+- a Pi project theme already present in that file is user-owned and remains
+  unchanged on later launches;
+- OpenAlice supplies the terminal palette and light/dark facts through xterm,
+  OSC/DSR queries, and mode 2031. Pi remains responsible for its own TUI theme;
+  OpenAlice does not generate or inject palette-specific Pi themes.
 
 Do not add external-Pi version probing or upgrade UX to preserve flags used by
 the packaged runtime. Compatibility for the packaged app is maintained by
@@ -363,9 +378,10 @@ OpenAlice copies Workspace skills into two canonical project paths:
 - `.agents/skills/` for Codex, current Pi, and compatible shared-skill readers.
 
 Pi's provider definition lives in its normal user `models.json`; the Workspace
-stores only provider/model selection and OpenAlice rollback metadata under
-`.pi/`. Do not restore a duplicate `.pi/skills/` copy: current Pi discovers the
-shared `.agents/skills/` tree from the Workspace working directory.
+stores provider/model selection, the automatic terminal theme default, and
+OpenAlice rollback metadata under `.pi/`. Do not restore a duplicate
+`.pi/skills/` copy: current Pi discovers the shared `.agents/skills/` tree from
+the Workspace working directory.
 
 Provider injection into shared native JSON config is node-owned, not
 file-owned. Claude Code's `.claude/settings.local.json` and opencode's

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -174,8 +174,11 @@ Workspace tools are exposed as CLI shims on `PATH`. The `alice*` and
 `traderhub` skills teach the native agents how to call those shims. Shared
 project skills are copied to `.agents/skills/` and Claude-specific discovery to
 `.claude/skills/`. Pi keeps providers in its normal user agent directory and
-selects a Workspace provider through `.pi/settings.json`; OpenAlice never
-redirects Pi away from its native global packages, settings, auth, or sessions.
+selects a Workspace provider through `.pi/settings.json`; the shared runtime
+lifecycle also gives Workspaces without an explicit Pi theme the native
+`light/dark` automatic pair. OpenAlice never redirects Pi away from its native
+global packages, settings, auth, or sessions and never replaces an explicit Pi
+project theme.
 Claude Code and opencode keep reversible OpenAlice ownership metadata in
 `.claude/openalice-provider.json` and `.opencode/openalice-provider.json` so
 provider reset preserves unrelated native settings. Those files are sensitive

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -45,7 +45,7 @@ function build(
     id: 'claude',
     capabilities: { headless: true },
     composeHeadlessCommand: () => [],
-    bootstrap: vi.fn(async () => {}),
+    lifecycle: { prepareWorkspace: vi.fn(async () => {}) },
   };
   const meta = opts.meta ?? { id: 'ws-1', dir: '/w', agents: ['claude'] };
   const adapters = opts.adapters ?? { claude };
@@ -555,7 +555,7 @@ describe('POST /:id/headless/:taskId/session', () => {
       id: 'codex',
       namePrefix: 'x',
       capabilities: { resumeById: true, resumeLast: true },
-      bootstrap: vi.fn(async () => {}),
+      lifecycle: { prepareWorkspace: vi.fn(async () => {}) },
     };
     const task = opts.task ?? {
       taskId: 'run-1',
@@ -793,7 +793,7 @@ describe('WebPi surface routes', () => {
       capabilities: { resumeById: true },
       readAiConfig: vi.fn(async () => ({ baseUrl: 'https://example.test', apiKey: 'test', model: 'model' })),
       writeAiConfig: vi.fn(async () => undefined),
-      bootstrap: vi.fn(async () => order.push('bootstrap')),
+      lifecycle: { prepareWorkspace: vi.fn(async () => { order.push('prepare-workspace'); }) },
     };
     const webPi = {
       get: vi.fn(() => snapshot),
@@ -827,7 +827,7 @@ describe('WebPi surface routes', () => {
     const result = await post(app, `/ws-1/sessions/${TOKEN}/webpi/open`);
     expect(result.status).toBe(200);
     expect(result.body.snapshot).toMatchObject({ resumeId: 'resume-webpi', phase: 'idle' });
-    expect(order).toEqual(['bootstrap', 'terminal-stopped', 'webpi-started']);
+    expect(order).toEqual(['prepare-workspace', 'terminal-stopped', 'webpi-started']);
     expect(svc.startWebPiSession).toHaveBeenCalledOnce();
   });
 
@@ -937,7 +937,7 @@ describe('Workspace manager surface routes', () => {
       id: 'pi',
       namePrefix: 'p',
       capabilities: { resumeById: true },
-      bootstrap: vi.fn(async () => undefined),
+      lifecycle: { prepareWorkspace: vi.fn(async () => undefined) },
     };
     const snapshot = {
       recordId: 'pi-manager-test',
@@ -1039,7 +1039,7 @@ describe('Workspace manager surface routes', () => {
       id: 'codex',
       namePrefix: 'x',
       capabilities: { resumeById: true },
-      bootstrap: vi.fn(async () => undefined),
+      lifecycle: { prepareWorkspace: vi.fn(async () => undefined) },
     };
     let spawnedContext: any = null;
     let liveSession: any = null;

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -27,7 +27,12 @@ import { readWorkspaceMetadata, workspaceMetadataSchema, writeWorkspaceMetadata 
 import type { SessionRecord } from '../../workspaces/session-registry.js';
 import type { WorkspaceMeta } from '../../workspaces/workspace-registry.js';
 import { HeadlessCapacityError, HeadlessResumeError, resumeFromRecord, type SessionFactoryContext, type WorkspaceService } from '../../workspaces/service.js';
-import { isAgentRuntime, type CliAdapter, type WorkspaceAiCred } from '../../workspaces/cli-adapter.js';
+import {
+  isAgentRuntime,
+  prepareAgentRuntimeWorkspace,
+  type CliAdapter,
+  type WorkspaceAiCred,
+} from '../../workspaces/cli-adapter.js';
 import { generatePetnameId } from '../../workspaces/petname-id.js';
 import { addCredential, readCredentials, readWorkspaceDefaultAgent, setCredentialLastModel, credentialWires, credentialWireShapeEnum, type Credential } from '../../core/config.js';
 import { inferCredentialVendor, resolveAnthropicAuthMode } from '../../core/credential-inference.js';
@@ -267,11 +272,13 @@ export function createWorkspaceRoutes(
       return { ok: false, status: 500, body: { error: 'agent_credential_failed', message: (err as Error).message } };
     }
     try {
-      if (adapter.bootstrap) {
-        await adapter.bootstrap({ wsId: id, cwd: meta.dir, launcherRepoRoot: svc.config.launcherRepoRoot });
-      }
+      await prepareAgentRuntimeWorkspace(adapter, {
+        wsId: id,
+        cwd: meta.dir,
+        launcherRepoRoot: svc.config.launcherRepoRoot,
+      });
     } catch (err) {
-      launcherLogger.error('adapter.bootstrap_failed', { id, agent: adapter.id, err });
+      launcherLogger.error('adapter.prepare_workspace_failed', { id, agent: adapter.id, err });
       return { ok: false, status: 500, body: { error: 'bootstrap_failed', message: (err as Error).message } };
     }
     await svc.sessionRegistry.ensureLoaded(id);
@@ -1388,15 +1395,13 @@ export function createWorkspaceRoutes(
         resumeHintInRecord: record.resumeHint ?? null,
       });
       try {
-        if (adapter.bootstrap) {
-          await adapter.bootstrap({
-            wsId: id,
-            cwd: meta.dir,
-            launcherRepoRoot: svc.config.launcherRepoRoot,
-          });
-        }
+        await prepareAgentRuntimeWorkspace(adapter, {
+          wsId: id,
+          cwd: meta.dir,
+          launcherRepoRoot: svc.config.launcherRepoRoot,
+        });
       } catch (err) {
-        launcherLogger.error('adapter.bootstrap_failed_on_resume', { id, agent: adapter.id, err });
+        launcherLogger.error('adapter.prepare_workspace_failed_on_resume', { id, agent: adapter.id, err });
         return c.json({ error: 'bootstrap_failed', message: (err as Error).message }, 500);
       }
       let initialReplayBytes: Buffer | null = null;
@@ -1502,9 +1507,11 @@ export function createWorkspaceRoutes(
     if (!adapter) return c.json({ error: 'unknown_agent' }, 500);
     try {
       await ensureAgentCredentialReady({ meta, agentId: 'pi', adapter, logger: launcherLogger });
-      if (adapter.bootstrap) {
-        await adapter.bootstrap({ wsId: id, cwd: meta.dir, launcherRepoRoot: svc.config.launcherRepoRoot });
-      }
+      await prepareAgentRuntimeWorkspace(adapter, {
+        wsId: id,
+        cwd: meta.dir,
+        launcherRepoRoot: svc.config.launcherRepoRoot,
+      });
       if (svc.pool.get(token)) svc.pool.disposeToken(token, 'switch to WebPi');
       const snapshot = await svc.startWebPiSession(
         meta,
@@ -1831,14 +1838,6 @@ export function createWorkspaceRoutes(
     const adapter = svc.resolveAdapter(meta, effectiveAgentId);
     if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
       return c.json({ error: 'no_headless', message: `adapter "${adapter.id}" has no headless mode` }, 400);
-    }
-    // Same one-time bootstrap as a real spawn (trust/MCP wiring), idempotent.
-    try {
-      if (adapter.bootstrap) {
-        await adapter.bootstrap({ wsId: id, cwd: meta.dir, launcherRepoRoot: svc.config.launcherRepoRoot });
-      }
-    } catch (err) {
-      launcherLogger.error('headless.bootstrap_failed', { id, agent: adapter.id, err });
     }
     launcherLogger.info('workspace.headless_started', {
       id,

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -17,6 +17,7 @@ import { codexAdapter } from './codex.js';
 import { opencodeAdapter } from './opencode.js';
 import { piAdapter, syncPiProjectTrust, syncPiWindowsShellPath } from './pi.js';
 import { migrateLegacyPiAgentDir, piWorkspaceProviderId } from './pi-config.js';
+import { prepareAgentRuntimeWorkspace } from '../cli-adapter.js';
 
 let dir: string;
 
@@ -548,6 +549,35 @@ describe('piAdapter AI-config', () => {
     const models = await readGlobalModels();
     return models['providers'][piWorkspaceProviderId(dir)] as Record<string, any>;
   };
+
+  it('prepares Pi to follow the terminal light/dark mode by default', async () => {
+    await mkdir(join(dir, '.pi'), { recursive: true });
+    await writeFile(join(dir, '.pi/settings.json'), JSON.stringify({ quietStartup: true }));
+
+    await prepareAgentRuntimeWorkspace(piAdapter, {
+      wsId: 'ws-abc',
+      cwd: dir,
+      launcherRepoRoot: '/repo',
+    });
+
+    expect(JSON.parse(await read('.pi/settings.json'))).toEqual({
+      quietStartup: true,
+      theme: 'light/dark',
+    });
+  });
+
+  it('preserves an explicit Pi project theme on later lifecycle runs', async () => {
+    await mkdir(join(dir, '.pi'), { recursive: true });
+    await writeFile(join(dir, '.pi/settings.json'), JSON.stringify({ theme: 'dark' }));
+
+    await prepareAgentRuntimeWorkspace(piAdapter, {
+      wsId: 'ws-abc',
+      cwd: dir,
+      launcherRepoRoot: '/repo',
+    });
+
+    expect(JSON.parse(await read('.pi/settings.json'))).toEqual({ theme: 'dark' });
+  });
 
   it('records a new OpenAlice workspace in Pi global trust without forcing agent-dir redirection', async () => {
     const home = join(dir, 'home');

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -124,8 +124,7 @@ function projectKey(workspaceDir: string): string {
  * is the verbatim move of `index.ts:composeCommand` from before refactor).
  *
  * MCP wiring for claude is handled by the template's `.mcp.json` (the launcher
- * still does the placeholder-substitution at spawn-env-build time). v2.M4
- * generalizes that into `bootstrap()` here.
+ * still does the placeholder-substitution at spawn-env-build time).
  */
 export const claudeAdapter: CliAdapter = {
   id: 'claude',

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 
-import type { BootstrapContext, CliAdapter, OnDiskSession, SpawnContext, WorkspaceAiCred } from '../cli-adapter.js';
+import type { CliAdapter, OnDiskSession, SpawnContext, WorkspaceAiCred } from '../cli-adapter.js';
 import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js';
 import type { HeadlessOutputEvent } from '../headless-output.js';
 
@@ -34,9 +34,9 @@ const CODEX_INTERACTIVE_PERMISSION_ARGS = [
  *   this workspace. v1 punts on this (`transcriptDiscovery: 'none'`); the
  *   `codex resume` picker is cwd-aware and handles the user-facing case.
  * - Trust model: codex prompts on first run for any cwd not in
- *   `~/.codex/config.toml` `[projects."<abs>"] trust_level`. `bootstrap()`
- *   pre-writes that entry so the launcher's spawn doesn't stall on the
- *   prompt.
+ *   `~/.codex/config.toml` `[projects."<abs>"] trust_level`. The shared
+ *   runtime lifecycle pre-writes that entry so the launcher's spawn doesn't
+ *   stall on the prompt.
  *
  * AI provider model — two modes, mutually exclusive:
  *
@@ -382,8 +382,10 @@ export const codexAdapter: CliAdapter = {
     return result;
   },
 
-  async bootstrap(ctx: BootstrapContext): Promise<void> {
-    await ensureTrustedProject(ctx.cwd);
+  lifecycle: {
+    async prepareWorkspace(ctx): Promise<void> {
+      await ensureTrustedProject(ctx.cwd);
+    },
   },
 
   /**

--- a/src/workspaces/adapters/pi-config.ts
+++ b/src/workspaces/adapters/pi-config.ts
@@ -22,6 +22,7 @@ import type { WorkspaceAiCred } from '../cli-adapter.js';
 export const PI_PROJECT_SETTINGS_PATH = '.pi/settings.json';
 export const PI_BINDING_STATE_PATH = '.pi/openalice-provider.json';
 export const LEGACY_PI_AGENT_DIR = '.pi-agent';
+export const PI_AUTOMATIC_THEME_PAIR = 'light/dark';
 
 const PI_PROVIDER_PREFIX = 'openalice-workspace-';
 const PI_PROVIDER_NAME_PREFIX = 'OpenAlice workspace provider';
@@ -223,6 +224,20 @@ async function removeGlobalProvider(agentDir: string, providerId: string): Promi
 
 async function readProjectSettings(cwd: string): Promise<Record<string, unknown>> {
   return await readJsonRecord(join(cwd, PI_PROJECT_SETTINGS_PATH), 'Pi project settings') ?? {};
+}
+
+/**
+ * Give OpenAlice-managed Pi Workspaces the same boundary Orca expects: Pi
+ * remains the owner of its TUI colors, while the terminal reports light/dark
+ * through OSC/DSR and mode 2031. A project choice wins over this default,
+ * including a choice the user later makes from Pi's own settings UI.
+ */
+export async function syncPiWorkspaceTheme(cwd: string): Promise<boolean> {
+  const settings = await readProjectSettings(cwd);
+  if (Object.prototype.hasOwnProperty.call(settings, 'theme')) return false;
+  settings['theme'] = PI_AUTOMATIC_THEME_PAIR;
+  await writeJsonAtomic(join(cwd, PI_PROJECT_SETTINGS_PATH), settings);
+  return true;
 }
 
 async function readBindingState(cwd: string): Promise<PiBindingState | null> {

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -12,6 +12,7 @@ import {
   PI_BINDING_STATE_PATH,
   readPiWorkspaceConfig,
   resolvePiAgentDir,
+  syncPiWorkspaceTheme,
   syncPiWorkspaceShellPath,
   writePiWorkspaceConfig,
 } from './pi-config.js';
@@ -188,22 +189,25 @@ export const piAdapter: CliAdapter = {
     headless: true,
   },
 
-  // Reconcile the derived Pi cache on every Windows launch so workspaces made
-  // before the global shell setting existed pick it up without requiring a
-  // credential rewrite. The helper returns before I/O on every other OS.
-  async bootstrap({ cwd }): Promise<void> {
-    await migrateLegacyPiAgentDir(cwd);
-    await syncPiWindowsShellPath(cwd);
-    await syncPiProjectTrust(cwd);
+  lifecycle: {
+    // Reconcile launcher-managed Pi project defaults before every surface
+    // starts. Each operation is idempotent and preserves explicit Pi-owned
+    // project choices.
+    async prepareWorkspace({ cwd }): Promise<void> {
+      await migrateLegacyPiAgentDir(cwd);
+      await syncPiWorkspaceTheme(cwd);
+      await syncPiWindowsShellPath(cwd);
+      await syncPiProjectTrust(cwd);
+    },
   },
 
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
     // Tools come from the CLI-injection path (alice on PATH + shared
     // .agents/skills), not flags — so the command head is just the binary + a
     // resume flag (if any).
-    // `bootstrap()` records trust for this OpenAlice-managed Workspace before
-    // every launch. Keeping argv free of `--approve` preserves compatibility
-    // with external Pi 0.78.x runtimes that predate the flag.
+    // The runtime lifecycle records trust for this OpenAlice-managed Workspace
+    // before every launch. Keeping argv free of `--approve` preserves
+    // compatibility with external Pi 0.78.x runtimes that predate the flag.
     const head = [...piCommandHead(ctx.env)];
     // Quick-chat seed: `pi [--session-id <id>] <messages…>` opens the
     // interactive TUI seeded with that first message. UNLIKE the other adapters,

--- a/src/workspaces/cli-adapter.spec.ts
+++ b/src/workspaces/cli-adapter.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  prepareAgentRuntimeWorkspace,
+  type AgentRuntimeWorkspaceContext,
+  type CliAdapter,
+} from './cli-adapter.js';
+
+const context: AgentRuntimeWorkspaceContext = {
+  wsId: 'ws-test',
+  cwd: '/tmp/ws-test',
+  launcherRepoRoot: '/repo',
+};
+
+function adapterWithLifecycle(
+  prepareWorkspace?: (ctx: AgentRuntimeWorkspaceContext) => Promise<void>,
+): CliAdapter {
+  return {
+    id: 'test',
+    displayName: 'Test runtime',
+    capabilities: {
+      parallelPerCwd: true,
+      resumeLast: false,
+      resumeById: false,
+      transcriptDiscovery: 'none',
+    },
+    composeCommand: () => ['test'],
+    ...(prepareWorkspace ? { lifecycle: { prepareWorkspace } } : {}),
+  };
+}
+
+describe('agent runtime lifecycle', () => {
+  it('dispatches workspace preparation through the common hook', async () => {
+    const prepareWorkspace = vi.fn(async () => undefined);
+
+    await prepareAgentRuntimeWorkspace(adapterWithLifecycle(prepareWorkspace), context);
+
+    expect(prepareWorkspace).toHaveBeenCalledOnce();
+    expect(prepareWorkspace).toHaveBeenCalledWith(context);
+  });
+
+  it('is a no-op for runtimes without workspace preparation', async () => {
+    await expect(
+      prepareAgentRuntimeWorkspace(adapterWithLifecycle(), context),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -4,8 +4,8 @@
  * The pool, watcher, and discovery layers consult an adapter to:
  *   1. Translate a spawn intent (`resume`?) into the CLI's native command flags.
  *   2. Decide whether/how to discover on-disk transcripts for this CLI.
- *   3. Provide CLI-specific env strips/sets and one-time bootstrap (writing
- *      config files, registering MCP servers in the CLI's native format, etc.).
+ *   3. Provide CLI-specific env strips/sets and idempotent lifecycle hooks
+ *      (writing config files, recording trust, etc.).
  *
  * In v2.M1 only `claude` is registered; the interface exists so v2.M2+ can
  * land codex/shell without touching the core PTY/protocol/UI plumbing.
@@ -60,11 +60,27 @@ export interface SpawnContext {
   readonly approveProject?: boolean;
 }
 
-export interface BootstrapContext {
+export interface AgentRuntimeWorkspaceContext {
   readonly wsId: string;
   readonly cwd: string;
   /** Absolute path to the launcher repo, so adapters can compose tool paths. */
   readonly launcherRepoRoot: string;
+}
+
+/**
+ * Shared lifecycle surface for native agent runtimes. Hooks are invoked by the
+ * launcher rather than by individual HTTP/headless/Web adapters, so every
+ * runtime gets the same preparation boundary. Implementations must be
+ * idempotent: workspace creation and every real process launch can both call
+ * `prepareWorkspace`.
+ */
+export interface AgentRuntimeLifecycle {
+  /**
+   * Reconcile launcher-managed runtime configuration before the Workspace is
+   * used. Native/user-owned config must be merged narrowly; never replace a
+   * runtime's global settings directory.
+   */
+  prepareWorkspace?(ctx: AgentRuntimeWorkspaceContext): Promise<void>;
 }
 
 /**
@@ -175,6 +191,9 @@ export interface CliAdapter {
     readonly headless?: boolean;
   };
 
+  /** Runtime-specific hooks executed through the shared launcher lifecycle. */
+  readonly lifecycle?: AgentRuntimeLifecycle;
+
   /**
    * Inspect native first-use state without changing it. Omit when the runtime
    * has no known pre-prompt interactive gate or exposes no safe read seam.
@@ -283,15 +302,6 @@ export interface CliAdapter {
   composeEnv?(ctx: SpawnContext): Record<string, string>;
 
   /**
-   * Workspace-creation hook. The launcher calls this once for every adapter
-   * enabled on a workspace. Responsible for technical wiring (writing
-   * `.mcp.json`, adding trust entries to global config, etc.) — NOT for
-   * instruction files like CLAUDE.md / AGENTS.md (template README covers
-   * the cross-CLI guidance).
-   */
-  bootstrap?(ctx: BootstrapContext): Promise<void>;
-
-  /**
    * Read/write the workspace's per-CLI AI-provider override. The launcher
    * dispatches uniformly; each adapter renders the shared `WorkspaceAiCred`
    * into (and parses it out of) its own native config files. An empty cred
@@ -308,6 +318,16 @@ export interface CliAdapter {
 
   /** Subprocess discovery (capabilities.transcriptDiscovery === 'subprocess'). */
   listOnDisk?(cwd: string): Promise<readonly OnDiskSession[]>;
+}
+
+/** Execute the common pre-use lifecycle without coupling callers to an
+ * adapter's hook layout. This is the only launcher entry point for runtime
+ * workspace preparation. */
+export async function prepareAgentRuntimeWorkspace(
+  adapter: CliAdapter,
+  ctx: AgentRuntimeWorkspaceContext,
+): Promise<void> {
+  await adapter.lifecycle?.prepareWorkspace?.(ctx);
 }
 
 export function isAgentRuntime(adapter: CliAdapter): boolean {

--- a/src/workspaces/conversation-control.spec.ts
+++ b/src/workspaces/conversation-control.spec.ts
@@ -24,7 +24,6 @@ function fakeAdapter(id = 'pi'): CliAdapter {
     kind: 'agent',
     capabilities: { headless: true },
     composeHeadlessCommand: () => [id],
-    bootstrap: vi.fn(async () => undefined),
   } as unknown as CliAdapter
 }
 

--- a/src/workspaces/conversation-control.ts
+++ b/src/workspaces/conversation-control.ts
@@ -241,11 +241,6 @@ export function createWorkspaceConversationControl(
         throw new Error(`agent runtime has no headless mode: ${agentId}`)
       }
 
-      await adapter.bootstrap?.({
-        wsId: meta.id,
-        cwd: meta.dir,
-        launcherRepoRoot: svc.config.launcherRepoRoot,
-      })
       const prompt = resolution.mode === 'exact'
         ? input.prompt
         : reconstructionPrompt(input.target, input.prompt, Boolean(continuingOrigin))

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -30,7 +30,12 @@ import { codexAdapter } from './adapters/codex.js';
 import { opencodeAdapter } from './adapters/opencode.js';
 import { piAdapter } from './adapters/pi.js';
 import { shellAdapter } from './adapters/shell.js';
-import { AdapterRegistry, isAgentRuntime, type CliAdapter } from './cli-adapter.js';
+import {
+  AdapterRegistry,
+  isAgentRuntime,
+  prepareAgentRuntimeWorkspace,
+  type CliAdapter,
+} from './cli-adapter.js';
 import { loadConfig, type ServerConfig } from './config.js';
 import { ensureAgentCredentialReady } from './agent-credential-readiness.js';
 import { logger as launcherLogger } from './logger.js';
@@ -856,13 +861,11 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
 
   const prepareRuntimeReadinessWorkspace = async (adapter: CliAdapter): Promise<WorkspaceMeta> => {
     const workspace = await resolveRuntimeReadinessWorkspace();
-    if (adapter.bootstrap) {
-      await adapter.bootstrap({
-        wsId: workspace.id,
-        cwd: workspace.dir,
-        launcherRepoRoot: config.launcherRepoRoot,
-      });
-    }
+    await prepareAgentRuntimeWorkspace(adapter, {
+      wsId: workspace.id,
+      cwd: workspace.dir,
+      launcherRepoRoot: config.launcherRepoRoot,
+    });
     return workspace;
   };
 
@@ -1129,6 +1132,11 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         adapter,
         logger: launcherLogger,
       });
+      await prepareAgentRuntimeWorkspace(adapter, {
+        wsId: ws.id,
+        cwd: ws.dir,
+        launcherRepoRoot: config.launcherRepoRoot,
+      });
       const { command, cwd, env, transcriptDir } = composeSpawnInputs(ws, adapter, resume);
       return await runHeadlessProbe({
         command,
@@ -1182,6 +1190,11 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         agentId: adapter.id,
         adapter,
         logger: launcherLogger,
+      });
+      await prepareAgentRuntimeWorkspace(adapter, {
+        wsId: ws.id,
+        cwd: ws.dir,
+        launcherRepoRoot: config.launcherRepoRoot,
       });
       if (catalog.get(ws.id)?.lifecycle !== 'active') {
         throw new Error(`workspace stopped accepting work before spawn: ${ws.id}`);

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -12,7 +12,7 @@ import {
   readWorkspaceDefaultContextWindow,
 } from '@/core/config.js';
 
-import type { AdapterRegistry } from './cli-adapter.js';
+import { prepareAgentRuntimeWorkspace, type AdapterRegistry } from './cli-adapter.js';
 import { injectWorkspaceContext } from './context-injector.js';
 import { injectWorkspaceCredentials } from './credential-injection.js';
 import type { Logger } from './logger.js';
@@ -234,21 +234,20 @@ export class WorkspaceCreator {
       };
     }
 
-    // Per-adapter technical bootstrap (MCP wiring, trust entries, …). Each
-    // adapter is responsible for idempotency. We log but don't fail the
-    // workspace create on a single adapter's bootstrap failure — the user
-    // can still use it manually, the launcher just won't have prepped it.
+    // Run the same per-runtime preparation hook used before later process
+    // launches. Hooks are idempotent. A single adapter failure does not fail
+    // Workspace creation; another enabled runtime can still be used.
     for (const a of agents) {
       const adapter = this.opts.adapterRegistry.get(a);
-      if (!adapter?.bootstrap) continue;
+      if (!adapter) continue;
       try {
-        await adapter.bootstrap({
+        await prepareAgentRuntimeWorkspace(adapter, {
           wsId: id,
           cwd: dir,
           launcherRepoRoot: this.opts.bootstrapEnv.launcherRepoRoot,
         });
       } catch (err) {
-        log.warn('adapter.bootstrap_failed', { agent: a, err });
+        log.warn('adapter.prepare_workspace_failed', { agent: a, err });
       }
     }
 


### PR DESCRIPTION
## Summary

- replace the ambiguous adapter bootstrap with a shared, idempotent `lifecycle.prepareWorkspace` hook used by Workspace creation, interactive TUI, resume, WebPi, headless, readiness, and probe paths
- give Pi Workspaces without an explicit project theme Pi's native `light/dark` automatic pair while preserving explicit project themes and the global Pi directory
- document the Orca-aligned ownership boundary and cover lifecycle/theme behavior with tests

## Why

Agent runtimes need one launcher-owned preparation boundary instead of adding a separate setup lifecycle to every surface. Pi theme selection then belongs in its adapter hook while Pi continues to own its TUI colors.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (339 files passed, 1 skipped; 3291 tests passed, 8 skipped)
- `pnpm electron:build`
- `pnpm electron:smoke:pty --skip-build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- isolated browser/dev Workspace: Pi rendered light in Day mode and changed live to dark in Night mode through terminal mode 2031

## Boundary

Touches runtime preparation, managed Pi, PTY/Electron, and docs. No trading, auth, credential schema, or persistence migration changes.