### PR TITLE
test(migrations): tolerate Windows symlink privilege

### DIFF
--- a/src/migrations/0024_pi_native_workspace_config.spec.ts
+++ b/src/migrations/0024_pi_native_workspace_config.spec.ts
@@ -41,13 +41,29 @@ async function seedLegacy(workspace: string, model: string): Promise<void> {
   await writeFile(join(legacy, 'sessions', model, 'turn.jsonl'), '{}\n')
 }
 
+async function seedSessionLink(workspace: string): Promise<boolean> {
+  try {
+    await symlink('sessions', join(workspace, '.pi-agent', 'session-link'))
+    return true
+  } catch (error) {
+    // Ordinary Windows installations cannot create symlinks without Developer
+    // Mode or elevation. Keep exercising the migration itself on those hosts;
+    // link preservation remains covered wherever the fixture can be created.
+    if (
+      process.platform === 'win32'
+      && (error as NodeJS.ErrnoException).code === 'EPERM'
+    ) return false
+    throw error
+  }
+}
+
 describe('0024 Pi native Workspace config', () => {
   it('backs up and migrates active and departed Workspaces idempotently', async () => {
     const active = join(root, 'workspaces', 'workspaces', 'chat-active')
     const departed = join(root, 'workspaces', 'departed-workspaces', 'chat-departed')
     await seedLegacy(active, 'active-model')
     await seedLegacy(departed, 'departed-model')
-    await symlink('sessions', join(active, '.pi-agent', 'session-link'))
+    const sessionLinkCreated = await seedSessionLink(active)
 
     await expect(migratePiNativeWorkspaceConfig(join(root, 'workspaces'), {
       env: { PI_CODING_AGENT_DIR: agentDir, HOME: join(root, 'home') },
@@ -60,7 +76,9 @@ describe('0024 Pi native Workspace config', () => {
     expect(existsSync(join(backupRoot, 'departed', 'chat-departed', '.pi-agent', 'models.json'))).toBe(true)
     expect(await readFile(join(agentDir, 'sessions', 'active-model', 'turn.jsonl'), 'utf8')).toBe('{}\n')
     expect(await readFile(join(agentDir, 'sessions', 'departed-model', 'turn.jsonl'), 'utf8')).toBe('{}\n')
-    expect(await readlink(join(agentDir, 'session-link'))).toBe('sessions')
+    if (sessionLinkCreated) {
+      expect(await readlink(join(agentDir, 'session-link'))).toBe('sessions')
+    }
     expect(JSON.parse(await readFile(join(agentDir, 'models.json'), 'utf8')).legacyMetadata)
       .toBe('active-model')
     expect(JSON.parse(await readFile(join(active, '.pi', 'settings.json'), 'utf8')).defaultModel)


### PR DESCRIPTION
## Summary

- treat only Windows `EPERM` from the migration spec's symlink fixture as an unavailable capability
- continue exercising active/departed Workspace migration, backups, file movement, malformed-state containment, and idempotency on ordinary non-elevated Windows hosts
- retain the link-preservation assertion on hosts where the fixture can be created; all non-Windows and non-`EPERM` errors still fail

Closes #722.

## Verification

- `pnpm exec vitest run src/migrations/0024_pi_native_workspace_config.spec.ts --reporter=verbose`
- `npx tsc --noEmit`
- `pnpm test` (3368 passed, 9 skipped)

An unrelated existing full-suite flake in `SettingsPage.data-home.spec.tsx` was observed before the successful full retry and recorded separately as #732.