### PR TITLE
Animate page sidebar collapse

### DIFF
--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -41,10 +41,23 @@ describe('PageSidebarLayout', () => {
       </PageSidebarLayout>,
     )
 
+    const desktopSidebar = screen.getByTestId('page-sidebar-desktop')
+    const expandedSurface = screen.getByTestId('page-sidebar-expanded')
+    const collapsedSurface = screen.getByTestId('page-sidebar-collapsed')
+    expect(desktopSidebar.getAttribute('data-state')).toBe('expanded')
+    expect(desktopSidebar.getAttribute('style')).toContain('width: 270px')
+    expect(desktopSidebar.className).toContain('transition-[width]')
+    expect(desktopSidebar.className).toContain('motion-reduce:transition-none')
+    expect(expandedSurface.hasAttribute('inert')).toBe(false)
+    expect(collapsedSurface.hasAttribute('inert')).toBe(true)
+
     fireEvent.click(screen.getByRole('button', { name: 'Collapse Market' }))
     expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('1')
+    expect(desktopSidebar.getAttribute('data-state')).toBe('collapsed')
+    expect(desktopSidebar.getAttribute('style')).toContain('width: 44px')
+    expect(expandedSurface.hasAttribute('inert')).toBe(true)
+    expect(collapsedSurface.hasAttribute('inert')).toBe(false)
     expect(screen.getByRole('button', { name: 'Open Market' })).toBeTruthy()
-    expect(screen.queryByText('Market navigation')).toBeNull()
 
     view.unmount()
     render(
@@ -56,6 +69,8 @@ describe('PageSidebarLayout', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Open Market' }))
     expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('0')
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('expanded')
+    expect(screen.getByTestId('page-sidebar-expanded').hasAttribute('inert')).toBe(false)
     expect(screen.getByText('Market navigation')).toBeTruthy()
   })
 

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -7,6 +7,7 @@ const MIN_WIDTH = 200
 const MAX_WIDTH = 420
 const MAIN_PANE_MIN_WIDTH = 500
 const COLLAPSED_WIDTH = 44
+const RESIZE_HANDLE_WIDTH = 10
 
 function clampWidth(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
@@ -195,9 +196,40 @@ export function PageSidebarLayout({
   if (isDesktop) {
     return (
       <div ref={rootRef} className="flex h-full min-h-0 w-full overflow-hidden">
-        {collapsed ? (
+        <div
+          data-testid="page-sidebar-desktop"
+          data-state={collapsed ? 'collapsed' : 'expanded'}
+          className="relative h-full min-h-0 shrink-0 overflow-hidden border-r border-border/80 bg-secondary transition-[width] duration-[var(--motion-slow)] [transition-timing-function:var(--motion-ease-out)] motion-reduce:transition-none"
+          style={{ width: collapsed ? COLLAPSED_WIDTH : width + RESIZE_HANDLE_WIDTH }}
+        >
+          <div
+            data-testid="page-sidebar-expanded"
+            aria-hidden={collapsed}
+            inert={collapsed ? true : undefined}
+            className={`absolute inset-y-0 left-0 flex transition-opacity duration-[var(--motion-fast)] [transition-timing-function:var(--motion-ease-standard)] motion-reduce:delay-0 motion-reduce:transition-none ${
+              collapsed
+                ? 'pointer-events-none opacity-0'
+                : 'opacity-100 delay-[60ms]'
+            }`}
+            style={{ width: width + RESIZE_HANDLE_WIDTH }}
+          >
+            <div
+              className="h-full min-h-0 shrink-0"
+              style={{ width }}
+            >
+              {sidebarPanel}
+            </div>
+            <ResizeHandle width={width} maxWidth={maxWidth} onPointerDown={beginResize} />
+          </div>
           <aside
-            className="flex h-full shrink-0 flex-col items-center border-r border-border/80 bg-secondary py-1.5"
+            data-testid="page-sidebar-collapsed"
+            aria-hidden={!collapsed}
+            inert={!collapsed ? true : undefined}
+            className={`absolute inset-y-0 left-0 flex shrink-0 flex-col items-center bg-secondary py-1.5 transition-opacity duration-[var(--motion-fast)] [transition-timing-function:var(--motion-ease-standard)] motion-reduce:delay-0 motion-reduce:transition-none ${
+              collapsed
+                ? 'opacity-100 delay-[80ms]'
+                : 'pointer-events-none opacity-0'
+            }`}
             style={{ width: COLLAPSED_WIDTH }}
           >
             <button
@@ -216,17 +248,7 @@ export function PageSidebarLayout({
               {title}
             </span>
           </aside>
-        ) : (
-          <>
-            <div
-              className="h-full min-h-0 shrink-0"
-              style={{ width }}
-            >
-              {sidebarPanel}
-            </div>
-            <ResizeHandle width={width} maxWidth={maxWidth} onPointerDown={beginResize} />
-          </>
-        )}
+        </div>
         <div className="min-h-0 min-w-0 flex flex-1 flex-col">
           {children}
         </div>


### PR DESCRIPTION
## Summary
- replace the desktop page sidebar's abrupt DOM swap with a stable width-transition shell
- animate collapse and expansion over the shared 260ms ease-out curve
- cross-fade expanded and collapsed controls while keeping the hidden surface inert
- honor reduced-motion preferences by disabling the transition

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (343 files, 3312 tests)
- targeted `PageSidebarLayout` component tests
- real Ask Alice route collapse/expand measurement, including 227 → 44px samples
- CDP reduced-motion emulation confirmed an immediate 44 ↔ 227px transition

## Boundary touch
- shared desktop UI sidebar motion only; mobile drawer, trading, credentials, migrations, runtime, and packaging are unchanged