### PR TITLE
fix(demo): restore Issue run conversations

### DIFF
--- a/ui/src/demo/fixtures/workspaces.ts
+++ b/ui/src/demo/fixtures/workspaces.ts
@@ -44,6 +44,8 @@ export const demoWorkspace: Workspace = {
 // history visible.
 export const DEMO_CHAT_WORKSPACE_ID = 'demo-chat-ws'
 export const DEMO_CHAT_SESSION_ID = 'demo-chat-session'
+export const DEMO_AUTO_QUANT_WORKSPACE_ID = 'demo-ws-auto-quant'
+export const DEMO_MACRO_WORKSPACE_ID = 'demo-ws-macro'
 
 // A small spread of agents + states so the sidebar shows the full session
 // styling (per-agent badge colours for claude/codex/opencode/pi, the paused
@@ -119,7 +121,34 @@ export const demoChatWorkspace: Workspace = {
   agentOverride: { claude: false, codex: false, opencode: false, pi: false },
 }
 
-export const demoWorkspaces: Workspace[] = [demoWorkspace, demoChatWorkspace]
+const demoIssueWorkspaces: Workspace[] = [
+  {
+    id: DEMO_AUTO_QUANT_WORKSPACE_ID,
+    tag: 'auto-quant',
+    displayName: 'Auto Quant',
+    dir: '/demo/workspaces/auto-quant',
+    createdAt: new Date().toISOString(),
+    agents: ['codex'],
+    sessions: [],
+    agentOverride: { claude: false, codex: false, opencode: false, pi: false },
+  },
+  {
+    id: DEMO_MACRO_WORKSPACE_ID,
+    tag: 'macro-research',
+    displayName: 'Macro Research',
+    dir: '/demo/workspaces/macro-research',
+    createdAt: new Date().toISOString(),
+    agents: ['codex'],
+    sessions: [],
+    agentOverride: { claude: false, codex: false, opencode: false, pi: false },
+  },
+]
+
+export const demoWorkspaces: Workspace[] = [
+  demoWorkspace,
+  demoChatWorkspace,
+  ...demoIssueWorkspaces,
+]
 
 // Templates — names + metadata mirror the real template at
 // src/workspaces/templates/chat/template.json. The name matters: the Chat /

--- a/ui/src/demo/handlers/workspaces-resume.spec.ts
+++ b/ui/src/demo/handlers/workspaces-resume.spec.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import {
+  DEMO_AUTO_QUANT_WORKSPACE_ID,
+  DEMO_MACRO_WORKSPACE_ID,
+} from '../fixtures/workspaces'
+import { resetDemoWorkspaceWebPiState, workspacesHandlers } from './workspaces'
+
+const server = setupServer(...workspacesHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => {
+  server.resetHandlers()
+  resetDemoWorkspaceWebPiState()
+})
+afterAll(() => server.close())
+
+describe('demo Workspace resume handlers', () => {
+  it('registers Issue workspaces and materializes a resumable run conversation', async () => {
+    const before = await fetch(`${baseUrl}/api/workspaces`).then((response) => response.json())
+    expect(before.workspaces.map((workspace: { id: string }) => workspace.id)).toEqual(
+      expect.arrayContaining([DEMO_AUTO_QUANT_WORKSPACE_ID, DEMO_MACRO_WORKSPACE_ID]),
+    )
+
+    const resumeId = 'demo-resume-morning-1'
+    const url = `${baseUrl}/api/workspaces/${DEMO_AUTO_QUANT_WORKSPACE_ID}/resumes/${resumeId}/session`
+    const createdResponse = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title: 'Morning movers scan · codex' }),
+    })
+    const created = await createdResponse.json()
+
+    expect(createdResponse.status).toBe(201)
+    expect(created).toMatchObject({
+      created: true,
+      session: {
+        id: `run-${resumeId}`,
+        wsId: DEMO_AUTO_QUANT_WORKSPACE_ID,
+        resumeId,
+        agent: 'codex',
+        state: 'running',
+        title: 'Morning movers scan · codex',
+      },
+    })
+
+    const reopenedResponse = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title: 'A different title should not replace the durable Session' }),
+    })
+    expect(reopenedResponse.status).toBe(200)
+    expect(await reopenedResponse.json()).toMatchObject({
+      created: false,
+      session: { id: `run-${resumeId}`, resumeId, title: 'Morning movers scan · codex' },
+    })
+
+    const after = await fetch(`${baseUrl}/api/workspaces`).then((response) => response.json())
+    const workspace = after.workspaces.find(
+      (candidate: { id: string }) => candidate.id === DEMO_AUTO_QUANT_WORKSPACE_ID,
+    )
+    expect(workspace.sessions).toContainEqual(expect.objectContaining({ id: `run-${resumeId}` }))
+  })
+})

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -1,5 +1,10 @@
 import { http, HttpResponse } from 'msw'
