### PR TITLE
Recover failed MCP configuration loads

### DIFF
--- a/ui/src/hooks/useConfigPage.ts
+++ b/ui/src/hooks/useConfigPage.ts
@@ -20,6 +20,8 @@ interface UseConfigPageResult<T> {
   updateConfig: (patch: Partial<T>) => void
   /** Update config and immediately flush (no debounce) */
   updateConfigImmediate: (patch: Partial<T>) => void
+  /** Retry the initial config read after a transient failure */
+  reload: () => Promise<void>
   retry: () => void
 }
 
@@ -36,16 +38,23 @@ export function useConfigPage<T extends object>({
   const [config, setConfig] = useState<T | null>(null)
   const [loadError, setLoadError] = useState(false)
   const flushRequestedRef = useRef(false)
+  const extractRef = useRef(extract)
+  extractRef.current = extract
+
+  const reload = useCallback(async () => {
+    setLoadError(false)
+    try {
+      const full = await api.config.load()
+      setFullConfig(full)
+      setConfig(extractRef.current(full))
+    } catch {
+      setLoadError(true)
+    }
+  }, [])
 
   useEffect(() => {
-    api.config
-      .load()
-      .then((full) => {
-        setFullConfig(full)
-        setConfig(extract(full))
-      })
-      .catch(() => setLoadError(true))
-  }, []) // extract is stable (caller should memoize or use inline arrow)
+    void reload()
+  }, [reload])
 
   const saveConfig = useCallback(
     async (data: T) => {
@@ -83,5 +92,5 @@ export function useConfigPage<T extends object>({
     flushRequestedRef.current = true
   }, [])
 
-  return { config, fullConfig, status, loadError, updateConfig, updateConfigImmediate, retry }
+  return { config, fullConfig, status, loadError, updateConfig, updateConfigImmediate, reload, retry }
 }

--- a/ui/src/pages/MCPPage.spec.tsx
+++ b/ui/src/pages/MCPPage.spec.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MCPPage } from './MCPPage'
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  updateSection: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    config: {
+      load: mocks.loadConfig,
+      updateSection: mocks.updateSection,
+    },
+  },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('MCPPage configuration loading', () => {
+  it('retries a failed configuration read', async () => {
+    mocks.loadConfig
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({
+        mcp: {
+          enabled: false,
+          port: 3003,
+        },
+      })
+
+    render(<MCPPage />)
+
+    expect(await screen.findByRole('alert')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.loadConfig).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('heading', { name: 'HTTP Server' })).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/MCPPage.tsx
+++ b/ui/src/pages/MCPPage.tsx
@@ -14,7 +14,7 @@ import { PageHeader } from '../components/PageHeader'
 import type { AppConfig, McpConfig } from '../api'
 
 export function MCPPage() {
-  const { config, status, loadError, updateConfig, retry } = useConfigPage<McpConfig>({
+  const { config, status, loadError, updateConfig, reload, retry } = useConfigPage<McpConfig>({
     section: 'mcp',
     extract: (full: AppConfig) => full.mcp,
   })
@@ -56,7 +56,14 @@ export function MCPPage() {
             </ConfigSection>
           </div>
         )}
-        {loadError && <p className="text-[13px] text-destructive">Failed to load configuration.</p>}
+        {loadError && (
+          <div role="alert" className="mx-auto max-w-[880px] text-center">
+            <p className="text-[13px] text-destructive">Failed to load configuration.</p>
+            <button type="button" className="btn-secondary-sm mt-3" onClick={() => void reload()}>
+              Retry
+            </button>
+          </div>
+        )}
       </SettingsScrollArea>
     </div>
   )


### PR DESCRIPTION
## Summary

- expose an explicit reload operation from the shared config-page hook
- show an accessible MCP configuration load error with a real Retry action
- verify the failed-first-load and successful-retry path through the page and actual hook

## Problem

The MCP Server page reported an initial configuration read failure but offered no way to repeat that read. Its existing SaveIndicator retry only retries writes, so users had to reload the entire application after a transient backend failure.

## Verification

- `pnpm -F open-alice-ui exec vitest run src/pages/MCPPage.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3,389 passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- isolated `pnpm dev:onboarding` browser walk at `/settings/mcp`
