### PR TITLE
Show Shell launch configuration

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -334,6 +334,12 @@ PTY pool, then shows:
 - only launcher-controlled environment contributions, grouped by terminal,
   Workspace, toolchain, and adapter ownership.
 
+The Shell utility is always present in this surface even when it is not listed
+as a Workspace agent runtime. Its plan uses the same launcher-built base
+environment and cwd as coding agents, so the injected `alice*` and `traderhub`
+CLI path and local tool transport remain visible. Shell does not receive an AI
+provider credential or another runtime's adapter-specific environment.
+
 Reading a launch plan never runs `prepareWorkspace`, writes native runtime
 configuration, or starts a process. The response omits inherited host
 environment values. Secret-like command arguments and environment values are

--- a/plans/workspace-launch-configuration.md
+++ b/plans/workspace-launch-configuration.md
@@ -23,7 +23,8 @@ cross-platform shell preference.
 ## Decisions
 
 - Add a dedicated **Launch** section beside General and AI Provider.
-- Preview one enabled Workspace runtime at a time.
+- Preview one enabled Workspace runtime at a time, with the Shell utility
+  always available because it shares the common launcher environment.
 - Show both adapter-composed argv and the platform-resolved process argv when
   they differ.
 - Describe only launcher-controlled environment contributions. Secret-like
@@ -55,6 +56,6 @@ cross-platform shell preference.
 ## Completion
 
 The Workspace settings panel can explain the exact safe launch plan for every
-enabled runtime, browser and Electron transports can read the same API shape,
-and all required checks pass without exposing credentials or changing launch
-behavior.
+enabled runtime and the always-available Shell utility. Browser and Electron
+transports can read the same API shape, and all required checks pass without
+exposing credentials or changing launch behavior.

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -218,21 +218,41 @@ describe('GET /:id/launch-plan', () => {
     })
   })
 
-  it('rejects missing, unknown, and disabled runtime selections', async () => {
+  it('rejects missing, unknown, and disabled agent runtimes but permits the Shell utility', async () => {
     const codex = {
       id: 'codex',
       displayName: 'Codex',
       capabilities: {},
     }
+    const shell = {
+      id: 'shell',
+      displayName: 'Shell',
+      kind: 'utility',
+      capabilities: {
+        parallelPerCwd: true,
+        resumeLast: false,
+        resumeById: false,
+        transcriptDiscovery: 'none',
+      },
+    }
     const { app } = build({ adapters: { claude: {
       id: 'claude',
       displayName: 'Claude Code',
       capabilities: { headless: true },
-    }, codex } })
+    }, codex, shell } })
 
     expect((await get(app, '/ws-1/launch-plan')).body.error).toBe('agent_required')
     expect((await get(app, '/ws-1/launch-plan?agent=ghost')).body.error).toBe('unknown_agent')
     expect((await get(app, '/ws-1/launch-plan?agent=codex')).body.error).toBe('agent_not_enabled')
