### PR TITLE
Confirm RSS feed removal

### DIFF
--- a/ui/src/pages/NewsCollectorPage.spec.tsx
+++ b/ui/src/pages/NewsCollectorPage.spec.tsx
@@ -8,6 +8,42 @@ import { FeedsSection } from './NewsCollectorPage'
 afterEach(cleanup)
 
 describe('NewsCollectorPage feed editor', () => {
+  it('confirms the named feed before removing it', () => {
+    const onChange = vi.fn()
+    const feeds = [
+      {
+        name: 'Federal Reserve Press',
+        url: 'https://www.federalreserve.gov/feeds/press_all.xml',
+        source: 'fed',
+        enabled: true,
+      },
+      {
+        name: 'ECB Press',
+        url: 'https://www.ecb.europa.eu/rss/press.html',
+        source: 'ecb',
+        enabled: true,
+      },
+    ]
+    render(<FeedsSection feeds={feeds} onChange={onChange} />)
+
+    const removeButton = screen.getByRole('button', { name: 'Remove Federal Reserve Press' })
+    fireEvent.click(removeButton)
+
+    expect(screen.getByRole('heading', { name: 'Remove Federal Reserve Press?' })).toBeTruthy()
+    expect(screen.getByText(/Existing articles remain available/)).toBeTruthy()
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByRole('heading', { name: 'Remove Federal Reserve Press?' })).toBeNull()
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.click(removeButton)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove feed' }))
+
+    expect(onChange).toHaveBeenCalledWith([feeds[1]])
+    expect(screen.queryByRole('heading', { name: 'Remove Federal Reserve Press?' })).toBeNull()
+  })
+
   it('rejects an invalid feed URL before submitting the feed', () => {
     const onChange = vi.fn()
     render(<FeedsSection feeds={[]} onChange={onChange} />)

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -5,6 +5,7 @@ import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../compone
 import { Toggle } from '../components/Toggle'
 import { useConfigPage } from '../hooks/useConfigPage'
 import { PageHeader } from '../components/PageHeader'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 
 // ==================== Config Section ====================
 
@@ -98,6 +99,10 @@ export function FeedsSection({
   const [newUrl, setNewUrl] = useState('')
   const [newSource, setNewSource] = useState('')
   const [newDescription, setNewDescription] = useState('')
+  const [pendingRemoval, setPendingRemoval] = useState<{
+    feed: NewsCollectorFeed
+    index: number
+  } | null>(null)
 
   const activeCount = useMemo(() => feeds.filter((f) => f.enabled !== false).length, [feeds])
   const feedUrlValid = isValidFeedUrl(newUrl)
@@ -164,9 +169,11 @@ export function FeedsSection({
                   </div>
                 </div>
                 <button
-                  onClick={() => removeFeed(i)}
-                  className="shrink-0 text-muted-foreground hover:text-destructive transition-colors p-1"
-                  title="Remove feed"
+                  type="button"
+                  onClick={() => setPendingRemoval({ feed, index: i })}
+                  aria-label={`Remove ${feed.name}`}
+                  className="oa-icon-action shrink-0 p-1 text-muted-foreground transition-colors hover:text-destructive"
+                  title={`Remove ${feed.name}`}
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <line x1="18" y1="6" x2="6" y2="18" />
@@ -217,6 +224,26 @@ export function FeedsSection({
           Add Feed
         </button>
       </div>
+
+      {pendingRemoval && (
+        <ConfirmDialog
+          title={`Remove ${pendingRemoval.feed.name}?`}
+          message={(
+            <>
+              OpenAlice will stop collecting new articles from{' '}
+              <strong>{pendingRemoval.feed.name}</strong> and remove it from your saved News Sources.
+              Existing articles remain available until the configured retention period expires.
+            </>
+          )}
+          confirmLabel="Remove feed"
+          workingLabel="Removing…"
+          onConfirm={() => {
+            removeFeed(pendingRemoval.index)
+            setPendingRemoval(null)
+          }}
+          onClose={() => setPendingRemoval(null)}
+        />
+      )}
     </ConfigSection>
   )
 }


### PR DESCRIPTION
## What changed

- replace immediate RSS feed deletion with the shared in-app confirmation flow
- name each remove control after the affected feed
- explain that existing articles remain until retention expires
- cover cancel and confirm behavior in the feed editor spec

## Why

News Sources currently exposes 28 compact remove controls that persist changes immediately. A stray click can silently remove a configured feed, and the controls do not identify their target to assistive technology.

## User impact

Removing a source is now deliberate and names the affected feed before any saved configuration changes. Cancel leaves the feed list untouched.

## Verification

- pnpm vitest run ui/src/pages/NewsCollectorPage.spec.tsx
- cd ui && npx tsc -b
- npx tsc --noEmit
- pnpm test
- git diff --check
- real pnpm dev route: /settings/news-collector, desktop and 390px mobile; confirmed cancel preserves all 28 feeds and the dialog has no horizontal overflow