### PR TITLE
fix(connectors): preserve bot token drafts

### DIFF
--- a/ui/src/pages/Connectors.demo.spec.tsx
+++ b/ui/src/pages/Connectors.demo.spec.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PublicConnectorConfig } from '../api'
 import { createDemoConnectorSnapshot } from '../demo/fixtures/connectors'
 import { ConnectorStatusPage } from './ConnectorStatusPage'
 import { ConnectorsPage } from './ConnectorsPage'
@@ -58,5 +59,21 @@ describe('Connector demo routes', () => {
     expect(screen.getByText('Telegram')).toBeTruthy()
     expect(screen.getByText('Application ID')).toBeTruthy()
     expect(screen.getAllByText('Bot token')).toHaveLength(2)
+  })
+
+  it('keeps the complete secret draft while the user types', async () => {
+    render(<ConnectorsPage />)
+
+    await screen.findByText('Run external notification connectors')
+    const input = screen.getAllByPlaceholderText('Stored locally and sealed')[0] as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: `${input.value}a` } })
+    expect(input.value).toBe('a')
+    fireEvent.change(input, { target: { value: `${input.value}b` } })
+    expect(input.value).toBe('ab')
+
+    await waitFor(() => expect(mocks.save).toHaveBeenCalled())
+    const saved = mocks.save.mock.calls.at(-1)?.[0] as PublicConnectorConfig
+    expect(saved.adapters.discord.settings.botToken).toBe('ab')
   })
 })

--- a/ui/src/pages/ConnectorsPage.tsx
+++ b/ui/src/pages/ConnectorsPage.tsx
@@ -210,7 +210,7 @@ export function ConnectorsPage() {
                                 <input
                                   className={inputClass}
                                   type={field.kind === 'secret' ? 'password' : field.kind}
-                                  value={field.kind === 'secret' ? '' : String(value ?? '')}
+                                  value={String(value ?? '')}
                                   placeholder={configured ? 'Configured — enter a new value to replace' : field.placeholder}
                                   autoComplete="off"
                                   onChange={(event) => updateSetting(


### PR DESCRIPTION
## What changed

- keep newly entered connector secrets as a local controlled-input draft while the user types
- continue clearing the password field once the save response replaces the draft with a `configuredSecrets` presence marker
- add regression coverage that types a token one character at a time and verifies the complete value reaches auto-save

## Why

Connector password inputs were hard-coded to `value=""`. Every keystroke therefore triggered a render that immediately emptied the field; the next key started from an empty input and overwrote the previous character. A human-entered bot token could silently save as only its final character.

The Settings API already never returns stored tokens. Rendering `adapter.settings[field.key]` is safe because that value exists only as the current local draft and disappears when the sealed save response arrives.

## User impact

Discord and Telegram bot tokens now accumulate normally behind password bullets and save in full. After saving, the field is blank again and only shows the configured placeholder, so stored secrets are still never revealed.

## Validation

- `pnpm vitest run ui/src/pages/Connectors.demo.spec.tsx` (3 passed)
- `pnpm -F @traderalice/connector-service typecheck`
- `pnpm test:connector-replay` (3 files, 11 tests passed)
- `pnpm -F @traderalice/connector-service build && pnpm test:connector-service`
- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (357 passed, 1 skipped files; 3389 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real demo walkthrough: sequential input retained `a`, then `ab`; after auto-save the value cleared and the placeholder changed to `Configured — enter a new value to replace`

External Discord/Telegram DM delivery was skipped because this input-only fix does not require or authorize user-owned platform credentials.