### PR TITLE
Improve market sidebar keyboard search

### DIFF
--- a/ui/src/components/MarketSidebar.spec.tsx
+++ b/ui/src/components/MarketSidebar.spec.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BarSourceCandidate } from '../api/market'
+import { i18n } from '../i18n'
+import { useWorkspace } from '../tabs/store'
+import { useWatchlist } from '../tabs/watchlist-store'
+import { getFocusedTab } from '../tabs/types'
+import { MarketSidebar } from './MarketSidebar'
+
+const searchResults: BarSourceCandidate[] = [
+  {
+    barId: 'yfinance|AAPL',
+    source: 'vendor',
+    sourceId: 'yfinance',
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    assetClass: 'equity',
+    label: 'AAPL',
+    barCapability: 'delayed',
+  },
+  {
+    barId: 'alpaca-paper|AAPL',
+    source: 'uta',
+    sourceId: 'alpaca-paper',
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    assetClass: 'equity',
+    label: 'AAPL',
+    barCapability: 'iex',
+  },
+]
+
+vi.mock('./market/useAssetSearch', () => ({
+  useAssetSearch: (query: string) => ({
+    results: query.trim() ? searchResults : [],
+    loading: false,
+  }),
+}))
+
+beforeEach(async () => {
+  window.localStorage.clear()
+  await i18n.changeLanguage('en')
+  useWorkspace.setState({
+    tabs: {},
+    tree: { kind: 'leaf', group: { id: 'g1', tabIds: [], activeTabId: null } },
+    focusedGroupId: 'g1',
+    selectedSidebar: null,
+  })
+  useWatchlist.setState({ entries: [] })
+})
+
+afterEach(cleanup)
+
+describe('MarketSidebar search keyboard controls', () => {
+  it('opens the first exact provider when Enter is pressed', () => {
+    render(<MarketSidebar />)
+    const search = screen.getByRole('textbox', { name: 'Search assets…' })
+
+    fireEvent.change(search, { target: { value: 'apple' } })
+    fireEvent.keyDown(search, { key: 'Enter' })
+
+    expect(getFocusedTab(useWorkspace.getState())?.spec).toEqual({
+      kind: 'market-detail',
+      params: {
+        assetClass: 'equity',
+        symbol: 'AAPL',
+        source: 'yfinance|AAPL',
+      },
+    })
+  })
+
+  it('moves the provider highlight with arrow keys before selecting', () => {
+    const view = render(<MarketSidebar />)
+    const search = screen.getByRole('textbox', { name: 'Search assets…' })
+
+    fireEvent.change(search, { target: { value: 'apple' } })
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+
+    const highlighted = view.container.querySelector('[data-keyboard-highlighted="true"]')
+    expect(highlighted?.textContent).toContain('alpaca-paper')
+
+    fireEvent.keyDown(search, { key: 'Enter' })
+    expect(getFocusedTab(useWorkspace.getState())?.spec).toEqual({
+      kind: 'market-detail',
+      params: {
+        assetClass: 'equity',
+        symbol: 'AAPL',
+        source: 'alpaca-paper|AAPL',
+      },
+    })
+  })
+
+  it('clears an inline search with Escape', () => {
+    render(<MarketSidebar />)
+    const search = screen.getByRole('textbox', { name: 'Search assets…' })
+
+    fireEvent.change(search, { target: { value: 'apple' } })
+    fireEvent.keyDown(search, { key: 'Escape' })
+
+    expect((search as HTMLInputElement).value).toBe('')
+    expect(screen.queryByRole('heading', { name: /Search Results/ })).toBeNull()
+  })
+})

--- a/ui/src/components/MarketSidebar.tsx
+++ b/ui/src/components/MarketSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { type AssetClass, type BarSourceCandidate } from '../api/market'
 import { useAssetSearch } from './market/useAssetSearch'
