### PR TITLE
Announce Workspace creation failures

### DIFF
--- a/ui/src/components/workspace/CreateWorkspaceForm.spec.tsx
+++ b/ui/src/components/workspace/CreateWorkspaceForm.spec.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { CreateWorkspaceForm } from './CreateWorkspaceForm'
+
+const mocks = vi.hoisted(() => ({
+  setTag: vi.fn(),
+  submit: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({ workspaces: [] }),
+}))
+
+vi.mock('../../hooks/useCreateWorkspace', () => ({
+  TAG_HINT: 'tag hint',
+  defaultTagFor: () => 'chat-jul29',
+  useCreateWorkspace: () => ({
+    tag: 'chat-jul29',
+    setTag: mocks.setTag,
+    creating: false,
+    error: 'Workspace bootstrap failed',
+    submit: mocks.submit,
+  }),
+}))
+
+afterEach(cleanup)
+
+describe('CreateWorkspaceForm error feedback', () => {
+  it('exposes creation failures as an immediate alert', () => {
+    render(
+      <CreateWorkspaceForm
+        templates={[{
+          name: 'chat',
+          displayName: 'Chat',
+          defaultAgents: ['codex'],
+          version: '0.2.0',
+          hasReadme: true,
+        }]}
+        onCreated={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('alert').textContent).toBe('Workspace bootstrap failed')
+  })
+})

--- a/ui/src/components/workspace/CreateWorkspaceForm.tsx
+++ b/ui/src/components/workspace/CreateWorkspaceForm.tsx
@@ -154,7 +154,7 @@ export function CreateWorkspaceForm(props: CreateWorkspaceFormProps): ReactEleme
         <p className={HINT}>{TAG_HINT}</p>
       </div>
 
-      {create.error && <div className="text-[12px] text-destructive">{create.error}</div>}
+      {create.error && <div role="alert" className="text-[12px] text-destructive">{create.error}</div>}
 
       <div className="flex items-center justify-end gap-2 pt-1">
         {onCancel && (


### PR DESCRIPTION
## Summary
- expose shared Workspace creation errors as an ARIA alert
- preserve the existing inline message and form position while making failures announce immediately
- cover the shared form's error semantics with a focused regression test

## Problem
All Workspace creation entry points use `CreateWorkspaceForm`, but its validation, collision, and bootstrap errors were rendered as ordinary text. Keyboard and screen-reader users could submit the form and receive no announcement while focus remained on the submit button.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/components/workspace/CreateWorkspaceForm.spec.tsx` (1 test)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 files passed, 3,389 tests passed)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walk at `/workspaces`, submitting `INVALID!` and reading the resulting alert