### PR TITLE
test(ui): wait for data-home toggle readiness

### DIFF
--- a/ui/src/pages/SettingsPage.data-home.spec.tsx
+++ b/ui/src/pages/SettingsPage.data-home.spec.tsx
@@ -77,6 +77,7 @@ describe('DataHomeSection', () => {
     render(<DataHomeSection />)
 
     const toggle = await screen.findByRole('switch', { name: 'Ask which location to use at startup' })
+    await waitFor(() => expect(toggle).toHaveProperty('disabled', false))
     fireEvent.click(toggle)
 
     await waitFor(() => expect(bridge.setAskOnStartup).toHaveBeenCalledWith(true))


### PR DESCRIPTION
## Summary

- wait for the data-home startup toggle to become enabled before clicking it
- align the test with the component's asynchronous `getStatus()` readiness boundary
- remove the full-suite race where `findByRole()` returned the initially disabled switch and `fireEvent.click()` correctly did nothing

Closes #732.

## Verification

- focused Settings data-home spec: 20/20 runs passed
- full `pnpm test`: 3 consecutive runs passed (3368 passed, 9 skipped each)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test:guardian-recovery`
- `pnpm -F @traderalice/guardian-runtime build && pnpm -F @traderalice/desktop typecheck`
- demo `/settings` route: Data location browser/development guidance rendered; no console errors

This is a one-line test-readiness fix; production UI behavior is unchanged.