### PR TITLE
Fix MiniMax reasoning transport selection

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -80,6 +80,17 @@ back to the Agent's native behavior. A model that documents only a thinking
 switch (for example LongCat 2.0) keeps `defaultEnabled` separate and never
 receives a fabricated effort tier.
 
+Wire selection normally follows the same rule: an explicit Workspace or
+creation-default protocol wins. A registered runtime incompatibility is the
+narrow exception. MiniMax's OpenAI Chat endpoint only separates thinking when
+`reasoning_split` is set, then returns it through the array-shaped
+`reasoning_details` extension. Pi and opencode's generic OpenAI transports do
+not consume that extension losslessly. Their own native MiniMax registrations,
+Models.dev, and MiniMax's AI SDK provider all choose the Anthropic-compatible
+path instead. OpenAlice therefore exposes only the Anthropic MiniMax wire to Pi
+and opencode; an old saved MiniMax OpenAI default is repaired to Anthropic on
+the next apply/injection so native thinking blocks and multi-turn replay survive.
+
 The native fields are deliberately runtime-owned projections of the same
 resolved value:
 

--- a/src/ai-providers/model-semantics.spec.ts
+++ b/src/ai-providers/model-semantics.spec.ts
@@ -39,6 +39,15 @@ describe('model semantics registry', () => {
     expect(describeModelSemantics(semantics)).toBe('Reasoning optional · thinking default on')
   })
 
