### PR TITLE
Expose selected K-line controls

### DIFF
--- a/ui/src/components/market/KlinePanel.spec.tsx
+++ b/ui/src/components/market/KlinePanel.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -202,5 +202,32 @@ describe('KlinePanel source routing', () => {
       </MemoryRouter>,
     )
     expect(mocks.bars).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('KlinePanel chart controls', () => {
+  it('names each control independently and exposes the selected interval and range', async () => {
+    mocks.bars.mockResolvedValue(response('AAPL', 'yfinance|AAPL'))
+
+    render(
+      <MemoryRouter initialEntries={['/market/equity/AAPL?interval=5m&range=3M']}>
+        <KlinePanel selection={{ symbol: 'AAPL', assetClass: 'equity' }} />
+      </MemoryRouter>,
+    )
+
+    const intervals = screen.getByRole('group', { name: 'Interval' })
+    expect(within(intervals).getByRole('button', { name: '5m' }).getAttribute('aria-pressed')).toBe('true')
+    expect(within(intervals).getByRole('button', { name: '1m' }).getAttribute('aria-pressed')).toBe('false')
+
+    const ranges = screen.getByRole('group', { name: 'Range' })
+    expect(within(ranges).getByRole('button', { name: '3M' }).getAttribute('aria-pressed')).toBe('true')
+    expect(within(ranges).getByRole('button', { name: '1Y' }).getAttribute('aria-pressed')).toBe('false')
+
+    fireEvent.click(within(intervals).getByRole('button', { name: '1h' }))
+
+    await waitFor(() => {
+      expect(within(intervals).getByRole('button', { name: '1h' }).getAttribute('aria-pressed')).toBe('true')
+      expect(mocks.bars).toHaveBeenCalledWith(expect.objectContaining({ interval: '1h' }))
+    })
   })
 })

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -338,13 +338,20 @@ export function KlinePanel({ selection, source, onSnapshot }: Props) {
               </select>
             </label>
           )}
-          <label className="flex items-center gap-2">
+          <div
+            className="flex items-center gap-2"
+            role="group"
+            aria-label="Interval"
+            title="Candle width (how much time each bar covers)"
+          >
             <span className="text-[11px] uppercase tracking-wide text-muted-foreground/70">Interval</span>
-            <div className="flex border border-border rounded overflow-hidden" title="Candle width (how much time each bar covers)">
+            <div className="flex border border-border rounded overflow-hidden">
               {INTERVALS.map((iv, i) => (
                 <button
                   key={iv}
+                  type="button"
                   onClick={() => selectInterval(iv)}
+                  aria-pressed={interval === iv}
                   className={`px-2 py-1 text-[12px] transition-colors cursor-pointer ${
                     i > 0 ? 'border-l border-border' : ''
                   } ${interval === iv ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
@@ -353,14 +360,21 @@ export function KlinePanel({ selection, source, onSnapshot }: Props) {
                 </button>
               ))}
             </div>
-          </label>
-          <label className="flex items-center gap-2">
+          </div>
+          <div
+            className="flex items-center gap-2"
+            role="group"
+            aria-label="Range"
+            title="How far back to load history"
+          >
             <span className="text-[11px] uppercase tracking-wide text-muted-foreground/70">Range</span>
-            <div className="flex border border-border rounded overflow-hidden" title="How far back to load history">
+            <div className="flex border border-border rounded overflow-hidden">
               {TIMEFRAMES.map((t, i) => (
                 <button
                   key={t}
+                  type="button"
                   onClick={() => setTf(t)}
+                  aria-pressed={tf === t}
                   className={`px-2 py-1 text-[12px] transition-colors cursor-pointer ${
                     i > 0 ? 'border-l border-border' : ''
                   } ${tf === t ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
@@ -369,7 +383,7 @@ export function KlinePanel({ selection, source, onSnapshot }: Props) {
                 </button>
               ))}
             </div>
-          </label>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- replace invalid labels that wrapped multiple K-line buttons with named interval and range button groups
- expose the selected interval and range through `aria-pressed`
- keep each control's accessible name limited to its own value
- mark chart controls as non-submit buttons so embedding the panel in a form remains safe
- add regression coverage for URL-derived selection and an interactive interval change

## Evidence

On the real EUR/USD market detail route, the accessibility tree named the first interval button `Interval 5m 1h 1d` and the first range button `Range 5D 1M 3M 1Y 5Y All`. The visually selected `1d` and `1Y` controls had no selected state. After this change the tree exposes `Interval` and `Range` groups, independent button names, and the active controls as pressed; switching to `1h` updates both the bar request and pressed state.

## Verification

- `pnpm vitest run ui/src/components/market/KlinePanel.spec.tsx` (7 tests)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (357 files passed, 3,389 tests passed; 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- real Simplified Chinese EUR/USD route accessibility-tree walkthrough before/after
- real route screenshot review after switching to `1h`