### PR TITLE
Add Agent conversation log UI

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,10 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/agent-conversation-log-ui.md]] — Adds a read-only, paginated Agent
+  collaboration view to Dev Logs without exposing launcher file paths or
+  introducing a new dispatch surface.
+
 ## Completed
 
 - [[plans/agent-conversation-semantics.md]] — Separates ordinary peer

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,12 +21,11 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/agent-conversation-log-ui.md]] — Adds a read-only, paginated Agent
-  collaboration view to Dev Logs without exposing launcher file paths or
-  introducing a new dispatch surface.
-
 ## Completed
 
+- [[plans/agent-conversation-log-ui.md]] — Adds a read-only, paginated Agent
+  collaboration view to Dev Logs without exposing launcher file paths or
+  introducing a new dispatch surface. Delivered in PR #742.
 - [[plans/agent-conversation-semantics.md]] — Separates ordinary peer
   conversation from explicit artifact reconstruction, documents synchronous
   and asynchronous delegation, and records cross-Agent exchanges in a

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -592,6 +592,19 @@ projection for prompt-flow studies and future visualization. A logging failure
 must not block or change message delivery, and the log is not an Agent
 notification mechanism.
 
+The authenticated Dev → Logs → Agent conversations view exposes a read-only
+projection of this stream. It joins dispatch and completion by `taskId`, shows
+newest conversations first, and polls only the newest page. A dispatch without
+a completion event is shown as running. Expanding a row reveals routing
+identities, the original prompt, the final reply, and the delivered prompt only
+when explicit reconstruction guidance changed it.
+
+The browser never receives the launcher log path or an arbitrary file-read
+capability. `/api/agent-conversations` returns bounded typed pages and provides
+no replay, resume, edit, or delete operation. Malformed or partially appended
+JSONL lines are ignored so an interrupted write cannot make the diagnostics
+surface unusable.
+
 ## Phase 2 Feature Design Skeleton
 
 Business convenience wrappers delegate to the same shipped resolver:
@@ -639,6 +652,8 @@ shapes should point back here rather than restating the rules differently.
 | `src/workspaces/agent-conversation-log.ts` | Private append-only peer-message prompt/reply event stream |
 | `src/tool/conversation.ts` | Embedded business-target ask/read CLI tools |
 | `src/webui/routes/inquiries.ts` | Human Inbox/Issue ask dispatch and durable inquiry projections |
+| `src/webui/routes/agent-conversations.ts` | Authenticated read-only joined conversation pages for Dev Logs |
+| `ui/src/pages/LogsPage.tsx` | Tool-call and Agent-conversation diagnostic views |
 | `src/core/inbox-store.ts` | Immutable notification records and sender provenance |
 | `src/server/inbox-origin.ts` | Server-side run/session attribution |
 | `src/workspaces/issues/declaration.ts` | Workspace-local Issue declaration |

--- a/plans/agent-conversation-log-ui.md
+++ b/plans/agent-conversation-log-ui.md
@@ -1,6 +1,8 @@
 # Agent Conversation Log UI
 
-Status: Active
+Status: Completed
+
+Delivered by PR #742.
 
 Related issues: none
 
@@ -65,7 +67,7 @@ Not in scope:
 - [x] Update the owner guide.
 - [x] Run required typechecks and tests.
 - [x] Exercise the real dev/demo route and Electron/package path.
-- [ ] Publish and merge a serial PR to `dev`.
+- [x] Publish and merge a serial PR to `dev`.
 
 ## Completion Criteria
 

--- a/plans/agent-conversation-log-ui.md
+++ b/plans/agent-conversation-log-ui.md
@@ -1,0 +1,76 @@
+# Agent Conversation Log UI
+
+Status: Active
+
+Related issues: none
+
+Owner guides: [[docs/conversation-provenance.md]],
+[[docs/ui-interaction-and-motion.md]]
+
+## Outcome
+
+The existing Dev → Logs surface can show Agent collaboration as complete
+message exchanges rather than raw JSONL events. Operators can inspect caller,
+target, provenance resolution, prompt injection, completion status, reply, and
+timing without gaining a second dispatch API or direct filesystem access.
+
+## Scope
+
+- Add a read-only query projection that joins dispatch/completion events by
+  task id and returns newest-first pages.
+- Mount an authenticated HTTP read route after Workspace service startup.
+- Add an Agent conversations view alongside the existing tool-call log.
+- Poll the newest page while active and support paging through older history.
+- Cover malformed/incomplete log records, API bounds, empty/loading/error
+  states, and expanded prompt/reply detail.
+- Update the demo contract and owner guide.
+
+Not in scope:
+
+- Editing or deleting conversation history.
+- Replaying, resuming, or dispatching conversations from the log.
+- Agent-to-Agent completion notifications.
+- Full-text indexing or a database migration.
+
+## Decisions
+
+1. The JSONL file remains private launcher state. The UI receives a typed,
+   authenticated projection and never a path or arbitrary file-read primitive.
+2. One UI row represents one dispatched task. A missing completion event is
+   shown as running.
+3. Original and delivered prompts are both visible. The delivered prompt gets
+   a separate panel only when reconstruction guidance changed it.
+4. The existing Dev → Logs page owns the feature. Tool calls and Agent
+   conversations are peer views selected by a segmented control.
+5. Page one polls for live changes. Older pages remain stable and do not jump
+   when new events arrive.
+
+## Work
+
+### 1. Read contract
+
+- [x] Add the joined query projection to the conversation log.
+- [x] Add bounded pagination and the authenticated Web UI route.
+- [x] Add focused store and route tests.
+
+### 2. UI
+
+- [x] Add the API client and demo handler.
+- [x] Add Tool calls / Agent conversations selection.
+- [x] Render source → target, status, mode, prompts, reply, and identifiers.
+- [x] Cover loading, empty, error, expansion, polling, and pagination.
+
+### 3. Verification and delivery
+
+- [x] Update the owner guide.
+- [x] Run required typechecks and tests.
+- [x] Exercise the real dev/demo route and Electron/package path.
+- [ ] Publish and merge a serial PR to `dev`.
+
+## Completion Criteria
+
+- Dev → Logs → Agent conversations shows joined exchanges newest-first.
+- A live dispatch appears as running and gains its reply after completion.
+- Explicit reconstruction exposes both original and delivered prompt text.
+- Malformed or partial JSONL lines cannot break the page.
+- The surface remains read-only and protected by OpenAlice's normal auth gate.

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -18,6 +18,7 @@ import { createTradingProxyRoutes } from './routes/trading-proxy.js'
 import { createTradingConfigRoutes } from './routes/trading-config.js'
 import { createToolsRoutes } from './routes/tools.js'
 import { createAgentStatusRoutes } from './routes/agent-status.js'
