### PR TITLE
Prepare the 0.85.0 beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.84.0-beta",
+  "version": "0.85.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary
- bump the root OpenAlice version from `0.84.0-beta` to `0.85.0-beta`
- prepare the accumulated `dev` changes for promotion through the protected release workflow

## Release intent
After the release-prep and post-merge `dev` gates are fully green, promote `dev` to `master`. The release workflow should create the unused `v0.85.0-beta` prerelease, signed/notarized macOS assets, the Windows installer, update feeds, Broker Packs, the release-owned CLI installer, and CDN aliases.

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm exec vitest run src/webui/routes/version.spec.ts ui/src/components/settings/AboutOpenAliceSection.spec.tsx scripts/prepare-desktop-release-assets.spec.ts` (7 passed)
- `pnpm test` (352 files passed, 1 skipped; 3,363 tests passed, 9 skipped)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- PR #725 and its post-merge `dev` CI are green across macOS, Windows, Vercel, Docker, cross-platform tests, package smokes, and Workspace runtime smoke

## Boundary touch
This commit changes only the root version field. Signing, notarization, public tag creation, installer publication, and CDN mutation remain owned by the protected `master` release workflow.