### PR TITLE
Make portfolio positions responsive

### DIFF
--- a/ui/src/pages/PortfolioPage.positions.spec.tsx
+++ b/ui/src/pages/PortfolioPage.positions.spec.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { PositionWithAccount } from './PortfolioPage'
+import { PositionsTable } from './PortfolioPage'
+
+const positions: PositionWithAccount[] = [
+  {
+    contract: {
+      aliceId: 'alpaca-paper|AAPL',
+      symbol: 'AAPL',
+      secType: 'STK',
+      currency: 'USD',
+    },
+    currency: 'USD',
+    side: 'long',
+    quantity: '72',
+    avgCost: '285.85',
+    marketPrice: '341.49',
+    marketValue: '24587.28',
+    unrealizedPnL: '4005.73',
+    realizedPnL: '0',
+    accountLabel: 'alpaca-paper',
+    accountProvider: 'alpaca',
+  },
+  {
+    contract: {
+      aliceId: 'ibkr|SAP',
+      symbol: 'SAP',
+      secType: 'STK',
+      currency: 'EUR',
+    },
+    currency: 'EUR',
+    side: 'short',
+    quantity: '4',
+    avgCost: '250',
+    marketPrice: '240',
+    marketValue: '960',
+    unrealizedPnL: '-40',
+    realizedPnL: '0',
+    accountLabel: 'ibkr-paper',
+    accountProvider: 'ibkr',
+  },
+]
+
+afterEach(cleanup)
+
+describe('Portfolio positions responsive presentation', () => {
+  it('keeps identity, market value, and PnL together in mobile summaries', () => {
+    render(
+      <PositionsTable
+        positions={positions}
+        fxRates={[{
+          currency: 'EUR',
+          rate: 1.15,
+          source: 'live',
+          updatedAt: '2026-07-29T00:00:00.000Z',
+        }]}
+      />,
+    )
+
+    const mobile = screen.getByTestId('portfolio-positions-mobile')
+    const desktop = screen.getByTestId('portfolio-positions-desktop')
+    expect(mobile.classList.contains('md:hidden')).toBe(true)
+    expect(desktop.classList.contains('hidden')).toBe(true)
+    expect(desktop.classList.contains('md:block')).toBe(true)
+
+    const appleSummary = within(mobile).getByLabelText(
+      'AAPL in alpaca-paper, market value $24,587.28, PnL +19.46%, +$4,005.73. Expand for position details.',
+    )
+    expect(appleSummary.textContent).toContain('AAPL')
+    expect(appleSummary.textContent).toContain('alpaca-paper · USD')
+    expect(appleSummary.textContent).toContain('$24,587.28')
+    expect(appleSummary.textContent).toContain('+19.46%')
+    expect(appleSummary.textContent).toContain('+$4,005.73')
+  })
+
+  it('reveals secondary position metrics without hiding the mobile summary', () => {
+    render(
+      <PositionsTable
+        positions={positions}
+        fxRates={[{
+          currency: 'EUR',
+          rate: 1.15,
+          source: 'live',
+          updatedAt: '2026-07-29T00:00:00.000Z',
+        }]}
+      />,
+    )
+
+    const mobile = screen.getByTestId('portfolio-positions-mobile')
+    const sapSummary = within(mobile).getByLabelText(
+      'SAP in ibkr-paper, market value €960.00, PnL -4.00%, -€40.00. Expand for position details.',
+    )
+    const details = sapSummary.closest('details')
+    expect(details?.open).toBe(false)
+
+    fireEvent.click(sapSummary)
+
+    expect(details?.open).toBe(true)
+    expect(within(details as HTMLElement).getByText('Quantity')).toBeTruthy()
+    expect(within(details as HTMLElement).getByText('Average cost')).toBeTruthy()
+    expect(within(details as HTMLElement).getByText('Current price')).toBeTruthy()
+    expect(within(details as HTMLElement).getByText('USD value')).toBeTruthy()
+    expect(within(details as HTMLElement).getByText('$1,104.00')).toBeTruthy()
+  })
+
+  it('preserves the dense comparison table for desktop layouts', () => {
+    render(<PositionsTable positions={positions} fxRates={[]} />)
+
+    const desktop = screen.getByTestId('portfolio-positions-desktop')
+    expect(within(desktop).getByRole('columnheader', { name: 'Symbol' })).toBeTruthy()
+    expect(within(desktop).getByRole('columnheader', { name: 'Mkt Value' })).toBeTruthy()
+    expect(within(desktop).getByRole('columnheader', { name: 'PnL %' })).toBeTruthy()
+    expect(within(desktop).getAllByRole('row')).toHaveLength(3)
+  })
+})

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import { ChevronDown } from 'lucide-react'
 import { api, type Position, type WalletCommitLog, type EquityCurvePoint, type UTASnapshotSummary } from '../api'
 import { useAutoSave } from '../hooks/useAutoSave'
 import { useAccountHealth } from '../hooks/useAccountHealth'
