### PR TITLE
Prevent position closes from crossing through flat

### DIFF
--- a/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts
@@ -244,6 +244,7 @@ describe('UTA — operation dispatch', () => {
 
   describe('closePosition', () => {
     it('calls broker.closePosition with contract and qty', async () => {
+      broker.externalDeposit({ nativeKey: 'AAPL', quantity: 10 })
       const spy = vi.spyOn(broker, 'closePosition')
       const contract = makeContract({ symbol: 'AAPL' })
       uta.git.add({ action: 'closePosition', contract, quantity: new Decimal(5) })
@@ -254,6 +255,31 @@ describe('UTA — operation dispatch', () => {
       const [passedContract, qty] = spy.mock.calls[0]
       expect(passedContract.symbol).toBe('AAPL')
       expect(qty!.toNumber()).toBe(5)
+    })
+
+    it('rejects an oversized partial close before calling the broker', async () => {
+      broker.externalDeposit({ nativeKey: 'AAPL', quantity: 10 })
+      const spy = vi.spyOn(broker, 'closePosition')
+      const contract = makeContract({ symbol: 'AAPL' })
+      uta.git.add({ action: 'closePosition', contract, quantity: new Decimal(11) })
+      uta.git.commit('oversized close AAPL')
+      const result = await uta.push()
+
+      expect(spy).not.toHaveBeenCalled()
+      expect(result.submitted).toHaveLength(0)
+      expect(result.rejected).toHaveLength(1)
+      expect(result.rejected[0].error).toMatch(/quantity 11 exceeds the open AAPL position size 10/)
+    })
+
+    it('rejects a stale partial close when the position no longer exists', async () => {
+      const spy = vi.spyOn(broker, 'closePosition')
+      const contract = makeContract({ symbol: 'AAPL' })
+      uta.git.add({ action: 'closePosition', contract, quantity: new Decimal(5) })
+      uta.git.commit('stale close AAPL')
+      const result = await uta.push()
+
+      expect(spy).not.toHaveBeenCalled()
+      expect(result.rejected[0].error).toMatch(/no open position found for AAPL/)
     })
 
     it('passes undefined qty for full close', async () => {
@@ -732,6 +758,15 @@ describe('UTA — stageClosePosition', () => {
     const op = staged[0] as Extract<Operation, { action: 'closePosition' }>
     expect(op.quantity).toBeUndefined()
   })
+
+  it.each(['0', '-1', 'Infinity', 'not-a-number'])(
+    'rejects invalid explicit quantity %s before staging',
+    (qty) => {
+      expect(() => uta.stageClosePosition({ aliceId: 'mock-paper|AAPL', qty }))
+        .toThrow(/qty must be a positive finite number/)
+      expect(uta.status().staged).toHaveLength(0)
+    },
+  )
 })
 
 // ==================== contractFromAliceId ====================

--- a/services/uta/src/domain/trading/UnifiedTradingAccount.ts
+++ b/services/uta/src/domain/trading/UnifiedTradingAccount.ts
@@ -185,6 +185,9 @@ export class UnifiedTradingAccount {
         case 'modifyOrder':
           return broker.modifyOrder(op.orderId, op.changes)
         case 'closePosition':
+          if (op.quantity != null) {
+            await this._assertCloseQuantityWithinPosition(op.contract, op.quantity)
+          }
           return broker.closePosition(op.contract, op.quantity)
         case 'cancelOrder':
           return broker.cancelOrder(op.orderId, op.orderCancel)
@@ -560,6 +563,38 @@ export class UnifiedTradingAccount {
   }
 
   /**
+   * Re-check an explicit partial-close quantity against the latest broker
+   * position immediately before dispatch. This is deliberately later than
+   * staging: a position can change after the UI or CLI created its proposal.
+   * Broker adapters do not all enforce reduce-only semantics, so allowing an
+   * oversized reverse order here could cross through flat into a new exposure.
+   */
+  private async _assertCloseQuantityWithinPosition(contract: Contract, quantity: Decimal): Promise<void> {
+    if (!quantity.isFinite() || quantity.lte(0)) {
+      throw new Error('closePosition: qty must be a positive finite number.')
+    }
+
+    const nativeKey = this.broker.getNativeKey(contract)
+    const positions = await this._callBroker(() => this.broker.getPositions())
+    const position = positions.find(candidate =>
+      this.broker.getNativeKey(candidate.contract) === nativeKey,
+    )
+    const label = contract.symbol || contract.localSymbol || nativeKey
+
+    if (!position) {
+      throw new Error(`closePosition: no open position found for ${label}. Refresh positions before retrying.`)
+    }
+
+    const available = position.quantity.abs()
+    if (quantity.gt(available)) {
+      throw new Error(
+        `closePosition: quantity ${quantity.toString()} exceeds the open ${label} position size ${available.toString()}. ` +
+        `Use a quantity no greater than ${available.toString()}, or omit qty to close the full position.`,
+      )
+    }
+  }
+
+  /**
    * Per-orderType required-field gate, enforced at stage time so a broken
    * order can never reach staging/commit. Without this, a caller that loses
    * fields on the way in (e.g. a CLI typo like --quantity for --totalQuantity)
@@ -709,13 +744,25 @@ export class UnifiedTradingAccount {
     const contract = this.contractFromAliceId(params.aliceId)
     if (params.symbol) contract.symbol = params.symbol
 
+    let quantity: Decimal | undefined
+    if (params.qty != null) {
+      try {
+        quantity = new Decimal(String(params.qty))
+      } catch {
+        throw new Error('closePosition: qty must be a positive finite number.')
+      }
+      if (!quantity.isFinite() || quantity.lte(0)) {
+        throw new Error('closePosition: qty must be a positive finite number.')
+      }
+    }
+
     const subAccountId = this._resolveWriteSubAccount(contract, params.subAccountId)
     if (subAccountId) this._stagedSubAccountIds.push(subAccountId)
 
     return this.git.add({
       action: 'closePosition',
       contract,
-      quantity: params.qty != null ? new Decimal(String(params.qty)) : undefined,
+      quantity,
     })
   }
 

--- a/ui/src/components/uta/OrderEntryDialog.spec.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.spec.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { closePosition } = vi.hoisted(() => ({
+  closePosition: vi.fn(),
+}))
+
+vi.mock('../../api/trading', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/trading')>()
+  return {
+    ...actual,
+    tradingApi: {
+      ...actual.tradingApi,
+      closePosition,
+    },
+  }
+})
+
+import { OrderEntryDialog } from './OrderEntryDialog'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function setup() {
+  render(
+    <OrderEntryDialog
+      utaId="alpaca-paper"
+      mode={{ kind: 'close', aliceId: 'alpaca-paper|AAPL', quantity: '120', symbol: 'AAPL' }}
+      onClose={vi.fn()}
+    />,
+  )
+}
+
+describe('OrderEntryDialog close-position quantity guard', () => {
+  it('blocks a quantity above the current position size', () => {
+    setup()
+
+    fireEvent.change(screen.getByLabelText('Quantity to close'), { target: { value: '200' } })
+    fireEvent.change(screen.getByLabelText('Commit Message — required'), { target: { value: 'Risk limit' } })
+
+    expect(screen.getByText('Quantity cannot exceed the current position size (120).')).toBeTruthy()
+    expect(screen.getByLabelText('Quantity to close').getAttribute('aria-invalid')).toBe('true')
+    expect((screen.getByRole('button', { name: 'Close Position' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(closePosition).not.toHaveBeenCalled()
+  })
+
+  it('submits a valid partial close with the exact decimal string', async () => {
+    closePosition.mockResolvedValue({
+      hash: 'commit-1',
+      message: 'Risk limit',
+      operationCount: 1,
+      submitted: [{ action: 'closePosition', success: true, status: 'filled' }],
+      rejected: [],
+    })
+    setup()
+
+    fireEvent.change(screen.getByLabelText('Quantity to close'), { target: { value: '60.25' } })
+    fireEvent.change(screen.getByLabelText('Commit Message — required'), { target: { value: 'Risk limit' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Close Position' }))
+
+    await waitFor(() => expect(closePosition).toHaveBeenCalledWith('alpaca-paper', {
+      aliceId: 'alpaca-paper|AAPL',
+      symbol: 'AAPL',
+      qty: '60.25',
+      message: 'Risk limit',
+    }))
+  })
+
+  it('allows clearing the quantity to request a full close', async () => {
+    closePosition.mockResolvedValue({
+      hash: 'commit-2',
+      message: 'Exit',
+      operationCount: 1,
+      submitted: [{ action: 'closePosition', success: true, status: 'filled' }],
+      rejected: [],
+    })
+    setup()
+
+    fireEvent.change(screen.getByLabelText('Quantity to close'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Commit Message — required'), { target: { value: 'Exit' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Close Position' }))
+
+    await waitFor(() => expect(closePosition).toHaveBeenCalledWith('alpaca-paper', {
+      aliceId: 'alpaca-paper|AAPL',
+      symbol: 'AAPL',
+      message: 'Exit',
+    }))
+  })
+})

--- a/ui/src/components/uta/OrderEntryDialog.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import Decimal from 'decimal.js'
 import { Field, inputClass } from '../form'
 import { Dialog } from './Dialog'
 import { tradingApi, OrderEntryError } from '../../api/trading'
@@ -281,13 +282,34 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
 
 // ==================== Close form ====================
 
+function closeQuantityError(qty: string, availableQty: string): string | null {
+  if (!qty.trim()) return null
+
+  const available = new Decimal(availableQty).abs()
+  let requested: Decimal
+  try {
+    requested = new Decimal(qty.trim())
+  } catch {
+    return `Enter a positive quantity no greater than ${available.toString()}.`
+  }
+
+  if (!requested.isFinite() || requested.lte(0)) {
+    return `Enter a positive quantity no greater than ${available.toString()}.`
+  }
+  if (requested.gt(available)) {
+    return `Quantity cannot exceed the current position size (${available.toString()}).`
+  }
+  return null
+}
+
 function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { aliceId: string; initialQty: string; symbol?: string }) {
   const [qty, setQty] = useState(initialQty)
   const [message, setMessage] = useState('')
   const [subAccountId, setSubAccountId] = useState(() => initialWallet(p.subAccounts, p.defaultSubAccountId))
 
   const multiWallet = (p.subAccounts?.length ?? 0) > 1
-  const canSubmit = !!message.trim() && (!multiWallet || !!subAccountId) && !p.submitting
+  const quantityError = closeQuantityError(qty, initialQty)
+  const canSubmit = !!message.trim() && !quantityError && (!multiWallet || !!subAccountId) && !p.submitting
 
   const handleSubmit = async () => {
     p.setError(null)
@@ -330,8 +352,16 @@ function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { al
           onChange={(e) => setQty(e.target.value)}
           placeholder="(empty = full position)"
           inputMode="decimal"
+          aria-label="Quantity to close"
+          aria-invalid={quantityError ? 'true' : undefined}
+          aria-describedby="close-position-quantity-help"
         />
-        <p className="text-[11px] text-muted-foreground/60 mt-1">Defaults to current position size. Override for partial close. Empty = close entire position.</p>
+        <p
+          id="close-position-quantity-help"
+          className={`text-[11px] mt-1 ${quantityError ? 'text-destructive' : 'text-muted-foreground/60'}`}
+        >
+          {quantityError ?? `Current position size: ${new Decimal(initialQty).abs().toString()}. Enter less for a partial close, or clear to close all.`}
+        </p>
       </Field>
 
       <Field label="Commit Message — required">
@@ -341,6 +371,7 @@ function CloseForm({ aliceId, initialQty, symbol, ...p }: SharedFormProps & { al
           onChange={(e) => setMessage(e.target.value)}
           placeholder="Why are you closing?"
           autoFocus
+          aria-label="Commit Message — required"
         />
       </Field>
 
@@ -482,4 +513,3 @@ function Segmented({ value, options, onChange }: {
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary

- validate close quantities in the manual order-entry dialog against the displayed position size
- reject non-positive and invalid explicit close quantities while staging
- re-read the latest broker positions immediately before dispatch and reject stale or oversized partial closes before any broker mutation

## Evidence

On the Demo Portfolio account, AAPL showed an open quantity of 120. The close dialog accepted `200` with a commit message and enabled **Close Position**; the Demo backend only rejected it later because Demo mutations are read-only. Alpaca and IBKR adapters build an explicit reverse market order for the supplied quantity, so an oversized close can cross through flat into a new opposite exposure.

## Verification

- `pnpm vitest run ui/src/components/uta/OrderEntryDialog.spec.tsx services/uta/src/domain/trading/UnifiedTradingAccount.spec.ts` (116 passed)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (3397 passed, 9 skipped)
- `pnpm test:e2e` (30 passed, 3 skipped)
- real Demo route: AAPL 120 → quantity 200 shows the current-position limit and keeps **Close Position** disabled; quantity 60 clears the error and enables the button

No live-paper order was sent: this is a broker-independent pre-dispatch safety boundary, and the MockBroker lifecycle verifies that rejected operations never reach `broker.closePosition`.