### PR TITLE
Make mobile Workspace overview scan-first and session-friendly

### DIFF
--- a/ui/src/components/workspace/OverviewCard.spec.tsx
+++ b/ui/src/components/workspace/OverviewCard.spec.tsx
@@ -111,9 +111,43 @@ describe('OverviewCard', () => {
     expect(screen.getAllByRole('button', { name: / (running|paused)$/ })).toHaveLength(5)
     expect(screen.getByRole('button', { name: 'x5 paused' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'x6 paused' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'x1 running' }).className).toContain('min-h-10')
+    expect(screen.getByRole('button', { name: 'x3 paused' }).closest('li')?.className)
+      .toContain('hidden sm:list-item')
 
-    fireEvent.click(screen.getByRole('button', { name: 'View all 8 sessions' }))
+    const viewAll = screen.getByRole('button', { name: 'View all 8 sessions' })
+    expect(viewAll.className).toContain('min-h-10')
+    expect(viewAll.textContent).toContain('+6')
+    expect(viewAll.textContent).toContain('+3')
+    fireEvent.click(viewAll)
     expect(onOpen).toHaveBeenCalledTimes(1)
     expect(onOpenSession).not.toHaveBeenCalled()
+  })
+
+  it('offers a mobile-only View all path when the desktop preview still fits', () => {
+    const threeSessionWorkspace: Workspace = {
+      ...workspace,
+      sessions: Array.from({ length: 3 }, (_, index) => ({
+        ...workspace.sessions[0]!,
+        id: `session-${index + 1}`,
+        resumeId: `resume-${index + 1}`,
+        name: `x${index + 1}`,
+      })),
+    }
+
+    render(
+      <OverviewCard
+        workspace={threeSessionWorkspace}
+        lastCommit={null}
+        onOpen={() => undefined}
+        onOpenSession={() => undefined}
+      />,
+    )
+
+    const viewAll = screen.getByRole('button', { name: 'View all 3 sessions' })
+    expect(viewAll.closest('li')?.className).toContain('sm:hidden')
+    expect(viewAll.textContent).toContain('+1')
+    expect(screen.getByRole('button', { name: 'x3 running' }).closest('li')?.className)
+      .toContain('hidden sm:list-item')
   })
 })

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -25,6 +25,7 @@ const AGENT_ICONS: Record<string, LucideIcon> = {
 }
 
 const SESSION_PREVIEW_LIMIT = 5
