### PR TITLE
Upgrade CLI lifecycle management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
         id: version
         run: |
           VERSION=$(node -p "require('./package.json').version")
+          CLI_VERSION=$(node -p "require('./packages/cli/package.json').version")
+          test "$CLI_VERSION" = "$VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "previous_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
@@ -362,7 +364,9 @@ jobs:
         run: |
           VERSION="${TAG#v}"
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          CLI_PACKAGE_VERSION=$(node -p "require('./packages/cli/package.json').version")
           test "$PACKAGE_VERSION" = "$VERSION"
+          test "$CLI_PACKAGE_VERSION" = "$VERSION"
           bash -n install
           cp install "dist/r2-upload/OpenAlice-${VERSION}-install"
 

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,10 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/cli-lifecycle-quality.md]] — Aligns the computer-level CLI with the
+  OpenAlice product version and adds bounded update discovery, installer-backed
+  updates, and state-preserving CLI uninstall.
+
 ## Completed
 
 - [[plans/agent-conversation-log-ui.md]] — Adds a read-only, paginated Agent

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,12 +21,11 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/cli-lifecycle-quality.md]] — Aligns the computer-level CLI with the
-  OpenAlice product version and adds bounded update discovery, installer-backed
-  updates, and state-preserving CLI uninstall.
-
 ## Completed
 
+- [[plans/cli-lifecycle-quality.md]] — Aligns the computer-level CLI with the
+  OpenAlice product version and adds bounded update discovery, installer-backed
+  updates, and state-preserving CLI uninstall. Delivered in PR #847.
 - [[plans/agent-conversation-log-ui.md]] — Adds a read-only, paginated Agent
   collaboration view to Dev Logs without exposing launcher file paths or
   introducing a new dispatch surface. Delivered in PR #742.

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -97,6 +97,12 @@ runs `npm ci --omit=dev --ignore-scripts` in the staged release.
 - `packages/cli/bin/openalice.mjs` — installed command entry point.
 - `packages/cli/src/install-source.mjs` — validated installation-source
   metadata used when managed remote reproduces the invoking CLI.
+- `packages/cli/src/install-layout.mjs` — strict discovery of installer-owned
+  roots from immutable release paths.
+- `packages/cli/src/update.mjs` — stable manifest checks, bounded start notice,
+  installer verification, and update handoff.
+- `packages/cli/src/uninstall.mjs` — installer-lock safety, PATH cleanup, and
+  the state-preserving CLI-only removal boundary.
 - `packages/cli/src/server{,-control}.mjs` — detached lifecycle and the
   Guardian control client.
 - `packages/cli/src/remote.mjs` — consent-first managed SSH orchestration.
@@ -267,8 +273,9 @@ That metadata is returned by `openalice version --json` together with the
 Managed `openalice remote` compares both provenance and content identity before
 deciding that a remote CLI matches, then invokes the same ordinary installer
 source and selector when it does not. This catches changed payload bytes even
-when the CLI semantic version and branch name are unchanged. `remote` has no
-independent branch/version option.
+when the product version and branch name are unchanged. The CLI package version
+must equal the root OpenAlice version; tests and the release workflow reject a
+mismatch. `remote` has no independent branch/version option.
 
 The resulting directory is:
 
@@ -298,8 +305,73 @@ complete old release or the complete new release, never to a half-written
 replacement tree. The final installed launcher is executed again with
 `--version` before success is reported.
 
-Old content-addressed releases are retained. There is currently no automatic
-garbage collection, rollback command, or CLI-only uninstall command.
+Old content-addressed releases are retained during installation and update.
+There is currently no automatic garbage collection or rollback command.
+
+## Product Version and Update Lifecycle
+
+The computer-level CLI uses the OpenAlice product version from the same release:
+
+```text
+package.json#version == packages/cli/package.json#version
+```
+
+There is no second user-facing CLI version sequence. Version bumps that do not
+update both manifests fail CLI tests and release preflight.
+
+An installed stable-channel CLI checks
+`https://download.openalice.ai/manifest.json` before an interactive
+`openalice start`:
+
+- only a recorded public `branch master` installation from
+  `https://openalice.ai/install` participates;
+- exact tag/commit installations remain pinned;
+- `dev` and other branch installations keep their selected development channel;
+- custom installer/mirror installations do not cross into the public trust
+  boundary;
+- checks time out after 1.5 seconds, failures are silent, and the result is
+  cached for 24 hours under `<install-root>/.cli-update-check.json`;
+- `--no-update-check` or `OPENALICE_NO_UPDATE_CHECK=1` disables the start check;
+- discovery only prints a notice. It never mutates files or makes startup
+  depend on a successful network request.
+
+Explicit controls are:
+
+```bash
+openalice update --check
+openalice update --check --json
+openalice update
+openalice update --yes
+```
+
+`openalice update` downloads the release's versioned Bash installer from the
+manifest, verifies its SHA-256, and invokes the ordinary installer for the
+detected install root. The normal install plan and default-no consent remain
+authoritative; `--yes` is the explicit automation path. The updater also passes
+the manifest version as an expected CLI version so a release/payload race cannot
+publish an unexpected product version.
+
+## CLI-Only Uninstall
+
+The supported removal flow is:
+
+```bash
+openalice uninstall --plan
+openalice uninstall
+openalice uninstall --yes
+```
+
+The command refuses to race a live installer and removes only:
+
+- the four `openalice`/`pi` shell and CMD launchers;
+- all immutable directories under `cli-versions/`;
+- the installer lock and update-check cache;
+- managed PATH blocks that reference this exact install root.
+
+It may remove an empty `bin/` directory, but it never removes the shared install
+root. It explicitly preserves `data/`, `workspaces/`, `sources/`,
+`provider-keys.json`, `sealing.key`, backups, credentials, and every other
+application or user-owned path. Symlinked shell profiles remain symlinks.
 
 ## Installed Layout
 
@@ -319,6 +391,7 @@ With the default installer and Runtime roots:
 │   ├── dev-<content-id>/   # only after an explicit --branch dev install
 │   └── <older-ref-or-content>/
 ├── .cli-install.lock/       # present only while an installer owns it
+├── .cli-update-check.json   # best-effort stable update cache
 ├── sources/                 # selector-specific managed remote checkouts
 ├── data/                    # application state, not installer debris
 ├── workspaces/              # user work, not installer debris
@@ -331,13 +404,9 @@ installer itself. The installer root and Runtime `OPENALICE_HOME` independently 
 `~/.openalice`. The installer does not read an `OPENALICE_HOME` override, and
 `openalice start` does not infer Runtime home from the CLI's install location.
 Either override may therefore diverge intentionally. Their default co-location
-is convenient, but it makes the uninstall boundary critical: never implement
-uninstall as `rm -rf ~/.openalice`.
-
-A future uninstall operation must remove only installer-owned launchers,
-installer-owned CLI releases, its lock, and its marked PATH block. It must
-preserve application data, Workspaces, credentials, keys, backups, and any
-other user-owned state.
+is convenient, but it makes the uninstall boundary critical:
+`openalice uninstall` resolves ownership from its immutable CLI path and never
+implements removal as `rm -rf ~/.openalice`.
 
 ## PATH Integration
 
@@ -403,6 +472,7 @@ Environment inputs:
 | `OPENALICE_PI_SOURCE_DIR` | Read the exact Pi manifest/lock assets from a local fixture |
 | `OPENALICE_NPM_BIN` | Use a single alternate npm executable in installer tests |
 | `OPENALICE_INSTALL_CONTEXT` | Internal managed-remote context; returns control without local checkout/start guidance |
+| `OPENALICE_EXPECTED_CLI_VERSION` | Internal verified-update guard; rejects a payload whose CLI/product version differs from the release manifest |
 | `NO_COLOR` | Disable installer color output |
 | `HOME`, `SHELL`, `PATH`, `TERM` | Standard environment used for paths, profile detection, conflicts, and color |
 
@@ -421,6 +491,8 @@ The public bootstrap is release-owned: each accepted release carries a
 versioned installer asset, the R2 manifest records its SHA-256, and the rolling
 main-site entry resolves to the mirrored bytes. The installed content identity
 then protects update layout and detects accidental or local modification.
+`openalice update` improves consistency by fetching the versioned installer URL
+from that manifest and verifying the recorded SHA-256 before execution.
 
 This is still not a cryptographic signature. The installer downloads the CLI
 payload as individual files from the selected raw GitHub ref, and the R2
@@ -466,7 +538,13 @@ The unit suite covers:
 - blank-input cancellation;
 - explicit interactive approval and separate start refusal;
 - source-build-tool preflight before pnpm;
-- live installer lock rejection.
+- live installer lock rejection;
+- product/CLI version alignment and release-version comparison;
+- stable, pinned, and development update-channel behavior;
+- daily-cached failure-tolerant start notices;
+- update installer checksum and expected-version enforcement;
+- uninstall plan, consent, live-lock refusal, symlink preservation, and exact
+  state-preservation boundaries.
 
 ### Clean Docker acceptance
 
@@ -497,7 +575,10 @@ It verifies:
 - runnable OpenAlice/Pi shell and CMD launchers plus managed-Pi env injection;
 - idempotent managed PATH configuration;
 - identical-release reuse;
