### PR TITLE
Identify credential edit actions by provider

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -327,6 +327,7 @@ export const en = {
     notSet: 'not set',
     officialEndpoint: 'provider official endpoint',
     deleteFailed: 'Delete failed',
+    editCredentialAria: 'Edit {{credential}}',
     deleteCredentialAria: 'Delete {{credential}}',
     deleteConfirmTitle: 'Delete {{credential}}?',
     deleteConfirmMessage: 'This permanently removes {{slug}} from Alice’s credential vault and clears any new Workspace defaults that use it. Existing Workspace files are not changed.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -316,6 +316,7 @@ export const ja: Resources = {
     notSet: '未設定',
     officialEndpoint: 'プロバイダー公式エンドポイント',
     deleteFailed: '削除に失敗しました',
+    editCredentialAria: '{{credential}} を編集',
     deleteCredentialAria: '{{credential}} を削除',
     deleteConfirmTitle: '{{credential}} を削除しますか？',
     deleteConfirmMessage: 'Alice の認証情報保管庫から {{slug}} を完全に削除し、それを使用する新規ワークスペースの既定値も解除します。既存のワークスペースファイルは変更されません。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -323,6 +323,7 @@ export const zhHant: Resources = {
     notSet: '未設定',
     officialEndpoint: '供應方官方端點',
     deleteFailed: '刪除失敗',
+    editCredentialAria: '編輯 {{credential}}',
     deleteCredentialAria: '刪除 {{credential}}',
     deleteConfirmTitle: '刪除 {{credential}}？',
     deleteConfirmMessage: '這會從 Alice 憑證庫中永久刪除 {{slug}}，並清除所有引用它的新工作區預設值。現有工作區檔案不會變更。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -315,6 +315,7 @@ export const zh: Resources = {
     notSet: '未设置',
     officialEndpoint: '提供方官方端点',
     deleteFailed: '删除失败',
+    editCredentialAria: '编辑 {{credential}}',
     deleteCredentialAria: '删除 {{credential}}',
     deleteConfirmTitle: '删除 {{credential}}？',
     deleteConfirmMessage: '这会从 Alice 凭证库中永久删除 {{slug}}，并清除所有引用它的新工作区默认值。现有工作区文件不会改变。',

--- a/ui/src/pages/AIProviderPage.spec.tsx
+++ b/ui/src/pages/AIProviderPage.spec.tsx
@@ -81,6 +81,13 @@ describe('AIProviderPage', () => {
     expect(await screen.findByText('已保存')).toBeTruthy()
   })
 
+  it('names each credential edit action with the credential it changes', async () => {
+    render(<AIProviderPage />)
+
+    expect(await screen.findByRole('button', { name: '编辑 Gemini' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: '编辑' })).toBeNull()
+  })
+
   it('confirms credential deletion and explains the default cleanup', async () => {
     render(<AIProviderPage />)
 

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -201,12 +201,20 @@ export function AIProviderPage() {
                     </div>
                     <div className="flex shrink-0 gap-2 self-end sm:self-auto">
                       <button
+                        type="button"
                         onClick={() => setModal({ mode: 'edit', cred })}
+                        title={t('aiProvider.editCredentialAria', {
+                          credential: credentialLabel(cred),
+                        })}
+                        aria-label={t('aiProvider.editCredentialAria', {
+                          credential: credentialLabel(cred),
+                        })}
                         className="text-[11px] px-2 py-1 rounded-md border border-border text-muted-foreground hover:text-foreground transition-colors"
                       >
                         {t('common.edit')}
                       </button>
                       <button
+                        type="button"
                         onClick={() => setPendingDelete(cred)}
                         title={t('aiProvider.deleteCredentialAria', {
                           credential: credentialLabel(cred),


### PR DESCRIPTION
## What changed

- give every AI Provider credential edit button an object-specific accessible name and tooltip
- use the same display-label fallback already used by the corresponding Delete action
- add localized names for English, Simplified Chinese, Traditional Chinese, and Japanese
- add a regression assertion that the visible concise label no longer produces a bare `Edit` control

## Why

The credential vault renders one Edit button per saved provider. All six buttons in the real page had the same accessible name, `Edit`, even though Delete already identified its target. Screen-reader button lists and voice control could not tell which credential an Edit action would change.

## User impact

The six real controls are now announced as `Edit glm-1`, `Edit minimax-1`, `Edit Meituan Longmao`, and so on, while the visible card design remains unchanged.

## Verification

- `pnpm vitest run ui/src/pages/AIProviderPage.spec.tsx ui/src/pages/AIProviderPage.loading.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 408 files passed, 1 skipped; 3520 tests passed, 9 skipped
- `pnpm dev` real `/settings/ai-provider` at 1280px and 390px
- browser role query: 6 object-specific Edit controls, 0 bare Edit controls