### PR TITLE
Make mobile page sidebars modal and touch-friendly

### DIFF
--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -99,19 +99,84 @@ describe('PageSidebarLayout', () => {
     )
 
     const drawer = screen.getByTestId('page-sidebar-drawer')
+    const opener = screen.getByRole('button', { name: 'Open Inbox' })
     expect(drawer.getAttribute('data-state')).toBe('closed')
     expect(drawer.getAttribute('aria-hidden')).toBe('true')
     expect(drawer.hasAttribute('inert')).toBe(true)
+    expect(opener.getAttribute('aria-expanded')).toBe('false')
+    expect(opener.getAttribute('aria-controls')).toBe(drawer.id)
+    expect(opener.getAttribute('aria-haspopup')).toBe('dialog')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open Inbox' }))
+    fireEvent.click(opener)
     expect(drawer.getAttribute('data-state')).toBe('open')
     expect(drawer.getAttribute('aria-hidden')).toBe('false')
     expect(drawer.hasAttribute('inert')).toBe(false)
+    expect(drawer.getAttribute('role')).toBe('dialog')
+    expect(drawer.getAttribute('aria-label')).toBe('Inbox')
+    expect(drawer.getAttribute('aria-modal')).toBe('true')
+    expect(opener.getAttribute('aria-expanded')).toBe('true')
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close Inbox' }))
+    expect(screen.getByText('Inbox message').closest('[inert]')).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Select message' }))
     expect(drawer.getAttribute('data-state')).toBe('closed')
     expect(drawer.getAttribute('aria-hidden')).toBe('true')
     expect(drawer.hasAttribute('inert')).toBe(true)
+    expect(drawer.hasAttribute('aria-modal')).toBe(false)
+    expect(opener.getAttribute('aria-expanded')).toBe('false')
+    expect(document.activeElement).toBe(opener)
+    expect(screen.getByText('Inbox message').closest('[inert]')).toBeNull()
+  })
+
+  it('contains phone drawer focus and closes on Escape', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })))
+
+    render(
+      <PageSidebarLayout
+        storageKey="tracked"
+        title="Tracked"
+        sidebar={(
+          <>
+            <button type="button">First item</button>
+            <button type="button" aria-current="page">Current item</button>
+            <button type="button">Last item</button>
+          </>
+        )}
+      >
+        <button type="button">Background action</button>
+      </PageSidebarLayout>,
+    )
+
+    const opener = screen.getByRole('button', { name: 'Open Tracked' })
+    fireEvent.click(opener)
+
+    const close = screen.getByRole('button', { name: 'Close Tracked' })
+    const current = screen.getByRole('button', { name: 'Current item' })
+    const last = screen.getByRole('button', { name: 'Last item' })
+    expect(document.activeElement).toBe(current)
+
+    last.focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(close)
+
+    close.focus()
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(last)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    const drawer = screen.getByTestId('page-sidebar-drawer')
+    expect(drawer.getAttribute('data-state')).toBe('closed')
+    expect(document.activeElement).toBe(opener)
+    expect(drawer.className).toContain('oa-page-sidebar-dialog')
   })
 
   it('keeps a page navigator in the drawer below its custom desktop breakpoint', () => {

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useId, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
 import { PanelLeftClose, PanelLeftOpen, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Sidebar } from './Sidebar'
@@ -8,6 +8,15 @@ const MAX_WIDTH = 420
 const MAIN_PANE_MIN_WIDTH = 500
 const COLLAPSED_WIDTH = 44
 const RESIZE_HANDLE_WIDTH = 10
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',')
 
 function clampWidth(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
@@ -95,6 +104,9 @@ export function PageSidebarLayout({
   const { t } = useTranslation()
   const isDesktop = useIsDesktop(desktopMinWidth)
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const mobileTriggerRef = useRef<HTMLButtonElement | null>(null)
+  const mobileDrawerRef = useRef<HTMLDialogElement | null>(null)
+  const mobileDrawerId = useId()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [collapsed, setCollapsed] = useState(() => readStoredCollapsed(storageKey))
   const [preferredWidth, setPreferredWidth] = useState(() =>
@@ -151,6 +163,75 @@ export function PageSidebarLayout({
   useEffect(() => {
     if (isDesktop) setDrawerOpen(false)
   }, [isDesktop])
+
+  useEffect(() => {
+    if (isDesktop) return
+    const drawer = mobileDrawerRef.current
+    if (!drawer) return
+
+    if (drawerOpen && !drawer.open) {
+      if (typeof drawer.showModal === 'function') {
+        drawer.showModal()
+      } else {
+        drawer.setAttribute('open', '')
+      }
+    } else if (!drawerOpen && drawer.open) {
+      if (typeof drawer.close === 'function') {
+        drawer.close()
+      } else {
+        drawer.removeAttribute('open')
+      }
+    }
+  }, [drawerOpen, isDesktop])
+
+  useEffect(() => {
+    if (isDesktop || !drawerOpen) return
+    const drawer = mobileDrawerRef.current
+    if (!drawer) return
+
+    const focusableElements = () =>
+      Array.from(drawer.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+        .filter((element) => element.getAttribute('aria-hidden') !== 'true')
+
+    const current = drawer.querySelector<HTMLElement>('[aria-current="page"]')
+    const initialFocus = current?.matches(FOCUSABLE_SELECTOR)
+      ? current
+      : focusableElements()[0] ?? drawer
+    initialFocus.focus({ preventScroll: true })
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setDrawerOpen(false)
+        return
+      }
+      if (event.key !== 'Tab') return
+
+      const focusables = focusableElements()
+      if (focusables.length === 0) {
+        event.preventDefault()
+        drawer.focus({ preventScroll: true })
+        return
+      }
+
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const active = document.activeElement
+      if (event.shiftKey && (active === first || !drawer.contains(active))) {
+        event.preventDefault()
+        last.focus({ preventScroll: true })
+      } else if (!event.shiftKey && (active === last || !drawer.contains(active))) {
+        event.preventDefault()
+        first.focus({ preventScroll: true })
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      mobileTriggerRef.current?.focus({ preventScroll: true })
+    }
+  }, [drawerOpen, isDesktop])
 
   useEffect(() => {
     if (!isDesktop) return
@@ -258,34 +339,52 @@ export function PageSidebarLayout({
 
   return (
     <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-background">
-      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border/70 bg-secondary/40 px-3">
-        <button
-          type="button"
-          onClick={() => setDrawerOpen(true)}
-          className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          aria-label={t('common.openPanel', { title })}
-          title={title}
-        >
-          <PanelLeftOpen size={17} strokeWidth={1.75} aria-hidden />
-        </button>
-        <span className="min-w-0 truncate text-[13px] font-semibold text-foreground">{title}</span>
+      <div
+        aria-hidden={drawerOpen ? true : undefined}
+        inert={drawerOpen ? true : undefined}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border/70 bg-secondary/40 px-3">
+          <button
+            ref={mobileTriggerRef}
+            type="button"
+            onClick={() => setDrawerOpen(true)}
+            className="oa-icon-action flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label={t('common.openPanel', { title })}
+            aria-expanded={drawerOpen}
+            aria-controls={mobileDrawerId}
+            aria-haspopup="dialog"
+            title={title}
+          >
+            <PanelLeftOpen size={17} strokeWidth={1.75} aria-hidden />
+          </button>
+          <span className="min-w-0 truncate text-[13px] font-semibold text-foreground">{title}</span>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col">{children}</div>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col">{children}</div>
 
-      <div
-        className={`absolute inset-0 z-30 bg-backdrop transition-opacity duration-200 ${
-          drawerOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
-        }`}
-        onClick={() => setDrawerOpen(false)}
-      />
-      <div
+      <dialog
+        ref={mobileDrawerRef}
+        id={mobileDrawerId}
         data-testid="page-sidebar-drawer"
         data-state={drawerOpen ? 'open' : 'closed'}
+        role="dialog"
+        aria-label={title}
+        aria-modal={drawerOpen ? true : undefined}
         aria-hidden={!drawerOpen}
         inert={!drawerOpen ? true : undefined}
-        className={`absolute inset-y-0 left-0 z-40 w-[280px] max-w-[85vw] transition-transform duration-200 ${
-          drawerOpen ? 'translate-x-0' : '-translate-x-full'
-        }`}
+        tabIndex={-1}
+        className="oa-page-sidebar-dialog fixed inset-y-0 left-0 right-auto m-0 h-dvh max-h-none w-[280px] max-w-[85vw] overflow-hidden border-0 bg-transparent p-0 text-foreground outline-none"
+        onCancel={(event) => {
+          event.preventDefault()
+          setDrawerOpen(false)
+        }}
+        onClose={() => {
+          if (drawerOpen) setDrawerOpen(false)
+        }}
+        onClick={(event) => {
+          if (event.target === event.currentTarget) setDrawerOpen(false)
+        }}
       >
         <Sidebar
           title={title}
@@ -294,7 +393,7 @@ export function PageSidebarLayout({
             <button
               type="button"
               onClick={() => setDrawerOpen(false)}
-              className="text-muted-foreground hover:text-foreground p-1 -ml-1"
+              className="oa-icon-action -ml-2 flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               aria-label={t('common.closePanel', { title })}
             >
               <X size={15} strokeWidth={1.75} aria-hidden />
@@ -303,7 +402,7 @@ export function PageSidebarLayout({
         >
           {sidebarContent}
         </Sidebar>
-      </div>
+      </dialog>
     </div>
   )
 }

--- a/ui/src/components/TrackedSidebar.spec.tsx
+++ b/ui/src/components/TrackedSidebar.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { EntityListItem } from '../api/entities'
@@ -97,5 +97,27 @@ describe('TrackedSidebar collection failure', () => {
 
     expect(screen.getByText('vst')).toBeTruthy()
     expect(screen.queryByRole('status')).toBeNull()
+  })
+})
+
+describe('TrackedSidebar navigation', () => {
+  it('notifies the page shell after selecting an entity', () => {
+    mocks.entitiesState.current = {
+      entities: [trackedEntity],
+      loading: false,
+      error: null,
+      refreshing: false,
+    }
+    const onNavigate = vi.fn()
+
+    render(<TrackedSidebar onNavigate={onNavigate} />)
+    mocks.select.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: 'stockvst1' }))
+
+    expect(mocks.select).toHaveBeenCalledWith('stock-vst')
+    expect(mocks.setSidebar).toHaveBeenCalledWith('tracked')
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({ kind: 'tracked', params: {} })
+    expect(onNavigate).toHaveBeenCalledOnce()
   })
 })

--- a/ui/src/components/TrackedSidebar.tsx
+++ b/ui/src/components/TrackedSidebar.tsx
@@ -14,7 +14,7 @@ import type { EntityListItem } from '../api/entities'
  * notes link to it. Selection lives in `useTrackedSelection` so it survives
  * remounts and is read by TrackedPage in the editor area.
  */
-export function TrackedSidebar() {
+export function TrackedSidebar({ onNavigate }: { onNavigate?: () => void }) {
   const { t } = useTranslation()
   const entities = entitiesLive.useStore((s) => s.entities)
   const loading = entitiesLive.useStore((s) => s.loading)
@@ -80,6 +80,7 @@ export function TrackedSidebar() {
         select(entity.name)
         setSidebar('tracked')
         openOrFocus({ kind: 'tracked', params: {} })
+        onNavigate?.()
       }}
     />
   )

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -262,6 +262,24 @@ body {
   animation: oa-backdrop-enter var(--motion-standard) ease-out both;
 }
 
+/* Page-owned navigators become touch surfaces inside the phone drawer.
+   A 40px height floor removes the old 18–28px rows; icon controls keep 36px
+   of horizontal room so adjacent workspace names remain distinguishable. */
+.oa-page-sidebar-dialog :is(button, [role="button"]) {
+  min-height: 2.5rem;
+}
+
+.oa-page-sidebar-dialog button:has(svg) {
+  min-width: 2.25rem;
+}
+
+.oa-page-sidebar-dialog :is(
+  input:not([type="checkbox"]):not([type="radio"]),
+  select
+) {
+  min-height: 2.5rem;
+}
+
 .oa-disclosure-enter {
   transform-origin: top;
   animation: oa-disclosure-enter var(--motion-standard) var(--motion-ease-out) both;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -214,6 +214,11 @@ body {
   to { opacity: 1; }
 }
 
+@keyframes oa-page-sidebar-enter {
+  from { transform: translateX(-100%); }
+  to { transform: none; }
+}
+
 @keyframes oa-disclosure-enter {
   from {
     opacity: 0;
@@ -245,6 +250,15 @@ body {
 }
 
 .oa-dialog-backdrop {
+  animation: oa-backdrop-enter var(--motion-standard) ease-out both;
+}
+
+.oa-page-sidebar-dialog[open] {
+  animation: oa-page-sidebar-enter var(--motion-standard) var(--motion-ease-out) both;
+}
+
+.oa-page-sidebar-dialog::backdrop {
+  background: var(--backdrop);
   animation: oa-backdrop-enter var(--motion-standard) ease-out both;
 }
 
@@ -558,6 +572,8 @@ html[lang="ja"] .oa-onboarding-title {
   .oa-view-enter,
   .oa-dialog-surface,
   .oa-dialog-backdrop,
+  .oa-page-sidebar-dialog[open],
+  .oa-page-sidebar-dialog::backdrop,
   .oa-disclosure-enter,
   .oa-popover-enter {
     animation: none;

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -154,7 +154,7 @@ const trackedIssueDetailModule: ViewModule<'tracked-issue-detail'> = {
       storageKey="tracked"
       titleKey="nav.item.tracked"
       defaultWidth={232}
-      sidebar={<TrackedSidebar />}
+      sidebar={({ closeMobileDrawer }) => <TrackedSidebar onNavigate={closeMobileDrawer} />}
     >
       <TrackedIssueDetailPage spec={spec} />
     </PageSidebarShell>
@@ -381,7 +381,7 @@ const trackedModule: ViewModule<'tracked'> = {
       storageKey="tracked"
       titleKey="nav.item.tracked"
       defaultWidth={232}
-      sidebar={<TrackedSidebar />}
+      sidebar={({ closeMobileDrawer }) => <TrackedSidebar onNavigate={closeMobileDrawer} />}
     >
       <TrackedPage />
     </PageSidebarShell>
@@ -521,7 +521,7 @@ const fileViewerModule: ViewModule<'file-viewer'> = {
           storageKey="tracked"
           titleKey="nav.item.tracked"
           defaultWidth={232}
-          sidebar={<TrackedSidebar />}
+          sidebar={({ closeMobileDrawer }) => <TrackedSidebar onNavigate={closeMobileDrawer} />}
         >
           <FileViewerPage spec={spec} />
         </PageSidebarShell>


### PR DESCRIPTION
## Topic

Make every page-owned mobile navigator behave like a real modal drawer and remain practical to operate by touch.

## Why

`PageSidebarLayout` previously rendered its phone navigator as an absolutely positioned `div` inside the active page. It looked modal, but focus stayed on the obscured page, Escape did nothing, background controls remained reachable, and the global app header could still open a second drawer above it. The shared drawer also retained desktop-sized 18–32px controls in Chat and Inbox.

Tracked exposed a related same-route edge case: selecting another entity updated the content behind the modal drawer without changing the URL, so the drawer stayed open and hid the result.

This is especially fragile for the planned remote-control path, where these navigators become a primary phone interaction rather than an occasional narrow-window fallback.

## Atomic increments

### 1. Make page sidebars truly modal

- Render the phone navigator with native `dialog.showModal()` so it owns the browser top layer and isolates the global app header as well as page content.
- Move focus into the drawer, prefer the current navigation item, contain Tab / Shift+Tab, close on Escape or backdrop click, and restore focus to the opener.
- Expose `aria-expanded`, `aria-controls`, `aria-haspopup`, dialog naming, and modal state.
- Keep the obscured page subtree `aria-hidden` and `inert` while the drawer is active.
- Raise the phone open/close controls to 40×40px.
- Add directional drawer/backdrop entrance motion using existing tokens and remove it under reduced motion.

### 2. Make drawer content touch-friendly

- Give all phone-drawer controls and navigation rows a 40px height floor.
- Give icon actions 36px of horizontal hit area, preserving enough room to distinguish adjacent workspace names at 320px.
- Raise text inputs and selects inside the drawer to 40px without changing checkbox/radio geometry.
- Keep the desktop sidebar branch and its compact 28px controls unchanged.

### 3. Reveal same-route Tracked selections immediately

- Let `TrackedSidebar` notify the page shell after a user selects an entity.
- Close the phone drawer after the entity store and focused Tracked view update, so the selected asset or topic is visible immediately.
- Wire the behavior through Tracked overview, Tracked Issue detail, and Tracked file-reader shells.
- Keep desktop selection and route semantics unchanged.

## User impact

The shared change covers Ask Alice, Inbox, Tracked, Portfolio, Settings, Workspaces, Market, Automation, and every other route using `PageSidebarLayout`. Phone users can enter, navigate, select same-route Tracked entities, and leave these surfaces without precise pointer work or escaping into the obscured page.

## Responsive behavior

- **320–390px:** 272–280px modal drawer, no horizontal page overflow, distinguishable Chat workspace labels, internally scrollable long lists.
- **Phone landscape:** the drawer keeps an independently scrollable body.
- **Desktop:** static/resizable page sidebar density and collapse controls are unchanged.

## Real-browser verification (`pnpm dev`)

- Chat at 390×844: secondary drawer opens above the global header, focus enters `Close Ask Alice`, and the primary app drawer cannot stack underneath it.
- Sequential primary → Inbox → secondary navigation: each drawer closes before the next surface opens.
- Chat at 320×700: all visible interactive rows are at least 40px tall, icon actions are at least 36×40px, `chat-jul12` / `chat-jul10` remain distinguishable, and there is no horizontal overflow.
- Inbox at 320×700: search is 40px tall; view toggles are 36×40px; no visible control is under 40px tall.
- Tracked at 390×844: selecting `LLY` closes the modal drawer and immediately reveals the `stock-lly` detail with its backlink.
- Tracked at 1280×900: desktop sidebar remains expanded and its collapse control remains 28×28px.
- Reduced-motion emulation: drawer and backdrop animation names resolve to `none`.

## Automated verification

- `npx tsc --noEmit`
- `pnpm --dir ui exec tsc -b`
- `pnpm test` — 431 files passed, 1 skipped; 3633 tests passed, 9 skipped
- `pnpm --dir ui exec vitest run src/components/PageSidebarLayout.spec.tsx src/components/TrackedSidebar.spec.tsx` — 7 passed
- Installer timeout observed under competing full-suite runs was isolated and rerun: `pnpm exec vitest run packages/cli/src/install.spec.mjs` — 10 passed

## Design review

- Removes the false-modal state and the possibility of two simultaneous navigation layers.
- Makes the focused navigator the unambiguous top layer.
- Makes a Tracked selection feel like navigation even though its URL does not change.
- Reuses the existing paper surfaces, backdrop token, motion durations, easing, and icon-action vocabulary.
- Introduces no new color or visual dialect.

## Boundary / non-goals

- No business navigation, Workspace lifecycle, Inbox data, broker, or trading behavior changes.
- No desktop density redesign.
- No attempt to regroup Chat's workspace actions; this topic only makes the existing actions operable and preserves their labels.

Closes #860
Related: #858, #859
