### PR TITLE
Close the mobile Chat drawer after navigation

### DIFF
--- a/ui/src/components/ChatChannelListContainer.tsx
+++ b/ui/src/components/ChatChannelListContainer.tsx
@@ -13,11 +13,11 @@ import { ChatWorkspaceSection } from './workspace/ChatWorkspaceSection'
  * have moved to the Legacy section of the ActivityBar — they're
  * pre-Workspace artifacts that don't share this surface anymore.
  */
-export function ChatChannelListContainer() {
+export function ChatChannelListContainer({ onNavigate }: { onNavigate?: () => void }) {
   return (
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto min-h-0">
-        <ChatWorkspaceSection />
+        <ChatWorkspaceSection onNavigate={onNavigate} />
       </div>
     </div>
   )

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -103,10 +103,11 @@ function workspaceContext(
 function renderSection(
   workspaces: readonly Workspace[] = [chatWorkspace],
   workspaceManager: ManagerWorkspaceSnapshot | null = null,
+  onNavigate?: () => void,
 ) {
   return render(
     <WorkspacesContext.Provider value={workspaceContext(workspaces, workspaceManager)}>
-      <ChatWorkspaceSection />
+      <ChatWorkspaceSection onNavigate={onNavigate} />
     </WorkspacesContext.Provider>,
   )
 }
@@ -120,13 +121,15 @@ afterEach(cleanup)
 
 describe('ChatWorkspaceSection actions', () => {
   it('keeps conversation creation primary and scopes workspace creation to the workspace list', () => {
-    renderSection()
+    const onNavigate = vi.fn()
+    renderSection([chatWorkspace], null, onNavigate)
 
     const newChat = screen.getByRole('button', { name: 'New chat' })
     const newWorkspace = screen.getByRole('button', { name: 'New workspace' })
     const workspaceHeading = screen.getByText('Workspaces', { selector: 'span' })
     const workspaceButton = screen.getByRole('button', { name: chatWorkspace.tag })
     const newSession = screen.getByRole('button', { name: 'New conversation in this workspace' })
+    const configureWorkspace = screen.getByRole('button', { name: 'Configure this workspace' })
 
     expect(newChat.className).toContain('w-full')
     expect(newChat.textContent).toBe('New chat')
@@ -137,20 +140,26 @@ describe('ChatWorkspaceSection actions', () => {
     expect(newWorkspace.querySelector('.lucide-panels-top-left')).toBeTruthy()
     expect(newSession.querySelector('.lucide-message-square-plus')).toBeTruthy()
 
+    fireEvent.click(configureWorkspace)
+    expect(onNavigate).not.toHaveBeenCalled()
+
     fireEvent.click(newChat)
     expect(openOrFocus).toHaveBeenCalledWith({ kind: 'chat-landing', params: {} })
+    expect(onNavigate).toHaveBeenCalledTimes(1)
 
     fireEvent.click(workspaceButton)
     expect(openOrFocus).toHaveBeenLastCalledWith({
       kind: 'chat-landing',
       params: { targetWsId: chatWorkspace.id },
     })
+    expect(onNavigate).toHaveBeenCalledTimes(2)
 
     fireEvent.click(newSession)
     expect(openOrFocus).toHaveBeenLastCalledWith({
       kind: 'chat-landing',
       params: { targetWsId: chatWorkspace.id },
     })
+    expect(onNavigate).toHaveBeenCalledTimes(3)
   })
 
   it('keeps an explicit workspace action in the empty state', () => {
@@ -162,7 +171,8 @@ describe('ChatWorkspaceSection actions', () => {
 
   it('bounds expanded Workspace history and routes the full catalog to the Session library', () => {
     const sessions = Array.from({ length: 9 }, (_, index) => chatSession(index + 1))
-    renderSection([{ ...chatWorkspace, sessions }])
+    const onNavigate = vi.fn()
+    renderSection([{ ...chatWorkspace, sessions }], null, onNavigate)
 
     expect(screen.getAllByRole('button', { name: /^Conversation/ })).toHaveLength(6)
     expect(screen.queryByRole('button', { name: 'Conversation 3' })).toBeNull()
@@ -172,9 +182,11 @@ describe('ChatWorkspaceSection actions', () => {
       kind: 'workspace',
       params: { wsId: chatWorkspace.id, source: 'chat' },
     })
+    expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
   it('owns Manager Session navigation and lifecycle actions under the Manager entry', () => {
+    const onNavigate = vi.fn()
     const manager: ManagerWorkspaceSnapshot = {
       id: MANAGER_WORKSPACE_ID,
       tag: 'Workspace Manager',
@@ -211,7 +223,7 @@ describe('ChatWorkspaceSection actions', () => {
       ],
     }
 
-    renderSection([], manager)
+    renderSection([], manager, onNavigate)
 
     const managerButton = screen.getByRole('button', { name: 'Workspace Manager' })
     const managerSection = managerButton.parentElement?.parentElement
@@ -229,19 +241,24 @@ describe('ChatWorkspaceSection actions', () => {
       kind: 'workspace-manager',
       params: { sessionId: 'manager-opencode' },
     })
+    expect(onNavigate).toHaveBeenCalledTimes(1)
 
     fireEvent.click(managerUi.getByRole('button', { name: 'Stop Inspect the floor' }))
     expect(actions.pauseSession).toHaveBeenCalledWith(MANAGER_WORKSPACE_ID, 'manager-opencode')
+    expect(onNavigate).toHaveBeenCalledTimes(1)
 
     fireEvent.click(managerUi.getByRole('button', { name: 'Resume Coordinate owners' }))
     expect(actions.openWebPiSession).toHaveBeenCalledWith(MANAGER_WORKSPACE_ID, 'manager-pi')
+    expect(onNavigate).toHaveBeenCalledTimes(2)
 
     const pausedRow = pausedSession.parentElement
     expect(pausedRow).toBeTruthy()
     fireEvent.click(within(pausedRow as HTMLElement).getByRole('button', { name: 'Delete Coordinate owners' }))
     expect(actions.requestDeleteSession).toHaveBeenCalledWith(MANAGER_WORKSPACE_ID, 'manager-pi')
+    expect(onNavigate).toHaveBeenCalledTimes(2)
 
     fireEvent.click(managerUi.getByRole('button', { name: 'Collapse sessions' }))
     expect(managerUi.queryByRole('button', { name: 'Inspect the floor' })).toBeNull()
+    expect(onNavigate).toHaveBeenCalledTimes(2)
   })
 })

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -50,7 +50,7 @@ function nextChatWorkspaceTag(workspaces: readonly Workspace[]): string {
   return `${CHAT_TEMPLATE}-${suffix}`
 }
 
-export function ChatWorkspaceSection(): ReactElement | null {
+export function ChatWorkspaceSection({ onNavigate = () => undefined }: { onNavigate?: () => void }): ReactElement | null {
   const { t } = useTranslation()
   const ctx = useWorkspaces()
   const focused = useWorkspace((s) => getFocusedTab(s)?.spec)
@@ -76,6 +76,11 @@ export function ChatWorkspaceSection(): ReactElement | null {
   const [pendingDelete, setPendingDelete] = useState<Workspace | null>(null)
   const [showCreate, setShowCreate] = useState(false)
 
+  const navigate = (target: Parameters<typeof openOrFocus>[0]): void => {
+    openOrFocus(target)
+    onNavigate()
+  }
+
   const rememberChatWorkspace = (workspaceId: string): void => {
     void preferencesApi.rememberRecentChatWorkspace(workspaceId).catch(() => undefined)
   }
@@ -94,7 +99,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
       <div className="px-2 pt-2 pb-1">
         <button
           type="button"
-          onClick={() => openOrFocus({ kind: 'chat-landing', params: {} })}
+          onClick={() => navigate({ kind: 'chat-landing', params: {} })}
           className="oa-pressable flex w-full items-center gap-2 rounded-lg border border-primary/25 bg-primary/10 px-3 py-2.5 text-left text-[13px] font-medium text-foreground hover:border-primary/45 hover:bg-primary/15"
         >
           <MessageSquarePlus size={15} strokeWidth={2.15} className="shrink-0 text-primary" />
@@ -107,8 +112,8 @@ export function ChatWorkspaceSection(): ReactElement | null {
         loaded={ctx.workspaceManagerLoaded}
         isFocused={isManagerFocus}
         activeSessionId={isManagerFocus ? focused.params.sessionId ?? null : null}
-        onOpen={() => openOrFocus({ kind: 'workspace-manager', params: {} })}
-        onOpenSession={(sessionId) => openOrFocus({
+        onOpen={() => navigate({ kind: 'workspace-manager', params: {} })}
+        onOpenSession={(sessionId) => navigate({
           kind: 'workspace-manager',
           params: { sessionId },
         })}
@@ -119,6 +124,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
           } else {
             void ctx.resumeSession(MANAGER_WORKSPACE_ID, sessionId)
           }
+          onNavigate()
         }}
         onDeleteSession={(sessionId) => ctx.requestDeleteSession(MANAGER_WORKSPACE_ID, sessionId)}
       />
@@ -149,7 +155,7 @@ export function ChatWorkspaceSection(): ReactElement | null {
           onCreated={(workspace) => {
             ctx.refresh()
             rememberChatWorkspace(workspace.id)
-            openOrFocus({ kind: 'chat-landing', params: { targetWsId: workspace.id } })
+            navigate({ kind: 'chat-landing', params: { targetWsId: workspace.id } })
           }}
           onClose={() => setShowCreate(false)}
         />
@@ -197,24 +203,25 @@ export function ChatWorkspaceSection(): ReactElement | null {
             selection={selection}
             onOpen={() => {
               rememberChatWorkspace(w.id)
-              openOrFocus({ kind: 'chat-landing', params: { targetWsId: w.id } })
+              navigate({ kind: 'chat-landing', params: { targetWsId: w.id } })
             }}
             onOpenSession={(sid) => {
               rememberChatWorkspace(w.id)
-              openOrFocus({ kind: 'workspace', params: { wsId: w.id, sessionId: sid, source: 'chat' } })
+              navigate({ kind: 'workspace', params: { wsId: w.id, sessionId: sid, source: 'chat' } })
             }}
             onPauseSession={(sid) => void ctx.pauseSession(w.id, sid)}
             onResumeSession={(sid) => {
               rememberChatWorkspace(w.id)
               void ctx.resumeSession(w.id, sid, 'chat')
+              onNavigate()
             }}
             onDeleteSession={(sid) => ctx.requestDeleteSession(w.id, sid)}
             onConfigure={() => ctx.openAgentConfig(w.id)}
             onDelete={() => setPendingDelete(w)}
-            onSpawn={() => openOrFocus({ kind: 'chat-landing', params: { targetWsId: w.id } })}
+            onSpawn={() => navigate({ kind: 'chat-landing', params: { targetWsId: w.id } })}
             onBrowseSessions={() => {
               rememberChatWorkspace(w.id)
-              openOrFocus({ kind: 'workspace', params: { wsId: w.id, source: 'chat' } })
+              navigate({ kind: 'workspace', params: { wsId: w.id, source: 'chat' } })
             }}
           />
         ))}

--- a/ui/src/pages/ChatPageShell.tsx
+++ b/ui/src/pages/ChatPageShell.tsx
@@ -14,7 +14,9 @@ export function ChatPageShell({ children }: ChatPageShellProps) {
       storageKey="chat"
       title={t('nav.item.chat')}
       defaultWidth={260}
-      sidebar={<ChatChannelListContainer />}
+      sidebar={({ closeMobileDrawer }) => (
+        <ChatChannelListContainer onNavigate={closeMobileDrawer} />
+      )}
     >
       {children}
     </PageSidebarLayout>


### PR DESCRIPTION
## Summary

- connect the Chat navigator to the shared mobile drawer lifecycle
- close the drawer after New chat, Workspace, Session, Manager, resume, and View all navigation
- keep the drawer open for local actions such as expand/collapse, configure, stop, delete, and workspace creation setup

At 390px, selecting a Session changed the URL and focused the new conversation, but the navigation drawer remained in front of it. The user had to close the drawer manually before seeing the result of their selection.

## Verification

- `pnpm vitest run ui/src/components/workspace/ChatWorkspaceSection.spec.tsx ui/src/components/PageSidebarLayout.spec.tsx` — 7 passed
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 3519 passed, 9 skipped
- real `pnpm dev` `/chat` at 390×844: reproduced Session selection leaving the drawer open; verified another Session selection closes it after the change
- real route: verified opening New workspace remains inside the open drawer rather than dismissing the navigator

## Design contract

- removes the extra close step after a navigation decision
- makes the newly focused work surface immediately visible
- reuses `PageSidebarLayout.closeMobileDrawer` instead of adding a Chat-specific responsive state
- distinguishes navigation from local list management so the drawer does not disappear unexpectedly

## Boundary touch

Chat navigation UI only. No Session lifecycle semantics, terminal state, persistence, agent runtime, or trading behavior changes.