### PR TITLE
Expose the active order view to assistive technology

### DIFF
--- a/ui/src/pages/UTADetailPage.orders-tabs.spec.tsx
+++ b/ui/src/pages/UTADetailPage.orders-tabs.spec.tsx
@@ -1,0 +1,36 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../api', () => ({
+  api: {
+    trading: {
+      orderHistory: vi.fn().mockResolvedValue({ orders: [] }),
+      tradeHistory: vi.fn().mockResolvedValue({ trades: [] }),
+    },
+  },
+}))
+
+import { OrdersArea } from './UTADetailPage'
+
+afterEach(cleanup)
+
+describe('UTADetailPage order views', () => {
+  it('exposes the current view and its controlled content region', () => {
+    render(<OrdersArea utaId="demo-paper" openOrders={[]} />)
+
+    expect(screen.getByRole('group', { name: 'Order views' })).toBeTruthy()
+
+    const open = screen.getByRole('button', { name: 'Open (0)' })
+    const history = screen.getByRole('button', { name: 'History' })
+    expect(open.getAttribute('aria-pressed')).toBe('true')
+    expect(history.getAttribute('aria-pressed')).toBe('false')
+    expect(screen.getByRole('region', { name: 'Open orders' }).id).toBe('orders-open-panel')
+
+    fireEvent.click(history)
+
+    expect(open.getAttribute('aria-pressed')).toBe('false')
+    expect(history.getAttribute('aria-pressed')).toBe('true')
+    expect(history.getAttribute('aria-controls')).toBe('orders-history-panel')
+    expect(screen.getByRole('region', { name: 'Order history' }).id).toBe('orders-history-panel')
+  })
+})

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -747,7 +747,7 @@ interface OpenOrderRow {
 
 type OrdersTab = 'open' | 'history' | 'trades'
 
-function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[] }) {
+export function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[] }) {
   const [tab, setTab] = useState<OrdersTab>('open')
   const [history, setHistory] = useState<OrderHistoryEntry[] | null>(null)
   const [trades, setTrades] = useState<TradeHistoryEntry[] | null>(null)
@@ -776,21 +776,25 @@ function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[
     return () => { cancelled = true; clearInterval(t) }
   }, [tab, utaId])
 
-  const tabs: Array<{ id: OrdersTab; label: string }> = [
-    { id: 'open', label: `Open (${openOrders.length})` },
-    { id: 'history', label: 'History' },
-    { id: 'trades', label: 'Trades' },
+  const tabs: Array<{ id: OrdersTab; label: string; panelLabel: string }> = [
+    { id: 'open', label: `Open (${openOrders.length})`, panelLabel: 'Open orders' },
+    { id: 'history', label: 'History', panelLabel: 'Order history' },
+    { id: 'trades', label: 'Trades', panelLabel: 'Trade history' },
   ]
+  const activeTab = tabs.find(candidate => candidate.id === tab)!
 
   return (
     <Section
       title="Orders"
       action={
-        <div className="flex gap-1">
+        <div className="flex gap-1" role="group" aria-label="Order views">
           {tabs.map(t => (
             <button
               key={t.id}
+              type="button"
               onClick={() => setTab(t.id)}
+              aria-pressed={tab === t.id}
+              aria-controls={`orders-${t.id}-panel`}
               className={`px-2 py-0.5 text-[11px] rounded transition-colors ${
                 tab === t.id
                   ? 'bg-primary/15 text-primary font-medium'
@@ -803,9 +807,15 @@ function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[
         </div>
       }
     >
-      {tab === 'open' && <OpenOrdersTable orders={openOrders} />}
-      {tab === 'history' && <OrderHistoryTable orders={history} />}
-      {tab === 'trades' && <TradeHistoryTable trades={trades} />}
+      <div
+        id={`orders-${tab}-panel`}
+        role="region"
+        aria-label={activeTab.panelLabel}
+      >
+        {tab === 'open' && <OpenOrdersTable orders={openOrders} />}
+        {tab === 'history' && <OrderHistoryTable orders={history} />}
+        {tab === 'trades' && <TradeHistoryTable trades={trades} />}
+      </div>
     </Section>
   )
 }


### PR DESCRIPTION
## Summary

- label the Open / History / Trades controls as an `Order views` button group
- expose the current view with `aria-pressed` and connect each control to its content region
- give the active content region a view-specific accessible name without changing visual styling or loading behavior

## Evidence

On the Demo Portfolio account, the accessibility tree exposed `Open (0)`, `History`, and `Trades` as three ordinary buttons. The selected view was conveyed only by color, so non-visual users could not determine which order dataset was currently displayed.

## Verification

- `pnpm vitest run ui/src/pages/UTADetailPage.orders-tabs.spec.tsx` (1 passed)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3389 passed, 9 skipped)
- real Demo route: initial `Open (0)` reports pressed with an `Open orders` region; after selecting History, Open reports false, History reports true, and the region is named `Order history`