### PR TITLE
Integrate UTA detail presentation improvements

### DIFF
--- a/ui/src/components/uta/EditUTADialog.tsx
+++ b/ui/src/components/uta/EditUTADialog.tsx
@@ -5,6 +5,7 @@ import { GuardsSection, CRYPTO_GUARD_TYPES, SECURITIES_GUARD_TYPES } from '../gu
 import { ReconnectButton } from '../ReconnectButton'
 import { useSchemaForm } from '../../hooks/useSchemaForm'
 import type { UTAConfig, BrokerPreset, BrokerHealthInfo } from '../../api/types'
+import { displayNameForUTA } from '../../lib/uta-account-filter'
 import { Dialog } from './Dialog'
 import { HealthBadge } from './HealthBadge'
 import { SchemaFormFields } from './SchemaFormFields'
@@ -71,13 +72,19 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
   }
 
   const guardTypes = (preset?.guardCategory === 'crypto') ? CRYPTO_GUARD_TYPES : SECURITIES_GUARD_TYPES
+  const displayName = displayNameForUTA(uta, preset)
 
   return (
     <Dialog onClose={onClose} width="w-[560px]">
       {/* Header */}
       <div className="shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
         <div className="flex items-center gap-3 min-w-0">
-          <h3 className="text-[14px] font-semibold text-foreground truncate">{uta.id}</h3>
+          <div className="min-w-0">
+            <h3 className="text-[14px] font-semibold text-foreground truncate">{displayName}</h3>
+            {displayName !== uta.id && (
+              <div className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">{uta.id}</div>
+            )}
+          </div>
           <HealthBadge health={health} size="md" />
         </div>
         <div className="flex items-center gap-3 shrink-0">

--- a/ui/src/lib/uta-account-filter.spec.ts
+++ b/ui/src/lib/uta-account-filter.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { UTASummary, UTATier } from '../api/types'
-import { displayProviderForUTA, filterAccountTierUTAs, isAccountTierUTA } from './uta-account-filter'
+import { displayNameForUTA, displayProviderForUTA, filterAccountTierUTAs, isAccountTierUTA } from './uta-account-filter'
 
 function summary(id: string, tier: UTATier): UTASummary {
   return {
@@ -41,5 +41,17 @@ describe('UTA account filtering', () => {
     expect(displayProviderForUTA({ id: 'paper', provider: 'alpaca' })).toBe('alpaca')
     expect(displayProviderForUTA({ id: 'binance-readonly' })).toBe('ccxt')
     expect(displayProviderForUTA({ id: 'ibkr-main' })).toBe('ibkr')
+  })
+
+  it('prefers the configured account label for display names', () => {
+    expect(displayNameForUTA(
+      { id: 'alpaca-paper', label: 'Retirement Paper' },
+      { label: 'Alpaca' },
+    )).toBe('Retirement Paper')
+    expect(displayNameForUTA(
+      { id: 'ibkr-main', label: '   ' },
+      { label: 'IBKR' },
+    )).toBe('IBKR')
+    expect(displayNameForUTA({ id: 'custom-broker' })).toBe('custom-broker')
   })
 })

--- a/ui/src/lib/uta-account-filter.ts
+++ b/ui/src/lib/uta-account-filter.ts
@@ -10,6 +10,13 @@ export function filterAccountTierUTAs<T extends UTAAccountCandidate>(utas: reado
   return utas.filter(isAccountTierUTA)
 }
 
+export function displayNameForUTA(
+  uta: { id: string; label?: string },
+  preset?: { label?: string },
+): string {
+  return uta.label?.trim() || preset?.label?.trim() || uta.id
+}
+
 export function displayProviderForUTA(uta: { id: string; provider?: string }): string {
   if (uta.provider) return uta.provider
   const id = uta.id.toLowerCase()

--- a/ui/src/pages/UTADetailPage.order-history.spec.tsx
+++ b/ui/src/pages/UTADetailPage.order-history.spec.tsx
@@ -1,0 +1,46 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { OrderHistoryEntry } from '../api/types'
+import { OrderHistoryTable } from './UTADetailPage'
+
+const order: OrderHistoryEntry = {
+  orderId: 'order-1',
+  timestamp: '2026-07-28T04:03:00.000Z',
+  contract: {
+    aliceId: 'demo-paper|AAPL',
+    symbol: 'AAPL',
+    secType: 'STK',
+    exchange: 'SMART',
+    currency: 'USD',
+  },
+  side: 'BUY',
+  orderType: 'LMT',
+  quantity: '20',
+  limitPrice: '188',
+  status: 'filled',
+  filledQty: '20',
+  avgFillPrice: '187.92',
+  source: 'alice',
+  commitHash: 'commit-1',
+  message: 'Add to the position after earnings',
+}
+
+afterEach(cleanup)
+
+describe('UTADetailPage order history', () => {
+  it('provides a keyboard-accessible details disclosure for each order', () => {
+    render(<OrderHistoryTable orders={[order]} />)
+
+    const details = screen.getByRole('button', { name: 'Show details for AAPL order' })
+    expect(details.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByText(order.message)).toBeNull()
+
+    fireEvent.click(details)
+
+    const hide = screen.getByRole('button', { name: 'Hide details for AAPL order' })
+    expect(hide.getAttribute('aria-expanded')).toBe('true')
+    expect(hide.getAttribute('aria-controls')).toBe('order-history-details-0')
+    expect(screen.getByText(order.message)).toBeTruthy()
+  })
+})

--- a/ui/src/pages/UTADetailPage.order-history.spec.tsx
+++ b/ui/src/pages/UTADetailPage.order-history.spec.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { OrderHistoryEntry } from '../api/types'
 import { OrderHistoryTable } from './UTADetailPage'
@@ -26,7 +26,10 @@ const order: OrderHistoryEntry = {
   message: 'Add to the position after earnings',
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 describe('UTADetailPage order history', () => {
   it('provides a keyboard-accessible details disclosure for each order', () => {
@@ -41,6 +44,36 @@ describe('UTADetailPage order history', () => {
     const hide = screen.getByRole('button', { name: 'Hide details for AAPL order' })
     expect(hide.getAttribute('aria-expanded')).toBe('true')
     expect(hide.getAttribute('aria-controls')).toBe('order-history-details-0')
+    expect(screen.getByText(order.message)).toBeTruthy()
+  })
+
+  it('uses a readable card layout when the available content width is narrow', async () => {
+    class CompactResizeObserver {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+
+      observe(target: Element) {
+        this.callback(
+          [{ target, contentRect: { width: 540 } } as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        )
+      }
+
+      disconnect() {}
+      unobserve() {}
+    }
+    vi.stubGlobal('ResizeObserver', CompactResizeObserver)
+
+    render(<OrderHistoryTable orders={[order]} />)
+
+    expect(await screen.findByRole('list', { name: 'Order history' })).toBeTruthy()
+    expect(screen.queryByRole('table')).toBeNull()
+    expect(screen.getByText('Qty')).toBeTruthy()
+    expect(screen.getByText('Limit')).toBeTruthy()
+    expect(screen.getByText('Fill')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for AAPL order' }))
+
+    expect(screen.getByRole('button', { name: 'Hide details for AAPL order' }).getAttribute('aria-expanded')).toBe('true')
     expect(screen.getByText(order.message)).toBeTruthy()
   })
 })

--- a/ui/src/pages/UTADetailPage.orders-tabs.spec.tsx
+++ b/ui/src/pages/UTADetailPage.orders-tabs.spec.tsx
@@ -1,0 +1,36 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../api', () => ({
+  api: {
+    trading: {
+      orderHistory: vi.fn().mockResolvedValue({ orders: [] }),
+      tradeHistory: vi.fn().mockResolvedValue({ trades: [] }),
+    },
+  },
+}))
+
+import { OrdersArea } from './UTADetailPage'
+
+afterEach(cleanup)
+
+describe('UTADetailPage order views', () => {
+  it('exposes the current view and its controlled content region', () => {
+    render(<OrdersArea utaId="demo-paper" openOrders={[]} />)
+
+    expect(screen.getByRole('group', { name: 'Order views' })).toBeTruthy()
+
+    const open = screen.getByRole('button', { name: 'Open (0)' })
+    const history = screen.getByRole('button', { name: 'History' })
+    expect(open.getAttribute('aria-pressed')).toBe('true')
+    expect(history.getAttribute('aria-pressed')).toBe('false')
+    expect(screen.getByRole('region', { name: 'Open orders' }).id).toBe('orders-open-panel')
+
+    fireEvent.click(history)
+
+    expect(open.getAttribute('aria-pressed')).toBe('false')
+    expect(history.getAttribute('aria-pressed')).toBe('true')
+    expect(history.getAttribute('aria-controls')).toBe('orders-history-panel')
+    expect(screen.getByRole('region', { name: 'Order history' }).id).toBe('orders-history-panel')
+  })
+})

--- a/ui/src/pages/UTADetailPage.positions.spec.tsx
+++ b/ui/src/pages/UTADetailPage.positions.spec.tsx
@@ -1,0 +1,49 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Position } from '../api/types'
+import { PositionsSection } from './UTADetailPage'
+
+function position(symbol: string): Position {
+  return {
+    contract: {
+      aliceId: `demo-paper|${symbol}`,
+      symbol,
+      secType: 'STK',
+      exchange: 'SMART',
+      currency: 'USD',
+    },
+    currency: 'USD',
+    side: 'long',
+    quantity: '10',
+    avgCost: '100',
+    marketPrice: '110',
+    marketValue: '1100',
+    unrealizedPnL: '100',
+    realizedPnL: '0',
+  }
+}
+
+afterEach(cleanup)
+
+describe('UTADetailPage positions table', () => {
+  it('identifies each close action by its contract', () => {
+    const aapl = position('AAPL')
+    const nvda = position('NVDA')
+    const onCloseClick = vi.fn()
+
+    render(
+      <PositionsSection
+        positions={[aapl, nvda]}
+        onCloseClick={onCloseClick}
+      />,
+    )
+
+    expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Close AAPL position' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close NVDA position' }))
+
+    expect(onCloseClick).toHaveBeenCalledWith(nvda)
+  })
+})

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -17,7 +17,7 @@ import { EquityCurve } from '../components/EquityCurve'
 import { Metric, signFromDelta } from '../components/Metric'
 import { fmt, fmtPnl, fmtNum, fmtPctSigned, isUnsetDecimal } from '../lib/format'
 import { secTypeToClass, assetClassLabel, ASSET_CLASS_ORDER, type AssetClass } from '../lib/asset-class'
