### PR TITLE
Self-host the Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,15 @@ Stuck? The fastest path is usually:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=TraderAlice/OpenAlice&type=Date)](https://star-history.com/#TraderAlice/OpenAlice&Date)
+<p align="center">
+  <a href="https://github.com/TraderAlice/OpenAlice">
+    <img src="docs/images/star-history.svg" alt="OpenAlice GitHub star history" width="900">
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/TraderAlice/OpenAlice"><img src="https://img.shields.io/github/stars/TraderAlice/OpenAlice?style=flat-square&logo=github&label=Current%20stars" alt="Current GitHub stars"></a>
+</p>
 
 ## Contributors
 

--- a/docs/images/star-history.svg
+++ b/docs/images/star-history.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="560" viewBox="0 0 1200 560" role="img" aria-labelledby="title description">
+  <title id="title">TraderAlice/OpenAlice star history</title>
+  <desc id="description">6,283 stars in this snapshot. 669 stars added in the latest 30-day window. Daily cumulative history from Feb 19, 2026 through Jul 28, 2026.</desc>
+  <metadata>
+    <repository>TraderAlice/OpenAlice</repository>
+    <generated-at>2026-07-28T06:56:51.503Z</generated-at>
+    <aggregation>daily cumulative active stargazers</aggregation>
+  </metadata>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#101713"/>
+      <stop offset="100%" stop-color="#080b09"/>
+    </linearGradient>
+    <linearGradient id="area" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e3b341" stop-opacity="0.42"/>
+      <stop offset="100%" stop-color="#e3b341" stop-opacity="0"/>
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .eyebrow { fill: #8b9890; font-size: 15px; font-weight: 650; letter-spacing: 2.3px; }
+      .title { fill: #f2f5f3; font-size: 28px; font-weight: 720; }
+      .metric { fill: #f2f5f3; font-size: 30px; font-weight: 740; }
+      .metric-label { fill: #8b9890; font-size: 14px; font-weight: 580; letter-spacing: 0.8px; }
+      .metric-accent { fill: #e3b341; }
+      .axis-label { fill: #7e8a83; font-size: 14px; font-weight: 520; }
+      .grid { stroke: #253029; stroke-width: 1; }
+      .tick { stroke: #465249; stroke-width: 1; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="560" rx="22" fill="url(#background)"/>
+  <rect x="0.75" y="0.75" width="1198.5" height="558.5" rx="21.25" fill="none" stroke="#29342d" stroke-width="1.5"/>
+
+  <path d="M 55 48 L 61 61 L 75 62.5 L 64.5 71.5 L 67.5 85 L 55 78 L 42.5 85 L 45.5 71.5 L 35 62.5 L 49 61 Z" fill="#e3b341"/>
+  <text x="92" y="59" class="eyebrow">OPENALICE</text>
+  <text x="92" y="91" class="title">Star History</text>
+
+  <g transform="translate(758 43)">
+    <text x="0" y="31" class="metric">6,283</text>
+    <text x="0" y="56" class="metric-label">STARS AT SNAPSHOT</text>
+    <line x1="160" y1="4" x2="160" y2="61" stroke="#2d3931"/>
+    <text x="198" y="31" class="metric metric-accent">+669</text>
+    <text x="198" y="56" class="metric-label">LAST 30 DAYS</text>
+  </g>
+
+  <text x="92" y="143" class="metric-label">DAILY CUMULATIVE · THROUGH JUL 28, 2026 UTC</text>
+
+        <line x1="92" y1="478.00" x2="1144" y2="478.00" class="grid"/>
+        <text x="74" y="483.00" text-anchor="end" class="axis-label">0</text>
+        <line x1="92" y1="402.00" x2="1144" y2="402.00" class="grid"/>
+        <text x="74" y="407.00" text-anchor="end" class="axis-label">2k</text>
+        <line x1="92" y1="326.00" x2="1144" y2="326.00" class="grid"/>
+        <text x="74" y="331.00" text-anchor="end" class="axis-label">4k</text>
+        <line x1="92" y1="250.00" x2="1144" y2="250.00" class="grid"/>
+        <text x="74" y="255.00" text-anchor="end" class="axis-label">6k</text>
+        <line x1="92" y1="174.00" x2="1144" y2="174.00" class="grid"/>
+        <text x="74" y="179.00" text-anchor="end" class="axis-label">8k</text>
+
+        <line x1="92.00" y1="478" x2="92.00" y2="485" class="tick"/>
+        <text x="92.00" y="508" text-anchor="start" class="axis-label">Feb 19</text>
+        <line x1="158.16" y1="478" x2="158.16" y2="485" class="tick"/>
+        <text x="158.16" y="508" text-anchor="middle" class="axis-label">Mar</text>
+        <line x1="363.27" y1="478" x2="363.27" y2="485" class="tick"/>
+        <text x="363.27" y="508" text-anchor="middle" class="axis-label">Apr</text>
+        <line x1="561.76" y1="478" x2="561.76" y2="485" class="tick"/>
+        <text x="561.76" y="508" text-anchor="middle" class="axis-label">May</text>
+        <line x1="766.87" y1="478" x2="766.87" y2="485" class="tick"/>
+        <text x="766.87" y="508" text-anchor="middle" class="axis-label">Jun</text>
+        <line x1="965.36" y1="478" x2="965.36" y2="485" class="tick"/>
+        <text x="965.36" y="508" text-anchor="middle" class="axis-label">Jul</text>
+        <line x1="1144.00" y1="478" x2="1144.00" y2="485" class="tick"/>
+        <text x="1144.00" y="508" text-anchor="end" class="axis-label">Jul 28</text>
+  <path d="M 92.00 472.79 L 98.62 468.27 L 105.23 467.17 L 111.85 463.71 L 118.47 456.87 L 125.08 454.93 L 131.70 454.14 L 138.31 453.60 L 144.93 451.13 L 151.55 449.50 L 158.16 448.93 L 164.78 447.87 L 171.40 447.45 L 178.01 447.11 L 184.63 446.84 L 191.25 446.76 L 197.86 443.50 L 204.48 442.05 L 211.09 441.44 L 217.71 441.22 L 224.33 441.03 L 230.94 440.19 L 237.56 439.01 L 244.18 433.27 L 250.79 415.00 L 257.41 396.64 L 264.03 394.06 L 270.64 390.41 L 277.26 385.28 L 283.87 383.27 L 290.49 380.68 L 297.11 377.98 L 303.72 374.53 L 310.34 372.36 L 316.96 370.12 L 323.57 368.07 L 330.19 366.28 L 336.81 365.22 L 343.42 364.27 L 350.04 363.43 L 356.65 362.90 L 363.27 362.33 L 369.89 361.49 L 376.50 361.04 L 383.12 360.43 L 389.74 360.28 L 396.35 359.93 L 402.97 355.41 L 409.58 349.64 L 416.20 346.98 L 422.82 345.34 L 429.43 344.66 L 436.05 344.09 L 442.67 343.71 L 449.28 343.21 L 455.90 342.95 L 462.52 342.72 L 469.13 342.42 L 475.75 342.07 L 482.36 341.24 L 488.98 340.55 L 495.60 339.95 L 502.21 339.49 L 508.83 338.96 L 515.45 338.24 L 522.06 337.63 L 528.68 336.91 L 535.30 336.37 L 541.91 336.03 L 548.53 335.46 L 555.14 335.08 L 561.76 334.85 L 568.38 334.47 L 574.99 333.64 L 581.61 332.73 L 588.23 331.97 L 594.84 331.32 L 601.46 329.46 L 608.08 327.44 L 614.69 327.18 L 621.31 327.14 L 627.92 326.76 L 634.54 326.15 L 641.16 325.81 L 647.77 325.43 L 654.39 325.20 L 661.01 324.82 L 667.62 324.52 L 674.24 324.06 L 680.86 322.31 L 687.47 320.64 L 694.09 319.77 L 700.70 319.05 L 707.32 318.70 L 713.94 318.29 L 720.55 317.91 L 727.17 317.60 L 733.79 316.84 L 740.40 311.10 L 747.02 306.62 L 753.64 304.11 L 760.25 303.31 L 766.87 301.00 L 773.48 297.65 L 780.10 296.32 L 786.72 294.38 L 793.33 293.13 L 799.95 292.37 L 806.57 291.46 L 813.18 289.56 L 819.80 287.92 L 826.42 287.09 L 833.03 284.12 L 839.65 281.39 L 846.26 280.10 L 852.88 278.73 L 859.50 277.74 L 866.11 276.94 L 872.73 276.30 L 879.35 275.73 L 885.96 273.94 L 892.58 272.50 L 899.19 271.81 L 905.81 271.20 L 912.43 270.52 L 919.04 270.03 L 925.66 269.53 L 932.28 268.85 L 938.89 266.49 L 945.51 264.67 L 952.13 262.01 L 958.74 260.94 L 965.36 260.41 L 971.97 259.88 L 978.59 259.42 L 985.21 258.59 L 991.82 257.45 L 998.44 256.50 L 1005.06 255.70 L 1011.67 255.24 L 1018.29 254.98 L 1024.91 254.79 L 1031.52 254.60 L 1038.14 254.22 L 1044.75 252.13 L 1051.37 250.95 L 1057.99 250.42 L 1064.60 249.73 L 1071.22 249.13 L 1077.84 248.48 L 1084.45 246.77 L 1091.07 244.87 L 1097.69 244.19 L 1104.30 243.31 L 1110.92 242.51 L 1117.53 241.45 L 1124.15 240.58 L 1130.77 240.01 L 1137.38 239.32 L 1144.00 239.25 L 1144.00 478 L 92 478 Z" fill="url(#area)"/>
+  <path d="M 92.00 472.79 L 98.62 468.27 L 105.23 467.17 L 111.85 463.71 L 118.47 456.87 L 125.08 454.93 L 131.70 454.14 L 138.31 453.60 L 144.93 451.13 L 151.55 449.50 L 158.16 448.93 L 164.78 447.87 L 171.40 447.45 L 178.01 447.11 L 184.63 446.84 L 191.25 446.76 L 197.86 443.50 L 204.48 442.05 L 211.09 441.44 L 217.71 441.22 L 224.33 441.03 L 230.94 440.19 L 237.56 439.01 L 244.18 433.27 L 250.79 415.00 L 257.41 396.64 L 264.03 394.06 L 270.64 390.41 L 277.26 385.28 L 283.87 383.27 L 290.49 380.68 L 297.11 377.98 L 303.72 374.53 L 310.34 372.36 L 316.96 370.12 L 323.57 368.07 L 330.19 366.28 L 336.81 365.22 L 343.42 364.27 L 350.04 363.43 L 356.65 362.90 L 363.27 362.33 L 369.89 361.49 L 376.50 361.04 L 383.12 360.43 L 389.74 360.28 L 396.35 359.93 L 402.97 355.41 L 409.58 349.64 L 416.20 346.98 L 422.82 345.34 L 429.43 344.66 L 436.05 344.09 L 442.67 343.71 L 449.28 343.21 L 455.90 342.95 L 462.52 342.72 L 469.13 342.42 L 475.75 342.07 L 482.36 341.24 L 488.98 340.55 L 495.60 339.95 L 502.21 339.49 L 508.83 338.96 L 515.45 338.24 L 522.06 337.63 L 528.68 336.91 L 535.30 336.37 L 541.91 336.03 L 548.53 335.46 L 555.14 335.08 L 561.76 334.85 L 568.38 334.47 L 574.99 333.64 L 581.61 332.73 L 588.23 331.97 L 594.84 331.32 L 601.46 329.46 L 608.08 327.44 L 614.69 327.18 L 621.31 327.14 L 627.92 326.76 L 634.54 326.15 L 641.16 325.81 L 647.77 325.43 L 654.39 325.20 L 661.01 324.82 L 667.62 324.52 L 674.24 324.06 L 680.86 322.31 L 687.47 320.64 L 694.09 319.77 L 700.70 319.05 L 707.32 318.70 L 713.94 318.29 L 720.55 317.91 L 727.17 317.60 L 733.79 316.84 L 740.40 311.10 L 747.02 306.62 L 753.64 304.11 L 760.25 303.31 L 766.87 301.00 L 773.48 297.65 L 780.10 296.32 L 786.72 294.38 L 793.33 293.13 L 799.95 292.37 L 806.57 291.46 L 813.18 289.56 L 819.80 287.92 L 826.42 287.09 L 833.03 284.12 L 839.65 281.39 L 846.26 280.10 L 852.88 278.73 L 859.50 277.74 L 866.11 276.94 L 872.73 276.30 L 879.35 275.73 L 885.96 273.94 L 892.58 272.50 L 899.19 271.81 L 905.81 271.20 L 912.43 270.52 L 919.04 270.03 L 925.66 269.53 L 932.28 268.85 L 938.89 266.49 L 945.51 264.67 L 952.13 262.01 L 958.74 260.94 L 965.36 260.41 L 971.97 259.88 L 978.59 259.42 L 985.21 258.59 L 991.82 257.45 L 998.44 256.50 L 1005.06 255.70 L 1011.67 255.24 L 1018.29 254.98 L 1024.91 254.79 L 1031.52 254.60 L 1038.14 254.22 L 1044.75 252.13 L 1051.37 250.95 L 1057.99 250.42 L 1064.60 249.73 L 1071.22 249.13 L 1077.84 248.48 L 1084.45 246.77 L 1091.07 244.87 L 1097.69 244.19 L 1104.30 243.31 L 1110.92 242.51 L 1117.53 241.45 L 1124.15 240.58 L 1130.77 240.01 L 1137.38 239.32 L 1144.00 239.25" fill="none" stroke="#e3b341" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" filter="url(#glow)"/>
+  <circle cx="1144.00" cy="239.25" r="6" fill="#f6d365" stroke="#101713" stroke-width="3"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:guardian-recovery": "tsx scripts/guardian/runtime-recovery-smoke.ts",
     "test:connector-service": "node scripts/connector-service-smoke.mjs",
     "test:connector-replay": "vitest run services/connector/src/core/io-replay.spec.ts services/connector/src/core/io-events.spec.ts services/connector/src/adapters/shared.spec.ts",
+    "star-history:generate": "node scripts/generate-star-history.mjs",
     "postinstall": "node scripts/fix-pty-perms.mjs"
   },
   "keywords": [

--- a/scripts/generate-star-history.mjs
+++ b/scripts/generate-star-history.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const DEFAULT_REPOSITORY = 'TraderAlice/OpenAlice'
+const DEFAULT_OUTPUT = 'docs/images/star-history.svg'
+
+function startOfUtcDay(value) {
+  const date = new Date(value)
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+}
+
+function formatCount(value) {
+  return new Intl.NumberFormat('en-US').format(value)
+}
+
+function formatCompactCount(value) {
+  if (value < 1_000) return String(value)
+  const thousands = value / 1_000
+  return `${thousands >= 10 || Number.isInteger(thousands) ? thousands.toFixed(0) : thousands.toFixed(1)}k`
+}
+
+function formatDate(value, includeDay = true) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    ...(includeDay ? { day: 'numeric' } : {}),
+    timeZone: 'UTC',
+  }).format(value)
+}
+
+function formatFullDate(value) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(value)
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+function niceAxis(maximum, targetIntervals = 4) {
+  if (maximum <= 0) return { maximum: 1, step: 1 }
+  const roughStep = maximum / targetIntervals
+  const magnitude = 10 ** Math.floor(Math.log10(roughStep))
+  const normalized = roughStep / magnitude
+  const niceNormalized = normalized <= 1
+    ? 1
+    : normalized <= 2
+      ? 2
+      : normalized <= 2.5
+        ? 2.5
+        : normalized <= 5
+          ? 5
+          : 10
+  const step = niceNormalized * magnitude
+  return {
+    maximum: Math.ceil(maximum / step) * step,
+    step,
+  }
+}
+
+export function aggregateStarHistory(timestamps) {
+  const sorted = timestamps
+    .map((value) => new Date(value))
+    .filter((value) => !Number.isNaN(value.getTime()))
+    .sort((left, right) => left.getTime() - right.getTime())
+
+  if (sorted.length === 0) {
+    throw new Error('[star-history] GitHub returned no valid stargazer timestamps')
+  }
+
+  const firstDay = startOfUtcDay(sorted[0])
+  const lastDay = startOfUtcDay(sorted.at(-1))
+  const dayCount = Math.floor((lastDay - firstDay) / DAY_MS) + 1
+  const points = []
+  let starIndex = 0
+
+  for (let dayIndex = 0; dayIndex < dayCount; dayIndex += 1) {
+    const day = firstDay + dayIndex * DAY_MS
+    const nextDay = day + DAY_MS
+    while (starIndex < sorted.length && sorted[starIndex].getTime() < nextDay) {
+      starIndex += 1
+    }
+    points.push({ date: new Date(day), count: starIndex })
+  }
+
+  return points
+}
+
+function selectDateTicks(points) {
+  const ticks = [points[0]]
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const date = points[index].date
+    if (date.getUTCDate() === 1) ticks.push(points[index])
+  }
+  if (points.length > 1) ticks.push(points.at(-1))
+  return ticks
+}
+
+export function renderStarHistorySvg({
+  points,
+  repository = DEFAULT_REPOSITORY,
+  generatedAt = new Date(),
+}) {
+  if (!Array.isArray(points) || points.length === 0) {
+    throw new Error('[star-history] at least one aggregate point is required')
+  }
+
+  const width = 1200
+  const height = 560
+  const plot = {
+    left: 92,
+    right: 1144,
+    top: 174,
+    bottom: 478,
+  }
+  const plotWidth = plot.right - plot.left
+  const plotHeight = plot.bottom - plot.top
+  const total = points.at(-1).count
+  const axis = niceAxis(total)
+  const xForIndex = (index) => {
+    if (points.length === 1) return plot.left
+    return plot.left + (index / (points.length - 1)) * plotWidth
+  }
+  const yForCount = (count) => plot.bottom - (count / axis.maximum) * plotHeight
+  const linePath = points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${xForIndex(index).toFixed(2)} ${yForCount(point.count).toFixed(2)}`)
+    .join(' ')
+  const areaPath = `${linePath} L ${xForIndex(points.length - 1).toFixed(2)} ${plot.bottom} L ${plot.left} ${plot.bottom} Z`
+  const intervalCount = Math.round(axis.maximum / axis.step)
+  const yTicks = Array.from({ length: intervalCount + 1 }, (_, index) => index * axis.step)
+  const dateTicks = selectDateTicks(points)
+  const pointIndexByTime = new Map(points.map((point, index) => [point.date.getTime(), index]))
+  const thirtyDayBaselineIndex = Math.max(0, points.length - 31)
+  const lastThirtyDays = total - points[thirtyDayBaselineIndex].count
+  const title = `${repository} star history`
+  const description = `${formatCount(total)} stars in this snapshot. ${formatCount(lastThirtyDays)} stars added in the latest 30-day window. Daily cumulative history from ${formatFullDate(points[0].date)} through ${formatFullDate(points.at(-1).date)}.`
+
+  const grid = yTicks
+    .map((tick) => {
+      const y = yForCount(tick)
+      return `
+        <line x1="${plot.left}" y1="${y.toFixed(2)}" x2="${plot.right}" y2="${y.toFixed(2)}" class="grid"/>
+        <text x="${plot.left - 18}" y="${(y + 5).toFixed(2)}" text-anchor="end" class="axis-label">${formatCompactCount(tick)}</text>`
+    })
+    .join('')
+
+  const xAxis = dateTicks
+    .map((point, tickIndex) => {
+      const index = pointIndexByTime.get(point.date.getTime())
+      const x = xForIndex(index)
+      const isEndpoint = tickIndex === 0 || tickIndex === dateTicks.length - 1
+      return `
+        <line x1="${x.toFixed(2)}" y1="${plot.bottom}" x2="${x.toFixed(2)}" y2="${plot.bottom + 7}" class="tick"/>
+        <text x="${x.toFixed(2)}" y="${plot.bottom + 30}" text-anchor="${tickIndex === 0 ? 'start' : tickIndex === dateTicks.length - 1 ? 'end' : 'middle'}" class="axis-label">${formatDate(point.date, isEndpoint)}</text>`
+    })
+    .join('')
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="title description">
+  <title id="title">${escapeXml(title)}</title>
+  <desc id="description">${escapeXml(description)}</desc>
+  <metadata>
+    <repository>${escapeXml(repository)}</repository>
+    <generated-at>${escapeXml(generatedAt.toISOString())}</generated-at>
+    <aggregation>daily cumulative active stargazers</aggregation>
+  </metadata>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#101713"/>
+      <stop offset="100%" stop-color="#080b09"/>
+    </linearGradient>
+    <linearGradient id="area" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e3b341" stop-opacity="0.42"/>
+      <stop offset="100%" stop-color="#e3b341" stop-opacity="0"/>
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .eyebrow { fill: #8b9890; font-size: 15px; font-weight: 650; letter-spacing: 2.3px; }
+      .title { fill: #f2f5f3; font-size: 28px; font-weight: 720; }
+      .metric { fill: #f2f5f3; font-size: 30px; font-weight: 740; }
+      .metric-label { fill: #8b9890; font-size: 14px; font-weight: 580; letter-spacing: 0.8px; }
+      .metric-accent { fill: #e3b341; }
+      .axis-label { fill: #7e8a83; font-size: 14px; font-weight: 520; }
+      .grid { stroke: #253029; stroke-width: 1; }
+      .tick { stroke: #465249; stroke-width: 1; }
+    </style>
+  </defs>
+
+  <rect width="${width}" height="${height}" rx="22" fill="url(#background)"/>
+  <rect x="0.75" y="0.75" width="${width - 1.5}" height="${height - 1.5}" rx="21.25" fill="none" stroke="#29342d" stroke-width="1.5"/>
+
+  <path d="M 55 48 L 61 61 L 75 62.5 L 64.5 71.5 L 67.5 85 L 55 78 L 42.5 85 L 45.5 71.5 L 35 62.5 L 49 61 Z" fill="#e3b341"/>
+  <text x="92" y="59" class="eyebrow">OPENALICE</text>
+  <text x="92" y="91" class="title">Star History</text>
+
+  <g transform="translate(758 43)">
+    <text x="0" y="31" class="metric">${formatCount(total)}</text>
+    <text x="0" y="56" class="metric-label">STARS AT SNAPSHOT</text>
+    <line x1="160" y1="4" x2="160" y2="61" stroke="#2d3931"/>
+    <text x="198" y="31" class="metric metric-accent">+${formatCount(lastThirtyDays)}</text>
+    <text x="198" y="56" class="metric-label">LAST 30 DAYS</text>
+  </g>
+
+  <text x="${plot.left}" y="143" class="metric-label">DAILY CUMULATIVE · THROUGH ${formatFullDate(points.at(-1).date).toUpperCase()} UTC</text>
+${grid}
+${xAxis}
+  <path d="${areaPath}" fill="url(#area)"/>
+  <path d="${linePath}" fill="none" stroke="#e3b341" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" filter="url(#glow)"/>
+  <circle cx="${xForIndex(points.length - 1).toFixed(2)}" cy="${yForCount(total).toFixed(2)}" r="6" fill="#f6d365" stroke="#101713" stroke-width="3"/>
+</svg>
+`
+}
+
+export async function fetchStargazerTimestamps({
+  repository = DEFAULT_REPOSITORY,
+  token,
+  fetchImpl = fetch,
+  onPage,
+}) {
+  if (!token) throw new Error('[star-history] a GitHub token is required')
+
+  const timestamps = []
+  const perPage = 100
+  for (let page = 1; ; page += 1) {
+    const url = new URL(`https://api.github.com/repos/${repository}/stargazers`)
+    url.searchParams.set('per_page', String(perPage))
+    url.searchParams.set('page', String(page))
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/vnd.github.star+json',
+        Authorization: `Bearer ${token}`,
+        'User-Agent': 'OpenAlice-Star-History',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    })
+
+    if (!response.ok) {
+      const detail = await response.text()
+      throw new Error(`[star-history] GitHub API returned ${response.status}: ${detail.slice(0, 240)}`)
+    }
+
+    const pageItems = await response.json()
+    if (!Array.isArray(pageItems)) {
+      throw new Error('[star-history] GitHub API returned an unexpected response')
+    }
+
+    for (const item of pageItems) {
+      if (typeof item?.starred_at === 'string') timestamps.push(item.starred_at)
+    }
+    onPage?.({ page, fetched: pageItems.length, total: timestamps.length })
+
+    if (pageItems.length < perPage) break
+  }
+
+  return timestamps
+}
+
+function resolveGitHubToken() {
+  const environmentToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
+  if (environmentToken) return environmentToken
+
+  try {
+    return execFileSync('gh', ['auth', 'token'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    throw new Error('[star-history] set GH_TOKEN/GITHUB_TOKEN or authenticate with `gh auth login`')
+  }
+}
+
+function parseArgs(argv) {
+  const values = {
+    repository: DEFAULT_REPOSITORY,
+    output: DEFAULT_OUTPUT,
+  }
+
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]
+    const value = argv[index + 1]
+    if (!key?.startsWith('--') || value == null) {
+      throw new Error(`[star-history] invalid arguments: ${argv.join(' ')}`)
+    }
+    if (key === '--repository') values.repository = value
+    else if (key === '--output') values.output = value
+    else throw new Error(`[star-history] unknown option: ${key}`)
+  }
+
+  return values
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const token = resolveGitHubToken()
+  const timestamps = await fetchStargazerTimestamps({
+    repository: options.repository,
+    token,
+    onPage: ({ page, total }) => {
+      if (page === 1 || page % 10 === 0) {
+        console.log(`[star-history] fetched page ${page} (${formatCount(total)} timestamps)`)
+      }
+    },
+  })
+  const points = aggregateStarHistory(timestamps)
+  const svg = renderStarHistorySvg({
+    points,
+    repository: options.repository,
+  })
+  const outputPath = resolve(options.output)
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, svg)
+  console.log(`[star-history] wrote ${options.output} from ${formatCount(timestamps.length)} active stargazers`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/generate-star-history.spec.ts
+++ b/scripts/generate-star-history.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  aggregateStarHistory,
+  fetchStargazerTimestamps,
+  renderStarHistorySvg,
+} from './generate-star-history.mjs'
+
+describe('aggregateStarHistory', () => {
+  it('creates a cumulative point for every UTC day without retaining user data', () => {
+    const points = aggregateStarHistory([
+      '2026-02-21T18:00:00Z',
+      '2026-02-19T10:40:01Z',
+      '2026-02-19T20:15:00Z',
+    ])
+
+    expect(points).toEqual([
+      { date: new Date('2026-02-19T00:00:00Z'), count: 2 },
+      { date: new Date('2026-02-20T00:00:00Z'), count: 2 },
+      { date: new Date('2026-02-21T00:00:00Z'), count: 3 },
+    ])
+  })
+
+  it('rejects empty or invalid histories', () => {
+    expect(() => aggregateStarHistory([])).toThrow('no valid stargazer timestamps')
+    expect(() => aggregateStarHistory(['not-a-date'])).toThrow('no valid stargazer timestamps')
+  })
+})
+
+describe('fetchStargazerTimestamps', () => {
+  it('paginates and keeps only timestamp fields', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      starred_at: `2026-02-19T10:${String(index % 60).padStart(2, '0')}:00Z`,
+      user: { login: `private-user-${index}` },
+    }))
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => firstPage,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ starred_at: '2026-02-20T12:00:00Z', user: { login: 'last-user' } }],
+      })
+
+    const timestamps = await fetchStargazerTimestamps({
+      token: 'test-token',
+      fetchImpl,
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(timestamps).toHaveLength(101)
+    expect(timestamps.at(-1)).toBe('2026-02-20T12:00:00Z')
+    expect(JSON.stringify(timestamps)).not.toContain('private-user')
+  })
+})
+
+describe('renderStarHistorySvg', () => {
+  it('renders an accessible self-contained chart without stargazer identities', () => {
+    const points = aggregateStarHistory([
+      '2026-02-19T10:40:01Z',
+      '2026-02-20T12:00:00Z',
+      '2026-03-20T12:00:00Z',
+    ])
+    const svg = renderStarHistorySvg({
+      points,
+      generatedAt: new Date('2026-03-20T13:00:00Z'),
+    })
+
+    expect(svg).toContain('<title id="title">TraderAlice/OpenAlice star history</title>')
+    expect(svg).toContain('<desc id="description">')
+    expect(svg).toContain('<aggregation>daily cumulative active stargazers</aggregation>')
+    expect(svg).toContain('<generated-at>2026-03-20T13:00:00.000Z</generated-at>')
+    expect(svg).not.toContain('login')
+    expect(svg).not.toContain('starred_at')
+  })
+})


