### PR TITLE
fix(ibkr): accept delayed quote fallback

### DIFF
--- a/services/uta/src/domain/trading/brokers/ibkr/request-bridge.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/request-bridge.spec.ts
@@ -132,6 +132,18 @@ describe('RequestBridge — error routing', () => {
     await expect(promise).rejects.toThrow(/subscription/)
   })
 
+  it('keeps snapshots open when 10167 announces delayed market data', async () => {
+    const b = new RequestBridge()
+    const promise = b.requestSnapshot(9002, 5000)
+
+    b.error(9002, 0, 10167, 'Requested market data is not subscribed. Displaying delayed market data.')
+    b.tickPrice(9002, TickTypeEnum.DELAYED_BID, 214.1, {} as never)
+    b.tickPrice(9002, TickTypeEnum.DELAYED_ASK, 214.14, {} as never)
+    b.tickSnapshotEnd(9002)
+
+    await expect(promise).resolves.toMatchObject({ bid: 214.1, ask: 214.14 })
+  })
+
   it('still ignores 21xx farm-status noise', () => {
     const b = new RequestBridge()
     // no pending request — must simply not throw

--- a/services/uta/src/domain/trading/brokers/ibkr/request-bridge.ts
+++ b/services/uta/src/domain/trading/brokers/ibkr/request-bridge.ts
@@ -506,6 +506,10 @@ export class RequestBridge extends DefaultEWrapper {
     }
 
     // Request-specific errors — reject the corresponding pending Promise
+    // 10167 announces that IBKR is falling back to delayed ticks after
+    // reqMarketDataType(3). Keep that snapshot open for DELAYED_* callbacks.
+    if (errorCode === 10167 && this.snapshots.has(reqId)) return
+
     const brokerError = classifyIbkrError(errorCode, errorString)
 
     // Try reqId-based first, then orderId-based


### PR DESCRIPTION
## Summary
- keep active market-data snapshots open when IBKR code 10167 announces delayed fallback
- continue rejecting real subscription error 10089
- cover delayed bid/ask resolution through snapshot end

## Verification
- RED: targeted RequestBridge spec rejected 10167 before delayed ticks
- GREEN: targeted spec 19/19
- `npx tsc --noEmit` equivalent via pinned pnpm worktree
- `pnpm test`: 357 files passed, 3389 tests passed, 9 skipped

No order path or trading permission changed.