+const MOBILE_SESSION_PREVIEW_LIMIT = 2
 
 function AgentGlyph({ agent }: { agent: string }) {
   const Icon = AGENT_ICONS[agent]
@@ -57,6 +58,7 @@ export function OverviewCard({
   const hasRunning = w.sessions.some((s) => s.state === 'running')
   const previewSessions = w.sessions.slice(0, SESSION_PREVIEW_LIMIT)
   const hiddenSessionCount = w.sessions.length - previewSessions.length
+  const mobileHiddenSessionCount = Math.max(0, w.sessions.length - MOBILE_SESSION_PREVIEW_LIMIT)
 
   const lastActivityMs = useMemo(() => {
     const sessionTs = w.sessions
@@ -80,7 +82,7 @@ export function OverviewCard({
 
   return (
     <article
-      className="group relative rounded-lg border border-border bg-secondary p-4 transition-colors hover:border-border/80 hover:bg-muted/40"
+      className="group relative rounded-lg border border-border bg-secondary p-3 transition-colors hover:border-border/80 hover:bg-muted/40 sm:p-4"
     >
       <button
         type="button"
@@ -113,7 +115,7 @@ export function OverviewCard({
                 from: w.upgradeAvailable.from,
                 to: w.upgradeAvailable.to,
               })}
-              className="oa-pressable pointer-events-auto shrink-0 flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-primary border border-primary/40 hover:border-primary/80 hover:bg-primary/10 transition-colors disabled:cursor-default disabled:hover:border-primary/40 disabled:hover:bg-transparent"
+              className="oa-pressable pointer-events-auto flex min-h-10 shrink-0 items-center gap-1 rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium text-primary transition-colors hover:border-primary/80 hover:bg-primary/10 disabled:cursor-default disabled:hover:border-primary/40 disabled:hover:bg-transparent sm:min-h-0"
             >
               <ArrowUpCircle size={10} strokeWidth={2.25} />
               <span>v{w.upgradeAvailable.to}</span>
@@ -131,13 +133,16 @@ export function OverviewCard({
             <p className="text-[12px] text-muted-foreground/80 italic">{t('workspace.noSessions')}</p>
           ) : (
             <ul className="space-y-0.5 -mx-2">
-              {previewSessions.map((s) => (
-                <li key={s.id}>
+              {previewSessions.map((s, index) => (
+                <li
+                  key={s.id}
+                  className={index >= MOBILE_SESSION_PREVIEW_LIMIT ? 'hidden sm:list-item' : undefined}
+                >
                   <button
                     type="button"
                     aria-label={`${s.name} ${t(s.state === 'running' ? 'workspace.running' : 'workspace.paused')}`}
                     onClick={() => onOpenSession(s.id)}
-                    className="oa-nav-row pointer-events-auto flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[12px] text-foreground hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    className="oa-nav-row pointer-events-auto flex min-h-10 w-full items-center gap-2 rounded px-2 py-1 text-left text-[12px] text-foreground hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:min-h-0"
                   >
                     <span className="w-3 flex justify-center text-muted-foreground">
                       <AgentGlyph agent={s.agent} />
@@ -152,21 +157,24 @@ export function OverviewCard({
                     </span>
                     <ChevronRight
                       size={10}
-                      className="ml-auto text-muted-foreground opacity-0 group-hover:opacity-60 transition-opacity"
+                      className="ml-auto text-muted-foreground opacity-60 transition-opacity sm:opacity-0 sm:group-hover:opacity-60"
                     />
                   </button>
                 </li>
               ))}
-              {hiddenSessionCount > 0 && (
-                <li className="mt-1 border-t border-border/60 pt-1">
+              {mobileHiddenSessionCount > 0 && (
+                <li className={`mt-1 border-t border-border/60 pt-1 ${hiddenSessionCount === 0 ? 'sm:hidden' : ''}`}>
                   <button
                     type="button"
                     onClick={onOpen}
                     aria-label={t('workspace.viewAllSessions', { count: w.sessions.length })}
-                    className="oa-nav-row pointer-events-auto flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[11px] font-medium text-primary hover:bg-primary/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    className="oa-nav-row pointer-events-auto flex min-h-10 w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[11px] font-medium text-primary hover:bg-primary/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:min-h-0"
                   >
                     <span>{t('workspace.viewAllSessions', { count: w.sessions.length })}</span>
-                    <span className="ml-auto tabular-nums text-muted-foreground/55">
+                    <span className="ml-auto tabular-nums text-muted-foreground/55 sm:hidden">
+                      +{mobileHiddenSessionCount}
+                    </span>
+                    <span className="ml-auto hidden tabular-nums text-muted-foreground/55 sm:inline">
                       +{hiddenSessionCount}
                     </span>
                     <ChevronRight size={11} className="text-primary/65" aria-hidden />
@@ -195,7 +203,7 @@ export function OverviewCard({
               <button
                 type="button"
                 onClick={onConfigure}
-                className="pointer-events-auto flex items-center gap-2 text-[11px] text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+                className="pointer-events-auto flex min-h-10 w-full items-center gap-2 text-left text-[11px] text-muted-foreground transition-colors hover:text-foreground sm:min-h-0"
               >
                 <Settings size={11} strokeWidth={2.25} className="shrink-0" />
                 <span>{t('workspace.override', { agents: overrideAgents.join(', ') })}</span>

--- a/ui/src/pages/WorkspaceListPage.tsx
+++ b/ui/src/pages/WorkspaceListPage.tsx
@@ -173,8 +173,8 @@ export function WorkspaceListPage() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="max-w-5xl mx-auto px-6 py-6">
-        <div className="mb-6 flex items-baseline justify-between gap-4">
+      <div className="mx-auto max-w-5xl px-4 py-4 sm:px-6 sm:py-6">
+        <div className="mb-4 flex items-baseline justify-between gap-4 sm:mb-6">
           <h2 className="text-[18px] font-semibold text-foreground">{t('workspace.overviewTitle')}</h2>
           <span className="text-[12px] text-muted-foreground">
             {t(workspaces.length === 1 ? 'workspace.workspaceSingular' : 'workspace.workspacePlural', {
@@ -183,7 +183,7 @@ export function WorkspaceListPage() {
           </span>
         </div>
 
-        <div className="space-y-7">
+        <div className="space-y-5 sm:space-y-7">
           {sections.map((sec) => (
             <section key={sec.key}>
               <div className="mb-3 flex items-baseline gap-2">
@@ -192,7 +192,7 @@ export function WorkspaceListPage() {
                 </h3>
                 <span className="text-[11px] text-muted-foreground">· {sec.workspaces.length}</span>
               </div>
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2">
                 {sec.workspaces.map((w) => (
                   <OverviewCard
                     key={w.id}
@@ -295,7 +295,7 @@ export function WorkspaceListPage() {
                         {!purged && workspace.lifecycle === 'departed' && (
                           <button
                             type="button"
-                            className="btn-secondary inline-flex items-center gap-1.5"
+                            className="btn-secondary inline-flex min-h-10 items-center gap-1.5 sm:min-h-0"
                             aria-label={t('workspace.restoreWorkspaceAria', { workspace: workspace.tag })}
                             disabled={lifecycleBusy !== null}
                             onClick={() => {
@@ -313,7 +313,7 @@ export function WorkspaceListPage() {
                         {!purged && workspace.lifecycle === 'departed' && (
                           <button
                             type="button"
-                            className="btn-danger inline-flex items-center gap-1.5"
+                            className="btn-danger inline-flex min-h-10 items-center gap-1.5 sm:min-h-0"
                             aria-label={t('workspace.purgeFilesAria', { workspace: workspace.tag })}
                             disabled={lifecycleBusy !== null}
                             onClick={() => setPendingPurge(workspace)}


### PR DESCRIPTION
## Summary

- use a distinct mobile information hierarchy for Workspace cards: preview two recent Sessions on phones while retaining the existing five-Session desktop preview
- expose one responsive **View all** action with the correct mobile and desktop hidden counts
- give Session drill-ins, View all, template-upgrade, provider-override, restore, and purge actions a 40px mobile minimum
- keep Session chevrons visible on touch layouts instead of relying on hover
- reclaim phone width and vertical rhythm with 16px page gutters, 12px card padding, and tighter section/card spacing; preserve the existing `sm`/desktop density

Closes #866

## User-facing effect

With realistic data (25 Sessions in the first Workspace), the first 390px-wide card changes from roughly 334×370px to 352×351px. It presents two 40px Session rows and **View all 25 sessions · +23** instead of five 25px rows and a 29px action. The next Workspace now enters the first screen, while the current desk and its immediate Sessions remain directly operable.

At 1280px the card still previews five 25px rows and **+20**, matching the existing dense management dashboard.

## Verification

- `npx tsc --noEmit`
- `pnpm --dir ui exec tsc -b`
- `pnpm --dir ui exec vitest run src/components/workspace/OverviewCard.spec.tsx src/pages/WorkspaceListPage.spec.tsx` (5 passed)
- `pnpm test` (431 files passed, 1 skipped; 3632 tests passed, 9 skipped)
- real `pnpm dev` `/workspaces` at 390×844: no horizontal overflow; first card 352×351; exactly two Session rows rendered at 40px; View all and provider override 40px; no visible card action below 40px
- real `pnpm dev` drill-in: tapping the first Session opened its exact `/workspaces/:workspaceId/s/:sessionId` route without triggering the Workspace card action
- real `pnpm dev` `/workspaces` at 1280×900: five Session rows remain visible at 25px; View all remains 29px; two-column card grid and original desktop spacing preserved
- departed Workspace actions were inspected but not invoked; lifecycle state and files were not mutated

## Review notes

This is presentation and navigation geometry only. Workspace lifecycle, Session ordering, restore/purge behavior, template upgrade behavior, and persisted state are unchanged. The mobile page-sidebar opener/closer remains owned by Draft PR #861.