@@ -589,7 +590,7 @@ function AccountStrip({ sources, perAccountCurve }: {
 
 // ==================== Positions Table ====================
 
-interface PositionWithAccount extends Position {
+export interface PositionWithAccount extends Position {
   accountLabel: string
   accountProvider: string
 }
@@ -610,16 +611,116 @@ function contractDisplay(p: Position): { name: string; tag: string } {
   return { name: contractPrimary(p.contract), tag: p.contract.secType || 'UNK' }
 }
 
-function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount[]; fxRates: FxRateInfo[] }) {
+function PositionDetail({
+  label,
+  value,
+  valueClassName = 'text-foreground',
+}: {
+  label: string
+  value: string
+  valueClassName?: string
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className={`mt-0.5 truncate text-[12px] tabular-nums ${valueClassName}`} title={value}>{value}</dd>
+    </div>
+  )
+}
+
+export function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount[]; fxRates: FxRateInfo[] }) {
   const rateMap = Object.fromEntries(fxRates.map(r => [r.currency, r.rate]))
   const hasNonUsd = positions.some(p => p.currency && p.currency !== 'USD')
+  const rows = positions.map((position, index) => {
+    const display = contractDisplay(position)
+    const currency = position.currency ?? 'USD'
+    const fxRate = currency === 'USD' ? 1 : (rateMap[currency] ?? 1)
+    const unrealizedPnl = Number(position.unrealizedPnL)
+    const cost = Number(position.avgCost) * Number(position.quantity)
+    const pnlPercent = cost > 0 ? (unrealizedPnl / cost) * 100 : 0
+
+    return {
+      key: `${position.accountProvider}:${position.accountLabel}:${position.contract.aliceId ?? display.name}:${index}`,
+      position,
+      display,
+      currency,
+      usdValue: Number(position.marketValue) * fxRate,
+      unrealizedPnl,
+      pnlPercent,
+      isShort: position.side === 'short',
+    }
+  })
 
   return (
     <div>
       <h3 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wide mb-3">
         Positions
       </h3>
-      <div className="border border-border rounded-lg overflow-x-auto">
+      <div
+        data-testid="portfolio-positions-mobile"
+        className="overflow-hidden rounded-lg border border-border md:hidden"
+      >
+        {rows.map(({ key, position, display, currency, usdValue, unrealizedPnl, pnlPercent, isShort }) => {
+          const pnlTone = unrealizedPnl >= 0 ? 'text-success' : 'text-destructive'
+          return (
+            <details key={key} className="group border-t border-border first:border-t-0">
+              <summary
+                aria-label={`${display.name} in ${position.accountLabel}, market value ${fmt(Number(position.marketValue), position.currency)}, PnL ${fmtPctSigned(pnlPercent)}, ${fmtPnl(unrealizedPnl, position.currency)}. Expand for position details.`}
+                className="list-none px-3 py-3 outline-none transition-colors hover:bg-muted/30 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary [&::-webkit-details-marker]:hidden"
+              >
+                <div className="flex items-start gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span className="truncate font-medium text-foreground" title={display.name}>{display.name}</span>
+                      <span className="shrink-0 rounded bg-muted px-1 py-0.5 font-mono text-[9px] tracking-tight text-muted-foreground">
+                        {display.tag}
+                      </span>
+                      {isShort && (
+                        <span className="shrink-0 rounded bg-destructive/15 px-1 py-0.5 text-[9px] font-medium text-destructive">
+                          SHORT
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-1 truncate text-[10px] text-muted-foreground">
+                      {position.accountLabel} · {currency}
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <div className="font-semibold tabular-nums text-foreground">
+                      {fmt(Number(position.marketValue), position.currency)}
+                    </div>
+                    <div className={`mt-0.5 text-[11px] tabular-nums ${pnlTone}`}>
+                      {fmtPctSigned(pnlPercent)} · {fmtPnl(unrealizedPnl, position.currency)}
+                    </div>
+                  </div>
+                  <ChevronDown
+                    size={14}
+                    aria-hidden="true"
+                    className="mt-1 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+                  />
+                </div>
+              </summary>
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-3 border-t border-border bg-secondary/35 px-3 py-3">
+                <PositionDetail label="Quantity" value={fmtNum(Number(position.quantity))} />
+                <PositionDetail label="Average cost" value={fmt(Number(position.avgCost), position.currency)} />
+                <PositionDetail label="Current price" value={fmt(Number(position.marketPrice), position.currency)} />
+                <PositionDetail
+                  label="Unrealized PnL"
+                  value={fmtPnl(unrealizedPnl, position.currency)}
+                  valueClassName={pnlTone}
+                />
+                {hasNonUsd && currency !== 'USD' && (
+                  <PositionDetail label="USD value" value={fmt(usdValue)} />
+                )}
+              </dl>
+            </details>
+          )
+        })}
+      </div>
+      <div
+        data-testid="portfolio-positions-desktop"
+        className="hidden overflow-x-auto rounded-lg border border-border md:block"
+      >
         <table className="w-full text-[13px]">
           <thead>
             <tr className="bg-secondary text-muted-foreground text-left">
@@ -635,15 +736,9 @@ function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount
             </tr>
           </thead>
           <tbody>
-            {positions.map((p, i) => {
-              const display = contractDisplay(p)
-              const ccy = p.currency ?? 'USD'
-              const fxRate = ccy === 'USD' ? 1 : (rateMap[ccy] ?? 1)
-              const usdValue = Number(p.marketValue) * fxRate
-              const isShort = p.side === 'short'
-
+            {rows.map(({ key, position: p, display, currency: ccy, usdValue, unrealizedPnl, pnlPercent, isShort }) => {
               return (
-                <tr key={i} className="border-t border-border hover:bg-muted/30 transition-colors">
+                <tr key={key} className="border-t border-border hover:bg-muted/30 transition-colors">
                   <td className="px-3 py-2">
                     <div className="flex items-center gap-1.5 flex-wrap">
                       <span className="font-medium text-foreground">{display.name}</span>
@@ -664,15 +759,11 @@ function PositionsTable({ positions, fxRates }: { positions: PositionWithAccount
                       {ccy === 'USD' ? '—' : fmt(usdValue)}
                     </td>
                   )}
-                  <td className={`px-3 py-2 text-right font-medium ${Number(p.unrealizedPnL) >= 0 ? 'text-success' : 'text-destructive'}`}>
-                    {fmtPnl(Number(p.unrealizedPnL), p.currency)}
+                  <td className={`px-3 py-2 text-right font-medium ${unrealizedPnl >= 0 ? 'text-success' : 'text-destructive'}`}>
+                    {fmtPnl(unrealizedPnl, p.currency)}
                   </td>
-                  <td className={`px-3 py-2 text-right ${Number(p.unrealizedPnL) >= 0 ? 'text-success' : 'text-destructive'}`}>
-                    {(() => {
-                      const cost = Number(p.avgCost) * Number(p.quantity)
-                      const pct = cost > 0 ? (Number(p.unrealizedPnL) / cost) * 100 : 0
-                      return fmtPctSigned(pct)
-                    })()}
+                  <td className={`px-3 py-2 text-right ${unrealizedPnl >= 0 ? 'text-success' : 'text-destructive'}`}>
+                    {fmtPctSigned(pnlPercent)}
                   </td>
                 </tr>
               )


### PR DESCRIPTION
## Summary

- replace the narrow-screen positions table with compact native disclosure rows
- keep symbol, account, currency, market value, and PnL visible in each mobile summary
- reveal quantity, average cost, current price, and converted USD value on demand
- preserve the dense comparison table at desktop widths

The existing table was roughly twice the available content width on a 390px viewport, forcing horizontal scrolling and separating position identity from its risk and value. This keeps the desktop workstation density while giving small screens a scan-first hierarchy.

## Verification

- `pnpm vitest run ui/src/pages/PortfolioPage.positions.spec.tsx ui/src/pages/PortfolioPage.snapshot-settings.spec.tsx` — 6 passed
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 3522 passed, 9 skipped
- real `pnpm dev` route at `/portfolio`: verified 390×844 mobile summaries and disclosure behavior, then 1280×900 desktop table preservation

## Design contract

- removes horizontal-scroll noise on narrow screens
- strengthens identity → value/PnL → secondary metrics hierarchy
- uses native `<details>` disclosure and existing color/type tokens rather than a new component dialect
- leaves desktop comparison density unchanged

## Boundary touch

Display-only Portfolio UI. No order writes, broker state, credentials, persistence, or UTA state-machine changes.