### PR TITLE
Make Market Movers readable on mobile

### DIFF
--- a/ui/src/pages/MarketBoardPage.spec.tsx
+++ b/ui/src/pages/MarketBoardPage.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -71,5 +71,30 @@ describe('MarketBoardPage', () => {
       kind: 'market-detail',
       params: { assetClass: 'equity', symbol: 'NVDA' },
     })
+  })
+
+  it('keeps every Movers list reachable and prioritizes primary metrics on narrow screens', async () => {
+    const user = userEvent.setup()
+    render(
+      <MarketBoardPage
+        spec={{ kind: 'market-board', params: { board: 'movers' } }}
+        visible
+      />,
+    )
+
+    const listGroup = screen.getByRole('group', { name: '异动' })
+    const listButtons = within(listGroup).getAllByRole('button')
+    expect(listButtons).toHaveLength(7)
+    expect(listGroup.className).toContain('flex-wrap')
+    expect(listButtons.every((button) => button.className.includes('whitespace-nowrap'))).toBe(true)
+    expect(screen.getByRole('button', { name: '涨幅榜' }).getAttribute('aria-pressed')).toBe('true')
+
+    expect(screen.getByRole('table').className).toContain('table-fixed')
+    expect(screen.getByRole('columnheader', { name: '成交量' }).className).toContain('hidden')
+    expect(screen.getByRole('columnheader', { name: 'RVOL' }).className).toContain('hidden')
+    expect(screen.getByRole('columnheader', { name: '成交额' }).className).toContain('hidden')
+
+    await user.click(screen.getByRole('button', { name: '成长科技' }))
+    expect(screen.getByRole('button', { name: '成长科技' }).getAttribute('aria-pressed')).toBe('true')
   })
 })

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -67,13 +67,18 @@ function MoversBoardView() {
         live={{ lastUpdated: updatedAt }}
       />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-4 min-h-0">
-        <div className="flex items-center gap-1">
+        <div
+          className="flex flex-wrap items-center gap-1"
+          role="group"
+          aria-label={t('market.boardMovers')}
+        >
           {(['gainers', 'losers', 'active', 'undervaluedGrowth', 'growthTech', 'smallCaps', 'undervaluedLarge'] as const).map((k) => (
             <button
               key={k}
               type="button"
               onClick={() => setList(k)}
-              className={`px-3 py-1 rounded-md text-[12px] font-medium transition-colors ${
+              aria-pressed={list === k}
+              className={`shrink-0 whitespace-nowrap px-3 py-1 rounded-md text-[12px] font-medium transition-colors ${
                 list === k
                   ? 'bg-muted text-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-secondary'
@@ -113,16 +118,16 @@ function MoversTable({ rows }: { rows: MoverRow[] }) {
   const { t } = useTranslation()
   const open = useOpenEquity()
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-[12px] border-collapse">
+    <div className="min-w-0 overflow-x-auto">
+      <table className="w-full table-fixed md:table-auto text-[12px] border-collapse">
         <thead>
           <tr className="text-muted-foreground/70 text-left border-b border-border">
-            <th className="py-1.5 pr-3 font-medium">{t('market.colSymbol')}</th>
-            <th className="py-1.5 px-3 font-medium text-right">{t('market.colPrice')}</th>
-            <th className="py-1.5 px-3 font-medium text-right">{t('market.colChangePct')}</th>
-            <th className="py-1.5 px-3 font-medium text-right">{t('market.colVolume')}</th>
-            <th className="py-1.5 px-3 font-medium text-right">{t('market.colRvol')}</th>
-            <th className="py-1.5 pl-3 font-medium text-right">{t('market.colDollarVolume')}</th>
+            <th className="w-1/2 md:w-auto py-1.5 pr-2 md:pr-3 font-medium">{t('market.colSymbol')}</th>
+            <th className="w-1/4 md:w-auto py-1.5 px-1.5 md:px-3 font-medium text-right">{t('market.colPrice')}</th>
+            <th className="w-1/4 md:w-auto py-1.5 pl-1.5 md:px-3 font-medium text-right">{t('market.colChangePct')}</th>
+            <th className="hidden md:table-cell py-1.5 px-3 font-medium text-right">{t('market.colVolume')}</th>
+            <th className="hidden md:table-cell py-1.5 px-3 font-medium text-right">{t('market.colRvol')}</th>
+            <th className="hidden md:table-cell py-1.5 pl-3 font-medium text-right">{t('market.colDollarVolume')}</th>
           </tr>
         </thead>
         <tbody>
@@ -132,14 +137,14 @@ function MoversTable({ rows }: { rows: MoverRow[] }) {
               className="border-b border-border/50 hover:bg-secondary/40 cursor-pointer"
               onClick={() => open(r.symbol)}
             >
-              <td className="py-1.5 pr-3">
+              <td className="min-w-0 py-1.5 pr-2 md:pr-3">
                 <EquityDetailButton symbol={r.symbol} name={r.name} />
               </td>
-              <td className="py-1.5 px-3 text-right font-mono text-foreground">{fmtPrice(r.price)}</td>
-              <td className={`py-1.5 px-3 text-right font-mono ${signColor(r.percent_change)}`}>{fmtPct(r.percent_change)}</td>
-              <td className="py-1.5 px-3 text-right text-foreground">{fmtCompact(r.volume)}</td>
-              <td className={`py-1.5 px-3 text-right ${rvolColor(r.relative_volume)}`}>{r.relative_volume?.toFixed(2) ?? '—'}</td>
-              <td className="py-1.5 pl-3 text-right text-foreground">{fmtCompact(r.dollar_volume, '$')}</td>
+              <td className="py-1.5 px-1.5 md:px-3 text-right font-mono text-foreground">{fmtPrice(r.price)}</td>
+              <td className={`py-1.5 pl-1.5 md:px-3 text-right font-mono ${signColor(r.percent_change)}`}>{fmtPct(r.percent_change)}</td>
+              <td className="hidden md:table-cell py-1.5 px-3 text-right text-foreground">{fmtCompact(r.volume)}</td>
+              <td className={`hidden md:table-cell py-1.5 px-3 text-right ${rvolColor(r.relative_volume)}`}>{r.relative_volume?.toFixed(2) ?? '—'}</td>
+              <td className="hidden md:table-cell py-1.5 pl-3 text-right text-foreground">{fmtCompact(r.dollar_volume, '$')}</td>
             </tr>
           ))}
         </tbody>
@@ -255,8 +260,8 @@ function EquityDetailButton({
       }}
       className="inline-flex max-w-full items-baseline gap-2 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
     >
-      <span className="font-mono font-semibold text-foreground">{symbol}</span>
-      {name && <span className="truncate text-muted-foreground">{name}</span>}
+      <span className="shrink-0 font-mono font-semibold text-foreground">{symbol}</span>
+      {name && <span className="min-w-0 truncate text-muted-foreground">{name}</span>}
     </button>
   )
 }


### PR DESCRIPTION
## Problem

At 390px, the Movers list selector was 531px wide inside a 358px container. The final categories ended beyond the viewport without their own scroll affordance. The results table also expanded to 567px, forcing horizontal scrolling before users could reliably compare the core move data.

## Change

- allow all seven Movers categories to wrap as stable, non-splitting controls
- expose the selected category with `aria-pressed` inside a named group
- prioritize Symbol, Price, and Chg % in a fixed mobile table
- hide secondary Volume, RVOL, and dollar-volume columns below the desktop breakpoint
- restore the full auto-sized six-column table on desktop
- make long company names truncate without shrinking ticker identity

This follows the Warm Editorial Workstation mobile rule: preserve scan order and primary decisions instead of compressing the desktop table into a clipped viewport.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 408 files passed, 1 skipped; 3520 tests passed, 9 skipped
- targeted MarketBoardPage tests — 2 passed
- real `pnpm dev` at 390px: all seven filters remain within the 358px content area; table clientWidth and scrollWidth are both 352px; visible headers are Symbol, Price, Chg %
- exercised the final Undervalued Large Caps filter and restored Gainers
- real route at 1280px: filters return to one row and all six columns remain visible