### PR TITLE
Fix workspace CLI guidance recovery

### DIFF
--- a/default/skills/alice-uta/SKILL.md
+++ b/default/skills/alice-uta/SKILL.md
@@ -1,23 +1,28 @@
 ---
 name: alice-uta
 description: >
-  Trading on your shell PATH via the `alice-uta` CLI — OpenAlice's trading
-  surface. These commands MUTATE real broker state, so resolve the
-  broker-native contract first and report every result. Use whenever you need
-  to place / modify / cancel an order; close a position; check an account,
-  portfolio, or order/trade history; resolve a contract or quote; or drive the
-  trading-as-git approval flow: "place a buy order for AAPL", "what's my
-  position in ETH", "close half my TSLA", "find the contract for this option",
-  "show pending trades", "approve my orders". Discover every group, verb, and
-  flag with `alice-uta --help` and `alice-uta <group> <verb> --help` — do NOT
-  guess flags.
+  Read broker accounts, portfolios, contracts, quotes, and order history, or
+  manage approved trading, through the `alice-uta` executable on the shell
+  PATH. Account/contract/history reads are safe and do not mutate broker state;
+  order writes, position-close, commit, push, reject, sync, and simulator
+  commands may change trading state. Use for "what's my position", "quote this
+  contract", "place or cancel an order", and the trading-as-git approval flow.
+  Run the documented command lines through Bash/Shell, never as tool names.
+  Discover current flags with `alice-uta <group> <verb> --help`; do not guess
+  aliases.
 ---
 
 # Trading — `alice-uta`
 
-Accounts, portfolio, orders, and the trading-as-git approval flow. **These
-mutate real broker state** — discover before you act, and act only on what
-the user's instructions actually cover.
+Accounts, portfolio, contracts, orders, and the trading-as-git approval flow.
+`alice-uta` is a **shell executable**. Invoke every command below through the
+Agent Runtime's Bash/Shell tool; never submit the whole command line as a tool
+name.
+
+Account, portfolio, contract, quote, market-clock, and history reads do not
+mutate broker state. Order writes, position closes, approval commands, and the
+simulator can mutate trading state: inspect their live help before acting, and
+act only on what the user's instructions actually cover.
 
 ## Discover, don't guess
 
@@ -26,20 +31,40 @@ alice-uta --help                       # the groups
 alice-uta <group> <verb> --help        # a verb's flags (which are required)
 ```
 
-## Accounts & portfolio
+Read this skill before the first UTA command in a task. If a command is
+rejected, follow the CLI's suggested command or run the exact verb's `--help`
+before retrying. Do not improvise a positional account id or flags such as
+`--account`, `--query`, or `--symbols`.
+
+## Common read-only recipes
 
 ```bash
-alice-uta account list                 # registered trading accounts + capabilities
-alice-uta account info --help          # one account's detail
-alice-uta account portfolio --help     # positions for an account
+alice-uta account list
+alice-uta account info --source <account-id>
+alice-uta account portfolio                         # every trading account
+alice-uta account portfolio --source <account-id>   # one account
+alice-uta account portfolio --source <account-id> --symbol AAPL
 ```
 
-## Resolve the contract first
+`--source` takes the id returned by `account list`; it is not `--account` and
+is not a broker-native account number.
+
+Resolve a broker contract before requesting a quote. Search uses `--pattern`
+(not `--query`). Quote accepts exactly one broker-resolved `--alice-id` at a
+time; repeat the command for multiple contracts rather than inventing a
+`--symbols` flag. Quote infers its account from the `aliceId` prefix.
 
 ```bash
