### PR TITLE
Make the mobile app drawer comfortably tappable and keyboard-safe

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -94,7 +94,7 @@ function AppShell() {
   const mainContent = (
     <main className="flex flex-col min-w-0 min-h-0 bg-background h-full">
       {/* Mobile header — visible only below md */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-border/80 bg-secondary shrink-0 md:hidden">
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-border/80 bg-secondary shrink-0 md:hidden">
         <MobileRailMenuButton onOpen={() => setSidebarOpen(true)} />
         <span className="text-sm font-semibold text-foreground">OpenAlice</span>
       </div>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { ActivityBar } from './components/ActivityBar'
 import { MobileRailMenuButton } from './components/MobileRailMenuButton'
@@ -68,6 +68,7 @@ function AppShell() {
   // (charts, money/date labels that don't call t()) refresh too.
   useLocale()
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const mobileRailMenuButtonRef = useRef<HTMLButtonElement>(null)
   const isDesktop = useIsDesktop() // ≥768 — rail is a static column
   const hasRailText = useHasRailText() // ≥960 — text rail is allowed
   const hasFullRail = useHasFullRail() // ≥1280 — full rail width
@@ -95,7 +96,12 @@ function AppShell() {
     <main className="flex flex-col min-w-0 min-h-0 bg-background h-full">
       {/* Mobile header — visible only below md */}
       <div className="flex items-center gap-3 px-4 py-2 border-b border-border/80 bg-secondary shrink-0 md:hidden">
-        <MobileRailMenuButton onOpen={() => setSidebarOpen(true)} />
+        <MobileRailMenuButton
+          ref={mobileRailMenuButtonRef}
+          open={sidebarOpen}
+          controlsId="activity-bar"
+          onOpen={() => setSidebarOpen(true)}
+        />
         <span className="text-sm font-semibold text-foreground">OpenAlice</span>
       </div>
 
@@ -115,8 +121,13 @@ function AppShell() {
           onClose={() => setSidebarOpen(false)}
           desktopStatic={isDesktop}
           railMode={railMode}
+          returnFocusRef={mobileRailMenuButtonRef}
         />
-        <div className="flex-1 min-h-0">
+        <div
+          aria-hidden={!isDesktop && sidebarOpen ? true : undefined}
+          inert={!isDesktop && sidebarOpen ? true : undefined}
+          className="flex-1 min-h-0"
+        >
           {mainContent}
         </div>
         <UrlAdopter />

--- a/ui/src/components/ActivityBar.drawer-state.spec.tsx
+++ b/ui/src/components/ActivityBar.drawer-state.spec.tsx
@@ -85,4 +85,21 @@ describe('ActivityBar mobile drawer state', () => {
     expect(activityBar.getAttribute('aria-hidden')).toBe('false')
     expect(activityBar.hasAttribute('inert')).toBe(false)
   })
+
+  it('keeps mobile drawer actions tappable without changing desktop density', () => {
+    render(<ActivityBar open onClose={vi.fn()} desktopStatic={false} />)
+
+    const primaryAction = screen.getByRole('button', { name: 'Ask Alice' })
+    const sectionToggle = screen.getByRole('button', { name: 'Beta' })
+    const sectionInfo = screen.getByRole('button', { name: 'nav.about' })
+
+    expect(primaryAction.className).toContain('min-h-10')
+    expect(primaryAction.className).toContain('md:min-h-[34px]')
+    expect(sectionToggle.className).toContain('min-h-10')
+    expect(sectionToggle.className).toContain('md:min-h-7')
+    expect(sectionInfo.className).toContain('min-h-10')
+    expect(sectionInfo.className).toContain('min-w-10')
+    expect(sectionInfo.className).toContain('md:min-h-7')
+    expect(sectionInfo.className).toContain('md:min-w-7')
+  })
 })

--- a/ui/src/components/ActivityBar.drawer-state.spec.tsx
+++ b/ui/src/components/ActivityBar.drawer-state.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ActivityBar } from './ActivityBar'
@@ -42,8 +42,10 @@ vi.mock('react-i18next', () => ({
     t: (key: string) => ({
       'nav.item.chat': 'Ask Alice',
       'nav.item.settings': 'Settings',
+      'nav.item.dev': 'Dev Panel',
       'nav.section.beta': 'Beta',
       'nav.section.system': 'System',
+      'nav.primaryNavigation': 'Primary navigation',
     })[key] ?? key,
   }),
 }))
@@ -84,6 +86,10 @@ describe('ActivityBar mobile drawer state', () => {
     rerender(<ActivityBar open={false} onClose={onClose} desktopStatic />)
     expect(activityBar.getAttribute('aria-hidden')).toBe('false')
     expect(activityBar.hasAttribute('inert')).toBe(false)
+    expect(activityBar.getAttribute('role')).toBeNull()
+    expect(activityBar.getAttribute('aria-modal')).toBeNull()
+    expect(activityBar.getAttribute('aria-label')).toBeNull()
+    expect(activityBar.getAttribute('tabindex')).toBeNull()
   })
 
   it('keeps mobile drawer actions tappable without changing desktop density', () => {
@@ -101,5 +107,56 @@ describe('ActivityBar mobile drawer state', () => {
     expect(sectionInfo.className).toContain('min-w-10')
     expect(sectionInfo.className).toContain('md:min-h-7')
     expect(sectionInfo.className).toContain('md:min-w-7')
+  })
+
+  it('contains mobile focus, closes on Escape, and restores the trigger', () => {
+    const trigger = document.createElement('button')
+    document.body.append(trigger)
+    trigger.focus()
+    const returnFocusRef = { current: trigger }
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <ActivityBar
+        open
+        onClose={onClose}
+        desktopStatic={false}
+        returnFocusRef={returnFocusRef}
+      />,
+    )
+
+    const drawer = screen.getByRole('dialog', { name: 'Primary navigation' })
+    const currentDestination = screen.getByRole('button', { name: 'Settings' })
+    const firstAction = screen.getByRole('button', { name: 'Ask Alice' })
+    const lastAction = screen.getByRole('button', { name: 'Dev Panel' })
+    const backdrop = document.querySelector<HTMLElement>('.bg-backdrop')
+
+    expect(drawer.getAttribute('aria-modal')).toBe('true')
+    expect(drawer.getAttribute('tabindex')).toBe('-1')
+    expect(document.activeElement).toBe(currentDestination)
+    expect(drawer.className).toContain('motion-reduce:transition-none')
+    expect(backdrop?.getAttribute('aria-hidden')).toBe('true')
+    expect(backdrop?.className).toContain('motion-reduce:transition-none')
+
+    lastAction.focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(firstAction)
+
+    firstAction.focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(lastAction)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+
+    rerender(
+      <ActivityBar
+        open={false}
+        onClose={onClose}
+        desktopStatic={false}
+        returnFocusRef={returnFocusRef}
+      />,
+    )
+    expect(document.activeElement).toBe(trigger)
+    trigger.remove()
   })
 })

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -202,7 +202,7 @@ export function ActivityBar({
                                 : 'md:h-9 md:w-11 md:min-h-9 md:justify-center md:gap-0 md:px-0 md:py-0'
                               : denseRail
                                 ? `min-h-[28px] ${narrowRail ? 'gap-2 px-2' : 'gap-2.5 px-2.5'} py-1 text-[12px]`
-                                : `min-h-[34px] ${narrowRail ? 'gap-2 px-2.5' : 'gap-3 px-3'} py-1.5 text-[13px]`
+                                : `min-h-10 md:min-h-[34px] ${narrowRail ? 'gap-2 px-2.5' : 'gap-3 px-3'} py-1.5 text-[13px]`
                           } ${
                             isActive
                               ? 'bg-primary-muted text-foreground'
@@ -311,7 +311,7 @@ function SectionHeader({
         <button
           type="button"
           onClick={onToggleCollapse}
-          className="flex min-h-7 flex-1 items-center gap-1.5 py-1 text-left text-[12px] font-semibold text-muted-foreground transition-colors hover:text-foreground"
+          className="flex min-h-10 flex-1 items-center gap-1.5 py-1 text-left text-[12px] font-semibold text-muted-foreground transition-colors hover:text-foreground md:min-h-7"
           aria-expanded={!isCollapsed}
           aria-controls={controlsId}
           title={label}
@@ -330,7 +330,7 @@ function SectionHeader({
           <button
             type="button"
             onClick={() => setHintOpen((o) => !o)}
-            className={`flex min-h-7 min-w-7 items-center justify-center p-0.5 transition-colors ${
+            className={`flex min-h-10 min-w-10 items-center justify-center p-0.5 transition-colors md:min-h-7 md:min-w-7 ${
               hintOpen ? 'text-muted-foreground' : 'text-muted-foreground/50 hover:text-muted-foreground'
             }`}
             aria-label={t('nav.about', { label })}

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Info, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState, type RefObject } from 'react'
 import { type Page } from '../App'
 import { useWorkspace } from '../tabs/store'
 import type { ActivitySection } from '../tabs/types'
@@ -41,6 +41,8 @@ interface ActivityBarProps {
   railMode?: 'compact' | 'narrow' | 'full'
   /** Force the static rail into icon-only mode at narrow desktop widths. */
   compactRailForced?: boolean
+  /** Mobile drawer trigger that receives focus again when the drawer closes. */
+  returnFocusRef?: RefObject<HTMLElement | null>
 }
 
 function useMediaQuery(query: string): boolean {
@@ -79,6 +81,7 @@ export function ActivityBar({
   desktopStatic = true,
   railMode = 'full',
   compactRailForced = false,
+  returnFocusRef,
 }: ActivityBarProps) {
   const { t } = useTranslation()
   const selectedSidebar = useWorkspace((state) => state.selectedSidebar)
@@ -99,12 +102,66 @@ export function ActivityBar({
   const narrowRail = desktopStatic && railMode === 'narrow' && !compactRail
   const denseRail = desktopStatic && shortRailHeight
   const mobileDrawerClosed = !desktopStatic && !open
+  const drawerRef = useRef<HTMLElement>(null)
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
+  useEffect(() => {
+    if (!open || desktopStatic) return
+    const drawer = drawerRef.current
+    if (!drawer) return
+
+    const previousFocus = returnFocusRef?.current
+      ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null)
+    const initialFocus = drawer.querySelector<HTMLElement>('[aria-current="page"]')
+      ?? drawerFocusableElements(drawer)[0]
+      ?? drawer
+    initialFocus.focus()
+
+    const handleDrawerKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCloseRef.current()
+        return
+      }
+      if (event.key !== 'Tab') return
+
+      const focusable = drawerFocusableElements(drawer)
+      if (focusable.length === 0) {
+        event.preventDefault()
+        drawer.focus()
+        return
+      }
+
+      const first = focusable[0]!
+      const last = focusable[focusable.length - 1]!
+      const active = document.activeElement
+      if (!drawer.contains(active)) {
+        event.preventDefault()
+        first.focus()
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleDrawerKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleDrawerKeyDown)
+      if (previousFocus?.isConnected) previousFocus.focus()
+    }
+  }, [desktopStatic, open, returnFocusRef])
 
   return (
     <>
       {/* Backdrop — mobile only */}
       <div
-        className={`fixed inset-0 bg-backdrop z-40 md:hidden transition-opacity duration-200 ${
+        aria-hidden
+        className={`fixed inset-0 bg-backdrop z-40 md:hidden transition-opacity duration-200 motion-reduce:transition-none ${
           open ? 'opacity-100' : 'opacity-0 pointer-events-none'
         }`}
         onClick={onClose}
@@ -113,14 +170,20 @@ export function ActivityBar({
       {/* ActivityBar — Linear-style workspace rail. Mobile: slide-in over
        *  page with backdrop. Desktop: static column flush left. */}
       <aside
+        ref={drawerRef}
+        id="activity-bar"
         data-testid="activity-bar"
+        role={!desktopStatic ? 'dialog' : undefined}
+        aria-modal={!desktopStatic && open ? 'true' : undefined}
+        aria-label={!desktopStatic ? t('nav.primaryNavigation') : undefined}
         aria-hidden={mobileDrawerClosed}
         inert={mobileDrawerClosed ? true : undefined}
+        tabIndex={!desktopStatic ? -1 : undefined}
         className={`
           w-[280px] ${compactRail ? 'md:w-[60px]' : narrowRail ? 'md:w-[152px]' : 'md:w-[188px]'} h-full flex flex-col shrink-0
           bg-muted
           border-r border-border/80
-          fixed z-50 top-0 left-0 transition-[transform,width] duration-200
+          fixed z-50 top-0 left-0 transition-[transform,width] duration-200 motion-reduce:transition-none
           ${open ? 'translate-x-0' : '-translate-x-full'}
           md:static md:translate-x-0 md:z-auto
         `}
@@ -259,6 +322,8 @@ export function ActivityBar({
               onClick={() => setRailCollapsed(!railCollapsed)}
               title={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
               aria-label={t(railCollapsed ? 'nav.expandRail' : 'nav.collapseRail')}
+              aria-hidden={!desktopStatic ? true : undefined}
+              tabIndex={!desktopStatic ? -1 : undefined}
               className={`oa-icon-action hidden ${denseRail ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground md:flex`}
             >
               {railCollapsed
@@ -270,6 +335,23 @@ export function ActivityBar({
       </aside>
     </>
   )
+}
+
+const DRAWER_FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function drawerFocusableElements(drawer: HTMLElement): HTMLElement[] {
+  return [...drawer.querySelectorAll<HTMLElement>(DRAWER_FOCUSABLE_SELECTOR)]
+    .filter((element) => (
+      element.tabIndex >= 0 &&
+      element.closest('[hidden], [aria-hidden="true"], [inert]') === null
+    ))
 }
 
 // ==================== SectionHeader ====================

--- a/ui/src/components/MobileRailMenuButton.spec.tsx
+++ b/ui/src/components/MobileRailMenuButton.spec.tsx
@@ -17,7 +17,11 @@ describe('MobileRailMenuButton', () => {
     const onOpen = vi.fn()
     render(<MobileRailMenuButton onOpen={onOpen} />)
 
-    fireEvent.click(screen.getByRole('button', { name: '展开活动栏' }))
+    const button = screen.getByRole('button', { name: '展开活动栏' })
+    expect(button.className).toContain('h-10')
+    expect(button.className).toContain('w-10')
+
+    fireEvent.click(button)
 
     expect(onOpen).toHaveBeenCalledOnce()
   })

--- a/ui/src/components/MobileRailMenuButton.spec.tsx
+++ b/ui/src/components/MobileRailMenuButton.spec.tsx
@@ -15,14 +15,22 @@ afterEach(cleanup)
 describe('MobileRailMenuButton', () => {
   it('uses the active locale for the mobile navigation action', () => {
     const onOpen = vi.fn()
-    render(<MobileRailMenuButton onOpen={onOpen} />)
+    const { rerender } = render(
+      <MobileRailMenuButton open={false} controlsId="activity-bar" onOpen={onOpen} />,
+    )
 
     const button = screen.getByRole('button', { name: '展开活动栏' })
     expect(button.className).toContain('h-10')
     expect(button.className).toContain('w-10')
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+    expect(button.getAttribute('aria-controls')).toBe('activity-bar')
+    expect(button.getAttribute('aria-haspopup')).toBe('dialog')
 
     fireEvent.click(button)
 
     expect(onOpen).toHaveBeenCalledOnce()
+
+    rerender(<MobileRailMenuButton open controlsId="activity-bar" onOpen={onOpen} />)
+    expect(button.getAttribute('aria-expanded')).toBe('true')
   })
 })

--- a/ui/src/components/MobileRailMenuButton.tsx
+++ b/ui/src/components/MobileRailMenuButton.tsx
@@ -1,26 +1,39 @@
+import { forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
-export function MobileRailMenuButton({ onOpen }: { onOpen: () => void }) {
-  const { t } = useTranslation()
-  return (
-    <button
-      type="button"
-      onClick={onOpen}
-      className="oa-icon-action -ml-2 flex h-10 w-10 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-      aria-label={t('nav.expandRail')}
-    >
-      <svg
-        width="20"
-        height="20"
-        viewBox="0 0 20 20"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        aria-hidden
-      >
-        <path d="M3 5h14M3 10h14M3 15h14" />
-      </svg>
-    </button>
-  )
+interface MobileRailMenuButtonProps {
+  open: boolean
+  controlsId: string
+  onOpen: () => void
 }
+
+export const MobileRailMenuButton = forwardRef<HTMLButtonElement, MobileRailMenuButtonProps>(
+  function MobileRailMenuButton({ open, controlsId, onOpen }, ref) {
+    const { t } = useTranslation()
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={onOpen}
+        className="oa-icon-action -ml-2 flex h-10 w-10 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        aria-label={t('nav.expandRail')}
+        aria-expanded={open}
+        aria-controls={controlsId}
+        aria-haspopup="dialog"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          aria-hidden
+        >
+          <path d="M3 5h14M3 10h14M3 15h14" />
+        </svg>
+      </button>
+    )
+  },
+)

--- a/ui/src/components/MobileRailMenuButton.tsx
+++ b/ui/src/components/MobileRailMenuButton.tsx
@@ -6,7 +6,7 @@ export function MobileRailMenuButton({ onOpen }: { onOpen: () => void }) {
     <button
       type="button"
       onClick={onOpen}
-      className="text-muted-foreground hover:text-foreground p-1 -ml-1"
+      className="oa-icon-action -ml-2 flex h-10 w-10 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
       aria-label={t('nav.expandRail')}
     >
       <svg

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -35,7 +35,7 @@ export function ThemeToggle({ compact = false }: { compact?: boolean }) {
       onClick={cycle}
       title={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
       aria-label={t('theme.switchTo', { mode: t(`theme.mode.${NEXT[theme]}`) })}
-      className={`relative flex ${compact ? 'h-9 w-9 md:h-[26px] md:w-[26px]' : 'h-9 w-9'} shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground`}
+      className={`relative flex ${compact ? 'h-10 w-10 md:h-[26px] md:w-[26px]' : 'h-10 w-10 md:h-9 md:w-9'} shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground`}
     >
       <Icon size={compact ? 14 : 17} strokeWidth={1.75} aria-hidden />
       {theme === 'auto' && (

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -38,6 +38,7 @@ export const en = {
     unread: '{{count}} unread',
     pendingPush: '{{count}} pending to push',
     about: 'About {{label}}',
+    primaryNavigation: 'Primary navigation',
     collapseRail: 'Collapse activity bar',
     expandRail: 'Expand activity bar',
   },

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -27,6 +27,7 @@ export const ja: Resources = {
     unread: '未読 {{count}} 件',
     pendingPush: 'プッシュ待ち {{count}} 件',
     about: '{{label}}について',
+    primaryNavigation: 'メインナビゲーション',
     collapseRail: 'アクティビティバーを折りたたむ',
     expandRail: 'アクティビティバーを展開',
   },

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -35,6 +35,7 @@ export const zhHant: Resources = {
     unread: '{{count}} 則未讀',
     pendingPush: '{{count}} 筆待推送',
     about: '關於{{label}}',
+    primaryNavigation: '主要導覽',
     collapseRail: '收合活動列',
     expandRail: '展開活動列',
   },

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -27,6 +27,7 @@ export const zh: Resources = {
     unread: '{{count}} 条未读',
     pendingPush: '{{count}} 笔待推送',
     about: '关于{{label}}',
+    primaryNavigation: '主导航',
     collapseRail: '折叠活动栏',
     expandRail: '展开活动栏',
   },


### PR DESCRIPTION
## Topic

Make the phone-width application drawer comfortably tappable and keyboard-safe without changing the desktop rail.

This is the single community-facing Draft PR for the app-shell topic tracked in #858. Related changes stay as atomic commits on this branch; unrelated page navigation and shell redesign are out of scope.

## Why

Real `pnpm dev` testing at 320 px found that:

- the always-visible menu trigger was 28×28 px;
- primary drawer rows were 34 px high, section controls were 28 px high, and the theme action was 36×36 px;
- opening the drawer left focus on the trigger behind its backdrop;
- the trigger did not expose expanded/controls state;
- Escape did not close the drawer;
- focus was not contained within the modal navigation surface.

The result looked usable with a pointer but was uncomfortable on touch and unsafe for keyboard or assistive-technology navigation.

## Topic checklist

- [x] Raise every phone drawer action to at least 40×40 px.
- [x] Preserve the compact/static desktop rail density.
- [x] Expose trigger expanded, controls, and dialog-popup state.
- [x] Give the phone drawer a localized accessible name and modal dialog semantics.
- [x] Move focus to the current destination when the drawer opens.
- [x] Contain forward and reverse Tab navigation within the drawer.
- [x] Close on Escape and restore focus to the trigger.
- [x] Keep obscured page content inert and hidden from assistive technology while open.
- [x] Preserve backdrop dismissal, navigation dismissal, and body scroll locking.
- [x] Remove drawer/backdrop transitions under reduced motion.
- [x] Verify real routes at narrow portrait, normal portrait, short landscape, and desktop widths.

## Atomic increments

1. `Make mobile app navigation comfortably tappable` — raises phone targets to at least 40×40 px while keeping existing desktop density.
2. `Make the mobile app drawer keyboard safe` — adds localized modal semantics, current-destination initial focus, Tab containment, Escape dismissal, focus restoration, background isolation, trigger state, and reduced-motion handling.

## Real-route evidence

Verified with `pnpm dev` on `/issues/chat-lucid-opal-summit/asia-cross-market-rotation-daily`:

- At 320×700, the trigger and every rendered drawer action measure at least 40×40 px; the 280 px drawer stays within the viewport and its navigation scrolls internally (`599` px viewport / `692` px content).
- At 390×844, every action remains at least 40×40 px and all navigation content fits without internal scrolling.
- At 700×320 landscape, the drawer remains 280 px wide, keeps 40×40 px minimum actions, and its short navigation area scrolls instead of clipping.
- At 1280×900, desktop densities remain unchanged: primary rows 34 px, section controls 28 px, and the theme action 36×36 px.
- The closed trigger reports `aria-expanded="false"`, `aria-controls="activity-bar"`, and `aria-haspopup="dialog"`; the closed drawer remains `aria-hidden` and `inert`.
- Opening reports `aria-expanded="true"`, exposes `Primary navigation` as an `aria-modal` dialog, moves focus to the current `Issues` destination, and makes the obscured main surface `aria-hidden` plus `inert`.
- Shift+Tab from the first action wraps to the theme action; Tab from the theme action wraps back to Ask Alice.
- Escape closes the drawer, restores focus to the menu trigger, removes background isolation, and clears the inline body scroll lock.
- With `prefers-reduced-motion: reduce`, both drawer and backdrop compute `transition-property: none`; restoring the media preference returns normal motion behavior.

## Verification

- `npx tsc --noEmit`
- `pnpm --dir ui exec tsc -b`
- `pnpm test` — 431 files passed, 1 skipped; 3631 tests passed, 9 skipped
- Targeted mobile trigger/drawer specs — 2 files, 4 tests passed
- `git diff --check`
- Real-route browser verification at 320×700, 390×844, 700×320, and 1280×900
- Real keyboard-path verification for focus entry, forward/reverse containment, Escape, and focus restoration
- CDP media emulation for `prefers-reduced-motion: reduce`, reset after verification

## Boundary touch

Global UI shell structure only. No trading, auth, credentials, persisted data, runtime, packaging, or API behavior.

## Non-goals

- Redesigning navigation hierarchy or labels
- Changing desktop rail widths or compact-mode density
- Changing page-owned sidebars
- Changing theme behavior
- Merging without maintainer acceptance

Related: #858
