### PR TITLE
Clarify the external order monitoring control

### DIFF
--- a/ui/src/pages/TradingPage.broker-packs.spec.tsx
+++ b/ui/src/pages/TradingPage.broker-packs.spec.tsx
@@ -9,7 +9,11 @@ vi.mock('../api', () => ({
   api: { trading: { installBrokerPack } },
 }))
 
-import { KeylessDataSourcesRow, MissingBrokerPacksNotice } from './TradingPage'
+import {
+  ExternalOrderMonitoringRow,
+  KeylessDataSourcesRow,
+  MissingBrokerPacksNotice,
+} from './TradingPage'
 
 const missingCcxt: BrokerPackStatus = {
   engine: 'ccxt',
@@ -110,5 +114,39 @@ describe('KeylessDataSourcesRow', () => {
     await waitFor(() => expect(installBrokerPack).toHaveBeenCalledWith('ccxt'))
     expect(onPackInstalled).toHaveBeenCalledWith(expect.objectContaining({ engine: 'ccxt', installed: true }))
     expect(screen.getByText('Installed — choose the feeds you want')).toBeTruthy()
+  })
+})
+
+describe('ExternalOrderMonitoringRow', () => {
+  it('names and describes the cadence picker, then announces a saved change', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'PUT') return new Response(null, { status: 204 })
+      return new Response(JSON.stringify({
+        trading: { observeExternalOrdersEvery: '15m', keylessDataSources: [] },
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<ExternalOrderMonitoringRow />)
+
+    const select = await screen.findByRole('combobox', { name: 'External order monitoring' })
+    const describedBy = select.getAttribute('aria-describedby')?.split(' ') ?? []
+
+    expect(select.id).not.toBe('')
+    expect(document.querySelector(`label[for="${select.id}"]`)?.textContent).toContain(
+      'External order monitoring',
+    )
+    expect(describedBy.some((id) =>
+      document.getElementById(id)?.textContent?.includes('orders placed outside Alice'),
+    )).toBe(true)
+
+    fireEvent.change(select, { target: { value: '5m' } })
+
+    await waitFor(() => expect(screen.getByRole('status').textContent).toBe(
+      'Saved — restarting UTA to apply',
+    ))
+    expect(fetchMock).toHaveBeenCalledWith('/api/config/trading', expect.objectContaining({
+      method: 'PUT',
+    }))
   })
 })

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useId, useMemo } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import { SettingsScrollArea, inputClass } from '../components/form'
 import { Skeleton } from '../components/StateViews'
@@ -65,10 +65,13 @@ async function saveTradingRuntimeConfigPatch(patch: Partial<TradingRuntimeConfig
   return next
 }
 
-function ExternalOrderMonitoringRow() {
+export function ExternalOrderMonitoringRow() {
   const [value, setValue] = useState<string | null>(null)
   const [runtimeConfig, setRuntimeConfig] = useState<TradingRuntimeConfig | null>(null)
   const [msg, setMsg] = useState('')
+  const selectId = useId()
+  const descriptionId = `${selectId}-description`
+  const statusId = `${selectId}-status`
 
   useEffect(() => {
     let cancelled = false
@@ -105,20 +108,31 @@ function ExternalOrderMonitoringRow() {
   if (value === null) return null
 
   return (
-    <div className="flex items-center justify-between gap-3 px-4 py-3 border border-border rounded-lg">
+    <div className="flex flex-col items-stretch gap-3 rounded-lg border border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
-        <div className="text-[12px] font-medium text-foreground">External order monitoring</div>
-        <div className="text-[11px] text-muted-foreground">
+        <label htmlFor={selectId} className="text-[12px] font-medium text-foreground">
+          External order monitoring
+        </label>
+        <div id={descriptionId} className="text-[11px] text-muted-foreground">
           How often to scan for orders placed outside Alice (exchange app, direct API).
           Known pending orders are tracked every 10s regardless.
         </div>
       </div>
-      <div className="flex items-center gap-2 shrink-0">
-        {msg && <span className="text-[11px] text-muted-foreground">{msg}</span>}
+      <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:shrink-0 sm:justify-end">
+        <span
+          id={statusId}
+          role="status"
+          aria-atomic="true"
+          className="text-[11px] text-muted-foreground"
+        >
+          {msg}
+        </span>
         <select
+          id={selectId}
+          aria-describedby={`${descriptionId} ${statusId}`}
           value={value}
           onChange={(e) => { void save(e.target.value) }}
-          className={inputClass + ' w-auto'}
+          className={inputClass + ' w-full sm:w-auto'}
         >
           {OBSERVE_CADENCE_OPTIONS.map((v) => (
             <option key={v} value={v}>{v === 'off' ? 'Off' : `Every ${v}`}</option>


### PR DESCRIPTION
## Summary

- associate the visible External order monitoring label and explanation with its cadence picker
- keep a persistent polite status region so save and restart feedback is announced
- stack the explanation and a full-width picker on narrow screens while preserving the compact desktop row
- cover the accessible name, description, save request, and status feedback

## Evidence

Before this change, `/settings/trading` exposed one combobox and zero comboboxes named “External order monitoring”. At 390 px, the horizontal picker also compressed the explanation into a narrow text column.

After the change, the route exposes exactly one combobox with that name and links both the explanation and save status through `aria-describedby`. The mobile card now gives the copy its full width and places the picker below it; desktop remains a compact row.

Verified against the real `pnpm dev` route without changing the configured monitoring cadence.

## Verification

- `pnpm vitest run ui/src/pages/TradingPage.broker-packs.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (408 files passed, 1 skipped; 3520 tests passed, 9 skipped)
- real browser verification at desktop width and 390 px
