### PR TITLE
Prepare the 0.83.0 beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.82.0-beta",
+  "version": "0.83.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## What changed

Bump the OpenAlice application version from `0.82.0-beta` to `0.83.0-beta` so the next `dev` → `master` promotion produces a new release candidate and tag `v0.83.0-beta`.

## Release intent

This is a beta prerelease. The GitHub release workflow will run only after the fully gated promotion reaches `master`; it will build signed/notarized macOS candidates, the Windows candidate, Broker Packs, Workspace acceptance, installer/remote acceptance, tag publication, and CDN mirroring.

## Validation

- confirmed `v0.83.0-beta` does not exist
- `node -p "require('./package.json').version"` → `0.83.0-beta`
- `npx tsc --noEmit`
- targeted version/update/release-asset tests — 3 files, 7 tests passed
- the exact pre-bump code already passed the full 3310-test suite, real browser verification, and packaged Electron Workspace acceptance in #692
