### PR TITLE
Fix managed Pi release hashes

### DIFF
--- a/scripts/vendor-managed-runtime.mjs
+++ b/scripts/vendor-managed-runtime.mjs
@@ -31,12 +31,12 @@ const PI_ASSETS = [
   {
     name: 'package.json',
     url: `${PI_RELEASE_BASE}/pi-coding-agent-install-package.json`,
-    sha256: 'ee080db64c3732daea5547bd6d9809465ffa236ef6099051e64a16753e48b795',
+    sha256: '41f07a3eb41227905ac436ad41d949e4589dcc34c15454d718f85f399b533cb6',
   },
   {
     name: 'package-lock.json',
     url: `${PI_RELEASE_BASE}/pi-coding-agent-install-package-lock.json`,
-    sha256: '0f409bf498507f93bfbde3dc6f2b4c83bc58bdea2e2f5eabf3053cc2a81568d4',
+    sha256: 'f5cb41dcfc60561ba54490b49c17beecec202900f73eb5f104b34f8b2a79a0af',
   },
 ]
 


### PR DESCRIPTION
## Summary
- update the desktop vendoring hashes for Pi 0.83.0
- restore the macOS package jobs broken by the Pi version bump in #871

## Verification
- `pnpm vendor:runtime --force`
- `pnpm exec vitest run scripts/vendor-managed-runtime.spec.ts packages/cli/src/install.spec.mjs`
- `npx tsc --noEmit`
- `pnpm test` (434 files passed, 1 skipped; 3,638 tests passed, 9 skipped)
- `git diff --check`