### PR TITLE
Keep keyboard focus inside named dialogs

### DIFF
--- a/ui/src/components/ConfirmDialog.tsx
+++ b/ui/src/components/ConfirmDialog.tsx
@@ -55,7 +55,11 @@ export function ConfirmDialog({
   const confirmClass = variant === 'danger' ? 'btn-danger' : 'btn-primary'
 
   return (
-    <Dialog onClose={busy ? () => {} : onClose} width="w-[440px]">
+    <Dialog
+      ariaLabel={title}
+      onClose={busy ? () => {} : onClose}
+      width="w-[440px]"
+    >
       <div className="px-5 py-4 border-b border-border">
         <h2 className="text-[15px] font-semibold text-foreground">{title}</h2>
       </div>
@@ -65,6 +69,7 @@ export function ConfirmDialog({
       <div className="px-5 py-3 border-t border-border flex justify-end gap-2">
         <button
           type="button"
+          autoFocus
           onClick={onClose}
           disabled={busy}
           className="btn-secondary"

--- a/ui/src/components/DesktopUpdatePrompt.tsx
+++ b/ui/src/components/DesktopUpdatePrompt.tsx
@@ -70,7 +70,11 @@ export function DesktopUpdatePrompt() {
   }
 
   return (
-    <Dialog onClose={busy ? () => {} : () => setStatus(null)} width="w-[480px]">
+    <Dialog
+      ariaLabel="OpenAlice update ready"
+      onClose={busy ? () => {} : () => setStatus(null)}
+      width="w-[480px]"
+    >
       <div className="px-5 py-4 border-b border-border flex items-center gap-3">
         <div className="h-9 w-9 rounded-lg border border-primary/30 bg-primary-muted/30 text-primary flex items-center justify-center shrink-0">
           <Download size={18} strokeWidth={1.8} />

--- a/ui/src/components/uta/CreateUTADialog.tsx
+++ b/ui/src/components/uta/CreateUTADialog.tsx
@@ -204,7 +204,7 @@ export function CreateUTADialog({
   ) : null
 
   return (
-    <Dialog onClose={onClose}>
+    <Dialog ariaLabel={headerLabel} onClose={onClose}>
       <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <h3 className="text-[14px] font-semibold text-foreground truncate">{headerLabel}</h3>

--- a/ui/src/components/uta/Dialog.spec.tsx
+++ b/ui/src/components/uta/Dialog.spec.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { useState } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Dialog } from './Dialog'
+
+afterEach(cleanup)
+
+function DialogHarness() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>Open dialog</button>
+      {open && (
+        <Dialog ariaLabel="Example dialog" onClose={() => setOpen(false)}>
+          <button type="button">First action</button>
+          <button type="button">Last action</button>
+        </Dialog>
+      )}
+    </>
+  )
+}
+
+describe('Dialog modal behavior', () => {
+  it('announces a named modal, contains keyboard focus, and restores the opener', async () => {
+    const user = userEvent.setup()
+    render(<DialogHarness />)
+
+    const opener = screen.getByRole('button', { name: 'Open dialog' })
+    await user.click(opener)
+
+    const dialog = screen.getByRole('dialog', { name: 'Example dialog' })
+    const first = screen.getByRole('button', { name: 'First action' })
+    const last = screen.getByRole('button', { name: 'Last action' })
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(document.activeElement).toBe(first)
+
+    await user.tab({ shift: true })
+    expect(document.activeElement).toBe(last)
+    await user.tab()
+    expect(document.activeElement).toBe(first)
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(document.activeElement).toBe(opener)
+  })
+})

--- a/ui/src/components/uta/Dialog.tsx
+++ b/ui/src/components/uta/Dialog.tsx
@@ -1,27 +1,100 @@
-import { useCallback, useEffect } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
 
 /** Generic modal dialog used by the UTA wizard + edit flows. */
-export function Dialog({ onClose, width, children }: {
+export function Dialog({ onClose, width, ariaLabel, children }: {
   onClose: () => void
   width?: string
+  ariaLabel: string
   children: React.ReactNode
 }) {
+  const surfaceRef = useRef<HTMLDivElement>(null)
+  const restoreFocusRef = useRef<HTMLElement | null>(
+    typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null,
+  )
+
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') onClose()
   }, [onClose])
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    const surface = surfaceRef.current
+    if (surface && !surface.contains(document.activeElement)) {
+      const initialFocus = focusableElements(surface)[0] ?? surface
+      initialFocus.focus()
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      const previousFocus = restoreFocusRef.current
+      if (previousFocus?.isConnected) previousFocus.focus()
+    }
   }, [handleKeyDown])
+
+  const trapFocus = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return
+    const surface = surfaceRef.current
+    if (!surface) return
+
+    const focusable = focusableElements(surface)
+    if (focusable.length === 0) {
+      event.preventDefault()
+      surface.focus()
+      return
+    }
+
+    const first = focusable[0]!
+    const last = focusable.at(-1)!
+    const active = document.activeElement
+    if (event.shiftKey && (active === first || !surface.contains(active))) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && (active === last || !surface.contains(active))) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
 
   return (
     // z-[60] keeps dialogs above the mobile nav drawers (z-50).
     <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
-      <div className="oa-dialog-backdrop absolute inset-0 bg-backdrop" onClick={onClose} />
-      <div className={`oa-dialog-surface relative ${width || 'w-full sm:w-[560px]'} max-w-[95vw] max-h-[85vh] bg-background rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden`}>
+      <div
+        aria-hidden
+        className="oa-dialog-backdrop absolute inset-0 bg-backdrop"
+        onClick={onClose}
+      />
+      <div
+        ref={surfaceRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        tabIndex={-1}
+        onKeyDown={trapFocus}
+        className={`oa-dialog-surface relative ${width || 'w-full sm:w-[560px]'} max-w-[95vw] max-h-[85vh] bg-background rounded-xl border border-border shadow-2xl flex flex-col overflow-hidden`}
+      >
         {children}
       </div>
     </div>
   )
+}
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  'a[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function focusableElements(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)]
+    .filter((element) => element.getAttribute('aria-hidden') !== 'true')
 }

--- a/ui/src/components/uta/EditUTADialog.tsx
+++ b/ui/src/components/uta/EditUTADialog.tsx
@@ -75,7 +75,7 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
   const displayName = displayNameForUTA(uta, preset)
 
   return (
-    <Dialog onClose={onClose} width="w-[560px]">
+    <Dialog ariaLabel={`Edit ${displayName}`} onClose={onClose} width="w-[560px]">
       {/* Header */}
       <div className="shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
         <div className="flex items-center gap-3 min-w-0">
@@ -100,7 +100,12 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
               </svg>
             </button>
           )}
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground p-1 transition-colors">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={`Close ${displayName} editor`}
+            className="text-muted-foreground hover:text-foreground p-1 transition-colors"
+          >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <path d="M18 6L6 18M6 6l12 12" />
             </svg>

--- a/ui/src/components/uta/OrderEntryDialog.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.tsx
@@ -42,6 +42,7 @@ export function OrderEntryDialog({ utaId, mode, onClose, subAccounts, defaultSub
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<{ message: string; phase?: string } | null>(null)
   const [result, setResult] = useState<WalletPushResult | null>(null)
+  const dialogTitle = mode.kind === 'place' ? 'Place Order' : 'Close Position'
 
   // Whether the result panel has shown — once it has, parent should
   // refresh on close. We notify via onPushComplete after a successful
@@ -52,8 +53,8 @@ export function OrderEntryDialog({ utaId, mode, onClose, subAccounts, defaultSub
   }
 
   return (
-    <Dialog onClose={handleClose} width="w-[560px]">
-      <Header mode={mode} onClose={handleClose} />
+    <Dialog ariaLabel={dialogTitle} onClose={handleClose} width="w-[560px]">
+      <Header title={dialogTitle} onClose={handleClose} />
 
       <div className="flex-1 overflow-y-auto px-6 py-6">
         {result
@@ -75,12 +76,16 @@ export function OrderEntryDialog({ utaId, mode, onClose, subAccounts, defaultSub
 
 // ==================== Header ====================
 
-function Header({ mode, onClose }: { mode: OrderEntryMode; onClose: () => void }) {
-  const title = mode.kind === 'place' ? 'Place Order' : 'Close Position'
+function Header({ title, onClose }: { title: string; onClose: () => void }) {
   return (
     <div className="shrink-0 px-6 py-4 border-b border-border flex items-center justify-between">
       <h3 className="text-[14px] font-semibold text-foreground">{title}</h3>
-      <button onClick={onClose} className="text-muted-foreground hover:text-foreground p-1 transition-colors">
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label={`Close ${title}`}
+        className="text-muted-foreground hover:text-foreground p-1 transition-colors"
+      >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
           <path d="M18 6L6 18M6 6l12 12" />
         </svg>

--- a/ui/src/components/workspace/CreateWorkspaceDialog.tsx
+++ b/ui/src/components/workspace/CreateWorkspaceDialog.tsx
@@ -27,7 +27,11 @@ export interface CreateWorkspaceDialogProps {
 export function CreateWorkspaceDialog(props: CreateWorkspaceDialogProps): ReactElement {
   const { t } = useTranslation()
   return (
-    <Dialog onClose={props.onClose} width="w-[460px]">
+    <Dialog
+      ariaLabel={t('createWorkspace.dialogTitle')}
+      onClose={props.onClose}
+      width="w-[460px]"
+    >
       <div className="px-5 py-4 border-b border-border">
         <h2 className="text-[15px] font-semibold text-foreground">{t('createWorkspace.dialogTitle')}</h2>
         <p className="text-[12px] text-muted-foreground mt-0.5">

--- a/ui/src/components/workspace/WorkspaceOffboardingDialog.tsx
+++ b/ui/src/components/workspace/WorkspaceOffboardingDialog.tsx
@@ -63,7 +63,11 @@ export function WorkspaceOffboardingDialog({
   }
 
   return (
-    <Dialog onClose={busy ? () => {} : onClose} width="w-[560px]">
+    <Dialog
+      ariaLabel={t('workspace.offboardTitle')}
+      onClose={busy ? () => {} : onClose}
+      width="w-[560px]"
+    >
       <div className="border-b border-border px-5 py-4">
         <h2 className="text-[15px] font-semibold text-foreground">{t('workspace.offboardTitle')}</h2>
         <p className="mt-1 text-[12px] text-muted-foreground">


### PR DESCRIPTION
## What changed

- expose every shared Dialog as a named aria-modal dialog
- move focus into the modal on open and restore the invoking control on close
- contain Tab and Shift+Tab within the modal
- default destructive confirmations to the safe Cancel action
- name previously anonymous close controls in order and account dialogs
- add a focused regression spec for dialog semantics and focus lifecycle

## Why

The existing overlay looked modal, but it had no dialog semantics and left keyboard focus on the obscured background control. Screen-reader and keyboard users therefore received no modal context and could tab behind the overlay.

## User impact

Confirmation, workspace, broker, order, account, and update dialogs now announce their purpose and behave as one contained interaction. Escape closes as before and focus returns to the control that opened the dialog.

## Verification

- pnpm vitest run ui/src/components/uta/Dialog.spec.tsx ui/src/components/uta/OrderEntryDialog.spec.tsx ui/src/components/uta/CreateUTADialog.spec.tsx
- cd ui && npx tsc -b
- npx tsc --noEmit
- pnpm test
- git diff --cached --check
- real pnpm dev route: /settings/ai-provider; confirmed named dialog semantics, Cancel initial focus, forward/backward focus wrapping, Escape close, and opener focus restoration