### PR TITLE
Keep Workspace overview cards compact

### DIFF
--- a/ui/src/components/workspace/OverviewCard.spec.tsx
+++ b/ui/src/components/workspace/OverviewCard.spec.tsx
@@ -83,4 +83,37 @@ describe('OverviewCard', () => {
     expect(onOpen).toHaveBeenCalledTimes(1)
     expect(onOpenSession).toHaveBeenCalledWith('session-1')
   })
+
+  it('keeps high-session workspaces compact while preserving recent drill-ins', () => {
+    const onOpen = vi.fn()
+    const onOpenSession = vi.fn()
+    const manySessionWorkspace: Workspace = {
+      ...workspace,
+      sessions: Array.from({ length: 8 }, (_, index) => ({
+        ...workspace.sessions[0]!,
+        id: `session-${index + 1}`,
+        resumeId: `resume-${index + 1}`,
+        name: `x${index + 1}`,
+        state: index === 0 ? 'running' : 'paused',
+        lastActiveAt: `2026-07-28T00:${String(59 - index).padStart(2, '0')}:00.000Z`,
+      })),
+    }
+
+    render(
+      <OverviewCard
+        workspace={manySessionWorkspace}
+        lastCommit={null}
+        onOpen={onOpen}
+        onOpenSession={onOpenSession}
+      />,
+    )
+
+    expect(screen.getAllByRole('button', { name: / (running|paused)$/ })).toHaveLength(5)
+    expect(screen.getByRole('button', { name: 'x5 paused' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'x6 paused' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'View all 8 sessions' }))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onOpenSession).not.toHaveBeenCalled()
+  })
 })

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -24,6 +24,8 @@ const AGENT_ICONS: Record<string, LucideIcon> = {
   shell: Terminal,
 }
 
+const SESSION_PREVIEW_LIMIT = 5
+
 function AgentGlyph({ agent }: { agent: string }) {
   const Icon = AGENT_ICONS[agent]
   if (Icon) return <Icon size={12} strokeWidth={2.25} aria-hidden="true" />
@@ -53,6 +55,8 @@ export function OverviewCard({
   const w = workspace
   const label = workspaceDisplayName(w)
   const hasRunning = w.sessions.some((s) => s.state === 'running')
+  const previewSessions = w.sessions.slice(0, SESSION_PREVIEW_LIMIT)
+  const hiddenSessionCount = w.sessions.length - previewSessions.length
 
   const lastActivityMs = useMemo(() => {
     const sessionTs = w.sessions
@@ -119,14 +123,15 @@ export function OverviewCard({
 
         {/* Sessions */}
         <div className="border-t border-border pt-3">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-1.5">
-            {t('workspace.sessions')}
+          <div className="mb-1.5 flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground/70">
+            <span>{t('workspace.sessions')}</span>
+            <span className="tabular-nums text-muted-foreground/45">{w.sessions.length}</span>
           </div>
           {w.sessions.length === 0 ? (
             <p className="text-[12px] text-muted-foreground/80 italic">{t('workspace.noSessions')}</p>
           ) : (
             <ul className="space-y-0.5 -mx-2">
-              {w.sessions.map((s) => (
+              {previewSessions.map((s) => (
                 <li key={s.id}>
                   <button
                     type="button"
@@ -152,6 +157,22 @@ export function OverviewCard({
                   </button>
                 </li>
               ))}
+              {hiddenSessionCount > 0 && (
+                <li className="mt-1 border-t border-border/60 pt-1">
+                  <button
+                    type="button"
+                    onClick={onOpen}
+                    aria-label={t('workspace.viewAllSessions', { count: w.sessions.length })}
+                    className="oa-nav-row pointer-events-auto flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[11px] font-medium text-primary hover:bg-primary/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  >
+                    <span>{t('workspace.viewAllSessions', { count: w.sessions.length })}</span>
+                    <span className="ml-auto tabular-nums text-muted-foreground/55">
+                      +{hiddenSessionCount}
+                    </span>
+                    <ChevronRight size={11} className="text-primary/65" aria-hidden />
+                  </button>
+                </li>
+              )}
             </ul>
           )}
         </div>

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1447,6 +1447,7 @@ export const en = {
     activeAgo: 'Active {{time}}',
     sessions: 'Sessions',
     noSessions: 'no sessions yet',
+    viewAllSessions: 'View all {{count}} sessions',
     fromTemplate: 'from {{template}} v{{version}}',
     override: 'Workspace override · {{agents}}',
     templateUpgrade: 'Review managed template changes from v{{from}} → v{{to}}.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1435,6 +1435,7 @@ export const ja: Resources = {
     activeAgo: '{{time}}にアクティブ',
     sessions: 'セッション',
     noSessions: 'セッションはまだありません',
+    viewAllSessions: '{{count}} 件のセッションをすべて表示',
     fromTemplate: '{{template}} v{{version}} から作成',
     override: 'ワークスペース上書き設定 · {{agents}}',
     templateUpgrade: 'v{{from}} → v{{to}} のテンプレート資産変更を確認します。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1442,6 +1442,7 @@ export const zhHant: Resources = {
     activeAgo: '活躍於{{time}}',
     sessions: '工作階段',
     noSessions: '還沒有工作階段',
+    viewAllSessions: '檢視全部 {{count}} 個工作階段',
     fromTemplate: '來自 {{template}} v{{version}}',
     override: '工作區覆寫設定 · {{agents}}',
     templateUpgrade: '檢視 v{{from}} → v{{to}} 的範本資產變更。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1434,6 +1434,7 @@ export const zh: Resources = {
     activeAgo: '活跃于{{time}}',
     sessions: '会话',
     noSessions: '还没有会话',
+    viewAllSessions: '查看全部 {{count}} 个会话',
     fromTemplate: '来自 {{template}} v{{version}}',
     override: '工作区覆盖配置 · {{agents}}',
     templateUpgrade: '查看 v{{from}} → v{{to}} 的模板资产变更。',


### PR DESCRIPTION
## Summary

- keep Workspace overview cards compact by previewing the five most recent sessions
- show the total session count and an explicit “View all” row that opens the full Workspace
- preserve direct drill-in for the visible session previews

## Why

A real Workspace with 25 sessions produced an 865px-tall overview card—taller than the viewport—and stretched neighboring cards into large empty panels. The compact preview reduces that card to 372px while keeping the complete list one click away.

## Verification

- `pnpm vitest run ui/src/components/workspace/OverviewCard.spec.tsx`
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (408 files passed, 1 skipped; 3520 tests passed, 9 skipped)
- real `pnpm dev` browser pass on `/workspaces`
- 390×844 responsive pass with no horizontal overflow
- verified “View all 25 sessions” opens the full Workspace
