### PR TITLE
Fix stale UTA bars by honoring trailing limits

### DIFF
--- a/docs/uta-live-testing.md
+++ b/docs/uta-live-testing.md
@@ -44,6 +44,22 @@ touched contract requires it.
 | New broker or new traded market type | Full applicable S1-S14 catalog for that venue | Always required before claiming support |
 | UTA health/restart/supervision without trading changes | Health and restart smoke with a broker disabled or read-only | Only if recovery of pending/open orders is part of the change |
 
+For CCXT public K-line changes, run the gated keyless freshness acceptance. It
+uses no credentials or trading endpoints, reproduces the same old start windows
+as `alice analysis bars(..., count=50)`, and asserts that Binance, OKX, and
+Bybit still return a latest bar across 1m, 15m, 1h, 4h, and 1d:
+
+```bash
+CCXT_E2E=1 pnpm exec vitest run \
+  --config vitest.e2e.config.ts \
+  services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.e2e.spec.ts
+```
+
+Keep this outside ordinary CI: it is real venue evidence, but DNS, venue
+availability, geo restrictions, and public rate limits are external failure
+modes. The deterministic broker specs must model the venue's first-page
+pagination behavior so the product regression remains covered offline.
+
 The commands are intentionally asymmetric:
 
 ```bash

--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
@@ -830,6 +830,35 @@ describe('AlpacaBroker — getHistorical()', () => {
     expect(acc.getCapabilities().historicalBars).toEqual({ supported: true, quality: 'iex' })
   })
 
+  it('tail-slices a bounded window instead of forwarding Alpaca first-N limit semantics', async () => {
+    const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
+    async function* gen() {
+      for (let day = 1; day <= 4; day++) {
+        yield {
+          Timestamp: `2025-01-0${day}T00:00:00Z`,
+          OpenPrice: day,
+          HighPrice: day,
+          LowPrice: day,
+          ClosePrice: day,
+          Volume: day,
+        }
+      }
+    }
+    const getBarsV2 = vi.fn(() => gen())
+    ;(acc as any).client = { getBarsV2 }
+
+    const bars = await acc.getHistorical(
+      Object.assign(new Contract(), { symbol: 'AAPL' }),
+      { interval: '1d', start: new Date('2025-01-01T00:00:00Z'), limit: 2 },
+    )
+
+    expect(bars.map((bar) => bar.close)).toEqual(['3', '4'])
+    expect(getBarsV2).toHaveBeenCalledWith(
+      'AAPL',
+      expect.not.objectContaining({ limit: expect.anything() }),
+    )
+  })
+
   it('throws when contract cannot be resolved', async () => {
     const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
     const contract = new Contract()

--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -538,10 +538,15 @@ export class AlpacaBroker implements IBroker {
     const symbol = resolveSymbol(contract)
     if (!symbol) throw new BrokerError('EXCHANGE', 'Cannot resolve contract to Alpaca symbol')
     const timeframe = ALPACA_TIMEFRAME[params.interval]
+    const limit = params.limit == null ? undefined : Math.max(1, Math.floor(params.limit))
     const baseOpts: Record<string, unknown> = { timeframe, adjustment: 'all' }
     if (params.start) baseOpts.start = params.start.toISOString()
     if (params.end) baseOpts.end = params.end.toISOString()
-    if (params.limit) baseOpts.limit = params.limit
+    // Alpaca applies limit to the FIRST rows after start. For a bounded Alice
+    // request, drain the window and tail-slice locally so BarParams.limit keeps
+    // its "most recent N" contract. Preserve the direct limit-only call shape
+    // for callers that provide no explicit bounds.
+    if (limit && !params.start && !params.end) baseOpts.limit = limit
 
     const drain = async (feed: 'sip' | 'iex'): Promise<Bar[]> => {
       const bars: Bar[] = []
@@ -560,6 +565,7 @@ export class AlpacaBroker implements IBroker {
     }
 
     try {
+      let bars: Bar[]
       // SIP = the full consolidated tape (the right feed for history/backtest —
       // real volume, real closes). The free tier can't query the last ~15 min of
       // SIP, so a window that reaches "now" 403s; fall back to IEX (free
@@ -567,16 +573,18 @@ export class AlpacaBroker implements IBroker {
       // request degrades to thinner data instead of dying. (Alpaca's OWN data
       // endpoint serves both feeds; this never touches a third-party vendor.)
       try {
-        return await drain('sip')
+        bars = await drain('sip')
       } catch (err) {
         if (isRecentSipDenied(err)) {
           console.warn(
             `AlpacaBroker[${this.id}]: SIP denied recent data for ${symbol} (${timeframe}) — falling back to IEX (thinner tape). Free tier can't query the last ~15min of SIP.`,
           )