+import { createAgentConversationRoutes } from './routes/agent-conversations.js'
 import { createPersonaRoutes } from './routes/persona.js'
 import { createNewsRoutes } from './routes/news.js'
 import { createMarketRoutes } from './routes/market.js'
@@ -261,6 +262,7 @@ export class WebPlugin implements Plugin {
     app.route('/api/workspaces', createWorkspaceRoutes(this.workspaceService))
     app.route('/api/agent-runtimes', createAgentRuntimeRoutes(this.workspaceService))
     app.route('/api/headless', createHeadlessRoutes(this.workspaceService))
+    app.route('/api/agent-conversations', createAgentConversationRoutes(this.workspaceService.agentConversationLog))
     app.route('/api/schedule', createScheduleRoutes(this.workspaceService))
     app.route('/api/issues', createIssuesRoutes(this.workspaceService))
     app.route('/api/inquiries', createInquiryRoutes({

--- a/src/webui/routes/agent-conversations.spec.ts
+++ b/src/webui/routes/agent-conversations.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AgentConversationLog } from '../../workspaces/agent-conversation-log.js'
+import { createAgentConversationRoutes } from './agent-conversations.js'
+
+describe('GET /api/agent-conversations', () => {
+  it('returns the joined log projection', async () => {
+    const query = vi.fn().mockResolvedValue({
+      entries: [{ taskId: 'run-1', status: 'running' }],
+      total: 1,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+    })
+    const app = createAgentConversationRoutes({ query } as unknown as AgentConversationLog)
+
+    const response = await app.request('/')
+
+    expect(response.status).toBe(200)
+    expect(query).toHaveBeenCalledWith({ page: 1, pageSize: 50 })
+    await expect(response.json()).resolves.toMatchObject({
+      entries: [{ taskId: 'run-1', status: 'running' }],
+      total: 1,
+    })
+  })
+
+  it('normalizes invalid pagination and caps page size', async () => {
+    const query = vi.fn().mockResolvedValue({
+      entries: [],
+      total: 0,
+      page: 1,
+      pageSize: 100,
+      totalPages: 1,
+    })
+    const app = createAgentConversationRoutes({ query } as unknown as AgentConversationLog)
+
+    await app.request('/?page=-4&pageSize=5000')
+
+    expect(query).toHaveBeenCalledWith({ page: 1, pageSize: 100 })
+  })
+})

--- a/src/webui/routes/agent-conversations.ts
+++ b/src/webui/routes/agent-conversations.ts
@@ -1,0 +1,27 @@
+/**
+ * Read-only Web UI projection of the private Agent conversation event log.
+ *
+ * The route is mounted below OpenAlice's normal auth gate and exposes joined,
+ * typed records only. It never exposes the launcher path or a filesystem read
+ * primitive, and it owns no replay/resume/delete operations.
+ */
+import { Hono } from 'hono'
+
+import type { AgentConversationLog } from '../../workspaces/agent-conversation-log.js'
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback
+}
+
+export function createAgentConversationRoutes(log: AgentConversationLog): Hono {
+  const app = new Hono()
+
+  app.get('/', async (c) => {
+    const page = positiveInteger(c.req.query('page'), 1)
+    const pageSize = Math.min(100, positiveInteger(c.req.query('pageSize'), 50))
+    return c.json(await log.query({ page, pageSize }))
+  })
+
+  return app
+}

--- a/src/workspaces/agent-conversation-log.spec.ts
+++ b/src/workspaces/agent-conversation-log.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { appendFile, mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -77,9 +77,107 @@ describe('AgentConversationLog', () => {
     })
     expect(events.some((event) => JSON.stringify(event).includes('native'))).toBe(false)
     expect(logger.warn).not.toHaveBeenCalled()
+    await expect(log.query()).resolves.toMatchObject({
+      entries: [{
+        source: {
+          kind: 'session',
+          workspaceId: 'ws-chat',
+          resumeId: 'resume-chat',
+          agent: 'codex',
+        },
+      }],
+    })
+    expect((await log.query()).entries[0]?.source).not.toHaveProperty('execution')
 
     if (process.platform !== 'win32') {
       expect((await stat(path)).mode & 0o777).toBe(0o600)
     }
+  })
+
+  it('joins dispatch and completion events into newest-first pages', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agent-conversation-query-'))
+    dirs.push(dir)
+    const path = join(dir, 'state', 'agent-conversations.jsonl')
+    const log = new AgentConversationLog(path, { warn: vi.fn() })
+
+    for (const [taskId, startedAt] of [['run-1', 10], ['run-2', 20]] as const) {
+      await log.recordDispatch({
+        taskId,
+        resumeId: `resume-${taskId}`,
+        workspaceId: 'ws-quant',
+        agent: 'codex',
+        startedAt,
+        conversation: {
+          source: { kind: 'workspace', workspaceId: 'ws-chat' },
+          requestedTarget: { kind: 'workspace', workspaceId: 'ws-quant' },
+          originalPrompt: `Prompt ${taskId}`,
+          deliveredPrompt: `Prompt ${taskId}`,
+          promptMode: 'plain',
+          resolution: { mode: 'reconstructed', workspaceId: 'ws-quant', reason: 'explicit-workspace' },
+        },
+      })
+    }
+    await log.recordCompletion({
+      taskId: 'run-1',
+      status: 'done',
+      finishedAt: 30,
+      assistantText: 'Finished.',
+      durationMs: 20,
+    })
+    await appendFile(path, '{"type":"conversation.dispatched","partial":', 'utf8')
+
+    await expect(log.query({ page: 1, pageSize: 1 })).resolves.toMatchObject({
+      total: 2,
+      page: 1,
+      pageSize: 1,
+      totalPages: 2,
+      entries: [{
+        taskId: 'run-2',
+        status: 'running',
+        assistantText: null,
+      }],
+    })
+    await expect(log.query({ page: 2, pageSize: 1 })).resolves.toMatchObject({
+      entries: [{
+        taskId: 'run-1',
+        status: 'done',
+        assistantText: 'Finished.',
+        completedAt: 30,
+      }],
+    })
+  })
+
+  it('returns an empty first page before the migration or first dispatch', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agent-conversation-empty-'))
+    dirs.push(dir)
+    const log = new AgentConversationLog(join(dir, 'missing', 'log.jsonl'), { warn: vi.fn() })
+
+    await expect(log.query()).resolves.toEqual({
+      entries: [],
+      total: 0,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+    })
+
+    await log.recordDispatch({
+      taskId: 'run-after-read',
+      resumeId: 'resume-after-read',
+      workspaceId: 'ws-peer',
+      agent: 'pi',
+      startedAt: 40,
+      conversation: {
+        source: { kind: 'human' },
+        requestedTarget: { kind: 'workspace', workspaceId: 'ws-peer' },
+        originalPrompt: 'Start after the first empty read.',
+        deliveredPrompt: 'Start after the first empty read.',
+        promptMode: 'plain',
+        resolution: { mode: 'reconstructed', workspaceId: 'ws-peer', reason: 'explicit-workspace' },
+      },
+    })
+    await expect(log.query()).resolves.toMatchObject({
+      total: 1,
+      entries: [{ taskId: 'run-after-read', status: 'running' }],
+    })
   })
 })

