### PR TITLE
fix(demo): show crypto markets as 24/7

### DIFF
--- a/ui/src/demo/handlers/trading.spec.ts
+++ b/ui/src/demo/handlers/trading.spec.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import { DEMO_UTA_CRYPTO, DEMO_UTA_PAPER } from '../fixtures/trading'
+import { tradingHandlers } from './trading'
+
+const server = setupServer(...tradingHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+async function marketClock(utaId: string): Promise<{
+  isOpen: boolean
+  nextOpen?: string
+  nextClose?: string
+}> {
+  const response = await fetch(`${baseUrl}/api/trading/uta/${utaId}/market-clock`)
+  expect(response.status).toBe(200)
+  return response.json()
+}
+
+describe('demo trading market clock', () => {
+  it('models crypto accounts as always open without an exchange-session schedule', async () => {
+    await expect(marketClock(DEMO_UTA_CRYPTO)).resolves.toEqual({ isOpen: true })
+  })
+
+  it('keeps scheduled market hours for securities accounts', async () => {
+    const clock = await marketClock(DEMO_UTA_PAPER)
+
+    expect(clock.isOpen).toBe(false)
+    expect(clock.nextOpen).toBeTypeOf('string')
+    expect(clock.nextClose).toBeTypeOf('string')
+  })
+})

--- a/ui/src/demo/handlers/trading.ts
+++ b/ui/src/demo/handlers/trading.ts
@@ -130,13 +130,16 @@ export const tradingHandlers = [
   http.get('/api/trading/uta/:id/trade-history', ({ params }) =>
     HttpResponse.json({ trades: demoTradeHistoryByUTA[utaId(params)] ?? [] }),
   ),
-  http.get('/api/trading/uta/:id/market-clock', () =>
-    HttpResponse.json({
+  http.get('/api/trading/uta/:id/market-clock', ({ params }) => {
+    if (utaId(params) === DEMO_UTA_CRYPTO) {
+      return HttpResponse.json({ isOpen: true })
+    }
+    return HttpResponse.json({
       isOpen: false,
       nextOpen: new Date(Date.now() + 3600_000).toISOString(),
       nextClose: new Date(Date.now() + 7 * 3600_000).toISOString(),
-    }),
-  ),
+    })
+  }),
 
   http.get('/api/trading/uta/:id/wallet/status', () =>
     HttpResponse.json({ staged: [], pendingMessage: null, head: null, commitCount: 0 }),


### PR DESCRIPTION
## What changed

- return an always-open market clock for the demo CCXT/Binance account
- preserve the scheduled closed/open clock fixture for Alpaca and IBKR demo accounts
- add handler contract tests covering both crypto and securities clocks

## Why

The demo market-clock handler returned the same stock-market schedule for every account. As a result, the Binance spot/perpetual portfolio claimed `Market Closed · opens in 1h` even though the production CCXT adapter correctly models crypto venues as 24/7.

## User impact

Users evaluating OpenAlice through the public demo now see `24/7` on the Binance account and no longer receive a false signal that crypto orders are unavailable. Securities accounts continue to demonstrate scheduled market hours.

## Validation

- `pnpm vitest run ui/src/demo/handlers/trading.spec.ts` (2 passed)
- `pnpm vitest run services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts -t getMarketClock` (1 passed)
- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 passed, 1 skipped files; 3390 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real demo walkthrough: Binance account displayed `24/7`; Alpaca Paper still displayed `Market Closed · opens in …`

Live-paper was not run because this changes only the deterministic demo handler and does not touch broker adapters, order writes, permissions, or venue behavior.