### PR TITLE
Use terminal-derived theme for OpenCode

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -333,6 +333,22 @@ Pi terminal appearance follows the same boundary used by Orca:
   OSC/DSR queries, and mode 2031. Pi remains responsible for its own TUI theme;
   OpenAlice does not generate or inject palette-specific Pi themes.
 
+Codex and OpenCode use that terminal boundary differently:
+
+- Codex natively probes OSC 10/11 at startup and derives its contrast-sensitive
+  TUI colors from the reported foreground and background. It needs no project
+  theme injection; OpenAlice's shared visible/headless terminal responders are
+  the complete Orca-aligned integration. Codex does not currently consume mode
+  2031 palette updates after startup, so relaunch a running Codex TUI after
+  switching between light and dark appearances.
+- OpenCode can consume the same terminal palette and mode 2031 updates, but its
+  native default is the fixed `opencode` theme. When a Workspace has no native
+  TUI config or legacy explicit theme, runtime preparation writes
+  `{ "theme": "system" }` to the dedicated `tui.json` project layer.
+- Existing `tui.json`, `tui.jsonc`, and legacy project theme choices remain
+  user-owned. OpenAlice does not generate an OpenCode palette or mix TUI
+  settings into the provider-owned `opencode.json` surface.
+
 Do not add external-Pi version probing or upgrade UX to preserve flags used by
 the packaged runtime. Compatibility for the packaged app is maintained by
 pinning and upgrading the bundled Pi with the OpenAlice release.
@@ -387,7 +403,8 @@ Provider injection into shared native JSON config is node-owned, not
 file-owned. Claude Code's `.claude/settings.local.json` and opencode's
 `opencode.json` preserve unknown/user keys and use their adjacent OpenAlice
 rollback sidecars for conflict-aware reset. Keep all native provider config and
-rollback paths in `_common.mjs`'s local git excludes.
+rollback paths, plus OpenCode's generated `tui.json`, in `_common.mjs`'s local
+git excludes.
 
 ## Packaging Invariants
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -179,6 +179,11 @@ lifecycle also gives Workspaces without an explicit Pi theme the native
 `light/dark` automatic pair. OpenAlice never redirects Pi away from its native
 global packages, settings, auth, or sessions and never replaces an explicit Pi
 project theme.
