### PR TITLE
Localize the tradeable contracts panel

### DIFF
--- a/ui/src/components/market/TradeableContractsPanel.spec.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.spec.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../../i18n'
+import { TradeableContractsPanel } from './TradeableContractsPanel'
+
+const mocks = vi.hoisted(() => ({
+  searchContracts: vi.fn(),
+}))
+
+vi.mock('../../api/trading', () => ({
+  tradingApi: {
+    searchContracts: mocks.searchContracts,
+  },
+}))
+
+const hit = (symbol: string, aliceId: string) => ({
+  source: 'alpaca-paper',
+  contract: {
+    symbol,
+    secType: 'STK',
+    description: `${symbol} equity`,
+    primaryExchange: 'NASDAQ',
+    currency: 'USD',
+    aliceId,
+  },
+})
+
+beforeEach(async () => {
+  mocks.searchContracts.mockReset()
+  await i18n.changeLanguage('zh')
+})
+
+afterEach(cleanup)
+
+describe('TradeableContractsPanel', () => {
+  it('localizes contract expansion and order-entry actions', async () => {
+    mocks.searchContracts.mockResolvedValue({
+      utasConfigured: 1,
+      results: [
+        hit('AAPL', 'alpaca:stock:AAPL'),
+        hit('MSFT', 'alpaca:stock:MSFT'),
+        hit('NVDA', 'alpaca:stock:NVDA'),
+        hit('GOOG', 'alpaca:stock:GOOG'),
+      ],
+    })
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <TradeableContractsPanel symbol="AAPL" assetClass="equity" />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('已配置券商中的可交易合约')).toBeTruthy()
+    expect(screen.getAllByRole('link', { name: '下单 →' })).toHaveLength(3)
+
+    await user.click(screen.getByRole('button', { name: '再显示 1 项（共 4 项）' }))
+
+    expect(screen.getAllByRole('link', { name: '下单 →' })).toHaveLength(4)
+    expect(screen.getByRole('button', { name: '收起' })).toBeTruthy()
+  })
+
+  it('localizes the no-match state with the requested symbol', async () => {
+    mocks.searchContracts.mockResolvedValue({ utasConfigured: 1, results: [] })
+
+    render(
+      <MemoryRouter>
+        <TradeableContractsPanel symbol="AAPL" assetClass="equity" />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('已配置券商中没有与 AAPL 匹配的可交易合约。')).toBeTruthy()
+  })
+
+  it('keeps the localized Trading setup action navigable', async () => {
+    mocks.searchContracts.mockResolvedValue({ utasConfigured: 0, results: [] })
+
+    render(
+      <MemoryRouter>
+        <TradeableContractsPanel symbol="AAPL" assetClass="equity" />
+      </MemoryRouter>,
+    )
+
+    const setupLink = await screen.findByRole('link', { name: '前往“交易”添加' })
+    expect(setupLink.getAttribute('href')).toBe('/trading')
+    expect(setupLink.parentElement?.textContent).toBe(
+      '尚未配置交易账户。前往“交易”添加，即可在此查看匹配合约。',
+    )
+  })
+})

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { tradingApi, type ContractSearchHit } from '../../api/trading'
 import type { AssetClass } from '../../api/market'
@@ -22,6 +23,7 @@ interface Props {
 const COLLAPSED_LIMIT = 3
 
 export function TradeableContractsPanel({ symbol, assetClass }: Props) {
+  const { t } = useTranslation()
   const [hits, setHits] = useState<ContractSearchHit[] | null>(null)
   const [utasConfigured, setAccountsConfigured] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
@@ -44,30 +46,25 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
     return () => { cancelled = true }
   }, [symbol, assetClass])
 
