### PR TITLE
chore: prepare 0.87.0 beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.86.0-beta",
+  "version": "0.87.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",


### PR DESCRIPTION
## Summary

- advance the OpenAlice release version to 0.87.0-beta
- make desktop installers, UTA Core, Broker Pack catalogs, and release metadata derive the new candidate version
- retain the v0.86.0-beta artifacts as the N-1 upgrade source

## Verification

- npx tsc --noEmit
- cd ui && npx tsc -b
- npx tsc -p apps/desktop/tsconfig.json --noEmit
- pnpm test — 408 files passed, 3519 tests passed
- pnpm test:e2e — 4 files passed, 30 tests passed
- pnpm build:migration-index — clean
- pnpm broker-packs:build — five darwin-arm64 0.87.0-beta Packs verified
- pnpm broker-packs:upgrade-smoke -- --from v0.86.0-beta — five Packs upgraded atomically
- pnpm electron:smoke:workspace — packaged CLI, managed Pi, Electron transport, scheduled side effect, and cleanup passed
- pnpm test:install:docker — clean installer acceptance passed
- PR #810 Windows cross-platform rerun — build and full tests passed after one runner 0xC0000142 DLL initialization failure

## Boundary touch

Release version, desktop packaging, UTA Core and Broker Pack publication. No broker adapter or credential changes; no live order was submitted.