### PR TITLE
Keep Workspace names consistent in focused views

### DIFF
--- a/ui/src/pages/FileViewerPage.spec.tsx
+++ b/ui/src/pages/FileViewerPage.spec.tsx
@@ -11,10 +11,11 @@ const mocks = vi.hoisted(() => ({
   setSidebar: vi.fn(),
   selectTracked: vi.fn(),
   readWorkspaceFile: vi.fn(),
+  workspaces: [] as Array<{ id: string; tag: string; displayName?: string }>,
 }))
 
 vi.mock('../contexts/workspaces-context', () => ({
-  useWorkspaces: () => ({ workspaces: [{ id: 'chat-1', tag: 'chat-jul20' }] }),
+  useWorkspaces: () => ({ workspaces: mocks.workspaces }),
 }))
 
 vi.mock('../tabs/store', () => ({
@@ -44,6 +45,11 @@ vi.mock('../components/FileContentView', () => ({
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.readWorkspaceFile.mockResolvedValue({ kind: 'ok', content: 'hello' })
+  mocks.workspaces = [{
+    id: 'chat-1',
+    tag: 'chat-jul20',
+    displayName: 'Semis and supply chain',
+  }]
 })
 
 afterEach(cleanup)
@@ -64,8 +70,10 @@ describe('FileViewerPage back navigation', () => {
       />,
     )
 
-    const back = screen.getByRole('button', { name: 'Back to chat-jul20' })
-    expect(back.getAttribute('title')).toBe('Back to chat-jul20')
+    const back = screen.getByRole('button', { name: 'Back to Semis and supply chain' })
+    expect(back.getAttribute('title')).toBe('Back to Semis and supply chain')
+    const workspaceIdentity = screen.getByText('Semis and supply chain')
+    expect(workspaceIdentity.getAttribute('title')).toBe('Semis and supply chain\nchat-jul20')
     fireEvent.click(back)
 
     expect(mocks.setSidebar).toHaveBeenCalledWith('chat')
@@ -80,6 +88,8 @@ describe('FileViewerPage back navigation', () => {
   })
 
   it('retains the existing generic Workspace fallback', () => {
+    mocks.workspaces = [{ id: 'chat-1', tag: 'chat-jul20' }]
+
     render(
       <FileViewerPage
         spec={{ kind: 'file-viewer', params: { wsId: 'chat-1', path: 'README.md' } }}

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -17,6 +17,7 @@ import { FileContentView } from '../components/FileContentView'
 import { CenteredLoading } from '../components/StateViews'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
+import { workspaceDisplayName, workspaceDisplayTitle } from '../components/workspace/display'
 import { useTrackedSelection } from '../live/tracked-selection'
 import { useWorkspace } from '../tabs/store'
 import type { ViewSpec } from '../tabs/types'
@@ -32,10 +33,12 @@ export function FileViewerPage({ spec }: Props) {
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
   const selectTracked = useTrackedSelection((s) => s.select)
-  const tag = workspaces.find((w) => w.id === wsId)?.tag ?? wsId.slice(0, 8)
+  const workspace = workspaces.find((w) => w.id === wsId)
+  const workspaceName = workspace ? workspaceDisplayName(workspace) : wsId.slice(0, 8)
+  const workspaceTitle = workspace ? workspaceDisplayTitle(workspace) : workspaceName
   const backLabel = source === 'tracked'
     ? t('fileViewer.backToTracked')
-    : t('fileViewer.backToWorkspace', { workspace: tag })
+    : t('fileViewer.backToWorkspace', { workspace: workspaceName })
 
   const [result, setResult] = useState<ReadFileResult | null>(null)
   useEffect(() => {
@@ -84,7 +87,12 @@ export function FileViewerPage({ spec }: Props) {
         <span className="font-mono text-[12px] text-foreground truncate" title={path}>
           {path}
         </span>
-        <span className="ml-auto shrink-0 text-[11px] text-muted-foreground/60">{tag}</span>
+        <span
+          className="ml-auto min-w-0 max-w-[min(35vw,20rem)] truncate text-right text-[11px] text-muted-foreground/70"
+          title={workspaceTitle}
+        >
+          {workspaceName}
+        </span>
       </div>
       <div className="flex-1 overflow-y-auto min-h-0">
         <div className="max-w-[820px] mx-auto px-6 py-6">

--- a/ui/src/pages/WorkspacePage.spec.tsx
+++ b/ui/src/pages/WorkspacePage.spec.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '../i18n'
+import type { Workspace } from '../components/workspace/api'
+import { WorkspacePage } from './WorkspacePage'
+
+const mocks = vi.hoisted(() => ({
+  openOrFocus: vi.fn(),
+  spawn: vi.fn(),
+  openAgentConfig: vi.fn(),
+  resumeSession: vi.fn(),
+  openWebPiSession: vi.fn(),
+  refresh: vi.fn(),
+  workspaceViewProps: vi.fn(),
+  workspaces: [] as Workspace[],
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => ({
+    workspaces: mocks.workspaces,
+    defaultAgent: 'codex',
+    agents: [{ id: 'codex', kind: 'native' }],
+    spawn: mocks.spawn,
+    openAgentConfig: mocks.openAgentConfig,
+    resumeSession: mocks.resumeSession,
+    openWebPiSession: mocks.openWebPiSession,
+    refresh: mocks.refresh,
+  }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (
+    selector: (state: { openOrFocus: typeof mocks.openOrFocus }) => unknown,
+  ) => selector({ openOrFocus: mocks.openOrFocus }),
+}))
+
+vi.mock('../components/workspace/WorkspaceView', () => ({
+  WorkspaceView: (props: { label?: string }) => {
+    mocks.workspaceViewProps(props)
+    return <div data-testid="workspace-view" data-label={props.label} />
+  },
+}))
+
+vi.mock('../components/workspace/WorkspaceFilesToggle', () => ({
+  WorkspaceFilesToggle: () => <button type="button">Files</button>,
+}))
+
+function workspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: 'chat-1',
+    tag: 'chat-jun30',
+    dir: '/tmp/chat-jun30',
+    createdAt: '2026-06-30T00:00:00.000Z',
+    agents: ['codex'],
+    sessions: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.workspaces = [workspace({ displayName: 'Optical Networking Follow-up' })]
+})
+
+afterEach(cleanup)
+
+describe('WorkspacePage identity', () => {
+  it('keeps the user-defined Workspace name primary in the header and runtime label', () => {
+    render(
+      <WorkspacePage
+        spec={{ kind: 'workspace', params: { wsId: 'chat-1' } }}
+        visible
+      />,
+    )
+
+    const workspaceName = screen.getByText('Optical Networking Follow-up')
+    const identity = workspaceName.parentElement
+    expect(identity?.getAttribute('title')).toBe('Optical Networking Follow-up\nchat-jun30')
+    expect(identity?.textContent).toContain('Optical Networking Follow-up')
+    expect(identity?.textContent).toContain('chat-jun30')
+    expect(screen.getByTestId('workspace-view').getAttribute('data-label'))
+      .toBe('Optical Networking Follow-up')
+  })
+
+  it('falls back to the stable tag when no display name is configured', () => {
+    mocks.workspaces = [workspace({ displayName: '   ' })]
+
+    render(
+      <WorkspacePage
+        spec={{ kind: 'workspace', params: { wsId: 'chat-1' } }}
+        visible
+      />,
+    )
+
+    expect(screen.getByTitle('chat-jun30').textContent).toBe('chat-jun30')
+    expect(screen.getByTestId('workspace-view').getAttribute('data-label')).toBe('chat-jun30')
+  })
+})

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -23,6 +23,7 @@ import '@xterm/xterm/css/xterm.css'
 
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { useWorkspace } from '../tabs/store'
+import { workspaceDisplayName, workspaceDisplayTitle } from '../components/workspace/display'
 import { WorkspaceView } from '../components/workspace/WorkspaceView'
 import { WorkspaceFilesToggle } from '../components/workspace/WorkspaceFilesToggle'
 import type { ViewSpec } from '../tabs/types'
@@ -88,6 +89,10 @@ export function WorkspacePage({ spec, visible }: Props) {
     )
   }
 
+  const workspaceName = workspaceDisplayName(workspace)
+  const workspaceTitle = workspaceDisplayTitle(workspace)
+  const hasCustomName = workspaceName !== workspace.tag
+
   // Sessions list: pass the full workspace.sessions. WorkspaceView's
   // `runningSlots` is gated on sessionId so the multi-terminal mount
   // only happens when a session is pinned (one session per tab still
@@ -99,8 +104,20 @@ export function WorkspacePage({ spec, visible }: Props) {
        *  launcher component itself is byte-faithful; we add the AI-provider
        *  affordance here. */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-secondary/30 shrink-0">
-        <span className="text-[12px] text-muted-foreground font-medium">{workspace.tag}</span>
-        <div className="flex items-center gap-1">
+        <div
+          className="flex min-w-0 items-baseline gap-2 pr-2"
+          title={workspaceTitle}
+        >
+          <span className="truncate text-[12px] font-medium text-foreground">
+            {workspaceName}
+          </span>
+          {hasCustomName && (
+            <span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground/70 sm:inline">
+              {workspace.tag}
+            </span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
           {activeRecord?.agent === 'pi' && activeRecord.state === 'running' && (
             <button
               type="button"
@@ -143,7 +160,7 @@ export function WorkspacePage({ spec, visible }: Props) {
           {...(source ? { source } : {})}
           activeRecord={activeRecord}
           sessions={workspace.sessions}
-          label={workspace.tag}
+          label={workspaceName}
           onSpawnFresh={spawnDefault}
           onResume={(id) => void ctx.resumeSession(wsId, id, source)}
           onOpenWebPi={(id) => void ctx.openWebPiSession(wsId, id, source)}


### PR DESCRIPTION
## Summary

- make the user-defined Workspace display name primary in the focused session header
- retain the stable tag as secondary desktop metadata and keep runtime/WebPi labels aligned with the user-visible name
- use the same display name in File Viewer identity and back navigation, with the tag preserved in its tooltip
- preserve the existing stable-tag fallback when no display name is configured

## Evidence

The real Workspace `Optical Networking Follow-up` is correctly named in the Ask Alice sidebar, but its focused session header and File Viewer previously reverted to the internal tag `chat-jun30`. This broke identity continuity exactly where users are reading and working inside the Workspace.

## Verification

- `npx vitest run ui/src/pages/WorkspacePage.spec.tsx ui/src/pages/FileViewerPage.spec.tsx` (5 tests)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (409 files passed, 3521 tests passed)
- real `pnpm dev` Workspace session: verified display name primary, tag secondary, and existing controls remain available
- real File Viewer: verified display name and named Back action
- both routes at 390x844: verified truncation behavior and zero page-level horizontal overflow