### PR TITLE
Start TypeScript Supervisor TUI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG CLAUDE_CODE_VERSION=2.1.202
 ARG CODEX_VERSION=0.144.1
 ARG OPENCODE_VERSION=1.17.18
-ARG PI_VERSION=0.80.6
+ARG PI_VERSION=0.83.0
 RUN npm install -g \
         "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
         "@openai/codex@${CODEX_VERSION}" \

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -87,7 +87,7 @@ infrastructure for maintainers, not a user-facing release mirror.
 exclusive. The default install root is `~/.openalice`, and the downloaded
 OpenAlice payload is the file set declared by `FILES` in the root `install`
 script. The installer also downloads Pi's release-owned install manifest and
-lockfile for version `0.80.6`, verifies both against pinned SHA-256 values, and
+lockfile for version `0.83.0`, verifies both against pinned SHA-256 values, and
 runs `npm ci --omit=dev --ignore-scripts` in the staged release.
 
 ## Load-Bearing Files
@@ -95,7 +95,8 @@ runs `npm ci --omit=dev --ignore-scripts` in the staged release.
 - `install` — user-facing Bash bootstrap and durable install transaction.
 - `packages/cli/package.json` — CLI version, engine requirement, bin entry, and
   published file list.
-- `packages/cli/bin/openalice.mjs` — installed command entry point.
+- `packages/cli/bin/openalice.ts` — installed TypeScript application entry;
+  Node 22.19+ executes its erasable types directly.
 - `packages/cli/src/install-source.mjs` — validated installation-source
   metadata used when managed remote reproduces the invoking CLI.
 - `packages/cli/src/install-layout.mjs` — strict discovery of installer-owned
@@ -267,7 +268,7 @@ Before a release becomes visible, the installer:
 3. executes the staged CLI with `--version` and compares its result with the
    package manifest;
 4. verifies the Pi install manifest and lockfile against the SHA-256 values
-   pinned in the installer, then requires the staged Pi CLI to report `0.80.6`;
+   pinned in the installer, then requires the staged Pi CLI to report `0.83.0`;
 5. writes `install-source.json` with the CLI version, selected branch/tag/commit,
    and installer URL that produced this CLI;
 6. hashes the ordered OpenAlice payload, install-source metadata, and both Pi
@@ -673,7 +674,7 @@ Runtime behavior, PTY behavior, or Electron files also change.
 Before publishing or promoting a change that affects the installer:
 
 1. Confirm the CLI payload list in `install` and `packages/cli/package.json`
-   still match the imports reachable from `bin/openalice.mjs`.
+   still match the imports reachable from `bin/openalice.ts`.
 2. Confirm the intended source ref, equal root and CLI package versions, Pi
    version, release asset hashes, lockfile engine floor, and root/CLI Node
    engines. Do not accidentally advertise mutable `dev` as a stable release.

--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -70,20 +70,23 @@ options documented in [[docs/local-runtime.md]]. `up` is browserless by default;
 
 ## Default and Compatibility Surface
 
-During the migration toward the Supervisor TUI:
-
-- bare `openalice` and `openalice start` retain the existing foreground,
-  browser-oriented source launcher;
+- bare `openalice` enters the local Supervisor TUI;
+- `openalice tui` is the explicit equivalent for tests and scripts;
+- `openalice start` retains the existing foreground, browser-oriented source
+  launcher;
 - `openalice server run|start|status|stop` remains available for managed remote
   and existing scripts;
 - new code uses `run|up|status|down`;
-- `server status --json` retains its legacy raw status payload;
-- the future change that makes bare `openalice` enter the TUI requires its own
-  PTY acceptance and compatibility decision.
+- `server status --json` retains its legacy raw status payload.
 
 The top-level commands and the `server` compatibility surface launch the same
 `cli-server` Guardian owner. They are presenters over one lifecycle rather than
 separate daemons.
+
+The first TypeScript TUI shell is deliberately read-only: it reports the
+selected Runtime and detaches with `q`, `Esc`, or `Ctrl+C`. Unfinished controls
+remain inside the application shell and do not change the default entry back to
+the compatibility launcher.
 
 ## Presentation-neutral Core
 
@@ -258,7 +261,13 @@ completion; detailed shell installation remains user-owned.
 
 ## Load-bearing Files
 
-- `packages/cli/bin/openalice.mjs` — root dispatch and process exit mapping.
+- `packages/cli/bin/openalice.ts` and `packages/cli/src/main.ts` — TypeScript
+  application entry and default-TUI/explicit-command dispatch.
+- `packages/cli/src/supervisor-tui.ts` — `pi-tui` Supervisor application shell.
+- `packages/cli/src/pi-tui-loader.ts` — workspace and installed managed-Pi TUI
+  resolution.
+- `packages/cli/bin/openalice.mjs` — transitional presenter for existing
+  non-interactive commands while their source moves to TypeScript.
 - `packages/cli/src/lifecycle.mjs` — presentation-neutral lifecycle.
 - `packages/cli/src/lifecycle-command.mjs` — canonical command parsing and
   presentation.

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -36,7 +36,7 @@ behavior.
 
 ## Stable Install
 
-The public installer distributes the small JavaScript CLI from the stable
+The public installer distributes the TypeScript CLI application from the stable
 `master` lane:
 
 ```bash
@@ -70,14 +70,17 @@ OpenAlice source checkout and run the CLI from inside it:
 ```bash
 git clone https://github.com/TraderAlice/OpenAlice.git
 cd OpenAlice
