### PR TITLE
fix(news): show latest articles first

### DIFF
--- a/ui/src/pages/NewsPage.spec.tsx
+++ b/ui/src/pages/NewsPage.spec.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { NewsPage } from './NewsPage'
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    news: {
+      list: mocks.list,
+    },
+  },
+}))
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+  mocks.list.mockResolvedValue({
+    items: [
+      {
+        time: '2026-07-29T08:00:00.000Z',
+        title: 'Middle update',
+        content: 'Middle content',
+        source: 'Reuters',
+        link: null,
+        categories: null,
+      },
+      {
+        time: '2026-07-29T10:00:00.000Z',
+        title: 'Newest update',
+        content: 'Newest content',
+        source: 'Bloomberg',
+        link: null,
+        categories: null,
+      },
+      {
+        time: '2026-07-29T06:00:00.000Z',
+        title: 'Oldest update',
+        content: 'Oldest content',
+        source: 'CNBC',
+        link: null,
+        categories: null,
+      },
+    ],
+    count: 3,
+    lookback: '24h',
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('NewsPage ordering', () => {
+  it('shows the newest article first regardless of API response order', async () => {
+    render(<NewsPage />)
+
+    const newest = await screen.findByText('Newest update')
+    const middle = screen.getByText('Middle update')
+    const oldest = screen.getByText('Oldest update')
+
+    expect(newest.compareDocumentPosition(middle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(middle.compareDocumentPosition(oldest) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})

--- a/ui/src/pages/NewsPage.tsx
+++ b/ui/src/pages/NewsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatRelativeTime } from '../lib/intl'
 import { api, type NewsArticle } from '../api'
@@ -87,6 +87,12 @@ export function NewsPage() {
   const [sourceFilter, setSourceFilter] = useState('')
   const [loading, setLoading] = useState(true)
   const [sources, setSources] = useState<string[]>([])
+  const orderedArticles = useMemo(
+    () => [...articles].sort(
+      (a, b) => new Date(b.time).getTime() - new Date(a.time).getTime(),
+    ),
+    [articles],
+  )
 
   const fetchArticles = useCallback(async (lb: string, src: string) => {
     try {
@@ -170,8 +176,11 @@ export function NewsPage() {
               <EmptyState title={t('news.noArticles')} description={t('news.noArticlesDescription')} />
             ) : (
               <div className="divide-y divide-border/50">
-                {[...articles].reverse().map((article, i) => (
-                  <ArticleRow key={`${article.time}-${i}`} article={article} />
+                {orderedArticles.map((article) => (
+                  <ArticleRow
+                    key={`${article.time}-${article.link ?? article.title}`}
+                    article={article}
+                  />
                 ))}
               </div>
             )}


### PR DESCRIPTION
## What changed

- sort News articles explicitly by publish time, newest first, instead of reversing the API array
- use a stable article key so periodic refreshes do not tie expansion state to a changing list index
- add UI coverage with deliberately unsorted API data

## Why

The News page assumed every response was oldest-first and blindly reversed it. The demo response was newest-first, so the default 24-hour feed put a 22-hour-old story at the top and the 30-minute catalyst at the bottom. Any provider/order drift could produce the same user-visible error.

## User impact

The newest market catalyst now stays at the top of the News feed regardless of response ordering, including after periodic refreshes.

## Validation

- `pnpm vitest run ui/src/pages/NewsPage.spec.tsx`
- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm vitest run services/uta/src/domain/trading/brokers/registry.spec.ts` (7 passed; confirms an earlier parallel-load timeout was transient)
- `pnpm test` serialized rerun (358 passed, 1 skipped files; 3389 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real demo walkthrough: verified the 24-hour feed displays 30-minute, 2-hour, 4-hour … 22-hour articles in descending recency