### PR TITLE
Expose the current top-level navigation destination

### DIFF
--- a/ui/src/components/ActivityBar.current-state.spec.tsx
+++ b/ui/src/components/ActivityBar.current-state.spec.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ActivityBar } from './ActivityBar'
+
+const mocks = vi.hoisted(() => ({
+  selectedSidebar: 'settings',
+  setSidebar: vi.fn(),
+  openOrFocus: vi.fn(),
+  setCollapsed: vi.fn(),
+  setRailCollapsed: vi.fn(),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: Record<string, unknown>) => unknown) => selector({
+    selectedSidebar: mocks.selectedSidebar,
+    setSidebar: mocks.setSidebar,
+    openOrFocus: mocks.openOrFocus,
+  }),
+}))
+
+vi.mock('../live/inbox-read', () => ({
+  useUnreadInboxCount: () => 0,
+}))
+
+vi.mock('../live/trading-push', () => ({
+  usePendingPushCount: () => 0,
+}))
+
+vi.mock('../live/activity-bar-collapse', () => ({
+  useActivityBarCollapse: (selector: (state: Record<string, unknown>) => unknown) => selector({
+    collapsedSections: {},
+    setCollapsed: mocks.setCollapsed,
+    railCollapsed: false,
+    setRailCollapsed: mocks.setRailCollapsed,
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => ({
+      'nav.item.chat': 'Ask Alice',
+      'nav.item.settings': 'Settings',
+      'nav.section.beta': 'Beta',
+      'nav.section.system': 'System',
+    })[key] ?? key,
+  }),
+}))
+
+vi.mock('./ThemeToggle', () => ({
+  ThemeToggle: () => null,
+}))
+
+beforeEach(() => {
+  mocks.selectedSidebar = 'settings'
+  vi.stubGlobal('matchMedia', vi.fn(() => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('ActivityBar current destination', () => {
+  it('exposes the visually active product area as the current page', () => {
+    const { rerender } = render(<ActivityBar open onClose={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Settings' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Ask Alice' }).getAttribute('aria-current')).toBeNull()
+    expect(document.querySelectorAll('nav [aria-current="page"]')).toHaveLength(1)
+
+    mocks.selectedSidebar = 'chat'
+    rerender(<ActivityBar open onClose={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Ask Alice' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('button', { name: 'Settings' }).getAttribute('aria-current')).toBeNull()
+    expect(document.querySelectorAll('nav [aria-current="page"]')).toHaveLength(1)
+  })
+})

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -190,6 +190,7 @@ export function ActivityBar({
                           type="button"
                           onClick={handleClick}
                           title={t(item.labelKey)}
+                          aria-current={isActive ? 'page' : undefined}
                           className={`oa-nav-item relative flex items-center rounded-md text-left ${
                             compactRail
                               ? denseRail


### PR DESCRIPTION
## Summary

- mark the visually active Activity Bar destination with `aria-current="page"`
- remove the current marker automatically when focus moves to another product area
- cover both the initial Settings state and a transition to Ask Alice

## Evidence

On `/settings/agent-permissions`, the Settings category sidebar correctly exposed its current item, but the primary Activity Bar exposed zero current destinations even though Settings was visually highlighted.

After this change, the Activity Bar exposes exactly one current destination on both the desktop rail and the 390 px mobile drawer. The marker follows the same `selectedSidebar` state that already drives the visual treatment, so interaction and styling remain unchanged.

## Verification

- `pnpm vitest run ui/src/components/ActivityBar.current-state.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (409 files passed, 1 skipped; 3520 tests passed, 9 skipped)
- real `pnpm dev` browser verification at desktop width and 390 px