-openalice
+openalice up
+openalice open
 ```
 
-`openalice` finds the checkout, installs the locked workspace dependencies
+`openalice up` finds the checkout, installs the locked workspace dependencies
 without `@traderalice/desktop`, runs `pnpm build:server`, starts
-`scripts/guardian/prod.mjs` on `127.0.0.1`, and opens the normal UI. If `pnpm`
-is absent but Corepack is available, preparation uses Corepack with the pnpm
-version pinned by the repository.
+`scripts/guardian/prod.mjs` on `127.0.0.1`, and leaves it running after the
+shell exits. `openalice open` verifies and opens the normal Web UI. Bare
+`openalice` enters the Supervisor TUI; `openalice start` preserves the legacy
+foreground-and-browser path. If `pnpm` is absent but Corepack is available,
+preparation uses Corepack with the pnpm version pinned by the repository.
 
 Live broker engines are still activated through the Trading UI and
 `<OPENALICE_HOME>/runtime/broker-packs/`. The source checkout contains their
@@ -89,13 +92,14 @@ installer presents a separate, default-no `Start OpenAlice now?` prompt after
 the CLI is complete. Installation consent never implies service-start consent,
 and `--yes` remains installation-only for automation.
 
-The CLI stays in the foreground and owns the Guardian lifetime. `Ctrl+C` stops
-the local Runtime. A normal second launch reuses an already healthy local URL;
-it does not kill the existing owner. Discovery first uses the selected home's
-Guardian control endpoint; for a source `pnpm dev` owner without control
-metadata, it verifies that owner's configured Web port before reuse. It never
-guesses that another home owns a reachable port. `openalice start --takeover`
-explicitly requests the existing Guardian recovery flow.
+`openalice run` and compatibility `openalice start` stay in the foreground and
+own the Guardian lifetime; `Ctrl+C` stops their self-owned local Runtime. The
+Supervisor TUI only detaches. A normal `up` reuses an already healthy matching
+owner and never kills it. Discovery first uses the selected home's Guardian
+control endpoint; for a source `pnpm dev` owner without control metadata, it
+verifies that owner's configured Web port before reuse. It never guesses that
+another home owns a reachable port. `openalice start --takeover` explicitly
+requests the existing Guardian recovery flow.
 
 Useful controls:
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -709,7 +709,7 @@ recovered in place after the tunnel returned on the same origin. The Server was
 stopped through its control endpoint and the Sandbox was destroyed.
 
 A later user-facing Railway Sandbox completed the missing authenticated Agent
-loop. Pi `0.80.6` was installed on the live remote host, OpenAlice selected Pi
+loop. Pi `0.83.0` was installed on the live remote host, OpenAlice selected Pi
 as the Workspace default, injected a sealed LongCat-compatible provider
 credential through the normal AI Provider flow, and started a trusted Pi TUI
 without the project-trust deadlock. The prompt `请只回复：远程 OpenAlice Pi

--- a/install
+++ b/install
@@ -8,11 +8,11 @@ VERSION=""
 REF_KIND=""
 REF_OPTION=""
 MINIMUM_NODE_VERSION="22.19.0"
-PI_VERSION="0.80.6"
+PI_VERSION="0.83.0"
 PI_RELEASE_BASE="${OPENALICE_PI_RELEASE_BASE_URL:-https://github.com/earendil-works/pi/releases/download/v${PI_VERSION}}"
 PI_RELEASE_BASE="${PI_RELEASE_BASE%/}"
-PI_PACKAGE_SHA256="ee080db64c3732daea5547bd6d9809465ffa236ef6099051e64a16753e48b795"
-PI_LOCK_SHA256="0f409bf498507f93bfbde3dc6f2b4c83bc58bdea2e2f5eabf3053cc2a81568d4"
+PI_PACKAGE_SHA256="41f07a3eb41227905ac436ad41d949e4589dcc34c15454d718f85f399b533cb6"
+PI_LOCK_SHA256="f5cb41dcfc60561ba54490b49c17beecec202900f73eb5f104b34f8b2a79a0af"
 PI_ASSET_SOURCE_DIR="${OPENALICE_PI_SOURCE_DIR:-}"
 NPM_BIN="${OPENALICE_NPM_BIN:-npm}"
 SOURCE_DIR=""
