### PR TITLE
Expose recorded Workspace artifacts in the Demo Files panel

### DIFF
--- a/ui/src/demo/fixtures/inbox.ts
+++ b/ui/src/demo/fixtures/inbox.ts
@@ -1,5 +1,9 @@
 import type { InboxEntry, InboxOrigin } from '../../api/inbox'
-import { DEMO_SESSION_ID, DEMO_WORKSPACE_ID } from './workspaces'
+import {
+  DEMO_CHAT_WORKSPACE_ID,
+  DEMO_SESSION_ID,
+  DEMO_WORKSPACE_ID,
+} from './workspaces'
 
 export const DEMO_REPORT_PATH = 'research-AAPL-q1.md'
 
@@ -239,4 +243,25 @@ Post-mortem on what we let run without us.
   pullback that didn't come. Lesson: on a [[ai-data-center-power]] leader,
   buy the first higher-low, not the deep retrace.
 `,
+}
+
+/** Files visible from each recorded Workspace's Files panel. The content map
+ *  above remains the read endpoint's source of truth; this index supplies the
+ *  owning Workspace needed by the directory-listing endpoint. */
+export const demoWorkspaceFilePaths: Readonly<Record<string, readonly string[]>> = {
+  [DEMO_WORKSPACE_ID]: [
+    DEMO_REPORT_PATH,
+  ],
+  [DEMO_CHAT_WORKSPACE_ID]: [
+    'power_buy_points_2026-06-02.md',
+    'rotation/2026-06-02.md',
+    'rotation/ai-chain-2026-06-02.md',
+    'rotation/missed-rightside-2026-06-02.md',
+  ],
+  'demo-ws-auto-quant': [
+    'reports/movers-2026-06-27.md',
+  ],
+  'demo-ws-macro': [
+    'digests/macro-2026-06-25.md',
+  ],
 }

--- a/ui/src/demo/handlers/workspaces-files.spec.ts
+++ b/ui/src/demo/handlers/workspaces-files.spec.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import {
+  DEMO_CHAT_WORKSPACE_ID,
+  DEMO_WORKSPACE_ID,
+} from '../fixtures/workspaces'
+import {
+  demoWorkspaceFilePaths,
+  demoWorkspaceFiles,
+} from '../fixtures/inbox'
+import { workspacesHandlers } from './workspaces'
+
+const server = setupServer(...workspacesHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+async function listFiles(workspaceId: string, path = '') {
+  const query = path ? `?path=${encodeURIComponent(path)}` : ''
+  const response = await fetch(`${baseUrl}/api/workspaces/${workspaceId}/files${query}`)
+  return {
+    response,
+    body: await response.json() as {
+      path: string
+      entries: Array<{
+        name: string
+        kind: 'file' | 'dir'
+        sizeBytes: number | null
+        mtime: string
+      }>
+    },
+  }
+}
+
+describe('demo Workspace file listings', () => {
+  it('assigns every readable demo artifact to a Workspace directory', () => {
+    const indexedPaths = Object.values(demoWorkspaceFilePaths).flat().sort()
+    expect(indexedPaths).toEqual(Object.keys(demoWorkspaceFiles).sort())
+  })
+
+  it('shows the report written by the featured AAPL Session', async () => {
+    const { response, body } = await listFiles(DEMO_WORKSPACE_ID)
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      path: '',
+      entries: [{
+        name: 'research-AAPL-q1.md',
+        kind: 'file',
+        mtime: expect.any(String),
+      }],
+    })
+    expect(body.entries[0]?.sizeBytes).toBeGreaterThan(0)
+  })
+
+  it('builds navigable directories for the Chat Workspace notes', async () => {
+    const root = await listFiles(DEMO_CHAT_WORKSPACE_ID)
+    expect(root.body.entries).toEqual([
+      expect.objectContaining({ name: 'rotation', kind: 'dir', sizeBytes: null }),
+      expect.objectContaining({ name: 'power_buy_points_2026-06-02.md', kind: 'file' }),
+    ])
+
+    const rotation = await listFiles(DEMO_CHAT_WORKSPACE_ID, 'rotation')
+    expect(rotation.body.path).toBe('rotation')
+    expect(rotation.body.entries.map((entry) => entry.name)).toEqual([
+      '2026-06-02.md',
+      'ai-chain-2026-06-02.md',
+      'missed-rightside-2026-06-02.md',
+    ])
+    expect(rotation.body.entries.every((entry) => entry.kind === 'file')).toBe(true)
+  })
+
+  it('rejects paths that try to leave the Workspace', async () => {
+    const { response } = await listFiles(DEMO_WORKSPACE_ID, '../secrets')
+    expect(response.status).toBe(400)
+  })
+})

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import { demoChatWorkspace, demoWorkspaces, demoTemplates } from '../fixtures/workspaces'
-import { demoWorkspaceFiles } from '../fixtures/inbox'
+import { demoWorkspaceFilePaths, demoWorkspaceFiles } from '../fixtures/inbox'
 import {
   createDemoWebPiSnapshot,
   demoWebPiFollowUp,
@@ -85,6 +85,50 @@ function ensureDemoWebPiSession(wsId: string, sessionId: string): WebPiSnapshot 
     startedAt: record.startedAt ?? Date.now(),
     messages: [],
   })
+}
+
+const DEMO_FILE_MTIME = new Date().toISOString()
+
+function demoDirectoryListing(workspaceId: string, requestedPath: string) {
+  const segments = requestedPath.split('/').filter((segment) => segment !== '' && segment !== '.')
+  if (segments.includes('..')) return null
+
+  const path = segments.join('/')
+  const prefix = path ? `${path}/` : ''
+  const entries = new Map<string, {
+    name: string
+    kind: 'file' | 'dir'
+    sizeBytes: number | null
+    mtime: string
+  }>()
+
+  for (const filePath of demoWorkspaceFilePaths[workspaceId] ?? []) {
+    if (!filePath.startsWith(prefix)) continue
+    const remainder = filePath.slice(prefix.length)
+    if (!remainder) continue
+    const slash = remainder.indexOf('/')
+    const name = slash === -1 ? remainder : remainder.slice(0, slash)
+    if (entries.has(name)) continue
+
+    const kind = slash === -1 ? 'file' as const : 'dir' as const
+    entries.set(name, {
+      name,
+      kind,
+      sizeBytes: kind === 'file'
+        ? new TextEncoder().encode(demoWorkspaceFiles[filePath] ?? '').byteLength
+        : null,
+      mtime: DEMO_FILE_MTIME,
+    })
+  }
+
+  return {
+    path,
+    entries: [...entries.values()].sort((a, b) => {
+      if (a.kind === 'dir' && b.kind !== 'dir') return -1
+      if (a.kind !== 'dir' && b.kind === 'dir') return 1
+      return a.name.localeCompare(b.name)
+    }),
+  }
 }
 
 function appendDemoWebPiMessages(
@@ -629,9 +673,17 @@ export const workspacesHandlers = [
   http.get('/api/workspaces/:id/git/status', () =>
     HttpResponse.json({ branch: 'main', clean: true, files: [] }),
   ),
-  http.get('/api/workspaces/:id/files', () =>
-    HttpResponse.json({ path: '/', entries: [] }),
-  ),
+  http.get('/api/workspaces/:id/files', ({ params, request }) => {
+    const path = new URL(request.url).searchParams.get('path') ?? ''
+    const listing = demoDirectoryListing(String(params.id), path)
+    if (!listing) {
+      return HttpResponse.json(
+        { error: 'invalid_path', message: `refused to escape workspace: ${path}` },
+        { status: 400 },
+      )
+    }
+    return HttpResponse.json(listing)
+  }),
   http.get('/api/workspaces/:id/file', ({ request }) => {
     const url = new URL(request.url)
     const path = url.searchParams.get('path') ?? ''


### PR DESCRIPTION
## What changed

- assign every readable demo artifact to its owning Workspace
- build root and nested directory listings from that artifact index, including byte sizes and fresh demo-session timestamps
- preserve the production directory contract by sorting folders first and rejecting parent-directory traversal
- add handler coverage for the featured AAPL report, nested Chat notes, complete artifact indexing, and traversal rejection

## Why

The featured AAPL Session says it saved the full earnings note into the Workspace, and the demo already serves that report through the file-read endpoint. However, the directory-listing handler always returned an empty array, so opening the same Workspace's Files panel showed `empty`. The same disconnect hid the research notes used by Tracked and scheduled-report fixtures.

## User impact

Demo visitors can now browse the artifacts the recorded Sessions claim to create: the AAPL report appears in its Workspace root, Chat notes expose a navigable `rotation/` directory, and clicking a listed file opens the existing viewer with its Session return path intact.

## Validation

- `pnpm exec vitest run ui/src/demo/handlers/workspaces-files.spec.ts` (4 passed)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (358 files passed, 1 skipped; 3392 tests passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- real Chinese demo walkthrough: AAPL Session -> Files -> `research-AAPL-q1.md`; verified the report opens with `sessionId=demo-session`
- real Chinese demo walkthrough: Chat Workspace -> Files -> `rotation/`; verified all three nested research notes are listed