### PR TITLE
Preserve Ask Alice Session across file navigation

### DIFF
--- a/ui/src/components/workspace/FilesPanel.spec.tsx
+++ b/ui/src/components/workspace/FilesPanel.spec.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FilesPanel } from './FilesPanel'
+
+const mocks = vi.hoisted(() => ({
+  listFiles: vi.fn(),
+  openOrFocus: vi.fn(),
+}))
+
+vi.mock('./api', () => ({
+  listFiles: mocks.listFiles,
+}))
+
+vi.mock('../../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: typeof mocks.openOrFocus }) => unknown) =>
+    selector({ openOrFocus: mocks.openOrFocus }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.listFiles.mockResolvedValue({
+    path: '',
+    entries: [{
+      name: 'research.md',
+      kind: 'file',
+      sizeBytes: 128,
+      mtime: '2026-07-20T00:00:00.000Z',
+    }],
+  })
+})
+
+afterEach(cleanup)
+
+describe('FilesPanel navigation provenance', () => {
+  it('carries the Ask Alice Session into a file drill-in', async () => {
+    render(
+      <FilesPanel
+        wsId="chat-1"
+        sessionId="pi-crisp-granite-pencil"
+        source="chat"
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText('research.md')).toBeTruthy())
+    fireEvent.click(screen.getByText('research.md'))
+
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'file-viewer',
+      params: {
+        wsId: 'chat-1',
+        path: 'research.md',
+        source: 'chat',
+        returnSessionId: 'pi-crisp-granite-pencil',
+      },
+    })
+  })
+
+  it('keeps a Workspace-level file drill-in source-neutral', async () => {
+    render(<FilesPanel wsId="workspace-1" sessionId={null} />)
+
+    await waitFor(() => expect(screen.getByText('research.md')).toBeTruthy())
+    fireEvent.click(screen.getByText('research.md'))
+
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'file-viewer',
+      params: { wsId: 'workspace-1', path: 'research.md' },
+    })
+  })
+})

--- a/ui/src/components/workspace/FilesPanel.tsx
+++ b/ui/src/components/workspace/FilesPanel.tsx
@@ -5,11 +5,14 @@ import type { ReactElement } from 'react';
 import { listFiles, type DirListing, type FileEntry } from './api';
 import { Skeleton } from '../StateViews';
 import { useWorkspace } from '../../tabs/store';
