### PR TITLE
docs: close broker pack release safety plan

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,12 +21,13 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/broker-pack-release-safety.md]] — Repairing the v0.85 existing-user
-  Broker Pack upgrade gap and making N-1→N reconciliation a blocking v0.86
-  release contract.
+No active implementation plans.
 
 ## Completed
 
+- [[plans/broker-pack-release-safety.md]] — Repaired the v0.85 existing-user
+  Broker Pack upgrade gap, shipped v0.86.0-beta, and made N-1→N reconciliation
+  a blocking release contract.
 - [[plans/workspace-launch-configuration.md]] — Made the next Workspace runtime
   launch plan inspectable from the existing Workspace settings panel.
 - [[plans/windows-headless-launch.md]] — Safely launches Windows npm Agent

--- a/plans/broker-pack-release-safety.md
+++ b/plans/broker-pack-release-safety.md
@@ -1,6 +1,6 @@
 # Broker Pack Release Safety
 
-Status: Active
+Status: Complete
 
 Related incident:
 [[docs/incidents/2026-07-28-broker-pack-upgrade-gap.md]]
@@ -45,8 +45,8 @@ safe reconciliation needed before those release cadences can be separated.
 - [x] Record the v0.85 incident and durable owner-guide contract.
 - [x] Complete focused, repository-wide, and packaged verification.
 - [x] Merge to `dev` and inspect trailing CI.
-- [ ] Prepare, promote, and publish `v0.86.0-beta`.
-- [ ] Verify GitHub Release and CDN artifacts after publication.
+- [x] Prepare, promote, and publish `v0.86.0-beta`.
+- [x] Verify GitHub Release and CDN artifacts after publication.
 
 ## Verification
 
@@ -61,6 +61,20 @@ safe reconciliation needed before those release cadences can be separated.
 - `pnpm test`
 - `pnpm electron:smoke:packaged --temp-data`
 - release matrix on macOS arm64, macOS x64, Windows x64, and Linux x64
+
+Release evidence:
+
+- GitHub Release:
+  <https://github.com/TraderAlice/OpenAlice/releases/tag/v0.86.0-beta>
+- Release workflow:
+  <https://github.com/TraderAlice/OpenAlice/actions/runs/30360097577>
+- The published tag resolves to master promotion merge `72862d38`.
+- The release contains 20 Broker Pack archives (five engines across four
+  platforms), four platform catalogs, both macOS architectures, and the
+  Windows installer.
+- The public CDN manifest advertises `0.86.0-beta`; versioned desktop
+  installers, update feeds, Broker Pack catalogs and archives, and the
+  release-owned CLI installer returned successfully after mirroring.
 
 ## Completion
 


### PR DESCRIPTION
## Summary

- mark the v0.86 Broker Pack release-safety plan complete
- record the published Release, workflow, tag, asset inventory, and CDN verification
- move the plan from Active to Completed

## Verification

- docs-only change
- git diff --check