+OpenCode keeps provider configuration in `opencode.json` and TUI configuration
+in its native `tui.json` project layer. The runtime lifecycle selects the
+native `system` theme only when the project has no explicit OpenCode TUI or
+legacy theme config. Codex needs no project theme setting: it derives its
+palette directly from the terminal's OSC 10/11 replies.
 Claude Code and opencode keep reversible OpenAlice ownership metadata in
 `.claude/openalice-provider.json` and `.opencode/openalice-provider.json` so
 provider reset preserves unrelated native settings. Those files are sensitive

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -308,6 +308,83 @@ describe('codexAdapter AI-config', () => {
 describe('opencodeAdapter AI-config', () => {
   const mcpEnv = { OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp', AQ_WS_ID: 'ws-abc' };
 
+  it('prepares OpenCode to derive its theme from the terminal palette', async () => {
+    await mkdir(join(dir, '.git/info'), { recursive: true });
+    await writeFile(join(dir, '.git/info/exclude'), 'existing.local\n');
+
+    await prepareAgentRuntimeWorkspace(opencodeAdapter, {
+      wsId: 'ws-abc',
+      cwd: dir,
+      launcherRepoRoot: '/repo',
+    });
+    await prepareAgentRuntimeWorkspace(opencodeAdapter, {
+      wsId: 'ws-abc',
+      cwd: dir,
+      launcherRepoRoot: '/repo',
+    });
+
+    expect(JSON.parse(await read('tui.json'))).toEqual({
+      $schema: 'https://opencode.ai/tui.json',
+      theme: 'system',
+    });
+    expect((await read('.git/info/exclude')).split(/\r?\n/).filter((line) => line === 'tui.json'))
+      .toEqual(['tui.json']);
+  });
+
+  it('preserves an explicit OpenCode project theme and sibling TUI settings', async () => {
+    await writeFile(join(dir, 'tui.json'), JSON.stringify({ theme: 'catppuccin', scroll_speed: 2 }));
+
+    await prepareAgentRuntimeWorkspace(opencodeAdapter, {
+      wsId: 'ws-abc',
+      cwd: dir,
+      launcherRepoRoot: '/repo',
+    });
+
+    expect(JSON.parse(await read('tui.json'))).toEqual({ theme: 'catppuccin', scroll_speed: 2 });
+  });
+
+  it('adds the system theme without replacing sibling TUI settings', async () => {
+    await writeFile(join(dir, 'tui.json'), JSON.stringify({ scroll_speed: 2 }));
+
+    await prepareAgentRuntimeWorkspace(opencodeAdapter, {
+      wsId: 'ws-abc',
+      cwd: dir,
+      launcherRepoRoot: '/repo',
+    });
+
+    expect(JSON.parse(await read('tui.json'))).toEqual({
+      scroll_speed: 2,
+      $schema: 'https://opencode.ai/tui.json',
+      theme: 'system',
+    });
+  });
+
+  it('leaves a legacy OpenCode theme in provider config for native migration', async () => {
+    await writeFile(join(dir, 'opencode.json'), JSON.stringify({ theme: 'system', share: 'disabled' }));
+
+    await prepareAgentRuntimeWorkspace(opencodeAdapter, {
+      wsId: 'ws-abc',
+      cwd: dir,
+      launcherRepoRoot: '/repo',
+    });
+
+    expect(existsSync(join(dir, 'tui.json'))).toBe(false);
+    expect(JSON.parse(await read('opencode.json'))).toEqual({ theme: 'system', share: 'disabled' });
+  });
+
+  it('leaves JSONC TUI configuration to OpenCode', async () => {
+    await writeFile(join(dir, 'tui.jsonc'), '{ // user-owned\n  "scroll_speed": 2\n}\n');
+
+    await prepareAgentRuntimeWorkspace(opencodeAdapter, {
+      wsId: 'ws-abc',
+      cwd: dir,
+      launcherRepoRoot: '/repo',
+    });
+
+    expect(existsSync(join(dir, 'tui.json'))).toBe(false);
+    expect(await read('tui.jsonc')).toBe('{ // user-owned\n  "scroll_speed": 2\n}\n');
+  });
+
   it('keeps OpenAlice MCP out of opencode env even when an MCP URL is present', () => {
     const env = opencodeAdapter.composeEnv!({ cwd: dir, env: mcpEnv });
     expect(env['OPENCODE_DISABLE_MODELS_FETCH']).toBe('1');

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -38,6 +38,9 @@ const CODEX_INTERACTIVE_PERMISSION_ARGS = [
  *   `~/.codex/config.toml` `[projects."<abs>"] trust_level`. The shared
  *   runtime lifecycle pre-writes that entry so the launcher's spawn doesn't
  *   stall on the prompt.
+ * - Terminal appearance: Codex has no project UI-theme default to replace.
+ *   Its TUI probes OSC 10/11 at startup and derives contrast-sensitive colors
+ *   from the terminal defaults supplied by OpenAlice's shared PTY layer.
  *
  * AI provider model — two modes, mutually exclusive:
  *

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -1,18 +1,22 @@
 import { execFile } from 'node:child_process';
+import { statSync } from 'node:fs';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
 import type { CliAdapter, OnDiskSession, SpawnContext, WorkspaceAiCred } from '../cli-adapter.js';
 import { isModelReasoningEffort } from '../../ai-providers/model-semantics.js';
-import { readWorkspaceFile } from '../file-service.js';
+import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js';
 import type { HeadlessOutputEvent } from '../headless-output.js';
 import { resetOwnedJsonConfig, writeOwnedJsonConfig } from './owned-json-config.js';
 
 const execFileAsync = promisify(execFile);
 
 const OPENCODE_CONFIG_PATH = 'opencode.json';
+const OPENCODE_TUI_CONFIG_PATH = 'tui.json';
+const OPENCODE_TUI_CONFIGC_PATH = 'tui.jsonc';
 const OPENCODE_BINDING_STATE_PATH = '.opencode/openalice-provider.json';
 const OPENCODE_PROVIDER_NAME = 'workspace';
+const OPENCODE_SYSTEM_THEME = 'system';
 const OPENCODE_OWNED_PATHS = [
   ['$schema'],
   ['provider', OPENCODE_PROVIDER_NAME],
@@ -70,6 +74,59 @@ function positiveNumber(value: number | null | undefined): number | null {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
 }
 
+function parseJsonRecord(raw: string | null): Record<string, unknown> | null {
+  if (raw === null) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureOpenCodeTuiConfigExcluded(cwd: string): Promise<void> {
+  // OpenAlice workspaces are Git repositories, but adapter tests and external
+  // callers may prepare a plain directory. Do not manufacture a partial .git.
+  try {
+    if (!statSync(join(cwd, '.git')).isDirectory()) return;
+  } catch {
+    return;
+  }
+  const path = '.git/info/exclude';
+  const current = await readWorkspaceFile(cwd, path) ?? '';
+  if (current.split(/\r?\n/).includes(OPENCODE_TUI_CONFIG_PATH)) return;
+  const separator = current.length === 0 || current.endsWith('\n') ? '' : '\n';
+  await writeWorkspaceFile(cwd, path, `${current}${separator}${OPENCODE_TUI_CONFIG_PATH}\n`);
+}
+
+/**
+ * Select OpenCode's native terminal-derived theme for OpenAlice workspaces.
+ * The dedicated tui.json layer is supported by OpenCode 1.16+ and has higher
+ * precedence than global TUI settings. Existing native project configuration,
+ * including the legacy opencode.json theme that OpenCode migrates itself,
+ * remains user-owned.
+ */
+export async function syncOpenCodeWorkspaceTheme(cwd: string): Promise<boolean> {
+  await ensureOpenCodeTuiConfigExcluded(cwd);
+
+  // A JSONC project file is user-owned. Avoid creating a competing tui.json
+  // because OpenCode accepts both and their same-directory ordering is native.
+  if (await readWorkspaceFile(cwd, OPENCODE_TUI_CONFIGC_PATH) !== null) return false;
+
+  const tui = parseJsonRecord(await readWorkspaceFile(cwd, OPENCODE_TUI_CONFIG_PATH));
+  if (tui === null || Object.prototype.hasOwnProperty.call(tui, 'theme')) return false;
+
+  const legacy = parseJsonRecord(await readWorkspaceFile(cwd, OPENCODE_CONFIG_PATH));
+  if (legacy === null || Object.prototype.hasOwnProperty.call(legacy, 'theme')) return false;
+
+  tui['$schema'] ??= 'https://opencode.ai/tui.json';
+  tui['theme'] = OPENCODE_SYSTEM_THEME;
+  await writeWorkspaceFile(cwd, OPENCODE_TUI_CONFIG_PATH, `${JSON.stringify(tui, null, 2)}\n`);
+  return true;
+}
+
 /**
  * opencode (github.com/anomalyco/opencode, formerly sst/opencode; MIT, by
  * Dax Raad / SST). Provider-agnostic open-source agent CLI — the third adapter
@@ -93,6 +150,11 @@ function positiveNumber(value: number | null | undefined): number | null {
  *     `.codex/env.json`). OpenAlice owns only `provider.workspace`, the matching
  *     top-level model, and its schema marker; unrelated opencode config survives
  *     both writes and reset.
+ *
+ *   - Terminal appearance: the shared runtime lifecycle selects OpenCode's
+ *     native `system` TUI theme through `tui.json` only when the project has
+ *     no explicit TUI/legacy theme config. OpenCode then derives its palette
+ *     from the terminal and handles mode 2031 updates itself.
  *
  *   - Hermetic spawn: `OPENCODE_DISABLE_{MODELS_FETCH,AUTOUPDATE,LSP_DOWNLOAD}`
  *     pinned in `composeEnv` so a trading workbench never phones home at spawn
@@ -132,6 +194,12 @@ export const opencodeAdapter: CliAdapter = {
     // `opencode --session <id>` (composeCommand) resumes by id.
     transcriptDiscovery: 'subprocess',
     headless: true,
+  },
+
+  lifecycle: {
+    async prepareWorkspace({ cwd }): Promise<void> {
+      await syncOpenCodeWorkspaceTheme(cwd);
+    },
   },
 
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {

--- a/src/workspaces/templates/_common.mjs
+++ b/src/workspaces/templates/_common.mjs
@@ -63,6 +63,7 @@ const DEFAULT_EXCLUDES = [
   '.codex/env.json',
   '.codex/config.toml',
   'opencode.json',
+  'tui.json',
   '.opencode/openalice-provider.json',
   '.pi/settings.json',
   '.pi/openalice-provider.json',

--- a/src/workspaces/workspace-creation.e2e.spec.ts
+++ b/src/workspaces/workspace-creation.e2e.spec.ts
@@ -134,6 +134,7 @@ describe('chat workspace create: bootstrap → inject → commit', () => {
     const excludes = await readFile(join(dir, '.git/info/exclude'), 'utf8');
     expect(excludes).toContain('.claude/openalice-provider.json\n');
     expect(excludes).toContain('.opencode/openalice-provider.json\n');
+    expect(excludes).toContain('tui.json\n');
   });
 });
 


### PR DESCRIPTION
## What changed

- prepare OpenCode workspaces with its native `tui.json` `system` theme when no explicit project TUI or legacy theme exists
- preserve user-owned `tui.json`, `tui.jsonc`, and legacy `opencode.json.theme` choices
- keep generated TUI config local via `.git/info/exclude`
- document Codex's native OSC 10/11 startup palette behavior and its upstream live-toggle limitation
- add lifecycle, preservation, idempotence, and workspace-bootstrap coverage

## Why

OpenCode defaults to its fixed `opencode` theme even when the terminal implements the Orca-compatible OSC/DSR and mode 2031 color boundary. Selecting OpenCode's native `system` theme lets the TUI consume the shared terminal palette and react to light/dark mode updates without introducing a custom palette injector. Codex already uses the terminal boundary at startup, so it intentionally receives no project theme mutation.

## User impact

OpenCode now follows the selected OpenAlice palette in both day and night modes, including live mode switches. Explicit OpenCode theme choices remain untouched. Codex starts with the correct day/night palette; running Codex instances still need a relaunch after a light/dark switch because Codex does not currently consume mode 2031 updates.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm vitest run src/workspaces/adapters/ai-config.spec.ts src/workspaces/cli-adapter.spec.ts` (89 passed)
- `pnpm test` (3,313 passed; 8 skipped)
- `pnpm test:e2e` (30 passed; 3 skipped)
- `pnpm electron:smoke:pty --skip-build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- browser E2E: real OpenCode TUI followed live day/night palette changes; real Codex TUI started correctly in both day and night modes