### PR TITLE
Prevent Broker Pack outages across app upgrades

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -17,6 +17,7 @@ on:
       - "scripts/desktop-packaged-smoke.mjs"
       - "scripts/desktop-packaged-smoke-plan.mjs"
       - "scripts/build-broker-packs.ts"
+      - "scripts/broker-pack-upgrade-smoke.ts"
       - "scripts/guardian/**"
       - "scripts/pnpm-command.mjs"
       - "scripts/pnpm-command.spec.ts"
@@ -56,6 +57,7 @@ on:
       - "scripts/desktop-packaged-smoke.mjs"
       - "scripts/desktop-packaged-smoke-plan.mjs"
       - "scripts/build-broker-packs.ts"
+      - "scripts/broker-pack-upgrade-smoke.ts"
       - "scripts/guardian/**"
       - "scripts/pnpm-command.mjs"
       - "scripts/pnpm-command.spec.ts"
@@ -111,6 +113,11 @@ jobs:
       - name: Build optional Broker Packs on Windows
         if: runner.os == 'Windows'
         run: pnpm broker-packs:build
+        timeout-minutes: 10
+
+      - name: Prove previous-release Broker Pack upgrade on Windows
+        if: runner.os == 'Windows'
+        run: pnpm broker-packs:upgrade-smoke
         timeout-minutes: 10
 
       # macOS still uses dugite's embedded Git. Windows keeps only dugite's JS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       created: ${{ !github.event.inputs.mirror_tag && steps.check.outputs.exists == 'false' }}
       tag: ${{ github.event.inputs.mirror_tag || steps.version.outputs.tag }}
       prerelease: ${{ steps.version.outputs.prerelease }}
