### PR TITLE
Localize Automation page headers

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -884,7 +884,9 @@ export const en = {
   },
   automation: {
     runs: 'Runs',
+    runsDescription: 'Headless agent runs across workspaces — what the workers are doing.',
     api: 'API',
+    apiDescription: 'Trigger workspace automation from outside, and review the schedule-file format.',
   },
   news: {
     lookback1h: '1 hour',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -873,7 +873,9 @@ export const ja: Resources = {
   },
   automation: {
     runs: '実行',
+    runsDescription: 'ワークスペースをまたぐヘッドレス Agent の実行状況を確認します。',
     api: 'API',
+    apiDescription: '外部からワークスペース自動化を起動し、スケジュールファイル形式を確認します。',
   },
   news: {
     lookback1h: '1 時間',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -881,7 +881,9 @@ export const zhHant: Resources = {
   },
   automation: {
     runs: '運行',
+    runsDescription: '查看跨工作區的無頭 Agent 運行與工作進度。',
     api: 'API',
+    apiDescription: '從外部觸發工作區自動化，並查看排程檔案格式。',
   },
   news: {
     lookback1h: '1 小時',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -873,7 +873,9 @@ export const zh: Resources = {
   },
   automation: {
     runs: '运行',
+    runsDescription: '查看跨工作区的无头 Agent 运行及工作进度。',
     api: 'API',
+    apiDescription: '从外部触发工作区自动化，并查看调度文件格式。',
   },
   news: {
     lookback1h: '1 小时',

--- a/ui/src/pages/AutomationPage.spec.tsx
+++ b/ui/src/pages/AutomationPage.spec.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { AutomationPage } from './AutomationPage'
+
+vi.mock('./AutomationApiSection', () => ({
+  AutomationApiSection: () => <div>API content</div>,
+}))
+
+vi.mock('./AutomationRunsSection', () => ({
+  AutomationRunsSection: () => <div>Runs content</div>,
+}))
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zh')
+})
+
+afterEach(cleanup)
+
+describe('AutomationPage localization', () => {
+  it('localizes the Runs header and description', () => {
+    render(<AutomationPage spec={{ kind: 'automation', params: { section: 'runs' } }} />)
+
+    expect(screen.getByRole('heading', { name: '运行' })).toBeTruthy()
+    expect(screen.getByText('查看跨工作区的无头 Agent 运行及工作进度。')).toBeTruthy()
+  })
+
+  it('localizes the API header description', () => {
+    render(<AutomationPage spec={{ kind: 'automation', params: { section: 'api' } }} />)
+
+    expect(screen.getByRole('heading', { name: 'API' })).toBeTruthy()
+    expect(screen.getByText('从外部触发工作区自动化，并查看调度文件格式。')).toBeTruthy()
+  })
+})

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 import { PageHeader } from '../components/PageHeader'
 import type { ViewSpec } from '../tabs/types'
 import { AutomationApiSection } from './AutomationApiSection'
@@ -5,14 +7,12 @@ import { AutomationRunsSection } from './AutomationRunsSection'
 
 type AutomationSection = Extract<ViewSpec, { kind: 'automation' }>['params']['section']
 
-const SECTION_TITLE: Record<AutomationSection, string> = {
-  runs: 'Runs',
-  api: 'API',
-}
-
-const SECTION_DESCRIPTION: Record<AutomationSection, string> = {
-  runs: 'Headless agent runs across workspaces — what the workers are doing.',
-  api: 'Trigger workspace automation from outside, and the schedule-file format.',
+const SECTION_DESCRIPTION_KEY: Record<
+  AutomationSection,
+  'automation.runsDescription' | 'automation.apiDescription'
+> = {
+  runs: 'automation.runsDescription',
+  api: 'automation.apiDescription',
 }
 
 interface AutomationPageProps {
@@ -26,11 +26,15 @@ interface AutomationPageProps {
  * Workspace issues; the retired event-bus surfaces are intentionally absent.
  */
 export function AutomationPage({ spec }: AutomationPageProps) {
+  const { t } = useTranslation()
   const section = spec.params.section
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <PageHeader title={SECTION_TITLE[section]} description={SECTION_DESCRIPTION[section]} />
+      <PageHeader
+        title={t(section === 'runs' ? 'automation.runs' : 'automation.api')}
+        description={t(SECTION_DESCRIPTION_KEY[section])}
+      />
       <div
         data-testid="automation-scroll-region"
         className="flex-1 flex flex-col min-h-0 overflow-y-auto px-4 md:px-6 py-5"


### PR DESCRIPTION
## Summary

- replace hard-coded Automation Runs and API page headers with i18n keys
- add localized descriptions for English, Simplified Chinese, Japanese, and Traditional Chinese
- cover both Automation views with focused Chinese localization tests

## Problem

The Automation sidebar was localized, but opening “运行” or “API” switched the main page header back to hard-coded English. This made a single navigation action visibly change language and obscured what each Automation view is for.

## Verification

- `pnpm -F open-alice-ui exec vitest run src/pages/AutomationPage.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3,390 passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walks at `/automation/runs` and `/automation/api`
