### PR TITLE
fix(ui): label every toggle control

### DIFF
--- a/ui/src/components/Toggle.spec.tsx
+++ b/ui/src/components/Toggle.spec.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Toggle } from './Toggle'
+
+afterEach(cleanup)
+
+describe('Toggle', () => {
+  it('exposes its purpose and checked state to assistive technology', () => {
+    const onChange = vi.fn()
+    render(
+      <Toggle
+        ariaLabel="Allow AI to push trades"
+        checked={false}
+        onChange={onChange}
+      />,
+    )
+
+    const toggle = screen.getByRole('switch', { name: 'Allow AI to push trades' })
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.click(toggle)
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/ui/src/components/Toggle.tsx
+++ b/ui/src/components/Toggle.tsx
@@ -2,7 +2,7 @@ interface ToggleProps {
   checked: boolean
   onChange: (v: boolean) => void
   size?: 'sm' | 'md'
-  ariaLabel?: string
+  ariaLabel: string
   disabled?: boolean
 }
 

--- a/ui/src/components/uta/CreateUTADialog.tsx
+++ b/ui/src/components/uta/CreateUTADialog.tsx
@@ -249,7 +249,7 @@ export function CreateUTADialog({
                     Allow analysis reads; block broker-side order changes.
                   </div>
                 </div>
-                <Toggle size="sm" checked={readOnly} onChange={setReadOnly} />
+                <Toggle ariaLabel="Read-only account" size="sm" checked={readOnly} onChange={setReadOnly} />
               </div>
               <div className="flex items-center justify-between gap-4 rounded-lg border border-border px-3 py-2.5">
                 <div className="min-w-0">
@@ -258,7 +258,7 @@ export function CreateUTADialog({
                     Include this connector in K-line and contract discovery.
                   </div>
                 </div>
-                <Toggle size="sm" checked={asVendor} onChange={setAsVendor} />
+                <Toggle ariaLabel="Use as data source" size="sm" checked={asVendor} onChange={setAsVendor} />
               </div>
               <SchemaFormFields
                 fields={fields}

--- a/ui/src/components/uta/EditUTADialog.tsx
+++ b/ui/src/components/uta/EditUTADialog.tsx
@@ -115,7 +115,12 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
                 Allow analysis reads; block broker-side order changes.
               </div>
             </div>
-            <Toggle size="sm" checked={draft.readOnly === true} onChange={(v) => setDraft(d => ({ ...d, readOnly: v }))} />
+            <Toggle
+              ariaLabel="Read-only account"
+              size="sm"
+              checked={draft.readOnly === true}
+              onChange={(v) => setDraft(d => ({ ...d, readOnly: v }))}
+            />
           </div>
           <div className="mb-3 flex items-center justify-between gap-4 rounded-lg border border-border px-3 py-2.5">
             <div className="min-w-0">
@@ -124,7 +129,12 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
                 Include this UTA in K-line and contract discovery.
               </div>
             </div>
-            <Toggle size="sm" checked={draft.asVendor !== false} onChange={(v) => setDraft(d => ({ ...d, asVendor: v }))} />
+            <Toggle
+              ariaLabel="Use as data source"
+              size="sm"
+              checked={draft.asVendor !== false}
+              onChange={(v) => setDraft(d => ({ ...d, asVendor: v }))}
+            />
           </div>
           <SchemaFormFields
             fields={fields}
@@ -181,11 +191,15 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
           )}
           {draft.enabled !== false && <ReconnectButton accountId={uta.id} />}
           <label className="flex items-center gap-2 cursor-pointer">
-            <Toggle checked={draft.enabled !== false} onChange={async (v) => {
-              const updated = { ...draft, enabled: v }
-              setDraft(updated)
-              await onSave(updated)
-            }} />
+            <Toggle
+              ariaLabel={`${uta.id} enabled`}
+              checked={draft.enabled !== false}
+              onChange={async (v) => {
+                const updated = { ...draft, enabled: v }
+                setDraft(updated)
+                await onSave(updated)
+              }}
+            />
             <span className="text-[12px] text-muted-foreground">{draft.enabled !== false ? 'Enabled' : 'Disabled'}</span>
           </label>
           {msg && <span className="text-[12px] text-muted-foreground">{msg}</span>}

--- a/ui/src/components/uta/SchemaFormFields.tsx
+++ b/ui/src/components/uta/SchemaFormFields.tsx
@@ -20,7 +20,12 @@ export function SchemaFormFields({ fields, formData, setField, showSecrets }: {
           case 'boolean':
             return (
               <label key={f.key} className="flex items-start gap-2 cursor-pointer select-none">
-                <Toggle size="sm" checked={value === 'true'} onChange={(v) => setField(f.key, v ? 'true' : 'false')} />
+                <Toggle
+                  ariaLabel={f.title}
+                  size="sm"
+                  checked={value === 'true'}
+                  onChange={(v) => setField(f.key, v ? 'true' : 'false')}
+                />
                 <span>
                   <span className="text-[13px] text-foreground">{f.title}</span>
                   {f.description && <p className="text-[11px] text-muted-foreground/60 mt-0.5">{f.description}</p>}

--- a/ui/src/pages/AgentPermissionsPage.tsx
+++ b/ui/src/pages/AgentPermissionsPage.tsx
@@ -190,7 +190,11 @@ function AiTradingToggle({
             {enabled ? t('settings.agent.allowAiTradingOn') : t('settings.agent.allowAiTradingOff')}
           </p>
         </div>
-        <Toggle checked={enabled} onChange={onToggle} />
+        <Toggle
+          ariaLabel={t('settings.agent.allowAiTrading')}
+          checked={enabled}
+          onChange={onToggle}
+        />
       </div>
       {enabled && (
         <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] text-destructive leading-relaxed">

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -243,7 +243,12 @@ export function MarketDataPage() {
         right={
           <div className="flex items-center gap-3">
             <SaveIndicator status={status} onRetry={retry} />
-            <Toggle size="sm" checked={enabled} onChange={(v) => updateConfigImmediate({ enabled: v })} />
+            <Toggle
+              ariaLabel="Market data"
+              size="sm"
+              checked={enabled}
+              onChange={(v) => updateConfigImmediate({ enabled: v })}
+            />
           </div>
         }
       />
@@ -294,7 +299,7 @@ function HubCard({
     <section className="mb-6 border border-border/60 rounded-xl bg-secondary/50 p-5">
       <div className="flex items-center justify-between mb-1.5">
         <h2 className="text-[14px] font-semibold">Data Hub</h2>
-        <Toggle size="sm" checked={hub.enabled} onChange={onToggle} />
+        <Toggle ariaLabel="Data Hub" size="sm" checked={hub.enabled} onChange={onToggle} />
       </div>
       {hub.enabled ? (
         <div className="flex items-center gap-2 mb-1.5">
@@ -385,7 +390,7 @@ function ChartVendorsSection({
                 {v.alwaysOn ? (
                   <span className="text-[11px] text-muted-foreground/60 uppercase tracking-wider shrink-0">always on</span>
                 ) : (
-                  <Toggle size="sm" checked={on} onChange={(val) => onToggle(v.id, val)} />
+                  <Toggle ariaLabel={v.name} size="sm" checked={on} onChange={(val) => onToggle(v.id, val)} />
                 )}
               </div>
               <p className="text-[12px] text-muted-foreground/70 mt-1.5 leading-relaxed">{v.desc}</p>

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -29,7 +29,12 @@ function CollectorSettings() {
     <div className="mx-auto w-full max-w-[880px]">
       <div className="mb-4 flex items-center justify-end gap-3">
         <SaveIndicator status={status} onRetry={retry} />
-        <Toggle size="sm" checked={enabled} onChange={(v) => updateConfigImmediate({ enabled: v })} />
+        <Toggle
+          ariaLabel="News collection"
+          size="sm"
+          checked={enabled}
+          onChange={(v) => updateConfigImmediate({ enabled: v })}
+        />
       </div>
 
       <div className={`${!enabled ? 'opacity-40 pointer-events-none' : ''}`}>
@@ -129,6 +134,7 @@ function FeedsSection({
                 className={`flex items-center gap-3 border border-border/60 rounded-lg px-3 py-2.5 ${isEnabled ? '' : 'opacity-50'}`}
               >
                 <Toggle
+                  ariaLabel={feed.name}
                   size="sm"
                   checked={isEnabled}
                   onChange={(v) => setEnabled(i, v)}

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -930,6 +930,7 @@ function ToolGroupCard({
           </span>
         </button>
         <Toggle
+          ariaLabel={`${label} tools`}
           size="sm"
           checked={!noneEnabled}
           onChange={(v) => onToggleGroup(group.tools, v)}
@@ -961,6 +962,7 @@ function ToolGroupCard({
                   )}
                 </div>
                 <Toggle
+                  ariaLabel={t.name}
                   size="sm"
                   checked={enabled}
                   onChange={() => onToggleTool(t.name)}

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -220,6 +220,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
           // paddings — mixed sizes were what made this row look drunk.
           <div className="flex items-center gap-2">
             <Toggle
+              ariaLabel={`${preset?.label ?? uta.id} enabled`}
               size="sm"
               checked={!isDisabled}
               onChange={async (v) => { await tc.saveUTA({ ...uta, enabled: v }) }}


### PR DESCRIPTION
## What changed

- make `ariaLabel` a required part of the shared `Toggle` contract
- label every toggle across Agent Permissions, Market Data, News, tool settings, UTA setup/edit/detail, schema-driven broker fields, and existing settings surfaces
- add a focused component test for the accessible switch name, checked state, and interaction

## Why

The shared toggle allowed callers to omit an accessible name. In the running Agent Permissions page, the high-risk AI trade-push control appeared in the accessibility tree only as an unnamed `switch`; the same omission affected multiple configuration and broker controls.

Making the label required fixes the current controls and prevents future unlabeled toggles at TypeScript compile time.

## User impact

Screen-reader and other assistive-technology users can now identify the purpose of each switch before changing it, including controls that enable broker writes, market/news providers, tools, and UTA accounts.

## Validation

- `pnpm exec vitest run ui/src/components/Toggle.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 files passed, 1 skipped; 3389 tests passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- walked the real demo routes and confirmed named switches for Agent Permissions, Market Data, Data Hub, chart vendors, and News collection
