### PR TITLE
Recover Workspace Manager loading

### DIFF
--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   getQuickChat: vi.fn(),
   rememberQuickChatCredential: vi.fn(),
   openAgentConfig: vi.fn(),
+  refreshWorkspaceManager: vi.fn(),
 }))
 
 vi.mock('../contexts/workspaces-context', () => ({
@@ -119,7 +120,7 @@ function context(
     hasLoaded: true,
     templatesLoaded: true,
     refresh: vi.fn(),
-    refreshWorkspaceManager: vi.fn(async () => undefined),
+    refreshWorkspaceManager: mocks.refreshWorkspaceManager,
     quickStartWorkspaceManager: mocks.quickStartWorkspaceManager,
     spawn: vi.fn(async () => undefined),
     openHeadlessRun: vi.fn(async () => undefined),
@@ -178,6 +179,7 @@ beforeEach(async () => {
   mocks.rememberQuickChatCredential.mockResolvedValue(undefined)
   mocks.openWebPiSession.mockResolvedValue(undefined)
   mocks.resumeSession.mockResolvedValue(undefined)
+  mocks.refreshWorkspaceManager.mockResolvedValue(undefined)
   mocks.quickStartWorkspaceManager.mockResolvedValue({
     manager: managerSnapshot(),
     session: {
@@ -201,6 +203,21 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('WorkspaceManagerPage runtime selection', () => {
+  it('offers a retry when the manager snapshot cannot load', async () => {
+    mocks.useWorkspaces.mockImplementation(() => ({
+      ...context('codex'),
+      workspaceManager: null,
+      workspaceManagerError: 'Manager snapshot unavailable',
+    }))
+
+    render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
+
+    expect(screen.getByRole('alert').textContent).toContain('Manager snapshot unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.refreshWorkspaceManager).toHaveBeenCalledOnce())
+  })
+
   it('uses the Quick Chat runtime catalog and launches the selected native runtime', async () => {
     render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
 

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -253,8 +253,20 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
         </section>
 
         {(error ?? workspaceManagerError) && (
-          <div className="mt-3 rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
-            {error ?? workspaceManagerError}
+          <div
+            role="alert"
+            className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-[12px] text-destructive"
+          >
+            <span>{error ?? workspaceManagerError}</span>
+            {!error && workspaceManagerError && (
+              <button
+                type="button"
+                className="shrink-0 rounded-md border border-destructive/30 px-2.5 py-1 font-medium hover:bg-destructive/10"
+                onClick={() => void refreshWorkspaceManager()}
+              >
+                {t('common.retry')}
+              </button>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- mark Workspace Manager control-plane load errors as accessible alerts
- expose a Retry action wired to the existing refresh operation
- keep session-launch errors distinct so Retry is not offered for unrelated failures
- cover failed snapshot recovery with a focused page regression test

## Problem
The Workspace Manager surfaced control-plane snapshot failures as plain text even though `refreshWorkspaceManager()` already existed. Users had to reload the entire application after a transient failure.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/pages/WorkspaceManagerPage.spec.tsx` (8 tests)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (357 files passed, 3,389 tests passed)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walk at `/chat/manager`