### PR TITLE
Confirm destructive Inbox deletion

### DIFF
--- a/ui/src/components/ConfirmDialog.tsx
+++ b/ui/src/components/ConfirmDialog.tsx
@@ -8,6 +8,8 @@ interface ConfirmDialogProps {
   message: React.ReactNode
   /** Confirm button label. Defaults to 'Delete' for the destructive case. */
   confirmLabel?: string
+  /** Cancel button label. Defaults to 'Cancel'. */
+  cancelLabel?: string
   /** Visual treatment of the confirm button. Defaults to 'danger'. */
   variant?: 'danger' | 'primary'
   /** Called on user confirm. May be async — the button shows a busy state until it resolves. */
@@ -31,6 +33,7 @@ export function ConfirmDialog({
   title,
   message,
   confirmLabel = 'Delete',
+  cancelLabel = 'Cancel',
   variant = 'danger',
   onConfirm,
   onClose,
@@ -63,7 +66,7 @@ export function ConfirmDialog({
           disabled={busy}
           className="btn-secondary"
         >
-          Cancel
+          {cancelLabel}
         </button>
         <button
           type="button"

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -972,6 +972,8 @@ export const en = {
     cannotReplyWorkspaceGone: 'Workspace no longer exists — nowhere to reply.',
     deleteEntryTitle: 'Delete this entry (Delete / Backspace)',
     deleteEntryAriaLabel: 'Delete this inbox entry',
+    deleteConfirmTitle: 'Delete Inbox entry?',
+    deleteConfirmMessage: 'This permanently removes this update from Inbox. Files linked from {{workspace}} are not deleted.',
   },
   templates: {
     catalogTitle: 'Workspace templates',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -961,6 +961,8 @@ export const ja: Resources = {
     cannotReplyWorkspaceGone: 'ワークスペースが存在しないため、返信先がありません。',
     deleteEntryTitle: 'この項目を削除（Delete / Backspace）',
     deleteEntryAriaLabel: 'この受信トレイの項目を削除',
+    deleteConfirmTitle: '受信トレイの項目を削除しますか？',
+    deleteConfirmMessage: 'この更新を受信トレイから完全に削除します。{{workspace}} でリンクされているファイルは削除されません。',
   },
   templates: {
     catalogTitle: 'ワークスペーステンプレート',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -969,6 +969,8 @@ export const zhHant: Resources = {
     cannotReplyWorkspaceGone: '工作區已不存在——無處回覆。',
     deleteEntryTitle: '刪除此則（Delete / Backspace）',
     deleteEntryAriaLabel: '刪除此收件匣項目',
+    deleteConfirmTitle: '刪除這則收件匣訊息？',
+    deleteConfirmMessage: '這會從收件匣中永久刪除此更新，但不會刪除 {{workspace}} 中連結的檔案。',
   },
   templates: {
     catalogTitle: '工作區模板',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -961,6 +961,8 @@ export const zh: Resources = {
     cannotReplyWorkspaceGone: '工作区已不存在——无处回复。',
     deleteEntryTitle: '删除此条（Delete / Backspace）',
     deleteEntryAriaLabel: '删除此收件箱条目',
+    deleteConfirmTitle: '删除这条收件箱消息？',
+    deleteConfirmMessage: '这会从收件箱中永久删除此更新，但不会删除 {{workspace}} 中链接的文件。',
   },
   templates: {
     catalogTitle: '工作区模板',

--- a/ui/src/pages/InboxPage.spec.tsx
+++ b/ui/src/pages/InboxPage.spec.tsx
@@ -1,11 +1,33 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '../i18n'
+import { api } from '../api'
+import { useInboxSelection } from '../live/inbox-selection'
 import { readWorkspaceFile } from '../components/workspace/api'
-import { InboxAttachment } from './InboxPage'
+import { InboxAttachment, InboxPage } from './InboxPage'
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    workspaces: [{
+      id: 'ws-1',
+      tag: 'research',
+      sessions: [],
+    }],
+    openHeadlessRun: vi.fn(),
+    resumeSession: vi.fn(),
+  }),
+}))
+
+vi.mock('../hooks/useIssues', () => ({
+  useIssues: () => ({ data: undefined }),
+}))
+
+vi.mock('../components/InboxReplyThread', () => ({
+  InboxReplyThread: () => null,
+}))
 
 vi.mock('../components/workspace/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../components/workspace/api')>()
@@ -22,6 +44,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   cleanup()
+  useInboxSelection.getState().select(null)
   vi.clearAllMocks()
 })
 
@@ -55,5 +78,42 @@ describe('InboxAttachment', () => {
 
     expect(await screen.findByTitle('HTML report: research/close-report.html')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Collapse attachment close-report.html' })).toBeTruthy()
+  })
+})
+
+describe('InboxPage deletion', () => {
+  it('requires confirmation for both the button and keyboard shortcut', async () => {
+    const entry = {
+      id: 'inbox-1',
+      ts: Date.now(),
+      workspaceId: 'ws-1',
+      workspaceLabel: 'research',
+      comments: 'A durable research update.',
+    }
+    vi.spyOn(api.inbox, 'history').mockResolvedValue({
+      entries: [entry],
+      hasMore: false,
+    })
+    const deleteEntry = vi.spyOn(api.inbox, 'delete').mockResolvedValue(true)
+    useInboxSelection.getState().select(entry.id)
+
+    render(<InboxPage visible />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete this inbox entry' }))
+    expect(screen.getByText('Delete Inbox entry?')).toBeTruthy()
+    expect(screen.getByText(/Files linked from research are not deleted/)).toBeTruthy()
+    expect(deleteEntry).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByText('Delete Inbox entry?')).toBeNull()
+    expect(deleteEntry).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(window, { key: 'Backspace' })
+    expect(screen.getByText('Delete Inbox entry?')).toBeTruthy()
+    expect(deleteEntry).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(deleteEntry).toHaveBeenCalledWith(entry.id))
+    await waitFor(() => expect(screen.queryByText('Delete Inbox entry?')).toBeNull())
   })
 })

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -17,6 +17,7 @@ import {
   Trash2,
 } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 import { Skeleton } from '../components/StateViews'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { FileContentView } from '../components/FileContentView'
