### PR TITLE
Make the Portfolio account header responsive

### DIFF
--- a/ui/src/components/PageHeader.spec.tsx
+++ b/ui/src/components/PageHeader.spec.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PageHeader } from './PageHeader'
+
+afterEach(cleanup)
+
+describe('PageHeader action layout', () => {
+  it('opts substantial action groups into content-pane responsive stacking', () => {
+    const { container } = render(
+      <PageHeader
+        title="Portfolio account"
+        description="Connected"
+        right={<button type="button">Place Order</button>}
+        stackActionsOnNarrow
+      />,
+    )
+
+    const header = container.firstElementChild as HTMLElement
+    expect(header.style.containerType).toBe('inline-size')
+    expect(header.querySelector('.oa-page-header-stack-actions')).toBeTruthy()
+    expect(
+      header.querySelector('.oa-page-header-actions')?.contains(
+        screen.getByRole('button', { name: 'Place Order' }),
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps ordinary compact headers on their existing inline layout', () => {
+    const { container } = render(
+      <PageHeader
+        title="Issues"
+        right={<button type="button" aria-label="Settings">Settings</button>}
+      />,
+    )
+
+    const header = container.firstElementChild as HTMLElement
+    expect(header.style.containerType).toBe('')
+    expect(header.querySelector('.oa-page-header-stack-actions')).toBeNull()
+    expect(header.querySelector('.oa-page-header-actions')).toBeNull()
+  })
+})

--- a/ui/src/components/PageHeader.tsx
+++ b/ui/src/components/PageHeader.tsx
@@ -5,6 +5,10 @@ interface PageHeaderProps {
   title: string
   description?: ReactNode
   right?: ReactNode
+  /** Move a substantial action group below the title when this header's own
+   *  content pane is narrow. Uses a container query rather than the browser
+   *  viewport so app and local sidebars are accounted for. */
+  stackActionsOnNarrow?: boolean
   /** Show a pulsing "data is live" indicator next to the title and a
    *  relative-time microcopy ("updated 14s ago") in the description row.
    *  Pass the timestamp of the last successful refresh; pass `null` to
@@ -12,10 +16,23 @@ interface PageHeaderProps {
   live?: { lastUpdated: Date | null }
 }
 
-export function PageHeader({ title, description, right, live }: PageHeaderProps) {
+export function PageHeader({
+  title,
+  description,
+  right,
+  stackActionsOnNarrow = false,
+  live,
+}: PageHeaderProps) {
   return (
-    <div className="shrink-0 border-b border-border">
-      <div className="px-4 md:px-6 py-5 flex items-center justify-between gap-4">
+    <div
+      className="shrink-0 border-b border-border"
+      style={stackActionsOnNarrow ? { containerType: 'inline-size' } : undefined}
+    >
+      <div
+        className={`px-4 md:px-6 py-5 flex items-center justify-between gap-4 ${
+          stackActionsOnNarrow ? 'oa-page-header-stack-actions' : ''
+        }`}
+      >
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <h2 className="text-title font-bold text-foreground truncate">{title}</h2>
@@ -38,7 +55,11 @@ export function PageHeader({ title, description, right, live }: PageHeaderProps)
             </div>
           )}
         </div>
-        {right && <div className="shrink-0">{right}</div>}
+        {right && (
+          <div className={`shrink-0 ${stackActionsOnNarrow ? 'oa-page-header-actions' : ''}`}>
+            {right}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -284,6 +284,29 @@ body {
   @apply text-[11px] tracking-wide;
 }
 
+/* Page headers normally keep compact actions inline. Dense operational
+   controls can opt into a content-pane-aware stack so their title and status
+   retain full width after app/local sidebars are accounted for. */
+@container (max-width: 34rem) {
+  .oa-page-header-stack-actions {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .oa-page-header-stack-actions > :first-child {
+    width: 100%;
+  }
+
+  .oa-page-header-actions {
+    width: 100%;
+  }
+
+  .oa-uta-header-divider {
+    display: none;
+  }
+}
+
 /* ==================== Live-data pulse ====================
    Small breathing dot used in PageHeader to communicate "this
    surface is auto-refreshing". 2.4s cycle so it reads as ambient

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -205,6 +205,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
       <PageHeader
         title={displayName}
         live={{ lastUpdated }}
+        stackActionsOnNarrow
         description={
           <>
             <Link to="/trading" className="text-muted-foreground hover:text-foreground">← Trading</Link>
@@ -220,25 +221,32 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
           // secondary actions share btn-secondary-sm; Place Order is the
           // single filled-accent primary at the same size. No hand-rolled
           // paddings — mixed sizes were what made this row look drunk.
-          <div className="flex items-center gap-2">
-            <Toggle
-              ariaLabel={`${preset?.label ?? uta.id} enabled`}
-              size="sm"
-              checked={!isDisabled}
-              onChange={async (v) => { await tc.saveUTA({ ...uta, enabled: v }) }}
-            />
-            <div className="w-px h-5 bg-border" />
-            <ReconnectButton accountId={uta.id} />
-            <button onClick={() => setEditing(true)} className="btn-secondary-sm">
-              Edit
-            </button>
-            <button
-              onClick={() => setOrderMode({ kind: 'place' })}
-              disabled={isDisabled}
-              className="px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 transition-all active:scale-[0.98] cursor-pointer"
-            >
-              + Place Order
-            </button>
+          <div className="flex w-full flex-wrap items-center gap-2">
+            <div className="mr-auto flex items-center gap-2">
+              <Toggle
+                ariaLabel={`${preset?.label ?? uta.id} enabled`}
+                size="sm"
+                checked={!isDisabled}
+                onChange={async (v) => { await tc.saveUTA({ ...uta, enabled: v }) }}
+              />
+              <span className="text-[11px] text-muted-foreground">
+                {isDisabled ? 'Account disabled' : 'Account enabled'}
+              </span>
+            </div>
+            <div className="oa-uta-header-divider h-5 w-px bg-border" />
+            <div className="flex flex-wrap items-center gap-2">
+              <ReconnectButton accountId={uta.id} />
+              <button onClick={() => setEditing(true)} className="btn-secondary-sm">
+                Edit
+              </button>
+              <button
+                onClick={() => setOrderMode({ kind: 'place' })}
+                disabled={isDisabled}
+                className="btn-primary-sm"
+              >
+                + Place Order
+              </button>
+            </div>
           </div>
         }
       />


### PR DESCRIPTION
## Summary
- let dense PageHeader action groups opt into content-pane-aware responsive stacking
- keep the Portfolio account name, provenance, health, and live timestamp readable at narrow widths
- label the account enable switch visibly and preserve one compact desktop action row
- reuse shared small-button primitives for the primary order action

## Evidence
At 390px the account title collapsed to `a…`, while the breadcrumb, health, toggle, timestamp, Reconnect, Edit, and Place Order controls collided across several partial rows. The portfolio body already reflowed correctly; the defect was isolated to the header.

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3521 passed, 9 skipped)
- `cd ui && npx tsc -b`
- targeted PageHeader and UTA detail specs (6 passed)
- real `pnpm dev` account route at 320px, 390px, 800px, 900px, and 1280px
- verified no horizontal overflow, full title/action visibility, pane-width stacking at 800px, and the dense inline row at 1280px

## UI contract
- noise removed: status and controls no longer interleave across accidental wraps
- hierarchy strengthened: identity/provenance first, account state and actions second
- next actions: Reconnect, Edit, or Place Order remain visible
- responsive: container query follows the actual content pane after both sidebars
- primitives: PageHeader, Toggle, and shared small-button styles; no new visual dialect