+    expect(await get(app, '/ws-1/launch-plan?agent=shell')).toMatchObject({
+      status: 200,
+      body: {
+        agent: {
+          id: 'shell',
+          kind: 'utility',
+        },
+      },
+    })
   })
 
   it('redacts secret-like command assignments and following flag values', async () => {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -711,7 +711,7 @@ export function createWorkspaceRoutes(
     }
     const adapter = svc.adapters.get(agentId);
     if (!adapter) return c.json({ error: 'unknown_agent' }, 400);
-    if (!meta.agents.includes(agentId)) {
+    if (isAgentRuntime(adapter) && !meta.agents.includes(agentId)) {
       return c.json({
         error: 'agent_not_enabled',
         message: `agent "${agentId}" not enabled on this workspace`,

--- a/src/workspaces/launch-plan.spec.ts
+++ b/src/workspaces/launch-plan.spec.ts
@@ -1,3 +1,5 @@
+import { delimiter } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { launchEnvironmentDisclosure } from './service.js';
@@ -6,7 +8,7 @@ describe('launchEnvironmentDisclosure', () => {
   it('shows only controlled keys and redacts adapter credential values', () => {
     const result = launchEnvironmentDisclosure({
       TERM: 'xterm-256color',
-      PATH: '/openalice/bin:/usr/bin',
+      PATH: ['/openalice/bin', '/usr/bin'].join(delimiter),
       PWD: '/workspace',
       AQ_WS_ID: 'ws-1',
       OPENALICE_TOOL_SOCKET: '/private/openalice.sock',
@@ -55,8 +57,8 @@ describe('launchEnvironmentDisclosure', () => {
 
   it('attributes an adapter override to the adapter even for a shared key', () => {
     expect(launchEnvironmentDisclosure(
-      { PATH: '/adapter/bin:/usr/bin' },
-      { PATH: '/adapter/bin:/usr/bin' },
+      { PATH: ['/adapter/bin', '/usr/bin'].join(delimiter) },
+      { PATH: ['/adapter/bin', '/usr/bin'].join(delimiter) },
     )).toEqual([{
       key: 'PATH',
       source: 'adapter',

--- a/ui/src/components/workspace/WorkspaceLaunchConfigurationPanel.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceLaunchConfigurationPanel.spec.tsx
@@ -96,7 +96,7 @@ describe('WorkspaceLaunchConfigurationPanel', () => {
     render(
       <WorkspaceLaunchConfigurationPanel
         wsId="chat-1"
-        agents={['codex', 'shell']}
+        agents={['codex']}
         initialAgent="codex"
       />,
     )
@@ -107,6 +107,19 @@ describe('WorkspaceLaunchConfigurationPanel', () => {
     expect((await screen.findAllByText('/bin/zsh')).length).toBe(2)
     expect(screen.getByText('不发现原生会话记录')).toBeTruthy()
     expect(mocks.getWorkspaceLaunchPlan).toHaveBeenLastCalledWith('chat-1', 'shell')
+  })
+
+  it('shows Shell even when the Workspace has no configured agent runtime', async () => {
+    render(
+      <WorkspaceLaunchConfigurationPanel
+        wsId="chat-1"
+        agents={[]}
+      />,
+    )
+
+    expect((await screen.findAllByText('/bin/zsh')).length).toBe(2)
+    expect(screen.getByRole('button', { name: 'Shell' })).toBeTruthy()
+    expect(mocks.getWorkspaceLaunchPlan).toHaveBeenCalledWith('chat-1', 'shell')
   })
 
   it('surfaces a read-only load failure without closing the settings panel', async () => {

--- a/ui/src/components/workspace/WorkspaceLaunchConfigurationPanel.tsx
+++ b/ui/src/components/workspace/WorkspaceLaunchConfigurationPanel.tsx
@@ -70,7 +70,7 @@ export function WorkspaceLaunchConfigurationPanel({
   initialAgent,
 }: Props) {
   const { t } = useTranslation()
-  const runtimeIds = useMemo(() => [...new Set(agents)], [agents])
+  const runtimeIds = useMemo(() => [...new Set([...agents, 'shell'])], [agents])
   const preferred = initialAgent && runtimeIds.includes(initialAgent)
     ? initialAgent
     : runtimeIds[0] ?? ''
@@ -112,16 +112,6 @@ export function WorkspaceLaunchConfigurationPanel({
       cancelled = true
     }
   }, [refreshToken, selectedAgent, wsId])
-
-  if (runtimeIds.length === 0) {
-    return (
-      <div className="flex min-h-0 flex-1 items-center justify-center p-6">
-        <p className="text-sm text-muted-foreground">
-          {t('workspaceSettings.launch.noRuntimes')}
-        </p>
-      </div>
-    )
-  }
 
   const copyCommand = async () => {
     if (!plan) return


### PR DESCRIPTION
## Summary
- keep the Shell utility visible in Workspace Config → Launch even when no coding-agent runtime is configured
- allow the read-only launch-plan API to preview utility adapters while continuing to reject disabled coding agents
- document that Shell shares the launcher-built cwd, CLI PATH, and tool transport without receiving AI-provider or agent-specific environment
- make the launch-plan PATH disclosure tests portable across Windows and POSIX, repairing the Windows assertion regression discovered in #724

## Verification
- `pnpm exec vitest run src/webui/routes/workspaces.spec.ts ui/src/components/workspace/WorkspaceLaunchConfigurationPanel.spec.tsx`
- `pnpm exec vitest run src/workspaces/launch-plan.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (352 files passed, 1 skipped; 3363 tests passed, 9 skipped)
- `pnpm electron:smoke:pty`
- manually verified Workspace Config → Launch → Shell in the live demo; browser console had no errors