-alice-uta contract search --help       # find the broker-native contract
-alice-uta contract details --help      # its full identity
-alice-uta contract quote --help        # a quote
+alice-uta contract search --source <account-id> --pattern AAPL
+alice-uta contract details --source <account-id> --alice-id '<alice-id-from-search>'
+alice-uta contract quote --alice-id '<alice-id-from-search>'
+```
+
+Keep `aliceId` values quoted because they contain `|`, which a shell otherwise
+interprets as a pipe. Contract search may return a directory rather than a
+tradeable leaf; expand it before quoting or ordering:
+
+```bash
 alice-uta contract expand --help       # expand a directory-style result (chains, families)
 ```
 

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -36,7 +36,7 @@ One concept has one primary owner:
 | Issue file shape, ownership, schedules, headless delivery | `self-scheduling` |
 | Low-frequency market/fundamental/macro data | `traderhub` |
 | Quantitative K-line panels and source choice | `alice-analysis` |
-| Broker state and trading writes | `alice-uta` |
+| Broker accounts/contracts/quotes and trading writes | `alice-uta` |
 
 Other instructions may route to that owner but should not copy its manual.
 
@@ -45,8 +45,10 @@ Other instructions may route to that owner but should not copy its manual.
 The CLI manifest and tool results are the final authority for verbs, flags, and
 validation. Durable Workspaces can carry old skill snapshots, so errors should
 be self-correcting: say what boundary was crossed and name the next appropriate
-command. A bare validation failure that forces the agent to guess is a product
-bug.
+command. Reject unknown flags and positional arguments before invocation, show
+the accepted flags, and give a semantic recovery command for common old or
+guessed routes. A bare validation failure that forces the agent to guess is a
+product bug.
 
 Use the real shim in the verification loop; direct tool calls do not exercise
 argv parsing or manifest help.

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -65,19 +65,31 @@ async function main() {
 
   const m = await manifest(base)
   const groupCmds = m.groups[group]
-  if (!groupCmds) fail(`unknown group "${group}". Run \`${BIN}\` to list groups.`)
+  if (!groupCmds) {
+    const recovery = commandRecoveryHint(group)
+    fail(
+      `unknown group "${group}". Run \`${BIN}\` to list groups.` +
+        (recovery ? `\n${recovery}` : ''),
+    )
+  }
 
   // `<bin> <group>` / `<bin> <group> --help` -> verb listing
   if (!verb || (wantsHelp && !m.groups[group][verb])) return printVerbs(group, groupCmds)
 
   const cmd = groupCmds[verb]
-  if (!cmd) fail(`unknown command "${group} ${verb}". Run \`${BIN} ${group}\` to list verbs.`)
+  if (!cmd) {
+    const recovery = commandRecoveryHint(group, verb)
+    fail(
+      `unknown command "${group} ${verb}". Run \`${BIN} ${group}\` to list verbs.` +
+        (recovery ? `\n${recovery}` : ''),
+    )
+  }
 
   // `alice <group> <verb> --help` -> flag listing
   if (wantsHelp) return printVerbHelp(group, verb, cmd)
 
   // Run it.
-  const args = parseFlags(argv.slice(argv.indexOf(verb) + 1), cmd.schema)
+  const args = parseFlags(argv.slice(argv.indexOf(verb) + 1), cmd.schema, { group, verb })
   const res = await invoke(base, cmd.tool, args)
   process.stdout.write(res.endsWith('\n') ? res : res + '\n')
 }
