### PR TITLE
feat(demo): simulate trading order pushes

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -406,6 +406,8 @@ export interface WalletPushResult {
   operationCount: number
   submitted: Array<{ action: string; success: boolean; orderId?: string; status: string; error?: string }>
   rejected: Array<{ action: string; success: boolean; error?: string; status: string }>
+  /** Demo-only marker: the response exercises the result UI without contacting a broker. */
+  simulated?: boolean
 }
 
 // ==================== Order / Trade History ====================

--- a/ui/src/components/uta/OrderEntryDialog.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.tsx
@@ -365,13 +365,16 @@ function PushResultPanel({ result }: { result: WalletPushResult }) {
   const totalRejected = result.rejected.length
   const totalSubmitted = result.submitted.length
   const fullySubmitted = totalRejected === 0 && totalSubmitted > 0
+  const simulated = result.simulated === true
 
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
         <span className={`w-2 h-2 rounded-full shrink-0 ${fullySubmitted ? 'bg-success' : 'bg-warning'}`} />
         <span className={`text-[13px] font-medium ${fullySubmitted ? 'text-success' : 'text-warning'}`}>
-          {fullySubmitted
+          {simulated
+            ? `${totalSubmitted} operation${totalSubmitted > 1 ? 's' : ''} simulated`
+            : fullySubmitted
             ? `${totalSubmitted} operation${totalSubmitted > 1 ? 's' : ''} submitted to broker`
             : `${totalSubmitted} submitted, ${totalRejected} rejected`}
         </span>
@@ -389,16 +392,24 @@ function PushResultPanel({ result }: { result: WalletPushResult }) {
       </div>
 
       {result.submitted.length > 0 && (
-        <OpTable title="Submitted" rows={result.submitted} kind="submitted" />
+        <OpTable title={simulated ? 'Simulated' : 'Submitted'} rows={result.submitted} kind="submitted" />
       )}
       {result.rejected.length > 0 && (
         <OpTable title="Rejected" rows={result.rejected} kind="rejected" />
       )}
 
-      <p className="text-[11px] text-muted-foreground leading-relaxed">
-        Status <strong className="text-foreground">Submitted</strong> means the broker accepted the order — fills happen async.
-        Refresh the positions / orders panels in a moment to see the order transition to <strong className="text-foreground">Filled</strong>.
-      </p>
+      {simulated
+        ? (
+          <p className="text-[11px] text-muted-foreground leading-relaxed">
+            Demo simulation only — no order was sent to a broker and portfolio data was not changed.
+          </p>
+        )
+        : (
+          <p className="text-[11px] text-muted-foreground leading-relaxed">
+            Status <strong className="text-foreground">Submitted</strong> means the broker accepted the order — fills happen async.
+            Refresh the positions / orders panels in a moment to see the order transition to <strong className="text-foreground">Filled</strong>.
+          </p>
+        )}
     </div>
   )
 }
@@ -482,4 +493,3 @@ function Segmented({ value, options, onChange }: {
     </div>
   )
 }
-

--- a/ui/src/demo/handlers/trading.spec.ts
+++ b/ui/src/demo/handlers/trading.spec.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import { tradingHandlers } from './trading'
+
+const server = setupServer(...tradingHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('demo trading handlers', () => {
+  it.each([
+    ['place-order', 'placeOrder', 'demo-placeOrder-order'],
+    ['close-position', 'closePosition', 'demo-closePosition-order'],
+  ])('simulates a successful %s push without persistence', async (route, action, orderId) => {
+    const response = await fetch(`${baseUrl}/api/trading/uta/demo-paper/wallet/${route}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message: 'Demo trading intent' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      hash: `demo-${action}-commit`,
+      message: 'Demo trading intent',
+      operationCount: 1,
+      submitted: [{ action, success: true, orderId, status: 'Simulated' }],
+      rejected: [],
+      simulated: true,
+    })
+  })
+
+  it('echoes the requested order id for a simulated cancellation', async () => {
+    const response = await fetch(`${baseUrl}/api/trading/uta/demo-paper/wallet/cancel-order`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orderId: 'broker-order-42', message: 'Cancel stale order' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      hash: 'demo-cancelOrder-commit',
+      message: 'Cancel stale order',
+      operationCount: 1,
+      submitted: [{
+        action: 'cancelOrder',
+        success: true,
+        orderId: 'broker-order-42',
+        status: 'Simulated',
+      }],
+      rejected: [],
+      simulated: true,
+    })
+  })
+})

--- a/ui/src/demo/handlers/trading.ts
+++ b/ui/src/demo/handlers/trading.ts
@@ -43,6 +43,27 @@ function utaId(params: { id?: string | readonly string[] }): string {
   return Array.isArray(v) ? v[0] ?? '' : String(v ?? '')
 }
 
+type DemoOrderAction = 'placeOrder' | 'closePosition' | 'cancelOrder'
+
+async function simulateOrderPush(request: Request, action: DemoOrderAction) {
+  const body = await request.json() as { message?: unknown; orderId?: unknown }
+  const message = typeof body.message === 'string' && body.message.trim()
+    ? body.message.trim()
+    : `Demo ${action}`
+  const orderId = action === 'cancelOrder' && typeof body.orderId === 'string'
+    ? body.orderId
+    : `demo-${action}-order`
+
+  return HttpResponse.json({
+    hash: `demo-${action}-commit`,
+    message,
+    operationCount: 1,
+    submitted: [{ action, success: true, orderId, status: 'Simulated' }],
+    rejected: [],
+    simulated: true,
+  })
+}
+
 const demoBrokerPresets = [
   {
     id: 'alpaca', label: 'Alpaca', description: 'US equities with paper-trading support.',
@@ -157,23 +178,14 @@ export const tradingHandlers = [
       rejected: [],
     }),
   ),
-  http.post('/api/trading/uta/:id/wallet/place-order', () =>
-    HttpResponse.json(
-      { error: 'Demo mode — orders are read-only.', phase: 'validate' },
-      { status: 400 },
-    ),
+  http.post('/api/trading/uta/:id/wallet/place-order', ({ request }) =>
+    simulateOrderPush(request, 'placeOrder'),
   ),
-  http.post('/api/trading/uta/:id/wallet/close-position', () =>
-    HttpResponse.json(
-      { error: 'Demo mode — orders are read-only.', phase: 'validate' },
-      { status: 400 },
-    ),
+  http.post('/api/trading/uta/:id/wallet/close-position', ({ request }) =>
+    simulateOrderPush(request, 'closePosition'),
   ),
-  http.post('/api/trading/uta/:id/wallet/cancel-order', () =>
-    HttpResponse.json(
-      { error: 'Demo mode — orders are read-only.', phase: 'validate' },
-      { status: 400 },
-    ),
+  http.post('/api/trading/uta/:id/wallet/cancel-order', ({ request }) =>
+    simulateOrderPush(request, 'cancelOrder'),
   ),
 
   http.get('/api/trading/config/broker-presets', () => HttpResponse.json({ presets: demoBrokerPresets })),


### PR DESCRIPTION
## Summary

- return deterministic, non-persistent demo push results for place, close, and cancel order endpoints
- mark demo results explicitly as simulated so the order dialog never claims a broker accepted them
- add demo handler contract coverage for all three order mutations

## Why

The demo exposes the complete manual order form and says mutations are simulated, but every trading submission previously ended in a hard-coded read-only validation error. That prevented visitors from seeing the stage → commit → push result surface. This keeps the demo safe and non-persistent while allowing the workflow to complete honestly.

## Verification

- `git diff --check`
- `npx tsc --noEmit`
- `pnpm test` (358 passed, 1 skipped; 3391 tests passed, 9 skipped)
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build:demo`
- walked `pnpm -F open-alice-ui dev:demo --host 127.0.0.1` in the real Portfolio → Alpaca Paper route
  - Place Order shows `1 operation simulated`
  - AAPL Close Position shows `1 operation simulated`
  - both state that no order was sent to a broker and portfolio data was not changed

## Safety

Demo MSW handlers only. No UTA state-machine, broker adapter, configured account, or live-paper path was exercised or changed.