### PR TITLE
Expose selected Settings controls

### DIFF
--- a/ui/src/pages/SettingsPage.selection-state.spec.tsx
+++ b/ui/src/pages/SettingsPage.selection-state.spec.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { useLocaleStore } from '../i18n/store'
+import { LanguageSection, SettingsTabBar } from './SettingsPage'
+
+beforeEach(async () => {
+  localStorage.clear()
+  useLocaleStore.setState({ locale: 'zh' })
+  await i18n.changeLanguage('zh')
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('Settings selection controls', () => {
+  it('exposes the current language and updates the pressed state immediately', () => {
+    render(<LanguageSection />)
+
+    const group = screen.getByRole('group', { name: '语言' })
+    expect(group).toBeTruthy()
+    expect(screen.getByRole('button', { name: '中文' }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: 'English' }).getAttribute('aria-pressed')).toBe('false')
+
+    fireEvent.click(screen.getByRole('button', { name: 'English' }))
+
+    expect(useLocaleStore.getState().locale).toBe('en')
+    expect(screen.getByRole('button', { name: 'English' }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: '中文' }).getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('exposes the active Settings page view without changing its button interaction', () => {
+    const onSelect = vi.fn()
+    const { rerender } = render(<SettingsTabBar tab="settings" onSelect={onSelect} />)
+
+    expect(screen.getByRole('button', { name: '设置' }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: '工具' }).getAttribute('aria-pressed')).toBe('false')
+
+    fireEvent.click(screen.getByRole('button', { name: '工具' }))
+    expect(onSelect).toHaveBeenCalledWith('tools')
+
+    rerender(<SettingsTabBar tab="tools" onSelect={onSelect} />)
+    expect(screen.getByRole('button', { name: '设置' }).getAttribute('aria-pressed')).toBe('false')
+    expect(screen.getByRole('button', { name: '工具' }).getAttribute('aria-pressed')).toBe('true')
+  })
+})

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -357,18 +357,23 @@ function PalettePicker({
 
 // ==================== Language ====================
 
-function LanguageSection() {
+export function LanguageSection() {
   const { t } = useTranslation()
   const locale = useLocale()
   const setLocale = useSetLocale()
   return (
     <ConfigSection title={t('settings.language.title')} description={t('settings.language.description')}>
-      <div className="flex flex-wrap gap-2 py-1">
+      <div
+        className="flex flex-wrap gap-2 py-1"
+        role="group"
+        aria-label={t('settings.language.title')}
+      >
         {(['en', 'zh', 'ja', 'zh-Hant'] as const).map((l) => (
           <button
             key={l}
             type="button"
             onClick={() => setLocale(l)}
+            aria-pressed={locale === l}
             className={`px-3 py-1.5 text-sm rounded border transition-colors ${
               locale === l
                 ? 'border-primary text-primary bg-primary/10'
@@ -983,6 +988,43 @@ const TABS: { key: Tab; labelKey: 'settings.tab.settings' | 'settings.tab.tools'
   { key: 'tools', labelKey: 'settings.tab.tools' },
 ]
 
+export function SettingsTabBar({
+  tab,
+  onSelect,
+}: {
+  tab: Tab
+  onSelect: (tab: Tab) => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div
+      className="flex gap-1"
+      role="group"
+      aria-label={t('settings.title')}
+    >
+      {TABS.map((item) => (
+        <button
+          key={item.key}
+          type="button"
+          onClick={() => onSelect(item.key)}
+          aria-pressed={tab === item.key}
+          className={`px-3 py-2 text-sm font-medium transition-colors relative ${
+            tab === item.key ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          {t(item.labelKey)}
+          {tab === item.key && (
+            <span
+              aria-hidden
+              className="absolute bottom-0 left-0 right-0 h-[2px] bg-primary rounded-t"
+            />
+          )}
+        </button>
+      ))}
+    </div>
+  )
+}
+
 export function SettingsPage() {
   const { t } = useTranslation()
   const [tab, setTab] = useState<Tab>('settings')
@@ -992,22 +1034,7 @@ export function SettingsPage() {
       <PageHeader title={t('settings.title')} />
 
       <div className="px-4 md:px-6 border-b border-border/60">
-        <div className="flex gap-1">
-          {TABS.map((item) => (
-            <button
-              key={item.key}
-              onClick={() => setTab(item.key)}
-              className={`px-3 py-2 text-sm font-medium transition-colors relative ${
-                tab === item.key ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {t(item.labelKey)}
-              {tab === item.key && (
-                <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-primary rounded-t" />
-              )}
-            </button>
-          ))}
-        </div>
+        <SettingsTabBar tab={tab} onSelect={setTab} />
       </div>
 
       <SettingsScrollArea className="px-4 py-6 md:px-8">


### PR DESCRIPTION
## What

- label the Settings/Tools switch and language picker as accessible groups
- expose the currently selected view and language with `aria-pressed`
- keep the existing immediate switching behavior and decorative active underline
- add regression coverage for both selection controls

## Why

A real walkthrough of the Chinese demo Settings page showed that both selections were communicated only through color. Screen-reader users could activate the controls, but could not determine the current Settings view or language.

## User impact

The selected Settings view and language are now announced consistently while the visual design and click behavior remain unchanged.

## Validation

- `pnpm exec vitest run ui/src/pages/SettingsPage.selection-state.spec.tsx` — 2 tests passed
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 358 files passed, 1 skipped; 3390 tests passed, 9 skipped
- `pnpm -F open-alice-ui build:demo`
- real Chinese demo walkthrough: verified Chinese language and Tools view expose the expected pressed state