### PR TITLE
Localize the Issues settings category

### DIFF
--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -147,7 +147,7 @@ export const ja: Resources = {
       aiProvider: 'AI プロバイダー',
       agentPermissions: 'エージェント権限',
       trading: '取引',
-      issues: 'Issues',
+      issues: 'イシュー',
       connectors: 'コネクター',
       mcpServer: 'MCP サーバー',
       marketData: 'マーケットデータ',

--- a/ui/src/i18n/locales/settings-category.spec.ts
+++ b/ui/src/i18n/locales/settings-category.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { en } from './en'
+import { ja } from './ja'
+import { zhHant } from './zh-Hant'
+import { zh } from './zh'
+
+const locales = {
+  en,
+  ja,
+  zh,
+  'zh-Hant': zhHant,
+}
+
+describe.each(Object.entries(locales))('%s locale', (_locale, resources) => {
+  it('uses the same Issues term in navigation and Settings', () => {
+    expect(resources.settings.category.issues).toBe(resources.nav.item.issue)
+  })
+})

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -155,7 +155,7 @@ export const zhHant: Resources = {
       aiProvider: 'AI 供應方',
       agentPermissions: '智慧體權限',
       trading: '交易',
-      issues: 'Issues',
+      issues: '議題',
       connectors: '連接器',
       mcpServer: 'MCP 伺服器',
       marketData: '市場資料',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -147,7 +147,7 @@ export const zh: Resources = {
       aiProvider: 'AI 提供方',
       agentPermissions: '智能体权限',
       trading: '交易',
-      issues: 'Issues',
+      issues: '议题',
       connectors: '连接器',
       mcpServer: 'MCP 服务器',
       marketData: '市场数据',


### PR DESCRIPTION
## Summary
- replace the hard-coded English `Issues` settings category in Simplified Chinese, Traditional Chinese, and Japanese
- reuse each locale's established navigation term so the same product area stays consistent across surfaces
- add a locale invariant test to prevent the Settings and primary navigation labels from diverging again

## Verification
- `pnpm vitest run ui/src/i18n/locales/settings-category.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 passed, 1 skipped; 3392 tests passed, 9 skipped)
- `git diff --check`
- Demo Settings browser walkthrough in Simplified Chinese, Traditional Chinese, and Japanese; confirmed `议题`, `議題`, and `イシュー` render in the category sidebar

## Boundary touch
- none; UI locale resources and tests only