### PR TITLE
Prefer real assets over same-ticker synthetic derivatives

### DIFF
--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -3,7 +3,7 @@
  * Real-provider accuracy is covered by bars.bbProvider.spec.ts (gated).
  */
 import { describe, it, expect, vi } from 'vitest'
-import { createBarService, parseBarId, formatBarId } from './index.js'
+import { createBarService, parseBarId, formatBarId, isDerivativeBarId } from './index.js'
 import type { BarServiceDeps, UtaBarGateway } from './types.js'
 import type {
   EquityClientLike, CryptoClientLike, CurrencyClientLike, CommodityClientLike,
@@ -55,6 +55,12 @@ describe('barId helpers', () => {
     expect(parseBarId('AAPL')).toBeNull()
     expect(parseBarId('|AAPL')).toBeNull()
     expect(parseBarId('yfinance|')).toBeNull()
+  })
+  it('distinguishes spot/native assets from perpetual and dated derivatives', () => {
+    expect(isDerivativeBarId('alpaca|AAPL')).toBe(false)
+    expect(isDerivativeBarId('binance|BTC/USDT')).toBe(false)
+    expect(isDerivativeBarId('binance|AAPL/USDT:USDT')).toBe(true)
+    expect(isDerivativeBarId('okx|BTC/USD:USD-310613')).toBe(true)
   })
 })
 
