### PR TITLE
Validate RSS feed URLs before saving

### DIFF
--- a/ui/src/pages/NewsCollectorPage.spec.tsx
+++ b/ui/src/pages/NewsCollectorPage.spec.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { FeedsSection } from './NewsCollectorPage'
+
+afterEach(cleanup)
+
+describe('NewsCollectorPage feed editor', () => {
+  it('rejects an invalid feed URL before submitting the feed', () => {
+    const onChange = vi.fn()
+    render(<FeedsSection feeds={[]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. CoinDesk'), {
+      target: { value: 'Example Markets' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('e.g. coindesk'), {
+      target: { value: 'example-markets' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('https://example.com/rss.xml'), {
+      target: { value: 'not-a-url' },
+    })
+
+    const addButton = screen.getByRole('button', { name: 'Add Feed' })
+    const urlInput = screen.getByPlaceholderText('https://example.com/rss.xml')
+
+    expect((addButton as HTMLButtonElement).disabled).toBe(true)
+    expect(urlInput.getAttribute('aria-invalid')).toBe('true')
+    expect(screen.getByRole('alert').textContent).toContain('Enter a valid URL')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('submits a trimmed feed after the URL becomes valid', () => {
+    const onChange = vi.fn()
+    render(<FeedsSection feeds={[]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. CoinDesk'), {
+      target: { value: ' Example Markets ' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('e.g. coindesk'), {
+      target: { value: ' example-markets ' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('https://example.com/rss.xml'), {
+      target: { value: ' https://example.com/rss.xml ' },
+    })
+
+    const addButton = screen.getByRole('button', { name: 'Add Feed' })
+
+    expect((addButton as HTMLButtonElement).disabled).toBe(false)
+    expect(screen.queryByRole('alert')).toBeNull()
+    fireEvent.click(addButton)
+
+    expect(onChange).toHaveBeenCalledWith([{
+      name: 'Example Markets',
+      url: 'https://example.com/rss.xml',
+      source: 'example-markets',
+      enabled: true,
+    }])
+  })
+})

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -73,7 +73,16 @@ function CollectorSettings() {
 
 // ==================== Feeds Section ====================
 
-function FeedsSection({
+export function isValidFeedUrl(value: string): boolean {
+  try {
+    new URL(value.trim())
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function FeedsSection({
   feeds,
   onChange,
 }: {
@@ -86,6 +95,8 @@ function FeedsSection({
   const [newDescription, setNewDescription] = useState('')
 
   const activeCount = useMemo(() => feeds.filter((f) => f.enabled !== false).length, [feeds])
+  const feedUrlValid = isValidFeedUrl(newUrl)
+  const showFeedUrlError = newUrl.trim().length > 0 && !feedUrlValid
 
   const removeFeed = (index: number) => onChange(feeds.filter((_, i) => i !== index))
 
@@ -94,7 +105,7 @@ function FeedsSection({
   }
 
   const addFeed = () => {
-    if (!newName.trim() || !newUrl.trim() || !newSource.trim()) return
+    if (!newName.trim() || !feedUrlValid || !newSource.trim()) return
     const entry: NewsCollectorFeed = {
       name: newName.trim(),
       url: newUrl.trim(),
@@ -174,14 +185,27 @@ function FeedsSection({
           </Field>
         </div>
         <Field label="Feed URL">
-          <input className={inputClass} value={newUrl} onChange={(e) => setNewUrl(e.target.value)} placeholder="https://example.com/rss.xml" />
+          <input
+            className={inputClass}
+            type="url"
+            value={newUrl}
+            onChange={(e) => setNewUrl(e.target.value)}
+            placeholder="https://example.com/rss.xml"
+            aria-invalid={showFeedUrlError}
+            aria-describedby={showFeedUrlError ? 'news-feed-url-error' : undefined}
+          />
+          {showFeedUrlError && (
+            <p id="news-feed-url-error" role="alert" className="mt-1 text-[12px] text-destructive">
+              Enter a valid URL, for example https://example.com/rss.xml.
+            </p>
+          )}
         </Field>
         <Field label="Description (optional)">
           <input className={inputClass} value={newDescription} onChange={(e) => setNewDescription(e.target.value)} placeholder="Short description shown in the feed list" />
         </Field>
         <button
           onClick={addFeed}
-          disabled={!newName.trim() || !newUrl.trim() || !newSource.trim()}
+          disabled={!newName.trim() || !feedUrlValid || !newSource.trim()}
           className="btn-secondary"
         >
           Add Feed


### PR DESCRIPTION
## Summary

- validate new RSS feed URLs in the News Sources form before submitting
- show an accessible inline error and keep **Add Feed** disabled for invalid URLs
- preserve the existing trim-on-save behavior and add focused component coverage

## Why

The production news configuration schema requires `z.string().url()`, but the UI previously checked only that the field was non-empty. Values such as `not-a-url` enabled **Add Feed** and were rejected only after the request reached the server, without any field-level explanation.

## User impact

Users now get immediate, actionable feedback while entering a feed URL. A valid URL clears the error and enables submission, so the UI contract matches the production validation boundary.

## Verification

- `pnpm exec vitest run ui/src/pages/NewsCollectorPage.spec.tsx` — 2 passed
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build:demo`
- `pnpm test` — 3390 passed, 9 skipped
- Real Demo route (`/settings/news-collector`): verified `not-a-url` shows the inline alert and keeps **Add Feed** disabled; replacing it with `https://example.com/rss.xml` clears the alert and enables the button
- `git diff --check`