### PR TITLE
Populate the Demo tool catalog

### DIFF
--- a/ui/src/demo/fixtures/tools.ts
+++ b/ui/src/demo/fixtures/tools.ts
@@ -1,0 +1,138 @@
+import type { ToolDetail, ToolInfo } from '../../api/tools'
+
+export const demoToolDetails = {
+  calculate: {
+    name: 'calculate',
+    group: 'thinking',
+    description:
+      'Perform mathematical calculations with precision. Supports basic operators: +, -, *, /, (), and decimals.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        expression: {
+          type: 'string',
+          description: 'Mathematical expression to evaluate, e.g. "(1000 * 0.1) / 2".',
+        },
+      },
+      required: ['expression'],
+      additionalProperties: false,
+      examples: [{ expression: '(1000 * 0.1) / 2' }],
+    },
+  },
+  marketSearchForResearch: {
+    name: 'marketSearchForResearch',
+    group: 'market-search',
+    description:
+      'Search for symbols across equities, crypto, currencies, and commodities for market-data research.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Keyword to search, e.g. "AAPL", "bitcoin", or "EUR".',
+        },
+        limit: {
+          type: 'integer',
+          description: 'Maximum results per asset class (default: 20).',
+        },
+      },
+      required: ['query'],
+      additionalProperties: false,
+      examples: [{ query: 'apple' }],
+    },
+  },
+  searchBars: {
+    name: 'searchBars',
+    group: 'quant',
+    description:
+      'Find broker and vendor K-line sources for a symbol, including the barId used by calculateQuant.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Symbol or keyword, e.g. "AAPL", "BTC", or "bitcoin".',
+        },
+        limit: {
+          type: 'integer',
+          description: 'Maximum candidates (default: 20).',
+        },
+      },
+      required: ['query'],
+      additionalProperties: false,
+      examples: [{ query: 'AAPL' }],
+    },
+  },
+  equityGetProfile: {
+    name: 'equityGetProfile',
+    group: 'equity',
+    description:
+      'Get a company profile and key valuation metrics for a stock symbol.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description: 'Ticker symbol, e.g. "AAPL" or "MSFT".',
+        },
+      },
+      required: ['symbol'],
+      additionalProperties: false,
+      examples: [{ symbol: 'AAPL' }],
+    },
+  },
+} satisfies Record<string, ToolDetail>
+
+export type DemoToolName = keyof typeof demoToolDetails
+
+export const demoToolInventory: ToolInfo[] = Object.values(demoToolDetails).map(
+  ({ name, group, description }) => ({ name, group: group ?? 'other', description }),
+)
+
+export const demoToolResults: Record<DemoToolName, unknown> = {
+  calculate: 50,
+  marketSearchForResearch: {
+    results: [
+      {
+        symbol: 'AAPL',
+        name: 'Apple Inc.',
+        assetClass: 'equity',
+        exchange: 'NASDAQ',
+      },
+    ],
+    count: 1,
+  },
+  searchBars: {
+    candidates: [
+      {
+        barId: 'alpaca-paper|AAPL',
+        symbol: 'AAPL',
+        source: 'uta',
+        provider: 'alpaca-paper',
+        barCapability: 'realtime',
+      },
+      {
+        barId: 'yfinance|AAPL',
+        symbol: 'AAPL',
+        source: 'vendor',
+        provider: 'yfinance',
+        barCapability: 'delayed',
+      },
+    ],
+    count: 2,
+  },
+  equityGetProfile: {
+    profile: {
+      symbol: 'AAPL',
+      name: 'Apple Inc.',
+      sector: 'Technology',
+      industry: 'Consumer Electronics',
+      website: 'https://www.apple.com',
+    },
+    metrics: {
+      market_cap: 3_280_000_000_000,
+      pe_ratio: 31.4,
+      dividend_yield: 0.0044,
+    },
+  },
+}

--- a/ui/src/demo/handlers/toolsSimulator.spec.ts
+++ b/ui/src/demo/handlers/toolsSimulator.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import { resetDemoToolsState, toolsSimulatorHandlers } from './toolsSimulator'
+
+const server = setupServer(...toolsSimulatorHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => {
+  server.resetHandlers()
+  resetDemoToolsState()
+})
+afterAll(() => server.close())
+
+describe('demo tool handlers', () => {
+  it('returns a representative catalog with runnable examples', async () => {
+    const inventoryResponse = await fetch(`${baseUrl}/api/tools`)
+    const inventory = await inventoryResponse.json()
+
+    expect(inventoryResponse.status).toBe(200)
+    expect(inventory.inventory.map((tool: { name: string }) => tool.name)).toEqual([
+      'calculate',
+      'marketSearchForResearch',
+      'searchBars',
+      'equityGetProfile',
+    ])
+    expect(inventory.disabled).toEqual([])
+
+    const detailResponse = await fetch(`${baseUrl}/api/tools/searchBars`)
+    const detail = await detailResponse.json()
+
+    expect(detailResponse.status).toBe(200)
+    expect(detail).toMatchObject({
+      name: 'searchBars',
+      group: 'quant',
+      inputSchema: {
+        required: ['query'],
+        examples: [{ query: 'AAPL' }],
+      },
+    })
+  })
+
+  it('returns a recorded result with the submitted input', async () => {
+    const response = await fetch(`${baseUrl}/api/tools/equityGetProfile/execute`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ symbol: 'AAPL' }),
+    })
+    const body = await response.json()
+    const result = JSON.parse(body.content[0].text)
+
+    expect(response.status).toBe(200)
+    expect(result).toMatchObject({
+      demo: true,
+      note: expect.stringContaining('Recorded result'),
+      input: { symbol: 'AAPL' },
+      result: {
+        profile: {
+          symbol: 'AAPL',
+          name: 'Apple Inc.',
+        },
+      },
+    })
+  })
+
+  it('round-trips disabled tool state and rejects unknown tools', async () => {
+    const updateResponse = await fetch(`${baseUrl}/api/tools`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        disabled: ['searchBars', 'missingTool'],
+      }),
+    })
+
+    expect(await updateResponse.json()).toEqual({ disabled: ['searchBars'] })
+    expect(await fetch(`${baseUrl}/api/tools`).then((result) => result.json())).toMatchObject({
+      disabled: ['searchBars'],
+    })
+
+    const missing = await fetch(`${baseUrl}/api/tools/missingTool`)
+    expect(missing.status).toBe(404)
+    expect(await missing.json()).toEqual({ error: 'Tool not found: missingTool' })
+  })
+})

