### PR TITLE
Preserve quant dates across repeated multi-interval bar IDs

### DIFF
--- a/default/skills/alice-analysis/SKILL.md
+++ b/default/skills/alice-analysis/SKILL.md
@@ -105,7 +105,8 @@ the full workflow):
   backtest one entry + one exit (`trailing_stop`/`ma_break`/`stop`/`target`/
   `hold`); returns entry/exit, returnPct, MFE/MAE.
 - **`alice analysis quant … --dates`** — opt-in date axis on a quant result
-  (`dates[barId]`), to map a dumped series back to days.
+  (`dates[barId]` for one interval; `dates["barId@interval"]` when the same
+  barId is used at multiple intervals), to map a dumped series back to days.
 
 ## Function catalog
 

--- a/default/skills/retrospective/SKILL.md
+++ b/default/skills/retrospective/SKILL.md
@@ -89,7 +89,8 @@ it.**
 4. **Map the index to dates when you need the path in a quant script.** Most
    reads are covered by snapshot; when you must compute over the series and want
    the date axis, add `--dates` to `alice analysis quant` (it returns
-   `dates[barId]` so you can map a dumped value back to its day).
+   `dates[barId]` for one interval, or `dates["barId@interval"]` when the same
+   barId appears at multiple intervals, so you can map each value to its day).
 
 ## Write it down honestly
 