-import { demoChatWorkspace, demoWorkspaces, demoTemplates } from '../fixtures/workspaces'
+import {
+  DEMO_AUTO_QUANT_WORKSPACE_ID,
+  demoChatWorkspace,
+  demoWorkspaces,
+  demoTemplates,
+} from '../fixtures/workspaces'
 import { demoWorkspaceFiles } from '../fixtures/inbox'
 import {
   createDemoWebPiSnapshot,
@@ -56,7 +61,9 @@ export function resetDemoWorkspaceWebPiState(): void {
     const workspace = demoWorkspaces[index]!
     demoWorkspaces[index] = {
       ...workspace,
-      sessions: workspace.sessions.filter((session) => !session.id.startsWith('demo-quick-chat-')),
+      sessions: workspace.sessions.filter((session) =>
+        !session.id.startsWith('demo-quick-chat-')
+        && !session.id.startsWith('run-demo-resume-')),
     }
   }
 }
@@ -657,7 +664,7 @@ export const workspacesHandlers = [
     const workspace = demoWorkspaces.find((candidate) =>
       candidate.sessions.some((session) => session.resumeId === resumeId),
     ) ?? (resumeId === 'resume-demo-thesis-owner'
-      ? demoWorkspaces.find((candidate) => candidate.id === 'demo-ws-auto-quant')
+      ? demoWorkspaces.find((candidate) => candidate.id === DEMO_AUTO_QUANT_WORKSPACE_ID)
       : undefined)
     if (!workspace) return HttpResponse.json({ error: 'not_found' }, { status: 404 })
     const session = workspace.sessions.find((candidate) => candidate.resumeId === resumeId)
@@ -672,7 +679,7 @@ export const workspacesHandlers = [
   }),
   http.get('/api/workspaces/:id/resumes', ({ params }) => {
     const wsId = String(params.id)
-    if (wsId === 'demo-ws-auto-quant') {
+    if (wsId === DEMO_AUTO_QUANT_WORKSPACE_ID) {
       return HttpResponse.json({
         workspace: { id: wsId, tag: 'auto-quant' },
         sessions: [{
@@ -707,13 +714,14 @@ export const workspacesHandlers = [
       })),
     })
   }),
-  http.post('/api/workspaces/:id/resumes/:resumeId/session', ({ params }) => {
+  http.post('/api/workspaces/:id/resumes/:resumeId/session', async ({ params, request }) => {
     const wsId = String(params.id)
     const resumeId = String(params.resumeId)
     const workspace = demoWorkspaces.find((candidate) => candidate.id === wsId)
     if (!workspace) return HttpResponse.json({ error: 'workspace_not_found' }, { status: 404 })
     const existing = workspace.sessions.find((session) => session.resumeId === resumeId)
     if (existing) return HttpResponse.json({ session: existing, created: false })
+    const body = await request.json().catch(() => ({})) as { title?: unknown }
     const now = new Date().toISOString()
     const session = {
       id: `run-${resumeId}`,
@@ -726,7 +734,9 @@ export const workspacesHandlers = [
       state: 'running' as const,
       pid: 0,
       startedAt: Date.now(),
-      title: 'Compute a quant snapshot of NVDA and push a report to the inbox.',
+      title: typeof body.title === 'string' && body.title.trim()
+        ? body.title.trim()
+        : 'Resumed demo run',
       sourceRunId: 'demo-headless-1',
     }
     ;(workspace.sessions as Array<typeof session>).push(session)


### PR DESCRIPTION
## Summary

- register the auto-quant and macro-research Workspaces referenced by demo Issues and Inbox records
- let the demo resume endpoint materialize and idempotently reopen an Issue run Session
- preserve the run-specific title supplied by the caller instead of using an unrelated hard-coded NVDA title
- reset generated resume Sessions between handler tests and cover the full create/reopen/list contract

## Why

Issue detail exposed enabled `Open conversation` buttons for resumable runs, but clicking one did nothing. The run belonged to `demo-ws-auto-quant` while the demo Workspace registry only contained `demo-ws` and `demo-chat-ws`, so `/resumes/:resumeId/session` returned `workspace_not_found`; the fire-and-forget UI call then had no navigation target.

## Verification

- `git diff --check`
- `npx tsc --noEmit`
- `pnpm vitest run ui/src/demo/handlers/workspaces-resume.spec.ts ui/src/demo/handlers/workspaces-webpi.spec.ts` (2 files, 4 tests passed)
- `pnpm test` (358 files passed, 1 skipped; 3389 tests passed, 9 skipped)
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build:demo`
- walked `pnpm -F open-alice-ui dev:demo --host 127.0.0.1`
  - opened Issues → Morning movers scan
  - clicked the newest resumable run's `Open conversation`
  - confirmed navigation into the `auto-quant · x1` demo Agent terminal

## Scope

Demo fixtures and MSW handlers only. The production Workspace resume API, Session identity, scheduler, and runtime behavior are unchanged.