### PR TITLE
Clarify Agent conversation semantics and logging

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,13 +21,12 @@ the durable truth after it changes.
 
 ## Active
 
+## Completed
+
 - [[plans/agent-conversation-semantics.md]] — Separates ordinary peer
   conversation from explicit artifact reconstruction, documents synchronous
   and asynchronous delegation, and records cross-Agent exchanges in a
-  dedicated local event log.
-
-## Completed
-
+  dedicated local event log. Delivered in PR #741.
 - [[plans/broker-pack-release-safety.md]] — Repaired the v0.85 existing-user
   Broker Pack upgrade gap, shipped v0.86.0-beta, and made N-1→N reconciliation
   a blocking release contract.

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,7 +21,10 @@ the durable truth after it changes.
 
 ## Active
 
-No active implementation plans.
+- [[plans/agent-conversation-semantics.md]] — Separates ordinary peer
+  conversation from explicit artifact reconstruction, documents synchronous
+  and asynchronous delegation, and records cross-Agent exchanges in a
+  dedicated local event log.
 
 ## Completed
 

--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -20,7 +20,7 @@ Choose the verb from the intent, not from whichever object you happen to have:
 | Inspect the shared work board | `issue list` / `issue show` |
 | Ask an Issue's creator or selected historical run | `issue ask` |
 | Discuss this Workspace's own Issue; notify its fixed owner | `issue comment` |
-| Ask by a known product Session/Workspace only when no business object exists | `conversation ask` |
+| Ask or delegate by product Session/Workspace when no business object exists | `conversation ask` |
 | Bring this desk's managed instructions and skills up to date | `template upgrade` |
 | Inventory every active desk before coordinating the floor | `peer list` |
 
@@ -111,7 +111,9 @@ alice-workspace issue ask --id <issueName> --run-id <taskId> \
 alice-workspace conversation ask --resume-id <resumeId> \
   --prompt 'Explain the missing context.' --await
 alice-workspace conversation ask --ws-id <ws> \
-  --prompt 'Reconstruct why this artifact was produced.' --await
+  --prompt 'Please investigate this bounded question and report back.'
+alice-workspace conversation ask --ws-id <ws> \
+  --prompt 'Reconstruct why this unattributed artifact was produced.' --reconstruct --await
 alice-workspace conversation await --task-id <taskId>
 alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
 alice-workspace conversation read --task-id <taskId>
@@ -123,13 +125,31 @@ requires a stable resume owner, while `--run-id` selects one exact run Session.
 Use the lower-level conversation command only when no business object already
 identifies whom to ask. Never construct or pass an internal target JSON object.
 
-For one question, start with `ask --await`: OpenAlice waits server-side and
-returns the final reply without making you guess a sleep duration. For several
-independent peers, issue every `ask` first without `--await` so all tasks run
-concurrently, then pass every short task id to one `conversation collect` call.
-If collect reports a task still `running`, do other useful work and collect
-again later or use one-shot `conversation read`; never build a shell `sleep`
-polling loop.
+Choose the waiting rhythm from the work:
+
+- **Short consultation needed for the current answer:** use `ask --await`.
+  OpenAlice waits server-side and returns the final reply without a guessed
+  sleep duration.
+- **Delegation that may take a while:** omit `--await`. Keep the returned
+  `taskId`/`resumeId`, continue useful work, and later use `conversation read`
+  or `conversation await`. The peer can create its own local Issue/schedule and
+  push a finished report to Inbox.
+- **Several independent peers:** dispatch every ask first without `--await`,
+  then pass the task ids to one `conversation collect` call.
+- **Human-facing completion:** ask the worker to use `inbox push` when the
+  result should surface in the user's Inbox.
+
+There is not yet an unsolicited Agent-to-Agent completion notification bus.
+Inbox reaches the human; `read`/`await`/`collect` retrieves a dispatched Agent
+reply. If collect reports a task still `running`, do other useful work and
+collect again later or use one-shot `conversation read`; never build a shell
+`sleep` polling loop.
+
+Prompts are delivered as ordinary coworker messages by default. Add
+`--reconstruct` only when the request explicitly asks a fresh fallback worker
+to reconstruct an artifact or decision whose author cannot be resumed. The
+`resolution.mode` may still say `reconstructed` for honest provenance even when
+that optional prompt guidance was not requested.
 
 Inspect `resolution.mode` on the ask result:
 

--- a/default/skills/workspace-manager/SKILL.md
+++ b/default/skills/workspace-manager/SKILL.md
@@ -28,15 +28,18 @@ For one desk or coworker:
 alice-workspace peer path --id <workspaceId>
 alice-workspace peer sessions --id <workspaceId>
 alice-workspace conversation ask --resume-id <resumeId> --prompt "..." --await