+  it('keeps supported legacy MiniMax M2.5 workspaces reasoning-aware', () => {
+    expect(resolveModelSemantics('minimax', 'MiniMax-M2.5')).toEqual({
+      contextWindow: 204_800,
+      reasoning: { mode: 'adaptive', interleaved: true },
+    })
+    expect(resolveModelSemantics('minimax', 'MiniMax-M2.5-highspeed'))
+      .toEqual(resolveModelSemantics('minimax', 'MiniMax-M2.5'))
+  })
+
   it('registers every built-in vendor injection default', () => {
     for (const [vendor, model] of Object.entries(DEFAULT_MODEL_BY_VENDOR)) {
       expect(resolveModelSemantics(vendor, model), `${vendor}/${model}`).not.toBeNull()

--- a/src/ai-providers/model-semantics.ts
+++ b/src/ai-providers/model-semantics.ts
@@ -78,7 +78,8 @@ const GEMINI_3_CONTEXT = 1_048_576
  * - OpenAI model/reasoning guides: https://developers.openai.com/api/docs/guides/latest-model
  * - Anthropic extended/adaptive thinking: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
  * - Gemini thinking: https://ai.google.dev/gemini-api/docs/generate-content/thinking
- * - MiniMax text models: https://platform.minimax.io/docs/guides/text-generation
+ * - MiniMax Anthropic API: https://platform.minimax.io/docs/api-reference/text-anthropic-api
+ * - MiniMax OpenAI `reasoning_split`: https://platform.minimax.io/docs/api-reference/text-openai-api
  * - Kimi thinking models: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
  * - DeepSeek thinking: https://api-docs.deepseek.com/guides/thinking_mode
  * - LongCat Chat API: https://longcat.chat/platform/docs/api/chat.html
@@ -202,6 +203,18 @@ export const MODEL_SEMANTICS_BY_VENDOR: Registry = {
       reasoning: { mode: 'adaptive', interleaved: true },
     },
     'MiniMax-M2.7': {
+      contextWindow: 204_800,
+      reasoning: { mode: 'adaptive', interleaved: true },
+    },
+    'MiniMax-M2.7-highspeed': {
+      contextWindow: 204_800,
+      reasoning: { mode: 'adaptive', interleaved: true },
+    },
+    'MiniMax-M2.5': {
+      contextWindow: 204_800,
+      reasoning: { mode: 'adaptive', interleaved: true },
+    },
+    'MiniMax-M2.5-highspeed': {
       contextWindow: 204_800,
       reasoning: { mode: 'adaptive', interleaved: true },
     },

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -236,7 +236,7 @@ export const MINIMAX: PresetDef = {
   description: 'MiniMax models via Claude Agent SDK (Anthropic-compatible)',
   category: 'third-party',
   defaultName: 'MiniMax',
-  hint: 'China console: minimaxi.com — International console: minimax.io. API keys are region-locked. MiniMax authenticates via Authorization: Bearer; the international endpoint (api.minimax.io) rejects x-api-key.',
+  hint: 'China console: minimaxi.com — International console: minimax.io. API keys are region-locked. Pi and opencode use MiniMax\'s Anthropic-compatible endpoint so thinking stays in native reasoning blocks; the OpenAI-compatible reasoning_details extension is not losslessly supported by their generic transports.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
@@ -265,7 +265,7 @@ export const MINIMAX: PresetDef = {
     apiKeyLabel: 'MiniMax API key',
     apiKeyHelp: 'Use the API key issued by the MiniMax platform selected above. China and International keys are not interchangeable.',
     modelHelp: 'MiniMax model IDs are case-sensitive. Pick a suggestion or paste the exact model ID shown by the selected platform.',
-    regionHelp: 'Choose the platform that issued this key. OpenAlice will store both supported API protocols for that region.',
+    regionHelp: 'Choose the platform that issued this key. OpenAlice stores both provider endpoints, while current coding runtimes use the Anthropic-compatible path for complete reasoning capture and replay.',
   },
   writeOnlyFields: ['apiKey'],
 }

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -18,6 +18,7 @@ import { opencodeAdapter } from './opencode.js';
 import { piAdapter, syncPiProjectTrust, syncPiWindowsShellPath } from './pi.js';
 import { migrateLegacyPiAgentDir, piWorkspaceProviderId } from './pi-config.js';
 import { prepareAgentRuntimeWorkspace } from '../cli-adapter.js';
+import { credentialToWorkspaceAiCred } from '../credential-injection.js';
 
 let dir: string;
 
@@ -494,6 +495,35 @@ describe('opencodeAdapter AI-config', () => {
       wireShape: 'anthropic',
       authMode: 'bearer',
     });
+  });
+
+  it('writes the automatic MiniMax opencode binding through native Anthropic thinking blocks', async () => {
+    const cred = credentialToWorkspaceAiCred({
+      vendor: 'minimax',
+      apiKey: 'mm-key',
+      wires: {
+        anthropic: 'https://api.minimax.io/anthropic',
+        'openai-chat': 'https://api.minimax.io/v1',
+      },
+    }, 'opencode', { model: 'MiniMax-M2.5' })!;
+
+    await opencodeAdapter.writeAiConfig!(dir, cred);
+    const config = JSON.parse(await read('opencode.json'));
+    expect(config.provider.workspace).toMatchObject({
+      npm: '@ai-sdk/anthropic',
+      options: {
+        baseURL: 'https://api.minimax.io/anthropic',
+        headers: { Authorization: 'Bearer mm-key' },
+      },
+      models: {
+        'MiniMax-M2.5': {
+          name: 'MiniMax-M2.5',
+          reasoning: true,
+          limit: { context: 204_800, output: 16_384 },
+        },
+      },
+    });
+    expect(config.model).toBe('workspace/MiniMax-M2.5');
   });
 
   it('reset (empty cred) deletes opencode.json', async () => {

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -90,16 +90,44 @@ describe('credentialToWorkspaceAiCred', () => {
         expect(cred.apiKey).toBe('k')
         expect(cred.baseUrl).toBe('https://gw.example.com/v1')
       })
+
+      it(`${agent}: defaults MiniMax to its Anthropic coding-agent wire`, () => {
+        const cred = credentialToWorkspaceAiCred(minimaxIntl, agent, { model: 'MiniMax-M2.5' })!
+        expect(cred).toMatchObject({
+          wireShape: 'anthropic',
+          baseUrl: 'https://api.minimax.io/anthropic',
+          authMode: 'bearer',
+          contextWindow: 204_800,
+          reasoning: true,
+        })
+      })
+
+      it(`${agent}: upgrades an old official MiniMax OpenAI-only credential`, () => {
+        const legacyOpenAIOnly: Credential = {
+          vendor: 'minimax',
+          authType: 'api-key',
+          apiKey: 'old-mm-key',
+          wires: { 'openai-chat': 'https://api.minimaxi.com/v1' },
+        }
+        expect(credentialToWorkspaceAiCred(legacyOpenAIOnly, agent, {
+          model: 'MiniMax-M2.5',
+          wireShape: 'openai-chat',
+        })).toMatchObject({
+          wireShape: 'anthropic',
+          baseUrl: 'https://api.minimaxi.com/anthropic',
+          authMode: 'bearer',
+        })
+      })
     }
   })
 
