### PR TITLE
Localize the file viewer return action

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -908,6 +908,10 @@ export const en = {
     referencedIn_one: 'Referenced in {{count}} note',
     referencedIn_other: 'Referenced in {{count}} notes',
   },
+  fileViewer: {
+    back: 'Back',
+    backToWorkspace: 'Back to {{workspace}}',
+  },
   inbox: {
     noMessages: 'No inbox messages.',
     emptyHint: 'Workspaces will push status updates here.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -897,6 +897,10 @@ export const ja: Resources = {
     referencedIn_one: '{{count}} 件のメモで参照',
     referencedIn_other: '{{count}} 件のメモで参照',
   },
+  fileViewer: {
+    back: '戻る',
+    backToWorkspace: '{{workspace}} に戻る',
+  },
   inbox: {
     noMessages: '受信トレイにメッセージがありません。',
     emptyHint: 'ワークスペースがステータス更新をここに送ります。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -905,6 +905,10 @@ export const zhHant: Resources = {
     referencedIn_one: '被 {{count}} 則筆記引用',
     referencedIn_other: '被 {{count}} 則筆記引用',
   },
+  fileViewer: {
+    back: '返回',
+    backToWorkspace: '返回 {{workspace}}',
+  },
   inbox: {
     noMessages: '收件匣是空的。',
     emptyHint: '工作區會將狀態更新推送到這裡。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -897,6 +897,10 @@ export const zh: Resources = {
     referencedIn_one: '被 {{count}} 条笔记引用',
     referencedIn_other: '被 {{count}} 条笔记引用',
   },
+  fileViewer: {
+    back: '返回',
+    backToWorkspace: '返回 {{workspace}}',
+  },
   inbox: {
     noMessages: '收件箱为空。',
     emptyHint: '工作区会把状态更新推送到这里。',

--- a/ui/src/pages/FileViewerPage.spec.tsx
+++ b/ui/src/pages/FileViewerPage.spec.tsx
@@ -3,6 +3,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import '../i18n'
 import { FileViewerPage } from './FileViewerPage'
 
 const mocks = vi.hoisted(() => ({
@@ -56,7 +57,9 @@ describe('FileViewerPage back navigation', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    const back = screen.getByRole('button', { name: 'Back to chat-jul20' })
+    expect(back.getAttribute('title')).toBe('Back to chat-jul20')
+    fireEvent.click(back)
 
     expect(mocks.setSidebar).toHaveBeenCalledWith('chat')
     expect(mocks.openOrFocus).toHaveBeenCalledWith({
@@ -76,7 +79,7 @@ describe('FileViewerPage back navigation', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Back to chat-jul20' }))
 
     expect(mocks.setSidebar).toHaveBeenCalledWith('workspaces')
     expect(mocks.openOrFocus).toHaveBeenCalledWith({

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ArrowLeft, FileText } from 'lucide-react'
 
 import { FileContentView } from '../components/FileContentView'
@@ -24,11 +25,13 @@ interface Props {
 }
 
 export function FileViewerPage({ spec }: Props) {
+  const { t } = useTranslation()
   const { wsId, path, source, returnSessionId } = spec.params
   const { workspaces } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
   const tag = workspaces.find((w) => w.id === wsId)?.tag ?? wsId.slice(0, 8)
+  const backLabel = t('fileViewer.backToWorkspace', { workspace: tag })
 
   const [result, setResult] = useState<ReadFileResult | null>(null)
   useEffect(() => {
@@ -60,11 +63,12 @@ export function FileViewerPage({ spec }: Props) {
         <button
           type="button"
           onClick={openWorkspace}
+          aria-label={backLabel}
           className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title={`Back to ${tag}`}
+          title={backLabel}
         >
           <ArrowLeft size={14} strokeWidth={1.8} aria-hidden />
-          <span className="hidden sm:inline">Back</span>
+          <span className="hidden sm:inline">{t('fileViewer.back')}</span>
         </button>
         <FileText size={13} strokeWidth={1.75} className="shrink-0 text-muted-foreground/70" aria-hidden />
         <span className="font-mono text-[12px] text-foreground truncate" title={path}>


### PR DESCRIPTION
## Summary

- move the file viewer Back label into the four checked-in UI locale catalogs
- give the return button a target-specific accessible name and tooltip using the owning Workspace tag
- extend the existing navigation regression to require that target context while preserving exact Session/workspace routing

## Evidence

On the Simplified Chinese Demo path `Tracked → stock-vst → power_buy_points_2026-06-02.md`, the file viewer still rendered the English word `Back`. Its accessible name was also only `Back`, even though the action does not return to the previous page: it opens the file's owning Workspace. The destination existed only in a mouse tooltip.

The stale `demo-ws-1` backlink identity visible on that route is already owned by open PR #749 and is intentionally not duplicated here. Once #749 lands, this button's target label will automatically use that corrected Workspace tag.

## Verification

- `pnpm vitest run ui/src/pages/FileViewerPage.spec.tsx` (2 passed)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3388 passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- real Simplified Chinese Demo route: visible label is `返回`; accessible name and tooltip are `返回 demo-ws-` on the current dev fixture