@@ -665,7 +665,11 @@ fi
 
 FILES=(
   "package.json"
+  "bin/openalice.ts"
   "bin/openalice.mjs"
+  "src/main.ts"
+  "src/pi-tui-loader.ts"
+  "src/supervisor-tui.ts"
   "src/doctor.mjs"
   "src/install-layout.mjs"
   "src/install-source.mjs"
@@ -735,7 +739,9 @@ PI_STAGED_VERSION="$(node "$PI_STAGED_ENTRY" --version)"
 ok "Managed Pi $PI_VERSION is ready"
 
 step 5 "Verifying the OpenAlice CLI"
+chmod +x "$STAGING/bin/openalice.ts"
 chmod +x "$STAGING/bin/openalice.mjs"
+node --check "$STAGING/bin/openalice.ts"
 node --check "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/src/doctor.mjs"
 node --check "$STAGING/src/install-layout.mjs"
@@ -763,7 +769,7 @@ if [[ -n "${OPENALICE_EXPECTED_CLI_VERSION:-}" \
   && "$CLI_VERSION" != "$OPENALICE_EXPECTED_CLI_VERSION" ]]; then
   die "The downloaded CLI reported $CLI_VERSION instead of expected release $OPENALICE_EXPECTED_CLI_VERSION"
 fi
-STAGED_VERSION="$(node "$STAGING/bin/openalice.mjs" --version)"
+STAGED_VERSION="$(node "$STAGING/bin/openalice.ts" --version)"
 [[ "$STAGED_VERSION" == "$CLI_VERSION" ]] || die "The downloaded CLI did not report its package version"
 node -e '
   const { writeFileSync } = require("node:fs");
@@ -776,7 +782,7 @@ node -e '
     installerUrl,
   }, null, 2)}\n`, { mode: 0o644 });
 ' "$STAGING/install-source.json" "$REPOSITORY" "$CLI_VERSION" "$REF_KIND" "$VERSION" "$INSTALLER_URL"
-node "$STAGING/bin/openalice.mjs" version --json | node -e '
+node "$STAGING/bin/openalice.ts" version --json | node -e '
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => { input += chunk; });
@@ -818,7 +824,7 @@ else
   STAGING=""
 fi
 
-CLI_ENTRY="$DESTINATION/bin/openalice.mjs"
+CLI_ENTRY="$DESTINATION/bin/openalice.ts"
 PI_ENTRY="$DESTINATION/$PI_RELATIVE_ENTRY"
 printf -v quoted_cli_entry '%q' "$CLI_ENTRY"
 printf -v quoted_pi_entry '%q' "$PI_ENTRY"

--- a/packages/cli/bin/openalice.ts
+++ b/packages/cli/bin/openalice.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { main } from '../src/main.ts'
+
+main().then(
+  (code) => {
+    process.exitCode = code
+  },
+  (error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`openalice: ${message}\n`)
+    process.exitCode = isCliError(error) ? error.exitCode : 1
+  },
+)
+
+function isCliError(error: unknown): error is Error & { exitCode: number } {
+  return error instanceof Error
+    && 'exitCode' in error
+    && Number.isInteger(error.exitCode)
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,10 +4,14 @@
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {
-    "openalice": "./bin/openalice.mjs"
+    "openalice": "./bin/openalice.ts"
   },
   "files": [
+    "bin/openalice.ts",
     "bin/openalice.mjs",
+    "src/main.ts",
+    "src/pi-tui-loader.ts",
+    "src/supervisor-tui.ts",
     "src/doctor.mjs",
     "src/install-layout.mjs",
     "src/install-source.mjs",
@@ -26,7 +30,8 @@
     "src/update.mjs"
   ],
   "scripts": {
-    "build": "node --check bin/openalice.mjs && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
+    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },
   "engines": {
@@ -40,5 +45,8 @@
     "type": "git",
     "url": "git+https://github.com/TraderAlice/OpenAlice.git",
     "directory": "packages/cli"
+  },
+  "dependencies": {
+    "@earendil-works/pi-tui": "0.83.0"
   }
 }

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -32,12 +32,12 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     expect(installer).toContain('DEFAULT_BRANCH="master"')
     expect(installer).toContain('PUBLIC_INSTALLER_URL="https://openalice.ai/install"')
     expect(installer).toContain('MINIMUM_NODE_VERSION="22.19.0"')
-    expect(installer).toContain('PI_VERSION="0.80.6"')
-    expect(desktopVendor).toContain("const PI_VERSION = '0.80.6'")
+    expect(installer).toContain('PI_VERSION="0.83.0"')
+    expect(desktopVendor).toContain("const PI_VERSION = '0.83.0'")
     expect(piManifest).toEqual(expect.objectContaining({
-      version: '0.80.6',
+      version: '0.83.0',
       engines: { node: '>=22.19.0' },
-      dependencies: { '@earendil-works/pi-coding-agent': '0.80.6' },
+      dependencies: { '@earendil-works/pi-coding-agent': '0.83.0' },
     }))
     expect(rootManifest.engines.node).toBe('>=22.19.0')
     expect(cliManifest.engines.node).toBe('>=22.19.0')
@@ -45,8 +45,8 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     for (const file of cliManifest.files) {
       expect(installer).toContain(`  "${file}"`)
     }
-    expect(sha256(packageBytes)).toBe('ee080db64c3732daea5547bd6d9809465ffa236ef6099051e64a16753e48b795')
-    expect(sha256(lockBytes)).toBe('0f409bf498507f93bfbde3dc6f2b4c83bc58bdea2e2f5eabf3053cc2a81568d4')
+    expect(sha256(packageBytes)).toBe('41f07a3eb41227905ac436ad41d949e4589dcc34c15454d718f85f399b533cb6')
+    expect(sha256(lockBytes)).toBe('f5cb41dcfc60561ba54490b49c17beecec202900f73eb5f104b34f8b2a79a0af')
   })
 
   it('defaults to master, accepts an explicit branch, and rejects multiple selectors', async () => {
@@ -122,12 +122,12 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     expect(installed.stdout).toContain('System build tools are optional and listed before consent')
     expect(installed.stdout).toContain('No system packages were changed')
     expect(installed.stdout).toContain('Install plan')
-    expect(installed.stdout).toContain('Managed agent  Pi 0.80.6')
+    expect(installed.stdout).toContain('Managed agent  Pi 0.83.0')
     expect(installed.stdout).toContain('OpenAlice and Pi are ready')
     const releases = await readdir(join(installRoot, 'cli-versions'))
     expect(releases).toHaveLength(1)
     expect(releases[0]).toMatch(/^test_ref-[a-f0-9]{16}$/)
-    await expect(access(join(installRoot, 'cli-versions', releases[0], 'bin', 'openalice.mjs'))).resolves.toBeUndefined()
+    await expect(access(join(installRoot, 'cli-versions', releases[0], 'bin', 'openalice.ts'))).resolves.toBeUndefined()
     await expect(access(join(installRoot, 'cli-versions', releases[0], 'managed', 'pi', 'node_modules', '@earendil-works', 'pi-coding-agent', 'dist', 'cli.js'))).resolves.toBeUndefined()
     await expect(access(join(installRoot, 'bin', 'openalice.cmd'))).resolves.toBeUndefined()
     await expect(access(join(installRoot, 'bin', 'pi.cmd'))).resolves.toBeUndefined()
@@ -148,7 +148,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     })
     await expect(access(join(installRoot, 'cli-versions', releases[0], 'install-source.json'))).resolves.toBeUndefined()
     const pi = await execFileAsync(join(installRoot, 'bin', 'pi'), ['--version'])
-    expect(pi.stdout.trim()).toBe('0.80.6')
+    expect(pi.stdout.trim()).toBe('0.83.0')
     const launcher = await readFile(join(installRoot, 'bin', 'openalice'), 'utf8')
     expect(launcher).toContain('OPENALICE_MANAGED_PI_PATH=')
   })

--- a/packages/cli/src/lifecycle-command.mjs
+++ b/packages/cli/src/lifecycle-command.mjs
@@ -11,6 +11,7 @@ export const LIFECYCLE_JSON_SCHEMA_VERSION = 1
 
 export const ROOT_COMMANDS = Object.freeze([
   { name: 'version', description: 'Print the OpenAlice product and install version' },
+  { name: 'tui', description: 'Open the local Supervisor TUI' },
   { name: 'up', description: 'Start a persistent local Runtime in the background' },
   { name: 'run', description: 'Run a local Runtime in the foreground' },
   { name: 'down', description: 'Stop the persistent local Runtime' },
@@ -209,8 +210,8 @@ Usage:
 Commands:
 ${commands}
 
-The current default without a command remains the compatibility foreground
-browser launcher. Use "openalice up" for a persistent background Runtime.
+The default without a command opens the Supervisor TUI. Use "openalice run"
+for a foreground Runtime or "openalice up" for a persistent background Runtime.
 
 Run "openalice <command> --help" for command details.
 `

