### PR TITLE
Integrate product consistency improvements

### DIFF
--- a/ui/src/components/InboxSidebar.spec.tsx
+++ b/ui/src/components/InboxSidebar.spec.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { InboxEntry } from '../api/inbox'
+import { i18n } from '../i18n'
+import { InboxSidebar } from './InboxSidebar'
+
+const mocks = vi.hoisted(() => ({
+  entries: [] as InboxEntry[],
+  loading: false,
+  selectedEntryId: 'inbox-1' as string | null,
+  mode: 'workspace' as 'workspace' | 'time',
+  workspaces: [] as Array<{ id: string; tag: string }>,
+  markRead: vi.fn(),
+  select: vi.fn(),
+  setMode: vi.fn(),
+}))
+
+vi.mock('../live/inbox', () => ({
+  inboxLive: {
+    useStore: (selector: (state: { entries: InboxEntry[]; loading: boolean }) => unknown) =>
+      selector({ entries: mocks.entries, loading: mocks.loading }),
+  },
+}))
+
+vi.mock('../live/inbox-read', () => ({
+  useInboxRead: (selector: (state: { markRead: typeof mocks.markRead }) => unknown) =>
+    selector({ markRead: mocks.markRead }),
+}))
+
+vi.mock('../live/inbox-selection', () => ({
+  useInboxSelection: (
+    selector: (state: {
+      selectedEntryId: string | null
+      select: typeof mocks.select
+    }) => unknown,
+  ) => selector({
+    selectedEntryId: mocks.selectedEntryId,
+    select: mocks.select,
+  }),
+}))
+
+vi.mock('../live/inbox-view-mode', () => ({
+  useInboxViewMode: (
+    selector: (state: {
+      mode: 'workspace' | 'time'
+      setMode: typeof mocks.setMode
+    }) => unknown,
+  ) => selector({ mode: mocks.mode, setMode: mocks.setMode }),
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({ workspaces: mocks.workspaces }),
+}))
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+  mocks.entries = [{
+    id: 'inbox-1',
+    ts: Date.now(),
+    workspaceId: 'workspace-1',
+    workspaceLabel: 'old-desk',
+    comments: 'Research is ready.',
+  }]
+  mocks.loading = false
+  mocks.selectedEntryId = 'inbox-1'
+  mocks.mode = 'workspace'
+  mocks.workspaces = [{ id: 'workspace-1', tag: 'renamed-desk' }]
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('InboxSidebar Workspace labels', () => {
+  it.each(['workspace', 'time'] as const)(
+    'uses the current Workspace tag in %s view',
+    (mode) => {
+      mocks.mode = mode
+
+      render(<InboxSidebar />)
+
+      expect(screen.getByText('renamed-desk')).toBeTruthy()
+      expect(screen.queryByText('old-desk')).toBeNull()
+    },
+  )
+
+  it('preserves the recorded label after the Workspace is gone', () => {
+    mocks.workspaces = []
+
+    render(<InboxSidebar />)
+
+    expect(screen.getByText('old-desk')).toBeTruthy()
+  })
+})

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Clock, Layers } from 'lucide-react'
+import { useWorkspaces } from '../contexts/workspaces-context'
 import { formatRelativeTime } from '../lib/intl'
 import { inboxLive } from '../live/inbox'
 import { useInboxRead } from '../live/inbox-read'
@@ -31,8 +32,13 @@ export function InboxSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
   const select = useInboxSelection((s) => s.select)
   const markRead = useInboxRead((s) => s.markRead)
   const mode = useInboxViewMode((s) => s.mode)
+  const { workspaces } = useWorkspaces()
 
   const threads = useMemo(() => groupThreads(entries), [entries])
