### PR TITLE
Identify each position close action by contract

### DIFF
--- a/ui/src/pages/UTADetailPage.positions.spec.tsx
+++ b/ui/src/pages/UTADetailPage.positions.spec.tsx
@@ -1,0 +1,49 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Position } from '../api/types'
+import { PositionsSection } from './UTADetailPage'
+
+function position(symbol: string): Position {
+  return {
+    contract: {
+      aliceId: `demo-paper|${symbol}`,
+      symbol,
+      secType: 'STK',
+      exchange: 'SMART',
+      currency: 'USD',
+    },
+    currency: 'USD',
+    side: 'long',
+    quantity: '10',
+    avgCost: '100',
+    marketPrice: '110',
+    marketValue: '1100',
+    unrealizedPnL: '100',
+    realizedPnL: '0',
+  }
+}
+
+afterEach(cleanup)
+
+describe('UTADetailPage positions table', () => {
+  it('identifies each close action by its contract', () => {
+    const aapl = position('AAPL')
+    const nvda = position('NVDA')
+    const onCloseClick = vi.fn()
+
+    render(
+      <PositionsSection
+        positions={[aapl, nvda]}
+        onCloseClick={onCloseClick}
+      />,
+    )
+
+    expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Close AAPL position' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close NVDA position' }))
+
+    expect(onCloseClick).toHaveBeenCalledWith(nvda)
+  })
+})

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -17,7 +17,7 @@ import { EquityCurve } from '../components/EquityCurve'
 import { Metric, signFromDelta } from '../components/Metric'
 import { fmt, fmtPnl, fmtNum, fmtPctSigned, isUnsetDecimal } from '../lib/format'
 import { secTypeToClass, assetClassLabel, ASSET_CLASS_ORDER, type AssetClass } from '../lib/asset-class'
-import { ContractCell } from '../lib/contract-display'
+import { ContractCell, contractPrimary } from '../lib/contract-display'
 
 // ==================== Page ====================
 
@@ -573,7 +573,7 @@ function Section({ title, action, children }: { title: string; action?: React.Re
 
 interface PositionGroup { class: AssetClass; positions: Position[] }
 
-function PositionsSection({ positions, onCloseClick }: {
+export function PositionsSection({ positions, onCloseClick }: {
   positions: Position[]
   onCloseClick: (p: Position) => void
 }) {
@@ -613,7 +613,9 @@ function PositionsSection({ positions, onCloseClick }: {
               <th className="px-3 py-2 font-medium text-right">Avg → Mark</th>
               <th className="px-3 py-2 font-medium text-right">Mkt Value</th>
               <th className="px-3 py-2 font-medium text-right">PnL</th>
-              <th className="px-3 py-2 font-medium text-right" />
+              <th className="px-3 py-2 font-medium text-right">
+                <span className="sr-only">Actions</span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -685,7 +687,9 @@ function PositionRow({ position: p, onClose }: { position: Position; onClose: ()
       </td>
       <td className="px-3 py-2 text-right">
         <button
+          type="button"
           onClick={onClose}
+          aria-label={`Close ${contractPrimary(p.contract)} position`}
           className="text-[11px] text-muted-foreground hover:text-destructive transition-colors"
         >
           Close


### PR DESCRIPTION
## Summary

- give the positions table action column an accessible `Actions` heading
- name each close button with the contract's canonical display label while keeping the visible text concise
- cover the column name, per-contract button names, and click routing with a focused component test

## Evidence

The Demo Portfolio page showed four open positions (AAPL, NVDA, GOOG, AMD), but its accessibility tree exposed four indistinguishable buttons all named only `Close`, and the action column had no heading. Keyboard and screen-reader users could not tell which position each action would close without reconstructing table position manually.

## Verification

- `pnpm vitest run ui/src/pages/UTADetailPage.positions.spec.tsx` (1 passed)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3389 passed, 9 skipped)
- real Demo route: action column exposes `Actions`; buttons expose `Close AAPL position`, `Close NVDA position`, `Close GOOG position`, and `Close AMD position`; visible button text remains `Close`