### PR TITLE
fix(ui): honor UTA account labels

### DIFF
--- a/ui/src/components/uta/EditUTADialog.tsx
+++ b/ui/src/components/uta/EditUTADialog.tsx
@@ -5,6 +5,7 @@ import { GuardsSection, CRYPTO_GUARD_TYPES, SECURITIES_GUARD_TYPES } from '../gu
 import { ReconnectButton } from '../ReconnectButton'
 import { useSchemaForm } from '../../hooks/useSchemaForm'
 import type { UTAConfig, BrokerPreset, BrokerHealthInfo } from '../../api/types'
+import { displayNameForUTA } from '../../lib/uta-account-filter'
 import { Dialog } from './Dialog'
 import { HealthBadge } from './HealthBadge'
 import { SchemaFormFields } from './SchemaFormFields'
@@ -71,13 +72,19 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
   }
 
   const guardTypes = (preset?.guardCategory === 'crypto') ? CRYPTO_GUARD_TYPES : SECURITIES_GUARD_TYPES
+  const displayName = displayNameForUTA(uta, preset)
 
   return (
     <Dialog onClose={onClose} width="w-[560px]">
       {/* Header */}
       <div className="shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
         <div className="flex items-center gap-3 min-w-0">
-          <h3 className="text-[14px] font-semibold text-foreground truncate">{uta.id}</h3>
+          <div className="min-w-0">
+            <h3 className="text-[14px] font-semibold text-foreground truncate">{displayName}</h3>
+            {displayName !== uta.id && (
+              <div className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">{uta.id}</div>
+            )}
+          </div>
           <HealthBadge health={health} size="md" />
         </div>
         <div className="flex items-center gap-3 shrink-0">

--- a/ui/src/lib/uta-account-filter.spec.ts
+++ b/ui/src/lib/uta-account-filter.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { UTASummary, UTATier } from '../api/types'
-import { displayProviderForUTA, filterAccountTierUTAs, isAccountTierUTA } from './uta-account-filter'
+import { displayNameForUTA, displayProviderForUTA, filterAccountTierUTAs, isAccountTierUTA } from './uta-account-filter'
 
 function summary(id: string, tier: UTATier): UTASummary {
   return {
@@ -41,5 +41,17 @@ describe('UTA account filtering', () => {
     expect(displayProviderForUTA({ id: 'paper', provider: 'alpaca' })).toBe('alpaca')
     expect(displayProviderForUTA({ id: 'binance-readonly' })).toBe('ccxt')
     expect(displayProviderForUTA({ id: 'ibkr-main' })).toBe('ibkr')
+  })
+
+  it('prefers the configured account label for display names', () => {
+    expect(displayNameForUTA(
+      { id: 'alpaca-paper', label: 'Retirement Paper' },
+      { label: 'Alpaca' },
+    )).toBe('Retirement Paper')
+    expect(displayNameForUTA(
+      { id: 'ibkr-main', label: '   ' },
+      { label: 'IBKR' },
+    )).toBe('IBKR')
+    expect(displayNameForUTA({ id: 'custom-broker' })).toBe('custom-broker')
   })
 })

--- a/ui/src/lib/uta-account-filter.ts
+++ b/ui/src/lib/uta-account-filter.ts
@@ -10,6 +10,13 @@ export function filterAccountTierUTAs<T extends UTAAccountCandidate>(utas: reado
   return utas.filter(isAccountTierUTA)
 }
 
+export function displayNameForUTA(
+  uta: { id: string; label?: string },
+  preset?: { label?: string },
+): string {
+  return uta.label?.trim() || preset?.label?.trim() || uta.id
+}
+
 export function displayProviderForUTA(uta: { id: string; provider?: string }): string {
   if (uta.provider) return uta.provider
   const id = uta.id.toLowerCase()

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -18,6 +18,7 @@ import { Metric, signFromDelta } from '../components/Metric'
 import { fmt, fmtPnl, fmtNum, fmtPctSigned, isUnsetDecimal } from '../lib/format'
 import { secTypeToClass, assetClassLabel, ASSET_CLASS_ORDER, type AssetClass } from '../lib/asset-class'
 import { ContractCell } from '../lib/contract-display'
+import { displayNameForUTA } from '../lib/uta-account-filter'
 
 // ==================== Page ====================
 
@@ -197,11 +198,12 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   }
 
   const isDisabled = uta.enabled === false
+  const displayName = displayNameForUTA(uta, preset)
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader
-        title={preset?.label ?? uta.id}
+        title={displayName}
         live={{ lastUpdated }}
         description={
           <>
@@ -276,7 +278,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
               {curvePoints.length >= 2 && (
                 <EquityCurve
                   points={curvePoints}
-                  accounts={[{ id, label: preset?.label ?? id }]}
+                  accounts={[{ id, label: displayName }]}
                   selectedAccountId={id}
                   onAccountChange={() => { /* single-account mode: switcher hidden */ }}
                 />


### PR DESCRIPTION
## Summary

- prefer each UTA's configured account label over broker preset names or internal ids
- use the same display name in the account detail header, single-account equity curve, and edit dialog
- keep the internal UTA id visible as secondary context in the detail and edit surfaces
- cover the display-name fallback order with a focused unit test

## Why

The Portfolio sidebar and Trading card show the user-configured account label, but the detail route and edit dialog ignored it. In the demo this produced `Alpaca Paper` in navigation and the internal id `demo-paper` as the page/dialog title. Real accounts with custom labels had the same inconsistency.

## Verification

- `git diff --check`
- `npx tsc --noEmit`
- `pnpm vitest run ui/src/lib/uta-account-filter.spec.ts` (4 passed)
- `pnpm vitest run services/uta/src/domain/trading/brokers/registry.spec.ts` (7 passed; reran after an unrelated one-off 5.023s timeout in the first full-suite attempt)
- `pnpm test` (357 files passed, 1 skipped; 3389 tests passed, 9 skipped)
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build:demo`
- walked `pnpm -F open-alice-ui dev:demo --host 127.0.0.1` in Portfolio → Alpaca Paper
  - account detail title shows `Alpaca Paper` while preserving `demo-paper` in the metadata row
  - Edit dialog shows `Alpaca Paper` as its heading and `demo-paper` as the secondary id

## Scope

UI display only. No broker, UTA state-machine, persisted config, or trading-write behavior changed.