-import { ContractCell } from '../lib/contract-display'
+import { ContractCell, contractPrimary } from '../lib/contract-display'
 
 // ==================== Page ====================
 
@@ -573,7 +573,7 @@ function Section({ title, action, children }: { title: string; action?: React.Re
 
 interface PositionGroup { class: AssetClass; positions: Position[] }
 
-function PositionsSection({ positions, onCloseClick }: {
+export function PositionsSection({ positions, onCloseClick }: {
   positions: Position[]
   onCloseClick: (p: Position) => void
 }) {
@@ -613,7 +613,9 @@ function PositionsSection({ positions, onCloseClick }: {
               <th className="px-3 py-2 font-medium text-right">Avg → Mark</th>
               <th className="px-3 py-2 font-medium text-right">Mkt Value</th>
               <th className="px-3 py-2 font-medium text-right">PnL</th>
-              <th className="px-3 py-2 font-medium text-right" />
+              <th className="px-3 py-2 font-medium text-right">
+                <span className="sr-only">Actions</span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -685,7 +687,9 @@ function PositionRow({ position: p, onClose }: { position: Position; onClose: ()
       </td>
       <td className="px-3 py-2 text-right">
         <button
+          type="button"
           onClick={onClose}
+          aria-label={`Close ${contractPrimary(p.contract)} position`}
           className="text-[11px] text-muted-foreground hover:text-destructive transition-colors"
         >
           Close

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -17,7 +17,7 @@ import { EquityCurve } from '../components/EquityCurve'
 import { Metric, signFromDelta } from '../components/Metric'
 import { fmt, fmtPnl, fmtNum, fmtPctSigned, isUnsetDecimal } from '../lib/format'
 import { secTypeToClass, assetClassLabel, ASSET_CLASS_ORDER, type AssetClass } from '../lib/asset-class'
-import { ContractCell } from '../lib/contract-display'
+import { ContractCell, contractPrimary } from '../lib/contract-display'
 
 // ==================== Page ====================
 
@@ -889,7 +889,7 @@ function SourceChip({ label }: { label: string }) {
   )
 }
 
-function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
+export function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
   const [expanded, setExpanded] = useState<number | null>(null)
 
   if (orders == null) {
@@ -919,6 +919,7 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
             <th className="px-3 py-2 font-medium text-right">Limit</th>
             <th className="px-3 py-2 font-medium text-right">Fill</th>
             <th className="px-3 py-2 font-medium">Status</th>
+            <th className="px-3 py-2 font-medium text-right">Details</th>
           </tr>
         </thead>
         <tbody>
@@ -943,10 +944,25 @@ function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
                     {o.source === 'external' && <SourceChip label="External" />}
                   </span>
                 </td>
+                <td className="px-3 py-2 text-right">
+                  <button
+                    type="button"
+                    aria-expanded={expanded === i}
+                    aria-controls={`order-history-details-${i}`}
+                    aria-label={`${expanded === i ? 'Hide' : 'Show'} details for ${contractPrimary(o.contract)} order`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      setExpanded(prev => prev === i ? null : i)
+                    }}
+                    className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {expanded === i ? 'Hide' : 'Details'}
+                  </button>
+                </td>
               </tr>
               {expanded === i && (
-                <tr className="border-t border-border bg-muted/20">
-                  <td colSpan={8} className="px-3 py-2 text-[11px] text-muted-foreground">
+                <tr id={`order-history-details-${i}`} className="border-t border-border bg-muted/20">
+                  <td colSpan={9} className="px-3 py-2 text-[11px] text-muted-foreground">
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
                       <span className="font-mono">{o.commitHash}</span>
                       <span>{o.message}</span>

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -18,6 +18,7 @@ import { Metric, signFromDelta } from '../components/Metric'
 import { fmt, fmtPnl, fmtNum, fmtPctSigned, isUnsetDecimal } from '../lib/format'
 import { secTypeToClass, assetClassLabel, ASSET_CLASS_ORDER, type AssetClass } from '../lib/asset-class'
 import { ContractCell } from '../lib/contract-display'
+import { displayNameForUTA } from '../lib/uta-account-filter'
 
 // ==================== Page ====================
 
@@ -197,11 +198,12 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   }
 
   const isDisabled = uta.enabled === false
+  const displayName = displayNameForUTA(uta, preset)
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader
-        title={preset?.label ?? uta.id}
+        title={displayName}
         live={{ lastUpdated }}
         description={
           <>
@@ -276,7 +278,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
               {curvePoints.length >= 2 && (
                 <EquityCurve
                   points={curvePoints}
-                  accounts={[{ id, label: preset?.label ?? id }]}
+                  accounts={[{ id, label: displayName }]}
                   selectedAccountId={id}
                   onAccountChange={() => { /* single-account mode: switcher hidden */ }}
                 />

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { Fragment, useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import type { ViewSpec } from '../tabs/types'
 import { api } from '../api'
@@ -882,6 +882,8 @@ const ORDER_STATUS_STYLES: Record<OrderHistoryStatus, string> = {
   submitted: 'bg-primary/15 text-primary',
 }
 
+const ORDER_HISTORY_COMPACT_WIDTH = 760
+
 function OrderStatusBadge({ status }: { status: OrderHistoryStatus }) {
   return (
     <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${ORDER_STATUS_STYLES[status] ?? 'bg-muted text-muted-foreground'}`}>
@@ -908,6 +910,17 @@ function SourceChip({ label }: { label: string }) {
 
 export function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | null }) {
   const [expanded, setExpanded] = useState<number | null>(null)
+  const [container, setContainer] = useState<HTMLDivElement | null>(null)
+  const [compact, setCompact] = useState(false)
+
+  useLayoutEffect(() => {
+    if (!container || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(([entry]) => {
+      setCompact(entry.contentRect.width < ORDER_HISTORY_COMPACT_WIDTH)
+    })
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [container])
 
   if (orders == null) {
     return (
@@ -923,9 +936,84 @@ export function OrderHistoryTable({ orders }: { orders: OrderHistoryEntry[] | nu
       </div>
     )
   }
+
+  if (compact) {
+    return (
+      <div ref={setContainer}>
+        <ul className="grid gap-2" aria-label="Order history">
+          {orders.map((o, i) => {
+            const detailsId = `order-history-card-details-${i}`
+            const isExpanded = expanded === i
+            return (
+              <li key={`${o.commitHash}-${i}`} className="overflow-hidden rounded-lg border border-border bg-background">
+                <div className="p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <ContractCell contract={o.contract} />
+                    <span className="inline-flex shrink-0 items-center gap-1.5">
+                      <OrderStatusBadge status={o.status} />
+                      {o.source === 'external' && <SourceChip label="External" />}
+                    </span>
+                  </div>
+
+                  <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+                    <span className="tabular-nums">{formatHistoryTime(o.timestamp)}</span>
+                    <span aria-hidden>·</span>
+                    <SideBadge side={o.side} />
+                    <span aria-hidden>·</span>
+                    <span>{o.orderType ?? '—'}</span>
+                  </div>
+
+                  <dl className="mt-3 grid grid-cols-3 gap-2">
+                    <div className="min-w-0 rounded-md bg-muted/35 px-2.5 py-2">
+                      <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Qty</dt>
+                      <dd className="mt-0.5 truncate text-[12px] text-foreground tabular-nums">
+                        {o.quantity != null ? fmtNum(o.quantity) : '—'}
+                      </dd>
+                    </div>
+                    <div className="min-w-0 rounded-md bg-muted/35 px-2.5 py-2">
+                      <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Limit</dt>
+                      <dd className="mt-0.5 truncate text-[12px] text-foreground tabular-nums">{o.limitPrice ?? '—'}</dd>
+                    </div>
+                    <div className="min-w-0 rounded-md bg-muted/35 px-2.5 py-2">
+                      <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">Fill</dt>
+                      <dd className="mt-0.5 truncate text-[12px] text-foreground tabular-nums">
+                        {o.avgFillPrice ? `${o.avgFillPrice}${o.filledQty ? ` × ${o.filledQty}` : ''}` : '—'}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <button
+                    type="button"
+                    aria-expanded={isExpanded}
+                    aria-controls={detailsId}
+                    aria-label={`${isExpanded ? 'Hide' : 'Show'} details for ${contractPrimary(o.contract)} order`}
+                    onClick={() => setExpanded(prev => prev === i ? null : i)}
+                    className="oa-pressable mt-3 flex w-full items-center justify-between rounded-md border border-border px-3 py-2 text-[11px] text-muted-foreground hover:text-foreground"
+                  >
+                    <span>Order details</span>
+                    <span>{isExpanded ? 'Hide' : 'Show'}</span>
+                  </button>
+                </div>
+
+                {isExpanded && (
+                  <div id={detailsId} className="oa-disclosure-enter border-t border-border bg-muted/20 px-3 py-2.5 text-[11px] text-muted-foreground">
+                    <div className="font-mono text-foreground">{o.commitHash}</div>
+                    <p className="mt-1 break-words leading-5">{o.message}</p>
+                    {o.error && <p className="mt-1 break-words text-destructive">{o.error}</p>}
+                    {o.resolvedAt && <p className="mt-1">resolved {formatHistoryTime(o.resolvedAt)}</p>}
+                  </div>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    )
+  }
+
   return (
-    <div className="border border-border rounded-lg overflow-x-auto">
-      <table className="w-full text-[13px]">
+    <div ref={setContainer} className="border border-border rounded-lg overflow-x-auto">
+      <table className="w-full min-w-[760px] text-[13px]">
         <thead>
           <tr className="bg-secondary text-muted-foreground text-left">
             <th className="px-3 py-2 font-medium">Time</th>

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -747,7 +747,7 @@ interface OpenOrderRow {
 
 type OrdersTab = 'open' | 'history' | 'trades'
 
-function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[] }) {
+export function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[] }) {
   const [tab, setTab] = useState<OrdersTab>('open')
   const [history, setHistory] = useState<OrderHistoryEntry[] | null>(null)
   const [trades, setTrades] = useState<TradeHistoryEntry[] | null>(null)
@@ -776,21 +776,25 @@ function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[
     return () => { cancelled = true; clearInterval(t) }
   }, [tab, utaId])
 
-  const tabs: Array<{ id: OrdersTab; label: string }> = [
-    { id: 'open', label: `Open (${openOrders.length})` },
-    { id: 'history', label: 'History' },
-    { id: 'trades', label: 'Trades' },
+  const tabs: Array<{ id: OrdersTab; label: string; panelLabel: string }> = [
+    { id: 'open', label: `Open (${openOrders.length})`, panelLabel: 'Open orders' },
+    { id: 'history', label: 'History', panelLabel: 'Order history' },
+    { id: 'trades', label: 'Trades', panelLabel: 'Trade history' },
   ]
+  const activeTab = tabs.find(candidate => candidate.id === tab)!
 
   return (
     <Section
       title="Orders"
       action={
-        <div className="flex gap-1">
+        <div className="flex gap-1" role="group" aria-label="Order views">
           {tabs.map(t => (
             <button
               key={t.id}
+              type="button"
               onClick={() => setTab(t.id)}
+              aria-pressed={tab === t.id}
+              aria-controls={`orders-${t.id}-panel`}
               className={`px-2 py-0.5 text-[11px] rounded transition-colors ${
                 tab === t.id
                   ? 'bg-primary/15 text-primary font-medium'
@@ -803,9 +807,15 @@ function OrdersArea({ utaId, openOrders }: { utaId: string; openOrders: unknown[
         </div>
       }
     >
-      {tab === 'open' && <OpenOrdersTable orders={openOrders} />}
-      {tab === 'history' && <OrderHistoryTable orders={history} />}
-      {tab === 'trades' && <TradeHistoryTable trades={trades} />}
+      <div
+        id={`orders-${tab}-panel`}
+        role="region"
+        aria-label={activeTab.panelLabel}
+      >
+        {tab === 'open' && <OpenOrdersTable orders={openOrders} />}
+        {tab === 'history' && <OrderHistoryTable orders={history} />}
+        {tab === 'trades' && <TradeHistoryTable trades={trades} />}
+      </div>
     </Section>
   )
 }

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -251,39 +251,45 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
             </div>
           )}
 
-          {/* Exchange-style two-column layout: tables get the wide main
-              column, the Account panel rides a sticky sidebar. On narrow
-              screens it collapses to one column with the Account panel
-              first — it's the summary. */}
-          <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-4 items-start">
-            <div className="lg:order-2 lg:sticky lg:top-4 self-start min-w-0 space-y-3">
-              {subAccounts.length > 1 && (
-                <SubAccountSelector
-                  subAccounts={subAccounts}
-                  selected={selectedSub}
-                  onSelect={(sub) => {
-                    // Drop the previous wallet's numbers immediately so the
-                    // panel shows "Loading account info…" during the (slow,
-                    // multi-round-trip) scoped read instead of briefly painting
-                    // the old scope's net-liquidation under the new pill.
-                    setAccount(null)
-                    setSelectedSub(sub)
-                  }}
-                />
-              )}
-              <AccountPanel account={account} positions={positions} delta24h={delta24h} clock={clock} connecting={health?.connecting ?? false} />
-            </div>
+          {!lastUpdated ? <UTADetailMainSkeleton /> : (
+            <div className="space-y-5">
+              {/* Keep the visual overview together, then give the operational
+                  tables the full content width. The auto-fit grid responds to
+                  this pane's real width after both app sidebars, rather than
+                  guessing from the browser viewport. */}
+              <div
+                className="grid items-stretch gap-4"
+                style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 26rem), 1fr))' }}
+              >
+                {curvePoints.length >= 2 && (
+                  <div className="min-w-0">
+                    <EquityCurve
+                      points={curvePoints}
+                      accounts={[{ id, label: displayName }]}
+                      selectedAccountId={id}
+                      onAccountChange={() => { /* single-account mode: switcher hidden */ }}
+                    />
+                  </div>
+                )}
 
-            <div className="lg:order-1 min-w-0 space-y-5">
-              {!lastUpdated ? <UTADetailMainSkeleton /> : <>
-              {curvePoints.length >= 2 && (
-                <EquityCurve
-                  points={curvePoints}
-                  accounts={[{ id, label: displayName }]}
-                  selectedAccountId={id}
-                  onAccountChange={() => { /* single-account mode: switcher hidden */ }}
-                />
-              )}
+                <div className="min-w-0 space-y-3">
+                  {subAccounts.length > 1 && (
+                    <SubAccountSelector
+                      subAccounts={subAccounts}
+                      selected={selectedSub}
+                      onSelect={(sub) => {
+                        // Drop the previous wallet's numbers immediately so the
+                        // panel shows "Loading account info…" during the (slow,
+                        // multi-round-trip) scoped read instead of briefly painting
+                        // the old scope's net-liquidation under the new pill.
+                        setAccount(null)
+                        setSelectedSub(sub)
+                      }}
+                    />
+                  )}
+                  <AccountPanel account={account} positions={positions} delta24h={delta24h} clock={clock} connecting={health?.connecting ?? false} />
+                </div>
+              </div>
 
               <PositionsSection
                 positions={positions}
@@ -296,9 +302,8 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
               />
 
               <OrdersArea utaId={id} openOrders={orders} />
-              </>}
             </div>
-          </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- integrate #747, #769, #770, and #771 into one reviewed UTA-detail presentation batch
- honor configured account display names and make position/order/history controls explicit and accessible
- finish the review feedback by giving operational tables the full content width and switching History to readable cards when the actual pane is narrower than 760px

## Verification

- `pnpm test` — 400 files passed, 1 skipped; 3477 tests passed, 9 skipped
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- targeted positions, order-tabs, and order-history specs — 3 files / 4 tests passed
- `git diff --check`
- real `pnpm dev` walkthrough on the Alpaca account detail route:
  - verified display label while retaining the internal account ID in edit context
  - verified explicit position Actions/Close labels
  - verified named Open/History/Trades panels and pressed state
  - verified keyboard-accessible History details and expanded audit metadata
  - verified narrow card layout without horizontal overflow and full-width desktop tables

No trade, configuration save, or order submission was performed during browser verification.

## Boundary touch

UI presentation and accessibility only. No broker implementation, UTA state machine, persisted configuration shape, or trading-write behavior changes.