-- ref switching without deleting the prior release.
+- ref switching without deleting the prior release;
+- development-channel update guidance without a stable-channel network check;
+- installed uninstall execution that removes CLI assets and PATH integration
+  while preserving data, Workspaces, sources, credentials, and keys.
 
 Relevant PRs run this deterministic acceptance in CI against the exact checkout.
 The same workflow runs `pnpm test:remote:docker` in a separate clean SSH fixture
@@ -544,6 +625,8 @@ with an explicit `y`, and run at least:
 command -v openalice
 openalice --version
 openalice version --json
+openalice update --check
+openalice uninstall --plan
 command -v pi
 pi --version
 cat ~/.bashrc
@@ -579,9 +662,9 @@ Before publishing or promoting a change that affects the installer:
 
 1. Confirm the CLI payload list in `install` and `packages/cli/package.json`
    still match the imports reachable from `bin/openalice.mjs`.
-2. Confirm the intended source ref, CLI package version, Pi version, release
-   asset hashes, lockfile engine floor, and root/CLI Node engines. Do not
-   accidentally advertise mutable `dev` as a stable release.
+2. Confirm the intended source ref, equal root and CLI package versions, Pi
+   version, release asset hashes, lockfile engine floor, and root/CLI Node
+   engines. Do not accidentally advertise mutable `dev` as a stable release.
 3. Run the fast installer tests and the full repository-required checks.
 4. Require checkout install and managed-remote CI acceptance to pass, then
    require the post-merge `pnpm test:install:dev-channel` result for current
@@ -614,6 +697,9 @@ versioned promotion under [[docs/development-workflow.md]].
 | npm is missing or Node is below 22.19.0 | Install the complete Node.js 22 LTS distribution; OpenAlice rejects the host before consent instead of publishing a broken Pi runtime |
 | Pi asset SHA-256 check fails | Stop. The pinned release metadata and downloaded asset disagree; do not bypass the check |
 | A `.damaged.<pid>` directory appears | A content-addressed release no longer matched its identity; preserve it for diagnosis while the validated replacement becomes active |
+| `stable release update checks are disabled` | This CLI is pinned or follows a development branch; re-run that selector's installer instead of silently crossing channels |
+| update installer SHA-256 fails | Stop. The release manifest and versioned installer bytes disagree; the updater must not execute them |
+| uninstall reports a live installer | Wait for that PID to finish; uninstall and install share the same ownership boundary and must not race |
 | CLI installs but localhost startup fails | Installation succeeded; continue with [[docs/local-runtime.md]] and Guardian/runtime diagnostics |
 | Remote install succeeds and then prints no clone command | Managed remote set the installer context and is continuing with its already-approved source plan |
 | Native PowerShell/CMD bootstrap is unavailable | Use the complete Electron installer, WSL, or Git Bash until a reviewed native bootstrap exists |

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -288,7 +288,8 @@ Before merging a promotion:
   and the post-merge live dev-channel job to be green, and walk the interactive
   installer locally when its human-facing flow changed;
 - confirm the new release version, notes, and tag intent; the release workflow
-  must see a version whose tag does not already exist;
+  must see a version whose tag does not already exist, and the root and
+  `packages/cli` manifests must carry that same product version;
 - confirm CI and release workflow triggers still match the branch policy.
 
 The release workflow repeats the deterministic installer and managed-remote

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -45,7 +45,9 @@ curl -fsSL https://openalice.ai/install | bash
 Development dogfooding can opt into `dev` explicitly with `--branch dev`. The
 installer requires Node.js 22.19.0 or newer and always installs the small CLI
 plus OpenAlice's pinned Pi runtime inside the same immutable install release;
-the two visible commands are `openalice` and `pi`.
+the two visible commands are `openalice` and `pi`. The installed CLI reports
+the same version as the OpenAlice product release; there is no independent CLI
+version sequence.
 When explicitly selected,
 it can also install missing Linux Git/Python/make/C++ tools needed to build the
 source Runtime. It does not clone OpenAlice, write application state, install
@@ -101,7 +103,15 @@ openalice start --no-open
 openalice start --rebuild
 openalice start --home /tmp/openalice-test-home --port 41000
 openalice start /path/to/OpenAlice
+openalice start --no-update-check
+openalice update --check
 ```
+
+An installed stable-channel CLI performs a short, daily-cached release check
+before an interactive local start. Failure is silent and never blocks startup.
+A newer release produces guidance for `openalice update`; it is not installed
+without the ordinary visible plan and consent. Exact-ref and development
+installations do not silently cross into the stable channel.
 
 For concurrent source worktrees, select a complete home outside the checkout:
 

--- a/install
+++ b/install
@@ -666,6 +666,7 @@ fi
 FILES=(
   "package.json"
   "bin/openalice.mjs"
+  "src/install-layout.mjs"
   "src/install-source.mjs"
   "src/local-start.mjs"
   "src/remote.mjs"
@@ -674,6 +675,8 @@ FILES=(
   "src/server.mjs"
   "src/server-control.mjs"
   "src/ssh-connect.mjs"
+  "src/uninstall.mjs"
+  "src/update.mjs"
 )
 
 step 3 "Downloading OpenAlice and managed Pi"
@@ -729,6 +732,7 @@ ok "Managed Pi $PI_VERSION is ready"
 step 5 "Verifying the OpenAlice CLI"
 chmod +x "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/bin/openalice.mjs"
+node --check "$STAGING/src/install-layout.mjs"
 node --check "$STAGING/src/install-source.mjs"
 node --check "$STAGING/src/local-start.mjs"
 node --check "$STAGING/src/remote.mjs"
@@ -737,12 +741,18 @@ node --check "$STAGING/src/runtime-client.mjs"
 node --check "$STAGING/src/server.mjs"
 node --check "$STAGING/src/server-control.mjs"
 node --check "$STAGING/src/ssh-connect.mjs"
+node --check "$STAGING/src/uninstall.mjs"
+node --check "$STAGING/src/update.mjs"
 
 CLI_VERSION="$(node -e '
   const manifest = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
   if (manifest.name !== "@traderalice/openalice-cli" || typeof manifest.version !== "string") process.exit(1);
   process.stdout.write(manifest.version);
 ' "$STAGING/package.json")" || die "The downloaded package manifest is not an OpenAlice CLI package"
+if [[ -n "${OPENALICE_EXPECTED_CLI_VERSION:-}" \
+  && "$CLI_VERSION" != "$OPENALICE_EXPECTED_CLI_VERSION" ]]; then
+  die "The downloaded CLI reported $CLI_VERSION instead of expected release $OPENALICE_EXPECTED_CLI_VERSION"
+fi
 STAGED_VERSION="$(node "$STAGING/bin/openalice.mjs" --version)"
 [[ "$STAGED_VERSION" == "$CLI_VERSION" ]] || die "The downloaded CLI did not report its package version"
 node -e '

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -8,6 +8,8 @@ import { formatLocalStartHelp, parseLocalStartArgs, startLocal } from '../src/lo
 import { connectRemote, formatRemoteHelp, parseRemoteArgs } from '../src/remote.mjs'
 import { formatServerHelp, parseServerArgs, runServerCommand } from '../src/server.mjs'
 import { connectSsh, formatSshHelp, parseSshConnectArgs } from '../src/ssh-connect.mjs'
+import { formatUninstallHelp, runUninstallCommand } from '../src/uninstall.mjs'
+import { formatUpdateHelp, maybeNotifyUpdate, runUpdateCommand } from '../src/update.mjs'
 
 export async function main(argv = process.argv.slice(2)) {
   const [command, ...args] = argv
@@ -33,7 +35,9 @@ export async function main(argv = process.argv.slice(2)) {
       process.stdout.write(formatLocalStartHelp())
       return 0
     }
-    return startLocal(parseLocalStartArgs(startArgs))
+    const options = parseLocalStartArgs(startArgs)
+    await maybeNotifyUpdate({ enabled: options.checkUpdates })
+    return startLocal(options)
   }
   if (command === 'ssh') {
     if (args.includes('--help') || args.includes('-h')) {
@@ -57,6 +61,20 @@ export async function main(argv = process.argv.slice(2)) {
     }
     return connectRemote(parseRemoteArgs(args))
   }
+  if (command === 'update') {
+    if (args.includes('--help') || args.includes('-h')) {
+      process.stdout.write(formatUpdateHelp())
+      return 0
+    }
+    return runUpdateCommand(args)
+  }
+  if (command === 'uninstall') {
+    if (args.includes('--help') || args.includes('-h')) {
+      process.stdout.write(formatUninstallHelp())
+      return 0
+    }
+    return runUninstallCommand(args)
+  }
   throw new Error(`Unknown command: ${command}\n\n${formatHelp()}`)
 }
 
@@ -70,6 +88,8 @@ Usage:
   openalice server <run|start|status|stop> [options]
   openalice ssh <user@host> [options]
   openalice remote <user@host> [options]
+  openalice update [--check] [--yes]
+  openalice uninstall [--plan] [--yes]
 
 Commands:
   version   Print the CLI version; --json also reports its recorded install source
@@ -77,9 +97,12 @@ Commands:
   server    Run, detach, inspect, or stop a browserless local Runtime
   ssh       Open a loopback-only SSH tunnel to an already-running OpenAlice
   remote    Plan, prepare, and connect to an OpenAlice Server over SSH
+  update    Check for or install a newer stable OpenAlice release
+  uninstall Remove the installed CLI and managed Pi while preserving user data
 
 Run "openalice start --help", "openalice server --help",
-"openalice ssh --help", or "openalice remote --help" for details.
+"openalice ssh --help", "openalice remote --help",
+"openalice update --help", or "openalice uninstall --help" for details.
 `
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.2.0",
+  "version": "0.87.0-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {
@@ -8,6 +8,7 @@
   },
   "files": [
     "bin/openalice.mjs",
+    "src/install-layout.mjs",
     "src/install-source.mjs",
     "src/local-start.mjs",
     "src/remote.mjs",
@@ -15,10 +16,12 @@
     "src/runtime-client.mjs",
     "src/server.mjs",
     "src/server-control.mjs",
-    "src/ssh-connect.mjs"
+    "src/ssh-connect.mjs",
+    "src/uninstall.mjs",
+    "src/update.mjs"
   ],
   "scripts": {
-    "build": "node --check bin/openalice.mjs && node --check src/install-source.mjs && node --check src/local-start.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs",
+    "build": "node --check bin/openalice.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/local-start.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },
   "engines": {

--- a/packages/cli/src/install-layout.mjs
+++ b/packages/cli/src/install-layout.mjs
@@ -1,0 +1,19 @@
+import { basename, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function resolveInstalledLayout(moduleUrl = import.meta.url) {
+  const modulePath = fileURLToPath(moduleUrl)
+  const releaseDir = dirname(dirname(modulePath))
+  const versionsDir = dirname(releaseDir)
+  if (basename(versionsDir) !== 'cli-versions') return null
+
+  const installRoot = dirname(versionsDir)
+  return {
+    installRoot,
+    versionsDir,
+    releaseDir,
+    binDir: join(installRoot, 'bin'),
+    lockDir: join(installRoot, '.cli-install.lock'),
+    updateCachePath: join(installRoot, '.cli-update-check.json'),
+  }
+}

--- a/packages/cli/src/install-layout.spec.mjs
+++ b/packages/cli/src/install-layout.spec.mjs
@@ -1,0 +1,38 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { resolveInstalledLayout } from './install-layout.mjs'
+
+describe('OpenAlice installed layout', () => {
+  it('derives only the installer-owned root from an immutable release path', () => {
+    const installRoot = join(tmpdir(), 'openalice-layout', '.openalice')
+    expect(resolveInstalledLayout(pathToFileURL(join(
+      installRoot,
+      'cli-versions',
+      'master-0123456789abcdef',
+      'src',
+      'update.mjs',
+    )))).toEqual({
+      installRoot,
+      versionsDir: join(installRoot, 'cli-versions'),
+      releaseDir: join(installRoot, 'cli-versions', 'master-0123456789abcdef'),
+      binDir: join(installRoot, 'bin'),
+      lockDir: join(installRoot, '.cli-install.lock'),
+      updateCachePath: join(installRoot, '.cli-update-check.json'),
+    })
+  })
+
+  it('does not treat a source checkout as an installed CLI', () => {
+    expect(resolveInstalledLayout(pathToFileURL(join(
+      tmpdir(),
+      'OpenAlice',
+      'packages',
+      'cli',
+      'src',
+      'update.mjs',
+    )))).toBeNull()
+  })
+})

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -41,6 +41,10 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     }))
     expect(rootManifest.engines.node).toBe('>=22.19.0')
     expect(cliManifest.engines.node).toBe('>=22.19.0')
