### PR TITLE
fix(demo): report current app version

### DIFF
--- a/ui/src/demo/handlers/devMisc.spec.ts
+++ b/ui/src/demo/handlers/devMisc.spec.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import packageJson from '../../../../package.json'
+import { devMiscHandlers } from './devMisc'
+
+const server = setupServer(...devMiscHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('demo version handlers', () => {
+  it.each([
+    ['GET', '/api/version'],
+    ['POST', '/api/version/check'],
+  ])('returns the checked-in application version for %s %s', async (method, path) => {
+    const response = await fetch(`${baseUrl}${path}`, { method })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.current).toBe(packageJson.version)
+  })
+})

--- a/ui/src/demo/handlers/devMisc.ts
+++ b/ui/src/demo/handlers/devMisc.ts
@@ -1,9 +1,13 @@
 import { http, HttpResponse } from 'msw'
 
+import packageJson from '../../../../package.json'
+
+const currentVersion = packageJson.version
+
 export const devMiscHandlers = [
   http.get('/api/version', () =>
     HttpResponse.json({
-      current: '0.21.0-demo',
+      current: currentVersion,
       latest: null,
       hasUpdate: false,
       releaseUrl: null,
@@ -15,7 +19,7 @@ export const devMiscHandlers = [
 
   http.post('/api/version/check', () =>
     HttpResponse.json({
-      current: '0.21.0-demo',
+      current: currentVersion,
       latest: null,
       hasUpdate: false,
       releaseUrl: null,


### PR DESCRIPTION
## What changed

- read the public demo's version response from the checked-in root `package.json`
- cover both `GET /api/version` and `POST /api/version/check` with an MSW handler test

## Why

The public demo still reported `0.21.0-demo` while the current application baseline is `0.86.0-beta`. That stale hard-coded value made the preview look several releases behind and would drift again on every release.

## User impact

The Settings → About OpenAlice surface now reports the version of the code that produced the demo build.

## Validation

- `pnpm exec vitest run ui/src/demo/handlers/devMisc.spec.ts`
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build:demo`
- `npx tsc --noEmit`
- `pnpm test` (356 files passed, 1 skipped; 3381 tests passed, 9 skipped)
- walked the real demo Settings route and confirmed `v0.86.0-beta` replaces `v0.21.0-demo`
