### PR TITLE
Make mobile Workspace Files toggle functional

### DIFF
--- a/ui/src/components/workspace/WorkspaceFilesToggle.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceFilesToggle.spec.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../../i18n'
+import { useWorkspaceSidePanels } from '../../live/workspace-side-panels'
+import { WorkspaceFilesToggle } from './WorkspaceFilesToggle'
+
+const toggleMocks = vi.hoisted(() => ({ isDesktop: true }))
+
+vi.mock('../../live/use-is-desktop', () => ({
+  useIsDesktop: () => toggleMocks.isDesktop,
+}))
+
+beforeEach(async () => {
+  localStorage.clear()
+  toggleMocks.isDesktop = true
+  useWorkspaceSidePanels.setState({
+    files: false,
+    autoHideMobile: true,
+    mobileFilesOpen: false,
+  })
+  await i18n.changeLanguage('en')
+})
+
+afterEach(cleanup)
+
+describe('WorkspaceFilesToggle', () => {
+  it('opens and closes Files on mobile without changing the desktop preference', () => {
+    toggleMocks.isDesktop = false
+    render(<WorkspaceFilesToggle />)
+
+    const button = screen.getByRole('button', { name: 'Files' })
+    expect(button.getAttribute('aria-pressed')).toBe('false')
+
+    fireEvent.click(button)
+
+    expect(button.getAttribute('aria-pressed')).toBe('true')
+    expect(useWorkspaceSidePanels.getState()).toMatchObject({
+      files: false,
+      mobileFilesOpen: true,
+    })
+
+    fireEvent.click(button)
+
+    expect(button.getAttribute('aria-pressed')).toBe('false')
+    expect(useWorkspaceSidePanels.getState()).toMatchObject({
+      files: false,
+      mobileFilesOpen: false,
+    })
+  })
+
+  it('continues to toggle the persisted preference on desktop', () => {
+    render(<WorkspaceFilesToggle />)
+
+    const button = screen.getByRole('button', { name: 'Files' })
+    fireEvent.click(button)
+
+    expect(button.getAttribute('aria-pressed')).toBe('true')
+    expect(useWorkspaceSidePanels.getState()).toMatchObject({
+      files: true,
+      mobileFilesOpen: false,
+    })
+  })
+})

