### PR TITLE
Associate the Issue runtime picker with its label

### DIFF
--- a/ui/src/components/form.tsx
+++ b/ui/src/components/form.tsx
@@ -97,16 +97,31 @@ export function ConfigSection({ title, description, children }: ConfigSectionPro
 interface FieldProps {
   label: string
   description?: string
+  controlId?: string
+  descriptionId?: string
   children: ReactNode
 }
 
-export function Field({ label, description, children }: FieldProps) {
+export function Field({
+  label,
+  description,
+  controlId,
+  descriptionId,
+  children,
+}: FieldProps) {
   return (
     <div className="mb-3.5 last:mb-0">
-      <label className="block text-[13px] text-foreground mb-1.5 font-medium">{label}</label>
+      <label
+        htmlFor={controlId}
+        className="block text-[13px] text-foreground mb-1.5 font-medium"
+      >
+        {label}
+      </label>
       {children}
       {description && (
-        <p className="text-[12px] text-muted-foreground/60 mt-1">{description}</p>
+        <p id={descriptionId} className="text-[12px] text-muted-foreground/60 mt-1">
+          {description}
+        </p>
       )}
     </div>
   )

--- a/ui/src/pages/IssueSettingsPage.spec.tsx
+++ b/ui/src/pages/IssueSettingsPage.spec.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { IssueSettingsPage } from './IssueSettingsPage'
+
+const mocks = vi.hoisted(() => ({
+  setIssueDefaultAgent: vi.fn(),
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    agents: [
+      { id: 'claude', displayName: 'Claude Code', kind: 'agent', installed: true },
+      { id: 'opencode', displayName: 'opencode', kind: 'agent', installed: true },
+      { id: 'shell', displayName: 'Shell', kind: 'utility', installed: true },
+    ],
+    defaultAgent: 'opencode',
+    issueDefaultAgent: null,
+    setIssueDefaultAgent: mocks.setIssueDefaultAgent,
+  }),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  cleanup()
+})
+
+describe('IssueSettingsPage', () => {
+  it('associates the runtime picker with its visible label and fallback explanation', () => {
+    render(<IssueSettingsPage />)
+
+    const select = screen.getByRole('combobox', { name: 'Agent runtime' })
+    const descriptionId = select.getAttribute('aria-describedby')
+    const description = descriptionId ? document.getElementById(descriptionId) : null
+
+    expect(select.id).not.toBe('')
+    expect(document.querySelector(`label[for="${select.id}"]`)?.textContent).toBe('Agent runtime')
+    expect(description?.textContent).toContain('workspace session default (opencode)')
+    expect(screen.queryByRole('option', { name: 'Shell' })).toBeNull()
+  })
+})

--- a/ui/src/pages/IssueSettingsPage.tsx
+++ b/ui/src/pages/IssueSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useId, useMemo, useState } from 'react'
 import { Bot } from 'lucide-react'
 
 import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
@@ -9,6 +9,8 @@ import { useWorkspaces } from '../contexts/workspaces-context'
 export function IssueSettingsPage() {
   const { agents, defaultAgent, issueDefaultAgent, setIssueDefaultAgent } = useWorkspaces()
   const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const runtimeSelectId = useId()
+  const runtimeDescriptionId = `${runtimeSelectId}-description`
 
   const runtimeAgents = useMemo(
     () => agents.filter((agent) => agent.kind !== 'utility'),
@@ -43,6 +45,8 @@ export function IssueSettingsPage() {
           >
             <Field
               label="Agent runtime"
+              controlId={runtimeSelectId}
+              descriptionId={runtimeDescriptionId}
               description={
                 workspaceDefault
                   ? `Unset uses the workspace session default (${workspaceDefault.displayName}), then the workspace's first enabled runtime.`
@@ -57,6 +61,8 @@ export function IssueSettingsPage() {
                     className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
                   />
                   <select
+                    id={runtimeSelectId}
+                    aria-describedby={runtimeDescriptionId}
                     value={issueDefaultAgent ?? ''}
                     disabled={status === 'saving'}
                     onChange={(event) => void save(event.target.value || null)}


### PR DESCRIPTION
## Summary

- associate the visible Agent runtime label with the Issue default-runtime select
- connect the fallback explanation through `aria-describedby`
- extend the shared Field primitive with optional association IDs
- cover the accessible name, fallback description, and utility-runtime filtering

## Evidence

Before this change, `/settings/issues` exposed one combobox but none named “Agent runtime”. After the change, the route exposes exactly one combobox with that name, and its description resolves to the workspace-default fallback text.

Verified in the real `pnpm dev` surface at desktop width and 390 px mobile width without changing the configured runtime.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm vitest run ui/src/pages/IssueSettingsPage.spec.tsx`
- `pnpm test` (409 files passed, 1 skipped; 3520 tests passed, 9 skipped)