--- a/src/domain/analysis/calc-v2/evaluator.spec.ts
+++ b/src/domain/analysis/calc-v2/evaluator.spec.ts
@@ -48,7 +48,7 @@ describe('calc-v2 evaluator', () => {
   it('reports source(s) in dataRange keyed by barId', async () => {
     const r = await run(`s = bars("yfinance|AAPL","1d",asset="equity")\nsma(s.close, 2)`, mockBars([1, 2, 3]))
     expect(Object.keys(r.dataRange!)).toEqual(['yfinance|AAPL'])
-    expect(r.dataRange!['yfinance|AAPL']).toMatchObject({ source: 'vendor', sourceId: 'yfinance', barCapability: 'delayed' })
+    expect(r.dataRange!['yfinance|AAPL']).toMatchObject({ source: 'vendor', sourceId: 'yfinance', barCapability: 'delayed', interval: '1d' })
   })
 
   it('insufficient-bars when the period exceeds available bars', async () => {
@@ -190,6 +190,67 @@ describe('calc-v2 evaluator', () => {
     expect(off.dates).toBeUndefined() // off by default
     const on = await runScript(`s = bars("x","1d",asset="equity")\ns.close[-1]`, { barService: svc }, 4, { withDates: true })
     expect(on.dates?.['yfinance|AAPL']).toEqual(['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05'])
+  })
+
+  it('keys provenance by barId@interval when one barId is fetched at multiple intervals', async () => {
+    const svc = {
+      searchBarSources: async () => [],
+      getBars: async (_ref: unknown, opts: GetBarsOpts): Promise<BarsResult> => {
+        const bars = [1, 2].map((close, index) => ({
+          date: `${opts.interval}-date-${index + 1}`,
+          open: close,
+          high: close,
+          low: close,
+          close,
+          volume: 1,
+        }))
+        return {
+          bars,
+          meta: {
+            symbol: 'BTC',
+            from: bars[0].date,
+            to: bars[1].date,
+            bars: bars.length,
+            source: 'uta',
+            sourceId: 'binance-readonly',
+            barId: 'binance-readonly|BTC/USDT:USDT',
+            barCapability: 'realtime',
+          },
+        }
+      },
+    } as BarService
+    const result = await runScript(
+      `h1 = bars("binance-readonly|BTC/USDT:USDT","1h",count=2)
+h4 = bars("binance-readonly|BTC/USDT:USDT","4h",count=2)
+{ "1h": h1.close[-1], "4h": h4.close[-1] }`,
+      { barService: svc },
+      4,
+      { withDates: true },
+    )
+
+    expect(Object.keys(result.dataRange!)).toEqual([
+      'binance-readonly|BTC/USDT:USDT@1h',
+      'binance-readonly|BTC/USDT:USDT@4h',
+    ])
+    expect(result.dataRange?.['binance-readonly|BTC/USDT:USDT@1h']).toMatchObject({ interval: '1h', to: '1h-date-2' })
+    expect(result.dataRange?.['binance-readonly|BTC/USDT:USDT@4h']).toMatchObject({ interval: '4h', to: '4h-date-2' })
+    expect(result.dates?.['binance-readonly|BTC/USDT:USDT@1h']).toEqual(['1h-date-1', '1h-date-2'])
+    expect(result.dates?.['binance-readonly|BTC/USDT:USDT@4h']).toEqual(['4h-date-1', '4h-date-2'])
+    expect(result.dates?.['binance-readonly|BTC/USDT:USDT']).toBeUndefined()
+  })
+
+  it('keeps one barId provenance key when the same interval is fetched repeatedly', async () => {
+    const result = await runScript(
+      `a = bars("yfinance|AAPL","1d",asset="equity")
+b = bars("yfinance|AAPL","1d",asset="equity")
+a.close[-1] + b.close[-1]`,
+      { barService: mockBars([1, 2, 3]) },
+      4,
+      { withDates: true },
+    )
+
+    expect(Object.keys(result.dataRange!)).toEqual(['yfinance|AAPL'])
+    expect(Object.keys(result.dates!)).toEqual(['yfinance|AAPL'])
   })
 
   it('a panel entry can be an indicator record (nested)', async () => {

--- a/src/domain/analysis/calc-v2/evaluator.ts
+++ b/src/domain/analysis/calc-v2/evaluator.ts
@@ -26,10 +26,12 @@ export type CalcValue = number | string | CalcValue[] | { [k: string]: CalcValue
 
 export interface CalcOutput {
   value: CalcValue
-  /** Sources actually fetched, keyed by barId. */
+  /** Sources actually fetched. A single interval keeps the barId key; when the
+   *  same barId is fetched at multiple intervals, keys become barId@interval. */
   dataRange: Record<string, DataSourceMeta>
-  /** Per-source date axis (ascending), keyed by barId — only when withDates. Lets
-   *  the caller map a dumped series back to dates without a second snapshot call. */
+  /** Per-series date axis (ascending), using the same keys as dataRange — only
+   *  when withDates. Lets the caller map a dumped series back to dates without
+   *  a second snapshot call. */
   dates?: Record<string, string[]>
 }
 
@@ -61,14 +63,51 @@ export async function evaluate(program: Program, deps: CalcDeps, opts: EvalOpts 
   const env = new Map<string, V>()
   const dataRange: Record<string, DataSourceMeta> = {}
   const dates: Record<string, string[]> = {}
+  const intervalsByBarId = new Map<string, Set<string>>()
+
+  const intervalKey = (barId: string, interval: string) => `${barId}@${interval}`
+
+  const recordProvenance = (r: BarsResult, interval: string): void => {
+    const barId = r.meta.barId
+    if (!barId) return
+    const meta: DataSourceMeta = { ...r.meta, interval }
+    const axis = opts.withDates ? r.bars.map((b) => b.date) : undefined
+    let intervals = intervalsByBarId.get(barId)
+
+    if (!intervals) {
+      intervals = new Set([interval])
+      intervalsByBarId.set(barId, intervals)
+      dataRange[barId] = meta
+      if (axis) dates[barId] = axis
+      return
+    }
+
+    if (!intervals.has(interval)) {
+      // Preserve the compact/backward-compatible barId key for the common
+      // single-interval case. Only upgrade to explicit series keys when a
+      // collision actually appears.
+      if (intervals.size === 1) {
+        const [firstInterval] = intervals
+        const firstKey = intervalKey(barId, firstInterval)
+        dataRange[firstKey] = dataRange[barId]
+        delete dataRange[barId]
+        if (opts.withDates && dates[barId]) {
+          dates[firstKey] = dates[barId]
+          delete dates[barId]
+        }
+      }
+      intervals.add(interval)
+    }
+
+    const key = intervals.size === 1 ? barId : intervalKey(barId, interval)
+    dataRange[key] = meta
+    if (axis) dates[key] = axis
+  }
 
   const fetchBars = async (barId: string, fetchOpts: GetBarsOpts, assetClass: AssetClass | undefined): Promise<BarsResult> => {
     const ref = assetClass ? { barId, assetClass } : { barId }
     const r = await deps.barService.getBars(ref, fetchOpts)
-    if (r.meta.barId) {
-      dataRange[r.meta.barId] = r.meta
-      if (opts.withDates) dates[r.meta.barId] = r.bars.map((b) => b.date)
-    }
+    recordProvenance(r, fetchOpts.interval)
     return r
   }
 

--- a/src/domain/analysis/calc-v2/index.ts
+++ b/src/domain/analysis/calc-v2/index.ts
@@ -14,9 +14,11 @@ import type { DataSourceMeta } from '../indicator/types.js'
 
 export interface RunResult {
   value?: CalcValue
-  /** Sources actually fetched, keyed by barId (source/provider/capability). */
+  /** Sources actually fetched. Single-interval sources use barId keys; repeated
+   *  barIds at multiple intervals use barId@interval keys. */
   dataRange?: Record<string, DataSourceMeta>
-  /** Per-source date axis (ascending) — present only when `dates` was requested. */
+  /** Per-series date axis (ascending), keyed exactly like dataRange — present
+   *  only when `dates` was requested. */
   dates?: Record<string, string[]>
   /** Present iff the script failed — actionable for self-correction. */
   error?: CalcDiagnostic

--- a/src/domain/analysis/indicator/types.ts
+++ b/src/domain/analysis/indicator/types.ts
@@ -31,6 +31,8 @@ export interface DataSourceMeta {
   sourceId?: string
   /** "{sourceId}|{nativeSymbol}" — 操作命名空间的唯一句柄。 */
   barId?: string
+  /** 本次序列的 K 线周期；quant 多周期溯源用它区分相同 barId。 */
+  interval?: string
   /** vendor 路径报的是请求 provider(SDK 执行器不回传响应 provider)。 */
   provider?: string
   /** 数据档位:free|delayed|subscription|iex|realtime。 */

--- a/src/tool/quant.spec.ts
+++ b/src/tool/quant.spec.ts
@@ -30,4 +30,19 @@ describe('quant tools wiring', () => {
     const r = (await calculateQuant.execute!({ script: `s = bars("yfinance|X","1d",asset="equity")\ns.close[-1]` }, ctx)) as { value: number }
     expect(r.value).toBe(4)
   })
+
+  it('calculateQuant preserves each interval provenance for a repeated barId', async () => {
+    const { calculateQuant } = createQuantTools({ barService: mockSvc })
+    const r = (await calculateQuant.execute!({
+      script: `h1 = bars("yfinance|X","1h",asset="equity")
+h4 = bars("yfinance|X","4h",asset="equity")
+{ "1h": h1.close[-1], "4h": h4.close[-1] }`,
+      dates: true,
+    }, ctx)) as { dataRange: Record<string, { interval?: string }>; dates: Record<string, string[]> }
+
+    expect(Object.keys(r.dataRange)).toEqual(['yfinance|X@1h', 'yfinance|X@4h'])
+    expect(r.dataRange['yfinance|X@1h'].interval).toBe('1h')
+    expect(r.dataRange['yfinance|X@4h'].interval).toBe('4h')
+    expect(Object.keys(r.dates)).toEqual(['yfinance|X@1h', 'yfinance|X@4h'])
+  })
 })

--- a/src/tool/quant.ts
+++ b/src/tool/quant.ts
@@ -91,12 +91,17 @@ on failure. Most kinds are script problems — read the error and fix the script
 pinpoints the problem). The exception is kind:"data-source": the K-line fetch itself
 failed (vendor rate-limited/blocked this client, network down, or a bad barId) — that
 is NOT a script bug. Do not rewrite the expression; follow the suggestion (retry later,
-switch source, or fix the barId), and tell the user if data is simply unavailable.`,
+switch source, or fix the barId), and tell the user if data is simply unavailable.
+
+With dates enabled, a single interval keeps the compact dates[barId] /
+dataRange[barId] keys. If the same barId is fetched at multiple intervals, both
+maps use explicit "barId@interval" keys (for example "...@1h" and "...@4h");
+each dataRange entry also carries interval.`,
 
       inputSchema: z.object({
         script: z.string().describe('The quant script (let-bindings + a final result expression).'),
         precision: z.number().int().min(0).max(10).optional().describe('Decimal places (default 4).'),
-        dates: z.stringbool().optional().describe('Opt-in: also return each source\'s date axis (dates[barId] = ["YYYY-MM-DD", …]) so a dumped series can be mapped to dates. Off by default. For a full dated snapshot, prefer marketSnapshot.'),
+        dates: z.stringbool().optional().describe('Opt-in: return each series date axis. Single-interval scripts use dates[barId]; repeated barIds at multiple intervals use dates["barId@interval"]. Off by default. For a full dated snapshot, prefer marketSnapshot.'),
       }).meta({ examples: [{ script: 's = bars("yfinance|AAPL", "1d", count=250, asset="equity")\nsma(s.close, 50)' }] }),
       execute: async ({ script, precision, dates }) => {
         return runScript(script, deps, precision ?? 4, { withDates: dates ?? false })


### PR DESCRIPTION
## Summary
- preserve every quant series provenance entry when one barId is fetched at multiple intervals
- keep the existing bare barId key for single-interval scripts, upgrading only collisions to `barId@interval`
- add `interval` to each `dataRange` entry and document the matching `dates` key contract in tool and agent guidance

## Root cause
`calculateQuant` stored `dataRange` and `dates` in maps keyed only by barId. Multi-timeframe scripts intentionally reuse one barId, so each later `bars()` call overwrote the earlier interval's metadata and date axis.

## Verification
- `npx tsc --noEmit`
- `pnpm test` — 3,354 passed, 9 skipped
- focused evaluator/tool/CLI/shim specs — 62 passed
- real `alice analysis quant --dates` against isolated keyless Binance: 1m/15m/1h/4h/1d produced five independent `barId@interval` ranges and date axes
- real single-interval CLI call retained the existing bare barId key

## Boundary touch
- quant result metadata and agent-facing CLI documentation
- no trading writes, credentials, migrations, runtime, packaging, or UI