### PR TITLE
Recover sector rotation loading

### DIFF
--- a/ui/src/pages/MarketRotationPage.spec.tsx
+++ b/ui/src/pages/MarketRotationPage.spec.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MarketRotationPage } from './MarketRotationPage'
+
+const mocks = vi.hoisted(() => ({
+  sectorRotation: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { sym?: string }) => {
+      if (key === 'common.retry') return 'Retry'
+      if (key === 'market.colVsBench') return `vs ${options?.sym ?? ''}`
+      return key
+    },
+  }),
+}))
+
+vi.mock('../api/market', () => ({
+  marketApi: {
+    sectorRotation: mocks.sectorRotation,
+  },
+}))
+
+vi.mock('../components/MeasuredChartFrame', () => ({
+  MeasuredChartFrame: () => <div data-testid="rotation-chart" />,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('MarketRotationPage recovery', () => {
+  it('lets the user retry an initial board failure immediately', async () => {
+    mocks.sectorRotation
+      .mockRejectedValueOnce(new Error('Rotation board unavailable'))
+      .mockResolvedValueOnce({
+        asOf: '2026-07-29',
+        benchmark: {
+          symbol: 'SPY',
+          returns: { '1D': 0, '1W': 0, '1M': 0, '3M': 0, '6M': 0 },
+        },
+        sectors: [],
+        methodology: 'Recovered methodology',
+      })
+
+    render(<MarketRotationPage />)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Rotation board unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await screen.findByText('Recovered methodology')
+    await waitFor(() => expect(mocks.sectorRotation).toHaveBeenCalledTimes(2))
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/MarketRotationPage.tsx
+++ b/ui/src/pages/MarketRotationPage.tsx
@@ -43,6 +43,7 @@ export function MarketRotationPage() {
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [requestVersion, setRequestVersion] = useState(0)
 
   useEffect(() => {
     let alive = true
@@ -63,7 +64,13 @@ export function MarketRotationPage() {
     load()
     const timer = setInterval(load, REFRESH_MS)
     return () => { alive = false; clearInterval(timer) }
-  }, [])
+  }, [requestVersion])
+
+  const retry = () => {
+    setError(null)
+    setLoading(true)
+    setRequestVersion((version) => version + 1)
+  }
 
   const points = useMemo<Point[]>(() => {
     if (!data) return []
@@ -92,7 +99,19 @@ export function MarketRotationPage() {
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-6 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
+          <div
+            role="alert"
+            className="flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[13px] text-destructive"
+          >
+            <span className="min-w-0 break-words">{error}</span>
+            <button
+              type="button"
+              className="shrink-0 rounded-md border border-destructive/30 px-2.5 py-1 font-medium hover:bg-destructive/10"
+              onClick={retry}
+            >
+              {t('common.retry')}
+            </button>
+          </div>
         )}
 
         {data && (


### PR DESCRIPTION
## Summary
- present sector-rotation request failures as accessible alerts
- add an immediate Retry action instead of waiting for the five-minute refresh interval
- restart the existing refresh cycle after a manual retry
- cover an initial failure followed by successful board recovery with a focused page test

## Problem
When the sector-rotation board failed on its first request, the page only showed an error message. Its next request was scheduled five minutes later, leaving users without an immediate way to recover the market view.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/pages/MarketRotationPage.spec.tsx` (1 test)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 files passed, 3,389 tests passed)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walk at `/market/rotation`