### PR TITLE
Fetch release tags for Broker Pack package smoke

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -99,6 +99,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # the N-1 Broker Pack smoke resolves the previous release tag
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Summary
- fetch full tag history in Desktop Package Smoke
- allow the N-1 Broker Pack upgrade gate to resolve the previous public release on Windows

## Verification
- parsed workflow YAML
- 

Follow-up to #736 after the new Windows release gate correctly blocked on a shallow checkout without tags.