### PR TITLE
Prepare the 0.84.0 beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.83.0-beta",
+  "version": "0.84.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## What changed

- Bump the root OpenAlice version from `0.83.0-beta` to `0.84.0-beta`.
- Prepare the next beta release candidate so the current `dev` fixes, including the legacy editor-tab overflow removal, can be promoted through the signed release workflow.

## Release intent

This is a version-only release preparation change. After the `dev` release gates are green, the integration branch will be promoted to `master`; the release workflow will create the `v0.84.0-beta` prerelease and publish its platform assets and update metadata.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm vitest run src/webui/routes/version.spec.ts ui/src/components/settings/AboutOpenAliceSection.spec.tsx scripts/prepare-desktop-release-assets.spec.ts`
- `pnpm test` (3321 passed, 8 skipped)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- PR #707 and its post-merge `dev` CI are green across macOS, Windows, Vercel, cross-platform tests, packaging, and Workspace smoke.

## Boundary

The diff is intentionally limited to the root version field. Signing and notarization remain owned by the protected `master` release workflow.