### PR TITLE
Validate and apply portfolio snapshot settings

### DIFF
--- a/src/core/config.spec.ts
+++ b/src/core/config.spec.ts
@@ -309,6 +309,26 @@ describe('writeConfigSection(trading)', () => {
   })
 })
 
+describe('writeConfigSection(snapshot)', () => {
+  it('normalizes a valid snapshot interval before writing it', async () => {
+    const snapshot = await writeConfigSection('snapshot', {
+      enabled: true,
+      every: ' 2h15m ',
+    }) as { enabled: boolean; every: string }
+
+    expect(snapshot).toEqual({ enabled: true, every: '2h15m' })
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string)
+    expect(written.every).toBe('2h15m')
+  })
+
+  it.each(['nonsense', '0m', ''])('rejects invalid snapshot interval %j without writing', async (every) => {
+    await expect(
+      writeConfigSection('snapshot', { enabled: true, every }),
+    ).rejects.toThrow(/positive duration/)
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})
+
 // ==================== aiProviderSchema (Zod schema validation) ====================
 
 describe('aiProviderSchema (credential vault)', () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -6,6 +6,7 @@ import { newsCollectorSchema } from '../domain/news/config.js'
 import { runMigrations } from '../migrations/runner.js'
 import { dataPath } from '@/core/paths.js'
 import { withConfigBootstrapLock } from './config-bootstrap-lock.js'
+import { parseDuration } from './duration.js'
 import { isSealedEnvelope, seal, unseal } from './sealing.js'
 
 const CONFIG_DIR = dataPath('config')
@@ -353,7 +354,13 @@ const portsSchema = z.object({
 
 const snapshotSchema = z.object({
   enabled: z.boolean().default(true),
-  every: z.string().default('15m'),
+  every: z.string()
+    .transform((value) => value.trim())
+    .refine(
+      (value) => parseDuration(value) !== null,
+      'Expected a positive duration such as "15m", "1h", or "2h15m"',
+    )
+    .default('15m'),
 })
 
 export const keylessDataSourceSchema = z.enum(['binance', 'okx', 'bybit'])

--- a/src/migrations/0027_repair_snapshot_interval/index.spec.ts
+++ b/src/migrations/0027_repair_snapshot_interval/index.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { MigrationContext } from '../types.js'
+import { migration, repairSnapshotInterval } from './index.js'
+
+function context(initial: unknown) {
+  let value = initial
+  const writeJson = vi.fn(async (_filename: string, next: unknown) => {
+    value = next
+  })
+  const ctx: MigrationContext = {
+    async readJson<T>(): Promise<T | undefined> {
+      return value as T | undefined
+    },
+    writeJson,
+    removeJson: vi.fn(async () => {}),
+    configDir: () => '/tmp/openalice-migration-test',
+  }
+  return { ctx, writeJson, value: () => value }
+}
+
+describe('0027 repair snapshot interval', () => {
+  it('replaces an invalid historical interval and is idempotent', async () => {
+    const state = context({ enabled: false, every: 'nonsense' })
+
+    await migration.up(state.ctx)
+    await migration.up(state.ctx)
+
+    expect(state.value()).toEqual({ enabled: false, every: '15m' })
+    expect(state.writeJson).toHaveBeenCalledOnce()
+    expect(state.writeJson).toHaveBeenCalledWith('snapshot.json', {
+      enabled: false,
+      every: '15m',
+    })
+  })
+
+  it('normalizes valid whitespace without changing other settings', () => {
+    expect(repairSnapshotInterval({
+      enabled: true,
+      every: ' 2h15m ',
+      futureSetting: true,
+    })).toEqual({
+      value: {
+        enabled: true,
+        every: '2h15m',
+        futureSetting: true,
+      },
+      updated: true,
+    })
+  })
+
+  it('leaves missing and already-valid intervals untouched', () => {
+    const current = { enabled: true, every: '30m' }
+    expect(repairSnapshotInterval(current)).toEqual({ value: current, updated: false })
+    expect(repairSnapshotInterval({ enabled: false })).toEqual({
+      value: { enabled: false },
+      updated: false,
+    })
+    expect(repairSnapshotInterval(undefined)).toEqual({ value: undefined, updated: false })
+  })
+})

--- a/src/migrations/0027_repair_snapshot_interval/index.ts
+++ b/src/migrations/0027_repair_snapshot_interval/index.ts
@@ -1,0 +1,35 @@
+import { parseDuration } from '../../core/duration.js'
+import type { Migration } from '../types.js'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function repairSnapshotInterval(raw: unknown): { value: unknown; updated: boolean } {
+  if (!isRecord(raw) || !Object.prototype.hasOwnProperty.call(raw, 'every')) {
+    return { value: raw, updated: false }
+  }
+
+  const every = raw.every
+  if (typeof every !== 'string' || parseDuration(every) === null) {
+    return { value: { ...raw, every: '15m' }, updated: true }
+  }
+
+  const normalized = every.trim()
+  if (normalized === every) return { value: raw, updated: false }
+  return { value: { ...raw, every: normalized }, updated: true }
+}
+
+export const migration: Migration = {
+  id: '0027_repair_snapshot_interval',
+  appVersion: '0.87.0-beta',
+  introducedAt: '2026-07-29',
+  affects: ['snapshot.json'],
+  summary: 'Repair invalid historical portfolio snapshot intervals before strict duration validation loads them.',
+  rationale: 'Older Portfolio UI versions persisted arbitrary strings even though the UTA snapshot pump accepts only positive h/m/s durations.',
+  up: async (ctx) => {
+    const snapshot = await ctx.readJson('snapshot.json')
+    const repaired = repairSnapshotInterval(snapshot)
+    if (repaired.updated) await ctx.writeJson('snapshot.json', repaired.value)
+  },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -26,3 +26,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0024_pi_native_workspace_config` | 0.82.0-beta | 2026-07-18 | workspaces/workspaces/*/.pi-agent, workspaces/departed-workspaces/*/.pi-agent, Pi user agent directory | Move redirected Pi Workspace homes into Pi's native global-provider and project-settings layers. |
 | `0025_retire_global_compaction_config` | 0.83.0-beta | 2026-07-19 | compaction.json, ai-provider-manager.json | Remove retired global context and compaction limits so model and native Agent runtime semantics remain authoritative. |
 | `0026_agent_conversation_log` | 0.87.0-beta | 2026-07-29 | workspaces/state/agent-conversations.jsonl | Create the private append-only cross-Agent conversation event log. |
+| `0027_repair_snapshot_interval` | 0.87.0-beta | 2026-07-29 | snapshot.json | Repair invalid historical portfolio snapshot intervals before strict duration validation loads them. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -14,7 +14,7 @@
  * deletion + Workspace pivot turned the pre-0.40 data shapes over completely, so
  * pre-0.40 installs rebuild `data/` rather than migrate. The framework stays for
  * future upgrades. Numbering continues FORWARD from the highest id ever shipped
- * (next: 0026) — never reuse a retired id, since existing installs' journals
+ * (next: 0028) — never reuse a retired id, since existing installs' journals
  * recorded the old ones.
  */
 
@@ -38,6 +38,7 @@ import { migration as migration_0023_google_native_credentials } from './0023_go
 import { migration as migration_0024_pi_native_workspace_config } from './0024_pi_native_workspace_config/index.js'
 import { migration as migration_0025_retire_global_compaction_config } from './0025_retire_global_compaction_config/index.js'
 import { migration as migration_0026_agent_conversation_log } from './0026_agent_conversation_log/index.js'
+import { migration as migration_0027_repair_snapshot_interval } from './0027_repair_snapshot_interval/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -59,4 +60,5 @@ export const REGISTRY: Migration[] = [
   migration_0024_pi_native_workspace_config,
   migration_0025_retire_global_compaction_config,
   migration_0026_agent_conversation_log,
+  migration_0027_repair_snapshot_interval,
 ]

--- a/src/services/uta-supervisor/restart-trigger.ts
+++ b/src/services/uta-supervisor/restart-trigger.ts
@@ -5,12 +5,9 @@
  *   1. Atomic-write `data/control/restart-uta.flag` (write to .tmp + rename)
  *      with content = ISO timestamp of the request.
  *   2. Guardian's fs.watch fires (debounced 100ms), Guardian SIGTERMs UTA,
- *      waits exit, respawns with fresh `accounts.json`.
+ *      waits exit, and respawns it with fresh boot-time configuration.
  *   3. Alice polls `${OPENALICE_UTA_URL}/__uta/health` until `startedAt` is
  *      newer than the pre-trigger value, or until timeout.
- *
- * Step 5 wires this into `trading-config.ts` so broker setup saves trigger
- * UTA reload automatically. Step 4 just exposes the helper.
  */
 
 import { writeFile, rename, mkdir } from 'fs/promises'

--- a/src/webui/routes/config-snapshot.spec.ts
+++ b/src/webui/routes/config-snapshot.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  writeConfigSection: vi.fn(),
+  triggerUTARestart: vi.fn(),
+}))
+
+vi.mock('../../core/config.js', async () => {
+  const actual = await vi.importActual<typeof import('../../core/config.js')>('../../core/config.js')
+  return {
+    ...actual,
+    writeConfigSection: mocks.writeConfigSection,
+  }
+})
+
+vi.mock('../../services/uta-supervisor/restart-trigger.js', () => ({
+  triggerUTARestart: mocks.triggerUTARestart,
+}))
+
+import { createConfigRoutes } from './config.js'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.writeConfigSection.mockImplementation(async (_section, body) => body)
+  mocks.triggerUTARestart.mockResolvedValue({ triggered: true, ready: true })
+})
+
+describe('snapshot config route', () => {
+  it('requests a supervised UTA restart after persisting snapshot settings', async () => {
+    const routes = createConfigRoutes()
+    const response = await routes.request('/snapshot', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: true, every: '2h' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ enabled: true, every: '2h' })
+    expect(mocks.writeConfigSection).toHaveBeenCalledWith('snapshot', {
+      enabled: true,
+      every: '2h',
+    })
+    await vi.waitFor(() => expect(mocks.triggerUTARestart).toHaveBeenCalledOnce())
+  })
+})

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -376,11 +376,11 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
         const fresh = await loadConfig()
         Object.assign(opts.ctx.config, fresh)
       }
-      // trading.json is consumed by the UTA process at boot (order-sync
-      // poller cadence) — bounce UTA via the Guardian flag protocol, same
-      // as broker config edits. Fire-and-forget: progress is visible
-      // through the health badges.
-      if (section === 'trading') {
+      // trading.json and snapshot.json are consumed by the UTA process at
+      // boot (order-sync and snapshot pump cadence) — bounce UTA via the
+      // Guardian flag protocol, same as broker config edits.
+      // Fire-and-forget: progress is visible through the health badges.
+      if (section === 'trading' || section === 'snapshot') {
         triggerUTARestart().catch(() => { /* surfaced via health badges */ })
       }
       // marketData edits are picked up lazily by the provider resolver

--- a/ui/src/demo/handlers/configKeys.spec.ts
+++ b/ui/src/demo/handlers/configKeys.spec.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
 
-import { demoCredentialPresets } from './configKeys'
+import { configKeysHandlers, demoCredentialPresets } from './configKeys'
+
+const server = setupServer(...configKeysHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 function modelIds(presetId: string): string[] {
   const preset = demoCredentialPresets.find((candidate) => candidate.id === presetId)
@@ -27,5 +35,27 @@ describe('demo credential catalog', () => {
       'claude-haiku-4-5',
       'claude-sonnet-4-6',
     ])
+  })
+})
+
+describe('demo snapshot config', () => {
+  it('mirrors production duration validation and normalization', async () => {
+    const invalid = await fetch(`${baseUrl}/api/config/snapshot`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: true, every: 'nonsense' }),
+    })
+
+    expect(invalid.status).toBe(400)
+    expect(await invalid.json()).toEqual({ error: 'Validation failed' })
+
+    const valid = await fetch(`${baseUrl}/api/config/snapshot`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: false, every: ' 2h15m ' }),
+    })
+
+    expect(valid.status).toBe(200)
+    expect(await valid.json()).toEqual({ enabled: false, every: '2h15m' })
   })
 })

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -134,6 +134,12 @@ export const demoCredentialPresets = [
   },
 ]
 
+function isValidDuration(value: string): boolean {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(value.trim())
+  if (!match) return false
+  return Number(match[1] ?? 0) > 0 || Number(match[2] ?? 0) > 0 || Number(match[3] ?? 0) > 0
+}
+
 export const configKeysHandlers = [
   http.get('/api/config/api-keys/status', () => HttpResponse.json({})),
   http.put('/api/config/apiKeys', () => new HttpResponse(null, { status: 204 })),
@@ -141,7 +147,20 @@ export const configKeysHandlers = [
   // and useConfigPage adopts the echo, so `{}` here would wipe the page.
   http.put('/api/config/marketData', async ({ request }) => HttpResponse.json(await request.json())),
   http.put('/api/config/trading', async ({ request }) => HttpResponse.json(await request.json())),
-  http.put('/api/config/snapshot', async ({ request }) => HttpResponse.json(await request.json())),
+  http.put('/api/config/snapshot', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+    const every = typeof body.every === 'string' ? body.every.trim() : '15m'
+    if (
+      (Object.prototype.hasOwnProperty.call(body, 'enabled') && typeof body.enabled !== 'boolean')
+      || !isValidDuration(every)
+    ) {
+      return HttpResponse.json({ error: 'Validation failed' }, { status: 400 })
+    }
+    return HttpResponse.json({
+      enabled: typeof body.enabled === 'boolean' ? body.enabled : true,
+      every,
+    })
+  }),
 
   http.get('/api/config', () =>
     HttpResponse.json({

--- a/ui/src/pages/PortfolioPage.snapshot-settings.spec.tsx
+++ b/ui/src/pages/PortfolioPage.snapshot-settings.spec.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PortfolioPage, SnapshotSettings } from './PortfolioPage'
+
+const mocks = vi.hoisted(() => ({
+  configLoad: vi.fn(),
+  updateSection: vi.fn(),
+  openOrFocus: vi.fn(),
+  setSidebar: vi.fn(),
+}))
+
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      config: {
+        ...actual.api.config,
+        load: mocks.configLoad,
+        updateSection: mocks.updateSection,
+      },
+      trading: {
+        ...actual.api.trading,
+        equity: vi.fn(async () => null),
+        listUTASummaries: vi.fn(async () => ({ utas: [] })),
+        fxRates: vi.fn(async () => ({ rates: [] })),
+        equityCurve: vi.fn(async () => ({ points: [] })),
+      },
+    },
+  }
+})
+
+vi.mock('../hooks/useAccountHealth', () => ({
+  useAccountHealth: () => ({}),
+}))
+
+vi.mock('../live/trading-mode', () => ({
+  ensureTradingModePolling: vi.fn(),
+  useTradingMode: (selector: (state: { status: { mode: string }; loading: boolean }) => unknown) =>
+    selector({ status: { mode: 'pro' }, loading: false }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: {
+    openOrFocus: typeof mocks.openOrFocus
+    setSidebar: typeof mocks.setSidebar
+  }) => unknown) => selector({
+    openOrFocus: mocks.openOrFocus,
+    setSidebar: mocks.setSidebar,
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.configLoad.mockResolvedValue({
+    snapshot: { enabled: false, every: '1h' },
+  })
+  mocks.updateSection.mockImplementation(async (_section, data) => data)
+})
+
+afterEach(cleanup)
+
+describe('Portfolio snapshot settings', () => {
+  it('shows an existing custom interval after configuration loads', () => {
+    const { rerender } = render(
+      <SnapshotSettings
+        enabled
+        every="1h"
+        onEnabledChange={vi.fn()}
+        onEveryChange={vi.fn()}
+        saveStatus="idle"
+      />,
+    )
+
+    expect(screen.queryByRole('textbox', { name: 'Custom portfolio snapshot interval' })).toBeNull()
+
+    rerender(
+      <SnapshotSettings
+        enabled
+        every="2h"
+        onEnabledChange={vi.fn()}
+        onEveryChange={vi.fn()}
+        saveStatus="idle"
+      />,
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Custom portfolio snapshot interval' })
+    expect((input as HTMLInputElement).value).toBe('2h')
+    expect(screen.getByRole('button', { name: 'Custom' }).getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('keeps invalid custom intervals local and explains the accepted format', () => {
+    const onEveryChange = vi.fn()
+    render(
+      <SnapshotSettings
+        enabled
+        every="1h"
+        onEnabledChange={vi.fn()}
+        onEveryChange={onEveryChange}
+        saveStatus="idle"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Custom' }))
+    const input = screen.getByRole('textbox', { name: 'Custom portfolio snapshot interval' })
+    fireEvent.change(input, { target: { value: 'nonsense' } })
+
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    expect(screen.getByRole('alert').textContent).toContain('Use a positive duration')
+    expect(onEveryChange).not.toHaveBeenCalled()
+
+    fireEvent.change(input, { target: { value: ' 2h15m ' } })
+
+    expect(input.getAttribute('aria-invalid')).toBe('false')
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(onEveryChange).toHaveBeenCalledWith('2h15m')
+  })
+})
+
+describe('Portfolio snapshot persistence', () => {
+  it('does not restart UTA just by loading the page, then saves the first user edit', async () => {
+    render(<PortfolioPage />)
+
+    const enabledToggle = await screen.findByRole('switch', {
+      name: 'Enable portfolio snapshots',
+    })
+    await new Promise((resolve) => setTimeout(resolve, 700))
+
+    expect(mocks.updateSection).not.toHaveBeenCalled()
+
+    fireEvent.click(enabledToggle)
+
+    await waitFor(() => expect(mocks.updateSection).toHaveBeenCalledWith('snapshot', {
+      enabled: true,
+      every: '1h',
+    }))
+  })
+})

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -122,6 +122,7 @@ export function PortfolioPage() {
   const [selectedSnapshot, setSelectedSnapshot] = useState<UTASnapshotSummary | null>(null)
   const [snapshotEnabled, setSnapshotEnabled] = useState(true)
   const [snapshotEvery, setSnapshotEvery] = useState('15m')
+  const [snapshotConfigLoaded, setSnapshotConfigLoaded] = useState(false)
   // Aggregate curve (all UTAs, full per-account breakdown) — shared between
   // hero today-PnL delta and per-account sparklines. Distinct from
   // curvePoints which follows the user's chart-account selection.
@@ -131,7 +132,11 @@ export function PortfolioPage() {
   const saveSnapshotConfig = useCallback(async (d: Record<string, unknown>) => {
     await api.config.updateSection('snapshot', d)
   }, [])
-  const { status: snapshotSaveStatus } = useAutoSave({ data: snapshotConfig, save: saveSnapshotConfig })
+  const { status: snapshotSaveStatus } = useAutoSave({
+    data: snapshotConfig,
+    save: saveSnapshotConfig,
+    enabled: snapshotConfigLoaded,
+  })
 
   // Fetch curve data for the user's chart-pane selection (single account
   // or 'all'). Distinct from aggregate-curve — that one is always fetched
@@ -177,6 +182,7 @@ export function PortfolioPage() {
       setSnapshotEnabled(configResult.snapshot.enabled)
       setSnapshotEvery(configResult.snapshot.every)
     }
+    setSnapshotConfigLoaded(true)
 
     // Default to first account on initial load
     const effectiveId = curveAccountId || result.accounts[0]?.id || 'all'
@@ -780,7 +786,16 @@ const INTERVAL_PRESETS = [
   { label: '1h', value: '1h' },
 ]
 
-function SnapshotSettings({ enabled, every, onEnabledChange, onEveryChange, saveStatus }: {
+export function isValidSnapshotInterval(value: string): boolean {
+  const match = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(value.trim())
+  if (!match) return false
+  const hours = Number(match[1] ?? 0)
+  const minutes = Number(match[2] ?? 0)
+  const seconds = Number(match[3] ?? 0)
+  return hours > 0 || minutes > 0 || seconds > 0
+}
+
+export function SnapshotSettings({ enabled, every, onEnabledChange, onEveryChange, saveStatus }: {
   enabled: boolean
   every: string
   onEnabledChange: (v: boolean) => void
@@ -789,6 +804,13 @@ function SnapshotSettings({ enabled, every, onEnabledChange, onEveryChange, save
 }) {
   const isPreset = INTERVAL_PRESETS.some(p => p.value === every)
   const [showCustom, setShowCustom] = useState(!isPreset)
+  const [customEvery, setCustomEvery] = useState(every)
+  const customEveryValid = isValidSnapshotInterval(customEvery)
+
+  useEffect(() => {
+    setCustomEvery(every)
+    if (!isPreset) setShowCustom(true)
+  }, [every, isPreset])
 
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-border/70 bg-secondary/45 px-3 py-2.5 text-[12px] text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
@@ -818,13 +840,30 @@ function SnapshotSettings({ enabled, every, onEnabledChange, onEveryChange, save
           compact
         />
         {showCustom && (
-          <input
-            aria-label="Custom portfolio snapshot interval"
-            className="w-16 rounded-md border border-border bg-background px-1.5 py-1 text-center text-[12px] text-foreground outline-none focus:border-primary"
-            value={every}
-            onChange={(e) => onEveryChange(e.target.value)}
-            placeholder="e.g. 2h"
-          />
+          <div className="relative">
+            <input
+              aria-label="Custom portfolio snapshot interval"
+              aria-invalid={!customEveryValid}
+              aria-describedby={!customEveryValid ? 'snapshot-interval-error' : undefined}
+              className="w-20 rounded-md border border-border bg-background px-1.5 py-1 text-center text-[12px] text-foreground outline-none focus:border-primary"
+              value={customEvery}
+              onChange={(e) => {
+                const next = e.target.value
+                setCustomEvery(next)
+                if (isValidSnapshotInterval(next)) onEveryChange(next.trim())
+              }}
+              placeholder="e.g. 2h"
+            />
+            {!customEveryValid && (
+              <p
+                id="snapshot-interval-error"
+                role="alert"
+                className="absolute right-0 top-full z-10 mt-1 w-max max-w-64 rounded-md border border-destructive/30 bg-background px-2 py-1 text-[11px] text-destructive shadow-md"
+              >
+                Use a positive duration such as 15m, 1h, or 2h15m.
+              </p>
+            )}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- validate custom portfolio snapshot intervals in the UI and core config before they reach the UTA pump
- keep invalid custom drafts local with an accessible format hint, while correctly revealing custom intervals loaded asynchronously
- restart UTA through the existing Guardian protocol after a valid snapshot config save so enable/cadence changes actually take effect
- avoid the inverse regression: merely opening Portfolio does not autosave the loaded config or restart UTA
- migrate historical invalid `snapshot.json` intervals to the safe `15m` default and keep the Demo API contract aligned

## Root cause

Portfolio previously persisted every non-empty custom interval, while `snapshotSchema` accepted any string. UTA's boot-time `createPump` accepts only positive `h`/`m`/`s` durations and throws for values such as `nonsense`. In addition, generic snapshot config writes did not request a UTA reload, so valid changes appeared saved in the UI but the running scheduler retained its old settings until a later restart.

## User impact

Users now receive immediate, field-level guidance for invalid intervals. Valid enable and cadence changes are applied to the running product through a supervised UTA restart, without causing a restart merely from visiting Portfolio. Existing invalid persisted values are repaired during upgrade before strict validation loads them.

## Verification

- `pnpm exec vitest run src/core/config.spec.ts src/migrations/0027_repair_snapshot_interval/index.spec.ts src/migrations/runner.spec.ts src/webui/routes/config-snapshot.spec.ts ui/src/pages/PortfolioPage.snapshot-settings.spec.tsx ui/src/demo/handlers/configKeys.spec.ts` — 55 passed
- `pnpm build:migration-index`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build:demo`
- `pnpm -F @traderalice/guardian-runtime typecheck`
- `pnpm -F @traderalice/guardian-runtime build`
- `pnpm test:e2e` — 30 passed, 3 skipped
- `pnpm test:smoke` — isolated Alice/UTA/Vite boot, migration 0027 application, UTA `startedAt` change after restart, and clean teardown passed
- `pnpm test` — 3400 passed, 9 skipped
- Real Demo `/portfolio`: verified `nonsense` keeps the custom interval invalid with an inline alert; `2h15m` clears the alert and becomes saveable
- `git diff --check`

## Boundary touch

UTA supervision and persisted snapshot configuration. No broker credentials, account state, order writes, or live-paper trading were used.