-  const info = [
-    'Endpoint: /api/trading/contracts/search',
-    'Heuristic broker-side fuzzy match — symbol on the analysis side is just a query string here, not the canonical id.',
-    'Tradeable identity is the broker\u2019s aliceId (alias:broker:exchange-id). Use it to actually place orders.',
-  ].join('\n')
-
   return (
-    <Card title="Tradeable on configured brokers" info={info}>
-      {loading && <div className="text-[12px] text-muted-foreground">Searching brokers…</div>}
+    <Card title={t('market.tradeableTitle')} info={t('market.tradeableInfo')}>
+      {loading && <div className="text-[12px] text-muted-foreground">{t('market.tradeableSearching')}</div>}
       {error && !loading && <div className="text-[12px] text-destructive">{error}</div>}
 
       {!loading && !error && utasConfigured === 0 && (
         <div className="text-[12px] text-muted-foreground">
-          No trading accounts configured.{' '}
-          <Link to="/trading" className="text-primary hover:underline">
-            Add one in Trading
-          </Link>
-          {' '}to see matching contracts here.
+          <Trans
+            i18nKey="market.tradeableNoAccounts"
+            components={{
+              tradingLink: <Link to="/trading" className="text-primary hover:underline" />,
+            }}
+          />
         </div>
       )}
 
       {!loading && !error && utasConfigured !== 0 && hits && hits.length === 0 && (
         <div className="text-[12px] text-muted-foreground">
-          No tradeable contracts matching <span className="font-mono">{symbol}</span> on your configured brokers.
+          {t('market.tradeableNoMatches', { symbol })}
         </div>
       )}
 
@@ -88,7 +85,9 @@ export function TradeableContractsPanel({ symbol, assetClass }: Props) {
                 onClick={() => setExpanded((v) => !v)}
                 className="mt-2 text-[11px] text-muted-foreground/70 hover:text-primary transition-colors cursor-pointer"
               >
-                {expanded ? `Show fewer` : `Show ${hidden} more (${sorted.length} total)`}
+                {expanded
+                  ? t('market.tradeableShowFewer')
+                  : t('market.tradeableShowMore', { hidden, total: sorted.length })}
               </button>
             )}
           </>
