### PR TITLE
fix(automation): show workspace tags on runs

### DIFF
--- a/ui/src/demo/handlers/headless.spec.ts
+++ b/ui/src/demo/handlers/headless.spec.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import type { HeadlessListSnapshot } from '../../api/headless'
+import { demoWorkspaces } from '../fixtures/workspaces'
+import { headlessHandlers } from './headless'
+
+const server = setupServer(...headlessHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('demo headless handlers', () => {
+  it('ties every run to a registered demo Workspace', async () => {
+    const response = await fetch(`${baseUrl}/api/headless`)
+    const body = await response.json() as HeadlessListSnapshot
+    const workspaceIds = new Set(demoWorkspaces.map((workspace) => workspace.id))
+
+    expect(response.status).toBe(200)
+    expect(body.tasks.length).toBeGreaterThan(0)
+    expect(body.tasks.every((task) => workspaceIds.has(task.wsId))).toBe(true)
+  })
+})

--- a/ui/src/demo/handlers/headless.ts
+++ b/ui/src/demo/handlers/headless.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw'
 
 import type { HeadlessOutput, HeadlessTaskRecord } from '../../api/headless'
+import { DEMO_CHAT_WORKSPACE_ID, DEMO_WORKSPACE_ID } from '../fixtures/workspaces'
 
 const now = Date.now()
 const demoHeadlessTasks: HeadlessTaskRecord[] = [
@@ -8,7 +9,7 @@ const demoHeadlessTasks: HeadlessTaskRecord[] = [
     taskId: 'demo-headless-1',
     resumeId: 'demo-resume-1',
     resumable: true,
-    wsId: 'demo-ws',
+    wsId: DEMO_WORKSPACE_ID,
     agent: 'codex',
     prompt: 'Compute a quant snapshot of NVDA and push a report to the inbox.',
     status: 'done',
@@ -21,7 +22,7 @@ const demoHeadlessTasks: HeadlessTaskRecord[] = [
     taskId: 'demo-headless-2',
     resumeId: 'demo-resume-2',
     resumable: false,
-    wsId: 'demo-chat',
+    wsId: DEMO_CHAT_WORKSPACE_ID,
     agent: 'claude',
     prompt: "Summarize today's AI-sector headlines and flag anything actionable.",
     status: 'running',
@@ -31,7 +32,7 @@ const demoHeadlessTasks: HeadlessTaskRecord[] = [
     taskId: 'demo-headless-3',
     resumeId: 'demo-resume-3',
     resumable: false,
-    wsId: 'demo-ws',
+    wsId: DEMO_WORKSPACE_ID,
     agent: 'pi',
     prompt: 'Refresh the uranium watchlist and note any breakouts.',
     status: 'interrupted',

--- a/ui/src/pages/AutomationRunsSection.spec.tsx
+++ b/ui/src/pages/AutomationRunsSection.spec.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HeadlessListSnapshot, HeadlessTaskRecord } from '../api/headless'
+import type { Workspace } from '../components/workspace/api'
+import { AutomationRunsSection } from './AutomationRunsSection'
+
+const mocks = vi.hoisted(() => ({
+  snapshot: vi.fn(),
+  output: vi.fn(),
+  openHeadlessRun: vi.fn(),
+  workspaces: [] as unknown[],
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    headless: {
+      snapshot: mocks.snapshot,
+      output: mocks.output,
+    },
+  },
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    workspaces: mocks.workspaces,
+    openHeadlessRun: mocks.openHeadlessRun,
+  }),
+}))
+
+const liveWorkspace: Workspace = {
+  id: 'ws-live-internal-id',
+  tag: 'quant-desk',
+  displayName: 'Quant research',
+  dir: '/tmp/quant-desk',
+  createdAt: '2026-07-29T00:00:00.000Z',
+  template: 'chat',
+  agents: ['codex'],
+  sessions: [],
+}
+
+function task(overrides: Partial<HeadlessTaskRecord>): HeadlessTaskRecord {
+  return {
+    taskId: 'run-default',
+    resumeId: 'resume-default',
+    resumable: false,
+    wsId: liveWorkspace.id,
+    agent: 'codex',
+    prompt: 'Review the latest market snapshot.',
+    status: 'running',
+    startedAt: Date.now() - 1_000,
+    ...overrides,
+  }
+}
+
+function snapshot(tasks: HeadlessTaskRecord[]): HeadlessListSnapshot {
+  return {
+    tasks,
+    page: { total: tasks.length, hasMore: false, nextCursor: null },
+    summary: { done: 0, needsAttention: 0 },
+    capacity: {
+      running: tasks.filter((item) => item.status === 'running').length,
+      limit: 8,
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.workspaces = [liveWorkspace]
+})
+
+afterEach(cleanup)
+
+describe('AutomationRunsSection workspace identity', () => {
+  it('shows the current Workspace tag instead of its internal id', async () => {
+    mocks.snapshot.mockResolvedValue(snapshot([task({})]))
+
+    render(<AutomationRunsSection />)
+
+    expect(await screen.findByText('quant-desk')).toBeTruthy()
+    expect(screen.queryByText(liveWorkspace.id)).toBeNull()
+    expect(screen.getByTitle('Quant research (quant-desk)')).toBeTruthy()
+  })
+
+  it('keeps the full stored id when the Workspace no longer exists', async () => {
+    const departedId = 'ws-departed-full-internal-id'
+    mocks.snapshot.mockResolvedValue(snapshot([
+      task({ taskId: 'run-departed', wsId: departedId }),
+    ]))
+
+    render(<AutomationRunsSection />)
+
+    expect(await screen.findByText(departedId)).toBeTruthy()
+    expect(screen.getByTitle(departedId).className).toContain('font-mono')
+  })
+})

--- a/ui/src/pages/AutomationRunsSection.tsx
+++ b/ui/src/pages/AutomationRunsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Bot,
   ChevronDown,
@@ -204,7 +204,19 @@ export function AutomationRunsSection() {
   const [error, setError] = useState<string | null>(null)
   const [loadingMore, setLoadingMore] = useState(false)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
-  const { openHeadlessRun } = useWorkspaces()
+  const { openHeadlessRun, workspaces } = useWorkspaces()
+  const workspaceLabels = useMemo(() => new Map(
+    workspaces.map((workspace) => {
+      const displayName = workspace.displayName?.trim()
+      return [
+        workspace.id,
+        {
+          label: workspace.tag,
+          title: displayName ? `${displayName} (${workspace.tag})` : workspace.tag,
+        },
+      ] as const
+    }),
+  ), [workspaces])
 
   const toggle = (id: string) => setExpanded((prev) => {
     const next = new Set(prev)
@@ -322,6 +334,7 @@ export function AutomationRunsSection() {
           {snapshot.tasks.map((task) => {
             const isExpanded = expanded.has(task.taskId)
             const openable = task.status !== 'running' && task.resumable
+            const workspaceLabel = workspaceLabels.get(task.wsId)
             const toolSummary = task.output?.toolCalls
               ? `${task.output.toolCalls} tool${task.output.toolCalls === 1 ? '' : 's'}`
               : task.output
@@ -349,7 +362,12 @@ export function AutomationRunsSection() {
                     </span>
                     <span className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
                       <span>{task.agent}</span>
-                      <span className="font-mono">{task.wsId.slice(0, 8)}</span>
+                      <span
+                        className={workspaceLabel ? undefined : 'font-mono'}
+                        title={workspaceLabel?.title ?? task.wsId}
+                      >
+                        {workspaceLabel?.label ?? task.wsId}
+                      </span>
                       <span>{formatRelativeTime(task.startedAt)}</span>
                       <span>{fmtDuration(task.durationMs)}</span>
                       <span>{toolSummary}</span>


### PR DESCRIPTION
## What changed

- resolve each Automation run's current Workspace id to its human-readable Workspace tag
- keep the full stored Workspace id as the fallback when that Workspace has departed
- show the optional display name in the tag tooltip
- align the demo running Chat task with the registered demo Workspace id
- add component coverage for live and departed Workspace identities plus a demo fixture contract test

## Why

The cross-Workspace Runs control plane truncated raw internal ids such as `demo-ws` and `demo-cha`. Operators could not tell which desk owned a run from the list, even though opening the completed run navigated to the recognizable `aapl-q1` Workspace. The demo's running Chat task also pointed at an unregistered stale id, masking the intended identity relationship.

## User impact

Automation Runs now show stable, recognizable Workspace tags such as `aapl-q1` and `chat-may26`. Historical runs whose Workspace has been removed remain diagnosable through their full stored id.

## Validation

- `pnpm vitest run ui/src/pages/AutomationRunsSection.spec.tsx ui/src/demo/handlers/headless.spec.ts` (3 passed)
- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (359 passed, 1 skipped files; 3391 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real demo walkthrough: Automation → Runs showed `aapl-q1`, `chat-may26`, and `aapl-q1`, with display-name tooltips