### PR TITLE
Recover Agent Permissions loading

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -177,6 +177,8 @@ export const en = {
     },
     agentPermissions: {
       title: 'Agent Permissions',
+      loadErrorTitle: 'Couldn’t load Agent Permissions',
+      loadErrorDescription: 'OpenAlice could not read the current configuration. Your permissions have not been changed.',
       mode: {
         title: 'Trading mode',
         description: 'Global broker capability for Alice and workspace agents.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -166,6 +166,8 @@ export const ja: Resources = {
     },
     agentPermissions: {
       title: 'エージェント権限',
+      loadErrorTitle: 'エージェント権限を読み込めませんでした',
+      loadErrorDescription: 'OpenAlice は現在の設定を読み取れませんでした。権限は変更されていません。',
       mode: {
         title: '取引モード',
         description: 'Alice とワークスペースエージェントのグローバルなブローカー権限。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -174,6 +174,8 @@ export const zhHant: Resources = {
     },
     agentPermissions: {
       title: '智慧體權限',
+      loadErrorTitle: '無法載入智慧體權限',
+      loadErrorDescription: 'OpenAlice 無法讀取目前設定。你的權限沒有變更。',
       mode: {
         title: '交易模式',
         description: 'Alice 與工作區智慧體的全域券商能力。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -166,6 +166,8 @@ export const zh: Resources = {
     },
     agentPermissions: {
       title: '智能体权限',
+      loadErrorTitle: '无法加载智能体权限',
+      loadErrorDescription: 'OpenAlice 无法读取当前配置。你的权限没有发生变化。',
       mode: {
         title: '交易模式',
         description: 'Alice 和工作区智能体的全局券商能力。',

--- a/ui/src/pages/AgentPermissionsPage.spec.tsx
+++ b/ui/src/pages/AgentPermissionsPage.spec.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { AgentPermissionsPage } from './AgentPermissionsPage'
+
+const mocks = vi.hoisted(() => ({
+  ensureTradingModePolling: vi.fn(),
+  loadConfig: vi.fn(),
+  setMode: vi.fn(),
+  updateSection: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    config: {
+      load: mocks.loadConfig,
+      updateSection: mocks.updateSection,
+    },
+  },
+}))
+
+vi.mock('../live/trading-mode', () => ({
+  ensureTradingModePolling: mocks.ensureTradingModePolling,
+  useTradingMode: (selector: (state: {
+    status: {
+      mode: 'lite'
+      modeSource: 'default'
+      envLocked: false
+    }
+    loading: false
+    saving: null
+    error: null
+    setMode: typeof mocks.setMode
+  }) => unknown) => selector({
+    status: {
+      mode: 'lite',
+      modeSource: 'default',
+      envLocked: false,
+    },
+    loading: false,
+    saving: null,
+    error: null,
+    setMode: mocks.setMode,
+  }),
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('AgentPermissionsPage', () => {
+  it('explains a configuration load failure and recovers on retry', async () => {
+    mocks.loadConfig
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({})
+
+    render(<AgentPermissionsPage />)
+
+    const alert = await screen.findByRole('alert')
+    expect(screen.getByRole('heading', { name: 'Agent Permissions' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Couldn’t load Agent Permissions' })).toBeTruthy()
+    expect(alert.textContent).toContain('Your permissions have not been changed.')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.loadConfig).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('heading', { name: 'Trading mode' })).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/AgentPermissionsPage.tsx
+++ b/ui/src/pages/AgentPermissionsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type Dispatch, type ReactNode, type SetStateAction } from 'react'
-import { Gauge, LockKeyhole, ShieldCheck, type LucideIcon } from 'lucide-react'
+import { CircleAlert, Gauge, LockKeyhole, ShieldCheck, type LucideIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { api, type AppConfig } from '../api'
@@ -38,28 +38,69 @@ const MODES: TradingMode[] = ['lite', 'readonly', 'pro']
 export function AgentPermissionsPage() {
   const { t } = useTranslation()
   const [config, setConfig] = useState<AppConfig | null>(null)
+  const [loadError, setLoadError] = useState(false)
+
+  const loadConfig = useCallback(async () => {
+    setConfig(null)
+    setLoadError(false)
+    try {
+      setConfig(await api.config.load())
+    } catch {
+      setLoadError(true)
+    }
+  }, [])
 
   useEffect(() => {
     ensureTradingModePolling()
-    api.config.load().then(setConfig).catch(() => {})
-  }, [])
-
-  if (!config) return <PageLoading />
+    void loadConfig()
+  }, [loadConfig])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader title={t('settings.agentPermissions.title')} />
-      <SettingsScrollArea>
-        <div className="mx-auto w-full max-w-[980px] px-4 md:px-6">
-          <TradingModeSection />
-          <PermissionSection
-            title={t('settings.agentPermissions.aiPush.title')}
-            description={t('settings.agentPermissions.aiPush.description')}
-          >
-            <AiTradingToggle config={config} setConfig={setConfig} />
-          </PermissionSection>
-        </div>
-      </SettingsScrollArea>
+      {!config ? (
+        loadError ? <PermissionsLoadError onRetry={() => void loadConfig()} /> : <PageLoading />
+      ) : (
+        <SettingsScrollArea>
+          <div className="mx-auto w-full max-w-[980px] px-4 md:px-6">
+            <TradingModeSection />
+            <PermissionSection
+              title={t('settings.agentPermissions.aiPush.title')}
+              description={t('settings.agentPermissions.aiPush.description')}
+            >
+              <AiTradingToggle config={config} setConfig={setConfig} />
+            </PermissionSection>
+          </div>
+        </SettingsScrollArea>
+      )}
+    </div>
+  )
+}
+
+function PermissionsLoadError({ onRetry }: { onRetry: () => void }) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-6 py-12">
+      <div
+        role="alert"
+        className="flex max-w-md flex-col items-center rounded-xl border border-destructive/30 bg-destructive/5 px-6 py-7 text-center"
+      >
+        <CircleAlert className="mb-3 text-destructive" size={28} strokeWidth={1.7} aria-hidden />
+        <h2 className="text-sm font-semibold text-foreground">
+          {t('settings.agentPermissions.loadErrorTitle')}
+        </h2>
+        <p className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
+          {t('settings.agentPermissions.loadErrorDescription')}
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-5 rounded-md border border-border bg-background px-3.5 py-2 text-[12px] font-medium text-foreground transition-colors hover:border-primary/50 hover:bg-muted"
+        >
+          {t('common.retry')}
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- keep the Agent Permissions page identity visible while its configuration loads
- replace the permanent spinner after a failed config read with a localized, accessible error state
- let users retry without changing any permission state
- cover the failed-first-load and successful-retry path with a focused UI regression test

## Problem

`AgentPermissionsPage` swallowed `api.config.load()` failures and left `config` as `null`, so a transient backend or IPC failure produced an unexplained spinner forever on the trading-permissions entry point.

## Verification

- `pnpm -F open-alice-ui exec vitest run src/pages/AgentPermissionsPage.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3,389 passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- isolated `pnpm dev:onboarding` browser walk at `/settings/agent-permissions`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:onboarding`