@@ -125,6 +124,7 @@ function byInstrumentFamiliarity(a: ContractSearchHit, b: ContractSearchHit): nu
 }
 
 function ContractRow({ hit }: { hit: ContractSearchHit }) {
+  const { t } = useTranslation()
   const c = hit.contract
   const aliceId = c.aliceId as string | undefined
   // Bridge to the UTA detail page's order entry — clicking jumps the
@@ -159,9 +159,9 @@ function ContractRow({ hit }: { hit: ContractSearchHit }) {
         <Link
           to={orderHref}
           className="text-[11px] text-primary hover:underline shrink-0"
-          title="Open order entry on the UTA"
+          title={t('market.tradeableOrderTitle')}
         >
-          Order →
+          {t('market.tradeableOrder')} →
         </Link>
       )}
     </li>

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -774,6 +774,17 @@ export const en = {
     title: 'Simulator',
   },
   market: {
+    tradeableTitle: 'Tradeable on configured brokers',
+    tradeableInfo:
+      'Endpoint: /api/trading/contracts/search\nHeuristic broker-side fuzzy match — the analysis symbol is a query, not the canonical id.\nTradeable identity is the broker’s aliceId (alias:broker:exchange-id). Use it to place orders.',
+    tradeableSearching: 'Searching brokers…',
+    tradeableNoAccounts:
+      'No trading accounts configured. <tradingLink>Add one in Trading</tradingLink> to see matching contracts here.',
+    tradeableNoMatches: 'No tradeable contracts matching {{symbol}} on your configured brokers.',
+    tradeableShowFewer: 'Show fewer',
+    tradeableShowMore: 'Show {{hidden}} more ({{total}} total)',
+    tradeableOrderTitle: 'Open order entry on the UTA',
+    tradeableOrder: 'Order',
     searchPlaceholder: 'Search assets…',
     browseSection: 'Browse',
     browseMarkets: 'Browse Markets',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -763,6 +763,17 @@ export const ja: Resources = {
     title: 'シミュレーター',
   },
   market: {
+    tradeableTitle: '設定済みブローカーで取引可能',
+    tradeableInfo:
+      'エンドポイント：/api/trading/contracts/search\nブローカー側でヒューリスティックなあいまい検索を行います。分析画面のシンボルは検索条件であり、正規 ID ではありません。\n取引時はブローカーの aliceId（alias:broker:exchange-id）を使用します。',
+    tradeableSearching: 'ブローカーを検索中…',
+    tradeableNoAccounts:
+      '取引口座が設定されていません。<tradingLink>「取引」で追加</tradingLink>すると、一致する取引商品を確認できます。',
+    tradeableNoMatches: '設定済みブローカーに {{symbol}} と一致する取引可能な商品はありません。',
+    tradeableShowFewer: '折りたたむ',
+    tradeableShowMore: 'ほか {{hidden}} 件を表示（全 {{total}} 件）',
+    tradeableOrderTitle: '対応する UTA の注文画面を開く',
+    tradeableOrder: '注文',
     searchPlaceholder: '銘柄を検索…',
     browseSection: '閲覧',
     browseMarkets: 'マーケットを見る',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -771,6 +771,17 @@ export const zhHant: Resources = {
     title: '模擬器',
   },
   market: {
+    tradeableTitle: '已設定券商中的可交易合約',
+    tradeableInfo:
+      '介面：/api/trading/contracts/search\n透過券商端啟發式模糊比對；分析頁標的是查詢條件，並非標準識別碼。\n可交易身分以券商的 aliceId（alias:broker:exchange-id）為準，下單時請使用它。',
+    tradeableSearching: '正在搜尋券商…',
+    tradeableNoAccounts:
+      '尚未設定交易帳戶。<tradingLink>前往「交易」新增</tradingLink>，即可在此查看相符合約。',
+    tradeableNoMatches: '已設定券商中沒有與 {{symbol}} 相符的可交易合約。',
+    tradeableShowFewer: '收合',
+    tradeableShowMore: '再顯示 {{hidden}} 項（共 {{total}} 項）',
+    tradeableOrderTitle: '在對應 UTA 中開啟下單面板',
+    tradeableOrder: '下單',
     searchPlaceholder: '搜尋資產…',
     browseSection: '瀏覽',
     browseMarkets: '瀏覽市場',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -763,6 +763,17 @@ export const zh: Resources = {
     title: '模拟器',
   },
   market: {
+    tradeableTitle: '已配置券商中的可交易合约',
+    tradeableInfo:
+      '接口：/api/trading/contracts/search\n通过券商侧启发式模糊匹配；分析页标的是查询条件，并非规范标识。\n可交易身份以券商的 aliceId（alias:broker:exchange-id）为准，下单时请使用它。',
+    tradeableSearching: '正在搜索券商…',
+    tradeableNoAccounts:
+      '尚未配置交易账户。<tradingLink>前往“交易”添加</tradingLink>，即可在此查看匹配合约。',
+    tradeableNoMatches: '已配置券商中没有与 {{symbol}} 匹配的可交易合约。',
+    tradeableShowFewer: '收起',
+    tradeableShowMore: '再显示 {{hidden}} 项（共 {{total}} 项）',
+    tradeableOrderTitle: '在对应 UTA 中打开下单面板',
+    tradeableOrder: '下单',
     searchPlaceholder: '搜索资产…',
     browseSection: '浏览',
     browseMarkets: '浏览市场',


### PR DESCRIPTION
## Summary
- localize the Tradeable Contracts panel across all four supported UI languages
- cover loading, account setup, no-match, expansion, and order-entry actions
- preserve the embedded Trading setup link and symbol-specific contract guidance
- add focused rendering coverage for multi-contract expansion, no matches, and no configured accounts

## Problem
On a Chinese Market detail route, the entire broker-contract bridge still rendered in English: panel title, explanation, empty state, expansion action, and order links. This made a primary transition from analysis to trading inconsistent with the selected interface language.

## Verification
- `pnpm -F open-alice-ui exec vitest run src/components/market/TradeableContractsPanel.spec.tsx` (3 tests)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3391 passed, 9 skipped)
- `pnpm -F open-alice-ui build:demo`
- real Demo browser walk at `/market/equity/AAPL`, confirming the localized panel title, technical help, and symbol-specific no-match state, with the old English component copy absent