### PR TITLE
Expose active sidebar destinations

### DIFF
--- a/ui/src/components/SidebarRow.spec.tsx
+++ b/ui/src/components/SidebarRow.spec.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarRow } from './SidebarRow'
+
+afterEach(cleanup)
+
+describe('SidebarRow current state', () => {
+  it('exposes the active navigation destination to assistive technology', () => {
+    render(
+      <>
+        <SidebarRow label="All accounts" active onClick={vi.fn()} />
+        <SidebarRow label="Alpaca Paper" onClick={vi.fn()} />
+      </>,
+    )
+
+    expect(screen.getByRole('button', { name: 'All accounts' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Alpaca Paper' }).getAttribute('aria-current')).toBeNull()
+  })
+})

--- a/ui/src/components/SidebarRow.tsx
+++ b/ui/src/components/SidebarRow.tsx
@@ -45,6 +45,7 @@ export function SidebarRow({ label, active = false, onClick, icon, trail, title,
     <div
       role="button"
       tabIndex={0}
+      aria-current={active ? 'page' : undefined}
       onClick={onClick}
       title={title}
       onKeyDown={(e) => {


### PR DESCRIPTION
## Summary
- expose the active shared sidebar row with `aria-current="page"`
- leave inactive navigation rows without a current-state announcement
- cover both states with a focused shared-component regression test

## Problem
OpenAlice's secondary sidebars communicated the current destination only through a tinted background and accent bar. Assistive technology received every row as an ordinary button, so users could not determine whether All Accounts, a specific account, or another sidebar destination was currently open.

Because Portfolio, Market, Settings, Dev, Tracked, and Workspace navigation all use `SidebarRow`, fixing the shared semantic keeps those surfaces consistent without changing their visual or keyboard behavior.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/components/SidebarRow.spec.tsx` (1 test)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 files passed, 3,389 tests passed)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walk at `/portfolio`, confirming `aria-current` moves from All Accounts to Alpaca Paper after navigation