### PR TITLE
fix(demo): reconnect Tracked note workspaces

### DIFF
--- a/ui/src/demo/fixtures/entities.ts
+++ b/ui/src/demo/fixtures/entities.ts
@@ -1,9 +1,10 @@
 import type { EntityListItem, EntityDetail } from '../../api/entities'
+import { DEMO_CHAT_WORKSPACE_ID, demoChatWorkspace } from './workspaces'
 
 /**
- * Demo tracked-entities — mirrors the real chat-jun3 power / AI-infra graph
- * so the marketing demo shows the actual shape: a few assets + the theme that
- * ties them together, each referenced across the dated rotation notes.
+ * Demo tracked-entities — mirrors the power / AI-infra graph so the marketing
+ * demo shows the actual shape: a few assets + the theme that ties them
+ * together, each referenced across the dated rotation notes.
  *
  * Backlinks now also include ISSUE NOTES. Since `.alice/issues/<id>.md` bodies
  * feed the same `[[name]]` reverse index, an entity's backlinks can point at an
@@ -38,7 +39,13 @@ export const demoEntities: EntityListItem[] = [
   },
 ]
 
-const ws = { workspaceId: 'demo-ws-1', workspaceTag: 'chat-jun3' }
+// Plain-note backlinks belong to the registered demo Chat Workspace. Keeping
+// this identity aligned makes the file viewer's provenance label and Back
+// action resolve to a real Workspace instead of a stale fixture-only id.
+const ws = {
+  workspaceId: DEMO_CHAT_WORKSPACE_ID,
+  workspaceTag: demoChatWorkspace.tag,
+}
 // Workspaces that own the demo issues (see ./issues.ts). Issue-note backlinks
 // carry the issue's wsId + a `.alice/issues/<id>.md` path so the Tracked UI can
 // route them to the issue detail rather than rendering a raw file path.

--- a/ui/src/demo/handlers/entities.spec.ts
+++ b/ui/src/demo/handlers/entities.spec.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import type { EntityDetail } from '../../api/entities'
+import {
+  DEMO_CHAT_WORKSPACE_ID,
+  demoChatWorkspace,
+  demoWorkspaces,
+} from '../fixtures/workspaces'
+import { entitiesHandlers } from './entities'
+
+const server = setupServer(...entitiesHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('demo Tracked handlers', () => {
+  it('keeps note backlinks attached to a registered Workspace', async () => {
+    const response = await fetch(`${baseUrl}/api/entities/stock-vst`)
+    const detail = await response.json() as EntityDetail
+    const noteBacklinks = detail.backlinks.filter(
+      (backlink) => !backlink.path.startsWith('.alice/issues/'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(demoWorkspaces).toContain(demoChatWorkspace)
+    expect(noteBacklinks).not.toHaveLength(0)
+    for (const backlink of noteBacklinks) {
+      expect(backlink).toMatchObject({
+        workspaceId: DEMO_CHAT_WORKSPACE_ID,
+        workspaceTag: demoChatWorkspace.tag,
+      })
+    }
+  })
+})


### PR DESCRIPTION
## What changed

- attach plain-note Tracked backlinks to the registered demo Chat Workspace instead of the stale fixture-only `demo-ws-1`
- derive the backlink label from the Workspace fixture so identity cannot drift independently
- add a demo handler contract test that requires ordinary note backlinks to resolve to that registered Workspace

## Why

Opening a normal note from Tracked showed the truncated internal label `demo-ws-` and its Back action targeted a Workspace that did not exist. The entity fixture carried an orphaned Workspace id/tag pair even though the demo already has the Workspace that owns these notes.

## User impact

Tracked note backlinks now keep a recognizable Workspace label (`chat-may26`), and Back returns to the real demo Chat Workspace instead of a dead fixture identity.

## Validation

- `pnpm vitest run ui/src/demo/handlers/entities.spec.ts`
- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 passed, 1 skipped files; 3389 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real demo walkthrough: Tracked → `stock-vst` → `power_buy_points_2026-06-02.md`; verified the `chat-may26` provenance label and Back navigation to `/workspaces/demo-chat-ws`