### PR TITLE
Keep Ask Alice sidebar mounted across drill-ins

### DIFF
--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -63,6 +63,14 @@ Animate `transform` and `opacity` for movement; use short color/border/box-shado
 transitions for feedback. Do not add permanent `will-change` to large lists or
 page containers.
 
+Navigation continuity is a component-lifetime concern before it is an animation
+concern. Views that belong to one product area and share a local navigator must
+declare the same `shell` in `ui/src/tabs/registry.tsx`; `TabHost` keeps that
+shell mounted while replacing the active-only view content. Do not wrap every
+drill-in in a fresh copy of the same shell or mask the resulting remount with a
+transition. Session terminals and other heavy page content remain active-only
+unless their own lifecycle explicitly requires otherwise.
+
 Keyboard focus is not a motion effect. Interactive controls still require a
 clear `focus-visible` treatment, meaningful labels, and sensible tab order.
 

--- a/ui/src/components/TabHost.spec.tsx
+++ b/ui/src/components/TabHost.spec.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+import { useWorkspace } from '../tabs/store'
+import type { Tab } from '../tabs/types'
+import { TabHost } from './TabHost'
+
+const mocks = vi.hoisted(() => ({
+  shellMounted: vi.fn(),
+  shellUnmounted: vi.fn(),
+}))
+
+vi.mock('../tabs/registry', () => {
+  function MockView({ spec }: { spec: { kind: string } }) {
+    return <div data-testid="view-content">{spec.kind}</div>
+  }
+
+  return {
+    getView: (kind: string) => ({
+      kind,
+      lifecycle: 'active-only',
+      Component: MockView,
+    }),
+    getViewShell: (spec: { kind: string; params: { source?: string } }) => (
+      spec.kind === 'chat-landing' ||
+      spec.kind === 'workspace-manager' ||
+      ((spec.kind === 'workspace' || spec.kind === 'file-viewer') && spec.params.source === 'chat')
+        ? 'chat'
+        : null
+    ),
+  }
+})
+
+vi.mock('../pages/ChatPageShell', async () => {
+  const React = await import('react')
+  return {
+    ChatPageShell: ({ children }: { children: ReactNode }) => {
+      React.useEffect(() => {
+        mocks.shellMounted()
+        return () => mocks.shellUnmounted()
+      }, [])
+      return <div data-testid="chat-shell">{children}</div>
+    },
+  }
+})
+
+vi.mock('./TabStrip', () => ({ TabStrip: () => null }))
+vi.mock('./EmptyEditor', () => ({ EmptyEditor: () => <div>empty</div> }))
+
+const workspaceTab: Tab = {
+  id: 'workspace-tab',
+  spec: {
+    kind: 'workspace',
+    params: { wsId: 'chat-1', sessionId: 'pi-1', source: 'chat' },
+  },
+}
+
+const fileTab: Tab = {
+  id: 'file-tab',
+  spec: {
+    kind: 'file-viewer',
+    params: {
+      wsId: 'chat-1',
+      path: 'README.md',
+      source: 'chat',
+      returnSessionId: 'pi-1',
+    },
+  },
+}
+
+function focus(activeTabId: string): void {
+  useWorkspace.setState({
+    tabs: {
+      [workspaceTab.id]: workspaceTab,
+      [fileTab.id]: fileTab,
+    },
+    tree: {
+      kind: 'leaf',
+      group: {
+        id: 'g1',
+        tabIds: [workspaceTab.id, fileTab.id],
+        activeTabId,
+      },
+    },
+    focusedGroupId: 'g1',
+    selectedSidebar: 'chat',
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+  focus(workspaceTab.id)
+})
+
+afterEach(() => {
+  cleanup()
+  useWorkspace.setState({
+    tabs: {},
+    tree: { kind: 'leaf', group: { id: 'g1', tabIds: [], activeTabId: null } },
+    focusedGroupId: 'g1',
+    selectedSidebar: null,
+  })
+})
+
+describe('TabHost shared product shells', () => {
+  it('keeps the Ask Alice shell mounted across Session → file → Session navigation', async () => {
+    const view = render(<TabHost />)
+
+    await waitFor(() => expect(mocks.shellMounted).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('view-content').textContent).toBe('workspace')
+
+    act(() => focus(fileTab.id))
+    expect(screen.getByTestId('view-content').textContent).toBe('file-viewer')
+    expect(mocks.shellMounted).toHaveBeenCalledTimes(1)
+    expect(mocks.shellUnmounted).not.toHaveBeenCalled()
+
+    act(() => focus(workspaceTab.id))
+    expect(screen.getByTestId('view-content').textContent).toBe('workspace')
+    expect(mocks.shellMounted).toHaveBeenCalledTimes(1)
+    expect(mocks.shellUnmounted).not.toHaveBeenCalled()
+
+    view.unmount()
+    expect(mocks.shellUnmounted).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/components/TabHost.tsx
+++ b/ui/src/components/TabHost.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
 import { useWorkspace } from '../tabs/store'
 import { type Tab } from '../tabs/types'
-import { getView } from '../tabs/registry'
+import { getView, getViewShell } from '../tabs/registry'
 import { TabStrip } from './TabStrip'
 import { EmptyEditor } from './EmptyEditor'
+import { ChatPageShell } from '../pages/ChatPageShell'
 
 /**
  * Main content host.
@@ -25,6 +26,14 @@ export function TabHost() {
   )
   const tabsMap = useWorkspace((state) => state.tabs)
   const isDesktop = useIsDesktop()
+  const activeTab = activeTabId ? tabsMap[activeTabId] ?? null : null
+  const activeView = activeTab ? getView(activeTab.spec.kind) : null
+  const activeUsesPersistentFrame = activeView?.lifecycle === 'keep-mounted' && isDesktop
+  const persistentTabs = isDesktop
+    ? tabIds
+      .map((id) => tabsMap[id])
+      .filter((tab): tab is Tab => tab != null && getView(tab.spec.kind).lifecycle === 'keep-mounted')
+    : []
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
@@ -33,17 +42,19 @@ export function TabHost() {
         {tabIds.length === 0 ? (
           <EmptyEditor />
         ) : (
-          tabIds.map((id) => {
-            const tab = tabsMap[id]
-            if (!tab) return null
-            const isActive = id === activeTabId
-            const view = getView(tab.spec.kind)
-            const keepMounted = view.lifecycle === 'keep-mounted'
-            // Mobile: only render the active tab to avoid blowing memory and
-            // because we don't even have a strip to switch tabs from.
-            if (!isActive && (!isDesktop || !keepMounted)) return null
-            return <TabFrame key={id} tab={tab} visible={isActive} />
-          })
+          <>
+            {/* Active-only views share one unkeyed slot. Moving between two
+                views with the same product shell replaces only the content;
+                the shell (notably Ask Alice's navigator) stays mounted. */}
+            {activeTab && !activeUsesPersistentFrame && (
+              <TabFrame tab={activeTab} visible />
+            )}
+            {/* Desktop keep-mounted views retain their keyed frame across
+                focus changes. Mobile still renders only its active view. */}
+            {persistentTabs.map((tab) => (
+              <TabFrame key={tab.id} tab={tab} visible={tab.id === activeTabId} />
+            ))}
+          </>
         )}
       </div>
     </div>
@@ -53,6 +64,7 @@ export function TabHost() {
 /** One mounted view frame. Hidden frames exist only for keep-mounted views. */
 function TabFrame({ tab, visible }: { tab: Tab; visible: boolean }) {
   const view = getView(tab.spec.kind)
+  const shell = getViewShell(tab.spec)
   // Cast: each ViewModule has a Component constrained to its spec kind. The
   // map lookup loses that narrowing; the runtime type matches by construction.
   const Component = view.Component as React.ComponentType<{ spec: typeof tab.spec; visible: boolean }>
@@ -71,7 +83,13 @@ function TabFrame({ tab, visible }: { tab: Tab; visible: boolean }) {
       // React 19 supports it as a JSX attribute.
       inert={!visible}
     >
-      <Component spec={tab.spec} visible={visible} />
+      {shell === 'chat' ? (
+        <ChatPageShell>
+          <Component key={tab.id} spec={tab.spec} visible={visible} />
+        </ChatPageShell>
+      ) : (
+        <Component key={tab.id} spec={tab.spec} visible={visible} />
+      )}
     </div>
   )
 }

--- a/ui/src/tabs/registry.spec.ts
+++ b/ui/src/tabs/registry.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getView } from './registry'
+import { getView, getViewShell } from './registry'
 
 describe('file-viewer URL projection', () => {
   it('projects Ask Alice artifacts into the chat route with Session context', () => {
@@ -22,5 +22,31 @@ describe('file-viewer URL projection', () => {
       kind: 'file-viewer',
       params: { wsId: 'workspace-1', path: 'README.md' },
     })).toBe('/workspaces/workspace-1/view/README.md')
+  })
+})
+
+describe('shared product shells', () => {
+  it('assigns every Ask Alice surface to the shared chat shell', () => {
+    expect(getViewShell({ kind: 'chat-landing', params: {} })).toBe('chat')
+    expect(getViewShell({ kind: 'workspace-manager', params: {} })).toBe('chat')
+    expect(getViewShell({
+      kind: 'workspace',
+      params: { wsId: 'chat-1', sessionId: 'pi-1', source: 'chat' },
+    })).toBe('chat')
+    expect(getViewShell({
+      kind: 'file-viewer',
+      params: { wsId: 'chat-1', path: 'README.md', source: 'chat' },
+    })).toBe('chat')
+  })
+
+  it('keeps generic Workspace surfaces outside the Ask Alice shell', () => {
+    expect(getViewShell({
+      kind: 'workspace',
+      params: { wsId: 'workspace-1' },
+    })).toBeNull()
+    expect(getViewShell({
+      kind: 'file-viewer',
+      params: { wsId: 'workspace-1', path: 'README.md' },
+    })).toBeNull()
   })
 })

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -33,7 +33,6 @@ import { InboxPageShell } from '../pages/InboxPageShell'
 import { TrackedPage } from '../pages/TrackedPage'
 import { ChatLandingPage } from '../pages/ChatLandingPage'
 import { WorkspaceManagerPage } from '../pages/WorkspaceManagerPage'
-import { ChatPageShell } from '../pages/ChatPageShell'
 import { PageSidebarShell } from '../pages/PageSidebarShell'
 import { WorkspaceListPage } from '../pages/WorkspaceListPage'
 import { WorkspacePage } from '../pages/WorkspacePage'
@@ -53,8 +52,9 @@ import { getDesignProject } from '../design/projects'
  * Central registry mapping each ViewKind to its render component and URL
  * projection. Adding a new view kind means adding one entry here.
  *
- * Page-owned sidebars live here with their pages. The app shell only owns the
- * ActivityBar; each view kind decides whether it needs local navigation.
+ * Page-owned sidebars live here with their pages. Shared product shells are
+ * declared here and mounted by TabHost so adjacent views can retain one local
+ * navigator instance. The app shell itself owns only the ActivityBar.
  */
 
 export interface TitleCtx {
@@ -69,6 +69,7 @@ interface ViewProps<K extends ViewKind> {
 }
 
 export type ViewLifecycle = 'active-only' | 'keep-mounted'
+export type ViewShell = 'chat'
 
 export interface ViewModule<K extends ViewKind> {
   kind: K
@@ -86,6 +87,12 @@ export interface ViewModule<K extends ViewKind> {
    * while backgrounded.
    */
   lifecycle?: ViewLifecycle
+  /**
+   * Shared product chrome owned by TabHost rather than this individual view.
+   * Adjacent views using the same shell swap only their content, preserving
+   * the navigator instance and its rendered state.
+   */
+  shell?: ViewShell | ((spec: Extract<ViewSpec, { kind: K }>) => ViewShell | null)
   /** The actual page component. Ignores `visible` unless it needs catch-up behaviour. */
   Component: ComponentType<ViewProps<K>>
 }
@@ -383,30 +390,24 @@ const trackedModule: ViewModule<'tracked'> = {
 
 const chatLandingModule: ViewModule<'chat-landing'> = {
   kind: 'chat-landing',
+  shell: 'chat',
   title: (spec, ctx) => {
     if (!spec.params.targetWsId) return 'Ask Alice'
     const tag = ctx.workspaces?.find((w) => w.id === spec.params.targetWsId)?.tag
     return tag ? `New session · ${tag}` : 'New session'
   },
   toUrl: () => '/chat',
-  Component: ({ spec }) => (
-    <ChatPageShell>
-      <ChatLandingPage spec={spec} />
-    </ChatPageShell>
-  ),
+  Component: ({ spec }) => <ChatLandingPage spec={spec} />,
 }
 
 const workspaceManagerModule: ViewModule<'workspace-manager'> = {
   kind: 'workspace-manager',
+  shell: 'chat',
   title: () => 'Workspace Manager',
   toUrl: (spec) => spec.params.sessionId
     ? `/chat/manager/s/${encodeURIComponent(spec.params.sessionId)}`
     : '/chat/manager',
-  Component: ({ spec }) => (
-    <ChatPageShell>
-      <WorkspaceManagerPage spec={spec} />
-    </ChatPageShell>
-  ),
+  Component: ({ spec }) => <WorkspaceManagerPage spec={spec} />,
 }
 
 const workspaceListModule: ViewModule<'workspace-list'> = {
@@ -427,6 +428,7 @@ const workspaceListModule: ViewModule<'workspace-list'> = {
 
 const workspaceModule: ViewModule<'workspace'> = {
   kind: 'workspace',
+  shell: (spec) => spec.params.source === 'chat' ? 'chat' : null,
   title: (spec, ctx) => {
     const ws = ctx.workspaces?.find((w) => w.id === spec.params.wsId)
     const tag = ws?.tag ?? spec.params.wsId.slice(0, 8)
@@ -446,11 +448,7 @@ const workspaceModule: ViewModule<'workspace'> = {
   },
   Component: (props) =>
     props.spec.params.source === 'chat'
-      ? (
-        <ChatPageShell>
-          <WorkspacePage {...props} />
-        </ChatPageShell>
-      )
+      ? <WorkspacePage {...props} />
       : (
         <PageSidebarShell
           storageKey="workspaces"
@@ -497,6 +495,7 @@ const templateDetailModule: ViewModule<'template-detail'> = {
 
 const fileViewerModule: ViewModule<'file-viewer'> = {
   kind: 'file-viewer',
+  shell: (spec) => spec.params.source === 'chat' ? 'chat' : null,
   // Tab title = file basename; path itself shows in the page header.
   title: (spec) => spec.params.path.split('/').filter(Boolean).pop() ?? spec.params.path,
   toUrl: (spec) => {
@@ -509,11 +508,7 @@ const fileViewerModule: ViewModule<'file-viewer'> = {
     return `${base}/view/${encodeURIComponent(spec.params.path)}${query}`
   },
   Component: ({ spec }) => spec.params.source === 'chat'
-    ? (
-      <ChatPageShell>
-        <FileViewerPage spec={spec} />
-      </ChatPageShell>
-    )
+    ? <FileViewerPage spec={spec} />
     : (
       <PageSidebarShell
         storageKey="workspaces"
@@ -560,4 +555,13 @@ const VIEWS = {
 /** Untyped lookup — narrow at the call site by inspecting `spec.kind`. */
 export function getView<K extends ViewKind>(kind: K): ViewModule<K> {
   return VIEWS[kind] as unknown as ViewModule<K>
+}
+
+/** Resolve shared product chrome without leaking per-kind generic narrowing to TabHost. */
+export function getViewShell(spec: ViewSpec): ViewShell | null {
+  const shell = (getView(spec.kind) as unknown as {
+    shell?: ViewShell | ((candidate: ViewSpec) => ViewShell | null)
+  }).shell
+  if (typeof shell === 'function') return shell(spec)
+  return shell ?? null
 }


### PR DESCRIPTION
## Summary
- move Ask Alice product-shell ownership from individual view modules into TabHost's stable active slot
- keep one ChatPageShell instance across landing, Manager, Session, and chat-origin file views
- preserve active-only lifecycle for Session terminals and page content; keep existing keep-mounted frame semantics
- document the shared-shell navigation-continuity rule

## Verification
- `npx tsc --noEmit`
- `pnpm -F open-alice-ui exec tsc -b`
- `pnpm test` (348 files passed, 3323 tests passed)
- targeted shell/navigation suite (11 tests passed)
- real browser flow: Ask Alice Session → Files → README.md → Back; exact Session and Files preference retained
- lifecycle regression: ChatPageShell mounts once across Session → file → Session