### PR TITLE
Label issue property controls

### DIFF
--- a/ui/src/components/IssueDetail.spec.tsx
+++ b/ui/src/components/IssueDetail.spec.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { IssueDetail as IssueDetailData } from '../api/issues'
+import { IssueDetail } from './IssueDetail'
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  openAgentConfig: vi.fn(),
+  openHeadlessRun: vi.fn(),
+}))
+
+const scheduledIssue: IssueDetailData = {
+  issue: {
+    id: 'morning-scan',
+    title: 'Morning movers scan',
+    what: 'Scan the market and publish a brief.',
+    status: 'in_progress',
+    priority: 'high',
+    assignee: '@workspace',
+    agent: 'codex',
+    when: {
+      kind: 'cron',
+      cron: '30 8 * * 1-5',
+      timezone: 'America/New_York',
+    },
+  },
+  runs: [],
+  comments: [],
+  activity: [],
+  inboxReports: [],
+}
+
+vi.mock('../hooks/useIssueDetail', () => ({
+  useIssueDetail: () => ({
+    data: scheduledIssue,
+    error: null,
+    loading: false,
+    mutate: mocks.mutate,
+  }),
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    agents: [
+      { id: 'codex', displayName: 'Codex', kind: 'agent', installed: true },
+      { id: 'pi', displayName: 'Pi', kind: 'agent', installed: true },
+    ],
+    defaultAgent: 'pi',
+    issueDefaultAgent: null,
+    workspaces: [{ id: 'demo-ws-auto-quant', agents: ['codex', 'pi'] }],
+    openAgentConfig: mocks.openAgentConfig,
+    openHeadlessRun: mocks.openHeadlessRun,
+  }),
+}))
+
+vi.mock('./workspace/api', () => ({
+  getAgentReadiness: vi.fn().mockResolvedValue({ agents: {} }),
+  getWorkspaceSessionDirectory: vi.fn().mockResolvedValue({ sessions: [] }),
+}))
+
+vi.mock('./MarkdownWhatEditor', () => ({
+  MarkdownWhatEditor: ({ value }: { value: string }) => <div>{value}</div>,
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('IssueDetail property controls', () => {
+  it('names every editable property in the work-item rail', () => {
+    render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
+
+    expect(screen.getByRole('combobox', { name: 'Status' })).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Priority' })).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Assignee' })).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Runtime' })).toBeTruthy()
+    expect(screen.getByRole('textbox', { name: 'Run model' })).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Run effort' })).toBeTruthy()
+  })
+})

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -190,6 +190,7 @@ function AgentEditor({
         className={railControl}
         value={selected}
         disabled={disabled}
+        aria-label="Runtime"
         onChange={(e) => {
           const next = e.target.value
           onChange(next ? next : null)
@@ -331,6 +332,7 @@ function PropertiesRail({
             className={railControl}
             value={issue.status}
             disabled={saving}
+            aria-label="Status"
             onChange={(e) => onPatch({ status: e.target.value as IssueStatus })}
           >
             {STATUS_OPTIONS.map((s) => (
@@ -346,6 +348,7 @@ function PropertiesRail({
             className={`${railControl} capitalize`}
             value={issue.priority}
             disabled={saving}
+            aria-label="Priority"
             onChange={(e) => onPatch({ priority: e.target.value as IssuePriority })}
           >
             {PRIORITY_OPTIONS.map((p) => (


### PR DESCRIPTION
## Summary
- give the Issue detail rail's Status, Priority, and Runtime selectors explicit accessible names
- preserve the existing visible labels and editing behavior while making every editable work-item property identifiable to assistive technology
- add a focused render test that covers Status, Priority, Assignee, Runtime, Model, and Effort together

## Verification
- `pnpm vitest run ui/src/components/IssueDetail.spec.tsx` (1 passed)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 files passed, 1 skipped; 3389 tests passed, 9 skipped)
- Demo browser: opened Issues, inspected the Session-owned CPI issue and the workspace-owned Morning movers issue, and confirmed Status, Priority, Assignee, Runtime, Run model, and Run effort expose distinct names while cadence, Activity, Runs, and linked Inbox reports remain present
- `git diff --check`

## Boundary touch
- none; UI-only accessibility metadata and regression coverage