### PR TITLE
Recover failed Tracked detail loads

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -900,6 +900,8 @@ export const en = {
   },
   tracked: {
     nothingTrackedYet: 'Nothing tracked yet.',
+    detailLoadErrorTitle: 'Couldn’t load {{name}}',
+    detailLoadErrorDescription: 'The tracked entity may have changed, or OpenAlice may be temporarily unavailable.',
     backlinksTooltip: '{{count}} notes link here',
     assets: 'Assets',
     topics: 'Topics',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -889,6 +889,8 @@ export const ja: Resources = {
   },
   tracked: {
     nothingTrackedYet: 'まだ何もトラッキングしていません。',
+    detailLoadErrorTitle: '{{name}} を読み込めませんでした',
+    detailLoadErrorDescription: '追跡対象が変更されたか、OpenAlice が一時的に利用できない可能性があります。',
     backlinksTooltip: '{{count}} 件のメモがここにリンク',
     assets: '銘柄',
     topics: 'トピック',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -897,6 +897,8 @@ export const zhHant: Resources = {
   },
   tracked: {
     nothingTrackedYet: '尚未追蹤任何項目。',
+    detailLoadErrorTitle: '無法載入 {{name}}',
+    detailLoadErrorDescription: '這個追蹤實體可能已變更，或 OpenAlice 暫時無法使用。',
     backlinksTooltip: '{{count}} 則筆記連結到此',
     assets: '標的',
     topics: '主題',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -889,6 +889,8 @@ export const zh: Resources = {
   },
   tracked: {
     nothingTrackedYet: '还没有追踪任何东西。',
+    detailLoadErrorTitle: '无法加载 {{name}}',
+    detailLoadErrorDescription: '这个追踪实体可能已经变更，或 OpenAlice 暂时不可用。',
     backlinksTooltip: '{{count}} 条笔记链接到此',
     assets: '标的',
     topics: '主题',

--- a/ui/src/pages/TrackedPage.spec.tsx
+++ b/ui/src/pages/TrackedPage.spec.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EntityDetail, EntityListItem } from '../api/entities'
+import { i18n } from '../i18n'
+import { TrackedPage } from './TrackedPage'
+
+const trackedEntity: EntityListItem = {
+  name: 'stock-vst',
+  description: 'Vistra',
+  type: 'asset',
+  createdAt: 1,
+  backlinkCount: 0,
+}
+
+const detail: EntityDetail = {
+  entity: trackedEntity,
+  backlinks: [],
+}
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  selectedName: 'stock-vst',
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    entities: {
+      get: mocks.get,
+    },
+  },
+}))
+
+vi.mock('../live/entities', () => ({
+  entitiesLive: {
+    useStore: (selector: (state: { entities: EntityListItem[]; loading: boolean }) => unknown) =>
+      selector({ entities: [trackedEntity], loading: false }),
+  },
+}))
+
+vi.mock('../live/tracked-selection', () => ({
+  useTrackedSelection: (selector: (state: { selectedName: string }) => unknown) =>
+    selector({ selectedName: mocks.selectedName }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: vi.fn(),
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('TrackedPage detail recovery', () => {
+  it('surfaces a failed detail request and retries it', async () => {
+    mocks.get
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(detail)
+
+    render(<TrackedPage />)
+
+    const error = await screen.findByRole('alert')
+    expect(error.textContent).toContain('Couldn’t load stock-vst')
+    expect(error.textContent).toContain('temporarily unavailable')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByRole('heading', { name: 'stock-vst' })).toBeTruthy()
+    expect(mocks.get).toHaveBeenCalledTimes(2)
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TrendingUp, Hash, FileText, ListChecks } from 'lucide-react'
+import { TrendingUp, Hash, FileText, ListChecks, CircleAlert } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
 import { PageLoading, Skeleton } from '../components/StateViews'
 import { api } from '../api'
@@ -27,27 +27,38 @@ export function TrackedPage() {
 
   const [detail, setDetail] = useState<EntityDetail | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState(false)
+  const [detailRequest, setDetailRequest] = useState(0)
   useEffect(() => {
     if (!selectedName) {
       setDetail(null)
       setDetailLoading(false)
+      setDetailError(false)
       return
     }
     let cancelled = false
     setDetail(null)
     setDetailLoading(true)
+    setDetailError(false)
     api.entities
       .get(selectedName)
       .then((d) => {
-        if (!cancelled) { setDetail(d); setDetailLoading(false) }
+        if (!cancelled) {
+          setDetail(d)
+          setDetailLoading(false)
+        }
       })
       .catch(() => {
-        if (!cancelled) { setDetail(null); setDetailLoading(false) }
+        if (!cancelled) {
+          setDetail(null)
+          setDetailLoading(false)
+          setDetailError(true)
+        }
       })
     return () => {
       cancelled = true
     }
-  }, [selectedName])
+  }, [selectedName, detailRequest])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -62,12 +73,42 @@ export function TrackedPage() {
           <EmptyState />
         ) : !selectedName ? (
           <div className="px-6 py-8 text-muted-foreground text-sm">{t('tracked.selectFromSidebar')}</div>
-        ) : detailLoading || !detail ? (
+        ) : detailLoading ? (
           <PageLoading />
+        ) : detailError || !detail ? (
+          <DetailLoadError
+            name={selectedName}
+            onRetry={() => setDetailRequest((request) => request + 1)}
+          />
         ) : (
           <Detail detail={detail} />
         )}
       </div>
+    </div>
+  )
+}
+
+function DetailLoadError({ name, onRetry }: { name: string; onRetry: () => void }) {
+  const { t } = useTranslation()
+  return (
+    <div
+      role="alert"
+      className="mx-auto flex max-w-[520px] flex-col items-center px-6 py-16 text-center"
+    >
+      <CircleAlert size={24} strokeWidth={1.75} className="text-destructive" aria-hidden />
+      <h2 className="mt-3 text-[15px] font-medium text-foreground">
+        {t('tracked.detailLoadErrorTitle', { name })}
+      </h2>
+      <p className="mt-1.5 text-[13px] leading-relaxed text-muted-foreground">
+        {t('tracked.detailLoadErrorDescription')}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="oa-pressable mt-4 rounded-md border border-border bg-secondary px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:border-primary/50 hover:bg-muted"
+      >
+        {t('common.retry')}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- distinguish Tracked entity detail failures from the in-progress loading state
- replace the permanent spinner with a localized, accessible error state and retry action
- keep retry requests inside the existing selected-entity lifecycle so stale responses remain ignored
- add regression coverage that forces the first request to fail and proves a retry restores the detail

## Root cause

`TrackedPage` cleared `detailLoading` after a rejected entity request but also left `detail` null. Its render condition treated either `detailLoading` or a missing `detail` as loading, so every failed request became an infinite spinner with no user-visible error or recovery path.

## User impact

A temporary API failure or an entity that changes between the list and detail reads now produces a clear explanation instead of an indefinite loading state. Users can retry in place without leaving Tracked.

## Verification

- `pnpm vitest run ui/src/pages/TrackedPage.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 files passed, 3,389 tests passed; 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- real Simplified Chinese Tracked route walkthrough for the unaffected successful detail path