### PR TITLE
Integrate reviewed loading recovery batch

### DIFF
--- a/ui/src/hooks/useConfigPage.ts
+++ b/ui/src/hooks/useConfigPage.ts
@@ -20,6 +20,8 @@ interface UseConfigPageResult<T> {
   updateConfig: (patch: Partial<T>) => void
   /** Update config and immediately flush (no debounce) */
   updateConfigImmediate: (patch: Partial<T>) => void
+  /** Retry the initial config read after a transient failure */
+  reload: () => Promise<void>
   retry: () => void
 }
 
@@ -36,16 +38,23 @@ export function useConfigPage<T extends object>({
   const [config, setConfig] = useState<T | null>(null)
   const [loadError, setLoadError] = useState(false)
   const flushRequestedRef = useRef(false)
+  const extractRef = useRef(extract)
+  extractRef.current = extract
+
+  const reload = useCallback(async () => {
+    setLoadError(false)
+    try {
+      const full = await api.config.load()
+      setFullConfig(full)
+      setConfig(extractRef.current(full))
+    } catch {
+      setLoadError(true)
+    }
+  }, [])
 
   useEffect(() => {
-    api.config
-      .load()
-      .then((full) => {
-        setFullConfig(full)
-        setConfig(extract(full))
-      })
-      .catch(() => setLoadError(true))
-  }, []) // extract is stable (caller should memoize or use inline arrow)
+    void reload()
+  }, [reload])
 
   const saveConfig = useCallback(
     async (data: T) => {
@@ -83,5 +92,5 @@ export function useConfigPage<T extends object>({
     flushRequestedRef.current = true
   }, [])
 
-  return { config, fullConfig, status, loadError, updateConfig, updateConfigImmediate, retry }
+  return { config, fullConfig, status, loadError, updateConfig, updateConfigImmediate, reload, retry }
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -177,6 +177,8 @@ export const en = {
     },
     agentPermissions: {
       title: 'Agent Permissions',
+      loadErrorTitle: 'Couldn’t load Agent Permissions',
+      loadErrorDescription: 'OpenAlice could not read the current configuration. Your permissions have not been changed.',
       mode: {
         title: 'Trading mode',
         description: 'Global broker capability for Alice and workspace agents.',

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -215,6 +215,7 @@ export const en = {
     },
     tools: {
       summary: '{{tools}} tools in {{groups}} groups — changes apply on next AI request',
+      loadError: 'Could not load the tool catalog.',
       emptyTitle: 'No tools registered.',
       emptyDescription: 'Tools will appear here when the engine starts.',
       group: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -234,6 +234,8 @@ export const en = {
   aiProvider: {
     title: 'AI Provider',
     description: 'Provider accounts and model defaults Alice can inject into workspaces.',
+    loadErrorTitle: 'Couldn’t load AI credentials',
+    loadErrorDescription: 'OpenAlice could not read the credential vault. Your saved credentials have not been changed.',
     vaultIntro: "API keys are kept centrally. New workspaces can receive a chosen default, and any workspace can load a saved credential. Subscription logins stay in the agent CLI (claude login / codex login).",
     credentials: 'Credentials',
     addFirst: 'Add your first credential',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -204,6 +204,7 @@ export const ja: Resources = {
     },
     tools: {
       summary: '{{groups}} グループ {{tools}} ツール——変更は次回の AI リクエストで反映されます',
+      loadError: 'ツールカタログを読み込めませんでした。',
       emptyTitle: '登録されたツールはありません。',
       emptyDescription: 'エンジンが起動するとツールがここに表示されます。',
       group: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -223,6 +223,8 @@ export const ja: Resources = {
   aiProvider: {
     title: 'AI プロバイダー',
     description: 'Alice がワークスペースへ注入できるプロバイダーアカウントとモデル既定値を管理します。',
+    loadErrorTitle: 'AI 認証情報を読み込めませんでした',
+    loadErrorDescription: 'OpenAlice は認証情報の保管庫を読み取れませんでした。保存済みの認証情報は変更されていません。',
     vaultIntro: 'API キーは Alice が一元管理します。新しいワークスペースには選択した既定の認証情報を書き込め、任意のワークスペースから保存済み認証情報を読み込めます。サブスクリプションのログインは agent CLI 側で管理します（claude login / codex login）。',
     credentials: '認証情報',
     addFirst: '最初の認証情報を追加',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -166,6 +166,8 @@ export const ja: Resources = {
     },
     agentPermissions: {
       title: 'エージェント権限',
+      loadErrorTitle: 'エージェント権限を読み込めませんでした',
+      loadErrorDescription: 'OpenAlice は現在の設定を読み取れませんでした。権限は変更されていません。',
       mode: {
         title: '取引モード',
         description: 'Alice とワークスペースエージェントのグローバルなブローカー権限。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -174,6 +174,8 @@ export const zhHant: Resources = {
     },
     agentPermissions: {
       title: '智慧體權限',
+      loadErrorTitle: '無法載入智慧體權限',
+      loadErrorDescription: 'OpenAlice 無法讀取目前設定。你的權限沒有變更。',
       mode: {
         title: '交易模式',
         description: 'Alice 與工作區智慧體的全域券商能力。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -231,6 +231,8 @@ export const zhHant: Resources = {
   aiProvider: {
     title: 'AI 供應方',
     description: '管理 Alice 可注入工作區的供應方帳戶與模型預設值。',
+    loadErrorTitle: '無法載入 AI 憑證',
+    loadErrorDescription: 'OpenAlice 無法讀取憑證庫。你已儲存的憑證沒有變更。',
     vaultIntro: 'API key 由 Alice 集中保管。新工作區可以寫入所選的預設憑證，任何工作區也都能載入已儲存憑證。訂閱登入仍由 agent CLI 自行管理（claude login / codex login）。',
     credentials: '憑證庫',
     addFirst: '新增第一個憑證',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -212,6 +212,7 @@ export const zhHant: Resources = {
     },
     tools: {
       summary: '{{groups}} 個分組共 {{tools}} 個工具——變更會在下次 AI 請求時生效',
+      loadError: '無法載入工具目錄。',
       emptyTitle: '尚未註冊任何工具。',
       emptyDescription: '引擎啟動後工具會顯示在這裡。',
       group: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -223,6 +223,8 @@ export const zh: Resources = {
   aiProvider: {
     title: 'AI 提供方',
     description: '管理 Alice 可注入工作区的提供方账户和模型默认值。',
+    loadErrorTitle: '无法加载 AI 凭证',
+    loadErrorDescription: 'OpenAlice 无法读取凭证库。你已保存的凭证没有发生变化。',
     vaultIntro: 'API key 由 Alice 集中保管。新工作区可以写入选定的默认凭证，任何工作区也都能载入已保存凭证。订阅登录仍由 agent CLI 自己管理（claude login / codex login）。',
     credentials: '凭证库',
     addFirst: '添加第一个凭证',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -204,6 +204,7 @@ export const zh: Resources = {
     },
     tools: {
       summary: '{{groups}} 个分组共 {{tools}} 个工具——更改在下次 AI 请求时生效',
+      loadError: '无法加载工具目录。',
       emptyTitle: '尚未注册任何工具。',
       emptyDescription: '引擎启动后工具会显示在这里。',
       group: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -166,6 +166,8 @@ export const zh: Resources = {
     },
     agentPermissions: {
       title: '智能体权限',
+      loadErrorTitle: '无法加载智能体权限',
+      loadErrorDescription: 'OpenAlice 无法读取当前配置。你的权限没有发生变化。',
       mode: {
         title: '交易模式',
         description: 'Alice 和工作区智能体的全局券商能力。',

--- a/ui/src/pages/AIProviderPage.loading.spec.tsx
+++ b/ui/src/pages/AIProviderPage.loading.spec.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { AIProviderPage } from './AIProviderPage'
+
+const mocks = vi.hoisted(() => ({
+  getCredentials: vi.fn(),
+  getPresets: vi.fn(),
+  getWorkspaceCredentialDefaults: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    config: {
+      getCredentials: mocks.getCredentials,
+      getPresets: mocks.getPresets,
+      getWorkspaceCredentialDefaults: mocks.getWorkspaceCredentialDefaults,
+    },
+  },
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+  mocks.getPresets.mockResolvedValue({ presets: [] })
+  mocks.getWorkspaceCredentialDefaults.mockResolvedValue({
+    defaults: {},
+    compatibleByAgent: {},
+  })
+})
+
+afterEach(cleanup)
+
+describe('AIProviderPage credential loading', () => {
+  it('distinguishes a failed vault read from an empty vault and retries', async () => {
+    mocks.getCredentials
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ credentials: [] })
+
+    render(<AIProviderPage />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Your saved credentials have not been changed.')
+    expect(screen.queryByRole('button', { name: /Add your first credential/ })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.getCredentials).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('button', { name: /Add your first credential/ })).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -14,7 +14,7 @@
  * helper: it carries each vendor's endpoint + model suggestions + request shape.
  */
 
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, type Preset, type WireShape } from '../api'
 import type {
@@ -93,15 +93,25 @@ const AGENT_RUNTIMES: RuntimeInfo[] = [
 export function AIProviderPage() {
   const { t } = useTranslation()
   const [credentials, setCredentials] = useState<CredentialSummary[] | null>(null)
+  const [credentialsLoadError, setCredentialsLoadError] = useState(false)
   const [presets, setPresets] = useState<Preset[]>([])
   const [modal, setModal] = useState<{ mode: 'add' } | { mode: 'edit'; cred: CredentialSummary } | null>(null)
 
-  const reload = () => api.config.getCredentials().then(({ credentials: c }) => setCredentials(c)).catch(() => setCredentials([]))
+  const reload = useCallback(async () => {
+    setCredentials(null)
+    setCredentialsLoadError(false)
+    try {
+      const { credentials: next } = await api.config.getCredentials()
+      setCredentials(next)
+    } catch {
+      setCredentialsLoadError(true)
+    }
+  }, [])
 
   useEffect(() => {
     void reload()
     api.config.getPresets().then(({ presets: p }) => setPresets(p)).catch(() => {})
-  }, [])
+  }, [reload])
 
   const apiKeyPresets = useMemo(() => presets.filter(isApiKeyPreset), [presets])
 
@@ -118,7 +128,21 @@ export function AIProviderPage() {
     return (
       <div className="flex flex-col flex-1 min-h-0">
         <PageHeader title={t('aiProvider.title')} description={t('aiProvider.description')} />
-        <PageLoading />
+        {credentialsLoadError ? (
+          <div className="flex flex-1 items-center justify-center px-6 py-12">
+            <div role="alert" className="max-w-md text-center">
+              <h2 className="text-sm font-semibold text-foreground">{t('aiProvider.loadErrorTitle')}</h2>
+              <p className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
+                {t('aiProvider.loadErrorDescription')}
+              </p>
+              <button type="button" className="btn-secondary-sm mt-4" onClick={() => void reload()}>
+                {t('common.retry')}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <PageLoading />
+        )}
       </div>
     )
   }

--- a/ui/src/pages/AgentPermissionsPage.spec.tsx
+++ b/ui/src/pages/AgentPermissionsPage.spec.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { AgentPermissionsPage } from './AgentPermissionsPage'
+
+const mocks = vi.hoisted(() => ({
+  ensureTradingModePolling: vi.fn(),
+  loadConfig: vi.fn(),
+  setMode: vi.fn(),
+  updateSection: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    config: {
+      load: mocks.loadConfig,
+      updateSection: mocks.updateSection,
+    },
+  },
+}))
+
+vi.mock('../live/trading-mode', () => ({
+  ensureTradingModePolling: mocks.ensureTradingModePolling,
+  useTradingMode: (selector: (state: {
+    status: {
+      mode: 'lite'
+      modeSource: 'default'
+      envLocked: false
+    }
+    loading: false
+    saving: null
+    error: null
+    setMode: typeof mocks.setMode
+  }) => unknown) => selector({
+    status: {
+      mode: 'lite',
+      modeSource: 'default',
+      envLocked: false,
+    },
+    loading: false,
+    saving: null,
+    error: null,
+    setMode: mocks.setMode,
+  }),
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('AgentPermissionsPage', () => {
+  it('explains a configuration load failure and recovers on retry', async () => {
+    mocks.loadConfig
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({})
+
+    render(<AgentPermissionsPage />)
+
+    const alert = await screen.findByRole('alert')
+    expect(screen.getByRole('heading', { name: 'Agent Permissions' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Couldn’t load Agent Permissions' })).toBeTruthy()
+    expect(alert.textContent).toContain('Your permissions have not been changed.')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.loadConfig).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('heading', { name: 'Trading mode' })).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/AgentPermissionsPage.tsx
+++ b/ui/src/pages/AgentPermissionsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type Dispatch, type ReactNode, type SetStateAction } from 'react'
-import { Gauge, LockKeyhole, ShieldCheck, type LucideIcon } from 'lucide-react'
+import { CircleAlert, Gauge, LockKeyhole, ShieldCheck, type LucideIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { api, type AppConfig } from '../api'
@@ -38,28 +38,69 @@ const MODES: TradingMode[] = ['lite', 'readonly', 'pro']
 export function AgentPermissionsPage() {
   const { t } = useTranslation()
   const [config, setConfig] = useState<AppConfig | null>(null)
+  const [loadError, setLoadError] = useState(false)
+
+  const loadConfig = useCallback(async () => {
+    setConfig(null)
+    setLoadError(false)
+    try {
+      setConfig(await api.config.load())
+    } catch {
+      setLoadError(true)
+    }
+  }, [])
 
   useEffect(() => {
     ensureTradingModePolling()
-    api.config.load().then(setConfig).catch(() => {})
-  }, [])
-
-  if (!config) return <PageLoading />
+    void loadConfig()
+  }, [loadConfig])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader title={t('settings.agentPermissions.title')} />
-      <SettingsScrollArea>
-        <div className="mx-auto w-full max-w-[980px] px-4 md:px-6">
-          <TradingModeSection />
-          <PermissionSection
-            title={t('settings.agentPermissions.aiPush.title')}
-            description={t('settings.agentPermissions.aiPush.description')}
-          >
-            <AiTradingToggle config={config} setConfig={setConfig} />
-          </PermissionSection>
-        </div>
-      </SettingsScrollArea>
+      {!config ? (
+        loadError ? <PermissionsLoadError onRetry={() => void loadConfig()} /> : <PageLoading />
+      ) : (
+        <SettingsScrollArea>
+          <div className="mx-auto w-full max-w-[980px] px-4 md:px-6">
+            <TradingModeSection />
+            <PermissionSection
+              title={t('settings.agentPermissions.aiPush.title')}
+              description={t('settings.agentPermissions.aiPush.description')}
+            >
+              <AiTradingToggle config={config} setConfig={setConfig} />
+            </PermissionSection>
+          </div>
+        </SettingsScrollArea>
+      )}
+    </div>
+  )
+}
+
+function PermissionsLoadError({ onRetry }: { onRetry: () => void }) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-6 py-12">
+      <div
+        role="alert"
+        className="flex max-w-md flex-col items-center rounded-xl border border-destructive/30 bg-destructive/5 px-6 py-7 text-center"
+      >
+        <CircleAlert className="mb-3 text-destructive" size={28} strokeWidth={1.7} aria-hidden />
+        <h2 className="text-sm font-semibold text-foreground">
+          {t('settings.agentPermissions.loadErrorTitle')}
+        </h2>
+        <p className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
+          {t('settings.agentPermissions.loadErrorDescription')}
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-5 rounded-md border border-border bg-background px-3.5 py-2 text-[12px] font-medium text-foreground transition-colors hover:border-primary/50 hover:bg-muted"
+        >
+          {t('common.retry')}
+        </button>
+      </div>
     </div>
   )
 }

--- a/ui/src/pages/LogsPage.spec.tsx
+++ b/ui/src/pages/LogsPage.spec.tsx
@@ -118,6 +118,23 @@ describe('LogsPage Agent conversations', () => {
     expect(screen.getByText('No tool calls yet')).toBeTruthy()
   })
 
+  it('distinguishes an unavailable tool-call log from an empty log', async () => {
+    mocks.toolQuery.mockRejectedValueOnce(new Error('offline'))
+    render(<LogsPage />)
+    await screen.findByText(/2 conversations/)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tool calls' }))
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not load tool calls')
+    expect(screen.getByText('Tool calls unavailable')).toBeTruthy()
+    expect(screen.queryByText('No tool calls yet')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.toolQuery).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('No tool calls yet')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
   it('offers a retry when the read-only projection is unavailable', async () => {
     mocks.conversationQuery.mockRejectedValueOnce(new Error('offline'))
     render(<LogsPage />)

--- a/ui/src/pages/LogsPage.tsx
+++ b/ui/src/pages/LogsPage.tsx
@@ -64,6 +64,7 @@ function ToolCallLogSection() {
   const [totalPages, setTotalPages] = useState(1)
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [failed, setFailed] = useState(false)
   const [toolNames, setToolNames] = useState<string[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -79,8 +80,10 @@ function ToolCallLogSection() {
       setPage(result.page)
       setTotalPages(result.totalPages)
       setTotal(result.total)
+      setFailed(false)
     } catch (err) {
       console.warn('Failed to load tool calls:', err)
+      setFailed(true)
     } finally {
       setLoading(false)
     }
@@ -146,9 +149,11 @@ function ToolCallLogSection() {
         </button>
 
         <span className="text-xs text-muted-foreground ml-auto">
-          {total > 0
-            ? `Page ${page} of ${totalPages} \u00b7 ${total} calls`
-            : '0 calls'
+          {failed && entries.length === 0
+            ? 'Tool calls unavailable'
+            : total > 0
+              ? `Page ${page} of ${totalPages} \u00b7 ${total} calls`
+              : '0 calls'
           }
           {nameFilter && ' (filtered)'}
         </span>
@@ -161,6 +166,23 @@ function ToolCallLogSection() {
       >
         {loading && entries.length === 0 ? (
           <LogRowsSkeleton />
+        ) : failed && entries.length === 0 ? (
+          <div
+            role="alert"
+            className="flex h-full min-h-64 flex-col items-center justify-center gap-3 px-6 text-center font-sans"
+          >
+            <div>
+              <p className="text-sm font-medium text-foreground">Could not load tool calls</p>
+              <p className="mt-1 text-xs text-muted-foreground">The read-only audit log was not changed.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void fetchPage(page, nameFilter || undefined)}
+              className="oa-pressable rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Retry
+            </button>
+          </div>
         ) : entries.length === 0 ? (
           <div className="px-4 py-8 text-center text-muted-foreground">No tool calls yet</div>
         ) : (

--- a/ui/src/pages/MCPPage.spec.tsx
+++ b/ui/src/pages/MCPPage.spec.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MCPPage } from './MCPPage'
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  updateSection: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    config: {
+      load: mocks.loadConfig,
+      updateSection: mocks.updateSection,
+    },
+  },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('MCPPage configuration loading', () => {
+  it('retries a failed configuration read', async () => {
+    mocks.loadConfig
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({
+        mcp: {
+          enabled: false,
+          port: 3003,
+        },
+      })
+
+    render(<MCPPage />)
+
+    expect(await screen.findByRole('alert')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.loadConfig).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('heading', { name: 'HTTP Server' })).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/MCPPage.tsx
+++ b/ui/src/pages/MCPPage.tsx
@@ -14,7 +14,7 @@ import { PageHeader } from '../components/PageHeader'
 import type { AppConfig, McpConfig } from '../api'
 
 export function MCPPage() {
-  const { config, status, loadError, updateConfig, retry } = useConfigPage<McpConfig>({
+  const { config, status, loadError, updateConfig, reload, retry } = useConfigPage<McpConfig>({
     section: 'mcp',
     extract: (full: AppConfig) => full.mcp,
   })
@@ -56,7 +56,14 @@ export function MCPPage() {
             </ConfigSection>
           </div>
         )}
-        {loadError && <p className="text-[13px] text-destructive">Failed to load configuration.</p>}
+        {loadError && (
+          <div role="alert" className="mx-auto max-w-[880px] text-center">
+            <p className="text-[13px] text-destructive">Failed to load configuration.</p>
+            <button type="button" className="btn-secondary-sm mt-3" onClick={() => void reload()}>
+              Retry
+            </button>
+          </div>
+        )}
       </SettingsScrollArea>
     </div>
   )

--- a/ui/src/pages/MarketRotationPage.spec.tsx
+++ b/ui/src/pages/MarketRotationPage.spec.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MarketRotationPage } from './MarketRotationPage'
+
+const mocks = vi.hoisted(() => ({
+  sectorRotation: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { sym?: string }) => {
+      if (key === 'common.retry') return 'Retry'
+      if (key === 'market.colVsBench') return `vs ${options?.sym ?? ''}`
+      return key
+    },
+  }),
+}))
+
+vi.mock('../api/market', () => ({
+  marketApi: {
+    sectorRotation: mocks.sectorRotation,
+  },
+}))
+
+vi.mock('../components/MeasuredChartFrame', () => ({
+  MeasuredChartFrame: () => <div data-testid="rotation-chart" />,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('MarketRotationPage recovery', () => {
+  it('lets the user retry an initial board failure immediately', async () => {
+    mocks.sectorRotation
+      .mockRejectedValueOnce(new Error('Rotation board unavailable'))
+      .mockResolvedValueOnce({
+        asOf: '2026-07-29',
+        benchmark: {
+          symbol: 'SPY',
+          returns: { '1D': 0, '1W': 0, '1M': 0, '3M': 0, '6M': 0 },
+        },
+        sectors: [],
+        methodology: 'Recovered methodology',
+      })
+
+    render(<MarketRotationPage />)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Rotation board unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await screen.findByText('Recovered methodology')
+    await waitFor(() => expect(mocks.sectorRotation).toHaveBeenCalledTimes(2))
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/MarketRotationPage.tsx
+++ b/ui/src/pages/MarketRotationPage.tsx
@@ -43,6 +43,7 @@ export function MarketRotationPage() {
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [requestVersion, setRequestVersion] = useState(0)
 
   useEffect(() => {
     let alive = true
@@ -63,7 +64,13 @@ export function MarketRotationPage() {
     load()
     const timer = setInterval(load, REFRESH_MS)
     return () => { alive = false; clearInterval(timer) }
-  }, [])
+  }, [requestVersion])
+
+  const retry = () => {
+    setError(null)
+    setLoading(true)
+    setRequestVersion((version) => version + 1)
+  }
 
   const points = useMemo<Point[]>(() => {
     if (!data) return []
@@ -92,7 +99,19 @@ export function MarketRotationPage() {
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-6 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
         {error && (
-          <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
+          <div
+            role="alert"
+            className="flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[13px] text-destructive"
+          >
+            <span className="min-w-0 break-words">{error}</span>
+            <button
+              type="button"
+              className="shrink-0 rounded-md border border-destructive/30 px-2.5 py-1 font-medium hover:bg-destructive/10"
+              onClick={retry}
+            >
+              {t('common.retry')}
+            </button>
+          </div>
         )}
 
         {data && (

--- a/ui/src/pages/SettingsPage.loading.spec.tsx
+++ b/ui/src/pages/SettingsPage.loading.spec.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { SettingsPage } from './SettingsPage'
+
+const mocks = vi.hoisted(() => ({
+  configLoad: vi.fn(),
+  getPersona: vi.fn(),
+  getVersion: vi.fn(),
+  getWorkspaceShell: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    config: {
+      load: mocks.configLoad,
+    },
+    persona: {
+      get: mocks.getPersona,
+    },
+    version: {
+      get: mocks.getVersion,
+    },
+  },
+}))
+
+vi.mock('../api/preferences', () => ({
+  preferencesApi: {
+    getWorkspaceShell: mocks.getWorkspaceShell,
+  },
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.stubGlobal('matchMedia', vi.fn(() => ({
+    matches: false,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } satisfies MediaQueryList)))
+  await i18n.changeLanguage('en')
+  mocks.getPersona.mockResolvedValue({ content: '', path: '' })
+  mocks.getVersion.mockResolvedValue({
+    current: '0.0.0',
+    latest: '0.0.0',
+    hasUpdate: false,
+    releaseUrl: '',
+  })
+  mocks.getWorkspaceShell.mockResolvedValue({ supported: false })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('SettingsPage loading', () => {
+  it('renders independent settings without waiting for an unused config read', async () => {
+    mocks.configLoad.mockRejectedValue(new Error('offline'))
+
+    render(<SettingsPage />)
+
+    expect(screen.getByRole('heading', { name: 'Appearance' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Language' })).toBeTruthy()
+    expect(screen.getByText('openalice start --home <path>')).toBeTruthy()
+    await waitFor(() => expect(mocks.getPersona).toHaveBeenCalledOnce())
+    expect(mocks.configLoad).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/pages/SettingsPage.tools-loading.spec.tsx
+++ b/ui/src/pages/SettingsPage.tools-loading.spec.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { ToolsSection } from './SettingsPage'
+
+const mocks = vi.hoisted(() => ({
+  loadTools: vi.fn(),
+  updateTools: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    tools: {
+      load: mocks.loadTools,
+      update: mocks.updateTools,
+    },
+  },
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('Settings Tools loading', () => {
+  it('explains a failed catalog load and retries it', async () => {
+    mocks.loadTools
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ inventory: [], disabled: [] })
+
+    render(<ToolsSection />)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Could not load the tool catalog.')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.loadTools).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('No tools registered.')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Moon, RotateCcw, Sun } from 'lucide-react'
-import { api, type AppConfig } from '../api'
+import { api } from '../api'
 import type { ToolInfo } from '../api/tools'
 import { Toggle } from '../components/Toggle'
 import { SaveIndicator } from '../components/SaveIndicator'
@@ -653,13 +653,6 @@ function WorkspaceShellSection() {
 
 function SettingsSection() {
   const { t } = useTranslation()
-  const [config, setConfig] = useState<AppConfig | null>(null)
-
-  useEffect(() => {
-    api.config.load().then(setConfig).catch(() => {})
-  }, [])
-
-  if (!config) return <PageLoading />
 
   return (
     <div className="mx-auto w-full max-w-[1100px]">

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -769,7 +769,7 @@ interface ToolGroup {
   tools: ToolInfo[]
 }
 
-function ToolsSection() {
+export function ToolsSection() {
   const { t } = useTranslation()
   const groupLabel = (key: string): string => {
     switch (key) {
@@ -789,15 +789,25 @@ function ToolsSection() {
   const [inventory, setInventory] = useState<ToolInfo[]>([])
   const [disabled, setDisabled] = useState<Set<string>>(new Set())
   const [loaded, setLoaded] = useState(false)
+  const [loadError, setLoadError] = useState(false)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
-  useEffect(() => {
-    api.tools.load().then((res) => {
+  const loadTools = useCallback(async () => {
+    setLoaded(false)
+    setLoadError(false)
+    try {
+      const res = await api.tools.load()
       setInventory(res.inventory)
       setDisabled(new Set(res.disabled))
       setLoaded(true)
-    }).catch(() => {})
+    } catch {
+      setLoadError(true)
+    }
   }, [])
+
+  useEffect(() => {
+    void loadTools()
+  }, [loadTools])
 
   const groups = useMemo<ToolGroup[]>(() => {
     const map = new Map<string, ToolInfo[]>()
@@ -854,7 +864,16 @@ function ToolsSection() {
   return (
     <div className="mx-auto w-full max-w-[1100px]">
       {!loaded ? (
-        <PageLoading />
+        loadError ? (
+          <div role="alert" className="flex flex-col items-center justify-center py-16 text-center">
+            <p className="text-sm font-medium text-foreground">{t('settings.tools.loadError')}</p>
+            <button type="button" className="btn-secondary-sm mt-4" onClick={() => void loadTools()}>
+              {t('common.retry')}
+            </button>
+          </div>
+        ) : (
+          <PageLoading />
+        )
       ) : groups.length === 0 ? (
         <EmptyState title={t('settings.tools.emptyTitle')} description={t('settings.tools.emptyDescription')} />
       ) : (

--- a/ui/src/pages/TemplateDetailPage.spec.tsx
+++ b/ui/src/pages/TemplateDetailPage.spec.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TemplateDetailPage } from './TemplateDetailPage'
+
+const mocks = vi.hoisted(() => ({
+  fetchTemplateReadme: vi.fn(),
+  openOrFocus: vi.fn(),
+  refresh: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key === 'common.retry' ? 'Retry' : key,
+  }),
+}))
+
+vi.mock('../components/workspace/api', () => ({
+  fetchTemplateReadme: mocks.fetchTemplateReadme,
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    templates: [{
+      name: 'chat',
+      displayName: 'Chat',
+      description: 'General-purpose workspace',
+      defaultAgents: ['codex'],
+      version: '0.2.0',
+      hasReadme: true,
+    }],
+    agents: [],
+    refresh: mocks.refresh,
+  }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: typeof mocks.openOrFocus }) => unknown) => selector({
+    openOrFocus: mocks.openOrFocus,
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(cleanup)
+
+describe('TemplateDetailPage README recovery', () => {
+  it('retries a failed README request without reloading the application', async () => {
+    mocks.fetchTemplateReadme
+      .mockRejectedValueOnce(new Error('README temporarily unavailable'))
+      .mockResolvedValueOnce('# Chat\n\nRecovered instructions')
+
+    render(<TemplateDetailPage spec={{ kind: 'template-detail', params: { name: 'chat' } }} />)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('README temporarily unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await screen.findByText('Recovered instructions')
+    await waitFor(() => expect(mocks.fetchTemplateReadme).toHaveBeenCalledTimes(2))
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/ui/src/pages/TemplateDetailPage.tsx
+++ b/ui/src/pages/TemplateDetailPage.tsx
@@ -54,6 +54,7 @@ export function TemplateDetailPage({ spec }: Props) {
   const [readme, setReadme] = useState<string | null>(null)
   const [readmeMissing, setReadmeMissing] = useState(false)
   const [readmeError, setReadmeError] = useState<string | null>(null)
+  const [readmeAttempt, setReadmeAttempt] = useState(0)
   useEffect(() => {
     let cancelled = false
     setReadme(null)
@@ -72,7 +73,7 @@ export function TemplateDetailPage({ spec }: Props) {
     return () => {
       cancelled = true
     }
-  }, [templateName])
+  }, [templateName, readmeAttempt])
 
   if (!template) {
     return (
@@ -152,7 +153,19 @@ export function TemplateDetailPage({ spec }: Props) {
             <p className="text-[12px] text-muted-foreground italic">{t('templates.noReadme')}</p>
           )}
           {readmeError && (
-            <p className="text-[12px] text-muted-foreground italic">{readmeError}</p>
+            <div
+              role="alert"
+              className="flex items-center justify-between gap-3 text-[12px] text-destructive"
+            >
+              <span className="min-w-0 break-words">{readmeError}</span>
+              <button
+                type="button"
+                className="shrink-0 rounded-md border border-destructive/30 px-2.5 py-1 font-medium hover:bg-destructive/10"
+                onClick={() => setReadmeAttempt((attempt) => attempt + 1)}
+              >
+                {t('common.retry')}
+              </button>
+            </div>
           )}
           {readmeBody && (
             <MarkdownContent text={readmeBody} className="text-[13px] leading-relaxed" />

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   getQuickChat: vi.fn(),
   rememberQuickChatCredential: vi.fn(),
   openAgentConfig: vi.fn(),
+  refreshWorkspaceManager: vi.fn(),
 }))
 
 vi.mock('../contexts/workspaces-context', () => ({
@@ -119,7 +120,7 @@ function context(
     hasLoaded: true,
     templatesLoaded: true,
     refresh: vi.fn(),
-    refreshWorkspaceManager: vi.fn(async () => undefined),
+    refreshWorkspaceManager: mocks.refreshWorkspaceManager,
     quickStartWorkspaceManager: mocks.quickStartWorkspaceManager,
     spawn: vi.fn(async () => undefined),
     openHeadlessRun: vi.fn(async () => undefined),
@@ -178,6 +179,7 @@ beforeEach(async () => {
   mocks.rememberQuickChatCredential.mockResolvedValue(undefined)
   mocks.openWebPiSession.mockResolvedValue(undefined)
   mocks.resumeSession.mockResolvedValue(undefined)
+  mocks.refreshWorkspaceManager.mockResolvedValue(undefined)
   mocks.quickStartWorkspaceManager.mockResolvedValue({
     manager: managerSnapshot(),
     session: {
@@ -201,6 +203,21 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('WorkspaceManagerPage runtime selection', () => {
+  it('offers a retry when the manager snapshot cannot load', async () => {
+    mocks.useWorkspaces.mockImplementation(() => ({
+      ...context('codex'),
+      workspaceManager: null,
+      workspaceManagerError: 'Manager snapshot unavailable',
+    }))
+
+    render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
+
+    expect(screen.getByRole('alert').textContent).toContain('Manager snapshot unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(mocks.refreshWorkspaceManager).toHaveBeenCalledOnce())
+  })
+
   it('uses the Quick Chat runtime catalog and launches the selected native runtime', async () => {
     render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
 

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -253,8 +253,20 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
         </section>
 
         {(error ?? workspaceManagerError) && (
-          <div className="mt-3 rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
-            {error ?? workspaceManagerError}
+          <div
+            role="alert"
+            className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-[12px] text-destructive"
+          >
+            <span>{error ?? workspaceManagerError}</span>
+            {!error && workspaceManagerError && (
+              <button
+                type="button"
+                className="shrink-0 rounded-md border border-destructive/30 px-2.5 py-1 font-medium hover:bg-destructive/10"
+                onClick={() => void refreshWorkspaceManager()}
+              >
+                {t('common.retry')}
+              </button>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

- integrate the reviewed loading-recovery PRs #782, #783, #784, #785, #786, #788, #789, #790, and #791
- replace permanent spinners, false empty states, and reload-only failures with explicit accessible errors and read-only Retry actions
- remove the unused General Settings config-read gate
- preserve normal loading, empty-state, polling, and existing-data behavior

## User impact

Transient backend, IPC, or network failures no longer strand users or pretend that saved data disappeared. Recovery retries only reads; this batch does not change backend, persistence, permissions, or trading writes.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 389 files passed, 1 skipped; 3456 tests passed, 9 skipped
- focused first-failure / successful-retry regression tests for every changed surface
- real `pnpm dev` normal-path walkthrough across Agent Permissions, General Settings, Tools, AI Provider, MCP, Workspace Manager, template details, Market Rotation, and Tool-call Logs
- no browser console errors
- `git diff --check origin/dev...HEAD`
