### PR TITLE
Localize the global Demo banner

### DIFF
--- a/ui/src/demo/DemoBanner.spec.tsx
+++ b/ui/src/demo/DemoBanner.spec.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { i18n } from '../i18n'
+import { DemoBanner } from './DemoBanner'
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zh')
+})
+
+afterEach(cleanup)
+
+describe('DemoBanner', () => {
+  it('uses the active interface language for the global demo notice', () => {
+    render(<DemoBanner />)
+
+    expect(screen.getByText('演示')).toBeTruthy()
+    expect(screen.getByText('快照数据 · 模拟 AI')).toBeTruthy()
+    expect(screen.getByText(/更改不会保存/)).toBeTruthy()
+    expect(screen.getByRole('link', { name: '安装 →' }).getAttribute('href')).toBe(
+      'https://github.com/TraderAlice/OpenAlice',
+    )
+  })
+})

--- a/ui/src/demo/DemoBanner.tsx
+++ b/ui/src/demo/DemoBanner.tsx
@@ -1,17 +1,20 @@
 import type { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export function DemoBanner(): ReactElement {
+  const { t } = useTranslation()
+
   return (
     <div className="flex min-h-8 items-center gap-2 border-b border-warning/40 bg-warning/10 px-3 text-[12px] text-foreground sm:gap-3 sm:px-4">
       <span className="inline-flex shrink-0 items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-warning">
         <span className="h-1.5 w-1.5 rounded-full bg-warning animate-pulse" />
-        Demo
+        {t('demoBanner.badge')}
       </span>
       <span className="min-w-0 flex-1 truncate font-medium text-muted-foreground sm:hidden">
-        Snapshot data · Simulated AI
+        {t('demoBanner.compact')}
       </span>
       <span className="hidden min-w-0 flex-1 truncate text-muted-foreground sm:block">
-        You&apos;re looking at a snapshot of OpenAlice with recorded data. Mutations don&apos;t persist; WebPi replies are simulated.
+        {t('demoBanner.description')}
       </span>
       <a
         href="https://github.com/TraderAlice/OpenAlice"
@@ -19,7 +22,7 @@ export function DemoBanner(): ReactElement {
         rel="noopener noreferrer"
         className="shrink-0 font-medium text-warning hover:underline"
       >
-        Install →
+        {t('demoBanner.install')} →
       </a>
     </div>
   )

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -41,6 +41,13 @@ export const en = {
     collapseRail: 'Collapse activity bar',
     expandRail: 'Expand activity bar',
   },
+  demoBanner: {
+    badge: 'Demo',
+    compact: 'Snapshot data · Simulated AI',
+    description:
+      'You’re looking at a snapshot of OpenAlice with recorded data. Changes aren’t saved; WebPi replies are simulated.',
+    install: 'Install',
+  },
   settings: {
     title: 'Settings',
     tab: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -30,6 +30,13 @@ export const ja: Resources = {
     collapseRail: 'アクティビティバーを折りたたむ',
     expandRail: 'アクティビティバーを展開',
   },
+  demoBanner: {
+    badge: 'デモ',
+    compact: 'スナップショットデータ · AI 応答はシミュレーション',
+    description:
+      '記録済みデータを使った OpenAlice のスナップショットを表示しています。変更は保存されず、WebPi の応答はシミュレーションです。',
+    install: 'インストール',
+  },
   settings: {
     title: '設定',
     tab: {

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -38,6 +38,12 @@ export const zhHant: Resources = {
     collapseRail: '收合活動列',
     expandRail: '展開活動列',
   },
+  demoBanner: {
+    badge: '示範',
+    compact: '快照資料 · 模擬 AI',
+    description: '你正在查看包含錄製資料的 OpenAlice 快照。變更不會儲存；WebPi 回覆為模擬產生。',
+    install: '安裝',
+  },
   settings: {
     title: '設定',
     tab: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -30,6 +30,12 @@ export const zh: Resources = {
     collapseRail: '折叠活动栏',
     expandRail: '展开活动栏',
   },
+  demoBanner: {
+    badge: '演示',
+    compact: '快照数据 · 模拟 AI',
+    description: '你正在查看包含录制数据的 OpenAlice 快照。更改不会保存；WebPi 回复为模拟生成。',
+    install: '安装',
+  },
   settings: {
     title: '设置',
     tab: {


### PR DESCRIPTION
## Summary
- move the global Demo badge, responsive summary, full notice, and install action into the UI translation catalog
- provide matching English, Simplified Chinese, Traditional Chinese, and Japanese copy
- add a focused component test that exercises the Chinese banner and preserves the install destination

## Problem
The Demo shell followed the selected interface language everywhere except its persistent top banner. With Chinese selected, every route still opened with an English badge, snapshot explanation, and install action, making the global preview notice look disconnected from the rest of the product.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/demo/DemoBanner.spec.tsx` (1 test)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 passed, 1 skipped test files; 3389 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real Demo browser walk at `/`, confirming the Chinese badge, notice, responsive summary, and `安装 →` link are present and the old English notice is absent