### PR TITLE
Make Workspace Settings a complete modal

### DIFF
--- a/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
@@ -104,6 +104,76 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('WorkspaceAIConfigModal local model metadata', () => {
+  it('exposes a named modal dialog and moves focus into the selected section', () => {
+    render(
+      <WorkspaceAIConfigModal
+        wsId="chat-1"
+        initialSection="general"
+        onClose={vi.fn()}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog', { name: '工作区设置' })
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(screen.getByRole('button', { name: '通用' }).getAttribute('aria-current')).toBe('page')
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: '通用' }))
+  })
+
+  it('keeps forward and reverse Tab navigation inside the dialog', () => {
+    render(
+      <WorkspaceAIConfigModal
+        wsId="chat-1"
+        initialSection="general"
+        onClose={vi.fn()}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog', { name: '工作区设置' })
+    const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ))
+    const first = focusable[0]!
+    const last = focusable[focusable.length - 1]!
+
+    last.focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(first)
+
+    first.focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(last)
+  })
+
+  it('closes on Escape, restores focus, and removes its keyboard listener', () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'Open workspace settings'
+    document.body.append(trigger)
+    trigger.focus()
+    const onClose = vi.fn()
+
+    const { unmount } = render(
+      <WorkspaceAIConfigModal
+        wsId="chat-1"
+        initialSection="general"
+        onClose={onClose}
+      />,
+    )
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: '通用' }))
+    expect(trigger.hasAttribute('inert')).toBe(true)
+    expect(trigger.getAttribute('aria-hidden')).toBe('true')
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    unmount()
+    expect(document.activeElement).toBe(trigger)
+    expect(trigger.hasAttribute('inert')).toBe(false)
+    expect(trigger.getAttribute('aria-hidden')).toBeNull()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    trigger.remove()
+  })
+
   it('saves a Codex native-login model without requiring an API probe', async () => {
     mocks.getAgentConfig.mockReset().mockResolvedValue({
       claude: null,

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -9,7 +9,7 @@
  * changes to take effect (env is read at CLI startup).
  */
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Bot, GitMerge, Info, Layers3, Rocket, Settings, X } from 'lucide-react'
 import {
@@ -83,6 +83,56 @@ const CONTEXT_WINDOW_OPTIONS = [
   { value: 512_000, label: '512K' },
   { value: 1_000_000, label: '1M' },
 ] as const
+
+const DIALOG_FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function dialogFocusableElements(dialog: HTMLElement): HTMLElement[] {
+  return Array.from(dialog.querySelectorAll<HTMLElement>(DIALOG_FOCUSABLE_SELECTOR))
+    .filter((element) => (
+      element.tabIndex >= 0 &&
+      element.closest('[hidden], [aria-hidden="true"]') === null
+    ))
+}
+
+function makeDialogBackgroundInert(modalBranch: HTMLElement): () => void {
+  const changed: Array<{
+    element: HTMLElement
+    hadInert: boolean
+    ariaHidden: string | null
+  }> = []
+  let branch: HTMLElement | null = modalBranch
+
+  while (branch?.parentElement) {
+    const parent: HTMLElement = branch.parentElement
+    for (const sibling of Array.from(parent.children)) {
+      if (sibling === branch || !(sibling instanceof HTMLElement)) continue
+      changed.push({
+        element: sibling,
+        hadInert: sibling.hasAttribute('inert'),
+        ariaHidden: sibling.getAttribute('aria-hidden'),
+      })
+      sibling.setAttribute('inert', '')
+      sibling.setAttribute('aria-hidden', 'true')
+    }
+    if (parent === document.body) break
+    branch = parent
+  }
+
+  return () => {
+    for (const { element, hadInert, ariaHidden } of changed.reverse()) {
+      if (!hadInert) element.removeAttribute('inert')
+      if (ariaHidden === null) element.removeAttribute('aria-hidden')
+      else element.setAttribute('aria-hidden', ariaHidden)
+    }
+  }
+}
 
 export interface FormState {
   baseUrl: string
@@ -221,6 +271,11 @@ export function WorkspaceAIConfigModal({
   initialSection = 'general',
 }: Props) {
   const { t } = useTranslation()
+  const backdropRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const onCloseRef = useRef(onClose)
+  const dialogTitleId = useId()
+  const dialogDescriptionId = useId()
   const { workspaces, refresh, saveWorkspaceMetadata } = useWorkspaces()
   const workspace = workspaces.find((w) => w.id === wsId) ?? null
   const workspaceLabel = workspace?.displayName?.trim() || workspace?.tag || wsId
@@ -254,6 +309,61 @@ export function WorkspaceAIConfigModal({
   const opencodeGate = useTestGate()
   const piGate = useTestGate()
   const [presets, setPresets] = useState<Preset[]>([])
+
+  onCloseRef.current = onClose
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    const backdrop = backdropRef.current
+    if (!dialog || !backdrop) return
+
+    const previouslyFocused = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null
+    const restoreBackground = makeDialogBackgroundInert(backdrop)
+    const initialFocus = dialog.querySelector<HTMLElement>('[aria-current="page"]')
+      ?? dialogFocusableElements(dialog)[0]
+      ?? dialog
+    initialFocus.focus()
+
+    const handleDialogKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCloseRef.current()
+        return
+      }
+      if (event.key !== 'Tab') return
+
+      const focusable = dialogFocusableElements(dialog)
+      if (focusable.length === 0) {
+        event.preventDefault()
+        dialog.focus()
+        return
+      }
+
+      const first = focusable[0]!
+      const last = focusable[focusable.length - 1]!
+      const active = document.activeElement
+      if (!dialog.contains(active)) {
+        event.preventDefault()
+        first.focus()
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleDialogKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleDialogKeyDown)
+      restoreBackground()
+      if (previouslyFocused?.isConnected) previouslyFocused.focus()
+    }
+  }, [])
 
   useEffect(() => {
     setSection(initialSection)
@@ -531,18 +641,25 @@ export function WorkspaceAIConfigModal({
 
   return (
     <div
+      ref={backdropRef}
       className="fixed inset-0 z-[60] flex items-center justify-center bg-backdrop backdrop-blur-sm"
       onMouseDown={handleBackdropMouseDown}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={dialogTitleId}
+        aria-describedby={dialogDescriptionId}
+        tabIndex={-1}
         className="bg-background border border-border rounded-xl shadow-2xl w-[calc(100vw-24px)] max-w-3xl max-h-[85vh] flex flex-col"
         onMouseDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
           <div className="min-w-0">
-            <h2 className="text-[15px] font-semibold text-foreground">{t('workspaceSettings.title')}</h2>
-            <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{workspaceLabel}</p>
+            <h2 id={dialogTitleId} className="text-[15px] font-semibold text-foreground">{t('workspaceSettings.title')}</h2>
+            <p id={dialogDescriptionId} className="mt-0.5 truncate text-[11px] text-muted-foreground">{workspaceLabel}</p>
           </div>
           <button
             type="button"
@@ -560,6 +677,7 @@ export function WorkspaceAIConfigModal({
             <button
               type="button"
               onClick={() => setSection('general')}
+              aria-current={section === 'general' ? 'page' : undefined}
               className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:w-full ${
                 section === 'general'
                   ? 'bg-primary/10 text-primary'
@@ -572,6 +690,7 @@ export function WorkspaceAIConfigModal({
             <button
               type="button"
               onClick={() => setSection('launch')}
+              aria-current={section === 'launch' ? 'page' : undefined}
               className={`flex min-w-0 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:mt-1 sm:w-full ${
                 section === 'launch'
                   ? 'bg-primary/10 text-primary'
@@ -584,6 +703,7 @@ export function WorkspaceAIConfigModal({
             <button
               type="button"
               onClick={() => setSection('ai')}
+              aria-current={section === 'ai' ? 'page' : undefined}
               className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:mt-1 sm:w-full ${
                 section === 'ai'
                   ? 'bg-primary/10 text-primary'
@@ -596,6 +716,7 @@ export function WorkspaceAIConfigModal({
             <button
               type="button"
               onClick={() => setSection('template')}
+              aria-current={section === 'template' ? 'page' : undefined}
               className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:mt-1 sm:w-full ${
                 section === 'template'
                   ? 'bg-primary/10 text-primary'
@@ -611,6 +732,7 @@ export function WorkspaceAIConfigModal({
             <button
               type="button"
               onClick={() => setSection('absorb')}
+              aria-current={section === 'absorb' ? 'page' : undefined}
               className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] font-medium transition-colors sm:mt-1 sm:w-full ${
                 section === 'absorb'
                   ? 'bg-primary/10 text-primary'


### PR DESCRIPTION
## Summary

- expose Workspace Settings as a named `aria-modal` dialog with its Workspace identity as context
- move initial focus to the selected settings section and expose the active section
- make the background inert while open and contain forward/reverse Tab navigation
- close on Escape, restore focus to the opener, and restore all prior background attributes/listeners on unmount

## Evidence

In the real Workspace session, opening Settings left focus on the background Settings button. The page had zero dialog/aria-modal elements, the full Activity Bar and Workspace shell remained keyboard/assistive-technology targets, and Escape did not close the panel.

After the change, the selected `General` section receives focus, background `Ask Alice` controls are no longer addressable while the dialog is open, both Tab directions wrap inside the dialog, and Escape closes it, restores the background, and returns focus to `Configure this workspace`.

This complements #836, which covers the shared UTA/confirmation dialogs but does not touch `WorkspaceAIConfigModal`.

## Verification

- `npx vitest run ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx ui/src/components/workspace/WorkspaceAIConfigModal.spec.ts` (23 tests)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (411 files passed, 3539 tests passed)
- real `pnpm dev` Workspace Settings: verified named dialog semantics, initial focus, inert background, forward/reverse Tab wrapping, Escape close, background restoration, and focus return
- 390x844 real route: verified visible focus, responsive section navigation, footer actions, and zero page-level horizontal overflow