### PR TITLE
Recover failed AI credential vault loads

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -234,6 +234,8 @@ export const en = {
   aiProvider: {
     title: 'AI Provider',
     description: 'Provider accounts and model defaults Alice can inject into workspaces.',
+    loadErrorTitle: 'Couldn’t load AI credentials',
+    loadErrorDescription: 'OpenAlice could not read the credential vault. Your saved credentials have not been changed.',
     vaultIntro: "API keys are kept centrally. New workspaces can receive a chosen default, and any workspace can load a saved credential. Subscription logins stay in the agent CLI (claude login / codex login).",
     credentials: 'Credentials',
     addFirst: 'Add your first credential',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -223,6 +223,8 @@ export const ja: Resources = {
   aiProvider: {
     title: 'AI プロバイダー',
     description: 'Alice がワークスペースへ注入できるプロバイダーアカウントとモデル既定値を管理します。',
+    loadErrorTitle: 'AI 認証情報を読み込めませんでした',
+    loadErrorDescription: 'OpenAlice は認証情報の保管庫を読み取れませんでした。保存済みの認証情報は変更されていません。',
     vaultIntro: 'API キーは Alice が一元管理します。新しいワークスペースには選択した既定の認証情報を書き込め、任意のワークスペースから保存済み認証情報を読み込めます。サブスクリプションのログインは agent CLI 側で管理します（claude login / codex login）。',
     credentials: '認証情報',
     addFirst: '最初の認証情報を追加',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -231,6 +231,8 @@ export const zhHant: Resources = {
   aiProvider: {
     title: 'AI 供應方',
     description: '管理 Alice 可注入工作區的供應方帳戶與模型預設值。',
+    loadErrorTitle: '無法載入 AI 憑證',
+    loadErrorDescription: 'OpenAlice 無法讀取憑證庫。你已儲存的憑證沒有變更。',
     vaultIntro: 'API key 由 Alice 集中保管。新工作區可以寫入所選的預設憑證，任何工作區也都能載入已儲存憑證。訂閱登入仍由 agent CLI 自行管理（claude login / codex login）。',
     credentials: '憑證庫',
     addFirst: '新增第一個憑證',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -223,6 +223,8 @@ export const zh: Resources = {
   aiProvider: {
     title: 'AI 提供方',
     description: '管理 Alice 可注入工作区的提供方账户和模型默认值。',
+    loadErrorTitle: '无法加载 AI 凭证',
+    loadErrorDescription: 'OpenAlice 无法读取凭证库。你已保存的凭证没有发生变化。',
     vaultIntro: 'API key 由 Alice 集中保管。新工作区可以写入选定的默认凭证，任何工作区也都能载入已保存凭证。订阅登录仍由 agent CLI 自己管理（claude login / codex login）。',
     credentials: '凭证库',
     addFirst: '添加第一个凭证',

--- a/ui/src/pages/AIProviderPage.loading.spec.tsx
+++ b/ui/src/pages/AIProviderPage.loading.spec.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { AIProviderPage } from './AIProviderPage'
+
+const mocks = vi.hoisted(() => ({
+  getCredentials: vi.fn(),
+  getPresets: vi.fn(),
+  getWorkspaceCredentialDefaults: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    config: {
+      getCredentials: mocks.getCredentials,
+      getPresets: mocks.getPresets,
+      getWorkspaceCredentialDefaults: mocks.getWorkspaceCredentialDefaults,
+    },
+  },
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+  mocks.getPresets.mockResolvedValue({ presets: [] })
+  mocks.getWorkspaceCredentialDefaults.mockResolvedValue({
+    defaults: {},
+    compatibleByAgent: {},
+  })
+})
+
+afterEach(cleanup)
+
+describe('AIProviderPage credential loading', () => {
+  it('distinguishes a failed vault read from an empty vault and retries', async () => {
+    mocks.getCredentials
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ credentials: [] })
+
+    render(<AIProviderPage />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Your saved credentials have not been changed.')
+    expect(screen.queryByRole('button', { name: /Add your first credential/ })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.getCredentials).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('button', { name: /Add your first credential/ })).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -14,7 +14,7 @@
  * helper: it carries each vendor's endpoint + model suggestions + request shape.
  */
 
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, type Preset, type WireShape } from '../api'
 import type {
@@ -93,15 +93,25 @@ const AGENT_RUNTIMES: RuntimeInfo[] = [
 export function AIProviderPage() {
   const { t } = useTranslation()
   const [credentials, setCredentials] = useState<CredentialSummary[] | null>(null)
+  const [credentialsLoadError, setCredentialsLoadError] = useState(false)
   const [presets, setPresets] = useState<Preset[]>([])
   const [modal, setModal] = useState<{ mode: 'add' } | { mode: 'edit'; cred: CredentialSummary } | null>(null)
 
-  const reload = () => api.config.getCredentials().then(({ credentials: c }) => setCredentials(c)).catch(() => setCredentials([]))
+  const reload = useCallback(async () => {
+    setCredentials(null)
+    setCredentialsLoadError(false)
+    try {
+      const { credentials: next } = await api.config.getCredentials()
+      setCredentials(next)
+    } catch {
+      setCredentialsLoadError(true)
+    }
+  }, [])
 
   useEffect(() => {
     void reload()
     api.config.getPresets().then(({ presets: p }) => setPresets(p)).catch(() => {})
-  }, [])
+  }, [reload])
 
   const apiKeyPresets = useMemo(() => presets.filter(isApiKeyPreset), [presets])
 
@@ -118,7 +128,21 @@ export function AIProviderPage() {
     return (
       <div className="flex flex-col flex-1 min-h-0">
         <PageHeader title={t('aiProvider.title')} description={t('aiProvider.description')} />
-        <PageLoading />
+        {credentialsLoadError ? (
+          <div className="flex flex-1 items-center justify-center px-6 py-12">
+            <div role="alert" className="max-w-md text-center">
+              <h2 className="text-sm font-semibold text-foreground">{t('aiProvider.loadErrorTitle')}</h2>
+              <p className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
+                {t('aiProvider.loadErrorDescription')}
+              </p>
+              <button type="button" className="btn-secondary-sm mt-4" onClick={() => void reload()}>
+                {t('common.retry')}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <PageLoading />
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary

- distinguish a credential-vault read failure from a genuinely empty vault
- explain that saved credentials were not changed when the read fails
- provide a Retry action and keep the normal empty-vault onboarding path intact
- add a focused failed-first-load and successful-retry regression test

## Problem

`AIProviderPage` converted `getCredentials()` failures into an empty credential array. A transient backend or IPC failure therefore presented the destructive-looking fiction that every saved credential had disappeared and invited the user to add a first credential.

## Verification

- `pnpm -F open-alice-ui exec vitest run src/pages/AIProviderPage.spec.tsx src/pages/AIProviderPage.loading.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3,389 passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- isolated `pnpm dev:onboarding` browser walk at `/settings/ai-provider`