+import type { WorkspaceSource } from '../../tabs/types';
 
 const POLL_MS = 5000;
 
 interface FilesPanelProps {
   readonly wsId: string;
+  readonly sessionId: string | null;
+  readonly source?: WorkspaceSource;
 }
 
 export function FilesPanel(props: FilesPanelProps): ReactElement {
@@ -56,7 +59,15 @@ export function FilesPanel(props: FilesPanelProps): ReactElement {
     if (entry.kind === 'file') {
       // Open the file in the dedicated viewer tab (VS Code-style).
       const rel = path ? `${path}/${entry.name}` : entry.name;
-      openOrFocus({ kind: 'file-viewer', params: { wsId: props.wsId, path: rel } });
+      openOrFocus({
+        kind: 'file-viewer',
+        params: {
+          wsId: props.wsId,
+          path: rel,
+          ...(props.source ? { source: props.source } : {}),
+          ...(props.sessionId ? { returnSessionId: props.sessionId } : {}),
+        },
+      });
     }
   };
 
@@ -142,4 +153,3 @@ function formatSize(n: number): string {
   if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}M`;
   return `${(n / (1024 * 1024 * 1024)).toFixed(1)}G`;
 }
-

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -11,11 +11,14 @@ import { TerminalView } from './Terminal';
 import { WebPiView } from './WebPiView';
 import { useIsDesktop } from '../../live/use-is-desktop';
 import { useWorkspaceSidePanels } from '../../live/workspace-side-panels';
+import type { WorkspaceSource } from '../../tabs/types';
 
 export interface WorkspaceViewProps {
   readonly wsId: string;
   /** Pinned record id, or null = no session pinned (empty pane). */
   readonly sessionId: string | null;
+  /** Product area that owns this Workspace view (for provenance-aware drill-ins). */
+  readonly source?: WorkspaceSource;
   /** Resolved record matching `sessionId`. null if `sessionId` is null OR the record was just deleted. */
   readonly activeRecord: SessionRecord | null;
   /**
@@ -125,7 +128,13 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
       </div>
       {showAside && (
         <aside className="workspace-side">
-          {showFiles && <FilesPanel wsId={props.wsId} />}
+          {showFiles && (
+            <FilesPanel
+              wsId={props.wsId}
+              sessionId={props.sessionId}
+              {...(props.source ? { source: props.source } : {})}
+            />
+          )}
         </aside>
       )}
     </div>

--- a/ui/src/pages/FileViewerPage.spec.tsx
+++ b/ui/src/pages/FileViewerPage.spec.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FileViewerPage } from './FileViewerPage'
+
+const mocks = vi.hoisted(() => ({
+  openOrFocus: vi.fn(),
+  setSidebar: vi.fn(),
+  readWorkspaceFile: vi.fn(),
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({ workspaces: [{ id: 'chat-1', tag: 'chat-jul20' }] }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: {
+    openOrFocus: typeof mocks.openOrFocus
+    setSidebar: typeof mocks.setSidebar
+  }) => unknown) => selector({
+    openOrFocus: mocks.openOrFocus,
+    setSidebar: mocks.setSidebar,
+  }),
+}))
+
+vi.mock('../components/workspace/api', () => ({
+  readWorkspaceFile: mocks.readWorkspaceFile,
+}))
+
+vi.mock('../components/FileContentView', () => ({
+  FileContentView: () => <div>file content</div>,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.readWorkspaceFile.mockResolvedValue({ kind: 'ok', content: 'hello' })
+})
+
+afterEach(cleanup)
+
+describe('FileViewerPage back navigation', () => {
+  it('returns an Ask Alice artifact to the exact Session', () => {
+    render(
+      <FileViewerPage
+        spec={{
+          kind: 'file-viewer',
+          params: {
+            wsId: 'chat-1',
+            path: 'research/note.md',
+            source: 'chat',
+            returnSessionId: 'pi-crisp-granite-pencil',
+          },
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(mocks.setSidebar).toHaveBeenCalledWith('chat')
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'workspace',
+      params: {
+        wsId: 'chat-1',
+        sessionId: 'pi-crisp-granite-pencil',
+        source: 'chat',
+      },
+    })
+  })
+
+  it('retains the existing generic Workspace fallback', () => {
+    render(
+      <FileViewerPage
+        spec={{ kind: 'file-viewer', params: { wsId: 'chat-1', path: 'README.md' } }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(mocks.setSidebar).toHaveBeenCalledWith('workspaces')
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'workspace',
+      params: { wsId: 'chat-1' },
+    })
+  })
+})

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -24,7 +24,7 @@ interface Props {
 }
 
 export function FileViewerPage({ spec }: Props) {
-  const { wsId, path } = spec.params
+  const { wsId, path, source, returnSessionId } = spec.params
   const { workspaces } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
@@ -43,8 +43,15 @@ export function FileViewerPage({ spec }: Props) {
   }, [wsId, path])
 
   const openWorkspace = () => {
-    setSidebar('workspaces')
-    openOrFocus({ kind: 'workspace', params: { wsId } })
+    setSidebar(source === 'chat' ? 'chat' : 'workspaces')
+    openOrFocus({
+      kind: 'workspace',
+      params: {
+        wsId,
+        ...(returnSessionId ? { sessionId: returnSessionId } : {}),
+        ...(source ? { source } : {}),
+      },
+    })
   }
 
   return (

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -140,6 +140,7 @@ export function WorkspacePage({ spec, visible }: Props) {
         <WorkspaceView
           wsId={wsId}
           sessionId={sessionId}
+          {...(source ? { source } : {})}
           activeRecord={activeRecord}
           sessions={workspace.sessions}
           label={workspace.tag}

--- a/ui/src/tabs/UrlAdopter.spec.tsx
+++ b/ui/src/tabs/UrlAdopter.spec.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { UrlAdopter } from './UrlAdopter'
+
+const mocks = vi.hoisted(() => ({
+  openOrFocus: vi.fn(),
+  setSidebar: vi.fn(),
+}))
+
+const emptyState = {
+  tabs: {},
+  tree: {
+    kind: 'leaf' as const,
+    group: { id: 'g1', tabIds: [], activeTabId: null },
+  },
+  openOrFocus: mocks.openOrFocus,
+  setSidebar: mocks.setSidebar,
+}
+
+vi.mock('./store', () => {
+  const useWorkspace = Object.assign(
+    (selector: (state: typeof emptyState) => unknown) => selector(emptyState),
+    { getState: () => emptyState },
+  )
+  return { useWorkspace }
+})
+
+vi.mock('./registry', () => ({
+  getView: vi.fn(),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('UrlAdopter file provenance', () => {
+  it('restores an Ask Alice file deep link with its Session return context', async () => {
+    render(
+      <MemoryRouter initialEntries={[
+        '/chat/workspaces/chat-1/view/research%2Fnote.md?sessionId=pi-crisp-granite-pencil',
+      ]}>
+        <UrlAdopter />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'file-viewer',
+      params: {
+        wsId: 'chat-1',
+        path: 'research/note.md',
+        source: 'chat',
+        returnSessionId: 'pi-crisp-granite-pencil',
+      },
+    }))
+    expect(mocks.setSidebar).toHaveBeenCalledWith('chat')
+  })
+
+  it('keeps legacy Workspace file deep links in Workspaces', async () => {
+    render(
+      <MemoryRouter initialEntries={['/workspaces/workspace-1/view/README.md']}>
+        <UrlAdopter />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'file-viewer',
+      params: { wsId: 'workspace-1', path: 'README.md' },
+    }))
+    expect(mocks.setSidebar).toHaveBeenCalledWith('workspaces')
+  })
+})

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -40,6 +40,7 @@ export function UrlAdopter() {
         <Route path="/chat" element={<AdoptStatic spec={{ kind: 'chat-landing', params: {} }} />} />
         <Route path="/chat/manager" element={<AdoptStatic spec={{ kind: 'workspace-manager', params: {} }} />} />
         <Route path="/chat/manager/s/:sessionId" element={<AdoptWorkspaceManager />} />
+        <Route path="/chat/workspaces/:wsId/view/:path" element={<AdoptChatFileViewer />} />
         <Route path="/chat/workspaces/:wsId" element={<AdoptChatWorkspace />} />
         <Route path="/chat/workspaces/:wsId/s/:sessionId" element={<AdoptChatWorkspace />} />
         <Route path="/chat/:channelId" element={<Navigate to="/inbox" replace />} />
@@ -243,10 +244,43 @@ function AdoptTemplateDetail() {
 
 function AdoptFileViewer() {
   const { wsId, path } = useParams<{ wsId: string; path: string }>()
+  const [search] = useSearchParams()
   if (!wsId || !path) return <Navigate to="/workspaces" replace />
+  const returnSessionId = search.get('sessionId') ?? undefined
   // `path` arrives already URL-decoded by react-router (toUrl encodes it as
   // a single segment), so it may contain slashes — pass through verbatim.
-  return <AdoptStatic spec={{ kind: 'file-viewer', params: { wsId, path } }} />
+  return (
+    <AdoptStatic
+      spec={{
+        kind: 'file-viewer',
+        params: {
+          wsId,
+          path,
+          ...(returnSessionId ? { returnSessionId } : {}),
+        },
+      }}
+    />
+  )
+}
+
+function AdoptChatFileViewer() {
+  const { wsId, path } = useParams<{ wsId: string; path: string }>()
+  const [search] = useSearchParams()
+  if (!wsId || !path) return <Navigate to="/chat" replace />
+  const returnSessionId = search.get('sessionId') ?? undefined
+  return (
+    <AdoptStatic
+      spec={{
+        kind: 'file-viewer',
+        params: {
+          wsId,
+          path,
+          source: 'chat',
+          ...(returnSessionId ? { returnSessionId } : {}),
+        },
+      }}
+    />
+  )
 }
 
 function AdoptDesignProject() {
@@ -277,10 +311,10 @@ function specToSection(spec: ViewSpec): ActivitySection {
     case 'chat-landing':       return 'chat'
     case 'workspace-manager':  return 'chat'
     case 'workspace':          return spec.params.source === 'chat' ? 'chat' : 'workspaces'
+    case 'file-viewer':        return spec.params.source === 'chat' ? 'chat' : 'workspaces'
     case 'workspace-list':
     case 'template-catalog':
-    case 'template-detail':
-    case 'file-viewer':        return 'workspaces'
+    case 'template-detail':    return 'workspaces'
     case 'trading-as-git':     return 'trading-as-git'
     case 'connectors':         return 'connectors'
     case 'portfolio':

--- a/ui/src/tabs/registry.spec.ts
+++ b/ui/src/tabs/registry.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { getView } from './registry'
+
+describe('file-viewer URL projection', () => {
+  it('projects Ask Alice artifacts into the chat route with Session context', () => {
+    expect(getView('file-viewer').toUrl({
+      kind: 'file-viewer',
+      params: {
+        wsId: 'chat-1',
+        path: 'research/note.md',
+        source: 'chat',
+        returnSessionId: 'pi-crisp-granite-pencil',
+      },
+    })).toBe(
+      '/chat/workspaces/chat-1/view/research%2Fnote.md?sessionId=pi-crisp-granite-pencil',
+    )
+  })
+
+  it('preserves the existing Workspace file URL', () => {
+    expect(getView('file-viewer').toUrl({
+      kind: 'file-viewer',
+      params: { wsId: 'workspace-1', path: 'README.md' },
+    })).toBe('/workspaces/workspace-1/view/README.md')
+  })
+})

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -499,18 +499,31 @@ const fileViewerModule: ViewModule<'file-viewer'> = {
   kind: 'file-viewer',
   // Tab title = file basename; path itself shows in the page header.
   title: (spec) => spec.params.path.split('/').filter(Boolean).pop() ?? spec.params.path,
-  toUrl: (spec) =>
-    `/workspaces/${encodeURIComponent(spec.params.wsId)}/view/${encodeURIComponent(spec.params.path)}`,
-  Component: ({ spec }) => (
-    <PageSidebarShell
-      storageKey="workspaces"
-      titleKey="nav.item.workspaces"
-      defaultWidth={300}
-      sidebar={<WorkspacesSidebar />}
-    >
-      <FileViewerPage spec={spec} />
-    </PageSidebarShell>
-  ),
+  toUrl: (spec) => {
+    const base = spec.params.source === 'chat'
+      ? `/chat/workspaces/${encodeURIComponent(spec.params.wsId)}`
+      : `/workspaces/${encodeURIComponent(spec.params.wsId)}`
+    const query = spec.params.returnSessionId
+      ? `?sessionId=${encodeURIComponent(spec.params.returnSessionId)}`
+      : ''
+    return `${base}/view/${encodeURIComponent(spec.params.path)}${query}`
+  },
+  Component: ({ spec }) => spec.params.source === 'chat'
+    ? (
+      <ChatPageShell>
+        <FileViewerPage spec={spec} />
+      </ChatPageShell>
+    )
+    : (
+      <PageSidebarShell
+        storageKey="workspaces"
+        titleKey="nav.item.workspaces"
+        defaultWidth={300}
+        sidebar={<WorkspacesSidebar />}
+      >
+        <FileViewerPage spec={spec} />
+      </PageSidebarShell>
+    ),
 }
 
 // ==================== Aggregate ====================

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -49,7 +49,17 @@ export type ViewSpec =
   | { kind: 'tracked';             params: Record<string, never> }
   | { kind: 'chat-landing';        params: { targetWsId?: string } }
   | { kind: 'workspace-manager';   params: { sessionId?: string } }
-  | { kind: 'file-viewer';         params: { wsId: string; path: string } }
+  | {
+      kind: 'file-viewer'
+      params: {
+        wsId: string
+        path: string
+        /** Preserve the product area that opened this Workspace artifact. */
+        source?: WorkspaceSource
+        /** Exact Session materialization to restore when leaving the artifact. */
+        returnSessionId?: string
+      }
+    }
 
 export type ViewKind = ViewSpec['kind']
 


### PR DESCRIPTION
## Summary
- carry the originating product area and exact Session into Workspace file drill-ins
- keep Ask Alice file viewers inside the Ask Alice shell and restore the originating Session on Back
- preserve provenance in the URL so refresh/deep links retain the same return context
- retain existing Workspaces and Tracked file behavior

## Verification
- `npx tsc --noEmit`
- `pnpm -F open-alice-ui exec tsc -b`
- `pnpm test` (347 files passed, 3320 tests passed)
- targeted navigation tests (8 passed)
- real browser flow: Ask Alice Session → Files → README.md → Back, restoring `/chat/workspaces/.../s/pi-crisp-granite-pencil`