### PR TITLE
Make mobile Automation Runs scan-first and touch-friendly

### DIFF
--- a/ui/src/pages/AutomationRunsSection.spec.tsx
+++ b/ui/src/pages/AutomationRunsSection.spec.tsx
@@ -217,6 +217,64 @@ describe('AutomationRunsSection workspace identity', () => {
 })
 
 describe('AutomationRunsSection run controls', () => {
+  it('keeps the mobile summary compact without dropping operational context', async () => {
+    const current = snapshot([task({ status: 'done' })])
+    current.page = { total: 147, hasMore: true, nextCursor: 'run-default' }
+    current.summary = { done: 105, needsAttention: 42 }
+    mocks.snapshot.mockResolvedValue(current)
+
+    render(<AutomationRunsSection />)
+
+    const summary = await screen.findByTestId('runs-summary')
+    expect(summary.className).toContain('grid-cols-3')
+    expect(within(summary).getByText('Workers')).toBeTruthy()
+    expect(within(summary).getByText('42 attention')).toBeTruthy()
+    expect(within(summary).getByText('CLI formats')).toBeTruthy()
+    expect(within(summary).getByText('No workers active')).toBeTruthy()
+    expect(within(summary).getByText('Showing 1 · 105 completed · 42 need attention')).toBeTruthy()
+  })
+
+  it('gives expanded run actions and pagination mobile-sized touch targets', async () => {
+    const issueTask = task({
+      taskId: 'run-touch-targets',
+      status: 'done',
+      resumable: true,
+      trigger: {
+        kind: 'issue',
+        workspaceId: liveWorkspace.id,
+        issueId: 'daily-risk-scan',
+      },
+    })
+    const current = snapshot([issueTask])
+    current.page = { total: 26, hasMore: true, nextCursor: issueTask.taskId }
+    mocks.snapshot.mockResolvedValue(current)
+    mocks.output.mockResolvedValue({
+      taskId: issueTask.taskId,
+      status: 'done',
+      structured: {
+        schemaVersion: 1,
+        assistantText: null,
+        blocks: [],
+        metrics: { textBlocks: 0, toolCalls: 0, toolFailures: 0 },
+        truncated: false,
+      },
+      stdout: null,
+      stderr: null,
+    })
+
+    render(<AutomationRunsSection />)
+
+    fireEvent.click(await screen.findByRole('button', {
+      name: 'Run details, done: daily-risk-scan. codex in quant-desk.',
+    }))
+
+    expect(screen.getByText('Task instructions').className).toContain('min-h-10')
+    expect(screen.getByRole('button', { name: 'Open Issue' }).className).toContain('min-h-10')
+    expect(screen.getByRole('button', { name: 'Open as session' }).className).toContain('min-h-10')
+    expect((await screen.findByText('Runtime diagnostics')).className).toContain('min-h-10')
+    expect(screen.getByTestId('runs-load-more').className).toContain('min-h-10')
+  })
+
   it('gives long task instructions a concise accessible name without hiding the visible prompt', async () => {
     const omittedTail = 'TAIL_MARKER_THAT_MUST_NOT_BE_READ_FOR_EVERY_RUN'
     const prompt = `Review the latest market snapshot and summarize material changes. ${'Include supporting detail. '.repeat(12)}${omittedTail}`

--- a/ui/src/pages/AutomationRunsSection.tsx
+++ b/ui/src/pages/AutomationRunsSection.tsx
@@ -71,7 +71,7 @@ function ToolBlock({ block }: { block: Extract<HeadlessMessageBlock, { type: 'to
       : 'text-info'
   return (
     <details className="group/tool rounded-lg border border-border/60 bg-secondary/35" open={block.status === 'failed'}>
-      <summary className={`flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs ${statusClass}`}>
+      <summary className={`flex min-h-10 cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs sm:min-h-0 ${statusClass}`}>
         <Wrench size={13} className="shrink-0" />
         <span className="min-w-0 flex-1 truncate font-medium text-foreground">{block.name}</span>
         <span className="shrink-0 uppercase tracking-wide">{block.status}</span>
@@ -177,7 +177,7 @@ function RunOutput({ task }: { task: HeadlessTaskRecord }) {
       )}
 
       <details className="rounded-lg border border-border/60">
-        <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground">
+        <summary className="flex min-h-10 cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:text-foreground sm:min-h-0">
           <TerminalSquare size={13} />
           Runtime diagnostics
         </summary>
@@ -201,12 +201,30 @@ function RunOutput({ task }: { task: HeadlessTaskRecord }) {
   )
 }
 
-function SummaryCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+function SummaryCard({
+  label,
+  mobileLabel = label,
+  value,
+  detail,
+  mobileDetail = detail,
+}: {
+  label: string
+  mobileLabel?: string
+  value: string
+  detail: string
+  mobileDetail?: string
+}) {
   return (
-    <div className="rounded-lg border border-border/60 bg-secondary/25 px-3 py-2">
-      <div className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/70">{label}</div>
+    <div className="min-w-0 rounded-lg border border-border/60 bg-secondary/25 px-2 py-2 sm:px-3">
+      <div className="truncate text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70 sm:tracking-[0.1em]">
+        <span className="sm:hidden">{mobileLabel}</span>
+        <span className="hidden sm:inline">{label}</span>
+      </div>
       <div className="mt-0.5 text-lg font-semibold text-foreground">{value}</div>
-      <div className="text-[11px] text-muted-foreground">{detail}</div>
+      <div className="truncate text-[10px] text-muted-foreground sm:overflow-visible sm:text-clip sm:whitespace-normal sm:text-[11px]">
+        <span className="sm:hidden">{mobileDetail}</span>
+        <span className="hidden sm:inline">{detail}</span>
+      </div>
     </div>
   )
 }
@@ -408,18 +426,27 @@ export function AutomationRunsSection() {
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+      <div data-testid="runs-summary" className="grid grid-cols-3 gap-2">
         <SummaryCard
           label="Concurrency"
+          mobileLabel="Workers"
           value={`${snapshot.capacity.running} / ${snapshot.capacity.limit}`}
           detail={snapshot.capacity.running === 0 ? 'No workers active' : 'Native agent workers active'}
+          mobileDetail={snapshot.capacity.running === 0 ? 'Idle' : `${snapshot.capacity.running} active`}
         />
         <SummaryCard
           label="Runs"
           value={String(snapshot.page.total)}
           detail={`Showing ${snapshot.tasks.length} · ${snapshot.summary.done} completed · ${snapshot.summary.needsAttention} need attention`}
+          mobileDetail={snapshot.summary.needsAttention === 0 ? 'All clear' : `${snapshot.summary.needsAttention} attention`}
         />
-        <SummaryCard label="Runtime parsers" value="4" detail="Claude · Codex · OpenCode · Pi" />
+        <SummaryCard
+          label="Runtime parsers"
+          mobileLabel="Parsers"
+          value="4"
+          detail="Claude · Codex · OpenCode · Pi"
+          mobileDetail="CLI formats"
+        />
       </div>
 
       {snapshot.tasks.length === 0 ? (
@@ -489,7 +516,7 @@ export function AutomationRunsSection() {
                 {isExpanded && (
                   <div className="space-y-3 border-t border-border/60 px-3 py-3">
                     <details className="rounded-lg border border-border/60 bg-secondary/25">
-                      <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground">
+                      <summary className="flex min-h-10 cursor-pointer items-center px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground sm:min-h-0">
                         Task instructions
                       </summary>
                       <pre className="max-h-64 overflow-auto border-t border-border/50 px-3 py-2 whitespace-pre-wrap break-words text-[11px] leading-relaxed text-muted-foreground">
@@ -507,7 +534,7 @@ export function AutomationRunsSection() {
                         {issueSource && (
                           <button
                             type="button"
-                            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-primary hover:bg-primary/10"
+                            className="inline-flex min-h-10 items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-primary hover:bg-primary/10 sm:min-h-0"
                             onClick={() => openOrFocus({
                               kind: 'issue-detail',
                               params: {
@@ -523,7 +550,7 @@ export function AutomationRunsSection() {
                         {openable && (
                           <button
                             type="button"
-                            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-success hover:bg-success/10"
+                            className="inline-flex min-h-10 items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-success hover:bg-success/10 sm:min-h-0"
                             title="Resume this run's conversation in an interactive session"
                             onClick={() => {
                               void openHeadlessRun(task.wsId, task.resumeId, {
@@ -550,7 +577,7 @@ export function AutomationRunsSection() {
                 data-testid="runs-load-more"
                 disabled={loadingMore}
                 onClick={() => void loadMore()}
-                className="rounded-lg border border-border bg-secondary/35 px-4 py-2 text-xs font-medium text-foreground hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+                className="min-h-10 rounded-lg border border-border bg-secondary/35 px-4 py-2 text-xs font-medium text-foreground hover:bg-muted disabled:cursor-wait disabled:opacity-60 sm:min-h-0"
               >
                 {loadingMore ? 'Loading older runs…' : `Load ${Math.min(RUNS_PAGE_SIZE, snapshot.page.total - snapshot.tasks.length)} older runs`}
               </button>


### PR DESCRIPTION
## Summary

- compress the three Automation Runs summary metrics into one scan-first phone row while keeping the existing full desktop cards
- preserve the mobile attention count and concise worker/parser state instead of hiding operational context
- give expanded run disclosures, Issue/Session actions, tool diagnostics, and older-run pagination 40px mobile touch targets
- keep desktop controls compact at the existing breakpoint

Closes #862

## Visual hierarchy

The first run now starts at roughly 316px in a 320px viewport instead of being pushed to about 500px by three stacked summary cards. The implementation reuses the existing warm cards, borders, typography, breakpoints, and semantic status colors; it does not add a new visual dialect.

## Verification

- `npx tsc --noEmit`
- `pnpm --dir ui exec tsc -b`
- `pnpm --dir ui exec vitest run src/pages/AutomationRunsSection.spec.tsx` (9 passed)
- `pnpm test` (431 files passed, 1 skipped; 3633 tests passed, 9 skipped)
- real `pnpm dev` route `/automation/runs` at 320×700: no horizontal overflow; summary is 78px high; first run begins at y=316; Task instructions, Open Issue, Runtime diagnostics, and Load older runs each measure 40px high
- real `pnpm dev` route at 1280×900: three-column summary retains full desktop detail; run list and desktop density remain unchanged

## Review notes

This topic intentionally does not alter run identity, Issue navigation behavior, dispatch semantics, or output parsing. Those are separate owner boundaries.