-# Only when no attributable Session exists:
-alice-workspace conversation ask --ws-id <workspaceId> --prompt "..." --await
+# Recruit a fresh coworker for new work:
+alice-workspace conversation ask --ws-id <workspaceId> --prompt "..."
+# Explicit historical reconstruction when no attributable Session exists:
+alice-workspace conversation ask --ws-id <workspaceId> --prompt "..." --reconstruct --await
 ```
 
 This distinction is not cosmetic. `--resume-id` continues the exact coworker
-and its working memory. `--ws-id` recruits or reconstructs a worker at that
-desk; it can inspect the Workspace, but it must not impersonate the historical
-owner. Preserve and report `resolution.mode` (`exact` versus `reconstructed`)
-when the difference affects the answer.
+and its working memory. `--ws-id` recruits a fresh worker at that desk. Its
+prompt stays ordinary unless `--reconstruct` explicitly asks it to recover
+missing historical intent; either way it must not impersonate an absent owner.
+Preserve and report `resolution.mode` (`exact` versus `reconstructed`) when the
+difference affects the answer.
 
 Use `alice-workspace <group> <verb> --help` whenever a flag is uncertain. The
 live manifest is authoritative even when an older Workspace carries stale
@@ -51,10 +54,11 @@ instructions.
 - Prefer asking an attributable `resumeId` when one is known. Recent Session
   titles in `peer list` are hints; use `peer sessions --id` only for the few
   relevant desks to resolve the exact identity. Otherwise recruit a worker from
-  the relevant Workspace with `conversation ask --ws-id`, and label the answer
-  as reconstruction rather than the original coworker's memory.
-- Ask several desks in parallel when useful, but use `--await` first and collect
-  the answers before giving the user one management view.
+  the relevant Workspace with `conversation ask --ws-id`. Add `--reconstruct`
+  only for missing historical intent and never claim the fresh worker carries
+  the original coworker's memory.
+- Use `--await` for a short answer needed now. For delegated work or several
+  desks, dispatch first and retrieve/collect the answers later.
 
 ## Mutations require a preview and a clear user instruction
 

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -507,6 +507,7 @@ The embedded generic entry point is:
 alice-workspace conversation ask --resume-id <resumeId> --prompt '<question>'
 alice-workspace conversation ask --issue-id <issueId> [--ws-id <workspaceId>] --prompt '<question>'
 alice-workspace conversation ask --ws-id <workspaceId> --prompt '<question>'
+alice-workspace conversation ask --ws-id <workspaceId> --prompt '<reconstruction request>' --reconstruct
 alice-workspace conversation await --task-id <taskId>
 alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
 alice-workspace conversation read --task-id <taskId>
@@ -528,11 +529,28 @@ inside the resolver and future business-specific convenience commands; agents
 never serialize them into `conversation ask`. The ask result reports a compact
 `resolution.mode`; read returns runtime status and the latest assistant text by
 default. Full tool/message blocks are diagnostic data behind `--mode detailed`.
-For one peer, `ask --await` is the preferred path. For multiple peers, dispatch
-all asks first so their runs overlap, then server-side collect their task ids in
-one ordered result before synthesizing. A timed-out collect preserves every task;
-callers fall back to a later collect/read snapshot instead of scripting arbitrary
-sleeps.
+
+Provenance resolution and prompt semantics are separate. A fallback worker is
+still labeled `reconstructed` so it cannot impersonate a missing author, but
+OpenAlice delivers the caller's prompt unchanged unless `--reconstruct` was
+explicitly requested. The optional flag adds the reconstruction preamble; it
+does not change whom OpenAlice addresses.
+
+Choose waiting behavior from the work rather than treating every ask as a
+blocking follow-up:
+
+- use `--await` for a bounded consultation whose answer is required in the
+  current turn;
+- omit it for delegation, retain the returned `taskId`/`resumeId`, and retrieve
+  the reply later with `read` or `await`;
+- dispatch multiple independent asks before one ordered `collect`;
+- ask a long-running peer to manage its own local Issue/schedule and `inbox
+  push` the finished report when the human should be notified.
+
+Inbox is human-facing delivery. OpenAlice does not yet inject an unsolicited
+completion message into another Agent's active transcript. A timed-out collect
+preserves every task; callers fall back to a later collect/read snapshot instead
+of scripting arbitrary sleeps.
 
 The first fresh reconstruction appends a `reconstructed` occurrence to the
 artifact. Later questions about that same otherwise-unattributed artifact
@@ -548,6 +566,31 @@ pages restore follow-up history after navigation or restart without parsing
 prompts or exposing adapter-native session ids. UI requests return immediately
 after dispatch; the page polls durable task state instead of holding an
 Electron IPC request open for the model turn.
+
+### Independent conversation event log
+
+Every dispatched Workspace conversation also appends a
+`conversation.dispatched` event to
+`<launcherRoot>/state/agent-conversations.jsonl`. Completion appends a matching
+`conversation.completed` event keyed by `taskId`. The stream records:
+
+- authoritative caller Workspace/Session identity when available;
+- target Workspace, product `resumeId`, and Agent runtime;
+- requested target and exact/reconstructed resolution;
+- the original prompt, delivered prompt, and whether explicit reconstruction
+  guidance changed it;
+- terminal status, final assistant text, duration, and compact error.
+
+The file is private launcher state (`0600` where supported), not Workspace Git
+content. It can contain complete prompts and replies and must be treated as
+sensitive local conversation history. Native runtime session ids and raw tool
+blocks never enter it.
+
+`HeadlessTaskRegistry` remains execution truth and structured headless logs
+remain diagnostic truth. The independent event stream is an analysis/audit
+projection for prompt-flow studies and future visualization. A logging failure
+must not block or change message delivery, and the log is not an Agent
+notification mechanism.
 
 ## Phase 2 Feature Design Skeleton
 
@@ -593,6 +636,7 @@ shapes should point back here rather than restating the rules differently.
 | `src/workspaces/session-registry.ts` | Interactive materializations and resume indexes |
 | `src/workspaces/service.ts` | Dispatch, resume, and per-Session concurrency |
 | `src/workspaces/conversation-control.ts` | Provenance resolution plus exact/reconstructed headless dispatch |
+| `src/workspaces/agent-conversation-log.ts` | Private append-only peer-message prompt/reply event stream |
 | `src/tool/conversation.ts` | Embedded business-target ask/read CLI tools |
 | `src/webui/routes/inquiries.ts` | Human Inbox/Issue ask dispatch and durable inquiry projections |
 | `src/core/inbox-store.ts` | Immutable notification records and sender provenance |

--- a/docs/data-locations.md
+++ b/docs/data-locations.md
@@ -26,6 +26,11 @@ homes and unpinned ports. Two writers must never share one home. Default ports
 probe upward independently, while explicitly pinned ports still fail if they
 collide.
 
+Workspace launcher state includes the private
+`workspaces/state/agent-conversations.jsonl` prompt/reply event stream. It moves
+with the complete home, is not part of any Workspace repository, and should be
+treated as sensitive conversation history when backing up or sharing a home.
+
 `AQ_LAUNCHER_ROOT` and `OPENALICE_GLOBAL_DIR` remain advanced split-root
 overrides. A fixed `AQ_LAUNCHER_ROOT` disables desktop home switching because
 changing only the rest of the home would still share Workspace files and

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -262,7 +262,7 @@ sealing, and Broker Packs must remain coherent.
 │   ├── workspaces/            active Workspace repositories only
 │   ├── departed-workspaces/   retained offboarded repositories
 │   ├── state/                 lifecycle catalog, Sessions, scrollback, tasks,
-│   │                          provenance, compatibility lock
+│   │                          provenance, Agent conversation log, compatibility lock
 │   └── auto-quant-mirror/     shared Auto-Quant source mirror
 ├── state/
 │   ├── guardian.lock          launcher ownership

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -316,12 +316,16 @@ assistant reply by default; diagnostic tool/message blocks require
 `--mode detailed`. New task ids are short `run-xxxxxxxx` codes; existing UUID
 task ids remain readable.
 
-Prefer `conversation ask ... --await` for a single follow-up. To question
-several independent Sessions, dispatch every ask first, then collect the tasks
-in one `conversation collect --task-id <a> --task-id <b>` call so the runs
-overlap. If server-side collection reaches its budget while a task still runs,
-use a later collect or one-shot read; agents should not manufacture shell sleep
-loops.
+Use `conversation ask ... --await` when one short follow-up is required for the
+current answer. For work delegated to another desk, omit `--await`, retain the
+returned task and Session ids, and retrieve the reply later; the peer may
+manage longer work through its own Issue/schedule and push a finished report to
+Inbox. To question several independent Sessions, dispatch every ask first, then
+collect the tasks in one `conversation collect --task-id <a> --task-id <b>`
+call so the runs overlap. If server-side collection reaches its budget while a
+task still runs, use a later collect or one-shot read; agents should not
+manufacture shell sleep loops. Add `--reconstruct` only when an unattributed
+artifact explicitly needs reconstruction guidance.
 
 The Issue detail UI treats scheduling as an intrinsic Work item capability.
 `assignee: "@new"` recruits one fresh Session on the first fire and then

--- a/docs/workspace-manager.md
+++ b/docs/workspace-manager.md
@@ -113,16 +113,19 @@ Drill into one selected desk with:
 alice-workspace peer path --id <workspaceId>
 alice-workspace peer sessions --id <workspaceId>
 alice-workspace conversation ask --resume-id <resumeId> --prompt "..." --await
-# Fallback only when no attributable Session exists:
-alice-workspace conversation ask --ws-id <workspaceId> --prompt "..." --await
+# Recruit a fresh coworker for new work:
+alice-workspace conversation ask --ws-id <workspaceId> --prompt "..."
+# Reconstruct missing historical intent explicitly:
+alice-workspace conversation ask --ws-id <workspaceId> --prompt "..." --reconstruct --await
 alice-workspace template upgrade --id <workspaceId>
 ```
 
 `--resume-id` continues the exact coworker and should report
-`resolution.mode: exact`. `--ws-id` recruits or reconstructs a worker whose
-answer may be useful but does not carry the historical owner's memory; the UI
-and manager must preserve that distinction instead of presenting the fallback
-as the original author.
+`resolution.mode: exact`. `--ws-id` recruits a fresh worker whose answer may be
+useful but does not carry an absent historical owner's memory. Prompts remain
+ordinary coworker messages unless `--reconstruct` explicitly requests the
+reconstruction preamble; the UI and manager must preserve the provenance
+distinction instead of presenting a fresh worker as the original author.
 
 The manager may read all peers. Existing command-level protections still apply:
 cross-Workspace mutations require an interactive manager Session, and template

--- a/plans/agent-conversation-semantics.md
+++ b/plans/agent-conversation-semantics.md
@@ -1,6 +1,8 @@
 # Agent Conversation Semantics and Log
 
-Status: Active
+Status: Completed
+
+Delivered by PR #741.
 
 Related issues: none
 
@@ -71,7 +73,7 @@ Not in scope:
 - [x] Update agent-facing guidance and owner docs for collaboration rhythms.
 - [x] Add focused tool, control, store, service, and migration tests.
 - [x] Run required typechecks, suite, and proportional runtime verification.
-- [ ] Publish and merge a serial PR to `dev`.
+- [x] Publish and merge a serial PR to `dev`.
 
 ## Completion Criteria
 