+      previous_tag: ${{ steps.version.outputs.previous_tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +38,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
 
           # Determine if pre-release (contains - like beta.1, rc.1)
           if [[ "$VERSION" == *-* ]]; then
@@ -120,6 +122,9 @@ jobs:
 
       - name: Build optional Broker Packs
         run: pnpm broker-packs:build
+
+      - name: Prove previous-release Broker Pack upgrade
+        run: pnpm broker-packs:upgrade-smoke -- --from "${{ needs.release.outputs.previous_tag }}"
 
       # macOS still uses dugite's embedded Git. Windows keeps only dugite's JS
       # wrapper and routes it to managed PortableGit in the packaged smoke.
@@ -263,6 +268,9 @@ jobs:
 
       - name: Build optional Broker Packs
         run: pnpm broker-packs:build
+
+      - name: Prove previous-release Broker Pack upgrade
+        run: pnpm broker-packs:upgrade-smoke -- --from "${{ needs.release.outputs.previous_tag }}"
 
       - name: Preserve Linux Broker Packs
         uses: actions/upload-artifact@v4

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,7 +21,9 @@ the durable truth after it changes.
 
 ## Active
 
-None.
+- [[plans/broker-pack-release-safety.md]] — Repairing the v0.85 existing-user
+  Broker Pack upgrade gap and making N-1→N reconciliation a blocking v0.86
+  release contract.
 
 ## Completed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,13 @@ vendoring third-party code. The
 pinned public-source architecture comparison behind the authoritative remote
 guide, also without vendoring third-party code.
 
+## Incident Records
+
+- [[docs/incidents/2026-07-28-broker-pack-upgrade-gap.md]] —
+  [v0.85 Broker Pack upgrade gap](incidents/2026-07-28-broker-pack-upgrade-gap.md):
+  previous-release Pack activation failed after a desktop upgrade and
+  established the N-1→N release gate.
+
 ## Maintenance Rule
 
 - Every owner guide states what it owns and points to the current load-bearing

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -58,6 +58,13 @@ not depend on class identity from a Pack's dependency tree; use structural
 checks such as `Decimal.isDecimal` and stable error codes instead of
 cross-package `instanceof` tests.
 
+Pack compatibility is governed by `BROKER_PACK_API_VERSION`, not by equality
+with the OpenAlice product version. `broker-pack.json#version` records which
+OpenAlice release produced the artifact and selects the matching update
+catalog; an older Pack with the supported API remains loadable while its
+replacement downloads. Increment `BROKER_PACK_API_VERSION` whenever UTA Core
+changes the exported module contract in a way an older Pack cannot satisfy.
+
 ## Installed Layout and Transaction
 
 Replaceable Pack payloads live outside portable user data:
@@ -93,6 +100,17 @@ have open. Pack directories are replaceable machine/runtime state: backup
 `data/`, credentials, and Workspaces, then reinstall Packs after moving to an
 incompatible machine.
 
+On production startup Alice reconciles only Packs that already have an active
+downloaded release. A Pack produced by another OpenAlice version continues
+serving through the supported Pack API while Alice downloads the current
+platform artifact, validates it, atomically switches `active.json`, and asks
+Guardian to restart UTA. A prior Pack with an old API is not loaded, but its
+typed incompatibility still qualifies it for automatic replacement. Missing
+Packs remain an explicit user choice; malformed or corrupt releases remain
+visible Repair cases rather than being silently trusted.
+`OPENALICE_BROKER_PACK_AUTO_UPDATE=0` is the emergency kill switch. Source
+development and test runtimes skip automatic network reconciliation.
+
 Linux catalogs may declare a minimum glibc version. The current Longbridge GNU
 artifact requires glibc 2.39, so older Ubuntu/WSL systems are rejected before
 the native module is loaded instead of crashing UTA with `ERR_DLOPEN_FAILED`.
@@ -110,6 +128,13 @@ OpenAlice-Broker-<engine>-<version>-<platform>-<arch>.tgz
 The release workflow runs this on macOS arm64, macOS x64, Windows x64, and
 Linux x64; publishes the files with the desktop release; mirrors them to the
 download CDN; and verifies every catalog and referenced archive.
+
+Before a candidate can publish, each platform runner downloads the real Broker
+Packs from the previous GitHub Release, activates them in an isolated
+`OPENALICE_HOME`, serves the current candidate catalog locally, and runs the
+production reconciliation path. The gate requires every active pointer to move
+to the candidate while every previous immutable release remains intact. A
+fresh-install-only Pack check is not sufficient for release acceptance.
 
 The build command also extracts every generated archive, verifies its catalog
 membership, size, SHA-256, package identity, entry containment, and absence of
@@ -143,13 +168,16 @@ The Trading page owns three installation entry points:
 
 - broker creation stops before credentials and offers Install/Repair when the
   chosen engine is absent;
-- existing enabled accounts show a missing-support banner with the exact
-  accounts that require each Pack;
+- existing enabled accounts show an Install, Update, or Repair banner with the
+  exact accounts that require each Pack;
 - public crypto data-source toggles require the CCXT Pack before a source can
   be enabled, while still allowing an already-enabled source to be disabled.
 
 Pack errors must be explicit and recoverable. Alice/Chat remains usable, UTA
 continues starting, and other installed broker engines remain independent.
+
+The v0.85.0-beta regression that established this contract is recorded in
+[[docs/incidents/2026-07-28-broker-pack-upgrade-gap.md]].
 
 ## Verification
 
@@ -157,6 +185,7 @@ Run the focused checks before the repository-wide gates:
 
 ```bash
 pnpm broker-packs:build
+pnpm broker-packs:upgrade-smoke
 pnpm vitest run src/services/broker-packs/installer.spec.ts \
   services/uta/src/domain/trading/brokers/registry.spec.ts \
   ui/src/components/uta/CreateUTADialog.spec.tsx

--- a/docs/incidents/2026-07-28-broker-pack-upgrade-gap.md
+++ b/docs/incidents/2026-07-28-broker-pack-upgrade-gap.md
@@ -1,0 +1,83 @@
+# v0.85 Broker Pack Upgrade Gap
+
+Date: 2026-07-28
+
+Affected release: `v0.85.0-beta`
+
+Impact: Existing live-broker accounts could remain offline after an otherwise
+successful OpenAlice desktop update.
+
+## User-visible symptom
+
+An existing OKX account backed by CCXT showed:
+
+```text
+Installed broker pack "ccxt" is invalid:
+Installed broker pack ccxt targets OpenAlice 0.84.0-beta;
+0.85.0-beta is running
+```
+
+The account detail page offered **Reconnect**, but reconnecting retried the same
+stale active Pack and returned the same error. The effective recovery was
+**Trading → Broker support → Repair**, which was not presented at the failure
+site.
+
+UTA Core had upgraded correctly inside the OpenAlice desktop package. The
+separately downloaded CCXT Broker Pack had not. No broker engine loaded for the
+affected account, so the failure caused loss of trading availability rather
+than an unintended trading write.
+
+## Root cause
+
+Broker Pack activation required
+`broker-pack.json#version === package.json#version`. The desktop updater
+replaced OpenAlice and its bundled UTA Core but did not reconcile active Broker
+Packs stored under `<OPENALICE_HOME>/runtime/broker-packs/`.
+
+The v0.85 release did publish matching Pack artifacts for every supported
+platform. Publication therefore succeeded while existing installations still
+retained an `active.json` pointer to their v0.84 immutable release.
+
+## Why release checks missed it
+
+- Release jobs built, validated, imported, published, and mirrored fresh v0.85
+  Pack artifacts.
+- Packaged Workspace acceptance started from isolated/fresh state.
+- No gate seeded the real previous-release Packs before launching the candidate.
+- Product version equality was treated as compatibility even though the
+  explicit `BROKER_PACK_API_VERSION` is the actual module boundary.
+- Recovery UI existed on the Trading overview, but not in the account failure
+  path where the user encountered the problem.
+
+The missing test was an existing-user upgrade, not a fresh install.
+
+## Immediate recovery for v0.85
+
+Open **Trading**, find **Broker support needs attention**, and choose **Repair**
+for each affected engine. Installation validates the v0.85 catalog and
+checksum, atomically activates the new immutable release, and asks Guardian to
+restart UTA.
+
+## Permanent safeguards
+
+Beginning with v0.86:
+
+1. A Pack remains loadable across OpenAlice product versions while its
+   `BROKER_PACK_API_VERSION` is supported.
+2. Production startup automatically reconciles only Packs the user already
+   installed. It never silently installs a new optional broker integration.
+3. Failed downloads or validation leave the previous compatible active pointer
+   untouched.
+4. Trading UI exposes **Update** and **Repair** with the accounts that require
+   the Pack.
+5. Every release platform must pass a real previous-release-to-candidate Pack
+   upgrade smoke before publication.
+6. A Pack API change requires an explicit API-version increment and a release
+   candidate containing compatible artifacts for every supported platform.
+
+## Release invariant
+
+A release is not accepted merely because its Broker Pack artifacts exist.
+It is accepted only when an installation carrying the previous public
+release's active Packs can start safely, reconcile to the candidate, retain a
+recoverable previous release, and load UTA through the declared Pack API.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:server": "turbo run build --filter=!@traderalice/desktop --filter=!./packages/uta-broker-* && tsup src/main.ts --format esm --dts",
     "build:migration-index": "tsx scripts/build-migration-index.ts",
     "broker-packs:build": "turbo run build --filter=./packages/uta-broker-* && tsx scripts/build-broker-packs.ts && pnpm broker-packs:verify",
+    "broker-packs:upgrade-smoke": "tsx scripts/broker-pack-upgrade-smoke.ts",
     "broker-packs:verify": "tsx scripts/verify-broker-packs.ts",
     "start": "node dist/main.js",
     "electron:tsc": "pnpm -F @traderalice/desktop build",

--- a/plans/broker-pack-release-safety.md
+++ b/plans/broker-pack-release-safety.md
@@ -1,0 +1,70 @@
+# Broker Pack Release Safety
+
+Status: Active
+
+Related incident:
+[[docs/incidents/2026-07-28-broker-pack-upgrade-gap.md]]
+
+Owner guides:
+
+- [[docs/broker-packs.md]]
+- [[docs/development-workflow.md]]
+- [[docs/managed-workspace-runtime.md]]
+
+## Scope
+
+Repair the v0.85 existing-user regression in which OpenAlice and bundled UTA
+Core upgraded while an already-installed Broker Pack remained pinned to v0.84.
+Ship the correction as v0.86.0-beta and make the previous-release upgrade path
+a blocking release contract.
+
+This emergency increment does not complete independent semantic versioning for
+UTA Core and Broker Packs. It establishes the API compatibility boundary and
+safe reconciliation needed before those release cadences can be separated.
+
+## Decisions
+
+1. `BROKER_PACK_API_VERSION` is the loader compatibility gate. Product-version
+   equality identifies an available update but does not take a compatible
+   account offline.
+2. Automatic reconciliation updates only previously downloaded Packs. Missing
+   integrations remain consented UI installs.
+3. Candidate activation stays content-addressed and atomic. A failed update
+   retains the prior compatible active pointer.
+4. Development/test runtimes do not perform surprise network updates; an
+   emergency environment kill switch remains available in production.
+5. Release acceptance starts with the real previous GitHub Release artifacts
+   on every supported platform.
+
+## Work
+
+- [x] Keep API-compatible previous-release Packs loadable.
+- [x] Detect and automatically reconcile outdated downloaded Packs.
+- [x] Expose Update separately from Install and Repair in Trading UI.
+- [x] Add the previous-release Broker Pack upgrade smoke to the release matrix.
+- [x] Record the v0.85 incident and durable owner-guide contract.
+- [x] Complete focused, repository-wide, and packaged verification.
+- [ ] Merge to `dev` and inspect trailing CI.
+- [ ] Prepare, promote, and publish `v0.86.0-beta`.
+- [ ] Verify GitHub Release and CDN artifacts after publication.
+
+## Verification
+
+- `pnpm vitest run src/core/broker-packs.spec.ts
+  src/services/broker-packs/installer.spec.ts
+  services/uta/src/domain/trading/brokers/registry.spec.ts
+  ui/src/pages/TradingPage.broker-packs.spec.tsx`
+- `pnpm broker-packs:build`
+- `pnpm broker-packs:upgrade-smoke -- --from v0.85.0-beta`
+- `npx tsc --noEmit`
+- `cd ui && npx tsc -b`
+- `pnpm test`
+- `pnpm electron:smoke:packaged --temp-data`
+- release matrix on macOS arm64, macOS x64, Windows x64, and Linux x64
+
+## Completion
+
+An existing installation carrying the previous public release's Broker Packs
+stays usable during update, reconciles atomically to the candidate, offers an
+actionable recovery surface, and cannot publish until every platform proves
+that path.

--- a/scripts/broker-pack-upgrade-smoke.ts
+++ b/scripts/broker-pack-upgrade-smoke.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env tsx
+
+/**
+ * Release acceptance for the existing-user Broker Pack path.
+ *
+ * Seeds the real Broker Packs from the previous GitHub Release, serves the
+ * current candidate catalog from dist/broker-packs, runs the same automatic
+ * reconciliation used by Alice, and proves every active pointer moves to the
+ * candidate without deleting the prior immutable release.
+ */
+
+import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { createServer, type Server } from 'node:http'
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, resolve } from 'node:path'
+import * as tar from 'tar'
+
+import {
+  brokerPackActivePath,
+  brokerPackReleasesRoot,
+  resolveActiveBrokerPack,
+  type BrokerPackActivePointer,
+  type InstalledBrokerPackManifest,
+  type InstallableBrokerEngine,
+} from '../src/core/broker-packs.js'
+import {
+  brokerPackCatalogFileName,
+  type BrokerPackReleaseAsset,
+  type BrokerPackReleaseCatalog,
+} from '../src/core/broker-pack-catalog.js'
+import { getCurrentVersion } from '../src/core/version.js'
+import { reconcileInstalledBrokerPacks } from '../src/services/broker-packs/auto-updater.js'
+import { getBrokerPackLocalStatus } from '../src/services/broker-packs/installer.js'
+
+const repoRoot = resolve(import.meta.dirname, '..')
+const candidateRoot = resolve(repoRoot, 'dist', 'broker-packs')
+const repository = 'TraderAlice/OpenAlice'
+
+async function main(): Promise<void> {
+  const currentVersion = getCurrentVersion()
+  const previousTag = readPreviousTag(process.argv.slice(2), currentVersion)
+  const previousVersion = previousTag.replace(/^v/, '')
+  if (previousVersion === currentVersion) {
+    throw new Error(`previous release ${previousTag} must differ from candidate ${currentVersion}`)
+  }
+
+  const candidateCatalog = await readCatalog(
+    resolve(candidateRoot, brokerPackCatalogFileName(currentVersion)),
+  )
+  const previousCatalog = await fetchJson<BrokerPackReleaseCatalog>(
+    releaseAssetUrl(previousTag, brokerPackCatalogFileName(previousVersion)),
+  )
+  assertCatalog(previousCatalog, previousVersion)
+  assertCatalog(candidateCatalog, currentVersion)
+
+  const home = await mkdtemp(resolve(tmpdir(), 'openalice-broker-pack-upgrade-'))
+  const oldHome = process.env['OPENALICE_HOME']
+  const oldCatalogUrl = process.env['OPENALICE_BROKER_PACK_CATALOG_URL']
+  const server = await serveCandidateAssets(candidateRoot)
+
+  try {
+    process.env['OPENALICE_HOME'] = home
+    process.env['OPENALICE_BROKER_PACK_CATALOG_URL'] =
+      `http://127.0.0.1:${serverPort(server)}/${brokerPackCatalogFileName(currentVersion)}`
+
+    const candidateEngines = new Set(candidateCatalog.packs.map((asset) => asset.engine))
+    const previousAssets = previousCatalog.packs.filter((asset) => candidateEngines.has(asset.engine))
+    if (previousAssets.length !== previousCatalog.packs.length) {
+      throw new Error(
+        `candidate is missing a Pack from ${previousTag}: ` +
+        `${previousCatalog.packs.filter((asset) => !candidateEngines.has(asset.engine)).map((asset) => asset.engine).join(', ')}`,
+      )
+    }
+
+    const previousReleases = new Map<InstallableBrokerEngine, string>()
+    for (const asset of previousAssets) {
+      const release = await seedPreviousRelease(previousTag, asset)
+      previousReleases.set(asset.engine, release)
+    }
+
+    const before = await Promise.all(
+      previousAssets.map((asset) => getBrokerPackLocalStatus(asset.engine)),
+    )
+    for (const status of before) {
+      if (!status.updateAvailable || status.version !== previousVersion) {
+        throw new Error(`previous ${status.engine} Pack was not recognized as updateable: ${JSON.stringify(status)}`)
+      }
+    }
+
+    const result = await reconcileInstalledBrokerPacks({ force: true, restart: false })
+    if (result.failed.length > 0) {
+      throw new Error(`candidate reconciliation failed: ${JSON.stringify(result.failed)}`)
+    }
+    const expected = [...candidateEngines].sort()
+    const updated = [...result.updated].sort()
+    if (JSON.stringify(updated) !== JSON.stringify(expected)) {
+      throw new Error(`updated ${updated.join(', ') || 'none'}; expected ${expected.join(', ')}`)
+    }
+
+    for (const engine of expected) {
+      const active = await resolveActiveBrokerPack(engine)
+      if (!active || active.manifest.version !== currentVersion) {
+        throw new Error(`${engine} did not activate candidate ${currentVersion}`)
+      }
+      const previousRelease = previousReleases.get(engine)
+      if (!previousRelease) throw new Error(`${engine} previous release id was not recorded`)
+      await stat(resolve(brokerPackReleasesRoot(engine), previousRelease))
+      const status = await getBrokerPackLocalStatus(engine)
+      if (!status.installed || status.updateAvailable || status.version !== currentVersion) {
+        throw new Error(`${engine} candidate status is invalid: ${JSON.stringify(status)}`)
+      }
+    }
+
+    console.log(
+      `[broker-pack-upgrade-smoke] ${previousTag} -> v${currentVersion}: ` +
+      `${expected.join(', ')} upgraded atomically`,
+    )
+  } finally {
+    await new Promise<void>((done) => server.close(() => done()))
+    await rm(home, { recursive: true, force: true })
+    restoreEnv('OPENALICE_HOME', oldHome)
+    restoreEnv('OPENALICE_BROKER_PACK_CATALOG_URL', oldCatalogUrl)
+  }
+}
+
+async function seedPreviousRelease(
+  tag: string,
+  asset: BrokerPackReleaseAsset,
+): Promise<string> {
+  const bytes = await fetchBytes(releaseAssetUrl(tag, asset.file))
+  const digest = createHash('sha256').update(bytes).digest('hex')
+  if (digest !== asset.sha256) {
+    throw new Error(`${asset.engine} previous-release checksum mismatch`)
+  }
+  if (bytes.length !== asset.size) {
+    throw new Error(`${asset.engine} previous-release size mismatch`)
+  }
+
+  const release = `${asset.version}-${digest.slice(0, 16)}-upgrade-smoke`
+  const releaseRoot = resolve(brokerPackReleasesRoot(asset.engine), release)
+  await mkdir(releaseRoot, { recursive: true })
+  const archive = resolve(releaseRoot, `${asset.engine}.tgz`)
+  await writeFile(archive, bytes)
+  await tar.x({ cwd: releaseRoot, file: archive, strict: true, preservePaths: false })
+  await rm(archive)
+
+  const manifest: InstalledBrokerPackManifest = {
+    schemaVersion: 1,
+    apiVersion: asset.apiVersion,
+    engine: asset.engine,
+    version: asset.version,
+    entry: asset.entry,
+    contentId: digest.slice(0, 16),
+    installedAt: new Date().toISOString(),
+    sourceUrl: releaseAssetUrl(tag, asset.file),
+  }
+  await writeFile(resolve(releaseRoot, 'broker-pack.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+  const pointer: BrokerPackActivePointer = {
+    schemaVersion: 1,
+    engine: asset.engine,
+    release,
+    activatedAt: new Date().toISOString(),
+  }
+  await mkdir(resolve(brokerPackActivePath(asset.engine), '..'), { recursive: true })
+  await writeFile(brokerPackActivePath(asset.engine), `${JSON.stringify(pointer, null, 2)}\n`)
+  return release
+}
+
+async function serveCandidateAssets(root: string): Promise<Server> {
+  const server = createServer(async (req, res) => {
+    try {
+      const name = basename(new URL(req.url ?? '/', 'http://127.0.0.1').pathname)
+      if (!name) {
+        res.statusCode = 404
+        res.end()
+        return
+      }
+      const bytes = await readFile(resolve(root, name))
+      res.setHeader('content-length', String(bytes.length))
+      res.end(bytes)
+    } catch {
+      res.statusCode = 404
+      res.end()
+    }
+  })
+  await new Promise<void>((done, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', done)
+  })
+  return server
+}
+
+function readPreviousTag(args: string[], currentVersion: string): string {
+  const index = args.indexOf('--from')
+  if (index >= 0) {
+    const value = args[index + 1]?.trim()
+    if (!value) throw new Error('--from requires a release tag')
+    return value.startsWith('v') ? value : `v${value}`
+  }
+  const tags = execFileSync('git', ['tag', '--sort=-creatordate'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).split(/\r?\n/).map((tag) => tag.trim()).filter(Boolean)
+  const previous = tags.find((tag) => tag.replace(/^v/, '') !== currentVersion)
+  if (!previous) throw new Error('no previous release tag found; pass --from <tag>')
+  return previous
+}
+
+function releaseAssetUrl(tag: string, file: string): string {
+  return `https://github.com/${repository}/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(file)}`
+}
+
+async function readCatalog(path: string): Promise<BrokerPackReleaseCatalog> {
+  return JSON.parse(await readFile(path, 'utf8')) as BrokerPackReleaseCatalog
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  return JSON.parse((await fetchBytes(url)).toString('utf8')) as T
+}
+
+async function fetchBytes(url: string): Promise<Buffer> {
+  const response = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(120_000) })
+  if (!response.ok) throw new Error(`GET ${url} failed: HTTP ${response.status}`)
+  return Buffer.from(await response.arrayBuffer())
+}
+
+function assertCatalog(catalog: BrokerPackReleaseCatalog, version: string): void {
+  if (
+    catalog.schemaVersion !== 1
+    || catalog.openAliceVersion !== version
+    || catalog.platform !== process.platform
+    || catalog.arch !== process.arch
+    || catalog.packs.length === 0
+  ) {
+    throw new Error(
+      `invalid ${version} catalog for ${process.platform}-${process.arch}: ${JSON.stringify(catalog)}`,
+    )
+  }
+}
+
+function serverPort(server: Server): number {
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('candidate server has no TCP port')
+  return address.port
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+}
+
+await main()

--- a/src/core/broker-packs.spec.ts
+++ b/src/core/broker-packs.spec.ts
@@ -112,11 +112,27 @@ describe('resolveActiveBrokerPack', () => {
     await expect(resolveActiveBrokerPack('ccxt')).rejects.toThrow(/incompatible/i)
   })
 
-  it('rejects a pack built for a different OpenAlice version', async () => {
+  it('reports an API-version mismatch with the installed release version', async () => {
+    await writeActivePack({ apiVersion: 2, version: '0.84.0-beta' })
+    const {
+      BrokerPackApiVersionMismatchError,
+      resolveActiveBrokerPack,
+    } = await import('./broker-packs.js')
+
+    await expect(resolveActiveBrokerPack('ccxt')).rejects.toEqual(expect.objectContaining({
+      name: BrokerPackApiVersionMismatchError.name,
+      installedApiVersion: 2,
+      installedVersion: '0.84.0-beta',
+    }))
+  })
+
+  it('keeps an older app-version Pack loadable when its Pack API is compatible', async () => {
     await writeActivePack({ version: '0.0.0-other' })
     const { resolveActiveBrokerPack } = await import('./broker-packs.js')
 
-    await expect(resolveActiveBrokerPack('ccxt')).rejects.toThrow(/targets OpenAlice 0\.0\.0-other/i)
+    await expect(resolveActiveBrokerPack('ccxt')).resolves.toMatchObject({
+      manifest: { version: '0.0.0-other', apiVersion: 1 },
+    })
   })
 
   it('rejects an entry path that escapes the immutable release', async () => {

--- a/src/core/broker-packs.ts
+++ b/src/core/broker-packs.ts
@@ -6,7 +6,6 @@
 import { readFile, realpath } from 'node:fs/promises'
 import { resolve, sep } from 'node:path'
 import { runtimePath } from './paths.js'
-import { getCurrentVersion } from './version.js'
 
 export const BROKER_PACK_SCHEMA_VERSION = 1 as const
 export const BROKER_PACK_API_VERSION = 1 as const
@@ -50,6 +49,22 @@ export interface ResolvedBrokerPackRelease {
   root: string
   entry: string
   manifest: InstalledBrokerPackManifest
+}
+
+export class BrokerPackApiVersionMismatchError extends Error {
+  readonly code = 'BROKER_PACK_API_VERSION_MISMATCH'
+
+  constructor(
+    readonly engine: InstallableBrokerEngine,
+    readonly installedApiVersion: number,
+    readonly installedVersion: string,
+  ) {
+    super(
+      `Installed broker pack ${engine} uses API ${installedApiVersion}; ` +
+      `this OpenAlice runtime requires API ${BROKER_PACK_API_VERSION}`,
+    )
+    this.name = 'BrokerPackApiVersionMismatchError'
+  }
 }
 
 export function isInstallableBrokerEngine(value: string): value is InstallableBrokerEngine {
@@ -109,12 +124,6 @@ export async function resolveBrokerPackRelease(
     JSON.parse(await readFile(manifestPath, 'utf8')),
     engine,
   )
-  const currentVersion = getCurrentVersion()
-  if (manifest.version !== currentVersion) {
-    throw new Error(
-      `Installed broker pack ${engine} targets OpenAlice ${manifest.version}; ${currentVersion} is running`,
-    )
-  }
   const pkg = JSON.parse(await readFile(packagePath, 'utf8')) as { name?: unknown; version?: unknown }
   if (pkg.name !== `@traderalice/uta-broker-${engine}` || pkg.version !== manifest.version) {
     throw new Error(`Installed broker pack ${engine} has an invalid package identity`)
@@ -144,7 +153,6 @@ function parseInstalledManifest(raw: unknown, engine: InstallableBrokerEngine): 
   const row = raw as Record<string, unknown>
   if (
     row.schemaVersion !== BROKER_PACK_SCHEMA_VERSION
-    || row.apiVersion !== BROKER_PACK_API_VERSION
     || row.engine !== engine
   ) {
     throw new Error(`Installed broker pack ${engine} is incompatible with this OpenAlice runtime`)
@@ -153,6 +161,13 @@ function parseInstalledManifest(raw: unknown, engine: InstallableBrokerEngine): 
     if (typeof row[key] !== 'string' || row[key].length === 0) {
       throw new Error(`Installed broker pack ${engine} has invalid ${key}`)
     }
+  }
+  if (typeof row.apiVersion !== 'number' || row.apiVersion !== BROKER_PACK_API_VERSION) {
+    throw new BrokerPackApiVersionMismatchError(
+      engine,
+      typeof row.apiVersion === 'number' ? row.apiVersion : -1,
+      row.version as string,
+    )
   }
   return row as unknown as InstalledBrokerPackManifest
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { createUTAClient } from '@traderalice/uta-protocol'
 import { UTAManagerSDK } from './services/uta-client/index.js'
 import { waitForUTAReady } from './services/uta-supervisor/health.js'
 import { resolveUTAUrl } from './services/uta-supervisor/url.js'
+import { scheduleInstalledBrokerPackReconciliation } from './services/broker-packs/auto-updater.js'
 import {
   liteUnavailableReason,
   readonlyMutationReason,
@@ -416,6 +417,7 @@ async function main() {
   }
 
   console.log('engine: started')
+  scheduleInstalledBrokerPackReconciliation()
 
   // Broker catalog refresh, snapshot scheduling, and broker close-on-
   // shutdown all live in the UTA service after Step 6.

--- a/src/services/broker-packs/auto-updater.ts
+++ b/src/services/broker-packs/auto-updater.ts
@@ -1,0 +1,125 @@
+/**
+ * Reconcile previously installed Broker Packs with the running OpenAlice
+ * release without turning optional integrations into implicit installs.
+ *
+ * A compatible older Pack remains loadable while the replacement downloads.
+ * installBrokerPack() activates atomically, so any failed update leaves the
+ * prior active pointer untouched.
+ */
+
+import {
+  INSTALLABLE_BROKER_ENGINES,
+  type InstallableBrokerEngine,
+} from '../../core/broker-packs.js'
+import { getCurrentVersion } from '../../core/version.js'
+import { triggerUTARestart, type TriggerResult } from '../uta-supervisor/restart-trigger.js'
+import {
+  getBrokerPackLocalStatus,
+  installBrokerPack,
+} from './installer.js'
+
+const STARTUP_RECONCILE_DELAY_MS = 1_500
+
+export interface BrokerPackReconcileFailure {
+  engine: InstallableBrokerEngine
+  error: string
+}
+
+export interface BrokerPackReconcileResult {
+  skipped?: string
+  checked: InstallableBrokerEngine[]
+  updated: InstallableBrokerEngine[]
+  failed: BrokerPackReconcileFailure[]
+  restart?: TriggerResult
+}
+
+export interface BrokerPackReconcileOptions {
+  force?: boolean
+  restart?: boolean
+}
+
+export async function reconcileInstalledBrokerPacks(
+  options: BrokerPackReconcileOptions = {},
+): Promise<BrokerPackReconcileResult> {
+  const skipReason = options.force ? null : automaticReconcileSkipReason()
+  if (skipReason) {
+    return { skipped: skipReason, checked: [], updated: [], failed: [] }
+  }
+
+  const statuses = await Promise.all(
+    INSTALLABLE_BROKER_ENGINES.map((engine) => getBrokerPackLocalStatus(engine)),
+  )
+  const outdated = statuses
+    .filter((status) => status.updateAvailable && status.version)
+    .map((status) => status.engine as InstallableBrokerEngine)
+
+  const settled = await Promise.allSettled(
+    outdated.map(async (engine) => {
+      await installBrokerPack(engine)
+      return engine
+    }),
+  )
+  const updated: InstallableBrokerEngine[] = []
+  const failed: BrokerPackReconcileFailure[] = []
+  settled.forEach((result, index) => {
+    const engine = outdated[index]!
+    if (result.status === 'fulfilled') updated.push(engine)
+    else {
+      failed.push({
+        engine,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      })
+    }
+  })
+
+  const restart = updated.length > 0 && options.restart !== false
+    ? await triggerUTARestart()
+    : undefined
+  return {
+    checked: outdated,
+    updated,
+    failed,
+    ...(restart ? { restart } : {}),
+  }
+}
+
+export function scheduleInstalledBrokerPackReconciliation(): void {
+  const skipReason = automaticReconcileSkipReason()
+  if (skipReason) {
+    console.log(`[broker-packs] automatic reconciliation skipped: ${skipReason}`)
+    return
+  }
+
+  const timer = setTimeout(() => {
+    void reconcileInstalledBrokerPacks()
+      .then((result) => {
+        if (result.updated.length > 0) {
+          console.log(
+            `[broker-packs] updated ${result.updated.join(', ')} for OpenAlice ${getCurrentVersion()}`,
+          )
+        }
+        for (const failure of result.failed) {
+          console.warn(
+            `[broker-packs] kept previous ${failure.engine} release after update failed: ${failure.error}`,
+          )
+        }
+        if (result.restart && !result.restart.ready) {
+          console.warn('[broker-packs] UTA restart after update did not become ready:', result.restart.error)
+        }
+      })
+      .catch((err) => {
+        console.warn(
+          '[broker-packs] automatic reconciliation failed:',
+          err instanceof Error ? err.message : err,
+        )
+      })
+  }, STARTUP_RECONCILE_DELAY_MS)
+  timer.unref?.()
+}
+
+function automaticReconcileSkipReason(): string | null {
+  if (process.env['OPENALICE_BROKER_PACK_AUTO_UPDATE'] === '0') return 'disabled by environment'
+  if (process.env['NODE_ENV'] === 'test') return 'test runtime'
+  if (process.env['OPENALICE_LAUNCHER'] === 'dev') return 'source development runtime'
+  return null
+}

--- a/src/services/broker-packs/installer.spec.ts
+++ b/src/services/broker-packs/installer.spec.ts
@@ -112,6 +112,36 @@ async function loadInstaller() {
   return import('./installer.js')
 }
 
+async function seedCompatibleCcxtPack(version = '0.84.0-beta', apiVersion = 1) {
+  const { brokerPackEngineRoot } = await import('../../core/broker-packs.js')
+  const engineRoot = brokerPackEngineRoot('ccxt')
+  const release = `${version}-existing`
+  const releaseRoot = resolve(engineRoot, 'releases', release)
+  await mkdir(resolve(releaseRoot, 'dist'), { recursive: true })
+  await writeFile(resolve(engineRoot, 'active.json'), JSON.stringify({
+    schemaVersion: 1,
+    engine: 'ccxt',
+    release,
+    activatedAt: '2026-07-20T00:00:00.000Z',
+  }))
+  await writeFile(resolve(releaseRoot, 'broker-pack.json'), JSON.stringify({
+    schemaVersion: 1,
+    apiVersion,
+    engine: 'ccxt',
+    version,
+    entry: 'dist/index.js',
+    contentId: 'existing',
+    installedAt: '2026-07-20T00:00:00.000Z',
+  }))
+  await writeFile(resolve(releaseRoot, 'package.json'), JSON.stringify({
+    name: '@traderalice/uta-broker-ccxt',
+    version,
+    type: 'module',
+  }))
+  await writeFile(resolve(releaseRoot, 'dist/index.js'), 'export const API_VERSION = 1\n')
+  return { engineRoot, release }
+}
+
 describe('broker-pack installer', () => {
   it('distinguishes built-in, workspace, missing, and broken local status', async () => {
     const { brokerPackEngineRoot } = await import('../../core/broker-packs.js')
@@ -158,6 +188,63 @@ describe('broker-pack installer', () => {
     expect(await readFile(active!.entry, 'utf8')).toContain('API_VERSION = 1')
     expect(await readdir(resolve(brokerPackEngineRoot('ccxt'), 'releases'))).toHaveLength(1)
     expect(await readdir(brokerPackEngineRoot('ccxt'))).not.toContain('.install.lock')
+  })
+
+  it('reports and atomically reconciles a compatible Pack left by the previous app release', async () => {
+    const old = await seedCompatibleCcxtPack()
+    const { version } = await publishCcxtPack()
+    const { getBrokerPackLocalStatus } = await loadInstaller()
+
+    await expect(getBrokerPackLocalStatus('ccxt')).resolves.toMatchObject({
+      installed: true,
+      source: 'downloaded',
+      version: '0.84.0-beta',
+      updateAvailable: true,
+    })
+
+    const { reconcileInstalledBrokerPacks } = await import('./auto-updater.js')
+    await expect(reconcileInstalledBrokerPacks({ force: true, restart: false })).resolves.toEqual({
+      checked: ['ccxt'],
+      updated: ['ccxt'],
+      failed: [],
+    })
+
+    const { resolveActiveBrokerPack } = await import('../../core/broker-packs.js')
+    await expect(resolveActiveBrokerPack('ccxt')).resolves.toMatchObject({
+      manifest: { version },
+    })
+    expect(await readdir(resolve(old.engineRoot, 'releases'))).toContain(old.release)
+    await expect(getBrokerPackLocalStatus('ccxt')).resolves.toMatchObject({
+      installed: true,
+      version,
+      updateAvailable: false,
+    })
+  })
+
+  it('automatically replaces an installed Pack whose declared API is no longer supported', async () => {
+    await seedCompatibleCcxtPack('0.84.0-beta', 0)
+    const { version } = await publishCcxtPack()
+    const { getBrokerPackLocalStatus } = await loadInstaller()
+
+    await expect(getBrokerPackLocalStatus('ccxt')).resolves.toMatchObject({
+      installed: false,
+      source: 'broken',
+      version: '0.84.0-beta',
+      updateAvailable: true,
+      reason: expect.stringMatching(/requires API 1/i),
+    })
+
+    const { reconcileInstalledBrokerPacks } = await import('./auto-updater.js')
+    await expect(reconcileInstalledBrokerPacks({ force: true, restart: false })).resolves.toEqual({
+      checked: ['ccxt'],
+      updated: ['ccxt'],
+      failed: [],
+    })
+    await expect(getBrokerPackLocalStatus('ccxt')).resolves.toMatchObject({
+      installed: true,
+      version,
+      updateAvailable: false,
+    })
   })
 
   it('does not activate a checksum mismatch and cleans staging plus its lock', async () => {

--- a/src/services/broker-packs/installer.ts
+++ b/src/services/broker-packs/installer.ts
@@ -13,6 +13,7 @@ import {
   brokerPackActivePath,
   brokerPackEngineRoot,
   brokerPackReleasesRoot,
+  BrokerPackApiVersionMismatchError,
   resolveActiveBrokerPack,
   resolveBrokerPackRelease,
   type BrokerPackActivePointer,
@@ -36,6 +37,7 @@ export interface BrokerPackLocalStatus {
   installed: boolean
   source: 'builtin' | 'workspace' | 'downloaded' | 'missing' | 'broken'
   version?: string
+  updateAvailable?: boolean
   reason?: string
 }
 
@@ -43,8 +45,26 @@ export async function getBrokerPackLocalStatus(engine: InstallableBrokerEngine |
   if (engine === 'mock') return { engine, installed: true, source: 'builtin', version: getCurrentVersion() }
   try {
     const active = await resolveActiveBrokerPack(engine)
-    if (active) return { engine, installed: true, source: 'downloaded', version: active.manifest.version }
+    if (active) {
+      return {
+        engine,
+        installed: true,
+        source: 'downloaded',
+        version: active.manifest.version,
+        updateAvailable: active.manifest.version !== getCurrentVersion(),
+      }
+    }
   } catch (err) {
+    if (err instanceof BrokerPackApiVersionMismatchError) {
+      return {
+        engine,
+        installed: false,
+        source: 'broken',
+        version: err.installedVersion,
+        updateAvailable: true,
+        reason: err.message,
+      }
+    }
     return { engine, installed: false, source: 'broken', reason: err instanceof Error ? err.message : String(err) }
   }
   if (workspacePacksAvailable()) {
@@ -113,7 +133,13 @@ export async function installBrokerPack(engine: InstallableBrokerEngine): Promis
     const activeTmp = `${activePath}.${process.pid}.tmp`
     await writeFile(activeTmp, JSON.stringify(pointer, null, 2) + '\n')
     await rename(activeTmp, activePath)
-    return { engine, installed: true, source: 'downloaded', version: asset.version }
+    return {
+      engine,
+      installed: true,
+      source: 'downloaded',
+      version: asset.version,
+      updateAvailable: false,
+    }
   } finally {
     await rm(workRoot, { recursive: true, force: true }).catch(() => undefined)
     await rm(lock, { recursive: true, force: true }).catch(() => undefined)

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -549,6 +549,7 @@ export interface BrokerPackStatus {
   installed: boolean
   source: 'builtin' | 'workspace' | 'downloaded' | 'missing' | 'broken'
   version?: string
+  updateAvailable?: boolean
   reason?: string
   requiredBy: string[]
 }

--- a/ui/src/demo/handlers/trading.ts
+++ b/ui/src/demo/handlers/trading.ts
@@ -179,8 +179,8 @@ export const tradingHandlers = [
   http.get('/api/trading/config/broker-presets', () => HttpResponse.json({ presets: demoBrokerPresets })),
   http.get('/api/trading/config/broker-packs', () => HttpResponse.json({
     packs: [
-      { engine: 'mock', installed: true, source: 'builtin', version: 'demo', requiredBy: [] },
-      { engine: 'ccxt', installed: true, source: 'workspace', version: 'demo', requiredBy: [] },
+      { engine: 'mock', installed: true, source: 'builtin', version: 'demo', updateAvailable: false, requiredBy: [] },
+      { engine: 'ccxt', installed: true, source: 'workspace', version: 'demo', updateAvailable: false, requiredBy: [] },
       { engine: 'alpaca', installed: false, source: 'missing', requiredBy: [] },
       { engine: 'ibkr', installed: false, source: 'missing', requiredBy: [] },
       { engine: 'leverup', installed: false, source: 'missing', requiredBy: [] },
@@ -188,7 +188,7 @@ export const tradingHandlers = [
     ],
   })),
   http.post('/api/trading/config/broker-packs/:engine/install', ({ params }) => HttpResponse.json({
-    engine: String(params.engine), installed: true, source: 'downloaded', version: 'demo', requiredBy: [],
+    engine: String(params.engine), installed: true, source: 'downloaded', version: 'demo', updateAvailable: false, requiredBy: [],
   })),
   http.get('/api/trading/config', () => HttpResponse.json({ utas: demoUTAConfigs })),
   http.post('/api/trading/config/uta', () => HttpResponse.json(demoUTAConfig, { status: 201 })),

--- a/ui/src/pages/TradingPage.broker-packs.spec.tsx
+++ b/ui/src/pages/TradingPage.broker-packs.spec.tsx
@@ -41,12 +41,28 @@ describe('MissingBrokerPacksNotice', () => {
       onInstalled={vi.fn()}
     />)
 
-    expect(screen.getByText('Optional broker support is missing')).toBeTruthy()
+    expect(screen.getByText('Broker support needs attention')).toBeTruthy()
     expect(screen.getByText('Required by Main OKX')).toBeTruthy()
     expect(screen.getByText('API version mismatch')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Repair' })).toBeTruthy()
     expect(screen.queryByText('ALPACA')).toBeNull()
     expect(screen.queryByText('IBKR')).toBeNull()
+  })
+
+  it('offers an in-place update while a compatible previous Pack remains installed', () => {
+    render(<MissingBrokerPacksNotice
+      packs={[{
+        ...missingCcxt,
+        installed: true,
+        source: 'downloaded',
+        version: '0.84.0-beta',
+        updateAvailable: true,
+      }]}
+      onInstalled={vi.fn()}
+    />)
+
+    expect(screen.getByText('Installed support is from OpenAlice 0.84.0-beta')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Update' })).toBeTruthy()
   })
 
   it('installs from the notice and reports a failed repair in place', async () => {

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -243,11 +243,13 @@ export function MissingBrokerPacksNotice({ packs, onInstalled }: {
   packs: BrokerPackStatus[]
   onInstalled: (status: BrokerPackStatus) => void
 }) {
-  const missing = packs.filter((pack) => !pack.installed && pack.requiredBy.length > 0)
+  const actionable = packs.filter(
+    (pack) => (!pack.installed || pack.updateAvailable) && pack.requiredBy.length > 0,
+  )
   const [installing, setInstalling] = useState<string | null>(null)
   const [error, setError] = useState('')
 
-  if (missing.length === 0) return null
+  if (actionable.length === 0) return null
 
   const install = async (pack: BrokerPackStatus) => {
     if (pack.engine === 'mock') return
@@ -267,16 +269,21 @@ export function MissingBrokerPacksNotice({ packs, onInstalled }: {
       <div className="flex items-start gap-2.5">
         <AlertTriangle size={15} className="mt-0.5 shrink-0 text-warning" />
         <div className="min-w-0 flex-1">
-          <div className="text-[12px] font-medium text-foreground">Optional broker support is missing</div>
+          <div className="text-[12px] font-medium text-foreground">Broker support needs attention</div>
           <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-            OpenAlice itself can keep running. Install only the integrations used by these accounts or K-line sources.
+            Update or repair only the integrations already used by these accounts or K-line sources.
           </p>
           <div className="mt-3 space-y-2">
-            {missing.map((pack) => (
+            {actionable.map((pack) => (
               <div key={pack.engine} className="flex items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2">
                 <div className="min-w-0">
                   <div className="text-[12px] font-medium uppercase text-foreground">{pack.engine}</div>
                   <div className="truncate text-[11px] text-muted-foreground">Required by {pack.requiredBy.join(', ')}</div>
+                  {pack.updateAvailable && pack.version && (
+                    <div className="mt-0.5 text-[11px] text-warning">
+                      Installed support is from OpenAlice {pack.version}
+                    </div>
+                  )}
                   {pack.reason && <div className="mt-0.5 text-[11px] text-warning">{pack.reason}</div>}
                 </div>
                 <button
@@ -284,7 +291,13 @@ export function MissingBrokerPacksNotice({ packs, onInstalled }: {
                   disabled={installing !== null}
                   onClick={() => { void install(pack) }}
                 >
-                  {installing === pack.engine ? 'Installing…' : pack.source === 'broken' ? 'Repair' : 'Install'}
+                  {installing === pack.engine
+                    ? 'Installing…'
+                    : pack.source === 'broken'
+                      ? 'Repair'
+                      : pack.updateAvailable
+                        ? 'Update'
+                        : 'Install'}
                 </button>
               </div>
             ))}


### PR DESCRIPTION
## Summary
- keep previous-release Broker Packs loadable through the explicit Pack API while current artifacts update atomically
- automatically reconcile only integrations the user already installed, with rollback-safe failure behavior and an Update/Repair UI
- gate releases with real previous GitHub Release artifacts on every supported platform
- record the v0.85 incident, root cause, recovery, and permanent release invariant

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (353 files passed, 3372 tests passed, 1 file/9 tests skipped)
- `pnpm broker-packs:build`
- `pnpm broker-packs:upgrade-smoke -- --from v0.84.0-beta`
- `pnpm electron:smoke:trading-mode`
- demo Trading route in the in-app browser; no console errors

## Boundary touch
- trading runtime, optional Broker Pack installation, Electron packaged startup, and release publication gates
- no broker credentials or live accounts used; no trading writes performed
