### PR TITLE
Recover template README loading

### DIFF
--- a/ui/src/pages/TemplateDetailPage.spec.tsx
+++ b/ui/src/pages/TemplateDetailPage.spec.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TemplateDetailPage } from './TemplateDetailPage'
+
+const mocks = vi.hoisted(() => ({
+  fetchTemplateReadme: vi.fn(),
+  openOrFocus: vi.fn(),
+  refresh: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key === 'common.retry' ? 'Retry' : key,
+  }),
+}))
+
+vi.mock('../components/workspace/api', () => ({
+  fetchTemplateReadme: mocks.fetchTemplateReadme,
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    templates: [{
+      name: 'chat',
+      displayName: 'Chat',
+      description: 'General-purpose workspace',
+      defaultAgents: ['codex'],
+      version: '0.2.0',
+      hasReadme: true,
+    }],
+    agents: [],
+    refresh: mocks.refresh,
+  }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: typeof mocks.openOrFocus }) => unknown) => selector({
+    openOrFocus: mocks.openOrFocus,
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('TemplateDetailPage README recovery', () => {
+  it('retries a failed README request without reloading the application', async () => {
+    mocks.fetchTemplateReadme
+      .mockRejectedValueOnce(new Error('README temporarily unavailable'))
+      .mockResolvedValueOnce('# Chat\n\nRecovered instructions')
+
+    render(<TemplateDetailPage spec={{ kind: 'template-detail', params: { name: 'chat' } }} />)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('README temporarily unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await screen.findByText('Recovered instructions')
+    await waitFor(() => expect(mocks.fetchTemplateReadme).toHaveBeenCalledTimes(2))
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/TemplateDetailPage.tsx
+++ b/ui/src/pages/TemplateDetailPage.tsx
@@ -54,6 +54,7 @@ export function TemplateDetailPage({ spec }: Props) {
   const [readme, setReadme] = useState<string | null>(null)
   const [readmeMissing, setReadmeMissing] = useState(false)
   const [readmeError, setReadmeError] = useState<string | null>(null)
+  const [readmeAttempt, setReadmeAttempt] = useState(0)
   useEffect(() => {
     let cancelled = false
     setReadme(null)
@@ -72,7 +73,7 @@ export function TemplateDetailPage({ spec }: Props) {
     return () => {
       cancelled = true
     }
-  }, [templateName])
+  }, [templateName, readmeAttempt])
 
   if (!template) {
     return (
@@ -152,7 +153,19 @@ export function TemplateDetailPage({ spec }: Props) {
             <p className="text-[12px] text-muted-foreground italic">{t('templates.noReadme')}</p>
           )}
           {readmeError && (
-            <p className="text-[12px] text-muted-foreground italic">{readmeError}</p>
+            <div
+              role="alert"
+              className="flex items-center justify-between gap-3 text-[12px] text-destructive"
+            >
+              <span className="min-w-0 break-words">{readmeError}</span>
+              <button
+                type="button"
+                className="shrink-0 rounded-md border border-destructive/30 px-2.5 py-1 font-medium hover:bg-destructive/10"
+                onClick={() => setReadmeAttempt((attempt) => attempt + 1)}
+              >
+                {t('common.retry')}
+              </button>
+            </div>
           )}
           {readmeBody && (
             <MarkdownContent text={readmeBody} className="text-[13px] leading-relaxed" />


### PR DESCRIPTION
## Summary
- present template README load failures as accessible alerts
- add an in-place Retry action that reruns the failed README request
- preserve the distinct missing-README state instead of treating it as an error
- cover a failed request followed by successful recovery with a focused page test

## Problem
The template detail README is the main description users inspect before creating a Workspace. A transient request failure only exposed the raw error and left no recovery action, forcing users to reload the application.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/pages/TemplateDetailPage.spec.tsx` (1 test)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 files passed, 3,389 tests passed)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walk at `/workspaces/templates/chat`