### PR TITLE
Keep collapsed Settings tool groups out of navigation

### DIFF
--- a/ui/src/pages/SettingsPage.tools-accordion.spec.tsx
+++ b/ui/src/pages/SettingsPage.tools-accordion.spec.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { ToolsSection } from './SettingsPage'
+
+const mocks = vi.hoisted(() => ({
+  loadTools: vi.fn(),
+  updateTools: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    tools: {
+      load: mocks.loadTools,
+      update: mocks.updateTools,
+    },
+  },
+}))
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+  mocks.loadTools.mockResolvedValue({
+    inventory: [
+      {
+        name: 'calculate',
+        group: 'thinking',
+        description: 'Perform mathematical calculations with precision.',
+      },
+    ],
+    disabled: [],
+  })
+})
+
+afterEach(cleanup)
+
+describe('Settings tool-group disclosures', () => {
+  it('keeps collapsed tool controls out of the accessibility tree and tab order', async () => {
+    render(<ToolsSection />)
+
+    const disclosure = await screen.findByRole('button', { name: /Thinking Kit/ })
+    const panelId = disclosure.getAttribute('aria-controls')
+    const panel = panelId ? document.getElementById(panelId) : null
+
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false')
+    expect(panel?.getAttribute('aria-hidden')).toBe('true')
+    expect(panel?.hasAttribute('inert')).toBe(true)
+    expect(screen.queryByRole('switch', { name: 'calculate' })).toBeNull()
+
+    fireEvent.click(disclosure)
+
+    expect(disclosure.getAttribute('aria-expanded')).toBe('true')
+    expect(panel?.getAttribute('aria-hidden')).toBe('false')
+    expect(panel?.hasAttribute('inert')).toBe(false)
+    expect(screen.getByRole('switch', { name: 'calculate' })).toBeTruthy()
+
+    fireEvent.click(disclosure)
+
+    expect(screen.queryByRole('switch', { name: 'calculate' })).toBeNull()
+  })
+})

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useId, useMemo } from 'react'
 import { Moon, RotateCcw, Sun } from 'lucide-react'
 import { api } from '../api'
 import type { ToolInfo } from '../api/tools'
@@ -925,14 +925,18 @@ function ToolGroupCard({
 }: ToolGroupCardProps) {
   const enabledCount = group.tools.filter((t) => !disabled.has(t.name)).length
   const noneEnabled = enabledCount === 0
+  const toolListId = useId()
 
   return (
     <div className="border border-border rounded-lg overflow-hidden">
       {/* Group header */}
       <div className="flex items-center gap-3 px-4 py-2.5 bg-secondary">
         <button
+          type="button"
           onClick={onToggleExpanded}
           className="flex items-center gap-2 flex-1 text-left min-w-0"
+          aria-expanded={expanded}
+          aria-controls={toolListId}
         >
           <svg
             width="14" height="14" viewBox="0 0 24 24"
@@ -956,6 +960,9 @@ function ToolGroupCard({
 
       {/* Tool list */}
       <div
+        id={toolListId}
+        aria-hidden={!expanded}
+        inert={!expanded ? true : undefined}
         className={`transition-all duration-150 ${
           expanded ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'
         } overflow-hidden`}


### PR DESCRIPTION
## What changed

- connect every Settings tool-group disclosure to its panel with `aria-expanded` and `aria-controls`
- mark collapsed panels `aria-hidden` and `inert` so their switches leave the accessibility tree and keyboard tab order
- preserve the existing height/opacity animation and restore controls immediately when a group expands
- add a focused regression test for collapse, expansion, and re-collapse semantics

## Why

Settings visually collapses all 15 tool groups by default, but the 72 child switches and their long descriptions remained exposed to assistive technology. A keyboard or screen-reader user therefore had to traverse controls that were not visible on screen, defeating the purpose of the accordion.

## User impact

The real 72-tool catalog now exposes only the 15 visible group-level switches while collapsed. Expanding Thinking Kit increases the navigable count to 16 and makes `calculate` available; collapsing it removes that control again. Visual layout and motion are unchanged on desktop and mobile.

## Verification

- `pnpm vitest run ui/src/pages/SettingsPage.tools-accordion.spec.tsx ui/src/pages/SettingsPage.tools-loading.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 409 files passed, 1 skipped; 3520 tests passed, 9 skipped
- `pnpm dev` real `/settings` Tools tab at 1280px and 390px
- browser role count: 15 switches collapsed, 16 after opening the one-tool Thinking Kit group, 15 after closing it