@@ -48,8 +49,8 @@ interface InboxPageProps {
  * background or open the same Session interactively.
  *
  * Selection (an entryId) is owned by `useInboxSelection`; the sidebar
- * drives it and marks the entry read on select. Delete (header trash +
- * page-level Delete/Backspace) advances selection to the next entry.
+ * drives it and marks the entry read on select. Confirmed Delete (header
+ * trash + page-level Delete/Backspace) advances selection to the next entry.
  */
 export function InboxPage({ visible }: InboxPageProps) {
   const { t } = useTranslation()
@@ -58,8 +59,10 @@ export function InboxPage({ visible }: InboxPageProps) {
   const selectedId = useInboxSelection((s) => s.selectedEntryId)
   const select = useInboxSelection((s) => s.select)
   const markRead = useInboxRead((s) => s.markRead)
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
 
   const selected = entries.find((e) => e.id === selectedId) ?? null
+  const pendingDelete = entries.find((e) => e.id === pendingDeleteId) ?? null
 
   /** Hard-delete an entry. Optimistically removes it, advances selection
    *  to the next-older entry (or previous if last), fires the DELETE,
@@ -88,8 +91,14 @@ export function InboxPage({ visible }: InboxPageProps) {
     refreshInbox()
   }, [entries, select, markRead])
 
+  const requestDelete = useCallback((id: string) => {
+    setPendingDeleteId(id)
+  }, [])
+
   // Delete / Backspace shortcut. Gated on `visible` (background inbox
-  // tabs must not intercept) and on a selected entry existing.
+  // tabs must not intercept) and on a selected entry existing. The
+  // shortcut requests confirmation rather than deleting durable Inbox
+  // history immediately.
   useEffect(() => {
     if (!visible) return
     if (!selectedId) return
@@ -98,36 +107,53 @@ export function InboxPage({ visible }: InboxPageProps) {
       if (e.metaKey || e.ctrlKey || e.altKey) return
       if (e.key !== 'Delete' && e.key !== 'Backspace') return
       e.preventDefault()
-      void handleDelete(selectedId!)
+      requestDelete(selectedId!)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [visible, selectedId, handleDelete])
+  }, [visible, selectedId, requestDelete])
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      <PageHeader
-        title={t('nav.item.inbox')}
-        description={t('inbox.pageDescription', { count: entries.length })}
-      />
-      <div className="flex-1 overflow-y-auto min-h-0">
-        {loading && entries.length === 0 ? (
-          <InboxLoadingSkeleton />
-        ) : entries.length === 0 ? (
-          <EmptyState />
-        ) : !selected ? (
-          <div className="px-6 py-8 text-muted-foreground text-sm">
-            {t('inbox.selectFromSidebar')}
-          </div>
-        ) : (
-          <Detail
-            key={selected.id}
-            entry={selected}
-            onDelete={() => handleDelete(selected.id)}
-          />
-        )}
+    <>
+      <div className="flex flex-col flex-1 min-h-0">
+        <PageHeader
+          title={t('nav.item.inbox')}
+          description={t('inbox.pageDescription', { count: entries.length })}
+        />
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {loading && entries.length === 0 ? (
+            <InboxLoadingSkeleton />
+          ) : entries.length === 0 ? (
+            <EmptyState />
+          ) : !selected ? (
+            <div className="px-6 py-8 text-muted-foreground text-sm">
+              {t('inbox.selectFromSidebar')}
+            </div>
+          ) : (
+            <Detail
+              key={selected.id}
+              entry={selected}
+              onDelete={() => requestDelete(selected.id)}
+            />
+          )}
+        </div>
       </div>
-    </div>
+      {pendingDelete && (
+        <ConfirmDialog
+          title={t('inbox.deleteConfirmTitle')}
+          message={t('inbox.deleteConfirmMessage', {
+            workspace: pendingDelete.workspaceLabel ?? pendingDelete.workspaceId,
+          })}
+          confirmLabel={t('common.delete')}
+          cancelLabel={t('common.cancel')}
+          onConfirm={async () => {
+            await handleDelete(pendingDelete.id)
+            setPendingDeleteId(null)
+          }}
+          onClose={() => setPendingDeleteId(null)}
+        />
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## What changed

- route the Inbox trash button through a confirmation dialog before hard deletion
- make the page-level Delete and Backspace shortcuts open the same confirmation instead of deleting immediately
- explain that the Inbox update is removed permanently while linked Workspace files remain intact
- localize the confirmation copy and cancel action in English, Simplified Chinese, Traditional Chinese, and Japanese
- add an integration test covering button confirmation, cancellation, keyboard confirmation, and the eventual API call

## Why

A real Demo walkthrough showed that one click on the Inbox trash icon immediately removed the selected update and advanced to the next entry. The page-level Delete/Backspace shortcut had the same behavior. Inbox entries are durable delivery records that can carry attachments, replies, sender Session identity, and provenance, so an accidental keypress or icon click should not issue a hard delete without confirming intent.

## User impact

Both mouse and keyboard deletion now pause at the same clear, localized confirmation. Cancelling leaves the entry selected and untouched; only the destructive confirmation calls the delete API.

## Verification

- `pnpm vitest run ui/src/pages/InboxPage.spec.tsx` — 3 tests passed
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 357 files passed, 1 skipped; 3389 tests passed, 9 skipped
- `pnpm -F open-alice-ui build:demo`
- real `pnpm -F open-alice-ui dev:demo` browser walkthrough:
  - clicked the Inbox trash action and confirmed the dialog appears without advancing selection
  - cancelled and confirmed the original entry remains selected
  - pressed Backspace and confirmed the same dialog appears
  - confirmed deletion and verified the dialog closes and selection advances to the next entry