### PR TITLE
Localize the Dev tools entry experience

### DIFF
--- a/ui/src/components/DevCategoryList.tsx
+++ b/ui/src/components/DevCategoryList.tsx
@@ -6,7 +6,7 @@ import { SidebarRow } from './SidebarRow'
 
 const CATEGORIES = [
   { labelKey: 'common.tools', tab: 'tools', Icon: Wrench },
-  { label: 'Onboarding', tab: 'onboarding', Icon: Compass },
+  { labelKey: 'dev.onboarding', tab: 'onboarding', Icon: Compass },
   { labelKey: 'dev.snapshots', tab: 'snapshots', Icon: Camera },
   { labelKey: 'common.logs', tab: 'logs', Icon: ScrollText },
   { labelKey: 'simulator.title', tab: 'simulator', Icon: FlaskConical },
@@ -28,7 +28,7 @@ export function DevCategoryList() {
         return (
           <SidebarRow
             key={item.tab}
-            label={'label' in item ? item.label : t(item.labelKey)}
+            label={t(item.labelKey)}
             active={active}
             icon={<item.Icon size={14} strokeWidth={1.75} className="text-muted-foreground/70" aria-hidden />}
             onClick={() => openOrFocus({ kind: 'dev', params: { tab: item.tab } })}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -768,7 +768,11 @@ export const en = {
     },
   },
   dev: {
+    onboarding: 'Onboarding',
     snapshots: 'Snapshots',
+    filterTools: 'Filter tools…',
+    selectTool: 'Select a tool from the left panel.',
+    toolDetailsLoadError: 'Failed to load tool details.',
   },
   simulator: {
     title: 'Simulator',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -757,7 +757,11 @@ export const ja: Resources = {
     },
   },
   dev: {
+    onboarding: 'オンボーディング',
     snapshots: 'スナップショット',
+    filterTools: 'ツールを絞り込む…',
+    selectTool: '左側のパネルからツールを選択してください。',
+    toolDetailsLoadError: 'ツールの詳細を読み込めませんでした。',
   },
   simulator: {
     title: 'シミュレーター',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -765,7 +765,11 @@ export const zhHant: Resources = {
     },
   },
   dev: {
+    onboarding: '新手引導',
     snapshots: '快照',
+    filterTools: '篩選工具…',
+    selectTool: '請從左側面板選擇一個工具。',
+    toolDetailsLoadError: '工具詳細資料載入失敗。',
   },
   simulator: {
     title: '模擬器',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -757,7 +757,11 @@ export const zh: Resources = {
     },
   },
   dev: {
+    onboarding: '新手引导',
     snapshots: '快照',
+    filterTools: '筛选工具…',
+    selectTool: '请从左侧面板选择一个工具。',
+    toolDetailsLoadError: '工具详情加载失败。',
   },
   simulator: {
     title: '模拟器',

--- a/ui/src/pages/DevPage.spec.tsx
+++ b/ui/src/pages/DevPage.spec.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { DevPage } from './DevPage'
+
+vi.mock('../api/tools', () => ({
+  toolsApi: {
+    load: vi.fn().mockResolvedValue({ inventory: [] }),
+    detail: vi.fn(),
+    execute: vi.fn(),
+  },
+}))
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zh')
+})
+
+afterEach(cleanup)
+
+describe('DevPage', () => {
+  it('localizes the Tools entry experience and names its filter', () => {
+    render(<DevPage spec={{ kind: 'dev', params: { tab: 'tools' } }} />)
+
+    expect(screen.getByRole('heading', { name: '工具' })).toBeTruthy()
+    expect(screen.getByRole('textbox', { name: '筛选工具…' }).getAttribute('placeholder')).toBe(
+      '筛选工具…',
+    )
+    expect(screen.getByText('请从左侧面板选择一个工具。')).toBeTruthy()
+  })
+})

--- a/ui/src/pages/DevPage.tsx
+++ b/ui/src/pages/DevPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { PageHeader } from '../components/PageHeader'
 import { Spinner, EmptyState } from '../components/StateViews'
 import { getIntlLocale } from '../lib/intl'
@@ -20,13 +21,13 @@ import { filterAccountTierUTAs } from '../lib/uta-account-filter'
 
 type Tab = Extract<ViewSpec, { kind: 'dev' }>['params']['tab']
 
-const TAB_TITLES: Record<Tab, string> = {
-  tools: 'Tools',
-  onboarding: 'Onboarding',
-  snapshots: 'Snapshots',
-  logs: 'Logs',
-  simulator: 'Simulator',
-}
+const TAB_TITLE_KEYS = {
+  tools: 'common.tools',
+  onboarding: 'dev.onboarding',
+  snapshots: 'dev.snapshots',
+  logs: 'common.logs',
+  simulator: 'simulator.title',
+} as const satisfies Record<Tab, string>
 
 /** Tabs that render content with internal scroll containers — the outer wrapper must NOT add overflow. */
 const SELF_SCROLLING_TABS: ReadonlySet<Tab> = new Set(['tools', 'logs'])
@@ -39,10 +40,11 @@ interface DevPageProps {
 
 export function DevPage({ spec }: DevPageProps) {
   const tab = spec.params.tab
+  const { t } = useTranslation()
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <PageHeader title={TAB_TITLES[tab]} />
+      <PageHeader title={t(TAB_TITLE_KEYS[tab])} />
       <div className={`flex-1 min-h-0 ${SELF_SCROLLING_TABS.has(tab) ? 'flex flex-col' : 'overflow-y-auto'}`}>
         {tab === 'tools' && <ToolsTab />}
         {tab === 'onboarding' && <OnboardingDesignPage />}
@@ -268,6 +270,7 @@ function SnapshotRow({ snapshot: s, expanded, onToggle, onDelete }: {
 // ==================== Tools Tab ====================
 
 function ToolsTab() {
+  const { t } = useTranslation()
   const [inventory, setInventory] = useState<ToolInfo[]>([])
   const [selected, setSelected] = useState<string | null>(null)
   const [detail, setDetail] = useState<ToolDetail | null>(null)
@@ -330,7 +333,8 @@ function ToolsTab() {
             type="text"
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter tools..."
+            placeholder={t('dev.filterTools')}
+            aria-label={t('dev.filterTools')}
             className="w-full px-2.5 py-1.5 bg-background text-foreground border border-border rounded-md text-xs outline-none focus:border-primary"
           />
         </div>
@@ -371,14 +375,14 @@ function ToolsTab() {
       <div className="flex-1 overflow-y-auto min-h-0 px-5 py-4">
         {!selected ? (
           <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-            Select a tool from the left panel.
+            {t('dev.selectTool')}
           </div>
         ) : loadingDetail ? (
           <div className="flex justify-center py-10"><Spinner size="sm" /></div>
         ) : detail ? (
           <ToolExecutePanel detail={detail} result={result} onResult={setResult} />
         ) : (
-          <p className="text-sm text-muted-foreground">Failed to load tool details.</p>
+          <p className="text-sm text-muted-foreground">{t('dev.toolDetailsLoadError')}</p>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- localize Dev page headers and the remaining Onboarding sidebar label through the four supported UI catalogs
- localize the Tools filter, empty guidance, and detail-load failure copy
- give the tool filter an accessible name that follows the active interface language
- add focused Chinese rendering coverage for the Tools entry state

## Problem
With Chinese selected, the Dev sidebar already labeled the Tools destination as `工具`, but opening it showed an English `Tools` header, `Filter tools...` input, and `Select a tool from the left panel.` empty state. The filter also relied on its placeholder as its only accessible description.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/pages/DevPage.spec.tsx` (1 test)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 passed, 1 skipped test files; 3389 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real Demo browser walk at `/dev/tools`, confirming the Chinese header, `新手引导` sidebar item, named `筛选工具…` input, localized empty guidance, successful filter input, and absence of the old English entry copy