--- a/src/workspaces/agent-conversation-log.ts
+++ b/src/workspaces/agent-conversation-log.ts
@@ -12,7 +12,7 @@
  * tool blocks do not enter it.
  */
 import { randomUUID } from 'node:crypto'
-import { appendFile, mkdir } from 'node:fs/promises'
+import { appendFile, mkdir, readFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
 import type {
@@ -81,8 +81,55 @@ export type AgentConversationLogEvent =
   | AgentConversationDispatchedEvent
   | AgentConversationCompletedEvent
 
+export type AgentConversationSource =
+  | { readonly kind: 'human' }
+  | { readonly kind: 'workspace'; readonly workspaceId: string }
+  | {
+      readonly kind: 'session'
+      readonly workspaceId: string
+      readonly resumeId: string
+      readonly agent: string
+    }
+
+export interface AgentConversationRecord {
+  readonly taskId: string
+  readonly parentTaskId?: string
+  readonly dispatchedAt: number
+  readonly completedAt?: number
+  readonly status: HeadlessTaskStatus
+  readonly source: AgentConversationSource
+  readonly target: {
+    readonly workspaceId: string
+    readonly resumeId: string
+    readonly agent: string
+  }
+  readonly requestedTarget: WorkspaceConversationTarget
+  readonly resolution: {
+    readonly mode: 'exact' | 'reconstructed'
+    readonly reason?: string
+  }
+  readonly prompt: {
+    readonly original: string
+    readonly delivered: string
+    readonly mode: 'plain' | 'reconstruction'
+  }
+  readonly assistantText: string | null
+  readonly durationMs?: number
+  readonly error?: string
+}
+
+export interface AgentConversationQueryResult {
+  readonly entries: AgentConversationRecord[]
+  readonly total: number
+  readonly page: number
+  readonly pageSize: number
+  readonly totalPages: number
+}
+
 export class AgentConversationLog {
   private appendChain: Promise<void> = Promise.resolve()
+  private cachedEvents: AgentConversationLogEvent[] | null = null
+  private cacheRevision = 0
 
   constructor(
     private readonly path: string,
@@ -149,6 +196,57 @@ export class AgentConversationLog {
     })
   }
 
+  /** Read a UI-safe joined projection. Page 1 contains the newest dispatches. */
+  async query(opts: {
+    readonly page?: number
+    readonly pageSize?: number
+  } = {}): Promise<AgentConversationQueryResult> {
+    await this.appendChain
+    const page = Math.max(1, Math.floor(opts.page ?? 1))
+    const pageSize = Math.min(100, Math.max(1, Math.floor(opts.pageSize ?? 50)))
+    const events = await this.readEvents()
+    const completions = new Map<string, AgentConversationCompletedEvent>()
+    const dispatches: AgentConversationDispatchedEvent[] = []
+    for (const event of events) {
+      if (event.type === 'conversation.dispatched') {
+        dispatches.push(event)
+      } else {
+        completions.set(event.taskId, event)
+      }
+    }
+
+    const all = dispatches
+      .map((dispatch): AgentConversationRecord => {
+        const completion = completions.get(dispatch.taskId)
+        return {
+          taskId: dispatch.taskId,
+          ...(dispatch.parentTaskId ? { parentTaskId: dispatch.parentTaskId } : {}),
+          dispatchedAt: dispatch.at,
+          ...(completion ? { completedAt: completion.at } : {}),
+          status: completion?.status ?? 'running',
+          source: publicConversationSource(dispatch.source),
+          target: dispatch.target,
+          requestedTarget: dispatch.requestedTarget,
+          resolution: dispatch.resolution,
+          prompt: dispatch.prompt,
+          assistantText: completion?.assistantText ?? null,
+          ...(completion?.durationMs !== undefined ? { durationMs: completion.durationMs } : {}),
+          ...(completion?.error ? { error: completion.error } : {}),
+        }
+      })
+      .sort((a, b) => b.dispatchedAt - a.dispatchedAt)
+    const total = all.length
+    const totalPages = Math.max(1, Math.ceil(total / pageSize))
+    const start = (page - 1) * pageSize
+    return {
+      entries: all.slice(start, start + pageSize),
+      total,
+      page,
+      pageSize,
+      totalPages,
+    }
+  }
+
   private async append(event: AgentConversationLogEvent): Promise<void> {
     const next = this.appendChain.then(async () => {
       try {
@@ -157,6 +255,8 @@ export class AgentConversationLog {
           encoding: 'utf8',
           mode: 0o600,
         })
+        this.cachedEvents?.push(event)
+        this.cacheRevision += 1
       } catch (err) {
         this.logger.warn('agent_conversation_log.append_failed', {
           taskId: event.taskId,
@@ -167,5 +267,112 @@ export class AgentConversationLog {
     })
     this.appendChain = next.catch(() => undefined)
     await next
+  }
+
+  private async readEvents(): Promise<AgentConversationLogEvent[]> {
+    if (this.cachedEvents) return this.cachedEvents
+    const revisionBeforeRead = this.cacheRevision
+    let raw: string
+    try {
+      raw = await readFile(this.path, 'utf8')
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.cachedEvents = []
+        return this.cachedEvents
+      }
+      throw err
+    }
+    const events: AgentConversationLogEvent[] = []
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const value = JSON.parse(line) as unknown
+        if (isAgentConversationLogEvent(value)) events.push(value)
+      } catch {
+        // Ignore an incomplete final append or a hand-edited malformed line.
+      }
+    }
+    if (this.cacheRevision !== revisionBeforeRead) return this.readEvents()
+    this.cachedEvents = events
+    return events
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function publicConversationSource(source: WorkspaceConversationCaller): AgentConversationSource {
+  if (source.kind !== 'session') return source
+  return {
+    kind: 'session',
+    workspaceId: source.workspaceId,
+    resumeId: source.resumeId,
+    agent: source.agent,
+  }
+}
+
+function isAgentConversationLogEvent(value: unknown): value is AgentConversationLogEvent {
+  if (!isRecord(value) || value.schemaVersion !== 1 || typeof value.taskId !== 'string') return false
+  if (value.type === 'conversation.completed') {
+    return typeof value.eventId === 'string'
+      && typeof value.at === 'number'
+      && ['running', 'done', 'failed', 'interrupted'].includes(String(value.status))
+      && (typeof value.assistantText === 'string' || value.assistantText === null)
+      && (value.durationMs === undefined || typeof value.durationMs === 'number')
+      && (value.error === undefined || typeof value.error === 'string')
+  }
+  if (value.type !== 'conversation.dispatched') return false
+  if (
+    typeof value.eventId !== 'string'
+    || typeof value.at !== 'number'
+    || !isConversationSource(value.source)
+    || !isRecord(value.target)
+    || typeof value.target.workspaceId !== 'string'
+    || typeof value.target.resumeId !== 'string'
+    || typeof value.target.agent !== 'string'
+    || !isConversationTarget(value.requestedTarget)
+    || !isRecord(value.resolution)
+    || !['exact', 'reconstructed'].includes(String(value.resolution.mode))
+    || (value.resolution.reason !== undefined && typeof value.resolution.reason !== 'string')
+    || !isRecord(value.prompt)
+    || typeof value.prompt.original !== 'string'
+    || typeof value.prompt.delivered !== 'string'
+    || !['plain', 'reconstruction'].includes(String(value.prompt.mode))
+    || (value.parentTaskId !== undefined && typeof value.parentTaskId !== 'string')
+  ) {
+    return false
+  }
+  return true
+}
+
+function isConversationSource(value: unknown): value is WorkspaceConversationCaller {
+  if (!isRecord(value)) return false
+  if (value.kind === 'human') return true
+  if (value.kind === 'workspace') return typeof value.workspaceId === 'string'
+  return value.kind === 'session'
+    && typeof value.workspaceId === 'string'
+    && typeof value.resumeId === 'string'
+    && typeof value.agent === 'string'
+}
+
+function isConversationTarget(value: unknown): value is WorkspaceConversationTarget {
+  if (!isRecord(value) || typeof value.kind !== 'string') return false
+  switch (value.kind) {
+    case 'resume':
+      return typeof value.resumeId === 'string'
+    case 'workspace':
+      return typeof value.workspaceId === 'string'
+    case 'inbox':
+      return typeof value.inboxEntryId === 'string'
+        && (value.workspaceId === undefined || typeof value.workspaceId === 'string')
+    case 'issue':
+      return typeof value.workspaceId === 'string' && typeof value.issueId === 'string'
+    case 'report':
+      return typeof value.workspaceId === 'string' && typeof value.path === 'string'
+    case 'trade-decision':
+      return typeof value.accountId === 'string' && typeof value.decisionId === 'string'
+    default:
+      return false
   }
 }

--- a/ui/src/api/agentConversations.ts
+++ b/ui/src/api/agentConversations.ts
@@ -1,0 +1,64 @@
+export type AgentConversationSource =
+  | { kind: 'human' }
+  | { kind: 'workspace'; workspaceId: string }
+  | {
+      kind: 'session'
+      workspaceId: string
+      resumeId: string
+      agent: string
+    }
+
+export type AgentConversationTarget =
+  | { kind: 'resume'; resumeId: string }
+  | { kind: 'workspace'; workspaceId: string }
+  | { kind: 'inbox'; inboxEntryId: string; workspaceId?: string }
+  | { kind: 'issue'; workspaceId: string; issueId: string; action?: string }
+  | { kind: 'report'; workspaceId: string; path: string; revision?: string; action?: string }
+  | { kind: 'trade-decision'; accountId: string; decisionId: string; workspaceId?: string }
+
+export interface AgentConversationRecord {
+  taskId: string
+  parentTaskId?: string
+  dispatchedAt: number
+  completedAt?: number
+  status: 'running' | 'done' | 'failed' | 'interrupted'
+  source: AgentConversationSource
+  target: {
+    workspaceId: string
+    resumeId: string
+    agent: string
+  }
+  requestedTarget: AgentConversationTarget
+  resolution: {
+    mode: 'exact' | 'reconstructed'
+    reason?: string
+  }
+  prompt: {
+    original: string
+    delivered: string
+    mode: 'plain' | 'reconstruction'
+  }
+  assistantText: string | null
+  durationMs?: number
+  error?: string
+}
+
+export interface AgentConversationQueryResult {
+  entries: AgentConversationRecord[]
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+export const agentConversationsApi = {
+  async query(opts: { page?: number; pageSize?: number } = {}): Promise<AgentConversationQueryResult> {
+    const params = new URLSearchParams()
+    if (opts.page) params.set('page', String(opts.page))
+    if (opts.pageSize) params.set('pageSize', String(opts.pageSize))
+    const query = params.toString()
+    const response = await fetch(`/api/agent-conversations${query ? `?${query}` : ''}`)
+    if (!response.ok) throw new Error('Failed to query Agent conversations')
+    return response.json()
+  },
+}

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -19,6 +19,7 @@ import { headlessApi } from './headless'
 import { preferencesApi } from './preferences'
 import { inquiriesApi } from './inquiries'
 import { connectorsApi } from './connectors'
+import { agentConversationsApi } from './agentConversations'
 export const api = {
   config: configApi,
   schedule: scheduleApi,
@@ -37,6 +38,7 @@ export const api = {
   preferences: preferencesApi,
   inquiries: inquiriesApi,
   connectors: connectorsApi,
+  agentConversations: agentConversationsApi,
 }
 
 // Re-export all types for convenience
@@ -90,3 +92,9 @@ export type {
   ConnectorSettingsSnapshot,
 } from './connectors'
 export type { ToolCallQueryResult } from './agentStatus'
+export type {
+  AgentConversationQueryResult,
+  AgentConversationRecord,
+  AgentConversationSource,
+  AgentConversationTarget,
+} from './agentConversations'

--- a/ui/src/demo/handlers/agentConversations.ts
+++ b/ui/src/demo/handlers/agentConversations.ts
@@ -1,0 +1,61 @@
+import { http, HttpResponse } from 'msw'
+
+const now = Date.now()
+
+export const agentConversationHandlers = [
+  http.get('/api/agent-conversations', () => HttpResponse.json({
+    entries: [
+      {
+        taskId: 'run-demo-quant',
+        dispatchedAt: now - 96_000,
+        completedAt: now - 42_000,
+        status: 'done',
+        source: {
+          kind: 'session',
+          workspaceId: 'chat-demo',
+          resumeId: 'resume-chat-demo',
+          agent: 'codex',
+        },
+        target: {
+          workspaceId: 'auto-quant-demo',
+          resumeId: 'resume-quant-demo',
+          agent: 'codex',
+        },
+        requestedTarget: { kind: 'workspace', workspaceId: 'auto-quant-demo' },
+        resolution: { mode: 'reconstructed', reason: 'explicit-workspace' },
+        prompt: {
+          original: '研究一下最近三个月黄金和美元实际利率的关系，给我一个可复现的结论。',
+          delivered: '研究一下最近三个月黄金和美元实际利率的关系，给我一个可复现的结论。',
+          mode: 'plain',
+        },
+        assistantText: '任务已完成。研究代码和报告已保存在 Workspace，并已推送摘要到 Inbox。',
+        durationMs: 54_000,
+      },
+      {
+        taskId: 'run-demo-reconstruction',
+        dispatchedAt: now - 6 * 60_000,
+        completedAt: now - 5 * 60_000,
+        status: 'done',
+        source: { kind: 'human' },
+        target: {
+          workspaceId: 'research-demo',
+          resumeId: 'resume-research-demo',
+          agent: 'pi',
+        },
+        requestedTarget: { kind: 'inbox', inboxEntryId: 'inbox-demo', workspaceId: 'research-demo' },
+        resolution: { mode: 'reconstructed', reason: 'missing-origin' },
+        prompt: {
+          original: '这个结论当时为什么排除了 2020 年样本？',
+          delivered: 'You are a reconstruction analyst. The original author is unavailable. Reconstruct the likely evidence and explicitly label uncertainty.\n\n这个结论当时为什么排除了 2020 年样本？',
+          mode: 'reconstruction',
+        },
+        assistantText: '从仓库中的数据清洗脚本看，2020 年被作为结构突变期单独排除；这是一项重建判断。',
+        durationMs: 41_000,
+      },
+    ],
+    total: 2,
+    page: 1,
+    pageSize: 50,
+    totalPages: 1,
+  })),
+]

--- a/ui/src/demo/handlers/index.ts
+++ b/ui/src/demo/handlers/index.ts
@@ -11,6 +11,7 @@ import { toolsSimulatorHandlers } from './toolsSimulator'
 import { marketHandlers } from './market'
 import { configKeysHandlers } from './configKeys'
 import { agentStatusHandlers } from './agentStatus'
+import { agentConversationHandlers } from './agentConversations'
 import { newsListHandlers } from './newsList'
 import { devMiscHandlers } from './devMisc'
 import { headlessHandlers } from './headless'
@@ -36,6 +37,7 @@ export const handlers = [
   ...marketHandlers,
   ...configKeysHandlers,
   ...agentStatusHandlers,
+  ...agentConversationHandlers,
   ...newsListHandlers,
   ...devMiscHandlers,
   ...headlessHandlers,

--- a/ui/src/pages/LogsPage.spec.tsx
+++ b/ui/src/pages/LogsPage.spec.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LogsPage } from './LogsPage'
+
+const mocks = vi.hoisted(() => ({
+  conversationQuery: vi.fn(),
+  toolQuery: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    agentConversations: { query: mocks.conversationQuery },
+    agentStatus: { query: mocks.toolQuery },
+  },
+}))
+
+const ordinary = {
+  taskId: 'run-plain',
+  dispatchedAt: 100,
+  completedAt: 120,
+  status: 'done',
+  source: {
+    kind: 'session',
+    workspaceId: 'chat-desk',
+    resumeId: 'resume-chat',
+    agent: 'codex',
+  },
+  target: {
+    workspaceId: 'quant-desk',
+    resumeId: 'resume-quant',
+    agent: 'codex',
+  },
+  requestedTarget: { kind: 'workspace', workspaceId: 'quant-desk' },
+  resolution: { mode: 'reconstructed', reason: 'explicit-workspace' },
+  prompt: {
+    original: 'Run an ordinary research task.',
+    delivered: 'Run an ordinary research task.',
+    mode: 'plain',
+  },
+  assistantText: 'Research complete.',
+  durationMs: 20,
+} as const
+
+const reconstructed = {
+  ...ordinary,
+  taskId: 'run-reconstructed',
+  dispatchedAt: 200,
+  prompt: {
+    original: 'Why was this artifact created?',
+    delivered: 'You are a reconstruction analyst.\n\nWhy was this artifact created?',
+    mode: 'reconstruction',
+  },
+  assistantText: 'This is a reconstructed explanation.',
+} as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.conversationQuery.mockResolvedValue({
+    entries: [reconstructed, ordinary],
+    total: 2,
+    page: 1,
+    pageSize: 50,
+    totalPages: 1,
+  })
+  mocks.toolQuery.mockResolvedValue({
+    entries: [],
+    total: 0,
+    page: 1,
+    pageSize: 100,
+    totalPages: 1,
+  })
+})
+
+afterEach(cleanup)
+
+describe('LogsPage Agent conversations', () => {
+  it('shows joined routing and keeps provenance separate from prompt injection', async () => {
+    render(<LogsPage />)
+
+    expect(await screen.findByText(/2 conversations/)).toBeTruthy()
+    expect(screen.getAllByText('Reconstructed provenance')).toHaveLength(2)
+    expect(screen.getByText('Guidance injected')).toBeTruthy()
+    expect(screen.getAllByText('chat-desk · codex')).toHaveLength(2)
+    expect(screen.getAllByText('quant-desk · codex')).toHaveLength(2)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run an ordinary research task/ }))
+
+    expect(screen.getByText('Original prompt')).toBeTruthy()
+    expect(screen.getByText('Research complete.')).toBeTruthy()
+    expect(screen.queryByText('Delivered prompt · reconstruction guidance applied')).toBeNull()
+  })
+
+  it('shows original and delivered prompts only for explicit reconstruction', async () => {
+    render(<LogsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Why was this artifact created/ }))
+
+    expect(screen.getByText('Delivered prompt · reconstruction guidance applied')).toBeTruthy()
+    expect(screen.getByText(/You are a reconstruction analyst/)).toBeTruthy()
+    expect(screen.getByText('This is a reconstructed explanation.')).toBeTruthy()
+    expect(screen.getByText('run-reconstructed')).toBeTruthy()
+  })
+
+  it('can switch back to the existing tool-call log', async () => {
+    render(<LogsPage />)
+    await screen.findByText(/2 conversations/)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tool calls' }))
+
+    await waitFor(() => expect(mocks.toolQuery).toHaveBeenCalledWith({
+      page: 1,
+      pageSize: 100,
+      name: undefined,
+    }))
+    expect(screen.getByText('No tool calls yet')).toBeTruthy()
+  })
+
+  it('offers a retry when the read-only projection is unavailable', async () => {
+    mocks.conversationQuery.mockRejectedValueOnce(new Error('offline'))
+    render(<LogsPage />)
+
+    expect(await screen.findByText('Could not load Agent conversations')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.conversationQuery).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText(/2 conversations/)).toBeTruthy()
+  })
+
+  it('requests older pages without turning off the read-only view', async () => {
+    mocks.conversationQuery.mockResolvedValue({
+      entries: [ordinary],
+      total: 51,
+      page: 1,
+      pageSize: 50,
+      totalPages: 2,
+    })
+    render(<LogsPage />)
+    await screen.findByText(/51 conversations/)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => expect(mocks.conversationQuery).toHaveBeenCalledWith({
+      page: 2,
+      pageSize: 50,
+    }))
+  })
+})

