### PR TITLE
Keep the closed mobile Activity Bar out of navigation

### DIFF
--- a/ui/src/components/ActivityBar.drawer-state.spec.tsx
+++ b/ui/src/components/ActivityBar.drawer-state.spec.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ActivityBar } from './ActivityBar'
+
+const mocks = vi.hoisted(() => ({
+  setSidebar: vi.fn(),
+  openOrFocus: vi.fn(),
+  setCollapsed: vi.fn(),
+  setRailCollapsed: vi.fn(),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: Record<string, unknown>) => unknown) => selector({
+    selectedSidebar: 'settings',
+    setSidebar: mocks.setSidebar,
+    openOrFocus: mocks.openOrFocus,
+  }),
+}))
+
+vi.mock('../live/inbox-read', () => ({
+  useUnreadInboxCount: () => 0,
+}))
+
+vi.mock('../live/trading-push', () => ({
+  usePendingPushCount: () => 0,
+}))
+
+vi.mock('../live/activity-bar-collapse', () => ({
+  useActivityBarCollapse: (selector: (state: Record<string, unknown>) => unknown) => selector({
+    collapsedSections: {},
+    setCollapsed: mocks.setCollapsed,
+    railCollapsed: false,
+    setRailCollapsed: mocks.setRailCollapsed,
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => ({
+      'nav.item.chat': 'Ask Alice',
+      'nav.item.settings': 'Settings',
+      'nav.section.beta': 'Beta',
+      'nav.section.system': 'System',
+    })[key] ?? key,
+  }),
+}))
+
+vi.mock('./ThemeToggle', () => ({
+  ThemeToggle: () => null,
+}))
+
+beforeEach(() => {
+  vi.stubGlobal('matchMedia', vi.fn(() => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('ActivityBar mobile drawer state', () => {
+  it('keeps the closed mobile drawer out of navigation without hiding the desktop rail', () => {
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <ActivityBar open={false} onClose={onClose} desktopStatic={false} />,
+    )
+    const activityBar = screen.getByTestId('activity-bar')
+
+    expect(activityBar.getAttribute('aria-hidden')).toBe('true')
+    expect(activityBar.hasAttribute('inert')).toBe(true)
+
+    rerender(<ActivityBar open onClose={onClose} desktopStatic={false} />)
+    expect(activityBar.getAttribute('aria-hidden')).toBe('false')
+    expect(activityBar.hasAttribute('inert')).toBe(false)
+
+    rerender(<ActivityBar open={false} onClose={onClose} desktopStatic />)
+    expect(activityBar.getAttribute('aria-hidden')).toBe('false')
+    expect(activityBar.hasAttribute('inert')).toBe(false)
+  })
+})

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -98,6 +98,7 @@ export function ActivityBar({
   const compactRail = desktopStatic && (forcedCompactRail || railCollapsed)
   const narrowRail = desktopStatic && railMode === 'narrow' && !compactRail
   const denseRail = desktopStatic && shortRailHeight
+  const mobileDrawerClosed = !desktopStatic && !open
 
   return (
     <>
@@ -112,6 +113,9 @@ export function ActivityBar({
       {/* ActivityBar — Linear-style workspace rail. Mobile: slide-in over
        *  page with backdrop. Desktop: static column flush left. */}
       <aside
+        data-testid="activity-bar"
+        aria-hidden={mobileDrawerClosed}
+        inert={mobileDrawerClosed ? true : undefined}
         className={`
           w-[280px] ${compactRail ? 'md:w-[60px]' : narrowRail ? 'md:w-[152px]' : 'md:w-[188px]'} h-full flex flex-col shrink-0
           bg-muted


### PR DESCRIPTION
## Summary

- mark the off-canvas mobile Activity Bar as `aria-hidden` and `inert` while closed
- restore the complete navigation tree when the drawer opens
- leave the static desktop rail interactive regardless of the mobile open flag
- align the primary drawer with the same closed-state contract proposed for page-level drawers in #816

## Evidence

At 390 px, the visually closed Activity Bar still exposed 17 buttons before the main content, including Ask Alice, Inbox, Settings, and the section controls. It had neither `aria-hidden` nor `inert`, so keyboard and assistive-technology users could traverse the off-screen rail.

After this change:

- closed mobile drawer: 0 exposed buttons, `aria-hidden="true"`, inert
- open mobile drawer: 17 exposed buttons, `aria-hidden="false"`, not inert
- desktop rail: 18 exposed controls, `aria-hidden="false"`, not inert

## Verification

- `pnpm vitest run ui/src/components/ActivityBar.drawer-state.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (409 files passed, 1 skipped; 3520 tests passed, 9 skipped)
- real `pnpm dev` browser verification at desktop width and 390 px, closed and open
