### PR TITLE
Keep Automation run labels concise for assistive tech

### DIFF
--- a/ui/src/pages/AutomationRunsSection.spec.tsx
+++ b/ui/src/pages/AutomationRunsSection.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HeadlessListSnapshot, HeadlessTaskRecord } from '../api/headless'
@@ -95,5 +96,38 @@ describe('AutomationRunsSection workspace identity', () => {
 
     expect(await screen.findByText(departedId)).toBeTruthy()
     expect(screen.getByTitle(departedId).className).toContain('font-mono')
+  })
+})
+
+describe('AutomationRunsSection run controls', () => {
+  it('gives long task instructions a concise accessible name without hiding the visible prompt', async () => {
+    const omittedTail = 'TAIL_MARKER_THAT_MUST_NOT_BE_READ_FOR_EVERY_RUN'
+    const prompt = `Review the latest market snapshot and summarize material changes. ${'Include supporting detail. '.repeat(12)}${omittedTail}`
+    mocks.snapshot.mockResolvedValue(snapshot([task({ prompt })]))
+
+    render(<AutomationRunsSection />)
+
+    const control = await screen.findByRole('button', { name: /^Run details, running:/ })
+    const accessibleName = control.getAttribute('aria-label')
+    expect(accessibleName).toContain('Review the latest market snapshot')
+    expect(accessibleName).toContain('codex in quant-desk')
+    expect(accessibleName).not.toContain(omittedTail)
+    expect(accessibleName?.length).toBeLessThan(160)
+    expect(screen.getByText(prompt)).toBeTruthy()
+
+    control.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(control.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByText('Task instructions')).toBeTruthy()
+  })
+
+  it('labels an empty stored prompt without exposing a blank control', async () => {
+    mocks.snapshot.mockResolvedValue(snapshot([task({ prompt: '' })]))
+
+    render(<AutomationRunsSection />)
+
+    expect(await screen.findByRole('button', {
+      name: 'Run details, running: Untitled task. codex in quant-desk.',
+    })).toBeTruthy()
   })
 })

--- a/ui/src/pages/AutomationRunsSection.tsx
+++ b/ui/src/pages/AutomationRunsSection.tsx
@@ -31,6 +31,7 @@ const STATUS_STYLE: Record<HeadlessTaskStatus, string> = {
 }
 
 const RUNS_PAGE_SIZE = 25
+const RUN_PROMPT_SUMMARY_LENGTH = 96
 
 function fmtDuration(ms?: number): string {
   if (ms == null) return '—'
@@ -47,6 +48,15 @@ function formatValue(value: unknown): string {
   } catch {
     return String(value)
   }
+}
+
+function summarizeRunPrompt(prompt: string): string {
+  const normalized = prompt.replace(/\s+/g, ' ').trim()
+  if (!normalized) return 'Untitled task'
+
+  const characters = Array.from(normalized)
+  if (characters.length <= RUN_PROMPT_SUMMARY_LENGTH) return normalized
+  return `${characters.slice(0, RUN_PROMPT_SUMMARY_LENGTH - 1).join('').trimEnd()}…`
 }
 
 function ToolBlock({ block }: { block: Extract<HeadlessMessageBlock, { type: 'tool' }> }) {
@@ -335,6 +345,8 @@ export function AutomationRunsSection() {
             const isExpanded = expanded.has(task.taskId)
             const openable = task.status !== 'running' && task.resumable
             const workspaceLabel = workspaceLabels.get(task.wsId)
+            const workspaceName = workspaceLabel?.label ?? task.wsId
+            const runLabel = `Run details, ${task.status}: ${summarizeRunPrompt(task.prompt)}. ${task.agent} in ${workspaceName}.`
             const toolSummary = task.output?.toolCalls
               ? `${task.output.toolCalls} tool${task.output.toolCalls === 1 ? '' : 's'}`
               : task.output
@@ -351,6 +363,7 @@ export function AutomationRunsSection() {
                   onClick={() => toggle(task.taskId)}
                   className="flex w-full items-start gap-3 px-3 py-3 text-left hover:bg-muted/35"
                   aria-expanded={isExpanded}
+                  aria-label={runLabel}
                 >
                   <span className={`mt-0.5 inline-flex rounded px-1.5 py-0.5 text-[11px] font-medium ${STATUS_STYLE[task.status]}`}>
                     {task.status}


### PR DESCRIPTION
## What changed

- give each Automation run disclosure a concise accessible name with status, a bounded task summary, Agent, and Workspace
- collapse prompt whitespace and truncate by Unicode code point without changing the visible or stored task instructions
- provide an explicit fallback for empty historical prompts
- cover long prompts, empty prompts, Workspace identity, and Enter-key disclosure behavior

## Why

The run card visually clips long task instructions to two lines, but its native button previously derived an accessible name from every descendant. A screen reader therefore encountered the entire stored prompt — often thousands of words — before reaching the next run. On a history with 143 runs this made the list impractical to navigate.

## User impact

Run controls now announce a useful summary of at most 147 characters in the current real dataset while the full prompt remains available visually and under Task instructions. Existing expansion, output, and resume behavior is unchanged.

## Verification

- `pnpm vitest run ui/src/pages/AutomationRunsSection.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 408 files passed, 1 skipped; 3521 tests passed, 9 skipped
- `pnpm dev` real `/automation/runs` at 1280px and 390px
- inspected all 25 loaded run controls: maximum accessible-name length 147 characters; visible full prompts and disclosure behavior preserved