--- a/packages/cli/src/main.spec.ts
+++ b/packages/cli/src/main.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { main } from './main.ts'
+
+describe('OpenAlice TypeScript application entry', () => {
+  it('opens the Supervisor TUI for the bare command', async () => {
+    const runTui = vi.fn(async () => 0)
+
+    await expect(main([], { runTui })).resolves.toBe(0)
+
+    expect(runTui).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the explicit tui alias', async () => {
+    const runTui = vi.fn(async () => 0)
+
+    await expect(main(['tui'], { runTui })).resolves.toBe(0)
+
+    expect(runTui).toHaveBeenCalledOnce()
+  })
+
+  it('rejects unknown tui options before terminal startup', async () => {
+    await expect(main(['tui', '--wat'], {
+      runTui: vi.fn(async () => 0),
+    })).rejects.toMatchObject({
+      code: 'EUSAGE',
+      exitCode: 2,
+    })
+  })
+})

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,38 @@
+import { main as runLegacyCommand } from '../bin/openalice.mjs'
+import { runSupervisorTui } from './supervisor-tui.ts'
+
+export interface CliDependencies {
+  runTui?: typeof runSupervisorTui
+}
+
+export async function main(
+  argv: string[] = process.argv.slice(2),
+  dependencies: CliDependencies = {},
+): Promise<number> {
+  const [command, ...args] = argv
+  if (command === 'tui') {
+    if (args.includes('--help') || args.includes('-h')) {
+      process.stdout.write(`Usage:
+  openalice tui
+
+Open the local OpenAlice Supervisor TUI. Detaching never stops the Runtime.
+`)
+      return 0
+    }
+    if (args.length > 0) {
+      throw usageError(`Unknown tui option: ${args[0]}`)
+    }
+    return (dependencies.runTui ?? runSupervisorTui)()
+  }
+  if (command === undefined) {
+    return (dependencies.runTui ?? runSupervisorTui)()
+  }
+  return runLegacyCommand(argv)
+}
+
+function usageError(message: string): Error & { code: string; exitCode: number } {
+  return Object.assign(new Error(message), {
+    code: 'EUSAGE',
+    exitCode: 2,
+  })
+}

--- a/packages/cli/src/pi-tui-loader.ts
+++ b/packages/cli/src/pi-tui-loader.ts
@@ -1,0 +1,24 @@
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+export type PiTuiModule = typeof import('@earendil-works/pi-tui')
+
+export async function loadPiTui(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<PiTuiModule> {
+  try {
+    return await import('@earendil-works/pi-tui')
+  } catch (error: unknown) {
+    const managedPiEntry = env.OPENALICE_MANAGED_PI_PATH
+    if (!managedPiEntry || !isMissingPackage(error)) throw error
+    const requireFromManagedPi = createRequire(managedPiEntry)
+    const entry = requireFromManagedPi.resolve('@earendil-works/pi-tui')
+    return import(pathToFileURL(entry).href) as Promise<PiTuiModule>
+  }
+}
+
+function isMissingPackage(error: unknown): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === 'ERR_MODULE_NOT_FOUND'
+}

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -18,7 +18,7 @@ import { formatMissingRuntimeBuildTools } from './runtime-deps.mjs'
 import { connectSsh } from './ssh-connect.mjs'
 
 const MINIMUM_NODE_VERSION = '22.19.0'
-const MANAGED_PI_VERSION = '0.80.6'
+const MANAGED_PI_VERSION = '0.83.0'
 const MAX_SSH_OUTPUT_BYTES = 1024 * 1024
 const REMOTE_STATE_VERSION = 1
 const MAX_REMEMBERED_TARGETS = 32

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -105,7 +105,7 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.startServer).toBe(true)
     expect(plan.mutations).toEqual([
       'install remote OpenAlice CLI',
-      'install managed Pi 0.80.6',
+      'install managed Pi 0.83.0',
       'install source Runtime build tools',
       'start remote OpenAlice Server',
     ])
@@ -159,8 +159,8 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.restartServer).toBe(true)
     expect(plan.serverAppDir).toBe('/srv/OpenAlice')
     expect(plan.mutations).toEqual([
-      'install managed Pi 0.80.6',
-      'restart remote OpenAlice Server with managed Pi 0.80.6',
+      'install managed Pi 0.83.0',
+      'restart remote OpenAlice Server with managed Pi 0.83.0',
     ])
   })
 
@@ -172,7 +172,7 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.installRuntimeDeps).toBe(false)
     expect(plan.mutations).toEqual([
       'install remote OpenAlice CLI',
-      'install managed Pi 0.80.6',
+      'install managed Pi 0.83.0',
       'start remote OpenAlice Server',
     ])
   })
