### PR TITLE
fix(ui): make workspace cards keyboard accessible

### DIFF
--- a/ui/src/components/workspace/OverviewCard.spec.tsx
+++ b/ui/src/components/workspace/OverviewCard.spec.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../../i18n'
+import type { Workspace } from './api'
+import { OverviewCard } from './OverviewCard'
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+const workspace: Workspace = {
+  id: 'research-desk',
+  tag: 'research',
+  displayName: 'Research desk',
+  dir: '/tmp/research',
+  createdAt: '2026-07-28T00:00:00.000Z',
+  template: 'chat',
+  spawnedFromVersion: '0.1.0',
+  upgradeAvailable: { from: '0.1.0', to: '0.2.0' },
+  agents: ['codex'],
+  agentOverride: {
+    claude: false,
+    codex: true,
+    opencode: false,
+    pi: false,
+  },
+  sessions: [
+    {
+      id: 'session-1',
+      resumeId: 'resume-1',
+      wsId: 'research-desk',
+      agent: 'codex',
+      name: 'x1',
+      createdAt: '2026-07-28T00:00:00.000Z',
+      lastActiveAt: '2026-07-28T00:01:00.000Z',
+      state: 'running',
+      pid: 42,
+      startedAt: 1,
+      title: 'Investigate the market',
+    },
+  ],
+}
+
+describe('OverviewCard', () => {
+  it('exposes native controls for the workspace and its sessions', () => {
+    const onOpen = vi.fn()
+    const onOpenSession = vi.fn()
+    const onConfigure = vi.fn()
+    const onUpgrade = vi.fn()
+    render(
+      <OverviewCard
+        workspace={workspace}
+        lastCommit={null}
+        onOpen={onOpen}
+        onOpenSession={onOpenSession}
+        onConfigure={onConfigure}
+        onUpgrade={onUpgrade}
+      />,
+    )
+
+    const workspaceButton = screen.getByRole('button', { name: 'Research desk' })
+    const sessionButton = screen.getByRole('button', { name: 'x1 running' })
+    expect(workspaceButton.tagName).toBe('BUTTON')
+    expect(sessionButton.tagName).toBe('BUTTON')
+    workspaceButton.focus()
+    expect(document.activeElement).toBe(workspaceButton)
+    sessionButton.focus()
+    expect(document.activeElement).toBe(sessionButton)
+
+    fireEvent.click(screen.getByRole('button', { name: 'v0.2.0' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Workspace override · codex' }))
+    expect(onUpgrade).toHaveBeenCalledTimes(1)
+    expect(onConfigure).toHaveBeenCalledTimes(1)
+    expect(onOpen).not.toHaveBeenCalled()
+
+    fireEvent.click(workspaceButton)
+    fireEvent.click(sessionButton)
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onOpenSession).toHaveBeenCalledWith('session-1')
+  })
+})

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -11,10 +11,9 @@ import { workspaceDisplayName, workspaceDisplayTitle } from './display'
  * relative-activity subtitle, sessions list (each clickable), provider
  * override + latest commit footer (rendered only when present).
  *
- * The card body is clickable (opens the workspace tab). Inner regions —
- * session rows, the ⚙ override row — stopPropagation and route to their
- * own handler so the user can drill in without going through the main
- * workspace landing.
+ * A full-card button opens the workspace tab. It is a sibling of the
+ * interactive session, upgrade, and provider controls so the whole card stays
+ * mouse-friendly without nesting buttons or excluding keyboard users.
  */
 
 const AGENT_ICONS: Record<string, LucideIcon> = {
@@ -76,126 +75,128 @@ export function OverviewCard({
   if (w.agentOverride?.pi) overrideAgents.push('pi')
 
   return (
-    <div
-      onClick={onOpen}
-      className="group rounded-lg border border-border bg-secondary hover:bg-muted/40 hover:border-border/80 transition-colors cursor-pointer p-4 flex flex-col gap-3"
+    <article
+      className="group relative rounded-lg border border-border bg-secondary p-4 transition-colors hover:border-border/80 hover:bg-muted/40"
     >
-      {/* Header */}
-      <div className="flex items-start gap-2.5">
-        <span
-          className={`w-2 h-2 rounded-full mt-1.5 shrink-0 ${dotClass}`}
-          aria-hidden="true"
-        />
-        <div className="flex-1 min-w-0">
-          <h3 className="text-[14px] font-semibold text-foreground truncate" title={workspaceDisplayTitle(w)}>
-            {label}
-          </h3>
-          <p className="text-[11px] text-muted-foreground truncate" title={w.description}>
-            {w.description?.trim() || t('workspace.activeAgo', { time: formatRelativeTime(lastActivityMs) })}
-          </p>
-        </div>
-        {w.upgradeAvailable && w.template && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              onUpgrade?.()
-            }}
-            disabled={!onUpgrade}
-            title={t('workspace.templateUpgrade', {
-              from: w.upgradeAvailable.from,
-              to: w.upgradeAvailable.to,
-            })}
-            className="oa-pressable shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-primary border border-primary/40 hover:border-primary/80 hover:bg-primary/10 transition-colors disabled:cursor-default disabled:hover:border-primary/40 disabled:hover:bg-transparent"
-          >
-            <ArrowUpCircle size={10} strokeWidth={2.25} />
-            <span>v{w.upgradeAvailable.to}</span>
-          </button>
-        )}
-      </div>
+      <button
+        type="button"
+        aria-label={label}
+        onClick={onOpen}
+        className="absolute inset-0 z-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      />
 
-      {/* Sessions */}
-      <div className="border-t border-border pt-3">
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-1.5">
-          {t('workspace.sessions')}
-        </div>
-        {w.sessions.length === 0 ? (
-          <p className="text-[12px] text-muted-foreground/80 italic">{t('workspace.noSessions')}</p>
-        ) : (
-          <ul className="space-y-0.5 -mx-2">
-            {w.sessions.map((s) => (
-              <li
-                key={s.id}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onOpenSession(s.id)
-                }}
-                className="flex items-center gap-2 text-[12px] text-foreground hover:bg-muted/40 px-2 py-1 rounded transition-colors cursor-pointer"
-              >
-                <span className="w-3 flex justify-center text-muted-foreground">
-                  <AgentGlyph agent={s.agent} />
-                </span>
-                <span className="font-mono text-[11px] tabular-nums">{s.name}</span>
-                <span
-                  className={`text-[11px] ${
-                    s.state === 'running' ? 'text-success' : 'text-muted-foreground'
-                  }`}
-                >
-                  {t(s.state === 'running' ? 'workspace.running' : 'workspace.paused')}
-                </span>
-                <ChevronRight
-                  size={10}
-                  className="ml-auto text-muted-foreground opacity-0 group-hover:opacity-60 transition-opacity"
-                />
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      {/* Footer — only rendered when there's something to show */}
-      {(overrideAgents.length > 0 || lastCommit || (w.template && w.spawnedFromVersion)) && (
-        <div className="border-t border-border pt-3 space-y-1.5">
-          {w.template && w.spawnedFromVersion && (
-            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-              <GitBranch size={11} strokeWidth={2.25} className="shrink-0" />
-              <span className="truncate">
-                {t('workspace.fromTemplate', {
-                  template: w.template,
-                  version: w.spawnedFromVersion,
-                })}
-              </span>
-            </div>
-          )}
-          {overrideAgents.length > 0 && onConfigure && (
+      <div className="pointer-events-none relative z-10 flex flex-col gap-3">
+        {/* Header */}
+        <div className="flex items-start gap-2.5">
+          <span
+            className={`w-2 h-2 rounded-full mt-1.5 shrink-0 ${dotClass}`}
+            aria-hidden="true"
+          />
+          <div className="flex-1 min-w-0">
+            <h3 className="text-[14px] font-semibold text-foreground truncate" title={workspaceDisplayTitle(w)}>
+              {label}
+            </h3>
+            <p className="text-[11px] text-muted-foreground truncate" title={w.description}>
+              {w.description?.trim() || t('workspace.activeAgo', { time: formatRelativeTime(lastActivityMs) })}
+            </p>
+          </div>
+          {w.upgradeAvailable && w.template && (
             <button
               type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                onConfigure()
-              }}
-              className="flex items-center gap-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+              onClick={() => onUpgrade?.()}
+              disabled={!onUpgrade}
+              title={t('workspace.templateUpgrade', {
+                from: w.upgradeAvailable.from,
+                to: w.upgradeAvailable.to,
+              })}
+              className="oa-pressable pointer-events-auto shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-primary border border-primary/40 hover:border-primary/80 hover:bg-primary/10 transition-colors disabled:cursor-default disabled:hover:border-primary/40 disabled:hover:bg-transparent"
             >
-              <Settings size={11} strokeWidth={2.25} className="shrink-0" />
-              <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
+              <ArrowUpCircle size={10} strokeWidth={2.25} />
+              <span>v{w.upgradeAvailable.to}</span>
             </button>
           )}
-          {overrideAgents.length > 0 && !onConfigure && (
-            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-              <Settings size={11} strokeWidth={2.25} className="shrink-0" />
-              <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
-            </div>
-          )}
-          {lastCommit && (
-            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-              <ScrollText size={11} strokeWidth={2.25} className="shrink-0" />
-              <span className="truncate" title={lastCommit.subject}>
-                {lastCommit.subject}
-              </span>
-            </div>
+        </div>
+
+        {/* Sessions */}
+        <div className="border-t border-border pt-3">
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-1.5">
+            {t('workspace.sessions')}
+          </div>
+          {w.sessions.length === 0 ? (
+            <p className="text-[12px] text-muted-foreground/80 italic">{t('workspace.noSessions')}</p>
+          ) : (
+            <ul className="space-y-0.5 -mx-2">
+              {w.sessions.map((s) => (
+                <li key={s.id}>
+                  <button
+                    type="button"
+                    aria-label={`${s.name} ${t(s.state === 'running' ? 'workspace.running' : 'workspace.paused')}`}
+                    onClick={() => onOpenSession(s.id)}
+                    className="oa-nav-row pointer-events-auto flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[12px] text-foreground hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  >
+                    <span className="w-3 flex justify-center text-muted-foreground">
+                      <AgentGlyph agent={s.agent} />
+                    </span>
+                    <span className="font-mono text-[11px] tabular-nums">{s.name}</span>
+                    <span
+                      className={`text-[11px] ${
+                        s.state === 'running' ? 'text-success' : 'text-muted-foreground'
+                      }`}
+                    >
+                      {t(s.state === 'running' ? 'workspace.running' : 'workspace.paused')}
+                    </span>
+                    <ChevronRight
+                      size={10}
+                      className="ml-auto text-muted-foreground opacity-0 group-hover:opacity-60 transition-opacity"
+                    />
+                  </button>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
-      )}
-    </div>
+
+        {/* Footer — only rendered when there's something to show */}
+        {(overrideAgents.length > 0 || lastCommit || (w.template && w.spawnedFromVersion)) && (
+          <div className="border-t border-border pt-3 space-y-1.5">
+            {w.template && w.spawnedFromVersion && (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <GitBranch size={11} strokeWidth={2.25} className="shrink-0" />
+                <span className="truncate">
+                  {t('workspace.fromTemplate', {
+                    template: w.template,
+                    version: w.spawnedFromVersion,
+                  })}
+                </span>
+              </div>
+            )}
+            {overrideAgents.length > 0 && onConfigure && (
+              <button
+                type="button"
+                onClick={onConfigure}
+                className="pointer-events-auto flex items-center gap-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+              >
+                <Settings size={11} strokeWidth={2.25} className="shrink-0" />
+                <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
+              </button>
+            )}
+            {overrideAgents.length > 0 && !onConfigure && (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <Settings size={11} strokeWidth={2.25} className="shrink-0" />
+                <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
+              </div>
+            )}
+            {lastCommit && (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <ScrollText size={11} strokeWidth={2.25} className="shrink-0" />
+                <span className="truncate" title={lastCommit.subject}>
+                  {lastCommit.subject}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </article>
   )
 }


### PR DESCRIPTION
## What changed

- replace click-only Workspace Overview card containers with a native full-card button
- render Session drill-in rows as native buttons with explicit state-aware accessible names
- keep template-upgrade and provider-configuration actions as independent sibling controls, avoiding nested interactive elements
- add a focused component regression test covering focusability, card/session routing, and independent inner actions

## Why

The overview described its card body and Session rows as clickable, but implemented them with `onClick` handlers on `<div>` and `<li>` elements. In the running demo they were absent from the accessibility tree as controls, so keyboard and screen-reader users could not open a Workspace or drill into a Session from the dashboard.

## User impact

Every active Workspace and Session in Workspaces Overview is now discoverable, focusable, and activatable as a named native button while preserving the existing full-card mouse target and visual layout.

## Validation

- `pnpm exec vitest run ui/src/components/workspace/OverviewCard.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 files passed, 1 skipped; 3389 tests passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- walked the real demo Workspaces Overview route and confirmed named Workspace/Session buttons, full-card navigation, AAPL Session drill-in, and unchanged visual layout