--- a/ui/src/components/workspace/WorkspaceFilesToggle.tsx
+++ b/ui/src/components/workspace/WorkspaceFilesToggle.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 import { PanelRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { useIsDesktop } from '../../live/use-is-desktop'
 import { useWorkspaceSidePanels } from '../../live/workspace-side-panels'
 
 /**
@@ -10,21 +11,26 @@ import { useWorkspaceSidePanels } from '../../live/workspace-side-panels'
  * leaving a narrow always-on column. Lives next to "Settings" in
  * WorkspacePage's header; replaces the old Layout popover.
  *
- * State is user-level + persisted (fold it once, it stays folded) — see
- * `useWorkspaceSidePanels`.
+ * Desktop state is user-level + persisted (fold it once, it stays folded).
+ * Auto-hidden mobile layouts use an explicit, transient overlay state so the
+ * control never claims a hidden panel is open and never changes the user's
+ * desktop preference.
  */
 export function WorkspaceFilesToggle(): ReactElement {
   const { t } = useTranslation()
-  const files = useWorkspaceSidePanels((s) => s.files)
-  const toggleFiles = useWorkspaceSidePanels((s) => s.toggleFiles)
+  const isDesktop = useIsDesktop()
+  const { files, autoHideMobile, mobileFilesOpen, toggleFiles, toggleMobileFiles } =
+    useWorkspaceSidePanels()
+  const usesMobileOverlay = !isDesktop && autoHideMobile
+  const filesVisible = usesMobileOverlay ? mobileFilesOpen : files
   return (
     <button
       type="button"
-      onClick={toggleFiles}
-      aria-pressed={files}
-      title={files ? t('workspace.hideFilesTitle') : t('workspace.showFilesTitle')}
+      onClick={usesMobileOverlay ? toggleMobileFiles : toggleFiles}
+      aria-pressed={filesVisible}
+      title={filesVisible ? t('workspace.hideFilesTitle') : t('workspace.showFilesTitle')}
       className={`workspace-files-toggle flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] transition-colors ${
-        files
+        filesVisible
           ? 'text-foreground bg-muted'
           : 'text-muted-foreground hover:text-foreground hover:bg-muted'
       }`}

--- a/ui/src/components/workspace/WorkspaceView.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceView.spec.tsx
@@ -7,11 +7,20 @@ import { i18n } from '../../i18n'
 import type { SessionRecord } from './api'
 import { WorkspaceView } from './WorkspaceView'
 
-vi.mock('../../live/use-is-desktop', () => ({ useIsDesktop: () => true }))
-vi.mock('../../live/workspace-side-panels', () => ({
-  useWorkspaceSidePanels: () => ({ files: false, autoHideMobile: true }),
+const viewMocks = vi.hoisted(() => ({
+  isDesktop: true,
+  sidePrefs: {
+    files: false,
+    autoHideMobile: true,
+    mobileFilesOpen: false,
+  },
 }))
-vi.mock('./FilesPanel', () => ({ FilesPanel: () => null }))
+
+vi.mock('../../live/use-is-desktop', () => ({ useIsDesktop: () => viewMocks.isDesktop }))
+vi.mock('../../live/workspace-side-panels', () => ({
+  useWorkspaceSidePanels: () => viewMocks.sidePrefs,
+}))
+vi.mock('./FilesPanel', () => ({ FilesPanel: () => <div data-testid="files-panel" /> }))
 vi.mock('./Terminal', () => ({ TerminalView: () => null }))
 vi.mock('./WebPiView', () => ({ WebPiView: () => null }))
 
@@ -33,6 +42,10 @@ function session(index: number, state: SessionRecord['state']): SessionRecord {
 }
 
 beforeEach(async () => {
+  viewMocks.isDesktop = true
+  viewMocks.sidePrefs.files = false
+  viewMocks.sidePrefs.autoHideMobile = true
+  viewMocks.sidePrefs.mobileFilesOpen = false
   await i18n.changeLanguage('en')
 })
 
@@ -88,5 +101,58 @@ describe('WorkspaceView Session library', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Start a new session' }))
     expect(onSpawnFresh).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('WorkspaceView Files panel', () => {
+  const renderWorkspace = () => render(
+    <WorkspaceView
+      wsId="chat-1"
+      sessionId={null}
+      activeRecord={null}
+      sessions={[]}
+      onSpawnFresh={vi.fn()}
+      onResume={vi.fn()}
+      onOpenWebPi={vi.fn()}
+      onSelectSession={vi.fn()}
+      onSessionLost={vi.fn()}
+    />,
+  )
+
+  it('uses the transient mobile state instead of the persisted desktop preference', () => {
+    viewMocks.isDesktop = false
+    viewMocks.sidePrefs.files = true
+
+    const { container, rerender } = renderWorkspace()
+
+    expect(screen.queryByTestId('files-panel')).toBeNull()
+    expect(container.querySelector('.workspace-view')?.classList.contains('has-no-side')).toBe(true)
+
+    viewMocks.sidePrefs.mobileFilesOpen = true
+    rerender(
+      <WorkspaceView
+        wsId="chat-1"
+        sessionId={null}
+        activeRecord={null}
+        sessions={[]}
+        onSpawnFresh={vi.fn()}
+        onResume={vi.fn()}
+        onOpenWebPi={vi.fn()}
+        onSelectSession={vi.fn()}
+        onSessionLost={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('files-panel')).toBeTruthy()
+    expect(container.querySelector('.workspace-view')?.classList.contains('has-no-side')).toBe(false)
+  })
+
+  it('continues to follow the persisted Files preference on desktop', () => {
+    viewMocks.sidePrefs.files = true
+
+    const { container } = renderWorkspace()
+
+    expect(screen.getByTestId('files-panel')).toBeTruthy()
+    expect(container.querySelector('.workspace-view')?.classList.contains('has-no-side')).toBe(false)
   })
 })

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -71,12 +71,14 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
     props.activeRecord.state === 'paused';
   const showEmptyCta = props.sessionId === null;
 
-  // Files panel visibility. User-level pref; mobile gets a separate
-  // kill-switch so the 360px right column doesn't eat half a phone screen.
+  // Files panel visibility. Desktop follows the persisted user preference;
+  // auto-hidden mobile layouts get an explicit transient overlay state. This
+  // keeps the first phone view clear without turning the Files button into a
+  // dead control or silently changing the user's desktop layout.
   const isDesktop = useIsDesktop();
   const sidePrefs = useWorkspaceSidePanels();
-  const mobileSuppresses = !isDesktop && sidePrefs.autoHideMobile;
-  const showFiles = sidePrefs.files && !mobileSuppresses;
+  const usesMobileOverlay = !isDesktop && sidePrefs.autoHideMobile;
+  const showFiles = usesMobileOverlay ? sidePrefs.mobileFilesOpen : sidePrefs.files;
   const showAside = showFiles;
   const viewClass = `workspace-view${showAside ? '' : ' has-no-side'}`;
 

--- a/ui/src/live/workspace-side-panels.spec.ts
+++ b/ui/src/live/workspace-side-panels.spec.ts
@@ -8,10 +8,11 @@ beforeEach(() => {
 })
 
 describe('Workspace Files panel preference', () => {
-  it('starts collapsed for a new user and persists an explicit opt-in', async () => {
+  it('starts collapsed for a new user and persists an explicit desktop opt-in', async () => {
     const { useWorkspaceSidePanels } = await import('./workspace-side-panels')
 
     expect(useWorkspaceSidePanels.getState().files).toBe(false)
+    expect(useWorkspaceSidePanels.getState().mobileFilesOpen).toBe(false)
     expect(localStorage.getItem('openalice.workspace.side-panels.v1')).toBeNull()
 
     useWorkspaceSidePanels.getState().setFiles(true)
@@ -26,5 +27,25 @@ describe('Workspace Files panel preference', () => {
       },
       version: 3,
     })
+  })
+
+  it('keeps the explicit mobile overlay state out of persisted preferences', async () => {
+    const { useWorkspaceSidePanels } = await import('./workspace-side-panels')
+
+    useWorkspaceSidePanels.getState().toggleMobileFiles()
+
+    expect(useWorkspaceSidePanels.getState().mobileFilesOpen).toBe(true)
+    expect(JSON.parse(
+      localStorage.getItem('openalice.workspace.side-panels.v1') ?? '{}',
+    )).toMatchObject({
+      state: {
+        files: false,
+        autoHideMobile: true,
+      },
+      version: 3,
+    })
+    expect(JSON.parse(
+      localStorage.getItem('openalice.workspace.side-panels.v1') ?? '{}',
+    ).state).not.toHaveProperty('mobileFilesOpen')
   })
 })

--- a/ui/src/live/workspace-side-panels.ts
+++ b/ui/src/live/workspace-side-panels.ts
@@ -17,9 +17,10 @@ reloadOnHotUpdate('live/workspace-side-panels')
  * better resting state. Users who do want it flip the Files button once
  * and the preference sticks.
  *
- * `autoHideMobile` hides the panel at sub-md viewports regardless. Default
- * true: on a phone, the right column eating 360px is worse than not seeing
- * files at all.
+ * `autoHideMobile` gives sub-md viewports their own transient Files state.
+ * Default true: a desktop preference must not make a 360px panel appear when
+ * a phone first opens a Workspace. Mobile users can still open Files
+ * explicitly; that choice is intentionally reset on reload.
  *
  * (The Git panel was removed — nobody reads workspace git by hand anymore,
  * the agent does. So this is Files-only now.)
@@ -28,12 +29,15 @@ reloadOnHotUpdate('live/workspace-side-panels')
 interface WorkspaceSidePanelsState {
   files: boolean
   autoHideMobile: boolean
+  mobileFilesOpen: boolean
 }
 
 interface WorkspaceSidePanelsActions {
   setFiles: (enabled: boolean) => void
   toggleFiles: () => void
   setAutoHideMobile: (enabled: boolean) => void
+  setMobileFilesOpen: (enabled: boolean) => void
+  toggleMobileFiles: () => void
 }
 
 export const useWorkspaceSidePanels = create<WorkspaceSidePanelsState & WorkspaceSidePanelsActions>()(
@@ -41,13 +45,20 @@ export const useWorkspaceSidePanels = create<WorkspaceSidePanelsState & Workspac
     (set) => ({
       files: false,
       autoHideMobile: true,
+      mobileFilesOpen: false,
       setFiles: (enabled) => set({ files: enabled }),
       toggleFiles: () => set((s) => ({ files: !s.files })),
       setAutoHideMobile: (enabled) => set({ autoHideMobile: enabled }),
+      setMobileFilesOpen: (enabled) => set({ mobileFilesOpen: enabled }),
+      toggleMobileFiles: () => set((s) => ({ mobileFilesOpen: !s.mobileFilesOpen })),
     }),
     // version bumped 2 → 3 to reset the old `files: true` default for
     // existing users (no migrate → persisted state is discarded, falling
     // back to the new collapsed default).
-    { name: 'openalice.workspace.side-panels.v1', version: 3 },
+    {
+      name: 'openalice.workspace.side-panels.v1',
+      version: 3,
+      partialize: ({ files, autoHideMobile }) => ({ files, autoHideMobile }),
+    },
   ),
 )


### PR DESCRIPTION
## Problem

At sub-768px widths, the Workspace Files button reflected the persisted desktop preference even though `WorkspaceView` unconditionally suppressed the panel. A user could therefore see a pressed button titled “Hide the files panel” while no Files panel existed, and pressing it only changed the future desktop layout.

## Change

- give auto-hidden mobile layouts a transient Files overlay state
- keep the persisted desktop Files preference independent
- derive the button pressed state and panel visibility from the same responsive state
- exclude the transient mobile state from persisted preferences
- cover the store, toggle, Workspace view, and 767/768 responsive boundary behavior

This follows the Warm Editorial Workstation rule that controls must expose their real state and that mobile layouts should be reorganized rather than silently disabling desktop affordances.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 409 files passed, 1 skipped; 3524 tests passed, 9 skipped
- targeted Vitest: 3 files, 7 tests passed
- real `pnpm dev` route at 390px: initial state closed, Files opens as a 360px overlay, closes from the same button, and produces no horizontal overflow
- real route at 767px/768px: mobile transient state ends at 767px and the original persisted desktop preference resumes at 768px