### PR TITLE
Make Issue Session assignees identity-first

### DIFF
--- a/ui/src/components/IssueDetail.spec.tsx
+++ b/ui/src/components/IssueDetail.spec.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
   IssueDetail as IssueDetailData,
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   mutate: vi.fn(),
   openAgentConfig: vi.fn(),
   openHeadlessRun: vi.fn(),
+  getWorkspaceSessionDirectory: vi.fn(),
 }))
 
 const scheduledIssue: IssueDetailData = {
@@ -71,12 +72,16 @@ vi.mock('../contexts/workspaces-context', () => ({
 vi.mock('./workspace/api', () => ({
   detectWorkspaceCredential: mocks.detectWorkspaceCredential,
   getAgentReadiness: vi.fn().mockResolvedValue({ agents: {} }),
-  getWorkspaceSessionDirectory: vi.fn().mockResolvedValue({ sessions: [] }),
+  getWorkspaceSessionDirectory: mocks.getWorkspaceSessionDirectory,
 }))
 
 vi.mock('./MarkdownWhatEditor', () => ({
   MarkdownWhatEditor: ({ value }: { value: string }) => <div>{value}</div>,
 }))
+
+beforeEach(() => {
+  mocks.getWorkspaceSessionDirectory.mockResolvedValue({ sessions: [] })
+})
 
 afterEach(() => {
   cleanup()
@@ -150,5 +155,50 @@ describe('IssueDetail property controls', () => {
 
     fireEvent.change(model, { target: { value: 'custom' } })
     expect(screen.getByRole('textbox', { name: 'Custom run model' })).toBeTruthy()
+  })
+
+  it('keeps stable Session identities first in a large assignee picker', async () => {
+    mocks.getWorkspaceSessionDirectory.mockResolvedValue({
+      sessions: [
+        {
+          resumeId: 'resume-recent-worker',
+          agent: 'codex',
+          createdAt: Date.now() - 120_000,
+          updatedAt: Date.now() - 60_000,
+          resumable: true,
+          active: false,
+          latestExecution: {
+            taskId: 'task-1',
+            status: 'done',
+            startedAt: Date.now() - 90_000,
+            assistantPreview: 'Updated a very long financial and industrial rotation report.',
+          },
+        },
+        {
+          resumeId: 'resume-active-owner',
+          agent: 'pi',
+          createdAt: Date.now() - 86_400_000,
+          updatedAt: Date.now() - 3_600_000,
+          resumable: true,
+          active: true,
+          interactive: {
+            name: 'p1',
+            title: 'Current thesis room',
+            state: 'running',
+            lastActiveAt: new Date().toISOString(),
+          },
+        },
+      ],
+    })
+
+    render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
+
+    const assignee = screen.getByRole('combobox', { name: 'Assignee' }) as HTMLSelectElement
+    await waitFor(() => expect(assignee.options).toHaveLength(4))
+    const labels = Array.from(assignee.options, (option) => option.textContent ?? '')
+
+    expect(labels[2]).toBe('@resume-active-owner · pi · active — Current thesis room')
+    expect(labels[3]).toMatch(/^@resume-recent-worker · codex · .+ — Updated a very long financi…$/)
+    expect(labels.some((label) => label.startsWith('Updated a very long'))).toBe(false)
   })
 })

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -120,18 +120,23 @@ function AssigneeEditor({
   disabled?: boolean
   onChange: (next: string) => void
 }) {
-  const sessionChoices = sessions.filter(
-    (session) => session.resumeId && session.agent !== 'shell' && session.resumable,
-  )
+  const sessionChoices = sessions
+    .filter((session) => session.resumeId && session.agent !== 'shell' && session.resumable)
+    .toSorted((a, b) => Number(b.active) - Number(a.active) || b.updatedAt - a.updatedAt)
   const selectedResumeId = value.startsWith('@resume-') ? value.slice(1) : null
   const hasSelected = !selectedResumeId || sessionChoices.some((session) => session.resumeId === selectedResumeId)
   const labelFor = (session: WorkspaceSessionDirectoryEntry) => {
-    const raw = session.interactive?.title
+    const rawContext = session.interactive?.title
       || session.interactive?.name
       || session.latestExecution?.assistantPreview
-      || session.resumeId
-    const label = raw.length > 38 ? `${raw.slice(0, 37)}…` : raw
-    return `${label} · ${session.agent}`
+    const normalizedContext = rawContext?.replace(/\s+/g, ' ').trim()
+    const context = normalizedContext && normalizedContext !== session.resumeId
+      ? normalizedContext.length > 28
+        ? `${normalizedContext.slice(0, 27)}…`
+        : normalizedContext
+      : null
+    const activity = session.active ? 'active' : formatRelativeTime(session.updatedAt)
+    return `@${session.resumeId} · ${session.agent} · ${activity}${context ? ` — ${context}` : ''}`
   }
 
   return (
@@ -153,7 +158,7 @@ function AssigneeEditor({
           </option>
         ))}
         {!hasSelected && selectedResumeId && (
-          <option value={value}>Signed Session · {selectedResumeId}</option>
+          <option value={value}>Signed Session · @{selectedResumeId}</option>
         )}
       </optgroup>
     </select>


### PR DESCRIPTION
## Summary

- lead every resumable Session option with its stable `@resumeId`
- show runtime and active/recent activity before optional conversation context
- keep a short normalized context suffix for recognition without letting report text become the identity
- sort active Sessions first, then by most recent activity
- preserve all existing option values and available Sessions

## Evidence

The real scheduled Issue assignee picker contains 53 options. Before this change, most Session choices began with assistant output or conversation text such as “Updated [financial-industrial-rotatio…” or “The dossier …”, while the durable identity users see in Issue activity was often absent.

After the change, all 51 Session choices begin with the exact stable identity, for example:

`@resume-smooth-clay-rain-qkrtgu · codex · 8h ago — Updated [financial-industri…`

This makes the native picker scannable without removing older Sessions or changing assignment values.

## Verification

- `pnpm vitest run ui/src/components/IssueDetail.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (408 files passed, 1 skipped; 3520 tests passed, 9 skipped)
- real `pnpm dev` Issue detail verification with 53 options at desktop width and 390 px