--- a/plans/agent-conversation-semantics.md
+++ b/plans/agent-conversation-semantics.md
@@ -1,0 +1,84 @@
+# Agent Conversation Semantics and Log
+
+Status: Active
+
+Related issues: none
+
+Owner guides: [[docs/conversation-provenance.md]],
+[[docs/workspace-issues-and-scheduling.md]],
+[[docs/workspace-agent-guidance.md]]
+
+## Outcome
+
+One Coding Agent can talk naturally to a coworker in another Workspace without
+receiving artifact-reconstruction instructions unless the caller explicitly
+requests them. Callers can choose a synchronous consultation or asynchronous
+delegation, and every dispatched cross-Agent exchange leaves a private,
+append-only launcher log suitable for later prompt-flow analysis and
+visualization.
+
+## Scope
+
+- Add an explicit reconstruction option to the generic and business-level
+  conversation tools.
+- Preserve provenance resolution independently from whether reconstruction
+  instructions are injected into the delivered prompt.
+- Record cross-Agent dispatch and completion events outside Workspace Git.
+- Document short consultation, asynchronous delegation, later collection, and
+  Inbox delivery as distinct collaboration rhythms.
+- Add the persisted-state migration and focused contract tests.
+
+Not in scope:
+
+- A live Agent-to-Agent notification bus.
+- A conversation-log UI or public query API.
+- A domain-specific AutoQuant task protocol.
+- Replacing headless task, Session, Issue, or Inbox persistence.
+
+## Decisions
+
+1. `reconstructed` remains an honest provenance resolution. Prompt wrapping is
+   a separate explicit `reconstruct` choice.
+2. Plain Workspace asks deliver the caller's prompt unchanged. The
+   reconstruction preamble is added only when resolution requires a fresh
+   worker and the caller requested reconstruction.
+3. The independent log is an append-only JSONL event stream under launcher
+   state. It records both the original and delivered prompts so injection can
+   be analyzed without making the log a dispatch authority.
+4. Headless task state remains execution truth. The conversation log is an
+   analysis/audit projection and must never block a worker if logging fails.
+5. Long-running work should normally be accepted by the peer, managed locally
+   through its own files/Issues/schedules, and surfaced through Inbox. OpenAlice
+   does not yet push an unsolicited completion message into another Agent's
+   active transcript.
+
+## Work
+
+### 1. Conversation semantics
+
+- [x] Add the explicit reconstruction input through CLI/tool/control layers.
+- [x] Keep ordinary fresh and exact peer prompts unwrapped.
+- [x] Preserve reconstruction provenance and artifact attribution.
+
+### 2. Independent exchange log
+
+- [x] Add the append-only log store and migration.
+- [x] Record authoritative caller/target Session identity when available.
+- [x] Record dispatch prompt flow and terminal reply/status events.
+
+### 3. Guidance and verification
+
+- [x] Update agent-facing guidance and owner docs for collaboration rhythms.
+- [x] Add focused tool, control, store, service, and migration tests.
+- [x] Run required typechecks, suite, and proportional runtime verification.
+- [ ] Publish and merge a serial PR to `dev`.
+
+## Completion Criteria
+
+- `conversation ask --ws-id ...` sends a plain prompt by default.
+- `--reconstruct` adds the reconstruction preamble only when a reconstructed
+  worker is used.
+- Every conversation dispatch and completion is represented in the private
+  conversation event log without exposing native runtime ids.
+- Guidance distinguishes waiting for a short answer, collecting a dispatched
+  reply later, and asking the peer to deliver completed work through Inbox.

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -66,6 +66,14 @@ export type WorkspaceConversationTarget =
       workspaceId?: string
     }
 
+/** Safe identity of whoever initiated one cross-Workspace message. Product
+ * Session origins are authoritative when the caller is an Agent. Workspace and
+ * human fallbacks keep manual/UI dispatches honest without inventing a Session. */
+export type WorkspaceConversationCaller =
+  | SessionOrigin
+  | { kind: 'workspace'; workspaceId: string }
+  | { kind: 'human' }
+
 export type WorkspaceConversationResolution =
   | {
       mode: 'exact'
@@ -130,6 +138,12 @@ export interface WorkspaceConversationControl {
     readonly timeoutMs: number
     readonly target: WorkspaceConversationTarget
     readonly agent?: string
+    /** Add the artifact-reconstruction preamble when a fresh fallback worker is
+     * required. Provenance may still resolve as reconstructed when this is
+     * false; prompt semantics and attribution are deliberately independent. */
+    readonly reconstruct?: boolean
+    /** Authoritative caller identity for the independent conversation log. */
+    readonly source?: WorkspaceConversationCaller
     /** Optional business reverse link persisted with the dispatched task. */
     readonly subject?: HeadlessInquirySubject
   }): Promise<WorkspaceConversationAskResult>

--- a/src/migrations/0026_agent_conversation_log/index.spec.ts
+++ b/src/migrations/0026_agent_conversation_log/index.spec.ts
@@ -1,0 +1,27 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ensureAgentConversationLog } from './index.js'
+
+const dirs: string[] = []
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('0026_agent_conversation_log', () => {
+  it('creates one private empty event stream and is idempotent', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'migration-conversation-log-'))
+    dirs.push(root)
+    const path = join(root, 'state', 'agent-conversations.jsonl')
+
+    await expect(ensureAgentConversationLog(root)).resolves.toEqual({ created: true })
+    await expect(ensureAgentConversationLog(root)).resolves.toEqual({ created: false })
+    await expect(readFile(path, 'utf8')).resolves.toBe('')
+    if (process.platform !== 'win32') {
+      expect((await stat(path)).mode & 0o777).toBe(0o600)
+    }
+  })
+})

