### PR TITLE
Keep failed Inbox deletions visible

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1342,6 +1342,8 @@ export const en = {
     deleteEntryAriaLabel: 'Delete this inbox entry',
     deleteConfirmTitle: 'Delete Inbox entry?',
     deleteConfirmMessage: 'This permanently removes this update from Inbox. Files linked from {{workspace}} are not deleted.',
+    deleting: 'Deleting…',
+    deleteFailed: 'Couldn’t delete this Inbox entry. It is still available. Try again.',
   },
   templates: {
     catalogTitle: 'Workspace templates',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1331,6 +1331,8 @@ export const ja: Resources = {
     deleteEntryAriaLabel: 'この受信トレイの項目を削除',
     deleteConfirmTitle: '受信トレイの項目を削除しますか？',
     deleteConfirmMessage: 'この更新を受信トレイから完全に削除します。{{workspace}} でリンクされているファイルは削除されません。',
+    deleting: '削除中…',
+    deleteFailed: '受信トレイの項目を削除できませんでした。項目はそのまま残っています。もう一度お試しください。',
   },
   templates: {
     catalogTitle: 'ワークスペーステンプレート',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1338,6 +1338,8 @@ export const zhHant: Resources = {
     deleteEntryAriaLabel: '刪除此收件匣項目',
     deleteConfirmTitle: '刪除這則收件匣訊息？',
     deleteConfirmMessage: '這會從收件匣中永久刪除此更新，但不會刪除 {{workspace}} 中連結的檔案。',
+    deleting: '正在刪除…',
+    deleteFailed: '無法刪除這則收件匣訊息。訊息仍保留，請再試一次。',
   },
   templates: {
     catalogTitle: '工作區模板',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1330,6 +1330,8 @@ export const zh: Resources = {
     deleteEntryAriaLabel: '删除此收件箱条目',
     deleteConfirmTitle: '删除这条收件箱消息？',
     deleteConfirmMessage: '这会从收件箱中永久删除此更新，但不会删除 {{workspace}} 中链接的文件。',
+    deleting: '正在删除…',
+    deleteFailed: '无法删除这条收件箱消息。消息仍然保留，请重试。',
   },
   templates: {
     catalogTitle: '工作区模板',

--- a/ui/src/live/inbox.ts
+++ b/ui/src/live/inbox.ts
@@ -13,10 +13,10 @@ reloadOnHotUpdate('live/inbox')
  * Single shared connection via LiveStore refcount; multiple subscribers
  * (sidebar list, detail page, Activity bar unread badge) share one timer.
  *
- * Two side-channel helpers (`refreshInbox` / `removeInboxOptimistically`)
- * are exported alongside for the delete flow: optimistic removal flips
- * the entry out of state immediately so the UI doesn't lag the
- * DELETE round-trip, then a refresh confirms truth from the server.
+ * Two side-channel helpers (`refreshInbox` / `removeInboxAfterDelete`)
+ * are exported alongside for the delete flow: once the server acknowledges
+ * the DELETE, the local removal updates every Inbox surface immediately,
+ * then a refresh reconciles with authoritative server state.
  */
 
 export interface InboxState {
@@ -73,10 +73,9 @@ export function refreshInbox(): void {
   triggerRefresh?.()
 }
 
-/** Optimistically remove an entry from the in-memory list before the
- *  DELETE round-trip completes. Pairs with `refreshInbox()` after the
- *  request lands so server state is the source of truth either way. */
-export function removeInboxOptimistically(id: string): void {
+/** Remove a server-confirmed deletion from the in-memory list immediately.
+ *  Pairs with `refreshInbox()` so server state remains authoritative. */
+export function removeInboxAfterDelete(id: string): void {
   applyState?.((prev) => ({
     ...prev,
     entries: prev.entries.filter((e) => e.id !== id),

--- a/ui/src/pages/InboxPage.spec.tsx
+++ b/ui/src/pages/InboxPage.spec.tsx
@@ -116,4 +116,43 @@ describe('InboxPage deletion', () => {
     await waitFor(() => expect(deleteEntry).toHaveBeenCalledWith(entry.id))
     await waitFor(() => expect(screen.queryByText('Delete Inbox entry?')).toBeNull())
   })
+
+  it('keeps the entry and confirmation available when deletion fails, then allows a retry', async () => {
+    const entry = {
+      id: 'inbox-retry',
+      ts: Date.now(),
+      workspaceId: 'ws-1',
+      workspaceLabel: 'research',
+      comments: 'Keep this update until the server confirms deletion.',
+    }
+    let serverHasEntry = true
+    vi.spyOn(api.inbox, 'history').mockImplementation(async () => ({
+      entries: serverHasEntry ? [entry] : [],
+      hasMore: false,
+    }))
+    const deleteEntry = vi.spyOn(api.inbox, 'delete')
+      .mockRejectedValueOnce(new Error('temporary network failure'))
+      .mockImplementationOnce(async () => {
+        serverHasEntry = false
+        return true
+      })
+    useInboxSelection.getState().select(entry.id)
+
+    render(<InboxPage visible />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete this inbox entry' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect((await screen.findByRole('alert')).textContent).toBe(
+      'Couldn’t delete this Inbox entry. It is still available. Try again.',
+    )
+    expect(screen.getByText(entry.comments)).toBeTruthy()
+    expect(screen.getByText('Delete Inbox entry?')).toBeTruthy()
+    expect(useInboxSelection.getState().selectedEntryId).toBe(entry.id)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(deleteEntry).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.queryByText('Delete Inbox entry?')).toBeNull())
+  })
 })

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -23,7 +23,7 @@ import { MarkdownContent } from '../components/MarkdownContent'
 import { FileContentView } from '../components/FileContentView'
 import { InboxReplyThread } from '../components/InboxReplyThread'
 import { api } from '../api'
-import { inboxLive, refreshInbox, removeInboxOptimistically } from '../live/inbox'
+import { inboxLive, refreshInbox, removeInboxAfterDelete } from '../live/inbox'
 import { useInboxSelection } from '../live/inbox-selection'
 import { useInboxRead } from '../live/inbox-read'
 import { useIssues } from '../hooks/useIssues'
@@ -60,38 +60,45 @@ export function InboxPage({ visible }: InboxPageProps) {
   const select = useInboxSelection((s) => s.select)
   const markRead = useInboxRead((s) => s.markRead)
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   const selected = entries.find((e) => e.id === selectedId) ?? null
   const pendingDelete = entries.find((e) => e.id === pendingDeleteId) ?? null
 
-  /** Hard-delete an entry. Optimistically removes it, advances selection
-   *  to the next-older entry (or previous if last), fires the DELETE,
-   *  then refreshes to reconcile with the server. */
-  const handleDelete = useCallback(async (id: string) => {
+  /** Hard-delete an entry. The durable DELETE must succeed before the UI
+   *  removes anything: a failed destructive action should keep both the
+   *  entry and its confirmation available for a retry, not briefly mimic
+   *  success until the next Inbox refresh restores the entry. */
+  const handleDelete = useCallback(async (id: string): Promise<boolean> => {
     const idx = entries.findIndex((e) => e.id === id)
-    if (idx < 0) return
+    if (idx < 0) return false
+    setDeleteError(null)
 
     // entries is newest-first; the "next" one is the next older entry.
     // Fall back to the previous (newer) if we deleted the tail.
     const nextId = entries[idx + 1]?.id ?? entries[idx - 1]?.id ?? null
 
-    removeInboxOptimistically(id)
+    try {
+      await api.inbox.delete(id)
+    } catch {
+      setDeleteError(t('inbox.deleteFailed'))
+      refreshInbox()
+      return false
+    }
+
+    removeInboxAfterDelete(id)
     if (nextId) {
       select(nextId)
       markRead(nextId)
     } else {
       select(null)
     }
-
-    try {
-      await api.inbox.delete(id)
-    } catch {
-      // best-effort — refreshInbox below reconciles if the server disagreed.
-    }
     refreshInbox()
-  }, [entries, select, markRead])
+    return true
+  }, [entries, select, markRead, t])
 
   const requestDelete = useCallback((id: string) => {
+    setDeleteError(null)
     setPendingDeleteId(id)
   }, [])
 
@@ -141,16 +148,34 @@ export function InboxPage({ visible }: InboxPageProps) {
       {pendingDelete && (
         <ConfirmDialog
           title={t('inbox.deleteConfirmTitle')}
-          message={t('inbox.deleteConfirmMessage', {
-            workspace: pendingDelete.workspaceLabel ?? pendingDelete.workspaceId,
-          })}
+          message={(
+            <div className="space-y-3">
+              <p>{t('inbox.deleteConfirmMessage', {
+                workspace: pendingDelete.workspaceLabel ?? pendingDelete.workspaceId,
+              })}</p>
+              {deleteError && (
+                <p
+                  role="alert"
+                  className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-destructive"
+                >
+                  {deleteError}
+                </p>
+              )}
+            </div>
+          )}
           confirmLabel={t('common.delete')}
           cancelLabel={t('common.cancel')}
+          workingLabel={t('inbox.deleting')}
           onConfirm={async () => {
-            await handleDelete(pendingDelete.id)
+            const deleted = await handleDelete(pendingDelete.id)
+            if (!deleted) return
+            setDeleteError(null)
             setPendingDeleteId(null)
           }}
-          onClose={() => setPendingDeleteId(null)}
+          onClose={() => {
+            setDeleteError(null)
+            setPendingDeleteId(null)
+          }}
         />
       )}
     </>


### PR DESCRIPTION
## Problem

Inbox removed an entry and advanced selection before issuing the durable DELETE. Any request exception was swallowed. The confirmation disappeared with the optimistically removed entry, so a failed deletion looked successful until polling restored the message with no explanation.

## Change

- wait for the server DELETE result before removing the entry or advancing selection
- keep the entry, selection, and confirmation dialog intact when the request fails
- show a localized `role=alert` that states the entry is still available
- clear stale failure state when retrying and provide a localized deleting label
- allow the same confirmation to retry immediately
- retain instant cross-surface removal after the server confirms success, followed by authoritative refresh

This follows the Warm Editorial Workstation state rule: destructive operations must expose their real outcome instead of presenting an optimistic success fiction.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 408 files passed, 1 skipped; 3520 tests passed, 9 skipped
- targeted InboxPage tests — 4 passed
- regression test proves a rejected DELETE preserves the entry, active selection, dialog, and retry action; the second request succeeds and closes the dialog
- real `pnpm dev` success path: deleted the old entry explicitly labeled `test entry, safe to dismiss`; Inbox count changed from 67 to 66, the dialog closed only after success, and selection advanced normally