### PR TITLE
Fix IME Enter submission in chat composers

### DIFF
--- a/ui/src/components/workspace/WebPiView.spec.tsx
+++ b/ui/src/components/workspace/WebPiView.spec.tsx
@@ -44,6 +44,7 @@ beforeEach(() => {
   Object.defineProperty(HTMLElement.prototype, 'scrollTo', { configurable: true, value: vi.fn() })
   mocks.getWebPiSession.mockResolvedValue(snapshot('compacting'))
   mocks.abortWebPiSession.mockResolvedValue(snapshot('idle'))
+  mocks.promptWebPiSession.mockResolvedValue(snapshot('idle'))
 })
 
 afterEach(() => {
@@ -107,6 +108,28 @@ describe('WebPi transcript scrolling', () => {
     expect(mocks.getWebPiSession).toHaveBeenCalledTimes(2)
     expect(scroller.scrollTo).toHaveBeenCalledTimes(scrollCallsBeforeUpdate)
     expect(screen.getByRole('button', { name: 'Jump to latest' })).toBeTruthy()
+  })
+})
+
+describe('WebPi composer keyboard submission', () => {
+  it('does not submit when Enter confirms an IME composition candidate', async () => {
+    mocks.getWebPiSession.mockResolvedValue(snapshot('idle'))
+    render(
+      <WebPiView wsId="workspace-manager" sessionId="p1" onSessionLost={vi.fn()} />,
+    )
+
+    const composer = await screen.findByPlaceholderText('Message Pi…')
+    fireEvent.change(composer, { target: { value: '继续检查' } })
+
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter', isComposing: true })
+    expect(mocks.promptWebPiSession).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter', isComposing: false })
+    await waitFor(() => expect(mocks.promptWebPiSession).toHaveBeenCalledWith(
+      'workspace-manager',
+      'p1',
+      '继续检查',
+    ))
   })
 })
 

--- a/ui/src/components/workspace/WebPiView.tsx
+++ b/ui/src/components/workspace/WebPiView.tsx
@@ -189,7 +189,7 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
+              if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
                 event.preventDefault()
                 void submit()
               }

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   probeAgentRuntimeReadiness: vi.fn(),
   getWorkspaceCredentialDefaults: vi.fn(),
   getQuickChat: vi.fn(),
+  quickChat: vi.fn(),
   rememberRecentChatWorkspace: vi.fn(),
   rememberQuickChatCredential: vi.fn(),
 }))
@@ -102,7 +103,7 @@ function context(workspaces: readonly Workspace[]): WorkspacesContextValue {
     openHeadlessRun: vi.fn(async () => undefined),
     setDefaultAgent: vi.fn(async () => undefined),
     setIssueDefaultAgent: vi.fn(async () => undefined),
-    quickChat: vi.fn(async () => 'chat-1'),
+    quickChat: mocks.quickChat,
     pauseSession: vi.fn(async () => undefined),
     resumeSession: vi.fn(async () => undefined),
     openWebPiSession: vi.fn(async () => undefined),
@@ -181,6 +182,7 @@ beforeEach(async () => {
     lastCredentialByAgent: {},
     recentChatWorkspaceId: 'chat-1',
   })
+  mocks.quickChat.mockResolvedValue('chat-1')
   mocks.rememberRecentChatWorkspace.mockResolvedValue(undefined)
   mocks.rememberQuickChatCredential.mockResolvedValue(undefined)
 })
@@ -200,6 +202,27 @@ describe('ChatLandingPage polling stability', () => {
 
     expect(mocks.detectWorkspaceCredential).toHaveBeenCalledTimes(1)
     expect(mocks.getAgentReadiness).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ChatLandingPage keyboard submission', () => {
+  it('does not submit when Enter confirms an IME composition candidate', async () => {
+    render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+
+    await screen.findByLabelText('Model gemini-3.1-flash-lite')
+    const composer = screen.getByPlaceholderText('Ask Alice…')
+    fireEvent.change(composer, { target: { value: '你好' } })
+
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter', isComposing: true })
+    expect(mocks.quickChat).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter', isComposing: false })
+    await waitFor(() => expect(mocks.quickChat).toHaveBeenCalledWith(
+      '你好',
+      'pi',
+      'google-1',
+      'chat-1',
+    ))
   })
 })
 

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -221,7 +221,7 @@ export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: strin
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     // Enter submits; Shift+Enter inserts a newline (standard chat-composer feel).
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault()
       void submit()
     }

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -203,6 +203,24 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('WorkspaceManagerPage runtime selection', () => {
+  it('does not submit when Enter confirms an IME composition candidate', async () => {
+    render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
+
+    await screen.findByRole('button', { name: 'Select agent' })
+    const composer = screen.getByRole('textbox')
+    fireEvent.change(composer, { target: { value: '检查工作区' } })
+
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter', isComposing: true })
+    expect(mocks.quickStartWorkspaceManager).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter', isComposing: false })
+    await waitFor(() => expect(mocks.quickStartWorkspaceManager).toHaveBeenCalledWith(
+      '检查工作区',
+      'codex',
+      undefined,
+    ))
+  })
+
   it('offers a retry when the manager snapshot cannot load', async () => {
     mocks.useWorkspaces.mockImplementation(() => ({
       ...context('codex'),

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -117,7 +117,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
   }
 
   const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
       event.preventDefault()
       void submit()
     }


### PR DESCRIPTION
## Summary

- ignore Enter keydown events while an input method editor is composing text
- apply the same message-composer contract to Ask Alice, Workspace Manager, and WebPi
- preserve ordinary Enter-to-send and Shift+Enter behavior after composition ends

Chinese and other IME users currently trigger a message submission when pressing Enter to confirm a composition candidate. Inbox already guards `nativeEvent.isComposing`; the three Workspace message composers did not.

Closes #714.

## Verification

- `pnpm vitest run ui/src/pages/ChatLandingPage.render.spec.tsx ui/src/pages/WorkspaceManagerPage.spec.tsx ui/src/components/workspace/WebPiView.spec.tsx` — 20 passed
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 3522 passed, 9 skipped
- loaded the real `/chat` route through the current `pnpm dev` runtime and confirmed the active Ask Alice composer surface

## Boundary touch

None. UI keyboard handling only; no trading, auth, credentials, persistence, runtime, or packaging changes.
