### PR TITLE
Recover tool-call log loading

### DIFF
--- a/ui/src/pages/LogsPage.spec.tsx
+++ b/ui/src/pages/LogsPage.spec.tsx
@@ -118,6 +118,23 @@ describe('LogsPage Agent conversations', () => {
     expect(screen.getByText('No tool calls yet')).toBeTruthy()
   })
 
+  it('distinguishes an unavailable tool-call log from an empty log', async () => {
+    mocks.toolQuery.mockRejectedValueOnce(new Error('offline'))
+    render(<LogsPage />)
+    await screen.findByText(/2 conversations/)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tool calls' }))
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not load tool calls')
+    expect(screen.getByText('Tool calls unavailable')).toBeTruthy()
+    expect(screen.queryByText('No tool calls yet')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.toolQuery).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('No tool calls yet')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
   it('offers a retry when the read-only projection is unavailable', async () => {
     mocks.conversationQuery.mockRejectedValueOnce(new Error('offline'))
     render(<LogsPage />)

--- a/ui/src/pages/LogsPage.tsx
+++ b/ui/src/pages/LogsPage.tsx
@@ -64,6 +64,7 @@ function ToolCallLogSection() {
   const [totalPages, setTotalPages] = useState(1)
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [failed, setFailed] = useState(false)
   const [toolNames, setToolNames] = useState<string[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -79,8 +80,10 @@ function ToolCallLogSection() {
       setPage(result.page)
       setTotalPages(result.totalPages)
       setTotal(result.total)
+      setFailed(false)
     } catch (err) {
       console.warn('Failed to load tool calls:', err)
+      setFailed(true)
     } finally {
       setLoading(false)
     }
@@ -146,9 +149,11 @@ function ToolCallLogSection() {
         </button>
 
         <span className="text-xs text-muted-foreground ml-auto">
-          {total > 0
-            ? `Page ${page} of ${totalPages} \u00b7 ${total} calls`
-            : '0 calls'
+          {failed && entries.length === 0
+            ? 'Tool calls unavailable'
+            : total > 0
+              ? `Page ${page} of ${totalPages} \u00b7 ${total} calls`
+              : '0 calls'
           }
           {nameFilter && ' (filtered)'}
         </span>
@@ -161,6 +166,23 @@ function ToolCallLogSection() {
       >
         {loading && entries.length === 0 ? (
           <LogRowsSkeleton />
+        ) : failed && entries.length === 0 ? (
+          <div
+            role="alert"
+            className="flex h-full min-h-64 flex-col items-center justify-center gap-3 px-6 text-center font-sans"
+          >
+            <div>
+              <p className="text-sm font-medium text-foreground">Could not load tool calls</p>
+              <p className="mt-1 text-xs text-muted-foreground">The read-only audit log was not changed.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void fetchPage(page, nameFilter || undefined)}
+              className="oa-pressable rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Retry
+            </button>
+          </div>
         ) : entries.length === 0 ? (
           <div className="px-4 py-8 text-center text-muted-foreground">No tool calls yet</div>
         ) : (


### PR DESCRIPTION
## Summary
- distinguish an unavailable Tool calls audit log from a genuinely empty log
- expose the failed state as an accessible alert with a read-only Retry action
- clear the failure indicator after a successful poll or retry while preserving existing entries
- cover failure, retry, and recovered empty-state behavior in the Logs page suite

## Problem
The Tool calls view swallowed query failures into the console and then rendered `0 calls` and `No tool calls yet`. That made an unavailable audit log indistinguishable from a workspace that genuinely had no recorded calls, while the adjacent Agent conversations view already handled this case explicitly.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/pages/LogsPage.spec.tsx` (6 tests)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (357 files passed, 3,389 tests passed)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walk at `/dev/logs` → `Tool calls`