### PR TITLE
Prepare the 0.86.0 beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.85.0-beta",
+  "version": "0.86.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/plans/broker-pack-release-safety.md
+++ b/plans/broker-pack-release-safety.md
@@ -44,7 +44,7 @@ safe reconciliation needed before those release cadences can be separated.
 - [x] Add the previous-release Broker Pack upgrade smoke to the release matrix.
 - [x] Record the v0.85 incident and durable owner-guide contract.
 - [x] Complete focused, repository-wide, and packaged verification.
-- [ ] Merge to `dev` and inspect trailing CI.
+- [x] Merge to `dev` and inspect trailing CI.
 - [ ] Prepare, promote, and publish `v0.86.0-beta`.
 - [ ] Verify GitHub Release and CDN artifacts after publication.
 


### PR DESCRIPTION
## Summary
- bump OpenAlice to `0.86.0-beta`
- record that the Broker Pack upgrade correction is integrated on `dev`

## Release acceptance completed locally
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (353 files passed; 3372 tests passed)
- `pnpm broker-packs:build`
- `pnpm broker-packs:upgrade-smoke -- --from v0.85.0-beta` (all five Pack engines upgraded atomically)

The promotion to `master` will wait for this candidate full cross-platform CI and package smoke.