@@ -324,6 +330,45 @@ describe('searchBarSources — federated candidates', () => {
     expect(out).toHaveLength(1)
     expect(out[0].symbol).toBe('AAPL')
     expect(out[0].barCapability).toBe('iex')
+  })
+
+  it('ranks the real asset ahead of a fresher same-ticker synthetic derivative', async () => {
+    const utaManager = {
+      has: async () => true,
+      get: async () => undefined,
+      searchContracts: async () => [
+        {
+          source: 'binance-readonly',
+          contract: {
+            aliceId: 'binance-readonly|AAPL/USDT:USDT',
+            symbol: 'AAPL',
+            secType: 'CRYPTO_PERP',
+          },
+          derivativeSecTypes: ['CRYPTO_PERP'],
+          assetClass: 'crypto',
+        },
+        {
+          source: 'alpaca-paper',
+          contract: { aliceId: 'alpaca-paper|AAPL', symbol: 'AAPL', secType: 'STK' },
+          derivativeSecTypes: [],
+          assetClass: 'equity',
+        },
+      ],
+      getBarCapabilities: async () => ({
+        'binance-readonly': 'realtime',
+        'alpaca-paper': 'iex',
+      }),
+    } as never
+
+    const out = await createBarService(makeDeps({ utaManager })).searchBarSources('AAPL')
+
+    expect(out[0]).toMatchObject({
+      barId: 'alpaca-paper|AAPL',
+      assetClass: 'equity',
+      barCapability: 'iex',
+    })
+    expect(out.findIndex((candidate) => candidate.barId === 'binance-readonly|AAPL/USDT:USDT'))
+      .toBeGreaterThan(out.findIndex((candidate) => candidate.barId === 'yfinance|AAPL'))
   })
 
   it('survives one side failing (vendor still returns if UTA throws)', async () => {

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -23,7 +23,7 @@ import type {
   BarMeta,
   BarCapability,
 } from './types.js'
-import { formatBarId, parseBarId } from './types.js'
+import { formatBarId, isDerivativeBarId, parseBarId } from './types.js'
 
 /** Hard ceiling on bars returned by any single fetch (explosion guard). */
 const MAX_BARS = 5000
@@ -350,15 +350,18 @@ export function createBarService(deps: BarServiceDeps): BarService {
         }
       }
 
-      // User intent first, freshness second: an exact delayed EURUSD result must
-      // not disappear below dozens of vaguely-related realtime contracts. Auto
-      // source resolution applies its own derivative/freshness policy later.
+      // User intent first, real/spot exposure second, freshness third. A bare
+      // ticker such as AAPL must not open a realtime synthetic
+      // AAPL/USDT:USDT contract ahead of the actual equity merely because the
+      // derivative is fresher. This mirrors bare-symbol auto resolution while
+      // preserving every provider as an explicit selectable result.
       const FRESHNESS_RANK: Record<BarCapability, number> = {
         realtime: 0, iex: 1, subscription: 2, delayed: 3, free: 4,
       }
       out.sort(
         (a, b) =>
           candidateRelevance(query, b) - candidateRelevance(query, a) ||
+          Number(isDerivativeBarId(a.barId)) - Number(isDerivativeBarId(b.barId)) ||
           (a.barCapability ? FRESHNESS_RANK[a.barCapability] : 5) -
           (b.barCapability ? FRESHNESS_RANK[b.barCapability] : 5),
       )

--- a/src/domain/market-data/bars/index.ts
+++ b/src/domain/market-data/bars/index.ts
@@ -2,6 +2,7 @@ export { createBarService } from './bar-service.js'
 export {
   parseBarId,
   formatBarId,
+  isDerivativeBarId,
   type BarRef,
   type OhlcvBar,
   type BarMeta,

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -44,6 +44,13 @@ export function formatBarId(sourceId: string, nativeSymbol: string): string {
   return `${sourceId}|${nativeSymbol}`
 }
 
+/** Perpetuals, swaps, and dated derivatives carry a settlement/expiry segment
+ *  in the native symbol (`XLE/USDT:USDT`, `BTC/USD:USD-310613`). A plain
+ *  ticker or spot pair has no `:` segment. */
+export function isDerivativeBarId(barId: string): boolean {
+  return (parseBarId(barId)?.nativeSymbol ?? '').includes(':')
+}
+
 // ==================== data shapes ====================
 
 /** OHLCV bar — structurally identical to `analysis/indicator` `OhlcvData`. */

--- a/src/tool/source-resolve.ts
+++ b/src/tool/source-resolve.ts
@@ -12,7 +12,7 @@
  */
 
 import type { BarService, BarCapability } from '@/domain/market-data/bars/index'
-import { parseBarId } from '@/domain/market-data/bars/index'
+import { isDerivativeBarId } from '@/domain/market-data/bars/index'
 import type { AssetClass } from '@/domain/market-data/aggregate-search'
 
 const FRESHNESS_RANK: Record<BarCapability, number> = {
@@ -30,13 +30,6 @@ export interface ResolveResult {
   pickedFrom?: string
 }
 
-/** A perp/swap/dated derivative carries a quote-currency or expiry segment in
- *  its native symbol (`XLE/USDT:USDT`, `BTC/USD:USD-310613`). A plain ticker
- *  ("XLE") or spot pair without the `:` does not. */
-function isDerivative(barId: string): boolean {
-  return (parseBarId(barId)?.nativeSymbol ?? '').includes(':')
-}
-
 export async function resolveBarSource(
   barService: BarService,
   input: { query?: string; barId?: string; asset?: AssetArg },
@@ -51,8 +44,8 @@ export async function resolveBarSource(
     return { error: `No bar source found for "${input.query}". Try searchBars to see candidates, or pass a barId.` }
   }
   const best = [...candidates].sort((a, b) => {
-    const da = Number(isDerivative(a.barId))
-    const db = Number(isDerivative(b.barId))
+    const da = Number(isDerivativeBarId(a.barId))
+    const db = Number(isDerivativeBarId(b.barId))
     if (da !== db) return da - db // non-derivative (the real contract) first
     const fa = a.barCapability ? FRESHNESS_RANK[a.barCapability] : 5
     const fb = b.barCapability ? FRESHNESS_RANK[b.barCapability] : 5


### PR DESCRIPTION
## Summary
- rank non-derivative/spot bar sources ahead of same-relevance perpetual and dated derivatives
- keep freshness as the next tie-breaker and preserve every provider as an explicit selectable result
- share the derivative classifier with the existing agent auto-resolution path
- add regression coverage for AAPL equity versus a fresher AAPL/USDT perpetual

## Evidence
On the real Market page, typing `AAPL` and pressing Enter opened `/market/crypto/AAPL?source=binance-readonly|AAPL/USDT:USDT`. Seven realtime synthetic crypto contracts appeared before the actual Apple equity because freshness broke an exact-symbol tie. The agent auto-resolver already encoded the intended rule—real/spot exposure before derivatives—but the federated search ordering did not.

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3521 passed, 9 skipped)
- `pnpm test:e2e` (30 passed, 3 skipped)
- targeted bar service, source resolver, and route specs (36 passed)
- real `/api/bars/search?query=AAPL` now returns Alpaca equity, then yfinance equity, before synthetic crypto derivatives
- real `pnpm dev` main search and desktop sidebar: Enter on AAPL opens `/market/equity/AAPL`; Enter on BTC still opens Binance spot `/BTC/USDT`

## Verification gap
The current dev process exposes the UI/API but no Alice CLI gateway (the 5173 `/cli` path is Vite HTML fallback), so I did not claim a live shim run. The shared tool semantics are covered by `source-resolve.spec.ts`, and the real API/browser paths exercise the changed ordering.

## UI contract
- noise removed: redundant synthetic contracts no longer bury the primary asset interpretation
- hierarchy strengthened: real/spot instrument first, derivative alternatives second, freshness within each tier
- next action: Enter opens the primary instrument while every source remains selectable
- responsive: verified the visible ordering in the 390px search overlay
- primitives: existing federated search and source identity contracts; no new visual dialect