### PR TITLE
Recover failed Settings tool catalog loads

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -215,6 +215,7 @@ export const en = {
     },
     tools: {
       summary: '{{tools}} tools in {{groups}} groups — changes apply on next AI request',
+      loadError: 'Could not load the tool catalog.',
       emptyTitle: 'No tools registered.',
       emptyDescription: 'Tools will appear here when the engine starts.',
       group: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -204,6 +204,7 @@ export const ja: Resources = {
     },
     tools: {
       summary: '{{groups}} グループ {{tools}} ツール——変更は次回の AI リクエストで反映されます',
+      loadError: 'ツールカタログを読み込めませんでした。',
       emptyTitle: '登録されたツールはありません。',
       emptyDescription: 'エンジンが起動するとツールがここに表示されます。',
       group: {

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -212,6 +212,7 @@ export const zhHant: Resources = {
     },
     tools: {
       summary: '{{groups}} 個分組共 {{tools}} 個工具——變更會在下次 AI 請求時生效',
+      loadError: '無法載入工具目錄。',
       emptyTitle: '尚未註冊任何工具。',
       emptyDescription: '引擎啟動後工具會顯示在這裡。',
       group: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -204,6 +204,7 @@ export const zh: Resources = {
     },
     tools: {
       summary: '{{groups}} 个分组共 {{tools}} 个工具——更改在下次 AI 请求时生效',
+      loadError: '无法加载工具目录。',
       emptyTitle: '尚未注册任何工具。',
       emptyDescription: '引擎启动后工具会显示在这里。',
       group: {

--- a/ui/src/pages/SettingsPage.tools-loading.spec.tsx
+++ b/ui/src/pages/SettingsPage.tools-loading.spec.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { ToolsSection } from './SettingsPage'
+
+const mocks = vi.hoisted(() => ({
+  loadTools: vi.fn(),
+  updateTools: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    tools: {
+      load: mocks.loadTools,
+      update: mocks.updateTools,
+    },
+  },
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('Settings Tools loading', () => {
+  it('explains a failed catalog load and retries it', async () => {
+    mocks.loadTools
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ inventory: [], disabled: [] })
+
+    render(<ToolsSection />)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not load the tool catalog.')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.loadTools).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('No tools registered.')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -769,7 +769,7 @@ interface ToolGroup {
   tools: ToolInfo[]
 }
 
-function ToolsSection() {
+export function ToolsSection() {
   const { t } = useTranslation()
   const groupLabel = (key: string): string => {
     switch (key) {
@@ -789,15 +789,25 @@ function ToolsSection() {
   const [inventory, setInventory] = useState<ToolInfo[]>([])
   const [disabled, setDisabled] = useState<Set<string>>(new Set())
   const [loaded, setLoaded] = useState(false)
+  const [loadError, setLoadError] = useState(false)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
-  useEffect(() => {
-    api.tools.load().then((res) => {
+  const loadTools = useCallback(async () => {
+    setLoaded(false)
+    setLoadError(false)
+    try {
+      const res = await api.tools.load()
       setInventory(res.inventory)
       setDisabled(new Set(res.disabled))
       setLoaded(true)
-    }).catch(() => {})
+    } catch {
+      setLoadError(true)
+    }
   }, [])
+
+  useEffect(() => {
+    void loadTools()
+  }, [loadTools])
 
   const groups = useMemo<ToolGroup[]>(() => {
     const map = new Map<string, ToolInfo[]>()
@@ -854,7 +864,16 @@ function ToolsSection() {
   return (
     <div className="mx-auto w-full max-w-[1100px]">
       {!loaded ? (
-        <PageLoading />
+        loadError ? (
+          <div role="alert" className="flex flex-col items-center justify-center py-16 text-center">
+            <p className="text-sm font-medium text-foreground">{t('settings.tools.loadError')}</p>
+            <button type="button" className="btn-secondary-sm mt-4" onClick={() => void loadTools()}>
+              {t('common.retry')}
+            </button>
+          </div>
+        ) : (
+          <PageLoading />
+        )
       ) : groups.length === 0 ? (
         <EmptyState title={t('settings.tools.emptyTitle')} description={t('settings.tools.emptyDescription')} />
       ) : (


### PR DESCRIPTION
## Summary

- surface a localized, accessible error when the Settings tool catalog cannot load
- provide a Retry action instead of leaving the Tools tab on a permanent spinner
- cover failed-first-load and successful retry behavior with a focused UI test

## Problem

`ToolsSection` swallowed `api.tools.load()` failures without transitioning out of its loading state. A transient API failure therefore left the Settings Tools tab spinning forever with no explanation or recovery path.

## Verification

- `pnpm -F open-alice-ui exec vitest run src/pages/SettingsPage.tools-loading.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3,389 passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walk through `/settings` → Tools
