### PR TITLE
Do not report unverified trading reviews as clean

### DIFF
--- a/ui/src/components/PushApprovalPanel.spec.tsx
+++ b/ui/src/components/PushApprovalPanel.spec.tsx
@@ -72,6 +72,83 @@ describe('PushApprovalPanel localization', () => {
     expect(screen.queryByText('Working tree clean')).toBeNull()
   })
 
+  it('never reports a failed account check as a clean review queue', async () => {
+    mocks.walletStatus.mockRejectedValue(new Error('account unavailable'))
+
+    render(<PushApprovalPanel />)
+
+    expect((await screen.findAllByText('已验证 0 / 1 个账户')).length).toBeGreaterThan(1)
+    expect(screen.getAllByText('审批状态尚未验证')).toHaveLength(2)
+    expect(screen.getByText('无法验证：模拟账户')).toBeTruthy()
+    expect(screen.getByRole('button', { name: '重试' })).toBeTruthy()
+    expect(screen.queryByText('工作树干净')).toBeNull()
+    expect(screen.queryByText('没有等待审批的券商写入。')).toBeNull()
+  })
+
+  it('shows partial account verification instead of a global clean state', async () => {
+    const secondAccount = { ...paperAccount, id: 'paper-account-2', label: '第二个模拟账户' }
+    mocks.listUTASummaries.mockResolvedValue({ utas: [paperAccount, secondAccount] })
+    mocks.walletStatus.mockImplementation(async (accountId: string) => {
+      if (accountId === secondAccount.id) throw new Error('account unavailable')
+      return {
+        staged: [],
+        pendingMessage: null,
+        head: 'abc123456789',
+        commitCount: 0,
+      }
+    })
+
+    render(<PushApprovalPanel />)
+
+    expect((await screen.findAllByText('已验证 1 / 2 个账户')).length).toBeGreaterThan(1)
+    expect(screen.getByText('无法验证：第二个模拟账户')).toBeTruthy()
+    expect(screen.queryByText('工作树干净')).toBeNull()
+  })
+
+  it('offers recovery when the trading account list cannot be verified', async () => {
+    mocks.listUTASummaries.mockRejectedValueOnce(new Error('UTA list unavailable'))
+
+    render(<PushApprovalPanel />)
+
+    expect((await screen.findAllByText('审批状态尚未验证')).length).toBeGreaterThan(1)
+    expect(screen.queryByText('没有交易账户')).toBeNull()
+    expect(screen.queryByText('工作树干净')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: '重试' }))
+
+    expect((await screen.findAllByText('工作树干净')).length).toBeGreaterThan(1)
+    expect(screen.queryByText('审批状态尚未验证')).toBeNull()
+  })
+
+  it('keeps last-known review items visible during a transient account failure', async () => {
+    mocks.walletStatus
+      .mockResolvedValueOnce({
+        staged: [{
+          action: 'placeOrder',
+          contract: { symbol: 'AAPL' },
+          order: {
+            action: 'BUY',
+            orderType: 'LMT',
+            totalQuantity: '2',
+            lmtPrice: '210',
+          },
+        }],
+        pendingMessage: '调整 AAPL 仓位',
+        head: 'abc123456789',
+        commitCount: 1,
+      })
+      .mockRejectedValue(new Error('account unavailable'))
+
+    render(<PushApprovalPanel />)
+
+    expect(await screen.findByText('调整 AAPL 仓位')).toBeTruthy()
+    await new Promise((resolve) => window.setTimeout(resolve, 3_200))
+
+    expect((await screen.findAllByText('已验证 0 / 1 个账户')).length).toBeGreaterThan(1)
+    expect(screen.getAllByText('调整 AAPL 仓位').length).toBeGreaterThan(0)
+    expect(screen.queryByText('工作树干净')).toBeNull()
+  })
+
   it('localizes a pending order review and its confirmation step', async () => {
     mocks.walletStatus.mockResolvedValue({
       staged: [{

--- a/ui/src/components/PushApprovalPanel.tsx
+++ b/ui/src/components/PushApprovalPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import type { TFunction } from 'i18next'
-import { AlertTriangle, CheckCircle2, Clock3, GitCommitHorizontal, GitPullRequest, History, XCircle } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, Clock3, GitCommitHorizontal, GitPullRequest, History, RefreshCw, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { EmptyState, Skeleton } from './StateViews'
 import { formatRelativeTime, getIntlLocale } from '../lib/intl'
@@ -27,6 +27,13 @@ interface AccountHistory {
   accountId: string
   label: string
   commits: WalletCommitLog[]
+}
+
+interface ReviewVerification {
+  total: number
+  verified: number
+  failed: AccountRef[]
+  listUnavailable: boolean
 }
 
 interface FlatCommit {
@@ -236,6 +243,23 @@ function itemOperations(item: ReviewItem, t: TFunction): OperationDisplay[] {
   return item.status.staged.map((operation) => operationDisplay(operation, t))
 }
 
+function mergeAccountResults<T>(
+  accounts: AccountRef[],
+  verifiedAccountIds: Set<string>,
+  fresh: T[],
+  previous: T[],
+  accountId: (item: T) => string,
+): T[] {
+  const freshByAccount = new Map(fresh.map((item) => [accountId(item), item]))
+  const previousByAccount = new Map(previous.map((item) => [accountId(item), item]))
+  return accounts.flatMap((account) => {
+    const item = verifiedAccountIds.has(account.id)
+      ? freshByAccount.get(account.id)
+      : previousByAccount.get(account.id)
+    return item ? [item] : []
+  })
+}
+
 // ==================== Component ====================
 
 export function PushApprovalPanel() {
@@ -252,6 +276,13 @@ export function PushApprovalPanel() {
   const [error, setError] = useState<string | null>(null)
   const [loaded, setLoaded] = useState(false)
   const [historyFilter, setHistoryFilter] = useState<string | null>(null)
+  const [retryingVerification, setRetryingVerification] = useState(false)
+  const [verification, setVerification] = useState<ReviewVerification>({
+    total: 0,
+    verified: 0,
+    failed: [],
+    listUnavailable: false,
+  })
 
   const poll = useCallback(async () => {
     try {
@@ -262,6 +293,8 @@ export function PushApprovalPanel() {
       const stagedResults: StagedAccount[] = []
       const pendingResults: PendingAccount[] = []
       const historyResults: AccountHistory[] = []
+      const verifiedAccountIds = new Set<string>()
+      const failedAccounts: AccountRef[] = []
 
       for (const account of accts) {
         try {
@@ -277,16 +310,46 @@ export function PushApprovalPanel() {
           if (commits.length > 0) {
             historyResults.push({ accountId: account.id, label: accountLabel(account), commits })
           }
+          verifiedAccountIds.add(account.id)
         } catch {
-          /* skip unreachable account */
+          failedAccounts.push(account)
         }
       }
 
-      setStaged(stagedResults)
-      setPending(pendingResults)
-      setHistory(historyResults)
+      setStaged((previous) => mergeAccountResults(
+        accts,
+        verifiedAccountIds,
+        stagedResults,
+        previous,
+        (item) => item.account.id,
+      ))
+      setPending((previous) => mergeAccountResults(
+        accts,
+        verifiedAccountIds,
+        pendingResults,
+        previous,
+        (item) => item.account.id,
+      ))
+      setHistory((previous) => mergeAccountResults(
+        accts,
+        verifiedAccountIds,
+        historyResults,
+        previous,
+        (item) => item.accountId,
+      ))
+      setVerification({
+        total: accts.length,
+        verified: verifiedAccountIds.size,
+        failed: failedAccounts,
+        listUnavailable: false,
+      })
     } catch {
-      /* ignore list failures here; global API surfaces already show errors */
+      setVerification((current) => ({
+        ...current,
+        verified: 0,
+        failed: [],
+        listUnavailable: true,
+      }))
     } finally {
       setLoaded(true)
     }
@@ -296,6 +359,15 @@ export function PushApprovalPanel() {
     poll()
     const id = setInterval(poll, 3000)
     return () => clearInterval(id)
+  }, [poll])
+
+  const retryVerification = useCallback(async () => {
+    setRetryingVerification(true)
+    try {
+      await poll()
+    } finally {
+      setRetryingVerification(false)
+    }
   }, [poll])
 
   const handlePush = useCallback(async (accountId: string) => {
@@ -388,8 +460,16 @@ export function PushApprovalPanel() {
   const waitingCount = pending.length
   const stagedCount = staged.length
   const historyCount = mergedHistory.length
+  const verificationIncomplete = verification.listUnavailable || verification.failed.length > 0
   const statusLabel =
-    waitingCount > 0
+    verificationIncomplete
+      ? verification.listUnavailable
+        ? t('tradingReview.queue.verificationUnknown')
+        : t('tradingReview.queue.verificationCount', {
+          verified: verification.verified,
+          total: verification.total,
+        })
+      : waitingCount > 0
       ? t('tradingReview.queue.waitingApproval', { count: waitingCount })
       : stagedCount > 0
         ? t('tradingReview.queue.stagedWaiting', { count: stagedCount })
@@ -397,7 +477,7 @@ export function PushApprovalPanel() {
 
   if (!loaded) return <TradingReviewSkeleton />
 
-  if (accounts.length === 0) {
+  if (accounts.length === 0 && !verification.listUnavailable) {
     return (
       <div className="h-full rounded-lg border border-border bg-secondary/30">
         <EmptyState
@@ -409,93 +489,152 @@ export function PushApprovalPanel() {
   }
 
   return (
-    <div className="grid h-full min-h-0 min-w-0 overflow-hidden rounded-lg border border-border bg-secondary/30 md:grid-cols-[250px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)]">
-      <div className="flex min-h-0 min-w-0 flex-col border-b border-border bg-secondary md:border-b-0 md:border-r">
-        <div className="shrink-0 border-b border-border/70 px-4 py-3">
-          <div className="flex items-center gap-2 text-[12px] font-medium text-foreground">
-            {waitingCount > 0 ? (
-              <AlertTriangle size={15} className="text-warning" aria-hidden />
-            ) : (
-              <CheckCircle2 size={15} className="text-success" aria-hidden />
-            )}
-            <span className="truncate">{statusLabel}</span>
-          </div>
-          <div className="mt-3 grid grid-cols-3 gap-1.5 text-center">
-            <QueueStat label={t('tradingReview.queue.needs')} value={waitingCount} tone={waitingCount > 0 ? 'warn' : 'muted'} />
-            <QueueStat label={t('tradingReview.queue.staged')} value={stagedCount} tone={stagedCount > 0 ? 'warn' : 'muted'} />
-            <QueueStat label={t('tradingReview.queue.pushed')} value={historyCount} tone="muted" />
-          </div>
-        </div>
-
-        {historyAccounts.length > 1 && (
-          <div className="shrink-0 border-b border-border/60 px-4 py-2">
-            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
-              {t('tradingReview.queue.accountFilter')}
+    <div className="flex h-full min-h-0 min-w-0 flex-col gap-3">
+      {verificationIncomplete && (
+        <VerificationNotice
+          verification={verification}
+          retrying={retryingVerification}
+          onRetry={() => void retryVerification()}
+        />
+      )}
+      <div className="grid min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border border-border bg-secondary/30 md:grid-cols-[250px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)]">
+        <div className="flex min-h-0 min-w-0 flex-col border-b border-border bg-secondary md:border-b-0 md:border-r">
+          <div className="shrink-0 border-b border-border/70 px-4 py-3">
+            <div className="flex items-center gap-2 text-[12px] font-medium text-foreground">
+              {verificationIncomplete || waitingCount > 0 ? (
+                <AlertTriangle size={15} className="text-warning" aria-hidden />
+              ) : (
+                <CheckCircle2 size={15} className="text-success" aria-hidden />
+              )}
+              <span className="truncate">{statusLabel}</span>
             </div>
-            <div className="flex flex-wrap gap-1">
-              <button
-                type="button"
-                onClick={() => setHistoryFilter(null)}
-                className={`rounded-full border px-2 py-0.5 text-[10px] transition-colors ${
-                  effectiveFilter === null
-                    ? 'border-border bg-muted text-foreground'
-                    : 'border-border/50 text-muted-foreground hover:border-border hover:text-foreground'
-                }`}
-              >
-                {t('tradingReview.queue.all')}
-              </button>
-              {historyAccounts.map((account) => (
+            <div className="mt-3 grid grid-cols-3 gap-1.5 text-center">
+              <QueueStat label={t('tradingReview.queue.needs')} value={waitingCount} tone={waitingCount > 0 ? 'warn' : 'muted'} />
+              <QueueStat label={t('tradingReview.queue.staged')} value={stagedCount} tone={stagedCount > 0 ? 'warn' : 'muted'} />
+              <QueueStat label={t('tradingReview.queue.pushed')} value={historyCount} tone="muted" />
+            </div>
+          </div>
+
+          {historyAccounts.length > 1 && (
+            <div className="shrink-0 border-b border-border/60 px-4 py-2">
+              <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                {t('tradingReview.queue.accountFilter')}
+              </div>
+              <div className="flex flex-wrap gap-1">
                 <button
-                  key={account.id}
                   type="button"
-                  onClick={() => setHistoryFilter(account.id)}
-                  title={account.label}
-                  className={`max-w-[120px] truncate rounded-full border px-2 py-0.5 text-[10px] transition-colors ${
-                    effectiveFilter === account.id
+                  onClick={() => setHistoryFilter(null)}
+                  className={`rounded-full border px-2 py-0.5 text-[10px] transition-colors ${
+                    effectiveFilter === null
                       ? 'border-border bg-muted text-foreground'
                       : 'border-border/50 text-muted-foreground hover:border-border hover:text-foreground'
                   }`}
                 >
-                  {account.label}
+                  {t('tradingReview.queue.all')}
                 </button>
-              ))}
+                {historyAccounts.map((account) => (
+                  <button
+                    key={account.id}
+                    type="button"
+                    onClick={() => setHistoryFilter(account.id)}
+                    title={account.label}
+                    className={`max-w-[120px] truncate rounded-full border px-2 py-0.5 text-[10px] transition-colors ${
+                      effectiveFilter === account.id
+                        ? 'border-border bg-muted text-foreground'
+                        : 'border-border/50 text-muted-foreground hover:border-border hover:text-foreground'
+                    }`}
+                  >
+                    {account.label}
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
-        )}
-
-        <div className="min-h-0 flex-1 overflow-y-auto p-2">
-          {reviewItems.length > 0 ? (
-            <div className="space-y-1">
-              {reviewItems.map((item) => (
-                <QueueRow
-                  key={item.id}
-                  item={item}
-                  active={item.id === selectedId}
-                  onClick={() => setSelectedId(item.id)}
-                />
-              ))}
-            </div>
-          ) : (
-            <CleanQueue />
           )}
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+            {reviewItems.length > 0 ? (
+              <div className="space-y-1">
+                {reviewItems.map((item) => (
+                  <QueueRow
+                    key={item.id}
+                    item={item}
+                    active={item.id === selectedId}
+                    onClick={() => setSelectedId(item.id)}
+                  />
+                ))}
+              </div>
+            ) : verificationIncomplete ? (
+              <UnverifiedQueue />
+            ) : (
+              <CleanQueue />
+            )}
+          </div>
+        </div>
+
+        <div className="min-h-0 min-w-0 overflow-y-auto">
+          <ReviewDetail
+            item={selected}
+            verificationIncomplete={verificationIncomplete}
+            lastResult={lastResult}
+            error={error}
+            confirmingPush={confirmingPush}
+            pushing={pushing}
+            rejecting={rejecting}
+            onConfirmPush={setConfirmingPush}
+            onPush={handlePush}
+            onReject={handleReject}
+            onDismissError={() => setError(null)}
+            onDismissResult={() => setLastResult(null)}
+          />
         </div>
       </div>
+    </div>
+  )
+}
 
-      <div className="min-h-0 min-w-0 overflow-y-auto">
-        <ReviewDetail
-          item={selected}
-          lastResult={lastResult}
-          error={error}
-          confirmingPush={confirmingPush}
-          pushing={pushing}
-          rejecting={rejecting}
-          onConfirmPush={setConfirmingPush}
-          onPush={handlePush}
-          onReject={handleReject}
-          onDismissError={() => setError(null)}
-          onDismissResult={() => setLastResult(null)}
-        />
+function VerificationNotice({
+  verification,
+  retrying,
+  onRetry,
+}: {
+  verification: ReviewVerification
+  retrying: boolean
+  onRetry: () => void
+}) {
+  const { t } = useTranslation()
+  const failedAccounts = verification.failed.map(accountLabel).join(', ')
+  return (
+    <div className="flex shrink-0 flex-wrap items-start gap-3 rounded-lg border border-warning/30 bg-warning/5 px-4 py-3 text-warning" role="status">
+      <AlertTriangle size={17} className="mt-0.5 shrink-0" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <div className="text-[13px] font-semibold text-foreground">
+          {verification.listUnavailable
+            ? t('tradingReview.queue.verificationUnknown')
+            : t('tradingReview.queue.verificationCount', {
+              verified: verification.verified,
+              total: verification.total,
+            })}
+        </div>
+        <p className="mt-0.5 text-[12px] leading-relaxed text-muted-foreground">
+          {verification.listUnavailable
+            ? t('tradingReview.queue.listUnavailableDescription')
+            : t('tradingReview.queue.verificationDescription')}
+        </p>
+        {failedAccounts && (
+          <p className="mt-1 text-[11px] text-warning">
+            {t('tradingReview.queue.failedAccounts', { accounts: failedAccounts })}
+          </p>
+        )}
       </div>
+      <button
+        type="button"
+        disabled={retrying}
+        onClick={onRetry}
+        className="oa-pressable inline-flex min-h-8 shrink-0 items-center gap-1.5 rounded-md border border-warning/35 bg-background px-2.5 py-1.5 text-[12px] font-medium text-foreground hover:bg-warning/10 disabled:cursor-wait disabled:opacity-60"
+      >
+        <RefreshCw size={13} className={retrying ? 'animate-spin' : undefined} aria-hidden />
+        {retrying ? t('tradingReview.queue.retrying') : t('tradingReview.queue.retry')}
+      </button>
     </div>
   )
 }
@@ -582,8 +721,22 @@ function CleanQueue() {
   )
 }
 
+function UnverifiedQueue() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex h-full min-h-[220px] flex-col items-center justify-center px-4 text-center">
+      <AlertTriangle size={26} className="text-warning/80" aria-hidden />
+      <div className="mt-3 text-[13px] font-medium text-foreground">{t('tradingReview.queue.verificationUnknown')}</div>
+      <div className="mt-1 max-w-[210px] text-[12px] leading-relaxed text-muted-foreground/70">
+        {t('tradingReview.queue.verificationDescription')}
+      </div>
+    </div>
+  )
+}
+
 function ReviewDetail({
   item,
+  verificationIncomplete,
   lastResult,
   error,
   confirmingPush,
@@ -596,6 +749,7 @@ function ReviewDetail({
   onDismissResult,
 }: {
   item: ReviewItem | null
+  verificationIncomplete: boolean
   lastResult: { accountId: string; data: WalletPushResult } | null
   error: string | null
   confirmingPush: string | null
@@ -612,9 +766,15 @@ function ReviewDetail({
     return (
       <div className="flex min-h-full items-center justify-center p-6">
         <EmptyState
-          icon={<CheckCircle2 size={24} aria-hidden />}
-          title={t('tradingReview.queue.clean')}
-          description={t('tradingReview.queue.cleanDetailDescription')}
+          icon={verificationIncomplete
+            ? <AlertTriangle size={24} className="text-warning" aria-hidden />
+            : <CheckCircle2 size={24} aria-hidden />}
+          title={t(verificationIncomplete
+            ? 'tradingReview.queue.verificationUnknown'
+            : 'tradingReview.queue.clean')}
+          description={t(verificationIncomplete
+            ? 'tradingReview.queue.verificationDescription'
+            : 'tradingReview.queue.cleanDetailDescription')}
         />
       </div>
     )

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1166,6 +1166,13 @@ export const en = {
       operationCount_other: '{{count}} ops',
       cleanDescription: 'No broker writes are waiting for approval.',
       cleanDetailDescription: 'No broker writes are waiting for approval. Recent pushed commits will appear here.',
+      verificationUnknown: 'Approval status not verified',
+      verificationCount: '{{verified}} / {{total}} accounts verified',
+      verificationDescription: 'Some accounts could not be checked. Last known review items remain visible; retry before treating the queue as clean.',
+      listUnavailableDescription: 'Trading accounts could not be loaded. The last known review state remains visible.',
+      failedAccounts: 'Could not verify: {{accounts}}',
+      retry: 'Retry',
+      retrying: 'Retrying…',
     },
     status: {
       needsApproval: 'Needs approval',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1155,6 +1155,13 @@ export const ja: Resources = {
       operationCount_other: '{{count}} 件の操作',
       cleanDescription: '承認待ちのブローカー書き込みはありません。',
       cleanDetailDescription: '承認待ちのブローカー書き込みはありません。最近プッシュしたコミットはここに表示されます。',
+      verificationUnknown: '承認状態を確認できません',
+      verificationCount: '{{verified}} / {{total}} 口座を確認済み',
+      verificationDescription: '一部の口座を確認できませんでした。最後に確認できた項目は保持されています。キューがクリーンと判断する前に再試行してください。',
+      listUnavailableDescription: '取引口座を読み込めませんでした。最後に確認できた審査状態は保持されています。',
+      failedAccounts: '確認できない口座: {{accounts}}',
+      retry: '再試行',
+      retrying: '再試行中…',
     },
     status: {
       needsApproval: '承認が必要',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1162,6 +1162,13 @@ export const zhHant: Resources = {
       operationCount_other: '{{count}} 項操作',
       cleanDescription: '沒有等待審批的券商寫入。',
       cleanDetailDescription: '沒有等待審批的券商寫入。最近推送的提交會顯示在這裡。',
+      verificationUnknown: '審批狀態尚未驗證',
+      verificationCount: '已驗證 {{verified}} / {{total}} 個帳戶',
+      verificationDescription: '部分帳戶無法檢查。最近一次已知的審閱項目仍會保留；請重試後再判斷佇列是否乾淨。',
+      listUnavailableDescription: '無法載入交易帳戶。最近一次已知的審閱狀態仍會保留。',
+      failedAccounts: '無法驗證：{{accounts}}',
+      retry: '重試',
+      retrying: '正在重試…',
     },
     status: {
       needsApproval: '需要審批',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1154,6 +1154,13 @@ export const zh: Resources = {
       operationCount_other: '{{count}} 项操作',
       cleanDescription: '没有等待审批的券商写入。',
       cleanDetailDescription: '没有等待审批的券商写入。最近推送的提交会显示在这里。',
+      verificationUnknown: '审批状态尚未验证',
+      verificationCount: '已验证 {{verified}} / {{total}} 个账户',
+      verificationDescription: '部分账户无法检查。最近一次已知的审阅项目仍会保留；请重试后再判断队列是否干净。',
+      listUnavailableDescription: '无法加载交易账户。最近一次已知的审阅状态仍会保留。',
+      failedAccounts: '无法验证：{{accounts}}',
+      retry: '重试',
+      retrying: '正在重试…',
     },
     status: {
       needsApproval: '需要审批',


### PR DESCRIPTION
## Summary

- distinguish verified-clean Trading as Git queues from account/list reads that could not be verified
- show verified-account coverage, failed account names, and an explicit Retry action
- retain last-known staged, pending, and history rows for accounts that fail a later poll
- keep healthy and no-account states unchanged
- localize the new state in English, Simplified Chinese, Traditional Chinese, and Japanese

## Evidence

`PushApprovalPanel` previously swallowed both the UTA-list error and every per-account `wallet/status` or `wallet/log` error. It then set `loaded` and rendered `Working tree clean` from empty arrays. An unreachable account could therefore have pending broker writes while the review UI asserted that no writes were waiting.

## Verification

- `pnpm vitest run ui/src/components/PushApprovalPanel.spec.tsx` (6 passed)
- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (408 files passed, 1 skipped; 3523 tests passed, 9 skipped)
- `git diff --check`
- real `pnpm dev` pass on `/trading-as-git`: verified healthy baseline still shows clean with 4 accounts and 40 history rows
- 390×844 responsive pass: main `scrollWidth === clientWidth === 390`

The regression coverage includes total account-list failure and recovery, partial account verification, and preservation of a last-known pending review across a transient poll failure. No broker writes, live-paper trades, Electron/IPC paths, or UTA state-machine code were exercised or changed.
