### PR TITLE
fix(inbox): follow current Workspace labels

### DIFF
--- a/ui/src/components/InboxSidebar.spec.tsx
+++ b/ui/src/components/InboxSidebar.spec.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { InboxEntry } from '../api/inbox'
+import { i18n } from '../i18n'
+import { InboxSidebar } from './InboxSidebar'
+
+const mocks = vi.hoisted(() => ({
+  entries: [] as InboxEntry[],
+  loading: false,
+  selectedEntryId: 'inbox-1' as string | null,
+  mode: 'workspace' as 'workspace' | 'time',
+  workspaces: [] as Array<{ id: string; tag: string }>,
+  markRead: vi.fn(),
+  select: vi.fn(),
+  setMode: vi.fn(),
+}))
+
+vi.mock('../live/inbox', () => ({
+  inboxLive: {
+    useStore: (selector: (state: { entries: InboxEntry[]; loading: boolean }) => unknown) =>
+      selector({ entries: mocks.entries, loading: mocks.loading }),
+  },
+}))
+
+vi.mock('../live/inbox-read', () => ({
+  useInboxRead: (selector: (state: { markRead: typeof mocks.markRead }) => unknown) =>
+    selector({ markRead: mocks.markRead }),
+}))
+
+vi.mock('../live/inbox-selection', () => ({
+  useInboxSelection: (
+    selector: (state: {
+      selectedEntryId: string | null
+      select: typeof mocks.select
+    }) => unknown,
+  ) => selector({
+    selectedEntryId: mocks.selectedEntryId,
+    select: mocks.select,
+  }),
+}))
+
+vi.mock('../live/inbox-view-mode', () => ({
+  useInboxViewMode: (
+    selector: (state: {
+      mode: 'workspace' | 'time'
+      setMode: typeof mocks.setMode
+    }) => unknown,
+  ) => selector({ mode: mocks.mode, setMode: mocks.setMode }),
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({ workspaces: mocks.workspaces }),
+}))
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+  mocks.entries = [{
+    id: 'inbox-1',
+    ts: Date.now(),
+    workspaceId: 'workspace-1',
+    workspaceLabel: 'old-desk',
+    comments: 'Research is ready.',
+  }]
+  mocks.loading = false
+  mocks.selectedEntryId = 'inbox-1'
+  mocks.mode = 'workspace'
+  mocks.workspaces = [{ id: 'workspace-1', tag: 'renamed-desk' }]
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('InboxSidebar Workspace labels', () => {
+  it.each(['workspace', 'time'] as const)(
+    'uses the current Workspace tag in %s view',
+    (mode) => {
+      mocks.mode = mode
+
+      render(<InboxSidebar />)
+
+      expect(screen.getByText('renamed-desk')).toBeTruthy()
+      expect(screen.queryByText('old-desk')).toBeNull()
+    },
+  )
+
+  it('preserves the recorded label after the Workspace is gone', () => {
+    mocks.workspaces = []
+
+    render(<InboxSidebar />)
+
+    expect(screen.getByText('old-desk')).toBeTruthy()
+  })
+})

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Clock, Layers } from 'lucide-react'
+import { useWorkspaces } from '../contexts/workspaces-context'
 import { formatRelativeTime } from '../lib/intl'
 import { inboxLive } from '../live/inbox'
 import { useInboxRead } from '../live/inbox-read'
@@ -31,8 +32,13 @@ export function InboxSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
   const select = useInboxSelection((s) => s.select)
   const markRead = useInboxRead((s) => s.markRead)
   const mode = useInboxViewMode((s) => s.mode)
+  const { workspaces } = useWorkspaces()
 
   const threads = useMemo(() => groupThreads(entries), [entries])
