### PR TITLE
Preserve Inbox provenance in demo replies

### DIFF
--- a/ui/src/demo/handlers/inquiries.spec.ts
+++ b/ui/src/demo/handlers/inquiries.spec.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import { DEMO_WORKSPACE_ID } from '../fixtures/workspaces'
+import { inquiryHandlers, resetDemoInquiryState } from './inquiries'
+
+const server = setupServer(...inquiryHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => {
+  server.resetHandlers()
+  resetDemoInquiryState()
+})
+afterAll(() => server.close())
+
+async function askInbox(entryId: string) {
+  const response = await fetch(`${baseUrl}/api/inquiries/inbox/${entryId}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ prompt: 'Which assumption is driving the result?' }),
+  })
+
+  return { response, body: await response.json() }
+}
+
+describe('demo Inquiry handlers', () => {
+  it('continues the known Codex Inbox sender in the original Workspace', async () => {
+    const { response, body } = await askInbox('demo-inbox-headless-session')
+
+    expect(response.status).toBe(202)
+    expect(body).toMatchObject({
+      status: 'dispatched',
+      workspaceId: DEMO_WORKSPACE_ID,
+      workspace: 'demo',
+      agent: 'codex',
+      resolution: { mode: 'exact' },
+    })
+
+    const history = await fetch(
+      `${baseUrl}/api/inquiries/inbox/demo-inbox-headless-session`,
+    ).then((result) => result.json())
+    expect(history.inquiries).toEqual([
+      expect.objectContaining({
+        workspaceId: DEMO_WORKSPACE_ID,
+        agent: 'codex',
+        inquiry: expect.objectContaining({
+          question: 'Which assumption is driving the result?',
+          resolution: { mode: 'exact' },
+        }),
+      }),
+    ])
+  })
+
+  it('preserves the interactive Claude sender label', async () => {
+    const { body } = await askInbox('demo-inbox-aapl-q1')
+
+    expect(body).toMatchObject({
+      workspaceId: DEMO_WORKSPACE_ID,
+      workspace: 'demo',
+      agent: 'claude',
+    })
+  })
+
+  it('preserves the source Workspace identity for scheduled Inbox reports', async () => {
+    const { body } = await askInbox('demo-inbox-morning-1')
+
+    expect(body).toMatchObject({
+      workspaceId: 'demo-ws-auto-quant',
+      workspace: 'auto-quant',
+      agent: 'codex',
+    })
+  })
+})

--- a/ui/src/demo/handlers/inquiries.ts
+++ b/ui/src/demo/handlers/inquiries.ts
@@ -1,8 +1,13 @@
 import { http, HttpResponse } from 'msw'
 
 import type { InquiryRecord, InquirySubject } from '../../api/inquiries'
+import { demoInboxEntries } from '../fixtures/inbox'
 
 const records: InquiryRecord[] = []
+
+export function resetDemoInquiryState(): void {
+  records.length = 0
+}
 
 function list(subject: InquirySubject) {
   return records.filter((record) => {
@@ -15,12 +20,16 @@ function list(subject: InquirySubject) {
   })
 }
 
-function completed(subject: InquirySubject, question: string): InquiryRecord {
+function completed(
+  subject: InquirySubject,
+  question: string,
+  context: Partial<Pick<InquiryRecord, 'workspaceId' | 'agent'>> = {},
+): InquiryRecord {
   return {
     taskId: `demo-inquiry-${records.length + 1}`,
     resumeId: `demo-inquiry-resume-${records.length + 1}`,
-    workspaceId: subject.kind === 'issue' ? subject.workspaceId : 'demo-ws',
-    agent: 'pi',
+    workspaceId: context.workspaceId ?? (subject.kind === 'issue' ? subject.workspaceId : 'demo-ws'),
+    agent: context.agent ?? 'pi',
     status: 'done',
     startedAt: Date.now(),
     finishedAt: Date.now(),
@@ -40,11 +49,20 @@ export const inquiryHandlers = [
   ),
   http.post('/api/inquiries/inbox/:id', async ({ params, request }) => {
     const body = await request.json() as { prompt?: string }
-    const record = completed({ kind: 'inbox', entryId: String(params.id) }, body.prompt ?? '')
+    const entryId = String(params.id)
+    const entry = demoInboxEntries.find((candidate) => candidate.id === entryId)
+    const record = completed(
+      { kind: 'inbox', entryId },
+      body.prompt ?? '',
+      {
+        workspaceId: entry?.workspaceId,
+        agent: entry?.origin?.agent,
+      },
+    )
     records.unshift(record)
     return HttpResponse.json({
       status: 'dispatched', taskId: record.taskId, resumeId: record.resumeId,
-      workspaceId: record.workspaceId, workspace: 'demo', agent: record.agent,
+      workspaceId: record.workspaceId, workspace: entry?.workspaceLabel ?? 'demo', agent: record.agent,
       resolution: record.inquiry.resolution,
     }, { status: 202 })
   }),


### PR DESCRIPTION
## Summary
- resolve demo Inbox replies from the selected fixture instead of hard-coding every reply to Pi and the demo Workspace
- preserve the original runtime label, Workspace id, and Workspace label in the inquiry dispatch
- add handler coverage for Codex, Claude, and scheduled reports from another Workspace

## Verification
- `pnpm vitest run ui/src/demo/handlers/inquiries.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 passed, 1 skipped; 3391 tests passed, 9 skipped)
- `git diff --check`
- Demo Inbox browser walkthrough: replied to the NVDA update attributed to `codex · @demo-resume-1` and confirmed the response renders `codex replied`

## Boundary touch
- none; demo-only inquiry handlers and tests