### PR TITLE
Make order history audit details discoverable

### DIFF
--- a/ui/src/pages/UTADetailPage.order-history.spec.tsx
+++ b/ui/src/pages/UTADetailPage.order-history.spec.tsx
@@ -1,0 +1,46 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { OrderHistoryEntry } from '../api/types'
+import { OrderHistoryTable } from './UTADetailPage'
+
+const order: OrderHistoryEntry = {
+  orderId: 'order-1',
+  timestamp: '2026-07-28T04:03:00.000Z',
+  contract: {
+    aliceId: 'demo-paper|AAPL',
+    symbol: 'AAPL',
+    secType: 'STK',
+    exchange: 'SMART',
+    currency: 'USD',
+  },
+  side: 'BUY',
+  orderType: 'LMT',
+  quantity: '20',
+  limitPrice: '188',
+  status: 'filled',
+  filledQty: '20',
+  avgFillPrice: '187.92',
+  source: 'alice',
+  commitHash: 'commit-1',
+  message: 'Add to the position after earnings',
+}
+
+afterEach(cleanup)
+
+describe('UTADetailPage order history', () => {
+  it('provides a keyboard-accessible details disclosure for each order', () => {
+    render(<OrderHistoryTable orders={[order]} />)
+
+    const details = screen.getByRole('button', { name: 'Show details for AAPL order' })
+    expect(details.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByText(order.message)).toBeNull()
+
+    fireEvent.click(details)
+
+    const hide = screen.getByRole('button', { name: 'Hide details for AAPL order' })
+    expect(hide.getAttribute('aria-expanded')).toBe('true')
+    expect(hide.getAttribute('aria-controls')).toBe('order-history-details-0')
+    expect(screen.getByText(order.message)).toBeTruthy()
+  })
+})

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -17,7 +17,7 @@ import { EquityCurve } from '../components/EquityCurve'
 import { Metric, signFromDelta } from '../components/Metric'
 import { fmt, fmtPnl, fmtNum, fmtPctSigned, isUnsetDecimal } from '../lib/format'
 import { secTypeToClass, assetClassLabel, ASSET_CLASS_ORDER, type AssetClass } from '../lib/asset-class'
-import { ContractCell } from '../lib/contract-display'
+import { ContractCell, contractPrimary } from '../lib/contract-display'
 
 // ==================== Page ====================
 
@@ -889,7 +889,7 @@ function SourceChip({ label }: { label: string }) {
   )
 }
 
-function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
+export function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
   const [expanded, setExpanded] = useState<number | null>(null)
 
   if (orders == null) {
@@ -919,6 +919,7 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
             <th className="px-3 py-2 font-medium text-right">Limit</th>
             <th className="px-3 py-2 font-medium text-right">Fill</th>
             <th className="px-3 py-2 font-medium">Status</th>
+            <th className="px-3 py-2 font-medium text-right">Details</th>
           </tr>
         </thead>
         <tbody>
@@ -943,10 +944,25 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
                     {o.source === 'external' && <SourceChip label="External" />}
                   </span>
                 </td>
+                <td className="px-3 py-2 text-right">
+                  <button
+                    type="button"
+                    aria-expanded={expanded === i}
+                    aria-controls={`order-history-details-${i}`}
+                    aria-label={`${expanded === i ? 'Hide' : 'Show'} details for ${contractPrimary(o.contract)} order`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      setExpanded(prev => prev === i ? null : i)
+                    }}
+                    className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {expanded === i ? 'Hide' : 'Details'}
+                  </button>
+                </td>
               </tr>
               {expanded === i && (
-                <tr className="border-t border-border bg-muted/20">
-                  <td colSpan={8} className="px-3 py-2 text-[11px] text-muted-foreground">
+                <tr id={`order-history-details-${i}`} className="border-t border-border bg-muted/20">
+                  <td colSpan={9} className="px-3 py-2 text-[11px] text-muted-foreground">
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
                       <span className="font-mono">{o.commitHash}</span>
                       <span>{o.message}</span>


### PR DESCRIPTION
## Summary

- add a visible Details column to order history instead of relying only on whole-row mouse clicks
- expose per-contract Show/Hide controls with `aria-expanded` and `aria-controls`
- retain the existing row-click convenience while making commit intent and errors keyboard accessible

## Evidence

The Demo Portfolio History view showed four static table rows in the accessibility tree. Although each row was clickable with a pointer, there was no focusable control or expanded state, so keyboard and screen-reader users could not reach the commit hash, intent message, rejection error, or resolution timestamp hidden behind the row.

## Verification

- `pnpm vitest run ui/src/pages/UTADetailPage.order-history.spec.tsx` (1 passed)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3389 passed, 9 skipped)
- real Demo route: AMD exposes `Show details for AMD order`; activating it changes to expanded `Hide details for AMD order` and reveals `f31c9a2 / Add AMD ahead of earnings`; AAPL, NVDA, and GOOG expose their own controls