### PR TITLE
Make Workspace Files keyboard accessible

### DIFF
--- a/ui/src/components/workspace/FilesPanel.spec.tsx
+++ b/ui/src/components/workspace/FilesPanel.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { FilesPanel } from './FilesPanel'
@@ -28,6 +29,16 @@ beforeEach(() => {
       kind: 'file',
       sizeBytes: 128,
       mtime: '2026-07-20T00:00:00.000Z',
+    }, {
+      name: 'notes',
+      kind: 'dir',
+      sizeBytes: null,
+      mtime: '2026-07-19T00:00:00.000Z',
+    }, {
+      name: 'workspace.sock',
+      kind: 'other',
+      sizeBytes: null,
+      mtime: '2026-07-18T00:00:00.000Z',
     }],
   })
 })
@@ -68,5 +79,29 @@ describe('FilesPanel navigation provenance', () => {
       kind: 'file-viewer',
       params: { wsId: 'workspace-1', path: 'research.md' },
     })
+  })
+
+  it('makes files and folders native keyboard controls while leaving other entries static', async () => {
+    const user = userEvent.setup()
+    render(<FilesPanel wsId="workspace-1" sessionId={null} />)
+
+    const file = await screen.findByRole('button', { name: /research\.md/ })
+    const folder = screen.getByRole('button', { name: /notes/ })
+    expect(file.tagName).toBe('BUTTON')
+    expect(file.tabIndex).toBe(0)
+    expect(folder.tagName).toBe('BUTTON')
+    expect(folder.tabIndex).toBe(0)
+    expect(screen.getByText('workspace.sock').closest('button')).toBeNull()
+
+    file.focus()
+    await user.keyboard('{Enter}')
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'file-viewer',
+      params: { wsId: 'workspace-1', path: 'research.md' },
+    })
+
+    folder.focus()
+    await user.keyboard(' ')
+    await waitFor(() => expect(mocks.listFiles).toHaveBeenCalledWith('workspace-1', 'notes'))
   })
 })

--- a/ui/src/components/workspace/FilesPanel.tsx
+++ b/ui/src/components/workspace/FilesPanel.tsx
@@ -119,17 +119,30 @@ export function FilesPanel(props: FilesPanelProps): ReactElement {
         {listing?.entries.length === 0 && !error && (
           <li className="panel-empty">empty</li>
         )}
-        {listing?.entries.map((e) => (
-          <li
-            key={e.name}
-            className={`files-row files-${e.kind}`}
-            onClick={() => enter(e)}
-          >
-            <span className="files-icon">{iconFor(e)}</span>
-            <span className="files-name">{e.name}</span>
-            <span className="files-meta">{formatMeta(e)}</span>
-          </li>
-        ))}
+        {listing?.entries.map((e) => {
+          const row = (
+            <>
+              <span className="files-icon">{iconFor(e)}</span>
+              <span className="files-name">{e.name}</span>
+              <span className="files-meta">{formatMeta(e)}</span>
+            </>
+          );
+          return (
+            <li key={e.name}>
+              {e.kind === 'other' ? (
+                <div className={`files-row files-${e.kind}`}>{row}</div>
+              ) : (
+                <button
+                  type="button"
+                  className={`files-row files-${e.kind}`}
+                  onClick={() => enter(e)}
+                >
+                  {row}
+                </button>
+              )}
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -1002,18 +1002,25 @@
   grid-template-columns: 18px 1fr auto;
   gap: 8px;
   align-items: baseline;
+  width: 100%;
   padding: 3px 12px;
+  border: 0;
+  background: transparent;
+  text-align: left;
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 12px;
   cursor: default;
 }
-.files-row.files-dir,
-.files-row.files-symlink {
+button.files-row {
   cursor: pointer;
 }
-.files-row.files-dir:hover,
-.files-row.files-symlink:hover {
+button.files-row:hover {
   background: var(--accent);
+}
+button.files-row:focus-visible {
+  background: var(--accent);
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
 }
 
 .files-icon {


### PR DESCRIPTION
## Summary

- render files, directories, and symlinks as native full-width buttons
- keep non-actionable filesystem entries outside the tab order
- add shared hover and focus-visible feedback to every actionable row
- preserve file-viewer provenance and directory traversal behavior

Workspace Files previously attached `onClick` to `<li>` rows. Mouse users could open them, but the rows were `tabIndex=-1`, had no button semantics, and ordinary files did not even receive the same hover affordance as directories.

## Verification

- `pnpm vitest run ui/src/components/workspace/FilesPanel.spec.tsx` — 3 passed
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 3520 passed, 9 skipped
- real `pnpm dev` Workspace route: before change, actionable rows were `LI` with `tabIndex=-1`; after change they are `BUTTON` with `tabIndex=0`
- real route: verified directory traversal, full-width layout, and visible focus treatment in the populated Files panel

## Design contract

- makes the existing action discoverable to keyboard and assistive-technology users
- aligns hover, focus, and click feedback across files and folders
- uses native button activation instead of custom key handlers
- preserves the dense file-list presentation without introducing a new component dialect

## Boundary touch

Workspace Files presentation only. No filesystem API, path resolution, file contents, Session lifecycle, persistence, or runtime changes.