### PR TITLE
Name Market Data provider controls by provider

### DIFF
--- a/ui/src/pages/MarketDataPage.spec.tsx
+++ b/ui/src/pages/MarketDataPage.spec.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MarketDataPage } from './MarketDataPage'
+
+const mocks = vi.hoisted(() => ({
+  hubStatus: vi.fn(),
+  testProvider: vi.fn(),
+  updateConfig: vi.fn(),
+  updateConfigImmediate: vi.fn(),
+  retry: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    marketData: {
+      hubStatus: mocks.hubStatus,
+      testProvider: mocks.testProvider,
+    },
+  },
+}))
+
+vi.mock('../hooks/useConfigPage', () => ({
+  useConfigPage: () => ({
+    config: {
+      enabled: true,
+      hub: { enabled: false, baseUrl: 'https://traderhub.openalice.ai' },
+      extraVendors: [],
+      providerKeys: {
+        fmp: 'test-fmp-key',
+        fred: 'test-fred-key',
+        bls: 'test-bls-key',
+        eia: 'test-eia-key',
+        econdb: 'test-econdb-key',
+        intrinio: 'test-intrinio-key',
+      },
+    },
+    status: 'idle',
+    loadError: false,
+    updateConfig: mocks.updateConfig,
+    updateConfigImmediate: mocks.updateConfigImmediate,
+    retry: mocks.retry,
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.testProvider.mockResolvedValue({ ok: true })
+})
+
+afterEach(cleanup)
+
+function openProviderKeys() {
+  render(<MarketDataPage />)
+  fireEvent.click(screen.getByRole('button', { name: /Advanced/ }))
+}
+
+describe('MarketDataPage provider credentials', () => {
+  it('gives every key field and test action a provider-specific name', () => {
+    openProviderKeys()
+
+    for (const provider of ['FMP', 'FRED', 'BLS', 'EIA', 'EconDB', 'Intrinio']) {
+      const input = screen.getByLabelText(`${provider} API key`)
+      expect(screen.getByText(provider, { selector: 'label' }).getAttribute('for'))
+        .toBe(input.getAttribute('id'))
+      expect(input.getAttribute('aria-describedby')).toBe(
+        `market-data-provider-${provider.toLowerCase()}-key-description ` +
+        `market-data-provider-${provider.toLowerCase()}-key-hint ` +
+        `market-data-provider-${provider.toLowerCase()}-key-test-status`,
+      )
+      expect(screen.getByRole('button', { name: `Test ${provider} key` })).toBeTruthy()
+    }
+  })
+
+  it('associates provider test progress and success with the matching field', async () => {
+    let finishTest: ((result: { ok: boolean }) => void) | undefined
+    mocks.testProvider.mockReturnValueOnce(new Promise((resolve) => {
+      finishTest = resolve
+    }))
+    openProviderKeys()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test FMP key' }))
+
+    expect(await screen.findByRole('button', { name: 'Testing FMP key' })).toBeTruthy()
+    expect(screen.getByText('Testing FMP key').getAttribute('id'))
+      .toBe('market-data-provider-fmp-key-test-status')
+
+    finishTest?.({ ok: true })
+
+    expect(await screen.findByRole('button', { name: 'FMP key test passed' })).toBeTruthy()
+    expect(screen.getByText('FMP key test passed').getAttribute('id'))
+      .toBe('market-data-provider-fmp-key-test-status')
+  })
+
+  it('announces a failed provider test without changing another provider action', async () => {
+    mocks.testProvider.mockResolvedValueOnce({ ok: false })
+    openProviderKeys()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test BLS key' }))
+
+    expect(await screen.findByRole('button', { name: 'BLS key test failed' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Test FRED key' })).toBeTruthy()
+  })
+})

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { api, type AppConfig } from '../api'
 import { SaveIndicator } from '../components/SaveIndicator'
-import { ConfigSection, Field, SettingsScrollArea, inputClass } from '../components/form'
+import { ConfigSection, SettingsScrollArea, inputClass } from '../components/form'
 import { Toggle } from '../components/Toggle'
 import { useConfigPage } from '../hooks/useConfigPage'
 import { PageHeader } from '../components/PageHeader'
@@ -462,19 +462,38 @@ function AdvancedSection({
 
 // ==================== Test Button ====================
 
+type ProviderTestStatus = 'idle' | 'testing' | 'ok' | 'error'
+
+function providerTestStatusLabel(providerName: string, status: ProviderTestStatus): string {
+  switch (status) {
+    case 'testing':
+      return `Testing ${providerName} key`
+    case 'ok':
+      return `${providerName} key test passed`
+    case 'error':
+      return `${providerName} key test failed`
+    default:
+      return `Test ${providerName} key`
+  }
+}
+
 function TestButton({
+  providerName,
   status,
   disabled,
   onClick,
 }: {
-  status: 'idle' | 'testing' | 'ok' | 'error'
+  providerName: string
+  status: ProviderTestStatus
   disabled: boolean
   onClick: () => void
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-label={providerTestStatusLabel(providerName, status)}
       className={`shrink-0 border rounded-md px-3 py-2 text-[13px] font-medium cursor-pointer transition-colors disabled:opacity-40 disabled:cursor-default ${
         status === 'ok'
           ? 'border-success text-success'
@@ -506,7 +525,7 @@ function KeyProvidersSection({
     for (const p of ALL_PROVIDERS) init[p.key] = providerKeys[p.key] || ''
     return init
   })
-  const [testStatus, setTestStatus] = useState<Record<string, 'idle' | 'testing' | 'ok' | 'error'>>({})
+  const [testStatus, setTestStatus] = useState<Record<string, ProviderTestStatus>>({})
 
   const handleKeyChange = (keyName: string, value: string) => {
     setLocalKeys((prev) => ({ ...prev, [keyName]: value }))
@@ -543,29 +562,56 @@ function KeyProvidersSection({
               {group.providers.map(({ key, name, desc, hint }) => {
                 const status = testStatus[key] || 'idle'
                 const isFmp = key === 'fmp'
+                const inputId = `market-data-provider-${key}-key`
+                const descriptionId = `${inputId}-description`
+                const hintId = `${inputId}-hint`
+                const statusId = `${inputId}-test-status`
                 return (
                   <div
                     key={key}
                     ref={isFmp ? fmpRef : undefined}
                     className={`rounded-lg transition-shadow ${isFmp && highlightFmp ? 'ring-2 ring-primary/60' : ''}`}
                   >
-                    <Field label={name} description={hint}>
-                      <p className="text-[12px] text-muted-foreground/70 mb-2">{desc}</p>
+                    <div className="mb-3.5 last:mb-0">
+                      <label
+                        htmlFor={inputId}
+                        className="block text-[13px] text-foreground mb-1.5 font-medium"
+                      >
+                        {name}
+                      </label>
+                      <p id={descriptionId} className="text-[12px] text-muted-foreground/70 mb-2">
+                        {desc}
+                      </p>
                       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                         <input
+                          id={inputId}
                           className={inputClass}
                           type="password"
                           value={localKeys[key]}
                           onChange={(e) => handleKeyChange(key, e.target.value)}
+                          aria-label={`${name} API key`}
+                          aria-describedby={`${descriptionId} ${hintId} ${statusId}`}
                           placeholder="Not configured"
                         />
                         <TestButton
+                          providerName={name}
                           status={status}
                           disabled={!localKeys[key] || status === 'testing'}
                           onClick={() => testProvider(key)}
                         />
                       </div>
-                    </Field>
+                      <p id={hintId} className="text-[12px] text-muted-foreground/60 mt-1">
+                        {hint}
+                      </p>
+                      <span
+                        id={statusId}
+                        className="sr-only"
+                        role="status"
+                        aria-live="polite"
+                      >
+                        {status === 'idle' ? '' : providerTestStatusLabel(name, status)}
+                      </span>
+                    </div>
                   </div>
                 )
               })}


### PR DESCRIPTION
## Summary

- associate each visible provider label with its credential field
- give all six password inputs and Test actions provider-specific accessible names
- connect provider descriptions, setup hints, and test status to the matching field
- expose testing, success, and failure as provider-specific live status without changing the visual layout

## Evidence

On the real `/settings/market-data` Advanced panel, all six provider-key inputs exposed the same accessible name (`Not configured`) and all six actions exposed only `Test`. There were zero controls addressable by provider name, so assistive technology and voice control could not distinguish FMP, FRED, BLS, EIA, EconDB, or Intrinio.

After the change, each provider has exactly one named input and one named Test action; the generic duplicate names are gone. Clicking the visible FMP label focuses the FMP field.

## Verification

- `npx vitest run ui/src/pages/MarketDataPage.spec.tsx` (3 tests)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` on latest dev (412 files passed, 3539 tests passed)
- real `pnpm dev` `/settings/market-data`: verified six unique field/action names, visible-label focus, linked description/status ids, and no generic duplicate names
- 390x844 real route: verified the stacked credential layout remains readable with zero page-level horizontal overflow