### PR TITLE
Add complete keyboard behavior to launch menus

### DIFF
--- a/ui/src/components/workspace/AgentLaunchControls.spec.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.spec.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentLaunchConfigState } from '../../hooks/useAgentLaunchConfig'
+import { i18n } from '../../i18n'
+import type { AgentInfo, SavedCredential } from './api'
+import { AgentLaunchSelectors } from './AgentLaunchControls'
+
+const agents: AgentInfo[] = [
+  {
+    id: 'opencode',
+    displayName: 'OpenCode',
+    installed: true,
+    capabilities: {
+      parallelPerCwd: true,
+      resumeLast: true,
+      resumeById: true,
+      transcriptDiscovery: 'fs-watch',
+    },
+  },
+  {
+    id: 'pi',
+    displayName: 'Pi',
+    installed: true,
+    capabilities: {
+      parallelPerCwd: true,
+      resumeLast: true,
+      resumeById: true,
+      transcriptDiscovery: 'fs-watch',
+    },
+  },
+]
+
+const credentials: SavedCredential[] = [
+  {
+    slug: 'primary',
+    vendor: 'OpenAI',
+    label: 'Primary',
+    authType: 'api-key',
+    wires: {},
+    resolvedModel: 'gpt-5',
+  },
+  {
+    slug: 'backup',
+    vendor: 'OpenAI',
+    label: 'Backup',
+    authType: 'api-key',
+    wires: {},
+    resolvedModel: 'gpt-4.1',
+  },
+]
+
+function launchConfig(overrides: Partial<AgentLaunchConfigState> = {}): AgentLaunchConfigState {
+  return {
+    agents,
+    effectiveAgent: 'opencode',
+    selectedAgent: agents[0]!,
+    runtimeReadiness: null,
+    selectedRuntimeReadiness: null,
+    needsCredential: true,
+    credentials,
+    effectiveCredential: 'primary',
+    credential: credentials[0]!,
+    detectedCredential: null,
+    workspaceConfigResolved: true,
+    aiDetails: null,
+    selectedRuntimeUsesGlobalConfig: false,
+    credentialSelectionReady: true,
+    noCredentials: false,
+    needsProviderSetup: false,
+    willOverwriteCredential: false,
+    selectedMissing: false,
+    anyInstalled: true,
+    agentsKnown: true,
+    launchCredentialSlug: 'primary',
+    selectAgent: vi.fn(),
+    selectCredential: vi.fn(),
+    resetCredentialSelection: vi.fn(),
+    checkSelectedRuntime: vi.fn(async () => null),
+    ...overrides,
+  }
+}
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('AgentLaunchSelectors keyboard menus', () => {
+  it('moves through the agent menu and returns focus on Escape', async () => {
+    const user = userEvent.setup()
+    render(<AgentLaunchSelectors config={launchConfig()} onConfigureProvider={vi.fn()} />)
+
+    const trigger = screen.getByRole('button', { name: i18n.t('chatLanding.selectAgent') })
+    trigger.focus()
+    await user.keyboard('{ArrowDown}')
+
+    const openCode = screen.getByRole('menuitem', { name: 'OpenCode' })
+    const pi = screen.getByRole('menuitem', { name: 'Pi' })
+    expect(document.activeElement).toBe(openCode)
+
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(pi)
+    await user.keyboard('{Home}')
+    expect(document.activeElement).toBe(openCode)
+    await user.keyboard('{End}')
+    expect(document.activeElement).toBe(pi)
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(openCode)
+    await user.keyboard('{ArrowUp}')
+    expect(document.activeElement).toBe(pi)
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('selects an agent with Enter and restores focus to the trigger', async () => {
+    const user = userEvent.setup()
+    const selectAgent = vi.fn()
+    render(
+      <AgentLaunchSelectors
+        config={launchConfig({ selectAgent })}
+        onConfigureProvider={vi.fn()}
+      />,
+    )
+
+    const trigger = screen.getByRole('button', { name: i18n.t('chatLanding.selectAgent') })
+    trigger.focus()
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}')
+
+    expect(selectAgent).toHaveBeenCalledWith('pi')
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('applies the same keyboard contract to credentials', async () => {
+    const user = userEvent.setup()
+    const selectCredential = vi.fn()
+    render(
+      <AgentLaunchSelectors
+        config={launchConfig({ selectCredential })}
+        onConfigureProvider={vi.fn()}
+      />,
+    )
+
+    const trigger = screen.getByRole('button', { name: i18n.t('chatLanding.selectCredential') })
+    trigger.focus()
+    await user.keyboard('{ArrowUp}')
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: /Backup/ }))
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+
+    await user.keyboard('{ArrowDown}{End}{Enter}')
+    expect(selectCredential).toHaveBeenCalledWith('backup')
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -1,4 +1,13 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState, type ReactNode } from 'react'
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  type RefObject,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   AlertTriangle,
@@ -34,6 +43,47 @@ export interface AgentLaunchSelectorsHandle {
   openAgentMenu(): void
 }
 
+function menuItems(menuRef: RefObject<HTMLDivElement | null>): HTMLButtonElement[] {
+  return Array.from(menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [])
+}
+
+function focusMenuEdge(
+  menuRef: RefObject<HTMLDivElement | null>,
+  edge: 'first' | 'last',
+): void {
+  const items = menuItems(menuRef)
+  items[edge === 'first' ? 0 : items.length - 1]?.focus()
+}
+
+function handleMenuKeyDown(
+  event: ReactKeyboardEvent<HTMLDivElement>,
+  menuRef: RefObject<HTMLDivElement | null>,
+  close: () => void,
+  triggerRef: RefObject<HTMLButtonElement | null>,
+): void {
+  const items = menuItems(menuRef)
+  if (items.length === 0) return
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    close()
+    triggerRef.current?.focus()
+    return
+  }
+
+  const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement)
+  let nextIndex: number | null = null
+  if (event.key === 'ArrowDown') nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
+  if (event.key === 'ArrowUp') nextIndex = currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length
+  if (event.key === 'Home') nextIndex = 0
+  if (event.key === 'End') nextIndex = items.length - 1
+  if (nextIndex === null) return
+
+  event.preventDefault()
+  items[nextIndex]?.focus()
+}
+
 /** The shared runtime + credential selector used by every chat-style launch
  * surface. Selection behavior and presentation now evolve together. */
 export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, AgentLaunchSelectorsProps>(function AgentLaunchSelectors(
@@ -45,10 +95,17 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
   const [credentialMenuOpen, setCredentialMenuOpen] = useState(false)
   const agentBoxRef = useRef<HTMLDivElement>(null)
   const credentialBoxRef = useRef<HTMLDivElement>(null)
+  const agentTriggerRef = useRef<HTMLButtonElement>(null)
+  const credentialTriggerRef = useRef<HTMLButtonElement>(null)
+  const agentMenuRef = useRef<HTMLDivElement>(null)
+  const credentialMenuRef = useRef<HTMLDivElement>(null)
+  const agentFocusEdgeRef = useRef<'first' | 'last'>('first')
+  const credentialFocusEdgeRef = useRef<'first' | 'last'>('first')
   const SelectedIcon = config.selectedAgent ? AGENT_ICONS[config.selectedAgent.id] : undefined
 
   useImperativeHandle(ref, () => ({
     openAgentMenu() {
+      agentFocusEdgeRef.current = 'first'
       setCredentialMenuOpen(false)
       setAgentMenuOpen(true)
     },
@@ -69,14 +126,42 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
     return () => document.removeEventListener('mousedown', onDown)
   }, [agentMenuOpen, credentialMenuOpen])
 
+  useEffect(() => {
+    if (!agentMenuOpen) return
+    focusMenuEdge(agentMenuRef, agentFocusEdgeRef.current)
+    agentFocusEdgeRef.current = 'first'
+  }, [agentMenuOpen])
+
+  useEffect(() => {
+    if (!credentialMenuOpen) return
+    focusMenuEdge(credentialMenuRef, credentialFocusEdgeRef.current)
+    credentialFocusEdgeRef.current = 'first'
+  }, [credentialMenuOpen])
+
   return (
     <>
-      <div ref={agentBoxRef} className="relative">
+      <div
+        ref={agentBoxRef}
+        className="relative"
+        onBlur={(event) => {
+          const next = event.relatedTarget as Node | null
+          if (!next || !event.currentTarget.contains(next)) setAgentMenuOpen(false)
+        }}
+      >
         <button
+          ref={agentTriggerRef}
           type="button"
           onClick={() => {
+            agentFocusEdgeRef.current = 'first'
             setAgentMenuOpen((open) => !open)
             setCredentialMenuOpen(false)
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+            event.preventDefault()
+            agentFocusEdgeRef.current = event.key === 'ArrowUp' ? 'last' : 'first'
+            setCredentialMenuOpen(false)
+            setAgentMenuOpen(true)
           }}
           disabled={config.agents.length === 0}
           aria-haspopup="menu"
@@ -90,7 +175,14 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
         </button>
         {agentMenuOpen && config.agents.length > 0 && (
           <div
+            ref={agentMenuRef}
             role="menu"
+            onKeyDown={(event) => handleMenuKeyDown(
+              event,
+              agentMenuRef,
+              () => setAgentMenuOpen(false),
+              agentTriggerRef,
+            )}
             className="oa-popover-enter absolute bottom-full left-0 z-20 mb-1 min-w-[180px] rounded-lg border border-border/70 bg-secondary py-1 shadow-lg"
           >
             {config.agents.map((agent) => {
@@ -102,9 +194,11 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
                   key={agent.id}
                   type="button"
                   role="menuitem"
+                  tabIndex={-1}
                   onClick={() => {
                     config.selectAgent(agent.id)
                     setAgentMenuOpen(false)
+                    agentTriggerRef.current?.focus()
                   }}
                   className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-muted ${active ? 'text-primary' : missing ? 'text-muted-foreground' : 'text-foreground'}`}
                 >
@@ -131,12 +225,28 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
       )}
 
       {config.needsCredential && !config.noCredentials && config.credentials && config.credentials.length > 0 && (
-        <div ref={credentialBoxRef} className="relative">
+        <div
+          ref={credentialBoxRef}
+          className="relative"
+          onBlur={(event) => {
+            const next = event.relatedTarget as Node | null
+            if (!next || !event.currentTarget.contains(next)) setCredentialMenuOpen(false)
+          }}
+        >
           <button
+            ref={credentialTriggerRef}
             type="button"
             onClick={() => {
+              credentialFocusEdgeRef.current = 'first'
               setCredentialMenuOpen((open) => !open)
               setAgentMenuOpen(false)
+            }}
+            onKeyDown={(event) => {
+              if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+              event.preventDefault()
+              credentialFocusEdgeRef.current = event.key === 'ArrowUp' ? 'last' : 'first'
+              setAgentMenuOpen(false)
+              setCredentialMenuOpen(true)
             }}
             aria-haspopup="menu"
             aria-expanded={credentialMenuOpen}
@@ -151,7 +261,14 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
           </button>
           {credentialMenuOpen && (
             <div
+              ref={credentialMenuRef}
               role="menu"
+              onKeyDown={(event) => handleMenuKeyDown(
+                event,
+                credentialMenuRef,
+                () => setCredentialMenuOpen(false),
+                credentialTriggerRef,
+              )}
               className="oa-popover-enter absolute bottom-full left-0 z-20 mb-1 min-w-[200px] rounded-lg border border-border/70 bg-secondary py-1 shadow-lg"
             >
               {config.credentials.map((credential) => {
@@ -161,9 +278,11 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
                     key={credential.slug}
                     type="button"
                     role="menuitem"
+                    tabIndex={-1}
                     onClick={() => {
                       config.selectCredential(credential.slug)
                       setCredentialMenuOpen(false)
+                      credentialTriggerRef.current?.focus()
                     }}
                     className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors hover:bg-muted ${active ? 'text-primary' : 'text-foreground'}`}
                   >


### PR DESCRIPTION
## Summary

- open agent and credential menus with ArrowDown/ArrowUp and focus the first/last item
- support ArrowUp, ArrowDown, Home, and End movement with wrapping
- close on Escape and restore focus to the originating trigger
- restore trigger focus after keyboard or pointer selection
- close menus when focus leaves their control group while preserving outside-click behavior

The shared launch selectors declared ARIA menu roles but behaved like click-only popovers. Escape did nothing, arrow keys did not move, and focus was lost when a menu closed.

## Verification

- `pnpm vitest run ui/src/components/workspace/AgentLaunchControls.spec.tsx` — 3 passed
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 3522 passed, 9 skipped
- real `pnpm dev` `/chat`: reproduced Escape leaving the agent menu open before the change
- real route: verified ArrowDown opens on Claude Code, ArrowDown moves to Codex, and Escape closes with focus restored to Select agent
- real route: verified ArrowUp opens the AI provider menu on its last credential and Escape restores focus to AI provider

## Design contract

- makes declared menu semantics match actual behavior
- keeps focus movement predictable and local
- applies one shared contract to every Chat and Workspace Manager launch surface
- adds no new visual treatment or selector-specific state model

## Boundary touch

Shared launch-selector interaction only. No agent choice semantics, credential storage, provider configuration, launch payload, Session lifecycle, or runtime changes.