### PR TITLE
Describe Market trend charts to assistive technology

### DIFF
--- a/ui/src/components/market/SeriesCard.spec.tsx
+++ b/ui/src/components/market/SeriesCard.spec.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { MacroSeriesCard } from '../../api/reference'
+import { SeriesCard } from './SeriesCard'
+
+afterEach(cleanup)
+
+describe('SeriesCard trend chart', () => {
+  it('presents a non-interactive chart with a concise range summary', () => {
+    const card: MacroSeriesCard = {
+      id: 'pe_month',
+      label: 'S&P 500 PE',
+      unit: 'index',
+      points: [
+        { date: '2026-01-01', value: 25 },
+        { date: '2026-04-01', value: 27.2 },
+        { date: '2026-07-28', value: 28.6 },
+      ],
+      latest: 28.6,
+      latestDate: '2026-07-28',
+      change: -0.11,
+    }
+
+    render(<SeriesCard card={card} label="S&P 500 PE" emptyText="No data" />)
+
+    expect(screen.getByRole('img', {
+      name: 'S&P 500 PE: 25.0 → 28.6 (2026-01-01 – 2026-07-28)',
+    })).toBeTruthy()
+    expect(screen.queryByRole('application')).toBeNull()
+  })
+})

--- a/ui/src/components/market/SeriesCard.tsx
+++ b/ui/src/components/market/SeriesCard.tsx
@@ -25,7 +25,15 @@ export function SeriesCard({ card, label, emptyText }: { card: MacroSeriesCard; 
         </div>
         <div className="h-9 w-24 shrink-0">
           {!empty && (
-            <LineChart width={96} height={36} data={card.points} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
+            <LineChart
+              width={96}
+              height={36}
+              data={card.points}
+              margin={{ top: 2, right: 0, bottom: 0, left: 0 }}
+              accessibilityLayer={false}
+              role="img"
+              aria-label={describeSeriesTrend(card, label)}
+            >
               <YAxis hide domain={['dataMin', 'dataMax']} />
               <Line type="monotone" dataKey="value" stroke="var(--primary)" strokeWidth={1.25} dot={false} isAnimationActive={false} />
             </LineChart>
@@ -35,6 +43,16 @@ export function SeriesCard({ card, label, emptyText }: { card: MacroSeriesCard; 
       {empty && <span className="text-[11px] text-muted-foreground">{emptyText}</span>}
     </div>
   )
+}
+
+export function describeSeriesTrend(card: MacroSeriesCard, label: string): string {
+  const first = card.points[0]
+  const last = card.points[card.points.length - 1]
+  if (!first || !last) return label
+  if (first === last) {
+    return `${label}: ${fmtSeriesValue(card, last.value)} (${last.date})`
+  }
+  return `${label}: ${fmtSeriesValue(card, first.value)} → ${fmtSeriesValue(card, last.value)} (${first.date} – ${last.date})`
 }
 
 export function fmtSeriesValue(card: MacroSeriesCard, v: number | null): string {


### PR DESCRIPTION
## Summary

- present compact SeriesCard trends as non-interactive images instead of unnamed applications
- name each chart with its localized metric label, first/latest values, and date range
- disable Recharts' interactive accessibility layer for charts that expose no controls
- cover the resulting role and range summary

## Evidence

The real Market landing page exposed four unnamed `application` nodes for the S&P 500 valuation strip. Those mini charts have no tooltip, focusable points, or other interaction, so the role both lacked context and implied controls that do not exist.

After this change the page exposes zero application nodes and four named trend images, for example:

`S&P 500 PE: 25.4 → 28.6 (2021-09-01 – 2026-07-28)`

The same SeriesCard contract also improves Macro and Fed board trends.

## Verification

- `pnpm vitest run ui/src/components/market/SeriesCard.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (409 files passed, 1 skipped; 3520 tests passed, 9 skipped)
- real `pnpm dev` Market verification at desktop width and 390 px
