### PR TITLE
Remove provider-specific CLI guidance

### DIFF
--- a/default/skills/alice-uta/SKILL.md
+++ b/default/skills/alice-uta/SKILL.md
@@ -7,7 +7,6 @@ description: >
   order writes, position-close, commit, push, reject, sync, and simulator
   commands may change trading state. Use for "what's my position", "quote this
   contract", "place or cancel an order", and the trading-as-git approval flow.
-  Run the documented command lines through Bash/Shell, never as tool names.
   Discover current flags with `alice-uta <group> <verb> --help`; do not guess
   aliases.
 ---
@@ -15,10 +14,6 @@ description: >
 # Trading — `alice-uta`
 
 Accounts, portfolio, contracts, orders, and the trading-as-git approval flow.
-`alice-uta` is a **shell executable**. Invoke every command below through the
-Agent Runtime's Bash/Shell tool; never submit the whole command line as a tool
-name.
-
 Account, portfolio, contract, quote, market-clock, and history reads do not
 mutate broker state. Order writes, position closes, approval commands, and the
 simulator can mutate trading state: inspect their live help before acting, and

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -125,7 +125,7 @@ describe('injectWorkspaceContext — skills', () => {
     expect(existsSync(join(dir, '.pi/skills'))).toBe(false);
   });
 
-  it('gives every runtime executable, copyable UTA read recipes', async () => {
+  it('gives every runtime copyable UTA read recipes', async () => {
     await injectWorkspaceContext({
       template: makeTemplate({ injectTools: true }),
       wsId: 'ws-abc',
@@ -133,7 +133,6 @@ describe('injectWorkspaceContext — skills', () => {
     });
     for (const root of ['.claude/skills', '.agents/skills']) {
       const skill = await read(`${root}/alice-uta/SKILL.md`);
-      expect(skill).toContain("Agent Runtime's Bash/Shell tool");
       expect(skill).toContain('alice-uta account portfolio --source <account-id>');
       expect(skill).toContain('alice-uta contract search --source <account-id> --pattern AAPL');
       expect(skill).toContain("alice-uta contract quote --alice-id '<alice-id-from-search>'");

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.6.3
+version: 1.6.4
 ---
 
 # Chat

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -34,11 +34,10 @@ files, Issues, Inbox reports, tracked entities, and attributable Sessions.
 
 ## Choose the right surface
 
-OpenAlice places these executables on PATH. They are shell commands, not direct
-tool names: invoke them through the Agent Runtime's Bash/Shell tool. Their
-skills own the current manuals; read the relevant skill before the first
-domain command and use `<cli> --help` / `<cli> <group> <verb> --help` instead
-of guessing flags or positional arguments.
+OpenAlice places these CLIs on PATH. Their skills own the current manuals; read
+the relevant skill before the first domain command and use `<cli> --help` /
+`<cli> <group> <verb> --help` instead of guessing flags or positional
+arguments.
 
 | Need | Surface | Skill |
 |---|---|---|


### PR DESCRIPTION
## What changed

- remove the Bash-versus-tool warning from the always-loaded Chat contract
- remove the same provider-specific warning from the UTA skill
- retain the copyable UTA parameter recipes, discover-before-guessing rule, and CLI self-recovery behavior
- bump the Chat template guidance version to 1.6.4

## Why

The malformed `</longcat_arg_value>` calls came from LongCat tool-call behavior. Encoding that provider quirk into every Workspace prompt adds permanent instruction noise for runtimes that already understand PATH CLIs correctly.

## Verification

- `npx tsc --noEmit`
- `pnpm test` (343 files, 3312 tests passed)
- context injection and template upgrade specs (29 tests passed)
- Workspace creation E2E (3 tests passed)