### PR TITLE
Make News article disclosures keyboard accessible

### DIFF
--- a/ui/src/pages/NewsPage.spec.tsx
+++ b/ui/src/pages/NewsPage.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '../i18n'
@@ -35,7 +36,7 @@ beforeEach(async () => {
         title: 'Newest update',
         content: 'Newest content',
         source: 'Bloomberg',
-        link: null,
+        link: 'https://example.com/newest',
         categories: null,
       },
       {
@@ -67,5 +68,28 @@ describe('NewsPage ordering', () => {
 
     expect(newest.compareDocumentPosition(middle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(middle.compareDocumentPosition(oldest) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})
+
+describe('NewsPage article disclosures', () => {
+  it('uses a native disclosure button that expands with the keyboard', async () => {
+    const user = userEvent.setup()
+    render(<NewsPage />)
+
+    const disclosure = await screen.findByRole('button', { name: 'Newest update' })
+    expect(disclosure.tagName).toBe('BUTTON')
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByRole('link', { name: 'Open original' })).toBeNull()
+
+    disclosure.focus()
+    await user.keyboard('{Enter}')
+
+    expect(disclosure.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByRole('link', { name: 'Open original' }).getAttribute('href'))
+      .toBe('https://example.com/newest')
+
+    await user.keyboard(' ')
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByRole('link', { name: 'Open original' })).toBeNull()
   })
 })

--- a/ui/src/pages/NewsPage.tsx
+++ b/ui/src/pages/NewsPage.tsx
@@ -25,40 +25,51 @@ function ArticleRow({ article }: { article: NewsArticle }) {
     : article.content
 
   return (
-    <div
-      className="px-4 py-3 hover:bg-muted/30 transition-colors cursor-pointer"
-      onClick={() => setExpanded(!expanded)}
-    >
-      {/* Header row */}
-      <div className="flex items-start gap-2">
-        <div className="flex-1 min-w-0">
-          <p className="text-[13px] font-medium text-foreground leading-snug">{article.title}</p>
-          <div className="flex items-center gap-2 mt-1">
-            {article.source && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-primary/10 text-primary">
-                {article.source}
-              </span>
-            )}
-            <span className="text-[11px] text-muted-foreground">{formatRelativeTime(article.time)}</span>
-            {article.categories && (
-              <span className="text-[11px] text-muted-foreground/50 truncate">{article.categories}</span>
-            )}
+    <article>
+      <button
+        type="button"
+        aria-label={article.title}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+        className="w-full px-4 py-3 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
+      >
+        <div className="flex items-start gap-2">
+          <div className="flex-1 min-w-0">
+            <p className="text-[13px] font-medium text-foreground leading-snug">{article.title}</p>
+            <div className="flex items-center gap-2 mt-1">
+              {article.source && (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-primary/10 text-primary">
+                  {article.source}
+                </span>
+              )}
+              <span className="text-[11px] text-muted-foreground">{formatRelativeTime(article.time)}</span>
+              {article.categories && (
+                <span className="text-[11px] text-muted-foreground/50 truncate">{article.categories}</span>
+              )}
+            </div>
           </div>
+          <span
+            className="text-muted-foreground text-xs shrink-0 mt-0.5"
+            aria-hidden
+          >
+            {expanded ? '▾' : '▸'}
+          </span>
         </div>
-        <span className="text-muted-foreground text-xs shrink-0 mt-0.5">{expanded ? '▾' : '▸'}</span>
-      </div>
 
-      {/* Preview / Expanded */}
-      {expanded ? (
-        <div className="mt-2 space-y-2">
+        {!expanded && article.content && (
+          <p className="mt-1 text-[12px] text-muted-foreground/50 truncate">{contentPreview}</p>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-3 space-y-2">
           <p className="text-[12px] text-muted-foreground/80 leading-relaxed whitespace-pre-wrap">{article.content}</p>
           {article.link && (
             <a
               href={article.link}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              className="inline-flex items-center gap-1 text-[12px] text-primary hover:underline"
+              className="inline-flex items-center gap-1 text-[12px] text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             >
               {t('news.openOriginal')}
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -69,12 +80,8 @@ function ArticleRow({ article }: { article: NewsArticle }) {
             </a>
           )}
         </div>
-      ) : (
-        article.content && (
-          <p className="mt-1 text-[12px] text-muted-foreground/50 truncate">{contentPreview}</p>
-        )
       )}
-    </div>
+    </article>
   )
 }
 


### PR DESCRIPTION
## Summary
- replace mouse-only News article rows with native disclosure buttons
- expose concise article-title names and `aria-expanded` state to assistive technology
- keep expanded prose and the external link outside the disclosure control
- add visible focus treatment for article rows and the Open original link

## Evidence
The real `/news` list rendered all 200 articles as cursor-styled `div` rows with React click handlers, but no role, tab stop, or keyboard handler. Mouse clicks expanded an article; keyboard users skipped directly past the full list.

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3520 passed, 9 skipped)
- `cd ui && npx tsc -b`
- targeted News spec (2 passed), including native button semantics and Enter/Space expansion
- real `pnpm dev` `/news` at 1280x900 and 390x844
- verified 200 semantic article elements, concise button names, expanded state, focus ring, external-link separation, and no horizontal overflow

## UI contract
- noise removed: screen readers no longer announce title, source, timestamp, categories, and preview as one oversized control name
- hierarchy strengthened: article header controls disclosure; expanded body owns reading and the outbound action
- next action: Enter/Space expands, then Open original is a separate focus target
- responsive: the same disclosure hierarchy remains intact at 390px
- primitives: native button/link semantics and existing color/focus tokens; no new visual dialect