### PR TITLE
Make market board results keyboard accessible

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -774,6 +774,7 @@ export const en = {
     title: 'Simulator',
   },
   market: {
+    openSymbol: 'Open {{symbol}} details',
     searchPlaceholder: 'Search assets…',
     browseSection: 'Browse',
     browseMarkets: 'Browse Markets',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -763,6 +763,7 @@ export const ja: Resources = {
     title: 'シミュレーター',
   },
   market: {
+    openSymbol: '{{symbol}} の詳細を開く',
     searchPlaceholder: '銘柄を検索…',
     browseSection: '閲覧',
     browseMarkets: 'マーケットを見る',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -771,6 +771,7 @@ export const zhHant: Resources = {
     title: '模擬器',
   },
   market: {
+    openSymbol: '開啟 {{symbol}} 詳情',
     searchPlaceholder: '搜尋資產…',
     browseSection: '瀏覽',
     browseMarkets: '瀏覽市場',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -763,6 +763,7 @@ export const zh: Resources = {
     title: '模拟器',
   },
   market: {
+    openSymbol: '打开 {{symbol}} 详情',
     searchPlaceholder: '搜索资产…',
     browseSection: '浏览',
     browseMarkets: '浏览市场',

--- a/ui/src/pages/MarketBoardPage.spec.tsx
+++ b/ui/src/pages/MarketBoardPage.spec.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { MarketBoardPage } from './MarketBoardPage'
+
+const mocks = vi.hoisted(() => ({
+  openOrFocus: vi.fn(),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: typeof mocks.openOrFocus }) => unknown) =>
+    selector({ openOrFocus: mocks.openOrFocus }),
+}))
+
+vi.mock('../components/market/BoardMeta', () => ({
+  BoardMeta: () => null,
+}))
+
+vi.mock('../components/market/useReferenceBoard', () => ({
+  useReferenceBoard: () => ({
+    data: {
+      meta: {},
+      gainers: [{
+        symbol: 'NVDA',
+        name: 'NVIDIA Corporation',
+        price: 1042.1,
+        percent_change: 0.062,
+        volume: 51_000_000,
+        relative_volume: 1.8,
+        dollar_volume: 53_150_000_000,
+      }],
+      losers: [],
+      active: [],
+      undervaluedGrowth: [],
+      growthTech: [],
+      smallCaps: [],
+      undervaluedLarge: [],
+    },
+    updatedAt: null,
+    loading: false,
+    error: null,
+  }),
+}))
+
+beforeEach(async () => {
+  mocks.openOrFocus.mockReset()
+  await i18n.changeLanguage('zh')
+})
+
+afterEach(cleanup)
+
+describe('MarketBoardPage', () => {
+  it('opens an equity detail from the keyboard-accessible symbol control', async () => {
+    const user = userEvent.setup()
+    render(
+      <MarketBoardPage
+        spec={{ kind: 'market-board', params: { board: 'movers' } }}
+        visible
+      />,
+    )
+
+    const detailButton = screen.getByRole('button', { name: '打开 NVDA 详情' })
+    detailButton.focus()
+    await user.keyboard('{Enter}')
+
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'market-detail',
+      params: { assetClass: 'equity', symbol: 'NVDA' },
+    })
+  })
+})

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -111,7 +111,7 @@ function listLabelKey(k: MoversList) {
 
 function MoversTable({ rows }: { rows: MoverRow[] }) {
   const { t } = useTranslation()
-  const openOrFocus = useWorkspace((s) => s.openOrFocus)
+  const open = useOpenEquity()
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-[12px] border-collapse">
@@ -130,11 +130,10 @@ function MoversTable({ rows }: { rows: MoverRow[] }) {
             <tr
               key={r.symbol}
               className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer"
-              onClick={() => openOrFocus({ kind: 'market-detail', params: { assetClass: 'equity', symbol: r.symbol } })}
+              onClick={() => open(r.symbol)}
             >
               <td className="py-1.5 pr-3">
-                <span className="font-mono font-semibold text-foreground">{r.symbol}</span>
-                {r.name && <span className="ml-2 text-muted-foreground">{r.name}</span>}
+                <EquityDetailButton symbol={r.symbol} name={r.name} />
               </td>
               <td className="py-1.5 px-3 text-right font-mono text-foreground">{fmtPrice(r.price)}</td>
               <td className={`py-1.5 px-3 text-right font-mono ${signColor(r.percent_change)}`}>{fmtPct(r.percent_change)}</td>
@@ -234,6 +233,34 @@ function useOpenEquity() {
   }
 }
 
+function EquityDetailButton({
+  symbol,
+  name,
+}: {
+  symbol: string | null
+  name?: string | null
+}) {
+  const { t } = useTranslation()
+  const open = useOpenEquity()
+
+  if (!symbol) return <span className="font-mono text-muted-foreground">—</span>
+
+  return (
+    <button
+      type="button"
+      aria-label={t('market.openSymbol', { symbol })}
+      onClick={(event) => {
+        event.stopPropagation()
+        open(symbol)
+      }}
+      className="inline-flex max-w-full items-baseline gap-2 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+    >
+      <span className="font-mono font-semibold text-foreground">{symbol}</span>
+      {name && <span className="truncate text-muted-foreground">{name}</span>}
+    </button>
+  )
+}
+
 function EarningsTable({ board }: { board: CalendarBoard }) {
   const { t } = useTranslation()
   const open = useOpenEquity()
@@ -245,8 +272,7 @@ function EarningsTable({ board }: { board: CalendarBoard }) {
         <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
           <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">{r.report_date}</td>
           <td className="py-1.5 px-3">
-            <span className="font-mono font-semibold text-foreground">{r.symbol}</span>
-            {r.name && <span className="ml-2 text-muted-foreground">{r.name}</span>}
+            <EquityDetailButton symbol={r.symbol} name={r.name} />
           </td>
           <td className="py-1.5 px-3 text-right font-mono text-foreground">{r.eps_previous ?? '—'}</td>
           <td className="py-1.5 pl-3 text-right font-mono text-foreground">{r.eps_consensus ?? '—'}</td>
@@ -262,16 +288,23 @@ function IpoTable({ board }: { board: CalendarBoard }) {
   const rows = [...board.ipos].sort((a, b) => (a.ipo_date ?? '').localeCompare(b.ipo_date ?? ''))
   return (
     <CalTable head={[t('market.colDate'), t('market.colSymbol'), t('market.colExchange')]}>
-      {rows.map((r, i) => (
-        <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
-          <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">{r.ipo_date ?? '—'}</td>
-          <td className="py-1.5 px-3">
-            <span className="font-mono font-semibold text-foreground">{r.symbol ?? '—'}</span>
-            {typeof r.name === 'string' && r.name && <span className="ml-2 text-muted-foreground">{r.name}</span>}
-          </td>
-          <td className="py-1.5 pl-3 text-muted-foreground">{typeof r.exchange === 'string' ? r.exchange : '—'}</td>
-        </tr>
-      ))}
+      {rows.map((r, i) => {
+        const symbol = typeof r.symbol === 'string' ? r.symbol : null
+        const name = typeof r.name === 'string' ? r.name : null
+        return (
+          <tr
+            key={`${r.symbol}-${i}`}
+            className={`border-b border-border/50 hover:bg-secondary/40 ${symbol ? 'cursor-pointer' : ''}`}
+            onClick={symbol ? () => open(symbol) : undefined}
+          >
+            <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">{r.ipo_date ?? '—'}</td>
+            <td className="py-1.5 px-3">
+              <EquityDetailButton symbol={symbol} name={name} />
+            </td>
+            <td className="py-1.5 pl-3 text-muted-foreground">{typeof r.exchange === 'string' ? r.exchange : '—'}</td>
+          </tr>
+        )
+      })}
     </CalTable>
   )
 }
@@ -286,8 +319,7 @@ function DividendTable({ board }: { board: CalendarBoard }) {
         <tr key={`${r.symbol}-${i}`} className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer" onClick={() => open(r.symbol)}>
           <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">{r.ex_dividend_date}</td>
           <td className="py-1.5 px-3">
-            <span className="font-mono font-semibold text-foreground">{r.symbol}</span>
-            {r.name && <span className="ml-2 text-muted-foreground">{r.name}</span>}
+            <EquityDetailButton symbol={r.symbol} name={r.name} />
           </td>
           <td className="py-1.5 px-3 text-right font-mono text-foreground">{r.amount ?? '—'}</td>
           <td className="py-1.5 pl-3 text-muted-foreground whitespace-nowrap">{r.payment_date ?? '—'}</td>


### PR DESCRIPTION
## Summary
- add native, focusable equity-detail controls to Movers, earnings, IPO, and dividend result tables
- preserve the existing whole-row mouse action while preventing nested controls from opening the detail twice
- give each control a localized, symbol-specific accessible name across all four UI languages
- avoid presenting symbol-less IPO rows as clickable
- add a focused keyboard navigation regression test

## Problem
Market board result rows looked and behaved like links for pointer users, but their table bodies contained no focusable controls and the rows had no keyboard behavior. On the Demo Movers board, all three results were therefore unreachable from the keyboard.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/pages/MarketBoardPage.spec.tsx` (1 test)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (358 passed, 1 skipped test files; 3389 passed, 9 skipped tests)
- `pnpm -F open-alice-ui build:demo`
- real Demo browser walk at `/market/boards/movers`: confirmed three named detail buttons, opened NVDA with Enter, and confirmed the original whole-row mouse click still opens the same detail