### PR TITLE
Define Pi-based CLI architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,9 @@ Reference notes under `docs/reference/` are non-authoritative research
 material. The [installer script note](reference/install-script/README.md)
 records Claude Code and Codex upstream links and design lessons without
 vendoring third-party code. The
+[Pi and Herdr CLI architecture note](reference/pi-herdr-cli-architecture.md)
+pins the TypeScript TUI, startup, configuration, persistent Runtime, command,
+and running-update comparison behind the Shell CLI plan. The
 [Herdr remote Runtime note](reference/herdr-remote-architecture.md) records a
 pinned public-source architecture comparison behind the authoritative remote
 guide, also without vendoring third-party code.

--- a/docs/reference/pi-herdr-cli-architecture.md
+++ b/docs/reference/pi-herdr-cli-architecture.md
@@ -1,0 +1,142 @@
+# Pi and Herdr CLI Architecture Reference
+
+This is a non-authoritative research note for the OpenAlice Shell CLI and
+Supervisor TUI. Product contracts belong to [[docs/cli-supervisor.md]],
+[[docs/cli-installer.md]], [[docs/local-runtime.md]], and
+[[docs/data-locations.md]].
+
+## Reviewed snapshots and license boundary
+
+The comparison was performed on 2026-07-30 against:
+
+- Pi
+  [`v0.83.0`](https://github.com/earendil-works/pi/tree/v0.83.0), especially
+  [`packages/coding-agent/src/main.ts`](https://github.com/earendil-works/pi/blob/v0.83.0/packages/coding-agent/src/main.ts),
+  [`packages/coding-agent/src/core/settings-manager.ts`](https://github.com/earendil-works/pi/blob/v0.83.0/packages/coding-agent/src/core/settings-manager.ts),
+  [`packages/coding-agent/src/utils/version-check.ts`](https://github.com/earendil-works/pi/blob/v0.83.0/packages/coding-agent/src/utils/version-check.ts),
+  and
+  [`packages/tui`](https://github.com/earendil-works/pi/tree/v0.83.0/packages/tui);
+- Herdr
+  [`v0.7.5`](https://github.com/herdrdev/herdr/tree/v0.7.5), especially
+  [`src/main.rs`](https://github.com/herdrdev/herdr/blob/v0.7.5/src/main.rs),
+  [`src/server/autodetect.rs`](https://github.com/herdrdev/herdr/blob/v0.7.5/src/server/autodetect.rs),
+  [`src/cli/status.rs`](https://github.com/herdrdev/herdr/blob/v0.7.5/src/cli/status.rs),
+  and
+  [`src/update.rs`](https://github.com/herdrdev/herdr/blob/v0.7.5/src/update.rs).
+
+`@earendil-works/pi-tui` declares the MIT license and can be consumed as a
+normal dependency with its notices preserved. Herdr declares
+AGPL-3.0-or-later with a commercial option. OpenAlice uses Herdr as a behavioral
+and interface reference; this note does not vendor Herdr source.
+
+## Executive decision
+
+OpenAlice does not choose between a TUI-first application and a scriptable CLI.
+It ships one application core with two entry modes:
+
+```text
+openalice
+  -> resolve launch context
+  -> inspect or ensure selected Guardian Runtime
+  -> start the pi-tui Supervisor application
+
+openalice <command>
+  -> resolve the same launch context
+  -> call the same typed application service
+  -> render human or schema-versioned JSON output
+```
+
+Pi is the primary reference for the TypeScript application shell, terminal
+library, startup sequencing, first-run/settings presentation, and asynchronous
+update notice. Herdr is the primary reference for persistent process
+attachment, named Runtime selection, protocol/version reporting, command/API
+symmetry, and running-update impact. OpenAlice's Guardian, complete-home model,
+browser product, and installer trust chain remain authoritative where the
+references differ.
+
+## Reference matrix
+
+| Concern | Pi lesson | Herdr lesson | OpenAlice decision |
+|---|---|---|---|
+| Bare command | Enter the interactive application after special commands and configuration resolve | Detect or spawn the persistent server, then attach a thin TUI client | Bare `openalice` always enters the Supervisor TUI; explicit subcommands bypass it |
+| Language and TUI | Strict TypeScript application using the MIT `pi-tui` component/terminal package | Rust `ratatui` application with a server-rendered client protocol | Strict TypeScript with `pi-tui`; no React/Ink layer and no repository-owned terminal renderer |
+| Command dispatch | Handle auth, package, config, print, and RPC-like modes before interactive startup | `maybe_run` intercepts stable CLI/API commands before default attach | One root parser dispatches explicit commands first; unknown commands never fall through into the TUI |
+| Persistent ownership | Interactive process normally owns its own agent session | Detached server owns PTYs and state while clients attach/detach | Existing Guardian remains the sole Runtime/process-tree owner; the TUI is only a control client |
+| Attach/start | Not the primary architecture | Probe the socket, validate protocol, start the daemon if absent, wait for readiness, then attach | Probe Guardian control, classify compatibility/ownership, attach if possible, and start only under explicit selected policy |
+| Foreground escape hatch | Print/RPC/noninteractive modes | `--no-session` monolithic mode | `openalice run` explicitly owns foreground lifetime; it is not the default user entry |
+| Settings | Global settings plus project settings, with later layers overriding and nested values merging | Platform config path, env path override, validation, diagnostics, and safe live reload | Resolve defaults < machine config < instance config < env < CLI once into `ResolvedLaunchContext`, retaining provenance |
+| Instance isolation | `PI_CODING_AGENT_DIR` can replace the global Pi configuration root | Named sessions isolate sockets and persistent data | Named OpenAlice instances select complete homes; managed Pi gets an instance-local Pi root, external Pi stays native |
+| First run | Reusable startup TUI and selectors | Native onboarding overlay | First run is a state inside the same Supervisor TUI, never a separate throwaway CLI wizard |
+| Status | Interactive UI owns most presentation | Human and JSON status separate client/server versions, protocol, capabilities, and restart need | Human and versioned JSON report installed CLI, running Runtime, protocol compatibility, ownership, components, and pending activation |
+| Logs/Doctor | Application diagnostics live in interactive surfaces | Stable socket API and config diagnostics | TUI panels and noninteractive commands reuse bounded, redacted presentation-neutral readers |
+| Update discovery | Start the version request after TUI initialization; failure is silent; show changelog/update state | Background check only advertises availability and release notes; configurable channels | Async, disableable, cached notice after first render; no automatic mutation |
+| Explicit update | Detect package manager and update the Pi package | Detect install manager; direct installs download/verify; enumerate running sessions; optionally hand off | Detect provenance; package-manager installs show manager guidance; direct installs invoke the verified OpenAlice multi-artifact transaction |
+| Running update | Primarily updates the CLI package for the next process | Distinguishes updated client binary from old running server and reports restart need | Treat installed and running versions separately; stage first, then keep compatible instances or confirm restart for incompatible activation |
+| Handoff | Not the reference | Capability-gated live server handoff with recovery classification | Do not promise live PTY handoff initially; use Guardian readiness-gated restart and rollback, leaving live handoff as a later capability |
+| Version channels | Package/release version check | Stable/preview manifests plus package-manager restrictions | One OpenAlice product version; channel and artifact identities are metadata, not additional user-facing version sequences |
+| Uninstall | Package-manager concern | Installer/package-manager concern rather than Runtime data deletion | Remove installer-owned CLI/Pi/Runtime assets and PATH integration; preserve every `OPENALICE_HOME` unless separately and explicitly deleted |
+| Test seams | Dependency-injected app resources and isolated config roots | Fake available-version/release-note seams and protocol/update tests | Inject manifest provider, clock, process control, browser opener, and fault points; use isolated homes and real PTY/install A-to-B journeys |
+
+## What is copied, adapted, and rejected
+
+### Copy as a direct dependency or close structural pattern
+
+- `@earendil-works/pi-tui` terminal lifecycle, differential rendering,
+  components, overlays, Unicode-width handling, and Windows terminal support;
+- Pi's entry ordering: special commands first, complete context resolution,
+  resource/application creation, TUI start, then optional background checks;
+- Herdr's separation of client version, server version, protocol,
+  capabilities, compatibility, and restart-needed state;
+- Herdr's default attach semantics and named persistent target grammar;
+- Herdr's update planning across every running target before any process
+  mutation.
+
+### Adapt to OpenAlice
+
+- Pi's global/project settings become machine/instance settings because an
+  OpenAlice instance is a complete data and Runtime boundary, not a source
+  repository preference;
+- Herdr's server becomes the existing Guardian tree rather than a second
+  daemon;
+- Herdr's session vocabulary becomes `instance` because OpenAlice already uses
+  Workspace Session as a product concept;
+- Pi/Herdr update notices feed the OpenAlice installer-owned release
+  transaction, which stages CLI, managed Pi, and the headless Runtime together;
+- managed Pi isolation is applied only to Pi launched inside an OpenAlice
+  instance.
+
+### Reject
+
+- keeping a non-TUI default entry until the TUI has every future panel;
+- maintaining a handwritten `.mjs` terminal renderer or adding React/Ink above
+  `pi-tui`;
+- resolving configuration independently inside the CLI, Guardian, Alice, UTA,
+  Connector, and managed Pi;
+- copying Herdr's private whole-screen server-rendering protocol;
+- using Pi's npm self-update or Herdr's single-binary rename for a multi-artifact
+  OpenAlice release;
+- storing the instance registry inside the currently selected
+  `OPENALICE_HOME`;
+- silently stopping active agents during update, uninstall, detach, or TUI
+  quit.
+
+## Required OpenAlice seams
+
+The application core must make these production dependencies replaceable in
+tests:
+
+- configuration files, environment, CLI flags, current working directory, and
+  clock;
+- Guardian status/control transport and process launcher;
+- browser opener and terminal capability detector;
+- release manifest, artifact downloader, checksum/authenticity verifier, and
+  installer runner;
+- installed-layout and instance-registry stores;
+- update fault injection at download, verify, stage, publish, pointer switch,
+  restart, readiness, rollback, and cleanup boundaries.
+
+The fast acceptance path uses those seams to install local release A, run its
+Guardian, advertise local release B, exercise the real `openalice update`
+command and TUI update state, and prove user data plus the prior runnable
+release survive success and every injected failure. Published dev/stable
+canaries remain separate network checks.

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -13,6 +13,12 @@ Superseded planning PR: #852 was opened under the earlier parallel direction.
 It is not retroactively merged; the first serial implementation PR carries the
 updated canonical plan and supersedes it.
 
+Superseded renderer PR: #857 proved the real PTY, Git Bash, terminal cleanup,
+and Windows Guardian seams, but its handwritten `.mjs` renderer is not the
+product architecture. Its platform and harness fixes are salvaged selectively;
+the renderer/session implementation is replaced by the TypeScript `pi-tui`
+application shell.
+
 Owner guides:
 
 - [[docs/cli-supervisor.md]]
@@ -25,6 +31,7 @@ Owner guides:
 
 Research:
 
+- [[docs/reference/pi-herdr-cli-architecture.md]]
 - [[docs/reference/herdr-remote-architecture.md]]
 
 Predecessor:
@@ -121,8 +128,14 @@ openalice completion <bash|zsh|fish|powershell>
 - source development moves to explicit `openalice dev` or
   `openalice run --source <path>` before stable installation stops depending on
   a checkout.
-- bare `openalice` changes to the TUI only after the PTY harness proves terminal
-  restoration and the compatibility transition is documented.
+- bare `openalice` is the product TUI entry from its first shipped CLI-app
+  increment. An unfinished panel is shown as unavailable inside that shell; it
+  is not a reason to preserve a second default entry model.
+- every explicit subcommand bypasses the TUI and uses the same typed
+  application services. Non-interactive commands are the automation API, not
+  a separate implementation.
+- `openalice run` remains the explicit foreground escape hatch for development,
+  containers, service managers, and diagnosis.
 
 ### TUI information architecture
 
@@ -157,18 +170,63 @@ parses human logs as lifecycle truth.
 
 ### Technical shape
 
-- Keep lifecycle actions in a presentation-neutral CLI core.
-- Keep command/TUI rendering as clients of that core.
-- Bundle the initial JavaScript TUI inside the immutable CLI release; do not
-  require a global npm install.
-- Select the renderer through a bounded spike comparing a maintained bundled
-  Node library and a small repository-owned renderer. Measure alternate screen,
-  resize, raw-mode restoration, bundle size, idle CPU, flicker, Unicode width,
-  and Git Bash behavior before choosing.
+- Build the CLI application in strict TypeScript and emit immutable ESM
+  artifacts for installation. Source readability and refactoring safety take
+  priority over maintaining a handwritten `.mjs` implementation.
+- Use `@earendil-works/pi-tui` as the terminal substrate. It already supplies
+  the TypeScript component model, differential rendering, overlays, Unicode
+  width, IME-aware input, terminal lifecycle, and Windows terminal support that
+  OpenAlice would otherwise have to reproduce.
+- Keep lifecycle, configuration, update planning, and diagnostics in a
+  presentation-neutral application core. Command presenters and the TUI are
+  two clients of the same services and schemas.
+- Follow Pi's startup shape: parse and dispatch explicit commands first,
+  resolve the complete launch context, build resources and application state,
+  enter the TUI, then perform optional network checks asynchronously.
+- Follow Herdr's process shape: detect the selected persistent Runtime, attach
+  when compatible, start it when policy allows, and keep the TUI as a
+  replaceable client of Guardian-owned facts.
 - Use an explicit reducer/state machine; render is a pure projection and effects
   call the same services as non-interactive commands.
 - Poll low-frequency status initially. Add streaming only when measured UX or
   remote efficiency requires it.
+- Bundle the dependency closure and any required native assets inside each
+  immutable CLI release; users never need a separate global TUI dependency.
+- Retain the real-PTY/xterm harness as the terminal acceptance boundary. Do not
+  retain the repository-owned ANSI renderer as product architecture.
+
+### Launch context and configuration
+
+Configuration resolves exactly once with observable provenance:
+
+```text
+defaults
+  < machine-wide Supervisor config
+  < selected instance config
+  < environment variables
+  < explicit CLI flags
+```
+
+- The resolver produces one immutable `ResolvedLaunchContext`. Guardian and
+  every child receive the resolved environment and do not independently
+  reinterpret configuration.
+- Every resolved field retains `value`, `source`, and whether it is locked by
+  an explicit override so the TUI and Doctor can explain launch behavior.
+- Machine-wide Supervisor configuration and the instance registry live outside
+  any selectable `OPENALICE_HOME`; the selector must not store the pointer that
+  selects itself.
+- `--home` is an explicit one-run instance-home override. `OPENALICE_HOME`
+  remains the highest-priority environment override for the complete
+  OpenAlice data root.
+- OpenAlice-managed Pi receives a per-instance `PI_CODING_AGENT_DIR` and
+  session root under the resolved home. This isolates settings, trust,
+  resources, and sessions between OpenAlice instances.
+- A user-installed Pi launched outside the managed OpenAlice path keeps Pi's
+  native global configuration. OpenAlice does not globally rewrite the user's
+  own Pi environment.
+- Configuration parse errors retain the last known valid running
+  configuration, appear in the TUI and Doctor, and are checked without
+  mutating state by `openalice config check`.
 
 ### Control compatibility
 
@@ -216,6 +274,22 @@ The update transaction is:
 Package-manager-owned installations show the correct manager command rather
 than self-update.
 
+Update discovery and update application are separate states:
+
+- after the TUI is usable, a bounded asynchronous check may advertise a newer
+  OpenAlice release and cache release notes; network failure is non-fatal;
+- `openalice update --check` and the TUI update panel expose the same result;
+- applying an update always uses the OpenAlice release transaction above, not
+  Pi's npm update transport or Herdr's single-binary replacement;
+- status reports installed CLI version, running Runtime version, protocol
+  compatibility, and `restartNeeded`/pending activation independently;
+- an update first enumerates every running instance and active-work impact;
+  compatible old Runtimes may remain attached to the old immutable release,
+  while incompatible activation requires explicit restart consent;
+- test-only manifest URLs, fake available versions, and transaction fault
+  points are supported through dependency injection into the application core,
+  never undocumented production environment switches.
+
 ## Non-goals
 
 - Terminal chat, trading, settings, Workspace management, or Agent TUIs.
@@ -257,26 +331,45 @@ and verification before the next dependent branch starts from updated `dev`.
   ownership, ports, components, update metadata, and source/bundle integrity.
 - [x] Exercise old-client/new-server and new-client/old-server fixtures.
 
-### 3. TUI renderer spike and PTY harness
+### 3. TypeScript CLI application shell and PTY harness
 
-- [ ] Build two bounded renderer candidates against the same fake control model.
-- [ ] Measure package size, startup, idle CPU, resize, flicker, Unicode,
-  no-color, restoration, and Git Bash behavior.
-- [ ] Select one renderer and remove the rejected spike.
-- [ ] Build a PTY harness with isolated HOME, deterministic control fixtures,
-  real input/resize, `@xterm/headless` parsing, transcripts, and timeouts.
-- [ ] Test normal exit, Ctrl+C, SIGTERM, renderer failure, and disconnect.
+- [x] Prototype a repository-owned renderer and real PTY harness in PR #857;
+  use the result as test evidence rather than the final architecture.
+- [x] Audit Pi `v0.83.0`, Herdr `v0.7.5`, current OpenAlice CLI/Guardian
+  boundaries, configuration precedence, and licenses.
+- [x] Select strict TypeScript plus `@earendil-works/pi-tui`; reject both a Rust
+  rewrite and a handwritten `.mjs` product renderer.
+- [ ] Convert `packages/cli` to TypeScript source with a deterministic build
+  output and installer-owned dependency closure.
+- [ ] Define one root command parser that dispatches explicit commands before
+  interactive startup.
+- [ ] Add `ResolvedLaunchContext`, typed application services, and dependency
+  injection for filesystem, process, control, browser, terminal, clock, and
+  update operations.
+- [ ] Port the PTY harness with isolated HOME and `OPENALICE_HOME`,
+  deterministic control fixtures, real input/resize, `@xterm/headless`
+  parsing, transcripts, and timeouts.
+- [ ] Test normal exit, Ctrl+C, SIGTERM, renderer failure, disconnect, resize,
+  Unicode, no-color, and Git Bash.
+- [ ] Salvage the independent Windows Guardian atomic-owner replacement fix
+  from #857 and close that superseded PR.
 
-### 4. Supervisor TUI MVP
+### 4. Supervisor TUI application
 
-- [ ] Add explicit `openalice tui`.
+- [ ] Make bare `openalice` enter the TUI; retain `openalice tui` as an explicit
+  alias useful for tests and scripts.
+- [ ] Render a stable application chrome from the first increment: product and
+  channel header, selected instance, lifecycle summary, navigation, action bar,
+  help, and update indicator.
+- [ ] Show unfinished product panels as unavailable within the TUI instead of
+  preserving a temporary non-TUI default command.
 - [ ] Implement stopped, starting, running, degraded, incompatible, stopping,
   and update-available states.
 - [ ] Add start, open, stop, restart, detach, help, and read-only detail.
 - [ ] Add component/instance panels and narrow fallback.
 - [ ] Keep the TUI open and reconnect across a self-owned restart.
-- [ ] Change bare `openalice` only after source-backed macOS/Linux PTY and real
-  browser acceptance.
+- [ ] Complete source-backed macOS/Linux PTY and real browser acceptance before
+  merging the bare-command behavior.
 
 ### 5. Logs, Doctor, and update UX
 
@@ -288,10 +381,20 @@ and verification before the next dependent branch starts from updated `dev`.
 - [ ] Add PTY journeys for failed start, disconnect, logs, incompatible control,
   update refusal, and reconnect.
 
-### 6. Instance model
+### 6. Configuration and instance model
 
+- [ ] Define machine-wide Supervisor and selected-instance schemas outside
+  `OPENALICE_HOME`.
+- [ ] Resolve defaults, machine config, instance config, environment, and CLI
+  flags once into `ResolvedLaunchContext`, retaining field-level provenance.
+- [ ] Add `openalice config check` plus TUI diagnostics; invalid live reload
+  retains the last valid configuration.
+- [ ] Give OpenAlice-managed Pi an instance-local `PI_CODING_AGENT_DIR` and
+  session root without changing a user-installed Pi launched externally.
+- [ ] Update the managed Workspace runtime owner guide and tests for the new
+  managed-Pi isolation boundary.
 - [ ] Define a versioned atomic CLI-owned registry mapping names to complete
-  homes.
+  homes; never store the registry inside a selected home.
 - [ ] Preserve implicit `default` without moving existing data.
 - [ ] Add `--instance`, list, TUI selection, and collision checks.
 - [ ] Make deletion remove registry ownership only by default.
@@ -422,7 +525,7 @@ non-trading and uses no real credentials or broker accounts.
 
 | Risk | Mitigation |
 |---|---|
-| Default command surprises foreground users | Explicit TUI command first; compatibility period |
+| Default command surprises foreground users | Document bare TUI semantics and preserve explicit `run`, commands, and the `tui` alias |
 | TUI leaves terminal broken | Central restoration guard plus PTY failure/signal tests |
 | TUI becomes a second product | Supervisor boundary and Web handoff |
 | Protocol strands old Runtime | Capabilities and cross-version fixtures |
@@ -477,3 +580,11 @@ This plan is complete only when:
   `EPERM`. The failed-job rerun passed Guardian recovery and the complete dev
   smoke without a runtime-lock change, so no speculative retry was introduced.
 - 2026-07-30: Published increment 2 as serial PR #855 targeting `dev`.
+- 2026-07-30: Rejected the handwritten `.mjs` renderer direction from PR #857
+  after the user selected a complete TUI application shell from day one.
+  Audited Pi `v0.83.0` and Herdr `v0.7.5` side by side. Selected strict
+  TypeScript plus `@earendil-works/pi-tui`; assigned Pi as the startup,
+  settings, and TUI reference, Herdr as the persistent Runtime and command
+  semantics reference, and Guardian plus the OpenAlice installer as the final
+  ownership and update authority. Recorded the comparison in
+  [[docs/reference/pi-herdr-cli-architecture.md]].


### PR DESCRIPTION
## What changed

- pin Pi v0.83.0 and Herdr v0.7.5 as complementary CLI references
- select strict TypeScript plus `@earendil-works/pi-tui`
- make bare `openalice` the TUI entry and explicit subcommands the automation API
- define a provenance-aware `ResolvedLaunchContext` and managed-Pi instance isolation
- model installed and running versions separately during update
- supersede PR #857's handwritten renderer while retaining its PTY, Windows, and Guardian evidence for selective salvage

## Why

OpenAlice already has a TypeScript application and Guardian-owned Runtime. Reimplementing a TUI stack in Rust or maintaining a custom `.mjs` renderer would duplicate state, build, and cross-platform infrastructure. Pi supplies the application/TUI substrate; Herdr supplies the persistent Runtime and command semantics; OpenAlice keeps its own process ownership and installer trust chain.

## Verification

- `git diff --check`
- documentation links and pinned upstream source paths reviewed locally

This is a documentation and execution-plan increment; it does not change runtime behavior.
