### PR TITLE
Stop gating General Settings on an unused config read

### DIFF
--- a/ui/src/pages/SettingsPage.loading.spec.tsx
+++ b/ui/src/pages/SettingsPage.loading.spec.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { SettingsPage } from './SettingsPage'
+
+const mocks = vi.hoisted(() => ({
+  configLoad: vi.fn(),
+  getPersona: vi.fn(),
+  getVersion: vi.fn(),
+  getWorkspaceShell: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    config: {
+      load: mocks.configLoad,
+    },
+    persona: {
+      get: mocks.getPersona,
+    },
+    version: {
+      get: mocks.getVersion,
+    },
+  },
+}))
+
+vi.mock('../api/preferences', () => ({
+  preferencesApi: {
+    getWorkspaceShell: mocks.getWorkspaceShell,
+  },
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.stubGlobal('matchMedia', vi.fn(() => ({
+    matches: false,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } satisfies MediaQueryList)))
+  await i18n.changeLanguage('en')
+  mocks.getPersona.mockResolvedValue({ content: '', path: '' })
+  mocks.getVersion.mockResolvedValue({
+    current: '0.0.0',
+    latest: '0.0.0',
+    hasUpdate: false,
+    releaseUrl: '',
+  })
+  mocks.getWorkspaceShell.mockResolvedValue({ supported: false })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('SettingsPage loading', () => {
+  it('renders independent settings without waiting for an unused config read', async () => {
+    mocks.configLoad.mockRejectedValue(new Error('offline'))
+
+    render(<SettingsPage />)
+
+    expect(screen.getByRole('heading', { name: 'Appearance' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Language' })).toBeTruthy()
+    expect(screen.getByText('openalice start --home <path>')).toBeTruthy()
+    await waitFor(() => expect(mocks.getPersona).toHaveBeenCalledOnce())
+    expect(mocks.configLoad).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Moon, RotateCcw, Sun } from 'lucide-react'
-import { api, type AppConfig } from '../api'
+import { api } from '../api'
 import type { ToolInfo } from '../api/tools'
 import { Toggle } from '../components/Toggle'
 import { SaveIndicator } from '../components/SaveIndicator'
@@ -653,13 +653,6 @@ function WorkspaceShellSection() {
 
 function SettingsSection() {
   const { t } = useTranslation()
-  const [config, setConfig] = useState<AppConfig | null>(null)
-
-  useEffect(() => {
-    api.config.load().then(setConfig).catch(() => {})
-  }, [])
-
-  if (!config) return <PageLoading />
 
   return (
     <div className="mx-auto w-full max-w-[1100px]">


### PR DESCRIPTION
## Summary

- remove the unused `api.config.load()` gate from General Settings
- render independent appearance, language, data-home, persona, and version controls immediately
- add a regression test proving General Settings does not depend on the unrelated config read

## Problem

`SettingsSection` loaded the app config only to decide whether to render a spinner; it never consumed the returned config. A transient failure therefore hid every General Settings control forever even though those controls load and persist through independent state and APIs.

## Verification

- `pnpm -F open-alice-ui exec vitest run src/pages/SettingsPage.loading.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3,389 passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- isolated `pnpm dev:onboarding` browser walk at `/settings`
