### PR TITLE
Complete Issue override implementation plan

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,10 +21,10 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/issue-model-effort-overrides.md]] — Separate login-backed Workspace
-  model defaults from provider isolation and add per-run Issue model/effort
-  overrides. Tracks GitHub issues #706 and #710.
+No active plans are indexed yet.
 
 ## Completed
 
-No completed plans are indexed yet.
+- [[plans/issue-model-effort-overrides.md]] — Separated login-backed Workspace
+  model defaults from provider isolation and added per-run Issue model/effort
+  overrides. Delivered in PR #715; closed GitHub issues #706 and #710.

--- a/plans/issue-model-effort-overrides.md
+++ b/plans/issue-model-effort-overrides.md
@@ -1,8 +1,10 @@
 # Issue Model and Effort Overrides
 
-Status: In progress
+Status: Completed
 
 Related issues: #706, #710
+
+Delivered by: #715
 
 Owner guides: [[docs/model-semantics-and-runtime-injection.md]],
 [[docs/workspace-issues-and-scheduling.md]],
@@ -102,7 +104,7 @@ Not in scope:
 - [x] Run the proportional Electron/workspace smoke required by the final
   touched runtime surface.
 - [x] Update this plan and owner guides to match delivered behavior.
-- [ ] Publish and merge a serial PR to `dev`, then move this plan to Completed.
+- [x] Publish and merge a serial PR to `dev`, then move this plan to Completed.
 
 ## Completion Criteria
 


### PR DESCRIPTION
## What changed

- Mark the Issue model/effort implementation plan completed after PR #715 merged.
- Move the plan from Active to Completed in `PLANS.md`.
- Record PR #715 and the completed #706 / #710 issue outcomes.

## Why

The plan contract requires progress checkboxes and index placement to reflect repository truth. This follow-up records delivery only after the implementation actually reached `dev`.

## Validation

- `git diff --check`
- PR #715 merged to `dev`
- Post-merge `dev` CI run succeeded
- Issues #706 and #710 are closed as completed