@@ -42,6 +42,11 @@ export function MarketSidebar() {
   const [query, setQuery] = useState('')
   // Shared with the main search box — one search logic, no drift.
   const { results, loading } = useAssetSearch(query)
+  const [highlight, setHighlight] = useState(0)
+
+  useEffect(() => {
+    setHighlight(0)
+  }, [results])
 
   const watchlist = useWatchlist((s) => s.entries)
   const removeFromWatchlist = useWatchlist((s) => s.remove)
@@ -61,6 +66,26 @@ export function MarketSidebar() {
     openOrFocus({ kind: 'market-detail', params: { assetClass: routeAssetClass(c.assetClass), symbol: c.symbol, source: c.barId } })
   }
 
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      if (!query) return
+      event.preventDefault()
+      setQuery('')
+      return
+    }
+    if (loading || results.length === 0) return
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setHighlight((current) => Math.min(current + 1, results.length - 1))
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setHighlight((current) => Math.max(current - 1, 0))
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      handleSelectResult(results[highlight])
+    }
+  }
+
   return (
     <div className="flex flex-col gap-3 h-full overflow-hidden">
       {/* Search box */}
@@ -69,7 +94,9 @@ export function MarketSidebar() {
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleSearchKeyDown}
           placeholder={t('market.searchPlaceholder')}
+          aria-label={t('market.searchPlaceholder')}
           className="w-full px-2.5 py-1.5 bg-background text-foreground border border-border/70 rounded-md text-[13px] outline-none focus:border-primary"
         />
       </div>
@@ -142,19 +169,25 @@ export function MarketSidebar() {
             {!loading && results.length === 0 && (
               <p className="px-3 py-2 text-[12px] leading-relaxed text-muted-foreground">{t('market.noMatches')}</p>
             )}
-            {results.map((c) => (
-              <SidebarRow
+            {results.map((c, index) => (
+              <div
                 key={c.barId}
-                label={
-                  <span className="flex items-center gap-1.5 min-w-0">
-                    <span className="font-mono font-semibold shrink-0">{c.symbol}</span>
-                    {c.name && <span className="text-muted-foreground truncate">{c.name}</span>}
-                  </span>
-                }
-                active={isFocusedDetail(routeAssetClass(c.assetClass), c.symbol, c.barId)}
-                onClick={() => handleSelectResult(c)}
-                trail={<SourceTrail c={c} />}
-              />
+                data-keyboard-highlighted={index === highlight ? 'true' : 'false'}
+                onMouseEnter={() => setHighlight(index)}
+                className={index === highlight ? 'bg-muted/70' : undefined}
+              >
+                <SidebarRow
+                  label={
+                    <span className="flex items-center gap-1.5 min-w-0">
+                      <span className="font-mono font-semibold shrink-0">{c.symbol}</span>
+                      {c.name && <span className="text-muted-foreground truncate">{c.name}</span>}
+                    </span>
+                  }
+                  active={isFocusedDetail(routeAssetClass(c.assetClass), c.symbol, c.barId)}
+                  onClick={() => handleSelectResult(c)}
+                  trail={<SourceTrail c={c} />}
+                />
+              </div>
             ))}
           </>
         )}


### PR DESCRIPTION
## Summary
- let users move between federated Market sidebar search providers with Arrow Up/Down and open the highlighted exact provider with Enter
- make Escape clear the inline search and keep mouse hover in sync with the keyboard highlight
- give the sidebar search input an explicit accessible name and add focused regression coverage

## Verification
- `pnpm vitest run ui/src/components/MarketSidebar.spec.tsx` (3 passed)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 files passed, 1 skipped; 3391 tests passed, 9 skipped)
- Demo browser at `/market`: expanded the Market sidebar, searched `apple`, pressed Arrow Down, confirmed the `alpaca-paper` row highlight, pressed Enter, and confirmed AAPL opened with `alpaca-paper · AAPL (iex)` selected
- `git diff --check`

## Boundary touch
- none; UI-only navigation and accessibility behavior