-  it('honors an explicit compatible wire and rejects an incompatible one', () => {
+  it('repairs legacy MiniMax OpenAI selections and rejects other incompatible wires', () => {
     for (const agent of ['opencode', 'pi']) {
-      const anthropic = credentialToWorkspaceAiCred(minimaxIntl, agent, {
+      const repaired = credentialToWorkspaceAiCred(minimaxIntl, agent, {
         model: 'MiniMax-M3',
-        wireShape: 'anthropic',
+        wireShape: 'openai-chat',
       })!
-      expect(anthropic).toMatchObject({
+      expect(repaired).toMatchObject({
         wireShape: 'anthropic',
         baseUrl: 'https://api.minimax.io/anthropic',
         authMode: 'bearer',

--- a/src/workspaces/credential-injection.ts
+++ b/src/workspaces/credential-injection.ts
@@ -41,6 +41,52 @@ export const AGENT_WIRE_PREFERENCE: Record<string, CredentialWireShape[]> = {
   pi: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
 }
 
+/**
+ * Provider-specific support inside an agent's wire set.
+ *
+ * MiniMax is the deliberate exception to the generic OpenAI-compatible set:
+ * its Anthropic endpoint is the documented coding-agent path and returns
+ * native thinking blocks. The OpenAI endpoint requires `reasoning_split` and
+ * returns an array-shaped `reasoning_details` extension that Pi and opencode's
+ * generic OpenAI transports do not parse losslessly. Do not expose a protocol
+ * choice that silently turns reasoning into visible `<think>` text or drops it.
+ */
+export function agentWirePreference(
+  agentId: string,
+  vendor?: string | null,
+): CredentialWireShape[] {
+  const preference = AGENT_WIRE_PREFERENCE[agentId]
+    ?? ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses']
+  if (vendor !== 'minimax' || (agentId !== 'opencode' && agentId !== 'pi')) return preference
+  return ['anthropic']
+}
+
+function inferredMinimaxAnthropicEndpoint(
+  wires: Partial<Record<CredentialWireShape, string>>,
+): string | undefined {
+  const chatEndpoint = wires['openai-chat']?.trim()
+  if (!chatEndpoint) return undefined
+  try {
+    const url = new URL(chatEndpoint)
+    if (url.hostname !== 'api.minimax.io' && url.hostname !== 'api.minimaxi.com') return undefined
+    return `${url.origin}/anthropic`
+  } catch {
+    return undefined
+  }
+}
+
+function wireEndpoint(
+  wires: Partial<Record<CredentialWireShape, string>>,
+  shape: CredentialWireShape,
+  vendor?: string | null,
+): string | undefined {
+  if (Object.prototype.hasOwnProperty.call(wires, shape)) return wires[shape] ?? ''
+  if (vendor === 'minimax' && shape === 'anthropic') {
+    return inferredMinimaxAnthropicEndpoint(wires)
+  }
+  return undefined
+}
+
 // Modern coding models are commonly sold as long-context runtimes. Pi defaults
 // unknown custom models to 128k and opencode defaults unknown limits to 0, so
 // new OpenAlice injections state the assumption explicitly while keeping the
@@ -59,7 +105,7 @@ export function compatibleCredentials(
   agentId: string,
 ): Array<[string, Credential]> {
   return Object.entries(credentials).filter(
-    ([, cred]) => pickAgentWire(credentialWires(cred), agentId) !== null,
+    ([, cred]) => pickAgentWire(credentialWires(cred), agentId, undefined, cred.vendor) !== null,
   )
 }
 
@@ -96,15 +142,30 @@ export function pickAgentWire(
   wires: Partial<Record<CredentialWireShape, string>>,
   agentId: string,
   requestedShape?: CredentialWireShape,
+  vendor?: string | null,
 ): { shape: CredentialWireShape; baseUrl: string } | null {
-  const pref = AGENT_WIRE_PREFERENCE[agentId]
-    ?? ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses']
+  const pref = agentWirePreference(agentId, vendor)
   if (requestedShape !== undefined) {
-    if (!pref.includes(requestedShape) || !(requestedShape in wires)) return null
-    return { shape: requestedShape, baseUrl: wires[requestedShape] ?? '' }
+    const requestedEndpoint = wireEndpoint(wires, requestedShape, vendor)
+    if (pref.includes(requestedShape) && requestedEndpoint !== undefined) {
+      return { shape: requestedShape, baseUrl: requestedEndpoint }
+    }
+    // Heal Workspace defaults saved before MiniMax's native-thinking boundary
+    // was registered. This is intentionally narrower than a generic fallback:
+    // other explicit protocol mismatches remain loud incompatibilities.
+    if (
+      vendor === 'minimax' &&
+      (agentId === 'opencode' || agentId === 'pi') &&
+      requestedShape === 'openai-chat' &&
+      wireEndpoint(wires, 'anthropic', vendor) !== undefined
+    ) {
+      return { shape: 'anthropic', baseUrl: wireEndpoint(wires, 'anthropic', vendor)! }
+    }
+    return null
   }
   for (const shape of pref) {
-    if (shape in wires) return { shape, baseUrl: wires[shape] ?? '' }
+    const endpoint = wireEndpoint(wires, shape, vendor)
+    if (endpoint !== undefined) return { shape, baseUrl: endpoint }
   }
   return null
 }
@@ -138,7 +199,7 @@ export function credentialToWorkspaceAiCred(
   overrides: CredentialInjectionOverrides = {},
 ): WorkspaceAiCred | null {
   const wires = credentialWires(credential as Credential)
-  const picked = pickAgentWire(wires, agentId, overrides.wireShape)
+  const picked = pickAgentWire(wires, agentId, overrides.wireShape, credential.vendor)
   if (!picked) return null
 
   const cred: WorkspaceAiCred = {

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
@@ -76,6 +76,39 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('WorkspaceAIConfigModal local model metadata', () => {
+  it('repairs a saved MiniMax OpenAI wire and removes the lossy protocol choice', async () => {
+    const minimaxPi = {
+      ...savedPi,
+      baseUrl: 'https://api.minimax.io/v1',
+      model: 'MiniMax-M2.5',
+    }
+    mocks.getAgentConfig.mockReset().mockResolvedValue({
+      claude: null,
+      codex: null,
+      opencode: null,
+      pi: minimaxPi,
+    })
+    mocks.listCredentials.mockResolvedValue([{
+      slug: 'minimax-test',
+      vendor: 'minimax',
+      authType: 'api-key',
+      wires: {
+        anthropic: 'https://api.minimax.io/anthropic',
+        'openai-chat': 'https://api.minimax.io/v1',
+      },
+      apiKey: 'secret',
+    }])
+
+    render(
+      <WorkspaceAIConfigModal wsId="chat-1" initialSection="ai" initialAgent="pi" onClose={vi.fn()} />,
+    )
+
+    const protocol = await screen.findByRole('combobox', { name: 'Pi API 协议' }) as HTMLSelectElement
+    await screen.findByRole('button', { name: '测试' })
+    expect(protocol.value).toBe('anthropic')
+    expect(Array.from(protocol.options).map((option) => option.value)).toEqual(['anthropic'])
+  })
+
   it('shows LongCat\'s real thinking default without inventing an effort selector', async () => {
     mocks.getAgentConfig.mockReset().mockResolvedValue({
       claude: null,

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -271,13 +271,42 @@ export function WorkspaceAIConfigModal({
 
   const form = { claude: claudeForm, codex: codexForm, opencode: opencodeForm, pi: piForm }[tab]
   const setForm = { claude: setClaudeForm, codex: setCodexForm, opencode: setOpencodeForm, pi: setPiForm }[tab]
+  const formCredentialByKey = useMemo(() => credentials.find((credential) => (
+    !!credential.apiKey && credential.apiKey === form.apiKey.trim()
+  )) ?? null, [credentials, form.apiKey])
   const formCredentialVendor = useMemo(() => {
     const selected = credentials.find((credential) => credential.slug === pickedCredential)
-    const matchedByKey = credentials.find((credential) => (
-      !!credential.apiKey && credential.apiKey === form.apiKey.trim()
-    ))
-    return selected?.vendor ?? matchedByKey?.vendor ?? null
-  }, [credentials, form.apiKey, pickedCredential])
+    return selected?.vendor ?? formCredentialByKey?.vendor ?? null
+  }, [credentials, formCredentialByKey, pickedCredential])
+  const formWireOptions = useMemo(() => {
+    if (tab !== 'opencode' && tab !== 'pi') return []
+    return formCredentialByKey?.vendor === 'minimax'
+      ? agentWireShapes(formCredentialByKey.wires, tab, formCredentialByKey.vendor)
+      : AGENT_WIRE_PREFERENCE[tab] ?? []
+  }, [formCredentialByKey, tab])
+
+  useEffect(() => {
+    if (
+      (tab !== 'opencode' && tab !== 'pi') ||
+      formCredentialByKey?.vendor !== 'minimax'
+    ) return
+    if (formWireOptions.includes(form.wireShape)) return
+    const repaired = pickAgentWire(
+      formCredentialByKey.wires,
+      tab,
+      form.wireShape,
+      formCredentialByKey.vendor,
+    )
+    if (!repaired || repaired.shape === form.wireShape) return
+    setForm({
+      ...form,
+      wireShape: repaired.shape,
+      baseUrl: repaired.baseUrl,
+      ...(repaired.shape === 'anthropic'
+        ? { authMode: anthropicAuthModeForBaseUrl(repaired.baseUrl) }
+        : {}),
+    })
+  }, [form, formCredentialByKey, formWireOptions, setForm, tab])
   // Model-id suggestions for the current field: infer the provider vendor from
   // the matched vault credential first, then its entered baseUrl (api.z.ai →
   // glm, …), with the tab as fallback. Official endpoints may intentionally be
@@ -343,7 +372,7 @@ export function WorkspaceAIConfigModal({
     if (!cred) return
     // Pick the wire this tab's agent speaks from the credential's capabilities.
     // (The picker only lists compatible credentials, so this is non-null.)
-    const picked = pickAgentWire(cred.wires, tab, pickedWireShape || undefined)
+    const picked = pickAgentWire(cred.wires, tab, pickedWireShape || undefined, cred.vendor)
     if (!picked) return
     // Prefer the model this credential last used. A newly-created credential
     // falls back to the catalog's explicit default, not list order: catalogs
@@ -684,10 +713,10 @@ export function WorkspaceAIConfigModal({
               // Only credentials that declare a wire THIS agent speaks. Codex is
               // Responses-only, so most credentials won't list here — the funnel
               // toward pi/opencode is by design.
-              const compatible = credentials.filter((c) => pickAgentWire(c.wires, tab))
+              const compatible = credentials.filter((c) => pickAgentWire(c.wires, tab, undefined, c.vendor))
               const selectedCredential = compatible.find((c) => c.slug === pickedCredential)
               const selectedWireOptions = selectedCredential
-                ? agentWireShapes(selectedCredential.wires, tab)
+                ? agentWireShapes(selectedCredential.wires, tab, selectedCredential.vendor)
                 : []
               return (
                 <>
@@ -699,7 +728,7 @@ export function WorkspaceAIConfigModal({
                         const slug = e.target.value
                         const cred = compatible.find((candidate) => candidate.slug === slug)
                         setPickedCredential(slug)
-                        setPickedWireShape(cred ? (agentWireShapes(cred.wires, tab)[0] ?? '') : '')
+                        setPickedWireShape(cred ? (agentWireShapes(cred.wires, tab, cred.vendor)[0] ?? '') : '')
                       }}
                       className={inputClass + ' flex-1'}
                       disabled={compatible.length === 0}
@@ -710,7 +739,7 @@ export function WorkspaceAIConfigModal({
                           : t('workspaceSettings.ai.selectCredential')}
                       </option>
                       {compatible.map((cred) => {
-                        const shapes = agentWireShapes(cred.wires, tab)
+                        const shapes = agentWireShapes(cred.wires, tab, cred.vendor)
                         return (
                           <option key={cred.slug} value={cred.slug}>
                             {(cred.label?.trim() || cred.slug)}{shapes.length > 1 ? ` · ${t('workspaceSettings.ai.protocolCount', { count: shapes.length })}` : ''}
@@ -771,7 +800,7 @@ export function WorkspaceAIConfigModal({
                 }}
                 className={inputClass}
               >
-                {(AGENT_WIRE_PREFERENCE[tab] ?? []).map((shape) => (
+                {formWireOptions.map((shape) => (
                   <option key={shape} value={shape}>{WIRE_SHAPE_GUIDANCE[shape]}</option>
                 ))}
               </select>

--- a/ui/src/lib/presetHelpers.spec.ts
+++ b/ui/src/lib/presetHelpers.spec.ts
@@ -54,8 +54,27 @@ describe('agent wire selection', () => {
     expect(agentWireShapes(multiWire, 'opencode')).toEqual(['openai-chat', 'anthropic'])
   })
 
-  it('honors an explicit compatible protocol and rejects an incompatible one', () => {
+  it('only exposes MiniMax Anthropic to coding CLIs without changing generic providers', () => {
+    expect(agentWireShapes(multiWire, 'pi', 'minimax')).toEqual(['anthropic'])
+    expect(agentWireShapes(multiWire, 'opencode', 'minimax')).toEqual(['anthropic'])
+    expect(pickAgentWire(multiWire, 'opencode', undefined, 'minimax')?.shape).toBe('anthropic')
+  })
+
+  it('derives the native endpoint for an old official MiniMax OpenAI-only credential', () => {
+    const oldCredential = { 'openai-chat': 'https://api.minimaxi.com/v1' } as const
+    expect(agentWireShapes(oldCredential, 'pi', 'minimax')).toEqual(['anthropic'])
+    expect(pickAgentWire(oldCredential, 'pi', 'openai-chat', 'minimax')).toEqual({
+      shape: 'anthropic',
+      baseUrl: 'https://api.minimaxi.com/anthropic',
+    })
+  })
+
+  it('repairs an old MiniMax OpenAI default and rejects other incompatible protocols', () => {
     expect(pickAgentWire(multiWire, 'pi', 'anthropic')).toEqual({
+      shape: 'anthropic',
+      baseUrl: 'https://provider.example/anthropic',
+    })
+    expect(pickAgentWire(multiWire, 'pi', 'openai-chat', 'minimax')).toEqual({
       shape: 'anthropic',
       baseUrl: 'https://provider.example/anthropic',
     })

--- a/ui/src/lib/presetHelpers.ts
+++ b/ui/src/lib/presetHelpers.ts
@@ -72,19 +72,71 @@ export const AGENT_WIRE_PREFERENCE: Record<string, WireShape[]> = {
   pi: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
 }
 
+/** Keep provider-aware runtime support aligned with the backend injector. */
+export function agentWirePreference(agentId: string, vendor?: string | null): WireShape[] {
+  const preference = AGENT_WIRE_PREFERENCE[agentId] ?? SHAPE_ORDER
+  if (vendor !== 'minimax' || (agentId !== 'opencode' && agentId !== 'pi')) return preference
+  // MiniMax OpenAI Chat emits its separated thinking as the non-standard
+  // `reasoning_details[]` extension. Neither runtime's generic OpenAI adapter
+  // consumes it losslessly; both runtimes' native MiniMax integrations use the
+  // Anthropic endpoint instead.
+  return ['anthropic']
+}
+
+function inferredMinimaxAnthropicEndpoint(
+  wires: Partial<Record<WireShape, string>>,
+): string | undefined {
+  const chatEndpoint = wires['openai-chat']?.trim()
+  if (!chatEndpoint) return undefined
+  try {
+    const url = new URL(chatEndpoint)
+    if (url.hostname !== 'api.minimax.io' && url.hostname !== 'api.minimaxi.com') return undefined
+    return `${url.origin}/anthropic`
+  } catch {
+    return undefined
+  }
+}
+
+function wireEndpoint(
+  wires: Partial<Record<WireShape, string>>,
+  shape: WireShape,
+  vendor?: string | null,
+): string | undefined {
+  if (Object.prototype.hasOwnProperty.call(wires, shape)) return wires[shape] ?? ''
+  if (vendor === 'minimax' && shape === 'anthropic') {
+    return inferredMinimaxAnthropicEndpoint(wires)
+  }
+  return undefined
+}
+
 /** Pick the wire an agent should use from a credential's capabilities (null = none compatible). */
 export function pickAgentWire(
   wires: Partial<Record<WireShape, string>>,
   agentId: string,
   requestedShape?: WireShape,
+  vendor?: string | null,
 ): { shape: WireShape; baseUrl: string } | null {
-  const pref = AGENT_WIRE_PREFERENCE[agentId] ?? SHAPE_ORDER
+  const pref = agentWirePreference(agentId, vendor)
   if (requestedShape !== undefined) {
-    if (!pref.includes(requestedShape) || !(requestedShape in wires)) return null
-    return { shape: requestedShape, baseUrl: wires[requestedShape] ?? '' }
+    const requestedEndpoint = wireEndpoint(wires, requestedShape, vendor)
+    if (pref.includes(requestedShape) && requestedEndpoint !== undefined) {
+      return { shape: requestedShape, baseUrl: requestedEndpoint }
+    }
+    // Transparently repair an old MiniMax OpenAI default when the credential
+    // still carries the native Anthropic endpoint.
+    if (
+      vendor === 'minimax' &&
+      (agentId === 'opencode' || agentId === 'pi') &&
+      requestedShape === 'openai-chat' &&
+      wireEndpoint(wires, 'anthropic', vendor) !== undefined
+    ) {
+      return { shape: 'anthropic', baseUrl: wireEndpoint(wires, 'anthropic', vendor)! }
+    }
+    return null
   }
   for (const shape of pref) {
-    if (shape in wires) return { shape, baseUrl: wires[shape] ?? '' }
+    const endpoint = wireEndpoint(wires, shape, vendor)
+    if (endpoint !== undefined) return { shape, baseUrl: endpoint }
   }
   return null
 }
@@ -93,9 +145,10 @@ export function pickAgentWire(
 export function agentWireShapes(
   wires: Partial<Record<WireShape, string>>,
   agentId: string,
+  vendor?: string | null,
 ): WireShape[] {
-  const pref = AGENT_WIRE_PREFERENCE[agentId] ?? SHAPE_ORDER
-  return pref.filter((shape) => shape in wires)
+  const pref = agentWirePreference(agentId, vendor)
+  return pref.filter((shape) => wireEndpoint(wires, shape, vendor) !== undefined)
 }
 
 /** Agent runtimes that can consume at least one declared wire shape. */

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -329,7 +329,7 @@ function WorkspaceDefaultsSection({ credentials, presets }: { credentials: Crede
     const nextDefaults = { ...data.defaults }
     if (slug) {
       const cred = credentials.find((candidate) => candidate.slug === slug)
-      const wireShape = cred ? agentWireShapes(cred.wires, agentId)[0] : undefined
+      const wireShape = cred ? agentWireShapes(cred.wires, agentId, cred.vendor)[0] : undefined
       nextDefaults[agentId] = { credentialSlug: slug, ...(wireShape ? { wireShape } : {}) }
     } else {
       delete nextDefaults[agentId]
@@ -380,7 +380,9 @@ function WorkspaceDefaultsSection({ credentials, presets }: { credentials: Crede
     const options = data?.compatibleByAgent[agent.id] ?? []
     const current = data?.defaults[agent.id]?.credentialSlug ?? ''
     const selectedCredential = credentials.find((candidate) => candidate.slug === current)
-    const wireShapes = selectedCredential ? agentWireShapes(selectedCredential.wires, agent.id) : []
+    const wireShapes = selectedCredential
+      ? agentWireShapes(selectedCredential.wires, agent.id, selectedCredential.vendor)
+      : []
     const configuredWire = data?.defaults[agent.id]?.wireShape
     const selectedWire = configuredWire && wireShapes.includes(configuredWire)
       ? configuredWire


### PR DESCRIPTION
## Summary

- route MiniMax credentials through the Anthropic-compatible wire for Pi and opencode
- repair legacy MiniMax OpenAI selections, including official OpenAI-only credentials
- register current and legacy MiniMax reasoning/context semantics and explain the `reasoning_details` boundary
- restrict the Workspace protocol picker so MiniMax cannot fall back to a lossy generic OpenAI transport

## Root cause

MiniMax’s OpenAI-compatible endpoint only separates thinking when `reasoning_split` is enabled, then returns it as an array-shaped `reasoning_details` extension. Pi and opencode’s generic OpenAI transports do not parse that extension losslessly, so the old generic OpenAI-first selection exposed raw `<think>` text or would have dropped reasoning. Both runtimes’ native MiniMax integrations use the Anthropic-compatible endpoint instead.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (3326 passed, 8 skipped)
- real Workspace Settings verification for Pi and opencode: MiniMax exposes only Anthropic Messages