--- a/ui/src/pages/LogsPage.tsx
+++ b/ui/src/pages/LogsPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { api, type ToolCallRecord } from '../api'
+import { api, type AgentConversationRecord, type ToolCallRecord } from '../api'
 import { getIntlLocale } from '../lib/intl'
-import { Skeleton } from '../components/StateViews'
+import { EmptyState, Skeleton } from '../components/StateViews'
+import { SegmentedControl } from '../components/SegmentedControl'
 
 // ==================== Helpers ====================
 
@@ -34,6 +35,12 @@ function formatDuration(ms: number): string {
 
 function statusColor(status: string): string {
   return status === 'error' ? 'text-destructive' : 'text-success'
+}
+
+function conversationStatusColor(status: AgentConversationRecord['status']): string {
+  if (status === 'failed' || status === 'interrupted') return 'text-destructive'
+  if (status === 'running') return 'text-warning'
+  return 'text-success'
 }
 
 /** Try to pretty-print JSON output, fall back to raw string. */
@@ -109,7 +116,7 @@ function ToolCallLogSection() {
 
   const goToPage = useCallback((p: number) => {
     fetchPage(p, nameFilter || undefined)
-    containerRef.current?.scrollTo(0, 0)
+    containerRef.current?.scrollTo?.(0, 0)
   }, [fetchPage, nameFilter])
 
   return (
@@ -260,10 +267,322 @@ function ToolCallRow({ record }: { record: ToolCallRecord }) {
   )
 }
 
-export function LogsPage() {
+// ==================== Agent Conversation Log ====================
+
+const CONVERSATION_PAGE_SIZE = 50
+
+function sourceLabel(source: AgentConversationRecord['source']): string {
+  if (source.kind === 'human') return 'Human'
+  if (source.kind === 'workspace') return source.workspaceId
+  return `${source.workspaceId} · ${source.agent}`
+}
+
+function targetLabel(target: AgentConversationRecord['target']): string {
+  return `${target.workspaceId} · ${target.agent}`
+}
+
+function requestedTargetLabel(target: AgentConversationRecord['requestedTarget']): string {
+  switch (target.kind) {
+    case 'resume':
+      return `Session ${target.resumeId}`
+    case 'workspace':
+      return `Workspace ${target.workspaceId}`
+    case 'inbox':
+      return `Inbox ${target.inboxEntryId}`
+    case 'issue':
+      return `Issue ${target.workspaceId}/${target.issueId}`
+    case 'report':
+      return `Report ${target.workspaceId}/${target.path}`
+    case 'trade-decision':
+      return `Trade decision ${target.accountId}/${target.decisionId}`
+  }
+}
+
+function ConversationLogSection() {
+  const [entries, setEntries] = useState<AgentConversationRecord[]>([])
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [failed, setFailed] = useState(false)
+  const [paused, setPaused] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const fetchPage = useCallback(async (nextPage: number) => {
+    setLoading(true)
+    try {
+      const result = await api.agentConversations.query({
+        page: nextPage,
+        pageSize: CONVERSATION_PAGE_SIZE,
+      })
+      setEntries(result.entries)
+      setPage(result.page)
+      setTotalPages(result.totalPages)
+      setTotal(result.total)
+      setFailed(false)
+    } catch (error) {
+      console.warn('Failed to load Agent conversations:', error)
+      setFailed(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void fetchPage(1) }, [fetchPage])
+
+  useEffect(() => {
+    if (paused || page !== 1) return
+    const interval = setInterval(() => { void fetchPage(1) }, 3000)
+    return () => clearInterval(interval)
+  }, [paused, page, fetchPage])
+
+  const goToPage = useCallback((nextPage: number) => {
+    void fetchPage(nextPage)
+    containerRef.current?.scrollTo?.(0, 0)
+  }, [fetchPage])
+
   return (
-    <div className="flex flex-col flex-1 min-h-0 px-4 md:px-6 py-5">
-      <ToolCallLogSection />
+    <div className="flex flex-col gap-3 min-h-0 flex-1">
+      <div className="flex items-center gap-3 shrink-0">
+        <button
+          type="button"
+          onClick={() => setPaused((value) => !value)}
+          className={`oa-pressable text-xs px-3 py-1.5 rounded-md border transition-colors ${
+            paused
+              ? 'border-warning-border text-warning hover:bg-warning-background'
+              : 'border-border text-muted-foreground hover:bg-muted'
+          }`}
+        >
+          {paused ? 'Resume live updates' : 'Pause live updates'}
+        </button>
+        <span className="text-xs text-muted-foreground ml-auto">
+          {total > 0 ? `Page ${page} of ${totalPages} · ${total} conversations` : '0 conversations'}
+        </span>
+      </div>
+
+      <div
+        ref={containerRef}
+        className="flex-1 min-h-0 bg-background rounded-lg border border-border overflow-auto"
+      >
+        {loading && entries.length === 0 ? (
+          <LogRowsSkeleton />
+        ) : failed && entries.length === 0 ? (
+          <div className="flex h-full min-h-64 flex-col items-center justify-center gap-3 px-6 text-center">
+            <div>
+              <p className="text-sm font-medium text-foreground">Could not load Agent conversations</p>
+              <p className="mt-1 text-xs text-muted-foreground">The private log was not changed.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void fetchPage(page)}
+              className="oa-pressable rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Retry
+            </button>
+          </div>
+        ) : entries.length === 0 ? (
+          <EmptyState
+            title="No Agent conversations yet"
+            description="Messages dispatched between Workspaces will appear here."
+          />
+        ) : (
+          <table className="w-full min-w-[760px] text-xs">
+            <thead className="sticky top-0 z-10 bg-secondary">
+              <tr className="text-left text-muted-foreground">
+                <th className="w-32 px-3 py-2">Time</th>
+                <th className="w-40 px-3 py-2">From</th>
+                <th className="w-40 px-3 py-2">To</th>
+                <th className="w-32 px-3 py-2">Resolution</th>
+                <th className="w-20 px-3 py-2">Status</th>
+                <th className="px-3 py-2">Prompt</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((record) => (
+                <ConversationRow key={record.taskId} record={record} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {failed && entries.length > 0 && (
+        <div className="text-xs text-warning" role="status">
+          Refresh failed; showing the last successful page.
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 shrink-0">
+          <button
+            type="button"
+            onClick={() => goToPage(page - 1)}
+            disabled={page <= 1 || loading}
+            className="oa-icon-action rounded border border-border px-2 py-1 text-xs text-muted-foreground disabled:cursor-not-allowed disabled:opacity-30"
+          >
+            Previous
+          </button>
+          <span className="px-2 text-xs text-muted-foreground">{page} / {totalPages}</span>
+          <button
+            type="button"
+            onClick={() => goToPage(page + 1)}
+            disabled={page >= totalPages || loading}
+            className="oa-icon-action rounded border border-border px-2 py-1 text-xs text-muted-foreground disabled:cursor-not-allowed disabled:opacity-30"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ConversationRow({ record }: { record: AgentConversationRecord }) {
+  const [expanded, setExpanded] = useState(false)
+  const preview = record.prompt.original.replace(/\s+/g, ' ').trim()
+  const promptChanged = record.prompt.original !== record.prompt.delivered
+
+  return (
+    <>
+      <tr className="border-t border-border/50 align-top hover:bg-muted/30">
+        <td className="px-3 py-2 font-mono text-muted-foreground whitespace-nowrap">
+          {formatDateTime(record.dispatchedAt)}
+        </td>
+        <td className="px-3 py-2">
+          <div className="font-medium text-foreground">{sourceLabel(record.source)}</div>
+          <div className="mt-0.5 font-mono text-[10px] text-muted-foreground">{record.source.kind}</div>
+        </td>
+        <td className="px-3 py-2">
+          <div className="font-medium text-foreground">{targetLabel(record.target)}</div>
+          <div className="mt-0.5 font-mono text-[10px] text-muted-foreground">{record.target.resumeId}</div>
+        </td>
+        <td className="px-3 py-2">
+          <div className="text-foreground">
+            {record.resolution.mode === 'exact' ? 'Exact session' : 'Reconstructed provenance'}
+          </div>
+          {record.prompt.mode === 'reconstruction' && (
+            <div className="mt-1 inline-flex rounded-full border border-warning-border bg-warning-background px-1.5 py-0.5 text-[10px] text-warning">
+              Guidance injected
+            </div>
+          )}
+        </td>
+        <td className={`px-3 py-2 font-medium ${conversationStatusColor(record.status)}`}>
+          {record.status}
+          {record.durationMs !== undefined && (
+            <div className="mt-0.5 font-normal text-[10px] text-muted-foreground">
+              {formatDuration(record.durationMs)}
+            </div>
+          )}
+        </td>
+        <td className="px-3 py-2">
+          <button
+            type="button"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((value) => !value)}
+            className="oa-nav-row flex w-full items-start gap-2 rounded px-1 py-0.5 text-left text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          >
+            <span className="min-w-0 flex-1 line-clamp-2">{preview}</span>
+            <span className="shrink-0 text-primary" aria-hidden>{expanded ? '▾' : '▸'}</span>
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-t border-border/30 bg-muted/10">
+          <td colSpan={6} className="px-4 py-4">
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+              <ConversationTextPanel title="Original prompt" text={record.prompt.original} />
+              {promptChanged ? (
+                <ConversationTextPanel
+                  title="Delivered prompt · reconstruction guidance applied"
+                  text={record.prompt.delivered}
+                  tone="warning"
+                />
+              ) : (
+                <ConversationTextPanel
+                  title={record.status === 'running' ? 'Agent reply · running' : 'Agent reply'}
+                  text={record.assistantText ?? record.error ?? 'No reply recorded.'}
+                  tone={record.error ? 'error' : 'default'}
+                />
+              )}
+              {promptChanged && (
+                <ConversationTextPanel
+                  title={record.status === 'running' ? 'Agent reply · running' : 'Agent reply'}
+                  text={record.assistantText ?? record.error ?? 'No reply recorded.'}
+                  tone={record.error ? 'error' : 'default'}
+                />
+              )}
+              <div className="rounded-lg border border-border/70 bg-background p-3">
+                <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Routing
+                </div>
+                <dl className="mt-2 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 font-mono text-[11px]">
+                  <dt className="text-muted-foreground">Requested</dt>
+                  <dd className="break-all text-foreground">{requestedTargetLabel(record.requestedTarget)}</dd>
+                  <dt className="text-muted-foreground">Task</dt>
+                  <dd className="break-all text-foreground">{record.taskId}</dd>
+                  <dt className="text-muted-foreground">Resume</dt>
+                  <dd className="break-all text-foreground">{record.target.resumeId}</dd>
+                  {record.parentTaskId && (
+                    <>
+                      <dt className="text-muted-foreground">Parent</dt>
+                      <dd className="break-all text-foreground">{record.parentTaskId}</dd>
+                    </>
+                  )}
+                  {record.resolution.reason && (
+                    <>
+                      <dt className="text-muted-foreground">Reason</dt>
+                      <dd className="break-all text-foreground">{record.resolution.reason}</dd>
+                    </>
+                  )}
+                </dl>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function ConversationTextPanel({
+  title,
+  text,
+  tone = 'default',
+}: {
+  title: string
+  text: string
+  tone?: 'default' | 'warning' | 'error'
+}) {
+  const toneClass = tone === 'warning'
+    ? 'border-warning-border bg-warning-background/30'
+    : tone === 'error'
+      ? 'border-destructive/30 bg-destructive/5'
+      : 'border-border/70 bg-background'
+  return (
+    <section className={`min-w-0 rounded-lg border p-3 ${toneClass}`}>
+      <h3 className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
+      <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-words font-sans text-xs leading-relaxed text-foreground">
+        {text}
+      </pre>
+    </section>
+  )
+}
+
+export function LogsPage() {
+  const [view, setView] = useState<'tool-calls' | 'agent-conversations'>('agent-conversations')
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 gap-4 px-4 md:px-6 py-5">
+      <SegmentedControl
+        value={view}
+        onChange={setView}
+        ariaLabel="Log type"
+        options={[
+          { value: 'agent-conversations', label: 'Agent conversations' },
+          { value: 'tool-calls', label: 'Tool calls' },
+        ]}
+      />
+      {view === 'agent-conversations' ? <ConversationLogSection /> : <ToolCallLogSection />}
     </div>
   )
 }


### PR DESCRIPTION
## What changed

- adds a read-only, authenticated `/api/agent-conversations` projection that joins dispatch and completion events by task id
- adds bounded newest-first pagination, in-memory read caching, malformed-line tolerance, and a minimized caller projection
- adds an Agent conversations view to Dev → Logs alongside the existing tool-call log
- shows source → target routing, exact/reconstructed provenance, explicit prompt injection, status, timing, original/delivered prompts, reply, and product identifiers
- polls only page one, supports pause/retry/older pages, and adds demo records for ordinary delegation and explicit reconstruction
- updates the conversation provenance owner guide and implementation plan

## Why

The independent JSONL stream introduced in #741 was intentionally suitable for prompt-flow analysis and future visualization, but had no product surface. Reading the file manually also leaks storage details and makes dispatch/completion events harder to understand. This change provides one typed, read-only diagnostic view without adding replay, mutation, notification, or filesystem APIs.

## Impact

Operators can inspect Agent collaboration from the existing Dev panel. Ordinary fresh-worker delegation remains visibly distinct from explicit reconstruction: both can carry reconstructed provenance, but only explicitly wrapped prompts show `Guidance injected` and a separate delivered-prompt panel.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 3388 passed, 9 skipped
- focused store, route, and LogsPage tests — 10 passed
- `pnpm -F open-alice-ui build:demo`
- real demo route visual/interaction check at desktop and narrow viewport; no console warnings/errors
- isolated real `pnpm dev` + `/api/agent-conversations` request and private file-mode check
- `pnpm electron:smoke:workspace` — packaged Workspace acceptance receipt with all checks true
- `git diff --check`