### PR TITLE
Confirm connector token removal

### DIFF
--- a/ui/src/pages/Connectors.demo.spec.tsx
+++ b/ui/src/pages/Connectors.demo.spec.tsx
@@ -116,7 +116,7 @@ describe('Connector demo routes', () => {
     expect(input.value).toBe('still-here')
   })
 
-  it('removes a configured secret only from the explicit remove action', async () => {
+  it('requires confirmation before removing a configured secret', async () => {
     const snapshot = createDemoConnectorSnapshot()
     snapshot.config.adapters.discord.configuredSecrets = ['botToken']
     mocks.load.mockResolvedValue(snapshot)
@@ -124,6 +124,20 @@ describe('Connector demo routes', () => {
 
     await screen.findByText('Run external notification connectors')
     fireEvent.click(screen.getByRole('button', { name: 'Remove token' }))
+
+    expect(screen.getByRole('heading', { name: 'Remove Discord token?' })).toBeTruthy()
+    expect(screen.getByText(/OpenAlice cannot recover this token after removal/)).toBeTruthy()
+    await new Promise((resolve) => window.setTimeout(resolve, 800))
+    expect(mocks.save).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByRole('heading', { name: 'Remove Discord token?' })).toBeNull()
+    await new Promise((resolve) => window.setTimeout(resolve, 800))
+    expect(mocks.save).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Remove token' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove token' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Remove token' }).at(-1)!)
 
     await waitFor(() => expect(mocks.save).toHaveBeenCalled(), { timeout: 1_200 })
     const saved = mocks.save.mock.calls.at(-1)?.[0] as PublicConnectorConfig

--- a/ui/src/pages/ConnectorsPage.tsx
+++ b/ui/src/pages/ConnectorsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Bot, CheckCircle2, CircleAlert, Link2, Power, Send, ShieldCheck } from 'lucide-react'
 import { api, type ConnectorDefinition, type ConnectorHealth, type PublicConnectorConfig } from '../api'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 import { PageHeader } from '../components/PageHeader'
 import { SaveIndicator } from '../components/SaveIndicator'
 import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
@@ -13,6 +14,13 @@ import {
 
 const LINK_POLL_MS = 2_500
 
+interface PendingSecretRemoval {
+  connectorId: string
+  connectorLabel: string
+  fieldKey: string
+  fieldLabel: string
+}
+
 export function ConnectorsPage() {
   const [definitions, setDefinitions] = useState<ConnectorDefinition[]>([])
   const [config, setConfig] = useState<PublicConnectorConfig | null>(null)
@@ -21,6 +29,7 @@ export function ConnectorsPage() {
   const [secretDrafts, setSecretDrafts] = useState<Record<string, string>>({})
   const [savingSecret, setSavingSecret] = useState<string | null>(null)
   const [secretErrors, setSecretErrors] = useState<Record<string, string>>({})
+  const [pendingSecretRemoval, setPendingSecretRemoval] = useState<PendingSecretRemoval | null>(null)
   const [testing, setTesting] = useState<string | null>(null)
   const [testError, setTestError] = useState<string | null>(null)
   const [lastProbe, setLastProbe] = useState<{ connectorId: string; probeId: string } | null>(null)
@@ -294,20 +303,11 @@ export function ConnectorsPage() {
                                       type="button"
                                       className="shrink-0 rounded-lg border border-border px-3 py-2 text-[12px] text-muted-foreground hover:text-destructive"
                                       disabled={secretSaving}
-                                      onClick={() => setConfig((current) => {
-                                        if (!current) return current
-                                        const currentAdapter = current.adapters[definition.id]!
-                                        return {
-                                          ...current,
-                                          adapters: {
-                                            ...current.adapters,
-                                            [definition.id]: {
-                                              ...currentAdapter,
-                                              settings: { ...currentAdapter.settings, [field.key]: '' },
-                                              configuredSecrets: currentAdapter.configuredSecrets.filter((key) => key !== field.key),
-                                            },
-                                          },
-                                        }
+                                      onClick={() => setPendingSecretRemoval({
+                                        connectorId: definition.id,
+                                        connectorLabel: definition.label,
+                                        fieldKey: field.key,
+                                        fieldLabel: field.label,
                                       })}
                                     >
                                       Remove token
@@ -370,6 +370,46 @@ export function ConnectorsPage() {
           {loadError && <p className="text-[13px] text-destructive">Failed to load connector settings.</p>}
         </div>
       </SettingsScrollArea>
+
+      {pendingSecretRemoval && (
+        <ConfirmDialog
+          title={`Remove ${pendingSecretRemoval.connectorLabel} token?`}
+          message={(
+            <>
+              OpenAlice will permanently delete the sealed{' '}
+              <strong>{pendingSecretRemoval.fieldLabel}</strong> for{' '}
+              <strong>{pendingSecretRemoval.connectorLabel}</strong>. The connector will stop until
+              you save a replacement. OpenAlice cannot recover this token after removal.
+            </>
+          )}
+          confirmLabel="Remove token"
+          workingLabel="Removing…"
+          onConfirm={() => {
+            setConfig((current) => {
+              if (!current) return current
+              const currentAdapter = current.adapters[pendingSecretRemoval.connectorId] ?? emptyAdapter()
+              return {
+                ...current,
+                adapters: {
+                  ...current.adapters,
+                  [pendingSecretRemoval.connectorId]: {
+                    ...currentAdapter,
+                    settings: {
+                      ...currentAdapter.settings,
+                      [pendingSecretRemoval.fieldKey]: '',
+                    },
+                    configuredSecrets: currentAdapter.configuredSecrets.filter(
+                      (key) => key !== pendingSecretRemoval.fieldKey,
+                    ),
+                  },
+                },
+              }
+            })
+            setPendingSecretRemoval(null)
+          }}
+          onClose={() => setPendingSecretRemoval(null)}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- require an explicit destructive confirmation before removing a sealed Connector token
- identify the affected connector and secret in the dialog
- explain that delivery stops until replacement and that OpenAlice cannot recover the removed token
- preserve the existing save path after confirmation; cancel leaves configuration untouched

## Evidence

The real `/settings/connectors` page exposes configured Discord and Telegram tokens. On current `dev`, one click on `Remove token` immediately mutates `configuredSecrets`; the 700ms auto-save then deletes the sealed value even though the browser cannot retrieve it for recovery.

## Verification

- `pnpm vitest run ui/src/pages/Connectors.demo.spec.tsx` (6 passed)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (408 files passed, 1 skipped; 3519 tests passed, 9 skipped)
- `git diff --check`
- real `pnpm dev` pass on `/settings/connectors`: opened the Discord confirmation and cancelled it; both configured tokens remained present
- 390×844 responsive pass: 358px dialog, no horizontal overflow

The live configured secret was deliberately not removed during verification.
