### PR TITLE
Add Issue model and effort overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ Keep this file short. It contains rules that apply to every task. Detailed
 architecture and operating procedures live in the owner guides linked below.
 Current code, tests, rendered behavior, and GitHub state override stale prose.
 
+Durable subsystem truth lives under [[docs/README.md]]. Active multi-step
+implementation work lives under [[PLANS.md]]. Keep both indexes current when a
+change introduces a new owner guide or execution plan.
+
 ## Start Here
 
 ```bash
@@ -165,6 +169,26 @@ Handle in-scope findings in the current PR instead of filing an issue for work
 the same change already owns. Product-roadmap ideas still belong to the user's
 planning surface rather than being silently converted into engineering tasks.
 
+## Implementation Plans
+
+Use `plans/<topic>.md` for substantial work that spans multiple surfaces,
+increments, or sessions. [[PLANS.md]] is the compact index and lifecycle
+contract.
+
+- A plan records scope, decisions, ordered work, verification, and live
+  progress. It is not an owner guide and must link to the relevant `docs/`
+  contract instead of copying it.
+- Update the plan in the same change as meaningful progress, newly discovered
+  constraints, scope changes, or completion. Checkboxes must reflect repository
+  truth rather than intent.
+- Keep one canonical plan per initiative. Extend or supersede it explicitly
+  instead of creating parallel TODO notes.
+- Active plans stay in `plans/`; completed plans remain as a concise execution
+  record and move to the Completed section of [[PLANS.md]].
+- GitHub issues remain the external defect/deferred-work surface. Reference
+  related issues and PRs from the plan; do not use a plan to hide actionable
+  deferred findings from the issue tracker.
+
 ## Owner Guides
 
 Read the relevant guide before editing its subsystem:
@@ -176,6 +200,9 @@ Read the relevant guide before editing its subsystem:
   delivery modes, promotions, external contributions, and risk gates.
 - [[docs/managed-workspace-runtime.md]] — [Managed Workspace runtime](docs/managed-workspace-runtime.md): Electron
   packaging, managed Pi, PortableGit/Bash, runtime profiles, and Workspace PATH.
+- [[docs/model-semantics-and-runtime-injection.md]] — [Model semantics and runtime injection](docs/model-semantics-and-runtime-injection.md):
+  credential access, model/effort semantics, Workspace-local defaults, and
+  one-run native CLI overrides.
 - [[docs/broker-packs.md]] — [Broker Packs](docs/broker-packs.md): optional broker SDK
   packaging, UI installation, activation, runtime loading, and release assets.
 - [[docs/cli-installer.md]] — [CLI installer](docs/cli-installer.md): consent, installed layout,

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,30 @@
+# OpenAlice Implementation Plans
+
+This file indexes substantial, multi-step implementation work. Plans describe
+how repository truth will change; owner guides under [[docs/README.md]] describe
+the durable truth after it changes.
+
+## Plan Contract
+
+- Create `plans/<topic>.md` when work spans multiple subsystems, delivery
+  increments, or sessions.
+- Each plan names its status, related issues, owner guides, scope, decisions,
+  ordered checklist, verification, and completion criteria.
+- Update progress in the same commit as the work it describes. Do not mark a
+  step complete before its code and required verification exist.
+- Record material discoveries and changed decisions in the plan. Move stable
+  architectural conclusions into the linked owner guide.
+- Keep completed plans in the repository as concise execution history and move
+  their index entry from Active to Completed.
+- Use GitHub issues for externally visible defects and deferred findings; plans
+  may coordinate those issues but do not replace them.
+
+## Active
+
+- [[plans/issue-model-effort-overrides.md]] — Separate login-backed Workspace
+  model defaults from provider isolation and add per-run Issue model/effort
+  overrides. Tracks GitHub issues #706 and #710.
+
+## Completed
+
+No completed plans are indexed yet.

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -43,7 +43,7 @@ You have two equivalent paths, and both write the **same**
    with no separate path.
 2. **Editing the file directly** with your normal file tools. Reach for this when
    you are writing rich markdown **What** or scheduling frontmatter
-   (`when` / `assignee` / `agent`) — the CLI verbs cover the board fields, What, and
+   (`when` / `assignee` / `agent` / `model` / `effort`) — the CLI verbs cover the board fields, What, and
    comments, but the document and schedule shape read most clearly as text. The
    file is always the single source of truth either way.
 
@@ -85,7 +85,9 @@ alice-workspace issue create --title "Pre-market brief" --priority high \
   --when '{"kind":"cron","cron":"30 8 * * 1-5","timezone":"America/New_York"}' \
   --assignee @me \
   --what "Pull pre-market movers and overnight news for my watchlist, write a short brief to research/premarket.md, then run: alice-workspace inbox push --doc research/premarket.md --comments 'Pre-market brief'." \
-  --agent claude
+  --agent codex \
+  --model gpt-5.6 \
+  --effort high
 ```
 
 The verb set is `list` / `show` / `create` / `update` / `comment` (no `delete` —
@@ -177,6 +179,17 @@ plain tracked item; add a `when` and it starts firing.
   scheduled work; defaults to this Workspace's runtime resolution. An exact
   Session assignee already has an immutable runtime, so Session-owned Issues
   cannot set this.
+- **`model`** *(optional)* — native model id for one scheduled run. Omit it to
+  inherit the Workspace/native runtime default. Provider routing and
+  authentication always remain Workspace-owned.
+- **`effort`** *(optional)* — one-run reasoning effort: `none`, `minimal`,
+  `low`, `medium`, `high`, `xhigh`, or `max`. Use a level supported by the
+  selected runtime; omit it to inherit.
+
+`agent`, `model`, and `effort` are one run-selection tuple. They are valid only
+for `@new` / `@workspace`; an exact `@resumeId` Session owns all three. The
+scheduler passes explicit model/effort values as one-run CLI arguments and does
+not rewrite persistent Workspace configuration.
 
 The old parallel `execution` field is retired and rejected after migration;
 never write it into a new Issue.

--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -99,6 +99,40 @@ resolved value:
 - Claude Code: project `effortLevel` (only values Claude can persist);
 - Codex: project `model_reasoning_effort`.
 
+### Persistent defaults and one-run overrides
+
+Workspace defaults and headless run selection are different configuration
+layers. A Workspace-local file expresses the durable preference; an explicit
+CLI argument selects one Issue run and wins without rewriting that file:
+
+| Runtime | Workspace-local preference | One-run headless override |
+|---|---|---|
+| Claude Code | `.claude/settings.local.json`: `model`, `effortLevel` | `--model`, `--effort` |
+| Codex | `.codex/config.toml`: `model`, `model_reasoning_effort` | `--model`, `-c model_reasoning_effort=...` |
+| opencode | `opencode.json` provider/model binding | `--model`, `--variant` |
+| Pi | project settings plus registered provider | `--model`, `--thinking` |
+
+An Issue may request only agent/model/effort. Endpoint, provider, key, auth, and
+wire shape always come from the selected Workspace/native login. Dispatch
+records the requested model/effort for provenance and translates them into CLI
+arguments; it never mutates persistent configuration.
+
+OpenAlice-managed opencode models register effort-named variants in the
+Workspace config up front, so `--variant` remains a genuine one-run selection.
+Dispatch rejects a custom-provider model or effort that is not registered
+instead of silently falling back or rewriting the provider during a run.
+
+Exact Session ownership is intentionally stricter. An `@resumeId` already owns
+its runtime conversation, so an Issue cannot attach agent, model, or effort
+overrides to it. This avoids silently changing a resumed conversation's saved
+model semantics.
+
+Codex project configuration must not be confused with `CODEX_HOME`; the latter
+owns global auth, sessions, skills, and user configuration. Provider definitions
+are not a supported Codex project layer, so OpenAlice-managed custom providers
+use an explicit `.codex/openalice-home/`, while model/effort-only login-backed
+preferences leave `CODEX_HOME` unset.
+
 Context-window and output limits follow the same ownership boundary. Registered
 model semantics provide known limits; an explicit Workspace preference may
 override the context registration for runtimes that support it; otherwise the
@@ -176,12 +210,16 @@ read-only, best-effort launch guidance, but it must not mark private global
 state complete or accept trust on the user's behalf. Unknown native state is
 advisory and fail-open; it never becomes a fabricated ready/not-ready fact.
 
-The test-before-save gate follows the same boundary as the probe. Changes to
-the key, endpoint, wire shape, authentication mode, or model require a fresh
-probe. Context-window, reasoning capability, and reasoning effort are local
-runtime registration fields; changing only those fields saves directly without
-making an unrelated provider request. Both automatic creation-default saves
-and explicit Workspace saves must acknowledge completion in the UI.
+The test-before-save gate follows the same boundary as the probe. Changes to a
+managed key, endpoint, wire shape, authentication mode, or its model require a
+fresh probe. A Codex/Claude native-login binding with no OpenAlice-managed key
+or endpoint has no HTTP credential for the modal to probe: model/effort-only
+changes save directly and are validated by the native runtime at launch.
+Context-window, reasoning capability, and reasoning effort are also local
+runtime registration fields and save without an unrelated provider request.
+Official endpoints may be omitted because the probe resolves their default from
+the wire shape. Both automatic creation-default saves and explicit Workspace
+saves must acknowledge completion in the UI.
 
 ## Configuration Ownership and Reset
 
@@ -195,9 +233,15 @@ Claude Code and opencode use the same lifecycle rule with
 the first write snapshots only the nodes OpenAlice will replace, later writes
 retain that original snapshot, and reset restores a node only if it still equals
 the last injected value. A user edit or whole-file deletion made after injection
-wins. Codex is the
-exception because its Workspace `.codex/` is an intentionally exclusive
-`CODEX_HOME`, not a shared project-config layer.
+wins.
+
+Codex applies the same reversible ownership rule to top-level `model` and
+`model_reasoning_effort` assignments in the shared project
+`.codex/config.toml`; comments, sections, and unknown keys remain untouched.
+Only `.codex/openalice-home/` is an exclusive `CODEX_HOME`, and only while an
+OpenAlice-managed custom provider is active. Reset removes that dedicated home
+and restores owned project scalars without deleting the user's `.codex/`
+directory or global login state.
 
 The rollback sidecars can contain prior or injected secrets and are therefore
 sensitive Workspace state. Templates must exclude both sidecars and native
@@ -215,6 +259,9 @@ contain credentials.
 - `src/core/config.ts` — credential access and creation-time Workspace defaults.
 - `src/workspaces/credential-injection.ts` — credential + selection + semantics composition.
 - `src/workspaces/adapters/` — native runtime projection and round-trip parsing.
+- `src/workspaces/adapters/owned-toml-config.ts` — reversible Codex project-scalar ownership.
+- `src/workspaces/schedule/scanner.ts` — Issue selection to one-run override dispatch.
+- `src/workspaces/headless-task-registry.ts` — durable requested model/effort provenance.
 - `ui/src/components/credentials/` — credential/account setup.
 - `ui/src/components/workspace/WorkspaceAIConfigModal.tsx` — per-Workspace selection and unknown-model overrides.
 

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -35,7 +35,9 @@ status: todo
 priority: high
 assignee: "@workspace"
 when: { kind: cron, cron: "30 8 * * 1-5", timezone: America/New_York }
-agent: pi
+agent: codex
+model: gpt-5.6
+effort: high
 ---
 
 Pull pre-market movers and overnight news, write `research/premarket.md`,
@@ -61,6 +63,18 @@ The filename stem is the stable issue id. Frontmatter:
 - `agent` — optional CLI adapter id for `@new` / `@workspace` scheduled work;
   otherwise Workspace/default resolution is used. A Session assignee already
   owns its runtime and cannot be overridden here.
+- `model` — optional native model id for this Issue's run. Omission inherits the
+  Workspace/native runtime model.
+- `effort` — optional one-run reasoning effort:
+  `none | minimal | low | medium | high | xhigh | max`. The chosen runtime must
+  expose that level; omission inherits its Workspace/native default.
+
+`agent`, `model`, and `effort` are one run-selection tuple. They never carry an
+endpoint, provider, or credential, and the scheduler expresses them as native
+CLI arguments without rewriting Workspace files. All three are forbidden when
+`assignee` is an exact `@resumeId`, because that Session owns its runtime
+conversation. `@new` may use them for its first dispatch; after it becomes an
+exact Session owner, the claim rewrite removes the tuple.
 
 Migration `0018_issue_assignee_ownership` removes the retired parallel
 `execution` field. It maps `resume` to the former `session:<resumeId>` shape and
@@ -120,14 +134,14 @@ Agents normally use:
 ```bash
 alice-workspace issue list
 alice-workspace issue show --id <id-or-title>
-alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee workspace
-alice-workspace issue update --id <id> --status done
+alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee @workspace --agent codex --model gpt-5.6 --effort high
+alice-workspace issue update --id <id> --model gpt-5.6 --effort high
 alice-workspace issue comment --id <id> --text "..."
 ```
 
 The CLI and MCP tools use the same implementation and write the same files.
 Direct file editing is also valid and is the clearest way to author rich What
-markdown plus `when` / `assignee` / `agent` frontmatter.
+markdown plus `when` / `assignee` / `agent` / `model` / `effort` frontmatter.
 
 `issue comment` is preferable to a generic `issue ask --owner` for normal
 collaboration because it leaves the question and answer in the Issue Activity
@@ -145,6 +159,7 @@ an attended, human-approved path and a commit in the peer repository.
   -> ScheduleScanner (~60s)
   -> due calculation from `when` + last-fired marker
   -> assignee selects a new Workspace Session or exact resumeId
+  -> optional model/effort become one-run native CLI arguments
   -> headless run of the owning Workspace
   -> native agent CLI
   -> normalized reply + message/tool blocks
@@ -159,6 +174,13 @@ run checks X and exits silently when false.
 The scanner persists only last-fired markers under the launcher state root.
 Schedule semantics remain in the issue file. Markers are written after a
 successful dispatch; capacity/transient rejection stays due for retry.
+
+The durable run record keeps the requested model and effort beside the resolved
+agent. This is selection provenance, not a claim that the provider honored an
+unknown model: native CLI failure remains visible in the run result. For an
+OpenAlice-managed opencode or Pi provider, the model must already be registered
+by that Workspace; otherwise dispatch fails with an actionable message instead
+of mutating provider registration during a concurrent run.
 
 The Issue API also derives an `automationHealth` projection from these markers,
 the latest scheduled run, and the assignee's resume availability. It is not

--- a/plans/issue-model-effort-overrides.md
+++ b/plans/issue-model-effort-overrides.md
@@ -1,0 +1,117 @@
+# Issue Model and Effort Overrides
+
+Status: In progress
+
+Related issues: #706, #710
+
+Owner guides: [[docs/model-semantics-and-runtime-injection.md]],
+[[docs/workspace-issues-and-scheduling.md]],
+[[docs/conversation-provenance.md]]
+
+## Outcome
+
+Users with native Codex or Claude Code login state can save a Workspace-local
+model and reasoning-effort preference without supplying an OpenAlice-managed
+API key. Scheduled Issues can optionally select an agent, model, and effort for
+one headless run without mutating the Workspace's persistent runtime files or
+copying authentication into the Issue.
+
+## Scope
+
+- Establish the repository plan index and plan lifecycle rules.
+- Correct login-backed Codex and Claude Code Workspace-local projection.
+- Correct the Workspace AI modal's probe/save boundary.
+- Extend the Issue file, API, tool, CLI, scheduler, task record, and runtime
+  dispatch contracts with optional model and effort overrides.
+- Project one-run overrides into all runtimes where the installed CLI exposes a
+  stable flag, while preserving provider/model registration constraints.
+- Update owner guides, agent-facing scheduling guidance, demo handlers, and
+  tests with the delivered contract.
+
+Not in scope:
+
+- Storing credentials, endpoints, or provider selection on an Issue.
+- Changing an exact Session assignee's runtime binding in the first increment.
+- Turning the model registry into a live remote catalog.
+- Rewriting existing Issue files merely because optional fields were added.
+
+## Decisions
+
+1. Workspace defaults and run overrides are separate layers.
+   Workspace-local files own durable defaults; explicit CLI arguments own one
+   Issue run and take precedence.
+2. An Issue stores flat optional `model` and `effort` fields beside `agent`.
+   Omission means inherit the Workspace/native runtime default.
+3. Authentication and provider routing are always inherited from the selected
+   Workspace runtime. Issue files never contain secrets.
+4. Exact `@resumeId` assignees continue to own their runtime and initially
+   reject `agent`, `model`, and `effort` overrides.
+5. Login-backed Codex project preferences use `.codex/config.toml` without
+   changing `CODEX_HOME`. OpenAlice-managed custom Codex providers retain an
+   explicit isolated home.
+6. A model/effort-only native-login save does not require an HTTP credential
+   probe. Endpoint, key, auth, or wire changes still do.
+7. Run records retain requested model and effort so the Runs UI and future
+   provenance work can explain the dispatch decision.
+
+## Work
+
+### 1. Planning and durable documentation
+
+- [x] Audit existing owner-guide and plan infrastructure.
+- [x] Add `PLANS.md`, this plan, and plan rules to `AGENTS.md`.
+- [x] Update model-injection and scheduling owner guides with the final
+  contract.
+
+### 2. Workspace-local native login configuration
+
+- [x] Split Codex native project preferences from isolated custom-provider
+  `CODEX_HOME` ownership.
+- [x] Preserve user-owned Codex project configuration and restore only
+  OpenAlice-owned keys.
+- [x] Treat Claude effort-only configuration as a valid local projection.
+- [x] Let native-login model/effort changes save without a credential probe.
+- [x] Add adapter, route, and UI regression tests for model-only and
+  effort-only login-backed configuration.
+
+### 3. Issue declaration and mutation contract
+
+- [x] Add optional `model` and `effort` fields to declaration parsing and
+  serialization.
+- [x] Enforce compatible assignee/agent/model/effort combinations.
+- [x] Extend HTTP, UI API, CLI, MCP tools, demo handlers, and agent-facing
+  scheduling instructions.
+- [x] Add Issue editor controls with clear inheritance semantics.
+
+### 4. Headless dispatch and runtime projection
+
+- [x] Carry requested model/effort through scanner dispatch and task records.
+- [x] Add typed per-run overrides to adapter command composition.
+- [x] Map Codex, Claude Code, opencode, and Pi overrides to native CLI flags.
+- [x] Define safe behavior when an opencode/Pi model is not registered by the
+  inherited provider configuration.
+- [x] Keep exact Session ownership unchanged and covered by tests.
+
+### 5. Verification and delivery
+
+- [x] Run targeted adapter, Issue, scheduler, route, demo, and UI tests.
+- [x] Run `npx tsc --noEmit`.
+- [x] Run `cd ui && npx tsc -b`.
+- [x] Run `pnpm test`.
+- [x] Walk the real Workspace AI and Issue editor routes in browser/dev.
+- [x] Run the proportional Electron/workspace smoke required by the final
+  touched runtime surface.
+- [x] Update this plan and owner guides to match delivered behavior.
+- [ ] Publish and merge a serial PR to `dev`, then move this plan to Completed.
+
+## Completion Criteria
+
+- A logged-in Codex or Claude Code user can persist only model and/or effort
+  for one Workspace without adding an API key or losing global login state.
+- A scheduled `@workspace` or `@new` Issue can inherit all runtime defaults or
+  explicitly select supported agent/model/effort values for that run.
+- One-run selection is visible in the durable task record and does not rewrite
+  Workspace configuration.
+- Exact Session ownership rejects conflicting runtime overrides.
+- Required typechecks, tests, real UI verification, and proportional runtime
+  smoke pass.

--- a/src/ai-providers/model-semantics.ts
+++ b/src/ai-providers/model-semantics.ts
@@ -22,7 +22,7 @@ export type ModelReasoningEffort =
   | 'xhigh'
   | 'max'
 
-export const MODEL_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
+export const MODEL_REASONING_EFFORTS = [
   'none',
   'minimal',
   'low',
@@ -30,7 +30,7 @@ export const MODEL_REASONING_EFFORTS: readonly ModelReasoningEffort[] = [
   'high',
   'xhigh',
   'max',
-]
+] as const satisfies readonly ModelReasoningEffort[]
 
 export function isModelReasoningEffort(value: unknown): value is ModelReasoningEffort {
   return typeof value === 'string' && MODEL_REASONING_EFFORTS.includes(value as ModelReasoningEffort)

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -64,6 +64,24 @@ describe('issue_create', () => {
     expect(issue?.title).toBe('Fix the thing')
   })
 
+  it('creates and returns one-run model and effort overrides', async () => {
+    const res = await run(issueCreateFactory.build(ctx()), {
+      id: 'tuned',
+      title: 'Tuned run',
+      when: { kind: 'every', every: '30m' },
+      assignee: '@workspace',
+      agent: 'codex',
+      model: 'gpt-5.6',
+      effort: 'high',
+    })
+    expect(res.issue).toMatchObject({ agent: 'codex', model: 'gpt-5.6', effort: 'high' })
+    expect(await readBack('tuned')).toMatchObject({
+      agent: 'codex',
+      model: 'gpt-5.6',
+      effort: 'high',
+    })
+  })
+
   it('records the creating product Session without accepting identity args', async () => {
     const append = vi.fn(async (input) => ({ id: 'p-1', ...input }))
     const context = ctx({
@@ -213,6 +231,34 @@ describe('issue_update', () => {
     expect(issue).toMatchObject({ status: 'in_progress', priority: 'high', what: 'new exact work' })
     // scheduling frontmatter survives a board-field patch
     expect(issue?.when).toEqual({ kind: 'every', every: '30m' })
+  })
+
+  it('updates and clears runtime selection fields', async () => {
+    await run(issueCreateFactory.build(ctx()), {
+      id: 'runtime-fields',
+      title: 'Runtime fields',
+      when: { kind: 'every', every: '30m' },
+      assignee: '@workspace',
+    })
+    await run(issueUpdateFactory.build(ctx()), {
+      id: 'runtime-fields',
+      agent: 'codex',
+      model: 'gpt-5.6',
+      effort: 'high',
+    })
+    expect(await readBack('runtime-fields')).toMatchObject({
+      agent: 'codex',
+      model: 'gpt-5.6',
+      effort: 'high',
+    })
+    await run(issueUpdateFactory.build(ctx()), {
+      id: 'runtime-fields',
+      model: null,
+      effort: null,
+    })
+    const cleared = await readBack('runtime-fields')
+    expect(cleared?.model).toBeUndefined()
+    expect(cleared?.effort).toBeUndefined()
   })
 
   it('records successful mutations but not rejected ones', async () => {

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 
+import { MODEL_REASONING_EFFORTS } from '../ai-providers/model-semantics.js'
 import type { WorkspaceToolFactory, WorkspaceToolContext } from '../core/workspace-tool-center.js'
 import {
   ACTIVITY_UPDATE_COALESCE_MS,
@@ -203,6 +204,8 @@ function rowOf(issue: IssueRecord) {
     priority: issue.priority,
     assignee: issue.assignee,
     ...(issue.agent ? { agent: issue.agent } : {}),
+    ...(issue.model ? { model: issue.model } : {}),
+    ...(issue.effort ? { effort: issue.effort } : {}),
     scheduled: issue.when !== undefined,
   }
 }
@@ -294,12 +297,13 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
       description: [
         "Update one of THIS workspace's issues — its board fields.",
         '',
-        'Patch any subset of `status`, `priority`, `assignee`, `what`; omitted fields are',
+        'Patch any subset of `status`, `priority`, `assignee`, `agent`, `model`,',
+        '`effort`, or `what`; omitted fields are',
         'left untouched. `assignee:"@me"` binds this current product',
         'Session; `@new` recruits once and assigns that first Session permanently;',
         'pass an exact `@resumeId` to assign another known Session. What is the',
         'canonical markdown work definition and exact scheduled prompt. Other scheduling',
-        'frontmatter (`when`/`agent`) is preserved — edit it by writing the file directly',
+        'schedule timing (`when`) is preserved — edit it by writing the file directly',
         '(`.alice/issues/<id>.md`).',
         '',
         'Marking an issue `done` or `canceled` is how a self-scheduled issue is',
@@ -312,20 +316,37 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
         assignee: issueAssigneeInputSchema
           .optional()
           .describe('@new, @workspace, @human, @unassigned, @me, or an exact @resumeId.'),
+        agent: z.string().min(1).nullable().optional().describe('Runtime id for @new/@workspace; null inherits the Workspace default.'),
+        model: z.string().min(1).nullable().optional().describe('Native one-run model id; null inherits the Workspace/runtime default.'),
+        effort: z.enum(MODEL_REASONING_EFFORTS).nullable().optional().describe('One-run reasoning effort; null inherits the Workspace/runtime default.'),
         what: z.string().min(1).optional().describe('Canonical markdown work definition; exact scheduled prompt.'),
       }),
-      execute: async ({ id, status, priority, assignee, what }) => {
+      execute: async ({ id, status, priority, assignee, agent, model, effort, what }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
         const resolvedAssignee = resolveIssueAssignee(ctx, assignee)
         if (!resolvedAssignee.ok) return { ok: false as const, error: resolvedAssignee.error }
-        if (status === undefined && priority === undefined && resolvedAssignee.assignee === undefined && what === undefined) {
-          return { ok: false as const, error: 'no fields to update (pass status/priority/assignee/what)' }
+        if (
+          status === undefined &&
+          priority === undefined &&
+          resolvedAssignee.assignee === undefined &&
+          agent === undefined &&
+          model === undefined &&
+          effort === undefined &&
+          what === undefined
+        ) {
+          return {
+            ok: false as const,
+            error: 'no fields to update (pass status/priority/assignee/agent/model/effort/what)',
+          }
         }
         const res = await updateIssueFields(dir.dir, id, {
           status,
           priority,
           assignee: resolvedAssignee.assignee,
+          agent,
+          model,
+          effort,
           what,
         })
         if (res.ok) {
@@ -455,8 +476,10 @@ export const issueCreateFactory: WorkspaceToolFactory = {
           .describe('Schedule shape — { kind:"at", at } | { kind:"every", every } | { kind:"cron", cron, timezone?:"local"|IANA }. Present iff the issue self-schedules.'),
         what: z.string().min(1).optional().describe('Markdown work definition; exact scheduled prompt. Defaults to title.'),
         agent: z.string().min(1).optional().describe('Adapter id when assignee is @new or @workspace; an exact Session owns its runtime.'),
+        model: z.string().min(1).optional().describe('Native model id for one scheduled run; provider/auth stay Workspace-owned.'),
+        effort: z.enum(MODEL_REASONING_EFFORTS).optional().describe('Reasoning effort for one scheduled run.'),
       }),
-      execute: async ({ title, id, status, priority, assignee, when, what, agent }) => {
+      execute: async ({ title, id, status, priority, assignee, when, what, agent, model, effort }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
         // Structured creation is attributable: "who creates it owns it". A
@@ -474,6 +497,8 @@ export const issueCreateFactory: WorkspaceToolFactory = {
           when,
           what,
           agent,
+          model,
+          effort,
         })
         if (res.ok) {
           await recordIssueProvenance(ctx, res.issue.id, 'created')

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -140,6 +140,14 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     expect((await req(app, 'PATCH', '/ws-1/i1', { agent: 'shell' })).body.error).toBe('invalid_agent')
   })
 
+  it('400 invalid_effort for an unsupported value', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T' })
+    const { app } = build()
+    const r = await req(app, 'PATCH', '/ws-1/i1', { effort: 'extreme' })
+    expect(r.status).toBe(400)
+    expect(r.body.error).toBe('invalid_effort')
+  })
+
   it('validates and persists explicit scheduled ownership', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
     const { app } = build()
@@ -176,7 +184,13 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', body: 'keep me' })
     const { app, appendProvenance } = build()
     const r = await req(app, 'PATCH', '/ws-1/i1', {
-      status: 'in_progress', priority: 'high', assignee: '@human', agent: 'pi', what: 'new exact work',
+      status: 'in_progress',
+      priority: 'high',
+      assignee: '@human',
+      agent: 'pi',
+      model: 'gemini-3.5-pro',
+      effort: 'high',
+      what: 'new exact work',
     })
     expect(r.status).toBe(200)
     expect(r.body.issue).toMatchObject({
@@ -185,6 +199,8 @@ describe('PATCH /api/issues/:wsId/:id', () => {
       priority: 'high',
       assignee: '@human',
       agent: 'pi',
+      model: 'gemini-3.5-pro',
+      effort: 'high',
       what: 'new exact work',
     })
     expect(Array.isArray(r.body.runs)).toBe(true)
@@ -192,6 +208,8 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     const re = await readWorkspaceIssues(wsDir)
     expect(re.ok && re.issues[0].status).toBe('in_progress')
     expect(re.ok && re.issues[0].agent).toBe('pi')
+    expect(re.ok && re.issues[0].model).toBe('gemini-3.5-pro')
+    expect(re.ok && re.issues[0].effort).toBe('high')
     expect(re.ok && re.issues[0].what).toBe('new exact work')
     expect(appendProvenance).toHaveBeenCalledWith(expect.objectContaining({
       artifact: { kind: 'issue', workspaceId: 'ws-1', issueId: 'i1' },
@@ -203,6 +221,8 @@ describe('PATCH /api/issues/:wsId/:id', () => {
           { field: 'priority', before: 'none', after: 'high' },
           { field: 'assignee', before: '@workspace', after: '@human' },
           { field: 'runtime', after: 'pi' },
+          { field: 'model', after: 'gemini-3.5-pro' },
+          { field: 'effort', after: 'high' },
           { field: 'what' },
         ]),
       },

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -26,6 +26,11 @@
  */
 import { Hono } from 'hono'
 
+import {
+  MODEL_REASONING_EFFORTS,
+  isModelReasoningEffort,
+  type ModelReasoningEffort,
+} from '../../ai-providers/model-semantics.js'
 import type { WorkspaceConversationControl } from '../../core/workspace-tool-center.js'
 import { ACTIVITY_UPDATE_COALESCE_MS } from '../../core/provenance-store.js'
 import { createWorkspaceConversationControl } from '../../workspaces/conversation-control.js'
@@ -134,7 +139,15 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
 
     const body = await safeJson(c)
     const fields = body && typeof body === 'object' ? (body as Record<string, unknown>) : {}
-    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string } = {}
+    const patch: {
+      status?: IssueStatus
+      priority?: IssuePriority
+      assignee?: string
+      agent?: string | null
+      model?: string | null
+      effort?: ModelReasoningEffort | null
+      what?: string
+    } = {}
     if ('status' in fields) {
       const s = fields['status']
       if (typeof s !== 'string' || !ISSUE_STATUSES.includes(s as IssueStatus)) {
@@ -194,6 +207,29 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
         patch.agent = agent
       }
     }
+    if ('model' in fields) {
+      const raw = fields['model']
+      if (raw === null || raw === '') {
+        patch.model = null
+      } else if (typeof raw !== 'string' || !raw.trim()) {
+        return c.json({ error: 'invalid_model', message: 'model must be a native model id or null' }, 400)
+      } else {
+        patch.model = raw.trim()
+      }
+    }
+    if ('effort' in fields) {
+      const raw = fields['effort']
+      if (raw === null || raw === '') {
+        patch.effort = null
+      } else if (!isModelReasoningEffort(raw)) {
+        return c.json({
+          error: 'invalid_effort',
+          message: `effort must be one of: ${MODEL_REASONING_EFFORTS.join(', ')}`,
+        }, 400)
+      } else {
+        patch.effort = raw
+      }
+    }
     if ('what' in fields) {
       const what = fields['what']
       if (typeof what !== 'string' || what.trim().length === 0) {
@@ -205,7 +241,10 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
       patch.what = what.trim()
     }
     if (Object.keys(patch).length === 0) {
-      return c.json({ error: 'no_fields', message: 'provide at least one of status, priority, assignee, agent, what' }, 400)
+      return c.json({
+        error: 'no_fields',
+        message: 'provide at least one of status, priority, assignee, agent, model, effort, what',
+      }, 400)
     }
 
     try {

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -157,6 +157,17 @@ describe('claudeAdapter AI-config', () => {
     expect(JSON.parse(await read('.claude/settings.local.json'))).toEqual({ effortLevel: 'low' });
   });
 
+  it('persists an effort-only Claude native-login preference', async () => {
+    await claudeAdapter.writeAiConfig!(dir, { reasoningEffort: 'high' });
+    expect(JSON.parse(await read('.claude/settings.local.json'))).toEqual({
+      effortLevel: 'high',
+    });
+    expect(await claudeAdapter.readAiConfig!(dir)).toMatchObject({
+      model: null,
+      reasoningEffort: 'high',
+    });
+  });
+
   it('rejects effort values Claude Code cannot persist in project settings', async () => {
     await expect(claudeAdapter.writeAiConfig!(dir, { model: 'claude-x', reasoningEffort: 'max' }))
       .rejects.toThrow(/cannot persist project effort max/);
@@ -242,29 +253,77 @@ describe('codexAdapter AI-config', () => {
     await codexAdapter.writeAiConfig!(dir, {
       baseUrl: 'https://oai.test/v1', apiKey: 'sk-c', model: 'gpt-x', wireApi: 'responses',
     });
-    expect(await read('.codex/config.toml')).toBe(
+    expect(await read('.codex/openalice-home/config.toml')).toBe(
       'model = "gpt-x"\nmodel_provider = "workspace"\n\n'
       + '[model_providers.workspace]\nname = "OpenAlice workspace provider"\n'
       + 'base_url = "https://oai.test/v1"\nenv_key = "OPENALICE_WORKSPACE_KEY"\nwire_api = "responses"\n',
     );
-    expect(await read('.codex/env.json')).toBe('{\n  "OPENALICE_WORKSPACE_KEY": "sk-c"\n}\n');
+    expect(await read('.codex/openalice-home/env.json'))
+      .toBe('{\n  "OPENALICE_WORKSPACE_KEY": "sk-c"\n}\n');
+    expect(codexAdapter.composeEnv!({ cwd: dir, env: {} })).toEqual({
+      CODEX_HOME: join(dir, '.codex/openalice-home'),
+      OPENALICE_WORKSPACE_KEY: 'sk-c',
+    });
+    expect(codexAdapter.composeCommand([], { cwd: dir, env: {} })).toEqual(expect.arrayContaining([
+      '--model',
+      'gpt-x',
+      '-c',
+      'model_provider="workspace"',
+    ]));
   });
 
   it('always writes wire_api = responses (codex is Responses-only)', async () => {
     await codexAdapter.writeAiConfig!(dir, { baseUrl: 'https://oai.test/v1', apiKey: 'sk-c', model: 'gpt-x' });
-    expect(await read('.codex/config.toml')).toContain('wire_api = "responses"\n');
+    expect(await read('.codex/openalice-home/config.toml')).toContain('wire_api = "responses"\n');
   });
 
-  it('model-only writes no provider block and an empty env.json', async () => {
+  it('binds a managed API key without an explicit endpoint to the official provider', async () => {
+    await codexAdapter.writeAiConfig!(dir, { apiKey: 'sk-c', model: 'gpt-x' });
+    expect(await read('.codex/openalice-home/config.toml')).toContain(
+      'base_url = "https://api.openai.com/v1"\n',
+    );
+    expect(await codexAdapter.readAiConfig!(dir)).toMatchObject({
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-c',
+      model: 'gpt-x',
+    });
+  });
+
+  it('model-only uses native project config without redirecting CODEX_HOME', async () => {
     await codexAdapter.writeAiConfig!(dir, { model: 'gpt-y' });
     expect(await read('.codex/config.toml')).toBe('model = "gpt-y"\n');
-    expect(await read('.codex/env.json')).toBe('{}\n');
+    expect(existsSync(join(dir, '.codex/env.json'))).toBe(false);
+    expect(existsSync(join(dir, '.codex/openalice-provider.json'))).toBe(true);
+    expect(codexAdapter.composeEnv!({ cwd: dir, env: {} })).toEqual({});
   });
 
-  it('reset (empty cred) tears down the entire .codex/ directory', async () => {
+  it('reset removes only OpenAlice-owned Codex config and preserves siblings', async () => {
+    await mkdir(join(dir, '.codex'), { recursive: true });
+    await writeFile(join(dir, '.codex/config.toml'), 'notify = true\n');
     await codexAdapter.writeAiConfig!(dir, { baseUrl: 'u', model: 'm' });
     await codexAdapter.writeAiConfig!(dir, {});
-    expect(existsSync(join(dir, '.codex'))).toBe(false);
+    expect(await read('.codex/config.toml')).toBe('notify = true\n');
+    expect(existsSync(join(dir, '.codex/openalice-home'))).toBe(false);
+  });
+
+  it('restores a user-owned project model after resetting a native preference', async () => {
+    await mkdir(join(dir, '.codex'), { recursive: true });
+    await writeFile(join(dir, '.codex/config.toml'), 'model = "user-model"\nnotify = true\n');
+
+    await codexAdapter.writeAiConfig!(dir, { model: 'openalice-model', reasoningEffort: 'high' });
+    expect(await read('.codex/config.toml')).toBe(
+      'model = "openalice-model"\nnotify = true\nmodel_reasoning_effort = "high"\n',
+    );
+    await codexAdapter.writeAiConfig!(dir, {});
+    expect(await read('.codex/config.toml')).toBe('model = "user-model"\nnotify = true\n');
+  });
+
+  it('does not restore over a user edit made after native injection', async () => {
+    await codexAdapter.writeAiConfig!(dir, { model: 'openalice-model' });
+    await writeFile(join(dir, '.codex/config.toml'), 'model = "user-edited"\n');
+
+    await codexAdapter.writeAiConfig!(dir, {});
+    expect(await read('.codex/config.toml')).toBe('model = "user-edited"\n');
   });
 
   it('round-trips through readAiConfig', async () => {
@@ -280,8 +339,19 @@ describe('codexAdapter AI-config', () => {
     await codexAdapter.writeAiConfig!(dir, {
       baseUrl: 'https://oai.test/v1', model: 'gpt-x', reasoningEffort: 'medium',
     });
-    expect(await read('.codex/config.toml')).toContain('model_reasoning_effort = "medium"\n');
+    expect(await read('.codex/openalice-home/config.toml'))
+      .toContain('model_reasoning_effort = "medium"\n');
     expect(await codexAdapter.readAiConfig!(dir)).toMatchObject({ reasoningEffort: 'medium' });
+  });
+
+  it('writes and round-trips an effort-only native-login preference', async () => {
+    await codexAdapter.writeAiConfig!(dir, { reasoningEffort: 'high' });
+    expect(await read('.codex/config.toml')).toBe('model_reasoning_effort = "high"\n');
+    expect(codexAdapter.composeEnv!({ cwd: dir, env: {} })).toEqual({});
+    expect(await codexAdapter.readAiConfig!(dir)).toMatchObject({
+      model: null,
+      reasoningEffort: 'high',
+    });
   });
 
   it('readAiConfig returns null when no files exist', async () => {
@@ -289,8 +359,9 @@ describe('codexAdapter AI-config', () => {
   });
 
   it('listOnDisk returns only rollouts whose session_meta cwd matches this workspace', async () => {
-    // Workspace has its own .codex → adapter reads <cwd>/.codex/sessions (not ~).
-    const leaf = join(dir, '.codex', 'sessions', '2026', '06', '05');
+    await codexAdapter.writeAiConfig!(dir, { baseUrl: 'https://oai.test/v1', model: 'gpt-x' });
+    // Only custom-provider mode reads sessions from its isolated CODEX_HOME.
+    const leaf = join(dir, '.codex', 'openalice-home', 'sessions', '2026', '06', '05');
     await mkdir(leaf, { recursive: true });
     const mine = { type: 'session_meta', payload: { id: 'mine-uuid-0001', cwd: dir } };
     const other = { type: 'session_meta', payload: { id: 'other-uuid-0002', cwd: '/some/other/workspace' } };
@@ -406,14 +477,23 @@ describe('opencodeAdapter AI-config', () => {
     await opencodeAdapter.writeAiConfig!(dir, {
       baseUrl: 'https://cn.test/v1', apiKey: 'sk-o', model: 'deepseek-chat',
     });
-    expect(JSON.parse(await read('opencode.json'))).toEqual({
+    expect(JSON.parse(await read('opencode.json'))).toMatchObject({
       $schema: 'https://opencode.ai/config.json',
       provider: {
         workspace: {
           npm: '@ai-sdk/openai-compatible',
           name: 'OpenAlice workspace provider',
           options: { baseURL: 'https://cn.test/v1', apiKey: 'sk-o' },
-          models: { 'deepseek-chat': { name: 'deepseek-chat' } },
+          models: {
+            'deepseek-chat': {
+              name: 'deepseek-chat',
+              variants: {
+                none: { reasoningEffort: 'none' },
+                high: { reasoningEffort: 'high' },
+                max: { reasoningEffort: 'max' },
+              },
+            },
+          },
         },
       },
       model: 'workspace/deepseek-chat',
@@ -424,7 +504,7 @@ describe('opencodeAdapter AI-config', () => {
     await opencodeAdapter.writeAiConfig!(dir, {
       baseUrl: 'https://cn.test/v1', apiKey: 'sk-o', model: 'deepseek-chat', contextWindow: 1_000_000,
     });
-    expect(JSON.parse(await read('opencode.json')).provider.workspace.models['deepseek-chat']).toEqual({
+    expect(JSON.parse(await read('opencode.json')).provider.workspace.models['deepseek-chat']).toMatchObject({
       name: 'deepseek-chat',
       limit: { context: 1_000_000, output: 16_384 },
     });
@@ -661,6 +741,83 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
     expect(piAdapter.composeHeadlessCommand!(['pi'], ctx({ OPENALICE_LAUNCHER: 'docker' }), 'do x')).toEqual([
       'pi', '--approve', '-p', '--mode', 'json', 'do x',
     ]);
+  });
+
+  it('projects one-run model and effort overrides into every native CLI', () => {
+    expect(claudeAdapter.composeHeadlessCommand!(
+      ['claude'],
+      ctx(),
+      'do x',
+      { model: 'claude-opus-4-8', reasoningEffort: 'high' },
+    )).toEqual(expect.arrayContaining([
+      '--model', 'claude-opus-4-8', '--effort', 'high',
+    ]));
+    expect(codexAdapter.composeHeadlessCommand!(
+      ['codex'],
+      ctx(),
+      'do x',
+      { model: 'gpt-5.6', reasoningEffort: 'xhigh' },
+    )).toEqual(expect.arrayContaining([
+      '--model', 'gpt-5.6', '-c', 'model_reasoning_effort="xhigh"',
+    ]));
+    expect(opencodeAdapter.composeHeadlessCommand!(
+      ['opencode'],
+      ctx(),
+      'do x',
+      { model: 'openai/gpt-5.6', reasoningEffort: 'high' },
+    )).toEqual(expect.arrayContaining([
+      '--model', 'openai/gpt-5.6', '--variant', 'high',
+    ]));
+    expect(piAdapter.composeHeadlessCommand!(
+      ['pi'],
+      ctx(),
+      'do x',
+      { model: 'gpt-5.6', reasoningEffort: 'none' },
+    )).toEqual(expect.arrayContaining([
+      '--model', 'gpt-5.6', '--thinking', 'off',
+    ]));
+  });
+
+  it('rejects a one-run effort Claude Code does not expose', () => {
+    expect(() => claudeAdapter.composeHeadlessCommand!(
+      ['claude'],
+      ctx(),
+      'do x',
+      { reasoningEffort: 'xhigh' },
+    )).toThrow(/cannot use one-run effort xhigh/);
+  });
+
+  it('keeps custom-provider model overrides inside registered opencode/Pi models', async () => {
+    await opencodeAdapter.writeAiConfig!(dir, {
+      baseUrl: 'https://provider.test/v1',
+      model: 'registered-model',
+    });
+    expect(opencodeAdapter.composeHeadlessCommand!(
+      ['opencode'],
+      { cwd: dir, env: {} },
+      'do x',
+      { model: 'registered-model', reasoningEffort: 'high' },
+    )).toEqual(expect.arrayContaining([
+      '--model', 'workspace/registered-model', '--variant', 'high',
+    ]));
+    expect(() => opencodeAdapter.composeHeadlessCommand!(
+      ['opencode'],
+      { cwd: dir, env: {} },
+      'do x',
+      { model: 'unregistered-model' },
+    )).toThrow(/not registered by this Workspace provider/);
+
+    await mkdir(join(dir, '.pi'), { recursive: true });
+    await writeFile(join(dir, '.pi/settings.json'), JSON.stringify({
+      defaultProvider: 'openalice-workspace-test',
+      defaultModel: 'registered-model',
+    }));
+    expect(() => piAdapter.composeHeadlessCommand!(
+      ['pi'],
+      { cwd: dir, env: {} },
+      'do x',
+      { model: 'unregistered-model' },
+    )).toThrow(/not registered by this Workspace provider/);
   });
 
   it('resumes headless conversations by backend-resolved native id for all runtimes', () => {

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path';
 import type {
   AgentInteractiveSetupStatus,
   CliAdapter,
+  HeadlessRunOverrides,
   SpawnContext,
   WorkspaceAiCred,
 } from '../cli-adapter.js';
@@ -25,6 +26,7 @@ const CLAUDE_OWNED_PATHS = [
 ] as const;
 
 const CLAUDE_PROJECT_EFFORTS = new Set<ModelReasoningEffort>(['low', 'medium', 'high', 'xhigh']);
+const CLAUDE_RUN_EFFORTS = new Set<ModelReasoningEffort>(['low', 'medium', 'high', 'max']);
 
 function claudeProjectEffort(value: unknown): ModelReasoningEffort | null {
   return typeof value === 'string' && CLAUDE_PROJECT_EFFORTS.has(value as ModelReasoningEffort)
@@ -190,14 +192,24 @@ export const claudeAdapter: CliAdapter = {
   // progress in the task log AND every event carries `session_id`, so the
   // run's identity is captured from line 1 instead of parsed out of a final
   // result blob (verified 2.1.x, 2026-06-11).
-  composeHeadlessCommand(base: readonly string[], ctx: SpawnContext, prompt: string): readonly string[] {
+  composeHeadlessCommand(
+    base: readonly string[],
+    ctx: SpawnContext,
+    prompt: string,
+    overrides?: HeadlessRunOverrides,
+  ): readonly string[] {
     if (ctx.resume === 'last') {
       throw new Error('claude headless: resume requires a concrete resumeId mapping')
+    }
+    if (overrides?.reasoningEffort && !CLAUDE_RUN_EFFORTS.has(overrides.reasoningEffort)) {
+      throw new Error(`Claude Code cannot use one-run effort ${overrides.reasoningEffort}`)
     }
     return [
       ...base,
       '--settings', AUTOTRUST_SETTINGS,
       '--allowedTools', HEADLESS_ALLOWED_TOOLS,
+      ...(overrides?.model ? ['--model', overrides.model] : []),
+      ...(overrides?.reasoningEffort ? ['--effort', overrides.reasoningEffort] : []),
       ...(ctx.resume ? ['--resume', ctx.resume.sessionId] : []),
       '-p', '--output-format', 'stream-json', '--verbose',
       '--', prompt,
@@ -295,7 +307,7 @@ export const claudeAdapter: CliAdapter = {
   },
 
   async writeAiConfig(cwd: string, cred: WorkspaceAiCred): Promise<void> {
-    const hasAny = cred.baseUrl || cred.apiKey || cred.model;
+    const hasAny = cred.baseUrl || cred.apiKey || cred.model || cred.reasoningEffort;
     if (!hasAny) {
       await resetOwnedJsonConfig({
         cwd,

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -4,15 +4,27 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 
-import type { CliAdapter, OnDiskSession, SpawnContext, WorkspaceAiCred } from '../cli-adapter.js';
+import type {
+  CliAdapter,
+  HeadlessRunOverrides,
+  OnDiskSession,
+  SpawnContext,
+  WorkspaceAiCred,
+} from '../cli-adapter.js';
 import { isModelReasoningEffort } from '../../ai-providers/model-semantics.js';
 import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js';
 import type { HeadlessOutputEvent } from '../headless-output.js';
+import { resetOwnedTomlConfig, writeOwnedTomlConfig } from './owned-toml-config.js';
 
 const CODEX_CONFIG_PATH = '.codex/config.toml';
-const CODEX_ENV_PATH = '.codex/env.json';
+const CODEX_BINDING_STATE_PATH = '.codex/openalice-provider.json';
+const CODEX_ISOLATED_HOME_PATH = '.codex/openalice-home';
+const CODEX_ISOLATED_CONFIG_PATH = `${CODEX_ISOLATED_HOME_PATH}/config.toml`;
+const CODEX_ISOLATED_ENV_PATH = `${CODEX_ISOLATED_HOME_PATH}/env.json`;
+const CODEX_LEGACY_ENV_PATH = '.codex/env.json';
 const CODEX_KEY_ENV_NAME = 'OPENALICE_WORKSPACE_KEY';
 const CODEX_PROVIDER_NAME = 'workspace';
+const CODEX_DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 const CODEX_INTERACTIVE_PERMISSION_ARGS = [
   '--sandbox',
   'danger-full-access',
@@ -42,7 +54,7 @@ const CODEX_INTERACTIVE_PERMISSION_ARGS = [
  *   Its TUI probes OSC 10/11 at startup and derives contrast-sensitive colors
  *   from the terminal defaults supplied by OpenAlice's shared PTY layer.
  *
- * AI provider model — two modes, mutually exclusive:
+ * AI provider model — three modes, selected explicitly:
  *
  *   1. **Default (no override).** Workspace has no `.codex/` directory.
  *      Adapter doesn't set `CODEX_HOME`. Codex reads the user's global
@@ -52,15 +64,17 @@ const CODEX_INTERACTIVE_PERMISSION_ARGS = [
  *      flags in `composeCommand` below, so MCP is visible without polluting
  *      the user's global config.
  *
- *   2. **Override (user-configured via OpenAlice UI).** Workspace has its
- *      own `.codex/{config.toml, env.json[, auth.json]}`. Adapter sets
- *      `CODEX_HOME=<cwd>/.codex`. Codex reads workspace files only,
- *      isolated from global state.
+ *   2. **Native login preference.** `.codex/config.toml` contains only the
+ *      project-local model / effort preference. `CODEX_HOME` remains unset, so
+ *      Codex keeps the user's normal login, sessions, skills, and user config.
  *
- * No symlinks, no global-fallback inheritance. The `-c` flag is OpenAlice's
- * "local MCP registration" — analogous to claude's `.mcp.json` cwd
- * discovery, but driven via codex's CLI override flag since codex has no
- * cwd-MCP convention of its own.
+ *   3. **OpenAlice-managed custom provider.** Provider config and its env key
+ *      live under `.codex/openalice-home/`; only this explicit mode sets
+ *      `CODEX_HOME` to that isolated directory.
+ *
+ * The `-c` flag is OpenAlice's "local MCP registration" — analogous to
+ * claude's `.mcp.json` cwd discovery, but driven via codex's CLI override flag
+ * since codex has no cwd-MCP convention of its own.
  */
 
 export const codexAdapter: CliAdapter = {
@@ -118,9 +132,22 @@ export const codexAdapter: CliAdapter = {
   //                       loopback CLI gateway (else: "...fetch failed").
   // No mcp_servers head (interactive composeCommand keeps it — MCP works there
   // with a human approver). `--` terminates options before the trailing prompt.
-  composeHeadlessCommand(_base: readonly string[], ctx: SpawnContext, prompt: string): readonly string[] {
+  composeHeadlessCommand(
+    _base: readonly string[],
+    ctx: SpawnContext,
+    prompt: string,
+    overrides?: HeadlessRunOverrides,
+  ): readonly string[] {
+    const custom = readCustomProviderSelection(ctx.cwd);
+    const model = overrides?.model ?? custom?.model;
+    const reasoningEffort = overrides?.reasoningEffort ?? custom?.reasoningEffort;
     const head = [
       'codex',
+      ...(model ? ['--model', model] : []),
+      ...(reasoningEffort
+        ? ['-c', `model_reasoning_effort=${tomlString(reasoningEffort)}`]
+        : []),
+      ...(custom ? ['-c', `model_provider=${tomlString(CODEX_PROVIDER_NAME)}`] : []),
       '-c',
       'approval_policy="never"',
       '-c',
@@ -265,55 +292,99 @@ export const codexAdapter: CliAdapter = {
   },
 
   async writeAiConfig(cwd: string, cred: WorkspaceAiCred): Promise<void> {
-    const hasProvider = !!(cred.baseUrl || cred.model);
+    const hasAny = !!(cred.baseUrl || cred.apiKey || cred.model || cred.reasoningEffort);
+    const legacyIsolated = isLegacyIsolatedHome(cwd);
+    const legacyNative = !legacyIsolated && existsSync(join(cwd, CODEX_LEGACY_ENV_PATH));
 
-    if (!hasProvider) {
-      // Reset: tear down the workspace's entire `.codex/` directory. The
-      // adapter's `composeEnv` won't set `CODEX_HOME` when the directory is
-      // absent, so codex falls back to the user's global `~/.codex/`. We
-      // don't leave empty stubs behind — workspace files exist only when
-      // there's an actual override. Note: `CODEX_HOME` is exclusive (not a
-      // merge layer), so a half-empty `.codex/` would *shadow* the user's
-      // global login and break auth. Full teardown is the only safe reset.
-      const codexDir = join(cwd, '.codex');
-      await rm(codexDir, { recursive: true, force: true });
+    if (!hasAny) {
+      await rm(join(cwd, CODEX_ISOLATED_HOME_PATH), { recursive: true, force: true });
+      if (legacyIsolated) await resetLegacyIsolatedHome(cwd);
+      else await rm(join(cwd, CODEX_LEGACY_ENV_PATH), { force: true });
+      await resetOwnedTomlConfig({
+        cwd,
+        configPath: CODEX_CONFIG_PATH,
+        statePath: CODEX_BINDING_STATE_PATH,
+        ...(legacyNative ? { legacyOwnedKeys: ['model', 'model_reasoning_effort'] } : {}),
+      });
       return;
     }
 
-    // Provider override. config.toml carries only model / model_provider /
-    // [model_providers.*] — the OpenAlice MCP server entries are wired per-spawn
-    // via this adapter's `-c mcp_servers...url=...` flags, so we
-    // don't repeat it here.
+    if (!cred.baseUrl && !cred.apiKey) {
+      // Native login mode: project-level model preferences are a normal Codex
+      // config layer. They must not redirect CODEX_HOME or shadow global auth.
+      await rm(join(cwd, CODEX_ISOLATED_HOME_PATH), { recursive: true, force: true });
+      if (legacyIsolated) await resetLegacyIsolatedHome(cwd);
+      else await rm(join(cwd, CODEX_LEGACY_ENV_PATH), { force: true });
+      await writeOwnedTomlConfig({
+        cwd,
+        configPath: CODEX_CONFIG_PATH,
+        statePath: CODEX_BINDING_STATE_PATH,
+        entries: [
+          { key: 'model', value: cred.model ? tomlString(cred.model) : null },
+          {
+            key: 'model_reasoning_effort',
+            value: cred.reasoningEffort ? tomlString(cred.reasoningEffort) : null,
+          },
+        ],
+        ...(legacyNative ? { legacyOwnedKeys: ['model', 'model_reasoning_effort'] } : {}),
+      });
+      return;
+    }
+
+    // Custom provider mode: provider tables are not a supported Codex project
+    // layer, so keep them in an explicit isolated CODEX_HOME. Restore any
+    // OpenAlice-owned native project keys before entering that mode.
+    await resetOwnedTomlConfig({
+      cwd,
+      configPath: CODEX_CONFIG_PATH,
+      statePath: CODEX_BINDING_STATE_PATH,
+      ...(legacyNative ? { legacyOwnedKeys: ['model', 'model_reasoning_effort'] } : {}),
+    });
+    if (legacyIsolated) await resetLegacyIsolatedHome(cwd);
+    else await rm(join(cwd, CODEX_LEGACY_ENV_PATH), { force: true });
+
+    // A managed API key without an explicit endpoint still means the official
+    // OpenAI provider. Materialize that endpoint because the isolated home has
+    // no inherited provider block to attach env_key to.
+    const providerBaseUrl = cred.baseUrl || CODEX_DEFAULT_BASE_URL;
     let toml = '';
     if (cred.model) toml += `model = ${tomlString(cred.model)}\n`;
-    if (cred.reasoningEffort) toml += `model_reasoning_effort = ${tomlString(cred.reasoningEffort)}\n`;
-    if (cred.baseUrl) toml += `model_provider = "${CODEX_PROVIDER_NAME}"\n`;
-    if (cred.baseUrl) {
-      toml += '\n';
-      toml += `[model_providers.${CODEX_PROVIDER_NAME}]\n`;
-      toml += `name = "OpenAlice workspace provider"\n`;
-      toml += `base_url = ${tomlString(cred.baseUrl)}\n`;
-      toml += `env_key = "${CODEX_KEY_ENV_NAME}"\n`;
-      // Codex 0.130+ only speaks the OpenAI Responses API — it hard-rejects
-      // wire_api="chat" — so this is always "responses" regardless of the
-      // credential's wireShape. See memory reference_codex_chat_dead.
-      toml += `wire_api = "responses"\n`;
+    if (cred.reasoningEffort) {
+      toml += `model_reasoning_effort = ${tomlString(cred.reasoningEffort)}\n`;
     }
-    await writeWorkspaceFile(cwd, CODEX_CONFIG_PATH, toml);
+    toml += `model_provider = "${CODEX_PROVIDER_NAME}"\n`;
+    toml += '\n';
+    toml += `[model_providers.${CODEX_PROVIDER_NAME}]\n`;
+    toml += `name = "OpenAlice workspace provider"\n`;
+    toml += `base_url = ${tomlString(providerBaseUrl)}\n`;
+    toml += `env_key = "${CODEX_KEY_ENV_NAME}"\n`;
+    // Codex 0.130+ only speaks the OpenAI Responses API — it hard-rejects
+    // wire_api="chat" — so this is always "responses" regardless of the
+    // credential's wireShape. See memory reference_codex_chat_dead.
+    toml += `wire_api = "responses"\n`;
+    await writeWorkspaceFile(cwd, CODEX_ISOLATED_CONFIG_PATH, toml);
 
     // env.json: holds the per-workspace API key codex picks up via env_key.
     // composeEnv reads this and exports at spawn.
     if (cred.apiKey) {
       const envObj: Record<string, string> = { [CODEX_KEY_ENV_NAME]: cred.apiKey };
-      await writeWorkspaceFile(cwd, CODEX_ENV_PATH, JSON.stringify(envObj, null, 2) + '\n');
+      await writeWorkspaceFile(cwd, CODEX_ISOLATED_ENV_PATH, JSON.stringify(envObj, null, 2) + '\n');
     } else {
-      await writeWorkspaceFile(cwd, CODEX_ENV_PATH, '{}\n');
+      await writeWorkspaceFile(cwd, CODEX_ISOLATED_ENV_PATH, '{}\n');
     }
   },
 
   async readAiConfig(cwd: string): Promise<WorkspaceAiCred | null> {
-    const tomlRaw = await readWorkspaceFile(cwd, CODEX_CONFIG_PATH);
-    const envRaw = await readWorkspaceFile(cwd, CODEX_ENV_PATH);
+    const isolatedHome = isolatedHomePath(cwd);
+    const tomlRaw = await readWorkspaceFile(
+      cwd,
+      isolatedHome === CODEX_ISOLATED_HOME_PATH ? CODEX_ISOLATED_CONFIG_PATH : CODEX_CONFIG_PATH,
+    );
+    const envRaw = isolatedHome === CODEX_ISOLATED_HOME_PATH
+      ? await readWorkspaceFile(cwd, CODEX_ISOLATED_ENV_PATH)
+      : isolatedHome === '.codex'
+        ? await readWorkspaceFile(cwd, CODEX_LEGACY_ENV_PATH)
+        : null;
     if (tomlRaw === null && envRaw === null) return null;
 
     let baseUrl: string | null = null;
@@ -361,11 +432,9 @@ export const codexAdapter: CliAdapter = {
   },
 
   /**
-   * Set `CODEX_HOME` only when workspace has its own `.codex/` directory
-   * (override mode). Otherwise codex falls back to its own `~/.codex/`,
-   * which is its normal behavior in any uninvolved project. The "reset
-   * to default" UI action deletes the entire `.codex/` directory so the
-   * adapter naturally falls back here.
+   * Set `CODEX_HOME` only for an explicit OpenAlice-managed custom provider.
+   * A normal `.codex/config.toml` is Codex's native project layer and must keep
+   * the user's global home/login/session state.
    *
    * `.codex/env.json` is OpenAlice's per-workspace key bridge. Codex's
    * `[model_providers.X].env_key` field indirects through an env var; the
@@ -376,8 +445,9 @@ export const codexAdapter: CliAdapter = {
    */
   composeEnv(ctx: SpawnContext): Record<string, string> {
     const result: Record<string, string> = {};
-    const workspaceCodex = join(ctx.cwd, '.codex');
-    if (!existsSync(workspaceCodex)) return result;
+    const relativeHome = isolatedHomePath(ctx.cwd);
+    if (!relativeHome) return result;
+    const workspaceCodex = join(ctx.cwd, relativeHome);
     result['CODEX_HOME'] = workspaceCodex;
     const envFile = join(workspaceCodex, 'env.json');
     if (existsSync(envFile)) {
@@ -406,15 +476,16 @@ export const codexAdapter: CliAdapter = {
   /**
    * List codex sessions belonging to THIS workspace cwd, for the transcript
    * watcher's post-spawn id capture (codex can't be assigned an id at spawn).
-   * Sessions live at `$CODEX_HOME/sessions` (override mode) or
+   * Sessions live at `$CODEX_HOME/sessions` (custom-provider mode) or
    * `~/.codex/sessions` (default), partitioned `YYYY/MM/DD`, GLOBAL across all
    * cwds. We read each rollout's line-1 `session_meta { id, cwd }` (written at
    * session start) and keep only those whose cwd matches — scanning just the
    * newest dated leaves since a just-spawned session is today's.
    */
   async listOnDisk(cwd: string): Promise<readonly OnDiskSession[]> {
-    const root = existsSync(join(cwd, '.codex'))
-      ? join(cwd, '.codex', 'sessions')
+    const relativeHome = isolatedHomePath(cwd);
+    const root = relativeHome
+      ? join(cwd, relativeHome, 'sessions')
       : join(homedir(), '.codex', 'sessions');
     const target = resolve(cwd);
     const out: OnDiskSession[] = [];
@@ -457,9 +528,20 @@ export const codexAdapter: CliAdapter = {
  * the injected `alice*` CLI tools.
  */
 function codexMcpHead(ctx: SpawnContext): string[] {
+  const custom = readCustomProviderSelection(ctx.cwd);
+  const selection = custom
+    ? [
+        ...(custom.model ? ['--model', custom.model] : []),
+        ...(custom.reasoningEffort
+          ? ['-c', `model_reasoning_effort=${tomlString(custom.reasoningEffort)}`]
+          : []),
+        '-c',
+        `model_provider=${tomlString(CODEX_PROVIDER_NAME)}`,
+      ]
+    : [];
   const mcpUrl = ctx.env['OPENALICE_MCP_URL'];
   if (!mcpUrl) {
-    return ['codex', ...CODEX_INTERACTIVE_PERMISSION_ARGS];
+    return ['codex', ...selection, ...CODEX_INTERACTIVE_PERMISSION_ARGS];
   }
   const workspaceId = ctx.env['AQ_WS_ID'];
   if (!workspaceId) {
@@ -467,6 +549,7 @@ function codexMcpHead(ctx: SpawnContext): string[] {
   }
   return [
     'codex',
+    ...selection,
     ...CODEX_INTERACTIVE_PERMISSION_ARGS,
     '-c',
     `mcp_servers.openalice.url="${mcpUrl}"`,
@@ -554,6 +637,97 @@ async function ensureTrustedProject(cwd: string): Promise<void> {
   const block = `\n[projects."${headerEsc}"]\ntrust_level = "trusted"\n`;
   const next = existing.endsWith('\n') || existing.length === 0 ? existing + block : existing + '\n' + block;
   await writeFile(configPath, next, 'utf8');
+}
+
+function isLegacyIsolatedHome(cwd: string): boolean {
+  if (existsSync(join(cwd, CODEX_ISOLATED_CONFIG_PATH))) return false;
+  const configPath = join(cwd, CODEX_CONFIG_PATH);
+  if (existsSync(configPath)) {
+    try {
+      const raw = readFileSync(configPath, 'utf8');
+      if (
+        /^\s*model_provider\s*=\s*"workspace"\s*$/m.test(raw) ||
+        /^\s*\[model_providers\.workspace\]\s*$/m.test(raw)
+      ) {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+  }
+  const envPath = join(cwd, CODEX_LEGACY_ENV_PATH);
+  if (!existsSync(envPath)) return false;
+  try {
+    const parsed = JSON.parse(readFileSync(envPath, 'utf8')) as Record<string, unknown>;
+    return typeof parsed[CODEX_KEY_ENV_NAME] === 'string';
+  } catch {
+    return false;
+  }
+}
+
+function isolatedHomePath(cwd: string): string | null {
+  if (
+    existsSync(join(cwd, CODEX_ISOLATED_CONFIG_PATH)) ||
+    existsSync(join(cwd, CODEX_ISOLATED_ENV_PATH))
+  ) {
+    return CODEX_ISOLATED_HOME_PATH;
+  }
+  return isLegacyIsolatedHome(cwd) ? '.codex' : null;
+}
+
+function readCustomProviderSelection(cwd: string): {
+  model?: string
+  reasoningEffort?: NonNullable<WorkspaceAiCred['reasoningEffort']>
+} | null {
+  const home = isolatedHomePath(cwd);
+  if (!home) return null;
+  const configPath = home === CODEX_ISOLATED_HOME_PATH
+    ? CODEX_ISOLATED_CONFIG_PATH
+    : CODEX_CONFIG_PATH;
+  try {
+    const raw = readFileSync(join(cwd, configPath), 'utf8');
+    const model = raw.match(/^model\s*=\s*"([^"]*)"\s*$/m)?.[1];
+    const effort = raw.match(/^model_reasoning_effort\s*=\s*"([^"]*)"\s*$/m)?.[1];
+    return {
+      ...(model ? { model } : {}),
+      ...(isModelReasoningEffort(effort) ? { reasoningEffort: effort } : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
+async function resetLegacyIsolatedHome(cwd: string): Promise<void> {
+  const raw = await readWorkspaceFile(cwd, CODEX_CONFIG_PATH);
+  if (raw !== null) {
+    const lines = raw.split(/\r?\n/);
+    const kept: string[] = [];
+    let inWorkspaceProvider = false;
+    let beforeFirstSection = true;
+    for (const line of lines) {
+      const section = line.match(/^\s*\[([^\]]+)\]\s*$/);
+      if (section) {
+        beforeFirstSection = false;
+        inWorkspaceProvider = section[1] === `model_providers.${CODEX_PROVIDER_NAME}`;
+        if (inWorkspaceProvider) continue;
+      }
+      if (inWorkspaceProvider) continue;
+      if (
+        beforeFirstSection &&
+        /^\s*(model|model_reasoning_effort|model_provider)\s*=/.test(line)
+      ) {
+        continue;
+      }
+      kept.push(line);
+    }
+    while (kept.at(-1)?.trim() === '') kept.pop();
+    if (kept.some((line) => line.trim().length > 0)) {
+      await writeWorkspaceFile(cwd, CODEX_CONFIG_PATH, `${kept.join('\n')}\n`);
+    } else {
+      await rm(join(cwd, CODEX_CONFIG_PATH), { force: true });
+    }
+  }
+  await rm(join(cwd, CODEX_LEGACY_ENV_PATH), { force: true });
 }
 
 function isENOENT(err: unknown): boolean {

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -1,10 +1,20 @@
 import { execFile } from 'node:child_process';
-import { statSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
-import type { CliAdapter, OnDiskSession, SpawnContext, WorkspaceAiCred } from '../cli-adapter.js';
-import { isModelReasoningEffort } from '../../ai-providers/model-semantics.js';
+import type {
+  CliAdapter,
+  HeadlessRunOverrides,
+  OnDiskSession,
+  SpawnContext,
+  WorkspaceAiCred,
+} from '../cli-adapter.js';
+import {
+  MODEL_REASONING_EFFORTS,
+  isModelReasoningEffort,
+  type ModelReasoningEffort,
+} from '../../ai-providers/model-semantics.js';
 import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js';
 import type { HeadlessOutputEvent } from '../headless-output.js';
 import { resetOwnedJsonConfig, writeOwnedJsonConfig } from './owned-json-config.js';
@@ -24,8 +34,72 @@ const OPENCODE_OWNED_PATHS = [
 ] as const;
 const DEFAULT_OUTPUT_TOKENS = 16_384;
 
-function modelEffortOptions(cred: WorkspaceAiCred): Record<string, unknown> | null {
-  const effort = cred.reasoningEffort;
+function opencodeRunModel(cwd: string, model: string): string {
+  if (model.includes('/')) return model;
+  try {
+    const config = JSON.parse(readFileSync(join(cwd, OPENCODE_CONFIG_PATH), 'utf8')) as Record<string, unknown>;
+    const providers = config['provider'];
+    const workspace = providers && typeof providers === 'object'
+      ? (providers as Record<string, unknown>)[OPENCODE_PROVIDER_NAME]
+      : null;
+    const models = workspace && typeof workspace === 'object'
+      ? (workspace as Record<string, unknown>)['models']
+      : null;
+    if (models && typeof models === 'object') {
+      if (Object.prototype.hasOwnProperty.call(models, model)) {
+        return `${OPENCODE_PROVIDER_NAME}/${model}`;
+      }
+      throw new Error(
+        `OpenCode model override "${model}" is not registered by this Workspace provider; use a provider/model id or save that model in Workspace AI settings first`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('OpenCode model override')) throw err;
+  }
+  return model;
+}
+
+function opencodeRunVariant(
+  cwd: string,
+  requestedModel: string | undefined,
+  effort: ModelReasoningEffort,
+): string {
+  if (requestedModel?.includes('/')) return effort;
+  try {
+    const config = JSON.parse(readFileSync(join(cwd, OPENCODE_CONFIG_PATH), 'utf8')) as Record<string, unknown>;
+    const topModel = typeof config['model'] === 'string' ? config['model'] : null;
+    const model = requestedModel
+      ?? (topModel?.startsWith(`${OPENCODE_PROVIDER_NAME}/`)
+        ? topModel.slice(OPENCODE_PROVIDER_NAME.length + 1)
+        : null);
+    if (!model) return effort;
+    const providers = config['provider'];
+    const workspace = providers && typeof providers === 'object'
+      ? (providers as Record<string, unknown>)[OPENCODE_PROVIDER_NAME]
+      : null;
+    const models = workspace && typeof workspace === 'object'
+      ? (workspace as Record<string, unknown>)['models']
+      : null;
+    const modelConfig = models && typeof models === 'object'
+      ? (models as Record<string, unknown>)[model]
+      : null;
+    if (!modelConfig || typeof modelConfig !== 'object') return effort;
+    const variants = (modelConfig as Record<string, unknown>)['variants'];
+    if (!variants || typeof variants !== 'object' || !Object.prototype.hasOwnProperty.call(variants, effort)) {
+      throw new Error(
+        `OpenCode effort override "${effort}" is not registered for Workspace model "${model}"`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('OpenCode effort override')) throw err;
+  }
+  return effort;
+}
+
+function modelEffortOptions(
+  cred: WorkspaceAiCred,
+  effort = cred.reasoningEffort,
+): Record<string, unknown> | null {
   if (!effort) return null;
   if (cred.wireShape === 'anthropic') {
     if (effort === 'none') return { thinking: { type: 'disabled' } };
@@ -38,9 +112,21 @@ function modelEffortOptions(cred: WorkspaceAiCred): Record<string, unknown> | nu
       : { effort };
   }
   if (cred.wireShape === 'google-generative-ai') {
-    return { thinkingConfig: { includeThoughts: effort !== 'none', thinkingLevel: effort } };
+    return effort === 'none'
+      ? { thinkingConfig: { includeThoughts: false } }
+      : { thinkingConfig: { includeThoughts: true, thinkingLevel: effort } };
   }
   return { reasoningEffort: effort };
+}
+
+function modelEffortVariants(cred: WorkspaceAiCred): Record<string, Record<string, unknown>> | null {
+  if (cred.reasoning === false) return null;
+  return Object.fromEntries(
+    MODEL_REASONING_EFFORTS.map((effort) => [
+      effort,
+      modelEffortOptions(cred, effort) ?? {},
+    ]),
+  );
 }
 
 function readModelEffort(
@@ -223,9 +309,18 @@ export const opencodeAdapter: CliAdapter = {
   // boundary. Tool access is via the injected CLI shims and bundled skills;
   // prompt is the trailing positional after a `--` end-of-options terminator
   // (so a `-`-leading prompt isn't read as a flag).
-  composeHeadlessCommand(_base: readonly string[], ctx: SpawnContext, prompt: string): readonly string[] {
+  composeHeadlessCommand(
+    _base: readonly string[],
+    ctx: SpawnContext,
+    prompt: string,
+    overrides?: HeadlessRunOverrides,
+  ): readonly string[] {
     return [
       'opencode', 'run', '--format', 'json',
+      ...(overrides?.model ? ['--model', opencodeRunModel(ctx.cwd, overrides.model)] : []),
+      ...(overrides?.reasoningEffort
+        ? ['--variant', opencodeRunVariant(ctx.cwd, overrides.model, overrides.reasoningEffort)]
+        : []),
       ...(ctx.resume === 'last' ? ['--continue'] : ctx.resume ? ['--session', ctx.resume.sessionId] : []),
       '--', prompt,
     ];
@@ -375,6 +470,8 @@ export const opencodeAdapter: CliAdapter = {
       if (typeof cred.reasoning === 'boolean') model['reasoning'] = cred.reasoning;
       const effortOptions = modelEffortOptions(cred);
       if (effortOptions) model['options'] = effortOptions;
+      const effortVariants = modelEffortVariants(cred);
+      if (effortVariants) model['variants'] = effortVariants;
       const contextWindow = positiveNumber(cred.contextWindow);
       if (contextWindow !== null) {
         // opencode treats missing custom-model limits as 0, which disables its

--- a/src/workspaces/adapters/owned-toml-config.ts
+++ b/src/workspaces/adapters/owned-toml-config.ts
@@ -1,0 +1,193 @@
+/**
+ * Reversible ownership for top-level scalar assignments OpenAlice injects into
+ * a native TOML config. Unknown assignments, sections, comments, and spacing
+ * remain byte-for-byte untouched.
+ *
+ * This deliberately supports only top-level keys. Provider tables belong in an
+ * isolated runtime home and must not be projected into a shared project file.
+ */
+
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js'
+
+interface SavedTomlLine {
+  readonly present: boolean
+  readonly line?: string
+}
+
+interface OwnedTomlStateEntry {
+  readonly key: string
+  readonly previous: SavedTomlLine
+  readonly injected: SavedTomlLine
+}
+
+interface OwnedTomlState {
+  readonly version: 1
+  readonly entries: OwnedTomlStateEntry[]
+}
+
+export interface OwnedTomlEntry {
+  readonly key: string
+  readonly value?: string | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isSafeKey(key: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_-]*$/.test(key)
+}
+
+function assignmentPattern(key: string): RegExp {
+  return new RegExp(`^\\s*${key.replaceAll('-', '\\-')}\\s*=`)
+}
+
+function sectionIndex(lines: readonly string[]): number {
+  const found = lines.findIndex((line) => /^\s*\[/.test(line))
+  return found === -1 ? lines.length : found
+}
+
+function findTopLevelLine(lines: readonly string[], key: string): number {
+  const end = sectionIndex(lines)
+  const pattern = assignmentPattern(key)
+  const matches: number[] = []
+  for (let index = 0; index < end; index += 1) {
+    if (pattern.test(lines[index] ?? '')) matches.push(index)
+  }
+  if (matches.length > 1) throw new Error(`TOML config contains duplicate top-level ${key} assignments`)
+  return matches[0] ?? -1
+}
+
+function snapshot(lines: readonly string[], key: string): SavedTomlLine {
+  const index = findTopLevelLine(lines, key)
+  return index === -1 ? { present: false } : { present: true, line: lines[index] }
+}
+
+function apply(lines: string[], key: string, saved: SavedTomlLine): void {
+  const index = findTopLevelLine(lines, key)
+  if (!saved.present) {
+    if (index !== -1) lines.splice(index, 1)
+    return
+  }
+  if (index !== -1) {
+    lines[index] = saved.line ?? ''
+    return
+  }
+  lines.splice(sectionIndex(lines), 0, saved.line ?? '')
+}
+
+function sameLine(left: SavedTomlLine, right: SavedTomlLine): boolean {
+  return left.present === right.present && (!left.present || left.line === right.line)
+}
+
+function splitToml(raw: string | null): string[] {
+  if (raw === null || raw.length === 0) return []
+  const lines = raw.split(/\r?\n/)
+  if (lines.at(-1) === '') lines.pop()
+  return lines
+}
+
+async function readState(cwd: string, statePath: string): Promise<OwnedTomlState | null> {
+  const raw = await readWorkspaceFile(cwd, statePath)
+  if (raw === null) return null
+  let value: unknown
+  try {
+    value = JSON.parse(raw) as unknown
+  } catch {
+    throw new Error(`OpenAlice TOML ownership state is not valid JSON: ${join(cwd, statePath)}`)
+  }
+  if (!isRecord(value) || value['version'] !== 1 || !Array.isArray(value['entries'])) {
+    throw new Error(`Unsupported OpenAlice TOML ownership state: ${join(cwd, statePath)}`)
+  }
+  const entries: OwnedTomlStateEntry[] = []
+  for (const entry of value['entries']) {
+    if (
+      !isRecord(entry) ||
+      typeof entry['key'] !== 'string' ||
+      !isSafeKey(entry['key']) ||
+      !isRecord(entry['previous']) ||
+      !isRecord(entry['injected']) ||
+      typeof entry['previous']['present'] !== 'boolean' ||
+      typeof entry['injected']['present'] !== 'boolean' ||
+      (entry['previous']['present'] === true && typeof entry['previous']['line'] !== 'string') ||
+      (entry['injected']['present'] === true && typeof entry['injected']['line'] !== 'string')
+    ) {
+      throw new Error(`Unsupported OpenAlice TOML ownership state: ${join(cwd, statePath)}`)
+    }
+    entries.push(entry as unknown as OwnedTomlStateEntry)
+  }
+  return { version: 1, entries }
+}
+
+async function writeLines(cwd: string, configPath: string, lines: readonly string[]): Promise<void> {
+  if (lines.every((line) => line.trim().length === 0)) {
+    await rm(join(cwd, configPath), { force: true })
+    return
+  }
+  await writeWorkspaceFile(cwd, configPath, `${lines.join('\n')}\n`)
+}
+
+export async function writeOwnedTomlConfig(opts: {
+  readonly cwd: string
+  readonly configPath: string
+  readonly statePath: string
+  readonly entries: readonly OwnedTomlEntry[]
+  /** Keys written by an older OpenAlice release before ownership state existed. */
+  readonly legacyOwnedKeys?: readonly string[]
+}): Promise<void> {
+  const raw = await readWorkspaceFile(opts.cwd, opts.configPath)
+  const lines = splitToml(raw)
+  const state = await readState(opts.cwd, opts.statePath)
+  const priorByKey = new Map(state?.entries.map((entry) => [entry.key, entry]) ?? [])
+  const legacyOwned = new Set(state ? [] : opts.legacyOwnedKeys ?? [])
+  const nextEntries: OwnedTomlStateEntry[] = []
+
+  for (const desired of opts.entries) {
+    if (!isSafeKey(desired.key)) throw new Error(`Invalid OpenAlice TOML ownership key: ${desired.key}`)
+    const previous = priorByKey.get(desired.key)?.previous
+      ?? (legacyOwned.has(desired.key) ? { present: false } : snapshot(lines, desired.key))
+    const injected: SavedTomlLine = desired.value
+      ? { present: true, line: `${desired.key} = ${desired.value}` }
+      : { present: false }
+    apply(lines, desired.key, injected)
+    nextEntries.push({ key: desired.key, previous, injected })
+  }
+
+  await writeLines(opts.cwd, opts.configPath, lines)
+  await writeWorkspaceFile(opts.cwd, opts.statePath, `${JSON.stringify({
+    version: 1,
+    entries: nextEntries,
+  } satisfies OwnedTomlState, null, 2)}\n`)
+}
+
+export async function resetOwnedTomlConfig(opts: {
+  readonly cwd: string
+  readonly configPath: string
+  readonly statePath: string
+  /** Keys written by an older OpenAlice release before ownership state existed. */
+  readonly legacyOwnedKeys?: readonly string[]
+}): Promise<void> {
+  const raw = await readWorkspaceFile(opts.cwd, opts.configPath)
+  const state = await readState(opts.cwd, opts.statePath)
+
+  if (state && raw === null) {
+    await rm(join(opts.cwd, opts.statePath), { force: true })
+    return
+  }
+
+  const lines = splitToml(raw)
+  if (state) {
+    for (const entry of state.entries) {
+      if (sameLine(snapshot(lines, entry.key), entry.injected)) {
+        apply(lines, entry.key, entry.previous)
+      }
+    }
+  } else {
+    for (const key of opts.legacyOwnedKeys ?? []) apply(lines, key, { present: false })
+  }
+  await writeLines(opts.cwd, opts.configPath, lines)
+  await rm(join(opts.cwd, opts.statePath), { force: true })
+}

--- a/src/workspaces/adapters/pi-config.ts
+++ b/src/workspaces/adapters/pi-config.ts
@@ -25,7 +25,7 @@ export const PI_BINDING_STATE_PATH = '.pi/openalice-provider.json';
 export const LEGACY_PI_AGENT_DIR = '.pi-agent';
 export const PI_AUTOMATIC_THEME_PAIR = 'light/dark';
 
-const PI_PROVIDER_PREFIX = 'openalice-workspace-';
+export const PI_PROVIDER_PREFIX = 'openalice-workspace-';
 const PI_PROVIDER_NAME_PREFIX = 'OpenAlice workspace provider';
 const PI_GLOBAL_MODELS_FILENAME = 'models.json';
 const PI_GLOBAL_SETTINGS_FILENAME = 'settings.json';

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -1,15 +1,22 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, readFile, realpath, rename, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 
 import { runtimeProfileFromEnv } from '@/core/runtime-profile.js';
 import { resolveBashPath } from '@/core/shell-resolver.js';
 
-import type { CliAdapter, SpawnContext, WorkspaceAiCred } from '../cli-adapter.js';
+import type {
+  CliAdapter,
+  HeadlessRunOverrides,
+  SpawnContext,
+  WorkspaceAiCred,
+} from '../cli-adapter.js';
 import type { HeadlessOutputEvent } from '../headless-output.js';
 import {
   migrateLegacyPiAgentDir,
   PI_BINDING_STATE_PATH,
+  PI_PROJECT_SETTINGS_PATH,
+  PI_PROVIDER_PREFIX,
   readPiWorkspaceConfig,
   resolvePiAgentDir,
   syncPiWorkspaceTheme,
@@ -20,6 +27,28 @@ import {
 const PI_TRUST_FILENAME = 'trust.json';
 
 let piTrustWriteQueue: Promise<void> = Promise.resolve();
+
+function piRunModel(cwd: string, model: string): string {
+  try {
+    const settings = JSON.parse(
+      readFileSync(join(cwd, PI_PROJECT_SETTINGS_PATH), 'utf8'),
+    ) as Record<string, unknown>;
+    const provider = settings['defaultProvider'];
+    const registeredModel = settings['defaultModel'];
+    if (
+      typeof provider === 'string' &&
+      provider.startsWith(PI_PROVIDER_PREFIX) &&
+      registeredModel !== model
+    ) {
+      throw new Error(
+        `Pi model override "${model}" is not registered by this Workspace provider; save that model in Workspace AI settings first`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Pi model override')) throw err;
+  }
+  return model;
+}
 
 function piCommandHead(env: Readonly<Record<string, string | undefined>>): readonly string[] {
   const profile = runtimeProfileFromEnv(env);
@@ -254,10 +283,19 @@ export const piAdapter: CliAdapter = {
   // REJECTS a `--` end-of-options terminator ("Unknown option: --", verified
   // 0.78.1), so the prompt is a bare trailing positional — a prompt literally
   // starting with `-`/`--` is unprotected on pi (rare for task prompts).
-  composeHeadlessCommand(_base: readonly string[], _ctx: SpawnContext, prompt: string): readonly string[] {
+  composeHeadlessCommand(
+    _base: readonly string[],
+    _ctx: SpawnContext,
+    prompt: string,
+    overrides?: HeadlessRunOverrides,
+  ): readonly string[] {
     return [
       ...piCommandHead(_ctx.env),
       ...piHeadlessApproveArgs(_ctx.env),
+      ...(overrides?.model ? ['--model', piRunModel(_ctx.cwd, overrides.model)] : []),
+      ...(overrides?.reasoningEffort
+        ? ['--thinking', overrides.reasoningEffort === 'none' ? 'off' : overrides.reasoningEffort]
+        : []),
       ...(_ctx.resume === 'last'
         ? ['--continue']
         : _ctx.resume

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -61,6 +61,13 @@ export interface SpawnContext {
   readonly approveProject?: boolean;
 }
 
+/** Explicit selection for one headless turn. Authentication, provider routing,
+ * and every omitted field remain inherited from the Workspace/native runtime. */
+export interface HeadlessRunOverrides {
+  readonly model?: string
+  readonly reasoningEffort?: ModelReasoningEffort
+}
+
 export interface AgentRuntimeWorkspaceContext {
   readonly wsId: string;
   readonly cwd: string;
@@ -88,7 +95,8 @@ export interface AgentRuntimeLifecycle {
  * Per-workspace AI-provider override (endpoint / key / model). The launcher
  * owns the *contract* — one shape, dispatched uniformly across CLIs — while
  * each adapter owns the *format* (claude → `.claude/settings.local.json`,
- * codex → `.codex/config.toml` + `.codex/env.json`). Superset shape: `authMode`
+ * codex native login → `.codex/config.toml`, custom provider → an isolated
+ * `.codex/openalice-home/`). Superset shape: `authMode`
  * is claude-only (which header carries the key), `wireApi` is codex-only
  * (Responses vs Chat Completions). Fields are optional/nullable so the same
  * shape serves both the write-input (absent ⇒ unset) and the read-output
@@ -244,7 +252,12 @@ export interface CliAdapter {
    *   opencode: [opencode, run, --format, json, <prompt>]
    *   pi:       [pi, -p, --mode, json, <prompt>]
    */
-  composeHeadlessCommand?(base: readonly string[], ctx: SpawnContext, prompt: string): readonly string[];
+  composeHeadlessCommand?(
+    base: readonly string[],
+    ctx: SpawnContext,
+    prompt: string,
+    overrides?: HeadlessRunOverrides,
+  ): readonly string[];
 
   /**
    * Extract the agent's OWN session id from one line of headless stdout.
@@ -308,7 +321,7 @@ export interface CliAdapter {
    * Read/write the workspace's per-CLI AI-provider override. The launcher
    * dispatches uniformly; each adapter renders the shared `WorkspaceAiCred`
    * into (and parses it out of) its own native config files. An empty cred
-   * resets — the adapter deletes its config so the CLI falls back to global.
+   * resets only OpenAlice-owned values so the CLI falls back to native/global.
    * Absent on adapters with no configurable provider (shell).
    */
   writeAiConfig?(cwd: string, cred: WorkspaceAiCred): Promise<void>;

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -85,6 +85,20 @@ describe('HeadlessTaskRegistry', () => {
     expect(reg2.get(fired.taskId)?.trigger?.issueId).toBe('daily-scan')
   })
 
+  it('persists requested one-run model and effort', async () => {
+    const reg = await HeadlessTaskRegistry.load(path, noopLogger)
+    const task = await createTask(reg, {
+      wsId: 'w1',
+      agent: 'codex',
+      model: 'gpt-5.6',
+      effort: 'high',
+      prompt: 'x',
+      startedAt: 1,
+    })
+    const reg2 = await HeadlessTaskRegistry.load(path, noopLogger)
+    expect(reg2.get(task.taskId)).toMatchObject({ model: 'gpt-5.6', effort: 'high' })
+  })
+
   it('persists and reverse-filters business inquiry subjects', async () => {
     const reg = await HeadlessTaskRegistry.load(path, noopLogger)
     const inbox = await createTask(reg, {

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -17,6 +17,7 @@ import { randomBytes } from 'node:crypto'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
+import type { ModelReasoningEffort } from '../ai-providers/model-semantics.js'
 import type { Logger } from './logger.js'
 
 export type HeadlessTaskStatus = 'running' | 'done' | 'failed' | 'interrupted'
@@ -95,6 +96,9 @@ export interface HeadlessTaskRecord {
   /** Durable reverse link for Inbox/Issue follow-up UI. */
   readonly inquiry?: HeadlessTaskInquiry
   readonly agent: string
+  /** Explicit one-run selections requested by the dispatching Issue. */
+  readonly model?: string
+  readonly effort?: ModelReasoningEffort
   /** The task prompt (the run's instruction) — shown collapsible in the panel. */
   readonly prompt: string
   status: HeadlessTaskStatus
@@ -176,6 +180,8 @@ export class HeadlessTaskRegistry {
   async create(input: {
     wsId: string
     agent: string
+    model?: string
+    effort?: ModelReasoningEffort
     prompt: string
     startedAt: number
     /** Product identity allocated by ResumeRegistry; reused across continued turns. */
@@ -195,6 +201,8 @@ export class HeadlessTaskRegistry {
       ...(input.parentTaskId ? { parentTaskId: input.parentTaskId } : {}),
       wsId: input.wsId,
       agent: input.agent,
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.effort ? { effort: input.effort } : {}),
       prompt: input.prompt,
       status: 'running',
       startedAt: input.startedAt,

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -12,6 +12,7 @@
  */
 
 import type { InboxEntry } from '../../core/inbox-store.js'
+import type { ModelReasoningEffort } from '../../ai-providers/model-semantics.js'
 import {
   ACTIVITY_UPDATE_COALESCE_MS,
   artifactOriginsMatch,
@@ -41,6 +42,8 @@ export interface IssuesSnapshotIssue {
   assignee: string
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
+  model?: string
+  effort?: ModelReasoningEffort
   /** Present iff the issue self-schedules. */
   when?: Schedule
   /** When the scanner last fired this issue (epoch ms); only for scheduled issues. */
@@ -138,6 +141,8 @@ export interface BoardRow {
   assignee: string
   /** Adapter id for the scheduled fire override, if set. */
   agent?: string
+  model?: string
+  effort?: ModelReasoningEffort
   /** True iff the issue self-schedules (snapshot `when` present). */
   scheduled: boolean
   /** Live scheduler/worker health for scheduled rows. */
@@ -178,6 +183,8 @@ export function flattenBoardRows(snapshot: IssuesSnapshot): {
         priority: issue.priority,
         assignee: issue.assignee,
         ...(issue.agent ? { agent: issue.agent } : {}),
+        ...(issue.model ? { model: issue.model } : {}),
+        ...(issue.effort ? { effort: issue.effort } : {}),
         scheduled: issue.when !== undefined,
         ...(issue.automationHealth ? { automationHealth: issue.automationHealth } : {}),
         workspace: { wsId: ws.wsId, tag: ws.tag },
@@ -304,6 +311,8 @@ export interface IssueRunRecord {
   wsId: string
   issueId?: string
   agent: string
+  model?: string
+  effort?: ModelReasoningEffort
   prompt: string
   status: HeadlessTaskStatus
   startedAt: number
@@ -332,6 +341,8 @@ export function issueRunRecord(task: HeadlessTaskRecord, resumable: boolean): Is
     wsId: task.wsId,
     ...(task.trigger?.kind === 'issue' ? { issueId: task.trigger.issueId } : {}),
     agent: task.agent,
+    ...(task.model ? { model: task.model } : {}),
+    ...(task.effort ? { effort: task.effort } : {}),
     prompt: task.prompt,
     status: task.status,
     startedAt: task.startedAt,
@@ -401,6 +412,8 @@ export function detailIssue(
     assignee: issue.assignee,
     ...(issue.when ? { when: issue.when } : {}),
     ...(issue.agent ? { agent: issue.agent } : {}),
+    ...(issue.model ? { model: issue.model } : {}),
+    ...(issue.effort ? { effort: issue.effort } : {}),
     ...(markers ? {
       lastFiredAtMs: markers.lastFiredAtMs,
       nextDueAtMs: markers.nextDueAtMs,
@@ -423,6 +436,8 @@ export function snapshotBoardIssue(
     priority: issue.priority,
     assignee: issue.assignee,
     ...(issue.agent ? { agent: issue.agent } : {}),
+    ...(issue.model ? { model: issue.model } : {}),
+    ...(issue.effort ? { effort: issue.effort } : {}),
     ...(issue.when ? { when: issue.when } : {}),
     ...(markers ? {
       lastFiredAtMs: markers.lastFiredAtMs,

--- a/src/workspaces/issues/change-tracker.ts
+++ b/src/workspaces/issues/change-tracker.ts
@@ -28,6 +28,8 @@ export interface IssueAuditSnapshot {
   assignee: string
   schedule?: string
   agent?: string
+  model?: string
+  effort?: string
   whatHash: string
 }
 
@@ -52,6 +54,8 @@ export function issueAuditSnapshot(issue: IssueRecord): IssueAuditSnapshot {
     assignee: issue.assignee,
     ...(issue.when ? { schedule: JSON.stringify(issue.when) } : {}),
     ...(issue.agent ? { agent: issue.agent } : {}),
+    ...(issue.model ? { model: issue.model } : {}),
+    ...(issue.effort ? { effort: issue.effort } : {}),
     whatHash: digest(issue.what),
   }
 }
@@ -81,6 +85,8 @@ export function issueMutation(
   valueField('assignee', left.assignee, right.assignee)
   valueField('schedule', left.schedule, right.schedule)
   valueField('runtime', left.agent, right.agent)
+  valueField('model', left.model, right.model)
+  valueField('effort', left.effort, right.effort)
   if (left.whatHash !== right.whatHash) fields.push({ field: 'what' })
   return fields.length > 0 ? { fields } : null
 }

--- a/src/workspaces/issues/declaration.spec.ts
+++ b/src/workspaces/issues/declaration.spec.ts
@@ -97,6 +97,8 @@ describe('readWorkspaceIssues', () => {
           'when: { kind: every, every: 30m }',
           'what: run the research routine',
           'agent: codex',
+          'model: gpt-5.6',
+          'effort: high',
         ].join('\n'),
         'Scan overnight movers and summarize.\n',
       ),
@@ -114,6 +116,8 @@ describe('readWorkspaceIssues', () => {
         assignee: '@workspace',
         what: 'run the research routine\n\n## Context\n\nScan overnight movers and summarize.',
         agent: 'codex',
+        model: 'gpt-5.6',
+        effort: 'high',
       })
       expect(i.when).toEqual({ kind: 'every', every: '30m' })
       expect(i.what).toBe('run the research routine\n\n## Context\n\nScan overnight movers and summarize.')
@@ -134,6 +138,21 @@ describe('readWorkspaceIssues', () => {
     const byId = Object.fromEntries(result.issues.map((issue) => [issue.id, issue]))
     expect(issueAssigneeResumeId(byId['owned'].assignee)).toBe('resume-kind-owl-abc123')
     expect(byId['legacy'].assignee).toBe('@workspace')
+  })
+
+  it('rejects every runtime override on an exact Session owner', async () => {
+    await writeIssue('owned-runtime', fm([
+      'title: Owned runtime',
+      'when: { kind: every, every: 30m }',
+      'assignee: "@resume-kind-owl-abc123"',
+      'agent: codex',
+      'model: gpt-5.6',
+      'effort: high',
+    ].join('\n')))
+    const result = await readWorkspaceIssues(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.invalid[0]?.error).toMatch(/agent.*model.*effort/)
   })
 
   it('rejects retired execution declarations instead of silently keeping two owner models', async () => {

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -25,6 +25,8 @@
  *         { kind: cron, cron, timezone?: local | IANA zone }  (OPTIONAL — present iff scheduled)
  *   what: <legacy fire prompt; migrated into the markdown What body>
  *   agent: <optional adapter id for the scheduled run>
+ *   model: <optional native model id for one scheduled run>
+ *   effort: none | minimal | low | medium | high | xhigh | max
  *   ---
  *   <markdown What — the exact work definition and scheduled prompt>
  *
@@ -39,6 +41,10 @@ import { parse as parseYaml } from 'yaml'
 import { z } from 'zod'
 
 import { isValidScheduleTimezone, type Schedule } from '../../core/schedule-expr.js'
+import {
+  isModelReasoningEffort,
+  type ModelReasoningEffort,
+} from '../../ai-providers/model-semantics.js'
 import {
   HUMAN_ASSIGNEE,
   NEW_ASSIGNEE,
@@ -126,6 +132,13 @@ export const issueFrontmatterSchema = z.object({
   /** Runtime override for Workspace-owned scheduled work. A Session owner
    * already carries its runtime identity and therefore cannot set this. */
   agent: z.string().min(1).optional(),
+  /** One-run model selection. Provider routing and authentication remain
+   * inherited from the Workspace/native login. */
+  model: z.string().min(1).optional(),
+  /** One-run reasoning effort, projected through the selected native CLI. */
+  effort: z.custom<ModelReasoningEffort>(isModelReasoningEffort, {
+    message: 'effort must be none, minimal, low, medium, high, xhigh, or max',
+  }).optional(),
   /** Migration 0018 removes the former parallel ownership field. Keeping a
    * `never` key makes stale files fail loudly instead of being silently read. */
   execution: z.never().optional(),
@@ -144,12 +157,15 @@ export const issueFrontmatterSchema = z.object({
       message: '@new needs a schedule so its first run can claim a Session',
     })
   }
-  if (issueAssigneeResumeId(value.assignee) && value.agent) {
-    ctx.addIssue({
-      code: 'custom',
-      path: ['agent'],
-      message: 'session assignee owns its runtime; remove the agent override',
-    })
+  if (issueAssigneeResumeId(value.assignee)) {
+    for (const field of ['agent', 'model', 'effort'] as const) {
+      if (!value[field]) continue
+      ctx.addIssue({
+        code: 'custom',
+        path: [field],
+        message: `session assignee owns its runtime; remove the ${field} override`,
+      })
+    }
   }
 })
 type IssueFrontmatterFile = z.infer<typeof issueFrontmatterSchema>

--- a/src/workspaces/issues/mutate.spec.ts
+++ b/src/workspaces/issues/mutate.spec.ts
@@ -117,12 +117,16 @@ describe('updateIssueFields', () => {
       when: { kind: 'every', every: '15m' },
       what: 'keep the fire prompt',
       agent: 'claude',
+      model: 'claude-opus-4-8',
+      effort: 'high',
     })
     const res = await updateIssueFields(dir, 'task-1', {
       status: 'in_progress',
       priority: 'urgent',
       assignee: '@workspace',
       agent: 'pi',
+      model: 'gemini-3.5-pro',
+      effort: 'medium',
     })
     expect(res.ok).toBe(true)
     if (res.ok) {
@@ -138,6 +142,8 @@ describe('updateIssueFields', () => {
       assignee: '@workspace',
       what: 'keep the fire prompt',
       agent: 'pi',
+      model: 'gemini-3.5-pro',
+      effort: 'medium',
     })
     expect(issue?.when).toEqual({ kind: 'every', every: '15m' })
     expect(issue?.what).toBe('keep the fire prompt')
@@ -158,6 +164,8 @@ describe('updateIssueFields', () => {
       when: { kind: 'every', every: '15m' },
       assignee: '@workspace',
       agent: 'codex',
+      model: 'gpt-5.6',
+      effort: 'high',
     })
     const res = await updateIssueFields(dir, 'owned', {
       assignee: '@resume-kind-owl-abc123',
@@ -166,6 +174,8 @@ describe('updateIssueFields', () => {
     const { issue } = await readBack('owned')
     expect(issue?.assignee).toBe('@resume-kind-owl-abc123')
     expect(issue?.agent).toBeUndefined()
+    expect(issue?.model).toBeUndefined()
+    expect(issue?.effort).toBeUndefined()
     expect(issue?.when).toEqual({ kind: 'every', every: '15m' })
   })
 

--- a/src/workspaces/issues/mutate.ts
+++ b/src/workspaces/issues/mutate.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path'
 
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 
+import { isModelReasoningEffort, type ModelReasoningEffort } from '../../ai-providers/model-semantics.js'
 import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js'
 import {
   ISSUE_PRIORITIES,
@@ -49,6 +50,10 @@ export interface IssueFieldPatch {
   assignee?: string
   /** Runtime override for scheduled fires; null removes the override. */
   agent?: string | null
+  /** Native model id for one scheduled fire; null inherits Workspace/runtime. */
+  model?: string | null
+  /** Reasoning effort for one scheduled fire; null inherits Workspace/runtime. */
+  effort?: ModelReasoningEffort | null
   /** Canonical markdown work definition; exact scheduled prompt. */
   what?: string
 }
@@ -64,6 +69,8 @@ export interface CreateIssueInput {
   when?: unknown
   what?: string
   agent?: string
+  model?: string
+  effort?: ModelReasoningEffort
   /** @deprecated Compatibility alias for callers written before What became the
    * sole markdown document. New callers must use `what`. */
   body?: string
@@ -156,7 +163,11 @@ export async function updateIssueFields(
       return { ok: false, reason: 'invalid', error: 'assignee must be @workspace, @new, @human, @unassigned, or an exact @resumeId' }
     }
     data.assignee = assignee.data
-    if (issueAssigneeResumeId(assignee.data)) delete data.agent
+    if (issueAssigneeResumeId(assignee.data)) {
+      delete data.agent
+      delete data.model
+      delete data.effort
+    }
   }
   if (patch.agent !== undefined) {
     if (patch.agent === null) {
@@ -165,6 +176,24 @@ export async function updateIssueFields(
       const a = patch.agent.trim()
       if (a.length === 0) return { ok: false, reason: 'invalid', error: 'agent must be a non-empty string or null' }
       data.agent = a
+    }
+  }
+  if (patch.model !== undefined) {
+    if (patch.model === null) {
+      delete data.model
+    } else {
+      const model = patch.model.trim()
+      if (!model) return { ok: false, reason: 'invalid', error: 'model must be a non-empty string or null' }
+      data.model = model
+    }
+  }
+  if (patch.effort !== undefined) {
+    if (patch.effort === null) {
+      delete data.effort
+    } else if (!isModelReasoningEffort(patch.effort)) {
+      return { ok: false, reason: 'invalid', error: 'invalid effort' }
+    } else {
+      data.effort = patch.effort
     }
   }
   let what = current.issue.what
@@ -211,6 +240,8 @@ export async function createIssue(wsDir: string, input: CreateIssueInput): Promi
   if (input.assignee !== undefined) data.assignee = input.assignee
   if (input.when !== undefined) data.when = input.when
   if (input.agent !== undefined) data.agent = input.agent
+  if (input.model !== undefined) data.model = input.model
+  if (input.effort !== undefined) data.effort = input.effort
 
   const parsed = issueFrontmatterSchema.safeParse(data)
   if (!parsed.success) {

--- a/src/workspaces/schedule/declaration.ts
+++ b/src/workspaces/schedule/declaration.ts
@@ -15,6 +15,7 @@
  */
 
 import { computeNextRun, type Schedule } from '../../core/schedule-expr.js'
+import type { ModelReasoningEffort } from '../../ai-providers/model-semantics.js'
 import {
   isFireable,
   isTerminalStatus,
@@ -48,6 +49,8 @@ export interface ScheduleSnapshotTask {
    * and an exact `@resumeId` resumes one accountable Session. */
   assignee: string
   agent?: string
+  model?: string
+  effort?: ModelReasoningEffort
   /** False once the owning issue reaches a terminal status (done/canceled). */
   enabled: boolean
   /** When the scanner last fired this issue (epoch ms), null if never. */
@@ -103,6 +106,8 @@ export function snapshotScheduledIssue(
     what: issueFirePrompt(issue),
     assignee: issue.assignee,
     ...(issue.agent ? { agent: issue.agent } : {}),
+    ...(issue.model ? { model: issue.model } : {}),
+    ...(issue.effort ? { effort: issue.effort } : {}),
     enabled: !isTerminalStatus(issue.status),
     lastFiredAtMs,
     // An overdue computed time clamps to now: a due-now task reads "due now",

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -69,6 +69,8 @@ interface IssueSpec {
   status?: string
   priority?: string
   agent?: string
+  model?: string
+  effort?: string
   assignee?: string
   body?: string
 }
@@ -80,6 +82,8 @@ function issueMd(spec: IssueSpec): string {
   if (spec.priority) lines.push(`priority: ${spec.priority}`)
   if (spec.what) lines.push(`what: ${spec.what}`)
   if (spec.agent) lines.push(`agent: ${spec.agent}`)
+  if (spec.model) lines.push(`model: ${spec.model}`)
+  if (spec.effort) lines.push(`effort: ${spec.effort}`)
   if (spec.assignee) lines.push(`assignee: ${JSON.stringify(spec.assignee)}`)
   if (spec.when) {
     const w = spec.when
@@ -185,6 +189,30 @@ describe('ScheduleScanner', () => {
       kind: 'issue', workspaceId: 'w1', issueId: 't1',
     })
     expect(markers.get('w1', 't1')).toBe(NOW)
+  })
+
+  it('passes Issue model and effort as one-run dispatch overrides', async () => {
+    const ws = await makeWs('w1', [{
+      id: 'tuned',
+      title: 'tuned run',
+      when: { kind: 'every', every: '30m' },
+      what: 'go',
+      agent: 'claude',
+      model: 'claude-opus-4-8',
+      effort: 'high',
+    }])
+    const { scanner, dispatch } = scannerFor([ws])
+    await scanner.scan()
+    expect(dispatch).toHaveBeenCalledWith(
+      ws,
+      headlessAdapter,
+      'go',
+      expect.any(Number),
+      { kind: 'issue', workspaceId: 'w1', issueId: 'tuned' },
+      undefined,
+      undefined,
+      { model: 'claude-opus-4-8', reasoningEffort: 'high' },
+    )
   })
 
   it('passes one exact resumeId through adapter resolution and dispatch', async () => {

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -26,7 +26,7 @@
  */
 
 import { computeNextRun, type Schedule } from '../../core/schedule-expr.js'
-import type { CliAdapter } from '../cli-adapter.js'
+import type { CliAdapter, HeadlessRunOverrides } from '../cli-adapter.js'
 import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
 import type { HeadlessTaskTrigger } from '../headless-task-registry.js'
@@ -91,6 +91,10 @@ export interface ScheduleScannerDeps {
     trigger?: HeadlessTaskTrigger,
     /** Product Session to continue. Omitted means allocate a fresh Session. */
     resumeId?: string,
+    /** Optional reverse-link metadata; scheduler leaves this absent. */
+    inquiry?: undefined,
+    /** One-run model/effort selection inherited from Issue frontmatter. */
+    overrides?: HeadlessRunOverrides,
   ) => Promise<{ taskId: string; resumeId: string }>
   /** Persist @new -> exact @resumeId after the first fresh dispatch. */
   claimFreshSession?: (input: {
@@ -176,6 +180,7 @@ export class ScheduleScanner {
       issue.id,
       issueFirePrompt(issue),
       issue.agent,
+      issueRunOverrides(issue),
       issueAssigneeResumeId(issue.assignee) ?? undefined,
       issueAssigneeClaimsFirstSession(issue.assignee),
       true,
@@ -265,6 +270,7 @@ export class ScheduleScanner {
           issue.id,
           issueFirePrompt(issue),
           issue.agent,
+          issueRunOverrides(issue),
           issueAssigneeResumeId(issue.assignee) ?? undefined,
           issueAssigneeClaimsFirstSession(issue.assignee),
           nowMs,
@@ -288,6 +294,7 @@ export class ScheduleScanner {
     taskId: string,
     what: string,
     agentId: string | undefined,
+    overrides: HeadlessRunOverrides | undefined,
     resumeId: string | undefined,
     claimFreshSession: boolean,
     nowMs: number,
@@ -298,6 +305,7 @@ export class ScheduleScanner {
         taskId,
         what,
         agentId,
+        overrides,
         resumeId,
         claimFreshSession,
       )
@@ -325,6 +333,7 @@ export class ScheduleScanner {
     issueId: string,
     what: string,
     agentId?: string,
+    overrides?: HeadlessRunOverrides,
     resumeId?: string,
     claimFreshSession = false,
     manual = false,
@@ -357,21 +366,43 @@ export class ScheduleScanner {
         issueId,
       }
       const result = resumeId
-        ? await this.deps.dispatch(
-            executionWorkspace,
-            adapter,
-            what,
-            SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
-            trigger,
-            resumeId,
-          )
-        : await this.deps.dispatch(
-            executionWorkspace,
-            adapter,
-            what,
-            SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
-            trigger,
-          )
+        ? overrides
+          ? await this.deps.dispatch(
+              executionWorkspace,
+              adapter,
+              what,
+              SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+              trigger,
+              resumeId,
+              undefined,
+              overrides,
+            )
+          : await this.deps.dispatch(
+              executionWorkspace,
+              adapter,
+              what,
+              SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+              trigger,
+              resumeId,
+            )
+        : overrides
+          ? await this.deps.dispatch(
+              executionWorkspace,
+              adapter,
+              what,
+              SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+              trigger,
+              undefined,
+              undefined,
+              overrides,
+            )
+          : await this.deps.dispatch(
+              executionWorkspace,
+              adapter,
+              what,
+              SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+              trigger,
+            )
       if (claimFreshSession) {
         if (!this.deps.claimFreshSession) {
           throw new Error('Issue @new ownership cannot be persisted in this runtime')
@@ -413,5 +444,13 @@ export class ScheduleScanner {
 
   private resolveResumeWorkspace(resumeId: string): WorkspaceMeta | undefined {
     return this.deps.resolveResumeWorkspace?.(resumeId)
+  }
+}
+
+function issueRunOverrides(issue: IssueRecord): HeadlessRunOverrides | undefined {
+  if (!issue.model && !issue.effort) return undefined
+  return {
+    ...(issue.model ? { model: issue.model } : {}),
+    ...(issue.effort ? { reasoningEffort: issue.effort } : {}),
   }
 }

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -35,6 +35,7 @@ import {
   isAgentRuntime,
   prepareAgentRuntimeWorkspace,
   type CliAdapter,
+  type HeadlessRunOverrides,
 } from './cli-adapter.js';
 import { loadConfig, type ServerConfig } from './config.js';
 import { ensureAgentCredentialReady } from './agent-credential-readiness.js';
@@ -344,6 +345,8 @@ export interface WorkspaceService {
     resumeId?: string,
     /** Optional Inbox/Issue reverse link for a user-initiated inquiry. */
     inquiry?: HeadlessTaskInquiry,
+    /** Explicit one-run model/effort; authentication remains Workspace-owned. */
+    overrides?: HeadlessRunOverrides,
   ): Promise<{ taskId: string; resumeId: string }>;
   /** Read-only scheduling projection of every workspace's `.alice/issues/`
    *  directory (scheduled issues only) + each task's last-fired marker and
@@ -1168,6 +1171,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       resumeId?: string;
       resume?: SessionFactoryContext['resume'];
       onSessionId?: (id: string) => void;
+      overrides?: HeadlessRunOverrides;
     } = {},
   ): Promise<HeadlessTaskResult> => {
     const operationLease = workspaceOperationGuard.acquire(ws.id, 'headless-run');
@@ -1222,6 +1226,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         config.command,
         { cwd, env, ...(opts.resume !== undefined ? { resume: opts.resume } : {}) },
         prompt,
+        opts.overrides,
       );
       const logPaths = opts.taskId ? headlessLogPaths(headlessLogsDir, opts.taskId) : null;
       const activityLease = headlessActivity.begin({
@@ -1284,6 +1289,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     trigger?: HeadlessTaskTrigger,
     resumeId?: string,
     inquiry?: HeadlessTaskInquiry,
+    overrides?: HeadlessRunOverrides,
   ): Promise<{ taskId: string; resumeId: string }> => {
     if (catalog.get(ws.id)?.lifecycle !== 'active') {
       throw new Error(`workspace is not active: ${ws.id}`);
@@ -1345,6 +1351,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       rec = await headlessTasks.create({
         wsId: ws.id,
         agent: adapter.id,
+        ...(overrides?.model ? { model: overrides.model } : {}),
+        ...(overrides?.reasoningEffort ? { effort: overrides.reasoningEffort } : {}),
         prompt,
         startedAt: Date.now(),
         resumeId: identity.resumeId,
@@ -1371,6 +1379,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       taskId: rec.taskId,
       resumeId: rec.resumeId,
       ...(nativeResume ? { resume: nativeResume } : {}),
+      ...(overrides ? { overrides } : {}),
       onSessionId: (id) => {
         void Promise.all([
           headlessTasks.setAgentSessionId(rec.taskId, id),

--- a/src/workspaces/templates/_common.mjs
+++ b/src/workspaces/templates/_common.mjs
@@ -62,6 +62,8 @@ const DEFAULT_EXCLUDES = [
   '.codex/auth.json',
   '.codex/env.json',
   '.codex/config.toml',
+  '.codex/openalice-provider.json',
+  '.codex/openalice-home/',
   'opencode.json',
   'tui.json',
   '.opencode/openalice-provider.json',

--- a/ui/src/api/headless.ts
+++ b/ui/src/api/headless.ts
@@ -1,4 +1,5 @@
 import { fetchJson } from './client'
+import type { ModelReasoningEffort } from './types'
 
 export type HeadlessTaskStatus = 'running' | 'done' | 'failed' | 'interrupted'
 
@@ -13,6 +14,8 @@ export interface HeadlessTaskRecord {
    * Session executes an Issue owned by another Workspace. */
   trigger?: { kind: 'issue'; workspaceId: string; issueId: string }
   agent: string
+  model?: string
+  effort?: ModelReasoningEffort
   prompt: string
   status: HeadlessTaskStatus
   startedAt: number

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -3,6 +3,7 @@ import type { Entity } from './entities'
 import type { HeadlessTaskRecord } from './headless'
 import type { InboxEntry } from './inbox'
 import type { ScheduleWhen } from './schedule'
+import type { ModelReasoningEffort } from './types'
 
 /**
  * Issue board — the canonical client shape for GET /api/issues.
@@ -113,6 +114,10 @@ export interface IssueListItem {
   assignee: string
   /** Adapter id for the scheduled fire override, if set. */
   agent?: string
+  /** Native model id for the scheduled fire override, if set. */
+  model?: string
+  /** Native reasoning effort for the scheduled fire override, if set. */
+  effort?: ModelReasoningEffort
   /** Present iff the issue is scheduled (shares the core Schedule union). */
   when?: ScheduleWhen
   /** Scanner last-fired marker (epoch ms) — scheduled issues only. */
@@ -203,6 +208,10 @@ export interface IssueDetailIssue {
   when?: ScheduleWhen
   /** Adapter id for the scheduled fire (frontmatter `agent`), if set. */
   agent?: string
+  /** Native model id for the scheduled fire (frontmatter `model`), if set. */
+  model?: string
+  /** Native reasoning effort for the scheduled fire (frontmatter `effort`), if set. */
+  effort?: ModelReasoningEffort
   /** Scanner last-fired marker (epoch ms) — scheduled issues only. */
   lastFiredAtMs?: number | null
   /** Computed next fire (epoch ms) — scheduled issues only. */
@@ -232,6 +241,16 @@ export interface IssueDetail {
   activity?: IssueActivityRecord[]
 }
 
+export interface IssuePatch {
+  status?: IssueStatus
+  priority?: IssuePriority
+  assignee?: string
+  agent?: string | null
+  model?: string | null
+  effort?: ModelReasoningEffort | null
+  what?: string
+}
+
 export const issuesApi = {
   /** Read-only board: every workspace's issues, scanned across all workspaces. */
   async get(): Promise<IssueSnapshot> {
@@ -258,15 +277,15 @@ export const issuesApi = {
 
   /**
    * Human write path: patch one issue's editable fields (any subset of
-   * status / priority / assignee / agent / what). `agent: null` clears the scheduled
-   * runtime override so the workspace default applies. Returns the SAME detail
+   * status / priority / assignee / agent / model / effort / what). Null runtime
+   * fields clear their one-run overrides so Workspace/native defaults apply. Returns the SAME detail
    * shape as `getDetail` so the caller can apply it directly (refetch-free).
    * Working-tree write on the server, no commit.
    */
   async update(
     wsId: string,
     id: string,
-    patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string },
+    patch: IssuePatch,
   ): Promise<IssueDetail> {
     return fetchJson<IssueDetail>(
       `/api/issues/${encodeURIComponent(wsId)}/${encodeURIComponent(id)}`,

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -7,6 +7,7 @@ import type { InboxEntry } from '../api/inbox'
 import type {
   IssueDetail as IssueDetailData,
   IssueDetailIssue,
+  IssuePatch,
   IssueActivityRecord,
   IssuePriority,
   IssueProvenanceRecord,
@@ -15,6 +16,7 @@ import type {
   WikilinkIssueRef,
   WikilinkResolution,
 } from '../api/issues'
+import type { ModelReasoningEffort } from '../api/types'
 import {
   getAgentReadiness,
   getWorkspaceSessionDirectory,
@@ -57,9 +59,17 @@ const railControl =
   'min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 text-[13px] text-foreground outline-none transition-colors focus:border-primary/60 focus:shadow-[0_0_0_1px_var(--primary-muted)] disabled:cursor-not-allowed disabled:opacity-50'
 
 const CONFIGURABLE_AGENTS: readonly AgentId[] = ['claude', 'codex', 'opencode', 'pi']
+const ALL_RUN_EFFORTS: readonly ModelReasoningEffort[] = [
+  'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max',
+]
 
 function isConfigurableAgent(agent: string | null | undefined): agent is AgentId {
   return CONFIGURABLE_AGENTS.includes(agent as AgentId)
+}
+
+function runEffortsForAgent(agent: string | null): readonly ModelReasoningEffort[] {
+  if (agent === 'claude') return ['low', 'medium', 'high', 'max']
+  return ALL_RUN_EFFORTS
 }
 
 function fmtDuration(ms?: number): string {
@@ -218,6 +228,40 @@ function AgentEditor({
   )
 }
 
+function ModelEditor({
+  value,
+  disabled,
+  onChange,
+}: {
+  value?: string
+  disabled?: boolean
+  onChange: (next: string | null) => void
+}) {
+  const [draft, setDraft] = useState(value ?? '')
+  useEffect(() => setDraft(value ?? ''), [value])
+  const commit = () => {
+    const next = draft.trim()
+    if (next !== (value ?? '')) onChange(next || null)
+  }
+  return (
+    <input
+      className={railControl}
+      value={draft}
+      disabled={disabled}
+      placeholder="Inherit Workspace"
+      aria-label="Run model"
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          commit()
+          event.currentTarget.blur()
+        }
+      }}
+    />
+  )
+}
+
 function PropertySection({
   title,
   description,
@@ -261,7 +305,7 @@ function PropertiesRail({
   retrying: boolean
   error: string | null
   canRetry: boolean
-  onPatch: (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string }) => void
+  onPatch: (patch: IssuePatch) => void
   onRetry: () => void
   onConfigureAgent: (agent: AgentId) => void
 }) {
@@ -277,6 +321,7 @@ function PropertiesRail({
   const effectiveAgent = ownerSession?.agent || issue.agent || issueDefaultInOptions || defaultInOptions || agentOptions[0]?.id || null
   const selectedReadiness = effectiveAgent ? agentReadiness[effectiveAgent] : undefined
   const agentNeedsCredential = selectedReadiness?.requiresCredential === true && !selectedReadiness.ready
+  const effortOptions = runEffortsForAgent(effectiveAgent)
   return (
     <aside className="min-w-0 w-full shrink-0 space-y-3 lg:col-start-2 lg:row-start-1 lg:row-span-2">
       <PropertySection title="Work item" description="Ownership and schedule are part of this Issue.">
@@ -337,10 +382,47 @@ function PropertiesRail({
                 options={agentOptions}
                 readiness={agentReadiness}
                 disabled={saving}
-                onChange={(agent) => onPatch({ agent })}
+                onChange={(agent) => {
+                  const nextAgent = agent || issueDefaultInOptions || defaultInOptions || agentOptions[0]?.id || null
+                  onPatch({
+                    agent,
+                    ...(issue.effort && !runEffortsForAgent(nextAgent).includes(issue.effort)
+                      ? { effort: null }
+                      : {}),
+                  })
+                }}
                 onConfigure={onConfigureAgent}
               />
             </EditRow>
+          )}
+          {!ownerResumeId && (
+            <>
+              <EditRow label="Model">
+                <ModelEditor
+                  value={issue.model}
+                  disabled={saving}
+                  onChange={(model) => onPatch({ model })}
+                />
+              </EditRow>
+              <EditRow label="Effort">
+                <select
+                  className={railControl}
+                  value={issue.effort ?? ''}
+                  disabled={saving}
+                  aria-label="Run effort"
+                  onChange={(event) => onPatch({
+                    effort: event.target.value
+                      ? event.target.value as ModelReasoningEffort
+                      : null,
+                  })}
+                >
+                  <option value="">Inherit Workspace</option>
+                  {effortOptions.map((effort) => (
+                    <option key={effort} value={effort}>{effort}</option>
+                  ))}
+                </select>
+              </EditRow>
+            </>
           )}
           {agentNeedsCredential && (
             <p className="py-2 text-right text-[11px] leading-snug text-warning">AI credential missing.</p>
@@ -496,6 +578,8 @@ function RunRow({ run, onOpen }: { run: IssueRunRecord; onOpen: (run: IssueRunRe
           {displayStatus}
         </span>
         <span className="text-xs text-muted-foreground">{run.agent}</span>
+        {run.model && <span className="text-xs text-muted-foreground">· {run.model}</span>}
+        {run.effort && <span className="text-xs text-muted-foreground">· {run.effort}</span>}
         <span className="ml-auto text-xs text-muted-foreground" title={new Date(run.startedAt).toLocaleString()}>
           {formatRelativeTime(run.startedAt)}
         </span>
@@ -612,6 +696,8 @@ const MUTATION_FIELD_LABEL: Record<string, string> = {
   assignee: 'Assignee',
   schedule: 'Schedule',
   runtime: 'Runtime',
+  model: 'Model',
+  effort: 'Effort',
   what: 'What',
 }
 
@@ -1048,7 +1134,7 @@ export function IssueDetail({
   )
 
   const onPatch = useCallback(
-    async (patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string }): Promise<boolean> => {
+    async (patch: IssuePatch): Promise<boolean> => {
       setSaving(true)
       setActionError(null)
       try {

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
@@ -76,6 +76,35 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('WorkspaceAIConfigModal local model metadata', () => {
+  it('saves a Codex native-login model without requiring an API probe', async () => {
+    mocks.getAgentConfig.mockReset().mockResolvedValue({
+      claude: null,
+      codex: null,
+      opencode: null,
+      pi: null,
+    })
+
+    render(
+      <WorkspaceAIConfigModal wsId="chat-1" initialSection="ai" initialAgent="codex" onClose={vi.fn()} />,
+    )
+
+    fireEvent.change(await screen.findByPlaceholderText('gpt-5.5'), {
+      target: { value: 'gpt-5.6' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '保存' }))
+
+    await waitFor(() => expect(mocks.saveAgentConfig).toHaveBeenCalledWith(
+      'chat-1',
+      'codex',
+      expect.objectContaining({
+        baseUrl: null,
+        apiKey: null,
+        model: 'gpt-5.6',
+      }),
+    ))
+    expect(mocks.testAgentConfig).not.toHaveBeenCalled()
+  })
+
   it('repairs a saved MiniMax OpenAI wire and removes the lossy protocol choice', async () => {
     const minimaxPi = {
       ...savedPi,

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.spec.ts
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.spec.ts
@@ -87,4 +87,15 @@ describe('WorkspaceAIConfigModal Pi model capability mapping', () => {
 
     expect(connectionFieldsChanged(saved, form, 'pi')).toBe(true)
   })
+
+  it.each(['codex', 'claude'] as const)(
+    'lets %s native-login model and effort changes save without an HTTP probe',
+    (agent) => {
+      const form = configToForm(null, agent)
+      form.model = agent === 'codex' ? 'gpt-5.6' : 'claude-opus-4-8'
+      form.reasoningEffort = 'high'
+
+      expect(connectionFieldsChanged(null, form, agent)).toBe(false)
+    },
+  )
 })

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -199,6 +199,16 @@ export function connectionFieldsChanged(
   form: FormState,
   tab: Tab,
 ): boolean {
+  // Codex and Claude Code can inherit their native login while a project file
+  // selects only model/effort. With no OpenAlice-managed endpoint or key there
+  // is no credential-bearing HTTP connection for this modal to probe.
+  if (
+    (tab === 'codex' || tab === 'claude') &&
+    !form.baseUrl.trim() &&
+    !form.apiKey.trim()
+  ) {
+    return false
+  }
   return testKey(configToForm(saved, tab)) !== testKey(form)
 }
 
@@ -463,8 +473,9 @@ export function WorkspaceAIConfigModal({
     window.dispatchEvent(new CustomEvent('openalice:credentials-changed'))
   }
 
-  const canTest =
-    !!form.baseUrl.trim() && !!form.apiKey.trim() && !!form.model.trim()
+  // Official endpoints may be omitted; the backend probe resolves them from
+  // the selected wire shape. Managed credentials still require key + model.
+  const canTest = !!form.apiKey.trim() && !!form.model.trim()
 
   const stableTag = workspace?.tag || wsId
   const savedDisplayName = workspace?.displayName ?? ''
@@ -1151,9 +1162,9 @@ export function WorkspaceAIConfigModal({
             >
               {t('common.cancel')}
             </button>
-            {/* Single primary CTA that walks the connection gate. Transport,
-                auth, or model changes show Test first; local runtime metadata
-                changes can be saved directly. */}
+            {/* Single primary CTA that walks the connection gate. Managed
+                transport/auth/model changes show Test first; native-login
+                model/effort and local runtime metadata save directly. */}
             {needsTest ? (
               <button
                 onClick={handleTest}

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -1,4 +1,10 @@
-import type { IssueComment, IssueDetail, IssuePriority, IssueRunRecord, IssueSnapshot, IssueStatus } from '../../api/issues'
+import type {
+  IssueComment,
+  IssueDetail,
+  IssuePatch,
+  IssueRunRecord,
+  IssueSnapshot,
+} from '../../api/issues'
 import { demoInboxEntries } from './inbox'
 
 // GET /api/issues aggregates every workspace's declared issues by SCANNING
@@ -491,13 +497,20 @@ const demoIssueComments: Record<string, IssueComment[]> = {}
 export function demoIssueUpdate(
   wsId: string,
   id: string,
-  patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string },
+  patch: IssuePatch,
 ): IssueDetail | null {
   const boardIssue = findBoardIssue(wsId, id)
   if (!boardIssue) return null
   if (patch.status !== undefined) boardIssue.status = patch.status
   if (patch.priority !== undefined) boardIssue.priority = patch.priority
-  if (patch.assignee !== undefined) boardIssue.assignee = patch.assignee
+  if (patch.assignee !== undefined) {
+    boardIssue.assignee = patch.assignee
+    if (patch.assignee.startsWith('@resume-')) {
+      delete boardIssue.agent
+      delete boardIssue.model
+      delete boardIssue.effort
+    }
+  }
   if (patch.what !== undefined) {
     const key = `${wsId}/${id}`
     const existing = demoIssueExtras[key]
@@ -519,6 +532,14 @@ export function demoIssueUpdate(
     } else if (patch.agent !== null) {
       demoIssueExtras[key] = { body: `${boardIssue.title}\n\n(No description.)`, agent: patch.agent, runs: [] }
     }
+  }
+  if (patch.model !== undefined) {
+    if (patch.model === null) delete boardIssue.model
+    else boardIssue.model = patch.model
+  }
+  if (patch.effort !== undefined) {
+    if (patch.effort === null) delete boardIssue.effort
+    else boardIssue.effort = patch.effort
   }
   return demoIssueDetail(wsId, id)
 }

--- a/ui/src/demo/handlers/issues.spec.ts
+++ b/ui/src/demo/handlers/issues.spec.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import { issuesHandlers } from './issues'
+
+const server = setupServer(...issuesHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('demo Issue handlers', () => {
+  it('round-trips model and effort patches through the detail contract', async () => {
+    const response = await fetch(
+      `${baseUrl}/api/issues/demo-ws-auto-quant/morning-scan`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-5.5', effort: 'high' }),
+      },
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.issue).toMatchObject({
+      id: 'morning-scan',
+      model: 'gpt-5.5',
+      effort: 'high',
+    })
+  })
+})

--- a/ui/src/demo/handlers/issues.ts
+++ b/ui/src/demo/handlers/issues.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw'
+import type { ModelReasoningEffort } from '../../api'
 import type { IssuePriority, IssueStatus } from '../../api/issues'
 import {
   demoIssueAddComment,
@@ -26,6 +27,15 @@ const ISSUE_PRIORITIES = [
   'low',
   'none',
 ] as const satisfies readonly IssuePriority[]
+const MODEL_REASONING_EFFORTS = [
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const satisfies readonly ModelReasoningEffort[]
 
 const COMMENT_MAX = 16_000
 
@@ -61,13 +71,23 @@ export const issuesHandlers = [
       priority?: unknown
       assignee?: unknown
       agent?: unknown
+      model?: unknown
+      effort?: unknown
       what?: unknown
     } | null
     if (!body || typeof body !== 'object') {
       return HttpResponse.json({ error: 'invalid_body' }, { status: 400 })
     }
 
-    const patch: { status?: IssueStatus; priority?: IssuePriority; assignee?: string; agent?: string | null; what?: string } = {}
+    const patch: {
+      status?: IssueStatus
+      priority?: IssuePriority
+      assignee?: string
+      agent?: string | null
+      model?: string | null
+      effort?: ModelReasoningEffort | null
+      what?: string
+    } = {}
     if (body.status !== undefined) {
       if (!ISSUE_STATUSES.includes(body.status as IssueStatus)) {
         return HttpResponse.json({ error: 'invalid_status' }, { status: 400 })
@@ -99,6 +119,24 @@ export const issuesHandlers = [
         patch.agent = agent
       }
     }
+    if (body.model !== undefined) {
+      if (body.model === null || body.model === '') {
+        patch.model = null
+      } else if (typeof body.model !== 'string' || !body.model.trim()) {
+        return HttpResponse.json({ error: 'invalid_model' }, { status: 400 })
+      } else {
+        patch.model = body.model.trim()
+      }
+    }
+    if (body.effort !== undefined) {
+      if (body.effort === null || body.effort === '') {
+        patch.effort = null
+      } else if (!MODEL_REASONING_EFFORTS.includes(body.effort as ModelReasoningEffort)) {
+        return HttpResponse.json({ error: 'invalid_effort' }, { status: 400 })
+      } else {
+        patch.effort = body.effort as ModelReasoningEffort
+      }
+    }
     if (body.what !== undefined) {
       if (typeof body.what !== 'string' || !body.what.trim()) {
         return HttpResponse.json({ error: 'invalid_what' }, { status: 400 })
@@ -110,6 +148,8 @@ export const issuesHandlers = [
       patch.priority === undefined &&
       patch.assignee === undefined &&
       patch.agent === undefined
+      && patch.model === undefined
+      && patch.effort === undefined
       && patch.what === undefined
     ) {
       return HttpResponse.json({ error: 'no_fields' }, { status: 400 })


### PR DESCRIPTION
## What changed

- Add `PLANS.md`, a first tracked implementation plan, and concise plan lifecycle rules in `AGENTS.md`.
- Let native-login Codex and Claude Code workspaces persist local model / reasoning-effort preferences without requiring an OpenAlice-managed API credential probe.
- Split Codex project preferences from the isolated `CODEX_HOME` used by explicit custom providers, with reversible ownership for OpenAlice-written TOML scalars.
- Add optional `model` and `effort` Issue fields across markdown parsing, mutations, HTTP, CLI/MCP tools, demo handlers, the Issue editor, scheduler dispatch, durable task records, and Runs UI.
- Project one-run selections through native CLI flags for Claude Code, Codex, OpenCode, and Pi; custom OpenCode variants and custom OpenCode/Pi model registration are validated before dispatch.
- Update the model-injection, scheduling, and self-scheduling guidance with the delivered inheritance and exact-Session ownership contract.

## Root cause

Workspace AI treated model changes as credential-bearing connection changes, so native login state had no completable test/save path. Codex also conflated project-local preferences with an exclusive `CODEX_HOME`, which could shadow global login state. Separately, Issue declarations and headless adapter contracts carried only the runtime id, so model and effort could not survive from the editor/frontmatter to native CLI invocation.

## User impact

A logged-in Codex or Claude Code user can now save only a Workspace model and/or effort while retaining global authentication. Scheduled `@new` / `@workspace` Issues can inherit defaults or choose a model and effort for one run without storing credentials or rewriting persistent Workspace configuration. Exact Session owners remain immutable and reject conflicting runtime overrides.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- Targeted adapter / Issue / scheduler / route / demo / UI tests: 241 passing
- `pnpm test`: full suite passed before the final OpenCode variant hardening (3338 passed, 8 skipped)
- Final full regression with constrained workers: 349 files / 3338 tests passed; the unrelated installer PTY test exceeded its fixed 10s threshold under suite load, then passed alone (1 passed, 8 skipped)
- Real demo browser walk: native-login Codex model/effort save, Issue model/effort mutation, and exact-Session control hiding
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- Previous serial increment PR #708 and its post-merge `dev` checks are green

Closes #706
Closes #710