### PR DESCRIPTION
## Summary
- replace the failing third-party Star History embed with a repository-owned static SVG and a live current-stars badge
- add a reproducible generator that reads authenticated GitHub stargazer timestamps, immediately discards identities, aggregates by UTC day, and renders the OpenAlice-styled chart
- add focused tests for aggregation, pagination/privacy behavior, and accessible SVG output

## Why
The public Star History endpoint returns HTTP 503 because its shared GitHub API tokens are exhausted. GitHub's new restrictions on stargazer-list access also make third-party live history embeds structurally unreliable. A checked-in snapshot preserves the growth slope without making README rendering depend on that service.

## User impact
The README keeps a visible historical growth curve. The chart remains available when third-party services are rate-limited, while the Shields badge supplies the live total between snapshot refreshes.

## Verification
- `pnpm star-history:generate` (6,283 active stargazers, 160 daily aggregate points)
- `pnpm exec vitest run scripts/generate-star-history.spec.ts`
- `npx tsc --noEmit`
- `pnpm test` (353 passed, 1 skipped; 3,367 tests passed, 9 skipped)
- `xmllint --noout docs/images/star-history.svg`
- `git diff --check`
- rendered the SVG at 1200×560 with `rsvg-convert` and visually inspected the result
- scanned the generated SVG for usernames, raw stargazer fields, and credential material

## Boundary touch
- none (documentation asset and generator only)