### PR TITLE
Keep Market watchlist actions visible

### DIFF
--- a/ui/src/components/MarketSidebar.spec.tsx
+++ b/ui/src/components/MarketSidebar.spec.tsx
@@ -103,4 +103,19 @@ describe('MarketSidebar search keyboard controls', () => {
     expect((search as HTMLInputElement).value).toBe('')
     expect(screen.queryByRole('heading', { name: /Search Results/ })).toBeNull()
   })
+
+  it('keeps the watchlist remove action visible and separate from row navigation', () => {
+    useWatchlist.setState({
+      entries: [{ assetClass: 'equity', symbol: 'AAPL', addedAt: 1 }],
+    })
+    render(<MarketSidebar />)
+
+    const remove = screen.getByRole('button', { name: 'Remove AAPL' })
+    expect(remove.className).not.toContain('opacity-0')
+
+    fireEvent.click(remove)
+
+    expect(useWatchlist.getState().entries).toEqual([])
+    expect(getFocusedTab(useWorkspace.getState())).toBeNull()
+  })
 })

--- a/ui/src/components/MarketSidebar.tsx
+++ b/ui/src/components/MarketSidebar.tsx
@@ -219,10 +219,10 @@ export function MarketSidebar() {
                       e.stopPropagation()
                       removeFromWatchlist(entry.assetClass, entry.symbol)
                     }}
-                    className="flex h-4 w-4 items-center justify-center rounded text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground group-hover:opacity-100"
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/70 hover:bg-muted hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:text-destructive"
                     aria-label={t('market.removeFromWatchlist', { symbol: entry.symbol })}
                   >
-                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
                       <path d="M18 6L6 18M6 6l12 12" />
                     </svg>
                   </button>


### PR DESCRIPTION
## Summary

- keep each Market watchlist remove action visible without requiring hover
- enlarge the action from 16×16 to 28×28 for a usable touch and keyboard target
- add explicit focus-visible treatment while preserving row navigation and reversible removal

## Evidence

On the real `/market` route with AAPL pinned, the remove button computed to `opacity: 0` and 16×16 at both desktop and 390px widths. It appeared only through `group-hover`, leaving touch users without a discoverable action and keyboard users able to focus an invisible control.

## Verification

- `pnpm vitest run ui/src/components/MarketSidebar.spec.tsx` (4 passed)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (408 files passed, 1 skipped; 3520 tests passed, 9 skipped)
- `git diff --check`
- real `pnpm dev` pass on `/market` at 1280px and 390×844
- measured after: `opacity: 1`, 28×28, no horizontal overflow

The live AAPL watchlist entry was not removed during browser verification.