@@ -205,7 +205,7 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.installRuntimeDeps).toBe(true)
     expect(plan.mutations).toEqual([
       'install remote OpenAlice CLI',
-      'install managed Pi 0.80.6',
+      'install managed Pi 0.83.0',
       'install source Runtime build tools',
       'clone OpenAlice source (branch master)',
       'start remote OpenAlice Server',
@@ -708,7 +708,7 @@ function compatibleRemote(statusOverrides = {}) {
     nodeVersion: 'v22.23.1',
     hasCurl: true,
     piPath: '/home/alice/.openalice/bin/pi',
-    piVersion: '0.80.6',
+    piVersion: '0.83.0',
     piCompatible: true,
     sourceCheckoutPresent: null,
     sourceCheckoutState: null,

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import * as pty from 'node-pty'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const cliEntry = join(dirname(fileURLToPath(import.meta.url)), '../bin/openalice.ts')
+const temporaryPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )))
+})
+
+describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
+  it('starts from the bare command and restores the terminal on detach', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-tui-'))
+    temporaryPaths.push(isolatedHome)
+    const child = pty.spawn(process.execPath, [cliEntry], {
+      cols: 80,
+      rows: 24,
+      cwd: dirname(cliEntry),
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        OPENALICE_HOME: join(isolatedHome, 'state'),
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor TUI timed out:\n${output}`))
+      }, 8_000)
+      child.onData((data) => {
+        output += data
+        if (!detached && output.includes('q / Esc / Ctrl+C  Detach')) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor TUI exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    expect(transcript).toContain('OpenAlice  0.87.0-beta  development')
+    expect(transcript).toContain('Runtime state: absent')
+    expect(transcript).toContain('\u001b[?25h')
+    expect(transcript).toContain('\u001b[?2004l')
+  })
+})

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { SupervisorScreen } from './supervisor-tui.ts'
+
+describe('Supervisor TUI screen', () => {
+  it('renders stable stopped-state application chrome', () => {
+    const screen = new SupervisorScreen({
+      version: '0.87.0-beta',
+      channel: 'dev',
+      runtime: {
+        class: 'absent',
+        home: '/tmp/openalice',
+        owner: null,
+        endpoints: {},
+      },
+    })
+
+    const lines = screen.render(80)
+
+    expect(lines).toContain('OpenAlice  0.87.0-beta  dev')
+    expect(lines).toContain('Runtime state: absent')
+    expect(lines).toContain('q / Esc / Ctrl+C  Detach')
+  })
+
+  it('uses a narrow projection and sanitizes diagnostics', () => {
+    const screen = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: null,
+      diagnostic: 'bad\u001b[31mstate',
+    })
+
+    const lines = screen.render(40)
+
+    expect(lines).toContain('Runtime: unavailable')
+    expect(lines.join('\n')).not.toContain('\u001b')
+    expect(lines.every((line) => line.length <= 40)).toBe(true)
+  })
+})

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from 'node:fs'
+import type { Component } from '@earendil-works/pi-tui'
+
+import { inspectRuntime } from './lifecycle.mjs'
+import { loadPiTui } from './pi-tui-loader.ts'
+
+interface RuntimeSummary {
+  class?: string
+  home?: string
+  productVersion?: string
+  runtimeVersion?: string
+  endpoints?: { web?: string | null }
+  owner?: {
+    surface?: string
+    pid?: number
+  } | null
+  components?: {
+    alice?: { status?: string }
+    uta?: { status?: string }
+    connector?: { status?: string }
+  }
+}
+
+export interface SupervisorSnapshot {
+  version: string
+  channel: string
+  runtime: RuntimeSummary | null
+  diagnostic?: string
+}
+
+export interface SupervisorTuiDependencies {
+  env?: NodeJS.ProcessEnv
+  stdin?: NodeJS.ReadStream
+  stdout?: NodeJS.WriteStream
+  inspect?: () => Promise<RuntimeSummary>
+  loadTui?: typeof loadPiTui
+  version?: string
+  channel?: string
+}
+
+export async function runSupervisorTui(
+  dependencies: SupervisorTuiDependencies = {},
+): Promise<number> {
+  const stdin = dependencies.stdin ?? process.stdin
+  const stdout = dependencies.stdout ?? process.stdout
+  if (!stdin.isTTY || !stdout.isTTY) {
+    throw Object.assign(
+      new Error('the Supervisor TUI requires an interactive terminal; use "openalice status --json" for automation'),
+      { code: 'ETTY', exitCode: 2 },
+    )
+  }
+
+  let runtime: RuntimeSummary | null = null
+  let diagnostic: string | undefined
+  try {
+    runtime = await (dependencies.inspect ?? (() => inspectRuntime()))()
+  } catch (error: unknown) {
+    diagnostic = error instanceof Error ? error.message : String(error)
+  }
+
+  const piTui = await (dependencies.loadTui ?? loadPiTui)(dependencies.env)
+  const terminal = new piTui.ProcessTerminal()
+  const ui = new piTui.TUI(terminal)
+  const screen = new SupervisorScreen({
+    version: dependencies.version ?? readCliVersion(),
+    channel: dependencies.channel ?? 'development',
+    runtime,
+    diagnostic,
+  })
+  ui.addChild(screen)
+
+  return new Promise<number>((resolve) => {
+    let settled = false
+    const finish = (code = 0) => {
+      if (settled) return
+      settled = true
+      removeInputListener()
+      process.off('SIGTERM', onTerminate)
+      process.off('SIGINT', onTerminate)
+      ui.stop()
+      resolve(code)
+    }
+    const onTerminate = () => finish()
+    const removeInputListener = ui.addInputListener((data) => {
+      if (
+        piTui.matchesKey(data, 'q')
+        || piTui.matchesKey(data, 'escape')
+        || piTui.matchesKey(data, 'ctrl+c')
+      ) {
+        finish()
+        return { consume: true }
+      }
+      return undefined
+    })
+
+    process.once('SIGTERM', onTerminate)
+    process.once('SIGINT', onTerminate)
+    ui.start()
+  })
+}
+
+export class SupervisorScreen implements Component {
+  private readonly snapshot: SupervisorSnapshot
+
+  constructor(snapshot: SupervisorSnapshot) {
+    this.snapshot = snapshot
+  }
+
+  render(width: number): string[] {
+    const runtime = this.snapshot.runtime
+    const narrow = width < 60
+    const state = runtime?.class ?? 'unavailable'
+    const lines = [
+      `OpenAlice  ${this.snapshot.version}  ${this.snapshot.channel}`,
+      '─'.repeat(Math.max(1, Math.min(width, 80))),
+      narrow ? `Runtime: ${state}` : `Runtime state: ${state}`,
+      `Home: ${runtime?.home ?? 'default'}`,
+    ]
+    if (!narrow) {
+      lines.push(
+        `Owner: ${formatOwner(runtime)}`,
+        `Web: ${runtime?.endpoints?.web ?? 'not available'}`,
+        `Components: ${formatComponents(runtime)}`,
+      )
+    }
+    if (this.snapshot.diagnostic) {
+      lines.push('', `Diagnostic: ${sanitize(this.snapshot.diagnostic)}`)
+    }
+    lines.push(
+      '',
+      state === 'absent'
+        ? 'OpenAlice is stopped. Runtime controls are coming in the next increment.'
+        : 'Open the Web UI for product interaction.',
+      '',
+      'q / Esc / Ctrl+C  Detach',
+    )
+    return lines.map((line) => truncate(line, width))
+  }
+
+  invalidate(): void {}
+}
+
+function formatOwner(runtime: RuntimeSummary | null): string {
+  if (!runtime?.owner) return 'none'
+  const pid = runtime.owner.pid === undefined ? '' : ` pid ${runtime.owner.pid}`
+  return `${runtime.owner.surface ?? 'unknown'}${pid}`
+}
+
+function formatComponents(runtime: RuntimeSummary | null): string {
+  const components = runtime?.components
+  if (!components) return 'not reported'
+  return [
+    `Alice ${components.alice?.status ?? 'unknown'}`,
+    `UTA ${components.uta?.status ?? 'optional'}`,
+    `Connector ${components.connector?.status ?? 'optional'}`,
+  ].join(' · ')
+}
+
+function sanitize(value: string): string {
+  return value.replaceAll(/[\u0000-\u001f\u007f-\u009f]/g, ' ')
+}
+
+function truncate(value: string, width: number): string {
+  if (width <= 0) return ''
+  return value.length <= width ? value : `${value.slice(0, Math.max(0, width - 1))}…`
+}
+
+function readCliVersion(): string {
+  const packageUrl = new URL('../package.json', import.meta.url)
+  const manifest = JSON.parse(readFileSync(packageUrl, 'utf8')) as { version?: unknown }
+  return typeof manifest.version === 'string' ? manifest.version : 'unknown'
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "rootDir": "../.."
+  },
+  "include": [
+    "bin/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.mjs"
+  ]
+}

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -356,12 +356,13 @@ and verification before the next dependent branch starts from updated `dev`.
 
 ### 4. Supervisor TUI application
 
-- [ ] Make bare `openalice` enter the TUI; retain `openalice tui` as an explicit
+- [x] Make bare `openalice` enter the TUI; retain `openalice tui` as an explicit
   alias useful for tests and scripts.
-- [ ] Render a stable application chrome from the first increment: product and
-  channel header, selected instance, lifecycle summary, navigation, action bar,
-  help, and update indicator.
-- [ ] Show unfinished product panels as unavailable within the TUI instead of
+- [x] Render the initial stable application chrome: product and channel header,
+  selected home, lifecycle summary, detach action bar, and unavailable-state
+  guidance.
+- [ ] Add navigation, help, update indicator, and selectable detail panels.
+- [x] Show unfinished product panels as unavailable within the TUI instead of
   preserving a temporary non-TUI default command.
 - [ ] Implement stopped, starting, running, degraded, incompatible, stopping,
   and update-available states.
@@ -588,3 +589,13 @@ This plan is complete only when:
   semantics reference, and Guardian plus the OpenAlice installer as the final
   ownership and update authority. Recorded the comparison in
   [[docs/reference/pi-herdr-cli-architecture.md]].
+- 2026-07-30: Started the replacement implementation from merged PR #868.
+  Added the native TypeScript CLI entry and first `pi-tui` Supervisor shell,
+  made bare `openalice` enter it, retained `openalice tui` and every explicit
+  command, and bumped the managed Pi/TUI release assets together to `0.83.0`.
+  CLI tests passed 132 including a real bare-command PTY detach/restoration
+  journey, root TypeScript passed, and root Vitest passed 3,637 with 9 skipped.
+  A real isolated source install verified the official Pi manifest/lock hashes,
+  installed both launchers, ran the installed TUI through a PTY, and restored
+  the terminal on detach. Docker installer smoke remained unrun because the
+  local Docker/OrbStack socket was absent.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,7 +176,11 @@ importers:
         specifier: ^6.8.9
         version: 6.8.9
 
-  packages/cli: {}
+  packages/cli:
+    dependencies:
+      '@earendil-works/pi-tui':
+        specifier: 0.83.0
+        version: 0.83.0
 
   packages/connector-protocol:
     dependencies:
@@ -813,6 +817,10 @@ packages:
   '@discordjs/ws@1.2.3':
     resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
     engines: {node: '>=16.11.0'}
+
+  '@earendil-works/pi-tui@0.83.0':
+    resolution: {integrity: sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==}
+    engines: {node: '>=22.19.0'}
 
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
@@ -2807,6 +2815,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -3371,6 +3383,11 @@ packages:
 
   marked@17.0.6:
     resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -5007,6 +5024,11 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@earendil-works/pi-tui@0.83.0':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -7033,6 +7055,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7533,6 +7557,8 @@ snapshots:
   marked@15.0.12: {}
 
   marked@17.0.6: {}
+
+  marked@18.0.5: {}
 
   matcher@3.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,9 @@ allowBuilds:
   node-pty: true
   protobufjs: false
 
+minimumReleaseAgeExclude:
+  - '@earendil-works/pi-tui@0.83.0'
+
 overrides:
   '@alpacahq/alpaca-trade-api>axios': ^0.32.0
   '@alpacahq/alpaca-trade-api>eslint': '-'

--- a/scripts/assert-desktop-package.spec.ts
+++ b/scripts/assert-desktop-package.spec.ts
@@ -25,7 +25,7 @@ function writeBasePackage(appRoot: string, manifest: unknown) {
 function piManifest() {
   return {
     pi: {
-      version: '0.80.6',
+      version: '0.83.0',
       mode: 'npm',
       cli: PI_CLI,
     },

--- a/scripts/install-smoke/fake-npm.sh
+++ b/scripts/install-smoke/fake-npm.sh
@@ -18,5 +18,5 @@ cli_dir="$PWD/node_modules/@earendil-works/pi-coding-agent/dist"
 mkdir -p "$cli_dir"
 printf '%s\n' \
   '#!/usr/bin/env node' \
-  "if (process.argv.includes('--version') || process.argv.includes('-v')) console.log('0.80.6')" \
+  "if (process.argv.includes('--version') || process.argv.includes('-v')) console.log('0.83.0')" \
   > "$cli_dir/cli.js"

--- a/scripts/install-smoke/pi-assets/README.md
+++ b/scripts/install-smoke/pi-assets/README.md
@@ -1,11 +1,11 @@
 # Managed Pi installer fixture
 
-These are the exact Pi `0.80.6` install manifest and lockfile consumed by the
+These are the exact Pi `0.83.0` install manifest and lockfile consumed by the
 OpenAlice bootstrap. They come from Pi's public MIT-licensed release assets:
 
 - `pi-coding-agent-install-package.json`
 - `pi-coding-agent-install-package-lock.json`
-- release: `https://github.com/earendil-works/pi/releases/tag/v0.80.6`
+- release: `https://github.com/earendil-works/pi/releases/tag/v0.83.0`
 
 The root `install` script pins and verifies these SHA-256 values before npm:
 

--- a/scripts/install-smoke/pi-assets/package-lock.json
+++ b/scripts/install-smoke/pi-assets/package-lock.json
@@ -1,14 +1,14 @@
 {
 	"name": "@earendil-works/pi-coding-agent-install",
-	"version": "0.80.6",
+	"version": "0.83.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@earendil-works/pi-coding-agent-install",
-			"version": "0.80.6",
+			"version": "0.83.0",
 			"dependencies": {
-				"@earendil-works/pi-coding-agent": "0.80.6"
+				"@earendil-works/pi-coding-agent": "0.83.0"
 			},
 			"engines": {
 				"node": ">=22.19.0"
@@ -450,13 +450,14 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+			"version": "0.83.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.80.6",
+				"@earendil-works/pi-ai": "^0.83.0",
+				"diff": "8.0.4",
 				"ignore": "7.0.5",
-				"typebox": "1.1.38",
+				"typebox": "1.3.7",
 				"yaml": "2.9.0"
 			},
 			"engines": {
@@ -464,8 +465,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+			"version": "0.83.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
@@ -478,23 +479,23 @@
 				"https-proxy-agent": "7.0.6",
 				"openai": "6.26.0",
 				"partial-json": "0.1.7",
-				"typebox": "1.1.38"
+				"typebox": "1.3.7"
 			},
 			"bin": {
-				"pi-ai": "./dist/cli.js"
+				"pi-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
+			"version": "0.83.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.83.0.tgz",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.80.6",
-				"@earendil-works/pi-ai": "^0.80.6",
-				"@earendil-works/pi-tui": "^0.80.6",
+				"@earendil-works/pi-agent-core": "^0.83.0",
+				"@earendil-works/pi-ai": "^0.83.0",
+				"@earendil-works/pi-tui": "^0.83.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -507,7 +508,7 @@
 				"minimatch": "10.2.5",
 				"proper-lockfile": "4.1.2",
 				"semver": "7.8.0",
-				"typebox": "1.1.38",
+				"typebox": "1.3.7",
 				"undici": "8.5.0",
 				"yaml": "2.9.0"
 			},
@@ -522,8 +523,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.6",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+			"version": "0.83.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",
@@ -638,9 +639,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
@@ -656,9 +654,6 @@
 			],
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"optional": true
 		},
@@ -676,9 +671,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
@@ -695,9 +687,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
@@ -713,9 +702,6 @@
 			],
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"optional": true
 		},