+  const workspaceLabels = useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspace.tag])),
+    [workspaces],
+  )
   const readIds = useMemo(() => {
     const ids: Record<string, true> = {}
     for (const entry of entries) {
@@ -112,6 +118,7 @@ export function InboxSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
           threads={threads}
           selectedId={selectedId}
           readIds={readIds}
+          workspaceLabels={workspaceLabels}
           onSelect={selectAndRead}
         />
       ) : (
@@ -119,6 +126,7 @@ export function InboxSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
           entries={entries}
           selectedId={selectedId}
           readIds={readIds}
+          workspaceLabels={workspaceLabels}
           onSelect={selectAndRead}
         />
       )}
@@ -180,23 +188,26 @@ function ToggleBtn({
 // ==================== Workspace (clustered) view ====================
 
 function WorkspaceView({
-  threads, selectedId, readIds, onSelect,
+  threads, selectedId, readIds, workspaceLabels, onSelect,
 }: {
   threads: ReturnType<typeof groupThreads>
   selectedId: string | null
   readIds: Record<string, true>
+  workspaceLabels: ReadonlyMap<string, string>
   onSelect: (id: string) => void
 }) {
   return (
     <>
       {threads.map((thread) => {
         const unread = thread.entries.reduce((n, e) => (readIds[e.id] ? n : n + 1), 0)
+        const workspaceLabel =
+          workspaceLabels.get(thread.workspaceId) ?? thread.workspaceLabel ?? thread.workspaceId
         return (
           <div key={thread.workspaceId} className="mb-1.5">
             {/* Cluster header: label · unread badge · latest time */}
             <div className="flex items-center gap-1.5 px-3 mt-1.5 mb-0.5">
               <span className="flex-1 truncate text-[12px] font-medium text-foreground/90">
-                {thread.workspaceLabel ?? thread.workspaceId}
+                {workspaceLabel}
               </span>
               {unread > 0 && (
                 <span className="shrink-0 min-w-[15px] h-[15px] px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-semibold tabular-nums flex items-center justify-center">
@@ -272,11 +283,12 @@ function ClusterRow({
 // ==================== Time (flat chronological) view ====================
 
 function TimeView({
-  entries, selectedId, readIds, onSelect,
+  entries, selectedId, readIds, workspaceLabels, onSelect,
 }: {
   entries: readonly InboxEntry[]
   selectedId: string | null
   readIds: Record<string, true>
+  workspaceLabels: ReadonlyMap<string, string>
   onSelect: (id: string) => void
 }) {
   const { t } = useTranslation()
@@ -296,6 +308,7 @@ function TimeView({
                 entry={entry}
                 active={entry.id === selectedId}
                 unread={!readIds[entry.id]}
+                workspaceLabel={workspaceLabels.get(entry.workspaceId)}
                 onClick={() => onSelect(entry.id)}
               />
             ))}
@@ -309,11 +322,12 @@ function TimeView({
 /** Row in the flat time feed — carries the workspace label (no cluster
  *  header to provide it). */
 function TimeRow({
-  entry, active, unread, onClick,
+  entry, active, unread, workspaceLabel, onClick,
 }: {
   entry: InboxEntry
   active: boolean
   unread: boolean
+  workspaceLabel?: string
   onClick: () => void
 }) {
   return (
@@ -342,7 +356,7 @@ function TimeRow({
           className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-primary' : 'bg-transparent'}`}
         />
         <span className={`flex-1 truncate text-[12px] ${unread ? 'font-medium text-foreground' : 'text-foreground'}`}>
-          {entry.workspaceLabel ?? entry.workspaceId}
+          {workspaceLabel ?? entry.workspaceLabel ?? entry.workspaceId}
         </span>
         <span className="shrink-0 text-[10px] text-muted-foreground/60 tabular-nums">
           {formatRelativeTime(entry.ts)}


### PR DESCRIPTION
## What changed

- resolve Inbox sidebar labels from the current Workspace list in both grouped and chronological views
- keep each notification's recorded `workspaceLabel` as the fallback when its Workspace has been deleted or is otherwise unavailable
- add component coverage for Workspace renames in both view modes and for the historical-label fallback

## Why

Inbox detail already preferred the live Workspace tag, but the sidebar rendered only the label captured when each notification was written. After a Workspace rename, the same entry could therefore appear under one name in navigation and another in detail; in the demo, AAPL was grouped under `demo` while its detail showed `aapl-q1`.

## User impact

Active Workspace notifications now follow the Workspace's current identity everywhere in Inbox. Historical notifications from removed Workspaces remain understandable because their recorded label is preserved as the fallback.

## Validation

- `pnpm vitest run ui/src/components/InboxSidebar.spec.tsx` (3 passed)
- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 passed, 1 skipped files; 3391 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real demo walkthrough: verified `aapl-q1` in both Workspace-grouped and time-ordered Inbox views while unavailable `auto-quant` / `macro-research` entries retained their recorded labels