--- a/ui/src/demo/handlers/toolsSimulator.ts
+++ b/ui/src/demo/handlers/toolsSimulator.ts
@@ -1,14 +1,64 @@
 import { http, HttpResponse } from 'msw'
 
+import {
+  demoToolDetails,
+  demoToolInventory,
+  demoToolResults,
+  type DemoToolName,
+} from '../fixtures/tools'
+
+let disabledTools = new Set<DemoToolName>()
+
+export function resetDemoToolsState(): void {
+  disabledTools = new Set()
+}
+
+function isDemoToolName(name: string): name is DemoToolName {
+  return name in demoToolDetails
+}
+
 export const toolsSimulatorHandlers = [
-  http.get('/api/tools', () => HttpResponse.json({ inventory: [], disabled: [] })),
-  http.put('/api/tools', () => HttpResponse.json({ disabled: [] })),
-  http.get('/api/tools/:name', () =>
-    HttpResponse.json({ error: 'not found' }, { status: 404 }),
+  http.get('/api/tools', () =>
+    HttpResponse.json({
+      inventory: demoToolInventory,
+      disabled: [...disabledTools],
+    }),
   ),
-  http.post('/api/tools/:name/execute', () =>
-    HttpResponse.json({ content: [{ type: 'text', text: 'Demo mode — tool execution is disabled.' }], isError: true }),
-  ),
+  http.put('/api/tools', async ({ request }) => {
+    const body = await request.json() as { disabled?: unknown }
+    const disabled = Array.isArray(body.disabled)
+      ? body.disabled.filter(
+          (name): name is DemoToolName => typeof name === 'string' && isDemoToolName(name),
+        )
+      : []
+    disabledTools = new Set(disabled)
+    return HttpResponse.json({ disabled: [...disabledTools] })
+  }),
+  http.get('/api/tools/:name', ({ params }) => {
+    const name = String(params.name)
+    if (!isDemoToolName(name)) {
+      return HttpResponse.json({ error: `Tool not found: ${name}` }, { status: 404 })
+    }
+    return HttpResponse.json(demoToolDetails[name])
+  }),
+  http.post('/api/tools/:name/execute', async ({ params, request }) => {
+    const name = String(params.name)
+    if (!isDemoToolName(name)) {
+      return HttpResponse.json({ error: `Tool not found: ${name}` }, { status: 404 })
+    }
+    const input = await request.json().catch(() => ({}))
+    return HttpResponse.json({
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          demo: true,
+          note: 'Recorded result for the prefilled example; submitted input is echoed for UI testing.',
+          input,
+          result: demoToolResults[name],
+        }, null, 2),
+      }],
+    })
+  }),
 
   http.get('/api/simulator/utas', () => HttpResponse.json({ utas: [] })),
   http.get('/api/simulator/uta/:id/state', () =>


### PR DESCRIPTION
## What changed

- replace the Demo's permanently empty tool inventory with four representative tools drawn from the current ToolCenter surface
- expose realistic tool details, JSON schemas, and prefilled examples in Dev Panel
- return clearly marked recorded execution results while echoing submitted input
- keep tool enable/disable changes in memory for the active Demo session
- add handler contract coverage for inventory, detail, execution, mutation, and unknown-tool behavior

## Why

A real Demo walkthrough showed that Dev Panel → Tools rendered a filter with no tool list and still instructed the user to select a tool from the left panel. Settings → Tools likewise fell through to an empty state. The Demo handler hard-coded `/api/tools` to `{ inventory: [], disabled: [] }`, so two otherwise complete product surfaces could not be evaluated or demonstrated.

## User impact

The static Demo now lets prospective users browse representative OpenAlice capabilities, inspect runnable schemas, execute a recorded example, and exercise tool configuration without a backend. Recorded results are explicitly labeled so the Demo does not imply live market-data execution.

## Verification

- `pnpm vitest run ui/src/demo/handlers/toolsSimulator.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 358 files passed, 1 skipped; 3391 tests passed, 9 skipped
- `pnpm -F open-alice-ui build:demo`
- real `pnpm -F open-alice-ui dev:demo` browser walkthrough:
  - confirmed four tool groups render in Dev Panel
  - opened `searchBars` and confirmed the AAPL example is prefilled
  - executed it and confirmed the recorded-result note and broker/vendor candidates render
  - toggled `searchBars` in Settings and confirmed the active-session disabled state updates