@@ -186,14 +198,19 @@ async function fetchSocketJson(socketPath, path, opts) {
 
 // ---- flag parsing ---------------------------------------------------------
 
-function parseFlags(tokens, schema) {
+function parseFlags(tokens, schema, command) {
   const args = {}
   const meta = {}
   const docs = []
   const properties = (schema && schema.properties) || {}
   for (let i = 0; i < tokens.length; i++) {
     let tok = tokens[i]
-    if (!tok.startsWith('--')) continue
+    if (!tok.startsWith('--')) {
+      fail(
+        `unexpected positional argument "${tok}" for \`${BIN} ${command.group} ${command.verb}\`. ` +
+          `Use named flags; run \`${BIN} ${command.group} ${command.verb} --help\` before retrying.`,
+      )
+    }
     tok = tok.slice(2)
     let key, val
     const eq = tok.indexOf('=')
@@ -226,6 +243,21 @@ function parseFlags(tokens, schema) {
         ? camelKey
         : key
     const propertySchema = properties[schemaKey]
+    const supportedAlias =
+      (schemaKey === 'meta' && Object.prototype.hasOwnProperty.call(properties, 'metadataFilter')) ||
+      (schemaKey === 'doc' && Object.prototype.hasOwnProperty.call(properties, 'docs'))
+    if (!propertySchema && !supportedAlias) {
+      const available = Object.keys(properties).map(shellFlagName)
+      const accepted = available.length > 0
+        ? `Accepted flags: ${available.map((name) => `--${name}`).join(', ')}.`
+        : 'This command accepts no flags.'
+      const recovery = flagRecoveryHint(command.group, command.verb, key)
+      fail(
+        `unknown flag "--${key}" for \`${BIN} ${command.group} ${command.verb}\`. ${accepted}\n` +
+          (recovery ? `${recovery}\n` : '') +
+          `Run \`${BIN} ${command.group} ${command.verb} --help\` before retrying.`,
+      )
+    }
     if (propertySchema && propertySchema.type === 'boolean' && typeof val === 'string') {
       if (val === 'true') val = true
       else if (val === 'false') val = false
@@ -287,9 +319,13 @@ function printVerbHelp(group, verb, cmd) {
   out('Flags:')
   for (const n of names) {
     const p = props[n] || {}
+    if (n === 'metadataFilter') {
+      out(`  --meta <key=value> (repeatable)   ${firstLine(p.description || '')}`)
+      continue
+    }
     const type = p.type || (p.enum ? 'enum' : '')
     const req = required.has(n) ? ' (required)' : ''
-    const flag = n.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+    const flag = shellFlagName(n)
     const valueHint = type === 'array'
       ? ' <value>'
       : type && type !== 'boolean'
@@ -301,6 +337,40 @@ function printVerbHelp(group, verb, cmd) {
 }
 
 // ---- util -----------------------------------------------------------------
+
+function commandRecoveryHint(group, verb) {
+  if (BIN !== 'alice-uta') return ''
+  if (group === 'positions' || group === 'portfolio' || (group === 'position' && verb === 'list')) {
+    return 'To list positions, run `alice-uta account portfolio --help`.'
+  }
+  if (group === 'quote') {
+    return 'Quotes live under `contract`: search first, then run `alice-uta contract quote --help`.'
+  }
+  if (group === 'orders') {
+    return 'Order reads and writes live under `order`; run `alice-uta order` to list verbs.'
+  }
+  return ''
+}
+
+function flagRecoveryHint(group, verb, flag) {
+  if (BIN !== 'alice-uta') return ''
+  if (flag === 'account') {
+    return 'Use `--source <account-id>`; obtain the id from `alice-uta account list`.'
+  }
+  if (group === 'contract' && verb === 'search' && (flag === 'query' || flag === 'symbol')) {
+    return 'Contract search uses `--pattern <symbol-or-keyword>`.'
+  }
+  if (group === 'contract' && verb === 'quote' && (flag === 'symbols' || flag === 'symbol')) {
+    return 'Quote accepts one `--alice-id` from `alice-uta contract search` at a time; repeat it for multiple contracts.'
+  }
+  return ''
+}
+
+function shellFlagName(name) {
+  if (name === 'docs') return 'doc'
+  if (name === 'metadataFilter') return 'meta'
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+}
 
 function firstLine(s) {
   return (s || '').split('\n')[0]

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -156,6 +156,8 @@ describe('CLI launchers and payload', () => {
                 accountId: { type: 'string' },
                 await: { type: 'boolean' },
                 taskId: { type: 'array', items: { type: 'string' } },
+                docs: { type: 'array', items: { type: 'object' } },
+                metadataFilter: { type: 'object' },
               },
             },
           },
@@ -194,10 +196,15 @@ describe('CLI launchers and payload', () => {
       expect(help.stdout).toContain('--task-id <value> (repeatable)')
       expect(help.stdout).not.toContain('--task-id <array>')
       expect(help.stdout).not.toContain('--issueId')
+      expect(help.stdout).toContain('--doc <value> (repeatable)')
+      expect(help.stdout).not.toContain('--docs')
+      expect(help.stdout).toContain('--meta <key=value> (repeatable)')
+      expect(help.stdout).not.toContain('--metadata-filter')
 
       await runCli('alice-workspace', [
         'provenance', 'show', '--issue-id', 'audit', '--account-id', 'alpaca-paper', '--await',
         '--task-id', 'run-a', '--task-id', 'run-b',
+        '--doc', 'research/a.md', '--meta', 'ticker=AAPL',
       ], env)
       expect(invocation).toEqual({
         tool: 'provenance_show',
@@ -206,8 +213,100 @@ describe('CLI launchers and payload', () => {
           accountId: 'alpaca-paper',
           await: true,
           taskId: ['run-a', 'run-b'],
+          docs: [{ path: 'research/a.md' }],
+          metadataFilter: { ticker: 'AAPL' },
         },
       })
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('turns common UTA command mistakes into executable recovery guidance', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openalice-cli-shim-uta-recovery-'))
+    const socketPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\openalice-cli-shim-uta-recovery-${process.pid}-${Date.now()}`
+      : join(dir, 'tools.sock')
+    let invocations = 0
+    const manifest = {
+      description: 'UTA test manifest',
+      groups: {
+        account: {
+          portfolio: {
+            tool: 'getPortfolio',
+            description: 'Query portfolio',
+            schema: {
+              type: 'object',
+              properties: {
+                source: { type: 'string' },
+                symbol: { type: 'string' },
+                subAccountId: { type: 'string' },
+              },
+            },
+          },
+        },
+        contract: {
+          search: {
+            tool: 'searchContracts',
+            description: 'Search contracts',
+            schema: {
+              type: 'object',
+              properties: {
+                pattern: { type: 'string' },
+                assetClass: { type: 'string' },
+                source: { type: 'string' },
+              },
+              required: ['pattern'],
+            },
+          },
+          quote: {
+            tool: 'getQuote',
+            description: 'Quote a contract',
+            schema: {
+              type: 'object',
+              properties: {
+                aliceId: { type: 'string' },
+                source: { type: 'string' },
+              },
+              required: ['aliceId'],
+            },
+          },
+        },
+      },
+    }
+    const server = createServer((req, res) => {
+      if (req.method === 'POST') invocations++
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify(manifest))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, resolve)
+    })
+    const env = {
+      ...process.env,
+      AQ_WS_ID: 'ws1',
+      OPENALICE_TOOL_SOCKET: socketPath,
+      OPENALICE_TOOL_URL: '/cli',
+    }
+    try {
+      await expect(runCli('alice-uta', ['positions', 'alpaca-paper'], env)).rejects.toMatchObject({
+        stderr: expect.stringContaining('To list positions, run `alice-uta account portfolio --help`.'),
+      })
+      await expect(runCli('alice-uta', ['account', 'portfolio', '--account', 'alpaca-paper'], env)).rejects.toMatchObject({
+        stderr: expect.stringContaining('Use `--source <account-id>`'),
+      })
+      await expect(runCli('alice-uta', ['contract', 'search', '--query', 'SPY'], env)).rejects.toMatchObject({
+        stderr: expect.stringContaining('Contract search uses `--pattern <symbol-or-keyword>`.'),
+      })
+      await expect(runCli('alice-uta', ['contract', 'quote', '--symbols', 'SPY,QQQ'], env)).rejects.toMatchObject({
+        stderr: expect.stringContaining('Quote accepts one `--alice-id`'),
+      })
+      await expect(runCli('alice-uta', ['account', 'portfolio', 'alpaca-paper'], env)).rejects.toMatchObject({
+        stderr: expect.stringContaining('unexpected positional argument "alpaca-paper"'),
+      })
+      expect(invocations).toBe(0)
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()))
       await rm(dir, { recursive: true, force: true })

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -125,6 +125,22 @@ describe('injectWorkspaceContext — skills', () => {
     expect(existsSync(join(dir, '.pi/skills'))).toBe(false);
   });
 
+  it('gives every runtime executable, copyable UTA read recipes', async () => {
+    await injectWorkspaceContext({
+      template: makeTemplate({ injectTools: true }),
+      wsId: 'ws-abc',
+      dir,
+    });
+    for (const root of ['.claude/skills', '.agents/skills']) {
+      const skill = await read(`${root}/alice-uta/SKILL.md`);
+      expect(skill).toContain("Agent Runtime's Bash/Shell tool");
+      expect(skill).toContain('alice-uta account portfolio --source <account-id>');
+      expect(skill).toContain('alice-uta contract search --source <account-id> --pattern AAPL');
+      expect(skill).toContain("alice-uta contract quote --alice-id '<alice-id-from-search>'");
+      expect(skill).toContain('`--symbols` flag');
+    }
+  });
+
   it('does not inject CLI playbooks when the template is not tool-bearing', async () => {
     await injectWorkspaceContext({
       template: makeTemplate({ injectTools: false, bundledSkills: ['scan-value-chain'] }),

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.6.2
+version: 1.6.3
 ---
 
 # Chat

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -34,9 +34,11 @@ files, Issues, Inbox reports, tracked entities, and attributable Sessions.
 
 ## Choose the right surface
 
-OpenAlice places these CLIs on PATH. Their skills own the current manuals; read
-the relevant skill and use `<cli> --help` / `<cli> <group> <verb> --help`
-instead of guessing flags.
+OpenAlice places these executables on PATH. They are shell commands, not direct
+tool names: invoke them through the Agent Runtime's Bash/Shell tool. Their
+skills own the current manuals; read the relevant skill before the first
+domain command and use `<cli> --help` / `<cli> <group> <verb> --help` instead
+of guessing flags or positional arguments.
 
 | Need | Surface | Skill |
 |---|---|---|


### PR DESCRIPTION
## What changed

- distinguish read-only UTA queries from broker-mutating operations and add copyable account, portfolio, contract-search, and quote recipes
- tell every Workspace runtime to execute PATH CLIs through Bash/Shell after reading the relevant skill
- reject unknown flags and positional arguments in the shared CLI shim before invocation
- provide semantic recovery for the historical `positions`, `quote`, `--account`, `--query`, and `--symbols` mistakes
- render the supported `--doc` and `--meta` aliases in CLI help
- bump the Chat template guidance version to 1.6.3

## Why

A real scheduled Pi session completed successfully but accumulated 17 tool failures. Eight UTA failures came from guessed command groups or flags; the skill only pointed at `--help`, and the CLI validation errors did not name a usable recovery command. The same run also showed that weaker models can mistake PATH commands for direct tool names.

## Verification

- `npx tsc --noEmit`
- `pnpm test` (343 files, 3312 tests passed)
- targeted shim, gateway, and context-injector specs (44 tests passed)
- template-upgrade specs (18 tests passed)
- Workspace creation E2E (3 tests passed)
- real source shim against the running Alice `/cli` manifest and read-only `alice-uta account list` path
- reproduced all five historical UTA mistake shapes and confirmed they fail locally with executable recovery guidance and no backend invocation