### PR TITLE
fix(demo): make News Sources configurable

### DIFF
--- a/ui/src/demo/fixtures/newsConfig.ts
+++ b/ui/src/demo/fixtures/newsConfig.ts
@@ -1,0 +1,28 @@
+import type { NewsCollectorConfig } from '../../api/types'
+
+export function createDemoNewsConfig(): NewsCollectorConfig {
+  return {
+    enabled: true,
+    intervalMinutes: 10,
+    maxInMemory: 2000,
+    retentionDays: 7,
+    feeds: [
+      {
+        name: 'Federal Reserve Press',
+        url: 'https://www.federalreserve.gov/feeds/press_all.xml',
+        source: 'fed',
+        categories: ['macro'],
+        description: 'US Federal Reserve press releases and policy statements.',
+        enabled: true,
+      },
+      {
+        name: 'CoinDesk',
+        url: 'https://www.coindesk.com/arc/outboundfeeds/rss/',
+        source: 'coindesk',
+        categories: ['crypto'],
+        description: 'Crypto markets, policy, and industry news.',
+        enabled: false,
+      },
+    ],
+  }
+}

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -1,4 +1,12 @@
 import { http, HttpResponse } from 'msw'
+import type { NewsCollectorConfig, NewsCollectorFeed } from '../../api/types'
+import { createDemoNewsConfig } from '../fixtures/newsConfig'
+
+let demoNewsConfig = createDemoNewsConfig()
+
+export function resetDemoNewsConfig(): void {
+  demoNewsConfig = createDemoNewsConfig()
+}
 
 export const demoCredentialPresets = [
   {
@@ -142,6 +150,14 @@ export const configKeysHandlers = [
   http.put('/api/config/marketData', async ({ request }) => HttpResponse.json(await request.json())),
   http.put('/api/config/trading', async ({ request }) => HttpResponse.json(await request.json())),
   http.put('/api/config/snapshot', async ({ request }) => HttpResponse.json(await request.json())),
+  http.put('/api/config/news', async ({ request }) => {
+    const body = await request.json().catch(() => null)
+    if (!isNewsCollectorConfig(body)) {
+      return HttpResponse.json({ error: 'invalid_news_config' }, { status: 400 })
+    }
+    demoNewsConfig = structuredClone(body)
+    return HttpResponse.json(demoNewsConfig)
+  }),
 
   http.get('/api/config', () =>
     HttpResponse.json({
@@ -158,6 +174,7 @@ export const configKeysHandlers = [
         providerKeys: {},
         hub: { enabled: true, baseUrl: 'https://traderhub.openalice.ai' },
       },
+      news: demoNewsConfig,
       ports: { web: 47331 },
     }),
   ),
@@ -211,3 +228,42 @@ export const configKeysHandlers = [
     return HttpResponse.json({ agent: typeof body.agent === 'string' ? body.agent : null })
   }),
 ]
+
+function isNewsCollectorConfig(value: unknown): value is NewsCollectorConfig {
+  if (!isRecord(value)) return false
+  return typeof value.enabled === 'boolean'
+    && isPositiveInteger(value.intervalMinutes)
+    && isPositiveInteger(value.maxInMemory)
+    && isPositiveInteger(value.retentionDays)
+    && Array.isArray(value.feeds)
+    && value.feeds.every(isNewsCollectorFeed)
+}
+
+function isNewsCollectorFeed(value: unknown): value is NewsCollectorFeed {
+  if (!isRecord(value)) return false
+  return typeof value.name === 'string'
+    && typeof value.url === 'string'
+    && isUrl(value.url)
+    && typeof value.source === 'string'
+    && (value.categories === undefined
+      || (Array.isArray(value.categories) && value.categories.every((item) => typeof item === 'string')))
+    && (value.description === undefined || typeof value.description === 'string')
+    && (value.enabled === undefined || typeof value.enabled === 'boolean')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function isUrl(value: string): boolean {
+  try {
+    new URL(value)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/ui/src/demo/handlers/configNews.spec.ts
+++ b/ui/src/demo/handlers/configNews.spec.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import type { AppConfig, NewsCollectorConfig } from '../../api/types'
+import { configKeysHandlers, resetDemoNewsConfig } from './configKeys'
+
+const server = setupServer(...configKeysHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+beforeEach(resetDemoNewsConfig)
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+async function loadConfig(): Promise<AppConfig> {
+  const response = await fetch(`${baseUrl}/api/config`)
+  expect(response.status).toBe(200)
+  return response.json()
+}
+
+describe('demo News Collector config', () => {
+  it('loads representative RSS feeds', async () => {
+    const config = await loadConfig()
+    const news = config.news as NewsCollectorConfig
+
+    expect(news.enabled).toBe(true)
+    expect(news.feeds.map((feed) => feed.source)).toEqual(['fed', 'coindesk'])
+  })
+
+  it('round-trips News Collector mutations for the current demo session', async () => {
+    const current = (await loadConfig()).news as NewsCollectorConfig
+    const next: NewsCollectorConfig = {
+      ...current,
+      intervalMinutes: 15,
+      feeds: [
+        ...current.feeds,
+        {
+          name: 'Example Markets',
+          url: 'https://example.com/markets.xml',
+          source: 'example-markets',
+          enabled: true,
+        },
+      ],
+    }
+
+    const response = await fetch(`${baseUrl}/api/config/news`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(next),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(next)
+    expect((await loadConfig()).news).toEqual(next)
+  })
+
+  it('rejects invalid feed URLs like the production schema', async () => {
+    const current = (await loadConfig()).news as NewsCollectorConfig
+    const response = await fetch(`${baseUrl}/api/config/news`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ...current,
+        feeds: [{ name: 'Broken', url: 'not-a-url', source: 'broken' }],
+      }),
+    })
+
+    expect(response.status).toBe(400)
+  })
+})


### PR DESCRIPTION
## What changed

- add a representative News Collector configuration to the demo `/api/config` response
- implement an in-memory `/api/config/news` mutation handler so enablement, intervals, feed toggles, additions, and removals round-trip during a demo session
- mirror the production config guard for positive numeric settings, feed shapes, and valid URLs
- add handler coverage for initial feeds, successful mutation persistence, and invalid URL rejection

## Why

The News Sources route used `useConfigPage`, but the demo config response omitted the entire `news` section and had no matching PUT handler. The page therefore rendered an empty fallback form, then silently discarded every attempted change: adding a feed cleared the form but left the list empty.

## User impact

The public demo now presents a realistic enabled/paused RSS pair and lets users exercise the full News Collector configuration flow. Changes remain available for the current demo session while still following the demo banner's non-persistent contract.

## Validation

- `pnpm vitest run ui/src/demo/handlers/configNews.spec.ts ui/src/demo/handlers/configKeys.spec.ts` (2 files, 4 tests passed)
- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 passed, 1 skipped files; 3391 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real demo walkthrough: News Sources loaded Fed enabled and CoinDesk paused; adding `Example Markets` produced `Saved` and a stable `2 of 3 feeds active` list

No external RSS fetch was run because this changes only the deterministic demo configuration contract, not the production collector or network parser.