### PR TITLE
Enable Workspace creation in the demo

### DIFF
--- a/ui/src/demo/handlers/workspaces-create.spec.ts
+++ b/ui/src/demo/handlers/workspaces-create.spec.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import { resetDemoWorkspaceCreateState, workspacesHandlers } from './workspaces'
+
+const server = setupServer(...workspacesHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => {
+  server.resetHandlers()
+  resetDemoWorkspaceCreateState()
+})
+afterAll(() => server.close())
+
+async function createWorkspace(tag: string, template = 'chat') {
+  return fetch(`${baseUrl}/api/workspaces`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ tag, template }),
+  })
+}
+
+describe('demo Workspace creation handler', () => {
+  it('creates an in-memory Workspace and includes it in later list responses', async () => {
+    const response = await createWorkspace('chat-jul29')
+    const body = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(body.workspace).toMatchObject({
+      id: 'demo-created-ws-1',
+      tag: 'chat-jul29',
+      dir: '/demo/workspaces/chat-jul29',
+      template: 'chat',
+      spawnedFromVersion: '0.2.0',
+      currentVersion: '0.2.0',
+      upgradeAvailable: null,
+      agents: ['claude', 'codex', 'opencode', 'pi'],
+      sessions: [],
+    })
+
+    const list = await fetch(`${baseUrl}/api/workspaces`).then((result) => result.json())
+    expect(list.workspaces).toContainEqual(body.workspace)
+  })
+
+  it('returns the production error shape for duplicate tags', async () => {
+    expect((await createWorkspace('chat-jul29')).status).toBe(201)
+
+    const duplicate = await createWorkspace('chat-jul29')
+    expect(duplicate.status).toBe(409)
+    expect(await duplicate.json()).toEqual({
+      error: 'tag_in_use',
+      message: 'A Workspace with tag "chat-jul29" already exists.',
+    })
+  })
+
+  it('rejects invalid tags without nesting the renderable error', async () => {
+    const response = await createWorkspace('Invalid Tag')
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'invalid_tag',
+      message: 'Use a-z, 0-9, "-", or "_"; start with a letter or number; maximum 33 characters.',
+    })
+  })
+})

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -14,6 +14,7 @@ import type {
   DepartedWorkspace,
   SessionRecord,
   WebPiSnapshot,
+  Workspace,
   WorkspaceMetadataPatch,
 } from '../../components/workspace/api'
 
@@ -34,6 +35,18 @@ const demoManagerSession = {
 
 let demoManagerMessages: unknown[] = []
 let demoQuickChatSequence = 0
+let demoWorkspaceCreateSequence = 0
+const demoCreatedWorkspaceIds = new Set<string>()
+const DEMO_WORKSPACE_TAG_RE = /^[a-z0-9][a-z0-9_-]{0,32}$/
+
+export function resetDemoWorkspaceCreateState(): void {
+  for (const id of demoCreatedWorkspaceIds) {
+    const index = demoWorkspaces.findIndex((workspace) => workspace.id === id)
+    if (index >= 0) demoWorkspaces.splice(index, 1)
+  }
+  demoCreatedWorkspaceIds.clear()
+  demoWorkspaceCreateSequence = 0
+}
 
 function webPiKey(wsId: string, sessionId: string): string {
   return `${wsId}::${sessionId}`
@@ -291,12 +304,64 @@ export const workspacesHandlers = [
     Object.assign(workspace, { lifecycle: 'purged', purgedAt: new Date().toISOString() })
     return HttpResponse.json({ ok: true })
   }),
-  http.post('/api/workspaces', () =>
-    HttpResponse.json(
-      { ok: false, status: 400, error: { error: 'bootstrap_failed', message: 'Demo mode — workspace creation is disabled.' } },
-      { status: 400 },
-    ),
-  ),
+  http.post('/api/workspaces', async ({ request }) => {
+    const body = await request.json().catch(() => ({})) as {
+      tag?: unknown
+      template?: unknown
+    }
+    if (typeof body.tag !== 'string') {
+      return HttpResponse.json({ error: 'tag_required', message: 'Workspace tag is required.' }, { status: 400 })
+    }
+    const tag = body.tag.trim()
+    if (!DEMO_WORKSPACE_TAG_RE.test(tag)) {
+      return HttpResponse.json({
+        error: 'invalid_tag',
+        message: 'Use a-z, 0-9, "-", or "_"; start with a letter or number; maximum 33 characters.',
+      }, { status: 400 })
+    }
+    if (demoWorkspaces.some((workspace) => workspace.tag === tag)) {
+      return HttpResponse.json({
+        error: 'tag_in_use',
+        message: `A Workspace with tag "${tag}" already exists.`,
+      }, { status: 409 })
+    }
+
+    const templateName = typeof body.template === 'string' && body.template.length > 0
+      ? body.template
+      : demoTemplates[0]?.name
+    if (!templateName) {
+      return HttpResponse.json({
+        error: 'no_templates_configured',
+        message: 'No Workspace templates are available.',
+      }, { status: 500 })
+    }
+    const template = demoTemplates.find((candidate) => candidate.name === templateName)
+    if (!template) {
+      return HttpResponse.json({
+        error: 'unknown_template',
+        message: `Unknown Workspace template: ${templateName}`,
+      }, { status: 400 })
+    }
+
+    demoWorkspaceCreateSequence += 1
+    const workspace: Workspace = {
+      id: `demo-created-ws-${demoWorkspaceCreateSequence}`,
+      tag,
+      dir: `/demo/workspaces/${tag}`,
+      createdAt: new Date().toISOString(),
+      template: template.name,
+      ...(template.version
+        ? { spawnedFromVersion: template.version, currentVersion: template.version }
+        : {}),
+      upgradeAvailable: null,
+      agents: ['claude', 'codex', 'opencode', 'pi'],
+      sessions: [],
+      agentOverride: { claude: false, codex: false, opencode: false, pi: false },
+    }
+    demoWorkspaces.push(workspace)
+    demoCreatedWorkspaceIds.add(workspace.id)
+    return HttpResponse.json({ workspace }, { status: 201 })
+  }),
   http.get('/api/workspaces/:id/offboarding', ({ params }) => {
     const workspace = demoWorkspaces.find((candidate) => candidate.id === String(params.id))
     if (!workspace) return HttpResponse.json({ error: 'not_found' }, { status: 404 })


### PR DESCRIPTION
## Summary
- replace the Demo Workspace creation stub with an in-memory implementation that follows the production response contract
- validate tags and templates, reject duplicate tags with renderable top-level errors, and expose newly created Workspaces through the list endpoint
- return a complete Workspace record so the real UI can navigate directly into the new empty desk
- add handler coverage for creation, list visibility, duplicate tags, and invalid tags

## Root cause
The Demo POST `/api/workspaces` route returned a nested `{ error: { ... } }` object even though the client expects the production `{ error, message }` shape. The form stored that object as renderable error text, causing React to crash to a blank page. The route also disabled a prominent mutation despite the Demo banner promising non-persistent mutations.

## Verification
- `pnpm vitest run ui/src/demo/handlers/workspaces-create.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 passed, 1 skipped; 3391 tests passed, 9 skipped)
- `git diff --check`
- Demo browser walkthrough: created `chat-jul29`, navigated to `/workspaces/demo-created-ws-1`, confirmed the empty Workspace/session surface renders, then retried the same tag and confirmed an inline duplicate error without a crash

## Boundary touch
- none; Demo-only Workspace handlers and tests