--- a/src/migrations/0026_agent_conversation_log/index.ts
+++ b/src/migrations/0026_agent_conversation_log/index.ts
@@ -1,0 +1,41 @@
+/** 0026_agent_conversation_log — create the private cross-Agent event stream. */
+import { access, mkdir, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import type { Migration } from '../types.js'
+
+function defaultLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+export async function ensureAgentConversationLog(
+  launcherRoot: string = defaultLauncherRoot(),
+): Promise<{ created: boolean }> {
+  const path = join(launcherRoot, 'state', 'agent-conversations.jsonl')
+  try {
+    await access(path)
+    return { created: false }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') return { created: false }
+  }
+
+  await mkdir(dirname(path), { recursive: true })
+  try {
+    await writeFile(path, '', { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+    return { created: true }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return { created: false }
+    throw err
+  }
+}
+
+export const migration: Migration = {
+  id: '0026_agent_conversation_log',
+  appVersion: '0.87.0-beta',
+  introducedAt: '2026-07-29',
+  affects: ['workspaces/state/agent-conversations.jsonl'],
+  summary: 'Create the private append-only cross-Agent conversation event log.',
+  rationale: 'Prompt-flow analysis and future collaboration visualization need one independent record of dispatched and completed peer messages without treating the log as execution authority.',
+  up: async () => { await ensureAgentConversationLog() },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -25,3 +25,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0023_google_native_credentials` | 0.81.0-beta | 2026-07-16 | ai-provider-manager.json | Route saved Google Gemini credentials through the native API so current AQ authorization keys work. |
 | `0024_pi_native_workspace_config` | 0.82.0-beta | 2026-07-18 | workspaces/workspaces/*/.pi-agent, workspaces/departed-workspaces/*/.pi-agent, Pi user agent directory | Move redirected Pi Workspace homes into Pi's native global-provider and project-settings layers. |
 | `0025_retire_global_compaction_config` | 0.83.0-beta | 2026-07-19 | compaction.json, ai-provider-manager.json | Remove retired global context and compaction limits so model and native Agent runtime semantics remain authoritative. |
+| `0026_agent_conversation_log` | 0.87.0-beta | 2026-07-29 | workspaces/state/agent-conversations.jsonl | Create the private append-only cross-Agent conversation event log. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -37,6 +37,7 @@ import { migration as migration_0022_connector_service_config } from './0022_con
 import { migration as migration_0023_google_native_credentials } from './0023_google_native_credentials/index.js'
 import { migration as migration_0024_pi_native_workspace_config } from './0024_pi_native_workspace_config/index.js'
 import { migration as migration_0025_retire_global_compaction_config } from './0025_retire_global_compaction_config/index.js'
+import { migration as migration_0026_agent_conversation_log } from './0026_agent_conversation_log/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -57,4 +58,5 @@ export const REGISTRY: Migration[] = [
   migration_0023_google_native_credentials,
   migration_0024_pi_native_workspace_config,
   migration_0025_retire_global_compaction_config,
+  migration_0026_agent_conversation_log,
 ]

--- a/src/tool/conversation-artifacts.spec.ts
+++ b/src/tool/conversation-artifacts.spec.ts
@@ -66,6 +66,7 @@ describe('inbox_ask', () => {
       target: { kind: 'resume', resumeId: 'resume-peer' },
       subject: { kind: 'inbox', entryId: entry.id },
       timeoutMs: 300_000,
+      source: { kind: 'workspace', workspaceId: 'ws-caller' },
     })
   })
 
@@ -81,6 +82,18 @@ describe('inbox_ask', () => {
     expect(ask).toHaveBeenCalledWith(expect.objectContaining({
       target: { kind: 'inbox', inboxEntryId: entry.id, workspaceId: 'ws-peer' },
     }))
+  })
+
+  it('forwards an explicit reconstruction request', async () => {
+    const inboxStore = createMemoryInboxStore()
+    const entry = await inboxStore.append({ workspaceId: 'ws-peer', comments: 'manual result' })
+    const ask = dispatchedAsk()
+    const tool = inboxAskFactory.build(baseContext({
+      inboxStore,
+      conversation: { ask, read: vi.fn() },
+    }))
+    await run(tool, { id: entry.id, prompt: 'reconstruct this', reconstruct: true })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({ reconstruct: true }))
   })
 })
 

--- a/src/tool/conversation-artifacts.ts
+++ b/src/tool/conversation-artifacts.ts
@@ -26,13 +26,22 @@ export const inboxAskFactory: WorkspaceToolFactory = {
         'The entry id is enough: OpenAlice resolves server-stamped provenance. A known',
         'Session is resumed exactly. An entry without an attributable Session recruits a',
         'fresh worker only in its source Workspace and labels the answer reconstructed.',
-        'Prefer --await for one entry; dispatch several without it before collecting them.',
+        'Use --await for a reply needed now; omit it for asynchronous follow-up or',
+        'several parallel questions. Add --reconstruct only when reconstruction',
+        'guidance for an unattributed entry is explicitly intended.',
       ].join('\n'),
       inputSchema: z.object({
         id: z.string().min(1).describe('Inbox entry id returned by inbox read.'),
         ...conversationAskCommonShape,
       }),
-      execute: async ({ id, prompt, agent, timeoutMs, await: shouldAwait = false }) => {
+      execute: async ({
+        id,
+        prompt,
+        agent,
+        timeoutMs,
+        await: shouldAwait = false,
+        reconstruct = false,
+      }) => {
         try {
           const entry = await ctx.inboxStore.get(id)
           if (!entry) return { ok: false as const, error: `inbox entry not found: ${id}` }
@@ -51,6 +60,7 @@ export const inboxAskFactory: WorkspaceToolFactory = {
             ...(agent ? { agent } : {}),
             ...(timeoutMs ? { timeoutMs } : {}),
             await: shouldAwait,
+            reconstruct,
           })
           return withSubject({ kind: 'inbox', id: entry.id }, result)
         } catch (err) {
@@ -71,6 +81,7 @@ export const issueAskFactory: WorkspaceToolFactory = {
         'The Issue name resolves across the global board. Omit selectors to ask its creator;',
         'use --owner for a stable resume owner or --run-id for one exact execution Session.',
         'A duplicate Issue name returns candidates; add --ws-id only to disambiguate.',
+        'Add --reconstruct only when a fallback worker should explicitly reconstruct missing intent.',
       ].join('\n'),
       inputSchema: z.object({
         id: z.string().min(1).describe('Issue id or title, resolved across the global board.'),
@@ -90,6 +101,7 @@ export const issueAskFactory: WorkspaceToolFactory = {
         agent,
         timeoutMs,
         await: shouldAwait = false,
+        reconstruct = false,
       }) => {
         if (!ctx.board) return { ok: false as const, error: 'global issue board is unavailable' }
         const selectorCount = Number(creator) + Number(owner) + Number(Boolean(runId))
@@ -166,6 +178,7 @@ export const issueAskFactory: WorkspaceToolFactory = {
             ...(agent ? { agent } : {}),
             ...(timeoutMs ? { timeoutMs } : {}),
             await: shouldAwait,
+            reconstruct,
           })
           return withSubject({
             kind: 'issue',

--- a/src/tool/conversation.spec.ts
+++ b/src/tool/conversation.spec.ts
@@ -58,7 +58,12 @@ describe('conversation_ask', () => {
     await expect(run(tool, { prompt: 'why?', wsId: 'ws-peer', issueId: 'audit' })).resolves.toMatchObject({
       ok: true, status: 'running', taskId: 'task-1', resolution: { mode: 'exact' },
     })
-    expect(ask).toHaveBeenCalledWith({ prompt: 'why?', target, timeoutMs: 300_000 })
+    expect(ask).toHaveBeenCalledWith({
+      prompt: 'why?',
+      target,
+      timeoutMs: 300_000,
+      source: { kind: 'workspace', workspaceId: 'ws-caller' },
+    })
   })
 
   it('surfaces unavailable attribution without starting another worker', async () => {
@@ -92,6 +97,60 @@ describe('conversation_ask', () => {
     })).resolves.toMatchObject({
       ok: false, error: expect.stringContaining('choose one target'),
     })
+  })
+
+  it('passes reconstruction guidance only when explicitly requested', async () => {
+    const ask = vi.fn(async () => ({
+      status: 'dispatched' as const,
+      taskId: 'task-1', resumeId: 'resume-1', workspaceId: 'ws-peer',
+      workspace: 'peer', agent: 'pi',
+      resolution: {
+        mode: 'reconstructed' as const,
+        workspaceId: 'ws-peer',
+        reason: 'explicit-workspace' as const,
+      },
+    }))
+    const tool = conversationAskFactory.build(context({
+      conversation: { ask, read: vi.fn() },
+    }))
+
+    await run(tool, {
+      prompt: 'Reconstruct the missing report.', wsId: 'ws-peer', reconstruct: true,
+    })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({ reconstruct: true }))
+  })
+
+  it('stamps the authoritative caller Session into the dispatch', async () => {
+    const ask = vi.fn(async () => ({
+      status: 'dispatched' as const,
+      taskId: 'task-1', resumeId: 'resume-peer', workspaceId: 'ws-peer',
+      workspace: 'peer', agent: 'pi',
+      resolution: {
+        mode: 'reconstructed' as const,
+        workspaceId: 'ws-peer',
+        reason: 'explicit-workspace' as const,
+      },
+    }))
+    const tool = conversationAskFactory.build(context({
+      origin: {
+        kind: 'headless',
+        runId: 'run-caller',
+        resumeId: 'resume-caller',
+        agent: 'codex',
+      },
+      conversation: { ask, read: vi.fn() },
+    }))
+
+    await run(tool, { prompt: 'Please take this work.', wsId: 'ws-peer' })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({
+      source: {
+        kind: 'session',
+        workspaceId: 'ws-caller',
+        resumeId: 'resume-caller',
+        agent: 'codex',
+        execution: { kind: 'headless', taskId: 'run-caller' },
+      },
+    }))
   })
 
   it('awaits a recorded task server-side and returns its final reply', async () => {

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceToolContext,
   WorkspaceToolFactory,
 } from '../core/workspace-tool-center.js'
+import { sessionOriginFromInboxOrigin } from '../core/provenance-store.js'
 import type { HeadlessMessageBlock } from '../workspaces/headless-output.js'
 import type { HeadlessInquirySubject } from '../workspaces/headless-task-registry.js'
 
@@ -24,7 +25,9 @@ export const conversationAskCommonShape = {
   timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
     .describe(`Headless watchdog in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
   await: z.boolean().optional().default(false)
-    .describe('Wait server-side for the final reply; on timeout, return the taskId for later await/read.'),
+    .describe('Wait server-side for a reply needed now; omit for asynchronous delegation and use the returned taskId later.'),
+  reconstruct: z.boolean().optional().default(false)
+    .describe('Explicitly add artifact-reconstruction guidance if OpenAlice must recruit a fallback worker.'),
 }
 
 function taskProjection(task: WorkspaceConversationTask, mode: 'summary' | 'detailed') {
@@ -79,6 +82,7 @@ export async function askWorkspaceConversation(
     agent?: string
     timeoutMs?: number
     await?: boolean
+    reconstruct?: boolean
   },
 ) {
   if (!ctx.conversation) {
@@ -90,8 +94,13 @@ export async function askWorkspaceConversation(
       prompt: input.prompt,
       target: input.target,
       timeoutMs: effectiveTimeoutMs,
+      source: sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin) ?? {
+        kind: 'workspace',
+        workspaceId: ctx.workspaceId,
+      },
       ...(input.subject ? { subject: input.subject } : {}),
       ...(input.agent ? { agent: input.agent } : {}),
+      ...(input.reconstruct ? { reconstruct: true } : {}),
     })
     if (result.status === 'unavailable') {
       return {
@@ -146,9 +155,12 @@ export const conversationAskFactory: WorkspaceToolFactory = {
         'The CLI exposes these as --resume-id, --issue-id, and --ws-id. It never requires',
         'callers to construct an internal target object.',
         '',
-        'Prefer --await for one question: the server waits without shell sleep loops.',
-        'Without --await the call returns a short taskId immediately, which lets several',
-        'questions run concurrently before conversation_await collects their replies.',
+        'Use --await when this turn needs the reply. Without it, the call returns a',
+        'short taskId immediately for delegated work or several concurrent questions;',
+        'retrieve those replies later with conversation_read/await/collect.',
+        '',
+        'Prompts are delivered unchanged by default. Use --reconstruct only when the',
+        'intent is to have a fresh worker reconstruct an artifact whose author is absent.',
       ].join('\n'),
       inputSchema: z.object({
         ...conversationAskCommonShape,
@@ -159,7 +171,16 @@ export const conversationAskFactory: WorkspaceToolFactory = {
         issueId: z.string().min(1).optional()
           .describe('Issue whose attributable Session should answer. Defaults to the current Workspace.'),
       }),
-      execute: async ({ prompt, resumeId, wsId, issueId, agent, timeoutMs, await: shouldAwait = false }) => {
+      execute: async ({
+        prompt,
+        resumeId,
+        wsId,
+        issueId,
+        agent,
+        timeoutMs,
+        await: shouldAwait = false,
+        reconstruct = false,
+      }) => {
         if (!ctx.conversation) {
           return { ok: false as const, error: 'workspace conversation control is unavailable' }
         }
@@ -186,6 +207,7 @@ export const conversationAskFactory: WorkspaceToolFactory = {
           ...(agent ? { agent } : {}),
           ...(timeoutMs ? { timeoutMs } : {}),
           await: shouldAwait,
+          reconstruct,
         })
       },
     })

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -399,6 +399,7 @@ export const issueCommentFactory: WorkspaceToolFactory = {
             issue: res.issue,
             comment: res.comment,
             ...(origin ? { authorResumeId: origin.resumeId } : {}),
+            source: origin ?? { kind: 'workspace', workspaceId: ctx.workspaceId },
           })
           if (dispatched.status !== 'not_requested') {
             const updated = await updateIssueCommentDelivery(

--- a/src/webui/routes/inquiries.spec.ts
+++ b/src/webui/routes/inquiries.spec.ts
@@ -17,6 +17,8 @@ function build(opts: { assignee?: string } = {}) {
     _issueId?: string,
     _resumeId?: string,
     _inquiry?: HeadlessTaskInquiry,
+    _overrides?: unknown,
+    _conversation?: unknown,
   ) => ({ taskId: 'run-new', resumeId: _resumeId ?? 'resume-new' }))
   const list = vi.fn((_filters: unknown) => [] as HeadlessTaskRecord[])
   const svc = {
@@ -73,10 +75,17 @@ describe('business inquiry routes', () => {
         question: 'Why?',
         resolution: { mode: 'exact' },
       }),
+      undefined,
+      expect.objectContaining({
+        source: { kind: 'human' },
+        originalPrompt: 'Why?',
+        deliveredPrompt: 'Why?',
+        promptMode: 'plain',
+      }),
     )
   })
 
-  it('reconstructs an unattributed Inbox entry without impersonating a sender', async () => {
+  it('keeps reconstruction provenance without changing an unattributed Inbox prompt by default', async () => {
     const { app, inboxStore, dispatchHeadlessTask } = build()
     const entry = await inboxStore.append({ workspaceId: 'ws-1', comments: 'manual note' })
     const response = await app.request(`/inbox/${entry.id}`, {
@@ -84,8 +93,26 @@ describe('business inquiry routes', () => {
     })
     expect(response.status).toBe(202)
     expect((await json(response)).resolution.mode).toBe('reconstructed')
+    expect(dispatchHeadlessTask.mock.calls[0]?.[2]).toBe('Recover context')
     expect(dispatchHeadlessTask.mock.calls[0]?.[5]).toBeUndefined()
     expect(dispatchHeadlessTask.mock.calls[0]?.[6]?.resolution).toMatchObject({ mode: 'reconstructed' })
+  })
+
+  it('adds reconstruction guidance when the UI request explicitly opts in', async () => {
+    const { app, inboxStore, dispatchHeadlessTask } = build()
+    const entry = await inboxStore.append({ workspaceId: 'ws-1', comments: 'manual note' })
+    const response = await app.request(`/inbox/${entry.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Recover context', reconstruct: true }),
+    })
+    expect(response.status).toBe(202)
+    expect(dispatchHeadlessTask.mock.calls[0]?.[2]).toContain('fresh worker reconstructing')
+    expect(dispatchHeadlessTask.mock.calls[0]?.[8]).toMatchObject({
+      source: { kind: 'human' },
+      originalPrompt: 'Recover context',
+      promptMode: 'reconstruction',
+    })
   })
 
   it('rejects Ask owner for a Workspace-owned Issue', async () => {

--- a/src/webui/routes/inquiries.ts
+++ b/src/webui/routes/inquiries.ts
@@ -29,12 +29,16 @@ function validId(id: string | undefined): id is string {
   return typeof id === 'string' && /^[a-zA-Z0-9_-]+$/.test(id)
 }
 
-async function promptFromRequest(c: import('hono').Context): Promise<string | null> {
+async function promptFromRequest(
+  c: import('hono').Context,
+): Promise<{ prompt: string; reconstruct: boolean } | null> {
   try {
-    const body = await c.req.json() as { prompt?: unknown }
+    const body = await c.req.json() as { prompt?: unknown; reconstruct?: unknown }
     if (typeof body.prompt !== 'string') return null
     const prompt = body.prompt.trim()
-    return prompt.length > 0 && prompt.length <= MAX_PROMPT_CHARS ? prompt : null
+    return prompt.length > 0 && prompt.length <= MAX_PROMPT_CHARS
+      ? { prompt, reconstruct: body.reconstruct === true }
+      : null
   } catch {
     return null
   }
@@ -89,8 +93,8 @@ export function createInquiryRoutes(deps: InquiryRoutesDeps): Hono {
 
   app.post('/inbox/:id', async (c) => {
     const id = c.req.param('id')
-    const prompt = await promptFromRequest(c)
-    if (!prompt) return c.json({ error: 'invalid_prompt', message: 'prompt must be 1-16000 characters' }, 400)
+    const request = await promptFromRequest(c)
+    if (!request) return c.json({ error: 'invalid_prompt', message: 'prompt must be 1-16000 characters' }, 400)
     const entry = await deps.inboxStore.get(id)
     if (!entry) return c.json({ error: 'not_found' }, 404)
     const origin = resolveInboxOrigin(entry)
@@ -99,9 +103,11 @@ export function createInquiryRoutes(deps: InquiryRoutesDeps): Hono {
       : { kind: 'inbox' as const, inboxEntryId: entry.id, workspaceId: entry.workspaceId }
     try {
       const result = await conversation.ask({
-        prompt,
+        prompt: request.prompt,
         target,
         timeoutMs: DEFAULT_TIMEOUT_MS,
+        source: { kind: 'human' },
+        ...(request.reconstruct ? { reconstruct: true } : {}),
         subject: { kind: 'inbox', entryId: entry.id },
       })
       if (result.status === 'unavailable') {
@@ -125,7 +131,7 @@ export function createInquiryRoutes(deps: InquiryRoutesDeps): Hono {
     const wsId = c.req.param('wsId')
     const id = c.req.param('id')
     if (!validId(wsId) || !validId(id)) return c.json({ error: 'not_found' }, 404)
-    let body: { prompt?: unknown; relation?: unknown; runId?: unknown }
+    let body: { prompt?: unknown; relation?: unknown; runId?: unknown; reconstruct?: unknown }
     try {
       body = await c.req.json() as typeof body
     } catch {
@@ -167,7 +173,14 @@ export function createInquiryRoutes(deps: InquiryRoutesDeps): Hono {
       ...(runId ? { runId } : {}),
     }
     try {
-      const result = await conversation.ask({ prompt, target, timeoutMs: DEFAULT_TIMEOUT_MS, subject })
+      const result = await conversation.ask({
+        prompt,
+        target,
+        timeoutMs: DEFAULT_TIMEOUT_MS,
+        source: { kind: 'human' },
+        ...(body.reconstruct === true ? { reconstruct: true } : {}),
+        subject,
+      })
       if (result.status === 'unavailable') {
         return c.json({ error: 'unavailable', resolution: result.resolution }, 409)
       }

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -312,6 +312,7 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
         issueWorkspaceId: wsId,
         issue: res.issue,
         comment: res.comment,
+        source: { kind: 'human' },
       })
       if (dispatched.status !== 'not_requested') {
         const updated = await updateIssueCommentDelivery(meta.dir, id, res.comment.id, dispatched.delivery)

--- a/src/workspaces/agent-conversation-log.spec.ts
+++ b/src/workspaces/agent-conversation-log.spec.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  AgentConversationLog,
+  type AgentConversationLogEvent,
+} from './agent-conversation-log.js'
+
+const dirs: string[] = []
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('AgentConversationLog', () => {
+  it('appends safe dispatch and completion events in order', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agent-conversation-log-'))
+    dirs.push(dir)
+    const path = join(dir, 'state', 'agent-conversations.jsonl')
+    const logger = { warn: vi.fn() }
+    const log = new AgentConversationLog(path, logger)
+
+    await Promise.all([
+      log.recordDispatch({
+        taskId: 'run-1',
+        resumeId: 'resume-peer',
+        workspaceId: 'ws-peer',
+        agent: 'pi',
+        startedAt: 10,
+        conversation: {
+          source: {
+            kind: 'session',
+            workspaceId: 'ws-chat',
+            resumeId: 'resume-chat',
+            agent: 'codex',
+            execution: { kind: 'interactive', sessionRecordId: 'session-chat' },
+          },
+          requestedTarget: { kind: 'workspace', workspaceId: 'ws-peer' },
+          originalPrompt: 'Research this.',
+          deliveredPrompt: 'Research this.',
+          promptMode: 'plain',
+          resolution: {
+            mode: 'reconstructed',
+            workspaceId: 'ws-peer',
+            reason: 'explicit-workspace',
+          },
+        },
+      }),
+      log.recordCompletion({
+        taskId: 'run-1',
+        status: 'done',
+        finishedAt: 20,
+        assistantText: 'Accepted.',
+        durationMs: 10,
+      }),
+    ])
+
+    const events = (await readFile(path, 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as AgentConversationLogEvent)
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      type: 'conversation.dispatched',
+      taskId: 'run-1',
+      source: { workspaceId: 'ws-chat', resumeId: 'resume-chat' },
+      target: { workspaceId: 'ws-peer', resumeId: 'resume-peer' },
+      prompt: { original: 'Research this.', delivered: 'Research this.', mode: 'plain' },
+    })
+    expect(events[1]).toMatchObject({
+      type: 'conversation.completed',
+      taskId: 'run-1',
+      status: 'done',
+      assistantText: 'Accepted.',
+    })
+    expect(events.some((event) => JSON.stringify(event).includes('native'))).toBe(false)
+    expect(logger.warn).not.toHaveBeenCalled()
+
+    if (process.platform !== 'win32') {
+      expect((await stat(path)).mode & 0o777).toBe(0o600)
+    }
+  })
+})

--- a/src/workspaces/agent-conversation-log.ts
+++ b/src/workspaces/agent-conversation-log.ts
@@ -1,0 +1,171 @@
+/**
+ * Append-only cross-Agent conversation log.
+ *
+ * HeadlessTaskRegistry remains execution truth for every automation/manual
+ * run. This separate stream records only messages dispatched through the
+ * Workspace conversation surface, preserving the original prompt, the prompt
+ * actually delivered after optional host guidance, safe product identities,
+ * and the terminal assistant reply. It is an analysis/audit projection for
+ * future prompt-flow inspection and visualization, never a dispatch authority.
+ *
+ * The log is launcher-owned and private (0600). Native runtime session ids and
+ * tool blocks do not enter it.
+ */
+import { randomUUID } from 'node:crypto'
+import { appendFile, mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+import type {
+  WorkspaceConversationCaller,
+  WorkspaceConversationResolution,
+  WorkspaceConversationTarget,
+} from '../core/workspace-tool-center.js'
+import type {
+  HeadlessInquirySubject,
+  HeadlessTaskStatus,
+} from './headless-task-registry.js'
+
+interface LoggerLike {
+  warn(message: string, meta?: Record<string, unknown>): void
+}
+
+export interface AgentConversationDispatch {
+  readonly source: WorkspaceConversationCaller
+  readonly requestedTarget: WorkspaceConversationTarget
+  readonly originalPrompt: string
+  readonly deliveredPrompt: string
+  readonly promptMode: 'plain' | 'reconstruction'
+  readonly resolution: Exclude<WorkspaceConversationResolution, { mode: 'unavailable' }>
+  readonly subject?: HeadlessInquirySubject
+}
+
+export interface AgentConversationDispatchedEvent {
+  readonly schemaVersion: 1
+  readonly eventId: string
+  readonly type: 'conversation.dispatched'
+  readonly at: number
+  readonly taskId: string
+  readonly parentTaskId?: string
+  readonly source: WorkspaceConversationCaller
+  readonly target: {
+    readonly workspaceId: string
+    readonly resumeId: string
+    readonly agent: string
+  }
+  readonly requestedTarget: WorkspaceConversationTarget
+  readonly resolution: {
+    readonly mode: 'exact' | 'reconstructed'
+    readonly reason?: string
+  }
+  readonly prompt: {
+    readonly original: string
+    readonly delivered: string
+    readonly mode: 'plain' | 'reconstruction'
+  }
+  readonly subject?: HeadlessInquirySubject
+}
+
+export interface AgentConversationCompletedEvent {
+  readonly schemaVersion: 1
+  readonly eventId: string
+  readonly type: 'conversation.completed'
+  readonly at: number
+  readonly taskId: string
+  readonly status: HeadlessTaskStatus
+  readonly assistantText: string | null
+  readonly durationMs?: number
+  readonly error?: string
+}
+
+export type AgentConversationLogEvent =
+  | AgentConversationDispatchedEvent
+  | AgentConversationCompletedEvent
+
+export class AgentConversationLog {
+  private appendChain: Promise<void> = Promise.resolve()
+
+  constructor(
+    private readonly path: string,
+    private readonly logger: LoggerLike,
+  ) {}
+
+  async recordDispatch(input: {
+    readonly taskId: string
+    readonly parentTaskId?: string
+    readonly resumeId: string
+    readonly workspaceId: string
+    readonly agent: string
+    readonly startedAt: number
+    readonly conversation: AgentConversationDispatch
+  }): Promise<void> {
+    const reason = input.conversation.resolution.mode === 'reconstructed'
+      ? input.conversation.resolution.reason
+      : undefined
+    await this.append({
+      schemaVersion: 1,
+      eventId: randomUUID(),
+      type: 'conversation.dispatched',
+      at: input.startedAt,
+      taskId: input.taskId,
+      ...(input.parentTaskId ? { parentTaskId: input.parentTaskId } : {}),
+      source: input.conversation.source,
+      target: {
+        workspaceId: input.workspaceId,
+        resumeId: input.resumeId,
+        agent: input.agent,
+      },
+      requestedTarget: input.conversation.requestedTarget,
+      resolution: {
+        mode: input.conversation.resolution.mode,
+        ...(reason ? { reason } : {}),
+      },
+      prompt: {
+        original: input.conversation.originalPrompt,
+        delivered: input.conversation.deliveredPrompt,
+        mode: input.conversation.promptMode,
+      },
+      ...(input.conversation.subject ? { subject: input.conversation.subject } : {}),
+    })
+  }
+
+  async recordCompletion(input: {
+    readonly taskId: string
+    readonly status: HeadlessTaskStatus
+    readonly finishedAt: number
+    readonly assistantText: string | null
+    readonly durationMs?: number
+    readonly error?: string
+  }): Promise<void> {
+    await this.append({
+      schemaVersion: 1,
+      eventId: randomUUID(),
+      type: 'conversation.completed',
+      at: input.finishedAt,
+      taskId: input.taskId,
+      status: input.status,
+      assistantText: input.assistantText,
+      ...(input.durationMs !== undefined ? { durationMs: input.durationMs } : {}),
+      ...(input.error ? { error: input.error } : {}),
+    })
+  }
+
+  private async append(event: AgentConversationLogEvent): Promise<void> {
+    const next = this.appendChain.then(async () => {
+      try {
+        await mkdir(dirname(this.path), { recursive: true })
+        await appendFile(this.path, `${JSON.stringify(event)}\n`, {
+          encoding: 'utf8',
+          mode: 0o600,
+        })
+      } catch (err) {
+        this.logger.warn('agent_conversation_log.append_failed', {
+          taskId: event.taskId,
+          type: event.type,
+          err,
+        })
+      }
+    })
+    this.appendChain = next.catch(() => undefined)
+    await next
+  }
+}

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -155,6 +155,7 @@ describe('CLI launchers and payload', () => {
                 issueId: { type: 'string' },
                 accountId: { type: 'string' },
                 await: { type: 'boolean' },
+                reconstruct: { type: 'boolean' },
                 taskId: { type: 'array', items: { type: 'string' } },
                 docs: { type: 'array', items: { type: 'object' } },
                 metadataFilter: { type: 'object' },
@@ -193,6 +194,8 @@ describe('CLI launchers and payload', () => {
       expect(help.stdout).toContain('--issue-id')
       expect(help.stdout).toContain('--await')
       expect(help.stdout).not.toContain('--await <boolean>')
+      expect(help.stdout).toContain('--reconstruct')
+      expect(help.stdout).not.toContain('--reconstruct <boolean>')
       expect(help.stdout).toContain('--task-id <value> (repeatable)')
       expect(help.stdout).not.toContain('--task-id <array>')
       expect(help.stdout).not.toContain('--issueId')
@@ -202,7 +205,8 @@ describe('CLI launchers and payload', () => {
       expect(help.stdout).not.toContain('--metadata-filter')
 
       await runCli('alice-workspace', [
-        'provenance', 'show', '--issue-id', 'audit', '--account-id', 'alpaca-paper', '--await',
+        'provenance', 'show', '--issue-id', 'audit', '--account-id', 'alpaca-paper',
+        '--await', '--reconstruct',
         '--task-id', 'run-a', '--task-id', 'run-b',
         '--doc', 'research/a.md', '--meta', 'ticker=AAPL',
       ], env)
@@ -212,6 +216,7 @@ describe('CLI launchers and payload', () => {
           issueId: 'audit',
           accountId: 'alpaca-paper',
           await: true,
+          reconstruct: true,
           taskId: ['run-a', 'run-b'],
           docs: [{ path: 'research/a.md' }],
           metadataFilter: { ticker: 'AAPL' },

--- a/src/workspaces/conversation-control.spec.ts
+++ b/src/workspaces/conversation-control.spec.ts
@@ -165,11 +165,23 @@ describe('Workspace conversation control', () => {
       resolution: { mode: 'exact', origin },
     })
     expect(dispatchHeadlessTask).toHaveBeenCalledWith(
-      workspace, adapter, 'Why did you create this?', 300_000, undefined, 'resume-peer',
+      workspace,
+      adapter,
+      'Why did you create this?',
+      300_000,
+      undefined,
+      'resume-peer',
+      undefined,
+      undefined,
+      expect.objectContaining({
+        originalPrompt: 'Why did you create this?',
+        deliveredPrompt: 'Why did you create this?',
+        promptMode: 'plain',
+      }),
     )
   })
 
-  it('labels and prompts a fresh reconstruction honestly', async () => {
+  it('keeps reconstructed provenance while delivering a plain prompt by default', async () => {
     const { svc, dispatchHeadlessTask, appendProvenance } = fakeService()
     const result = await createWorkspaceConversationControl(svc).ask({
       target: { kind: 'report', workspaceId: 'ws-peer', path: 'research/report.md' },
@@ -182,13 +194,38 @@ describe('Workspace conversation control', () => {
       resolution: { mode: 'reconstructed', reason: 'missing-origin' },
     })
     const dispatchedPrompt = (dispatchHeadlessTask.mock.calls as unknown[][])[0]?.[2]
-    expect(dispatchedPrompt).toContain('fresh worker reconstructing')
-    expect(dispatchedPrompt).toContain('not the original author')
-    expect(dispatchedPrompt).toContain('research/report.md')
+    expect(dispatchedPrompt).toBe('Why did the report reach this conclusion?')
+    const conversation = (dispatchHeadlessTask.mock.calls as unknown[][])[0]?.[8]
+    expect(conversation).toMatchObject({
+      promptMode: 'plain',
+      originalPrompt: 'Why did the report reach this conclusion?',
+      deliveredPrompt: 'Why did the report reach this conclusion?',
+    })
     expect(appendProvenance).toHaveBeenCalledWith(expect.objectContaining({
       action: 'reconstructed',
       origin: expect.objectContaining({ resumeId: 'resume-fresh' }),
     }))
+  })
+
+  it('adds reconstruction guidance only when explicitly requested', async () => {
+    const { svc, dispatchHeadlessTask } = fakeService()
+    await createWorkspaceConversationControl(svc).ask({
+      target: { kind: 'report', workspaceId: 'ws-peer', path: 'research/report.md' },
+      prompt: 'Why did the report reach this conclusion?',
+      timeoutMs: 300_000,
+      reconstruct: true,
+    })
+
+    const dispatchedPrompt = (dispatchHeadlessTask.mock.calls as unknown[][])[0]?.[2]
+    expect(dispatchedPrompt).toContain('fresh worker reconstructing')
+    expect(dispatchedPrompt).toContain('not the original author')
+    expect(dispatchedPrompt).toContain('research/report.md')
+    const conversation = (dispatchHeadlessTask.mock.calls as unknown[][])[0]?.[8]
+    expect(conversation).toMatchObject({
+      promptMode: 'reconstruction',
+      originalPrompt: 'Why did the report reach this conclusion?',
+      deliveredPrompt: expect.stringContaining('fresh worker reconstructing'),
+    })
   })
 
   it('returns unavailable without dispatching when the attributed Session cannot resume', async () => {

--- a/src/workspaces/conversation-control.ts
+++ b/src/workspaces/conversation-control.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceConversationTask,
 } from '../core/workspace-tool-center.js'
 import type { ArtifactRef, ProvenanceAction, SessionOrigin } from '../core/provenance-store.js'
+import type { AgentConversationDispatch } from './agent-conversation-log.js'
 import { isAgentRuntime } from './cli-adapter.js'
 import type { HeadlessStructuredOutput } from './headless-output.js'
 import { headlessLogPaths } from './headless-task-registry.js'
@@ -241,9 +242,21 @@ export function createWorkspaceConversationControl(
         throw new Error(`agent runtime has no headless mode: ${agentId}`)
       }
 
-      const prompt = resolution.mode === 'exact'
-        ? input.prompt
-        : reconstructionPrompt(input.target, input.prompt, Boolean(continuingOrigin))
+      const promptMode = resolution.mode === 'reconstructed' && input.reconstruct === true
+        ? 'reconstruction'
+        : 'plain'
+      const prompt = promptMode === 'reconstruction'
+        ? reconstructionPrompt(input.target, input.prompt, Boolean(continuingOrigin))
+        : input.prompt
+      const conversation: AgentConversationDispatch = {
+        source: input.source ?? { kind: 'human' },
+        requestedTarget: input.target,
+        originalPrompt: input.prompt,
+        deliveredPrompt: prompt,
+        promptMode,
+        resolution,
+        ...(input.subject ? { subject: input.subject } : {}),
+      }
       const inquiry = input.subject
         ? {
             subject: input.subject,
@@ -256,10 +269,26 @@ export function createWorkspaceConversationControl(
         : undefined
       const dispatched = inquiry
         ? await svc.dispatchHeadlessTask(
-            meta, adapter, prompt, input.timeoutMs, undefined, continuingOrigin?.resumeId, inquiry,
+            meta,
+            adapter,
+            prompt,
+            input.timeoutMs,
+            undefined,
+            continuingOrigin?.resumeId,
+            inquiry,
+            undefined,
+            conversation,
           )
         : await svc.dispatchHeadlessTask(
-            meta, adapter, prompt, input.timeoutMs, undefined, continuingOrigin?.resumeId,
+            meta,
+            adapter,
+            prompt,
+            input.timeoutMs,
+            undefined,
+            continuingOrigin?.resumeId,
+            undefined,
+            undefined,
+            conversation,
           )
       let effectiveResolution = resolution
       if (resolution.mode === 'reconstructed' && resolution.artifact && !resolution.origin) {

--- a/src/workspaces/issues/comment-delivery.ts
+++ b/src/workspaces/issues/comment-delivery.ts
@@ -1,4 +1,7 @@
-import type { WorkspaceConversationControl } from '../../core/workspace-tool-center.js'
+import type {
+  WorkspaceConversationCaller,
+  WorkspaceConversationControl,
+} from '../../core/workspace-tool-center.js'
 import type { IProvenanceStore } from '../../core/provenance-store.js'
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from '../headless-task-registry.js'
 import { sessionSignature } from '../session-signature.js'
@@ -44,6 +47,7 @@ export async function dispatchIssueCommentReply(input: {
   issue: IssueRecord
   comment: IssueComment
   authorResumeId?: string
+  source?: WorkspaceConversationCaller
 }): Promise<IssueCommentDispatchResult> {
   const targetResumeId = issueAssigneeResumeId(input.issue.assignee)
   if (!targetResumeId) return { status: 'not_requested', reason: 'no_fixed_owner' }
@@ -66,6 +70,7 @@ export async function dispatchIssueCommentReply(input: {
       prompt: issueCommentReplyPrompt(input),
       target: { kind: 'resume', resumeId: targetResumeId },
       timeoutMs: COMMENT_REPLY_TIMEOUT_MS,
+      ...(input.source ? { source: input.source } : {}),
       subject: {
         kind: 'issue',
         workspaceId: input.issueWorkspaceId,

--- a/src/workspaces/manager-workspace.ts
+++ b/src/workspaces/manager-workspace.ts
@@ -40,10 +40,10 @@ Operating contract:
 - Prefer OpenAlice's alice-workspace CLI over raw HTTP. Start from live CLI help when a flag is uncertain.
 - Use peer inventory, global Issue reads, Session provenance, and attributable conversation commands before guessing why a desk or coworker did something.
 - The first management pass MUST use structured product indexes only: peer list and, when relevant, issue list. Recent Session titles in peer list are the first-pass responsibility map.
-- Treat the identity hierarchy as load-bearing: when a relevant recent Session exposes a resumeId, continue that exact coworker with conversation ask --resume-id. Use --ws-id only when no attributable Session exists and clearly label the answer as a recruited/reconstructed fallback that may not remember the desk's history.
+- Treat the identity hierarchy as load-bearing: when a relevant recent Session exposes a resumeId, continue that exact coworker with conversation ask --resume-id. Use --ws-id to recruit a fresh coworker for new work or when no attributable Session exists. Add --reconstruct only when missing historical intent must be reconstructed, and never present a fresh worker as the original author.
 - NEVER batch-crawl every Workspace directory, read the same template README across the floor, or run shell loops that dump many desks at once. State what remains ambiguous, then inspect or question only the selected desks that matter.
 - Prefer a concise floor snapshot quickly. Offer deeper inspection as a next step instead of making every audit exhaustive.
-- Prefer conversation ask with --await for a direct answer. Parallel questions are fine; collect their answers before reporting back.
+- Use conversation ask with --await when the current management answer needs a short reply. Omit it for delegated work, keep the task/resume ids, and retrieve or collect the answer later.
 - Preview lifecycle or template mutations first. Do not offboard, merge, purge, or apply an upgrade unless the user clearly asked for that mutation.
 - If you edit a target Workspace directly, commit the change in that Workspace with a clear message. Never edit-and-walk-away.
 - Departed Workspaces are intentionally outside this directory. Do not treat an absent desk as deleted or unknown without checking lifecycle state through OpenAlice.

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -111,6 +111,10 @@ import { issueRunFailure } from './issues/run-failure.js';
 import type { IInboxStore } from '@/core/inbox-store.js';
 import { toSafeInboxOrigin } from '@/core/workspace-tool-center.js';
 import {
+  AgentConversationLog,
+  type AgentConversationDispatch,
+} from './agent-conversation-log.js';
+import {
   HeadlessTaskRegistry,
   headlessLogPaths,
   type HeadlessTaskInquiry,
@@ -464,6 +468,8 @@ export interface WorkspaceService {
     inquiry?: HeadlessTaskInquiry,
     /** Explicit one-run model/effort; authentication remains Workspace-owned. */
     overrides?: HeadlessRunOverrides,
+    /** Cross-Agent message metadata for the independent conversation log. */
+    conversation?: AgentConversationDispatch,
   ): Promise<{ taskId: string; resumeId: string }>;
   /** Read-only scheduling projection of every workspace's `.alice/issues/`
    *  directory (scheduled issues only) + each task's last-fired marker and
@@ -493,6 +499,8 @@ export interface WorkspaceService {
   resumeRegistry: ResumeRegistry;
   /** Durable product Session -> business artifact attribution index. */
   provenanceStore: ArtifactProvenanceStore;
+  /** Append-only analysis/audit projection of cross-Agent messages. */
+  agentConversationLog: AgentConversationLog;
   /** True while a headless turn owns this conversation transcript. */
   isResumeActive(resumeId: string): boolean;
   /** Atomically reserve a conversation before crossing an async spawn boundary. */
@@ -575,6 +583,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   const provenanceStore = await ArtifactProvenanceStore.load(
     join(config.launcherRoot, 'state', 'artifact-provenance.json'),
     launcherLogger.child({ scope: 'provenance-store' }),
+  );
+  const agentConversationLog = new AgentConversationLog(
+    join(config.launcherRoot, 'state', 'agent-conversations.jsonl'),
+    launcherLogger.child({ scope: 'agent-conversation-log' }),
   );
   const issueChangeTracker = await IssueChangeTracker.load(
     join(config.launcherRoot, 'state', 'issue-audit-snapshots.json'),
@@ -1436,6 +1448,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     resumeId?: string,
     inquiry?: HeadlessTaskInquiry,
     overrides?: HeadlessRunOverrides,
+    conversation?: AgentConversationDispatch,
   ): Promise<{ taskId: string; resumeId: string }> => {
     if (catalog.get(ws.id)?.lifecycle !== 'active') {
       throw new Error(`workspace is not active: ${ws.id}`);
@@ -1512,6 +1525,17 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         agent: adapter.id,
         latestTaskId: rec.taskId,
       });
+      if (conversation) {
+        await agentConversationLog.recordDispatch({
+          taskId: rec.taskId,
+          ...(rec.parentTaskId ? { parentTaskId: rec.parentTaskId } : {}),
+          resumeId: rec.resumeId,
+          workspaceId: ws.id,
+          agent: adapter.id,
+          startedAt: rec.startedAt,
+          conversation,
+        });
+      }
     } catch (err) {
       if (resumeId) activeResumeIds.delete(resumeId);
       throw err;
@@ -1559,6 +1583,16 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
             toolFailures: r.structured.metrics.toolFailures,
           },
         });
+        if (conversation) {
+          await agentConversationLog.recordCompletion({
+            taskId: rec.taskId,
+            status,
+            finishedAt: rec.finishedAt ?? Date.now(),
+            assistantText: r.structured.assistantText,
+            durationMs: r.durationMs,
+            ...(status !== 'done' && r.stderrTail ? { error: r.stderrTail.slice(-1000) } : {}),
+          });
+        }
         await completeIssueCommentInquiry({
           task: rec,
           status,
@@ -1619,6 +1653,15 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           finishedAt: Date.now(),
           error: message,
         });
+        if (conversation) {
+          await agentConversationLog.recordCompletion({
+            taskId: rec.taskId,
+            status: 'failed',
+            finishedAt: rec.finishedAt ?? Date.now(),
+            assistantText: null,
+            error: message,
+          });
+        }
         await completeIssueCommentInquiry({
           task: rec,
           status: 'failed',
@@ -2363,6 +2406,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     headlessTasks,
     resumeRegistry,
     provenanceStore,
+    agentConversationLog,
     isResumeActive: (resumeId) => activeResumeIds.has(resumeId),
     claimResume,
     releaseResume: (resumeId) => activeResumeIds.delete(resumeId),

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -40,8 +40,9 @@ headless workspace run.
 
 Inbox keeps durable report delivery separate from the live terminal. A user or
 peer agent can ask the attributable sender about a report; when only the
-Workspace is known, OpenAlice creates a fresh reconstruction Session and labels
-it honestly instead of pretending it found the original author.
+Workspace is known, OpenAlice creates a fresh Session and labels its provenance
+honestly instead of pretending it found the original author. Reconstruction
+instructions are added only when the caller explicitly requests them.
 
 Things Alice will route here:
 - Research notes, thesis updates, and market snapshots worth re-reading later.

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -57,8 +57,16 @@ They are methods, not mandatory ceremony.
 - **Need to understand an Inbox result:** use `inbox ask --id … --await`.
 - **Need the creator, owner, or one run of an Issue:** use `issue ask` with the
   corresponding target and start with `--await`.
+- **Need to delegate new work to another desk:** use `conversation ask --ws-id
+  …` with a normal coworker prompt. Omit `--await` when the peer should accept
+  the work, manage it locally, and report back later.
+- **Need a missing author's intent reconstructed:** add `--reconstruct`
+  explicitly. Ordinary peer messages must not carry reconstruction framing.
 - **Need several independent answers:** dispatch the asks concurrently, then
   collect them; do not write shell sleep loops.
+- **Need a long-running result surfaced to the user:** ask the peer to commit
+  its report and push it to Inbox. Inbox is human-facing delivery; later
+  `read`/`await`/`collect` retrieves the direct Agent reply.
 - **Need to record progress on this Workspace's own Issue:** use `issue comment`.
 - **Need to read a peer artifact:** resolve its Workspace from the Inbox entry,
   then read the referenced file. Autonomous runs never edit a peer Workspace.

--- a/ui/src/api/inquiries.ts
+++ b/ui/src/api/inquiries.ts
@@ -48,7 +48,10 @@ export const inquiriesApi = {
 
   async askInbox(entryId: string, prompt: string): Promise<InquiryDispatch> {
     return fetchJson(`/api/inquiries/inbox/${encodeURIComponent(entryId)}`, {
-      method: 'POST', headers, body: JSON.stringify({ prompt }),
+      // This surface is explicitly a historical Inbox follow-up. Exact senders
+      // receive the plain prompt; only an unattributed fallback gets the
+      // reconstruction preamble.
+      method: 'POST', headers, body: JSON.stringify({ prompt, reconstruct: true }),
     })
   },
 
@@ -65,7 +68,8 @@ export const inquiriesApi = {
   ): Promise<InquiryDispatch> {
     return fetchJson(
       `/api/inquiries/issues/${encodeURIComponent(workspaceId)}/${encodeURIComponent(issueId)}`,
-      { method: 'POST', headers, body: JSON.stringify(input) },
+      // Issue inquiries explicitly ask historical creator/owner/run context.
+      { method: 'POST', headers, body: JSON.stringify({ ...input, reconstruct: true }) },
     )
   },
 }


### PR DESCRIPTION
## What changed

- keeps `conversation ask` prompts plain by default and adds explicit `--reconstruct` guidance only for historical artifact reconstruction
- preserves `resolution.mode: reconstructed` as provenance independently from prompt injection
- distinguishes short `--await` consultations, asynchronous delegation, later read/await/collect, and human-facing Inbox delivery in live CLI/template/manager guidance
- adds a private append-only `agent-conversations.jsonl` dispatch/completion stream with caller, target, prompt-flow, status, and reply data
- adds migration `0026_agent_conversation_log` and focused contract coverage

## Why

Ordinary Coding Agents need to speak as coworkers. Treating every Workspace fallback as an artifact reconstruction caused unrelated delegation to receive a reconstruction-analyst preamble, while blanket `--await` guidance obscured the product's actual synchronous and asynchronous collaboration rhythms. Independent prompt/reply logging is also needed for collaboration analysis and future visualization without becoming a workflow engine or notification bus.

## Impact

Generic peer asks now deliver the caller's text unchanged unless reconstruction is explicitly requested. Historical Inbox/Issue follow-up surfaces opt in deliberately. Long-running delegation remains task-backed and can later be collected or surfaced to the human through Inbox; no Agent-to-Agent notification bus is introduced.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- focused conversation, CLI shim, service/log, route, and migration tests (88 passed)
- `pnpm test` (3378 passed, 9 skipped; one unrelated SettingsPage timeout passed 5/5 on immediate targeted rerun)
- real isolated dev server + generated CLI manifest/help/`--reconstruct` parsing
- `pnpm electron:smoke:pty`
- `pnpm electron:smoke:workspace --skip-build` (packaged Workspace acceptance receipt: all checks true)
- `git diff --check`