### PR TITLE
Enforce valid order sizing in manual entry

### DIFF
--- a/ui/src/components/uta/OrderEntryDialog.spec.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.spec.tsx
@@ -1,0 +1,89 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { tradingApi } from '../../api/trading'
+import { OrderEntryDialog } from './OrderEntryDialog'
+
+const pushResult = {
+  hash: 'demo-order',
+  message: 'Order sizing test',
+  operationCount: 1,
+  submitted: [{ action: 'placeOrder', success: true, orderId: 'order-1', status: 'Submitted' }],
+  rejected: [],
+}
+
+function setup() {
+  const placeOrder = vi.spyOn(tradingApi, 'placeOrder').mockResolvedValue(pushResult)
+  render(
+    <OrderEntryDialog
+      utaId="demo-paper"
+      mode={{ kind: 'place' }}
+      onClose={vi.fn()}
+    />,
+  )
+
+  fireEvent.change(screen.getByPlaceholderText('okx-test|BTC/USDT'), {
+    target: { value: 'demo-paper|AAPL' },
+  })
+  fireEvent.change(screen.getByPlaceholderText('Why are you placing this order?'), {
+    target: { value: 'Order sizing test' },
+  })
+
+  return placeOrder
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('OrderEntryDialog sizing', () => {
+  it('clears Quantity when Cash Qty becomes authoritative', async () => {
+    const placeOrder = setup()
+    const quantity = screen.getByPlaceholderText('0.001') as HTMLInputElement
+    fireEvent.change(quantity, { target: { value: '1' } })
+    fireEvent.click(screen.getByRole('button', { name: '▸ Show advanced (cash qty, TIF)' }))
+    const cashQty = screen.getByPlaceholderText('50') as HTMLInputElement
+    fireEvent.change(cashQty, { target: { value: '100' } })
+
+    expect(quantity.value).toBe('')
+    expect(cashQty.value).toBe('100')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Place Order' }))
+    await waitFor(() => expect(placeOrder).toHaveBeenCalledWith('demo-paper', expect.objectContaining({
+      aliceId: 'demo-paper|AAPL',
+      cashQty: '100',
+    })))
+    expect(placeOrder.mock.calls[0]?.[1]).not.toHaveProperty('totalQuantity')
+  })
+
+  it('clears Cash Qty when Quantity becomes authoritative', async () => {
+    const placeOrder = setup()
+    fireEvent.click(screen.getByRole('button', { name: '▸ Show advanced (cash qty, TIF)' }))
+    const cashQty = screen.getByPlaceholderText('50') as HTMLInputElement
+    fireEvent.change(cashQty, { target: { value: '100' } })
+    const quantity = screen.getByPlaceholderText('0.001') as HTMLInputElement
+    fireEvent.change(quantity, { target: { value: '2' } })
+
+    expect(cashQty.value).toBe('')
+    expect(quantity.value).toBe('2')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Place Order' }))
+    await waitFor(() => expect(placeOrder).toHaveBeenCalledWith('demo-paper', expect.objectContaining({
+      aliceId: 'demo-paper|AAPL',
+      totalQuantity: '2',
+    })))
+    expect(placeOrder.mock.calls[0]?.[1]).not.toHaveProperty('cashQty')
+  })
+
+  it('removes Cash Qty when switching to a Limit order', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button', { name: '▸ Show advanced (cash qty, TIF)' }))
+    fireEvent.change(screen.getByPlaceholderText('50'), { target: { value: '100' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Limit' }))
+
+    expect(screen.queryByPlaceholderText('50')).toBeNull()
+    expect((screen.getByRole('button', { name: 'Place Order' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/ui/src/components/uta/OrderEntryDialog.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.tsx
@@ -142,10 +142,11 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
   const [subAccountId, setSubAccountId] = useState(() => initialWallet(p.subAccounts, p.defaultSubAccountId))
 
   const multiWallet = (p.subAccounts?.length ?? 0) > 1
+  const hasOrderSize = !!quantity.trim() || (orderType === 'MKT' && !!cashQty.trim())
   const canSubmit =
     !!aliceId.trim() &&
     !!message.trim() &&
-    (!!quantity.trim() || !!cashQty.trim()) &&
+    hasOrderSize &&
     (orderType !== 'LMT' || !!lmtPrice.trim()) &&
     (!multiWallet || !!subAccountId) &&
     !p.submitting
@@ -160,8 +161,11 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
         orderType,
         tif,
         message: message.trim(),
-        ...(quantity.trim() && { totalQuantity: quantity.trim() }),
-        ...(cashQty.trim() && { cashQty: cashQty.trim() }),
+        ...(orderType === 'MKT' && cashQty.trim()
+          ? { cashQty: cashQty.trim() }
+          : quantity.trim()
+            ? { totalQuantity: quantity.trim() }
+            : {}),
         ...(orderType === 'LMT' && lmtPrice.trim() && { lmtPrice: lmtPrice.trim() }),
         ...(multiWallet && subAccountId && { subAccountId }),
       }
@@ -197,15 +201,27 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
           <Segmented value={action} options={[{ id: 'BUY' }, { id: 'SELL' }]} onChange={(v) => setAction(v as 'BUY' | 'SELL')} />
         </Field>
         <Field label="Order Type">
-          <Segmented value={orderType} options={[{ id: 'MKT', label: 'Market' }, { id: 'LMT', label: 'Limit' }]} onChange={(v) => setOrderType(v as 'MKT' | 'LMT')} />
+          <Segmented
+            value={orderType}
+            options={[{ id: 'MKT', label: 'Market' }, { id: 'LMT', label: 'Limit' }]}
+            onChange={(v) => {
+              const next = v as 'MKT' | 'LMT'
+              setOrderType(next)
+              if (next !== 'MKT') setCashQty('')
+            }}
+          />
         </Field>
       </div>
 
-      <Field label={`Quantity${cashQty ? ' (or use Cash Qty below)' : ''}`}>
+      <Field label={`Quantity${cashQty ? ' (using Cash Qty below)' : ''}`}>
         <input
           className={`${inputClass} font-mono`}
           value={quantity}
-          onChange={(e) => setQuantity(e.target.value)}
+          onChange={(e) => {
+            const next = e.target.value
+            setQuantity(next)
+            if (next.trim()) setCashQty('')
+          }}
           placeholder="0.001"
           inputMode="decimal"
         />
@@ -232,16 +248,24 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
       </button>
       {showAdvanced && (
         <div className="space-y-3 border-l border-border pl-3">
-          <Field label="Cash Qty (notional)">
-            <input
-              className={`${inputClass} font-mono`}
-              value={cashQty}
-              onChange={(e) => setCashQty(e.target.value)}
-              placeholder="50"
-              inputMode="decimal"
-            />
-            <p className="text-[11px] text-muted-foreground/60 mt-1">USDT-equivalent notional. Overrides Quantity if both are set.</p>
-          </Field>
+          {orderType === 'MKT' && (
+            <Field label="Cash Qty (notional)">
+              <input
+                className={`${inputClass} font-mono`}
+                value={cashQty}
+                onChange={(e) => {
+                  const next = e.target.value
+                  setCashQty(next)
+                  if (next.trim()) setQuantity('')
+                }}
+                placeholder="50"
+                inputMode="decimal"
+              />
+              <p className="text-[11px] text-muted-foreground/60 mt-1">
+                Market orders only. Entering a cash quantity clears Quantity.
+              </p>
+            </Field>
+          )}
           <Field label="Time in Force">
             <select className={inputClass} value={tif} onChange={(e) => setTif(e.target.value)}>
               <option value="DAY">DAY</option>
@@ -482,4 +506,3 @@ function Segmented({ value, options, onChange }: {
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary
- make Quantity and Cash Qty mutually exclusive in the manual order form
- clear Quantity when notional sizing is entered, and clear Cash Qty when share/contract sizing becomes authoritative
- expose Cash Qty only for Market orders and remove it when switching to Limit
- build the request defensively so it can never carry both sizing fields
- add component coverage for both sizing directions and the Market-to-Limit transition

## Root cause
The form claimed Cash Qty would override Quantity, but retained both values and sent both fields. UTA explicitly rejects `totalQuantity + cashQty` as mutually exclusive. The form also allowed a Limit order to use Cash Qty even though UTA supports notional sizing only for Market orders.

## Verification
- `pnpm vitest run ui/src/components/uta/OrderEntryDialog.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 passed, 1 skipped; 3391 tests passed, 9 skipped)
- `git diff --check`
- Demo browser walkthrough on Alpaca Paper: reproduced Quantity `1` + Cash Qty `100` with submit enabled before the fix; after the fix, entering Cash Qty clears Quantity, and switching to Limit removes Cash Qty and disables submit until valid Limit sizing is supplied

## Boundary touch
- trading UI validation only; no UTA, broker adapter, account state, or order execution code changed
- live-paper execution was not required because the change prevents a request that UTA already rejects before any broker write