+  const workspaceLabels = useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspace.tag])),
+    [workspaces],
+  )
   const readIds = useMemo(() => {
     const ids: Record<string, true> = {}
     for (const entry of entries) {
@@ -112,6 +118,7 @@ export function InboxSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
           threads={threads}
           selectedId={selectedId}
           readIds={readIds}
+          workspaceLabels={workspaceLabels}
           onSelect={selectAndRead}
         />
       ) : (
@@ -119,6 +126,7 @@ export function InboxSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
           entries={entries}
           selectedId={selectedId}
           readIds={readIds}
+          workspaceLabels={workspaceLabels}
           onSelect={selectAndRead}
         />
       )}
@@ -180,23 +188,26 @@ function ToggleBtn({
 // ==================== Workspace (clustered) view ====================
 
 function WorkspaceView({
-  threads, selectedId, readIds, onSelect,
+  threads, selectedId, readIds, workspaceLabels, onSelect,
 }: {
   threads: ReturnType<typeof groupThreads>
   selectedId: string | null
   readIds: Record<string, true>
+  workspaceLabels: ReadonlyMap<string, string>
   onSelect: (id: string) => void
 }) {
   return (
     <>
       {threads.map((thread) => {
         const unread = thread.entries.reduce((n, e) => (readIds[e.id] ? n : n + 1), 0)
+        const workspaceLabel =
+          workspaceLabels.get(thread.workspaceId) ?? thread.workspaceLabel ?? thread.workspaceId
         return (
           <div key={thread.workspaceId} className="mb-1.5">
             {/* Cluster header: label · unread badge · latest time */}
             <div className="flex items-center gap-1.5 px-3 mt-1.5 mb-0.5">
               <span className="flex-1 truncate text-[12px] font-medium text-foreground/90">
-                {thread.workspaceLabel ?? thread.workspaceId}
+                {workspaceLabel}
               </span>
               {unread > 0 && (
                 <span className="shrink-0 min-w-[15px] h-[15px] px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-semibold tabular-nums flex items-center justify-center">
@@ -272,11 +283,12 @@ function ClusterRow({
 // ==================== Time (flat chronological) view ====================
 
 function TimeView({
-  entries, selectedId, readIds, onSelect,
+  entries, selectedId, readIds, workspaceLabels, onSelect,
 }: {
   entries: readonly InboxEntry[]
   selectedId: string | null
   readIds: Record<string, true>
+  workspaceLabels: ReadonlyMap<string, string>
   onSelect: (id: string) => void
 }) {
   const { t } = useTranslation()
@@ -296,6 +308,7 @@ function TimeView({
                 entry={entry}
                 active={entry.id === selectedId}
                 unread={!readIds[entry.id]}
+                workspaceLabel={workspaceLabels.get(entry.workspaceId)}
                 onClick={() => onSelect(entry.id)}
               />
             ))}
@@ -309,11 +322,12 @@ function TimeView({
 /** Row in the flat time feed — carries the workspace label (no cluster
  *  header to provide it). */
 function TimeRow({
-  entry, active, unread, onClick,
+  entry, active, unread, workspaceLabel, onClick,
 }: {
   entry: InboxEntry
   active: boolean
   unread: boolean
+  workspaceLabel?: string
   onClick: () => void
 }) {
   return (
@@ -342,7 +356,7 @@ function TimeRow({
           className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-primary' : 'bg-transparent'}`}
         />
         <span className={`flex-1 truncate text-[12px] ${unread ? 'font-medium text-foreground' : 'text-foreground'}`}>
-          {entry.workspaceLabel ?? entry.workspaceId}
+          {workspaceLabel ?? entry.workspaceLabel ?? entry.workspaceId}
         </span>
         <span className="shrink-0 text-[10px] text-muted-foreground/60 tabular-nums">
           {formatRelativeTime(entry.ts)}

--- a/ui/src/components/Toggle.spec.tsx
+++ b/ui/src/components/Toggle.spec.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Toggle } from './Toggle'
+
+afterEach(cleanup)
+
+describe('Toggle', () => {
+  it('exposes its purpose and checked state to assistive technology', () => {
+    const onChange = vi.fn()
+    render(
+      <Toggle
+        ariaLabel="Allow AI to push trades"
+        checked={false}
+        onChange={onChange}
+      />,
+    )
+
+    const toggle = screen.getByRole('switch', { name: 'Allow AI to push trades' })
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.click(toggle)
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/ui/src/components/Toggle.tsx
+++ b/ui/src/components/Toggle.tsx
@@ -2,7 +2,7 @@ interface ToggleProps {
   checked: boolean
   onChange: (v: boolean) => void
   size?: 'sm' | 'md'
-  ariaLabel?: string
+  ariaLabel: string
   disabled?: boolean
 }
 

--- a/ui/src/components/uta/CreateUTADialog.tsx
+++ b/ui/src/components/uta/CreateUTADialog.tsx
@@ -249,7 +249,7 @@ export function CreateUTADialog({
                     Allow analysis reads; block broker-side order changes.
                   </div>
                 </div>
-                <Toggle size="sm" checked={readOnly} onChange={setReadOnly} />
+                <Toggle ariaLabel="Read-only account" size="sm" checked={readOnly} onChange={setReadOnly} />
               </div>
               <div className="flex items-center justify-between gap-4 rounded-lg border border-border px-3 py-2.5">
                 <div className="min-w-0">
@@ -258,7 +258,7 @@ export function CreateUTADialog({
                     Include this connector in K-line and contract discovery.
                   </div>
                 </div>
-                <Toggle size="sm" checked={asVendor} onChange={setAsVendor} />
+                <Toggle ariaLabel="Use as data source" size="sm" checked={asVendor} onChange={setAsVendor} />
               </div>
               <SchemaFormFields
                 fields={fields}

--- a/ui/src/components/uta/EditUTADialog.tsx
+++ b/ui/src/components/uta/EditUTADialog.tsx
@@ -115,7 +115,12 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
                 Allow analysis reads; block broker-side order changes.
               </div>
             </div>
-            <Toggle size="sm" checked={draft.readOnly === true} onChange={(v) => setDraft(d => ({ ...d, readOnly: v }))} />
+            <Toggle
+              ariaLabel="Read-only account"
+              size="sm"
+              checked={draft.readOnly === true}
+              onChange={(v) => setDraft(d => ({ ...d, readOnly: v }))}
+            />
           </div>
           <div className="mb-3 flex items-center justify-between gap-4 rounded-lg border border-border px-3 py-2.5">
             <div className="min-w-0">
@@ -124,7 +129,12 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
                 Include this UTA in K-line and contract discovery.
               </div>
             </div>
-            <Toggle size="sm" checked={draft.asVendor !== false} onChange={(v) => setDraft(d => ({ ...d, asVendor: v }))} />
+            <Toggle
+              ariaLabel="Use as data source"
+              size="sm"
+              checked={draft.asVendor !== false}
+              onChange={(v) => setDraft(d => ({ ...d, asVendor: v }))}
+            />
           </div>
           <SchemaFormFields
             fields={fields}
@@ -181,11 +191,15 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
           )}
           {draft.enabled !== false && <ReconnectButton accountId={uta.id} />}
           <label className="flex items-center gap-2 cursor-pointer">
-            <Toggle checked={draft.enabled !== false} onChange={async (v) => {
-              const updated = { ...draft, enabled: v }
-              setDraft(updated)
-              await onSave(updated)
-            }} />
+            <Toggle
+              ariaLabel={`${uta.id} enabled`}
+              checked={draft.enabled !== false}
+              onChange={async (v) => {
+                const updated = { ...draft, enabled: v }
+                setDraft(updated)
+                await onSave(updated)
+              }}
+            />
             <span className="text-[12px] text-muted-foreground">{draft.enabled !== false ? 'Enabled' : 'Disabled'}</span>
           </label>
           {msg && <span className="text-[12px] text-muted-foreground">{msg}</span>}

--- a/ui/src/components/uta/SchemaFormFields.tsx
+++ b/ui/src/components/uta/SchemaFormFields.tsx
@@ -20,7 +20,12 @@ export function SchemaFormFields({ fields, formData, setField, showSecrets }: {
           case 'boolean':
             return (
               <label key={f.key} className="flex items-start gap-2 cursor-pointer select-none">
-                <Toggle size="sm" checked={value === 'true'} onChange={(v) => setField(f.key, v ? 'true' : 'false')} />
+                <Toggle
+                  ariaLabel={f.title}
+                  size="sm"
+                  checked={value === 'true'}
+                  onChange={(v) => setField(f.key, v ? 'true' : 'false')}
+                />
                 <span>
                   <span className="text-[13px] text-foreground">{f.title}</span>
                   {f.description && <p className="text-[11px] text-muted-foreground/60 mt-0.5">{f.description}</p>}

--- a/ui/src/components/workspace/OverviewCard.spec.tsx
+++ b/ui/src/components/workspace/OverviewCard.spec.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../../i18n'
+import type { Workspace } from './api'
+import { OverviewCard } from './OverviewCard'
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+const workspace: Workspace = {
+  id: 'research-desk',
+  tag: 'research',
+  displayName: 'Research desk',
+  dir: '/tmp/research',
+  createdAt: '2026-07-28T00:00:00.000Z',
+  template: 'chat',
+  spawnedFromVersion: '0.1.0',
+  upgradeAvailable: { from: '0.1.0', to: '0.2.0' },
+  agents: ['codex'],
+  agentOverride: {
+    claude: false,
+    codex: true,
+    opencode: false,
+    pi: false,
+  },
+  sessions: [
+    {
+      id: 'session-1',
+      resumeId: 'resume-1',
+      wsId: 'research-desk',
+      agent: 'codex',
+      name: 'x1',
+      createdAt: '2026-07-28T00:00:00.000Z',
+      lastActiveAt: '2026-07-28T00:01:00.000Z',
+      state: 'running',
+      pid: 42,
+      startedAt: 1,
+      title: 'Investigate the market',
+    },
+  ],
+}
+
+describe('OverviewCard', () => {
+  it('exposes native controls for the workspace and its sessions', () => {
+    const onOpen = vi.fn()
+    const onOpenSession = vi.fn()
+    const onConfigure = vi.fn()
+    const onUpgrade = vi.fn()
+    render(
+      <OverviewCard
+        workspace={workspace}
+        lastCommit={null}
+        onOpen={onOpen}
+        onOpenSession={onOpenSession}
+        onConfigure={onConfigure}
+        onUpgrade={onUpgrade}
+      />,
+    )
+
+    const workspaceButton = screen.getByRole('button', { name: 'Research desk' })
+    const sessionButton = screen.getByRole('button', { name: 'x1 running' })
+    expect(workspaceButton.tagName).toBe('BUTTON')
+    expect(sessionButton.tagName).toBe('BUTTON')
+    workspaceButton.focus()
+    expect(document.activeElement).toBe(workspaceButton)
+    sessionButton.focus()
+    expect(document.activeElement).toBe(sessionButton)
+
+    fireEvent.click(screen.getByRole('button', { name: 'v0.2.0' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Workspace override · codex' }))
+    expect(onUpgrade).toHaveBeenCalledTimes(1)
+    expect(onConfigure).toHaveBeenCalledTimes(1)
+    expect(onOpen).not.toHaveBeenCalled()
+
+    fireEvent.click(workspaceButton)
+    fireEvent.click(sessionButton)
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onOpenSession).toHaveBeenCalledWith('session-1')
+  })
+})

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -11,10 +11,9 @@ import { workspaceDisplayName, workspaceDisplayTitle } from './display'
  * relative-activity subtitle, sessions list (each clickable), provider
  * override + latest commit footer (rendered only when present).
  *
- * The card body is clickable (opens the workspace tab). Inner regions —
- * session rows, the ⚙ override row — stopPropagation and route to their
- * own handler so the user can drill in without going through the main
- * workspace landing.
+ * A full-card button opens the workspace tab. It is a sibling of the
+ * interactive session, upgrade, and provider controls so the whole card stays
+ * mouse-friendly without nesting buttons or excluding keyboard users.
  */
 
 const AGENT_ICONS: Record<string, LucideIcon> = {
@@ -76,126 +75,128 @@ export function OverviewCard({
   if (w.agentOverride?.pi) overrideAgents.push('pi')
 
   return (
-    <div
-      onClick={onOpen}
-      className="group rounded-lg border border-border bg-secondary hover:bg-muted/40 hover:border-border/80 transition-colors cursor-pointer p-4 flex flex-col gap-3"
+    <article
+      className="group relative rounded-lg border border-border bg-secondary p-4 transition-colors hover:border-border/80 hover:bg-muted/40"
     >
-      {/* Header */}
-      <div className="flex items-start gap-2.5">
-        <span
-          className={`w-2 h-2 rounded-full mt-1.5 shrink-0 ${dotClass}`}
-          aria-hidden="true"
-        />
-        <div className="flex-1 min-w-0">
-          <h3 className="text-[14px] font-semibold text-foreground truncate" title={workspaceDisplayTitle(w)}>
-            {label}
-          </h3>
-          <p className="text-[11px] text-muted-foreground truncate" title={w.description}>
-            {w.description?.trim() || t('workspace.activeAgo', { time: formatRelativeTime(lastActivityMs) })}
-          </p>
-        </div>
-        {w.upgradeAvailable && w.template && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              onUpgrade?.()
-            }}
-            disabled={!onUpgrade}
-            title={t('workspace.templateUpgrade', {
-              from: w.upgradeAvailable.from,
-              to: w.upgradeAvailable.to,
-            })}
-            className="oa-pressable shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-primary border border-primary/40 hover:border-primary/80 hover:bg-primary/10 transition-colors disabled:cursor-default disabled:hover:border-primary/40 disabled:hover:bg-transparent"
-          >
-            <ArrowUpCircle size={10} strokeWidth={2.25} />
-            <span>v{w.upgradeAvailable.to}</span>
-          </button>
-        )}
-      </div>
+      <button
+        type="button"
+        aria-label={label}
+        onClick={onOpen}
+        className="absolute inset-0 z-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      />
 
-      {/* Sessions */}
-      <div className="border-t border-border pt-3">
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-1.5">
-          {t('workspace.sessions')}
-        </div>
-        {w.sessions.length === 0 ? (
-          <p className="text-[12px] text-muted-foreground/80 italic">{t('workspace.noSessions')}</p>
-        ) : (
-          <ul className="space-y-0.5 -mx-2">
-            {w.sessions.map((s) => (
-              <li
-                key={s.id}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onOpenSession(s.id)
-                }}
-                className="flex items-center gap-2 text-[12px] text-foreground hover:bg-muted/40 px-2 py-1 rounded transition-colors cursor-pointer"
-              >
-                <span className="w-3 flex justify-center text-muted-foreground">
-                  <AgentGlyph agent={s.agent} />
-                </span>
-                <span className="font-mono text-[11px] tabular-nums">{s.name}</span>
-                <span
-                  className={`text-[11px] ${
-                    s.state === 'running' ? 'text-success' : 'text-muted-foreground'
-                  }`}
-                >
-                  {t(s.state === 'running' ? 'workspace.running' : 'workspace.paused')}
-                </span>
-                <ChevronRight
-                  size={10}
-                  className="ml-auto text-muted-foreground opacity-0 group-hover:opacity-60 transition-opacity"
-                />
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      {/* Footer — only rendered when there's something to show */}
-      {(overrideAgents.length > 0 || lastCommit || (w.template && w.spawnedFromVersion)) && (
-        <div className="border-t border-border pt-3 space-y-1.5">
-          {w.template && w.spawnedFromVersion && (
-            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-              <GitBranch size={11} strokeWidth={2.25} className="shrink-0" />
-              <span className="truncate">
-                {t('workspace.fromTemplate', {
-                  template: w.template,
-                  version: w.spawnedFromVersion,
-                })}
-              </span>
-            </div>
-          )}
-          {overrideAgents.length > 0 && onConfigure && (
+      <div className="pointer-events-none relative z-10 flex flex-col gap-3">
+        {/* Header */}
+        <div className="flex items-start gap-2.5">
+          <span
+            className={`w-2 h-2 rounded-full mt-1.5 shrink-0 ${dotClass}`}
+            aria-hidden="true"
+          />
+          <div className="flex-1 min-w-0">
+            <h3 className="text-[14px] font-semibold text-foreground truncate" title={workspaceDisplayTitle(w)}>
+              {label}
+            </h3>
+            <p className="text-[11px] text-muted-foreground truncate" title={w.description}>
+              {w.description?.trim() || t('workspace.activeAgo', { time: formatRelativeTime(lastActivityMs) })}
+            </p>
+          </div>
+          {w.upgradeAvailable && w.template && (
             <button
               type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                onConfigure()
-              }}
-              className="flex items-center gap-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+              onClick={() => onUpgrade?.()}
+              disabled={!onUpgrade}
+              title={t('workspace.templateUpgrade', {
+                from: w.upgradeAvailable.from,
+                to: w.upgradeAvailable.to,
+              })}
+              className="oa-pressable pointer-events-auto shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-primary border border-primary/40 hover:border-primary/80 hover:bg-primary/10 transition-colors disabled:cursor-default disabled:hover:border-primary/40 disabled:hover:bg-transparent"
             >
-              <Settings size={11} strokeWidth={2.25} className="shrink-0" />
-              <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
+              <ArrowUpCircle size={10} strokeWidth={2.25} />
+              <span>v{w.upgradeAvailable.to}</span>
             </button>
           )}
-          {overrideAgents.length > 0 && !onConfigure && (
-            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-              <Settings size={11} strokeWidth={2.25} className="shrink-0" />
-              <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
-            </div>
-          )}
-          {lastCommit && (
-            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-              <ScrollText size={11} strokeWidth={2.25} className="shrink-0" />
-              <span className="truncate" title={lastCommit.subject}>
-                {lastCommit.subject}
-              </span>
-            </div>
+        </div>
+
+        {/* Sessions */}
+        <div className="border-t border-border pt-3">
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-1.5">
+            {t('workspace.sessions')}
+          </div>
+          {w.sessions.length === 0 ? (
+            <p className="text-[12px] text-muted-foreground/80 italic">{t('workspace.noSessions')}</p>
+          ) : (
+            <ul className="space-y-0.5 -mx-2">
+              {w.sessions.map((s) => (
+                <li key={s.id}>
+                  <button
+                    type="button"
+                    aria-label={`${s.name} ${t(s.state === 'running' ? 'workspace.running' : 'workspace.paused')}`}
+                    onClick={() => onOpenSession(s.id)}
+                    className="oa-nav-row pointer-events-auto flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[12px] text-foreground hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  >
+                    <span className="w-3 flex justify-center text-muted-foreground">
+                      <AgentGlyph agent={s.agent} />
+                    </span>
+                    <span className="font-mono text-[11px] tabular-nums">{s.name}</span>
+                    <span
+                      className={`text-[11px] ${
+                        s.state === 'running' ? 'text-success' : 'text-muted-foreground'
+                      }`}
+                    >
+                      {t(s.state === 'running' ? 'workspace.running' : 'workspace.paused')}
+                    </span>
+                    <ChevronRight
+                      size={10}
+                      className="ml-auto text-muted-foreground opacity-0 group-hover:opacity-60 transition-opacity"
+                    />
+                  </button>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
-      )}
-    </div>
+
+        {/* Footer — only rendered when there's something to show */}
+        {(overrideAgents.length > 0 || lastCommit || (w.template && w.spawnedFromVersion)) && (
+          <div className="border-t border-border pt-3 space-y-1.5">
+            {w.template && w.spawnedFromVersion && (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <GitBranch size={11} strokeWidth={2.25} className="shrink-0" />
+                <span className="truncate">
+                  {t('workspace.fromTemplate', {
+                    template: w.template,
+                    version: w.spawnedFromVersion,
+                  })}
+                </span>
+              </div>
+            )}
+            {overrideAgents.length > 0 && onConfigure && (
+              <button
+                type="button"
+                onClick={onConfigure}
+                className="pointer-events-auto flex items-center gap-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+              >
+                <Settings size={11} strokeWidth={2.25} className="shrink-0" />
+                <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
+              </button>
+            )}
+            {overrideAgents.length > 0 && !onConfigure && (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <Settings size={11} strokeWidth={2.25} className="shrink-0" />
+                <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>
+              </div>
+            )}
+            {lastCommit && (
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <ScrollText size={11} strokeWidth={2.25} className="shrink-0" />
+                <span className="truncate" title={lastCommit.subject}>
+                  {lastCommit.subject}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </article>
   )
 }

--- a/ui/src/demo/handlers/headless.spec.ts
+++ b/ui/src/demo/handlers/headless.spec.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import type { HeadlessListSnapshot } from '../../api/headless'
+import { demoWorkspaces } from '../fixtures/workspaces'
+import { headlessHandlers } from './headless'
+
+const server = setupServer(...headlessHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('demo headless handlers', () => {
+  it('ties every run to a registered demo Workspace', async () => {
+    const response = await fetch(`${baseUrl}/api/headless`)
+    const body = await response.json() as HeadlessListSnapshot
+    const workspaceIds = new Set(demoWorkspaces.map((workspace) => workspace.id))
+
+    expect(response.status).toBe(200)
+    expect(body.tasks.length).toBeGreaterThan(0)
+    expect(body.tasks.every((task) => workspaceIds.has(task.wsId))).toBe(true)
+  })
+})

--- a/ui/src/demo/handlers/headless.ts
+++ b/ui/src/demo/handlers/headless.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw'
 
 import type { HeadlessOutput, HeadlessTaskRecord } from '../../api/headless'
+import { DEMO_CHAT_WORKSPACE_ID, DEMO_WORKSPACE_ID } from '../fixtures/workspaces'
 
 const now = Date.now()
 const demoHeadlessTasks: HeadlessTaskRecord[] = [
@@ -8,7 +9,7 @@ const demoHeadlessTasks: HeadlessTaskRecord[] = [
     taskId: 'demo-headless-1',
     resumeId: 'demo-resume-1',
     resumable: true,
-    wsId: 'demo-ws',
+    wsId: DEMO_WORKSPACE_ID,
     agent: 'codex',
     prompt: 'Compute a quant snapshot of NVDA and push a report to the inbox.',
     status: 'done',
@@ -21,7 +22,7 @@ const demoHeadlessTasks: HeadlessTaskRecord[] = [
     taskId: 'demo-headless-2',
     resumeId: 'demo-resume-2',
     resumable: false,
-    wsId: 'demo-chat',
+    wsId: DEMO_CHAT_WORKSPACE_ID,
     agent: 'claude',
     prompt: "Summarize today's AI-sector headlines and flag anything actionable.",
     status: 'running',
@@ -31,7 +32,7 @@ const demoHeadlessTasks: HeadlessTaskRecord[] = [
     taskId: 'demo-headless-3',
     resumeId: 'demo-resume-3',
     resumable: false,
-    wsId: 'demo-ws',
+    wsId: DEMO_WORKSPACE_ID,
     agent: 'pi',
     prompt: 'Refresh the uranium watchlist and note any breakouts.',
     status: 'interrupted',

--- a/ui/src/demo/handlers/trading.spec.ts
+++ b/ui/src/demo/handlers/trading.spec.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+
+import { DEMO_UTA_CRYPTO, DEMO_UTA_PAPER } from '../fixtures/trading'
+import { tradingHandlers } from './trading'
+
+const server = setupServer(...tradingHandlers)
+const baseUrl = window.location.origin
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+async function marketClock(utaId: string): Promise<{
+  isOpen: boolean
+  nextOpen?: string
+  nextClose?: string
+}> {
+  const response = await fetch(`${baseUrl}/api/trading/uta/${utaId}/market-clock`)
+  expect(response.status).toBe(200)
+  return response.json()
+}
+
+describe('demo trading market clock', () => {
+  it('models crypto accounts as always open without an exchange-session schedule', async () => {
+    await expect(marketClock(DEMO_UTA_CRYPTO)).resolves.toEqual({ isOpen: true })
+  })
+
+  it('keeps scheduled market hours for securities accounts', async () => {
+    const clock = await marketClock(DEMO_UTA_PAPER)
+
+    expect(clock.isOpen).toBe(false)
+    expect(clock.nextOpen).toBeTypeOf('string')
+    expect(clock.nextClose).toBeTypeOf('string')
+  })
+})

--- a/ui/src/demo/handlers/trading.ts
+++ b/ui/src/demo/handlers/trading.ts
@@ -130,13 +130,16 @@ export const tradingHandlers = [
   http.get('/api/trading/uta/:id/trade-history', ({ params }) =>
     HttpResponse.json({ trades: demoTradeHistoryByUTA[utaId(params)] ?? [] }),
   ),
-  http.get('/api/trading/uta/:id/market-clock', () =>
-    HttpResponse.json({
+  http.get('/api/trading/uta/:id/market-clock', ({ params }) => {
+    if (utaId(params) === DEMO_UTA_CRYPTO) {
+      return HttpResponse.json({ isOpen: true })
+    }
+    return HttpResponse.json({
       isOpen: false,
       nextOpen: new Date(Date.now() + 3600_000).toISOString(),
       nextClose: new Date(Date.now() + 7 * 3600_000).toISOString(),
-    }),
-  ),
+    })
+  }),
 
   http.get('/api/trading/uta/:id/wallet/status', () =>
     HttpResponse.json({ staged: [], pendingMessage: null, head: null, commitCount: 0 }),

--- a/ui/src/pages/AgentPermissionsPage.tsx
+++ b/ui/src/pages/AgentPermissionsPage.tsx
@@ -190,7 +190,11 @@ function AiTradingToggle({
             {enabled ? t('settings.agent.allowAiTradingOn') : t('settings.agent.allowAiTradingOff')}
           </p>
         </div>
-        <Toggle checked={enabled} onChange={onToggle} />
+        <Toggle
+          ariaLabel={t('settings.agent.allowAiTrading')}
+          checked={enabled}
+          onChange={onToggle}
+        />
       </div>
       {enabled && (
         <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] text-destructive leading-relaxed">

--- a/ui/src/pages/AutomationRunsSection.spec.tsx
+++ b/ui/src/pages/AutomationRunsSection.spec.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HeadlessListSnapshot, HeadlessTaskRecord } from '../api/headless'
+import type { Workspace } from '../components/workspace/api'
+import { AutomationRunsSection } from './AutomationRunsSection'
+
+const mocks = vi.hoisted(() => ({
+  snapshot: vi.fn(),
+  output: vi.fn(),
+  openHeadlessRun: vi.fn(),
+  workspaces: [] as unknown[],
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    headless: {
+      snapshot: mocks.snapshot,
+      output: mocks.output,
+    },
+  },
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    workspaces: mocks.workspaces,
+    openHeadlessRun: mocks.openHeadlessRun,
+  }),
+}))
+
+const liveWorkspace: Workspace = {
+  id: 'ws-live-internal-id',
+  tag: 'quant-desk',
+  displayName: 'Quant research',
+  dir: '/tmp/quant-desk',
+  createdAt: '2026-07-29T00:00:00.000Z',
+  template: 'chat',
+  agents: ['codex'],
+  sessions: [],
+}
+
+function task(overrides: Partial<HeadlessTaskRecord>): HeadlessTaskRecord {
+  return {
+    taskId: 'run-default',
+    resumeId: 'resume-default',
+    resumable: false,
+    wsId: liveWorkspace.id,
+    agent: 'codex',
+    prompt: 'Review the latest market snapshot.',
+    status: 'running',
+    startedAt: Date.now() - 1_000,
+    ...overrides,
+  }
+}
+
+function snapshot(tasks: HeadlessTaskRecord[]): HeadlessListSnapshot {
+  return {
+    tasks,
+    page: { total: tasks.length, hasMore: false, nextCursor: null },
+    summary: { done: 0, needsAttention: 0 },
+    capacity: {
+      running: tasks.filter((item) => item.status === 'running').length,
+      limit: 8,
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.workspaces = [liveWorkspace]
+})
+
+afterEach(cleanup)
+
+describe('AutomationRunsSection workspace identity', () => {
+  it('shows the current Workspace tag instead of its internal id', async () => {
+    mocks.snapshot.mockResolvedValue(snapshot([task({})]))
+
+    render(<AutomationRunsSection />)
+
+    expect(await screen.findByText('quant-desk')).toBeTruthy()
+    expect(screen.queryByText(liveWorkspace.id)).toBeNull()
+    expect(screen.getByTitle('Quant research (quant-desk)')).toBeTruthy()
+  })
+
+  it('keeps the full stored id when the Workspace no longer exists', async () => {
+    const departedId = 'ws-departed-full-internal-id'
+    mocks.snapshot.mockResolvedValue(snapshot([
+      task({ taskId: 'run-departed', wsId: departedId }),
+    ]))
+
+    render(<AutomationRunsSection />)
+
+    expect(await screen.findByText(departedId)).toBeTruthy()
+    expect(screen.getByTitle(departedId).className).toContain('font-mono')
+  })
+})

--- a/ui/src/pages/AutomationRunsSection.tsx
+++ b/ui/src/pages/AutomationRunsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Bot,
   ChevronDown,
@@ -204,7 +204,19 @@ export function AutomationRunsSection() {
   const [error, setError] = useState<string | null>(null)
   const [loadingMore, setLoadingMore] = useState(false)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
-  const { openHeadlessRun } = useWorkspaces()
+  const { openHeadlessRun, workspaces } = useWorkspaces()
+  const workspaceLabels = useMemo(() => new Map(
+    workspaces.map((workspace) => {
+      const displayName = workspace.displayName?.trim()
+      return [
+        workspace.id,
+        {
+          label: workspace.tag,
+          title: displayName ? `${displayName} (${workspace.tag})` : workspace.tag,
+        },
+      ] as const
+    }),
+  ), [workspaces])
 
   const toggle = (id: string) => setExpanded((prev) => {
     const next = new Set(prev)
@@ -322,6 +334,7 @@ export function AutomationRunsSection() {
           {snapshot.tasks.map((task) => {
             const isExpanded = expanded.has(task.taskId)
             const openable = task.status !== 'running' && task.resumable
+            const workspaceLabel = workspaceLabels.get(task.wsId)
             const toolSummary = task.output?.toolCalls
               ? `${task.output.toolCalls} tool${task.output.toolCalls === 1 ? '' : 's'}`
               : task.output
@@ -349,7 +362,12 @@ export function AutomationRunsSection() {
                     </span>
                     <span className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
                       <span>{task.agent}</span>
-                      <span className="font-mono">{task.wsId.slice(0, 8)}</span>
+                      <span
+                        className={workspaceLabel ? undefined : 'font-mono'}
+                        title={workspaceLabel?.title ?? task.wsId}
+                      >
+                        {workspaceLabel?.label ?? task.wsId}
+                      </span>
                       <span>{formatRelativeTime(task.startedAt)}</span>
                       <span>{fmtDuration(task.durationMs)}</span>
                       <span>{toolSummary}</span>

--- a/ui/src/pages/Connectors.demo.spec.tsx
+++ b/ui/src/pages/Connectors.demo.spec.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PublicConnectorConfig } from '../api'
 import { createDemoConnectorSnapshot } from '../demo/fixtures/connectors'
 import { ConnectorStatusPage } from './ConnectorStatusPage'
 import { ConnectorsPage } from './ConnectorsPage'
@@ -58,5 +59,21 @@ describe('Connector demo routes', () => {
     expect(screen.getByText('Telegram')).toBeTruthy()
     expect(screen.getByText('Application ID')).toBeTruthy()
     expect(screen.getAllByText('Bot token')).toHaveLength(2)
+  })
+
+  it('keeps the complete secret draft while the user types', async () => {
+    render(<ConnectorsPage />)
+
+    await screen.findByText('Run external notification connectors')
+    const input = screen.getAllByPlaceholderText('Stored locally and sealed')[0] as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: `${input.value}a` } })
+    expect(input.value).toBe('a')
+    fireEvent.change(input, { target: { value: `${input.value}b` } })
+    expect(input.value).toBe('ab')
+
+    await waitFor(() => expect(mocks.save).toHaveBeenCalled())
+    const saved = mocks.save.mock.calls.at(-1)?.[0] as PublicConnectorConfig
+    expect(saved.adapters.discord.settings.botToken).toBe('ab')
   })
 })

--- a/ui/src/pages/Connectors.demo.spec.tsx
+++ b/ui/src/pages/Connectors.demo.spec.tsx
@@ -37,7 +37,7 @@ beforeEach(async () => {
   vi.clearAllMocks()
   await i18n.changeLanguage('en')
   mocks.load.mockImplementation(async () => createDemoConnectorSnapshot())
-  mocks.save.mockImplementation(async (config) => ({ config }))
+  mocks.save.mockImplementation(async (config) => ({ config: redactSecrets(config) }))
   mocks.test.mockResolvedValue({ ok: true, probeId: 'connector-probe-demo' })
 })
 
@@ -77,19 +77,74 @@ describe('Connector demo routes', () => {
     expect(screen.getAllByText('Bot token')).toHaveLength(2)
   })
 
-  it('keeps the complete secret draft while the user types', async () => {
+  it('keeps a secret as a local draft until the user saves it explicitly', async () => {
     render(<ConnectorsPage />)
 
     await screen.findByText('Run external notification connectors')
     const input = screen.getAllByPlaceholderText('Stored locally and sealed')[0] as HTMLInputElement
 
-    fireEvent.change(input, { target: { value: `${input.value}a` } })
+    fireEvent.change(input, { target: { value: 'a' } })
     expect(input.value).toBe('a')
-    fireEvent.change(input, { target: { value: `${input.value}b` } })
+    await new Promise((resolve) => window.setTimeout(resolve, 800))
+    expect(mocks.save).not.toHaveBeenCalled()
+    expect(input.value).toBe('a')
+
+    fireEvent.change(input, { target: { value: 'ab' } })
     expect(input.value).toBe('ab')
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save token' })[0])
 
     await waitFor(() => expect(mocks.save).toHaveBeenCalled())
     const saved = mocks.save.mock.calls.at(-1)?.[0] as PublicConnectorConfig
     expect(saved.adapters.discord.settings.botToken).toBe('ab')
+    await waitFor(() => expect(input.value).toBe(''))
+    expect(input.placeholder).toBe('Configured — enter a new value to replace')
+    expect((screen.getAllByRole('button', { name: 'Replace token' })[0] as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('retains a secret draft when saving fails', async () => {
+    mocks.save.mockRejectedValueOnce(new Error('Connector settings unavailable'))
+    render(<ConnectorsPage />)
+
+    await screen.findByText('Run external notification connectors')
+    const input = screen.getAllByPlaceholderText('Stored locally and sealed')[0] as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'still-here' } })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save token' })[0])
+
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Token was not saved: Connector settings unavailable',
+    )
+    expect(input.value).toBe('still-here')
+  })
+
+  it('removes a configured secret only from the explicit remove action', async () => {
+    const snapshot = createDemoConnectorSnapshot()
+    snapshot.config.adapters.discord.configuredSecrets = ['botToken']
+    mocks.load.mockResolvedValue(snapshot)
+    render(<ConnectorsPage />)
+
+    await screen.findByText('Run external notification connectors')
+    fireEvent.click(screen.getByRole('button', { name: 'Remove token' }))
+
+    await waitFor(() => expect(mocks.save).toHaveBeenCalled(), { timeout: 1_200 })
+    const saved = mocks.save.mock.calls.at(-1)?.[0] as PublicConnectorConfig
+    expect(saved.adapters.discord.configuredSecrets).toEqual([])
+    expect(saved.adapters.discord.settings.botToken).toBe('')
   })
 })
+
+function redactSecrets(config: PublicConnectorConfig): PublicConnectorConfig {
+  return {
+    ...config,
+    adapters: Object.fromEntries(Object.entries(config.adapters).map(([id, adapter]) => {
+      const secretKeys = id === 'discord' || id === 'telegram' ? ['botToken'] : []
+      const configuredSecrets = new Set(adapter.configuredSecrets)
+      const settings = { ...adapter.settings }
+      for (const key of secretKeys) {
+        const value = settings[key]
+        if (typeof value === 'string' && value.length > 0) configuredSecrets.add(key)
+        delete settings[key]
+      }
+      return [id, { ...adapter, settings, configuredSecrets: [...configuredSecrets] }]
+    })),
+  }
+}

--- a/ui/src/pages/ConnectorsPage.tsx
+++ b/ui/src/pages/ConnectorsPage.tsx
@@ -18,6 +18,9 @@ export function ConnectorsPage() {
   const [config, setConfig] = useState<PublicConnectorConfig | null>(null)
   const [health, setHealth] = useState<ConnectorHealth | null>(null)
   const [loadError, setLoadError] = useState(false)
+  const [secretDrafts, setSecretDrafts] = useState<Record<string, string>>({})
+  const [savingSecret, setSavingSecret] = useState<string | null>(null)
+  const [secretErrors, setSecretErrors] = useState<Record<string, string>>({})
   const [testing, setTesting] = useState<string | null>(null)
   const [testError, setTestError] = useState<string | null>(null)
   const [lastProbe, setLastProbe] = useState<{ connectorId: string; probeId: string } | null>(null)
@@ -128,6 +131,57 @@ export function ConnectorsPage() {
     })
   }, [])
 
+  const saveSecret = useCallback(async (id: string, key: string) => {
+    if (!config) return
+    const draftKey = connectorFieldKey(id, key)
+    const value = secretDrafts[draftKey] ?? ''
+    if (!value) return
+
+    const existing = config.adapters[id] ?? emptyAdapter()
+    const next: PublicConnectorConfig = {
+      ...config,
+      adapters: {
+        ...config.adapters,
+        [id]: {
+          ...existing,
+          settings: { ...existing.settings, [key]: value },
+          configuredSecrets: [...new Set([...existing.configuredSecrets, key])],
+        },
+      },
+    }
+
+    setSavingSecret(draftKey)
+    setSecretErrors((current) => omitRecordKey(current, draftKey))
+    try {
+      const response = await api.connectors.save(next)
+      setConfig((current) => {
+        if (!current) return response.config
+        const currentAdapter = current.adapters[id] ?? emptyAdapter()
+        const savedAdapter = response.config.adapters[id]
+        if (!savedAdapter) return current
+        const configuredSecrets = savedAdapter.configuredSecrets
+        if (sameStrings(currentAdapter.configuredSecrets, configuredSecrets)) return current
+        return {
+          ...current,
+          adapters: {
+            ...current.adapters,
+            [id]: { ...currentAdapter, configuredSecrets },
+          },
+        }
+      })
+      setSecretDrafts((current) => omitRecordKey(current, draftKey))
+      window.setTimeout(() => { void refreshRuntime() }, 900)
+      window.setTimeout(() => { void refreshRuntime() }, 2_400)
+    } catch (error) {
+      setSecretErrors((current) => ({
+        ...current,
+        [draftKey]: error instanceof Error ? error.message : String(error),
+      }))
+    } finally {
+      setSavingSecret((current) => current === draftKey ? null : current)
+    }
+  }, [config, refreshRuntime, secretDrafts])
+
   const test = useCallback(async (id: string) => {
     setTesting(id)
     setTestError(null)
@@ -197,52 +251,90 @@ export function ConnectorsPage() {
                       {definition.fields.filter((field) => !field.learnedBy).map((field) => {
                         const configured = adapter.configuredSecrets.includes(field.key)
                         const value = adapter.settings[field.key]
+                        const draftKey = connectorFieldKey(definition.id, field.key)
+                        const secretDraft = secretDrafts[draftKey] ?? ''
+                        const secretSaving = savingSecret === draftKey
+                        const inputId = `connector-${definition.id}-${field.key}`
                         return (
                           <Field key={field.key} label={field.label} description={field.description}>
                             {field.kind === 'boolean' ? (
                               <input
+                                id={inputId}
+                                aria-label={`${definition.label} ${field.label}`}
                                 type="checkbox"
                                 checked={value === true}
                                 onChange={(event) => updateSetting(definition.id, field.key, event.target.checked)}
                               />
-                            ) : (
-                              <div className="flex flex-col gap-2 sm:flex-row">
-                                <input
-                                  className={inputClass}
-                                  type={field.kind === 'secret' ? 'password' : field.kind}
-                                  value={String(value ?? '')}
-                                  placeholder={configured ? 'Configured — enter a new value to replace' : field.placeholder}
-                                  autoComplete="off"
-                                  onChange={(event) => updateSetting(
-                                    definition.id,
-                                    field.key,
-                                    field.kind === 'number' ? Number(event.target.value) : event.target.value,
-                                  )}
-                                />
-                                {field.kind === 'secret' && configured && (
+                            ) : field.kind === 'secret' ? (
+                              <>
+                                <div className="flex flex-col gap-2 sm:flex-row">
+                                  <input
+                                    id={inputId}
+                                    aria-label={`${definition.label} ${field.label}`}
+                                    className={inputClass}
+                                    type="password"
+                                    value={secretDraft}
+                                    placeholder={configured ? 'Configured — enter a new value to replace' : field.placeholder}
+                                    autoComplete="off"
+                                    onChange={(event) => {
+                                      setSecretDrafts((current) => ({ ...current, [draftKey]: event.target.value }))
+                                      setSecretErrors((current) => omitRecordKey(current, draftKey))
+                                    }}
+                                  />
                                   <button
                                     type="button"
-                                    className="shrink-0 rounded-lg border border-border px-3 text-[12px] text-muted-foreground hover:text-destructive"
-                                    onClick={() => setConfig((current) => {
-                                      if (!current) return current
-                                      const currentAdapter = current.adapters[definition.id]!
-                                      return {
-                                        ...current,
-                                        adapters: {
-                                          ...current.adapters,
-                                          [definition.id]: {
-                                            ...currentAdapter,
-                                            settings: { ...currentAdapter.settings, [field.key]: '' },
-                                            configuredSecrets: currentAdapter.configuredSecrets.filter((key) => key !== field.key),
-                                          },
-                                        },
-                                      }
-                                    })}
+                                    className="shrink-0 rounded-lg border border-border px-3 py-2 text-[12px] text-foreground hover:border-primary/50 disabled:opacity-50"
+                                    disabled={!secretDraft || secretSaving}
+                                    onClick={() => void saveSecret(definition.id, field.key)}
                                   >
-                                    Clear
+                                    {secretSaving ? 'Saving…' : configured ? 'Replace token' : 'Save token'}
                                   </button>
+                                  {configured && (
+                                    <button
+                                      type="button"
+                                      className="shrink-0 rounded-lg border border-border px-3 py-2 text-[12px] text-muted-foreground hover:text-destructive"
+                                      disabled={secretSaving}
+                                      onClick={() => setConfig((current) => {
+                                        if (!current) return current
+                                        const currentAdapter = current.adapters[definition.id]!
+                                        return {
+                                          ...current,
+                                          adapters: {
+                                            ...current.adapters,
+                                            [definition.id]: {
+                                              ...currentAdapter,
+                                              settings: { ...currentAdapter.settings, [field.key]: '' },
+                                              configuredSecrets: currentAdapter.configuredSecrets.filter((key) => key !== field.key),
+                                            },
+                                          },
+                                        }
+                                      })}
+                                    >
+                                      Remove token
+                                    </button>
+                                  )}
+                                </div>
+                                {secretErrors[draftKey] && (
+                                  <p className="mt-1 text-[12px] text-destructive" role="alert">
+                                    Token was not saved: {secretErrors[draftKey]}
+                                  </p>
                                 )}
-                              </div>
+                              </>
+                            ) : (
+                              <input
+                                id={inputId}
+                                aria-label={`${definition.label} ${field.label}`}
+                                className={inputClass}
+                                type={field.kind}
+                                value={String(value ?? '')}
+                                placeholder={field.placeholder}
+                                autoComplete="off"
+                                onChange={(event) => updateSetting(
+                                  definition.id,
+                                  field.key,
+                                  field.kind === 'number' ? Number(event.target.value) : event.target.value,
+                                )}
+                              />
                             )}
                           </Field>
                         )
@@ -451,4 +543,19 @@ function HealthLine({ health }: { health: ConnectorHealth | null }) {
 
 function emptyAdapter(): PublicConnectorConfig['adapters'][string] {
   return { enabled: false, settings: {}, configuredSecrets: [] }
+}
+
+function connectorFieldKey(connectorId: string, fieldKey: string): string {
+  return `${connectorId}:${fieldKey}`
+}
+
+function omitRecordKey(record: Record<string, string>, key: string): Record<string, string> {
+  if (!(key in record)) return record
+  const next = { ...record }
+  delete next[key]
+  return next
+}
+
+function sameStrings(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
 }

--- a/ui/src/pages/ConnectorsPage.tsx
+++ b/ui/src/pages/ConnectorsPage.tsx
@@ -210,7 +210,7 @@ export function ConnectorsPage() {
                                 <input
                                   className={inputClass}
                                   type={field.kind === 'secret' ? 'password' : field.kind}
-                                  value={field.kind === 'secret' ? '' : String(value ?? '')}
+                                  value={String(value ?? '')}
                                   placeholder={configured ? 'Configured — enter a new value to replace' : field.placeholder}
                                   autoComplete="off"
                                   onChange={(event) => updateSetting(

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -243,7 +243,12 @@ export function MarketDataPage() {
         right={
           <div className="flex items-center gap-3">
             <SaveIndicator status={status} onRetry={retry} />
-            <Toggle size="sm" checked={enabled} onChange={(v) => updateConfigImmediate({ enabled: v })} />
+            <Toggle
+              ariaLabel="Market data"
+              size="sm"
+              checked={enabled}
+              onChange={(v) => updateConfigImmediate({ enabled: v })}
+            />
           </div>
         }
       />
@@ -294,7 +299,7 @@ function HubCard({
     <section className="mb-6 border border-border/60 rounded-xl bg-secondary/50 p-5">
       <div className="flex items-center justify-between mb-1.5">
         <h2 className="text-[14px] font-semibold">Data Hub</h2>
-        <Toggle size="sm" checked={hub.enabled} onChange={onToggle} />
+        <Toggle ariaLabel="Data Hub" size="sm" checked={hub.enabled} onChange={onToggle} />
       </div>
       {hub.enabled ? (
         <div className="flex items-center gap-2 mb-1.5">
@@ -385,7 +390,7 @@ function ChartVendorsSection({
                 {v.alwaysOn ? (
                   <span className="text-[11px] text-muted-foreground/60 uppercase tracking-wider shrink-0">always on</span>
                 ) : (
-                  <Toggle size="sm" checked={on} onChange={(val) => onToggle(v.id, val)} />
+                  <Toggle ariaLabel={v.name} size="sm" checked={on} onChange={(val) => onToggle(v.id, val)} />
                 )}
               </div>
               <p className="text-[12px] text-muted-foreground/70 mt-1.5 leading-relaxed">{v.desc}</p>

--- a/ui/src/pages/NewsCollectorPage.spec.tsx
+++ b/ui/src/pages/NewsCollectorPage.spec.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { FeedsSection } from './NewsCollectorPage'
+
+afterEach(cleanup)
+
+describe('NewsCollectorPage feed editor', () => {
+  it('rejects an invalid feed URL before submitting the feed', () => {
+    const onChange = vi.fn()
+    render(<FeedsSection feeds={[]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. CoinDesk'), {
+      target: { value: 'Example Markets' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('e.g. coindesk'), {
+      target: { value: 'example-markets' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('https://example.com/rss.xml'), {
+      target: { value: 'not-a-url' },
+    })
+
+    const addButton = screen.getByRole('button', { name: 'Add Feed' })
+    const urlInput = screen.getByPlaceholderText('https://example.com/rss.xml')
+
+    expect((addButton as HTMLButtonElement).disabled).toBe(true)
+    expect(urlInput.getAttribute('aria-invalid')).toBe('true')
+    expect(screen.getByRole('alert').textContent).toContain('Enter a valid URL')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('submits a trimmed feed after the URL becomes valid', () => {
+    const onChange = vi.fn()
+    render(<FeedsSection feeds={[]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. CoinDesk'), {
+      target: { value: ' Example Markets ' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('e.g. coindesk'), {
+      target: { value: ' example-markets ' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('https://example.com/rss.xml'), {
+      target: { value: ' https://example.com/rss.xml ' },
+    })
+
+    const addButton = screen.getByRole('button', { name: 'Add Feed' })
+
+    expect((addButton as HTMLButtonElement).disabled).toBe(false)
+    expect(screen.queryByRole('alert')).toBeNull()
+    fireEvent.click(addButton)
+
+    expect(onChange).toHaveBeenCalledWith([{
+      name: 'Example Markets',
+      url: 'https://example.com/rss.xml',
+      source: 'example-markets',
+      enabled: true,
+    }])
+  })
+})

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -29,7 +29,12 @@ function CollectorSettings() {
     <div className="mx-auto w-full max-w-[880px]">
       <div className="mb-4 flex items-center justify-end gap-3">
         <SaveIndicator status={status} onRetry={retry} />
-        <Toggle size="sm" checked={enabled} onChange={(v) => updateConfigImmediate({ enabled: v })} />
+        <Toggle
+          ariaLabel="News collection"
+          size="sm"
+          checked={enabled}
+          onChange={(v) => updateConfigImmediate({ enabled: v })}
+        />
       </div>
 
       <div className={`${!enabled ? 'opacity-40 pointer-events-none' : ''}`}>
@@ -129,6 +134,7 @@ function FeedsSection({
                 className={`flex items-center gap-3 border border-border/60 rounded-lg px-3 py-2.5 ${isEnabled ? '' : 'opacity-50'}`}
               >
                 <Toggle
+                  ariaLabel={feed.name}
                   size="sm"
                   checked={isEnabled}
                   onChange={(v) => setEnabled(i, v)}

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -73,7 +73,16 @@ function CollectorSettings() {
 
 // ==================== Feeds Section ====================
 
-function FeedsSection({
+export function isValidFeedUrl(value: string): boolean {
+  try {
+    new URL(value.trim())
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function FeedsSection({
   feeds,
   onChange,
 }: {
@@ -86,6 +95,8 @@ function FeedsSection({
   const [newDescription, setNewDescription] = useState('')
 
   const activeCount = useMemo(() => feeds.filter((f) => f.enabled !== false).length, [feeds])
+  const feedUrlValid = isValidFeedUrl(newUrl)
+  const showFeedUrlError = newUrl.trim().length > 0 && !feedUrlValid
 
   const removeFeed = (index: number) => onChange(feeds.filter((_, i) => i !== index))
 
@@ -94,7 +105,7 @@ function FeedsSection({
   }
 
   const addFeed = () => {
-    if (!newName.trim() || !newUrl.trim() || !newSource.trim()) return
+    if (!newName.trim() || !feedUrlValid || !newSource.trim()) return
     const entry: NewsCollectorFeed = {
       name: newName.trim(),
       url: newUrl.trim(),
@@ -174,14 +185,27 @@ function FeedsSection({
           </Field>
         </div>
         <Field label="Feed URL">
-          <input className={inputClass} value={newUrl} onChange={(e) => setNewUrl(e.target.value)} placeholder="https://example.com/rss.xml" />
+          <input
+            className={inputClass}
+            type="url"
+            value={newUrl}
+            onChange={(e) => setNewUrl(e.target.value)}
+            placeholder="https://example.com/rss.xml"
+            aria-invalid={showFeedUrlError}
+            aria-describedby={showFeedUrlError ? 'news-feed-url-error' : undefined}
+          />
+          {showFeedUrlError && (
+            <p id="news-feed-url-error" role="alert" className="mt-1 text-[12px] text-destructive">
+              Enter a valid URL, for example https://example.com/rss.xml.
+            </p>
+          )}
         </Field>
         <Field label="Description (optional)">
           <input className={inputClass} value={newDescription} onChange={(e) => setNewDescription(e.target.value)} placeholder="Short description shown in the feed list" />
         </Field>
         <button
           onClick={addFeed}
-          disabled={!newName.trim() || !newUrl.trim() || !newSource.trim()}
+          disabled={!newName.trim() || !feedUrlValid || !newSource.trim()}
           className="btn-secondary"
         >
           Add Feed

--- a/ui/src/pages/NewsPage.spec.tsx
+++ b/ui/src/pages/NewsPage.spec.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { NewsPage } from './NewsPage'
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    news: {
+      list: mocks.list,
+    },
+  },
+}))
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+  mocks.list.mockResolvedValue({
+    items: [
+      {
+        time: '2026-07-29T08:00:00.000Z',
+        title: 'Middle update',
+        content: 'Middle content',
+        source: 'Reuters',
+        link: null,
+        categories: null,
+      },
+      {
+        time: '2026-07-29T10:00:00.000Z',
+        title: 'Newest update',
+        content: 'Newest content',
+        source: 'Bloomberg',
+        link: null,
+        categories: null,
+      },
+      {
+        time: '2026-07-29T06:00:00.000Z',
+        title: 'Oldest update',
+        content: 'Oldest content',
+        source: 'CNBC',
+        link: null,
+        categories: null,
+      },
+    ],
+    count: 3,
+    lookback: '24h',
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('NewsPage ordering', () => {
+  it('shows the newest article first regardless of API response order', async () => {
+    render(<NewsPage />)
+
+    const newest = await screen.findByText('Newest update')
+    const middle = screen.getByText('Middle update')
+    const oldest = screen.getByText('Oldest update')
+
+    expect(newest.compareDocumentPosition(middle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(middle.compareDocumentPosition(oldest) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})

--- a/ui/src/pages/NewsPage.tsx
+++ b/ui/src/pages/NewsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatRelativeTime } from '../lib/intl'
 import { api, type NewsArticle } from '../api'
@@ -87,6 +87,12 @@ export function NewsPage() {
   const [sourceFilter, setSourceFilter] = useState('')
   const [loading, setLoading] = useState(true)
   const [sources, setSources] = useState<string[]>([])
+  const orderedArticles = useMemo(
+    () => [...articles].sort(
+      (a, b) => new Date(b.time).getTime() - new Date(a.time).getTime(),
+    ),
+    [articles],
+  )
 
   const fetchArticles = useCallback(async (lb: string, src: string) => {
     try {
@@ -170,8 +176,11 @@ export function NewsPage() {
               <EmptyState title={t('news.noArticles')} description={t('news.noArticlesDescription')} />
             ) : (
               <div className="divide-y divide-border/50">
-                {[...articles].reverse().map((article, i) => (
-                  <ArticleRow key={`${article.time}-${i}`} article={article} />
+                {orderedArticles.map((article) => (
+                  <ArticleRow
+                    key={`${article.time}-${article.link ?? article.title}`}
+                    article={article}
+                  />
                 ))}
               </div>
             )}

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -930,6 +930,7 @@ function ToolGroupCard({
           </span>
         </button>
         <Toggle
+          ariaLabel={`${label} tools`}
           size="sm"
           checked={!noneEnabled}
           onChange={(v) => onToggleGroup(group.tools, v)}
@@ -961,6 +962,7 @@ function ToolGroupCard({
                   )}
                 </div>
                 <Toggle
+                  ariaLabel={t.name}
                   size="sm"
                   checked={enabled}
                   onChange={() => onToggleTool(t.name)}

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -220,6 +220,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
           // paddings — mixed sizes were what made this row look drunk.
           <div className="flex items-center gap-2">
             <Toggle
+              ariaLabel={`${preset?.label ?? uta.id} enabled`}
               size="sm"
               checked={!isDisabled}
               onChange={async (v) => { await tc.saveUTA({ ...uta, enabled: v }) }}


### PR DESCRIPTION
## Summary
- integrate the reviewed product-consistency contributions from #744, #745, #750, #751, #752, #753, #754, and #756
- improve toggle and Workspace overview accessibility, preserve current Workspace context in Inbox and Automation, and make News ordering explicit
- align demo crypto market clocks, validate RSS feed URLs before submission, and retain connector token drafts
- finish the connector-token interaction by keeping secrets in local drafts until an explicit Save/Replace action; failed saves retain the draft and Remove token remains a separate action

## Verification
- `pnpm test` — 397 files passed, 1 skipped; 3472 tests passed, 9 skipped
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F @traderalice/connector-service typecheck`
- `pnpm -F @traderalice/connector-service build`
- `pnpm test:connector-replay` — 11 tests passed
- `pnpm test:connector-service` — real-process smoke passed
- real `pnpm dev` browser checks across Workspace Overview, Inbox, News, Automation Runs, News Sources, Agent Permissions, Market Data, and Connectors
- verified a configured token field at slow typing cadence (`x` → `xy` → `xyz`, 850 ms pauses) retains the complete unsaved draft; the temporary draft was cleared without saving
- connector tests now emulate the production API contract where saved secrets are never returned to the browser
- #753 is demo-handler-only and is covered by its handler contract test rather than the real dev API

## Boundary touch
- credentials UI and sealed-secret public API contract; no token values are returned, logged, or included in tests
- demo surface for #753
- no trading writes, migrations, packaging, or release changes