-          return await drain('iex')
+          bars = await drain('iex')
+        } else {
+          throw err
         }
-        throw err
       }
+      return limit == null ? bars : bars.slice(-limit)
     } catch (err) {
       throw BrokerError.from(err)
     }

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.e2e.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.e2e.spec.ts
@@ -3,15 +3,25 @@
  * key). Proves the whole keyless path: construct → init() WITHOUT credentials
  * (must not throw) → getHistorical → real OHLCV. Gated; does NOT mock ccxt.
  *
- *   Run:  CCXT_E2E=1 pnpm -F @traderalice/uta-service exec vitest run CcxtBroker.e2e
+ *   Run:  CCXT_E2E=1 pnpm exec vitest run --config vitest.e2e.config.ts \
+ *           services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.e2e.spec.ts
  */
 import { describe, it, expect } from 'vitest'
 import { CcxtBroker } from './CcxtBroker.js'
 import { Contract } from '@traderalice/ibkr'
 
 describe.skipIf(!process.env.CCXT_E2E)('CcxtBroker — keyless e2e (real exchange, no key)', () => {
+  const intervalMs = {
+    '1m': 60_000,
+    '15m': 15 * 60_000,
+    '1h': 60 * 60_000,
+    '4h': 4 * 60 * 60_000,
+    '1d': 24 * 60 * 60_000,
+  } as const
+  const legacyWindowDays = { '1m': 30, '15m': 450, '1h': 90, '4h': 360, '1d': 730 } as const
+
   for (const exchange of ['binance', 'okx', 'bybit']) {
-    it(`${exchange}: keyless init + getHistorical returns real bars`, async () => {
+    it(`${exchange}: keyless history stays fresh across analysis intervals`, async () => {
       const acc = new CcxtBroker({ exchange, keyless: true, sandbox: false })
       await acc.init() // no credentials — keyless must skip the credential check
 
@@ -20,15 +30,22 @@ describe.skipIf(!process.env.CCXT_E2E)('CcxtBroker — keyless e2e (real exchang
       const c = new Contract()
       c.symbol = 'BTC'
       c.localSymbol = 'BTC/USDT'
-      const bars = await acc.getHistorical(c, { interval: '1d', limit: 5 })
+      for (const interval of Object.keys(intervalMs) as Array<keyof typeof intervalMs>) {
+        const requestedAt = Date.now()
+        // Match BarService's count-only request shape. Before issue #717 this
+        // returned the exchange's first page at the old start date.
+        const start = new Date(requestedAt - legacyWindowDays[interval] * 24 * 60 * 60_000)
+        const bars = await acc.getHistorical(c, { interval, start, limit: 50 })
 
-      expect(bars.length).toBeGreaterThan(0)
-      expect(bars.length).toBeLessThanOrEqual(5)
-      expect(typeof bars[0].close).toBe('string')
-      expect(Number(bars[bars.length - 1].close)).toBeGreaterThan(0)
-      // ascending by time
-      const ts = bars.map((b) => b.timestamp.getTime())
-      expect(ts).toEqual([...ts].sort((a, b) => a - b))
-    }, 30_000)
+        expect(bars).toHaveLength(50)
+        expect(typeof bars[0].close).toBe('string')
+        expect(Number(bars[bars.length - 1].close)).toBeGreaterThan(0)
+        const ts = bars.map((b) => b.timestamp.getTime())
+        expect(ts).toEqual([...ts].sort((a, b) => a - b))
+        // Crypto trades continuously. Allow two intervals plus five minutes
+        // for an in-progress candle, clock skew, and a slow public endpoint.
+        expect(requestedAt - ts.at(-1)!).toBeLessThanOrEqual(intervalMs[interval] * 2 + 5 * 60_000)
+      }
+    }, 60_000)
   }
 })

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
@@ -1490,7 +1490,75 @@ describe('CcxtBroker — getHistorical', () => {
       { timestamp: new Date(1700000000000), open: '60000', high: '61000', low: '59000', close: '60500', volume: '1234.5' },
       { timestamp: new Date(1700086400000), open: '60500', high: '62000', low: '60000', close: '61800', volume: '2000' },
     ])
-    expect((acc as any).exchange.fetchOHLCV).toHaveBeenCalledWith('BTC/USDT:USDT', '1d', undefined, 2)
+    expect((acc as any).exchange.fetchOHLCV).toHaveBeenCalledWith(
+      'BTC/USDT:USDT',
+      '1d',
+      expect.any(Number),
+      3,
+    )
+  })
+
+  it.each([
+    ['1m', 30],
+    ['15m', 450],
+    ['1h', 90],
+    ['4h', 360],
+    ['1d', 730],
+  ] as const)('anchors a bounded %s limit at the latest page, not the stale window start', async (interval, staleDays) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-25T12:00:00Z'))
+    try {
+      const acc = makeAccount()
+      setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })
+      const step = ({ '1m': 60_000, '15m': 15 * 60_000, '1h': 60 * 60_000, '4h': 4 * 60 * 60_000, '1d': 24 * 60 * 60_000 } as const)[interval]
+      const latest = Date.now()
+      ;(acc as any).exchange.fetchOHLCV = vi.fn(async (_symbol: string, _timeframe: string, since?: number, limit?: number) => {
+        // Real venues align an arbitrary `since` to the next candle boundary.
+        const first = since == null
+          ? latest - step * ((limit ?? 500) - 1)
+          : Math.ceil(since / step) * step
+        return Array.from({ length: limit ?? 500 }, (_, index) => {
+          const ts = first + index * step
+          return [ts, 1, 2, 0.5, 1.5, 10]
+        })
+      })
+      const contract = new Contract()
+      contract.localSymbol = 'BTC/USDT:USDT'
+      const start = new Date(Date.now() - staleDays * 24 * 60 * 60_000)
+
+      const bars = await acc.getHistorical(contract, { interval, start, limit: 50 })
+
+      expect(bars).toHaveLength(50)
+      expect(bars.at(-1)?.timestamp).toEqual(new Date(Math.floor(latest / step) * step))
+      expect((acc as any).exchange.fetchOHLCV).toHaveBeenCalledWith(
+        'BTC/USDT:USDT',
+        interval,
+        latest - step * 51 + 1,
+        51,
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('enforces an explicit end bound before tail truncation', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })
+    const end = new Date('2026-07-20T00:00:00Z')
+    ;(acc as any).exchange.fetchOHLCV = vi.fn().mockResolvedValue([
+      [end.getTime() - 60_000, 1, 2, 0.5, 1.5, 10],
+      [end.getTime(), 2, 3, 1, 2.5, 20],
+      [end.getTime() + 60_000, 3, 4, 2, 3.5, 30],
+    ])
+    const contract = new Contract()
+    contract.localSymbol = 'BTC/USDT:USDT'
+
+    const bars = await acc.getHistorical(contract, { interval: '1m', end, limit: 2 })
+
+    expect(bars.map((bar) => bar.timestamp)).toEqual([
+      new Date(end.getTime() - 60_000),
+      end,
+    ])
   })
 
   it('loud-refuses an interval the exchange does not support', async () => {

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -56,6 +56,17 @@ import {
  *  — one plain fetchBalance() covers everything, so no selector is ever needed. */
 const UNIFIED_SUBACCOUNT: CcxtSubAccountDef = { id: 'default', label: 'Account', kind: 'unified', walletTypes: [] }
 
+const BAR_INTERVAL_MS: Record<BarParams['interval'], number> = {
+  '1m': 60_000,
+  '5m': 5 * 60_000,
+  '15m': 15 * 60_000,
+  '30m': 30 * 60_000,
+  '1h': 60 * 60_000,
+  '4h': 4 * 60 * 60_000,
+  '1d': 24 * 60 * 60_000,
+  '1w': 7 * 24 * 60 * 60_000,
+}
+
 /**
  * Pull leveraged-derivative risk metadata (leverage / liquidation price /
  * margin mode) off a raw CCXT position. Returns `undefined` when the venue
@@ -1214,9 +1225,29 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       throw new BrokerError('EXCHANGE', `${this.exchangeName} does not support the ${params.interval} interval`)
     }
     try {
-      const since = params.start ? params.start.getTime() : undefined
-      const rows = await this.exchange.fetchOHLCV(ccxtSymbol, timeframe, since, params.limit)
-      return (rows as number[][]).map(([ts, o, h, l, c, v]) => ({
+      const limit = params.limit == null ? undefined : Math.max(1, Math.floor(params.limit))
+      const lowerBound = params.start?.getTime()
+      const upperBound = params.end?.getTime() ?? Date.now()
+      // CCXT exchanges return the FIRST `limit` rows at/after `since`. Alice's
+      // BarParams contract is the opposite: limit truncates to the MOST RECENT
+      // rows in the requested window. Anchor `since` immediately before that
+      // trailing window so one exchange page contains the latest bars instead
+      // of an ancient first page (issue #717). Ask for one extra interval:
+      // venues differ on whether the in-progress candle is visible, and an
+      // exact N-interval window otherwise returns only N-1 completed candles.
+      const queryLimit = limit == null ? undefined : limit + 1
+      const trailingSince = limit == null
+        ? undefined
+        : upperBound - BAR_INTERVAL_MS[params.interval] * queryLimit! + 1
+      const since = trailingSince == null
+        ? lowerBound
+        : Math.max(lowerBound ?? Number.NEGATIVE_INFINITY, trailingSince)
+      const rows = await this.exchange.fetchOHLCV(ccxtSymbol, timeframe, since, queryLimit)
+      const bounded = (rows as number[][]).filter(([ts]) =>
+        (lowerBound == null || ts >= lowerBound) && ts <= upperBound,
+      )
+      const selected = limit == null ? bounded : bounded.slice(-limit)
+      return selected.map(([ts, o, h, l, c, v]) => ({
         timestamp: new Date(ts),
         open: String(o), high: String(h), low: String(l), close: String(c),
         volume: String(v ?? 0),

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -209,12 +209,10 @@ describe('getBars — UTA branch', () => {
     expect(bars.map((b) => b.date)).toEqual(['2026-02-17', '2026-06-25']) // date-only, no time, no DST flip
   })
 
-  it('count-only request becomes a START WINDOW, not a broker `limit` (alpaca count-anchoring bug)', async () => {
-    // A count-only request must reach the broker as a start-bounded window — NOT
-    // as `limit: count` with no start. Alpaca's getBarsV2 anchors `limit` to a
-    // default start and returns the FIRST N bars ascending, so `1d count=60`
-    // collapsed to a single in-progress daily bar. We over-fetch a window and
-    // tail-slice instead. Regression guard for the 2026-06-25 repro.
+  it('count-only request carries both a bounded window and a tail limit', async () => {
+    // The synthesized start bounds broker work; limit means "most-recent N"
+    // according to BarParams. Each adapter owns translating that semantic to
+    // upstream APIs that otherwise return the first N rows from `start`.
     const getHistorical = vi.fn(async (_ref: unknown, params: { start?: Date; limit?: number }) => {
       void params
       return WIRE
@@ -227,8 +225,8 @@ describe('getBars — UTA branch', () => {
     const svc = createBarService(makeDeps({ utaManager }))
     await svc.getBars({ barId: 'alpaca-paper|AAPL' }, { interval: '1d', count: 60 })
     const params = getHistorical.mock.calls[0][1]
-    expect(params.start).toBeInstanceOf(Date)       // count → synthesized start window
-    expect(params.limit).toBeUndefined()            // count is NOT forwarded as limit
+    expect(params.start).toBeInstanceOf(Date)
+    expect(params.limit).toBe(60)
   })
 })
 

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -247,20 +247,17 @@ export function createBarService(deps: BarServiceDeps): BarService {
       throw new Error(`UTA source "${sourceId}" does not advertise historical-bar support.`)
     }
     const effectiveCap: BarCapability = cap ?? 'realtime'
-    // Mirror the vendor branch: a count-only request becomes a START WINDOW we
-    // over-fetch and then tail-slice (finalize keeps the most-recent `count`).
-    // We deliberately do NOT forward `count` as the broker's `limit`. Alpaca's
-    // getBarsV2 — and any API that anchors `limit` to a default *start* and
-    // returns the FIRST N bars ascending — would otherwise collapse a count-only
-    // request to the in-progress session: a single daily bar timestamped at the
-    // premarket open, or just the first minutes of an intraday series, instead
-    // of the most recent N. (Reproduced 2026-06-25 against alpaca paper: `1d
-    // count=60` → 1 bar timestamped 04:00; `1m count=50` → 08:00–08:49.)
+    // Mirror the vendor branch: a count-only request gets a bounded start
+    // window, while `limit` carries the cross-broker contract that the caller
+    // wants the most-recent N bars in that window. Broker adapters must enforce
+    // tail semantics even when their upstream API interprets limit as "first N
+    // from since" (CCXT and Alpaca both need adapter-specific handling).
     const start = opts.start ?? (opts.count != null ? startDateFor(opts) : undefined)
     const params: BarParams = {
       interval: toBarInterval(opts.interval),
       start: start ? new Date(start) : undefined,
       end: (opts.end ?? opts.asOf) ? new Date((opts.end ?? opts.asOf)!) : undefined,
+      limit: opts.count,
     }
     const wireBars = await acct.getHistorical({ aliceId: barId }, params)
     const bars = finalize(wireBars.map((b) => barToOhlcv(b, params.interval)), opts.count)


### PR DESCRIPTION
## Summary
- restore the `BarParams.limit` contract so `alice analysis bars(..., count=N)` requests the most recent N broker bars inside its bounded window
- anchor CCXT OHLCV reads at the trailing edge, filter explicit time bounds, and preserve Alpaca's local tail slicing instead of leaking upstream first-N semantics
- add deterministic pagination/freshness regressions plus a working keyless live acceptance across Binance, OKX, and Bybit

## Root cause
Issue #717 was not a stale cache: each call reached UTA and CCXT, but Alice synthesized an old `start` without forwarding `limit`. CCXT exchanges returned their first page after that start, producing the interval-shaped stale dates reported in the issue.

## Verification
- `npx tsc --noEmit`
- `pnpm test` — 3,351 passed, 9 skipped
- `pnpm test:e2e` — 30 passed, 3 skipped (after building the local guardian-runtime package required by a fresh worktree)
- targeted BarService, CCXT, and Alpaca specs — 163 passed
- `CCXT_E2E=1 CCXT_INIT_RETRIES=2 CCXT_INIT_RETRY_BASE_MS=250 pnpm exec vitest run --config vitest.e2e.config.ts services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.e2e.spec.ts` — Binance, OKX, and Bybit passed for 1m/15m/1h/4h/1d with 50 fresh bars each

## Boundary touch
- read-only public market data and Alice-to-UTA historical-bar parameters
- no trading writes, credentials, migrations, runtime, or packaging

Addresses #717