### PR TITLE
Show recoverable Tracked list failures

### DIFF
--- a/ui/src/components/TrackedSidebar.spec.tsx
+++ b/ui/src/components/TrackedSidebar.spec.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EntityListItem } from '../api/entities'
+import { i18n } from '../i18n'
+import { TrackedSidebar } from './TrackedSidebar'
+
+const trackedEntity: EntityListItem = {
+  name: 'stock-vst',
+  description: 'Vistra',
+  type: 'asset',
+  createdAt: 1,
+  backlinkCount: 1,
+}
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  openOrFocus: vi.fn(),
+  setSidebar: vi.fn(),
+  entitiesState: {
+    current: {
+      entities: [] as EntityListItem[],
+      loading: false,
+      error: null as string | null,
+      refreshing: false,
+    },
+  },
+}))
+
+vi.mock('../live/entities', () => ({
+  entitiesLive: {
+    useStore: (selector: (state: typeof mocks.entitiesState.current) => unknown) =>
+      selector(mocks.entitiesState.current),
+  },
+}))
+
+vi.mock('../live/tracked-selection', () => ({
+  useTrackedSelection: (selector: (state: {
+    selectedName: string | null
+    select: typeof mocks.select
+  }) => unknown) => selector({
+    selectedName: null,
+    select: mocks.select,
+  }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: {
+    openOrFocus: typeof mocks.openOrFocus
+    setSidebar: typeof mocks.setSidebar
+  }) => unknown) => selector({
+    openOrFocus: mocks.openOrFocus,
+    setSidebar: mocks.setSidebar,
+  }),
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  mocks.entitiesState.current = {
+    entities: [],
+    loading: false,
+    error: null,
+    refreshing: false,
+  }
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('TrackedSidebar collection failure', () => {
+  it('reports an unavailable list without duplicating the page recovery action', () => {
+    mocks.entitiesState.current = {
+      entities: [],
+      loading: false,
+      error: 'offline',
+      refreshing: false,
+    }
+
+    render(<TrackedSidebar />)
+
+    expect(screen.getByText('Couldn’t load Tracked')).toBeTruthy()
+    expect(screen.queryByText('Nothing tracked yet.')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+  })
+
+  it('keeps stale rows available without adding a second warning', () => {
+    mocks.entitiesState.current = {
+      entities: [trackedEntity],
+      loading: false,
+      error: 'offline',
+      refreshing: false,
+    }
+
+    render(<TrackedSidebar />)
+
+    expect(screen.getByText('vst')).toBeTruthy()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/ui/src/components/TrackedSidebar.tsx
+++ b/ui/src/components/TrackedSidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TrendingUp, Hash } from 'lucide-react'
+import { TrendingUp, Hash, CircleAlert } from 'lucide-react'
 import { entitiesLive } from '../live/entities'
 import { useTrackedSelection } from '../live/tracked-selection'
 import { useWorkspace } from '../tabs/store'
@@ -18,6 +18,7 @@ export function TrackedSidebar() {
   const { t } = useTranslation()
   const entities = entitiesLive.useStore((s) => s.entities)
   const loading = entitiesLive.useStore((s) => s.loading)
+  const listError = entitiesLive.useStore((s) => s.error)
   const selected = useTrackedSelection((s) => s.selectedName)
   const select = useTrackedSelection((s) => s.select)
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
@@ -44,6 +45,15 @@ export function TrackedSidebar() {
     return (
       <div className="flex flex-col h-full overflow-y-auto py-1">
         <SidebarRowsSkeleton rows={6} icon />
+      </div>
+    )
+  }
+
+  if (listError && entities.length === 0) {
+    return (
+      <div className="flex items-start gap-2 px-3 py-4 text-[12px] leading-relaxed text-muted-foreground">
+        <CircleAlert size={14} className="mt-0.5 shrink-0 text-destructive" aria-hidden />
+        <span>{t('tracked.listLoadErrorTitle')}</span>
       </div>
     )
   }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1221,6 +1221,9 @@ export const en = {
   },
   tracked: {
     nothingTrackedYet: 'Nothing tracked yet.',
+    listLoadErrorTitle: 'Couldn’t load Tracked',
+    listLoadErrorDescription: 'OpenAlice could not refresh the tracked assets and topics. Nothing has been removed.',
+    listStale: 'Live refresh failed — showing the last known tracked items.',
     detailLoadErrorTitle: 'Couldn’t load {{name}}',
     detailLoadErrorDescription: 'The tracked entity may have changed, or OpenAlice may be temporarily unavailable.',
     backlinksTooltip: '{{count}} notes link here',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1210,6 +1210,9 @@ export const ja: Resources = {
   },
   tracked: {
     nothingTrackedYet: 'まだ何もトラッキングしていません。',
+    listLoadErrorTitle: '追跡リストを読み込めませんでした',
+    listLoadErrorDescription: 'OpenAlice は追跡中の銘柄とトピックを更新できませんでした。既存の内容は削除されていません。',
+    listStale: 'ライブ更新に失敗しました。最後に取得できた追跡項目を表示しています。',
     detailLoadErrorTitle: '{{name}} を読み込めませんでした',
     detailLoadErrorDescription: '追跡対象が変更されたか、OpenAlice が一時的に利用できない可能性があります。',
     backlinksTooltip: '{{count}} 件のメモがここにリンク',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1217,6 +1217,9 @@ export const zhHant: Resources = {
   },
   tracked: {
     nothingTrackedYet: '尚未追蹤任何項目。',
+    listLoadErrorTitle: '無法載入追蹤清單',
+    listLoadErrorDescription: 'OpenAlice 暫時無法重新整理追蹤的資產與主題。現有內容並未被刪除。',
+    listStale: '即時重新整理失敗——目前顯示上次成功載入的追蹤項目。',
     detailLoadErrorTitle: '無法載入 {{name}}',
     detailLoadErrorDescription: '這個追蹤實體可能已變更，或 OpenAlice 暫時無法使用。',
     backlinksTooltip: '{{count}} 則筆記連結到此',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1209,6 +1209,9 @@ export const zh: Resources = {
   },
   tracked: {
     nothingTrackedYet: '还没有追踪任何东西。',
+    listLoadErrorTitle: '无法加载追踪列表',
+    listLoadErrorDescription: 'OpenAlice 暂时无法刷新追踪的资产和主题。现有内容没有被删除。',
+    listStale: '实时刷新失败——当前显示上次成功加载的追踪项。',
     detailLoadErrorTitle: '无法加载 {{name}}',
     detailLoadErrorDescription: '这个追踪实体可能已经变更，或 OpenAlice 暂时不可用。',
     backlinksTooltip: '{{count}} 条笔记链接到此',

--- a/ui/src/live/__tests__/entities.spec.ts
+++ b/ui/src/live/__tests__/entities.spec.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { EntityListItem } from '../../api/entities'
+import { entitiesLive, refreshEntities } from '../entities'
+
+const mocks = vi.hoisted(() => ({
+  listEntities: vi.fn(),
+}))
+
+vi.mock('../../api', () => ({
+  api: {
+    entities: {
+      list: mocks.listEntities,
+    },
+  },
+}))
+
+const entity: EntityListItem = {
+  name: 'stock-vst',
+  description: 'Vistra',
+  type: 'asset',
+  createdAt: 1,
+  backlinkCount: 1,
+}
+
+let unsubscribe: (() => void) | null = null
+
+afterEach(() => {
+  unsubscribe?.()
+  unsubscribe = null
+  vi.clearAllMocks()
+})
+
+describe('entitiesLive refresh recovery', () => {
+  it('reports initial failure, clears it after retry, and preserves stale entities on later failure', async () => {
+    mocks.listEntities
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ entities: [entity] })
+      .mockRejectedValueOnce(new Error('offline again'))
+
+    unsubscribe = entitiesLive.subscribe(() => undefined)
+
+    await vi.waitFor(() => {
+      expect(entitiesLive.getState()).toMatchObject({
+        entities: [],
+        loading: false,
+        error: 'offline',
+        refreshing: false,
+      })
+    })
+
+    refreshEntities()
+    expect(entitiesLive.getState().refreshing).toBe(true)
+    await vi.waitFor(() => {
+      expect(entitiesLive.getState()).toMatchObject({
+        entities: [entity],
+        loading: false,
+        error: null,
+        refreshing: false,
+      })
+    })
+
+    refreshEntities()
+    await vi.waitFor(() => {
+      expect(entitiesLive.getState()).toMatchObject({
+        entities: [entity],
+        loading: false,
+        error: 'offline again',
+        refreshing: false,
+      })
+    })
+  })
+})

--- a/ui/src/live/entities.ts
+++ b/ui/src/live/entities.ts
@@ -16,6 +16,10 @@ export interface EntitiesState {
   entities: EntityListItem[]
   /** True until the initial list fetch resolves. */
   loading: boolean
+  /** The latest list request failed. Existing entities remain usable as stale data. */
+  error: string | null
+  /** An initial, scheduled, or user-requested refresh is currently in flight. */
+  refreshing: boolean
 }
 
 const POLL_INTERVAL_MS = 20_000
@@ -24,18 +28,30 @@ let triggerRefresh: (() => void) | null = null
 
 export const entitiesLive = createLiveStore<EntitiesState>({
   name: 'entities',
-  initialState: { entities: [], loading: true },
+  initialState: { entities: [], loading: true, error: null, refreshing: false },
   subscribe: ({ apply }) => {
     let disposed = false
 
     async function refresh() {
+      apply((prev) => ({ ...prev, refreshing: true }))
       try {
         const { entities } = await api.entities.list()
         if (disposed) return
-        apply((prev) => ({ ...prev, entities, loading: false }))
-      } catch {
+        apply((prev) => ({
+          ...prev,
+          entities,
+          loading: false,
+          error: null,
+          refreshing: false,
+        }))
+      } catch (error) {
         if (disposed) return
-        apply((prev) => ({ ...prev, loading: false }))
+        apply((prev) => ({
+          ...prev,
+          loading: false,
+          error: error instanceof Error ? error.message : 'Tracked entities are unavailable.',
+          refreshing: false,
+        }))
       }
     }
 

--- a/ui/src/pages/TrackedPage.spec.tsx
+++ b/ui/src/pages/TrackedPage.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { EntityDetail, EntityListItem } from '../api/entities'
@@ -28,6 +28,15 @@ const mocks = vi.hoisted(() => ({
   getEntity: vi.fn(),
   openOrFocus: vi.fn(),
   setSidebar: vi.fn(),
+  refreshEntities: vi.fn(),
+  entitiesState: {
+    current: {
+      entities: [] as EntityListItem[],
+      loading: false,
+      error: null as string | null,
+      refreshing: false,
+    },
+  },
 }))
 
 vi.mock('../api', () => ({
@@ -40,9 +49,10 @@ vi.mock('../api', () => ({
 
 vi.mock('../live/entities', () => ({
   entitiesLive: {
-    useStore: (selector: (state: { entities: EntityListItem[]; loading: boolean }) => unknown) =>
-      selector({ entities: [trackedEntity], loading: false }),
+    useStore: (selector: (state: typeof mocks.entitiesState.current) => unknown) =>
+      selector(mocks.entitiesState.current),
   },
+  refreshEntities: mocks.refreshEntities,
 }))
 
 vi.mock('../live/tracked-selection', () => ({
@@ -63,6 +73,12 @@ vi.mock('../tabs/store', () => ({
 
 beforeEach(async () => {
   vi.clearAllMocks()
+  mocks.entitiesState.current = {
+    entities: [trackedEntity],
+    loading: false,
+    error: null,
+    refreshing: false,
+  }
   await i18n.changeLanguage('en')
   mocks.getEntity.mockResolvedValue(detail)
 })
@@ -108,5 +124,43 @@ describe('TrackedPage detail recovery', () => {
     expect(await screen.findByRole('heading', { name: 'stock-vst' })).toBeTruthy()
     expect(mocks.getEntity).toHaveBeenCalledTimes(2)
     expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('TrackedPage collection recovery', () => {
+  it('distinguishes an unavailable list from a genuinely empty watchlist', () => {
+    mocks.entitiesState.current = {
+      entities: [],
+      loading: false,
+      error: 'offline',
+      refreshing: false,
+    }
+
+    render(<TrackedPage />)
+
+    const error = screen.getByRole('alert')
+    expect(error.textContent).toContain('Couldn’t load Tracked')
+    expect(error.textContent).toContain('Nothing has been removed')
+    expect(screen.queryByText('Nothing tracked yet.')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(mocks.refreshEntities).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps stale entities visible while reporting a failed refresh', async () => {
+    mocks.entitiesState.current = {
+      entities: [trackedEntity],
+      loading: false,
+      error: 'offline',
+      refreshing: false,
+    }
+
+    render(<TrackedPage />)
+
+    expect(await screen.findByRole('heading', { name: 'stock-vst' })).toBeTruthy()
+    const status = screen.getByRole('status')
+    expect(status.textContent).toContain('showing the last known tracked items')
+    fireEvent.click(within(status).getByRole('button', { name: 'Retry' }))
+    expect(mocks.refreshEntities).toHaveBeenCalledTimes(1)
   })
 })

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -4,7 +4,7 @@ import { TrendingUp, Hash, FileText, ListChecks, CircleAlert } from 'lucide-reac
 import { PageHeader } from '../components/PageHeader'
 import { PageLoading, Skeleton } from '../components/StateViews'
 import { api } from '../api'
-import { entitiesLive } from '../live/entities'
+import { entitiesLive, refreshEntities } from '../live/entities'
 import { useTrackedSelection } from '../live/tracked-selection'
 import { useWorkspace } from '../tabs/store'
 import type { EntityDetail, Backlink } from '../api/entities'
@@ -23,6 +23,8 @@ export function TrackedPage() {
   const { t } = useTranslation()
   const entities = entitiesLive.useStore((s) => s.entities)
   const loading = entitiesLive.useStore((s) => s.loading)
+  const listError = entitiesLive.useStore((s) => s.error)
+  const refreshing = entitiesLive.useStore((s) => s.refreshing)
   const selectedName = useTrackedSelection((s) => s.selectedName)
 
   const [detail, setDetail] = useState<EntityDetail | null>(null)
@@ -67,8 +69,13 @@ export function TrackedPage() {
         description={t('tracked.pageDescription', { count: entities.length })}
       />
       <div className="flex-1 overflow-y-auto min-h-0">
+        {listError && entities.length > 0 && (
+          <StaleCollectionNotice refreshing={refreshing} onRetry={refreshEntities} />
+        )}
         {loading && entities.length === 0 ? (
           <TrackedListSkeleton />
+        ) : listError && entities.length === 0 ? (
+          <CollectionLoadError refreshing={refreshing} onRetry={refreshEntities} />
         ) : entities.length === 0 ? (
           <EmptyState />
         ) : !selectedName ? (
@@ -84,6 +91,65 @@ export function TrackedPage() {
           <Detail detail={detail} />
         )}
       </div>
+    </div>
+  )
+}
+
+function CollectionLoadError({
+  refreshing,
+  onRetry,
+}: {
+  refreshing: boolean
+  onRetry: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div
+      role="alert"
+      className="mx-auto flex max-w-[520px] flex-col items-center px-6 py-16 text-center"
+    >
+      <CircleAlert size={24} strokeWidth={1.75} className="text-destructive" aria-hidden />
+      <h2 className="mt-3 text-[15px] font-medium text-foreground">
+        {t('tracked.listLoadErrorTitle')}
+      </h2>
+      <p className="mt-1.5 text-[13px] leading-relaxed text-muted-foreground">
+        {t('tracked.listLoadErrorDescription')}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={refreshing}
+        className="oa-pressable mt-4 rounded-md border border-border bg-secondary px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:border-primary/50 hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+      >
+        {refreshing ? t('common.loading') : t('common.retry')}
+      </button>
+    </div>
+  )
+}
+
+function StaleCollectionNotice({
+  refreshing,
+  onRetry,
+}: {
+  refreshing: boolean
+  onRetry: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div
+      role="status"
+      className="mx-4 mt-4 flex items-center gap-2 rounded-md border border-warning/25 bg-warning/[0.06] px-3 py-2 text-[12px] text-muted-foreground md:mx-8"
+    >
+      <CircleAlert size={14} className="shrink-0 text-warning" aria-hidden />
+      <span className="min-w-0 flex-1">{t('tracked.listStale')}</span>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={refreshing}
+        className="oa-pressable shrink-0 rounded px-2 py-1 font-medium text-foreground hover:bg-warning/10 disabled:cursor-wait disabled:opacity-60"
+      >
+        {refreshing ? t('common.loading') : t('common.retry')}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- distinguish a failed Tracked collection request from a genuinely empty list
- preserve stale entities after polling failures and expose one clear retry action
- keep the sidebar quiet while the focused page owns recovery
- localize the new states and cover the live store, page, and sidebar behavior

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3524 passed, 9 skipped)
- `cd ui && npx tsc -b`
- `pnpm vitest run ui/src/live/__tests__/entities.spec.ts ui/src/pages/TrackedPage.spec.tsx ui/src/components/TrackedSidebar.spec.tsx`
- real `pnpm dev` `/tracked` at 1280x900 and 390x844 with `/api/entities` blocked; verified Retry recovers after unblocking

## UI contract
- noise removed: the failure no longer appears as two competing recovery panels
- hierarchy strengthened: the main view owns explanation/action; the navigator only reports availability
- next action: Retry
- responsive: centered scan-first error state with no horizontal overflow
- primitives: existing tokens, buttons, `PageHeader`, and live-store patterns; no new visual dialect