@@ -1047,9 +1033,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -1617,9 +1603,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
@@ -1732,9 +1718,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/typebox": {
-			"version": "1.1.38",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+			"integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
 			"license": "MIT"
 		},
 		"node_modules/undici": {

--- a/scripts/install-smoke/pi-assets/package.json
+++ b/scripts/install-smoke/pi-assets/package.json
@@ -1,12 +1,13 @@
 {
 	"name": "@earendil-works/pi-coding-agent-install",
-	"version": "0.80.6",
+	"version": "0.83.0",
 	"private": true,
 	"description": "Lockfile root used by the Pi installer and updater.",
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "0.80.6"
+		"@earendil-works/pi-coding-agent": "0.83.0"
 	},
 	"overrides": {
+		"protobufjs": "7.6.5",
 		"rimraf": "6.1.2",
 		"gaxios": {
 			"rimraf": "6.1.2"

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -97,7 +97,7 @@ if (value.installSource?.cliVersion !== expectedVersion) process.exit(1);
 if (value.installSource?.selector?.kind !== "branch" || value.installSource?.selector?.value !== "smoke-v1") process.exit(1);
 if (value.installSource?.installerUrl !== "http://127.0.0.1:18080/install") process.exit(1);
 ' "$install_source" "$cli_version" || fail "installed CLI did not preserve its install source"
-[[ "$($bin_dir/pi --version)" == "0.80.6" ]] || fail "installed managed Pi version check failed"
+[[ "$($bin_dir/pi --version)" == "0.83.0" ]] || fail "installed managed Pi version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"
 server_status="$($bin_dir/openalice server status --home "$HOME/openalice-server-smoke" --json)"
 node -e '
@@ -130,7 +130,7 @@ if (value.result?.doctor?.summary?.failures !== 0 || value.result?.doctor?.runti
 [[ -f "$bin_dir/pi.cmd" ]] || fail "Windows managed Pi launcher was not installed"
 [[ ! -e "$HOME/.openalice/.cli-install.lock" ]] || fail "installer lock was not released"
 v1_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-v1-*' -print -quit)"
-[[ -n "$v1_release" && -f "$v1_release/bin/openalice.mjs" ]] || fail "content-addressed CLI release was not installed"
+[[ -n "$v1_release" && -f "$v1_release/bin/openalice.ts" ]] || fail "content-addressed CLI release was not installed"
 [[ -f "$v1_release/install-source.json" ]] || fail "content-addressed CLI release omitted install source metadata"
 [[ -f "$v1_release/managed/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js" ]] \
   || fail "content-addressed managed Pi runtime was not installed"
@@ -201,7 +201,7 @@ v2_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d -name 'smoke-
 [[ -n "$v2_release" && -d "$v2_release" ]] || fail "version switch did not install the new CLI"
 version_count="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
 [[ "$version_count" == "2" ]] || fail "unexpected number of installed CLI versions: $version_count"
-grep -Fq "$v2_release/bin/openalice.mjs" "$bin_dir/openalice" \
+grep -Fq "$v2_release/bin/openalice.ts" "$bin_dir/openalice" \
   || fail "stable launcher did not switch to the latest install"
 [[ "$($bin_dir/openalice --version)" == "$cli_version" ]] || fail "switched CLI is not runnable"
 

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url))
-const cliEntry = join(repoRoot, 'packages/cli/bin/openalice.mjs')
+const cliEntry = join(repoRoot, 'packages/cli/bin/openalice.ts')
 const suffix = `${process.pid}-${Date.now().toString(36)}`
 const image = `openalice-remote-smoke:${suffix}`
 const args = process.argv.slice(2)
@@ -104,7 +104,7 @@ try {
     '--plan', '--no-open',
   ], { cwd: repoRoot, env: smokeEnv })
   requireText(initialPlan, 'install remote OpenAlice CLI')
-  requireText(initialPlan, 'install managed Pi 0.80.6')
+  requireText(initialPlan, 'install managed Pi 0.83.0')
   requireText(initialPlan, 'clone OpenAlice source (version remote-smoke)')
   requireText(initialPlan, 'start remote OpenAlice Server')
   run('ssh', [remoteTarget, 'test ! -x "$HOME/.openalice/bin/openalice"'], { env: smokeEnv })
@@ -118,7 +118,7 @@ try {
     throw new Error(`Remote Server did not survive tunnel disconnect: ${JSON.stringify(running)}`)
   }
   const piVersion = run('ssh', [remoteTarget, '"$HOME/.openalice/bin/pi" --version'], { env: smokeEnv }).trim()
-  if (piVersion !== '0.80.6') throw new Error(`Remote managed Pi version mismatch: ${piVersion}`)
+  if (piVersion !== '0.83.0') throw new Error(`Remote managed Pi version mismatch: ${piVersion}`)
   const launchRoot = running.owner?.launchRoot
   if (typeof launchRoot !== 'string' || !launchRoot.includes('/.openalice/sources/')) {
     throw new Error(`Remote Server did not use a managed checkout: ${JSON.stringify(launchRoot)}`)
@@ -132,7 +132,7 @@ try {
     throw new Error(`Managed Pi repair changed the remembered browser origin (${firstTunnelUrl} -> ${repairedTunnelUrl})`)
   }
   const repairedPiVersion = run('ssh', [remoteTarget, '"$HOME/.openalice/bin/pi" --version'], { env: smokeEnv }).trim()
-  if (repairedPiVersion !== '0.80.6') throw new Error(`Repaired managed Pi version mismatch: ${repairedPiVersion}`)
+  if (repairedPiVersion !== '0.83.0') throw new Error(`Repaired managed Pi version mismatch: ${repairedPiVersion}`)
 
   console.log('[remote-ssh-smoke] checking reuse plan and reconnecting')
   const reusePlan = run(process.execPath, [

--- a/scripts/vendor-managed-runtime.mjs
+++ b/scripts/vendor-managed-runtime.mjs
@@ -25,7 +25,7 @@ const piCliPath = resolve(
 const knownArgs = new Set(['--force', '--help', '-h'])
 let force = false
 
-const PI_VERSION = '0.80.6'
+const PI_VERSION = '0.83.0'
 const PI_RELEASE_BASE = `https://github.com/earendil-works/pi/releases/download/v${PI_VERSION}`
 const PI_ASSETS = [
   {

--- a/scripts/vendor-managed-runtime.spec.ts
+++ b/scripts/vendor-managed-runtime.spec.ts
@@ -10,7 +10,7 @@ import {
 
 describe('vendor managed runtime helpers', () => {
   it('pins the managed Pi release', () => {
-    expect(buildVendorRuntimeManifest(null).pi.version).toBe('0.80.6')
+    expect(buildVendorRuntimeManifest(null).pi.version).toBe('0.83.0')
   })
 
   it('pins both Pi search tools for every supported desktop architecture', () => {


### PR DESCRIPTION
## What changed

- add a native TypeScript `openalice` application entry on Node 22.19+
- make bare `openalice` enter a `pi-tui` Supervisor shell and retain `openalice tui`
- preserve every existing explicit command through the current presentation-neutral CLI core
- load `pi-tui` from the workspace or the immutable managed-Pi install
- bump managed Pi and pi-tui together from 0.80.6 to 0.83.0 using the official release manifest and lockfile hashes
- extend installer payload, launchers, tests, Docker pin, remote checks, and owner guides
- add a real PTY test for bare startup, detach, cursor restoration, and bracketed-paste restoration

## Product impact

The CLI now has the intended application shape from day one: the bare command is the Supervisor TUI, while explicit subcommands remain the script/automation API. The first shell is read-only and reports Runtime state; lifecycle controls arrive in the next serial increment.

## Verification

- `pnpm -F @traderalice/openalice-cli build`
- `pnpm -F @traderalice/openalice-cli test` — 132 passed
- `npx tsc --noEmit`
- `pnpm test` — 3,637 passed, 9 skipped
- real isolated local installer with official Pi 0.83.0 assets
- real installed-CLI PTY launch and `q` detach with terminal restoration
- `git diff --check`

`pnpm test:install:docker` could not start because the local Docker/OrbStack socket is absent. The equivalent local installer transaction and installed-TUI PTY passed; CI remains responsible for the clean Docker lane.
