### PR TITLE
Keep closed mobile page drawers out of navigation

### DIFF
--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -100,12 +100,18 @@ describe('PageSidebarLayout', () => {
 
     const drawer = screen.getByTestId('page-sidebar-drawer')
     expect(drawer.getAttribute('data-state')).toBe('closed')
+    expect(drawer.getAttribute('aria-hidden')).toBe('true')
+    expect(drawer.hasAttribute('inert')).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'Open Inbox' }))
     expect(drawer.getAttribute('data-state')).toBe('open')
+    expect(drawer.getAttribute('aria-hidden')).toBe('false')
+    expect(drawer.hasAttribute('inert')).toBe(false)
 
     fireEvent.click(screen.getByRole('button', { name: 'Select message' }))
     expect(drawer.getAttribute('data-state')).toBe('closed')
+    expect(drawer.getAttribute('aria-hidden')).toBe('true')
+    expect(drawer.hasAttribute('inert')).toBe(true)
   })
 
   it('keeps a page navigator in the drawer below its custom desktop breakpoint', () => {
@@ -125,11 +131,17 @@ describe('PageSidebarLayout', () => {
     expect(window.matchMedia).toHaveBeenCalledWith('(min-width: 960px)')
     const drawer = screen.getByTestId('page-sidebar-drawer')
     expect(drawer.getAttribute('data-state')).toBe('closed')
+    expect(drawer.getAttribute('aria-hidden')).toBe('true')
+    expect(drawer.hasAttribute('inert')).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'Open Settings' }))
     expect(drawer.getAttribute('data-state')).toBe('open')
+    expect(drawer.getAttribute('aria-hidden')).toBe('false')
+    expect(drawer.hasAttribute('inert')).toBe(false)
 
     fireEvent.click(screen.getByRole('button', { name: 'Select General' }))
     expect(drawer.getAttribute('data-state')).toBe('closed')
+    expect(drawer.getAttribute('aria-hidden')).toBe('true')
+    expect(drawer.hasAttribute('inert')).toBe(true)
   })
 })

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -281,6 +281,8 @@ export function PageSidebarLayout({
       <div
         data-testid="page-sidebar-drawer"
         data-state={drawerOpen ? 'open' : 'closed'}
+        aria-hidden={!drawerOpen}
+        inert={!drawerOpen ? true : undefined}
         className={`absolute inset-y-0 left-0 z-40 w-[280px] max-w-[85vw] transition-transform duration-200 ${
           drawerOpen ? 'translate-x-0' : '-translate-x-full'
         }`}


### PR DESCRIPTION
## Summary

- mark closed mobile page drawers `aria-hidden`
- make their controls inert until the drawer opens
- cover both default and custom responsive breakpoints with state-transition tests

The drawer previously translated off-screen visually but left every navigator control available to keyboard and assistive-technology navigation. A user could tab into controls they could not see.

## Verification

- `pnpm vitest run ui/src/components/PageSidebarLayout.spec.tsx` — 3 passed
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 3519 passed, 9 skipped
- real `pnpm dev` `/inbox` at 390×844: verified closed → open → closed transitions toggle `aria-hidden` and `inert` together

## Design contract

- removes invisible navigation noise without changing drawer appearance or motion
- makes the visible state and interaction state agree
- reuses the same hidden-surface contract already used by the desktop sidebar

## Boundary touch

Shared UI layout semantics only. No route, data, persistence, trading, credential, or runtime changes.