+    expect(cliManifest.version).toBe(rootManifest.version)
+    for (const file of cliManifest.files) {
+      expect(installer).toContain(`  "${file}"`)
+    }
     expect(sha256(packageBytes)).toBe('ee080db64c3732daea5547bd6d9809465ffa236ef6099051e64a16753e48b795')
     expect(sha256(lockBytes)).toBe('0f409bf498507f93bfbde3dc6f2b4c83bc58bdea2e2f5eabf3053cc2a81568d4')
   })
@@ -129,15 +133,15 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     await expect(access(join(installRoot, 'bin', 'pi.cmd'))).resolves.toBeUndefined()
 
     const result = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['--version'])
-    expect(result.stdout.trim()).toBe('0.2.0')
+    expect(result.stdout.trim()).toBe('0.87.0-beta')
     const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
     expect(JSON.parse(versionInfo.stdout)).toEqual({
-      version: '0.2.0',
+      version: '0.87.0-beta',
       contentIdentity: releases[0].slice(-16),
       installSource: {
         schemaVersion: 1,
         repository: 'TraderAlice/OpenAlice',
-        cliVersion: '0.2.0',
+        cliVersion: '0.87.0-beta',
         selector: { kind: 'version', value: 'test/ref' },
         installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/test/ref/install',
       },
@@ -165,6 +169,26 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     expect(result.stdout).toContain('Install plan')
     expect(result.stdout).toContain('Plan complete')
     await expect(access(installRoot)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects a payload that does not match the update manifest version', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-expected-version-'))
+    temporaryPaths.push(home)
+    await expect(execFileAsync('bash', [join(repositoryRoot, 'install'),
+      '--source', repositoryRoot,
+      '--install-dir', join(home, '.openalice'),
+      '--no-modify-path',
+      '--yes',
+    ], {
+      env: {
+        ...installerEnv(home),
+        OPENALICE_EXPECTED_CLI_VERSION: '999.0.0',
+      },
+    })).rejects.toMatchObject({
+      stderr: expect.stringContaining('instead of expected release 999.0.0'),
+    })
+    await expect(access(join(home, '.openalice', 'bin', 'openalice')))
+      .rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('requires explicit approval when no interactive terminal is available', async () => {

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -35,6 +35,7 @@ export function parseLocalStartArgs(argv) {
     prepare: true,
     rebuild: false,
     takeover: false,
+    checkUpdates: true,
     waitMs: 120_000,
   }
 
@@ -55,6 +56,10 @@ export function parseLocalStartArgs(argv) {
     }
     if (arg === '--takeover') {
       options.takeover = true
+      continue
+    }
+    if (arg === '--no-update-check') {
+      options.checkUpdates = false
       continue
     }
     if (arg === '--app-dir') {
@@ -302,6 +307,7 @@ Options:
   --rebuild          Reinstall dependencies and rebuild server artifacts
   --skip-prepare     Fail instead of installing/building missing artifacts
   --takeover         Replace the recorded local Guardian owner tree
+  --no-update-check  Skip the bounded stable-release update check
   --wait <seconds>   Readiness timeout, 1-600 (default: 120)
   --no-open          Print the URL without opening a browser
   -h, --help         Show this help

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -38,6 +38,7 @@ describe('OpenAlice local Runtime launcher', () => {
       prepare: true,
       rebuild: true,
       takeover: true,
+      checkUpdates: true,
       waitMs: 15_000,
     })
   })

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { readFileSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { PassThrough } from 'node:stream'
 
@@ -24,10 +25,13 @@ import {
   runSshCommand,
 } from './remote.mjs'
 
+const CLI_VERSION = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+).version
 const masterInstallSource = {
   schemaVersion: 1,
   repository: 'TraderAlice/OpenAlice',
-  cliVersion: '0.2.0',
+  cliVersion: CLI_VERSION,
   selector: { kind: 'branch', value: 'master' },
   installerUrl: 'https://openalice.ai/install',
 }
@@ -327,9 +331,9 @@ describe('OpenAlice managed remote connector', () => {
       expect(command).toContain("--home '/data/openalice'")
       return [
         'cli=/home/alice/.openalice/bin/openalice',
-        'version=0.2.0',
+        `version=${CLI_VERSION}`,
         'identity=' + JSON.stringify({
-          version: '0.2.0',
+          version: CLI_VERSION,
           installSource: masterInstallSource,
           contentIdentity: '1234567890abcdef',
         }),
@@ -346,7 +350,7 @@ describe('OpenAlice managed remote connector', () => {
     expect(runRemote).toHaveBeenCalledOnce()
     expect(remote).toEqual(expect.objectContaining({
       cliPath: '/home/alice/.openalice/bin/openalice',
-      cliVersion: '0.2.0',
+      cliVersion: CLI_VERSION,
       cliContentIdentity: '1234567890abcdef',
       cliCompatible: true,
       status: expect.objectContaining({ class: 'running' }),
@@ -711,7 +715,7 @@ function compatibleRemote(statusOverrides = {}) {
     sourceArtifactsReady: null,
     runtimeBuildToolsMissing: [],
     cliPath: '/home/alice/.openalice/bin/openalice',
-    cliVersion: '0.2.0',
+    cliVersion: CLI_VERSION,
     installSource: masterInstallSource,
     cliCompatible: true,
     status: {

--- a/packages/cli/src/uninstall.mjs
+++ b/packages/cli/src/uninstall.mjs
@@ -1,0 +1,214 @@
+import { lstat, readFile, rename, rm, rmdir, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { createInterface } from 'node:readline/promises'
+
+import { resolveInstalledLayout } from './install-layout.mjs'
+
+const BEGIN_MARKER = '# >>> OpenAlice CLI >>>'
+const END_MARKER = '# <<< OpenAlice CLI <<<'
+const LAUNCHERS = ['openalice', 'openalice.cmd', 'pi', 'pi.cmd']
+
+export function parseUninstallArgs(argv) {
+  const options = { planOnly: false, yes: false }
+  for (const arg of argv) {
+    if (arg === '--plan') options.planOnly = true
+    else if (arg === '--yes' || arg === '-y') options.yes = true
+    else throw new Error(`Unknown uninstall option: ${arg}`)
+  }
+  return options
+}
+
+export async function runUninstallCommand(argv, dependencies = {}) {
+  const options = parseUninstallArgs(argv)
+  const stdout = dependencies.stdout ?? process.stdout
+  const stdin = dependencies.stdin ?? process.stdin
+  const layout = Object.hasOwn(dependencies, 'layout')
+    ? dependencies.layout
+    : resolveInstalledLayout(import.meta.url)
+  if (!layout) {
+    throw new Error('This OpenAlice CLI is running from source, not an installed release.')
+  }
+
+  const profiles = dependencies.profiles ?? shellProfileCandidates(
+    dependencies.homeDir ?? homedir(),
+  )
+  printUninstallPlan(stdout, layout, profiles)
+  if (options.planOnly) {
+    stdout.write('\nPlan complete. No files were changed.\n')
+    return 0
+  }
+  if (!options.yes) {
+    const confirm = dependencies.confirm ?? confirmUninstall
+    if (!stdin.isTTY && !dependencies.confirm) {
+      throw new Error('No interactive terminal is available. Review "openalice uninstall --plan", then re-run with --yes.')
+    }
+    if (!await confirm({ stdin, stdout })) {
+      stdout.write('\nNo changes made.\n')
+      return 0
+    }
+  }
+
+  const uninstall = dependencies.uninstall ?? performUninstall
+  const result = await uninstall(layout, {
+    profiles,
+    processKill: dependencies.processKill,
+  })
+  stdout.write('\nOpenAlice CLI and managed Pi were removed.\n')
+  stdout.write(`Preserved application data and user work under ${layout.installRoot}.\n`)
+  if (result.profilesChanged.length > 0) {
+    stdout.write(`Removed managed PATH configuration from: ${result.profilesChanged.join(', ')}\n`)
+  }
+  return 0
+}
+
+export async function performUninstall(layout, options = {}) {
+  const processKill = options.processKill ?? process.kill
+  await assertNoLiveInstaller(layout.lockDir, processKill)
+
+  const profilesChanged = []
+  for (const profile of options.profiles ?? []) {
+    if (await removeManagedPathBlock(profile, layout.binDir)) profilesChanged.push(profile)
+  }
+
+  for (const launcher of LAUNCHERS) {
+    await rm(join(layout.binDir, launcher), { force: true })
+  }
+  await rm(layout.updateCachePath, { force: true })
+  await rm(layout.lockDir, { recursive: true, force: true })
+  await rm(layout.versionsDir, { recursive: true, force: true })
+  try {
+    await rmdir(layout.binDir)
+  } catch (error) {
+    if (!['ENOENT', 'ENOTEMPTY', 'EEXIST'].includes(error?.code)) throw error
+  }
+  return { profilesChanged }
+}
+
+export async function removeManagedPathBlock(profile, binDir, dependencies = {}) {
+  const readFileImpl = dependencies.readFileImpl ?? readFile
+  const writeFileImpl = dependencies.writeFileImpl ?? writeFile
+  let content
+  try {
+    content = await readFileImpl(profile, 'utf8')
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false
+    throw error
+  }
+  const cleaned = removeMatchingBlocks(content, binDir)
+  if (cleaned === content) return false
+
+  const lstatImpl = dependencies.lstatImpl ?? lstat
+  const status = await lstatImpl(profile)
+  if (status.isSymbolicLink()) {
+    await writeFileImpl(profile, cleaned)
+  } else {
+    const temporary = `${profile}.openalice-uninstall.${process.pid}`
+    await writeFileImpl(temporary, cleaned, { mode: status.mode })
+    await (dependencies.renameImpl ?? rename)(temporary, profile)
+  }
+  return true
+}
+
+export function removeMatchingBlocks(content, binDir) {
+  const lines = content.split(/(?<=\n)/)
+  const output = []
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].replace(/\r?\n$/, '') !== BEGIN_MARKER) {
+      output.push(lines[index])
+      continue
+    }
+    const block = [lines[index]]
+    let cursor = index + 1
+    while (cursor < lines.length) {
+      block.push(lines[cursor])
+      if (lines[cursor].replace(/\r?\n$/, '') === END_MARKER) break
+      cursor += 1
+    }
+    if (block.at(-1)?.replace(/\r?\n$/, '') !== END_MARKER) {
+      output.push(...block)
+      index = cursor
+      continue
+    }
+    if (!block.join('').includes(binDir)) output.push(...block)
+    index = cursor
+  }
+  return output.join('')
+}
+
+export function formatUninstallHelp() {
+  return `Usage:
+  openalice uninstall --plan
+  openalice uninstall [--yes]
+
+Removes the installed OpenAlice CLI, managed Pi, immutable CLI releases, and
+matching managed PATH blocks. It preserves OpenAlice data, Workspaces, source
+checkouts, credentials, keys, and the shared install root.
+
+Options:
+  --plan     Show exact ownership boundaries without changing files
+  -y, --yes  Approve uninstall non-interactively
+  -h, --help Show this help
+`
+}
+
+function printUninstallPlan(stdout, layout, profiles) {
+  stdout.write(`OpenAlice CLI uninstall plan
+
+Remove:
+  ${join(layout.binDir, 'openalice')} and .cmd launcher
+  ${join(layout.binDir, 'pi')} and .cmd launcher
+  ${layout.versionsDir}
+  ${layout.updateCachePath}
+  matching managed PATH blocks in ${profiles.join(', ')}
+
+Preserve:
+  ${join(layout.installRoot, 'data')}
+  ${join(layout.installRoot, 'workspaces')}
+  ${join(layout.installRoot, 'sources')}
+  ${join(layout.installRoot, 'provider-keys.json')}
+  ${join(layout.installRoot, 'sealing.key')}
+  ${layout.installRoot}
+`)
+}
+
+async function confirmUninstall({ stdin, stdout }) {
+  const prompt = createInterface({ input: stdin, output: stdout })
+  try {
+    const answer = await prompt.question('\nContinue with CLI uninstall? [y/N] ')
+    return /^y(?:es)?$/i.test(answer.trim())
+  } finally {
+    prompt.close()
+  }
+}
+
+async function assertNoLiveInstaller(lockDir, processKill) {
+  let pid
+  try {
+    pid = Number((await readFile(join(lockDir, 'pid'), 'utf8')).trim())
+  } catch (error) {
+    if (error?.code === 'ENOENT') return
+    throw error
+  }
+  if (!Number.isInteger(pid) || pid < 1) return
+  try {
+    processKill(pid, 0)
+    throw new Error(`Another OpenAlice CLI installer is running (pid ${pid}). Wait for it to finish before uninstalling.`)
+  } catch (error) {
+    if (error?.code === 'ESRCH') return
+    if (error?.code === 'EPERM') {
+      throw new Error(`OpenAlice cannot verify installer lock owner ${pid}; wait or inspect ${lockDir}.`)
+    }
+    throw error
+  }
+}
+
+function shellProfileCandidates(homeDir) {
+  return [
+    join(homeDir, '.zprofile'),
+    join(homeDir, '.zshrc'),
+    join(homeDir, '.bash_profile'),
+    join(homeDir, '.bashrc'),
+    join(homeDir, '.config', 'fish', 'config.fish'),
+  ]
+}

--- a/packages/cli/src/uninstall.spec.mjs
+++ b/packages/cli/src/uninstall.spec.mjs
@@ -1,0 +1,128 @@
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  performUninstall,
+  removeManagedPathBlock,
+  removeMatchingBlocks,
+  runUninstallCommand,
+} from './uninstall.mjs'
+
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('OpenAlice CLI uninstall', () => {
+  it('removes only the managed PATH block for this install root', () => {
+    const content = `before
+# >>> OpenAlice CLI >>>
+export PATH=/tmp/first/bin:$PATH
+# <<< OpenAlice CLI <<<
+middle
+# >>> OpenAlice CLI >>>
+export PATH=/tmp/second/bin:$PATH
+# <<< OpenAlice CLI <<<
+after
+`
+    expect(removeMatchingBlocks(content, '/tmp/first/bin')).toBe(`before
+middle
+# >>> OpenAlice CLI >>>
+export PATH=/tmp/second/bin:$PATH
+# <<< OpenAlice CLI <<<
+after
+`)
+  })
+
+  it('preserves a symlinked profile while removing its matching block', async () => {
+    const root = await makeTempDir()
+    const target = join(root, 'profile-target')
+    const profile = join(root, '.zprofile')
+    await writeFile(target, `keep\n# >>> OpenAlice CLI >>>\nexport PATH=/tmp/alice/bin:$PATH\n# <<< OpenAlice CLI <<<\n`)
+    await import('node:fs/promises').then(({ symlink }) => symlink(target, profile))
+    await expect(removeManagedPathBlock(profile, '/tmp/alice/bin')).resolves.toBe(true)
+    expect(await readFile(target, 'utf8')).toBe('keep\n')
+    expect((await import('node:fs/promises').then(({ lstat }) => lstat(profile))).isSymbolicLink()).toBe(true)
+  })
+
+  it('removes installer-owned files while preserving application state and sources', async () => {
+    const root = await makeTempDir()
+    const layout = await makeInstalledLayout(root)
+    const profile = join(root, '.zprofile')
+    await writeFile(profile, `# >>> OpenAlice CLI >>>\nexport PATH=${layout.binDir}:$PATH\n# <<< OpenAlice CLI <<<\n`)
+    await writeFile(join(layout.installRoot, 'data', 'state.json'), '{}')
+    await writeFile(join(layout.installRoot, 'workspaces', 'desk.txt'), 'desk')
+    await writeFile(join(layout.installRoot, 'sources', 'checkout.txt'), 'source')
+    await writeFile(join(layout.installRoot, 'provider-keys.json'), '{}')
+    await writeFile(join(layout.installRoot, 'sealing.key'), 'secret')
+
+    await expect(performUninstall(layout, { profiles: [profile] })).resolves.toEqual({
+      profilesChanged: [profile],
+    })
+    await expect(access(layout.versionsDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(access(join(layout.binDir, 'openalice'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(join(layout.installRoot, 'data', 'state.json'), 'utf8')).resolves.toBe('{}')
+    await expect(readFile(join(layout.installRoot, 'workspaces', 'desk.txt'), 'utf8')).resolves.toBe('desk')
+    await expect(readFile(join(layout.installRoot, 'sources', 'checkout.txt'), 'utf8')).resolves.toBe('source')
+    await expect(readFile(join(layout.installRoot, 'provider-keys.json'), 'utf8')).resolves.toBe('{}')
+    await expect(readFile(join(layout.installRoot, 'sealing.key'), 'utf8')).resolves.toBe('secret')
+    await expect(readFile(profile, 'utf8')).resolves.toBe('')
+  })
+
+  it('shows a non-mutating plan with explicit preserved paths', async () => {
+    const root = await makeTempDir()
+    const layout = await makeInstalledLayout(root)
+    const output = []
+    await expect(runUninstallCommand(['--plan'], {
+      layout,
+      profiles: [],
+      stdout: { write: (value) => output.push(value) },
+    })).resolves.toBe(0)
+    expect(output.join('')).toContain(join(layout.installRoot, 'workspaces'))
+    await expect(access(layout.versionsDir)).resolves.toBeUndefined()
+  })
+
+  it('refuses to race a live installer', async () => {
+    const root = await makeTempDir()
+    const layout = await makeInstalledLayout(root)
+    await mkdir(layout.lockDir, { recursive: true })
+    await writeFile(join(layout.lockDir, 'pid'), '42\n')
+    await expect(performUninstall(layout, {
+      profiles: [],
+      processKill: () => undefined,
+    })).rejects.toThrow('installer is running')
+    await expect(access(layout.versionsDir)).resolves.toBeUndefined()
+  })
+})
+
+async function makeTempDir() {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-uninstall-'))
+  temporaryPaths.push(root)
+  return root
+}
+
+async function makeInstalledLayout(root) {
+  const installRoot = join(root, '.openalice')
+  const layout = {
+    installRoot,
+    versionsDir: join(installRoot, 'cli-versions'),
+    releaseDir: join(installRoot, 'cli-versions', 'master-0123456789abcdef'),
+    binDir: join(installRoot, 'bin'),
+    lockDir: join(installRoot, '.cli-install.lock'),
+    updateCachePath: join(installRoot, '.cli-update-check.json'),
+  }
+  await mkdir(layout.releaseDir, { recursive: true })
+  await mkdir(layout.binDir, { recursive: true })
+  await mkdir(join(installRoot, 'data'), { recursive: true })
+  await mkdir(join(installRoot, 'workspaces'), { recursive: true })
+  await mkdir(join(installRoot, 'sources'), { recursive: true })
+  for (const launcher of ['openalice', 'openalice.cmd', 'pi', 'pi.cmd']) {
+    await writeFile(join(layout.binDir, launcher), launcher)
+  }
+  await writeFile(layout.updateCachePath, '{}')
+  return layout
+}

--- a/packages/cli/src/update.mjs
+++ b/packages/cli/src/update.mjs
@@ -1,0 +1,406 @@
+import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { resolveInstalledLayout } from './install-layout.mjs'
+import { readInstallSource } from './install-source.mjs'
+
+const CURRENT_VERSION = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+).version
+const DEFAULT_MANIFEST_URL = 'https://download.openalice.ai/manifest.json'
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1_000
+const CHECK_TIMEOUT_MS = 1_500
+const EXPLICIT_CHECK_TIMEOUT_MS = 10_000
+const INSTALLER_DOWNLOAD_TIMEOUT_MS = 30_000
+
+export function parseUpdateArgs(argv) {
+  const options = { checkOnly: false, yes: false, json: false }
+  for (const arg of argv) {
+    if (arg === '--check') options.checkOnly = true
+    else if (arg === '--yes' || arg === '-y') options.yes = true
+    else if (arg === '--json') options.json = true
+    else throw new Error(`Unknown update option: ${arg}`)
+  }
+  if (options.json && !options.checkOnly) {
+    throw new Error('--json requires --check')
+  }
+  return options
+}
+
+export async function checkForUpdate(options = {}, dependencies = {}) {
+  const currentVersion = options.currentVersion ?? CURRENT_VERSION
+  const installSource = options.installSource ?? await (
+    dependencies.readInstallSourceImpl ?? readInstallSource
+  )()
+  const channel = updateChannel(installSource)
+  if (channel !== 'stable') {
+    return {
+      status: 'unsupported',
+      currentVersion,
+      channel,
+      message: unsupportedChannelMessage(installSource, channel),
+    }
+  }
+
+  const manifest = await fetchReleaseManifest({
+    manifestUrl: options.manifestUrl
+      ?? dependencies.env?.['OPENALICE_UPDATE_MANIFEST_URL']
+      ?? process.env['OPENALICE_UPDATE_MANIFEST_URL']
+      ?? DEFAULT_MANIFEST_URL,
+    timeoutMs: options.timeoutMs ?? EXPLICIT_CHECK_TIMEOUT_MS,
+  }, dependencies)
+  const comparison = compareVersions(manifest.version, currentVersion)
+  return {
+    status: comparison > 0 ? 'available' : 'current',
+    currentVersion,
+    latestVersion: manifest.version,
+    releaseNotesUrl: manifest.releaseNotesUrl,
+    installer: manifest.installer,
+    channel,
+  }
+}
+
+export async function runUpdateCommand(argv, dependencies = {}) {
+  const options = parseUpdateArgs(argv)
+  const stdout = dependencies.stdout ?? process.stdout
+  let result
+  try {
+    result = await checkForUpdate({}, dependencies)
+  } catch (error) {
+    throw new Error(`Could not check for OpenAlice updates: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  if (options.json) {
+    stdout.write(`${JSON.stringify(result)}\n`)
+    return 0
+  }
+  if (result.status === 'unsupported') {
+    stdout.write(`${result.message}\n`)
+    return 0
+  }
+  if (result.status === 'current') {
+    stdout.write(`OpenAlice ${result.currentVersion} is current.\n`)
+    return 0
+  }
+
+  stdout.write(`OpenAlice ${result.latestVersion} is available (current ${result.currentVersion}).\n`)
+  if (result.releaseNotesUrl) stdout.write(`Release notes: ${result.releaseNotesUrl}\n`)
+  if (options.checkOnly) {
+    stdout.write('Run "openalice update" to review and install it.\n')
+    return 0
+  }
+
+  const layout = Object.hasOwn(dependencies, 'layout')
+    ? dependencies.layout
+    : resolveInstalledLayout(import.meta.url)
+  if (!layout) {
+    throw new Error('This OpenAlice CLI is running from source, not an installed release. Re-run the public installer to update the installed command.')
+  }
+  const applyUpdate = dependencies.applyUpdate ?? downloadAndRunInstaller
+  return await applyUpdate(result, {
+    layout,
+    yes: options.yes,
+    env: dependencies.env ?? process.env,
+    fetchImpl: dependencies.fetchImpl,
+    spawnImpl: dependencies.spawnImpl,
+  })
+}
+
+export async function maybeNotifyUpdate(options = {}, dependencies = {}) {
+  const env = dependencies.env ?? process.env
+  const stderr = dependencies.stderr ?? process.stderr
+  const interactive = dependencies.interactive ?? Boolean(stderr.isTTY)
+  if (
+    options.enabled === false
+    || !interactive
+    || env['OPENALICE_NO_UPDATE_CHECK'] === '1'
+    || env['CI']
+  ) {
+    return null
+  }
+
+  const layout = Object.hasOwn(dependencies, 'layout')
+    ? dependencies.layout
+    : resolveInstalledLayout(import.meta.url)
+  if (!layout) return null
+
+  const readFileImpl = dependencies.readFileImpl ?? readFile
+  const writeFileImpl = dependencies.writeFileImpl ?? writeFile
+  const now = dependencies.now?.() ?? Date.now()
+  let cache = await readUpdateCache(layout.updateCachePath, readFileImpl)
+  let result = cachedResult(cache, now)
+
+  if (!result) {
+    try {
+      result = await checkForUpdate({ timeoutMs: CHECK_TIMEOUT_MS }, dependencies)
+      cache = {
+        schemaVersion: 1,
+        checkedAt: new Date(now).toISOString(),
+        result,
+        notifiedAt: cache?.notifiedAt ?? null,
+        notifiedVersion: cache?.notifiedVersion ?? null,
+      }
+    } catch {
+      cache = {
+        schemaVersion: 1,
+        checkedAt: new Date(now).toISOString(),
+        result: null,
+        notifiedAt: cache?.notifiedAt ?? null,
+        notifiedVersion: cache?.notifiedVersion ?? null,
+      }
+      await writeCacheBestEffort(layout.updateCachePath, cache, writeFileImpl)
+      return null
+    }
+  }
+
+  if (result.status !== 'available') {
+    await writeCacheBestEffort(layout.updateCachePath, cache, writeFileImpl)
+    return result
+  }
+  const lastNotified = Date.parse(cache?.notifiedAt ?? '')
+  const alreadyRecent = cache?.notifiedVersion === result.latestVersion
+    && Number.isFinite(lastNotified)
+    && now - lastNotified < CHECK_INTERVAL_MS
+  if (!alreadyRecent) {
+    stderr.write(
+      `\nOpenAlice ${result.latestVersion} is available (current ${result.currentVersion}). `
+      + 'Run "openalice update" to review and install it.\n\n',
+    )
+    cache.notifiedAt = new Date(now).toISOString()
+    cache.notifiedVersion = result.latestVersion
+  }
+  await writeCacheBestEffort(layout.updateCachePath, cache, writeFileImpl)
+  return result
+}
+
+export function compareVersions(left, right) {
+  const parsedLeft = parseVersion(left)
+  const parsedRight = parseVersion(right)
+  for (let index = 0; index < 3; index += 1) {
+    if (parsedLeft.core[index] !== parsedRight.core[index]) {
+      return parsedLeft.core[index] > parsedRight.core[index] ? 1 : -1
+    }
+  }
+  return comparePrerelease(parsedLeft.prerelease, parsedRight.prerelease)
+}
+
+export function formatUpdateHelp() {
+  return `Usage:
+  openalice update --check [--json]
+  openalice update [--yes]
+
+Checks the stable release manifest. Applying an update downloads the
+release-owned installer, verifies its SHA-256, and runs the ordinary atomic
+installer transaction for this install root.
+
+Options:
+  --check    Check and report without changing files
+  --json     Print machine-readable check output (requires --check)
+  -y, --yes  Approve the installer plan non-interactively
+  -h, --help Show this help
+`
+}
+
+async function fetchReleaseManifest(options, dependencies) {
+  const fetchImpl = dependencies.fetchImpl ?? fetch
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs)
+  timeout.unref?.()
+  try {
+    const response = await fetchImpl(options.manifestUrl, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    })
+    if (!response.ok) throw new Error(`release manifest returned HTTP ${response.status}`)
+    return requireReleaseManifest(await response.json())
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function requireReleaseManifest(value) {
+  const installer = value?.installer
+  if (
+    !value
+    || typeof value.version !== 'string'
+    || !isVersion(value.version)
+    || typeof value.releaseNotesUrl !== 'string'
+    || !isHttpUrl(value.releaseNotesUrl)
+    || !installer
+    || typeof installer.url !== 'string'
+    || !isHttpUrl(installer.url)
+    || typeof installer.versionedUrl !== 'string'
+    || !isHttpUrl(installer.versionedUrl)
+    || typeof installer.sha256 !== 'string'
+    || !/^[a-f0-9]{64}$/.test(installer.sha256)
+  ) {
+    throw new Error('release manifest does not contain a valid CLI installer')
+  }
+  return {
+    version: value.version,
+    releaseNotesUrl: value.releaseNotesUrl,
+    installer: {
+      url: installer.url,
+      versionedUrl: installer.versionedUrl,
+      sha256: installer.sha256,
+    },
+  }
+}
+
+export async function downloadAndRunInstaller(result, context) {
+  const fetchImpl = context.fetchImpl ?? fetch
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), INSTALLER_DOWNLOAD_TIMEOUT_MS)
+  timeout.unref?.()
+  let bytes
+  try {
+    const response = await fetchImpl(result.installer.versionedUrl, {
+      signal: controller.signal,
+      headers: { accept: 'text/plain' },
+    })
+    if (!response.ok) throw new Error(`installer download returned HTTP ${response.status}`)
+    bytes = Buffer.from(await response.arrayBuffer())
+  } finally {
+    clearTimeout(timeout)
+  }
+  const digest = createHash('sha256').update(bytes).digest('hex')
+  if (digest !== result.installer.sha256) {
+    throw new Error('downloaded installer failed SHA-256 verification')
+  }
+  if (!bytes.toString('utf8', 0, 64).startsWith('#!/usr/bin/env bash')) {
+    throw new Error('downloaded installer is not the OpenAlice Bash installer')
+  }
+
+  const temporary = await mkdtemp(join(tmpdir(), 'openalice-update-'))
+  const installerPath = join(temporary, 'install')
+  try {
+    await writeFile(installerPath, bytes, { mode: 0o700 })
+    await chmod(installerPath, 0o700)
+    const args = [
+      installerPath,
+      '--install-dir', context.layout.installRoot,
+      '--no-modify-path',
+      ...(context.yes ? ['--yes'] : []),
+    ]
+    return await runProcess(context.spawnImpl ?? spawn, 'bash', args, {
+      stdio: 'inherit',
+      env: {
+        ...context.env,
+        OPENALICE_EXPECTED_CLI_VERSION: result.latestVersion,
+      },
+    })
+  } finally {
+    await rm(temporary, { recursive: true, force: true })
+  }
+}
+
+function runProcess(spawnImpl, command, args, options) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawnImpl(command, args, options)
+    child.once('error', rejectPromise)
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolvePromise(0)
+      else rejectPromise(new Error(`installer exited with code=${String(code)}, signal=${String(signal)}`))
+    })
+  })
+}
+
+function updateChannel(source) {
+  if (source?.selector?.kind === 'version') return 'pinned'
+  if (
+    source?.selector?.kind === 'branch'
+    && source.selector.value === 'master'
+    && source.installerUrl === 'https://openalice.ai/install'
+  ) {
+    return 'stable'
+  }
+  if (source?.selector?.kind === 'branch' && source.selector.value === 'master') return 'custom'
+  return 'development'
+}
+
+function unsupportedChannelMessage(source, channel) {
+  if (channel === 'pinned') {
+    return `This CLI is pinned to ${source.selector.value}; automatic stable-channel updates are disabled. Re-run the installer with a different selector to change channels.`
+  }
+  if (channel === 'custom') {
+    return `This CLI was installed from ${source.installerUrl}; public stable-channel updates are disabled for custom installers. Use that installer to update without crossing trust boundaries.`
+  }
+  return `This CLI follows branch ${source?.selector?.value ?? 'unknown'}; stable release update checks are disabled for development channels. Re-run that branch's installer to refresh it.`
+}
+
+function parseVersion(value) {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(value)
+  if (!match) throw new Error(`Invalid OpenAlice version: ${value}`)
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4]?.split('.') ?? [],
+  }
+}
+
+function isVersion(value) {
+  try {
+    parseVersion(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function comparePrerelease(left, right) {
+  if (left.length === 0 && right.length === 0) return 0
+  if (left.length === 0) return 1
+  if (right.length === 0) return -1
+  const length = Math.max(left.length, right.length)
+  for (let index = 0; index < length; index += 1) {
+    if (left[index] === undefined) return -1
+    if (right[index] === undefined) return 1
+    if (left[index] === right[index]) continue
+    const leftNumeric = /^\d+$/.test(left[index])
+    const rightNumeric = /^\d+$/.test(right[index])
+    if (leftNumeric && rightNumeric) return Number(left[index]) > Number(right[index]) ? 1 : -1
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1
+    return left[index] > right[index] ? 1 : -1
+  }
+  return 0
+}
+
+function cachedResult(cache, now) {
+  const checkedAt = Date.parse(cache?.checkedAt ?? '')
+  if (
+    cache?.schemaVersion !== 1
+    || !Number.isFinite(checkedAt)
+    || now - checkedAt >= CHECK_INTERVAL_MS
+  ) {
+    return null
+  }
+  return cache.result ?? null
+}
+
+async function readUpdateCache(path, readFileImpl) {
+  try {
+    return JSON.parse(await readFileImpl(path, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+async function writeCacheBestEffort(path, value, writeFileImpl) {
+  try {
+    await writeFileImpl(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  } catch {
+    // Update discovery must never block OpenAlice startup.
+  }
+}
+
+function isHttpUrl(value) {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}

--- a/packages/cli/src/update.spec.mjs
+++ b/packages/cli/src/update.spec.mjs
@@ -1,0 +1,218 @@
+import { createHash } from 'node:crypto'
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  checkForUpdate,
+  compareVersions,
+  downloadAndRunInstaller,
+  maybeNotifyUpdate,
+  parseUpdateArgs,
+  runUpdateCommand,
+} from './update.mjs'
+
+const stableSource = {
+  schemaVersion: 1,
+  repository: 'TraderAlice/OpenAlice',
+  cliVersion: '0.87.0-beta',
+  selector: { kind: 'branch', value: 'master' },
+  installerUrl: 'https://openalice.ai/install',
+}
+
+describe('OpenAlice CLI updates', () => {
+  it('compares product release and prerelease versions', () => {
+    expect(compareVersions('0.88.0-beta', '0.87.0-beta')).toBe(1)
+    expect(compareVersions('0.87.0', '0.87.0-beta')).toBe(1)
+    expect(compareVersions('0.87.0-beta.2', '0.87.0-beta.1')).toBe(1)
+    expect(compareVersions('0.87.0-beta', '0.87.0-beta')).toBe(0)
+    expect(compareVersions('0.86.0', '0.87.0-beta')).toBe(-1)
+  })
+
+  it('requires JSON update output to be a read-only check', () => {
+    expect(parseUpdateArgs(['--check', '--json'])).toEqual({
+      checkOnly: true,
+      yes: false,
+      json: true,
+    })
+    expect(() => parseUpdateArgs(['--json'])).toThrow('--json requires --check')
+  })
+
+  it('reports a newer stable product release from the download manifest', async () => {
+    const result = await checkForUpdate({
+      currentVersion: '0.87.0-beta',
+      installSource: stableSource,
+    }, {
+      fetchImpl: manifestFetch('0.88.0-beta'),
+      env: {},
+    })
+    expect(result).toMatchObject({
+      status: 'available',
+      currentVersion: '0.87.0-beta',
+      latestVersion: '0.88.0-beta',
+      channel: 'stable',
+    })
+  })
+
+  it('keeps exact refs and development branches outside stable auto-update', async () => {
+    await expect(checkForUpdate({
+      installSource: {
+        ...stableSource,
+        selector: { kind: 'version', value: 'v0.87.0-beta' },
+      },
+    })).resolves.toMatchObject({ status: 'unsupported', channel: 'pinned' })
+    await expect(checkForUpdate({
+      installSource: {
+        ...stableSource,
+        selector: { kind: 'branch', value: 'dev' },
+      },
+    })).resolves.toMatchObject({ status: 'unsupported', channel: 'development' })
+    await expect(checkForUpdate({
+      installSource: {
+        ...stableSource,
+        installerUrl: 'https://mirror.example.test/install',
+      },
+    })).resolves.toMatchObject({ status: 'unsupported', channel: 'custom' })
+  })
+
+  it('uses the ordinary installer only after an explicit update command', async () => {
+    const applyUpdate = vi.fn(async () => 0)
+    const stdout = { write: vi.fn() }
+    await expect(runUpdateCommand(['--yes'], {
+      applyUpdate,
+      fetchImpl: manifestFetch('0.88.0-beta'),
+      layout: { installRoot: '/tmp/.openalice' },
+      readInstallSourceImpl: async () => stableSource,
+      stdout,
+      env: {},
+    })).resolves.toBe(0)
+    expect(applyUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ latestVersion: '0.88.0-beta' }),
+      expect.objectContaining({
+        layout: { installRoot: '/tmp/.openalice' },
+        yes: true,
+      }),
+    )
+  })
+
+  it('verifies the versioned installer and binds it to the manifest version', async () => {
+    const bytes = Buffer.from('#!/usr/bin/env bash\nexit 0\n')
+    let invocation
+    const spawnImpl = (command, args, options) => {
+      invocation = { command, args, options }
+      const child = new EventEmitter()
+      queueMicrotask(() => child.emit('exit', 0, null))
+      return child
+    }
+    await expect(downloadAndRunInstaller({
+      latestVersion: '0.88.0-beta',
+      installer: {
+        versionedUrl: 'https://download.openalice.ai/OpenAlice-0.88.0-beta-install',
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+      },
+    }, {
+      layout: { installRoot: '/tmp/.openalice' },
+      yes: true,
+      env: { PATH: '/bin' },
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => bytes,
+      }),
+      spawnImpl,
+    })).resolves.toBe(0)
+    expect(invocation).toMatchObject({
+      command: 'bash',
+      args: expect.arrayContaining([
+        '--install-dir', '/tmp/.openalice', '--no-modify-path', '--yes',
+      ]),
+      options: {
+        stdio: 'inherit',
+        env: expect.objectContaining({
+          OPENALICE_EXPECTED_CLI_VERSION: '0.88.0-beta',
+        }),
+      },
+    })
+  })
+
+  it('never executes an installer whose release checksum differs', async () => {
+    const spawnImpl = vi.fn()
+    await expect(downloadAndRunInstaller({
+      latestVersion: '0.88.0-beta',
+      installer: {
+        versionedUrl: 'https://download.openalice.ai/OpenAlice-0.88.0-beta-install',
+        sha256: '0'.repeat(64),
+      },
+    }, {
+      layout: { installRoot: '/tmp/.openalice' },
+      yes: false,
+      env: {},
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => Buffer.from('#!/usr/bin/env bash\n'),
+      }),
+      spawnImpl,
+    })).rejects.toThrow('SHA-256')
+    expect(spawnImpl).not.toHaveBeenCalled()
+  })
+
+  it('checks silently on startup and emits at most one notice per day', async () => {
+    let cache = null
+    const stderr = { isTTY: true, write: vi.fn() }
+    const dependencies = {
+      interactive: true,
+      layout: { updateCachePath: '/tmp/update-cache.json' },
+      readFileImpl: async () => {
+        if (cache == null) {
+          const error = new Error('missing')
+          error.code = 'ENOENT'
+          throw error
+        }
+        return cache
+      },
+      writeFileImpl: async (_path, value) => { cache = value },
+      readInstallSourceImpl: async () => stableSource,
+      fetchImpl: manifestFetch('0.88.0-beta'),
+      stderr,
+      env: {},
+      now: () => Date.parse('2026-07-29T00:00:00.000Z'),
+    }
+    await maybeNotifyUpdate({}, dependencies)
+    await maybeNotifyUpdate({}, dependencies)
+    expect(stderr.write).toHaveBeenCalledTimes(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringContaining('openalice update'))
+  })
+
+  it('does not make startup depend on release-check availability', async () => {
+    const stderr = { isTTY: true, write: vi.fn() }
+    await expect(maybeNotifyUpdate({}, {
+      interactive: true,
+      layout: { updateCachePath: '/tmp/update-cache.json' },
+      readFileImpl: async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }) },
+      writeFileImpl: async () => undefined,
+      readInstallSourceImpl: async () => stableSource,
+      fetchImpl: async () => { throw new Error('offline') },
+      stderr,
+      env: {},
+    })).resolves.toBeNull()
+    expect(stderr.write).not.toHaveBeenCalled()
+  })
+})
+
+function manifestFetch(version) {
+  const installer = '#!/usr/bin/env bash\n'
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      version,
+      releaseNotesUrl: `https://github.com/TraderAlice/OpenAlice/releases/tag/v${version}`,
+      installer: {
+        url: 'https://download.openalice.ai/install',
+        versionedUrl: `https://download.openalice.ai/OpenAlice-${version}-install`,
+        sha256: createHash('sha256').update(installer).digest('hex'),
+      },
+    }),
+  }))
+}

--- a/plans/cli-lifecycle-quality.md
+++ b/plans/cli-lifecycle-quality.md
@@ -1,8 +1,8 @@
 # CLI Lifecycle Quality
 
-Status: Active
+Status: Complete
 
-Related issues: None
+Related PR: #847
 
 Owner guides:
 
@@ -44,7 +44,7 @@ Workspace template upgrades are out of scope.
 - [x] Align CLI and root versions and enforce the invariant in tests/release.
 - [x] Extend the distributed payload, installer acceptance, and owner guide.
 - [x] Run required repository, CLI, Docker, and real installer-path checks.
-- [ ] Publish and merge a serial PR into `dev`.
+- [x] Publish the completed serial change through PR #847 targeting `dev`.
 
 ## Verification
 

--- a/plans/cli-lifecycle-quality.md
+++ b/plans/cli-lifecycle-quality.md
@@ -1,0 +1,64 @@
+# CLI Lifecycle Quality
+
+Status: Active
+
+Related issues: None
+
+Owner guides:
+
+- [[docs/cli-installer.md]]
+- [[docs/local-runtime.md]]
+- [[docs/development-workflow.md]]
+
+## Scope
+
+Make the computer-level `openalice` CLI share the OpenAlice product version,
+notify interactive stable-channel users when a newer release exists, provide a
+safe installer-backed update command, and provide a CLI-only uninstall that
+preserves every application-state and user-work path.
+
+Workspace-injected CLIs, Electron auto-update, source-checkout updates, and
+Workspace template upgrades are out of scope.
+
+## Decisions
+
+- `packages/cli/package.json#version` must equal the root product version.
+- Stable installed CLIs check the release download manifest on an interactive
+  local start, with a short timeout, a daily cache, and an explicit opt-out.
+- Automatic checks only notify. `openalice update` delegates mutation to the
+  ordinary installer and preserves its visible plan and consent contract.
+- Exact tag/commit installs remain pinned. Development-channel installs do not
+  claim stable release update semantics.
+- Update downloads the release-owned installer, verifies its manifest SHA-256,
+  and then runs the normal transaction against the detected install root.
+- Uninstall removes only installer-owned launchers, immutable CLI releases,
+  installer locks/cache, and matching managed PATH blocks. It never removes
+  application data, Workspaces, sources, credentials, sealing keys, or the
+  shared install root.
+
+## Work
+
+- [x] Add installed-layout discovery and release-version comparison.
+- [x] Add `openalice update`, explicit update checking, and daily start notice.
+- [x] Add `openalice uninstall` with plan, consent, lock safety, and PATH cleanup.
+- [x] Align CLI and root versions and enforce the invariant in tests/release.
+- [x] Extend the distributed payload, installer acceptance, and owner guide.
+- [x] Run required repository, CLI, Docker, and real installer-path checks.
+- [ ] Publish and merge a serial PR into `dev`.
+
+## Verification
+
+- `bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh scripts/install-channel-smoke/run.sh`
+- `pnpm -F @traderalice/openalice-cli test`
+- `pnpm test:install:docker`
+- `npx tsc --noEmit`
+- `pnpm test`
+- installed `openalice update --check`
+- isolated installed `openalice uninstall --plan` and `openalice uninstall --yes`
+
+## Completion
+
+The installed CLI reports the product version, stable users receive a bounded
+non-blocking update notice, confirmed updates reuse the ordinary atomic
+installer, confirmed uninstall removes only installer-owned files, and all
+documented verification passes.

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -53,6 +53,7 @@ curl --fail --silent --output /dev/null "$installer_url" || {
 }
 
 export OPENALICE_INSTALL_BASE_URL="http://127.0.0.1:18080/packages/cli/"
+cli_version="$(node -p "require('/fixture/packages/cli/package.json').version")"
 
 default_plan="$(curl -fsSL "$installer_url" | bash -s -- --plan)"
 grep -Fq "Branch         master" <<<"$default_plan" || fail "installer did not default to master"
@@ -86,15 +87,16 @@ install_branch smoke-v1
 
 bin_dir="$HOME/.openalice/bin"
 versions_dir="$HOME/.openalice/cli-versions"
-[[ "$($bin_dir/openalice --version)" == "0.2.0" ]] || fail "installed CLI version check failed"
+[[ "$($bin_dir/openalice --version)" == "$cli_version" ]] || fail "installed CLI version check failed"
 install_source="$($bin_dir/openalice version --json)"
 node -e '
 const value = JSON.parse(process.argv[1]);
-if (value.version !== "0.2.0") process.exit(1);
-if (value.installSource?.cliVersion !== "0.2.0") process.exit(1);
+const expectedVersion = process.argv[2];
+if (value.version !== expectedVersion) process.exit(1);
+if (value.installSource?.cliVersion !== expectedVersion) process.exit(1);
 if (value.installSource?.selector?.kind !== "branch" || value.installSource?.selector?.value !== "smoke-v1") process.exit(1);
 if (value.installSource?.installerUrl !== "http://127.0.0.1:18080/install") process.exit(1);
-' "$install_source" || fail "installed CLI did not preserve its install source"
+' "$install_source" "$cli_version" || fail "installed CLI did not preserve its install source"
 [[ "$($bin_dir/pi --version)" == "0.80.6" ]] || fail "installed managed Pi version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"
 server_status="$($bin_dir/openalice server status --home "$HOME/openalice-server-smoke" --json)"
@@ -116,6 +118,8 @@ cmp /fixture/packages/cli/src/local-start.mjs "$v1_release/src/local-start.mjs" 
   || fail "downloaded CLI file differs from the fixture"
 cmp /fixture/packages/cli/src/install-source.mjs "$v1_release/src/install-source.mjs" \
   || fail "downloaded install-source module differs from the fixture"
+cmp /fixture/packages/cli/src/install-layout.mjs "$v1_release/src/install-layout.mjs" \
+  || fail "downloaded install-layout module differs from the fixture"
 cmp /fixture/packages/cli/src/remote.mjs "$v1_release/src/remote.mjs" \
   || fail "downloaded Remote CLI file differs from the fixture"
 cmp /fixture/packages/cli/src/runtime-deps.mjs "$v1_release/src/runtime-deps.mjs" \
@@ -124,6 +128,10 @@ cmp /fixture/packages/cli/src/server.mjs "$v1_release/src/server.mjs" \
   || fail "downloaded Server CLI file differs from the fixture"
 cmp /fixture/packages/cli/src/server-control.mjs "$v1_release/src/server-control.mjs" \
   || fail "downloaded Server control file differs from the fixture"
+cmp /fixture/packages/cli/src/update.mjs "$v1_release/src/update.mjs" \
+  || fail "downloaded update module differs from the fixture"
+cmp /fixture/packages/cli/src/uninstall.mjs "$v1_release/src/uninstall.mjs" \
+  || fail "downloaded uninstall module differs from the fixture"
 
 expected_path_line="export PATH=$HOME/.openalice/bin:\$PATH"
 path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
@@ -151,6 +159,10 @@ path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"
 v1_count="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v1-*' | wc -l | tr -d ' ')"
 [[ "$v1_count" == "1" ]] || fail "repeat install duplicated an identical CLI release"
 
+update_check="$("$bin_dir/openalice" update --check)"
+grep -Fq "stable release update checks are disabled" <<<"$update_check" \
+  || fail "development-channel CLI did not explain its update policy"
+
 curl -fsSL "$installer_url" | bash -s -- --yes --version smoke-v2
 v2_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v2-*' -print -quit)"
 [[ -d "$v1_release" ]] || fail "version switch removed the previous CLI"
@@ -159,9 +171,29 @@ version_count="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d | wc -l | 
 [[ "$version_count" == "2" ]] || fail "unexpected number of installed CLI versions: $version_count"
 grep -Fq "$v2_release/bin/openalice.mjs" "$bin_dir/openalice" \
   || fail "stable launcher did not switch to the latest install"
-[[ "$($bin_dir/openalice --version)" == "0.2.0" ]] || fail "switched CLI is not runnable"
+[[ "$($bin_dir/openalice --version)" == "$cli_version" ]] || fail "switched CLI is not runnable"
 
 grep -Fq "GET /packages/cli/package.json" "$server_log" \
   || fail "installer did not exercise the HTTP download branch"
+
+mkdir -p "$HOME/.openalice/data" "$HOME/.openalice/workspaces" "$HOME/.openalice/sources"
+printf 'state\n' > "$HOME/.openalice/data/preserved"
+printf 'desk\n' > "$HOME/.openalice/workspaces/preserved"
+printf 'checkout\n' > "$HOME/.openalice/sources/preserved"
+printf 'keys\n' > "$HOME/.openalice/provider-keys.json"
+printf 'seal\n' > "$HOME/.openalice/sealing.key"
+uninstall_plan="$("$bin_dir/openalice" uninstall --plan)"
+grep -Fq "$HOME/.openalice/workspaces" <<<"$uninstall_plan" \
+  || fail "uninstall plan did not name preserved Workspaces"
+"$bin_dir/openalice" uninstall --yes
+[[ ! -e "$bin_dir/openalice" ]] || fail "uninstall left the OpenAlice launcher"
+[[ ! -e "$versions_dir" ]] || fail "uninstall left immutable CLI releases"
+[[ -f "$HOME/.openalice/data/preserved" ]] || fail "uninstall removed application data"
+[[ -f "$HOME/.openalice/workspaces/preserved" ]] || fail "uninstall removed Workspaces"
+[[ -f "$HOME/.openalice/sources/preserved" ]] || fail "uninstall removed source checkouts"
+[[ -f "$HOME/.openalice/provider-keys.json" ]] || fail "uninstall removed provider credentials"
+[[ -f "$HOME/.openalice/sealing.key" ]] || fail "uninstall removed the sealing key"
+[[ "$(grep -Fxc '# >>> OpenAlice CLI >>>' "$HOME/.bashrc" || true)" == "0" ]] \
+  || fail "uninstall left the managed PATH block"
 
 echo "[install-docker-smoke] passed"


### PR DESCRIPTION
## What changed

- align the installed `openalice` CLI version with the OpenAlice product version and enforce the invariant in tests and release preflight
- add bounded, daily-cached stable release notices plus `openalice update --check` and installer-backed `openalice update`
- verify the release-owned versioned installer SHA-256 and expected product version before publishing an update
- add consent-first `openalice uninstall` that removes only CLI/Pi assets and matching PATH blocks while preserving application state, Workspaces, sources, credentials, and keys
- extend the distributed payload, owner guides, unit coverage, and clean-host installer smoke

## User impact

Stable interactive local starts now surface a newer OpenAlice release without blocking startup. Users can review and install updates through the ordinary atomic installer, and can remove the computer-level CLI without risking the shared `~/.openalice` data root. Pinned refs, dev branches, and custom mirrors do not silently cross update channels.

## Validation

- `npx tsc --noEmit`
- `pnpm -F @traderalice/openalice-cli test` (98 passed)
- `pnpm test` (3536 passed, 9 skipped)
- `bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh scripts/install-channel-smoke/run.sh`
- `pnpm test:install:docker`
- real public `openalice update --check --json` manifest path
- interactive default-no and confirmed uninstall review with isolated data