### PR TITLE
Localize the mobile navigation menu

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { ActivityBar } from './components/ActivityBar'
+import { MobileRailMenuButton } from './components/MobileRailMenuButton'
 import { TabHost } from './components/TabHost'
 import { DesktopUpdatePrompt } from './components/DesktopUpdatePrompt'
 import { UpdateBanner } from './components/UpdateBanner'
@@ -94,15 +95,7 @@ function AppShell() {
     <main className="flex flex-col min-w-0 min-h-0 bg-background h-full">
       {/* Mobile header — visible only below md */}
       <div className="flex items-center gap-3 px-4 py-3 border-b border-border/80 bg-secondary shrink-0 md:hidden">
-        <button
-          onClick={() => setSidebarOpen(true)}
-          className="text-muted-foreground hover:text-foreground p-1 -ml-1"
-          aria-label="Open menu"
-        >
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-            <path d="M3 5h14M3 10h14M3 15h14" />
-          </svg>
-        </button>
+        <MobileRailMenuButton onOpen={() => setSidebarOpen(true)} />
         <span className="text-sm font-semibold text-foreground">OpenAlice</span>
       </div>
 

--- a/ui/src/components/MobileRailMenuButton.spec.tsx
+++ b/ui/src/components/MobileRailMenuButton.spec.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { MobileRailMenuButton } from './MobileRailMenuButton'
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zh')
+})
+
+afterEach(cleanup)
+
+describe('MobileRailMenuButton', () => {
+  it('uses the active locale for the mobile navigation action', () => {
+    const onOpen = vi.fn()
+    render(<MobileRailMenuButton onOpen={onOpen} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '展开活动栏' }))
+
+    expect(onOpen).toHaveBeenCalledOnce()
+  })
+})

--- a/ui/src/components/MobileRailMenuButton.tsx
+++ b/ui/src/components/MobileRailMenuButton.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next'
+
+export function MobileRailMenuButton({ onOpen }: { onOpen: () => void }) {
+  const { t } = useTranslation()
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="text-muted-foreground hover:text-foreground p-1 -ml-1"
+      aria-label={t('nav.expandRail')}
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 20 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        aria-hidden
+      >
+        <path d="M3 5h14M3 10h14M3 15h14" />
+      </svg>
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the hard-coded mobile rail menu label with the existing localized activity-bar action
- mark the hamburger SVG as decorative and make the button type explicit
- isolate the shell control as a focused component with a Chinese-label interaction test

## Problem
The mobile header used `aria-label="Open menu"` directly in `App.tsx`. In Chinese and Japanese interfaces, this primary navigation control remained English even though the rest of the activity bar was localized.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/components/MobileRailMenuButton.spec.tsx` (1 test)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 passed, 1 skipped test files; 3389 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real demo browser walk at `/portfolio`, confirming the mobile rail button exposes `展开活动栏`, the SVG is decorative, and `Open menu` is absent